### PR TITLE
Revert "WT-18510 Update coding style to reflect current use of FIXME comments (#12599)"

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -52,10 +52,7 @@ existing example in the source code and copy it.
 
   * Describe intended functionality
   * Not reference variable names where possible
-  * Not reference closed ticket numbers in Jira
-  * Not reference pull request numbers
-  * Use a keyword of the form ``FIXME-WT-12345`` when describing a deficiency or opportunity
-    for improvement that has an open WiredTiger Jira ticket
+  * Not reference JIRA ticket numbers nor pull request numbers
   * Be fully formed sentences
   * Use C-style with ``/* ... */`` and not C++ style double-slash comments
   * Single-line comments should place the delimiters on the same line as the text

--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -759,8 +759,7 @@ connection_runtime_config = [
                 type='boolean', undoc=True),
             Config('legacy_page_visit_strategy', 'false', r'''
                 Use legacy page visit strategy for eviction. Using this option is highly discouraged
-                as it will re-introduce a bug where eviction can fail to find older cache
-                content.''',
+                as it will re-introduce the bug described in WT-9121.''',
                 type='boolean'),
             Config('app_eviction_min_cache_fill_ratio', '0', r'''
                 This setting establishes a minimum cache fill ratio that must be met before

--- a/src/block/block_open.c
+++ b/src/block/block_open.c
@@ -372,8 +372,8 @@ __desc_read(WT_SESSION_IMPL *session, uint32_t allocsize, WT_BLOCK *block)
      * hits this logic if the relevant data handle isn't already open). However this code gets run
      * in rollback to stable as part of recovery where we want to skip any corrupted data files
      * temporarily to allow MongoDB to initiate salvage. This is why we've been forced into this
-     * situation. We should address this and clarify what error codes we expect to return across the
-     * API boundary.
+     * situation. We should address this as part of WT-5832 and clarify what error codes we expect
+     * to be returning across the API boundary.
      */
     if (block->size < allocsize) {
         if (F_ISSET(session, WT_SESSION_ROLLBACK_TO_STABLE))

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -152,11 +152,11 @@ __cursor_page_pinned(WT_CURSOR_BTREE *cbt, bool search_operation)
         return (false);
 
     /*
-     * FIXME-WT-5147 No fast-path searches at read-committed isolation. Underlying transactional
-     * functions called by the fast and slow path search code handle transaction IDs differently,
-     * resulting in different search results at read-committed isolation. This makes no difference
-     * for the update functions, but in the case of a search, we will see different results based on
-     * the cursor's initial location.
+     * XXX No fast-path searches at read-committed isolation. Underlying transactional functions
+     * called by the fast and slow path search code handle transaction IDs differently, resulting in
+     * different search results at read-committed isolation. This makes no difference for the update
+     * functions, but in the case of a search, we will see different results based on the cursor's
+     * initial location. See WT-5134 for the details.
      */
     if (search_operation && session->txn->isolation == WT_ISO_READ_COMMITTED)
         return (false);

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -316,7 +316,7 @@ __evict_thread_run(WT_SESSION_IMPL *session, WT_THREAD *thread)
     /*
      * Cache a history store cursor to avoid deadlock: if an eviction thread marks a file busy and
      * then opens a different file (in this case, the HS file), it can deadlock with a thread
-     * waiting for the first file to drain from the eviction queue.
+     * waiting for the first file to drain from the eviction queue. See WT-5946 for details.
      */
     WT_ERR(__wt_curhs_cache(session));
     if (__wt_atomic_load_bool_relaxed(&conn->evict_server_running) &&
@@ -1207,9 +1207,9 @@ __wt_evict_file_exclusive_off(WT_SESSION_IMPL *session)
 /*
  * Atomically decrement the evict-disabled count, without acquiring the eviction walk-lock. We can't
  * acquire that lock here because there's a potential deadlock. When acquiring exclusive eviction
- * access, we acquire the eviction walk-lock and then the eviction's pass-intr lock. The eviction
- * server can hold the pass-intr lock and call into this function, which might deadlock with another
- * thread trying to get exclusive eviction access.
+ * access, we acquire the eviction walk-lock and then the eviction's pass-intr lock. The current
+ * eviction implementation can hold the pass-intr lock and call into this function (see WT-3303 for
+ * the details), which might deadlock with another thread trying to get exclusive eviction access.
  */
 #if defined(HAVE_DIAGNOSTIC)
     {

--- a/src/include/api.h
+++ b/src/include/api.h
@@ -143,9 +143,8 @@
         if ((s)->api_call_counter == 1 && !F_ISSET(s, WT_SESSION_INTERNAL))                \
             __wt_op_timer_stop(s);                                                         \
         /*                                                                                 \
-         * FIXME-WT-7247 Ideally we would not leave any history store cursors open when we \
-         * return from an api call. But we cannot do a stricter check due to the way we    \
-         * nest calls to the API macros.                                                   \
+         * We should not leave any history store cursor open when return from an api call. \
+         * However, we cannot do a stricter check before WT-7247 is resolved.              \
          */                                                                                \
         WT_ASSERT(s, (s)->api_call_counter > 1 || (s)->hs_cursor_counter <= 3);            \
         /*                                                                                 \

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -2285,24 +2285,24 @@ struct __wt_connection {
      * Only a part of application threads will participate in cache management when a cache
      * threshold reaches its trigger limit., a boolean flag; default \c false.}
      * @config{&nbsp;&nbsp;&nbsp;&nbsp;legacy_page_visit_strategy, Use legacy page visit strategy
-     * for eviction.  Using this option is highly discouraged as it will re-introduce a bug where
-     * eviction can fail to find older cache content., a boolean flag; default \c false.}
-     * @config{&nbsp;&nbsp;&nbsp;&nbsp;prefer_scrub_eviction, Change the eviction strategy to scrub
-     * eviction when the cache usage is under half way between the target limit to the trigger
-     * limit., a boolean flag; default \c false.}
+     * for eviction.  Using this option is highly discouraged as it will re-introduce the bug
+     * described in WT-9121., a boolean flag; default \c false.}
      * @config{&nbsp;&nbsp;&nbsp;&nbsp;
-     * skip_update_obsolete_check, Skip checking for obsolete updates whenever an update operation
-     * is performed., a boolean flag; default \c false.}
-     * @config{&nbsp;&nbsp;&nbsp;&nbsp;
-     * threads_max, maximum number of threads WiredTiger will start to help evict pages from cache.
-     * The number of threads started will vary depending on the current eviction load.  Each
-     * eviction worker thread uses a session from the configured session_max., an integer between \c
-     * 1 and \c 64; default \c 8.}
-     * @config{&nbsp;&nbsp;&nbsp;&nbsp;threads_min, minimum number of
-     * threads WiredTiger will start to help evict pages from cache.  The number of threads
-     * currently running will vary depending on the current eviction load., an integer between \c 1
-     * and \c 64; default \c 1.}
-     * @config{ ),,}
+     * prefer_scrub_eviction, Change the eviction strategy to scrub eviction when the cache usage is
+     * under half way between the target limit to the trigger limit., a boolean flag; default \c
+     * false.}
+     * @config{&nbsp;&nbsp;&nbsp;&nbsp;skip_update_obsolete_check, Skip checking for
+     * obsolete updates whenever an update operation is performed., a boolean flag; default \c
+     * false.}
+     * @config{&nbsp;&nbsp;&nbsp;&nbsp;threads_max, maximum number of threads WiredTiger
+     * will start to help evict pages from cache.  The number of threads started will vary depending
+     * on the current eviction load.  Each eviction worker thread uses a session from the configured
+     * session_max., an integer between \c 1 and \c 64; default \c 8.}
+     * @config{&nbsp;&nbsp;&nbsp;&nbsp;threads_min, minimum number of threads WiredTiger will start
+     * to help evict pages from cache.  The number of threads currently running will vary depending
+     * on the current eviction load., an integer between \c 1 and \c 64; default \c 1.}
+     * @config{
+     * ),,}
      * @config{eviction_checkpoint_target, perform eviction at the beginning of checkpoints to bring
      * the dirty content in cache to this level.  It is a percentage of the cache size if the value
      * is within the range of 0 to 100 or an absolute size when greater than 100. The value is not
@@ -3223,22 +3223,21 @@ struct __wt_connection {
  * incremental_app_eviction, Only a part of application threads will participate in cache management
  * when a cache threshold reaches its trigger limit., a boolean flag; default \c false.}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;legacy_page_visit_strategy, Use legacy page visit strategy for
- * eviction.  Using this option is highly discouraged as it will re-introduce a bug where eviction
- * can fail to find older cache content., a boolean flag; default \c false.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;prefer_scrub_eviction, Change the eviction strategy to scrub
- * eviction when the cache usage is under half way between the target limit to the trigger limit., a
- * boolean flag; default \c false.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;skip_update_obsolete_check, Skip
- * checking for obsolete updates whenever an update operation is performed., a boolean flag; default
- * \c false.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;threads_max, maximum number of threads WiredTiger will
- * start to help evict pages from cache.  The number of threads started will vary depending on the
- * current eviction load.  Each eviction worker thread uses a session from the configured
- * session_max., an integer between \c 1 and \c 64; default \c 8.}
+ * eviction.  Using this option is highly discouraged as it will re-introduce the bug described in
+ * WT-9121., a boolean flag; default \c false.}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;
- * threads_min, minimum number of threads WiredTiger will start to help evict pages from cache.  The
- * number of threads currently running will vary depending on the current eviction load., an integer
- * between \c 1 and \c 64; default \c 1.}
+ * prefer_scrub_eviction, Change the eviction strategy to scrub eviction when the cache usage is
+ * under half way between the target limit to the trigger limit., a boolean flag; default \c false.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;skip_update_obsolete_check, Skip checking for obsolete updates
+ * whenever an update operation is performed., a boolean flag; default \c false.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;threads_max, maximum number of threads WiredTiger will start to
+ * help evict pages from cache.  The number of threads started will vary depending on the current
+ * eviction load.  Each eviction worker thread uses a session from the configured session_max., an
+ * integer between \c 1 and \c 64; default \c 8.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;threads_min,
+ * minimum number of threads WiredTiger will start to help evict pages from cache.  The number of
+ * threads currently running will vary depending on the current eviction load., an integer between
+ * \c 1 and \c 64; default \c 1.}
  * @config{ ),,}
  * @config{eviction_checkpoint_target, perform eviction at the beginning of checkpoints to bring the
  * dirty content in cache to this level.  It is a percentage of the cache size if the value is

--- a/src/log/log.h
+++ b/src/log/log.h
@@ -110,7 +110,7 @@ struct __wt_log_record {
 /*
  * WiredTiger release version where log format version changed.
  *
- * FIXME-WT-8681 - According to WT_MIN_STARTUP_VERSION any WT version less then 3.2.0 will not
+ * FIXME WT-8681 - According to WT_MIN_STARTUP_VERSION any WT version less then 3.2.0 will not
  * start. Can we drop V2, V3 here?
  */
 #define WT_LOG_V2_VERSION ((WT_VERSION){3, 0, 0})

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -714,8 +714,8 @@ __meta_ckptlist_allocate_new_ckpt(
      *
      * Second, a single-tree checkpoint can occur while a global checkpoint is in progress. In that
      * case the global checkpoint will have an earlier time, but might get to the tree in question
-     * later. This should only be possible with the metadata, so we could rule it out by only
-     * checking non-metadata files.
+     * later. With WT-8695 this should only be possible with the metadata, so we could rule it out
+     * by only checking non-metadata files.
      *
      * Third, it appears to be possible for a close checkpoint to occur while a global checkpoint is
      * in progress, with the same consequences. There doesn't seem to be any obvious way to detect
@@ -1613,11 +1613,11 @@ __wt_meta_read_checkpoint_snapshot(WT_SESSION_IMPL *session, const char *ckpt_na
     sys_config = NULL;
 
     /*
-     * There was an issue with checkpoints produced by certain old versions having bad snapshot
-     * data. We should ignore those snapshots when we can identify them. This only applies to
-     * reading the last checkpoint during recovery, however, so it is done in our caller. (In other
-     * cases, for WiredTigerCheckpoint the checkpoint taken after recovery will have replaced any
-     * old and broken snapshot; and for named checkpoints, the broken versions didn't write out
+     * There's an issue with checkpoints produced by some old versions having bad snapshot data.
+     * (See WT-8395.) We should ignore those snapshots when we can identify them. This only applies
+     * to reading the last checkpoint during recovery, however, so it is done in our caller. (In
+     * other cases, for WiredTigerCheckpoint the checkpoint taken after recovery will have replaced
+     * any old and broken snapshot; and for named checkpoints, the broken versions didn't write out
      * snapshot information at all anyway.)
      */
 

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -423,7 +423,7 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
     rec = WT_CLOCKDIFF_MS(rec_finish, rec_start);
 
     /*
-     * Sanity check timings (WT_DAY is in seconds, and we have milliseconds). FIXME-WT-12192
+     * Sanity check timings (WT_DAY is in seconds, and we have milliseconds). FIXME WT-12192
      * rec_hs_wrapup and rec_img_build should also have an assertion here.
      */
     WT_ASSERT(session, rec < WT_DAY * WT_THOUSAND);

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1045,9 +1045,8 @@ err:
 /*
  * __txn_resolve_prepared_update_chain --
  *     Helper for resolving updates. Recursively visit the update chain and resolve the updates on
- *     the way back out, so older updates are resolved first. This ensures that a reconciliation
- *     racing with us will always see the newest update from the prepared transaction if any updates
- *     are still unresolved.
+ *     the way back out, so older updates are resolved first; this avoids a race with reconciliation
+ *     (see WT-6778).
  */
 static void
 __txn_resolve_prepared_update_chain(WT_SESSION_IMPL *session, WT_UPDATE *upd, bool commit)
@@ -2601,7 +2600,7 @@ __wt_txn_is_blocking(WT_SESSION_IMPL *session)
 
 #ifndef WT_STANDALONE_BUILD
     /*
-     * FIXME-WT-15823
+     * FIXME: SERVER-44870
      *
      * MongoDB can't (yet) handle rolling back read only transactions. For this reason, don't check
      * unless there's at least one update or we're configured to time out thread operations (a way

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -610,8 +610,8 @@ __recovery_set_checkpoint_snapshot(WT_SESSION_IMPL *session)
     /*
      * WiredTiger versions 10.0.1 onward have a valid checkpoint snapshot on-disk. There was a bug
      * in some versions of WiredTiger that are tagged with the 10.0.0 release, which saved the wrong
-     * checkpoint snapshot, so we ignore the snapshot when it was created with one of those
-     * versions. Versions of WiredTiger prior to 10.0.0 never saved a checkpoint snapshot.
+     * checkpoint snapshot (see WT-8395), so we ignore the snapshot when it was created with one of
+     * those versions. Versions of WiredTiger prior to 10.0.0 never saved a checkpoint snapshot.
      * Additionally the turtle file doesn't always exist (for example, backup doesn't include the
      * turtle file), so there isn't always a WiredTiger version available. If there is no version
      * available, assume that the snapshot is valid, otherwise restoring from a backup won't work.


### PR DESCRIPTION
This reverts commit 28706123203b725e83c65d4623111203161d5318.

The initial PR #12599 has an incorrect ticket number in the title. It requires reverting the commit and merging it back with the correct number to unblock the drop process.
