### PR TITLE
WT-15544 Fix internal_uri memory leak in __wt_cursor_init

### DIFF
--- a/src/cursor/cur_std.c
+++ b/src/cursor/cur_std.c
@@ -1489,6 +1489,7 @@ __wt_cursor_init(
 {
     WT_CONFIG_ITEM cval;
     WT_CURSOR *cdump;
+    WT_DECL_RET;
     WT_SESSION_IMPL *session;
     bool readonly;
 
@@ -1501,13 +1502,13 @@ __wt_cursor_init(
     }
 
     /* WT_CURSTD_OVERWRITE */
-    WT_RET(__wt_config_gets_def(session, cfg, "overwrite", 1, &cval));
+    WT_ERR(__wt_config_gets_def(session, cfg, "overwrite", 1, &cval));
     if (cval.val)
         F_SET(cursor, WT_CURSTD_OVERWRITE);
     else
         F_CLR(cursor, WT_CURSTD_OVERWRITE);
 
-    WT_RET(__cursor_reuse_or_init(session, cursor, cfg, &readonly, &owner, &cdump));
+    WT_ERR(__cursor_reuse_or_init(session, cursor, cfg, &readonly, &owner, &cdump));
 
     if (readonly) {
         cursor->insert = __wt_cursor_notsup;
@@ -1547,4 +1548,11 @@ __wt_cursor_init(
 
     *cursorp = (cdump != NULL) ? cdump : cursor;
     return (0);
+
+err:
+    if (ret != 0) {
+        __wt_free(session, cursor->internal_uri);
+        cursor->internal_uri = NULL;
+    }
+    return (ret);
 }

--- a/test/suite/test_cursor_tracker.py
+++ b/test/suite/test_cursor_tracker.py
@@ -293,10 +293,6 @@ class TestCursorTracker(wttest.WiredTigerTestCase):
         self.assertEqual(expect, cursor.prev())
         self.curremoved = False
 
-    def cur_update(self, cursor, key):
-        # TODO:
-        pass
-
     def bitspos(self, bits):
         list = self.bitlist
         return next(i for i in range(len(list)) if list[i] == bits)


### PR DESCRIPTION
We use `__wt_strdup` in that function to copy the URI name, but we don't free it if next functions' calls would fail.

Additionally, remove noop unused function from `test_cursor_tracker.py` that was there for a long time :)