### PR TITLE
WT-15376 Suppress the rest of TSAN warnings

### DIFF
--- a/src/block_cache/block_chunkcache.c
+++ b/src/block_cache/block_chunkcache.c
@@ -582,7 +582,7 @@ __chunkcache_eviction_thread(void *arg)
         uint64_t bytes_used = __wt_tsan_suppress_load_uint64(&chunkcache->bytes_used);
         /* Do not evict if we are not close to exceeding capacity. */
         if ((bytes_used + chunkcache->chunk_size) <
-        chunkcache->evict_trigger * chunkcache->capacity / 100) {
+          chunkcache->evict_trigger * chunkcache->capacity / 100) {
             __wt_sleep(1, 0);
             continue;
         }

--- a/src/block_cache/block_chunkcache.c
+++ b/src/block_cache/block_chunkcache.c
@@ -579,9 +579,10 @@ __chunkcache_eviction_thread(void *arg)
     chunkcache = &S2C(session)->chunkcache;
 
     while (!F_ISSET(chunkcache, WT_CHUNK_CACHE_EXITING)) {
+        uint64_t bytes_used = __wt_tsan_suppress_load_uint64(&chunkcache->bytes_used);
         /* Do not evict if we are not close to exceeding capacity. */
-        if ((chunkcache->bytes_used + chunkcache->chunk_size) <
-          chunkcache->evict_trigger * chunkcache->capacity / 100) {
+        if ((bytes_used + chunkcache->chunk_size) <
+        chunkcache->evict_trigger * chunkcache->capacity / 100) {
             __wt_sleep(1, 0);
             continue;
         }

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -356,7 +356,8 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
             tried_eviction = false;
 
             WT_STAT_CONN_INCR(session, checkpoint_pages_reconciled);
-            WT_STAT_CONN_INCRV(session, checkpoint_pages_reconciled_bytes, page->memory_footprint);
+            WT_STAT_CONN_INCRV(session, checkpoint_pages_reconciled_bytes,
+                __wt_tsan_suppress_load_uint64(&page->memory_footprint));
             WT_STATP_DSRC_INCR(session, btree->dhandle->stats, btree_checkpoint_pages_reconciled);
             if (WT_IS_HS(btree->dhandle))
                 WT_STAT_CONN_INCR(session, checkpoint_hs_pages_reconciled);

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -357,7 +357,7 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 
             WT_STAT_CONN_INCR(session, checkpoint_pages_reconciled);
             WT_STAT_CONN_INCRV(session, checkpoint_pages_reconciled_bytes,
-                __wt_tsan_suppress_load_uint64(&page->memory_footprint));
+              __wt_tsan_suppress_load_uint64(&page->memory_footprint));
             WT_STATP_DSRC_INCR(session, btree->dhandle->stats, btree_checkpoint_pages_reconciled);
             if (WT_IS_HS(btree->dhandle))
                 WT_STAT_CONN_INCR(session, checkpoint_hs_pages_reconciled);

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -871,7 +871,7 @@ __checkpoint_prepare(WT_SESSION_IMPL *session, bool *trackingp, const char *cfg[
      * time and only write to the metadata.
      */
     __wt_writelock(session, &txn_global->rwlock);
-    txn_global->checkpoint_txn_shared = *txn_shared;
+    __wt_tsan_suppress_memcpy(&txn_global->checkpoint_txn_shared, txn_shared, sizeof(*txn_shared));
     __wt_atomic_store_uint64_v_relaxed(
       &txn_global->checkpoint_txn_shared.pinned_id, txn->snapshot_data.snap_min);
 

--- a/src/include/tsan_suppress.h
+++ b/src/include/tsan_suppress.h
@@ -22,6 +22,16 @@
  */
 
 /*
+ * __wt_tsan_suppress_store_uint8_v --
+ *     TSAN warnings suppression for volatile uint8 store.
+ */
+static WT_INLINE void
+__wt_tsan_suppress_store_uint8_v(volatile uint8_t *vp, uint8_t v)
+{
+    __wt_atomic_store_uint8_v_relaxed(vp, v);
+}
+
+/*
  * __wt_tsan_suppress_store_uint8 --
  *     TSAN warnings suppression for uint8 store.
  */

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1366,8 +1366,8 @@ __wt_txn_upd_visible_type(WT_SESSION_IMPL *session, WT_UPDATE *upd)
             return (WT_VISIBLE_TRUE);
 
         /* FIXME-WT-15884: data race around accesses to upd_start_ts and upd_durable_ts */
-        upd_visible = __wt_txn_visible(session, upd->txnid,
-            __wt_tsan_suppress_load_uint64(&upd->upd_start_ts),
+        upd_visible =
+          __wt_txn_visible(session, upd->txnid, __wt_tsan_suppress_load_uint64(&upd->upd_start_ts),
             __wt_tsan_suppress_load_uint64(&upd->upd_durable_ts));
 
         /*

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -208,10 +208,11 @@ __txn_apply_prepare_state_update(WT_SESSION_IMPL *session, WT_UPDATE *upd, bool 
          * TODO: we can remove the prepare locked state once we separate the prepared timestamp and
          * commit timestamp.
          */
-        upd->prepare_state = WT_PREPARE_LOCKED;
+        __wt_tsan_suppress_store_uint8_v(&upd->prepare_state, WT_PREPARE_LOCKED);
         WT_RELEASE_BARRIER();
-        upd->upd_start_ts = txn->commit_timestamp;
-        upd->upd_durable_ts = txn->durable_timestamp;
+        /* FIXME-WT-15884: data race around accesses to upd_start_ts and upd_durable_ts */
+        __wt_tsan_suppress_store_uint64(&upd->upd_start_ts, txn->commit_timestamp);
+        __wt_tsan_suppress_store_uint64(&upd->upd_durable_ts, txn->durable_timestamp);
         __wt_atomic_store_uint8_v_release(&upd->prepare_state, WT_PREPARE_RESOLVED);
     } else {
         /* Set prepare timestamp and id. */
@@ -1364,7 +1365,10 @@ __wt_txn_upd_visible_type(WT_SESSION_IMPL *session, WT_UPDATE *upd)
               upd->type == WT_UPDATE_STANDARD))
             return (WT_VISIBLE_TRUE);
 
-        upd_visible = __wt_txn_visible(session, upd->txnid, upd->upd_start_ts, upd->upd_durable_ts);
+        /* FIXME-WT-15884: data race around accesses to upd_start_ts and upd_durable_ts */
+        upd_visible = __wt_txn_visible(session, upd->txnid,
+            __wt_tsan_suppress_load_uint64(&upd->upd_start_ts),
+            __wt_tsan_suppress_load_uint64(&upd->upd_durable_ts));
 
         /*
          * The visibility check is only valid if the update does not change state. If the state does

--- a/src/log/log_mgr.c
+++ b/src/log/log_mgr.c
@@ -692,7 +692,7 @@ __log_file_server(void *arg)
                  * cursor traversal.
                  */
                 if (__wt_atomic_load_uint64_relaxed(&conn->hot_backup_start) == 0 &&
-                    __wt_tsan_suppress_load_uint32(&conn->log_mgr.cursors) == 0) {
+                  __wt_tsan_suppress_load_uint32(&conn->log_mgr.cursors) == 0) {
                     WT_WITH_HOTBACKUP_READ_LOCK(session,
                       ret = __wt_ftruncate(session, close_fh, __wt_lsn_offset(&close_end_lsn)),
                       NULL);

--- a/src/log/log_mgr.c
+++ b/src/log/log_mgr.c
@@ -692,7 +692,7 @@ __log_file_server(void *arg)
                  * cursor traversal.
                  */
                 if (__wt_atomic_load_uint64_relaxed(&conn->hot_backup_start) == 0 &&
-                  conn->log_mgr.cursors == 0) {
+                    __wt_tsan_suppress_load_uint32(&conn->log_mgr.cursors) == 0) {
                     WT_WITH_HOTBACKUP_READ_LOCK(session,
                       ret = __wt_ftruncate(session, close_fh, __wt_lsn_offset(&close_end_lsn)),
                       NULL);

--- a/src/support/mtx_rw.c
+++ b/src/support/mtx_rw.c
@@ -130,7 +130,7 @@ __wt_try_readlock(WT_SESSION_IMPL *session, WT_RWLOCK *l)
     WT_STAT_CONN_INCR(session, rwlock_read);
     if (l->stat_read_count_off != -1 && WT_STAT_ENABLED(session)) {
         stats = (int64_t **)S2C(session)->stats;
-        stats[session->stat_conn_bucket][l->stat_read_count_off]++;
+        __wt_tsan_suppress_add_int64(&stats[session->stat_conn_bucket][l->stat_read_count_off], 1);
     }
 
     old.u.v = __wt_atomic_load_uint64_v_relaxed(&l->u.v);

--- a/src/support/mtx_rw.c
+++ b/src/support/mtx_rw.c
@@ -255,12 +255,12 @@ stall:
         time_diff = WT_CLOCKDIFF_US(time_stop, time_start);
 
         stats = (int64_t **)S2C(session)->stats;
-        stats[session->stat_conn_bucket][l->stat_read_count_off]++;
+        __wt_tsan_suppress_add_int64(&stats[session->stat_conn_bucket][l->stat_read_count_off], 1);
         session_stats = (int64_t *)&(session->stats);
         if (F_ISSET(session, WT_SESSION_INTERNAL))
-            stats[session->stat_conn_bucket][l->stat_int_usecs_off] += (int64_t)time_diff;
+            __wt_tsan_suppress_add_int64(&stats[session->stat_conn_bucket][l->stat_int_usecs_off], (int64_t)time_diff);
         else {
-            stats[session->stat_conn_bucket][l->stat_app_usecs_off] += (int64_t)time_diff;
+            __wt_tsan_suppress_add_int64(&stats[session->stat_conn_bucket][l->stat_app_usecs_off], (int64_t)time_diff);
         }
 
         /*
@@ -268,7 +268,7 @@ stall:
          * initialized to determine whether they are enabled.
          */
         if (l->stat_session_usecs_off != -1)
-            session_stats[l->stat_session_usecs_off] += (int64_t)time_diff;
+            __wt_tsan_suppress_add_int64(&session_stats[l->stat_session_usecs_off], (int64_t)time_diff);
     }
 
     /*
@@ -332,7 +332,7 @@ __wt_try_writelock(WT_SESSION_IMPL *session, WT_RWLOCK *l)
     WT_STAT_CONN_INCR(session, rwlock_write);
     if (l->stat_write_count_off != -1 && WT_STAT_ENABLED(session)) {
         stats = (int64_t **)S2C(session)->stats;
-        stats[session->stat_conn_bucket][l->stat_write_count_off]++;
+        __wt_tsan_suppress_add_int64(&stats[session->stat_conn_bucket][l->stat_write_count_off], 1);
     }
 
     /*
@@ -442,19 +442,19 @@ __wt_writelock(WT_SESSION_IMPL *session, WT_RWLOCK *l)
         time_diff = WT_CLOCKDIFF_US(time_stop, time_start);
 
         stats = (int64_t **)S2C(session)->stats;
-        stats[session->stat_conn_bucket][l->stat_write_count_off]++;
+        __wt_tsan_suppress_add_int64(&stats[session->stat_conn_bucket][l->stat_write_count_off], 1);
         session_stats = (int64_t *)&(session->stats);
         if (F_ISSET(session, WT_SESSION_INTERNAL))
-            stats[session->stat_conn_bucket][l->stat_int_usecs_off] += (int64_t)time_diff;
+            __wt_tsan_suppress_add_int64(&stats[session->stat_conn_bucket][l->stat_int_usecs_off], (int64_t)time_diff);
         else
-            stats[session->stat_conn_bucket][l->stat_app_usecs_off] += (int64_t)time_diff;
+            __wt_tsan_suppress_add_int64(&stats[session->stat_conn_bucket][l->stat_app_usecs_off], (int64_t)time_diff);
 
         /*
          * Not all read-write locks increment session statistics. Check whether the offset is
          * initialized to determine whether they are enabled.
          */
         if (l->stat_session_usecs_off != -1)
-            session_stats[l->stat_session_usecs_off] += (int64_t)time_diff;
+            __wt_tsan_suppress_add_int64(&session_stats[l->stat_session_usecs_off], (int64_t)time_diff);
     }
 
     /*

--- a/src/support/mtx_rw.c
+++ b/src/support/mtx_rw.c
@@ -258,9 +258,11 @@ stall:
         __wt_tsan_suppress_add_int64(&stats[session->stat_conn_bucket][l->stat_read_count_off], 1);
         session_stats = (int64_t *)&(session->stats);
         if (F_ISSET(session, WT_SESSION_INTERNAL))
-            __wt_tsan_suppress_add_int64(&stats[session->stat_conn_bucket][l->stat_int_usecs_off], (int64_t)time_diff);
+            __wt_tsan_suppress_add_int64(
+              &stats[session->stat_conn_bucket][l->stat_int_usecs_off], (int64_t)time_diff);
         else {
-            __wt_tsan_suppress_add_int64(&stats[session->stat_conn_bucket][l->stat_app_usecs_off], (int64_t)time_diff);
+            __wt_tsan_suppress_add_int64(
+              &stats[session->stat_conn_bucket][l->stat_app_usecs_off], (int64_t)time_diff);
         }
 
         /*
@@ -268,7 +270,8 @@ stall:
          * initialized to determine whether they are enabled.
          */
         if (l->stat_session_usecs_off != -1)
-            __wt_tsan_suppress_add_int64(&session_stats[l->stat_session_usecs_off], (int64_t)time_diff);
+            __wt_tsan_suppress_add_int64(
+              &session_stats[l->stat_session_usecs_off], (int64_t)time_diff);
     }
 
     /*
@@ -445,16 +448,19 @@ __wt_writelock(WT_SESSION_IMPL *session, WT_RWLOCK *l)
         __wt_tsan_suppress_add_int64(&stats[session->stat_conn_bucket][l->stat_write_count_off], 1);
         session_stats = (int64_t *)&(session->stats);
         if (F_ISSET(session, WT_SESSION_INTERNAL))
-            __wt_tsan_suppress_add_int64(&stats[session->stat_conn_bucket][l->stat_int_usecs_off], (int64_t)time_diff);
+            __wt_tsan_suppress_add_int64(
+              &stats[session->stat_conn_bucket][l->stat_int_usecs_off], (int64_t)time_diff);
         else
-            __wt_tsan_suppress_add_int64(&stats[session->stat_conn_bucket][l->stat_app_usecs_off], (int64_t)time_diff);
+            __wt_tsan_suppress_add_int64(
+              &stats[session->stat_conn_bucket][l->stat_app_usecs_off], (int64_t)time_diff);
 
         /*
          * Not all read-write locks increment session statistics. Check whether the offset is
          * initialized to determine whether they are enabled.
          */
         if (l->stat_session_usecs_off != -1)
-            __wt_tsan_suppress_add_int64(&session_stats[l->stat_session_usecs_off], (int64_t)time_diff);
+            __wt_tsan_suppress_add_int64(
+              &session_stats[l->stat_session_usecs_off], (int64_t)time_diff);
     }
 
     /*

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -911,7 +911,7 @@ functions:
         set -o errexit
         set -o verbose
         ${PREPARE_PATH}
-        python3 test/evergreen/tsan_warnings_analysis.py --timestamp ${timestamp}
+        python3 test/evergreen/tsan_warnings_analysis.py
 
   "code coverage analysis":
     command: shell.exec
@@ -4858,9 +4858,6 @@ tasks:
           dependent_task: unit-test-tsan
           destination: wiredtiger/unit-test-tsan
       - func: "tsan warning metric"
-        vars:
-          # Report all warnings
-          timestamp: 0
 
   - name: generate-tsan-metric-disagg
     tags: ["pull_request_code_statistics"]
@@ -4878,9 +4875,6 @@ tasks:
           dependent_task: unit-test-disagg-follower-tsan
           destination: wiredtiger/unit-test-disagg-follower-tsan
       - func: "tsan warning metric"
-        vars:
-          # Generate all warnings
-          timestamp: 0
 
     ###############################
     # Performance Tests for btree #

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4847,21 +4847,6 @@ tasks:
           test-name: modularity_metrics
           collection: CodeModularityMetrics
 
-  - name: generate-tsan-metric-timestamp
-    tags: ["pull_request_code_statistics"]
-    depends_on:
-      - name: "unit-test-tsan"
-    commands:
-      - func: "get project"
-      - func: "fetch artifacts"
-        vars:
-          dependent_task: unit-test-tsan
-          destination: wiredtiger/unit-test-tsan
-      - func: "tsan warning metric"
-        vars:
-          # Track warnings only after time 2025-08-06 06:07:50.655735+00:00
-          timestamp: 1754460496
-
   - name: generate-tsan-metric
     tags: ["pull_request_code_statistics"]
     depends_on:
@@ -4876,26 +4861,6 @@ tasks:
         vars:
           # Report all warnings
           timestamp: 0
-
-  - name: generate-tsan-metric-disagg-timestamp
-    tags: ["pull_request_code_statistics"]
-    depends_on:
-      - name: "unit-test-disagg-leader-tsan"
-      - name: "unit-test-disagg-follower-tsan"
-    commands:
-      - func: "get project"
-      - func: "fetch artifacts"
-        vars:
-          dependent_task: unit-test-disagg-leader-tsan
-          destination: wiredtiger/unit-test-disagg-leader-tsan
-      - func: "fetch artifacts"
-        vars:
-          dependent_task: unit-test-disagg-follower-tsan
-          destination: wiredtiger/unit-test-disagg-follower-tsan
-      - func: "tsan warning metric"
-        vars:
-          # Track warnings right before disagg merge 2025-08-02.
-          timestamp: 1746576000
 
   - name: generate-tsan-metric-disagg
     tags: ["pull_request_code_statistics"]

--- a/test/evergreen/tsan_warnings.supp
+++ b/test/evergreen/tsan_warnings.supp
@@ -74,6 +74,7 @@ race:__wt_page_alloc
 race:__wt_page_modify_alloc
 race:__wt_upd_alloc
 race:__sweep_discard_trees
+race:__wt_conn_dhandle_alloc
 
 # FIXME-WT-15770 Fix python testing non-disagg TSAN warnings
 race:__wt_row_modify

--- a/test/evergreen/tsan_warnings_analysis.py
+++ b/test/evergreen/tsan_warnings_analysis.py
@@ -25,7 +25,7 @@
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
-import argparse, os, subprocess
+import argparse, os, sys, subprocess
 import re
 # The script will look through all tsan logs from the current directory
 # and collect all the warnings the found under tsan logs.
@@ -132,6 +132,7 @@ def main():
             print("\n".join(warning_lines))
             print("=" * 150)
         print(f"Overall TSAN Warnings: {len(tsan_warnings_dict)}")
+        sys.exit(1)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Most of the TSAN warnings were suppressed previously, and currently we have only around 10 issues remaining. This PR suppresses all of these issues, leaving FIXME tickets for the recently introduced ones so they can be shared with other teams later.

It also removes the `generate-tsan-metric-*-timestamp` CI jobs, as we assume that after this change there will no longer be any difference between jobs with and without timestamp filtering.