### PR TITLE
WT-15912 Fix log flooding during page sleep and when cache is full of updates or dirty pages 

### DIFF
--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -619,7 +619,7 @@ skip_evict:
         }
         __wt_spin_backoff(&yield_cnt, &sleep_usecs);
         ++sleep_count;
-        if (sleep_count > 10 * WT_THOUSAND && sleep_count % 10 * WT_THOUSAND == 0)
+        if (sleep_count > 10 * WT_THOUSAND && sleep_count % (10 * WT_THOUSAND) == 0)
             __wt_verbose_warning(session, WT_VERB_READ,
               "sleep to wait the page %p for %" WT_SIZET_FMT " times", (void *)ref, sleep_count);
         WT_STAT_CONN_INCRV(session, page_sleep, sleep_usecs);

--- a/src/evict/evict_inline.h
+++ b/src/evict/evict_inline.h
@@ -556,11 +556,11 @@ __wt_evict_needed(
           (!conn->layered_table_manager.leader || F_ISSET(conn, WT_CONN_RECONFIGURING_STEP_UP))) {
             double cache_full = (evict->eviction_target + evict->eviction_trigger) / 2;
             if (pct_updates > cache_full)
-                __wt_verbose_warning(
+                __wt_verbose_debug1(
                   session, WT_VERB_EVICTION, "cache is full of updates: %f percent", pct_updates);
 
             if (pct_dirty > cache_full)
-                __wt_verbose_warning(
+                __wt_verbose_debug1(
                   session, WT_VERB_EVICTION, "cache is full of dirty pages: %f percent", pct_dirty);
 
             if (dirty_needed || updates_needed)


### PR DESCRIPTION
This ticket is to fix following full of logs issues:
1. Fix the bug that we are not log this `sleep to wait the page 0x... for <num> times` warning message in a right frequency.
2. Decrease the verbosity level to debug when cache is full of updates or dirty pages.