### PR TITLE
WT-15819 test/format (disagg.mode=follower) MSAN use-of-uninitialized-value in PALite

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1570,7 +1570,7 @@ variables:
           format_args: disagg.page_log=palite disagg.mode=switch runs.timer=10:15
           times: 5
 
-  - &format-stress-test-disagg-follower
+  - &format-stress-test-disagg-follower-palite
     depends_on:
       - name: compile
     commands:
@@ -1579,6 +1579,16 @@ variables:
         vars:
           format_args: disagg.page_log=palite disagg.mode=follower runs.timer=10:15
           times: 10
+
+  - &format-stress-test-disagg-follower
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "format test disagg"
+        vars:
+          format_args: disagg.mode=follower runs.timer=10:15
+          times: 5
 
   - &format-stress-data-validation-test-disagg-follower
     depends_on:
@@ -4585,12 +4595,15 @@ tasks:
     name: format-stress-data-validation-test-disagg-leader-3
     tags: ["stress-test-disagg-fail"]
   - <<: *format-stress-test-disagg-follower
-    name: format-stress-test-disagg-follower-1
+    name: format-stress-test-disagg-follower-palm
     tags: ["stress-test-disagg", "stress-test-disagg-san-fail"]
-  - <<: *format-stress-test-disagg-follower
+  - <<: *format-stress-test-disagg-follower-palite
+    name: format-stress-test-disagg-follower-1
+    tags: ["stress-test-disagg"]
+  - <<: *format-stress-test-disagg-follower-palite
     name: format-stress-test-disagg-follower-2
     tags: ["stress-test-disagg"]
-  - <<: *format-stress-test-disagg-follower
+  - <<: *format-stress-test-disagg-follower-palite
     name: format-stress-test-disagg-follower-3
     tags: ["stress-test-disagg"]
   - <<: *format-stress-data-validation-test-disagg-follower
@@ -7454,7 +7467,6 @@ buildvariants:
   tasks:
     - name: compile
     - name: ".stress-test-disagg-san-fail"
-    - name: checkpoint-test
 
 - name: amazon2023-disagg-ubsan-stress
   display_name: "[Failure Expected] (ARMV9) Amazon 2023 UBSAN Disagg Stress tests"


### PR DESCRIPTION
PALite cannot be used with MSan builds. (For more info, see: WT-15950)

Solution:
- Use PALM with MSan disagg build
- Skip `checkpoint-test` under MSan