### PR TITLE
WT-15669 Fix ingest table timestamps are lost

### DIFF
--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -1782,8 +1782,12 @@ __inmem_row_leaf(WT_SESSION_IMPL *session, WT_PAGE *page, bool *instantiate_updp
              * Pages from checkpoint-related files that have been pushed onto the pre-fetch queue
              * will be comprised of data that is globally visible, and so the reader thread which
              * attempts to read the page into cache can skip the visible all check.
+             *
+             * We need the original timestamps of the ingest tables for the step-up even they are
+             * globally visible.
              */
             if (!(WT_READING_CHECKPOINT(session) && F_ISSET(session, WT_SESSION_PREFETCH_THREAD)) &&
+              !F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT) &&
               (WT_TIME_WINDOW_IS_EMPTY(&unpack.tw) ||
                 (!WT_TIME_WINDOW_HAS_STOP(&unpack.tw) &&
                   __wt_txn_tw_start_visible_all(session, &unpack.tw))))

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -1773,6 +1773,17 @@ __inmem_row_leaf(WT_SESSION_IMPL *session, WT_PAGE *page, bool *instantiate_updp
             ++rip;
             continue;
         case WT_CELL_VALUE:
+            /* Checkpoints use a different visibility model, so avoid clearing the timestamps. */
+            if (WT_READING_CHECKPOINT(session))
+                break;
+
+            /*
+             * We need the original timestamps of the ingest tables for the step-up even they are
+             * globally visible.
+             */
+            if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
+                break;
+
             /*
              * Simple values without compression can be directly referenced on the page to avoid
              * repeatedly unpacking their cells.
@@ -1782,15 +1793,10 @@ __inmem_row_leaf(WT_SESSION_IMPL *session, WT_PAGE *page, bool *instantiate_updp
              * Pages from checkpoint-related files that have been pushed onto the pre-fetch queue
              * will be comprised of data that is globally visible, and so the reader thread which
              * attempts to read the page into cache can skip the visible all check.
-             *
-             * We need the original timestamps of the ingest tables for the step-up even they are
-             * globally visible.
              */
-            if (!(WT_READING_CHECKPOINT(session) && F_ISSET(session, WT_SESSION_PREFETCH_THREAD)) &&
-              !F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT) &&
-              (WT_TIME_WINDOW_IS_EMPTY(&unpack.tw) ||
-                (!WT_TIME_WINDOW_HAS_STOP(&unpack.tw) &&
-                  __wt_txn_tw_start_visible_all(session, &unpack.tw))))
+            if (WT_TIME_WINDOW_IS_EMPTY(&unpack.tw) ||
+              (!WT_TIME_WINDOW_HAS_STOP(&unpack.tw) &&
+                __wt_txn_tw_start_visible_all(session, &unpack.tw)))
                 __wt_row_leaf_value_set(rip - 1, &unpack);
             break;
         case WT_CELL_VALUE_OVFL:

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -1778,8 +1778,8 @@ __inmem_row_leaf(WT_SESSION_IMPL *session, WT_PAGE *page, bool *instantiate_updp
                 break;
 
             /*
-             * We need the original timestamps of the ingest tables for the step-up even they are
-             * globally visible.
+             * We need the original timestamps of the ingest tables for the step-up even when they
+             * are globally visible.
              */
             if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
                 break;

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -1790,9 +1790,6 @@ __inmem_row_leaf(WT_SESSION_IMPL *session, WT_PAGE *page, bool *instantiate_updp
              *
              * The visibility information is not referenced on the page so we need to ensure that
              * the value is globally visible at the point in time where we read the page into cache.
-             * Pages from checkpoint-related files that have been pushed onto the pre-fetch queue
-             * will be comprised of data that is globally visible, and so the reader thread which
-             * attempts to read the page into cache can skip the visible all check.
              */
             if (WT_TIME_WINDOW_IS_EMPTY(&unpack.tw) ||
               (!WT_TIME_WINDOW_HAS_STOP(&unpack.tw) &&

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -30,21 +30,19 @@ __cell_check_value_validity(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw, bool e
 }
 
 /*
- * __cell_assert_tw_has_ts_for_garbage_collection --
+ * __cell_assert_tw_has_ts_for_garbage_collection_table --
  *     Assert that time window has timestamps if garbage collection is enabled for the btree.
  */
 static WT_INLINE void
-__cell_assert_tw_has_ts_for_garbage_collection(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw)
+__cell_assert_tw_has_ts_for_garbage_collection_table(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw)
 {
     WT_UNUSED(session);
     WT_UNUSED(tw);
 
+    WT_ASSERT(
+      session, tw->start_ts != WT_TS_NONE || !F_ISSET(S2BT(session), WT_BTREE_GARBAGE_COLLECT));
     WT_ASSERT(session,
-      (tw->start_ts != WT_TS_NONE && tw->durable_start_ts != WT_TS_NONE) ||
-        !F_ISSET(S2BT(session), WT_BTREE_GARBAGE_COLLECT));
-    WT_ASSERT(session,
-      !WT_TIME_WINDOW_HAS_STOP(tw) ||
-        (tw->stop_ts != WT_TS_NONE && tw->durable_stop_ts != WT_TS_NONE) ||
+      !WT_TIME_WINDOW_HAS_STOP(tw) || tw->stop_ts != WT_TS_NONE ||
         !F_ISSET(S2BT(session), WT_BTREE_GARBAGE_COLLECT));
 }
 
@@ -57,7 +55,7 @@ __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_WINDO
 {
     uint8_t flags, *flagsp;
 
-    __cell_assert_tw_has_ts_for_garbage_collection(session, tw);
+    __cell_assert_tw_has_ts_for_garbage_collection_table(session, tw);
 
     /* Globally visible values have no associated validity window. */
     if (WT_TIME_WINDOW_IS_EMPTY(tw)) {
@@ -1052,7 +1050,7 @@ copy_cell_restart:
                 tw->durable_stop_ts = tw->stop_ts;
         }
 
-        __cell_assert_tw_has_ts_for_garbage_collection(session, tw);
+        __cell_assert_tw_has_ts_for_garbage_collection_table(session, tw);
 
         WT_RET(__cell_check_value_validity(session, tw, end != NULL));
         break;

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -36,6 +36,9 @@ __cell_check_value_validity(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw, bool e
 static WT_INLINE void
 __cell_assert_tw_has_ts_for_garbage_collection(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw)
 {
+    WT_UNUSED(session);
+    WT_UNUSED(tw);
+
     WT_ASSERT(session,
       (tw->start_ts != WT_TS_NONE && tw->durable_start_ts != WT_TS_NONE) ||
         !F_ISSET(S2BT(session), WT_BTREE_GARBAGE_COLLECT));

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -38,6 +38,14 @@ __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_WINDO
 {
     uint8_t flags, *flagsp;
 
+    WT_ASSERT(session,
+      (tw->start_ts != WT_TS_NONE && tw->durable_start_ts != WT_TS_NONE) ||
+        !F_ISSET(S2BT(session), WT_BTREE_GARBAGE_COLLECT));
+    WT_ASSERT(session,
+      !WT_TIME_WINDOW_HAS_STOP(tw) ||
+        (tw->stop_ts != WT_TS_NONE && tw->durable_stop_ts != WT_TS_NONE) ||
+        !F_ISSET(S2BT(session), WT_BTREE_GARBAGE_COLLECT));
+
     /* Globally visible values have no associated validity window. */
     if (WT_TIME_WINDOW_IS_EMPTY(tw)) {
         ++*pp;
@@ -923,9 +931,8 @@ copy_cell_restart:
         temp_start_ts = temp_durable_start_ts = temp_durable_stop_ts = WT_TS_NONE;
         temp_stop_ts = WT_TS_MAX;
 
-        if (LF_ISSET(WT_CELL_TS_START)) {
+        if (LF_ISSET(WT_CELL_TS_START))
             WT_RET(__wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &temp_start_ts));
-        }
         if (LF_ISSET(WT_CELL_TXN_START))
             WT_RET(__wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &tw->start_txn));
         if (LF_ISSET(WT_CELL_TS_DURABLE_START))
@@ -1031,6 +1038,14 @@ copy_cell_restart:
             else if (tw->stop_ts != WT_TS_MAX)
                 tw->durable_stop_ts = tw->stop_ts;
         }
+
+        WT_ASSERT(session,
+          (tw->start_ts != WT_TS_NONE && tw->durable_start_ts != WT_TS_NONE) ||
+            !F_ISSET(S2BT(session), WT_BTREE_GARBAGE_COLLECT));
+        WT_ASSERT(session,
+          !WT_TIME_WINDOW_HAS_STOP(tw) ||
+            (tw->stop_ts != WT_TS_NONE && tw->durable_stop_ts != WT_TS_NONE) ||
+            !F_ISSET(S2BT(session), WT_BTREE_GARBAGE_COLLECT));
 
         WT_RET(__cell_check_value_validity(session, tw, end != NULL));
         break;

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -30,6 +30,22 @@ __cell_check_value_validity(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw, bool e
 }
 
 /*
+ * __cell_assert_tw_has_ts_for_garbage_collection --
+ *     Assert that time window has timestamps if garbage collection is enabled for the btree.
+ */
+static WT_INLINE void
+__cell_assert_tw_has_ts_for_garbage_collection(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw)
+{
+    WT_ASSERT(session,
+      (tw->start_ts != WT_TS_NONE && tw->durable_start_ts != WT_TS_NONE) ||
+        !F_ISSET(S2BT(session), WT_BTREE_GARBAGE_COLLECT));
+    WT_ASSERT(session,
+      !WT_TIME_WINDOW_HAS_STOP(tw) ||
+        (tw->stop_ts != WT_TS_NONE && tw->durable_stop_ts != WT_TS_NONE) ||
+        !F_ISSET(S2BT(session), WT_BTREE_GARBAGE_COLLECT));
+}
+
+/*
  * __cell_pack_value_validity --
  *     Pack the validity window for a value.
  */
@@ -38,13 +54,7 @@ __cell_pack_value_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_WINDO
 {
     uint8_t flags, *flagsp;
 
-    WT_ASSERT(session,
-      (tw->start_ts != WT_TS_NONE && tw->durable_start_ts != WT_TS_NONE) ||
-        !F_ISSET(S2BT(session), WT_BTREE_GARBAGE_COLLECT));
-    WT_ASSERT(session,
-      !WT_TIME_WINDOW_HAS_STOP(tw) ||
-        (tw->stop_ts != WT_TS_NONE && tw->durable_stop_ts != WT_TS_NONE) ||
-        !F_ISSET(S2BT(session), WT_BTREE_GARBAGE_COLLECT));
+    __cell_assert_tw_has_ts_for_garbage_collection(session, tw);
 
     /* Globally visible values have no associated validity window. */
     if (WT_TIME_WINDOW_IS_EMPTY(tw)) {
@@ -1039,13 +1049,7 @@ copy_cell_restart:
                 tw->durable_stop_ts = tw->stop_ts;
         }
 
-        WT_ASSERT(session,
-          (tw->start_ts != WT_TS_NONE && tw->durable_start_ts != WT_TS_NONE) ||
-            !F_ISSET(S2BT(session), WT_BTREE_GARBAGE_COLLECT));
-        WT_ASSERT(session,
-          !WT_TIME_WINDOW_HAS_STOP(tw) ||
-            (tw->stop_ts != WT_TS_NONE && tw->durable_stop_ts != WT_TS_NONE) ||
-            !F_ISSET(S2BT(session), WT_BTREE_GARBAGE_COLLECT));
+        __cell_assert_tw_has_ts_for_garbage_collection(session, tw);
 
         WT_RET(__cell_check_value_validity(session, tw, end != NULL));
         break;

--- a/src/reconcile/reconcile_inline.h
+++ b/src/reconcile/reconcile_inline.h
@@ -510,8 +510,10 @@ __wti_rec_time_window_clear_obsolete(WT_SESSION_IMPL *session, WTI_UPDATE_SELECT
 
     btree = S2BT(session);
 
-    /* Never clear the timestamps from the ingest table. They are needed for step-up even they are
-     * globally visible. */
+    /*
+     * Never clear the timestamps on the ingest tables. They are needed for step-up even they are
+     * globally visible.
+     */
     if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
         return;
 

--- a/src/reconcile/reconcile_inline.h
+++ b/src/reconcile/reconcile_inline.h
@@ -511,8 +511,8 @@ __wti_rec_time_window_clear_obsolete(WT_SESSION_IMPL *session, WTI_UPDATE_SELECT
     btree = S2BT(session);
 
     /*
-     * Never clear the timestamps on the ingest tables. They are needed for step-up even they are
-     * globally visible.
+     * Never clear the timestamps on the ingest tables. They are needed for step-up even when they
+     * are globally visible.
      */
     if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
         return;

--- a/src/reconcile/reconcile_inline.h
+++ b/src/reconcile/reconcile_inline.h
@@ -501,11 +501,19 @@ static WT_INLINE void
 __wti_rec_time_window_clear_obsolete(WT_SESSION_IMPL *session, WTI_UPDATE_SELECT *upd_select,
   WT_CELL_UNPACK_KV *vpack, WTI_RECONCILE *r)
 {
+    WT_BTREE *btree;
     WT_TIME_WINDOW *tw;
 
     WT_ASSERT(
       session, (upd_select != NULL && vpack == NULL) || (upd_select == NULL && vpack != NULL));
     tw = upd_select != NULL ? &upd_select->tw : &vpack->tw;
+
+    btree = S2BT(session);
+
+    /* Never clear the timestamps from the ingest table. They are needed for step-up even they are
+     * globally visible. */
+    if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
+        return;
 
     /* Return if the start time window is empty. */
     if (!WT_TIME_WINDOW_HAS_START(tw))
@@ -517,7 +525,7 @@ __wti_rec_time_window_clear_obsolete(WT_SESSION_IMPL *session, WTI_UPDATE_SELECT
      * disk image value to the update chain.
      */
     if (!WT_TIME_WINDOW_HAS_PREPARE(tw) && !F_ISSET(S2C(session), WT_CONN_IN_MEMORY) &&
-      !F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY)) {
+      !F_ISSET(btree, WT_BTREE_IN_MEMORY)) {
         /*
          * Check if the start of the time window is globally visible, and if so remove unnecessary
          * values.

--- a/test/suite/test_layered22.py
+++ b/test/suite/test_layered22.py
@@ -56,9 +56,11 @@ class test_layered22(wttest.WiredTigerTestCase):
 
         cursor = self.session.open_cursor(self.uri, None, None)
         for i in range(self.nitems):
+            self.session.begin_transaction()
             cursor["Hello " + str(i)] = "World"
             cursor["Hi " + str(i)] = "There"
             cursor["OK " + str(i)] = "Go"
+            self.session.commit_transaction(f"commit_timestamp={self.timestamp_str(10)}")
         cursor.close()
 
         cursor = self.session.open_cursor(self.uri, None, None)
@@ -84,7 +86,9 @@ class test_layered22(wttest.WiredTigerTestCase):
         value2 = "abaa"
 
         for i in range(self.nitems):
+            self.session.begin_transaction()
             cursor[str(i)] = value1
+            self.session.commit_transaction(f"commit_timestamp={self.timestamp_str(10)}")
 
         for i in range(self.nitems):
             if i % 10 == 0:
@@ -92,7 +96,7 @@ class test_layered22(wttest.WiredTigerTestCase):
                 cursor.set_key(str(i))
                 mods = [wiredtiger.Modify('b', 1, 1)]
                 self.assertEqual(cursor.modify(mods), 0)
-                self.session.commit_transaction()
+                self.session.commit_transaction(f"commit_timestamp={self.timestamp_str(20)}")
 
         cursor.close()
 
@@ -113,7 +117,9 @@ class test_layered22(wttest.WiredTigerTestCase):
         self.assertEqual(cursor.search(), wiredtiger.WT_NOTFOUND)
         self.assertEqual(cursor.search_near(), wiredtiger.WT_NOTFOUND)
 
+        self.session.begin_transaction()
         cursor["found"] = "yes"
+        self.session.commit_transaction(f"commit_timestamp={self.timestamp_str(10)}")
         cursor.set_key("found")
         self.assertEqual(cursor.search(), 0)
         self.assertEqual(cursor.search_near(), 0)
@@ -123,9 +129,11 @@ class test_layered22(wttest.WiredTigerTestCase):
 
         cursor = self.session.open_cursor(self.uri, None, None)
         for i in range(self.nitems):
+            self.session.begin_transaction()
             cursor["Hello " + str(i)] = "World"
             cursor["Hi " + str(i)] = "There"
             cursor["OK " + str(i)] = "Go"
+            self.session.commit_transaction(f"commit_timestamp={self.timestamp_str(10)}")
         cursor.close()
 
         cursor = self.session.open_cursor(self.uri, None, None)
@@ -137,7 +145,9 @@ class test_layered22(wttest.WiredTigerTestCase):
 
         cursor = self.session.open_cursor(self.uri, None, None)
         for i in range(self.nitems):
+            self.session.begin_transaction()
             cursor["Hello " + str(i)] = "World"
+            self.session.commit_transaction(f"commit_timestamp={self.timestamp_str(10)}")
         cursor.close()
 
         random_cursor = self.session.open_cursor(self.uri, None, "next_random=true")

--- a/test/suite/test_layered61.py
+++ b/test/suite/test_layered61.py
@@ -40,8 +40,8 @@ class test_layered61(wttest.WiredTigerTestCase):
                      + 'precise_checkpoint=true,'
     conn_config = conn_base_config + 'disaggregated=(role="follower")'
 
-    create_session_config = 'key_format=S,value_format=S,type=layered'
-    uri = "table:test_layered61"
+    create_session_config = 'key_format=S,value_format=S'
+    uri = "layered:test_layered61"
 
     disagg_storages = gen_disagg_storages('test_layered61', disagg_only = True)
     scenarios = make_scenarios(disagg_storages)

--- a/test/suite/test_layered61.py
+++ b/test/suite/test_layered61.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import os, os.path, shutil, threading, time, wiredtiger, wttest
+from helper_disagg import disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
+
+# test_layered61.py
+# Test reconciliation never cleans the timestamp for the ingest table
+@disagg_test_class
+class test_layered61(wttest.WiredTigerTestCase):
+    conn_base_config = 'statistics=(all),' \
+                     + 'statistics_log=(wait=1,json=true,on_close=true),' \
+                     + 'precise_checkpoint=true,'
+    conn_config = conn_base_config + 'disaggregated=(role="follower")'
+
+    create_session_config = 'key_format=S,value_format=S,type=layered'
+    uri = "table:test_layered61"
+
+    disagg_storages = gen_disagg_storages('test_layered61', disagg_only = True)
+    scenarios = make_scenarios(disagg_storages)
+
+    def test_layered61(self):
+        # Create a table with some data
+        self.session.create(self.uri, self.create_session_config)
+        cursor = self.session.open_cursor(self.uri, None, None)
+        self.session.begin_transaction()
+        cursor['a'] = 'b'
+        self.session.commit_transaction(f"commit_timestamp={self.timestamp_str(10)}")
+        cursor.close()
+
+        self.conn.set_timestamp(f"stable_timestamp={self.timestamp_str(20)},oldest_timestamp={self.timestamp_str(20)}")
+
+        # Evict the data.
+        session = self.conn.open_session("debug=(release_evict_page)")
+        evict_cursor = session.open_cursor(self.uri, None, None)
+        session.begin_transaction()
+        evict_cursor.set_key('a')
+        evict_cursor.search()
+        session.rollback_transaction()
+        evict_cursor.close()
+        session.close()
+
+        # Step up
+        self.conn.reconfigure('disaggregated=(role="leader")')

--- a/test/suite/test_layered61.py
+++ b/test/suite/test_layered61.py
@@ -31,7 +31,8 @@ from helper_disagg import disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 
 # test_layered61.py
-# Test reconciliation never cleans the timestamp for the ingest table
+# Test the timestamps on the ingest tables are not cleared even they are globally
+# visible.
 @disagg_test_class
 class test_layered61(wttest.WiredTigerTestCase):
     conn_base_config = 'statistics=(all),' \

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -623,7 +623,7 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
         if passed and self.__module__.startswith("test_layered"):
             # FIXME-WT-15786: Handle the transient state where a follower that has not yet picked up
             # its first checkpoint may fail with ENOENT due to missing its stable table.
-            if not re.match("test_layered(61|57|41|22|21|17)", str(self)):
+            if not re.match("test_layered(57|41|22|21|17)", str(self)):
                 self.verifyLayered()
 
         try:

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -623,7 +623,7 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
         if passed and self.__module__.startswith("test_layered"):
             # FIXME-WT-15786: Handle the transient state where a follower that has not yet picked up
             # its first checkpoint may fail with ENOENT due to missing its stable table.
-            if not re.match("test_layered(57|41|21|22|17)", str(self)):
+            if not re.match("test_layered(61|57|41|22|21|17)", str(self)):
                 self.verifyLayered()
 
         try:


### PR DESCRIPTION
We should never clear the timestamps for ingest tables even they are globally visible as they are needed during step-up.
