### PR TITLE
WT-15520 Dump the error log after a failed test/suite test

### DIFF
--- a/lang/python/wiredtiger.i
+++ b/lang/python/wiredtiger.i
@@ -1541,8 +1541,6 @@ wiredtiger_dump_error_log_helper(const char *message)
 	if (wiredtiger_dump_error_log_callback == NULL)
 		return (EINVAL);
 
-	SWIG_PYTHON_THREAD_BEGIN_BLOCK;
-
 	/* Build the argument list. */
 	if ((arglist = Py_BuildValue("(s)", message)) == NULL) {
 		ret = WT_ERROR;
@@ -1563,8 +1561,6 @@ wiredtiger_dump_error_log_helper(const char *message)
 err:
 	Py_XDECREF(arglist);
 	Py_XDECREF(result);
-
-	SWIG_PYTHON_THREAD_END_BLOCK;
 	return (ret);
 }
 
@@ -1576,11 +1572,19 @@ int _wiredtiger_dump_error_log(PyObject *callback)
 	if (callback == NULL || callback == Py_None)
 		ret = wiredtiger_dump_error_log(NULL);
 	else {
+		/*
+		 * Acquire the Global Interpreter Lock (GIL) to protect the Python object, and to call the
+		 * provided callback function safely.
+		 */
+		SWIG_PYTHON_THREAD_BEGIN_BLOCK;
 		Py_INCREF(callback);
+
 		wiredtiger_dump_error_log_callback = callback;
 		ret = wiredtiger_dump_error_log(wiredtiger_dump_error_log_helper);
 		wiredtiger_dump_error_log_callback = NULL;
+
 		Py_XDECREF(callback);
+		SWIG_PYTHON_THREAD_END_BLOCK;
 	}
 
 	return (ret);

--- a/lang/python/wiredtiger.i
+++ b/lang/python/wiredtiger.i
@@ -583,6 +583,9 @@ def wiredtiger_calc_modify(session, oldv, newv, maxdiff, nmod):
 def wiredtiger_calc_modify_string(session, oldv, newv, maxdiff, nmod):
 	return _wiredtiger_calc_modify_string(session, oldv, newv, maxdiff, nmod)
 
+def wiredtiger_dump_error_log(callback=None):
+	return _wiredtiger_dump_error_log(callback)
+
 %}
 
 /* Bail out if arg or arg.this is None, else set res to the C pointer. */
@@ -1460,6 +1463,7 @@ OVERRIDE_METHOD(__wt_session, WT_SESSION, log_printf, (self, msg))
 %ignore wiredtiger_struct_unpack;
 
 %ignore wiredtiger_calc_modify;
+%ignore wiredtiger_dump_error_log;
 %ignore wiredtiger_extension_init;
 %ignore wiredtiger_extension_terminate;
 
@@ -1495,6 +1499,10 @@ extern int _wiredtiger_calc_modify(WT_SESSION *session,
 extern int _wiredtiger_calc_modify_string(WT_SESSION *session,
     const WT_ITEM *oldv, const WT_ITEM *newv,
     size_t maxdiff, WT_MODIFY *entries_string, int *nentriesp);
+
+/* A wrapper function for wiredtiger_dump_error_log, which takes a function argument. */
+extern int _wiredtiger_dump_error_log(PyObject *callback);
+
 %{
 int _wiredtiger_calc_modify(WT_SESSION *session,
     const WT_ITEM *oldv, const WT_ITEM *newv,
@@ -1510,6 +1518,72 @@ int _wiredtiger_calc_modify_string(WT_SESSION *session,
 {
 	return (wiredtiger_calc_modify(
 	    session, oldv, newv, maxdiff, entries_string, nentriesp));
+}
+
+/* Python callback for wiredtiger_dump_error_log. */
+#ifdef _WIN32
+__declspec(thread) static PyObject *wiredtiger_dump_error_log_callback = NULL;
+#else
+_Thread_local static PyObject *wiredtiger_dump_error_log_callback = NULL;
+#endif
+
+/* The callback function for wiredtiger_dump_error_log. */
+static int
+wiredtiger_dump_error_log_helper(const char *message)
+{
+	PyObject *arglist, *result;
+	int ret;
+
+	ret = 0;
+	arglist = NULL;
+	result = NULL;
+
+	if (wiredtiger_dump_error_log_callback == NULL)
+		return (EINVAL);
+
+	SWIG_PYTHON_THREAD_BEGIN_BLOCK;
+
+	/* Build the argument list. */
+	if ((arglist = Py_BuildValue("(s)", message)) == NULL) {
+		ret = WT_ERROR;
+		goto err;
+	}
+
+	/* Call the Python function. */
+	result = PyObject_CallObject(wiredtiger_dump_error_log_callback, arglist);
+	if (result == NULL) {
+		ret = WT_ERROR;
+		goto err;
+	}
+
+	/* Set the error code, if provided. */
+	if (PyLong_Check(result))
+		ret = (int)PyLong_AsLong(result);
+
+err:
+	Py_XDECREF(arglist);
+	Py_XDECREF(result);
+
+	SWIG_PYTHON_THREAD_END_BLOCK;
+	return (ret);
+}
+
+/* A wrapper function for wiredtiger_dump_error_log, which takes a function argument. */
+int _wiredtiger_dump_error_log(PyObject *callback)
+{
+	int ret;
+
+	if (callback == NULL || callback == Py_None)
+		ret = wiredtiger_dump_error_log(NULL);
+	else {
+		Py_INCREF(callback);
+		wiredtiger_dump_error_log_callback = callback;
+		ret = wiredtiger_dump_error_log(wiredtiger_dump_error_log_helper);
+		wiredtiger_dump_error_log_callback = NULL;
+		Py_XDECREF(callback);
+	}
+
+	return (ret);
 }
 
 /* Add event handler support. */

--- a/test/suite/test_autoclose.py
+++ b/test/suite/test_autoclose.py
@@ -154,6 +154,6 @@ class test_autoclose(wttest.WiredTigerTestCase):
         """
         conn = self.conn
         self.close_conn()
-        self.assertRaisesHavingMessage(self.expected_exception,
+        self.assertRaisesHavingMessage(Exception,
                                        lambda: conn.open_session(None),
-                                       '/wt_connection.* is None/')
+                                       '/connection is closed/')

--- a/test/suite/test_autoclose.py
+++ b/test/suite/test_autoclose.py
@@ -154,6 +154,8 @@ class test_autoclose(wttest.WiredTigerTestCase):
         """
         conn = self.conn
         self.close_conn()
+        # Check for Exception instead of self.expected_exception, because TestSuiteConnection checks
+        # whether the connection is open explicitly, instead of delegating to the SWIG layer.
         self.assertRaisesHavingMessage(Exception,
                                        lambda: conn.open_session(None),
                                        '/connection is closed/')

--- a/test/suite/test_layered30.py
+++ b/test/suite/test_layered30.py
@@ -141,3 +141,5 @@ class test_layered30(wttest.WiredTigerTestCase):
             item_count += 1
         cursor.close()
         self.assertEqual(item_count, 0)
+
+        self.session.open_cursor(self.uri + 'y', None, None)

--- a/test/suite/test_layered30.py
+++ b/test/suite/test_layered30.py
@@ -141,5 +141,3 @@ class test_layered30(wttest.WiredTigerTestCase):
             item_count += 1
         cursor.close()
         self.assertEqual(item_count, 0)
-
-        self.session.open_cursor(self.uri + 'y', None, None)

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -88,8 +88,13 @@ class TestSuiteConnection(object):
         self._connlist = connlist
 
     def close(self, config=''):
+        conn = self._conn
         self._connlist.remove(self._conn)
-        return self._conn.close(config)
+        self._conn = None
+        return conn.close(config)
+
+    def is_open(self):
+        return self._conn is not None
 
     # Proxy everything except what we explicitly define to the
     # wrapped connection
@@ -297,7 +302,13 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
                     rollbacksAllowed -= 1
             except wiredtiger.WiredTigerError as err:
                 self.prexception(sys.exc_info())
-                self.conn.dump_error_log()
+                if self.conn is not None and self.conn.is_open():
+                    self.conn.dump_error_log()
+                else:
+                    sys.stderr.write('Error log after WiredTigerError exception, connection is closed:\n')
+                    wiredtiger.wiredtiger_dump_error_log(lambda e: sys.stderr.write(e))
+                # Prevent an unnecessary "unexpected output" error.
+                self.ignoreTearDownLogs = True
                 raise
 
     # Construct the expected filename for an extension library and return
@@ -568,6 +579,7 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
         self.teardown_actions.append(action)
 
     def tearDown(self, dueToRetry=False):
+        dumped_error_log = False
         teardown_failed = False
         teardown_msg = None
         if not dueToRetry:
@@ -585,13 +597,6 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
                         teardown_msg = str(tmp[1])
                     else:
                         teardown_msg += "; " + str(tmp[1])
-
-        dumped_error_log = False
-        if self.failed():
-            dumped_error_log = True
-            # Dump the error log directly to stderr, as it is easier to read.
-            sys.stderr.write('\nWiredTiger error log:\n')
-            wiredtiger.wiredtiger_dump_error_log(lambda e: sys.stderr.write(e))
 
         passed = not (self.failed() or teardown_failed)
 
@@ -620,9 +625,20 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
         # self.conn is on the list of active connections.
         if not self.conn in self._connections:
             self._connections.append(self.conn)
+        close_failed = False
         for conn in self._connections:
             try:
                 conn.close()
+            except wiredtiger.WiredTigerError as err:
+                # If the test already failed, we let the connection close fail silently to avoid
+                # unnecessary noise.
+                if passed:
+                    self.prexception(sys.exc_info())
+                    sys.stderr.write('Error log from closing a connection:\n')
+                    wiredtiger.wiredtiger_dump_error_log(lambda e: sys.stderr.write(e))
+                    close_failed = True
+                    dumped_error_log = True
+                    passed = False
             except:
                 pass
         self._connections = []
@@ -657,6 +673,8 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
             print("[pid:{}]: {}: {:.2f} seconds".format(os.getpid(), str(self), elapsed))
         if teardown_failed:
             self.fail(f'Teardown of {self} failed with message: {teardown_msg}')
+        if close_failed:
+            self.fail(f'Closing the connection failed')
         if (not passed or teardown_failed) and (not self.skipped):
             print("[pid:{}]: ERROR in {}".format(os.getpid(), str(self)))
             self.pr('FAIL')

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -582,6 +582,13 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
                     else:
                         teardown_msg += "; " + str(tmp[1])
 
+        dumped_error_log = False
+        if self.failed():
+            dumped_error_log = True
+            # Dump the error log directly to stderr, as it is easier to read.
+            sys.stderr.write('\nWiredTiger error log:\n')
+            wiredtiger.wiredtiger_dump_error_log(lambda e: sys.stderr.write(e))
+
         passed = not (self.failed() or teardown_failed)
 
         try:
@@ -617,7 +624,7 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
         self._connections = []
         try:
             self.fdTearDown()
-            if not (dueToRetry or self.ignoreTearDownLogs):
+            if not (dueToRetry or self.ignoreTearDownLogs or dumped_error_log):
                 self.captureout.check(self)
                 self.captureerr.check(self)
         finally:

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -102,6 +102,8 @@ class TestSuiteConnection(object):
         if attr in self.__dict__:
             return getattr(self, attr)
         else:
+            if self._conn is None:
+                raise Exception('The connection is closed')
             return getattr(self._conn, attr)
 
 # Just like a list of strings, but with a convenience function


### PR DESCRIPTION
After a failed test/suite test, dump the contents of the error log to `stderr`. It skips calling the connection's event handler, as printing directly to `stderr` results in an easier to read output.

The PR also overrides `wiredtiger_dump_error_log` in Python, so that we can use a Python function as a callback.