### PR TITLE
WT-15567 Support claiming prepared transactions in test checkpoint

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -104,7 +104,7 @@ Deterministically
 Disagg
 Disaggregated
 Dk
-DmpRvXx
+DmpeRkvXx
 Dxxx
 EACCES
 EB

--- a/test/checkpoint/checkpointer.c
+++ b/test/checkpoint/checkpointer.c
@@ -33,7 +33,7 @@ static WT_THREAD_RET clock_thread(void *);
 static int compare_cursors(WT_CURSOR *, table_type, WT_CURSOR *, table_type);
 static int diagnose_key_error(WT_CURSOR *, table_type, int, WT_CURSOR *, table_type, int);
 static int real_checkpointer(THREAD_DATA *);
-static void prepare_discover(WT_CONNECTION *conn, THREAD_DATA *td);
+
 /*
  * set_stable --
  *     Set the given timestamp as the stable timestamp.
@@ -348,10 +348,6 @@ real_checkpointer(THREAD_DATA *td)
             testutil_check(g.conn->set_timestamp(g.conn, timestamp_buf));
         }
 
-        if (g.precise_checkpoint && g.prepare) {
-            prepare_discover(g.conn, td);
-        }
-
         if (g.sweep_stress)
             /*
              * Random value between 4 and 8 seconds. Use the extra random generator as the tier
@@ -382,7 +378,7 @@ done:
  *     Claim pending prepared transactions, do a checkpoint then verify the consistency of the data
  *     post claiming.
  */
-static void
+void
 prepare_discover(WT_CONNECTION *conn, THREAD_DATA *td)
 {
     WT_UNUSED(td);
@@ -391,7 +387,7 @@ prepare_discover(WT_CONNECTION *conn, THREAD_DATA *td)
      * all pending prepared transactions. When precise checkpoint is not configure, there's no need
      * to run prepare discover.
      */
-    if (!g.precise_checkpoint || !g.prepare)
+    if (!g.precise_checkpoint)
         return;
 
     WT_CURSOR *cursor;

--- a/test/checkpoint/checkpointer.c
+++ b/test/checkpoint/checkpointer.c
@@ -33,7 +33,7 @@ static WT_THREAD_RET clock_thread(void *);
 static int compare_cursors(WT_CURSOR *, table_type, WT_CURSOR *, table_type);
 static int diagnose_key_error(WT_CURSOR *, table_type, int, WT_CURSOR *, table_type, int);
 static int real_checkpointer(THREAD_DATA *);
-
+static void prepare_discover(WT_CONNECTION *conn, THREAD_DATA *td);
 /*
  * set_stable --
  *     Set the given timestamp as the stable timestamp.
@@ -348,6 +348,10 @@ real_checkpointer(THREAD_DATA *td)
             testutil_check(g.conn->set_timestamp(g.conn, timestamp_buf));
         }
 
+        if (g.precise_checkpoint && g.prepare) {
+            prepare_discover(g.conn, td);
+        }
+
         if (g.sweep_stress)
             /*
              * Random value between 4 and 8 seconds. Use the extra random generator as the tier
@@ -371,6 +375,99 @@ done:
         return (log_print_err("session.close", ret, 1));
 
     return (0);
+}
+
+static void
+prepare_discover(WT_CONNECTION *conn, THREAD_DATA *td)
+{
+    WT_UNUSED(td);
+    printf("%s\n", "prepared discover is CALLED");
+    /*
+     * Since RTS is not ran with precise checkpoint, we need to use prepare discover cursor to claim
+     * all pending prepared transactions. When precise checkpoint is not configure, there's no need
+     * to run prepare discover.
+     */
+    if (!g.precise_checkpoint || !g.prepare)
+        return;
+
+    WT_CURSOR *cursor;
+    WT_DECL_RET;
+    WT_SESSION *session;
+    uint64_t prepared_id;
+    uint32_t discover_count;
+    char buf[128];
+    char timestamp_buf[64];
+    bool should_commit;
+    /*
+     * Individual object verification. Do a full checkpoint to reduce the possibility of returning
+     * EBUSY from the following verify calls.
+     */
+    testutil_check(conn->open_session(conn, NULL, NULL, &session));
+    /* Open the prepare discover cursor */
+    ret = session->open_cursor(session, "prepared_discover:", NULL, NULL, &cursor);
+    if (ret == WT_NOTFOUND) {
+        /* No prepared transactions found - this is normal */
+        testutil_check(session->close(session, NULL));
+        return;
+    }
+    testutil_check(ret);
+    /* Iterate through all prepared transactions and claim pending prepared transactions. */
+    discover_count = 0;
+    testutil_check(g.conn->query_timestamp(g.conn, timestamp_buf, "get=stable_timestamp"));
+    uint64_t stable_ts = testutil_timestamp_parse(timestamp_buf);
+    printf(
+      "stable_ts=%" PRIu64 ", prepare latest ts=%" PRIu64 "\n", stable_ts, g.latest_prepared_ts);
+    if (g.latest_prepared_ts >= stable_ts) {
+        stable_ts = g.latest_prepared_ts + 1;
+        g.ts_stable = stable_ts;
+        set_stable(stable_ts);
+    }
+    while ((ret = cursor->next(cursor)) == 0) {
+        discover_count++;
+        testutil_check(cursor->get_key(cursor, &prepared_id));
+
+        /* Claim the prepared transaction */
+        testutil_snprintf(buf, sizeof(buf), "claim_prepared_id=%" PRIx64, prepared_id);
+        testutil_check(session->begin_transaction(session, buf));
+
+        /* Randomly decide whether to commit or roll back */
+        u_int rnd = __wt_random(&td->data_rnd);
+        should_commit = rnd % 2 == 0;
+
+        if (should_commit) {
+            printf("committing txn with prepared_id=%" PRIu64, prepared_id);
+            /* Commit with a timestamp greater than the prepare timestamp. */
+            testutil_snprintf(buf, sizeof(buf),
+              "durable_timestamp=%" PRIx64 ",commit_timestamp=%" PRIx64, g.ts_stable + 2,
+              g.ts_stable + 1);
+            g.ts_stable += 2;
+            testutil_check(session->commit_transaction(session, buf));
+        } else {
+            printf("aborting txn with prepared_id=%" PRIu64, prepared_id);
+            testutil_snprintf(buf, sizeof(buf), "rollback_timestamp=%" PRIx64, g.ts_stable + 2);
+            /* Roll back the transaction */
+            testutil_check(session->rollback_transaction(session, NULL));
+            g.ts_stable += 2;
+        }
+        printf("setting stable to %" PRIu64, g.ts_stable + 1);
+        set_stable(++g.ts_stable);
+    }
+    /* WT_NOTFOUND is expected when we reach the end of the cursor */
+    testutil_assert(ret == WT_NOTFOUND);
+
+    /* Report what we found and did */
+    printf(
+      "Prepare discover: found and claimed %" PRIu32 " prepared transactions\n", discover_count);
+    testutil_check(cursor->close(cursor));
+    if (discover_count > 0) {
+        g.ts_stable++;
+        printf("Final: setting stable to %" PRIu64, stable_ts);
+        set_stable(g.ts_stable);
+        session->checkpoint(session, NULL);
+        if ((ret = verify_consistency(session, WT_TS_NONE, true)) != 0)
+            log_print_err("verify_consistency (post prepare-discover)", ret, 1);
+    }
+    testutil_check(session->close(session, NULL));
 }
 
 /*

--- a/test/checkpoint/checkpointer.c
+++ b/test/checkpoint/checkpointer.c
@@ -377,11 +377,15 @@ done:
     return (0);
 }
 
+/*
+ * prepare_discover --
+ *     Claim pending prepared transactions, do a checkpoint then verify the consistency of the data
+ *     post claiming.
+ */
 static void
 prepare_discover(WT_CONNECTION *conn, THREAD_DATA *td)
 {
     WT_UNUSED(td);
-    printf("%s\n", "prepared discover is CALLED");
     /*
      * Since RTS is not ran with precise checkpoint, we need to use prepare discover cursor to claim
      * all pending prepared transactions. When precise checkpoint is not configure, there's no need
@@ -398,10 +402,7 @@ prepare_discover(WT_CONNECTION *conn, THREAD_DATA *td)
     char buf[128];
     char timestamp_buf[64];
     bool should_commit;
-    /*
-     * Individual object verification. Do a full checkpoint to reduce the possibility of returning
-     * EBUSY from the following verify calls.
-     */
+
     testutil_check(conn->open_session(conn, NULL, NULL, &session));
     /* Open the prepare discover cursor */
     ret = session->open_cursor(session, "prepared_discover:", NULL, NULL, &cursor);
@@ -423,6 +424,8 @@ prepare_discover(WT_CONNECTION *conn, THREAD_DATA *td)
         set_stable(stable_ts);
     }
     while ((ret = cursor->next(cursor)) == 0) {
+        uint64_t commit_ts, durable_ts, rollback_ts;
+
         discover_count++;
         testutil_check(cursor->get_key(cursor, &prepared_id));
 
@@ -436,21 +439,39 @@ prepare_discover(WT_CONNECTION *conn, THREAD_DATA *td)
 
         if (should_commit) {
             printf("committing txn with prepared_id=%" PRIu64, prepared_id);
-            /* Commit with a timestamp greater than the prepare timestamp. */
+            /* Get current stable timestamp and use it for new timestamps */
+            testutil_check(g.conn->query_timestamp(g.conn, timestamp_buf, "get=stable_timestamp"));
+            uint64_t current_stable = testutil_timestamp_parse(timestamp_buf);
+
+            /* Use timestamps greater than current stable */
+            commit_ts = current_stable + 1;
+            durable_ts = commit_ts + 2;
+
             testutil_snprintf(buf, sizeof(buf),
-              "durable_timestamp=%" PRIx64 ",commit_timestamp=%" PRIx64, g.ts_stable + 2,
-              g.ts_stable + 1);
-            g.ts_stable += 2;
+              "durable_timestamp=%" PRIx64 ",commit_timestamp=%" PRIx64, durable_ts, commit_ts);
             testutil_check(session->commit_transaction(session, buf));
+
+            printf(
+              " committed at commit_ts=%" PRIu64 ", durable_ts=%" PRIu64, commit_ts, durable_ts);
         } else {
             printf("aborting txn with prepared_id=%" PRIu64, prepared_id);
-            testutil_snprintf(buf, sizeof(buf), "rollback_timestamp=%" PRIx64, g.ts_stable + 2);
-            /* Roll back the transaction */
-            testutil_check(session->rollback_transaction(session, NULL));
-            g.ts_stable += 2;
+            testutil_check(g.conn->query_timestamp(g.conn, timestamp_buf, "get=stable_timestamp"));
+            uint64_t current_stable = testutil_timestamp_parse(timestamp_buf);
+
+            rollback_ts = current_stable + 2;
+            testutil_snprintf(buf, sizeof(buf), "rollback_timestamp=%" PRIx64, rollback_ts);
+            testutil_check(session->rollback_transaction(session, buf));
         }
-        printf("setting stable to %" PRIu64, g.ts_stable + 1);
-        set_stable(++g.ts_stable);
+        /*
+         * Don't directly modify g.ts_stable in predictable replay mode. In predictable replay mode,
+         * let the clock thread handle stable timestamp advancement.
+         */
+        if (!g.predictable_replay) {
+            if (should_commit) {
+                g.ts_stable = durable_ts + 1;
+                set_stable(g.ts_stable);
+            }
+        }
     }
     /* WT_NOTFOUND is expected when we reach the end of the cursor */
     testutil_assert(ret == WT_NOTFOUND);
@@ -460,9 +481,13 @@ prepare_discover(WT_CONNECTION *conn, THREAD_DATA *td)
       "Prepare discover: found and claimed %" PRIu32 " prepared transactions\n", discover_count);
     testutil_check(cursor->close(cursor));
     if (discover_count > 0) {
-        g.ts_stable++;
-        printf("Final: setting stable to %" PRIu64, stable_ts);
-        set_stable(g.ts_stable);
+        /* Only modify stable timestamp if not in predictable replay mode */
+        if (!g.predictable_replay) {
+            g.ts_stable++;
+            printf("Final: setting stable to %" PRIu64, g.ts_stable);
+            set_stable(g.ts_stable);
+        }
+        /* In both modes, do a checkpoint after processing prepared transactions */
         session->checkpoint(session, NULL);
         if ((ret = verify_consistency(session, WT_TS_NONE, true)) != 0)
             log_print_err("verify_consistency (post prepare-discover)", ret, 1);

--- a/test/checkpoint/checkpointer.c
+++ b/test/checkpoint/checkpointer.c
@@ -413,7 +413,7 @@ prepare_discover(WT_CONNECTION *conn, THREAD_DATA *td)
     testutil_check(g.conn->query_timestamp(g.conn, timestamp_buf, "get=stable_timestamp"));
     uint64_t stable_ts = testutil_timestamp_parse(timestamp_buf);
     printf(
-      "stable_ts=%" PRIu64 ", prepare latest ts=%" PRIu64 "\n", stable_ts, g.latest_prepared_ts);
+      "stable_ts=%" PRIu64 ", latest_prepared_ts=%" PRIu64 "\n", stable_ts, g.latest_prepared_ts);
     if (g.latest_prepared_ts >= stable_ts) {
         stable_ts = g.latest_prepared_ts + 1;
         g.ts_stable = stable_ts;

--- a/test/checkpoint/checkpointer.c
+++ b/test/checkpoint/checkpointer.c
@@ -449,6 +449,10 @@ prepare_discover(WT_CONNECTION *conn, THREAD_DATA *td)
 
             printf(
               " committed at commit_ts=%" PRIu64 ", durable_ts=%" PRIu64, commit_ts, durable_ts);
+            if (!g.predictable_replay) {
+                g.ts_stable = durable_ts + 1;
+                set_stable(g.ts_stable);
+            }
         } else {
             printf("aborting txn with prepared_id=%" PRIu64, prepared_id);
             testutil_check(g.conn->query_timestamp(g.conn, timestamp_buf, "get=stable_timestamp"));
@@ -457,14 +461,8 @@ prepare_discover(WT_CONNECTION *conn, THREAD_DATA *td)
             rollback_ts = current_stable + 2;
             testutil_snprintf(buf, sizeof(buf), "rollback_timestamp=%" PRIx64, rollback_ts);
             testutil_check(session->rollback_transaction(session, buf));
-        }
-        /*
-         * Don't directly modify g.ts_stable in predictable replay mode. In predictable replay mode,
-         * let the clock thread handle stable timestamp advancement.
-         */
-        if (!g.predictable_replay) {
-            if (should_commit) {
-                g.ts_stable = durable_ts + 1;
+            if (!g.predictable_replay) {
+                g.ts_stable = rollback_ts + 1;
                 set_stable(g.ts_stable);
             }
         }

--- a/test/checkpoint/checkpointer.c
+++ b/test/checkpoint/checkpointer.c
@@ -411,18 +411,11 @@ prepare_discover(WT_CONNECTION *conn, THREAD_DATA *td)
     /* Iterate through all prepared transactions and claim pending prepared transactions. */
     discover_count = 0;
     testutil_check(g.conn->query_timestamp(g.conn, timestamp_buf, "get=stable_timestamp"));
-    uint64_t stable_ts = testutil_timestamp_parse(timestamp_buf);
-    printf(
-      "stable_ts=%" PRIu64 ", latest_prepared_ts=%" PRIu64 "\n", stable_ts, g.latest_prepared_ts);
-    if (g.latest_prepared_ts >= stable_ts) {
-        stable_ts = g.latest_prepared_ts + 1;
-        g.ts_stable = stable_ts;
-        set_stable(stable_ts);
-    }
+    uint64_t current_stable = testutil_timestamp_parse(timestamp_buf);
     while ((ret = cursor->next(cursor)) == 0) {
         uint64_t commit_ts, durable_ts, rollback_ts;
 
-        discover_count++;
+        ++discover_count;
         testutil_check(cursor->get_key(cursor, &prepared_id));
 
         /* Claim the prepared transaction */
@@ -434,37 +427,19 @@ prepare_discover(WT_CONNECTION *conn, THREAD_DATA *td)
         should_commit = rnd % 2 == 0;
 
         if (should_commit) {
-            printf("committing txn with prepared_id=%" PRIu64, prepared_id);
-            /* Get current stable timestamp and use it for new timestamps */
-            testutil_check(g.conn->query_timestamp(g.conn, timestamp_buf, "get=stable_timestamp"));
-            uint64_t current_stable = testutil_timestamp_parse(timestamp_buf);
-
             /* Use timestamps greater than current stable */
             commit_ts = current_stable + 1;
-            durable_ts = commit_ts + 2;
+            durable_ts = commit_ts + 1;
 
             testutil_snprintf(buf, sizeof(buf),
               "durable_timestamp=%" PRIx64 ",commit_timestamp=%" PRIx64, durable_ts, commit_ts);
             testutil_check(session->commit_transaction(session, buf));
 
-            printf(
-              " committed at commit_ts=%" PRIu64 ", durable_ts=%" PRIu64, commit_ts, durable_ts);
-            if (!g.predictable_replay) {
-                g.ts_stable = durable_ts + 1;
-                set_stable(g.ts_stable);
-            }
         } else {
-            printf("aborting txn with prepared_id=%" PRIu64, prepared_id);
-            testutil_check(g.conn->query_timestamp(g.conn, timestamp_buf, "get=stable_timestamp"));
-            uint64_t current_stable = testutil_timestamp_parse(timestamp_buf);
 
             rollback_ts = current_stable + 2;
             testutil_snprintf(buf, sizeof(buf), "rollback_timestamp=%" PRIx64, rollback_ts);
             testutil_check(session->rollback_transaction(session, buf));
-            if (!g.predictable_replay) {
-                g.ts_stable = rollback_ts + 1;
-                set_stable(g.ts_stable);
-            }
         }
     }
     /* WT_NOTFOUND is expected when we reach the end of the cursor */
@@ -477,7 +452,7 @@ prepare_discover(WT_CONNECTION *conn, THREAD_DATA *td)
     if (discover_count > 0) {
         /* Only modify stable timestamp if not in predictable replay mode */
         if (!g.predictable_replay) {
-            g.ts_stable++;
+            g.ts_stable = current_stable + 3;
             printf("Final: setting stable to %" PRIu64, g.ts_stable);
             set_stable(g.ts_stable);
         }

--- a/test/checkpoint/test_checkpoint.c
+++ b/test/checkpoint/test_checkpoint.c
@@ -108,14 +108,15 @@ main(int argc, char *argv[])
     g.hs_checkpoint_timing_stress = false;
     g.checkpoint_slow_timing_stress = false;
     g.no_ts_deletes = false;
+    g.precise_checkpoint = false;
     g.predictable_replay = false;
     runs = 1;
     verify_only = false;
 
     testutil_parse_begin_opt(argc, argv, SHARED_PARSE_OPTIONS, &g.opts);
 
-    while ((ch = __wt_getopt(
-              progname, argc, argv, "C:c:d:Dk:l:mn:pr:Rs:S:T:t:vW:xX" SHARED_PARSE_OPTIONS)) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv,
+              "C:c:d:Dk:l:mn:pPr:Rs:S:T:t:vW:xX" SHARED_PARSE_OPTIONS)) != EOF)
         switch (ch) {
         case 'c':
             g.checkpoint_name = __wt_optarg;
@@ -147,6 +148,9 @@ main(int argc, char *argv[])
             break;
         case 'p': /* prepare */
             g.prepare = true;
+            break;
+        case 'P': /* precise checkpoint */
+            g.precise_checkpoint = true;
             break;
         case 'r': /* runs */
             runs = atoi(__wt_optarg);
@@ -237,6 +241,10 @@ main(int argc, char *argv[])
 
     if (g.stop_ts > 0 && (!g.predictable_replay || !g.use_timestamps)) {
         fprintf(stderr, "-S is only valid if specified along with -X and -R.\n");
+        return (EXIT_FAILURE);
+    }
+    if (g.precise_checkpoint && !g.use_timestamps) {
+        fprintf(stderr, "precise checkpoint (-P) is only valid if specified along with -x.\n");
         return (EXIT_FAILURE);
     }
 
@@ -458,7 +466,9 @@ wt_connect(const char *config_open)
      */
     if (g.sweep_stress)
         strcat(config, SWEEP_CFG);
-
+    /* Add config for preserve prepared and precise config */
+    if (g.precise_checkpoint)
+        strcat(config, ",precise_checkpoint=true,preserve_prepared=true");
     /*
      * If we are using tiered add in the extension and tiered storage configuration.
      */
@@ -764,7 +774,7 @@ usage(void)
 {
     fprintf(stderr,
       "usage: %s\n"
-      "    [-DmpRvXx] [-C wiredtiger-config] [-c checkpoint] [-d disagg-mode] [-h home] [-k keys] "
+      "    [-DmpPRvXx] [-C wiredtiger-config] [-c checkpoint] [-d disagg-mode] [-h home] [-k keys] "
       "[-l log]\n"
       "    [-n ops] [-r runs] [-s 1|2|3|4|5] [-T table-config] [-t f|r|v]\n"
       "    [-W workers]\n",
@@ -780,6 +790,7 @@ usage(void)
       "\t-m perform delete operations without timestamps\n"
       "\t-n set number of operations each thread does\n"
       "\t-p use prepare\n"
+      "\t-P use precise checkpoint\n"
       "\t-r set number of runs (0 for continuous)\n"
       "\t-R configure predictable replay\n"
       "\t-s specify which timing stress configuration to use ( 1 | 2 | 3 | 4 | 5 )\n"

--- a/test/checkpoint/test_checkpoint.c
+++ b/test/checkpoint/test_checkpoint.c
@@ -774,7 +774,8 @@ usage(void)
 {
     fprintf(stderr,
       "usage: %s\n"
-      "    [-DmpeRkvXx] [-C wiredtiger-config] [-c checkpoint] [-d disagg-mode] [-h home] [-k keys] "
+      "    [-DmpeRkvXx] [-C wiredtiger-config] [-c checkpoint] [-d disagg-mode] [-h home] [-k "
+      "keys] "
       "[-l log]\n"
       "    [-n ops] [-r runs] [-s 1|2|3|4|5] [-T table-config] [-t f|r|v]\n"
       "    [-W workers]\n",

--- a/test/checkpoint/test_checkpoint.c
+++ b/test/checkpoint/test_checkpoint.c
@@ -468,8 +468,11 @@ wt_connect(const char *config_open)
     if (g.sweep_stress)
         strcat(config, SWEEP_CFG);
     /* Add config for preserve prepared and precise config */
-    if (g.precise_checkpoint)
-        strcat(config, ",precise_checkpoint=true,preserve_prepared=true");
+    if (g.precise_checkpoint) {
+        strcat(config, ",precise_checkpoint=true");
+        if (g.prepare)
+            strcat(config, ",preserve_prepared=true");
+    }
     /*
      * If we are using tiered add in the extension and tiered storage configuration.
      */

--- a/test/checkpoint/test_checkpoint.c
+++ b/test/checkpoint/test_checkpoint.c
@@ -346,6 +346,7 @@ main(int argc, char *argv[])
                 (void)log_print_err("conn.open_session", ret, 1);
                 break;
             }
+            prepare_discover(g.conn, NULL);
 
             verify_consistency(session, WT_TS_NONE, false);
             goto run_complete;

--- a/test/checkpoint/test_checkpoint.c
+++ b/test/checkpoint/test_checkpoint.c
@@ -116,7 +116,7 @@ main(int argc, char *argv[])
     testutil_parse_begin_opt(argc, argv, SHARED_PARSE_OPTIONS, &g.opts);
 
     while ((ch = __wt_getopt(progname, argc, argv,
-              "C:c:d:Dk:l:mn:pPr:Rs:S:T:t:vW:xX" SHARED_PARSE_OPTIONS)) != EOF)
+              "C:c:d:Dk:l:mn:per:Rs:S:T:t:vW:xX" SHARED_PARSE_OPTIONS)) != EOF)
         switch (ch) {
         case 'c':
             g.checkpoint_name = __wt_optarg;
@@ -149,7 +149,7 @@ main(int argc, char *argv[])
         case 'p': /* prepare */
             g.prepare = true;
             break;
-        case 'P': /* precise checkpoint */
+        case 'e': /* precise checkpoint */
             g.precise_checkpoint = true;
             break;
         case 'r': /* runs */
@@ -244,7 +244,7 @@ main(int argc, char *argv[])
         return (EXIT_FAILURE);
     }
     if (g.precise_checkpoint && !g.use_timestamps) {
-        fprintf(stderr, "precise checkpoint (-P) is only valid if specified along with -x.\n");
+        fprintf(stderr, "precise checkpoint (-e) is only valid if specified along with -x.\n");
         return (EXIT_FAILURE);
     }
 
@@ -774,7 +774,7 @@ usage(void)
 {
     fprintf(stderr,
       "usage: %s\n"
-      "    [-DmpPRvXx] [-C wiredtiger-config] [-c checkpoint] [-d disagg-mode] [-h home] [-k keys] "
+      "    [-DmpeRkvXx] [-C wiredtiger-config] [-c checkpoint] [-d disagg-mode] [-h home] [-k keys] "
       "[-l log]\n"
       "    [-n ops] [-r runs] [-s 1|2|3|4|5] [-T table-config] [-t f|r|v]\n"
       "    [-W workers]\n",
@@ -790,7 +790,7 @@ usage(void)
       "\t-m perform delete operations without timestamps\n"
       "\t-n set number of operations each thread does\n"
       "\t-p use prepare\n"
-      "\t-P use precise checkpoint\n"
+      "\t-e use precise checkpoint\n"
       "\t-r set number of runs (0 for continuous)\n"
       "\t-R configure predictable replay\n"
       "\t-s specify which timing stress configuration to use ( 1 | 2 | 3 | 4 | 5 )\n"

--- a/test/checkpoint/test_checkpoint.h
+++ b/test/checkpoint/test_checkpoint.h
@@ -94,6 +94,7 @@ typedef struct {
     bool checkpoint_slow_timing_stress;  /* Checkpoint slow timing stress */
     bool evict_reposition_timing_stress; /* Reposition the cursor for read operations */
     bool hs_checkpoint_timing_stress;    /* History store checkpoint timing stress */
+    bool precise_checkpoint;             /* Use precise checkpoint */
     bool sweep_stress;                   /* Sweep stress test */
 
     uint64_t ts_oldest;                   /* Current oldest timestamp */

--- a/test/checkpoint/test_checkpoint.h
+++ b/test/checkpoint/test_checkpoint.h
@@ -133,3 +133,4 @@ void start_threads(void);
 int start_workers(void);
 const char *type_to_string(table_type);
 int verify_consistency(WT_SESSION *, wt_timestamp_t, bool);
+void prepare_discover(WT_CONNECTION *conn, THREAD_DATA *td);

--- a/test/checkpoint/test_checkpoint.h
+++ b/test/checkpoint/test_checkpoint.h
@@ -97,9 +97,10 @@ typedef struct {
     bool precise_checkpoint;             /* Use precise checkpoint */
     bool sweep_stress;                   /* Sweep stress test */
 
-    uint64_t ts_oldest;                   /* Current oldest timestamp */
-    uint64_t ts_stable;                   /* Current stable timestamp */
-    uint64_t prepared_id;                 /* Current prepared id */
+    uint64_t ts_oldest;   /* Current oldest timestamp */
+    uint64_t ts_stable;   /* Current stable timestamp */
+    uint64_t prepared_id; /* Current prepared id */
+    uint64_t latest_prepared_ts;
     bool failpoint_eviction_split;        /* Fail point for eviction split. */
     bool failpoint_hs_delete_key_from_ts; /* Failpoint for hs key deletion. */
     bool failpoint_rec_before_wrapup;     /* Failpoint for reconciliation before wrapup */

--- a/test/checkpoint/test_checkpoint.h
+++ b/test/checkpoint/test_checkpoint.h
@@ -97,10 +97,9 @@ typedef struct {
     bool precise_checkpoint;             /* Use precise checkpoint */
     bool sweep_stress;                   /* Sweep stress test */
 
-    uint64_t ts_oldest;   /* Current oldest timestamp */
-    uint64_t ts_stable;   /* Current stable timestamp */
-    uint64_t prepared_id; /* Current prepared id */
-    uint64_t latest_prepared_ts;
+    uint64_t ts_oldest;                   /* Current oldest timestamp */
+    uint64_t ts_stable;                   /* Current stable timestamp */
+    uint64_t prepared_id;                 /* Current prepared id */
     bool failpoint_eviction_split;        /* Fail point for eviction split. */
     bool failpoint_hs_delete_key_from_ts; /* Failpoint for hs key deletion. */
     bool failpoint_rec_before_wrapup;     /* Failpoint for reconciliation before wrapup */

--- a/test/checkpoint/workers.c
+++ b/test/checkpoint/workers.c
@@ -477,6 +477,8 @@ real_worker(THREAD_DATA *td)
                             testutil_snprintf(buf, sizeof(buf),
                               "prepare_timestamp=%" PRIx64 ",prepared_id=%" PRIx64, base_ts,
                               prepared_id);
+                            if (base_ts > g.latest_prepared_ts)
+                                g.latest_prepared_ts = base_ts;
                             if ((ret = session->prepare_transaction(session, buf)) != 0) {
                                 if (!g.predictable_replay)
                                     __wt_readunlock((WT_SESSION_IMPL *)session, &g.clock_lock);

--- a/test/checkpoint/workers.c
+++ b/test/checkpoint/workers.c
@@ -477,8 +477,6 @@ real_worker(THREAD_DATA *td)
                             testutil_snprintf(buf, sizeof(buf),
                               "prepare_timestamp=%" PRIx64 ",prepared_id=%" PRIx64, base_ts,
                               prepared_id);
-                            if (base_ts > g.latest_prepared_ts)
-                                g.latest_prepared_ts = base_ts;
                             if ((ret = session->prepare_transaction(session, buf)) != 0) {
                                 if (!g.predictable_replay)
                                     __wt_readunlock((WT_SESSION_IMPL *)session, &g.clock_lock);

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4171,7 +4171,7 @@ tasks:
     commands:
       - func: "run data validation stress test checkpoint"
         vars:
-          run_test_checkpoint_args: -x -p -C cache_size=1000MB,precise_checkpoint=true,preserve_prepared=true
+          run_test_checkpoint_args: -x -p -e -x -C cache_size=1000MB
 
   - name: data-validation-stress-test-precise-checkpoint-fp-hs-insert-s1
     tags: ["data-validation-stress-test"]
@@ -4180,7 +4180,7 @@ tasks:
     commands:
       - func: "run data validation stress test checkpoint"
         vars:
-          run_test_checkpoint_args: -x -p -s 1 -C cache_size=1000MB,precise_checkpoint=true,preserve_prepared=true
+          run_test_checkpoint_args: -x -p -e -x -s 1 -C cache_size=1000MB
 
   - name: data-validation-stress-test-precise-checkpoint-fp-hs-insert-s2
     tags: ["data-validation-stress-test"]
@@ -4189,7 +4189,7 @@ tasks:
     commands:
       - func: "run data validation stress test checkpoint"
         vars:
-          run_test_checkpoint_args: -x -p -s 2 -C cache_size=1000MB,precise_checkpoint=true,preserve_prepared=true
+          run_test_checkpoint_args: -x -p -e -x -s 2 -C cache_size=1000MB
 
   - name: data-validation-stress-test-precise-checkpoint-fp-hs-insert-s3
     tags: ["data-validation-stress-test"]
@@ -4198,7 +4198,7 @@ tasks:
     commands:
       - func: "run data validation stress test checkpoint"
         vars:
-          run_test_checkpoint_args: -x -p -s 3 -C cache_size=1000MB,precise_checkpoint=true,preserve_prepared=true
+          run_test_checkpoint_args: -x -p -e -x -s 3 -C
 
   - name: data-validation-stress-test-precise-checkpoint-fp-hs-insert-s4
     tags: ["data-validation-stress-test"]
@@ -4207,7 +4207,7 @@ tasks:
     commands:
       - func: "run data validation stress test checkpoint"
         vars:
-          run_test_checkpoint_args: -x -p -s 4 -C cache_size=1000MB,precise_checkpoint=true,preserve_prepared=true
+          run_test_checkpoint_args: -x -p -e -x -s 4 -C cache_size=1000MB
 
   - name: data-validation-stress-test-precise-checkpoint-fp-hs-insert-s5
     tags: ["data-validation-stress-test"]
@@ -4216,7 +4216,7 @@ tasks:
     commands:
       - func: "run data validation stress test checkpoint"
         vars:
-          run_test_checkpoint_args: -x -p -s 5 -C cache_size=1000MB,precise_checkpoint=true,preserve_prepared=true
+          run_test_checkpoint_args: -x -p -e -x -s 5 -C cache_size=1000MB
 
   - name: data-validation-stress-test-precise-checkpoint-fp-hs-insert-s6
     tags: ["data-validation-stress-test"]
@@ -4225,7 +4225,7 @@ tasks:
     commands:
       - func: "run data validation stress test checkpoint"
         vars:
-          run_test_checkpoint_args: -x -pe -s 6 -C cache_size=1000MB
+          run_test_checkpoint_args: -x -p -e -x -s 6 -C cache_size=1000MB
 
   - name: data-validation-stress-test-precise-checkpoint-fp-hs-insert-s7
     tags: ["data-validation-stress-test"]
@@ -4234,7 +4234,7 @@ tasks:
     commands:
       - func: "run data validation stress test checkpoint"
         vars:
-          run_test_checkpoint_args: -x -e -s 7 -C cache_size=1000MB
+          run_test_checkpoint_args: -x -e -x -s 7 -C cache_size=1000MB
 
   - name: format-failure-configs-test
     depends_on:

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4171,7 +4171,7 @@ tasks:
     commands:
       - func: "run data validation stress test checkpoint"
         vars:
-          run_test_checkpoint_args: -x -p -e -x -C cache_size=1000MB
+          run_test_checkpoint_args: -p -e -x -C cache_size=1000MB
 
   - name: data-validation-stress-test-precise-checkpoint-fp-hs-insert-s1
     tags: ["data-validation-stress-test"]
@@ -4180,7 +4180,7 @@ tasks:
     commands:
       - func: "run data validation stress test checkpoint"
         vars:
-          run_test_checkpoint_args: -x -p -e -x -s 1 -C cache_size=1000MB
+          run_test_checkpoint_args: -p -e -x -s 1 -C cache_size=1000MB
 
   - name: data-validation-stress-test-precise-checkpoint-fp-hs-insert-s2
     tags: ["data-validation-stress-test"]
@@ -4189,7 +4189,7 @@ tasks:
     commands:
       - func: "run data validation stress test checkpoint"
         vars:
-          run_test_checkpoint_args: -x -p -e -x -s 2 -C cache_size=1000MB
+          run_test_checkpoint_args: -p -e -x -s 2 -C cache_size=1000MB
 
   - name: data-validation-stress-test-precise-checkpoint-fp-hs-insert-s3
     tags: ["data-validation-stress-test"]
@@ -4198,7 +4198,7 @@ tasks:
     commands:
       - func: "run data validation stress test checkpoint"
         vars:
-          run_test_checkpoint_args: -x -p -e -x -s 3 -C
+          run_test_checkpoint_args: -p -e -x -s 3 -C
 
   - name: data-validation-stress-test-precise-checkpoint-fp-hs-insert-s4
     tags: ["data-validation-stress-test"]
@@ -4207,7 +4207,7 @@ tasks:
     commands:
       - func: "run data validation stress test checkpoint"
         vars:
-          run_test_checkpoint_args: -x -p -e -x -s 4 -C cache_size=1000MB
+          run_test_checkpoint_args: -p -e -x -s 4 -C cache_size=1000MB
 
   - name: data-validation-stress-test-precise-checkpoint-fp-hs-insert-s5
     tags: ["data-validation-stress-test"]
@@ -4216,7 +4216,7 @@ tasks:
     commands:
       - func: "run data validation stress test checkpoint"
         vars:
-          run_test_checkpoint_args: -x -p -e -x -s 5 -C cache_size=1000MB
+          run_test_checkpoint_args: -p -e -x -s 5 -C cache_size=1000MB
 
   - name: data-validation-stress-test-precise-checkpoint-fp-hs-insert-s6
     tags: ["data-validation-stress-test"]
@@ -4225,7 +4225,7 @@ tasks:
     commands:
       - func: "run data validation stress test checkpoint"
         vars:
-          run_test_checkpoint_args: -x -p -e -x -s 6 -C cache_size=1000MB
+          run_test_checkpoint_args: -p -e -x -s 6 -C cache_size=1000MB
 
   - name: data-validation-stress-test-precise-checkpoint-fp-hs-insert-s7
     tags: ["data-validation-stress-test"]
@@ -4234,7 +4234,7 @@ tasks:
     commands:
       - func: "run data validation stress test checkpoint"
         vars:
-          run_test_checkpoint_args: -x -e -x -s 7 -C cache_size=1000MB
+          run_test_checkpoint_args: -e -x -s 7 -C cache_size=1000MB
 
   - name: format-failure-configs-test
     depends_on:
@@ -4459,7 +4459,7 @@ tasks:
             set -o verbose
             ${PREPARE_TEST_ENV}
             # Check if we running in disagg mode.
-            disagg_args=""
+            disagg_args=""x
             if [[ "${disagg_run|false}" == "true" ]]; then
                 disagg_args="-D"
             fi

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4346,7 +4346,7 @@ tasks:
       - func: "checkpoint stress test"
         vars:
           timestamp_config: -e -x
-          wt_config: cache_size=1000M,precise_checkpoint=true
+          wt_config: cache_size=1000M
           no_of_procs: 5  # Number of processes to run in the background
           tiered: 1       # Enable tiered storage
           times: 1        # Number of times to run the loop

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4225,7 +4225,7 @@ tasks:
     commands:
       - func: "run data validation stress test checkpoint"
         vars:
-          run_test_checkpoint_args: -x -p -s 6 -C cache_size=1000MB,precise_checkpoint=true,preserve_prepared=true
+          run_test_checkpoint_args: -x -pe -s 6 -C cache_size=1000MB
 
   - name: data-validation-stress-test-precise-checkpoint-fp-hs-insert-s7
     tags: ["data-validation-stress-test"]
@@ -4234,7 +4234,7 @@ tasks:
     commands:
       - func: "run data validation stress test checkpoint"
         vars:
-          run_test_checkpoint_args: -x -s 7 -C cache_size=1000MB,precise_checkpoint=true,preserve_prepared=true
+          run_test_checkpoint_args: -x -e -s 7 -C cache_size=1000MB
 
   - name: format-failure-configs-test
     depends_on:
@@ -4327,8 +4327,8 @@ tasks:
           <<: *configure_flags_with_builtins
       - func: "checkpoint stress test"
         vars:
-          timestamp_config: -x
-          wt_config: cache_size=1000M,precise_checkpoint=true
+          timestamp_config: -e -x
+          wt_config: cache_size=1000M
           no_of_procs: 10 # Number of processes to run in the background
           tiered: 0       # Don't enable tiered storage
           times: 1        # Number of times to run the loop
@@ -4345,7 +4345,7 @@ tasks:
           <<: *configure_flags_with_builtins
       - func: "checkpoint stress test"
         vars:
-          timestamp_config: -x
+          timestamp_config: -e -x
           wt_config: cache_size=1000M,precise_checkpoint=true
           no_of_procs: 5  # Number of processes to run in the background
           tiered: 1       # Enable tiered storage


### PR DESCRIPTION
With precise checkpoint, in recovery we don't run rollback to stable but instead, open a prepare_discover cursor and claim all pending prepared transactions on startup. This PR adds the ability to claim pending prepared transactions for precise checkpoint config in test/checkpoint when running data validation.