### PR TITLE
WT-15859 Fix __wt_meta_checkpoint_last_name result leaks

### DIFF
--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -255,6 +255,7 @@ __clayered_open_stable(WT_CURSOR_LAYERED *clayered, bool leader)
     session = CUR2S(clayered);
     layered = (WT_LAYERED_TABLE *)clayered->dhandle;
     stable_uri = layered->stable_uri;
+    checkpoint_name = NULL;
 
     WT_RET(__wt_scr_alloc(session, 0, &random_config));
     /* Get the configuration for random cursors, if any. */
@@ -273,7 +274,6 @@ __clayered_open_stable(WT_CURSOR_LAYERED *clayered, bool leader)
          */
 
         /* Look up the most recent data store checkpoint. This fetches the exact name to use. */
-        checkpoint_name = NULL;
         WT_ERR_NOTFOUND_OK(
           __wt_meta_checkpoint_last_name(session, stable_uri, &checkpoint_name, NULL, NULL), true);
 
@@ -320,6 +320,7 @@ __clayered_open_stable(WT_CURSOR_LAYERED *clayered, bool leader)
 err:
     __wt_scr_free(session, &random_config);
     __wt_scr_free(session, &stable_uri_buf);
+    __wt_free(session, checkpoint_name);
 
     return (ret);
 }

--- a/src/cursor/cur_stat.c
+++ b/src/cursor/cur_stat.c
@@ -414,11 +414,9 @@ __curstat_layered_init(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR_STAT
     WT_DATA_HANDLE *dhandle;
     WT_DECL_ITEM(stable_uri_buf);
     WT_DECL_RET;
-    WT_LAYERED_TABLE *layered;
-    const char *checkpoint_name;
-    const char *stable_uri;
-
-    layered = NULL;
+    WT_LAYERED_TABLE *layered = NULL;
+    const char *checkpoint_name = NULL;
+    const char *stable_uri = NULL;
 
     WT_RET(__wt_session_get_dhandle(session, uri, NULL, NULL, 0));
     dhandle = session->dhandle;
@@ -436,7 +434,6 @@ __curstat_layered_init(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR_STAT
     /* Now do the stable table. */
     if (!S2C(session)->layered_table_manager.leader) {
         /* Look up the most recent data store checkpoint. This fetches the exact name to use. */
-        checkpoint_name = NULL;
         WT_ERR_NOTFOUND_OK(
           __wt_meta_checkpoint_last_name(session, stable_uri, &checkpoint_name, NULL, NULL), true);
 
@@ -464,6 +461,7 @@ done:
     __wt_curstat_dsrc_final(cst);
 
 err:
+    __wt_free(session, checkpoint_name);
     __wt_scr_free(session, &stable_uri_buf);
     /* The constituent table dhandles have been released. Release the layered dhandle. */
     if (session->dhandle == NULL)


### PR DESCRIPTION
Currently, in the places changed by this PR, we call `__wt_meta_checkpoint_last_name()` that allocates a string that we never free. 