### PR TITLE
WT-16177 Refactoring the cppsuite so it can be used more generally

### DIFF
--- a/dist/test_data.py
+++ b/dist/test_data.py
@@ -109,14 +109,11 @@ stat_config = range_config + [
 
 component_config = throttle_config
 
-transaction_config = [
+thread_worker_config = [
     Config('ops_per_transaction', '', r'''
         Defines how many operations a transaction can perform, the range is defined with a minimum
         and a maximum and a random number is chosen between the two using a linear distribution.''',
         type='category', subconfig=range_config),
-]
-
-thread_count = [
     Config('thread_count', 0, r'''
         Specifies the number of threads that will be used to perform a certain function.''', min=0)
 ]
@@ -137,10 +134,10 @@ background_compact_thread_config = throttle_config + [
     Config('free_space_target_mb', '20', r'''
         Minimum amount of space in MB recoverable for compaction to proceed.''')
 ]
-custom_operation_thread_config = thread_count + transaction_config + throttle_config + record_config
-read_thread_config = thread_count + throttle_config + transaction_config + record_config
-remove_thread_config = thread_count + transaction_config + throttle_config
-update_insert_thread_config = thread_count + transaction_config + throttle_config + record_config
+custom_operation_thread_config = thread_worker_config + throttle_config + record_config
+read_thread_config = thread_worker_config + throttle_config + record_config
+remove_thread_config = thread_worker_config + throttle_config
+update_insert_thread_config = thread_worker_config + throttle_config + record_config
 
 #
 # Configuration that applies to the runtime monitor component, this should be a list of statistics

--- a/test/cppsuite/src/main/crud.h
+++ b/test/cppsuite/src/main/crud.h
@@ -1,0 +1,87 @@
+/*-
+ * Public Domain 2014-present MongoDB, Inc.
+ * Public Domain 2008-2014 WiredTiger, Inc.
+ *
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#pragma once
+
+#include "src/storage/scoped_cursor.h"
+#include "transaction.h"
+
+extern "C" {
+#include "wiredtiger.h"
+}
+
+namespace test_harness {
+namespace crud {
+inline bool
+insert(scoped_cursor &cursor, transaction &txn, const std::string &key, const std::string &value)
+{
+    cursor->set_key(cursor.get(), key.c_str());
+    cursor->set_value(cursor.get(), value.c_str());
+    int ret = cursor->insert(cursor.get());
+
+    if (ret != 0) {
+        if (ret == WT_ROLLBACK) {
+            txn.set_needs_rollback();
+            return (false);
+        } else
+            testutil_die(ret, "unhandled error while trying to insert a key");
+    }
+    return (true);
+}
+inline bool
+update(scoped_cursor &cursor, transaction &txn, const std::string &key, const std::string &value)
+{
+    cursor->set_key(cursor.get(), key.c_str());
+    cursor->set_value(cursor.get(), value.c_str());
+    int ret = cursor->update(cursor.get());
+
+    if (ret != 0) {
+        if (ret == WT_ROLLBACK) {
+            txn.set_needs_rollback();
+            return (false);
+        } else
+            testutil_die(ret, "unhandled error while trying to update a key");
+    }
+    return (true);
+}
+inline bool
+remove(scoped_cursor &cursor, transaction &txn, const std::string &key)
+{
+    cursor->set_key(cursor.get(), key.c_str());
+    int ret = cursor->remove(cursor.get());
+    if (ret != 0) {
+        if (ret == WT_ROLLBACK) {
+            txn.set_needs_rollback();
+            return (false);
+        } else
+            testutil_die(ret, "unhandled error while trying to remove a key");
+    }
+    return (true);
+}
+}; // namespace crud
+} // namespace test_harness

--- a/test/cppsuite/src/main/database.h
+++ b/test/cppsuite/src/main/database.h
@@ -48,7 +48,7 @@ public:
     /*
      * Add a new collection, this will create the underlying collection in the database.
      */
-    void add_collection(uint64_t key_count = 0);
+    void add_collection(scoped_session &session, uint64_t key_count = 0);
 
     /* Get a collection using the id of the collection. */
     collection &get_collection(uint64_t id);
@@ -72,7 +72,6 @@ public:
 
 private:
     std::string _collection_create_config = "";
-    scoped_session _session;
     timestamp_manager *_tsm = nullptr;
     operation_tracker *_operation_tracker = nullptr;
     uint64_t _next_collection_id = 0;

--- a/test/cppsuite/src/main/database_operation.cpp
+++ b/test/cppsuite/src/main/database_operation.cpp
@@ -57,15 +57,15 @@ populate_worker(thread_worker *tc)
         scoped_cursor cursor = tc->session.open_scoped_cursor(coll.name);
         uint64_t j = 0;
         while (j < tc->key_count) {
-            tc->txn.begin();
+            tc->begin();
             auto key = tc->pad_string(std::to_string(j), tc->key_size);
             auto value = random_generator::instance().generate_pseudo_random_string(tc->value_size);
             if (tc->insert(cursor, coll.id, key, value)) {
-                if (tc->txn.commit()) {
+                if (tc->commit()) {
                     ++j;
                 }
             } else {
-                tc->txn.rollback();
+                tc->rollback();
             }
         }
     }
@@ -204,21 +204,21 @@ database_operation::insert_operation(thread_worker *tc)
     while (tc->running()) {
         uint64_t start_key = ccv[counter].coll.get_key_count();
         uint64_t added_count = 0;
-        tc->txn.begin();
+        tc->begin();
 
         /* Collection cursor. */
         auto &cc = ccv[counter];
-        while (tc->txn.active() && tc->running()) {
+        while (tc->active() && tc->running()) {
             /* Insert a key value pair, rolling back the transaction if required. */
             auto key = tc->pad_string(std::to_string(start_key + added_count), tc->key_size);
             auto value = random_generator::instance().generate_pseudo_random_string(tc->value_size);
             if (!tc->insert(cc.cursor, cc.coll.id, key, value)) {
                 added_count = 0;
-                tc->txn.rollback();
+                tc->rollback();
             } else {
                 added_count++;
-                if (tc->txn.can_commit()) {
-                    if (tc->txn.commit()) {
+                if (tc->can_commit()) {
+                    if (tc->commit()) {
                         /*
                          * We need to inform the database model that we've added these keys as some
                          * other thread may rely on the key_count data. Only do so if we
@@ -242,7 +242,7 @@ database_operation::insert_operation(thread_worker *tc)
         testutil_assert(counter < tc_collection_count);
     }
     /* Make sure the last transaction is rolled back now the work is finished. */
-    tc->txn.try_rollback();
+    tc->try_rollback();
 }
 
 void
@@ -262,29 +262,29 @@ database_operation::read_operation(thread_worker *tc)
         /* Do a second lookup now that we know it exists. */
         auto &cursor = cursors[coll.id];
 
-        tc->txn.begin();
-        while (tc->txn.active() && tc->running()) {
+        tc->begin();
+        while (tc->active() && tc->running()) {
             auto ret = cursor->next(cursor.get());
             if (ret != 0) {
                 if (ret == WT_NOTFOUND) {
                     testutil_check(cursor->reset(cursor.get()));
                 } else if (ret == WT_ROLLBACK) {
-                    tc->txn.rollback();
+                    tc->rollback();
                     tc->sleep();
                     continue;
                 } else
                     testutil_die(ret, "Unexpected error returned from cursor->next()");
             }
-            tc->txn.add_op();
-            if (tc->txn.get_op_count() >= tc->txn.get_target_op_count())
-                tc->txn.rollback();
+            tc->add_op();
+            if (tc->get_op_count() >= tc->get_target_op_count())
+                tc->rollback();
             tc->sleep();
         }
         /* Reset our cursor to avoid pinning content. */
         testutil_check(cursor->reset(cursor.get()));
     }
     /* Make sure the last transaction is rolled back now the work is finished. */
-    tc->txn.try_rollback();
+    tc->try_rollback();
 }
 
 void
@@ -325,7 +325,7 @@ database_operation::remove_operation(thread_worker *tc)
         }
 
         /* Start a transaction if possible. */
-        tc->txn.try_begin();
+        tc->try_begin();
 
         /* Get the cursor associated with the collection. */
         scoped_cursor &rnd_cursor = rnd_cursors[coll.id];
@@ -341,9 +341,9 @@ database_operation::remove_operation(thread_worker *tc)
              * one.
              */
             if (ret == WT_NOTFOUND) {
-                testutil_ignore_ret_bool(tc->txn.commit());
+                testutil_ignore_ret_bool(tc->commit());
             } else if (ret == WT_ROLLBACK) {
-                tc->txn.rollback();
+                tc->rollback();
             } else {
                 testutil_die(ret, "Unexpected error returned from cursor->next()");
             }
@@ -354,7 +354,7 @@ database_operation::remove_operation(thread_worker *tc)
         const char *key_str;
         testutil_check(rnd_cursor->get_key(rnd_cursor.get(), &key_str));
         if (!tc->remove(cursor, coll.id, key_str)) {
-            tc->txn.rollback();
+            tc->rollback();
         }
 
         /* Reset our cursors to avoid pinning content. */
@@ -362,12 +362,12 @@ database_operation::remove_operation(thread_worker *tc)
         testutil_check(rnd_cursor->reset(rnd_cursor.get()));
 
         /* Commit the current transaction if we're able to. */
-        if (tc->txn.can_commit())
-            testutil_ignore_ret_bool(tc->txn.commit());
+        if (tc->can_commit())
+            testutil_ignore_ret_bool(tc->commit());
     }
 
     /* Make sure the last operation is rolled back now the work is finished. */
-    tc->txn.try_rollback();
+    tc->try_rollback();
 }
 
 void
@@ -402,7 +402,7 @@ database_operation::update_operation(thread_worker *tc)
         }
 
         /* Start a transaction if possible. */
-        tc->txn.try_begin();
+        tc->try_begin();
 
         /* Get the cursor associated with the collection. */
         scoped_cursor &cursor = cursors[coll.id];
@@ -414,19 +414,19 @@ database_operation::update_operation(thread_worker *tc)
         auto key = tc->pad_string(std::to_string(key_id), tc->key_size);
         auto value = random_generator::instance().generate_pseudo_random_string(tc->value_size);
         if (!tc->update(cursor, coll.id, key, value)) {
-            tc->txn.rollback();
+            tc->rollback();
         }
 
         /* Reset our cursor to avoid pinning content. */
         testutil_check(cursor->reset(cursor.get()));
 
         /* Commit the current transaction if we're able to. */
-        if (tc->txn.can_commit())
-            testutil_ignore_ret_bool(tc->txn.commit());
+        if (tc->can_commit())
+            testutil_ignore_ret_bool(tc->commit());
     }
 
     /* Make sure the last operation is rolled back now the work is finished. */
-    tc->txn.try_rollback();
+    tc->try_rollback();
 }
 
 void

--- a/test/cppsuite/src/main/database_operation.cpp
+++ b/test/cppsuite/src/main/database_operation.cpp
@@ -96,12 +96,13 @@ database_operation::populate(
       LOG_INFO, "Populate: creating " + std::to_string(collection_count) + " collections.");
 
     /* Create n collections as per the configuration. */
+    scoped_session session = connection_manager::instance().create_session();
     for (int64_t i = 0; i < collection_count; ++i)
         /*
          * The database model will call into the API and create the collection, with its own
          * session.
          */
-        database.add_collection(key_count);
+        database.add_collection(session, key_count);
 
     logger::log_msg(
       LOG_INFO, "Populate: " + std::to_string(collection_count) + " collections created.");

--- a/test/cppsuite/src/main/thread_worker.cpp
+++ b/test/cppsuite/src/main/thread_worker.cpp
@@ -33,6 +33,7 @@
 #include "src/common/constants.h"
 #include "src/common/logger.h"
 #include "src/common/random_generator.h"
+#include "crud.h"
 #include "transaction.h"
 
 namespace test_harness {
@@ -117,17 +118,8 @@ thread_worker::update(
         return (false);
     }
 
-    cursor->set_key(cursor.get(), key.c_str());
-    cursor->set_value(cursor.get(), value.c_str());
-    ret = cursor->update(cursor.get());
-
-    if (ret != 0) {
-        if (ret == WT_ROLLBACK) {
-            _txn.set_needs_rollback();
-            return (false);
-        } else
-            testutil_die(ret, "unhandled error while trying to update a key");
-    }
+    if (crud::update(cursor, _txn, key, value) == false)
+        return (false);
 
     ret = op_tracker->save_operation(
       session.get(), tracking_operation::INSERT, collection_id, key, value, ts, op_track_cursor);
@@ -158,17 +150,8 @@ thread_worker::insert(
         return (false);
     }
 
-    cursor->set_key(cursor.get(), key.c_str());
-    cursor->set_value(cursor.get(), value.c_str());
-    ret = cursor->insert(cursor.get());
-
-    if (ret != 0) {
-        if (ret == WT_ROLLBACK) {
-            _txn.set_needs_rollback();
-            return (false);
-        } else
-            testutil_die(ret, "unhandled error while trying to insert a key");
-    }
+   if (crud::insert(cursor, _txn, key, value) == false)
+        return (false);
 
     ret = op_tracker->save_operation(
       session.get(), tracking_operation::INSERT, collection_id, key, value, ts, op_track_cursor);
@@ -197,15 +180,8 @@ thread_worker::remove(scoped_cursor &cursor, uint64_t collection_id, const std::
         return (false);
     }
 
-    cursor->set_key(cursor.get(), key.c_str());
-    ret = cursor->remove(cursor.get());
-    if (ret != 0) {
-        if (ret == WT_ROLLBACK) {
-            _txn.set_needs_rollback();
-            return (false);
-        } else
-            testutil_die(ret, "unhandled error while trying to remove a key");
-    }
+    if (crud::remove(cursor, _txn, key) == false)
+        return (false);
 
     ret = op_tracker->save_operation(
       session.get(), tracking_operation::DELETE_KEY, collection_id, key, "", ts, op_track_cursor);

--- a/test/cppsuite/src/main/thread_worker.cpp
+++ b/test/cppsuite/src/main/thread_worker.cpp
@@ -352,7 +352,7 @@ thread_worker::add_op()
 }
 
 void
-thread_worker::begin(const std::string &config = "")
+thread_worker::begin(const std::string &config)
 {
     /* This randomizes the number of operations to be executed in one transaction. */
     _target_op_count =
@@ -363,7 +363,7 @@ thread_worker::begin(const std::string &config = "")
 
 /* Begin a transaction if we are not currently in one. */
 void
-thread_worker::try_begin(const std::string &config = "")
+thread_worker::try_begin(const std::string &config)
 {
     _txn.try_begin(session, config);
 }
@@ -372,7 +372,7 @@ thread_worker::try_begin(const std::string &config = "")
  * Commit a transaction and return true if the commit was successful.
  */
 bool
-thread_worker::commit(const std::string &config = "")
+thread_worker::commit(const std::string &config)
 {
     _op_count = 0;
     return _txn.commit(session, config);
@@ -380,7 +380,7 @@ thread_worker::commit(const std::string &config = "")
 
 /* Rollback a transaction, failure will abort the test. */
 void
-thread_worker::rollback(const std::string &config = "")
+thread_worker::rollback(const std::string &config)
 {
     _op_count = 0;
     _txn.rollback(session, config);
@@ -388,7 +388,7 @@ thread_worker::rollback(const std::string &config = "")
 
 /* Attempt to rollback the transaction given the requirements are met. */
 void
-thread_worker::try_rollback(const std::string &config = "")
+thread_worker::try_rollback(const std::string &config)
 {
     _txn.try_rollback(session, config);
 }

--- a/test/cppsuite/src/main/thread_worker.cpp
+++ b/test/cppsuite/src/main/thread_worker.cpp
@@ -77,8 +77,7 @@ thread_worker::thread_worker(uint64_t id, thread_type type, configuration *confi
       key_size(config->get_optional_int(KEY_SIZE, 1)),
       value_size(config->get_optional_int(VALUE_SIZE, 1)),
       thread_count(config->get_int(THREAD_COUNT)), type(type), id(id), db(dbase),
-      session(std::move(created_session)), tsm(timestamp_manager),
-      txn(transaction(config, timestamp_manager, session.get())), op_tracker(op_tracker),
+      session(std::move(created_session)), tsm(timestamp_manager), op_tracker(op_tracker),
       _sleep_time_ms(std::chrono::milliseconds(config->get_throttle_ms())), _barrier(barrier_ptr)
 {
     if (op_tracker->enabled())
@@ -111,10 +110,10 @@ thread_worker::update(
     testutil_assert(cursor.get() != nullptr);
 
     wt_timestamp_t ts = tsm->get_next_ts();
-    ret = txn.set_commit_timestamp(ts);
+    ret = set_commit_timestamp(ts);
     testutil_assert(ret == 0 || ret == EINVAL);
     if (ret != 0) {
-        txn.set_needs_rollback(true);
+        _txn.set_needs_rollback();
         return (false);
     }
 
@@ -124,7 +123,7 @@ thread_worker::update(
 
     if (ret != 0) {
         if (ret == WT_ROLLBACK) {
-            txn.set_needs_rollback(true);
+            _txn.set_needs_rollback();
             return (false);
         } else
             testutil_die(ret, "unhandled error while trying to update a key");
@@ -134,9 +133,9 @@ thread_worker::update(
       session.get(), tracking_operation::INSERT, collection_id, key, value, ts, op_track_cursor);
 
     if (ret == 0)
-        txn.add_op();
+        add_op();
     else if (ret == WT_ROLLBACK)
-        txn.set_needs_rollback(true);
+        _txn.set_needs_rollback();
     else
         testutil_die(ret, "unhandled error while trying to save an update to the tracking table");
     return (ret == 0);
@@ -152,10 +151,10 @@ thread_worker::insert(
     testutil_assert(cursor.get() != nullptr);
 
     wt_timestamp_t ts = tsm->get_next_ts();
-    ret = txn.set_commit_timestamp(ts);
+    ret = set_commit_timestamp(ts);
     testutil_assert(ret == 0 || ret == EINVAL);
     if (ret != 0) {
-        txn.set_needs_rollback(true);
+        _txn.set_needs_rollback();
         return (false);
     }
 
@@ -165,7 +164,7 @@ thread_worker::insert(
 
     if (ret != 0) {
         if (ret == WT_ROLLBACK) {
-            txn.set_needs_rollback(true);
+            _txn.set_needs_rollback();
             return (false);
         } else
             testutil_die(ret, "unhandled error while trying to insert a key");
@@ -175,9 +174,9 @@ thread_worker::insert(
       session.get(), tracking_operation::INSERT, collection_id, key, value, ts, op_track_cursor);
 
     if (ret == 0)
-        txn.add_op();
+        add_op();
     else if (ret == WT_ROLLBACK)
-        txn.set_needs_rollback(true);
+        _txn.set_needs_rollback();
     else
         testutil_die(ret, "unhandled error while trying to save an insert to the tracking table");
     return (ret == 0);
@@ -191,10 +190,10 @@ thread_worker::remove(scoped_cursor &cursor, uint64_t collection_id, const std::
     testutil_assert(cursor.get() != nullptr);
 
     wt_timestamp_t ts = tsm->get_next_ts();
-    ret = txn.set_commit_timestamp(ts);
+    ret = set_commit_timestamp(ts);
     testutil_assert(ret == 0 || ret == EINVAL);
     if (ret != 0) {
-        txn.set_needs_rollback(true);
+        _txn.set_needs_rollback();
         return (false);
     }
 
@@ -202,7 +201,7 @@ thread_worker::remove(scoped_cursor &cursor, uint64_t collection_id, const std::
     ret = cursor->remove(cursor.get());
     if (ret != 0) {
         if (ret == WT_ROLLBACK) {
-            txn.set_needs_rollback(true);
+            _txn.set_needs_rollback();
             return (false);
         } else
             testutil_die(ret, "unhandled error while trying to remove a key");
@@ -212,9 +211,9 @@ thread_worker::remove(scoped_cursor &cursor, uint64_t collection_id, const std::
       session.get(), tracking_operation::DELETE_KEY, collection_id, key, "", ts, op_track_cursor);
 
     if (ret == 0)
-        txn.add_op();
+        add_op();
     else if (ret == WT_ROLLBACK)
-        txn.set_needs_rollback(true);
+        _txn.set_needs_rollback();
     else
         testutil_die(ret, "unhandled error while trying to save a remove to the tracking table");
     return (ret == 0);
@@ -233,10 +232,10 @@ thread_worker::truncate(uint64_t collection_id, std::optional<std::string> start
     int ret = 0;
 
     wt_timestamp_t ts = tsm->get_next_ts();
-    ret = txn.set_commit_timestamp(ts);
+    ret = set_commit_timestamp(ts);
     testutil_assert(ret == 0 || ret == EINVAL);
     if (ret != 0) {
-        txn.set_needs_rollback(true);
+        _txn.set_needs_rollback();
         return (false);
     }
 
@@ -256,7 +255,7 @@ thread_worker::truncate(uint64_t collection_id, std::optional<std::string> start
 
     if (ret != 0) {
         if (ret == WT_ROLLBACK) {
-            txn.set_needs_rollback(true);
+            _txn.set_needs_rollback();
             return (false);
         } else
             testutil_die(ret, "unhandled error while trying to truncate a key range");
@@ -316,4 +315,96 @@ thread_worker::get_assigned_collection_count() const
     uint64_t collection_count = db.get_collection_count();
     return collection_count / thread_count + (collection_count % thread_count > id);
 }
+
+/*
+ * Returns true if a transaction can be committed as determined by the op count and the state of the
+ * transaction.
+ */
+bool
+thread_worker::can_commit()
+{
+    return (!_txn.needs_rollback() && _txn.active() && get_op_count() >= get_target_op_count());
+};
+
+/* Get the current number of operations executed. */
+int64_t
+thread_worker::get_op_count() const
+{
+    return _op_count;
+}
+
+/* Get the number of operations this transaction needs before it can commit */
+int64_t
+thread_worker::get_target_op_count() const
+{
+    return _target_op_count;
+}
+
+bool
+thread_worker::active() const
+{
+    return _txn.active();
+}
+void
+thread_worker::add_op()
+{
+    _op_count++;
+}
+
+void
+thread_worker::begin(const std::string &config = "")
+{
+    /* This randomizes the number of operations to be executed in one transaction. */
+    _target_op_count =
+      random_generator::instance().generate_integer<int64_t>(_min_op_count, _max_op_count);
+    _op_count = 0;
+    _txn.begin(session, config);
+}
+
+/* Begin a transaction if we are not currently in one. */
+void
+thread_worker::try_begin(const std::string &config = "")
+{
+    _txn.try_begin(session, config);
+}
+
+/*
+ * Commit a transaction and return true if the commit was successful.
+ */
+bool
+thread_worker::commit(const std::string &config = "")
+{
+    _op_count = 0;
+    return _txn.commit(session, config);
+}
+
+/* Rollback a transaction, failure will abort the test. */
+void
+thread_worker::rollback(const std::string &config = "")
+{
+    _op_count = 0;
+    _txn.rollback(session, config);
+}
+
+/* Attempt to rollback the transaction given the requirements are met. */
+void
+thread_worker::try_rollback(const std::string &config = "")
+{
+    _txn.try_rollback(session, config);
+}
+
+/*
+ * FIXME: WT-9198 We're concurrently doing a transaction that contains a bunch of operations while
+ * moving the stable timestamp. Eat the occasional EINVAL from the transaction's first commit
+ * timestamp being earlier than the stable timestamp.
+ */
+int
+thread_worker::set_commit_timestamp(wt_timestamp_t ts)
+{
+    if (!tsm->enabled())
+        return (0);
+    const std::string config = COMMIT_TS + "=" + timestamp_manager::decimal_to_hex(ts);
+    return session->timestamp_transaction(session.get(), config.c_str());
+}
+
 } // namespace test_harness

--- a/test/cppsuite/src/main/thread_worker.cpp
+++ b/test/cppsuite/src/main/thread_worker.cpp
@@ -84,6 +84,13 @@ thread_worker::thread_worker(uint64_t id, thread_type type, configuration *confi
     if (op_tracker->enabled())
         op_track_cursor = session.open_scoped_cursor(op_tracker->get_operation_table_name());
 
+    /* Use optional here as our populate threads don't define this configuration. */
+    configuration *ops_config = config->get_optional_subconfig(OPS_PER_TRANSACTION);
+    if (ops_config != nullptr) {
+        _min_op_count = ops_config->get_optional_int(MIN, 1);
+        _max_op_count = ops_config->get_optional_int(MAX, 1);
+        delete ops_config;
+    }
     testutil_assert(key_size > 0 && value_size > 0);
 }
 

--- a/test/cppsuite/src/main/thread_worker.cpp
+++ b/test/cppsuite/src/main/thread_worker.cpp
@@ -150,7 +150,7 @@ thread_worker::insert(
         return (false);
     }
 
-   if (crud::insert(cursor, _txn, key, value) == false)
+    if (crud::insert(cursor, _txn, key, value) == false)
         return (false);
 
     ret = op_tracker->save_operation(

--- a/test/cppsuite/src/main/thread_worker.h
+++ b/test/cppsuite/src/main/thread_worker.h
@@ -107,24 +107,26 @@ public:
 
     /* Get the number of collections assigned to the thread worker */
     uint64_t get_assigned_collection_count() const;
-    /*
-     * Returns true if a transaction can be committed as determined by the op count and the state of
-     * the transaction.
-     */
-    bool can_commit();
+
+    /* Add an operation to the current work item. */
+    void add_op();
     /* Get the current number of operations executed. */
     int64_t get_op_count() const;
-    /* Get the number of operations this transaction needs before it can commit */
+    /* Get the number of operations this work item needs before it can commit */
     int64_t get_target_op_count() const;
 
+    /*
+     * Returns true if our transaction can be committed as determined by the op count and the state
+     * of the transaction.
+     */
+    bool can_commit();
+    /* Returns whether there is an active transaction. */
     bool active() const;
-    void add_op();
+    /* Begins a transaction. */
     void begin(const std::string &config = "");
     /* Begin a transaction if we are not currently in one. */
     void try_begin(const std::string &config = "");
-    /*
-     * Commit a transaction and return true if the commit was successful.
-     */
+    /* Commit a transaction and return true if the commit was successful. */
     bool commit(const std::string &config = "");
     /* Rollback a transaction, failure will abort the test. */
     void rollback(const std::string &config = "");

--- a/test/cppsuite/src/main/thread_worker.h
+++ b/test/cppsuite/src/main/thread_worker.h
@@ -159,7 +159,6 @@ private:
 
     /*
      * _min_op_count and _max_op_count are the minimum and maximum number of operations within one
-     * transaction. is the current maximum number of operations that can be executed in the current
      * transaction.
      */
     int64_t _max_op_count = INT64_MAX;

--- a/test/cppsuite/src/main/thread_worker.h
+++ b/test/cppsuite/src/main/thread_worker.h
@@ -107,6 +107,31 @@ public:
 
     /* Get the number of collections assigned to the thread worker */
     uint64_t get_assigned_collection_count() const;
+    /*
+     * Returns true if a transaction can be committed as determined by the op count and the state of
+     * the transaction.
+     */
+    bool can_commit();
+    /* Get the current number of operations executed. */
+    int64_t get_op_count() const;
+    /* Get the number of operations this transaction needs before it can commit */
+    int64_t get_target_op_count() const;
+
+    bool active() const;
+    void add_op();
+    void begin(const std::string &config = "");
+    /* Begin a transaction if we are not currently in one. */
+    void try_begin(const std::string &config = "");
+    /*
+     * Commit a transaction and return true if the commit was successful.
+     */
+    bool commit(const std::string &config = "");
+    /* Rollback a transaction, failure will abort the test. */
+    void rollback(const std::string &config = "");
+    /* Attempt to rollback the transaction given the requirements are met. */
+    void try_rollback(const std::string &config = "");
+    /* Set a commit timestamp. */
+    int set_commit_timestamp(wt_timestamp_t ts);
 
 public:
     const int64_t collection_count;
@@ -122,12 +147,26 @@ public:
     scoped_cursor op_track_cursor;
     scoped_cursor stat_cursor;
     timestamp_manager *tsm;
-    transaction txn;
     operation_tracker *op_tracker;
 
 private:
     std::shared_ptr<barrier> _barrier = nullptr;
     bool _running = true;
     std::chrono::milliseconds _sleep_time_ms;
+    transaction _txn;
+
+    /*
+     * _min_op_count and _max_op_count are the minimum and maximum number of operations within one
+     * transaction. is the current maximum number of operations that can be executed in the current
+     * transaction.
+     */
+    int64_t _max_op_count = INT64_MAX;
+    int64_t _min_op_count = 0;
+    /*
+     * op_count is the current number of operations that have been executed in the current
+     * transaction.
+     */
+    int64_t _op_count = 0;
+    int64_t _target_op_count = 0;
 };
 } // namespace test_harness

--- a/test/cppsuite/src/main/transaction.cpp
+++ b/test/cppsuite/src/main/transaction.cpp
@@ -30,23 +30,12 @@
 
 #include "src/common/constants.h"
 #include "src/common/logger.h"
-#include "src/common/random_generator.h"
-
-namespace test_harness {
-
-transaction::transaction(
-  configuration *config, timestamp_manager *timestamp_manager, WT_SESSION *session)
-    : _timestamp_manager(timestamp_manager), _session(session)
-{
-    /* Use optional here as our populate threads don't define this configuration. */
-    configuration *transaction_config = config->get_optional_subconfig(OPS_PER_TRANSACTION);
-    if (transaction_config != nullptr) {
-        _min_op_count = transaction_config->get_optional_int(MIN, 1);
-        _max_op_count = transaction_config->get_optional_int(MAX, 1);
-        delete transaction_config;
-    }
+#include "src/storage/scoped_session.h"
+extern "C" {
+#include "test_util.h"
 }
 
+namespace test_harness {
 bool
 transaction::active() const
 {
@@ -54,30 +43,20 @@ transaction::active() const
 }
 
 void
-transaction::add_op()
-{
-    _op_count++;
-}
-
-void
-transaction::begin(const std::string &config)
+transaction::begin(scoped_session &session, const std::string &config)
 {
     testutil_assert(!_in_txn);
     testutil_check(
-      _session->begin_transaction(_session, config.empty() ? nullptr : config.c_str()));
-    /* This randomizes the number of operations to be executed in one transaction. */
-    _target_op_count =
-      random_generator::instance().generate_integer<int64_t>(_min_op_count, _max_op_count);
-    _op_count = 0;
+      session->begin_transaction(session.get(), config.empty() ? nullptr : config.c_str()));
     _in_txn = true;
     _needs_rollback = false;
 }
 
 void
-transaction::try_begin(const std::string &config)
+transaction::try_begin(scoped_session &session, const std::string &config)
 {
     if (!_in_txn)
-        begin(config);
+        begin(session, config);
 }
 
 /*
@@ -85,12 +64,12 @@ transaction::try_begin(const std::string &config)
  * transaction internally.
  */
 bool
-transaction::commit(const std::string &config)
+transaction::commit(scoped_session &session, const std::string &config)
 {
     int ret = 0;
     testutil_assert(_in_txn && !_needs_rollback);
 
-    ret = _session->commit_transaction(_session, config.empty() ? nullptr : config.c_str());
+    ret = session->commit_transaction(session.get(), config.empty() ? nullptr : config.c_str());
     /*
      * FIXME-WT-9198 Now we are accepting the error code EINVAL because of possible invalid
      * timestamps as we know it can happen due to the nature of the framework. The framework may set
@@ -103,65 +82,36 @@ transaction::commit(const std::string &config)
     if (ret != 0)
         logger::log_msg(LOG_WARN,
           "Failed to commit transaction in commit, received error code: " + std::to_string(ret));
-    _op_count = 0;
     _in_txn = false;
     return (ret == 0);
 }
 
 void
-transaction::rollback(const std::string &config)
+transaction::rollback(scoped_session &session, const std::string &config)
 {
     testutil_assert(_in_txn);
     testutil_check(
-      _session->rollback_transaction(_session, config.empty() ? nullptr : config.c_str()));
+      session->rollback_transaction(session.get(), config.empty() ? nullptr : config.c_str()));
     _needs_rollback = false;
-    _op_count = 0;
     _in_txn = false;
 }
 
 void
-transaction::try_rollback(const std::string &config)
+transaction::try_rollback(scoped_session &session, const std::string &config)
 {
     if (_in_txn)
-        rollback(config);
-}
-
-int64_t
-transaction::get_op_count() const
-{
-    return _op_count;
-}
-
-int64_t
-transaction::get_target_op_count() const
-{
-    return _target_op_count;
-}
-
-/*
- * FIXME: WT-9198 We're concurrently doing a transaction that contains a bunch of operations while
- * moving the stable timestamp. Eat the occasional EINVAL from the transaction's first commit
- * timestamp being earlier than the stable timestamp.
- */
-int
-transaction::set_commit_timestamp(wt_timestamp_t ts)
-{
-    /* We don't want to set zero timestamps on transactions if we're not using timestamps. */
-    if (!_timestamp_manager->enabled())
-        return 0;
-    const std::string config = COMMIT_TS + "=" + timestamp_manager::decimal_to_hex(ts);
-    return _session->timestamp_transaction(_session, config.c_str());
+        rollback(session, config);
 }
 
 void
-transaction::set_needs_rollback(bool rollback)
+transaction::set_needs_rollback()
 {
-    _needs_rollback = rollback;
+    _needs_rollback = true;
 }
 
 bool
-transaction::can_commit()
+transaction::needs_rollback()
 {
-    return (!_needs_rollback && _in_txn && _op_count >= _target_op_count);
+    return _needs_rollback;
 }
 } // namespace test_harness

--- a/test/cppsuite/src/main/transaction.h
+++ b/test/cppsuite/src/main/transaction.h
@@ -30,9 +30,7 @@
 
 #include <string>
 
-#include "src/main/configuration.h"
-#include "src/component/timestamp_manager.h"
-
+#include "src/storage/scoped_session.h"
 extern "C" {
 #include "wiredtiger.h"
 }
@@ -41,55 +39,26 @@ namespace test_harness {
 
 class transaction {
 public:
-    transaction(configuration *config, timestamp_manager *timestamp_manager, WT_SESSION *session);
-
     bool active() const;
-    void add_op();
-    void begin(const std::string &config = "");
+    void begin(scoped_session &session, const std::string &config = "");
     /* Begin a transaction if we are not currently in one. */
-    void try_begin(const std::string &config = "");
+    void try_begin(scoped_session &session, const std::string &config = "");
     /*
      * Commit a transaction and return true if the commit was successful.
      */
-    bool commit(const std::string &config = "");
+    bool commit(scoped_session &session, const std::string &config = "");
     /* Rollback a transaction, failure will abort the test. */
-    void rollback(const std::string &config = "");
+    void rollback(scoped_session &session, const std::string &config = "");
     /* Attempt to rollback the transaction given the requirements are met. */
-    void try_rollback(const std::string &config = "");
-    /* Set a commit timestamp. */
-    int set_commit_timestamp(wt_timestamp_t ts);
+    void try_rollback(scoped_session &session, const std::string &config = "");
     /* Set that the transaction needs to be rolled back. */
-    void set_needs_rollback(bool rollback);
-    /*
-     * Returns true if a transaction can be committed as determined by the op count and the state of
-     * the transaction.
-     */
-    bool can_commit();
-    /* Get the current number of operations executed. */
-    int64_t get_op_count() const;
-    /* Get the number of operations this transaction needs before it can commit */
-    int64_t get_target_op_count() const;
+    void set_needs_rollback();
+    /* Return whether the transaction needs to be rolled back.*/
+    bool needs_rollback();
 
 private:
     bool _in_txn = false;
     bool _needs_rollback = false;
-
-    /*
-     * _min_op_count and _max_op_count are the minimum and maximum number of operations within one
-     * transaction. is the current maximum number of operations that can be executed in the current
-     * transaction.
-     */
-    int64_t _max_op_count = INT64_MAX;
-    int64_t _min_op_count = 0;
-    /*
-     * op_count is the current number of operations that have been executed in the current
-     * transaction.
-     */
-    int64_t _op_count = 0;
-    int64_t _target_op_count = 0;
-
-    timestamp_manager *_timestamp_manager = nullptr;
-    WT_SESSION *_session = nullptr;
 };
 
 } // namespace test_harness

--- a/test/cppsuite/tests/background_compact.cpp
+++ b/test/cppsuite/tests/background_compact.cpp
@@ -138,7 +138,7 @@ public:
             const uint64_t MAX_RETRIES = 100;
             while (tw->running() && keys_truncated < n_keys_to_truncate && retries < MAX_RETRIES) {
                 /* Start a transaction if possible. */
-                tw->txn.try_begin();
+                tw->try_begin();
 
                 /* Choose a random key to delete. */
                 int ret = rnd_cursor->next(rnd_cursor.get());
@@ -150,9 +150,9 @@ public:
                      * starting a new one.
                      */
                     if (ret == WT_NOTFOUND)
-                        testutil_ignore_ret_bool(tw->txn.commit());
+                        testutil_ignore_ret_bool(tw->commit());
                     else if (ret == WT_ROLLBACK)
-                        tw->txn.rollback();
+                        tw->rollback();
                     else
                         testutil_die(ret, "Unexpected error returned from cursor->next()");
 
@@ -173,7 +173,7 @@ public:
                  * If we generate an invalid range or our truncate fails rollback the transaction.
                  */
                 if (end_key == first_key || !tw->truncate(coll.id, first_key, end_key, "")) {
-                    tw->txn.rollback();
+                    tw->rollback();
                     if (end_key == first_key)
                         logger::log_msg(
                           LOG_TRACE, log_prefix + "truncate failed because of an invalid range");
@@ -183,7 +183,7 @@ public:
                     continue;
                 }
 
-                if (tw->txn.commit()) {
+                if (tw->commit()) {
                     logger::log_msg(LOG_TRACE,
                       log_prefix + " committed truncation of " + std::to_string(truncate_range) +
                         " records.");
@@ -211,7 +211,7 @@ public:
         }
 
         /* Make sure the last operation is rolled back now the work is finished. */
-        tw->txn.try_rollback();
+        tw->try_rollback();
     }
 
     void
@@ -257,22 +257,22 @@ public:
 
             uint64_t start_key = ccv[counter].coll.get_key_count();
             uint64_t added_count = 0;
-            tw->txn.begin();
+            tw->begin();
 
             /* Collection cursor. */
             auto &cc = ccv[counter];
-            while (tw->txn.active() && tw->running()) {
+            while (tw->active() && tw->running()) {
                 /* Insert a key value pair, rolling back the transaction if required. */
                 auto key = tw->pad_string(std::to_string(start_key + added_count), tw->key_size);
                 auto value =
                   random_generator::instance().generate_pseudo_random_string(tw->value_size);
                 if (!tw->insert(cc.cursor, cc.coll.id, key, value)) {
                     added_count = 0;
-                    tw->txn.rollback();
+                    tw->rollback();
                 } else {
                     added_count++;
-                    if (tw->txn.can_commit()) {
-                        if (tw->txn.commit())
+                    if (tw->can_commit()) {
+                        if (tw->commit())
                             /*
                              * We need to inform the database model that we've added these keys as
                              * some other thread may rely on the key_count data. Only do so if we
@@ -295,7 +295,7 @@ public:
             testutil_assert(counter < tw_collection_count);
         }
         /* Make sure the last transaction is rolled back now the work is finished. */
-        tw->txn.try_rollback();
+        tw->try_rollback();
     }
 
     void

--- a/test/cppsuite/tests/bounded_cursor_prefix_indices.cpp
+++ b/test/cppsuite/tests/bounded_cursor_prefix_indices.cpp
@@ -120,7 +120,7 @@ public:
         collection &coll = tc->db.get_collection(tc->id);
         scoped_cursor cursor = tc->session.open_scoped_cursor(coll.name);
         for (uint64_t count = 0; count < tc->key_count; ++count) {
-            tc->txn.begin();
+            tc->begin();
             /*
              * Generate the prefix key, and append a random generated key string based on the key
              * size configuration.
@@ -128,9 +128,9 @@ public:
             prefix_key = random_generator::instance().generate_random_string(tc->key_size);
             testutil_assert(cursor.get() != nullptr);
             if (perform_unique_index_insertions(tc, cursor, coll, prefix_key)) {
-                tc->txn.commit();
+                tc->commit();
             } else {
-                tc->txn.rollback();
+                tc->rollback();
                 ++rollback_retries;
                 if (count > 0)
                     --count;
@@ -243,7 +243,7 @@ public:
 
             /* Do a second lookup now that we know it exists. */
             auto &cursor = cursors[coll.id];
-            tc->txn.begin();
+            tc->begin();
             /*
              * Grab a random existing prefix and perform unique index insertion. We expect it to
              * fail to insert, because it should already exist.
@@ -258,7 +258,7 @@ public:
                 ".");
             testutil_assert(!perform_unique_index_insertions(tc, cursor, coll, prefix_key));
             testutil_check(cursor->reset(cursor.get()));
-            tc->txn.rollback();
+            tc->rollback();
         }
     }
 
@@ -273,7 +273,7 @@ public:
          * Each read thread will count the number of keys in each collection, and will double check
          * if the size of the table hasn't changed.
          */
-        tc->txn.begin();
+        tc->begin();
         while (tc->running()) {
             for (int i = 0; i < tc->db.get_collection_count(); i++) {
                 collection &coll = tc->db.get_collection(i);
@@ -298,6 +298,6 @@ public:
             }
             key_count = 0;
         }
-        tc->txn.rollback();
+        tc->rollback();
     }
 };

--- a/test/cppsuite/tests/bounded_cursor_prefix_indices.cpp
+++ b/test/cppsuite/tests/bounded_cursor_prefix_indices.cpp
@@ -169,12 +169,13 @@ public:
             ", key size: " + std::to_string(key_size));
 
         /* Create n collections as per the configuration. */
+        scoped_session session = connection_manager::instance().create_session();
         for (uint64_t i = 0; i < collection_count; ++i)
             /*
              * The database model will call into the API and create the collection, with its own
              * session.
              */
-            database.add_collection();
+            database.add_collection(session);
 
         /* Spawn a populate thread for each collection in the database. */
         for (uint64_t i = 0; i < collection_count; ++i) {
@@ -199,7 +200,6 @@ public:
          * traverse through each collection using a cursor to collect the prefix and push it into a
          * 2D vector.
          */
-        scoped_session session = connection_manager::instance().create_session();
         const char *key_tmp;
         int ret = 0;
         for (uint64_t i = 0; i < database.get_collection_count(); i++) {

--- a/test/cppsuite/tests/bounded_cursor_prefix_search_near.cpp
+++ b/test/cppsuite/tests/bounded_cursor_prefix_search_near.cpp
@@ -107,9 +107,9 @@ public:
         while (tc->running()) {
 
             auto &cc = ccv[counter];
-            tc->txn.begin();
+            tc->begin();
 
-            while (tc->txn.active() && tc->running()) {
+            while (tc->active() && tc->running()) {
 
                 /* Generate a random key/value pair. */
                 std::string key = random_generator::instance().generate_random_string(tc->key_size);
@@ -118,15 +118,15 @@ public:
 
                 /* Insert a key value pair. */
                 if (tc->insert(cc.cursor, cc.coll.id, key, value)) {
-                    if (tc->txn.can_commit()) {
+                    if (tc->can_commit()) {
                         /* We are not checking the result of commit as it is not necessary. */
-                        if (tc->txn.commit())
+                        if (tc->commit())
                             rollback_retries = 0;
                         else
                             ++rollback_retries;
                     }
                 } else {
-                    tc->txn.rollback();
+                    tc->rollback();
                     ++rollback_retries;
                 }
                 testutil_assert(rollback_retries < MAX_ROLLBACKS);
@@ -136,7 +136,7 @@ public:
             }
 
             /* Rollback any transaction that could not commit before the end of the test. */
-            tc->txn.try_rollback();
+            tc->try_rollback();
 
             /* Reset our cursor to avoid pinning content. */
             testutil_check(cc.cursor->reset(cc.cursor.get()));
@@ -178,10 +178,10 @@ public:
              * The oldest timestamp might move ahead and the reading timestamp might become invalid.
              * To tackle this issue, we round the timestamp to the oldest timestamp value.
              */
-            tc->txn.begin(
+            tc->begin(
               "roundup_timestamps=(read=true),read_timestamp=" + tc->tsm->decimal_to_hex(ts));
 
-            while (tc->txn.active() && tc->running()) {
+            while (tc->active() && tc->running()) {
                 /*
                  * Generate a random prefix. For this, we start by generating a random size and then
                  * its value.
@@ -211,15 +211,15 @@ public:
                 validate_prefix_search_near(
                   ret, exact_prefix, key_prefix_str, cursor_default, generated_prefix);
 
-                tc->txn.add_op();
-                if (tc->txn.get_op_count() >= tc->txn.get_target_op_count())
-                    tc->txn.rollback();
+                tc->add_op();
+                if (tc->get_op_count() >= tc->get_target_op_count())
+                    tc->rollback();
                 tc->sleep();
             }
             testutil_check(cursor_prefix->reset(cursor_prefix.get()));
         }
         /* Roll back the last transaction if still active now the work is finished. */
-        tc->txn.try_rollback();
+        tc->try_rollback();
     }
 
 private:

--- a/test/cppsuite/tests/bounded_cursor_prefix_search_near.cpp
+++ b/test/cppsuite/tests/bounded_cursor_prefix_search_near.cpp
@@ -61,8 +61,9 @@ public:
         logger::log_msg(
           LOG_INFO, "Populate: " + std::to_string(collection_count) + " creating collections.");
 
+        scoped_session session = connection_manager::instance().create_session();
         for (uint64_t i = 0; i < collection_count; ++i)
-            database.add_collection();
+            database.add_collection(session);
 
         logger::log_msg(LOG_INFO, "Populate: finished.");
     }

--- a/test/cppsuite/tests/bounded_cursor_prefix_stat.cpp
+++ b/test/cppsuite/tests/bounded_cursor_prefix_stat.cpp
@@ -131,12 +131,13 @@ public:
             " number of collections: " + std::to_string(collection_count));
 
         /* Create n collections as per the configuration. */
+        scoped_session session = connection_manager::instance().create_session();
         for (uint64_t i = 0; i < collection_count; ++i)
             /*
              * The database model will call into the API and create the collection, with its own
              * session.
              */
-            database.add_collection();
+            database.add_collection(session);
 
         /* Spawn 26 threads to populate the database. */
         for (uint64_t i = 0; i < ALPHABET.size(); ++i) {
@@ -158,7 +159,6 @@ public:
 
         /* Force evict all the populated keys in all of the collections. */
         int cmpp;
-        scoped_session session = connection_manager::instance().create_session();
         for (uint64_t count = 0; count < collection_count; ++count) {
             collection &coll = database.get_collection(count);
             scoped_cursor evict_cursor =

--- a/test/cppsuite/tests/bounded_cursor_prefix_stat.cpp
+++ b/test/cppsuite/tests/bounded_cursor_prefix_stat.cpp
@@ -71,7 +71,7 @@ class bounded_cursor_prefix_stat : public test {
             for (uint64_t j = 0; j < ALPHABET.size(); ++j) {
                 for (uint64_t k = 0; k < ALPHABET.size(); ++k) {
                     for (uint64_t count = 0; count < tc->key_count; ++count) {
-                        tc->txn.begin();
+                        tc->begin();
                         /*
                          * Generate the prefix key, and append a random generated key string based
                          * on the key size configuration.
@@ -86,14 +86,14 @@ class bounded_cursor_prefix_stat : public test {
                         if (!tc->insert(cursor, coll.id, prefix_key, value)) {
                             testutil_assert(rollback_retries < MAX_ROLLBACKS);
                             /* We failed to insert, rollback our transaction and retry. */
-                            tc->txn.rollback();
+                            tc->rollback();
                             ++rollback_retries;
                             if (count > 0)
                                 --count;
                         } else {
                             /* Commit txn at commit timestamp 100. */
                             testutil_assert(
-                              tc->txn.commit("commit_timestamp=" + tc->tsm->decimal_to_hex(100)));
+                              tc->commit("commit_timestamp=" + tc->tsm->decimal_to_hex(100)));
                             rollback_retries = 0;
                         }
                     }
@@ -200,7 +200,7 @@ public:
          * bounded search near, we expect the search to early exit out of its prefix key range and
          * return WT_NOTFOUND.
          */
-        tc->txn.begin("read_timestamp=" + tc->tsm->decimal_to_hex(10));
+        tc->begin("read_timestamp=" + tc->tsm->decimal_to_hex(10));
         cursor->set_key(cursor.get(), srch_key.c_str());
         bound_set prefix_bounds = bound_set(srch_key);
         prefix_bounds.apply(cursor);
@@ -220,7 +220,7 @@ public:
          */
         if (srch_key == "z" || srch_key == "zz" || srch_key == "zzz")
             ++z_key_searches;
-        tc->txn.rollback();
+        tc->rollback();
     }
 
     void

--- a/test/cppsuite/tests/bounded_cursor_stress.cpp
+++ b/test/cppsuite/tests/bounded_cursor_stress.cpp
@@ -383,9 +383,9 @@ public:
 
             collection &coll = tc->db.get_random_collection();
             scoped_cursor cursor = tc->session.open_scoped_cursor(coll.name);
-            tc->txn.try_begin();
+            tc->try_begin();
 
-            while (tc->txn.active() && tc->running()) {
+            while (tc->active() && tc->running()) {
 
                 /* Generate a random key. */
                 auto key = random_generator::instance().generate_random_string(tc->key_size);
@@ -393,15 +393,15 @@ public:
                   random_generator::instance().generate_pseudo_random_string(tc->value_size);
                 /* Insert a key/value pair. */
                 if (tc->insert(cursor, coll.id, key, value)) {
-                    if (tc->txn.can_commit()) {
+                    if (tc->can_commit()) {
                         /* We are not checking the result of commit as it is not necessary. */
-                        if (tc->txn.commit())
+                        if (tc->commit())
                             rollback_retries = 0;
                         else
                             ++rollback_retries;
                     }
                 } else {
-                    tc->txn.rollback();
+                    tc->rollback();
                     ++rollback_retries;
                 }
                 testutil_assert(rollback_retries < MAX_ROLLBACKS);
@@ -414,7 +414,7 @@ public:
             testutil_check(cursor->reset(cursor.get()));
         }
         /* Rollback any transaction that could not commit before the end of the test. */
-        tc->txn.try_rollback();
+        tc->try_rollback();
     }
 
     void
@@ -431,9 +431,9 @@ public:
             scoped_cursor cursor = tc->session.open_scoped_cursor(coll.name);
             scoped_cursor rnd_cursor =
               tc->session.open_scoped_cursor(coll.name, "next_random=true");
-            tc->txn.try_begin();
+            tc->try_begin();
 
-            while (tc->txn.active() && tc->running()) {
+            while (tc->active() && tc->running()) {
                 int ret = rnd_cursor->next(rnd_cursor.get());
 
                 /* It is possible not to find anything if the collection is empty. */
@@ -443,7 +443,7 @@ public:
                      * If we cannot find any record, finish the current transaction as we might be
                      * able to see new records after starting a new one.
                      */
-                    testutil_ignore_ret_bool(tc->txn.commit());
+                    testutil_ignore_ret_bool(tc->commit());
                     continue;
                 } else if (ret == WT_ROLLBACK)
                     break;
@@ -455,15 +455,15 @@ public:
                 auto value =
                   random_generator::instance().generate_pseudo_random_string(tc->value_size);
                 if (tc->update(cursor, coll.id, key, value)) {
-                    if (tc->txn.can_commit()) {
+                    if (tc->can_commit()) {
                         /* We are not checking the result of commit as it is not necessary. */
-                        if (tc->txn.commit())
+                        if (tc->commit())
                             rollback_retries = 0;
                         else
                             ++rollback_retries;
                     }
                 } else {
-                    tc->txn.rollback();
+                    tc->rollback();
                     ++rollback_retries;
                 }
                 testutil_assert(rollback_retries < MAX_ROLLBACKS);
@@ -478,7 +478,7 @@ public:
         }
 
         /* Rollback any transaction that could not commit before the end of the test. */
-        tc->txn.try_rollback();
+        tc->try_rollback();
     }
 
     void
@@ -511,9 +511,9 @@ public:
              * The oldest timestamp might move ahead and the reading timestamp might become invalid.
              * To tackle this issue, we round the timestamp to the oldest timestamp value.
              */
-            tc->txn.try_begin(
+            tc->try_begin(
               "roundup_timestamps=(read=true),read_timestamp=" + tc->tsm->decimal_to_hex(ts));
-            while (tc->txn.active() && tc->running()) {
+            while (tc->active() && tc->running()) {
                 /* Generate a random string. */
                 auto key_size = random_generator::instance().generate_integer(
                   static_cast<int64_t>(1), tc->key_size);
@@ -552,16 +552,16 @@ public:
                     validate_bound_search(ret, bounded_cursor, range_key_copy, bound_pair);
                 }
 
-                tc->txn.add_op();
-                if (tc->txn.can_commit())
-                    tc->txn.commit();
+                tc->add_op();
+                if (tc->can_commit())
+                    tc->commit();
                 tc->sleep();
             }
             bounded_cursor->reset(bounded_cursor.get());
             normal_cursor->reset(normal_cursor.get());
         }
         /* Roll back the last transaction if still active now the work is finished. */
-        tc->txn.try_rollback();
+        tc->try_rollback();
     }
 
     /*
@@ -745,9 +745,9 @@ public:
              * The oldest timestamp might move ahead and the reading timestamp might become invalid.
              * To tackle this issue, we round the timestamp to the oldest timestamp value.
              */
-            tc->txn.begin(
+            tc->begin(
               "roundup_timestamps=(read=true),read_timestamp=" + tc->tsm->decimal_to_hex(ts));
-            while (tc->txn.active() && tc->running()) {
+            while (tc->active() && tc->running()) {
                 int ret = cursor_traversal(bounded_cursor, normal_cursor, bound_pair.get_lower(),
                   bound_pair.get_upper(), true);
                 if (ret != 0)
@@ -766,14 +766,14 @@ public:
                       bound_pair.get_upper(), false);
                     testutil_assert(ret == 0 || ret == WT_ROLLBACK);
                 }
-                tc->txn.add_op();
-                if (tc->txn.get_op_count() >= tc->txn.get_target_op_count())
-                    tc->txn.rollback();
+                tc->add_op();
+                if (tc->get_op_count() >= tc->get_target_op_count())
+                    tc->rollback();
                 tc->sleep();
             }
             normal_cursor->reset(normal_cursor.get());
         }
         /* Roll back the last transaction if still active now the work is finished. */
-        tc->txn.try_rollback();
+        tc->try_rollback();
     }
 };

--- a/test/cppsuite/tests/hs_cleanup.cpp
+++ b/test/cppsuite/tests/hs_cleanup.cpp
@@ -69,14 +69,14 @@ public:
             tc->sleep();
 
             /* Start a transaction if possible. */
-            tc->txn.try_begin();
+            tc->try_begin();
 
             auto ret = cursor->next(cursor.get());
             if (ret != 0) {
                 if (ret == WT_NOTFOUND)
                     testutil_check(cursor->reset(cursor.get()));
                 else if (ret == WT_ROLLBACK)
-                    tc->txn.rollback();
+                    tc->rollback();
                 else
                     testutil_die(ret, "Unexpected error returned from cursor->next()");
                 continue;
@@ -93,19 +93,19 @@ public:
             std::string value =
               random_generator::instance().generate_pseudo_random_string(tc->value_size);
             if (tc->update(cursor, coll.id, key_tmp, value)) {
-                if (tc->txn.can_commit()) {
-                    if (tc->txn.commit())
+                if (tc->can_commit()) {
+                    if (tc->commit())
                         rollback_retries = 0;
                     else
                         ++rollback_retries;
                 }
             } else {
-                tc->txn.rollback();
+                tc->rollback();
                 ++rollback_retries;
             }
             testutil_assert(rollback_retries < MAX_ROLLBACKS);
         }
         /* Ensure our last transaction is resolved. */
-        tc->txn.try_rollback();
+        tc->try_rollback();
     }
 };

--- a/test/cppsuite/tests/reverse_split.cpp
+++ b/test/cppsuite/tests/reverse_split.cpp
@@ -70,10 +70,10 @@ public:
 
         while (tc->running()) {
             testutil_check(write_cursor->reset(write_cursor.get()));
-            tc->txn.begin();
+            tc->begin();
             int ret = write_cursor->next(write_cursor.get());
             if (ret != 0) {
-                tc->txn.rollback();
+                tc->rollback();
                 continue;
             }
             const char *key;
@@ -87,10 +87,10 @@ public:
             std::string end_key = tc->pad_string(std::to_string(end_key_id), tc->key_size);
             /* If we generate an invalid range or our truncate fails rollback the transaction. */
             if (min_key_id == end_key_id || !tc->truncate(coll.id, key_str, end_key, "")) {
-                tc->txn.rollback();
+                tc->rollback();
                 continue;
             }
-            if (tc->txn.commit())
+            if (tc->commit())
                 logger::log_msg(LOG_TRACE,
                   "thread {" + std::to_string(tc->id) + "} committed truncation of " +
                     std::to_string(end_key_id - min_key_id) + " records.");
@@ -111,7 +111,7 @@ public:
             tc->sync();
         }
         /* Make sure the last transaction is rolled back now the work is finished. */
-        tc->txn.try_rollback();
+        tc->try_rollback();
     }
 };
 } // namespace test_harness


### PR DESCRIPTION
- Transaction was bad, improved by removing the session, timestamp manager, configuration and op tracking.

- Moved a lot of this into thread_worker

- Database model was silly removed session. Now it can restart

- Added a "crud" inline class that does some basic management things of crud operations.