### PR TITLE
WT-15694 Introduce MSAN and UBSAN to disagg test/format builds

### DIFF
--- a/test/checkpoint/checkpointer.c
+++ b/test/checkpoint/checkpointer.c
@@ -646,6 +646,8 @@ diagnose_key_error(WT_CURSOR *cursor1, table_type type1, int index1, WT_CURSOR *
     /* Hack to avoid passing session as parameter. */
     session = cursor1->session;
     key1_orig = key2_orig = 0;
+    memset(ckpt, 0, sizeof(ckpt));
+
 
     /* FIXME-WT-15357: Checkpoint cursors are not compatible with disagg for now. */
     if (!g.opts.disagg_storage)

--- a/test/checkpoint/checkpointer.c
+++ b/test/checkpoint/checkpointer.c
@@ -648,7 +648,6 @@ diagnose_key_error(WT_CURSOR *cursor1, table_type type1, int index1, WT_CURSOR *
     key1_orig = key2_orig = 0;
     memset(ckpt, 0, sizeof(ckpt));
 
-
     /* FIXME-WT-15357: Checkpoint cursors are not compatible with disagg for now. */
     if (!g.opts.disagg_storage)
         testutil_snprintf(ckpt, sizeof(ckpt), "checkpoint=%s", g.checkpoint_name);

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4497,7 +4497,7 @@ tasks:
    # FIXME-WT-14566: Enable disagg leader mode on all platforms once failures has been resolved.
   - <<: *format-stress-test-disagg-leader
     name: format-stress-test-disagg-leader-1
-    tags: ["stress-test-disagg-fail", "stress-test-disagg-asan-fail"]
+    tags: ["stress-test-disagg-fail", "stress-test-disagg-san-fail"]
   - <<: *format-stress-test-disagg-leader
     name: format-stress-test-disagg-leader-2
     tags: ["stress-test-disagg-fail"]
@@ -4527,7 +4527,7 @@ tasks:
     tags: ["stress-test-disagg-fail"]
   - <<: *format-stress-test-disagg-follower
     name: format-stress-test-disagg-follower-1
-    tags: ["stress-test-disagg", "stress-test-disagg-asan-fail"]
+    tags: ["stress-test-disagg", "stress-test-disagg-san-fail"]
   - <<: *format-stress-test-disagg-follower
     name: format-stress-test-disagg-follower-2
     tags: ["stress-test-disagg"]
@@ -4558,7 +4558,7 @@ tasks:
   # FIXME-WT-14566: Enable disagg switch mode on all platforms once failures has been resolved.
   - <<: *format-stress-test-disagg-switch
     name: format-stress-test-disagg-switch-1
-    tags: ["stress-test-disagg-fail", "stress-test-disagg-asan-fail"]
+    tags: ["stress-test-disagg-fail", "stress-test-disagg-san-fail"]
   - <<: *format-stress-test-disagg-switch
     name: format-stress-test-disagg-switch-2
     tags: ["stress-test-disagg-fail"]
@@ -7346,4 +7346,41 @@ buildvariants:
     additional_san_vars: export ASAN_OPTIONS="$COMMON_SAN_OPTIONS:unmap_shadow_on_exit=1"
   tasks:
     - name: compile
-    - name: ".stress-test-disagg-asan-fail"
+    - name: ".stress-test-disagg-san-fail"
+    - name: checkpoint-test
+
+- name: amazon2023-disagg-msan-stress
+  display_name: "[Failure Expected] (ARMV9) Amazon 2023 MSAN Disagg Stress tests"
+  batchtime: 4320 # once every three days
+  run_on:
+  - amazon2023-arm64-latest-large-m8g
+  expansions:
+    CMAKE_TOOLCHAIN_FILE: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_stable_clang.cmake
+    CMAKE_BUILD_TYPE: -DCMAKE_BUILD_TYPE=MSan
+    # MemorySanitizer requires that all program code is instrumented, otherwise it may generate false reports.
+    posix_configure_flags: -DENABLE_LZ4=0 -DENABLE_SNAPPY=0 -DENABLE_ZLIB=0 -DENABLE_ZSTD=0
+    CC_OPTIMIZE_LEVEL: -DCC_OPTIMIZE_LEVEL=-O0
+    ENABLE_TCMALLOC: 0
+    num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo` / 2" | bc)
+    disagg_run: true
+  tasks:
+    - name: compile
+    - name: ".stress-test-disagg-san-fail"
+    - name: checkpoint-test
+
+- name: amazon2023-disagg-ubsan-stress
+  display_name: "[Failure Expected] (ARMV9) Amazon 2023 UBSAN Disagg Stress tests"
+  batchtime: 4320 # once every three days
+  run_on:
+  - amazon2023-arm64-latest-large-m8g
+  expansions:
+    CMAKE_TOOLCHAIN_FILE: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/clang.cmake
+    CMAKE_BUILD_TYPE: -DCMAKE_BUILD_TYPE=UBSan
+    CC_OPTIMIZE_LEVEL: -DCC_OPTIMIZE_LEVEL=-O0
+    ENABLE_TCMALLOC: 0
+    num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
+    disagg_run: true
+  tasks:
+    - name: compile
+    - name: ".stress-test-disagg-san-fail"
+    - name: checkpoint-test


### PR DESCRIPTION
This pull request adds MSAN and UBSAN to disagg test/format. The hope is to find out any memory corruption related issues that may be present in the disagg feature code.