### PR TITLE
WT-15636 WT_PAGE_LOG::pl_get_complete_checkpoint_ext swallows WT_NOTFOUND

### DIFF
--- a/ext/page_log/palite/palite.cpp
+++ b/ext/page_log/palite/palite.cpp
@@ -1502,7 +1502,7 @@ public:
             memset(checkpoint_metadata, 0, sizeof(WT_ITEM));
 
         Storage::Transaction txn = storage.begin_transaction();
-        storage.get_last_checkpoint(
+        int ret = storage.get_last_checkpoint(
           txn.conn, checkpoint_lsn, checkpoint_timestamp, checkpoint_metadata);
         storage.commit_transaction(txn);
 
@@ -1512,7 +1512,7 @@ public:
           checkpoint_metadata ? checkpoint_metadata->size : 0,
           palite_verbose_item(checkpoint_metadata));
 
-        return 0;
+        return ret;
     }
 
     int

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -50,7 +50,7 @@ __layered_get_disagg_checkpoint(WT_SESSION_IMPL *session, const char **cfg,
 
     ret = page_log->pl_get_complete_checkpoint_ext(page_log, &session->iface,
       complete_checkpoint_lsn, NULL, complete_checkpoint_timestamp, complete_checkpoint_metadata);
-    WT_RET_NOTFOUND_OK(ret);
+    WT_ERR_NOTFOUND_OK(ret, true);
 
 err:
     if (page_log != NULL)

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -50,7 +50,7 @@ __layered_get_disagg_checkpoint(WT_SESSION_IMPL *session, const char **cfg,
 
     ret = page_log->pl_get_complete_checkpoint_ext(page_log, &session->iface,
       complete_checkpoint_lsn, NULL, complete_checkpoint_timestamp, complete_checkpoint_metadata);
-    WT_ERR_NOTFOUND_OK(ret, true);
+    WT_RET_NOTFOUND_OK(ret);
 
 err:
     if (page_log != NULL)

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -48,8 +48,9 @@ __layered_get_disagg_checkpoint(WT_SESSION_IMPL *session, const char **cfg,
     if (page_log->pl_get_complete_checkpoint_ext == NULL)
         WT_ERR(ENOTSUP);
 
-    WT_ERR(page_log->pl_get_complete_checkpoint_ext(page_log, &session->iface,
-      complete_checkpoint_lsn, NULL, complete_checkpoint_timestamp, complete_checkpoint_metadata));
+    ret = page_log->pl_get_complete_checkpoint_ext(page_log, &session->iface,
+      complete_checkpoint_lsn, NULL, complete_checkpoint_timestamp, complete_checkpoint_metadata);
+    WT_ERR_NOTFOUND_OK(ret, true);
 
 err:
     if (page_log != NULL)

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -53,7 +53,7 @@ __layered_get_disagg_checkpoint(WT_SESSION_IMPL *session, const char **cfg,
     WT_ERR_NOTFOUND_OK(ret, true);
 
 err:
-    if (page_log != NULL)
+    if (ret != 0 && ret != WT_NOTFOUND && page_log != NULL)
         WT_TRET(page_log->terminate(page_log, &session->iface)); /* dereference */
     __wt_free(session, page_log_name);
     return (ret);


### PR DESCRIPTION
- Propagate WT_NOTFOUND when looking for the last opened checkpoint