### PR TITLE
WT-16160 Avoid prepare wt item externally

### DIFF
--- a/ext/page_log/palite/palite.cpp
+++ b/ext/page_log/palite/palite.cpp
@@ -275,7 +275,6 @@ resize_item(WT_ITEM *item, size_t new_size)
 static void
 fill_item(WT_ITEM *item, const void *data, size_t size)
 {
-    memset(item, 0, sizeof(WT_ITEM));
     resize_item(item, size);
     if (size > 0 && data != nullptr)
         memcpy(item->mem, data, size);

--- a/src/block_cache/block_io.c
+++ b/src/block_cache/block_io.c
@@ -105,10 +105,11 @@ __wt_blkcache_read(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *b
     WT_BTREE *btree;
     WT_COMPRESSOR *compressor;
     WT_DECL_ITEM(etmp);
+    WT_DECL_ITEM(ip);
+    WT_DECL_ITEM(ip_orig);
     WT_DECL_ITEM(tmp);
     WT_DECL_RET;
     WT_ENCRYPTOR *encryptor;
-    WT_ITEM *ip, *ip_orig;
     WT_ITEM results[WT_DELTA_LIMIT + 1];
     WT_PAGE_BLOCK_META block_meta_tmp;
     const WT_PAGE_HEADER *dsk;
@@ -125,6 +126,7 @@ __wt_blkcache_read(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *b
     encryptor = btree->kencryptor == NULL ? NULL : btree->kencryptor->encryptor;
     blkcache_found = found = false;
     skip_cache_put = (blkcache->type == WT_BLKCACHE_UNCONFIGURED);
+    memset(results, 0, sizeof(results));
     results_count = 0;
 
     WT_ASSERT_ALWAYS(session, session->dhandle != NULL, "The block cache requires a dhandle");

--- a/test/evergreen/asan_leaks.supp
+++ b/test/evergreen/asan_leaks.supp
@@ -3,5 +3,3 @@
 leak:InitModule
 # ARM64 python leaks memory from an unclear source. This suppresses that one leak.
 leak:PyObject_Malloc
-# FIXME-WT-16126 : Temporarily suppression until the underlying issue is resolved.
-leak:__wti_block_disagg_addr_string


### PR DESCRIPTION
For `WT_ITEM` allocated by `scr_alloc`, it's possible to carry existing memory space. `memset` to 0 can lead to a potential memory leakage.
And for the caller side, wiredtiger should meet the assumption that all `WT_ITEM`s passed in as parameters are prepared.