### PR TITLE
WT-16353 Solve the MSVC source script issue

### DIFF
--- a/test/evergreen/build_windows.ps1
+++ b/test/evergreen/build_windows.ps1
@@ -11,19 +11,19 @@ function Find-VcVars {
     }
 
     # 17 is the version of Visual Studio 2022.
-    $installPaths = & $vswhere `
+    # -latest flag ensures only one (the newest) installation is returned
+    $installPath = & $vswhere `
+        -latest `
         -version "[17.0,)" `
         -products * `
         -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
         -property installationPath `
         -nologo
 
-    if ($LastExitCode -ne 0 -or -not $installPaths) {
+    if ($LastExitCode -ne 0 -or -not $installPath) {
         throw "vswhere did not find any suitable Visual Studio installations."
     }
 
-    # vswhere may return multiple installations, take the first one
-    $installPath = $installPaths | Select-Object -First 1
     Write-Host "Selected Visual Studio installation: $installPath"
 
     $candidate = Join-Path $installPath "VC\Auxiliary\Build\vcvars64.bat"

--- a/test/evergreen/build_windows.ps1
+++ b/test/evergreen/build_windows.ps1
@@ -11,16 +11,20 @@ function Find-VcVars {
     }
 
     # 17 is the version of Visual Studio 2022.
-    $installPath = & $vswhere `
+    $installPaths = & $vswhere `
         -version "[17.0,)" `
         -products * `
         -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
         -property installationPath `
         -nologo
 
-    if ($LastExitCode -ne 0 -or -not $installPath) {
+    if ($LastExitCode -ne 0 -or -not $installPaths) {
         throw "vswhere did not find any suitable Visual Studio installations."
     }
+
+    # vswhere may return multiple installations, take the first one
+    $installPath = $installPaths | Select-Object -First 1
+    Write-Host "Selected Visual Studio installation: $installPath"
 
     $candidate = Join-Path $installPath "VC\Auxiliary\Build\vcvars64.bat"
     if (Test-Path $candidate) {


### PR DESCRIPTION
After the last update the compilation task on Windows started to produce the following error:

```
[2025/12/22 10:52:50.987] Using config flags                                                                                     -DENABLE_COLORIZE_OUTPUT=0
[2025/12/22 10:52:53.763] 'C:\Program' is not recognized as an internal or external command,
[2025/12/22 10:52:53.763] operable program or batch file.
[2025/12/22 10:52:53.829]     Directory: C:\data\mci\6e6b\wiredtiger
[2025/12/22 10:52:53.829] Mode                 LastWriteTime         Length Name
[2025/12/22 10:52:53.830] ----                 -------------         ------ ----
[2025/12/22 10:52:53.830] d-----        12/22/2025  12:22 AM                cmake_build
[2025/12/22 10:53:30.114] cmake : The term 'cmake' is not recognized as the name of a cmdlet, function, script file, or operable program. Check
[2025/12/22 10:53:30.114] the spelling of the name, or if a path was included, verify that the path is correct and try again.
[2025/12/22 10:53:30.114] At C:\data\mci\6e6b\wiredtiger\test\evergreen\build_windows.ps1:72 char:5
[2025/12/22 10:53:30.114] +     cmake --version
[2025/12/22 10:53:30.114] +     ~~~~~
[2025/12/22 10:53:30.114]     + CategoryInfo          : ObjectNotFound: (cmake:String) [], ParentContainsErrorRecordException
[2025/12/22 10:53:30.143]     + FullyQualifiedErrorId : CommandNotFoundException
[2025/12/22 10:53:30.143] Command 'shell.exec' in function 'compile wiredtiger' (step 2.3 of 4) failed: shell script encountered problem: exit code 1.
[2025/12/22 10:53:30.143] Finished command 'shell.exec' in function 'compile wiredtiger' (step 2.3 of 4) in 39.6991815s.
[2025/12/22 10:53:30.143] Running task commands failed: running command: command failed: shell script encountered problem: exit code 1
```

The issue is that for some reason after the system update `vswhere` started to return all the available paths to Visual Studio instances but the script is assuming that it'll return one version only.
