### PR TITLE
WT-15571 Fix `configure-combinations` build

### DIFF
--- a/cmake/configs/base.cmake
+++ b/cmake/configs/base.cmake
@@ -12,6 +12,7 @@ set(default_enable_iaa OFF)
 set(default_enable_debug_info ON)
 set(default_enable_static OFF)
 set(default_enable_shared ON)
+set(default_internal_sqlite3 ON)
 
 if("${CMAKE_BUILD_TYPE}" MATCHES "^(Release|RelWithDebInfo)$")
     set(default_have_diagnostics OFF)
@@ -47,6 +48,13 @@ endif()
 
 if("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
     set(default_enable_debug_info OFF)
+endif()
+
+# Use system provided sqlite3 if available.
+find_package(SQLite3 QUIET)
+
+if(SQLite3_FOUND)
+    set(default_internal_sqlite3 OFF)
 endif()
 
 if(WT_WIN)
@@ -351,7 +359,7 @@ config_bool(
 config_bool(
     ENABLE_INTERNAL_SQLITE3
     "Enable internal SQLite3 library. If disabled, the system SQLite3 library will be used."
-    DEFAULT ON
+    DEFAULT ${default_internal_sqlite3}
 )
 
 set(default_optimize_level "-Og")

--- a/cmake/third_party/sqlite3.cmake
+++ b/cmake/third_party/sqlite3.cmake
@@ -1,40 +1,43 @@
-if(ENABLE_INTERNAL_SQLITE3)
-    message(CHECK_START "Looking for library SQLite3")
-
-    set(SQLITE3_DIR ${CMAKE_SOURCE_DIR}/test/3rdparty/sqlite3)
-
-    add_library(sqlite3_lib STATIC
-        ${SQLITE3_DIR}/sqlite3.c
-        ${SQLITE3_DIR}/sqlite3.h
-    )
-    target_include_directories(sqlite3_lib PUBLIC ${SQLITE3_DIR})
-    set_target_properties(sqlite3_lib PROPERTIES
-        POSITION_INDEPENDENT_CODE ON
-    )
-
-    # Needed for SQLite3 on some platforms
-    target_link_libraries(sqlite3_lib PUBLIC
-        $<$<BOOL:${WT_POSIX}>:${HAVE_LIBPTHREAD}>
-        $<$<BOOL:${WT_POSIX}>:${HAVE_LIBDL}>
-        $<$<BOOL:${WT_POSIX}>:m>
-    )
-
-    add_library(wt::sqlite3 ALIAS sqlite3_lib)
-
-    add_executable(sqlite3
-        ${SQLITE3_DIR}/shell.c
-    )
-    target_link_libraries(sqlite3 PRIVATE sqlite3_lib)
-
-    # Read the header file and find the SQLITE_VERSION definition
-    file(STRINGS "${SQLITE3_DIR}/sqlite3.h" SQLITE_VERSION_LINE
-        REGEX "^#define[ \t]+SQLITE_VERSION[ \t]+\"[.0-9]+\"")
-    # Extract the version string (e.g., "3.XX.YY") from the matched line
-    string(REGEX MATCH "\"[.0-9]+\"" SQLITE3_VERSION "${SQLITE_VERSION_LINE}")
-
-    message(CHECK_PASS "Found internal SQLite3: ${SQLITE3_DIR}"
-        " (found version ${SQLITE3_VERSION})")
-else()
+if(NOT ENABLE_INTERNAL_SQLITE3)
     find_package(SQLite3 REQUIRED)
     add_library(wt::sqlite3 ALIAS SQLite::SQLite3)
+    return()
 endif()
+
+# Use internal Sqlite3
+
+message(CHECK_START "Looking for library SQLite3")
+
+set(SQLITE3_DIR ${CMAKE_SOURCE_DIR}/test/3rdparty/sqlite3)
+
+add_library(sqlite3_lib STATIC
+    ${SQLITE3_DIR}/sqlite3.c
+    ${SQLITE3_DIR}/sqlite3.h
+)
+target_include_directories(sqlite3_lib PUBLIC ${SQLITE3_DIR})
+set_target_properties(sqlite3_lib PROPERTIES
+    POSITION_INDEPENDENT_CODE ON
+)
+
+# Needed for SQLite3 on some platforms
+target_link_libraries(sqlite3_lib PUBLIC
+    $<$<BOOL:${WT_POSIX}>:${HAVE_LIBPTHREAD}>
+    $<$<BOOL:${WT_POSIX}>:${HAVE_LIBDL}>
+    $<$<BOOL:${WT_POSIX}>:m>
+)
+
+add_library(wt::sqlite3 ALIAS sqlite3_lib)
+
+add_executable(sqlite3
+    ${SQLITE3_DIR}/shell.c
+)
+target_link_libraries(sqlite3 PRIVATE sqlite3_lib)
+
+# Read the header file and find the SQLITE_VERSION definition
+file(STRINGS "${SQLITE3_DIR}/sqlite3.h" SQLITE_VERSION_LINE
+    REGEX "^#define[ \t]+SQLITE_VERSION[ \t]+\"[.0-9]+\"")
+# Extract the version string (e.g., "3.XX.YY") from the matched line
+string(REGEX MATCH "\"[.0-9]+\"" SQLITE3_VERSION "${SQLITE_VERSION_LINE}")
+
+message(CHECK_PASS "Found internal SQLite3: ${SQLITE3_DIR}"
+    " (found version ${SQLITE3_VERSION})")

--- a/cmake/third_party/sqlite3.cmake
+++ b/cmake/third_party/sqlite3.cmake
@@ -19,7 +19,7 @@ if(ENABLE_INTERNAL_SQLITE3)
         $<$<BOOL:${WT_POSIX}>:m>
     )
 
-    add_library(SQLite::SQLite3 ALIAS sqlite3_lib)
+    add_library(wt::sqlite3 ALIAS sqlite3_lib)
 
     add_executable(sqlite3
         ${SQLITE3_DIR}/shell.c
@@ -32,8 +32,9 @@ if(ENABLE_INTERNAL_SQLITE3)
     # Extract the version string (e.g., "3.XX.YY") from the matched line
     string(REGEX MATCH "\"[.0-9]+\"" SQLITE3_VERSION "${SQLITE_VERSION_LINE}")
 
-    message(CHECK_PASS "found internal SQLite3 ${SQLITE3_VERSION}, "
-        "include path ${SQLITE3_DIR}")
+    message(CHECK_PASS "Found internal SQLite3: ${SQLITE3_DIR}"
+        " (found version ${SQLITE3_VERSION})")
 else()
     find_package(SQLite3 REQUIRED)
+    add_library(wt::sqlite3 ALIAS SQLite::SQLite3)
 endif()

--- a/ext/page_log/palite/CMakeLists.txt
+++ b/ext/page_log/palite/CMakeLists.txt
@@ -27,7 +27,7 @@ add_library(wiredtiger_palite MODULE
 target_link_libraries(
     wiredtiger_palite
     PRIVATE
-        SQLite::SQLite3
+        wt::sqlite3
 )
 
 target_include_directories(


### PR DESCRIPTION
- Favour system provided sqlite3, if available
- Helps avoid compilation warnings when enforcing WT code polices, e.g. `configure-combinations` build task.