### PR TITLE
WT-15413 Test that verify accounts for followers missing stable constituent prior to checkpoint pickup

### DIFF
--- a/src/schema/schema_worker.c
+++ b/src/schema/schema_worker.c
@@ -84,24 +84,7 @@ __schema_layered_worker_verify(WT_SESSION_IMPL *session, const char *uri,
     conn = S2C(session);
     ingest_ret = 0;
 
-    ret = __wt_session_get_dhandle(session, uri, NULL, NULL, open_flags);
-    if (ret == ENOENT) {
-        if (!conn->layered_table_manager.leader) {
-            /*
-             * We've called verify on the follower before it has picked up its first checkpoint. The
-             * follower will not recognize the layered URI while in this transient state.
-             */
-            __wt_verbose_level(session, WT_VERB_VERIFY, WT_VERBOSE_DEBUG_2,
-              "Verify (layered): Skipping verification for %s - "
-              "the follower has not picked up a checkpoint",
-              uri);
-            return (0);
-        }
-        /* We are a leader. Report real error. */
-        WT_RET(ret);
-    }
-    WT_RET(ret);
-
+    WT_RET(__wt_session_get_dhandle(session, uri, NULL, NULL, open_flags));
     WT_LAYERED_TABLE *layered = (WT_LAYERED_TABLE *)session->dhandle;
 
     const char *ingest_uri = layered->ingest_uri;
@@ -121,22 +104,9 @@ __schema_layered_worker_verify(WT_SESSION_IMPL *session, const char *uri,
     /* Verify the stable table of the layered table. */
     WT_WITHOUT_DHANDLE(session,
       stable_ret = __wt_schema_worker(session, stable_uri, file_func, name_func, cfg, open_flags));
-
-    if (stable_ret != 0 && stable_ret != EBUSY) {
-        /*
-         * If we are a follower, and the stable table is missing, it may be because we have not yet
-         * picked up a checkpoint. In that case, skip the error.
-         */
-        if (stable_ret == ENOENT && !conn->layered_table_manager.leader) {
-            __wt_verbose_level(session, WT_VERB_VERIFY, WT_VERBOSE_DEBUG_2,
-              "Verify (layered): Skipping stable table verification for %s - "
-              "no stable table exists as the follower has not picked up a checkpoint",
-              uri);
-            stable_ret = 0;
-        } else
-            WT_ERR_MSG(session, stable_ret,
-              "Verify (layered): %s stable table verification failed. ", stable_uri);
-    }
+    if (stable_ret != 0 && stable_ret != EBUSY)
+        WT_ERR_MSG(session, stable_ret,
+            "Verify (layered): %s stable table verification failed ", stable_uri);
 
     /*
      * Verify the ingest table of the layered table. FIXME-WT-15047: Implement ingest table

--- a/src/schema/schema_worker.c
+++ b/src/schema/schema_worker.c
@@ -84,18 +84,29 @@ __schema_layered_worker_verify(WT_SESSION_IMPL *session, const char *uri,
     conn = S2C(session);
     ingest_ret = 0;
 
-    WT_RET(__wt_session_get_dhandle(session, uri, NULL, NULL, open_flags));
+    ret = __wt_session_get_dhandle(session, uri, NULL, NULL, open_flags);
+    if (ret == ENOENT) {
+        if (!conn->layered_table_manager.leader) {
+            /*
+             * We've called verify on the follower before it has picked up its first checkpoint. The
+             * follower will not recognize the layered URI while in this transient state.
+             */
+            __wt_verbose_level(session, WT_VERB_VERIFY, WT_VERBOSE_DEBUG_2,
+              "Verify (layered): Skipping verification for %s - "
+              "the follower has not picked up a checkpoint",
+              uri);
+            return (0);
+        }
+        /* We are a leader. Report real error. */
+        WT_RET(ret);
+    }
+    WT_RET(ret);
+
     WT_LAYERED_TABLE *layered = (WT_LAYERED_TABLE *)session->dhandle;
 
     const char *ingest_uri = layered->ingest_uri;
     const char *stable_uri = layered->stable_uri;
 
-    /*
-     * FIXME-WT-15413 - Verify assumes the stable table always exists. However, on followers that
-     * have not yet picked up their first checkpoint, the stable constituent will be missing. We
-     * should handle this transient state by skipping stable verification instead of failing with
-     * ENOENT.
-     */
     WT_ASSERT(session, stable_uri != NULL);
     WT_ASSERT(session, ingest_uri != NULL);
     WT_ASSERT(session, file_func == __wt_verify);
@@ -116,20 +127,12 @@ __schema_layered_worker_verify(WT_SESSION_IMPL *session, const char *uri,
          * If we are a follower, and the stable table is missing, it may be because we have not yet
          * picked up a checkpoint. In that case, skip the error.
          */
-        uint64_t lsn;
-        WT_ACQUIRE_READ(lsn, conn->disaggregated_storage.last_checkpoint_meta_lsn);
-        /*
-         * If the lsn == 0: No checkpoint has ever been picked up, so no stable constituents exist.
-         * If the lsn != 0: At least one checkpoint has been picked up, so stable constituents
-         * should exist.
-         */
-        if (stable_ret == ENOENT && !conn->layered_table_manager.leader &&
-          lsn == WT_DISAGG_LSN_NONE) {
-            stable_ret = 0;
+        if (stable_ret == ENOENT && !conn->layered_table_manager.leader) {
             __wt_verbose_level(session, WT_VERB_VERIFY, WT_VERBOSE_DEBUG_2,
               "Verify (layered): Skipping stable table verification for %s - "
-              "follower has not picked up any checkpoint",
+              "no stable table exists as the follower has not picked up a checkpoint",
               uri);
+            stable_ret = 0;
         } else
             WT_ERR_MSG(session, stable_ret,
               "Verify (layered): %s stable table verification failed. ", stable_uri);

--- a/src/schema/schema_worker.c
+++ b/src/schema/schema_worker.c
@@ -111,9 +111,29 @@ __schema_layered_worker_verify(WT_SESSION_IMPL *session, const char *uri,
     WT_WITHOUT_DHANDLE(session,
       stable_ret = __wt_schema_worker(session, stable_uri, file_func, name_func, cfg, open_flags));
 
-    if (stable_ret != 0 && stable_ret != EBUSY)
-        WT_ERR_MSG(session, stable_ret, "Verify (layered): %s stable table verification failed. ",
-          stable_uri);
+    if (stable_ret != 0 && stable_ret != EBUSY) {
+        /*
+         * If we are a follower, and the stable table is missing, it may be because we have not yet
+         * picked up a checkpoint. In that case, skip the error.
+         */
+        uint64_t lsn;
+        WT_ACQUIRE_READ(lsn, conn->disaggregated_storage.last_checkpoint_meta_lsn);
+        /*
+         * If the lsn == 0: No checkpoint has ever been picked up, so no stable constituents exist.
+         * If the lsn != 0: At least one checkpoint has been picked up, so stable constituents
+         * should exist.
+         */
+        if (stable_ret == ENOENT && !conn->layered_table_manager.leader &&
+          lsn == WT_DISAGG_LSN_NONE) {
+            stable_ret = 0;
+            __wt_verbose_level(session, WT_VERB_VERIFY, WT_VERBOSE_DEBUG_2,
+              "Verify (layered): Skipping stable table verification for %s - "
+              "follower has not picked up any checkpoint",
+              uri);
+        } else
+            WT_ERR_MSG(session, stable_ret,
+              "Verify (layered): %s stable table verification failed. ", stable_uri);
+    }
 
     /*
      * Verify the ingest table of the layered table. FIXME-WT-15047: Implement ingest table

--- a/src/schema/schema_worker.c
+++ b/src/schema/schema_worker.c
@@ -104,9 +104,10 @@ __schema_layered_worker_verify(WT_SESSION_IMPL *session, const char *uri,
     /* Verify the stable table of the layered table. */
     WT_WITHOUT_DHANDLE(session,
       stable_ret = __wt_schema_worker(session, stable_uri, file_func, name_func, cfg, open_flags));
+
     if (stable_ret != 0 && stable_ret != EBUSY)
-        WT_ERR_MSG(session, stable_ret,
-            "Verify (layered): %s stable table verification failed ", stable_uri);
+        WT_ERR_MSG(session, stable_ret, "Verify (layered): %s stable table verification failed ",
+          stable_uri);
 
     /*
      * Verify the ingest table of the layered table. FIXME-WT-15047: Implement ingest table

--- a/test/format/verify.c
+++ b/test/format/verify.c
@@ -57,6 +57,14 @@ table_verify(TABLE *table, void *arg)
     wt_wrap_open_session(conn, &sap, table->track_prefix,
       enable_session_prefetch() ? SESSION_PREFETCH_CFG_ON : NULL, &session);
     ret = session->verify(session, table->uri, "strict");
+    /*
+     * On followers, verify returns ENOENT if the stable constituent is missing. Before the first
+     * checkpoint is picked up or if the table has not been created locally, this is expected
+     * behavior.
+     *
+     * FIXME-WT-15398: verify will always return ENOENT on followers until test/format supports
+     * checkpoint pickup.
+     */
     testutil_assert(
       ret == 0 || ret == EBUSY || (g.disagg_storage_config && !g.disagg_leader && ret == ENOENT));
 

--- a/test/format/verify.c
+++ b/test/format/verify.c
@@ -46,12 +46,12 @@ table_verify(TABLE *table, void *arg)
     /*
      * FIXME-WT-14885: We can run verify on layered tables when deltas are written as a full image.
      */
-    // if (TV(DISAGG_ENABLED)) {
-    //     printf("table.%u skipped verify because verify does not support disagg delta pages. ",
-    //       table->id);
-    //     fflush(stdout);
-    //     return;
-    // }
+    if (TV(DISAGG_ENABLED)) {
+        printf("table.%u skipped verify because verify does not support disagg delta pages. ",
+          table->id);
+        fflush(stdout);
+        return;
+    }
 
     memset(&sap, 0, sizeof(sap));
     wt_wrap_open_session(conn, &sap, table->track_prefix,

--- a/test/format/verify.c
+++ b/test/format/verify.c
@@ -57,8 +57,8 @@ table_verify(TABLE *table, void *arg)
     wt_wrap_open_session(conn, &sap, table->track_prefix,
       enable_session_prefetch() ? SESSION_PREFETCH_CFG_ON : NULL, &session);
     ret = session->verify(session, table->uri, "strict");
-    testutil_assert(ret == 0 || ret == EBUSY ||
-        (g.disagg_storage_config && !g.disagg_leader && ret == ENOENT));
+    testutil_assert(
+      ret == 0 || ret == EBUSY || (g.disagg_storage_config && !g.disagg_leader && ret == ENOENT));
 
     if (ret == EBUSY)
         WARN("table.%u skipped verify because of EBUSY", table->id);

--- a/test/format/verify.c
+++ b/test/format/verify.c
@@ -57,7 +57,8 @@ table_verify(TABLE *table, void *arg)
     wt_wrap_open_session(conn, &sap, table->track_prefix,
       enable_session_prefetch() ? SESSION_PREFETCH_CFG_ON : NULL, &session);
     ret = session->verify(session, table->uri, "strict");
-    testutil_assert(ret == 0 || ret == EBUSY);
+    testutil_assert(ret == 0 || ret == EBUSY ||
+        (g.disagg_storage_config && !g.disagg_leader && ret == ENOENT));
 
     if (ret == EBUSY)
         WARN("table.%u skipped verify because of EBUSY", table->id);

--- a/test/format/verify.c
+++ b/test/format/verify.c
@@ -46,20 +46,18 @@ table_verify(TABLE *table, void *arg)
     /*
      * FIXME-WT-14885: We can run verify on layered tables when deltas are written as a full image.
      */
-    if (TV(DISAGG_ENABLED)) {
-        printf("table.%u skipped verify because verify does not support disagg delta pages. ",
-          table->id);
-        fflush(stdout);
-        return;
-    }
+    // if (TV(DISAGG_ENABLED)) {
+    //     printf("table.%u skipped verify because verify does not support disagg delta pages. ",
+    //       table->id);
+    //     fflush(stdout);
+    //     return;
+    // }
 
     memset(&sap, 0, sizeof(sap));
     wt_wrap_open_session(conn, &sap, table->track_prefix,
       enable_session_prefetch() ? SESSION_PREFETCH_CFG_ON : NULL, &session);
     ret = session->verify(session, table->uri, "strict");
-    testutil_assert(ret == 0 || ret == EBUSY ||
-      /* FIXME-WT-15413: Verify on follower may return ENOENT if stable uri is missing. */
-      (g.disagg_storage_config && !g.disagg_leader && ret == ENOENT));
+    testutil_assert(ret == 0 || ret == EBUSY);
 
     if (ret == EBUSY)
         WARN("table.%u skipped verify because of EBUSY", table->id);

--- a/test/suite/test_verify2.py
+++ b/test/suite/test_verify2.py
@@ -26,7 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import wiredtiger, wttest
+import errno, os, wiredtiger, wttest
 class test_verify2(wttest.WiredTigerTestCase):
     tablename = 'test_verify'
     params = 'key_format=S,value_format=S'
@@ -71,3 +71,10 @@ class test_verify2(wttest.WiredTigerTestCase):
         # We don't need to call checkpoint before calling verify as the btree is not marked as
         # modified.
         self.assertEqual(self.session.verify(self.uri, None), 0)
+
+    # write test just doing session.verify
+    def test_verify_empty(self):
+        #  Verifying a non existant table should return ENOENT
+        self.assertRaisesException(wiredtiger.WiredTigerError,   
+                              lambda: self.session.verify(self.uri, None),  
+                              os.strerror(errno.ENOENT))

--- a/test/suite/test_verify2.py
+++ b/test/suite/test_verify2.py
@@ -73,7 +73,7 @@ class test_verify2(wttest.WiredTigerTestCase):
         self.assertEqual(self.session.verify(self.uri, None), 0)
 
     def test_verify_empty(self):
-        #  Verifying a non existant table should return ENOENT
+        #  Verifying a non-existent table should return ENOENT.
         self.assertRaisesException(wiredtiger.WiredTigerError,
                               lambda: self.session.verify(self.uri, None),
                               os.strerror(errno.ENOENT))

--- a/test/suite/test_verify2.py
+++ b/test/suite/test_verify2.py
@@ -72,9 +72,8 @@ class test_verify2(wttest.WiredTigerTestCase):
         # modified.
         self.assertEqual(self.session.verify(self.uri, None), 0)
 
-    # write test just doing session.verify
     def test_verify_empty(self):
         #  Verifying a non existant table should return ENOENT
-        self.assertRaisesException(wiredtiger.WiredTigerError,   
-                              lambda: self.session.verify(self.uri, None),  
+        self.assertRaisesException(wiredtiger.WiredTigerError,
+                              lambda: self.session.verify(self.uri, None),
                               os.strerror(errno.ENOENT))

--- a/test/suite/test_verify_disagg.py
+++ b/test/suite/test_verify_disagg.py
@@ -101,7 +101,7 @@ class test_verify_disagg(wttest.WiredTigerTestCase, DisaggConfigMixin):
         self.verify([self.session])
 
         # The follower has not picked up its first checkpoint. The follower will not recognize
-        # the layered URI while in this transient state. ENOENT
+        # the layered URI while in this transient state, expect ENOENT.
         self.verify([self.session_follow], errno.ENOENT)
 
         # Create an empty checkpoint

--- a/test/suite/test_verify_disagg.py
+++ b/test/suite/test_verify_disagg.py
@@ -58,8 +58,6 @@ class test_verify_disagg(wttest.WiredTigerTestCase, DisaggConfigMixin):
     conn_follow = None
 
     uri = 'layered:test_verify_disagg'
-    # Use internals to test a specific edge case scenario.
-    ingest_uri = 'file:test_verify_disagg.wt_ingest'
 
     def leader_put_data(self, value_prefix = '', low = 1, high = nitems):
         cursor = self.session.open_cursor(self.uri, None, None)
@@ -101,9 +99,9 @@ class test_verify_disagg(wttest.WiredTigerTestCase, DisaggConfigMixin):
         # ingest constituents. They see stable through checkpoint or step-up.
         self.verify([self.session])
 
-        # Follower has not picked up a checkpoint yet, so it has no stable constituent yet
-        # FIXME-WT-15413 - until this is fixed, expect ENOENT
-        self.verify([self.session_follow], errno.ENOENT)
+        # The follower has not picked up its first checkpoint. The follower will not recognize
+        # the layered URI while in this transient state. Skip verification and return success.
+        self.verify([self.session_follow])
 
         # Create an empty checkpoint
         self.session.checkpoint()

--- a/test/suite/test_verify_disagg.py
+++ b/test/suite/test_verify_disagg.py
@@ -83,6 +83,7 @@ class test_verify_disagg(wttest.WiredTigerTestCase, DisaggConfigMixin):
                                                 self.conn_config_follower)
         self.session_follow = self.conn_follow.open_session('')
 
+
     def test_verify_disagg(self):
         if self.fill_hs:
             self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(self.timestamp))
@@ -100,8 +101,8 @@ class test_verify_disagg(wttest.WiredTigerTestCase, DisaggConfigMixin):
         self.verify([self.session])
 
         # The follower has not picked up its first checkpoint. The follower will not recognize
-        # the layered URI while in this transient state. Skip verification and return success.
-        self.verify([self.session_follow])
+        # the layered URI while in this transient state. ENOENT
+        self.verify([self.session_follow], errno.ENOENT)
 
         # Create an empty checkpoint
         self.session.checkpoint()
@@ -136,3 +137,42 @@ class test_verify_disagg(wttest.WiredTigerTestCase, DisaggConfigMixin):
         self.verify([self.session])
         # FIXME-WT-14700: remove ignore after freeing root pages is addressed.
         self.ignoreStdoutPattern("Mismatch in page IDs")
+
+    def test_verify_leader_no_table(self):
+        # Layered table does not exist, expect ENOENT
+        self.verify([self.session], errno.ENOENT)
+
+    def test_verify_follower_no_metadata(self):
+         # Create a layered table on the leader
+        self.session.create(self.uri, self.table_cfg)
+        # Verify the empty leader's table
+        self.verify([self.session])
+
+        # Create a follower
+        self.create_follower()
+        # The follower has not picked up its first checkpoint. The follower will not recognize
+        # the layered URI while in this transient state. Return ENOENT.
+        self.verify([self.session_follow], errno.ENOENT)
+
+        self.session_follow.close()
+        self.conn_follow.close()
+
+    def test_verify_follower_no_checkpoint(self):
+        # Create a layered table on the leader
+        self.session.create(self.uri, self.table_cfg)
+        # Verify the empty leader's table
+        self.verify([self.session])
+
+        # Create a follower
+        self.create_follower()
+        # Create a table on the follower
+        self.session_follow.create(self.uri, self.table_cfg)
+
+        # The follower has not picked up its first checkpoint. But since we created the layered
+        # table, it should be able to run verify on the layered URI. However,the stable table
+        # does not exist, so we expect ENOENT. Followers are only able to create their ingest
+        # constituents. They see stable through checkpoint or step-up.
+        self.verify([self.session_follow], errno.ENOENT)
+
+        self.session_follow.close()
+        self.conn_follow.close()

--- a/test/suite/test_verify_disagg.py
+++ b/test/suite/test_verify_disagg.py
@@ -151,7 +151,7 @@ class test_verify_disagg(wttest.WiredTigerTestCase, DisaggConfigMixin):
         # Create a follower
         self.create_follower()
         # The follower has not picked up its first checkpoint. The follower will not recognize
-        # the layered URI while in this transient state. Return ENOENT.
+        # the layered URI while in this transient state. Expect ENOENT.
         self.verify([self.session_follow], errno.ENOENT)
 
         self.session_follow.close()

--- a/test/suite/test_verify_disagg.py
+++ b/test/suite/test_verify_disagg.py
@@ -154,6 +154,13 @@ class test_verify_disagg(wttest.WiredTigerTestCase, DisaggConfigMixin):
         # the layered URI while in this transient state. Expect ENOENT.
         self.verify([self.session_follow], errno.ENOENT)
 
+        # Create an empty checkpoint
+        self.session.checkpoint()
+        # Load the latest checkpoint to the follower
+        self.disagg_advance_checkpoint(self.conn_follow)
+        # Follower verification now succeeds
+        self.verify([self.session_follow])
+
         self.session_follow.close()
         self.conn_follow.close()
 
@@ -173,6 +180,13 @@ class test_verify_disagg(wttest.WiredTigerTestCase, DisaggConfigMixin):
         # does not exist, so we expect ENOENT. Followers are only able to create their ingest
         # constituents. They see stable through checkpoint or step-up.
         self.verify([self.session_follow], errno.ENOENT)
+
+        # Create an empty checkpoint
+        self.session.checkpoint()
+        # Load the latest checkpoint to the follower
+        self.disagg_advance_checkpoint(self.conn_follow)
+        # Follower verification now succeeds
+        self.verify([self.session_follow])
 
         self.session_follow.close()
         self.conn_follow.close()


### PR DESCRIPTION
Add testing to ensure that verify returns ENOENT for followers that have not picked up their first checkpoint to match verify behaviour for regular tables