### PR TITLE
WT-15658 disable block cache wt tests

### DIFF
--- a/src/block_cache/block_cache.c
+++ b/src/block_cache/block_cache.c
@@ -860,10 +860,6 @@ __wt_blkcache_setup(WT_SESSION_IMPL *session, const char *cfg[], bool reconfig)
     if (blkcache->type != WT_BLKCACHE_UNCONFIGURED && !reconfig)
         WT_RET_MSG(session, EINVAL, "block cache setup requested for a configured cache");
 
-    /* FIXME-WT-15663 Disable block cache in disagg mode */
-    if (__wt_conn_is_disagg(session))
-        return (0);
-
     /* When reconfiguring, check if there are any modifications that we care about. */
     if (blkcache->type != WT_BLKCACHE_UNCONFIGURED && reconfig) {
         if ((ret = __wt_config_gets(session, cfg + 1, "block_cache", &cval)) == WT_NOTFOUND)
@@ -874,6 +870,13 @@ __wt_blkcache_setup(WT_SESSION_IMPL *session, const char *cfg[], bool reconfig)
     WT_RET(__wt_config_gets(session, cfg, "block_cache.enabled", &cval));
     if (cval.val == 0)
         return (0);
+
+    /* FIXME-WT-15663 Disable block cache before it's stable */
+    __wt_verbose_warning(session, WT_VERB_BLKCACHE,
+      "Block cache is currently disabled (wait WT-15663). Continuing without block cache, "
+      "enable:%" PRIi64,
+      cval.val);
+    return (0);
 
     WT_RET(__wt_config_gets(session, cfg, "block_cache.size", &cval));
     if ((cache_size = (uint64_t)cval.val) <= 0)

--- a/src/block_cache/block_cache.c
+++ b/src/block_cache/block_cache.c
@@ -871,7 +871,7 @@ __wt_blkcache_setup(WT_SESSION_IMPL *session, const char *cfg[], bool reconfig)
     if (cval.val == 0)
         return (0);
 
-    /* FIXME-WT-15663 Disable block cache until it is stable */
+    /* FIXME-WT-15663 Disable block cache until it is stable. */
     if (cval.val == 1) {
         __wt_verbose_warning(session, WT_VERB_BLKCACHE,
           "Block cache is currently disabled. Continuing without block cache "

--- a/src/block_cache/block_cache.c
+++ b/src/block_cache/block_cache.c
@@ -873,10 +873,8 @@ __wt_blkcache_setup(WT_SESSION_IMPL *session, const char *cfg[], bool reconfig)
 
     /* FIXME-WT-15663 Disable block cache until it is stable */
     if (cval.val == 1) {
-        __wt_verbose_warning(session, WT_VERB_BLKCACHE,
-          "Block cache is currently disabled. Continuing without block cache "
-          "enable:%" PRIi64,
-          cval.val);
+        __wt_verbose_warning(session, WT_VERB_BLKCACHE, "%s",
+          "Block cache is currently disabled. Continuing without block cache enable.");
         return (0);
     }
 

--- a/src/block_cache/block_cache.c
+++ b/src/block_cache/block_cache.c
@@ -871,12 +871,14 @@ __wt_blkcache_setup(WT_SESSION_IMPL *session, const char *cfg[], bool reconfig)
     if (cval.val == 0)
         return (0);
 
-    /* FIXME-WT-15663 Disable block cache before it's stable */
-    __wt_verbose_warning(session, WT_VERB_BLKCACHE,
-      "Block cache is currently disabled (wait WT-15663). Continuing without block cache, "
-      "enable:%" PRIi64,
-      cval.val);
-    return (0);
+    /* FIXME-WT-15663 Disable block cache until it is stable */
+    if (cval.val == 1) {
+        __wt_verbose_warning(session, WT_VERB_BLKCACHE,
+          "Block cache is currently disabled. Continuing without block cache "
+          "enable:%" PRIi64,
+          cval.val);
+        return (0);
+    }
 
     WT_RET(__wt_config_gets(session, cfg, "block_cache.size", &cval));
     if ((cache_size = (uint64_t)cval.val) <= 0)

--- a/src/block_cache/block_cache.c
+++ b/src/block_cache/block_cache.c
@@ -860,6 +860,10 @@ __wt_blkcache_setup(WT_SESSION_IMPL *session, const char *cfg[], bool reconfig)
     if (blkcache->type != WT_BLKCACHE_UNCONFIGURED && !reconfig)
         WT_RET_MSG(session, EINVAL, "block cache setup requested for a configured cache");
 
+    /* FIXME-WT-15663 Disable block cache in disagg mode */
+    if (__wt_conn_is_disagg(session))
+        return (0);
+
     /* When reconfiguring, check if there are any modifications that we care about. */
     if (blkcache->type != WT_BLKCACHE_UNCONFIGURED && reconfig) {
         if ((ret = __wt_config_gets(session, cfg + 1, "block_cache", &cval)) == WT_NOTFOUND)

--- a/test/suite/test_layered43.py
+++ b/test/suite/test_layered43.py
@@ -74,6 +74,7 @@ class test_layered43(wttest.WiredTigerTestCase, DisaggConfigMixin):
 
     # Test long delta chains
     def test_layered43(self):
+        self.skipTest("FIXME-WT-15663: currently block cache is disabled.")
 
         # Create table
         self.uri = self.prefix + self.table_name

--- a/test/suite/test_layered43.py
+++ b/test/suite/test_layered43.py
@@ -64,6 +64,7 @@ class test_layered43(wttest.WiredTigerTestCase, DisaggConfigMixin):
 
     # Custom test case setup
     def early_setup(self):
+        self.skipTest("FIXME-WT-15663: currently block cache is disabled.")
         os.mkdir('kv_home')
 
     def get_stat(self, stat):
@@ -74,7 +75,6 @@ class test_layered43(wttest.WiredTigerTestCase, DisaggConfigMixin):
 
     # Test long delta chains
     def test_layered43(self):
-        self.skipTest("FIXME-WT-15663: currently block cache is disabled.")
 
         # Create table
         self.uri = self.prefix + self.table_name


### PR DESCRIPTION
- Always disable `block_cache`
- Skip test `test_layered43`, call skip before setup.