### PR TITLE
WT-15778 Fix rec_prefix_compression miscount for page delta

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -1072,7 +1072,8 @@ dsrc_stats = [
     ##########################################
     RecStat('rec_dictionary', 'dictionary matches'),
     RecStat('rec_multiblock_max', 'maximum blocks required for a page', 'max_aggregate,no_scale'),
-    RecStat('rec_prefix_compression', 'leaf page key bytes discarded using prefix compression', 'size'),
+    RecStat('rec_prefix_compression_delta', 'leaf delta page key bytes discarded using prefix compression', 'size'),
+    RecStat('rec_prefix_compression_full', 'leaf full page key bytes discarded using prefix compression', 'size'),
     RecStat('rec_suffix_compression', 'internal page key bytes discarded using suffix compression', 'size'),
 
     ##########################################

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -1667,8 +1667,9 @@ struct __wt_dsrc_stats {
     int64_t rec_page_delta_internal;
     int64_t rec_suffix_compression;
     int64_t rec_multiblock_internal;
+    int64_t rec_prefix_compression_delta;
+    int64_t rec_prefix_compression_full;
     int64_t rec_page_delta_leaf;
-    int64_t rec_prefix_compression;
     int64_t rec_multiblock_leaf;
     int64_t rec_overflow_key_leaf;
     int64_t rec_max_internal_page_deltas;

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -9407,193 +9407,201 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_DSRC_REC_SUFFIX_COMPRESSION		2317
 /*! reconciliation: internal page multi-block writes */
 #define	WT_STAT_DSRC_REC_MULTIBLOCK_INTERNAL		2318
+/*!
+ * reconciliation: leaf delta page key bytes discarded using prefix
+ * compression
+ */
+#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION_DELTA	2319
+/*!
+ * reconciliation: leaf full page key bytes discarded using prefix
+ * compression
+ */
+#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION_FULL	2320
 /*! reconciliation: leaf page deltas written */
-#define	WT_STAT_DSRC_REC_PAGE_DELTA_LEAF		2319
-/*! reconciliation: leaf page key bytes discarded using prefix compression */
-#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION		2320
+#define	WT_STAT_DSRC_REC_PAGE_DELTA_LEAF		2321
 /*! reconciliation: leaf page multi-block writes */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_LEAF		2321
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_LEAF		2322
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_LEAF		2322
+#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_LEAF		2323
 /*! reconciliation: max deltas seen on internal page during reconciliation */
-#define	WT_STAT_DSRC_REC_MAX_INTERNAL_PAGE_DELTAS	2323
+#define	WT_STAT_DSRC_REC_MAX_INTERNAL_PAGE_DELTAS	2324
 /*! reconciliation: max deltas seen on leaf page during reconciliation */
-#define	WT_STAT_DSRC_REC_MAX_LEAF_PAGE_DELTAS		2324
+#define	WT_STAT_DSRC_REC_MAX_LEAF_PAGE_DELTAS		2325
 /*! reconciliation: maximum blocks required for a page */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_MAX			2325
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_MAX			2326
 /*!
  * reconciliation: number of keys that are garbage collected in the
  * ingest table for disaggregated storage
  */
-#define	WT_STAT_DSRC_REC_INGEST_GARBAGE_COLLECTION_KEYS	2326
+#define	WT_STAT_DSRC_REC_INGEST_GARBAGE_COLLECTION_KEYS	2327
 /*! reconciliation: overflow values written */
-#define	WT_STAT_DSRC_REC_OVERFLOW_VALUE			2327
+#define	WT_STAT_DSRC_REC_OVERFLOW_VALUE			2328
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_DSRC_REC_PAGES				2328
+#define	WT_STAT_DSRC_REC_PAGES				2329
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_DSRC_REC_PAGES_EVICTION			2329
+#define	WT_STAT_DSRC_REC_PAGES_EVICTION			2330
 /*! reconciliation: page reconciliation calls for pages between 1 and 10MB */
-#define	WT_STAT_DSRC_REC_PAGES_SIZE_1MB_TO_10MB		2330
+#define	WT_STAT_DSRC_REC_PAGES_SIZE_1MB_TO_10MB		2331
 /*!
  * reconciliation: page reconciliation calls for pages between 10 and
  * 100MB
  */
-#define	WT_STAT_DSRC_REC_PAGES_SIZE_10MB_TO_100MB	2331
+#define	WT_STAT_DSRC_REC_PAGES_SIZE_10MB_TO_100MB	2332
 /*!
  * reconciliation: page reconciliation calls for pages between 100MB and
  * 1GB
  */
-#define	WT_STAT_DSRC_REC_PAGES_SIZE_100MB_TO_1GB	2332
+#define	WT_STAT_DSRC_REC_PAGES_SIZE_100MB_TO_1GB	2333
 /*! reconciliation: page reconciliation calls for pages over 1GB */
-#define	WT_STAT_DSRC_REC_PAGES_SIZE_1GB_PLUS		2333
+#define	WT_STAT_DSRC_REC_PAGES_SIZE_1GB_PLUS		2334
 /*! reconciliation: pages deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELETE			2334
+#define	WT_STAT_DSRC_REC_PAGE_DELETE			2335
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	2335
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	2336
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	2336
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	2337
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TS	2337
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TS	2338
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TXN	2338
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TXN	2339
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_TXN		2339
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_TXN		2340
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_OLDEST_START_TS	2340
+#define	WT_STAT_DSRC_REC_TIME_AGGR_OLDEST_START_TS	2341
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_PREPARED		2341
+#define	WT_STAT_DSRC_REC_TIME_AGGR_PREPARED		2342
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_PREPARED	2342
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_PREPARED	2343
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	2343
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	2344
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TS	2344
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TS	2345
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TXN	2345
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TXN	2346
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	2346
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	2347
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TS	2347
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TS	2348
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TXN	2348
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TXN	2349
 /*! reconciliation: pages written with at least one internal page delta */
-#define	WT_STAT_DSRC_REC_PAGES_WITH_INTERNAL_DELTAS	2349
+#define	WT_STAT_DSRC_REC_PAGES_WITH_INTERNAL_DELTAS	2350
 /*! reconciliation: pages written with at least one leaf page delta */
-#define	WT_STAT_DSRC_REC_PAGES_WITH_LEAF_DELTAS		2350
+#define	WT_STAT_DSRC_REC_PAGES_WITH_LEAF_DELTAS		2351
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PREPARED		2351
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PREPARED		2352
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_START_TS	2352
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_START_TS	2353
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TS		2353
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TS		2354
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TXN		2354
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TXN		2355
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_STOP_TS	2355
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_STOP_TS	2356
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TS		2356
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TS		2357
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TXN		2357
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TXN		2358
 /*! session: object compaction */
-#define	WT_STAT_DSRC_SESSION_COMPACT			2358
+#define	WT_STAT_DSRC_SESSION_COMPACT			2359
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_COMMIT	2359
+#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_COMMIT	2360
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_DSRC_TXN_READ_OVERFLOW_REMOVE		2360
+#define	WT_STAT_DSRC_TXN_READ_OVERFLOW_REMOVE		2361
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_UPDATE	2361
+#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_UPDATE	2362
 /*! transaction: rollback to stable applied btrees */
-#define	WT_STAT_DSRC_TXN_RTS_BTREES_APPLIED		2362
+#define	WT_STAT_DSRC_TXN_RTS_BTREES_APPLIED		2363
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	2363
+#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	2364
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2364
+#define	WT_STAT_DSRC_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2365
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_DSRC_TXN_RTS_INCONSISTENT_CKPT		2365
+#define	WT_STAT_DSRC_TXN_RTS_INCONSISTENT_CKPT		2366
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED		2366
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED		2367
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED		2367
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED		2368
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED_DRYRUN	2368
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED_DRYRUN	2369
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED_DRYRUN	2369
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED_DRYRUN	2370
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES	2370
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES	2371
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES		2371
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES		2372
 /*! transaction: rollback to stable skipped btrees */
-#define	WT_STAT_DSRC_TXN_RTS_BTREES_SKIPPED		2372
+#define	WT_STAT_DSRC_TXN_RTS_BTREES_SKIPPED		2373
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_DSRC_TXN_RTS_DELETE_RLE_SKIPPED		2373
+#define	WT_STAT_DSRC_TXN_RTS_DELETE_RLE_SKIPPED		2374
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_DSRC_TXN_RTS_STABLE_RLE_SKIPPED		2374
+#define	WT_STAT_DSRC_TXN_RTS_STABLE_RLE_SKIPPED		2375
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS		2375
+#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS		2376
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	2376
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	2377
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	2377
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	2378
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED			2378
+#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED			2379
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED_DRYRUN		2379
+#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED_DRYRUN		2380
 /*! transaction: update conflicts */
-#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2380
+#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2381
 
 /*!
  * @}

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -80,7 +80,7 @@ __rec_cell_build_int_key(WT_SESSION_IMPL *session, WTI_RECONCILE *r, const void 
  */
 static int
 __rec_cell_build_leaf_key(WT_SESSION_IMPL *session, WTI_RECONCILE *r, const void *data, size_t size,
-  bool *is_ovflp, bool is_delta)
+  bool is_delta, bool *is_ovflp)
 {
     WT_BTREE *btree;
     WTI_REC_KV *key;
@@ -165,7 +165,7 @@ __rec_cell_build_leaf_key(WT_SESSION_IMPL *session, WTI_RECONCILE *r, const void
             *is_ovflp = true;
             return (__wti_rec_cell_build_ovfl(session, r, key, WT_CELL_KEY_OVFL, NULL, 0));
         }
-        return (__rec_cell_build_leaf_key(session, r, NULL, 0, is_ovflp, is_delta));
+        return (__rec_cell_build_leaf_key(session, r, NULL, 0, is_delta, is_ovflp));
     }
 
     key->cell_len = __wt_cell_pack_leaf_key(&key->cell, pfx, key->buf.size);
@@ -196,7 +196,7 @@ __wt_bulk_insert_row(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk)
     key = &r->k;
     val = &r->v;
     WT_RET(__rec_cell_build_leaf_key(session, r, /* Build key cell */
-      cursor->key.data, cursor->key.size, &ovfl_key, false));
+      cursor->key.data, cursor->key.size, false, &ovfl_key));
     if (cursor->value.size == 0)
         val->len = 0;
     else
@@ -213,7 +213,7 @@ __wt_bulk_insert_row(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk)
             r->key_pfx_compress = false;
             r->key_pfx_last = 0;
             if (!ovfl_key)
-                WT_RET(__rec_cell_build_leaf_key(session, r, NULL, 0, &ovfl_key, false));
+                WT_RET(__rec_cell_build_leaf_key(session, r, NULL, 0, false, &ovfl_key));
         }
         WT_RET(__wti_rec_split_crossing_bnd(session, r, key->len + val->len));
     }
@@ -335,7 +335,7 @@ __wti_rec_pack_delta_row_leaf(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_SAV
     /* Get the key data and pack it into a key cell. */
     WT_ERR(__wt_scr_alloc(session, 0, &key));
     WT_ERR(__wti_rec_get_row_leaf_key(session, S2BT(session), r, supd->ins, supd->rip, key));
-    WT_ERR(__rec_cell_build_leaf_key(session, r, key->data, key->size, &ovfl_key, true));
+    WT_ERR(__rec_cell_build_leaf_key(session, r, key->data, key->size, true, &ovfl_key));
     WT_ASSERT(session, !ovfl_key);
 
     /*
@@ -1023,7 +1023,7 @@ __rec_row_leaf_insert(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_INSERT *ins
 
         /* Build key cell. */
         WT_ERR(__rec_cell_build_leaf_key(
-          session, r, WT_INSERT_KEY(ins), WT_INSERT_KEY_SIZE(ins), &ovfl_key, false));
+          session, r, WT_INSERT_KEY(ins), WT_INSERT_KEY_SIZE(ins), false, &ovfl_key));
 
         /* Boundary: split or write the page. */
         if (__wti_rec_need_split(r, key->len + val->len)) {
@@ -1035,7 +1035,7 @@ __rec_row_leaf_insert(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_INSERT *ins
                 r->key_pfx_compress = false;
                 r->key_pfx_last = 0;
                 if (!ovfl_key)
-                    WT_ERR(__rec_cell_build_leaf_key(session, r, NULL, 0, &ovfl_key, false));
+                    WT_ERR(__rec_cell_build_leaf_key(session, r, NULL, 0, false, &ovfl_key));
             }
 
             WT_ERR(__wti_rec_split_crossing_bnd(session, r, key->len + val->len));
@@ -1418,7 +1418,7 @@ slow:
             }
 
             WT_ERR(__rec_cell_build_leaf_key(
-              session, r, lastkey->data, lastkey->size, &ovfl_key, false));
+              session, r, lastkey->data, lastkey->size, false, &ovfl_key));
         }
 
         /* Boundary: split or write the page. */
@@ -1440,7 +1440,7 @@ slow:
                 r->key_pfx_compress = false;
                 r->key_pfx_last = 0;
                 if (!ovfl_key)
-                    WT_ERR(__rec_cell_build_leaf_key(session, r, NULL, 0, &ovfl_key, false));
+                    WT_ERR(__rec_cell_build_leaf_key(session, r, NULL, 0, false, &ovfl_key));
             }
 
             WT_ERR(__wti_rec_split_crossing_bnd(session, r, key->len + val->len));

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -79,8 +79,8 @@ __rec_cell_build_int_key(WT_SESSION_IMPL *session, WTI_RECONCILE *r, const void 
  *     page.
  */
 static int
-__rec_cell_build_leaf_key(
-  WT_SESSION_IMPL *session, WTI_RECONCILE *r, const void *data, size_t size, bool *is_ovflp)
+__rec_cell_build_leaf_key(WT_SESSION_IMPL *session, WTI_RECONCILE *r, const void *data, size_t size,
+  bool *is_ovflp, bool is_delta)
 {
     WT_BTREE *btree;
     WTI_REC_KV *key;
@@ -140,8 +140,12 @@ __rec_cell_build_leaf_key(
               pfx < r->key_pfx_last + WTI_KEY_PREFIX_PREVIOUS_MINIMUM)
                 pfx = r->key_pfx_last;
 
-            if (pfx != 0)
-                WT_STAT_DSRC_INCRV(session, rec_prefix_compression, pfx);
+            if (pfx != 0) {
+                if (is_delta)
+                    r->bytes_prefix_compression_delta += pfx;
+                else
+                    r->bytes_prefix_compression_full += pfx;
+            }
         }
 
         /* Copy the non-prefix bytes into the key buffer. */
@@ -161,7 +165,7 @@ __rec_cell_build_leaf_key(
             *is_ovflp = true;
             return (__wti_rec_cell_build_ovfl(session, r, key, WT_CELL_KEY_OVFL, NULL, 0));
         }
-        return (__rec_cell_build_leaf_key(session, r, NULL, 0, is_ovflp));
+        return (__rec_cell_build_leaf_key(session, r, NULL, 0, is_ovflp, is_delta));
     }
 
     key->cell_len = __wt_cell_pack_leaf_key(&key->cell, pfx, key->buf.size);
@@ -192,7 +196,7 @@ __wt_bulk_insert_row(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk)
     key = &r->k;
     val = &r->v;
     WT_RET(__rec_cell_build_leaf_key(session, r, /* Build key cell */
-      cursor->key.data, cursor->key.size, &ovfl_key));
+      cursor->key.data, cursor->key.size, &ovfl_key, false));
     if (cursor->value.size == 0)
         val->len = 0;
     else
@@ -209,7 +213,7 @@ __wt_bulk_insert_row(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk)
             r->key_pfx_compress = false;
             r->key_pfx_last = 0;
             if (!ovfl_key)
-                WT_RET(__rec_cell_build_leaf_key(session, r, NULL, 0, &ovfl_key));
+                WT_RET(__rec_cell_build_leaf_key(session, r, NULL, 0, &ovfl_key, false));
         }
         WT_RET(__wti_rec_split_crossing_bnd(session, r, key->len + val->len));
     }
@@ -331,7 +335,7 @@ __wti_rec_pack_delta_row_leaf(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_SAV
     /* Get the key data and pack it into a key cell. */
     WT_ERR(__wt_scr_alloc(session, 0, &key));
     WT_ERR(__wti_rec_get_row_leaf_key(session, S2BT(session), r, supd->ins, supd->rip, key));
-    WT_ERR(__rec_cell_build_leaf_key(session, r, key->data, key->size, &ovfl_key));
+    WT_ERR(__rec_cell_build_leaf_key(session, r, key->data, key->size, &ovfl_key, true));
     WT_ASSERT(session, !ovfl_key);
 
     /*
@@ -1019,7 +1023,7 @@ __rec_row_leaf_insert(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_INSERT *ins
 
         /* Build key cell. */
         WT_ERR(__rec_cell_build_leaf_key(
-          session, r, WT_INSERT_KEY(ins), WT_INSERT_KEY_SIZE(ins), &ovfl_key));
+          session, r, WT_INSERT_KEY(ins), WT_INSERT_KEY_SIZE(ins), &ovfl_key, false));
 
         /* Boundary: split or write the page. */
         if (__wti_rec_need_split(r, key->len + val->len)) {
@@ -1031,7 +1035,7 @@ __rec_row_leaf_insert(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_INSERT *ins
                 r->key_pfx_compress = false;
                 r->key_pfx_last = 0;
                 if (!ovfl_key)
-                    WT_ERR(__rec_cell_build_leaf_key(session, r, NULL, 0, &ovfl_key));
+                    WT_ERR(__rec_cell_build_leaf_key(session, r, NULL, 0, &ovfl_key, false));
             }
 
             WT_ERR(__wti_rec_split_crossing_bnd(session, r, key->len + val->len));
@@ -1413,7 +1417,8 @@ slow:
                 WT_ERR(__wt_row_leaf_key_copy(session, page, rip, lastkey));
             }
 
-            WT_ERR(__rec_cell_build_leaf_key(session, r, lastkey->data, lastkey->size, &ovfl_key));
+            WT_ERR(__rec_cell_build_leaf_key(
+              session, r, lastkey->data, lastkey->size, &ovfl_key, false));
         }
 
         /* Boundary: split or write the page. */
@@ -1435,7 +1440,7 @@ slow:
                 r->key_pfx_compress = false;
                 r->key_pfx_last = 0;
                 if (!ovfl_key)
-                    WT_ERR(__rec_cell_build_leaf_key(session, r, NULL, 0, &ovfl_key));
+                    WT_ERR(__rec_cell_build_leaf_key(session, r, NULL, 0, &ovfl_key, false));
             }
 
             WT_ERR(__wti_rec_split_crossing_bnd(session, r, key->len + val->len));

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2403,6 +2403,8 @@ __rec_write_delta(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_CHUNK *chu
         WT_STAT_CONN_DSRC_INCR(session, rec_page_delta_leaf);
         WT_STAT_CONN_INCRV(
           session, block_byte_write_saved_delta_leaf, chunk->image.size - r->delta.size);
+        WT_STAT_DSRC_INCRV(
+          session, rec_prefix_compression_delta, r->bytes_prefix_compression_delta);
 
         if (delta_pct <= 20)
             WT_STAT_CONN_INCR(session, block_byte_write_leaf_delta_lt20);
@@ -2726,6 +2728,7 @@ __rec_split_write(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_CHUNK *chu
     } else {
         WT_RET(
           __rec_write_image(session, r, chunk, addr, &addr_size, &compressed_size, last_block));
+        WT_STAT_DSRC_INCRV(session, rec_prefix_compression_full, r->bytes_prefix_compression_full);
 #ifdef HAVE_DIAGNOSTIC
         verify_image = true;
 #endif
@@ -2766,6 +2769,7 @@ copy_image:
     /* Whether we wrote or not, clear the accumulated time statistics. */
     __rec_page_time_stats_clear(r);
     __rec_page_delta_stats_clear(r);
+    __rec_page_pfx_compression_stats_clear(r);
 
     return (0);
 }

--- a/src/reconcile/reconcile_inline.h
+++ b/src/reconcile/reconcile_inline.h
@@ -84,6 +84,17 @@ __rec_page_delta_stats_clear(WTI_RECONCILE *r)
 }
 
 /*
+ * __rec_page_pfx_compression_stats_clear --
+ *     Clear page prefix compression statistics.
+ */
+static WT_INLINE void
+__rec_page_pfx_compression_stats_clear(WTI_RECONCILE *r)
+{
+    r->bytes_prefix_compression_delta = 0;
+    r->bytes_prefix_compression_full = 0;
+}
+
+/*
  * __rec_page_time_stats --
  *     Update statistics about this page.
  */

--- a/src/reconcile/reconcile_private.h
+++ b/src/reconcile/reconcile_private.h
@@ -305,6 +305,10 @@ struct __wti_reconcile {
     uint32_t count_internal_page_delta_key_deleted;
     uint32_t count_internal_page_delta_key_updated;
 
+    /* Stats for key bytes discarded using prefix compression.*/
+    uint32_t bytes_prefix_compression_delta;
+    uint32_t bytes_prefix_compression_full;
+
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */
 #define WTI_REC_TIME_NEWEST_START_DURABLE_TS 0x01u
 #define WTI_REC_TIME_NEWEST_STOP_DURABLE_TS 0x02u

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -339,8 +339,9 @@ static const char *const __stats_dsrc_desc[] = {
   "reconciliation: internal page deltas written",
   "reconciliation: internal page key bytes discarded using suffix compression",
   "reconciliation: internal page multi-block writes",
+  "reconciliation: leaf delta page key bytes discarded using prefix compression",
+  "reconciliation: leaf full page key bytes discarded using prefix compression",
   "reconciliation: leaf page deltas written",
-  "reconciliation: leaf page key bytes discarded using prefix compression",
   "reconciliation: leaf page multi-block writes",
   "reconciliation: leaf-page overflow keys",
   "reconciliation: max deltas seen on internal page during reconciliation",
@@ -766,8 +767,9 @@ __wt_stat_dsrc_clear_single(WT_DSRC_STATS *stats)
     stats->rec_page_delta_internal = 0;
     stats->rec_suffix_compression = 0;
     stats->rec_multiblock_internal = 0;
+    stats->rec_prefix_compression_delta = 0;
+    stats->rec_prefix_compression_full = 0;
     stats->rec_page_delta_leaf = 0;
-    stats->rec_prefix_compression = 0;
     stats->rec_multiblock_leaf = 0;
     stats->rec_overflow_key_leaf = 0;
     stats->rec_max_internal_page_deltas = 0;
@@ -1197,8 +1199,9 @@ __wt_stat_dsrc_aggregate_single(WT_DSRC_STATS *from, WT_DSRC_STATS *to)
     to->rec_page_delta_internal += from->rec_page_delta_internal;
     to->rec_suffix_compression += from->rec_suffix_compression;
     to->rec_multiblock_internal += from->rec_multiblock_internal;
+    to->rec_prefix_compression_delta += from->rec_prefix_compression_delta;
+    to->rec_prefix_compression_full += from->rec_prefix_compression_full;
     to->rec_page_delta_leaf += from->rec_page_delta_leaf;
-    to->rec_prefix_compression += from->rec_prefix_compression;
     to->rec_multiblock_leaf += from->rec_multiblock_leaf;
     to->rec_overflow_key_leaf += from->rec_overflow_key_leaf;
     to->rec_max_internal_page_deltas += from->rec_max_internal_page_deltas;
@@ -1665,8 +1668,9 @@ __wt_stat_dsrc_aggregate(WT_DSRC_STATS **from, WT_DSRC_STATS *to)
     to->rec_page_delta_internal += WT_STAT_DSRC_READ(from, rec_page_delta_internal);
     to->rec_suffix_compression += WT_STAT_DSRC_READ(from, rec_suffix_compression);
     to->rec_multiblock_internal += WT_STAT_DSRC_READ(from, rec_multiblock_internal);
+    to->rec_prefix_compression_delta += WT_STAT_DSRC_READ(from, rec_prefix_compression_delta);
+    to->rec_prefix_compression_full += WT_STAT_DSRC_READ(from, rec_prefix_compression_full);
     to->rec_page_delta_leaf += WT_STAT_DSRC_READ(from, rec_page_delta_leaf);
-    to->rec_prefix_compression += WT_STAT_DSRC_READ(from, rec_prefix_compression);
     to->rec_multiblock_leaf += WT_STAT_DSRC_READ(from, rec_multiblock_leaf);
     to->rec_overflow_key_leaf += WT_STAT_DSRC_READ(from, rec_overflow_key_leaf);
     to->rec_max_internal_page_deltas += WT_STAT_DSRC_READ(from, rec_max_internal_page_deltas);

--- a/test/suite/test_layered54.py
+++ b/test/suite/test_layered54.py
@@ -72,7 +72,7 @@ class test_layered54(wttest.WiredTigerTestCase):
         stat_cursor.close()
         return val
 
-    def insert(self, kv, ts):
+    def insert_or_update(self, kv, ts):
         cursor = self.session.open_cursor(self.uri, None, None)
         for k, v in kv.items():
             self.session.begin_transaction()
@@ -99,26 +99,32 @@ class test_layered54(wttest.WiredTigerTestCase):
         initial_value = "abc" * 10
         initial_ts = 5
         kv = {f'{initial_key}{i}': initial_value for i in range(1, self.nrows + 1)}
-        self.insert(kv, initial_ts)
+        self.insert_or_update(kv, initial_ts)
         self.session.checkpoint()
         # We should see suffix compression happened.
         self.assertGreater(self.get_stat(stat.dsrc.rec_suffix_compression, self.uri), 0)
-        # We should see prefix compression happened if it is configured.
+        # There's no prefix compression for delta yet.
+        self.assertEqual(self.get_stat(stat.dsrc.rec_prefix_compression_delta, self.uri), 0)
+        # We should see prefix compression for full page if it is configured.
         if (prefix_compression):
-            self.assertGreater(self.get_stat(stat.dsrc.rec_prefix_compression, self.uri), 0)
+            self.assertGreater(self.get_stat(stat.dsrc.rec_prefix_compression_full, self.uri), 0)
         else:
-            self.assertEqual(self.get_stat(stat.dsrc.rec_prefix_compression, self.uri), 0)
+            self.assertEqual(self.get_stat(stat.dsrc.rec_prefix_compression_full, self.uri), 0)
 
-        # Re-open the connection to clear contents out of memory.
+         # Re-open the connection to clear contents out of memory.
         self.reopen_disagg_conn(self.conn_config())
-        # Perform two small updates.
-        kv_modified = {f'{initial_key}{400}': "10abc", f'{initial_key}{800}': "220abc"}
-        self.insert(kv_modified, initial_ts + 1)
-        # Perform a checkpoint to write out a delta.
+        # Perform some updates.
+        kv_modified = {}
+        for i in range(1, 20):
+            kv_modified[f'{initial_key}{i}'] = '10abc'
+        self.insert_or_update(kv_modified, initial_ts + 1)
         self.session.checkpoint()
-        # Verify delta built.
         if (self.delta_type == 'both' or self.delta_type == 'leaf_only'):
             self.assertGreater(self.get_stat(stat.conn.rec_page_delta_leaf), 0)
+            # We should see prefix compression for delta and there's no prefix compression for full page.
+            if (prefix_compression):
+                self.assertGreater(self.get_stat(stat.dsrc.rec_prefix_compression_delta, self.uri), 0)
+                self.assertEqual(self.get_stat(stat.dsrc.rec_prefix_compression_full, self.uri), 0)
         if (self.delta_type == 'both' or self.delta_type == 'internal_only'):
             self.assertGreater(self.get_stat(stat.conn.rec_page_delta_internal), 0)
 

--- a/test/suite/test_layered54.py
+++ b/test/suite/test_layered54.py
@@ -111,7 +111,7 @@ class test_layered54(wttest.WiredTigerTestCase):
         else:
             self.assertEqual(self.get_stat(stat.dsrc.rec_prefix_compression_full, self.uri), 0)
 
-         # Re-open the connection to clear contents out of memory.
+        # Re-open the connection to clear contents out of memory.
         self.reopen_disagg_conn(self.conn_config())
         # Perform some updates.
         kv_modified = {}


### PR DESCRIPTION
Currently, `rec_prefix_compression` does not correctly reflect the number of key bytes discarded using prefix compression because both of delta build and full disk image build will add the metric, though we only pick either the delta or the full page. This PR is to split the `rec_prefix_compression` into `rec_prefix_compression_delta` and `rec_prefix_compression_full`, and modify the current prefix compression layered54 test so it can properly test prefix compression for page delta.