### PR TITLE
WT-16230 Add stat to track time eviction worker threads spend waiting for locks

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -446,6 +446,7 @@ conn_stats = [
     EvictStat('eviction_walks_stopped', 'eviction walks gave up because they restarted their walk twice'),
     EvictStat('eviction_worker_evict_attempt', 'evict page attempts by eviction worker threads'),
     EvictStat('eviction_worker_evict_fail', 'evict page failures by eviction worker threads'),
+    EvictStat('eviction_worker_lock_wait_time', 'time eviction worker threads spend waiting for locks (usecs)'),
     # Note eviction_worker_evict_attempt - eviction_worker_evict_fail = evict page successes by eviction worker threads.
 
     ##########################################

--- a/src/evict/evict.h
+++ b/src/evict/evict.h
@@ -30,6 +30,8 @@ struct __wt_evict {
     uint64_t reentry_hs_eviction_ms; /* Total milliseconds spent inside a nested eviction */
     struct timespec stuck_time;      /* Stuck time */
 
+    wt_shared uint64_t evict_lock_wait_time; /* Time spent waiting for locks during eviction */
+
     /*
      * Read information.
      */

--- a/src/evict/evict_conn.c
+++ b/src/evict/evict_conn.c
@@ -341,6 +341,7 @@ __wt_evict_create(WT_SESSION_IMPL *session, const char *cfg[])
     evict->evict_current_queue = evict->evict_fill_queue = &evict->evict_queues[0];
     evict->evict_other_queue = &evict->evict_queues[1];
     evict->evict_urgent_queue = &evict->evict_queues[WTI_EVICT_URGENT_QUEUE];
+    evict->evict_lock_wait_time = 0;
 
     /*
      * We get/set some values in the evict statistics (rather than have two copies), configure them.
@@ -442,6 +443,9 @@ __wt_evict_stats_update(WT_SESSION_IMPL *session)
       __wt_atomic_load_uint16_relaxed(&evict->evict_max_eviction_queue_attempts));
     WT_STATP_CONN_SET(session, stats, eviction_maximum_attempts_to_evict_page,
       __wt_atomic_load_uint16_relaxed(&evict->evict_max_evict_page_attempts));
+
+    WT_STATP_CONN_SET(session, stats, eviction_worker_lock_wait_time,
+      __wt_atomic_load64(&evict->evict_lock_wait_time));
 
     /*
      * The number of files with active walks ~= number of hazard pointers in the walk session. Note:

--- a/src/evict/evict_conn.c
+++ b/src/evict/evict_conn.c
@@ -445,7 +445,7 @@ __wt_evict_stats_update(WT_SESSION_IMPL *session)
       __wt_atomic_load_uint16_relaxed(&evict->evict_max_evict_page_attempts));
 
     WT_STATP_CONN_SET(session, stats, eviction_worker_lock_wait_time,
-      __wt_atomic_load64(&evict->evict_lock_wait_time));
+      __wt_atomic_load_uint64_relaxed(&evict->evict_lock_wait_time));
 
     /*
      * The number of files with active walks ~= number of hazard pointers in the walk session. Note:

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2887,11 +2887,10 @@ __evict_get_ref(WT_SESSION_IMPL *session, bool is_server, WT_BTREE **btreep, WT_
     __wt_spin_lock(session, &evict->evict_queue_lock);
     lock_wait_end = __wt_clock(session);
 
-    /* Only track lock wait time for eviction server threads */
-    if (F_ISSET(session, WT_SESSION_INTERNAL)) {
+    /* Only track lock wait time for eviction worker threads */
+    if (F_ISSET(session, WT_SESSION_INTERNAL))
         __wt_atomic_add_uint64_v(
           &evict->evict_lock_wait_time, WT_CLOCKDIFF_US(lock_wait_end, lock_wait_start));
-    }
 
     /* Check the urgent queue first. */
     if (urgent_ok && !__evict_queue_empty(urgent_queue, false))
@@ -2928,10 +2927,9 @@ __evict_get_ref(WT_SESSION_IMPL *session, bool is_server, WT_BTREE **btreep, WT_
             lock_wait_start = __wt_clock(session);
             __wt_spin_lock(session, &queue->evict_lock);
             lock_wait_end = __wt_clock(session);
-            if (F_ISSET(session, WT_SESSION_INTERNAL)) {
+            if (F_ISSET(session, WT_SESSION_INTERNAL))
                 __wt_atomic_add_uint64_v(
                   &evict->evict_lock_wait_time, WT_CLOCKDIFF_US(lock_wait_end, lock_wait_start));
-            }
         } else if (__wt_spin_trylock(session, &queue->evict_lock) != 0)
             continue;
         break;

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2888,8 +2888,9 @@ __evict_get_ref(WT_SESSION_IMPL *session, bool is_server, WT_BTREE **btreep, WT_
     lock_wait_end = __wt_clock(session);
 
     /* Only track lock wait time for eviction server threads */
-    if (is_server) {
-        __wt_atomic_add_uint64_v(&evict->evict_lock_wait_time, WT_CLOCKDIFF_US(lock_wait_end, lock_wait_start));
+    if (F_ISSET(session, WT_SESSION_INTERNAL)) {
+        __wt_atomic_add_uint64_v(
+          &evict->evict_lock_wait_time, WT_CLOCKDIFF_US(lock_wait_end, lock_wait_start));
     }
 
     /* Check the urgent queue first. */
@@ -2911,14 +2912,7 @@ __evict_get_ref(WT_SESSION_IMPL *session, bool is_server, WT_BTREE **btreep, WT_
         }
     }
 
-    /* Track time waiting for the lock when releasing it too */
-    lock_wait_start = __wt_clock(session);
     __wt_spin_unlock(session, &evict->evict_queue_lock);
-    lock_wait_end = __wt_clock(session);
-
-    if (is_server) {
-        __wt_atomic_add_uint64_v(&evict->evict_lock_wait_time, WT_CLOCKDIFF_US(lock_wait_end, lock_wait_start));
-    }
 
     /*
      * We got the queue lock, which should be fast, and chose a queue. Now we want to get the lock
@@ -2930,9 +2924,15 @@ __evict_get_ref(WT_SESSION_IMPL *session, bool is_server, WT_BTREE **btreep, WT_
             WT_STAT_CONN_INCR(session, eviction_get_ref_empty2);
             return (WT_NOTFOUND);
         }
-        if (!is_server)
+        if (!is_server) {
+            lock_wait_start = __wt_clock(session);
             __wt_spin_lock(session, &queue->evict_lock);
-        else if (__wt_spin_trylock(session, &queue->evict_lock) != 0)
+            lock_wait_end = __wt_clock(session);
+            if (F_ISSET(session, WT_SESSION_INTERNAL)) {
+                __wt_atomic_add_uint64_v(
+                  &evict->evict_lock_wait_time, WT_CLOCKDIFF_US(lock_wait_end, lock_wait_start));
+            }
+        } else if (__wt_spin_trylock(session, &queue->evict_lock) != 0)
             continue;
         break;
     }

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2881,7 +2881,16 @@ __evict_get_ref(WT_SESSION_IMPL *session, bool is_server, WT_BTREE **btreep, WT_
         __evict_queue_empty(evict->evict_fill_queue, false)))
         return (WT_NOTFOUND);
 
+    uint64_t lock_wait_start, lock_wait_time;
+    /* Track time spent waiting for the evict queue lock */
+    lock_wait_start = __wt_clock(session);
     __wt_spin_lock(session, &evict->evict_queue_lock);
+    lock_wait_time = __wt_clock(session) - lock_wait_start;
+
+    /* Only track lock wait time for eviction server threads */
+    if (is_server) {
+        __wt_atomic_add64(&evict->evict_lock_wait_time, WT_CLOCKTIME_NS_TO_US(lock_wait_time));
+    }
 
     /* Check the urgent queue first. */
     if (urgent_ok && !__evict_queue_empty(urgent_queue, false))
@@ -2902,7 +2911,14 @@ __evict_get_ref(WT_SESSION_IMPL *session, bool is_server, WT_BTREE **btreep, WT_
         }
     }
 
+    /* Track time waiting for the lock when releasing it too */
+    lock_wait_start = __wt_clock(session);
     __wt_spin_unlock(session, &evict->evict_queue_lock);
+    lock_wait_time = __wt_clock(session) - lock_wait_start;
+
+    if (is_server) {
+        __wt_atomic_add64(&evict->evict_lock_wait_time, WT_CLOCKTIME_NS_TO_US(lock_wait_time));
+    }
 
     /*
      * We got the queue lock, which should be fast, and chose a queue. Now we want to get the lock

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2881,15 +2881,15 @@ __evict_get_ref(WT_SESSION_IMPL *session, bool is_server, WT_BTREE **btreep, WT_
         __evict_queue_empty(evict->evict_fill_queue, false)))
         return (WT_NOTFOUND);
 
-    uint64_t lock_wait_start, lock_wait_time;
+    uint64_t lock_wait_start, lock_wait_end;
     /* Track time spent waiting for the evict queue lock */
     lock_wait_start = __wt_clock(session);
     __wt_spin_lock(session, &evict->evict_queue_lock);
-    lock_wait_time = __wt_clock(session) - lock_wait_start;
+    lock_wait_end = __wt_clock(session);
 
     /* Only track lock wait time for eviction server threads */
     if (is_server) {
-        __wt_atomic_add64(&evict->evict_lock_wait_time, WT_CLOCKTIME_NS_TO_US(lock_wait_time));
+        __wt_atomic_add_uint64_v(&evict->evict_lock_wait_time, WT_CLOCKDIFF_US(lock_wait_end, lock_wait_start));
     }
 
     /* Check the urgent queue first. */
@@ -2914,10 +2914,10 @@ __evict_get_ref(WT_SESSION_IMPL *session, bool is_server, WT_BTREE **btreep, WT_
     /* Track time waiting for the lock when releasing it too */
     lock_wait_start = __wt_clock(session);
     __wt_spin_unlock(session, &evict->evict_queue_lock);
-    lock_wait_time = __wt_clock(session) - lock_wait_start;
+    lock_wait_end = __wt_clock(session);
 
     if (is_server) {
-        __wt_atomic_add64(&evict->evict_lock_wait_time, WT_CLOCKTIME_NS_TO_US(lock_wait_time));
+        __wt_atomic_add_uint64_v(&evict->evict_lock_wait_time, WT_CLOCKDIFF_US(lock_wait_end, lock_wait_start));
     }
 
     /*

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -742,6 +742,7 @@ struct __wt_connection_stats {
     int64_t cache_read_restored_tombstone_bytes;
     int64_t cache_hs_insert_full_update;
     int64_t cache_hs_insert_reverse_modify;
+    int64_t eviction_worker_lock_wait_time;
     int64_t eviction_reentry_hs_eviction_milliseconds;
     int64_t cache_bytes_internal;
     int64_t cache_bytes_internal_ingest;

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -7016,1644 +7016,1646 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1318
 /*! cache: the number of times reverse modify inserted to history store */
 #define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1319
+/*! cache: time eviction worker threads spend waiting for locks (usecs) */
+#define	WT_STAT_CONN_EVICTION_WORKER_LOCK_WAIT_TIME	1320
 /*!
  * cache: total milliseconds spent inside reentrant history store
  * evictions in a reconciliation
  */
-#define	WT_STAT_CONN_EVICTION_REENTRY_HS_EVICTION_MILLISECONDS	1320
+#define	WT_STAT_CONN_EVICTION_REENTRY_HS_EVICTION_MILLISECONDS	1321
 /*! cache: tracked bytes belonging to internal pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1321
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1322
 /*!
  * cache: tracked bytes belonging to internal pages in the cache from the
  * ingest btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL_INGEST	1322
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL_INGEST	1323
 /*!
  * cache: tracked bytes belonging to internal pages in the cache from the
  * stable btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL_STABLE	1323
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL_STABLE	1324
 /*! cache: tracked bytes belonging to leaf pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1324
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1325
 /*!
  * cache: tracked bytes belonging to leaf pages in the cache from the
  * ingest btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF_INGEST		1325
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF_INGEST		1326
 /*!
  * cache: tracked bytes belonging to leaf pages in the cache from the
  * stable btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF_STABLE		1326
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF_STABLE		1327
 /*! cache: tracked dirty bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1327
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1328
 /*! cache: tracked dirty bytes in the cache from the ingest btrees */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INGEST		1328
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INGEST		1329
 /*! cache: tracked dirty bytes in the cache from the stable btrees */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_STABLE		1329
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_STABLE		1330
 /*! cache: tracked dirty internal page bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL		1330
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL		1331
 /*!
  * cache: tracked dirty internal page bytes in the cache from the ingest
  * btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL_INGEST	1331
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL_INGEST	1332
 /*!
  * cache: tracked dirty internal page bytes in the cache from the stable
  * btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL_STABLE	1332
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL_STABLE	1333
 /*! cache: tracked dirty leaf page bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF		1333
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF		1334
 /*!
  * cache: tracked dirty leaf page bytes in the cache from the ingest
  * btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF_INGEST	1334
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF_INGEST	1335
 /*!
  * cache: tracked dirty leaf page bytes in the cache from the stable
  * btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF_STABLE	1335
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF_STABLE	1336
 /*! cache: tracked dirty pages in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1336
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1337
 /*! cache: tracked dirty pages in the cache from the ingest btrees */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY_INGEST		1337
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY_INGEST		1338
 /*! cache: tracked dirty pages in the cache from the stable btrees */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY_STABLE		1338
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY_STABLE		1339
 /*! cache: uncommitted truncate blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	1339
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	1340
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1340
+#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1341
 /*! cache: update bytes belonging to the history store table in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_HS_UPDATES		1341
+#define	WT_STAT_CONN_CACHE_BYTES_HS_UPDATES		1342
 /*! cache: updates in uncommitted txn - bytes */
-#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_BYTES	1342
+#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_BYTES	1343
 /*! cache: updates in uncommitted txn - count */
-#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_COUNT	1343
+#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_COUNT	1344
 /*! capacity: background fsync file handles considered */
-#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1344
+#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1345
 /*! capacity: background fsync file handles synced */
-#define	WT_STAT_CONN_FSYNC_ALL_FH			1345
+#define	WT_STAT_CONN_FSYNC_ALL_FH			1346
 /*! capacity: background fsync time (msecs) */
-#define	WT_STAT_CONN_FSYNC_ALL_TIME			1346
+#define	WT_STAT_CONN_FSYNC_ALL_TIME			1347
 /*! capacity: bytes read */
-#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1347
+#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1348
 /*! capacity: bytes written for checkpoint */
-#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1348
+#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1349
 /*! capacity: bytes written for chunk cache */
-#define	WT_STAT_CONN_CAPACITY_BYTES_CHUNKCACHE		1349
+#define	WT_STAT_CONN_CAPACITY_BYTES_CHUNKCACHE		1350
 /*! capacity: bytes written for eviction */
-#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1350
+#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1351
 /*! capacity: bytes written for log */
-#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1351
+#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1352
 /*! capacity: bytes written total */
-#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1352
+#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1353
 /*! capacity: threshold to call fsync */
-#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1353
+#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1354
 /*! capacity: time waiting due to total capacity (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1354
+#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1355
 /*! capacity: time waiting during checkpoint (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1355
+#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1356
 /*! capacity: time waiting during eviction (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1356
+#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1357
 /*! capacity: time waiting during logging (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1357
+#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1358
 /*! capacity: time waiting during read (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_READ			1358
+#define	WT_STAT_CONN_CAPACITY_TIME_READ			1359
 /*! capacity: time waiting for chunk cache IO bandwidth (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_CHUNKCACHE		1359
+#define	WT_STAT_CONN_CAPACITY_TIME_CHUNKCACHE		1360
 /*! checkpoint: checkpoint cleanup successful calls */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_SUCCESS		1360
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_SUCCESS		1361
 /*! checkpoint: checkpoint has acquired a snapshot for its transaction */
-#define	WT_STAT_CONN_CHECKPOINT_SNAPSHOT_ACQUIRED	1361
+#define	WT_STAT_CONN_CHECKPOINT_SNAPSHOT_ACQUIRED	1362
 /*! checkpoint: checkpoints skipped because database was clean */
-#define	WT_STAT_CONN_CHECKPOINT_SKIPPED			1362
+#define	WT_STAT_CONN_CHECKPOINT_SKIPPED			1363
 /*! checkpoint: fsync calls after allocating the transaction ID */
-#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST		1363
+#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST		1364
 /*! checkpoint: fsync duration after allocating the transaction ID (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST_DURATION	1364
+#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST_DURATION	1365
 /*! checkpoint: generation */
-#define	WT_STAT_CONN_CHECKPOINT_GENERATION		1365
+#define	WT_STAT_CONN_CHECKPOINT_GENERATION		1366
 /*! checkpoint: max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_MAX		1366
+#define	WT_STAT_CONN_CHECKPOINT_TIME_MAX		1367
 /*! checkpoint: min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_MIN		1367
+#define	WT_STAT_CONN_CHECKPOINT_TIME_MIN		1368
 /*!
  * checkpoint: most recent duration for checkpoint dropping all handles
  * (usecs)
  */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROP_DURATION	1368
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROP_DURATION	1369
 /*! checkpoint: most recent duration for gathering all handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION		1369
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION		1370
 /*! checkpoint: most recent duration for gathering applied handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLY_DURATION	1370
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLY_DURATION	1371
 /*! checkpoint: most recent duration for gathering skipped handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIP_DURATION	1371
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIP_DURATION	1372
 /*! checkpoint: most recent duration for handles metadata checked (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECK_DURATION	1372
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECK_DURATION	1373
 /*! checkpoint: most recent duration for locking the handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCK_DURATION	1373
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCK_DURATION	1374
 /*! checkpoint: most recent handles applied */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLIED		1374
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLIED		1375
 /*! checkpoint: most recent handles checkpoint dropped */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROPPED		1375
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROPPED		1376
 /*! checkpoint: most recent handles metadata checked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECKED	1376
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECKED	1377
 /*! checkpoint: most recent handles metadata locked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCKED		1377
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCKED		1378
 /*! checkpoint: most recent handles skipped */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIPPED		1378
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIPPED		1379
 /*! checkpoint: most recent handles walked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_WALKED		1379
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_WALKED		1380
 /*! checkpoint: most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_RECENT		1380
+#define	WT_STAT_CONN_CHECKPOINT_TIME_RECENT		1381
 /*! checkpoint: number of bytes caused to be reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED_BYTES	1381
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED_BYTES	1382
 /*! checkpoint: number of checkpoints started by api */
-#define	WT_STAT_CONN_CHECKPOINTS_API			1382
+#define	WT_STAT_CONN_CHECKPOINTS_API			1383
 /*! checkpoint: number of checkpoints started by compaction */
-#define	WT_STAT_CONN_CHECKPOINTS_COMPACT		1383
+#define	WT_STAT_CONN_CHECKPOINTS_COMPACT		1384
 /*! checkpoint: number of files synced */
-#define	WT_STAT_CONN_CHECKPOINT_SYNC			1384
+#define	WT_STAT_CONN_CHECKPOINT_SYNC			1385
 /*! checkpoint: number of handles visited after writes complete */
-#define	WT_STAT_CONN_CHECKPOINT_PRESYNC			1385
+#define	WT_STAT_CONN_CHECKPOINT_PRESYNC			1386
 /*! checkpoint: number of history store pages caused to be reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_HS_PAGES_RECONCILED	1386
+#define	WT_STAT_CONN_CHECKPOINT_HS_PAGES_RECONCILED	1387
 /*! checkpoint: number of internal pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_INTERNAL	1387
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_INTERNAL	1388
 /*! checkpoint: number of leaf pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_LEAF	1388
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_LEAF	1389
 /*! checkpoint: number of pages caused to be reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED	1389
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED	1390
 /*! checkpoint: pages added for eviction during checkpoint cleanup */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_EVICT	1390
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_EVICT	1391
 /*!
  * checkpoint: pages dirtied due to obsolete time window by checkpoint
  * cleanup
  */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	1391
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	1392
 /*!
  * checkpoint: pages read into cache during checkpoint cleanup
  * (reclaim_space)
  */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	1392
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	1393
 /*!
  * checkpoint: pages read into cache during checkpoint cleanup due to
  * obsolete time window
  */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	1393
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	1394
 /*! checkpoint: pages removed during checkpoint cleanup */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_REMOVED	1394
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_REMOVED	1395
 /*! checkpoint: pages skipped during checkpoint cleanup tree walk */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	1395
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	1396
 /*! checkpoint: pages visited during checkpoint cleanup */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_VISITED	1396
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_VISITED	1397
 /*! checkpoint: prepare currently running */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1397
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1398
 /*! checkpoint: prepare max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1398
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1399
 /*! checkpoint: prepare min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1399
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1400
 /*! checkpoint: prepare most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1400
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1401
 /*! checkpoint: prepare total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1401
+#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1402
 /*! checkpoint: progress state */
-#define	WT_STAT_CONN_CHECKPOINT_STATE			1402
+#define	WT_STAT_CONN_CHECKPOINT_STATE			1403
 /*! checkpoint: scrub dirty target */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1403
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1404
 /*! checkpoint: scrub max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1404
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1405
 /*! checkpoint: scrub min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1405
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1406
 /*! checkpoint: scrub most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1406
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1407
 /*! checkpoint: scrub total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1407
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1408
 /*! checkpoint: stop timing stress active */
-#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1408
+#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1409
 /*! checkpoint: time spent on per-tree checkpoint work (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1409
+#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1410
 /*! checkpoint: total failed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1410
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1411
 /*! checkpoint: total succeed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1411
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1412
 /*! checkpoint: total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1412
+#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1413
 /*! checkpoint: wait cycles while cache dirty level is decreasing */
-#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1413
+#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1414
 /*! chunk-cache: aggregate number of spanned chunks on read */
-#define	WT_STAT_CONN_CHUNKCACHE_SPANS_CHUNKS_READ	1414
+#define	WT_STAT_CONN_CHUNKCACHE_SPANS_CHUNKS_READ	1415
 /*! chunk-cache: chunks evicted */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_EVICTED		1415
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_EVICTED		1416
 /*! chunk-cache: could not allocate due to exceeding bitmap capacity */
-#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_BITMAP_CAPACITY	1416
+#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_BITMAP_CAPACITY	1417
 /*! chunk-cache: could not allocate due to exceeding capacity */
-#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_CAPACITY	1417
+#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_CAPACITY	1418
 /*! chunk-cache: lookups */
-#define	WT_STAT_CONN_CHUNKCACHE_LOOKUPS			1418
+#define	WT_STAT_CONN_CHUNKCACHE_LOOKUPS			1419
 /*!
  * chunk-cache: number of chunks loaded from flushed tables in chunk
  * cache
  */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_LOADED_FROM_FLUSHED_TABLES	1419
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_LOADED_FROM_FLUSHED_TABLES	1420
 /*! chunk-cache: number of metadata entries inserted */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_INSERTED	1420
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_INSERTED	1421
 /*! chunk-cache: number of metadata entries removed */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_REMOVED	1421
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_REMOVED	1422
 /*!
  * chunk-cache: number of metadata inserts/deletes dropped by the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DROPPED	1422
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DROPPED	1423
 /*!
  * chunk-cache: number of metadata inserts/deletes pushed to the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_CREATED	1423
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_CREATED	1424
 /*!
  * chunk-cache: number of metadata inserts/deletes read by the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DEQUEUED	1424
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DEQUEUED	1425
 /*! chunk-cache: number of misses */
-#define	WT_STAT_CONN_CHUNKCACHE_MISSES			1425
+#define	WT_STAT_CONN_CHUNKCACHE_MISSES			1426
 /*! chunk-cache: number of times a read from storage failed */
-#define	WT_STAT_CONN_CHUNKCACHE_IO_FAILED		1426
+#define	WT_STAT_CONN_CHUNKCACHE_IO_FAILED		1427
 /*! chunk-cache: retried accessing a chunk while I/O was in progress */
-#define	WT_STAT_CONN_CHUNKCACHE_RETRIES			1427
+#define	WT_STAT_CONN_CHUNKCACHE_RETRIES			1428
 /*! chunk-cache: retries from a chunk cache checksum mismatch */
-#define	WT_STAT_CONN_CHUNKCACHE_RETRIES_CHECKSUM_MISMATCH	1428
+#define	WT_STAT_CONN_CHUNKCACHE_RETRIES_CHECKSUM_MISMATCH	1429
 /*! chunk-cache: timed out due to too many retries */
-#define	WT_STAT_CONN_CHUNKCACHE_TOOMANY_RETRIES		1429
+#define	WT_STAT_CONN_CHUNKCACHE_TOOMANY_RETRIES		1430
 /*! chunk-cache: total bytes read from persistent content */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_READ_PERSISTENT	1430
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_READ_PERSISTENT	1431
 /*! chunk-cache: total bytes used by the cache */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE		1431
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE		1432
 /*! chunk-cache: total bytes used by the cache for pinned chunks */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE_PINNED	1432
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE_PINNED	1433
 /*! chunk-cache: total chunks held by the chunk cache */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_INUSE		1433
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_INUSE		1434
 /*!
  * chunk-cache: total number of chunks inserted on startup from persisted
  * metadata.
  */
-#define	WT_STAT_CONN_CHUNKCACHE_CREATED_FROM_METADATA	1434
+#define	WT_STAT_CONN_CHUNKCACHE_CREATED_FROM_METADATA	1435
 /*! chunk-cache: total pinned chunks held by the chunk cache */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_PINNED		1435
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_PINNED		1436
 /*! connection: auto adjusting condition resets */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1436
+#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1437
 /*! connection: auto adjusting condition wait calls */
-#define	WT_STAT_CONN_COND_AUTO_WAIT			1437
+#define	WT_STAT_CONN_COND_AUTO_WAIT			1438
 /*!
  * connection: auto adjusting condition wait raced to update timeout and
  * skipped updating
  */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1438
+#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1439
 /*! connection: detected system time went backwards */
-#define	WT_STAT_CONN_TIME_TRAVEL			1439
+#define	WT_STAT_CONN_TIME_TRAVEL			1440
 /*! connection: files currently open */
-#define	WT_STAT_CONN_FILE_OPEN				1440
+#define	WT_STAT_CONN_FILE_OPEN				1441
 /*! connection: hash bucket array size for data handles */
-#define	WT_STAT_CONN_BUCKETS_DH				1441
+#define	WT_STAT_CONN_BUCKETS_DH				1442
 /*! connection: hash bucket array size general */
-#define	WT_STAT_CONN_BUCKETS				1442
+#define	WT_STAT_CONN_BUCKETS				1443
 /*! connection: memory allocations */
-#define	WT_STAT_CONN_MEMORY_ALLOCATION			1443
+#define	WT_STAT_CONN_MEMORY_ALLOCATION			1444
 /*! connection: memory frees */
-#define	WT_STAT_CONN_MEMORY_FREE			1444
+#define	WT_STAT_CONN_MEMORY_FREE			1445
 /*! connection: memory re-allocations */
-#define	WT_STAT_CONN_MEMORY_GROW			1445
+#define	WT_STAT_CONN_MEMORY_GROW			1446
 /*! connection: number of sessions without a sweep for 5+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1446
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1447
 /*! connection: number of sessions without a sweep for 60+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1447
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1448
 /*! connection: pthread mutex condition wait calls */
-#define	WT_STAT_CONN_COND_WAIT				1448
+#define	WT_STAT_CONN_COND_WAIT				1449
 /*! connection: pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			1449
+#define	WT_STAT_CONN_RWLOCK_READ			1450
 /*! connection: pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			1450
+#define	WT_STAT_CONN_RWLOCK_WRITE			1451
 /*! connection: total fsync I/Os */
-#define	WT_STAT_CONN_FSYNC_IO				1451
+#define	WT_STAT_CONN_FSYNC_IO				1452
 /*! connection: total read I/Os */
-#define	WT_STAT_CONN_READ_IO				1452
+#define	WT_STAT_CONN_READ_IO				1453
 /*! connection: total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				1453
+#define	WT_STAT_CONN_WRITE_IO				1454
 /*! cursor: Total number of deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1454
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1455
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1455
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1456
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1456
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1457
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1457
+#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1458
 /*!
  * cursor: Total number of in-memory deleted pages skipped during tree
  * walk
  */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1458
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1459
 /*! cursor: Total number of on-disk deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1459
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1460
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1460
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1461
 /*!
  * cursor: Total number of times cursor fails to temporarily release
  * pinned page to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1461
+#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1462
 /*!
  * cursor: Total number of times cursor temporarily releases pinned page
  * to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION			1462
+#define	WT_STAT_CONN_CURSOR_REPOSITION			1463
 /*! cursor: bulk cursor count */
-#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1463
+#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1464
 /*! cursor: cached cursor count */
-#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1464
+#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1465
 /*! cursor: cursor bound calls that return an error */
-#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1465
+#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1466
 /*! cursor: cursor bounds cleared from reset */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1466
+#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1467
 /*! cursor: cursor bounds comparisons performed */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1467
+#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1468
 /*! cursor: cursor bounds next called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1468
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1469
 /*! cursor: cursor bounds next early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1469
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1470
 /*! cursor: cursor bounds prev called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1470
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1471
 /*! cursor: cursor bounds prev early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1471
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1472
 /*! cursor: cursor bounds search early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1472
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1473
 /*! cursor: cursor bounds search near call repositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1473
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1474
 /*! cursor: cursor bulk loaded cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1474
+#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1475
 /*! cursor: cursor cache calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1475
+#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1476
 /*! cursor: cursor close calls that result in cache */
-#define	WT_STAT_CONN_CURSOR_CACHE			1476
+#define	WT_STAT_CONN_CURSOR_CACHE			1477
 /*! cursor: cursor close calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1477
+#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1478
 /*! cursor: cursor compare calls that return an error */
-#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1478
+#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1479
 /*! cursor: cursor create calls */
-#define	WT_STAT_CONN_CURSOR_CREATE			1479
+#define	WT_STAT_CONN_CURSOR_CREATE			1480
 /*! cursor: cursor equals calls that return an error */
-#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1480
+#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1481
 /*! cursor: cursor get key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1481
+#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1482
 /*! cursor: cursor get value calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1482
+#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1483
 /*! cursor: cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT			1483
+#define	WT_STAT_CONN_CURSOR_INSERT			1484
 /*! cursor: cursor insert calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1484
+#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1485
 /*! cursor: cursor insert check calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1485
+#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1486
 /*! cursor: cursor insert key and value bytes */
-#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1486
+#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1487
 /*! cursor: cursor largest key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1487
+#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1488
 /*! cursor: cursor modify calls */
-#define	WT_STAT_CONN_CURSOR_MODIFY			1488
+#define	WT_STAT_CONN_CURSOR_MODIFY			1489
 /*! cursor: cursor modify calls that return an error */
-#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1489
+#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1490
 /*! cursor: cursor modify key and value bytes affected */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1490
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1491
 /*! cursor: cursor modify value bytes modified */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1491
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1492
 /*! cursor: cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT			1492
+#define	WT_STAT_CONN_CURSOR_NEXT			1493
 /*! cursor: cursor next calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1493
+#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1494
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1494
+#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1495
 /*!
  * cursor: cursor next calls that skip greater than 1 and fewer than 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1495
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1496
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1496
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1497
 /*! cursor: cursor next random calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1497
+#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1498
 /*! cursor: cursor operation restarted */
-#define	WT_STAT_CONN_CURSOR_RESTART			1498
+#define	WT_STAT_CONN_CURSOR_RESTART			1499
 /*! cursor: cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV			1499
+#define	WT_STAT_CONN_CURSOR_PREV			1500
 /*! cursor: cursor prev calls that return an error */
-#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1500
+#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1501
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1501
+#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1502
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1502
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1503
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1503
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1504
 /*! cursor: cursor reconfigure calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1504
+#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1505
 /*! cursor: cursor remove calls */
-#define	WT_STAT_CONN_CURSOR_REMOVE			1505
+#define	WT_STAT_CONN_CURSOR_REMOVE			1506
 /*! cursor: cursor remove calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1506
+#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1507
 /*! cursor: cursor remove key bytes removed */
-#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1507
+#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1508
 /*! cursor: cursor reopen calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1508
+#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1509
 /*! cursor: cursor reserve calls */
-#define	WT_STAT_CONN_CURSOR_RESERVE			1509
+#define	WT_STAT_CONN_CURSOR_RESERVE			1510
 /*! cursor: cursor reserve calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1510
+#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1511
 /*! cursor: cursor reset calls */
-#define	WT_STAT_CONN_CURSOR_RESET			1511
+#define	WT_STAT_CONN_CURSOR_RESET			1512
 /*! cursor: cursor reset calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1512
+#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1513
 /*! cursor: cursor search calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH			1513
+#define	WT_STAT_CONN_CURSOR_SEARCH			1514
 /*! cursor: cursor search calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1514
+#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1515
 /*! cursor: cursor search history store calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1515
+#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1516
 /*! cursor: cursor search near calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1516
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1517
 /*! cursor: cursor search near calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1517
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1518
 /*! cursor: cursor sweep buckets */
-#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1518
+#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1519
 /*! cursor: cursor sweep cursors closed */
-#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1519
+#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1520
 /*! cursor: cursor sweep cursors examined */
-#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1520
+#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1521
 /*! cursor: cursor sweeps */
-#define	WT_STAT_CONN_CURSOR_SWEEP			1521
+#define	WT_STAT_CONN_CURSOR_SWEEP			1522
 /*! cursor: cursor truncate calls */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE			1522
+#define	WT_STAT_CONN_CURSOR_TRUNCATE			1523
 /*! cursor: cursor truncates performed on individual keys */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1523
+#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1524
 /*! cursor: cursor update calls */
-#define	WT_STAT_CONN_CURSOR_UPDATE			1524
+#define	WT_STAT_CONN_CURSOR_UPDATE			1525
 /*! cursor: cursor update calls that return an error */
-#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1525
+#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1526
 /*! cursor: cursor update key and value bytes */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1526
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1527
 /*! cursor: cursor update value size change */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1527
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1528
 /*! cursor: cursors reused from cache */
-#define	WT_STAT_CONN_CURSOR_REOPEN			1528
+#define	WT_STAT_CONN_CURSOR_REOPEN			1529
 /*! cursor: open cursor count */
-#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1529
+#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1530
 /*! cursor: open cursor time application (usecs) */
-#define	WT_STAT_CONN_CURSOR_OPEN_TIME_USER_USECS	1530
+#define	WT_STAT_CONN_CURSOR_OPEN_TIME_USER_USECS	1531
 /*! cursor: open cursor time internal (usecs) */
-#define	WT_STAT_CONN_CURSOR_OPEN_TIME_INTERNAL_USECS	1531
+#define	WT_STAT_CONN_CURSOR_OPEN_TIME_INTERNAL_USECS	1532
 /*! data-handle: Table connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TABLE_COUNT		1532
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TABLE_COUNT		1533
 /*! data-handle: Tiered connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_COUNT	1533
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_COUNT	1534
 /*! data-handle: Tiered_Tree connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_TREE_COUNT	1534
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_TREE_COUNT	1535
 /*! data-handle: btree connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_BTREE_COUNT		1535
+#define	WT_STAT_CONN_DH_CONN_HANDLE_BTREE_COUNT		1536
 /*! data-handle: checkpoint connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_CHECKPOINT_COUNT	1536
+#define	WT_STAT_CONN_DH_CONN_HANDLE_CHECKPOINT_COUNT	1537
 /*! data-handle: connection data handle size */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1537
+#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1538
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1538
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1539
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1539
+#define	WT_STAT_CONN_DH_SWEEP_REF			1540
 /*! data-handle: connection sweep dead dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_DEAD_CLOSE		1540
+#define	WT_STAT_CONN_DH_SWEEP_DEAD_CLOSE		1541
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1541
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1542
 /*! data-handle: connection sweep expired dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_EXPIRED_CLOSE		1542
+#define	WT_STAT_CONN_DH_SWEEP_EXPIRED_CLOSE		1543
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1543
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1544
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1544
+#define	WT_STAT_CONN_DH_SWEEPS				1545
 /*!
  * data-handle: connection sweeps skipped due to checkpoint gathering
  * handles
  */
-#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1545
+#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1546
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1546
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1547
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1547
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1548
 /*! disagg: role leader */
-#define	WT_STAT_CONN_DISAGG_ROLE_LEADER			1548
+#define	WT_STAT_CONN_DISAGG_ROLE_LEADER			1549
 /*! disagg: step down most recent time (msecs) */
-#define	WT_STAT_CONN_DISAGG_STEP_DOWN_TIME		1549
+#define	WT_STAT_CONN_DISAGG_STEP_DOWN_TIME		1550
 /*! disagg: step up most recent time (msecs) */
-#define	WT_STAT_CONN_DISAGG_STEP_UP_TIME		1550
+#define	WT_STAT_CONN_DISAGG_STEP_UP_TIME		1551
 /*! layered: Layered table cursor insert operations */
-#define	WT_STAT_CONN_LAYERED_CURS_INSERT		1551
+#define	WT_STAT_CONN_LAYERED_CURS_INSERT		1552
 /*! layered: Layered table cursor next operations */
-#define	WT_STAT_CONN_LAYERED_CURS_NEXT			1552
+#define	WT_STAT_CONN_LAYERED_CURS_NEXT			1553
 /*! layered: Layered table cursor next operations from the ingest btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_NEXT_INGEST		1553
+#define	WT_STAT_CONN_LAYERED_CURS_NEXT_INGEST		1554
 /*! layered: Layered table cursor next operations from the stable btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_NEXT_STABLE		1554
+#define	WT_STAT_CONN_LAYERED_CURS_NEXT_STABLE		1555
 /*! layered: Layered table cursor prev operations */
-#define	WT_STAT_CONN_LAYERED_CURS_PREV			1555
+#define	WT_STAT_CONN_LAYERED_CURS_PREV			1556
 /*! layered: Layered table cursor prev operations from the ingest btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_PREV_INGEST		1556
+#define	WT_STAT_CONN_LAYERED_CURS_PREV_INGEST		1557
 /*! layered: Layered table cursor prev operations from the stable btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_PREV_STABLE		1557
+#define	WT_STAT_CONN_LAYERED_CURS_PREV_STABLE		1558
 /*! layered: Layered table cursor remove operations */
-#define	WT_STAT_CONN_LAYERED_CURS_REMOVE		1558
+#define	WT_STAT_CONN_LAYERED_CURS_REMOVE		1559
 /*! layered: Layered table cursor search near operations */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR		1559
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR		1560
 /*!
  * layered: Layered table cursor search near operations from the ingest
  * btrees
  */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_INGEST	1560
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_INGEST	1561
 /*!
  * layered: Layered table cursor search near operations from the stable
  * btrees
  */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_STABLE	1561
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_STABLE	1562
 /*! layered: Layered table cursor search operations */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH		1562
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH		1563
 /*! layered: Layered table cursor search operations from the ingest btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_INGEST		1563
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_INGEST		1564
 /*! layered: Layered table cursor search operations from the stable btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_STABLE		1564
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_STABLE		1565
 /*! layered: Layered table cursor update operations */
-#define	WT_STAT_CONN_LAYERED_CURS_UPDATE		1565
+#define	WT_STAT_CONN_LAYERED_CURS_UPDATE		1566
 /*! layered: Layered table cursor upgrade state for the ingest btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_UPGRADE_INGEST	1566
+#define	WT_STAT_CONN_LAYERED_CURS_UPGRADE_INGEST	1567
 /*! layered: Layered table cursor upgrade state for the stable btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_UPGRADE_STABLE	1567
+#define	WT_STAT_CONN_LAYERED_CURS_UPGRADE_STABLE	1568
 /*!
  * layered: checkpoints performed on this table by the layered table
  * manager
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS	1568
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS	1569
 /*! layered: disagg pick up checkpoints failed */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FAILED	1569
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FAILED	1570
 /*! layered: disagg pick up checkpoints succeeded */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_SUCCEED	1570
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_SUCCEED	1571
 /*!
  * layered: how many log applications the layered table manager applied
  * on this tree
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_APPLIED	1571
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_APPLIED	1572
 /*!
  * layered: how many log applications the layered table manager skipped
  * on this tree
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_SKIPPED	1572
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_SKIPPED	1573
 /*!
  * layered: how many previously-applied LSNs the layered table manager
  * skipped on this tree
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_SKIP_LSN	1573
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_SKIP_LSN	1574
 /*! layered: the number of tables the layered table manager has open */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_TABLES	1574
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_TABLES	1575
 /*!
  * live-restore: number of bytes copied from the source to the
  * destination
  */
-#define	WT_STAT_CONN_LIVE_RESTORE_BYTES_COPIED		1575
+#define	WT_STAT_CONN_LIVE_RESTORE_BYTES_COPIED		1576
 /*! live-restore: number of files remaining for migration completion */
-#define	WT_STAT_CONN_LIVE_RESTORE_WORK_REMAINING	1576
+#define	WT_STAT_CONN_LIVE_RESTORE_WORK_REMAINING	1577
 /*! live-restore: number of reads from the source database */
-#define	WT_STAT_CONN_LIVE_RESTORE_SOURCE_READ_COUNT	1577
+#define	WT_STAT_CONN_LIVE_RESTORE_SOURCE_READ_COUNT	1578
 /*! live-restore: source read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT2	1578
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT2	1579
 /*! live-restore: source read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT5	1579
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT5	1580
 /*! live-restore: source read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT10	1580
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT10	1581
 /*! live-restore: source read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT50	1581
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT50	1582
 /*! live-restore: source read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT100	1582
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT100	1583
 /*! live-restore: source read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT250	1583
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT250	1584
 /*! live-restore: source read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT500	1584
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT500	1585
 /*! live-restore: source read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT1000	1585
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT1000	1586
 /*! live-restore: source read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_GT1000	1586
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_GT1000	1587
 /*! live-restore: source read latency histogram total (msecs) */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_TOTAL_MSECS	1587
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_TOTAL_MSECS	1588
 /*! live-restore: state */
-#define	WT_STAT_CONN_LIVE_RESTORE_STATE			1588
+#define	WT_STAT_CONN_LIVE_RESTORE_STATE			1589
 /*! lock: btree page lock acquisitions */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_COUNT		1589
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_COUNT		1590
 /*! lock: btree page lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_APPLICATION	1590
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_APPLICATION	1591
 /*! lock: btree page lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_INTERNAL	1591
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_INTERNAL	1592
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1592
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1593
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1593
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1594
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1594
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1595
 /*! lock: dhandle lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1595
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1596
 /*! lock: dhandle lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1596
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1597
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1597
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1598
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1598
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1599
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1599
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1600
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1600
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1601
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1601
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1602
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1602
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1603
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1603
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1604
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1604
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1605
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1605
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1606
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1606
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1607
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1607
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1608
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1608
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1609
 /*! lock: txn global lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1609
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1610
 /*! lock: txn global lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1610
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1611
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1611
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1612
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1612
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1613
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1613
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1614
 /*! log: force log remove time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1614
+#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1615
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1615
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1616
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1616
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1617
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1617
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1618
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1618
+#define	WT_STAT_CONN_LOG_FLUSH				1619
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1619
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1620
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1620
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1621
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1621
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1622
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1622
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1623
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1623
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1624
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1624
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1625
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1625
+#define	WT_STAT_CONN_LOG_SCANS				1626
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1626
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1627
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1627
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1628
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1628
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1629
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1629
+#define	WT_STAT_CONN_LOG_SYNC				1630
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1630
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1631
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1631
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1632
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1632
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1633
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1633
+#define	WT_STAT_CONN_LOG_WRITES				1634
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1634
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1635
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1635
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1636
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1636
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1637
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1637
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1638
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1638
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1639
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1639
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1640
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1640
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1641
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1641
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1642
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1642
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1643
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1643
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1644
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1644
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1645
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1645
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1646
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1646
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1647
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1647
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1648
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1648
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1649
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1649
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1650
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1650
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1651
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1651
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1652
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1652
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1653
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1653
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1654
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1654
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1655
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1655
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1656
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1656
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1657
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1657
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1658
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1658
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1659
 /*! perf: block manager read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT2	1659
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT2	1660
 /*! perf: block manager read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT5	1660
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT5	1661
 /*! perf: block manager read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT10	1661
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT10	1662
 /*! perf: block manager read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT50	1662
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT50	1663
 /*! perf: block manager read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT100	1663
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT100	1664
 /*! perf: block manager read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT250	1664
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT250	1665
 /*! perf: block manager read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT500	1665
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT500	1666
 /*! perf: block manager read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT1000	1666
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT1000	1667
 /*! perf: block manager read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_GT1000	1667
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_GT1000	1668
 /*! perf: block manager read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_TOTAL_MSECS	1668
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_TOTAL_MSECS	1669
 /*! perf: block manager write latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT2	1669
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT2	1670
 /*! perf: block manager write latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT5	1670
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT5	1671
 /*! perf: block manager write latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT10	1671
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT10	1672
 /*! perf: block manager write latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT50	1672
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT50	1673
 /*! perf: block manager write latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT100	1673
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT100	1674
 /*! perf: block manager write latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT250	1674
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT250	1675
 /*! perf: block manager write latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT500	1675
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT500	1676
 /*! perf: block manager write latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT1000	1676
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT1000	1677
 /*! perf: block manager write latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_GT1000	1677
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_GT1000	1678
 /*! perf: block manager write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_TOTAL_MSECS	1678
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_TOTAL_MSECS	1679
 /*! perf: disagg block manager read latency histogram (bucket 1) - 50-99us */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT100	1679
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT100	1680
 /*!
  * perf: disagg block manager read latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT250	1680
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT250	1681
 /*!
  * perf: disagg block manager read latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT500	1681
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT500	1682
 /*!
  * perf: disagg block manager read latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT1000	1682
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT1000	1683
 /*!
  * perf: disagg block manager read latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT2500	1683
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT2500	1684
 /*!
  * perf: disagg block manager read latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT5000	1684
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT5000	1685
 /*!
  * perf: disagg block manager read latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT10000	1685
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT10000	1686
 /*!
  * perf: disagg block manager read latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_GT10000	1686
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_GT10000	1687
 /*! perf: disagg block manager read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_TOTAL_USECS	1687
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_TOTAL_USECS	1688
 /*!
  * perf: disagg block manager write latency histogram (bucket 1) -
  * 50-99us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT100	1688
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT100	1689
 /*!
  * perf: disagg block manager write latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT250	1689
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT250	1690
 /*!
  * perf: disagg block manager write latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT500	1690
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT500	1691
 /*!
  * perf: disagg block manager write latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT1000	1691
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT1000	1692
 /*!
  * perf: disagg block manager write latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT2500	1692
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT2500	1693
 /*!
  * perf: disagg block manager write latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT5000	1693
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT5000	1694
 /*!
  * perf: disagg block manager write latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT10000	1694
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT10000	1695
 /*!
  * perf: disagg block manager write latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_GT10000	1695
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_GT10000	1696
 /*! perf: disagg block manager write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_TOTAL_USECS	1696
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_TOTAL_USECS	1697
 /*! perf: file system read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT2	1697
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT2	1698
 /*! perf: file system read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT5	1698
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT5	1699
 /*! perf: file system read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1699
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1700
 /*! perf: file system read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1700
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1701
 /*! perf: file system read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1701
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1702
 /*! perf: file system read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1702
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1703
 /*! perf: file system read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1703
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1704
 /*! perf: file system read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1704
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1705
 /*! perf: file system read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1705
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1706
 /*! perf: file system read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1706
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1707
 /*! perf: file system write latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT2	1707
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT2	1708
 /*! perf: file system write latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT5	1708
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT5	1709
 /*! perf: file system write latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1709
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1710
 /*! perf: file system write latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1710
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1711
 /*! perf: file system write latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1711
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1712
 /*! perf: file system write latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1712
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1713
 /*! perf: file system write latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1713
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1714
 /*! perf: file system write latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1714
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1715
 /*! perf: file system write latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1715
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1716
 /*! perf: file system write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1716
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1717
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 1) -
  * 0-100us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT100	1717
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT100	1718
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT250	1718
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT250	1719
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT500	1719
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT500	1720
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT1000	1720
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT1000	1721
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT2500	1721
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT2500	1722
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT5000	1722
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT5000	1723
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT10000	1723
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT10000	1724
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_GT10000	1724
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_GT10000	1725
 /*! perf: internal page deltas reconstruct latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_TOTAL_USECS	1725
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_TOTAL_USECS	1726
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 1) -
  * 0-100us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT100	1726
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT100	1727
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT250	1727
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT250	1728
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT500	1728
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT500	1729
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT1000	1729
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT1000	1730
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT2500	1730
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT2500	1731
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT5000	1731
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT5000	1732
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT10000	1732
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT10000	1733
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_GT10000	1733
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_GT10000	1734
 /*! perf: leaf page deltas reconstruct latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_TOTAL_USECS	1734
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_TOTAL_USECS	1735
 /*! perf: operation read latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1735
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1736
 /*! perf: operation read latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1736
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1737
 /*! perf: operation read latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1737
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1738
 /*! perf: operation read latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1738
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1739
 /*! perf: operation read latency histogram (bucket 5) - 1000-2499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT2500	1739
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT2500	1740
 /*! perf: operation read latency histogram (bucket 6) - 2500-4999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT5000	1740
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT5000	1741
 /*! perf: operation read latency histogram (bucket 7) - 5000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1741
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1742
 /*! perf: operation read latency histogram (bucket 8) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1742
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1743
 /*! perf: operation read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1743
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1744
 /*! perf: operation write latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1744
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1745
 /*! perf: operation write latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1745
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1746
 /*! perf: operation write latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1746
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1747
 /*! perf: operation write latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1747
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1748
 /*! perf: operation write latency histogram (bucket 5) - 1000-2499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT2500	1748
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT2500	1749
 /*! perf: operation write latency histogram (bucket 6) - 2500-4999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT5000	1749
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT5000	1750
 /*! perf: operation write latency histogram (bucket 7) - 5000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1750
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1751
 /*! perf: operation write latency histogram (bucket 8) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1751
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1752
 /*! perf: operation write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1752
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1753
 /*! prefetch: could not perform pre-fetch on internal page */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1753
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1754
 /*!
  * prefetch: could not perform pre-fetch on ref without the pre-fetch
  * flag set
  */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1754
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1755
 /*! prefetch: number of times pre-fetch failed to start */
-#define	WT_STAT_CONN_PREFETCH_FAILED_START		1755
+#define	WT_STAT_CONN_PREFETCH_FAILED_START		1756
 /*! prefetch: pre-fetch not repeating for recently pre-fetched ref */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1756
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1757
 /*! prefetch: pre-fetch not triggered after single disk read */
-#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1757
+#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1758
 /*! prefetch: pre-fetch not triggered as there is no valid dhandle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1758
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1759
 /*! prefetch: pre-fetch not triggered by page read */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED			1759
+#define	WT_STAT_CONN_PREFETCH_SKIPPED			1760
 /*! prefetch: pre-fetch not triggered due to disk read count */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1760
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1761
 /*! prefetch: pre-fetch not triggered due to internal session */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1761
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1762
 /*! prefetch: pre-fetch not triggered due to special btree handle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1762
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1763
 /*! prefetch: pre-fetch page not on disk when reading */
-#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1763
+#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1764
 /*! prefetch: pre-fetch pages queued */
-#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1764
+#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1765
 /*! prefetch: pre-fetch pages read in background */
-#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1765
+#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1766
 /*! prefetch: pre-fetch skipped reading in a page due to harmless error */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1766
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1767
 /*! prefetch: pre-fetch triggered by page read */
-#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1767
+#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1768
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1768
+#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1769
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1769
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1770
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1770
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1771
 /*!
  * reconciliation: average length of delta chain on internal page with
  * deltas
  */
-#define	WT_STAT_CONN_REC_AVERAGE_INTERNAL_PAGE_DELTA_CHAIN_LENGTH	1771
+#define	WT_STAT_CONN_REC_AVERAGE_INTERNAL_PAGE_DELTA_CHAIN_LENGTH	1772
 /*! reconciliation: average length of delta chain on leaf page with deltas */
-#define	WT_STAT_CONN_REC_AVERAGE_LEAF_PAGE_DELTA_CHAIN_LENGTH	1772
+#define	WT_STAT_CONN_REC_AVERAGE_LEAF_PAGE_DELTA_CHAIN_LENGTH	1773
 /*!
  * reconciliation: changes since prior reconciliation (bucket 1) between
  * 1 and 5
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE5			1773
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE5			1774
 /*!
  * reconciliation: changes since prior reconciliation (bucket 2) between
  * 6 and 10
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE10			1774
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE10			1775
 /*!
  * reconciliation: changes since prior reconciliation (bucket 3) between
  * 11 and 20
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE20			1775
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE20			1776
 /*!
  * reconciliation: changes since prior reconciliation (bucket 4) between
  * 21 and 50
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE50			1776
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE50			1777
 /*!
  * reconciliation: changes since prior reconciliation (bucket 5) between
  * 51 and 100
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE100		1777
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE100		1778
 /*!
  * reconciliation: changes since prior reconciliation (bucket 6) between
  * 101 and 200
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE200		1778
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE200		1779
 /*!
  * reconciliation: changes since prior reconciliation (bucket 7) between
  * 201 and 500
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE500		1779
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE500		1780
 /*!
  * reconciliation: changes since prior reconciliation (bucket 8) greater
  * than 500
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_GT500		1780
+#define	WT_STAT_CONN_REC_PAGE_MODS_GT500		1781
 /*! reconciliation: cursor next/prev calls during HS wrapup search_near */
-#define	WT_STAT_CONN_REC_HS_WRAPUP_NEXT_PREV_CALLS	1781
+#define	WT_STAT_CONN_REC_HS_WRAPUP_NEXT_PREV_CALLS	1782
 /*! reconciliation: empty deltas skipped in disaggregated storage */
-#define	WT_STAT_CONN_REC_SKIP_EMPTY_DELTAS		1782
+#define	WT_STAT_CONN_REC_SKIP_EMPTY_DELTAS		1783
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1783
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1784
 /*! reconciliation: full internal pages written instead of a page delta */
-#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_INTERNAL	1784
+#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_INTERNAL	1785
 /*! reconciliation: full leaf pages written instead of a page delta */
-#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_LEAF		1785
+#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_LEAF		1786
 /*! reconciliation: internal page delta keys deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_DELETED	1786
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_DELETED	1787
 /*! reconciliation: internal page delta keys updated/inserted */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_UPDATED	1787
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_UPDATED	1788
 /*! reconciliation: internal page deltas written */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL		1788
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL		1789
 /*! reconciliation: internal page multi-block writes */
-#define	WT_STAT_CONN_REC_MULTIBLOCK_INTERNAL		1789
+#define	WT_STAT_CONN_REC_MULTIBLOCK_INTERNAL		1790
 /*! reconciliation: leaf page deltas written */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_LEAF		1790
+#define	WT_STAT_CONN_REC_PAGE_DELTA_LEAF		1791
 /*! reconciliation: leaf page multi-block writes */
-#define	WT_STAT_CONN_REC_MULTIBLOCK_LEAF		1791
+#define	WT_STAT_CONN_REC_MULTIBLOCK_LEAF		1792
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1792
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1793
 /*! reconciliation: max deltas seen on internal page during reconciliation */
-#define	WT_STAT_CONN_REC_MAX_INTERNAL_PAGE_DELTAS	1793
+#define	WT_STAT_CONN_REC_MAX_INTERNAL_PAGE_DELTAS	1794
 /*! reconciliation: max deltas seen on leaf page during reconciliation */
-#define	WT_STAT_CONN_REC_MAX_LEAF_PAGE_DELTAS		1794
+#define	WT_STAT_CONN_REC_MAX_LEAF_PAGE_DELTAS		1795
 /*! reconciliation: maximum milliseconds spent in a reconciliation call */
-#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1795
+#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1796
 /*!
  * reconciliation: maximum milliseconds spent in building a disk image in
  * a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1796
+#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1797
 /*!
  * reconciliation: maximum milliseconds spent in moving updates to the
  * history store in a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1797
+#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1798
 /*!
  * reconciliation: number of keys that are garbage collected form the
  * disk images in the ingest btrees for disaggregated storage
  */
-#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_DISK_IMAGE	1798
+#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_DISK_IMAGE	1799
 /*!
  * reconciliation: number of keys that are garbage collected form the
  * update chains in the ingest btrees for disaggregated storage
  */
-#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_UPDATE_CHAIN	1799
+#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_UPDATE_CHAIN	1800
 /*! reconciliation: overflow values written */
-#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1800
+#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1801
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1801
+#define	WT_STAT_CONN_REC_PAGES				1802
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1802
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1803
 /*! reconciliation: page reconciliation calls for pages between 1 and 10MB */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_1MB_TO_10MB		1803
+#define	WT_STAT_CONN_REC_PAGES_SIZE_1MB_TO_10MB		1804
 /*!
  * reconciliation: page reconciliation calls for pages between 10 and
  * 100MB
  */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_10MB_TO_100MB	1804
+#define	WT_STAT_CONN_REC_PAGES_SIZE_10MB_TO_100MB	1805
 /*!
  * reconciliation: page reconciliation calls for pages between 100MB and
  * 1GB
  */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_100MB_TO_1GB	1805
+#define	WT_STAT_CONN_REC_PAGES_SIZE_100MB_TO_1GB	1806
 /*! reconciliation: page reconciliation calls for pages over 1GB */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_1GB_PLUS		1806
+#define	WT_STAT_CONN_REC_PAGES_SIZE_1GB_PLUS		1807
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * prepared transaction metadata
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1807
+#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1808
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * timestamps
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1808
+#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1809
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * transaction ids
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1809
+#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1810
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1810
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1811
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1811
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1812
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1812
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1813
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1813
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1814
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1814
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1815
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1815
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1816
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1816
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1817
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1817
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1818
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1818
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1819
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1819
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1820
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1820
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1821
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1821
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1822
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1822
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1823
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1823
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1824
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1824
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1825
 /*! reconciliation: pages written with at least one internal page delta */
-#define	WT_STAT_CONN_REC_PAGES_WITH_INTERNAL_DELTAS	1825
+#define	WT_STAT_CONN_REC_PAGES_WITH_INTERNAL_DELTAS	1826
 /*! reconciliation: pages written with at least one leaf page delta */
-#define	WT_STAT_CONN_REC_PAGES_WITH_LEAF_DELTAS		1826
+#define	WT_STAT_CONN_REC_PAGES_WITH_LEAF_DELTAS		1827
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1827
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1828
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1828
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1829
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1829
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1830
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1830
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1831
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1831
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1832
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1832
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1833
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1833
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1834
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1834
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1835
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1835
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1836
 /*! session: attempts to remove a local object and the object is in use */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1836
+#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1837
 /*! session: flush_tier failed calls */
-#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1837
+#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1838
 /*! session: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1838
+#define	WT_STAT_CONN_FLUSH_TIER				1839
 /*! session: flush_tier tables skipped due to no checkpoint */
-#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1839
+#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1840
 /*! session: flush_tier tables switched */
-#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1840
+#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1841
 /*! session: local objects removed */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1841
+#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1842
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1842
+#define	WT_STAT_CONN_SESSION_OPEN			1843
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1843
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1844
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1844
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1845
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1845
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1846
 /*! session: table alter triggering checkpoint calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1846
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1847
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1847
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1848
 /*! session: table compact conflicted with checkpoint */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1848
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1849
 /*! session: table compact dhandle successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1849
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1850
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1850
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1851
 /*! session: table compact failed calls due to cache pressure */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1851
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1852
 /*! session: table compact passes */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1852
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1853
 /*! session: table compact pulled into eviction */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1853
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1854
 /*! session: table compact running */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1854
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1855
 /*! session: table compact skipped as process would not reduce file size */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1855
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1856
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1856
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1857
 /*! session: table compact timeout */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1857
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1858
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1858
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1859
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1859
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1860
 /*! session: table create with import failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1860
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1861
 /*! session: table create with import repair calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1861
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1862
 /*! session: table create with import successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1862
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1863
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1863
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1864
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1864
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1865
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1865
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1866
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1866
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1867
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1867
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1868
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1868
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1869
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1869
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1870
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1870
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1871
 /*! session: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1871
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1872
 /*! session: tiered operations removed without processing */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1872
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1873
 /*! session: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1873
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1874
 /*! session: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1874
+#define	WT_STAT_CONN_TIERED_RETENTION			1875
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1875
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1876
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1876
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1877
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1877
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1878
 /*! thread-yield: application thread operations waiting for cache */
-#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1878
+#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1879
 /*!
  * thread-yield: application thread operations waiting for interruptible
  * cache eviction
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_OPS	1879
+#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_OPS	1880
 /*!
  * thread-yield: application thread operations waiting for mandatory
  * cache eviction
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_OPS	1880
+#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_OPS	1881
 /*! thread-yield: application thread snapshot refreshed for eviction */
-#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1881
+#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1882
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1882
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1883
 /*!
  * thread-yield: application thread time waiting for interruptible cache
  * eviction (usecs)
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_TIME	1883
+#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_TIME	1884
 /*!
  * thread-yield: application thread time waiting for mandatory cache
  * eviction (usecs)
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_TIME	1884
+#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_TIME	1885
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1885
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1886
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1886
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1887
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1887
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1888
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1888
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1889
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1889
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1890
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1890
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1891
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1891
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1892
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1892
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1893
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1893
+#define	WT_STAT_CONN_PAGE_SLEEP				1894
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1894
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1895
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1895
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1896
 /*! thread-yield: page split and restart read */
-#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1896
+#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1897
 /*! thread-yield: pages skipped during read due to deleted state */
-#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1897
+#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1898
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1898
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1899
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1899
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1900
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1900
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1901
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1901
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1902
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1902
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1903
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1903
+#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1904
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1904
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1905
 /*! transaction: oldest transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1905
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1906
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1906
+#define	WT_STAT_CONN_TXN_PREPARE			1907
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1907
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1908
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1908
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1909
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1909
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1910
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1910
+#define	WT_STAT_CONN_TXN_QUERY_TS			1911
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1911
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1912
 /*! transaction: rollback to stable applied btrees */
-#define	WT_STAT_CONN_TXN_RTS_BTREES_APPLIED		1912
+#define	WT_STAT_CONN_TXN_RTS_BTREES_APPLIED		1913
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1913
+#define	WT_STAT_CONN_TXN_RTS				1914
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1914
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1915
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1915
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1916
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1916
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1917
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1917
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1918
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1918
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1919
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1919
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1920
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1920
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1921
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1921
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1922
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1922
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1923
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1923
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1924
 /*! transaction: rollback to stable skipped btrees */
-#define	WT_STAT_CONN_TXN_RTS_BTREES_SKIPPED		1924
+#define	WT_STAT_CONN_TXN_RTS_BTREES_SKIPPED		1925
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1925
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1926
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1926
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1927
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1927
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1928
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1928
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1929
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1929
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1930
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1930
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1931
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1931
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1932
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1932
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1933
 /*!
  * transaction: rollback to stable updates that would have been aborted
  * in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1933
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1934
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1934
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1935
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1935
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1936
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1936
+#define	WT_STAT_CONN_TXN_SET_TS				1937
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1937
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1938
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1938
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1939
 /*! transaction: set timestamp force calls */
-#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1939
+#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1940
 /*!
  * transaction: set timestamp global oldest timestamp set to be more
  * recent than the global stable timestamp
  */
-#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1940
+#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1941
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1941
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1942
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1942
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1943
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1943
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1944
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1944
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1945
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1945
+#define	WT_STAT_CONN_TXN_BEGIN				1946
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1946
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1947
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1947
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1948
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1948
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1949
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1949
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1950
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1950
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1951
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1951
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1952
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1952
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1953
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1953
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1954
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1954
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1955
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1955
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1956
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1956
+#define	WT_STAT_CONN_TXN_COMMIT				1957
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1957
+#define	WT_STAT_CONN_TXN_ROLLBACK			1958
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1958
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1959
 
 /*!
  * @}

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -2118,6 +2118,7 @@ static const char *const __stats_connection_desc[] = {
   "cache: size of tombstones restored when reading a page",
   "cache: the number of times full update inserted to history store",
   "cache: the number of times reverse modify inserted to history store",
+  "cache: time eviction worker threads spend waiting for locks (usecs)",
   "cache: total milliseconds spent inside reentrant history store evictions in a reconciliation",
   "cache: tracked bytes belonging to internal pages in the cache",
   "cache: tracked bytes belonging to internal pages in the cache from the ingest btrees",
@@ -3129,6 +3130,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->cache_read_restored_tombstone_bytes = 0;
     stats->cache_hs_insert_full_update = 0;
     stats->cache_hs_insert_reverse_modify = 0;
+    stats->eviction_worker_lock_wait_time = 0;
     /* not clearing eviction_reentry_hs_eviction_milliseconds */
     /* not clearing cache_bytes_internal */
     /* not clearing cache_bytes_internal_ingest */
@@ -4210,6 +4212,7 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
       WT_STAT_CONN_READ(from, cache_read_restored_tombstone_bytes);
     to->cache_hs_insert_full_update += WT_STAT_CONN_READ(from, cache_hs_insert_full_update);
     to->cache_hs_insert_reverse_modify += WT_STAT_CONN_READ(from, cache_hs_insert_reverse_modify);
+    to->eviction_worker_lock_wait_time += WT_STAT_CONN_READ(from, eviction_worker_lock_wait_time);
     to->eviction_reentry_hs_eviction_milliseconds +=
       WT_STAT_CONN_READ(from, eviction_reentry_hs_eviction_milliseconds);
     to->cache_bytes_internal += WT_STAT_CONN_READ(from, cache_bytes_internal);


### PR DESCRIPTION
This PR adds a stat to track how long eviction worker threads spend waiting for locks in `__evict_get_ref`.
