### PR TITLE
WT-15622 Skip walking read-only btrees in eviction server if we are not looking for clean pages

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -381,6 +381,7 @@ conn_stats = [
     EvictStat('eviction_server_skip_pages_retry', 'eviction server skips pages that previously failed eviction and likely will again'),
     EvictStat('eviction_server_skip_trees_eviction_disabled', 'eviction server skips trees that disable eviction'),
     EvictStat('eviction_server_skip_trees_not_useful_before', 'eviction server skips trees that were not useful before'),
+    EvictStat('eviction_server_skip_trees_read_only', 'eviction server skips trees that are read-only if it is not looking for clean pages'),
     EvictStat('eviction_server_skip_trees_stick_in_cache', 'eviction server skips trees that are configured to stick in cache'),
     EvictStat('eviction_server_skip_trees_too_many_active_walks', 'eviction server skips trees because there are too many active walks'),
     EvictStat('eviction_server_skip_unwanted_pages', 'eviction server skips pages that we do not want to evict'),

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1789,9 +1789,13 @@ retry:
             continue;
         }
 
-        /*
-         * Skip files that are checkpointing if we are only looking for dirty pages.
-         */
+        /* Skip read-only btrees if we are not looking for clean pages. */
+        if (!F_ISSET(evict, WT_EVICT_CACHE_CLEAN) && F_ISSET(btree, WT_BTREE_READONLY)) {
+            WT_STAT_CONN_INCR(session, eviction_server_skip_trees_read_only);
+            continue;
+        }
+
+        /* Skip files that are checkpointing if we are only looking for dirty pages. */
         if (WT_BTREE_SYNCING(btree) &&
           !F_ISSET(evict, WT_EVICT_CACHE_CLEAN | WT_EVICT_CACHE_UPDATES)) {
             WT_STAT_CONN_INCR(session, eviction_server_skip_checkpointing_trees);

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -558,6 +558,7 @@ struct __wt_connection_stats {
     int64_t eviction_server_skip_trees_too_many_active_walks;
     int64_t eviction_server_skip_checkpointing_trees;
     int64_t eviction_server_skip_trees_stick_in_cache;
+    int64_t eviction_server_skip_trees_read_only;
     int64_t eviction_server_skip_trees_eviction_disabled;
     int64_t eviction_server_skip_trees_not_useful_before;
     int64_t eviction_server_slept;

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -6393,1985 +6393,1990 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
  * cache
  */
 #define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_STICK_IN_CACHE	1140
+/*!
+ * cache: eviction server skips trees that are read-only if it is not
+ * looking for clean pages
+ */
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_READ_ONLY	1141
 /*! cache: eviction server skips trees that disable eviction */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_EVICTION_DISABLED	1141
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_EVICTION_DISABLED	1142
 /*! cache: eviction server skips trees that were not useful before */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_NOT_USEFUL_BEFORE	1142
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_NOT_USEFUL_BEFORE	1143
 /*!
  * cache: eviction server slept, because we did not make progress with
  * eviction
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SLEPT		1143
+#define	WT_STAT_CONN_EVICTION_SERVER_SLEPT		1144
 /*! cache: eviction server unable to reach eviction goal */
-#define	WT_STAT_CONN_EVICTION_SLOW			1144
+#define	WT_STAT_CONN_EVICTION_SLOW			1145
 /*! cache: eviction server waiting for a leaf page */
-#define	WT_STAT_CONN_EVICTION_WALK_LEAF_NOTFOUND	1145
+#define	WT_STAT_CONN_EVICTION_WALK_LEAF_NOTFOUND	1146
 /*! cache: eviction state */
-#define	WT_STAT_CONN_EVICTION_STATE			1146
+#define	WT_STAT_CONN_EVICTION_STATE			1147
 /*!
  * cache: eviction walk most recent sleeps for checkpoint handle
  * gathering
  */
-#define	WT_STAT_CONN_EVICTION_WALK_SLEEPS		1147
+#define	WT_STAT_CONN_EVICTION_WALK_SLEEPS		1148
 /*! cache: eviction walk pages queued that had updates */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_UPDATES	1148
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_UPDATES	1149
 /*! cache: eviction walk pages queued that were clean */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_CLEAN	1149
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_CLEAN	1150
 /*! cache: eviction walk pages queued that were dirty */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_DIRTY	1150
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_DIRTY	1151
 /*! cache: eviction walk pages seen that had updates */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN_UPDATES	1151
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN_UPDATES	1152
 /*! cache: eviction walk pages seen that were clean */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN_CLEAN	1152
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN_CLEAN	1153
 /*! cache: eviction walk pages seen that were dirty */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN_DIRTY	1153
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN_DIRTY	1154
 /*! cache: eviction walk restored - had to walk this many pages */
-#define	WT_STAT_CONN_NPOS_EVICT_WALK_MAX		1154
+#define	WT_STAT_CONN_NPOS_EVICT_WALK_MAX		1155
 /*! cache: eviction walk restored position */
-#define	WT_STAT_CONN_EVICTION_RESTORED_POS		1155
+#define	WT_STAT_CONN_EVICTION_RESTORED_POS		1156
 /*! cache: eviction walk restored position differs from the saved one */
-#define	WT_STAT_CONN_EVICTION_RESTORED_POS_DIFFER	1156
+#define	WT_STAT_CONN_EVICTION_RESTORED_POS_DIFFER	1157
 /*! cache: eviction walk target pages histogram - 0-9 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT10	1157
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT10	1158
 /*! cache: eviction walk target pages histogram - 10-31 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT32	1158
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT32	1159
 /*! cache: eviction walk target pages histogram - 128 and higher */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_GE128	1159
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_GE128	1160
 /*! cache: eviction walk target pages histogram - 32-63 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT64	1160
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT64	1161
 /*! cache: eviction walk target pages histogram - 64-128 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT128	1161
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT128	1162
 /*!
  * cache: eviction walk target pages reduced due to history store cache
  * pressure
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_REDUCED	1162
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_REDUCED	1163
 /*! cache: eviction walk target strategy clean pages */
-#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_CLEAN	1163
+#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_CLEAN	1164
 /*! cache: eviction walk target strategy dirty pages */
-#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_DIRTY	1164
+#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_DIRTY	1165
 /*! cache: eviction walk target strategy pages with updates */
-#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_UPDATES	1165
+#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_UPDATES	1166
 /*! cache: eviction walks abandoned */
-#define	WT_STAT_CONN_EVICTION_WALKS_ABANDONED		1166
+#define	WT_STAT_CONN_EVICTION_WALKS_ABANDONED		1167
 /*! cache: eviction walks gave up because they restarted their walk twice */
-#define	WT_STAT_CONN_EVICTION_WALKS_STOPPED		1167
+#define	WT_STAT_CONN_EVICTION_WALKS_STOPPED		1168
 /*!
  * cache: eviction walks gave up because they saw too many pages and
  * found no candidates
  */
-#define	WT_STAT_CONN_EVICTION_WALKS_GAVE_UP_NO_TARGETS	1168
+#define	WT_STAT_CONN_EVICTION_WALKS_GAVE_UP_NO_TARGETS	1169
 /*!
  * cache: eviction walks gave up because they saw too many pages and
  * found too few candidates
  */
-#define	WT_STAT_CONN_EVICTION_WALKS_GAVE_UP_RATIO	1169
+#define	WT_STAT_CONN_EVICTION_WALKS_GAVE_UP_RATIO	1170
 /*!
  * cache: eviction walks random search fails to locate a page, results in
  * a null position
  */
-#define	WT_STAT_CONN_EVICTION_WALK_RANDOM_RETURNS_NULL_POSITION	1170
+#define	WT_STAT_CONN_EVICTION_WALK_RANDOM_RETURNS_NULL_POSITION	1171
 /*! cache: eviction walks reached end of tree */
-#define	WT_STAT_CONN_EVICTION_WALKS_ENDED		1171
+#define	WT_STAT_CONN_EVICTION_WALKS_ENDED		1172
 /*! cache: eviction walks restarted */
-#define	WT_STAT_CONN_EVICTION_WALK_RESTART		1172
+#define	WT_STAT_CONN_EVICTION_WALK_RESTART		1173
 /*! cache: eviction walks started from root of tree */
-#define	WT_STAT_CONN_EVICTION_WALK_FROM_ROOT		1173
+#define	WT_STAT_CONN_EVICTION_WALK_FROM_ROOT		1174
 /*! cache: eviction walks started from saved location in tree */
-#define	WT_STAT_CONN_EVICTION_WALK_SAVED_POS		1174
+#define	WT_STAT_CONN_EVICTION_WALK_SAVED_POS		1175
 /*! cache: eviction worker thread active */
-#define	WT_STAT_CONN_EVICTION_ACTIVE_WORKERS		1175
+#define	WT_STAT_CONN_EVICTION_ACTIVE_WORKERS		1176
 /*! cache: eviction worker thread stable number */
-#define	WT_STAT_CONN_EVICTION_STABLE_STATE_WORKERS	1176
+#define	WT_STAT_CONN_EVICTION_STABLE_STATE_WORKERS	1177
 /*! cache: files with active eviction walks */
-#define	WT_STAT_CONN_EVICTION_WALKS_ACTIVE		1177
+#define	WT_STAT_CONN_EVICTION_WALKS_ACTIVE		1178
 /*! cache: files with new eviction walks started */
-#define	WT_STAT_CONN_EVICTION_WALKS_STARTED		1178
+#define	WT_STAT_CONN_EVICTION_WALKS_STARTED		1179
 /*!
  * cache: forced eviction - do not retry count to evict pages selected to
  * evict during reconciliation
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_NO_RETRY		1179
+#define	WT_STAT_CONN_EVICTION_FORCE_NO_RETRY		1180
 /*!
  * cache: forced eviction - history store pages failed to evict while
  * session has history store cursor open
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_HS_FAIL		1180
+#define	WT_STAT_CONN_EVICTION_FORCE_HS_FAIL		1181
 /*!
  * cache: forced eviction - history store pages selected while session
  * has history store cursor open
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_HS			1181
+#define	WT_STAT_CONN_EVICTION_FORCE_HS			1182
 /*!
  * cache: forced eviction - history store pages successfully evicted
  * while session has history store cursor open
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_HS_SUCCESS		1182
+#define	WT_STAT_CONN_EVICTION_FORCE_HS_SUCCESS		1183
 /*! cache: forced eviction - pages evicted that were clean count */
-#define	WT_STAT_CONN_EVICTION_FORCE_CLEAN		1183
+#define	WT_STAT_CONN_EVICTION_FORCE_CLEAN		1184
 /*! cache: forced eviction - pages evicted that were dirty count */
-#define	WT_STAT_CONN_EVICTION_FORCE_DIRTY		1184
+#define	WT_STAT_CONN_EVICTION_FORCE_DIRTY		1185
 /*!
  * cache: forced eviction - pages selected because of a large number of
  * updates to a single item
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_LONG_UPDATE_LIST	1185
+#define	WT_STAT_CONN_EVICTION_FORCE_LONG_UPDATE_LIST	1186
 /*!
  * cache: forced eviction - pages selected because of too many deleted
  * items count
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_DELETE		1186
+#define	WT_STAT_CONN_EVICTION_FORCE_DELETE		1187
 /*! cache: forced eviction - pages selected count */
-#define	WT_STAT_CONN_EVICTION_FORCE			1187
+#define	WT_STAT_CONN_EVICTION_FORCE			1188
 /*! cache: forced eviction - pages selected unable to be evicted count */
-#define	WT_STAT_CONN_EVICTION_FORCE_FAIL		1188
+#define	WT_STAT_CONN_EVICTION_FORCE_FAIL		1189
 /*! cache: hazard pointer blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_HAZARD	1189
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_HAZARD	1190
 /*! cache: hazard pointer check calls */
-#define	WT_STAT_CONN_CACHE_HAZARD_CHECKS		1190
+#define	WT_STAT_CONN_CACHE_HAZARD_CHECKS		1191
 /*! cache: hazard pointer check entries walked */
-#define	WT_STAT_CONN_CACHE_HAZARD_WALKS			1191
+#define	WT_STAT_CONN_CACHE_HAZARD_WALKS			1192
 /*! cache: hazard pointer maximum array length */
-#define	WT_STAT_CONN_CACHE_HAZARD_MAX			1192
+#define	WT_STAT_CONN_CACHE_HAZARD_MAX			1193
 /*! cache: history store cursor not cached during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_HS_CURSOR_NOT_CACHED	1193
+#define	WT_STAT_CONN_CACHE_EVICTION_HS_CURSOR_NOT_CACHED	1194
 /*! cache: history store table insert calls */
-#define	WT_STAT_CONN_CACHE_HS_INSERT			1194
+#define	WT_STAT_CONN_CACHE_HS_INSERT			1195
 /*! cache: history store table insert calls that returned restart */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_RESTART		1195
+#define	WT_STAT_CONN_CACHE_HS_INSERT_RESTART		1196
 /*! cache: history store table max on-disk size */
-#define	WT_STAT_CONN_CACHE_HS_ONDISK_MAX		1196
+#define	WT_STAT_CONN_CACHE_HS_ONDISK_MAX		1197
 /*! cache: history store table on-disk size */
-#define	WT_STAT_CONN_CACHE_HS_ONDISK			1197
+#define	WT_STAT_CONN_CACHE_HS_ONDISK			1198
 /*! cache: history store table reads */
-#define	WT_STAT_CONN_CACHE_HS_READ			1198
+#define	WT_STAT_CONN_CACHE_HS_READ			1199
 /*! cache: history store table reads missed */
-#define	WT_STAT_CONN_CACHE_HS_READ_MISS			1199
+#define	WT_STAT_CONN_CACHE_HS_READ_MISS			1200
 /*! cache: history store table reads requiring squashed modifies */
-#define	WT_STAT_CONN_CACHE_HS_READ_SQUASH		1200
+#define	WT_STAT_CONN_CACHE_HS_READ_SQUASH		1201
 /*!
  * cache: history store table resolved updates without timestamps that
  * lose their durable timestamp
  */
-#define	WT_STAT_CONN_CACHE_HS_ORDER_LOSE_DURABLE_TIMESTAMP	1201
+#define	WT_STAT_CONN_CACHE_HS_ORDER_LOSE_DURABLE_TIMESTAMP	1202
 /*!
  * cache: history store table truncation by rollback to stable to remove
  * an unstable update
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE	1202
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE	1203
 /*!
  * cache: history store table truncation by rollback to stable to remove
  * an update
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS		1203
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS		1204
 /*!
  * cache: history store table truncation to remove all the keys of a
  * btree
  */
-#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE		1204
+#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE		1205
 /*! cache: history store table truncation to remove an update */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE		1205
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE		1206
 /*!
  * cache: history store table truncation to remove range of updates due
  * to an update without a timestamp on data page
  */
-#define	WT_STAT_CONN_CACHE_HS_ORDER_REMOVE		1206
+#define	WT_STAT_CONN_CACHE_HS_ORDER_REMOVE		1207
 /*!
  * cache: history store table truncation to remove range of updates due
  * to key being removed from the data page during reconciliation
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_ONPAGE_REMOVAL	1207
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_ONPAGE_REMOVAL	1208
 /*!
  * cache: history store table truncations that would have happened in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE_DRYRUN	1208
+#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE_DRYRUN	1209
 /*!
  * cache: history store table truncations to remove an unstable update
  * that would have happened in non-dryrun mode
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE_DRYRUN	1209
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE_DRYRUN	1210
 /*!
  * cache: history store table truncations to remove an update that would
  * have happened in non-dryrun mode
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_DRYRUN	1210
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_DRYRUN	1211
 /*!
  * cache: history store table updates without timestamps fixed up by
  * reinserting with the fixed timestamp
  */
-#define	WT_STAT_CONN_CACHE_HS_ORDER_REINSERT		1211
+#define	WT_STAT_CONN_CACHE_HS_ORDER_REINSERT		1212
 /*! cache: history store table writes requiring squashed modifies */
-#define	WT_STAT_CONN_CACHE_HS_WRITE_SQUASH		1212
+#define	WT_STAT_CONN_CACHE_HS_WRITE_SQUASH		1213
 /*! cache: in-memory page passed criteria to be split */
-#define	WT_STAT_CONN_CACHE_INMEM_SPLITTABLE		1213
+#define	WT_STAT_CONN_CACHE_INMEM_SPLITTABLE		1214
 /*! cache: in-memory page splits */
-#define	WT_STAT_CONN_CACHE_INMEM_SPLIT			1214
+#define	WT_STAT_CONN_CACHE_INMEM_SPLIT			1215
 /*! cache: internal page split blocked its eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_INTERNAL_PAGE_SPLIT	1215
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_INTERNAL_PAGE_SPLIT	1216
 /*! cache: internal pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL		1216
+#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL		1217
 /*! cache: internal pages queued for eviction */
-#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_QUEUED	1217
+#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_QUEUED	1218
 /*! cache: internal pages seen by eviction walk */
-#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_SEEN	1218
+#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_SEEN	1219
 /*! cache: internal pages seen by eviction walk that are already queued */
-#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_ALREADY_QUEUED	1219
+#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_ALREADY_QUEUED	1220
 /*! cache: internal pages split during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_INTERNAL	1220
+#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_INTERNAL	1221
 /*! cache: leaf pages split during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_LEAF		1221
+#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_LEAF		1222
 /*!
  * cache: locate a random in-mem ref by examining all entries on the root
  * page
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_RANDOM_SAMPLE_INMEM_ROOT	1222
+#define	WT_STAT_CONN_CACHE_EVICTION_RANDOM_SAMPLE_INMEM_ROOT	1223
 /*! cache: maximum bytes configured */
-#define	WT_STAT_CONN_CACHE_BYTES_MAX			1223
+#define	WT_STAT_CONN_CACHE_BYTES_MAX			1224
 /*!
  * cache: maximum gap between page and connection evict pass generation
  * seen at eviction
  */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_GEN_GAP		1224
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_GEN_GAP		1225
 /*! cache: maximum milliseconds spent at a single eviction */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_MILLISECONDS	1225
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_MILLISECONDS	1226
 /*! cache: maximum page size seen at eviction */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_PAGE_SIZE		1226
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_PAGE_SIZE		1227
 /*! cache: modified page evict attempts by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_DIRTY_ATTEMPT		1227
+#define	WT_STAT_CONN_EVICTION_APP_DIRTY_ATTEMPT		1228
 /*! cache: modified page evict failures by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_DIRTY_FAIL		1228
+#define	WT_STAT_CONN_EVICTION_APP_DIRTY_FAIL		1229
 /*! cache: modified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1229
+#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1230
 /*! cache: multi-block reconciliation blocked whilst checkpoint is running */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_MULTI_BLOCK_RECONCILIATION_DURING_CHECKPOINT	1230
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_MULTI_BLOCK_RECONCILIATION_DURING_CHECKPOINT	1231
 /*! cache: npos read - had to walk this many pages */
-#define	WT_STAT_CONN_NPOS_READ_WALK_MAX			1231
+#define	WT_STAT_CONN_NPOS_READ_WALK_MAX			1232
 /*! cache: number of internal pages read that had deltas attached */
-#define	WT_STAT_CONN_CACHE_READ_INTERNAL_DELTA		1232
+#define	WT_STAT_CONN_CACHE_READ_INTERNAL_DELTA		1233
 /*! cache: number of leaf pages flattened that had deltas attached */
-#define	WT_STAT_CONN_CACHE_READ_FLATTEN_LEAF_DELTA	1233
+#define	WT_STAT_CONN_CACHE_READ_FLATTEN_LEAF_DELTA	1234
 /*!
  * cache: number of leaf pages not flattened that had deltas attached due
  * to failure
  */
-#define	WT_STAT_CONN_CACHE_READ_FLATTEN_LEAF_DELTA_FAIL	1234
+#define	WT_STAT_CONN_CACHE_READ_FLATTEN_LEAF_DELTA_FAIL	1235
 /*! cache: number of leaf pages read that had deltas attached */
-#define	WT_STAT_CONN_CACHE_READ_LEAF_DELTA		1235
+#define	WT_STAT_CONN_CACHE_READ_LEAF_DELTA		1236
 /*! cache: number of times dirty trigger was reached */
-#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_DIRTY_REACHED	1236
+#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_DIRTY_REACHED	1237
 /*! cache: number of times eviction trigger was reached */
-#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_REACHED	1237
+#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_REACHED	1238
 /*! cache: number of times updates trigger was reached */
-#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_UPDATES_REACHED	1238
+#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_UPDATES_REACHED	1239
 /*! cache: operations timed out waiting for space in cache */
-#define	WT_STAT_CONN_EVICTION_TIMED_OUT_OPS		1239
+#define	WT_STAT_CONN_EVICTION_TIMED_OUT_OPS		1240
 /*!
  * cache: overflow keys on a multiblock row-store page blocked its
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_OVERFLOW_KEYS	1240
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_OVERFLOW_KEYS	1241
 /*! cache: overflow pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ_OVERFLOW		1241
+#define	WT_STAT_CONN_CACHE_READ_OVERFLOW		1242
 /*! cache: page evict attempts by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_ATTEMPT		1242
+#define	WT_STAT_CONN_EVICTION_APP_ATTEMPT		1243
 /*! cache: page evict failures by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_FAIL			1243
+#define	WT_STAT_CONN_EVICTION_APP_FAIL			1244
 /*! cache: page eviction blocked due to materialization frontier */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_MATERIALIZATION	1244
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_MATERIALIZATION	1245
 /*!
  * cache: page eviction blocked in disaggregated storage as it can only
  * be written by the next checkpoint
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_DISAGG_NEXT_CHECKPOINT	1245
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_DISAGG_NEXT_CHECKPOINT	1246
 /*! cache: page split during eviction deepened the tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1246
+#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1247
 /*! cache: page written requiring history store records */
-#define	WT_STAT_CONN_CACHE_WRITE_HS			1247
+#define	WT_STAT_CONN_CACHE_WRITE_HS			1248
 /*! cache: pages considered for eviction that were brought in by pre-fetch */
-#define	WT_STAT_CONN_EVICTION_CONSIDER_PREFETCH		1248
+#define	WT_STAT_CONN_EVICTION_CONSIDER_PREFETCH		1249
 /*! cache: pages currently held in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_INUSE			1249
+#define	WT_STAT_CONN_CACHE_PAGES_INUSE			1250
 /*! cache: pages dirtied due to obsolete time window by eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY_OBSOLETE_TW	1250
+#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY_OBSOLETE_TW	1251
 /*! cache: pages evicted ahead of the page materialization frontier */
-#define	WT_STAT_CONN_CACHE_EVICTION_AHEAD_OF_LAST_MATERIALIZED_LSN	1251
+#define	WT_STAT_CONN_CACHE_EVICTION_AHEAD_OF_LAST_MATERIALIZED_LSN	1252
 /*! cache: pages evicted in parallel with checkpoint */
-#define	WT_STAT_CONN_EVICTION_PAGES_IN_PARALLEL_WITH_CHECKPOINT	1252
+#define	WT_STAT_CONN_EVICTION_PAGES_IN_PARALLEL_WITH_CHECKPOINT	1253
 /*! cache: pages queued for eviction */
-#define	WT_STAT_CONN_EVICTION_PAGES_ORDINARY_QUEUED	1253
+#define	WT_STAT_CONN_EVICTION_PAGES_ORDINARY_QUEUED	1254
 /*! cache: pages queued for eviction post lru sorting */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_POST_LRU	1254
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_POST_LRU	1255
 /*! cache: pages queued for urgent eviction */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT	1255
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT	1256
 /*! cache: pages queued for urgent eviction during walk */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_OLDEST	1256
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_OLDEST	1257
 /*!
  * cache: pages queued for urgent eviction from history store due to high
  * dirty content
  */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT_HS_DIRTY	1257
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT_HS_DIRTY	1258
 /*! cache: pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ				1258
+#define	WT_STAT_CONN_CACHE_READ				1259
 /*! cache: pages read into cache after truncate */
-#define	WT_STAT_CONN_CACHE_READ_DELETED			1259
+#define	WT_STAT_CONN_CACHE_READ_DELETED			1260
 /*! cache: pages read into cache after truncate in prepare state */
-#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1260
+#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1261
 /*! cache: pages read into cache by checkpoint */
-#define	WT_STAT_CONN_CACHE_READ_CHECKPOINT		1261
+#define	WT_STAT_CONN_CACHE_READ_CHECKPOINT		1262
 /*!
  * cache: pages removed from the ordinary queue to be queued for urgent
  * eviction
  */
-#define	WT_STAT_CONN_EVICTION_CLEAR_ORDINARY		1262
+#define	WT_STAT_CONN_EVICTION_CLEAR_ORDINARY		1263
 /*! cache: pages requested from the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1263
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1264
 /*! cache: pages requested from the cache due to pre-fetch */
-#define	WT_STAT_CONN_CACHE_PAGES_PREFETCH		1264
+#define	WT_STAT_CONN_CACHE_PAGES_PREFETCH		1265
 /*! cache: pages requested from the cache internal */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_INTERNAL	1265
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_INTERNAL	1266
 /*! cache: pages requested from the cache leaf */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_LEAF		1266
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_LEAF		1267
 /*! cache: pages seen by eviction walk */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1267
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1268
 /*! cache: pages seen by eviction walk that are already queued */
-#define	WT_STAT_CONN_EVICTION_PAGES_ALREADY_QUEUED	1268
+#define	WT_STAT_CONN_EVICTION_PAGES_ALREADY_QUEUED	1269
 /*! cache: pages selected for eviction unable to be evicted */
-#define	WT_STAT_CONN_EVICTION_FAIL			1269
+#define	WT_STAT_CONN_EVICTION_FAIL			1270
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * active children on an internal page
  */
-#define	WT_STAT_CONN_EVICTION_FAIL_ACTIVE_CHILDREN_ON_AN_INTERNAL_PAGE	1270
+#define	WT_STAT_CONN_EVICTION_FAIL_ACTIVE_CHILDREN_ON_AN_INTERNAL_PAGE	1271
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * failure in reconciliation
  */
-#define	WT_STAT_CONN_EVICTION_FAIL_IN_RECONCILIATION	1271
+#define	WT_STAT_CONN_EVICTION_FAIL_IN_RECONCILIATION	1272
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * race between checkpoint and updates without timestamps
  */
-#define	WT_STAT_CONN_EVICTION_FAIL_CHECKPOINT_NO_TS	1272
+#define	WT_STAT_CONN_EVICTION_FAIL_CHECKPOINT_NO_TS	1273
 /*! cache: pages walked for eviction */
-#define	WT_STAT_CONN_EVICTION_WALK			1273
+#define	WT_STAT_CONN_EVICTION_WALK			1274
 /*! cache: pages written from cache */
-#define	WT_STAT_CONN_CACHE_WRITE			1274
+#define	WT_STAT_CONN_CACHE_WRITE			1275
 /*! cache: pages written requiring in-memory restoration */
-#define	WT_STAT_CONN_CACHE_WRITE_RESTORE		1275
+#define	WT_STAT_CONN_CACHE_WRITE_RESTORE		1276
 /*! cache: percentage overhead */
-#define	WT_STAT_CONN_CACHE_OVERHEAD			1276
+#define	WT_STAT_CONN_CACHE_OVERHEAD			1277
 /*!
  * cache: precise checkpoint caused an eviction to be skipped because any
  * dirty content needs to remain in cache
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_PRECISE_CHECKPOINT	1277
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_PRECISE_CHECKPOINT	1278
 /*!
  * cache: realizing in-memory split after reconciliation failed due to
  * internal lock busy
  */
-#define	WT_STAT_CONN_CACHE_EVICT_SPLIT_FAILED_LOCK	1278
+#define	WT_STAT_CONN_CACHE_EVICT_SPLIT_FAILED_LOCK	1279
 /*! cache: recent modification of a page blocked its eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	1279
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	1280
 /*! cache: reconciled pages scrubbed and added back to the cache clean */
-#define	WT_STAT_CONN_CACHE_SCRUB_RESTORE		1280
+#define	WT_STAT_CONN_CACHE_SCRUB_RESTORE		1281
 /*! cache: reverse splits performed */
-#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS		1281
+#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS		1282
 /*!
  * cache: reverse splits skipped because of VLCS namespace gap
  * restrictions
  */
-#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	1282
+#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	1283
 /*! cache: shared history store cursor not cached during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_HS_SHARED_CURSOR_NOT_CACHED	1283
+#define	WT_STAT_CONN_CACHE_EVICTION_HS_SHARED_CURSOR_NOT_CACHED	1284
 /*! cache: size of delta updates reconstructed on the base page */
-#define	WT_STAT_CONN_CACHE_READ_DELTA_UPDATES		1284
+#define	WT_STAT_CONN_CACHE_READ_DELTA_UPDATES		1285
 /*! cache: size of tombstones restored when reading a page */
-#define	WT_STAT_CONN_CACHE_READ_RESTORED_TOMBSTONE_BYTES	1285
+#define	WT_STAT_CONN_CACHE_READ_RESTORED_TOMBSTONE_BYTES	1286
 /*! cache: the number of times full update inserted to history store */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1286
+#define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1287
 /*! cache: the number of times reverse modify inserted to history store */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1287
+#define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1288
 /*!
  * cache: total milliseconds spent inside reentrant history store
  * evictions in a reconciliation
  */
-#define	WT_STAT_CONN_EVICTION_REENTRY_HS_EVICTION_MILLISECONDS	1288
+#define	WT_STAT_CONN_EVICTION_REENTRY_HS_EVICTION_MILLISECONDS	1289
 /*! cache: tracked bytes belonging to internal pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1289
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1290
 /*! cache: tracked bytes belonging to leaf pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1290
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1291
 /*! cache: tracked dirty bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1291
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1292
 /*! cache: tracked dirty internal page bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL		1292
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL		1293
 /*! cache: tracked dirty leaf page bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF		1293
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF		1294
 /*! cache: tracked dirty pages in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1294
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1295
 /*! cache: uncommitted truncate blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	1295
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	1296
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1296
+#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1297
 /*! cache: update bytes belonging to the history store table in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_HS_UPDATES		1297
+#define	WT_STAT_CONN_CACHE_BYTES_HS_UPDATES		1298
 /*! cache: updates in uncommitted txn - bytes */
-#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_BYTES	1298
+#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_BYTES	1299
 /*! cache: updates in uncommitted txn - count */
-#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_COUNT	1299
+#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_COUNT	1300
 /*! capacity: background fsync file handles considered */
-#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1300
+#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1301
 /*! capacity: background fsync file handles synced */
-#define	WT_STAT_CONN_FSYNC_ALL_FH			1301
+#define	WT_STAT_CONN_FSYNC_ALL_FH			1302
 /*! capacity: background fsync time (msecs) */
-#define	WT_STAT_CONN_FSYNC_ALL_TIME			1302
+#define	WT_STAT_CONN_FSYNC_ALL_TIME			1303
 /*! capacity: bytes read */
-#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1303
+#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1304
 /*! capacity: bytes written for checkpoint */
-#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1304
+#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1305
 /*! capacity: bytes written for chunk cache */
-#define	WT_STAT_CONN_CAPACITY_BYTES_CHUNKCACHE		1305
+#define	WT_STAT_CONN_CAPACITY_BYTES_CHUNKCACHE		1306
 /*! capacity: bytes written for eviction */
-#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1306
+#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1307
 /*! capacity: bytes written for log */
-#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1307
+#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1308
 /*! capacity: bytes written total */
-#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1308
+#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1309
 /*! capacity: threshold to call fsync */
-#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1309
+#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1310
 /*! capacity: time waiting due to total capacity (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1310
+#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1311
 /*! capacity: time waiting during checkpoint (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1311
+#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1312
 /*! capacity: time waiting during eviction (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1312
+#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1313
 /*! capacity: time waiting during logging (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1313
+#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1314
 /*! capacity: time waiting during read (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_READ			1314
+#define	WT_STAT_CONN_CAPACITY_TIME_READ			1315
 /*! capacity: time waiting for chunk cache IO bandwidth (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_CHUNKCACHE		1315
+#define	WT_STAT_CONN_CAPACITY_TIME_CHUNKCACHE		1316
 /*! checkpoint: checkpoint cleanup successful calls */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_SUCCESS		1316
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_SUCCESS		1317
 /*! checkpoint: checkpoint has acquired a snapshot for its transaction */
-#define	WT_STAT_CONN_CHECKPOINT_SNAPSHOT_ACQUIRED	1317
+#define	WT_STAT_CONN_CHECKPOINT_SNAPSHOT_ACQUIRED	1318
 /*! checkpoint: checkpoints skipped because database was clean */
-#define	WT_STAT_CONN_CHECKPOINT_SKIPPED			1318
+#define	WT_STAT_CONN_CHECKPOINT_SKIPPED			1319
 /*! checkpoint: fsync calls after allocating the transaction ID */
-#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST		1319
+#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST		1320
 /*! checkpoint: fsync duration after allocating the transaction ID (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST_DURATION	1320
+#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST_DURATION	1321
 /*! checkpoint: generation */
-#define	WT_STAT_CONN_CHECKPOINT_GENERATION		1321
+#define	WT_STAT_CONN_CHECKPOINT_GENERATION		1322
 /*! checkpoint: max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_MAX		1322
+#define	WT_STAT_CONN_CHECKPOINT_TIME_MAX		1323
 /*! checkpoint: min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_MIN		1323
+#define	WT_STAT_CONN_CHECKPOINT_TIME_MIN		1324
 /*!
  * checkpoint: most recent duration for checkpoint dropping all handles
  * (usecs)
  */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROP_DURATION	1324
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROP_DURATION	1325
 /*! checkpoint: most recent duration for gathering all handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION		1325
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION		1326
 /*! checkpoint: most recent duration for gathering applied handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLY_DURATION	1326
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLY_DURATION	1327
 /*! checkpoint: most recent duration for gathering skipped handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIP_DURATION	1327
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIP_DURATION	1328
 /*! checkpoint: most recent duration for handles metadata checked (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECK_DURATION	1328
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECK_DURATION	1329
 /*! checkpoint: most recent duration for locking the handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCK_DURATION	1329
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCK_DURATION	1330
 /*! checkpoint: most recent handles applied */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLIED		1330
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLIED		1331
 /*! checkpoint: most recent handles checkpoint dropped */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROPPED		1331
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROPPED		1332
 /*! checkpoint: most recent handles metadata checked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECKED	1332
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECKED	1333
 /*! checkpoint: most recent handles metadata locked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCKED		1333
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCKED		1334
 /*! checkpoint: most recent handles skipped */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIPPED		1334
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIPPED		1335
 /*! checkpoint: most recent handles walked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_WALKED		1335
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_WALKED		1336
 /*! checkpoint: most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_RECENT		1336
+#define	WT_STAT_CONN_CHECKPOINT_TIME_RECENT		1337
 /*! checkpoint: number of bytes caused to be reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED_BYTES	1337
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED_BYTES	1338
 /*! checkpoint: number of checkpoints started by api */
-#define	WT_STAT_CONN_CHECKPOINTS_API			1338
+#define	WT_STAT_CONN_CHECKPOINTS_API			1339
 /*! checkpoint: number of checkpoints started by compaction */
-#define	WT_STAT_CONN_CHECKPOINTS_COMPACT		1339
+#define	WT_STAT_CONN_CHECKPOINTS_COMPACT		1340
 /*! checkpoint: number of files synced */
-#define	WT_STAT_CONN_CHECKPOINT_SYNC			1340
+#define	WT_STAT_CONN_CHECKPOINT_SYNC			1341
 /*! checkpoint: number of handles visited after writes complete */
-#define	WT_STAT_CONN_CHECKPOINT_PRESYNC			1341
+#define	WT_STAT_CONN_CHECKPOINT_PRESYNC			1342
 /*! checkpoint: number of history store pages caused to be reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_HS_PAGES_RECONCILED	1342
+#define	WT_STAT_CONN_CHECKPOINT_HS_PAGES_RECONCILED	1343
 /*! checkpoint: number of internal pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_INTERNAL	1343
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_INTERNAL	1344
 /*! checkpoint: number of leaf pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_LEAF	1344
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_LEAF	1345
 /*! checkpoint: number of pages caused to be reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED	1345
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED	1346
 /*! checkpoint: pages added for eviction during checkpoint cleanup */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_EVICT	1346
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_EVICT	1347
 /*!
  * checkpoint: pages dirtied due to obsolete time window by checkpoint
  * cleanup
  */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	1347
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	1348
 /*!
  * checkpoint: pages read into cache during checkpoint cleanup
  * (reclaim_space)
  */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	1348
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	1349
 /*!
  * checkpoint: pages read into cache during checkpoint cleanup due to
  * obsolete time window
  */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	1349
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	1350
 /*! checkpoint: pages removed during checkpoint cleanup */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_REMOVED	1350
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_REMOVED	1351
 /*! checkpoint: pages skipped during checkpoint cleanup tree walk */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	1351
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	1352
 /*! checkpoint: pages visited during checkpoint cleanup */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_VISITED	1352
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_VISITED	1353
 /*! checkpoint: prepare currently running */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1353
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1354
 /*! checkpoint: prepare max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1354
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1355
 /*! checkpoint: prepare min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1355
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1356
 /*! checkpoint: prepare most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1356
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1357
 /*! checkpoint: prepare total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1357
+#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1358
 /*! checkpoint: progress state */
-#define	WT_STAT_CONN_CHECKPOINT_STATE			1358
+#define	WT_STAT_CONN_CHECKPOINT_STATE			1359
 /*! checkpoint: scrub dirty target */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1359
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1360
 /*! checkpoint: scrub max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1360
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1361
 /*! checkpoint: scrub min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1361
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1362
 /*! checkpoint: scrub most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1362
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1363
 /*! checkpoint: scrub total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1363
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1364
 /*! checkpoint: stop timing stress active */
-#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1364
+#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1365
 /*! checkpoint: time spent on per-tree checkpoint work (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1365
+#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1366
 /*! checkpoint: total failed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1366
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1367
 /*! checkpoint: total succeed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1367
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1368
 /*! checkpoint: total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1368
+#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1369
 /*! checkpoint: wait cycles while cache dirty level is decreasing */
-#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1369
+#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1370
 /*! chunk-cache: aggregate number of spanned chunks on read */
-#define	WT_STAT_CONN_CHUNKCACHE_SPANS_CHUNKS_READ	1370
+#define	WT_STAT_CONN_CHUNKCACHE_SPANS_CHUNKS_READ	1371
 /*! chunk-cache: chunks evicted */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_EVICTED		1371
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_EVICTED		1372
 /*! chunk-cache: could not allocate due to exceeding bitmap capacity */
-#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_BITMAP_CAPACITY	1372
+#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_BITMAP_CAPACITY	1373
 /*! chunk-cache: could not allocate due to exceeding capacity */
-#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_CAPACITY	1373
+#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_CAPACITY	1374
 /*! chunk-cache: lookups */
-#define	WT_STAT_CONN_CHUNKCACHE_LOOKUPS			1374
+#define	WT_STAT_CONN_CHUNKCACHE_LOOKUPS			1375
 /*!
  * chunk-cache: number of chunks loaded from flushed tables in chunk
  * cache
  */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_LOADED_FROM_FLUSHED_TABLES	1375
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_LOADED_FROM_FLUSHED_TABLES	1376
 /*! chunk-cache: number of metadata entries inserted */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_INSERTED	1376
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_INSERTED	1377
 /*! chunk-cache: number of metadata entries removed */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_REMOVED	1377
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_REMOVED	1378
 /*!
  * chunk-cache: number of metadata inserts/deletes dropped by the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DROPPED	1378
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DROPPED	1379
 /*!
  * chunk-cache: number of metadata inserts/deletes pushed to the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_CREATED	1379
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_CREATED	1380
 /*!
  * chunk-cache: number of metadata inserts/deletes read by the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DEQUEUED	1380
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DEQUEUED	1381
 /*! chunk-cache: number of misses */
-#define	WT_STAT_CONN_CHUNKCACHE_MISSES			1381
+#define	WT_STAT_CONN_CHUNKCACHE_MISSES			1382
 /*! chunk-cache: number of times a read from storage failed */
-#define	WT_STAT_CONN_CHUNKCACHE_IO_FAILED		1382
+#define	WT_STAT_CONN_CHUNKCACHE_IO_FAILED		1383
 /*! chunk-cache: retried accessing a chunk while I/O was in progress */
-#define	WT_STAT_CONN_CHUNKCACHE_RETRIES			1383
+#define	WT_STAT_CONN_CHUNKCACHE_RETRIES			1384
 /*! chunk-cache: retries from a chunk cache checksum mismatch */
-#define	WT_STAT_CONN_CHUNKCACHE_RETRIES_CHECKSUM_MISMATCH	1384
+#define	WT_STAT_CONN_CHUNKCACHE_RETRIES_CHECKSUM_MISMATCH	1385
 /*! chunk-cache: timed out due to too many retries */
-#define	WT_STAT_CONN_CHUNKCACHE_TOOMANY_RETRIES		1385
+#define	WT_STAT_CONN_CHUNKCACHE_TOOMANY_RETRIES		1386
 /*! chunk-cache: total bytes read from persistent content */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_READ_PERSISTENT	1386
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_READ_PERSISTENT	1387
 /*! chunk-cache: total bytes used by the cache */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE		1387
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE		1388
 /*! chunk-cache: total bytes used by the cache for pinned chunks */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE_PINNED	1388
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE_PINNED	1389
 /*! chunk-cache: total chunks held by the chunk cache */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_INUSE		1389
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_INUSE		1390
 /*!
  * chunk-cache: total number of chunks inserted on startup from persisted
  * metadata.
  */
-#define	WT_STAT_CONN_CHUNKCACHE_CREATED_FROM_METADATA	1390
+#define	WT_STAT_CONN_CHUNKCACHE_CREATED_FROM_METADATA	1391
 /*! chunk-cache: total pinned chunks held by the chunk cache */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_PINNED		1391
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_PINNED		1392
 /*! connection: auto adjusting condition resets */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1392
+#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1393
 /*! connection: auto adjusting condition wait calls */
-#define	WT_STAT_CONN_COND_AUTO_WAIT			1393
+#define	WT_STAT_CONN_COND_AUTO_WAIT			1394
 /*!
  * connection: auto adjusting condition wait raced to update timeout and
  * skipped updating
  */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1394
+#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1395
 /*! connection: detected system time went backwards */
-#define	WT_STAT_CONN_TIME_TRAVEL			1395
+#define	WT_STAT_CONN_TIME_TRAVEL			1396
 /*! connection: files currently open */
-#define	WT_STAT_CONN_FILE_OPEN				1396
+#define	WT_STAT_CONN_FILE_OPEN				1397
 /*! connection: hash bucket array size for data handles */
-#define	WT_STAT_CONN_BUCKETS_DH				1397
+#define	WT_STAT_CONN_BUCKETS_DH				1398
 /*! connection: hash bucket array size general */
-#define	WT_STAT_CONN_BUCKETS				1398
+#define	WT_STAT_CONN_BUCKETS				1399
 /*! connection: memory allocations */
-#define	WT_STAT_CONN_MEMORY_ALLOCATION			1399
+#define	WT_STAT_CONN_MEMORY_ALLOCATION			1400
 /*! connection: memory frees */
-#define	WT_STAT_CONN_MEMORY_FREE			1400
+#define	WT_STAT_CONN_MEMORY_FREE			1401
 /*! connection: memory re-allocations */
-#define	WT_STAT_CONN_MEMORY_GROW			1401
+#define	WT_STAT_CONN_MEMORY_GROW			1402
 /*! connection: number of sessions without a sweep for 5+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1402
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1403
 /*! connection: number of sessions without a sweep for 60+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1403
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1404
 /*! connection: pthread mutex condition wait calls */
-#define	WT_STAT_CONN_COND_WAIT				1404
+#define	WT_STAT_CONN_COND_WAIT				1405
 /*! connection: pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			1405
+#define	WT_STAT_CONN_RWLOCK_READ			1406
 /*! connection: pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			1406
+#define	WT_STAT_CONN_RWLOCK_WRITE			1407
 /*! connection: total fsync I/Os */
-#define	WT_STAT_CONN_FSYNC_IO				1407
+#define	WT_STAT_CONN_FSYNC_IO				1408
 /*! connection: total read I/Os */
-#define	WT_STAT_CONN_READ_IO				1408
+#define	WT_STAT_CONN_READ_IO				1409
 /*! connection: total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				1409
+#define	WT_STAT_CONN_WRITE_IO				1410
 /*! cursor: Total number of deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1410
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1411
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1411
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1412
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1412
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1413
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1413
+#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1414
 /*!
  * cursor: Total number of in-memory deleted pages skipped during tree
  * walk
  */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1414
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1415
 /*! cursor: Total number of on-disk deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1415
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1416
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1416
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1417
 /*!
  * cursor: Total number of times cursor fails to temporarily release
  * pinned page to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1417
+#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1418
 /*!
  * cursor: Total number of times cursor temporarily releases pinned page
  * to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION			1418
+#define	WT_STAT_CONN_CURSOR_REPOSITION			1419
 /*! cursor: bulk cursor count */
-#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1419
+#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1420
 /*! cursor: cached cursor count */
-#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1420
+#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1421
 /*! cursor: cursor bound calls that return an error */
-#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1421
+#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1422
 /*! cursor: cursor bounds cleared from reset */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1422
+#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1423
 /*! cursor: cursor bounds comparisons performed */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1423
+#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1424
 /*! cursor: cursor bounds next called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1424
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1425
 /*! cursor: cursor bounds next early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1425
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1426
 /*! cursor: cursor bounds prev called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1426
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1427
 /*! cursor: cursor bounds prev early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1427
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1428
 /*! cursor: cursor bounds search early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1428
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1429
 /*! cursor: cursor bounds search near call repositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1429
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1430
 /*! cursor: cursor bulk loaded cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1430
+#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1431
 /*! cursor: cursor cache calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1431
+#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1432
 /*! cursor: cursor close calls that result in cache */
-#define	WT_STAT_CONN_CURSOR_CACHE			1432
+#define	WT_STAT_CONN_CURSOR_CACHE			1433
 /*! cursor: cursor close calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1433
+#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1434
 /*! cursor: cursor compare calls that return an error */
-#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1434
+#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1435
 /*! cursor: cursor create calls */
-#define	WT_STAT_CONN_CURSOR_CREATE			1435
+#define	WT_STAT_CONN_CURSOR_CREATE			1436
 /*! cursor: cursor equals calls that return an error */
-#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1436
+#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1437
 /*! cursor: cursor get key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1437
+#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1438
 /*! cursor: cursor get value calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1438
+#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1439
 /*! cursor: cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT			1439
+#define	WT_STAT_CONN_CURSOR_INSERT			1440
 /*! cursor: cursor insert calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1440
+#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1441
 /*! cursor: cursor insert check calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1441
+#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1442
 /*! cursor: cursor insert key and value bytes */
-#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1442
+#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1443
 /*! cursor: cursor largest key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1443
+#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1444
 /*! cursor: cursor modify calls */
-#define	WT_STAT_CONN_CURSOR_MODIFY			1444
+#define	WT_STAT_CONN_CURSOR_MODIFY			1445
 /*! cursor: cursor modify calls that return an error */
-#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1445
+#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1446
 /*! cursor: cursor modify key and value bytes affected */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1446
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1447
 /*! cursor: cursor modify value bytes modified */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1447
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1448
 /*! cursor: cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT			1448
+#define	WT_STAT_CONN_CURSOR_NEXT			1449
 /*! cursor: cursor next calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1449
+#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1450
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1450
+#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1451
 /*!
  * cursor: cursor next calls that skip greater than 1 and fewer than 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1451
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1452
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1452
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1453
 /*! cursor: cursor next random calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1453
+#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1454
 /*! cursor: cursor operation restarted */
-#define	WT_STAT_CONN_CURSOR_RESTART			1454
+#define	WT_STAT_CONN_CURSOR_RESTART			1455
 /*! cursor: cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV			1455
+#define	WT_STAT_CONN_CURSOR_PREV			1456
 /*! cursor: cursor prev calls that return an error */
-#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1456
+#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1457
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1457
+#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1458
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1458
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1459
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1459
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1460
 /*! cursor: cursor reconfigure calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1460
+#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1461
 /*! cursor: cursor remove calls */
-#define	WT_STAT_CONN_CURSOR_REMOVE			1461
+#define	WT_STAT_CONN_CURSOR_REMOVE			1462
 /*! cursor: cursor remove calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1462
+#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1463
 /*! cursor: cursor remove key bytes removed */
-#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1463
+#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1464
 /*! cursor: cursor reopen calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1464
+#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1465
 /*! cursor: cursor reserve calls */
-#define	WT_STAT_CONN_CURSOR_RESERVE			1465
+#define	WT_STAT_CONN_CURSOR_RESERVE			1466
 /*! cursor: cursor reserve calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1466
+#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1467
 /*! cursor: cursor reset calls */
-#define	WT_STAT_CONN_CURSOR_RESET			1467
+#define	WT_STAT_CONN_CURSOR_RESET			1468
 /*! cursor: cursor reset calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1468
+#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1469
 /*! cursor: cursor search calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH			1469
+#define	WT_STAT_CONN_CURSOR_SEARCH			1470
 /*! cursor: cursor search calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1470
+#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1471
 /*! cursor: cursor search history store calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1471
+#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1472
 /*! cursor: cursor search near calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1472
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1473
 /*! cursor: cursor search near calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1473
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1474
 /*! cursor: cursor sweep buckets */
-#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1474
+#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1475
 /*! cursor: cursor sweep cursors closed */
-#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1475
+#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1476
 /*! cursor: cursor sweep cursors examined */
-#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1476
+#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1477
 /*! cursor: cursor sweeps */
-#define	WT_STAT_CONN_CURSOR_SWEEP			1477
+#define	WT_STAT_CONN_CURSOR_SWEEP			1478
 /*! cursor: cursor truncate calls */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE			1478
+#define	WT_STAT_CONN_CURSOR_TRUNCATE			1479
 /*! cursor: cursor truncates performed on individual keys */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1479
+#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1480
 /*! cursor: cursor update calls */
-#define	WT_STAT_CONN_CURSOR_UPDATE			1480
+#define	WT_STAT_CONN_CURSOR_UPDATE			1481
 /*! cursor: cursor update calls that return an error */
-#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1481
+#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1482
 /*! cursor: cursor update key and value bytes */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1482
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1483
 /*! cursor: cursor update value size change */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1483
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1484
 /*! cursor: cursors reused from cache */
-#define	WT_STAT_CONN_CURSOR_REOPEN			1484
+#define	WT_STAT_CONN_CURSOR_REOPEN			1485
 /*! cursor: open cursor count */
-#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1485
+#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1486
 /*! cursor: open cursor time application (usecs) */
-#define	WT_STAT_CONN_CURSOR_OPEN_TIME_USER_USECS	1486
+#define	WT_STAT_CONN_CURSOR_OPEN_TIME_USER_USECS	1487
 /*! cursor: open cursor time internal (usecs) */
-#define	WT_STAT_CONN_CURSOR_OPEN_TIME_INTERNAL_USECS	1487
+#define	WT_STAT_CONN_CURSOR_OPEN_TIME_INTERNAL_USECS	1488
 /*! data-handle: Table connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TABLE_COUNT		1488
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TABLE_COUNT		1489
 /*! data-handle: Tiered connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_COUNT	1489
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_COUNT	1490
 /*! data-handle: Tiered_Tree connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_TREE_COUNT	1490
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_TREE_COUNT	1491
 /*! data-handle: btree connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_BTREE_COUNT		1491
+#define	WT_STAT_CONN_DH_CONN_HANDLE_BTREE_COUNT		1492
 /*! data-handle: checkpoint connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_CHECKPOINT_COUNT	1492
+#define	WT_STAT_CONN_DH_CONN_HANDLE_CHECKPOINT_COUNT	1493
 /*! data-handle: connection data handle size */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1493
+#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1494
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1494
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1495
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1495
+#define	WT_STAT_CONN_DH_SWEEP_REF			1496
 /*! data-handle: connection sweep dead dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_DEAD_CLOSE		1496
+#define	WT_STAT_CONN_DH_SWEEP_DEAD_CLOSE		1497
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1497
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1498
 /*! data-handle: connection sweep expired dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_EXPIRED_CLOSE		1498
+#define	WT_STAT_CONN_DH_SWEEP_EXPIRED_CLOSE		1499
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1499
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1500
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1500
+#define	WT_STAT_CONN_DH_SWEEPS				1501
 /*!
  * data-handle: connection sweeps skipped due to checkpoint gathering
  * handles
  */
-#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1501
+#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1502
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1502
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1503
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1503
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1504
 /*! disagg: role leader */
-#define	WT_STAT_CONN_DISAGG_ROLE_LEADER			1504
+#define	WT_STAT_CONN_DISAGG_ROLE_LEADER			1505
 /*! layered: Layered table cursor insert operations */
-#define	WT_STAT_CONN_LAYERED_CURS_INSERT		1505
+#define	WT_STAT_CONN_LAYERED_CURS_INSERT		1506
 /*! layered: Layered table cursor next operations */
-#define	WT_STAT_CONN_LAYERED_CURS_NEXT			1506
+#define	WT_STAT_CONN_LAYERED_CURS_NEXT			1507
 /*! layered: Layered table cursor next operations from ingest table */
-#define	WT_STAT_CONN_LAYERED_CURS_NEXT_INGEST		1507
+#define	WT_STAT_CONN_LAYERED_CURS_NEXT_INGEST		1508
 /*! layered: Layered table cursor next operations from stable table */
-#define	WT_STAT_CONN_LAYERED_CURS_NEXT_STABLE		1508
+#define	WT_STAT_CONN_LAYERED_CURS_NEXT_STABLE		1509
 /*! layered: Layered table cursor prev operations */
-#define	WT_STAT_CONN_LAYERED_CURS_PREV			1509
+#define	WT_STAT_CONN_LAYERED_CURS_PREV			1510
 /*! layered: Layered table cursor prev operations from ingest table */
-#define	WT_STAT_CONN_LAYERED_CURS_PREV_INGEST		1510
+#define	WT_STAT_CONN_LAYERED_CURS_PREV_INGEST		1511
 /*! layered: Layered table cursor prev operations from stable table */
-#define	WT_STAT_CONN_LAYERED_CURS_PREV_STABLE		1511
+#define	WT_STAT_CONN_LAYERED_CURS_PREV_STABLE		1512
 /*! layered: Layered table cursor remove operations */
-#define	WT_STAT_CONN_LAYERED_CURS_REMOVE		1512
+#define	WT_STAT_CONN_LAYERED_CURS_REMOVE		1513
 /*! layered: Layered table cursor search near operations */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR		1513
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR		1514
 /*! layered: Layered table cursor search near operations from ingest table */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_INGEST	1514
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_INGEST	1515
 /*! layered: Layered table cursor search near operations from stable table */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_STABLE	1515
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_STABLE	1516
 /*! layered: Layered table cursor search operations */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH		1516
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH		1517
 /*! layered: Layered table cursor search operations from ingest table */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_INGEST		1517
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_INGEST		1518
 /*! layered: Layered table cursor search operations from stable table */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_STABLE		1518
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_STABLE		1519
 /*! layered: Layered table cursor update operations */
-#define	WT_STAT_CONN_LAYERED_CURS_UPDATE		1519
+#define	WT_STAT_CONN_LAYERED_CURS_UPDATE		1520
 /*! layered: Layered table cursor upgrade state for ingest table */
-#define	WT_STAT_CONN_LAYERED_CURS_UPGRADE_INGEST	1520
+#define	WT_STAT_CONN_LAYERED_CURS_UPGRADE_INGEST	1521
 /*! layered: Layered table cursor upgrade state for stable table */
-#define	WT_STAT_CONN_LAYERED_CURS_UPGRADE_STABLE	1521
+#define	WT_STAT_CONN_LAYERED_CURS_UPGRADE_STABLE	1522
 /*!
  * layered: checkpoints performed on this table by the layered table
  * manager
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS	1522
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS	1523
 /*! layered: checkpoints refreshed on shared layered constituents */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_REFRESHED	1523
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_REFRESHED	1524
 /*! layered: disagg pick up checkpoints failed */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FAILED	1524
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FAILED	1525
 /*! layered: disagg pick up checkpoints succeeded */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_SUCCEED	1525
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_SUCCEED	1526
 /*!
  * layered: how many log applications the layered table manager applied
  * on this tree
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_APPLIED	1526
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_APPLIED	1527
 /*!
  * layered: how many log applications the layered table manager skipped
  * on this tree
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_SKIPPED	1527
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_SKIPPED	1528
 /*!
  * layered: how many previously-applied LSNs the layered table manager
  * skipped on this tree
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_SKIP_LSN	1528
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_SKIP_LSN	1529
 /*! layered: the number of tables the layered table manager has open */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_TABLES	1529
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_TABLES	1530
 /*! layered: whether the layered table manager thread has been started */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_RUNNING	1530
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_RUNNING	1531
 /*!
  * layered: whether the layered table manager thread is currently busy
  * doing work
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_ACTIVE	1531
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_ACTIVE	1532
 /*!
  * live-restore: number of bytes copied from the source to the
  * destination
  */
-#define	WT_STAT_CONN_LIVE_RESTORE_BYTES_COPIED		1532
+#define	WT_STAT_CONN_LIVE_RESTORE_BYTES_COPIED		1533
 /*! live-restore: number of files remaining for migration completion */
-#define	WT_STAT_CONN_LIVE_RESTORE_WORK_REMAINING	1533
+#define	WT_STAT_CONN_LIVE_RESTORE_WORK_REMAINING	1534
 /*! live-restore: number of reads from the source database */
-#define	WT_STAT_CONN_LIVE_RESTORE_SOURCE_READ_COUNT	1534
+#define	WT_STAT_CONN_LIVE_RESTORE_SOURCE_READ_COUNT	1535
 /*! live-restore: source read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT2	1535
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT2	1536
 /*! live-restore: source read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT5	1536
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT5	1537
 /*! live-restore: source read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT10	1537
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT10	1538
 /*! live-restore: source read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT50	1538
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT50	1539
 /*! live-restore: source read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT100	1539
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT100	1540
 /*! live-restore: source read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT250	1540
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT250	1541
 /*! live-restore: source read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT500	1541
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT500	1542
 /*! live-restore: source read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT1000	1542
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT1000	1543
 /*! live-restore: source read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_GT1000	1543
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_GT1000	1544
 /*! live-restore: source read latency histogram total (msecs) */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_TOTAL_MSECS	1544
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_TOTAL_MSECS	1545
 /*! live-restore: state */
-#define	WT_STAT_CONN_LIVE_RESTORE_STATE			1545
+#define	WT_STAT_CONN_LIVE_RESTORE_STATE			1546
 /*! lock: btree page lock acquisitions */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_COUNT		1546
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_COUNT		1547
 /*! lock: btree page lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_APPLICATION	1547
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_APPLICATION	1548
 /*! lock: btree page lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_INTERNAL	1548
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_INTERNAL	1549
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1549
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1550
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1550
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1551
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1551
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1552
 /*! lock: dhandle lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1552
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1553
 /*! lock: dhandle lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1553
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1554
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1554
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1555
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1555
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1556
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1556
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1557
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1557
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1558
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1558
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1559
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1559
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1560
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1560
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1561
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1561
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1562
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1562
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1563
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1563
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1564
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1564
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1565
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1565
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1566
 /*! lock: txn global lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1566
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1567
 /*! lock: txn global lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1567
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1568
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1568
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1569
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1569
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1570
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1570
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1571
 /*! log: force log remove time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1571
+#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1572
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1572
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1573
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1573
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1574
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1574
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1575
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1575
+#define	WT_STAT_CONN_LOG_FLUSH				1576
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1576
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1577
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1577
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1578
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1578
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1579
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1579
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1580
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1580
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1581
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1581
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1582
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1582
+#define	WT_STAT_CONN_LOG_SCANS				1583
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1583
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1584
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1584
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1585
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1585
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1586
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1586
+#define	WT_STAT_CONN_LOG_SYNC				1587
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1587
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1588
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1588
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1589
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1589
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1590
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1590
+#define	WT_STAT_CONN_LOG_WRITES				1591
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1591
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1592
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1592
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1593
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1593
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1594
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1594
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1595
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1595
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1596
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1596
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1597
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1597
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1598
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1598
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1599
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1599
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1600
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1600
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1601
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1601
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1602
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1602
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1603
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1603
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1604
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1604
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1605
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1605
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1606
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1606
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1607
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1607
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1608
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1608
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1609
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1609
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1610
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1610
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1611
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1611
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1612
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1612
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1613
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1613
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1614
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1614
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1615
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1615
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1616
 /*! perf: block manager read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT2	1616
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT2	1617
 /*! perf: block manager read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT5	1617
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT5	1618
 /*! perf: block manager read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT10	1618
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT10	1619
 /*! perf: block manager read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT50	1619
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT50	1620
 /*! perf: block manager read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT100	1620
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT100	1621
 /*! perf: block manager read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT250	1621
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT250	1622
 /*! perf: block manager read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT500	1622
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT500	1623
 /*! perf: block manager read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT1000	1623
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT1000	1624
 /*! perf: block manager read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_GT1000	1624
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_GT1000	1625
 /*! perf: block manager read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_TOTAL_MSECS	1625
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_TOTAL_MSECS	1626
 /*! perf: block manager write latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT2	1626
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT2	1627
 /*! perf: block manager write latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT5	1627
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT5	1628
 /*! perf: block manager write latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT10	1628
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT10	1629
 /*! perf: block manager write latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT50	1629
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT50	1630
 /*! perf: block manager write latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT100	1630
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT100	1631
 /*! perf: block manager write latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT250	1631
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT250	1632
 /*! perf: block manager write latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT500	1632
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT500	1633
 /*! perf: block manager write latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT1000	1633
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT1000	1634
 /*! perf: block manager write latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_GT1000	1634
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_GT1000	1635
 /*! perf: block manager write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_TOTAL_MSECS	1635
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_TOTAL_MSECS	1636
 /*! perf: disagg block manager read latency histogram (bucket 1) - 50-99us */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT100	1636
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT100	1637
 /*!
  * perf: disagg block manager read latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT250	1637
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT250	1638
 /*!
  * perf: disagg block manager read latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT500	1638
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT500	1639
 /*!
  * perf: disagg block manager read latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT1000	1639
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT1000	1640
 /*!
  * perf: disagg block manager read latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT2500	1640
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT2500	1641
 /*!
  * perf: disagg block manager read latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT5000	1641
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT5000	1642
 /*!
  * perf: disagg block manager read latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT10000	1642
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT10000	1643
 /*!
  * perf: disagg block manager read latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_GT10000	1643
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_GT10000	1644
 /*! perf: disagg block manager read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_TOTAL_USECS	1644
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_TOTAL_USECS	1645
 /*!
  * perf: disagg block manager write latency histogram (bucket 1) -
  * 50-99us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT100	1645
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT100	1646
 /*!
  * perf: disagg block manager write latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT250	1646
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT250	1647
 /*!
  * perf: disagg block manager write latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT500	1647
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT500	1648
 /*!
  * perf: disagg block manager write latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT1000	1648
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT1000	1649
 /*!
  * perf: disagg block manager write latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT2500	1649
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT2500	1650
 /*!
  * perf: disagg block manager write latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT5000	1650
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT5000	1651
 /*!
  * perf: disagg block manager write latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT10000	1651
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT10000	1652
 /*!
  * perf: disagg block manager write latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_GT10000	1652
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_GT10000	1653
 /*! perf: disagg block manager write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_TOTAL_USECS	1653
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_TOTAL_USECS	1654
 /*! perf: file system read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT2	1654
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT2	1655
 /*! perf: file system read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT5	1655
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT5	1656
 /*! perf: file system read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1656
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1657
 /*! perf: file system read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1657
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1658
 /*! perf: file system read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1658
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1659
 /*! perf: file system read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1659
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1660
 /*! perf: file system read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1660
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1661
 /*! perf: file system read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1661
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1662
 /*! perf: file system read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1662
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1663
 /*! perf: file system read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1663
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1664
 /*! perf: file system write latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT2	1664
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT2	1665
 /*! perf: file system write latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT5	1665
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT5	1666
 /*! perf: file system write latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1666
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1667
 /*! perf: file system write latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1667
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1668
 /*! perf: file system write latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1668
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1669
 /*! perf: file system write latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1669
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1670
 /*! perf: file system write latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1670
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1671
 /*! perf: file system write latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1671
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1672
 /*! perf: file system write latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1672
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1673
 /*! perf: file system write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1673
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1674
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 1) -
  * 0-100us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT100	1674
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT100	1675
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT250	1675
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT250	1676
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT500	1676
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT500	1677
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT1000	1677
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT1000	1678
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT2500	1678
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT2500	1679
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT5000	1679
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT5000	1680
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT10000	1680
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT10000	1681
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_GT10000	1681
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_GT10000	1682
 /*! perf: internal page deltas reconstruct latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_TOTAL_USECS	1682
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_TOTAL_USECS	1683
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 1) -
  * 0-100us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT100	1683
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT100	1684
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT250	1684
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT250	1685
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT500	1685
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT500	1686
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT1000	1686
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT1000	1687
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT2500	1687
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT2500	1688
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT5000	1688
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT5000	1689
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT10000	1689
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT10000	1690
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_GT10000	1690
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_GT10000	1691
 /*! perf: leaf page deltas reconstruct latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_TOTAL_USECS	1691
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_TOTAL_USECS	1692
 /*! perf: operation read latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1692
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1693
 /*! perf: operation read latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1693
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1694
 /*! perf: operation read latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1694
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1695
 /*! perf: operation read latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1695
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1696
 /*! perf: operation read latency histogram (bucket 5) - 1000-2499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT2500	1696
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT2500	1697
 /*! perf: operation read latency histogram (bucket 6) - 2500-4999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT5000	1697
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT5000	1698
 /*! perf: operation read latency histogram (bucket 7) - 5000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1698
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1699
 /*! perf: operation read latency histogram (bucket 8) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1699
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1700
 /*! perf: operation read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1700
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1701
 /*! perf: operation write latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1701
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1702
 /*! perf: operation write latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1702
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1703
 /*! perf: operation write latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1703
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1704
 /*! perf: operation write latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1704
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1705
 /*! perf: operation write latency histogram (bucket 5) - 1000-2499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT2500	1705
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT2500	1706
 /*! perf: operation write latency histogram (bucket 6) - 2500-4999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT5000	1706
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT5000	1707
 /*! perf: operation write latency histogram (bucket 7) - 5000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1707
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1708
 /*! perf: operation write latency histogram (bucket 8) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1708
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1709
 /*! perf: operation write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1709
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1710
 /*! prefetch: could not perform pre-fetch on internal page */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1710
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1711
 /*!
  * prefetch: could not perform pre-fetch on ref without the pre-fetch
  * flag set
  */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1711
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1712
 /*! prefetch: number of times pre-fetch failed to start */
-#define	WT_STAT_CONN_PREFETCH_FAILED_START		1712
+#define	WT_STAT_CONN_PREFETCH_FAILED_START		1713
 /*! prefetch: pre-fetch not repeating for recently pre-fetched ref */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1713
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1714
 /*! prefetch: pre-fetch not triggered after single disk read */
-#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1714
+#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1715
 /*! prefetch: pre-fetch not triggered as there is no valid dhandle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1715
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1716
 /*! prefetch: pre-fetch not triggered by page read */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED			1716
+#define	WT_STAT_CONN_PREFETCH_SKIPPED			1717
 /*! prefetch: pre-fetch not triggered due to disk read count */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1717
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1718
 /*! prefetch: pre-fetch not triggered due to internal session */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1718
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1719
 /*! prefetch: pre-fetch not triggered due to special btree handle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1719
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1720
 /*! prefetch: pre-fetch page not on disk when reading */
-#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1720
+#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1721
 /*! prefetch: pre-fetch pages queued */
-#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1721
+#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1722
 /*! prefetch: pre-fetch pages read in background */
-#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1722
+#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1723
 /*! prefetch: pre-fetch skipped reading in a page due to harmless error */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1723
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1724
 /*! prefetch: pre-fetch triggered by page read */
-#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1724
+#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1725
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1725
+#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1726
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1726
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1727
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1727
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1728
 /*!
  * reconciliation: average length of delta chain on internal page with
  * deltas
  */
-#define	WT_STAT_CONN_REC_AVERAGE_INTERNAL_PAGE_DELTA_CHAIN_LENGTH	1728
+#define	WT_STAT_CONN_REC_AVERAGE_INTERNAL_PAGE_DELTA_CHAIN_LENGTH	1729
 /*! reconciliation: average length of delta chain on leaf page with deltas */
-#define	WT_STAT_CONN_REC_AVERAGE_LEAF_PAGE_DELTA_CHAIN_LENGTH	1729
+#define	WT_STAT_CONN_REC_AVERAGE_LEAF_PAGE_DELTA_CHAIN_LENGTH	1730
 /*!
  * reconciliation: changes since prior reconciliation (bucket 1) between
  * 1 and 5
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE5			1730
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE5			1731
 /*!
  * reconciliation: changes since prior reconciliation (bucket 2) between
  * 6 and 10
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE10			1731
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE10			1732
 /*!
  * reconciliation: changes since prior reconciliation (bucket 3) between
  * 11 and 20
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE20			1732
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE20			1733
 /*!
  * reconciliation: changes since prior reconciliation (bucket 4) between
  * 21 and 50
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE50			1733
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE50			1734
 /*!
  * reconciliation: changes since prior reconciliation (bucket 5) between
  * 51 and 100
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE100		1734
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE100		1735
 /*!
  * reconciliation: changes since prior reconciliation (bucket 6) between
  * 101 and 200
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE200		1735
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE200		1736
 /*!
  * reconciliation: changes since prior reconciliation (bucket 7) between
  * 201 and 500
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE500		1736
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE500		1737
 /*!
  * reconciliation: changes since prior reconciliation (bucket 8) greater
  * than 500
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_GT500		1737
+#define	WT_STAT_CONN_REC_PAGE_MODS_GT500		1738
 /*! reconciliation: cursor next/prev calls during HS wrapup search_near */
-#define	WT_STAT_CONN_REC_HS_WRAPUP_NEXT_PREV_CALLS	1738
+#define	WT_STAT_CONN_REC_HS_WRAPUP_NEXT_PREV_CALLS	1739
 /*! reconciliation: empty deltas skipped in disaggregated storage */
-#define	WT_STAT_CONN_REC_SKIP_EMPTY_DELTAS		1739
+#define	WT_STAT_CONN_REC_SKIP_EMPTY_DELTAS		1740
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1740
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1741
 /*! reconciliation: full internal pages written instead of a page delta */
-#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_INTERNAL	1741
+#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_INTERNAL	1742
 /*! reconciliation: full leaf pages written instead of a page delta */
-#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_LEAF		1742
+#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_LEAF		1743
 /*! reconciliation: internal page delta keys deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_DELETED	1743
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_DELETED	1744
 /*! reconciliation: internal page delta keys updated/inserted */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_UPDATED	1744
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_UPDATED	1745
 /*! reconciliation: internal page deltas written */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL		1745
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL		1746
 /*! reconciliation: internal page multi-block writes */
-#define	WT_STAT_CONN_REC_MULTIBLOCK_INTERNAL		1746
+#define	WT_STAT_CONN_REC_MULTIBLOCK_INTERNAL		1747
 /*! reconciliation: leaf page deltas written */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_LEAF		1747
+#define	WT_STAT_CONN_REC_PAGE_DELTA_LEAF		1748
 /*! reconciliation: leaf page multi-block writes */
-#define	WT_STAT_CONN_REC_MULTIBLOCK_LEAF		1748
+#define	WT_STAT_CONN_REC_MULTIBLOCK_LEAF		1749
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1749
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1750
 /*! reconciliation: max deltas seen on internal page during reconciliation */
-#define	WT_STAT_CONN_REC_MAX_INTERNAL_PAGE_DELTAS	1750
+#define	WT_STAT_CONN_REC_MAX_INTERNAL_PAGE_DELTAS	1751
 /*! reconciliation: max deltas seen on leaf page during reconciliation */
-#define	WT_STAT_CONN_REC_MAX_LEAF_PAGE_DELTAS		1751
+#define	WT_STAT_CONN_REC_MAX_LEAF_PAGE_DELTAS		1752
 /*! reconciliation: maximum milliseconds spent in a reconciliation call */
-#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1752
+#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1753
 /*!
  * reconciliation: maximum milliseconds spent in building a disk image in
  * a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1753
+#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1754
 /*!
  * reconciliation: maximum milliseconds spent in moving updates to the
  * history store in a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1754
+#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1755
 /*!
  * reconciliation: number of keys that are garbage collected in the
  * ingest table for disaggregated storage
  */
-#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS	1755
+#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS	1756
 /*! reconciliation: overflow values written */
-#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1756
+#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1757
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1757
+#define	WT_STAT_CONN_REC_PAGES				1758
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1758
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1759
 /*! reconciliation: page reconciliation calls for pages between 1 and 10MB */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_1MB_TO_10MB		1759
+#define	WT_STAT_CONN_REC_PAGES_SIZE_1MB_TO_10MB		1760
 /*!
  * reconciliation: page reconciliation calls for pages between 10 and
  * 100MB
  */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_10MB_TO_100MB	1760
+#define	WT_STAT_CONN_REC_PAGES_SIZE_10MB_TO_100MB	1761
 /*!
  * reconciliation: page reconciliation calls for pages between 100MB and
  * 1GB
  */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_100MB_TO_1GB	1761
+#define	WT_STAT_CONN_REC_PAGES_SIZE_100MB_TO_1GB	1762
 /*! reconciliation: page reconciliation calls for pages over 1GB */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_1GB_PLUS		1762
+#define	WT_STAT_CONN_REC_PAGES_SIZE_1GB_PLUS		1763
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * prepared transaction metadata
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1763
+#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1764
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * timestamps
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1764
+#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1765
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * transaction ids
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1765
+#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1766
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1766
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1767
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1767
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1768
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1768
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1769
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1769
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1770
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1770
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1771
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1771
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1772
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1772
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1773
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1773
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1774
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1774
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1775
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1775
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1776
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1776
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1777
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1777
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1778
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1778
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1779
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1779
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1780
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1780
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1781
 /*! reconciliation: pages written with at least one internal page delta */
-#define	WT_STAT_CONN_REC_PAGES_WITH_INTERNAL_DELTAS	1781
+#define	WT_STAT_CONN_REC_PAGES_WITH_INTERNAL_DELTAS	1782
 /*! reconciliation: pages written with at least one leaf page delta */
-#define	WT_STAT_CONN_REC_PAGES_WITH_LEAF_DELTAS		1782
+#define	WT_STAT_CONN_REC_PAGES_WITH_LEAF_DELTAS		1783
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1783
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1784
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1784
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1785
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1785
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1786
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1786
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1787
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1787
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1788
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1788
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1789
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1789
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1790
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1790
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1791
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1791
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1792
 /*! session: attempts to remove a local object and the object is in use */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1792
+#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1793
 /*! session: flush_tier failed calls */
-#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1793
+#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1794
 /*! session: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1794
+#define	WT_STAT_CONN_FLUSH_TIER				1795
 /*! session: flush_tier tables skipped due to no checkpoint */
-#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1795
+#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1796
 /*! session: flush_tier tables switched */
-#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1796
+#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1797
 /*! session: local objects removed */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1797
+#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1798
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1798
+#define	WT_STAT_CONN_SESSION_OPEN			1799
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1799
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1800
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1800
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1801
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1801
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1802
 /*! session: table alter triggering checkpoint calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1802
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1803
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1803
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1804
 /*! session: table compact conflicted with checkpoint */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1804
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1805
 /*! session: table compact dhandle successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1805
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1806
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1806
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1807
 /*! session: table compact failed calls due to cache pressure */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1807
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1808
 /*! session: table compact passes */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1808
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1809
 /*! session: table compact pulled into eviction */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1809
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1810
 /*! session: table compact running */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1810
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1811
 /*! session: table compact skipped as process would not reduce file size */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1811
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1812
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1812
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1813
 /*! session: table compact timeout */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1813
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1814
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1814
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1815
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1815
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1816
 /*! session: table create with import failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1816
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1817
 /*! session: table create with import repair calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1817
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1818
 /*! session: table create with import successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1818
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1819
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1819
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1820
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1820
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1821
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1821
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1822
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1822
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1823
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1823
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1824
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1824
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1825
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1825
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1826
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1826
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1827
 /*! session: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1827
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1828
 /*! session: tiered operations removed without processing */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1828
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1829
 /*! session: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1829
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1830
 /*! session: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1830
+#define	WT_STAT_CONN_TIERED_RETENTION			1831
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1831
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1832
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1832
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1833
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1833
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1834
 /*! thread-yield: application thread operations waiting for cache */
-#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1834
+#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1835
 /*!
  * thread-yield: application thread operations waiting for interruptible
  * cache eviction
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_OPS	1835
+#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_OPS	1836
 /*!
  * thread-yield: application thread operations waiting for mandatory
  * cache eviction
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_OPS	1836
+#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_OPS	1837
 /*! thread-yield: application thread snapshot refreshed for eviction */
-#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1837
+#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1838
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1838
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1839
 /*!
  * thread-yield: application thread time waiting for interruptible cache
  * eviction (usecs)
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_TIME	1839
+#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_TIME	1840
 /*!
  * thread-yield: application thread time waiting for mandatory cache
  * eviction (usecs)
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_TIME	1840
+#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_TIME	1841
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1841
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1842
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1842
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1843
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1843
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1844
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1844
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1845
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1845
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1846
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1846
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1847
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1847
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1848
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1848
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1849
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1849
+#define	WT_STAT_CONN_PAGE_SLEEP				1850
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1850
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1851
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1851
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1852
 /*! thread-yield: page split and restart read */
-#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1852
+#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1853
 /*! thread-yield: pages skipped during read due to deleted state */
-#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1853
+#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1854
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1854
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1855
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1855
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1856
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1856
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1857
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1857
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1858
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1858
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1859
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1859
+#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1860
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1860
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1861
 /*! transaction: oldest transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1861
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1862
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1862
+#define	WT_STAT_CONN_TXN_PREPARE			1863
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1863
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1864
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1864
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1865
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1865
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1866
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1866
+#define	WT_STAT_CONN_TXN_QUERY_TS			1867
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1867
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1868
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1868
+#define	WT_STAT_CONN_TXN_RTS				1869
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1869
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1870
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1870
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1871
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1871
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1872
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1872
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1873
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1873
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1874
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1874
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1875
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1875
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1876
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1876
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1877
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1877
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1878
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1878
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1879
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1879
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1880
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1880
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1881
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1881
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1882
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1882
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1883
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1883
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1884
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1884
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1885
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1885
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1886
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1886
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1887
 /*!
  * transaction: rollback to stable updates that would have been aborted
  * in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1887
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1888
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1888
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1889
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1889
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1890
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1890
+#define	WT_STAT_CONN_TXN_SET_TS				1891
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1891
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1892
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1892
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1893
 /*! transaction: set timestamp force calls */
-#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1893
+#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1894
 /*!
  * transaction: set timestamp global oldest timestamp set to be more
  * recent than the global stable timestamp
  */
-#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1894
+#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1895
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1895
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1896
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1896
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1897
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1897
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1898
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1898
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1899
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1899
+#define	WT_STAT_CONN_TXN_BEGIN				1900
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1900
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1901
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1901
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1902
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1902
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1903
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1903
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1904
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1904
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1905
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1905
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1906
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1906
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1907
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1907
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1908
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1908
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1909
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1909
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1910
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1910
+#define	WT_STAT_CONN_TXN_COMMIT				1911
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1911
+#define	WT_STAT_CONN_TXN_ROLLBACK			1912
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1912
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1913
 
 /*!
  * @}

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -1880,6 +1880,7 @@ static const char *const __stats_connection_desc[] = {
   "cache: eviction server skips trees because there are too many active walks",
   "cache: eviction server skips trees that are being checkpointed",
   "cache: eviction server skips trees that are configured to stick in cache",
+  "cache: eviction server skips trees that are read-only if it is not looking for clean pages",
   "cache: eviction server skips trees that disable eviction",
   "cache: eviction server skips trees that were not useful before",
   "cache: eviction server slept, because we did not make progress with eviction",
@@ -2858,6 +2859,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->eviction_server_skip_trees_too_many_active_walks = 0;
     stats->eviction_server_skip_checkpointing_trees = 0;
     stats->eviction_server_skip_trees_stick_in_cache = 0;
+    stats->eviction_server_skip_trees_read_only = 0;
     stats->eviction_server_skip_trees_eviction_disabled = 0;
     stats->eviction_server_skip_trees_not_useful_before = 0;
     stats->eviction_server_slept = 0;
@@ -3831,6 +3833,8 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
       WT_STAT_CONN_READ(from, eviction_server_skip_checkpointing_trees);
     to->eviction_server_skip_trees_stick_in_cache +=
       WT_STAT_CONN_READ(from, eviction_server_skip_trees_stick_in_cache);
+    to->eviction_server_skip_trees_read_only +=
+      WT_STAT_CONN_READ(from, eviction_server_skip_trees_read_only);
     to->eviction_server_skip_trees_eviction_disabled +=
       WT_STAT_CONN_READ(from, eviction_server_skip_trees_eviction_disabled);
     to->eviction_server_skip_trees_not_useful_before +=


### PR DESCRIPTION
* Skip walking read-only btrees in eviction server if we are not looking for clean pages.
* Add a stat to track that.