### PR TITLE
WT-15892 Fix __wt_page_in_func segfault because use after free of the page

### DIFF
--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -277,6 +277,7 @@ __page_read(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
         for (i = 0; i < count - 1; ++i)
             __wt_buf_free(session, &deltas[i]);
         WT_ERR(ret);
+        page = ref->page;
     }
 
     __wt_free(session, tmp);

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -277,6 +277,7 @@ __page_read(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
         for (i = 0; i < count - 1; ++i)
             __wt_buf_free(session, &deltas[i]);
         WT_ERR(ret);
+        /* The page may be changed if we consolidate the deltas to a new page. */
         page = ref->page;
     }
 


### PR DESCRIPTION
The delta rewrite code changes the page inside ref underneath. While the caller still has a pointer to the old page, which causes this issue. Refresh the pointer in the caller to fix this.

This should all go away after we can generate a full page directly from the base page and the deltas.