### PR TITLE
WT-16303 Implement hook key_provider testing

### DIFF
--- a/lang/python/wiredtiger.i
+++ b/lang/python/wiredtiger.i
@@ -1480,7 +1480,6 @@ int standalone_build();
 %ignore __wt_connection::add_data_source;
 %ignore __wt_connection::add_encryptor;
 %ignore __wt_connection::get_extension_api;
-%ignore __wt_connection::set_key_provider;
 %ignore __wt_session::log_printf;
 
 OVERRIDE_METHOD(__wt_session, WT_SESSION, log_printf, (self, msg))

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2493,6 +2493,19 @@ tasks:
           format_args: disagg.mode=leader runs.rows=100000:300000 runs.tables=1:3 runs.ops=300000
           additional_san_vars: export TSAN_OPTIONS="$TSAN_OPTIONS:detect_deadlocks=0"
           times: 3
+  - name: unit-test-hook-disagg-leader-key-provider
+    tags: ["python"]
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+        vars:
+          # As leader, run the set of tests that are not in the fail list.
+          unit_test_ignore: test/suite/hook_disagg.fail
+          # The timeout for this command is on a test file basis. Make the timeouts long,
+          # as there are a few files that contain a large number of slower tests.
+          unit_test_args: -v 2 --timeout 1800 --hook "disagg=(role=leader,key_provider=true)"
 
   - name: unit-test-hook-disagg-leader-bucket00
     tags: ["pull_request", "python"]
@@ -6416,6 +6429,7 @@ buildvariants:
     - name: unit-test-zstd
     - name: unit-test-random-seed
     - name: unit-test-hook-disagg-follower
+    - name: unit-test-hook-disagg-leader-key-provider
     - name: unit-test-hook-disagg-follower-table
     - name: unit-test-hook-tiered
     - name: unit-test-hook-tiered-with-delays
@@ -6486,6 +6500,7 @@ buildvariants:
   tags: ["pull_request", "sanitizer"]
   tasks:
     - name: ".pull_request !.pull_request_compilers !.python !.tiered_unittest !csuite-wt12015-backup-corruption-test"
+    - name: unit-test-hook-disagg-leader-key-provider
     - name: examples-c-test
     - name: format-asan-smoke-test
     - name: model-test-long

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -6500,7 +6500,6 @@ buildvariants:
   tags: ["pull_request", "sanitizer"]
   tasks:
     - name: ".pull_request !.pull_request_compilers !.python !.tiered_unittest !csuite-wt12015-backup-corruption-test"
-    - name: unit-test-hook-disagg-leader-key-provider
     - name: examples-c-test
     - name: format-asan-smoke-test
     - name: model-test-long

--- a/test/suite/hook_disagg.py
+++ b/test/suite/hook_disagg.py
@@ -158,7 +158,7 @@ def wiredtiger_open_replace(orig_wiredtiger_open, homedir, conn_config):
         ext_lib = '\"%s\"=(config=\"%s\")' % (page_log_extension[0], page_log_config)
 
     if key_provider:
-        key_provider_extension_config =  '\"%s\"=(early_load=true,config="verbose=-1")' % (key_provider_extension[0])
+        key_provider_extension_config =  '\"%s\"=(early_load=true,config="verbose=-1,key_expires=0")' % (key_provider_extension[0])
         disagg_config += ',' + ext_string + ',%s,%s]' % (ext_lib, key_provider_extension_config)
     else:
         disagg_config += ',' + ext_string + ',%s]' % ext_lib

--- a/test/suite/hook_disagg.py
+++ b/test/suite/hook_disagg.py
@@ -97,13 +97,13 @@ def wiredtiger_open_replace(orig_wiredtiger_open, homedir, conn_config):
 
     page_log_extension = WiredTigerTestCase.findExtension('page_log', page_log_name)
     if len(page_log_extension) == 0:
-        raise Exception(page_log_name + ' storage source extension not found')
+        raise RuntimeError(page_log_name + ' storage source extension not found')
 
     key_provider_extension = None
     if (key_provider is not None):
         key_provider_extension = WiredTigerTestCase.findExtension('test', "key_provider")
         if len(key_provider_extension) == 0:
-            raise Exception(key_provider_extension[0] + ' key provider extension not found')
+            raise RuntimeError(key_provider_extension[0] + ' key provider extension not found')
 
     WiredTigerTestCase.verbose(None, 3, f'role={disagg_parameters.role}')
     disagg_config = ',verbose=[layered]' \
@@ -157,11 +157,13 @@ def wiredtiger_open_replace(orig_wiredtiger_open, homedir, conn_config):
     else:
         ext_lib = '\"%s\"=(config=\"%s\")' % (page_log_extension[0], page_log_config)
 
+    disagg_config += f',{ext_string},{ext_lib}'
+    # Load the key provider extension. Configure low verbosity to eliminate test failures due to unexpected output and
+    # to always key expire such that we can perform a key rotation everytime a checkpoint is called.
     if key_provider:
         key_provider_extension_config =  '\"%s\"=(early_load=true,config="verbose=-1,key_expires=0")' % (key_provider_extension[0])
-        disagg_config += ',' + ext_string + ',%s,%s]' % (ext_lib, key_provider_extension_config)
-    else:
-        disagg_config += ',' + ext_string + ',%s]' % ext_lib
+        disagg_config += f',{key_provider_extension_config}'
+    disagg_config += ']'
 
     config = conn_config + disagg_config
 

--- a/test/suite/hook_disagg.py
+++ b/test/suite/hook_disagg.py
@@ -153,15 +153,15 @@ def wiredtiger_open_replace(orig_wiredtiger_open, homedir, conn_config):
             page_log_config = f"cache_size_mb=2048,{page_log_config}"
 
     if page_log_config == None:
-        ext_lib = '\"%s\"' % page_log_extension[0]
+        ext_lib = f'\"{page_log_extension[0]}\"'
     else:
-        ext_lib = '\"%s\"=(config=\"%s\")' % (page_log_extension[0], page_log_config)
+        ext_lib = f'\"{page_log_extension[0]}\"=(config=\"{page_log_config}\")'
 
     disagg_config += f',{ext_string},{ext_lib}'
     # Load the key provider extension. Configure low verbosity to eliminate test failures due to unexpected output and
     # to always key expire such that we can perform a key rotation everytime a checkpoint is called.
     if key_provider:
-        key_provider_extension_config =  '\"%s\"=(early_load=true,config="verbose=-1,key_expires=0")' % (key_provider_extension[0])
+        key_provider_extension_config =  f'\"{key_provider_extension[0]}\"=(early_load=true,config="verbose=-1,key_expires=0")'
         disagg_config += f',{key_provider_extension_config}'
     disagg_config += ']'
 

--- a/test/suite/hook_disagg.py
+++ b/test/suite/hook_disagg.py
@@ -63,6 +63,7 @@ def wiredtiger_open_replace(orig_wiredtiger_open, homedir, conn_config):
     disagg_parameters = platform_api.getDisaggParameters()
     page_log_name = disagg_parameters.page_log
     page_log_config = disagg_parameters.config
+    key_provider = disagg_parameters.key_provider
 
     valid_page_log = False
     # Construct the configuration string based on the storage source.
@@ -94,10 +95,15 @@ def wiredtiger_open_replace(orig_wiredtiger_open, homedir, conn_config):
     if 'tiered_storage=' in conn_config:
         skip_test("cannot run disagg hook on a test that uses tiered_storage in the config string")
 
+    page_log_extension = WiredTigerTestCase.findExtension('page_log', page_log_name)
+    if len(page_log_extension) == 0:
+        raise Exception(page_log_name + ' storage source extension not found')
 
-    extension_libs = WiredTigerTestCase.findExtension('page_log', page_log_name)
-    if len(extension_libs) == 0:
-        raise Exception(extension_name + ' storage source extension not found')
+    key_provider_extension = None
+    if (key_provider is not None):
+        key_provider_extension = WiredTigerTestCase.findExtension('test', "key_provider")
+        if len(key_provider_extension) == 0:
+            raise Exception(key_provider_extension[0] + ' key provider extension not found')
 
     WiredTigerTestCase.verbose(None, 3, f'role={disagg_parameters.role}')
     disagg_config = ',verbose=[layered]' \
@@ -147,11 +153,15 @@ def wiredtiger_open_replace(orig_wiredtiger_open, homedir, conn_config):
             page_log_config = f"cache_size_mb=2048,{page_log_config}"
 
     if page_log_config == None:
-        ext_lib = '\"%s\"' % extension_libs[0]
+        ext_lib = '\"%s\"' % page_log_extension[0]
     else:
-        ext_lib = '\"%s\"=(config=\"%s\")' % (extension_libs[0], page_log_config)
+        ext_lib = '\"%s\"=(config=\"%s\")' % (page_log_extension[0], page_log_config)
 
-    disagg_config += ',' + ext_string + ',%s]' % ext_lib
+    if key_provider:
+        key_provider_extension_config =  '\"%s\"=(early_load=true,config="verbose=-1")' % (key_provider_extension[0])
+        disagg_config += ',' + ext_string + ',%s,%s]' % (ext_lib, key_provider_extension_config)
+    else:
+        disagg_config += ',' + ext_string + ',%s]' % ext_lib
 
     config = conn_config + disagg_config
 
@@ -448,6 +458,7 @@ class DisaggPlatformAPI(wthooks.WiredTigerHookPlatformAPI):
         #wttest.WiredTigerTestCase.tty('Disagg hook params={}'.format(params))
 
         self.disagg_config = ''
+        self.disagg_key_provider= None
         self.disagg_page_log = None
         self.disagg_role = 'leader'
         self.table_prefix = 'layered'
@@ -455,6 +466,8 @@ class DisaggPlatformAPI(wthooks.WiredTigerHookPlatformAPI):
         for param_key, param_value in params:
             if param_key == 'config':
                 self.disagg_config = param_value
+            elif param_key == 'key_provider':
+                self.disagg_key_provider = param_value
             elif param_key == 'page_log':
                 self.disagg_page_log = param_value
             elif param_key == 'role':
@@ -500,6 +513,7 @@ class DisaggPlatformAPI(wthooks.WiredTigerHookPlatformAPI):
         result.role = self.disagg_role
         result.page_log = self.disagg_page_log if self.disagg_page_log else WiredTigerTestCase.vars().page_log
         result.table_prefix = self.table_prefix
+        result.key_provider = self.disagg_key_provider
         return result
 
 # Every hook file must have a top level initialize function,


### PR DESCRIPTION
The mock key provider module validates correct get_key(), load_key() and on_key_update usage semantics. 

By enabling the mock key provider module via disagg hook testing, we can utilise all of WT python tests and directly test key provider implementation.
