### PR TITLE
WT-15192 Avoid cross-tables checkpoint order comparison during checkpoint pickup

### DIFF
--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -686,10 +686,10 @@ __btree_conf(WT_SESSION_IMPL *session, WT_CKPT *ckpt, bool is_ckpt)
     if (F_ISSET(session, WT_SESSION_IMPORT))
         btree->modified = true;
 
-    WT_ACQUIRE_READ(btree->checkpoint_timestamp,
-        conn->disaggregated_storage.last_checkpoint_timestamp);
+    WT_ACQUIRE_READ(
+      btree->checkpoint_timestamp, conn->disaggregated_storage.last_checkpoint_timestamp);
     if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
-          btree->prune_timestamp = btree->checkpoint_timestamp;
+        btree->prune_timestamp = btree->checkpoint_timestamp;
 
     return (0);
 }

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -686,9 +686,10 @@ __btree_conf(WT_SESSION_IMPL *session, WT_CKPT *ckpt, bool is_ckpt)
     if (F_ISSET(session, WT_SESSION_IMPORT))
         btree->modified = true;
 
+    WT_ACQUIRE_READ(btree->checkpoint_timestamp,
+        conn->disaggregated_storage.last_checkpoint_timestamp);
     if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
-        WT_ACQUIRE_READ(
-          btree->prune_timestamp, conn->disaggregated_storage.last_checkpoint_timestamp);
+          btree->prune_timestamp = btree->checkpoint_timestamp;
 
     return (0);
 }

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -686,9 +686,9 @@ __btree_conf(WT_SESSION_IMPL *session, WT_CKPT *ckpt, bool is_ckpt)
     if (F_ISSET(session, WT_SESSION_IMPORT))
         btree->modified = true;
 
-    /* FIXME-WT-15192: Consider setting `prune_timestamp` to `last_checkpoint_timestamp` */
     if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
-        btree->prune_timestamp = WT_TS_NONE;
+        WT_ACQUIRE_READ(
+          btree->prune_timestamp, conn->disaggregated_storage.last_checkpoint_timestamp);
 
     return (0);
 }

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -1892,14 +1892,6 @@ __layered_update_gc_ingest_tables_prune_timestamps(
             len = strlen(layered_table->stable_uri) + strlen(WT_CHECKPOINT) + 20;
             WT_ERR(__wt_realloc_def(session, &uri_alloc, len, &uri_at_checkpoint));
 
-            /* Track the stable table's last checkpoint timestamp */
-            WT_ERR(__wt_snprintf(uri_at_checkpoint, uri_alloc, "%s/%s.%" PRId64,
-              layered_table->stable_uri, WT_CHECKPOINT, last_ckpt));
-            WT_ERR(__wt_session_get_dhandle(session, uri_at_checkpoint, NULL, NULL, 0));
-            btree = (WT_BTREE *)session->dhandle->handle;
-            btree->ckpt_timestamp = checkpoint_timestamp;
-
-            WT_ERR(__wt_session_release_dhandle(session));
             /*
              * For each layered table, we want to see what is the oldest checkpoint on that table
              * that is in use by any open cursor. Even if there are no open cursors on it, the most
@@ -1913,11 +1905,18 @@ __layered_update_gc_ingest_tables_prune_timestamps(
              */
             ckpt_inuse = layered_table->last_ckpt_inuse;
 
-            /* Picking up a checkpoint the first time, so it's OK to set it to the current one. */
-            if (ckpt_inuse == 0) {
-                ckpt_inuse = last_ckpt;
-            }
+            /*
+             * If we are setting a prune timestamp the first time, the previous checkpoint could
+             * still be in use, so start from it.
+             */
+            if (ckpt_inuse == 0)
+                ckpt_inuse = (last_ckpt > 1) ? last_ckpt - 1 : last_ckpt;
 
+            /* Allocate enough room for the uri and the WiredTigerCheckpoint.NNN */
+            len = strlen(layered_table->stable_uri) + strlen(WT_CHECKPOINT) + 20;
+            WT_ERR(__wt_realloc_def(session, &uri_alloc, len, &uri_at_checkpoint));
+
+            /* Find the last checkpoint which is still in use. */
             while (ckpt_inuse < last_ckpt) {
                 WT_ERR(__wt_snprintf(uri_at_checkpoint, uri_alloc, "%s/%s.%" PRId64,
                   layered_table->stable_uri, WT_CHECKPOINT, ckpt_inuse));
@@ -1937,9 +1936,8 @@ __layered_update_gc_ingest_tables_prune_timestamps(
                 ++ckpt_inuse;
             }
 
-            if (ckpt_inuse == last_ckpt) {
+            if (ckpt_inuse == last_ckpt)
                 prune_timestamp = checkpoint_timestamp;
-            }
 
             /*
              * We now have the oldest checkpoint in use for this table. If it's different from the
@@ -1948,8 +1946,12 @@ __layered_update_gc_ingest_tables_prune_timestamps(
              */
             if (ckpt_inuse != layered_table->last_ckpt_inuse) {
                 for (track = 0; track < ds->ckpt_track_cnt; ++track)
-                    if (ds->ckpt_track[track].ckpt_order == ckpt_inuse)
+                    if (ds->ckpt_track[track].ckpt_order == ckpt_inuse) {
+                        __wt_verbose_level(session, WT_VERB_LAYERED, WT_VERBOSE_DEBUG_5,
+                          "GC %s: global TS is %" PRIu64,
+                          layered_table->iface.name, ds->ckpt_track[track].timestamp);
                         break;
+                    }
 
                 /*
                  * Set the prune timestamp in the btree if it is open, typically it is. However,

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -1868,12 +1868,23 @@ __layered_update_gc_ingest_tables_prune_timestamps(
 
     table_count = manager->open_layered_table_count;
 
+    /*
+     * For each layered table, we want to see what is the oldest checkpoint on that table that is in
+     * use by any open cursor. Even if there are no open cursors on it, the most recent checkpoint
+     * on the table is always considered in use. The basic plan is to start with the last checkpoint
+     * in use that we knew about, and check it again. If it's no longer in use, we go to the next
+     * one, etc. This gives us a list (possibly zero length), of checkpoints that are no longer in
+     * use by cursors on this table. Thus, the timestamp associated with the newest such checkpoint
+     * can be used for garbage collection pruning. Any item in the ingest table older than that
+     * timestamp must be including in one of the checkpoints we're saving, and thus can be removed.
+     */
     for (i = 0; i < table_count; i++) {
         if ((entry = manager->entries[i]) != NULL) {
             layered_table = entry->layered_table;
             WT_ERR_NOTFOUND_OK(
               __layered_last_checkpoint_order(session, layered_table->stable_uri, &last_ckpt),
               true);
+
             /*
              * If we've never seen a checkpoint, then there's nothing in the ingest table we can
              * remove. Move on.
@@ -1887,28 +1898,10 @@ __layered_update_gc_ingest_tables_prune_timestamps(
             }
 
             /*
-             * Allocate enough room for the uri and the WiredTigerCheckpoint.NNN
-             */
-            len = strlen(layered_table->stable_uri) + strlen(WT_CHECKPOINT) + 20;
-            WT_ERR(__wt_realloc_def(session, &uri_alloc, len, &uri_at_checkpoint));
-
-            /*
-             * For each layered table, we want to see what is the oldest checkpoint on that table
-             * that is in use by any open cursor. Even if there are no open cursors on it, the most
-             * recent checkpoint on the table is always considered in use. The basic plan is to
-             * start with the last checkpoint in use that we knew about, and check it again. If it's
-             * no longer in use, we go to the next one, etc. This gives us a list (possibly zero
-             * length), of checkpoints that are no longer in use by cursors on this table. Thus, the
-             * timestamp associated with the newest such checkpoint can be used for garbage
-             * collection pruning. Any item in the ingest table older than that timestamp must be
-             * including in one of the checkpoints we're saving, and thus can be removed.
-             */
-            ckpt_inuse = layered_table->last_ckpt_inuse;
-
-            /*
              * If we are setting a prune timestamp the first time, the previous checkpoint could
              * still be in use, so start from it.
              */
+            ckpt_inuse = layered_table->last_ckpt_inuse;
             if (ckpt_inuse == 0)
                 ckpt_inuse = (last_ckpt > 1) ? last_ckpt - 1 : last_ckpt;
 
@@ -1927,8 +1920,7 @@ __layered_update_gc_ingest_tables_prune_timestamps(
 
                 /* If it's in use by any session, then we're done. */
                 if (ret == 0 && session->dhandle->session_inuse > 0) {
-                    btree = (WT_BTREE *)session->dhandle->handle;
-                    prune_timestamp = btree->ckpt_timestamp;
+                    prune_timestamp = S2BT(session)->ckpt_timestamp;
                     break;
                 }
 
@@ -1948,8 +1940,8 @@ __layered_update_gc_ingest_tables_prune_timestamps(
                 for (track = 0; track < ds->ckpt_track_cnt; ++track)
                     if (ds->ckpt_track[track].ckpt_order == ckpt_inuse) {
                         __wt_verbose_level(session, WT_VERB_LAYERED, WT_VERBOSE_DEBUG_5,
-                          "GC %s: global TS is %" PRIu64,
-                          layered_table->iface.name, ds->ckpt_track[track].timestamp);
+                          "GC %s: global TS is %" PRIu64, layered_table->iface.name,
+                          ds->ckpt_track[track].timestamp);
                         break;
                     }
 

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -1834,7 +1834,7 @@ err:
  * __layered_update_prune_timestamps_print_update_logs --
  *     Print logs for the prune timestamp update.
  */
-static void
+static WT_INLINE void
 __layered_update_prune_timestamps_print_update_logs(WT_SESSION_IMPL *session,
   WT_LAYERED_TABLE *layered_table, wt_timestamp_t prune_timestamp, int64_t ckpt_inuse)
 {
@@ -1861,8 +1861,9 @@ __layered_update_gc_ingest_tables_prune_timestamps(
     WT_LAYERED_TABLE *layered_table;
     WT_LAYERED_TABLE_MANAGER *manager;
     WT_LAYERED_TABLE_MANAGER_ENTRY *entry;
-    wt_timestamp_t prune_timestamp;
+    wt_timestamp_t prune_timestamp, btree_checkpoint_timestamp;
     size_t i, len, table_count, uri_alloc;
+    int32_t dhandle_inuse;
     int64_t ckpt_inuse, last_ckpt;
     char *uri_at_checkpoint;
 
@@ -1921,20 +1922,32 @@ __layered_update_gc_ingest_tables_prune_timestamps(
 
             /* Find the last checkpoint which is still in use. */
             while (ckpt_inuse < last_ckpt) {
+                btree_checkpoint_timestamp = WT_TS_NONE;
+                dhandle_inuse = 0;
+
                 WT_ERR(__wt_snprintf(uri_at_checkpoint, uri_alloc, "%s/%s.%" PRId64,
                   layered_table->stable_uri, WT_CHECKPOINT, ckpt_inuse));
 
                 /* If it's in use, then it must be in the connection cache. */
-                WT_WITH_HANDLE_LIST_READ_LOCK(
-                  session, (ret = __wt_conn_dhandle_find(session, uri_at_checkpoint, NULL)));
+                WT_WITH_HANDLE_LIST_READ_LOCK(session,
+                  if ((ret = __wt_conn_dhandle_find(session, uri_at_checkpoint, NULL)) == 0)
+                    WT_DHANDLE_ACQUIRE(session->dhandle));
 
-                /* If it's in use by any session, then we're done. */
-                if (ret == 0 && session->dhandle->session_inuse > 0) {
-                    prune_timestamp = S2BT(session)->ckpt_timestamp;
-                    break;
+                /* If one exists, read all the required info, then release. */
+                if (ret == 0) {
+                    dhandle_inuse = session->dhandle->session_inuse;
+                    btree_checkpoint_timestamp = S2BT(session)->checkpoint_timestamp;
+                    WT_DHANDLE_RELEASE(session->dhandle);
                 }
 
                 WT_ERR_NOTFOUND_OK(ret, false);
+
+                /* If it's in use by any session, then we're done. */
+                if (dhandle_inuse > 0) {
+                    prune_timestamp = btree_checkpoint_timestamp;
+                    break;
+                }
+
                 ++ckpt_inuse;
             }
 

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -10,9 +10,10 @@
 
 static int __disagg_copy_shared_metadata_one(WT_SESSION_IMPL *session, const char *uri);
 static int __layered_drain_ingest_tables(WT_SESSION_IMPL *session);
+static void __layered_update_prune_timestamps_print_update_logs(WT_SESSION_IMPL *session,
+  WT_LAYERED_TABLE *layered_table, wt_timestamp_t prune_timestamp, int64_t ckpt_inuse);
 static int __layered_update_gc_ingest_tables_prune_timestamps(
   WT_SESSION_IMPL *session, wt_timestamp_t checkpoint_timestamp);
-static int __layered_track_checkpoint(WT_SESSION_IMPL *session, uint64_t checkpoint_timestamp);
 static int __layered_last_checkpoint_order(
   WT_SESSION_IMPL *session, const char *shared_uri, int64_t *ckpt_order);
 
@@ -537,10 +538,6 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, uint64_t meta_lsn)
     /* Remember the root config of the last checkpoint. */
     __wt_free(session, conn->disaggregated_storage.last_checkpoint_root);
     WT_ERR(__wt_strdup(session, root, &conn->disaggregated_storage.last_checkpoint_root));
-
-    /* Keep a record of past checkpoints, they will be needed for ingest garbage collection. */
-    WT_ERR_MSG_CHK(session, __layered_track_checkpoint(session, checkpoint_timestamp),
-      "Updating disagg checkpoint tracking failed");
 
     /* Update ingest tables' prune timestamps. */
     WT_ERR_MSG_CHK(session,
@@ -1834,6 +1831,23 @@ err:
 }
 
 /*
+ * __layered_update_prune_timestamps_print_update_logs --
+ *     Print logs for the prune timestamp update.
+ */
+static void
+__layered_update_prune_timestamps_print_update_logs(WT_SESSION_IMPL *session,
+  WT_LAYERED_TABLE *layered_table, wt_timestamp_t prune_timestamp, int64_t ckpt_inuse)
+{
+    __wt_verbose_level(session, WT_VERB_LAYERED, WT_VERBOSE_DEBUG_5,
+      "GC %s: update prune timestamp from %" PRIu64 " to %" PRIu64, layered_table->iface.name,
+      S2BT(session)->prune_timestamp, prune_timestamp);
+
+    __wt_verbose_level(session, WT_VERB_LAYERED, WT_VERBOSE_DEBUG_5,
+      "GC %s: update checkpoint in use from %" PRId64 " to %" PRId64, layered_table->iface.name,
+      layered_table->last_ckpt_inuse, ckpt_inuse);
+}
+
+/*
  * __layered_update_gc_ingest_tables_prune_timestamps --
  *     Update the timestamp we can prune the ingest tables.
  */
@@ -1844,20 +1858,16 @@ __layered_update_gc_ingest_tables_prune_timestamps(
     WT_BTREE *btree;
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
-    WT_DISAGGREGATED_STORAGE *ds;
     WT_LAYERED_TABLE *layered_table;
     WT_LAYERED_TABLE_MANAGER *manager;
     WT_LAYERED_TABLE_MANAGER_ENTRY *entry;
     wt_timestamp_t prune_timestamp;
     size_t i, len, table_count, uri_alloc;
-    int64_t ckpt_inuse, last_ckpt, min_ckpt_inuse;
-    uint32_t track;
+    int64_t ckpt_inuse, last_ckpt;
     char *uri_at_checkpoint;
 
     conn = S2C(session);
     manager = &conn->layered_table_manager;
-    ds = &conn->disaggregated_storage;
-    min_ckpt_inuse = ds->ckpt_track_cnt;
     uri_at_checkpoint = NULL;
     uri_alloc = 0;
     prune_timestamp = WT_TS_NONE;
@@ -1933,18 +1943,9 @@ __layered_update_gc_ingest_tables_prune_timestamps(
 
             /*
              * We now have the oldest checkpoint in use for this table. If it's different from the
-             * last time we checked, find out what timestamp that checkpoint corresponds to. That
-             * will be the timestamp we use for pruning.
+             * last time we checked, update the timestamp for pruning
              */
             if (ckpt_inuse != layered_table->last_ckpt_inuse) {
-                for (track = 0; track < ds->ckpt_track_cnt; ++track)
-                    if (ds->ckpt_track[track].ckpt_order == ckpt_inuse) {
-                        __wt_verbose_level(session, WT_VERB_LAYERED, WT_VERBOSE_DEBUG_5,
-                          "GC %s: global TS is %" PRIu64, layered_table->iface.name,
-                          ds->ckpt_track[track].timestamp);
-                        break;
-                    }
-
                 /*
                  * Set the prune timestamp in the btree if it is open, typically it is. However,
                  * it's possible that it hasn't been opened yet. In that case, we need to skip
@@ -1957,16 +1958,13 @@ __layered_update_gc_ingest_tables_prune_timestamps(
                 if (ret != WT_NOTFOUND) {
                     btree = (WT_BTREE *)session->dhandle->handle;
 
-                    __wt_verbose_level(session, WT_VERB_LAYERED, WT_VERBOSE_DEBUG_5,
-                      "GC %s: update prune timestamp from %" PRIu64 " to %" PRIu64,
-                      layered_table->iface.name, btree->prune_timestamp, prune_timestamp);
+                    __layered_update_prune_timestamps_print_update_logs(
+                      session, layered_table, prune_timestamp, ckpt_inuse);
+
                     WT_ASSERT(session, prune_timestamp >= btree->prune_timestamp);
                     WT_RELEASE_WRITE(btree->prune_timestamp, prune_timestamp);
-
-                    __wt_verbose_level(session, WT_VERB_LAYERED, WT_VERBOSE_DEBUG_5,
-                      "GC %s: update checkpoint in use from %" PRId64 " to %" PRId64,
-                      layered_table->iface.name, layered_table->last_ckpt_inuse, ckpt_inuse);
                     layered_table->last_ckpt_inuse = ckpt_inuse;
+
                     WT_ERR(__wt_session_release_dhandle(session));
                 } else {
                     __wt_verbose_level(session, WT_VERB_LAYERED, WT_VERBOSE_DEBUG_5,
@@ -1975,10 +1973,8 @@ __layered_update_gc_ingest_tables_prune_timestamps(
                     ret = 0;
                 }
             }
-            min_ckpt_inuse = WT_MIN(layered_table->last_ckpt_inuse, min_ckpt_inuse);
         }
     }
-    ds->ckpt_min_inuse = min_ckpt_inuse;
 
 err:
     if (ret != 0)
@@ -2023,57 +2019,6 @@ __layered_last_checkpoint_order(
 
     /* These should always be the same. */
     WT_ASSERT(session, *ckpt_order == order_from_name);
-
-    return (0);
-}
-
-/*
- * __layered_track_checkpoint --
- *     Keep a record of past checkpoints, they will be needed for ingest garbage collection.
- */
-static int
-__layered_track_checkpoint(WT_SESSION_IMPL *session, uint64_t checkpoint_timestamp)
-{
-    WT_CONNECTION_IMPL *conn;
-    WT_DECL_RET;
-    WT_DISAGGREGATED_STORAGE *ds;
-    int64_t order;
-    uint32_t entry, expire;
-
-    conn = S2C(session);
-    ds = &conn->disaggregated_storage;
-
-    WT_RET_NOTFOUND_OK(
-      ret = __layered_last_checkpoint_order(session, WT_DISAGG_METADATA_URI, &order));
-
-    /* If we didn't find a checkpoint, it means that there are no data in the shared storage. */
-    if (ret == WT_NOTFOUND)
-        return (0);
-
-    /* Figure out how many entries at the beginning are no longer useful. */
-    for (expire = 0; expire < ds->ckpt_track_cnt; ++expire) {
-        if (ds->ckpt_track[expire].ckpt_order >= ds->ckpt_min_inuse)
-            break;
-        __wt_verbose_level(session, WT_VERB_LAYERED, WT_VERBOSE_DEBUG_5,
-          "expiring tracked checkpoint: %" PRId64 " %" PRIu64 "\n",
-          ds->ckpt_track[expire].ckpt_order, ds->ckpt_track[expire].timestamp);
-    }
-
-    /* Shift the array of tracked items down to remove any expired entries. */
-    if (expire != 0) {
-        memmove(&ds->ckpt_track[0], &ds->ckpt_track[expire],
-          sizeof(ds->ckpt_track[0]) * (ds->ckpt_track_cnt - expire));
-        ds->ckpt_track_cnt -= expire;
-    }
-
-    /* Allocate one more, and fill it. */
-    entry = ds->ckpt_track_cnt;
-    WT_RET(__wt_realloc_def(session, &ds->ckpt_track_alloc, entry + 1, &ds->ckpt_track));
-    ds->ckpt_track[entry].ckpt_order = order;
-    ds->ckpt_track[entry].timestamp = checkpoint_timestamp;
-    ++ds->ckpt_track_cnt;
-    __wt_verbose_level(session, WT_VERB_LAYERED, WT_VERBOSE_DEBUG_5,
-      "tracking checkpoint: %" PRId64 " %" PRIu64 "\n", order, checkpoint_timestamp);
 
     return (0);
 }

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -1943,7 +1943,7 @@ __layered_update_gc_ingest_tables_prune_timestamps(
 
             /*
              * We now have the oldest checkpoint in use for this table. If it's different from the
-             * last time we checked, update the timestamp for pruning
+             * last time we checked, update the timestamp for pruning.
              */
             if (ckpt_inuse != layered_table->last_ckpt_inuse) {
                 /*

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -1863,8 +1863,8 @@ __layered_update_gc_ingest_tables_prune_timestamps(
     WT_LAYERED_TABLE_MANAGER_ENTRY *entry;
     wt_timestamp_t prune_timestamp, btree_checkpoint_timestamp;
     size_t i, len, table_count, uri_alloc;
-    int32_t dhandle_inuse;
     int64_t ckpt_inuse, last_ckpt;
+    int32_t dhandle_inuse;
     char *uri_at_checkpoint;
 
     conn = S2C(session);

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -10,7 +10,8 @@
 
 static int __disagg_copy_shared_metadata_one(WT_SESSION_IMPL *session, const char *uri);
 static int __layered_drain_ingest_tables(WT_SESSION_IMPL *session);
-static int __layered_update_gc_ingest_tables_prune_timestamps(WT_SESSION_IMPL *session);
+static int __layered_update_gc_ingest_tables_prune_timestamps(WT_SESSION_IMPL *session,
+                                                              wt_timestamp_t checkpoint_timestamp);
 static int __layered_track_checkpoint(WT_SESSION_IMPL *session, uint64_t checkpoint_timestamp);
 static int __layered_last_checkpoint_order(
   WT_SESSION_IMPL *session, const char *shared_uri, int64_t *ckpt_order);
@@ -542,7 +543,7 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, uint64_t meta_lsn)
       "Updating disagg checkpoint tracking failed");
 
     /* Update ingest tables' prune timestamps. */
-    WT_ERR_MSG_CHK(session, __layered_update_gc_ingest_tables_prune_timestamps(internal_session),
+    WT_ERR_MSG_CHK(session, __layered_update_gc_ingest_tables_prune_timestamps(internal_session, checkpoint_timestamp),
       "Updating prune timestamp failed");
 
 err:
@@ -1836,7 +1837,8 @@ err:
  *     Update the timestamp we can prune the ingest tables.
  */
 static int
-__layered_update_gc_ingest_tables_prune_timestamps(WT_SESSION_IMPL *session)
+__layered_update_gc_ingest_tables_prune_timestamps(WT_SESSION_IMPL *session,
+                                                   wt_timestamp_t checkpoint_timestamp)
 {
     WT_BTREE *btree;
     WT_CONNECTION_IMPL *conn;
@@ -1883,6 +1885,20 @@ __layered_update_gc_ingest_tables_prune_timestamps(WT_SESSION_IMPL *session)
             }
 
             /*
+             * Allocate enough room for the uri and the WiredTigerCheckpoint.NNN
+             */
+            len = strlen(layered_table->stable_uri) + strlen(WT_CHECKPOINT) + 20;
+            WT_ERR(__wt_realloc_def(session, &uri_alloc, len, &uri_at_checkpoint));
+
+            /* Track the stable table's last checkpoint timestamp for further checkpo*/
+            WT_ERR(__wt_snprintf(uri_at_checkpoint, uri_alloc, "%s/%s.%" PRId64,
+              layered_table->stable_uri, WT_CHECKPOINT, last_ckpt));
+            WT_ERR(__wt_session_get_dhandle(session, uri_at_checkpoint, NULL, NULL, 0));
+            btree = (WT_BTREE *)session->dhandle->handle;
+            btree->ckpt_timestamp = checkpoint_timestamp;
+
+            WT_ERR(__wt_session_release_dhandle(session));
+            /*
              * For each layered table, we want to see what is the oldest checkpoint on that table
              * that is in use by any open cursor. Even if there are no open cursors on it, the most
              * recent checkpoint on the table is always considered in use. The basic plan is to
@@ -1894,29 +1910,12 @@ __layered_update_gc_ingest_tables_prune_timestamps(WT_SESSION_IMPL *session)
              * including in one of the checkpoints we're saving, and thus can be removed.
              */
             ckpt_inuse = layered_table->last_ckpt_inuse;
+
+            /* Picking up a checkpoint the first time, so it's OK to set it to the current one. */
             if (ckpt_inuse == 0) {
-                /*
-                 * If we've never checked this layered table before, it's safe to start at the
-                 * oldest checkpoint that we're tracking. There are no cursors in the system that
-                 * are open at checkpoints older than that one. It's probably impossible that we
-                 * haven't tracked any checkpoints, if that happens, we'll start checking at zero.
-                 */
-                if (ds->ckpt_track_cnt > 0)
-                    ckpt_inuse = ds->ckpt_track[0].ckpt_order;
+                ckpt_inuse = last_ckpt;
             }
 
-            /*
-             * Allocate enough room for the uri and the WiredTigerCheckpoint.NNN
-             */
-            len = strlen(layered_table->stable_uri) + strlen(WT_CHECKPOINT) + 20;
-            WT_ERR(__wt_realloc_def(session, &uri_alloc, len, &uri_at_checkpoint));
-
-            /*
-             * For each checkpoint, see of the handle is in use. If not, it is safe to gc.
-             * FIXME-WT-15192: `ckpt_inuse` and `last_ckpt` could be obtained from different tables
-             * and that's not correct to compare checkpoint orders from different tables since they
-             * are unrelated.
-             */
             while (ckpt_inuse < last_ckpt) {
                 WT_ERR(__wt_snprintf(uri_at_checkpoint, uri_alloc, "%s/%s.%" PRId64,
                   layered_table->stable_uri, WT_CHECKPOINT, ckpt_inuse));
@@ -1926,11 +1925,18 @@ __layered_update_gc_ingest_tables_prune_timestamps(WT_SESSION_IMPL *session)
                   session, (ret = __wt_conn_dhandle_find(session, uri_at_checkpoint, NULL)));
 
                 /* If it's in use by any session, then we're done. */
-                if (ret == 0 && session->dhandle->session_inuse > 0)
+                if (ret == 0 && session->dhandle->session_inuse > 0) {
+                    btree = (WT_BTREE *)session->dhandle->handle;
+                    prune_timestamp = btree->ckpt_timestamp;
                     break;
+                }
 
                 WT_ERR_NOTFOUND_OK(ret, false);
                 ++ckpt_inuse;
+            }
+
+            if (ckpt_inuse == last_ckpt) {
+                prune_timestamp = checkpoint_timestamp;
             }
 
             /*
@@ -1942,12 +1948,12 @@ __layered_update_gc_ingest_tables_prune_timestamps(WT_SESSION_IMPL *session)
                 for (track = 0; track < ds->ckpt_track_cnt; ++track)
                     if (ds->ckpt_track[track].ckpt_order == ckpt_inuse)
                         break;
-                if (track >= ds->ckpt_track_cnt)
-                    WT_ERR_MSG(session, WT_NOTFOUND,
-                      "could not find checkpoint order %" PRId64 " in list of tracked checkpoints",
-                      ckpt_inuse);
+                // if (track >= ds->ckpt_track_cnt)
+                //     WT_ERR_MSG(session, WT_NOTFOUND,
+                //       "could not find checkpoint order %" PRId64 " in list of tracked checkpoints",
+                //       ckpt_inuse);
 
-                prune_timestamp = ds->ckpt_track[track].timestamp;
+                // prune_timestamp = ds->ckpt_track[track].timestamp;
 
                 /*
                  * Set the prune timestamp in the btree if it is open, typically it is. However,

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -10,8 +10,8 @@
 
 static int __disagg_copy_shared_metadata_one(WT_SESSION_IMPL *session, const char *uri);
 static int __layered_drain_ingest_tables(WT_SESSION_IMPL *session);
-static int __layered_update_gc_ingest_tables_prune_timestamps(WT_SESSION_IMPL *session,
-                                                              wt_timestamp_t checkpoint_timestamp);
+static int __layered_update_gc_ingest_tables_prune_timestamps(
+  WT_SESSION_IMPL *session, wt_timestamp_t checkpoint_timestamp);
 static int __layered_track_checkpoint(WT_SESSION_IMPL *session, uint64_t checkpoint_timestamp);
 static int __layered_last_checkpoint_order(
   WT_SESSION_IMPL *session, const char *shared_uri, int64_t *ckpt_order);
@@ -543,7 +543,8 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, uint64_t meta_lsn)
       "Updating disagg checkpoint tracking failed");
 
     /* Update ingest tables' prune timestamps. */
-    WT_ERR_MSG_CHK(session, __layered_update_gc_ingest_tables_prune_timestamps(internal_session, checkpoint_timestamp),
+    WT_ERR_MSG_CHK(session,
+      __layered_update_gc_ingest_tables_prune_timestamps(internal_session, checkpoint_timestamp),
       "Updating prune timestamp failed");
 
 err:
@@ -1837,8 +1838,8 @@ err:
  *     Update the timestamp we can prune the ingest tables.
  */
 static int
-__layered_update_gc_ingest_tables_prune_timestamps(WT_SESSION_IMPL *session,
-                                                   wt_timestamp_t checkpoint_timestamp)
+__layered_update_gc_ingest_tables_prune_timestamps(
+  WT_SESSION_IMPL *session, wt_timestamp_t checkpoint_timestamp)
 {
     WT_BTREE *btree;
     WT_CONNECTION_IMPL *conn;
@@ -1859,6 +1860,7 @@ __layered_update_gc_ingest_tables_prune_timestamps(WT_SESSION_IMPL *session,
     min_ckpt_inuse = ds->ckpt_track_cnt;
     uri_at_checkpoint = NULL;
     uri_alloc = 0;
+    prune_timestamp = WT_TS_NONE;
 
     WT_ASSERT(session, manager->state == WT_LAYERED_TABLE_MANAGER_RUNNING);
 
@@ -1890,7 +1892,7 @@ __layered_update_gc_ingest_tables_prune_timestamps(WT_SESSION_IMPL *session,
             len = strlen(layered_table->stable_uri) + strlen(WT_CHECKPOINT) + 20;
             WT_ERR(__wt_realloc_def(session, &uri_alloc, len, &uri_at_checkpoint));
 
-            /* Track the stable table's last checkpoint timestamp for further checkpo*/
+            /* Track the stable table's last checkpoint timestamp */
             WT_ERR(__wt_snprintf(uri_at_checkpoint, uri_alloc, "%s/%s.%" PRId64,
               layered_table->stable_uri, WT_CHECKPOINT, last_ckpt));
             WT_ERR(__wt_session_get_dhandle(session, uri_at_checkpoint, NULL, NULL, 0));
@@ -1948,12 +1950,6 @@ __layered_update_gc_ingest_tables_prune_timestamps(WT_SESSION_IMPL *session,
                 for (track = 0; track < ds->ckpt_track_cnt; ++track)
                     if (ds->ckpt_track[track].ckpt_order == ckpt_inuse)
                         break;
-                // if (track >= ds->ckpt_track_cnt)
-                //     WT_ERR_MSG(session, WT_NOTFOUND,
-                //       "could not find checkpoint order %" PRId64 " in list of tracked checkpoints",
-                //       ckpt_inuse);
-
-                // prune_timestamp = ds->ckpt_track[track].timestamp;
 
                 /*
                  * Set the prune timestamp in the btree if it is open, typically it is. However,

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -251,10 +251,12 @@ __clayered_open_stable(WT_CURSOR_LAYERED *clayered, bool leader)
     WT_SESSION_IMPL *session;
     const char *cfg[4] = {WT_CONFIG_BASE(CUR2S(clayered), WT_SESSION_open_cursor), "", NULL, NULL};
     const char *checkpoint_name, *stable_uri;
+    wt_timestamp_t last_ckpt_timestamp;
 
     session = CUR2S(clayered);
     layered = (WT_LAYERED_TABLE *)clayered->dhandle;
     stable_uri = layered->stable_uri;
+    last_ckpt_timestamp = S2C(session)->disaggregated_storage.last_checkpoint_timestamp;
 
     WT_RET(__wt_scr_alloc(session, 0, &random_config));
     /* Get the configuration for random cursors, if any. */
@@ -318,9 +320,10 @@ __clayered_open_stable(WT_CURSOR_LAYERED *clayered, bool leader)
         /* Layered cursor is not compatible with cursor_copy config. */
         F_CLR(clayered->stable_cursor, WT_CURSTD_DEBUG_COPY_KEY | WT_CURSTD_DEBUG_COPY_VALUE);
 
-        /* Update stable table checkpoint timestamp */
-        S2BT(session)->ckpt_timestamp =
-          S2C(session)->disaggregated_storage.last_checkpoint_timestamp;
+        /* Update the stable table checkpoint timestamp. */
+        WT_ASSERT(
+          session, __wt_atomic_load64(&S2BT(session)->ckpt_timestamp) <= last_ckpt_timestamp);
+        __wt_atomic_store64(&S2BT(session)->ckpt_timestamp, last_ckpt_timestamp);
     }
 
 err:

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -251,12 +251,10 @@ __clayered_open_stable(WT_CURSOR_LAYERED *clayered, bool leader)
     WT_SESSION_IMPL *session;
     const char *cfg[4] = {WT_CONFIG_BASE(CUR2S(clayered), WT_SESSION_open_cursor), "", NULL, NULL};
     const char *checkpoint_name, *stable_uri;
-    wt_timestamp_t last_ckpt_timestamp;
 
     session = CUR2S(clayered);
     layered = (WT_LAYERED_TABLE *)clayered->dhandle;
     stable_uri = layered->stable_uri;
-    last_ckpt_timestamp = S2C(session)->disaggregated_storage.last_checkpoint_timestamp;
 
     WT_RET(__wt_scr_alloc(session, 0, &random_config));
     /* Get the configuration for random cursors, if any. */
@@ -319,11 +317,6 @@ __clayered_open_stable(WT_CURSOR_LAYERED *clayered, bool leader)
 
         /* Layered cursor is not compatible with cursor_copy config. */
         F_CLR(clayered->stable_cursor, WT_CURSTD_DEBUG_COPY_KEY | WT_CURSTD_DEBUG_COPY_VALUE);
-
-        /* Update the stable table checkpoint timestamp. */
-        WT_ASSERT(
-          session, __wt_atomic_load64(&S2BT(session)->ckpt_timestamp) <= last_ckpt_timestamp);
-        __wt_atomic_store64(&S2BT(session)->ckpt_timestamp, last_ckpt_timestamp);
     }
 
 err:

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -317,6 +317,9 @@ __clayered_open_stable(WT_CURSOR_LAYERED *clayered, bool leader)
 
         /* Layered cursor is not compatible with cursor_copy config. */
         F_CLR(clayered->stable_cursor, WT_CURSTD_DEBUG_COPY_KEY | WT_CURSTD_DEBUG_COPY_VALUE);
+
+        /* Update stable table checkpoint timestamp */
+        S2BT(session)->ckpt_timestamp = S2C(session)->disaggregated_storage.last_checkpoint_timestamp;
     }
 
 err:

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -319,7 +319,8 @@ __clayered_open_stable(WT_CURSOR_LAYERED *clayered, bool leader)
         F_CLR(clayered->stable_cursor, WT_CURSTD_DEBUG_COPY_KEY | WT_CURSTD_DEBUG_COPY_VALUE);
 
         /* Update stable table checkpoint timestamp */
-        S2BT(session)->ckpt_timestamp = S2C(session)->disaggregated_storage.last_checkpoint_timestamp;
+        S2BT(session)->ckpt_timestamp =
+          S2C(session)->disaggregated_storage.last_checkpoint_timestamp;
     }
 
 err:

--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -149,7 +149,7 @@ struct __wt_btree {
 
     /* FIXME-WT-15633: Combine `prune_timestamp` and `ckpt_timestamp` into one variable */
     wt_shared wt_timestamp_t prune_timestamp; /* Ingest table GC collection timestamp */
-    wt_shared wt_timestamp_t ckpt_timestamp;  /* Stable table checkpoint timestamp */
+    wt_timestamp_t checkpoint_timestamp;      /* Stable table checkpoint timestamp */
 
 #define WT_SPLIT_DEEPEN_MIN_CHILD_DEF (10 * WT_THOUSAND)
     u_int split_deepen_min_child; /* Minimum entries to deepen tree */

--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -147,12 +147,7 @@ struct __wt_btree {
     bool prefix_compression;      /* Prefix compression */
     u_int prefix_compression_min; /* Prefix compression min */
 
-    /*
-     * prune_timestamp is used only for ingest tables, and ckpt_timestamp is used only for stable
-     * tables. These fields could be combined into a single field or a union. However, since it's
-     * just two fields for now and the space overhead is minimal, it was decided to leave them as
-     * is.
-     */
+    /* FIXME-WT-15633: Combine `prune_timestamp` and `ckpt_timestamp` into one variable */
     wt_shared wt_timestamp_t prune_timestamp; /* Ingest table GC collection timestamp */
     wt_shared wt_timestamp_t ckpt_timestamp;  /* Stable table checkpoint timestamp */
 

--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -142,13 +142,19 @@ struct __wt_btree {
     /*
      * Reconciliation...
      */
-    u_int dictionary;                         /* Dictionary slots */
-    bool internal_key_truncate;               /* Internal key truncate */
-    bool prefix_compression;                  /* Prefix compression */
-    u_int prefix_compression_min;             /* Prefix compression min */
-    wt_shared wt_timestamp_t prune_timestamp; /* Garbage collection timestamp for the ingest
-                                                 component of layered tables */
-    wt_timestamp_t ckpt_timestamp;            /* Stable table timestamp */
+    u_int dictionary;             /* Dictionary slots */
+    bool internal_key_truncate;   /* Internal key truncate */
+    bool prefix_compression;      /* Prefix compression */
+    u_int prefix_compression_min; /* Prefix compression min */
+
+    /*
+     * prune_timestamp is used only for ingest tables, and ckpt_timestamp is used only for stable
+     * tables. These fields could be combined into a single field or a union. However, since it's
+     * just two fields for now and the space overhead is minimal, it was decided to leave them as
+     * is.
+     */
+    wt_shared wt_timestamp_t prune_timestamp; /* Ingest table GC collection timestamp */
+    wt_shared wt_timestamp_t ckpt_timestamp;  /* Stable table checkpoint timestamp */
 
 #define WT_SPLIT_DEEPEN_MIN_CHILD_DEF (10 * WT_THOUSAND)
     u_int split_deepen_min_child; /* Minimum entries to deepen tree */

--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -148,6 +148,7 @@ struct __wt_btree {
     u_int prefix_compression_min;             /* Prefix compression min */
     wt_shared wt_timestamp_t prune_timestamp; /* Garbage collection timestamp for the ingest
                                                  component of layered tables */
+    wt_timestamp_t ckpt_timestamp;            /* Stable table timestamp */
 
 #define WT_SPLIT_DEEPEN_MIN_CHILD_DEF (10 * WT_THOUSAND)
     u_int split_deepen_min_child; /* Minimum entries to deepen tree */

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -223,11 +223,6 @@ struct __wt_disaggregated_storage {
     TAILQ_HEAD(__wt_disagg_copy_metadata_qh, __wt_disagg_copy_metadata) copy_metadata_qh;
     WT_SPINLOCK copy_metadata_lock;
 
-    WT_DISAGGREGATED_CHECKPOINT_TRACK *ckpt_track; /* Checkpoint info retained for GC. */
-    size_t ckpt_track_alloc;                       /* Allocated bytes for checkpoint track. */
-    uint32_t ckpt_track_cnt; /* Number of entries in use for checkpoint track. */
-    int64_t ckpt_min_inuse;  /* The minimum checkpoint order in use. */
-
     /*
      * Ideally we'd have flags passed to the IO system, which could make it all the way to the
      * callers of posix_sync. But that's not possible because (1) posix_directory_sync also has no

--- a/src/schema/schema_open.c
+++ b/src/schema/schema_open.c
@@ -639,8 +639,8 @@ __schema_open_layered_ingest(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered
     /* Flag the ingest btree as participating in automatic garbage collection */
     F_SET(ingest_btree, WT_BTREE_GARBAGE_COLLECT);
 
-    /* FIXME-WT-15192: Consider setting `prune_timestamp` to `last_checkpoint_timestamp` */
-    ingest_btree->prune_timestamp = WT_TS_NONE;
+    WT_ACQUIRE_READ(
+      ingest_btree->prune_timestamp, S2C(session)->disaggregated_storage.last_checkpoint_timestamp);
 
     WT_RET(__wt_session_release_dhandle(session));
     return (0);

--- a/src/schema/schema_open.c
+++ b/src/schema/schema_open.c
@@ -639,9 +639,6 @@ __schema_open_layered_ingest(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered
     /* Flag the ingest btree as participating in automatic garbage collection */
     F_SET(ingest_btree, WT_BTREE_GARBAGE_COLLECT);
 
-    WT_ACQUIRE_READ(
-      ingest_btree->prune_timestamp, S2C(session)->disaggregated_storage.last_checkpoint_timestamp);
-
     WT_RET(__wt_session_release_dhandle(session));
     return (0);
 }

--- a/test/suite/test_layered38.py
+++ b/test/suite/test_layered38.py
@@ -78,7 +78,7 @@ class test_layered38(wttest.WiredTigerTestCase, DisaggConfigMixin):
             session.rollback_transaction()
         return count
 
-    def test_gc_ingest_table(self):
+    def setup(self):
         # Create the oplog
         oplog = Oplog(value_size=500)
 
@@ -91,6 +91,10 @@ class test_layered38(wttest.WiredTigerTestCase, DisaggConfigMixin):
         conn_follow = self.wiredtiger_open('follower', self.extensionsConfig() + self.conn_base_config + 'disaggregated=(role="follower")')
         session_follow = conn_follow.open_session('')
         session_follow.create(self.uri, "allocation_size=512,leaf_page_max=512,key_format=S,value_format=S")
+        return (oplog, t, conn_follow, session_follow)
+
+    def test_gc_ingest_table(self):
+        oplog, t, conn_follow, session_follow = self.setup()
 
         # Load the data for oplog
         oplog.insert(t, self.nitems)
@@ -137,18 +141,7 @@ class test_layered38(wttest.WiredTigerTestCase, DisaggConfigMixin):
         self.assertEqual(count, 0)
 
     def test_gc_ingest_table_with_remove(self):
-        # Create the oplog
-        oplog = Oplog(value_size=500)
-
-        # Create the table on leader and tell oplog about it
-        self.session.create(self.uri, "allocation_size=512,leaf_page_max=512,key_format=S,value_format=S")
-        t = oplog.add_uri(self.uri)
-
-        # Create the follower and create its table
-        # To keep this test relatively easy, we're only using a single URI.
-        conn_follow = self.wiredtiger_open('follower', self.extensionsConfig() + self.conn_base_config + 'disaggregated=(role="follower")')
-        session_follow = conn_follow.open_session('')
-        session_follow.create(self.uri, "allocation_size=512,leaf_page_max=512,key_format=S,value_format=S")
+        oplog, t, conn_follow, session_follow = self.setup()
 
         # Load the data for oplog
         oplog.insert(t, self.nitems)
@@ -236,21 +229,7 @@ class test_layered38(wttest.WiredTigerTestCase, DisaggConfigMixin):
         Test picking up the first checkpoint when an ingest talbe has some data and a cursor pointed
         to this data.
         '''
-        if platform.processor() == 's390x':
-            self.skipTest("FIXME-WT-15000: not working on zSeries")
-
-        # Create the oplog
-        oplog = Oplog(value_size=500)
-
-        # Create the table on leader and tell oplog about it
-        self.session.create(self.uri, "allocation_size=512,leaf_page_max=512,key_format=S,value_format=S")
-        t = oplog.add_uri(self.uri)
-
-        # Create the follower and create its table
-        # To keep this test relatively easy, we're only using a single URI.
-        conn_follow = self.wiredtiger_open('follower', self.extensionsConfig() + self.conn_base_config + 'disaggregated=(role="follower")')
-        session_follow = conn_follow.open_session('')
-        session_follow.create(self.uri, "allocation_size=512,leaf_page_max=512,key_format=S,value_format=S")
+        oplog, t, conn_follow, session_follow = self.setup()
 
         oplog.insert(t, self.nitems)
 

--- a/test/suite/test_layered38.py
+++ b/test/suite/test_layered38.py
@@ -226,7 +226,7 @@ class test_layered38(wttest.WiredTigerTestCase, DisaggConfigMixin):
 
     def test_gc_ingest_with_cursor(self):
         '''
-        Test picking up the first checkpoint when an ingest talbe has some data and a cursor pointed
+        Test picking up the first checkpoint when an ingest table has some data and a cursor pointed
         to this data.
         '''
         oplog, t, conn_follow, session_follow = self.setup()

--- a/test/suite/test_layered38.py
+++ b/test/suite/test_layered38.py
@@ -230,3 +230,54 @@ class test_layered38(wttest.WiredTigerTestCase, DisaggConfigMixin):
         self.evict_ingest(session_follow, ts)
         count = self.count_ingest(session_follow, ts)
         self.assertEqual(count, 0)
+
+    def test_gc_ingest_with_cursor(self):
+        '''
+        Test picking up the first checkpoint when an ingest talbe has some data and a cursor pointed
+        to this data.
+        '''
+        if platform.processor() == 's390x':
+            self.skipTest("FIXME-WT-15000: not working on zSeries")
+
+        # Create the oplog
+        oplog = Oplog(value_size=500)
+
+        # Create the table on leader and tell oplog about it
+        self.session.create(self.uri, "allocation_size=512,leaf_page_max=512,key_format=S,value_format=S")
+        t = oplog.add_uri(self.uri)
+
+        # Create the follower and create its table
+        # To keep this test relatively easy, we're only using a single URI.
+        conn_follow = self.wiredtiger_open('follower', self.extensionsConfig() + self.conn_base_config + 'disaggregated=(role="follower")')
+        session_follow = conn_follow.open_session('')
+        session_follow.create(self.uri, "allocation_size=512,leaf_page_max=512,key_format=S,value_format=S")
+
+        oplog.insert(t, self.nitems)
+
+        ts = oplog.last_timestamp()
+
+        # Apply the changes to the leader
+        oplog.apply(self, self.session, 0, self.nitems)
+        oplog.check(self, self.session, 0, self.nitems)
+
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(ts)}')
+
+        # Take a checkpoint
+        self.session.checkpoint()
+
+        # Apply the changes to the follower
+        oplog.apply(self, session_follow, 0, self.nitems)
+        oplog.check(self, session_follow, 0, self.nitems)
+
+        # Hold a cursor open on the layered table, and on the ingest as well.
+        session_follow2 = conn_follow.open_session('')
+        hold_cursor = session_follow2.open_cursor(self.uri)
+        hold_cursor.next()
+
+        # Take a checkpoint and advance it, make sure everything is still good
+        self.disagg_advance_checkpoint(conn_follow)
+        oplog.check(self, session_follow, 0, self.nitems)
+
+        # Close the cursor held open.
+        hold_cursor.close()
+        self.disagg_advance_checkpoint(conn_follow)

--- a/test/suite/test_layered47.py
+++ b/test/suite/test_layered47.py
@@ -50,7 +50,18 @@ class test_layered47(wttest.WiredTigerTestCase, DisaggConfigMixin):
     session_follow = None
     conn_follow = None
 
-    uris = ['layered:test_layered47.a', 'layered:test_layered47.b']
+    def setup(self, uris):
+        '''
+        Setup: create tables, put some content to them and pick them up on the follower
+        Checkpoint order for both tables is 1 after this step
+        '''
+        for uri in uris:
+            self.session.create(uri, self.table_cfg)
+            self.leader_put_data(uri)
+
+        self.create_follower()
+        self.checkpoint()
+        self.disagg_advance_checkpoint(self.conn_follow)
 
     def leader_put_data(self, uri, value_prefix = '', low = 1, high = nitems):
         cursor = self.session.open_cursor(uri, None, None)
@@ -82,34 +93,26 @@ class test_layered47(wttest.WiredTigerTestCase, DisaggConfigMixin):
     # This test initializes the `prune_timestamp` to `ckpt2` while `ckpt1` is still in use,
     # creating a conflict by attempting to update the timestamp to an older checkpoint (`ckpt1`) during the checkpoint operation.
     def test_prune_timestamp_initialization(self):
-        # Setup
-        self.session.create(self.uris[0], self.table_cfg)
-        self.session.create(self.uris[1], self.table_cfg)
-        self.create_follower()
-
-        # Create and pick-up checkpoint #1
-        self.leader_put_data(self.uris[1])
-        self.leader_put_data(self.uris[0])
-        self.checkpoint()
-        self.disagg_advance_checkpoint(self.conn_follow)
+        uris = ['layered:test_layered47.a', 'layered:test_layered47.b']
+        self.setup(uris)
 
         # Open a cursor on uris[0] to pin ckpt as in use
-        cursor = self.session_follow.open_cursor(self.uris[0], None, None)
+        cursor = self.session_follow.open_cursor(uris[0], None, None)
         self.session_follow.begin_transaction()
         cursor.set_key(str(1))
         cursor.search()
         self.session_follow.commit_transaction()
 
         # Create and pick-up checkpoint #2
-        self.leader_put_data(self.uris[0], 'aaa')
+        self.leader_put_data(uris[0], 'aaa')
         self.checkpoint()
         self.disagg_advance_checkpoint(self.conn_follow)
 
         # Initialize prune_timestamp (should be set to the ckpt 2, but ckpt 1 is still in use)
-        cursor2 = self.session_follow.open_cursor(self.uris[1], None, None)
+        cursor2 = self.session_follow.open_cursor(uris[1], None, None)
 
         # Create and pick-up checkpoint #3 to initiate checkpoint pickup for `uris[1]`
-        self.leader_put_data(self.uris[0], 'bbb')
+        self.leader_put_data(uris[0], 'bbb')
         self.checkpoint()
         self.disagg_advance_checkpoint(self.conn_follow)
 
@@ -124,30 +127,47 @@ class test_layered47(wttest.WiredTigerTestCase, DisaggConfigMixin):
     # and different tables could have a different order for the same checkpoint, so that logic
     # could easily be broken.
     def test_checkpoint_order_mismatch(self):
-        # Setup: create tables, put some content to them and pick them up on the follower
-        # Checkpoint order for both tables is 1 after this step
-        self.session.create(self.uris[0], self.table_cfg)
-        self.session.create(self.uris[1], self.table_cfg)
-        self.create_follower()
-        self.leader_put_data(self.uris[0])
-        self.leader_put_data(self.uris[1])
-        self.checkpoint()
-        self.disagg_advance_checkpoint(self.conn_follow)
+        uris = ['layered:test_layered47.a', 'layered:test_layered47.b']
+        self.setup(uris)
 
         # Open ingest tables on the follower to make them participate in pruning during pick-ups
-        self.follower_open_close_dummy_cursor(self.uris[0])
-        self.follower_open_close_dummy_cursor(self.uris[1])
+        self.follower_open_close_dummy_cursor(uris[0])
+        self.follower_open_close_dummy_cursor(uris[1])
 
         # Create more checkpoints for the first table only
         # Assuming that checkpoint order for metadata and uris[0] after that is 11
         for i in range(0, 10):
-            self.leader_put_data(self.uris[0], str(i))
+            self.leader_put_data(uris[0], str(i))
             self.checkpoint()
         self.disagg_advance_checkpoint(self.conn_follow)
 
         # Put more content and create new checkpoint for uris[1]
         # Checkpoint order for it would be 2 which is different from metadata and uris[0] checkpoints
-        self.leader_put_data(self.uris[1])
+        self.leader_put_data(uris[1])
+        self.checkpoint()
+        self.disagg_advance_checkpoint(self.conn_follow)
+
+        self.session_follow.close()
+        self.conn_follow.close()
+
+    # Test setting prune TS when previous checkpoints weren't needed it and cursor is open
+    def test_first_gc_with_cursor_on_previous_checkpoint(self):
+        uri = 'layered:test_layered47.a'
+        self.setup([uri])
+
+        # Create 3 checkpoints with a content on the leader and pick them up on the follower
+        # No cursors on the follower were opened so far, so the didn't participate in ingest GC
+        for i in range(0, 3):
+            self.leader_put_data(uri, str(i))
+            self.checkpoint()
+        self.disagg_advance_checkpoint(self.conn_follow)
+
+        # Cursor is pointing to the last checkpoint that exists at this point (ckpt #4)
+        cursor = self.session_follow.open_cursor(uri)
+        cursor.next()
+
+        # Add ckpt #5
+        self.leader_put_data(uri)
         self.checkpoint()
         self.disagg_advance_checkpoint(self.conn_follow)
 

--- a/test/suite/test_layered47.py
+++ b/test/suite/test_layered47.py
@@ -30,12 +30,8 @@ import errno, os, wiredtiger, wttest
 from helper_disagg import DisaggConfigMixin, disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 
-# Regression test for WT-15158
-# Before the fix, during the initialization of an ingest table, `prune_timestamp` was initialized to the last checkpoint timestamp.
-# During the subsequent checkpoint operation, it should be updated to the most recent checkpoint in use.
-# This test is designed to initialize the `prune_timestamp` to `ckpt2` while `ckpt1` is still in use,
-# in order to create a conflict by updating the timestamp to an older one (to `ckpt1`) during the checkpoint operation.
-
+# test_layered47.py
+#    Test pruning of ingest tables on the follower during checkpoint pick-ups.
 @disagg_test_class
 class test_layered47(wttest.WiredTigerTestCase, DisaggConfigMixin):
     disagg_storages = gen_disagg_storages('test_layered47', disagg_only = True)
@@ -76,7 +72,16 @@ class test_layered47(wttest.WiredTigerTestCase, DisaggConfigMixin):
                                                 self.conn_config_follower)
         self.session_follow = self.conn_follow.open_session('')
 
-    def test_layered47(self):
+    def follower_open_close_dummy_cursor(self, uri):
+        cursor = self.session_follow.open_cursor(uri, None, None)
+        cursor.close()
+
+    # Regression test for WT-15158
+    # Before the fix, during the initialization of an ingest table, `prune_timestamp` was set to the last checkpoint timestamp.
+    # During a subsequent checkpoint operation, it should be updated to the most recent checkpoint currently in use.
+    # This test initializes the `prune_timestamp` to `ckpt2` while `ckpt1` is still in use,
+    # creating a conflict by attempting to update the timestamp to an older checkpoint (`ckpt1`) during the checkpoint operation.
+    def test_prune_timestamp_initialization(self):
         # Setup
         self.session.create(self.uris[0], self.table_cfg)
         self.session.create(self.uris[1], self.table_cfg)
@@ -108,6 +113,43 @@ class test_layered47(wttest.WiredTigerTestCase, DisaggConfigMixin):
         self.checkpoint()
         self.disagg_advance_checkpoint(self.conn_follow)
 
+        cursor2.close()
         cursor.close()
+        self.session_follow.close()
+        self.conn_follow.close()
+
+    # Regression test for WT-15192
+    # The root cause of the issue reproduced here is that the logic for selecting a prune
+    # timestamp was based on the metadata checkpoint order. However, this order is table-local,
+    # and different tables could have a different order for the same checkpoint, so that logic
+    # could easily be broken.
+    def test_checkpoint_order_mismatch(self):
+        # Setup: create tables, put some content to them and pick them up on the follower
+        # Checkpoint order for both tables is 1 after this step
+        self.session.create(self.uris[0], self.table_cfg)
+        self.session.create(self.uris[1], self.table_cfg)
+        self.create_follower()
+        self.leader_put_data(self.uris[0])
+        self.leader_put_data(self.uris[1])
+        self.checkpoint()
+        self.disagg_advance_checkpoint(self.conn_follow)
+
+        # Open ingest tables on the follower to make them participate in pruning during pick-ups
+        self.follower_open_close_dummy_cursor(self.uris[0])
+        self.follower_open_close_dummy_cursor(self.uris[1])
+
+        # Create more checkpoints for the first table only
+        # Assuming that checkpoint order for metadata and uris[0] after that is 11
+        for i in range(0, 10):
+            self.leader_put_data(self.uris[0], str(i))
+            self.checkpoint()
+        self.disagg_advance_checkpoint(self.conn_follow)
+
+        # Put more content and create new checkpoint for uris[1]
+        # Checkpoint order for it would be 2 which is different from metadata and uris[0] checkpoints
+        self.leader_put_data(self.uris[1])
+        self.checkpoint()
+        self.disagg_advance_checkpoint(self.conn_follow)
+
         self.session_follow.close()
         self.conn_follow.close()


### PR DESCRIPTION
During the process of searching for the last checkpoint that is still in use, we open local table checkpoints using checkpoint-specific dhandles (e.g., `table_name/WiredTigerCheckpoint###`). When we find one, we currently use the global `conn->disaggregated_storage->ds_track` structure, which stores a `{metadata_ckpt_order, timestamp}` mapping, to determine the new prune_timestamp value. This approach is incorrect, since tables' checkpoint orders are unrelated, and we cannot match a local table's checkpoint order with `metadata_ckpt_order` to define the checkpoint.

This PR implements tracking of checkpoint timestamps inside the stable btree, which allows us to update `prune_timestamp` without accessing any global structures and avoids incorrect comparisons between different tables' checkpoint orders.