### PR TITLE
WT-15548 Disable checkpoint_cleanup config in test/format if all related options are off

### DIFF
--- a/test/compatibility/compatibility_test_for_releases.sh
+++ b/test/compatibility/compatibility_test_for_releases.sh
@@ -30,6 +30,7 @@ bflag()
 {
     # Return if the branch's format command takes the -B flag for backward compatibility.
     test "$1" = "develop" && echo "-B "
+    test "$1" = "mongodb-8.2" && echo "-B"
     test "$1" = "mongodb-8.0" && echo "-B"
     test "$1" = "mongodb-7.0" && echo "-B "
     test "$1" = "mongodb-6.0" && echo "-B "
@@ -178,6 +179,7 @@ create_configs()
     echo "runs.type=row" >> $file_name                # WT-7379 - Temporarily disable column store tests
     echo "btree.huffman_value=0" >> $file_name        # WT-12456 - Never used, removed from newer releases
     echo "btree.prefix=0" >> $file_name               # WT-7579 - Prefix testing isn't portable between releases
+    echo "btree.prefix_len=0" >> $file_name           # WT-15548 - Not supported by older releases
     echo "cache=80" >> $file_name                     # Medium cache so there's eviction
     echo "checksum=on" >> $file_name                  # WT-7851 Fix illegal checksum configuration
     echo "checkpoints=1"  >> $file_name               # Force periodic writes
@@ -192,6 +194,8 @@ create_configs()
     echo "leak_memory=1" >> $file_name                # Faster runs
     echo "logging=1" >> $file_name                    # Test log compatibility
     echo "logging_compression=snappy" >> $file_name   # We only built with snappy, force the choice
+    echo "obsolete_cleanup.method=off" >> $file_name  # WT-14142 - Not supported by older releases
+    echo "obsolete_cleanup.wait=0" >> $file_name      # WT-14142 - Not supported by older releases
     echo "prefetch=0" >> $file_name                   # WT-12978 - Not supported by older releases
     echo "rows=1000000" >> $file_name
     echo "salvage=0" >> $file_name                    # Faster runs

--- a/test/format/config.sh
+++ b/test/format/config.sh
@@ -241,7 +241,7 @@ CONFIG configuration_list[] = {
 
 {"obsolete_cleanup.method", "obsolete cleanup strategy", C_IGNORE | C_STRING, 0, 0, 0}
 
-{"obsolete_cleanup.wait", "obsolete cleanup interval in seconds", 0x0, 1, 3600, 100000}
+{"obsolete_cleanup.wait", "obsolete cleanup interval in seconds", 0x0, 0, 3600, 100000}
 
 {"ops.alter", "configure table alterations", C_BOOL, 10, 0, 0}
 

--- a/test/format/format_config_def.c
+++ b/test/format/format_config_def.c
@@ -247,7 +247,7 @@ CONFIG configuration_list[] = {{"assert.read_timestamp", "assert read_timestamp"
   {"obsolete_cleanup.method", "obsolete cleanup strategy", C_IGNORE | C_STRING, 0, 0, 0,
     V_GLOBAL_OBSOLETE_CLEANUP_METHOD},
 
-  {"obsolete_cleanup.wait", "obsolete cleanup interval in seconds", 0x0, 1, 3600, 100000,
+  {"obsolete_cleanup.wait", "obsolete cleanup interval in seconds", 0x0, 0, 3600, 100000,
     V_GLOBAL_OBSOLETE_CLEANUP_WAIT},
 
   {"ops.alter", "configure table alterations", C_BOOL, 10, 0, 0, V_GLOBAL_OPS_ALTER},

--- a/test/format/wts.c
+++ b/test/format/wts.c
@@ -425,6 +425,14 @@ configure_prefetch(char **p, size_t max)
 static void
 configure_obsolete_cleanup(char **p, size_t max)
 {
+     /*
+     * If it's all off, don't even generate the outer checkpoint_cleanup config. It's not compatible
+     * with older branches, so take both options being configured off as a proxy for the whole
+     * feature being turned off.
+     */
+    if (strcmp(GVS(OBSOLETE_CLEANUP_METHOD), "off") == 0 && GV(OBSOLETE_CLEANUP_WAIT) == 0)
+        return;
+
     CONFIG_APPEND(*p, ",checkpoint_cleanup=[");
 
     /* Strategy. */
@@ -432,7 +440,8 @@ configure_obsolete_cleanup(char **p, size_t max)
         CONFIG_APPEND(*p, "method=%s", (char *)GVS(OBSOLETE_CLEANUP_METHOD));
 
     /* Interval. */
-    CONFIG_APPEND(*p, ",wait=%" PRIu32, GV(OBSOLETE_CLEANUP_WAIT));
+    if (GV(OBSOLETE_CLEANUP_WAIT) != 0)
+        CONFIG_APPEND(*p, ",wait=%" PRIu32, GV(OBSOLETE_CLEANUP_WAIT));
 
     CONFIG_APPEND(*p, "]");
 }

--- a/test/format/wts.c
+++ b/test/format/wts.c
@@ -425,7 +425,7 @@ configure_prefetch(char **p, size_t max)
 static void
 configure_obsolete_cleanup(char **p, size_t max)
 {
-     /*
+    /*
      * If it's all off, don't even generate the outer checkpoint_cleanup config. It's not compatible
      * with older branches, so take both options being configured off as a proxy for the whole
      * feature being turned off.


### PR DESCRIPTION
This is most of the WT-15375 PR, pulled across for easier backporting.

It includes the compatibility test script changes that 8.2 needs in order to generate valid configs for older branches, as well as the change in the title.

It does not include the dirty restart fixes, which only need to be on develop.