### PR TITLE
WT-14273 Add stat to track maximum gap between page and connection evict pass generation (v8.0 backport)

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -322,6 +322,7 @@ conn_stats = [
     CacheStat('cache_eviction_internal_pages_already_queued', 'internal pages seen by eviction walk that are already queued'),
     CacheStat('cache_eviction_internal_pages_queued', 'internal pages queued for eviction'),
     CacheStat('cache_eviction_internal_pages_seen', 'internal pages seen by eviction walk'),
+    CacheStat('cache_eviction_maximum_gen_gap', 'maximum gap between page and connection evict pass generation seen at eviction', 'no_clear,no_scale,size'),
     CacheStat('cache_eviction_maximum_page_size', 'maximum page size seen at eviction', 'no_clear,no_scale,size'),
     CacheStat('cache_eviction_maximum_milliseconds', 'maximum milliseconds spent at a single eviction', 'no_clear,no_scale,size'),
     CacheStat('cache_eviction_pages_already_queued', 'pages seen by eviction walk that are already queued'),

--- a/src/conn/conn_cache.c
+++ b/src/conn/conn_cache.c
@@ -354,6 +354,8 @@ __wti_cache_stats_update(WT_SESSION_IMPL *session)
     WT_STAT_SET(session, stats, cache_bytes_other, __wt_cache_bytes_other(cache));
     WT_STAT_SET(session, stats, cache_bytes_updates, __wt_cache_bytes_updates(cache));
 
+    WT_STAT_SET(
+      session, stats, cache_eviction_maximum_gen_gap, cache->evict_max_gen_gap);
     WT_STAT_SET(session, stats, cache_eviction_maximum_page_size, cache->evict_max_page_size);
     WT_STAT_SET(session, stats, cache_eviction_maximum_milliseconds, cache->evict_max_ms);
     WT_STAT_SET(

--- a/src/conn/conn_cache.c
+++ b/src/conn/conn_cache.c
@@ -354,8 +354,7 @@ __wti_cache_stats_update(WT_SESSION_IMPL *session)
     WT_STAT_SET(session, stats, cache_bytes_other, __wt_cache_bytes_other(cache));
     WT_STAT_SET(session, stats, cache_bytes_updates, __wt_cache_bytes_updates(cache));
 
-    WT_STAT_SET(
-      session, stats, cache_eviction_maximum_gen_gap, cache->evict_max_gen_gap);
+    WT_STAT_SET(session, stats, cache_eviction_maximum_gen_gap, cache->evict_max_gen_gap);
     WT_STAT_SET(session, stats, cache_eviction_maximum_page_size, cache->evict_max_page_size);
     WT_STAT_SET(session, stats, cache_eviction_maximum_milliseconds, cache->evict_max_ms);
     WT_STAT_SET(

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2129,6 +2129,18 @@ rand_next:
         else
             ++pages_seen_clean;
 
+        /*
+         * Update the maximum evict pass generation gap seen at time of eviction. This helps track
+         * how long it's been since a page was last queued for eviction. We need to update the
+         * statistic here during the walk and not at __evict_page because the evict_pass_gen is
+         * reset here.
+         */
+        const uint64_t gen_gap = cache->evict_pass_gen - page->evict_pass_gen;
+        if (gen_gap > cache->evict_max_gen_gap)
+            cache->evict_max_gen_gap = gen_gap;
+
+        page->evict_pass_gen = cache->evict_pass_gen;
+
         /* Count internal pages seen. */
         if (F_ISSET(ref, WT_REF_FLAG_INTERNAL))
             internal_pages_seen++;

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1870,7 +1870,7 @@ __evict_walk_tree(WT_SESSION_IMPL *session, WT_EVICT_QUEUE *queue, u_int max_ent
     WT_REF *ref;
     WT_TXN *txn;
     uint64_t internal_pages_already_queued, internal_pages_queued, internal_pages_seen;
-    uint64_t min_pages, pages_already_queued, pages_queued, pages_seen, refs_walked;
+    uint64_t gen_gap, min_pages, pages_already_queued, pages_queued, pages_seen, refs_walked;
     uint64_t pages_seen_clean, pages_seen_dirty, pages_seen_updates;
     uint32_t read_flags, remaining_slots, target_pages, walk_flags;
     int restarts;
@@ -2126,7 +2126,7 @@ rand_next:
          * statistic here during the walk and not at __evict_page because the evict_pass_gen is
          * reset here.
          */
-        const uint64_t gen_gap = __wt_atomic_load64(&cache->evict_pass_gen) - page->evict_pass_gen;
+        gen_gap = __wt_atomic_load64(&cache->evict_pass_gen) - page->evict_pass_gen;
         if (gen_gap > __wt_atomic_load64(&cache->evict_max_gen_gap))
             __wt_atomic_store64(&cache->evict_max_gen_gap, gen_gap);
 

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2119,6 +2119,17 @@ rand_next:
             continue;
 
         page = ref->page;
+
+        /*
+         * Update the maximum evict pass generation gap seen at time of eviction. This helps track
+         * how long it's been since a page was last queued for eviction. We need to update the
+         * statistic here during the walk and not at __evict_page because the evict_pass_gen is
+         * reset here.
+         */
+        const uint64_t gen_gap = __wt_atomic_load64(&cache->evict_pass_gen) - page->evict_pass_gen;
+        if (gen_gap > __wt_atomic_load64(&cache->evict_max_gen_gap))
+            __wt_atomic_store64(&cache->evict_max_gen_gap, gen_gap);
+
         modified = __wt_page_is_modified(page);
         page->evict_pass_gen = __wt_atomic_load64(&cache->evict_pass_gen);
 
@@ -2128,18 +2139,6 @@ rand_next:
             ++pages_seen_updates;
         else
             ++pages_seen_clean;
-
-        /*
-         * Update the maximum evict pass generation gap seen at time of eviction. This helps track
-         * how long it's been since a page was last queued for eviction. We need to update the
-         * statistic here during the walk and not at __evict_page because the evict_pass_gen is
-         * reset here.
-         */
-        const uint64_t gen_gap = cache->evict_pass_gen - page->evict_pass_gen;
-        if (gen_gap > cache->evict_max_gen_gap)
-            cache->evict_max_gen_gap = gen_gap;
-
-        page->evict_pass_gen = cache->evict_pass_gen;
 
         /* Count internal pages seen. */
         if (F_ISSET(ref, WT_REF_FLAG_INTERNAL))

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1869,8 +1869,8 @@ __evict_walk_tree(WT_SESSION_IMPL *session, WT_EVICT_QUEUE *queue, u_int max_ent
     WT_PAGE *last_parent, *page;
     WT_REF *ref;
     WT_TXN *txn;
-    uint64_t internal_pages_already_queued, internal_pages_queued, internal_pages_seen;
     uint64_t gen_gap, min_pages, pages_already_queued, pages_queued, pages_seen, refs_walked;
+    uint64_t internal_pages_already_queued, internal_pages_queued, internal_pages_seen;
     uint64_t pages_seen_clean, pages_seen_dirty, pages_seen_updates;
     uint32_t read_flags, remaining_slots, target_pages, walk_flags;
     int restarts;

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -114,6 +114,7 @@ struct __wt_cache {
     uint64_t app_waits;  /* User threads waited for cache */
     uint64_t app_evicts; /* Pages evicted by user threads */
 
+    uint64_t evict_max_gen_gap;    /* Maximum gap between page and connection evict pass generation */
     uint64_t evict_max_page_size;    /* Largest page seen at eviction */
     uint64_t evict_max_ms;           /* Longest milliseconds spent at a single eviction */
     uint64_t reentry_hs_eviction_ms; /* Total milliseconds spent inside a nested eviction */

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -114,7 +114,7 @@ struct __wt_cache {
     uint64_t app_waits;  /* User threads waited for cache */
     uint64_t app_evicts; /* Pages evicted by user threads */
 
-    uint64_t evict_max_gen_gap;    /* Maximum gap between page and connection evict pass generation */
+    uint64_t evict_max_gen_gap; /* Maximum gap between page and connection evict pass generation */
     uint64_t evict_max_page_size;    /* Largest page seen at eviction */
     uint64_t evict_max_ms;           /* Longest milliseconds spent at a single eviction */
     uint64_t reentry_hs_eviction_ms; /* Total milliseconds spent inside a nested eviction */

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -566,9 +566,9 @@ struct __wt_connection_stats {
     int64_t cache_eviction_split_leaf;
     int64_t cache_eviction_random_sample_inmem_root;
     int64_t cache_bytes_max;
-    int64_t eviction_maximum_gen_gap;
-    int64_t eviction_maximum_milliseconds;
-    int64_t eviction_maximum_page_size;
+    int64_t cache_eviction_maximum_gen_gap;
+    int64_t cache_eviction_maximum_milliseconds;
+    int64_t cache_eviction_maximum_page_size;
     int64_t eviction_app_dirty_attempt;
     int64_t eviction_app_dirty_fail;
     int64_t cache_eviction_dirty;

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -566,8 +566,9 @@ struct __wt_connection_stats {
     int64_t cache_eviction_split_leaf;
     int64_t cache_eviction_random_sample_inmem_root;
     int64_t cache_bytes_max;
-    int64_t cache_eviction_maximum_milliseconds;
-    int64_t cache_eviction_maximum_page_size;
+    int64_t eviction_maximum_gen_gap;
+    int64_t eviction_maximum_milliseconds;
+    int64_t eviction_maximum_page_size;
     int64_t eviction_app_dirty_attempt;
     int64_t eviction_app_dirty_fail;
     int64_t cache_eviction_dirty;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -6073,1245 +6073,1402 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
  */
 #define	WT_STAT_CONN_CACHE_EVICTION_RANDOM_SAMPLE_INMEM_ROOT	1199
 /*! cache: maximum bytes configured */
-#define	WT_STAT_CONN_CACHE_BYTES_MAX			1200
+#define	WT_STAT_CONN_CACHE_BYTES_MAX			1197
+/*!
+ * cache: maximum gap between page and connection evict pass generation
+ * seen at eviction
+ */
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_GEN_GAP		1198
 /*! cache: maximum milliseconds spent at a single eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_MILLISECONDS	1201
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_MILLISECONDS	1199
 /*! cache: maximum page size seen at eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_PAGE_SIZE	1202
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_PAGE_SIZE		1200
 /*! cache: modified page evict attempts by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_DIRTY_ATTEMPT		1203
+#define	WT_STAT_CONN_EVICTION_APP_DIRTY_ATTEMPT		1201
 /*! cache: modified page evict failures by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_DIRTY_FAIL		1204
+#define	WT_STAT_CONN_EVICTION_APP_DIRTY_FAIL		1202
 /*! cache: modified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1205
+#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1203
 /*! cache: multi-block reconciliation blocked whilst checkpoint is running */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_MULTI_BLOCK_RECONCILATION_DURING_CHECKPOINT	1206
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_MULTI_BLOCK_RECONCILIATION_DURING_CHECKPOINT	1204
+/*! cache: npos read - had to walk this many pages */
+#define	WT_STAT_CONN_NPOS_READ_WALK_MAX			1205
 /*! cache: number of times dirty trigger was reached */
-#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_DIRTY_REACHED	1207
+#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_DIRTY_REACHED	1206
 /*! cache: number of times eviction trigger was reached */
-#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_REACHED	1208
+#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_REACHED	1207
 /*! cache: number of times updates trigger was reached */
-#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_UPDATES_REACHED	1209
+#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_UPDATES_REACHED	1208
 /*! cache: operations timed out waiting for space in cache */
-#define	WT_STAT_CONN_CACHE_TIMED_OUT_OPS		1210
+#define	WT_STAT_CONN_EVICTION_TIMED_OUT_OPS		1209
 /*!
  * cache: overflow keys on a multiblock row-store page blocked its
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_OVERFLOW_KEYS	1211
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_OVERFLOW_KEYS	1210
 /*! cache: overflow pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ_OVERFLOW		1212
+#define	WT_STAT_CONN_CACHE_READ_OVERFLOW		1211
 /*! cache: page evict attempts by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_ATTEMPT		1213
+#define	WT_STAT_CONN_EVICTION_APP_ATTEMPT		1212
 /*! cache: page evict failures by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_FAIL			1214
+#define	WT_STAT_CONN_EVICTION_APP_FAIL			1213
 /*! cache: page split during eviction deepened the tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1215
+#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1214
 /*! cache: page written requiring history store records */
-#define	WT_STAT_CONN_CACHE_WRITE_HS			1216
+#define	WT_STAT_CONN_CACHE_WRITE_HS			1215
 /*! cache: pages considered for eviction that were brought in by pre-fetch */
-#define	WT_STAT_CONN_CACHE_EVICTION_CONSIDER_PREFETCH	1217
+#define	WT_STAT_CONN_EVICTION_CONSIDER_PREFETCH		1216
 /*! cache: pages currently held in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_INUSE			1218
+#define	WT_STAT_CONN_CACHE_PAGES_INUSE			1217
 /*! cache: pages dirtied due to obsolete time window by eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY_OBSOLETE_TW	1219
+#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY_OBSOLETE_TW	1218
 /*! cache: pages evicted in parallel with checkpoint */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_IN_PARALLEL_WITH_CHECKPOINT	1220
+#define	WT_STAT_CONN_EVICTION_PAGES_IN_PARALLEL_WITH_CHECKPOINT	1219
 /*! cache: pages queued for eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED	1221
+#define	WT_STAT_CONN_EVICTION_PAGES_ORDINARY_QUEUED	1220
 /*! cache: pages queued for eviction post lru sorting */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_POST_LRU	1222
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_POST_LRU	1221
 /*! cache: pages queued for urgent eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_URGENT	1223
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT	1222
 /*! cache: pages queued for urgent eviction during walk */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_OLDEST	1224
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_OLDEST	1223
 /*!
  * cache: pages queued for urgent eviction from history store due to high
  * dirty content
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_URGENT_HS_DIRTY	1225
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT_HS_DIRTY	1224
 /*! cache: pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ				1226
+#define	WT_STAT_CONN_CACHE_READ				1225
 /*! cache: pages read into cache after truncate */
-#define	WT_STAT_CONN_CACHE_READ_DELETED			1227
+#define	WT_STAT_CONN_CACHE_READ_DELETED			1226
 /*! cache: pages read into cache after truncate in prepare state */
-#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1228
+#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1227
 /*! cache: pages read into cache by checkpoint */
-#define	WT_STAT_CONN_CACHE_READ_CHECKPOINT		1229
+#define	WT_STAT_CONN_CACHE_READ_CHECKPOINT		1228
 /*!
  * cache: pages removed from the ordinary queue to be queued for urgent
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_CLEAR_ORDINARY	1230
+#define	WT_STAT_CONN_EVICTION_CLEAR_ORDINARY		1229
 /*! cache: pages requested from the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1231
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1230
 /*! cache: pages requested from the cache due to pre-fetch */
-#define	WT_STAT_CONN_CACHE_PAGES_PREFETCH		1232
+#define	WT_STAT_CONN_CACHE_PAGES_PREFETCH		1231
 /*! cache: pages seen by eviction walk */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1233
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1232
 /*! cache: pages seen by eviction walk that are already queued */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_ALREADY_QUEUED	1234
+#define	WT_STAT_CONN_EVICTION_PAGES_ALREADY_QUEUED	1233
 /*! cache: pages selected for eviction unable to be evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_FAIL		1235
+#define	WT_STAT_CONN_EVICTION_FAIL			1234
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * active children on an internal page
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_ACTIVE_CHILDREN_ON_AN_INTERNAL_PAGE	1236
+#define	WT_STAT_CONN_EVICTION_FAIL_ACTIVE_CHILDREN_ON_AN_INTERNAL_PAGE	1235
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * failure in reconciliation
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_IN_RECONCILIATION	1237
+#define	WT_STAT_CONN_EVICTION_FAIL_IN_RECONCILIATION	1236
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * race between checkpoint and updates without timestamps
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_CHECKPOINT_NO_TS	1238
+#define	WT_STAT_CONN_EVICTION_FAIL_CHECKPOINT_NO_TS	1237
 /*! cache: pages walked for eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK		1239
+#define	WT_STAT_CONN_EVICTION_WALK			1238
 /*! cache: pages written from cache */
-#define	WT_STAT_CONN_CACHE_WRITE			1240
+#define	WT_STAT_CONN_CACHE_WRITE			1239
 /*! cache: pages written requiring in-memory restoration */
-#define	WT_STAT_CONN_CACHE_WRITE_RESTORE		1241
+#define	WT_STAT_CONN_CACHE_WRITE_RESTORE		1240
 /*! cache: percentage overhead */
-#define	WT_STAT_CONN_CACHE_OVERHEAD			1242
+#define	WT_STAT_CONN_CACHE_OVERHEAD			1241
 /*! cache: recent modification of a page blocked its eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	1243
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	1242
 /*! cache: reverse splits performed */
-#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS		1244
+#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS		1243
 /*!
  * cache: reverse splits skipped because of VLCS namespace gap
  * restrictions
  */
-#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	1245
+#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	1244
 /*! cache: the number of times full update inserted to history store */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1246
+#define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1245
 /*! cache: the number of times reverse modify inserted to history store */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1247
+#define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1246
 /*!
  * cache: total milliseconds spent inside reentrant history store
  * evictions in a reconciliation
  */
-#define	WT_STAT_CONN_CACHE_REENTRY_HS_EVICTION_MILLISECONDS	1248
+#define	WT_STAT_CONN_EVICTION_REENTRY_HS_EVICTION_MILLISECONDS	1247
 /*! cache: tracked bytes belonging to internal pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1249
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1248
 /*! cache: tracked bytes belonging to leaf pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1250
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1249
 /*! cache: tracked dirty bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1251
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1250
 /*! cache: tracked dirty internal page bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL		1252
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL		1251
 /*! cache: tracked dirty leaf page bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF		1253
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF		1252
 /*! cache: tracked dirty pages in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1254
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1253
 /*! cache: uncommitted truncate blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	1255
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	1254
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1256
+#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1255
+/*! cache: update bytes belonging to the history store table in the cache */
+#define	WT_STAT_CONN_CACHE_BYTES_HS_UPDATES		1256
+/*! cache: updates in uncommitted txn - bytes */
+#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_BYTES	1257
+/*! cache: updates in uncommitted txn - count */
+#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_COUNT	1258
 /*! capacity: background fsync file handles considered */
-#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1257
+#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1259
 /*! capacity: background fsync file handles synced */
-#define	WT_STAT_CONN_FSYNC_ALL_FH			1258
+#define	WT_STAT_CONN_FSYNC_ALL_FH			1260
 /*! capacity: background fsync time (msecs) */
-#define	WT_STAT_CONN_FSYNC_ALL_TIME			1259
+#define	WT_STAT_CONN_FSYNC_ALL_TIME			1261
 /*! capacity: bytes read */
-#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1260
+#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1262
 /*! capacity: bytes written for checkpoint */
-#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1261
+#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1263
 /*! capacity: bytes written for chunk cache */
-#define	WT_STAT_CONN_CAPACITY_BYTES_CHUNKCACHE		1262
+#define	WT_STAT_CONN_CAPACITY_BYTES_CHUNKCACHE		1264
 /*! capacity: bytes written for eviction */
-#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1263
+#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1265
 /*! capacity: bytes written for log */
-#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1264
+#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1266
 /*! capacity: bytes written total */
-#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1265
+#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1267
 /*! capacity: threshold to call fsync */
-#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1266
+#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1268
 /*! capacity: time waiting due to total capacity (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1267
+#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1269
 /*! capacity: time waiting during checkpoint (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1268
+#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1270
 /*! capacity: time waiting during eviction (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1269
+#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1271
 /*! capacity: time waiting during logging (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1270
+#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1272
 /*! capacity: time waiting during read (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_READ			1271
+#define	WT_STAT_CONN_CAPACITY_TIME_READ			1273
 /*! capacity: time waiting for chunk cache IO bandwidth (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_CHUNKCACHE		1272
+#define	WT_STAT_CONN_CAPACITY_TIME_CHUNKCACHE		1274
 /*! checkpoint: checkpoint cleanup successful calls */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_SUCCESS		1273
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_SUCCESS		1275
 /*! checkpoint: checkpoint has acquired a snapshot for its transaction */
-#define	WT_STAT_CONN_CHECKPOINT_SNAPSHOT_ACQUIRED	1274
+#define	WT_STAT_CONN_CHECKPOINT_SNAPSHOT_ACQUIRED	1276
 /*! checkpoint: checkpoints skipped because database was clean */
-#define	WT_STAT_CONN_CHECKPOINT_SKIPPED			1275
+#define	WT_STAT_CONN_CHECKPOINT_SKIPPED			1277
 /*! checkpoint: fsync calls after allocating the transaction ID */
-#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST		1276
+#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST		1278
 /*! checkpoint: fsync duration after allocating the transaction ID (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST_DURATION	1277
+#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST_DURATION	1279
 /*! checkpoint: generation */
-#define	WT_STAT_CONN_CHECKPOINT_GENERATION		1278
+#define	WT_STAT_CONN_CHECKPOINT_GENERATION		1280
 /*! checkpoint: max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_MAX		1279
+#define	WT_STAT_CONN_CHECKPOINT_TIME_MAX		1281
 /*! checkpoint: min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_MIN		1280
+#define	WT_STAT_CONN_CHECKPOINT_TIME_MIN		1282
 /*!
  * checkpoint: most recent duration for checkpoint dropping all handles
  * (usecs)
  */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROP_DURATION	1281
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROP_DURATION	1283
 /*! checkpoint: most recent duration for gathering all handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION		1282
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION		1284
 /*! checkpoint: most recent duration for gathering applied handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLY_DURATION	1283
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLY_DURATION	1285
 /*! checkpoint: most recent duration for gathering skipped handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIP_DURATION	1284
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIP_DURATION	1286
 /*! checkpoint: most recent duration for handles metadata checked (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECK_DURATION	1285
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECK_DURATION	1287
 /*! checkpoint: most recent duration for locking the handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCK_DURATION	1286
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCK_DURATION	1288
 /*! checkpoint: most recent handles applied */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLIED		1287
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLIED		1289
 /*! checkpoint: most recent handles checkpoint dropped */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROPPED		1288
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROPPED		1290
 /*! checkpoint: most recent handles metadata checked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECKED	1289
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECKED	1291
 /*! checkpoint: most recent handles metadata locked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCKED		1290
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCKED		1292
 /*! checkpoint: most recent handles skipped */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIPPED		1291
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIPPED		1293
 /*! checkpoint: most recent handles walked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_WALKED		1292
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_WALKED		1294
 /*! checkpoint: most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_RECENT		1293
+#define	WT_STAT_CONN_CHECKPOINT_TIME_RECENT		1295
 /*! checkpoint: number of checkpoints started by api */
-#define	WT_STAT_CONN_CHECKPOINTS_API			1294
+#define	WT_STAT_CONN_CHECKPOINTS_API			1296
 /*! checkpoint: number of checkpoints started by compaction */
-#define	WT_STAT_CONN_CHECKPOINTS_COMPACT		1295
+#define	WT_STAT_CONN_CHECKPOINTS_COMPACT		1297
 /*! checkpoint: number of files synced */
-#define	WT_STAT_CONN_CHECKPOINT_SYNC			1296
+#define	WT_STAT_CONN_CHECKPOINT_SYNC			1298
 /*! checkpoint: number of handles visited after writes complete */
-#define	WT_STAT_CONN_CHECKPOINT_PRESYNC			1297
+#define	WT_STAT_CONN_CHECKPOINT_PRESYNC			1299
 /*! checkpoint: number of history store pages caused to be reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_HS_PAGES_RECONCILED	1298
+#define	WT_STAT_CONN_CHECKPOINT_HS_PAGES_RECONCILED	1300
 /*! checkpoint: number of internal pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_INTERNAL	1299
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_INTERNAL	1301
 /*! checkpoint: number of leaf pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_LEAF	1300
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_LEAF	1302
 /*! checkpoint: number of pages caused to be reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED	1301
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED	1303
 /*! checkpoint: pages added for eviction during checkpoint cleanup */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_EVICT	1302
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_EVICT	1304
 /*!
  * checkpoint: pages dirtied due to obsolete time window by checkpoint
  * cleanup
  */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	1303
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	1305
 /*!
  * checkpoint: pages read into cache during checkpoint cleanup
  * (reclaim_space)
  */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	1304
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	1306
 /*!
  * checkpoint: pages read into cache during checkpoint cleanup due to
  * obsolete time window
  */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	1305
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	1307
 /*! checkpoint: pages removed during checkpoint cleanup */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_REMOVED	1306
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_REMOVED	1308
 /*! checkpoint: pages skipped during checkpoint cleanup tree walk */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	1307
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	1309
 /*! checkpoint: pages visited during checkpoint cleanup */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_VISITED	1308
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_VISITED	1310
 /*! checkpoint: prepare currently running */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1309
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1311
 /*! checkpoint: prepare max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1310
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1312
 /*! checkpoint: prepare min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1311
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1313
 /*! checkpoint: prepare most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1312
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1314
 /*! checkpoint: prepare total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1313
+#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1315
 /*! checkpoint: progress state */
-#define	WT_STAT_CONN_CHECKPOINT_STATE			1314
+#define	WT_STAT_CONN_CHECKPOINT_STATE			1316
 /*! checkpoint: scrub dirty target */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1315
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1317
 /*! checkpoint: scrub max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1316
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1318
 /*! checkpoint: scrub min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1317
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1319
 /*! checkpoint: scrub most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1318
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1320
 /*! checkpoint: scrub total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1319
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1321
 /*! checkpoint: stop timing stress active */
-#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1320
+#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1322
 /*! checkpoint: time spent on per-tree checkpoint work (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1321
+#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1323
 /*! checkpoint: total failed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1322
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1324
 /*! checkpoint: total succeed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1323
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1325
 /*! checkpoint: total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1324
-/*! checkpoint: transaction checkpoints due to obsolete pages */
-#define	WT_STAT_CONN_CHECKPOINT_OBSOLETE_APPLIED	1325
+#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1326
 /*! checkpoint: wait cycles while cache dirty level is decreasing */
-#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1326
+#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1327
 /*! chunk-cache: aggregate number of spanned chunks on read */
-#define	WT_STAT_CONN_CHUNKCACHE_SPANS_CHUNKS_READ	1327
+#define	WT_STAT_CONN_CHUNKCACHE_SPANS_CHUNKS_READ	1328
 /*! chunk-cache: chunks evicted */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_EVICTED		1328
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_EVICTED		1329
 /*! chunk-cache: could not allocate due to exceeding bitmap capacity */
-#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_BITMAP_CAPACITY	1329
+#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_BITMAP_CAPACITY	1330
 /*! chunk-cache: could not allocate due to exceeding capacity */
-#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_CAPACITY	1330
+#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_CAPACITY	1331
 /*! chunk-cache: lookups */
-#define	WT_STAT_CONN_CHUNKCACHE_LOOKUPS			1331
+#define	WT_STAT_CONN_CHUNKCACHE_LOOKUPS			1332
 /*!
  * chunk-cache: number of chunks loaded from flushed tables in chunk
  * cache
  */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_LOADED_FROM_FLUSHED_TABLES	1332
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_LOADED_FROM_FLUSHED_TABLES	1333
 /*! chunk-cache: number of metadata entries inserted */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_INSERTED	1333
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_INSERTED	1334
 /*! chunk-cache: number of metadata entries removed */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_REMOVED	1334
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_REMOVED	1335
 /*!
  * chunk-cache: number of metadata inserts/deletes dropped by the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DROPPED	1335
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DROPPED	1336
 /*!
  * chunk-cache: number of metadata inserts/deletes pushed to the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_CREATED	1336
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_CREATED	1337
 /*!
  * chunk-cache: number of metadata inserts/deletes read by the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DEQUEUED	1337
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DEQUEUED	1338
 /*! chunk-cache: number of misses */
-#define	WT_STAT_CONN_CHUNKCACHE_MISSES			1338
+#define	WT_STAT_CONN_CHUNKCACHE_MISSES			1339
 /*! chunk-cache: number of times a read from storage failed */
-#define	WT_STAT_CONN_CHUNKCACHE_IO_FAILED		1339
+#define	WT_STAT_CONN_CHUNKCACHE_IO_FAILED		1340
 /*! chunk-cache: retried accessing a chunk while I/O was in progress */
-#define	WT_STAT_CONN_CHUNKCACHE_RETRIES			1340
+#define	WT_STAT_CONN_CHUNKCACHE_RETRIES			1341
 /*! chunk-cache: retries from a chunk cache checksum mismatch */
-#define	WT_STAT_CONN_CHUNKCACHE_RETRIES_CHECKSUM_MISMATCH	1341
+#define	WT_STAT_CONN_CHUNKCACHE_RETRIES_CHECKSUM_MISMATCH	1342
 /*! chunk-cache: timed out due to too many retries */
-#define	WT_STAT_CONN_CHUNKCACHE_TOOMANY_RETRIES		1342
+#define	WT_STAT_CONN_CHUNKCACHE_TOOMANY_RETRIES		1343
 /*! chunk-cache: total bytes read from persistent content */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_READ_PERSISTENT	1343
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_READ_PERSISTENT	1344
 /*! chunk-cache: total bytes used by the cache */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE		1344
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE		1345
 /*! chunk-cache: total bytes used by the cache for pinned chunks */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE_PINNED	1345
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE_PINNED	1346
 /*! chunk-cache: total chunks held by the chunk cache */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_INUSE		1346
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_INUSE		1347
 /*!
  * chunk-cache: total number of chunks inserted on startup from persisted
  * metadata.
  */
-#define	WT_STAT_CONN_CHUNKCACHE_CREATED_FROM_METADATA	1347
+#define	WT_STAT_CONN_CHUNKCACHE_CREATED_FROM_METADATA	1348
 /*! chunk-cache: total pinned chunks held by the chunk cache */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_PINNED		1348
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_PINNED		1349
 /*! connection: auto adjusting condition resets */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1349
+#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1350
 /*! connection: auto adjusting condition wait calls */
-#define	WT_STAT_CONN_COND_AUTO_WAIT			1350
+#define	WT_STAT_CONN_COND_AUTO_WAIT			1351
 /*!
  * connection: auto adjusting condition wait raced to update timeout and
  * skipped updating
  */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1351
+#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1352
 /*! connection: detected system time went backwards */
-#define	WT_STAT_CONN_TIME_TRAVEL			1352
+#define	WT_STAT_CONN_TIME_TRAVEL			1353
 /*! connection: files currently open */
-#define	WT_STAT_CONN_FILE_OPEN				1353
+#define	WT_STAT_CONN_FILE_OPEN				1354
 /*! connection: hash bucket array size for data handles */
-#define	WT_STAT_CONN_BUCKETS_DH				1354
+#define	WT_STAT_CONN_BUCKETS_DH				1355
 /*! connection: hash bucket array size general */
-#define	WT_STAT_CONN_BUCKETS				1355
+#define	WT_STAT_CONN_BUCKETS				1356
 /*! connection: memory allocations */
-#define	WT_STAT_CONN_MEMORY_ALLOCATION			1356
+#define	WT_STAT_CONN_MEMORY_ALLOCATION			1357
 /*! connection: memory frees */
-#define	WT_STAT_CONN_MEMORY_FREE			1357
+#define	WT_STAT_CONN_MEMORY_FREE			1358
 /*! connection: memory re-allocations */
-#define	WT_STAT_CONN_MEMORY_GROW			1358
+#define	WT_STAT_CONN_MEMORY_GROW			1359
 /*! connection: number of sessions without a sweep for 5+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1359
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1360
 /*! connection: number of sessions without a sweep for 60+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1360
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1361
 /*! connection: pthread mutex condition wait calls */
-#define	WT_STAT_CONN_COND_WAIT				1361
+#define	WT_STAT_CONN_COND_WAIT				1362
 /*! connection: pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			1362
+#define	WT_STAT_CONN_RWLOCK_READ			1363
 /*! connection: pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			1363
+#define	WT_STAT_CONN_RWLOCK_WRITE			1364
 /*! connection: total fsync I/Os */
-#define	WT_STAT_CONN_FSYNC_IO				1364
+#define	WT_STAT_CONN_FSYNC_IO				1365
 /*! connection: total read I/Os */
-#define	WT_STAT_CONN_READ_IO				1365
+#define	WT_STAT_CONN_READ_IO				1366
 /*! connection: total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				1366
+#define	WT_STAT_CONN_WRITE_IO				1367
 /*! cursor: Total number of deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1367
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1368
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1368
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1369
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1369
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1370
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1370
+#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1371
 /*!
  * cursor: Total number of in-memory deleted pages skipped during tree
  * walk
  */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1371
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1372
 /*! cursor: Total number of on-disk deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1372
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1373
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1373
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1374
 /*!
  * cursor: Total number of times cursor fails to temporarily release
  * pinned page to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1374
+#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1375
 /*!
  * cursor: Total number of times cursor temporarily releases pinned page
  * to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION			1375
+#define	WT_STAT_CONN_CURSOR_REPOSITION			1376
 /*! cursor: bulk cursor count */
-#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1376
+#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1377
 /*! cursor: cached cursor count */
-#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1377
+#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1378
 /*! cursor: cursor bound calls that return an error */
-#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1378
+#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1379
 /*! cursor: cursor bounds cleared from reset */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1379
+#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1380
 /*! cursor: cursor bounds comparisons performed */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1380
+#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1381
 /*! cursor: cursor bounds next called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1381
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1382
 /*! cursor: cursor bounds next early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1382
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1383
 /*! cursor: cursor bounds prev called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1383
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1384
 /*! cursor: cursor bounds prev early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1384
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1385
 /*! cursor: cursor bounds search early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1385
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1386
 /*! cursor: cursor bounds search near call repositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1386
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1387
 /*! cursor: cursor bulk loaded cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1387
+#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1388
 /*! cursor: cursor cache calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1388
+#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1389
 /*! cursor: cursor close calls that result in cache */
-#define	WT_STAT_CONN_CURSOR_CACHE			1389
+#define	WT_STAT_CONN_CURSOR_CACHE			1390
 /*! cursor: cursor close calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1390
+#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1391
 /*! cursor: cursor compare calls that return an error */
-#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1391
+#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1392
 /*! cursor: cursor create calls */
-#define	WT_STAT_CONN_CURSOR_CREATE			1392
+#define	WT_STAT_CONN_CURSOR_CREATE			1393
 /*! cursor: cursor equals calls that return an error */
-#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1393
+#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1394
 /*! cursor: cursor get key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1394
+#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1395
 /*! cursor: cursor get value calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1395
+#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1396
 /*! cursor: cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT			1396
+#define	WT_STAT_CONN_CURSOR_INSERT			1397
 /*! cursor: cursor insert calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1397
+#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1398
 /*! cursor: cursor insert check calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1398
+#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1399
 /*! cursor: cursor insert key and value bytes */
-#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1399
+#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1400
 /*! cursor: cursor largest key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1400
+#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1401
 /*! cursor: cursor modify calls */
-#define	WT_STAT_CONN_CURSOR_MODIFY			1401
+#define	WT_STAT_CONN_CURSOR_MODIFY			1402
 /*! cursor: cursor modify calls that return an error */
-#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1402
+#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1403
 /*! cursor: cursor modify key and value bytes affected */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1403
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1404
 /*! cursor: cursor modify value bytes modified */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1404
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1405
 /*! cursor: cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT			1405
+#define	WT_STAT_CONN_CURSOR_NEXT			1406
 /*! cursor: cursor next calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1406
+#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1407
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1407
+#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1408
 /*!
  * cursor: cursor next calls that skip greater than 1 and fewer than 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1408
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1409
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1409
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1410
 /*! cursor: cursor next random calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1410
+#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1411
 /*! cursor: cursor operation restarted */
-#define	WT_STAT_CONN_CURSOR_RESTART			1411
+#define	WT_STAT_CONN_CURSOR_RESTART			1412
 /*! cursor: cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV			1412
+#define	WT_STAT_CONN_CURSOR_PREV			1413
 /*! cursor: cursor prev calls that return an error */
-#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1413
+#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1414
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1414
+#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1415
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1415
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1416
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1416
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1417
 /*! cursor: cursor reconfigure calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1417
+#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1418
 /*! cursor: cursor remove calls */
-#define	WT_STAT_CONN_CURSOR_REMOVE			1418
+#define	WT_STAT_CONN_CURSOR_REMOVE			1419
 /*! cursor: cursor remove calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1419
+#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1420
 /*! cursor: cursor remove key bytes removed */
-#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1420
+#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1421
 /*! cursor: cursor reopen calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1421
+#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1422
 /*! cursor: cursor reserve calls */
-#define	WT_STAT_CONN_CURSOR_RESERVE			1422
+#define	WT_STAT_CONN_CURSOR_RESERVE			1423
 /*! cursor: cursor reserve calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1423
+#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1424
 /*! cursor: cursor reset calls */
-#define	WT_STAT_CONN_CURSOR_RESET			1424
+#define	WT_STAT_CONN_CURSOR_RESET			1425
 /*! cursor: cursor reset calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1425
+#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1426
 /*! cursor: cursor search calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH			1426
+#define	WT_STAT_CONN_CURSOR_SEARCH			1427
 /*! cursor: cursor search calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1427
+#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1428
 /*! cursor: cursor search history store calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1428
+#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1429
 /*! cursor: cursor search near calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1429
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1430
 /*! cursor: cursor search near calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1430
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1431
 /*! cursor: cursor sweep buckets */
-#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1431
+#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1432
 /*! cursor: cursor sweep cursors closed */
-#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1432
+#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1433
 /*! cursor: cursor sweep cursors examined */
-#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1433
+#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1434
 /*! cursor: cursor sweeps */
-#define	WT_STAT_CONN_CURSOR_SWEEP			1434
+#define	WT_STAT_CONN_CURSOR_SWEEP			1435
 /*! cursor: cursor truncate calls */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE			1435
+#define	WT_STAT_CONN_CURSOR_TRUNCATE			1436
 /*! cursor: cursor truncates performed on individual keys */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1436
+#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1437
 /*! cursor: cursor update calls */
-#define	WT_STAT_CONN_CURSOR_UPDATE			1437
+#define	WT_STAT_CONN_CURSOR_UPDATE			1438
 /*! cursor: cursor update calls that return an error */
-#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1438
+#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1439
 /*! cursor: cursor update key and value bytes */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1439
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1440
 /*! cursor: cursor update value size change */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1440
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1441
 /*! cursor: cursors reused from cache */
-#define	WT_STAT_CONN_CURSOR_REOPEN			1441
+#define	WT_STAT_CONN_CURSOR_REOPEN			1442
 /*! cursor: open cursor count */
-#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1442
+#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1443
+/*! data-handle: Table connection data handles currently active */
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TABLE_COUNT		1444
+/*! data-handle: Tiered connection data handles currently active */
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_COUNT	1445
+/*! data-handle: Tiered_Tree connection data handles currently active */
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_TREE_COUNT	1446
+/*! data-handle: btree connection data handles currently active */
+#define	WT_STAT_CONN_DH_CONN_HANDLE_BTREE_COUNT		1447
+/*! data-handle: checkpoint connection data handles currently active */
+#define	WT_STAT_CONN_DH_CONN_HANDLE_CHECKPOINT_COUNT	1448
 /*! data-handle: connection data handle size */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1443
+#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1449
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1444
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1450
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1445
-/*! data-handle: connection sweep dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1446
+#define	WT_STAT_CONN_DH_SWEEP_REF			1451
+/*! data-handle: connection sweep dead dhandles closed */
+#define	WT_STAT_CONN_DH_SWEEP_DEAD_CLOSE		1452
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1447
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1453
+/*! data-handle: connection sweep expired dhandles closed */
+#define	WT_STAT_CONN_DH_SWEEP_EXPIRED_CLOSE		1454
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1448
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1455
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1449
+#define	WT_STAT_CONN_DH_SWEEPS				1456
 /*!
  * data-handle: connection sweeps skipped due to checkpoint gathering
  * handles
  */
-#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1450
+#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1457
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1451
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1458
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1452
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1459
+/*!
+ * live-restore: number of bytes copied from the source to the
+ * destination
+ */
+#define	WT_STAT_CONN_LIVE_RESTORE_BYTES_COPIED		1460
+/*! live-restore: number of files remaining for migration completion */
+#define	WT_STAT_CONN_LIVE_RESTORE_WORK_REMAINING	1461
+/*! live-restore: number of reads from the source database */
+#define	WT_STAT_CONN_LIVE_RESTORE_SOURCE_READ_COUNT	1462
+/*! live-restore: source read latency histogram (bucket 1) - 0-10ms */
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT10	1463
+/*! live-restore: source read latency histogram (bucket 2) - 10-49ms */
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT50	1464
+/*! live-restore: source read latency histogram (bucket 3) - 50-99ms */
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT100	1465
+/*! live-restore: source read latency histogram (bucket 4) - 100-249ms */
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT250	1466
+/*! live-restore: source read latency histogram (bucket 5) - 250-499ms */
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT500	1467
+/*! live-restore: source read latency histogram (bucket 6) - 500-999ms */
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT1000	1468
+/*! live-restore: source read latency histogram (bucket 7) - 1000ms+ */
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_GT1000	1469
+/*! live-restore: source read latency histogram total (msecs) */
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_TOTAL_MSECS	1470
+/*! live-restore: state */
+#define	WT_STAT_CONN_LIVE_RESTORE_STATE			1471
+/*! lock: btree page lock acquisitions */
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_COUNT		1472
+/*! lock: btree page lock application thread wait time (usecs) */
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_APPLICATION	1473
+/*! lock: btree page lock internal thread wait time (usecs) */
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_INTERNAL	1474
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1453
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1475
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1454
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1476
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1455
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1477
 /*! lock: dhandle lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1456
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1478
 /*! lock: dhandle lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1457
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1479
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1458
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1480
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1459
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1481
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1460
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1482
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1461
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1483
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1462
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1484
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1463
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1485
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1464
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1486
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1465
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1487
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1466
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1488
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1467
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1489
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1468
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1490
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1469
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1491
 /*! lock: txn global lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1470
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1492
 /*! lock: txn global lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1471
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1493
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1472
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1494
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1473
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1495
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1474
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1496
 /*! log: force log remove time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1475
+#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1497
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1476
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1498
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1477
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1499
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1478
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1500
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1479
+#define	WT_STAT_CONN_LOG_FLUSH				1501
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1480
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1502
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1481
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1503
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1482
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1504
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1483
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1505
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1484
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1506
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1485
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1507
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1486
+#define	WT_STAT_CONN_LOG_SCANS				1508
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1487
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1509
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1488
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1510
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1489
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1511
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1490
+#define	WT_STAT_CONN_LOG_SYNC				1512
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1491
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1513
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1492
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1514
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1493
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1515
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1494
+#define	WT_STAT_CONN_LOG_WRITES				1516
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1495
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1517
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1496
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1518
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1497
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1519
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1498
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1520
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1499
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1521
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1500
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1522
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1501
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1523
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1502
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1524
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1503
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1525
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1504
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1526
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1505
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1527
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1506
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1528
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1507
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1529
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1508
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1530
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1509
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1531
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1510
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1532
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1511
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1533
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1512
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1534
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1513
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1535
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1514
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1536
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1515
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1537
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1516
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1538
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1517
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1539
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1518
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1540
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1519
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1541
+/*! perf: block manager read latency histogram (bucket 1) - 0-10ms */
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT10	1542
+/*! perf: block manager read latency histogram (bucket 2) - 10-49ms */
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT50	1543
+/*! perf: block manager read latency histogram (bucket 3) - 50-99ms */
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT100	1544
+/*! perf: block manager read latency histogram (bucket 4) - 100-249ms */
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT250	1545
+/*! perf: block manager read latency histogram (bucket 5) - 250-499ms */
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT500	1546
+/*! perf: block manager read latency histogram (bucket 6) - 500-999ms */
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT1000	1547
+/*! perf: block manager read latency histogram (bucket 7) - 1000ms+ */
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_GT1000	1548
+/*! perf: block manager read latency histogram total (msecs) */
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_TOTAL_MSECS	1549
+/*! perf: block manager write latency histogram (bucket 1) - 0-10ms */
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT10	1550
+/*! perf: block manager write latency histogram (bucket 2) - 10-49ms */
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT50	1551
+/*! perf: block manager write latency histogram (bucket 3) - 50-99ms */
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT100	1552
+/*! perf: block manager write latency histogram (bucket 4) - 100-249ms */
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT250	1553
+/*! perf: block manager write latency histogram (bucket 5) - 250-499ms */
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT500	1554
+/*! perf: block manager write latency histogram (bucket 6) - 500-999ms */
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT1000	1555
+/*! perf: block manager write latency histogram (bucket 7) - 1000ms+ */
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_GT1000	1556
+/*! perf: block manager write latency histogram total (msecs) */
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_TOTAL_MSECS	1557
+/*! perf: disagg block manager read latency histogram (bucket 1) - 50-99us */
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT100	1558
+/*!
+ * perf: disagg block manager read latency histogram (bucket 2) -
+ * 100-249us
+ */
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT250	1559
+/*!
+ * perf: disagg block manager read latency histogram (bucket 3) -
+ * 250-499us
+ */
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT500	1560
+/*!
+ * perf: disagg block manager read latency histogram (bucket 4) -
+ * 500-999us
+ */
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT1000	1561
+/*!
+ * perf: disagg block manager read latency histogram (bucket 5) -
+ * 1000-9999us
+ */
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT10000	1562
+/*!
+ * perf: disagg block manager read latency histogram (bucket 6) -
+ * 10000us+
+ */
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_GT10000	1563
+/*! perf: disagg block manager read latency histogram total (usecs) */
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_TOTAL_USECS	1564
+/*!
+ * perf: disagg block manager write latency histogram (bucket 1) -
+ * 50-99us
+ */
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT100	1565
+/*!
+ * perf: disagg block manager write latency histogram (bucket 2) -
+ * 100-249us
+ */
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT250	1566
+/*!
+ * perf: disagg block manager write latency histogram (bucket 3) -
+ * 250-499us
+ */
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT500	1567
+/*!
+ * perf: disagg block manager write latency histogram (bucket 4) -
+ * 500-999us
+ */
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT1000	1568
+/*!
+ * perf: disagg block manager write latency histogram (bucket 5) -
+ * 1000-9999us
+ */
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT10000	1569
+/*!
+ * perf: disagg block manager write latency histogram (bucket 6) -
+ * 10000us+
+ */
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_GT10000	1570
+/*! perf: disagg block manager write latency histogram total (usecs) */
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_TOTAL_USECS	1571
 /*! perf: file system read latency histogram (bucket 1) - 0-10ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1520
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1572
 /*! perf: file system read latency histogram (bucket 2) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1521
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1573
 /*! perf: file system read latency histogram (bucket 3) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1522
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1574
 /*! perf: file system read latency histogram (bucket 4) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1523
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1575
 /*! perf: file system read latency histogram (bucket 5) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1524
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1576
 /*! perf: file system read latency histogram (bucket 6) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1525
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1577
 /*! perf: file system read latency histogram (bucket 7) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1526
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1578
 /*! perf: file system read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1527
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1579
 /*! perf: file system write latency histogram (bucket 1) - 0-10ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1528
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1580
 /*! perf: file system write latency histogram (bucket 2) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1529
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1581
 /*! perf: file system write latency histogram (bucket 3) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1530
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1582
 /*! perf: file system write latency histogram (bucket 4) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1531
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1583
 /*! perf: file system write latency histogram (bucket 5) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1532
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1584
 /*! perf: file system write latency histogram (bucket 6) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1533
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1585
 /*! perf: file system write latency histogram (bucket 7) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1534
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1586
 /*! perf: file system write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1535
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1587
 /*! perf: operation read latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1536
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1588
 /*! perf: operation read latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1537
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1589
 /*! perf: operation read latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1538
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1590
 /*! perf: operation read latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1539
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1591
 /*! perf: operation read latency histogram (bucket 5) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1540
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1592
 /*! perf: operation read latency histogram (bucket 6) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1541
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1593
 /*! perf: operation read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1542
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1594
 /*! perf: operation write latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1543
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1595
 /*! perf: operation write latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1544
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1596
 /*! perf: operation write latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1545
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1597
 /*! perf: operation write latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1546
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1598
 /*! perf: operation write latency histogram (bucket 5) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1547
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1599
 /*! perf: operation write latency histogram (bucket 6) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1548
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1600
 /*! perf: operation write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1549
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1601
 /*! prefetch: could not perform pre-fetch on internal page */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1550
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1602
 /*!
  * prefetch: could not perform pre-fetch on ref without the pre-fetch
  * flag set
  */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1551
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1603
 /*! prefetch: number of times pre-fetch failed to start */
-#define	WT_STAT_CONN_PREFETCH_FAILED_START		1552
+#define	WT_STAT_CONN_PREFETCH_FAILED_START		1604
 /*! prefetch: pre-fetch not repeating for recently pre-fetched ref */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1553
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1605
 /*! prefetch: pre-fetch not triggered after single disk read */
-#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1554
+#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1606
 /*! prefetch: pre-fetch not triggered as there is no valid dhandle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1555
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1607
 /*! prefetch: pre-fetch not triggered by page read */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED			1556
+#define	WT_STAT_CONN_PREFETCH_SKIPPED			1608
 /*! prefetch: pre-fetch not triggered due to disk read count */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1557
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1609
 /*! prefetch: pre-fetch not triggered due to internal session */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1558
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1610
 /*! prefetch: pre-fetch not triggered due to special btree handle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1559
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1611
 /*! prefetch: pre-fetch page not on disk when reading */
-#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1560
+#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1612
 /*! prefetch: pre-fetch pages queued */
-#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1561
+#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1613
 /*! prefetch: pre-fetch pages read in background */
-#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1562
+#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1614
 /*! prefetch: pre-fetch skipped reading in a page due to harmless error */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1563
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1615
 /*! prefetch: pre-fetch triggered by page read */
-#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1564
+#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1616
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1565
+#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1617
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1566
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1618
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1567
-/*! reconciliation: cursor next/prev calls during HS wrapup search_near */
-#define	WT_STAT_CONN_REC_HS_WRAPUP_NEXT_PREV_CALLS	1568
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1619
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1569
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1620
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1570
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1621
 /*! reconciliation: maximum milliseconds spent in a reconciliation call */
-#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1571
+#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1622
 /*!
  * reconciliation: maximum milliseconds spent in building a disk image in
  * a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1572
+#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1623
 /*!
  * reconciliation: maximum milliseconds spent in moving updates to the
  * history store in a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1573
+#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1624
 /*! reconciliation: overflow values written */
-#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1574
+#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1625
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1575
+#define	WT_STAT_CONN_REC_PAGES				1626
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1576
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1627
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * prepared transaction metadata
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1577
+#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1628
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * timestamps
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1578
+#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1629
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * transaction ids
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1579
+#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1630
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1580
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1631
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1581
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1632
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1582
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1633
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1583
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1634
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1584
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1635
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1585
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1636
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1586
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1637
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1587
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1638
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1588
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1639
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1589
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1640
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1590
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1641
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1591
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1642
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1592
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1643
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1593
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1644
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1594
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1645
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1595
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1646
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1596
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1647
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1597
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1648
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1598
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1649
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1599
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1650
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1600
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1651
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1601
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1652
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1602
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1653
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1603
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1654
 /*! session: attempts to remove a local object and the object is in use */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1604
+#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1655
 /*! session: flush_tier failed calls */
-#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1605
+#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1656
 /*! session: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1606
+#define	WT_STAT_CONN_FLUSH_TIER				1657
 /*! session: flush_tier tables skipped due to no checkpoint */
-#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1607
+#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1658
 /*! session: flush_tier tables switched */
-#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1608
+#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1659
 /*! session: local objects removed */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1609
+#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1660
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1610
+#define	WT_STAT_CONN_SESSION_OPEN			1661
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1611
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1662
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1612
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1663
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1613
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1664
 /*! session: table alter triggering checkpoint calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1614
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1665
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1615
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1666
 /*! session: table compact conflicted with checkpoint */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1616
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1667
 /*! session: table compact dhandle successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1617
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1668
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1618
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1669
 /*! session: table compact failed calls due to cache pressure */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1619
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1670
 /*! session: table compact passes */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1620
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1671
 /*! session: table compact pulled into eviction */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1621
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1672
 /*! session: table compact running */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1622
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1673
 /*! session: table compact skipped as process would not reduce file size */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1623
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1674
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1624
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1675
 /*! session: table compact timeout */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1625
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1676
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1626
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1677
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1627
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1678
 /*! session: table create with import failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1628
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1679
 /*! session: table create with import repair calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1629
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1680
 /*! session: table create with import successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1630
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1681
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1631
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1682
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1632
-/*! session: table rename failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1633
-/*! session: table rename successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1634
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1683
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1635
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1684
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1636
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1685
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1637
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1686
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1638
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1687
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1639
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1688
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1640
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1689
 /*! session: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1641
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1690
 /*! session: tiered operations removed without processing */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1642
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1691
 /*! session: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1643
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1692
 /*! session: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1644
+#define	WT_STAT_CONN_TIERED_RETENTION			1693
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1645
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1694
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1646
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1695
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1647
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1696
 /*! thread-yield: application thread operations waiting for cache */
-#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1648
+#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1697
+/*!
+ * thread-yield: application thread operations waiting for interruptible
+ * cache eviction
+ */
+#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_OPS	1698
+/*!
+ * thread-yield: application thread operations waiting for mandatory
+ * cache eviction
+ */
+#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_OPS	1699
 /*! thread-yield: application thread snapshot refreshed for eviction */
-#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1649
+#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1700
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1650
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1701
+/*!
+ * thread-yield: application thread time waiting for interruptible cache
+ * eviction (usecs)
+ */
+#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_TIME	1702
+/*!
+ * thread-yield: application thread time waiting for mandatory cache
+ * eviction (usecs)
+ */
+#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_TIME	1703
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1651
-/*! thread-yield: connection close yielded for lsm manager shutdown */
-#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1652
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1704
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1653
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1705
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1654
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1706
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1655
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1707
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1656
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1708
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1657
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1709
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1658
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1710
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1659
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1711
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1660
+#define	WT_STAT_CONN_PAGE_SLEEP				1712
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1661
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1713
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1662
-/*! thread-yield: page split and restart read */
-#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1663
-/*! thread-yield: pages skipped during read due to deleted state */
-#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1664
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1714
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1665
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1715
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1666
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1716
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1667
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1717
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1668
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1718
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1669
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1719
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1670
+#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1720
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1671
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1721
 /*! transaction: oldest transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1672
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1722
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1673
+#define	WT_STAT_CONN_TXN_PREPARE			1723
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1674
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1724
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1675
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1725
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1676
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1726
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1677
+#define	WT_STAT_CONN_TXN_QUERY_TS			1727
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1678
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1728
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1679
+#define	WT_STAT_CONN_TXN_RTS				1729
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1680
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1730
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1681
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1731
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1682
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1732
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1683
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1733
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1684
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1734
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1685
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1735
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1686
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1736
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1687
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1737
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1688
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1738
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1689
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1739
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1690
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1740
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1691
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1741
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1692
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1742
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1693
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1743
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1694
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1744
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1695
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1745
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1696
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1746
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1697
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1747
 /*!
  * transaction: rollback to stable updates that would have been aborted
  * in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1698
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1748
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1699
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1749
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1700
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1750
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1701
+#define	WT_STAT_CONN_TXN_SET_TS				1751
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1702
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1752
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1703
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1753
 /*! transaction: set timestamp force calls */
-#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1704
+#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1754
 /*!
  * transaction: set timestamp global oldest timestamp set to be more
  * recent than the global stable timestamp
  */
-#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1705
+#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1755
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1706
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1756
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1707
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1757
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1708
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1758
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1709
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1759
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1710
+#define	WT_STAT_CONN_TXN_BEGIN				1760
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1711
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1761
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1712
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1762
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1713
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1763
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1714
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1764
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1715
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1765
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1716
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1766
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1717
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1767
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1718
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1768
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1719
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1769
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1720
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1770
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1721
+#define	WT_STAT_CONN_TXN_COMMIT				1771
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1722
+#define	WT_STAT_CONN_TXN_ROLLBACK			1772
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1723
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1773
 
 /*!
  * @}

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -6073,304 +6073,298 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
  */
 #define	WT_STAT_CONN_CACHE_EVICTION_RANDOM_SAMPLE_INMEM_ROOT	1199
 /*! cache: maximum bytes configured */
-#define	WT_STAT_CONN_CACHE_BYTES_MAX			1197
+#define	WT_STAT_CONN_CACHE_BYTES_MAX			1200
 /*!
  * cache: maximum gap between page and connection evict pass generation
  * seen at eviction
  */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_GEN_GAP		1198
+#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_GEN_GAP	1201
 /*! cache: maximum milliseconds spent at a single eviction */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_MILLISECONDS	1199
+#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_MILLISECONDS	1202
 /*! cache: maximum page size seen at eviction */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_PAGE_SIZE		1200
+#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_PAGE_SIZE	1203
 /*! cache: modified page evict attempts by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_DIRTY_ATTEMPT		1201
+#define	WT_STAT_CONN_EVICTION_APP_DIRTY_ATTEMPT		1204
 /*! cache: modified page evict failures by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_DIRTY_FAIL		1202
+#define	WT_STAT_CONN_EVICTION_APP_DIRTY_FAIL		1205
 /*! cache: modified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1203
+#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1206
 /*! cache: multi-block reconciliation blocked whilst checkpoint is running */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_MULTI_BLOCK_RECONCILIATION_DURING_CHECKPOINT	1204
-/*! cache: npos read - had to walk this many pages */
-#define	WT_STAT_CONN_NPOS_READ_WALK_MAX			1205
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_MULTI_BLOCK_RECONCILATION_DURING_CHECKPOINT	1207
 /*! cache: number of times dirty trigger was reached */
-#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_DIRTY_REACHED	1206
+#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_DIRTY_REACHED	1208
 /*! cache: number of times eviction trigger was reached */
-#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_REACHED	1207
+#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_REACHED	1209
 /*! cache: number of times updates trigger was reached */
-#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_UPDATES_REACHED	1208
+#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_UPDATES_REACHED	1210
 /*! cache: operations timed out waiting for space in cache */
-#define	WT_STAT_CONN_EVICTION_TIMED_OUT_OPS		1209
+#define	WT_STAT_CONN_CACHE_TIMED_OUT_OPS		1211
 /*!
  * cache: overflow keys on a multiblock row-store page blocked its
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_OVERFLOW_KEYS	1210
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_OVERFLOW_KEYS	1212
 /*! cache: overflow pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ_OVERFLOW		1211
+#define	WT_STAT_CONN_CACHE_READ_OVERFLOW		1213
 /*! cache: page evict attempts by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_ATTEMPT		1212
+#define	WT_STAT_CONN_EVICTION_APP_ATTEMPT		1214
 /*! cache: page evict failures by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_FAIL			1213
+#define	WT_STAT_CONN_EVICTION_APP_FAIL			1215
 /*! cache: page split during eviction deepened the tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1214
+#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1216
 /*! cache: page written requiring history store records */
-#define	WT_STAT_CONN_CACHE_WRITE_HS			1215
+#define	WT_STAT_CONN_CACHE_WRITE_HS			1217
 /*! cache: pages considered for eviction that were brought in by pre-fetch */
-#define	WT_STAT_CONN_EVICTION_CONSIDER_PREFETCH		1216
+#define	WT_STAT_CONN_CACHE_EVICTION_CONSIDER_PREFETCH	1218
 /*! cache: pages currently held in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_INUSE			1217
+#define	WT_STAT_CONN_CACHE_PAGES_INUSE			1219
 /*! cache: pages dirtied due to obsolete time window by eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY_OBSOLETE_TW	1218
+#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY_OBSOLETE_TW	1220
 /*! cache: pages evicted in parallel with checkpoint */
-#define	WT_STAT_CONN_EVICTION_PAGES_IN_PARALLEL_WITH_CHECKPOINT	1219
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_IN_PARALLEL_WITH_CHECKPOINT	1221
 /*! cache: pages queued for eviction */
-#define	WT_STAT_CONN_EVICTION_PAGES_ORDINARY_QUEUED	1220
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED	1222
 /*! cache: pages queued for eviction post lru sorting */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_POST_LRU	1221
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_POST_LRU	1223
 /*! cache: pages queued for urgent eviction */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT	1222
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_URGENT	1224
 /*! cache: pages queued for urgent eviction during walk */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_OLDEST	1223
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_OLDEST	1225
 /*!
  * cache: pages queued for urgent eviction from history store due to high
  * dirty content
  */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT_HS_DIRTY	1224
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_URGENT_HS_DIRTY	1226
 /*! cache: pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ				1225
+#define	WT_STAT_CONN_CACHE_READ				1227
 /*! cache: pages read into cache after truncate */
-#define	WT_STAT_CONN_CACHE_READ_DELETED			1226
+#define	WT_STAT_CONN_CACHE_READ_DELETED			1228
 /*! cache: pages read into cache after truncate in prepare state */
-#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1227
+#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1229
 /*! cache: pages read into cache by checkpoint */
-#define	WT_STAT_CONN_CACHE_READ_CHECKPOINT		1228
+#define	WT_STAT_CONN_CACHE_READ_CHECKPOINT		1230
 /*!
  * cache: pages removed from the ordinary queue to be queued for urgent
  * eviction
  */
-#define	WT_STAT_CONN_EVICTION_CLEAR_ORDINARY		1229
+#define	WT_STAT_CONN_CACHE_EVICTION_CLEAR_ORDINARY	1231
 /*! cache: pages requested from the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1230
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1232
 /*! cache: pages requested from the cache due to pre-fetch */
-#define	WT_STAT_CONN_CACHE_PAGES_PREFETCH		1231
+#define	WT_STAT_CONN_CACHE_PAGES_PREFETCH		1233
 /*! cache: pages seen by eviction walk */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1232
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1234
 /*! cache: pages seen by eviction walk that are already queued */
-#define	WT_STAT_CONN_EVICTION_PAGES_ALREADY_QUEUED	1233
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_ALREADY_QUEUED	1235
 /*! cache: pages selected for eviction unable to be evicted */
-#define	WT_STAT_CONN_EVICTION_FAIL			1234
+#define	WT_STAT_CONN_CACHE_EVICTION_FAIL		1236
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * active children on an internal page
  */
-#define	WT_STAT_CONN_EVICTION_FAIL_ACTIVE_CHILDREN_ON_AN_INTERNAL_PAGE	1235
+#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_ACTIVE_CHILDREN_ON_AN_INTERNAL_PAGE	1237
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * failure in reconciliation
  */
-#define	WT_STAT_CONN_EVICTION_FAIL_IN_RECONCILIATION	1236
+#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_IN_RECONCILIATION	1238
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * race between checkpoint and updates without timestamps
  */
-#define	WT_STAT_CONN_EVICTION_FAIL_CHECKPOINT_NO_TS	1237
+#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_CHECKPOINT_NO_TS	1239
 /*! cache: pages walked for eviction */
-#define	WT_STAT_CONN_EVICTION_WALK			1238
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK		1240
 /*! cache: pages written from cache */
-#define	WT_STAT_CONN_CACHE_WRITE			1239
+#define	WT_STAT_CONN_CACHE_WRITE			1241
 /*! cache: pages written requiring in-memory restoration */
-#define	WT_STAT_CONN_CACHE_WRITE_RESTORE		1240
+#define	WT_STAT_CONN_CACHE_WRITE_RESTORE		1242
 /*! cache: percentage overhead */
-#define	WT_STAT_CONN_CACHE_OVERHEAD			1241
+#define	WT_STAT_CONN_CACHE_OVERHEAD			1243
 /*! cache: recent modification of a page blocked its eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	1242
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	1244
 /*! cache: reverse splits performed */
-#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS		1243
+#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS		1245
 /*!
  * cache: reverse splits skipped because of VLCS namespace gap
  * restrictions
  */
-#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	1244
+#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	1246
 /*! cache: the number of times full update inserted to history store */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1245
+#define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1247
 /*! cache: the number of times reverse modify inserted to history store */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1246
+#define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1248
 /*!
  * cache: total milliseconds spent inside reentrant history store
  * evictions in a reconciliation
  */
-#define	WT_STAT_CONN_EVICTION_REENTRY_HS_EVICTION_MILLISECONDS	1247
+#define	WT_STAT_CONN_CACHE_REENTRY_HS_EVICTION_MILLISECONDS	1249
 /*! cache: tracked bytes belonging to internal pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1248
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1250
 /*! cache: tracked bytes belonging to leaf pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1249
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1251
 /*! cache: tracked dirty bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1250
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1252
 /*! cache: tracked dirty internal page bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL		1251
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL		1253
 /*! cache: tracked dirty leaf page bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF		1252
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF		1254
 /*! cache: tracked dirty pages in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1253
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1255
 /*! cache: uncommitted truncate blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	1254
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	1256
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1255
-/*! cache: update bytes belonging to the history store table in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_HS_UPDATES		1256
-/*! cache: updates in uncommitted txn - bytes */
-#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_BYTES	1257
-/*! cache: updates in uncommitted txn - count */
-#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_COUNT	1258
+#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1257
 /*! capacity: background fsync file handles considered */
-#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1259
+#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1258
 /*! capacity: background fsync file handles synced */
-#define	WT_STAT_CONN_FSYNC_ALL_FH			1260
+#define	WT_STAT_CONN_FSYNC_ALL_FH			1259
 /*! capacity: background fsync time (msecs) */
-#define	WT_STAT_CONN_FSYNC_ALL_TIME			1261
+#define	WT_STAT_CONN_FSYNC_ALL_TIME			1260
 /*! capacity: bytes read */
-#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1262
+#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1261
 /*! capacity: bytes written for checkpoint */
-#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1263
+#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1262
 /*! capacity: bytes written for chunk cache */
-#define	WT_STAT_CONN_CAPACITY_BYTES_CHUNKCACHE		1264
+#define	WT_STAT_CONN_CAPACITY_BYTES_CHUNKCACHE		1263
 /*! capacity: bytes written for eviction */
-#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1265
+#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1264
 /*! capacity: bytes written for log */
-#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1266
+#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1265
 /*! capacity: bytes written total */
-#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1267
+#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1266
 /*! capacity: threshold to call fsync */
-#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1268
+#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1267
 /*! capacity: time waiting due to total capacity (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1269
+#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1268
 /*! capacity: time waiting during checkpoint (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1270
+#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1269
 /*! capacity: time waiting during eviction (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1271
+#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1270
 /*! capacity: time waiting during logging (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1272
+#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1271
 /*! capacity: time waiting during read (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_READ			1273
+#define	WT_STAT_CONN_CAPACITY_TIME_READ			1272
 /*! capacity: time waiting for chunk cache IO bandwidth (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_CHUNKCACHE		1274
+#define	WT_STAT_CONN_CAPACITY_TIME_CHUNKCACHE		1273
 /*! checkpoint: checkpoint cleanup successful calls */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_SUCCESS		1275
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_SUCCESS		1274
 /*! checkpoint: checkpoint has acquired a snapshot for its transaction */
-#define	WT_STAT_CONN_CHECKPOINT_SNAPSHOT_ACQUIRED	1276
+#define	WT_STAT_CONN_CHECKPOINT_SNAPSHOT_ACQUIRED	1275
 /*! checkpoint: checkpoints skipped because database was clean */
-#define	WT_STAT_CONN_CHECKPOINT_SKIPPED			1277
+#define	WT_STAT_CONN_CHECKPOINT_SKIPPED			1276
 /*! checkpoint: fsync calls after allocating the transaction ID */
-#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST		1278
+#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST		1277
 /*! checkpoint: fsync duration after allocating the transaction ID (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST_DURATION	1279
+#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST_DURATION	1278
 /*! checkpoint: generation */
-#define	WT_STAT_CONN_CHECKPOINT_GENERATION		1280
+#define	WT_STAT_CONN_CHECKPOINT_GENERATION		1279
 /*! checkpoint: max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_MAX		1281
+#define	WT_STAT_CONN_CHECKPOINT_TIME_MAX		1280
 /*! checkpoint: min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_MIN		1282
+#define	WT_STAT_CONN_CHECKPOINT_TIME_MIN		1281
 /*!
  * checkpoint: most recent duration for checkpoint dropping all handles
  * (usecs)
  */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROP_DURATION	1283
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROP_DURATION	1282
 /*! checkpoint: most recent duration for gathering all handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION		1284
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION		1283
 /*! checkpoint: most recent duration for gathering applied handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLY_DURATION	1285
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLY_DURATION	1284
 /*! checkpoint: most recent duration for gathering skipped handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIP_DURATION	1286
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIP_DURATION	1285
 /*! checkpoint: most recent duration for handles metadata checked (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECK_DURATION	1287
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECK_DURATION	1286
 /*! checkpoint: most recent duration for locking the handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCK_DURATION	1288
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCK_DURATION	1287
 /*! checkpoint: most recent handles applied */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLIED		1289
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLIED		1288
 /*! checkpoint: most recent handles checkpoint dropped */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROPPED		1290
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROPPED		1289
 /*! checkpoint: most recent handles metadata checked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECKED	1291
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECKED	1290
 /*! checkpoint: most recent handles metadata locked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCKED		1292
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCKED		1291
 /*! checkpoint: most recent handles skipped */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIPPED		1293
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIPPED		1292
 /*! checkpoint: most recent handles walked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_WALKED		1294
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_WALKED		1293
 /*! checkpoint: most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_RECENT		1295
+#define	WT_STAT_CONN_CHECKPOINT_TIME_RECENT		1294
 /*! checkpoint: number of checkpoints started by api */
-#define	WT_STAT_CONN_CHECKPOINTS_API			1296
+#define	WT_STAT_CONN_CHECKPOINTS_API			1295
 /*! checkpoint: number of checkpoints started by compaction */
-#define	WT_STAT_CONN_CHECKPOINTS_COMPACT		1297
+#define	WT_STAT_CONN_CHECKPOINTS_COMPACT		1296
 /*! checkpoint: number of files synced */
-#define	WT_STAT_CONN_CHECKPOINT_SYNC			1298
+#define	WT_STAT_CONN_CHECKPOINT_SYNC			1297
 /*! checkpoint: number of handles visited after writes complete */
-#define	WT_STAT_CONN_CHECKPOINT_PRESYNC			1299
+#define	WT_STAT_CONN_CHECKPOINT_PRESYNC			1298
 /*! checkpoint: number of history store pages caused to be reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_HS_PAGES_RECONCILED	1300
+#define	WT_STAT_CONN_CHECKPOINT_HS_PAGES_RECONCILED	1299
 /*! checkpoint: number of internal pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_INTERNAL	1301
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_INTERNAL	1300
 /*! checkpoint: number of leaf pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_LEAF	1302
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_LEAF	1301
 /*! checkpoint: number of pages caused to be reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED	1303
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED	1302
 /*! checkpoint: pages added for eviction during checkpoint cleanup */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_EVICT	1304
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_EVICT	1303
 /*!
  * checkpoint: pages dirtied due to obsolete time window by checkpoint
  * cleanup
  */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	1305
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	1304
 /*!
  * checkpoint: pages read into cache during checkpoint cleanup
  * (reclaim_space)
  */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	1306
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	1305
 /*!
  * checkpoint: pages read into cache during checkpoint cleanup due to
  * obsolete time window
  */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	1307
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	1306
 /*! checkpoint: pages removed during checkpoint cleanup */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_REMOVED	1308
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_REMOVED	1307
 /*! checkpoint: pages skipped during checkpoint cleanup tree walk */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	1309
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	1308
 /*! checkpoint: pages visited during checkpoint cleanup */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_VISITED	1310
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_VISITED	1309
 /*! checkpoint: prepare currently running */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1311
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1310
 /*! checkpoint: prepare max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1312
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1311
 /*! checkpoint: prepare min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1313
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1312
 /*! checkpoint: prepare most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1314
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1313
 /*! checkpoint: prepare total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1315
+#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1314
 /*! checkpoint: progress state */
-#define	WT_STAT_CONN_CHECKPOINT_STATE			1316
+#define	WT_STAT_CONN_CHECKPOINT_STATE			1315
 /*! checkpoint: scrub dirty target */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1317
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1316
 /*! checkpoint: scrub max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1318
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1317
 /*! checkpoint: scrub min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1319
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1318
 /*! checkpoint: scrub most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1320
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1319
 /*! checkpoint: scrub total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1321
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1320
 /*! checkpoint: stop timing stress active */
-#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1322
+#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1321
 /*! checkpoint: time spent on per-tree checkpoint work (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1323
+#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1322
 /*! checkpoint: total failed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1324
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1323
 /*! checkpoint: total succeed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1325
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1324
 /*! checkpoint: total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1326
+#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1325
+/*! checkpoint: transaction checkpoints due to obsolete pages */
+#define	WT_STAT_CONN_CHECKPOINT_OBSOLETE_APPLIED	1326
 /*! checkpoint: wait cycles while cache dirty level is decreasing */
 #define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1327
 /*! chunk-cache: aggregate number of spanned chunks on read */
@@ -6653,822 +6647,676 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_CURSOR_REOPEN			1442
 /*! cursor: open cursor count */
 #define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1443
-/*! data-handle: Table connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TABLE_COUNT		1444
-/*! data-handle: Tiered connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_COUNT	1445
-/*! data-handle: Tiered_Tree connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_TREE_COUNT	1446
-/*! data-handle: btree connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_BTREE_COUNT		1447
-/*! data-handle: checkpoint connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_CHECKPOINT_COUNT	1448
 /*! data-handle: connection data handle size */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1449
+#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1444
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1450
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1445
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1451
-/*! data-handle: connection sweep dead dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_DEAD_CLOSE		1452
+#define	WT_STAT_CONN_DH_SWEEP_REF			1446
+/*! data-handle: connection sweep dhandles closed */
+#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1447
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1453
-/*! data-handle: connection sweep expired dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_EXPIRED_CLOSE		1454
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1448
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1455
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1449
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1456
+#define	WT_STAT_CONN_DH_SWEEPS				1450
 /*!
  * data-handle: connection sweeps skipped due to checkpoint gathering
  * handles
  */
-#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1457
+#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1451
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1458
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1452
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1459
-/*!
- * live-restore: number of bytes copied from the source to the
- * destination
- */
-#define	WT_STAT_CONN_LIVE_RESTORE_BYTES_COPIED		1460
-/*! live-restore: number of files remaining for migration completion */
-#define	WT_STAT_CONN_LIVE_RESTORE_WORK_REMAINING	1461
-/*! live-restore: number of reads from the source database */
-#define	WT_STAT_CONN_LIVE_RESTORE_SOURCE_READ_COUNT	1462
-/*! live-restore: source read latency histogram (bucket 1) - 0-10ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT10	1463
-/*! live-restore: source read latency histogram (bucket 2) - 10-49ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT50	1464
-/*! live-restore: source read latency histogram (bucket 3) - 50-99ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT100	1465
-/*! live-restore: source read latency histogram (bucket 4) - 100-249ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT250	1466
-/*! live-restore: source read latency histogram (bucket 5) - 250-499ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT500	1467
-/*! live-restore: source read latency histogram (bucket 6) - 500-999ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT1000	1468
-/*! live-restore: source read latency histogram (bucket 7) - 1000ms+ */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_GT1000	1469
-/*! live-restore: source read latency histogram total (msecs) */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_TOTAL_MSECS	1470
-/*! live-restore: state */
-#define	WT_STAT_CONN_LIVE_RESTORE_STATE			1471
-/*! lock: btree page lock acquisitions */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_COUNT		1472
-/*! lock: btree page lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_APPLICATION	1473
-/*! lock: btree page lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_INTERNAL	1474
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1453
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1475
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1454
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1476
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1455
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1477
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1456
 /*! lock: dhandle lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1478
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1457
 /*! lock: dhandle lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1479
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1458
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1480
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1459
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1481
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1460
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1482
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1461
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1483
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1462
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1484
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1463
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1485
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1464
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1486
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1465
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1487
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1466
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1488
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1467
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1489
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1468
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1490
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1469
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1491
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1470
 /*! lock: txn global lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1492
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1471
 /*! lock: txn global lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1493
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1472
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1494
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1473
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1495
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1474
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1496
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1475
 /*! log: force log remove time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1497
+#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1476
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1498
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1477
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1499
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1478
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1500
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1479
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1501
+#define	WT_STAT_CONN_LOG_FLUSH				1480
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1502
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1481
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1503
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1482
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1504
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1483
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1505
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1484
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1506
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1485
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1507
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1486
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1508
+#define	WT_STAT_CONN_LOG_SCANS				1487
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1509
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1488
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1510
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1489
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1511
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1490
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1512
+#define	WT_STAT_CONN_LOG_SYNC				1491
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1513
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1492
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1514
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1493
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1515
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1494
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1516
+#define	WT_STAT_CONN_LOG_WRITES				1495
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1517
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1496
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1518
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1497
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1519
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1498
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1520
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1499
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1521
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1500
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1522
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1501
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1523
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1502
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1524
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1503
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1525
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1504
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1526
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1505
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1527
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1506
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1528
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1507
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1529
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1508
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1530
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1509
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1531
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1510
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1532
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1511
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1533
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1512
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1534
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1513
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1535
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1514
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1536
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1515
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1537
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1516
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1538
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1517
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1539
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1518
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1540
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1519
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1541
-/*! perf: block manager read latency histogram (bucket 1) - 0-10ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT10	1542
-/*! perf: block manager read latency histogram (bucket 2) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT50	1543
-/*! perf: block manager read latency histogram (bucket 3) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT100	1544
-/*! perf: block manager read latency histogram (bucket 4) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT250	1545
-/*! perf: block manager read latency histogram (bucket 5) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT500	1546
-/*! perf: block manager read latency histogram (bucket 6) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT1000	1547
-/*! perf: block manager read latency histogram (bucket 7) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_GT1000	1548
-/*! perf: block manager read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_TOTAL_MSECS	1549
-/*! perf: block manager write latency histogram (bucket 1) - 0-10ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT10	1550
-/*! perf: block manager write latency histogram (bucket 2) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT50	1551
-/*! perf: block manager write latency histogram (bucket 3) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT100	1552
-/*! perf: block manager write latency histogram (bucket 4) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT250	1553
-/*! perf: block manager write latency histogram (bucket 5) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT500	1554
-/*! perf: block manager write latency histogram (bucket 6) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT1000	1555
-/*! perf: block manager write latency histogram (bucket 7) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_GT1000	1556
-/*! perf: block manager write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_TOTAL_MSECS	1557
-/*! perf: disagg block manager read latency histogram (bucket 1) - 50-99us */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT100	1558
-/*!
- * perf: disagg block manager read latency histogram (bucket 2) -
- * 100-249us
- */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT250	1559
-/*!
- * perf: disagg block manager read latency histogram (bucket 3) -
- * 250-499us
- */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT500	1560
-/*!
- * perf: disagg block manager read latency histogram (bucket 4) -
- * 500-999us
- */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT1000	1561
-/*!
- * perf: disagg block manager read latency histogram (bucket 5) -
- * 1000-9999us
- */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT10000	1562
-/*!
- * perf: disagg block manager read latency histogram (bucket 6) -
- * 10000us+
- */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_GT10000	1563
-/*! perf: disagg block manager read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_TOTAL_USECS	1564
-/*!
- * perf: disagg block manager write latency histogram (bucket 1) -
- * 50-99us
- */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT100	1565
-/*!
- * perf: disagg block manager write latency histogram (bucket 2) -
- * 100-249us
- */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT250	1566
-/*!
- * perf: disagg block manager write latency histogram (bucket 3) -
- * 250-499us
- */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT500	1567
-/*!
- * perf: disagg block manager write latency histogram (bucket 4) -
- * 500-999us
- */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT1000	1568
-/*!
- * perf: disagg block manager write latency histogram (bucket 5) -
- * 1000-9999us
- */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT10000	1569
-/*!
- * perf: disagg block manager write latency histogram (bucket 6) -
- * 10000us+
- */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_GT10000	1570
-/*! perf: disagg block manager write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_TOTAL_USECS	1571
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1520
 /*! perf: file system read latency histogram (bucket 1) - 0-10ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1572
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1521
 /*! perf: file system read latency histogram (bucket 2) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1573
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1522
 /*! perf: file system read latency histogram (bucket 3) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1574
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1523
 /*! perf: file system read latency histogram (bucket 4) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1575
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1524
 /*! perf: file system read latency histogram (bucket 5) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1576
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1525
 /*! perf: file system read latency histogram (bucket 6) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1577
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1526
 /*! perf: file system read latency histogram (bucket 7) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1578
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1527
 /*! perf: file system read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1579
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1528
 /*! perf: file system write latency histogram (bucket 1) - 0-10ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1580
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1529
 /*! perf: file system write latency histogram (bucket 2) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1581
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1530
 /*! perf: file system write latency histogram (bucket 3) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1582
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1531
 /*! perf: file system write latency histogram (bucket 4) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1583
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1532
 /*! perf: file system write latency histogram (bucket 5) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1584
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1533
 /*! perf: file system write latency histogram (bucket 6) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1585
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1534
 /*! perf: file system write latency histogram (bucket 7) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1586
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1535
 /*! perf: file system write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1587
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1536
 /*! perf: operation read latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1588
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1537
 /*! perf: operation read latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1589
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1538
 /*! perf: operation read latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1590
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1539
 /*! perf: operation read latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1591
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1540
 /*! perf: operation read latency histogram (bucket 5) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1592
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1541
 /*! perf: operation read latency histogram (bucket 6) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1593
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1542
 /*! perf: operation read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1594
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1543
 /*! perf: operation write latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1595
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1544
 /*! perf: operation write latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1596
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1545
 /*! perf: operation write latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1597
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1546
 /*! perf: operation write latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1598
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1547
 /*! perf: operation write latency histogram (bucket 5) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1599
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1548
 /*! perf: operation write latency histogram (bucket 6) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1600
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1549
 /*! perf: operation write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1601
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1550
 /*! prefetch: could not perform pre-fetch on internal page */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1602
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1551
 /*!
  * prefetch: could not perform pre-fetch on ref without the pre-fetch
  * flag set
  */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1603
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1552
 /*! prefetch: number of times pre-fetch failed to start */
-#define	WT_STAT_CONN_PREFETCH_FAILED_START		1604
+#define	WT_STAT_CONN_PREFETCH_FAILED_START		1553
 /*! prefetch: pre-fetch not repeating for recently pre-fetched ref */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1605
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1554
 /*! prefetch: pre-fetch not triggered after single disk read */
-#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1606
+#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1555
 /*! prefetch: pre-fetch not triggered as there is no valid dhandle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1607
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1556
 /*! prefetch: pre-fetch not triggered by page read */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED			1608
+#define	WT_STAT_CONN_PREFETCH_SKIPPED			1557
 /*! prefetch: pre-fetch not triggered due to disk read count */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1609
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1558
 /*! prefetch: pre-fetch not triggered due to internal session */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1610
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1559
 /*! prefetch: pre-fetch not triggered due to special btree handle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1611
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1560
 /*! prefetch: pre-fetch page not on disk when reading */
-#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1612
+#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1561
 /*! prefetch: pre-fetch pages queued */
-#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1613
+#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1562
 /*! prefetch: pre-fetch pages read in background */
-#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1614
+#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1563
 /*! prefetch: pre-fetch skipped reading in a page due to harmless error */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1615
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1564
 /*! prefetch: pre-fetch triggered by page read */
-#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1616
+#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1565
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1617
+#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1566
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1618
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1567
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1619
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1568
+/*! reconciliation: cursor next/prev calls during HS wrapup search_near */
+#define	WT_STAT_CONN_REC_HS_WRAPUP_NEXT_PREV_CALLS	1569
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1620
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1570
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1621
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1571
 /*! reconciliation: maximum milliseconds spent in a reconciliation call */
-#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1622
+#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1572
 /*!
  * reconciliation: maximum milliseconds spent in building a disk image in
  * a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1623
+#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1573
 /*!
  * reconciliation: maximum milliseconds spent in moving updates to the
  * history store in a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1624
+#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1574
 /*! reconciliation: overflow values written */
-#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1625
+#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1575
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1626
+#define	WT_STAT_CONN_REC_PAGES				1576
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1627
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1577
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * prepared transaction metadata
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1628
+#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1578
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * timestamps
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1629
+#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1579
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * transaction ids
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1630
+#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1580
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1631
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1581
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1632
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1582
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1633
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1583
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1634
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1584
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1635
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1585
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1636
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1586
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1637
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1587
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1638
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1588
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1639
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1589
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1640
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1590
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1641
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1591
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1642
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1592
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1643
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1593
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1644
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1594
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1645
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1595
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1646
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1596
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1647
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1597
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1648
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1598
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1649
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1599
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1650
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1600
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1651
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1601
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1652
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1602
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1653
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1603
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1654
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1604
 /*! session: attempts to remove a local object and the object is in use */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1655
+#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1605
 /*! session: flush_tier failed calls */
-#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1656
+#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1606
 /*! session: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1657
+#define	WT_STAT_CONN_FLUSH_TIER				1607
 /*! session: flush_tier tables skipped due to no checkpoint */
-#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1658
+#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1608
 /*! session: flush_tier tables switched */
-#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1659
+#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1609
 /*! session: local objects removed */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1660
+#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1610
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1661
+#define	WT_STAT_CONN_SESSION_OPEN			1611
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1662
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1612
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1663
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1613
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1664
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1614
 /*! session: table alter triggering checkpoint calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1665
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1615
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1666
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1616
 /*! session: table compact conflicted with checkpoint */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1667
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1617
 /*! session: table compact dhandle successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1668
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1618
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1669
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1619
 /*! session: table compact failed calls due to cache pressure */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1670
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1620
 /*! session: table compact passes */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1671
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1621
 /*! session: table compact pulled into eviction */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1672
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1622
 /*! session: table compact running */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1673
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1623
 /*! session: table compact skipped as process would not reduce file size */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1674
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1624
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1675
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1625
 /*! session: table compact timeout */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1676
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1626
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1677
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1627
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1678
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1628
 /*! session: table create with import failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1679
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1629
 /*! session: table create with import repair calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1680
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1630
 /*! session: table create with import successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1681
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1631
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1682
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1632
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1683
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1633
+/*! session: table rename failed calls */
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1634
+/*! session: table rename successful calls */
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1635
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1684
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1636
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1685
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1637
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1686
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1638
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1687
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1639
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1688
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1640
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1689
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1641
 /*! session: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1690
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1642
 /*! session: tiered operations removed without processing */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1691
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1643
 /*! session: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1692
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1644
 /*! session: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1693
+#define	WT_STAT_CONN_TIERED_RETENTION			1645
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1694
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1646
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1695
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1647
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1696
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1648
 /*! thread-yield: application thread operations waiting for cache */
-#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1697
-/*!
- * thread-yield: application thread operations waiting for interruptible
- * cache eviction
- */
-#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_OPS	1698
-/*!
- * thread-yield: application thread operations waiting for mandatory
- * cache eviction
- */
-#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_OPS	1699
+#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1649
 /*! thread-yield: application thread snapshot refreshed for eviction */
-#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1700
+#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1650
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1701
-/*!
- * thread-yield: application thread time waiting for interruptible cache
- * eviction (usecs)
- */
-#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_TIME	1702
-/*!
- * thread-yield: application thread time waiting for mandatory cache
- * eviction (usecs)
- */
-#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_TIME	1703
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1651
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1704
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1652
+/*! thread-yield: connection close yielded for lsm manager shutdown */
+#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1653
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1705
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1654
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1706
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1655
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1707
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1656
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1708
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1657
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1709
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1658
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1710
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1659
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1711
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1660
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1712
+#define	WT_STAT_CONN_PAGE_SLEEP				1661
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1713
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1662
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1714
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1663
+/*! thread-yield: page split and restart read */
+#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1664
+/*! thread-yield: pages skipped during read due to deleted state */
+#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1665
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1715
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1666
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1716
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1667
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1717
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1668
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1718
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1669
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1719
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1670
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1720
+#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1671
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1721
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1672
 /*! transaction: oldest transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1722
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1673
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1723
+#define	WT_STAT_CONN_TXN_PREPARE			1674
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1724
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1675
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1725
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1676
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1726
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1677
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1727
+#define	WT_STAT_CONN_TXN_QUERY_TS			1678
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1728
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1679
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1729
+#define	WT_STAT_CONN_TXN_RTS				1680
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1730
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1681
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1731
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1682
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1732
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1683
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1733
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1684
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1734
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1685
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1735
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1686
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1736
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1687
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1737
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1688
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1738
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1689
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1739
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1690
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1740
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1691
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1741
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1692
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1742
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1693
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1743
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1694
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1744
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1695
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1745
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1696
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1746
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1697
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1747
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1698
 /*!
  * transaction: rollback to stable updates that would have been aborted
  * in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1748
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1699
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1749
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1700
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1750
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1701
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1751
+#define	WT_STAT_CONN_TXN_SET_TS				1702
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1752
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1703
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1753
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1704
 /*! transaction: set timestamp force calls */
-#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1754
+#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1705
 /*!
  * transaction: set timestamp global oldest timestamp set to be more
  * recent than the global stable timestamp
  */
-#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1755
+#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1706
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1756
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1707
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1757
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1708
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1758
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1709
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1759
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1710
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1760
+#define	WT_STAT_CONN_TXN_BEGIN				1711
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1761
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1712
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1762
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1713
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1763
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1714
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1764
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1715
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1765
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1716
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1766
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1717
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1767
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1718
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1768
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1719
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1769
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1720
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1770
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1721
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1771
+#define	WT_STAT_CONN_TXN_COMMIT				1722
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1772
+#define	WT_STAT_CONN_TXN_ROLLBACK			1723
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1773
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1724
 
 /*!
  * @}

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -1680,6 +1680,7 @@ static const char *const __stats_connection_desc[] = {
   "cache: leaf pages split during eviction",
   "cache: locate a random in-mem ref by examining all entries on the root page",
   "cache: maximum bytes configured",
+  "cache: maximum gap between page and connection evict pass generation seen at eviction",
   "cache: maximum milliseconds spent at a single eviction",
   "cache: maximum page size seen at eviction",
   "cache: modified page evict attempts by application threads",
@@ -2456,8 +2457,9 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->cache_eviction_split_leaf = 0;
     stats->cache_eviction_random_sample_inmem_root = 0;
     /* not clearing cache_bytes_max */
-    /* not clearing cache_eviction_maximum_milliseconds */
-    /* not clearing cache_eviction_maximum_page_size */
+    /* not clearing eviction_maximum_gen_gap */
+    /* not clearing eviction_maximum_milliseconds */
+    /* not clearing eviction_maximum_page_size */
     stats->eviction_app_dirty_attempt = 0;
     stats->eviction_app_dirty_fail = 0;
     stats->cache_eviction_dirty = 0;
@@ -3243,6 +3245,7 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->cache_eviction_random_sample_inmem_root +=
       WT_STAT_READ(from, cache_eviction_random_sample_inmem_root);
     to->cache_bytes_max += WT_STAT_READ(from, cache_bytes_max);
+    to->eviction_maximum_gen_gap += WT_STAT_READ(from, eviction_maximum_gen_gap);
     to->cache_eviction_maximum_milliseconds +=
       WT_STAT_READ(from, cache_eviction_maximum_milliseconds);
     to->cache_eviction_maximum_page_size += WT_STAT_READ(from, cache_eviction_maximum_page_size);

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -2457,9 +2457,9 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->cache_eviction_split_leaf = 0;
     stats->cache_eviction_random_sample_inmem_root = 0;
     /* not clearing cache_bytes_max */
-    /* not clearing eviction_maximum_gen_gap */
-    /* not clearing eviction_maximum_milliseconds */
-    /* not clearing eviction_maximum_page_size */
+    /* not clearing cache_eviction_maximum_gen_gap */
+    /* not clearing cache_eviction_maximum_milliseconds */
+    /* not clearing cache_eviction_maximum_page_size */
     stats->eviction_app_dirty_attempt = 0;
     stats->eviction_app_dirty_fail = 0;
     stats->cache_eviction_dirty = 0;
@@ -3245,7 +3245,7 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->cache_eviction_random_sample_inmem_root +=
       WT_STAT_READ(from, cache_eviction_random_sample_inmem_root);
     to->cache_bytes_max += WT_STAT_READ(from, cache_bytes_max);
-    to->eviction_maximum_gen_gap += WT_STAT_READ(from, eviction_maximum_gen_gap);
+    to->cache_eviction_maximum_gen_gap += WT_STAT_READ(from, cache_eviction_maximum_gen_gap);
     to->cache_eviction_maximum_milliseconds +=
       WT_STAT_READ(from, cache_eviction_maximum_milliseconds);
     to->cache_eviction_maximum_page_size += WT_STAT_READ(from, cache_eviction_maximum_page_size);

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -1156,6 +1156,7 @@ __txn_checkpoint(WT_SESSION_IMPL *session, const char *cfg[])
     logging = FLD_ISSET(conn->log_flags, WT_CONN_LOG_ENABLED);
 
     /* Reset the statistics tracked per checkpoint. */
+    cache->evict_max_gen_gap = 0;
     cache->evict_max_page_size = 0;
     cache->evict_max_ms = 0;
     cache->reentry_hs_eviction_ms = 0;


### PR DESCRIPTION
This backports the evict_max_gen_gap stat added in WT-14273, moving it from an EvictStat to a CacheStat