### PR TITLE
WT-15662 Fix handling of EBUSY in tests

### DIFF
--- a/test/suite/test_backup05.py
+++ b/test/suite/test_backup05.py
@@ -71,7 +71,7 @@ class test_backup05(wttest.WiredTigerTestCase, suite_subprocess):
         # Open the new directory and verify
         conn = self.setUpConnectionOpen(newdir)
         session = self.setUpSessionOpen(conn)
-        session.verify(self.uri)
+        self.verifyUntilSuccess(session)
         conn.close()
 
     def backup(self):

--- a/test/suite/test_checkpoint01.py
+++ b/test/suite/test_checkpoint01.py
@@ -108,7 +108,7 @@ class test_checkpoint(wttest.WiredTigerTestCase):
     # should, and no other checkpoints exist.
     def check(self):
         # Physically verify the file, including the individual checkpoints.
-        self.session.verify(self.uri, None)
+        self.verifyUntilSuccess()
 
         for checkpoint_name, entry in self.checkpoints.items():
             if entry[1] == 0:

--- a/test/suite/test_cursor12.py
+++ b/test/suite/test_cursor12.py
@@ -331,7 +331,7 @@ class test_cursor12(wttest.WiredTigerTestCase):
         self.conn.close()
         self.conn = self.setUpConnectionOpen(newdir)
         self.session = self.setUpSessionOpen(self.conn)
-        self.session.verify(self.uri)
+        self.verifyUntilSuccess()
 
         self.modify_confirm(ds, False)
 

--- a/test/suite/test_durability01.py
+++ b/test/suite/test_durability01.py
@@ -47,7 +47,7 @@ class test_durability01(wttest.WiredTigerTestCase, suite_subprocess):
         # Open the new directory
         conn = self.setUpConnectionOpen(newdir)
         session = self.setUpSessionOpen(conn)
-        session.verify(self.uri)
+        self.verifyUntilSuccess(session)
         conn.close()
 
     def test_durability(self):

--- a/test/suite/test_layered44.py
+++ b/test/suite/test_layered44.py
@@ -133,4 +133,4 @@ class test_layered44(wttest.WiredTigerTestCase):
                 page_number = int(line.split('page_id')[1].split(',')[0].strip())
                 self.assertNotIn(page_number, freed_pages, f"Unexpected page read: {page_number}")
         self.assertGreater(num_pages_read, 0)
-        self.session.verify(self.uri)
+        self.verifyUntilSuccess()

--- a/test/suite/test_truncate03.py
+++ b/test/suite/test_truncate03.py
@@ -59,7 +59,7 @@ class test_truncate_address_deleted(wttest.WiredTigerTestCase):
             key_format=self.key_format, value_format = self.value_format, config=self.config)
         ds.populate()
         self.reopen_conn()
-        self.session.verify(self.uri)
+        self.verifyUntilSuccess()
 
         if self.value_format == '8t':
             changed_value = 0xfe
@@ -86,7 +86,7 @@ class test_truncate_address_deleted(wttest.WiredTigerTestCase):
 
         # Crash/reopen the connection and verify the object.
         self.reopen_conn()
-        self.session.verify(self.uri)
+        self.verifyUntilSuccess()
 
         # Open a cursor and update a record (to dirty the tree, else we won't
         # mark pages with address-deleted cells dirty), then walk the tree so
@@ -150,7 +150,7 @@ class test_truncate_address_deleted(wttest.WiredTigerTestCase):
 
         self.session.checkpoint()
         self.reopen_conn()
-        self.session.verify(self.uri)
+        self.verifyUntilSuccess()
 
         cursor = ds.open_cursor(self.uri, None)
         for i in range(3000, 7000, 137):

--- a/test/suite/test_truncate18.py
+++ b/test/suite/test_truncate18.py
@@ -216,4 +216,4 @@ class test_truncate18(wttest.WiredTigerTestCase):
         self.reopen_conn()
 
         # Now verify the tree. In the problem scenario described above, this will assert.
-        self.session.verify(ds.uri, None)
+        self.verifyUntilSuccess(uri=ds.uri)

--- a/test/suite/test_truncate29.py
+++ b/test/suite/test_truncate29.py
@@ -97,4 +97,4 @@ class test_truncate29(wttest.WiredTigerTestCase):
         pinned_cursor.close()
         s1.rollback_transaction()
 
-        self.session.verify(self.uri, None)
+        self.verifyUntilSuccess()

--- a/test/suite/test_verify.py
+++ b/test/suite/test_verify.py
@@ -244,7 +244,7 @@ class test_verify(wttest.WiredTigerTestCase, suite_subprocess):
         offset = 0
         lines = open('dump.out').readlines()
         for line in lines:
-            m = re.search('(\d+)-(\d+).*row-store leaf', line)
+            m = re.search(r'(\d+)-(\d+).*row-store leaf', line)
             if m:
                 offset = int((int(m.group(2)) - int(m.group(1)))/2)
                 break

--- a/test/suite/test_verify_disagg.py
+++ b/test/suite/test_verify_disagg.py
@@ -76,7 +76,7 @@ class test_verify_disagg(wttest.WiredTigerTestCase):
                 self.assertRaisesException(wiredtiger.WiredTigerError, \
                     lambda: session.verify(self.uri), os.strerror(expected_error))
             else:
-                session.verify(self.uri)
+                self.verifyUntilSuccess()
 
     def create_follower(self):
         self.conn_follow = self.wiredtiger_open('follower', self.extensionsConfig() + ',create,' +

--- a/test/suite/test_verify_disagg.py
+++ b/test/suite/test_verify_disagg.py
@@ -76,7 +76,7 @@ class test_verify_disagg(wttest.WiredTigerTestCase):
                 self.assertRaisesException(wiredtiger.WiredTigerError, \
                     lambda: session.verify(self.uri), os.strerror(expected_error))
             else:
-                self.verifyUntilSuccess()
+                self.verifyUntilSuccess(session)
 
     def create_follower(self):
         self.conn_follow = self.wiredtiger_open('follower', self.extensionsConfig() + ',create,' +

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -857,7 +857,9 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
         return func()
 
     # TODO-WT-15791 review instances of "session.compact(...)" and replace with "self.compactUntilSuccess" where appropriate.
-    def compactUntilSuccess(self, session, uri, config=None):
+    def compactUntilSuccess(self, session=None, uri=None, config=None):
+        session = self.session if session is None else session
+        uri = self.uri if uri is None else uri
         return self.retryEBUSY(session, lambda: session.compact(uri, config), checkpoint_on_busy=False, max_retries=100, sleep=0.1)
 
     # TODO-WT-15791 review instances of "session.drop(...)" and replace with "self.dropUntilSuccess" where appropriate.

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -856,13 +856,13 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
         # One last try, if it fails we let the exception propagate.
         return func()
 
-    # TODO-WT-15791 review instances of "session.compact(...)" and replace with "self.compactUntilSuccess" where appropriate.
+    # FIXME-WT-15791 review instances of "session.compact(...)" and replace with "self.compactUntilSuccess" where appropriate.
     def compactUntilSuccess(self, session=None, uri=None, config=None, **kwargs):
         session = self.session if session is None else session
         uri = self.uri if uri is None else uri
         return self.retryEBUSY(session, lambda: session.compact(uri, config), checkpoint_on_busy=False, max_retries=100, sleep=0.1, **kwargs)
 
-    # TODO-WT-15791 review instances of "session.drop(...)" and replace with "self.dropUntilSuccess" where appropriate.
+    # FIXME-WT-15791 review instances of "session.drop(...)" and replace with "self.dropUntilSuccess" where appropriate.
     def dropUntilSuccess(self, session=None, uri=None, config=None, **kwargs):
         # Most test cases consider a drop, and especially a 'drop until success',
         # to completely remove a file's artifacts, so that the name can be reused.
@@ -877,7 +877,7 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
         uri = self.uri if uri is None else uri
         return self.retryEBUSY(session, lambda: session.verify(uri, config), **kwargs)
 
-    # TODO-WT-15791 review instances of "session.salvage(...)" and replace with "self.salvageUntilSuccess" where appropriate.
+    # FIXME-WT-15791 review instances of "session.salvage(...)" and replace with "self.salvageUntilSuccess" where appropriate.
     def salvageUntilSuccess(self, session=None, uri=None, config=None, **kwargs):
         session = self.session if session is None else session
         uri = self.uri if uri is None else uri

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -856,22 +856,29 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
         # One last try, if it fails we let the exception propagate.
         return func()
 
+    # TODO-WT-15791 review instances of "session.compact(...)" and replace with "self.compactUntilSuccess" where appropriate.
     def compactUntilSuccess(self, session, uri, config=None):
         return self.retryEBUSY(session, lambda: session.compact(uri, config), checkpoint_on_busy=False, max_retries=100, sleep=0.1)
 
-    def dropUntilSuccess(self, session, uri, config=None):
+    # TODO-WT-15791 review instances of "session.drop(...)" and replace with "self.dropUntilSuccess" where appropriate.
+    def dropUntilSuccess(self, session=None, uri=None, config=None):
         # Most test cases consider a drop, and especially a 'drop until success',
         # to completely remove a file's artifacts, so that the name can be reused.
         # Require this behavior.
         self.requireDropRemovesNameConflict()
+        session = self.session if session is None else session
+        uri = self.uri if uri is None else uri
         return self.retryEBUSY(session, lambda: session.drop(uri, config))
 
-    def verifyUntilSuccess(self, session = None, uri = None, config=None):
+    def verifyUntilSuccess(self, session=None, uri=None, config=None):
         session = self.session if session is None else session
         uri = self.uri if uri is None else uri
         return self.retryEBUSY(session, lambda: session.verify(uri, config))
 
-    def salvageUntilSuccess(self, session, uri, config=None):
+    # TODO-WT-15791 review instances of "session.salvage(...)" and replace with "self.salvageUntilSuccess" where appropriate.
+    def salvageUntilSuccess(self, session=None, uri=None, config=None):
+        session = self.session if session is None else session
+        uri = self.uri if uri is None else uri
         return self.retryEBUSY(session, lambda: session.salvage(uri, config))
 
     def exceptionToStderr(self, expr):

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -834,7 +834,7 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
         if self.runningHook('tiered'):
             self.skipTest('Test requires removal from cloud storage, which is not yet permitted')
 
-    def retryEBUSY(self, session, func, checkpoint_on_busy=True, max_retries=1, sleep=0):
+    def retryEBUSY(self, session, func, checkpoint_on_busy=True, max_retries=5, sleep=0):
         """
         Call the given function.
         If the function succeeds, the function's return value is returned.
@@ -857,31 +857,31 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
         return func()
 
     # TODO-WT-15791 review instances of "session.compact(...)" and replace with "self.compactUntilSuccess" where appropriate.
-    def compactUntilSuccess(self, session=None, uri=None, config=None):
+    def compactUntilSuccess(self, session=None, uri=None, config=None, **kwargs):
         session = self.session if session is None else session
         uri = self.uri if uri is None else uri
-        return self.retryEBUSY(session, lambda: session.compact(uri, config), checkpoint_on_busy=False, max_retries=100, sleep=0.1)
+        return self.retryEBUSY(session, lambda: session.compact(uri, config), checkpoint_on_busy=False, max_retries=100, sleep=0.1, **kwargs)
 
     # TODO-WT-15791 review instances of "session.drop(...)" and replace with "self.dropUntilSuccess" where appropriate.
-    def dropUntilSuccess(self, session=None, uri=None, config=None):
+    def dropUntilSuccess(self, session=None, uri=None, config=None, **kwargs):
         # Most test cases consider a drop, and especially a 'drop until success',
         # to completely remove a file's artifacts, so that the name can be reused.
         # Require this behavior.
         self.requireDropRemovesNameConflict()
         session = self.session if session is None else session
         uri = self.uri if uri is None else uri
-        return self.retryEBUSY(session, lambda: session.drop(uri, config))
+        return self.retryEBUSY(session, lambda: session.drop(uri, config), **kwargs)
 
-    def verifyUntilSuccess(self, session=None, uri=None, config=None):
+    def verifyUntilSuccess(self, session=None, uri=None, config=None, **kwargs):
         session = self.session if session is None else session
         uri = self.uri if uri is None else uri
-        return self.retryEBUSY(session, lambda: session.verify(uri, config))
+        return self.retryEBUSY(session, lambda: session.verify(uri, config), **kwargs)
 
     # TODO-WT-15791 review instances of "session.salvage(...)" and replace with "self.salvageUntilSuccess" where appropriate.
-    def salvageUntilSuccess(self, session=None, uri=None, config=None):
+    def salvageUntilSuccess(self, session=None, uri=None, config=None, **kwargs):
         session = self.session if session is None else session
         uri = self.uri if uri is None else uri
-        return self.retryEBUSY(session, lambda: session.salvage(uri, config))
+        return self.retryEBUSY(session, lambda: session.salvage(uri, config), **kwargs)
 
     def exceptionToStderr(self, expr):
         """

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -295,6 +295,10 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
                         print("[pid:{}]: {}: restarting after rollback error".format(os.getpid(), self))
                     self.setUp()
                     rollbacksAllowed -= 1
+            except wiredtiger.WiredTigerError as err:
+                self.prexception(sys.exc_info())
+                self.conn.dump_error_log()
+                raise
 
     # Construct the expected filename for an extension library and return
     # the name if the file exists.
@@ -830,48 +834,45 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
         if self.runningHook('tiered'):
             self.skipTest('Test requires removal from cloud storage, which is not yet permitted')
 
-    def compactUntilSuccess(self, session, uri, config=None):
-        while True:
+    def retryEBUSY(self, session, func, checkpoint_on_busy=True, max_retries=1, sleep=0):
+        """
+        Call the given function.
+        If the function succeeds, the function's return value is returned.
+        If the function raises any exception other than EBUSY, the exception is raised to the caller.
+        If the function raises a WiredTigerError with EBUSY, we call checkpoint and retry, up to max_retries times.
+        If the function continues to raise EBUSY after max_retries, the exception is raised to the caller.
+        In general, one retry after a checkpoint is sufficient as per test/suite/test_verify2.py.
+        """
+        for _ in range(max_retries):
             try:
-                session.compact(uri, config)
-                return
+                return func()
             except wiredtiger.WiredTigerError as err:
                 if str(err) != os.strerror(errno.EBUSY):
                     raise err
+                if checkpoint_on_busy:
+                    session.checkpoint()
+                if sleep > 0:
+                    time.sleep(sleep)
+        # One last try, if it fails we let the exception propagate.
+        return func()
+
+    def compactUntilSuccess(self, session, uri, config=None):
+        return self.retryEBUSY(session, lambda: session.compact(uri, config), checkpoint_on_busy=False, max_retries=100, sleep=0.1)
 
     def dropUntilSuccess(self, session, uri, config=None):
         # Most test cases consider a drop, and especially a 'drop until success',
         # to completely remove a file's artifacts, so that the name can be reused.
         # Require this behavior.
         self.requireDropRemovesNameConflict()
-        while True:
-            try:
-                session.drop(uri, config)
-                return
-            except wiredtiger.WiredTigerError as err:
-                if str(err) != os.strerror(errno.EBUSY):
-                    raise err
-                session.checkpoint()
+        return self.retryEBUSY(session, lambda: session.drop(uri, config))
 
-    def verifyUntilSuccess(self, session, uri, config=None):
-        while True:
-            try:
-                session.verify(uri, config)
-                return
-            except wiredtiger.WiredTigerError as err:
-                if str(err) != os.strerror(errno.EBUSY):
-                    raise err
-                session.checkpoint()
+    def verifyUntilSuccess(self, session = None, uri = None, config=None):
+        session = self.session if session is None else session
+        uri = self.uri if uri is None else uri
+        return self.retryEBUSY(session, lambda: session.verify(uri, config))
 
     def salvageUntilSuccess(self, session, uri, config=None):
-        while True:
-            try:
-                session.salvage(uri, config)
-                return
-            except wiredtiger.WiredTigerError as err:
-                if str(err) != os.strerror(errno.EBUSY):
-                    raise err
-                session.checkpoint()
+        return self.retryEBUSY(session, lambda: session.salvage(uri, config))
 
     def exceptionToStderr(self, expr):
         """


### PR DESCRIPTION
Fix handling of EBUSY in tests.

* Update tests to use the `verifyUntilSuccess()` function rather than direct calls to `session.verify()` as there needs to be special treatment for the `EBUSY` error.
* Generalise similar code for `compactUntilSuccess()`, `dropUntilSuccess()`, `salvageUntilSuccess()`.