### PR TITLE
WT-15345 Fix TSAN statistics warnings

### DIFF
--- a/src/block/block_ext.c
+++ b/src/block/block_ext.c
@@ -225,7 +225,7 @@ __block_ext_insert(WT_SESSION_IMPL *session, WT_EXTLIST *el, WT_EXT *ext)
     }
 
     ++el->entries;
-    el->bytes += (uint64_t)ext->size;
+    __wt_atomic_add_uint64_relaxed(&el->bytes, (uint64_t)ext->size);
 
     /* Update the cached end-of-list. */
     if (ext->next[0] == NULL)

--- a/src/block/block_ext.c
+++ b/src/block/block_ext.c
@@ -390,7 +390,7 @@ __block_off_remove(
 #endif
 
     --el->entries;
-    el->bytes -= (uint64_t)ext->size;
+    __wt_atomic_sub_uint64_relaxed(&el->bytes, (uint64_t)ext->size);
 
     /* Return the record if our caller wants it, otherwise free it. */
     if (extp == NULL) {

--- a/src/block/block_open.c
+++ b/src/block/block_open.c
@@ -467,7 +467,8 @@ __wt_block_stat(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_DSRC_STATS *stats)
     WT_STAT_WRITE(session, stats, block_magic, WT_BLOCK_MAGIC);
     WT_STAT_WRITE(session, stats, block_major, WT_BLOCK_MAJOR_VERSION);
     WT_STAT_WRITE(session, stats, block_minor, WT_BLOCK_MINOR_VERSION);
-    WT_STAT_WRITE(session, stats, block_reuse_bytes, (int64_t)block->live.avail.bytes);
+    WT_STAT_WRITE(session, stats, block_reuse_bytes,
+      (int64_t)(__wt_atomic_load_uint64_relaxed(&block->live.avail.bytes)));
     WT_STAT_WRITE(session, stats, block_size, block->size);
 }
 

--- a/src/cache/cache.c
+++ b/src/cache/cache.c
@@ -151,10 +151,10 @@ __wt_cache_stats_update(WT_SESSION_IMPL *session)
       session, stats, rec_average_internal_page_delta_chain_length, avg_internal_chain);
     WT_STATP_CONN_SET(session, stats, rec_average_leaf_page_delta_chain_length, avg_leaf_chain);
 
-    WT_STATP_CONN_SET(
-      session, stats, rec_max_internal_page_deltas, conn->page_delta.max_internal_delta_count);
-    WT_STATP_CONN_SET(
-      session, stats, rec_max_leaf_page_deltas, conn->page_delta.max_leaf_delta_count);
+    WT_STATP_CONN_SET(session, stats, rec_max_internal_page_deltas,
+      __wt_atomic_load_uint64_relaxed(&conn->page_delta.max_internal_delta_count));
+    WT_STATP_CONN_SET(session, stats, rec_max_leaf_page_deltas,
+      __wt_atomic_load_uint64_relaxed(&conn->page_delta.max_leaf_delta_count));
 }
 
 /*

--- a/src/cache/cache.c
+++ b/src/cache/cache.c
@@ -128,14 +128,16 @@ __wt_cache_stats_update(WT_SESSION_IMPL *session)
     WT_STATP_CONN_SET(session, stats, cache_bytes_other, __wt_cache_bytes_other(cache));
     WT_STATP_CONN_SET(session, stats, cache_bytes_updates, __wt_cache_bytes_updates(cache));
 
-    WT_STATP_CONN_SET(
-      session, stats, cache_pages_dirty, cache->pages_dirty_intl + cache->pages_dirty_leaf);
+    WT_STATP_CONN_SET(session, stats, cache_pages_dirty,
+      __wt_atomic_load_uint64_relaxed(&cache->pages_dirty_intl) +
+        __wt_atomic_load_uint64_relaxed(&cache->pages_dirty_leaf));
 
-    WT_STATP_CONN_SET(
-      session, stats, rec_maximum_hs_wrapup_milliseconds, conn->rec_maximum_hs_wrapup_milliseconds);
+    WT_STATP_CONN_SET(session, stats, rec_maximum_hs_wrapup_milliseconds,
+      __wt_atomic_load_uint64_relaxed(&conn->rec_maximum_hs_wrapup_milliseconds));
     WT_STATP_CONN_SET(session, stats, rec_maximum_image_build_milliseconds,
-      conn->rec_maximum_image_build_milliseconds);
-    WT_STATP_CONN_SET(session, stats, rec_maximum_milliseconds, conn->rec_maximum_milliseconds);
+      __wt_atomic_load_uint64_relaxed(&conn->rec_maximum_image_build_milliseconds));
+    WT_STATP_CONN_SET(session, stats, rec_maximum_milliseconds,
+      __wt_atomic_load_uint64_relaxed(&conn->rec_maximum_milliseconds));
 
     avg_internal_chain = (uint64_t)WT_STAT_CONN_READ(stats, rec_pages_with_internal_deltas) == 0 ?
       0 :

--- a/src/checkpoint/checkpoint_stats.c
+++ b/src/checkpoint/checkpoint_stats.c
@@ -67,24 +67,37 @@ void
 __wt_checkpoint_timer_stats(WT_SESSION_IMPL *session)
 {
     WT_CKPT_CONNECTION *ckpt = &S2C(session)->ckpt;
+    uint64_t min;
 
-    WT_STAT_CONN_SET(session, checkpoint_scrub_max, ckpt->scrub.max);
-    if (ckpt->scrub.min != UINT64_MAX)
-        WT_STAT_CONN_SET(session, checkpoint_scrub_min, ckpt->scrub.min);
-    WT_STAT_CONN_SET(session, checkpoint_scrub_recent, ckpt->scrub.recent);
-    WT_STAT_CONN_SET(session, checkpoint_scrub_total, ckpt->scrub.total);
+    WT_STAT_CONN_SET(
+      session, checkpoint_scrub_max, __wt_atomic_load_uint64_relaxed(&ckpt->scrub.max));
+    min = __wt_atomic_load_uint64_relaxed(&ckpt->scrub.min);
+    if (min != UINT64_MAX)
+        WT_STAT_CONN_SET(session, checkpoint_scrub_min, min);
+    WT_STAT_CONN_SET(
+      session, checkpoint_scrub_recent, __wt_atomic_load_uint64_relaxed(&ckpt->scrub.recent));
+    WT_STAT_CONN_SET(
+      session, checkpoint_scrub_total, __wt_atomic_load_uint64_relaxed(&ckpt->scrub.total));
 
-    WT_STAT_CONN_SET(session, checkpoint_prep_max, ckpt->prepare.max);
-    if (ckpt->prepare.min != UINT64_MAX)
-        WT_STAT_CONN_SET(session, checkpoint_prep_min, ckpt->prepare.min);
-    WT_STAT_CONN_SET(session, checkpoint_prep_recent, ckpt->prepare.recent);
-    WT_STAT_CONN_SET(session, checkpoint_prep_total, ckpt->prepare.total);
+    WT_STAT_CONN_SET(
+      session, checkpoint_prep_max, __wt_atomic_load_uint64_relaxed(&ckpt->prepare.max));
+    min = __wt_atomic_load_uint64_relaxed(&ckpt->prepare.min);
+    if (min != UINT64_MAX)
+        WT_STAT_CONN_SET(session, checkpoint_prep_min, min);
+    WT_STAT_CONN_SET(
+      session, checkpoint_prep_recent, __wt_atomic_load_uint64_relaxed(&ckpt->prepare.recent));
+    WT_STAT_CONN_SET(
+      session, checkpoint_prep_total, __wt_atomic_load_uint64_relaxed(&ckpt->prepare.total));
 
-    WT_STAT_CONN_SET(session, checkpoint_time_max, ckpt->ckpt_api.max);
-    if (ckpt->ckpt_api.min != UINT64_MAX)
-        WT_STAT_CONN_SET(session, checkpoint_time_min, ckpt->ckpt_api.min);
-    WT_STAT_CONN_SET(session, checkpoint_time_recent, ckpt->ckpt_api.recent);
-    WT_STAT_CONN_SET(session, checkpoint_time_total, ckpt->ckpt_api.total);
+    WT_STAT_CONN_SET(
+      session, checkpoint_time_max, __wt_atomic_load_uint64_relaxed(&ckpt->ckpt_api.max));
+    min = __wt_atomic_load_uint64_relaxed(&ckpt->ckpt_api.min);
+    if (min != UINT64_MAX)
+        WT_STAT_CONN_SET(session, checkpoint_time_min, min);
+    WT_STAT_CONN_SET(
+      session, checkpoint_time_recent, __wt_atomic_load_uint64_relaxed(&ckpt->ckpt_api.recent));
+    WT_STAT_CONN_SET(
+      session, checkpoint_time_total, __wt_atomic_load_uint64_relaxed(&ckpt->ckpt_api.total));
 }
 
 /*

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -1208,8 +1208,8 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
     __wt_atomic_store_uint64_relaxed(&conn->rec_maximum_hs_wrapup_milliseconds, 0);
     __wt_atomic_store_uint64_relaxed(&conn->rec_maximum_image_build_milliseconds, 0);
     __wt_atomic_store_uint64_relaxed(&conn->rec_maximum_milliseconds, 0);
-    conn->page_delta.max_internal_delta_count = 0;
-    conn->page_delta.max_leaf_delta_count = 0;
+    __wt_atomic_store_uint64_relaxed(&conn->page_delta.max_internal_delta_count, 0);
+    __wt_atomic_store_uint64_relaxed(&conn->page_delta.max_leaf_delta_count, 0);
 
     /* Initialize the verbose tracking timer */
     __wt_epoch(session, &conn->ckpt.ckpt_api.timer_start);

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -691,6 +691,19 @@ __wt_checkpoint_verbose_timer_started(WT_SESSION_IMPL *session)
 }
 
 /*
+ * __checkpoint_timer_stats_set --
+ *     Update checkpoint timer stats for a specific timer.
+ */
+static void
+__checkpoint_timer_stats_set(WTI_CKPT_TIMER *timer, uint64_t msec)
+{
+    __wt_atomic_stats_max(&timer->max, msec);
+    __wt_atomic_stats_min(&timer->min, msec);
+    __wt_atomic_store_uint64_relaxed(&timer->recent, msec);
+    (void)__wt_atomic_add_uint64_relaxed(&timer->total, msec);
+}
+
+/*
  * __checkpoint_stats --
  *     Update checkpoint timer stats.
  */
@@ -710,33 +723,15 @@ __checkpoint_stats(WT_SESSION_IMPL *session)
     /* Compute end-to-end timer statistics for checkpoint. */
     __wt_epoch(session, &stop);
     msec = WT_TIMEDIFF_MS(stop, conn->ckpt.ckpt_api.timer_start);
-
-    if (msec > conn->ckpt.ckpt_api.max)
-        conn->ckpt.ckpt_api.max = msec;
-    if (msec < conn->ckpt.ckpt_api.min)
-        conn->ckpt.ckpt_api.min = msec;
-    conn->ckpt.ckpt_api.recent = msec;
-    conn->ckpt.ckpt_api.total += msec;
+    __checkpoint_timer_stats_set(&conn->ckpt.ckpt_api, msec);
 
     /* Compute timer statistics for the scrub. */
     msec = WT_TIMEDIFF_MS(conn->ckpt.scrub.timer_end, conn->ckpt.ckpt_api.timer_start);
-
-    if (msec > conn->ckpt.scrub.max)
-        conn->ckpt.scrub.max = msec;
-    if (msec < conn->ckpt.scrub.min)
-        conn->ckpt.scrub.min = msec;
-    conn->ckpt.scrub.recent = msec;
-    conn->ckpt.scrub.total += msec;
+    __checkpoint_timer_stats_set(&conn->ckpt.scrub, msec);
 
     /* Compute timer statistics for the checkpoint prepare. */
     msec = WT_TIMEDIFF_MS(conn->ckpt.prepare.timer_end, conn->ckpt.prepare.timer_start);
-
-    if (msec > conn->ckpt.prepare.max)
-        conn->ckpt.prepare.max = msec;
-    if (msec < conn->ckpt.prepare.min)
-        conn->ckpt.prepare.min = msec;
-    conn->ckpt.prepare.recent = msec;
-    conn->ckpt.prepare.total += msec;
+    __checkpoint_timer_stats_set(&conn->ckpt.prepare, msec);
 }
 
 /*
@@ -1208,11 +1203,11 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
     __wt_atomic_store_uint64_relaxed(&evict->evict_max_dirty_page_size_per_checkpoint, 0);
     __wt_atomic_store_uint64_relaxed(&evict->evict_max_updates_page_size_per_checkpoint, 0);
     __wt_atomic_store_uint64_relaxed(&evict->evict_max_ms_per_checkpoint, 0);
-    evict->reentry_hs_eviction_ms = 0;
+    __wt_atomic_store_uint64_relaxed(&evict->reentry_hs_eviction_ms, 0);
     __wt_atomic_store_uint32_relaxed(&conn->heuristic_controls.obsolete_tw_btree_count, 0);
-    conn->rec_maximum_hs_wrapup_milliseconds = 0;
-    conn->rec_maximum_image_build_milliseconds = 0;
-    conn->rec_maximum_milliseconds = 0;
+    __wt_atomic_store_uint64_relaxed(&conn->rec_maximum_hs_wrapup_milliseconds, 0);
+    __wt_atomic_store_uint64_relaxed(&conn->rec_maximum_image_build_milliseconds, 0);
+    __wt_atomic_store_uint64_relaxed(&conn->rec_maximum_milliseconds, 0);
     conn->page_delta.max_internal_delta_count = 0;
     conn->page_delta.max_leaf_delta_count = 0;
 

--- a/src/conn/conn_stat.c
+++ b/src/conn/conn_stat.c
@@ -78,22 +78,26 @@ __wt_conn_stat_init(WT_SESSION_IMPL *session)
     __wt_evict_stats_update(session);
     __wt_txn_stats_update(session);
 
-    WT_STATP_CONN_SET(session, stats, file_open, conn->open_file_count);
+    WT_STATP_CONN_SET(
+      session, stats, file_open, __wt_atomic_load_uint32_relaxed(&conn->open_file_count));
     WT_STATP_CONN_SET(
       session, stats, cursor_open_count, __wt_atomic_load_uint32_relaxed(&conn->open_cursor_count));
-    WT_STATP_CONN_SET(session, stats, dh_conn_handle_count, conn->dhandle_count);
     WT_STATP_CONN_SET(
-      session, stats, dh_conn_handle_btree_count, conn->dhandle_types_count[WT_DHANDLE_TYPE_BTREE]);
-    WT_STATP_CONN_SET(
-      session, stats, dh_conn_handle_table_count, conn->dhandle_types_count[WT_DHANDLE_TYPE_TABLE]);
+      session, stats, dh_conn_handle_count, __wt_atomic_load_uint64_relaxed(&conn->dhandle_count));
+    WT_STATP_CONN_SET(session, stats, dh_conn_handle_btree_count,
+      __wt_atomic_load_uint64_relaxed(&conn->dhandle_types_count[WT_DHANDLE_TYPE_BTREE]));
+    WT_STATP_CONN_SET(session, stats, dh_conn_handle_table_count,
+      __wt_atomic_load_uint64_relaxed(&conn->dhandle_types_count[WT_DHANDLE_TYPE_TABLE]));
     WT_STATP_CONN_SET(session, stats, dh_conn_handle_tiered_count,
-      conn->dhandle_types_count[WT_DHANDLE_TYPE_TIERED]);
+      __wt_atomic_load_uint64_relaxed(&conn->dhandle_types_count[WT_DHANDLE_TYPE_TIERED]));
     WT_STATP_CONN_SET(session, stats, dh_conn_handle_tiered_tree_count,
-      conn->dhandle_types_count[WT_DHANDLE_TYPE_TIERED_TREE]);
-    WT_STATP_CONN_SET(
-      session, stats, dh_conn_handle_checkpoint_count, conn->dhandle_checkpoint_count);
-    WT_STATP_CONN_SET(session, stats, rec_split_stashed_objects, conn->stashed_objects);
-    WT_STATP_CONN_SET(session, stats, rec_split_stashed_bytes, conn->stashed_bytes);
+      __wt_atomic_load_uint64_relaxed(&conn->dhandle_types_count[WT_DHANDLE_TYPE_TIERED_TREE]));
+    WT_STATP_CONN_SET(session, stats, dh_conn_handle_checkpoint_count,
+      __wt_atomic_load_uint64_relaxed(&conn->dhandle_checkpoint_count));
+    WT_STATP_CONN_SET(session, stats, rec_split_stashed_objects,
+      __wt_atomic_load_uint64_relaxed(&conn->stashed_objects));
+    WT_STATP_CONN_SET(session, stats, rec_split_stashed_bytes,
+      __wt_atomic_load_uint64_relaxed(&conn->stashed_bytes));
 }
 
 /*

--- a/src/cursor/cur_std.c
+++ b/src/cursor/cur_std.c
@@ -757,7 +757,7 @@ __wti_cursor_cache(WT_CURSOR *cursor, WT_DATA_HANDLE *dhandle)
     TAILQ_REMOVE(&session->cursors, cursor, q);
     TAILQ_INSERT_HEAD(&session->cursor_cache[bucket], cursor, q);
 
-    (void)__wt_atomic_sub_uint32(&S2C(session)->open_cursor_count, 1);
+    (void)__wt_atomic_sub_uint32_relaxed(&S2C(session)->open_cursor_count, 1);
     WT_STAT_CONN_INCR_ATOMIC(session, cursor_cached_count);
     WT_STAT_DSRC_DECR(session, cursor_open_count);
     F_SET(cursor, WT_CURSTD_CACHED);
@@ -787,7 +787,7 @@ __wti_cursor_reopen(WT_CURSOR *cursor, WT_DATA_HANDLE *dhandle)
     __wt_cursor_dhandle_incr_use(session);
     WT_DHANDLE_RELEASE(dhandle);
 
-    (void)__wt_atomic_add_uint32(&S2C(session)->open_cursor_count, 1);
+    (void)__wt_atomic_add_uint32_relaxed(&S2C(session)->open_cursor_count, 1);
     WT_STAT_CONN_DECR_ATOMIC(session, cursor_cached_count);
     WT_STAT_DSRC_INCR(session, cursor_open_count);
 
@@ -1140,7 +1140,7 @@ __wt_cursor_close(WT_CURSOR *cursor)
     if (F_ISSET(cursor, WT_CURSTD_OPEN)) {
         TAILQ_REMOVE(&session->cursors, cursor, q);
 
-        (void)__wt_atomic_sub_uint32(&S2C(session)->open_cursor_count, 1);
+        (void)__wt_atomic_sub_uint32_relaxed(&S2C(session)->open_cursor_count, 1);
         WT_STAT_DSRC_DECR(session, cursor_open_count);
     }
     __wt_buf_free(session, &cursor->key);
@@ -1544,7 +1544,7 @@ __wt_cursor_init(
 
     /* WT_CURSTD_OPEN */
     F_SET(cursor, WT_CURSTD_OPEN);
-    (void)__wt_atomic_add_uint32(&S2C(session)->open_cursor_count, 1);
+    (void)__wt_atomic_add_uint32_relaxed(&S2C(session)->open_cursor_count, 1);
     WT_STAT_DSRC_INCR(session, cursor_open_count);
 
     *cursorp = (cdump != NULL) ? cdump : cursor;

--- a/src/evict/evict_conn.c
+++ b/src/evict/evict_conn.c
@@ -423,8 +423,8 @@ __wt_evict_stats_update(WT_SESSION_IMPL *session)
       __wt_atomic_load_uint64_relaxed(&evict->evict_max_ms));
     WT_STATP_CONN_SET(session, stats, eviction_maximum_milliseconds_per_checkpoint,
       __wt_atomic_load_uint64_relaxed(&evict->evict_max_ms_per_checkpoint));
-    WT_STATP_CONN_SET(
-      session, stats, eviction_reentry_hs_eviction_milliseconds, evict->reentry_hs_eviction_ms);
+    WT_STATP_CONN_SET(session, stats, eviction_reentry_hs_eviction_milliseconds,
+      __wt_atomic_load_uint64_relaxed(&evict->reentry_hs_eviction_ms));
     WT_STATP_CONN_SET(session, stats, eviction_maximum_unvisited_gen_gap,
       __wt_atomic_load_uint64_relaxed(&evict->evict_max_unvisited_gen_gap));
     WT_STATP_CONN_SET(session, stats, eviction_maximum_unvisited_gen_gap_per_checkpoint,
@@ -435,13 +435,14 @@ __wt_evict_stats_update(WT_SESSION_IMPL *session)
       __wt_atomic_load_uint64_relaxed(&evict->evict_max_visited_gen_gap_per_checkpoint));
     WT_STATP_CONN_SET(
       session, stats, eviction_state, __wt_atomic_load_uint32_relaxed(&evict->flags));
-    WT_STATP_CONN_SET(session, stats, eviction_aggressive_set, evict->evict_aggressive_score);
+    WT_STATP_CONN_SET(session, stats, eviction_aggressive_set,
+      __wt_atomic_load_uint32_relaxed(&evict->evict_aggressive_score));
     WT_STATP_CONN_SET(session, stats, eviction_empty_score, evict->evict_empty_score);
 
     WT_STATP_CONN_SET(session, stats, eviction_active_workers,
       __wt_atomic_load_uint32_relaxed(&conn->evict_threads.current_threads));
-    WT_STATP_CONN_SET(
-      session, stats, eviction_stable_state_workers, evict->evict_tune_workers_best);
+    WT_STATP_CONN_SET(session, stats, eviction_stable_state_workers,
+      __wt_atomic_load_uint32_relaxed(&evict->evict_tune_workers_best));
 
     /*
      * The number of files with active walks ~= number of hazard pointers in the walk session. Note:

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1326,8 +1326,8 @@ __evict_tune_workers(WT_SESSION_IMPL *session)
      */
     if (eviction_progress_rate > evict->evict_tune_progress_rate_max) {
         evict->evict_tune_progress_rate_max = eviction_progress_rate;
-        evict->evict_tune_workers_best =
-          __wt_atomic_load_uint32_relaxed(&conn->evict_threads.current_threads);
+        current_threads = __wt_atomic_load_uint32_relaxed(&conn->evict_threads.current_threads);
+        __wt_atomic_store_uint32_relaxed(&evict->evict_tune_workers_best, current_threads);
     }
 
     /*

--- a/src/include/block.h
+++ b/src/include/block.h
@@ -50,8 +50,8 @@
 struct __wt_extlist {
     char *name; /* Name */
 
-    uint64_t bytes;   /* Byte count */
-    uint32_t entries; /* Entry count */
+    wt_shared uint64_t bytes; /* Byte count */
+    uint32_t entries;         /* Entry count */
 
     uint32_t objectid; /* Written object ID */
     wt_off_t offset;   /* Written extent offset */

--- a/src/include/cache_inline.h
+++ b/src/include/cache_inline.h
@@ -15,7 +15,7 @@
 static WT_INLINE uint64_t
 __wt_cache_pages_inuse(WT_CACHE *cache)
 {
-    return (cache->pages_inmem - cache->pages_evicted);
+    return (__wt_atomic_load_uint64_relaxed(&cache->pages_inmem) - cache->pages_evicted);
 }
 
 /*

--- a/src/include/gcc.h
+++ b/src/include/gcc.h
@@ -349,6 +349,10 @@
     {                                                                                   \
         return (__atomic_sub_fetch(vp, v, __ATOMIC_SEQ_CST));                           \
     }                                                                                   \
+    static inline _type __wt_atomic_sub_##suffix##_relaxed(_type *vp, _type v)          \
+    {                                                                                   \
+        return (__atomic_sub_fetch(vp, v, __ATOMIC_RELAXED));                           \
+    }                                                                                   \
     static inline _type __wt_atomic_add_##suffix##_v(volatile _type *vp, _type v)       \
     {                                                                                   \
         return (__atomic_add_fetch(vp, v, __ATOMIC_SEQ_CST));                           \

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -522,3 +522,17 @@ __wt_atomic_stats_max(uint64_t *stat, uint64_t value)
         __wt_atomic_store_uint64_relaxed(stat, value);
     }
 }
+
+/*
+ * __wt_atomic_stats_min --
+ *     Calculate max statistic values. Currently we use load + store for that purpose since
+ *     statistic is allowed to be fuzzy. FIXME-WT-15755: Consider using relaxed CAS instead to
+ *     ensure it is lossless.
+ */
+static inline void
+__wt_atomic_stats_min(uint64_t *stat, uint64_t value)
+{
+    if (value < __wt_atomic_load_uint64_relaxed(stat)) {
+        __wt_atomic_store_uint64_relaxed(stat, value);
+    }
+}

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -525,7 +525,7 @@ __wt_atomic_stats_max(uint64_t *stat, uint64_t value)
 
 /*
  * __wt_atomic_stats_min --
- *     Calculate max statistic values. Currently we use load + store for that purpose since
+ *     Calculate min statistic values. Currently we use load + store for that purpose since
  *     statistic is allowed to be fuzzy. FIXME-WT-15755: Consider using relaxed CAS instead to
  *     ensure it is lossless.
  */

--- a/src/include/msvc.h
+++ b/src/include/msvc.h
@@ -164,6 +164,10 @@ WT_RELEASE_BARRIER(void)
     {                                                                                             \
         return (_InterlockedExchangeAdd##s((t *)(vp), -(t)v) - (v));                              \
     }                                                                                             \
+    static inline _type __wt_atomic_sub_##suffix##_relaxed(_type *vp, _type v)                    \
+    {                                                                                             \
+        return (_InterlockedExchangeAdd##s((t *)(vp), -(t)v) - (v));                              \
+    }                                                                                             \
     static inline _type __wt_atomic_add_##suffix##_v(volatile _type *vp, _type v)                 \
     {                                                                                             \
         return (_InterlockedExchangeAdd##s((t *)(vp), (t)(v)) + (v));                             \

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -246,6 +246,7 @@ __wt_stats_clear_dsrc(void *stats_arg, int slot)
     WT_STAT_INCRV_ATOMIC_BASE(session, S2C(session)->stats[(session)->stat_conn_bucket], fld, value)
 #define WT_STAT_CONN_INCR(session, fld) WT_STAT_CONN_INCRV(session, fld, 1)
 
+/* FIXME-WT-15961 Introduce thread-safe stats interfaces. */
 #define WT_STATP_CONN_SET(session, stats, fld, value)                           \
     do {                                                                        \
         if (WT_STAT_ENABLED(session)) {                                         \

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -178,6 +178,9 @@ __wt_stats_clear_dsrc(void *stats_arg, int slot)
  * The read statistics are separated into data-source or connection statistics as the counter slots
  * for the statistics are separate. The write statistics do not rely on counter slots in this way so
  * they do not need to be split.
+ *
+ * FIXME-WT-15752: Remove __wt_tsan_suppress_* wrappers and implement proper atomics synchronization
+ * where needed.
  */
 #define WT_STAT_ENABLED(session) (S2C(session)->stat_flags != 0)
 
@@ -202,6 +205,7 @@ __wt_stats_clear_dsrc(void *stats_arg, int slot)
         if (WT_STAT_ENABLED(session))                                     \
             __wt_tsan_suppress_sub_int64(&(stat)->fld, (int64_t)(value)); \
     } while (0)
+/* FIXME-WT-15754: Consider using relaxed memory order for all statistic operations. */
 #define WT_STAT_DECRV_ATOMIC_BASE(session, stat, fld, value)             \
     do {                                                                 \
         if (WT_STAT_ENABLED(session))                                    \

--- a/src/include/tsan_suppress.h
+++ b/src/include/tsan_suppress.h
@@ -233,12 +233,22 @@ __wt_tsan_suppress_store_pointer(void **vp, void *v)
 
 /*
  * __wt_tsan_suppress_memcpy --
- *     TSAN warnings suppression for memory copy.
+ *     TSAN warnings suppression for memcpy.
  */
 static WT_INLINE void *
 __wt_tsan_suppress_memcpy(void *dest, void *src, size_t count)
 {
     return (memcpy(dest, src, count));
+}
+
+/*
+ * __wt_tsan_suppress_memset --
+ *     TSAN warnings suppression for memset.
+ */
+static WT_INLINE void *
+__wt_tsan_suppress_memset(void *ptr, int val, size_t size)
+{
+    return (memset(ptr, val, size));
 }
 
 /*

--- a/src/os_common/os_alloc.c
+++ b/src/os_common/os_alloc.c
@@ -63,7 +63,7 @@ __wt_calloc(WT_SESSION_IMPL *session, size_t number, size_t size, void *retp)
     WT_ASSERT(session, number != 0 && size != 0);
 
     if (session != NULL)
-        WT_STAT_CONN_INCR(session, memory_allocation);
+        WT_STAT_CONN_INCR_ATOMIC(session, memory_allocation);
 
     if ((p = calloc(number, size)) == NULL)
         WT_RET_MSG(session, __wt_errno(), "memory allocation of %" WT_SIZET_FMT " bytes failed",
@@ -94,7 +94,7 @@ __wt_malloc(WT_SESSION_IMPL *session, size_t bytes_to_allocate, void *retp)
     WT_ASSERT(session, bytes_to_allocate != 0);
 
     if (session != NULL)
-        WT_STAT_CONN_INCR(session, memory_allocation);
+        WT_STAT_CONN_INCR_ATOMIC(session, memory_allocation);
 
     if ((p = malloc(bytes_to_allocate)) == NULL)
         WT_RET_MSG(session, __wt_errno(), "memory allocation of %" WT_SIZET_FMT " bytes failed",

--- a/src/os_posix/os_mtx_cond.c
+++ b/src/os_posix/os_mtx_cond.c
@@ -73,7 +73,7 @@ __wt_cond_wait_signal(WT_SESSION_IMPL *session, WT_CONDVAR *cond, uint64_t usecs
     }
 
     __wt_verbose_debug2(session, WT_VERB_MUTEX, "wait %s", cond->name);
-    WT_STAT_CONN_INCR(session, cond_wait);
+    WT_STAT_CONN_INCR_ATOMIC(session, cond_wait);
 
     WT_ERR(pthread_mutex_lock(&cond->mtx));
     locked = true;

--- a/src/os_win/os_mtx_cond.c
+++ b/src/os_win/os_mtx_cond.c
@@ -53,7 +53,7 @@ __wt_cond_wait_signal(WT_SESSION_IMPL *session, WT_CONDVAR *cond, uint64_t usecs
         return;
 
     __wt_verbose_debug2(session, WT_VERB_MUTEX, "wait %s", cond->name);
-    WT_STAT_CONN_INCR(session, cond_wait);
+    WT_STAT_CONN_INCR_ATOMIC(session, cond_wait);
 
     EnterCriticalSection(&cond->mtx);
     locked = true;

--- a/src/rollback_to_stable/rts_api.c
+++ b/src/rollback_to_stable/rts_api.c
@@ -175,7 +175,8 @@ __rollback_to_stable_int(WT_SESSION_IMPL *session, bool no_ckpt)
     /* Rollback the global durable timestamp to the stable timestamp. */
     if (!dryrun) {
         txn_global->has_durable_timestamp = txn_global->has_stable_timestamp;
-        txn_global->durable_timestamp = txn_global->stable_timestamp;
+        __wt_atomic_store_uint64_relaxed(
+          &txn_global->durable_timestamp, txn_global->stable_timestamp);
     }
     __rts_assert_timestamps_unchanged(session, pinned_timestamp, stable_timestamp);
 

--- a/src/support/generation.c
+++ b/src/support/generation.c
@@ -387,8 +387,8 @@ __stash_discard(WT_SESSION_IMPL *session, int which)
         if (stash->gen >= oldest)
             break;
 
-        (void)__wt_atomic_sub_uint64(&conn->stashed_bytes, stash->len);
-        (void)__wt_atomic_sub_uint64(&conn->stashed_objects, 1);
+        (void)__wt_atomic_sub_uint64_relaxed(&conn->stashed_bytes, stash->len);
+        (void)__wt_atomic_sub_uint64_relaxed(&conn->stashed_objects, 1);
 
         /*
          * It's a bad thing if another thread is in this memory after we free it, make sure nothing

--- a/src/support/mtx_rw.c
+++ b/src/support/mtx_rw.c
@@ -127,10 +127,10 @@ __wt_try_readlock(WT_SESSION_IMPL *session, WT_RWLOCK *l)
     WT_RWLOCK new, old;
     int64_t **stats;
 
-    WT_STAT_CONN_INCR(session, rwlock_read);
+    WT_STAT_CONN_INCR_ATOMIC(session, rwlock_read);
     if (l->stat_read_count_off != -1 && WT_STAT_ENABLED(session)) {
         stats = (int64_t **)S2C(session)->stats;
-        __wt_tsan_suppress_add_int64(&stats[session->stat_conn_bucket][l->stat_read_count_off], 1);
+        __wt_atomic_add_int64_relaxed(&stats[session->stat_conn_bucket][l->stat_read_count_off], 1);
     }
 
     old.u.v = __wt_atomic_load_uint64_v_relaxed(&l->u.v);
@@ -183,7 +183,7 @@ __wt_readlock(WT_SESSION_IMPL *session, WT_RWLOCK *l)
     uint8_t ticket;
     int pause_cnt;
 
-    WT_STAT_CONN_INCR(session, rwlock_read);
+    WT_STAT_CONN_INCR_ATOMIC(session, rwlock_read);
 
     WT_DIAGNOSTIC_YIELD;
 
@@ -255,13 +255,13 @@ stall:
         time_diff = WT_CLOCKDIFF_US(time_stop, time_start);
 
         stats = (int64_t **)S2C(session)->stats;
-        __wt_tsan_suppress_add_int64(&stats[session->stat_conn_bucket][l->stat_read_count_off], 1);
+        __wt_atomic_add_int64_relaxed(&stats[session->stat_conn_bucket][l->stat_read_count_off], 1);
         session_stats = (int64_t *)&(session->stats);
         if (F_ISSET(session, WT_SESSION_INTERNAL))
-            __wt_tsan_suppress_add_int64(
+            __wt_atomic_add_int64_relaxed(
               &stats[session->stat_conn_bucket][l->stat_int_usecs_off], (int64_t)time_diff);
         else {
-            __wt_tsan_suppress_add_int64(
+            __wt_atomic_add_int64_relaxed(
               &stats[session->stat_conn_bucket][l->stat_app_usecs_off], (int64_t)time_diff);
         }
 
@@ -270,7 +270,7 @@ stall:
          * initialized to determine whether they are enabled.
          */
         if (l->stat_session_usecs_off != -1)
-            __wt_tsan_suppress_add_int64(
+            __wt_atomic_add_int64_relaxed(
               &session_stats[l->stat_session_usecs_off], (int64_t)time_diff);
     }
 
@@ -332,10 +332,11 @@ __wt_try_writelock(WT_SESSION_IMPL *session, WT_RWLOCK *l)
     WT_RWLOCK new, old;
     int64_t **stats;
 
-    WT_STAT_CONN_INCR(session, rwlock_write);
+    WT_STAT_CONN_INCR_ATOMIC(session, rwlock_write);
     if (l->stat_write_count_off != -1 && WT_STAT_ENABLED(session)) {
         stats = (int64_t **)S2C(session)->stats;
-        __wt_tsan_suppress_add_int64(&stats[session->stat_conn_bucket][l->stat_write_count_off], 1);
+        __wt_atomic_add_int64_relaxed(
+          &stats[session->stat_conn_bucket][l->stat_write_count_off], 1);
     }
 
     /*
@@ -445,13 +446,14 @@ __wt_writelock(WT_SESSION_IMPL *session, WT_RWLOCK *l)
         time_diff = WT_CLOCKDIFF_US(time_stop, time_start);
 
         stats = (int64_t **)S2C(session)->stats;
-        __wt_tsan_suppress_add_int64(&stats[session->stat_conn_bucket][l->stat_write_count_off], 1);
+        __wt_atomic_add_int64_relaxed(
+          &stats[session->stat_conn_bucket][l->stat_write_count_off], 1);
         session_stats = (int64_t *)&(session->stats);
         if (F_ISSET(session, WT_SESSION_INTERNAL))
-            __wt_tsan_suppress_add_int64(
+            __wt_atomic_add_int64_relaxed(
               &stats[session->stat_conn_bucket][l->stat_int_usecs_off], (int64_t)time_diff);
         else
-            __wt_tsan_suppress_add_int64(
+            __wt_atomic_add_int64_relaxed(
               &stats[session->stat_conn_bucket][l->stat_app_usecs_off], (int64_t)time_diff);
 
         /*
@@ -459,7 +461,7 @@ __wt_writelock(WT_SESSION_IMPL *session, WT_RWLOCK *l)
          * initialized to determine whether they are enabled.
          */
         if (l->stat_session_usecs_off != -1)
-            __wt_tsan_suppress_add_int64(
+            __wt_atomic_add_int64_relaxed(
               &session_stats[l->stat_session_usecs_off], (int64_t)time_diff);
     }
 

--- a/src/support/thread_group.c
+++ b/src/support/thread_group.c
@@ -331,8 +331,11 @@ __wt_thread_group_destroy(WT_SESSION_IMPL *session, WT_THREAD_GROUP *group)
     /*
      * Clear out any settings from the group, some structures are reused for different thread groups
      * - in particular the eviction thread group for recovery and then normal runtime.
+     *
+     * TSAN suppression function is used here since the group.current_threads field could be
+     * accessed in parallel by __statlog_server.
      */
-    memset(group, 0, sizeof(*group));
+    __wt_tsan_suppress_memset(group, 0, sizeof(*group));
 
     return (ret);
 }

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -586,7 +586,7 @@ __recovery_set_oldest_timestamp(WT_RECOVERY *r)
      * of the last checkpoint for later query. This gets saved in the connection.
      */
     WT_RET(__wt_meta_read_checkpoint_oldest(r->session, NULL, &oldest_timestamp, NULL));
-    conn->txn_global.oldest_timestamp = oldest_timestamp;
+    __wt_atomic_store_uint64_relaxed(&conn->txn_global.oldest_timestamp, oldest_timestamp);
     __wt_atomic_store_bool_relaxed(
       &conn->txn_global.has_oldest_timestamp, oldest_timestamp != WT_TS_NONE);
 

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -460,7 +460,7 @@ set:
      * largest durable_timestamp so it moves forward whenever transactions are assigned timestamps).
      */
     if (has_durable) {
-        txn_global->durable_timestamp = durable_ts;
+        __wt_tsan_suppress_store_uint64(&txn_global->durable_timestamp, durable_ts);
         txn_global->has_durable_timestamp = true;
         WT_STAT_CONN_INCR(session, txn_set_ts_durable_upd);
         __wt_verbose_timestamp(session, durable_ts, "Updated global durable timestamp");
@@ -966,7 +966,7 @@ __wti_txn_set_read_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t read_ts)
             return (EINVAL);
         }
     } else
-        txn_shared->read_timestamp = read_ts;
+        __wt_tsan_suppress_store_uint64(&txn_shared->read_timestamp, read_ts);
 
     F_SET(txn, WT_TXN_SHARED_TS_READ);
     __wt_readunlock(session, &txn_global->rwlock);

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -1314,5 +1314,5 @@ __wti_txn_clear_read_timestamp(WT_SESSION_IMPL *session)
         WT_RELEASE_BARRIER();
         F_CLR(txn, WT_TXN_SHARED_TS_READ);
     }
-    __wt_atomic_store_uint64_relaxed(&txn_shared->read_timestamp, WT_TS_NONE);
+    __wt_tsan_suppress_store_uint64(&txn_shared->read_timestamp, WT_TS_NONE);
 }

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -469,7 +469,7 @@ set:
     if (has_oldest &&
       (!__wt_atomic_load_bool_relaxed(&txn_global->has_oldest_timestamp) || force ||
         oldest_ts > txn_global->oldest_timestamp)) {
-        txn_global->oldest_timestamp = oldest_ts;
+        __wt_atomic_store_uint64_relaxed(&txn_global->oldest_timestamp, oldest_ts);
         WT_STAT_CONN_INCR(session, txn_set_ts_oldest_upd);
         __wt_atomic_store_bool_relaxed(&txn_global->has_oldest_timestamp, true);
         txn_global->oldest_is_pinned = false;
@@ -1314,5 +1314,5 @@ __wti_txn_clear_read_timestamp(WT_SESSION_IMPL *session)
         WT_RELEASE_BARRIER();
         F_CLR(txn, WT_TXN_SHARED_TS_READ);
     }
-    __wt_tsan_suppress_store_uint64(&txn_shared->read_timestamp, WT_TS_NONE);
+    __wt_atomic_store_uint64_relaxed(&txn_shared->read_timestamp, WT_TS_NONE);
 }

--- a/test/evergreen/tsan_warnings.supp
+++ b/test/evergreen/tsan_warnings.supp
@@ -6,11 +6,6 @@
 # Stats are allowed to be fuzzy. Ignore races in TSan
 race:src/include/stat.h
 race:src/support/stat.c
-race:__wt_block_stat
-race:__wt_cache_stats_update
-race:__wt_checkpoint_timer_stats
-race:__wt_conn_stat_init
-race:__wt_evict_stats_update
 
 # These functions were created for fine-grained suppressions. Please search for appropriate FIXME tickets
 # around usages of these functions.


### PR DESCRIPTION
This PR fixes almost all the statistic issues reported by running python tests under TSAN. Warnings from stat.h remain suppressed (for now). Since we remove the suppression, the infrastructure now provides the necessary testing to show whether all the data races are gone in the changed places.