### PR TITLE
WT-15451 Print missmatch page ids and add missing search program

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -434,6 +434,7 @@ UnlockFile
 Unmap
 UnmapViewOfFile
 Unmount
+Unreferenced
 Uryyb
 VARCHAR
 VLCS

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1471,7 +1471,7 @@ __verify_page_discard(WT_SESSION_IMPL *session, WT_BM *bm)
      */
     __wt_qsort(page_ids, num_pages_found_in_btree, sizeof(uint64_t), __verify_compare_page_id);
 
-    for (size_t index_in_palm = 0, index_in_btree = 0;
+    for (uint32_t index_in_palm = 0, index_in_btree = 0;
          index_in_palm <= num_pages_found_in_palm && index_in_btree <= num_pages_found_in_btree;) {
         if (index_in_palm == num_pages_found_in_palm && index_in_btree == num_pages_found_in_btree)
             break;
@@ -1486,12 +1486,12 @@ __verify_page_discard(WT_SESSION_IMPL *session, WT_BM *bm)
          */
         if (index_in_btree == num_pages_found_in_btree || id_in_palm < id_in_btree) {
             __wt_verbose_level(session, WT_VERB_DISAGGREGATED_STORAGE, WT_VERBOSE_DEBUG_5,
-              "Unreferenced page was not discarded: PALM[%" PRIu64 "] %" PRIu64, index_in_palm,
+              "Unreferenced page was not discarded: PALM[%" PRIu32 "] %" PRIu64, index_in_palm,
               id_in_palm);
             index_in_palm++;
         } else if (index_in_palm == num_pages_found_in_palm || id_in_palm > id_in_btree) {
             __wt_verbose_level(session, WT_VERB_DISAGGREGATED_STORAGE, WT_VERBOSE_DEBUG_5,
-              "Discarded page is still in use: BTREE[%" PRIu64 "] %" PRIu64, index_in_btree,
+              "Discarded page is still in use: BTREE[%" PRIu32 "] %" PRIu64, index_in_btree,
               id_in_btree);
             index_in_btree++;
         } else {

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1471,22 +1471,32 @@ __verify_page_discard(WT_SESSION_IMPL *session, WT_BM *bm)
      */
     __wt_qsort(page_ids, num_pages_found_in_btree, sizeof(uint64_t), __verify_compare_page_id);
 
-    for (size_t i = 0, j = 0; i <= num_pages_found_in_palm && j <= num_pages_found_in_btree;) {
-        if (i == num_pages_found_in_palm && j == num_pages_found_in_btree)
+    for (size_t index_in_palm = 0, index_in_btree = 0;
+         index_in_palm <= num_pages_found_in_palm && index_in_btree <= num_pages_found_in_btree;) {
+        if (index_in_palm == num_pages_found_in_palm && index_in_btree == num_pages_found_in_btree)
             break;
-        uint64_t id_in_palm = i < num_pages_found_in_palm ? ((uint64_t *)item->data)[i] : 0;
-        uint64_t id_in_btree = j < num_pages_found_in_btree ? page_ids[j] : 0;
-        if (j == num_pages_found_in_btree || id_in_palm < id_in_btree) {
+        uint64_t id_in_palm =
+          index_in_palm < num_pages_found_in_palm ? ((uint64_t *)item->data)[index_in_palm] : 0;
+        uint64_t id_in_btree =
+          index_in_btree < num_pages_found_in_btree ? page_ids[index_in_btree] : 0;
+        /*
+         * FIXME-WT-14700: Investigate whether we need to do anything special when freeing a root
+         * page. Change below warning to an error after root page discard is implemented, if a
+         * mismatch is found this function will return the corresponding error code.
+         */
+        if (index_in_btree == num_pages_found_in_btree || id_in_palm < id_in_btree) {
             __wt_verbose_level(session, WT_VERB_DISAGGREGATED_STORAGE, WT_VERBOSE_DEBUG_5,
-              "Unreferenced page was not discarded: PALM[%" PRIu64 "] %" PRIu64, i, id_in_palm);
-            i++;
-        } else if (i == num_pages_found_in_palm || id_in_palm > id_in_btree) {
+              "Unreferenced page was not discarded: PALM[%" PRIu64 "] %" PRIu64, index_in_palm,
+              id_in_palm);
+            index_in_palm++;
+        } else if (index_in_palm == num_pages_found_in_palm || id_in_palm > id_in_btree) {
             __wt_verbose_level(session, WT_VERB_DISAGGREGATED_STORAGE, WT_VERBOSE_DEBUG_5,
-              "Discarded page is still in use: BTREE[%" PRIu64 "] %" PRIu64, j, id_in_btree);
-            j++;
+              "Discarded page is still in use: BTREE[%" PRIu64 "] %" PRIu64, index_in_btree,
+              id_in_btree);
+            index_in_btree++;
         } else {
-            i++;
-            j++;
+            index_in_palm++;
+            index_in_btree++;
         }
     }
 

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1473,16 +1473,10 @@ __verify_page_discard(WT_SESSION_IMPL *session, WT_BM *bm)
 
     size_t i = 0, j = 0;
     while (i <= num_pages_found_in_palm && j <= num_pages_found_in_btree) {
-        uint64_t id_in_palm = 0, id_in_btree = 0;
-        if (i == num_pages_found_in_palm && j == num_pages_found_in_btree) {
+        if (i == num_pages_found_in_palm && j == num_pages_found_in_btree)
             break;
-        }
-        if (i < num_pages_found_in_palm) {
-            id_in_palm = ((uint64_t *)item->data)[i];
-        }
-        if (j < num_pages_found_in_btree) {
-            id_in_btree = page_ids[j];
-        }
+        uint64_t id_in_palm = i < num_pages_found_in_palm ? ((uint64_t *)item->data)[i] : 0;
+        uint64_t id_in_btree = j < num_pages_found_in_btree ? page_ids[j] : 0;
         if (j == num_pages_found_in_btree || id_in_palm < id_in_btree) {
             __wt_verbose_level(session, WT_VERB_DISAGGREGATED_STORAGE, WT_VERBOSE_DEBUG_5,
               "Missing in page IDs from PALM and btree walk: PALM %" PRIu64, id_in_palm);

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1478,13 +1478,11 @@ __verify_page_discard(WT_SESSION_IMPL *session, WT_BM *bm)
         uint64_t id_in_btree = j < num_pages_found_in_btree ? page_ids[j] : 0;
         if (j == num_pages_found_in_btree || id_in_palm < id_in_btree) {
             __wt_verbose_level(session, WT_VERB_DISAGGREGATED_STORAGE, WT_VERBOSE_DEBUG_5,
-              "Missing in page IDs from PALM and btree walk: PALM[%" PRIu64 "] %" PRIu64, i,
-              id_in_palm);
+              "Unreferenced page was not discarded: PALM[%" PRIu64 "] %" PRIu64, i, id_in_palm);
             i++;
         } else if (i == num_pages_found_in_palm || id_in_palm > id_in_btree) {
             __wt_verbose_level(session, WT_VERB_DISAGGREGATED_STORAGE, WT_VERBOSE_DEBUG_5,
-              "Missing in page IDs from PALM and btree walk: BTREE[%" PRIu64 "] %" PRIu64, j,
-              id_in_btree);
+              "Discarded page is still in use: BTREE[%" PRIu64 "] %" PRIu64, j, id_in_btree);
             j++;
         } else {
             i++;

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1470,7 +1470,7 @@ __verify_page_discard(WT_SESSION_IMPL *session, WT_BM *bm)
      * walk.
      */
     __wt_qsort(page_ids, num_pages_found_in_btree, sizeof(uint64_t), __verify_compare_page_id);
-    
+
     for (size_t i = 0, j = 0; i <= num_pages_found_in_palm && j <= num_pages_found_in_btree;) {
         if (i == num_pages_found_in_palm && j == num_pages_found_in_btree)
             break;
@@ -1478,11 +1478,13 @@ __verify_page_discard(WT_SESSION_IMPL *session, WT_BM *bm)
         uint64_t id_in_btree = j < num_pages_found_in_btree ? page_ids[j] : 0;
         if (j == num_pages_found_in_btree || id_in_palm < id_in_btree) {
             __wt_verbose_level(session, WT_VERB_DISAGGREGATED_STORAGE, WT_VERBOSE_DEBUG_5,
-              "Missing in page IDs from PALM and btree walk: PALM[%" PRIu64 "] %" PRIu64, i, id_in_palm);
+              "Missing in page IDs from PALM and btree walk: PALM[%" PRIu64 "] %" PRIu64, i,
+              id_in_palm);
             i++;
         } else if (i == num_pages_found_in_palm || id_in_palm > id_in_btree) {
             __wt_verbose_level(session, WT_VERB_DISAGGREGATED_STORAGE, WT_VERBOSE_DEBUG_5,
-              "Missing in page IDs from PALM and btree walk: BTREE[%" PRIu64 "] %" PRIu64, j, id_in_btree);
+              "Missing in page IDs from PALM and btree walk: BTREE[%" PRIu64 "] %" PRIu64, j,
+              id_in_btree);
             j++;
         } else {
             i++;

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1470,20 +1470,19 @@ __verify_page_discard(WT_SESSION_IMPL *session, WT_BM *bm)
      * walk.
      */
     __wt_qsort(page_ids, num_pages_found_in_btree, sizeof(uint64_t), __verify_compare_page_id);
-
-    size_t i = 0, j = 0;
-    while (i <= num_pages_found_in_palm && j <= num_pages_found_in_btree) {
+    
+    for (size_t i = 0, j = 0; i <= num_pages_found_in_palm && j <= num_pages_found_in_btree;) {
         if (i == num_pages_found_in_palm && j == num_pages_found_in_btree)
             break;
         uint64_t id_in_palm = i < num_pages_found_in_palm ? ((uint64_t *)item->data)[i] : 0;
         uint64_t id_in_btree = j < num_pages_found_in_btree ? page_ids[j] : 0;
         if (j == num_pages_found_in_btree || id_in_palm < id_in_btree) {
             __wt_verbose_level(session, WT_VERB_DISAGGREGATED_STORAGE, WT_VERBOSE_DEBUG_5,
-              "Missing in page IDs from PALM and btree walk: PALM %" PRIu64, id_in_palm);
+              "Missing in page IDs from PALM and btree walk: PALM[%" PRIu64 "] %" PRIu64, i, id_in_palm);
             i++;
         } else if (i == num_pages_found_in_palm || id_in_palm > id_in_btree) {
             __wt_verbose_level(session, WT_VERB_DISAGGREGATED_STORAGE, WT_VERBOSE_DEBUG_5,
-              "Missing in page IDs from PALM and btree walk: BTREE %" PRIu64, id_in_btree);
+              "Missing in page IDs from PALM and btree walk: BTREE[%" PRIu64 "] %" PRIu64, j, id_in_btree);
             j++;
         } else {
             i++;

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1471,17 +1471,29 @@ __verify_page_discard(WT_SESSION_IMPL *session, WT_BM *bm)
      */
     __wt_qsort(page_ids, num_pages_found_in_btree, sizeof(uint64_t), __verify_compare_page_id);
 
-    for (size_t i = 0; i < num_pages_found_in_palm; i++) {
-        /* FIXME-WT-15451: Print mismatch page IDs for discard verify. */
-        if (((uint64_t *)item->data)[i] != page_ids[i]) {
-            /*
-             * FIXME-WT-14700: Investigate whether we need to do anything special when freeing a
-             * root page. Change below warning to an error after root page discard is implemented,
-             * if a mismatch is found this function will return the corresponding error code.
-             */
+    size_t i = 0, j = 0;
+    while (i <= num_pages_found_in_palm && j <= num_pages_found_in_btree) {
+        uint64_t id_in_palm = 0, id_in_btree = 0;
+        if (i == num_pages_found_in_palm && j == num_pages_found_in_btree) {
+            break;
+        }
+        if (i < num_pages_found_in_palm) {
+            id_in_palm = ((uint64_t *)item->data)[i];
+        }
+        if (j < num_pages_found_in_btree) {
+            id_in_btree = page_ids[j];
+        }
+        if (j == num_pages_found_in_btree || id_in_palm < id_in_btree) {
             __wt_verbose_level(session, WT_VERB_DISAGGREGATED_STORAGE, WT_VERBOSE_DEBUG_5,
-              "Mismatch in page IDs from PALM and btree walk: PALM %" PRIu64 " Btree walk %" PRIu64,
-              ((uint64_t *)item->data)[i], page_ids[i]);
+              "Missing in page IDs from PALM and btree walk: PALM %" PRIu64, id_in_palm);
+            i++;
+        } else if (i == num_pages_found_in_palm || id_in_palm > id_in_btree) {
+            __wt_verbose_level(session, WT_VERB_DISAGGREGATED_STORAGE, WT_VERBOSE_DEBUG_5,
+              "Missing in page IDs from PALM and btree walk: BTREE %" PRIu64, id_in_btree);
+            j++;
+        } else {
+            i++;
+            j++;
         }
     }
 


### PR DESCRIPTION
Two modification:
- Add a missing item search implementation.
- Print the missing items appeared in array.