### PR TITLE
WT-15222  Fix history store not cleared if we have a globally visible tombstone on the insert list

### DIFF
--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -1547,7 +1547,8 @@ __wti_rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_INSERT *ins,
      * Returning EBUSY here is okay as the previous call to validate the update chain wouldn't have
      * caught the situation where only a tombstone is selected.
      */
-    if (__timestamp_no_ts_fix(session, &upd_select->tw) && F_ISSET(r, WT_REC_HS) &&
+    if (upd_select->upd->type != WT_UPDATE_TOMBSTONE &&
+      __timestamp_no_ts_fix(session, &upd_select->tw) && F_ISSET(r, WT_REC_HS) &&
       F_ISSET(r, WT_REC_CHECKPOINT_RUNNING)) {
         /* Catch this case in diagnostic builds. */
         WT_STAT_CONN_DSRC_INCR(session, cache_eviction_blocked_no_ts_checkpoint_race_3);

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -1254,9 +1254,10 @@ __rec_fill_tw_from_upd_select(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_U
          * that a prepared update from the same transaction was rolled back. In such cases, ensure
          * that the rolled-back update is also written to disk to maintain data consistency.
          *
-         * Additionally, if a tombstone with a zero timestamp is selected, it is critical to
-         * identify the update it deletes. Failure to do so may result in missed deletions of
-         * corresponding updates in the history store, leading to potential inconsistencies.
+         * Additionally, if a tombstone with a zero timestamp is selected and there is a need to
+         * move the updates from this btree to the history store, it is essential to identify the
+         * update that the tombstone deletes. Failing to do so could lead to missed deletions of
+         * related updates in the history store, potentially causing data inconsistencies.
          */
         tombstone_globally_visible = __wt_txn_upd_visible_all(session, upd);
         if (write_prepare || (F_ISSET(r, WT_REC_HS) && upd->upd_start_ts == WT_TS_NONE) ||

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -1547,9 +1547,8 @@ __wti_rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_INSERT *ins,
      * Returning EBUSY here is okay as the previous call to validate the update chain wouldn't have
      * caught the situation where only a tombstone is selected.
      */
-    if (upd_select->upd->type != WT_UPDATE_TOMBSTONE &&
-      __timestamp_no_ts_fix(session, &upd_select->tw) && F_ISSET(r, WT_REC_HS) &&
-      F_ISSET(r, WT_REC_CHECKPOINT_RUNNING)) {
+    if (onpage_upd != NULL && __timestamp_no_ts_fix(session, &upd_select->tw) &&
+      F_ISSET(r, WT_REC_HS) && F_ISSET(r, WT_REC_CHECKPOINT_RUNNING)) {
         /* Catch this case in diagnostic builds. */
         WT_STAT_CONN_DSRC_INCR(session, cache_eviction_blocked_no_ts_checkpoint_race_3);
         WT_ASSERT(session, false);

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -1218,6 +1218,7 @@ __rec_fill_tw_from_upd_select(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_U
     WT_UPDATE *last_upd, *tombstone, *upd;
     uint64_t tombstone_txnid;
     uint8_t prepare_state;
+    bool tombstone_globally_visible;
 
     upd = upd_select->upd;
     last_upd = tombstone = NULL;
@@ -1245,14 +1246,12 @@ __rec_fill_tw_from_upd_select(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_U
         if (tombstone_txnid == WT_TXN_ABORTED)
             tombstone_txnid = tombstone->upd_saved_txnid;
         /*
-         * Find the update this tombstone applies to.
-         *
-         * We need to find the full update if the prepared tombstone is rolled back. We resolve
-         * prepare updates recursively from the oldest to the newest. If we write a prepared
-         * tombstone, we may see a prepared update that is rolled back from the same transaction.
-         * Ensure we also write it to the disk in this case.
+         * Identify the update associated with this tombstone, unless a globally visible tombstone
+         * is encountered in the history store. The history store may contain two consecutive
+         * tombstones if the key is deleted with a globally visible tombstone.
          */
-        if (write_prepare || !__wt_txn_upd_visible_all(session, upd)) {
+        tombstone_globally_visible = __wt_txn_upd_visible_all(session, upd);
+        if (!WT_IS_HS(session->dhandle) || !tombstone_globally_visible) {
             uint64_t next_txnid = WT_TXN_NONE;
             for (; upd->next != NULL; upd = upd->next) {
                 next_txnid = __wt_atomic_load_uint64_v_acquire(&upd->next->txnid);
@@ -1305,10 +1304,21 @@ __rec_fill_tw_from_upd_select(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_U
                   upd->next == NULL || next_txnid != WT_TXN_ABORTED ||
                     (write_start_prepare &&
                       upd->next->upd_saved_txnid == tombstone->upd_saved_txnid));
-            upd_select->upd = upd = upd->next;
-            /* We should not see multiple consecutive tombstones. */
-            WT_ASSERT_ALWAYS(session, upd == NULL || upd->type != WT_UPDATE_TOMBSTONE,
-              "Consecutive tombstones found on the update chain");
+
+            /*
+             * Do not write the key to the disk image if the tombstone is globally visible. However,
+             * the timestamps of the update it deletes are still required to determine whether the
+             * key's values need to be removed from the history store.
+             */
+            if (tombstone_globally_visible) {
+                if (upd->next != NULL)
+                    upd = upd->next;
+            } else {
+                upd_select->upd = upd = upd->next;
+                /* We should not see multiple consecutive tombstones. */
+                WT_ASSERT_ALWAYS(session, upd == NULL || upd->type != WT_UPDATE_TOMBSTONE,
+                  "Consecutive tombstones found on the update chain");
+            }
         }
     }
 
@@ -1519,10 +1529,10 @@ __wti_rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_INSERT *ins,
      * functions perform the history store truncation for this key.
      */
     if (!WT_IS_HS(session->dhandle) && upd_select->tombstone != NULL &&
-      !F_ISSET(upd_select->tombstone, WT_UPDATE_RESTORED_FROM_DS | WT_UPDATE_RESTORED_FROM_HS) &&
+      !F_ISSET(upd_select->tombstone,
+        WT_UPDATE_RESTORED_FROM_DS | WT_UPDATE_RESTORED_FROM_HS | WT_UPDATE_RESTORED_FROM_DELTA) &&
       !WT_TIME_WINDOW_HAS_STOP_PREPARE(&upd_select->tw)) {
-        if ((upd_select->tombstone != upd_select->upd &&
-              upd_select->tw.start_ts > upd_select->tw.stop_ts) ||
+        if (upd_select->tw.start_ts > upd_select->tw.stop_ts ||
           (WT_REC_HAS_ON_DISK(vpack) && vpack->tw.start_ts > upd_select->tw.stop_ts &&
             upd_select->tw.stop_ts == WT_TS_NONE)) {
             WT_ASSERT(session, upd_select->tw.stop_ts == WT_TS_NONE);

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -1246,12 +1246,20 @@ __rec_fill_tw_from_upd_select(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_U
         if (tombstone_txnid == WT_TXN_ABORTED)
             tombstone_txnid = tombstone->upd_saved_txnid;
         /*
-         * Identify the update associated with this tombstone, unless a globally visible tombstone
-         * is encountered in the history store. The history store may contain two consecutive
-         * tombstones if the key is deleted with a globally visible tombstone.
+         * Find the update this tombstone applies to.
+         *
+         * To handle scenarios where a prepared tombstone is rolled back, we need to retrieve the
+         * full update associated with it. We resolve prepared updates recursively, processing them
+         * from the oldest to the newest. If a prepared tombstone is written, there's a possibility
+         * that a prepared update from the same transaction was rolled back. In such cases, ensure
+         * that the rolled-back update is also written to disk to maintain data consistency.
+         *
+         * Additionally, if a tombstone with a zero timestamp is selected, it is critical to
+         * identify the update it deletes. Failure to do so may result in missed deletions of
+         * corresponding updates in the history store, leading to potential inconsistencies.
          */
         tombstone_globally_visible = __wt_txn_upd_visible_all(session, upd);
-        if (write_prepare || (!WT_IS_HS(session->dhandle) && upd->upd_start_ts == WT_TS_NONE) ||
+        if (write_prepare || (F_ISSET(r, WT_REC_HS) && upd->upd_start_ts == WT_TS_NONE) ||
           !tombstone_globally_visible) {
             uint64_t next_txnid = WT_TXN_NONE;
             for (; upd->next != NULL; upd = upd->next) {

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -1251,7 +1251,8 @@ __rec_fill_tw_from_upd_select(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_U
          * tombstones if the key is deleted with a globally visible tombstone.
          */
         tombstone_globally_visible = __wt_txn_upd_visible_all(session, upd);
-        if (!WT_IS_HS(session->dhandle) || !tombstone_globally_visible) {
+        if (write_prepare || (!WT_IS_HS(session->dhandle) && upd->upd_start_ts == WT_TS_NONE) ||
+          !tombstone_globally_visible) {
             uint64_t next_txnid = WT_TXN_NONE;
             for (; upd->next != NULL; upd = upd->next) {
                 next_txnid = __wt_atomic_load_uint64_v_acquire(&upd->next->txnid);
@@ -1313,6 +1314,8 @@ __rec_fill_tw_from_upd_select(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_U
             if (tombstone_globally_visible) {
                 if (upd->next != NULL)
                     upd = upd->next;
+                else
+                    upd = tombstone;
             } else {
                 upd_select->upd = upd = upd->next;
                 /* We should not see multiple consecutive tombstones. */
@@ -1322,10 +1325,11 @@ __rec_fill_tw_from_upd_select(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_U
         }
     }
 
-    if (upd != NULL)
+    if (upd != NULL) {
         /* The beginning of the validity window is the selected update's time point. */
-        WT_TIME_WINDOW_SET_START(select_tw, upd, write_start_prepare);
-    else if (select_tw->stop_ts != WT_TS_NONE || select_tw->stop_txn != WT_TXN_NONE) {
+        if (upd->type != WT_UPDATE_TOMBSTONE)
+            WT_TIME_WINDOW_SET_START(select_tw, upd, write_start_prepare);
+    } else if (select_tw->stop_ts != WT_TS_NONE || select_tw->stop_txn != WT_TXN_NONE) {
         WT_ASSERT_ALWAYS(
           session, tombstone != NULL, "The only contents of the update list is a single tombstone");
 

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -3561,8 +3561,7 @@ __wti_rec_hs_clear_on_tombstone(
       __wt_failpoint(session, WT_TIMING_STRESS_FAILPOINT_HISTORY_STORE_DELETE_KEY_FROM_TS, 1))
         return (EBUSY);
 
-    WT_STAT_CONN_INCR(session, cache_hs_key_truncate_onpage_removal);
-    WT_STAT_DSRC_INCR(session, cache_hs_key_truncate_onpage_removal);
+    WT_STAT_CONN_DSRC_INCR(session, cache_hs_key_truncate_onpage_removal);
 
     return (0);
 }

--- a/test/suite/hook_disagg.fail
+++ b/test/suite/hook_disagg.fail
@@ -45,7 +45,6 @@ test_eviction03.py
 test_hs01.py  # FIXME: WT-15371
 test_hs06.py
 test_hs09.py
-test_hs11.py
 test_hs18.py
 test_hs21.py
 test_hs24.py

--- a/test/suite/test_hs11.py
+++ b/test/suite/test_hs11.py
@@ -53,10 +53,14 @@ class test_hs11(wttest.WiredTigerTestCase):
         ('no-modify', dict(modify=False))
     ]
     nrows = [
-        ('small-nrows', dict(nrows=10)),
+        ('small-nrows', dict(nrows=100)),
         ('large-nrows', dict(nrows=10000))
     ]
-    scenarios = make_scenarios(format_values, update_type_values,long_running_txn_values, last_update_type_values, nrows)
+    location = [
+        ('insert-list', dict(insert=True)),
+        ('update-list', dict(insert=False))
+    ]
+    scenarios = make_scenarios(format_values, update_type_values,long_running_txn_values, last_update_type_values, nrows, location)
     timestamps = 5
 
     def create_key(self, i):
@@ -105,7 +109,8 @@ class test_hs11(wttest.WiredTigerTestCase):
 
         # Reconcile and flush versions 1-3 to the history store.
         self.session.checkpoint()
-        self.evict_cursor(uri, self.nrows)
+        if not self.insert:
+            self.evict_cursor(uri, self.nrows)
 
         # Apply a modify update at timestamp 5.
         if self.modify and self.value_format != '8t':
@@ -194,6 +199,8 @@ class test_hs11(wttest.WiredTigerTestCase):
 
         # Reconcile and flush versions 1-3 to the history store.
         self.session.checkpoint()
+        if not self.insert:
+            self.evict_cursor(uri, self.nrows)
 
         # Apply a modify update at timestamp 5.
         if self.modify and self.value_format != '8t':
@@ -216,8 +223,8 @@ class test_hs11(wttest.WiredTigerTestCase):
 
         # Now apply an update at timestamp 20.
         for i in range(1, self.nrows):
-                with self.transaction(commit_timestamp = 20):
-                    cursor[self.create_key(i)] = value2
+            with self.transaction(commit_timestamp = 20):
+                cursor[self.create_key(i)] = value2
 
         # Ensure that we didn't select old history store content even if it is not blew away.
         with self.transaction(read_timestamp = 10, rollback = True):

--- a/test/suite/test_hs11.py
+++ b/test/suite/test_hs11.py
@@ -53,7 +53,7 @@ class test_hs11(wttest.WiredTigerTestCase):
         ('no-modify', dict(modify=False))
     ]
     nrows = [
-        ('small-nrows', dict(nrows=100)),
+        ('small-nrows', dict(nrows=10)),
         ('large-nrows', dict(nrows=10000))
     ]
     scenarios = make_scenarios(format_values, update_type_values,long_running_txn_values, last_update_type_values, nrows)

--- a/test/suite/test_hs11.py
+++ b/test/suite/test_hs11.py
@@ -45,7 +45,7 @@ class test_hs11(wttest.WiredTigerTestCase):
         ('update', dict(update_type='update'))
     ]
     long_running_txn_values = [
-       ('long-running', dict(long_run_txn=True)),
+        ('long-running', dict(long_run_txn=True)),
         ('no-long-running', dict(long_run_txn=False))
     ]
     last_update_type_values = [


### PR DESCRIPTION
If a globally visible tombstone is present, we must identify the update it deletes. Failing to do so could result in missed deletions of relevant updates from the history store.