### PR TITLE
WT-15441 Fix __clayered_compare failure

### DIFF
--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -688,10 +688,9 @@ __clayered_compare(WT_CURSOR *a, WT_CURSOR *b, int *cmpp)
     /*
      * Confirm both cursors refer to the same source and have keys, then compare the keys.
      */
-    if (strcmp(a->internal_uri, b->internal_uri) != 0) {
-        WT_ASSERT(session, false);
+    if (strcmp(a->internal_uri, b->internal_uri) != 0)
         WT_ERR_MSG(session, EINVAL, "comparison method cursors must reference the same object");
-    }
+
     /* Both cursors are from the same tree - they share the same collator */
     __clayered_get_collator(clayered, &collator);
 

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -688,9 +688,10 @@ __clayered_compare(WT_CURSOR *a, WT_CURSOR *b, int *cmpp)
     /*
      * Confirm both cursors refer to the same source and have keys, then compare the keys.
      */
-    if (strcmp(a->uri, b->uri) != 0)
-        WT_ERR_MSG(session, EINVAL, "comparison method cursors must reference the same object");
-
+    if (strcmp(a->internal_uri, b->internal_uri) != 0) {
+        WT_ASSERT(session, false);
+        WT_ERR_MSG(session, EINVAL, "comparison method cursors must reference the same object %s %s", a->uri, b->uri);
+    }
     /* Both cursors are from the same tree - they share the same collator */
     __clayered_get_collator(clayered, &collator);
 

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -690,7 +690,7 @@ __clayered_compare(WT_CURSOR *a, WT_CURSOR *b, int *cmpp)
      */
     if (strcmp(a->internal_uri, b->internal_uri) != 0) {
         WT_ASSERT(session, false);
-        WT_ERR_MSG(session, EINVAL, "comparison method cursors must reference the same object %s %s", a->uri, b->uri);
+        WT_ERR_MSG(session, EINVAL, "comparison method cursors must reference the same object");
     }
     /* Both cursors are from the same tree - they share the same collator */
     __clayered_get_collator(clayered, &collator);

--- a/test/suite/hook_disagg.fail
+++ b/test/suite/hook_disagg.fail
@@ -101,6 +101,10 @@ test_stat_log01.py
 test_stat_log02.py
 test_sweep03.py  # FIXME: WT-15417
 test_timestamp20.py
+test_timestamp26.py
+test_truncate01.py # WT-15474
+test_truncate21.py # WT-15472
+test_truncate24.py # WT-15473
 test_txn02.py
 test_txn04.py
 test_txn06.py

--- a/test/suite/hook_disagg.fail
+++ b/test/suite/hook_disagg.fail
@@ -13,6 +13,7 @@ test_bug027.py
 test_bug033.py
 test_bulk01.py
 test_bulk02.py
+test_checkpoint06.py # FIXME: WT-15507
 test_config02.py
 test_config09.py
 test_config10.py
@@ -101,9 +102,9 @@ test_stat_log01.py
 test_stat_log02.py
 test_sweep03.py  # FIXME: WT-15417
 test_timestamp20.py
-test_truncate01.py # WT-15474
-test_truncate21.py # WT-15472
-test_truncate24.py # WT-15473
+test_truncate01.py # FIXME: WT-15474
+test_truncate21.py # FIXME: WT-15472
+test_truncate24.py # FIXME: WT-15473
 test_txn02.py
 test_txn04.py
 test_txn06.py

--- a/test/suite/hook_disagg.fail
+++ b/test/suite/hook_disagg.fail
@@ -101,7 +101,6 @@ test_stat_log01.py
 test_stat_log02.py
 test_sweep03.py  # FIXME: WT-15417
 test_timestamp20.py
-test_timestamp26.py
 test_truncate01.py # WT-15474
 test_truncate21.py # WT-15472
 test_truncate24.py # WT-15473

--- a/test/suite/hook_disagg.py
+++ b/test/suite/hook_disagg.py
@@ -290,9 +290,9 @@ def session_salvage_replace(orig_session_salvage, session_self, uri, config):
 
 # Called to replace Session.truncate.
 def session_truncate_replace(orig_session_truncate, session_self, uri, start, stop, config):
-    #uri = replace_uri(uri)
-    #return orig_session_truncate(session_self, uri, start, stop, config)
-    skip_test("truncate on disagg tables not yet implemented")
+    if (uri != None):
+        uri = replace_uri(uri)
+    return orig_session_truncate(session_self, uri, start, stop, config)
 
 # Called to replace Session.verify
 def session_verify_replace(orig_session_verify, session_self, uri, config):
@@ -327,7 +327,6 @@ class DisaggHookCreator(wthooks.WiredTigerHookCreator):
             ("test_cursor_big",      "Cursor caching verified with stats"),
             ("test_cursor_bound",    "Can't use cursor bounds with a disagg table"),
             ("test_salvage",         "Salvage tests directly name files ending in '.wt'"),
-            ("test_truncate",        "Truncate on disagg tables not yet implemented"),
             ("tiered",               "Tiered tests do not apply to disagg"),
         ]
 

--- a/test/suite/test_checkpoint34.py
+++ b/test/suite/test_checkpoint34.py
@@ -35,7 +35,8 @@ from helper import simulate_crash_restart
 # test_checkpoint34.py
 #
 # Test precise checkpoint with fast truncate
-@wttest.skip_for_hook("tiered", "FIXME-WT-14937: this is crashing for disagg.")
+# FIXME-WT-15430: Re-enable once disaggregated storage works with fast truncate tests.
+@wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_checkpoint34(wttest.WiredTigerTestCase):
 
     format_values = [

--- a/test/suite/test_checkpoint34.py
+++ b/test/suite/test_checkpoint34.py
@@ -37,6 +37,7 @@ from helper import simulate_crash_restart
 # Test precise checkpoint with fast truncate
 # FIXME-WT-15430: Re-enable once disaggregated storage works with fast truncate tests.
 @wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
+@wttest.skip_for_hook("tiered", "FIXME-WT-14937: this is crashing for disagg.")
 class test_checkpoint34(wttest.WiredTigerTestCase):
 
     format_values = [

--- a/test/suite/test_prepare34.py
+++ b/test/suite/test_prepare34.py
@@ -192,7 +192,7 @@ class test_prepare34(test_prepare_preserve_prepare_base):
 
         # Write prepare update to disk when prepare ts is stable but durable timestamp is not stable
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(80))
-        if 'disagg' in self.hook_names:
+        if self.runningHook('disagg'):
             # We should write an empty delta as we still write prepared.
             self.checkpoint_and_verify_stats({
                 wiredtiger.stat.dsrc.rec_page_delta_leaf: False,

--- a/test/suite/test_prepare36.py
+++ b/test/suite/test_prepare36.py
@@ -71,7 +71,7 @@ class test_prepare36(test_prepare_preserve_prepare_base):
         # Setup: Initialize timestamps with stable < prepare timestamp
         self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10))
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(20))
-        if 'disagg' in self.hook_names:
+        if self.runningHook('disagg'):
             self.skipTest("Skip test until cell packing/unpacking is supported for page delta and tier storage")
         create_params = 'key_format=i,value_format=S'
         self.session.create(self.uri, create_params)

--- a/test/suite/test_truncate01.py
+++ b/test/suite/test_truncate01.py
@@ -515,7 +515,7 @@ class test_truncate_cursor(test_truncate_base):
     def test_truncate_complex(self):
 
         # We only care about tables.
-        if self.type != 'table:' or not self.runningHook('disagg')
+        if self.type != 'table:' or not self.runningHook('disagg'):
                 return
 
         uri = self.type + self.name

--- a/test/suite/test_truncate01.py
+++ b/test/suite/test_truncate01.py
@@ -40,14 +40,11 @@ from wtdataset import SimpleDataSet, ComplexDataSet, simple_key
 from wtscenario import make_scenarios
 
 class test_truncate_base(wttest.WiredTigerTestCase):
-    conn_base_config = 'transaction_sync=(enabled,method=fsync),statistics=(all),statistics_log=(wait=1,json=true,on_close=true),'
+    conn_config = 'transaction_sync=(enabled,method=fsync),statistics=(all),statistics_log=(wait=1,json=true,on_close=true),'
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.ignoreStdoutPattern('WT_VERB_RTS')
-
-    def conn_config(self):
-        return self.conn_base_config
 
 # Test truncation arguments.
 class test_truncate_arguments(test_truncate_base):
@@ -250,15 +247,12 @@ class test_truncate_empty(test_truncate_base):
 # Test truncation timestamp handling.
 class test_truncate_timestamp(test_truncate_base):
     name = 'test_truncate'
-
+    conn_config += 'log=(enabled=true),'
     scenarios = make_scenarios([
         ('file', dict(type='file:')),
         ('table', dict(type='table:')),
 
     ])
-
-    def conn_config(self):
-        return self.conn_base_config + 'log=(enabled=true),'
 
     # Prevent these from running under a hook that will cause truncate to use a slow path.
     # Test truncation of an object without a timestamp, expect success.

--- a/test/suite/test_truncate01.py
+++ b/test/suite/test_truncate01.py
@@ -113,6 +113,9 @@ class test_truncate_uri(test_truncate_base):
         confirm_empty(self, uri)
 
         # TODO: layered table drop not supported yet.
+        if self.type != "layered:":
+            self.dropUntilSuccess(self.session, uri)
+
         if self.type == "table:" and 'disagg' not in self.hook_names:
             cds = ComplexDataSet(self, uri, 100)
             cds.populate()
@@ -190,6 +193,9 @@ class test_truncate_cursor_end(test_truncate_base):
         self.assertEqual(c2.close(), 0)
 
         # TODO: layered table drop not supported yet.
+        if self.type != "layered:":
+            self.dropUntilSuccess(self.session, uri)
+
         if self.type == "table:" and 'disagg' not in self.hook_names:
             ds = ComplexDataSet(self, uri, 100, key_format=self.keyfmt)
             ds.populate()

--- a/test/suite/test_truncate01.py
+++ b/test/suite/test_truncate01.py
@@ -116,7 +116,7 @@ class test_truncate_uri(test_truncate_base):
         if self.type != "layered:":
             self.dropUntilSuccess(self.session, uri)
 
-        if self.type == "table:" and 'disagg' not in self.hook_names:
+        if self.type == "table:" and not self.runningHook('disagg'):
             cds = ComplexDataSet(self, uri, 100)
             cds.populate()
             cds.truncate(uri, None, None, None)
@@ -141,7 +141,7 @@ class test_truncate_cursor_order(test_truncate_base):
     # Test an illegal order, then confirm that equal cursors works.
     def test_truncate_cursor_order(self):
         # Column store not supported on truncate with disaggregated storage.
-        if 'disagg' in self.hook_names and self.keyfmt == 'r':
+        if self.runningHook('disagg') and self.keyfmt == 'r':
             return
 
         uri = self.type + self.name
@@ -176,7 +176,7 @@ class test_truncate_cursor_end(test_truncate_base):
 
     # Test truncation of cursors past the end of the object.
     def test_truncate_cursor_order(self):
-        if 'disagg' in self.hook_names and self.keyfmt == 'r':
+        if self.runningHook('disagg') and self.keyfmt == 'r':
             return
 
         uri = self.type + self.name
@@ -196,7 +196,7 @@ class test_truncate_cursor_end(test_truncate_base):
         if self.type != "layered:":
             self.dropUntilSuccess(self.session, uri)
 
-        if self.type == "table:" and 'disagg' not in self.hook_names:
+        if self.type == "table:" and not self.runningHook('disagg'):
             ds = ComplexDataSet(self, uri, 100, key_format=self.keyfmt)
             ds.populate()
             c1 = self.session.open_cursor(uri, None)
@@ -225,7 +225,7 @@ class test_truncate_empty(test_truncate_base):
 
     # Test truncation of empty objects using a cursor
     def test_truncate_empty_cursor(self):
-        if 'disagg' in self.hook_names and self.keyfmt == 'r':
+        if self.runningHook('disagg') and self.keyfmt == 'r':
             return
 
         uri = self.type + self.name
@@ -239,7 +239,7 @@ class test_truncate_empty(test_truncate_base):
 
     # Test truncation of empty objects using a URI
     def test_truncate_empty_uri(self):
-        if 'disagg' in self.hook_names and self.keyfmt == 'r':
+        if self.runningHook('disagg') and self.keyfmt == 'r':
             return
 
         uri = self.type + self.name
@@ -325,7 +325,7 @@ class test_truncate_cursor(test_truncate_base):
 
     # Truncate a range using cursors, and check the results.
     def truncateRangeAndCheck(self, ds, uri, begin, end, expected):
-        if 'disagg' in self.hook_names and self.keyfmt == 'r':
+        if self.runningHook('disagg') and self.keyfmt == 'r':
             return
 
         self.pr('truncateRangeAndCheck: ' + str(begin) + ',' + str(end))
@@ -365,7 +365,7 @@ class test_truncate_cursor(test_truncate_base):
 
     # Test truncation of files and simple tables using cursors.
     def test_truncate_simple(self):
-        if 'disagg' in self.hook_names and self.keyfmt == 'r':
+        if self.runningHook('disagg') and self.keyfmt == 'r':
             return
 
         uri = self.type + self.name
@@ -506,7 +506,7 @@ class test_truncate_cursor(test_truncate_base):
                 cursor.close()
 
                 self.truncateRangeAndCheck(ds, uri, begin, end, expected)
-                if 'disagg' not in self.hook_names:
+                if not self.runningHook('disagg'):
                     self.dropUntilSuccess(self.session, uri)
 
     # Test truncation of complex tables using cursors.  We can't do the kind of
@@ -515,7 +515,7 @@ class test_truncate_cursor(test_truncate_base):
     def test_truncate_complex(self):
 
         # We only care about tables.
-        if self.type != 'table:' or 'disagg' not in self.hook_names:
+        if self.type != 'table:' or not self.runningHook('disagg')
                 return
 
         uri = self.type + self.name

--- a/test/suite/test_truncate01.py
+++ b/test/suite/test_truncate01.py
@@ -40,11 +40,13 @@ from wtdataset import SimpleDataSet, ComplexDataSet, simple_key
 from wtscenario import make_scenarios
 
 class test_truncate_base(wttest.WiredTigerTestCase):
-    conn_config = 'transaction_sync=(enabled,method=fsync),statistics=(all),statistics_log=(wait=1,json=true,on_close=true),'
-
+    conn_base_config = 'transaction_sync=(enabled,method=fsync),statistics=(all),statistics_log=(wait=1,json=true,on_close=true),'
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.ignoreStdoutPattern('WT_VERB_RTS')
+
+    def conn_config(self):
+        return self.conn_base_config
 
 # Test truncation arguments.
 class test_truncate_arguments(test_truncate_base):
@@ -247,12 +249,14 @@ class test_truncate_empty(test_truncate_base):
 # Test truncation timestamp handling.
 class test_truncate_timestamp(test_truncate_base):
     name = 'test_truncate'
-    conn_config += 'log=(enabled=true),'
     scenarios = make_scenarios([
         ('file', dict(type='file:')),
         ('table', dict(type='table:')),
 
     ])
+
+    def conn_config(self):
+        return self.conn_base_config + 'log=(enabled=true),'
 
     # Prevent these from running under a hook that will cause truncate to use a slow path.
     # Test truncation of an object without a timestamp, expect success.

--- a/test/suite/test_truncate01.py
+++ b/test/suite/test_truncate01.py
@@ -36,35 +36,26 @@
 
 import wiredtiger, wttest
 from helper import confirm_empty
-from helper_disagg import DisaggConfigMixin, gen_disagg_storages
 from wtdataset import SimpleDataSet, ComplexDataSet, simple_key
 from wtscenario import make_scenarios
 
-class test_truncate_base(wttest.WiredTigerTestCase, DisaggConfigMixin):
-    conn_base_config = 'transaction_sync=(enabled,method=fsync),statistics=(all),statistics_log=(wait=1,json=true,on_close=true),' \
-                     + 'disaggregated=(page_log=palm),'
-    disagg_storages = gen_disagg_storages('test_truncate', disagg_only = True)
+class test_truncate_base(wttest.WiredTigerTestCase):
+    conn_base_config = 'transaction_sync=(enabled,method=fsync),statistics=(all),statistics_log=(wait=1,json=true,on_close=true),'
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.ignoreStdoutPattern('WT_VERB_RTS')
 
     def conn_config(self):
-        return self.conn_base_config + 'disaggregated=(role="leader"),'
-
-    # Load the storage store extension.
-    def conn_extensions(self, extlist):
-        DisaggConfigMixin.conn_extensions(self, extlist)
+        return self.conn_base_config
 
 # Test truncation arguments.
 class test_truncate_arguments(test_truncate_base):
     name = 'test_truncate'
 
-    scenarios = make_scenarios(test_truncate_base.disagg_storages, [
+    scenarios = make_scenarios([
         ('file', dict(type='file:')),
         ('table', dict(type='table:')),
-        # FIXME-WT-14998 Re-enable layered tables on truncate tests.
-        # ('layered', dict(type='layered:'))
     ])
 
     # Test truncation without URI or cursors specified, or with a URI and
@@ -105,11 +96,9 @@ class test_truncate_arguments(test_truncate_base):
 class test_truncate_uri(test_truncate_base):
     name = 'test_truncate'
 
-    scenarios = make_scenarios(test_truncate_base.disagg_storages, [
+    scenarios = make_scenarios([
         ('file', dict(type='file:')),
         ('table', dict(type='table:')),
-        # FIXME-WT-14998 Re-enable layered tables on truncate tests.
-        # ('layered', dict(type='layered:'))
     ])
 
     # Populate an object, truncate it by URI, and confirm it's empty.
@@ -124,10 +113,7 @@ class test_truncate_uri(test_truncate_base):
         confirm_empty(self, uri)
 
         # TODO: layered table drop not supported yet.
-        if self.type != "layered:":
-            self.dropUntilSuccess(self.session, uri)
-
-        if self.type == "table:":
+        if self.type == "table:" and 'disagg' not in self.hook_names:
             cds = ComplexDataSet(self, uri, 100)
             cds.populate()
             cds.truncate(uri, None, None, None)
@@ -141,18 +127,18 @@ class test_truncate_cursor_order(test_truncate_base):
     types = [
         ('file', dict(type='file:')),
         ('table', dict(type='table:')),
-        # ('layered', dict(type='layered:'))
     ]
     keyfmt = [
         ('integer', dict(keyfmt='i')),
         ('recno', dict(keyfmt='r')),
         ('string', dict(keyfmt='S')),
     ]
-    scenarios = make_scenarios(test_truncate_base.disagg_storages, types, keyfmt)
+    scenarios = make_scenarios(types, keyfmt)
 
     # Test an illegal order, then confirm that equal cursors works.
     def test_truncate_cursor_order(self):
-        if self.type == 'layered:' and self.keyfmt == 'r':
+        # Column store not supported on truncate with disaggregated storage.
+        if 'disagg' in self.hook_names and self.keyfmt == 'r':
             return
 
         uri = self.type + self.name
@@ -177,19 +163,17 @@ class test_truncate_cursor_end(test_truncate_base):
     types = [
         ('file', dict(type='file:')),
         ('table', dict(type='table:')),
-        # FIXME-WT-14998 Re-enable layered tables on truncate tests.
-        # ('layered', dict(type='layered:'))
     ]
     keyfmt = [
         ('integer', dict(keyfmt='i')),
         ('recno', dict(keyfmt='r')),
         ('string', dict(keyfmt='S')),
     ]
-    scenarios = make_scenarios(test_truncate_base.disagg_storages, types, keyfmt)
+    scenarios = make_scenarios(types, keyfmt)
 
     # Test truncation of cursors past the end of the object.
     def test_truncate_cursor_order(self):
-        if self.type == 'layered:' and self.keyfmt == 'r':
+        if 'disagg' in self.hook_names and self.keyfmt == 'r':
             return
 
         uri = self.type + self.name
@@ -206,10 +190,7 @@ class test_truncate_cursor_end(test_truncate_base):
         self.assertEqual(c2.close(), 0)
 
         # TODO: layered table drop not supported yet.
-        if self.type != "layered:":
-            self.dropUntilSuccess(self.session, uri)
-
-        if self.type == "table:":
+        if self.type == "table:" and 'disagg' not in self.hook_names:
             ds = ComplexDataSet(self, uri, 100, key_format=self.keyfmt)
             ds.populate()
             c1 = self.session.open_cursor(uri, None)
@@ -228,19 +209,17 @@ class test_truncate_empty(test_truncate_base):
     types = [
         ('file', dict(type='file:')),
         ('table', dict(type='table:')),
-        # FIXME-WT-14998 Re-enable layered tables on truncate tests.
-        # ('layered', dict(type='layered:'))
     ]
     keyfmt = [
         ('integer', dict(keyfmt='i')),
         ('recno', dict(keyfmt='r')),
         ('string', dict(keyfmt='S')),
     ]
-    scenarios = make_scenarios(test_truncate_base.disagg_storages, types, keyfmt)
+    scenarios = make_scenarios(types, keyfmt)
 
     # Test truncation of empty objects using a cursor
     def test_truncate_empty_cursor(self):
-        if self.type == 'layered:' and self.keyfmt == 'r':
+        if 'disagg' in self.hook_names and self.keyfmt == 'r':
             return
 
         uri = self.type + self.name
@@ -254,7 +233,7 @@ class test_truncate_empty(test_truncate_base):
 
     # Test truncation of empty objects using a URI
     def test_truncate_empty_uri(self):
-        if self.type == 'layered:' and self.keyfmt == 'r':
+        if 'disagg' in self.hook_names and self.keyfmt == 'r':
             return
 
         uri = self.type + self.name
@@ -266,15 +245,14 @@ class test_truncate_empty(test_truncate_base):
 class test_truncate_timestamp(test_truncate_base):
     name = 'test_truncate'
 
-    scenarios = make_scenarios(test_truncate_base.disagg_storages, [
+    scenarios = make_scenarios([
         ('file', dict(type='file:')),
         ('table', dict(type='table:')),
-        # FIXME-WT-14998 Re-enable layered tables on truncate tests.
-        # ('layered', dict(type='layered:'))
+
     ])
 
     def conn_config(self):
-        return self.conn_base_config + 'disaggregated=(role="leader"),log=(enabled=true),'
+        return self.conn_base_config + 'log=(enabled=true),'
 
     # Prevent these from running under a hook that will cause truncate to use a slow path.
     # Test truncation of an object without a timestamp, expect success.
@@ -313,9 +291,6 @@ class test_truncate_cursor(test_truncate_base):
             config='allocation_size=512,leaf_page_max=512', P=0.25)),
         ('table', dict(type='table:', valuefmt='S',
             config='allocation_size=512,leaf_page_max=512', P=0.5)),
-        # FIXME-WT-14998 Re-enable layered tables on truncate tests.
-        # ('layered', dict(type='layered:', valuefmt='S',
-        #     config='allocation_size=512,leaf_page_max=512', P=0.25)),
     ]
     keyfmt = [
         ('integer', dict(keyfmt='i')),
@@ -331,7 +306,7 @@ class test_truncate_cursor(test_truncate_base):
         ('big', dict(nentries=1000,skip=37)),
     ]
 
-    scenarios = make_scenarios(test_truncate_base.disagg_storages, types, keyfmt, size, reopen,
+    scenarios = make_scenarios(types, keyfmt, size, reopen,
         prune=10, prunelong=1000)
 
     # Set a cursor key.
@@ -344,7 +319,7 @@ class test_truncate_cursor(test_truncate_base):
 
     # Truncate a range using cursors, and check the results.
     def truncateRangeAndCheck(self, ds, uri, begin, end, expected):
-        if self.type == 'layered:' and self.keyfmt == 'r':
+        if 'disagg' in self.hook_names and self.keyfmt == 'r':
             return
 
         self.pr('truncateRangeAndCheck: ' + str(begin) + ',' + str(end))
@@ -384,7 +359,7 @@ class test_truncate_cursor(test_truncate_base):
 
     # Test truncation of files and simple tables using cursors.
     def test_truncate_simple(self):
-        if self.type == 'layered:' and self.keyfmt == 'r':
+        if 'disagg' in self.hook_names and self.keyfmt == 'r':
             return
 
         uri = self.type + self.name
@@ -525,7 +500,8 @@ class test_truncate_cursor(test_truncate_base):
                 cursor.close()
 
                 self.truncateRangeAndCheck(ds, uri, begin, end, expected)
-                self.dropUntilSuccess(self.session, uri)
+                if 'disagg' not in self.hook_names:
+                    self.dropUntilSuccess(self.session, uri)
 
     # Test truncation of complex tables using cursors.  We can't do the kind of
     # layout and detailed testing as we can with files, but this will at least
@@ -533,7 +509,7 @@ class test_truncate_cursor(test_truncate_base):
     def test_truncate_complex(self):
 
         # We only care about tables.
-        if self.type != 'table:':
+        if self.type != 'table:' or 'disagg' not in self.hook_names:
                 return
 
         uri = self.type + self.name

--- a/test/suite/test_truncate02.py
+++ b/test/suite/test_truncate02.py
@@ -39,6 +39,7 @@ import wttest
 #       When deleting leaf pages that aren't in memory, we set transactional
 # information in the page's WT_REF structure, which results in interesting
 # issues.
+# FIXME-WT-15430: Re-enable once disaggregated storage works with fast truncate tests.
 @wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_truncate_fast_delete(test_truncate_base):
     name = 'test_truncate'

--- a/test/suite/test_truncate02.py
+++ b/test/suite/test_truncate02.py
@@ -39,6 +39,7 @@ import wttest
 #       When deleting leaf pages that aren't in memory, we set transactional
 # information in the page's WT_REF structure, which results in interesting
 # issues.
+@wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_truncate_fast_delete(test_truncate_base):
     name = 'test_truncate'
     nentries = 10000
@@ -48,7 +49,7 @@ class test_truncate_fast_delete(test_truncate_base):
     types = [
         ('file', dict(type='file:', config=\
             'allocation_size=512,leaf_page_max=512')),
-        # FIXME-WT-14998 Re-enable the layered table scenario once disaggregated storage works with truncate tests.
+        # FIXME-WT-15430 Re-enable the layered table scenario once disaggregated storage works with fast truncate tests.
         # Consider whether we need this scenario here if the scenario is already defined in the test truncate base test.
         # ('layered', dict(type='layered:', config=\
         #     'allocation_size=512,leaf_page_max=512'))
@@ -90,7 +91,7 @@ class test_truncate_fast_delete(test_truncate_base):
         ('txn2', dict(commit=False)),
         ]
 
-    scenarios = make_scenarios(test_truncate_base.disagg_storages, types, keyfmt, overflow, reads, writes, txn,
+    scenarios = make_scenarios(types, keyfmt, overflow, reads, writes, txn,
                                prune=20, prunelong=1000)
 
     # Return the number of records visible to the cursor; test both forward

--- a/test/suite/test_truncate05.py
+++ b/test/suite/test_truncate05.py
@@ -31,6 +31,7 @@ from wtscenario import make_scenarios
 
 # test_truncate05.py
 # Test various fast truncate visibility scenarios
+# FIXME-WT-15430: Re-enable once disaggregated storage works with fast truncate tests.
 @wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_truncate05(wttest.WiredTigerTestCase):
     conn_config = 'cache_size=2MB'

--- a/test/suite/test_truncate05.py
+++ b/test/suite/test_truncate05.py
@@ -31,6 +31,7 @@ from wtscenario import make_scenarios
 
 # test_truncate05.py
 # Test various fast truncate visibility scenarios
+@wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_truncate05(wttest.WiredTigerTestCase):
     conn_config = 'cache_size=2MB'
 

--- a/test/suite/test_truncate08.py
+++ b/test/suite/test_truncate08.py
@@ -33,7 +33,7 @@
 import wttest
 from wtdataset import simple_key, simple_value
 from wtscenario import make_scenarios
-
+@wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_truncate08(wttest.WiredTigerTestCase):
     format_values = [
         ('column', dict(key_format='r', value_format='S')),

--- a/test/suite/test_truncate08.py
+++ b/test/suite/test_truncate08.py
@@ -33,6 +33,7 @@
 import wttest
 from wtdataset import simple_key, simple_value
 from wtscenario import make_scenarios
+# FIXME-WT-15430: Re-enable once disaggregated storage works with fast truncate tests.
 @wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_truncate08(wttest.WiredTigerTestCase):
     format_values = [

--- a/test/suite/test_truncate09.py
+++ b/test/suite/test_truncate09.py
@@ -33,7 +33,7 @@ import wttest
 from helper import simulate_crash_restart
 from wtdataset import simple_key, simple_value
 from wtscenario import make_scenarios
-
+@wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_truncate09(wttest.WiredTigerTestCase):
     # We don't test FLCS, missing records return as 0 values.
     format_values = [

--- a/test/suite/test_truncate09.py
+++ b/test/suite/test_truncate09.py
@@ -33,6 +33,7 @@ import wttest
 from helper import simulate_crash_restart
 from wtdataset import simple_key, simple_value
 from wtscenario import make_scenarios
+# FIXME-WT-15430: Re-enable once disaggregated storage works with fast truncate tests.
 @wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_truncate09(wttest.WiredTigerTestCase):
     # We don't test FLCS, missing records return as 0 values.

--- a/test/suite/test_truncate10.py
+++ b/test/suite/test_truncate10.py
@@ -34,7 +34,7 @@ from wtscenario import make_scenarios
 # test_truncate10.py
 #
 # Check that nothing comes unstuck if we commit a truncate with durable > commit.
-
+@wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_truncate10(wttest.WiredTigerTestCase):
     conn_config = 'statistics=(all)'
     session_config = 'isolation=snapshot'

--- a/test/suite/test_truncate10.py
+++ b/test/suite/test_truncate10.py
@@ -34,6 +34,7 @@ from wtscenario import make_scenarios
 # test_truncate10.py
 #
 # Check that nothing comes unstuck if we commit a truncate with durable > commit.
+# FIXME-WT-15430: Re-enable once disaggregated storage works with fast truncate tests.
 @wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_truncate10(wttest.WiredTigerTestCase):
     conn_config = 'statistics=(all)'

--- a/test/suite/test_truncate11.py
+++ b/test/suite/test_truncate11.py
@@ -36,6 +36,7 @@ from wtscenario import make_scenarios
 from wiredtiger import stat
 from wtthread import checkpoint_thread
 
+@wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_truncate11(wttest.WiredTigerTestCase):
     conn_config = 'cache_size=50MB,statistics=(all),statistics_log=(json,on_close,wait=1),timing_stress_for_test=[checkpoint_slow]'
 

--- a/test/suite/test_truncate11.py
+++ b/test/suite/test_truncate11.py
@@ -35,7 +35,7 @@ from wtdataset import simple_key, simple_value
 from wtscenario import make_scenarios
 from wiredtiger import stat
 from wtthread import checkpoint_thread
-
+# FIXME-WT-15430: Re-enable once disaggregated storage works with fast truncate tests.
 @wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_truncate11(wttest.WiredTigerTestCase):
     conn_config = 'cache_size=50MB,statistics=(all),statistics_log=(json,on_close,wait=1),timing_stress_for_test=[checkpoint_slow]'

--- a/test/suite/test_truncate12.py
+++ b/test/suite/test_truncate12.py
@@ -38,6 +38,7 @@ from wtscenario import make_scenarios
 # even if the truncate information is loaded during recovery and stays in cache.
 #
 # This version uses timestamps and no logging.
+# FIXME-WT-15430: Re-enable once disaggregated storage works with fast truncate tests.
 @wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_truncate12(wttest.WiredTigerTestCase):
     conn_config = 'statistics=(all)'

--- a/test/suite/test_truncate12.py
+++ b/test/suite/test_truncate12.py
@@ -38,7 +38,7 @@ from wtscenario import make_scenarios
 # even if the truncate information is loaded during recovery and stays in cache.
 #
 # This version uses timestamps and no logging.
-
+@wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_truncate12(wttest.WiredTigerTestCase):
     conn_config = 'statistics=(all)'
     session_config = 'isolation=snapshot'

--- a/test/suite/test_truncate13.py
+++ b/test/suite/test_truncate13.py
@@ -33,7 +33,7 @@ from wtscenario import make_scenarios
 
 # test_truncate13.py
 # Test reading in the gaps created by a fast-delete.
-
+@wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_truncate13(wttest.WiredTigerTestCase):
     session_config = 'isolation=snapshot'
     conn_config = 'cache_size=50MB,statistics=(all),log=(enabled=false)'

--- a/test/suite/test_truncate13.py
+++ b/test/suite/test_truncate13.py
@@ -33,6 +33,7 @@ from wtscenario import make_scenarios
 
 # test_truncate13.py
 # Test reading in the gaps created by a fast-delete.
+# FIXME-WT-15430: Re-enable once disaggregated storage works with fast truncate tests.
 @wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_truncate13(wttest.WiredTigerTestCase):
     session_config = 'isolation=snapshot'

--- a/test/suite/test_truncate14.py
+++ b/test/suite/test_truncate14.py
@@ -34,7 +34,7 @@ from wtscenario import make_scenarios
 
 # test_truncate14.py
 # Generate very large namespace gaps with truncate.
-
+@wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_truncate14(wttest.WiredTigerTestCase):
     session_config = 'isolation=snapshot'
     conn_config = 'cache_size=50MB,statistics=(all),log=(enabled=false)'

--- a/test/suite/test_truncate14.py
+++ b/test/suite/test_truncate14.py
@@ -34,6 +34,7 @@ from wtscenario import make_scenarios
 
 # test_truncate14.py
 # Generate very large namespace gaps with truncate.
+# FIXME-WT-15430: Re-enable once disaggregated storage works with fast truncate tests.
 @wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_truncate14(wttest.WiredTigerTestCase):
     session_config = 'isolation=snapshot'

--- a/test/suite/test_truncate15.py
+++ b/test/suite/test_truncate15.py
@@ -34,7 +34,7 @@ from wtscenario import make_scenarios
 # test_truncate15.py
 #
 # Check that readonly database reading fast truncated pages doesn't lead to cache stuck.
-
+@wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_truncate15(wttest.WiredTigerTestCase):
     conn_config = 'statistics=(all)'
     session_config = 'isolation=snapshot'

--- a/test/suite/test_truncate15.py
+++ b/test/suite/test_truncate15.py
@@ -34,6 +34,7 @@ from wtscenario import make_scenarios
 # test_truncate15.py
 #
 # Check that readonly database reading fast truncated pages doesn't lead to cache stuck.
+# FIXME-WT-15430: Re-enable once disaggregated storage works with fast truncate tests.
 @wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_truncate15(wttest.WiredTigerTestCase):
     conn_config = 'statistics=(all)'

--- a/test/suite/test_truncate16.py
+++ b/test/suite/test_truncate16.py
@@ -35,6 +35,7 @@ from wtscenario import make_scenarios
 #
 # Make sure that no shenanigans occur if we try to read from a page that's been
 # fast-truncated by a prepared transaction.
+# FIXME-WT-15430: Re-enable once disaggregated storage works with fast truncate tests.
 @wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_truncate16(wttest.WiredTigerTestCase):
     conn_config = 'statistics=(all)'

--- a/test/suite/test_truncate16.py
+++ b/test/suite/test_truncate16.py
@@ -35,7 +35,7 @@ from wtscenario import make_scenarios
 #
 # Make sure that no shenanigans occur if we try to read from a page that's been
 # fast-truncated by a prepared transaction.
-
+@wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_truncate16(wttest.WiredTigerTestCase):
     conn_config = 'statistics=(all)'
     session_config = 'isolation=snapshot'

--- a/test/suite/test_truncate17.py
+++ b/test/suite/test_truncate17.py
@@ -35,6 +35,7 @@ from wtscenario import make_scenarios
 #
 # Make sure that no shenanigans occur if we try to read from a page that's been
 # fast-truncated by a prepared transaction.
+# FIXME-WT-15430: Re-enable once disaggregated storage works with fast truncate tests.
 @wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_truncate17(wttest.WiredTigerTestCase):
     conn_config = 'statistics=(all)'

--- a/test/suite/test_truncate17.py
+++ b/test/suite/test_truncate17.py
@@ -35,7 +35,7 @@ from wtscenario import make_scenarios
 #
 # Make sure that no shenanigans occur if we try to read from a page that's been
 # fast-truncated by a prepared transaction.
-
+@wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_truncate17(wttest.WiredTigerTestCase):
     conn_config = 'statistics=(all)'
     session_config = 'isolation=snapshot'

--- a/test/suite/test_truncate18.py
+++ b/test/suite/test_truncate18.py
@@ -58,6 +58,7 @@ from wtscenario import make_scenarios
 # That currently asserts. The fix for this is likely to disable the optimization when in
 # verify, so the only real purpose of this test is to prevent the behavior from regressing.
 # It is therefore not full of scenarios but specific to this one problem.
+# FIXME-WT-15430: Re-enable once disaggregated storage works with fast truncate tests.
 @wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_truncate18(wttest.WiredTigerTestCase):
     conn_config = 'statistics=(all)'

--- a/test/suite/test_truncate18.py
+++ b/test/suite/test_truncate18.py
@@ -58,7 +58,7 @@ from wtscenario import make_scenarios
 # That currently asserts. The fix for this is likely to disable the optimization when in
 # verify, so the only real purpose of this test is to prevent the behavior from regressing.
 # It is therefore not full of scenarios but specific to this one problem.
-
+@wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_truncate18(wttest.WiredTigerTestCase):
     conn_config = 'statistics=(all)'
     session_config = 'isolation=snapshot'

--- a/test/suite/test_truncate19.py
+++ b/test/suite/test_truncate19.py
@@ -34,6 +34,7 @@ from wtscenario import make_scenarios
 #
 # Test to mimic oplog workload in MongoDB. Ensure the deleted pages are
 # cleaned up on disk and we are not using excessive disk space.
+@wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_truncate19(wttest.WiredTigerTestCase):
     conn_config = 'statistics=(all)'
 

--- a/test/suite/test_truncate19.py
+++ b/test/suite/test_truncate19.py
@@ -34,6 +34,7 @@ from wtscenario import make_scenarios
 #
 # Test to mimic oplog workload in MongoDB. Ensure the deleted pages are
 # cleaned up on disk and we are not using excessive disk space.
+# FIXME-WT-15430: Re-enable once disaggregated storage works with fast truncate tests.
 @wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_truncate19(wttest.WiredTigerTestCase):
     conn_config = 'statistics=(all)'

--- a/test/suite/test_truncate20.py
+++ b/test/suite/test_truncate20.py
@@ -35,6 +35,7 @@ from wtscenario import make_scenarios
 #
 # Test to mimic oplog workload in MongoDB. Ensure the deleted pages are
 # cleaned up on disk and we are not using excessive disk space.
+@wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_truncate20(test_cc_base):
     conn_config = 'statistics=(all),log=(enabled=true)'
 

--- a/test/suite/test_truncate20.py
+++ b/test/suite/test_truncate20.py
@@ -35,6 +35,7 @@ from wtscenario import make_scenarios
 #
 # Test to mimic oplog workload in MongoDB. Ensure the deleted pages are
 # cleaned up on disk and we are not using excessive disk space.
+# FIXME-WT-15430: Re-enable once disaggregated storage works with fast truncate tests.
 @wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_truncate20(test_cc_base):
     conn_config = 'statistics=(all),log=(enabled=true)'

--- a/test/suite/test_truncate22.py
+++ b/test/suite/test_truncate22.py
@@ -32,6 +32,7 @@ from wtdataset import SimpleDataSet
 
 # test_truncate22.py
 # Test that we can set the commit timestamp before performing fast truncate.
+# FIXME-WT-15430: Re-enable once disaggregated storage works with fast truncate tests.
 @wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_truncate22(wttest.WiredTigerTestCase):
     uri = 'table:test_truncate22'

--- a/test/suite/test_truncate22.py
+++ b/test/suite/test_truncate22.py
@@ -32,6 +32,7 @@ from wtdataset import SimpleDataSet
 
 # test_truncate22.py
 # Test that we can set the commit timestamp before performing fast truncate.
+@wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_truncate22(wttest.WiredTigerTestCase):
     uri = 'table:test_truncate22'
     conn_config = 'statistics=(all)'


### PR DESCRIPTION
When performing WT_CURSOR::compare, we should not be using the uri but instead the internal_uri. 

The `cursor->internal_uri` is an internal representation is always set for a cursor. It's used by various internal cursor code that requires the internal uri variable. This should be used for public purposes such as WT_CURSOR::compare. 

The `cursor->uri` is the application-visible URI that represents what the user requested, and thus accurately reflects the correct URI state.

While figuring this out, I also went through triaged all python test truncate tests and test/format tests and created tickets for python tests that fail. As a result, evergreen CI should now be running python truncate tests 

**Update:** Accidentally removed a skip_for_hook for tiered tests. Replaced back now