### PR TITLE
WT-16145 Acquire schema lock while updating the shared metadata table

### DIFF
--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -1355,8 +1355,10 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
      * a protection against someone creating a layered table, dropping the table, and then
      * recreating a local table with the same name.
      */
-    if (__wt_conn_is_disagg(session) && conn->layered_table_manager.leader)
-        WT_ERR(__wt_disagg_copy_metadata_process(session));
+    if (__wt_conn_is_disagg(session) && conn->layered_table_manager.leader) {
+        WT_WITH_SCHEMA_LOCK(session, ret = __wt_disagg_copy_metadata_process(session));
+        WT_ERR(ret);
+    }
 
     /* Wait prior to checkpointing the history store to simulate checkpoint slowness. */
     __checkpoint_timing_stress(session, WT_TIMING_STRESS_HS_CHECKPOINT_DELAY, &tsp);

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -975,6 +975,13 @@ __wt_disagg_copy_metadata_process(WT_SESSION_IMPL *session)
 
     conn = S2C(session);
 
+    /*
+     * This requires schema lock to ensure that we capture a consistent snapshot of metadata entries
+     * related to the given shared table, e.g., the various file, colgroup, table, and layered
+     * entries.
+     */
+    WT_ASSERT_SPINLOCK_OWNED(session, &conn->schema_lock);
+
     __wt_spin_lock(session, &conn->disaggregated_storage.copy_metadata_lock);
 
     TAILQ_FOREACH_SAFE(entry, &conn->disaggregated_storage.copy_metadata_qh, q, tmp)


### PR DESCRIPTION
Acquire the schema lock when updating the shared metadata table, so that we can copy a consistent snapshot of a given table's metadata, i.e., a consistent combination of the various file, colgroup, layered, and table metadata entries.