### PR TITLE
WT-15560 Fix failing assertion when unpacking a prepared tombstone

### DIFF
--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -951,15 +951,11 @@ copy_cell_restart:
              * recovering, all transaction ids are reset to WT_TXN_NONE, so we cannot compare the
              * transaction ids.
              */
-            if (tw->start_txn == tw->stop_txn) {
+            if (tw->start_txn == tw->stop_txn && temp_stop_ts == WT_TS_NONE) {
                 /*
                  * This is a special case where both transaction start and stop are in prepared
-                 * state.
-                 */
-                WT_ASSERT(session, temp_stop_ts == WT_TS_NONE);
-                /*
-                 * The prepared record is written with the preserve prepared config enabled. The
-                 * same prepared id is packed to WT_CELL_TS_DURABLE_START.
+                 * state. The prepared record is written with the preserve prepared config enabled.
+                 * The same prepared id is packed to WT_CELL_TS_DURABLE_START.
                  */
                 if (temp_durable_start_ts != WT_TS_NONE) {
                     WT_ASSERT(session, temp_durable_stop_ts == WT_TS_NONE);
@@ -1001,7 +997,7 @@ copy_cell_restart:
                       "Read prepared record with no prepared id when preserve prepared is "
                       "enabled.");
             } else {
-                WT_ASSERT(session, tw->start_ts == WT_TXN_NONE);
+                WT_ASSERT(session, tw->start_ts == WT_TS_NONE);
                 /*
                  * This case happens when only transaction start is prepared, and there is no
                  * transaction stop. In this case, we store the prepare ts in WT_CELL_TS_START.

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -955,7 +955,9 @@ copy_cell_restart:
                 /*
                  * This is a special case where both transaction start and stop are in prepared
                  * state. The prepared record is written with the preserve prepared config enabled.
-                 * The same prepared id is packed to WT_CELL_TS_DURABLE_START.
+                 * The same prepared id is packed to WT_CELL_TS_DURABLE_START. Since temp_stop_ts
+                 * here stores the difference between start_prepared_id and stop_prepared_id,
+                 * temp_stop_ts must be 0.
                  */
                 if (temp_durable_start_ts != WT_TS_NONE) {
                     WT_ASSERT(session, temp_durable_stop_ts == WT_TS_NONE);

--- a/test/suite/test_prepare_discover04.py
+++ b/test/suite/test_prepare_discover04.py
@@ -44,7 +44,11 @@ class test_prepare_discover04(wttest.WiredTigerTestCase, suite_subprocess):
         ('txn_commit', dict(txn_commit=True)),
         ('txn_rollback', dict(txn_commit=False)),
     ]
-    scenarios = make_scenarios(txn_end)
+    move_stable_ts = [
+        ('move_stable_ts', dict(move_stable_ts=True)),
+        ('keep_stable_ts', dict(move_stable_ts=False)),
+    ]
+    scenarios = make_scenarios(txn_end, move_stable_ts)
 
     def test_prepare_discover04(self):
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(50))
@@ -95,5 +99,6 @@ class test_prepare_discover04(wttest.WiredTigerTestCase, suite_subprocess):
                 c2s2.rollback_transaction("rollback_timestamp=" + self.timestamp_str(200))
 
         self.assertEqual(count, 1)
-        conn2.set_timestamp('stable_timestamp=' + self.timestamp_str(220))
+        if self.move_stable_ts:
+            conn2.set_timestamp('stable_timestamp=' + self.timestamp_str(220))
         c2s2.checkpoint()

--- a/test/suite/test_prepare_discover05.py
+++ b/test/suite/test_prepare_discover05.py
@@ -95,5 +95,20 @@ class test_prepare_discover04(wttest.WiredTigerTestCase, suite_subprocess):
                 c2s2.rollback_transaction("rollback_timestamp=" + self.timestamp_str(200))
 
         self.assertEqual(count, 1)
-        conn2.set_timestamp('stable_timestamp=' + self.timestamp_str(220))
+
+        # Force eviction to trigger reconciliation, since we haven't moved stable timestamp, all updates should be saved to disk
+        # as prepared
+        session_evict = conn2.open_session("debug=(release_evict_page=true)")
+        session_evict.begin_transaction("ignore_prepare=true")
+        evict_cursor = session_evict.open_cursor(self.uri, None, None)
+        for i in range(1, 2):
+            evict_cursor.set_key(i)
+            evict_cursor.search()
+            evict_cursor.reset()
+        evict_cursor.close()
+        session_evict.rollback_transaction()
+        session_evict.close()
+
+        # Calling checkpoint, as part of disk verification it will try to unpack cells that were written by eviction.
+        # Unpacking these cells should not cause the program to crash
         c2s2.checkpoint()


### PR DESCRIPTION
This PR fixes an edge case when unpacking a cell with stop_txn == start_txn == 0. Consider this scenario with precise_checkpoint=ON and preserve_prepared=ON:

- A prepared tombstone with a globally visible start is saved to disk. At this point, start_txn = 0 and stop_txn != 0
- In recovery, we unpack this cell and reset all the cell's start & stop txn to 0.
- Prepare discover cursor claims the tombstone update. However we don't create a new transaction for this claim prepare work, so `stop_txn` never got assigned a new txn id.
- If stable ts doesn't move and we call a checkpoint,  the tombstone will still be saved as prepared (because stop ts is not stable). It will be saved as prepared and stop_txn = 0 == start_txn, which fails a validity rule when unpack again.

This PR fixes that by relaxing the cell unpacking validity rule.