### PR TITLE
WT-16201 Additional logging of checkpoint pickup

### DIFF
--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -368,7 +368,7 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPOINT
     WT_SESSION_IMPL *internal_session, *shared_metadata_session;
     size_t len, metadata_value_cfg_len;
     uint64_t checkpoint_timestamp, current_meta_lsn;
-    uint32_t checksum;
+    uint32_t checksum, existing_tables, new_ingest, new_tables;
     char *buf, *cfg_ret, *checkpoint_config, *root, *metadata_value_cfg, *layered_ingest_uri;
     char ts_string[WT_TS_INT_STRING_SIZE];
     const char *cfg[3], *current_value, *metadata_key, *metadata_value;
@@ -387,6 +387,7 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPOINT
     shared_metadata_session = NULL;
     cfg_ret = NULL;
     WT_CLEAR(item);
+    existing_tables = new_ingest = new_tables = 0;
 
     WT_ASSERT_SPINLOCK_OWNED(session, &conn->checkpoint_lock);
 
@@ -515,9 +516,6 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPOINT
     cfg[1] = NULL;
     WT_ERR(__wt_open_cursor(shared_metadata_session, WT_DISAGG_METADATA_URI, NULL, cfg, &cursor));
 
-    uint32_t existing_tables = 0;
-    uint32_t new_tables = 0;
-    uint32_t new_ingest = 0;
     while ((ret = cursor->next(cursor)) == 0) {
         WT_ERR(cursor->get_key(cursor, &metadata_key));
         WT_ERR(cursor->get_value(cursor, &metadata_value));

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -507,10 +507,17 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPOINT
     WT_ERR_MSG_CHK(session, __wti_conn_dhandle_outdated(session, WT_DISAGG_METADATA_URI),
       "Removing old references to disagg tables failed: \"%s\"", WT_DISAGG_METADATA_URI);
 
+    __wt_verbose_debug1(session, WT_VERB_DISAGGREGATED_STORAGE,
+      "Processing new disaggregated storage checkpoint: metadata_lsn=%" PRIu64,
+      ckpt_meta->metadata_lsn);
+
     cfg[0] = WT_CONFIG_BASE(session, WT_SESSION_open_cursor);
     cfg[1] = NULL;
     WT_ERR(__wt_open_cursor(shared_metadata_session, WT_DISAGG_METADATA_URI, NULL, cfg, &cursor));
 
+    uint32_t existing_tables = 0;
+    uint32_t new_tables = 0;
+    uint32_t new_ingest = 0;
     while ((ret = cursor->next(cursor)) == 0) {
         WT_ERR(cursor->get_key(cursor, &metadata_key));
         WT_ERR(cursor->get_value(cursor, &metadata_value));
@@ -544,6 +551,7 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPOINT
             WT_ERR_MSG_CHK(session, md_cursor->insert(md_cursor),
               "Failed to insert metadata for key \"%s\"", metadata_key);
 
+            existing_tables++;
             __wt_verbose_debug2(session, WT_VERB_DISAGGREGATED_STORAGE,
               "Updated the local metadata for key \"%s\" to include new checkpoint: \"%.*s\"",
               metadata_key, (int)cval.len, cval.str);
@@ -568,14 +576,17 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPOINT
                     layered_ingest_uri[cval.len] = '\0';
                     md_cursor->set_key(md_cursor, layered_ingest_uri);
                     WT_ERR_NOTFOUND_OK(md_cursor->search(md_cursor), true);
-                    if (ret == WT_NOTFOUND)
+                    if (ret == WT_NOTFOUND) {
                         WT_ERR_MSG_CHK(session,
                           __layered_create_missing_ingest_table(
                             internal_session, layered_ingest_uri, metadata_value),
                           "Failed to create missing ingest table \"%s\" from \"%s\"",
                           layered_ingest_uri, metadata_value);
+                        new_ingest++;
+                    }
                     __wt_free(session, layered_ingest_uri);
                 }
+                new_tables++;
             }
 
             /* Insert the actual metadata. */
@@ -590,6 +601,9 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPOINT
         }
     }
     WT_ERR_NOTFOUND_OK(ret, false);
+
+    __wt_verbose_debug1(session, WT_VERB_DISAGGREGATED_STORAGE,
+      "Checkpoint pickup processed %" PRIu32 " existing tables, %" PRIu32 " new tables, %" PRIu32 " new ingest tables", existing_tables, new_tables, new_ingest);
 
     /*
      * Part 3: Do the bookkeeping.

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -603,7 +603,9 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPOINT
     WT_ERR_NOTFOUND_OK(ret, false);
 
     __wt_verbose_debug1(session, WT_VERB_DISAGGREGATED_STORAGE,
-      "Checkpoint pickup processed %" PRIu32 " existing tables, %" PRIu32 " new tables, %" PRIu32 " new ingest tables", existing_tables, new_tables, new_ingest);
+      "Checkpoint pickup processed %" PRIu32 " existing tables, %" PRIu32 " new tables, %" PRIu32
+      " new ingest tables",
+      existing_tables, new_tables, new_ingest);
 
     /*
      * Part 3: Do the bookkeeping.


### PR DESCRIPTION
We want to make sure there is enough logging at verbose level 1 to know where time is being spent during checkpoint pickup. But we want this to be light enough that we could, potentially, have it on full time. I.e., the logging should be fixed per checkpoint and not proportional to number of entries in the metadata.

This change:

- Includes a message at the beginning of each of the 3 steps of checkpoint pickup (see comments in `__disagg_pick_up_checkpoint`).
- Prints a summary of the table processing, the number of existing tables vs. new tables processed. Taking 15 seconds to process a checkpoint with a million tables is different than taking 15 seconds to process a checkpoint with just one table.
- Includes a message at the end of checkpoint pickup.

All at verbose level 1.

My testing has been minimal. It compiles and passes the layered table python tests. 