### PR TITLE
WT-15614 Performance regression due to missing optimisation flags for Release builds

### DIFF
--- a/cmake/configs/base.cmake
+++ b/cmake/configs/base.cmake
@@ -48,7 +48,6 @@ if(NOT HAVE_BUILTIN_EXTENSION_IAA)
     set(default_enable_iaa ${HAVE_LIBQPL})
 endif()
 
-
 if(${CMAKE_BUILD_TYPE_UPPER} STREQUAL "RELEASE")
     set(default_enable_debug_info OFF)
 endif()

--- a/cmake/configs/base.cmake
+++ b/cmake/configs/base.cmake
@@ -14,7 +14,9 @@ set(default_enable_static OFF)
 set(default_enable_shared ON)
 set(default_internal_sqlite3 ON)
 
-if("${CMAKE_BUILD_TYPE}" MATCHES "^(Release|RelWithDebInfo)$")
+string(TOUPPER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE_UPPER)
+
+if(${CMAKE_BUILD_TYPE_UPPER} MATCHES "^(RELEASE|RELWITHDEBINFO)$")
     set(default_have_diagnostics OFF)
 endif()
 
@@ -26,7 +28,7 @@ if(Python3_FOUND)
 endif()
 
 # MSan / UBSan fails on Python tests due to linking issue.
-if("${CMAKE_BUILD_TYPE}" MATCHES "^(MSan|UBSan)$")
+if(${CMAKE_BUILD_TYPE_UPPER} MATCHES "^(MSAN|UBSAN)$")
     set(default_enable_python OFF)
 endif()
 
@@ -46,7 +48,8 @@ if(NOT HAVE_BUILTIN_EXTENSION_IAA)
     set(default_enable_iaa ${HAVE_LIBQPL})
 endif()
 
-if("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
+
+if(${CMAKE_BUILD_TYPE_UPPER} STREQUAL "RELEASE")
     set(default_enable_debug_info OFF)
 endif()
 
@@ -371,7 +374,7 @@ config_bool(
 )
 
 set(default_optimize_level "-Og")
-if("${CMAKE_BUILD_TYPE}" MATCHES "^(Release|RelWithDebInfo)$")
+if(${CMAKE_BUILD_TYPE_UPPER} MATCHES "^(RELEASE|RELWITHDEBINFO)$")
     if(WT_WIN)
         set(default_optimize_level "/O2")
     else()
@@ -457,6 +460,39 @@ if(ENABLE_DEBUG_INFO AND NOT WT_DEBUG_FLAGS_INITIALIZED)
     # Mark that we've set the initial debug flags
     set(WT_DEBUG_FLAGS_INITIALIZED TRUE CACHE INTERNAL
         "WiredTiger debug flags have been initialized")
+endif()
+
+# We want to use the optimization level from CC_OPTIMIZE_LEVEL.
+if(NOT ("${WT_OPTIMIZE_FLAGS_SAVED}" STREQUAL "${CC_OPTIMIZE_LEVEL}"))
+    if(MSVC_C_COMPILER)
+        set(opt_flags "/O3" "/O2")
+    else()
+        set(opt_flags "-O3" "-O2")
+    endif()
+    set(prev_opt_flags "${WT_OPTIMIZE_FLAGS_SAVED}")
+    separate_arguments(prev_opt_flags)
+    list(APPEND opt_flags ${prev_opt_flags})
+
+    set(new_opt_flags "${CC_OPTIMIZE_LEVEL}")
+    separate_arguments(new_opt_flags)
+
+    foreach(lang C CXX)
+        foreach(build_type RELEASE RELWITHDEBINFO)
+            replace_compile_options(CMAKE_${lang}_FLAGS_${build_type}
+                REMOVE ${opt_flags}
+                ADD ${new_opt_flags})
+        endforeach()
+    endforeach()
+
+    if(GNU_C_COMPILER OR GNU_CXX_COMPILER)
+        foreach(lang C CXX)
+            add_cmake_flag(CMAKE_${lang}_FLAGS -fno-strict-aliasing)
+        endforeach()
+    endif()
+
+    # Mark that we've set the initial optimize flags
+    set(WT_OPTIMIZE_FLAGS_SAVED "${CC_OPTIMIZE_LEVEL}" CACHE INTERNAL
+        "WiredTiger optimize flags have been initialized")
 endif()
 
 # Ref tracking is always enabled in diagnostic build.

--- a/cmake/configs/modes.cmake
+++ b/cmake/configs/modes.cmake
@@ -203,26 +203,3 @@ if(CMAKE_BUILD_TYPE)
 endif()
 
 set(CMAKE_CONFIGURATION_TYPES ${BUILD_MODES})
-
-# We want to use the optimization level from CC_OPTIMIZE_LEVEL and our DEBUG settings as well.
-if(MSVC_C_COMPILER)
-    set(opt_flags "/O3" "/O2")
-else()
-    set(opt_flags "-O3" "-O2")
-    set(debug_flags "-g")
-endif()
-
-foreach(lang C CXX)
-    replace_compile_options(CMAKE_${lang}_FLAGS_RELEASE
-        REMOVE ${opt_flags}
-        ADD ${CC_OPTIMIZE_LEVEL})
-    replace_compile_options(CMAKE_${lang}_FLAGS_RELWITHDEBINFO
-        REMOVE ${opt_flags} ${debug_flags}
-        ADD ${CC_OPTIMIZE_LEVEL})
-endforeach()
-
-if(GNU_C_COMPILER OR GNU_CXX_COMPILER)
-    foreach(lang C CXX)
-        add_cmake_flag(CMAKE_${lang}_FLAGS -fno-strict-aliasing)
-    endforeach()
-endif()

--- a/cmake/helpers.cmake
+++ b/cmake/helpers.cmake
@@ -709,8 +709,11 @@ function(replace_compile_options flag_var)
 
     # Remove existing flags
     foreach(flag ${REPLACE_REMOVE})
-        string(REPLACE "${flag}" "" ${flag_var} ${${flag_var}})
+        string(REPLACE " ${flag} " "" ${flag_var} " ${${flag_var}} ")
     endforeach()
+
+    # Clean up extra spaces
+    string(STRIP "${${flag_var}}" ${flag_var})
 
     # Add custom flags if provided
     foreach(flag ${REPLACE_ADD})
@@ -719,5 +722,6 @@ function(replace_compile_options flag_var)
 
     # Clean up extra spaces
     string(STRIP "${${flag_var}}" ${flag_var})
+
     set(${flag_var} "${${flag_var}}" CACHE STRING "" FORCE)
 endfunction()

--- a/cmake/helpers.cmake
+++ b/cmake/helpers.cmake
@@ -592,6 +592,8 @@ endfunction()
 # add_cmake_flag(dest_var flag)
 # A helper function that adds a CMake flag to a list of included flags if it's not already present.
 function(add_cmake_flag included_flags flag)
+    # Add extra spaces to ensure we only match whole flags.
+    # This avoids partial matches and ensures correct match at the start/end of the string.
     string(FIND " ${${included_flags}} " " ${flag} " flag_position)
     if(flag_position EQUAL -1)
         set(${included_flags} "${${included_flags}} ${flag}" CACHE STRING "" FORCE)
@@ -709,6 +711,8 @@ function(replace_compile_options flag_var)
 
     # Remove existing flags
     foreach(flag ${REPLACE_REMOVE})
+        # Add extra spaces to ensure we only match whole flags.
+        # This avoids partial matches and ensures correct match at the start/end of the string.
         string(REPLACE " ${flag} " "" ${flag_var} " ${${flag_var}} ")
     endforeach()
 


### PR DESCRIPTION
- Fix: missing optimisation flags for `Release`|`RelWithDebInfo` build types
- Optimisation flags were defined after they have been used.