### PR TITLE
WT-15792 Add variant tags to evergreen yml

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -6440,6 +6440,7 @@ buildvariants:
     ENABLE_TCMALLOC: 1
     data_validation_stress_test_args: -t r -m -W 3 -D -p -n 100000 -k 100000
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo` / 2" | bc)
+  tags: ["pull_request"]
   tasks:
     - name: ".pull_request !.pull_request_compilers"
     - name: ".lint"
@@ -6514,6 +6515,7 @@ buildvariants:
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
     # Exclude wt12015_backup_corruption for ASan builds. It creates false positives when it deliberately kills processes that invoke corruption.
     ctest_extra_args: -E "wt12015_backup_corruption"
+  tags: ["pull_request", "sanitizer"]
   tasks:
     - name: ".pull_request !.pull_request_compilers !.python !.tiered_unittest !csuite-wt12015-backup-corruption-test"
     - name: examples-c-test
@@ -6536,6 +6538,7 @@ buildvariants:
     additional_env_vars: |
       export TSAN_OPTIONS="$COMMON_SAN_OPTIONS:history_size=7:print_suppressions=0:suppressions=$(git rev-parse --show-toplevel)/test/evergreen/tsan_warnings.supp"
     num_jobs: 2
+  tags: ["sanitizer"]
   tasks:
     - name: compile
     - name: examples-c-test
@@ -6638,6 +6641,7 @@ buildvariants:
     # make-check-test task and are covered by the csuite-long-running task.
     ctest_extra_args: -LE "cppsuite|long_running|disagg"
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo` / 2" | bc)
+  tags: ["sanitizer"]
   tasks:
     - name: compile
     - name: compile-production-disable-shared
@@ -6660,6 +6664,7 @@ buildvariants:
     CC_OPTIMIZE_LEVEL: -DCC_OPTIMIZE_LEVEL=-O0
     ENABLE_TCMALLOC: 0
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
+  tags: ["sanitizer"]
   tasks:
     - name: compile
     - name: compile-production-disable-shared
@@ -6678,6 +6683,7 @@ buildvariants:
   expansions:
     ENABLE_TCMALLOC: 1
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
+  tags: ["pull_request"]
   tasks:
     - name: ".pull_request_compilers"
 

--- a/test/evergreen_develop.yml
+++ b/test/evergreen_develop.yml
@@ -13,6 +13,7 @@ variables:
     CMAKE_BUILD_TYPE: -DCMAKE_BUILD_TYPE=Release
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo` * 2" | bc)
     database: WTPerformanceDataDB
+  tags: ["perf"]
   tasks:
     - name: compile
     - ".btree-perf"


### PR DESCRIPTION
This PR adds a few [variant tags](https://docs.devprod.prod.corp.mongodb.com/evergreen/Project-Configuration/Project-Configuration-Files#task-and-variant-tags) into evergreen.yml, as a prerequisite to leverage the patch aliases configuration to assist the ease of targeted patch creations.

This is a [sample patch build](https://spruce.mongodb.com/patch/68f071cbb396eb00070ff32b/configure/tasks) leveraging the `pull_request` patch alias, which is configured to use the variant tag `pull_request` implemented in this PR. Compared to a normal PR build like [this one](https://spruce.mongodb.com/version/68f057d2ddc8dd00075446de/tasks?page=0&sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC), it includes subset of the tasks without covering Windows compile task, code coverage tasks, etc. Otherwise it has comparable coverage to the current PR testing. 
