### PR TITLE
WT-16378 Allow test/checkpoint & test/model (disagg) to run under various variants

### DIFF
--- a/test/checkpoint/CMakeLists.txt
+++ b/test/checkpoint/CMakeLists.txt
@@ -50,14 +50,24 @@ define_test_variants(test_checkpoint
 # Define test variants for the disagg test
 define_test_variants(test_checkpoint
     VARIANTS
-        "disagg_6_row|-d leader -t r -T 6 -x"
+        "disagg_leader_6_row|-d leader -e -t r -T 6 -x"
+        "disagg_leader_6_row_long_running|-d leader -e -t r -W 3 -x -n 1000000 -k 1000000 -C cache_size=4000MB"
         # Prepare operations is not supported on Disagg yet.
-        #"disagg_6_row_prepare|-d leader -t r -T 6 -p -x"
-        "disagg_leader_row_stress_sweep_timestamps|-d leader -t r -W 3 -r 2 -s 1 -x -n 100000 -k 100000 -D"
-        "disagg_leader_row_sweep_timestamps|-d leader -t r -W 3 -r 2 -s 1 -x -n 100000 -k 100000"
+        #"disagg_6_row_prepare|-d leader -e -t r -T 6 -p -x"
+        "disagg_leader_row_stress_sweep|-d leader -e -t r -W 3 -r 2 -s 1 -x -n 100000 -k 100000 -D"
+        "disagg_leader_row_sweep|-d leader -e -t r -W 3 -r 2 -s 1 -x -n 100000 -k 100000"
+        "disagg_leader_row_failpoint_hs_delete_key_from_ts|-d leader -e -t r -W 3 -r 2 -s 2 -x -n 100000 -k 100000"
+        "disagg_leader_row_hs_checkpoint_timing_stress|-d leader -e -t r -W 3 -r 2 -s 3 -x -n 100000 -k 100000"
+        "disagg_leader_row_checkpoint_slow_timing_stress|-d leader -e -t r -W 3 -r 2 -s 5 -x -n 100000 -k 100000"
+        "disagg_leader_row_evict_reposition_timing_stress|-d leader -e -t r -W 3 -r 2 -s 6 -x -n 100000 -k 100000"
+        "disagg_leader_row_failpoint_eviction_split|-d leader -e -t r -W 3 -r 2 -s 7 -x -n 100000 -k 100000"
+        "disagg_leader_row_failpoint_rec_before_wrapup|-d leader -e -t r -W 3 -r 2 -s 8 -x -n 100000 -k 100000"
+
+        # FIXME-WT-16228: Re-evaluate whether setting large cache size is need after cache stuck issue is solved.
+        "disagg_leader_row_server_93028|-d leader -e -t r -W 50 -r 2 -s 1 -x -n 100000 -k 100000 -C cache_size=1500MB"
     LABELS
         check
-        disagg
+        disagg_leader
         test_checkpoint
 )
 
@@ -69,18 +79,6 @@ define_test_variants(test_checkpoint
         "row_server_93028_2|-t r -W 50 -r 2 -s 1 -n 100000 -k 100000 -C cache_size=250MB"
     LABELS
         check
-        test_checkpoint
-        long_running
-)
-
-# Define long running test variants for the disagg test
-define_test_variants(test_checkpoint
-    VARIANTS
-        # FIXME-WT-16228: Re-evaluate whether setting large cache size is need after cache stuck issue is solved.
-        "disagg_leader_row_server_93028|-d leader -t r -W 50 -r 2 -s 1 -x -n 100000 -k 100000 -C cache_size=1500MB"
-    LABELS
-        check
-        disagg
         test_checkpoint
         long_running
 )

--- a/test/checkpoint/CMakeLists.txt
+++ b/test/checkpoint/CMakeLists.txt
@@ -47,6 +47,18 @@ define_test_variants(test_checkpoint
         test_checkpoint
 )
 
+# Define long running test variants for the checkpoint test
+# See SERVER-93028
+define_test_variants(test_checkpoint
+    VARIANTS
+        "row_server_93028_1|-t r -W 50 -r 2 -s 1 -x -n 100000 -k 100000 -C cache_size=250MB"
+        "row_server_93028_2|-t r -W 50 -r 2 -s 1 -n 100000 -k 100000 -C cache_size=250MB"
+    LABELS
+        check
+        test_checkpoint
+        long_running
+)
+
 # Define test variants for the disagg test
 define_test_variants(test_checkpoint
     VARIANTS
@@ -66,19 +78,6 @@ define_test_variants(test_checkpoint
         # FIXME-WT-16228: Re-evaluate whether setting large cache size is need after cache stuck issue is solved.
         "disagg_leader_row_server_93028|-d leader -e -t r -W 50 -r 2 -s 1 -x -n 100000 -k 100000 -C cache_size=1500MB"
     LABELS
-        check
-        disagg_leader
+        check_disagg
         test_checkpoint
-)
-
-# Define long running test variants for the checkpoint test
-# See SERVER-93028
-define_test_variants(test_checkpoint
-    VARIANTS
-        "row_server_93028_1|-t r -W 50 -r 2 -s 1 -x -n 100000 -k 100000 -C cache_size=250MB"
-        "row_server_93028_2|-t r -W 50 -r 2 -s 1 -n 100000 -k 100000 -C cache_size=250MB"
-    LABELS
-        check
-        test_checkpoint
-        long_running
 )

--- a/test/checkpoint/CMakeLists.txt
+++ b/test/checkpoint/CMakeLists.txt
@@ -63,6 +63,7 @@ define_test_variants(test_checkpoint
 define_test_variants(test_checkpoint
     VARIANTS
         "disagg_leader_6_row|-d leader -e -t r -T 6 -x"
+        # FIXME-WT-16228: Re-evaluate whether setting large cache size is needed after PALI.
         "disagg_leader_6_row_long_running|-d leader -e -t r -W 3 -x -n 1000000 -k 1000000 -C cache_size=4000MB"
         # Prepare operations is not supported on Disagg yet.
         #"disagg_6_row_prepare|-d leader -e -t r -T 6 -p -x"
@@ -75,7 +76,7 @@ define_test_variants(test_checkpoint
         "disagg_leader_row_failpoint_eviction_split|-d leader -e -t r -W 3 -r 2 -s 7 -x -n 100000 -k 100000"
         "disagg_leader_row_failpoint_rec_before_wrapup|-d leader -e -t r -W 3 -r 2 -s 8 -x -n 100000 -k 100000"
 
-        # FIXME-WT-16228: Re-evaluate whether setting large cache size is need after cache stuck issue is solved.
+        # FIXME-WT-16228: Re-evaluate whether setting large cache size is needed after PALI.
         "disagg_leader_row_server_93028|-d leader -e -t r -W 50 -r 2 -s 1 -x -n 100000 -k 100000 -C cache_size=1500MB"
     LABELS
         check_disagg

--- a/test/checkpoint/test_checkpoint.c
+++ b/test/checkpoint/test_checkpoint.c
@@ -241,8 +241,8 @@ main(int argc, char *argv[])
         return (EXIT_FAILURE);
     }
     if (g.precise_checkpoint && !g.use_timestamps) {
-        fprintf(stderr, "precise checkpoint (-e) is only valid if specified along with -x.\n");
-        return (EXIT_FAILURE);
+        WARN("%s", "Timestamps automatically enabled for precise checkpoint (-e).");
+        g.use_timestamps = true;
     }
 
     /*
@@ -259,14 +259,13 @@ main(int argc, char *argv[])
             return (usage());
 
         if (!g.use_timestamps) {
-            fprintf(stderr, "disaggregated storage feature requires usage of timestamps (-x/-X)");
-            return (EXIT_FAILURE);
+            WARN("%s", "Timestamps automatically enabled for disaggregated storage (-x/-X).");
+            g.use_timestamps = true;
         }
 
         if (!g.precise_checkpoint) {
-            fprintf(
-              stderr, "disaggregated storage feature requires usage of precise checkpoint (-e)");
-            return (EXIT_FAILURE);
+            WARN("%s", "Precise checkpoint automatically enabled for disaggregated storage (-e).");
+            g.precise_checkpoint = true;
         }
 
         if (ttype != ROW) {

--- a/test/checkpoint/test_checkpoint.c
+++ b/test/checkpoint/test_checkpoint.c
@@ -262,6 +262,13 @@ main(int argc, char *argv[])
             fprintf(stderr, "disaggregated storage feature requires usage of timestamps (-x/-X)");
             return (EXIT_FAILURE);
         }
+
+        if (!g.precise_checkpoint) {
+            fprintf(
+              stderr, "disaggregated storage feature requires usage of precise checkpoint (-e)");
+            return (EXIT_FAILURE);
+        }
+
         if (ttype != ROW) {
             fprintf(
               stderr, "disaggregated storage feature only supports row store table types (-r)");

--- a/test/checkpoint/test_checkpoint.h
+++ b/test/checkpoint/test_checkpoint.h
@@ -119,6 +119,8 @@ extern GLOBAL g;
 
 #define log_print_err(m, e, fatal) log_print_err_worker(__func__, __LINE__, m, e, fatal)
 
+#define WARN(fmt, ...) fprintf(stderr, "%s: WARNING: " fmt "\n", progname, __VA_ARGS__)
+
 void end_threads(void);
 int disagg_switch_roles(void);
 int log_print_err_worker(const char *, int, const char *, int, int);

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -477,6 +477,7 @@ functions:
       content_type: text/plain
       remote_file: wiredtiger/${build_variant}/${revision}/artifacts/${task_name}_${build_id}/
       preserve_path: true
+
   "run data validation stress test checkpoint":
     - *fetch_artifacts
     - command: shell.exec
@@ -487,13 +488,8 @@ functions:
           set -o errexit
           set -o verbose
           ${PREPARE_TEST_ENV}
+          ../../../tools/run_parallel.sh 'nice ./recovery-test.sh "${data_validation_stress_test_args} ${run_test_checkpoint_args}" WT_TEST.$t test_checkpoint' ${validation_stress_num_runs|120}
 
-          # Check if we running in disagg mode.
-          disagg_args=""
-          if [[ "${disagg_run|false}" == "true" ]]; then
-              disagg_args="-d leader -t row"
-          fi
-          ../../../tools/run_parallel.sh "nice ./recovery-test.sh \"${data_validation_stress_test_args} ${run_test_checkpoint_args} $disagg_args\" WT_TEST.\$t test_checkpoint" ${validation_stress_num_runs|120}
   "run tiered storage test":
     - command: shell.exec
       params:
@@ -670,22 +666,7 @@ functions:
         ${PREPARE_TEST_ENV}
         . test/evergreen/find_cmake.sh
         cd cmake_build/${directory}
-
-        # Determine if we want to exclude or include disagg labels.
-        disagg_filter=""
-        if [[ "${disagg_run|false}" == "true" ]]; then
-          disagg_filter='-L'  # Include labels
-        else
-          disagg_filter='-LE'  # Exclude labels
-        fi
-        # Create new disagg label filter or append to the existing one.
-        ctest_args='${ctest_extra_args}'
-        if $(echo "$ctest_args" | grep -q -w -- "$disagg_filter"); then
-          ctest_args=$(echo "$ctest_args" | sed -E "s/$disagg_filter \"([^\"]*)\"/$disagg_filter \"\1|disagg\"/")
-        else
-          ctest_args+=" $disagg_filter \"disagg\""
-        fi
-        eval $CTEST $ctest_args --output-on-failure 2>&1
+        $CTEST ${ctest_extra_args} --output-on-failure 2>&1
 
   "make check all":
     command: shell.exec
@@ -699,15 +680,7 @@ functions:
         . test/evergreen/find_cmake.sh
         cd cmake_build
         echo "Using number of parallel processes '-j ${num_jobs}' for 'make check all'"
-        # Create new disagg label filter or append to the existing one.
-        ctest_args='${ctest_extra_args}'
-        disagg_filter='-LE'  # Exclude labels
-        if $(echo "$ctest_args" | grep -q -w -- $disagg_filter); then
-          ctest_args=$(echo "$ctest_args" | sed -E "s/$disagg_filter \"([^\"]*)\"/$disagg_filter \"\1|disagg\"/")
-        else
-          ctest_args+=" $disagg_filter \"disagg\""
-        fi
-        eval $CTEST -L "^check$" $ctest_args -j ${num_jobs} --output-on-failure  2>&1
+        $CTEST -L "^check$" -j ${num_jobs} --output-on-failure ${ctest_extra_args|} 2>&1
 
   # The following cppsuite tasks define a greater overall task.
   "cppsuite test run": &cppsuite_test_run
@@ -1228,13 +1201,7 @@ functions:
         set -o errexit
         set -o verbose
         ${PREPARE_TEST_ENV}
-        # Check if we running in disagg mode.
-        disagg_args=""
-        if [[ "${disagg_run|false}" == "true" ]]; then
-            # FIXME-WT-16228: Re-evaluate whether setting large cache size is need after cache stuck issue is solved.
-            disagg_args="-d leader -t row -x -C cache_size=1000MB"
-        fi
-        ./test_checkpoint ${checkpoint_args} $disagg_args  2>&1
+        ./test_checkpoint ${checkpoint_args} 2>&1
 
   "checkpoint test predictable":
     command: shell.exec
@@ -1246,12 +1213,7 @@ functions:
         set -o errexit
         set -o verbose
         ${PREPARE_TEST_ENV}
-        disagg_args=""
-        if [[ "${disagg_run|false}" == "true" ]]; then
-            # FIXME-WT-16228: Re-evaluate whether setting large cache size is need after cache stuck issue is solved.
-            disagg_args="-d leader -t row -x -C cache_size=1000MB"
-        fi
-        ../../../test/evergreen/checkpoint_test_predictable.sh ${times} "${checkpoint_args} $disagg_args"
+        ../../../test/evergreen/checkpoint_test_predictable.sh ${times} ${checkpoint_args}
 
   "checkpoint stress test":
     command: shell.exec
@@ -1891,6 +1853,16 @@ tasks:
       - func: "make check directory"
         vars:
           ctest_extra_args: -LE "long_running" ${ctest_extra_args}
+          directory: test/checkpoint
+
+  - name: checkpoint-test-disagg-leader
+    tags: ["stress-test-disagg"]
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+      - func: "make check directory"
+        vars:
+          ctest_extra_args: -L "disagg_leader"
           directory: test/checkpoint
 
   - name: checkpoint-test-long-running
@@ -4072,14 +4044,6 @@ tasks:
             set -o verbose
             ${PREPARE_TEST_ENV}
             ../tools/tsan_playground/collect_warnings.sh
-
-  - name: data-validation-disagg-stress-test-checkpoint
-    depends_on:
-    - name: compile
-    commands:
-      - func: "run data validation stress test checkpoint"
-        vars:
-          run_test_checkpoint_args: -x -C cache_size=100MB
 
   - name: data-validation-stress-test-checkpoint
     tags: ["data-validation-stress-test"]
@@ -7543,12 +7507,6 @@ buildvariants:
   tasks:
     - name: compile
     - name: ".stress-test-disagg-fail"
-    - name: data-validation-disagg-stress-test-checkpoint
-      batchtime: 10080 # once every week
-    - name: checkpoint-test-long-running
-    - name: checkpoint-test
-    - name: checkpoint-filetypes-predictable-test
-    - name: checkpoint-filetypes-test
     - name: model-test-long
     - name: model-test-long-random-config
 
@@ -7570,20 +7528,3 @@ buildvariants:
   tasks:
     - name: compile
     - name: ".stress-test-disagg-san-fail"
-    - name: checkpoint-test
-
-- name: amazon2023-disagg-ubsan-stress
-  display_name: "[Failure Expected] (ARMV9) Amazon 2023 UBSAN Disagg Stress tests"
-  batchtime: 4320 # once every three days
-  run_on:
-  - amazon2023-arm64-latest-large-m8g
-  expansions:
-    CMAKE_TOOLCHAIN_FILE: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/clang.cmake
-    CMAKE_BUILD_TYPE: -DCMAKE_BUILD_TYPE=UBSan
-    CC_OPTIMIZE_LEVEL: -DCC_OPTIMIZE_LEVEL=-O0
-    ENABLE_TCMALLOC: 0
-    num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
-    disagg_run: true
-  tasks:
-    - name: compile
-    - name: checkpoint-test

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1226,6 +1226,17 @@ functions:
         ${PREPARE_TEST_ENV}
         ../../../test/evergreen/checkpoint_stress_test.sh ${tiered|0} ${times|1} ${no_of_procs|1} "${wt_config|cache_size=100M}" "${timestamp_config|}"
 
+  "model test":
+    command: shell.exec
+    params:
+      working_dir: "wiredtiger/cmake_build/test/model/tools"
+      shell: bash
+      script: |
+        set -o errexit
+        set -o verbose
+        ${PREPARE_TEST_ENV}
+        ./model_test ${model_test_args}
+
   "compatibility test":
     - command: shell.exec
       params:
@@ -4417,44 +4428,36 @@ tasks:
     commands:
       - func: "get project"
       - func: "compile wiredtiger"
-      - command: shell.exec
-        params:
-          working_dir: "wiredtiger/cmake_build/test/model/tools"
-          shell: bash
-          script: |
-            set -o errexit
-            set -o verbose
-            ${PREPARE_TEST_ENV}
-            # Check if we running in disagg mode.
-            disagg_args=""
-            if [[ "${disagg_run|false}" == "true" ]]; then
-                disagg_args="-D"
-            fi
-            echo "./model_test $disagg_args -l 2000-3000 -t 3600"
-            # Keep repeating the model test for 60 minutes
-            ./model_test $disagg_args -l 2000-3000 -t 3600
+      - func: "model test"
+        vars:
+          model_test_args: -l 2000-3000 -t 3600
+
+  - name: model-test-long-disagg
+    tags: ["model_checking"]
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+      - func: "model test"
+        vars:
+          model_test_args: -D -l 2000-3000 -t 3600
 
   - name: model-test-long-random-config
     tags: ["model_checking"]
     commands:
       - func: "get project"
       - func: "compile wiredtiger"
-      - command: shell.exec
-        params:
-          working_dir: "wiredtiger/cmake_build/test/model/tools"
-          shell: bash
-          script: |
-            set -o errexit
-            set -o verbose
-            ${PREPARE_TEST_ENV}
-            # Check if we running in disagg mode.
-            disagg_args=""
-            if [[ "${disagg_run|false}" == "true" ]]; then
-                disagg_args="-D"
-            fi
+      - func: "model test"
+        vars:
+          model_test_args: -l 100-200 -g -t 3600
 
-            # Keep repeating the model test for 60 minutes
-            ./model_test $disagg_args -l 100-200 -g -t 3600
+  - name: model-test-long-random-config-disagg
+    tags: ["model_checking"]
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+      - func: "model test"
+        vars:
+          model_test_args: -D -l 100-200 -g -t 3600
 
   - name: model-test-long-with-coverage
     tags: ["model_checking"]
@@ -6437,6 +6440,10 @@ buildvariants:
       batchtime: 1440 # once a day
     - name: model-test-long-random-config
       batchtime: 1440 # once a day
+    - name: model-test-long-disagg
+      batchtime: 1440 # once a day
+    - name: model-test-long-random-config-disagg
+      batchtime: 1440 # once a day
     - name: csuite-long-running
       batchtime: 1440 # once a day
     - name: live-restore-long
@@ -6469,6 +6476,10 @@ buildvariants:
     - name: model-test-long
       batchtime: 1440 # once a day
     - name: model-test-long-random-config
+      batchtime: 1440 # once a day
+    - name: model-test-long-disagg
+      batchtime: 1440 # once a day
+    - name: model-test-long-random-config-disagg
       batchtime: 1440 # once a day
     - name: live-restore-long
     - name: ".stress-test-asan"
@@ -6888,6 +6899,10 @@ buildvariants:
     - name: model-test-long-random-config
       batchtime: 1440 # once a day
     - name: model-unit-test
+    - name: model-test-long-disagg
+      batchtime: 1440 # once a day
+    - name: model-test-long-random-config-disagg
+      batchtime: 1440 # once a day
     - name: s3-tiered-storage-extensions-test
     - name: spinlock-gcc-test
     - name: spinlock-pthread-adaptive-test
@@ -7293,6 +7308,10 @@ buildvariants:
     - name: model-test-long-random-config
       batchtime: 1440 # once a day
     - name: model-unit-test
+    - name: model-test-long-disagg
+      batchtime: 1440 # once a day
+    - name: model-test-long-random-config-disagg
+      batchtime: 1440 # once a day
     - name: s3-tiered-storage-extensions-test
     - name: spinlock-gcc-test
     - name: spinlock-pthread-adaptive-test
@@ -7368,6 +7387,10 @@ buildvariants:
     - name: model-test-long
       batchtime: 1440 # once a day
     - name: model-test-long-random-config
+      batchtime: 1440 # once a day
+    - name: model-test-long-disagg
+      batchtime: 1440 # once a day
+    - name: model-test-long-random-config-disagg
       batchtime: 1440 # once a day
     - name: live-restore-long
     - name: ".stress-test-asan"
@@ -7507,8 +7530,6 @@ buildvariants:
   tasks:
     - name: compile
     - name: ".stress-test-disagg-fail"
-    - name: model-test-long
-    - name: model-test-long-random-config
 
 - name: amazon2023-disagg-asan-stress
   display_name: "[Failure Expected] (ARMV9) Amazon 2023 ASAN Disagg Stress tests"

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1863,7 +1863,7 @@ tasks:
       - func: "compile wiredtiger"
       - func: "make check directory"
         vars:
-          ctest_extra_args: -LE "long_running" ${ctest_extra_args}
+          ctest_extra_args: -LE "long_running|check_disagg" ${ctest_extra_args}
           directory: test/checkpoint
 
   - name: checkpoint-test-disagg-leader
@@ -1873,7 +1873,7 @@ tasks:
       - func: "compile wiredtiger"
       - func: "make check directory"
         vars:
-          ctest_extra_args: -L "disagg_leader"
+          ctest_extra_args: -L "check_disagg"
           directory: test/checkpoint
 
   - name: checkpoint-test-long-running
@@ -2240,7 +2240,7 @@ tasks:
       - func: "make check directory"
         vars:
           directory: test/csuite
-          ctest_extra_args: -LE "long_running|disagg" ${ctest_extra_args} -j ${num_jobs}
+          ctest_extra_args: -LE "long_running|check_disagg" ${ctest_extra_args} -j ${num_jobs}
 
   - name: csuite-timestamp-abort-test-s3
     commands:

--- a/test/format/format_config.c
+++ b/test/format/format_config.c
@@ -728,8 +728,7 @@ config_cache(void)
     cache *= 2;
 
     /*
-     * FIXME-WT-16228: Re-evaluate whether setting large cache size is need after cache stuck issue
-     * is solved.
+     * FIXME-WT-16228: Re-evaluate whether setting large cache size is needed after PALI.
      */
     if (GV(PRECISE_CHECKPOINT))
         cache *= 2;


### PR DESCRIPTION
test/checkpoint is currently run in evergreen across multiple tasks as follows 

1. data-validation-stress-test-checkpoint, fp-hs-insert-s1…s7
There are multiple evg tasks under the name “data-validation-stress-test-checkpoint-*”, but the name does not accurately reflect what these tests are doing. These tests primarily testing crash/recovery scenarios and additionally, they run test/checkpoint in 120 parallel executions. I have decided to simply add these tests as part of the CTESTS, given we are not yet testing crash/recovery and we cannot run 120 parallel testing runs due to PALite limitations. I have made a note of it tho, for next quarter.

2. checkpoint-test, checkpoint-test-long-running
I have replaced this with a single task checkpoint-test-disagg-leader that runs for ~25 min

3. Checkpoint file type – predictable
Focuses on predictable replay, not test/checkpoint, therefore not included.

4. Checkpoint file type tests
For testing various filetypes like VLCS, FLCS and row-store, Disagg only supports row-store, therefore not included 
