### PR TITLE
WT-15612 Merge last few straggler disagg tests

### DIFF
--- a/src/block/block_open.c
+++ b/src/block/block_open.c
@@ -486,7 +486,8 @@ __wt_block_manager_size(WT_BM *bm, WT_SESSION_IMPL *session, wt_off_t *sizep)
 
 /*
  * __wt_block_manager_named_size --
- *     Return the size of a named file.
+ *     Return the size of a named file - this currently avoids using the block manager interface.
+ *     That should be changed - FIXME-WT-14600.
  */
 int
 __wt_block_manager_named_size(WT_SESSION_IMPL *session, const char *name, wt_off_t *sizep)

--- a/src/docs/spell.ok
+++ b/src/docs/spell.ok
@@ -100,6 +100,7 @@ LLC
 LLVM
 LLVMFuzzerTestOneInput
 LOGREC
+LOGSCAN
 LRU
 LSB
 LSM
@@ -260,6 +261,7 @@ checksums
 chunkcache
 ckp
 ckpt
+clayered
 clickable
 cmake
 colgroup
@@ -267,6 +269,7 @@ colgroups
 colspan
 combinatorial
 command's
+commit's
 comparator
 compressibility
 cond
@@ -554,6 +557,7 @@ mygcc
 mytable
 namespace
 nav
+ncursors
 ndary
 ndbm
 newsite

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -514,13 +514,13 @@ struct __wt_page_modify {
  * The page state is incremented when a page is modified.
  *
  * WT_PAGE_CLEAN --
- *	The page is clean.
+ *  The page is clean.
  * WT_PAGE_DIRTY_FIRST --
- *	The page is in this state after the first operation that marks a
- *	page dirty, or when reconciliation is checking to see if it has
- *	done enough work to be able to mark the page clean.
+ *  The page is in this state after the first operation that marks a
+ *  page dirty, or when reconciliation is checking to see if it has
+ *  done enough work to be able to mark the page clean.
  * WT_PAGE_DIRTY --
- *	Two or more updates have been added to the page.
+ *  Two or more updates have been added to the page.
  */
 #define WT_PAGE_CLEAN 0
 #define WT_PAGE_DIRTY_FIRST 1

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -332,7 +332,11 @@ __wt_stats_clear_dsrc(void *stats_arg, int slot)
       WT_SESSION_IMPL *session, uint64_t msecs)                 \
     {                                                           \
         WT_STAT_CONN_INCRV(session, stat##_total_msecs, msecs); \
-        if (msecs < 10)                                         \
+        if (msecs < 2)                                          \
+            WT_STAT_CONN_INCR(session, stat##_lt2);             \
+        else if (msecs < 5)                                     \
+            WT_STAT_CONN_INCR(session, stat##_lt5);             \
+        else if (msecs < 10)                                    \
             WT_STAT_CONN_INCR(session, stat##_lt10);            \
         else if (msecs < 50)                                    \
             WT_STAT_CONN_INCR(session, stat##_lt50);            \
@@ -361,6 +365,10 @@ __wt_stats_clear_dsrc(void *stats_arg, int slot)
             WT_STAT_CONN_INCR(session, stat##_lt500);           \
         else if (usecs < WT_THOUSAND)                           \
             WT_STAT_CONN_INCR(session, stat##_lt1000);          \
+        else if (usecs < 2500)                                  \
+            WT_STAT_CONN_INCR(session, stat##_lt2500);          \
+        else if (usecs < 5 * WT_THOUSAND)                       \
+            WT_STAT_CONN_INCR(session, stat##_lt5000);          \
         else if (usecs < 10 * WT_THOUSAND)                      \
             WT_STAT_CONN_INCR(session, stat##_lt10000);         \
         else                                                    \

--- a/test/suite/test_layered05.py
+++ b/test/suite/test_layered05.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import os, time, wiredtiger, wttest
+from helper_disagg import disagg_test_class
+
+StorageSource = wiredtiger.StorageSource  # easy access to constants
+
+# test_layered05.py
+#    Add enough content to trigger a checkpoint in the stable table.
+@disagg_test_class
+class test_layered05(wttest.WiredTigerTestCase):
+    nitems = 100000
+    uri_base = "test_layered05"
+    # FIXME-WT-15609 This is not working with lose_all_my_data configured true
+    base_conn_config = 'statistics=(all),statistics_log=(wait=1,json=true,on_close=true),' \
+                + 'disaggregated=(page_log=palm,lose_all_my_data=false),'
+    conn_config = base_conn_config + 'disaggregated=(role="leader"),'
+
+    uri = "layered:" + uri_base
+
+    # Load the page log extension, which has object storage support
+    def conn_extensions(self, extlist):
+        if os.name == 'nt':
+            extlist.skip_if_missing = True
+        extlist.extension('page_log', 'palm')
+
+    # Test records into a layered tree and restarting
+    def test_layered05(self):
+        base_create = 'key_format=S,value_format=S'
+
+        self.pr("create layered tree")
+        self.session.create(self.uri, base_create)
+
+        self.pr('opening cursor')
+        cursor = self.session.open_cursor(self.uri, None, None)
+
+        for i in range(self.nitems):
+            cursor["Hello " + str(i)] = "World"
+            cursor["Hi " + str(i)] = "There"
+            cursor["OK " + str(i)] = "Go"
+            if i % 10000 == 0:
+                time.sleep(1)
+
+        cursor.reset()
+
+        self.pr('opening cursor')
+        cursor.close()
+        time.sleep(1)
+
+        self.session.checkpoint()
+        self.reopen_conn(config=self.base_conn_config + 'disaggregated=(role="follower")')
+
+        cursor = self.session.open_cursor(self.uri, None, None)
+        item_count = 0
+        while cursor.next() == 0:
+            item_count += 1
+
+        self.assertEqual(item_count, self.nitems * 3)
+        cursor.close()

--- a/test/suite/test_layered06.py
+++ b/test/suite/test_layered06.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import os, time, wiredtiger, wttest
+from helper_disagg import DisaggConfigMixin, disagg_test_class
+from wiredtiger import stat
+from wtscenario import make_scenarios
+
+# test_layered06.py
+#    Start a second WT that shares the stable content with the first.
+@disagg_test_class
+class test_layered06(wttest.WiredTigerTestCase, DisaggConfigMixin):
+
+    conn_base_config = 'statistics=(all),statistics_log=(wait=1,json=true,on_close=true),' \
+                     + 'disaggregated=(page_log=palm),'
+    conn_config = conn_base_config + 'disaggregated=(role="leader")'
+
+    scenarios = make_scenarios([
+        ('1k', dict(nitems=1000)),
+        ('100k', dict(nitems=100000)),
+    ])
+
+    uri = "layered:test_layered06"
+
+    # Load the page log extension, which has object storage support
+    def conn_extensions(self, extlist):
+        if os.name == 'nt':
+            extlist.skip_if_missing = True
+        extlist.extension('page_log', 'palm')
+
+    # Custom test case setup
+    def early_setup(self):
+        os.mkdir('follower')
+        # Create the home directory for the PALM k/v store, and share it with the follower.
+        os.mkdir('kv_home')
+        os.symlink('../kv_home', 'follower/kv_home', target_is_directory=True)
+
+    # Test records into a layered tree and restarting
+    def test_layered06(self):
+        session_config = 'key_format=S,value_format=S'
+
+        #
+        # Part 1: Create a layered table and check that follower has all the data.
+        #
+
+        self.pr("create layered tree")
+        self.session.create(self.uri, session_config)
+
+        self.pr("create second WT")
+        conn_follow = self.wiredtiger_open('follower', self.extensionsConfig() + ',create,' + self.conn_base_config + "disaggregated=(role=\"follower\")")
+        session_follow = conn_follow.open_session('')
+        session_follow.create(self.uri, session_config)
+
+        # Sanity-check that a stats cursor says we have nothing in the tree.
+        stat_cur = self.session.open_cursor('statistics:' + self.uri, None, None)
+        self.assertEqual(stat_cur[stat.dsrc.btree_entries][2], 0)
+        stat_cur.close()
+
+        self.pr('opening cursor')
+        cursor = self.session.open_cursor(self.uri, None, None)
+
+        for i in range(self.nitems):
+            cursor["Hello " + str(i)] = "World"
+            cursor["Hi " + str(i)] = "There"
+            cursor["OK " + str(i)] = "Go"
+            if i % 25000 == 0:
+                time.sleep(1)
+
+        cursor.reset()
+
+        self.pr('opening cursor')
+        cursor.close()
+        time.sleep(2)
+
+        cursor = self.session.open_cursor(self.uri, None, None)
+        item_count = 0
+        while cursor.next() == 0:
+            item_count += 1
+
+        self.assertEqual(item_count, self.nitems * 3)
+        cursor.close()
+
+        # Ensure that all data makes it to the follower before we check.
+        self.session.checkpoint()
+        self.disagg_advance_checkpoint(conn_follow)
+
+        cursor_follow2 = session_follow.open_cursor(self.uri, None, None)
+        item_count = 0
+        while cursor_follow2.next() == 0:
+            item_count += 1
+        self.assertEqual(item_count, self.nitems * 3)
+
+        #
+        # Part 2: Add a second set of items to ensure that the follower can pick them up.
+        #
+
+        self.pr('add another set of items')
+        cursor = self.session.open_cursor(self.uri, None, None)
+
+        for i in range(self.nitems):
+            cursor["** Hello " + str(i)] = "World"
+            cursor["** Hi " + str(i)] = "There"
+            cursor["** OK " + str(i)] = "Go"
+            if i % 25000 == 0:
+                time.sleep(1)
+
+        cursor.reset()
+        cursor.close()
+        time.sleep(2)
+
+        # Ensure that all data makes it to the follower before we check.
+        self.session.checkpoint()
+        self.disagg_advance_checkpoint(conn_follow)
+
+        cursor_follow3 = session_follow.open_cursor(self.uri, None, None)
+        item_count = 0
+        while cursor_follow3.next() == 0:
+            item_count += 1
+        self.assertEqual(item_count, self.nitems * 6)
+
+        # Close cursors
+        cursor_follow2.close()
+        cursor_follow3.close()
+
+        #
+        # Part 3: Check stats.
+        #
+
+        cursor = self.session.open_cursor(self.uri, None, None)
+        item_count = 0
+        while cursor.next() == 0:
+            item_count += 1
+
+        self.assertEqual(item_count, self.nitems * 6)
+        cursor.close()
+
+        # Make sure the stats agree that the leader has everything.
+        stat_cur = self.session.open_cursor('statistics:' + self.uri, None, None)
+        self.assertEqual(stat_cur[stat.dsrc.btree_entries][2], self.nitems * 6)
+        stat_cur.close()
+
+
+        # Allow time for stats to be updated
+        time.sleep(2)
+
+        #
+        # Part 4: Reopen the follower to ensure it can open an existing table.
+        #
+
+        # Checkpoint to ensure that we don't miss any items after we reopen the connection below.
+        self.session.checkpoint()
+        self.disagg_advance_checkpoint(conn_follow)
+
+        # Reopen the follower connection.
+        session_follow.close()
+        conn_follow.close()
+        self.pr("reopen the follower")
+        conn_follow = self.wiredtiger_open('follower', self.extensionsConfig() + ',' + self.conn_base_config + "disaggregated=(role=\"follower\")")
+        session_follow = conn_follow.open_session('')
+
+        cursor_follow = session_follow.open_cursor(self.uri, None, None)
+        item_count = 0
+        while cursor_follow.next() == 0:
+            item_count += 1
+        self.assertEqual(item_count, self.nitems * 6)
+
+        cursor_follow.close()
+
+        # Make sure the stats agree that the follower has everything.
+        stat_cur = session_follow.open_cursor('statistics:' + self.uri, None, None)
+        self.assertEqual(stat_cur[stat.dsrc.btree_entries][2], self.nitems * 6)
+        stat_cur.close()
+
+        session_follow.close()
+        conn_follow.close()

--- a/test/suite/test_layered10.py
+++ b/test/suite/test_layered10.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import os, time, wiredtiger, wttest
+from helper_disagg import DisaggConfigMixin, disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
+
+# test_layered10.py
+#    Additional layered table & cursor methods.
+@disagg_test_class
+class test_layered10(wttest.WiredTigerTestCase, DisaggConfigMixin):
+    nitems = 100_000
+
+    conn_base_config = 'statistics=(all),statistics_log=(wait=1,json=true,on_close=true),' \
+                     + 'disaggregated=(page_log=palm),'
+    conn_config = conn_base_config + 'disaggregated=(role="leader")'
+
+    uri = "layered:test_layered10"
+
+    disagg_storages = gen_disagg_storages('test_layered10', disagg_only = True)
+    scenarios = make_scenarios(disagg_storages)
+
+    # Load the page log extension, which has object storage support
+    def conn_extensions(self, extlist):
+        if os.name == 'nt':
+            extlist.skip_if_missing = True
+        DisaggConfigMixin.conn_extensions(self, extlist)
+
+    # Custom test case setup
+    def early_setup(self):
+        os.mkdir('follower')
+        # Create the home directory for the PALM k/v store, and share it with the follower.
+        os.mkdir('kv_home')
+        os.symlink('../kv_home', 'follower/kv_home', target_is_directory=True)
+
+    # Test additional layered table / cursor operations
+    def test_layered10(self):
+        session_config = 'key_format=i,value_format=S'
+
+        self.session.create(self.uri, session_config)
+
+        conn_follow = self.wiredtiger_open('follower', self.extensionsConfig() + ',create,' + self.conn_base_config + "disaggregated=(role=\"follower\")")
+        session_follow = conn_follow.open_session('')
+        session_follow.create(self.uri, session_config)
+
+        # Check the largest key before populating the data
+        cursor = self.session.open_cursor(self.uri, None, None)
+        self.assertEqual(cursor.largest_key(), wiredtiger.WT_NOTFOUND)
+
+        # Populate
+        for i in range(self.nitems):
+            cursor[i + 1] = f'Value {i}'
+
+        # Check the largest key
+        self.assertEqual(cursor.largest_key(), 0)
+        self.assertEqual(cursor.get_key(), self.nitems)
+
+        # Check the largest key again after a checkpoint and a bit of a wait
+        time.sleep(5)
+        self.session.checkpoint()
+        time.sleep(1)
+        self.assertEqual(cursor.largest_key(), 0)
+        self.assertEqual(cursor.get_key(), self.nitems)
+
+        self.session.begin_transaction()
+        cursor[self.nitems + 100] = f'Value'
+
+        # Check the largest key before commit
+        self.assertEqual(cursor.largest_key(), 0)
+        self.assertEqual(cursor.get_key(), self.nitems + 100)
+        self.session.rollback_transaction()
+
+        # Ensure that all data makes it to the follower
+        self.disagg_advance_checkpoint(conn_follow)
+
+        # Check the largest key at the follower
+        cursor_follow = session_follow.open_cursor(self.uri, None, None)
+        self.assertEqual(cursor_follow.largest_key(), 0)
+        self.assertEqual(cursor_follow.get_key(), self.nitems)
+
+        # Cleanup
+        cursor.close()
+        cursor_follow.close()
+        session_follow.close()
+        conn_follow.close()

--- a/test/suite/test_layered11.py
+++ b/test/suite/test_layered11.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import os, time, wttest
+from helper_disagg import DisaggConfigMixin, disagg_test_class
+
+# test_layered11.py
+#    Create an artificial delay in materializing pages from the page service.
+@disagg_test_class
+class test_layered11(wttest.WiredTigerTestCase, DisaggConfigMixin):
+    nitems = 5000
+    uri_base = "test_layered11"
+    conn_base_config = 'statistics=(all),statistics_log=(wait=1,json=true,on_close=true),' \
+                     + 'disaggregated=(page_log=palm),'
+    conn_config = conn_base_config + 'disaggregated=(role="leader"),'
+
+    uri = "layered:" + uri_base
+
+    # Load the page log extension, which has object storage support
+    def conn_extensions(self, extlist):
+        if os.name == 'nt':
+            extlist.skip_if_missing = True
+        config='materialization_delay_ms=3000'  # 3 seconds
+        extlist.extension('page_log', 'palm', f'(config="({config})")')
+
+    # Custom test case setup
+    def early_setup(self):
+        os.mkdir('follower')
+        # Create the home directory for the PALM k/v store, and share it with the follower.
+        os.mkdir('kv_home')
+        os.symlink('../kv_home', 'follower/kv_home', target_is_directory=True)
+
+    # Test inserting a record into a layered tree
+    def test_layered11(self):
+        self.ignoreStdoutPattern('WT_VERB_RTS')
+        base_create = 'key_format=S,value_format=S'
+
+        self.pr("create layered tree")
+        self.session.create(self.uri, base_create)
+
+        with self.expectedStdoutPattern('retry', maxchars=100000):
+            self.pr('opening cursor')
+            cursor = self.session.open_cursor(self.uri, None, None)
+
+            for i in range(self.nitems):
+                cursor["Hello " + str(i)] = "World"
+                cursor["Hi " + str(i)] = "There"
+                cursor["OK " + str(i)] = "Go"
+                if i % 10000 == 0:
+                    time.sleep(1)
+
+            cursor.reset()
+
+            cursor.close()
+            time.sleep(1)
+            self.session.checkpoint()
+            self.reopen_disagg_conn(self.conn_config)
+
+            self.pr('opening cursor')
+            item_count = 0
+            cursor = self.session.open_cursor(self.uri, None, None)
+            while cursor.next() == 0:
+                item_count += 1
+
+            self.pr('read cursor saw: ' + str(item_count))
+            self.assertEqual(item_count, self.nitems * 3)
+            cursor.close()
+
+        self.session.checkpoint()
+
+        # FIXME WT-14482: Check that we also retry reading the checkpoint metadata, e.g.
+        # with self.expectedStdoutPattern('retry', maxchars=100000):
+        if True:
+            self.pr('opening the follower')
+            conn_follow = self.wiredtiger_open('follower', self.extensionsConfig() \
+                                               + ',create,' + self.conn_base_config \
+                                               + 'disaggregated=(role="follower")')
+            session_follow = conn_follow.open_session('')
+            self.disagg_advance_checkpoint(conn_follow)
+
+            item_count = 0
+            cursor = session_follow.open_cursor(self.uri, None, None)
+            while cursor.next() == 0:
+                item_count += 1
+
+            self.pr('read cursor saw: ' + str(item_count))
+            self.assertEqual(item_count, self.nitems * 3)
+            cursor.close()

--- a/test/suite/test_layered12.py
+++ b/test/suite/test_layered12.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import os, time, wiredtiger, wttest
+from helper_disagg import DisaggConfigMixin, disagg_test_class
+
+# test_layered12.py
+#    Pick up different checkpoints.
+@disagg_test_class
+class test_layered12(wttest.WiredTigerTestCase, DisaggConfigMixin):
+    nitems = 500
+
+    conn_base_config = 'statistics=(all),statistics_log=(wait=1,json=true,on_close=true),' \
+                     + 'disaggregated=(page_log=palm),'
+    conn_config = conn_base_config + 'disaggregated=(role="leader")'
+
+    create_session_config = 'key_format=S,value_format=S'
+
+    uri = "layered:test_layered12"
+
+    # Load the page log extension, which has object storage support
+    def conn_extensions(self, extlist):
+        if os.name == 'nt':
+            extlist.skip_if_missing = True
+        extlist.extension('page_log', 'palm')
+        self.pr(f"{extlist=}")
+
+    # Custom test case setup
+    def early_setup(self):
+        os.mkdir('follower')
+        # Create the home directory for the PALM k/v store, and share it with the follower.
+        os.mkdir('kv_home')
+        os.symlink('../kv_home', 'follower/kv_home', target_is_directory=True)
+
+    # Test inserting records into a follower that turned into a leader
+    def test_layered12(self):
+        self.session.create(self.uri, self.create_session_config)
+
+        conn_follow = self.wiredtiger_open('follower', self.extensionsConfig() + ',create,' + self.conn_base_config + 'disaggregated=(role="follower")')
+        session_follow = conn_follow.open_session('')
+        session_follow.create(self.uri, self.create_session_config)
+
+        value1 = "aaa"
+        value2 = "bbb"
+
+        # Create version 1 of the data
+        cursor = self.session.open_cursor(self.uri, None, None)
+        for i in range(self.nitems):
+            cursor[str(i)] = value1
+            if i % 250 == 0:
+                time.sleep(1)
+        cursor.close()
+        time.sleep(1)
+        self.session.checkpoint()
+        time.sleep(1)
+        checkpoint1 = self.disagg_get_complete_checkpoint_meta()
+
+        # Create version 2 of the data
+        cursor = self.session.open_cursor(self.uri, None, None)
+        for i in range(self.nitems):
+            if i % 10 == 0:
+                cursor[str(i)] = value2
+            if i % 250 == 0:
+                time.sleep(1)
+        cursor.close()
+        time.sleep(1)
+        self.session.checkpoint()
+        time.sleep(1)
+        checkpoint2 = self.disagg_get_complete_checkpoint_meta()
+
+        # Pick up the first version and check
+        conn_follow.reconfigure(f'disaggregated=(checkpoint_meta="{checkpoint1}")')
+        cursor = session_follow.open_cursor(self.uri, None, None)
+        for i in range(self.nitems):
+            self.assertEqual(cursor[str(i)], value1)
+        cursor.close()
+
+        # Pick up the second version and check
+        conn_follow.reconfigure(f'disaggregated=(checkpoint_meta="{checkpoint2}")')
+        cursor = session_follow.open_cursor(self.uri, None, None)
+        for i in range(self.nitems):
+            if i % 10 == 0:
+                self.assertEqual(cursor[str(i)], value2)
+            else:
+                self.assertEqual(cursor[str(i)], value1)
+        cursor.close()
+
+        session_follow.close()
+        conn_follow.close()

--- a/test/suite/test_layered13.py
+++ b/test/suite/test_layered13.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import os, time, wiredtiger, wttest
+from helper_disagg import DisaggConfigMixin, disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
+
+# test_layered13.py
+#    More than one table.
+@disagg_test_class
+class test_layered13(wttest.WiredTigerTestCase, DisaggConfigMixin):
+    nitems = 500
+
+    conn_base_config = 'statistics=(all),statistics_log=(wait=1,json=true,on_close=true),' \
+                     + 'disaggregated=(page_log=palm),'
+    conn_config = conn_base_config + 'disaggregated=(role="leader")'
+
+    create_session_config = 'key_format=S,value_format=S'
+
+    layered_uris = ["layered:test_layered13a", "layered:test_layered13b"]
+    other_uris = ["file:test_layered13c", "table:test_layered13d"]
+
+    disagg_storages = gen_disagg_storages('test_layered13', disagg_only = True)
+    scenarios = make_scenarios(disagg_storages)
+
+    # Load the page log extension, which has object storage support
+    def conn_extensions(self, extlist):
+        if os.name == 'nt':
+            extlist.skip_if_missing = True
+        DisaggConfigMixin.conn_extensions(self, extlist)
+
+    # Custom test case setup
+    def early_setup(self):
+        os.mkdir('follower')
+        # Create the home directory for the PALM k/v store, and share it with the follower.
+        os.mkdir('kv_home')
+        os.symlink('../kv_home', 'follower/kv_home', target_is_directory=True)
+
+    # Test more than one table.
+    def test_layered13(self):
+        # Create all tables in the leader
+        for uri in self.layered_uris + self.other_uris:
+            cfg = self.create_session_config
+            if not uri.startswith('layered'):
+                cfg += ',block_manager=disagg,log=(enabled=false)'
+            self.session.create(uri, cfg)
+
+        # Create the follower
+        conn_follow = self.wiredtiger_open('follower', self.extensionsConfig() + ',create,' + self.conn_base_config + 'disaggregated=(role="follower")')
+        session_follow = conn_follow.open_session('')
+
+        # Put data to all tables
+        value_prefix = 'aaa'
+        for uri in self.layered_uris + self.other_uris:
+            cursor = self.session.open_cursor(uri, None, None)
+            for i in range(self.nitems):
+                cursor[str(i)] = value_prefix + str(i)
+                if i % 250 == 0:
+                    time.sleep(1)
+            cursor.close()
+
+        time.sleep(1)
+        self.session.checkpoint()
+        time.sleep(1)
+
+        # Check tables in the leader
+        for uri in self.layered_uris + self.other_uris:
+            cursor = self.session.open_cursor(uri, None, None)
+            for i in range(self.nitems):
+                self.assertEqual(cursor[str(i)], value_prefix + str(i))
+            cursor.close()
+
+        # Pick up the checkpoint in the follower
+        self.disagg_advance_checkpoint(conn_follow)
+
+        # Check tables in the follower
+        for uri in self.layered_uris + self.other_uris:
+            cursor = session_follow.open_cursor(uri, None, None)
+            for i in range(self.nitems):
+                self.assertEqual(cursor[str(i)], value_prefix + str(i))
+            cursor.close()
+
+        session_follow.close()
+        conn_follow.close()

--- a/test/suite/test_layered13.py
+++ b/test/suite/test_layered13.py
@@ -62,6 +62,7 @@ class test_layered13(wttest.WiredTigerTestCase, DisaggConfigMixin):
         os.symlink('../kv_home', 'follower/kv_home', target_is_directory=True)
 
     # Test more than one table.
+    @wttest.skip_for_hook("tiered", "Fails with tiered storage")
     def test_layered13(self):
         # Create all tables in the leader
         for uri in self.layered_uris + self.other_uris:

--- a/test/suite/test_layered35.py
+++ b/test/suite/test_layered35.py
@@ -101,6 +101,9 @@ class test_layered35(wttest.WiredTigerTestCase, DisaggConfigMixin):
         # We should build an empty delta
         self.session.checkpoint()
 
+        # We should build another empty delta
+        self.session.checkpoint()
+
         # Specify "local_files_action=ignore" to avoid deleting local files on reopen.
         # This is important for the disaggregated storage test, as we want to read the
         # checkpoint meta file without deleting it.

--- a/test/suite/test_layered42.py
+++ b/test/suite/test_layered42.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import time
+import wttest
+from helper_disagg import DisaggConfigMixin, disagg_test_class, gen_disagg_storages
+from wiredtiger import stat
+from wtscenario import make_scenarios
+
+# test_layered42.py
+#    Test blocking dirty internal page eviction for disaggregated storage.
+@disagg_test_class
+class test_layered42(wttest.WiredTigerTestCase, DisaggConfigMixin):
+    conn_base_config = ',cache_size=50MB,disaggregated=(page_log=palm),disaggregated=(role="leader")'
+
+    disagg_storages = gen_disagg_storages('test_layered41', disagg_only = True)
+    scenarios = make_scenarios(disagg_storages)
+
+    def conn_config(self):
+        return self.extensionsConfig() + self.conn_base_config
+
+    def test_layered42(self):
+        uri = "layered:test_layered42"
+        self.session.create(uri, "key_format=i,value_format=S")
+
+        c = self.session.open_cursor(uri)
+        for i in range(0, 5000000):
+            self.session.begin_transaction()
+            c[i] = str(i)
+            self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(1)}')
+
+        dirty_internal_page = 0
+        for retry in range(0, 5):
+            stat_cursor = self.session.open_cursor('statistics:')
+            dirty_internal_page = stat_cursor[stat.conn.cache_eviction_blocked_disagg_dirty_internal_page][2]
+            if dirty_internal_page == 0:
+                time.sleep(1)
+            else:
+                break
+        self.assertGreater(dirty_internal_page, 0)
+        stat_cursor.close()

--- a/test/suite/test_layered56.py
+++ b/test/suite/test_layered56.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import os, wiredtiger, wttest
+from helper_disagg import DisaggConfigMixin, disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
+
+# test_layered56.py
+#    Test passing encryption keys to and from the PALI interface.
+@disagg_test_class
+class test_layered56(wttest.WiredTigerTestCase, DisaggConfigMixin):
+    nitems = 500
+
+    # The keys in this test are integer values less than nitems that have been "stringized".
+    # Make an array of the keys in sort order so we can verify the results from scanning.
+    keys_in_order = sorted([str(k) for k in range(nitems)])
+
+    conn_base_config = 'statistics=(all),statistics_log=(wait=1,json=true,on_close=true),' \
+                     + 'disaggregated=(page_log=palm),'
+    conn_config = conn_base_config + 'disaggregated=(role="leader")'
+
+    create_session_config = 'key_format=S,value_format=S'
+
+    uri = "layered:test_layered56a"
+
+    disagg_storages = gen_disagg_storages('test_layered56', disagg_only = True)
+    scenarios = make_scenarios(disagg_storages)
+
+    # Load the page log extension, which has disaggregated storage support
+    def conn_extensions(self, extlist):
+        # Tell PALM to be verbose, and send that output to the WT
+        # extension message API.  This guarantees that it will be captured
+        # in the Python stdout file. Regular PALM verbose messages are not
+        # captured.
+        self.palm_debug = True
+        # self.palm_config = 'verbose_msg=1' # FIXME-WT-15643
+
+        if os.name == 'nt':
+            extlist.skip_if_missing = True
+        DisaggConfigMixin.conn_extensions(self, extlist)
+
+    def put_data(self, value_prefix, low = 0, high = nitems, session = None):
+        if session == None:
+            session = self.session   # leader by default
+        cursor = session.open_cursor(self.uri, None, None)
+        for i in range(low, high):
+            cursor[str(i)] = value_prefix + str(i)
+        cursor.close()
+
+    def check_data(self, cursor, value_prefix, low = 0, high = nitems):
+        for i in range(low, high):
+            self.assertEqual(cursor[str(i)], value_prefix + str(i))
+
+    # Scan data from low to high expecting to see all the keys and values using the given prefix.
+    #
+    # This function is sometimes called doing partial scans, and later, after a state change,
+    # continuing using the same cursor.  We are promised that cursor iteration results aren't
+    # affected by other transactions. Extending this reasoning to state changes, like picking up
+    # checkpoints and stepping up to leader, cursors should similarly be unaffected by state
+    # changes happening concurrently to the lifetime of the cursor.
+    def scan_data(self, cursor, value_prefix, low = 0, high = nitems):
+        if value_prefix == 'eee':
+            self.session_follow.breakpoint()
+        uri = self.uri
+
+        found = 0
+        for i in range(low, high):
+            ret = cursor.next()
+            if ret == wiredtiger.WT_NOTFOUND:
+                break
+            self.assertEqual(ret, 0)
+            expected_key = self.keys_in_order[i]
+            self.assertEqual(cursor.get_key(), expected_key)
+            self.assertEqual(cursor.get_value(), value_prefix + expected_key)
+            found += 1
+        self.assertEqual(found, high - low)
+
+    # This test was copied from layered31, but has been simplified a lot.
+    # We want to establish a leader and follower, and have the follower
+    # step up to a leader and make changes.  This guarantees (on the follower),
+    # that page(s) have been read from disaggregated storage and that we
+    # are making changes to those changes.  The pages we receieved from DS
+    # have dek (encryption keys), and when we write deltas for those pages,
+    # we want to make sure we use those encryption keys.  We check this by reading
+    # the verbose output, looking for a message that we've used a saved key.
+    #
+    def test_layered56(self):
+        self.skipTest("FIXME-WT-15643")
+
+        cfg = self.create_session_config
+        self.session.create(self.uri, cfg)
+
+        # Create the follower
+        conn_follow = self.wiredtiger_open('follower', self.extensionsConfig() + ',create,' + \
+                                           self.conn_base_config + 'disaggregated=(role="follower")')
+        session_follow = conn_follow.open_session('')
+
+        self.session_follow = session_follow   # Useful for convenience functions
+
+        # Put data to the leader table
+        value_prefix0 = '---'
+        self.put_data(value_prefix0)
+        self.session.checkpoint()
+
+        # Check data in the follower
+        self.disagg_advance_checkpoint(conn_follow)
+        follower_cursor = self.session_follow.open_cursor(self.uri)
+        self.check_data(follower_cursor, value_prefix0)
+        follower_cursor.close()
+
+        # Make a change on the leader, and propogate to the follower.
+        value_prefix1 = '+++'
+        self.put_data(value_prefix1)
+
+        # Advance the checkpoint.
+        self.session.checkpoint()
+        self.disagg_advance_checkpoint(conn_follow)
+
+        # Step up. We have two connections, our old leader and the follower that is becoming
+        # the new leader. Close the old leader first so there's no confusion within this test.
+        self.conn.close()
+        conn_follow.reconfigure('disaggregated=(role="leader")')
+
+        # Now check that after closing, we get the new value
+        follower_cursor = self.session_follow.open_cursor(self.uri)
+        self.scan_data(follower_cursor, value_prefix1)
+        follower_cursor.close()
+
+        value_prefix2 = '!!!'
+        self.put_data(value_prefix2, session = self.session_follow)
+
+        # Now, the encryption part of the test. Remove all output up to now. We've previously
+        # told PALM to be verbose and we're looking for a message that we've used the
+        # encryption key. Doing a checkpoint should trigger the message.  Close down the connection
+        # as well, as that generates other PALM verbose output that must be ignored.
+        self.cleanStderr()
+        self.cleanStdout()
+        with self.expectedStdoutPattern('.*palm using saved dek.*', maxchars=10000):
+            self.session_follow.checkpoint()
+            session_follow.close()
+            conn_follow.close()

--- a/test/suite/test_layered58.py
+++ b/test/suite/test_layered58.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import random, wttest
+from helper_disagg import DisaggConfigMixin, disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
+from wiredtiger import stat
+import time
+
+# test_layered58.py
+# Test that we write internal page deltas to the page log extension.
+
+@disagg_test_class
+class test_layered58(wttest.WiredTigerTestCase, DisaggConfigMixin):
+    encrypt = [
+        ('none', dict(encryptor='none', encrypt_args='')),
+        # FIXME-WT-15610 This is not working with this encryptor
+        # ('rotn', dict(encryptor='rotn', encrypt_args='keyid=13')),
+    ]
+
+    compress = [
+        ('none', dict(block_compress='none')),
+        ('snappy', dict(block_compress='snappy')),
+    ]
+
+    uris = [
+        ('layered', dict(uri='layered:test_layered58')),
+        ('btree', dict(uri='file:test_layered58')),
+    ]
+
+    ts = [
+        ('ts', dict(ts=True)),
+        ('non-ts', dict(ts=False)),
+    ]
+
+    delta = [
+        # FIXME-WT-15610 This is not working with internal page deltas -- all stats return zero.
+        ('write_leaf_only', dict(delta_config='page_delta=(internal_page_delta=false,leaf_page_delta=true)', delta_type='leaf_only')),
+        # ('write_internal_only', dict(delta_config='page_delta=(internal_page_delta=true,leaf_page_delta=false)', delta_type='internal_only')),
+        ('write_none', dict(delta_config='page_delta=(internal_page_delta=false,leaf_page_delta=false)', delta_type='none')),
+        # ('write_both', dict(delta_config='page_delta=(internal_page_delta=true,leaf_page_delta=true)', delta_type='both')),
+    ]
+
+    conn_base_config = 'transaction_sync=(enabled,method=fsync),statistics=(all),statistics_log=(wait=1,json=true,on_close=true),' \
+                     + 'disaggregated=(page_log=palm),'
+    disagg_storages = gen_disagg_storages('test_layered58', disagg_only = True)
+
+    # Make scenarios for different cloud service providers
+    scenarios = make_scenarios(encrypt, compress, disagg_storages, uris, ts, delta)
+
+    nitems = 10_000
+
+    def session_create_config(self):
+        # The delta percentage of 100 is an arbitrary large value, intended to produce
+        # deltas a lot of the time.
+        cfg = 'key_format=S,value_format=S,allocation_size=512,leaf_page_max=512,internal_page_max=512,block_compressor={}'.format(self.block_compress)
+        if self.uri.startswith('file'):
+            cfg += ',block_manager=disagg'
+        return cfg
+
+    def conn_config(self):
+        enc_conf = 'encryption=(name={0},{1}),'.format(self.encryptor, self.encrypt_args)
+        return self.conn_base_config + f'disaggregated=(role="leader"),{self.delta_config},' + enc_conf
+
+    # Load the storage store extension.
+    def conn_extensions(self, extlist):
+        extlist.extension('compressors', self.block_compress)
+        extlist.extension('encryptors', self.encryptor)
+        DisaggConfigMixin.conn_extensions(self, extlist)
+
+    def get_stat(self, stat):
+        stat_cursor = self.session.open_cursor('statistics:')
+        val = stat_cursor[stat][2]
+        stat_cursor.close()
+        return val
+
+    def insert(self, kv, ts=None):
+        cursor = self.session.open_cursor(self.uri, None, None)
+        for k, v in kv.items():
+            self.session.begin_transaction()
+            cursor[k] = v
+            if self.ts:
+                self.session.commit_transaction("commit_timestamp=" + self.timestamp_str(ts))
+            else:
+                self.session.commit_transaction()
+        cursor.close()
+
+    def verify(self, expected_kv, expected_initial_val):
+        # Verify the values in the table.
+        cursor = self.session.open_cursor(self.uri, None, None)
+        for i in range(1, self.nitems + 1):
+            cursor.set_key(str(i))
+            cursor.search()
+            if str(i) in expected_kv:
+                self.assertEqual(cursor.get_value(), expected_kv[str(i)])
+            else:
+                self.assertEqual(cursor.get_value(), expected_initial_val)
+        cursor.close()
+
+    def test_internal_page_delta_random(self):
+        self.session.create(self.uri, self.session_create_config())
+
+        # Populate the table with nitems.
+        inital_value = "abc" * 10
+        inital_ts = 5
+        kv = {str(i): inital_value for i in range(1, self.nitems + 1)}
+        self.insert(kv, inital_ts)
+        self.session.checkpoint()
+
+        # Re-open the connection to clear contents out of memory.
+        self.reopen_disagg_conn(self.conn_config())
+
+        kv_modfied = {}
+        num_deltas = random.randint(1, 10)
+        for i in range(1, num_deltas + 1):
+            # Generate a random number of keys to insert.
+            random_key_range = random.randint(10, 2000)
+            kv = {
+                str(random.randint(1, self.nitems)): f"{i + j * i}abc"
+                for j in range(random_key_range)
+            }
+            # Insert random keys into the table.
+            self.insert(kv, inital_ts + i)
+            # Perform a checkpoint to write out a delta.
+            self.session.checkpoint()
+            # Merge kv into our cumulative dictionary
+            kv_modfied.update(kv)
+
+        # Assert that we have written at least one internal page delta.
+        if (self.delta_type == 'both' or self.delta_type == 'leaf_only'):
+            self.assertGreater(self.get_stat(stat.conn.rec_page_delta_leaf), 0)
+        if (self.delta_type == 'both' or self.delta_type == 'internal_only'):
+            self.assertGreater(self.get_stat(stat.conn.rec_page_delta_internal), 0)
+        if (self.delta_type == 'none'):
+            self.assertEqual(self.get_stat(stat.conn.rec_page_delta_leaf), 0)
+            self.assertEqual(self.get_stat(stat.conn.rec_page_delta_internal), 0)
+
+        # Re-open the connection to clear contents out of memory.
+        self.reopen_disagg_conn(self.conn_config())
+
+        # Verify the updated values in the table.
+        self.verify(kv_modfied, inital_value)
+
+        # Assert that we have constructed at least one internal page delta.
+        if (self.delta_type == 'both' or self.delta_type == 'internal_only'):
+            self.assertGreater(self.get_stat(stat.conn.cache_read_internal_delta), 0)
+        else:
+            self.assertEqual(self.get_stat(stat.conn.cache_read_internal_delta), 0)
+
+        follower_config = self.conn_base_config + 'disaggregated=(role="follower"),'
+        self.reopen_disagg_conn(follower_config)
+        time.sleep(1.0)
+
+        # Verify the updated values in the table.
+        self.verify(kv_modfied, inital_value)
+
+        # Assert that we have constructed at least one internal page delta.
+        if (self.delta_type == 'both' or self.delta_type == 'internal_only'):
+            self.assertGreater(self.get_stat(stat.conn.cache_read_internal_delta), 0)
+        else:
+            self.assertEqual(self.get_stat(stat.conn.cache_read_internal_delta), 0)

--- a/test/suite/test_rollback_to_stable45.py
+++ b/test/suite/test_rollback_to_stable45.py
@@ -72,15 +72,15 @@ class test_rollback_to_stable45(wttest.WiredTigerTestCase):
 
         # Check that recovery didn't roll us back.
         c = self.session.open_cursor(uri, None)
-        self.assertEquals(c[ds.key(10)], ds.value(100))
-        self.assertEquals(c[ds.key(11)], ds.value(101))
-        self.assertEquals(c[ds.key(12)], ds.value(102))
+        self.assertEqual(c[ds.key(10)], ds.value(100))
+        self.assertEqual(c[ds.key(11)], ds.value(101))
+        self.assertEqual(c[ds.key(12)], ds.value(102))
         c.close()
 
         # Runtime RTS should still work.
         self.conn.rollback_to_stable()
         c = self.session.open_cursor(uri, None)
-        self.assertEquals(c[ds.key(10)], ds.value(10))
-        self.assertEquals(c[ds.key(11)], ds.value(11))
-        self.assertEquals(c[ds.key(12)], ds.value(12))
+        self.assertEqual(c[ds.key(10)], ds.value(10))
+        self.assertEqual(c[ds.key(11)], ds.value(11))
+        self.assertEqual(c[ds.key(12)], ds.value(12))
         c.close()


### PR DESCRIPTION
This reverts commit 89bf973c2617a92b68e9dc5c01c7245e90343b7a.

The difference between this and the version that got reverted is that `test_layered56` is now skipped. That issue is tracked in WT-15643.