### PR TITLE
WT-15951 Use weights for timing stress, which don't have to add up to 1

### DIFF
--- a/test/model/src/driver/kv_workload_generator.cpp
+++ b/test/model/src/driver/kv_workload_generator.cpp
@@ -84,7 +84,8 @@ kv_workload_generator_spec::kv_workload_generator_spec()
     prepared_transaction_rollback_before_prepare = 0.1;
 
     /* Relative weights for the timing stress tests, which don't have to add up to 1.0. */
-    weight_init_block(timing_stress_total) {
+    weight_init_block(timing_stress_total)
+    {
         weight_init(timing_stress_ckpt_slow, 0.1f);
         weight_init(timing_stress_ckpt_evict_page, 0.1f);
         weight_init(timing_stress_ckpt_handle, 0.1f);

--- a/test/model/src/driver/kv_workload_generator.cpp
+++ b/test/model/src/driver/kv_workload_generator.cpp
@@ -83,17 +83,20 @@ kv_workload_generator_spec::kv_workload_generator_spec()
     prepared_transaction_rollback_after_prepare = 0.1;
     prepared_transaction_rollback_before_prepare = 0.1;
 
-    timing_stress_ckpt_slow = 0.1;
-    timing_stress_ckpt_evict_page = 0.1;
-    timing_stress_ckpt_handle = 0.1;
-    timing_stress_ckpt_stop = 0.1;
-    timing_stress_compact_slow = 0.1;
-    timing_stress_hs_ckpt_delay = 0.1;
-    timing_stress_hs_search = 0.1;
-    timing_stress_hs_sweep_race = 0.1;
-    timing_stress_prepare_ckpt_delay = 0.1;
-    timing_stress_commit_txn_slow = 0.1;
-    timing_stress_rec_before_wrapup = 0.1;
+    /* Relative weights for the timing stress tests, which don't have to add up to 1.0. */
+    weight_init_block(timing_stress_total) {
+        weight_init(timing_stress_ckpt_slow, 0.1f);
+        weight_init(timing_stress_ckpt_evict_page, 0.1f);
+        weight_init(timing_stress_ckpt_handle, 0.1f);
+        weight_init(timing_stress_ckpt_stop, 0.1f);
+        weight_init(timing_stress_compact_slow, 0.1f);
+        weight_init(timing_stress_hs_ckpt_delay, 0.1f);
+        weight_init(timing_stress_hs_search, 0.1f);
+        weight_init(timing_stress_hs_sweep_race, 0.1f);
+        weight_init(timing_stress_prepare_ckpt_delay, 0.1f);
+        weight_init(timing_stress_commit_txn_slow, 0.1f);
+        weight_init(timing_stress_rec_before_wrapup, 0.1f);
+    }
 }
 
 /*
@@ -339,7 +342,7 @@ std::string
 kv_workload_generator::generate_connection_stress_config()
 {
     std::string wt_env_config;
-    probability_switch(_random.next_float())
+    probability_switch(_random.next_float() * _spec.timing_stress_total())
     {
         probability_case(_spec.timing_stress_ckpt_slow) wt_env_config +=
           "timing_stress_for_test=[checkpoint_slow]";

--- a/test/model/src/include/model/driver/kv_workload_generator.h
+++ b/test/model/src/include/model/driver/kv_workload_generator.h
@@ -109,7 +109,7 @@ struct kv_workload_generator_spec {
     float prepared_transaction_rollback_after_prepare;
     float prepared_transaction_rollback_before_prepare;
 
-    /* Probabilities of WiredTiger timing stress configurations. */
+    /* Weights of WiredTiger timing stress configurations. */
     /* FIXME-WT-13878 : Refactor this code and move into a separate structure. */
     float timing_stress_ckpt_slow;
     float timing_stress_ckpt_evict_page;
@@ -128,6 +128,12 @@ struct kv_workload_generator_spec {
      *     Create the generator specification using default probability values.
      */
     kv_workload_generator_spec();
+
+    /*
+     * kv_workload_generator_spec::compute_timing_stress_total --
+     *     The function to compute the sum of weights.
+     */
+    std::function<float()> timing_stress_total;
 };
 
 /*

--- a/test/model/src/include/model/random.h
+++ b/test/model/src/include/model/random.h
@@ -131,7 +131,7 @@ private:
 /*
  * weight_init_block --
  *     A convenience macro to wrap initialization of weights that don't have to add up to 1.0. It
- * also creates a function for computing the sum of a set of weights.
+ *     also creates a function for computing the sum of a set of weights.
  */
 #define weight_init_block(total_func)                                                           \
     for (                                                                                       \

--- a/test/model/src/include/model/random.h
+++ b/test/model/src/include/model/random.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #include <cstddef>
+#include <functional>
 #include "model/core.h"
 
 extern "C" {
@@ -126,5 +127,27 @@ private:
  *     The default case within a probability switch.
  */
 #define probability_default if (__r >= 0)
+
+/*
+ * weight_init_block --
+ *     A convenience macro to wrap initialization of weights that don't have to add up to 1.0. It
+ * also creates a function for computing the sum of a set of weights.
+ */
+#define weight_init_block(total_func)                                                           \
+    for (                                                                                       \
+      std::function<float()> __tmp_total = [this]() { return 0.0f; },                           \
+                             __tmp_done = []() { return -1; } /* execute the body just once */; \
+      __tmp_done() < 0; total_func = std::move(__tmp_total), __tmp_done = []() { return 1; })
+
+/*
+ * weight_init --
+ *     A convenience macro to initialize a weight and update the total function.
+ */
+#define weight_init(name, value)                                                \
+    {                                                                           \
+        name = (value);                                                         \
+        auto __prev_total = __tmp_total;                                        \
+        __tmp_total = [__prev_total, this]() { return __prev_total() + name; }; \
+    }
 
 } /* namespace model */


### PR DESCRIPTION
Introduce a new pair of macros to `test/model`, which allow the user to easily initialize a list of weights that don't have to add up to 1. The macros create a function for producing the sum of weights, which will remain accurate even if the weights change after the initialization.

The reason for this macro is to ensure that there is only one list of weights, instead of one list of weights when initializing them and one list when adding them up, so that they would never get out of sync. If, for example, someone added a new weight variable and initialized it, but forgot to add it to where the weights are summed up, some options might not ever be triggered (as explained on the ticket).

The macros were written to optimize the ease of use, not performance, given that the callers to the created "total weights" function are not on the critical path.