### PR TITLE
WT-15773 Fix unit test on MacOS

### DIFF
--- a/ext/page_log/palite/CMakeLists.txt
+++ b/ext/page_log/palite/CMakeLists.txt
@@ -11,7 +11,7 @@ else()
 endif()
 
 if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS CXX_COMPILER_MIN_VERSION)
-    message(WARNING "Skipping PALite build: C++ compiler does not support C++20."
+    message(FATAL_ERROR "Cannot build PALite: C++ compiler does not support C++20."
         "Required version: ${CXX_COMPILER_MIN_VERSION}; found: ${CMAKE_CXX_COMPILER_VERSION}")
     return()
 endif()

--- a/ext/page_log/palite/CMakeLists.txt
+++ b/ext/page_log/palite/CMakeLists.txt
@@ -11,7 +11,7 @@ else()
 endif()
 
 if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS CXX_COMPILER_MIN_VERSION)
-    message(FATAL_ERROR "Cannot build PALite: C++ compiler does not support C++20."
+    message(FATAL_ERROR "Cannot build PALite: C++ compiler does not support C++20. "
         "Required version: ${CXX_COMPILER_MIN_VERSION}; found: ${CMAKE_CXX_COMPILER_VERSION}")
     return()
 endif()

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -558,8 +558,9 @@ functions:
               if [ -d cmake_build ]; then rm -r cmake_build; fi
               mkdir -p cmake_build
               pushd cmake_build
-              # Adding -DENABLE_PYTHON=1 -DENABLE_STRICT=1 as 6.0 does not default these like develop.
-              $CMAKE -DCMAKE_C_FLAGS="-DMIGHT_NOT_RUN -Wno-error" -DENABLE_PYTHON=1 -DENABLE_STRICT=1 ../.
+              # Adding -DENABLE_PYTHON=ON -DENABLE_STRICT=ON as 6.0 does not default these like develop.
+              # Disable PALite build, as docs build does not need it and it can fail to build on some platforms.
+              $CMAKE -DCMAKE_C_FLAGS="-DMIGHT_NOT_RUN -Wno-error" -DENABLE_PYTHON=ON -DENABLE_STRICT=ON -DENABLE_PALITE=OFF ../.
               make -C lang/python -j ${num_jobs}
             fi
             # Pop to root project directory.

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -320,6 +320,8 @@ functions:
 
           if [ "${build_variant|}" = "macos-14-arm64" ]; then
             DEFINED_EVERGREEN_CONFIG_FLAGS="$DEFINED_EVERGREEN_CONFIG_FLAGS -DPython3_EXECUTABLE=$SYSPY -DPython3_LIBRARY=$SYSPYLIB -DPython3_INCLUDE_DIR=$SYSPYINCDEF"
+            # FIXME-WT-15777 PALite currently does not build on macOS 14 (ARM64) because of outdated CLang.
+            DEFINED_EVERGREEN_CONFIG_FLAGS="$DEFINED_EVERGREEN_CONFIG_FLAGS -DENABLE_PALITE=OFF"
           else
             DEFINED_EVERGREEN_CONFIG_FLAGS="$DEFINED_EVERGREEN_CONFIG_FLAGS -DPYTHON_EXECUTABLE:FILEPATH=$SYSPY -DPYTHON_LIBRARY=$SYSPYLIB -DPYTHON_INCLUDE_DIR=$SYSPYINCDEF"
           fi
@@ -1459,6 +1461,8 @@ variables:
         export DYLD_LIBRARY_PATH=$WT_BUILDDIR
       # Must disable TCMALLOC as it may be picked up locally and its not on all hosts.
       ENABLE_TCMALLOC: 0
+      # FIXME-WT-15777 Use PALM for unit tests for now until we can build PALite on macos-14.
+      unit_test_variant_args: "page_log=palm"
     tasks:
       - name: compile
         # This is a special case and should *only* be used for the macOS buildvariant.

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -321,8 +321,6 @@ functions:
 
           if [ "${build_variant|}" = "macos-14-arm64" ]; then
             DEFINED_EVERGREEN_CONFIG_FLAGS="$DEFINED_EVERGREEN_CONFIG_FLAGS -DPython3_EXECUTABLE=$SYSPY -DPython3_LIBRARY=$SYSPYLIB -DPython3_INCLUDE_DIR=$SYSPYINCDEF"
-            # FIXME-WT-15777 PALite currently does not build on macOS 14 (ARM64) because of outdated CLang.
-            DEFINED_EVERGREEN_CONFIG_FLAGS="$DEFINED_EVERGREEN_CONFIG_FLAGS -DENABLE_PALITE=OFF"
           else
             DEFINED_EVERGREEN_CONFIG_FLAGS="$DEFINED_EVERGREEN_CONFIG_FLAGS -DPYTHON_EXECUTABLE:FILEPATH=$SYSPY -DPYTHON_LIBRARY=$SYSPYLIB -DPYTHON_INCLUDE_DIR=$SYSPYINCDEF"
           fi
@@ -1456,6 +1454,8 @@ variables:
       # We'll explicitly use the python3 in /usr/bin, we use the same in configuring cmake.
       CMAKE_TOOLCHAIN_FILE:
       CC_OPTIMIZE_LEVEL: -DCC_OPTIMIZE_LEVEL=-O0
+      # FIXME-WT-15777 PALite currently does not build on macOS 14 (ARM64) because of outdated CLang.
+      ENABLE_PALITE: -DENABLE_PALITE=OFF
       num_jobs: $(echo $(sysctl -n hw.logicalcpu) / 2 | bc)
       cmake_generator: "Unix Makefiles"
       additional_env_vars: |

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -280,6 +280,7 @@ functions:
           ${ENABLE_CPPSUITE|} \
           ${ENABLE_GCP|} \
           ${ENABLE_S3|} \
+          ${ENABLE_PALITE|-DENABLE_PALITE=ON} \
           ${IMPORT_AZURE_SDK|} \
           ${IMPORT_GCP_SDK|} \
           ${IMPORT_S3_SDK|} \
@@ -1716,18 +1717,22 @@ tasks:
       - func: "compile wiredtiger"
         vars:
           GNU_C_VERSION: -DGNU_C_VERSION=7
+          ENABLE_PALITE: -DENABLE_PALITE=OFF
       - func: "compile wiredtiger"
         vars:
           GNU_C_VERSION: -DGNU_C_VERSION=8
           GNU_CXX_VERSION: -DGNU_CXX_VERSION=8
+          ENABLE_PALITE: -DENABLE_PALITE=OFF
       - func: "compile wiredtiger"
         vars:
           GNU_C_VERSION: -DGNU_C_VERSION=9
           GNU_CXX_VERSION: -DGNU_CXX_VERSION=9
+          ENABLE_PALITE: -DENABLE_PALITE=OFF
       - func: "compile wiredtiger"
         vars:
           GNU_C_VERSION: -DGNU_C_VERSION=11
           GNU_CXX_VERSION: -DGNU_CXX_VERSION=11
+          ENABLE_PALITE: -DENABLE_PALITE=OFF
 
   - name: compile-clang
     tags: ["pull_request", "pull_request_compilers"]
@@ -1749,30 +1754,37 @@ tasks:
         vars:
           CLANG_C_VERSION: -DCLANG_C_VERSION=7
           CLANG_CXX_VERSION: -DCLANG_CXX_VERSION=7
+          ENABLE_PALITE: -DENABLE_PALITE=OFF
       - func: "compile wiredtiger"
         vars:
           CLANG_C_VERSION: -DCLANG_C_VERSION=8
           CLANG_CXX_VERSION: -DCLANG_CXX_VERSION=8
+          ENABLE_PALITE: -DENABLE_PALITE=OFF
       - func: "compile wiredtiger"
         vars:
           CLANG_C_VERSION: -DCLANG_C_VERSION=9
           CLANG_CXX_VERSION: -DCLANG_CXX_VERSION=9
+          ENABLE_PALITE: -DENABLE_PALITE=OFF
       - func: "compile wiredtiger"
         vars:
           CLANG_C_VERSION: -DCLANG_C_VERSION=10
           CLANG_CXX_VERSION: -DCLANG_CXX_VERSION=10
+          ENABLE_PALITE: -DENABLE_PALITE=OFF
       - func: "compile wiredtiger"
         vars:
           CLANG_C_VERSION: -DCLANG_C_VERSION=11
           CLANG_CXX_VERSION: -DCLANG_CXX_VERSION=12
+          ENABLE_PALITE: -DENABLE_PALITE=OFF
       - func: "compile wiredtiger"
         vars:
           CLANG_C_VERSION: -DCLANG_C_VERSION=13
           CLANG_CXX_VERSION: -DCLANG_CXX_VERSION=13
+          ENABLE_PALITE: -DENABLE_PALITE=OFF
       - func: "compile wiredtiger"
         vars:
           CLANG_C_VERSION: -DCLANG_C_VERSION=14
           CLANG_CXX_VERSION: -DCLANG_CXX_VERSION=14
+          ENABLE_PALITE: -DENABLE_PALITE=OFF
 
   # Compile WiredTiger with uncommon build flags to make sure we compile code that
   # is often pre-processed out.

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -519,7 +519,7 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
         # tearDown needs a conn field, set it here in case the open fails.
         self.conn = None
         try:
-            self.conn = self.setUpConnectionOpen(".")
+            self.conn = self.setUpConnectionOpen(self.testdir)
             self.session = self.setUpSessionOpen(self.conn)
         except:
             self.tearDown()

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -519,7 +519,7 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
         # tearDown needs a conn field, set it here in case the open fails.
         self.conn = None
         try:
-            self.conn = self.setUpConnectionOpen(self.testdir)
+            self.conn = self.setUpConnectionOpen(".")
             self.session = self.setUpSessionOpen(self.conn)
         except:
             self.tearDown()


### PR DESCRIPTION
- If `ENABLE_PALITE=ON` and compiler does not support PALite build, then make it a cmake error.
- Run `unit-test-macos` with PALM for now, until newer compiler is available for MacOS builds.