### PR TITLE
WT-15603 Performance regression fix: use optimisation for Debug builds

### DIFF
--- a/cmake/configs/base.cmake
+++ b/cmake/configs/base.cmake
@@ -476,7 +476,7 @@ if(NOT ("${WT_OPTIMIZE_FLAGS_SAVED}" STREQUAL "${CC_OPTIMIZE_LEVEL}"))
     separate_arguments(new_opt_flags)
 
     foreach(lang C CXX)
-        foreach(build_type RELEASE RELWITHDEBINFO)
+        foreach(build_type DEBUG RELEASE RELWITHDEBINFO)
             replace_compile_options(CMAKE_${lang}_FLAGS_${build_type}
                 REMOVE ${opt_flags}
                 ADD ${new_opt_flags})


### PR DESCRIPTION
- Reinstate optimisation flag `-Og` (GCC, CLang) for Debug builds