### PR TITLE
WT-15851 Apply PR title check using Github actions

### DIFF
--- a/.github/workflows/pr_title_checker.yml
+++ b/.github/workflows/pr_title_checker.yml
@@ -5,8 +5,6 @@ on:
       - opened
       - edited
       - synchronize
-      - labeled
-      - unlabeled
 
 jobs:
   check:
@@ -17,4 +15,4 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           pass_on_octokit_error: false
-          configuration_path: .github/workflows/pr_title_checker_config.json #(optional. defaults to .github/pr-title-checker-config.json)
+          configuration_path: .github/workflows/pr_title_checker_config.json

--- a/.github/workflows/pr_title_checker.yml
+++ b/.github/workflows/pr_title_checker.yml
@@ -1,0 +1,20 @@
+name: "PR Title Checker"
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - labeled
+      - unlabeled
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: thehanimo/pr-title-checker@v1.4.3
+        continue-on-error: false # fail the job if the check fails
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          pass_on_octokit_error: false
+          configuration_path: .github/workflows/pr_title_checker_config.json #(optional. defaults to .github/pr-title-checker-config.json)

--- a/.github/workflows/pr_title_checker_config.json
+++ b/.github/workflows/pr_title_checker_config.json
@@ -1,0 +1,11 @@
+{
+  "CHECKS": {
+    "regexp": "^(Revert \")?WT-[0-9]+ ",
+    "alwaysPassCI": false
+  },
+  "MESSAGES": {
+    "success": "All OK",
+    "failure": "Failing CI test",
+    "notice": ""
+  }
+}

--- a/.github/workflows/pr_title_checker_config.json
+++ b/.github/workflows/pr_title_checker_config.json
@@ -5,7 +5,7 @@
   },
   "MESSAGES": {
     "success": "All OK",
-    "failure": "Failing CI test",
+    "failure": "PR title does not match the regex: \"^(Revert \")?WT-[0-9]+ \"",
     "notice": ""
   }
 }


### PR DESCRIPTION
This PR adds a new Github action workflow to perform PR title check - matching PR title starting with e.g. `WT-12345 ` or `Revert "WT-12345 `. See the new "PR Title Checkers" check on this PR below. This is to replace/deprecate the legacy wiredtiger-pr-bot Github app. 

I changed the title on this PR to various valid/invalid formats (see the change history in below) to verify the regex setting works as expected.