### PR TITLE
Revert "WT-15773 Fix unit test on MacOS"

### DIFF
--- a/ext/page_log/palite/CMakeLists.txt
+++ b/ext/page_log/palite/CMakeLists.txt
@@ -11,7 +11,7 @@ else()
 endif()
 
 if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS CXX_COMPILER_MIN_VERSION)
-    message(FATAL_ERROR "Cannot build PALite: C++ compiler does not support C++20. "
+    message(WARNING "Skipping PALite build: C++ compiler does not support C++20."
         "Required version: ${CXX_COMPILER_MIN_VERSION}; found: ${CMAKE_CXX_COMPILER_VERSION}")
     return()
 endif()

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -275,7 +275,6 @@ functions:
           ${ENABLE_CPPSUITE|} \
           ${ENABLE_GCP|} \
           ${ENABLE_S3|} \
-          ${ENABLE_PALITE|-DENABLE_PALITE=ON} \
           ${IMPORT_AZURE_SDK|} \
           ${IMPORT_GCP_SDK|} \
           ${IMPORT_S3_SDK|} \
@@ -551,9 +550,8 @@ functions:
               if [ -d cmake_build ]; then rm -r cmake_build; fi
               mkdir -p cmake_build
               pushd cmake_build
-              # Adding -DENABLE_PYTHON=ON -DENABLE_STRICT=ON as 6.0 does not default these like develop.
-              # Disable PALite build, as docs build does not need it and it can fail to build on some platforms.
-              $CMAKE -DCMAKE_C_FLAGS="-DMIGHT_NOT_RUN -Wno-error" -DENABLE_PYTHON=ON -DENABLE_STRICT=ON -DENABLE_PALITE=OFF ../.
+              # Adding -DENABLE_PYTHON=1 -DENABLE_STRICT=1 as 6.0 does not default these like develop.
+              $CMAKE -DCMAKE_C_FLAGS="-DMIGHT_NOT_RUN -Wno-error" -DENABLE_PYTHON=1 -DENABLE_STRICT=1 ../.
               make -C lang/python -j ${num_jobs}
             fi
             # Pop to root project directory.
@@ -1449,8 +1447,6 @@ variables:
       # We'll explicitly use the python3 in /usr/bin, we use the same in configuring cmake.
       CMAKE_TOOLCHAIN_FILE:
       CC_OPTIMIZE_LEVEL: -DCC_OPTIMIZE_LEVEL=-O0
-      # FIXME-WT-15777 PALite currently does not build on macOS 14 (ARM64) because of outdated CLang.
-      ENABLE_PALITE: -DENABLE_PALITE=OFF
       num_jobs: $(echo $(sysctl -n hw.logicalcpu) / 2 | bc)
       cmake_generator: "Unix Makefiles"
       additional_env_vars: |
@@ -1458,8 +1454,6 @@ variables:
         export DYLD_LIBRARY_PATH=$WT_BUILDDIR
       # Must disable TCMALLOC as it may be picked up locally and its not on all hosts.
       ENABLE_TCMALLOC: 0
-      # FIXME-WT-15777 Use PALM for unit tests for now until we can build PALite on macos-14.
-      unit_test_variant_args: "page_log=palm"
     tasks:
       - name: compile
         # This is a special case and should *only* be used for the macOS buildvariant.
@@ -1713,22 +1707,18 @@ tasks:
       - func: "compile wiredtiger"
         vars:
           GNU_C_VERSION: -DGNU_C_VERSION=7
-          ENABLE_PALITE: -DENABLE_PALITE=OFF
       - func: "compile wiredtiger"
         vars:
           GNU_C_VERSION: -DGNU_C_VERSION=8
           GNU_CXX_VERSION: -DGNU_CXX_VERSION=8
-          ENABLE_PALITE: -DENABLE_PALITE=OFF
       - func: "compile wiredtiger"
         vars:
           GNU_C_VERSION: -DGNU_C_VERSION=9
           GNU_CXX_VERSION: -DGNU_CXX_VERSION=9
-          ENABLE_PALITE: -DENABLE_PALITE=OFF
       - func: "compile wiredtiger"
         vars:
           GNU_C_VERSION: -DGNU_C_VERSION=11
           GNU_CXX_VERSION: -DGNU_CXX_VERSION=11
-          ENABLE_PALITE: -DENABLE_PALITE=OFF
 
   - name: compile-clang
     tags: ["pull_request", "pull_request_compilers"]
@@ -1750,37 +1740,30 @@ tasks:
         vars:
           CLANG_C_VERSION: -DCLANG_C_VERSION=7
           CLANG_CXX_VERSION: -DCLANG_CXX_VERSION=7
-          ENABLE_PALITE: -DENABLE_PALITE=OFF
       - func: "compile wiredtiger"
         vars:
           CLANG_C_VERSION: -DCLANG_C_VERSION=8
           CLANG_CXX_VERSION: -DCLANG_CXX_VERSION=8
-          ENABLE_PALITE: -DENABLE_PALITE=OFF
       - func: "compile wiredtiger"
         vars:
           CLANG_C_VERSION: -DCLANG_C_VERSION=9
           CLANG_CXX_VERSION: -DCLANG_CXX_VERSION=9
-          ENABLE_PALITE: -DENABLE_PALITE=OFF
       - func: "compile wiredtiger"
         vars:
           CLANG_C_VERSION: -DCLANG_C_VERSION=10
           CLANG_CXX_VERSION: -DCLANG_CXX_VERSION=10
-          ENABLE_PALITE: -DENABLE_PALITE=OFF
       - func: "compile wiredtiger"
         vars:
           CLANG_C_VERSION: -DCLANG_C_VERSION=11
           CLANG_CXX_VERSION: -DCLANG_CXX_VERSION=12
-          ENABLE_PALITE: -DENABLE_PALITE=OFF
       - func: "compile wiredtiger"
         vars:
           CLANG_C_VERSION: -DCLANG_C_VERSION=13
           CLANG_CXX_VERSION: -DCLANG_CXX_VERSION=13
-          ENABLE_PALITE: -DENABLE_PALITE=OFF
       - func: "compile wiredtiger"
         vars:
           CLANG_C_VERSION: -DCLANG_C_VERSION=14
           CLANG_CXX_VERSION: -DCLANG_CXX_VERSION=14
-          ENABLE_PALITE: -DENABLE_PALITE=OFF
 
   # Compile WiredTiger with uncommon build flags to make sure we compile code that
   # is often pre-processed out.


### PR DESCRIPTION
Reverts wiredtiger/wiredtiger#12572

- Requiring newer compiler breaks several builds.
- Need to fix all these failures first, before applying the change.