### PR TITLE
WT-15568 Add the ability to dump the error log without the connection object

### DIFF
--- a/dist/s_export.list
+++ b/dist/s_export.list
@@ -4,6 +4,7 @@ wiredtiger_config_parser_open
 wiredtiger_config_validate
 wiredtiger_crc32c_func
 wiredtiger_crc32c_with_seed_func
+wiredtiger_dump_error_log
 wiredtiger_open
 wiredtiger_pack_close
 wiredtiger_pack_int

--- a/src/include/error.h
+++ b/src/include/error.h
@@ -78,6 +78,11 @@
             goto err;                                    \
         }                                                \
     } while (0)
+#define WT_ERR_NOLOG(a)       \
+    do {                      \
+        if ((ret = (a)) != 0) \
+            goto err;         \
+    } while (0)
 #define WT_ERR_MSG(session, v, ...)                                    \
     do {                                                               \
         ret = (v);                                                     \

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -2939,8 +2939,8 @@ struct __wt_connection {
         uint64_t value);
 
     /*!
-     * Dump any logged error messages into the event handler. This works only if this level of
-     * diagnostics is enabled.
+     * Dump any logged error messages into the event handler and clear the error log. This works
+     * only if this level of diagnostics is enabled.
      *
      * @param connection the connection handle
      * @errors
@@ -3556,6 +3556,19 @@ int wiredtiger_open(const char *home,
  * @returns a string representation of the error
  */
 const char *wiredtiger_strerror(int error) WT_ATTRIBUTE_LIBRARY_VISIBLE;
+
+#if !defined(DOXYGEN)
+/*!
+ * Dump any logged error messages into the provided function, one per line, and clear the error log.
+ * This works only if this level of diagnostics is enabled. See WT_CONNECTION::dump_error_log for a
+ * similar function, which dumps the error information to the event handler associated with the
+ * connection.
+ *
+ * @param callback the callback for each line of the error log; use NULL to print to stderr.
+ * @errors
+ */
+int wiredtiger_dump_error_log(int (*callback)(const char *)) WT_ATTRIBUTE_LIBRARY_VISIBLE;
+#endif
 
 /*! WT_EVENT_HANDLER::special event types */
 typedef enum {

--- a/src/support/err.c
+++ b/src/support/err.c
@@ -950,7 +950,7 @@ wiredtiger_dump_error_log(int (*callback)(const char *))
         WT_ERR_NOLOG(callback(buf));
     }
 
-    __wt_error_log_clear(); /* Avoid double reporting on the same. */
+    __wt_error_log_clear(); /* Avoid double reporting the same errors. */
 
 err:
     __wt_free(NULL, buf);
@@ -983,5 +983,5 @@ __wt_error_log_to_handler(WT_SESSION_IMPL *session)
           entry->suberror == WT_NONE ? "" : __wt_strerror(session, entry->suberror, NULL, 0));
     }
 
-    __wt_error_log_clear(); /* Avoid double reporting on the same. */
+    __wt_error_log_clear(); /* Avoid double reporting the same errors. */
 }

--- a/src/support/err.c
+++ b/src/support/err.c
@@ -901,6 +901,63 @@ __simplify_path(const char *path)
 }
 
 /*
+ * __fprintf_stderr --
+ *     Print to stderr.
+ */
+static int
+__fprintf_stderr(const char *msg)
+{
+    if (fprintf(stderr, "%s", msg) < 0)
+        return (EIO);
+    if (fflush(stderr) != 0)
+        return (EIO);
+    return (0);
+}
+
+/*
+ * wiredtiger_dump_error_log --
+ *     Dump any logged error messages into the provided function, one per line.
+ */
+int
+wiredtiger_dump_error_log(int (*callback)(const char *))
+{
+    WT_DECL_RET;
+    WT_ERROR_LOG_ENTRY *entry;
+    size_t buflen;
+    int i;
+    char *buf;
+
+    if (callback == NULL)
+        callback = __fprintf_stderr;
+
+    buf = NULL;
+    buflen = 4096;
+    WT_ERR_NOLOG(__wt_calloc_def(NULL, buflen, &buf));
+
+    if (error_log.count > WT_MAX_ERROR_LOG_MAX) {
+        WT_ERR_NOLOG(__wt_snprintf(buf, buflen, "%d errors occurred, only the last %d are shown\n",
+                       error_log.count, WT_MAX_ERROR_LOG_MAX) != 0);
+        WT_ERR_NOLOG(callback(buf));
+    }
+
+    for (i = error_log.head; i != error_log.tail; i = (i + 1) % WT_MAX_ERROR_LOG_MAX) {
+        entry = &error_log.log[i];
+        WT_ERR_NOLOG(__wt_snprintf(buf, buflen, "Error at %s:%d: \"%s\" failed with %s (%d)%s%s\n",
+          __simplify_path(entry->file), entry->line, entry->expr,
+          __wt_strerror(NULL, entry->error, NULL, 0), entry->error,
+          entry->suberror == WT_NONE ? "" : ", ",
+          entry->suberror == WT_NONE ? "" : __wt_strerror(NULL, entry->suberror, NULL, 0)));
+        WT_ERR_NOLOG(callback(buf));
+    }
+
+    __wt_error_log_clear(); /* Avoid double reporting on the same. */
+
+err:
+    __wt_free(NULL, buf);
+    return (ret);
+}
+
+/*
  * __wt_error_log_to_handler --
  *     Print all entries from the error log to the event handler.
  */
@@ -911,29 +968,19 @@ __wt_error_log_to_handler(WT_SESSION_IMPL *session)
     int i;
 
     if (session == NULL) {
-        if (error_log.count > WT_MAX_ERROR_LOG_MAX)
-            fprintf(stderr, "%d errors occurred, only the last %d are shown\n", error_log.count,
-              WT_MAX_ERROR_LOG_MAX);
-        for (i = error_log.head; i != error_log.tail; i = (i + 1) % WT_MAX_ERROR_LOG_MAX) {
-            entry = &error_log.log[i];
-            fprintf(stderr, "Error at %s:%d: \"%s\" failed with %s (%d)%s%s\n",
-              __simplify_path(entry->file), entry->line, entry->expr,
-              __wt_strerror(NULL, entry->error, NULL, 0), entry->error,
-              entry->suberror == WT_NONE ? "" : ", ",
-              entry->suberror == WT_NONE ? "" : __wt_strerror(NULL, entry->suberror, NULL, 0));
-        }
-    } else {
-        if (error_log.count > WT_MAX_ERROR_LOG_MAX)
-            __wt_verbose_warning(session, WT_VERB_ERROR_RETURNS,
-              "%d errors occurred, only the last %d are shown", error_log.count,
-              WT_MAX_ERROR_LOG_MAX);
-        for (i = error_log.head; i != error_log.tail; i = (i + 1) % WT_MAX_ERROR_LOG_MAX) {
-            entry = &error_log.log[i];
-            __wt_err_func(session, entry->error, entry->func, entry->line, WT_VERB_ERROR_RETURNS,
-              "Error at %s:%d: \"%s\" failed%s%s", __simplify_path(entry->file), entry->line,
-              entry->expr, entry->suberror == WT_NONE ? "" : " with ",
-              entry->suberror == WT_NONE ? "" : __wt_strerror(session, entry->suberror, NULL, 0));
-        }
+        wiredtiger_dump_error_log(NULL);
+        return;
+    }
+
+    if (error_log.count > WT_MAX_ERROR_LOG_MAX)
+        __wt_verbose_warning(session, WT_VERB_ERROR_RETURNS,
+          "%d errors occurred, only the last %d are shown", error_log.count, WT_MAX_ERROR_LOG_MAX);
+    for (i = error_log.head; i != error_log.tail; i = (i + 1) % WT_MAX_ERROR_LOG_MAX) {
+        entry = &error_log.log[i];
+        __wt_err_func(session, entry->error, entry->func, entry->line, WT_VERB_ERROR_RETURNS,
+          "Error at %s:%d: \"%s\" failed%s%s", __simplify_path(entry->file), entry->line,
+          entry->expr, entry->suberror == WT_NONE ? "" : " with ",
+          entry->suberror == WT_NONE ? "" : __wt_strerror(session, entry->suberror, NULL, 0));
     }
 
     __wt_error_log_clear(); /* Avoid double reporting on the same. */


### PR DESCRIPTION
Add a new global (undocumented) API function called `wiredtiger_dump_error_log`, which can dump the error log to the provided callback function without the needing a `WT_CONNECTION` object.