### PR TITLE
WT-15184 Add more null pointer checks for avoiding Fault segment error

### DIFF
--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -2672,6 +2672,9 @@ __wt_verbose_dump_txn_one(
     txn_shared = WT_SESSION_TXN_SHARED(txn_session);
     WT_ERROR_INFO *txn_err_info = &(txn_session->err_info);
 
+    if (txn == NULL || txn_shared == NULL || txn_err_info == NULL)
+        return (0);
+
     /*
      * Unless an error occurs, there's no need to print transactions without a snapshot, as they are
      * typically harmless to the database.
@@ -2755,7 +2758,7 @@ __wt_verbose_dump_txn_one(
         __wt_timestamp_to_string(txn_shared->pinned_durable_timestamp, ts_string[4]),
         __wt_timestamp_to_string(txn_shared->read_timestamp, ts_string[5]), ckpt_lsn_str,
         txn->full_ckpt ? "true" : "false", txn->flags, iso_tag, txn_err_info->err,
-        txn_err_info->sub_level_err, txn_err_info->err_msg));
+        txn_err_info->sub_level_err, txn_err_info->err_msg == NULL ? "" : txn_err_info->err_msg));
 
     /*
      * Log a message and return an error if error code and an optional error string has been passed.


### PR DESCRIPTION
WT-15184
There was an Atlas failure which hits a segmentation fault when trying to dump each session's transaction state after eviction was stuck for too long. We don't have a core dump to track down exactly which variable caused the segmentation fault, but we can definitely add in some conditions to check whether certain variables are NULL before attempting to dereference them.