### PR TITLE
WT-16243 Adding asserts in __wt_page_in_func to help investigate a page fault error

### DIFF
--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -595,6 +595,7 @@ read:
                 break;
             }
 
+            WT_ASSERT(session, ref->page != NULL);
             /*
              * If a page has grown too large, we'll try and forcibly evict it before making it
              * available to the caller. There are a variety of cases where that's not possible.
@@ -661,6 +662,8 @@ read:
 
 skip_evict:
             page = ref->page;
+            WT_ASSERT(session, page != NULL);
+
             /*
              * Keep track of whether a session is reading leaf pages into the cache. This allows for
              * the session to decide whether pre-fetch would be helpful. It might not work if a


### PR DESCRIPTION
Add some Assert to get more info to investigate the page fault issue in 
__wt_page_in_func;
The source of this is from[ WT-16098](https://jira.mongodb.org/browse/WT-16098)