### PR TITLE
WT-16280 Disable test_ovfl01 Python test temporarily

### DIFF
--- a/test/suite/test_ovfl01.py
+++ b/test/suite/test_ovfl01.py
@@ -71,6 +71,8 @@ class test_ovfl01(wttest.WiredTigerTestCase):
                     raise e
 
     def test_ovfl01(self):
+        # FIXME-WT-15849: Need to fix bulk insert with overflow keys and page splits.
+        self.skipTest("Bulk insert with overflow keys and page splits needs fixing")
         # Create and populate a table.
         self.session.create(self.uri, self.table_config)
         self.populate(self.uri)


### PR DESCRIPTION
This PR disables Python test `test_ovfl01` which failed frequently as a CI-blocker, to avoid more failure instances and buy us time to address the issue properly in the next sprint.

WT-15849 should be used to address the root cause of the issue and re-enable this test. 