### PR TITLE
WT-15531 Fix error log handling in test_layered31

### DIFF
--- a/test/suite/test_layered31.py
+++ b/test/suite/test_layered31.py
@@ -302,11 +302,11 @@ class test_layered31(wttest.WiredTigerTestCase, DisaggConfigMixin):
         conn_follow.reconfigure('disaggregated=(role="follower")')
 
         # Pick up a non-existent checkpoint
-        with self.expectedStderrPattern('WT_VERB_ERROR_RETURNS'):
-            l = lambda: conn_follow.reconfigure('disaggregated=(checkpoint_meta="test")')
-            self.assertRaisesException(wiredtiger.WiredTigerError, l, '/WT_NOTFOUND/')
-        with self.expectedStderrPattern('WT_VERB_ERROR_RETURNS'):
-            conn_follow.dump_error_log()
+        l = lambda: conn_follow.reconfigure('disaggregated=(checkpoint_meta="test")')
+        self.assertRaisesException(wiredtiger.WiredTigerError, l, '/WT_NOTFOUND/')
+        if wiredtiger.diagnostic_build():
+            with self.expectedStderrPattern('WT_VERB_ERROR_RETURNS'):
+                conn_follow.dump_error_log()
 
         #
         # Cleanup

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -728,11 +728,17 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
                 fail = False
                 self.pr('Expecting string msg: ' + exceptionString)
                 if len(exceptionString) > 2 and \
-                  exceptionString[0] == '/' and exceptionString[-1] == '/' :
-                      if re.search(exceptionString[1:-1], str(err)) == None:
+                  exceptionString[0] == '/' and exceptionString[-1] == '/':
+                    if re.search(exceptionString[1:-1], str(err)) == None:
                         fail = True
+                    else:
+                        # Skip stderr lines matching the exception pattern, if it was also printed.
+                        self.skipStderrLinesWithPattern(exceptionString[1:-1])
                 elif exceptionString != str(err):
                         fail = True
+                else:
+                    # Skip stderr lines matching the exception string, if it was also printed.
+                    self.skipStderrLinesWithPattern(exceptionString)
                 if fail:
                     self.fail('Exception with incorrect string raised, got: "' + \
                         str(err) + '" Expected: ' + exceptionString)

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -41,6 +41,9 @@ from contextlib import contextmanager
 import errno, glob, os, re, shutil, sys, threading, time, traceback, types
 import abstract_test_case, test_result, wiredtiger, wthooks, wtscenario
 
+# The pattern for ignoring file/line number messages.
+WT_ERROR_LOG_PATTERN = "WT_VERB_ERROR_RETURNS.*Error at "
+
 # Use as "with timeout(seconds): ....". Argument of 0 means no timeout,
 # and only available (with non-zero argument) on Unix systems.
 class timeout(object):
@@ -679,6 +682,12 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
         if self.captureerr.hasUnexpectedOutput(self):
             self.captureerr.checkAdditionalPattern(self, pat, re_flags)
 
+    def skipStdoutLinesWithPattern(self, pat):
+        self.captureout.skipLinesWithPattern(pat)
+
+    def skipStderrLinesWithPattern(self, pat):
+        self.captureerr.skipLinesWithPattern(pat)
+
     def assertRaisesWithMessage(self, exceptionType, expr, message):
         """
         Like TestCase.assertRaises(), but also checks to see
@@ -688,12 +697,11 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
         error output).  Otherwise, the message must match verbatim,
         including any trailing newlines.
         """
-        ignore_pat = "WT_VERB_ERROR_RETURNS.*Error at " # Ignore file/line number messages.
         if len(message) > 2 and message[0] == '/' and message[-1] == '/':
-            with self.expectedStderrPattern(message[1:-1], ignore_pat=ignore_pat):
+            with self.expectedStderrPattern(message[1:-1], ignore_pat=WT_ERROR_LOG_PATTERN):
                 self.assertRaises(exceptionType, expr)
         else:
-            with self.expectedStderr(message, ignore_pat=ignore_pat):
+            with self.expectedStderr(message, ignore_pat=WT_ERROR_LOG_PATTERN):
                 self.assertRaises(exceptionType, expr)
 
     def assertRaisesException(self, exceptionType, expr,
@@ -731,8 +739,8 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
             raised = True
         if not raised and not optional:
             self.fail('no assertion raised')
-        ignore_pat = "WT_VERB_ERROR_RETURNS.*Error at " # Ignore file/line number messages.
-        self.ignoreStderrPatternIfExists(ignore_pat)
+        # Ignore file/line number messages.
+        self.skipStderrLinesWithPattern(WT_ERROR_LOG_PATTERN)
         return raised
 
     def raisesBusy(self, expr):

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -731,6 +731,8 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
             raised = True
         if not raised and not optional:
             self.fail('no assertion raised')
+        ignore_pat = "WT_VERB_ERROR_RETURNS.*Error at " # Ignore file/line number messages.
+        self.ignoreStderrPatternIfExists(ignore_pat)
         return raised
 
     def raisesBusy(self, expr):


### PR DESCRIPTION
`test_layered31` does not currently work in the release mode, because it expects the error log, but the error log is not available in the release mode.

The solution is two-fold:
* `assertRaisesException` now ignores the file/line number log records, if they are present, and it also ignores the log record that repeat the exception, if present.
* `test_layered31` calls `dump_error_log` with `self.expectedStderrPattern('WT_VERB_ERROR_RETURNS')` only in the diagnostic mode.