### PR TITLE
WT-15806 Account for follower transient state

### DIFF
--- a/src/schema/schema_worker.c
+++ b/src/schema/schema_worker.c
@@ -105,6 +105,14 @@ __schema_layered_worker_verify(WT_SESSION_IMPL *session, const char *uri,
     WT_WITHOUT_DHANDLE(session,
       stable_ret = __wt_schema_worker(session, stable_uri, file_func, name_func, cfg, open_flags));
 
+    /* On followers, it is possible not to have any stable table. This is a transient state. */
+    if (!conn->layered_table_manager.leader && stable_ret == ENOENT) {
+        __wt_verbose_level(session, WT_VERB_VERIFY, WT_VERBOSE_DEBUG_2,
+          "Verify (layered): %s stable table not found on follower, it can be a transient state.",
+          stable_uri);
+        stable_ret = 0;
+    }
+
     if (stable_ret != 0 && stable_ret != EBUSY)
         WT_ERR_MSG(session, stable_ret, "Verify (layered): %s stable table verification failed ",
           stable_uri);

--- a/test/suite/test_verify_disagg.py
+++ b/test/suite/test_verify_disagg.py
@@ -176,7 +176,7 @@ class test_verify_disagg(wttest.WiredTigerTestCase):
         self.session_follow.create(self.uri, self.table_cfg)
 
         # The follower has not picked up its first checkpoint. But since we created the layered
-        # table, it should be able to run verify on the layered URI. However,the stable table
+        # table, it should be able to run verify on the layered URI. However, the stable table
         # does not exist, so we catch ENOENT and return 0. Followers are only able to create
         # their ingest constituents. They see stable through checkpoint or step-up.
         self.verify([self.session_follow])

--- a/test/suite/test_verify_disagg.py
+++ b/test/suite/test_verify_disagg.py
@@ -177,9 +177,9 @@ class test_verify_disagg(wttest.WiredTigerTestCase):
 
         # The follower has not picked up its first checkpoint. But since we created the layered
         # table, it should be able to run verify on the layered URI. However,the stable table
-        # does not exist, so we expect ENOENT. Followers are only able to create their ingest
-        # constituents. They see stable through checkpoint or step-up.
-        self.verify([self.session_follow], errno.ENOENT)
+        # does not exist, so we catch ENOENT and return 0. Followers are only able to create
+        # their ingest constituents. They see stable through checkpoint or step-up.
+        self.verify([self.session_follow])
 
         # Create an empty checkpoint
         self.session.checkpoint()


### PR DESCRIPTION
It is possible for a follower to be missing its stable table. This is a transient state that occurs when a follower has not picked up its first checkpoint. Account for this in `verify`.