### PR TITLE
WT-16003 Fix __disagg_pick_up_checkpoint_meta memory leak

### DIFF
--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -652,11 +652,12 @@ err:
 }
 
 /*
- * __disagg_pick_up_checkpoint_meta_item --
- *     Pick up a new checkpoint from metadata config, expressed as an item.
+ * __disagg_pick_up_checkpoint_meta --
+ *     Pick up a new checkpoint from metadata config.
  */
 static int
-__disagg_pick_up_checkpoint_meta_item(WT_SESSION_IMPL *session, WT_ITEM *meta_item)
+__disagg_pick_up_checkpoint_meta(
+  WT_SESSION_IMPL *session, const char *meta_data, size_t meta_data_size)
 {
     WT_CONFIG_ITEM cval;
     WT_DECL_RET;
@@ -668,7 +669,7 @@ __disagg_pick_up_checkpoint_meta_item(WT_SESSION_IMPL *session, WT_ITEM *meta_it
     meta_str = NULL;
 
     /* Extract the item into a string. */
-    WT_ERR(__wt_strndup(session, meta_item->data, meta_item->size, &meta_str));
+    WT_ERR(__wt_strndup(session, meta_data, meta_data_size, &meta_str));
 
     /* Extract the LSN of the metadata page. */
     WT_ERR(__wt_config_getones(session, meta_str, "metadata_lsn", &cval));
@@ -694,22 +695,6 @@ __disagg_pick_up_checkpoint_meta_item(WT_SESSION_IMPL *session, WT_ITEM *meta_it
 err:
     __wt_free(session, meta_str);
     return (ret);
-}
-
-/*
- * __disagg_pick_up_checkpoint_meta --
- *     Pick up a new checkpoint from metadata config.
- */
-static int
-__disagg_pick_up_checkpoint_meta(WT_SESSION_IMPL *session, WT_CONFIG_ITEM *meta_item)
-{
-    WT_ITEM buf;
-
-    WT_CLEAR(buf);
-    WT_RET(__wt_buf_set(session, &buf, meta_item->str, meta_item->len));
-    WT_RET(__disagg_pick_up_checkpoint_meta_item(session, &buf));
-
-    return (0);
 }
 
 /*
@@ -1277,7 +1262,7 @@ __wti_disagg_conn_config(WT_SESSION_IMPL *session, const char **cfg, bool reconf
              */
             if (!leader) {
                 WT_WITH_CHECKPOINT_LOCK(
-                  session, ret = __disagg_pick_up_checkpoint_meta(session, &cval));
+                  session, ret = __disagg_pick_up_checkpoint_meta(session, cval.str, cval.len));
                 WT_ERR_MSG_CHK(session, ret, "Failed to pick up a new checkpoint with config: %.*s",
                   (int)cval.len, cval.str);
             }
@@ -1353,7 +1338,7 @@ __wti_disagg_conn_config(WT_SESSION_IMPL *session, const char **cfg, bool reconf
           __wt_config_gets(session, cfg, "disaggregated.checkpoint_meta", &cval), true);
         if (ret == 0 && cval.len > 0) {
             WT_WITH_CHECKPOINT_LOCK(
-              session, ret = __disagg_pick_up_checkpoint_meta(session, &cval));
+              session, ret = __disagg_pick_up_checkpoint_meta(session, cval.str, cval.len));
             WT_ERR_MSG_CHK(session, ret, "Failed to pick up a new checkpoint with config: %.*s",
               (int)cval.len, cval.str);
             picked_up = true;
@@ -1367,7 +1352,8 @@ __wti_disagg_conn_config(WT_SESSION_IMPL *session, const char **cfg, bool reconf
             if (ret == 0) {
                 /* Pick up the checkpoint we just found. */
                 WT_WITH_CHECKPOINT_LOCK(session,
-                  ret = __disagg_pick_up_checkpoint_meta_item(session, &complete_checkpoint_meta));
+                  ret = __disagg_pick_up_checkpoint_meta(
+                    session, complete_checkpoint_meta.data, complete_checkpoint_meta.size));
 
                 __wt_buf_free(session, &complete_checkpoint_meta);
                 WT_ERR_MSG_CHK(session, ret, "Failed to pick up checkpoint metadata");


### PR DESCRIPTION
ASAN reports the following issue:
```
Direct leak of 41 byte(s) in 1 object(s) allocated from:
    #0 0x7f2b40d05cdc in realloc /data/mci/35d44bafaf07d0d34e58f8888b61215a/toolchain-builder/tmp/build-llvm-v5.sh-dB2/llvm-project-llvmorg/compiler-rt/lib/asan/asan_malloc_linux.cpp:82:3
    #1 0x7f2b3c3a4751 in __realloc_func /home/ubuntu/work/git/wiredtiger/src/os_common/os_alloc.c:160:18
    #2 0x7f2b3c3a497e in __wt_realloc_noclear /home/ubuntu/work/git/wiredtiger/src/os_common/os_alloc.c:198:13
    #3 0x7f2b3c692eb0 in __wt_buf_grow_worker /home/ubuntu/work/git/wiredtiger/src/support/scratch.c:52:9
    #4 0x7f2b3c05ad3d in __wt_buf_grow /home/ubuntu/work/git/wiredtiger/src/include/buf_inline.h:24:9
    #5 0x7f2b3c05ab3e in __wt_buf_set /home/ubuntu/work/git/wiredtiger/src/include/buf_inline.h:88:13
    #6 0x7f2b3c053a6d in __disagg_pick_up_checkpoint_meta /home/ubuntu/work/git/wiredtiger/src/conn/conn_layered.c:709:5
    #7 0x7f2b3c0515e4 in __wti_disagg_conn_config /home/ubuntu/work/git/wiredtiger/src/conn/conn_layered.c:1279:17
    #8 0x7f2b3c0821ef in __wti_conn_reconfig /home/ubuntu/work/git/wiredtiger/src/conn/conn_reconfig.c:450:13
    #9 0x7f2b3bff5a82 in __conn_reconfigure /home/ubuntu/work/git/wiredtiger/src/conn/conn_api.c:1354:11
    #10 0x7f2b3df87878 in _wrap_Connection_reconfigure /home/ubuntu/work/git/wiredtiger/build/lang/python/CMakeFiles/wiredtiger_python.dir/wiredtigerPYTHON_wrap.c:8926:21
    #11 0x7f2b4093cee7 in cfunction_call /data/mci/ffd7bdd8113a1675e4d94dc66e419fee/toolchain-builder/tmp/build-python-v4.sh-VJS/build-Python-3.10.4/../src/Python-3.10.4/Objects/methodobject.c:552:18
```

The issue is that we allocate the content for `WT_ITEM buf` but don't clear it.
