### PR TITLE
WT-15465 Handle prepared updates in layered cursor stable

### DIFF
--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -1288,8 +1288,7 @@ __clayered_lookup(WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, WT_ITEM
          * conflict issue. Therefore for layered cursor operations, we need to ignore these prepared
          * updates to allow reading through to committed data.
          */
-        if ((!conn->layered_table_manager.leader || F_ISSET(conn, WT_CONN_RECONFIGURING_STEP_UP)) &&
-          !F_ISSET(session->txn, WT_TXN_IGNORE_PREPARE)) {
+        if (!conn->layered_table_manager.leader && !F_ISSET(session->txn, WT_TXN_IGNORE_PREPARE)) {
             reset_ignore_prepare = true;
             F_SET(session->txn, WT_TXN_IGNORE_PREPARE);
         }

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -1259,9 +1259,7 @@ __clayered_lookup(WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, WT_ITEM
     conn = S2C(session);
     cursor = &clayered->iface;
     found = false;
-
-    reset_ignore_prepare =
-      F_ISSET(session->txn, WT_TXN_IGNORE_PREPARE) && !conn->layered_table_manager.leader;
+    reset_ignore_prepare = false;
 
     if (!conn->layered_table_manager.leader) {
         c = clayered->ingest_cursor;
@@ -1290,8 +1288,11 @@ __clayered_lookup(WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, WT_ITEM
          * conflict issue. Therefore for layered cursor operations, we need to ignore these prepared
          * updates to allow reading through to committed data.
          */
-        if (reset_ignore_prepare)
+        if ((!conn->layered_table_manager.leader || F_ISSET(conn, WT_CONN_RECONFIGURING_STEP_UP)) &&
+          !F_ISSET(session->txn, WT_TXN_IGNORE_PREPARE)) {
+            reset_ignore_prepare = true;
             F_SET(session->txn, WT_TXN_IGNORE_PREPARE);
+        }
         WT_ERR_NOTFOUND_OK(__clayered_lookup_constituent(c, clayered, value), true);
         if (ret == 0)
             found = true;

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -1254,6 +1254,7 @@ __clayered_lookup(WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, WT_ITEM
     WT_CURSOR *c, *cursor;
     WT_DECL_RET;
     bool found;
+    bool ignore_prepared = F_ISSET(session->txn, WT_TXN_IGNORE_PREPARE);
 
     c = NULL;
     conn = S2C(session);
@@ -1280,6 +1281,15 @@ __clayered_lookup(WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, WT_ITEM
      */
     if (!found && F_ISSET(clayered, WT_CLAYERED_OPEN_READ) && clayered->stable_cursor != NULL) {
         c = clayered->stable_cursor;
+        /*
+         * Temporarily set ignore prepared flag when searching for update in the stable cursor. In
+         * disaggregated storage, the stable table may contain prepared updates that is rolled back
+         * on ingest table. If reading this prepared update on stable table, it will cause prepared
+         * conflict issue. Therefore for layered cursor operations, we need to ignore these prepared
+         * updates to allow reading through to committed data.
+         */
+        if (!was_ignoring_prepared)
+            F_SET(session->txn, WT_TXN_IGNORE_PREPARE);
         WT_ERR_NOTFOUND_OK(__clayered_lookup_constituent(c, clayered, value), true);
         if (ret == 0)
             found = true;
@@ -1289,6 +1299,8 @@ __clayered_lookup(WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, WT_ITEM
         F_CLR(c, WT_CURSTD_KEY_SET);
 
 err:
+    if (!was_ignoring_prepared)
+        F_CLR(session->txn, WT_TXN_IGNORE_PREPARE);
     if (ret == 0) {
         F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
         F_SET(cursor, WT_CURSTD_KEY_INT);

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -1253,13 +1253,15 @@ __clayered_lookup(WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, WT_ITEM
     WT_CONNECTION_IMPL *conn;
     WT_CURSOR *c, *cursor;
     WT_DECL_RET;
-    bool found;
-    bool ignore_prepared = F_ISSET(session->txn, WT_TXN_IGNORE_PREPARE);
+    bool found, reset_ignore_prepare;
 
     c = NULL;
     conn = S2C(session);
     cursor = &clayered->iface;
     found = false;
+
+    reset_ignore_prepare =
+      F_ISSET(session->txn, WT_TXN_IGNORE_PREPARE) && !conn->layered_table_manager.leader;
 
     if (!conn->layered_table_manager.leader) {
         c = clayered->ingest_cursor;
@@ -1288,7 +1290,7 @@ __clayered_lookup(WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, WT_ITEM
          * conflict issue. Therefore for layered cursor operations, we need to ignore these prepared
          * updates to allow reading through to committed data.
          */
-        if (!ignore_prepared)
+        if (reset_ignore_prepare)
             F_SET(session->txn, WT_TXN_IGNORE_PREPARE);
         WT_ERR_NOTFOUND_OK(__clayered_lookup_constituent(c, clayered, value), true);
         if (ret == 0)
@@ -1299,7 +1301,7 @@ __clayered_lookup(WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, WT_ITEM
         F_CLR(c, WT_CURSTD_KEY_SET);
 
 err:
-    if (!ignore_prepared)
+    if (reset_ignore_prepare)
         F_CLR(session->txn, WT_TXN_IGNORE_PREPARE);
     if (ret == 0) {
         F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -1288,7 +1288,7 @@ __clayered_lookup(WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, WT_ITEM
          * conflict issue. Therefore for layered cursor operations, we need to ignore these prepared
          * updates to allow reading through to committed data.
          */
-        if (!was_ignoring_prepared)
+        if (!ignore_prepared)
             F_SET(session->txn, WT_TXN_IGNORE_PREPARE);
         WT_ERR_NOTFOUND_OK(__clayered_lookup_constituent(c, clayered, value), true);
         if (ret == 0)
@@ -1299,7 +1299,7 @@ __clayered_lookup(WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, WT_ITEM
         F_CLR(c, WT_CURSTD_KEY_SET);
 
 err:
-    if (!was_ignoring_prepared)
+    if (!ignore_prepared)
         F_CLR(session->txn, WT_TXN_IGNORE_PREPARE);
     if (ret == 0) {
         F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1701,10 +1701,6 @@ retry:
              */
             if (!have_stop_tw) {
                 WT_VISIBLE_TYPE visible_type = __wt_txn_tw_stop_visible(session, &tw);
-                /*
-                 * FIXME-WT-15465: handle cursor walks for prepared updates on the stable table for
-                 * standby.
-                 */
                 if (visible_type == WT_VISIBLE_PREPARE) {
                     if (!F_ISSET(session->txn, WT_TXN_IGNORE_PREPARE))
                         return (WT_PREPARE_CONFLICT);
@@ -1739,10 +1735,6 @@ retry:
             }
 
             WT_VISIBLE_TYPE visible_type = __wt_txn_tw_start_visible(session, &tw);
-            /*
-             * FIXME-WT-15465: handle cursor walks for prepared updates on the stable table for
-             * standby.
-             */
             if (visible_type == WT_VISIBLE_PREPARE) {
                 if (!F_ISSET(session->txn, WT_TXN_IGNORE_PREPARE))
                     return (WT_PREPARE_CONFLICT);

--- a/test/suite/test_prepare_discover06.py
+++ b/test/suite/test_prepare_discover06.py
@@ -44,9 +44,7 @@ class test_prepare_discover06(wttest.WiredTigerTestCase):
     uri = 'layered:' + tablename
 
     resolve_scenarios = [
-        ('commit', dict(commit=True)),
-        # FIXME-WT-15465 Fix throwing a prepare conflict when encountering prepared update on stable table
-        # ('rollback', dict(commit=False)),
+        ('rollback', dict(commit=False)),
     ]
     # Use disaggregated storage scenarios
     disagg_storages = gen_disagg_storages('test_prepare_discover06', disagg_only=True)

--- a/test/suite/test_prepare_discover06.py
+++ b/test/suite/test_prepare_discover06.py
@@ -44,6 +44,7 @@ class test_prepare_discover06(wttest.WiredTigerTestCase):
     uri = 'layered:' + tablename
 
     resolve_scenarios = [
+        ('commit', dict(commit=True)),
         ('rollback', dict(commit=False)),
     ]
     # Use disaggregated storage scenarios

--- a/test/suite/test_prepare_discover07.py
+++ b/test/suite/test_prepare_discover07.py
@@ -44,7 +44,8 @@ class test_prepare_discover07(wttest.WiredTigerTestCase):
     uri = 'layered:' + tablename
 
     resolve_scenarios = [
-        ('commit', dict(commit=True)),
+        # FIXME-WT-15051 handle searching for committed prepared tombstone on standby
+        # ('commit', dict(commit=True)),
         ('rollback', dict(commit=False)),
     ]
     # Use disaggregated storage scenarios
@@ -64,7 +65,6 @@ class test_prepare_discover07(wttest.WiredTigerTestCase):
         # Set initial timestamps
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(50))
         self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(50))
-        self.skipTest('FIXME-WT-15465 Fix throwing a prepare conflict when encountering prepared update on stable table')
 
         # Create the layered table
         self.session.create(self.uri, 'key_format=i,value_format=S')
@@ -199,7 +199,7 @@ class test_prepare_discover07(wttest.WiredTigerTestCase):
                 self.assertEqual(wiredtiger.WT_NOTFOUND, read_cursor.search())
             else:
                 self.assertEqual(0, read_cursor.search())
-                self.assertEqual(f'prepared_value_{i}', read_cursor.get_value())
+                self.assertEqual(f'committed_value_{i}', read_cursor.get_value())
         read_session.rollback_transaction()
 
         read_cursor.close()


### PR DESCRIPTION
Temporarily set ignore prepared flag when searching for update in the stable cursor. In disaggregated storage, the stable table may contain prepared updates that is rolled back on ingest table. If reading this prepared update on stable table, it will cause prepared conflict issue. Therefore for layered cursor operations, we need to ignore these prepared updates to allow reading through to committed data.

This PR temporarily sets IGNORE_PREPARE to true when searching in the stable table