### PR TITLE
WT-15707 Reducing the test/format runs and fix test/checkpoint issues for disagg variants

### DIFF
--- a/test/checkpoint/CMakeLists.txt
+++ b/test/checkpoint/CMakeLists.txt
@@ -77,7 +77,7 @@ define_test_variants(test_checkpoint
 # Define long running test variants for the disagg test
 define_test_variants(test_checkpoint
     VARIANTS
-        "disagg_leader_row_server_93028|-d leader -t r -W 50 -r 2 -s 1 -x -n 100000 -k 100000 -C cache_size=250MB"
+        "disagg_leader_row_server_93028|-d leader -t r -W 50 -r 2 -s 1 -x -n 100000 -k 100000 -C cache_size=1500MB"
     LABELS
         check
         disagg

--- a/test/checkpoint/CMakeLists.txt
+++ b/test/checkpoint/CMakeLists.txt
@@ -77,6 +77,7 @@ define_test_variants(test_checkpoint
 # Define long running test variants for the disagg test
 define_test_variants(test_checkpoint
     VARIANTS
+        # FIXME-WT-15723: Re-evaluate whether setting large cache size is need after cache stuck issue is solved.
         "disagg_leader_row_server_93028|-d leader -t r -W 50 -r 2 -s 1 -x -n 100000 -k 100000 -C cache_size=1500MB"
     LABELS
         check

--- a/test/checkpoint/recovery-test.sh
+++ b/test/checkpoint/recovery-test.sh
@@ -45,6 +45,11 @@ while kill -STOP $pid ; do
 	cp $home/* $backup
 	kill -CONT $pid
 	cp $backup/* $recovery
+
+	# Timestamp must be set for disaggregate configuration.
+	if [ -n "$disagg_config" ]; then
+		disagg_config+=" -x"
+	fi
 	./${bin} $disagg_config -t r -D -v -h $recovery || exit 1
 done
 

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1541,7 +1541,7 @@ variables:
       - func: "fetch artifacts"
       - func: "format test disagg"
         vars:
-          format_args: disagg.page_log=palite disagg.mode=leader runs.tables=3 runs.timer=15:30
+          format_args: disagg.page_log=palite disagg.mode=leader runs.tables=3 runs.timer=10:15
           times: 5
 
   - &format-stress-data-validation-test-disagg-leader-palite
@@ -1552,7 +1552,7 @@ variables:
       - func: "format test disagg"
         vars:
           # Validate data with a non-layered table.
-          format_args: disagg.page_log=palite disagg.mode=leader ops.verify=1 runs.mirror=1 table1.runs.source=table table1.disagg.enabled=0 runs.tables=2 runs.timer=15:30
+          format_args: disagg.page_log=palite disagg.mode=leader ops.verify=1 runs.mirror=1 table1.runs.source=table table1.disagg.enabled=0 runs.tables=2 runs.timer=10:15
           times: 5
 
   - &format-stress-test-disagg-switch-palite
@@ -1562,7 +1562,7 @@ variables:
       - func: "fetch artifacts"
       - func: "format test disagg"
         vars:
-          format_args: disagg.page_log=palite disagg.mode=switch runs.tables=1 runs.timer=15:30
+          format_args: disagg.page_log=palite disagg.mode=switch runs.tables=1 runs.timer=10:15
           times: 5
 
   - &format-stress-test-disagg-follower-palite
@@ -1572,7 +1572,7 @@ variables:
       - func: "fetch artifacts"
       - func: "format test disagg"
         vars:
-          format_args: disagg.page_log=palite disagg.mode=follower runs.timer=15:30
+          format_args: disagg.page_log=palite disagg.mode=follower runs.timer=10:15
           times: 10
 
   - &format-stress-data-validation-test-disagg-follower-palite
@@ -1582,7 +1582,7 @@ variables:
       - func: "fetch artifacts"
       - func: "format test disagg"
         vars:
-          format_args: disagg.page_log=palite disagg.mode=follower ops.verify=1 runs.mirror=1 runs.timer=15:30
+          format_args: disagg.page_log=palite disagg.mode=follower ops.verify=1 runs.mirror=1 runs.timer=10:15
           times: 10
 
   - &format-stress-test

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1522,7 +1522,7 @@ variables:
       - func: "format test disagg"
         vars:
           format_args: disagg.mode=follower
-          times: 5
+          times: 10
 
   - &format-stress-data-validation-test-disagg-follower
     depends_on:
@@ -1532,7 +1532,7 @@ variables:
       - func: "format test disagg"
         vars:
           format_args: disagg.mode=follower ops.verify=1 runs.mirror=1
-          times: 5
+          times: 10
 
   - &format-stress-test-disagg-leader-palite
     depends_on:
@@ -1541,7 +1541,7 @@ variables:
       - func: "fetch artifacts"
       - func: "format test disagg"
         vars:
-          format_args: disagg.page_log=palite disagg.mode=leader runs.tables=3
+          format_args: disagg.page_log=palite disagg.mode=leader runs.tables=3 runs.timer=15:30
           times: 5
 
   - &format-stress-data-validation-test-disagg-leader-palite
@@ -1552,7 +1552,7 @@ variables:
       - func: "format test disagg"
         vars:
           # Validate data with a non-layered table.
-          format_args: disagg.page_log=palite disagg.mode=leader ops.verify=1 runs.mirror=1 table1.runs.source=table table1.disagg.enabled=0 runs.tables=2
+          format_args: disagg.page_log=palite disagg.mode=leader ops.verify=1 runs.mirror=1 table1.runs.source=table table1.disagg.enabled=0 runs.tables=2 runs.timer=15:30
           times: 5
 
   - &format-stress-test-disagg-switch-palite
@@ -1562,7 +1562,7 @@ variables:
       - func: "fetch artifacts"
       - func: "format test disagg"
         vars:
-          format_args: disagg.page_log=palite disagg.mode=switch runs.tables=1
+          format_args: disagg.page_log=palite disagg.mode=switch runs.tables=1 runs.timer=15:30
           times: 5
 
   - &format-stress-test-disagg-follower-palite
@@ -1572,8 +1572,8 @@ variables:
       - func: "fetch artifacts"
       - func: "format test disagg"
         vars:
-          format_args: disagg.page_log=palite disagg.mode=follower
-          times: 5
+          format_args: disagg.page_log=palite disagg.mode=follower runs.timer=15:30
+          times: 10
 
   - &format-stress-data-validation-test-disagg-follower-palite
     depends_on:
@@ -1582,8 +1582,8 @@ variables:
       - func: "fetch artifacts"
       - func: "format test disagg"
         vars:
-          format_args: disagg.page_log=palite disagg.mode=follower ops.verify=1 runs.mirror=1
-          times: 5
+          format_args: disagg.page_log=palite disagg.mode=follower ops.verify=1 runs.mirror=1 runs.timer=15:30
+          times: 10
 
   - &format-stress-test
     exec_timeout_secs: 25200
@@ -4555,12 +4555,6 @@ tasks:
   - <<: *format-stress-test-disagg-leader
     name: format-stress-test-disagg-leader-3
     tags: ["stress-test-disagg-fail"]
-  - <<: *format-stress-test-disagg-leader
-    name: format-stress-test-disagg-leader-4
-    tags: ["stress-test-disagg-fail"]
-  - <<: *format-stress-test-disagg-leader
-    name: format-stress-test-disagg-leader-5
-    tags: ["stress-test-disagg-fail"]
   - <<: *format-stress-data-validation-test-disagg-leader
     name: format-stress-data-validation-test-disagg-leader-1
     tags: ["stress-test-disagg-fail"]
@@ -4569,12 +4563,6 @@ tasks:
     tags: ["stress-test-disagg-fail"]
   - <<: *format-stress-data-validation-test-disagg-leader
     name: format-stress-data-validation-test-disagg-leader-3
-    tags: ["stress-test-disagg-fail"]
-  - <<: *format-stress-data-validation-test-disagg-leader
-    name: format-stress-data-validation-test-disagg-leader-4
-    tags: ["stress-test-disagg-fail"]
-  - <<: *format-stress-data-validation-test-disagg-leader
-    name: format-stress-data-validation-test-disagg-leader-5
     tags: ["stress-test-disagg-fail"]
   - <<: *format-stress-test-disagg-follower
     name: format-stress-test-disagg-follower-1
@@ -4585,12 +4573,6 @@ tasks:
   - <<: *format-stress-test-disagg-follower
     name: format-stress-test-disagg-follower-3
     tags: ["stress-test-disagg"]
-  - <<: *format-stress-test-disagg-follower
-    name: format-stress-test-disagg-follower-4
-    tags: ["stress-test-disagg"]
-  - <<: *format-stress-test-disagg-follower
-    name: format-stress-test-disagg-follower-5
-    tags: ["stress-test-disagg"]
   - <<: *format-stress-data-validation-test-disagg-follower
     name: format-stress-data-validation-test-disagg-follower-1
     tags: ["stress-test-disagg"]
@@ -4599,12 +4581,6 @@ tasks:
     tags: ["stress-test-disagg"]
   - <<: *format-stress-data-validation-test-disagg-follower
     name: format-stress-data-validation-test-disagg-follower-3
-    tags: ["stress-test-disagg"]
-  - <<: *format-stress-data-validation-test-disagg-follower
-    name: format-stress-data-validation-test-disagg-follower-4
-    tags: ["stress-test-disagg"]
-  - <<: *format-stress-data-validation-test-disagg-follower
-    name: format-stress-data-validation-test-disagg-follower-5
     tags: ["stress-test-disagg"]
   # FIXME-WT-14566: Enable disagg switch mode on all platforms once failures have been resolved.
   - <<: *format-stress-test-disagg-switch
@@ -4615,12 +4591,6 @@ tasks:
     tags: ["stress-test-disagg-fail"]
   - <<: *format-stress-test-disagg-switch
     name: format-stress-test-disagg-switch-3
-    tags: ["stress-test-disagg-fail"]
-  - <<: *format-stress-test-disagg-switch
-    name: format-stress-test-disagg-switch-4
-    tags: ["stress-test-disagg-fail"]
-  - <<: *format-stress-test-disagg-switch
-    name: format-stress-test-disagg-switch-5
     tags: ["stress-test-disagg-fail"]
 
    # FIXME-WT-14566: Enable disagg leader mode on all platforms once failures have been resolved.
@@ -4633,12 +4603,6 @@ tasks:
   - <<: *format-stress-test-disagg-leader-palite
     name: format-stress-test-disagg-leader-palite-3
     tags: ["stress-test-disagg-fail"]
-  - <<: *format-stress-test-disagg-leader-palite
-    name: format-stress-test-disagg-leader-palite-4
-    tags: ["stress-test-disagg-fail"]
-  - <<: *format-stress-test-disagg-leader-palite
-    name: format-stress-test-disagg-leader-palite-5
-    tags: ["stress-test-disagg-fail"]
   - <<: *format-stress-data-validation-test-disagg-leader-palite
     name: format-stress-data-validation-test-disagg-leader-palite-1
     tags: ["stress-test-disagg-fail"]
@@ -4647,12 +4611,6 @@ tasks:
     tags: ["stress-test-disagg-fail"]
   - <<: *format-stress-data-validation-test-disagg-leader-palite
     name: format-stress-data-validation-test-disagg-leader-palite-3
-    tags: ["stress-test-disagg-fail"]
-  - <<: *format-stress-data-validation-test-disagg-leader-palite
-    name: format-stress-data-validation-test-disagg-leader-palite-4
-    tags: ["stress-test-disagg-fail"]
-  - <<: *format-stress-data-validation-test-disagg-leader-palite
-    name: format-stress-data-validation-test-disagg-leader-palite-5
     tags: ["stress-test-disagg-fail"]
   - <<: *format-stress-test-disagg-follower-palite
     name: format-stress-test-disagg-follower-palite-1
@@ -4663,12 +4621,6 @@ tasks:
   - <<: *format-stress-test-disagg-follower-palite
     name: format-stress-test-disagg-follower-palite-3
     tags: ["stress-test-disagg"]
-  - <<: *format-stress-test-disagg-follower-palite
-    name: format-stress-test-disagg-follower-palite-4
-    tags: ["stress-test-disagg"]
-  - <<: *format-stress-test-disagg-follower-palite
-    name: format-stress-test-disagg-follower-palite-5
-    tags: ["stress-test-disagg"]
   - <<: *format-stress-data-validation-test-disagg-follower-palite
     name: format-stress-data-validation-test-disagg-follower-palite-1
     tags: ["stress-test-disagg"]
@@ -4677,12 +4629,6 @@ tasks:
     tags: ["stress-test-disagg"]
   - <<: *format-stress-data-validation-test-disagg-follower-palite
     name: format-stress-data-validation-test-disagg-follower-palite-3
-    tags: ["stress-test-disagg"]
-  - <<: *format-stress-data-validation-test-disagg-follower-palite
-    name: format-stress-data-validation-test-disagg-follower-palite-4
-    tags: ["stress-test-disagg"]
-  - <<: *format-stress-data-validation-test-disagg-follower-palite
-    name: format-stress-data-validation-test-disagg-follower-palite-5
     tags: ["stress-test-disagg"]
   # FIXME-WT-14566: Enable disagg switch mode on all platforms once failures have been resolved.
   - <<: *format-stress-test-disagg-switch-palite
@@ -4693,12 +4639,6 @@ tasks:
     tags: ["stress-test-disagg-fail"]
   - <<: *format-stress-test-disagg-switch-palite
     name: format-stress-test-disagg-switch-palite-3
-    tags: ["stress-test-disagg-fail"]
-  - <<: *format-stress-test-disagg-switch-palite
-    name: format-stress-test-disagg-switch-palite-4
-    tags: ["stress-test-disagg-fail"]
-  - <<: *format-stress-test-disagg-switch-palite
-    name: format-stress-test-disagg-switch-palite-5
     tags: ["stress-test-disagg-fail"]
 
   - name: format-stress-test-no-barrier

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1191,7 +1191,7 @@ functions:
         # Check if we running in disagg mode.
         disagg_args=""
         if [[ "${disagg_run|false}" == "true" ]]; then
-            disagg_args="-d leader -t row -x"
+            disagg_args="-d leader -t row -x -C cache_size=500MB"
         fi
         ./test_checkpoint ${checkpoint_args} $disagg_args  2>&1
 
@@ -1207,7 +1207,7 @@ functions:
         ${PREPARE_TEST_ENV}
         disagg_args=""
         if [[ "${disagg_run|false}" == "true" ]]; then
-            disagg_args="-d leader -t row -x"
+            disagg_args="-d leader -t row -x -C cache_size=500MB"
         fi
         ../../../test/evergreen/checkpoint_test_predictable.sh ${times} "${checkpoint_args} $disagg_args"
 

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1514,26 +1514,6 @@ variables:
           format_args: disagg.mode=switch runs.rows=100000:300000 runs.tables=1:3 runs.ops=300000
           times: 5
 
-  - &format-stress-test-disagg-follower
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "format test disagg"
-        vars:
-          format_args: disagg.mode=follower
-          times: 10
-
-  - &format-stress-data-validation-test-disagg-follower
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "format test disagg"
-        vars:
-          format_args: disagg.mode=follower ops.verify=1 runs.mirror=1
-          times: 10
-
   - &format-stress-test-disagg-leader-palite
     depends_on:
       - name: compile
@@ -1565,7 +1545,7 @@ variables:
           format_args: disagg.page_log=palite disagg.mode=switch runs.timer=10:15
           times: 5
 
-  - &format-stress-test-disagg-follower-palite
+  - &format-stress-test-disagg-follower
     depends_on:
       - name: compile
     commands:
@@ -1575,7 +1555,7 @@ variables:
           format_args: disagg.page_log=palite disagg.mode=follower runs.timer=10:15
           times: 10
 
-  - &format-stress-data-validation-test-disagg-follower-palite
+  - &format-stress-data-validation-test-disagg-follower
     depends_on:
       - name: compile
     commands:
@@ -4612,24 +4592,6 @@ tasks:
   - <<: *format-stress-data-validation-test-disagg-leader-palite
     name: format-stress-data-validation-test-disagg-leader-palite-3
     tags: ["stress-test-disagg-fail"]
-  - <<: *format-stress-test-disagg-follower-palite
-    name: format-stress-test-disagg-follower-palite-1
-    tags: ["stress-test-disagg"]
-  - <<: *format-stress-test-disagg-follower-palite
-    name: format-stress-test-disagg-follower-palite-2
-    tags: ["stress-test-disagg"]
-  - <<: *format-stress-test-disagg-follower-palite
-    name: format-stress-test-disagg-follower-palite-3
-    tags: ["stress-test-disagg"]
-  - <<: *format-stress-data-validation-test-disagg-follower-palite
-    name: format-stress-data-validation-test-disagg-follower-palite-1
-    tags: ["stress-test-disagg"]
-  - <<: *format-stress-data-validation-test-disagg-follower-palite
-    name: format-stress-data-validation-test-disagg-follower-palite-2
-    tags: ["stress-test-disagg"]
-  - <<: *format-stress-data-validation-test-disagg-follower-palite
-    name: format-stress-data-validation-test-disagg-follower-palite-3
-    tags: ["stress-test-disagg"]
   # FIXME-WT-14566: Enable disagg switch mode on all platforms once failures have been resolved.
   - <<: *format-stress-test-disagg-switch-palite
     name: format-stress-test-disagg-switch-palite-1

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1191,7 +1191,7 @@ functions:
         # Check if we running in disagg mode.
         disagg_args=""
         if [[ "${disagg_run|false}" == "true" ]]; then
-            disagg_args="-d leader -t row -x -C cache_size=500MB"
+            disagg_args="-d leader -t row -x -C cache_size=1000MB"
         fi
         ./test_checkpoint ${checkpoint_args} $disagg_args  2>&1
 
@@ -1207,7 +1207,7 @@ functions:
         ${PREPARE_TEST_ENV}
         disagg_args=""
         if [[ "${disagg_run|false}" == "true" ]]; then
-            disagg_args="-d leader -t row -x -C cache_size=500MB"
+            disagg_args="-d leader -t row -x -C cache_size=1000MB"
         fi
         ../../../test/evergreen/checkpoint_test_predictable.sh ${times} "${checkpoint_args} $disagg_args"
 
@@ -1541,7 +1541,7 @@ variables:
       - func: "fetch artifacts"
       - func: "format test disagg"
         vars:
-          format_args: disagg.page_log=palite disagg.mode=leader runs.tables=3 runs.timer=10:15
+          format_args: disagg.page_log=palite disagg.mode=leader runs.timer=10:15
           times: 5
 
   - &format-stress-data-validation-test-disagg-leader-palite
@@ -1562,7 +1562,7 @@ variables:
       - func: "fetch artifacts"
       - func: "format test disagg"
         vars:
-          format_args: disagg.page_log=palite disagg.mode=switch runs.tables=1 runs.timer=10:15
+          format_args: disagg.page_log=palite disagg.mode=switch runs.timer=10:15
           times: 5
 
   - &format-stress-test-disagg-follower-palite

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1191,6 +1191,7 @@ functions:
         # Check if we running in disagg mode.
         disagg_args=""
         if [[ "${disagg_run|false}" == "true" ]]; then
+            # FIXME-WT-15723: Re-evaluate whether setting large cache size is need after cache stuck issue is solved.
             disagg_args="-d leader -t row -x -C cache_size=1000MB"
         fi
         ./test_checkpoint ${checkpoint_args} $disagg_args  2>&1
@@ -1207,6 +1208,7 @@ functions:
         ${PREPARE_TEST_ENV}
         disagg_args=""
         if [[ "${disagg_run|false}" == "true" ]]; then
+            # FIXME-WT-15723: Re-evaluate whether setting large cache size is need after cache stuck issue is solved.
             disagg_args="-d leader -t row -x -C cache_size=1000MB"
         fi
         ../../../test/evergreen/checkpoint_test_predictable.sh ${times} "${checkpoint_args} $disagg_args"

--- a/test/format/format_config.c
+++ b/test/format/format_config.c
@@ -734,9 +734,9 @@ config_cache(void)
     cache *= workers;
     cache *= 2;
 
-    /* 
+    /*
      * FIXME-WT-15723: Re-evaluate whether setting large cache size is need after cache stuck issue
-     * is solved. 
+     * is solved.
      */
     if (GV(PRECISE_CHECKPOINT))
         cache *= 6;

--- a/test/format/format_config.c
+++ b/test/format/format_config.c
@@ -734,6 +734,10 @@ config_cache(void)
     cache *= workers;
     cache *= 2;
 
+    /* 
+     * FIXME-WT-15723: Re-evaluate whether setting large cache size is need after cache stuck issue
+     * is solved. 
+     */
     if (GV(PRECISE_CHECKPOINT))
         cache *= 6;
 


### PR DESCRIPTION
PAlite introduced much more test/format runs. It is not feasible to have as many test/format tests as we use to.  HThis pull request has these changes:
- Reduce the number of test/format runs. 
- Fixed test_checkpoint timeout and usage issues. [WT-15665](https://jira.mongodb.org/browse/WT-15665),  [WT-15749](https://jira.mongodb.org/browse/WT-15749)
- Limit stress configurations so we don't get test/format timeouts e.g. WT-15733