### PR TITLE
WT-15718 Favour internal SQLite3 library during build

### DIFF
--- a/cmake/configs/base.cmake
+++ b/cmake/configs/base.cmake
@@ -12,7 +12,6 @@ set(default_enable_iaa OFF)
 set(default_enable_debug_info ON)
 set(default_enable_static OFF)
 set(default_enable_shared ON)
-set(default_internal_sqlite3 ON)
 
 string(TOUPPER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE_UPPER)
 
@@ -341,6 +340,12 @@ config_bool(
 )
 
 config_bool(
+    ENABLE_PALITE
+    "Build the PALite storage extension (mock implementation of the PALI)"
+    DEFAULT ON
+)
+
+config_bool(
     ENABLE_LLVM
     "Enable compilation of LLVM-based tools and executables i.e. xray & fuzzer."
     DEFAULT OFF
@@ -359,17 +364,10 @@ config_string(
     DEFAULT "3.8"   # Minimum version for partial indexes (used in PALite)
 )
 
-# Use system provided sqlite3 if available.
-find_package(SQLite3 ${SQLITE3_REQUIRED_VERSION} QUIET)
-
-if(SQLite3_FOUND)
-    set(default_internal_sqlite3 OFF)
-endif()
-
 config_bool(
     ENABLE_INTERNAL_SQLITE3
     "Enable internal SQLite3 library. If disabled, the system SQLite3 library will be used."
-    DEFAULT ${default_internal_sqlite3}
+    DEFAULT ON
 )
 
 set(default_optimize_level "-Og")

--- a/cmake/configs/base.cmake
+++ b/cmake/configs/base.cmake
@@ -365,9 +365,9 @@ config_string(
 )
 
 config_bool(
-    ENABLE_INTERNAL_SQLITE3
-    "Enable internal SQLite3 library. If disabled, the system SQLite3 library will be used."
-    DEFAULT ON
+    USE_SYSTEM_SQLITE3
+    "Use system SQLite3 library. If OFF, WiredTiger will use the bundled SQLite3 library."
+    DEFAULT OFF
 )
 
 set(default_optimize_level "-Og")

--- a/cmake/third_party/sqlite3.cmake
+++ b/cmake/third_party/sqlite3.cmake
@@ -2,7 +2,7 @@ if(NOT ENABLE_PALITE)
     return() # PALite is disabled, skip the rest of this file
 endif()
 
-if(NOT ENABLE_INTERNAL_SQLITE3)
+if(USE_SYSTEM_SQLITE3)
     find_package(SQLite3 ${SQLITE3_REQUIRED_VERSION} REQUIRED)
     add_library(wt::sqlite3 ALIAS SQLite::SQLite3)
     return()

--- a/cmake/third_party/sqlite3.cmake
+++ b/cmake/third_party/sqlite3.cmake
@@ -1,3 +1,7 @@
+if(NOT ENABLE_PALITE)
+    return() # PALite is disabled, skip the rest of this file
+endif()
+
 if(NOT ENABLE_INTERNAL_SQLITE3)
     find_package(SQLite3 ${SQLITE3_REQUIRED_VERSION} REQUIRED)
     add_library(wt::sqlite3 ALIAS SQLite::SQLite3)
@@ -9,6 +13,23 @@ endif()
 message(CHECK_START "Looking for library SQLite3")
 
 set(SQLITE3_DIR ${CMAKE_SOURCE_DIR}/test/3rdparty/sqlite3)
+
+# Read the header file and find the SQLITE_VERSION definition
+file(STRINGS "${SQLITE3_DIR}/sqlite3.h" SQLITE_VERSION_LINE
+    REGEX "^#define[ \t]+SQLITE_VERSION[ \t]+\"[.0-9]+\"")
+# Extract the version string (e.g., "3.XX.YY") from the matched line
+string(REGEX MATCH "\"[.0-9]+\"" SQLITE3_VERSION "${SQLITE_VERSION_LINE}")
+# Strip the quotes from the version string
+string(REPLACE "\"" "" SQLITE3_VERSION "${SQLITE3_VERSION}")
+
+if(${SQLITE3_VERSION} VERSION_LESS ${SQLITE3_REQUIRED_VERSION})
+    message(FATAL_ERROR "Could NOT find SQLite3: Found unsuitable version"
+        " \"${SQLITE3_VERSION}\", but required is at least"
+        " \"${SQLITE3_REQUIRED_VERSION}\" (found ${SQLITE3_DIR})")
+else()
+    message(CHECK_PASS "Found internal SQLite3: ${SQLITE3_DIR}"
+        " (found version \"${SQLITE3_VERSION}\")")
+endif()
 
 add_library(sqlite3_lib STATIC
     ${SQLITE3_DIR}/sqlite3.c
@@ -32,12 +53,3 @@ add_executable(sqlite3
     ${SQLITE3_DIR}/shell.c
 )
 target_link_libraries(sqlite3 PRIVATE sqlite3_lib)
-
-# Read the header file and find the SQLITE_VERSION definition
-file(STRINGS "${SQLITE3_DIR}/sqlite3.h" SQLITE_VERSION_LINE
-    REGEX "^#define[ \t]+SQLITE_VERSION[ \t]+\"[.0-9]+\"")
-# Extract the version string (e.g., "3.XX.YY") from the matched line
-string(REGEX MATCH "\"[.0-9]+\"" SQLITE3_VERSION "${SQLITE_VERSION_LINE}")
-
-message(CHECK_PASS "Found internal SQLite3: ${SQLITE3_DIR}"
-    " (found version ${SQLITE3_VERSION})")

--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -22,7 +22,9 @@ if(WT_POSIX)
 
     # Build the page log extensions.
     add_subdirectory(page_log/palm)
-    add_subdirectory(page_log/palite)
+    if(ENABLE_PALITE)
+        add_subdirectory(page_log/palite)
+    endif()
 
     # Build the storage_sources extensions.
     add_subdirectory(storage_sources/dir_store)


### PR DESCRIPTION
- Add `ENABLE_PALITE` flag to control whether PALite is included in the build (default=ON)
- Set default preference for SQLite3 library: `ENABLE_INTERNAL_SQLITE3=ON`