### PR TITLE
WT-15605 Fix cursor walk interuptted by a WT_NOTFOUND error

### DIFF
--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2189,8 +2189,8 @@ static WT_INLINE int __wt_txn_read(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cb
 static WT_INLINE int __wt_txn_read_upd_list(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt,
   WT_ITEM *key, uint64_t recno, WT_UPDATE *upd) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_txn_read_upd_list_internal(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt,
-  WT_ITEM *key, uint64_t recno, WT_UPDATE *upd, WT_UPDATE **prepare_updp, WT_UPDATE **restored_updp)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+  WT_ITEM *key, uint64_t recno, WT_UPDATE *upd, WT_UPDATE **prepare_updp, WT_UPDATE **restored_updp,
+  bool *seen_restored_deltap) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_txn_search_check(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_txn_timestamp_usage_check(

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1467,7 +1467,8 @@ __wt_upd_alloc_tombstone(WT_SESSION_IMPL *session, WT_UPDATE **updp, size_t *siz
  */
 static WT_INLINE int
 __wt_txn_read_upd_list_internal(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_ITEM *key,
-  uint64_t recno, WT_UPDATE *upd, WT_UPDATE **prepare_updp, WT_UPDATE **restored_updp)
+  uint64_t recno, WT_UPDATE *upd, WT_UPDATE **prepare_updp, WT_UPDATE **restored_updp,
+  bool *seen_restored_deltap)
 {
     WT_VISIBLE_TYPE upd_visible;
     uint64_t prepare_txnid;
@@ -1566,6 +1567,8 @@ __wt_txn_read_upd_list_internal(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, 
 
         if (F_ISSET(upd, WT_UPDATE_RESTORED_FROM_DELTA) && upd->type == WT_UPDATE_STANDARD) {
             WT_ASSERT(session, !F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY));
+            if (seen_restored_deltap != NULL)
+                *seen_restored_deltap = true;
             /*
              * If we see an update that is not visible to the reader and it is restored from delta,
              * we should search the history store.
@@ -1576,8 +1579,6 @@ __wt_txn_read_upd_list_internal(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, 
                 __wt_timing_stress(session, WT_TIMING_STRESS_HS_SEARCH, NULL);
                 WT_RET(__wt_hs_find_upd(session, S2BT(session)->id, key, cbt->iface.value_format,
                   recno, cbt->upd_value, &cbt->upd_value->buf));
-                if (cbt->upd_value->type == WT_UPDATE_INVALID)
-                    return (0);
                 return (0);
             }
         }
@@ -1610,8 +1611,7 @@ static WT_INLINE int
 __wt_txn_read_upd_list(
   WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_ITEM *key, uint64_t recno, WT_UPDATE *upd)
 {
-    WT_RET_NOTFOUND_OK(__wt_txn_read_upd_list_internal(session, cbt, key, recno, upd, NULL, NULL));
-    return (0);
+    return (__wt_txn_read_upd_list_internal(session, cbt, key, recno, upd, NULL, NULL, NULL));
 }
 
 /*
@@ -1628,14 +1628,17 @@ __wt_txn_read(
     WT_DECL_RET;
     WT_TIME_WINDOW tw;
     WT_UPDATE *prepare_upd, *restored_upd;
-    bool have_stop_tw, prepare_retry, read_onpage;
+    bool have_stop_tw, prepare_retry, read_onpage, seen_restored_delta;
 
     prepare_upd = restored_upd = NULL;
     read_onpage = prepare_retry = true;
+    seen_restored_delta = false;
 
 retry:
-    WT_RET(
-      __wt_txn_read_upd_list_internal(session, cbt, key, recno, upd, &prepare_upd, &restored_upd));
+    WT_RET(__wt_txn_read_upd_list_internal(
+      session, cbt, key, recno, upd, &prepare_upd, &restored_upd, &seen_restored_delta));
+    if (seen_restored_delta)
+        return (0);
     if (WT_UPDATE_DATA_VALUE(cbt->upd_value) ||
       (cbt->upd_value->type == WT_UPDATE_MODIFY && cbt->upd_value->skip_buf))
         return (0);

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1576,8 +1576,6 @@ __wt_txn_read_upd_list_internal(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, 
                 __wt_timing_stress(session, WT_TIMING_STRESS_HS_SEARCH, NULL);
                 WT_RET(__wt_hs_find_upd(session, S2BT(session)->id, key, cbt->iface.value_format,
                   recno, cbt->upd_value, &cbt->upd_value->buf));
-                if (cbt->upd_value->type == WT_UPDATE_INVALID)
-                    return (WT_NOTFOUND);
                 return (0);
             }
         }

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1576,6 +1576,8 @@ __wt_txn_read_upd_list_internal(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, 
                 __wt_timing_stress(session, WT_TIMING_STRESS_HS_SEARCH, NULL);
                 WT_RET(__wt_hs_find_upd(session, S2BT(session)->id, key, cbt->iface.value_format,
                   recno, cbt->upd_value, &cbt->upd_value->buf));
+                if (cbt->upd_value->type == WT_UPDATE_INVALID)
+                    return (0);
                 return (0);
             }
         }
@@ -1608,7 +1610,8 @@ static WT_INLINE int
 __wt_txn_read_upd_list(
   WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_ITEM *key, uint64_t recno, WT_UPDATE *upd)
 {
-    return (__wt_txn_read_upd_list_internal(session, cbt, key, recno, upd, NULL, NULL));
+    WT_RET_NOTFOUND_OK(__wt_txn_read_upd_list_internal(session, cbt, key, recno, upd, NULL, NULL));
+    return (0);
 }
 
 /*

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1637,6 +1637,10 @@ __wt_txn_read(
 retry:
     WT_RET(__wt_txn_read_upd_list_internal(
       session, cbt, key, recno, upd, &prepare_upd, &restored_upd, &seen_restored_delta));
+    /*
+     * If we see an update restored from delta, we must have already tried the history store if
+     * necessary. We are done.
+     */
     if (seen_restored_delta)
         return (0);
     if (WT_UPDATE_DATA_VALUE(cbt->upd_value) ||

--- a/test/checkpoint/checkpointer.c
+++ b/test/checkpoint/checkpointer.c
@@ -650,6 +650,8 @@ diagnose_key_error(WT_CURSOR *cursor1, table_type type1, int index1, WT_CURSOR *
     /* FIXME-WT-15357: Checkpoint cursors are not compatible with disagg for now. */
     if (!g.opts.disagg_storage)
         testutil_snprintf(ckpt, sizeof(ckpt), "checkpoint=%s", g.checkpoint_name);
+    else
+        testutil_snprintf(ckpt, sizeof(ckpt), "%s", "");
 
     /* Save the failed keys. */
     if (cursor1->get_key(cursor1, &key1_orig) != 0 || cursor2->get_key(cursor2, &key2_orig) != 0) {

--- a/test/suite/test_layered58.py
+++ b/test/suite/test_layered58.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import random, string, wttest
+from wiredtiger import stat
+from helper_disagg import DisaggConfigMixin, disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
+
+# test_layered58.py
+#    Test cursor walk with delta.
+@disagg_test_class
+class test_layered58(wttest.WiredTigerTestCase, DisaggConfigMixin):
+    disagg_storages = gen_disagg_storages('test_layered58', disagg_only = True)
+    scenarios = make_scenarios(disagg_storages)
+
+    conn_config = 'disaggregated=(page_log=palm),cache_size=10MB,statistics=(all),disaggregated=(role="leader")'
+
+    nitems = 100
+
+    def test_cursor_walk_with_delta(self):
+        uri = "layered:test_layered58"
+
+        # Setup.
+        self.session.create(uri, 'key_format=S,value_format=S')
+
+        # Insert some data.
+        cursor = self.session.open_cursor(uri, None, None)
+        for i in range(1, self.nitems):
+            self.session.begin_transaction()
+            cursor[str(i)] = "value"
+            if i == 50:
+                self.session.commit_transaction(f"commit_timestamp={self.timestamp_str(20)}")
+            else:
+                self.session.commit_transaction(f"commit_timestamp={self.timestamp_str(10)}")
+
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(20))
+
+        # Do a checkpoint
+        self.session.checkpoint()
+
+        # Update a key in the middle
+        self.session.begin_transaction()
+        cursor[str(50)] = "value2"
+        self.session.commit_transaction(f"commit_timestamp={self.timestamp_str(30)}")
+
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(30))
+
+        # Do another checkpoint
+        self.session.checkpoint()
+
+        # Verfiy that we have written a delta
+        stat_cursor = self.session.open_cursor('statistics:' + uri)
+        self.assertGreater(stat_cursor[stat.dsrc.rec_page_delta_leaf][2], 0)
+        stat_cursor.close()
+
+        self.reopen_conn()
+
+        cursor = self.session.open_cursor(uri, None, None)
+        # Read with the latest timestamp
+        self.session.begin_transaction("read_timestamp=" + self.timestamp_str(30))
+        count = 0
+        while cursor.next() == 0:
+            if cursor.get_key() == str(50):
+                self.assertEqual(cursor.get_value(), "value2")
+            else:
+                self.assertEqual(cursor.get_value(), "value")
+            count += 1
+        self.assertEqual(count, self.nitems - 1)
+
+        count = 0
+        while cursor.prev() == 0:
+            if cursor.get_key() == str(50):
+                self.assertEqual(cursor.get_value(), "value2")
+            else:
+                self.assertEqual(cursor.get_value(), "value")
+            count += 1
+        self.assertEqual(count, self.nitems - 1)
+        self.session.rollback_transaction()
+
+        # Read with timestamp 10
+        self.session.begin_transaction("read_timestamp=" + self.timestamp_str(10))
+        count = 0
+        while cursor.next() == 0:
+            self.assertEqual(cursor.get_value(), "value")
+            count += 1
+        self.assertEqual(count, self.nitems - 2)
+
+        count = 0
+        while cursor.prev() == 0:
+            self.assertEqual(cursor.get_value(), "value")
+            count += 1
+        self.assertEqual(count, self.nitems - 2)
+        self.session.rollback_transaction()


### PR DESCRIPTION
* Fix cursor walk skips the rest keys on the page if it is interrupted by a WT_NOTFOUND error.
* Fix a usage of uninitialized variable in test checkpoint.