### PR TITLE
WT-15828 Add test case for wt verify redacted

### DIFF
--- a/test/suite/helper.py
+++ b/test/suite/helper.py
@@ -181,9 +181,9 @@ class WiredTigerCursor:
         self.cursor = session.open_cursor(uri, *args, **kwargs)
 
     def __enter__(self):
-        # Get a statistics cursor
+        # Get the opened cursor
         return self.cursor
 
     def __exit__(self, exception_type, exception_value, exception_traceback):
-        # Close the statistics cursor
+        # Close the cursor
         self.cursor.close()

--- a/test/suite/helper.py
+++ b/test/suite/helper.py
@@ -176,7 +176,6 @@ class WiredTigerStat:
         self.stat_cursor.close()
 
 class WiredTigerCursor:
-
     def __init__(self, session, uri = 'statistics:', *args, **kwargs):
         self.cursor = session.open_cursor(uri, *args, **kwargs)
 

--- a/test/suite/helper.py
+++ b/test/suite/helper.py
@@ -174,3 +174,16 @@ class WiredTigerStat:
     def __exit__(self, exception_type, exception_value, exception_traceback):
         # Close the statistics cursor
         self.stat_cursor.close()
+
+class WiredTigerCursor:
+
+    def __init__(self, session, uri = 'statistics:', *args, **kwargs):
+        self.cursor = session.open_cursor(uri, *args, **kwargs)
+
+    def __enter__(self):
+        # Get a statistics cursor
+        return self.cursor
+
+    def __exit__(self, exception_type, exception_value, exception_traceback):
+        # Close the statistics cursor
+        self.cursor.close()

--- a/test/suite/suite_subprocess.py
+++ b/test/suite/suite_subprocess.py
@@ -37,7 +37,9 @@ import wttest
 # Used as a 'mixin' class along with a WiredTigerTestCase class
 class suite_subprocess:
     subproc = None
-    # Set the max file bytes to 1GB
+    """
+    Check the first 1GB content from a file.
+    """
     maxbytes = 1 * 1024 ** 3
 
     def has_error_in_file(self, filename):
@@ -99,9 +101,6 @@ class suite_subprocess:
     # Check contents of the file against a provided checklist. Expected is used as a bool to either
     # ensure checklist is included or ensure the checklist is not included in the file.
     def check_file_contains_one_of(self, filename, checklist, expected):
-        """
-        Check that the file contains the expected string in the first 100K bytes
-        """
         with open(filename, 'r') as f:
             got = f.read(self.maxbytes)
             found = False
@@ -129,7 +128,7 @@ class suite_subprocess:
                 gotstr = '\'' + \
                     (got if len(got) < 1000 else (got[0:1000] + '...')) + '\''
                 if len(got) >= self.maxbytes:
-                    self.fail(filename + ': does not contain expected ' + expect + ', or output is too large, got ' + gotstr)
+                    self.fail(filename + ': does not contain expected ' + expect + ', or output is larger than ' + str(self.maxbytes) + ' Bytes')
                 else:
                     self.fail(filename + ': does not contain expected ' + expect + ', got ' + gotstr)
 

--- a/test/suite/suite_subprocess.py
+++ b/test/suite/suite_subprocess.py
@@ -37,6 +37,8 @@ import wttest
 # Used as a 'mixin' class along with a WiredTigerTestCase class
 class suite_subprocess:
     subproc = None
+    # Set the max file bytes to 1GB
+    maxbytes = 1 * 1024 ** 3
 
     def has_error_in_file(self, filename):
         """
@@ -100,9 +102,8 @@ class suite_subprocess:
         """
         Check that the file contains the expected string in the first 100K bytes
         """
-        maxbytes = 1024*100
         with open(filename, 'r') as f:
-            got = f.read(maxbytes)
+            got = f.read(self.maxbytes)
             found = False
             for expect in checklist:
                 pat = self.convert_to_pattern(expect)
@@ -127,7 +128,7 @@ class suite_subprocess:
                     expect = str(checklist)
                 gotstr = '\'' + \
                     (got if len(got) < 1000 else (got[0:1000] + '...')) + '\''
-                if len(got) >= maxbytes:
+                if len(got) >= self.maxbytes:
                     self.fail(filename + ': does not contain expected ' + expect + ', or output is too large, got ' + gotstr)
                 else:
                     self.fail(filename + ': does not contain expected ' + expect + ', got ' + gotstr)
@@ -172,11 +173,10 @@ class suite_subprocess:
               'output files follow:'
         WiredTigerTestCase.prout(out)
         for filename in filenames:
-            maxbytes = 1024*100
             with open(filename, 'r') as f:
-                contents = f.read(maxbytes)
+                contents = f.read(self.maxbytes)
                 if len(contents) > 0:
-                    if len(contents) >= maxbytes:
+                    if len(contents) >= self.maxbytes:
                         contents += '...\n'
                     sepline = '*' * 50 + '\n'
                     out = sepline + filename + '\n' + sepline + contents

--- a/test/suite/test_verify.py
+++ b/test/suite/test_verify.py
@@ -386,9 +386,9 @@ class test_verify(wttest.WiredTigerTestCase, suite_subprocess):
         # does not exist. Ignore that.
         self.ignoreStderrPatternIfExists('No such file or directory')
 
-    def test_verify_reducted(self):
+    def test_verify_redacted(self):
         """
-        Test verify in a 'wt' process on a table with reducted.
+        Test verify in a 'wt' process on a table with redacted.
         """
         self.skip_disagg_wt_verify_test()
         if not wiredtiger.diagnostic_build():
@@ -406,21 +406,21 @@ class test_verify(wttest.WiredTigerTestCase, suite_subprocess):
         # stabilize the table with a checkpoint
         self.session.checkpoint()
 
-        # Check the reducted output
+        # Check the redacted output
         self.runWt(["-p", "verify", '-d', 'dump_pages', f"file:{self.tablename}.wt"],
-            outfilename='verify_reducted.out', errfilename="verify_reducted.err", failure=False)
+            outfilename='verify_redacted.out', errfilename="verify_redacted.err", failure=False)
 
-        self.check_empty_file('verify_reducted.err')
-        self.check_file_not_contains('verify_reducted.out', 'secret_key')
-        self.check_file_not_contains('verify_reducted.out', '#hidden#')
+        self.check_empty_file('verify_redacted.err')
+        self.check_file_not_contains('verify_redacted.out', 'secret_key')
+        self.check_file_not_contains('verify_redacted.out', '#hidden#')
 
-        # Check the unreducted output
+        # Check the unredacted output
         self.runWt(["-p", "verify", '-d', 'dump_pages', '-u', f"file:{self.tablename}.wt"],
-            outfilename='verify_reducted.out', errfilename="verify_reducted.err", failure=False)
+            outfilename='verify_redacted.out', errfilename="verify_redacted.err", failure=False)
 
-        self.check_empty_file('verify_reducted.err')
-        self.check_file_contains('verify_reducted.out', 'secret_key')
-        self.check_file_contains('verify_reducted.out', '#hidden#')
+        self.check_empty_file('verify_redacted.err')
+        self.check_file_contains('verify_redacted.out', 'secret_key')
+        self.check_file_contains('verify_redacted.out', '#hidden#')
 
     def test_verify_all(self):
         """

--- a/test/suite/test_verify.py
+++ b/test/suite/test_verify.py
@@ -396,7 +396,6 @@ class test_verify(wttest.WiredTigerTestCase, suite_subprocess):
 
         params = 'key_format=S,value_format=S'
         self.session.create('table:' + self.tablename, params)
-        self.nentries = 10
         self.populate(self.tablename)
         """
         Insert some secret entries into the table

--- a/test/suite/test_verify.py
+++ b/test/suite/test_verify.py
@@ -29,6 +29,7 @@
 import os, re, struct
 from suite_subprocess import suite_subprocess
 import wiredtiger, wttest
+from helper import WiredTigerCursor
 
 # test_verify.py
 #    Utilities: wt verify
@@ -78,6 +79,9 @@ class test_verify(wttest.WiredTigerTestCase, suite_subprocess):
                     count += 1
             f.close()
         return count
+
+    def check_file_contains(self, filename, content):
+        return super().check_file_contains(filename, content)
 
     # FIXME-WT-15064:
     @wttest.skip_for_hook("disagg", " We cannot access shared tables data directly")
@@ -384,6 +388,43 @@ class test_verify(wttest.WiredTigerTestCase, suite_subprocess):
         # The test may output the following error message while opening a file that
         # does not exist. Ignore that.
         self.ignoreStderrPatternIfExists('No such file or directory')
+
+    def test_verify_reducted(self):
+        """
+        Test verify in a 'wt' process on a table with reducted.
+        """
+        self.skip_disagg_wt_verify_test()
+        if not wiredtiger.diagnostic_build():
+            self.skipTest('requires a diagnostic build as the test uses verify -d dump_pages')
+
+        params = 'key_format=S,value_format=S'
+        self.session.create('table:' + self.tablename, params)
+        self.nentries = 10
+        self.populate(self.tablename)
+        """
+        Insert some secret entries into the table
+        """
+        with WiredTigerCursor(self.session, 'table:' + self.tablename, None, None) as cursor:
+            cursor['secret_key'] = "#hidden#"
+
+        # stabilize the table with a checkpoint
+        self.session.checkpoint()
+
+        # Check the reducted output
+        self.runWt(["-p", "verify", '-d', 'dump_pages', f"file:{self.tablename}.wt"],
+            outfilename='verify_reducted.out', errfilename="verify_reducted.err", failure=False)
+
+        self.check_empty_file('verify_reducted.err')
+        self.check_file_not_contains('verify_reducted.out', 'secret_key')
+        self.check_file_not_contains('verify_reducted.out', '#hidden#')
+
+        # Check the unreducted output
+        self.runWt(["-p", "verify", '-d', 'dump_pages', '-u', f"file:{self.tablename}.wt"],
+            outfilename='verify_reducted.out', errfilename="verify_reducted.err", failure=False)
+
+        self.check_empty_file('verify_reducted.err')
+        self.check_file_contains('verify_reducted.out', 'secret_key')
+        self.check_file_contains('verify_reducted.out', '#hidden#')
 
     def test_verify_all(self):
         """

--- a/test/suite/test_verify.py
+++ b/test/suite/test_verify.py
@@ -80,9 +80,6 @@ class test_verify(wttest.WiredTigerTestCase, suite_subprocess):
             f.close()
         return count
 
-    def check_file_contains(self, filename, content):
-        return super().check_file_contains(filename, content)
-
     # FIXME-WT-15064:
     @wttest.skip_for_hook("disagg", " We cannot access shared tables data directly")
     def open_and_position(self, tablename, pct):


### PR DESCRIPTION
- Added redacted verification to ensure that sensitive content is properly hidden for `wt verify`.
- Increase the maximum file size check from `100KB` to `1GB` to fit the large dump file check.
- Introduced an automatic cursor-closing context manager to improve the reliability and maintainability of Python tests.