### PR TITLE
WT-15905 Fix delta rewriting lead to instantiate the updates twice and wrongly decrease the dirty leaf count

### DIFF
--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -154,12 +154,12 @@ __page_read(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
     WT_REF_STATE previous_state;
     size_t count, i;
     uint32_t page_flags;
-    bool instantiate_upd, disk_image_freed;
+    bool instantiate_upd, disk_image_freed, page_change;
 
     WT_CLEAR(block_meta);
     tmp = NULL;
     count = 0;
-    disk_image_freed = false;
+    disk_image_freed = page_change = false;
     page = NULL;
 
     /* Lock the WT_REF. */
@@ -278,12 +278,15 @@ __page_read(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
             __wt_buf_free(session, &deltas[i]);
         WT_ERR(ret);
         /* The page may be changed if we consolidate the deltas to a new page. */
-        page = ref->page;
+        if (page != ref->page) {
+            page = ref->page;
+            page_change = true;
+        }
     }
 
     __wt_free(session, tmp);
 
-    if (instantiate_upd && !WT_IS_HS(session->dhandle))
+    if (!page_change && instantiate_upd && !WT_IS_HS(session->dhandle))
         WT_ERR(__wti_page_inmem_updates(session, ref));
 
     /*

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -789,8 +789,8 @@ __wt_page_only_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page)
     size = 0;
     if (WT_UNLIKELY(!WT_PAGE_IS_INTERNAL(page) &&
           __wt_atomic_load_uint64_relaxed(&S2C(session)->cache->pages_dirty_leaf) < 10 &&
-          (F_ISSET(session, WT_SESSION_INTERNAL) || WT_IS_METADATA(session->dhandle) ||
-            WT_IS_DISAGG_META(session->dhandle) || WT_IS_HS(session->dhandle)))) {
+          (WT_IS_METADATA(session->dhandle) || WT_IS_DISAGG_META(session->dhandle) ||
+            WT_IS_HS(session->dhandle)))) {
         increase_dirty_size_first = true;
         size = __wt_atomic_load_size_relaxed(&page->memory_footprint);
         __wt_cache_dirty_incr_size(session, size, false);

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -789,8 +789,8 @@ __wt_page_only_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page)
     size = 0;
     if (WT_UNLIKELY(!WT_PAGE_IS_INTERNAL(page) &&
           __wt_atomic_load_uint64_relaxed(&S2C(session)->cache->pages_dirty_leaf) < 10 &&
-          (WT_IS_METADATA(session->dhandle) || WT_IS_DISAGG_META(session->dhandle) ||
-            WT_IS_HS(session->dhandle)))) {
+          (F_ISSET(session, WT_SESSION_INTERNAL) || WT_IS_METADATA(session->dhandle) ||
+            WT_IS_DISAGG_META(session->dhandle) || WT_IS_HS(session->dhandle)))) {
         increase_dirty_size_first = true;
         size = __wt_atomic_load_size_relaxed(&page->memory_footprint);
         __wt_cache_dirty_incr_size(session, size, false);

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -525,7 +525,8 @@ __rec_write_page_status(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
          * If the page state changed, the page has been written since reconciliation started and
          * remains dirty (that can't happen when evicting, the page is exclusively locked).
          */
-        if (__wt_atomic_cas_uint32(&mod->page_state, WT_PAGE_DIRTY_FIRST, WT_PAGE_CLEAN))
+        if (__wt_atomic_cas_uint32(&mod->page_state, WT_PAGE_DIRTY_FIRST, WT_PAGE_CLEAN) &&
+          !F_ISSET(r, WT_REC_REWRITE_DELTA))
             __wt_cache_dirty_decr(session, page);
         else
             WT_ASSERT_ALWAYS(
@@ -2680,8 +2681,11 @@ __rec_split_write(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_CHUNK *chu
      * If we are rewriting a page restored from delta, no need to write it but directly instantiate
      * it into memory.
      */
-    if (F_ISSET(r, WT_REC_IN_MEMORY | WT_REC_REWRITE_DELTA))
+    if (F_ISSET(r, WT_REC_IN_MEMORY | WT_REC_REWRITE_DELTA)) {
+        if (page->disagg_info != NULL)
+            *multi->block_meta = page->disagg_info->block_meta;
         goto copy_image;
+    }
 
     /* Check the eviction flag as checkpoint also saves updates. */
     if (F_ISSET(r, WT_REC_EVICT) && multi->supd != NULL) {

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -525,10 +525,10 @@ __rec_write_page_status(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
          * If the page state changed, the page has been written since reconciliation started and
          * remains dirty (that can't happen when evicting, the page is exclusively locked).
          */
-        if (__wt_atomic_cas_uint32(&mod->page_state, WT_PAGE_DIRTY_FIRST, WT_PAGE_CLEAN) &&
-          !F_ISSET(r, WT_REC_REWRITE_DELTA))
-            __wt_cache_dirty_decr(session, page);
-        else
+        if (__wt_atomic_cas_uint32(&mod->page_state, WT_PAGE_DIRTY_FIRST, WT_PAGE_CLEAN)) {
+            if (!F_ISSET(r, WT_REC_REWRITE_DELTA))
+                __wt_cache_dirty_decr(session, page);
+        } else
             WT_ASSERT_ALWAYS(
               session, !F_ISSET(r, WT_REC_EVICT), "Page state has been modified during eviction");
     }


### PR DESCRIPTION
This is a temporary fix for the issues caused by rewriting the deltas. These code should go away after we have finished the work to directly consolidate the base page and deltas to a single disk image.