### PR TITLE
WT-15827 Catch "buffer allocated and never discarded" in wt tool dump_offsets

### DIFF
--- a/src/include/error.h
+++ b/src/include/error.h
@@ -109,11 +109,6 @@
         if (ret != 0)                              \
             WT_ERR_MSG(session, ret, __VA_ARGS__); \
     } while (0)
-#define WT_USE_ERR()   \
-    do {               \
-        ret = usage(); \
-        goto err;      \
-    } while (0)
 #define WT_ERR_ERROR_OK(a, e, keep) WT_ERR_TEST((ret = (a)) != 0 && ret != (e), ret, keep)
 #define WT_ERR_NOTFOUND_OK(a, keep) WT_ERR_ERROR_OK(a, WT_NOTFOUND, keep)
 

--- a/src/include/error.h
+++ b/src/include/error.h
@@ -109,6 +109,11 @@
         if (ret != 0)                              \
             WT_ERR_MSG(session, ret, __VA_ARGS__); \
     } while (0)
+#define WT_USE_ERR()   \
+    do {               \
+        ret = usage(); \
+        goto err;      \
+    } while (0)
 #define WT_ERR_ERROR_OK(a, e, keep) WT_ERR_TEST((ret = (a)) != 0 && ret != (e), ret, keep)
 #define WT_ERR_NOTFOUND_OK(a, keep) WT_ERR_ERROR_OK(a, WT_NOTFOUND, keep)
 

--- a/src/utilities/util_verify.c
+++ b/src/utilities/util_verify.c
@@ -34,6 +34,12 @@ usage(void)
     return (1);
 }
 
+#define WT_USE_ERR()   \
+    do {               \
+        ret = usage(); \
+        goto err;      \
+    } while (0)
+
 /*
  * verify_one --
  *     Verify the file specified by the URI.

--- a/src/utilities/util_verify.c
+++ b/src/utilities/util_verify.c
@@ -93,14 +93,14 @@ util_verify(WT_SESSION *session, int argc, char *argv[])
                 if (dump_offsets != NULL) {
                     fprintf(
                       stderr, "%s: only a single 'dump_offsets' argument supported\n", progname);
-                    return (usage());
+                    WT_USE_ERR();
                 }
                 dump_offsets = __wt_optarg + strlen("dump_offsets=");
                 WT_ERR(__wt_buf_catfmt(session_impl, config, "dump_offsets=[%s],", dump_offsets));
             } else if (strcmp(__wt_optarg, "dump_pages") == 0)
                 WT_ERR(__wt_buf_catfmt(session_impl, config, "dump_pages,"));
             else
-                return (usage());
+                WT_USE_ERR();
             break;
         case 'k':
             dump_key_data = true;
@@ -123,7 +123,7 @@ util_verify(WT_SESSION *session, int argc, char *argv[])
             usage();
             return (0);
         default:
-            return (usage());
+            WT_USE_ERR();
         }
 
     if (dump_all_data && dump_key_data)

--- a/test/suite/test_util23.py
+++ b/test/suite/test_util23.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wttest
+from suite_subprocess import suite_subprocess
+
+# test_util23.py
+# Test that wt verify properly handles scratch buffers on usage path
+# as part of WT-15827
+class test_util23(wttest.WiredTigerTestCase, suite_subprocess):
+    tablename = 'test_util23.wt'
+    uri = 'file:' + tablename
+    conn_config = ''
+    home = ''
+
+    commands = ["-r", "verify", "-d", "dump_offsets", uri]
+
+    def test_verify_scratch_buffer(self):
+        create_params = 'key_format=S,value_format=S'
+        self.session.create(self.uri, create_params)
+
+        self.runWt(self.commands,
+                   errfilename="errfile.txt",
+                   failure=True)
+
+        self.check_file_contains("errfile.txt", 'usage:')
+        with open("errfile.txt", 'r') as f:
+            content = f.read()
+            # ensure that we no longer see the following error:
+            # "scratch buffer allocated and never discarded: util_verify: 73"
+            self.assertNotIn('scratch buffer allocated and never discarded', content)
+

--- a/test/suite/test_util23.py
+++ b/test/suite/test_util23.py
@@ -50,7 +50,6 @@ class test_util23(wttest.WiredTigerTestCase, suite_subprocess):
         self.check_file_contains("errfile.txt", 'usage:')
         with open("errfile.txt", 'r') as f:
             content = f.read()
-            # ensure that we no longer see the following error:
-            # "scratch buffer allocated and never discarded: util_verify: 73"
+            # Ensure that we no longer see the following error.
             self.assertNotIn('scratch buffer allocated and never discarded', content)
 

--- a/test/suite/test_util23.py
+++ b/test/suite/test_util23.py
@@ -30,8 +30,7 @@ import wttest
 from suite_subprocess import suite_subprocess
 
 # test_util23.py
-# Test that wt verify properly handles scratch buffers on usage path
-# as part of WT-15827
+# Test that wt verify properly handles scratch buffers on usage path.
 class test_util23(wttest.WiredTigerTestCase, suite_subprocess):
     tablename = 'test_util23.wt'
     uri = 'file:' + tablename

--- a/test/suite/test_util23.py
+++ b/test/suite/test_util23.py
@@ -34,8 +34,6 @@ from suite_subprocess import suite_subprocess
 class test_util23(wttest.WiredTigerTestCase, suite_subprocess):
     tablename = 'test_util23.wt'
     uri = 'file:' + tablename
-    conn_config = ''
-    home = ''
 
     commands = ["-r", "verify", "-d", "dump_offsets", uri]
 


### PR DESCRIPTION
Introduced `WT_USE_ERR` macro to capture the return value of `usage` function call and `goto err` so that allocated resources are properly cleaned up.

Also introduced a python test to ensure we no longer encounter this leak. As a sanity check, I ran the test without the fix to ensure it fails appropriately, and it does. 