### PR TITLE
WT-13430 Config parser allows unbalanced quotation marks

### DIFF
--- a/src/config/config_check.c
+++ b/src/config/config_check.c
@@ -174,7 +174,7 @@ __config_check(WT_SESSION_IMPL *session, const WT_CONFIG_CHECK *checks, u_int ch
         case WT_CONFIG_COMPILED_TYPE_CATEGORY:
             /* Deal with categories of the form: XXX=(XXX=blah). */
             ret = __config_check(session, check->subconfigs, check->subconfigs_entries,
-              check->subconfigs_jump, k.str + strlen(check->name) + 1, v.len);
+              check->subconfigs_jump, v.str, v.len);
             badtype = (ret == EINVAL);
             break;
         case WT_CONFIG_COMPILED_TYPE_FORMAT:

--- a/test/suite/test_config04.py
+++ b/test/suite/test_config04.py
@@ -248,23 +248,37 @@ class test_config04(wttest.WiredTigerTestCase):
     def test_invalid_config(self):
         # The tiered/disagg hook modifies the wiredtiger_open configuration string.
         # This may influence what particular error message occurs in certain cases.
-        if self.runningHook('tiered') or self.runningHook('disagg'):
-            msg = '/./'
-        else:
-            msg = '/Unbalanced brackets/'
+        classic = not (self.runningHook('tiered') or self.runningHook('disagg'))
+        dot_pat = '/./'
 
-        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
-            lambda: self.wiredtiger_open('.', '}'), msg)
-        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
-            lambda: self.wiredtiger_open('.', '{'), msg)
-        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
-            lambda: self.wiredtiger_open('.', '{}}'), msg)
-        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
-            lambda: self.wiredtiger_open('.', '(]}'), msg)
-        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
-            lambda: self.wiredtiger_open('.', '(create=]}'), msg)
-        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
-            lambda: self.wiredtiger_open('.', '(create='), msg)
+        unbalanced_brackets = (['}', '{', '{}}', '(]}', '(create=]}', '(create='],
+                               '/Unbalanced brackets/' if classic else dot_pat)
+
+        unbalanced_quotes = (['"', '"""', '",', '"create=', 'create=,"', 'error_prefix="a'],
+                             '/Unbalanced quotes/' if classic else dot_pat)
+
+        unexpected_escape = ([f'error_prefix="{esc}"'
+                              for esc in ['\a', '\b', '\f', '\n', '\r', '\t', '\v']],
+                             '/Unexpected escaped character/' if classic else dot_pat)
+
+        for bad_configs, msg in (unbalanced_brackets, unbalanced_quotes, unexpected_escape):
+            for config in bad_configs:
+                self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+                    lambda cfg=config: self.wiredtiger_open('.', cfg), msg)
+
+    def test_valid_config_with_quotes(self):
+        valid_configs = [
+            # '"create"',
+            # '"",create',
+            # 'create,"",',
+            # 'create,log="(enabled)"',
+            'log="(enabled)",create']
+
+        home_dir = os.path.join('.', 'WT_HOME')
+        for config in valid_configs:
+            with self.temporaryDirectory(home_dir):
+                conn = self.wiredtiger_open(home_dir, config)
+                conn.close()
 
     def test_error_prefix(self):
         self.common_test('error_prefix="MyOwnPrefix"')

--- a/test/suite/test_config04.py
+++ b/test/suite/test_config04.py
@@ -268,10 +268,10 @@ class test_config04(wttest.WiredTigerTestCase):
 
     def test_valid_config_with_quotes(self):
         valid_configs = [
-            # '"create"',
-            # '"",create',
-            # 'create,"",',
-            # 'create,log="(enabled)"',
+            '"create"',
+            '"",create',
+            'create,"",',
+            'create,log="(enabled)"',
             'log="(enabled)",create']
 
         home_dir = os.path.join('.', 'WT_HOME')

--- a/test/suite/test_config04.py
+++ b/test/suite/test_config04.py
@@ -249,17 +249,17 @@ class test_config04(wttest.WiredTigerTestCase):
         # The tiered/disagg hook modifies the wiredtiger_open configuration string.
         # This may influence what particular error message occurs in certain cases.
         classic = not (self.runningHook('tiered') or self.runningHook('disagg'))
-        dot_pat = '/./'
+        match_any = '/./'
 
         unbalanced_brackets = (['}', '{', '{}}', '(]}', '(create=]}', '(create='],
-                               '/Unbalanced brackets/' if classic else dot_pat)
+                               '/Unbalanced brackets/' if classic else match_any)
 
         unbalanced_quotes = (['"', '"""', '",', '"create=', 'create=,"', 'error_prefix="a'],
-                             '/Unbalanced quotes/' if classic else dot_pat)
+                             '/Unbalanced quotes/' if classic else match_any)
 
         unexpected_escape = ([f'error_prefix="{esc}"'
                               for esc in ['\a', '\b', '\f', '\n', '\r', '\t', '\v']],
-                             '/Unexpected escaped character/' if classic else dot_pat)
+                             '/Unexpected escaped character/' if classic else match_any)
 
         for bad_configs, msg in (unbalanced_brackets, unbalanced_quotes, unexpected_escape):
             for config in bad_configs:

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -38,7 +38,7 @@ from __future__ import print_function
 import unittest
 
 from contextlib import contextmanager
-import errno, glob, os, re, shutil, sys, threading, time, traceback, types
+import errno, glob, os, re, shutil, sys, threading, time, traceback, types, shutil
 import abstract_test_case, test_result, wiredtiger, wthooks, wtscenario
 from dataclasses import dataclass
 from types import SimpleNamespace
@@ -982,6 +982,14 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
         return a recno key
         """
         return i
+
+    @contextmanager
+    def temporaryDirectory(self, path, exist_ok=False):
+        os.makedirs(path, exist_ok=exist_ok)
+        try:
+            yield path
+        finally:
+            shutil.rmtree(path, ignore_errors=True)
 
 @contextmanager
 def open_cursor(session, uri: str, **kwargs):


### PR DESCRIPTION
- Detect unbalanced quotes
- Add unit test
- Add missing escaped characters: `\a`, `\v` (rare, but valid C escapes)