### PR TITLE
WT-16049 Refactor restart_without_local_files into a shared Python module

### DIFF
--- a/test/suite/helper_disagg.py
+++ b/test/suite/helper_disagg.py
@@ -27,7 +27,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-import functools, os, wttest
+import functools, os, shutil, wttest
 
 # These routines help run the various page log sources used by disaggregated storage.
 # They are required to manage the generation of disaggregated storage specific configurations.
@@ -108,11 +108,16 @@ def disagg_test_class(cls):
 
     return disagg_test_case_class
 
-# This mixin class provides disaggregated storage configuration methods.
+# This mixin class provides disaggregated storage configuration methods and a few utility functions.
 class DisaggConfigMixin:
+
+    # Configuration parameters, can be overridden in test class
     disagg_verbose = 0        # (0 <= level <=3) can be overridden in test class
     disagg_config = None      # a string, can be overridden in test class
     palm_cache_size_mb = -1   # this uses the default, can be overridden
+
+    # Internal state tracking
+    num_restarts = 0
 
     # Returns True if the current scenario is disaggregated.
     def is_disagg_scenario(self):
@@ -245,3 +250,40 @@ class DisaggConfigMixin:
         self.conn.reconfigure('disaggregated=(role="follower")')
         self.close_conn()
         self.open_conn(directory, config)
+
+    def restart_without_local_files(self, pickup_checkpoint=True, step_up=False):
+        """
+        Restart the node without local files.
+        """
+
+        if pickup_checkpoint:
+            # Step down to avoid shutdown checkpoint
+            self.conn.reconfigure('disaggregated=(role="follower")')
+            checkpoint_meta = self.disagg_get_complete_checkpoint_meta()
+
+        # Close the current connection
+        self.close_conn()
+
+        # Move the local files to another directory
+        self.num_restarts += 1
+        dir = f'SAVE.{self.num_restarts}'
+        os.mkdir(dir)
+        for f in os.listdir():
+            if os.path.isdir(f):
+                continue
+            if f.startswith('WiredTiger') or f.startswith('test_'):
+                os.rename(f, os.path.join(dir, f))
+
+        # Also save the PALI database (to aid debugging)
+        shutil.copytree('kv_home', os.path.join(dir, 'kv_home'))
+
+        # Reopen the connection
+        self.open_conn()
+
+        # Pick up the last checkpoint
+        if pickup_checkpoint:
+            self.conn.reconfigure(f'disaggregated=(checkpoint_meta="{checkpoint_meta}")')
+
+        # Step up as the leader
+        if step_up:
+            self.conn.reconfigure(f'disaggregated=(role="leader")')

--- a/test/suite/helper_disagg.py
+++ b/test/suite/helper_disagg.py
@@ -271,7 +271,7 @@ class DisaggConfigMixin:
         for f in os.listdir():
             if os.path.isdir(f):
                 continue
-            if f.startswith('WiredTiger') or f.startswith('test_'):
+            if f.startswith('WiredTiger') or f.endswith('.wt') or f.endswith('.wt_ingest'):
                 os.rename(f, os.path.join(dir, f))
 
         # Also save the PALI database (to aid debugging)

--- a/test/suite/test_layered30.py
+++ b/test/suite/test_layered30.py
@@ -26,7 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import os, os.path, shutil, wiredtiger, wttest
+import wiredtiger, wttest
 from helper_disagg import disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 
@@ -55,29 +55,6 @@ class test_layered30(wttest.WiredTigerTestCase):
         ('one-table', dict(another_table=False)),
         ('two-tables', dict(another_table=True)),
     ])
-
-    num_restarts = 0
-
-    # Restart the node without local files
-    def restart_without_local_files(self):
-        # Close the current connection
-        self.close_conn()
-
-        # Move the local files to another directory
-        self.num_restarts += 1
-        dir = f'SAVE.{self.num_restarts}'
-        os.mkdir(dir)
-        for f in os.listdir():
-            if os.path.isdir(f):
-                continue
-            if f.startswith('WiredTiger') or f.startswith('test_'):
-                os.rename(f, os.path.join(dir, f))
-
-        # Also save the PALM database (to aid debugging)
-        shutil.copytree('kv_home', os.path.join(dir, 'kv_home'))
-
-        # Reopen the connection
-        self.open_conn()
 
     # Test creating an empty table.
     def test_layered30(self):
@@ -126,10 +103,7 @@ class test_layered30(wttest.WiredTigerTestCase):
         # Part 2: Check the new table after restart
         #
 
-        checkpoint_meta = self.disagg_get_complete_checkpoint_meta()
-        self.restart_without_local_files()
-        self.conn.reconfigure(f'disaggregated=(checkpoint_meta="{checkpoint_meta}")')
-        self.conn.reconfigure(f'disaggregated=(role="leader")')
+        self.restart_without_local_files(step_up=True)
 
         # Avoid checkpoint error with precise checkpoint
         self.conn.set_timestamp('stable_timestamp=1')

--- a/test/suite/test_layered62.py
+++ b/test/suite/test_layered62.py
@@ -26,7 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import os, os.path, shutil, threading, time, wiredtiger, wttest
+import threading, time, wiredtiger, wttest
 from helper_disagg import disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 
@@ -58,29 +58,6 @@ class test_layered62(wttest.WiredTigerTestCase):
     disagg_storages = gen_disagg_storages('test_layered62', disagg_only = True)
     scenarios = make_scenarios(disagg_storages)
 
-    num_restarts = 0
-
-    # Restart the node without local files
-    def restart_without_local_files(self):
-        # Close the current connection
-        self.close_conn()
-
-        # Move the local files to another directory
-        self.num_restarts += 1
-        dir = f'SAVE.{self.num_restarts}'
-        os.mkdir(dir)
-        for f in os.listdir():
-            if os.path.isdir(f):
-                continue
-            if f.startswith('WiredTiger') or f.startswith('test_'):
-                os.rename(f, os.path.join(dir, f))
-
-        # Also save the PALI database (to aid debugging)
-        shutil.copytree('kv_home', os.path.join(dir, 'kv_home'))
-
-        # Reopen the connection
-        self.open_conn()
-
     # Wait for a checkpoint to start running
     def wait_for_checkpoint_start(self):
         while True:
@@ -107,13 +84,8 @@ class test_layered62(wttest.WiredTigerTestCase):
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(1))
         self.session.checkpoint()
 
-        # Prevent the shutdown checkpoint.
-        self.conn.reconfigure('disaggregated=(role="follower")')
-
         # Reopen the connection as a follower.
-        checkpoint_meta = self.disagg_get_complete_checkpoint_meta()
         self.restart_without_local_files()
-        self.conn.reconfigure(f'disaggregated=(checkpoint_meta="{checkpoint_meta}")')
 
         #
         # Part 1: Step up while a checkpoint is running.
@@ -207,9 +179,7 @@ class test_layered62(wttest.WiredTigerTestCase):
         self.assertEqual(checkpoint_timestamp, 3)
 
         # Reopen the connection.
-        checkpoint_meta = self.disagg_get_complete_checkpoint_meta()
         self.restart_without_local_files()
-        self.conn.reconfigure(f'disaggregated=(checkpoint_meta="{checkpoint_meta}")')
 
         # Check that all the data is present.
         cursor = self.session.open_cursor(self.uri, None, None)


### PR DESCRIPTION
Moved `restart_without_local_files` into the disagg helper mixin, plus added ability for it to pick up a checkpoint and step up.