### PR TITLE
WT-10858 Don't report errors from __verify_filefrag_chk if verify ends early due to other errors

### DIFF
--- a/src/block/block_vrfy.c
+++ b/src/block/block_vrfy.c
@@ -179,12 +179,12 @@ err:
  *     End file verification.
  */
 int
-__wt_block_verify_end(WT_SESSION_IMPL *session, WT_BLOCK *block, int verify_error)
+__wt_block_verify_end(WT_SESSION_IMPL *session, WT_BLOCK *block, bool verify_success)
 {
     WT_DECL_RET;
 
     /* Only run file fragments check if verify didn't exit early due to any error. */
-    if (verify_error == 0)
+    if (verify_success)
         /* Confirm we verified every file block. */
         ret = __verify_filefrag_chk(session, block);
 

--- a/src/block/block_vrfy.c
+++ b/src/block/block_vrfy.c
@@ -179,12 +179,12 @@ err:
  *     End file verification.
  */
 int
-__wt_block_verify_end(WT_SESSION_IMPL *session, WT_BLOCK *block, int verify_success)
+__wt_block_verify_end(WT_SESSION_IMPL *session, WT_BLOCK *block, int verify_error)
 {
     WT_DECL_RET;
 
     /* Only run file fragments check if verify didn't exit early due to any error. */
-    if (verify_success == 0)
+    if (verify_error == 0)
         /* Confirm we verified every file block. */
         ret = __verify_filefrag_chk(session, block);
 

--- a/src/block/block_vrfy.c
+++ b/src/block/block_vrfy.c
@@ -179,12 +179,14 @@ err:
  *     End file verification.
  */
 int
-__wt_block_verify_end(WT_SESSION_IMPL *session, WT_BLOCK *block)
+__wt_block_verify_end(WT_SESSION_IMPL *session, WT_BLOCK *block, int verify_success)
 {
     WT_DECL_RET;
 
-    /* Confirm we verified every file block. */
-    ret = __verify_filefrag_chk(session, block);
+    /* Only run file fragments check if verify didn't exit early due to any error. */
+    if (verify_success == 0)
+        /* Confirm we verified every file block. */
+        ret = __verify_filefrag_chk(session, block);
 
     block->verify = false;
     block->verify_strict = false;

--- a/src/block_cache/block_mgr.c
+++ b/src/block_cache/block_mgr.c
@@ -837,9 +837,9 @@ __bm_verify_addr(WT_BM *bm, WT_SESSION_IMPL *session, const uint8_t *addr, size_
  *     End a block manager verify.
  */
 static int
-__bm_verify_end(WT_BM *bm, WT_SESSION_IMPL *session, int ret)
+__bm_verify_end(WT_BM *bm, WT_SESSION_IMPL *session, bool verify_success)
 {
-    return (__wt_block_verify_end(session, bm->block, ret));
+    return (__wt_block_verify_end(session, bm->block, verify_success));
 }
 
 /*

--- a/src/block_cache/block_mgr.c
+++ b/src/block_cache/block_mgr.c
@@ -837,9 +837,9 @@ __bm_verify_addr(WT_BM *bm, WT_SESSION_IMPL *session, const uint8_t *addr, size_
  *     End a block manager verify.
  */
 static int
-__bm_verify_end(WT_BM *bm, WT_SESSION_IMPL *session)
+__bm_verify_end(WT_BM *bm, WT_SESSION_IMPL *session, int ret)
 {
-    return (__wt_block_verify_end(session, bm->block));
+    return (__wt_block_verify_end(session, bm->block, ret));
 }
 
 /*

--- a/src/block_disagg/block_disagg_unsup.c
+++ b/src/block_disagg/block_disagg_unsup.c
@@ -200,10 +200,11 @@ __wti_block_disagg_verify_addr(
  *     End a block manager verify.
  */
 int
-__wti_block_disagg_verify_end(WT_BM *bm, WT_SESSION_IMPL *session)
+__wti_block_disagg_verify_end(WT_BM *bm, WT_SESSION_IMPL *session, int ret)
 {
     WT_UNUSED(bm);
     WT_UNUSED(session);
+    WT_UNUSED(ret);
     return (0);
 }
 

--- a/src/block_disagg/block_disagg_unsup.c
+++ b/src/block_disagg/block_disagg_unsup.c
@@ -200,11 +200,11 @@ __wti_block_disagg_verify_addr(
  *     End a block manager verify.
  */
 int
-__wti_block_disagg_verify_end(WT_BM *bm, WT_SESSION_IMPL *session, int ret)
+__wti_block_disagg_verify_end(WT_BM *bm, WT_SESSION_IMPL *session, bool verify_success)
 {
     WT_UNUSED(bm);
     WT_UNUSED(session);
-    WT_UNUSED(ret);
+    WT_UNUSED(verify_success);
     return (0);
 }
 

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -370,7 +370,7 @@ done:
 err:
     /* Inform the underlying block manager we're done. */
     if (bm_start)
-        WT_TRET(bm->verify_end(bm, session));
+        WT_TRET(bm->verify_end(bm, session, ret));
 
     /* Discard the list of checkpoints. */
     if (ckptbase != NULL)

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -370,7 +370,7 @@ done:
 err:
     /* Inform the underlying block manager we're done. */
     if (bm_start)
-        WT_TRET(bm->verify_end(bm, session, ret));
+        WT_TRET(bm->verify_end(bm, session, ret == 0));
 
     /* Discard the list of checkpoints. */
     if (ckptbase != NULL)

--- a/src/include/block.h
+++ b/src/include/block.h
@@ -232,7 +232,7 @@ struct __wt_bm {
     int (*switch_object_end)(WT_BM *, WT_SESSION_IMPL *, uint32_t);
     int (*sync)(WT_BM *, WT_SESSION_IMPL *, bool);
     int (*verify_addr)(WT_BM *, WT_SESSION_IMPL *, const uint8_t *, size_t);
-    int (*verify_end)(WT_BM *, WT_SESSION_IMPL *);
+    int (*verify_end)(WT_BM *, WT_SESSION_IMPL *, int ret);
     int (*verify_start)(WT_BM *, WT_SESSION_IMPL *, WT_CKPT *, const char *[]);
     int (*write)(
       WT_BM *, WT_SESSION_IMPL *, WT_ITEM *, WT_PAGE_BLOCK_META *, uint8_t *, size_t *, bool, bool);

--- a/src/include/block.h
+++ b/src/include/block.h
@@ -232,7 +232,7 @@ struct __wt_bm {
     int (*switch_object_end)(WT_BM *, WT_SESSION_IMPL *, uint32_t);
     int (*sync)(WT_BM *, WT_SESSION_IMPL *, bool);
     int (*verify_addr)(WT_BM *, WT_SESSION_IMPL *, const uint8_t *, size_t);
-    int (*verify_end)(WT_BM *, WT_SESSION_IMPL *, int ret);
+    int (*verify_end)(WT_BM *, WT_SESSION_IMPL *, bool verify_success);
     int (*verify_start)(WT_BM *, WT_SESSION_IMPL *, WT_CKPT *, const char *[]);
     int (*write)(
       WT_BM *, WT_SESSION_IMPL *, WT_ITEM *, WT_PAGE_BLOCK_META *, uint8_t *, size_t *, bool, bool);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -202,7 +202,7 @@ extern int __wt_block_salvage_valid(WT_SESSION_IMPL *session, WT_BLOCK *block, u
   size_t addr_size, bool valid) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_block_verify_addr(WT_SESSION_IMPL *session, WT_BLOCK *block, const uint8_t *addr,
   size_t addr_size) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_block_verify_end(WT_SESSION_IMPL *session, WT_BLOCK *block, int verify_error)
+extern int __wt_block_verify_end(WT_SESSION_IMPL *session, WT_BLOCK *block, bool verify_success)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_block_verify_start(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_CKPT *ckptbase,
   const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -1302,7 +1302,7 @@ extern int __wti_block_disagg_sync(WT_BM *bm, WT_SESSION_IMPL *session, bool blo
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_block_disagg_verify_addr(WT_BM *bm, WT_SESSION_IMPL *session, const uint8_t *addr,
   size_t addr_size) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wti_block_disagg_verify_end(WT_BM *bm, WT_SESSION_IMPL *session, int ret)
+extern int __wti_block_disagg_verify_end(WT_BM *bm, WT_SESSION_IMPL *session, bool verify_success)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_block_disagg_verify_start(WT_BM *bm, WT_SESSION_IMPL *session, WT_CKPT *ckptbase,
   const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -202,7 +202,7 @@ extern int __wt_block_salvage_valid(WT_SESSION_IMPL *session, WT_BLOCK *block, u
   size_t addr_size, bool valid) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_block_verify_addr(WT_SESSION_IMPL *session, WT_BLOCK *block, const uint8_t *addr,
   size_t addr_size) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_block_verify_end(WT_SESSION_IMPL *session, WT_BLOCK *block, int verify_success)
+extern int __wt_block_verify_end(WT_SESSION_IMPL *session, WT_BLOCK *block, int verify_error)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_block_verify_start(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_CKPT *ckptbase,
   const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -202,7 +202,7 @@ extern int __wt_block_salvage_valid(WT_SESSION_IMPL *session, WT_BLOCK *block, u
   size_t addr_size, bool valid) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_block_verify_addr(WT_SESSION_IMPL *session, WT_BLOCK *block, const uint8_t *addr,
   size_t addr_size) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_block_verify_end(WT_SESSION_IMPL *session, WT_BLOCK *block)
+extern int __wt_block_verify_end(WT_SESSION_IMPL *session, WT_BLOCK *block, int verify_success)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_block_verify_start(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_CKPT *ckptbase,
   const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -1302,7 +1302,7 @@ extern int __wti_block_disagg_sync(WT_BM *bm, WT_SESSION_IMPL *session, bool blo
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_block_disagg_verify_addr(WT_BM *bm, WT_SESSION_IMPL *session, const uint8_t *addr,
   size_t addr_size) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wti_block_disagg_verify_end(WT_BM *bm, WT_SESSION_IMPL *session)
+extern int __wti_block_disagg_verify_end(WT_BM *bm, WT_SESSION_IMPL *session, int ret)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_block_disagg_verify_start(WT_BM *bm, WT_SESSION_IMPL *session, WT_CKPT *ckptbase,
   const char *cfg[]) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));


### PR DESCRIPTION
Currently we always perform verify for file fragments during the process of verify_end, even when verify exits early due to an error. As a result we always see errors from __verify_filefrag_chk when an error occurs during verify, which is quite misleading. This PR changes avoids running __verify_filefrag_chk for when verify exits early with an error, and only runs cleanup as part of verify_end. 
