### PR TITLE
WT-15852 Enable configurable PALite log verbosity in Python tests

### DIFF
--- a/test/suite/run.py
+++ b/test/suite/run.py
@@ -164,7 +164,8 @@ def parse_int_list(str):
 def verify_command_line_vars(vars):
     # The list of allowed variables, with defaults. Matches the usage message.
     vars_allowed = {
-        'page_log' : 'palite'
+        'page_log' : 'palite',
+        'page_log_verbose' : '0'  # INFO level logging by default
     }
 
     for name in vars:


### PR DESCRIPTION
- Add `page_log_verbose` command-live variable to `test/suite/run.py` to control verbosity level of PALite
- Minor fix in PALite hex dumps: avoid non-ASCII characters