### PR TITLE
WT-16098 MongoDB crash in page read Add a assert info trying to identify this in test stage.

### DIFF
--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -661,6 +661,8 @@ read:
 
 skip_evict:
             page = ref->page;
+            WT_ASSERT(session, page != NULL);
+
             /*
              * Keep track of whether a session is reading leaf pages into the cache. This allows for
              * the session to decide whether pre-fetch would be helpful. It might not work if a

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -572,6 +572,8 @@ read:
             WT_STAT_CONN_INCR(session, page_split_restart);
             return (WT_RESTART);
         case WT_REF_MEM:
+            WT_ASSERT(session, page != NULL);
+
             /*
              * The page is in memory.
              *


### PR DESCRIPTION
[WT-16098](https://jira.mongodb.org/browse/WT-16098) MongoDB crash in page read
Add a assert info trying to identify this in test stage.

skip_evict:
            page = ref->page; // Crash here, page is null
            /*
             * Keep track of whether a session is reading leaf pages into the cache. This allows for
             * the session to decide whether pre-fetch would be helpful. It might not work if a
             * session has multiple cursors on different tables open, since the operations on
             * different tables get in the way of the heuristic. That isn't super likely - this is
             * to catch traversals through a btree, not complex multi-table user transactions.
             */
            if (!LF_ISSET(WT_READ_PREFETCH) && F_ISSET(ref, WT_REF_FLAG_LEAF)) {
                /*
                 * If the page was read by this retrieval or was pulled into the cache via the
                 * pre-fetch mechanism, count that as a page read directly from disk.
                 */
                if (F_ISSET_ATOMIC_16(page, WT_PAGE_PREFETCH) || read_from_disk)
                    ++session->pf.prefetch_disk_read_count;
                else
                    session->pf.prefetch_disk_read_count = 0;
            }