### PR TITLE
WT-15838 Increase verbose level when generation gen is timeout and add some verbose messages in reconciliation (8.0) (#12692)

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -747,8 +747,9 @@ connection_runtime_config = [
             min=1, max=100000),
         ]),
     Config('generation_drain_timeout_ms', '240000', r'''
-        the number of milliseconds to wait for a resource to drain before timing out in diagnostic
-        mode. Default will wait for 4 minutes, 0 will wait forever''',
+        the number of milliseconds to wait for a resource to drain before timing out. In the
+        diagnostic mode, it will log an error and crash the system. In the production mode, it will
+        only log an error. Default will wait for 4 minutes, 0 will wait forever''',
         min=0),
     Config('heuristic_controls', '', r'''
         control the behavior of various optimizations. This is primarily used as a mechanism for

--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -1081,6 +1081,7 @@ conn_dsrc_stats = [
     CacheStat('cache_eviction_blocked_multi_block_reconcilation_during_checkpoint', 'multi-block reconciliation blocked whilst checkpoint is running'),
     CacheStat('cache_pages_prefetch', 'pages requested from the cache due to pre-fetch'),
     CacheStat('cache_pages_requested', 'pages requested from the cache'),
+    CacheStat('cache_pages_requested_hs', 'pages requested from the history store'),
     CacheStat('cache_read', 'pages read into cache'),
     CacheStat('cache_read_checkpoint', 'pages read into cache by checkpoint'),
     CacheStat('cache_read_deleted', 'pages read into cache after truncate'),

--- a/src/btree/bt_walk.c
+++ b/src/btree/bt_walk.c
@@ -243,11 +243,12 @@ __tree_walk_internal(WT_SESSION_IMPL *session, WT_REF **refp, uint64_t *walkcntp
   int (*skip_func)(WT_SESSION_IMPL *, WT_REF *, void *, bool, bool *), void *func_cookie,
   uint32_t flags)
 {
+    struct timespec start, stop;
     WT_BTREE *btree;
     WT_DECL_RET;
     WT_PAGE_INDEX *pindex;
     WT_REF *couple, *ref, *ref_orig;
-    uint64_t restart_sleep, restart_yield;
+    uint64_t restart_sleep, restart_yield, time_diff_ms;
     uint32_t slot;
     uint8_t current_state;
     bool empty_internal, prev, skip;
@@ -322,6 +323,7 @@ __tree_walk_internal(WT_SESSION_IMPL *session, WT_REF **refp, uint64_t *walkcntp
      */
     WT_ENTER_PAGE_INDEX(session);
 
+    __wt_epoch(session, &start);
     /* If no page is active, begin a walk from the start/end of the tree. */
     if ((ref = ref_orig) == NULL) {
         if (0) {
@@ -526,6 +528,11 @@ descend:
     }
 
 done:
+    __wt_epoch(session, &stop);
+    time_diff_ms = WT_TIMEDIFF_MS(stop, start);
+    if (time_diff_ms > 10 * WT_THOUSAND)
+        __wt_verbose_warning(session, WT_VERB_READ,
+          "tree walk took more than 10 seconds (%" PRIu64 "ms)", time_diff_ms);
 err:
     WT_TRET(__wt_page_release(session, couple, flags));
     WT_TRET(__wt_page_release(session, ref_orig, flags));

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -607,6 +607,7 @@ struct __wt_connection_stats {
     int64_t cache_eviction_clear_ordinary;
     int64_t cache_pages_requested;
     int64_t cache_pages_prefetch;
+    int64_t cache_pages_requested_hs;
     int64_t cache_eviction_pages_seen;
     int64_t cache_eviction_pages_already_queued;
     int64_t cache_eviction_fail;
@@ -1237,6 +1238,7 @@ struct __wt_dsrc_stats {
     int64_t cache_read_checkpoint;
     int64_t cache_pages_requested;
     int64_t cache_pages_prefetch;
+    int64_t cache_pages_requested_hs;
     int64_t cache_eviction_pages_seen;
     int64_t cache_write;
     int64_t cache_write_restore;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -2400,8 +2400,9 @@ struct __wt_connection {
      * \c 10.}
      * @config{ ),,}
      * @config{generation_drain_timeout_ms, the number of milliseconds to wait for a resource to
-     * drain before timing out in diagnostic mode.  Default will wait for 4 minutes\, 0 will wait
-     * forever., an integer greater than or equal to \c 0; default \c 240000.}
+     * drain before timing out.  In the diagnostic mode\, it will log an error and crash the system.
+     * In the production mode\, it will only log an error.  Default will wait for 4 minutes\, 0 will
+     * wait forever., an integer greater than or equal to \c 0; default \c 240000.}
      * @config{heuristic_controls = (, control the behavior of various optimizations.  This is
      * primarily used as a mechanism for rolling out changes to internal heuristics while providing
      * a mechanism for quickly reverting to prior behavior in the field., a set of related
@@ -3295,8 +3296,9 @@ struct __wt_connection {
  * files that are inactive and close them., an integer between \c 1 and \c 100000; default \c 10.}
  * @config{ ),,}
  * @config{generation_drain_timeout_ms, the number of milliseconds to wait for a resource to drain
- * before timing out in diagnostic mode.  Default will wait for 4 minutes\, 0 will wait forever., an
- * integer greater than or equal to \c 0; default \c 240000.}
+ * before timing out.  In the diagnostic mode\, it will log an error and crash the system.  In the
+ * production mode\, it will only log an error.  Default will wait for 4 minutes\, 0 will wait
+ * forever., an integer greater than or equal to \c 0; default \c 240000.}
  * @config{hash = (, manage resources used by hash bucket arrays.  All values must be a power of
  * two.  Note that setting large values can significantly increase memory usage inside WiredTiger.,
  * a set of related configuration options defined as follows.}
@@ -6180,1171 +6182,1173 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1240
 /*! cache: pages requested from the cache due to pre-fetch */
 #define	WT_STAT_CONN_CACHE_PAGES_PREFETCH		1241
+/*! cache: pages requested from the history store */
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_HS		1242
 /*! cache: pages seen by eviction walk */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1242
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1243
 /*! cache: pages seen by eviction walk that are already queued */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_ALREADY_QUEUED	1243
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_ALREADY_QUEUED	1244
 /*! cache: pages selected for eviction unable to be evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_FAIL		1244
+#define	WT_STAT_CONN_CACHE_EVICTION_FAIL		1245
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * active children on an internal page
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_ACTIVE_CHILDREN_ON_AN_INTERNAL_PAGE	1245
+#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_ACTIVE_CHILDREN_ON_AN_INTERNAL_PAGE	1246
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * failure in reconciliation
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_IN_RECONCILIATION	1246
+#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_IN_RECONCILIATION	1247
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * race between checkpoint and updates without timestamps
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_CHECKPOINT_NO_TS	1247
+#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_CHECKPOINT_NO_TS	1248
 /*! cache: pages walked for eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK		1248
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK		1249
 /*! cache: pages written from cache */
-#define	WT_STAT_CONN_CACHE_WRITE			1249
+#define	WT_STAT_CONN_CACHE_WRITE			1250
 /*! cache: pages written requiring in-memory restoration */
-#define	WT_STAT_CONN_CACHE_WRITE_RESTORE		1250
+#define	WT_STAT_CONN_CACHE_WRITE_RESTORE		1251
 /*! cache: percentage overhead */
-#define	WT_STAT_CONN_CACHE_OVERHEAD			1251
+#define	WT_STAT_CONN_CACHE_OVERHEAD			1252
 /*! cache: recent modification of a page blocked its eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	1252
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	1253
 /*! cache: reverse splits performed */
-#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS		1253
+#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS		1254
 /*!
  * cache: reverse splits skipped because of VLCS namespace gap
  * restrictions
  */
-#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	1254
+#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	1255
 /*! cache: the number of times full update inserted to history store */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1255
+#define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1256
 /*! cache: the number of times reverse modify inserted to history store */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1256
+#define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1257
 /*!
  * cache: total milliseconds spent inside reentrant history store
  * evictions in a reconciliation
  */
-#define	WT_STAT_CONN_CACHE_REENTRY_HS_EVICTION_MILLISECONDS	1257
+#define	WT_STAT_CONN_CACHE_REENTRY_HS_EVICTION_MILLISECONDS	1258
 /*! cache: tracked bytes belonging to internal pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1258
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1259
 /*! cache: tracked bytes belonging to leaf pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1259
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1260
 /*! cache: tracked dirty bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1260
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1261
 /*! cache: tracked dirty internal page bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL		1261
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL		1262
 /*! cache: tracked dirty leaf page bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF		1262
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF		1263
 /*! cache: tracked dirty pages in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1263
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1264
 /*! cache: uncommitted truncate blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	1264
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	1265
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1265
+#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1266
 /*! capacity: background fsync file handles considered */
-#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1266
+#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1267
 /*! capacity: background fsync file handles synced */
-#define	WT_STAT_CONN_FSYNC_ALL_FH			1267
+#define	WT_STAT_CONN_FSYNC_ALL_FH			1268
 /*! capacity: background fsync time (msecs) */
-#define	WT_STAT_CONN_FSYNC_ALL_TIME			1268
+#define	WT_STAT_CONN_FSYNC_ALL_TIME			1269
 /*! capacity: bytes read */
-#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1269
+#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1270
 /*! capacity: bytes written for checkpoint */
-#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1270
+#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1271
 /*! capacity: bytes written for chunk cache */
-#define	WT_STAT_CONN_CAPACITY_BYTES_CHUNKCACHE		1271
+#define	WT_STAT_CONN_CAPACITY_BYTES_CHUNKCACHE		1272
 /*! capacity: bytes written for eviction */
-#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1272
+#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1273
 /*! capacity: bytes written for log */
-#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1273
+#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1274
 /*! capacity: bytes written total */
-#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1274
+#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1275
 /*! capacity: threshold to call fsync */
-#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1275
+#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1276
 /*! capacity: time waiting due to total capacity (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1276
+#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1277
 /*! capacity: time waiting during checkpoint (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1277
+#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1278
 /*! capacity: time waiting during eviction (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1278
+#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1279
 /*! capacity: time waiting during logging (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1279
+#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1280
 /*! capacity: time waiting during read (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_READ			1280
+#define	WT_STAT_CONN_CAPACITY_TIME_READ			1281
 /*! capacity: time waiting for chunk cache IO bandwidth (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_CHUNKCACHE		1281
+#define	WT_STAT_CONN_CAPACITY_TIME_CHUNKCACHE		1282
 /*! checkpoint: checkpoint cleanup successful calls */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_SUCCESS		1282
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_SUCCESS		1283
 /*! checkpoint: checkpoint has acquired a snapshot for its transaction */
-#define	WT_STAT_CONN_CHECKPOINT_SNAPSHOT_ACQUIRED	1283
+#define	WT_STAT_CONN_CHECKPOINT_SNAPSHOT_ACQUIRED	1284
 /*! checkpoint: checkpoints skipped because database was clean */
-#define	WT_STAT_CONN_CHECKPOINT_SKIPPED			1284
+#define	WT_STAT_CONN_CHECKPOINT_SKIPPED			1285
 /*! checkpoint: fsync calls after allocating the transaction ID */
-#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST		1285
+#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST		1286
 /*! checkpoint: fsync duration after allocating the transaction ID (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST_DURATION	1286
+#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST_DURATION	1287
 /*! checkpoint: generation */
-#define	WT_STAT_CONN_CHECKPOINT_GENERATION		1287
+#define	WT_STAT_CONN_CHECKPOINT_GENERATION		1288
 /*! checkpoint: max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_MAX		1288
+#define	WT_STAT_CONN_CHECKPOINT_TIME_MAX		1289
 /*! checkpoint: min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_MIN		1289
+#define	WT_STAT_CONN_CHECKPOINT_TIME_MIN		1290
 /*!
  * checkpoint: most recent duration for checkpoint dropping all handles
  * (usecs)
  */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROP_DURATION	1290
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROP_DURATION	1291
 /*! checkpoint: most recent duration for gathering all handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION		1291
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION		1292
 /*! checkpoint: most recent duration for gathering applied handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLY_DURATION	1292
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLY_DURATION	1293
 /*! checkpoint: most recent duration for gathering skipped handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIP_DURATION	1293
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIP_DURATION	1294
 /*! checkpoint: most recent duration for handles metadata checked (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECK_DURATION	1294
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECK_DURATION	1295
 /*! checkpoint: most recent duration for locking the handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCK_DURATION	1295
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCK_DURATION	1296
 /*! checkpoint: most recent handles applied */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLIED		1296
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLIED		1297
 /*! checkpoint: most recent handles checkpoint dropped */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROPPED		1297
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROPPED		1298
 /*! checkpoint: most recent handles metadata checked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECKED	1298
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECKED	1299
 /*! checkpoint: most recent handles metadata locked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCKED		1299
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCKED		1300
 /*! checkpoint: most recent handles skipped */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIPPED		1300
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIPPED		1301
 /*! checkpoint: most recent handles walked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_WALKED		1301
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_WALKED		1302
 /*! checkpoint: most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_RECENT		1302
+#define	WT_STAT_CONN_CHECKPOINT_TIME_RECENT		1303
 /*! checkpoint: number of checkpoints started by api */
-#define	WT_STAT_CONN_CHECKPOINTS_API			1303
+#define	WT_STAT_CONN_CHECKPOINTS_API			1304
 /*! checkpoint: number of checkpoints started by compaction */
-#define	WT_STAT_CONN_CHECKPOINTS_COMPACT		1304
+#define	WT_STAT_CONN_CHECKPOINTS_COMPACT		1305
 /*! checkpoint: number of files synced */
-#define	WT_STAT_CONN_CHECKPOINT_SYNC			1305
+#define	WT_STAT_CONN_CHECKPOINT_SYNC			1306
 /*! checkpoint: number of handles visited after writes complete */
-#define	WT_STAT_CONN_CHECKPOINT_PRESYNC			1306
+#define	WT_STAT_CONN_CHECKPOINT_PRESYNC			1307
 /*! checkpoint: number of history store pages caused to be reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_HS_PAGES_RECONCILED	1307
+#define	WT_STAT_CONN_CHECKPOINT_HS_PAGES_RECONCILED	1308
 /*! checkpoint: number of internal pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_INTERNAL	1308
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_INTERNAL	1309
 /*! checkpoint: number of leaf pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_LEAF	1309
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_LEAF	1310
 /*! checkpoint: number of pages caused to be reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED	1310
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED	1311
 /*! checkpoint: pages added for eviction during checkpoint cleanup */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_EVICT	1311
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_EVICT	1312
 /*!
  * checkpoint: pages dirtied due to obsolete time window by checkpoint
  * cleanup
  */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	1312
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	1313
 /*!
  * checkpoint: pages read into cache during checkpoint cleanup
  * (reclaim_space)
  */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	1313
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	1314
 /*!
  * checkpoint: pages read into cache during checkpoint cleanup due to
  * obsolete time window
  */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	1314
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	1315
 /*! checkpoint: pages removed during checkpoint cleanup */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_REMOVED	1315
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_REMOVED	1316
 /*! checkpoint: pages skipped during checkpoint cleanup tree walk */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	1316
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	1317
 /*! checkpoint: pages visited during checkpoint cleanup */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_VISITED	1317
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_VISITED	1318
 /*! checkpoint: prepare currently running */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1318
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1319
 /*! checkpoint: prepare max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1319
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1320
 /*! checkpoint: prepare min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1320
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1321
 /*! checkpoint: prepare most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1321
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1322
 /*! checkpoint: prepare total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1322
+#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1323
 /*! checkpoint: progress state */
-#define	WT_STAT_CONN_CHECKPOINT_STATE			1323
+#define	WT_STAT_CONN_CHECKPOINT_STATE			1324
 /*! checkpoint: scrub dirty target */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1324
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1325
 /*! checkpoint: scrub max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1325
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1326
 /*! checkpoint: scrub min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1326
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1327
 /*! checkpoint: scrub most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1327
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1328
 /*! checkpoint: scrub total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1328
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1329
 /*! checkpoint: stop timing stress active */
-#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1329
+#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1330
 /*! checkpoint: time spent on per-tree checkpoint work (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1330
+#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1331
 /*! checkpoint: total failed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1331
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1332
 /*! checkpoint: total succeed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1332
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1333
 /*! checkpoint: total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1333
+#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1334
 /*! checkpoint: transaction checkpoints due to obsolete pages */
-#define	WT_STAT_CONN_CHECKPOINT_OBSOLETE_APPLIED	1334
+#define	WT_STAT_CONN_CHECKPOINT_OBSOLETE_APPLIED	1335
 /*! checkpoint: wait cycles while cache dirty level is decreasing */
-#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1335
+#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1336
 /*! chunk-cache: aggregate number of spanned chunks on read */
-#define	WT_STAT_CONN_CHUNKCACHE_SPANS_CHUNKS_READ	1336
+#define	WT_STAT_CONN_CHUNKCACHE_SPANS_CHUNKS_READ	1337
 /*! chunk-cache: chunks evicted */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_EVICTED		1337
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_EVICTED		1338
 /*! chunk-cache: could not allocate due to exceeding bitmap capacity */
-#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_BITMAP_CAPACITY	1338
+#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_BITMAP_CAPACITY	1339
 /*! chunk-cache: could not allocate due to exceeding capacity */
-#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_CAPACITY	1339
+#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_CAPACITY	1340
 /*! chunk-cache: lookups */
-#define	WT_STAT_CONN_CHUNKCACHE_LOOKUPS			1340
+#define	WT_STAT_CONN_CHUNKCACHE_LOOKUPS			1341
 /*!
  * chunk-cache: number of chunks loaded from flushed tables in chunk
  * cache
  */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_LOADED_FROM_FLUSHED_TABLES	1341
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_LOADED_FROM_FLUSHED_TABLES	1342
 /*! chunk-cache: number of metadata entries inserted */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_INSERTED	1342
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_INSERTED	1343
 /*! chunk-cache: number of metadata entries removed */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_REMOVED	1343
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_REMOVED	1344
 /*!
  * chunk-cache: number of metadata inserts/deletes dropped by the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DROPPED	1344
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DROPPED	1345
 /*!
  * chunk-cache: number of metadata inserts/deletes pushed to the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_CREATED	1345
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_CREATED	1346
 /*!
  * chunk-cache: number of metadata inserts/deletes read by the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DEQUEUED	1346
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DEQUEUED	1347
 /*! chunk-cache: number of misses */
-#define	WT_STAT_CONN_CHUNKCACHE_MISSES			1347
+#define	WT_STAT_CONN_CHUNKCACHE_MISSES			1348
 /*! chunk-cache: number of times a read from storage failed */
-#define	WT_STAT_CONN_CHUNKCACHE_IO_FAILED		1348
+#define	WT_STAT_CONN_CHUNKCACHE_IO_FAILED		1349
 /*! chunk-cache: retried accessing a chunk while I/O was in progress */
-#define	WT_STAT_CONN_CHUNKCACHE_RETRIES			1349
+#define	WT_STAT_CONN_CHUNKCACHE_RETRIES			1350
 /*! chunk-cache: retries from a chunk cache checksum mismatch */
-#define	WT_STAT_CONN_CHUNKCACHE_RETRIES_CHECKSUM_MISMATCH	1350
+#define	WT_STAT_CONN_CHUNKCACHE_RETRIES_CHECKSUM_MISMATCH	1351
 /*! chunk-cache: timed out due to too many retries */
-#define	WT_STAT_CONN_CHUNKCACHE_TOOMANY_RETRIES		1351
+#define	WT_STAT_CONN_CHUNKCACHE_TOOMANY_RETRIES		1352
 /*! chunk-cache: total bytes read from persistent content */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_READ_PERSISTENT	1352
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_READ_PERSISTENT	1353
 /*! chunk-cache: total bytes used by the cache */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE		1353
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE		1354
 /*! chunk-cache: total bytes used by the cache for pinned chunks */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE_PINNED	1354
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE_PINNED	1355
 /*! chunk-cache: total chunks held by the chunk cache */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_INUSE		1355
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_INUSE		1356
 /*!
  * chunk-cache: total number of chunks inserted on startup from persisted
  * metadata.
  */
-#define	WT_STAT_CONN_CHUNKCACHE_CREATED_FROM_METADATA	1356
+#define	WT_STAT_CONN_CHUNKCACHE_CREATED_FROM_METADATA	1357
 /*! chunk-cache: total pinned chunks held by the chunk cache */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_PINNED		1357
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_PINNED		1358
 /*! connection: auto adjusting condition resets */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1358
+#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1359
 /*! connection: auto adjusting condition wait calls */
-#define	WT_STAT_CONN_COND_AUTO_WAIT			1359
+#define	WT_STAT_CONN_COND_AUTO_WAIT			1360
 /*!
  * connection: auto adjusting condition wait raced to update timeout and
  * skipped updating
  */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1360
+#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1361
 /*! connection: detected system time went backwards */
-#define	WT_STAT_CONN_TIME_TRAVEL			1361
+#define	WT_STAT_CONN_TIME_TRAVEL			1362
 /*! connection: files currently open */
-#define	WT_STAT_CONN_FILE_OPEN				1362
+#define	WT_STAT_CONN_FILE_OPEN				1363
 /*! connection: hash bucket array size for data handles */
-#define	WT_STAT_CONN_BUCKETS_DH				1363
+#define	WT_STAT_CONN_BUCKETS_DH				1364
 /*! connection: hash bucket array size general */
-#define	WT_STAT_CONN_BUCKETS				1364
+#define	WT_STAT_CONN_BUCKETS				1365
 /*! connection: memory allocations */
-#define	WT_STAT_CONN_MEMORY_ALLOCATION			1365
+#define	WT_STAT_CONN_MEMORY_ALLOCATION			1366
 /*! connection: memory frees */
-#define	WT_STAT_CONN_MEMORY_FREE			1366
+#define	WT_STAT_CONN_MEMORY_FREE			1367
 /*! connection: memory re-allocations */
-#define	WT_STAT_CONN_MEMORY_GROW			1367
+#define	WT_STAT_CONN_MEMORY_GROW			1368
 /*! connection: number of sessions without a sweep for 5+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1368
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1369
 /*! connection: number of sessions without a sweep for 60+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1369
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1370
 /*! connection: pthread mutex condition wait calls */
-#define	WT_STAT_CONN_COND_WAIT				1370
+#define	WT_STAT_CONN_COND_WAIT				1371
 /*! connection: pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			1371
+#define	WT_STAT_CONN_RWLOCK_READ			1372
 /*! connection: pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			1372
+#define	WT_STAT_CONN_RWLOCK_WRITE			1373
 /*! connection: total fsync I/Os */
-#define	WT_STAT_CONN_FSYNC_IO				1373
+#define	WT_STAT_CONN_FSYNC_IO				1374
 /*! connection: total read I/Os */
-#define	WT_STAT_CONN_READ_IO				1374
+#define	WT_STAT_CONN_READ_IO				1375
 /*! connection: total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				1375
+#define	WT_STAT_CONN_WRITE_IO				1376
 /*! cursor: Total number of deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1376
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1377
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1377
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1378
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1378
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1379
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1379
+#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1380
 /*!
  * cursor: Total number of in-memory deleted pages skipped during tree
  * walk
  */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1380
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1381
 /*! cursor: Total number of on-disk deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1381
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1382
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1382
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1383
 /*!
  * cursor: Total number of times cursor fails to temporarily release
  * pinned page to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1383
+#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1384
 /*!
  * cursor: Total number of times cursor temporarily releases pinned page
  * to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION			1384
+#define	WT_STAT_CONN_CURSOR_REPOSITION			1385
 /*! cursor: bulk cursor count */
-#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1385
+#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1386
 /*! cursor: cached cursor count */
-#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1386
+#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1387
 /*! cursor: cursor bound calls that return an error */
-#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1387
+#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1388
 /*! cursor: cursor bounds cleared from reset */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1388
+#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1389
 /*! cursor: cursor bounds comparisons performed */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1389
+#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1390
 /*! cursor: cursor bounds next called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1390
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1391
 /*! cursor: cursor bounds next early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1391
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1392
 /*! cursor: cursor bounds prev called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1392
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1393
 /*! cursor: cursor bounds prev early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1393
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1394
 /*! cursor: cursor bounds search early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1394
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1395
 /*! cursor: cursor bounds search near call repositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1395
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1396
 /*! cursor: cursor bulk loaded cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1396
+#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1397
 /*! cursor: cursor cache calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1397
+#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1398
 /*! cursor: cursor close calls that result in cache */
-#define	WT_STAT_CONN_CURSOR_CACHE			1398
+#define	WT_STAT_CONN_CURSOR_CACHE			1399
 /*! cursor: cursor close calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1399
+#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1400
 /*! cursor: cursor compare calls that return an error */
-#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1400
+#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1401
 /*! cursor: cursor create calls */
-#define	WT_STAT_CONN_CURSOR_CREATE			1401
+#define	WT_STAT_CONN_CURSOR_CREATE			1402
 /*! cursor: cursor equals calls that return an error */
-#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1402
+#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1403
 /*! cursor: cursor get key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1403
+#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1404
 /*! cursor: cursor get value calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1404
+#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1405
 /*! cursor: cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT			1405
+#define	WT_STAT_CONN_CURSOR_INSERT			1406
 /*! cursor: cursor insert calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1406
+#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1407
 /*! cursor: cursor insert check calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1407
+#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1408
 /*! cursor: cursor insert key and value bytes */
-#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1408
+#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1409
 /*! cursor: cursor largest key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1409
+#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1410
 /*! cursor: cursor modify calls */
-#define	WT_STAT_CONN_CURSOR_MODIFY			1410
+#define	WT_STAT_CONN_CURSOR_MODIFY			1411
 /*! cursor: cursor modify calls that return an error */
-#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1411
+#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1412
 /*! cursor: cursor modify key and value bytes affected */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1412
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1413
 /*! cursor: cursor modify value bytes modified */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1413
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1414
 /*! cursor: cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT			1414
+#define	WT_STAT_CONN_CURSOR_NEXT			1415
 /*! cursor: cursor next calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1415
+#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1416
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1416
+#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1417
 /*!
  * cursor: cursor next calls that skip greater than 1 and fewer than 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1417
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1418
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1418
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1419
 /*! cursor: cursor next random calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1419
+#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1420
 /*! cursor: cursor operation restarted */
-#define	WT_STAT_CONN_CURSOR_RESTART			1420
+#define	WT_STAT_CONN_CURSOR_RESTART			1421
 /*! cursor: cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV			1421
+#define	WT_STAT_CONN_CURSOR_PREV			1422
 /*! cursor: cursor prev calls that return an error */
-#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1422
+#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1423
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1423
+#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1424
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1424
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1425
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1425
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1426
 /*! cursor: cursor reconfigure calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1426
+#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1427
 /*! cursor: cursor remove calls */
-#define	WT_STAT_CONN_CURSOR_REMOVE			1427
+#define	WT_STAT_CONN_CURSOR_REMOVE			1428
 /*! cursor: cursor remove calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1428
+#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1429
 /*! cursor: cursor remove key bytes removed */
-#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1429
+#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1430
 /*! cursor: cursor reopen calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1430
+#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1431
 /*! cursor: cursor reserve calls */
-#define	WT_STAT_CONN_CURSOR_RESERVE			1431
+#define	WT_STAT_CONN_CURSOR_RESERVE			1432
 /*! cursor: cursor reserve calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1432
+#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1433
 /*! cursor: cursor reset calls */
-#define	WT_STAT_CONN_CURSOR_RESET			1433
+#define	WT_STAT_CONN_CURSOR_RESET			1434
 /*! cursor: cursor reset calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1434
+#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1435
 /*! cursor: cursor search calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH			1435
+#define	WT_STAT_CONN_CURSOR_SEARCH			1436
 /*! cursor: cursor search calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1436
+#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1437
 /*! cursor: cursor search history store calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1437
+#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1438
 /*! cursor: cursor search near calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1438
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1439
 /*! cursor: cursor search near calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1439
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1440
 /*! cursor: cursor sweep buckets */
-#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1440
+#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1441
 /*! cursor: cursor sweep cursors closed */
-#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1441
+#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1442
 /*! cursor: cursor sweep cursors examined */
-#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1442
+#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1443
 /*! cursor: cursor sweeps */
-#define	WT_STAT_CONN_CURSOR_SWEEP			1443
+#define	WT_STAT_CONN_CURSOR_SWEEP			1444
 /*! cursor: cursor truncate calls */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE			1444
+#define	WT_STAT_CONN_CURSOR_TRUNCATE			1445
 /*! cursor: cursor truncates performed on individual keys */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1445
+#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1446
 /*! cursor: cursor update calls */
-#define	WT_STAT_CONN_CURSOR_UPDATE			1446
+#define	WT_STAT_CONN_CURSOR_UPDATE			1447
 /*! cursor: cursor update calls that return an error */
-#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1447
+#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1448
 /*! cursor: cursor update key and value bytes */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1448
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1449
 /*! cursor: cursor update value size change */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1449
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1450
 /*! cursor: cursors reused from cache */
-#define	WT_STAT_CONN_CURSOR_REOPEN			1450
+#define	WT_STAT_CONN_CURSOR_REOPEN			1451
 /*! cursor: open cursor count */
-#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1451
+#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1452
 /*! data-handle: connection data handle size */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1452
+#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1453
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1453
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1454
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1454
+#define	WT_STAT_CONN_DH_SWEEP_REF			1455
 /*! data-handle: connection sweep dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1455
+#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1456
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1456
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1457
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1457
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1458
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1458
+#define	WT_STAT_CONN_DH_SWEEPS				1459
 /*!
  * data-handle: connection sweeps skipped due to checkpoint gathering
  * handles
  */
-#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1459
+#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1460
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1460
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1461
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1461
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1462
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1462
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1463
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1463
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1464
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1464
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1465
 /*! lock: dhandle lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1465
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1466
 /*! lock: dhandle lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1466
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1467
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1467
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1468
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1468
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1469
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1469
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1470
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1470
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1471
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1471
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1472
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1472
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1473
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1473
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1474
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1474
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1475
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1475
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1476
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1476
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1477
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1477
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1478
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1478
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1479
 /*! lock: txn global lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1479
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1480
 /*! lock: txn global lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1480
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1481
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1481
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1482
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1482
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1483
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1483
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1484
 /*! log: force log remove time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1484
+#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1485
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1485
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1486
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1486
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1487
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1487
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1488
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1488
+#define	WT_STAT_CONN_LOG_FLUSH				1489
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1489
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1490
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1490
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1491
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1491
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1492
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1492
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1493
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1493
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1494
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1494
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1495
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1495
+#define	WT_STAT_CONN_LOG_SCANS				1496
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1496
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1497
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1497
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1498
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1498
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1499
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1499
+#define	WT_STAT_CONN_LOG_SYNC				1500
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1500
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1501
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1501
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1502
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1502
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1503
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1503
+#define	WT_STAT_CONN_LOG_WRITES				1504
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1504
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1505
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1505
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1506
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1506
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1507
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1507
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1508
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1508
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1509
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1509
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1510
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1510
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1511
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1511
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1512
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1512
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1513
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1513
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1514
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1514
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1515
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1515
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1516
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1516
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1517
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1517
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1518
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1518
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1519
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1519
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1520
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1520
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1521
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1521
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1522
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1522
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1523
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1523
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1524
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1524
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1525
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1525
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1526
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1526
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1527
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1527
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1528
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1528
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1529
 /*! perf: file system read latency histogram (bucket 1) - 0-10ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1529
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1530
 /*! perf: file system read latency histogram (bucket 2) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1530
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1531
 /*! perf: file system read latency histogram (bucket 3) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1531
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1532
 /*! perf: file system read latency histogram (bucket 4) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1532
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1533
 /*! perf: file system read latency histogram (bucket 5) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1533
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1534
 /*! perf: file system read latency histogram (bucket 6) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1534
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1535
 /*! perf: file system read latency histogram (bucket 7) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1535
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1536
 /*! perf: file system read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1536
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1537
 /*! perf: file system write latency histogram (bucket 1) - 0-10ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1537
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1538
 /*! perf: file system write latency histogram (bucket 2) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1538
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1539
 /*! perf: file system write latency histogram (bucket 3) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1539
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1540
 /*! perf: file system write latency histogram (bucket 4) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1540
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1541
 /*! perf: file system write latency histogram (bucket 5) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1541
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1542
 /*! perf: file system write latency histogram (bucket 6) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1542
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1543
 /*! perf: file system write latency histogram (bucket 7) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1543
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1544
 /*! perf: file system write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1544
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1545
 /*! perf: operation read latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1545
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1546
 /*! perf: operation read latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1546
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1547
 /*! perf: operation read latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1547
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1548
 /*! perf: operation read latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1548
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1549
 /*! perf: operation read latency histogram (bucket 5) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1549
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1550
 /*! perf: operation read latency histogram (bucket 6) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1550
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1551
 /*! perf: operation read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1551
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1552
 /*! perf: operation write latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1552
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1553
 /*! perf: operation write latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1553
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1554
 /*! perf: operation write latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1554
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1555
 /*! perf: operation write latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1555
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1556
 /*! perf: operation write latency histogram (bucket 5) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1556
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1557
 /*! perf: operation write latency histogram (bucket 6) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1557
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1558
 /*! perf: operation write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1558
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1559
 /*! prefetch: could not perform pre-fetch on internal page */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1559
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1560
 /*!
  * prefetch: could not perform pre-fetch on ref without the pre-fetch
  * flag set
  */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1560
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1561
 /*! prefetch: number of times pre-fetch failed to start */
-#define	WT_STAT_CONN_PREFETCH_FAILED_START		1561
+#define	WT_STAT_CONN_PREFETCH_FAILED_START		1562
 /*! prefetch: pre-fetch not repeating for recently pre-fetched ref */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1562
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1563
 /*! prefetch: pre-fetch not triggered after single disk read */
-#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1563
+#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1564
 /*! prefetch: pre-fetch not triggered as there is no valid dhandle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1564
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1565
 /*! prefetch: pre-fetch not triggered by page read */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED			1565
+#define	WT_STAT_CONN_PREFETCH_SKIPPED			1566
 /*! prefetch: pre-fetch not triggered due to disk read count */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1566
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1567
 /*! prefetch: pre-fetch not triggered due to internal session */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1567
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1568
 /*! prefetch: pre-fetch not triggered due to special btree handle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1568
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1569
 /*! prefetch: pre-fetch page not on disk when reading */
-#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1569
+#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1570
 /*! prefetch: pre-fetch pages queued */
-#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1570
+#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1571
 /*! prefetch: pre-fetch pages read in background */
-#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1571
+#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1572
 /*! prefetch: pre-fetch skipped reading in a page due to harmless error */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1572
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1573
 /*! prefetch: pre-fetch triggered by page read */
-#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1573
+#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1574
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1574
+#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1575
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1575
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1576
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1576
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1577
 /*! reconciliation: cursor next/prev calls during HS wrapup search_near */
-#define	WT_STAT_CONN_REC_HS_WRAPUP_NEXT_PREV_CALLS	1577
+#define	WT_STAT_CONN_REC_HS_WRAPUP_NEXT_PREV_CALLS	1578
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1578
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1579
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1579
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1580
 /*! reconciliation: maximum milliseconds spent in a reconciliation call */
-#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1580
+#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1581
 /*!
  * reconciliation: maximum milliseconds spent in building a disk image in
  * a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1581
+#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1582
 /*!
  * reconciliation: maximum milliseconds spent in moving updates to the
  * history store in a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1582
+#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1583
 /*! reconciliation: overflow values written */
-#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1583
+#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1584
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1584
+#define	WT_STAT_CONN_REC_PAGES				1585
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1585
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1586
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * prepared transaction metadata
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1586
+#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1587
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * timestamps
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1587
+#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1588
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * transaction ids
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1588
+#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1589
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1589
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1590
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1590
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1591
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1591
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1592
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1592
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1593
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1593
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1594
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1594
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1595
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1595
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1596
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1596
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1597
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1597
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1598
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1598
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1599
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1599
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1600
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1600
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1601
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1601
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1602
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1602
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1603
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1603
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1604
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1604
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1605
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1605
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1606
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1606
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1607
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1607
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1608
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1608
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1609
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1609
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1610
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1610
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1611
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1611
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1612
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1612
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1613
 /*! session: attempts to remove a local object and the object is in use */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1613
+#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1614
 /*! session: flush_tier failed calls */
-#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1614
+#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1615
 /*! session: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1615
+#define	WT_STAT_CONN_FLUSH_TIER				1616
 /*! session: flush_tier tables skipped due to no checkpoint */
-#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1616
+#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1617
 /*! session: flush_tier tables switched */
-#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1617
+#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1618
 /*! session: local objects removed */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1618
+#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1619
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1619
+#define	WT_STAT_CONN_SESSION_OPEN			1620
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1620
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1621
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1621
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1622
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1622
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1623
 /*! session: table alter triggering checkpoint calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1623
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1624
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1624
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1625
 /*! session: table compact conflicted with checkpoint */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1625
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1626
 /*! session: table compact dhandle successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1626
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1627
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1627
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1628
 /*! session: table compact failed calls due to cache pressure */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1628
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1629
 /*! session: table compact passes */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1629
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1630
 /*! session: table compact pulled into eviction */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1630
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1631
 /*! session: table compact running */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1631
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1632
 /*! session: table compact skipped as process would not reduce file size */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1632
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1633
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1633
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1634
 /*! session: table compact timeout */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1634
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1635
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1635
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1636
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1636
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1637
 /*! session: table create with import failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1637
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1638
 /*! session: table create with import repair calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1638
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1639
 /*! session: table create with import successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1639
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1640
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1640
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1641
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1641
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1642
 /*! session: table rename failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1642
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1643
 /*! session: table rename successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1643
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1644
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1644
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1645
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1645
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1646
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1646
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1647
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1647
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1648
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1648
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1649
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1649
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1650
 /*! session: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1650
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1651
 /*! session: tiered operations removed without processing */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1651
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1652
 /*! session: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1652
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1653
 /*! session: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1653
+#define	WT_STAT_CONN_TIERED_RETENTION			1654
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1654
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1655
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1655
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1656
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1656
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1657
 /*! thread-yield: application thread operations waiting for cache */
-#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1657
+#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1658
 /*! thread-yield: application thread snapshot refreshed for eviction */
-#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1658
+#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1659
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1659
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1660
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1660
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1661
 /*! thread-yield: connection close yielded for lsm manager shutdown */
-#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1661
+#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1662
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1662
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1663
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1663
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1664
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1664
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1665
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1665
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1666
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1666
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1667
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1667
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1668
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1668
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1669
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1669
+#define	WT_STAT_CONN_PAGE_SLEEP				1670
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1670
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1671
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1671
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1672
 /*! thread-yield: page split and restart read */
-#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1672
+#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1673
 /*! thread-yield: pages skipped during read due to deleted state */
-#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1673
+#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1674
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1674
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1675
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1675
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1676
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1676
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1677
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1677
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1678
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1678
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1679
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1679
+#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1680
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1680
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1681
 /*! transaction: oldest transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1681
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1682
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1682
+#define	WT_STAT_CONN_TXN_PREPARE			1683
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1683
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1684
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1684
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1685
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1685
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1686
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1686
+#define	WT_STAT_CONN_TXN_QUERY_TS			1687
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1687
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1688
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1688
+#define	WT_STAT_CONN_TXN_RTS				1689
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1689
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1690
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1690
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1691
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1691
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1692
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1692
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1693
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1693
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1694
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1694
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1695
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1695
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1696
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1696
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1697
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1697
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1698
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1698
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1699
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1699
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1700
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1700
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1701
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1701
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1702
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1702
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1703
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1703
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1704
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1704
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1705
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1705
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1706
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1706
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1707
 /*!
  * transaction: rollback to stable updates that would have been aborted
  * in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1707
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1708
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1708
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1709
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1709
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1710
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1710
+#define	WT_STAT_CONN_TXN_SET_TS				1711
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1711
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1712
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1712
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1713
 /*! transaction: set timestamp force calls */
-#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1713
+#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1714
 /*!
  * transaction: set timestamp global oldest timestamp set to be more
  * recent than the global stable timestamp
  */
-#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1714
+#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1715
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1715
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1716
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1716
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1717
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1717
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1718
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1718
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1719
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1719
+#define	WT_STAT_CONN_TXN_BEGIN				1720
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1720
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1721
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1721
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1722
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1722
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1723
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1723
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1724
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1724
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1725
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1725
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1726
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1726
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1727
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1727
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1728
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1728
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1729
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1729
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1730
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1730
+#define	WT_STAT_CONN_TXN_COMMIT				1731
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1731
+#define	WT_STAT_CONN_TXN_ROLLBACK			1732
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1732
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1733
 
 /*!
  * @}
@@ -7731,603 +7735,605 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_DSRC_CACHE_PAGES_REQUESTED		2130
 /*! cache: pages requested from the cache due to pre-fetch */
 #define	WT_STAT_DSRC_CACHE_PAGES_PREFETCH		2131
+/*! cache: pages requested from the history store */
+#define	WT_STAT_DSRC_CACHE_PAGES_REQUESTED_HS		2132
 /*! cache: pages seen by eviction walk */
-#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_SEEN		2132
+#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_SEEN		2133
 /*! cache: pages written from cache */
-#define	WT_STAT_DSRC_CACHE_WRITE			2133
+#define	WT_STAT_DSRC_CACHE_WRITE			2134
 /*! cache: pages written requiring in-memory restoration */
-#define	WT_STAT_DSRC_CACHE_WRITE_RESTORE		2134
+#define	WT_STAT_DSRC_CACHE_WRITE_RESTORE		2135
 /*! cache: recent modification of a page blocked its eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	2135
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	2136
 /*! cache: reverse splits performed */
-#define	WT_STAT_DSRC_CACHE_REVERSE_SPLITS		2136
+#define	WT_STAT_DSRC_CACHE_REVERSE_SPLITS		2137
 /*!
  * cache: reverse splits skipped because of VLCS namespace gap
  * restrictions
  */
-#define	WT_STAT_DSRC_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	2137
+#define	WT_STAT_DSRC_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	2138
 /*! cache: the number of times full update inserted to history store */
-#define	WT_STAT_DSRC_CACHE_HS_INSERT_FULL_UPDATE	2138
+#define	WT_STAT_DSRC_CACHE_HS_INSERT_FULL_UPDATE	2139
 /*! cache: the number of times reverse modify inserted to history store */
-#define	WT_STAT_DSRC_CACHE_HS_INSERT_REVERSE_MODIFY	2139
+#define	WT_STAT_DSRC_CACHE_HS_INSERT_REVERSE_MODIFY	2140
 /*! cache: tracked dirty bytes in the cache */
-#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY			2140
+#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY			2141
 /*! cache: tracked dirty internal page bytes in the cache */
-#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY_INTERNAL		2141
+#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY_INTERNAL		2142
 /*! cache: tracked dirty leaf page bytes in the cache */
-#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY_LEAF		2142
+#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY_LEAF		2143
 /*! cache: uncommitted truncate blocked page eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	2143
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	2144
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_DSRC_CACHE_EVICTION_CLEAN		2144
+#define	WT_STAT_DSRC_CACHE_EVICTION_CLEAN		2145
 /*!
  * cache_walk: Average difference between current eviction generation
  * when the page was last considered, only reported if cache_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_GEN_AVG_GAP		2145
+#define	WT_STAT_DSRC_CACHE_STATE_GEN_AVG_GAP		2146
 /*!
  * cache_walk: Average on-disk page image size seen, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_AVG_WRITTEN_SIZE	2146
+#define	WT_STAT_DSRC_CACHE_STATE_AVG_WRITTEN_SIZE	2147
 /*!
  * cache_walk: Average time in cache for pages that have been visited by
  * the eviction server, only reported if cache_walk or all statistics are
  * enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_AVG_VISITED_AGE	2147
+#define	WT_STAT_DSRC_CACHE_STATE_AVG_VISITED_AGE	2148
 /*!
  * cache_walk: Average time in cache for pages that have not been visited
  * by the eviction server, only reported if cache_walk or all statistics
  * are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_AVG_UNVISITED_AGE	2148
+#define	WT_STAT_DSRC_CACHE_STATE_AVG_UNVISITED_AGE	2149
 /*!
  * cache_walk: Clean pages currently in cache, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES_CLEAN		2149
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES_CLEAN		2150
 /*!
  * cache_walk: Current eviction generation, only reported if cache_walk
  * or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_GEN_CURRENT		2150
+#define	WT_STAT_DSRC_CACHE_STATE_GEN_CURRENT		2151
 /*!
  * cache_walk: Dirty pages currently in cache, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES_DIRTY		2151
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES_DIRTY		2152
 /*!
  * cache_walk: Entries in the root page, only reported if cache_walk or
  * all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_ROOT_ENTRIES		2152
+#define	WT_STAT_DSRC_CACHE_STATE_ROOT_ENTRIES		2153
 /*!
  * cache_walk: Internal pages currently in cache, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES_INTERNAL		2153
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES_INTERNAL		2154
 /*!
  * cache_walk: Leaf pages currently in cache, only reported if cache_walk
  * or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES_LEAF		2154
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES_LEAF		2155
 /*!
  * cache_walk: Maximum difference between current eviction generation
  * when the page was last considered, only reported if cache_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_GEN_MAX_GAP		2155
+#define	WT_STAT_DSRC_CACHE_STATE_GEN_MAX_GAP		2156
 /*!
  * cache_walk: Maximum page size seen, only reported if cache_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_MAX_PAGESIZE		2156
+#define	WT_STAT_DSRC_CACHE_STATE_MAX_PAGESIZE		2157
 /*!
  * cache_walk: Minimum on-disk page image size seen, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_MIN_WRITTEN_SIZE	2157
+#define	WT_STAT_DSRC_CACHE_STATE_MIN_WRITTEN_SIZE	2158
 /*!
  * cache_walk: Number of pages never visited by eviction server, only
  * reported if cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_UNVISITED_COUNT	2158
+#define	WT_STAT_DSRC_CACHE_STATE_UNVISITED_COUNT	2159
 /*!
  * cache_walk: On-disk page image sizes smaller than a single allocation
  * unit, only reported if cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_SMALLER_ALLOC_SIZE	2159
+#define	WT_STAT_DSRC_CACHE_STATE_SMALLER_ALLOC_SIZE	2160
 /*!
  * cache_walk: Pages created in memory and never written, only reported
  * if cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_MEMORY			2160
+#define	WT_STAT_DSRC_CACHE_STATE_MEMORY			2161
 /*!
  * cache_walk: Pages currently queued for eviction, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_QUEUED			2161
+#define	WT_STAT_DSRC_CACHE_STATE_QUEUED			2162
 /*!
  * cache_walk: Pages that could not be queued for eviction, only reported
  * if cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_NOT_QUEUEABLE		2162
+#define	WT_STAT_DSRC_CACHE_STATE_NOT_QUEUEABLE		2163
 /*!
  * cache_walk: Refs skipped during cache traversal, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_REFS_SKIPPED		2163
+#define	WT_STAT_DSRC_CACHE_STATE_REFS_SKIPPED		2164
 /*!
  * cache_walk: Size of the root page, only reported if cache_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_ROOT_SIZE		2164
+#define	WT_STAT_DSRC_CACHE_STATE_ROOT_SIZE		2165
 /*!
  * cache_walk: Total number of pages currently in cache, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES			2165
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES			2166
 /*! checkpoint: checkpoint has acquired a snapshot for its transaction */
-#define	WT_STAT_DSRC_CHECKPOINT_SNAPSHOT_ACQUIRED	2166
+#define	WT_STAT_DSRC_CHECKPOINT_SNAPSHOT_ACQUIRED	2167
 /*! checkpoint: pages added for eviction during checkpoint cleanup */
-#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_EVICT	2167
+#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_EVICT	2168
 /*!
  * checkpoint: pages dirtied due to obsolete time window by checkpoint
  * cleanup
  */
-#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	2168
+#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	2169
 /*!
  * checkpoint: pages read into cache during checkpoint cleanup
  * (reclaim_space)
  */
-#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	2169
+#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	2170
 /*!
  * checkpoint: pages read into cache during checkpoint cleanup due to
  * obsolete time window
  */
-#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	2170
+#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	2171
 /*! checkpoint: pages removed during checkpoint cleanup */
-#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_REMOVED	2171
+#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_REMOVED	2172
 /*! checkpoint: pages skipped during checkpoint cleanup tree walk */
-#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	2172
+#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	2173
 /*! checkpoint: pages visited during checkpoint cleanup */
-#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_VISITED	2173
+#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_VISITED	2174
 /*! checkpoint: transaction checkpoints due to obsolete pages */
-#define	WT_STAT_DSRC_CHECKPOINT_OBSOLETE_APPLIED	2174
+#define	WT_STAT_DSRC_CHECKPOINT_OBSOLETE_APPLIED	2175
 /*!
  * compression: compressed page maximum internal page size prior to
  * compression
  */
-#define	WT_STAT_DSRC_COMPRESS_PRECOMP_INTL_MAX_PAGE_SIZE	2175
+#define	WT_STAT_DSRC_COMPRESS_PRECOMP_INTL_MAX_PAGE_SIZE	2176
 /*!
  * compression: compressed page maximum leaf page size prior to
  * compression
  */
-#define	WT_STAT_DSRC_COMPRESS_PRECOMP_LEAF_MAX_PAGE_SIZE	2176
+#define	WT_STAT_DSRC_COMPRESS_PRECOMP_LEAF_MAX_PAGE_SIZE	2177
 /*! compression: page written to disk failed to compress */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_FAIL		2177
+#define	WT_STAT_DSRC_COMPRESS_WRITE_FAIL		2178
 /*! compression: page written to disk was too small to compress */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_TOO_SMALL		2178
+#define	WT_STAT_DSRC_COMPRESS_WRITE_TOO_SMALL		2179
 /*! compression: pages read from disk */
-#define	WT_STAT_DSRC_COMPRESS_READ			2179
+#define	WT_STAT_DSRC_COMPRESS_READ			2180
 /*!
  * compression: pages read from disk with compression ratio greater than
  * 64
  */
-#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_MAX	2180
+#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_MAX	2181
 /*!
  * compression: pages read from disk with compression ratio smaller than
  * 2
  */
-#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_2		2181
+#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_2		2182
 /*!
  * compression: pages read from disk with compression ratio smaller than
  * 4
  */
-#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_4		2182
+#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_4		2183
 /*!
  * compression: pages read from disk with compression ratio smaller than
  * 8
  */
-#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_8		2183
+#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_8		2184
 /*!
  * compression: pages read from disk with compression ratio smaller than
  * 16
  */
-#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_16	2184
+#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_16	2185
 /*!
  * compression: pages read from disk with compression ratio smaller than
  * 32
  */
-#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_32	2185
+#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_32	2186
 /*!
  * compression: pages read from disk with compression ratio smaller than
  * 64
  */
-#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_64	2186
+#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_64	2187
 /*! compression: pages written to disk */
-#define	WT_STAT_DSRC_COMPRESS_WRITE			2187
+#define	WT_STAT_DSRC_COMPRESS_WRITE			2188
 /*!
  * compression: pages written to disk with compression ratio greater than
  * 64
  */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_MAX	2188
+#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_MAX	2189
 /*!
  * compression: pages written to disk with compression ratio smaller than
  * 2
  */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_2	2189
+#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_2	2190
 /*!
  * compression: pages written to disk with compression ratio smaller than
  * 4
  */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_4	2190
+#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_4	2191
 /*!
  * compression: pages written to disk with compression ratio smaller than
  * 8
  */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_8	2191
+#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_8	2192
 /*!
  * compression: pages written to disk with compression ratio smaller than
  * 16
  */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_16	2192
+#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_16	2193
 /*!
  * compression: pages written to disk with compression ratio smaller than
  * 32
  */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_32	2193
+#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_32	2194
 /*!
  * compression: pages written to disk with compression ratio smaller than
  * 64
  */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_64	2194
+#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_64	2195
 /*! cursor: Total number of deleted pages skipped during tree walk */
-#define	WT_STAT_DSRC_CURSOR_TREE_WALK_DEL_PAGE_SKIP	2195
+#define	WT_STAT_DSRC_CURSOR_TREE_WALK_DEL_PAGE_SKIP	2196
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_TOTAL		2196
+#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_TOTAL		2197
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_TOTAL		2197
+#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_TOTAL		2198
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_DSRC_CURSOR_SKIP_HS_CUR_POSITION	2198
+#define	WT_STAT_DSRC_CURSOR_SKIP_HS_CUR_POSITION	2199
 /*!
  * cursor: Total number of in-memory deleted pages skipped during tree
  * walk
  */
-#define	WT_STAT_DSRC_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	2199
+#define	WT_STAT_DSRC_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	2200
 /*! cursor: Total number of on-disk deleted pages skipped during tree walk */
-#define	WT_STAT_DSRC_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	2200
+#define	WT_STAT_DSRC_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	2201
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	2201
+#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	2202
 /*!
  * cursor: Total number of times cursor fails to temporarily release
  * pinned page to encourage eviction of hot or large page
  */
-#define	WT_STAT_DSRC_CURSOR_REPOSITION_FAILED		2202
+#define	WT_STAT_DSRC_CURSOR_REPOSITION_FAILED		2203
 /*!
  * cursor: Total number of times cursor temporarily releases pinned page
  * to encourage eviction of hot or large page
  */
-#define	WT_STAT_DSRC_CURSOR_REPOSITION			2203
+#define	WT_STAT_DSRC_CURSOR_REPOSITION			2204
 /*! cursor: bulk loaded cursor insert calls */
-#define	WT_STAT_DSRC_CURSOR_INSERT_BULK			2204
+#define	WT_STAT_DSRC_CURSOR_INSERT_BULK			2205
 /*! cursor: cache cursors reuse count */
-#define	WT_STAT_DSRC_CURSOR_REOPEN			2205
+#define	WT_STAT_DSRC_CURSOR_REOPEN			2206
 /*! cursor: close calls that result in cache */
-#define	WT_STAT_DSRC_CURSOR_CACHE			2206
+#define	WT_STAT_DSRC_CURSOR_CACHE			2207
 /*! cursor: create calls */
-#define	WT_STAT_DSRC_CURSOR_CREATE			2207
+#define	WT_STAT_DSRC_CURSOR_CREATE			2208
 /*! cursor: cursor bound calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_BOUND_ERROR			2208
+#define	WT_STAT_DSRC_CURSOR_BOUND_ERROR			2209
 /*! cursor: cursor bounds cleared from reset */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_RESET		2209
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_RESET		2210
 /*! cursor: cursor bounds comparisons performed */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_COMPARISONS		2210
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_COMPARISONS		2211
 /*! cursor: cursor bounds next called on an unpositioned cursor */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_NEXT_UNPOSITIONED	2211
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_NEXT_UNPOSITIONED	2212
 /*! cursor: cursor bounds next early exit */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_NEXT_EARLY_EXIT	2212
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_NEXT_EARLY_EXIT	2213
 /*! cursor: cursor bounds prev called on an unpositioned cursor */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_PREV_UNPOSITIONED	2213
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_PREV_UNPOSITIONED	2214
 /*! cursor: cursor bounds prev early exit */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_PREV_EARLY_EXIT	2214
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_PREV_EARLY_EXIT	2215
 /*! cursor: cursor bounds search early exit */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	2215
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	2216
 /*! cursor: cursor bounds search near call repositioned cursor */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	2216
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	2217
 /*! cursor: cursor cache calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_CACHE_ERROR			2217
+#define	WT_STAT_DSRC_CURSOR_CACHE_ERROR			2218
 /*! cursor: cursor close calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_CLOSE_ERROR			2218
+#define	WT_STAT_DSRC_CURSOR_CLOSE_ERROR			2219
 /*! cursor: cursor compare calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_COMPARE_ERROR		2219
+#define	WT_STAT_DSRC_CURSOR_COMPARE_ERROR		2220
 /*! cursor: cursor equals calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_EQUALS_ERROR		2220
+#define	WT_STAT_DSRC_CURSOR_EQUALS_ERROR		2221
 /*! cursor: cursor get key calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_GET_KEY_ERROR		2221
+#define	WT_STAT_DSRC_CURSOR_GET_KEY_ERROR		2222
 /*! cursor: cursor get value calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_GET_VALUE_ERROR		2222
+#define	WT_STAT_DSRC_CURSOR_GET_VALUE_ERROR		2223
 /*! cursor: cursor insert calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_INSERT_ERROR		2223
+#define	WT_STAT_DSRC_CURSOR_INSERT_ERROR		2224
 /*! cursor: cursor insert check calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_INSERT_CHECK_ERROR		2224
+#define	WT_STAT_DSRC_CURSOR_INSERT_CHECK_ERROR		2225
 /*! cursor: cursor largest key calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_LARGEST_KEY_ERROR		2225
+#define	WT_STAT_DSRC_CURSOR_LARGEST_KEY_ERROR		2226
 /*! cursor: cursor modify calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_MODIFY_ERROR		2226
+#define	WT_STAT_DSRC_CURSOR_MODIFY_ERROR		2227
 /*! cursor: cursor next calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_NEXT_ERROR			2227
+#define	WT_STAT_DSRC_CURSOR_NEXT_ERROR			2228
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_DSRC_CURSOR_NEXT_HS_TOMBSTONE		2228
+#define	WT_STAT_DSRC_CURSOR_NEXT_HS_TOMBSTONE		2229
 /*!
  * cursor: cursor next calls that skip greater than 1 and fewer than 100
  * entries
  */
-#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_LT_100		2229
+#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_LT_100		2230
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_GE_100		2230
+#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_GE_100		2231
 /*! cursor: cursor next random calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_NEXT_RANDOM_ERROR		2231
+#define	WT_STAT_DSRC_CURSOR_NEXT_RANDOM_ERROR		2232
 /*! cursor: cursor prev calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_PREV_ERROR			2232
+#define	WT_STAT_DSRC_CURSOR_PREV_ERROR			2233
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_DSRC_CURSOR_PREV_HS_TOMBSTONE		2233
+#define	WT_STAT_DSRC_CURSOR_PREV_HS_TOMBSTONE		2234
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_GE_100		2234
+#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_GE_100		2235
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_LT_100		2235
+#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_LT_100		2236
 /*! cursor: cursor reconfigure calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_RECONFIGURE_ERROR		2236
+#define	WT_STAT_DSRC_CURSOR_RECONFIGURE_ERROR		2237
 /*! cursor: cursor remove calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_REMOVE_ERROR		2237
+#define	WT_STAT_DSRC_CURSOR_REMOVE_ERROR		2238
 /*! cursor: cursor reopen calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_REOPEN_ERROR		2238
+#define	WT_STAT_DSRC_CURSOR_REOPEN_ERROR		2239
 /*! cursor: cursor reserve calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_RESERVE_ERROR		2239
+#define	WT_STAT_DSRC_CURSOR_RESERVE_ERROR		2240
 /*! cursor: cursor reset calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_RESET_ERROR			2240
+#define	WT_STAT_DSRC_CURSOR_RESET_ERROR			2241
 /*! cursor: cursor search calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_ERROR		2241
+#define	WT_STAT_DSRC_CURSOR_SEARCH_ERROR		2242
 /*! cursor: cursor search near calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR_ERROR		2242
+#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR_ERROR		2243
 /*! cursor: cursor update calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_UPDATE_ERROR		2243
+#define	WT_STAT_DSRC_CURSOR_UPDATE_ERROR		2244
 /*! cursor: insert calls */
-#define	WT_STAT_DSRC_CURSOR_INSERT			2244
+#define	WT_STAT_DSRC_CURSOR_INSERT			2245
 /*! cursor: insert key and value bytes */
-#define	WT_STAT_DSRC_CURSOR_INSERT_BYTES		2245
+#define	WT_STAT_DSRC_CURSOR_INSERT_BYTES		2246
 /*! cursor: modify */
-#define	WT_STAT_DSRC_CURSOR_MODIFY			2246
+#define	WT_STAT_DSRC_CURSOR_MODIFY			2247
 /*! cursor: modify key and value bytes affected */
-#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES		2247
+#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES		2248
 /*! cursor: modify value bytes modified */
-#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES_TOUCH		2248
+#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES_TOUCH		2249
 /*! cursor: next calls */
-#define	WT_STAT_DSRC_CURSOR_NEXT			2249
+#define	WT_STAT_DSRC_CURSOR_NEXT			2250
 /*! cursor: open cursor count */
-#define	WT_STAT_DSRC_CURSOR_OPEN_COUNT			2250
+#define	WT_STAT_DSRC_CURSOR_OPEN_COUNT			2251
 /*! cursor: operation restarted */
-#define	WT_STAT_DSRC_CURSOR_RESTART			2251
+#define	WT_STAT_DSRC_CURSOR_RESTART			2252
 /*! cursor: prev calls */
-#define	WT_STAT_DSRC_CURSOR_PREV			2252
+#define	WT_STAT_DSRC_CURSOR_PREV			2253
 /*! cursor: remove calls */
-#define	WT_STAT_DSRC_CURSOR_REMOVE			2253
+#define	WT_STAT_DSRC_CURSOR_REMOVE			2254
 /*! cursor: remove key bytes removed */
-#define	WT_STAT_DSRC_CURSOR_REMOVE_BYTES		2254
+#define	WT_STAT_DSRC_CURSOR_REMOVE_BYTES		2255
 /*! cursor: reserve calls */
-#define	WT_STAT_DSRC_CURSOR_RESERVE			2255
+#define	WT_STAT_DSRC_CURSOR_RESERVE			2256
 /*! cursor: reset calls */
-#define	WT_STAT_DSRC_CURSOR_RESET			2256
+#define	WT_STAT_DSRC_CURSOR_RESET			2257
 /*! cursor: search calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH			2257
+#define	WT_STAT_DSRC_CURSOR_SEARCH			2258
 /*! cursor: search history store calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_HS			2258
+#define	WT_STAT_DSRC_CURSOR_SEARCH_HS			2259
 /*! cursor: search near calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR			2259
+#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR			2260
 /*! cursor: truncate calls */
-#define	WT_STAT_DSRC_CURSOR_TRUNCATE			2260
+#define	WT_STAT_DSRC_CURSOR_TRUNCATE			2261
 /*! cursor: update calls */
-#define	WT_STAT_DSRC_CURSOR_UPDATE			2261
+#define	WT_STAT_DSRC_CURSOR_UPDATE			2262
 /*! cursor: update key and value bytes */
-#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES		2262
+#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES		2263
 /*! cursor: update value size change */
-#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES_CHANGED	2263
+#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES_CHANGED	2264
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_DSRC_REC_VLCS_EMPTIED_PAGES		2264
+#define	WT_STAT_DSRC_REC_VLCS_EMPTIED_PAGES		2265
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TS		2265
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TS		2266
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TXN		2266
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TXN		2267
 /*! reconciliation: cursor next/prev calls during HS wrapup search_near */
-#define	WT_STAT_DSRC_REC_HS_WRAPUP_NEXT_PREV_CALLS	2267
+#define	WT_STAT_DSRC_REC_HS_WRAPUP_NEXT_PREV_CALLS	2268
 /*! reconciliation: dictionary matches */
-#define	WT_STAT_DSRC_REC_DICTIONARY			2268
+#define	WT_STAT_DSRC_REC_DICTIONARY			2269
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELETE_FAST		2269
+#define	WT_STAT_DSRC_REC_PAGE_DELETE_FAST		2270
 /*!
  * reconciliation: internal page key bytes discarded using suffix
  * compression
  */
-#define	WT_STAT_DSRC_REC_SUFFIX_COMPRESSION		2270
+#define	WT_STAT_DSRC_REC_SUFFIX_COMPRESSION		2271
 /*! reconciliation: internal page multi-block writes */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_INTERNAL		2271
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_INTERNAL		2272
 /*! reconciliation: leaf page key bytes discarded using prefix compression */
-#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION		2272
+#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION		2273
 /*! reconciliation: leaf page multi-block writes */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_LEAF		2273
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_LEAF		2274
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_LEAF		2274
+#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_LEAF		2275
 /*! reconciliation: maximum blocks required for a page */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_MAX			2275
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_MAX			2276
 /*! reconciliation: overflow values written */
-#define	WT_STAT_DSRC_REC_OVERFLOW_VALUE			2276
+#define	WT_STAT_DSRC_REC_OVERFLOW_VALUE			2277
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_DSRC_REC_PAGES				2277
+#define	WT_STAT_DSRC_REC_PAGES				2278
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_DSRC_REC_PAGES_EVICTION			2278
+#define	WT_STAT_DSRC_REC_PAGES_EVICTION			2279
 /*! reconciliation: pages deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELETE			2279
+#define	WT_STAT_DSRC_REC_PAGE_DELETE			2280
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	2280
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	2281
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	2281
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	2282
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TS	2282
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TS	2283
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TXN	2283
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TXN	2284
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_TXN		2284
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_TXN		2285
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_OLDEST_START_TS	2285
+#define	WT_STAT_DSRC_REC_TIME_AGGR_OLDEST_START_TS	2286
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_PREPARED		2286
+#define	WT_STAT_DSRC_REC_TIME_AGGR_PREPARED		2287
 /*! reconciliation: pages written including at least one prepare */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_PREPARED	2287
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_PREPARED	2288
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	2288
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	2289
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TS	2289
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TS	2290
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TXN	2290
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TXN	2291
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	2291
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	2292
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TS	2292
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TS	2293
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TXN	2293
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TXN	2294
 /*! reconciliation: records written including a prepare */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PREPARED		2294
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PREPARED		2295
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_START_TS	2295
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_START_TS	2296
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TS		2296
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TS		2297
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TXN		2297
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TXN		2298
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_STOP_TS	2298
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_STOP_TS	2299
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TS		2299
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TS		2300
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TXN		2300
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TXN		2301
 /*! session: object compaction */
-#define	WT_STAT_DSRC_SESSION_COMPACT			2301
+#define	WT_STAT_DSRC_SESSION_COMPACT			2302
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_COMMIT	2302
+#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_COMMIT	2303
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_DSRC_TXN_READ_OVERFLOW_REMOVE		2303
+#define	WT_STAT_DSRC_TXN_READ_OVERFLOW_REMOVE		2304
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_UPDATE	2304
+#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_UPDATE	2305
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	2305
+#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	2306
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2306
+#define	WT_STAT_DSRC_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2307
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_DSRC_TXN_RTS_INCONSISTENT_CKPT		2307
+#define	WT_STAT_DSRC_TXN_RTS_INCONSISTENT_CKPT		2308
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED		2308
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED		2309
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED		2309
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED		2310
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED_DRYRUN	2310
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED_DRYRUN	2311
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED_DRYRUN	2311
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED_DRYRUN	2312
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES	2312
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES	2313
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES		2313
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES		2314
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_DSRC_TXN_RTS_DELETE_RLE_SKIPPED		2314
+#define	WT_STAT_DSRC_TXN_RTS_DELETE_RLE_SKIPPED		2315
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_DSRC_TXN_RTS_STABLE_RLE_SKIPPED		2315
+#define	WT_STAT_DSRC_TXN_RTS_STABLE_RLE_SKIPPED		2316
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS		2316
+#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS		2317
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	2317
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	2318
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	2318
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	2319
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED			2319
+#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED			2320
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED_DRYRUN		2320
+#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED_DRYRUN		2321
 /*! transaction: update conflicts */
-#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2321
+#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2322
 
 /*!
  * @}

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -37,7 +37,7 @@ __wt_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage
     btree = S2BT(session);
     page = ref->page;
 
-    __wt_verbose(session, WT_VERB_RECONCILE, "%p reconcile %s (%s%s)", (void *)ref,
+    __wt_verbose_debug1(session, WT_VERB_RECONCILE, "%p reconcile %s (%s%s)", (void *)ref,
       __wt_page_type_string(page->type), LF_ISSET(WT_REC_EVICT) ? "evict" : "checkpoint",
       LF_ISSET(WT_REC_HS) ? ", history store" : "");
 
@@ -325,6 +325,9 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
          */
         return (ret);
     }
+
+    __wt_verbose_debug1(
+      session, WT_VERB_RECONCILE, "finished building disk image for %p", (void *)ref);
 
     /* Wrap up the page reconciliation. Panic on failure. */
     WT_ERR(__rec_write_wrapup(session, r, page));
@@ -2522,8 +2525,8 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WT_RECONCILE *r, WT_PAGE *page)
     __rec_page_modify_ta_safe_free(session, &mod->stop_ta);
     WT_TIME_AGGREGATE_INIT_MERGE(&stop_ta);
 
-    __wt_verbose(session, WT_VERB_RECONCILE, "%p reconciled into %" PRIu32 " pages", (void *)ref,
-      r->multi_next);
+    __wt_verbose_debug1(session, WT_VERB_RECONCILE, "%p reconciled into %" PRIu32 " pages",
+      (void *)ref, r->multi_next);
 
     switch (r->multi_next) {
     case 0: /* Page delete */
@@ -2694,6 +2697,9 @@ __rec_hs_wrapup(WT_SESSION_IMPL *session, WT_RECONCILE *r)
 
     btree = S2BT(session);
 
+    __wt_verbose_debug1(session, WT_VERB_RECONCILE,
+      "start moving updates to the history store for %p", (void *)r->ref);
+
     /* Set a flag in the session to track that we're in HS wrapup */
     F_SET(session, WT_SESSION_HS_WRAPUP);
     session->reconcile_stats.hs_wrapup_next_prev_calls = 0;
@@ -2722,6 +2728,9 @@ __rec_hs_wrapup(WT_SESSION_IMPL *session, WT_RECONCILE *r)
 
     WT_STAT_CONN_INCRV(
       session, rec_hs_wrapup_next_prev_calls, session->reconcile_stats.hs_wrapup_next_prev_calls);
+
+    __wt_verbose_debug1(session, WT_VERB_RECONCILE,
+      "finished moving updates to the history store for %p", (void *)r->ref);
 err:
     F_CLR(session, WT_SESSION_HS_WRAPUP);
     return (ret);

--- a/src/support/generation.c
+++ b/src/support/generation.c
@@ -110,14 +110,14 @@ __gen_drain_callback(
     struct timespec stop;
     WT_CONNECTION_IMPL *conn;
     WT_GENERATION_DRAIN_COOKIE *cookie;
-    uint64_t time_diff_ms, v;
-#ifdef HAVE_DIAGNOSTIC
     WT_VERBOSE_LEVEL verbose_orig_level[WT_VERB_NUM_CATEGORIES];
-    WT_CLEAR(verbose_orig_level);
-#endif
+    uint64_t time_diff_ms, v;
+    bool timeout_triggered;
 
+    WT_CLEAR(verbose_orig_level);
     cookie = (WT_GENERATION_DRAIN_COOKIE *)cookiep;
     conn = S2C(session);
+    timeout_triggered = false;
 
     for (;;) {
         /* Ensure we only read the value once. */
@@ -130,25 +130,22 @@ __gen_drain_callback(
          * The thread's generation may be 0 (that is, not set).
          */
         if (v == 0 || v >= cookie->base.target_generation) {
-#ifdef HAVE_DIAGNOSTIC
             /*
-             * We turn on additional logging just before generation drain times out, but it's
-             * possible that we get unblocked after increasing the traces but before hitting the
-             * timeout. If this occurs set verbose levels back to their original values so we can
-             * continue normal operation.
+             * We turn on additional logging just before generation drain times out, restore the
+             * original verbose level after we have been unblocked.
              */
-            if (cookie->verbose_timeout_flags == true) {
+            if (cookie->verbose_timeout_flags) {
                 if (cookie->base.which == WT_GEN_EVICT) {
                     WT_VERBOSE_RESTORE(session, verbose_orig_level, WT_VERB_EVICT);
                     WT_VERBOSE_RESTORE(session, verbose_orig_level, WT_VERB_EVICTSERVER);
                     WT_VERBOSE_RESTORE(session, verbose_orig_level, WT_VERB_EVICT_STUCK);
+                    WT_VERBOSE_RESTORE(session, verbose_orig_level, WT_VERB_RECONCILE);
                 } else if (cookie->base.which == WT_GEN_CHECKPOINT) {
                     WT_VERBOSE_RESTORE(session, verbose_orig_level, WT_VERB_CHECKPOINT);
                     WT_VERBOSE_RESTORE(session, verbose_orig_level, WT_VERB_CHECKPOINT_CLEANUP);
                     WT_VERBOSE_RESTORE(session, verbose_orig_level, WT_VERB_CHECKPOINT_PROGRESS);
                 }
             }
-#endif
             break;
         }
         /* If we're waiting on ourselves, we're deadlocked. */
@@ -189,8 +186,7 @@ __gen_drain_callback(
             if (conn->gen_drain_timeout_ms == 0)
                 continue;
 
-#ifdef HAVE_DIAGNOSTIC
-            /* In diagnostic mode, enable extra logs 20ms before reaching the timeout. */
+            /* Enable extra logs 20ms before reaching the timeout. */
             if (!cookie->verbose_timeout_flags &&
               (conn->gen_drain_timeout_ms < 20 ||
                 time_diff_ms > (conn->gen_drain_timeout_ms - 20))) {
@@ -201,6 +197,8 @@ __gen_drain_callback(
                       session, verbose_orig_level, WT_VERB_EVICTSERVER, WT_VERBOSE_DEBUG_1);
                     WT_VERBOSE_SET_AND_SAVE(
                       session, verbose_orig_level, WT_VERB_EVICT_STUCK, WT_VERBOSE_DEBUG_1);
+                    WT_VERBOSE_SET_AND_SAVE(
+                      session, verbose_orig_level, WT_VERB_RECONCILE, WT_VERBOSE_DEBUG_1);
                 } else if (cookie->base.which == WT_GEN_CHECKPOINT) {
                     WT_VERBOSE_SET_AND_SAVE(
                       session, verbose_orig_level, WT_VERB_CHECKPOINT, WT_VERBOSE_DEBUG_1);
@@ -210,13 +208,16 @@ __gen_drain_callback(
                       session, verbose_orig_level, WT_VERB_CHECKPOINT_PROGRESS, WT_VERBOSE_DEBUG_1);
                 }
                 cookie->verbose_timeout_flags = true;
-                /* Now we have enabled more logs, spin another time to get some information. */
+                /* Now we have enabled more logs, continue waiting to get more information. */
                 continue;
             }
-#endif
-            if (time_diff_ms >= conn->gen_drain_timeout_ms) {
+
+            if (!timeout_triggered && time_diff_ms >= conn->gen_drain_timeout_ms) {
                 __wt_verbose_error(session, WT_VERB_GENERATION, "%s generation drain timed out",
                   __gen_name(cookie->base.which));
+#ifndef HAVE_DIAGNOSTIC
+                timeout_triggered = true;
+#endif
                 WT_ASSERT(session, false);
             }
         }

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -146,6 +146,7 @@ static const char *const __stats_dsrc_desc[] = {
   "cache: pages read into cache by checkpoint",
   "cache: pages requested from the cache",
   "cache: pages requested from the cache due to pre-fetch",
+  "cache: pages requested from the history store",
   "cache: pages seen by eviction walk",
   "cache: pages written from cache",
   "cache: pages written requiring in-memory restoration",
@@ -517,6 +518,7 @@ __wt_stat_dsrc_clear_single(WT_DSRC_STATS *stats)
     stats->cache_read_checkpoint = 0;
     stats->cache_pages_requested = 0;
     stats->cache_pages_prefetch = 0;
+    stats->cache_pages_requested_hs = 0;
     stats->cache_eviction_pages_seen = 0;
     stats->cache_write = 0;
     stats->cache_write_restore = 0;
@@ -877,6 +879,7 @@ __wt_stat_dsrc_aggregate_single(WT_DSRC_STATS *from, WT_DSRC_STATS *to)
     to->cache_read_checkpoint += from->cache_read_checkpoint;
     to->cache_pages_requested += from->cache_pages_requested;
     to->cache_pages_prefetch += from->cache_pages_prefetch;
+    to->cache_pages_requested_hs += from->cache_pages_requested_hs;
     to->cache_eviction_pages_seen += from->cache_eviction_pages_seen;
     to->cache_write += from->cache_write;
     to->cache_write_restore += from->cache_write_restore;
@@ -1250,6 +1253,7 @@ __wt_stat_dsrc_aggregate(WT_DSRC_STATS **from, WT_DSRC_STATS *to)
     to->cache_read_checkpoint += WT_STAT_READ(from, cache_read_checkpoint);
     to->cache_pages_requested += WT_STAT_READ(from, cache_pages_requested);
     to->cache_pages_prefetch += WT_STAT_READ(from, cache_pages_prefetch);
+    to->cache_pages_requested_hs += WT_STAT_READ(from, cache_pages_requested_hs);
     to->cache_eviction_pages_seen += WT_STAT_READ(from, cache_eviction_pages_seen);
     to->cache_write += WT_STAT_READ(from, cache_write);
     to->cache_write_restore += WT_STAT_READ(from, cache_write_restore);
@@ -1724,6 +1728,7 @@ static const char *const __stats_connection_desc[] = {
   "cache: pages removed from the ordinary queue to be queued for urgent eviction",
   "cache: pages requested from the cache",
   "cache: pages requested from the cache due to pre-fetch",
+  "cache: pages requested from the history store",
   "cache: pages seen by eviction walk",
   "cache: pages seen by eviction walk that are already queued",
   "cache: pages selected for eviction unable to be evicted",
@@ -2509,6 +2514,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->cache_eviction_clear_ordinary = 0;
     stats->cache_pages_requested = 0;
     stats->cache_pages_prefetch = 0;
+    stats->cache_pages_requested_hs = 0;
     stats->cache_eviction_pages_seen = 0;
     stats->cache_eviction_pages_already_queued = 0;
     stats->cache_eviction_fail = 0;
@@ -3323,6 +3329,7 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->cache_eviction_clear_ordinary += WT_STAT_READ(from, cache_eviction_clear_ordinary);
     to->cache_pages_requested += WT_STAT_READ(from, cache_pages_requested);
     to->cache_pages_prefetch += WT_STAT_READ(from, cache_pages_prefetch);
+    to->cache_pages_requested_hs += WT_STAT_READ(from, cache_pages_requested_hs);
     to->cache_eviction_pages_seen += WT_STAT_READ(from, cache_eviction_pages_seen);
     to->cache_eviction_pages_already_queued +=
       WT_STAT_READ(from, cache_eviction_pages_already_queued);

--- a/test/suite/rollback_to_stable_util.py
+++ b/test/suite/rollback_to_stable_util.py
@@ -68,7 +68,7 @@ class test_rollback_to_stable_base(wttest.WiredTigerTestCase):
     # run on the test output.
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.ignoreStdoutPattern('WT_VERB_RTS')
+        self.ignoreStdoutPattern('WT_VERB_RTS|WT_VERB_READ')
         self.addTearDownAction(verify_rts_logs)
 
     def retry_rollback(self, name, txn_session, code):


### PR DESCRIPTION
(cherry picked from commit 8aa4baf9e9d7a8398458c7ca253b7d959bfa374a)

Summarize the reason behind this change (this might be the problem you're solving, or the context around the request) and the solution you have chosen.`
