### PR TITLE
WT-15623 Add --print-output option for run.py

### DIFF
--- a/test/compatibility/suite/compatibility_test.py
+++ b/test/compatibility/suite/compatibility_test.py
@@ -105,6 +105,8 @@ class CompatibilityTestCase(abstract_test_case.AbstractWiredTigerTestCase):
                     return True
                 if k == 'captureout' or k == 'captureerr':
                     return True
+                if k == 'tee_stdout' or k == 'tee_stderr':
+                    return True
                 return False
 
             def export_class_attributes(cls):

--- a/test/py_utility/abstract_test_case.py
+++ b/test/py_utility/abstract_test_case.py
@@ -28,6 +28,41 @@
 
 import inspect, os, re, shutil, sys, time, traceback, unittest
 
+class TeeFile(object):
+    """
+    A file-like object that writes to multiple destinations simultaneously.
+    Useful for capturing output while still showing it on the terminal.
+    """
+    def __init__(self, files):
+        self.files = files
+
+    def add_file(self, file):
+        self.files.append(file)
+
+    def write(self, text):
+        for f in self.files:
+            f.write(text)
+            f.flush()  # Ensure immediate output
+
+    def flush(self):
+        for f in self.files:
+            f.flush()
+
+    def fileno(self):
+        # Return the fileno of the first file
+        return self.files[0].fileno()
+
+    def close(self):
+        for f in self.files:
+            # Check if file is already closed
+            if hasattr(f, 'closed') and f.closed:
+                continue  # Skip already closed files
+            # Don't close the original stdout/stderr
+            if hasattr(f, 'fileno') and f.fileno() in (1, 2):
+                continue
+            if hasattr(f, 'close'):
+                f.close()
+
 def shortenWithEllipsis(s, maxlen):
     if len(s) > maxlen:
         s = s[0:maxlen-3] + '...'
@@ -213,6 +248,7 @@ class AbstractWiredTigerTestCase(unittest.TestCase):
     # Placeholder configuration, in the case no one calls the setup functions.
     _dupout = sys.stdout
     _ignoreStdout = False
+    _realtimeStdout = False
     _parentTestdir = None
     _resultFile = sys.stdout
     _stderr = sys.stderr
@@ -287,7 +323,8 @@ class AbstractWiredTigerTestCase(unittest.TestCase):
     #
 
     @staticmethod
-    def setupIO(resultFileName = 'results.txt', ignoreStdout = False, verbose = 1):
+    def setupIO(resultFileName = 'results.txt', ignoreStdout = False, realtimeOutput = False,
+                verbose = 1):
         '''
         Set up I/O for the test.
         '''
@@ -297,6 +334,7 @@ class AbstractWiredTigerTestCase(unittest.TestCase):
             os.path.join(AbstractWiredTigerTestCase._parentTestdir, resultFileName))
 
         AbstractWiredTigerTestCase._ignoreStdout = ignoreStdout
+        AbstractWiredTigerTestCase._realtimeOutput = realtimeOutput
         AbstractWiredTigerTestCase._resultFileName = resultFilePath
         AbstractWiredTigerTestCase._verbose = verbose
 
@@ -323,10 +361,23 @@ class AbstractWiredTigerTestCase(unittest.TestCase):
         '''
         Set up stderr/stdout after a test.
         '''
+        # Create capture object to intercept the output and check for unexpected entries
         self.captureout = CapturedFd('stdout.txt', 'standard output')
         self.captureerr = CapturedFd('stderr.txt', 'error output')
-        sys.stdout = self.captureout.capture()
-        sys.stderr = self.captureerr.capture()
+
+        # Create tee objects that write to both capture files and original stdout/stderr
+        self.tee_stdout = TeeFile([self.captureout.capture()])
+        self.tee_stderr = TeeFile([self.captureerr.capture()])
+
+        # If real-time output is enabled, add the original stdout/stderr BEFORE replacing sys.stdout/stderr
+        if (self._realtimeOutput):
+            self.tee_stdout.add_file(sys.stdout)
+            self.tee_stderr.add_file(sys.stderr)
+
+        # Now replace sys.stdout and sys.stderr with the tee objects
+        sys.stdout = self.tee_stdout
+        sys.stderr = self.tee_stderr
+
         if self.ignore_regex is not None:
             self.captureout.setIgnorePattern(self.ignore_regex)
 
@@ -334,8 +385,14 @@ class AbstractWiredTigerTestCase(unittest.TestCase):
         '''
         Restore stderr/stdout after a test.
         '''
+        # Release capturing objects
         self.captureout.release()
         self.captureerr.release()
+
+        # Close tee objects
+        self.tee_stdout.close()
+        self.tee_stderr.close()
+
         sys.stdout = AbstractWiredTigerTestCase._stdout
         sys.stderr = AbstractWiredTigerTestCase._stderr
 

--- a/test/py_utility/abstract_test_case.py
+++ b/test/py_utility/abstract_test_case.py
@@ -33,35 +33,38 @@ class TeeFile(object):
     A file-like object that writes to multiple destinations simultaneously.
     Useful for capturing output while still showing it on the terminal.
     """
-    def __init__(self, files):
-        self.files = files
+    capture_file = None
+    std_file = None
 
-    def add_file(self, file):
-        self.files.append(file)
+    def __init__(self, capture_file):
+        self.capture_file = capture_file
+
+    def add_std_file(self, std_file):
+        self.std_file = std_file
+
+    def get_files(self):
+        files = [self.capture_file]
+        if (self.std_file):
+            files.append(self.std_file)
+        return files
 
     def write(self, text):
-        for f in self.files:
+        for f in self.get_files():
             f.write(text)
-            f.flush()  # Ensure immediate output
+            f.flush()
 
     def flush(self):
-        for f in self.files:
+        for f in self.get_files():
             f.flush()
 
     def fileno(self):
-        # Return the fileno of the first file
-        return self.files[0].fileno()
+        if self.std_file:
+            return self.std_file.fileno()
+        return self.capture_file.fileno()
 
     def close(self):
-        for f in self.files:
-            # Check if file is already closed
-            if hasattr(f, 'closed') and f.closed:
-                continue  # Skip already closed files
-            # Don't close the original stdout/stderr
-            if hasattr(f, 'fileno') and f.fileno() in (1, 2):
-                continue
-            if hasattr(f, 'close'):
-                f.close()
+        # We shouldn't close std file
+        self.capture_file.close()
 
 def shortenWithEllipsis(s, maxlen):
     if len(s) > maxlen:
@@ -248,7 +251,7 @@ class AbstractWiredTigerTestCase(unittest.TestCase):
     # Placeholder configuration, in the case no one calls the setup functions.
     _dupout = sys.stdout
     _ignoreStdout = False
-    _realtimeStdout = False
+    _printOutput = False
     _parentTestdir = None
     _resultFile = sys.stdout
     _stderr = sys.stderr
@@ -323,7 +326,7 @@ class AbstractWiredTigerTestCase(unittest.TestCase):
     #
 
     @staticmethod
-    def setupIO(resultFileName = 'results.txt', ignoreStdout = False, realtimeOutput = False,
+    def setupIO(resultFileName = 'results.txt', ignoreStdout = False, printOutput = False,
                 verbose = 1):
         '''
         Set up I/O for the test.
@@ -334,7 +337,7 @@ class AbstractWiredTigerTestCase(unittest.TestCase):
             os.path.join(AbstractWiredTigerTestCase._parentTestdir, resultFileName))
 
         AbstractWiredTigerTestCase._ignoreStdout = ignoreStdout
-        AbstractWiredTigerTestCase._realtimeOutput = realtimeOutput
+        AbstractWiredTigerTestCase._printOutput = printOutput
         AbstractWiredTigerTestCase._resultFileName = resultFilePath
         AbstractWiredTigerTestCase._verbose = verbose
 
@@ -366,13 +369,13 @@ class AbstractWiredTigerTestCase(unittest.TestCase):
         self.captureerr = CapturedFd('stderr.txt', 'error output')
 
         # Create tee objects that write to both capture files and original stdout/stderr
-        self.tee_stdout = TeeFile([self.captureout.capture()])
-        self.tee_stderr = TeeFile([self.captureerr.capture()])
+        self.tee_stdout = TeeFile(self.captureout.capture())
+        self.tee_stderr = TeeFile(self.captureerr.capture())
 
         # If real-time output is enabled, add the original stdout/stderr BEFORE replacing sys.stdout/stderr
-        if (self._realtimeOutput):
-            self.tee_stdout.add_file(sys.stdout)
-            self.tee_stderr.add_file(sys.stderr)
+        if (self._printOutput):
+            self.tee_stdout.add_std_file(sys.stdout)
+            self.tee_stderr.add_std_file(sys.stderr)
 
         # Now replace sys.stdout and sys.stderr with the tee objects
         sys.stdout = self.tee_stdout

--- a/test/suite/run.py
+++ b/test/suite/run.py
@@ -84,7 +84,7 @@ Options:\n\
             --timeout N          have any test that exceeds N seconds throw an error.\n\
   -v N    | --verbose N          set verboseness to N (0<=N<=3, default=1)\n\
   -i      | --ignore-stdout      dont fail on unexpected stdout or stderr\n\
-  -rt     | --realtime-output    print all intercepted output in real time\n\
+  -P      | --print-output       duplicate all intercepted output to a standard stream\n\
   -R      | --randomseed         run with random seeds for generates random numbers\n\
   -S      | --seed               run with two seeds that generates random numbers, \n\
                                  format "seed1.seed2", seed1 or seed2 can\'t be zero\n\
@@ -299,7 +299,7 @@ def error(exitval, prefix, msg):
 
 if __name__ == '__main__':
     # Turn numbers and ranges into test module names
-    preserve = timestamp = debug = dryRun = gdbSub = lldbSub = longtest = zstdtest = ignoreStdout = realtimeOutput = extralongtest = False
+    preserve = timestamp = debug = dryRun = gdbSub = lldbSub = longtest = zstdtest = ignoreStdout = printOutput = extralongtest = False
     removeAtStart = True
     asan = False
     parallel = 0
@@ -433,8 +433,8 @@ if __name__ == '__main__':
             if option == '-ignore-stdout' or option == 'i':
                 ignoreStdout = True
                 continue
-            if option == '-realtime-output' or option == 'rt':
-                realtimeOutput = True
+            if option == '-print-output' or option == 'P':
+                printOutput = True
                 continue
             if option == '-config' or option == 'c':
                 if configfile != None or len(args) == 0:
@@ -551,7 +551,7 @@ if __name__ == '__main__':
     # That way, verbose printing can be done at the class definition level.
     wttest.WiredTigerTestCase.globalSetup(preserve, removeAtStart, timestamp, gdbSub, lldbSub,
                                           verbose, wt_builddir, dirarg, longtest, extralongtest,
-                                          zstdtest, ignoreStdout, realtimeOutput, seedw, seedz,
+                                          zstdtest, ignoreStdout, printOutput, seedw, seedz,
                                           hookmgr, ss_random_prefix, timeout)
 
     # Without any tests listed as arguments, do discovery

--- a/test/suite/run.py
+++ b/test/suite/run.py
@@ -84,6 +84,7 @@ Options:\n\
             --timeout N          have any test that exceeds N seconds throw an error.\n\
   -v N    | --verbose N          set verboseness to N (0<=N<=3, default=1)\n\
   -i      | --ignore-stdout      dont fail on unexpected stdout or stderr\n\
+  -rt     | --realtime-output    print all intercepted output in real time\n\
   -R      | --randomseed         run with random seeds for generates random numbers\n\
   -S      | --seed               run with two seeds that generates random numbers, \n\
                                  format "seed1.seed2", seed1 or seed2 can\'t be zero\n\
@@ -298,7 +299,7 @@ def error(exitval, prefix, msg):
 
 if __name__ == '__main__':
     # Turn numbers and ranges into test module names
-    preserve = timestamp = debug = dryRun = gdbSub = lldbSub = longtest = zstdtest = ignoreStdout = extralongtest = False
+    preserve = timestamp = debug = dryRun = gdbSub = lldbSub = longtest = zstdtest = ignoreStdout = realtimeOutput = extralongtest = False
     removeAtStart = True
     asan = False
     parallel = 0
@@ -432,6 +433,9 @@ if __name__ == '__main__':
             if option == '-ignore-stdout' or option == 'i':
                 ignoreStdout = True
                 continue
+            if option == '-realtime-output' or option == 'rt':
+                realtimeOutput = True
+                continue
             if option == '-config' or option == 'c':
                 if configfile != None or len(args) == 0:
                     usage()
@@ -547,8 +551,8 @@ if __name__ == '__main__':
     # That way, verbose printing can be done at the class definition level.
     wttest.WiredTigerTestCase.globalSetup(preserve, removeAtStart, timestamp, gdbSub, lldbSub,
                                           verbose, wt_builddir, dirarg, longtest, extralongtest,
-                                          zstdtest, ignoreStdout, seedw, seedz, hookmgr,
-                                          ss_random_prefix, timeout)
+                                          zstdtest, ignoreStdout, realtimeOutput, seedw, seedz,
+                                          hookmgr, ss_random_prefix, timeout)
 
     # Without any tests listed as arguments, do discovery
     if len(testargs) == 0:

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -138,7 +138,8 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
     def globalSetup(preserveFiles = False, removeAtStart = True, useTimestamp = False,
                     gdbSub = False, lldbSub = False, verbose = 1, builddir = None, dirarg = None,
                     longtest = False, extralongtest = False, zstdtest = False, ignoreStdout = False,
-                    seedw = 0, seedz = 0, hookmgr = None, ss_random_prefix = 0, timeout = 0):
+                    realtimeOutput = False, seedw = 0, seedz = 0, hookmgr = None,
+                    ss_random_prefix = 0, timeout = 0):
         parentTestDir = 'WT_TEST' if dirarg == None else dirarg
         wtscenario.set_long_run(longtest)
         WiredTigerTestCase._builddir = builddir
@@ -158,7 +159,7 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
         WiredTigerTestCase.hook_names = hookmgr.get_hook_names()
 
         WiredTigerTestCase.setupTestDir(parentTestDir, preserveFiles, removeAtStart, useTimestamp)
-        WiredTigerTestCase.setupIO('results.txt', ignoreStdout, verbose)
+        WiredTigerTestCase.setupIO('results.txt', ignoreStdout, realtimeOutput, verbose)
         WiredTigerTestCase.setupRandom(seedw, seedz)
         WiredTigerTestCase._globalSetup = True
 

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -138,7 +138,7 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
     def globalSetup(preserveFiles = False, removeAtStart = True, useTimestamp = False,
                     gdbSub = False, lldbSub = False, verbose = 1, builddir = None, dirarg = None,
                     longtest = False, extralongtest = False, zstdtest = False, ignoreStdout = False,
-                    realtimeOutput = False, seedw = 0, seedz = 0, hookmgr = None,
+                    printOutput = False, seedw = 0, seedz = 0, hookmgr = None,
                     ss_random_prefix = 0, timeout = 0):
         parentTestDir = 'WT_TEST' if dirarg == None else dirarg
         wtscenario.set_long_run(longtest)
@@ -159,7 +159,7 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
         WiredTigerTestCase.hook_names = hookmgr.get_hook_names()
 
         WiredTigerTestCase.setupTestDir(parentTestDir, preserveFiles, removeAtStart, useTimestamp)
-        WiredTigerTestCase.setupIO('results.txt', ignoreStdout, realtimeOutput, verbose)
+        WiredTigerTestCase.setupIO('results.txt', ignoreStdout, printOutput, verbose)
         WiredTigerTestCase.setupRandom(seedw, seedz)
         WiredTigerTestCase._globalSetup = True
 


### PR DESCRIPTION
Currently, by default, run.py intercepts stdout and stderr, redirecting them to separate files to check for unexpected output later. The goal of this ticket is to create an option that also allows duplicating the output to the normal stdout/stderr, which can be useful for debugging.

**This is the second PR, [the first one](https://github.com/wiredtiger/wiredtiger/pull/12477) was reverted because of a CI failure caused in compatibility tests. The last commit fixes it.**