### PR TITLE
WT-15989 checkpoint-test (disagg.mode=leader, PALite, UBSAN) undefined symbol

### DIFF
--- a/test/checkpoint/CMakeLists.txt
+++ b/test/checkpoint/CMakeLists.txt
@@ -7,6 +7,13 @@ create_test_executable(test_checkpoint
         ${CMAKE_CURRENT_SOURCE_DIR}/recovery-test.sh
 )
 
+# Use C++ linker for building this target.
+# When building sanitized builds (ASan, UBSan, etc) the C++ linker is required
+# to link against the C++ sanitizer runtimes.
+# Some extensions (PALite, tiered storage) require C++ runtime to be linked
+# for sanitizers to work correctly.
+set_target_properties(test_checkpoint PROPERTIES LINKER_LANGUAGE CXX)
+
 # Define test variants for the checkpoint test
 define_test_variants(test_checkpoint
     VARIANTS


### PR DESCRIPTION
- Use C++ linker to build `test_checkpoint` executable.
- C++ linker is required for correct sanitized build (ASan, UBSan, etc.).