### PR TITLE
WT-15758 Retry forever on read failures in disagg block manager

### DIFF
--- a/src/block_disagg/block_disagg_read.c
+++ b/src/block_disagg/block_disagg_read.c
@@ -67,7 +67,7 @@ __block_disagg_read_multiple(WT_SESSION_IMPL *session, WT_BLOCK_DISAGG *block_di
     WT_ITEM *current;
     WT_PAGE_LOG_GET_ARGS get_args;
     uint64_t time_start, time_stop;
-    uint32_t orig_count, retry;
+    uint32_t retry, tmp_count;
     int32_t last, result;
     uint8_t compatible_version, expected_magic;
     bool is_delta;
@@ -94,37 +94,35 @@ __block_disagg_read_multiple(WT_SESSION_IMPL *session, WT_BLOCK_DISAGG *block_di
         WT_STAT_CONN_INCRV(session, disagg_block_hs_byte_read, size);
     }
 
-    orig_count = *results_count;
-
-    for (retry = 0;; retry++) {
+    /*
+     * If the page server returns no data but doesn't explicitly fail with an error, retry the the
+     * read a few times in case the issue is transient.
+     *
+     * XXX: To support current testing, we never give up. It is better to hang here as that will
+     * allow us to generate a core dump if desired.
+     */
+    for (retry = 0, tmp_count = 0; tmp_count == 0; retry++) {
         if (retry > 0) {
-            /*
-             * The page server didn't return any data. Retry a few times in case this is a transient
-             * error.
-             *
-             * XXX: To support current testing, we never give up. It is better to hang here as that
-             * will allow us to generate a core dump if desired.
-             */
             __wt_verbose_notice(session, WT_VERB_READ,
               "retry #%" PRIu32 " for page_id %" PRIu64 ", flags %" PRIx64 ", lsn %" PRIu64
               ", base_lsn %" PRIu64 ", size %" PRIu32 ", checksum %" PRIx32,
               retry, page_id, flags, lsn, base_lsn, size, checksum);
 
             __wt_sleep(0, WT_MIN(10000 + retry * 5000, 500000));
-
-            *results_count = orig_count;
         }
+
+        tmp_count = *results_count;
+
         /*
          * Output buffers do not need to be pre-allocated, the PALI interface does that.
          */
         WT_ERR(block_disagg->plhandle->plh_get(block_disagg->plhandle, &session->iface, page_id, 0,
-          &get_args, results_array, results_count));
+          &get_args, results_array, &tmp_count));
 
-        WT_ASSERT(session, *results_count <= WT_DELTA_LIMIT + 1);
-
-        if (*results_count > 0)
-            break;
+        WT_ASSERT(session, tmp_count <= WT_DELTA_LIMIT + 1);
     }
+
+    *results_count = tmp_count;
 
     last = (int32_t)(*results_count - 1);
 

--- a/src/block_disagg/block_disagg_read.c
+++ b/src/block_disagg/block_disagg_read.c
@@ -96,14 +96,14 @@ __block_disagg_read_multiple(WT_SESSION_IMPL *session, WT_BLOCK_DISAGG *block_di
 
     orig_count = *results_count;
 
-    for (retry = 0; ; retry++) {
+    for (retry = 0;; retry++) {
         if (retry > 0) {
             /*
-             * The page server didn't return any data. Retry a few times in case this is a 
-             * transient error.
+             * The page server didn't return any data. Retry a few times in case this is a transient
+             * error.
              *
-             * XXX: To support current testing, we never give up. It is better to hang here as
-             * that will allow us to generate a core dump if desired.
+             * XXX: To support current testing, we never give up. It is better to hang here as that
+             * will allow us to generate a core dump if desired.
              */
             __wt_verbose_notice(session, WT_VERB_READ,
               "retry #%" PRIu32 " for page_id %" PRIu64 ", flags %" PRIx64 ", lsn %" PRIu64

--- a/src/block_disagg/block_disagg_read.c
+++ b/src/block_disagg/block_disagg_read.c
@@ -106,7 +106,8 @@ reread:
           "retry #%" PRIu32 " for page_id %" PRIu64 ", flags %" PRIx64 ", lsn %" PRIu64
           ", base_lsn %" PRIu64 ", size %" PRIu32 ", checksum %" PRIx32,
           retry, page_id, flags, lsn, base_lsn, size, checksum);
-        __wt_sleep(0, 10000 + retry * 5000);
+
+        __wt_sleep(0, WT_MIN(10000 + retry * 5000, 500000));
 
         for (i = 0; i < *results_count; i++)
             __wt_buf_free(session, &results_array[i]);
@@ -125,20 +126,13 @@ reread:
 
     if (*results_count == 0) {
         /*
-         * The page was not found for this page id. This would normally be an error, as we will
-         * never ask for a page that we haven't previously written. However, if it hasn't
-         * materialized yet in the page service, this can happen, so retry with a delay.
+         * We didn't get any data back from the page read. Retry a few times in case this is a
+         * transient error.
          *
-         * This code may go away once we establish a way to ask for a particular delta, and the PALI
-         * interface will be obligated to wait until it appears.
+         * XXX: Currently we retry forever as we would rather hang in testing so we can 
+         * more easily get a core dump if needed. 
          */
-        if (retry < 100)
-            goto reread;
-        __wt_verbose_error(session, WT_VERB_READ,
-          "%s: read failed for table ID %" PRIu64 ", page ID %" PRIu64 ", flags %" PRIx64
-          ", lsn %" PRIu64 ", base_lsn %" PRIu64 ", size %" PRIu32 ", checksum %" PRIx32,
-          block_disagg->name, block_disagg->tableid, page_id, flags, lsn, base_lsn, size, checksum);
-        WT_ERR(EIO);
+         goto reread;
     }
 
     last = (int32_t)(*results_count - 1);

--- a/src/block_disagg/block_disagg_read.c
+++ b/src/block_disagg/block_disagg_read.c
@@ -112,10 +112,6 @@ __block_disagg_read_multiple(WT_SESSION_IMPL *session, WT_BLOCK_DISAGG *block_di
 
             __wt_sleep(0, WT_MIN(10000 + retry * 5000, 500000));
 
-            for (i = 0; i < *results_count; i++)
-                __wt_buf_free(session, &results_array[i]);
-
-            memset(results_array, 0, *results_count * sizeof(results_array[0]));
             *results_count = orig_count;
         }
         /*

--- a/src/block_disagg/block_disagg_read.c
+++ b/src/block_disagg/block_disagg_read.c
@@ -67,7 +67,7 @@ __block_disagg_read_multiple(WT_SESSION_IMPL *session, WT_BLOCK_DISAGG *block_di
     WT_ITEM *current;
     WT_PAGE_LOG_GET_ARGS get_args;
     uint64_t time_start, time_stop;
-    uint32_t i, orig_count, retry;
+    uint32_t orig_count, retry;
     int32_t last, result;
     uint8_t compatible_version, expected_magic;
     bool is_delta;
@@ -96,43 +96,38 @@ __block_disagg_read_multiple(WT_SESSION_IMPL *session, WT_BLOCK_DISAGG *block_di
 
     orig_count = *results_count;
 
-    if (0) {
-reread:
+    for (retry = 0; ; retry++) {
+        if (retry > 0) {
+            /*
+             * The page server didn't return any data. Retry a few times in case this is a 
+             * transient error.
+             *
+             * XXX: To support current testing, we never give up. It is better to hang here as
+             * that will allow us to generate a core dump if desired.
+             */
+            __wt_verbose_notice(session, WT_VERB_READ,
+              "retry #%" PRIu32 " for page_id %" PRIu64 ", flags %" PRIx64 ", lsn %" PRIu64
+              ", base_lsn %" PRIu64 ", size %" PRIu32 ", checksum %" PRIx32,
+              retry, page_id, flags, lsn, base_lsn, size, checksum);
+
+            __wt_sleep(0, WT_MIN(10000 + retry * 5000, 500000));
+
+            for (i = 0; i < *results_count; i++)
+                __wt_buf_free(session, &results_array[i]);
+
+            memset(results_array, 0, *results_count * sizeof(results_array[0]));
+            *results_count = orig_count;
+        }
         /*
-         * Retry a read again. This code may go away once we establish a way to ask for a particular
-         * delta.
+         * Output buffers do not need to be pre-allocated, the PALI interface does that.
          */
-        __wt_verbose_notice(session, WT_VERB_READ,
-          "retry #%" PRIu32 " for page_id %" PRIu64 ", flags %" PRIx64 ", lsn %" PRIu64
-          ", base_lsn %" PRIu64 ", size %" PRIu32 ", checksum %" PRIx32,
-          retry, page_id, flags, lsn, base_lsn, size, checksum);
+        WT_ERR(block_disagg->plhandle->plh_get(block_disagg->plhandle, &session->iface, page_id, 0,
+          &get_args, results_array, results_count));
 
-        __wt_sleep(0, WT_MIN(10000 + retry * 5000, 500000));
+        WT_ASSERT(session, *results_count <= WT_DELTA_LIMIT + 1);
 
-        for (i = 0; i < *results_count; i++)
-            __wt_buf_free(session, &results_array[i]);
-
-        memset(results_array, 0, *results_count * sizeof(results_array[0]));
-        *results_count = orig_count;
-        ++retry;
-    }
-    /*
-     * Output buffers do not need to be pre-allocated, the PALI interface does that.
-     */
-    WT_ERR(block_disagg->plhandle->plh_get(block_disagg->plhandle, &session->iface, page_id, 0,
-      &get_args, results_array, results_count));
-
-    WT_ASSERT(session, *results_count <= WT_DELTA_LIMIT + 1);
-
-    if (*results_count == 0) {
-        /*
-         * We didn't get any data back from the page read. Retry a few times in case this is a
-         * transient error.
-         *
-         * XXX: Currently we retry forever as we would rather hang in testing so we can 
-         * more easily get a core dump if needed. 
-         */
-         goto reread;
+        if (*results_count > 0)
+            break;
     }
 
     last = (int32_t)(*results_count - 1);

--- a/src/block_disagg/block_disagg_read.c
+++ b/src/block_disagg/block_disagg_read.c
@@ -74,8 +74,6 @@ __block_disagg_read_multiple(WT_SESSION_IMPL *session, WT_BLOCK_DISAGG *block_di
 
     time_start = __wt_clock(session);
 
-    retry = 0;
-
     WT_CLEAR(get_args);
     get_args.lsn = lsn;
     WT_ASSERT(session, block_meta != NULL);

--- a/src/block_disagg/block_disagg_read.c
+++ b/src/block_disagg/block_disagg_read.c
@@ -96,8 +96,9 @@ __block_disagg_read_multiple(WT_SESSION_IMPL *session, WT_BLOCK_DISAGG *block_di
      * If the page server returns no data but doesn't explicitly fail with an error, retry the the
      * read a few times in case the issue is transient.
      *
-     * XXX: To support current testing, we never give up. It is better to hang here as that will
-     * allow us to generate a core dump if desired.
+     * FIXME: WT-15768: To support current testing, we never give up. It is better to hang here as
+     * that will allow us to generate a core dump if desired. We should revisit this when we have
+     * more complete end-to-end story for handling read failures.
      */
     for (retry = 0, tmp_count = 0; tmp_count == 0; retry++) {
         if (retry > 0) {


### PR DESCRIPTION
To better support current testing, change the disagg block manager to retry indefinitely if it gets no data back on a read.

I also included some refactoring in this PR, adding an actual loop for the retries and eliminating some dead code (because `*results_count == 0` in that code making it do nothing).
