### PR TITLE
WT-16132 Fix ingest tables are set with the WT_BTREE_DISAGGREGATED flag

### DIFF
--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -500,17 +500,21 @@ __btree_conf(WT_SESSION_IMPL *session, WT_CKPT *ckpt, bool is_ckpt)
      * Detect if the btree is disaggregated. FIXME-WT-14721: the file extension check should be
      * replaced with something more robust.
      */
-    WT_RET(__wt_config_gets(session, cfg, "block_manager", &cval));
-    if (strstr(btree->dhandle->name, ".wt_stable") != NULL || WT_CONFIG_LIT_MATCH("disagg", cval)) {
-        F_SET(btree, WT_BTREE_DISAGGREGATED);
-
-        WT_RET(__btree_setup_page_log(session, btree));
-
-        /* A page log service and a storage source cannot both be enabled. */
-        WT_ASSERT(session, btree->page_log == NULL || btree->bstorage == NULL);
-    } else if (strstr(btree->dhandle->name, ".wt_ingest") != NULL)
+    if (strstr(btree->dhandle->name, ".wt_ingest") != NULL)
         /* Flag the ingest btree as participating in automatic garbage collection */
         F_SET(btree, WT_BTREE_GARBAGE_COLLECT);
+    else {
+        WT_RET(__wt_config_gets(session, cfg, "block_manager", &cval));
+        if (strstr(btree->dhandle->name, ".wt_stable") != NULL ||
+          WT_CONFIG_LIT_MATCH("disagg", cval)) {
+            F_SET(btree, WT_BTREE_DISAGGREGATED);
+
+            WT_RET(__btree_setup_page_log(session, btree));
+
+            /* A page log service and a storage source cannot both be enabled. */
+            WT_ASSERT(session, btree->page_log == NULL || btree->bstorage == NULL);
+        }
+    }
 
     /* Page sizes */
     WT_RET(__btree_page_sizes(session));

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -189,6 +189,10 @@ __wt_btree_open(WT_SESSION_IMPL *session, const char *op_cfg[])
         btree->evict_disabled_open = true;
     }
 
+    /* A btree cannot be both an ingest btree and a stable btree. */
+    WT_ASSERT(session,
+      !F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT) || !F_ISSET(btree, WT_BTREE_DISAGGREGATED));
+
     if (0) {
 err:
         WT_TRET(__wt_btree_close(session));

--- a/test/suite/test_layered65.py
+++ b/test/suite/test_layered65.py
@@ -41,12 +41,14 @@ class test_layered65(wttest.WiredTigerTestCase):
     conn_config = base_config + 'disaggregated=(role="leader")'
     conn_config_follower = base_config + 'disaggregated=(role="follower")'
 
-    create_session_config = 'key_format=i,value_format=S'
-
-    uri = "layered:test_layered65"
+    table_type = [
+        ('layered', dict(prefix='layered:', create_session_config='key_format=i,value_format=S')),
+        ('table', dict(prefix='table:', create_session_config='key_format=i,value_format=S,block_manager=disagg,type=layered')),
+    ]
+    table_name = "test_layered65"
 
     disagg_storages = gen_disagg_storages('test_layered65', disagg_only = True)
-    scenarios = make_scenarios(disagg_storages)
+    scenarios = make_scenarios(disagg_storages, table_type)
 
     session_follow = None
     conn_follow = None
@@ -57,19 +59,20 @@ class test_layered65(wttest.WiredTigerTestCase):
         self.session_follow = self.conn_follow.open_session()
 
     def test_prepared_insert(self):
+        uri = self.prefix + self.table_name
         self.create_follower()
-        self.session.create(self.uri, self.create_session_config)
-        self.session_follow.create(self.uri, self.create_session_config)
+        self.session.create(uri, self.create_session_config)
+        self.session_follow.create(uri, self.create_session_config)
 
         # Insert a committed update.
         self.session.begin_transaction()
-        cursor = self.session.open_cursor(self.uri)
+        cursor = self.session.open_cursor(uri)
         cursor[1] = "value1"
         self.session.commit_transaction(f"commit_timestamp={self.timestamp_str(10)}")
 
         # Insert the committed update on follower.
         self.session_follow.begin_transaction()
-        cursor_follow = self.session_follow.open_cursor(self.uri)
+        cursor_follow = self.session_follow.open_cursor(uri)
         cursor_follow[1] = "value1"
         self.session_follow.commit_transaction(f"commit_timestamp={self.timestamp_str(10)}")
 
@@ -97,30 +100,31 @@ class test_layered65(wttest.WiredTigerTestCase):
 
         # Evict the data.
         session_follow2 = self.conn_follow.open_session("debug=(release_evict_page)")
-        evict_cursor = session_follow2.open_cursor(self.uri)
+        evict_cursor = session_follow2.open_cursor(uri)
         evict_cursor.set_key(1)
         evict_cursor.search()
         evict_cursor.close()
 
-        stat_cursor = session_follow2.open_cursor('statistics:' + self.uri)
+        stat_cursor = session_follow2.open_cursor('statistics:' + uri)
         garbage_collected = stat_cursor[stat.dsrc.rec_ingest_garbage_collection_keys_update_chain][2]
         # Only the committed update can be garbage collected.
         self.assertEqual(garbage_collected, 1)
 
     def test_prepared_insert_rollback(self):
+        uri = self.prefix + self.table_name
         self.create_follower()
-        self.session.create(self.uri, self.create_session_config)
-        self.session_follow.create(self.uri, self.create_session_config)
+        self.session.create(uri, self.create_session_config)
+        self.session_follow.create(uri, self.create_session_config)
 
         # Insert a committed update.
         self.session.begin_transaction()
-        cursor = self.session.open_cursor(self.uri)
+        cursor = self.session.open_cursor(uri)
         cursor[1] = "value1"
         self.session.commit_transaction(f"commit_timestamp={self.timestamp_str(10)}")
 
         # Insert the committed update on follower.
         self.session_follow.begin_transaction()
-        cursor_follow = self.session_follow.open_cursor(self.uri)
+        cursor_follow = self.session_follow.open_cursor(uri)
         cursor_follow[1] = "value1"
         self.session_follow.commit_transaction(f"commit_timestamp={self.timestamp_str(10)}")
 
@@ -152,12 +156,12 @@ class test_layered65(wttest.WiredTigerTestCase):
 
         # Evict the data.
         session_follow2 = self.conn_follow.open_session("debug=(release_evict_page)")
-        evict_cursor = session_follow2.open_cursor(self.uri)
+        evict_cursor = session_follow2.open_cursor(uri)
         evict_cursor.set_key(1)
         evict_cursor.search()
         evict_cursor.close()
 
-        stat_cursor = self.session_follow.open_cursor('statistics:' + self.uri)
+        stat_cursor = self.session_follow.open_cursor('statistics:' + uri)
         garbage_collected = stat_cursor[stat.dsrc.rec_ingest_garbage_collection_keys_update_chain][2]
         # Only the committed update can be garbage collected.
         self.assertEqual(garbage_collected, 1)
@@ -165,13 +169,13 @@ class test_layered65(wttest.WiredTigerTestCase):
 
         # Insert another committed update.
         self.session.begin_transaction()
-        cursor = self.session.open_cursor(self.uri)
+        cursor = self.session.open_cursor(uri)
         cursor[3] = "value1"
         self.session.commit_transaction(f"commit_timestamp={self.timestamp_str(40)}")
 
         # Insert the committed update on follower.
         self.session_follow.begin_transaction()
-        cursor_follow = self.session_follow.open_cursor(self.uri)
+        cursor_follow = self.session_follow.open_cursor(uri)
         cursor_follow[3] = "value1"
         self.session_follow.commit_transaction(f"commit_timestamp={self.timestamp_str(40)}")
         cursor_follow.close()
@@ -187,43 +191,44 @@ class test_layered65(wttest.WiredTigerTestCase):
 
         # Evict the data.
         session_follow2 = self.conn_follow.open_session("debug=(release_evict_page)")
-        evict_cursor = session_follow2.open_cursor(self.uri)
+        evict_cursor = session_follow2.open_cursor(uri)
         evict_cursor.set_key(3)
         evict_cursor.search()
         evict_cursor.close()
 
-        stat_cursor = self.session_follow.open_cursor('statistics:' + self.uri)
+        stat_cursor = self.session_follow.open_cursor('statistics:' + uri)
         garbage_collected = stat_cursor[stat.dsrc.rec_ingest_garbage_collection_keys_update_chain][2]
         # The aborted prepared update is garbage collected.
         self.assertEqual(garbage_collected, 2)
         stat_cursor.close()
 
     def test_prepared_update(self):
+        uri = self.prefix + self.table_name
         self.create_follower()
-        self.session.create(self.uri, self.create_session_config)
-        self.session_follow.create(self.uri, self.create_session_config)
+        self.session.create(uri, self.create_session_config)
+        self.session_follow.create(uri, self.create_session_config)
 
         # Insert a committed update.
         self.session.begin_transaction()
-        cursor = self.session.open_cursor(self.uri)
+        cursor = self.session.open_cursor(uri)
         cursor[1] = "value1"
         self.session.commit_transaction(f"commit_timestamp={self.timestamp_str(10)}")
 
         # Insert the committed update on follower.
         self.session_follow.begin_transaction()
-        cursor_follow = self.session_follow.open_cursor(self.uri)
+        cursor_follow = self.session_follow.open_cursor(uri)
         cursor_follow[1] = "value1"
         self.session_follow.commit_transaction(f"commit_timestamp={self.timestamp_str(10)}")
 
         # Insert another committed update.
         self.session.begin_transaction()
-        cursor = self.session.open_cursor(self.uri)
+        cursor = self.session.open_cursor(uri)
         cursor[2] = "value1"
         self.session.commit_transaction(f"commit_timestamp={self.timestamp_str(10)}")
 
         # Insert the committed update on follower.
         self.session_follow.begin_transaction()
-        cursor_follow = self.session_follow.open_cursor(self.uri)
+        cursor_follow = self.session_follow.open_cursor(uri)
         cursor_follow[2] = "value1"
         self.session_follow.commit_transaction(f"commit_timestamp={self.timestamp_str(10)}")
 
@@ -233,7 +238,7 @@ class test_layered65(wttest.WiredTigerTestCase):
 
         # Evict the data.
         session_follow2 = self.conn_follow.open_session("debug=(release_evict_page)")
-        evict_cursor = session_follow2.open_cursor(self.uri)
+        evict_cursor = session_follow2.open_cursor(uri)
         evict_cursor.set_key(1)
         evict_cursor.search()
         evict_cursor.close()
@@ -262,12 +267,12 @@ class test_layered65(wttest.WiredTigerTestCase):
 
         # Evict the data.
         session_follow2 = self.conn_follow.open_session("debug=(release_evict_page)")
-        evict_cursor = session_follow2.open_cursor(self.uri)
+        evict_cursor = session_follow2.open_cursor(uri)
         evict_cursor.set_key(1)
         evict_cursor.search()
         evict_cursor.close()
 
-        stat_cursor = session_follow2.open_cursor('statistics:' + self.uri)
+        stat_cursor = session_follow2.open_cursor('statistics:' + uri)
         garbage_collected_update_chain = stat_cursor[stat.dsrc.rec_ingest_garbage_collection_keys_update_chain][2]
         # The keys are garbaged collected from the disk image.
         self.assertEqual(garbage_collected_update_chain, 0)
@@ -277,31 +282,32 @@ class test_layered65(wttest.WiredTigerTestCase):
         self.assertEqual(garbage_collected_disk_image, 2)
 
     def test_prepared_update_rollback(self):
+        uri = self.prefix + self.table_name
         self.create_follower()
-        self.session.create(self.uri, self.create_session_config)
-        self.session_follow.create(self.uri, self.create_session_config)
+        self.session.create(uri, self.create_session_config)
+        self.session_follow.create(uri, self.create_session_config)
 
         # Insert a committed update.
         self.session.begin_transaction()
-        cursor = self.session.open_cursor(self.uri)
+        cursor = self.session.open_cursor(uri)
         cursor[1] = "value1"
         self.session.commit_transaction(f"commit_timestamp={self.timestamp_str(10)}")
 
         # Insert the committed update on follower.
         self.session_follow.begin_transaction()
-        cursor_follow = self.session_follow.open_cursor(self.uri)
+        cursor_follow = self.session_follow.open_cursor(uri)
         cursor_follow[1] = "value1"
         self.session_follow.commit_transaction(f"commit_timestamp={self.timestamp_str(10)}")
 
         # Insert another committed update.
         self.session.begin_transaction()
-        cursor = self.session.open_cursor(self.uri)
+        cursor = self.session.open_cursor(uri)
         cursor[2] = "value1"
         self.session.commit_transaction(f"commit_timestamp={self.timestamp_str(10)}")
 
         # Insert the committed update on follower.
         self.session_follow.begin_transaction()
-        cursor_follow = self.session_follow.open_cursor(self.uri)
+        cursor_follow = self.session_follow.open_cursor(uri)
         cursor_follow[2] = "value1"
         self.session_follow.commit_transaction(f"commit_timestamp={self.timestamp_str(10)}")
 
@@ -311,7 +317,7 @@ class test_layered65(wttest.WiredTigerTestCase):
 
         # Evict the data.
         session_follow2 = self.conn_follow.open_session("debug=(release_evict_page)")
-        evict_cursor = session_follow2.open_cursor(self.uri)
+        evict_cursor = session_follow2.open_cursor(uri)
         evict_cursor.set_key(1)
         evict_cursor.search()
         evict_cursor.close()
@@ -344,12 +350,12 @@ class test_layered65(wttest.WiredTigerTestCase):
 
         # Evict the data.
         session_follow2 = self.conn_follow.open_session("debug=(release_evict_page)")
-        evict_cursor = session_follow2.open_cursor(self.uri)
+        evict_cursor = session_follow2.open_cursor(uri)
         evict_cursor.set_key(1)
         evict_cursor.search()
         evict_cursor.close()
 
-        stat_cursor = self.session_follow.open_cursor('statistics:' + self.uri)
+        stat_cursor = self.session_follow.open_cursor('statistics:' + uri)
         garbage_collected_update_chain = stat_cursor[stat.dsrc.rec_ingest_garbage_collection_keys_update_chain][2]
         # The keys are garbaged collected from the disk image.
         self.assertEqual(garbage_collected_update_chain, 0)
@@ -361,13 +367,13 @@ class test_layered65(wttest.WiredTigerTestCase):
 
         # Insert another committed update.
         self.session.begin_transaction()
-        cursor = self.session.open_cursor(self.uri)
+        cursor = self.session.open_cursor(uri)
         cursor[3] = "value1"
         self.session.commit_transaction(f"commit_timestamp={self.timestamp_str(40)}")
 
         # Insert the committed update on follower.
         self.session_follow.begin_transaction()
-        cursor_follow = self.session_follow.open_cursor(self.uri)
+        cursor_follow = self.session_follow.open_cursor(uri)
         cursor_follow[3] = "value1"
         self.session_follow.commit_transaction(f"commit_timestamp={self.timestamp_str(40)}")
         cursor_follow.close()
@@ -383,12 +389,12 @@ class test_layered65(wttest.WiredTigerTestCase):
 
         # Evict the data.
         session_follow2 = self.conn_follow.open_session("debug=(release_evict_page)")
-        evict_cursor = session_follow2.open_cursor(self.uri)
+        evict_cursor = session_follow2.open_cursor(uri)
         evict_cursor.set_key(3)
         evict_cursor.search()
         evict_cursor.close()
 
-        stat_cursor = self.session_follow.open_cursor('statistics:' + self.uri)
+        stat_cursor = self.session_follow.open_cursor('statistics:' + uri)
         garbage_collected_update_chain = stat_cursor[stat.dsrc.rec_ingest_garbage_collection_keys_update_chain][2]
         # The aborted prepared update is garbage collected.
         self.assertEqual(garbage_collected_update_chain, 1)


### PR DESCRIPTION
MongoDB uses the "block_manager=disagg" config to create the layered table, which leads to the ingest table also be marked as WT_BTREE_DISAGGREGATED.