### PR TITLE
WT-16371 Improve statistic usage in CppSuite

### DIFF
--- a/test/cppsuite/src/component/metrics_monitor.cpp
+++ b/test/cppsuite/src/component/metrics_monitor.cpp
@@ -124,18 +124,15 @@ metrics_monitor::finish()
         const std::string stat_name = stat->get_name();
 
         /* Append stats to the statistics writer if it needs to be saved. */
-        if (stat->get_save()) {
-            auto stat_str =
-              "{\"name\":\"" + stat_name + "\",\"value\":" + stat->get_value_str(_cursor) + "}";
-            metrics_writer::instance().add_stat(stat_str);
-        }
+        if (stat->get_save())
+            metrics_writer::instance().add_stat(stat_name, stat->get_value<int64_t>(_cursor));
 
         if (!stat->get_postrun())
             continue;
 
         int64_t stat_max = stat->get_max();
         int64_t stat_min = stat->get_min();
-        int64_t stat_value = std::stoi(stat->get_value_str(_cursor));
+        int64_t stat_value = stat->get_value<int64_t>(_cursor);
 
         if (stat_value < stat_min || stat_value > stat_max) {
             const std::string error_string = "metrics_monitor: Post-run stat \"" + stat_name +

--- a/test/cppsuite/src/component/metrics_monitor.cpp
+++ b/test/cppsuite/src/component/metrics_monitor.cpp
@@ -125,14 +125,14 @@ metrics_monitor::finish()
 
         /* Append stats to the statistics writer if it needs to be saved. */
         if (stat->get_save())
-            metrics_writer::instance().add_stat(stat_name, stat->get_value<int64_t>(_cursor));
+            metrics_writer::instance().add_stat(stat_name, stat->get_value(_cursor));
 
         if (!stat->get_postrun())
             continue;
 
         int64_t stat_max = stat->get_max();
         int64_t stat_min = stat->get_min();
-        int64_t stat_value = stat->get_value<int64_t>(_cursor);
+        int64_t stat_value = stat->get_value(_cursor);
 
         if (stat_value < stat_min || stat_value > stat_max) {
             const std::string error_string = "metrics_monitor: Post-run stat \"" + stat_name +

--- a/test/cppsuite/src/component/metrics_monitor.cpp
+++ b/test/cppsuite/src/component/metrics_monitor.cpp
@@ -60,14 +60,16 @@ get_stat_field(const std::string &name)
     testutil_die(EINVAL, "get_stat_field: Stat \"%s\" is unrecognized", name.c_str());
 }
 
-void
-metrics_monitor::get_stat(scoped_cursor &cursor, int stat_field, int64_t *valuep)
+int64_t
+metrics_monitor::get_stat(scoped_cursor &cursor, int stat_field)
 {
     const char *desc, *pvalue;
     cursor->set_key(cursor.get(), stat_field);
     testutil_check(cursor->search(cursor.get()));
-    testutil_check(cursor->get_value(cursor.get(), &desc, &pvalue, valuep));
+    int64_t value = 0;
+    testutil_check(cursor->get_value(cursor.get(), &desc, &pvalue, &value));
     testutil_check(cursor->reset(cursor.get()));
+    return value;
 }
 
 metrics_monitor::metrics_monitor(

--- a/test/cppsuite/src/component/metrics_monitor.h
+++ b/test/cppsuite/src/component/metrics_monitor.h
@@ -46,7 +46,7 @@ namespace test_harness {
  */
 class metrics_monitor : public component {
 public:
-    static void get_stat(scoped_cursor &, int, int64_t *);
+    static int64_t get_stat(scoped_cursor &, int);
 
 public:
     metrics_monitor(const std::string &test_name, configuration *config, database &database);

--- a/test/cppsuite/src/component/metrics_writer.cpp
+++ b/test/cppsuite/src/component/metrics_writer.cpp
@@ -30,13 +30,6 @@
 
 namespace test_harness {
 void
-metrics_writer::add_stat(const std::string &stat_string)
-{
-    std::lock_guard<std::mutex> lg(_stat_mutex);
-    _stats.push_back(stat_string);
-}
-
-void
 metrics_writer::output_perf_file(const std::string &test_name)
 {
     std::ofstream perf_file(test_name + ".json");

--- a/test/cppsuite/src/component/metrics_writer.h
+++ b/test/cppsuite/src/component/metrics_writer.h
@@ -32,6 +32,7 @@
 #include <mutex>
 #include <string>
 #include <vector>
+#include <type_traits>
 
 namespace test_harness {
 /* Singleton class that can write statistics to a file. */
@@ -44,7 +45,17 @@ public:
     metrics_writer(metrics_writer const &) = delete;
     metrics_writer &operator=(metrics_writer const &) = delete;
 
-    void add_stat(const std::string &stat_string);
+    template <typename T>
+    void
+    add_stat(const std::string &name, T value)
+    {
+        static_assert(
+          std::is_arithmetic<T>::value, "T must be an arithmetic type for std::to_string");
+        std::lock_guard<std::mutex> lg(_stat_mutex);
+        std::string stat_string =
+          "{\"name\":\"" + name + "\",\"value\":" + std::to_string(value) + "}";
+        _stats.push_back(stat_string);
+    }
     void output_perf_file(const std::string &test_name);
 
 private:

--- a/test/cppsuite/src/component/metrics_writer.h
+++ b/test/cppsuite/src/component/metrics_writer.h
@@ -54,7 +54,7 @@ public:
         std::lock_guard<std::mutex> lg(_stat_mutex);
         std::string stat_string =
           "{\"name\":\"" + name + "\",\"value\":" + std::to_string(value) + "}";
-        _stats.push_back(stat_string);
+        _stats.emplace_back(std::move(stat_string));
     }
     void output_perf_file(const std::string &test_name);
 

--- a/test/cppsuite/src/component/statistics/cache_limit.cpp
+++ b/test/cppsuite/src/component/statistics/cache_limit.cpp
@@ -63,7 +63,7 @@ cache_limit::get_value(scoped_cursor &cursor)
     cache_bytes_image = metrics_monitor::get_stat(cursor, WT_STAT_CONN_CACHE_BYTES_IMAGE);
     cache_bytes_other = metrics_monitor::get_stat(cursor, WT_STAT_CONN_CACHE_BYTES_OTHER);
     cache_bytes_max = metrics_monitor::get_stat(cursor, WT_STAT_CONN_CACHE_BYTES_MAX);
-    testutil_assert(cache_bytes_image + cache_bytes_other < INT64_MAX / 100);
+    testutil_assert((cache_bytes_image + cache_bytes_other) * 100 < INT64_MAX);
     /* Assert that we never exceed our configured limit for cache usage. */
     testutil_assert(cache_bytes_max > 0);
     return (cache_bytes_image + cache_bytes_other) * 100 / cache_bytes_max;

--- a/test/cppsuite/src/component/statistics/cache_limit.cpp
+++ b/test/cppsuite/src/component/statistics/cache_limit.cpp
@@ -55,10 +55,10 @@ cache_limit::check(scoped_cursor &cursor)
         logger::log_msg(LOG_TRACE, name + " usage: " + std::to_string(use_percent));
 }
 
-std::string
-cache_limit::get_value_str(scoped_cursor &cursor)
+double
+cache_limit::get_value_double(scoped_cursor &cursor)
 {
-    return std::to_string(get_cache_value(cursor));
+    return get_cache_value(cursor);
 }
 
 double

--- a/test/cppsuite/src/component/statistics/cache_limit.cpp
+++ b/test/cppsuite/src/component/statistics/cache_limit.cpp
@@ -55,10 +55,11 @@ cache_limit::check(scoped_cursor &cursor)
         logger::log_msg(LOG_TRACE, name + " usage: " + std::to_string(use_percent));
 }
 
-double
-cache_limit::get_value_double(scoped_cursor &cursor)
+/* This loses precision but the metrics monitor requires an int64_t return type. */
+int64_t
+cache_limit::get_value(scoped_cursor &cursor)
 {
-    return get_cache_value(cursor);
+    return static_cast<int64_t>(get_cache_value(cursor));
 }
 
 double

--- a/test/cppsuite/src/component/statistics/cache_limit.cpp
+++ b/test/cppsuite/src/component/statistics/cache_limit.cpp
@@ -59,17 +59,12 @@ int64_t
 cache_limit::get_value(scoped_cursor &cursor)
 {
     int64_t cache_bytes_image, cache_bytes_other, cache_bytes_max;
-    double use_percent;
     /* Three statistics are required to compute cache use percentage. */
     cache_bytes_image = metrics_monitor::get_stat(cursor, WT_STAT_CONN_CACHE_BYTES_IMAGE);
     cache_bytes_other = metrics_monitor::get_stat(cursor, WT_STAT_CONN_CACHE_BYTES_OTHER);
     cache_bytes_max = metrics_monitor::get_stat(cursor, WT_STAT_CONN_CACHE_BYTES_MAX);
-    /*
-     * Assert that we never exceed our configured limit for cache usage. Add 0.0 to avoid floating
-     * point conversion errors.
-     */
+    /* Assert that we never exceed our configured limit for cache usage. */
     testutil_assert(cache_bytes_max > 0);
-    use_percent = ((cache_bytes_image + cache_bytes_other + 0.0) / cache_bytes_max) * 100;
-    return static_cast<int64_t>(use_percent);
+    return (cache_bytes_image + cache_bytes_other) / cache_bytes_max * 100;
 }
 } // namespace test_harness

--- a/test/cppsuite/src/component/statistics/cache_limit.cpp
+++ b/test/cppsuite/src/component/statistics/cache_limit.cpp
@@ -68,9 +68,9 @@ cache_limit::get_cache_value(scoped_cursor &cursor)
     int64_t cache_bytes_image, cache_bytes_other, cache_bytes_max;
     double use_percent;
     /* Three statistics are required to compute cache use percentage. */
-    metrics_monitor::get_stat(cursor, WT_STAT_CONN_CACHE_BYTES_IMAGE, &cache_bytes_image);
-    metrics_monitor::get_stat(cursor, WT_STAT_CONN_CACHE_BYTES_OTHER, &cache_bytes_other);
-    metrics_monitor::get_stat(cursor, WT_STAT_CONN_CACHE_BYTES_MAX, &cache_bytes_max);
+    cache_bytes_image = metrics_monitor::get_stat(cursor, WT_STAT_CONN_CACHE_BYTES_IMAGE);
+    cache_bytes_other = metrics_monitor::get_stat(cursor, WT_STAT_CONN_CACHE_BYTES_OTHER);
+    cache_bytes_max = metrics_monitor::get_stat(cursor, WT_STAT_CONN_CACHE_BYTES_MAX);
     /*
      * Assert that we never exceed our configured limit for cache usage. Add 0.0 to avoid floating
      * point conversion errors.

--- a/test/cppsuite/src/component/statistics/cache_limit.cpp
+++ b/test/cppsuite/src/component/statistics/cache_limit.cpp
@@ -45,7 +45,7 @@ cache_limit::cache_limit(configuration &config, const std::string &name)
 void
 cache_limit::check(scoped_cursor &cursor)
 {
-    double use_percent = get_cache_value(cursor);
+    int64_t use_percent = get_value(cursor);
     if (use_percent > max) {
         const std::string error_string =
           "metrics_monitor: Cache usage exceeded during test! Limit: " + std::to_string(max) +
@@ -55,15 +55,8 @@ cache_limit::check(scoped_cursor &cursor)
         logger::log_msg(LOG_TRACE, name + " usage: " + std::to_string(use_percent));
 }
 
-/* This loses precision but the metrics monitor requires an int64_t return type. */
 int64_t
 cache_limit::get_value(scoped_cursor &cursor)
-{
-    return static_cast<int64_t>(get_cache_value(cursor));
-}
-
-double
-cache_limit::get_cache_value(scoped_cursor &cursor)
 {
     int64_t cache_bytes_image, cache_bytes_other, cache_bytes_max;
     double use_percent;
@@ -77,6 +70,6 @@ cache_limit::get_cache_value(scoped_cursor &cursor)
      */
     testutil_assert(cache_bytes_max > 0);
     use_percent = ((cache_bytes_image + cache_bytes_other + 0.0) / cache_bytes_max) * 100;
-    return use_percent;
+    return static_cast<int64_t>(use_percent);
 }
 } // namespace test_harness

--- a/test/cppsuite/src/component/statistics/cache_limit.cpp
+++ b/test/cppsuite/src/component/statistics/cache_limit.cpp
@@ -63,8 +63,9 @@ cache_limit::get_value(scoped_cursor &cursor)
     cache_bytes_image = metrics_monitor::get_stat(cursor, WT_STAT_CONN_CACHE_BYTES_IMAGE);
     cache_bytes_other = metrics_monitor::get_stat(cursor, WT_STAT_CONN_CACHE_BYTES_OTHER);
     cache_bytes_max = metrics_monitor::get_stat(cursor, WT_STAT_CONN_CACHE_BYTES_MAX);
+    testutil_assert(cache_bytes_image + cache_bytes_other < INT64_MAX / 100);
     /* Assert that we never exceed our configured limit for cache usage. */
     testutil_assert(cache_bytes_max > 0);
-    return (cache_bytes_image + cache_bytes_other) / cache_bytes_max * 100;
+    return (cache_bytes_image + cache_bytes_other) * 100 / cache_bytes_max;
 }
 } // namespace test_harness

--- a/test/cppsuite/src/component/statistics/cache_limit.h
+++ b/test/cppsuite/src/component/statistics/cache_limit.h
@@ -43,8 +43,8 @@ public:
 
     void check(scoped_cursor &cursor) override final;
     int64_t get_value(scoped_cursor &cursor) override final;
-protected:
 
+protected:
 private:
     double get_cache_value(scoped_cursor &cursor);
 };

--- a/test/cppsuite/src/component/statistics/cache_limit.h
+++ b/test/cppsuite/src/component/statistics/cache_limit.h
@@ -42,9 +42,8 @@ public:
     virtual ~cache_limit() = default;
 
     void check(scoped_cursor &cursor) override final;
-
+    int64_t get_value(scoped_cursor &cursor) override final;
 protected:
-    double get_value_double(scoped_cursor &cursor) override final;
 
 private:
     double get_cache_value(scoped_cursor &cursor);

--- a/test/cppsuite/src/component/statistics/cache_limit.h
+++ b/test/cppsuite/src/component/statistics/cache_limit.h
@@ -42,7 +42,9 @@ public:
     virtual ~cache_limit() = default;
 
     void check(scoped_cursor &cursor) override final;
-    std::string get_value_str(scoped_cursor &cursor) override final;
+
+protected:
+    double get_value_double(scoped_cursor &cursor) override final;
 
 private:
     double get_cache_value(scoped_cursor &cursor);

--- a/test/cppsuite/src/component/statistics/cache_limit.h
+++ b/test/cppsuite/src/component/statistics/cache_limit.h
@@ -43,9 +43,5 @@ public:
 
     void check(scoped_cursor &cursor) override final;
     int64_t get_value(scoped_cursor &cursor) override final;
-
-protected:
-private:
-    double get_cache_value(scoped_cursor &cursor);
 };
 } // namespace test_harness

--- a/test/cppsuite/src/component/statistics/database_size.cpp
+++ b/test/cppsuite/src/component/statistics/database_size.cpp
@@ -73,10 +73,10 @@ database_size::check(scoped_cursor &)
 #endif
 }
 
-std::string
-database_size::get_value_str(scoped_cursor &)
+size_t
+database_size::get_value_size_t(scoped_cursor &)
 {
-    return std::to_string(get_db_size());
+    return get_db_size();
 }
 
 size_t

--- a/test/cppsuite/src/component/statistics/database_size.cpp
+++ b/test/cppsuite/src/component/statistics/database_size.cpp
@@ -73,10 +73,11 @@ database_size::check(scoped_cursor &)
 #endif
 }
 
-size_t
-database_size::get_value_size_t(scoped_cursor &)
+/* We assume that the database will never grow larger than INT64_MAX.*/
+int64_t
+database_size::get_value(scoped_cursor &)
 {
-    return get_db_size();
+    return static_cast<int64_t>(get_db_size());
 }
 
 size_t

--- a/test/cppsuite/src/component/statistics/database_size.h
+++ b/test/cppsuite/src/component/statistics/database_size.h
@@ -43,7 +43,9 @@ public:
 
     /* Don't need the stat cursor for these. */
     void check(scoped_cursor &) override final;
-    std::string get_value_str(scoped_cursor &) override final;
+
+protected:
+    size_t get_value_size_t(scoped_cursor &) override final;
 
 private:
     size_t get_db_size() const;

--- a/test/cppsuite/src/component/statistics/database_size.h
+++ b/test/cppsuite/src/component/statistics/database_size.h
@@ -43,7 +43,7 @@ public:
 
     /* Don't need the stat cursor for these. */
     void check(scoped_cursor &) override final;
-    int64_t get_value(scoped_cursor &)override final;
+    int64_t get_value(scoped_cursor &) override final;
 
 private:
     size_t get_db_size() const;

--- a/test/cppsuite/src/component/statistics/database_size.h
+++ b/test/cppsuite/src/component/statistics/database_size.h
@@ -43,9 +43,7 @@ public:
 
     /* Don't need the stat cursor for these. */
     void check(scoped_cursor &) override final;
-
-protected:
-    size_t get_value_size_t(scoped_cursor &) override final;
+    int64_t get_value(scoped_cursor &)override final;
 
 private:
     size_t get_db_size() const;

--- a/test/cppsuite/src/component/statistics/statistics.cpp
+++ b/test/cppsuite/src/component/statistics/statistics.cpp
@@ -66,13 +66,15 @@ statistics::get_value_int64(scoped_cursor &cursor)
 double
 statistics::get_value_double(scoped_cursor &cursor)
 {
-    return static_cast<double>(get_value_int64(cursor));
+    testutil_assert(false);
+    return 0.0;
 }
 
 size_t
 statistics::get_value_size_t(scoped_cursor &cursor)
 {
-    return static_cast<size_t>(get_value_int64(cursor));
+    testutil_assert(false);
+    return 0;
 }
 
 int

--- a/test/cppsuite/src/component/statistics/statistics.cpp
+++ b/test/cppsuite/src/component/statistics/statistics.cpp
@@ -55,12 +55,24 @@ statistics::check(scoped_cursor &cursor)
         logger::log_msg(LOG_TRACE, name + " usage: " + std::to_string(stat_value));
 }
 
-std::string
-statistics::get_value_str(scoped_cursor &cursor)
+int64_t
+statistics::get_value_int64(scoped_cursor &cursor)
 {
     int64_t stat_value;
     metrics_monitor::get_stat(cursor, field, &stat_value);
-    return std::to_string(stat_value);
+    return stat_value;
+}
+
+double
+statistics::get_value_double(scoped_cursor &cursor)
+{
+    return static_cast<double>(get_value_int64(cursor));
+}
+
+size_t
+statistics::get_value_size_t(scoped_cursor &cursor)
+{
+    return static_cast<size_t>(get_value_int64(cursor));
 }
 
 int

--- a/test/cppsuite/src/component/statistics/statistics.cpp
+++ b/test/cppsuite/src/component/statistics/statistics.cpp
@@ -56,25 +56,11 @@ statistics::check(scoped_cursor &cursor)
 }
 
 int64_t
-statistics::get_value_int64(scoped_cursor &cursor)
+statistics::get_value(scoped_cursor &cursor)
 {
     int64_t stat_value;
     metrics_monitor::get_stat(cursor, field, &stat_value);
     return stat_value;
-}
-
-double
-statistics::get_value_double(scoped_cursor &cursor)
-{
-    testutil_assert(false);
-    return 0.0;
-}
-
-size_t
-statistics::get_value_size_t(scoped_cursor &cursor)
-{
-    testutil_assert(false);
-    return 0;
 }
 
 int

--- a/test/cppsuite/src/component/statistics/statistics.cpp
+++ b/test/cppsuite/src/component/statistics/statistics.cpp
@@ -44,8 +44,7 @@ statistics::statistics(configuration &config, const std::string &stat_name, int 
 void
 statistics::check(scoped_cursor &cursor)
 {
-    int64_t stat_value;
-    metrics_monitor::get_stat(cursor, field, &stat_value);
+    int64_t stat_value = metrics_monitor::get_stat(cursor, field);
     if (stat_value < min || stat_value > max) {
         const std::string error_string = "metrics_monitor: Post-run stat \"" + name +
           "\" was outside of the specified limits. Min=" + std::to_string(min) +
@@ -58,9 +57,7 @@ statistics::check(scoped_cursor &cursor)
 int64_t
 statistics::get_value(scoped_cursor &cursor)
 {
-    int64_t stat_value;
-    metrics_monitor::get_stat(cursor, field, &stat_value);
-    return stat_value;
+    return metrics_monitor::get_stat(cursor, field);
 }
 
 int

--- a/test/cppsuite/src/component/statistics/statistics.h
+++ b/test/cppsuite/src/component/statistics/statistics.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #include <string>
+#include <type_traits>
 
 #include "src/main/configuration.h"
 #include "src/storage/scoped_cursor.h"
@@ -44,8 +45,21 @@ public:
     /* Check that the statistics are within bounds. */
     virtual void check(scoped_cursor &cursor);
 
-    /* Retrieve the value associated to the stat in a string format. */
-    virtual std::string get_value_str(scoped_cursor &cursor);
+    /* Retrieve the value and return it as an arithmetic type. */
+    template <typename T>
+    T
+    get_value(scoped_cursor &cursor)
+    {
+        static_assert(std::is_same<T, size_t>::value || std::is_same<T, int64_t>::value ||
+            std::is_same<T, double>::value,
+          "T must be an implemented type.");
+        if constexpr (std::is_same<T, size_t>::value)
+            return get_value_size_t(cursor);
+        else if constexpr (std::is_same<T, int64_t>::value)
+            return get_value_int64(cursor);
+        else if constexpr (std::is_same<T, double>::value)
+            return get_value_double(cursor);
+    }
 
     /* Getters. */
     int get_field() const;
@@ -57,6 +71,11 @@ public:
     bool get_save() const;
 
 protected:
+    /* Virtual functions that derived classes can override to return their numeric value. */
+    virtual int64_t get_value_int64(scoped_cursor &cursor);
+    virtual double get_value_double(scoped_cursor &cursor);
+    virtual size_t get_value_size_t(scoped_cursor &cursor);
+
     int field;
     int64_t max;
     int64_t min;

--- a/test/cppsuite/src/component/statistics/statistics.h
+++ b/test/cppsuite/src/component/statistics/statistics.h
@@ -45,21 +45,8 @@ public:
     /* Check that the statistics are within bounds. */
     virtual void check(scoped_cursor &cursor);
 
-    /* Retrieve the value and return it as an arithmetic type. */
-    template <typename T>
-    T
-    get_value(scoped_cursor &cursor)
-    {
-        static_assert(std::is_same<T, size_t>::value || std::is_same<T, int64_t>::value ||
-            std::is_same<T, double>::value,
-          "T must be an implemented type.");
-        if constexpr (std::is_same<T, size_t>::value)
-            return get_value_size_t(cursor);
-        else if constexpr (std::is_same<T, int64_t>::value)
-            return get_value_int64(cursor);
-        else if constexpr (std::is_same<T, double>::value)
-            return get_value_double(cursor);
-    }
+    /* Retrieve the value and return it. */
+    virtual int64_t get_value(scoped_cursor &cursor);
 
     /* Getters. */
     int get_field() const;
@@ -71,11 +58,6 @@ public:
     bool get_save() const;
 
 protected:
-    /* Virtual functions that derived classes can override to return their numeric value. */
-    virtual int64_t get_value_int64(scoped_cursor &cursor);
-    virtual double get_value_double(scoped_cursor &cursor);
-    virtual size_t get_value_size_t(scoped_cursor &cursor);
-
     int field;
     int64_t max;
     int64_t min;

--- a/test/cppsuite/src/util/execution_timer.cpp
+++ b/test/cppsuite/src/util/execution_timer.cpp
@@ -45,8 +45,7 @@ execution_timer::append_stats()
 {
     std::sort(_time_recordings.begin(), _time_recordings.end());
     auto percentile = _time_recordings[std::floor(_time_recordings.size() * 0.9)];
-    metrics_writer::instance().add_stat("{\"name\":\"" + _id +
-      "_nanoseconds_90th_percentile\",\"value\":" + std::to_string(percentile) + "}");
+    metrics_writer::instance().add_stat(_id + "_nanoseconds_90th_percentile", percentile);
 }
 
 execution_timer::~execution_timer()

--- a/test/cppsuite/src/util/instruction_counter.cpp
+++ b/test/cppsuite/src/util/instruction_counter.cpp
@@ -50,8 +50,7 @@ instruction_counter::instruction_counter(const std::string &id, const std::strin
 void
 instruction_counter::append_stats()
 {
-    metrics_writer::instance().add_stat("{\"name\":\"" + _id +
-      "_instructions\",\"value\":" + std::to_string(_instruction_count) + "}");
+    metrics_writer::instance().add_stat(_id + "_instructions", _instruction_count);
 }
 
 instruction_counter::~instruction_counter()

--- a/test/cppsuite/tests/background_compact.cpp
+++ b/test/cppsuite/tests/background_compact.cpp
@@ -112,11 +112,10 @@ public:
             scoped_cursor &rnd_cursor = rnd_cursors[coll.id];
 
             /* Get the file statistics so we know how much to truncate. */
-            int64_t entries, bytes_avail_reuse, file_size;
-            metrics_monitor::get_stat(stat_cursor, WT_STAT_DSRC_BTREE_ENTRIES, &entries);
-            metrics_monitor::get_stat(
-              stat_cursor, WT_STAT_DSRC_BLOCK_REUSE_BYTES, &bytes_avail_reuse);
-            metrics_monitor::get_stat(stat_cursor, WT_STAT_DSRC_BLOCK_SIZE, &file_size);
+            int64_t entries = metrics_monitor::get_stat(stat_cursor, WT_STAT_DSRC_BTREE_ENTRIES);
+            int64_t bytes_avail_reuse =
+              metrics_monitor::get_stat(stat_cursor, WT_STAT_DSRC_BLOCK_REUSE_BYTES);
+            int64_t file_size = metrics_monitor::get_stat(stat_cursor, WT_STAT_DSRC_BLOCK_SIZE);
 
             /* Don't truncate if we already have enough free space for compact to do work. */
             const int64_t pct_free_space_threshold = 10;
@@ -326,32 +325,29 @@ public:
         scoped_session session = connection_manager::instance().create_session();
 
         /* Check the background compact statistics. */
-        int64_t bytes_recovered, bytes_rewritten_ema, bytes_written, files_tracked, skipped,
-          success;
         scoped_cursor conn_stat_cursor = session.open_scoped_cursor(STATISTICS_URI);
-
-        metrics_monitor::get_stat(
-          conn_stat_cursor, WT_STAT_CONN_BACKGROUND_COMPACT_BYTES_RECOVERED, &bytes_recovered);
+        int64_t bytes_recovered = metrics_monitor::get_stat(
+          conn_stat_cursor, WT_STAT_CONN_BACKGROUND_COMPACT_BYTES_RECOVERED);
         testutil_assert(bytes_recovered > 0);
 
-        metrics_monitor::get_stat(
-          conn_stat_cursor, WT_STAT_CONN_BACKGROUND_COMPACT_EMA, &bytes_rewritten_ema);
+        int64_t bytes_rewritten_ema =
+          metrics_monitor::get_stat(conn_stat_cursor, WT_STAT_CONN_BACKGROUND_COMPACT_EMA);
         testutil_assert(bytes_rewritten_ema > 0);
 
-        metrics_monitor::get_stat(
-          conn_stat_cursor, WT_STAT_CONN_BLOCK_BYTE_WRITE_COMPACT, &bytes_written);
+        int64_t bytes_written =
+          metrics_monitor::get_stat(conn_stat_cursor, WT_STAT_CONN_BLOCK_BYTE_WRITE_COMPACT);
         testutil_assert(bytes_written > 0);
 
-        metrics_monitor::get_stat(
-          conn_stat_cursor, WT_STAT_CONN_BACKGROUND_COMPACT_FILES_TRACKED, &files_tracked);
+        int64_t files_tracked = metrics_monitor::get_stat(
+          conn_stat_cursor, WT_STAT_CONN_BACKGROUND_COMPACT_FILES_TRACKED);
         testutil_assert(files_tracked > 0);
 
-        metrics_monitor::get_stat(
-          conn_stat_cursor, WT_STAT_CONN_BACKGROUND_COMPACT_SKIPPED, &skipped);
+        int64_t skipped =
+          metrics_monitor::get_stat(conn_stat_cursor, WT_STAT_CONN_BACKGROUND_COMPACT_SKIPPED);
         testutil_assert(skipped > 0);
 
-        metrics_monitor::get_stat(
-          conn_stat_cursor, WT_STAT_CONN_BACKGROUND_COMPACT_SUCCESS, &success);
+        int64_t success =
+          metrics_monitor::get_stat(conn_stat_cursor, WT_STAT_CONN_BACKGROUND_COMPACT_SUCCESS);
         testutil_assert(success > 0);
 
         logger::log_msg(LOG_INFO, "Validation successful.");


### PR DESCRIPTION
Two functional changes:
1. Callers of metrics writer needed to know JSON formatting, which was weird.
2. Our high level statistics class used a get_value_str function to avoid casting types, this works but I'd prefer everything to just be int64_t.