### PR TITLE
WT-15488 test_verify.py fails with mismatch in page IDs from PALM and btree walk

### DIFF
--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1408,7 +1408,7 @@ __verify_page_discard(WT_SESSION_IMPL *session, WT_BM *bm)
 {
     WT_REF *ref = NULL;
     uint64_t num_pages_found_in_btree = 0;
-    size_t capacity = 0;
+    size_t capacity_in_bytes = 0;
     uint64_t *page_ids = NULL;
     int ret = 0;
 
@@ -1424,9 +1424,9 @@ __verify_page_discard(WT_SESSION_IMPL *session, WT_BM *bm)
          * Use dynamically allocated array to track page IDs as we don't know the number of pages
          *  here. Check if the array size needs to grow.
          */
-        if (num_pages_found_in_btree == (capacity / sizeof(uint64_t))) {
+        if (num_pages_found_in_btree == (capacity_in_bytes / sizeof(uint64_t))) {
             uint64_t new_capacity_count = num_pages_found_in_btree * 2 + 1;
-            WT_RET(__wt_realloc_def(session, &capacity, new_capacity_count, &page_ids));
+            WT_RET(__wt_realloc_def(session, &capacity_in_bytes, new_capacity_count, &page_ids));
         }
 
         if (page != NULL) {

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1424,7 +1424,7 @@ __verify_page_discard(WT_SESSION_IMPL *session, WT_BM *bm)
          * Use dynamically allocated array to track page IDs as we don't know the number of pages
          *  here. Check if the array size needs to grow.
          */
-        if (num_pages_found_in_btree == (capacity_in_bytes / sizeof(uint64_t))) {
+        if (num_pages_found_in_btree == (capacity_in_bytes / sizeof(*page_ids))) {
             uint64_t new_capacity_count = num_pages_found_in_btree * 2 + 1;
             WT_RET(__wt_realloc_def(session, &capacity_in_bytes, new_capacity_count, &page_ids));
         }

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1425,7 +1425,7 @@ __verify_page_discard(WT_SESSION_IMPL *session, WT_BM *bm)
          *  here. Check if the array size needs to grow.
          */
         if (num_pages_found_in_btree == (capacity_in_bytes / sizeof(*page_ids))) {
-            uint64_t new_capacity_count = num_pages_found_in_btree * 2 + 1;
+            uint64_t new_capacity_count = num_pages_found_in_btree * 2 + 10;
             WT_RET(__wt_realloc_def(session, &capacity_in_bytes, new_capacity_count, &page_ids));
         }
 

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1424,10 +1424,9 @@ __verify_page_discard(WT_SESSION_IMPL *session, WT_BM *bm)
          * Use dynamically allocated array to track page IDs as we don't know the number of pages
          *  here. Check if the array size needs to grow.
          */
-        if (num_pages_found_in_btree == capacity) {
-            uint64_t new_capacity = (capacity * 2 + 1) * sizeof(uint64_t);
-            WT_RET(__wt_realloc_def(session, &capacity, new_capacity, &page_ids));
-            capacity = new_capacity;
+        if (num_pages_found_in_btree == (capacity / sizeof(uint64_t))) {
+            uint64_t new_capacity_count = num_pages_found_in_btree * 2 + 1;
+            WT_RET(__wt_realloc_def(session, &capacity, new_capacity_count, &page_ids));
         }
 
         if (page != NULL) {


### PR DESCRIPTION
The memory allocation for the page_id was incorrect before. With the macro __wt_realloc_def, the capacity it takes in is in bytes, and the new capacity is the increment of array size. With the previous comparison, capacity would be 8 and we never correctly allocate memory for the array before index 8 due to this check. Therefore we need to compare `(capacity_in_bytes / sizeof(uint64_t))` instead with `num_pages_found_in_btree`, so they would both be number of items tracked/allocated, instead of bytes of memory. 