### PR TITLE
WT-15483 Add check and reset macro

### DIFF
--- a/src/conn/conn_compact.c
+++ b/src/conn/conn_compact.c
@@ -632,7 +632,7 @@ __background_compact_server(void *arg)
         WT_ERR_NOTFOUND_OK(__background_compact_find_next_uri(session, uri, next_uri), true);
 
         /* All the keys with the specified prefix have been parsed. */
-        if (WT_CHECK_AND_RESET(ret, WT_NOTFOUND, 0)) {
+        if (WT_CHECK_AND_RESET(ret, WT_NOTFOUND)) {
             full_iteration = true;
             continue;
         }

--- a/src/conn/conn_compact.c
+++ b/src/conn/conn_compact.c
@@ -632,7 +632,7 @@ __background_compact_server(void *arg)
         WT_ERR_NOTFOUND_OK(__background_compact_find_next_uri(session, uri, next_uri), true);
 
         /* All the keys with the specified prefix have been parsed. */
-        if (ret == WT_NOTFOUND) {
+        if (WT_CHECK_AND_RESET(ret, WT_NOTFOUND, 0)) {
             full_iteration = true;
             continue;
         }

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -102,8 +102,8 @@
 #define WT_MAX(a, b) ((a) < (b) ? (b) : (a))
 #define WT_CLAMP(x, low, high) (WT_MIN(WT_MAX((x), (low)), (high)))
 
-/* Check and reset */
-#define WT_CHECK_AND_RESET(a, v, r) ((a) == (v) ? ((a) = (r), true) : false)
+/* Check and reset, implicitly reset to 0. */
+#define WT_CHECK_AND_RESET(a, v) ((a) == (v) ? ((a) = 0, true) : false)
 
 /* Ceil for unsigned/positive real numbers. */
 #define WT_CEIL_POS(a) ((a) - (double)(uintmax_t)(a) > 0.0 ? (uintmax_t)(a) + 1 : (uintmax_t)(a))

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -102,6 +102,9 @@
 #define WT_MAX(a, b) ((a) < (b) ? (b) : (a))
 #define WT_CLAMP(x, low, high) (WT_MIN(WT_MAX((x), (low)), (high)))
 
+/* Check and reset */
+#define WT_CHECK_AND_RESET(a, v, r) ((a) == (v) ? ((a) = (r), true) : false)
+
 /* Ceil for unsigned/positive real numbers. */
 #define WT_CEIL_POS(a) ((a) - (double)(uintmax_t)(a) > 0.0 ? (uintmax_t)(a) + 1 : (uintmax_t)(a))
 


### PR DESCRIPTION
It's a common scenario to check whether the result is WT_NOTFOUND, and if so then do something (and sometimes should reset it to 0), and if not just keep the value. But as ret is outer domain and err label goto is used to do the final check, so mistakenly bring the value into the err label without reset it to 0 can lead to hidden bugs

Create a macro to automatically check ret and reset it to a default value