### PR TITLE
WT-15906 Log all flags set for each update in readable format when dumping btree

### DIFF
--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -1718,7 +1718,7 @@ __debug_update_dump_flags(WT_DBG *ds, WT_UPDATE *upd)
         WT_RET(ds->f(ds, " | flags: ["));
         int flag_num = 0;
         if (F_ISSET(upd, WT_UPDATE_DELETE_DURABLE)) {
-            WT_RET(flag_num == 0 ? ds->f(ds, "delete-durable") : ds->f(ds, ", delete-durable"));
+            WT_RET(ds->f(ds, "delete-durable"));
             ++flag_num;
         }
         if (F_ISSET(upd, WT_UPDATE_DS)) {

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -1719,53 +1719,53 @@ __debug_update_dump_flags(WT_DBG *ds, WT_UPDATE *upd)
         int flag_num = 0;
         if (F_ISSET(upd, WT_UPDATE_DELETE_DURABLE)) {
             WT_RET(flag_num == 0 ? ds->f(ds, "delete-durable") : ds->f(ds, ", delete-durable"));
-            flag_num++;
+            ++flag_num;
         }
         if (F_ISSET(upd, WT_UPDATE_DS)) {
             WT_RET(flag_num == 0 ? ds->f(ds, "data-store") : ds->f(ds, ", data-store"));
-            flag_num++;
+            ++flag_num;
         }
         if (F_ISSET(upd, WT_UPDATE_DURABLE)) {
-            WT_RET(flag_num == 0 ? ds->f(ds, "durable") : ds->f(ds, ", data-store"));
-            flag_num++;
+            WT_RET(flag_num == 0 ? ds->f(ds, "durable") : ds->f(ds, ", durable"));
+            ++flag_num;
         }
         if (F_ISSET(upd, WT_UPDATE_HS)) {
             WT_RET(flag_num == 0 ? ds->f(ds, "history-store") : ds->f(ds, ", history-store"));
-            flag_num++;
+            ++flag_num;
         }
         if (F_ISSET(upd, WT_UPDATE_HS_MAX_STOP)) {
             WT_RET(flag_num == 0 ? ds->f(ds, "hs-max-stop") : ds->f(ds, ", hs-max-stop"));
-            flag_num++;
+            ++flag_num;
         }
         if (F_ISSET(upd, WT_UPDATE_PREPARE_DURABLE)) {
             WT_RET(flag_num == 0 ? ds->f(ds, "prepare-durable") : ds->f(ds, ", prepare-durable"));
-            flag_num++;
+            ++flag_num;
         }
         if (F_ISSET(upd, WT_UPDATE_PREPARE_RESTORED_FROM_DS)) {
             WT_RET(flag_num == 0 ? ds->f(ds, "prepare-restored-from-ds") :
                                    ds->f(ds, ", prepare-restored-from-ds"));
-            flag_num++;
+            ++flag_num;
         }
         if (F_ISSET(upd, WT_UPDATE_PREPARE_ROLLBACK)) {
             WT_RET(flag_num == 0 ? ds->f(ds, "prepare-rollback") : ds->f(ds, ", prepare-rollback"));
-            flag_num++;
+            ++flag_num;
         }
         if (F_ISSET(upd, WT_UPDATE_RESTORED_FAST_TRUNCATE)) {
             WT_RET(flag_num == 0 ? ds->f(ds, "fast-truncate") : ds->f(ds, ", fast-truncate"));
-            flag_num++;
+            ++flag_num;
         }
         if (F_ISSET(upd, WT_UPDATE_RESTORED_FROM_DELTA)) {
             WT_RET(flag_num == 0 ? ds->f(ds, "restored-from-delta") :
                                    ds->f(ds, ", restored-from-delta"));
-            flag_num++;
+            ++flag_num;
         }
         if (F_ISSET(upd, WT_UPDATE_RESTORED_FROM_DS)) {
             WT_RET(flag_num == 0 ? ds->f(ds, "restored-from-ds") : ds->f(ds, ", restored-from-ds"));
-            flag_num++;
+            ++flag_num;
         }
         if (F_ISSET(upd, WT_UPDATE_RESTORED_FROM_HS)) {
             WT_RET(flag_num == 0 ? ds->f(ds, "restored-from-hs") : ds->f(ds, ", restored-from-hs"));
-            flag_num++;
+            ++flag_num;
         }
         WT_RET(ds->f(ds, "]\n"));
     }

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -63,6 +63,7 @@ static int __debug_ref(WT_DBG *, WT_REF *);
 static int __debug_row_skip(WT_DBG *, WT_INSERT_HEAD *);
 static int __debug_tree(WT_SESSION_IMPL *, WT_REF *, const char *, uint32_t);
 static int __debug_update(WT_DBG *, WT_UPDATE *, bool);
+static int __debug_update_dump_flags(WT_DBG *ds, WT_UPDATE *upd);
 static int __debug_wrapup(WT_DBG *);
 
 /*
@@ -1701,7 +1702,72 @@ __debug_update(WT_DBG *ds, WT_UPDATE *upd, bool hexbyte)
         if (prepare_state != NULL)
             WT_RET(ds->f(ds, ", prepare: %s", prepare_state));
 
-        WT_RET(ds->f(ds, ", flags: 0x%" PRIx16 "\n", upd->flags));
+        WT_RET(__debug_update_dump_flags(ds, upd));
+    }
+    return (0);
+}
+
+/*
+ * __debug_update_dump_flags --
+ *     Dump the list of flags set on an update
+ */
+static int
+__debug_update_dump_flags(WT_DBG *ds, WT_UPDATE *upd)
+{
+    if (upd->flags != 0) {
+        WT_RET(ds->f(ds, " | flags: ["));
+        int flag_num = 0;
+        if (F_ISSET(upd, WT_UPDATE_DELETE_DURABLE)) {
+            WT_RET(flag_num == 0 ? ds->f(ds, "delete-durable") : ds->f(ds, ", delete-durable"));
+            flag_num++;
+        }
+        if (F_ISSET(upd, WT_UPDATE_DS)) {
+            WT_RET(flag_num == 0 ? ds->f(ds, "data-store") : ds->f(ds, ", data-store"));
+            flag_num++;
+        }
+        if (F_ISSET(upd, WT_UPDATE_DURABLE)) {
+            WT_RET(flag_num == 0 ? ds->f(ds, "durable") : ds->f(ds, ", data-store"));
+            flag_num++;
+        }
+        if (F_ISSET(upd, WT_UPDATE_HS)) {
+            WT_RET(flag_num == 0 ? ds->f(ds, "history-store") : ds->f(ds, ", history-store"));
+            flag_num++;
+        }
+        if (F_ISSET(upd, WT_UPDATE_HS_MAX_STOP)) {
+            WT_RET(flag_num == 0 ? ds->f(ds, "hs-max-stop") : ds->f(ds, ", hs-max-stop"));
+            flag_num++;
+        }
+        if (F_ISSET(upd, WT_UPDATE_PREPARE_DURABLE)) {
+            WT_RET(flag_num == 0 ? ds->f(ds, "prepare-durable") : ds->f(ds, ", prepare-durable"));
+            flag_num++;
+        }
+        if (F_ISSET(upd, WT_UPDATE_PREPARE_RESTORED_FROM_DS)) {
+            WT_RET(flag_num == 0 ? ds->f(ds, "prepare-restored-from-ds") :
+                                   ds->f(ds, ", prepare-restored-from-ds"));
+            flag_num++;
+        }
+        if (F_ISSET(upd, WT_UPDATE_PREPARE_ROLLBACK)) {
+            WT_RET(flag_num == 0 ? ds->f(ds, "prepare-rollback") : ds->f(ds, ", prepare-rollback"));
+            flag_num++;
+        }
+        if (F_ISSET(upd, WT_UPDATE_RESTORED_FAST_TRUNCATE)) {
+            WT_RET(flag_num == 0 ? ds->f(ds, "fast-truncate") : ds->f(ds, ", fast-truncate"));
+            flag_num++;
+        }
+        if (F_ISSET(upd, WT_UPDATE_RESTORED_FROM_DELTA)) {
+            WT_RET(flag_num == 0 ? ds->f(ds, "restored-from-delta") :
+                                   ds->f(ds, ", restored-from-delta"));
+            flag_num++;
+        }
+        if (F_ISSET(upd, WT_UPDATE_RESTORED_FROM_DS)) {
+            WT_RET(flag_num == 0 ? ds->f(ds, "restored-from-ds") : ds->f(ds, ", restored-from-ds"));
+            flag_num++;
+        }
+        if (F_ISSET(upd, WT_UPDATE_RESTORED_FROM_HS)) {
+            WT_RET(flag_num == 0 ? ds->f(ds, "restored-from-hs") : ds->f(ds, ", restored-from-hs"));
+            flag_num++;
+        }
+        WT_RET(ds->f(ds, "]\n"));
     }
     return (0);
 }


### PR DESCRIPTION
This PR logs the updates' flag names in human readable format when dumping the btree. This is useful to check if the update is restored from deltas, history store or data store and would be useful for debugging.