### PR TITLE
WT-15999 Add virtual destructor to kv_transaction_snapshot

### DIFF
--- a/test/model/CMakeLists.txt
+++ b/test/model/CMakeLists.txt
@@ -38,7 +38,7 @@ target_include_directories(
 
 target_compile_options(
     wiredtiger_model
-    PUBLIC -std=c++17
+    PUBLIC -std=c++17 -Wnon-virtual-dtor
     PRIVATE ${COMPILER_DIAGNOSTIC_CXX_FLAGS}
 )
 

--- a/test/model/src/include/model/kv_transaction_snapshot.h
+++ b/test/model/src/include/model/kv_transaction_snapshot.h
@@ -47,6 +47,12 @@ class kv_transaction_snapshot {
 
 public:
     /*
+     * kv_transaction_snapshot::~kv_transaction_snapshot --
+     *     Destroy the snapshot.
+     */
+    virtual ~kv_transaction_snapshot() = default;
+
+    /*
      * kv_transaction_snapshot::contains --
      *     Check whether the given update belongs to the snapshot.
      */


### PR DESCRIPTION
Added a missing virtual destructor to `kv_transaction_snapshot` and enabled the corresponding warning (just for `test/model`).