### PR TITLE
WT-16356 Run the disagg failover perf test in evergreen CI

### DIFF
--- a/test/cppsuite/tests/test_disagg_failover_perf.cpp
+++ b/test/cppsuite/tests/test_disagg_failover_perf.cpp
@@ -39,6 +39,8 @@
 #include "src/main/database.h"
 #include "src/main/database_operation.h"
 #include "src/main/crud.h"
+#include "src/component/metrics_monitor.h"
+#include "src/component/metrics_writer.h"
 
 extern "C" {
 #include "wiredtiger.h"
@@ -590,6 +592,21 @@ main(int argc, char *argv[])
     /* Sleep for 10 seconds, hopefully this will help with FTDC files. */
     logger::log_msg(LOG_INFO, "Sleeping 10 seconds to allow FTDC files to flush.");
     std::this_thread::sleep_for(std::chrono::seconds(10));
+
+    /* Retrieve any useful statistics. */
+    logger::log_msg(LOG_INFO, "Retrieving statistics.");
+    scoped_session stat_session = connection_manager::instance().create_session();
+    scoped_cursor stat_cursor = stat_session.open_scoped_cursor("statistics:");
+    int64_t step_up_time = 0;
+    metrics_monitor::get_stat(stat_cursor, WT_STAT_CONN_DISAGG_STEP_UP_TIME, &step_up_time);
+    logger::log_msg(LOG_INFO, "disagg_step_up_time = " + std::to_string(step_up_time) + " msecs");
+
+    /* Add the statistics to metrics_writer and output to JSON file. */
+    std::string stat_json =
+      "{\"name\":\"disagg_step_up_time\",\"value\":" + std::to_string(step_up_time) + "}";
+    metrics_writer::instance().add_stat(stat_json);
+    metrics_writer::instance().output_perf_file(progname);
+    logger::log_msg(LOG_INFO, "Statistics written to " + progname + ".json");
 
     /* Cleanup. */
     delete database_model;

--- a/test/cppsuite/tests/test_disagg_failover_perf.cpp
+++ b/test/cppsuite/tests/test_disagg_failover_perf.cpp
@@ -597,13 +597,9 @@ main(int argc, char *argv[])
     logger::log_msg(LOG_INFO, "Retrieving statistics.");
     scoped_session stat_session = connection_manager::instance().create_session();
     scoped_cursor stat_cursor = stat_session.open_scoped_cursor("statistics:");
-    int64_t step_up_time = 0;
-    metrics_monitor::get_stat(stat_cursor, WT_STAT_CONN_DISAGG_STEP_UP_TIME, &step_up_time);
-
+    int64_t step_up_time = metrics_monitor::get_stat(stat_cursor, WT_STAT_CONN_DISAGG_STEP_UP_TIME);
     /* Add the statistics to metrics_writer and output to JSON file. */
-    std::string stat_json =
-      "{\"name\":\"disagg_step_up_time\",\"value\":" + std::to_string(step_up_time) + "}";
-    metrics_writer::instance().add_stat(stat_json);
+    metrics_writer::instance().add_stat("disagg_step_up_time", step_up_time);
     metrics_writer::instance().output_perf_file(progname);
     logger::log_msg(LOG_INFO, "Statistics written to " + progname + ".json");
 

--- a/test/cppsuite/tests/test_disagg_failover_perf.cpp
+++ b/test/cppsuite/tests/test_disagg_failover_perf.cpp
@@ -599,7 +599,6 @@ main(int argc, char *argv[])
     scoped_cursor stat_cursor = stat_session.open_scoped_cursor("statistics:");
     int64_t step_up_time = 0;
     metrics_monitor::get_stat(stat_cursor, WT_STAT_CONN_DISAGG_STEP_UP_TIME, &step_up_time);
-    logger::log_msg(LOG_INFO, "disagg_step_up_time = " + std::to_string(step_up_time) + " msecs");
 
     /* Add the statistics to metrics_writer and output to JSON file. */
     std::string stat_json =

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -834,6 +834,35 @@ functions:
     - *cppsuite_s3_put
     - *cppsuite_remove_dir
 
+  "disagg failover perf test":
+    - command: shell.exec
+      params:
+        working_dir: "wiredtiger/cmake_build/test/cppsuite"
+        shell: bash
+        script: |
+          set -o errexit
+          set -o verbose
+          ${PREPARE_TEST_ENV}
+          ./test_disagg_failover_perf ${test_args|}
+    - *dump_stacktraces
+    - *upload_stacktraces
+    - command: subprocess.exec
+      params:
+        binary: bash
+        args:
+          - ./wiredtiger/test/evergreen/perf_submission.sh
+        env:
+          perf_file_path: ./wiredtiger/cmake_build/test/cppsuite/test_disagg_failover_perf.json
+        include_expansions_in_env:
+          - requester
+          - revision_order_id
+          - project_id
+          - version_id
+          - build_variant
+          - task_name
+          - task_id
+          - execution
+
   "wt2853_perf test":
     command: shell.exec
     params:
@@ -2246,6 +2275,30 @@ tasks:
         vars:
           test_config_filename: configs/api_timing_benchmarks_default.txt
           test_name: api_timing_benchmarks
+
+  - name: cppsuite-disagg-failover-perf-append
+    depends_on:
+      - name: compile
+    tags: ["cppsuite-perf-test-arm"]
+    commands:
+      - func: "fetch artifacts"
+      - func: "disagg failover perf test"
+        vars:
+          # Ingest 3.2GB of data into 10 1GB tables using append operations, keys are 10 bytes long
+          # and values 1014 bytes. Cache size is 32GB.
+          test_args: "-c 10 -k 1000000 -i 3200 -S append -g 32 -s 10 -v 1014 -V 1"
+
+  - name: cppsuite-disagg-failover-perf-updates
+    depends_on:
+      - name: compile
+    tags: ["cppsuite-perf-test-arm"]
+    commands:
+      - func: "fetch artifacts"
+      - func: "disagg failover perf test"
+        vars:
+          # Ingest 3.2GB of data into 10 1GB tables using append operations, keys are 10 bytes long
+          # and values 1014 bytes. Cache size is 32GB.
+          test_args: "-c 10 -k 1000000 -i 3200 -S updates -g 32 -s 10 -v 1014 -V 1"
 
   # End of cppsuite test tasks.
   # Start of csuite test tasks

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2288,8 +2288,8 @@ tasks:
       - func: "fetch artifacts"
       - func: "disagg failover perf test"
         vars:
-          # Ingest 3.2GB of data into 10 1GB tables using append operations, keys are 10 bytes long
-          # and values 1014 bytes. Cache size is 32GB.
+          # Ingest 3.2GB of data into 10 1GB tables using append operations, keys are 10 bytes and
+          # values 1014 bytes. Cache size is 32GB.
           test_args: "-c 10 -k 1000000 -i 3200 -S append -g 32 -s 10 -v 1014 -V 1"
 
   - name: cppsuite-disagg-failover-perf-updates
@@ -2300,8 +2300,8 @@ tasks:
       - func: "fetch artifacts"
       - func: "disagg failover perf test"
         vars:
-          # Ingest 3.2GB of data into 10 1GB tables using append operations, keys are 10 bytes long
-          # and values 1014 bytes. Cache size is 32GB.
+          # Ingest 3.2GB of data into 10 1GB tables using update operations, keys are 10 bytes and
+          # values 1014 bytes. Cache size is 32GB.
           test_args: "-c 10 -k 1000000 -i 3200 -S updates -g 32 -s 10 -v 1014 -V 1"
 
   # End of cppsuite test tasks.


### PR DESCRIPTION
This change runs the disagg perf failover test in evergreen, helping us monitor for regressions and improvements in the relevant code paths. 

There are two configurations:
- Append
- Update

Both run under their own task as they have very different workload characteristics and I think we'd like coverage for both. I have chosen to only run them on ARM as x86 is too slow and not that high priority anymore.