### PR TITLE
WT-16242 Fix disagg block header decoding

### DIFF
--- a/tools/py_common/btree_format.py
+++ b/tools/py_common/btree_format.py
@@ -219,7 +219,9 @@ class BlockDisaggFlags(enum.IntFlag):
 
 class BlockDisaggHeader(object):
     '''
-    A block header (WT_BLOCK_DISAGG_HEADER).
+    A block header (WT_BLOCK_DISAGG_HEADER). Disagg uses additional header fields in the block 
+    header in comparison to standard WiredTiger blocks. This class should only be used for disagg 
+    blocks.
     '''
     magic: int
     version: int
@@ -254,8 +256,6 @@ class BlockDisaggHeader(object):
         '''
         # WT_BLOCK_DISAGG_HEADER in block.h (16 bytes)
         h = BlockDisaggHeader()
-        # Disagg sets additional fields.  If they are examined
-        # by non-disagg code, an exception will be thrown (by design).
         h.magic = b. read_uint8()
         h.version = b.read_uint8()
         h.compatible_version = b.read_uint8()

--- a/tools/py_common/btree_format.py
+++ b/tools/py_common/btree_format.py
@@ -152,7 +152,7 @@ class PageHeader(object):
             f"  recno: {str(self.recno)}\n"
             f"  writegen: {str(self.write_gen)}\n"
             f"  memsize: {str(self.mem_size)}\n"
-            f"  ncells (oflow len): {str(self.entries)}\n"
+            f"  ncells (overflow len): {str(self.entries)}\n"
             f"  page type: {str(self.type.value)} ({self.type.name})\n"
             f"  page flags: {str(self.flags)}\n"
             f"  version: {str(self.version)}"
@@ -188,7 +188,7 @@ class BlockHeader(object):
         self.unused = 0
 
     @staticmethod
-    def parse(b: binary_data.BinaryFile, disagg = False) -> 'BlockHeader':
+    def parse(b: binary_data.BinaryFile) -> 'BlockHeader':
         '''
         Parse a block header.
         '''
@@ -202,7 +202,7 @@ class BlockHeader(object):
     
     def __str__(self):
         header_string = (
-            f"Block Disagg Header:\n"
+            f"Block Header:\n"
             f"  disk_size: {str(self.disk_size)}"
             f"  checksum: {str(self.checksum)}"
             f"  flags: {str(self.flags)}"

--- a/tools/py_common/btree_format.py
+++ b/tools/py_common/btree_format.py
@@ -92,6 +92,16 @@ class PageType(enum.Enum):
     WT_PAGE_ROW_INT = 6
     WT_PAGE_ROW_LEAF = 7
 
+class PageFlags(enum.IntFlag):
+    '''
+    Page flags from btmem.h.
+    '''
+    WT_PAGE_COMPRESSED = enum.auto()
+    WT_PAGE_EMPTY_V_ALL = enum.auto()
+    WT_PAGE_EMPTY_V_NONE = enum.auto()
+    WT_PAGE_ENCRYPTED = enum.auto()
+    WT_PAGE_UNUSED = enum.auto()
+    WT_PAGE_FT_UPDATE = enum.auto()
 
 class PageHeader(object):
     '''
@@ -102,17 +112,9 @@ class PageHeader(object):
     memsize: int
     entries: int # Or: overflow data length
     type: PageType
-    flags: int
+    flags: PageFlags
     unused: int
     version: int
-
-    # Flags
-    WT_PAGE_COMPRESSED: typing.Final[int] = 0x01
-    WT_PAGE_EMPTY_V_ALL: typing.Final[int] = 0x02
-    WT_PAGE_EMPTY_V_NONE: typing.Final[int] = 0x04
-    WT_PAGE_ENCRYPTED: typing.Final[int] = 0x08
-    WT_PAGE_UNUSED: typing.Final[int] = 0x10
-    WT_PAGE_FT_UPDATE: typing.Final[int] = 0x20
 
     def __init__(self) -> None:
         '''
@@ -139,14 +141,33 @@ class PageHeader(object):
         h.mem_size = b.read_uint32()
         h.entries = b.read_uint32()
         h.type = PageType(b.read_uint8())
-        h.flags = b.read_uint8()
+        h.flags = PageFlags(b.read_uint8())
         h.unused = b.read_uint8()
         h.version = b.read_uint8()
         return h
 
+    def __str__(self):
+        header_string = (
+            f"Page Header:\n"
+            f"  recno: {str(self.recno)}\n"
+            f"  writegen: {str(self.write_gen)}\n"
+            f"  memsize: {str(self.mem_size)}\n"
+            f"  ncells (oflow len): {str(self.entries)}\n"
+            f"  page type: {str(self.type.value)} ({self.type.name})\n"
+            f"  page flags: {str(self.flags)}\n"
+            f"  version: {str(self.version)}"
+        )
+        
+        return header_string
 #
 # Block
 #
+
+class BlockFlags(enum.IntFlag):
+    '''
+    Block flags from block.h
+    '''
+    WT_BLOCK_DATA_CKSUM = enum.auto()
 
 class BlockHeader(object):
     '''
@@ -154,13 +175,8 @@ class BlockHeader(object):
     '''
     disk_size: int
     checksum: int
-    flags: int
+    flags: BlockFlags
     unused: int
-
-    # Flags
-    WT_BLOCK_DATA_CKSUM: typing.Final[int] = 0x1
-    WT_BLOCK_DISAGG_ENCRYPTED: typing.Final[int] = 0x2  # disagg only
-    WT_BLOCK_DISAGG_COMPRESSED: typing.Final[int] = 0x4 # disagg only
 
     def __init__(self) -> None:
         '''
@@ -178,26 +194,92 @@ class BlockHeader(object):
         '''
         # WT_BLOCK_HEADER in block.h (12 bytes)
         h = BlockHeader()
-        if disagg:
-            # Disagg sets additional fields.  If they are examined
-            # by non-disagg code, an exception will be thrown (by design).
-            h.disagg_magic = b.read_uint8()
-            h.disagg_version = b.read_uint8()
-            h.disagg_compatible_version = b.read_uint8()
-            h.disagg_header_size = b.read_uint8()
-            h.checksum = b.read_uint32()
-            h.disagg_previous_checksum = b.read_uint32()
-            h.disagg_reconciliation_id = b.read_uint8()
-            h.flags = b.read_uint8()
-            h.unused = int.from_bytes(b.read(2), byteorder='little')
-        else:
-            h.disk_size = b.read_uint32()
-            h.checksum = b.read_uint32()
-            h.flags = b.read_uint8()
-            h.unused = int.from_bytes(b.read(3), byteorder='little')
+        h.disk_size = b.read_uint32()
+        h.checksum = b.read_uint32()
+        h.flags = BlockFlags(b.read_uint8())
+        h.unused = int.from_bytes(b.read(3), byteorder='little')
         return h
+    
+    def __str__(self):
+        header_string = (
+            f"Block Disagg Header:\n"
+            f"  disk_size: {str(self.disk_size)}"
+            f"  checksum: {str(self.checksum)}"
+            f"  flags: {str(self.flags)}"
+        )
+        return header_string
 
+class BlockDisaggFlags(enum.IntFlag):
+    '''
+    Disagg block flags from block.h
+    '''
+    WT_BLOCK_DISAGG_DATA_CKSUM = enum.auto()
+    WT_BLOCK_DISAGG_ENCRYPTED = enum.auto()
+    WT_BLOCK_DISAGG_COMPRESSED = enum.auto()
 
+class BlockDisaggHeader(object):
+    '''
+    A block header (WT_BLOCK_DISAGG_HEADER).
+    '''
+    magic: int
+    version: int
+    compatible_version: int
+    header_size: int
+    checksum: int
+    previous_checksum: int
+    flags: BlockDisaggFlags
+    unused: int
+
+    # Block types (magic byte)
+    WT_BLOCK_DISAGG_MAGIC_BASE: typing.Final[int] = 0xdb
+    WT_BLOCK_DISAGG_MAGIC_DELTA: typing.Final[int] = 0xdd
+
+    def __init__(self) -> None:
+        '''
+        Initialize the instance with default values.
+        '''
+        self.magic = 0
+        self.version = 0
+        self.compatible_version = 0
+        self.header_size = 0
+        self.checksum = 0
+        self.previous_checksum = 0
+        self.flags = 0
+        self.unused = 0
+
+    @staticmethod
+    def parse(b: binary_data.BinaryFile, disagg = False) -> 'BlockDisaggHeader':
+        '''
+        Parse a block header.
+        '''
+        # WT_BLOCK_DISAGG_HEADER in block.h (16 bytes)
+        h = BlockDisaggHeader()
+        # Disagg sets additional fields.  If they are examined
+        # by non-disagg code, an exception will be thrown (by design).
+        h.magic = b. read_uint8()
+        h.version = b.read_uint8()
+        h.compatible_version = b.read_uint8()
+        h.header_size = b.read_uint8()
+        h.checksum = b.read_uint32()
+        h.previous_checksum = b.read_uint32()
+        h.flags = BlockDisaggFlags(b.read_uint8())
+        h.unused = int.from_bytes(b.read(2), byteorder='little')
+        return h
+    
+    def __str__(self):
+        header_string = (
+            f"Block Disagg Header:\n"
+            f"  magic: {hex(self.magic)} ({'delta' if self.magic == self.WT_BLOCK_DISAGG_MAGIC_DELTA else 'full image'})\n"
+            f"  version: {str(self.version)}\n"
+            f"  compatible_version: {str(self.compatible_version)}\n"
+            f"  header_size: {str(self.header_size)}\n"
+            f"  checksum: {str(self.checksum)}\n"
+            f"  previous_checksum: {str(self.previous_checksum)}\n"
+            f"  flags: {str(self.flags)}"
+        )
+        
+        return header_string
+    
 #
 # Cell
 #
@@ -432,4 +514,3 @@ class Cell(object):
         Check if this cell belongs to a prepared transaction.
         '''
         return self.extra_descriptor & Cell.WT_CELL_PREPARE != 0
-

--- a/tools/py_common/btree_format.py
+++ b/tools/py_common/btree_format.py
@@ -96,12 +96,12 @@ class PageFlags(enum.IntFlag):
     '''
     Page flags from btmem.h.
     '''
-    WT_PAGE_COMPRESSED = enum.auto()
-    WT_PAGE_EMPTY_V_ALL = enum.auto()
-    WT_PAGE_EMPTY_V_NONE = enum.auto()
-    WT_PAGE_ENCRYPTED = enum.auto()
-    WT_PAGE_UNUSED = enum.auto()
-    WT_PAGE_FT_UPDATE = enum.auto()
+    WT_PAGE_COMPRESSED = 0x01
+    WT_PAGE_EMPTY_V_ALL = 0x02
+    WT_PAGE_EMPTY_V_NONE = 0x04
+    WT_PAGE_ENCRYPTED = 0x08
+    WT_PAGE_UNUSED = 0x10
+    WT_PAGE_FT_UPDATE = 0x20
 
 class PageHeader(object):
     '''
@@ -167,7 +167,7 @@ class BlockFlags(enum.IntFlag):
     '''
     Block flags from block.h
     '''
-    WT_BLOCK_DATA_CKSUM = enum.auto()
+    WT_BLOCK_DATA_CKSUM = 0x1
 
 class BlockHeader(object):
     '''
@@ -213,9 +213,9 @@ class BlockDisaggFlags(enum.IntFlag):
     '''
     Disagg block flags from block.h
     '''
-    WT_BLOCK_DISAGG_DATA_CKSUM = enum.auto()
-    WT_BLOCK_DISAGG_ENCRYPTED = enum.auto()
-    WT_BLOCK_DISAGG_COMPRESSED = enum.auto()
+    WT_BLOCK_DISAGG_DATA_CKSUM = 0x1
+    WT_BLOCK_DISAGG_ENCRYPTED = 0x2
+    WT_BLOCK_DISAGG_COMPRESSED = 0x4
 
 class BlockDisaggHeader(object):
     '''

--- a/tools/wt_binary_decode.py
+++ b/tools/wt_binary_decode.py
@@ -214,7 +214,6 @@ class Printer(object):
         if pfx == '' and self.in_cell:
             pfx = '  '
         print(pfx + str(s))
-        # print(f'{pfx}{s}')
 
     def rint_v(self, s):
         if self.verbose:
@@ -374,14 +373,13 @@ def block_decode(p, b, nbytes, opts):
         p.rint('garbage in unused bytes')
         return
 
-    if opts.disagg and nbytes > 0:
-        blockhead.disk_size = nbytes
+    disk_size = nbytes if opts.disagg else blockhead.disk_size
 
-    if blockhead.disk_size > 17 * 1024 * 1024:
+    if disk_size > 17 * 1024 * 1024:
         # The maximum document size in MongoDB is 16MB. Larger block sizes are suspect.
         p.rint('the block is too big')
         return
-    if blockhead.disk_size < 40 and not opts.disagg:
+    if disk_size < 40 and not opts.disagg:
         # The disk size is too small
         return
 
@@ -394,7 +392,7 @@ def block_decode(p, b, nbytes, opts):
         savepos = b.tell()
         b.seek(disk_pos)
         if blockhead.flags & btree_format.BlockFlags.WT_BLOCK_DATA_CKSUM != 0:
-            check_size = blockhead.disk_size
+            check_size = disk_size
         else:
             check_size = 64
         data = bytearray(b.read(check_size))
@@ -420,7 +418,7 @@ def block_decode(p, b, nbytes, opts):
         skip_data = True
 
     if skip_data:
-        b.seek(disk_pos + blockhead.disk_size)
+        b.seek(disk_pos + disk_size)
         return
 
     # Read the block contents
@@ -435,10 +433,10 @@ def block_decode(p, b, nbytes, opts):
             # The first few bytes are uncompressed
             payload_data = bytearray(b.read(compress_skip - header_length))
             # Read the length of the remaining data
-            length = min(b.read_uint64(), blockhead.disk_size - compress_skip - 8)
+            length = min(b.read_uint64(), disk_size - compress_skip - 8)
             # Read the compressed data, seek to the end of the block, and uncompress
             compressed_data = b.read(length)
-            b.seek(disk_pos + blockhead.disk_size)
+            b.seek(disk_pos + disk_size)
             payload_data.extend(snappy.uncompress(compressed_data))
         except:
             p.rint('? the page failed to uncompress')
@@ -447,7 +445,7 @@ def block_decode(p, b, nbytes, opts):
             return
     else:
         payload_data = b.read(pagehead.mem_size - header_length)
-        b.seek(disk_pos + blockhead.disk_size)
+        b.seek(disk_pos + disk_size)
 
     # Add the payload to the page data & reinitialize the stream and the printer
     page_data.extend(payload_data)

--- a/tools/wt_binary_decode.py
+++ b/tools/wt_binary_decode.py
@@ -213,7 +213,8 @@ class Printer(object):
         self.cellpfx = ''
         if pfx == '' and self.in_cell:
             pfx = '  '
-        print(pfx + s)
+        print(pfx + str(s))
+        # print(f'{pfx}{s}')
 
     def rint_v(self, s):
         if self.verbose:
@@ -337,7 +338,6 @@ def process_timestamps(p, cell: btree_format.Cell, pagestats: PageStats):
 
 def block_decode(p, b, nbytes, opts):
     disk_pos = b.tell()
-    disagg_delta = False
 
     # Switch the printer and the binary stream to work on the page data as opposed to working on
     # the file itself. We need to do this to support compressed blocks. As a consequence, offsets
@@ -345,11 +345,7 @@ def block_decode(p, b, nbytes, opts):
     # the file.
     if opts.disagg:
         # Size of WT_PAGE_HEADER
-        page_data = bytearray(b.read(28))
-        if page_data[0] == 0xdd:
-            disagg_delta = True
-         # Add 16 for block header + 28 bytes for page header, total of 44
-        page_data += bytearray(b.read(16))
+        page_data = bytearray(b.read(44))
     else:
         # Size of WT_PAGE_HEADER + size of WT_BLOCK_HEADER
         page_data = bytearray(b.read(40))
@@ -357,32 +353,22 @@ def block_decode(p, b, nbytes, opts):
     b_page = binary_data.BinaryFile(io.BytesIO(page_data))
     p = Printer(b_page, opts)
 
-    if disagg_delta:
-        # WT_BLOCK_HEADER in block.h (44 bytes)
-        blockhead = btree_format.BlockHeader.parse(b_page, disagg=opts.disagg)
-        # WT_PAGE_HEADER in btmem.h (28 bytes)
-        pagehead = btree_format.PageHeader.parse(b_page)
+    # WT_PAGE_HEADER in btmem.h (28 bytes)
+    pagehead = btree_format.PageHeader.parse(b_page)
+    # WT_BLOCK_HEADER in block.h (12 bytes or 44 bytes)
+    if opts.disagg:
+        blockhead = btree_format.BlockDisaggHeader.parse(b_page)
     else:
-        # WT_PAGE_HEADER in btmem.h (28 bytes)
-        pagehead = btree_format.PageHeader.parse(b_page)
-        # WT_BLOCK_HEADER in block.h (12 bytes or 44 bytes)
-        blockhead = btree_format.BlockHeader.parse(b_page, disagg=opts.disagg)
+        blockhead = btree_format.BlockHeader.parse(b_page)
 
-        if pagehead.unused != 0:
-            p.rint('? garbage in unused bytes')
-            return
-        if pagehead.type == btree_format.PageType.WT_PAGE_INVALID:
-            p.rint('? invalid page')
-            return
+    if pagehead.unused != 0:
+        p.rint('? garbage in unused bytes')
+        return
+    if pagehead.type == btree_format.PageType.WT_PAGE_INVALID:
+        p.rint('? invalid page')
+        return
 
-        p.rint('Page Header:')
-        p.rint('  recno: ' + str(pagehead.recno))
-        p.rint('  writegen: ' + str(pagehead.write_gen))
-        p.rint('  memsize: ' + str(pagehead.mem_size))
-        p.rint('  ncells (oflow len): ' + str(pagehead.entries))
-        p.rint('  page type: ' + str(pagehead.type.value) + ' (' + pagehead.type.name + ')')
-        p.rint('  page flags: ' + hex(pagehead.flags))
-        p.rint('  version: ' + str(pagehead.version))
+    p.rint(pagehead)
 
     if blockhead.unused != 0:
         p.rint('garbage in unused bytes')
@@ -399,19 +385,7 @@ def block_decode(p, b, nbytes, opts):
         # The disk size is too small
         return
 
-    p.rint('Block Header:')
-    p.rint('  disk_size: ' + str(blockhead.disk_size))
-    p.rint('  checksum: ' + hex(blockhead.checksum))
-    p.rint('  block flags: ' + hex(blockhead.flags))
-
-    if disagg_delta:
-        p.rint('Delta Page Header:')
-        p.rint('  writegen: ' + str(pagehead.write_gen))
-        p.rint('  memsize: ' + str(pagehead.mem_size))
-        p.rint('  ncells (oflow len): ' + str(pagehead.entries))
-        p.rint('  page type: ' + str(pagehead.type.value) + ' (' + pagehead.type.name + ')')
-        p.rint('  page flags: ' + hex(pagehead.flags))
-        p.rint('  version: ' + str(pagehead.version))
+    p.rint(blockhead)
 
     pagestats = PageStats()
 
@@ -419,7 +393,7 @@ def block_decode(p, b, nbytes, opts):
     if have_crc32c:
         savepos = b.tell()
         b.seek(disk_pos)
-        if blockhead.flags & btree_format.BlockHeader.WT_BLOCK_DATA_CKSUM != 0:
+        if blockhead.flags & btree_format.BlockFlags.WT_BLOCK_DATA_CKSUM != 0:
             check_size = blockhead.disk_size
         else:
             check_size = 64
@@ -438,10 +412,10 @@ def block_decode(p, b, nbytes, opts):
 
     # Skip the rest if we don't want to display the data
     skip_data = opts.skip_data
-    if opts.disagg and blockhead.flags & btree_format.BlockHeader.WT_BLOCK_DISAGG_COMPRESSED:
+    if opts.disagg and blockhead.flags & btree_format.BlockDisaggFlags.WT_BLOCK_DISAGG_COMPRESSED:
         p.rint(f'? the block is compressed, skipping payload')
         skip_data = True
-    if opts.disagg and blockhead.flags & btree_format.BlockHeader.WT_BLOCK_DISAGG_ENCRYPTED:
+    if opts.disagg and blockhead.flags & btree_format.BlockDisaggFlags.WT_BLOCK_DISAGG_ENCRYPTED:
         p.rint(f'? the block is encrypted, skipping payload')
         skip_data = True
 
@@ -452,7 +426,7 @@ def block_decode(p, b, nbytes, opts):
     # Read the block contents
     payload_pos = b.tell()
     header_length = payload_pos - disk_pos
-    if pagehead.flags & btree_format.PageHeader.WT_PAGE_COMPRESSED != 0:
+    if pagehead.flags & btree_format.PageFlags.WT_PAGE_COMPRESSED:
         if not have_snappy:
             p.rint('? the page is compressed (install python-snappy to parse)')
             return


### PR DESCRIPTION
- Fixed block header decoding for disagg pages.
- Moved flags to their own IntFlag class for easier bit checking and printing
    - Multiple set flags should print as PageFlags.WT_PAGE_COMPRESSED|WT_PAGE_ENCRYPTED
- Added `__str__` to print header objects
- See ticket for example output