### PR TITLE
WT-15161 Fix statistic tracking history reconciliations during checkpoint

### DIFF
--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -358,7 +358,7 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
             WT_STAT_CONN_INCR(session, checkpoint_pages_reconciled);
             WT_STAT_CONN_INCRV(session, checkpoint_pages_reconciled_bytes, page->memory_footprint);
             WT_STATP_DSRC_INCR(session, btree->dhandle->stats, btree_checkpoint_pages_reconciled);
-            if (FLD_ISSET(rec_flags, WT_REC_HS))
+            if (WT_IS_HS(btree->dhandle))
                 WT_STAT_CONN_INCR(session, checkpoint_hs_pages_reconciled);
 
             WT_ERR(__wt_reconcile(session, walk, NULL, rec_flags));


### PR DESCRIPTION
Check the dhandle flag instead of the rec flag to decide if it is the history store.