### PR TITLE
WT-15982 Add checksum to "checkpoint_meta"

### DIFF
--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -17,6 +17,20 @@ static int __layered_iterate_ingest_tables_for_gc_pruning(
 static int __layered_last_checkpoint_order(
   WT_SESSION_IMPL *session, const char *shared_uri, int64_t *ckpt_order);
 
+struct __wt_disagg_checkpoint_meta;
+typedef struct __wt_disagg_checkpoint_meta WT_DISAGG_CHECKPOINT_META;
+
+/*
+ * WT_DISAGG_CHECKPOINT_META --
+ *     Checkpoint metadata structure for disaggregated storage.
+ */
+struct __wt_disagg_checkpoint_meta {
+    uint64_t metadata_lsn; /* The LSN of the metadata page. */
+
+    bool has_metadata_checksum; /* Whether the metadata page checksum is present. */
+    uint32_t metadata_checksum; /* The checksum of the metadata page. */
+};
+
 /*
  * __layered_get_disagg_checkpoint --
  *     Get existing checkpoint information from disaggregated storage.
@@ -347,8 +361,7 @@ err:
  *     Pick up a new checkpoint.
  */
 static int
-__disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, uint64_t meta_lsn, bool has_metadata_checksum,
-  uint32_t metadata_checksum)
+__disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPOINT_META *ckpt_meta)
 {
     WT_CONFIG_ITEM cval;
     WT_CONNECTION_IMPL *conn;
@@ -383,19 +396,18 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, uint64_t meta_lsn, bool ha
     /* We should not pick up a checkpoint with an earlier LSN. */
     current_meta_lsn =
       __wt_atomic_load_uint64_acquire(&conn->disaggregated_storage.last_checkpoint_meta_lsn);
-    if (meta_lsn < current_meta_lsn)
+    if (ckpt_meta->metadata_lsn < current_meta_lsn)
         WT_RET_MSG(session, EINVAL,
           "Attempting to pick up an older checkpoint: current metadata LSN = %" PRIu64
           ", new metadata LSN = %" PRIu64,
-          current_meta_lsn, meta_lsn);
-
+          current_meta_lsn, ckpt_meta->metadata_lsn);
     /*
      * Warn if we are picking up the same checkpoint again. There's nothing else to do here, goto
      * err for cleanup.
      */
-    if (meta_lsn == current_meta_lsn) {
+    if (ckpt_meta->metadata_lsn == current_meta_lsn) {
         __wt_verbose_level(session, WT_VERB_LAYERED, WT_VERBOSE_WARNING,
-          "Picking up the same checkpoint again: metadata LSN = %" PRIu64, meta_lsn);
+          "Picking up the same checkpoint again: metadata LSN = %" PRIu64, ckpt_meta->metadata_lsn);
         /* Keep previous ret value to avoid overlapping error message */
         goto err;
     }
@@ -405,20 +417,21 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, uint64_t meta_lsn, bool ha
      */
 
     __wt_verbose_debug1(session, WT_VERB_DISAGGREGATED_STORAGE,
-      "Picking up disaggregated storage checkpoint: metadata_lsn=%" PRIu64, meta_lsn);
+      "Picking up disaggregated storage checkpoint: metadata_lsn=%" PRIu64,
+      ckpt_meta->metadata_lsn);
 
     /* Read the checkpoint metadata of the shared metadata table from the special metadata page. */
     WT_ERR_MSG_CHK(session,
-      __disagg_get_meta(session, WT_DISAGG_METADATA_MAIN_PAGE_ID, meta_lsn, &item),
-      "Disagg metadata fetching failed, with lsn: %" PRIu64, meta_lsn);
+      __disagg_get_meta(session, WT_DISAGG_METADATA_MAIN_PAGE_ID, ckpt_meta->metadata_lsn, &item),
+      "Disagg metadata fetching failed, with lsn: %" PRIu64, ckpt_meta->metadata_lsn);
 
     /* Validate the checksum. */
-    if (has_metadata_checksum) {
+    if (ckpt_meta->has_metadata_checksum) {
         checksum = __wt_checksum(item.data, item.size);
-        if (checksum != metadata_checksum) {
+        if (checksum != ckpt_meta->metadata_checksum) {
             WT_ERR_MSG(session, EIO,
               "Checkpoint metadata checksum mismatch: expected %" PRIx32 ", got %" PRIx32,
-              metadata_checksum, checksum);
+              ckpt_meta->metadata_checksum, checksum);
         }
     }
 
@@ -450,8 +463,8 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, uint64_t meta_lsn, bool ha
       "Picking up disaggregated storage checkpoint: metadata_lsn=%" PRIu64 ", timestamp=%" PRIu64
       " %s"
       ", root=\"%s\"",
-      meta_lsn, checkpoint_timestamp, __wt_timestamp_to_string(checkpoint_timestamp, ts_string),
-      root);
+      ckpt_meta->metadata_lsn, checkpoint_timestamp,
+      __wt_timestamp_to_string(checkpoint_timestamp, ts_string), root);
 
     /* We need an internal session when modifying metadata. */
     WT_ERR(__wt_open_internal_session(conn, "checkpoint-pick-up", false, 0, 0, &internal_session));
@@ -590,7 +603,7 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, uint64_t meta_lsn, bool ha
      * updates are protected by the checkpoint lock.
      */
     __wt_atomic_store_uint64_release(
-      &conn->disaggregated_storage.last_checkpoint_meta_lsn, meta_lsn);
+      &conn->disaggregated_storage.last_checkpoint_meta_lsn, ckpt_meta->metadata_lsn);
 
     /* Update the checkpoint timestamp. */
     __wt_atomic_store_uint64_release(
@@ -607,7 +620,8 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, uint64_t meta_lsn, bool ha
 
     /* Log the completion of the checkpoint pick-up. */
     __wt_verbose_debug1(session, WT_VERB_DISAGGREGATED_STORAGE,
-      "Finished picking up disaggregated storage checkpoint: metadata_lsn=%" PRIu64, meta_lsn);
+      "Finished picking up disaggregated storage checkpoint: metadata_lsn=%" PRIu64,
+      ckpt_meta->metadata_lsn);
 
 err:
     if (ret == 0)
@@ -616,7 +630,7 @@ err:
         WT_STAT_CONN_INCR(session, layered_table_manager_checkpoints_disagg_pick_up_failed);
         __wt_verbose_level(session, WT_VERB_LAYERED, WT_VERBOSE_ERROR,
           "Failed to pick up disaggregated storage checkpoint for metadata_lsn=%" PRIu64 ": ret=%d",
-          meta_lsn, ret);
+          ckpt_meta->metadata_lsn, ret);
     }
 
     /* Free memory allocated by the page log interface */
@@ -649,21 +663,19 @@ __disagg_pick_up_checkpoint_meta_item(WT_SESSION_IMPL *session, WT_ITEM *meta_it
 {
     WT_CONFIG_ITEM cval;
     WT_DECL_RET;
-    uint64_t metadata_checksum, metadata_lsn;
+    WT_DISAGG_CHECKPOINT_META ckpt_meta;
+    uint64_t metadata_checksum;
     char *meta_str;
-    bool has_metadata_checksum;
 
+    WT_CLEAR(ckpt_meta);
     meta_str = NULL;
-
-    has_metadata_checksum = false;
-    metadata_checksum = 0;
 
     /* Extract the item into a string. */
     WT_ERR(__wt_strndup(session, meta_item->data, meta_item->size, &meta_str));
 
     /* Extract the LSN of the metadata page. */
     WT_ERR(__wt_config_getones(session, meta_str, "metadata_lsn", &cval));
-    metadata_lsn = (uint64_t)cval.val;
+    ckpt_meta.metadata_lsn = (uint64_t)cval.val;
 
     /*
      * Extract the checksum of the metadata page, if it exists. We added the checksum later, so
@@ -675,12 +687,12 @@ __disagg_pick_up_checkpoint_meta_item(WT_SESSION_IMPL *session, WT_ITEM *meta_it
         if (metadata_checksum > UINT32_MAX)
             WT_ERR_MSG(
               session, EINVAL, "Invalid metadata checksum value: %" PRIx64, metadata_checksum);
-        has_metadata_checksum = true;
+        ckpt_meta.has_metadata_checksum = true;
+        ckpt_meta.metadata_checksum = (uint32_t)metadata_checksum;
     }
 
     /* Now actually pick up the checkpoint. */
-    WT_ERR(__disagg_pick_up_checkpoint(
-      session, metadata_lsn, has_metadata_checksum, (uint32_t)metadata_checksum));
+    WT_ERR(__disagg_pick_up_checkpoint(session, &ckpt_meta));
 
 err:
     __wt_free(session, meta_str);

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -17,19 +17,16 @@ static int __layered_iterate_ingest_tables_for_gc_pruning(
 static int __layered_last_checkpoint_order(
   WT_SESSION_IMPL *session, const char *shared_uri, int64_t *ckpt_order);
 
-struct __wt_disagg_checkpoint_meta;
-typedef struct __wt_disagg_checkpoint_meta WT_DISAGG_CHECKPOINT_META;
-
 /*
  * WT_DISAGG_CHECKPOINT_META --
  *     Checkpoint metadata structure for disaggregated storage.
  */
-struct __wt_disagg_checkpoint_meta {
+typedef struct __wt_disagg_checkpoint_meta {
     uint64_t metadata_lsn; /* The LSN of the metadata page. */
 
     bool has_metadata_checksum; /* Whether the metadata page checksum is present. */
     uint32_t metadata_checksum; /* The checksum of the metadata page. */
-};
+} WT_DISAGG_CHECKPOINT_META;
 
 /*
  * __layered_get_disagg_checkpoint --

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -283,6 +283,7 @@ __wt_disagg_put_checkpoint_meta(WT_SESSION_IMPL *session, const char *checkpoint
     WT_DECL_RET;
     WT_DISAGGREGATED_STORAGE *disagg;
     uint64_t lsn;
+    uint32_t checksum;
     char *checkpoint_root_copy, ts_string[WT_TS_INT_STRING_SIZE];
 
     buf = NULL;
@@ -308,22 +309,28 @@ __wt_disagg_put_checkpoint_meta(WT_SESSION_IMPL *session, const char *checkpoint
       "timestamp=%" PRIx64,
       checkpoint_root_copy, checkpoint_timestamp));
 
+    /* Compute the checksum for the metadata page. */
+    checksum = __wt_checksum(buf->data, buf->size);
+
     /*
      * Write the metadata to disaggregated storage. This should be the last statement in this
      * function that is allowed to fail.
      */
     WT_ERR(__disagg_put_meta(session, WT_DISAGG_METADATA_MAIN_PAGE_ID, buf, &lsn));
 
-    /* Do the bookkeeping. */
+    /*
+     * Do the bookkeeping. We cannot fail this function past this point, so that our bookkeeping is
+     * correct and self-consistent.
+     */
     __wt_atomic_store_uint64_release(&disagg->last_checkpoint_meta_lsn, lsn);
     __wt_atomic_store_uint64_release(&disagg->last_checkpoint_timestamp, checkpoint_timestamp);
+    disagg->last_checkpoint_meta_checksum = checksum; /* Protected by the checkpoint lock. */
 
     __wt_verbose_debug2(session, WT_VERB_DISAGGREGATED_STORAGE,
       "Wrote disaggregated checkpoint metadata: lsn=%" PRIu64 ", timestamp=%" PRIu64
-      " %s"
-      ", root=\"%s\"",
+      " %s, checksum=%" PRIx32 ", root=\"%s\"",
       lsn, checkpoint_timestamp, __wt_timestamp_to_string(checkpoint_timestamp, ts_string),
-      checkpoint_root_copy);
+      checksum, checkpoint_root_copy);
 
     __wt_free(session, disagg->last_checkpoint_root);
     disagg->last_checkpoint_root = checkpoint_root_copy;
@@ -340,7 +347,8 @@ err:
  *     Pick up a new checkpoint.
  */
 static int
-__disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, uint64_t meta_lsn)
+__disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, uint64_t meta_lsn, bool has_metadata_checksum,
+  uint32_t metadata_checksum)
 {
     WT_CONFIG_ITEM cval;
     WT_CONNECTION_IMPL *conn;
@@ -350,6 +358,7 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, uint64_t meta_lsn)
     WT_SESSION_IMPL *internal_session, *shared_metadata_session;
     size_t len, metadata_value_cfg_len;
     uint64_t checkpoint_timestamp, current_meta_lsn;
+    uint32_t checksum;
     char *buf, *cfg_ret, *checkpoint_config, *root, *metadata_value_cfg, *layered_ingest_uri;
     char ts_string[WT_TS_INT_STRING_SIZE];
     const char *cfg[3], *current_value, *metadata_key, *metadata_value;
@@ -402,6 +411,16 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, uint64_t meta_lsn)
     WT_ERR_MSG_CHK(session,
       __disagg_get_meta(session, WT_DISAGG_METADATA_MAIN_PAGE_ID, meta_lsn, &item),
       "Disagg metadata fetching failed, with lsn: %" PRIu64, meta_lsn);
+
+    /* Validate the checksum. */
+    if (has_metadata_checksum) {
+        checksum = __wt_checksum(item.data, item.size);
+        if (checksum != metadata_checksum) {
+            WT_ERR_MSG(session, EIO,
+              "Checkpoint metadata checksum mismatch: expected %" PRIx32 ", got %" PRIx32,
+              metadata_checksum, checksum);
+        }
+    }
 
     /* Add the terminating zero byte to the end of the buffer. */
     len = item.size + 1;
@@ -596,7 +615,8 @@ err:
     else {
         WT_STAT_CONN_INCR(session, layered_table_manager_checkpoints_disagg_pick_up_failed);
         __wt_verbose_level(session, WT_VERB_LAYERED, WT_VERBOSE_ERROR,
-          "Disagg pick up checkpoint for meta_lsn =%" PRIu64 ", failed with: %d", meta_lsn, ret);
+          "Failed to pick up disaggregated storage checkpoint for metadata_lsn=%" PRIu64 ": ret=%d",
+          meta_lsn, ret);
     }
 
     /* Free memory allocated by the page log interface */
@@ -621,24 +641,6 @@ err:
 }
 
 /*
- * __disagg_pick_up_checkpoint_meta --
- *     Pick up a new checkpoint from metadata config.
- */
-static int
-__disagg_pick_up_checkpoint_meta(WT_SESSION_IMPL *session, WT_CONFIG_ITEM *meta_item)
-{
-    WT_CONFIG_ITEM cval;
-    uint64_t metadata_lsn;
-
-    /* Extract the arguments. */
-    WT_RET(__wt_config_subgets(session, meta_item, "metadata_lsn", &cval));
-    metadata_lsn = (uint64_t)cval.val;
-
-    /* Now actually pick up the checkpoint. */
-    return (__disagg_pick_up_checkpoint(session, metadata_lsn));
-}
-
-/*
  * __disagg_pick_up_checkpoint_meta_item --
  *     Pick up a new checkpoint from metadata config, expressed as an item.
  */
@@ -647,24 +649,58 @@ __disagg_pick_up_checkpoint_meta_item(WT_SESSION_IMPL *session, WT_ITEM *meta_it
 {
     WT_CONFIG_ITEM cval;
     WT_DECL_RET;
-    uint64_t metadata_lsn;
+    uint64_t metadata_checksum, metadata_lsn;
     char *meta_str;
+    bool has_metadata_checksum;
 
     meta_str = NULL;
+
+    has_metadata_checksum = false;
+    metadata_checksum = 0;
 
     /* Extract the item into a string. */
     WT_ERR(__wt_strndup(session, meta_item->data, meta_item->size, &meta_str));
 
-    /* Extract the arguments. */
+    /* Extract the LSN of the metadata page. */
     WT_ERR(__wt_config_getones(session, meta_str, "metadata_lsn", &cval));
     metadata_lsn = (uint64_t)cval.val;
 
+    /*
+     * Extract the checksum of the metadata page, if it exists. We added the checksum later, so
+     * treat it as optional, in order to support clusters with an earlier data format.
+     */
+    WT_ERR_NOTFOUND_OK(__wt_config_getones(session, meta_str, "metadata_checksum", &cval), true);
+    if (WT_CHECK_AND_RESET(ret, 0) && cval.len != 0) {
+        WT_ERR(__wt_conf_parse_hex(session, "metadata_checksum", &metadata_checksum, &cval));
+        if (metadata_checksum > UINT32_MAX)
+            WT_ERR_MSG(
+              session, EINVAL, "Invalid metadata checksum value: %" PRIx64, metadata_checksum);
+        has_metadata_checksum = true;
+    }
+
     /* Now actually pick up the checkpoint. */
-    WT_ERR(__disagg_pick_up_checkpoint(session, metadata_lsn));
+    WT_ERR(__disagg_pick_up_checkpoint(
+      session, metadata_lsn, has_metadata_checksum, (uint32_t)metadata_checksum));
 
 err:
     __wt_free(session, meta_str);
     return (ret);
+}
+
+/*
+ * __disagg_pick_up_checkpoint_meta --
+ *     Pick up a new checkpoint from metadata config.
+ */
+static int
+__disagg_pick_up_checkpoint_meta(WT_SESSION_IMPL *session, WT_CONFIG_ITEM *meta_item)
+{
+    WT_ITEM buf;
+
+    WT_CLEAR(buf);
+    WT_RET(__wt_buf_set(session, &buf, meta_item->str, meta_item->len));
+    WT_RET(__disagg_pick_up_checkpoint_meta_item(session, &buf));
+
+    return (0);
 }
 
 /*
@@ -1600,6 +1636,7 @@ __wt_disagg_advance_checkpoint(WT_SESSION_IMPL *session, bool ckpt_success)
     WT_DISAGGREGATED_STORAGE *disagg;
     wt_timestamp_t checkpoint_timestamp;
     uint64_t meta_lsn;
+    uint32_t meta_checksum;
     char ts_string[WT_TS_INT_STRING_SIZE];
 
     conn = S2C(session);
@@ -1612,6 +1649,11 @@ __wt_disagg_advance_checkpoint(WT_SESSION_IMPL *session, bool ckpt_success)
         return (0);
 
     WT_RET(__wt_scr_alloc(session, 0, &meta));
+
+    /* Get the checksum of the metadata page. This access is protected by the checkpoint lock. */
+    meta_checksum = conn->disaggregated_storage.last_checkpoint_meta_checksum;
+
+    /* The following accesses are read from atomic variables. */
     meta_lsn =
       __wt_atomic_load_uint64_acquire(&conn->disaggregated_storage.last_checkpoint_meta_lsn);
     checkpoint_timestamp =
@@ -1623,7 +1665,8 @@ __wt_disagg_advance_checkpoint(WT_SESSION_IMPL *session, bool ckpt_success)
          * Important: To keep testing simple, keep the metadata to be a valid configuration string
          * without quotation marks or escape characters.
          */
-        WT_ERR(__wt_buf_fmt(session, meta, "metadata_lsn=%" PRIu64, meta_lsn));
+        WT_ERR(__wt_buf_fmt(session, meta, "metadata_lsn=%" PRIu64 ",metadata_checksum=%" PRIx32,
+          meta_lsn, meta_checksum));
         WT_ERR(disagg->npage_log->page_log->pl_complete_checkpoint_ext(disagg->npage_log->page_log,
           &session->iface, 0, (uint64_t)checkpoint_timestamp, meta, NULL));
         __wt_atomic_store_uint64_release(

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -193,9 +193,11 @@ struct __wt_disaggregated_storage {
     char *page_log;
 
     /* Updates are protected by the checkpoint lock. */
+    char *last_checkpoint_root;             /* The root config of the last checkpoint. */
+    uint32_t last_checkpoint_meta_checksum; /* The checksum of the last checkpoint metadata page. */
+
     wt_shared uint64_t last_checkpoint_meta_lsn; /* The LSN of the last checkpoint metadata. */
     wt_shared uint64_t last_materialized_lsn;    /* The LSN of the last materialized page. */
-    char *last_checkpoint_root;                  /* The root config of the last checkpoint. */
 
     wt_timestamp_t cur_checkpoint_timestamp; /* The timestamp of the in-progress checkpoint. */
     wt_shared wt_timestamp_t last_checkpoint_timestamp; /* The timestamp of the last checkpoint. */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2042,6 +2042,8 @@ static WT_INLINE int __wt_conf_check_one(WT_SESSION_IMPL *session, const WT_CONF
   WT_CONFIG_ITEM *value) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_conf_gets_def_func(WT_SESSION_IMPL *session, const WT_CONF *conf,
   uint64_t keys, int def, WT_CONFIG_ITEM *value) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static WT_INLINE int __wt_conf_parse_hex(WT_SESSION_IMPL *session, const char *name,
+  uint64_t *valuep, WT_CONFIG_ITEM *cval) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_curindex_get_valuev(WT_CURSOR *cursor, va_list ap)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE int __wt_cursor_func_init(WT_CURSOR_BTREE *cbt, bool reenter)

--- a/test/suite/test_layered64.py
+++ b/test/suite/test_layered64.py
@@ -90,6 +90,7 @@ class test_layered64(wttest.WiredTigerTestCase):
 
         # Get the checkpoint metadata string and ensure that it contains a checksum.
         checkpoint_meta = self.disagg_get_complete_checkpoint_meta()
+        self.pr(f'Checkpoint metadata: {checkpoint_meta}')
         self.assertTrue('metadata_checksum=' in checkpoint_meta)
 
         # Extract the checksum from the checkpoint metadata.
@@ -103,6 +104,7 @@ class test_layered64(wttest.WiredTigerTestCase):
 
         # Ensure that we can pick up the checkpoint without a checksum.
         checkpoint_meta_no_checksum = re.sub(r',metadata_checksum=[0-9a-fA-F]+', '', checkpoint_meta)
+        self.pr(f'Checkpoint metadata without a checksum: {checkpoint_meta_no_checksum}')
         self.conn.reconfigure(f'disaggregated=(checkpoint_meta="{checkpoint_meta_no_checksum}")')
 
         # Check that all the data is present.
@@ -120,6 +122,7 @@ class test_layered64(wttest.WiredTigerTestCase):
         corrupted_checksum_hex = format(corrupted_checksum_int, 'x')
         corrupted_checkpoint_meta = checkpoint_meta.replace(f'metadata_checksum={checksum_hex}',
                                                   f'metadata_checksum={corrupted_checksum_hex}')
+        self.pr(f'Corrupted checkpoint metadata: {corrupted_checkpoint_meta}')
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.conn.reconfigure(
                 f'disaggregated=(checkpoint_meta="{corrupted_checkpoint_meta}")'),

--- a/test/suite/test_layered64.py
+++ b/test/suite/test_layered64.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import os, os.path, shutil, re, wiredtiger, wttest
+from helper_disagg import disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
+
+# test_layered64.py
+#    Test the checksum part of the checkpoint metadata.
+@disagg_test_class
+@wttest.skip_for_hook("tiered", "FIXME-WT-14938: crashing with tiered hook.")
+class test_layered64(wttest.WiredTigerTestCase):
+    conn_base_config = 'statistics=(all),' \
+                     + 'statistics_log=(wait=1,json=true,on_close=true),' \
+                     + 'precise_checkpoint=true,'
+    conn_config = conn_base_config + 'disaggregated=(role="follower")'
+
+    create_session_config = 'key_format=S,value_format=S,type=layered'
+
+    uri = "table:test_layered64"
+
+    disagg_storages = gen_disagg_storages('test_layered64', disagg_only = True)
+    scenarios = make_scenarios(disagg_storages)
+
+    num_restarts = 0
+
+    # Restart the node without local files
+    def restart_without_local_files(self):
+        # Close the current connection
+        self.close_conn()
+
+        # Move the local files to another directory
+        self.num_restarts += 1
+        dir = f'SAVE.{self.num_restarts}'
+        os.mkdir(dir)
+        for f in os.listdir():
+            if os.path.isdir(f):
+                continue
+            if f.startswith('WiredTiger') or f.startswith('test_'):
+                os.rename(f, os.path.join(dir, f))
+
+        # Also save the PALI database (to aid debugging)
+        shutil.copytree('kv_home', os.path.join(dir, 'kv_home'))
+
+        # Reopen the connection
+        self.open_conn()
+
+    # Test checkpoint metadata checksums.
+    def test_layered64(self):
+        self.conn.reconfigure('disaggregated=(role="leader")')
+
+        self.session.create(self.uri, self.create_session_config)
+
+        # Create tables with some data.
+        self.session.begin_transaction()
+        cursor = self.session.open_cursor(self.uri, None, None)
+        cursor['a'] = 'value1'
+        cursor['b'] = 'value2'
+        cursor['c'] = 'value3'
+        cursor.close()
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(1))
+
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(1))
+        self.session.checkpoint()
+
+        # Get the checkpoint metadata string and ensure that it contains a checksum.
+        checkpoint_meta = self.disagg_get_complete_checkpoint_meta()
+        self.assertTrue('metadata_checksum=' in checkpoint_meta)
+
+        # Extract the checksum from the checkpoint metadata.
+        match = re.search(r'metadata_checksum=([0-9a-fA-F]+)', checkpoint_meta)
+        checksum_hex = match.group(1)
+        checksum_int = int(checksum_hex, 16)
+
+        # Prevent the shutdown checkpoint, and restart as follower.
+        self.conn.reconfigure('disaggregated=(role="follower")')
+        self.restart_without_local_files()
+
+        # Ensure that we can pick up the checkpoint without a checksum.
+        checkpoint_meta_no_checksum = re.sub(r',metadata_checksum=[0-9a-fA-F]+', '', checkpoint_meta)
+        self.conn.reconfigure(f'disaggregated=(checkpoint_meta="{checkpoint_meta_no_checksum}")')
+
+        # Check that all the data is present.
+        cursor = self.session.open_cursor(self.uri, None, None)
+        self.assertEqual(cursor['a'], 'value1')
+        self.assertEqual(cursor['b'], 'value2')
+        self.assertEqual(cursor['c'], 'value3')
+        cursor.close()
+
+        # Restart again.
+        self.restart_without_local_files()
+
+        # Corrupt the checksum. Ensure that the follower cannot pick up the checkpoint.
+        corrupted_checksum_int = checksum_int ^ 0xFF
+        corrupted_checksum_hex = format(corrupted_checksum_int, 'x')
+        corrupted_checkpoint_meta = checkpoint_meta.replace(f'metadata_checksum={checksum_hex}',
+                                                  f'metadata_checksum={corrupted_checksum_hex}')
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.conn.reconfigure(
+                f'disaggregated=(checkpoint_meta="{corrupted_checkpoint_meta}")'),
+            "/Checkpoint metadata checksum mismatch/")


### PR DESCRIPTION
Compute a checksum of the checkpoint metadata page (`table_id` = 1, `page_id` = 1) and keep it in the `checkpoint_meta` to quickly detect corruption.