### PR TITLE
WT-15883 Enable parallel access to storage

### DIFF
--- a/ext/page_log/palite/palite.cpp
+++ b/ext/page_log/palite/palite.cpp
@@ -433,6 +433,7 @@ safe_call(WT_SESSION *sess, S *api, MemberFunc func, Args &&...args)
     }
 
     session(sess);
+    /* std::unique_ptr is used as a simple scope guard to reset the session upon function exit */
     std::unique_ptr<WT_SESSION, std::function<decltype(session)>> reset_session{nullptr, &session};
 
     T *obj = static_cast<T *>(api);
@@ -651,7 +652,6 @@ class Connection {
     sqlite3 *db = nullptr;
     std::vector<sqlite3_stmt *> statements;
 
-public:
     /* Common configuration parameters for connections */
     constexpr static std::string_view config_statements[] = {
       /*
@@ -672,6 +672,7 @@ public:
       /* Set busy timeout to 10 seconds. */
       "PRAGMA busy_timeout = 10000;"};
 
+public:
     using StatementPtr = std::unique_ptr<sqlite3_stmt, std::function<decltype(sqlite3_reset)>>;
 
     ~Connection() = default;
@@ -834,17 +835,6 @@ protected:
 
         Access(const Access &) = delete;
         Access &operator=(const Access &) = delete;
-
-        void
-        release()
-        {
-            if (table_read_lock.owns_lock())
-                table_read_lock.unlock();
-            if (table_write_lock.owns_lock())
-                table_write_lock.unlock();
-            if (store_lock.owns_lock())
-                store_lock.unlock();
-        }
     };
 
     Access
@@ -1527,23 +1517,25 @@ struct Pages : public Table<Pages> {
     put(uint64_t table_id, uint64_t page_id, uint64_t lsn, WT_PAGE_LOG_PUT_ARGS *args,
       const WT_ITEM *buf)
     {
-        auto acc_w = request(AccessMode::WRITE);
-        Connection &conn = acc_w.conn;
+        {
+            auto acc_w = request(AccessMode::WRITE);
+            Connection &conn = acc_w.conn;
 
-        Connection::StatementPtr stmt = conn.db_statement(Statement::PUT_PAGE);
-        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 1, static_cast<sqlite3_int64>(table_id));
-        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 2, static_cast<sqlite3_int64>(page_id));
-        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 3, static_cast<sqlite3_int64>(lsn));
-        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 4, static_cast<sqlite3_int64>(args->backlink_lsn));
-        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 5, static_cast<sqlite3_int64>(args->base_lsn));
-        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 6, static_cast<sqlite3_int64>(args->flags));
-        SQ_CHECK(sqlite3_bind_text, stmt.get(), 7, args->encryption.dek,
-          strlen(args->encryption.dek), SQLITE_STATIC);
-        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 8,
-          static_cast<sqlite3_int64>(now_us() + (config.materialization_delay_ms * 1ms / 1us)));
-        SQ_CHECK(sqlite3_bind_blob, stmt.get(), 9, buf->data, buf->size, SQLITE_STATIC);
-        SQ_CHECK(sqlite3_step, stmt.get());
-        acc_w.release();
+            Connection::StatementPtr stmt = conn.db_statement(Statement::PUT_PAGE);
+            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 1, static_cast<sqlite3_int64>(table_id));
+            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 2, static_cast<sqlite3_int64>(page_id));
+            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 3, static_cast<sqlite3_int64>(lsn));
+            SQ_CHECK(
+              sqlite3_bind_int64, stmt.get(), 4, static_cast<sqlite3_int64>(args->backlink_lsn));
+            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 5, static_cast<sqlite3_int64>(args->base_lsn));
+            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 6, static_cast<sqlite3_int64>(args->flags));
+            SQ_CHECK(sqlite3_bind_text, stmt.get(), 7, args->encryption.dek,
+              strlen(args->encryption.dek), SQLITE_STATIC);
+            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 8,
+              static_cast<sqlite3_int64>(now_us() + (config.materialization_delay_ms * 1ms / 1us)));
+            SQ_CHECK(sqlite3_bind_blob, stmt.get(), 9, buf->data, buf->size, SQLITE_STATIC);
+            SQ_CHECK(sqlite3_step, stmt.get());
+        }
 
         if (config.verify) {
             auto acc_r = request(AccessMode::READ);

--- a/ext/page_log/palite/palite.cpp
+++ b/ext/page_log/palite/palite.cpp
@@ -46,7 +46,6 @@
 #include <mutex>
 #include <random>
 #include <ranges>
-#include <semaphore>
 #include <shared_mutex>
 #include <span>
 #include <source_location>
@@ -364,7 +363,7 @@ template <> struct std::formatter<Config> {
 };
 
 WT_SESSION *const INVALID_PTR = reinterpret_cast<WT_SESSION *>(-1);
-const uint64_t INVALID_LSN = UINT64_MAX;
+constexpr uint64_t INVALID_LSN = UINT64_MAX;
 
 static WT_SESSION *
 session(WT_SESSION *s = INVALID_PTR)
@@ -418,10 +417,10 @@ log(std::source_location loc, Config &config, WT_VERBOSE_LEVEL level,
 #define LOG_DIAG(...) LOG_AT(WT_VERBOSE_DEBUG_2, __VA_ARGS__)
 #define LOG_TRACE(...) LOG_AT(WT_VERBOSE_DEBUG_3, __VA_ARGS__)
 
-#define LOG_SQL_TRACE(fmt, ...)         \
-    do {                                \
-        if (config.sql_trace)           \
-            LOG_DIAG(fmt, __VA_ARGS__); \
+#define LOG_SQL_TRACE(str)       \
+    do {                         \
+        if (config.sql_trace)    \
+            LOG_DIAG("{}", str); \
     } while (0)
 
 /* Exception-safe template method that catches C++ exceptions */
@@ -478,10 +477,15 @@ log_and_throw(
 
 #define LOG_AND_THROW(...) log_and_throw(std::source_location::current(), config, __VA_ARGS__)
 
-/* Generic formatter for custom pointer types. */
+/*
+ * Generic formatter for custom pointer types. Excludes char* and void* specializations provided by
+ * the standard library.
+ */
 template <typename T>
-requires(!std::is_same_v<std::remove_cv_t<T>, char> &&
-  !std::is_void_v<std::remove_cv_t<T>>) struct std::formatter<T *, char> {
+concept custom_ptr_t =
+  !std::is_same_v<std::remove_cv_t<T>, char> && !std::is_void_v<std::remove_cv_t<T>>;
+
+template <custom_ptr_t T> struct std::formatter<T *, char> {
     /* Use the same format specifiers as for uintptr_t */
     std::formatter<std::uintptr_t, char> underlying;
 
@@ -513,14 +517,14 @@ class SQLiteCall {
     static consteval auto
     make_log_format(const char (&prefix)[K])
     {
-        constexpr std::size_t prefix_len = sizeof(prefix) - 1; /* exclude null terminator */
+        const std::size_t prefix_len = sizeof(prefix) - 1; /* exclude null terminator */
         /* Each argument contributes: 4 chars for "'{}'" plus 2 chars for ", " */
-        constexpr std::size_t braces_len = N == 0 ? 0 : (N * 6);
+        const std::size_t braces_len = N == 0 ? 0 : (N * 6);
         std::array<char, prefix_len + braces_len + 1> fmt{};
 
         std::copy_n(prefix, prefix_len, fmt.begin()); /* excludes null terminator */
 
-        constexpr const char c[] = "'{}', ";
+        const char c[] = "'{}', ";
         for (size_t i = prefix_len; i != fmt.size() - 1; ++i)
             fmt[i] = c[(i - prefix_len) % 6];
         fmt[fmt.size() - 3] = '\0';
@@ -561,7 +565,7 @@ public:
     exec(Func &&c_func, Args &&...args)
     {
         auto ret = std::invoke(std::forward<Func>(c_func), std::forward<Args>(args)...);
-        LOG_SQL_TRACE("{}", trace_sqlite3_call(ret, args...));
+        LOG_SQL_TRACE(trace_sqlite3_call(ret, args...));
 
         if (ret != SQLITE_OK && ret != SQLITE_ROW && ret != SQLITE_DONE) {
             std::string error_msg = trace_sqlite3_call(ret, args...);
@@ -640,8 +644,523 @@ public:
 #define SQ_CHECK(func, ...) SQL_CALL_CHECK(conn.db_instance(), func, __VA_ARGS__)
 
 /*
- * Storage layer
+ * SQLite database connection. Manages opening/closing the database and preparing statements.
  */
+class Connection {
+    Config &config;
+    sqlite3 *db = nullptr;
+    std::vector<sqlite3_stmt *> statements;
+
+public:
+    /* Common configuration parameters for connections */
+    constexpr static std::string_view config_statements[] = {
+      /*
+       * The WAL journaling mode uses a write-ahead log instead of a rollback journal to implement
+       * transactions. This significantly improves performance.
+       */
+      "PRAGMA journal_mode = WAL;",
+
+      /*
+       * Turn Synchronous mode OFF for better performance. We don't care about database corruption
+       * in case of OS crash or power failure.
+       */
+      "PRAGMA synchronous = OFF;",
+
+      /* For temporary store use memory instead of disk. */
+      "PRAGMA temp_store = MEMORY;",
+
+      /* Set busy timeout to 10 seconds. */
+      "PRAGMA busy_timeout = 10000;"};
+
+    using StatementPtr = std::unique_ptr<sqlite3_stmt, std::function<decltype(sqlite3_reset)>>;
+
+    ~Connection() = default;
+    Connection(Config &cfg, const std::filesystem::path &db_path)
+        : config(cfg), db(open_db(cfg, db_path))
+    {
+        configure(Connection::config_statements);
+    }
+
+    StatementPtr
+    db_statement(size_t idx)
+    {
+        return StatementPtr(statements[idx], [this](sqlite3_stmt *s) {
+            /* do not throw from d'tor */
+            return SQL_CALL_CHECK_NO_THROW(db, sqlite3_reset, s);
+        });
+    }
+
+    sqlite3 *
+    db_instance() const
+    {
+        return db;
+    }
+
+    template <typename Container>
+    void
+    configure(const Container &cfg_statements)
+    {
+        for (const auto &stmt : cfg_statements) {
+            SQL_CALL_CHECK(db, sqlite3_exec, db, stmt.data(), nullptr, nullptr, nullptr);
+        }
+    }
+
+    template <typename Container>
+    void
+    prepare_statements(const Container &sql_statements)
+    {
+        statements.clear();
+        for (const auto &stmt : sql_statements) {
+            sqlite3_stmt *prepared_stmt = nullptr;
+            SQL_CALL_CHECK(db, sqlite3_prepare_v2, db, stmt.data(), -1, &prepared_stmt, nullptr);
+            statements.push_back(prepared_stmt);
+        }
+    }
+
+    void
+    close()
+    {
+        finalize_statements();
+        close_db();
+    }
+
+private:
+    static sqlite3 *
+    open_db(Config &config, const std::filesystem::path &db_path)
+    {
+        const unsigned flags =
+          /*
+           * The database is opened for reading and writing, and is created if it does not already
+           * exist.
+           */
+          SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE |
+          /*
+           * Use the "multi-thread" threading mode. Cannot share this connection between threads.
+           */
+          SQLITE_OPEN_NOMUTEX;
+
+        sqlite3 *pdb = nullptr;
+        SQL_CALL_OPEN(sqlite3_open_v2, db_path.c_str(), &pdb, flags, nullptr);
+        LOG_DEBUG("Opened SQLite database: {} ({})", pdb, db_path.c_str());
+
+        return pdb;
+    }
+
+    void
+    finalize_statements()
+    {
+        std::ranges::for_each(
+          statements, [this](sqlite3_stmt *s) { SQL_CALL_CHECK(db, sqlite3_finalize, s); });
+        statements.clear();
+    }
+
+    void
+    close_db()
+    {
+        int ret = sqlite3_close(db);
+        if (ret == SQLITE_OK) {
+            LOG_DEBUG("Closed SQLite database: {}", db);
+        } else {
+            LOG_ERROR(
+              "Failed to close SQLite database: {}. Error: {} ({})", db, ret, sqlite3_errstr(ret));
+        }
+        db = nullptr;
+    }
+};
+
+/*
+ * Generic functionality of a database table. Manages connections per thread and provides access
+ * control.
+ */
+template <typename Traits> class Table {
+protected:
+    Config &config;
+    std::shared_mutex &store_access; /* Store-wide access mutex */
+
+    std::filesystem::path table_file;
+
+    std::once_flag create_table;
+    std::shared_mutex conn_state; /* protects 'connections' map */
+    std::unordered_map<std::thread::id, std::unique_ptr<Connection>> connections;
+
+public:
+    std::shared_mutex access; /* readers-writer mutex for table */
+
+    ~Table() = default;
+    Table(Config &cfg, std::shared_mutex &str_access, const std::filesystem::path &file)
+        : config(cfg), store_access(str_access), table_file(file)
+    {
+    }
+
+    void
+    close()
+    {
+        std::ranges::for_each(connections, [](auto &kv) { kv.second->close(); });
+        connections.clear();
+    }
+
+    enum AccessMode { READ, WRITE, BYPASS };
+
+protected:
+    class Access {
+        std::shared_lock<std::shared_mutex> store_lock;
+        std::shared_lock<std::shared_mutex> table_read_lock;
+        std::unique_lock<std::shared_mutex> table_write_lock;
+
+    public:
+        Connection &conn;
+
+        ~Access() = default;
+        Access(AccessMode mode, Connection &cn, std::shared_mutex &store_access,
+          std::shared_mutex &table_access)
+            : conn(cn)
+        {
+            switch (mode) {
+            case AccessMode::READ:
+                store_lock = std::shared_lock(store_access);
+                table_read_lock = std::shared_lock(table_access);
+                break;
+            case AccessMode::WRITE:
+                store_lock = std::shared_lock(store_access);
+                table_write_lock = std::unique_lock(table_access);
+                break;
+            case AccessMode::BYPASS:
+                /* no locking */
+                break;
+            default:
+                assert(false && "Invalid AccessMode");
+            }
+        }
+
+        Access(const Access &) = delete;
+        Access &operator=(const Access &) = delete;
+
+        void
+        release()
+        {
+            if (table_read_lock.owns_lock())
+                table_read_lock.unlock();
+            if (table_write_lock.owns_lock())
+                table_write_lock.unlock();
+            if (store_lock.owns_lock())
+                store_lock.unlock();
+        }
+    };
+
+    Access
+    request(AccessMode mode)
+    {
+        return Access{mode, conn(), store_access, access};
+    }
+
+private:
+    Connection &
+    conn()
+    {
+        {
+            std::shared_lock read_lock(conn_state);
+            auto it = connections.find(std::this_thread::get_id());
+            if (it != connections.end())
+                return *(it->second);
+        }
+
+        {
+            std::unique_lock write_lock(conn_state);
+            auto [it, inserted] = connections.try_emplace(
+              std::this_thread::get_id(), std::make_unique<Connection>(config, table_file));
+
+            if (!inserted)
+                LOG_AND_THROW("Connection already exists for this thread");
+
+            Connection &new_conn = *(it->second);
+            new_conn.configure(static_cast<Traits *>(this)->conn_config());
+
+            std::call_once(
+              create_table,
+              [this](Connection &c) {
+                  c.configure(Traits::create_statements);
+                  LOG_DEBUG("SQLite database schema initialized: {}", c.db_instance());
+              },
+              new_conn);
+
+            new_conn.prepare_statements(Traits::sql_statements);
+
+            return new_conn;
+        }
+    }
+};
+
+/*
+ * Specific Tables
+ */
+
+struct Globals : public Table<Globals> {
+    constexpr static std::string_view prefix = "globals";
+
+    enum Statement {
+        MAKE_NEXT_LSN,
+        GET_LAST_LSN,
+        ADD_TABLE_ID,
+        GET_TABLE_IDS,
+        COUNT /* number of statements */
+    };
+
+    constexpr static auto sql_statements = []() constexpr
+    {
+        std::array<std::string_view, COUNT> stmt{};
+
+        /* Increment LSN. */
+        stmt[MAKE_NEXT_LSN] =
+          R"(UPDATE globals
+             SET val = val + 1
+             WHERE id = 0
+             RETURNING val;)";
+
+        /* Get the last LSN. */
+        stmt[GET_LAST_LSN] =
+          R"(SELECT val
+             FROM globals
+             WHERE id = 0;)",
+
+        /* Add a new table ID if it does not already exist. */
+          stmt[ADD_TABLE_ID] =
+            R"(INSERT OR IGNORE INTO globals (id, val)
+               VALUES (1, ?);)";
+
+        /* Get all known table IDs. */
+        stmt[GET_TABLE_IDS] =
+          R"(SELECT val
+             FROM globals
+             WHERE id = 1;)";
+
+        return stmt;
+    }
+    ();
+
+    static_assert(
+      std::ranges::none_of(Globals::sql_statements, [](const auto &s) { return s.empty(); }),
+      "Not all SQL statements were initialized");
+
+    constexpr static std::string_view create_statements[] = {
+      /*
+       * Globals table to store LSN counter and known table IDs.
+       *  - LSN counter id = 0
+       *  - Table IDs id = 1
+       */
+      R"(CREATE TABLE IF NOT EXISTS globals (
+            id INTEGER CHECK (id = 0 OR id = 1),
+            val INTEGER NOT NULL,
+         PRIMARY KEY (id, val));)",
+
+      /* Init LSN counter, if the table is empty; do nothing otherwise. */
+      R"(INSERT INTO globals (id, val)
+         SELECT 0, 0
+         WHERE NOT EXISTS (SELECT 1 FROM globals WHERE id = 0);)"};
+
+    ~Globals() = default;
+    Globals(Config &cfg, std::shared_mutex &store_access, const std::filesystem::path &home)
+        : Table<Globals>(cfg, store_access, home / std::format("{}.db", Globals::prefix))
+    {
+    }
+
+    Globals(const Globals &) = delete;
+    Globals &operator=(const Globals &) = delete;
+
+    auto
+    conn_config() -> std::ranges::view auto
+    {
+        /* No special configuration is required for the 'globals' table. */
+        return std::views::empty<std::string_view>;
+    }
+
+    uint64_t
+    fetch_lsn(Connection &conn, Statement stmt_type)
+    {
+        Connection::StatementPtr stmt = conn.db_statement(stmt_type);
+        SQ_CHECK(sqlite3_step, stmt.get());
+
+        return sqlite3_column_int64(stmt.get(), 0);
+    }
+
+    uint64_t
+    make_next_lsn()
+    {
+        auto acc = request(AccessMode::WRITE);
+
+        return fetch_lsn(acc.conn, Statement::MAKE_NEXT_LSN);
+    }
+
+    uint64_t
+    get_last_lsn()
+    {
+        auto acc = request(AccessMode::READ);
+
+        return fetch_lsn(acc.conn, Statement::GET_LAST_LSN);
+    }
+
+    void
+    add_table_id(uint64_t table_id)
+    {
+        auto acc = request(AccessMode::WRITE);
+        Connection &conn = acc.conn;
+
+        Connection::StatementPtr stmt = conn.db_statement(Statement::ADD_TABLE_ID);
+        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 1, static_cast<sqlite3_int64>(table_id));
+        SQ_CHECK(sqlite3_step, stmt.get());
+    }
+
+    std::vector<uint64_t>
+    get_table_ids(AccessMode mode = AccessMode::READ)
+    {
+        auto acc = request(mode);
+        Connection &conn = acc.conn;
+
+        Connection::StatementPtr stmt = conn.db_statement(Statement::GET_TABLE_IDS);
+        std::vector<uint64_t> table_ids;
+        while (SQ_CHECK(sqlite3_step, stmt.get()) == SQLITE_ROW) {
+            table_ids.push_back(static_cast<uint64_t>(sqlite3_column_int64(stmt.get(), 0)));
+        }
+
+        return table_ids;
+    }
+};
+
+struct Checkpoints : public Table<Checkpoints> {
+    constexpr static std::string_view prefix = "checkpoints";
+
+    enum Statement {
+        PUT_CHECKPOINT,
+        GET_CHECKPOINT,
+        DELETE_CHECKPOINTS,
+        COUNT /* number of statements */
+    };
+
+    constexpr static auto sql_statements = []() constexpr
+    {
+        std::array<std::string_view, COUNT> stmt{};
+
+        /*
+         * Insert a new checkpoint.
+         */
+        stmt[PUT_CHECKPOINT] =
+          R"(INSERT INTO checkpoints (lsn, timestamp, checkpoint_metadata)
+             VALUES (?, ?, ?);)";
+
+        /*
+         * Get the latest checkpoint (i.e., checkpoint with the highest lsn) if query lsn equals to
+         * WT_PAGE_LOG_LSN_MAX ( passed as parameter: ?2); otherwise get the checkpoint with the
+         * given lsn.
+         */
+        stmt[GET_CHECKPOINT] =
+          R"(SELECT lsn, timestamp, checkpoint_metadata
+             FROM checkpoints
+             WHERE (?1 = ?2 OR lsn = ?1)
+             ORDER BY
+                 lsn DESC,
+                 timestamp DESC
+             LIMIT 1;)";
+
+        /*
+         * Delete all checkpoints with lsn greater than the given lsn.
+         */
+        stmt[DELETE_CHECKPOINTS] =
+          R"(DELETE FROM checkpoints
+             WHERE lsn > ?;)";
+
+        return stmt;
+    }
+    ();
+
+    static_assert(
+      std::ranges::none_of(Checkpoints::sql_statements, [](const auto &s) { return s.empty(); }),
+      "Not all SQL statements were initialized");
+
+    constexpr static std::string_view create_statements[] = {
+      R"(CREATE TABLE IF NOT EXISTS checkpoints (
+            lsn INTEGER NOT NULL,
+            timestamp INTEGER NOT NULL,
+            checkpoint_metadata BLOB,
+         PRIMARY KEY (lsn, timestamp));)"};
+
+    ~Checkpoints() = default;
+    Checkpoints(Config &cfg, std::shared_mutex &store_access, const std::filesystem::path &home)
+        : Table<Checkpoints>(cfg, store_access, home / std::format("{}.db", Checkpoints::prefix))
+    {
+    }
+
+    Checkpoints(const Checkpoints &) = delete;
+    Checkpoints &operator=(const Checkpoints &) = delete;
+
+    auto
+    conn_config() -> std::ranges::view auto
+    {
+        /* No special configuration is required for the 'checkpoints' table. */
+        return std::views::empty<std::string_view>;
+    }
+
+    void
+    put(uint64_t lsn, uint64_t checkpoint_timestamp, const WT_ITEM *checkpoint_metadata)
+    {
+        auto acc = request(AccessMode::WRITE);
+        Connection &conn = acc.conn;
+
+        Connection::StatementPtr stmt = conn.db_statement(Statement::PUT_CHECKPOINT);
+        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 1, lsn);
+        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 2, checkpoint_timestamp);
+        SQ_CHECK(sqlite3_bind_blob, stmt.get(), 3, checkpoint_metadata->data,
+          checkpoint_metadata->size, SQLITE_STATIC);
+        SQ_CHECK(sqlite3_step, stmt.get());
+    }
+
+    int
+    get(uint64_t &lsn, uint64_t *timestamp, WT_ITEM *checkpoint_metadata,
+      AccessMode mode = AccessMode::READ)
+    {
+        auto acc = request(mode);
+        Connection &conn = acc.conn;
+
+        Connection::StatementPtr stmt = conn.db_statement(Statement::GET_CHECKPOINT);
+        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 1, static_cast<sqlite3_int64>(lsn));
+        SQ_CHECK(
+          sqlite3_bind_int64, stmt.get(), 2, static_cast<sqlite3_int64>(WT_PAGE_LOG_LSN_MAX));
+        int ret = SQ_CHECK(sqlite3_step, stmt.get());
+        if (ret == SQLITE_DONE) {
+            /* No checkpoint found */
+            if (timestamp)
+                *timestamp = 0;
+
+            if (checkpoint_metadata) {
+                checkpoint_metadata->data = nullptr;
+                checkpoint_metadata->size = 0;
+            }
+
+            return WT_NOTFOUND;
+        }
+
+        lsn = sqlite3_column_int64(stmt.get(), 0);
+        if (timestamp)
+            *timestamp = sqlite3_column_int64(stmt.get(), 1);
+
+        if (checkpoint_metadata) {
+            const void *blob = sqlite3_column_blob(stmt.get(), 2);
+            int size = sqlite3_column_bytes(stmt.get(), 2);
+            fill_item(checkpoint_metadata, blob, static_cast<size_t>(size));
+        }
+
+        return 0;
+    }
+
+    void
+    delete_many(uint64_t lsn, AccessMode mode = AccessMode::WRITE)
+    {
+        auto acc = request(mode);
+        Connection &conn = acc.conn;
+
+        Connection::StatementPtr stmt = conn.db_statement(Statement::DELETE_CHECKPOINTS);
+        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 1, static_cast<sqlite3_int64>(lsn));
+        SQ_CHECK(sqlite3_step, stmt.get());
+    }
+};
 
 struct PageInfo {
     uint64_t table_id;
@@ -671,455 +1190,56 @@ template <> struct std::formatter<PageInfo> {
     }
 };
 
-class Storage {
-    Config &config;
-    const std::filesystem::path db_home;
+struct Pages : public Table<Pages> {
+    constexpr static std::string_view prefix = "pages";
 
-    class Connection {
-        Config &config;
-        sqlite3 *db = nullptr;
-        std::vector<sqlite3_stmt *> statements;
-
-    public:
-        /* Common configuration parameters for connections */
-        constexpr static std::string_view config_statements[] = {
-          /*
-           * The WAL journaling mode uses a write-ahead log instead of a rollback journal to
-           * implement transactions. This significantly improves performance.
-           */
-          "PRAGMA journal_mode = WAL;",
-
-          /*
-           * Turn Synchronous mode OFF for better performance. We don't care about database
-           * corruption in case of OS crash or power failure.
-           */
-          "PRAGMA synchronous = OFF;",
-
-          /* For temporary store use memory instead of disk. */
-          "PRAGMA temp_store = MEMORY;",
-
-          /* Set busy timeout to 10 seconds. */
-          "PRAGMA busy_timeout = 10000;"};
-
-        using StatementPtr = std::unique_ptr<sqlite3_stmt, std::function<decltype(sqlite3_reset)>>;
-
-        ~Connection() = default;
-        Connection(Config &cfg, const std::filesystem::path &db_path)
-            : config(cfg), db(open_db(cfg, db_path))
-        {
-            configure(Connection::config_statements);
-        }
-
-        StatementPtr
-        db_statement(size_t idx)
-        {
-            return StatementPtr(statements[idx], [this](sqlite3_stmt *s) {
-                /* do not throw from d'tor */
-                return SQL_CALL_CHECK_NO_THROW(db, sqlite3_reset, s);
-            });
-        }
-
-        sqlite3 *
-        db_instance() const
-        {
-            return db;
-        }
-
-        template <typename Container>
-        void
-        configure(const Container &cfg_statements)
-        {
-            for (const auto &stmt : cfg_statements) {
-                SQL_CALL_CHECK(db, sqlite3_exec, db, stmt.data(), nullptr, nullptr, nullptr);
-            }
-        }
-
-        template <typename Container>
-        void
-        prepare_statements(const Container &sql_statements)
-        {
-            statements.clear();
-            for (const auto &stmt : sql_statements) {
-                sqlite3_stmt *prepared_stmt = nullptr;
-                SQL_CALL_CHECK(
-                  db, sqlite3_prepare_v2, db, stmt.data(), -1, &prepared_stmt, nullptr);
-                statements.push_back(prepared_stmt);
-            }
-        }
-
-        void
-        close()
-        {
-            finalize_statements();
-            close_db();
-        }
-
-    private:
-        static sqlite3 *
-        open_db(Config &config, const std::filesystem::path &db_path)
-        {
-            const unsigned flags =
-              /*
-               * The database is opened for reading and writing, and is created if it does not
-               * already exist.
-               */
-              SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE |
-              /*
-               * Use the "multi-thread" threading mode. Cannot share this connection between
-               * threads.
-               */
-              SQLITE_OPEN_NOMUTEX;
-
-            sqlite3 *pdb = nullptr;
-            SQL_CALL_OPEN(sqlite3_open_v2, db_path.c_str(), &pdb, flags, nullptr);
-            LOG_DEBUG("Opened SQLite database: {} ({})", pdb, db_path.c_str());
-
-            return pdb;
-        }
-
-        void
-        finalize_statements()
-        {
-            std::ranges::for_each(
-              statements, [this](sqlite3_stmt *s) { SQL_CALL_CHECK(db, sqlite3_finalize, s); });
-            statements.clear();
-        }
-
-        void
-        close_db()
-        {
-            int ret = sqlite3_close(db);
-            if (ret == SQLITE_OK) {
-                LOG_DEBUG("Closed SQLite database: {}", db);
-            } else {
-                LOG_ERROR("Failed to close SQLite database: {}. Error: {} ({})", db, ret,
-                  sqlite3_errstr(ret));
-            }
-            db = nullptr;
-        }
-    };
-
-    template <typename Traits> class Table {
-    protected:
-        Config &config;
-        std::filesystem::path table_file;
-
-        std::once_flag create_table;
-        std::shared_mutex conn_state; /* protects 'connections' map */
-        std::unordered_map<std::thread::id, std::unique_ptr<Connection>> connections;
-
-    public:
-        std::shared_mutex access; /* readers-writer mutex for table */
-
-        ~Table() = default;
-        Table(Config &cfg, const std::filesystem::path &file) : config(cfg), table_file(file) {}
-
-        Connection &
-        conn()
-        {
-            {
-                std::shared_lock read_lock(conn_state);
-                auto it = connections.find(std::this_thread::get_id());
-                if (it != connections.end())
-                    return *(it->second);
-            }
-
-            {
-                std::unique_lock write_lock(conn_state);
-                auto [it, inserted] = connections.try_emplace(
-                  std::this_thread::get_id(), std::make_unique<Connection>(config, table_file));
-
-                if (!inserted)
-                    LOG_AND_THROW("Connection already exists for this thread");
-
-                Connection &new_conn = *(it->second);
-                new_conn.configure(static_cast<Traits *>(this)->conn_config());
-                create_tables(new_conn);
-                new_conn.prepare_statements(Traits::sql_statements);
-
-                return new_conn;
-            }
-        }
-
-        void
-        close()
-        {
-            std::ranges::for_each(connections, [](auto &kv) { kv.second->close(); });
-            connections.clear();
-        }
-
-    private:
-        void
-        create_tables(Connection &conn)
-        {
-            std::call_once(
-              create_table,
-              [this](sqlite3 *d) {
-                  for (const auto &stmt : Traits::create_statements) {
-                      SQL_CALL_CHECK(d, sqlite3_exec, d, stmt.data(), nullptr, nullptr, nullptr);
-                  }
-                  LOG_DEBUG("SQLite database schema initialized: {}", table_file.c_str());
-              },
-              conn.db_instance());
-        }
+    enum Statement {
+        PUT_PAGE,
+        GET_PAGE_IDS,
+        GET_FULL_PAGE_LSN,
+        GET_PAGE_INFOS,
+        GET_PAGES,
+        DELETE_PAGES,
+        COUNT /* number of statements */
     };
 
     /*
-     * Tables
+     * Our flags start at the 16th bit (0x10000u) to avoid conflicts with WT_PAGE_LOG_PUT_ARGS
+     * flags.
      */
+    static constexpr uint32_t WT_PAGE_LOG_DISCARDED = 0x10000u;
 
-    struct Globals : public Table<Globals> {
-        constexpr static std::string_view prefix = "globals";
-
-        enum Statement { MAKE_NEXT_LSN, GET_LAST_LSN, ADD_TABLE_ID, GET_TABLE_IDS };
-
-        constexpr static std::string_view sql_statements[] = {
-
-          /* MAKE_NEXT_LSN: Increment LSN. */
-          R"(UPDATE globals
-             SET val = val + 1
-             WHERE id = 0
-             RETURNING val;)",
-
-          /* GET_LAST_LSN: Get the last LSN. */
-          R"(SELECT val
-             FROM globals
-             WHERE id = 0;)",
-
-          /* ADD_TABLE_ID: Add a new table ID if it does not already exist. */
-          R"(INSERT OR IGNORE INTO globals (id, val)
-             VALUES (1, ?);)",
-
-          /* GET_TABLE_IDS: Get all known table IDs. */
-          R"(SELECT val
-             FROM globals
-             WHERE id = 1;)"};
-
-        constexpr static std::string_view create_statements[] = {
-          /*
-           * Globals table to store LSN counter and known table IDs.
-           *  - LSN counter id = 0
-           *  - Table IDs id = 1
-           */
-          R"(CREATE TABLE IF NOT EXISTS globals (
-                 id INTEGER CHECK (id = 0 OR id = 1),
-                 val INTEGER NOT NULL,
-             PRIMARY KEY (id, val));)",
-
-          /* Init LSN counter, if the table is empty; do nothing otherwise. */
-          R"(INSERT INTO globals (id, val)
-             SELECT 0, 0
-             WHERE NOT EXISTS (SELECT 1 FROM globals WHERE id = 0);)"};
-
-        ~Globals() = default;
-        Globals(Config &cfg, const std::filesystem::path &home)
-            : Table<Globals>(cfg, home / std::format("{}.db", Globals::prefix))
-        {
-        }
-
-        Globals(const Globals &) = delete;
-        Globals &operator=(const Globals &) = delete;
-
-        auto
-        conn_config() -> std::ranges::view auto
-        {
-            /* No special configuration is required for the 'globals' table. */
-            return std::views::empty<std::string_view>;
-        }
-
-        uint64_t
-        fetch_lsn(Connection &conn, Statement stmt_type)
-        {
-            Connection::StatementPtr stmt = conn.db_statement(stmt_type);
-            SQ_CHECK(sqlite3_step, stmt.get());
-            return sqlite3_column_int64(stmt.get(), 0);
-        }
-
-        uint64_t
-        make_next_lsn(Connection &conn)
-        {
-            return fetch_lsn(conn, Statement::MAKE_NEXT_LSN);
-        }
-
-        uint64_t
-        get_last_lsn(Connection &conn)
-        {
-            return fetch_lsn(conn, Statement::GET_LAST_LSN);
-        }
-
-        void
-        add_table_id(Connection &conn, uint64_t table_id)
-        {
-            Connection::StatementPtr stmt = conn.db_statement(Statement::ADD_TABLE_ID);
-            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 1, static_cast<sqlite3_int64>(table_id));
-            SQ_CHECK(sqlite3_step, stmt.get());
-        }
-
-        std::vector<uint64_t>
-        get_table_ids(Connection &conn)
-        {
-            Connection::StatementPtr stmt = conn.db_statement(Statement::GET_TABLE_IDS);
-            std::vector<uint64_t> table_ids;
-            while (SQ_CHECK(sqlite3_step, stmt.get()) == SQLITE_ROW) {
-                table_ids.push_back(static_cast<uint64_t>(sqlite3_column_int64(stmt.get(), 0)));
-            }
-            return table_ids;
-        }
-    };
-
-    struct Checkpoints : public Table<Checkpoints> {
-        constexpr static std::string_view prefix = "checkpoints";
-
-        enum Statement { PUT_CHECKPOINT, GET_CHECKPOINT, DELETE_CHECKPOINTS };
-
-        constexpr static std::string_view sql_statements[] = {
-          /*
-           * PUT_CHECKPOINT: Insert a new checkpoint.
-           */
-          R"(INSERT INTO checkpoints (lsn, timestamp, checkpoint_metadata)
-             VALUES (?, ?, ?);)",
-
-          /*
-           * GET_CHECKPOINT: Get the latest checkpoint (i.e., checkpoint with the highest lsn) if
-           * query lsn equals to WT_PAGE_LOG_LSN_MAX ( passed as parameter: ?2); otherwise get the
-           * checkpoint with the given lsn.
-           */
-          R"(SELECT lsn, timestamp, checkpoint_metadata
-             FROM checkpoints
-             WHERE (?1 = ?2 OR lsn = ?1)
-             ORDER BY
-                 lsn DESC,
-                 timestamp DESC
-             LIMIT 1;)",
-
-          /*
-           * DELETE_CHECKPOINTS: Delete all checkpoints with lsn greater than the given lsn.
-           */
-          R"(DELETE FROM checkpoints
-             WHERE lsn > ?;)"};
-
-        constexpr static std::string_view create_statements[] = {
-          R"(CREATE TABLE IF NOT EXISTS checkpoints (
-                lsn INTEGER NOT NULL,
-                timestamp INTEGER NOT NULL,
-                checkpoint_metadata BLOB,
-             PRIMARY KEY (lsn, timestamp));)"};
-
-        ~Checkpoints() = default;
-        Checkpoints(Config &cfg, const std::filesystem::path &home)
-            : Table<Checkpoints>(cfg, home / std::format("{}.db", Checkpoints::prefix))
-        {
-        }
-
-        Checkpoints(const Checkpoints &) = delete;
-        Checkpoints &operator=(const Checkpoints &) = delete;
-
-        auto
-        conn_config() -> std::ranges::view auto
-        {
-            /* No special configuration is required for the 'checkpoints' table. */
-            return std::views::empty<std::string_view>;
-        }
-
-        void
-        put(Connection &conn, uint64_t lsn, uint64_t checkpoint_timestamp,
-          const WT_ITEM *checkpoint_metadata)
-        {
-            Connection::StatementPtr stmt = conn.db_statement(Statement::PUT_CHECKPOINT);
-            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 1, lsn);
-            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 2, checkpoint_timestamp);
-            SQ_CHECK(sqlite3_bind_blob, stmt.get(), 3, checkpoint_metadata->data,
-              checkpoint_metadata->size, SQLITE_STATIC);
-            SQ_CHECK(sqlite3_step, stmt.get());
-        }
-
-        int
-        get(Connection &conn, uint64_t &lsn, uint64_t *timestamp, WT_ITEM *checkpoint_metadata)
-        {
-            Connection::StatementPtr stmt = conn.db_statement(Statement::GET_CHECKPOINT);
-            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 1, static_cast<sqlite3_int64>(lsn));
-            SQ_CHECK(
-              sqlite3_bind_int64, stmt.get(), 2, static_cast<sqlite3_int64>(WT_PAGE_LOG_LSN_MAX));
-            int ret = SQ_CHECK(sqlite3_step, stmt.get());
-            if (ret == SQLITE_DONE) {
-                /* No checkpoint found */
-                if (timestamp)
-                    *timestamp = 0;
-
-                if (checkpoint_metadata) {
-                    checkpoint_metadata->data = nullptr;
-                    checkpoint_metadata->size = 0;
-                }
-
-                return WT_NOTFOUND;
-            }
-
-            lsn = sqlite3_column_int64(stmt.get(), 0);
-            if (timestamp)
-                *timestamp = sqlite3_column_int64(stmt.get(), 1);
-
-            if (checkpoint_metadata) {
-                const void *blob = sqlite3_column_blob(stmt.get(), 2);
-                int size = sqlite3_column_bytes(stmt.get(), 2);
-                fill_item(checkpoint_metadata, blob, static_cast<size_t>(size));
-            }
-
-            return 0;
-        }
-
-        void
-        delete_many(Connection &conn, uint64_t lsn)
-        {
-            Connection::StatementPtr stmt = conn.db_statement(Statement::DELETE_CHECKPOINTS);
-            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 1, static_cast<sqlite3_int64>(lsn));
-            SQ_CHECK(sqlite3_step, stmt.get());
-        }
-    };
-
-    struct Pages : public Table<Pages> {
-        constexpr static std::string_view prefix = "pages";
-
-        enum Statement {
-            PUT_PAGE,
-            GET_PAGE_IDS,
-            GET_FULL_PAGE_LSN,
-            GET_PAGE_INFOS,
-            GET_PAGES,
-            DELETE_PAGES
-        };
+    constexpr static auto sql_statements = []() constexpr
+    {
+        std::array<std::string_view, COUNT> stmt{};
 
         /*
-         * Our flags start at the 16th bit (0x10000u) to avoid conflicts with WT_PAGE_LOG_PUT_ARGS
-         * flags.
+         * Insert new pages or replace write failures.
+         *
+         * When writing a new delta page, if a delta page already exists with the same (table_id,
+         * page_id, backlink_lsn), the existing page is treated as a write failure and replaced.
+         *
+         * This uniqueness constraint is enforced by a partial index that applies only to delta
+         * pages. See the CREATE TABLE statement for the 'pages' table.
          */
-        static constexpr uint32_t WT_PAGE_LOG_DISCARDED = 0x10000u;
-
-        constexpr static std::string_view sql_statements[] = {
-          /*
-           * PUT_PAGE: Insert new pages or replace write failures.
-           *
-           * When writing a new delta page, if a delta page already exists with the same (table_id,
-           * page_id, backlink_lsn), the existing page is treated as a write failure and replaced.
-           *
-           * This uniqueness constraint is enforced by a partial index that applies only to delta
-           * pages. See the CREATE TABLE statement for the 'pages' table.
-           */
+        stmt[PUT_PAGE] =
           R"(INSERT OR REPLACE INTO pages (
-                 table_id,
-                 page_id,
-                 lsn,
-                 backlink_lsn,
-                 base_lsn,
-                 flags,
-                 encryption,
-                 timestamp_materialized_us,
-                 page_data)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);)",
+                  table_id,
+                  page_id,
+                  lsn,
+                  backlink_lsn,
+                  base_lsn,
+                  flags,
+                  encryption,
+                  timestamp_materialized_us,
+                  page_data)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);)";
 
-          /*
-           * GET_PAGE_IDS: Get all unique page IDs for a given table that have their latest page
-           * record with LSN <= query LSN and not discarded.
-           */
+        /*
+         * Get all unique page IDs for a given table that have their latest page record with LSN <=
+         * query LSN and not discarded.
+         */
+        stmt[GET_PAGE_IDS] =
           R"(SELECT DISTINCT p1.page_id
              FROM pages AS p1
              WHERE p1.table_id = ?1
@@ -1131,25 +1251,25 @@ class Storage {
                          AND p2.page_id = p1.page_id
                          AND p2.lsn <= ?2
                          AND p2.discarded = 1
-                 );)",
+                 );)";
 
-          /*
-           * GET_FULL_PAGE_LSN: Get the LSN of the first non-discarded full page below the given
-           * LSN.
-           *
-           * The query LSN may belong to a delta page. Therefore, we find the corresponding full
-           * page LSN first. Then we look for the previous full page LSN. Assuming that given query
-           * LSN does not belong to discarded page.
-           *
-           * This is used with full page backlink verification.
-           */
+        /*
+         * Get the LSN of the first non-discarded full page below the given LSN.
+         *
+         * The query LSN may belong to a delta page. Therefore, we find the corresponding full page
+         * LSN first. Then we look for the previous full page LSN. Assuming that given query LSN
+         * does not belong to discarded page.
+         *
+         * This is used with full page backlink verification.
+         */
+        stmt[GET_FULL_PAGE_LSN] =
           R"(WITH full_page AS (
-               SELECT MAX(p0.lsn) AS lsn
-               FROM pages AS p0
-               WHERE p0.table_id = ?1
-                   AND p0.page_id = ?2
-                   AND p0.lsn <= ?3
-                   AND p0.delta = 0
+             SELECT MAX(p0.lsn) AS lsn
+             FROM pages AS p0
+             WHERE p0.table_id = ?1
+                 AND p0.page_id = ?2
+                 AND p0.lsn <= ?3
+                 AND p0.delta = 0
              )
              SELECT MAX(p1.lsn)
              FROM
@@ -1166,81 +1286,82 @@ class Storage {
                          AND p2.page_id = p1.page_id
                          AND p2.lsn < fp.lsn
                          AND p2.discarded = 1
-                 );)",
+                 );)";
 
-          /*
-           * GET_PAGE_INFOS: Retrieve information about entire delta chain
-           * stopping at the first full page. The chain may include discarded page.
-           *
-           * This query uses a window function OVER to assign a group number
-           * to rows based on the 'delta' column. This is more performant
-           * than discovering full page in a separate query as it may only
-           * require a single scan over the data.
-           *
-           * The window function works as follows:
-           *
-           * First, the inner part:
-           *     CASE
-           *         WHEN delta = 0 THEN 1
-           *         ELSE 0
-           *     END
-           *
-           * This expression looks at each row one by one. For delta pages
-           * (where delta = 1), it produces a 0. For full pages (where
-           * delta = 0), it produces a 1.
-           *
-           * So, it's essentially a marker for the rows with full pages.
-           * We consider such rows as terminators.
-           *
-           * Next, the outer part:
-           *     SUM(...) OVER (ORDER BY lsn DESC) as page_group
-           *
-           * This expression takes the markers produced by the inner part
-           * and computes a running total (SUM) of these markers, ordered
-           * by LSN in descending order (from newest to oldest).
-           *
-           * This creates a cumulative count of how many "terminating" rows
-           * (delta = 0) have been seen so far.
-           *
-           * Example:
-           *
-           *   lsn | delta | inner CASE | page_group | explanation
-           *   ----+-------+------------+------------+------------
-           *   10  | 1     | 0          | 0          | Sum of (0)
-           *   9   | 1     | 0          | 0          | Sum of (0, 0)
-           *   8   | 1     | 0          | 0          | Sum of (0, 0, 0)
-           *   7   | 0     | 1          | 1          | Sum of (0, 0, 0, 1)
-           *   6   | 0     | 1          | 2          | Sum of (0, 0, 0, 1, 1)
-           *
-           * The entire chain of pages (lsn 10, 9, 8, 7) is returned, stopping
-           * at the first full page (lsn 7). The next full page (lsn 6) is
-           * not included because page_group becomes 2 and we explicitly check
-           * for that:
-           *     ...
-           *     WHERE page_group = 0
-           *         OR (page_group = 1 AND delta = 0)
-           *
-           * This condition ensures that we get all delta pages in the chain
-           * up to the first full page.
-           */
+        /*
+         * Retrieve information about entire delta chain
+         * stopping at the first full page. The chain may include discarded page.
+         *
+         * This query uses a window function OVER to assign a group number
+         * to rows based on the 'delta' column. This is more performant
+         * than discovering full page in a separate query as it may only
+         * require a single scan over the data.
+         *
+         * The window function works as follows:
+         *
+         * First, the inner part:
+         *     CASE
+         *         WHEN delta = 0 THEN 1
+         *         ELSE 0
+         *     END
+         *
+         * This expression looks at each row one by one. For delta pages
+         * (where delta = 1), it produces a 0. For full pages (where
+         * delta = 0), it produces a 1.
+         *
+         * So, it's essentially a marker for the rows with full pages.
+         * We consider such rows as terminators.
+         *
+         * Next, the outer part:
+         *     SUM(...) OVER (ORDER BY lsn DESC) as page_group
+         *
+         * This expression takes the markers produced by the inner part
+         * and computes a running total (SUM) of these markers, ordered
+         * by LSN in descending order (from newest to oldest).
+         *
+         * This creates a cumulative count of how many "terminating" rows
+         * (delta = 0) have been seen so far.
+         *
+         * Example:
+         *
+         *   lsn | delta | inner CASE | page_group | explanation
+         *   ----+-------+------------+------------+------------
+         *   10  | 1     | 0          | 0          | Sum of (0)
+         *   9   | 1     | 0          | 0          | Sum of (0, 0)
+         *   8   | 1     | 0          | 0          | Sum of (0, 0, 0)
+         *   7   | 0     | 1          | 1          | Sum of (0, 0, 0, 1)
+         *   6   | 0     | 1          | 2          | Sum of (0, 0, 0, 1, 1)
+         *
+         * The entire chain of pages (lsn 10, 9, 8, 7) is returned, stopping
+         * at the first full page (lsn 7). The next full page (lsn 6) is
+         * not included because page_group becomes 2 and we explicitly check
+         * for that:
+         *     ...
+         *     WHERE page_group = 0
+         *         OR (page_group = 1 AND delta = 0)
+         *
+         * This condition ensures that we get all delta pages in the chain
+         * up to the first full page.
+         */
+        stmt[GET_PAGE_INFOS] =
           R"(WITH chained_pages AS (
-               SELECT
-                  table_id,
-                  page_id,
-                  lsn,
-                  backlink_lsn,
-                  base_lsn,
-                  flags,
-                  delta,
-                  SUM(CASE
-                          WHEN delta = 0 THEN 1
-                          ELSE 0
-                      END) OVER (ORDER BY lsn DESC) as page_group
-               FROM pages
-               WHERE table_id = ?
-                   AND page_id = ?
-                   AND lsn <= ?
-                   AND timestamp_materialized_us <= ?
+             SELECT
+                 table_id,
+                 page_id,
+                 lsn,
+                 backlink_lsn,
+                 base_lsn,
+                 flags,
+                 delta,
+                 SUM(CASE
+                         WHEN delta = 0 THEN 1
+                         ELSE 0
+                     END) OVER (ORDER BY lsn DESC) as page_group
+             FROM pages
+             WHERE table_id = ?
+                 AND page_id = ?
+                 AND lsn <= ?
+                 AND timestamp_materialized_us <= ?
              )
              SELECT
                  table_id,
@@ -1252,470 +1373,495 @@ class Storage {
              FROM chained_pages
              WHERE page_group = 0
                  OR (page_group = 1 AND delta = 0)
-             ORDER BY lsn DESC;)",
+             ORDER BY lsn DESC;)";
 
-          /*
-           * GET_PAGES: Simple selection of all pages below the given LSN. Verification of the delta
-           * chain and stopping at the terminating full page is done in code.
-           */
+        /*
+         * Simple selection of all pages below the given LSN. Verification of the delta chain and
+         * stopping at the terminating full page is done in code.
+         */
+        stmt[GET_PAGES] =
           R"(SELECT
-                lsn,
-                backlink_lsn,
-                base_lsn,
-                flags,
-                encryption,
-                page_data
+                  lsn,
+                  backlink_lsn,
+                  base_lsn,
+                  flags,
+                  encryption,
+                  page_data
              FROM pages
              WHERE table_id = ?
                  AND page_id = ?
                  AND lsn <= ?
                  AND timestamp_materialized_us <= ?
-             ORDER BY lsn DESC;)",
+             ORDER BY lsn DESC;)";
 
-          /* DELETE_PAGES: Remove all pages above the given LSN. */
+        /* Remove all pages above the given LSN. */
+        stmt[DELETE_PAGES] =
           R"(DELETE FROM pages
-             WHERE lsn > ?;)"};
+             WHERE lsn > ?;)";
 
-        /* These flags used below in generated columns for 'pages' table. */
-        static_assert(WT_PAGE_LOG_DELTA == 0x2, "WT_PAGE_LOG_DELTA value changed");
-        static_assert(WT_PAGE_LOG_DISCARDED == 0x10000, "WT_PAGE_LOG_DISCARDED value changed");
+        return stmt;
+    }
+    ();
 
-        constexpr static std::string_view create_statements[] = {
-          R"(CREATE TABLE IF NOT EXISTS pages (
-                  table_id INTEGER NOT NULL,
-                  page_id INTEGER NOT NULL,
-                  lsn INTEGER NOT NULL,
-                  backlink_lsn INTEGER NOT NULL,
-                  base_lsn INTEGER NOT NULL,
-                  flags INTEGER NOT NULL,
-                  delta INTEGER AS ((flags & 0x2) != 0) VIRTUAL, -- WT_PAGE_LOG_DELTA
-                  discarded INTEGER AS ((flags & 0x10000) != 0) VIRTUAL, -- WT_PAGE_LOG_DISCARDED
-                  encryption STRING NOT NULL,
-                  timestamp_materialized_us INTEGER NOT NULL,
-                  page_data BLOB,
-               PRIMARY KEY (table_id, page_id, lsn)
-             );)",
+    static_assert(
+      std::ranges::none_of(Pages::sql_statements, [](const auto &s) { return s.empty(); }),
+      "SQL statements must not be empty");
+
+    /* These flags used below in generated columns for 'pages' table. */
+    static_assert(WT_PAGE_LOG_DELTA == 0x2, "WT_PAGE_LOG_DELTA value changed");
+    static_assert(WT_PAGE_LOG_DISCARDED == 0x10000, "WT_PAGE_LOG_DISCARDED value changed");
+
+    constexpr static std::string_view create_statements[] = {
+      R"(CREATE TABLE IF NOT EXISTS pages (
+             table_id INTEGER NOT NULL,
+             page_id INTEGER NOT NULL,
+             lsn INTEGER NOT NULL,
+             backlink_lsn INTEGER NOT NULL,
+             base_lsn INTEGER NOT NULL,
+             flags INTEGER NOT NULL,
+             delta INTEGER AS ((flags & 0x2) != 0) VIRTUAL, -- WT_PAGE_LOG_DELTA
+             discarded INTEGER AS ((flags & 0x10000) != 0) VIRTUAL, -- WT_PAGE_LOG_DISCARDED
+             encryption STRING NOT NULL,
+             timestamp_materialized_us INTEGER NOT NULL,
+             page_data BLOB,
+         PRIMARY KEY (table_id, page_id, lsn));)",
+
+      /*
+       * This index exists for the case in which we have written a page
+       * delta and then need to write it again.
+       *
+       * This generally happens in eviction. We have a base page already written
+       * and we now try to evict it. We finished writing a delta to disk but
+       * then we fail the reconciliation. It is a delta so we cannot explicitly
+       * free the write with the same page id. After a while, we retry the
+       * eviction and this time we writes a delta based on the same base page.
+       * Thus this write will have the same backlink_lsn to the previous write.
+       *
+       * At this stage, there may be no checkpoint running so discarding the
+       * unfinished checkpoint doesn't help in this case. It is also possible
+       * that these two writes will be included in the same checkpoint that is
+       * not discarded.
+       *
+       * To gracefully handle write failures of delta pages we will keep
+       * track of the backlink_lsn within each delta chain. Tracking is done via
+       * a *partial* unique index on (table_id, page_id, backlink_lsn) for
+       * genuine delta pages only: delta=1 AND discarded=0.
+       * (Partial index can include only a subset of rows in the table.)
+       *
+       * The primary key for the table (table_id, page_id, lsn) does not help
+       * because lsn is always increasing, making each record unique.
+       *
+       * Including backlink_lsn in the primary key would not work because
+       * together with always increasing lsn the constraint is always satisfied.
+       *
+       * Hence, we need a separate unique index for delta pages only (excluding
+       * discarded pages, which are a special case).
+       *
+       * Example:
+       *
+       *   table_id | page_id | lsn | backlink_lsn | base_lsn | delta
+       *   ---------+---------+-----+--------------+----------+------
+       *       1    |   100   | 5   |      0       |   0      |   0
+       *       1    |   100   | 6   |      5       |   5      |   1
+       *       1    |   100   | 7   |      6       |   5      |   1
+       *       1    |   100   | 8   |      7       |   5      |   1    <-- write failure
+       *       1    |   100   | 9   |      7       |   5      |   1    <-- new delta page
+       *
+       * Suppose, the page with lsn=8 is a write failure. When a new delta page
+       * is written with (lsn=9, backlink_lsn=7, base_lsn=5), then it will
+       * conflict with the existing page with lsn=8 because they have the same
+       * (table_id, page_id, backlink_lsn). The partial index will ensure
+       * that there is at most one such delta page.
+       *
+       * The new page with lsn=9 will replace the failed page with lsn=8 because
+       * pages are inserted with 'INSERT OR REPLACE INTO pages'.
+       *
+       * See also PUT_PAGE statement.
+       */
+      R"(CREATE UNIQUE INDEX IF NOT EXISTS ux_delta
+         ON pages (table_id, page_id, backlink_lsn)
+         WHERE delta = 1 AND discarded = 0;)",
+    };
+
+    ~Pages() = default;
+    Pages(Config &cfg, std::shared_mutex &store_access, const std::filesystem::path &home,
+      uint64_t table_id)
+        : Table<Pages>(
+            cfg, store_access, home / std::format("{}_{:06}.db", Pages::prefix, table_id))
+    {
+    }
+
+    Pages(const Pages &) = delete;
+    Pages &operator=(const Pages &) = delete;
+
+    auto
+    conn_config() -> std::ranges::view auto
+    {
+        const uint64_t MMAP_SIZE = config.mmap_size_mb * 1_MB;
+        const uint64_t PAGE_SIZE = 16_KB;
+        const uint64_t CACHE_PAGES = (config.cache_size_mb * 1_MB) / PAGE_SIZE;
+
+        const static std::string config_statements[] = {
+          /*
+           * Uses memory mapping instead of read/write calls when the database is < mmap_size in
+           * bytes.
+           */
+          std::format("PRAGMA mmap_size = {};", MMAP_SIZE),
 
           /*
-           * This index exists for the case in which we have written a page
-           * delta and then need to write it again.
-           *
-           * This generally happens in eviction. We have a base page already written
-           * and we now try to evict it. We finished writing a delta to disk but
-           * then we fail the reconciliation. It is a delta so we cannot explicitly
-           * free the write with the same page id. After a while, we retry the
-           * eviction and this time we writes a delta based on the same base page.
-           * Thus this write will have the same backlink_lsn to the previous write.
-           *
-           * At this stage, there may be no checkpoint running so discarding the
-           * unfinished checkpoint doesn't help in this case. It is also possible
-           * that these two writes will be included in the same checkpoint that is
-           * not discarded.
-           *
-           * To gracefully handle write failures of delta pages we will keep
-           * track of the backlink_lsn within each delta chain. Tracking is done via
-           * a *partial* unique index on (table_id, page_id, backlink_lsn) for
-           * genuine delta pages only: delta=1 AND discarded=0.
-           * (Partial index can include only a subset of rows in the table.)
-           *
-           * The primary key for the table (table_id, page_id, lsn) does not help
-           * because lsn is always increasing, making each record unique.
-           *
-           * Including backlink_lsn in the primary key would not work because
-           * together with always increasing lsn the constraint is always satisfied.
-           *
-           * Hence, we need a separate unique index for delta pages only (excluding
-           * discarded pages, which are a special case).
-           *
-           * Example:
-           *
-           *   table_id | page_id | lsn | backlink_lsn | base_lsn | delta
-           *   ---------+---------+-----+--------------+----------+------
-           *       1    |   100   | 5   |      0       |   0      |   0
-           *       1    |   100   | 6   |      5       |   5      |   1
-           *       1    |   100   | 7   |      6       |   5      |   1
-           *       1    |   100   | 8   |      7       |   5      |   1    <-- write failure
-           *       1    |   100   | 9   |      7       |   5      |   1    <-- new delta page
-           *
-           * Suppose, the page with lsn=8 is a write failure. When a new delta page
-           * is written with (lsn=9, backlink_lsn=7, base_lsn=5), then it will
-           * conflict with the existing page with lsn=8 because they have the same
-           * (table_id, page_id, backlink_lsn). The partial index will ensure
-           * that there is at most one such delta page.
-           *
-           * The new page with lsn=9 will replace the failed page with lsn=8 because
-           * pages are inserted with 'INSERT OR REPLACE INTO pages'.
-           *
-           * See also PUT_PAGE statement.
+           * Increase page size to 16KB (default is 4KB). This improves performance for tables with
+           * BLOBs.
            */
-          R"(CREATE UNIQUE INDEX IF NOT EXISTS ux_delta
-             ON pages (table_id, page_id, backlink_lsn)
-             WHERE delta = 1 AND discarded = 0;)",
+          std::format("PRAGMA page_size = {};", PAGE_SIZE),
+
+          /*
+           * Set cache size as configured. Cache size is specified in megabytes. Convert to number
+           * of pages.
+           */
+          std::format("PRAGMA cache_size = {};", CACHE_PAGES)};
+
+        return std::views::all(config_statements);
+    }
+
+    void
+    put(uint64_t table_id, uint64_t page_id, uint64_t lsn, WT_PAGE_LOG_PUT_ARGS *args,
+      const WT_ITEM *buf)
+    {
+        auto acc_w = request(AccessMode::WRITE);
+        Connection &conn = acc_w.conn;
+
+        Connection::StatementPtr stmt = conn.db_statement(Statement::PUT_PAGE);
+        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 1, static_cast<sqlite3_int64>(table_id));
+        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 2, static_cast<sqlite3_int64>(page_id));
+        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 3, static_cast<sqlite3_int64>(lsn));
+        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 4, static_cast<sqlite3_int64>(args->backlink_lsn));
+        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 5, static_cast<sqlite3_int64>(args->base_lsn));
+        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 6, static_cast<sqlite3_int64>(args->flags));
+        SQ_CHECK(sqlite3_bind_text, stmt.get(), 7, args->encryption.dek,
+          strlen(args->encryption.dek), SQLITE_STATIC);
+        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 8,
+          static_cast<sqlite3_int64>(now_us() + (config.materialization_delay_ms * 1ms / 1us)));
+        SQ_CHECK(sqlite3_bind_blob, stmt.get(), 9, buf->data, buf->size, SQLITE_STATIC);
+        SQ_CHECK(sqlite3_step, stmt.get());
+        acc_w.release();
+
+        if (config.verify) {
+            auto acc_r = request(AccessMode::READ);
+            verify_chain(acc_r.conn, table_id, page_id, lsn);
+        }
+    }
+
+    int
+    get(uint64_t table_id, uint64_t page_id, WT_PAGE_LOG_GET_ARGS *args, uint32_t *flags,
+      WT_ITEM *results_array, uint32_t *results_count)
+    {
+        auto acc = request(AccessMode::READ);
+        Connection &conn = acc.conn;
+
+        Connection::StatementPtr stmt = conn.db_statement(Statement::GET_PAGES);
+        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 1, static_cast<sqlite3_int64>(table_id));
+        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 2, static_cast<sqlite3_int64>(page_id));
+        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 3, static_cast<sqlite3_int64>(args->lsn));
+        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 4, static_cast<sqlite3_int64>(now_us()));
+
+        auto make_page_info = [](uint64_t table_id, uint64_t page_id, sqlite3_stmt *stmt) {
+            PageInfo page{.table_id = table_id,
+              .page_id = page_id,
+              .lsn = static_cast<uint64_t>(sqlite3_column_int64(stmt, 0)),
+              .backlink_lsn = static_cast<uint64_t>(sqlite3_column_int64(stmt, 1)),
+              .base_lsn = static_cast<uint64_t>(sqlite3_column_int64(stmt, 2)),
+              .flags = static_cast<uint32_t>(sqlite3_column_int64(stmt, 3)),
+              .encryption = WT_PAGE_LOG_ENCRYPTION{}};
+
+            const char *enc = reinterpret_cast<const char *>(sqlite3_column_text(stmt, 4));
+            strncpy(page.encryption.dek, enc ? enc : "", sizeof(page.encryption.dek));
+
+            return std::move(page);
         };
 
-        ~Pages() = default;
-        Pages(Config &cfg, const std::filesystem::path &home, uint64_t table_id)
-            : Table<Pages>(cfg, home / std::format("{}_{:06}.db", Pages::prefix, table_id))
-        {
-        }
-
-        Pages(const Pages &) = delete;
-        Pages &operator=(const Pages &) = delete;
-
-        auto
-        conn_config() -> std::ranges::view auto
-        {
-            const uint64_t MMAP_SIZE = config.mmap_size_mb * 1_MB;
-            const uint64_t PAGE_SIZE = 16_KB;
-            const uint64_t CACHE_PAGES = (config.cache_size_mb * 1_MB) / PAGE_SIZE;
-
-            const static std::string config_statements[] = {
-              /*
-               * Uses memory mapping instead of read/write calls when the database is < mmap_size in
-               * bytes.
-               */
-              std::format("PRAGMA mmap_size = {};", MMAP_SIZE),
-
-              /*
-               * Increase page size to 16KB (default is 4KB). This improves performance for tables
-               * with BLOBs.
-               */
-              std::format("PRAGMA page_size = {};", PAGE_SIZE),
-
-              /*
-               * Set cache size as configured. Cache size is specified in megabytes. Convert to
-               * number of pages.
-               */
-              std::format("PRAGMA cache_size = {};", CACHE_PAGES)};
-
-            return std::views::all(config_statements);
-        }
-
-        void
-        put(Connection &conn, uint64_t table_id, uint64_t page_id, uint64_t lsn,
-          WT_PAGE_LOG_PUT_ARGS *args, const WT_ITEM *buf)
-        {
-            Connection::StatementPtr stmt = conn.db_statement(Statement::PUT_PAGE);
-            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 1, static_cast<sqlite3_int64>(table_id));
-            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 2, static_cast<sqlite3_int64>(page_id));
-            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 3, static_cast<sqlite3_int64>(lsn));
-            SQ_CHECK(
-              sqlite3_bind_int64, stmt.get(), 4, static_cast<sqlite3_int64>(args->backlink_lsn));
-            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 5, static_cast<sqlite3_int64>(args->base_lsn));
-            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 6, static_cast<sqlite3_int64>(args->flags));
-            SQ_CHECK(sqlite3_bind_text, stmt.get(), 7, args->encryption.dek,
-              strlen(args->encryption.dek), SQLITE_STATIC);
-            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 8,
-              static_cast<sqlite3_int64>(now_us() + (config.materialization_delay_ms * 1ms / 1us)));
-            SQ_CHECK(sqlite3_bind_blob, stmt.get(), 9, buf->data, buf->size, SQLITE_STATIC);
-            SQ_CHECK(sqlite3_step, stmt.get());
-
-            if (config.verify) {
-                verify_chain(conn, table_id, page_id, lsn);
-            }
-        }
-
-        int
-        get_infos(Connection &conn, uint64_t table_id, uint64_t page_id, uint64_t lsn,
-          std::vector<PageInfo> &pages)
-        {
-            Connection::StatementPtr stmt = conn.db_statement(Statement::GET_PAGE_INFOS);
-            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 1, static_cast<sqlite3_int64>(table_id));
-            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 2, static_cast<sqlite3_int64>(page_id));
-            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 3, static_cast<sqlite3_int64>(lsn));
-            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 4, static_cast<sqlite3_int64>(now_us()));
-
-            pages.clear();
-            while (SQ_CHECK(sqlite3_step, stmt.get()) == SQLITE_ROW) {
-                pages.emplace_back(
-                  PageInfo{.table_id = static_cast<uint64_t>(sqlite3_column_int64(stmt.get(), 0)),
-                    .page_id = static_cast<uint64_t>(sqlite3_column_int64(stmt.get(), 1)),
-                    .lsn = static_cast<uint64_t>(sqlite3_column_int64(stmt.get(), 2)),
-                    .backlink_lsn = static_cast<uint64_t>(sqlite3_column_int64(stmt.get(), 3)),
-                    .base_lsn = static_cast<uint64_t>(sqlite3_column_int64(stmt.get(), 4)),
-                    .flags = static_cast<uint32_t>(sqlite3_column_int64(stmt.get(), 5)),
-                    .encryption = WT_PAGE_LOG_ENCRYPTION{}});
-            }
-
-            return 0;
-        }
-
-        int
-        get(Connection &conn, uint64_t table_id, uint64_t page_id, WT_PAGE_LOG_GET_ARGS *args,
-          uint32_t *flags, WT_ITEM *results_array, uint32_t *results_count)
-        {
-            Connection::StatementPtr stmt = conn.db_statement(Statement::GET_PAGES);
-            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 1, static_cast<sqlite3_int64>(table_id));
-            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 2, static_cast<sqlite3_int64>(page_id));
-            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 3, static_cast<sqlite3_int64>(args->lsn));
-            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 4, static_cast<sqlite3_int64>(now_us()));
-
-            auto make_page_info = [](uint64_t table_id, uint64_t page_id, sqlite3_stmt *stmt) {
-                PageInfo page{.table_id = table_id,
-                  .page_id = page_id,
-                  .lsn = static_cast<uint64_t>(sqlite3_column_int64(stmt, 0)),
-                  .backlink_lsn = static_cast<uint64_t>(sqlite3_column_int64(stmt, 1)),
-                  .base_lsn = static_cast<uint64_t>(sqlite3_column_int64(stmt, 2)),
-                  .flags = static_cast<uint32_t>(sqlite3_column_int64(stmt, 3)),
-                  .encryption = WT_PAGE_LOG_ENCRYPTION{}};
-
-                const char *enc = reinterpret_cast<const char *>(sqlite3_column_text(stmt, 4));
-                strncpy(page.encryption.dek, enc ? enc : "", sizeof(page.encryption.dek));
-
-                return std::move(page);
-            };
-
-            /*
-             * Note: Results are ordered by lsn DESC, so the first row is the most recent.
-             * In case of a delta chain, deltas (D) appear first, followed by the full page (B):
-             *     D2, D1, B
-             * We will reverse the order before returning to the caller:
-             *     B, D1, D2
-             */
-            uint32_t count = 0;
-            int ret = 0;
-            std::vector<PageInfo> pages;
-
-            while (
-              (ret = SQ_CHECK(sqlite3_step, stmt.get())) == SQLITE_ROW && count < *results_count) {
-                pages.push_back(make_page_info(table_id, page_id, stmt.get()));
-                PageInfo &page = pages.back();
-
-                if (page.flags & WT_PAGE_LOG_DISCARDED) {
-                    LOG_AND_THROW("Got discarded page: {}", page);
-                }
-
-                const void *blob = sqlite3_column_blob(stmt.get(), 5);
-                int size = sqlite3_column_bytes(stmt.get(), 5);
-                fill_item(&results_array[count], blob, static_cast<size_t>(size));
-
-                /* Continue to next row */
-                count++;
-
-                if (!(page.flags & WT_PAGE_LOG_DELTA)) {
-                    /* Stop if this is a full page */
-                    ret = SQLITE_DONE;
-                    break;
-                }
-            }
-            /* By now ret is either SQLITE_DONE or SQLITE_ROW. */
-
-            /* SQLITE_ROW means there are more rows available than space in results_array. */
-            if (ret == SQLITE_ROW) {
-                LOG_AND_THROW("Insufficient space in results_array: {}", *results_count);
-            }
-
-            /* Verify full page, if configured */
-            const uint64_t prev_full_lsn =
-              config.verify ? get_prev_full_page_lsn(conn, table_id, page_id, args->lsn) : 0;
-            /* Always verify the delta chain when retrieving pages, even if config.verify=false. */
-            verify_chain(pages, prev_full_lsn);
-
-            /* Fill args from the first found page. (It will be the last in returned array.) */
-            uint64_t save_lsn = args->lsn;
-            memset(args, 0, sizeof(*args));
-            args->lsn = save_lsn; /* Preserve the requested LSN */
-            if (!pages.empty()) {
-                const PageInfo &page = pages.front();
-                args->backlink_lsn = page.backlink_lsn;
-                args->base_lsn = page.base_lsn;
-                args->encryption = page.encryption;
-                assert(flags != nullptr);
-                *flags = page.flags;
-            }
-
-            /* Reverse the results array to have the full page first, followed by deltas. */
-            std::reverse(results_array, results_array + count);
-            *results_count = count;
-
-            return 0;
-        }
-
-        /* Invalid LSN means "no check required". */
-        void
-        verify_chain(const std::vector<PageInfo> &pages, uint64_t prev_full_lsn = INVALID_LSN)
-        {
-            PageInfo prev{};
-            PageInfo full{};
-            PageInfo discarded{};
-
-            auto verify_full = [&](const PageInfo &page) {
-                if (full.lsn != 0) {
-                    LOG_AND_THROW("Multiple full pages in chain: {}, {}", full, page);
-                }
-
-                if (page.base_lsn != 0) {
-                    LOG_AND_THROW("Full page base_lsn must be 0: {}", page);
-                }
-
-                if (prev_full_lsn != INVALID_LSN && page.backlink_lsn != prev_full_lsn) {
-                    LOG_AND_THROW(
-                      "Full page backlink_lsn mismatch: {}, expected: {}", page, prev_full_lsn);
-                }
-
-                if (page.flags & WT_PAGE_LOG_DISCARDED) {
-                    LOG_AND_THROW("Full page cannot be discarded: {}", page);
-                }
-
-                if (discarded.lsn != 0) {
-                    LOG_AND_THROW(
-                      "Discarded page cannot be followed by another page: {}, {}", discarded, page);
-                }
-
-                full = page;
-            };
-
-            auto verify_delta = [&](const PageInfo &page) {
-                assert(prev.lsn != 0); /* Cannot be the first page in the chain */
-
-                if (full.lsn == 0) {
-                    LOG_AND_THROW("Delta page without full page: {}", page);
-                }
-
-                if (full.lsn != page.base_lsn) {
-                    LOG_AND_THROW("Delta page base_lsn mismatch: {}, full page: {}", page, full);
-                }
-
-                /* Discarded pages can backlink to any page that we've seen in the chain. */
-                if (!(page.flags & WT_PAGE_LOG_DISCARDED) && page.backlink_lsn != prev.lsn) {
-                    LOG_AND_THROW(
-                      "Delta chain backlink_lsn mismatch: {}, previous page: {}", page, prev);
-                }
-
-                if (page.flags & WT_PAGE_LOG_DISCARDED) {
-                    if (discarded.lsn != 0) {
-                        LOG_AND_THROW("Multiple discarded pages in chain: {}, {}", discarded, page);
-                    }
-                    discarded = page;
-                } else if (discarded.lsn != 0) {
-                    LOG_AND_THROW(
-                      "Discarded page cannot be followed by another page: {}, {}", discarded, page);
-                }
-            };
-
-            auto verify_page = [&](const PageInfo &page) {
-                if (page.flags & WT_PAGE_LOG_DELTA)
-                    verify_delta(page);
-                else
-                    verify_full(page);
-                prev = page;
-            };
-
-            /* Iterate in reverse order to validate the chain from full page. */
-            std::for_each(pages.rbegin(), pages.rend(), verify_page);
-
-            /* Verify discarded page separately because it can backlink to any page in the chain. */
-            if (discarded.lsn != 0) {
-                auto found_it = std::ranges::find_if(pages,
-                  [&discarded](const PageInfo &p) { return p.lsn == discarded.backlink_lsn; });
-                if (found_it == pages.end()) {
-                    LOG_AND_THROW("Discarded page backlink_lsn not found in chain: {}", discarded);
-                }
-            }
-        }
-
         /*
-         * Verify the entire page chain for consistency.
-         *
-         * The pages are expected to be ordered by lsn DESC (newest first).
-         * The chain may include a single discarded page as the first page,
-         * zero or more deltas, and one terminating full page.
-         * Discarded pages can backlink to any page in the chain.
-         *
-         * Example of a valid chain:
-         *     Discarded (lsn=10, backlink_lsn=8, base_lsn=7, flags=DISCARDED|DELTA)
-         *     Delta     (lsn=9,  backlink_lsn=8, base_lsn=7, flags=DELTA)
-         *     Delta     (lsn=8,  backlink_lsn=7, base_lsn=7, flags=DELTA)
-         *     Full      (lsn=7,  backlink_lsn=0, base_lsn=0, flags=0)
-         *
-         * Throws on error.
+         * Note: Results are ordered by lsn DESC, so the first row is the most recent.
+         * In case of a delta chain, deltas (D) appear first, followed by the full page (B):
+         *     D2, D1, B
+         * We will reverse the order before returning to the caller:
+         *     B, D1, D2
          */
-        void
-        verify_chain(Connection &conn, uint64_t table_id, uint64_t page_id, uint64_t lsn)
-        {
-            std::vector<PageInfo> pages;
-            get_infos(conn, table_id, page_id, lsn, pages);
-            if (pages.size() == 0) {
+        uint32_t count = 0;
+        int ret = 0;
+        std::vector<PageInfo> pages;
+
+        while ((ret = SQ_CHECK(sqlite3_step, stmt.get())) == SQLITE_ROW && count < *results_count) {
+            pages.push_back(make_page_info(table_id, page_id, stmt.get()));
+            PageInfo &page = pages.back();
+
+            if (page.flags & WT_PAGE_LOG_DISCARDED) {
+                LOG_AND_THROW("Got discarded page: {}", page);
+            }
+
+            const void *blob = sqlite3_column_blob(stmt.get(), 5);
+            int size = sqlite3_column_bytes(stmt.get(), 5);
+            fill_item(&results_array[count], blob, static_cast<size_t>(size));
+
+            /* Continue to next row */
+            count++;
+
+            if (!(page.flags & WT_PAGE_LOG_DELTA)) {
+                /* Stop if this is a full page */
+                ret = SQLITE_DONE;
+                break;
+            }
+        }
+        /* By now ret is either SQLITE_DONE or SQLITE_ROW. */
+
+        /* SQLITE_ROW means there are more rows available than space in results_array. */
+        if (ret == SQLITE_ROW) {
+            LOG_AND_THROW("Insufficient space in results_array: {}", *results_count);
+        }
+
+        /* Verify full page, if configured */
+        const uint64_t prev_full_lsn =
+          config.verify ? get_prev_full_page_lsn(acc.conn, table_id, page_id, args->lsn) : 0;
+        /* Always verify the delta chain when retrieving pages, even if config.verify=false. */
+        verify_chain(pages, prev_full_lsn);
+
+        /* Fill args from the first found page. (It will be the last in returned array.) */
+        uint64_t save_lsn = args->lsn;
+        memset(args, 0, sizeof(*args));
+        args->lsn = save_lsn; /* Preserve the requested LSN */
+        if (!pages.empty()) {
+            const PageInfo &page = pages.front();
+            args->backlink_lsn = page.backlink_lsn;
+            args->base_lsn = page.base_lsn;
+            args->encryption = page.encryption;
+            assert(flags != nullptr);
+            *flags = page.flags;
+        }
+
+        /* Reverse the results array to have the full page first, followed by deltas. */
+        std::reverse(results_array, results_array + count);
+        *results_count = count;
+
+        return 0;
+    }
+
+    int
+    get_ids(uint64_t checkpoint_lsn, uint64_t table_id, WT_ITEM *page_ids, size_t *page_count)
+    {
+        auto acc = request(AccessMode::READ);
+        Connection &conn = acc.conn;
+
+        Connection::StatementPtr stmt = conn.db_statement(Statement::GET_PAGE_IDS);
+        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 1, static_cast<sqlite3_int64>(table_id));
+        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 2, static_cast<sqlite3_int64>(checkpoint_lsn));
+
+        std::vector<uint64_t> ids;
+        while (SQ_CHECK(sqlite3_step, stmt.get()) == SQLITE_ROW) {
+            ids.push_back(sqlite3_column_int64(stmt.get(), 0));
+        }
+        LOG_DEBUG("Found {} page IDs for table_id={} at checkpoint_lsn={}", ids.size(), table_id,
+          checkpoint_lsn);
+        LOG_DIAG("Page IDs: {}", join(ids, ", "));
+
+        *page_count = ids.size();
+        if (ids.size() > 0) {
+            fill_item(page_ids, ids.data(), ids.size() * sizeof(uint64_t));
+        }
+
+        return 0;
+    }
+
+    void
+    discard(uint64_t table_id, uint64_t page_id, uint64_t lsn, WT_PAGE_LOG_DISCARD_ARGS *args)
+    {
+        if (args->flags != 0)
+            LOG_AND_THROW("Non-zero flags: {:#x}", args->flags);
+
+        WT_PAGE_LOG_PUT_ARGS put_args{};
+        put_args.backlink_lsn = args->backlink_lsn;
+        put_args.base_lsn = args->base_lsn;
+        /* Discarded pages are deltas */
+        put_args.flags = WT_PAGE_LOG_DELTA | WT_PAGE_LOG_DISCARDED;
+
+        WT_ITEM dummy_page{};
+        put(table_id, page_id, lsn, &put_args, &dummy_page);
+        args->lsn = put_args.lsn;
+
+        LOG_DEBUG("Discarded page_id={} at lsn={}, backlink_lsn={}, base_lsn={}; discarded_lsn={}",
+          page_id, lsn, args->backlink_lsn, args->base_lsn, args->lsn);
+    }
+
+    void
+    delete_many(uint64_t lsn, AccessMode mode = AccessMode::WRITE)
+    {
+        auto acc = request(mode);
+        Connection &conn = acc.conn;
+
+        LOG_DEBUG("Deleting pages with lsn > {}", lsn);
+        Connection::StatementPtr stmt = conn.db_statement(Statement::DELETE_PAGES);
+        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 1, static_cast<sqlite3_int64>(lsn));
+        SQ_CHECK(sqlite3_step, stmt.get());
+    }
+
+private:
+    uint64_t
+    get_prev_full_page_lsn(Connection &conn, uint64_t table_id, uint64_t page_id, uint64_t lsn)
+    {
+        Connection::StatementPtr stmt = conn.db_statement(Statement::GET_FULL_PAGE_LSN);
+        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 1, static_cast<sqlite3_int64>(table_id));
+        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 2, static_cast<sqlite3_int64>(page_id));
+        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 3, static_cast<sqlite3_int64>(lsn));
+
+        int ret = SQ_CHECK(sqlite3_step, stmt.get());
+        if (ret == SQLITE_DONE) {
+            return 0; /* No previous full page found */
+        }
+
+        return static_cast<uint64_t>(sqlite3_column_int64(stmt.get(), 0));
+    }
+
+    /* Invalid LSN means "no check required". */
+    void
+    verify_chain(const std::vector<PageInfo> &pages, uint64_t prev_full_lsn = INVALID_LSN)
+    {
+        PageInfo prev{};
+        PageInfo full{};
+        PageInfo discarded{};
+
+        auto verify_full = [&](const PageInfo &page) {
+            if (full.lsn != 0) {
+                LOG_AND_THROW("Multiple full pages in chain: {}, {}", full, page);
+            }
+
+            if (page.base_lsn != 0) {
+                LOG_AND_THROW("Full page base_lsn must be 0: {}", page);
+            }
+
+            if (prev_full_lsn != INVALID_LSN && page.backlink_lsn != prev_full_lsn) {
                 LOG_AND_THROW(
-                  "No pages found for table_id={}, page_id={} at lsn<={}", table_id, page_id, lsn);
+                  "Full page backlink_lsn mismatch: {}, expected: {}", page, prev_full_lsn);
             }
 
-            const uint64_t prev_full_lsn = get_prev_full_page_lsn(conn, table_id, page_id, lsn);
-
-            verify_chain(pages, prev_full_lsn);
-        }
-
-        int
-        get_ids(Connection &conn, uint64_t checkpoint_lsn, uint64_t table_id, WT_ITEM *page_ids,
-          size_t *page_count)
-        {
-            Connection::StatementPtr stmt = conn.db_statement(Statement::GET_PAGE_IDS);
-            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 1, static_cast<sqlite3_int64>(table_id));
-            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 2, static_cast<sqlite3_int64>(checkpoint_lsn));
-
-            std::vector<uint64_t> ids;
-            while (SQ_CHECK(sqlite3_step, stmt.get()) == SQLITE_ROW) {
-                ids.push_back(sqlite3_column_int64(stmt.get(), 0));
-            }
-            LOG_DEBUG("Found {} page IDs for table_id={} at checkpoint_lsn={}", ids.size(),
-              table_id, checkpoint_lsn);
-            LOG_DIAG("Page IDs: {}", join(ids, ", "));
-
-            *page_count = ids.size();
-            if (ids.size() > 0) {
-                fill_item(page_ids, ids.data(), ids.size() * sizeof(uint64_t));
+            if (page.flags & WT_PAGE_LOG_DISCARDED) {
+                LOG_AND_THROW("Full page cannot be discarded: {}", page);
             }
 
-            return 0;
-        }
-
-        uint64_t
-        get_prev_full_page_lsn(Connection &conn, uint64_t table_id, uint64_t page_id, uint64_t lsn)
-        {
-            Connection::StatementPtr stmt = conn.db_statement(Statement::GET_FULL_PAGE_LSN);
-            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 1, static_cast<sqlite3_int64>(table_id));
-            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 2, static_cast<sqlite3_int64>(page_id));
-            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 3, static_cast<sqlite3_int64>(lsn));
-
-            int ret = SQ_CHECK(sqlite3_step, stmt.get());
-            if (ret == SQLITE_DONE) {
-                return 0; /* No previous full page found */
+            if (discarded.lsn != 0) {
+                LOG_AND_THROW(
+                  "Discarded page cannot be followed by another page: {}, {}", discarded, page);
             }
 
-            return static_cast<uint64_t>(sqlite3_column_int64(stmt.get(), 0));
+            full = page;
+        };
+
+        auto verify_delta = [&](const PageInfo &page) {
+            assert(prev.lsn != 0); /* Cannot be the first page in the chain */
+
+            if (full.lsn == 0) {
+                LOG_AND_THROW("Delta page without full page: {}", page);
+            }
+
+            if (full.lsn != page.base_lsn) {
+                LOG_AND_THROW("Delta page base_lsn mismatch: {}, full page: {}", page, full);
+            }
+
+            /* Discarded pages can backlink to any page that we've seen in the chain. */
+            if (!(page.flags & WT_PAGE_LOG_DISCARDED) && page.backlink_lsn != prev.lsn) {
+                LOG_AND_THROW(
+                  "Delta chain backlink_lsn mismatch: {}, previous page: {}", page, prev);
+            }
+
+            if (page.flags & WT_PAGE_LOG_DISCARDED) {
+                if (discarded.lsn != 0) {
+                    LOG_AND_THROW("Multiple discarded pages in chain: {}, {}", discarded, page);
+                }
+                discarded = page;
+            } else if (discarded.lsn != 0) {
+                LOG_AND_THROW(
+                  "Discarded page cannot be followed by another page: {}, {}", discarded, page);
+            }
+        };
+
+        auto verify_page = [&](const PageInfo &page) {
+            if (page.flags & WT_PAGE_LOG_DELTA)
+                verify_delta(page);
+            else
+                verify_full(page);
+            prev = page;
+        };
+
+        /* Iterate in reverse order to validate the chain from full page. */
+        std::for_each(pages.rbegin(), pages.rend(), verify_page);
+
+        /* Verify discarded page separately because it can backlink to any page in the chain. */
+        if (discarded.lsn != 0) {
+            auto found_it = std::ranges::find_if(
+              pages, [&discarded](const PageInfo &p) { return p.lsn == discarded.backlink_lsn; });
+            if (found_it == pages.end()) {
+                LOG_AND_THROW("Discarded page backlink_lsn not found in chain: {}", discarded);
+            }
+        }
+    }
+
+    int
+    get_infos(Connection &conn, uint64_t table_id, uint64_t page_id, uint64_t lsn,
+      std::vector<PageInfo> &pages)
+    {
+        Connection::StatementPtr stmt = conn.db_statement(Statement::GET_PAGE_INFOS);
+        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 1, static_cast<sqlite3_int64>(table_id));
+        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 2, static_cast<sqlite3_int64>(page_id));
+        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 3, static_cast<sqlite3_int64>(lsn));
+        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 4, static_cast<sqlite3_int64>(now_us()));
+
+        pages.clear();
+        while (SQ_CHECK(sqlite3_step, stmt.get()) == SQLITE_ROW) {
+            pages.emplace_back(
+              PageInfo{.table_id = static_cast<uint64_t>(sqlite3_column_int64(stmt.get(), 0)),
+                .page_id = static_cast<uint64_t>(sqlite3_column_int64(stmt.get(), 1)),
+                .lsn = static_cast<uint64_t>(sqlite3_column_int64(stmt.get(), 2)),
+                .backlink_lsn = static_cast<uint64_t>(sqlite3_column_int64(stmt.get(), 3)),
+                .base_lsn = static_cast<uint64_t>(sqlite3_column_int64(stmt.get(), 4)),
+                .flags = static_cast<uint32_t>(sqlite3_column_int64(stmt.get(), 5)),
+                .encryption = WT_PAGE_LOG_ENCRYPTION{}});
         }
 
-        void
-        discard(Connection &conn, uint64_t table_id, uint64_t page_id, uint64_t lsn,
-          WT_PAGE_LOG_DISCARD_ARGS *args)
-        {
-            if (args->flags != 0)
-                LOG_AND_THROW("Non-zero flags: {:#x}", args->flags);
+        return 0;
+    }
 
-            WT_PAGE_LOG_PUT_ARGS put_args{};
-            put_args.backlink_lsn = args->backlink_lsn;
-            put_args.base_lsn = args->base_lsn;
-            /* Discarded pages are deltas */
-            put_args.flags = WT_PAGE_LOG_DELTA | WT_PAGE_LOG_DISCARDED;
-
-            WT_ITEM dummy_page{};
-            put(conn, table_id, page_id, lsn, &put_args, &dummy_page);
-            args->lsn = put_args.lsn;
-
-            LOG_DEBUG(
-              "Discarded page_id={} at lsn={}, backlink_lsn={}, base_lsn={}; discarded_lsn={}",
-              page_id, lsn, args->backlink_lsn, args->base_lsn, args->lsn);
+    /*
+     * Verify the entire page chain for consistency.
+     *
+     * The pages are expected to be ordered by lsn DESC (newest first).
+     * The chain may include a single discarded page as the first page,
+     * zero or more deltas, and one terminating full page.
+     * Discarded pages can backlink to any page in the chain.
+     *
+     * Example of a valid chain:
+     *     Discarded (lsn=10, backlink_lsn=8, base_lsn=7, flags=DISCARDED|DELTA)
+     *     Delta     (lsn=9,  backlink_lsn=8, base_lsn=7, flags=DELTA)
+     *     Delta     (lsn=8,  backlink_lsn=7, base_lsn=7, flags=DELTA)
+     *     Full      (lsn=7,  backlink_lsn=0, base_lsn=0, flags=0)
+     *
+     * Throws on error.
+     */
+    void
+    verify_chain(Connection &conn, uint64_t table_id, uint64_t page_id, uint64_t lsn)
+    {
+        std::vector<PageInfo> pages;
+        get_infos(conn, table_id, page_id, lsn, pages);
+        if (pages.size() == 0) {
+            LOG_AND_THROW(
+              "No pages found for table_id={}, page_id={} at lsn<={}", table_id, page_id, lsn);
         }
 
-        void
-        delete_many(Connection &conn, uint64_t lsn)
-        {
-            LOG_DEBUG("Deleting pages with lsn > {}", lsn);
-            Connection::StatementPtr stmt = conn.db_statement(Statement::DELETE_PAGES);
-            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 1, static_cast<sqlite3_int64>(lsn));
-            SQ_CHECK(sqlite3_step, stmt.get());
-        }
-    };
+        const uint64_t prev_full_lsn = get_prev_full_page_lsn(conn, table_id, page_id, lsn);
+
+        verify_chain(pages, prev_full_lsn);
+    }
+};
+
+class Storage {
+    Config &config;
+    const std::filesystem::path db_home;
 
     Globals globals;
     Checkpoints checkpoints;
@@ -1733,7 +1879,8 @@ class Storage {
 public:
     ~Storage() = default;
     Storage(Config &cfg, const std::filesystem::path &dbp)
-        : config(cfg), db_home(dbp), globals(cfg, db_home), checkpoints(cfg, db_home)
+        : config(cfg), db_home(dbp), globals(cfg, store_access, db_home),
+          checkpoints(cfg, store_access, db_home)
     {
     }
 
@@ -1741,73 +1888,25 @@ public:
     Storage &operator=(const Storage &) = delete;
 
 private:
-    enum AccessMode { READ, WRITE };
-
-    template <typename TableType, AccessMode Mode> class Access {
-        Config &config;
-        std::shared_lock<std::shared_mutex> store_lock;
-        std::conditional_t<Mode == AccessMode::READ, std::shared_lock<std::shared_mutex>,
-          std::unique_lock<std::shared_mutex>>
-          table_lock;
-
-    public:
-        TableType &table;
-        Connection &conn;
-
-        ~Access() = default;
-
-        Access(Config &c, std::shared_mutex &store_access, TableType &tbl)
-            : config(c), store_lock(store_access), table_lock(tbl.access), table(tbl),
-              conn(table.conn())
-        {
-        }
-
-        Access(const Access &) = delete;
-        Access &operator=(const Access &) = delete;
-
-        void
-        release()
-        {
-            table_lock.unlock();
-            store_lock.unlock();
-        }
-    };
-
     Pages &
-    fetch_pages_table(uint64_t table_id)
+    get_or_open_table(uint64_t table_id)
     {
         std::unique_lock write_lock(pages_access);
-        auto [it, inserted] =
-          pages.try_emplace(table_id, std::make_unique<Pages>(config, db_home, table_id));
+        auto [it, inserted] = pages.try_emplace(
+          table_id, std::make_unique<Pages>(config, store_access, db_home, table_id));
         return *(it->second);
     }
 
-    template <typename TableType>
-    TableType &
-    get_table(uint64_t id = 0)
+    Pages &
+    get_table(uint64_t table_id)
     {
-        if constexpr (std::is_same_v<TableType, Globals>) {
-            return globals;
-        } else if constexpr (std::is_same_v<TableType, Checkpoints>) {
-            return checkpoints;
-        } else if constexpr (std::is_same_v<TableType, Pages>) {
-            std::shared_lock read_lock(pages_access);
-            auto it = pages.find(id);
-            if (it == pages.end()) {
-                LOG_AND_THROW("Pages table not found for table ID {}", id);
-            }
-            return *(it->second);
-        } else {
-            static_assert(std::false_type::value, "Unknown category type in get_table");
+        std::shared_lock read_lock(pages_access);
+        auto it = pages.find(table_id);
+        if (it == pages.end()) {
+            LOG_AND_THROW("Pages table not found for table ID {}", table_id);
         }
-    }
 
-    template <typename TableType, AccessMode Mode>
-    Access<TableType, Mode>
-    request(uint64_t id = 0)
-    {
-        TableType &table = get_table<TableType>(id);
-        return Access<TableType, Mode>{config, store_access, table};
+        return *(it->second);
     }
 
 public:
@@ -1849,71 +1948,52 @@ public:
     uint64_t
     make_next_lsn()
     {
-        auto acc = request<Globals, AccessMode::WRITE>();
-        const uint64_t lsn = acc.table.make_next_lsn(acc.conn);
-
-        return lsn;
+        return globals.make_next_lsn();
     }
 
     uint64_t
     get_last_lsn()
     {
-        auto acc = request<Globals, AccessMode::READ>();
-        const uint64_t lsn = acc.table.get_last_lsn(acc.conn);
-
-        return lsn;
+        return globals.get_last_lsn();
     }
 
     void
     add_table_id(uint64_t table_id)
     {
         /* Ensure Pages table exists for this table ID */
-        fetch_pages_table(table_id);
+        get_or_open_table(table_id);
 
         /*
          * Add table ID to global table. Adding more than once is OK. The table index will ensure
          * uniqueness.
          */
-        auto acc = request<Globals, AccessMode::WRITE>();
-        acc.table.add_table_id(acc.conn, table_id);
+        globals.add_table_id(table_id);
     }
 
     std::vector<uint64_t>
     get_table_ids()
     {
-        auto acc = request<Globals, AccessMode::READ>();
-
-        return acc.table.get_table_ids(acc.conn);
+        return globals.get_table_ids();
     }
 
     void
     put_checkpoint(uint64_t lsn, uint64_t checkpoint_timestamp, const WT_ITEM *checkpoint_metadata)
     {
-        auto acc = request<Checkpoints, AccessMode::WRITE>();
-        acc.table.put(acc.conn, lsn, checkpoint_timestamp, checkpoint_metadata);
+        checkpoints.put(lsn, checkpoint_timestamp, checkpoint_metadata);
     }
 
     int
     get_checkpoint(uint64_t &lsn, uint64_t *timestamp, WT_ITEM *checkpoint_metadata)
     {
-        auto acc = request<Checkpoints, AccessMode::READ>();
-
-        return acc.table.get(acc.conn, lsn, timestamp, checkpoint_metadata);
-    }
-
-    void
-    delete_checkpoints(uint64_t lsn)
-    {
-        auto acc = request<Checkpoints, AccessMode::WRITE>();
-        acc.table.delete_many(acc.conn, lsn);
+        return checkpoints.get(lsn, timestamp, checkpoint_metadata);
     }
 
     void
     put_page(uint64_t table_id, uint64_t page_id, uint64_t lsn, WT_PAGE_LOG_PUT_ARGS *args,
       const WT_ITEM *buf)
     {
-        auto acc = request<Pages, AccessMode::WRITE>(table_id);
-        acc.table.put(acc.conn, table_id, page_id, lsn, args, buf);
+        Pages &table = get_table(table_id);
+        table.put(table_id, page_id, lsn, args, buf);
         object_puts++;
     }
 
@@ -1921,10 +2001,8 @@ public:
     get_pages(uint64_t table_id, uint64_t page_id, WT_PAGE_LOG_GET_ARGS *args, uint32_t *flags,
       WT_ITEM *results_array, uint32_t *results_count)
     {
-        auto acc = request<Pages, AccessMode::READ>(table_id);
-        const int ret =
-          acc.table.get(acc.conn, table_id, page_id, args, flags, results_array, results_count);
-        acc.release();
+        Pages &table = get_table(table_id);
+        const int ret = table.get(table_id, page_id, args, flags, results_array, results_count);
 
         assert(results_count != nullptr);
         object_gets += *results_count;
@@ -1935,29 +2013,27 @@ public:
     void
     get_page_ids(uint64_t checkpoint_lsn, uint64_t table_id, WT_ITEM *page_ids, size_t *page_count)
     {
-        auto acc = request<Pages, AccessMode::READ>(table_id);
-        acc.table.get_ids(acc.conn, checkpoint_lsn, table_id, page_ids, page_count);
+        Pages &table = get_table(table_id);
+        table.get_ids(checkpoint_lsn, table_id, page_ids, page_count);
     }
 
     void
     discard_page(uint64_t table_id, uint64_t page_id, uint64_t lsn, WT_PAGE_LOG_DISCARD_ARGS *args)
     {
-        auto acc = request<Pages, AccessMode::WRITE>(table_id);
-        acc.table.discard(acc.conn, table_id, page_id, lsn, args);
+        Pages &table = get_table(table_id);
+        table.discard(table_id, page_id, lsn, args);
     }
 
     void
     abandon_checkpoint(uint64_t checkpoint_lsn)
     {
-        /* Ensure exclusive access to storage during since we update multiple tables. */
+        /* Ensure exclusive access to storage since we update multiple tables. */
         std::unique_lock write_lock(store_access);
 
-        /* Using regular Access would block, so we update tables directly here. */
-
-        Connection &chkp_conn = checkpoints.conn();
         int ret = 0;
         if (checkpoint_lsn == WT_PAGE_LOG_LSN_MAX) {
-            ret = checkpoints.get(chkp_conn, checkpoint_lsn, nullptr, nullptr);
+            ret =
+              checkpoints.get(checkpoint_lsn, nullptr, nullptr, Checkpoints::AccessMode::BYPASS);
         }
 
         if (ret == WT_NOTFOUND) {
@@ -1967,12 +2043,16 @@ public:
 
         /* Note: global LSN counter is not decremented */
 
-        checkpoints.delete_many(chkp_conn, checkpoint_lsn);
+        checkpoints.delete_many(checkpoint_lsn, Checkpoints::AccessMode::BYPASS);
 
-        Connection &glob_conn = globals.conn();
-        for (auto table_id : globals.get_table_ids(glob_conn)) {
-            auto &pages_tbl = fetch_pages_table(table_id);
-            pages_tbl.delete_many(pages_tbl.conn(), checkpoint_lsn);
+        for (auto table_id : globals.get_table_ids(Globals::AccessMode::BYPASS)) {
+            /*
+             * Table ID's may be recorded in the 'globals' table, however connection to their
+             * 'pages' table may have never been opened. For example, on restart. Therefore, we use
+             * get_or_open_table().
+             */
+            auto &pages_tbl = get_or_open_table(table_id);
+            pages_tbl.delete_many(checkpoint_lsn, Pages::AccessMode::BYPASS);
         }
     }
 };

--- a/ext/page_log/palite/palite.cpp
+++ b/ext/page_log/palite/palite.cpp
@@ -1551,7 +1551,7 @@ struct Pages : public Table<Pages> {
         }
     }
 
-    int
+    void
     get(uint64_t table_id, uint64_t page_id, WT_PAGE_LOG_GET_ARGS *args, uint32_t *flags,
       WT_ITEM *results_array, uint32_t *results_count)
     {
@@ -1640,11 +1640,9 @@ struct Pages : public Table<Pages> {
         /* Reverse the results array to have the full page first, followed by deltas. */
         std::reverse(results_array, results_array + count);
         *results_count = count;
-
-        return 0;
     }
 
-    int
+    void
     get_ids(uint64_t checkpoint_lsn, uint64_t table_id, WT_ITEM *page_ids, size_t *page_count)
     {
         auto acc = request(AccessMode::READ);
@@ -1666,8 +1664,6 @@ struct Pages : public Table<Pages> {
         if (ids.size() > 0) {
             fill_item(page_ids, ids.data(), ids.size() * sizeof(uint64_t));
         }
-
-        return 0;
     }
 
     void
@@ -1802,7 +1798,7 @@ private:
         }
     }
 
-    int
+    void
     get_infos(Connection &conn, uint64_t table_id, uint64_t page_id, uint64_t lsn,
       std::vector<PageInfo> &pages)
     {
@@ -1823,8 +1819,6 @@ private:
                 .flags = static_cast<uint32_t>(sqlite3_column_int64(stmt.get(), 5)),
                 .encryption = WT_PAGE_LOG_ENCRYPTION{}});
         }
-
-        return 0;
     }
 
     /*
@@ -1997,17 +1991,15 @@ public:
         object_puts++;
     }
 
-    int
+    void
     get_pages(uint64_t table_id, uint64_t page_id, WT_PAGE_LOG_GET_ARGS *args, uint32_t *flags,
       WT_ITEM *results_array, uint32_t *results_count)
     {
         Pages &table = get_table(table_id);
-        const int ret = table.get(table_id, page_id, args, flags, results_array, results_count);
+        table.get(table_id, page_id, args, flags, results_array, results_count);
 
         assert(results_count != nullptr);
         object_gets += *results_count;
-
-        return ret;
     }
 
     void
@@ -2303,17 +2295,17 @@ public:
         if (checkpoint_timestamp)
             *checkpoint_timestamp = 0;
 
-        uint64_t query_lsn = WT_PAGE_LOG_LSN_MAX; /* most recent checkpoint */
-        int ret = storage.get_checkpoint(query_lsn, checkpoint_timestamp, checkpoint_metadata);
+        uint64_t last_ckpt_lsn = WT_PAGE_LOG_LSN_MAX; /* most recent checkpoint */
+        int ret = storage.get_checkpoint(last_ckpt_lsn, checkpoint_timestamp, checkpoint_metadata);
 
-        LOG_DEBUG("checkpoint_lsn={}, timestamp={}", query_lsn,
+        LOG_DEBUG("checkpoint_lsn={}, timestamp={}", last_ckpt_lsn,
           checkpoint_timestamp ? *checkpoint_timestamp : 0);
         LOG_TRACE("checkpoint_metadata (size={}) =====\n{}",
           checkpoint_metadata ? checkpoint_metadata->size : 0,
           checkpoint_metadata ? verbose_item(checkpoint_metadata) : "<none>");
 
         if (checkpoint_lsn)
-            *checkpoint_lsn = query_lsn;
+            *checkpoint_lsn = last_ckpt_lsn;
 
         return ret;
     }

--- a/ext/page_log/palite/palite.cpp
+++ b/ext/page_log/palite/palite.cpp
@@ -63,7 +63,7 @@ constexpr size_t BYTES_PER_LINE = 16;
 constexpr size_t LINE_BUFFER_SIZE = 80;
 constexpr size_t BUFFER_SIZE = 1024;
 
-// Helper to write hex bytes for one line
+/* Helper to write hex bytes for one line */
 char *
 write_hex_bytes(char *buf_ptr, std::span<const uint8_t> line_data)
 {
@@ -80,7 +80,7 @@ write_hex_bytes(char *buf_ptr, std::span<const uint8_t> line_data)
     return buf_ptr;
 }
 
-// Helper to write ASCII representation for one line
+/* Helper to write ASCII representation for one line */
 char *
 write_ascii_chars(char *buf_ptr, std::span<const uint8_t> line_data)
 {
@@ -90,7 +90,7 @@ write_ascii_chars(char *buf_ptr, std::span<const uint8_t> line_data)
     return buf_ptr;
 }
 
-// Helper to check if there's enough buffer space and handle truncation
+/* Helper to check if there's enough buffer space and handle truncation */
 bool
 check_buffer_space(char *&buf_ptr, char *buffer_start, size_t current_offset, size_t total_size)
 {
@@ -118,27 +118,27 @@ hexdump(const void *data, size_t size)
             break;
         }
 
-        // Write offset
+        /* Write offset */
         buf_ptr = std::format_to(buf_ptr, "{:08x}  ", i);
 
         size_t chunk_size = std::min(BYTES_PER_LINE, size - i);
         std::span<const uint8_t> line_data = all_data.subspan(i, chunk_size);
 
-        // Write hex bytes
+        /* Write hex bytes */
         buf_ptr = write_hex_bytes(buf_ptr, line_data);
 
-        // Write ASCII representation
+        /* Write ASCII representation */
         buf_ptr = std::format_to(buf_ptr, "|");
         buf_ptr = write_ascii_chars(buf_ptr, line_data);
         buf_ptr = std::format_to(buf_ptr, "|\n");
     }
 
-    // Write final offset if needed
+    /* Write final offset if needed */
     if (buf_ptr < buffer + BUFFER_SIZE && (size % BYTES_PER_LINE != 0 || size == 0)) {
         buf_ptr = std::format_to(buf_ptr, "{:08x}\n", size);
     }
 
-    // Null-terminate safely
+    /* Null-terminate safely */
     if (buf_ptr < buffer + BUFFER_SIZE) {
         *buf_ptr = '\0';
     } else {
@@ -147,15 +147,51 @@ hexdump(const void *data, size_t size)
 
     return buffer;
 }
-} // namespace
+} /* namespace */
 
 static const char *
-palite_verbose_item(const WT_ITEM *buf)
+verbose_item(const WT_ITEM *buf)
 {
     return hexdump(buf->data, buf->size);
 }
 
-// Simple joiner for collections
+static void
+resize_item(WT_ITEM *item, size_t new_size)
+{
+    if (item->memsize < new_size) {
+        item->mem = realloc(item->mem, new_size);
+        if (item->mem == NULL)
+            throw std::bad_alloc();
+        item->memsize = new_size;
+    }
+    item->data = item->mem;
+    item->size = new_size;
+}
+
+static void
+fill_item(WT_ITEM *item, const void *data, size_t size)
+{
+    memset(item, 0, sizeof(WT_ITEM));
+    resize_item(item, size);
+    if (size > 0 && data != nullptr)
+        memcpy(item->mem, data, size);
+}
+
+/*
+ * Compute a random jitter (milliseconds) around an average, uniformly in [0.5 * avg_ms, 1.5 *
+ * avg_ms].
+ */
+static uint64_t
+jitter_ms(uint32_t avg_ms)
+{
+    thread_local static std::mt19937_64 rng;
+    uint64_t min_ms = avg_ms / 2;          /* 0.5 * avg */
+    uint64_t max_ms = avg_ms + avg_ms / 2; /* 1.5 * avg */
+    std::uniform_int_distribution<uint64_t> dist(min_ms, max_ms);
+    return dist(rng);
+}
+
+/* Simple joiner for collections */
 template <typename Range, typename Separator>
 std::string
 join(const Range &range, const Separator &sep)
@@ -165,20 +201,20 @@ join(const Range &range, const Separator &sep)
     auto end = std::end(range);
 
     if (it != end) {
-        ss << *it; // Add the first element
+        ss << *it; /* Add the first element */
         ++it;
     }
 
     while (it != end) {
-        ss << sep; // Add separator before the next element
-        ss << *it; // Add the element
+        ss << sep; /* Add separator before the next element */
+        ss << *it; /* Add the element */
         ++it;
     }
 
     return ss.str();
 }
 
-// Base-2 (binary) units
+/* Base-2 (binary) units */
 constexpr uint64_t operator""_KB(unsigned long long val)
 {
     return val * 1024;
@@ -192,7 +228,7 @@ constexpr uint64_t operator""_GB(unsigned long long val)
     return val * 1024 * 1024 * 1024;
 }
 
-// Unix epoch microseconds
+/* Unix epoch microseconds */
 inline auto
 now_us()
 {
@@ -200,23 +236,23 @@ now_us()
     return duration_cast<microseconds>(steady_clock::now().time_since_epoch()).count();
 }
 
-// Configuration settings with defaults
+/* Configuration settings with defaults */
 struct Config {
-    WT_EXTENSION_API *extapi = nullptr; // WiredTiger extension API
+    WT_EXTENSION_API *extapi = nullptr; /* WiredTiger extension API */
 
-    std::filesystem::path home_dir;        // Home directory for the extension
-    uint32_t cache_size_mb = 8'192;        // Size of cache in megabytes (default)
-    uint32_t mmap_size_mb = 8'192;         // Size of memory map in megabytes (default)
-    uint32_t delay_ms = 0;                 // Average length of delay when simulated
-    uint32_t error_ms = 0;                 // Average length of sleep when simulated
-    uint32_t force_delay = 0;              // Force a simulated network delay every N operations
-    uint32_t force_error = 0;              // Force a simulated network error every N operations
-    uint32_t materialization_delay_ms = 0; // Average length of materialization delay
-    uint64_t last_materialized_lsn = 0;    // The last materialized LSN (0 if not set)
-    uint32_t verbose = WT_VERBOSE_INFO;    // Verbose level
-    bool verbose_msg = true;               // Send verbose messages to msg callback interface
-    bool sql_trace = false;                // Trace all SQLite calls
-    bool verify = true;                    // Verify integrity of page delta chains
+    std::filesystem::path home_dir;        /* Home directory for the extension */
+    uint32_t cache_size_mb = 1'024;        /* Size of cache in megabytes (default) */
+    uint32_t mmap_size_mb = 1'024;         /* Size of memory map in megabytes (default) */
+    uint32_t delay_ms = 0;                 /* Average length of delay when simulated */
+    uint32_t error_ms = 0;                 /* Average length of sleep when simulated */
+    uint32_t force_delay = 0;              /* Force a simulated network delay every N operations */
+    uint32_t force_error = 0;              /* Force a simulated network error every N operations */
+    uint32_t materialization_delay_ms = 0; /* Average length of materialization delay */
+    uint64_t last_materialized_lsn = 0;    /* The last materialized LSN (0 if not set) */
+    uint32_t verbose = WT_VERBOSE_INFO;    /* Verbose level */
+    bool verbose_msg = true;               /* Send verbose messages to msg callback interface */
+    bool sql_trace = false;                /* Trace all SQLite calls */
+    bool verify = true;                    /* Verify integrity of page delta chains */
 
     Config() = default;
     Config(WT_EXTENSION_API *wt_api, WT_CONFIG_ARG *config) : extapi(wt_api)
@@ -268,7 +304,7 @@ private:
     void
     configure_value(WT_CONFIG_PARSER *parser, WT_CONFIG_ARG *config, const char *key, T &value)
     {
-        // Guard for supported types (bool, integral, string, and filesystem::path types)
+        /* Guard for supported types (bool, integral, string, and filesystem::path types) */
         static_assert(std::is_same_v<T, bool> || std::is_integral_v<T> ||
             std::is_same_v<T, std::string> || std::is_same_v<T, std::filesystem::path>,
           "Unsupported type for configuration");
@@ -280,14 +316,14 @@ private:
             } else if constexpr (std::is_same_v<T, std::string> ||
               std::is_same_v<T, std::filesystem::path>) {
                 return type == WT_CONFIG_ITEM::WT_CONFIG_ITEM_STRING;
-            } else { // integral types
+            } else { /* integral types */
                 return type == WT_CONFIG_ITEM::WT_CONFIG_ITEM_NUM;
             }
         };
 
         WT_CONFIG_ITEM v{};
         int ret = 0;
-        // Check environment config first, then regular config
+        /* Check environment config first, then regular config */
         if ((ret = parser->get(parser, key, &v)) == 0 ||
           (ret = extapi->config_get(extapi, nullptr, config, key, &v)) == 0) {
             if (v.len == 0 || !validate(v.type)) {
@@ -328,6 +364,7 @@ template <> struct std::formatter<Config> {
 };
 
 WT_SESSION *const INVALID_PTR = reinterpret_cast<WT_SESSION *>(-1);
+const uint64_t INVALID_LSN = UINT64_MAX;
 
 static WT_SESSION *
 session(WT_SESSION *s = INVALID_PTR)
@@ -375,8 +412,8 @@ log(std::source_location loc, Config &config, WT_VERBOSE_LEVEL level,
 
 #define LOG_ERROR(...) LOG_AT(WT_VERBOSE_ERROR, __VA_ARGS__)
 #define LOG_WARN(...) LOG_AT(WT_VERBOSE_WARNING, __VA_ARGS__)
-//#define LOG_NOTICE(...)  LOG_AT(WT_VERBOSE_NOTICE,   __VA_ARGS__) // unused
-//#define LOG_INFO(...)    LOG_AT(WT_VERBOSE_INFO,     __VA_ARGS__) // unused
+/*#define LOG_NOTICE(...)  LOG_AT(WT_VERBOSE_NOTICE,   __VA_ARGS__) */ /* unused */
+/*#define LOG_INFO(...)    LOG_AT(WT_VERBOSE_INFO,     __VA_ARGS__) */ /* unused */
 #define LOG_DEBUG(...) LOG_AT(WT_VERBOSE_DEBUG_1, __VA_ARGS__)
 #define LOG_DIAG(...) LOG_AT(WT_VERBOSE_DEBUG_2, __VA_ARGS__)
 #define LOG_TRACE(...) LOG_AT(WT_VERBOSE_DEBUG_3, __VA_ARGS__)
@@ -387,7 +424,7 @@ log(std::source_location loc, Config &config, WT_VERBOSE_LEVEL level,
             LOG_DIAG(fmt, __VA_ARGS__); \
     } while (0)
 
-// Exception-safe template method that catches C++ exceptions
+/* Exception-safe template method that catches C++ exceptions */
 template <typename T, typename S, typename MemberFunc, typename... Args>
 static int
 safe_call(WT_SESSION *sess, S *api, MemberFunc func, Args &&...args)
@@ -400,7 +437,7 @@ safe_call(WT_SESSION *sess, S *api, MemberFunc func, Args &&...args)
     std::unique_ptr<WT_SESSION, std::function<decltype(session)>> reset_session{nullptr, &session};
 
     T *obj = static_cast<T *>(api);
-    Config &config = obj->config; // needed for logging macros bellow
+    Config &config = obj->config; /* needed for logging macros bellow */
     try {
         return std::invoke(func, obj, std::forward<Args>(args)...);
     } catch (const std::bad_alloc &e) {
@@ -441,51 +478,47 @@ log_and_throw(
 
 #define LOG_AND_THROW(...) log_and_throw(std::source_location::current(), config, __VA_ARGS__)
 
-// Unified pointer formatters: all forwarded to const void* formatter.
+/* Generic formatter for custom pointer types. */
+template <typename T>
+requires(!std::is_same_v<std::remove_cv_t<T>, char> &&
+  !std::is_void_v<std::remove_cv_t<T>>) struct std::formatter<T *, char> {
+    /* Use the same format specifiers as for uintptr_t */
+    std::formatter<std::uintptr_t, char> underlying;
 
-#define PALITE_DEFINE_PTR_FORMATTER(T)                                                \
-    template <> struct std::formatter<T, char> : std::formatter<const void *, char> { \
-        auto                                                                          \
-        format(T value, std::format_context &ctx) const                               \
-        {                                                                             \
-            return std::formatter<const void *, char>::format(                        \
-              reinterpret_cast<const void *>(value), ctx);                            \
-        }                                                                             \
-    };
+    constexpr auto
+    parse(std::format_parse_context &ctx)
+    {
+        return underlying.parse(ctx);
+    }
 
-// TODO: find more elegant solution
-PALITE_DEFINE_PTR_FORMATTER(char **)
-PALITE_DEFINE_PTR_FORMATTER(sqlite3 *)
-PALITE_DEFINE_PTR_FORMATTER(sqlite3 **)
-PALITE_DEFINE_PTR_FORMATTER(sqlite3_stmt *)
-PALITE_DEFINE_PTR_FORMATTER(const sqlite3_stmt *)
-PALITE_DEFINE_PTR_FORMATTER(sqlite3_stmt **)
-using callback_ptr_t = void (*)(void *);
-PALITE_DEFINE_PTR_FORMATTER(callback_ptr_t)
-using busy_handler_ptr_t = int (*)(void *, int);
-PALITE_DEFINE_PTR_FORMATTER(busy_handler_ptr_t)
+    auto
+    format(T *ptr, std::format_context &ctx) const
+    {
+        return underlying.format(reinterpret_cast<std::uintptr_t>(ptr), ctx);
+    }
+};
 
-#undef PALITE_DEFINE_PTR_FORMATTER
-
-// SQLite3 exec helper
+/* SQLite3 exec helper */
 class SQLiteCall {
     Config &config;
     sqlite3 *db;
     std::source_location loc;
     const char *const func_name;
 
-    // Build format string at compile time. It contains the fixed prefix
-    // followed by N occurrences of the pattern `'{}', ` with the final comma+space trimmed.
+    /*
+     * Build format string at compile time. It contains the fixed prefix followed by N occurrences
+     * of the pattern `'{}', ` with the final comma+space trimmed.
+     */
     template <std::size_t N, std::size_t K>
     static consteval auto
     make_log_format(const char (&prefix)[K])
     {
-        constexpr std::size_t prefix_len = sizeof(prefix) - 1; // exclude null terminator
-        // Each argument contributes: 4 chars for "'{}'" plus 2 chars for ", "
+        constexpr std::size_t prefix_len = sizeof(prefix) - 1; /* exclude null terminator */
+        /* Each argument contributes: 4 chars for "'{}'" plus 2 chars for ", " */
         constexpr std::size_t braces_len = N == 0 ? 0 : (N * 6);
         std::array<char, prefix_len + braces_len + 1> fmt{};
 
-        std::copy_n(prefix, prefix_len, fmt.begin()); // excludes null terminator
+        std::copy_n(prefix, prefix_len, fmt.begin()); /* excludes null terminator */
 
         constexpr const char c[] = "'{}', ";
         for (size_t i = prefix_len; i != fmt.size() - 1; ++i)
@@ -499,7 +532,7 @@ class SQLiteCall {
     std::string
     trace_sqlite3_call(R ret, Args &&...args)
     {
-        // Build format string with fixed prefix and N occurrences of '{}'
+        /* Build format string with fixed prefix and N occurrences of '{}' */
         static constexpr auto fmt_arr =
           make_log_format<sizeof...(Args)>("{}; return: {} ({}); details: {} ({}); args: ");
 
@@ -550,7 +583,7 @@ public:
         static constexpr auto sqlite2errno = []() constexpr
         {
             std::array<std::errc, SQLITE_NOTADB + 1> a{};
-            a[SQLITE_OK] = std::errc::operation_not_permitted; // unused
+            a[SQLITE_OK] = std::errc::operation_not_permitted; /* unused */
             a[SQLITE_ERROR] = std::errc::invalid_argument;
             a[SQLITE_INTERNAL] = std::errc::invalid_argument;
             a[SQLITE_PERM] = std::errc::permission_denied;
@@ -581,7 +614,7 @@ public:
         }
         ();
 
-        // Verify that each slot was assigned.
+        /* Verify that each slot was assigned. */
         static_assert(
           std::ranges::none_of(sqlite2errno, [](std::errc e) { return static_cast<int>(e) == 0; }),
           "Uninitialized SQLite error code found");
@@ -603,34 +636,12 @@ public:
 #define SQL_CALL_OPEN(func, ...) \
     SQLiteCall(config, nullptr, std::source_location::current(), #func).exec(func, __VA_ARGS__)
 
-// TODO: Handle SQLITE_BUSY in better way
-// SQLite3 busy handler - Experimental!
-extern "C" {
-static int
-db_busy_handler(void *ptr, int count)
-{
-    Config &config = *static_cast<Config *>(ptr);
-    LOG_TRACE("SQLite busy handler invoked (count={})", count);
+/* Requires a Connection object to be available as 'conn'. */
+#define SQ_CHECK(func, ...) SQL_CALL_CHECK(conn.db_instance(), func, __VA_ARGS__)
 
-    /* Backoff strategy:
-    - Per-attempt sleep = 100ms
-    - Stop retrying once total accumulated sleep would exceed 10s (10000 ms)
-    */
-    static constexpr int PER_ATTEMPT_MS = 100;
-    static constexpr int MAX_TOTAL_MS = 10'000;
-
-    if (PER_ATTEMPT_MS * count > MAX_TOTAL_MS) {
-        LOG_TRACE("Busy handler giving up (projected total sleep={} ms)", PER_ATTEMPT_MS * count);
-        return 0; // Stop retrying
-    }
-
-    std::this_thread::sleep_for(std::chrono::milliseconds(PER_ATTEMPT_MS));
-    return 1; // Retry
-}
-} // extern "C"
-
-// Storage layer
-//
+/*
+ * Storage layer
+ */
 
 struct PageInfo {
     uint64_t table_id;
@@ -652,7 +663,7 @@ template <> struct std::formatter<PageInfo> {
     auto
     format(const PageInfo &page, format_context &ctx) const
     {
-        // TODO: print encryption if special formatting is given, e.g. {:e}
+        /* TODO: print encryption if special formatting is given, e.g. {:e} */
         return std::format_to(ctx.out(),
           "{{table_id={}, page_id={}, lsn={}, backlink_lsn={}, base_lsn={}, "
           "flags={:#x}}}",
@@ -661,55 +672,49 @@ template <> struct std::formatter<PageInfo> {
 };
 
 class Storage {
-    enum Statement {
-        BEGIN,
-        COMMIT,
-        ROLLBACK,
-        PUT_CHECKPOINT,
-        GET_CHECKPOINT,
-        DELETE_CHECKPOINTS,
-        GET_NEXT_LSN,
-        GET_LAST_LSN,
-        PUT_PAGE,
-        GET_PAGE_IDS,
-        GET_FULL_PAGE_LSN,
-        GET_PAGE_INFOS,
-        GET_PAGES,
-        DELETE_PAGES,
-        COUNT // must be last
-    };
-
-    // Our flags start at the 16th bit (0x10000u) to avoid
-    // conflicts with WT_PAGE_LOG_PUT_ARGS flags.
-    static constexpr uint32_t WT_PAGE_LOG_DISCARDED = 0x10000u;
-
     Config &config;
-
-    const std::filesystem::path db_path;
-
-    using StatementPtr = std::unique_ptr<sqlite3_stmt, std::function<decltype(sqlite3_reset)>>;
-    using InitDbCall = std::function<void(sqlite3 *)>;
+    const std::filesystem::path db_home;
 
     class Connection {
         Config &config;
         sqlite3 *db = nullptr;
-
-        using StatementArray = std::array<sqlite3_stmt *, Statement::COUNT>;
-        StatementArray statements;
+        std::vector<sqlite3_stmt *> statements;
 
     public:
+        /* Common configuration parameters for connections */
+        constexpr static std::string_view config_statements[] = {
+          /*
+           * The WAL journaling mode uses a write-ahead log instead of a rollback journal to
+           * implement transactions. This significantly improves performance.
+           */
+          "PRAGMA journal_mode = WAL;",
+
+          /*
+           * Turn Synchronous mode OFF for better performance. We don't care about database
+           * corruption in case of OS crash or power failure.
+           */
+          "PRAGMA synchronous = OFF;",
+
+          /* For temporary store use memory instead of disk. */
+          "PRAGMA temp_store = MEMORY;",
+
+          /* Set busy timeout to 10 seconds. */
+          "PRAGMA busy_timeout = 10000;"};
+
+        using StatementPtr = std::unique_ptr<sqlite3_stmt, std::function<decltype(sqlite3_reset)>>;
+
         ~Connection() = default;
-        Connection(Config &cfg, const std::filesystem::path &db_path, InitDbCall &&init_db)
-            : config(cfg), db(open_db(cfg, db_path, init_db))
+        Connection(Config &cfg, const std::filesystem::path &db_path)
+            : config(cfg), db(open_db(cfg, db_path))
         {
-            prepare_statements();
+            configure(Connection::config_statements);
         }
 
         StatementPtr
-        db_statement(Statement stmt)
+        db_statement(size_t idx)
         {
-            return StatementPtr(statements[stmt], [this](sqlite3_stmt *s) {
-                // do not throw from d'tor
+            return StatementPtr(statements[idx], [this](sqlite3_stmt *s) {
+                /* do not throw from d'tor */
                 return SQL_CALL_CHECK_NO_THROW(db, sqlite3_reset, s);
             });
         }
@@ -718,6 +723,28 @@ class Storage {
         db_instance() const
         {
             return db;
+        }
+
+        template <typename Container>
+        void
+        configure(const Container &cfg_statements)
+        {
+            for (const auto &stmt : cfg_statements) {
+                SQL_CALL_CHECK(db, sqlite3_exec, db, stmt.data(), nullptr, nullptr, nullptr);
+            }
+        }
+
+        template <typename Container>
+        void
+        prepare_statements(const Container &sql_statements)
+        {
+            statements.clear();
+            for (const auto &stmt : sql_statements) {
+                sqlite3_stmt *prepared_stmt = nullptr;
+                SQL_CALL_CHECK(
+                  db, sqlite3_prepare_v2, db, stmt.data(), -1, &prepared_stmt, nullptr);
+                statements.push_back(prepared_stmt);
+            }
         }
 
         void
@@ -729,272 +756,25 @@ class Storage {
 
     private:
         static sqlite3 *
-        open_db(Config &config, const std::filesystem::path &db_path, InitDbCall &init_db)
+        open_db(Config &config, const std::filesystem::path &db_path)
         {
             const unsigned flags =
-              // The database is opened for reading and writing,
-              // and is created if it does not already exist.
+              /*
+               * The database is opened for reading and writing, and is created if it does not
+               * already exist.
+               */
               SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE |
-              // Use the "multi-thread" threading mode.
-              // Cannot share this connection between threads.
+              /*
+               * Use the "multi-thread" threading mode. Cannot share this connection between
+               * threads.
+               */
               SQLITE_OPEN_NOMUTEX;
 
             sqlite3 *pdb = nullptr;
             SQL_CALL_OPEN(sqlite3_open_v2, db_path.c_str(), &pdb, flags, nullptr);
             LOG_DEBUG("Opened SQLite database: {} ({})", pdb, db_path.c_str());
 
-            init_db(pdb);
-
-            SQL_CALL_CHECK(
-              pdb, sqlite3_busy_handler, pdb, &db_busy_handler, static_cast<void *>(&config));
             return pdb;
-        }
-
-        using SqlArray = std::array<const char *, Statement::COUNT>;
-
-        static SqlArray
-        init_sql_statements()
-        {
-            constexpr SqlArray stmts = []() constexpr
-            {
-                SqlArray a{}; // all nullptr initially
-                a[BEGIN] = R"(BEGIN TRANSACTION;)";
-                a[COMMIT] = R"(COMMIT;)";
-                a[ROLLBACK] = R"(ROLLBACK;)";
-                a[PUT_CHECKPOINT] = R"(
-                    INSERT INTO checkpoints (lsn, timestamp, checkpoint_metadata)
-                    VALUES (?, ?, ?);)";
-
-                /* !!! Get the latest checkpoint (i.e., checkpoint with the
-                highest lsn) if query lsn equals to WT_PAGE_LOG_LSN_MAX (
-                passed as parameter: ?2); otherwise get the checkpoint with the
-                given lsn. */
-                a[GET_CHECKPOINT] = R"(
-                    SELECT lsn, timestamp, checkpoint_metadata
-                    FROM checkpoints
-                    WHERE (?1 = ?2 OR lsn = ?1)
-                    ORDER BY
-                        lsn DESC,
-                        timestamp DESC
-                    LIMIT 1;)";
-                a[DELETE_CHECKPOINTS] = R"(
-                    DELETE FROM checkpoints
-                    WHERE lsn > ?;)";
-
-                /* Increment LSN and get the value. */
-                a[GET_NEXT_LSN] = R"(
-                    UPDATE lsn
-                    SET lsn = lsn + 1
-                    WHERE id = 0
-                    RETURNING lsn;)";
-
-                /* Get the last LSN. */
-                a[GET_LAST_LSN] = R"(
-                    SELECT lsn
-                    FROM lsn
-                    WHERE id = 0;)";
-
-                /* !!! Insert new pages or replace write failures.
-
-                When writing a new delta page, if a delta page already exists with
-                the same (table_id, page_id, backlink_lsn), the existing page is
-                treated as a write failure and replaced.
-
-                This uniqueness constraint is enforced by a partial index that
-                applies only to delta pages. See the CREATE TABLE statement for
-                the 'pages' table. */
-                a[PUT_PAGE] = R"(
-                    INSERT OR REPLACE INTO pages (
-                        table_id,
-                        page_id,
-                        lsn,
-                        backlink_lsn,
-                        base_lsn,
-                        flags,
-                        encryption,
-                        timestamp_materialized_us,
-                        page_data)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);)";
-
-                /* !!! Get all unique page IDs for a given table that have their
-                latest page record with LSN <= query LSN and not discarded. */
-                a[GET_PAGE_IDS] = R"(
-                    SELECT DISTINCT p1.page_id
-                    FROM pages AS p1
-                    WHERE p1.table_id = ?1
-                        AND p1.lsn <= ?2
-                        AND NOT EXISTS (
-                            SELECT 1
-                            FROM pages AS p2
-                            WHERE p2.table_id = p1.table_id
-                              AND p2.page_id = p1.page_id
-                              AND p2.lsn <= ?2
-                              AND p2.discarded = 1
-                        );)";
-
-                /* !!! Get the LSN of the first non-discarded full page below the
-                given LSN.
-
-                The query LSN may belong to a delta page. Therefore,
-                we find the corresponding full page LSN first. Then we look for
-                the previous full page LSN.
-                Assuming that given query LSN does not belong to discarded page.
-
-                This is used with full page backlink verification. */
-                a[GET_FULL_PAGE_LSN] = R"(
-                    WITH full_page AS (
-                        SELECT MAX(p0.lsn) AS lsn
-                        FROM pages AS p0
-                        WHERE p0.table_id = ?1
-                          AND p0.page_id = ?2
-                          AND p0.lsn <= ?3
-                          AND p0.delta = 0
-                    )
-                    SELECT MAX(p1.lsn)
-                    FROM
-                      pages AS p1,
-                      full_page AS fp
-                    WHERE p1.table_id = ?1
-                        AND p1.page_id = ?2
-                        AND p1.lsn < fp.lsn
-                        AND p1.delta = 0
-                        AND NOT EXISTS (
-                            SELECT 1
-                            FROM pages AS p2
-                            WHERE p2.table_id = p1.table_id
-                              AND p2.page_id = p1.page_id
-                              AND p2.lsn < fp.lsn
-                              AND p2.discarded = 1
-                        );)";
-
-                /* !!! Retrieve information about entire delta chain stopping at
-                the first full page. The chain may include discarded page.
-
-                This query uses a window function OVER to assign a group number
-                to rows based on the 'delta' column. This is more performant
-                than discovering full page in a separate query as it may only
-                require a single scan over the data.
-
-                The window function works as follows:
-
-                First, the inner part:
-                    CASE
-                      WHEN delta = 0 THEN 1
-                      ELSE 0
-                    END
-
-                This expression looks at each row one by one. For delta pages
-                (where delta = 1), it produces a 0. For full pages (where
-                delta = 0), it produces a 1.
-
-                So, it's essentially a marker for the rows with full pages.
-                We consider such rows as terminators.
-
-                Next, the outer part:
-                    SUM(...) OVER (ORDER BY lsn DESC) as page_group
-
-                This expression takes the markers produced by the inner part
-                and computes a running total (SUM) of these markers, ordered
-                by LSN in descending order (from newest to oldest).
-
-                This creates a cumulative count of how many "terminating" rows
-                (delta = 0) have been seen so far.
-
-                Example:
-
-                lsn | delta | inner CASE | page_group | explanation
-                ----+-------+------------+------------+------------
-                10  | 1     | 0          | 0          | Sum of (0)
-                9   | 1     | 0          | 0          | Sum of (0, 0)
-                8   | 1     | 0          | 0          | Sum of (0, 0, 0)
-                7   | 0     | 1          | 1          | Sum of (0, 0, 0, 1)
-                6   | 0     | 1          | 2          | Sum of (0, 0, 0, 1, 1)
-
-                The entire chain of pages (lsn 10, 9, 8, 7) is returned, stopping
-                at the first full page (lsn 7). The next full page (lsn 6) is
-                not included because page_group becomes 2 and we explicitly check
-                for that:
-                    ...
-                    WHERE page_group = 0
-                      OR (page_group = 1 AND delta = 0)
-
-                This condition ensures that we get all delta pages in the chain
-                up to the first full page. */
-                a[GET_PAGE_INFOS] = R"(
-                    WITH chained_pages AS (
-                      SELECT
-                        table_id,
-                        page_id,
-                        lsn,
-                        backlink_lsn,
-                        base_lsn,
-                        flags,
-                        delta,
-                        SUM(CASE
-                              WHEN delta = 0 THEN 1
-                              ELSE 0
-                            END) OVER (ORDER BY lsn DESC) as page_group
-                      FROM pages
-                      WHERE table_id = ?
-                        AND page_id = ?
-                        AND lsn <= ?
-                        AND timestamp_materialized_us <= ?
-                    )
-                    SELECT
-                      table_id,
-                      page_id,
-                      lsn,
-                      backlink_lsn,
-                      base_lsn,
-                      flags
-                    FROM chained_pages
-                    WHERE page_group = 0
-                      OR (page_group = 1 AND delta = 0)
-                    ORDER BY lsn DESC;
-                )";
-
-                /* !!! Simple selection of all pages below the given LSN.
-                Verification of the delta chain and stopping at the terminating
-                full page is done in code. */
-                a[GET_PAGES] = R"(
-                    SELECT
-                        lsn,
-                        backlink_lsn,
-                        base_lsn,
-                        flags,
-                        encryption,
-                        page_data
-                    FROM pages
-                    WHERE table_id = ?
-                        AND page_id = ?
-                        AND lsn <= ?
-                        AND timestamp_materialized_us <= ?
-                    ORDER BY lsn DESC;)";
-
-                a[DELETE_PAGES] = R"(
-                    DELETE FROM pages
-                    WHERE lsn > ?;)";
-
-                return a;
-            }
-            ();
-
-            // Verify that each slot was assigned.
-            static_assert(
-              std::ranges::none_of(stmts, [](const char *stmt) { return stmt == nullptr; }),
-              "Uninitialized SQL statement found");
-            return stmts;
-        }
-
-        void
-        prepare_statements()
-        {
-            static const SqlArray sql_statements = init_sql_statements();
-
-            for (size_t i = 0; i < statements.size(); ++i) {
-                SQL_CALL_CHECK(
-                  db, sqlite3_prepare_v2, db, sql_statements[i], -1, &statements[i], nullptr);
-            }
         }
 
         void
@@ -1002,7 +782,7 @@ class Storage {
         {
             std::ranges::for_each(
               statements, [this](sqlite3_stmt *s) { SQL_CALL_CHECK(db, sqlite3_finalize, s); });
-            statements.fill(nullptr);
+            statements.clear();
         }
 
         void
@@ -1019,234 +799,1030 @@ class Storage {
         }
     };
 
-    // DB state management
-    std::once_flag db_init;
-    std::shared_mutex db_mutex;
-    std::unordered_map<std::thread::id, std::unique_ptr<Connection>> connections;
+    template <typename Traits> class Table {
+    protected:
+        Config &config;
+        std::filesystem::path table_file;
 
-    // DBG
-    std::binary_semaphore db_access;
-    // DBG
+        std::once_flag create_table;
+        std::shared_mutex conn_state; /* protects 'connections' map */
+        std::unordered_map<std::thread::id, std::unique_ptr<Connection>> connections;
 
-    // Stats
-    std::atomic_ullong object_puts; // (What would be) network writes
-    std::atomic_ullong object_gets; // (What would be) network requests for data
+    public:
+        std::shared_mutex access; /* readers-writer mutex for table */
 
-public:
-    ~Storage() = default;
-    Storage(Config &cfg, const std::filesystem::path &dbp)
-        : config(cfg), db_path(dbp / "sqlite.db"), db_access(1)
-    {
-    }
-    Storage(const Storage &) = delete;
+        ~Table() = default;
+        Table(Config &cfg, const std::filesystem::path &file) : config(cfg), table_file(file) {}
 
-private:
-    Connection &
-    db_conn()
-    {
+        Connection &
+        conn()
         {
-            std::shared_lock read_lock(db_mutex);
-            auto it = connections.find(std::this_thread::get_id());
-            if (it != connections.end())
-                return *(it->second);
+            {
+                std::shared_lock read_lock(conn_state);
+                auto it = connections.find(std::this_thread::get_id());
+                if (it != connections.end())
+                    return *(it->second);
+            }
+
+            {
+                std::unique_lock write_lock(conn_state);
+                auto [it, inserted] = connections.try_emplace(
+                  std::this_thread::get_id(), std::make_unique<Connection>(config, table_file));
+
+                if (!inserted)
+                    LOG_AND_THROW("Connection already exists for this thread");
+
+                Connection &new_conn = *(it->second);
+                new_conn.configure(static_cast<Traits *>(this)->conn_config());
+                create_tables(new_conn);
+                new_conn.prepare_statements(Traits::sql_statements);
+
+                return new_conn;
+            }
         }
 
+        void
+        close()
         {
-            std::unique_lock write_lock(db_mutex);
-            auto [it, inserted] = connections.try_emplace(std::this_thread::get_id(),
-              std::make_unique<Connection>(config, db_path, [this](sqlite3 *db) { init_db(db); }));
-
-            if (!inserted)
-                LOG_AND_THROW("Connection already exists for this thread");
-
-            return *(it->second);
+            std::ranges::for_each(connections, [](auto &kv) { kv.second->close(); });
+            connections.clear();
         }
-    }
 
-    void
-    init_db(sqlite3 *db)
-    {
-        std::call_once(
-          db_init, [this](sqlite3 *d) { create_tables(d); }, db);
-        configure_connection(db);
-    }
+    private:
+        void
+        create_tables(Connection &conn)
+        {
+            std::call_once(
+              create_table,
+              [this](sqlite3 *d) {
+                  for (const auto &stmt : Traits::create_statements) {
+                      SQL_CALL_CHECK(d, sqlite3_exec, d, stmt.data(), nullptr, nullptr, nullptr);
+                  }
+                  LOG_DEBUG("SQLite database schema initialized: {}", table_file.c_str());
+              },
+              conn.db_instance());
+        }
+    };
 
-    void
-    create_tables(sqlite3 *db)
-    {
-        // These flags used below in generated columns for 'pages' table.
-        static_assert(WT_PAGE_LOG_DELTA == 0x2, "WT_PAGE_LOG_DELTA value changed");
-        static_assert(WT_PAGE_LOG_DISCARDED == 0x10000, "WT_PAGE_LOG_DISCARDED value changed");
+    /*
+     * Tables
+     */
 
-        static const char *create_statements[] = {
-          R"(CREATE TABLE IF NOT EXISTS pages (
-                table_id INTEGER NOT NULL,
-                page_id INTEGER NOT NULL,
-                lsn INTEGER NOT NULL,
-                backlink_lsn INTEGER NOT NULL,
-                base_lsn INTEGER NOT NULL,
-                flags INTEGER NOT NULL,
-                delta INTEGER AS ((flags & 0x2) != 0) VIRTUAL, -- WT_PAGE_LOG_DELTA
-                discarded INTEGER AS ((flags & 0x10000) != 0) VIRTUAL, -- WT_PAGE_LOG_DISCARDED
-                encryption STRING NOT NULL,
-                timestamp_materialized_us INTEGER NOT NULL,
-                page_data BLOB,
-             PRIMARY KEY (table_id, page_id, lsn)
-            );)",
+    struct Globals : public Table<Globals> {
+        constexpr static std::string_view prefix = "globals";
 
-          /* !!! This index exists for the case in which we have written a page
-          delta and then need to write it again.
+        enum Statement { MAKE_NEXT_LSN, GET_LAST_LSN, ADD_TABLE_ID, GET_TABLE_IDS };
 
-          This generally happens in eviction. We have a base page already written
-          and we now try to evict it. We finished writing a delta to disk but
-          then we fail the reconciliation. It is a delta so we cannot explicitly
-          free the write with the same page id. After a while, we retry the
-          eviction and this time we writes a delta based on the same base page.
-          Thus this write will have the same backlink_lsn to the previous write.
+        constexpr static std::string_view sql_statements[] = {
 
-          At this stage, there may be no checkpoint running so discarding the
-          unfinished checkpoint doesn't help in this case. It is also possible
-          that these two writes will be included in the same checkpoint that is
-          not discarded.
+          /* MAKE_NEXT_LSN: Increment LSN. */
+          R"(UPDATE globals
+             SET val = val + 1
+             WHERE id = 0
+             RETURNING val;)",
 
-          To gracefully handle write failures of delta pages we will keep
-          track of the backlink_lsn within each delta chain. Tracking is done via
-          a *partial* unique index on (table_id, page_id, backlink_lsn) for
-          genuine delta pages only: delta=1 AND discarded=0.
-          (Partial index can include only a subset of rows in the table.)
+          /* GET_LAST_LSN: Get the last LSN. */
+          R"(SELECT val
+             FROM globals
+             WHERE id = 0;)",
 
-          The primary key for the table (table_id, page_id, lsn) does not help
-          because lsn is always increasing, making each record unique.
+          /* ADD_TABLE_ID: Add a new table ID if it does not already exist. */
+          R"(INSERT OR IGNORE INTO globals (id, val)
+             VALUES (1, ?);)",
 
-          Including backlink_lsn in the primary key would not work because
-          together with always increasing lsn the constraint is always satisfied.
+          /* GET_TABLE_IDS: Get all known table IDs. */
+          R"(SELECT val
+             FROM globals
+             WHERE id = 1;)"};
 
-          Hence, we need a separate unique index for delta pages only (excluding
-          discarded pages, which are a special case).
-
-          Example:
-
-            table_id | page_id | lsn | backlink_lsn | base_lsn | delta
-            ---------+---------+-----+--------------+----------+------
-                1    |   100   | 5   |      0       |   0      |   0
-                1    |   100   | 6   |      5       |   5      |   1
-                1    |   100   | 7   |      6       |   5      |   1
-                1    |   100   | 8   |      7       |   5      |   1    <-- write failure
-                1    |   100   | 9   |      7       |   5      |   1    <-- new delta page
-
-          Suppose, the page with lsn=8 is a write failure. When a new delta page
-          is written with (lsn=9, backlink_lsn=7, base_lsn=5), then it will
-          conflict with the existing page with lsn=8 because they have the same
-          (table_id, page_id, backlink_lsn). The partial index will ensure
-          that there is at most one such delta page.
-
-          The new page with lsn=9 will replace the failed page with lsn=8 because
-          pages are inserted with 'INSERT OR REPLACE INTO pages'.
-
-          See also PUT_PAGE statement. */
-          R"(CREATE UNIQUE INDEX IF NOT EXISTS ux_delta
-             ON pages (table_id, page_id, backlink_lsn)
-             WHERE delta = 1 AND discarded = 0;)",
-
-          /* LSN counter table. */
-          R"(CREATE TABLE IF NOT EXISTS lsn (
-                id INTEGER PRIMARY KEY DEFAULT 0 CHECK (id = 0),
-                lsn INTEGER NOT NULL
-            );)",
+        constexpr static std::string_view create_statements[] = {
+          /*
+           * Globals table to store LSN counter and known table IDs.
+           *  - LSN counter id = 0
+           *  - Table IDs id = 1
+           */
+          R"(CREATE TABLE IF NOT EXISTS globals (
+                 id INTEGER CHECK (id = 0 OR id = 1),
+                 val INTEGER NOT NULL,
+             PRIMARY KEY (id, val));)",
 
           /* Init LSN counter, if the table is empty; do nothing otherwise. */
-          R"(INSERT OR IGNORE INTO lsn(id, lsn) VALUES (0, 0);)"
+          R"(INSERT INTO globals (id, val)
+             SELECT 0, 0
+             WHERE NOT EXISTS (SELECT 1 FROM globals WHERE id = 0);)"};
 
+        ~Globals() = default;
+        Globals(Config &cfg, const std::filesystem::path &home)
+            : Table<Globals>(cfg, home / std::format("{}.db", Globals::prefix))
+        {
+        }
+
+        Globals(const Globals &) = delete;
+        Globals &operator=(const Globals &) = delete;
+
+        auto
+        conn_config() -> std::ranges::view auto
+        {
+            /* No special configuration is required for the 'globals' table. */
+            return std::views::empty<std::string_view>;
+        }
+
+        uint64_t
+        fetch_lsn(Connection &conn, Statement stmt_type)
+        {
+            Connection::StatementPtr stmt = conn.db_statement(stmt_type);
+            SQ_CHECK(sqlite3_step, stmt.get());
+            return sqlite3_column_int64(stmt.get(), 0);
+        }
+
+        uint64_t
+        make_next_lsn(Connection &conn)
+        {
+            return fetch_lsn(conn, Statement::MAKE_NEXT_LSN);
+        }
+
+        uint64_t
+        get_last_lsn(Connection &conn)
+        {
+            return fetch_lsn(conn, Statement::GET_LAST_LSN);
+        }
+
+        void
+        add_table_id(Connection &conn, uint64_t table_id)
+        {
+            Connection::StatementPtr stmt = conn.db_statement(Statement::ADD_TABLE_ID);
+            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 1, static_cast<sqlite3_int64>(table_id));
+            SQ_CHECK(sqlite3_step, stmt.get());
+        }
+
+        std::vector<uint64_t>
+        get_table_ids(Connection &conn)
+        {
+            Connection::StatementPtr stmt = conn.db_statement(Statement::GET_TABLE_IDS);
+            std::vector<uint64_t> table_ids;
+            while (SQ_CHECK(sqlite3_step, stmt.get()) == SQLITE_ROW) {
+                table_ids.push_back(static_cast<uint64_t>(sqlite3_column_int64(stmt.get(), 0)));
+            }
+            return table_ids;
+        }
+    };
+
+    struct Checkpoints : public Table<Checkpoints> {
+        constexpr static std::string_view prefix = "checkpoints";
+
+        enum Statement { PUT_CHECKPOINT, GET_CHECKPOINT, DELETE_CHECKPOINTS };
+
+        constexpr static std::string_view sql_statements[] = {
+          /*
+           * PUT_CHECKPOINT: Insert a new checkpoint.
+           */
+          R"(INSERT INTO checkpoints (lsn, timestamp, checkpoint_metadata)
+             VALUES (?, ?, ?);)",
+
+          /*
+           * GET_CHECKPOINT: Get the latest checkpoint (i.e., checkpoint with the highest lsn) if
+           * query lsn equals to WT_PAGE_LOG_LSN_MAX ( passed as parameter: ?2); otherwise get the
+           * checkpoint with the given lsn.
+           */
+          R"(SELECT lsn, timestamp, checkpoint_metadata
+             FROM checkpoints
+             WHERE (?1 = ?2 OR lsn = ?1)
+             ORDER BY
+                 lsn DESC,
+                 timestamp DESC
+             LIMIT 1;)",
+
+          /*
+           * DELETE_CHECKPOINTS: Delete all checkpoints with lsn greater than the given lsn.
+           */
+          R"(DELETE FROM checkpoints
+             WHERE lsn > ?;)"};
+
+        constexpr static std::string_view create_statements[] = {
           R"(CREATE TABLE IF NOT EXISTS checkpoints (
                 lsn INTEGER NOT NULL,
                 timestamp INTEGER NOT NULL,
                 checkpoint_metadata BLOB,
-                PRIMARY KEY (lsn, timestamp)
-            );)"};
+             PRIMARY KEY (lsn, timestamp));)"};
 
-        for (const char *sql : create_statements) {
-            SQL_CALL_CHECK(db, sqlite3_exec, db, sql, nullptr, nullptr, nullptr);
+        ~Checkpoints() = default;
+        Checkpoints(Config &cfg, const std::filesystem::path &home)
+            : Table<Checkpoints>(cfg, home / std::format("{}.db", Checkpoints::prefix))
+        {
         }
 
-        LOG_DEBUG("SQLite database schema initialized");
-    }
+        Checkpoints(const Checkpoints &) = delete;
+        Checkpoints &operator=(const Checkpoints &) = delete;
 
-    void
-    configure_connection(sqlite3 *db)
-    {
-        // The WAL journaling mode uses a write-ahead log instead of a rollback
-        // journal to implement transactions. This significantly improves performance.
-        SQL_CALL_CHECK(
-          db, sqlite3_exec, db, "PRAGMA journal_mode = WAL;", nullptr, nullptr, nullptr);
-
-        // Turn Synchronous mode OFF for better performance.
-        // We don't care about database corruption in case of OS crash or power failure.
-        SQL_CALL_CHECK(
-          db, sqlite3_exec, db, "PRAGMA synchronous = OFF;", nullptr, nullptr, nullptr);
-
-        // For temporary store use memory instead of disk.
-        SQL_CALL_CHECK(
-          db, sqlite3_exec, db, "PRAGMA temp_store = MEMORY;", nullptr, nullptr, nullptr);
-
-        // Uses memory mapping instead of read/write calls when the database
-        // is < mmap_size in bytes.
-        const uint64_t MMAP_SIZE = config.mmap_size_mb * 1_MB;
-        SQL_CALL_CHECK(db, sqlite3_exec, db,
-          std::format("PRAGMA mmap_size = {};", MMAP_SIZE).c_str(), nullptr, nullptr, nullptr);
-
-        // Increase page size to 16KB (default is 4KB). This improves performance
-        // for tables with BLOBs.
-        const uint64_t PAGE_SIZE = 16_KB;
-        SQL_CALL_CHECK(db, sqlite3_exec, db,
-          std::format("PRAGMA page_size = {};", PAGE_SIZE).c_str(), nullptr, nullptr, nullptr);
-
-        // Set cache size as configured.
-        // Cache size is specified in megabytes. Convert to number of pages.
-        const uint64_t CACHE_PAGES = (config.cache_size_mb * 1_MB) / PAGE_SIZE;
-        SQL_CALL_CHECK(db, sqlite3_exec, db,
-          std::format("PRAGMA cache_size = {};", CACHE_PAGES).c_str(), nullptr, nullptr, nullptr);
-
-        // Set busy timeout to 10 seconds.
-        SQL_CALL_CHECK(
-          db, sqlite3_exec, db, "PRAGMA busy_timeout = 10000;", nullptr, nullptr, nullptr);
-    }
-
-    void
-    resize_item(WT_ITEM *item, size_t new_size)
-    {
-        if (item->memsize < new_size) {
-            item->mem = realloc(item->mem, new_size);
-            if (item->mem == NULL)
-                LOG_AND_THROW("Failed to allocate memory for WT_ITEM");
-            item->memsize = new_size;
+        auto
+        conn_config() -> std::ranges::view auto
+        {
+            /* No special configuration is required for the 'checkpoints' table. */
+            return std::views::empty<std::string_view>;
         }
-        item->data = item->mem;
-        item->size = new_size;
+
+        void
+        put(Connection &conn, uint64_t lsn, uint64_t checkpoint_timestamp,
+          const WT_ITEM *checkpoint_metadata)
+        {
+            Connection::StatementPtr stmt = conn.db_statement(Statement::PUT_CHECKPOINT);
+            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 1, lsn);
+            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 2, checkpoint_timestamp);
+            SQ_CHECK(sqlite3_bind_blob, stmt.get(), 3, checkpoint_metadata->data,
+              checkpoint_metadata->size, SQLITE_STATIC);
+            SQ_CHECK(sqlite3_step, stmt.get());
+        }
+
+        int
+        get(Connection &conn, uint64_t &lsn, uint64_t *timestamp, WT_ITEM *checkpoint_metadata)
+        {
+            Connection::StatementPtr stmt = conn.db_statement(Statement::GET_CHECKPOINT);
+            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 1, static_cast<sqlite3_int64>(lsn));
+            SQ_CHECK(
+              sqlite3_bind_int64, stmt.get(), 2, static_cast<sqlite3_int64>(WT_PAGE_LOG_LSN_MAX));
+            int ret = SQ_CHECK(sqlite3_step, stmt.get());
+            if (ret == SQLITE_DONE) {
+                /* No checkpoint found */
+                if (timestamp)
+                    *timestamp = 0;
+
+                if (checkpoint_metadata) {
+                    checkpoint_metadata->data = nullptr;
+                    checkpoint_metadata->size = 0;
+                }
+
+                return WT_NOTFOUND;
+            }
+
+            lsn = sqlite3_column_int64(stmt.get(), 0);
+            if (timestamp)
+                *timestamp = sqlite3_column_int64(stmt.get(), 1);
+
+            if (checkpoint_metadata) {
+                const void *blob = sqlite3_column_blob(stmt.get(), 2);
+                int size = sqlite3_column_bytes(stmt.get(), 2);
+                fill_item(checkpoint_metadata, blob, static_cast<size_t>(size));
+            }
+
+            return 0;
+        }
+
+        void
+        delete_many(Connection &conn, uint64_t lsn)
+        {
+            Connection::StatementPtr stmt = conn.db_statement(Statement::DELETE_CHECKPOINTS);
+            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 1, static_cast<sqlite3_int64>(lsn));
+            SQ_CHECK(sqlite3_step, stmt.get());
+        }
+    };
+
+    struct Pages : public Table<Pages> {
+        constexpr static std::string_view prefix = "pages";
+
+        enum Statement {
+            PUT_PAGE,
+            GET_PAGE_IDS,
+            GET_FULL_PAGE_LSN,
+            GET_PAGE_INFOS,
+            GET_PAGES,
+            DELETE_PAGES
+        };
+
+        /*
+         * Our flags start at the 16th bit (0x10000u) to avoid conflicts with WT_PAGE_LOG_PUT_ARGS
+         * flags.
+         */
+        static constexpr uint32_t WT_PAGE_LOG_DISCARDED = 0x10000u;
+
+        constexpr static std::string_view sql_statements[] = {
+          /*
+           * PUT_PAGE: Insert new pages or replace write failures.
+           *
+           * When writing a new delta page, if a delta page already exists with the same (table_id,
+           * page_id, backlink_lsn), the existing page is treated as a write failure and replaced.
+           *
+           * This uniqueness constraint is enforced by a partial index that applies only to delta
+           * pages. See the CREATE TABLE statement for the 'pages' table.
+           */
+          R"(INSERT OR REPLACE INTO pages (
+                 table_id,
+                 page_id,
+                 lsn,
+                 backlink_lsn,
+                 base_lsn,
+                 flags,
+                 encryption,
+                 timestamp_materialized_us,
+                 page_data)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);)",
+
+          /*
+           * GET_PAGE_IDS: Get all unique page IDs for a given table that have their latest page
+           * record with LSN <= query LSN and not discarded.
+           */
+          R"(SELECT DISTINCT p1.page_id
+             FROM pages AS p1
+             WHERE p1.table_id = ?1
+                 AND p1.lsn <= ?2
+                 AND NOT EXISTS (
+                     SELECT 1
+                     FROM pages AS p2
+                     WHERE p2.table_id = p1.table_id
+                         AND p2.page_id = p1.page_id
+                         AND p2.lsn <= ?2
+                         AND p2.discarded = 1
+                 );)",
+
+          /*
+           * GET_FULL_PAGE_LSN: Get the LSN of the first non-discarded full page below the given
+           * LSN.
+           *
+           * The query LSN may belong to a delta page. Therefore, we find the corresponding full
+           * page LSN first. Then we look for the previous full page LSN. Assuming that given query
+           * LSN does not belong to discarded page.
+           *
+           * This is used with full page backlink verification.
+           */
+          R"(WITH full_page AS (
+               SELECT MAX(p0.lsn) AS lsn
+               FROM pages AS p0
+               WHERE p0.table_id = ?1
+                   AND p0.page_id = ?2
+                   AND p0.lsn <= ?3
+                   AND p0.delta = 0
+             )
+             SELECT MAX(p1.lsn)
+             FROM
+                 pages AS p1,
+                 full_page AS fp
+             WHERE p1.table_id = ?1
+                 AND p1.page_id = ?2
+                 AND p1.lsn < fp.lsn
+                 AND p1.delta = 0
+                 AND NOT EXISTS (
+                     SELECT 1
+                     FROM pages AS p2
+                     WHERE p2.table_id = p1.table_id
+                         AND p2.page_id = p1.page_id
+                         AND p2.lsn < fp.lsn
+                         AND p2.discarded = 1
+                 );)",
+
+          /*
+           * GET_PAGE_INFOS: Retrieve information about entire delta chain
+           * stopping at the first full page. The chain may include discarded page.
+           *
+           * This query uses a window function OVER to assign a group number
+           * to rows based on the 'delta' column. This is more performant
+           * than discovering full page in a separate query as it may only
+           * require a single scan over the data.
+           *
+           * The window function works as follows:
+           *
+           * First, the inner part:
+           *     CASE
+           *         WHEN delta = 0 THEN 1
+           *         ELSE 0
+           *     END
+           *
+           * This expression looks at each row one by one. For delta pages
+           * (where delta = 1), it produces a 0. For full pages (where
+           * delta = 0), it produces a 1.
+           *
+           * So, it's essentially a marker for the rows with full pages.
+           * We consider such rows as terminators.
+           *
+           * Next, the outer part:
+           *     SUM(...) OVER (ORDER BY lsn DESC) as page_group
+           *
+           * This expression takes the markers produced by the inner part
+           * and computes a running total (SUM) of these markers, ordered
+           * by LSN in descending order (from newest to oldest).
+           *
+           * This creates a cumulative count of how many "terminating" rows
+           * (delta = 0) have been seen so far.
+           *
+           * Example:
+           *
+           *   lsn | delta | inner CASE | page_group | explanation
+           *   ----+-------+------------+------------+------------
+           *   10  | 1     | 0          | 0          | Sum of (0)
+           *   9   | 1     | 0          | 0          | Sum of (0, 0)
+           *   8   | 1     | 0          | 0          | Sum of (0, 0, 0)
+           *   7   | 0     | 1          | 1          | Sum of (0, 0, 0, 1)
+           *   6   | 0     | 1          | 2          | Sum of (0, 0, 0, 1, 1)
+           *
+           * The entire chain of pages (lsn 10, 9, 8, 7) is returned, stopping
+           * at the first full page (lsn 7). The next full page (lsn 6) is
+           * not included because page_group becomes 2 and we explicitly check
+           * for that:
+           *     ...
+           *     WHERE page_group = 0
+           *         OR (page_group = 1 AND delta = 0)
+           *
+           * This condition ensures that we get all delta pages in the chain
+           * up to the first full page.
+           */
+          R"(WITH chained_pages AS (
+               SELECT
+                  table_id,
+                  page_id,
+                  lsn,
+                  backlink_lsn,
+                  base_lsn,
+                  flags,
+                  delta,
+                  SUM(CASE
+                          WHEN delta = 0 THEN 1
+                          ELSE 0
+                      END) OVER (ORDER BY lsn DESC) as page_group
+               FROM pages
+               WHERE table_id = ?
+                   AND page_id = ?
+                   AND lsn <= ?
+                   AND timestamp_materialized_us <= ?
+             )
+             SELECT
+                 table_id,
+                 page_id,
+                 lsn,
+                 backlink_lsn,
+                 base_lsn,
+                 flags
+             FROM chained_pages
+             WHERE page_group = 0
+                 OR (page_group = 1 AND delta = 0)
+             ORDER BY lsn DESC;)",
+
+          /*
+           * GET_PAGES: Simple selection of all pages below the given LSN. Verification of the delta
+           * chain and stopping at the terminating full page is done in code.
+           */
+          R"(SELECT
+                lsn,
+                backlink_lsn,
+                base_lsn,
+                flags,
+                encryption,
+                page_data
+             FROM pages
+             WHERE table_id = ?
+                 AND page_id = ?
+                 AND lsn <= ?
+                 AND timestamp_materialized_us <= ?
+             ORDER BY lsn DESC;)",
+
+          /* DELETE_PAGES: Remove all pages above the given LSN. */
+          R"(DELETE FROM pages
+             WHERE lsn > ?;)"};
+
+        /* These flags used below in generated columns for 'pages' table. */
+        static_assert(WT_PAGE_LOG_DELTA == 0x2, "WT_PAGE_LOG_DELTA value changed");
+        static_assert(WT_PAGE_LOG_DISCARDED == 0x10000, "WT_PAGE_LOG_DISCARDED value changed");
+
+        constexpr static std::string_view create_statements[] = {
+          R"(CREATE TABLE IF NOT EXISTS pages (
+                  table_id INTEGER NOT NULL,
+                  page_id INTEGER NOT NULL,
+                  lsn INTEGER NOT NULL,
+                  backlink_lsn INTEGER NOT NULL,
+                  base_lsn INTEGER NOT NULL,
+                  flags INTEGER NOT NULL,
+                  delta INTEGER AS ((flags & 0x2) != 0) VIRTUAL, -- WT_PAGE_LOG_DELTA
+                  discarded INTEGER AS ((flags & 0x10000) != 0) VIRTUAL, -- WT_PAGE_LOG_DISCARDED
+                  encryption STRING NOT NULL,
+                  timestamp_materialized_us INTEGER NOT NULL,
+                  page_data BLOB,
+               PRIMARY KEY (table_id, page_id, lsn)
+             );)",
+
+          /*
+           * This index exists for the case in which we have written a page
+           * delta and then need to write it again.
+           *
+           * This generally happens in eviction. We have a base page already written
+           * and we now try to evict it. We finished writing a delta to disk but
+           * then we fail the reconciliation. It is a delta so we cannot explicitly
+           * free the write with the same page id. After a while, we retry the
+           * eviction and this time we writes a delta based on the same base page.
+           * Thus this write will have the same backlink_lsn to the previous write.
+           *
+           * At this stage, there may be no checkpoint running so discarding the
+           * unfinished checkpoint doesn't help in this case. It is also possible
+           * that these two writes will be included in the same checkpoint that is
+           * not discarded.
+           *
+           * To gracefully handle write failures of delta pages we will keep
+           * track of the backlink_lsn within each delta chain. Tracking is done via
+           * a *partial* unique index on (table_id, page_id, backlink_lsn) for
+           * genuine delta pages only: delta=1 AND discarded=0.
+           * (Partial index can include only a subset of rows in the table.)
+           *
+           * The primary key for the table (table_id, page_id, lsn) does not help
+           * because lsn is always increasing, making each record unique.
+           *
+           * Including backlink_lsn in the primary key would not work because
+           * together with always increasing lsn the constraint is always satisfied.
+           *
+           * Hence, we need a separate unique index for delta pages only (excluding
+           * discarded pages, which are a special case).
+           *
+           * Example:
+           *
+           *   table_id | page_id | lsn | backlink_lsn | base_lsn | delta
+           *   ---------+---------+-----+--------------+----------+------
+           *       1    |   100   | 5   |      0       |   0      |   0
+           *       1    |   100   | 6   |      5       |   5      |   1
+           *       1    |   100   | 7   |      6       |   5      |   1
+           *       1    |   100   | 8   |      7       |   5      |   1    <-- write failure
+           *       1    |   100   | 9   |      7       |   5      |   1    <-- new delta page
+           *
+           * Suppose, the page with lsn=8 is a write failure. When a new delta page
+           * is written with (lsn=9, backlink_lsn=7, base_lsn=5), then it will
+           * conflict with the existing page with lsn=8 because they have the same
+           * (table_id, page_id, backlink_lsn). The partial index will ensure
+           * that there is at most one such delta page.
+           *
+           * The new page with lsn=9 will replace the failed page with lsn=8 because
+           * pages are inserted with 'INSERT OR REPLACE INTO pages'.
+           *
+           * See also PUT_PAGE statement.
+           */
+          R"(CREATE UNIQUE INDEX IF NOT EXISTS ux_delta
+             ON pages (table_id, page_id, backlink_lsn)
+             WHERE delta = 1 AND discarded = 0;)",
+        };
+
+        ~Pages() = default;
+        Pages(Config &cfg, const std::filesystem::path &home, uint64_t table_id)
+            : Table<Pages>(cfg, home / std::format("{}_{:06}.db", Pages::prefix, table_id))
+        {
+        }
+
+        Pages(const Pages &) = delete;
+        Pages &operator=(const Pages &) = delete;
+
+        auto
+        conn_config() -> std::ranges::view auto
+        {
+            const uint64_t MMAP_SIZE = config.mmap_size_mb * 1_MB;
+            const uint64_t PAGE_SIZE = 16_KB;
+            const uint64_t CACHE_PAGES = (config.cache_size_mb * 1_MB) / PAGE_SIZE;
+
+            const static std::string config_statements[] = {
+              /*
+               * Uses memory mapping instead of read/write calls when the database is < mmap_size in
+               * bytes.
+               */
+              std::format("PRAGMA mmap_size = {};", MMAP_SIZE),
+
+              /*
+               * Increase page size to 16KB (default is 4KB). This improves performance for tables
+               * with BLOBs.
+               */
+              std::format("PRAGMA page_size = {};", PAGE_SIZE),
+
+              /*
+               * Set cache size as configured. Cache size is specified in megabytes. Convert to
+               * number of pages.
+               */
+              std::format("PRAGMA cache_size = {};", CACHE_PAGES)};
+
+            return std::views::all(config_statements);
+        }
+
+        void
+        put(Connection &conn, uint64_t table_id, uint64_t page_id, uint64_t lsn,
+          WT_PAGE_LOG_PUT_ARGS *args, const WT_ITEM *buf)
+        {
+            Connection::StatementPtr stmt = conn.db_statement(Statement::PUT_PAGE);
+            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 1, static_cast<sqlite3_int64>(table_id));
+            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 2, static_cast<sqlite3_int64>(page_id));
+            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 3, static_cast<sqlite3_int64>(lsn));
+            SQ_CHECK(
+              sqlite3_bind_int64, stmt.get(), 4, static_cast<sqlite3_int64>(args->backlink_lsn));
+            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 5, static_cast<sqlite3_int64>(args->base_lsn));
+            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 6, static_cast<sqlite3_int64>(args->flags));
+            SQ_CHECK(sqlite3_bind_text, stmt.get(), 7, args->encryption.dek,
+              strlen(args->encryption.dek), SQLITE_STATIC);
+            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 8,
+              static_cast<sqlite3_int64>(now_us() + (config.materialization_delay_ms * 1ms / 1us)));
+            SQ_CHECK(sqlite3_bind_blob, stmt.get(), 9, buf->data, buf->size, SQLITE_STATIC);
+            SQ_CHECK(sqlite3_step, stmt.get());
+
+            if (config.verify) {
+                verify_chain(conn, table_id, page_id, lsn);
+            }
+        }
+
+        int
+        get_infos(Connection &conn, uint64_t table_id, uint64_t page_id, uint64_t lsn,
+          std::vector<PageInfo> &pages)
+        {
+            Connection::StatementPtr stmt = conn.db_statement(Statement::GET_PAGE_INFOS);
+            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 1, static_cast<sqlite3_int64>(table_id));
+            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 2, static_cast<sqlite3_int64>(page_id));
+            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 3, static_cast<sqlite3_int64>(lsn));
+            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 4, static_cast<sqlite3_int64>(now_us()));
+
+            pages.clear();
+            while (SQ_CHECK(sqlite3_step, stmt.get()) == SQLITE_ROW) {
+                pages.emplace_back(
+                  PageInfo{.table_id = static_cast<uint64_t>(sqlite3_column_int64(stmt.get(), 0)),
+                    .page_id = static_cast<uint64_t>(sqlite3_column_int64(stmt.get(), 1)),
+                    .lsn = static_cast<uint64_t>(sqlite3_column_int64(stmt.get(), 2)),
+                    .backlink_lsn = static_cast<uint64_t>(sqlite3_column_int64(stmt.get(), 3)),
+                    .base_lsn = static_cast<uint64_t>(sqlite3_column_int64(stmt.get(), 4)),
+                    .flags = static_cast<uint32_t>(sqlite3_column_int64(stmt.get(), 5)),
+                    .encryption = WT_PAGE_LOG_ENCRYPTION{}});
+            }
+
+            return 0;
+        }
+
+        int
+        get(Connection &conn, uint64_t table_id, uint64_t page_id, WT_PAGE_LOG_GET_ARGS *args,
+          uint32_t *flags, WT_ITEM *results_array, uint32_t *results_count)
+        {
+            Connection::StatementPtr stmt = conn.db_statement(Statement::GET_PAGES);
+            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 1, static_cast<sqlite3_int64>(table_id));
+            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 2, static_cast<sqlite3_int64>(page_id));
+            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 3, static_cast<sqlite3_int64>(args->lsn));
+            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 4, static_cast<sqlite3_int64>(now_us()));
+
+            auto make_page_info = [](uint64_t table_id, uint64_t page_id, sqlite3_stmt *stmt) {
+                PageInfo page{.table_id = table_id,
+                  .page_id = page_id,
+                  .lsn = static_cast<uint64_t>(sqlite3_column_int64(stmt, 0)),
+                  .backlink_lsn = static_cast<uint64_t>(sqlite3_column_int64(stmt, 1)),
+                  .base_lsn = static_cast<uint64_t>(sqlite3_column_int64(stmt, 2)),
+                  .flags = static_cast<uint32_t>(sqlite3_column_int64(stmt, 3)),
+                  .encryption = WT_PAGE_LOG_ENCRYPTION{}};
+
+                const char *enc = reinterpret_cast<const char *>(sqlite3_column_text(stmt, 4));
+                strncpy(page.encryption.dek, enc ? enc : "", sizeof(page.encryption.dek));
+
+                return std::move(page);
+            };
+
+            /*
+             * Note: Results are ordered by lsn DESC, so the first row is the most recent.
+             * In case of a delta chain, deltas (D) appear first, followed by the full page (B):
+             *     D2, D1, B
+             * We will reverse the order before returning to the caller:
+             *     B, D1, D2
+             */
+            uint32_t count = 0;
+            int ret = 0;
+            std::vector<PageInfo> pages;
+
+            while (
+              (ret = SQ_CHECK(sqlite3_step, stmt.get())) == SQLITE_ROW && count < *results_count) {
+                pages.push_back(make_page_info(table_id, page_id, stmt.get()));
+                PageInfo &page = pages.back();
+
+                if (page.flags & WT_PAGE_LOG_DISCARDED) {
+                    LOG_AND_THROW("Got discarded page: {}", page);
+                }
+
+                const void *blob = sqlite3_column_blob(stmt.get(), 5);
+                int size = sqlite3_column_bytes(stmt.get(), 5);
+                fill_item(&results_array[count], blob, static_cast<size_t>(size));
+
+                /* Continue to next row */
+                count++;
+
+                if (!(page.flags & WT_PAGE_LOG_DELTA)) {
+                    /* Stop if this is a full page */
+                    ret = SQLITE_DONE;
+                    break;
+                }
+            }
+            /* By now ret is either SQLITE_DONE or SQLITE_ROW. */
+
+            /* SQLITE_ROW means there are more rows available than space in results_array. */
+            if (ret == SQLITE_ROW) {
+                LOG_AND_THROW("Insufficient space in results_array: {}", *results_count);
+            }
+
+            /* Verify full page, if configured */
+            const uint64_t prev_full_lsn =
+              config.verify ? get_prev_full_page_lsn(conn, table_id, page_id, args->lsn) : 0;
+            /* Always verify the delta chain when retrieving pages, even if config.verify=false. */
+            verify_chain(pages, prev_full_lsn);
+
+            /* Fill args from the first found page. (It will be the last in returned array.) */
+            uint64_t save_lsn = args->lsn;
+            memset(args, 0, sizeof(*args));
+            args->lsn = save_lsn; /* Preserve the requested LSN */
+            if (!pages.empty()) {
+                const PageInfo &page = pages.front();
+                args->backlink_lsn = page.backlink_lsn;
+                args->base_lsn = page.base_lsn;
+                args->encryption = page.encryption;
+                assert(flags != nullptr);
+                *flags = page.flags;
+            }
+
+            /* Reverse the results array to have the full page first, followed by deltas. */
+            std::reverse(results_array, results_array + count);
+            *results_count = count;
+
+            return 0;
+        }
+
+        /* Invalid LSN means "no check required". */
+        void
+        verify_chain(const std::vector<PageInfo> &pages, uint64_t prev_full_lsn = INVALID_LSN)
+        {
+            PageInfo prev{};
+            PageInfo full{};
+            PageInfo discarded{};
+
+            auto verify_full = [&](const PageInfo &page) {
+                if (full.lsn != 0) {
+                    LOG_AND_THROW("Multiple full pages in chain: {}, {}", full, page);
+                }
+
+                if (page.base_lsn != 0) {
+                    LOG_AND_THROW("Full page base_lsn must be 0: {}", page);
+                }
+
+                if (prev_full_lsn != INVALID_LSN && page.backlink_lsn != prev_full_lsn) {
+                    LOG_AND_THROW(
+                      "Full page backlink_lsn mismatch: {}, expected: {}", page, prev_full_lsn);
+                }
+
+                if (page.flags & WT_PAGE_LOG_DISCARDED) {
+                    LOG_AND_THROW("Full page cannot be discarded: {}", page);
+                }
+
+                if (discarded.lsn != 0) {
+                    LOG_AND_THROW(
+                      "Discarded page cannot be followed by another page: {}, {}", discarded, page);
+                }
+
+                full = page;
+            };
+
+            auto verify_delta = [&](const PageInfo &page) {
+                assert(prev.lsn != 0); /* Cannot be the first page in the chain */
+
+                if (full.lsn == 0) {
+                    LOG_AND_THROW("Delta page without full page: {}", page);
+                }
+
+                if (full.lsn != page.base_lsn) {
+                    LOG_AND_THROW("Delta page base_lsn mismatch: {}, full page: {}", page, full);
+                }
+
+                /* Discarded pages can backlink to any page that we've seen in the chain. */
+                if (!(page.flags & WT_PAGE_LOG_DISCARDED) && page.backlink_lsn != prev.lsn) {
+                    LOG_AND_THROW(
+                      "Delta chain backlink_lsn mismatch: {}, previous page: {}", page, prev);
+                }
+
+                if (page.flags & WT_PAGE_LOG_DISCARDED) {
+                    if (discarded.lsn != 0) {
+                        LOG_AND_THROW("Multiple discarded pages in chain: {}, {}", discarded, page);
+                    }
+                    discarded = page;
+                } else if (discarded.lsn != 0) {
+                    LOG_AND_THROW(
+                      "Discarded page cannot be followed by another page: {}, {}", discarded, page);
+                }
+            };
+
+            auto verify_page = [&](const PageInfo &page) {
+                if (page.flags & WT_PAGE_LOG_DELTA)
+                    verify_delta(page);
+                else
+                    verify_full(page);
+                prev = page;
+            };
+
+            /* Iterate in reverse order to validate the chain from full page. */
+            std::for_each(pages.rbegin(), pages.rend(), verify_page);
+
+            /* Verify discarded page separately because it can backlink to any page in the chain. */
+            if (discarded.lsn != 0) {
+                auto found_it = std::ranges::find_if(pages,
+                  [&discarded](const PageInfo &p) { return p.lsn == discarded.backlink_lsn; });
+                if (found_it == pages.end()) {
+                    LOG_AND_THROW("Discarded page backlink_lsn not found in chain: {}", discarded);
+                }
+            }
+        }
+
+        /*
+         * Verify the entire page chain for consistency.
+         *
+         * The pages are expected to be ordered by lsn DESC (newest first).
+         * The chain may include a single discarded page as the first page,
+         * zero or more deltas, and one terminating full page.
+         * Discarded pages can backlink to any page in the chain.
+         *
+         * Example of a valid chain:
+         *     Discarded (lsn=10, backlink_lsn=8, base_lsn=7, flags=DISCARDED|DELTA)
+         *     Delta     (lsn=9,  backlink_lsn=8, base_lsn=7, flags=DELTA)
+         *     Delta     (lsn=8,  backlink_lsn=7, base_lsn=7, flags=DELTA)
+         *     Full      (lsn=7,  backlink_lsn=0, base_lsn=0, flags=0)
+         *
+         * Throws on error.
+         */
+        void
+        verify_chain(Connection &conn, uint64_t table_id, uint64_t page_id, uint64_t lsn)
+        {
+            std::vector<PageInfo> pages;
+            get_infos(conn, table_id, page_id, lsn, pages);
+            if (pages.size() == 0) {
+                LOG_AND_THROW(
+                  "No pages found for table_id={}, page_id={} at lsn<={}", table_id, page_id, lsn);
+            }
+
+            const uint64_t prev_full_lsn = get_prev_full_page_lsn(conn, table_id, page_id, lsn);
+
+            verify_chain(pages, prev_full_lsn);
+        }
+
+        int
+        get_ids(Connection &conn, uint64_t checkpoint_lsn, uint64_t table_id, WT_ITEM *page_ids,
+          size_t *page_count)
+        {
+            Connection::StatementPtr stmt = conn.db_statement(Statement::GET_PAGE_IDS);
+            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 1, static_cast<sqlite3_int64>(table_id));
+            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 2, static_cast<sqlite3_int64>(checkpoint_lsn));
+
+            std::vector<uint64_t> ids;
+            while (SQ_CHECK(sqlite3_step, stmt.get()) == SQLITE_ROW) {
+                ids.push_back(sqlite3_column_int64(stmt.get(), 0));
+            }
+            LOG_DEBUG("Found {} page IDs for table_id={} at checkpoint_lsn={}", ids.size(),
+              table_id, checkpoint_lsn);
+            LOG_DIAG("Page IDs: {}", join(ids, ", "));
+
+            *page_count = ids.size();
+            if (ids.size() > 0) {
+                fill_item(page_ids, ids.data(), ids.size() * sizeof(uint64_t));
+            }
+
+            return 0;
+        }
+
+        uint64_t
+        get_prev_full_page_lsn(Connection &conn, uint64_t table_id, uint64_t page_id, uint64_t lsn)
+        {
+            Connection::StatementPtr stmt = conn.db_statement(Statement::GET_FULL_PAGE_LSN);
+            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 1, static_cast<sqlite3_int64>(table_id));
+            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 2, static_cast<sqlite3_int64>(page_id));
+            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 3, static_cast<sqlite3_int64>(lsn));
+
+            int ret = SQ_CHECK(sqlite3_step, stmt.get());
+            if (ret == SQLITE_DONE) {
+                return 0; /* No previous full page found */
+            }
+
+            return static_cast<uint64_t>(sqlite3_column_int64(stmt.get(), 0));
+        }
+
+        void
+        discard(Connection &conn, uint64_t table_id, uint64_t page_id, uint64_t lsn,
+          WT_PAGE_LOG_DISCARD_ARGS *args)
+        {
+            if (args->flags != 0)
+                LOG_AND_THROW("Non-zero flags: {:#x}", args->flags);
+
+            WT_PAGE_LOG_PUT_ARGS put_args{};
+            put_args.backlink_lsn = args->backlink_lsn;
+            put_args.base_lsn = args->base_lsn;
+            /* Discarded pages are deltas */
+            put_args.flags = WT_PAGE_LOG_DELTA | WT_PAGE_LOG_DISCARDED;
+
+            WT_ITEM dummy_page{};
+            put(conn, table_id, page_id, lsn, &put_args, &dummy_page);
+            args->lsn = put_args.lsn;
+
+            LOG_DEBUG(
+              "Discarded page_id={} at lsn={}, backlink_lsn={}, base_lsn={}; discarded_lsn={}",
+              page_id, lsn, args->backlink_lsn, args->base_lsn, args->lsn);
+        }
+
+        void
+        delete_many(Connection &conn, uint64_t lsn)
+        {
+            LOG_DEBUG("Deleting pages with lsn > {}", lsn);
+            Connection::StatementPtr stmt = conn.db_statement(Statement::DELETE_PAGES);
+            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 1, static_cast<sqlite3_int64>(lsn));
+            SQ_CHECK(sqlite3_step, stmt.get());
+        }
+    };
+
+    Globals globals;
+    Checkpoints checkpoints;
+
+    std::unordered_map<uint64_t, std::unique_ptr<Pages>> pages;
+    std::shared_mutex pages_access; /* protects 'pages' map */
+
+    /* Enables exclusive access to entire storage */
+    std::shared_mutex store_access;
+
+    /* Stats */
+    std::atomic_ullong object_puts; /* (What would be) network writes */
+    std::atomic_ullong object_gets; /* (What would be) network requests for data */
+
+public:
+    ~Storage() = default;
+    Storage(Config &cfg, const std::filesystem::path &dbp)
+        : config(cfg), db_home(dbp), globals(cfg, db_home), checkpoints(cfg, db_home)
+    {
     }
 
-    void
-    fill_item(WT_ITEM *item, const void *data, size_t size)
+    Storage(const Storage &) = delete;
+    Storage &operator=(const Storage &) = delete;
+
+private:
+    enum AccessMode { READ, WRITE };
+
+    template <typename TableType, AccessMode Mode> class Access {
+        Config &config;
+        std::shared_lock<std::shared_mutex> store_lock;
+        std::conditional_t<Mode == AccessMode::READ, std::shared_lock<std::shared_mutex>,
+          std::unique_lock<std::shared_mutex>>
+          table_lock;
+
+    public:
+        TableType &table;
+        Connection &conn;
+
+        ~Access() = default;
+
+        Access(Config &c, std::shared_mutex &store_access, TableType &tbl)
+            : config(c), store_lock(store_access), table_lock(tbl.access), table(tbl),
+              conn(table.conn())
+        {
+        }
+
+        Access(const Access &) = delete;
+        Access &operator=(const Access &) = delete;
+
+        void
+        release()
+        {
+            table_lock.unlock();
+            store_lock.unlock();
+        }
+    };
+
+    Pages &
+    fetch_pages_table(uint64_t table_id)
     {
-        memset(item, 0, sizeof(WT_ITEM));
-        resize_item(item, size);
-        if (size > 0 && data != nullptr)
-            memcpy(item->mem, data, size);
+        std::unique_lock write_lock(pages_access);
+        auto [it, inserted] =
+          pages.try_emplace(table_id, std::make_unique<Pages>(config, db_home, table_id));
+        return *(it->second);
     }
 
-    // Compute a random jitter (milliseconds) around an average,
-    // uniformly in [0.5 * avg_ms, 1.5 * avg_ms].
-    static uint64_t
-    jitter_ms(uint32_t avg_ms)
+    template <typename TableType>
+    TableType &
+    get_table(uint64_t id = 0)
     {
-        thread_local static std::mt19937_64 rng;
-        uint64_t min_ms = avg_ms / 2;          // 0.5 * avg
-        uint64_t max_ms = avg_ms + avg_ms / 2; // 1.5 * avg
-        std::uniform_int_distribution<uint64_t> dist(min_ms, max_ms);
-        return dist(rng);
+        if constexpr (std::is_same_v<TableType, Globals>) {
+            return globals;
+        } else if constexpr (std::is_same_v<TableType, Checkpoints>) {
+            return checkpoints;
+        } else if constexpr (std::is_same_v<TableType, Pages>) {
+            std::shared_lock read_lock(pages_access);
+            auto it = pages.find(id);
+            if (it == pages.end()) {
+                LOG_AND_THROW("Pages table not found for table ID {}", id);
+            }
+            return *(it->second);
+        } else {
+            static_assert(std::false_type::value, "Unknown category type in get_table");
+        }
+    }
+
+    template <typename TableType, AccessMode Mode>
+    Access<TableType, Mode>
+    request(uint64_t id = 0)
+    {
+        TableType &table = get_table<TableType>(id);
+        return Access<TableType, Mode>{config, store_access, table};
     }
 
 public:
-    // Artificial delay or simulated network error during an object transfer.
+    void
+    close()
+    {
+        std::unique_lock write_lock(store_access);
+        std::ranges::for_each(pages, [](auto &kv) { kv.second->close(); });
+        pages.clear();
+
+        checkpoints.close();
+        globals.close();
+    }
+
+    /* Artificial delay or simulated network error during an object transfer. */
     void
     simulate_unstable_network()
     {
@@ -1270,490 +1846,143 @@ public:
         simulate(config.force_error, config.error_ms, true);
     }
 
-    void
-    close()
+    uint64_t
+    make_next_lsn()
     {
-        std::ranges::for_each(connections, [](auto &pair) { pair.second->close(); });
-        connections.clear();
-    }
+        auto acc = request<Globals, AccessMode::WRITE>();
+        const uint64_t lsn = acc.table.make_next_lsn(acc.conn);
 
-    void
-    rollback_transaction(Connection &conn)
-    {
-        StatementPtr stmt = conn.db_statement(Statement::ROLLBACK);
-        // rollback performed in d'tors, so no throw
-        SQL_CALL_CHECK_NO_THROW(conn.db_instance(), sqlite3_step, stmt.get());
-    }
-
-    // using Transaction = std::unique_ptr<Storage, std::function<void(Storage*)>>;
-    struct Transaction {
-        Connection &conn;
-        Storage *store;
-        std::source_location &loc;
-
-        ~Transaction()
-        {
-            if (store) {
-                store->rollback_transaction(conn);
-                // DBG
-                store->db_access.release();
-                // DBG
-            }
-            store = nullptr;
-        }
-
-        Transaction(Connection &c, Storage *s, std::source_location &l) : conn(c), store(s), loc(l)
-        {
-        }
-
-        void
-        release()
-        {
-            // DBG
-            store->db_access.release();
-            // DBG
-            store = nullptr;
-            loc = std::source_location();
-        }
-    };
-
-#define SQ_CHECK(func, ...) SQL_CALL_CHECK(conn.db_instance(), func, __VA_ARGS__)
-
-    /* Transaction begin_transaction( ) {
-        StatementPtr stmt = db_statement(Statement::BEGIN);
-        SQ_CHECK(sqlite3_step, stmt.get());
-        return Transaction{this, [](Storage* s) { s->rollback_transaction(); }};
-    } */
-    Transaction
-    begin_transaction(std::source_location loc = std::source_location::current())
-    {
-        thread_local static std::source_location current_txn;
-        if (current_txn.line() != 0) {
-            LOG_AND_THROW("Transaction already in progress! Started at: {}:{}: {}",
-              current_txn.file_name(), current_txn.line(), current_txn.function_name());
-        }
-        current_txn = loc;
-
-        // DBG
-        db_access.acquire();
-        // DBG
-
-        Connection &conn = db_conn();
-        StatementPtr stmt = conn.db_statement(Statement::BEGIN);
-        SQ_CHECK(sqlite3_step, stmt.get());
-        // return Transaction{this, [](Storage* s) { s->rollback_transaction(); }};
-        return Transaction{conn, this, current_txn};
-    }
-
-    void
-    commit_transaction(Transaction &txn)
-    {
-        StatementPtr stmt = txn.conn.db_statement(Statement::COMMIT);
-        SQL_CALL_CHECK(txn.conn.db_instance(), sqlite3_step, stmt.get());
-        LOG_SQL_TRACE("{} records affected", sqlite3_changes(txn.conn.db_instance()));
-        txn.release();
+        return lsn;
     }
 
     uint64_t
-    get_lsn(Connection &conn, Statement stmt_type)
+    get_last_lsn()
     {
-        StatementPtr stmt = conn.db_statement(stmt_type);
-        SQ_CHECK(sqlite3_step, stmt.get());
-        return sqlite3_column_int64(stmt.get(), 0);
-    }
+        auto acc = request<Globals, AccessMode::READ>();
+        const uint64_t lsn = acc.table.get_last_lsn(acc.conn);
 
-    uint64_t
-    get_next_lsn(Connection &conn)
-    {
-        return get_lsn(conn, Statement::GET_NEXT_LSN);
-    }
-
-    uint64_t
-    get_last_lsn(Connection &conn)
-    {
-        return get_lsn(conn, Statement::GET_LAST_LSN);
+        return lsn;
     }
 
     void
-    put_checkpoint(Connection &conn, uint64_t lsn, uint64_t checkpoint_timestamp,
-      const WT_ITEM *checkpoint_metadata)
+    add_table_id(uint64_t table_id)
     {
-        StatementPtr stmt = conn.db_statement(Statement::PUT_CHECKPOINT);
-        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 1, lsn);
-        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 2, checkpoint_timestamp);
-        SQ_CHECK(sqlite3_bind_blob, stmt.get(), 3, checkpoint_metadata->data,
-          checkpoint_metadata->size, SQLITE_STATIC);
-        SQ_CHECK(sqlite3_step, stmt.get());
+        /* Ensure Pages table exists for this table ID */
+        fetch_pages_table(table_id);
+
+        /*
+         * Add table ID to global table. Adding more than once is OK. The table index will ensure
+         * uniqueness.
+         */
+        auto acc = request<Globals, AccessMode::WRITE>();
+        acc.table.add_table_id(acc.conn, table_id);
+    }
+
+    std::vector<uint64_t>
+    get_table_ids()
+    {
+        auto acc = request<Globals, AccessMode::READ>();
+
+        return acc.table.get_table_ids(acc.conn);
+    }
+
+    void
+    put_checkpoint(uint64_t lsn, uint64_t checkpoint_timestamp, const WT_ITEM *checkpoint_metadata)
+    {
+        auto acc = request<Checkpoints, AccessMode::WRITE>();
+        acc.table.put(acc.conn, lsn, checkpoint_timestamp, checkpoint_metadata);
     }
 
     int
-    get_checkpoint(
-      Connection &conn, uint64_t &lsn, uint64_t *timestamp, WT_ITEM *checkpoint_metadata)
+    get_checkpoint(uint64_t &lsn, uint64_t *timestamp, WT_ITEM *checkpoint_metadata)
     {
-        StatementPtr stmt = conn.db_statement(Statement::GET_CHECKPOINT);
-        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 1, static_cast<sqlite3_int64>(lsn));
-        SQ_CHECK(
-          sqlite3_bind_int64, stmt.get(), 2, static_cast<sqlite3_int64>(WT_PAGE_LOG_LSN_MAX));
-        int ret = SQ_CHECK(sqlite3_step, stmt.get());
-        if (ret == SQLITE_DONE) {
-            // No checkpoint found
-            if (timestamp)
-                *timestamp = 0;
-            if (checkpoint_metadata) {
-                checkpoint_metadata->data = nullptr;
-                checkpoint_metadata->size = 0;
-            }
-            return WT_NOTFOUND;
-        }
+        auto acc = request<Checkpoints, AccessMode::READ>();
 
-        lsn = sqlite3_column_int64(stmt.get(), 0);
-        if (timestamp)
-            *timestamp = sqlite3_column_int64(stmt.get(), 1);
-        if (checkpoint_metadata) {
-            const void *blob = sqlite3_column_blob(stmt.get(), 2);
-            int size = sqlite3_column_bytes(stmt.get(), 2);
-            fill_item(checkpoint_metadata, blob, static_cast<size_t>(size));
-        }
-        return 0;
+        return acc.table.get(acc.conn, lsn, timestamp, checkpoint_metadata);
     }
 
     void
-    delete_checkpoints(Connection &conn, uint64_t lsn)
+    delete_checkpoints(uint64_t lsn)
     {
-        StatementPtr stmt = conn.db_statement(Statement::DELETE_CHECKPOINTS);
-        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 1, static_cast<sqlite3_int64>(lsn));
-        SQ_CHECK(sqlite3_step, stmt.get());
+        auto acc = request<Checkpoints, AccessMode::WRITE>();
+        acc.table.delete_many(acc.conn, lsn);
     }
 
     void
-    put_page(Connection &conn, uint64_t table_id, uint64_t page_id, uint64_t lsn,
-      WT_PAGE_LOG_PUT_ARGS *args, const WT_ITEM *buf)
+    put_page(uint64_t table_id, uint64_t page_id, uint64_t lsn, WT_PAGE_LOG_PUT_ARGS *args,
+      const WT_ITEM *buf)
     {
-        StatementPtr stmt = conn.db_statement(Statement::PUT_PAGE);
-        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 1, static_cast<sqlite3_int64>(table_id));
-        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 2, static_cast<sqlite3_int64>(page_id));
-        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 3, static_cast<sqlite3_int64>(lsn));
-        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 4, static_cast<sqlite3_int64>(args->backlink_lsn));
-        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 5, static_cast<sqlite3_int64>(args->base_lsn));
-        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 6, static_cast<sqlite3_int64>(args->flags));
-        SQ_CHECK(sqlite3_bind_text, stmt.get(), 7, args->encryption.dek,
-          strlen(args->encryption.dek), SQLITE_STATIC);
-        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 8,
-          static_cast<sqlite3_int64>(now_us() + (config.materialization_delay_ms * 1ms / 1us)));
-        SQ_CHECK(sqlite3_bind_blob, stmt.get(), 9, buf->data, buf->size, SQLITE_STATIC);
-        SQ_CHECK(sqlite3_step, stmt.get());
-
+        auto acc = request<Pages, AccessMode::WRITE>(table_id);
+        acc.table.put(acc.conn, table_id, page_id, lsn, args, buf);
         object_puts++;
     }
 
     int
-    get_page_infos(Connection &conn, uint64_t table_id, uint64_t page_id, uint64_t lsn,
-      std::vector<PageInfo> &pages)
+    get_pages(uint64_t table_id, uint64_t page_id, WT_PAGE_LOG_GET_ARGS *args, uint32_t *flags,
+      WT_ITEM *results_array, uint32_t *results_count)
     {
-        StatementPtr stmt = conn.db_statement(Statement::GET_PAGE_INFOS);
-        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 1, static_cast<sqlite3_int64>(table_id));
-        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 2, static_cast<sqlite3_int64>(page_id));
-        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 3, static_cast<sqlite3_int64>(lsn));
-        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 4, static_cast<sqlite3_int64>(now_us()));
+        auto acc = request<Pages, AccessMode::READ>(table_id);
+        const int ret =
+          acc.table.get(acc.conn, table_id, page_id, args, flags, results_array, results_count);
+        acc.release();
 
-        pages.clear();
-        while (SQ_CHECK(sqlite3_step, stmt.get()) == SQLITE_ROW) {
-            pages.emplace_back(
-              PageInfo{.table_id = static_cast<uint64_t>(sqlite3_column_int64(stmt.get(), 0)),
-                .page_id = static_cast<uint64_t>(sqlite3_column_int64(stmt.get(), 1)),
-                .lsn = static_cast<uint64_t>(sqlite3_column_int64(stmt.get(), 2)),
-                .backlink_lsn = static_cast<uint64_t>(sqlite3_column_int64(stmt.get(), 3)),
-                .base_lsn = static_cast<uint64_t>(sqlite3_column_int64(stmt.get(), 4)),
-                .flags = static_cast<uint32_t>(sqlite3_column_int64(stmt.get(), 5)),
-                .encryption = WT_PAGE_LOG_ENCRYPTION{}});
-        }
+        assert(results_count != nullptr);
+        object_gets += *results_count;
 
-        return 0;
+        return ret;
     }
 
-    int
-    get_pages(Connection &conn, uint64_t table_id, uint64_t page_id, WT_PAGE_LOG_GET_ARGS *args,
-      uint32_t *flags, WT_ITEM *results_array, uint32_t *results_count)
+    void
+    get_page_ids(uint64_t checkpoint_lsn, uint64_t table_id, WT_ITEM *page_ids, size_t *page_count)
     {
-        StatementPtr stmt = conn.db_statement(Statement::GET_PAGES);
-        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 1, static_cast<sqlite3_int64>(table_id));
-        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 2, static_cast<sqlite3_int64>(page_id));
-        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 3, static_cast<sqlite3_int64>(args->lsn));
-        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 4, static_cast<sqlite3_int64>(now_us()));
+        auto acc = request<Pages, AccessMode::READ>(table_id);
+        acc.table.get_ids(acc.conn, checkpoint_lsn, table_id, page_ids, page_count);
+    }
 
-        auto make_page_info = [](uint64_t table_id, uint64_t page_id, sqlite3_stmt *stmt) {
-            PageInfo page{.table_id = table_id,
-              .page_id = page_id,
-              .lsn = static_cast<uint64_t>(sqlite3_column_int64(stmt, 0)),
-              .backlink_lsn = static_cast<uint64_t>(sqlite3_column_int64(stmt, 1)),
-              .base_lsn = static_cast<uint64_t>(sqlite3_column_int64(stmt, 2)),
-              .flags = static_cast<uint32_t>(sqlite3_column_int64(stmt, 3)),
-              .encryption = WT_PAGE_LOG_ENCRYPTION{}};
+    void
+    discard_page(uint64_t table_id, uint64_t page_id, uint64_t lsn, WT_PAGE_LOG_DISCARD_ARGS *args)
+    {
+        auto acc = request<Pages, AccessMode::WRITE>(table_id);
+        acc.table.discard(acc.conn, table_id, page_id, lsn, args);
+    }
 
-            const char *enc = reinterpret_cast<const char *>(sqlite3_column_text(stmt, 4));
-            strncpy(page.encryption.dek, enc ? enc : "", sizeof(page.encryption.dek));
+    void
+    abandon_checkpoint(uint64_t checkpoint_lsn)
+    {
+        /* Ensure exclusive access to storage during since we update multiple tables. */
+        std::unique_lock write_lock(store_access);
 
-            return std::move(page);
-        };
+        /* Using regular Access would block, so we update tables directly here. */
 
-        /* !!! Note: Results are ordered by lsn DESC, so the first row is the most recent.
-         In case of a delta chain, deltas (D) appear first, followed by the full page (B):
-              D2, D1, B
-         We will reverse the order before returning to the caller:
-              B, D1, D2
-        */
-        uint32_t count = 0;
+        Connection &chkp_conn = checkpoints.conn();
         int ret = 0;
-        std::vector<PageInfo> pages;
-
-        while ((ret = SQ_CHECK(sqlite3_step, stmt.get())) == SQLITE_ROW && count < *results_count) {
-            pages.push_back(make_page_info(table_id, page_id, stmt.get()));
-            PageInfo &page = pages.back();
-
-            if (page.flags & WT_PAGE_LOG_DISCARDED) {
-                LOG_AND_THROW("Got discarded page: {}", page);
-            }
-
-            const void *blob = sqlite3_column_blob(stmt.get(), 5);
-            int size = sqlite3_column_bytes(stmt.get(), 5);
-            fill_item(&results_array[count], blob, static_cast<size_t>(size));
-
-            // Continue to next row
-            count++;
-
-            if (!(page.flags & WT_PAGE_LOG_DELTA)) {
-                // Stop if this is a full page
-                ret = SQLITE_DONE;
-                break;
-            }
-        }
-        // By now ret is either SQLITE_DONE or SQLITE_ROW.
-
-        // SQLITE_ROW means there are more rows available than space in results_array.
-        if (ret == SQLITE_ROW) {
-            LOG_AND_THROW("Insufficient space in results_array: {}", *results_count);
+        if (checkpoint_lsn == WT_PAGE_LOG_LSN_MAX) {
+            ret = checkpoints.get(chkp_conn, checkpoint_lsn, nullptr, nullptr);
         }
 
-        // Verify full page, if configured
-        const uint64_t prev_full_lsn =
-          config.verify ? get_prev_full_page_lsn(conn, table_id, page_id, args->lsn) : 0;
-        // Always verify the delta chain when retrieving pages, even if config.verify=false.
-        verify_chain(pages, prev_full_lsn);
-
-        // Fill args from the first found page. (It will be the last in returned array.)
-        uint64_t save_lsn = args->lsn;
-        memset(args, 0, sizeof(*args));
-        args->lsn = save_lsn; // Preserve the requested LSN
-        if (!pages.empty()) {
-            const PageInfo &page = pages.front();
-            args->backlink_lsn = page.backlink_lsn;
-            args->base_lsn = page.base_lsn;
-            args->encryption = page.encryption;
-            assert(flags != nullptr);
-            *flags = page.flags;
+        if (ret == WT_NOTFOUND) {
+            LOG_DEBUG("No checkpoint found to abandon; lsn = {}", checkpoint_lsn);
+            return;
         }
 
-        // Reverse the results array to have the full page first, followed by deltas.
-        std::reverse(results_array, results_array + count);
-        *results_count = count;
-        object_gets += count;
+        /* Note: global LSN counter is not decremented */
 
-        return 0;
-    }
+        checkpoints.delete_many(chkp_conn, checkpoint_lsn);
 
-    // UINT64_MAX is an invalid LSN, meaning "no check required".
-    void
-    verify_chain(const std::vector<PageInfo> &pages, uint64_t prev_full_lsn = UINT64_MAX)
-    {
-        PageInfo prev{};
-        PageInfo full{};
-        PageInfo discarded{};
-
-        auto verify_full = [&](const PageInfo &page) {
-            if (full.lsn != 0) {
-                LOG_AND_THROW("Multiple full pages in chain: {}, {}", full, page);
-            }
-
-            if (page.base_lsn != 0) {
-                LOG_AND_THROW("Full page base_lsn must be 0: {}", page);
-            }
-
-            if (prev_full_lsn != UINT64_MAX && page.backlink_lsn != prev_full_lsn) {
-                LOG_AND_THROW(
-                  "Full page backlink_lsn mismatch: {}, expected: {}", page, prev_full_lsn);
-            }
-
-            if (page.flags & WT_PAGE_LOG_DISCARDED) {
-                LOG_AND_THROW("Full page cannot be discarded: {}", page);
-            }
-
-            if (discarded.lsn != 0) {
-                LOG_AND_THROW(
-                  "Discarded page cannot be followed by another page: {}, {}", discarded, page);
-            }
-
-            full = page;
-        };
-
-        auto verify_delta = [&](const PageInfo &page) {
-            assert(prev.lsn != 0); // Cannot be the first page in the chain
-
-            if (full.lsn == 0) {
-                LOG_AND_THROW("Delta page without full page: {}", page);
-            }
-
-            if (full.lsn != page.base_lsn) {
-                LOG_AND_THROW("Delta page base_lsn mismatch: {}, full page: {}", page, full);
-            }
-
-            // Discarded pages can backlink to any page that we've seen in the chain.
-            if (!(page.flags & WT_PAGE_LOG_DISCARDED) && page.backlink_lsn != prev.lsn) {
-                LOG_AND_THROW(
-                  "Delta chain backlink_lsn mismatch: {}, previous page: {}", page, prev);
-            }
-
-            if (page.flags & WT_PAGE_LOG_DISCARDED) {
-                if (discarded.lsn != 0) {
-                    LOG_AND_THROW("Multiple discarded pages in chain: {}, {}", discarded, page);
-                }
-                discarded = page;
-            } else if (discarded.lsn != 0) {
-                LOG_AND_THROW(
-                  "Discarded page cannot be followed by another page: {}, {}", discarded, page);
-            }
-        };
-
-        auto verify_page = [&](const PageInfo &page) {
-            if (page.flags & WT_PAGE_LOG_DELTA)
-                verify_delta(page);
-            else
-                verify_full(page);
-            prev = page;
-        };
-
-        // Iterate in reverse order to validate the chain from full page.
-        std::for_each(pages.rbegin(), pages.rend(), verify_page);
-
-        // Verify discarded page separately because it can backlink to any page in the chain.
-        if (discarded.lsn != 0) {
-            auto found_it = std::ranges::find_if(
-              pages, [&discarded](const PageInfo &p) { return p.lsn == discarded.backlink_lsn; });
-            if (found_it == pages.end()) {
-                LOG_AND_THROW("Discarded page backlink_lsn not found in chain: {}", discarded);
-            }
+        Connection &glob_conn = globals.conn();
+        for (auto table_id : globals.get_table_ids(glob_conn)) {
+            auto &pages_tbl = fetch_pages_table(table_id);
+            pages_tbl.delete_many(pages_tbl.conn(), checkpoint_lsn);
         }
-    }
-
-    /* !!! Verify the entire page chain for consistency.
-
-    The pages are expected to be ordered by lsn DESC (newest first).
-    The chain may include a single discarded page as the first page,
-    zero or more deltas, and one terminating full page.
-    Discarded pages can backlink to any page in the chain.
-
-    Example of a valid chain:
-        Discarded (lsn=10, backlink_lsn=8, base_lsn=7, flags=DISCARDED|DELTA)
-        Delta     (lsn=9,  backlink_lsn=8, base_lsn=7, flags=DELTA)
-        Delta     (lsn=8,  backlink_lsn=7, base_lsn=7, flags=DELTA)
-        Full      (lsn=7,  backlink_lsn=0, base_lsn=0, flags=0)
-
-    Returns 0 on success or throws on error. */
-    int
-    verify_page_chain(Connection &conn, uint64_t table_id, uint64_t page_id, uint64_t lsn)
-    {
-        if (!config.verify) {
-            return 0;
-        }
-
-        std::vector<PageInfo> pages;
-        get_page_infos(conn, table_id, page_id, lsn, pages);
-        if (pages.size() == 0) {
-            LOG_AND_THROW(
-              "No pages found for table_id={}, page_id={} at lsn<={}", table_id, page_id, lsn);
-        }
-
-        const uint64_t prev_full_lsn = get_prev_full_page_lsn(conn, table_id, page_id, lsn);
-
-        verify_chain(pages, prev_full_lsn);
-
-        return 0;
-    }
-
-    int
-    get_page_ids(Connection &conn, uint64_t checkpoint_lsn, uint64_t table_id, WT_ITEM *page_ids,
-      size_t *page_count)
-    {
-        StatementPtr stmt = conn.db_statement(Statement::GET_PAGE_IDS);
-        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 1, static_cast<sqlite3_int64>(table_id));
-        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 2, static_cast<sqlite3_int64>(checkpoint_lsn));
-
-        std::vector<uint64_t> ids;
-        while (SQ_CHECK(sqlite3_step, stmt.get()) == SQLITE_ROW) {
-            ids.push_back(sqlite3_column_int64(stmt.get(), 0));
-        }
-        LOG_DEBUG("Found {} page IDs for table_id={} at checkpoint_lsn={}", ids.size(), table_id,
-          checkpoint_lsn);
-        LOG_DIAG("Page IDs: {}", join(ids, ", "));
-
-        *page_count = ids.size();
-        if (ids.size() > 0) {
-            fill_item(page_ids, ids.data(), ids.size() * sizeof(uint64_t));
-        }
-
-        return 0;
-    }
-
-    uint64_t
-    get_prev_full_page_lsn(Connection &conn, uint64_t table_id, uint64_t page_id, uint64_t lsn)
-    {
-        StatementPtr stmt = conn.db_statement(Statement::GET_FULL_PAGE_LSN);
-        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 1, static_cast<sqlite3_int64>(table_id));
-        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 2, static_cast<sqlite3_int64>(page_id));
-        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 3, static_cast<sqlite3_int64>(lsn));
-
-        int ret = SQ_CHECK(sqlite3_step, stmt.get());
-        if (ret == SQLITE_DONE) {
-            return 0; // No previous full page found
-        }
-
-        return static_cast<uint64_t>(sqlite3_column_int64(stmt.get(), 0));
-    }
-
-    void
-    discard_page(Connection &conn, uint64_t table_id, uint64_t page_id, uint64_t lsn,
-      WT_PAGE_LOG_DISCARD_ARGS *args)
-    {
-        if (args->flags != 0)
-            LOG_AND_THROW("Non-zero flags: {:#x}", args->flags);
-
-        WT_PAGE_LOG_PUT_ARGS put_args{};
-        put_args.backlink_lsn = args->backlink_lsn;
-        put_args.base_lsn = args->base_lsn;
-        // Discarded pages are deltas
-        put_args.flags = WT_PAGE_LOG_DELTA | WT_PAGE_LOG_DISCARDED;
-
-        WT_ITEM dummy_page{};
-        put_page(conn, table_id, page_id, lsn, &put_args, &dummy_page);
-        args->lsn = put_args.lsn;
-        LOG_DEBUG("Discarded page_id={} at lsn={}, backlink_lsn={}, base_lsn={}; discarded_lsn={}",
-          page_id, lsn, args->backlink_lsn, args->base_lsn, args->lsn);
-    }
-
-    void
-    delete_pages(Connection &conn, uint64_t lsn)
-    {
-        LOG_DEBUG("Deleting pages with lsn > {}", lsn);
-        StatementPtr stmt = conn.db_statement(Statement::DELETE_PAGES);
-        SQ_CHECK(sqlite3_bind_int64, stmt.get(), 1, static_cast<sqlite3_int64>(lsn));
-        SQ_CHECK(sqlite3_step, stmt.get());
     }
 };
 
-// PaliteHandle class
-//
+/*
+ * PaliteHandle class
+ */
 
 class PaliteHandle : public WT_PAGE_LOG_HANDLE {
-    uint64_t table_id; // Table ID for this handle
+    uint64_t table_id; /* Table ID for this handle */
     Storage &storage;
 
     void initialize_interface();
@@ -1767,29 +1996,27 @@ public:
     {
         WT_PAGE_LOG_HANDLE::page_log = palite;
         initialize_interface();
+        storage.add_table_id(table_id);
         LOG_DEBUG("Created PaliteHandle for table_id={}", table_id);
     }
 
-    // Instance methods that implement the actual functionality
+    /* Instance methods that implement the actual functionality */
     int
     put(uint64_t page_id, uint64_t checkpoint_id, WT_PAGE_LOG_PUT_ARGS *args, const WT_ITEM *buf)
     {
         storage.simulate_unstable_network();
 
-        // TODO: handle dek encryption
+        /* TODO: handle dek encryption */
 
-        Storage::Transaction txn = storage.begin_transaction();
-        uint64_t lsn = storage.get_next_lsn(txn.conn);
-        storage.put_page(txn.conn, table_id, page_id, lsn, args, buf);
-        storage.verify_page_chain(txn.conn, table_id, page_id, lsn);
-        storage.commit_transaction(txn);
+        const uint64_t lsn = storage.make_next_lsn();
+        storage.put_page(table_id, page_id, lsn, args, buf);
         args->lsn = lsn;
 
         LOG_DIAG(
           "Put page_id={} at lsn={}, backlink_lsn={}, base_lsn={}, "
           "flags={:#x}, image_size={}",
           page_id, lsn, args->backlink_lsn, args->base_lsn, args->flags, args->image_size);
-        LOG_TRACE("Page data (size={}) =====\n{}", buf->size, palite_verbose_item(buf));
+        LOG_TRACE("Page data (size={}) =====\n{}", buf->size, verbose_item(buf));
 
         return 0;
     }
@@ -1800,23 +2027,22 @@ public:
     {
         storage.simulate_unstable_network();
 
-        Storage::Transaction txn = storage.begin_transaction();
         uint32_t flags = 0;
-        storage.get_pages(txn.conn, table_id, page_id, args, &flags, results_array, results_count);
-        storage.commit_transaction(txn);
+        storage.get_pages(table_id, page_id, args, &flags, results_array, results_count);
+
         LOG_DEBUG(
           "Get page_id={} at lsn={}, returned {} entries, "
           "backlink_lsn={}, base_lsn={}, flags={:#x}",
           page_id, args->lsn, *results_count, args->backlink_lsn, args->base_lsn, flags);
+
         return 0;
     }
 
     int
     get_page_ids(uint64_t checkpoint_lsn, WT_ITEM *page_ids, size_t *page_count)
     {
-        Storage::Transaction txn = storage.begin_transaction();
-        storage.get_page_ids(txn.conn, checkpoint_lsn, table_id, page_ids, page_count);
-        storage.commit_transaction(txn);
+        storage.get_page_ids(checkpoint_lsn, table_id, page_ids, page_count);
+
         LOG_DEBUG(
           "Get page_ids for table_id={} at checkpoint_lsn={}, "
           "returned {} page IDs",
@@ -1829,14 +2055,14 @@ public:
     discard(uint64_t page_id, uint64_t checkpoint_id, WT_PAGE_LOG_DISCARD_ARGS *args)
     {
         storage.simulate_unstable_network();
-        Storage::Transaction txn = storage.begin_transaction();
-        uint64_t lsn = storage.get_next_lsn(txn.conn);
-        storage.discard_page(txn.conn, table_id, page_id, lsn, args);
-        storage.verify_page_chain(txn.conn, table_id, page_id, lsn);
-        storage.commit_transaction(txn);
+
+        const uint64_t lsn = storage.make_next_lsn();
+        storage.discard_page(table_id, page_id, lsn, args);
         args->lsn = lsn;
+
         LOG_DEBUG("Discard page_id={} at lsn={}, backlink_lsn={}, base_lsn={}", page_id, lsn,
           args->backlink_lsn, args->base_lsn);
+
         return 0;
     }
 
@@ -1844,7 +2070,7 @@ public:
     close()
     {
         LOG_DEBUG("Closing PaliteHandle for table_id={}", table_id);
-        delete this; // No calls expected after WT_PAGE_LOG_HANDLE::plh_close
+        delete this; /* No calls expected after WT_PAGE_LOG_HANDLE::plh_close */
         return 0;
     }
 };
@@ -1887,7 +2113,7 @@ palite_handle_close(WT_PAGE_LOG_HANDLE *plh, WT_SESSION *sess)
 {
     return safe_call<PaliteHandle>(sess, plh, &PaliteHandle::close);
 }
-} // extern "C"
+} /* extern "C" */
 
 void
 PaliteHandle::initialize_interface()
@@ -1899,21 +2125,15 @@ PaliteHandle::initialize_interface()
     plh_close = palite_handle_close;
 }
 
-// Palite class
-//
+/*
+ * Palite class
+ */
 class Palite : public WT_PAGE_LOG {
 public:
-    // The LSN when the database is opened, used to check encryption
-    uint64_t begin_lsn;
-
-    // Reference counting for the page log service
-    std::atomic_int ref_count;
-
-    // Configuration
-    Config config;
-
-    // Storage layer
-    Storage storage;
+    uint64_t begin_lsn;        /* LSN at creation time */
+    std::atomic_int ref_count; /* Reference counting for the page log service */
+    Config config;             /* Configuration options */
+    Storage storage;           /* Storage backend for page log */
 
 public:
     ~Palite() = default;
@@ -1959,29 +2179,16 @@ public:
         return 0;
     }
 
-    // Abandon (delete) all page log entries and checkpoint records with an LSN
-    // greater than the given LSN.
+    /*
+     * Abandon (delete) all page log entries and checkpoint records with an LSN greater than the
+     * given LSN.
+     */
     int
     abandon_checkpoint(uint64_t checkpoint_lsn)
     {
-        int ret = 0;
-        if (checkpoint_lsn == WT_PAGE_LOG_LSN_MAX) {
-            Storage::Transaction txn = storage.begin_transaction();
-            ret = storage.get_checkpoint(txn.conn, checkpoint_lsn, nullptr, nullptr);
-            storage.commit_transaction(txn);
-        }
+        LOG_DEBUG("Abandoning checkpoint at lsn={}", checkpoint_lsn);
+        storage.abandon_checkpoint(checkpoint_lsn);
 
-        if (ret == WT_NOTFOUND) {
-            LOG_DEBUG("No checkpoint found to abandon; lsn = {}", checkpoint_lsn);
-            return 0;
-        }
-
-        LOG_DEBUG("Deleting pages and checkpoints with lsn > {}", checkpoint_lsn);
-        Storage::Transaction txn = storage.begin_transaction();
-        storage.delete_pages(txn.conn, checkpoint_lsn);
-        storage.delete_checkpoints(txn.conn, checkpoint_lsn);
-        // Note: global LSN counter is not decremented
-        storage.commit_transaction(txn);
         return 0;
     }
 
@@ -1989,16 +2196,14 @@ public:
     complete_checkpoint_ext(uint64_t checkpoint_id, uint64_t checkpoint_timestamp,
       const WT_ITEM *checkpoint_metadata, uint64_t *lsnp)
     {
-        Storage::Transaction txn = storage.begin_transaction();
-        uint64_t lsn = storage.get_next_lsn(txn.conn);
-        storage.put_checkpoint(txn.conn, lsn, checkpoint_timestamp, checkpoint_metadata);
-        storage.commit_transaction(txn);
+        const uint64_t lsn = storage.make_next_lsn();
+        storage.put_checkpoint(lsn, checkpoint_timestamp, checkpoint_metadata);
 
         LOG_DEBUG(
           "checkpoint_id={}, timestamp={}, lsn={}", checkpoint_id, checkpoint_timestamp, lsn);
         LOG_TRACE("checkpoint_metadata (size={}) =====\n{}",
           checkpoint_metadata ? checkpoint_metadata->size : 0,
-          checkpoint_metadata ? palite_verbose_item(checkpoint_metadata) : "<none>");
+          checkpoint_metadata ? verbose_item(checkpoint_metadata) : "<none>");
 
         if (lsnp) {
             *lsnp = lsn;
@@ -2018,17 +2223,14 @@ public:
         if (checkpoint_timestamp)
             *checkpoint_timestamp = 0;
 
-        uint64_t query_lsn = WT_PAGE_LOG_LSN_MAX; // most recent checkpoint
-        Storage::Transaction txn = storage.begin_transaction();
-        int ret =
-          storage.get_checkpoint(txn.conn, query_lsn, checkpoint_timestamp, checkpoint_metadata);
-        storage.commit_transaction(txn);
+        uint64_t query_lsn = WT_PAGE_LOG_LSN_MAX; /* most recent checkpoint */
+        int ret = storage.get_checkpoint(query_lsn, checkpoint_timestamp, checkpoint_metadata);
 
         LOG_DEBUG("checkpoint_lsn={}, timestamp={}", query_lsn,
           checkpoint_timestamp ? *checkpoint_timestamp : 0);
         LOG_TRACE("checkpoint_metadata (size={}) =====\n{}",
           checkpoint_metadata ? checkpoint_metadata->size : 0,
-          checkpoint_metadata ? palite_verbose_item(checkpoint_metadata) : "<none>");
+          checkpoint_metadata ? verbose_item(checkpoint_metadata) : "<none>");
 
         if (checkpoint_lsn)
             *checkpoint_lsn = query_lsn;
@@ -2044,9 +2246,7 @@ public:
             return EINVAL;
         }
 
-        Storage::Transaction txn = storage.begin_transaction();
-        *lsn = storage.get_last_lsn(txn.conn);
-        storage.commit_transaction(txn);
+        *lsn = storage.get_last_lsn();
         LOG_TRACE("last_lsn={}", *lsn);
 
         return 0;
@@ -2070,7 +2270,7 @@ public:
     int
     set_last_materialized_lsn(uint64_t lsn)
     {
-        config.last_materialized_lsn = lsn; // Update config value
+        config.last_materialized_lsn = lsn; /* Update config value */
         LOG_DEBUG("Set last_materialized_lsn={}", lsn);
         return 0;
     }
@@ -2083,7 +2283,7 @@ public:
         if (ref_count <= 0) {
             storage.close();
             LOG_DEBUG("Destroying Palite page log");
-            delete this; // No calls expected after the last WT_PAGE_LOG::terminate
+            delete this; /* No calls expected after the last WT_PAGE_LOG::terminate */
         }
         return 0;
     }
@@ -2149,7 +2349,7 @@ palite_terminate(WT_PAGE_LOG *page_log, WT_SESSION *sess)
 {
     return safe_call<Palite>(sess, page_log, &Palite::terminate);
 }
-} // extern "C"
+} /* extern "C" */
 
 void
 Palite::initialize_interface()
@@ -2175,14 +2375,14 @@ palite_extension_init(WT_CONNECTION *connection, WT_CONFIG_ARG *cfg_arg)
 {
     int ret = 0;
     session(nullptr);
-    Config config{}; // default config for logging macros bellow
+    Config config{}; /* default config for logging macros bellow */
 
     try {
         const auto home_dir = connection->get_home(connection);
         auto wt_api = connection->get_extension_api(connection);
         std::unique_ptr<Palite> palite = std::make_unique<Palite>(home_dir, wt_api, cfg_arg);
 
-        // Register the page log service with WiredTiger
+        /* Register the page log service with WiredTiger */
         ret = connection->add_page_log(connection, "palite", palite.get(), nullptr);
 
         if (ret == 0) {
@@ -2210,7 +2410,7 @@ palite_extension_init(WT_CONNECTION *connection, WT_CONFIG_ARG *cfg_arg)
 
     return ret;
 }
-} // extern "C"
+} /* extern "C" */
 
 /*
  * We have to remove this symbol when building as a builtin extension otherwise it will conflict


### PR DESCRIPTION
- Switch from a single DB file for entire storage to separate files for each table: globals, checkpoints, pages (a file per table).
- Change `Transaction` class to `Access` to reflect its actual functionality
- Style fix: restyle comments according to the coding guidelines.