### PR TITLE
WT-15706 Fix many-collection-test mongo build

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -123,20 +123,15 @@ functions:
         # Pulled from evergreen/generate_evergreen_engflow_bazelrc.sh
         # FIXME-SERVER-86966: consider consolidating once prelude.sh is runnable in the perf project.
 
-        source ./evergreen/bazel_RBE_supported.sh
+        uri="https://spruce.mongodb.com/task/${task_id}?execution=${execution}"
 
-        if bazel_rbe_supported; then
-
-          uri="https://spruce.mongodb.com/task/${task_id}?execution=${execution}"
-
-          echo "build --tls_client_certificate=./engflow.cert" > .bazelrc.evergreen_engflow_creds
-          echo "build --tls_client_key=./engflow.key" >> .bazelrc.evergreen_engflow_creds
-          echo "build --bes_keywords=engflow:CiCdPipelineName=${build_variant}" >> .bazelrc.evergreen_engflow_creds
-          echo "build --bes_keywords=engflow:CiCdJobName=${task_name}" >> .bazelrc.evergreen_engflow_creds
-          echo "build --bes_keywords=engflow:CiCdUri=$uri" >> .bazelrc.evergreen_engflow_creds
-          echo "build --bes_keywords=evg:project=${project}" >> .bazelrc.evergreen_engflow_creds
-          echo "build --workspace_status_command=./evergreen/engflow_workspace_status.sh" >> .bazelrc.evergreen_engflow_creds
-        fi
+        echo "build --tls_client_certificate=./engflow.cert" > .bazelrc.evergreen_engflow_creds
+        echo "build --tls_client_key=./engflow.key" >> .bazelrc.evergreen_engflow_creds
+        echo "build --bes_keywords=engflow:CiCdPipelineName=${build_variant}" >> .bazelrc.evergreen_engflow_creds
+        echo "build --bes_keywords=engflow:CiCdJobName=${task_name}" >> .bazelrc.evergreen_engflow_creds
+        echo "build --bes_keywords=engflow:CiCdUri=$uri" >> .bazelrc.evergreen_engflow_creds
+        echo "build --bes_keywords=evg:project=${project}" >> .bazelrc.evergreen_engflow_creds
+        echo "build --workspace_status_command=./evergreen/engflow_workspace_status.sh" >> .bazelrc.evergreen_engflow_creds
   "get project":
     command: git.get_project
     type: setup


### PR DESCRIPTION
Currently many collection test is failing due to absence of `bazel_RBE_supported.sh` that was removed from the Mongo repo recently. According to the MongoDB `generate_evergreen_engflow_bazelrc.sh` calling this script could be safely removed now. Please see all the info in the ticket.
