### PR TITLE
WT-15807 Fix evicting unmaterialized pages during file close

### DIFF
--- a/src/evict/evict_file.c
+++ b/src/evict/evict_file.c
@@ -107,10 +107,10 @@ __wt_evict_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
             /*
              * Discard the page regardless of whether it is dirty or clean. The check to determine
              * if the page can be evicted is not comprehensive but performs basic validation of the
-             * page's status. In the disaggregated architecture, there may be situations where a file
-             * needs to be closed even if its pages have not been fully materialized. In such cases,
-             * return an error to ensure the pages remain readable later. Otherwise, you risk losing
-             * access to those pages upon attempting retrieval.
+             * page's status. In the disaggregated architecture, there may be situations where a
+             * file needs to be closed even if its pages have not been fully materialized. In such
+             * cases, return an error to ensure the pages remain readable later. Otherwise, you risk
+             * losing access to those pages upon attempting retrieval.
              */
             if (F_ISSET(dhandle, WT_DHANDLE_DEAD) ||
               F_ISSET_ATOMIC_32(S2C(session), WT_CONN_CLOSING) ||

--- a/src/evict/evict_file.c
+++ b/src/evict/evict_file.c
@@ -105,14 +105,19 @@ __wt_evict_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
             break;
         case WT_SYNC_DISCARD:
             /*
-             * Discard the page whether it is dirty or not. The check if the page can be evicted is
-             * not exhaustive, but provides basic checking on the page's status.
+             * Discard the page regardless of whether it is dirty or clean. The check to determine
+             * if the page can be evicted is not comprehensive but performs basic validation of the
+             * page's status. In the disaggregated architecture, there may be situations where a file
+             * needs to be closed even if its pages have not been fully materialized. In such cases,
+             * return an error to ensure the pages remain readable later. Otherwise, you risk losing
+             * access to those pages upon attempting retrieval.
              */
-            WT_ASSERT(session,
-              F_ISSET(dhandle, WT_DHANDLE_DEAD) ||
-                F_ISSET_ATOMIC_32(S2C(session), WT_CONN_CLOSING) ||
-                __wt_page_can_evict(session, ref, NULL));
-            __wt_ref_out(session, ref);
+            if (F_ISSET(dhandle, WT_DHANDLE_DEAD) ||
+              F_ISSET_ATOMIC_32(S2C(session), WT_CONN_CLOSING) ||
+              __wt_page_can_evict(session, ref, NULL))
+                __wt_ref_out(session, ref);
+            else
+                WT_ERR(__wt_set_return(session, EBUSY));
             break;
         case WT_SYNC_CHECKPOINT:
         case WT_SYNC_WRITE_LEAVES:

--- a/test/suite/test_layered39.py
+++ b/test/suite/test_layered39.py
@@ -110,11 +110,3 @@ class test_layered39(wttest.WiredTigerTestCase):
         self.assertRaisesException(wiredtiger.WiredTigerError,
             lambda: self.conn.set_context_uint(wiredtiger.WT_CONTEXT_TYPE_LAST_MATERIALIZED_LSN,
                                                last_lsn + 5))
-
-        # FIXME-WT-15807: layered39 aborts when closing dhandle as part of verify.
-        # Delete all code below this point as part of this ticket.
-        self.close_conn()
-
-        # Ignore "Removing local file due to disagg mode" messages printed by
-        # __wti_ensure_clean_startup_dir during disagg mode restarts.
-        self.ignoreStdoutPattern('local file')

--- a/test/suite/test_layered66.py
+++ b/test/suite/test_layered66.py
@@ -79,3 +79,13 @@ class test_layered66(wttest.WiredTigerTestCase):
 
         self.assertRaises(wiredtiger.WiredTigerError, lambda:
             self.session.verify(self.uri))
+
+        # Update the last materialized LSN to the checkpoint LSN.
+        (ret, checkpoint_last_lsn) = page_log.pl_get_last_lsn(self.session)
+        self.assertEqual(ret, 0)
+
+        page_log.pl_set_last_materialized_lsn(self.session, checkpoint_last_lsn)
+        self.conn.set_context_uint(wiredtiger.WT_CONTEXT_TYPE_LAST_MATERIALIZED_LSN, checkpoint_last_lsn)
+
+        # Verify should now succeed.
+        self.session.verify(self.uri)

--- a/test/suite/test_layered66.py
+++ b/test/suite/test_layered66.py
@@ -26,7 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import os, os.path, shutil, threading, time, wiredtiger, wttest
+import wiredtiger, wttest
 from helper_disagg import disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 

--- a/test/suite/test_layered66.py
+++ b/test/suite/test_layered66.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import os, os.path, shutil, threading, time, wiredtiger, wttest
+from helper_disagg import disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
+
+# test_layered66.py
+#    Test evicting pages that haven't been materialized when closing a file
+#    returns an error.
+@disagg_test_class
+class test_layered66(wttest.WiredTigerTestCase):
+    conn_config = 'disaggregated=(role="leader")'
+
+    create_session_config = 'key_format=i,value_format=S'
+
+    uri = "layered:test_layered66"
+
+    disagg_storages = gen_disagg_storages('test_layered66', disagg_only = True)
+    scenarios = make_scenarios(disagg_storages)
+
+    def test_layered66(self):
+        page_log = self.conn.get_page_log(self.vars.page_log)
+        self.session.create(self.uri, self.create_session_config)
+
+        # Insert a key.
+        self.session.begin_transaction()
+        cursor = self.session.open_cursor(self.uri)
+        cursor[1] = 'value1'
+        cursor.close()
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(1))
+
+        # Do a checkpoint.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(1))
+        self.session.checkpoint()
+
+        (ret, checkpoint_last_lsn) = page_log.pl_get_last_lsn(self.session)
+        self.assertEqual(ret, 0)
+
+        page_log.pl_set_last_materialized_lsn(self.session, checkpoint_last_lsn)
+        self.conn.reconfigure(f'disaggregated=(last_materialized_lsn={checkpoint_last_lsn})')
+
+        # Insert another key.
+        self.session.begin_transaction()
+        cursor = self.session.open_cursor(self.uri)
+        cursor[2] = 'value1'
+        cursor.close()
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(2))
+
+        # Do a second checkpoint.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(2))
+        self.session.checkpoint()
+
+        self.assertRaises(wiredtiger.WiredTigerError, lambda:
+            self.session.verify(self.uri))

--- a/test/suite/test_layered66.py
+++ b/test/suite/test_layered66.py
@@ -64,7 +64,7 @@ class test_layered66(wttest.WiredTigerTestCase):
         self.assertEqual(ret, 0)
 
         page_log.pl_set_last_materialized_lsn(self.session, checkpoint_last_lsn)
-        self.conn.reconfigure(f'disaggregated=(last_materialized_lsn={checkpoint_last_lsn})')
+        self.conn.set_context_uint(wiredtiger.WT_CONTEXT_TYPE_LAST_MATERIALIZED_LSN, checkpoint_last_lsn)
 
         # Insert another key.
         self.session.begin_transaction()

--- a/test/suite/test_layered66.py
+++ b/test/suite/test_layered66.py
@@ -59,6 +59,7 @@ class test_layered66(wttest.WiredTigerTestCase):
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(1))
         self.session.checkpoint()
 
+        # Update the last materialized LSN to the checkpoint LSN.
         (ret, checkpoint_last_lsn) = page_log.pl_get_last_lsn(self.session)
         self.assertEqual(ret, 0)
 


### PR DESCRIPTION
When closing the file, we should also ensure all the pages on that file are materialized.
