### PR TITLE
WT-16138 Skip disagg/layered Python tests with tiered hook

### DIFF
--- a/test/suite/hook_tiered.py
+++ b/test/suite/hook_tiered.py
@@ -296,6 +296,7 @@ class TieredHookCreator(wthooks.WiredTigerHookCreator):
     def should_skip(self, test) -> (bool, str):
         skip_categories = [
             ("backup",               "Can't backup a tiered table"),
+            ("disagg",               "Disagg tests are not supported with tiered storage"),
             ("inmem",                "In memory tests don't make sense with tiered storage"),
             ("layered",              "Layered tests are not supported with tiered storage"),
             ("live_restore",         "Live restore is not supported with tiered storage"),

--- a/test/suite/hook_tiered.py
+++ b/test/suite/hook_tiered.py
@@ -297,6 +297,7 @@ class TieredHookCreator(wthooks.WiredTigerHookCreator):
         skip_categories = [
             ("backup",               "Can't backup a tiered table"),
             ("inmem",                "In memory tests don't make sense with tiered storage"),
+            ("layered",              "Layered tests are not supported with tiered storage"),
             ("live_restore",         "Live restore is not supported with tiered storage"),
             ("modify_smoke_recover", "Copying WT dir doesn't copy the bucket directory"),
             ("test_config_json",     "Tiered hook's create function can't handle a json config string"),

--- a/test/suite/test_layered15.py
+++ b/test/suite/test_layered15.py
@@ -32,7 +32,6 @@ from wtscenario import make_scenarios
 
 # test_layered15.py
 #    Start without local files.
-@wttest.skip_for_hook("tiered", "FIXME-WT-14938: crashing with tiered hook.")
 @disagg_test_class
 class test_layered15(wttest.WiredTigerTestCase):
     nitems = 500

--- a/test/suite/test_layered17.py
+++ b/test/suite/test_layered17.py
@@ -32,7 +32,6 @@ from wtscenario import make_scenarios
 
 # test_layered17.py
 #    Check timestamps.
-@wttest.skip_for_hook("tiered", "FIXME-WT-14938: crashing with tiered hook.")
 @disagg_test_class
 class test_layered17(wttest.WiredTigerTestCase):
     nitems = 500

--- a/test/suite/test_layered18.py
+++ b/test/suite/test_layered18.py
@@ -32,7 +32,6 @@ from wtscenario import make_scenarios
 
 # test_layered18.py
 #    Create long delta chains.
-@wttest.skip_for_hook("tiered", "FIXME-WT-14938: crashing with tiered hook.")
 @disagg_test_class
 class test_layered18(wttest.WiredTigerTestCase):
     nitems = 500

--- a/test/suite/test_layered25.py
+++ b/test/suite/test_layered25.py
@@ -32,7 +32,6 @@ from wtscenario import make_scenarios
 
 # test_layered25.py
 #    Start without local files and test historical reads.
-@wttest.skip_for_hook("tiered", "FIXME-WT-14938: crashing with tiered hook.")
 @disagg_test_class
 class test_layered25(wttest.WiredTigerTestCase):
     nitems = 500

--- a/test/suite/test_layered26.py
+++ b/test/suite/test_layered26.py
@@ -33,7 +33,6 @@ from wtscenario import make_scenarios
 # test_layered26.py
 #    Make sure a secondary picking up a checkpoint adds in the stable
 #    component of the table.
-@wttest.skip_for_hook("tiered", "FIXME-WT-14938: crashing with tiered hook.")
 @disagg_test_class
 class test_layered26(wttest.WiredTigerTestCase):
     nitems = 5000

--- a/test/suite/test_layered27.py
+++ b/test/suite/test_layered27.py
@@ -33,7 +33,6 @@ from wtscenario import make_scenarios
 
 # test_layered27.py
 # Test draining the ingest table
-@wttest.skip_for_hook("tiered", "FIXME-WT-14938: crashing with tiered hook.")
 @disagg_test_class
 class test_layered27(wttest.WiredTigerTestCase):
     conn_base_config = ',create,statistics=(all),statistics_log=(wait=1,json=true,on_close=true),' \

--- a/test/suite/test_layered30.py
+++ b/test/suite/test_layered30.py
@@ -32,7 +32,6 @@ from wtscenario import make_scenarios
 
 # test_layered30.py
 #    Test creating empty tables.
-@wttest.skip_for_hook("tiered", "FIXME-WT-14938: crashing with tiered hook.")
 @disagg_test_class
 class test_layered30(wttest.WiredTigerTestCase):
     nitems = 500

--- a/test/suite/test_layered34.py
+++ b/test/suite/test_layered34.py
@@ -32,7 +32,6 @@ from wtscenario import make_scenarios
 
 # test_layered34.py
 #    Test materialization frontier.
-@wttest.skip_for_hook("tiered", "FIXME-WT-14938: crashing with tiered hook.")
 @disagg_test_class
 class test_layered34(wttest.WiredTigerTestCase):
     conn_base_config = 'statistics=(all),' \

--- a/test/suite/test_layered36.py
+++ b/test/suite/test_layered36.py
@@ -32,7 +32,6 @@ from wtscenario import make_scenarios
 
 # test_layered36.py
 #    Test creating missing stable tables.
-@wttest.skip_for_hook("tiered", "FIXME-WT-14938: crashing with tiered hook.")
 @disagg_test_class
 class test_layered36(wttest.WiredTigerTestCase):
     nitems = 500

--- a/test/suite/test_layered38.py
+++ b/test/suite/test_layered38.py
@@ -33,7 +33,6 @@ from wtscenario import make_scenarios
 
 # test_layered38.py
 # Test garbage collecting redundant content in the ingest table
-@wttest.skip_for_hook("tiered", "FIXME-WT-14938: crashing with tiered hook.")
 @disagg_test_class
 class test_layered38(wttest.WiredTigerTestCase):
     conn_base_config = ',create,cache_size=10GB,statistics=(all),statistics_log=(wait=1,json=true,on_close=true),' \

--- a/test/suite/test_layered40.py
+++ b/test/suite/test_layered40.py
@@ -32,7 +32,6 @@ from wtscenario import make_scenarios
 
 # test_layered40.py
 #    Test layered table metadata has logging disabled.
-@wttest.skip_for_hook("tiered", "FIXME-WT-14938: crashing with tiered hook.")
 @disagg_test_class
 class test_layered40(wttest.WiredTigerTestCase):
     conn_config = 'log=(enabled=true),disaggregated=(role="leader"),'

--- a/test/suite/test_layered43.py
+++ b/test/suite/test_layered43.py
@@ -33,7 +33,6 @@ from wiredtiger import stat
 
 # test_layered43.py
 #    Test disaggregated storage with block cache.
-@wttest.skip_for_hook("tiered", "FIXME-WT-14938: crashing with tiered hook.")
 @disagg_test_class
 class test_layered43(wttest.WiredTigerTestCase):
     nitems = 500

--- a/test/suite/test_layered60.py
+++ b/test/suite/test_layered60.py
@@ -32,7 +32,6 @@ from wtscenario import make_scenarios
 
 # test_layered60.py
 #    Test creating empty tables while a checkpoint is running.
-@wttest.skip_for_hook("tiered", "FIXME-WT-14938: crashing with tiered hook.")
 @disagg_test_class
 class test_layered60(wttest.WiredTigerTestCase):
     conn_base_config = 'statistics=(all),' \

--- a/test/suite/test_layered62.py
+++ b/test/suite/test_layered62.py
@@ -44,7 +44,6 @@ from wtscenario import make_scenarios
 # change happened after the checkpoint started.
 #
 @disagg_test_class
-@wttest.skip_for_hook("tiered", "FIXME-WT-14938: crashing with tiered hook.")
 class test_layered62(wttest.WiredTigerTestCase):
     conn_base_config = 'statistics=(all),' \
                      + 'statistics_log=(wait=1,json=true,on_close=true),' \

--- a/test/suite/test_layered64.py
+++ b/test/suite/test_layered64.py
@@ -33,7 +33,6 @@ from wtscenario import make_scenarios
 # test_layered64.py
 #    Test the checksum part of the checkpoint metadata.
 @disagg_test_class
-@wttest.skip_for_hook("tiered", "FIXME-WT-14938: crashing with tiered hook.")
 class test_layered64(wttest.WiredTigerTestCase):
     conn_base_config = 'statistics=(all),' \
                      + 'statistics_log=(wait=1,json=true,on_close=true),' \

--- a/test/suite/test_layered65.py
+++ b/test/suite/test_layered65.py
@@ -35,7 +35,6 @@ from wiredtiger import stat
 #    Test garbage collection ensures that prepared updates and aborted
 #    prepared updates are not removed if the rollback timestamps are newer than
 #    the checkpoint timestamp of the stable table.
-@wttest.skip_for_hook("tiered", "FIXME-WT-14938: crashing with tiered hook.")
 @disagg_test_class
 class test_layered65(wttest.WiredTigerTestCase):
     base_config = 'statistics=(all),precise_checkpoint=true,preserve_prepared=true,'

--- a/test/suite/test_layered68.py
+++ b/test/suite/test_layered68.py
@@ -33,7 +33,6 @@ from wtscenario import make_scenarios
 # test_layered68.py
 #    Test that address cookies in disaggregated storage can be upgraded/downgraded safely.
 @disagg_test_class
-@wttest.skip_for_hook("tiered", "FIXME-WT-14938: crashing with tiered hook.")
 class test_layered68(wttest.WiredTigerTestCase):
     conn_base_config = 'statistics=(all),' \
                      + 'statistics_log=(wait=1,json=true,on_close=true),' \


### PR DESCRIPTION
Disagg/Layered Python tests are no longer executed when the tiered hook is used.