### PR TITLE
WT-16192 `terminate` method is missing in WT_KEY_PROVIDER interface

### DIFF
--- a/examples/c/ex_key_provider.c
+++ b/examples/c/ex_key_provider.c
@@ -53,7 +53,7 @@ typedef struct {
 
     /* This example stores a fixed size blob in the key provider struct. It is not required. */
     MY_CRYPT_DATA *encryption_data;
-    uint64_t returned_lsn;
+    uint64_t checkpoint_lsn;
 } MY_KEY_PROVIDER;
 
 /*
@@ -77,6 +77,8 @@ my_load_key(WT_KEY_PROVIDER *kp, WT_SESSION *session, const WT_CRYPT_KEYS *keys)
     /* Assign new encryption data. */
     memcpy((uint8_t *)encryption_data, keys->data, keys->size);
     my_kp->encryption_data = encryption_data;
+    my_kp->checkpoint_lsn = keys->r.lsn;
+
     return (0);
 }
 
@@ -117,7 +119,7 @@ my_on_key_update(WT_KEY_PROVIDER *kp, WT_SESSION *session, WT_CRYPT_KEYS *keys)
 
     /* Check size field to determine that the key was successfully persisted. */
     if (keys->size != 0)
-        my_kp->returned_lsn = keys->r.lsn;
+        my_kp->checkpoint_lsn = keys->r.lsn;
     else
         /* Handle error */
         (void)wtext->err_printf(
@@ -125,6 +127,19 @@ my_on_key_update(WT_KEY_PROVIDER *kp, WT_SESSION *session, WT_CRYPT_KEYS *keys)
 
     /* Free the allocated key. */
     free(keys);
+
+    return (0);
+}
+
+static int
+my_terminate(WT_KEY_PROVIDER *kp, WT_SESSION *session)
+{
+    WT_UNUSED(session);
+    MY_KEY_PROVIDER *my_kp = (MY_KEY_PROVIDER *)kp;
+
+    /* Free any allocated encryption data. */
+    free(my_kp->encryption_data);
+    free(my_kp);
 
     return (0);
 }
@@ -153,6 +168,7 @@ set_my_key_provider(WT_CONNECTION *conn, WT_CONFIG_ARG *config)
     kp->load_key = my_load_key;
     kp->get_key = my_get_key;
     kp->on_key_update = my_on_key_update;
+    kp->terminate = my_terminate;
 
     error_check(conn->set_key_provider(conn, (WT_KEY_PROVIDER *)my_kp, NULL));
     return (0);

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -5779,7 +5779,7 @@ struct __wt_key_provider {
      *
      * @param kp the WT_KEY_PROVIDER instance.
      * @param session the current WiredTiger session.
-     * @param keysp the WT_CRYPT_KEYS to hold the new key (if changed).
+     * @param[out] keysp the WT_CRYPT_KEYS to hold the new key (if changed).
      */
     int (*get_key)(WT_KEY_PROVIDER *kp, WT_SESSION *session, WT_CRYPT_KEYS **keysp);
 
@@ -5794,6 +5794,21 @@ struct __wt_key_provider {
      * @param keys the WT_CRYPT_KEYS information to confirm key persistence.
      */
     int (*on_key_update)(WT_KEY_PROVIDER *kp, WT_SESSION *session, WT_CRYPT_KEYS *keys);
+
+    /*!
+     * A callback performed when the key provider is closed and will no
+     * longer be accessed by the WiredTiger database.
+     *
+     * This method is not required and should be set to NULL when not
+     * required by the key provider.
+     *
+     * The WT_KEY_PROVIDER::terminate callback is intended to allow cleanup;
+     * the handle will not be subsequently accessed by WiredTiger.
+     *
+     * @param kp the WT_KEY_PROVIDER instance.
+     * @param session the current WiredTiger session.
+     */
+    int (*terminate)(WT_KEY_PROVIDER *key_provider, WT_SESSION *session);
 };
 #endif
 


### PR DESCRIPTION
- Add `terminate` method to `WT_KEY_PROVIDER` interface.