### PR TITLE
WT-16115 Fix __wt_struct_check call for FLCS

### DIFF
--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -405,7 +405,8 @@ __btree_conf(WT_SESSION_IMPL *session, WT_CKPT *ckpt, bool is_ckpt)
     /* Column-store: check for fixed-length column-store data. */
     if (btree->type == BTREE_COL_VAR) {
         bool fixed = false;
-        WT_RET(__wt_struct_check(session, cval.str, cval.len, &fixed, NULL));
+        uint32_t fixed_len = 0;
+        WT_RET(__wt_struct_check(session, cval.str, cval.len, &fixed, &fixed_len));
         if (fixed)
             WT_RET_MSG(session, EINVAL,
               "fixed-length column-store is deprecated, if you are upgrading from an older version "


### PR DESCRIPTION
Currently parsing in a NULL value for __wt_struct_check will not make it return fixed status, and thus we would not hit the error that we are supposed to get when trying to open a FLCS table when it's not supported. This PR fixes this issue. 