### PR TITLE
WT-15626 Fix RTS verbose output to print all the timestamps

### DIFF
--- a/src/rollback_to_stable/rts_btree.c
+++ b/src/rollback_to_stable/rts_btree.c
@@ -66,8 +66,8 @@ __rts_btree_abort_update(WT_SESSION_IMPL *session, WT_ITEM *key, WT_UPDATE *firs
                                            ", stable_timestamp=%s < durable_timestamp=%s: %s, "
                                            "prepare_state=%s, flags 0x%" PRIx16,
               upd->txnid, !txn_id_visible ? "true" : "false",
-              __wt_timestamp_to_string(rollback_timestamp, ts_string[1]),
-              __wt_timestamp_to_string(upd->upd_durable_ts, ts_string[0]),
+              __wt_timestamp_to_string(rollback_timestamp, ts_string[0]),
+              __wt_timestamp_to_string(upd->upd_durable_ts, ts_string[1]),
               rollback_timestamp < upd->upd_durable_ts ? "true" : "false",
               __wt_prepare_state_str(upd->prepare_state), upd->flags);
 

--- a/src/rollback_to_stable/rts_btree.c
+++ b/src/rollback_to_stable/rts_btree.c
@@ -83,8 +83,8 @@ __rts_btree_abort_update(WT_SESSION_IMPL *session, WT_ITEM *key, WT_UPDATE *firs
               WT_RTS_VERB_TAG_STABLE_UPDATE_FOUND
               "stable update found with txnid=%" PRIu64
               ", stable_timestamp=%s,  durable_timestamp=%s, flags 0x%" PRIx16,
-              upd->txnid, __wt_timestamp_to_string(rollback_timestamp, ts_string[1]),
-              __wt_timestamp_to_string(upd->upd_durable_ts, ts_string[0]), upd->flags);
+              upd->txnid, __wt_timestamp_to_string(rollback_timestamp, ts_string[0]),
+              __wt_timestamp_to_string(upd->upd_durable_ts, ts_string[1]), upd->flags);
             break;
         }
     }
@@ -517,7 +517,7 @@ __rts_btree_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_REF *ref, WT_ROW *rip,
           WT_RTS_VERB_TAG_HS_UPDATE_ABORT
           "history store update aborted with time_window=%s, type=%s and stable_timestamp=%s",
           __wt_time_window_to_string(hs_tw, tw_string), __wt_update_type_str(type),
-          __wt_timestamp_to_string(rollback_timestamp, ts_string[3]));
+          __wt_timestamp_to_string(rollback_timestamp, ts_string[0]));
 
         /*
          * Start time point of the current record may be used as stop time point of the previous

--- a/src/support/timestamp.c
+++ b/src/support/timestamp.c
@@ -28,11 +28,12 @@ char *
 __wt_time_point_to_string(wt_timestamp_t durable_ts, wt_timestamp_t ts, wt_timestamp_t prepare_ts,
   uint64_t prepared_id, uint64_t txn_id, char *tp_string)
 {
-    char ts_string[WT_TS_INT_STRING_SIZE];
+    char ts_string[3][WT_TS_INT_STRING_SIZE];
 
     WT_IGNORE_RET(__wt_snprintf(tp_string, WT_TIME_STRING_SIZE, "%s/%s/%s/%" PRIu64 "/%" PRIu64,
-      __wt_timestamp_to_string(durable_ts, ts_string), __wt_timestamp_to_string(ts, ts_string),
-      __wt_timestamp_to_string(prepare_ts, ts_string), prepared_id, txn_id));
+      __wt_timestamp_to_string(durable_ts, ts_string[0]),
+      __wt_timestamp_to_string(ts, ts_string[1]),
+      __wt_timestamp_to_string(prepare_ts, ts_string[2]), prepared_id, txn_id));
     return (tp_string);
 }
 


### PR DESCRIPTION
Allocate the correct number of array strings to hold all the timestamp values being printed, ensuring that previous data isn't overwritten.
