### PR TITLE
WT-15390 Disable FLCS config in test_rollback_to_stable18.py

### DIFF
--- a/test/suite/test_rollback_to_stable18.py
+++ b/test/suite/test_rollback_to_stable18.py
@@ -42,7 +42,7 @@ class test_rollback_to_stable18(test_rollback_to_stable_base):
 
     format_values = [
         ('column', dict(key_format='r', value_format='S')),
-        ('column_fix', dict(key_format='r', value_format='8t')),
+        # ('column_fix', dict(key_format='r', value_format='8t')),  # FIXME-WT-14972
         ('row_integer', dict(key_format='i', value_format='S')),
     ]
 


### PR DESCRIPTION
The FLCS config in `test_rollback_to_stable18.py` started to fail more frequently on Windows and became a CI blocker. Instead of digging up the cause of this failure (another instance of WT-14972) I will apply a workaround by disabling the failed FLCS config in the test for now. 

It's worth noting there's an ongoing project trying to remove FLCS support in the codebase, and the feature branch won't get merged into develop until weeks later.