### PR TITLE
WT-15843 change eviction update trigger to be equal to dirty by default

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -811,10 +811,11 @@ connection_runtime_config = [
     Config('eviction_updates_trigger', '0', r'''
         trigger application threads to perform eviction when the cache contains at least this
         many bytes of updates. It is a percentage of the cache size if the value is within
-        the range of 1 to 100 or an absolute size when greater than 100\. Calculated as equal
-        to \c eviction_dirty_trigger by default. The value is not allowed to exceed the \c
-        cache_size and has to be greater than its counterpart \c eviction_updates_target. This
-        setting only alters behavior if it is lower than \c eviction_trigger''',
+        the range of 1 to 100 or an absolute size when greater than 100\. Calculated as half
+        of \c eviction_dirty_trigger by default in attached storage or equal in disaggregated
+        storage. The value is not allowed to exceed the \c cache_size and has to be greater than
+        its counterpart \c eviction_updates_target. This setting only alters behavior if it is
+        lower than \c eviction_trigger''',
         min=0, max='10TB'),
     Config('extra_diagnostics', '[]', r'''
         enable additional diagnostics in WiredTiger. These additional diagnostics include

--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -811,8 +811,8 @@ connection_runtime_config = [
     Config('eviction_updates_trigger', '0', r'''
         trigger application threads to perform eviction when the cache contains at least this
         many bytes of updates. It is a percentage of the cache size if the value is within
-        the range of 1 to 100 or an absolute size when greater than 100\. Calculated as half
-        of \c eviction_dirty_trigger by default. The value is not allowed to exceed the \c
+        the range of 1 to 100 or an absolute size when greater than 100\. Calculated as equal
+        to \c eviction_dirty_trigger by default. The value is not allowed to exceed the \c
         cache_size and has to be greater than its counterpart \c eviction_updates_target. This
         setting only alters behavior if it is lower than \c eviction_trigger''',
         min=0, max='10TB'),

--- a/src/evict/evict_conn.c
+++ b/src/evict/evict_conn.c
@@ -146,9 +146,9 @@ __evict_validate_config(WT_SESSION_IMPL *session, const char *cfg[])
     if (evict->eviction_updates_trigger < DBL_EPSILON) {
         WT_CONFIG_DEBUG(session,
           "config eviction_updates_trigger (%f) cannot be zero. Setting "
-          "to 50%% of eviction_dirty_trigger (%f).",
-          evict->eviction_updates_trigger, evict->eviction_dirty_trigger / 2);
-        evict->eviction_updates_trigger = evict->eviction_dirty_trigger / 2;
+          "to 100%% of eviction_dirty_trigger (%f).",
+          evict->eviction_updates_trigger, evict->eviction_dirty_trigger);
+        evict->eviction_updates_trigger = evict->eviction_dirty_trigger;
     }
 
     /* Don't allow the trigger to be larger than the overall trigger. */

--- a/src/evict/evict_conn.c
+++ b/src/evict/evict_conn.c
@@ -146,9 +146,14 @@ __evict_validate_config(WT_SESSION_IMPL *session, const char *cfg[])
     if (evict->eviction_updates_trigger < DBL_EPSILON) {
         WT_CONFIG_DEBUG(session,
           "config eviction_updates_trigger (%f) cannot be zero. Setting "
-          "to 100%% of eviction_dirty_trigger (%f).",
+          "to 50%% (attached) or 100%% (disagg) of eviction_dirty_trigger (%f).",
           evict->eviction_updates_trigger, evict->eviction_dirty_trigger);
-        evict->eviction_updates_trigger = evict->eviction_dirty_trigger;
+
+        if (__wt_conn_is_disagg(session)) {
+            evict->eviction_updates_trigger = evict->eviction_dirty_trigger;
+        } else {
+            evict->eviction_updates_trigger = evict->eviction_dirty_trigger / 2;
+        }
     }
 
     /* Don't allow the trigger to be larger than the overall trigger. */

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -2346,7 +2346,7 @@ struct __wt_connection {
      * @config{eviction_updates_trigger, trigger application threads to perform eviction when the
      * cache contains at least this many bytes of updates.  It is a percentage of the cache size if
      * the value is within the range of 1 to 100 or an absolute size when greater than 100\.
-     * Calculated as half of \c eviction_dirty_trigger by default.  The value is not allowed to
+     * Calculated as equal to \c eviction_dirty_trigger by default.  The value is not allowed to
      * exceed the \c cache_size and has to be greater than its counterpart \c
      * eviction_updates_target.  This setting only alters behavior if it is lower than \c
      * eviction_trigger., an integer between \c 0 and \c 10TB; default \c 0.}
@@ -3262,9 +3262,9 @@ struct __wt_connection {
  * 10TB; default \c 0.}
  * @config{eviction_updates_trigger, trigger application threads to perform eviction when the cache
  * contains at least this many bytes of updates.  It is a percentage of the cache size if the value
- * is within the range of 1 to 100 or an absolute size when greater than 100\. Calculated as half of
- * \c eviction_dirty_trigger by default.  The value is not allowed to exceed the \c cache_size and
- * has to be greater than its counterpart \c eviction_updates_target.  This setting only alters
+ * is within the range of 1 to 100 or an absolute size when greater than 100\. Calculated as equal
+ * to \c eviction_dirty_trigger by default.  The value is not allowed to exceed the \c cache_size
+ * and has to be greater than its counterpart \c eviction_updates_target.  This setting only alters
  * behavior if it is lower than \c eviction_trigger., an integer between \c 0 and \c 10TB; default
  * \c 0.}
  * @config{exclusive, fail if the database already exists\, generally used with the \c create

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -2346,10 +2346,10 @@ struct __wt_connection {
      * @config{eviction_updates_trigger, trigger application threads to perform eviction when the
      * cache contains at least this many bytes of updates.  It is a percentage of the cache size if
      * the value is within the range of 1 to 100 or an absolute size when greater than 100\.
-     * Calculated as equal to \c eviction_dirty_trigger by default.  The value is not allowed to
-     * exceed the \c cache_size and has to be greater than its counterpart \c
-     * eviction_updates_target.  This setting only alters behavior if it is lower than \c
-     * eviction_trigger., an integer between \c 0 and \c 10TB; default \c 0.}
+     * Calculated as half of \c eviction_dirty_trigger by default in attached storage or equal in
+     * disaggregated storage.  The value is not allowed to exceed the \c cache_size and has to be
+     * greater than its counterpart \c eviction_updates_target.  This setting only alters behavior
+     * if it is lower than \c eviction_trigger., an integer between \c 0 and \c 10TB; default \c 0.}
      * @config{extra_diagnostics, enable additional diagnostics in WiredTiger.  These additional
      * diagnostics include diagnostic assertions that can cause WiredTiger to abort when an invalid
      * state is detected.  Options are given as a list\, such as
@@ -3262,11 +3262,11 @@ struct __wt_connection {
  * 10TB; default \c 0.}
  * @config{eviction_updates_trigger, trigger application threads to perform eviction when the cache
  * contains at least this many bytes of updates.  It is a percentage of the cache size if the value
- * is within the range of 1 to 100 or an absolute size when greater than 100\. Calculated as equal
- * to \c eviction_dirty_trigger by default.  The value is not allowed to exceed the \c cache_size
- * and has to be greater than its counterpart \c eviction_updates_target.  This setting only alters
- * behavior if it is lower than \c eviction_trigger., an integer between \c 0 and \c 10TB; default
- * \c 0.}
+ * is within the range of 1 to 100 or an absolute size when greater than 100\. Calculated as half of
+ * \c eviction_dirty_trigger by default in attached storage or equal in disaggregated storage.  The
+ * value is not allowed to exceed the \c cache_size and has to be greater than its counterpart \c
+ * eviction_updates_target.  This setting only alters behavior if it is lower than \c
+ * eviction_trigger., an integer between \c 0 and \c 10TB; default \c 0.}
  * @config{exclusive, fail if the database already exists\, generally used with the \c create
  * option., a boolean flag; default \c false.}
  * @config{extensions, list of shared library extensions to load (using dlopen). Any values

--- a/test/suite/test_app_thread_evict01.py
+++ b/test/suite/test_app_thread_evict01.py
@@ -69,8 +69,8 @@ class test_app_thread_evict01(wttest.WiredTigerTestCase):
             # and on the second insert the app thread is pulled into eviction since
             # trigger levels are exceeded.
             self.session.begin_transaction()
-            cursor[100001] = 'a' * 20 * 1024 * 1024
-            cursor[100002] = 'a' * 20 * 1024 * 1024
+            cursor[100001] = 'a' * 40 * 1024 * 1024
+            cursor[100002] = 'a' * 40 * 1024 * 1024
             self.session.commit_transaction()
 
             num_app_evict_snapshot_refreshed = self.get_stat(wiredtiger.stat.conn.application_evict_snapshot_refreshed)


### PR DESCRIPTION
There's a reoccurring issue from customers where application threads are blocked from doing work due to update eviction trigger threshold being exceeded. A common work around to this issue is to increase the setting for the update trigger threshold. We can set the update threshold to the 20% default rather than 10% of cache to help alleviate this problem. This PR changes the default for update trigger threshold to be equal to the dirty trigger threshold when no other value has been specified. 
