### PR TITLE
Revert "WT-15589 Make sure we're not reading ahead of materialization frontier (#12561)"

### DIFF
--- a/dist/api_err.py
+++ b/dist/api_err.py
@@ -186,7 +186,7 @@ sub_errors = [
         a checkpoint.'''),
     Error('WT_MODIFY_READ_UNCOMMITTED', -32012,
         "Read-uncommitted readers do not support reconstructing a record with modifies", '''
-        This sub-level error indicates that a reader with uncommitted isolation
+        This sub-level error indicates that a reader with uncommitted isolation 
         is trying to reconstruct a record with modifies. This is not supported.'''),
     Error('WT_CONFLICT_LIVE_RESTORE', -32013,
         "Conflict performing operation due to an in-progress live restore", '''
@@ -195,10 +195,7 @@ sub_errors = [
     Error('WT_CONFLICT_DISAGG', -32014,
         "Conflict with disaggregated storage", '''
         This sub-level error indicates that an operation or configuration conflicts with
-        disaggregated storage.'''),
-    Error('WT_DISAGG_BAD_LSN', -32015,
-        "Attempt to operate on a wrong LSN number", '''
-        This sub-level error indicates that an operation with a bad LSN number was attempted.'''),
+        disaggregated storage.'''),     
 ]
 
 # Update the #defines in the wiredtiger.h.in file.
@@ -272,7 +269,7 @@ wiredtiger_strerror(int error)
 
 /*
  * __wt_is_valid_sub_level_error --
- *\tReturn true if the provided error falls within the valid range for sub level error codes,
+ *\tReturn true if the provided error falls within the valid range for sub level error codes, 
  *\treturn false otherwise.
  */
 bool
@@ -295,7 +292,7 @@ for line in open(doc, 'r'):
         tfile.write(line)
     skip = check_write_document_errors(tfile, skip, 'ERR', errors)
     skip = check_write_document_errors(tfile, skip, 'SUB_ERR', sub_errors)
-
+    
 tfile.close()
 format_srcfile(tmp_file)
 compare_srcfile(tmp_file, doc)

--- a/src/block_disagg/block_disagg_read.c
+++ b/src/block_disagg/block_disagg_read.c
@@ -53,35 +53,6 @@ __block_disagg_read_checksum_err(WT_SESSION_IMPL *session, const char *name, uin
 }
 
 /*
- * __block_disagg_check_lsn_frontier --
- *     Check that the LSN is not ahead of the materialization frontier.
- *
- * FIXME-WT-15760: make sure last_materialized_lsn is properly updated on secondaries.
- */
-static int
-__block_disagg_check_lsn_frontier(WT_SESSION_IMPL *session, uint64_t lsn)
-{
-    uint64_t last_materialized_lsn;
-
-    WT_ACQUIRE_READ(
-      last_materialized_lsn, S2C(session)->disaggregated_storage.last_materialized_lsn);
-    if (last_materialized_lsn != WT_DISAGG_LSN_NONE &&
-      /*
-       * FIXME-WT-15759 last_materialized_lsn = 0 means it's not initialized yet but we're reading
-       * something.
-       */
-      lsn > last_materialized_lsn) {
-        WT_RET_SUB_MSG(session, EINVAL, WT_DISAGG_BAD_LSN,
-          "Attempted to read page with LSN %" PRIu64
-          " ahead of the materialization frontier at "
-          "LSN %" PRIu64,
-          lsn, last_materialized_lsn);
-        return (EINVAL);
-    }
-    return (0);
-}
-
-/*
  * __block_disagg_read_multiple --
  *     Read a full page along with its deltas, into multiple buffers. The page is referenced by a
  *     page id, checkpoint id pair.
@@ -111,8 +82,6 @@ __block_disagg_read_multiple(WT_SESSION_IMPL *session, WT_BLOCK_DISAGG *block_di
       "page_id %" PRIu64 ", flags %" PRIx64 ", lsn %" PRIu64 ", base_lsn %" PRIu64 ", size %" PRIu32
       ", checksum %" PRIx32,
       page_id, flags, lsn, base_lsn, size, checksum);
-
-    WT_RET(__block_disagg_check_lsn_frontier(session, lsn));
 
     WT_STAT_CONN_INCR(session, disagg_block_get);
     WT_STAT_CONN_INCR(session, block_read);

--- a/src/conn/api_strerror.c
+++ b/src/conn/api_strerror.c
@@ -77,8 +77,6 @@ __wt_wiredtiger_error(int error)
           "restore");
     case WT_CONFLICT_DISAGG:
         return ("WT_CONFLICT_DISAGG: Conflict with disaggregated storage");
-    case WT_DISAGG_BAD_LSN:
-        return ("WT_DISAGG_BAD_LSN: Attempt to operate on a wrong LSN number");
     }
 
     /* Windows strerror doesn't support ENOTSUP. */

--- a/src/docs/error-handling.dox
+++ b/src/docs/error-handling.dox
@@ -158,9 +158,6 @@ running live restore in the system.
 This sub-level error indicates that an operation or configuration conflicts with disaggregated
 storage.
 
-@par \c WT_DISAGG_BAD_LSN
-This sub-level error indicates that an operation with a bad LSN number was attempted.
-
 @if IGNORE_BUILT_BY_API_ERR_END
 @endif
 

--- a/src/include/error.h
+++ b/src/include/error.h
@@ -154,14 +154,6 @@
         __wt_session_set_last_error(session, v, sub_v, __VA_ARGS__); \
         return (__ret);                                              \
     } while (0)
-#define WT_RET_SUB_MSG(session, v, sub_v, ...)                       \
-    do {                                                             \
-        int __ret = (v);                                             \
-        __wt_error_log_add_helper(#v, __ret, sub_v);                 \
-        __wt_err(session, __ret, __VA_ARGS__);                       \
-        __wt_session_set_last_error(session, v, sub_v, __VA_ARGS__); \
-        return (__ret);                                              \
-    } while (0)
 #define WT_RET_TEST(a, v)                              \
     do {                                               \
         if (a) {                                       \

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -4361,7 +4361,7 @@ const char *wiredtiger_version(int *majorp, int *minorp, int *patchp)
 #define	WT_CONFLICT_CHECKPOINT_LOCK	(-32011)
 /*!
  * Read-uncommitted readers do not support reconstructing a record with modifies.
- * This sub-level error indicates that a reader with uncommitted isolation is
+ * This sub-level error indicates that a reader with uncommitted isolation  is
  * trying to reconstruct a record with modifies. This is not supported.
  */
 #define	WT_MODIFY_READ_UNCOMMITTED	(-32012)
@@ -4377,12 +4377,6 @@ const char *wiredtiger_version(int *majorp, int *minorp, int *patchp)
  * with disaggregated storage.
  */
 #define	WT_CONFLICT_DISAGG	(-32014)
-/*!
- * Attempt to operate on a wrong LSN number.
- * This sub-level error indicates that an operation with a bad LSN number was
- * attempted.
- */
-#define	WT_DISAGG_BAD_LSN	(-32015)
 /*
  * Sub-level error return section: END
  * DO NOT EDIT: automatically built by dist/api_err.py.


### PR DESCRIPTION
Revert "WT-15589 Make sure we're not reading ahead of materialization frontier (#12561)" as it caused fallouts