### PR TITLE
WT-15993 Only set transaction error for required api calls

### DIFF
--- a/src/docs/arch-schema.dox
+++ b/src/docs/arch-schema.dox
@@ -93,9 +93,15 @@ WT_SESSION::drop operation drops the specified \c uri. The method will delete al
 and metadata entries. It is possible to keep the underlying files by specifying
 \c "remove_files=false" in the config string.
 
+Although the drop operation is non-transactional, if it fails, it will force the current
+transaction to roll back to avoid potential disruption to the data written by the transaction.
+
 @subsection schema_alter Alter
 
 WT_SESSION::alter allows modification of some table settings after creation.
+
+Although the alter operation is non-transactional, if it fails, it will force the current
+transaction to roll back to avoid potential disruption to the data written by the transaction.
 
 @subsection schema_truncate Truncate
 

--- a/src/include/api.h
+++ b/src/include/api.h
@@ -274,7 +274,7 @@
     API_CALL_NOCONF(s, WT_SESSION, func_name, NULL, false)
 
 #define SESSION_API_CALL_PREPARE_NOT_ALLOWED(s, ret, func_name, config, cfg, set_err) \
-    API_CALL(s, WT_SESSION, func_name, NULL, config, cfg, set_err);             \
+    API_CALL(s, WT_SESSION, func_name, NULL, config, cfg, set_err);                   \
     SESSION_API_PREPARE_CHECK(s, ret, WT_SESSION, func_name)
 
 #define SESSION_API_CALL_PREPARE_NOT_ALLOWED_NOCONF(s, ret, func_name) \
@@ -296,7 +296,7 @@
         }                                                                                        \
     } while (0)
 
-#define SESSION_API_CALL(s, ret, func_name, config, cfg, set_err) \
+#define SESSION_API_CALL(s, ret, func_name, config, cfg, set_err)   \
     API_CALL(s, WT_SESSION, func_name, NULL, config, cfg, set_err); \
     SESSION_API_PREPARE_CHECK(s, ret, WT_SESSION, func_name)
 

--- a/src/include/api.h
+++ b/src/include/api.h
@@ -273,8 +273,8 @@
 #define SESSION_API_CALL_PREPARE_ALLOWED_NOCONF(s, func_name) \
     API_CALL_NOCONF(s, WT_SESSION, func_name, NULL, false)
 
-#define SESSION_API_CALL_PREPARE_NOT_ALLOWED(s, ret, func_name, config, cfg) \
-    API_CALL(s, WT_SESSION, func_name, NULL, config, cfg, false);            \
+#define SESSION_API_CALL_PREPARE_NOT_ALLOWED(s, ret, func_name, config, cfg, set_err) \
+    API_CALL(s, WT_SESSION, func_name, NULL, config, cfg, set_err);             \
     SESSION_API_PREPARE_CHECK(s, ret, WT_SESSION, func_name)
 
 #define SESSION_API_CALL_PREPARE_NOT_ALLOWED_NOCONF(s, ret, func_name) \
@@ -296,8 +296,8 @@
         }                                                                                        \
     } while (0)
 
-#define SESSION_API_CALL(s, ret, func_name, config, cfg)          \
-    API_CALL(s, WT_SESSION, func_name, NULL, config, cfg, false); \
+#define SESSION_API_CALL(s, ret, func_name, config, cfg, set_err) \
+    API_CALL(s, WT_SESSION, func_name, NULL, config, cfg, set_err); \
     SESSION_API_PREPARE_CHECK(s, ret, WT_SESSION, func_name)
 
 #define SESSION_API_CALL_NOCONF(s, func_name) API_CALL_NOCONF(s, WT_SESSION, func_name, NULL, false)

--- a/src/include/api.h
+++ b/src/include/api.h
@@ -93,19 +93,19 @@
         __wt_session_reset_last_error((s));                                              \
     __wt_verbose((s), WT_VERB_API, "%s", "CALL: " #struct_name ":" #func_name)
 
-#define API_CALL_NOCONF_NOERRCLEAR(s, struct_name, func_name, dh) \
-    do {                                                          \
-        bool __set_err = true;                                    \
+#define API_CALL_NOCONF_NOERRCLEAR(s, struct_name, func_name, dh, set_err) \
+    do {                                                                   \
+        bool __set_err = (set_err);                                        \
     API_SESSION_INIT(s, struct_name, func_name, dh)
 
-#define API_CALL_NOCONF(s, struct_name, func_name, dh)                  \
-    API_CALL_NOCONF_NOERRCLEAR(s, struct_name, func_name, dh);          \
+#define API_CALL_NOCONF(s, struct_name, func_name, dh, set_err)         \
+    API_CALL_NOCONF_NOERRCLEAR(s, struct_name, func_name, dh, set_err); \
     if ((s)->api_call_counter == 1 && !F_ISSET(s, WT_SESSION_INTERNAL)) \
         __wt_error_log_clear_helper();
 
-#define API_CALL(s, struct_name, func_name, dh, config, cfg)                                \
+#define API_CALL(s, struct_name, func_name, dh, config, cfg, set_err)                       \
     do {                                                                                    \
-        bool __set_err = true;                                                              \
+        bool __set_err = (set_err);                                                         \
         const char *(cfg)[] = {WT_CONFIG_BASE(s, struct_name##_##func_name), config, NULL}; \
         API_SESSION_INIT(s, struct_name, func_name, dh);                                    \
         if ((s)->api_call_counter == 1 && !F_ISSET(s, WT_SESSION_INTERNAL))                 \
@@ -160,7 +160,7 @@
 #define TXN_API_CALL(s, struct_name, func_name, dh, config, cfg)            \
     do {                                                                    \
         bool __autotxn = false, __update = false;                           \
-        API_CALL(s, struct_name, func_name, dh, config, cfg);               \
+        API_CALL(s, struct_name, func_name, dh, config, cfg, true);         \
         __autotxn = !F_ISSET((s)->txn, WT_TXN_AUTOCOMMIT | WT_TXN_RUNNING); \
         if (__autotxn)                                                      \
             F_SET((s)->txn, WT_TXN_AUTOCOMMIT);                             \
@@ -172,7 +172,7 @@
 #define TXN_API_CALL_NOCONF(s, struct_name, func_name, dh)                  \
     do {                                                                    \
         bool __autotxn = false, __update = false;                           \
-        API_CALL_NOCONF(s, struct_name, func_name, dh);                     \
+        API_CALL_NOCONF(s, struct_name, func_name, dh, true);               \
         __autotxn = !F_ISSET((s)->txn, WT_TXN_AUTOCOMMIT | WT_TXN_RUNNING); \
         if (__autotxn)                                                      \
             F_SET((s)->txn, WT_TXN_AUTOCOMMIT);                             \
@@ -257,28 +257,28 @@
 
 #define CONNECTION_API_CALL(conn, s, func_name, config, cfg) \
     s = (conn)->default_session;                             \
-    API_CALL(s, WT_CONNECTION, func_name, NULL, config, cfg)
+    API_CALL(s, WT_CONNECTION, func_name, NULL, config, cfg, false)
 
 #define CONNECTION_API_CALL_NOCONF(conn, s, func_name) \
     s = (conn)->default_session;                       \
-    API_CALL_NOCONF(s, WT_CONNECTION, func_name, NULL)
+    API_CALL_NOCONF(s, WT_CONNECTION, func_name, NULL, false)
 
 #define CONNECTION_API_CALL_NOCONF_NOERRCLEAR(conn, s, func_name) \
     s = (conn)->default_session;                                  \
-    API_CALL_NOCONF_NOERRCLEAR(s, WT_CONNECTION, func_name, NULL)
+    API_CALL_NOCONF_NOERRCLEAR(s, WT_CONNECTION, func_name, NULL, false)
 
 #define SESSION_API_CALL_PREPARE_ALLOWED(s, func_name, config, cfg) \
-    API_CALL(s, WT_SESSION, func_name, NULL, config, cfg)
+    API_CALL(s, WT_SESSION, func_name, NULL, config, cfg, false)
 
 #define SESSION_API_CALL_PREPARE_ALLOWED_NOCONF(s, func_name) \
-    API_CALL_NOCONF(s, WT_SESSION, func_name, NULL)
+    API_CALL_NOCONF(s, WT_SESSION, func_name, NULL, false)
 
 #define SESSION_API_CALL_PREPARE_NOT_ALLOWED(s, ret, func_name, config, cfg) \
-    API_CALL(s, WT_SESSION, func_name, NULL, config, cfg);                   \
+    API_CALL(s, WT_SESSION, func_name, NULL, config, cfg, false);            \
     SESSION_API_PREPARE_CHECK(s, ret, WT_SESSION, func_name)
 
 #define SESSION_API_CALL_PREPARE_NOT_ALLOWED_NOCONF(s, ret, func_name) \
-    API_CALL_NOCONF(s, WT_SESSION, func_name, NULL);                   \
+    API_CALL_NOCONF(s, WT_SESSION, func_name, NULL, false);            \
     SESSION_API_PREPARE_CHECK(s, ret, WT_SESSION, func_name)
 
 #define SESSION_API_PREPARE_CHECK(s, ret, struct_name, func_name)                                \
@@ -296,11 +296,11 @@
         }                                                                                        \
     } while (0)
 
-#define SESSION_API_CALL(s, ret, func_name, config, cfg)   \
-    API_CALL(s, WT_SESSION, func_name, NULL, config, cfg); \
+#define SESSION_API_CALL(s, ret, func_name, config, cfg)          \
+    API_CALL(s, WT_SESSION, func_name, NULL, config, cfg, false); \
     SESSION_API_PREPARE_CHECK(s, ret, WT_SESSION, func_name)
 
-#define SESSION_API_CALL_NOCONF(s, func_name) API_CALL_NOCONF(s, WT_SESSION, func_name, NULL)
+#define SESSION_API_CALL_NOCONF(s, func_name) API_CALL_NOCONF(s, WT_SESSION, func_name, NULL, false)
 
 #define SESSION_TXN_API_CALL(s, ret, func_name, config, cfg)   \
     TXN_API_CALL(s, WT_SESSION, func_name, NULL, config, cfg); \
@@ -308,21 +308,21 @@
 
 #define CURSOR_API_CALL(cur, s, ret, func_name, dh)          \
     (s) = CUR2S(cur);                                        \
-    API_CALL_NOCONF(s, WT_CURSOR, func_name, dh);            \
+    API_CALL_NOCONF(s, WT_CURSOR, func_name, dh, true);      \
     SESSION_API_PREPARE_CHECK(s, ret, WT_CURSOR, func_name); \
     if (F_ISSET(cur, WT_CURSTD_CACHED))                      \
     WT_ERR(__wt_cursor_cached(cur))
 
 #define CURSOR_API_CALL_CONF(cur, s, ret, func_name, config, cfg, dh) \
     (s) = CUR2S(cur);                                                 \
-    API_CALL(s, WT_CURSOR, func_name, (dh), config, cfg);             \
+    API_CALL(s, WT_CURSOR, func_name, (dh), config, cfg, true);       \
     SESSION_API_PREPARE_CHECK(s, ret, WT_CURSOR, func_name);          \
     if (F_ISSET(cur, WT_CURSTD_CACHED))                               \
     WT_ERR(__wt_cursor_cached(cur))
 
 #define CURSOR_API_CALL_PREPARE_ALLOWED(cur, s, func_name, dh) \
     (s) = CUR2S(cur);                                          \
-    API_CALL_NOCONF(s, WT_CURSOR, func_name, (dh));            \
+    API_CALL_NOCONF(s, WT_CURSOR, func_name, (dh), true);      \
     if (F_ISSET(cur, WT_CURSTD_CACHED))                        \
     WT_ERR(__wt_cursor_cached(cur))
 

--- a/src/include/api.h
+++ b/src/include/api.h
@@ -267,8 +267,8 @@
     s = (conn)->default_session;                                  \
     API_CALL_NOCONF_NOERRCLEAR(s, WT_CONNECTION, func_name, NULL, false)
 
-#define SESSION_API_CALL_PREPARE_ALLOWED(s, func_name, config, cfg) \
-    API_CALL(s, WT_SESSION, func_name, NULL, config, cfg, false)
+#define SESSION_API_CALL_PREPARE_ALLOWED(s, func_name, config, cfg, set_err) \
+    API_CALL(s, WT_SESSION, func_name, NULL, config, cfg, set_err)
 
 #define SESSION_API_CALL_PREPARE_ALLOWED_NOCONF(s, func_name) \
     API_CALL_NOCONF(s, WT_SESSION, func_name, NULL, false)

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -1086,7 +1086,9 @@ struct __wt_session {
      * Alter a table.
      *
      * This will allow modification of some table settings after
-     * creation. Although the alter operation is non-transactional, if it fails, it will force the current transaction to roll back to avoid potential disruption to the data written by the transaction.
+     * creation. Although the alter operation is non-transactional, if it fails, it will force the
+     * current transaction to roll back to avoid potential disruption to the data written by the
+     * transaction.
      *
      * @exclusive
      *
@@ -1414,7 +1416,9 @@ struct __wt_session {
     /*!
      * Drop (delete) a table.
      *
-     * Although the drop operation is non-transactional, if it fails, it will force the current transaction to roll back to avoid potential disruption to the data written by the transaction.
+     * Although the drop operation is non-transactional, if it fails, it will force the current
+     * transaction to roll back to avoid potential disruption to the data written by the
+     * transaction.
      *
      * @exclusive
      *

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -1086,7 +1086,7 @@ struct __wt_session {
      * Alter a table.
      *
      * This will allow modification of some table settings after
-     * creation.
+     * creation. Although the alter operation is non-transactional, if it fails, it will force the current transaction to roll back to avoid potential disruption to the data written by the transaction.
      *
      * @exclusive
      *
@@ -1413,6 +1413,8 @@ struct __wt_session {
 
     /*!
      * Drop (delete) a table.
+     *
+     * Although the drop operation is non-transactional, if it fails, it will force the current transaction to roll back to avoid potential disruption to the data written by the transaction.
      *
      * @exclusive
      *

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -1085,10 +1085,9 @@ struct __wt_session {
     /*!
      * Alter a table.
      *
-     * This will allow modification of some table settings after
-     * creation. Although the alter operation is non-transactional, if it fails, it will force the
-     * current transaction to roll back to avoid potential disruption to the data written by the
-     * transaction.
+     * This will allow modification of some table settings after creation. Although the alter
+     * operation is non-transactional, if it fails, it will force the current transaction to
+     * roll back to avoid potential disruption to the data written by the transaction.
      *
      * @exclusive
      *

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -854,7 +854,7 @@ __session_open_cursor(WT_SESSION *wt_session, const char *uri, WT_CURSOR *to_dup
     hash_value = 0;
     dup_backup = false;
     session = (WT_SESSION_IMPL *)wt_session;
-    SESSION_API_CALL(session, ret, open_cursor, config, cfg);
+    SESSION_API_CALL(session, ret, open_cursor, config, cfg, false);
 
 #ifdef HAVE_DIAGNOSTIC
     if (session->cursor_open_timer_running == false) {
@@ -1024,7 +1024,7 @@ __session_alter(WT_SESSION *wt_session, const char *uri, const char *config)
     WT_SESSION_IMPL *session;
 
     session = (WT_SESSION_IMPL *)wt_session;
-    SESSION_API_CALL(session, ret, alter, config, cfg);
+    SESSION_API_CALL(session, ret, alter, config, cfg, true);
     /*
      * We replace the default configuration listing with the current configuration. Otherwise the
      * defaults for values that can be altered would override settings used by the user in create.
@@ -1122,7 +1122,7 @@ __session_create(WT_SESSION *wt_session, const char *uri, const char *config)
     session = (WT_SESSION_IMPL *)wt_session;
     is_import = session->import_list != NULL ||
       (__wt_config_getones(session, config, "import.enabled", &cval) == 0 && cval.val != 0);
-    SESSION_API_CALL(session, ret, create, config, cfg);
+    SESSION_API_CALL(session, ret, create, config, cfg, false);
     WT_UNUSED(cfg);
 
     /* Disallow objects in the WiredTiger name space. */
@@ -1197,7 +1197,7 @@ __session_log_flush(WT_SESSION *wt_session, const char *config)
     uint32_t flags;
 
     session = (WT_SESSION_IMPL *)wt_session;
-    SESSION_API_CALL(session, ret, log_flush, config, cfg);
+    SESSION_API_CALL(session, ret, log_flush, config, cfg, false);
     WT_STAT_CONN_INCR(session, log_flush);
 
     conn = S2C(session);
@@ -1349,7 +1349,7 @@ __session_drop(WT_SESSION *wt_session, const char *uri, const char *config)
     bool checkpoint_wait, lock_wait;
 
     session = (WT_SESSION_IMPL *)wt_session;
-    SESSION_API_CALL(session, ret, drop, config, cfg);
+    SESSION_API_CALL(session, ret, drop, config, cfg, true);
 
     /* Disallow objects in the WiredTiger name space. */
     WT_ERR(__wt_str_name_check(session, uri));
@@ -1445,7 +1445,7 @@ __session_salvage(WT_SESSION *wt_session, const char *uri, const char *config)
 
     session = (WT_SESSION_IMPL *)wt_session;
 
-    SESSION_API_CALL(session, ret, salvage, config, cfg);
+    SESSION_API_CALL(session, ret, salvage, config, cfg, false);
 
     WT_ERR(__wt_inmem_unsupported_op(session, NULL));
 
@@ -1810,7 +1810,7 @@ __session_verify(WT_SESSION *wt_session, const char *uri, const char *config)
     WT_SESSION_IMPL *session;
 
     session = (WT_SESSION_IMPL *)wt_session;
-    SESSION_API_CALL(session, ret, verify, config, cfg);
+    SESSION_API_CALL(session, ret, verify, config, cfg, false);
     WT_ERR(__wt_inmem_unsupported_op(session, NULL));
 
     /* Block out checkpoints to avoid spurious EBUSY errors. */
@@ -1978,7 +1978,7 @@ __session_prepare_transaction(WT_SESSION *wt_session, const char *config)
     WT_SESSION_IMPL *session;
 
     session = (WT_SESSION_IMPL *)wt_session;
-    SESSION_API_CALL(session, ret, prepare_transaction, config, cfg);
+    SESSION_API_CALL(session, ret, prepare_transaction, config, cfg, true);
     WT_STAT_CONN_INCR(session, txn_prepare);
     WT_STAT_CONN_INCR(session, txn_prepare_active);
 
@@ -2420,7 +2420,7 @@ __session_checkpoint(WT_SESSION *wt_session, const char *config)
 
     session = (WT_SESSION_IMPL *)wt_session;
     WT_STAT_CONN_INCR(session, checkpoints_api);
-    SESSION_API_CALL_PREPARE_NOT_ALLOWED(session, ret, checkpoint, config, cfg);
+    SESSION_API_CALL_PREPARE_NOT_ALLOWED(session, ret, checkpoint, config, cfg, true);
 
     WT_ERR(__wt_inmem_unsupported_op(session, NULL));
 

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -316,7 +316,7 @@ __session_close(WT_SESSION *wt_session, const char *config)
 
     session = (WT_SESSION_IMPL *)wt_session;
 
-    SESSION_API_CALL_PREPARE_ALLOWED(session, close, config, cfg);
+    SESSION_API_CALL_PREPARE_ALLOWED(session, close, config, cfg, false);
     WT_UNUSED(cfg);
 
     WT_TRET(__wt_session_close_internal(session));
@@ -1908,7 +1908,7 @@ __session_commit_transaction(WT_SESSION *wt_session, const char *config)
 
     session = (WT_SESSION_IMPL *)wt_session;
     txn = session->txn;
-    SESSION_API_CALL_PREPARE_ALLOWED(session, commit_transaction, config, cfg);
+    SESSION_API_CALL_PREPARE_ALLOWED(session, commit_transaction, config, cfg, false);
     WT_STAT_CONN_INCR(session, txn_commit);
 
     if (F_ISSET(txn, WT_TXN_PREPARE)) {
@@ -2027,7 +2027,7 @@ __session_rollback_transaction(WT_SESSION *wt_session, const char *config)
     WT_TXN *txn;
 
     session = (WT_SESSION_IMPL *)wt_session;
-    SESSION_API_CALL_PREPARE_ALLOWED(session, rollback_transaction, config, cfg);
+    SESSION_API_CALL_PREPARE_ALLOWED(session, rollback_transaction, config, cfg, false);
     WT_STAT_CONN_INCR(session, txn_rollback);
 
     txn = session->txn;
@@ -2094,9 +2094,9 @@ __session_timestamp_transaction(WT_SESSION *wt_session, const char *config)
 
     session = (WT_SESSION_IMPL *)wt_session;
 #ifdef HAVE_DIAGNOSTIC
-    SESSION_API_CALL_PREPARE_ALLOWED(session, timestamp_transaction, config, cfg);
+    SESSION_API_CALL_PREPARE_ALLOWED(session, timestamp_transaction, config, cfg, true);
 #else
-    SESSION_API_CALL_PREPARE_ALLOWED(session, timestamp_transaction, NULL, cfg);
+    SESSION_API_CALL_PREPARE_ALLOWED(session, timestamp_transaction, NULL, cfg, true);
     cfg[1] = config;
 #endif
 
@@ -2182,9 +2182,9 @@ __session_prepared_id_transaction(WT_SESSION *wt_session, const char *config)
 
     session = (WT_SESSION_IMPL *)wt_session;
 #ifdef HAVE_DIAGNOSTIC
-    SESSION_API_CALL_PREPARE_ALLOWED(session, prepared_id_transaction, config, cfg);
+    SESSION_API_CALL_PREPARE_ALLOWED(session, prepared_id_transaction, config, cfg, true);
 #else
-    SESSION_API_CALL_PREPARE_ALLOWED(session, prepared_id_transaction, NULL, cfg);
+    SESSION_API_CALL_PREPARE_ALLOWED(session, prepared_id_transaction, NULL, cfg, true);
     cfg[1] = config;
 #endif
 
@@ -2266,7 +2266,7 @@ __session_query_timestamp(WT_SESSION *wt_session, char *hex_timestamp, const cha
     WT_SESSION_IMPL *session;
 
     session = (WT_SESSION_IMPL *)wt_session;
-    SESSION_API_CALL_PREPARE_ALLOWED(session, query_timestamp, config, cfg);
+    SESSION_API_CALL_PREPARE_ALLOWED(session, query_timestamp, config, cfg, false);
 
     ret = __wt_txn_query_timestamp(session, hex_timestamp, cfg, false);
 err:

--- a/src/session/session_compact.c
+++ b/src/session/session_compact.c
@@ -403,7 +403,7 @@ __wti_session_compact(WT_SESSION *wt_session, const char *uri, const char *confi
     u_int i;
 
     session = (WT_SESSION_IMPL *)wt_session;
-    SESSION_API_CALL(session, ret, compact, config, cfg);
+    SESSION_API_CALL(session, ret, compact, config, cfg, false);
 
     if (__wt_conn_is_disagg(session))
         WT_ERR_MSG(session, ENOTSUP, "Compaction does not work with disaggregated storage.");

--- a/test/catch2/cursors/api/test_bulk_cursor.cpp
+++ b/test/catch2/cursors/api/test_bulk_cursor.cpp
@@ -376,6 +376,6 @@ TEST_CASE("Cursor: bulk, non-bulk, checkpoint and drop combinations", "[cursor]"
 
     // multiple_drop_test("", 0, EINVAL, false, diagnostics);
     // multiple_drop_test("", 0, EINVAL, true, diagnostics);
-    // multiple_drop_test("bulk", EINVAL, 0, false, diagnostics);
+    multiple_drop_test("bulk", EINVAL, 0, false, diagnostics);
     multiple_drop_test("bulk", EINVAL, 0, true, diagnostics);
 }

--- a/test/catch2/cursors/api/test_bulk_cursor.cpp
+++ b/test/catch2/cursors/api/test_bulk_cursor.cpp
@@ -376,6 +376,6 @@ TEST_CASE("Cursor: bulk, non-bulk, checkpoint and drop combinations", "[cursor]"
 
     // multiple_drop_test("", 0, EINVAL, false, diagnostics);
     // multiple_drop_test("", 0, EINVAL, true, diagnostics);
-    multiple_drop_test("bulk", EINVAL, 0, false, diagnostics);
+    // multiple_drop_test("bulk", EINVAL, 0, false, diagnostics);
     multiple_drop_test("bulk", EINVAL, 0, true, diagnostics);
 }

--- a/test/suite/test_txn30.py
+++ b/test/suite/test_txn30.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wiredtiger, wttest
+from helper import simulate_crash_restart
+
+# test_txn30.py
+#   Test schema operation failures should not block transaction commit.
+class test_txn30(wttest.WiredTigerTestCase):
+
+    def test_txn30(self):
+        uri = "file:txn30"
+
+        # Create a table
+        self.session.create(uri, 'key_format=i,value_format=S,exclusive=true')
+
+        # Start a transaction, do a schema operation that will fail
+        self.session.begin_transaction()
+        cursor = self.session.open_cursor(uri)
+        cursor[1] = 'value1'
+        self.assertRaises(wiredtiger.WiredTigerError,
+                                     lambda: self.session.create(uri, 'key_format=i,value_format=S,exclusive=true'))
+        self.session.commit_transaction()


### PR DESCRIPTION
We should track transaction errors only during transactional API calls. For schema operations, a failure in session::create should not result in a transaction failure, as it does not affect the current transaction's state. However, failures in session::drop or session::alter could lead to transaction issues, as they may modify the data handle that has already been affected by the ongoing transaction.