### PR TITLE
WT-15938 Fix BB UI for TSAN

### DIFF
--- a/test/evergreen/tsan_warnings_analysis.py
+++ b/test/evergreen/tsan_warnings_analysis.py
@@ -76,22 +76,24 @@ def get_tsan_warnings():
                     for line in file:
                         if ("WARNING:" in line.strip()):
                             start_record = True
+                        if not start_record:
                             continue
-                        if start_record:
-                            warning_lines.append(line.strip())
-                            if (line.startswith("SUMMARY:")):
-                                # Strip away the path
-                                pattern_to_remove = r"/.*/wiredtiger/"
-                                cleaned_text = re.sub(pattern_to_remove, "", line).strip()
 
-                                # Strip away the column line information.
-                                pattern_to_remove = r':(\d+):\d+'
-                                cleaned_text = re.sub(pattern_to_remove, r':\1', cleaned_text).strip()
-                                tsan_warnings_dict[cleaned_text] = (file_name, warning_lines.copy())
+                        warning_lines.append(line.strip())
 
-                                # Restart the warning recording.
-                                warning_lines = []
-                                start_record = False
+                        if (line.startswith("SUMMARY:")):
+                            # Strip away the path
+                            pattern_to_remove = r"/.*/wiredtiger/"
+                            cleaned_text = re.sub(pattern_to_remove, "", line).strip()
+
+                            # Strip away the column line information.
+                            pattern_to_remove = r':(\d+):\d+'
+                            cleaned_text = re.sub(pattern_to_remove, r':\1', cleaned_text).strip()
+                            tsan_warnings_dict[cleaned_text] = (file_name, warning_lines.copy())
+
+                            # Restart the warning recording.
+                            warning_lines = []
+                            start_record = False
     return tsan_warnings_dict
 
 


### PR DESCRIPTION
Currently the BB UI for generate-tsan-warnings tasks show only summary and doesn't show the warning text itself. That's happening because `tsan_warnings_analysis.py` doesn't include the first line into the output. This PR was created to fix this.