### PR TITLE
WT-13612 Time aggregate merge logic incorrect for chunk merge, page split scenario (v7.0 backport) (#12148)

### DIFF
--- a/src/include/reconcile.h
+++ b/src/include/reconcile.h
@@ -34,12 +34,30 @@ struct __wt_rec_dictionary {
 
 /*
  * WT_REC_CHUNK --
- *	Reconciliation split chunk.
+ *	Reconciliation split chunk. If the total chunk size crosses the split size additional
+ *  information is stored about where that is.
  */
 struct __wt_rec_chunk {
     /*
-     * The recno and entries fields are the starting record number of the split chunk (for
-     * column-store splits), and the number of entries in the split chunk.
+     * These fields track the amount of entries and their associated timestamps prior to the split
+     * boundary.
+     */
+    uint32_t entries_before_split_boundary;
+    WT_TIME_AGGREGATE ta_before_split_boundary;
+
+    /* These fields track the key or recno of the very first entry past the split boundary. */
+    uint64_t recno_at_split_boundary;
+    WT_ITEM key_at_split_boundary;
+
+    /*
+     * This time aggregate tracks the aggregated timestamps of all the entries past the split
+     * boundary. Merged with the "before" entry it will equal the full time aggregate for the chunk.
+     */
+    WT_TIME_AGGREGATE ta_after_split_boundary;
+
+    /*
+     * The recno and entries fields are the starting record number of the chunk (for column-store
+     * splits), and the number of entries in the chunk.
      *
      * The key for a row-store page; no column-store key is needed because the page's recno, stored
      * in the recno field, is the column-store key.
@@ -49,12 +67,6 @@ struct __wt_rec_chunk {
     WT_ITEM key;
     WT_TIME_AGGREGATE ta;
 
-    /* Saved minimum split-size boundary information. */
-    uint32_t min_entries;
-    uint64_t min_recno;
-    WT_ITEM min_key;
-    WT_TIME_AGGREGATE ta_min;
-
     size_t min_offset; /* byte offset */
 
     WT_ITEM image; /* disk-image */
@@ -63,6 +75,22 @@ struct __wt_rec_chunk {
     uint32_t aux_start_offset;
     uint32_t auxentries;
 };
+
+/*
+ * Reconciliation tracks two time aggregates per chunk, one for the full chunk and one for the part
+ * of the chunk past the split boundary. In every situation that we write to the main aggregate we
+ * need to write to the "after" aggregate. These helper macros were added with that in mind.
+ */
+#define WT_REC_CHUNK_TA_UPDATE(session, chunk, tw)                                    \
+    do {                                                                              \
+        WT_TIME_AGGREGATE_UPDATE((session), &(chunk)->ta, (tw));                      \
+        WT_TIME_AGGREGATE_UPDATE((session), &(chunk)->ta_after_split_boundary, (tw)); \
+    } while (0)
+#define WT_REC_CHUNK_TA_MERGE(session, chunk, ta_agg)                                    \
+    do {                                                                                 \
+        WT_TIME_AGGREGATE_MERGE((session), &(chunk)->ta, (ta_agg));                      \
+        WT_TIME_AGGREGATE_MERGE((session), &(chunk)->ta_after_split_boundary, (ta_agg)); \
+    } while (0)
 
 /*
  * WT_DELETE_HS_UPD --

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -73,7 +73,7 @@ __wt_bulk_insert_fix(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk, bool delet
      * Also, it should reflect the fact that we've just loaded a batch of stable values.
      */
     WT_TIME_WINDOW_INIT(&tw);
-    WT_TIME_AGGREGATE_UPDATE(session, &r->cur_ptr->ta, &tw);
+    WT_REC_CHUNK_TA_UPDATE(session, r->cur_ptr, &tw);
     return (0);
 }
 
@@ -111,7 +111,7 @@ __wt_bulk_insert_fix_bitmap(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk)
 
     /* Initialize the time aggregate that's going into the parent page. See note above. */
     WT_TIME_WINDOW_INIT(&tw);
-    WT_TIME_AGGREGATE_UPDATE(session, &r->cur_ptr->ta, &tw);
+    WT_REC_CHUNK_TA_UPDATE(session, r->cur_ptr, &tw);
     return (0);
 }
 
@@ -155,7 +155,7 @@ __wt_bulk_insert_var(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk, bool delet
     __wt_rec_image_copy(session, r, val);
 
     /* Initialize the time aggregate that's going into the parent page. See note above. */
-    WT_TIME_AGGREGATE_UPDATE(session, &r->cur_ptr->ta, &tw);
+    WT_REC_CHUNK_TA_UPDATE(session, r->cur_ptr, &tw);
 
     /* Update the starting record number in case we split. */
     r->recno += cbulk->rle;
@@ -195,7 +195,7 @@ __rec_col_merge(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
 
         /* Copy the value onto the page. */
         __wt_rec_image_copy(session, r, val);
-        WT_TIME_AGGREGATE_MERGE(session, &r->cur_ptr->ta, &addr->ta);
+        WT_REC_CHUNK_TA_MERGE(session, r->cur_ptr, &addr->ta);
     }
     return (0);
 }
@@ -319,8 +319,8 @@ __wt_rec_col_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REF *pageref)
         /* Copy the value (which is in val, val == r->v) onto the page. */
         __wt_rec_image_copy(session, r, val);
         if (page_del != NULL)
-            WT_TIME_AGGREGATE_MERGE(session, &r->cur_ptr->ta, &ft_ta);
-        WT_TIME_AGGREGATE_MERGE(session, &r->cur_ptr->ta, &ta);
+            WT_REC_CHUNK_TA_MERGE(session, r->cur_ptr, &ft_ta);
+        WT_REC_CHUNK_TA_MERGE(session, r->cur_ptr, &ta);
     }
     WT_INTL_FOREACH_END;
 
@@ -446,7 +446,7 @@ __wt_rec_col_fix_addtw(
     __wt_rec_auximage_copy(session, r, 0, key);
     __wt_rec_auximage_copy(session, r, 1, val);
 
-    WT_TIME_AGGREGATE_UPDATE(session, &r->cur_ptr->ta, tw);
+    WT_REC_CHUNK_TA_UPDATE(session, r->cur_ptr, tw);
 
     /* If we're on key 3 we should have just written at most the 4th time window. */
     WT_ASSERT(session, r->aux_entries <= recno_offset + 1);
@@ -949,7 +949,7 @@ __wt_rec_col_fix(
             /* If there are entries we didn't write timestamps for, aggregate a stable timestamp. */
             if (r->aux_entries < r->entries) {
                 WT_TIME_WINDOW_INIT(&unpack.tw);
-                WT_TIME_AGGREGATE_UPDATE(session, &r->cur_ptr->ta, &unpack.tw);
+                WT_REC_CHUNK_TA_UPDATE(session, r->cur_ptr, &unpack.tw);
             }
 
             /* Make sure the trailing bits in the bitmap get cleared. */
@@ -983,7 +983,7 @@ __wt_rec_col_fix(
      */
     if (r->aux_entries < r->entries || r->entries == 0) {
         WT_TIME_WINDOW_INIT(&unpack.tw);
-        WT_TIME_AGGREGATE_UPDATE(session, &r->cur_ptr->ta, &unpack.tw);
+        WT_REC_CHUNK_TA_UPDATE(session, r->cur_ptr, &unpack.tw);
     }
 
     /* Make sure the trailing bits in the bitmap get cleared. */
@@ -1174,7 +1174,7 @@ __rec_col_var_helper(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_SALVAGE_COOKI
     if (!deleted && ovfl_usedp == NULL && btree->dictionary)
         WT_RET(__wt_rec_dict_replace(session, r, tw, rle, val));
     __wt_rec_image_copy(session, r, val);
-    WT_TIME_AGGREGATE_UPDATE(session, &r->cur_ptr->ta, tw);
+    WT_REC_CHUNK_TA_UPDATE(session, r->cur_ptr, tw);
 
     /* Update the starting record number in case we split. */
     r->recno += rle;

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -222,7 +222,7 @@ __wt_bulk_insert_row(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk)
             WT_RET(__wt_rec_dict_replace(session, r, &tw, 0, val));
         __wt_rec_image_copy(session, r, val);
     }
-    WT_TIME_AGGREGATE_UPDATE(session, &r->cur_ptr->ta, &tw);
+    WT_REC_CHUNK_TA_UPDATE(session, r->cur_ptr, &tw);
 
     /* Update compression state. */
     __rec_key_state_update(r, ovfl_key);
@@ -265,7 +265,7 @@ __rec_row_merge(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
         /* Copy the key and value onto the page. */
         __wt_rec_image_copy(session, r, key);
         __wt_rec_image_copy(session, r, val);
-        WT_TIME_AGGREGATE_MERGE(session, &r->cur_ptr->ta, &addr->ta);
+        WT_REC_CHUNK_TA_MERGE(session, r->cur_ptr, &addr->ta);
 
         /* Update compression state. */
         __rec_key_state_update(r, false);
@@ -455,8 +455,8 @@ __wt_rec_row_int(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
         __wt_rec_image_copy(session, r, key);
         __wt_rec_image_copy(session, r, val);
         if (page_del != NULL)
-            WT_TIME_AGGREGATE_MERGE(session, &r->cur_ptr->ta, &ft_ta);
-        WT_TIME_AGGREGATE_MERGE(session, &r->cur_ptr->ta, &ta);
+            WT_REC_CHUNK_TA_MERGE(session, r->cur_ptr, &ft_ta);
+        WT_REC_CHUNK_TA_MERGE(session, r->cur_ptr, &ta);
 
         /* Update compression state. */
         __rec_key_state_update(r, false);
@@ -624,7 +624,7 @@ __rec_row_leaf_insert(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_INSERT *ins)
                 WT_ERR(__wt_rec_dict_replace(session, r, &tw, 0, val));
             __wt_rec_image_copy(session, r, val);
         }
-        WT_TIME_AGGREGATE_UPDATE(session, &r->cur_ptr->ta, &tw);
+        WT_REC_CHUNK_TA_UPDATE(session, r->cur_ptr, &tw);
 
         /* Update compression state. */
         __rec_key_state_update(r, ovfl_key);
@@ -1000,7 +1000,7 @@ slow:
                 WT_ERR(__wt_rec_dict_replace(session, r, twp, 0, val));
             __wt_rec_image_copy(session, r, val);
         }
-        WT_TIME_AGGREGATE_UPDATE(session, &r->cur_ptr->ta, twp);
+        WT_REC_CHUNK_TA_UPDATE(session, r->cur_ptr, twp);
 
         /* Update compression state. */
         __rec_key_state_update(r, ovfl_key);

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -817,10 +817,10 @@ __rec_destroy(WT_SESSION_IMPL *session, void *reconcilep)
     *(WT_RECONCILE **)reconcilep = NULL;
 
     __wt_buf_free(session, &r->chunk_A.key);
-    __wt_buf_free(session, &r->chunk_A.min_key);
+    __wt_buf_free(session, &r->chunk_A.key_at_split_boundary);
     __wt_buf_free(session, &r->chunk_A.image);
     __wt_buf_free(session, &r->chunk_B.key);
-    __wt_buf_free(session, &r->chunk_B.min_key);
+    __wt_buf_free(session, &r->chunk_B.key_at_split_boundary);
     __wt_buf_free(session, &r->chunk_B.image);
 
     __wt_free(session, r->supd);
@@ -1029,12 +1029,14 @@ __rec_split_chunk_init(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_REC_CHUNK *
     chunk->entries = 0;
     WT_TIME_AGGREGATE_INIT_MERGE(&chunk->ta);
 
-    chunk->min_recno = WT_RECNO_OOB;
+    chunk->recno_at_split_boundary = WT_RECNO_OOB;
     /* Don't touch the key item memory, that memory is reused. */
-    chunk->min_key.size = 0;
-    chunk->min_entries = 0;
-    WT_TIME_AGGREGATE_INIT_MERGE(&chunk->ta_min);
+    chunk->key_at_split_boundary.size = 0;
+    chunk->entries_before_split_boundary = 0;
     chunk->min_offset = 0;
+    /* Initialize our two special split time aggregates. */
+    WT_TIME_AGGREGATE_INIT_MERGE(&chunk->ta_before_split_boundary);
+    WT_TIME_AGGREGATE_INIT_MERGE(&chunk->ta_after_split_boundary);
 
     /*
      * Allocate and clear the disk image buffer.
@@ -1596,12 +1598,14 @@ __wt_rec_split_crossing_bnd(WT_SESSION_IMPL *session, WT_RECONCILE *r, size_t ne
         if (r->entries == 0)
             return (0);
 
-        r->cur_ptr->min_entries = r->entries;
-        r->cur_ptr->min_recno = r->recno;
+        r->cur_ptr->entries_before_split_boundary = r->entries;
+        r->cur_ptr->recno_at_split_boundary = r->recno;
         if (S2BT(session)->type == BTREE_ROW)
-            WT_RET(__rec_split_row_promote(session, r, &r->cur_ptr->min_key, r->page->type));
-        WT_TIME_AGGREGATE_COPY(&r->cur_ptr->ta_min, &r->cur_ptr->ta);
-
+            WT_RET(__rec_split_row_promote(
+              session, r, &r->cur_ptr->key_at_split_boundary, r->page->type));
+        WT_TIME_AGGREGATE_COPY(&r->cur_ptr->ta_before_split_boundary, &r->cur_ptr->ta);
+        /* Reset the "next" time aggregate which may be used in certain split scenarios. */
+        WT_TIME_AGGREGATE_INIT_MERGE(&r->cur_ptr->ta_after_split_boundary);
         WT_ASSERT_ALWAYS(
           session, r->cur_ptr->min_offset == 0, "Trying to re-enter __wt_rec_split_crossing_bnd");
         r->cur_ptr->min_offset = WT_PTRDIFF(r->first_free, r->cur_ptr->image.mem);
@@ -1695,16 +1699,30 @@ __rec_split_finish_process_prev(WT_SESSION_IMPL *session, WT_RECONCILE *r)
         memcpy(
           cur_dsk_start, (uint8_t *)r->prev_ptr->image.mem + prev_ptr->min_offset, len_to_move);
 
+#ifdef HAVE_DIAGNOSTIC
+        /* This indentation lets us define temp_ta here. */
+        {
+            WT_TIME_AGGREGATE temp_ta;
+            WT_TIME_AGGREGATE_COPY(&temp_ta, &prev_ptr->ta_before_split_boundary);
+            WT_TIME_AGGREGATE_MERGE(session, &temp_ta, &prev_ptr->ta_after_split_boundary);
+            /*
+             * We track a bit more information than we need to because ta should always be a
+             * combination of the before split ta and after split ta. We can assert that here.
+             */
+            WT_ASSERT(session, memcmp(&prev_ptr->ta, &temp_ta, sizeof(WT_TIME_AGGREGATE)) == 0);
+        }
+#endif
+
         /* Update boundary information */
-        cur_ptr->entries += prev_ptr->entries - prev_ptr->min_entries;
-        cur_ptr->recno = prev_ptr->min_recno;
-        WT_RET(
-          __wt_buf_set(session, &cur_ptr->key, prev_ptr->min_key.data, prev_ptr->min_key.size));
-        WT_TIME_AGGREGATE_MERGE(session, &cur_ptr->ta, &prev_ptr->ta);
+        cur_ptr->entries += prev_ptr->entries - prev_ptr->entries_before_split_boundary;
+        cur_ptr->recno = prev_ptr->recno_at_split_boundary;
+        WT_RET(__wt_buf_set(session, &cur_ptr->key, prev_ptr->key_at_split_boundary.data,
+          prev_ptr->key_at_split_boundary.size));
+        WT_TIME_AGGREGATE_MERGE(session, &cur_ptr->ta, &prev_ptr->ta_after_split_boundary);
         cur_ptr->image.size += len_to_move;
 
-        prev_ptr->entries = prev_ptr->min_entries;
-        WT_TIME_AGGREGATE_COPY(&prev_ptr->ta, &prev_ptr->ta_min);
+        prev_ptr->entries = prev_ptr->entries_before_split_boundary;
+        WT_TIME_AGGREGATE_COPY(&prev_ptr->ta, &prev_ptr->ta_before_split_boundary);
         prev_ptr->image.size -= len_to_move;
     }
 


### PR DESCRIPTION
Cherry-pick of 5921384a93a77a5386f49a3a5c5785d577d8201f for BACKPORT-23553

(cherry picked from commit d860df9b9160fd676466688c1178e6e1d6963724)
