### PR TITLE
WT-15730 fix page delta assertion for the wrong page

### DIFF
--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -723,7 +723,7 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
              * delta.
              */
             WT_ASSERT_ALWAYS(session,
-              cms.state == WTI_CHILD_ORIGINAL || WT_DELTA_ENABLED_FOR_PAGE(session, page->type),
+              cms.state == WTI_CHILD_ORIGINAL || WT_DELTA_ENABLED_FOR_PAGE(session, child->type),
               "Not propagating the original fast-truncate information");
             /*
              * The transaction ids are cleared after restart. Repack the cell with new validity


### PR DESCRIPTION
This PR fixes an assert in `rec_row_int`. It should check if the child page has delta enabled instead of the parent page.