### PR TITLE
WT-16289 Handle error from bm->free in __checkpoint_tree

### DIFF
--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -2633,7 +2633,7 @@ err:
                  * the discard logic would also need to be reconsidered.
                  */
                 if (F_ISSET(ckpt_temp, WT_CKPT_DELETE) && ckpt_temp->raw.data)
-                    bm->free(bm, session, ckpt_temp->raw.data, ckpt_temp->raw.size);
+                    WT_TRET(bm->free(bm, session, ckpt_temp->raw.data, ckpt_temp->raw.size));
             }
         }
     }


### PR DESCRIPTION
We now capture potential errors from `bm->free`.