### PR TITLE
WT-16048 Upload Workgen Stats in Evergreen

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1347,50 +1347,6 @@ functions:
         content_type: text/html
         remote_file: wiredtiger/${build_variant}/${revision}/${task_name}-${build_id}-${execution}/
 
-  "upload perf test stats files":
-    - command: shell.exec
-      params:
-        working_dir: "wiredtiger/cmake_build/bench/wtperf"
-        include_expansions_in_env:
-          - test_type
-        shell: bash
-        script: |
-          set -o errexit
-          set -o verbose
-          # Archive the WT_TEST directory which includes the generated stat files
-          # For workgen tests, the WT_TEST is created in the runner directory
-          if [ "${test_type}" = "workgen" ]; then
-            cd ../../../bench/workgen/runner
-          fi
-          
-          # Find the WT_TEST directory (could be WT_TEST, WT_TEST_0_0, etc.)
-          WT_TEST_DIR=$(find . -maxdepth 1 -type d -name "WT_TEST*" | head -1)
-          
-          if [ -n "$WT_TEST_DIR" ]; then
-            echo "Found directory: $WT_TEST_DIR"
-            # Archive all .stat files and WiredTiger.Stat from the directory
-            tar -zcvf WT_TEST_stats.tgz "$WT_TEST_DIR"/*.stat "$WT_TEST_DIR"/WiredTiger.Stat 2>/dev/null || {
-              echo "Some stat files not found, archiving what exists"
-              # Try to archive just what's available
-              find "$WT_TEST_DIR" -name "*.stat" -o -name "WiredTiger.Stat" | tar -zcvf WT_TEST_stats.tgz -T - 2>/dev/null || echo "No stat files found"
-            }
-          else
-            echo "WT_TEST directory not found, skipping archive"
-            exit 0
-          fi
-    - command: s3.put
-      type: setup
-      params:
-        optional: true
-        aws_secret: ${aws_secret}
-        aws_key: ${aws_key}
-        local_file: wiredtiger/${test_dir|cmake_build/bench/wtperf}/WT_TEST_stats.tgz
-        bucket: build_external
-        permissions: public-read
-        content_type: application/tar
-        display_name: Performance Test Stats Files
-        remote_file: wiredtiger/${build_variant}/${revision}/${task_name}-${build_id}-${execution}/WT_TEST_stats.tgz
-
   "validate-expected-stats":
     - command: shell.exec
       params:
@@ -5614,6 +5570,10 @@ tasks:
       - func: "upload stats to evergreen"
         vars:
           test-name: cache_dirty_trigger_read-10_write-90.py
+      - func: "upload artifact"
+        vars:
+          upload_source_dir: wiredtiger/cmake_build/bench/wtperf/WT_TEST_0_0/
+          artifacts_name: WT_TEST.tgz
 
   - name: perf-cache_dirty_trigger_read-25_write-75
     tags: ["evict-perf"]
@@ -5635,6 +5595,10 @@ tasks:
       - func: "upload stats to evergreen"
         vars:
           test-name: cache_dirty_trigger_read-25_write-75.py
+      - func: "upload artifact"
+        vars:
+          upload_source_dir: wiredtiger/cmake_build/bench/wtperf/WT_TEST_0_0/
+          artifacts_name: WT_TEST.tgz
 
   - name: perf-cache_dirty_trigger_read-50_write-50
     tags: ["evict-perf"]
@@ -5656,6 +5620,10 @@ tasks:
       - func: "upload stats to evergreen"
         vars:
           test-name: cache_dirty_trigger_read-50_write-50.py
+      - func: "upload artifact"
+        vars:
+          upload_source_dir: wiredtiger/cmake_build/bench/wtperf/WT_TEST_0_0/
+          artifacts_name: WT_TEST.tgz
 
   - name: perf-cache_dirty_trigger_read-75_write-25
     tags: ["evict-perf"]
@@ -5677,6 +5645,10 @@ tasks:
       - func: "upload stats to evergreen"
         vars:
           test-name: cache_dirty_trigger_read-75_write-25.py
+      - func: "upload artifact"
+        vars:
+          artifacts_name: WT_TEST.tgz
+          upload_source_dir: wiredtiger/cmake_build/bench/wtperf/WT_TEST_0_0/
 
   - name: perf-cache_dirty_trigger_read-90_write-10
     tags: ["evict-perf"]
@@ -5698,6 +5670,10 @@ tasks:
       - func: "upload stats to evergreen"
         vars:
           test-name: cache_dirty_trigger_read-90_write-10.py
+      - func: "upload artifact"
+        vars:
+          artifacts_name: WT_TEST.tgz
+          upload_source_dir: wiredtiger/cmake_build/bench/wtperf/WT_TEST_0_0/
 
   - name: perf-cache_update_trigger_read-10_write-90
     tags: ["evict-perf"]
@@ -5713,10 +5689,6 @@ tasks:
           perf-test-name: cache_update_trigger_read-10_write-90.py
           maxruns: 1
           wtarg: -ops ['"read_ops","update_ops","read_latency_us","read_latency_ms","read_latency_sec","update_latency_us","update_latency_ms","update_latency_sec"']
-      - func: "upload perf test stats files"
-        vars:
-          test_type: workgen
-          test_dir: bench/workgen/runner
       - func: "upload stats to atlas"
         vars:
           test-name: cache_update_trigger_read-10_write-90.py
@@ -5725,7 +5697,7 @@ tasks:
           test-name: cache_update_trigger_read-10_write-90.py
       - func: "upload artifact"
         vars:
-          upload_filename: WT_TEST.tgz
+          artifacts_name: WT_TEST.tgz
           upload_source_dir: wiredtiger/cmake_build/bench/wtperf/WT_TEST_0_0/
 
   - name: perf-cache_update_trigger_read-25_write-75
@@ -5742,16 +5714,16 @@ tasks:
           perf-test-name: cache_update_trigger_read-25_write-75.py
           maxruns: 1
           wtarg: -ops ['"read_ops","update_ops","read_latency_us","read_latency_ms","read_latency_sec","update_latency_us","update_latency_ms","update_latency_sec"']
-      - func: "upload perf test stats files"
-        vars:
-          test_type: workgen
-          test_dir: bench/workgen/runner
       - func: "upload stats to atlas"
         vars:
           test-name: cache_update_trigger_read-25_write-75.py
       - func: "upload stats to evergreen"
         vars:
           test-name: cache_update_trigger_read-25_write-75.py
+      - func: "upload artifact"
+        vars:
+          artifacts_name: WT_TEST.tgz
+          upload_source_dir: wiredtiger/cmake_build/bench/wtperf/WT_TEST_0_0/
 
   - name: perf-cache_update_trigger_read-50_write-50
     tags: ["evict-perf"]
@@ -5767,16 +5739,16 @@ tasks:
           perf-test-name: cache_update_trigger_read-50_write-50.py
           maxruns: 1
           wtarg: -ops ['"read_ops","update_ops","read_latency_us","read_latency_ms","read_latency_sec","update_latency_us","update_latency_ms","update_latency_sec"']
-      - func: "upload perf test stats files"
-        vars:
-          test_type: workgen
-          test_dir: bench/workgen/runner
       - func: "upload stats to atlas"
         vars:
           test-name: cache_update_trigger_read-50_write-50.py
       - func: "upload stats to evergreen"
         vars:
           test-name: cache_update_trigger_read-50_write-50.py
+      - func: "upload artifact"
+        vars:
+          artifacts_name: WT_TEST.tgz
+          upload_source_dir: wiredtiger/cmake_build/bench/wtperf/WT_TEST_0_0/
 
   - name: perf-cache_update_trigger_read-75_write-25
     tags: ["evict-perf"]
@@ -5792,16 +5764,16 @@ tasks:
           perf-test-name: cache_update_trigger_read-75_write-25.py
           maxruns: 1
           wtarg: -ops ['"read_ops","update_ops","read_latency_us","read_latency_ms","read_latency_sec","update_latency_us","update_latency_ms","update_latency_sec"']
-      - func: "upload perf test stats files"
-        vars:
-          test_type: workgen
-          test_dir: bench/workgen/runner
       - func: "upload stats to atlas"
         vars:
           test-name: cache_update_trigger_read-75_write-25.py
       - func: "upload stats to evergreen"
         vars:
           test-name: cache_update_trigger_read-75_write-25.py
+      - func: "upload artifact"
+        vars:
+          artifacts_name: WT_TEST.tgz
+          upload_source_dir: wiredtiger/cmake_build/bench/wtperf/WT_TEST_0_0/
 
   - name: perf-cache_update_trigger_read-90_write-10
     tags: ["evict-perf"]
@@ -5817,16 +5789,16 @@ tasks:
           perf-test-name: cache_update_trigger_read-90_write-10.py
           maxruns: 1
           wtarg: -ops ['"read_ops","update_ops","read_latency_us","read_latency_ms","read_latency_sec","update_latency_us","update_latency_ms","update_latency_sec"']
-      - func: "upload perf test stats files"
-        vars:
-          test_type: workgen
-          test_dir: bench/workgen/runner
       - func: "upload stats to atlas"
         vars:
           test-name: cache_update_trigger_read-90_write-10.py
       - func: "upload stats to evergreen"
         vars:
           test-name: cache_update_trigger_read-90_write-10.py
+      - func: "upload artifact"
+        vars:
+          artifacts_name: WT_TEST.tgz
+          upload_source_dir: wiredtiger/cmake_build/bench/wtperf/WT_TEST_0_0/
 
     ###########################################
     # Performance Tests for log consolidation #

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1347,6 +1347,50 @@ functions:
         content_type: text/html
         remote_file: wiredtiger/${build_variant}/${revision}/${task_name}-${build_id}-${execution}/
 
+  "upload perf test stats files":
+    - command: shell.exec
+      params:
+        working_dir: "wiredtiger/cmake_build/bench/wtperf"
+        include_expansions_in_env:
+          - test_type
+        shell: bash
+        script: |
+          set -o errexit
+          set -o verbose
+          # Archive the WT_TEST directory which includes the generated stat files
+          # For workgen tests, the WT_TEST is created in the runner directory
+          if [ "${test_type}" = "workgen" ]; then
+            cd ../../../bench/workgen/runner
+          fi
+          
+          # Find the WT_TEST directory (could be WT_TEST, WT_TEST_0_0, etc.)
+          WT_TEST_DIR=$(find . -maxdepth 1 -type d -name "WT_TEST*" | head -1)
+          
+          if [ -n "$WT_TEST_DIR" ]; then
+            echo "Found directory: $WT_TEST_DIR"
+            # Archive all .stat files and WiredTiger.Stat from the directory
+            tar -zcvf WT_TEST_stats.tgz "$WT_TEST_DIR"/*.stat "$WT_TEST_DIR"/WiredTiger.Stat 2>/dev/null || {
+              echo "Some stat files not found, archiving what exists"
+              # Try to archive just what's available
+              find "$WT_TEST_DIR" -name "*.stat" -o -name "WiredTiger.Stat" | tar -zcvf WT_TEST_stats.tgz -T - 2>/dev/null || echo "No stat files found"
+            }
+          else
+            echo "WT_TEST directory not found, skipping archive"
+            exit 0
+          fi
+    - command: s3.put
+      type: setup
+      params:
+        optional: true
+        aws_secret: ${aws_secret}
+        aws_key: ${aws_key}
+        local_file: wiredtiger/${test_dir|cmake_build/bench/wtperf}/WT_TEST_stats.tgz
+        bucket: build_external
+        permissions: public-read
+        content_type: application/tar
+        display_name: Performance Test Stats Files
+        remote_file: wiredtiger/${build_variant}/${revision}/${task_name}-${build_id}-${execution}/WT_TEST_stats.tgz
+
   "validate-expected-stats":
     - command: shell.exec
       params:
@@ -5669,12 +5713,20 @@ tasks:
           perf-test-name: cache_update_trigger_read-10_write-90.py
           maxruns: 1
           wtarg: -ops ['"read_ops","update_ops","read_latency_us","read_latency_ms","read_latency_sec","update_latency_us","update_latency_ms","update_latency_sec"']
+      - func: "upload perf test stats files"
+        vars:
+          test_type: workgen
+          test_dir: bench/workgen/runner
       - func: "upload stats to atlas"
         vars:
           test-name: cache_update_trigger_read-10_write-90.py
       - func: "upload stats to evergreen"
         vars:
           test-name: cache_update_trigger_read-10_write-90.py
+      - func: "upload artifact"
+        vars:
+          upload_filename: WT_TEST.tgz
+          upload_source_dir: wiredtiger/cmake_build/bench/wtperf/WT_TEST_0_0/
 
   - name: perf-cache_update_trigger_read-25_write-75
     tags: ["evict-perf"]
@@ -5690,6 +5742,10 @@ tasks:
           perf-test-name: cache_update_trigger_read-25_write-75.py
           maxruns: 1
           wtarg: -ops ['"read_ops","update_ops","read_latency_us","read_latency_ms","read_latency_sec","update_latency_us","update_latency_ms","update_latency_sec"']
+      - func: "upload perf test stats files"
+        vars:
+          test_type: workgen
+          test_dir: bench/workgen/runner
       - func: "upload stats to atlas"
         vars:
           test-name: cache_update_trigger_read-25_write-75.py
@@ -5711,6 +5767,10 @@ tasks:
           perf-test-name: cache_update_trigger_read-50_write-50.py
           maxruns: 1
           wtarg: -ops ['"read_ops","update_ops","read_latency_us","read_latency_ms","read_latency_sec","update_latency_us","update_latency_ms","update_latency_sec"']
+      - func: "upload perf test stats files"
+        vars:
+          test_type: workgen
+          test_dir: bench/workgen/runner
       - func: "upload stats to atlas"
         vars:
           test-name: cache_update_trigger_read-50_write-50.py
@@ -5732,6 +5792,10 @@ tasks:
           perf-test-name: cache_update_trigger_read-75_write-25.py
           maxruns: 1
           wtarg: -ops ['"read_ops","update_ops","read_latency_us","read_latency_ms","read_latency_sec","update_latency_us","update_latency_ms","update_latency_sec"']
+      - func: "upload perf test stats files"
+        vars:
+          test_type: workgen
+          test_dir: bench/workgen/runner
       - func: "upload stats to atlas"
         vars:
           test-name: cache_update_trigger_read-75_write-25.py
@@ -5753,6 +5817,10 @@ tasks:
           perf-test-name: cache_update_trigger_read-90_write-10.py
           maxruns: 1
           wtarg: -ops ['"read_ops","update_ops","read_latency_us","read_latency_ms","read_latency_sec","update_latency_us","update_latency_ms","update_latency_sec"']
+      - func: "upload perf test stats files"
+        vars:
+          test_type: workgen
+          test_dir: bench/workgen/runner
       - func: "upload stats to atlas"
         vars:
           test-name: cache_update_trigger_read-90_write-10.py

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1126,6 +1126,25 @@ functions:
         content_type: application/tar
         display_name: ${artifacts_name|Artifacts}
         remote_file: wiredtiger/${build_variant}/${revision}/artifacts/${task_name}_${build_id}${postfix|}.tgz
+  "upload wtperf test artifact":
+    - command: archive.targz_pack
+      type: setup
+      params:
+        target: ${upload_filename|wt_test.tgz}
+        source_dir: ${upload_source_dir|wiredtiger/cmake_build/bench/wtperf/WT_TEST_0_0/}
+        include:
+          - "./**"
+    - command: s3.put
+      type: setup
+      params:
+        aws_secret: ${aws_secret}
+        aws_key: ${aws_key}
+        local_file: ${upload_filename|wt_test.tgz}
+        bucket: build_external
+        permissions: public-read
+        content_type: application/tar
+        display_name: ${artifacts_name|WT_TEST}
+        remote_file: wiredtiger/${build_variant}/${revision}/artifacts/${task_name}_${build_id}${postfix|}.tgz
   "upload endian format artifacts":
     - command: s3.put
       type: setup
@@ -5570,10 +5589,7 @@ tasks:
       - func: "upload stats to evergreen"
         vars:
           test-name: cache_dirty_trigger_read-10_write-90.py
-      - func: "upload artifact"
-        vars:
-          upload_source_dir: wiredtiger/cmake_build/bench/wtperf/WT_TEST_0_0/
-          artifacts_name: WT_TEST.tgz
+      - func: "upload wtperf test artifact"
 
   - name: perf-cache_dirty_trigger_read-25_write-75
     tags: ["evict-perf"]
@@ -5595,10 +5611,7 @@ tasks:
       - func: "upload stats to evergreen"
         vars:
           test-name: cache_dirty_trigger_read-25_write-75.py
-      - func: "upload artifact"
-        vars:
-          upload_source_dir: wiredtiger/cmake_build/bench/wtperf/WT_TEST_0_0/
-          artifacts_name: WT_TEST.tgz
+      - func: "upload wtperf test artifact"
 
   - name: perf-cache_dirty_trigger_read-50_write-50
     tags: ["evict-perf"]
@@ -5620,10 +5633,7 @@ tasks:
       - func: "upload stats to evergreen"
         vars:
           test-name: cache_dirty_trigger_read-50_write-50.py
-      - func: "upload artifact"
-        vars:
-          upload_source_dir: wiredtiger/cmake_build/bench/wtperf/WT_TEST_0_0/
-          artifacts_name: WT_TEST.tgz
+      - func: "upload wtperf test artifact"
 
   - name: perf-cache_dirty_trigger_read-75_write-25
     tags: ["evict-perf"]
@@ -5645,10 +5655,7 @@ tasks:
       - func: "upload stats to evergreen"
         vars:
           test-name: cache_dirty_trigger_read-75_write-25.py
-      - func: "upload artifact"
-        vars:
-          artifacts_name: WT_TEST.tgz
-          upload_source_dir: wiredtiger/cmake_build/bench/wtperf/WT_TEST_0_0/
+      - func: "upload wtperf test artifact"
 
   - name: perf-cache_dirty_trigger_read-90_write-10
     tags: ["evict-perf"]
@@ -5670,10 +5677,7 @@ tasks:
       - func: "upload stats to evergreen"
         vars:
           test-name: cache_dirty_trigger_read-90_write-10.py
-      - func: "upload artifact"
-        vars:
-          artifacts_name: WT_TEST.tgz
-          upload_source_dir: wiredtiger/cmake_build/bench/wtperf/WT_TEST_0_0/
+      - func: "upload wtperf test artifact"
 
   - name: perf-cache_update_trigger_read-10_write-90
     tags: ["evict-perf"]
@@ -5695,10 +5699,7 @@ tasks:
       - func: "upload stats to evergreen"
         vars:
           test-name: cache_update_trigger_read-10_write-90.py
-      - func: "upload artifact"
-        vars:
-          artifacts_name: WT_TEST.tgz
-          upload_source_dir: wiredtiger/cmake_build/bench/wtperf/WT_TEST_0_0/
+      - func: "upload wtperf test artifact"
 
   - name: perf-cache_update_trigger_read-25_write-75
     tags: ["evict-perf"]
@@ -5720,10 +5721,7 @@ tasks:
       - func: "upload stats to evergreen"
         vars:
           test-name: cache_update_trigger_read-25_write-75.py
-      - func: "upload artifact"
-        vars:
-          artifacts_name: WT_TEST.tgz
-          upload_source_dir: wiredtiger/cmake_build/bench/wtperf/WT_TEST_0_0/
+      - func: "upload wtperf test artifact"
 
   - name: perf-cache_update_trigger_read-50_write-50
     tags: ["evict-perf"]
@@ -5745,10 +5743,7 @@ tasks:
       - func: "upload stats to evergreen"
         vars:
           test-name: cache_update_trigger_read-50_write-50.py
-      - func: "upload artifact"
-        vars:
-          artifacts_name: WT_TEST.tgz
-          upload_source_dir: wiredtiger/cmake_build/bench/wtperf/WT_TEST_0_0/
+      - func: "upload wtperf test artifact"
 
   - name: perf-cache_update_trigger_read-75_write-25
     tags: ["evict-perf"]
@@ -5770,10 +5765,7 @@ tasks:
       - func: "upload stats to evergreen"
         vars:
           test-name: cache_update_trigger_read-75_write-25.py
-      - func: "upload artifact"
-        vars:
-          artifacts_name: WT_TEST.tgz
-          upload_source_dir: wiredtiger/cmake_build/bench/wtperf/WT_TEST_0_0/
+      - func: "upload wtperf test artifact"
 
   - name: perf-cache_update_trigger_read-90_write-10
     tags: ["evict-perf"]
@@ -5795,10 +5787,7 @@ tasks:
       - func: "upload stats to evergreen"
         vars:
           test-name: cache_update_trigger_read-90_write-10.py
-      - func: "upload artifact"
-        vars:
-          artifacts_name: WT_TEST.tgz
-          upload_source_dir: wiredtiger/cmake_build/bench/wtperf/WT_TEST_0_0/
+      - func: "upload wtperf test artifact"
 
     ###########################################
     # Performance Tests for log consolidation #
@@ -5977,10 +5966,7 @@ tasks:
       - func: "upload stats to evergreen"
         vars:
           test-name: 500m-btree-populate.wtperf
-      - func: "upload artifact"
-        vars:
-          upload_filename: WT_TEST.tgz
-          upload_source_dir: wiredtiger/cmake_build/bench/wtperf/WT_TEST_0_0/
+      - func: "upload wtperf test artifact"
       # Now take and upload a backup. We use this as the source in our live restore perf tests.
       - command: shell.exec
         params:


### PR DESCRIPTION
The cache eviction workgen tests creates a local WT_TEST folder when run that includes statistics files `latency.stat` and `cache_eviction.stat`. These stats are difficult to locate in evergreen runs. This PR uploads this folder as an artifact separately so it can be easily found under files. [Evergreen patch](https://spruce.mongodb.com/version/693529b1b3de00000780caf9/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

