### PR TITLE
WT-15922 Clean up missing FIXME comments and increase Evergreen check frequency

### DIFF
--- a/test/checkpoint/CMakeLists.txt
+++ b/test/checkpoint/CMakeLists.txt
@@ -76,7 +76,7 @@ define_test_variants(test_checkpoint
 # Define long running test variants for the disagg test
 define_test_variants(test_checkpoint
     VARIANTS
-        # FIXME-WT-15723: Re-evaluate whether setting large cache size is need after cache stuck issue is solved.
+        # FIXME-WT-16228: Re-evaluate whether setting large cache size is need after cache stuck issue is solved.
         "disagg_leader_row_server_93028|-d leader -t r -W 50 -r 2 -s 1 -x -n 100000 -k 100000 -C cache_size=1500MB"
     LABELS
         check

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1229,7 +1229,7 @@ functions:
         # Check if we running in disagg mode.
         disagg_args=""
         if [[ "${disagg_run|false}" == "true" ]]; then
-            # FIXME-WT-15723: Re-evaluate whether setting large cache size is need after cache stuck issue is solved.
+            # FIXME-WT-16228: Re-evaluate whether setting large cache size is need after cache stuck issue is solved.
             disagg_args="-d leader -t row -x -C cache_size=1000MB"
         fi
         ./test_checkpoint ${checkpoint_args} $disagg_args  2>&1
@@ -1246,7 +1246,7 @@ functions:
         ${PREPARE_TEST_ENV}
         disagg_args=""
         if [[ "${disagg_run|false}" == "true" ]]; then
-            # FIXME-WT-15723: Re-evaluate whether setting large cache size is need after cache stuck issue is solved.
+            # FIXME-WT-16228: Re-evaluate whether setting large cache size is need after cache stuck issue is solved.
             disagg_args="-d leader -t row -x -C cache_size=1000MB"
         fi
         ../../../test/evergreen/checkpoint_test_predictable.sh ${times} "${checkpoint_args} $disagg_args"

--- a/test/evergreen_develop.yml
+++ b/test/evergreen_develop.yml
@@ -152,7 +152,7 @@ buildvariants:
     - name: memory-model-test
       batchtime: 40320 # 28 days
     - name: s-outdated-fixmes
-      batchtime: 10080 # 7 days
+      batchtime: 1440 # 1 day
 
 - name: lazyfs-tests
   display_name: "~ LazyFS tests"

--- a/test/format/format_config.c
+++ b/test/format/format_config.c
@@ -727,7 +727,7 @@ config_cache(void)
     cache *= 2;
 
     /*
-     * FIXME-WT-15723: Re-evaluate whether setting large cache size is need after cache stuck issue
+     * FIXME-WT-16228: Re-evaluate whether setting large cache size is need after cache stuck issue
      * is solved.
      */
     if (GV(PRECISE_CHECKPOINT))

--- a/test/suite/test_checkpoint33.py
+++ b/test/suite/test_checkpoint33.py
@@ -80,8 +80,6 @@ class test_checkpoint33(test_cc_base, suite_subprocess):
         self.session.rollback_transaction()
         evict_cursor.close()
 
-    # FIXME-WT-14982
-    @wttest.skip_for_hook("disagg", "PALM environment mapsize limitation")
     def test_checkpoint33(self):
 
         if os.environ.get("TSAN_OPTIONS"):

--- a/test/suite/test_checkpoint35.py
+++ b/test/suite/test_checkpoint35.py
@@ -46,8 +46,6 @@ class test_checkpoint35(wttest.WiredTigerTestCase):
 
     scenarios = make_scenarios(format_values)
 
-    # FIXME-WT-14982
-    @wttest.skip_for_hook("disagg", "PALM environment mapsize limitation")
     def test_checkpoint(self):
         uri = 'table:checkpoint35'
         nrows = 1000000

--- a/test/suite/test_cursor13.py
+++ b/test/suite/test_cursor13.py
@@ -128,18 +128,12 @@ class test_cursor13_base(wttest.WiredTigerTestCase):
 
 # Override other cursor tests with cursors cached.
 
-# FIXME-WT-15072: Investigate failed to advance panic failure.
-@wttest.skip_for_hook("disagg", "Disabled due to checking expected table prefix")
 class test_cursor13_01(test_cursor01.test_cursor01, test_cursor13_base):
     pass
 
-# FIXME-WT-15072: Investigate failed to advance panic failure.
-@wttest.skip_for_hook("disagg", "Fails to advance the checkpoint in disagg world")
 class test_cursor13_02(test_cursor02.test_cursor02, test_cursor13_base):
     pass
 
-# FIXME-WT-15072: Investigate failed to advance panic failure.
-@wttest.skip_for_hook("disagg", "Fails to advance the checkpoint in disagg world")
 class test_cursor13_03(test_cursor03.test_cursor03, test_cursor13_base):
     pass
 


### PR DESCRIPTION
This PR clean up some missed FIXME comments after ticket closure, and increase the running frequency of the `s-outdated-fixmes` Evergreen task, so that we can capture such missing FIXME cleanup earlier going forward.