### PR TITLE
WT-15743 Fix incorrect handling of WT_NOTFOUND when opening stable cursor

### DIFF
--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -301,7 +301,7 @@ __clayered_open_stable(WT_CURSOR_LAYERED *clayered, bool leader)
     }
 
     ret = __wt_open_cursor(session, stable_uri, &clayered->iface, cfg, &clayered->stable_cursor);
-    /* Opening a cursor can return both of these, unfortunately. FIXME-WT-15743. */
+    /* Opening a cursor can return both of these, unfortunately. FIXME-WT-15816. */
     if ((ret == ENOENT || ret == WT_NOTFOUND) && !leader)
         /*
          * This is fine on followers, we simply may not have seen a checkpoint with this table yet.

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -299,18 +299,18 @@ __clayered_open_stable(WT_CURSOR_LAYERED *clayered, bool leader)
             stable_uri = stable_uri_buf->data;
         }
     }
-    ret = __wt_open_cursor(session, stable_uri, &clayered->iface, cfg, &clayered->stable_cursor);
 
-    if (ret == ENOENT && !leader) {
-        /*
-         * This is fine, we may not have seen a checkpoint with this table yet. The open will be
-         * deferred.
-         */
-        ret = 0;
-    } else if (ret == WT_NOTFOUND)
-        WT_ERR_PANIC(session, WT_PANIC, "Layered table could not access stable table on leader");
-    else
+    ret = __wt_open_cursor(session, stable_uri, &clayered->iface, cfg, &clayered->stable_cursor);
+    if (ret != 0) {
+        /* Opening a cursor can return both of these, unfortunately. */
+        if ((ret == ENOENT || ret == WT_NOTFOUND) && !leader)
+            /*
+             * This is fine on followers, we simply may not have seen a checkpoint with this table
+             * yet. Defer the open.
+             */
+            ret = 0;
         WT_ERR(ret);
+    }
 
     if (clayered->stable_cursor != NULL) {
         F_SET(clayered->stable_cursor, WT_CURSTD_OVERWRITE | WT_CURSTD_RAW);

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -301,16 +301,14 @@ __clayered_open_stable(WT_CURSOR_LAYERED *clayered, bool leader)
     }
 
     ret = __wt_open_cursor(session, stable_uri, &clayered->iface, cfg, &clayered->stable_cursor);
-    if (ret != 0) {
-        /* Opening a cursor can return both of these, unfortunately. */
-        if ((ret == ENOENT || ret == WT_NOTFOUND) && !leader)
-            /*
-             * This is fine on followers, we simply may not have seen a checkpoint with this table
-             * yet. Defer the open.
-             */
-            ret = 0;
-        WT_ERR(ret);
-    }
+    /* Opening a cursor can return both of these, unfortunately. FIXME-WT-15743. */
+    if ((ret == ENOENT || ret == WT_NOTFOUND) && !leader)
+        /*
+         * This is fine on followers, we simply may not have seen a checkpoint with this table yet.
+         * Defer the open.
+         */
+        ret = 0;
+    WT_ERR(ret);
 
     if (clayered->stable_cursor != NULL) {
         F_SET(clayered->stable_cursor, WT_CURSTD_OVERWRITE | WT_CURSTD_RAW);


### PR DESCRIPTION
To be honest, I'm not 100% comfortable with this. We still don't know what conditions cause a `WT_NOTFOUND` rather than an `ENOENT` (see the SLS ticket linked to the WT ticket), which means (1) it's hard to be confident this fixes the root cause of the bug, and (2) we can't test for it.

To deal with this, how about (in addition to this PR) I raise a new ticket for investigating why we get `WT_NOTFOUND` and adding a test?
