### PR TITLE
WT-15949 Implement bitflip detection on checksum mismatch

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -527,6 +527,7 @@ bitcnt
 bitfield
 bitfields
 bitflip
+bitflips
 bitpack
 bitstr
 bitstring

--- a/src/block/block_read.c
+++ b/src/block/block_read.c
@@ -126,6 +126,57 @@ err:
     return (ret);
 }
 
+/*
+ * __block_bitflip_detect --
+ *     Check if flipping a single bit in the data would match the expected checksum. This helps
+ *     diagnose single-bit memory corruption. Skip check for blocks larger than 512KB to avoid
+ *     excessive CPU usage.
+ */
+static bool
+__block_bitflip_detect(
+    void *data, size_t check_size, uint32_t expected_checksum, size_t *bit_position)
+{
+    uint8_t *bytes;
+    size_t byte_idx, bit_idx;
+
+    /* Skip bitflip detection for blocks larger than 512KB */
+    if (check_size > WT_BITFLIP_MAX_SIZE)
+        return (false);
+
+    bytes = (uint8_t *)data;
+
+    /* Try flipping each bit in the data */
+    for (byte_idx = 0; byte_idx < check_size; ++byte_idx) {
+        for (bit_idx = 0; bit_idx < 8; ++bit_idx) {
+            /* Flip the bit */
+            bytes[byte_idx] ^= (1U << bit_idx);
+
+            /* Check if it matches the expected checksum */
+            if (__wt_checksum_match(data, check_size, expected_checksum)) {
+                /* Found a single bit flip that would produce the expected checksum */
+                *bit_position = byte_idx * 8 + bit_idx;
+                /* Flip the bit back before returning */
+                bytes[byte_idx] ^= (1U << bit_idx);
+                return (true);
+            }
+
+            /* Flip the bit back */
+            bytes[byte_idx] ^= (1U << bit_idx);
+        }
+    }
+
+    return (false);
+}
+
+#ifdef HAVE_UNITTEST
+bool
+__ut_block_bitflip_detect(
+  void *data, size_t check_size, uint32_t expected_checksum, size_t *bit_position)
+{
+    return (__block_bitflip_detect(data, check_size, expected_checksum, bit_position));
+}
+#endif
+
 #ifdef HAVE_DIAGNOSTIC
 /*
  * __wt_block_read_off_blind --
@@ -282,6 +333,20 @@ __wti_block_read_off(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_ITEM *buf, ui
               "B block at offset %" PRIuMAX ": block header checksum of %#" PRIx32
               " doesn't match expected checksum of %#" PRIx32,
               block->name, size, (uintmax_t)offset, swap.checksum, checksum);
+
+        /*
+         * Attempt to detect single-bit flips in the data. This can help diagnose memory corruption
+         * issues.
+         */
+        size_t bit_position = 0;
+        if (full_checksum_mismatch &&
+          __block_bitflip_detect(buf->mem, check_size, checksum, &bit_position))
+            __wt_errx(session,
+              "%s: single-bit flip detected at bit position %" WT_SIZET_FMT
+              " (byte %" WT_SIZET_FMT ", bit %" WT_SIZET_FMT
+              ") would produce the expected checksum",
+              block->name, bit_position, bit_position / 8, bit_position % 8);
+
         WT_IGNORE_RET(__wt_bm_corrupt_dump(session, buf, objectid, offset, size, checksum));
     }
 

--- a/src/block/block_read.c
+++ b/src/block/block_read.c
@@ -134,10 +134,10 @@ err:
  */
 static bool
 __block_bitflip_detect(
-    void *data, size_t check_size, uint32_t expected_checksum, size_t *bit_position)
+  void *data, size_t check_size, uint32_t expected_checksum, size_t *bit_position)
 {
-    uint8_t *bytes;
     size_t byte_idx, bit_idx;
+    uint8_t *bytes;
 
     /* Skip bitflip detection for blocks larger than 512KB */
     if (check_size > WT_BITFLIP_MAX_SIZE)
@@ -167,15 +167,6 @@ __block_bitflip_detect(
 
     return (false);
 }
-
-#ifdef HAVE_UNITTEST
-bool
-__ut_block_bitflip_detect(
-  void *data, size_t check_size, uint32_t expected_checksum, size_t *bit_position)
-{
-    return (__block_bitflip_detect(data, check_size, expected_checksum, bit_position));
-}
-#endif
 
 #ifdef HAVE_DIAGNOSTIC
 /*
@@ -339,13 +330,17 @@ __wti_block_read_off(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_ITEM *buf, ui
          * issues.
          */
         size_t bit_position = 0;
-        if (full_checksum_mismatch &&
-          __block_bitflip_detect(buf->mem, check_size, checksum, &bit_position))
-            __wt_errx(session,
-              "%s: single-bit flip detected at bit position %" WT_SIZET_FMT
-              " (byte %" WT_SIZET_FMT ", bit %" WT_SIZET_FMT
-              ") would produce the expected checksum",
-              block->name, bit_position, bit_position / 8, bit_position % 8);
+        if (full_checksum_mismatch) {
+            if (__block_bitflip_detect(buf->mem, check_size, checksum, &bit_position))
+                __wt_errx(session,
+                  "%s: single-bit flip detected at bit position %" WT_SIZET_FMT
+                  " (byte %" WT_SIZET_FMT ", bit %" WT_SIZET_FMT
+                  ") would produce the expected checksum",
+                  block->name, bit_position, bit_position / 8, bit_position % 8);
+            else
+                __wt_errx(session, "%s: bitflip detection performed but no single-bit flip found",
+                  block->name);
+        }
 
         WT_IGNORE_RET(__wt_bm_corrupt_dump(session, buf, objectid, offset, size, checksum));
     }
@@ -360,3 +355,12 @@ __wti_block_read_off(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_ITEM *buf, ui
 
     WT_RET_PANIC(session, WT_ERROR, "%s: fatal read error", block->name);
 }
+
+#ifdef HAVE_UNITTEST
+bool
+__ut_block_bitflip_detect(
+  void *data, size_t check_size, uint32_t expected_checksum, size_t *bit_position)
+{
+    return (__block_bitflip_detect(data, check_size, expected_checksum, bit_position));
+}
+#endif

--- a/src/block/block_read.c
+++ b/src/block/block_read.c
@@ -129,8 +129,8 @@ err:
 /*
  * __block_bitflip_detect --
  *     Check if flipping a single bit in the data would match the expected checksum. This helps
- *     diagnose single-bit memory corruption. Skip check for blocks larger than 512KB to avoid
- *     excessive CPU usage.
+ *     diagnose single-bit memory corruption. Skip check for blocks larger than WT_BITFLIP_MAX_SIZE
+ *     to avoid excessive CPU usage.
  */
 static bool
 __block_bitflip_detect(

--- a/src/block/block_read.c
+++ b/src/block/block_read.c
@@ -326,11 +326,17 @@ __wti_block_read_off(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_ITEM *buf, ui
               block->name, size, (uintmax_t)offset, swap.checksum, checksum);
 
         /*
+         * Dump the corrupted block for analysis prior to bitflip detection in case detection takes
+         * too long.
+         */
+        WT_IGNORE_RET(__wt_bm_corrupt_dump(session, buf, objectid, offset, size, checksum));
+
+        /*
          * Attempt to detect single-bit flips in the data. This can help diagnose memory corruption
          * issues.
          */
-        size_t bit_position = 0;
         if (full_checksum_mismatch) {
+            size_t bit_position = 0;
             if (__block_bitflip_detect(buf->mem, check_size, checksum, &bit_position))
                 __wt_errx(session,
                   "%s: single-bit flip detected at bit position %" WT_SIZET_FMT
@@ -341,8 +347,6 @@ __wti_block_read_off(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_ITEM *buf, ui
                 __wt_errx(session, "%s: bitflip detection performed but no single-bit flip found",
                   block->name);
         }
-
-        WT_IGNORE_RET(__wt_bm_corrupt_dump(session, buf, objectid, offset, size, checksum));
     }
 
     /* Panic if a checksum fails during an ordinary read. */

--- a/src/block/block_read.c
+++ b/src/block/block_read.c
@@ -129,39 +129,38 @@ err:
 /*
  * __block_bitflip_detect --
  *     Check if flipping a single bit in the data would match the expected checksum. This helps
- *     diagnose single-bit memory corruption. Skip check for blocks larger than WT_BITFLIP_MAX_SIZE
- *     to avoid excessive CPU usage.
+ *     diagnose single-bit memory corruption. Skip check for blocks larger than a defined size to
+ *     avoid excessive CPU usage.
  */
 static bool
 __block_bitflip_detect(
   void *data, size_t check_size, uint32_t expected_checksum, size_t *bit_position)
 {
-    size_t byte_idx, bit_idx;
+    size_t byte_index, bit_index;
     uint8_t *bytes;
 
-    /* Skip bitflip detection for blocks larger than 512KB */
     if (check_size > WT_BITFLIP_MAX_SIZE)
         return (false);
 
     bytes = (uint8_t *)data;
 
-    /* Try flipping each bit in the data */
-    for (byte_idx = 0; byte_idx < check_size; ++byte_idx) {
-        for (bit_idx = 0; bit_idx < 8; ++bit_idx) {
-            /* Flip the bit */
-            bytes[byte_idx] ^= (1U << bit_idx);
+    /* Try flipping each bit in the data. */
+    for (byte_index = 0; byte_index < check_size; ++byte_index) {
+        for (bit_index = 0; bit_index < 8; ++bit_index) {
+            /* Flip the bit. */
+            bytes[byte_index] ^= (1U << bit_index);
 
-            /* Check if it matches the expected checksum */
+            /* Check if it matches the expected checksum. */
             if (__wt_checksum_match(data, check_size, expected_checksum)) {
-                /* Found a single bit flip that would produce the expected checksum */
-                *bit_position = byte_idx * 8 + bit_idx;
-                /* Flip the bit back before returning */
-                bytes[byte_idx] ^= (1U << bit_idx);
+                /* Found a single bit flip that would produce the expected checksum. */
+                *bit_position = byte_index * 8 + bit_index;
+                /* Flip the bit back before returning. */
+                bytes[byte_index] ^= (1U << bit_index);
                 return (true);
             }
 
-            /* Flip the bit back */
-            bytes[byte_idx] ^= (1U << bit_idx);
+            /* Flip the bit back. */
+            bytes[byte_index] ^= (1U << bit_index);
         }
     }
 

--- a/src/include/block.h
+++ b/src/include/block.h
@@ -19,6 +19,13 @@
 #define WT_BLOCK_INVALID_OFFSET 0
 
 /*
+ * The max corrupt block size that we'll attempt to detect bitflips for. Essentially default
+ * leaf_page_max with a buffer.
+ */
+#define WT_BITFLIP_MAX_SIZE (WT_KILOBYTE * 33) /* 33KB */
+
+
+/*
  * The block manager maintains three per-checkpoint extent lists:
  *	alloc:	 the extents allocated in this checkpoint
  *	avail:	 the extents available for allocation

--- a/src/include/block.h
+++ b/src/include/block.h
@@ -24,7 +24,6 @@
  */
 #define WT_BITFLIP_MAX_SIZE (WT_KILOBYTE * 33) /* 33KB */
 
-
 /*
  * The block manager maintains three per-checkpoint extent lists:
  *	alloc:	 the extents allocated in this checkpoint

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2489,6 +2489,8 @@ static inline bool __wt_get_page_modify_ta(WT_SESSION_IMPL *session, WT_PAGE *pa
 #ifdef HAVE_UNITTEST
 extern WT_EXT *__ut_block_off_srch_last(WT_EXT **head, WT_EXT ***stack)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern bool __ut_block_bitflip_detect(void *data, size_t check_size, uint32_t expected_checksum,
+  size_t *bit_position) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __ut_block_first_srch(WT_SESSION_IMPL *session, WT_EXT **head, wt_off_t size,
   WT_EXT ***stack) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __ut_block_off_match(WT_EXTLIST *el, wt_off_t off, wt_off_t size)

--- a/test/catch2/CMakeLists.txt
+++ b/test/catch2/CMakeLists.txt
@@ -25,6 +25,7 @@ else()
         block/api/test_block_api_write.cpp
         block/unit/test_bitstring.cpp
         block/unit/test_block_addr.cpp
+        block/unit/test_block_bitflip.cpp
         block/unit/test_block_ckpt.cpp
         block/unit/test_block_file.cpp
         block/unit/test_block_other.cpp

--- a/test/catch2/block/unit/test_block_bitflip.cpp
+++ b/test/catch2/block/unit/test_block_bitflip.cpp
@@ -1,0 +1,318 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+/*
+ * [block_bitflip]: block_read.c
+ * This file unit tests the bitflip detection function used to diagnose single-bit memory
+ * corruption in block checksums.
+ */
+
+#include <catch2/catch.hpp>
+#include <cstring>
+#include <vector>
+
+#include "wt_internal.h"
+
+/*
+ * Fixture to initialize the checksum function needed by __wt_checksum and __wt_checksum_match.
+ */
+struct checksum_fixture {
+    checksum_fixture()
+    {
+        // Initialize the checksum function if not already initialized
+        if (__wt_process.checksum == nullptr)
+            __wt_process.checksum = wiredtiger_crc32c_func();
+    }
+};
+
+TEST_CASE("Block bitflip detection: basic functionality", "[block_bitflip]")
+{
+    checksum_fixture fixture;
+    std::vector<uint8_t> data(128, 0);
+    size_t bit_position = 0;
+
+    SECTION("Detect single bit flip in first byte")
+    {
+        // Initialize with some data
+        for (size_t i = 0; i < data.size(); ++i)
+            data[i] = static_cast<uint8_t>(i);
+
+        // Calculate the correct checksum
+        uint32_t correct_checksum = __wt_checksum(data.data(), data.size());
+
+        // Flip the first bit (bit 0 of byte 0)
+        data[0] ^= 1;
+
+        // The function should find that flipping bit 0 would match the correct_checksum
+        bool found =
+          __ut_block_bitflip_detect(data.data(), data.size(), correct_checksum, &bit_position);
+
+        CHECK(found == true);
+        CHECK(bit_position == 0);
+    }
+
+    SECTION("Detect single bit flip in middle byte")
+    {
+        // Initialize with some data
+        for (size_t i = 0; i < data.size(); ++i)
+            data[i] = static_cast<uint8_t>(i * 3 + 42);
+
+        // Calculate the correct checksum
+        uint32_t correct_checksum = __wt_checksum(data.data(), data.size());
+
+        // Flip bit 3 of byte 64
+        size_t target_byte = 64;
+        size_t target_bit = 3;
+        data[target_byte] ^= (1U << target_bit);
+
+        // The function should find the flipped bit
+        bool found =
+          __ut_block_bitflip_detect(data.data(), data.size(), correct_checksum, &bit_position);
+
+        CHECK(found == true);
+        CHECK(bit_position == target_byte * 8 + target_bit);
+    }
+
+    SECTION("Detect single bit flip in last byte")
+    {
+        // Initialize with some data
+        for (size_t i = 0; i < data.size(); ++i)
+            data[i] = static_cast<uint8_t>(0xFF - i);
+
+        // Calculate the correct checksum
+        uint32_t correct_checksum = __wt_checksum(data.data(), data.size());
+
+        // Flip the last bit (bit 7 of last byte)
+        size_t target_byte = data.size() - 1;
+        size_t target_bit = 7;
+        data[target_byte] ^= (1U << target_bit);
+
+        // The function should find the flipped bit
+        bool found =
+          __ut_block_bitflip_detect(data.data(), data.size(), correct_checksum, &bit_position);
+
+        CHECK(found == true);
+        CHECK(bit_position == target_byte * 8 + target_bit);
+    }
+}
+
+TEST_CASE("Block bitflip detection: no bit flip", "[block_bitflip]")
+{
+    checksum_fixture fixture;
+    std::vector<uint8_t> data(64, 0);
+    size_t bit_position = 0;
+
+    SECTION("Checksums match - no corruption")
+    {
+        // Initialize with some data
+        for (size_t i = 0; i < data.size(); ++i)
+            data[i] = static_cast<uint8_t>(i * 7);
+
+        // Calculate checksum
+        uint32_t checksum = __wt_checksum(data.data(), data.size());
+
+        // Pass the same checksum - should not find any bit flip
+        bool found = __ut_block_bitflip_detect(data.data(), data.size(), checksum, &bit_position);
+
+        CHECK(found == false);
+    }
+
+    SECTION("Multiple bits flipped - not detectable")
+    {
+        // Initialize with some data
+        for (size_t i = 0; i < data.size(); ++i)
+            data[i] = static_cast<uint8_t>(i);
+
+        // Calculate the correct checksum
+        uint32_t correct_checksum = __wt_checksum(data.data(), data.size());
+
+        // Flip two bits
+        data[10] ^= 1;
+        data[20] ^= 2;
+
+        // The function should not find a single bit flip that matches
+        // (unless by extreme coincidence two single-bit flips result in the same checksum)
+        bool found =
+          __ut_block_bitflip_detect(data.data(), data.size(), correct_checksum, &bit_position);
+
+        // Most likely this will be false, but checksums can collide
+        // We mainly want to ensure the function doesn't crash
+        (void)found;
+    }
+}
+
+TEST_CASE("Block bitflip detection: size limits", "[block_bitflip]")
+{
+    checksum_fixture fixture;
+    size_t bit_position = 0;
+
+    SECTION("Block size at limit - 512KB")
+    {
+        size_t size = WT_BITFLIP_MAX_SIZE;
+        std::vector<uint8_t> data(size, 0);
+
+        // Initialize with pattern
+        for (size_t i = 0; i < size; ++i)
+            data[i] = static_cast<uint8_t>(i & 0xFF);
+
+        uint32_t correct_checksum = __wt_checksum(data.data(), data.size());
+
+        // Flip a bit near the beginning
+        data[100] ^= 4;
+
+        // Should still work at exactly the limit
+        bool found =
+          __ut_block_bitflip_detect(data.data(), data.size(), correct_checksum, &bit_position);
+
+        CHECK(found == true);
+        CHECK(bit_position == 100 * 8 + 2);
+    }
+
+    SECTION("Block size exceeds limit - skip detection")
+    {
+        size_t size = WT_BITFLIP_MAX_SIZE + 1;
+        std::vector<uint8_t> data(size, 0);
+
+        // Initialize with pattern
+        for (size_t i = 0; i < std::min(size, (size_t)1024); ++i)
+            data[i] = static_cast<uint8_t>(i);
+
+        uint32_t checksum = __wt_checksum(data.data(), data.size());
+
+        // Should return false immediately without checking
+        bool found = __ut_block_bitflip_detect(data.data(), data.size(), checksum, &bit_position);
+
+        CHECK(found == false);
+    }
+}
+
+TEST_CASE("Block bitflip detection: all bit positions", "[block_bitflip]")
+{
+    checksum_fixture fixture;
+    // Test that we can detect a flip in each of the 8 bit positions
+    std::vector<uint8_t> data(32, 0);
+
+    for (size_t i = 0; i < data.size(); ++i)
+        data[i] = static_cast<uint8_t>(i * 13 + 7);
+
+    SECTION("Test each bit position in a single byte")
+    {
+        for (size_t bit = 0; bit < 8; ++bit) {
+            size_t bit_position = 0;
+            size_t target_byte = 15;
+
+            // Calculate correct checksum
+            uint32_t correct_checksum = __wt_checksum(data.data(), data.size());
+
+            // Flip the target bit
+            data[target_byte] ^= (1U << bit);
+
+            // Detect the flip
+            bool found =
+              __ut_block_bitflip_detect(data.data(), data.size(), correct_checksum, &bit_position);
+
+            CHECK(found == true);
+            CHECK(bit_position == target_byte * 8 + bit);
+
+            // Flip back for next iteration
+            data[target_byte] ^= (1U << bit);
+        }
+    }
+}
+
+TEST_CASE("Block bitflip detection: edge cases", "[block_bitflip]")
+{
+    checksum_fixture fixture;
+    size_t bit_position = 0;
+
+    SECTION("Single byte buffer")
+    {
+        std::vector<uint8_t> data(1, 0x42);
+
+        uint32_t correct_checksum = __wt_checksum(data.data(), data.size());
+
+        // Flip bit 5
+        data[0] ^= (1U << 5);
+
+        bool found =
+          __ut_block_bitflip_detect(data.data(), data.size(), correct_checksum, &bit_position);
+
+        CHECK(found == true);
+        CHECK(bit_position == 5);
+    }
+
+    SECTION("All zeros with single bit flip")
+    {
+        std::vector<uint8_t> data(100, 0);
+
+        uint32_t correct_checksum = __wt_checksum(data.data(), data.size());
+
+        // Flip one bit
+        data[50] ^= 1;
+
+        bool found =
+          __ut_block_bitflip_detect(data.data(), data.size(), correct_checksum, &bit_position);
+
+        CHECK(found == true);
+        CHECK(bit_position == 50 * 8);
+    }
+
+    SECTION("All ones with single bit flip")
+    {
+        std::vector<uint8_t> data(100, 0xFF);
+
+        uint32_t correct_checksum = __wt_checksum(data.data(), data.size());
+
+        // Flip one bit (changing 1 to 0)
+        data[33] ^= (1U << 4);
+
+        bool found =
+          __ut_block_bitflip_detect(data.data(), data.size(), correct_checksum, &bit_position);
+
+        CHECK(found == true);
+        CHECK(bit_position == 33 * 8 + 4);
+    }
+}
+
+TEST_CASE("Block bitflip detection: data integrity", "[block_bitflip]")
+{
+    std::vector<uint8_t> data(256, 0);
+    size_t bit_position = 0;
+
+    SECTION("Data is restored after detection")
+    {
+        // Initialize with a known pattern
+        for (size_t i = 0; i < data.size(); ++i)
+            data[i] = static_cast<uint8_t>(i);
+
+        // Save original data
+        std::vector<uint8_t> original_data = data;
+
+        uint32_t correct_checksum = __wt_checksum(data.data(), data.size());
+
+        // Flip a bit
+        data[128] ^= (1U << 3);
+
+        // Run detection
+        bool found =
+          __ut_block_bitflip_detect(data.data(), data.size(), correct_checksum, &bit_position);
+
+        CHECK(found == true);
+
+        // Data should be restored to the corrupted state (with the one flipped bit)
+        // The function flips bits back after testing each one
+        CHECK(data[128] == (original_data[128] ^ (1U << 3)));
+
+        // All other bytes should be unchanged
+        for (size_t i = 0; i < data.size(); ++i) {
+            if (i != 128) {
+                CHECK(data[i] == original_data[i]);
+            }
+        }
+    }
+}

--- a/test/catch2/block/unit/test_block_bitflip.cpp
+++ b/test/catch2/block/unit/test_block_bitflip.cpp
@@ -149,7 +149,7 @@ TEST_CASE("Block bitflip detection: size limits", "[block_bitflip]")
     checksum_fixture fixture;
     size_t bit_position = 0;
 
-    SECTION("Block size at limit - 512KB")
+    SECTION("Block size at limit")
     {
         size_t size = WT_BITFLIP_MAX_SIZE;
         std::vector<uint8_t> data(size, 0);
@@ -177,7 +177,7 @@ TEST_CASE("Block bitflip detection: size limits", "[block_bitflip]")
         std::vector<uint8_t> data(size, 0);
 
         // Initialize with pattern.
-        for (size_t i = 0; i < std::min(size, (size_t)1024); ++i)
+        for (size_t i = 0; i < size; ++i)
             data[i] = static_cast<uint8_t>(i);
 
         uint32_t checksum = __wt_checksum(data.data(), data.size());
@@ -279,6 +279,7 @@ TEST_CASE("Block bitflip detection: edge cases", "[block_bitflip]")
 
 TEST_CASE("Block bitflip detection: data integrity", "[block_bitflip]")
 {
+    checksum_fixture fixture;
     std::vector<uint8_t> data(256, 0);
     size_t bit_position = 0;
 

--- a/test/catch2/block/unit/test_block_bitflip.cpp
+++ b/test/catch2/block/unit/test_block_bitflip.cpp
@@ -18,13 +18,11 @@
 
 #include "wt_internal.h"
 
-/*
- * Fixture to initialize the checksum function needed by __wt_checksum and __wt_checksum_match.
- */
+/* Fixture to initialize the checksum function needed by __wt_checksum and __wt_checksum_match. */
 struct checksum_fixture {
     checksum_fixture()
     {
-        // Initialize the checksum function if not already initialized
+        // Initialize the checksum function if not already initialized.
         if (__wt_process.checksum == nullptr)
             __wt_process.checksum = wiredtiger_crc32c_func();
     }
@@ -38,17 +36,17 @@ TEST_CASE("Block bitflip detection: basic functionality", "[block_bitflip]")
 
     SECTION("Detect single bit flip in first byte")
     {
-        // Initialize with some data
+        // Initialize with some data.
         for (size_t i = 0; i < data.size(); ++i)
             data[i] = static_cast<uint8_t>(i);
 
-        // Calculate the correct checksum
+        // Calculate the correct checksum.
         uint32_t correct_checksum = __wt_checksum(data.data(), data.size());
 
-        // Flip the first bit (bit 0 of byte 0)
+        // Flip the first bit (bit 0 of byte 0).
         data[0] ^= 1;
 
-        // The function should find that flipping bit 0 would match the correct_checksum
+        // The function should find that flipping bit 0 would match the correct_checksum.
         bool found =
           __ut_block_bitflip_detect(data.data(), data.size(), correct_checksum, &bit_position);
 
@@ -58,19 +56,19 @@ TEST_CASE("Block bitflip detection: basic functionality", "[block_bitflip]")
 
     SECTION("Detect single bit flip in middle byte")
     {
-        // Initialize with some data
+        // Initialize with some data.
         for (size_t i = 0; i < data.size(); ++i)
             data[i] = static_cast<uint8_t>(i * 3 + 42);
 
-        // Calculate the correct checksum
+        // Calculate the correct checksum.
         uint32_t correct_checksum = __wt_checksum(data.data(), data.size());
 
-        // Flip bit 3 of byte 64
+        // Flip bit 3 of byte 64.
         size_t target_byte = 64;
         size_t target_bit = 3;
         data[target_byte] ^= (1U << target_bit);
 
-        // The function should find the flipped bit
+        // The function should find the flipped bit.
         bool found =
           __ut_block_bitflip_detect(data.data(), data.size(), correct_checksum, &bit_position);
 
@@ -80,19 +78,19 @@ TEST_CASE("Block bitflip detection: basic functionality", "[block_bitflip]")
 
     SECTION("Detect single bit flip in last byte")
     {
-        // Initialize with some data
+        // Initialize with some data.
         for (size_t i = 0; i < data.size(); ++i)
             data[i] = static_cast<uint8_t>(0xFF - i);
 
-        // Calculate the correct checksum
+        // Calculate the correct checksum.
         uint32_t correct_checksum = __wt_checksum(data.data(), data.size());
 
-        // Flip the last bit (bit 7 of last byte)
+        // Flip the last bit (bit 7 of last byte).
         size_t target_byte = data.size() - 1;
         size_t target_bit = 7;
         data[target_byte] ^= (1U << target_bit);
 
-        // The function should find the flipped bit
+        // The function should find the flipped bit.
         bool found =
           __ut_block_bitflip_detect(data.data(), data.size(), correct_checksum, &bit_position);
 
@@ -109,14 +107,14 @@ TEST_CASE("Block bitflip detection: no bit flip", "[block_bitflip]")
 
     SECTION("Checksums match - no corruption")
     {
-        // Initialize with some data
+        // Initialize with some data.
         for (size_t i = 0; i < data.size(); ++i)
             data[i] = static_cast<uint8_t>(i * 7);
 
-        // Calculate checksum
+        // Calculate checksum.
         uint32_t checksum = __wt_checksum(data.data(), data.size());
 
-        // Pass the same checksum - should not find any bit flip
+        // Pass the same checksum - should not find any bit flip.
         bool found = __ut_block_bitflip_detect(data.data(), data.size(), checksum, &bit_position);
 
         CHECK(found == false);
@@ -124,24 +122,24 @@ TEST_CASE("Block bitflip detection: no bit flip", "[block_bitflip]")
 
     SECTION("Multiple bits flipped - not detectable")
     {
-        // Initialize with some data
+        // Initialize with some data.
         for (size_t i = 0; i < data.size(); ++i)
             data[i] = static_cast<uint8_t>(i);
 
-        // Calculate the correct checksum
+        // Calculate the correct checksum.
         uint32_t correct_checksum = __wt_checksum(data.data(), data.size());
 
-        // Flip two bits
+        // Flip two bits.
         data[10] ^= 1;
         data[20] ^= 2;
 
         // The function should not find a single bit flip that matches
-        // (unless by extreme coincidence two single-bit flips result in the same checksum)
+        // (unless by extreme coincidence two single-bit flips result in the same checksum).
         bool found =
           __ut_block_bitflip_detect(data.data(), data.size(), correct_checksum, &bit_position);
 
-        // Most likely this will be false, but checksums can collide
-        // We mainly want to ensure the function doesn't crash
+        // Most likely this will be false, but checksums can collide.
+        // We mainly want to ensure the function doesn't crash.
         (void)found;
     }
 }
@@ -156,16 +154,16 @@ TEST_CASE("Block bitflip detection: size limits", "[block_bitflip]")
         size_t size = WT_BITFLIP_MAX_SIZE;
         std::vector<uint8_t> data(size, 0);
 
-        // Initialize with pattern
+        // Initialize with pattern.
         for (size_t i = 0; i < size; ++i)
             data[i] = static_cast<uint8_t>(i & 0xFF);
 
         uint32_t correct_checksum = __wt_checksum(data.data(), data.size());
 
-        // Flip a bit near the beginning
+        // Flip a bit near the beginning.
         data[100] ^= 4;
 
-        // Should still work at exactly the limit
+        // Should still work at exactly the limit.
         bool found =
           __ut_block_bitflip_detect(data.data(), data.size(), correct_checksum, &bit_position);
 
@@ -178,13 +176,13 @@ TEST_CASE("Block bitflip detection: size limits", "[block_bitflip]")
         size_t size = WT_BITFLIP_MAX_SIZE + 1;
         std::vector<uint8_t> data(size, 0);
 
-        // Initialize with pattern
+        // Initialize with pattern.
         for (size_t i = 0; i < std::min(size, (size_t)1024); ++i)
             data[i] = static_cast<uint8_t>(i);
 
         uint32_t checksum = __wt_checksum(data.data(), data.size());
 
-        // Should return false immediately without checking
+        // Should return false immediately without checking.
         bool found = __ut_block_bitflip_detect(data.data(), data.size(), checksum, &bit_position);
 
         CHECK(found == false);
@@ -194,7 +192,7 @@ TEST_CASE("Block bitflip detection: size limits", "[block_bitflip]")
 TEST_CASE("Block bitflip detection: all bit positions", "[block_bitflip]")
 {
     checksum_fixture fixture;
-    // Test that we can detect a flip in each of the 8 bit positions
+    // Test that we can detect a flip in each of the 8 bit positions.
     std::vector<uint8_t> data(32, 0);
 
     for (size_t i = 0; i < data.size(); ++i)
@@ -206,20 +204,20 @@ TEST_CASE("Block bitflip detection: all bit positions", "[block_bitflip]")
             size_t bit_position = 0;
             size_t target_byte = 15;
 
-            // Calculate correct checksum
+            // Calculate correct checksum.
             uint32_t correct_checksum = __wt_checksum(data.data(), data.size());
 
-            // Flip the target bit
+            // Flip the target bit.
             data[target_byte] ^= (1U << bit);
 
-            // Detect the flip
+            // Detect the flip.
             bool found =
               __ut_block_bitflip_detect(data.data(), data.size(), correct_checksum, &bit_position);
 
             CHECK(found == true);
             CHECK(bit_position == target_byte * 8 + bit);
 
-            // Flip back for next iteration
+            // Flip back for next iteration.
             data[target_byte] ^= (1U << bit);
         }
     }
@@ -236,7 +234,7 @@ TEST_CASE("Block bitflip detection: edge cases", "[block_bitflip]")
 
         uint32_t correct_checksum = __wt_checksum(data.data(), data.size());
 
-        // Flip bit 5
+        // Flip bit 5.
         data[0] ^= (1U << 5);
 
         bool found =
@@ -252,7 +250,7 @@ TEST_CASE("Block bitflip detection: edge cases", "[block_bitflip]")
 
         uint32_t correct_checksum = __wt_checksum(data.data(), data.size());
 
-        // Flip one bit
+        // Flip one bit.
         data[50] ^= 1;
 
         bool found =
@@ -268,7 +266,7 @@ TEST_CASE("Block bitflip detection: edge cases", "[block_bitflip]")
 
         uint32_t correct_checksum = __wt_checksum(data.data(), data.size());
 
-        // Flip one bit (changing 1 to 0)
+        // Flip one bit (changing 1 to 0).
         data[33] ^= (1U << 4);
 
         bool found =
@@ -286,29 +284,29 @@ TEST_CASE("Block bitflip detection: data integrity", "[block_bitflip]")
 
     SECTION("Data is restored after detection")
     {
-        // Initialize with a known pattern
+        // Initialize with a known pattern.
         for (size_t i = 0; i < data.size(); ++i)
             data[i] = static_cast<uint8_t>(i);
 
-        // Save original data
+        // Save original data.
         std::vector<uint8_t> original_data = data;
 
         uint32_t correct_checksum = __wt_checksum(data.data(), data.size());
 
-        // Flip a bit
+        // Flip a bit.
         data[128] ^= (1U << 3);
 
-        // Run detection
+        // Run detection.
         bool found =
           __ut_block_bitflip_detect(data.data(), data.size(), correct_checksum, &bit_position);
 
         CHECK(found == true);
 
-        // Data should be restored to the corrupted state (with the one flipped bit)
-        // The function flips bits back after testing each one
+        // Data should be restored to the corrupted state (with the one flipped bit).
+        // The function flips bits back after testing each one.
         CHECK(data[128] == (original_data[128] ^ (1U << 3)));
 
-        // All other bytes should be unchanged
+        // All other bytes should be unchanged.
         for (size_t i = 0; i < data.size(); ++i) {
             if (i != 128) {
                 CHECK(data[i] == original_data[i]);


### PR DESCRIPTION
This change closes a gap we have w.r.t. AF corruption analysis. Essentially we flip every bit in the block and recompute the checksum. If it matches we log success and the location of the bit, if it doesn't we log that we attempted to do the bitflip detection but failed.

Comes with unit testing as python testing is painfully hard.