### PR TITLE
WT-15543 Documentation: extend cursors positioning expectations

### DIFF
--- a/dist/s_docs
+++ b/dist/s_docs
@@ -198,11 +198,10 @@ setup_doxygen()
     v=$(doxygen --version)
     case "$v" in
         1.8.17) doxyfile="Doxyfile";;
-        1.9.1) doxyfile="Doxyfile.9";;
-        1.9.3) doxyfile="Doxyfile.9";;
+        1.9.*) doxyfile="Doxyfile.9";;
         1.11.*) doxyfile="Doxyfile.11";;
         *)
-            echo "$0 skipped: unsupported version of doxygen: $v, not 1.8.17, 1.9.1, 1.9.3 or 1.11.*"
+            echo "$0 skipped: unsupported version of doxygen: $v, not 1.8.17, 1.9.* or 1.11.*"
             exit 0
     esac
 }

--- a/dist/s_docs
+++ b/dist/s_docs
@@ -198,10 +198,11 @@ setup_doxygen()
     v=$(doxygen --version)
     case "$v" in
         1.8.17) doxyfile="Doxyfile";;
-        1.9.*) doxyfile="Doxyfile.9";;
+        1.9.1) doxyfile="Doxyfile.9";;
+        1.9.3) doxyfile="Doxyfile.9";;
         1.11.*) doxyfile="Doxyfile.11";;
         *)
-            echo "$0 skipped: unsupported version of doxygen: $v, not 1.8.17, 1.9.* or 1.11.*"
+            echo "$0 skipped: unsupported version of doxygen: $v, not 1.8.17, 1.9.1, 1.9.3 or 1.11.*"
             exit 0
     esac
 }

--- a/src/docs/cursor-ops.dox
+++ b/src/docs/cursor-ops.dox
@@ -98,7 +98,7 @@ the record previously exists.  When an application configures \c overwrite to
 previously exists and WT_CURSOR::update will fail with ::WT_NOTFOUND if the
 record does not previously exist.
 
-WT_CURSOR::update rreturns the cursor positioned on the record after a successful update,
+WT_CURSOR::update returns the cursor positioned on the record after a successful update,
 whereas WT_CURSOR::insert method never keeps a cursor position.
 
 To remove existing data using a cursor, use the WT_CURSOR::remove method:

--- a/src/docs/cursor-ops.dox
+++ b/src/docs/cursor-ops.dox
@@ -98,9 +98,15 @@ the record previously exists.  When an application configures \c overwrite to
 previously exists and WT_CURSOR::update will fail with ::WT_NOTFOUND if the
 record does not previously exist.
 
+WT_CURSOR::update rreturns the cursor positioned on the record after a successful update,
+whereas WT_CURSOR::insert method never keeps a cursor position.
+
 To remove existing data using a cursor, use the WT_CURSOR::remove method:
 
 @snippet ex_cursor.c cursor remove
+
+WT_CURSOR::remove does not change the cursor position: if the cursor was positioned
+before, the cursor remains positioned at the removed record.
 
 @section cursor_largest Returning the largest key
 


### PR DESCRIPTION
Currently that rules are defined only for `search`, `search_near`, `prev` and `next`. But we also expect `modify`, `update` and `remove` to return positioned cursors, while `insert` should always return the cursor unpositioned. This PR adds it to the documentation.

It also extends the Doxygen supported versions since I've noticed that my 1.9.8 doxygen works fine, so I think all the 1.9.* should work fine as well 