### PR TITLE
WT-15935 Use right suppression function to fix MacOS compilation

### DIFF
--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -357,7 +357,7 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 
             WT_STAT_CONN_INCR(session, checkpoint_pages_reconciled);
             WT_STAT_CONN_INCRV(session, checkpoint_pages_reconciled_bytes,
-              __wt_tsan_suppress_load_uint64(&page->memory_footprint));
+              __wt_tsan_suppress_load_size(&page->memory_footprint));
             WT_STATP_DSRC_INCR(session, btree->dhandle->stats, btree_checkpoint_pages_reconciled);
             if (WT_IS_HS(btree->dhandle))
                 WT_STAT_CONN_INCR(session, checkpoint_hs_pages_reconciled);

--- a/src/include/tsan_suppress.h
+++ b/src/include/tsan_suppress.h
@@ -132,6 +132,16 @@ __wt_tsan_suppress_add_uint64_v(volatile uint64_t *var, uint64_t value)
 }
 
 /*
+ * __wt_tsan_suppress_load_size --
+ *     TSAN warnings suppression for uint64 load.
+ */
+static WT_INLINE size_t
+__wt_tsan_suppress_load_size(size_t *vp)
+{
+    return (__wt_atomic_load_size_relaxed(vp));
+}
+
+/*
  * __wt_tsan_suppress_store_int64 --
  *     TSAN warnings suppression for int64 store.
  */

--- a/src/include/tsan_suppress.h
+++ b/src/include/tsan_suppress.h
@@ -133,7 +133,7 @@ __wt_tsan_suppress_add_uint64_v(volatile uint64_t *var, uint64_t value)
 
 /*
  * __wt_tsan_suppress_load_size --
- *     TSAN warnings suppression for uint64 load.
+ *     TSAN warnings suppression for size_t load.
  */
 static WT_INLINE size_t
 __wt_tsan_suppress_load_size(size_t *vp)


### PR DESCRIPTION
Use the right suppression function to fix compilation on MacOS that was broken by https://github.com/wiredtiger/wiredtiger/pull/12678