### PR TITLE
WT-15576 Use EIO to indicate I/O errors in disagg

### DIFF
--- a/src/block_disagg/block_disagg_read.c
+++ b/src/block_disagg/block_disagg_read.c
@@ -138,7 +138,7 @@ reread:
           "%s: read failed for table ID %" PRIu64 ", page ID %" PRIu64 ", flags %" PRIx64
           ", lsn %" PRIu64 ", base_lsn %" PRIu64 ", size %" PRIu32 ", checksum %" PRIx32,
           block_disagg->name, block_disagg->tableid, page_id, flags, lsn, base_lsn, size, checksum);
-        WT_ERR(WT_NOTFOUND);
+        WT_ERR(EIO);
     }
 
     last = (int32_t)(*results_count - 1);

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -215,7 +215,7 @@ __disagg_get_meta(WT_SESSION_IMPL *session, uint64_t page_id, uint64_t lsn, WT_I
         if (retry > 100) {
             __wt_verbose_error(session, WT_VERB_READ,
               "read failed for metadata page ID %" PRIu64 ", lsn %" PRIu64, page_id, lsn);
-            return (WT_NOTFOUND);
+            return (EIO);
         }
         __wt_verbose_notice(session, WT_VERB_READ,
           "retry #%" PRIu32 " for metadata page_id %" PRIu64 ", lsn %" PRIu64, retry, page_id, lsn);


### PR DESCRIPTION
As the use of `WT_NOTFOUND` to indicate a failed page read has been generating some confusion during triage, use a more appropriate error code instead.