### PR TITLE
WT-15969 Reduce progress log size exponentially

### DIFF
--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -18,7 +18,6 @@ typedef struct {
     WT_ITEM *max_key;  /* Largest key */
     WT_ITEM *max_addr; /* Largest key page */
 
-#define WT_VERIFY_PROGRESS_INTERVAL 100
     uint64_t fcnt; /* Progress counter */
 
     /* Configuration options passed in. */
@@ -586,8 +585,7 @@ __verify_tree(
      *
      * Report progress occasionally.
      */
-    if (++vs->fcnt % WT_VERIFY_PROGRESS_INTERVAL == 0)
-        WT_RET(__wt_progress(session, NULL, vs->fcnt));
+    WT_RET(__wt_progress_backoff(session, NULL, ++vs->fcnt));
 
 #ifdef HAVE_DIAGNOSTIC
     /* Optionally dump the blocks or page in debugging mode. */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -878,6 +878,8 @@ extern int __wt_prepared_discover_remove_item(WT_SESSION_IMPL *session, uint64_t
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_progress(WT_SESSION_IMPL *session, const char *s, uint64_t v)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_progress_backoff(WT_SESSION_IMPL *session, const char *s, uint64_t v)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_random_descent(WT_SESSION_IMPL *session, WT_REF **refp, uint32_t flags,
   WT_RAND_STATE *rnd) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_range_truncate(WT_CURSOR *start, WT_CURSOR *stop)

--- a/src/support/err.c
+++ b/src/support/err.c
@@ -788,6 +788,26 @@ __wt_progress(WT_SESSION_IMPL *session, const char *s, uint64_t v)
 }
 
 /*
+ * __wt_progress_backoff --
+ *     Emit progress messages only when the leading two digits of 'v' change, so the reporting
+ *     interval grows with 'v' and avoids excessive logging.
+ */
+int
+__wt_progress_backoff(WT_SESSION_IMPL *session, const char *s, uint64_t v)
+{
+    WT_DECL_RET;
+    /*
+     * Using v - 1 is safe even when v == 0 because the check is edge-triggered.
+     */
+    uint64_t base, v_last = v - 1;
+    for (base = 1; v / base > 100; base *= 10)
+        ;
+    if (v / base != v_last / base)
+        ret = __wt_progress(session, s, v);
+    return (ret);
+}
+
+/*
  * __wt_inmem_unsupported_op --
  *     Print a standard error message for an operation that's not supported for in-memory
  *     configurations.


### PR DESCRIPTION
Introduce a helper that emits progress messages only when the leading two digits of the counter change. This provides a simple logarithmic backoff so long-running walks produce meaningful progress output without excessive logging.