### PR TITLE
WT-16037 Add disagg Python tests into code coverage test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ cscope.in.out
 cscope.out
 cscope.po.out
 build/
+build_*/
 dist/clang-format
 /docs/
 test-compatibility-run/

--- a/test/evergreen/code_coverage/code_coverage_config.json
+++ b/test/evergreen/code_coverage/code_coverage_config.json
@@ -256,7 +256,6 @@
     "./wt -?",
     "test/csuite/wt4117_checksum/test_wt4117_checksum",
     "python3 ../test/suite/run.py test_live_restore01",
-    "python3 ../test/suite/run.py --hook 'disagg=(role=leader)' --skip-tests-in-file ../test/suite/hook_disagg.fail" ,
-    "python3 ../test/suite/run.py --hook 'disagg=(role=follower)' base01"
+    "python3 ../test/suite/run.py --hook disagg --skip-tests-in-file ../test/suite/hook_disagg.fail base"
   ]
 }

--- a/test/evergreen/code_coverage/code_coverage_config.json
+++ b/test/evergreen/code_coverage/code_coverage_config.json
@@ -255,6 +255,8 @@
     "test/csuite/wt3363_checkpoint_op_races/test_wt3363_checkpoint_op_races",
     "./wt -?",
     "test/csuite/wt4117_checksum/test_wt4117_checksum",
-    "python3 ../test/suite/run.py test_live_restore01"
+    "python3 ../test/suite/run.py test_live_restore01",
+    "python3 ../test/suite/run.py --hook 'disagg=(role=leader)' --skip-tests-in-file ../test/suite/hook_disagg.fail" ,
+    "python3 ../test/suite/run.py --hook 'disagg=(role=follower)' base01"
   ]
 }

--- a/test/evergreen/code_coverage/parallel_code_coverage.py
+++ b/test/evergreen/code_coverage/parallel_code_coverage.py
@@ -54,7 +54,7 @@ def run_task(index, task):
     start_time = datetime.now()
     try:
         split_command = task.split()
-        subprocess.run(split_command, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=env)
+        subprocess.run(split_command, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=env, shell=True)
     except subprocess.CalledProcessError as exception:
         logging.error(f'Command {exception.cmd} failed with error {exception.returncode}')
         sys.exit(f'Exiting because command {exception.cmd} failed with error {exception.returncode}')

--- a/test/evergreen/code_coverage/parallel_code_coverage.py
+++ b/test/evergreen/code_coverage/parallel_code_coverage.py
@@ -54,7 +54,7 @@ def run_task(index, task):
     start_time = datetime.now()
     try:
         split_command = task.split()
-        subprocess.run(split_command, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=env, shell=True)
+        subprocess.run(split_command, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=env)
     except subprocess.CalledProcessError as exception:
         logging.error(f'Command {exception.cmd} failed with error {exception.returncode}')
         sys.exit(f'Exiting because command {exception.cmd} failed with error {exception.returncode}')

--- a/test/suite/run.py
+++ b/test/suite/run.py
@@ -611,7 +611,7 @@ if __name__ == '__main__':
     if skipFileForTests:
         with open(skipFileForTests, 'r') as f:
             # Read the skip file and process it to get a list of tests to skip.
-            skipTests = f.read().splitlines() 
+            skipTests = f.read().splitlines()
             # Remove comment lines starting with '#'.
             skipTests = [test for test in skipTests if not test.lstrip().startswith('#')]
             # Remove trailing comments and file extensions for each line.

--- a/test/suite/run.py
+++ b/test/suite/run.py
@@ -293,19 +293,24 @@ def configApply(suites, configfilename, configwrite):
             json.dump(configmap, f, sort_keys=True, indent=4)
     return newsuite
 
-def testsFromArg(tests, loader, arg, scenario):
+def testsFromArg(tests, loader, arg, scenario, skipTests):
     # If a group of test is mentioned, do all tests in that group
     # e.g. 'run.py base'
     groupedfiles = glob.glob(suitedir + os.sep + 'test_' + arg + '*.py')
     if len(groupedfiles) > 0:
         for file in groupedfiles:
-            testsFromArg(tests, loader, os.path.basename(file), scenario)
+            testsFromArg(tests, loader, os.path.basename(file), scenario, skipTests)
         return
 
     # Explicit test class names
     if not arg[0].isdigit():
         if arg.endswith('.py'):
             arg = arg[:-3]
+
+        # Skip tests that are in the skip list.
+        if skipTests and arg in skipTests:
+            return
+
         addScenarioTests(tests, loader, arg, scenario)
         return
 
@@ -334,6 +339,7 @@ if __name__ == '__main__':
     configwrite = False
     dirarg = None
     scenario = ''
+    skipFileForTests = ''
     verbose = 1
     args = sys.argv[1:]
     testargs = []
@@ -398,6 +404,12 @@ if __name__ == '__main__':
                     usage()
                     sys.exit(2)
                 hook_names.append(args.pop(0))
+                continue
+            if option == '-skip-tests-in-file' or option == 'sf':
+                if len(args) == 0:
+                    usage()
+                    sys.exit(2)
+                skipFileForTests = args.pop(0)
                 continue
             if option == '-long' or option == 'l':
                 longtest = True
@@ -595,10 +607,37 @@ if __name__ == '__main__':
                                           extralongtest, zstdtest, ignoreStdout, printOutput,
                                           seedw, seedz, hookmgr, ss_random_prefix, timeout)
 
+    skipTests = []
+    if skipFileForTests:
+        with open(skipFileForTests, 'r') as f:
+            # Read the skip file and process it to get a list of tests to skip.
+            skipTests = f.read().splitlines() 
+            # Remove comment lines starting with '#'.
+            skipTests = [test for test in skipTests if not test.lstrip().startswith('#')]
+            # Remove trailing comments and file extensions for each line.
+            skipTests = [re.split(r'\s+#', test)[0].strip().replace('.py', '') for test in skipTests]
+
     # Without any tests listed as arguments, do discovery
     if len(testargs) == 0:
         from discover import defaultTestLoader as loader
         suites = loader.discover(suitedir)
+
+        # Remove tests if the skip list is not empty.
+        if skipTests:
+            def remove_test_from_suite(suite, skipTests):
+                new_suite = unittest.TestSuite()
+                for test in suite:
+                    if type(test) is unittest.TestSuite:
+                        # Recursively process nested suites.
+                        subsuite = remove_test_from_suite(test, skipTests)
+                        if subsuite.countTestCases() > 0:
+                            new_suite.addTest(subsuite)
+                    else:
+                        test_name = test.__class__.__name__
+                        if test_name not in skipTests:
+                            new_suite.addTest(test)
+                return new_suite
+            suites = remove_test_from_suite(suites, skipTests)
 
         # If you have an empty Python file, it comes back as an empty entry in suites
         # and then the sort explodes. Drop empty entries first. Note: this converts
@@ -619,7 +658,7 @@ if __name__ == '__main__':
         tests.addTests(restrictScenario(generate_scenarios(suites), scenario))
     else:
         for arg in testargs:
-            testsFromArg(tests, loader, arg, scenario)
+            testsFromArg(tests, loader, arg, scenario, skipTests)
 
     hookmgr.register_skipped_tests(tests)
 


### PR DESCRIPTION
This PR adds the disagg Python tests (both leader and follower modes) into code coverage Evergreen task, so that the coverage report could have more accurate data for disagg related source files, and the PR code change report becomes more useful show coverage data for disagg related changes.

Please note only disagg leader mode Python tests are added this time around, currently limited to `base` tests. 

- Not all tests are added for disagg leader mode because code coverage tests run with non-diagnostic (release) build, and certain Python tests (e.g. `test_timestamp26`) currently fail running with non-diagnostic build. 
- The disagg follower mode is not added because`parallel_code_coverage.py` script does not like quotes in commands.
