### PR TITLE
WT-15903 Ignore expected output in test_ovfl01 if it exists (8.2) (#12683)

### DIFF
--- a/test/suite/test_ovfl01.py
+++ b/test/suite/test_ovfl01.py
@@ -81,4 +81,4 @@ class test_ovfl01(wttest.WiredTigerTestCase):
         # Verify on disk contents.
         self.session.verify(self.uri)
 
-        self.ignoreStdoutPattern('bulk insert failed during page split')
+        self.ignoreStdoutPatternIfExists('bulk insert failed during page split')


### PR DESCRIPTION
Update the function from `ignoreStdoutPattern` to
`ignoreStdoutPatternIfExists` as the logs are not always produced by the test.

(cherry picked from commit b4824c39da965453edf58eefa933b4733fdc8e55)