### PR TITLE
WT-16218 Fix linker warnings about duplicate libraries

### DIFF
--- a/bench/tiered/CMakeLists.txt
+++ b/bench/tiered/CMakeLists.txt
@@ -2,8 +2,3 @@
 create_test_executable(test_push_pull
     SOURCES push_pull.c
 )
-
-if(WT_POSIX)
-    # Need to link math on POSIX systems.
-    target_link_libraries(test_push_pull m)
-endif()

--- a/bench/wtperf/CMakeLists.txt
+++ b/bench/wtperf/CMakeLists.txt
@@ -25,11 +25,6 @@ create_test_executable(wtperf
         ${wt_perf_flags}
 )
 
-if(WT_POSIX)
-    # Need to link math on POSIX systems.
-    target_link_libraries(wtperf m)
-endif()
-
 # Smoke-test wtperf as part of running "ctest check".
 define_test_variants(wtperf
     VARIANTS

--- a/cmake/third_party/sqlite3.cmake
+++ b/cmake/third_party/sqlite3.cmake
@@ -66,9 +66,9 @@ endif()
 
 # Needed for SQLite3 on some platforms
 target_link_libraries(sqlite3_lib PUBLIC
-    $<$<BOOL:${WT_POSIX}>:${HAVE_LIBPTHREAD}>
-    $<$<BOOL:${WT_POSIX}>:${HAVE_LIBDL}>
-    $<$<BOOL:${WT_POSIX}>:m>
+    $<$<BOOL:${WT_LINUX}>:${HAVE_LIBPTHREAD}>
+    $<$<BOOL:${WT_LINUX}>:${HAVE_LIBDL}>
+    $<$<BOOL:${WT_LINUX}>:m>
 )
 
 add_library(wt::sqlite3 ALIAS sqlite3_lib)

--- a/test/ctest_helpers.cmake
+++ b/test/ctest_helpers.cmake
@@ -24,7 +24,7 @@ SOURCES <source files>
 
 CXX
     Indicates that this is a C++ test.
-    
+
 NO_TEST_UTIL
     Do not link against the test_util library.
 
@@ -165,7 +165,7 @@ function(create_test_executable target)
         )
     endif()
 
-    if (NOT WT_WIN)
+    if (WT_LINUX)
         target_link_libraries(${target} m)
     endif()
 


### PR DESCRIPTION
- Remove duplicate/redundant linker flags to avoid warnings during build