### PR TITLE
WT-15967 Create the prepared update on the ingest table in standby when claiming the prepared update

### DIFF
--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -1519,11 +1519,11 @@ err:
 }
 
 /*
- * __page_inmem_update --
+ * __wt_page_inmem_update --
  *     Create the actual update.
  */
-static int
-__page_inmem_update(WT_SESSION_IMPL *session, WT_ITEM *value, WT_CELL_UNPACK_KV *unpack,
+int
+__wt_page_inmem_update(WT_SESSION_IMPL *session, WT_ITEM *value, WT_CELL_UNPACK_KV *unpack,
   WT_UPDATE **updp, size_t *sizep)
 {
     if (WT_TIME_WINDOW_HAS_PREPARE(&unpack->tw))
@@ -1541,7 +1541,7 @@ static int
 __page_inmem_update_col(WT_SESSION_IMPL *session, WT_REF *ref, WT_CURSOR_BTREE *cbt, uint64_t recno,
   WT_ITEM *value, WT_CELL_UNPACK_KV *unpack, WT_UPDATE **updp, size_t *sizep)
 {
-    WT_RET(__page_inmem_update(session, value, unpack, updp, sizep));
+    WT_RET(__wt_page_inmem_update(session, value, unpack, updp, sizep));
 
     /* Search the page and apply the modification. */
     WT_RET(__wt_col_search(cbt, recno, ref, true, NULL));
@@ -1659,7 +1659,7 @@ __wti_page_inmem_updates(WT_SESSION_IMPL *session, WT_REF *ref)
              * it.
              */
             if (first_upd == NULL) {
-                WT_ERR(__page_inmem_update(session, value, &unpack, &upd, &size));
+                WT_ERR(__wt_page_inmem_update(session, value, &unpack, &upd, &size));
                 total_size += size;
 
                 /* Search the page and apply the modification. */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -871,6 +871,9 @@ extern int __wt_page_in_func(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t fla
   const char *func, int line
 #endif
   ) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_page_inmem_update(WT_SESSION_IMPL *session, WT_ITEM *value,
+  WT_CELL_UNPACK_KV *unpack, WT_UPDATE **updp, size_t *sizep)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_page_modify_alloc(WT_SESSION_IMPL *session, WT_PAGE *page)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_page_release_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
@@ -1530,11 +1533,11 @@ extern int __wti_prefetch_create(WT_SESSION_IMPL *session, const char *cfg[])
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_prefetch_destroy(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wti_prepared_discover_add_artifact_ondisk_row(
-  WT_SESSION_IMPL *session, uint64_t prepared_id, WT_TIME_WINDOW *tw, WT_ITEM *key)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_prepared_discover_add_artifact_upd(WT_SESSION_IMPL *session, uint64_t prepared_id,
-  WT_ITEM *key, WT_UPDATE *upd) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+  wt_timestamp_t prepare_ts, WT_ITEM *key) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wti_prepared_discover_restore_and_add_artifact_upd(WT_SESSION_IMPL *session,
+  const char *stable_uri, WT_ITEM *key, WT_ITEM *value, WT_CELL_UNPACK_KV *unpack)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_row_ikey(WT_SESSION_IMPL *session, uint32_t cell_offset, const void *key,
   size_t size, WT_REF *ref) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_row_ikey_incr(WT_SESSION_IMPL *session, WT_PAGE *page, uint32_t cell_offset,

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1533,8 +1533,8 @@ extern int __wti_prefetch_create(WT_SESSION_IMPL *session, const char *cfg[])
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_prefetch_destroy(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wti_prepared_discover_add_artifact_upd(WT_SESSION_IMPL *session, uint64_t prepared_id,
-  wt_timestamp_t prepare_ts, WT_ITEM *key) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wti_prepared_discover_add_artifact_upd(WT_SESSION_IMPL *session, WT_UPDATE *upd,
+  WT_ITEM *key) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_prepared_discover_restore_and_add_artifact_upd(WT_SESSION_IMPL *session,
   const char *stable_uri, WT_ITEM *key, WT_ITEM *value, WT_CELL_UNPACK_KV *unpack)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -695,13 +695,8 @@ __wt_txn_op_set_timestamp(WT_SESSION_IMPL *session, WT_TXN_OP *op, bool validate
             __wt_txn_op_delete_apply_prepare_state(session, op, true);
         else {
             upd = op->u.op_upd;
-            /*
-             * upd can be NULL when called from prepared discover module to initialize a new op, in
-             * which case we won't need to resolve the prepare state here.
-             */
-            if (upd != NULL)
-                /* Resolve prepared update to be committed update. */
-                __txn_apply_prepare_state_update(session, upd, true);
+            /* Resolve prepared update to be committed update. */
+            __txn_apply_prepare_state_update(session, upd, true);
         }
     } else {
         if (op->type == WT_TXN_OP_REF_DELETE)

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -695,9 +695,13 @@ __wt_txn_op_set_timestamp(WT_SESSION_IMPL *session, WT_TXN_OP *op, bool validate
             __wt_txn_op_delete_apply_prepare_state(session, op, true);
         else {
             upd = op->u.op_upd;
-
-            /* Resolve prepared update to be committed update. */
-            __txn_apply_prepare_state_update(session, upd, true);
+            /*
+             * upd can be NULL when called from prepared discover module to initialize a new op, in
+             * which case we won't need to resolve the prepare state here.
+             */
+            if (upd != NULL)
+                /* Resolve prepared update to be committed update. */
+                __txn_apply_prepare_state_update(session, upd, true);
         }
     } else {
         if (op->type == WT_TXN_OP_REF_DELETE)

--- a/src/prepared_discover/prepared_discover_txn.c
+++ b/src/prepared_discover/prepared_discover_txn.c
@@ -132,21 +132,18 @@ __wt_prepared_discover_remove_item(WT_SESSION_IMPL *session, uint64_t prepared_i
  *     Add an artifact to a pending prepared transaction.
  */
 int
-__wti_prepared_discover_add_artifact_upd(
-  WT_SESSION_IMPL *session, uint64_t prepared_id, wt_timestamp_t prepare_ts, WT_ITEM *key)
+__wti_prepared_discover_add_artifact_upd(WT_SESSION_IMPL *session, WT_UPDATE *upd, WT_ITEM *key)
 {
     WT_PENDING_PREPARED_ITEM *prepared_item;
     WT_TXN_OP *op;
-
-    WT_RET(
-      __prepared_discover_find_or_create_item(session, prepared_id, prepare_ts, &prepared_item));
+    WT_RET(__prepared_discover_find_or_create_item(
+      session, upd->prepared_id, upd->prepare_ts, &prepared_item));
     /*
-     * When committing/aborting a prepared update, we always do a search for the prepared update in
-     * the update chain, so no point passing the actual update to __wt_op_modify. We only need the
-     * key and btree information to help with the search of the update when resolving txn.
+     * We need the key and btree information to help with the search of the update when resolving
+     * txn.
      */
     WT_RET(__wt_pending_prepared_next_op(session, &op, prepared_item, key));
-    WT_RET(__wt_op_modify(session, NULL, op));
+    WT_RET(__wt_op_modify(session, upd, op));
 
     WT_ASSERT(session, op->type == WT_TXN_OP_BASIC_ROW || op->type == WT_TXN_OP_INMEM_ROW);
 
@@ -205,8 +202,7 @@ __wti_prepared_discover_restore_and_add_artifact_upd(WT_SESSION_IMPL *session,
     WT_WITH_PAGE_INDEX(session, ret = __wt_row_search(cbt, key, true, NULL, false, NULL));
     WT_ERR(ret);
     WT_ERR(__wt_row_modify(cbt, key, NULL, &upd, WT_UPDATE_INVALID, true, true));
-    WT_ERR(
-      __wti_prepared_discover_add_artifact_upd(session, upd->prepared_id, upd->prepare_ts, key));
+    WT_ERR(__wti_prepared_discover_add_artifact_upd(session, upd, key));
 err:
     if (cursor != NULL)
         WT_TRET(cursor->close(cursor));

--- a/src/prepared_discover/prepared_discover_txn.c
+++ b/src/prepared_discover/prepared_discover_txn.c
@@ -133,16 +133,20 @@ __wt_prepared_discover_remove_item(WT_SESSION_IMPL *session, uint64_t prepared_i
  */
 int
 __wti_prepared_discover_add_artifact_upd(
-  WT_SESSION_IMPL *session, uint64_t prepared_id, WT_ITEM *key, WT_UPDATE *upd)
+  WT_SESSION_IMPL *session, uint64_t prepared_id, wt_timestamp_t prepare_ts, WT_ITEM *key)
 {
     WT_PENDING_PREPARED_ITEM *prepared_item;
     WT_TXN_OP *op;
 
-    WT_RET(__prepared_discover_find_or_create_item(
-      session, prepared_id, upd->prepare_ts, &prepared_item));
-
+    WT_RET(
+      __prepared_discover_find_or_create_item(session, prepared_id, prepare_ts, &prepared_item));
+    /*
+     * When committing/aborting a prepared update, we always do a search for the prepared update in
+     * the update chain, so no point passing the actual update to __wt_op_modify. We only need the
+     * key and btree information to help with the search of the update when resolving txn.
+     */
     WT_RET(__wt_pending_prepared_next_op(session, &op, prepared_item, key));
-    WT_RET(__wt_op_modify(session, upd, op));
+    WT_RET(__wt_op_modify(session, NULL, op));
 
     WT_ASSERT(session, op->type == WT_TXN_OP_BASIC_ROW || op->type == WT_TXN_OP_INMEM_ROW);
 
@@ -153,32 +157,58 @@ __wti_prepared_discover_add_artifact_upd(
 }
 
 /*
- * __wti_prepared_discover_add_artifact_ondisk_row --
- *     Add an artifact to a pending prepared transaction.
+ * __wti_prepared_discover_restore_and_add_artifact_upd --
+ *     In disaggregated storage, in follower mode, stable table cannot be modified, therefore a
+ *     prepared update needs to be restored onto ingest table so that the follower node can then
+ *     commit the prepared transaction. This function opens the ingest table and inserts the update
+ *     restored from disk onto the ingest table.
  */
 int
-__wti_prepared_discover_add_artifact_ondisk_row(
-  WT_SESSION_IMPL *session, uint64_t prepared_id, WT_TIME_WINDOW *tw, WT_ITEM *key)
+__wti_prepared_discover_restore_and_add_artifact_upd(WT_SESSION_IMPL *session,
+  const char *stable_uri, WT_ITEM *key, WT_ITEM *value, WT_CELL_UNPACK_KV *unpack)
 {
+    WT_CONNECTION_IMPL *conn;
+    WT_CURSOR *cursor;
+    WT_CURSOR_BTREE *cbt;
     WT_DECL_RET;
+    WT_LAYERED_TABLE_MANAGER *manager;
+    WT_LAYERED_TABLE_MANAGER_ENTRY *entry;
     WT_UPDATE *upd;
+    uint32_t i, table_count;
 
-    /*
-     * Create an update structure with the time information and state populated - that allows this
-     * code to reuse existing machinery for installing transaction operations.
-     */
-    WT_RET(__wt_upd_alloc(session, NULL, WT_UPDATE_STANDARD, &upd, NULL));
-    upd->txnid = session->txn->id;
-    upd->upd_durable_ts = tw->durable_start_ts;
-    upd->prepare_state = WT_PREPARE_INPROGRESS;
-    upd->prepared_id = prepared_id;
-    upd->upd_start_ts = upd->prepare_ts = tw->start_prepare_ts;
-    WT_ERR(__wti_prepared_discover_add_artifact_upd(session, prepared_id, key, upd));
+    const char *cfg[] = {WT_CONFIG_BASE(session, WT_SESSION_open_cursor), "overwrite", NULL, NULL};
+
+    cursor = NULL;
+    entry = NULL;
+    conn = S2C(session);
+    manager = &conn->layered_table_manager;
+    table_count = manager->open_layered_table_count;
+    for (i = 0; i < table_count; i++) {
+        /* Find the entry with stable uri that matches the currently opened dhandle. */
+        if (manager->entries[i] != NULL) {
+            if (WT_PREFIX_MATCH(stable_uri, manager->entries[i]->stable_uri)) {
+                entry = manager->entries[i];
+                break;
+            }
+        }
+    }
+    WT_ASSERT_ALWAYS(
+      session, entry != NULL, "Unable to find matching ingest table to restore prepared update");
+    /* Open cursor on the ingest table */
+    WT_ERR(__wt_open_cursor(session, entry->ingest_uri, NULL, cfg, &cursor));
+
+    cbt = (WT_CURSOR_BTREE *)cursor;
+    size_t size;
+    WT_ERR(__wt_page_inmem_update(session, value, unpack, &upd, &size));
+
+    /* Search the page and apply the modification. */
+    WT_WITH_PAGE_INDEX(session, ret = __wt_row_search(cbt, key, true, NULL, false, NULL));
+    WT_ERR(ret);
+    WT_ERR(__wt_row_modify(cbt, key, NULL, &upd, WT_UPDATE_INVALID, true, true));
+    WT_ERR(
+      __wti_prepared_discover_add_artifact_upd(session, upd->prepared_id, upd->prepare_ts, key));
 err:
-    /*
-     * It's OK to free the update now, the transaction structure will lookup using the key since
-     * this is for a prepared transaction.
-     */
-    __wt_free_update_list(session, &upd);
+    if (cursor != NULL)
+        WT_TRET(cursor->close(cursor));
     return (ret);
 }

--- a/src/prepared_discover/prepared_discover_walk.c
+++ b/src/prepared_discover/prepared_discover_walk.c
@@ -43,6 +43,7 @@ static int
 __prepared_discover_process_ondisk_kv(WT_SESSION_IMPL *session, WT_REF *ref, WT_ROW *rip,
   uint64_t recno, WT_ITEM *row_key, WT_CELL_UNPACK_KV *vpack)
 {
+    WT_DECL_ITEM(value);
     WT_DECL_RET;
     WT_ITEM *key;
     WT_PAGE *page;
@@ -66,20 +67,42 @@ __prepared_discover_process_ondisk_kv(WT_SESSION_IMPL *session, WT_REF *ref, WT_
         key->size = WT_PTRDIFF(memp, key->data);
     }
 
-    /* Retrieve the time window from the unpacked value cell. */
-    __wt_cell_get_tw(vpack, &tw);
-
     /* Add an entry for this key to the transaction structure */
-    if (rip != NULL)
-        WT_ERR(
-          __wti_prepared_discover_add_artifact_ondisk_row(session, tw->start_prepared_id, tw, key));
-    else
+    if (rip != NULL) {
+        /*
+         * In disagg, follower node needs to restore prepared updates from stable checkpoint onto
+         * the ingest table for resolving txn since it can only edit the ingest table. Therefore it
+         * needs to do a full restoration of the update and move it to the ingest table. For leader
+         * mode and non-disagg btree, it should already have restored the prepared update to its
+         * btree, so we can just add the prepared ts and prepared id to the hash map.
+         */
+        if (__wt_conn_is_disagg(session) && !S2C(session)->layered_table_manager.leader) {
+            WT_ERR(__wt_scr_alloc(session, 0, &value));
+            WT_ERR(__wt_page_cell_data_ref_kv(session, page, vpack, value));
+            const char *stable_uri = session->dhandle->name;
+            WT_SAVE_DHANDLE(session,
+              ret = __wti_prepared_discover_restore_and_add_artifact_upd(
+                session, stable_uri, key, value, vpack));
+        } else {
+            /* Retrieve the time window from the unpacked value cell. */
+            __wt_cell_get_tw(vpack, &tw);
+            if (WT_TIME_WINDOW_HAS_STOP_PREPARE(tw))
+                WT_ERR(__wti_prepared_discover_add_artifact_upd(
+                  session, tw->stop_prepared_id, tw->stop_prepare_ts, key));
+            else {
+                WT_ASSERT(session, WT_TIME_WINDOW_HAS_START_PREPARE(tw));
+                WT_ERR(__wti_prepared_discover_add_artifact_upd(
+                  session, tw->start_prepared_id, tw->start_prepare_ts, key));
+            }
+        }
+    } else
         WT_ASSERT_ALWAYS(
           session, false, "Column store prepared transaction discovery not supported");
 
 err:
     if (rip == NULL || row_key == NULL)
         __wt_scr_free(session, &key);
+    __wt_scr_free(session, &value);
     return (ret);
 }
 
@@ -119,13 +142,11 @@ __prepared_discover_check_ondisk_kv(WT_SESSION_IMPL *session, WT_REF *ref, WT_RO
 static int
 __prepared_discover_process_prepared_update(WT_SESSION_IMPL *session, WT_ITEM *key, WT_UPDATE *upd)
 {
-    uint64_t prepared_id;
-
     WT_ASSERT(
       session, upd->prepare_state != WT_PREPARE_INIT && upd->prepare_state != WT_PREPARE_RESOLVED);
 
-    prepared_id = upd->prepared_id;
-    WT_RET(__wti_prepared_discover_add_artifact_upd(session, prepared_id, key, upd));
+    WT_RET(
+      __wti_prepared_discover_add_artifact_upd(session, upd->prepared_id, upd->prepare_ts, key));
     return (0);
 }
 
@@ -399,10 +420,10 @@ int
 __wt_prepared_discover_filter_apply_handles(WT_SESSION_IMPL *session)
 {
     WT_CURSOR *cursor;
+    WT_DECL_ITEM(stable_uri_buf);
     WT_DECL_RET;
-    const char *uri, *config;
+    const char *checkpoint_name, *uri, *config;
     bool has_prepare;
-
     /*
      * TODO: how careful does this need to be about concurrent schema operations? If this step needs
      * to be exclusive in some way it should probably accumulate a set of relevant handles before
@@ -415,7 +436,6 @@ __wt_prepared_discover_filter_apply_handles(WT_SESSION_IMPL *session)
         /* Only interested in btree handles that aren't the metadata */
         if (!WT_BTREE_PREFIX(uri) || strcmp(uri, WT_METAFILE_URI) == 0)
             continue;
-
         WT_ERR_NOTFOUND_OK(cursor->get_value(cursor, &config), true);
         if (ret == WT_NOTFOUND)
             config = NULL;
@@ -423,12 +443,25 @@ __wt_prepared_discover_filter_apply_handles(WT_SESSION_IMPL *session)
         WT_ERR(__prepared_discover_btree_has_prepare(session, config, &has_prepare));
         if (!has_prepare)
             continue;
+        /* If this is a follower node, open the stable table and search for prepared update there */
+        if (__wt_conn_is_disagg(session) && !S2C(session)->layered_table_manager.leader) {
+            /* Look up the most recent data store checkpoint. This fetches the exact name to use. */
+            WT_ERR(__wt_meta_checkpoint_last_name(session, uri, &checkpoint_name, NULL, NULL));
+            WT_ASSERT(session, ret == 0);
+            WT_ERR(__wt_scr_alloc(session, 0, &stable_uri_buf));
+            /*
+             * Use a URI with a "/<checkpoint name> suffix. This is interpreted as reading from the
+             * stable checkpoint, but without it being a traditional checkpoint cursor.
+             */
+            WT_ERR(__wt_buf_fmt(session, stable_uri_buf, "%s/%s", uri, checkpoint_name));
+            uri = stable_uri_buf->data;
+        }
         WT_ERR(__prepared_discover_walk_one_tree(session, uri));
     }
     if (ret == WT_NOTFOUND)
         ret = 0;
 err:
     WT_TRET(__wt_metadata_cursor_release(session, &cursor));
-
+    __wt_scr_free(session, &stable_uri_buf);
     return (ret);
 }

--- a/src/prepared_discover/prepared_discover_walk.c
+++ b/src/prepared_discover/prepared_discover_walk.c
@@ -47,7 +47,6 @@ __prepared_discover_process_ondisk_kv(WT_SESSION_IMPL *session, WT_REF *ref, WT_
     WT_DECL_RET;
     WT_ITEM *key;
     WT_PAGE *page;
-    WT_TIME_WINDOW *tw;
     uint8_t *memp;
 
     page = ref->page;
@@ -74,31 +73,21 @@ __prepared_discover_process_ondisk_kv(WT_SESSION_IMPL *session, WT_REF *ref, WT_
          * the ingest table for resolving txn since it can only edit the ingest table. Therefore it
          * needs to do a full restoration of the update and move it to the ingest table. For leader
          * mode and non-disagg btree, it should already have restored the prepared update to its
-         * btree, so we can just add the prepared ts and prepared id to the hash map.
+         * btree, so we would never hit this block.
          */
-        if (__wt_conn_is_disagg(session) && !S2C(session)->layered_table_manager.leader) {
-            WT_ERR(__wt_scr_alloc(session, 0, &value));
-            WT_ERR(__wt_page_cell_data_ref_kv(session, page, vpack, value));
-            const char *stable_uri = session->dhandle->name;
-            WT_SAVE_DHANDLE(session,
-              ret = __wti_prepared_discover_restore_and_add_artifact_upd(
-                session, stable_uri, key, value, vpack));
-        } else {
-            /* Retrieve the time window from the unpacked value cell. */
-            __wt_cell_get_tw(vpack, &tw);
-            if (WT_TIME_WINDOW_HAS_STOP_PREPARE(tw))
-                WT_ERR(__wti_prepared_discover_add_artifact_upd(
-                  session, tw->stop_prepared_id, tw->stop_prepare_ts, key));
-            else {
-                WT_ASSERT(session, WT_TIME_WINDOW_HAS_START_PREPARE(tw));
-                WT_ERR(__wti_prepared_discover_add_artifact_upd(
-                  session, tw->start_prepared_id, tw->start_prepare_ts, key));
-            }
-        }
+        WT_ASSERT_ALWAYS(session,
+          __wt_conn_is_disagg(session) && !S2C(session)->layered_table_manager.leader,
+          "prepared update restoration should only happen on disaggregated follower nodes");
+
+        WT_ERR(__wt_scr_alloc(session, 0, &value));
+        WT_ERR(__wt_page_cell_data_ref_kv(session, page, vpack, value));
+        const char *stable_uri = session->dhandle->name;
+        WT_SAVE_DHANDLE(session,
+          ret = __wti_prepared_discover_restore_and_add_artifact_upd(
+            session, stable_uri, key, value, vpack));
     } else
         WT_ASSERT_ALWAYS(
           session, false, "Column store prepared transaction discovery not supported");
-
 err:
     if (rip == NULL || row_key == NULL)
         __wt_scr_free(session, &key);
@@ -145,8 +134,7 @@ __prepared_discover_process_prepared_update(WT_SESSION_IMPL *session, WT_ITEM *k
     WT_ASSERT(
       session, upd->prepare_state != WT_PREPARE_INIT && upd->prepare_state != WT_PREPARE_RESOLVED);
 
-    WT_RET(
-      __wti_prepared_discover_add_artifact_upd(session, upd->prepared_id, upd->prepare_ts, key));
+    WT_RET(__wti_prepared_discover_add_artifact_upd(session, upd, key));
     return (0);
 }
 

--- a/test/suite/test_prepare_discover06.py
+++ b/test/suite/test_prepare_discover06.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# test_prepare_discover06.py
+#   Test layered cursor with prepared transaction discovery in disaggregated storage:
+#   - Setup layered cursor as leader, insert and commit data
+#   - Prepare transaction, advance stable timestamp, checkpoint
+#   - Reopen as follower and pickup checkpoint, verify committed data visibility
+#   - Step up as leader, discover and claim prepared transaction, commit and verify
+
+import wiredtiger
+import wttest
+from helper_disagg import disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
+
+@disagg_test_class
+class test_prepare_discover06(wttest.WiredTigerTestCase):
+    tablename = 'test_prepare_discover06'
+    uri = 'layered:' + tablename
+
+    resolve_scenarios = [
+        ('commit', dict(commit=True)),
+        # FIXME-WT-15465 Fix throwing a prepare conflict when encountering prepared update on stable table
+        # ('rollback', dict(commit=False)),
+    ]
+    # Use disaggregated storage scenarios
+    disagg_storages = gen_disagg_storages('test_prepare_discover06', disagg_only=True)
+    scenarios = make_scenarios(disagg_storages, resolve_scenarios)
+
+    # Base configuration for leader connection
+    conn_base_config = 'cache_size=10MB,statistics=(all),precise_checkpoint=true,preserve_prepared=true,'
+
+    def conn_config(self):
+        return self.conn_base_config + 'disaggregated=(role="leader")'
+
+    def test_prepare_discover_layered(self):
+        # Step 1: Setup layered cursor as leader and insert initial committed data
+        self.pr("=== Phase 1: Setup layered cursor as leader ===")
+
+        # Set initial timestamps
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(50))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(50))
+
+        # Create the layered table
+        self.session.create(self.uri, 'key_format=i,value_format=S')
+        cursor = self.session.open_cursor(self.uri)
+
+        # Insert some initial data and commit at timestamp 60
+        self.session.begin_transaction()
+        cursor[1] = "committed_value_1"
+        cursor[2] = "committed_value_2"
+        cursor[3] = "committed_value_3"
+        self.session.commit_transaction("commit_timestamp=" + self.timestamp_str(60))
+
+        # Advance stable timestamp to include committed data
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(70))
+
+        # Verify committed data can be read
+        self.session.begin_transaction("read_timestamp=" + self.timestamp_str(60))
+        self.assertEqual(cursor[1], "committed_value_1")
+        self.assertEqual(cursor[2], "committed_value_2")
+        self.assertEqual(cursor[3], "committed_value_3")
+        self.session.rollback_transaction()
+
+        # Step 2: Prepare transaction and create checkpoint
+
+        # Insert more data and prepare the transaction at timestamp 100
+        self.session.begin_transaction()
+        cursor[4] = "prepared_value_4"
+        cursor[5] = "prepared_value_5"
+        cursor[6] = "prepared_value_6"
+
+        # Prepare with prepared_id 123 at timestamp 100
+        self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(100) +
+                                       ',prepared_id=' + self.prepared_id_str(123))
+
+        # Advance stable timestamp past the prepare timestamp
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(150))
+
+        # Create checkpoint to persist the prepared transaction
+        checkpoint_session = self.conn.open_session()
+        checkpoint_session.checkpoint()
+        checkpoint_session.close()
+
+        # Step 3: Reopen as follower and pickup checkpoint
+
+        # Get the checkpoint metadata before closing
+        checkpoint_meta = self.disagg_get_complete_checkpoint_meta()
+
+        # Configure as follower with checkpoint pickup (not using backup)
+        follower_config = self.conn_base_config + \
+                         'disaggregated=(role="follower",' + \
+                         f'checkpoint_meta="{checkpoint_meta}")'
+        # Reopen connection as follower
+        self.reopen_conn(config=follower_config)
+
+        # Verify committed data is visible but prepared data is not
+        cursor = self.session.open_cursor(self.uri)
+
+        # Should see committed data at timestamp 60
+        self.session.begin_transaction("read_timestamp=" + self.timestamp_str(60))
+        self.assertEqual(cursor[1], "committed_value_1")
+        self.assertEqual(cursor[2], "committed_value_2")
+        self.assertEqual(cursor[3], "committed_value_3")
+
+        # Prepared data should not be visible yet
+        cursor.set_key(4)
+        self.assertEqual(cursor.search(), wiredtiger.WT_NOTFOUND)
+        cursor.set_key(5)
+        self.assertEqual(cursor.search(), wiredtiger.WT_NOTFOUND)
+        cursor.set_key(6)
+        self.assertEqual(cursor.search(), wiredtiger.WT_NOTFOUND)
+        self.session.rollback_transaction()
+
+        cursor.close()
+
+        # Open prepared discover cursor to find pending prepared transactions
+        prepared_discover_cursor = self.session.open_cursor("prepared_discover:")
+
+        # Walk through prepared discover cursor to find our transaction
+        discover_session = self.conn.open_session()
+        count = 0
+        found_prepared_id = None
+
+        while prepared_discover_cursor.next() == 0:
+            count += 1
+            prepared_id = prepared_discover_cursor.get_key()
+            self.assertEqual(prepared_id, 123)  # Should find our prepared transaction
+            found_prepared_id = prepared_id
+
+            # Claim the prepared transaction
+            discover_session.begin_transaction("claim_prepared_id=" + self.prepared_id_str(prepared_id))
+            break
+
+        self.assertEqual(count, 1)  # Should find exactly one prepared transaction
+        self.assertEqual(found_prepared_id, 123)
+        prepared_discover_cursor.close()
+        if self.commit:
+            # Commit the claimed prepared transaction at timestamp 200
+            discover_session.commit_transaction("commit_timestamp=" + self.timestamp_str(200) +
+                                            ",durable_timestamp=" + self.timestamp_str(210))
+        else:
+            discover_session.rollback_transaction("rollback_timestamp=" + self.timestamp_str(210))
+        discover_session.close()
+
+        # Update stable timestamp to include the committed transaction
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(220))
+
+        # Verify all data
+        read_session = self.conn.open_session()
+        read_cursor = read_session.open_cursor(self.uri)
+
+        # Check committed data is still visible at timestamp 60
+        read_session.begin_transaction("read_timestamp=" + self.timestamp_str(60))
+        self.assertEqual(read_cursor[1], "committed_value_1")
+        self.assertEqual(read_cursor[2], "committed_value_2")
+        self.assertEqual(read_cursor[3], "committed_value_3")
+        for i in range(4, 7):
+            read_cursor.set_key(i)
+            self.assertEqual(wiredtiger.WT_NOTFOUND, read_cursor.search())
+        read_session.rollback_transaction()
+
+        # Check all data is visible at timestamp 200
+        read_session.begin_transaction("read_timestamp=" + self.timestamp_str(200))
+        self.assertEqual(read_cursor[1], "committed_value_1")
+        self.assertEqual(read_cursor[2], "committed_value_2")
+        self.assertEqual(read_cursor[3], "committed_value_3")
+        for i in range(4, 7):
+            read_cursor.set_key(i)
+            if self.commit:
+                self.assertEqual(0, read_cursor.search())
+                self.assertEqual(f'prepared_value_{i}', read_cursor.get_value())
+            else:
+                self.assertEqual(wiredtiger.WT_NOTFOUND, read_cursor.search())
+        read_session.rollback_transaction()
+
+        read_cursor.close()
+        read_session.close()
+

--- a/test/suite/test_prepare_discover07.py
+++ b/test/suite/test_prepare_discover07.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# test_prepare_discover07.py
+#   Test layered cursor with prepared tombstone transaction discovery in disaggregated storage:
+#   - Setup layered cursor as leader, insert and commit data
+#   - Prepare transaction, advance stable timestamp, checkpoint
+#   - Reopen as follower and pickup checkpoint, verify committed data visibility
+#   - Step up as leader, discover and claim prepared transaction, commit and verify
+
+import wiredtiger
+import wttest
+from helper_disagg import disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
+
+@disagg_test_class
+class test_prepare_discover07(wttest.WiredTigerTestCase):
+    tablename = 'test_prepare_discover07'
+    uri = 'layered:' + tablename
+
+    resolve_scenarios = [
+        ('commit', dict(commit=True)),
+        ('rollback', dict(commit=False)),
+    ]
+    # Use disaggregated storage scenarios
+    disagg_storages = gen_disagg_storages('test_prepare_discover07', disagg_only=True)
+    scenarios = make_scenarios(disagg_storages, resolve_scenarios)
+
+    # Base configuration for leader connection
+    conn_base_config = 'cache_size=10MB,statistics=(all),precise_checkpoint=true,preserve_prepared=true,'
+
+    def conn_config(self):
+        return self.conn_base_config + 'disaggregated=(role="leader")'
+
+    def test_prepare_discover_layered(self):
+        # Step 1: Setup layered cursor as leader and insert initial committed data
+        self.pr("=== Phase 1: Setup layered cursor as leader ===")
+
+        # Set initial timestamps
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(50))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(50))
+        self.skipTest('FIXME-WT-15465 Fix throwing a prepare conflict when encountering prepared update on stable table')
+
+        # Create the layered table
+        self.session.create(self.uri, 'key_format=i,value_format=S')
+        cursor = self.session.open_cursor(self.uri)
+
+        # Insert some initial data and commit at timestamp 60
+        self.session.begin_transaction()
+        cursor[1] = "committed_value_1"
+        cursor[2] = "committed_value_2"
+        cursor[3] = "committed_value_3"
+        cursor[4] = "committed_value_4"
+        cursor[5] = "committed_value_5"
+        cursor[6] = "committed_value_6"
+        self.session.commit_transaction("commit_timestamp=" + self.timestamp_str(60))
+
+        # Advance stable timestamp to include committed data
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(70))
+
+        # Verify committed data can be read
+        self.session.begin_transaction("read_timestamp=" + self.timestamp_str(60))
+        self.assertEqual(cursor[1], "committed_value_1")
+        self.assertEqual(cursor[2], "committed_value_2")
+        self.assertEqual(cursor[3], "committed_value_3")
+        self.assertEqual(cursor[4], "committed_value_4")
+        self.assertEqual(cursor[5], "committed_value_5")
+        self.assertEqual(cursor[6], "committed_value_6")
+        self.session.rollback_transaction()
+
+        # Step 2: Prepare transaction and create checkpoint
+
+        # Insert more data and prepare the transaction at timestamp 100
+        self.session.begin_transaction()
+        for i in range(4, 7):
+            cursor.set_key(i)
+            self.assertEqual(cursor.remove(), 0)
+
+        # Prepare with prepared_id 123 at timestamp 100
+        self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(100) +
+                                       ',prepared_id=' + self.prepared_id_str(123))
+
+        # Advance stable timestamp past the prepare timestamp
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(150))
+
+        # Create checkpoint to persist the prepared transaction
+        checkpoint_session = self.conn.open_session()
+        checkpoint_session.checkpoint()
+        checkpoint_session.close()
+
+        # Step 3: Reopen as follower and pickup checkpoint
+
+        # Get the checkpoint metadata before closing
+        checkpoint_meta = self.disagg_get_complete_checkpoint_meta()
+
+        # Configure as follower with checkpoint pickup (not using backup)
+        follower_config = self.conn_base_config + \
+                         'disaggregated=(role="follower",' + \
+                         f'checkpoint_meta="{checkpoint_meta}")'
+        # Reopen connection as follower
+        self.reopen_conn(config=follower_config)
+
+        # Verify committed data is visible but prepared data is not
+        cursor = self.session.open_cursor(self.uri)
+
+        # Should see committed data at timestamp 60
+        self.session.begin_transaction("read_timestamp=" + self.timestamp_str(60))
+        self.assertEqual(cursor[1], "committed_value_1")
+        self.assertEqual(cursor[2], "committed_value_2")
+        self.assertEqual(cursor[3], "committed_value_3")
+        self.assertEqual(cursor[4], "committed_value_4")
+        self.assertEqual(cursor[5], "committed_value_5")
+        self.assertEqual(cursor[6], "committed_value_6")
+        self.session.rollback_transaction()
+
+        cursor.close()
+
+        # Open prepared discover cursor to find pending prepared transactions
+        prepared_discover_cursor = self.session.open_cursor("prepared_discover:")
+
+        # Walk through prepared discover cursor to find our transaction
+        discover_session = self.conn.open_session()
+        count = 0
+        found_prepared_id = None
+
+        while prepared_discover_cursor.next() == 0:
+            count += 1
+            prepared_id = prepared_discover_cursor.get_key()
+            self.assertEqual(prepared_id, 123)  # Should find our prepared transaction
+            found_prepared_id = prepared_id
+
+            # Claim the prepared transaction
+            discover_session.begin_transaction("claim_prepared_id=" + self.prepared_id_str(prepared_id))
+            break
+
+        self.assertEqual(count, 1)  # Should find exactly one prepared transaction
+        self.assertEqual(found_prepared_id, 123)
+        prepared_discover_cursor.close()
+        if self.commit:
+            # Commit the claimed prepared transaction at timestamp 200
+            discover_session.commit_transaction("commit_timestamp=" + self.timestamp_str(200) +
+                                            ",durable_timestamp=" + self.timestamp_str(210))
+        else:
+            discover_session.rollback_transaction("rollback_timestamp=" + self.timestamp_str(210))
+        discover_session.close()
+
+        # Update stable timestamp to include the committed transaction
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(220))
+
+        # Verify all data
+        read_session = self.conn.open_session()
+        read_cursor = read_session.open_cursor(self.uri)
+
+        # Check committed data is still visible at timestamp 60
+        read_session.begin_transaction("read_timestamp=" + self.timestamp_str(60))
+        self.assertEqual(read_cursor[1], "committed_value_1")
+        self.assertEqual(read_cursor[2], "committed_value_2")
+        self.assertEqual(read_cursor[3], "committed_value_3")
+        self.assertEqual(read_cursor[4], "committed_value_4")
+        self.assertEqual(read_cursor[5], "committed_value_5")
+        self.assertEqual(read_cursor[6], "committed_value_6")
+
+        read_session.rollback_transaction()
+
+        # Check all data is visible at timestamp 200
+        read_session.begin_transaction("read_timestamp=" + self.timestamp_str(200))
+        self.assertEqual(read_cursor[1], "committed_value_1")
+        self.assertEqual(read_cursor[2], "committed_value_2")
+        self.assertEqual(read_cursor[3], "committed_value_3")
+        self.session.breakpoint()
+        for i in range(4, 7):
+            read_cursor.set_key(i)
+            if self.commit:
+                self.assertEqual(wiredtiger.WT_NOTFOUND, read_cursor.search())
+            else:
+                self.assertEqual(0, read_cursor.search())
+                self.assertEqual(f'prepared_value_{i}', read_cursor.get_value())
+        read_session.rollback_transaction()
+
+        read_cursor.close()
+        read_session.close()
+


### PR DESCRIPTION
In disaggregated storage, follower nodes can only modify the ingest table, not the stable table. However, with precise checkpoints, prepared transactions are stored in the stable table. This creates a problem: when follower nodes pick up checkpoints containing prepared transactions, they cannot resolve these transactions because they lack write access to the stable table where the prepared updates are.

This PR resolves the issue by restoring prepared updates from the stable table to the ingest table during the prepared transaction discovery process. The implementation:

- Find prepared transactions in stable table checkpoints during discovery
- Restores prepared updates from stable table to ingest table and adds it to the prepared discover resulting hash map for claiming.
- After the prepared transactions are claimed and committed/rolled back, transaction resolution are now accessible in the ingest table.
