### PR TITLE
WT-15448 Add check for picking up the same checkpoint again

### DIFF
--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -363,10 +363,16 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, uint64_t meta_lsn)
           ", new metadata LSN = %" PRIu64,
           current_meta_lsn, meta_lsn);
 
-    /* Warn if we are picking up the same checkpoint again. */
-    if (meta_lsn == current_meta_lsn)
+    /*
+     * Warn if we are picking up the same checkpoint again. There's nothing else to do here, goto
+     * err for cleanup.
+     */
+    if (meta_lsn == current_meta_lsn) {
         __wt_verbose_level(session, WT_VERB_LAYERED, WT_VERBOSE_WARNING,
           "Picking up the same checkpoint again: metadata LSN = %" PRIu64, meta_lsn);
+        ret = 0;
+        goto err;
+    }
 
     /*
      * Part 1: Get the metadata of the shared metadata table and insert it into our metadata table.

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -370,7 +370,7 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, uint64_t meta_lsn)
     if (meta_lsn == current_meta_lsn) {
         __wt_verbose_level(session, WT_VERB_LAYERED, WT_VERBOSE_WARNING,
           "Picking up the same checkpoint again: metadata LSN = %" PRIu64, meta_lsn);
-        ret = 0;
+        /* Keep previous ret value to avoid overlapping error message */
         goto err;
     }
 

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -363,7 +363,10 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, uint64_t meta_lsn)
           ", new metadata LSN = %" PRIu64,
           current_meta_lsn, meta_lsn);
 
-    /* FIXME-WT-15448 We might also want to add a check for picking up the same checkpoint again. */
+    /* Warn if we are picking up the same checkpoint again. */
+    if (meta_lsn == current_meta_lsn)
+        __wt_verbose_level(session, WT_VERB_LAYERED, WT_VERBOSE_WARNING,
+          "Picking up the same checkpoint again: metadata LSN = %" PRIu64, meta_lsn);
 
     /*
      * Part 1: Get the metadata of the shared metadata table and insert it into our metadata table.

--- a/test/suite/test_layered07.py
+++ b/test/suite/test_layered07.py
@@ -88,12 +88,13 @@ class test_layered07(wttest.WiredTigerTestCase, DisaggConfigMixin):
         time.sleep(1)
         self.session.checkpoint()
         time.sleep(1)
-        self.disagg_advance_checkpoint(conn_follow)
 
         #
         # Part 2: The big switcheroo
         #
         self.pr('switch the leader and the follower')
+
+        # This function call implies the follower will pick up a new checkpoint.
         self.disagg_switch_follower_and_leader(conn_follow, self.conn)
         time.sleep(2)
 

--- a/test/suite/test_layered38.py
+++ b/test/suite/test_layered38.py
@@ -222,6 +222,9 @@ class test_layered38(wttest.WiredTigerTestCase, DisaggConfigMixin):
         # Close the cursor held open.
         hold_cursor.close()
 
+        # Push forward the checkpoint again to avoid picking up the same checkpoint twice.
+        self.session.checkpoint()
+
         # Trigger advance checkpoint code again to set the prune timestamp to the last
         # checkpoint timestamp. We couldn't do that because there was a cursor holding the old content.
         self.disagg_advance_checkpoint(conn_follow)

--- a/test/suite/test_layered38.py
+++ b/test/suite/test_layered38.py
@@ -222,6 +222,10 @@ class test_layered38(wttest.WiredTigerTestCase, DisaggConfigMixin):
         # Close the cursor held open.
         hold_cursor.close()
 
+        # Picking up the same checkpoint should log a message about picking up the same checkpoint.
+        with self.expectedStdoutPattern(".*Picking up the same checkpoint again.*"):
+            self.disagg_advance_checkpoint(conn_follow)
+
         # Push forward the checkpoint again to avoid picking up the same checkpoint twice.
         self.session.checkpoint()
 

--- a/test/suite/test_layered38.py
+++ b/test/suite/test_layered38.py
@@ -222,10 +222,6 @@ class test_layered38(wttest.WiredTigerTestCase, DisaggConfigMixin):
         # Close the cursor held open.
         hold_cursor.close()
 
-        # Picking up the same checkpoint should log a message about picking up the same checkpoint.
-        with self.expectedStdoutPattern(".*Picking up the same checkpoint again.*"):
-            self.disagg_advance_checkpoint(conn_follow)
-
         # Push forward the checkpoint again to avoid picking up the same checkpoint twice.
         self.session.checkpoint()
 

--- a/test/suite/test_layered38.py
+++ b/test/suite/test_layered38.py
@@ -222,7 +222,7 @@ class test_layered38(wttest.WiredTigerTestCase, DisaggConfigMixin):
         # Close the cursor held open.
         hold_cursor.close()
 
-        # Picking up the same checkpoint should log a message about picking up the same checkpoint.
+        # Expect a message when picking up the same checkpoint.
         with self.expectedStdoutPattern(".*Picking up the same checkpoint again.*"):
             self.disagg_advance_checkpoint(conn_follow)
 

--- a/test/suite/test_layered53.py
+++ b/test/suite/test_layered53.py
@@ -104,9 +104,9 @@ class test_layered53(wttest.WiredTigerTestCase, DisaggConfigMixin):
         # And two conditions implied here:
         # 1) The metadata LSN should not change.
         # 2) Error log should be raised.
+        meta_lsn = self.disagg_get_complete_checkpoint_meta()
         with self.expectedStdoutPattern(".*Picking up the same checkpoint again.*"):
-            meta_lsn = self.disagg_get_complete_checkpoint_meta()
             self.disagg_advance_checkpoint(self.conn_follow)
-            # Check that the metadata LSN did not change.
-            current_meta_lsn = self.disagg_get_complete_checkpoint_meta()
-            self.assertEqual(meta_lsn, current_meta_lsn)
+        # Check that the metadata LSN did not change.
+        current_meta_lsn = self.disagg_get_complete_checkpoint_meta()
+        self.assertEqual(meta_lsn, current_meta_lsn)

--- a/test/suite/test_layered53.py
+++ b/test/suite/test_layered53.py
@@ -98,3 +98,8 @@ class test_layered53(wttest.WiredTigerTestCase, DisaggConfigMixin):
         self.session_follow.checkpoint()
         _, _, checkpoint_timestamp, _ = self.disagg_get_complete_checkpoint_ext()
         self.assertEqual(checkpoint_timestamp, 20)
+
+        # Idempotence check: advancing the follower again should *not* change state.
+        # It should simply log that the same checkpoint is being picked up again.
+        with self.expectedStdoutPattern(".*Picking up the same checkpoint again.*"):
+            self.disagg_advance_checkpoint(self.conn_follow)

--- a/test/suite/test_layered53.py
+++ b/test/suite/test_layered53.py
@@ -101,5 +101,12 @@ class test_layered53(wttest.WiredTigerTestCase, DisaggConfigMixin):
 
         # Idempotence check: advancing the follower again should *not* change state.
         # It should simply log that the same checkpoint is being picked up again.
+        # And two conditions implied here:
+        # 1) The metadata LSN should not change.
+        # 2) Error log should be raised.
         with self.expectedStdoutPattern(".*Picking up the same checkpoint again.*"):
+            meta_lsn = self.disagg_get_complete_checkpoint_meta()
             self.disagg_advance_checkpoint(self.conn_follow)
+            # Check that the metadata LSN did not change.
+            current_meta_lsn = self.disagg_get_complete_checkpoint_meta()
+            self.assertEqual(meta_lsn, current_meta_lsn)


### PR DESCRIPTION
- Add warning log and check for repeat picking same checkpoint.
- Adjust `test_layered38` to this change