### PR TITLE
WT-15627 Enable output of compile commands during generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.21)
 
 project(WiredTiger C CXX ASM)
 
+# Generate a compile_commands.json file containing the exact compiler calls for
+# all translation units of the project in machine-readable form.
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # Import our available build types prior to initializing the
 # project.
 include(cmake/configs/modes.cmake)

--- a/tools/io-trace-explorer/CMakeLists.txt
+++ b/tools/io-trace-explorer/CMakeLists.txt
@@ -5,8 +5,6 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE RelWithDebInfo)
 endif()
 
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-
 if (NOT VCPKG_TOOLCHAIN)
   find_package(PkgConfig)
   pkg_check_modules(GTKMM gtkmm-4.0)


### PR DESCRIPTION
Enable output of compile commands during generation.

When this option is enabled, CMake generates a compile_commands.json file containing the exact compiler calls for all translation units of the project in machine-readable form.
This helps VSCode with code navigation, and allows developers to examine actual compiler flags to be used during build.