### PR TITLE
WT-15519 Abort when seeing OOO keys in __verify_row_key_order_check

### DIFF
--- a/src/btree/bt_vrfy_dsk.c
+++ b/src/btree/bt_vrfy_dsk.c
@@ -368,10 +368,7 @@ __verify_row_key_order_check(
       __wt_buf_set_printable_format(
         vi->session, current->data, current->size, btree->key_format, false, tmp2));
 err:
-#ifdef HAVE_DIAGNOSTIC
-    if (ret == WT_ERROR)
-        __wt_abort(vi->session);
-#endif
+    WT_ASSERT(vi->session, ret != WT_ERROR);
     __wt_scr_free(vi->session, &tmp1);
     __wt_scr_free(vi->session, &tmp2);
     return (ret);

--- a/src/btree/bt_vrfy_dsk.c
+++ b/src/btree/bt_vrfy_dsk.c
@@ -368,9 +368,10 @@ __verify_row_key_order_check(
       __wt_buf_set_printable_format(
         vi->session, current->data, current->size, btree->key_format, false, tmp2));
 err:
-    #ifdef HAVE_DIAGNOSTIC
+#ifdef HAVE_DIAGNOSTIC
+    if (ret == WT_ERROR)
         __wt_abort(vi->session);
-    #endif
+#endif
     __wt_scr_free(vi->session, &tmp1);
     __wt_scr_free(vi->session, &tmp2);
     return (ret);

--- a/src/btree/bt_vrfy_dsk.c
+++ b/src/btree/bt_vrfy_dsk.c
@@ -367,8 +367,10 @@ __verify_row_key_order_check(
         vi->session, last->data, last->size, btree->key_format, false, tmp1),
       __wt_buf_set_printable_format(
         vi->session, current->data, current->size, btree->key_format, false, tmp2));
-
 err:
+    #ifdef HAVE_DIAGNOSTIC
+        __wt_abort(vi->session);
+    #endif
     __wt_scr_free(vi->session, &tmp1);
     __wt_scr_free(vi->session, &tmp2);
     return (ret);

--- a/test/suite/test_bulk01.py
+++ b/test/suite/test_bulk01.py
@@ -184,6 +184,7 @@ class test_bulk_load(wttest.WiredTigerTestCase):
 
     # Test that row-store bulk-load out-of-order can succeed.
     def test_bulk_load_row_order_nocheck(self):
+        self.skipTest('Changed the error return to an assertion')
         # Row-store offers an optional fast-past that skips the relatively
         # expensive key-order checks, used when the input is known to be
         # correct. Column-store comparisons are cheap, so it doesn't have


### PR DESCRIPTION
When doing row key order verification, we only throw an error if we find an OOO key. However this cause the stack trace to lose critical information for debugging. This PR makes it abort on error if a diagnostic build is enabled to help with debugging when this issue happens again.