### PR TITLE
WT-16368 Print error traces if TearDown verification fails

### DIFF
--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -304,11 +304,7 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
                     rollbacksAllowed -= 1
             except wiredtiger.WiredTigerError as err:
                 self.prexception(sys.exc_info())
-                if self.conn is not None and self.conn.is_open():
-                    self.conn.dump_error_log()
-                else:
-                    sys.stderr.write('Error log after WiredTigerError exception, connection is closed:\n')
-                    wiredtiger.wiredtiger_dump_error_log(lambda e: sys.stderr.write(e))
+                self.dumpErrorLog()
                 # Prevent an unnecessary "unexpected output" error.
                 self.ignoreTearDownLogs = True
                 raise
@@ -548,6 +544,17 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
         if exc_list and exc_list[-1][0] is self:
             return exc_list[-1][1]
 
+    # FIXME-WT-16369: Consider printing error dumps for self.conn_follow in DisAgg tests
+    def dumpErrorLog(self):
+        """
+        Dump the error log, handling both open and closed connection cases.
+        """
+        if self.conn is not None and self.conn.is_open():
+            self.conn.dump_error_log()
+        else:
+            sys.stderr.write('Error log after WiredTigerError exception, connection is closed:\n')
+            wiredtiger.wiredtiger_dump_error_log(lambda e: sys.stderr.write(e))
+
     def cleanStderr(self):
         self.captureerr.ignorePreviousOutput()
 
@@ -598,6 +605,7 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
                 try:
                     self.verifyUntilSuccess(sess, uri)
                 except wiredtiger.WiredTigerError as e:
+                    self.dumpErrorLog()
                     raise Exception(f'Layered verification failed for {uri}: {str(e)}')
 
         sess.close()

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -150,6 +150,24 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
     #                       'test/fail_fs={allow_writes=100}')
     conn_extensions = ()
 
+    # FIXME-WT-16369: Consider printing error dumps for self.conn_follow in DisAgg tests
+    @staticmethod
+    def dumpErrorLogOnWtError(func):
+        """
+        Decorator that catches WiredTigerError exceptions, dumps the error log, and re-raises.
+        """
+        def wrapper(self, *args, **kwargs):
+            try:
+                return func(self, *args, **kwargs)
+            except wiredtiger.WiredTigerError as e:
+                if self.conn is not None and self.conn.is_open():
+                    self.conn.dump_error_log()
+                else:
+                    sys.stderr.write('Error log after WiredTigerError exception, connection is closed:\n')
+                    wiredtiger.wiredtiger_dump_error_log(lambda e: sys.stderr.write(e))
+                raise
+        return wrapper
+
     @staticmethod
     def globalSetup(command_line_vars, preserveFiles = False, removeAtStart = True, useTimestamp = False,
                     gdbSub = False, lldbSub = False, verbose = 1, builddir = None, dirarg = None,
@@ -280,6 +298,7 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
     # Note that this method first appears in Python 3.7.  When running with an older Python,
     # this method does not override anything.  The test method is called a different way,
     # and we will not get any retry behavior.
+    @dumpErrorLogOnWtError
     def _callTestMethod(self, method):
         rollbacksAllowed = self.rollbacks_allowed
         finished = False
@@ -304,7 +323,6 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
                     rollbacksAllowed -= 1
             except wiredtiger.WiredTigerError as err:
                 self.prexception(sys.exc_info())
-                self.dumpErrorLog()
                 # Prevent an unnecessary "unexpected output" error.
                 self.ignoreTearDownLogs = True
                 raise
@@ -544,17 +562,6 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
         if exc_list and exc_list[-1][0] is self:
             return exc_list[-1][1]
 
-    # FIXME-WT-16369: Consider printing error dumps for self.conn_follow in DisAgg tests
-    def dumpErrorLog(self):
-        """
-        Dump the error log, handling both open and closed connection cases.
-        """
-        if self.conn is not None and self.conn.is_open():
-            self.conn.dump_error_log()
-        else:
-            sys.stderr.write('Error log after WiredTigerError exception, connection is closed:\n')
-            wiredtiger.wiredtiger_dump_error_log(lambda e: sys.stderr.write(e))
-
     def cleanStderr(self):
         self.captureerr.ignorePreviousOutput()
 
@@ -605,11 +612,12 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
                 try:
                     self.verifyUntilSuccess(sess, uri)
                 except wiredtiger.WiredTigerError as e:
-                    self.dumpErrorLog()
-                    raise Exception(f'Layered verification failed for {uri}: {str(e)}')
+                    print(f'Layered verification failed for {uri}: {str(e)}')
+                    raise e
 
         sess.close()
 
+    @dumpErrorLogOnWtError
     def tearDown(self, dueToRetry=False):
         dumped_error_log = False
         teardown_failed = False


### PR DESCRIPTION
Currently if the TearDown verification fails we don't call `dump_error_log()` which is required to access errors origins through `stderr.txt`. Currently we print the dump only if test case fails not as part of the TearDown function. This PR fixes it to make debugging more convenient.