### PR TITLE
WT-15301 Disallow external cursor creation on a leaders ingest

### DIFF
--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -832,13 +832,16 @@ __session_open_cursor(WT_SESSION *wt_session, const char *uri, WT_CURSOR *to_dup
           session, EINVAL, "should be passed either a URI or a cursor to duplicate, but not both");
 
     /*
-     * Disallow cursor creation on a leaders ingest table if not configured with readonly
+     * Disallow external cursor creation on a leaders ingest table if not configured with readonly
      * configuration.
      */
     if (S2C(session)->layered_table_manager.leader && uri != NULL &&
-      WT_SUFFIX_MATCH(uri, ".wt_ingest") && !F_ISSET(session, WT_SESSION_INTERNAL))
-        if ((__wt_config_gets_def(session, cfg, "readonly", 0, &cval) == 0) && !cval.val)
+      WT_SUFFIX_MATCH(uri, ".wt_ingest") && !F_ISSET(session, WT_SESSION_INTERNAL)) {
+        ret = __wt_config_gets_def(session, cfg, "readonly", 0, &cval);
+        if (ret == 0 && !cval.val)
             WT_ERR_MSG(session, EINVAL, "writes to ingest tables are disallowed on leader nodes");
+        WT_ERR_NOTFOUND_OK(ret, false);
+    }
 
     __wt_cursor_get_hash(session, uri, to_dup, &hash_value);
     if ((ret = __wt_cursor_cache_get(session, uri, hash_value, to_dup, cfg, &cursor)) == 0)

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -837,7 +837,7 @@ __session_open_cursor(WT_SESSION *wt_session, const char *uri, WT_CURSOR *to_dup
      */
     if (S2C(session)->layered_table_manager.leader && uri != NULL &&
       WT_SUFFIX_MATCH(uri, ".wt_ingest") && !F_ISSET(session, WT_SESSION_INTERNAL))
-        if ((ret = __wt_config_gets_def(session, cfg, "readonly", 0, &cval) == 0) && !cval.val)
+        if ((__wt_config_gets_def(session, cfg, "readonly", 0, &cval) == 0) && !cval.val)
             WT_ERR_MSG(session, EINVAL, "writes to ingest tables are disallowed on leader nodes");
 
     __wt_cursor_get_hash(session, uri, to_dup, &hash_value);

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -812,6 +812,7 @@ __session_open_cursor(WT_SESSION *wt_session, const char *uri, WT_CURSOR *to_dup
     dup_backup = false;
     session = (WT_SESSION_IMPL *)wt_session;
     SESSION_API_CALL(session, ret, open_cursor, config, cfg);
+    WT_CONFIG_ITEM cval;
 
     /*
      * Check for early usage of a user session to collect statistics. If the connection is not fully
@@ -829,6 +830,15 @@ __session_open_cursor(WT_SESSION *wt_session, const char *uri, WT_CURSOR *to_dup
     if ((to_dup == NULL && uri == NULL) || (to_dup != NULL && uri != NULL))
         WT_ERR_MSG(
           session, EINVAL, "should be passed either a URI or a cursor to duplicate, but not both");
+
+    /*
+     * Disallow cursor creation on a leaders ingest table if not configured with readonly
+     * configuration.
+     */
+    if (S2C(session)->layered_table_manager.leader && uri != NULL &&
+      WT_SUFFIX_MATCH(uri, ".wt_ingest"))
+        if ((ret = __wt_config_gets_def(session, cfg, "readonly", 0, &cval) == 0) && !cval.val)
+            WT_ERR_MSG(session, EINVAL, "writes to ingest tables are disallowed on leader nodes");
 
     __wt_cursor_get_hash(session, uri, to_dup, &hash_value);
     if ((ret = __wt_cursor_cache_get(session, uri, hash_value, to_dup, cfg, &cursor)) == 0)

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -836,7 +836,7 @@ __session_open_cursor(WT_SESSION *wt_session, const char *uri, WT_CURSOR *to_dup
      * configuration.
      */
     if (S2C(session)->layered_table_manager.leader && uri != NULL &&
-      WT_SUFFIX_MATCH(uri, ".wt_ingest"))
+      WT_SUFFIX_MATCH(uri, ".wt_ingest") && !F_ISSET(session, WT_SESSION_INTERNAL))
         if ((ret = __wt_config_gets_def(session, cfg, "readonly", 0, &cval) == 0) && !cval.val)
             WT_ERR_MSG(session, EINVAL, "writes to ingest tables are disallowed on leader nodes");
 

--- a/test/suite/test_layered51.py
+++ b/test/suite/test_layered51.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+
+import wiredtiger, wttest
+from helper_disagg import DisaggConfigMixin, disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
+
+
+# test_layered51.py
+#    Test accessing ingest tables (WT-15301)
+
+@disagg_test_class
+class test_layered51(wttest.WiredTigerTestCase, DisaggConfigMixin):
+    disagg_storages = gen_disagg_storages('test_layered51', disagg_only = True)
+    scenarios = make_scenarios(disagg_storages)
+
+    conn_base_config = 'disaggregated=(page_log=palm),'
+    conn_config = conn_base_config + 'disaggregated=(role="leader")'
+    conn_config_follower = conn_base_config + 'disaggregated=(role="follower")'
+
+    table_cfg = 'key_format=S,value_format=S,block_manager=disagg'
+
+    session_follow = None
+    conn_follow = None
+
+    uri = 'layered:test_layered51'
+    # Use internals to test a specific edge case scenario.
+    ingest_uri = 'file:test_layered51.wt_ingest'
+
+    msg = '/writes to ingest tables are disallowed on leader nodes/'
+
+    def test_illegal_cursor_open(self):
+        # Create a layered table on the leader
+        self.session.create(self.uri, self.table_cfg)
+        self.session.checkpoint()
+
+        # Open an ingest cursor on leader. We bypass __clayered_put and attempt to
+        # open a cursior externally through __session_open_cursor to write to leader.
+        # This should fail.
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.session.open_cursor(self.ingest_uri, None, None), self.msg)
+
+    def test_switch_role_ingest_access(self):
+        # Start as leader. Ingest access should be blocked
+        self.session.create(self.uri, self.table_cfg)
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.session.open_cursor(self.ingest_uri, None, None), self.msg)
+
+        # Switch to follower role
+        self.conn.reconfigure('disaggregated=(role="follower")')
+
+        # Now ingest access should work
+        ingest_cursor = self.session.open_cursor(self.ingest_uri, None, None)
+        ingest_cursor.close()
+
+    def test_ingest_cursor_cfgs(self):
+        self.session.create(self.uri, self.table_cfg)
+
+        # Test that all cursor cfgs fail on a leader ingest table
+        ops = [
+            lambda: self.session.open_cursor(self.ingest_uri, None, None),
+            lambda: self.session.open_cursor(self.ingest_uri, None, "readonly=false"),
+            lambda: self.session.open_cursor(self.ingest_uri, None, "overwrite"),
+            lambda: self.session.open_cursor(self.ingest_uri, None, "overwrite=false"),
+            lambda: self.session.open_cursor(self.ingest_uri, None, "append"),
+            lambda: self.session.open_cursor(self.ingest_uri, None, "append=false"),
+            lambda: self.session.open_cursor(self.ingest_uri, None, "bulk"),
+            lambda: self.session.open_cursor(self.ingest_uri, None, "bulk=false"),
+            lambda: self.session.open_cursor(self.ingest_uri, None, "raw"),
+            lambda: self.session.open_cursor(self.ingest_uri, None, "raw=false"),
+            lambda: self.session.open_cursor(self.ingest_uri, None, "read_once"),
+            lambda: self.session.open_cursor(self.ingest_uri, None, "read_once=false"),
+        ]
+
+        for op in ops:
+            self.assertRaisesWithMessage(wiredtiger.WiredTigerError, op, self.msg)
+
+        # We are able to open readonly cursors on leader ingest tables
+        readonly_cursor = self.session.open_cursor(self.ingest_uri, None, "readonly=true")
+
+        readonly_cursor.close()

--- a/test/suite/test_layered51.py
+++ b/test/suite/test_layered51.py
@@ -60,7 +60,7 @@ class test_layered51(wttest.WiredTigerTestCase, DisaggConfigMixin):
         self.session.create(self.uri, self.table_cfg)
         self.session.checkpoint()
 
-        # Open an ingest cursor on leader. We bypass __clayered_put and attempt to
+        # Open an ingest cursor on leader. We bypass __clayered_open_cursors and attempt to
         # open a cursor externally through __session_open_cursor to write to leader.
         # This should fail.
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,

--- a/test/suite/test_layered51.py
+++ b/test/suite/test_layered51.py
@@ -61,7 +61,7 @@ class test_layered51(wttest.WiredTigerTestCase, DisaggConfigMixin):
         self.session.checkpoint()
 
         # Open an ingest cursor on leader. We bypass __clayered_put and attempt to
-        # open a cursior externally through __session_open_cursor to write to leader.
+        # open a cursor externally through __session_open_cursor to write to leader.
         # This should fail.
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.session.open_cursor(self.ingest_uri, None, None), self.msg)

--- a/test/suite/test_layered51.py
+++ b/test/suite/test_layered51.py
@@ -33,7 +33,7 @@ from wtscenario import make_scenarios
 
 
 # test_layered51.py
-#    Test accessing ingest tables (WT-15301)
+#    Test accessing ingest tables.
 
 @disagg_test_class
 class test_layered51(wttest.WiredTigerTestCase, DisaggConfigMixin):

--- a/test/suite/test_layered52.py
+++ b/test/suite/test_layered52.py
@@ -32,12 +32,12 @@ from helper_disagg import DisaggConfigMixin, disagg_test_class, gen_disagg_stora
 from wtscenario import make_scenarios
 
 
-# test_layered51.py
+# test_layered52.py
 #    Test accessing ingest tables.
 
 @disagg_test_class
-class test_layered51(wttest.WiredTigerTestCase, DisaggConfigMixin):
-    disagg_storages = gen_disagg_storages('test_layered51', disagg_only = True)
+class test_layered52(wttest.WiredTigerTestCase, DisaggConfigMixin):
+    disagg_storages = gen_disagg_storages('test_layered52', disagg_only = True)
     scenarios = make_scenarios(disagg_storages)
 
     conn_base_config = 'disaggregated=(page_log=palm),'
@@ -49,9 +49,9 @@ class test_layered51(wttest.WiredTigerTestCase, DisaggConfigMixin):
     session_follow = None
     conn_follow = None
 
-    uri = 'layered:test_layered51'
+    uri = 'layered:test_layered52'
     # Use internals to test a specific edge case scenario.
-    ingest_uri = 'file:test_layered51.wt_ingest'
+    ingest_uri = 'file:test_layered52.wt_ingest'
 
     msg = '/writes to ingest tables are disallowed on leader nodes/'
 


### PR DESCRIPTION
This PR prevents external cursor creation on a leader's ingest table when bypassing the clayered code and attempting to open a cursor externally through `__session_open_cursor`. `readonly` cfgs are the only permitted exception.