### PR TITLE
WT-16191 Disallow non-ASCII characters in PR titles

### DIFF
--- a/.github/workflows/pr_title_checker_config.json
+++ b/.github/workflows/pr_title_checker_config.json
@@ -5,7 +5,7 @@
   },
   "MESSAGES": {
     "success": "All OK",
-    "failure": "PR title does not match the regex: \"^(Revert \")?WT-[0-9]+ \" and contain only ASCII characters",
+    "failure": "PR title does not match the regex: \"^(Revert \")?WT-[0-9]+ \" or contains non-ASCII characters",
     "notice": ""
   }
 }

--- a/.github/workflows/pr_title_checker_config.json
+++ b/.github/workflows/pr_title_checker_config.json
@@ -1,11 +1,11 @@
 {
   "CHECKS": {
-    "regexp": "^(Revert \")?WT-[0-9]+ ",
+    "regexp": "^(Revert \")?WT-[0-9]+ [ -~]+$",
     "alwaysPassCI": false
   },
   "MESSAGES": {
     "success": "All OK",
-    "failure": "PR title does not match the regex: \"^(Revert \")?WT-[0-9]+ \"",
+    "failure": "PR title does not match the regex: \"^(Revert \")?WT-[0-9]+ \" and contain only ASCII characters",
     "notice": ""
   }
 }


### PR DESCRIPTION
Having non-ASCII symbols in a PR description leads to failures during the vendoring process. To avoid having such problems in the future, we could simply restrict using  any non-ASCII symbols in PR titles. 

I created a separate PR to test the changes: https://github.com/wiredtiger/wiredtiger/pull/12864

Anyone who wants to check the PR can change the title of the test PR by inserting different non-ASCII symbols there.