### PR TITLE
WT-15274 Remove FIXME for supporting preserved prepared for column stores

### DIFF
--- a/src/prepared_discover/prepared_discover_walk.c
+++ b/src/prepared_discover/prepared_discover_walk.c
@@ -276,7 +276,6 @@ __prepared_discover_process_leaf_page(WT_SESSION_IMPL *session, WT_REF *ref)
         WT_RET(__prepared_discover_process_row_store_leaf_page(session, ref));
         break;
     case WT_PAGE_COL_VAR:
-        /* FIXME-WT-15274 Support column store with prepared discovery */
         WT_ASSERT_ALWAYS(session, false, "Prepared discovery does not support column stores");
         /* Fall through. */
     case WT_PAGE_COL_INT:

--- a/test/format/format_config.c
+++ b/test/format/format_config.c
@@ -428,7 +428,6 @@ config_table(TABLE *table, void *arg)
     /* Column-store tables require special row insert resolution. */
     if (table->type != ROW) {
         g.column_store_config = true;
-        /* FIXME-WT-15274 Support column store with precise checkpoint */
         if (GV(PRECISE_CHECKPOINT)) {
             if (config_explicit(NULL, "precise_checkpoint"))
                 WARN("turning off precise_checkpoint as table%" PRIu32 " is a column-store",


### PR DESCRIPTION
Column store is about to be removed. No need to support it for preserved prepared. Remove the FIXME instead.