### PR TITLE
WT-15566 Remove redundant table_id in plh_get_page_ids call

### DIFF
--- a/ext/page_log/palite/palite.cpp
+++ b/ext/page_log/palite/palite.cpp
@@ -1280,7 +1280,7 @@ public:
     }
 
     int
-    get_page_ids(uint64_t checkpoint_lsn, uint64_t table_id, WT_ITEM *page_ids, size_t *page_count)
+    get_page_ids(uint64_t checkpoint_lsn, WT_ITEM *page_ids, size_t *page_count)
     {
         Storage::Transaction txn = storage.begin_transaction();
         storage.get_page_ids(txn.conn, checkpoint_lsn, table_id, page_ids, page_count);
@@ -1337,10 +1337,10 @@ palite_handle_get(WT_PAGE_LOG_HANDLE *plh, WT_SESSION *sess, uint64_t page_id,
 
 static int
 palite_handle_get_page_ids(WT_PAGE_LOG_HANDLE *plh, WT_SESSION *sess, uint64_t checkpoint_lsn,
-  uint64_t table_id, WT_ITEM *page_ids, size_t *page_count)
+  WT_ITEM *page_ids, size_t *page_count)
 {
     return safe_call<PaliteHandle>(
-      sess, plh, &PaliteHandle::get_page_ids, checkpoint_lsn, table_id, page_ids, page_count);
+      sess, plh, &PaliteHandle::get_page_ids, checkpoint_lsn, page_ids, page_count);
 }
 
 static int

--- a/ext/page_log/palm/palm.c
+++ b/ext/page_log/palm/palm.c
@@ -979,7 +979,7 @@ err:
 
 static int
 palm_handle_get_page_ids(WT_PAGE_LOG_HANDLE *plh, WT_SESSION *session, uint64_t checkpoint_lsn,
-  uint64_t table_id, WT_ITEM *item, size_t *size)
+  WT_ITEM *item, size_t *size)
 {
     PALM_KV_CONTEXT context;
     PALM_HANDLE *palm_handle = (PALM_HANDLE *)plh;
@@ -990,7 +990,7 @@ palm_handle_get_page_ids(WT_PAGE_LOG_HANDLE *plh, WT_SESSION *session, uint64_t 
     PALM_KV_RET(palm, session, palm_kv_begin_transaction(&context, palm->kv_env, false));
 
     int ret;
-    ret = palm_kv_get_page_ids(&context, item, checkpoint_lsn, table_id, size);
+    ret = palm_kv_get_page_ids(&context, item, checkpoint_lsn, palm_handle->table_id, size);
 
     palm_kv_rollback_transaction(&context);
 

--- a/lang/python/wiredtiger.i
+++ b/lang/python/wiredtiger.i
@@ -1262,8 +1262,8 @@ SIDESTEP_METHOD(__wt_page_log_handle, plh_get,
   (self, session, page_id, checkpoint_id, get_args, results_array, results_count))
 
 SIDESTEP_METHOD(__wt_page_log_handle, plh_get_page_ids,
-  (WT_SESSION *session, int checkpoint_lsn, int table_id, WT_ITEM *item, size_t *size),
-  (self, session, checkpoint_lsn, table_id, item, size))
+  (WT_SESSION *session, int checkpoint_lsn, WT_ITEM *item, size_t *size),
+  (self, session, checkpoint_lsn, item, size))
 
 SIDESTEP_METHOD(__wt_page_log_handle, plh_discard,
   (WT_SESSION *session, int page_id, int checkpoint_id, WT_PAGE_LOG_DISCARD_ARGS *discard_args),

--- a/src/block_disagg/block_disagg_mgr.c
+++ b/src/block_disagg/block_disagg_mgr.c
@@ -145,12 +145,10 @@ __bmd_get_page_ids(
   WT_BM *bm, WT_SESSION_IMPL *session, WT_ITEM *item, size_t *size, uint64_t checkpoint_lsn)
 {
     WT_BLOCK_DISAGG *block_disagg;
-    uint64_t table_id;
 
     /* FIXME-WT-15564: Check block is safe to cast as disagg block. */
     WT_ASSERT(session, F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED));
     block_disagg = (WT_BLOCK_DISAGG *)bm->block;
-    table_id = block_disagg->tableid;
 
     if (block_disagg->plhandle->plh_get_page_ids == NULL) {
         __wt_verbose_warning(
@@ -159,7 +157,7 @@ __bmd_get_page_ids(
     }
 
     WT_RET(block_disagg->plhandle->plh_get_page_ids(
-      block_disagg->plhandle, &session->iface, checkpoint_lsn, table_id, item, size));
+      block_disagg->plhandle, &session->iface, checkpoint_lsn, item, size));
 
     return (0);
 }

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -5800,12 +5800,11 @@ struct __wt_page_log_handle {
      * @param plh the WT_PAGE_LOG_HANDLE
      * @param session the current WiredTiger session
      * @param checkpoint_lsn the checkpoint to use
-     * @param table_id the table where we want to get the pages from
      * @param item the WT_ITEM to hold the page ids
      * @param size number of page IDs stored in the array
      */
     int (*plh_get_page_ids)(WT_PAGE_LOG_HANDLE *plh, WT_SESSION *session,
-        uint64_t checkpoint_lsn, uint64_t table_id, WT_ITEM *item, size_t *size);
+        uint64_t checkpoint_lsn, WT_ITEM *item, size_t *size);
 
     /*!
      * Discard an object into the paging/logging service.


### PR DESCRIPTION
Remove redundant parameter of `table_id` in declare and implementation of `plh_get_page_ids`. The modification include both `PALM` and `PALite`