### PR TITLE
WT-15656 Apply block extlist dump to multi places

### DIFF
--- a/src/block/block_ext.c
+++ b/src/block/block_ext.c
@@ -1502,8 +1502,8 @@ err:
 
 /*
  * __wti_block_extlist_dump_all --
- *     Dump all extent lists as verbose messages including the live checkpoint and historical ones. As
- *     this is a debug function, errors are ignored.
+ *     Dump all extent lists as verbose messages including the live checkpoint and historical ones.
+ *     As this is a debug function, errors are ignored.
  */
 void
 __wti_block_extlist_dump_all(WT_SESSION_IMPL *session, WT_BLOCK *block)

--- a/src/block/block_ext.c
+++ b/src/block/block_ext.c
@@ -1502,7 +1502,7 @@ err:
 
 /*
  * __wti_block_extlist_dump_all --
- *     Dump all extent lists as verbose messages including living checkpoint and historical ones. As
+ *     Dump all extent lists as verbose messages including the live checkpoint and historical ones. As
  *     this is a debug function, errors are ignored.
  */
 void

--- a/src/block/block_ext.c
+++ b/src/block/block_ext.c
@@ -1501,6 +1501,35 @@ err:
 }
 
 /*
+ * __wti_block_extlist_dump_all --
+ *     Dump all extent lists as verbose messages including living checkpoint and historical ones. As
+ *     this is a debug function, errors are ignored.
+ */
+void
+__wti_block_extlist_dump_all(WT_SESSION_IMPL *session, WT_BLOCK *block)
+{
+    /*
+     * Dump the extent lists associated with all available checkpoints in the system. Viewing the
+     * state of the extent lists in the event of a read error can help pinpoint the reason for the
+     * read error. Since dumping the extent lists also requires reading the block, we must set the
+     * WT_SESSION_DUMPING_EXTLIST flag to ensure we don't recursively attempt to dump extent lists.
+     */
+    if (!F_ISSET(session, WT_SESSION_DUMPING_EXTLIST)) {
+        F_SET(session, WT_SESSION_DUMPING_EXTLIST);
+        /* Dump the live checkpoint extent lists. */
+        WT_IGNORE_RET(__wti_block_extlist_dump(session, &block->live.alloc));
+        WT_IGNORE_RET(__wti_block_extlist_dump(session, &block->live.avail));
+        WT_IGNORE_RET(__wti_block_extlist_dump(session, &block->live.discard));
+
+        /* Dump the rest of the extent lists associated with any other valid checkpoints in the
+         * file. */
+        WT_IGNORE_RET(__wti_block_checkpoint_extlist_dump(session, block));
+
+        F_CLR(session, WT_SESSION_DUMPING_EXTLIST);
+    }
+}
+
+/*
  * __wti_block_extlist_dump --
  *     Dump an extent list as verbose messages. Large extent lists are dumped in chunks to avoid
  *     verbose message size limits. Only printed with WT_VERB_BLOCK level 3, or if data corruption

--- a/src/block/block_read.c
+++ b/src/block/block_read.c
@@ -291,25 +291,7 @@ __wti_block_read_off(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_ITEM *buf, ui
     if (block->verify || F_ISSET(session, WT_SESSION_QUIET_CORRUPT_FILE))
         return (WT_ERROR);
 
-    /*
-     * Dump the extent lists associated with all available checkpoints in the system. Viewing the
-     * state of the extent lists in the event of a read error can help pinpoint the reason for the
-     * read error. Since dumping the extent lists also requires reading the block, we must set the
-     * WT_SESSION_DUMPING_EXTLIST flag to ensure we don't recursively attempt to dump extent lists.
-     */
-    if (!F_ISSET(session, WT_SESSION_DUMPING_EXTLIST)) {
-        F_SET(session, WT_SESSION_DUMPING_EXTLIST);
-        /* Dump the live checkpoint extent lists. */
-        WT_IGNORE_RET(__wti_block_extlist_dump(session, &block->live.alloc));
-        WT_IGNORE_RET(__wti_block_extlist_dump(session, &block->live.avail));
-        WT_IGNORE_RET(__wti_block_extlist_dump(session, &block->live.discard));
-
-        /* Dump the rest of the extent lists associated with any other valid checkpoints in the
-         * file. */
-        WT_IGNORE_RET(__wti_block_checkpoint_extlist_dump(session, block));
-
-        F_CLR(session, WT_SESSION_DUMPING_EXTLIST);
-    }
+    __wti_block_extlist_dump_all(session, block);
 
     WT_RET_PANIC(session, WT_ERROR, "%s: fatal read error", block->name);
 }

--- a/src/block/block_vrfy.c
+++ b/src/block/block_vrfy.c
@@ -435,6 +435,9 @@ __verify_filefrag_chk(WT_SESSION_IMPL *session, WT_BLOCK *block)
         return (0);
 
     __wt_errx(session, "file ranges never verified: %" PRIu64, count);
+
+    __wti_block_extlist_dump_all(session, block);
+
     return (block->verify_strict ? WT_ERROR : 0);
 }
 
@@ -518,5 +521,8 @@ __verify_ckptfrag_chk(WT_SESSION_IMPL *session, WT_BLOCK *block)
         return (0);
 
     __wt_errx(session, "checkpoint ranges never verified: %" PRIu64, count);
+
+    __wti_block_extlist_dump_all(session, block);
+
     return (block->verify_strict ? WT_ERROR : 0);
 }

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1827,6 +1827,7 @@ extern void __wti_block_disagg_header_byteswap_copy(
 extern void __wti_block_disagg_stat(
   WT_SESSION_IMPL *session, WT_BLOCK_DISAGG *block_disagg, WT_DSRC_STATS *stats);
 extern void __wti_block_ext_free(WT_SESSION_IMPL *session, WT_EXT **ext);
+extern void __wti_block_extlist_dump_all(WT_SESSION_IMPL *session, WT_BLOCK *block);
 extern void __wti_block_extlist_free(WT_SESSION_IMPL *session, WT_EXTLIST *el);
 extern void __wti_block_size_free(WT_SESSION_IMPL *session, WT_SIZE **sz);
 extern void __wti_bm_method_set(WT_BM *bm, bool readonly);


### PR DESCRIPTION
- Create `__wti_block_extlist_dump_all` to dump both live and historical checkpoints block extlist.
- Apply `extlist` dump to `range never verified` points.