### PR TITLE
WT-16060 Deprecate use of flcs_extrarows in check() RTS

### DIFF
--- a/test/suite/rollback_to_stable_util.py
+++ b/test/suite/rollback_to_stable_util.py
@@ -173,7 +173,7 @@ class test_rollback_to_stable_base(wttest.WiredTigerTestCase):
                 session.rollback_transaction()
             raise(e)
 
-    def check(self, check_value, uri, nrows, flcs_extrarows, read_ts):
+    def check(self, check_value, uri, nrows, read_ts):
 
         session = self.session
         if read_ts == 0:

--- a/test/suite/test_prepare21.py
+++ b/test/suite/test_prepare21.py
@@ -91,8 +91,8 @@ class test_prepare21(test_rollback_to_stable_base):
         prepare_session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(50))
 
         # Verify data is visible and correct.
-        self.check(value_a, uri, nrows, None, 20)
-        self.check(value_b, uri, nrows, None, 30)
+        self.check(value_a, uri, nrows, 20)
+        self.check(value_b, uri, nrows, 30)
 
         self.evict_cursor(uri, nrows)
 
@@ -121,6 +121,6 @@ class test_prepare21(test_rollback_to_stable_base):
             ckpt.join()
 
         # Verify data is visible and correct.
-        self.check(value_a, uri, nrows, None, 20)
-        self.check(value_b, uri, nrows, None, 30)
-        self.check(value_d, uri, nrows, None, 60)
+        self.check(value_a, uri, nrows, 20)
+        self.check(value_b, uri, nrows, 30)
+        self.check(value_d, uri, nrows, 60)

--- a/test/suite/test_rollback_to_stable01.py
+++ b/test/suite/test_rollback_to_stable01.py
@@ -91,12 +91,12 @@ class test_rollback_to_stable01(test_rollback_to_stable_base):
 
         self.large_updates(uri, valuea, ds, nrows, self.prepare, 10)
         # Check that all updates are seen.
-        self.check(valuea, uri, nrows, None, 11 if self.prepare else 10)
+        self.check(valuea, uri, nrows, 11 if self.prepare else 10)
 
         # Remove all keys with newer timestamp.
         self.large_removes(uri, ds, nrows, self.prepare, 20)
         # Check that the no keys should be visible.
-        self.check(valuea, uri, 0, nrows, 21 if self.prepare else 20)
+        self.check(valuea, uri, 0, 21 if self.prepare else 20)
 
         # Pin stable to timestamp 20 if prepare otherwise 10.
         if self.prepare:
@@ -111,9 +111,9 @@ class test_rollback_to_stable01(test_rollback_to_stable_base):
         # Check that the new updates are only seen after the update timestamp.
         self.session.breakpoint()
         if self.dryrun:
-            self.check(0, uri, 0, None, 20)
+            self.check(0, uri, 0, 20)
         else:
-            self.check(valuea, uri, nrows, None, 20)
+            self.check(valuea, uri, nrows, 20)
 
         stat_cursor = self.session.open_cursor('statistics:', None, None)
         calls = stat_cursor[stat.conn.txn_rts][2]

--- a/test/suite/test_rollback_to_stable02.py
+++ b/test/suite/test_rollback_to_stable02.py
@@ -95,19 +95,19 @@ class test_rollback_to_stable02(test_rollback_to_stable_base):
 
         self.large_updates(uri, valuea, ds, nrows, self.prepare, 10)
         # Check that all updates are seen.
-        self.check(valuea, uri, nrows, None, 11 if self.prepare else 10)
+        self.check(valuea, uri, nrows, 11 if self.prepare else 10)
 
         self.large_updates(uri, valueb, ds, nrows, self.prepare, 20)
         # Check that the new updates are only seen after the update timestamp.
-        self.check(valueb, uri, nrows, None, 21 if self.prepare else 20)
+        self.check(valueb, uri, nrows, 21 if self.prepare else 20)
 
         self.large_updates(uri, valuec, ds, nrows, self.prepare, 30)
         # Check that the new updates are only seen after the update timestamp.
-        self.check(valuec, uri, nrows, None, 31 if self.prepare else 30)
+        self.check(valuec, uri, nrows, 31 if self.prepare else 30)
 
         self.large_updates(uri, valued, ds, nrows, self.prepare, 40)
         # Check that the new updates are only seen after the update timestamp.
-        self.check(valued, uri, nrows, None, 41 if self.prepare else 40)
+        self.check(valued, uri, nrows, 41 if self.prepare else 40)
 
         # Pin stable to timestamp 30 if prepare otherwise 20.
         if self.prepare:
@@ -124,12 +124,12 @@ class test_rollback_to_stable02(test_rollback_to_stable_base):
         self.session.breakpoint()
 
         if self.dryrun:
-            self.check(valued, uri, nrows, None, 40)
+            self.check(valued, uri, nrows, 40)
         else:
-            self.check(valueb, uri, nrows, None, 40)
+            self.check(valueb, uri, nrows, 40)
 
-        self.check(valueb, uri, nrows, None, 20)
-        self.check(valuea, uri, nrows, None, 10)
+        self.check(valueb, uri, nrows, 20)
+        self.check(valuea, uri, nrows, 10)
 
         stat_cursor = self.session.open_cursor('statistics:', None, None)
         calls = stat_cursor[stat.conn.txn_rts][2]

--- a/test/suite/test_rollback_to_stable03.py
+++ b/test/suite/test_rollback_to_stable03.py
@@ -88,15 +88,15 @@ class test_rollback_to_stable03(test_rollback_to_stable_base):
 
         self.large_updates(uri, valuea, ds, nrows, self.prepare, 10)
         # Check that all updates are seen.
-        self.check(valuea, uri, nrows, None, 11 if self.prepare else 10)
+        self.check(valuea, uri, nrows, 11 if self.prepare else 10)
 
         self.large_updates(uri, valueb, ds, nrows, self.prepare, 20)
         # Check that all updates are seen.
-        self.check(valueb, uri, nrows, None, 21 if self.prepare else 20)
+        self.check(valueb, uri, nrows, 21 if self.prepare else 20)
 
         self.large_updates(uri, valuec, ds, nrows, self.prepare, 30)
         # Check that all updates are seen.
-        self.check(valuec, uri, nrows, None, 31 if self.prepare else 30)
+        self.check(valuec, uri, nrows, 31 if self.prepare else 30)
 
         # Pin stable to timestamp 30 if prepare otherwise 20.
         if self.prepare:
@@ -109,8 +109,8 @@ class test_rollback_to_stable03(test_rollback_to_stable_base):
 
         self.conn.rollback_to_stable('threads=' + str(self.threads))
         # Check that the old updates are only seen even with the update timestamp.
-        self.check(valueb, uri, nrows, None, 20)
-        self.check(valuea, uri, nrows, None, 10)
+        self.check(valueb, uri, nrows, 20)
+        self.check(valuea, uri, nrows, 10)
 
         with WiredTigerStat(self.session) as stat_cursor:
             calls = stat_cursor[stat.conn.txn_rts][2]

--- a/test/suite/test_rollback_to_stable04.py
+++ b/test/suite/test_rollback_to_stable04.py
@@ -128,19 +128,19 @@ class test_rollback_to_stable04(test_rollback_to_stable_base):
         self.large_modifies(uri, 'Z', ds, 7, 1, nrows, self.prepare, 140)
 
         # Verify data is visible and correct.
-        self.check(value_a, uri, nrows, None, 21 if self.prepare else 20)
-        self.check(value_modQ, uri, nrows, None, 31 if self.prepare else 30)
-        self.check(value_modR, uri, nrows, None, 41 if self.prepare else 40)
-        self.check(value_modS, uri, nrows, None, 51 if self.prepare else 50)
-        self.check(value_b, uri, nrows, None, 61 if self.prepare else 60)
-        self.check(value_c, uri, nrows, None, 71 if self.prepare else 70)
-        self.check(value_modT, uri, nrows, None, 81 if self.prepare else 80)
-        self.check(value_d, uri, nrows, None, 91 if self.prepare else 90)
-        self.check(value_modW, uri, nrows, None, 101 if self.prepare else 100)
-        self.check(value_a, uri, nrows, None, 111 if self.prepare else 110)
-        self.check(value_modX, uri, nrows, None, 121 if self.prepare else 120)
-        self.check(value_modY, uri, nrows, None, 131 if self.prepare else 130)
-        self.check(value_modZ, uri, nrows, None, 141 if self.prepare else 140)
+        self.check(value_a, uri, nrows, 21 if self.prepare else 20)
+        self.check(value_modQ, uri, nrows, 31 if self.prepare else 30)
+        self.check(value_modR, uri, nrows, 41 if self.prepare else 40)
+        self.check(value_modS, uri, nrows, 51 if self.prepare else 50)
+        self.check(value_b, uri, nrows, 61 if self.prepare else 60)
+        self.check(value_c, uri, nrows, 71 if self.prepare else 70)
+        self.check(value_modT, uri, nrows, 81 if self.prepare else 80)
+        self.check(value_d, uri, nrows, 91 if self.prepare else 90)
+        self.check(value_modW, uri, nrows, 101 if self.prepare else 100)
+        self.check(value_a, uri, nrows, 111 if self.prepare else 110)
+        self.check(value_modX, uri, nrows, 121 if self.prepare else 120)
+        self.check(value_modY, uri, nrows, 131 if self.prepare else 130)
+        self.check(value_modZ, uri, nrows, 141 if self.prepare else 140)
 
         # Pin stable to timestamp 40 if prepare otherwise 30.
         if self.prepare:
@@ -154,13 +154,13 @@ class test_rollback_to_stable04(test_rollback_to_stable_base):
         self.conn.rollback_to_stable('dryrun={}'.format('true' if self.dryrun else 'false') + ',threads=' + str(self.threads))
 
         # Check that the correct data is seen at and after the stable timestamp.
-        self.check(value_modQ, uri, nrows, None, 30)
+        self.check(value_modQ, uri, nrows, 30)
         if self.dryrun:
-            self.check(value_modZ, uri, nrows, None, 150)
-            self.check(value_a, uri, nrows, None, 20)
+            self.check(value_modZ, uri, nrows, 150)
+            self.check(value_a, uri, nrows, 20)
         else:
-            self.check(value_modQ, uri, nrows, None, 150)
-            self.check(value_a, uri, nrows, None, 20)
+            self.check(value_modQ, uri, nrows, 150)
+            self.check(value_a, uri, nrows, 20)
 
         stat_cursor = self.session.open_cursor('statistics:', None, None)
         calls = stat_cursor[stat.conn.txn_rts][2]

--- a/test/suite/test_rollback_to_stable05.py
+++ b/test/suite/test_rollback_to_stable05.py
@@ -87,33 +87,33 @@ class test_rollback_to_stable05(test_rollback_to_stable_base):
         valued = "ddddd" * 100
 
         self.large_updates(uri_1, valuea, ds_1, nrows, self.prepare, 0)
-        self.check(valuea, uri_1, nrows, None, 0)
+        self.check(valuea, uri_1, nrows, 0)
 
         self.large_updates(uri_2, valuea, ds_2, nrows, self.prepare, 0)
-        self.check(valuea, uri_2, nrows, None, 0)
+        self.check(valuea, uri_2, nrows, 0)
 
         # Start a long running transaction and keep it open.
         session_2 = self.conn.open_session()
         session_2.begin_transaction()
 
         self.large_updates(uri_1, valueb, ds_1, nrows, self.prepare, 0)
-        self.check(valueb, uri_1, nrows, None, 0)
+        self.check(valueb, uri_1, nrows, 0)
 
         self.large_updates(uri_1, valuec, ds_1, nrows, self.prepare, 0)
-        self.check(valuec, uri_1, nrows, None, 0)
+        self.check(valuec, uri_1, nrows, 0)
 
         self.large_updates(uri_1, valued, ds_1, nrows, self.prepare, 0)
-        self.check(valued, uri_1, nrows, None, 0)
+        self.check(valued, uri_1, nrows, 0)
 
         # Add updates to the another table.
         self.large_updates(uri_2, valueb, ds_2, nrows, self.prepare, 0)
-        self.check(valueb, uri_2, nrows, None, 0)
+        self.check(valueb, uri_2, nrows, 0)
 
         self.large_updates(uri_2, valuec, ds_2, nrows, self.prepare, 0)
-        self.check(valuec, uri_2, nrows, None, 0)
+        self.check(valuec, uri_2, nrows, 0)
 
         self.large_updates(uri_2, valued, ds_2, nrows, self.prepare, 0)
-        self.check(valued, uri_2, nrows, None, 0)
+        self.check(valued, uri_2, nrows, 0)
 
         # Checkpoint to ensure that all the data is flushed.
         if not self.in_memory:
@@ -124,8 +124,8 @@ class test_rollback_to_stable05(test_rollback_to_stable_base):
         session_2.close()
 
         self.conn.rollback_to_stable('threads=' + str(self.threads))
-        self.check(valued, uri_1, nrows, None, 0)
-        self.check(valued, uri_2, nrows, None, 0)
+        self.check(valued, uri_1, nrows, 0)
+        self.check(valued, uri_2, nrows, 0)
 
         stat_cursor = self.session.open_cursor('statistics:', None, None)
         calls = stat_cursor[stat.conn.txn_rts][2]

--- a/test/suite/test_rollback_to_stable06.py
+++ b/test/suite/test_rollback_to_stable06.py
@@ -97,10 +97,10 @@ class test_rollback_to_stable06(test_rollback_to_stable_base):
         self.large_updates(uri, value_d, ds, nrows, self.prepare, 50)
 
         # Verify data is visible and correct.
-        self.check(value_a, uri, nrows, None, 21 if self.prepare else 20)
-        self.check(value_b, uri, nrows, None, 31 if self.prepare else 30)
-        self.check(value_c, uri, nrows, None, 41 if self.prepare else 40)
-        self.check(value_d, uri, nrows, None, 51 if self.prepare else 50)
+        self.check(value_a, uri, nrows, 21 if self.prepare else 20)
+        self.check(value_b, uri, nrows, 31 if self.prepare else 30)
+        self.check(value_c, uri, nrows, 41 if self.prepare else 40)
+        self.check(value_d, uri, nrows, 51 if self.prepare else 50)
 
         # Checkpoint to ensure the data is flushed, then rollback to the stable timestamp.
         if not self.in_memory:
@@ -108,10 +108,10 @@ class test_rollback_to_stable06(test_rollback_to_stable_base):
         self.conn.rollback_to_stable('threads=' + str(self.threads))
 
         # Check that all keys are removed.
-        self.check(value_a, uri, 0, nrows, 20)
-        self.check(value_b, uri, 0, nrows, 30)
-        self.check(value_c, uri, 0, nrows, 40)
-        self.check(value_d, uri, 0, nrows, 50)
+        self.check(value_a, uri, 0, 20)
+        self.check(value_b, uri, 0, 30)
+        self.check(value_c, uri, 0, 40)
+        self.check(value_d, uri, 0, 50)
 
         stat_cursor = self.session.open_cursor('statistics:', None, None)
         calls = stat_cursor[stat.conn.txn_rts][2]

--- a/test/suite/test_rollback_to_stable07.py
+++ b/test/suite/test_rollback_to_stable07.py
@@ -81,10 +81,10 @@ class test_rollback_to_stable07(test_rollback_to_stable_base):
         self.large_updates(uri, value_a, ds, nrows, self.prepare, 50)
 
         # Verify data is visible and correct.
-        self.check(value_d, uri, nrows, None, 21 if self.prepare else 20)
-        self.check(value_c, uri, nrows, None, 31 if self.prepare else 30)
-        self.check(value_b, uri, nrows, None, 41 if self.prepare else 40)
-        self.check(value_a, uri, nrows, None, 51 if self.prepare else 50)
+        self.check(value_d, uri, nrows, 21 if self.prepare else 20)
+        self.check(value_c, uri, nrows, 31 if self.prepare else 30)
+        self.check(value_b, uri, nrows, 41 if self.prepare else 40)
+        self.check(value_a, uri, nrows, 51 if self.prepare else 50)
 
         # Pin stable to timestamp 50 if prepare otherwise 40.
         if self.prepare:
@@ -101,18 +101,18 @@ class test_rollback_to_stable07(test_rollback_to_stable_base):
         self.session.checkpoint()
 
         # Verify additional update data is visible and correct.
-        self.check(value_b, uri, nrows, None, 61 if self.prepare else 60)
-        self.check(value_c, uri, nrows, None, 71 if self.prepare else 70)
-        self.check(value_d, uri, nrows, None, 81 if self.prepare else 80)
+        self.check(value_b, uri, nrows, 61 if self.prepare else 60)
+        self.check(value_c, uri, nrows, 71 if self.prepare else 70)
+        self.check(value_d, uri, nrows, 81 if self.prepare else 80)
 
         # Simulate a server crash and restart.
         simulate_crash_restart(self, ".", "RESTART")
 
         # Check that the correct data is seen at and after the stable timestamp.
-        self.check(value_b, uri, nrows, None, 40)
-        self.check(value_b, uri, nrows, None, 80)
-        self.check(value_c, uri, nrows, None, 30)
-        self.check(value_d, uri, nrows, None, 20)
+        self.check(value_b, uri, nrows, 40)
+        self.check(value_b, uri, nrows, 80)
+        self.check(value_c, uri, nrows, 30)
+        self.check(value_d, uri, nrows, 20)
 
         stat_cursor = self.session.open_cursor('statistics:', None, None)
         calls = stat_cursor[stat.conn.txn_rts][2]
@@ -134,10 +134,10 @@ class test_rollback_to_stable07(test_rollback_to_stable_base):
         simulate_crash_restart(self, "RESTART", "RESTART2")
 
         # Check that the correct data is seen at and after the stable timestamp.
-        self.check(value_b, uri, nrows, None, 40)
-        self.check(value_b, uri, nrows, None, 80)
-        self.check(value_c, uri, nrows, None, 30)
-        self.check(value_d, uri, nrows, None, 20)
+        self.check(value_b, uri, nrows, 40)
+        self.check(value_b, uri, nrows, 80)
+        self.check(value_c, uri, nrows, 30)
+        self.check(value_d, uri, nrows, 20)
 
         stat_cursor = self.session.open_cursor('statistics:', None, None)
         calls = stat_cursor[stat.conn.txn_rts][2]

--- a/test/suite/test_rollback_to_stable08.py
+++ b/test/suite/test_rollback_to_stable08.py
@@ -93,10 +93,10 @@ class test_rollback_to_stable08(test_rollback_to_stable_base):
         self.large_updates(uri, value_d, ds, nrows, self.prepare, 50)
 
         # Verify data is visible and correct.
-        self.check(value_a, uri, nrows, None, 21 if self.prepare else 20)
-        self.check(value_b, uri, nrows, None, 31 if self.prepare else 30)
-        self.check(value_c, uri, nrows, None, 41 if self.prepare else 40)
-        self.check(value_d, uri, nrows, None, 51 if self.prepare else 50)
+        self.check(value_a, uri, nrows, 21 if self.prepare else 20)
+        self.check(value_b, uri, nrows, 31 if self.prepare else 30)
+        self.check(value_c, uri, nrows, 41 if self.prepare else 40)
+        self.check(value_d, uri, nrows, 51 if self.prepare else 50)
 
         # Pin stable to timestamp 60 if prepare otherwise 50.
         if self.prepare:
@@ -110,10 +110,10 @@ class test_rollback_to_stable08(test_rollback_to_stable_base):
         self.conn.rollback_to_stable('threads=' + str(self.threads))
 
         # Check that the correct data is seen.
-        self.check(value_a, uri, nrows, None, 20)
-        self.check(value_b, uri, nrows, None, 30)
-        self.check(value_c, uri, nrows, None, 40)
-        self.check(value_d, uri, nrows, None, 50)
+        self.check(value_a, uri, nrows, 20)
+        self.check(value_b, uri, nrows, 30)
+        self.check(value_c, uri, nrows, 40)
+        self.check(value_d, uri, nrows, 50)
 
         stat_cursor = self.session.open_cursor('statistics:', None, None)
         calls = stat_cursor[stat.conn.txn_rts][2]

--- a/test/suite/test_rollback_to_stable10.py
+++ b/test/suite/test_rollback_to_stable10.py
@@ -122,15 +122,15 @@ class test_rollback_to_stable10(test_rollback_to_stable_base):
         self.large_updates(uri_2, value_a, ds_2, nrows, self.prepare, 50)
 
         # Verify data is visible and correct.
-        self.check(value_d, uri_1, nrows, None, 21 if self.prepare else 20)
-        self.check(value_c, uri_1, nrows, None, 31 if self.prepare else 30)
-        self.check(value_b, uri_1, nrows, None, 41 if self.prepare else 40)
-        self.check(value_a, uri_1, nrows, None, 51 if self.prepare else 50)
+        self.check(value_d, uri_1, nrows, 21 if self.prepare else 20)
+        self.check(value_c, uri_1, nrows, 31 if self.prepare else 30)
+        self.check(value_b, uri_1, nrows, 41 if self.prepare else 40)
+        self.check(value_a, uri_1, nrows, 51 if self.prepare else 50)
 
-        self.check(value_d, uri_2, nrows, None, 21 if self.prepare else 20)
-        self.check(value_c, uri_2, nrows, None, 31 if self.prepare else 30)
-        self.check(value_b, uri_2, nrows, None, 41 if self.prepare else 40)
-        self.check(value_a, uri_2, nrows, None, 51 if self.prepare else 50)
+        self.check(value_d, uri_2, nrows, 21 if self.prepare else 20)
+        self.check(value_c, uri_2, nrows, 31 if self.prepare else 30)
+        self.check(value_b, uri_2, nrows, 41 if self.prepare else 40)
+        self.check(value_a, uri_2, nrows, 51 if self.prepare else 50)
 
         # Pin stable to timestamp 60 if prepare otherwise 50.
         if self.prepare:
@@ -172,18 +172,18 @@ class test_rollback_to_stable10(test_rollback_to_stable_base):
         self.pr("restart complete")
 
         # Check that the correct data is seen at and after the stable timestamp.
-        self.check(value_a, uri_1, nrows, None, 50)
-        self.check(value_a, uri_1, nrows, None, 80)
-        self.check(value_b, uri_1, nrows, None, 40)
-        self.check(value_c, uri_1, nrows, None, 30)
-        self.check(value_d, uri_1, nrows, None, 20)
+        self.check(value_a, uri_1, nrows, 50)
+        self.check(value_a, uri_1, nrows, 80)
+        self.check(value_b, uri_1, nrows, 40)
+        self.check(value_c, uri_1, nrows, 30)
+        self.check(value_d, uri_1, nrows, 20)
 
         # Check that the correct data is seen at and after the stable timestamp.
-        self.check(value_c, uri_2, nrows, None, 30)
-        self.check(value_a, uri_2, nrows, None, 50)
-        self.check(value_a, uri_2, nrows, None, 80)
-        self.check(value_b, uri_2, nrows, None, 40)
-        self.check(value_d, uri_2, nrows, None, 20)
+        self.check(value_c, uri_2, nrows, 30)
+        self.check(value_a, uri_2, nrows, 50)
+        self.check(value_a, uri_2, nrows, 80)
+        self.check(value_b, uri_2, nrows, 40)
+        self.check(value_d, uri_2, nrows, 20)
 
         self.check_hs_stats()
 
@@ -228,15 +228,15 @@ class test_rollback_to_stable10(test_rollback_to_stable_base):
         self.large_updates(uri_2, value_a, ds_2, nrows, self.prepare, 50)
 
         # Verify data is visible and correct.
-        self.check(value_d, uri_1, nrows, None, 21 if self.prepare else 20)
-        self.check(value_c, uri_1, nrows, None, 31 if self.prepare else 30)
-        self.check(value_b, uri_1, nrows, None, 41 if self.prepare else 40)
-        self.check(value_a, uri_1, nrows, None, 51 if self.prepare else 50)
+        self.check(value_d, uri_1, nrows, 21 if self.prepare else 20)
+        self.check(value_c, uri_1, nrows, 31 if self.prepare else 30)
+        self.check(value_b, uri_1, nrows, 41 if self.prepare else 40)
+        self.check(value_a, uri_1, nrows, 51 if self.prepare else 50)
 
-        self.check(value_d, uri_2, nrows, None, 21 if self.prepare else 20)
-        self.check(value_c, uri_2, nrows, None, 31 if self.prepare else 30)
-        self.check(value_b, uri_2, nrows, None, 41 if self.prepare else 40)
-        self.check(value_a, uri_2, nrows, None, 51 if self.prepare else 50)
+        self.check(value_d, uri_2, nrows, 21 if self.prepare else 20)
+        self.check(value_c, uri_2, nrows, 31 if self.prepare else 30)
+        self.check(value_b, uri_2, nrows, 41 if self.prepare else 40)
+        self.check(value_a, uri_2, nrows, 51 if self.prepare else 50)
 
         # Pin stable to timestamp 60 if prepare otherwise 50.
         if self.prepare:
@@ -333,17 +333,17 @@ class test_rollback_to_stable10(test_rollback_to_stable_base):
         self.assertGreater(cache_hs_ondisk, 0)
 
         # Check that the correct data is seen at and after the stable timestamp.
-        self.check(value_a, uri_1, nrows, None, 50)
-        self.check(value_a, uri_1, nrows, None, 80)
-        self.check(value_b, uri_1, nrows, None, 40)
-        self.check(value_c, uri_1, nrows, None, 30)
-        self.check(value_d, uri_1, nrows, None, 20)
+        self.check(value_a, uri_1, nrows, 50)
+        self.check(value_a, uri_1, nrows, 80)
+        self.check(value_b, uri_1, nrows, 40)
+        self.check(value_c, uri_1, nrows, 30)
+        self.check(value_d, uri_1, nrows, 20)
 
         # Check that the correct data is seen at and after the stable timestamp.
-        self.check(value_a, uri_2, nrows, None, 50)
-        self.check(value_a, uri_2, nrows, None, 80)
-        self.check(value_b, uri_2, nrows, None, 40)
-        self.check(value_c, uri_2, nrows, None, 30)
-        self.check(value_d, uri_2, nrows, None, 20)
+        self.check(value_a, uri_2, nrows, 50)
+        self.check(value_a, uri_2, nrows, 80)
+        self.check(value_b, uri_2, nrows, 40)
+        self.check(value_c, uri_2, nrows, 30)
+        self.check(value_d, uri_2, nrows, 20)
 
         self.check_hs_stats()

--- a/test/suite/test_rollback_to_stable11.py
+++ b/test/suite/test_rollback_to_stable11.py
@@ -78,7 +78,7 @@ class test_rollback_to_stable11(test_rollback_to_stable_base):
         self.large_updates(uri, value_b, ds, nrows, self.prepare, 20)
 
         # Verify data is visible and correct.
-        self.check(value_b, uri, nrows, None, 21 if self.prepare else 20)
+        self.check(value_b, uri, nrows, 21 if self.prepare else 20)
 
         # Pin stable to timestamp 28 if prepare otherwise 20.
         # large_updates() prepares at 1 before the timestamp passed (so 29)
@@ -95,7 +95,7 @@ class test_rollback_to_stable11(test_rollback_to_stable_base):
         simulate_crash_restart(self, ".", "RESTART")
 
         # Check that the correct data is seen at and after the stable timestamp.
-        self.check(value_b, uri, nrows, None, 20)
+        self.check(value_b, uri, nrows, 20)
 
         # Perform several updates.
         self.large_updates(uri, value_c, ds, nrows, self.prepare, 30)
@@ -104,7 +104,7 @@ class test_rollback_to_stable11(test_rollback_to_stable_base):
         self.large_updates(uri, value_d, ds, nrows, self.prepare, 36)
 
         # Verify data is visible and correct.
-        self.check(value_d, uri, nrows, None, 37 if self.prepare else 36)
+        self.check(value_d, uri, nrows, 37 if self.prepare else 36)
 
         # Checkpoint to ensure that all the updates are flushed to disk.
         self.session.checkpoint()
@@ -113,8 +113,8 @@ class test_rollback_to_stable11(test_rollback_to_stable_base):
         simulate_crash_restart(self, "RESTART", "RESTART2")
 
         # Check that the correct data is seen at and after the stable timestamp.
-        self.check(value_b, uri, nrows, None, 20)
-        self.check(value_b, uri, nrows, None, 40)
+        self.check(value_b, uri, nrows, 20)
+        self.check(value_b, uri, nrows, 40)
 
         stat_cursor = self.session.open_cursor('statistics:', None, None)
         calls = stat_cursor[stat.conn.txn_rts][2]

--- a/test/suite/test_rollback_to_stable12.py
+++ b/test/suite/test_rollback_to_stable12.py
@@ -80,7 +80,7 @@ class test_rollback_to_stable12(test_rollback_to_stable_base):
         self.large_updates(uri, value_a, ds, nrows, self.prepare, 20)
 
         # Verify data is visible and correct.
-        self.check(value_a, uri, nrows, None, 21 if self.prepare else 20)
+        self.check(value_a, uri, nrows, 21 if self.prepare else 20)
 
         # Pin stable to timestamp 28 if prepare otherwise 20.
         # We prepare at commit_ts - 1 (so 29) and this is required to be strictly
@@ -110,7 +110,7 @@ class test_rollback_to_stable12(test_rollback_to_stable_base):
         simulate_crash_restart(self, ".", "RESTART")
 
         # Check that the correct data is seen at and after the stable timestamp.
-        self.check(value_a, uri, nrows, None, 30)
+        self.check(value_a, uri, nrows, 30)
 
         stat_cursor = self.session.open_cursor('statistics:', None, None)
         calls = stat_cursor[stat.conn.txn_rts][2]

--- a/test/suite/test_rollback_to_stable13.py
+++ b/test/suite/test_rollback_to_stable13.py
@@ -93,9 +93,9 @@ class test_rollback_to_stable13(test_rollback_to_stable_base):
         self.large_updates(uri, value_b, ds, nrows, self.prepare, 60)
 
         # Verify data is visible and correct.
-        self.check(value_a, uri, nrows, None, 21 if self.prepare else 20)
-        self.check(None, uri, 0, nrows, 31 if self.prepare else 30)
-        self.check(value_b, uri, nrows, None, 61 if self.prepare else 60)
+        self.check(value_a, uri, nrows, 21 if self.prepare else 20)
+        self.check(None, uri, 0, 31 if self.prepare else 30)
+        self.check(value_b, uri, nrows, 61 if self.prepare else 60)
 
         # Pin stable to timestamp 50 if prepare otherwise 40.
         if self.prepare:
@@ -108,10 +108,10 @@ class test_rollback_to_stable13(test_rollback_to_stable_base):
         simulate_crash_restart(self, ".", "RESTART")
 
         # Check that the correct data is seen at and after the stable timestamp.
-        self.check(None, uri, 0, nrows, 50)
+        self.check(None, uri, 0, 50)
 
         # Check that we restore the correct value from the history store.
-        self.check(value_a, uri, nrows, None, 20)
+        self.check(value_a, uri, nrows, 20)
 
         stat_cursor = self.session.open_cursor('statistics:', None, None)
         restored_tombstones = stat_cursor[stat.conn.txn_rts_hs_restore_tombstones][2]
@@ -162,9 +162,9 @@ class test_rollback_to_stable13(test_rollback_to_stable_base):
         self.large_updates(uri, value_d, ds, nrows, self.prepare, 60)
 
         # Verify data is visible and correct.
-        self.check(value_a, uri, nrows, None, 21 if self.prepare else 20)
-        self.check(None, uri, 0, nrows, 31 if self.prepare else 30)
-        self.check(value_d, uri, nrows, None, 61 if self.prepare else 60)
+        self.check(value_a, uri, nrows, 21 if self.prepare else 20)
+        self.check(None, uri, 0, 31 if self.prepare else 30)
+        self.check(value_d, uri, nrows, 61 if self.prepare else 60)
 
         # Pin stable to timestamp 50 if prepare otherwise 40.
         if self.prepare:
@@ -177,10 +177,10 @@ class test_rollback_to_stable13(test_rollback_to_stable_base):
         simulate_crash_restart(self, ".", "RESTART")
 
         # Check that the correct data is seen at and after the stable timestamp.
-        self.check(None, uri, 0, nrows, 50)
+        self.check(None, uri, 0, 50)
 
         # Check that we restore the correct value from the history store.
-        self.check(value_a, uri, nrows, None, 20)
+        self.check(value_a, uri, nrows, 20)
 
         stat_cursor = self.session.open_cursor('statistics:', None, None)
         restored_tombstones = stat_cursor[stat.conn.txn_rts_hs_restore_tombstones][2]
@@ -233,18 +233,18 @@ class test_rollback_to_stable13(test_rollback_to_stable_base):
         self.session.checkpoint()
 
         # Verify data is visible and correct.
-        self.check(value_a, uri, nrows, None, 21 if self.prepare else 20)
-        self.check(None, uri, 0, nrows, 41 if self.prepare else 40)
-        self.check(value_c, uri, nrows, None, 61 if self.prepare else 60)
+        self.check(value_a, uri, nrows, 21 if self.prepare else 20)
+        self.check(None, uri, 0, 41 if self.prepare else 40)
+        self.check(value_c, uri, nrows, 61 if self.prepare else 60)
 
         # Simulate a server crash and restart.
         simulate_crash_restart(self, ".", "RESTART")
 
         # Check that the correct data is seen at and after the stable timestamp.
-        self.check(None, uri, 0, nrows, 50)
+        self.check(None, uri, 0, 50)
 
         # Check that we restore the correct value from the history store.
-        self.check(value_a, uri, nrows, None, 20)
+        self.check(value_a, uri, nrows, 20)
 
         stat_cursor = self.session.open_cursor('statistics:', None, None)
         restored_tombstones = stat_cursor[stat.conn.txn_rts_hs_restore_tombstones][2]
@@ -283,9 +283,9 @@ class test_rollback_to_stable13(test_rollback_to_stable_base):
         self.session.checkpoint()
 
         # Verify data is visible and correct.
-        self.check(value_a, uri, nrows, None, 21 if self.prepare else 20)
-        self.check(None, uri, 0, nrows, 41 if self.prepare else 40)
-        self.check(value_c, uri, nrows, None, 61 if self.prepare else 60)
+        self.check(value_a, uri, nrows, 21 if self.prepare else 20)
+        self.check(None, uri, 0, 41 if self.prepare else 40)
+        self.check(value_c, uri, nrows, 61 if self.prepare else 60)
 
         self.conn.rollback_to_stable("dryrun={}".format("true" if self.dryrun else "false") + ',threads=' + str(self.threads))
         # Perform several updates and checkpoint.
@@ -294,9 +294,9 @@ class test_rollback_to_stable13(test_rollback_to_stable_base):
         # Simulate a server crash and restart.
         simulate_crash_restart(self, ".", "RESTART")
         # Check that the correct data is seen at and after the stable timestamp.
-        self.check(None, uri, 0, nrows, 50)
+        self.check(None, uri, 0, 50)
         # Check that we restore the correct value from the history store.
-        self.check(value_a, uri, nrows, None, 20)
+        self.check(value_a, uri, nrows, 20)
         stat_cursor = self.session.open_cursor('statistics:', None, None)
         restored_tombstones = stat_cursor[stat.conn.txn_rts_hs_restore_tombstones][2]
 

--- a/test/suite/test_rollback_to_stable14.py
+++ b/test/suite/test_rollback_to_stable14.py
@@ -95,11 +95,11 @@ class test_rollback_to_stable14(test_rollback_to_stable_base):
         self.large_modifies(uri, 'T', ds, 3, 1, nrows, self.prepare, 60)
 
         # Verify data is visible and correct.
-        self.check(value_a, uri, nrows, None, 21 if self.prepare else 20)
-        self.check(value_modQ, uri, nrows, None, 31 if self.prepare else 30)
-        self.check(value_modR, uri, nrows, None, 41 if self.prepare else 40)
-        self.check(value_modS, uri, nrows, None, 51 if self.prepare else 50)
-        self.check(value_modT, uri, nrows, None, 61 if self.prepare else 60)
+        self.check(value_a, uri, nrows, 21 if self.prepare else 20)
+        self.check(value_modQ, uri, nrows, 31 if self.prepare else 30)
+        self.check(value_modR, uri, nrows, 41 if self.prepare else 40)
+        self.check(value_modS, uri, nrows, 51 if self.prepare else 50)
+        self.check(value_modT, uri, nrows, 61 if self.prepare else 60)
 
         # Pin stable to timestamp 60 if prepare otherwise 50.
         if self.prepare:
@@ -169,10 +169,10 @@ class test_rollback_to_stable14(test_rollback_to_stable_base):
         self.assertGreaterEqual(hs_removed + hs_sweep, nrows)
 
         # Check that the correct data is seen at and after the stable timestamp.
-        self.check(value_a, uri, nrows, None, 20)
-        self.check(value_modQ, uri, nrows, None, 30)
-        self.check(value_modR, uri, nrows, None, 40)
-        self.check(value_modS, uri, nrows, None, 50)
+        self.check(value_a, uri, nrows, 20)
+        self.check(value_modQ, uri, nrows, 30)
+        self.check(value_modR, uri, nrows, 40)
+        self.check(value_modS, uri, nrows, 50)
 
     def test_rollback_to_stable_same_ts(self):
         nrows = 100
@@ -213,9 +213,9 @@ class test_rollback_to_stable14(test_rollback_to_stable_base):
             self.large_modifies(uri, 'T', ds, 3, 1, nrows, self.prepare, 60)
 
         # Verify data is visible and correct.
-        self.check(value_a, uri, nrows, None, 21 if self.prepare else 20)
-        self.check(value_modQ, uri, nrows, None, 31 if self.prepare else 30)
-        self.check(value_modT, uri, nrows, None, 61 if self.prepare else 60)
+        self.check(value_a, uri, nrows, 21 if self.prepare else 20)
+        self.check(value_modQ, uri, nrows, 31 if self.prepare else 30)
+        self.check(value_modT, uri, nrows, 61 if self.prepare else 60)
 
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(50))
 
@@ -281,8 +281,8 @@ class test_rollback_to_stable14(test_rollback_to_stable_base):
         self.assertGreaterEqual(hs_removed + hs_sweep, nrows * 3)
 
         # Check that the correct data is seen at and after the stable timestamp.
-        self.check(value_a, uri, nrows, None, 20)
-        self.check(value_modQ, uri, nrows, None, 30)
+        self.check(value_a, uri, nrows, 20)
+        self.check(value_modQ, uri, nrows, 30)
 
     def test_rollback_to_stable_same_ts_append(self):
         nrows = 100
@@ -323,9 +323,9 @@ class test_rollback_to_stable14(test_rollback_to_stable_base):
             self.large_modifies(uri, 'T', ds, len(value_modS), 1, nrows, self.prepare, 60)
 
         # Verify data is visible and correct.
-        self.check(value_a, uri, nrows, None, 21 if self.prepare else 20)
-        self.check(value_modQ, uri, nrows, None, 31 if self.prepare else 30)
-        self.check(value_modT, uri, nrows, None, 61 if self.prepare else 60)
+        self.check(value_a, uri, nrows, 21 if self.prepare else 20)
+        self.check(value_modQ, uri, nrows, 31 if self.prepare else 30)
+        self.check(value_modT, uri, nrows, 61 if self.prepare else 60)
 
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(50))
 
@@ -389,5 +389,5 @@ class test_rollback_to_stable14(test_rollback_to_stable_base):
         self.assertGreaterEqual(hs_removed + hs_sweep, nrows * 3)
 
         # Check that the correct data is seen at and after the stable timestamp.
-        self.check(value_a, uri, nrows, None, 20)
-        self.check(value_modQ, uri, nrows, None, 30)
+        self.check(value_a, uri, nrows, 20)
+        self.check(value_modQ, uri, nrows, 30)

--- a/test/suite/test_rollback_to_stable18.py
+++ b/test/suite/test_rollback_to_stable18.py
@@ -88,8 +88,8 @@ class test_rollback_to_stable18(test_rollback_to_stable_base):
         self.large_removes(uri, ds, nrows, self.prepare, 30)
 
         # Verify data is visible and correct.
-        self.check(value_a, uri, nrows, None, 21 if self.prepare else 20)
-        self.check(None, uri, 0, nrows, 31 if self.prepare else 30)
+        self.check(value_a, uri, nrows, 21 if self.prepare else 20)
+        self.check(None, uri, 0, 31 if self.prepare else 30)
 
         # Configure debug behavior on a cursor to evict the page positioned on when the reset API is used.
         evict_cursor = self.session.open_cursor(uri, None, "debug=(release_evict)")
@@ -112,7 +112,7 @@ class test_rollback_to_stable18(test_rollback_to_stable_base):
         self.conn.rollback_to_stable('threads=' + str(self.threads))
 
         # Verify data is not visible.
-        self.check(value_a, uri, nrows, None, 30)
+        self.check(value_a, uri, nrows, 30)
 
         stat_cursor = self.session.open_cursor('statistics:', None, None)
         calls = stat_cursor[stat.conn.txn_rts][2]

--- a/test/suite/test_rollback_to_stable19.py
+++ b/test/suite/test_rollback_to_stable19.py
@@ -124,8 +124,8 @@ class test_rollback_to_stable19(test_rollback_to_stable_base):
             s.rollback_transaction()
 
         # Verify data is not visible.
-        self.check(valuea, uri, 0, nrows, 20)
-        self.check(valuea, uri, 0, nrows, 30)
+        self.check(valuea, uri, 0, 20)
+        self.check(valuea, uri, 0, 30)
 
         stat_cursor = self.session.open_cursor('statistics:', None, None)
         upd_aborted = stat_cursor[stat.conn.txn_rts_upd_aborted][2]
@@ -212,9 +212,9 @@ class test_rollback_to_stable19(test_rollback_to_stable_base):
             s.rollback_transaction()
 
         # Verify data.
-        self.check(valuea, uri, nrows, None, 20)
-        self.check(valuea, uri, 0, nrows, 30)
-        self.check(valuea, uri, 0, nrows, 40)
+        self.check(valuea, uri, nrows, 20)
+        self.check(valuea, uri, 0, 30)
+        self.check(valuea, uri, 0, 40)
 
         stat_cursor = self.session.open_cursor('statistics:', None, None)
         upd_aborted = stat_cursor[stat.conn.txn_rts_upd_aborted][2]

--- a/test/suite/test_rollback_to_stable23.py
+++ b/test/suite/test_rollback_to_stable23.py
@@ -94,11 +94,11 @@ class test_rollback_to_stable23(test_rollback_to_stable_base):
         self.large_modifies(uri, 'T', ds, 3, 1, nrows, self.prepare, 60)
 
         # Verify data is visible and correct.
-        self.check(value_a, uri, nrows, None, 21 if self.prepare else 20)
-        self.check(value_modQ, uri, nrows, None, 31 if self.prepare else 30)
-        self.check(value_modR, uri, nrows, None, 41 if self.prepare else 40)
-        self.check(value_modS, uri, nrows, None, 51 if self.prepare else 50)
-        self.check(value_modT, uri, nrows, None, 61 if self.prepare else 60)
+        self.check(value_a, uri, nrows, 21 if self.prepare else 20)
+        self.check(value_modQ, uri, nrows, 31 if self.prepare else 30)
+        self.check(value_modR, uri, nrows, 41 if self.prepare else 40)
+        self.check(value_modS, uri, nrows, 51 if self.prepare else 50)
+        self.check(value_modT, uri, nrows, 61 if self.prepare else 60)
 
         # Pin stable to timestamp 60 if prepare otherwise 50.
         if self.prepare:

--- a/test/suite/test_rollback_to_stable26.py
+++ b/test/suite/test_rollback_to_stable26.py
@@ -114,8 +114,8 @@ class test_rollback_to_stable26(test_rollback_to_stable_base):
         prepare_session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(50))
 
         # Verify data is visible and correct.
-        self.check(value_a, uri, nrows, None, 21 if self.prepare else 20)
-        self.check(value_b, uri, nrows, None, 31 if self.prepare else 30)
+        self.check(value_a, uri, nrows, 21 if self.prepare else 20)
+        self.check(value_b, uri, nrows, 31 if self.prepare else 30)
 
         self.evict_cursor(uri, nrows)
 
@@ -144,9 +144,9 @@ class test_rollback_to_stable26(test_rollback_to_stable_base):
         self.large_updates(uri, value_d, ds, nrows, self.prepare, 60)
 
         # Check that the correct data.
-        self.check(value_a, uri, nrows, None, 21 if self.prepare else 20)
-        self.check(value_b, uri, nrows, None, 31 if self.prepare else 30)
-        self.check(value_d, uri, nrows, None, 61 if self.prepare else 60)
+        self.check(value_a, uri, nrows, 21 if self.prepare else 20)
+        self.check(value_b, uri, nrows, 31 if self.prepare else 30)
+        self.check(value_d, uri, nrows, 61 if self.prepare else 60)
 
         # Simulate a server crash and restart.
         simulate_crash_restart(self, ".", "RESTART")
@@ -162,14 +162,14 @@ class test_rollback_to_stable26(test_rollback_to_stable_base):
         self.assertEqual(hs_removed, nrows)
 
         # Check that the correct data.
-        self.check(value_a, uri, nrows, None, 21 if self.prepare else 20)
-        self.check(value_b, uri, nrows, None, 31 if self.prepare else 30)
+        self.check(value_a, uri, nrows, 21 if self.prepare else 20)
+        self.check(value_b, uri, nrows, 31 if self.prepare else 30)
 
         self.large_updates(uri, value_e, ds, nrows, self.prepare, 70)
 
         self.evict_cursor(uri, nrows)
 
         # Check that the correct data.
-        self.check(value_a, uri, nrows, None, 21 if self.prepare else 20)
-        self.check(value_b, uri, nrows, None, 31 if self.prepare else 30)
-        self.check(value_e, uri, nrows, None, 71 if self.prepare else 70)
+        self.check(value_a, uri, nrows, 21 if self.prepare else 20)
+        self.check(value_b, uri, nrows, 31 if self.prepare else 30)
+        self.check(value_e, uri, nrows, 71 if self.prepare else 70)

--- a/test/suite/test_rollback_to_stable28.py
+++ b/test/suite/test_rollback_to_stable28.py
@@ -106,9 +106,9 @@ class test_rollback_to_stable28(test_rollback_to_stable_base):
         self.large_updates(uri, value_b, ds, nrows, False, 30)
         self.large_updates(uri, value_c, ds, nrows, False, 40)
         # Verify data is visible and correct.
-        self.check(value_a, uri, nrows, None, 20)
-        self.check(value_b, uri, nrows, None, 30)
-        self.check(value_c, uri, nrows, None, 40)
+        self.check(value_a, uri, nrows, 20)
+        self.check(value_b, uri, nrows, 30)
+        self.check(value_c, uri, nrows, 40)
 
         # Pin the stable timestamp to 40. We will be validating the state of the data post-stable timestamp
         # after we perform a recovery.
@@ -120,9 +120,9 @@ class test_rollback_to_stable28(test_rollback_to_stable_base):
         self.large_updates(uri, value_b, ds, nrows, False, 70)
 
         # Verify additional updated data is visible and correct.
-        self.check(value_d, uri, nrows, None, 50)
-        self.check(value_a, uri, nrows, None, 60)
-        self.check(value_b, uri, nrows, None, 70)
+        self.check(value_d, uri, nrows, 50)
+        self.check(value_a, uri, nrows, 60)
+        self.check(value_b, uri, nrows, 70)
 
         # Checkpoint to ensure the data is flushed to disk.
         self.session.checkpoint()
@@ -156,11 +156,11 @@ class test_rollback_to_stable28(test_rollback_to_stable_base):
         self.assertGreater(pages_update_restored, 0)
 
         # Check that after recovery, we see the correct data with respect to our previous stable timestamp (40).
-        self.check(value_c, uri, nrows, None, 40)
-        self.check(value_c, uri, nrows, None, 50)
-        self.check(value_c, uri, nrows, None, 60)
-        self.check(value_c, uri, nrows, None, 70)
-        self.check(value_b, uri, nrows, None, 30)
-        self.check(value_a, uri, nrows, None, 20)
+        self.check(value_c, uri, nrows, 40)
+        self.check(value_c, uri, nrows, 50)
+        self.check(value_c, uri, nrows, 60)
+        self.check(value_c, uri, nrows, 70)
+        self.check(value_b, uri, nrows, 30)
+        self.check(value_a, uri, nrows, 20)
         # Passing 0 results in opening a transaction with no read timestamp.
-        self.check(value_c, uri, nrows, None, 0)
+        self.check(value_c, uri, nrows, 0)

--- a/test/suite/test_rollback_to_stable29.py
+++ b/test/suite/test_rollback_to_stable29.py
@@ -76,29 +76,29 @@ class test_rollback_to_stable29(test_rollback_to_stable_base):
 
         self.large_removes(uri, ds, nrows, False, 30)
         self.large_updates(uri, value_b, ds, nrows, False, 40)
-        self.check(value_b, uri, nrows, None, 40)
+        self.check(value_b, uri, nrows, 40)
 
         self.session.checkpoint()
         self.evict_cursor(uri, nrows, value_b)
 
         self.large_updates(uri, value_c, ds, nrows, False, 50)
-        self.check(value_c, uri, nrows, None, 50)
+        self.check(value_c, uri, nrows, 50)
         self.evict_cursor(uri, nrows, value_c)
 
         # Insert update without a timestamp.
         self.large_updates(uri, value_d, ds, nrows, False, 0)
 
-        self.check(value_d, uri, nrows, None, 10)
-        self.check(value_d, uri, nrows, None, 40)
-        self.check(value_d, uri, nrows, None, 50)
-        self.check(value_d, uri, nrows, None, 20)
+        self.check(value_d, uri, nrows, 10)
+        self.check(value_d, uri, nrows, 40)
+        self.check(value_d, uri, nrows, 50)
+        self.check(value_d, uri, nrows, 20)
 
         self.session.checkpoint()
 
         # Simulate a crash by copying to a new directory(RESTART).
         simulate_crash_restart(self, ".", "RESTART")
 
-        self.check(value_d, uri, nrows, None, 10)
+        self.check(value_d, uri, nrows, 10)
 
         stat_cursor = self.session.open_cursor('statistics:', None, None)
         hs_removed = stat_cursor[stat.conn.txn_rts_hs_removed][2]

--- a/test/suite/test_rollback_to_stable31.py
+++ b/test/suite/test_rollback_to_stable31.py
@@ -97,19 +97,19 @@ class test_rollback_to_stable31(test_rollback_to_stable_base):
         if self.crash:
             if self.checkpoint:
                 # Recovery-time RTS does nothing when no stable timestamp is set.
-                self.check(0, uri, 0, nrows, 5)
-                self.check(value_a, uri, nrows, 0, 15)
-                self.check(value_b, uri, nrows, 0, 25)
-                self.check(value_c, uri, nrows, 0, 35)
+                self.check(0, uri, 0, 5)
+                self.check(value_a, uri, nrows, 15)
+                self.check(value_b, uri, nrows, 25)
+                self.check(value_c, uri, nrows, 35)
             else:
                 # If we crashed without a checkpoint, everything should disappear entirely.
-                self.check(0, uri, 0, 0, 5)
-                self.check(value_a, uri, 0, 0, 15)
-                self.check(value_b, uri, 0, 0, 25)
-                self.check(value_c, uri, 0, 0, 35)
+                self.check(0, uri, 0, 5)
+                self.check(value_a, uri, 0, 15)
+                self.check(value_b, uri, 0, 25)
+                self.check(value_c, uri, 0, 35)
         else:
             # With an explicit runtime RTS, the RTS does not do anything.
-            self.check(0, uri, 0, nrows, 5)
-            self.check(value_a, uri, nrows, 0, 15)
-            self.check(value_b, uri, nrows, 0, 25)
-            self.check(value_c, uri, nrows, 0, 35)
+            self.check(0, uri, 0, 5)
+            self.check(value_a, uri, nrows, 15)
+            self.check(value_b, uri, nrows, 25)
+            self.check(value_c, uri, nrows, 35)

--- a/test/suite/test_rollback_to_stable32.py
+++ b/test/suite/test_rollback_to_stable32.py
@@ -90,9 +90,9 @@ class test_rollback_to_stable32(test_rollback_to_stable_base):
         self.session.checkpoint()
 
         # Verify data is visible and correct.
-        self.check(value_a, uri, nrows, None, 21 if self.prepare else 20)
-        self.check(None, uri, 0, nrows, 41 if self.prepare else 40)
-        self.check(value_c, uri, nrows, None, 61 if self.prepare else 60)
+        self.check(value_a, uri, nrows, 21 if self.prepare else 20)
+        self.check(None, uri, 0, 41 if self.prepare else 40)
+        self.check(value_c, uri, nrows, 61 if self.prepare else 60)
         self.evict_cursor(uri, nrows, value_c)
 
         self.conn.rollback_to_stable('threads=' + str(self.threads))
@@ -110,5 +110,5 @@ class test_rollback_to_stable32(test_rollback_to_stable_base):
         # Perform several updates and checkpoint.
         self.large_updates(uri, value_c, ds, nrows, self.prepare, 60)
         self.evict_cursor(uri, nrows, value_c)
-        self.check(value_b, uri, nrows, None, 31 if self.prepare else 30)
+        self.check(value_b, uri, nrows, 31 if self.prepare else 30)
         self.conn.close()

--- a/test/suite/test_rollback_to_stable37.py
+++ b/test/suite/test_rollback_to_stable37.py
@@ -82,18 +82,18 @@ class test_rollback_to_stable37(test_rollback_to_stable_base):
         old_reader_session.begin_transaction('read_timestamp=' + self.timestamp_str(10))
 
         self.large_updates(uri, value_b, ds, nrows, False, 2000)
-        self.check(value_b, uri, nrows, None, 2000)
+        self.check(value_b, uri, nrows, 2000)
 
         self.evict_cursor(uri, nrows, value_b)
 
         # Insert update without a timestamp.
         self.large_updates(uri, value_c, ds, nrows, False, 0)
-        self.check(value_c, uri, nrows, None, 0)
+        self.check(value_c, uri, nrows, 0)
 
         self.evict_cursor(uri, nrows, value_c)
 
         self.large_updates(uri, value_d, ds, nrows, False, 3000)
-        self.check(value_d, uri, nrows, None, 3000)
+        self.check(value_d, uri, nrows, 3000)
 
         old_reader_session.rollback_transaction()
         self.session.checkpoint()
@@ -103,13 +103,13 @@ class test_rollback_to_stable37(test_rollback_to_stable_base):
 
         self.conn.rollback_to_stable('dryrun={}'.format('true' if self.dryrun else 'false') + ',threads=' + str(self.threads))
 
-        self.check(value_c, uri, nrows, None, 1000)
-        self.check(value_c, uri, nrows, None, 2000)
+        self.check(value_c, uri, nrows, 1000)
+        self.check(value_c, uri, nrows, 2000)
 
         if self.dryrun:
-            self.check(value_d, uri, nrows, None, 3000)
+            self.check(value_d, uri, nrows, 3000)
         else:
-            self.check(value_c, uri, nrows, None, 3000)
+            self.check(value_c, uri, nrows, 3000)
 
         stat_cursor = self.session.open_cursor('statistics:', None, None)
         keys_removed = stat_cursor[stat.conn.txn_rts_keys_removed][2]

--- a/test/suite/test_rollback_to_stable39.py
+++ b/test/suite/test_rollback_to_stable39.py
@@ -82,11 +82,11 @@ class test_rollback_to_stable39(test_rollback_to_stable_base):
         # Perform several updates.
         self.large_updates(uri, value_a, ds, nrows, self.prepare, 20)
         # Verify data is visible and correct.
-        self.check(value_a, uri, nrows, None, 21 if self.prepare else 20)
+        self.check(value_a, uri, nrows, 21 if self.prepare else 20)
 
         self.large_removes(uri, ds, nrows, self.prepare, 30)
         # Verify no data is visible.
-        self.check(value_a, uri, 0, nrows, 31 if self.prepare else 30)
+        self.check(value_a, uri, 0, 31 if self.prepare else 30)
 
         # Pin stable to timestamp 40 if prepare otherwise 30.
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(40 if self.prepare else 30))
@@ -119,8 +119,8 @@ class test_rollback_to_stable39(test_rollback_to_stable_base):
         simulate_crash_restart(self, ".", "RESTART")
 
         # Check that the correct data is seen at and after the stable timestamp.
-        self.check(value_a, uri, nrows, None, 21 if self.prepare else 20)
-        self.check(value_a, uri, 0, nrows, 40)
+        self.check(value_a, uri, nrows, 21 if self.prepare else 20)
+        self.check(value_a, uri, 0, 40)
 
         stat_cursor = self.session.open_cursor('statistics:', None, None)
         hs_removed = stat_cursor[stat.conn.txn_rts_hs_removed][2]
@@ -140,7 +140,7 @@ class test_rollback_to_stable39(test_rollback_to_stable_base):
         self.large_updates(uri, value_c, ds, nrows, self.prepare, 60)
 
         # Verify data is visible and correct.
-        self.check(value_c, uri, nrows, None, 61 if self.prepare else 60)
+        self.check(value_c, uri, nrows, 61 if self.prepare else 60)
 
         # Create a checkpoint thread
         done = threading.Event()

--- a/test/suite/test_rollback_to_stable41.py
+++ b/test/suite/test_rollback_to_stable41.py
@@ -64,16 +64,16 @@ class test_rollback_to_stable41(test_rollback_to_stable_base):
 
         # Insert some data either side of the stable timestamp we set below.
         self.large_updates(uri, value_a, ds, nrows, False, 10)
-        self.check(value_a, uri, nrows, None, 10)
+        self.check(value_a, uri, nrows, 10)
         self.large_updates(uri, value_b, ds, nrows, False, 30)
-        self.check(value_b, uri, nrows, None, 30)
+        self.check(value_b, uri, nrows, 30)
 
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(20))
 
         # Fake RTS, newer data should still exist.
         self.conn.rollback_to_stable('dryrun=true' + ', threads=' + str(self.threads))
-        self.check(value_b, uri, nrows, None, 30)
+        self.check(value_b, uri, nrows, 30)
 
         # Real RTS, newer data should vanish.
         self.conn.rollback_to_stable('threads=' + str(self.threads))
-        self.check(value_a, uri, nrows, None, 30)
+        self.check(value_a, uri, nrows, 30)

--- a/test/suite/test_rollback_to_stable43.py
+++ b/test/suite/test_rollback_to_stable43.py
@@ -97,19 +97,19 @@ class test_rollback_to_stable43(test_rollback_to_stable_base):
             uri = "table:rollback_to_stable43" + str(i)
             self.large_updates(uri, valuea, ds, nrows, None, 10)
             # Check that all updates are seen.
-            self.check(valuea, uri, nrows, None, 10)
+            self.check(valuea, uri, nrows, 10)
 
             self.large_updates(uri, valueb, ds, nrows, None, 20)
             # Check that the new updates are only seen after the update timestamp.
-            self.check(valueb, uri, nrows, None, 20)
+            self.check(valueb, uri, nrows, 20)
 
             self.large_updates(uri, valuec, ds, nrows, None, 30)
             # Check that the new updates are only seen after the update timestamp.
-            self.check(valuec, uri, nrows, None, 30)
+            self.check(valuec, uri, nrows, 30)
 
             self.large_updates(uri, valued, ds, nrows, None, 40)
             # Check that the new updates are only seen after the update timestamp.
-            self.check(valued, uri, nrows, None, 40)
+            self.check(valued, uri, nrows, 40)
 
         # Pin stable to timestamp 20.
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(20))
@@ -124,12 +124,12 @@ class test_rollback_to_stable43(test_rollback_to_stable_base):
         self.session.breakpoint()
 
         if self.dryrun:
-            self.check(valued, uri, nrows, None, 40)
+            self.check(valued, uri, nrows, 40)
         else:
-            self.check(valueb, uri, nrows, None, 40)
+            self.check(valueb, uri, nrows, 40)
 
-        self.check(valueb, uri, nrows, None, 20)
-        self.check(valuea, uri, nrows, None, 10)
+        self.check(valueb, uri, nrows, 20)
+        self.check(valuea, uri, nrows, 10)
 
         stat_cursor = self.session.open_cursor('statistics:', None, None)
         calls = stat_cursor[stat.conn.txn_rts][2]

--- a/test/suite/test_rollback_to_stable44.py
+++ b/test/suite/test_rollback_to_stable44.py
@@ -87,6 +87,6 @@ class test_rollback_to_stable44(test_rollback_to_stable_base):
         simulate_crash_restart(self, '.', 'RESTART')
 
         # Check that the prepare operation did not have any effect.
-        self.check(0, uri, 0, nrows, 5)
-        self.check(value_a, uri, nrows, 0, 15)
-        self.check(value_a, uri, nrows, 0, 25)
+        self.check(0, uri, 0, 5)
+        self.check(value_a, uri, nrows, 15)
+        self.check(value_a, uri, nrows, 25)


### PR DESCRIPTION
This PR deprecates the use of flcs_extrarows in the check() function as FLCS is soon to be deprecated.
