### PR TITLE
WT-16249 Fix the update before the prepared update not included in the delta after prepare rollback

### DIFF
--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -1403,7 +1403,7 @@ __rec_fill_tw_from_upd_select(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_U
         }
     }
 
-    if (F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED)) {
+    if (WT_DELTA_LEAF_ENABLED(session)) {
         if (write_start_prepare) {
             WT_UPDATE *first_committed_upd = upd_select->upd->next;
             for (; first_committed_upd != NULL; first_committed_upd = first_committed_upd->next) {

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -1403,36 +1403,6 @@ __rec_fill_tw_from_upd_select(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_U
         }
     }
 
-    if (WT_DELTA_LEAF_ENABLED(session)) {
-        if (write_start_prepare) {
-            WT_UPDATE *first_committed_upd = upd_select->upd->next;
-            for (; first_committed_upd != NULL; first_committed_upd = first_committed_upd->next) {
-                uint64_t next_txnid =
-                  __wt_atomic_load_uint64_v_relaxed(&first_committed_upd->txnid);
-                if (next_txnid == WT_TXN_ABORTED)
-                    continue;
-
-                if (next_txnid == upd_select->tw.start_txn)
-                    continue;
-
-                break;
-            }
-
-            /*
-             * Clear the durable flags on the first committed update to ensure it can be included in
-             * the next delta if the prepared update is rolled back.
-             */
-            if (first_committed_upd != NULL)
-                F_CLR(first_committed_upd, WT_UPDATE_DURABLE | WT_UPDATE_DELETE_DURABLE);
-        } else if (write_prepare)
-            /*
-             * When only writing a prepared tombstone, ensure the durable flags on the on-page value
-             * are cleared. Otherwise, if the prepared tombstone is rolled back, the on-page value
-             * may be missed in the next delta.
-             */
-            F_CLR(upd_select->upd, WT_UPDATE_DURABLE | WT_UPDATE_DELETE_DURABLE);
-    }
-
     WT_ASSERT(session,
       !WT_TIME_WINDOW_HAS_STOP_PREPARE(&upd_select->tw) ||
         upd_select->tw.stop_prepare_ts >= upd_select->tw.start_ts);
@@ -1647,6 +1617,36 @@ __wti_rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_INSERT *ins,
           session, page, upd_select->upd, vpack, WT_TIME_WINDOW_HAS_PREPARE(&upd_select->tw)));
 
     __wti_rec_time_window_clear_obsolete(session, upd_select, NULL, r);
+
+    if (WT_DELTA_LEAF_ENABLED(session)) {
+        if (WT_TIME_WINDOW_HAS_START_PREPARE(&upd_select->tw)) {
+            WT_UPDATE *first_committed_upd = upd_select->upd->next;
+            for (; first_committed_upd != NULL; first_committed_upd = first_committed_upd->next) {
+                uint64_t next_txnid =
+                  __wt_atomic_load_uint64_v_relaxed(&first_committed_upd->txnid);
+                if (next_txnid == WT_TXN_ABORTED)
+                    continue;
+
+                if (next_txnid == upd_select->tw.start_txn)
+                    continue;
+
+                break;
+            }
+
+            /*
+             * Clear the durable flags on the first committed update to ensure it can be included in
+             * the next delta if the prepared update is rolled back.
+             */
+            if (first_committed_upd != NULL)
+                F_CLR(first_committed_upd, WT_UPDATE_DURABLE | WT_UPDATE_DELETE_DURABLE);
+        } else if (WT_TIME_WINDOW_HAS_STOP_PREPARE(&upd_select->tw))
+            /*
+             * When only writing a prepared tombstone, ensure the durable flags on the on-page value
+             * are cleared. Otherwise, if the prepared tombstone is rolled back, the on-page value
+             * may be missed in the next delta.
+             */
+            F_CLR(upd_select->upd, WT_UPDATE_DURABLE | WT_UPDATE_DELETE_DURABLE);
+    }
 
     WT_ASSERT(
       session, upd_select->tw.stop_txn != WT_TXN_MAX || upd_select->tw.stop_ts == WT_TS_MAX);

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -1420,7 +1420,7 @@ __rec_fill_tw_from_upd_select(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_U
 
             /*
              * Clear the durable flags on the first committed update to ensure it can be included in
-             * a future write if the prepared update is rolled back.
+             * a future delta if the prepared update is rolled back.
              */
             if (first_committed_upd != NULL)
                 F_CLR(first_committed_upd, WT_UPDATE_DURABLE | WT_UPDATE_DELETE_DURABLE);
@@ -1428,7 +1428,7 @@ __rec_fill_tw_from_upd_select(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_U
             /*
              * When only writing a prepared tombstone, ensure the durable flags on the on-page value
              * are cleared. Otherwise, if the prepared tombstone is rolled back, the on-page value
-             * may be missed during future reconciliations.
+             * may be missed in the next delta.
              */
             F_CLR(upd_select->upd, WT_UPDATE_DURABLE | WT_UPDATE_DELETE_DURABLE);
     }

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -1402,7 +1402,6 @@ __rec_fill_tw_from_upd_select(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_U
             upd_select->upd = tombstone;
         }
     }
-
     WT_ASSERT(session,
       !WT_TIME_WINDOW_HAS_STOP_PREPARE(&upd_select->tw) ||
         upd_select->tw.stop_prepare_ts >= upd_select->tw.start_ts);

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -1420,7 +1420,7 @@ __rec_fill_tw_from_upd_select(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_U
 
             /*
              * Clear the durable flags on the first committed update to ensure it can be included in
-             * a future delta if the prepared update is rolled back.
+             * the next delta if the prepared update is rolled back.
              */
             if (first_committed_upd != NULL)
                 F_CLR(first_committed_upd, WT_UPDATE_DURABLE | WT_UPDATE_DELETE_DURABLE);

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -71,13 +71,6 @@ __rec_delete_hs_upd_save(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_INSERT *
     delete_hs_upd->tombstone = tombstone;
     ++r->delete_hs_upd_next;
 
-    /* Clear the durable flag to allow them being included in a delta. */
-    if (F_ISSET(upd, WT_UPDATE_DURABLE))
-        F_CLR(upd, WT_UPDATE_DURABLE);
-
-    if (tombstone != NULL && F_ISSET(tombstone, WT_UPDATE_DURABLE))
-        F_CLR(tombstone, WT_UPDATE_DURABLE);
-
     return (0);
 }
 
@@ -1409,6 +1402,37 @@ __rec_fill_tw_from_upd_select(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_U
             upd_select->upd = tombstone;
         }
     }
+
+    if (F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED)) {
+        if (write_start_prepare) {
+            WT_UPDATE *first_committed_upd = upd_select->upd->next;
+            for (; first_committed_upd != NULL; first_committed_upd = first_committed_upd->next) {
+                uint64_t next_txnid =
+                  __wt_atomic_load_uint64_v_relaxed(&first_committed_upd->txnid);
+                if (next_txnid == WT_TXN_ABORTED)
+                    continue;
+
+                if (next_txnid == upd_select->tw.start_txn)
+                    continue;
+
+                break;
+            }
+
+            /*
+             * Clear the durable flags on the first committed update to ensure it can be included in
+             * a future write if the prepared update is rolled back.
+             */
+            if (first_committed_upd != NULL)
+                F_CLR(first_committed_upd, WT_UPDATE_DURABLE | WT_UPDATE_DELETE_DURABLE);
+        } else if (write_prepare)
+            /*
+             * When only writing a prepared tombstone, ensure the durable flags on the on-page value
+             * are cleared. Otherwise, if the prepared tombstone is rolled back, the on-page value
+             * may be missed during future reconciliations.
+             */
+            F_CLR(upd_select->upd, WT_UPDATE_DURABLE | WT_UPDATE_DELETE_DURABLE);
+    }
+
     WT_ASSERT(session,
       !WT_TIME_WINDOW_HAS_STOP_PREPARE(&upd_select->tw) ||
         upd_select->tw.stop_prepare_ts >= upd_select->tw.start_ts);

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2105,8 +2105,11 @@ __rec_set_updates_durable(WT_SESSION_IMPL *session, WT_MULTI *multi)
                     /* The on page value is also a prepared update from the same transaction. */
                     if (WT_TIME_WINDOW_HAS_START_PREPARE(&supd->tw))
                         F_SET(supd->onpage_upd, WT_UPDATE_PREPARE_DURABLE);
-                    else
-                        F_SET(supd->onpage_upd, WT_UPDATE_DURABLE);
+
+                    /*
+                     * Never mark the on-page value as durable to ensure it can be included in a
+                     * future write if the prepared tombstone is rolled back.
+                     */
                 } else {
                     F_SET(supd->onpage_tombstone, WT_UPDATE_DURABLE);
                     F_SET(supd->onpage_upd, WT_UPDATE_DURABLE);

--- a/test/suite/test_layered69.py
+++ b/test/suite/test_layered69.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wiredtiger, wttest
+from helper_disagg import disagg_test_class, gen_disagg_storages
+from prepare_util import test_prepare_preserve_prepare_base
+from wtscenario import make_scenarios
+
+# Test building deltas with prepared rollback. Ensure the old value is included
+# in the delta after the prepared update is rolled back.
+@disagg_test_class
+class test_layered69(test_prepare_preserve_prepare_base):
+    conn_config = test_prepare_preserve_prepare_base.conn_config + ',disaggregated=(role="leader"),'
+
+    uri = "table:test_layered68"
+
+    disagg_storages = gen_disagg_storages('test_layered69', disagg_only = True)
+    scenarios = make_scenarios(disagg_storages)
+
+    def test_rollback_prepared_update(self):
+        # Setup: Initialize stable timestamp
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(20)}')
+
+        create_params = 'key_format=i,value_format=S,type=layered'
+        self.session.create(self.uri, create_params)
+
+        # Insert a value and commit for keys 1-19
+        cursor = self.session.open_cursor(self.uri)
+        self.session.begin_transaction()
+        for i in range(1, 20):
+            cursor.set_key(i)
+            cursor.set_value('commit_value')
+            cursor.insert()
+        self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(21)}')
+
+        # Make the updates stable
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(21)}')
+
+        # Verify checkpoint writes no prepared to disk
+        self.checkpoint_and_verify_stats({
+            wiredtiger.stat.dsrc.rec_time_window_prepared: False,
+            wiredtiger.stat.dsrc.rec_page_delta_leaf: False,
+        }, self.uri)
+
+        # Update key 19 with a prepared update prepared_id=1
+        session_prepare = self.conn.open_session()
+        cursor_prepare = session_prepare.open_cursor(self.uri)
+        session_prepare.begin_transaction()
+        cursor_prepare.set_key(19)
+        cursor_prepare.set_value('prepared_value_20_3')
+        cursor_prepare.insert()
+        session_prepare.prepare_transaction(f'prepare_timestamp={self.timestamp_str(35)},prepared_id={self.prepared_id_str(1)}')
+
+        # Rollback the prepared transaction
+        session_prepare.rollback_transaction(f'rollback_timestamp={self.timestamp_str(45)}')
+
+        # Verify checkpoint writes an empty delta to disk
+        self.checkpoint_and_verify_stats({
+            wiredtiger.stat.dsrc.rec_time_window_prepared: False,
+            wiredtiger.stat.dsrc.rec_page_delta_leaf: False,
+        }, self.uri)
+
+        # Make stable timestamp equal to prepare timestamp - this should allow checkpoint to reconcile prepared update
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(35)}')
+
+        # Verify checkpoint writes a delta with prepared time window to disk
+        self.checkpoint_and_verify_stats({
+            wiredtiger.stat.dsrc.rec_time_window_prepared: True,
+            wiredtiger.stat.dsrc.rec_page_delta_leaf: True,
+        }, self.uri)
+
+        # Make stable timestamp equal to rollback timestamp
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(45)}')
+
+        # Verify checkpoint writes a delta with the committed update to disk
+        self.checkpoint_and_verify_stats({
+            wiredtiger.stat.dsrc.rec_time_window_prepared: False,
+            wiredtiger.stat.dsrc.rec_page_delta_leaf: True,
+        }, self.uri)
+
+        # Verify the key
+        self.assertEqual(cursor[19], 'commit_value')
+
+    def test_rollback_prepared_reinsert(self):
+        # Setup: Initialize timestamps with stable < prepare timestamp
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(20)}')
+        self.conn.set_timestamp(f'oldest_timestamp={self.timestamp_str(10)}')
+
+        create_params = 'key_format=i,value_format=S,type=layered'
+        self.session.create(self.uri, create_params)
+
+        # Insert a value and commit for keys 1-19
+        cursor = self.session.open_cursor(self.uri)
+        self.session.begin_transaction()
+        for i in range(1, 20):
+            cursor.set_key(i)
+            cursor.set_value('commit_value')
+            cursor.insert()
+        self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(21)}')
+
+        # Delete key 19
+        self.session.begin_transaction()
+        cursor.set_key(19)
+        cursor.remove()
+        self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(22)}')
+
+        # Make the delete globally visible
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(30)},oldest_timestamp={self.timestamp_str(22)}')
+
+        # Verify checkpoint writes no prepared to disk
+        self.checkpoint_and_verify_stats({
+            wiredtiger.stat.dsrc.rec_time_window_prepared: False,
+            wiredtiger.stat.dsrc.rec_page_delta_leaf: False,
+        }, self.uri)
+
+        # Update key 19 with a prepared update prepared_id=1
+        session_prepare = self.conn.open_session()
+        cursor_prepare = session_prepare.open_cursor(self.uri)
+        session_prepare.begin_transaction()
+        cursor_prepare.set_key(19)
+        cursor_prepare.set_value('prepared_value_20_3')
+        cursor_prepare.insert()
+        session_prepare.prepare_transaction(f'prepare_timestamp={self.timestamp_str(35)},prepared_id={self.prepared_id_str(1)}')
+
+        # Rollback the prepared transaction
+        session_prepare.rollback_transaction(f'rollback_timestamp={self.timestamp_str(45)}')
+
+        # Verify checkpoint writes an empty delta to disk
+        self.checkpoint_and_verify_stats({
+            wiredtiger.stat.dsrc.rec_time_window_prepared: False,
+            wiredtiger.stat.dsrc.rec_page_delta_leaf: False,
+        }, self.uri)
+
+        # Make stable timestamp equal to prepare timestamp - this should allow checkpoint to reconcile prepared update
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(35)}')
+
+        # Verify checkpoint writes a delta with prepared time window to disk
+        self.checkpoint_and_verify_stats({
+            wiredtiger.stat.dsrc.rec_time_window_prepared: True,
+            wiredtiger.stat.dsrc.rec_page_delta_leaf: True,
+        }, self.uri)
+
+        # Make stable timestamp equal to rollback timestamp
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(45)}')
+
+        # Verify checkpoint writes a delta with the committed update to disk
+        self.checkpoint_and_verify_stats({
+            wiredtiger.stat.dsrc.rec_time_window_prepared: False,
+            wiredtiger.stat.dsrc.rec_page_delta_leaf: True,
+        }, self.uri)
+
+        # Verify the key
+        cursor.set_key(19)
+        self.assertEqual(cursor.search(), wiredtiger.WT_NOTFOUND)
+
+    def test_rollback_prepared_update(self):
+        # Setup: Initialize stable timestamp
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(20)}')
+
+        create_params = 'key_format=i,value_format=S,type=layered'
+        self.session.create(self.uri, create_params)
+
+        # Insert a value and commit for keys 1-19
+        cursor = self.session.open_cursor(self.uri)
+        self.session.begin_transaction()
+        for i in range(1, 20):
+            cursor.set_key(i)
+            cursor.set_value('commit_value')
+            cursor.insert()
+        self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(21)}')
+
+        # Make the updates stable
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(21)}')
+
+        # Verify checkpoint writes no prepared to disk
+        self.checkpoint_and_verify_stats({
+            wiredtiger.stat.dsrc.rec_time_window_prepared: False,
+            wiredtiger.stat.dsrc.rec_page_delta_leaf: False,
+        }, self.uri)
+
+        # Delete key 19 with a prepared update prepared_id=1
+        session_prepare = self.conn.open_session()
+        cursor_prepare = session_prepare.open_cursor(self.uri)
+        session_prepare.begin_transaction()
+        cursor_prepare.set_key(19)
+        cursor_prepare.remove()
+        session_prepare.prepare_transaction(f'prepare_timestamp={self.timestamp_str(35)},prepared_id={self.prepared_id_str(1)}')
+
+        # Rollback the prepared transaction
+        session_prepare.rollback_transaction(f'rollback_timestamp={self.timestamp_str(45)}')
+
+        # Verify checkpoint writes an empty delta to disk
+        self.checkpoint_and_verify_stats({
+            wiredtiger.stat.dsrc.rec_time_window_prepared: False,
+            wiredtiger.stat.dsrc.rec_page_delta_leaf: False,
+        }, self.uri)
+
+        # Make stable timestamp equal to prepare timestamp - this should allow checkpoint to reconcile prepared update
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(35)}')
+
+        # Verify checkpoint writes a delta with prepared time window to disk
+        self.checkpoint_and_verify_stats({
+            wiredtiger.stat.dsrc.rec_time_window_prepared: True,
+            wiredtiger.stat.dsrc.rec_page_delta_leaf: True,
+        }, self.uri)
+
+        # Make stable timestamp equal to rollback timestamp
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(45)}')
+
+        # Verify checkpoint writes a delta with the committed update to disk
+        self.checkpoint_and_verify_stats({
+            wiredtiger.stat.dsrc.rec_time_window_prepared: False,
+            wiredtiger.stat.dsrc.rec_page_delta_leaf: True,
+        }, self.uri)
+
+        # Verify the key
+        self.assertEqual(cursor[19], 'commit_value')

--- a/test/suite/test_layered69.py
+++ b/test/suite/test_layered69.py
@@ -39,8 +39,13 @@ class test_layered69(test_prepare_preserve_prepare_base):
 
     uri = "table:test_layered68"
 
+    evict = [
+        ('none', dict(evict=False)),
+        ('evict', dict(evict=True)),
+    ]
+
     disagg_storages = gen_disagg_storages('test_layered69', disagg_only = True)
-    scenarios = make_scenarios(disagg_storages)
+    scenarios = make_scenarios(disagg_storages, evict)
 
     def test_rollback_prepared_update(self):
         # Setup: Initialize stable timestamp
@@ -66,6 +71,17 @@ class test_layered69(test_prepare_preserve_prepare_base):
             wiredtiger.stat.dsrc.rec_time_window_prepared: False,
             wiredtiger.stat.dsrc.rec_page_delta_leaf: False,
         }, self.uri)
+
+        if self.evict:
+            # Force the page to be evicted
+            evict_cursor = self.session.open_cursor(self.uri, None, "debug=(release_evict)")
+            self.session.begin_transaction()
+            for i in range(1, 19):
+                evict_cursor.set_key(i)
+                self.assertEqual(evict_cursor.search(), 0)
+                evict_cursor.reset()
+            self.session.rollback_transaction()
+            evict_cursor.close()
 
         # Update key 19 with a prepared update prepared_id=1
         session_prepare = self.conn.open_session()
@@ -138,6 +154,17 @@ class test_layered69(test_prepare_preserve_prepare_base):
             wiredtiger.stat.dsrc.rec_page_delta_leaf: False,
         }, self.uri)
 
+        if self.evict:
+            # Force the page to be evicted
+            evict_cursor = self.session.open_cursor(self.uri, None, "debug=(release_evict)")
+            self.session.begin_transaction()
+            for i in range(1, 19):
+                evict_cursor.set_key(i)
+                self.assertEqual(evict_cursor.search(), 0)
+                evict_cursor.reset()
+            self.session.rollback_transaction()
+            evict_cursor.close()
+
         # Update key 19 with a prepared update prepared_id=1
         session_prepare = self.conn.open_session()
         cursor_prepare = session_prepare.open_cursor(self.uri)
@@ -202,6 +229,17 @@ class test_layered69(test_prepare_preserve_prepare_base):
             wiredtiger.stat.dsrc.rec_time_window_prepared: False,
             wiredtiger.stat.dsrc.rec_page_delta_leaf: False,
         }, self.uri)
+
+        if self.evict:
+            # Force the page to be evicted
+            evict_cursor = self.session.open_cursor(self.uri, None, "debug=(release_evict)")
+            self.session.begin_transaction()
+            for i in range(1, 19):
+                evict_cursor.set_key(i)
+                self.assertEqual(evict_cursor.search(), 0)
+                evict_cursor.reset()
+            self.session.rollback_transaction()
+            evict_cursor.close()
 
         # Delete key 19 with a prepared update prepared_id=1
         session_prepare = self.conn.open_session()

--- a/test/suite/test_layered69.py
+++ b/test/suite/test_layered69.py
@@ -178,7 +178,7 @@ class test_layered69(test_prepare_preserve_prepare_base):
         cursor.set_key(19)
         self.assertEqual(cursor.search(), wiredtiger.WT_NOTFOUND)
 
-    def test_rollback_prepared_update(self):
+    def test_rollback_prepared_remove(self):
         # Setup: Initialize stable timestamp
         self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(20)}')
 


### PR DESCRIPTION
This change resolves an issue related to building deltas after a prepared rollback. Specifically, when rolling back prepared updates, the change ensures that updates older than the rolled-back prepared update are unmarked as durable. This adjustment allows these updates to be included in future writes. Without this fix, such updates might be skipped if they were previously written and marked as durable.