### PR TITLE
WT-15683 Fix comment describing __wt_btree_bytes_updates

### DIFF
--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -251,7 +251,7 @@ __wt_btree_dirty_leaf_inuse(WT_SESSION_IMPL *session)
 
 /*
  * __wt_btree_bytes_updates --
- *     Return the number of bytes in use by dirty leaf pages.
+ *     Return the number of bytes .used by updates on a page.
  */
 static WT_INLINE uint64_t
 __wt_btree_bytes_updates(WT_SESSION_IMPL *session)

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -251,7 +251,7 @@ __wt_btree_dirty_leaf_inuse(WT_SESSION_IMPL *session)
 
 /*
  * __wt_btree_bytes_updates --
- *     Return the number of bytes .used by updates on a page.
+ *     Return the number of bytes used by updates on pages.
  */
 static WT_INLINE uint64_t
 __wt_btree_bytes_updates(WT_SESSION_IMPL *session)


### PR DESCRIPTION
The header comment describing __wt_btree_bytes_updates was cut-and-pasted unchanged from __wt_btree_dirty_leaf_inuse. Update the comment to accurately describe the function.