### PR TITLE
WT-14700 Discard root pages for old checkpoints

### DIFF
--- a/src/block_disagg/block_disagg_ckpt.c
+++ b/src/block_disagg/block_disagg_ckpt.c
@@ -46,6 +46,11 @@ __bmd_checkpoint_pack_raw(WT_BLOCK_DISAGG *block_disagg, WT_SESSION_IMPL *sessio
         WT_RET(__wt_buf_init(session, &ckpt->raw, WT_BLOCK_CHECKPOINT_BUFFER));
         endp = ckpt->raw.mem;
         __wt_page_header_byteswap((void *)root_image->data);
+        /*
+         * In disaggregated storage, checkpoint cookie is the same as address cookie of the root
+         * page, and currently we rely on this assumption to discard older checkpoint root page when
+         * the checkpoint becomes redundant.
+         */
         WT_RET(__wti_block_disagg_write_internal(
           session, block_disagg, root_image, block_meta, &size, &checksum, true, true));
         __wt_page_header_byteswap((void *)root_image->data);

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1475,11 +1475,6 @@ __verify_page_discard(WT_SESSION_IMPL *session, WT_BM *bm)
     WT_ERR(bm->get_page_ids(bm, session, item, &num_pages_found_in_palm, checkpoint_lsn));
 
     if ((uint64_t)num_pages_found_in_palm != num_pages_found_in_btree) {
-        /*
-         * FIXME-WT-14700: Investigate whether we need to do anything special when freeing a root
-         * page. Change below warning to an error after root page discard is implemented, if a
-         * mismatch is found this function will return the corresponding error code.
-         */
         WT_ERR_MSG(session, EINVAL,
           "Mismatch in the number of page IDs found from PALI and btree walk: PALI %" PRIu64
           " Btree walk %" PRIu64,
@@ -1500,11 +1495,7 @@ __verify_page_discard(WT_SESSION_IMPL *session, WT_BM *bm)
           index_in_palm < num_pages_found_in_palm ? ((uint64_t *)item->data)[index_in_palm] : 0;
         uint64_t id_in_btree =
           index_in_btree < num_pages_found_in_btree ? page_ids[index_in_btree] : 0;
-        /*
-         * FIXME-WT-14700: Investigate whether we need to do anything special when freeing a root
-         * page. Change below warning to an error after root page discard is implemented, if a
-         * mismatch is found this function will return the corresponding error code.
-         */
+
         if (index_in_btree == num_pages_found_in_btree || id_in_palm < id_in_btree) {
             WT_ERR_MSG(session, EINVAL,
               "Unreferenced page was not discarded: PALM[%" PRIu32 "] %" PRIu64, index_in_palm,

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -319,7 +319,7 @@ __wt_verify(WT_SESSION_IMPL *session, const char *cfg[])
              * page discard function if we're in disagg mode.
              */
             if (ret == 0 && (ckpt + 1)->name == NULL) {
-                if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))
+                if (F_ISSET(btree, WT_BTREE_DISAGGREGATED) && ckpt->raw.data)
                     WT_TRET(__verify_page_discard(session, bm));
 
                 if (!skip_hs) {
@@ -1462,7 +1462,11 @@ __verify_page_discard(WT_SESSION_IMPL *session, WT_BM *bm)
      */
     size_t num_pages_found_in_palm = 0;
     uint64_t checkpoint_lsn;
-    checkpoint_lsn = S2C(session)->disaggregated_storage.last_checkpoint_meta_lsn;
+    checkpoint_lsn =
+      S2C(session)->disaggregated_storage.last_checkpoint_meta_lsn == WT_DISAGG_LSN_NONE ?
+      INT_MAX :
+      S2C(session)->disaggregated_storage.last_checkpoint_meta_lsn;
+
     WT_DECL_ITEM(item);
     WT_RET(__wt_scr_alloc(session, num_pages_found_in_palm, &item));
 
@@ -1477,7 +1481,7 @@ __verify_page_discard(WT_SESSION_IMPL *session, WT_BM *bm)
          * mismatch is found this function will return the corresponding error code.
          */
         WT_ERR_MSG(session, EINVAL,
-          "Mismatch in the number of page IDs found from PALM and btree walk: PALM %" PRIu64
+          "Mismatch in the number of page IDs found from PALI and btree walk: PALI %" PRIu64
           " Btree walk %" PRIu64,
           (uint64_t)num_pages_found_in_palm, num_pages_found_in_btree);
     }

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1468,7 +1468,7 @@ __verify_page_discard(WT_SESSION_IMPL *session, WT_BM *bm)
 
     WT_ASSERT(session, bm->get_page_ids != NULL);
     /* Get page IDs from PALM. */
-    WT_RET(bm->get_page_ids(bm, session, item, &num_pages_found_in_palm, checkpoint_lsn));
+    WT_ERR(bm->get_page_ids(bm, session, item, &num_pages_found_in_palm, checkpoint_lsn));
 
     if ((uint64_t)num_pages_found_in_palm != num_pages_found_in_btree) {
         /*
@@ -1476,7 +1476,7 @@ __verify_page_discard(WT_SESSION_IMPL *session, WT_BM *bm)
          * page. Change below warning to an error after root page discard is implemented, if a
          * mismatch is found this function will return the corresponding error code.
          */
-        WT_RET_MSG(session, EINVAL,
+        WT_ERR_MSG(session, EINVAL,
           "Mismatch in the number of page IDs found from PALM and btree walk: PALM %" PRIu64
           " Btree walk %" PRIu64,
           (uint64_t)num_pages_found_in_palm, num_pages_found_in_btree);
@@ -1502,12 +1502,12 @@ __verify_page_discard(WT_SESSION_IMPL *session, WT_BM *bm)
          * mismatch is found this function will return the corresponding error code.
          */
         if (index_in_btree == num_pages_found_in_btree || id_in_palm < id_in_btree) {
-            WT_RET_MSG(session, EINVAL,
+            WT_ERR_MSG(session, EINVAL,
               "Unreferenced page was not discarded: PALM[%" PRIu32 "] %" PRIu64, index_in_palm,
               id_in_palm);
             index_in_palm++;
         } else if (index_in_palm == num_pages_found_in_palm || id_in_palm > id_in_btree) {
-            WT_RET_MSG(session, EINVAL,
+            WT_ERR_MSG(session, EINVAL,
               "Discarded page is still in use: BTREE[%" PRIu32 "] %" PRIu64, index_in_btree,
               id_in_btree);
             index_in_btree++;
@@ -1516,6 +1516,8 @@ __verify_page_discard(WT_SESSION_IMPL *session, WT_BM *bm)
             index_in_btree++;
         }
     }
+
+    err:
 
     __wt_free(session, page_ids);
     __wt_scr_free(session, &item);

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1476,7 +1476,7 @@ __verify_page_discard(WT_SESSION_IMPL *session, WT_BM *bm)
          * page. Change below warning to an error after root page discard is implemented, if a
          * mismatch is found this function will return the corresponding error code.
          */
-        __wt_verbose_level(session, WT_VERB_DISAGGREGATED_STORAGE, WT_VERBOSE_DEBUG_5,
+        WT_RET_MSG(session, EINVAL,
           "Mismatch in the number of page IDs found from PALM and btree walk: PALM %" PRIu64
           " Btree walk %" PRIu64,
           (uint64_t)num_pages_found_in_palm, num_pages_found_in_btree);
@@ -1502,12 +1502,12 @@ __verify_page_discard(WT_SESSION_IMPL *session, WT_BM *bm)
          * mismatch is found this function will return the corresponding error code.
          */
         if (index_in_btree == num_pages_found_in_btree || id_in_palm < id_in_btree) {
-            __wt_verbose_level(session, WT_VERB_DISAGGREGATED_STORAGE, WT_VERBOSE_DEBUG_5,
+            WT_RET_MSG(session, EINVAL,
               "Unreferenced page was not discarded: PALM[%" PRIu32 "] %" PRIu64, index_in_palm,
               id_in_palm);
             index_in_palm++;
         } else if (index_in_palm == num_pages_found_in_palm || id_in_palm > id_in_btree) {
-            __wt_verbose_level(session, WT_VERB_DISAGGREGATED_STORAGE, WT_VERBOSE_DEBUG_5,
+            WT_RET_MSG(session, EINVAL,
               "Discarded page is still in use: BTREE[%" PRIu32 "] %" PRIu64, index_in_btree,
               id_in_btree);
             index_in_btree++;

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1517,7 +1517,7 @@ __verify_page_discard(WT_SESSION_IMPL *session, WT_BM *bm)
         }
     }
 
-    err:
+err:
 
     __wt_free(session, page_ids);
     __wt_scr_free(session, &item);

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -2636,6 +2636,8 @@ err:
         /*
          * If in disaggregated mode, discard the root page associated with checkpoints that are
          * marked for deletion.
+         *
+         * FIXME-WT-15879: Fix up layering for checkpoint root page discard
          */
         if (ret == 0 && F_ISSET(btree, WT_BTREE_DISAGGREGATED)) {
             WT_CKPT *ckptbase, *ckpt_temp;

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -2630,42 +2630,43 @@ fake:
 
 err:
     /* Resolved the checkpoint for the block manager in the error path. */
-    if (resolve_bm)
+    if (resolve_bm) {
         WT_TRET(bm->checkpoint_resolve(bm, session, ret != 0));
 
-    WT_CKPT *ckptbase, *ckpt_temp;
+        if (ret == 0) {
+            WT_CKPT *ckptbase, *ckpt_temp;
 
-    ckptbase = btree->ckpt;
+            ckptbase = btree->ckpt;
 
-    WT_CKPT_FOREACH (ckptbase, ckpt_temp) {
-        if (F_ISSET(btree, WT_BTREE_DISAGGREGATED) && F_ISSET(ckpt_temp, WT_CKPT_DELETE)) {
+            WT_CKPT_FOREACH (ckptbase, ckpt_temp) {
+                if (F_ISSET(btree, WT_BTREE_DISAGGREGATED) && F_ISSET(ckpt_temp, WT_CKPT_DELETE) &&
+                  ckpt_temp->raw.data)
+                    bm->free(bm, session, ckpt_temp->raw.data, ckpt_temp->raw.size);
+            }
         }
-        if (ckpt_temp->raw.data)
-            bm->free(bm, session, ckpt_temp->raw.data, ckpt_temp->raw.size);
     }
-}
 
-/*
- * If the checkpoint didn't complete successfully, make sure the tree is marked dirty.
- */
-if (ret != 0) {
-    btree->modified = true;
-    conn->modified = true;
-}
+    /*
+     * If the checkpoint didn't complete successfully, make sure the tree is marked dirty.
+     */
+    if (ret != 0) {
+        btree->modified = true;
+        conn->modified = true;
+    }
 
-/* For a successful checkpoint, post process the ckptlist, to keep a cached copy around. */
-if (WT_SESSION_IS_CHECKPOINT(session))
-    WT_STAT_CONN_SET(session, checkpoint_state, WTI_CHECKPOINT_STATE_POSTPROCESS);
-if (ret != 0 || WT_IS_METADATA(session->dhandle) || F_ISSET_ATOMIC_32(conn, WT_CONN_CLOSING))
-    __wt_ckptlist_saved_free(session);
-else {
-    ret = __checkpoint_save_ckptlist(session, btree->ckpt);
-    /* Discard the saved checkpoint list if processing the list did not work. */
-    if (ret != 0)
+    /* For a successful checkpoint, post process the ckptlist, to keep a cached copy around. */
+    if (WT_SESSION_IS_CHECKPOINT(session))
+        WT_STAT_CONN_SET(session, checkpoint_state, WTI_CHECKPOINT_STATE_POSTPROCESS);
+    if (ret != 0 || WT_IS_METADATA(session->dhandle) || F_ISSET_ATOMIC_32(conn, WT_CONN_CLOSING))
         __wt_ckptlist_saved_free(session);
-}
+    else {
+        ret = __checkpoint_save_ckptlist(session, btree->ckpt);
+        /* Discard the saved checkpoint list if processing the list did not work. */
+        if (ret != 0)
+            __wt_ckptlist_saved_free(session);
+    }
 
-return (ret);
+    return (ret);
 }
 
 /*

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -2633,14 +2633,16 @@ err:
     if (resolve_bm) {
         WT_TRET(bm->checkpoint_resolve(bm, session, ret != 0));
 
-        if (ret == 0) {
+        /*
+         * If in disaggregated mode, discard the root page associated with checkpoints that are
+         * marked for deletion.
+         */
+        if (ret == 0 && F_ISSET(btree, WT_BTREE_DISAGGREGATED)) {
             WT_CKPT *ckptbase, *ckpt_temp;
-
             ckptbase = btree->ckpt;
 
             WT_CKPT_FOREACH (ckptbase, ckpt_temp) {
-                if (F_ISSET(btree, WT_BTREE_DISAGGREGATED) && F_ISSET(ckpt_temp, WT_CKPT_DELETE) &&
-                  ckpt_temp->raw.data)
+                if (F_ISSET(ckpt_temp, WT_CKPT_DELETE) && ckpt_temp->raw.data)
                     bm->free(bm, session, ckpt_temp->raw.data, ckpt_temp->raw.size);
             }
         }

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -2633,27 +2633,39 @@ err:
     if (resolve_bm)
         WT_TRET(bm->checkpoint_resolve(bm, session, ret != 0));
 
-    /*
-     * If the checkpoint didn't complete successfully, make sure the tree is marked dirty.
-     */
-    if (ret != 0) {
-        btree->modified = true;
-        conn->modified = true;
-    }
+    WT_CKPT *ckptbase, *ckpt_temp;
 
-    /* For a successful checkpoint, post process the ckptlist, to keep a cached copy around. */
-    if (WT_SESSION_IS_CHECKPOINT(session))
-        WT_STAT_CONN_SET(session, checkpoint_state, WTI_CHECKPOINT_STATE_POSTPROCESS);
-    if (ret != 0 || WT_IS_METADATA(session->dhandle) || F_ISSET_ATOMIC_32(conn, WT_CONN_CLOSING))
+    ckptbase = btree->ckpt;
+
+    WT_CKPT_FOREACH (ckptbase, ckpt_temp) {
+        if (F_ISSET(btree, WT_BTREE_DISAGGREGATED) && F_ISSET(ckpt_temp, WT_CKPT_DELETE)) {
+        }
+        if (ckpt_temp->raw.data)
+            bm->free(bm, session, ckpt_temp->raw.data, ckpt_temp->raw.size);
+    }
+}
+
+/*
+ * If the checkpoint didn't complete successfully, make sure the tree is marked dirty.
+ */
+if (ret != 0) {
+    btree->modified = true;
+    conn->modified = true;
+}
+
+/* For a successful checkpoint, post process the ckptlist, to keep a cached copy around. */
+if (WT_SESSION_IS_CHECKPOINT(session))
+    WT_STAT_CONN_SET(session, checkpoint_state, WTI_CHECKPOINT_STATE_POSTPROCESS);
+if (ret != 0 || WT_IS_METADATA(session->dhandle) || F_ISSET_ATOMIC_32(conn, WT_CONN_CLOSING))
+    __wt_ckptlist_saved_free(session);
+else {
+    ret = __checkpoint_save_ckptlist(session, btree->ckpt);
+    /* Discard the saved checkpoint list if processing the list did not work. */
+    if (ret != 0)
         __wt_ckptlist_saved_free(session);
-    else {
-        ret = __checkpoint_save_ckptlist(session, btree->ckpt);
-        /* Discard the saved checkpoint list if processing the list did not work. */
-        if (ret != 0)
-            __wt_ckptlist_saved_free(session);
-    }
+}
 
-    return (ret);
+return (ret);
 }
 
 /*

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -2642,6 +2642,13 @@ err:
             ckptbase = btree->ckpt;
 
             WT_CKPT_FOREACH (ckptbase, ckpt_temp) {
+                /*
+                 * In disagg, checkpoint cookie is the same as address cookie of the root page, this
+                 * applies to disagg only and not classic WT. Currently all checkpoint root page are
+                 * written with an unique page ID, therefore discarding the old checkpoint root page
+                 * here is appropriate. If the logic for writing checkpoint root pages ever change,
+                 * the discard logic would also need to be reconsidered.
+                 */
                 if (F_ISSET(ckpt_temp, WT_CKPT_DELETE) && ckpt_temp->raw.data)
                     bm->free(bm, session, ckpt_temp->raw.data, ckpt_temp->raw.size);
             }

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -3062,9 +3062,6 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
              *
              * The exception is root pages are never tracked or free'd, they
              * are checkpoints, and must be explicitly dropped.
-             *
-             * FIXME-WT-14700: Does the root work for the same way in disagg? Do we need a separate
-             * API to tell the SLS that we are discarding a root page?
              */
         if (__wt_ref_is_root(ref))
             break;
@@ -3096,10 +3093,6 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
                              *
                              * The exception is root pages are never tracked or free'd, they are
                              * checkpoints, and must be explicitly dropped.
-                             *
-                             * FIXME-WT-14700: Does the root work for the same way in disagg? Do we
-                             * need a separate API to tell the SLS that we are discarding a root
-                             * page?
                              */
         if (!__wt_ref_is_root(ref)) {
             /*

--- a/test/suite/test_verify_disagg.py
+++ b/test/suite/test_verify_disagg.py
@@ -135,8 +135,6 @@ class test_verify_disagg(wttest.WiredTigerTestCase):
 
         # The leader is still alive, verify it.
         self.verify([self.session])
-        # FIXME-WT-14700: remove ignore after freeing root pages is addressed.
-        self.ignoreStdoutPattern("Mismatch in page IDs")
 
     def test_verify_leader_no_table(self):
         # Layered table does not exist, expect ENOENT


### PR DESCRIPTION
This PR adds a discard call for the checkpoint root page whenever we delete an old checkpoint.