### PR TITLE
WT-16381 Refactor `__disagg_pick_up_checkpoint` function

### DIFF
--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -582,7 +582,7 @@ __disagg_load_checkpoint_meta(
                   session, "checkpoint timestamp", &checkpoint_timestamp, &cfg_value));
             timestamp_found = true;
         } else if (WT_CONFIG_LIT_MATCH("key_provider", cfg_key)) {
-            /* FIXME-WT-16055 Implement KEK read path mechanism */
+            /* FIXME-WT-16055 Implement key read path mechanism */
         }
     }
     WT_ERR_NOTFOUND_OK(ret, false);

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -8,15 +8,6 @@
 
 #include "wt_internal.h"
 
-static int __disagg_copy_shared_metadata_one(WT_SESSION_IMPL *session, const char *uri);
-static int __layered_drain_ingest_tables(WT_SESSION_IMPL *session);
-static void __layered_update_prune_timestamps_print_update_logs(WT_SESSION_IMPL *session,
-  WT_LAYERED_TABLE *layered_table, wt_timestamp_t prune_timestamp, int64_t ckpt_inuse);
-static int __layered_iterate_ingest_tables_for_gc_pruning(
-  WT_SESSION_IMPL *session, wt_timestamp_t checkpoint_timestamp);
-static int __layered_last_checkpoint_order(
-  WT_SESSION_IMPL *session, const char *shared_uri, int64_t *ckpt_order);
-
 /*
  * WT_DISAGG_CHECKPOINT_META --
  *     Checkpoint metadata structure for disaggregated storage.
@@ -27,6 +18,28 @@ typedef struct __wt_disagg_checkpoint_meta {
     bool has_metadata_checksum; /* Whether the metadata page checksum is present. */
     uint32_t metadata_checksum; /* The checksum of the metadata page. */
 } WT_DISAGG_CHECKPOINT_META;
+
+/* Function prototypes for disaggregated storage and layered tables. */
+
+static int __disagg_copy_shared_metadata_one(WT_SESSION_IMPL *session, const char *uri);
+static int __layered_drain_ingest_tables(WT_SESSION_IMPL *session);
+static void __layered_update_prune_timestamps_print_update_logs(WT_SESSION_IMPL *session,
+  WT_LAYERED_TABLE *layered_table, wt_timestamp_t prune_timestamp, int64_t ckpt_inuse);
+static int __layered_iterate_ingest_tables_for_gc_pruning(
+  WT_SESSION_IMPL *session, wt_timestamp_t checkpoint_timestamp);
+static int __layered_last_checkpoint_order(
+  WT_SESSION_IMPL *session, const char *shared_uri, int64_t *ckpt_order);
+static int __disagg_save_meta(WT_SESSION_IMPL *session, WT_SESSION_IMPL *internal_session,
+  WT_CURSOR *md_cursor, const char *metadata_value, char **metadata_value_cfgp,
+  size_t *metadata_value_cfg_lenp);
+static int __disagg_load_checkpoint_meta(WT_SESSION_IMPL *session, char *meta_buf,
+  char **metadata_valuep, uint64_t *checkpoint_timestampp);
+static int __disagg_process_checkpoint(WT_SESSION_IMPL *session,
+  const WT_DISAGG_CHECKPOINT_META *ckpt_meta, WT_SESSION_IMPL *internal_session,
+  WT_CURSOR *md_cursor, char **metadata_value_cfgp, size_t *metadata_value_cfg_lenp);
+static int __disagg_update_checkpoint_meta(WT_SESSION_IMPL *session,
+  const WT_DISAGG_CHECKPOINT_META *ckpt_meta, WT_SESSION_IMPL *internal_session,
+  WT_CONNECTION_IMPL *conn, char *root, uint64_t checkpoint_timestamp);
 
 /*
  * __layered_get_disagg_checkpoint --
@@ -442,11 +455,11 @@ __wt_disagg_put_checkpoint_meta(WT_SESSION_IMPL *session, const char *checkpoint
     WT_ERR(__wt_scr_alloc(session, 0, &buf));
     WT_ERR(
       __wt_buf_fmt(session, buf,
-        "%s\n"
-        "timestamp=%" PRIx64 "\n"
-        "%s\n",
+        "checkpoint=%s,\n"
+        "timestamp=%" PRIx64 ",\n"
+        "%s",
         checkpoint_root_copy, checkpoint_timestamp,
-        key_provider_buf != NULL ? (char *)key_provider_buf->data : ""));
+        key_provider_buf != NULL ? (const char *)key_provider_buf->data : ""));
 
     /* Compute the checksum for the metadata page. */
     checksum = __wt_checksum(buf->data, buf->size);
@@ -483,97 +496,22 @@ err:
 }
 
 /*
- * __disagg_construct_meta_config_array --
- *     Construct the metadata configuration array from the shared metadata table. Each configuration
- *     is separated by a newline (\n). Modify all newlines to null terminator and reference each
- *     separate configuration to result.
- */
-static void
-__disagg_construct_meta_config_array(char *meta_cfg, char **results)
-{
-    u_int i;
-    char *cur_config;
-
-    cur_config = meta_cfg;
-    for (i = 0; i < MAX_NUM_CONFIG; i++) {
-        results[i] = cur_config;
-
-        /* Each configuration is separated by a new line. */
-        cur_config = strchr(cur_config, '\n');
-        if (cur_config == NULL)
-            break;
-
-        /* Convert new line to null terminator. */
-        *cur_config = '\0';
-        cur_config++;
-    }
-}
-/*
- * __disagg_pick_up_checkpoint --
- *     Pick up a new checkpoint.
+ * __disagg_read_meta --
+ *     Fetch the checkpoint metadata page, validate it, and return a zero-terminated buffer copy.
  */
 static int
-__disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPOINT_META *ckpt_meta)
+__disagg_read_meta(
+  WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPOINT_META *ckpt_meta, char **bufp)
 {
-    WT_CONFIG_ITEM cval;
-    WT_CONNECTION_IMPL *conn;
-    WT_CURSOR *cursor, *md_cursor;
     WT_DECL_RET;
     WT_ITEM item;
-    WT_SESSION_IMPL *internal_session, *shared_metadata_session;
-    size_t len, metadata_value_cfg_len;
-    uint64_t checkpoint_timestamp, current_meta_lsn;
-    uint32_t checksum, existing_tables, new_ingest, new_tables;
-    char *buf, *cfg_ret, *cfg_meta_array[MAX_NUM_CONFIG], *root, *metadata_value_cfg,
-      *layered_ingest_uri;
-    char ts_string[WT_TS_INT_STRING_SIZE];
-    const char *cfg[3], *current_value, *metadata_key, *metadata_value;
-
-    conn = S2C(session);
+    size_t len;
+    uint32_t checksum;
+    char *buf;
 
     buf = NULL;
-    cursor = NULL;
-    internal_session = NULL;
-    md_cursor = NULL;
-    metadata_key = NULL;
-    metadata_value = NULL;
-    metadata_value_cfg = NULL;
-    layered_ingest_uri = NULL;
-    root = NULL;
-    shared_metadata_session = NULL;
-    cfg_ret = NULL;
     WT_CLEAR(item);
-    existing_tables = new_ingest = new_tables = 0;
-    memset(cfg_meta_array, 0, sizeof(cfg_meta_array));
-
-    WT_ASSERT_SPINLOCK_OWNED(session, &conn->checkpoint_lock);
-
-    /* We should not pick up a checkpoint with an earlier LSN. */
-    current_meta_lsn =
-      __wt_atomic_load_uint64_acquire(&conn->disaggregated_storage.last_checkpoint_meta_lsn);
-    if (ckpt_meta->metadata_lsn < current_meta_lsn)
-        WT_RET_MSG(session, EINVAL,
-          "Attempting to pick up an older checkpoint: current metadata LSN = %" PRIu64
-          ", new metadata LSN = %" PRIu64,
-          current_meta_lsn, ckpt_meta->metadata_lsn);
-    /*
-     * Warn if we are picking up the same checkpoint again. There's nothing else to do here, goto
-     * err for cleanup.
-     */
-    if (ckpt_meta->metadata_lsn == current_meta_lsn) {
-        __wt_verbose_level(session, WT_VERB_LAYERED, WT_VERBOSE_WARNING,
-          "Picking up the same checkpoint again: metadata LSN = %" PRIu64, ckpt_meta->metadata_lsn);
-        /* Keep previous ret value to avoid overlapping error message */
-        goto err;
-    }
-
-    /*
-     * Part 1: Get the metadata of the shared metadata table and insert it into our metadata table.
-     */
-
-    __wt_verbose_debug1(session, WT_VERB_DISAGGREGATED_STORAGE,
-      "Picking up disaggregated storage checkpoint: metadata_lsn=%" PRIu64,
-      ckpt_meta->metadata_lsn);
+    *bufp = NULL;
 
     /* Read the checkpoint metadata of the shared metadata table from the special metadata page. */
     WT_ERR_MSG_CHK(session,
@@ -592,44 +530,107 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPOINT
 
     /* Add the terminating zero byte to the end of the buffer. */
     len = item.size + 1;
-    WT_ERR(__wt_calloc_def(session, len, &buf)); /* This already zeroes out the buffer. */
+    WT_ERR(__wt_calloc_def(session, len, &buf));
     memcpy(buf, item.data, item.size);
 
-    __disagg_construct_meta_config_array(buf, cfg_meta_array);
-    WT_ERR(__wt_config_getones(session, cfg_meta_array[TIMESTAMP_CONFIG], "timestamp", &cval));
-    if (cval.len > 0 && cval.val == 0)
-        checkpoint_timestamp = WT_TS_NONE;
-    else
-        WT_ERR(
-          __wt_txn_parse_timestamp(session, "checkpoint timestamp", &checkpoint_timestamp, &cval));
+    *bufp = buf;
+    buf = NULL;
 
-    /* Save the metadata key-value pair. */
+err:
+    __wt_free(session, buf);
+    __wt_free(session, item.mem);
+    return (ret);
+}
+
+/*
+ * __disagg_load_checkpoint_meta --
+ *     Parse checkpoint metadata pulled from the shared metadata buffer.
+ */
+static int
+__disagg_load_checkpoint_meta(
+  WT_SESSION_IMPL *session, char *meta_buf, char **metadata_valuep, uint64_t *checkpoint_timestampp)
+{
+    WT_CONFIG meta_cfg;
+    WT_CONFIG_ITEM cfg_key, cfg_value;
+    WT_DECL_RET;
+    uint64_t checkpoint_timestamp;
+    char *metadata_value;
+    bool checkpoint_found, timestamp_found;
+
+    WT_CLEAR(meta_cfg);
+    metadata_value = NULL;
+    checkpoint_timestamp = WT_TS_NONE;
+    checkpoint_found = timestamp_found = false;
+
+    __wt_config_init(session, &meta_cfg, meta_buf);
+    while ((ret = __wt_config_next(&meta_cfg, &cfg_key, &cfg_value)) == 0) {
+        __wt_verbose_debug2(session, WT_VERB_DISAGGREGATED_STORAGE,
+          "Disaggregated checkpoint metadata item \"%.*s\"=\"%.*s\"", (int)cfg_key.len, cfg_key.str,
+          (int)cfg_value.len, cfg_value.str);
+        if (WT_CONFIG_LIT_MATCH("checkpoint", cfg_key)) {
+            if (checkpoint_found)
+                WT_ERR_MSG(
+                  session, EINVAL, "Duplicate checkpoint entry in disaggregated storage metadata");
+            WT_ERR(__wt_strndup(session, cfg_value.str, cfg_value.len, &metadata_value));
+            checkpoint_found = true;
+        } else if (WT_CONFIG_LIT_MATCH("timestamp", cfg_key)) {
+            if (cfg_value.len > 0 && cfg_value.val == 0)
+                checkpoint_timestamp = WT_TS_NONE;
+            else
+                WT_ERR(__wt_txn_parse_timestamp(
+                  session, "checkpoint timestamp", &checkpoint_timestamp, &cfg_value));
+            timestamp_found = true;
+        } else if (WT_CONFIG_LIT_MATCH("key_provider", cfg_key)) {
+            /* Logged above; no additional action required yet. */
+        }
+    }
+    WT_ERR_NOTFOUND_OK(ret, false);
+
+    if (!checkpoint_found)
+        WT_ERR_MSG(session, EINVAL, "Missing checkpoint entry in disaggregated storage metadata");
+    if (!timestamp_found)
+        WT_ERR_MSG(session, EINVAL, "Missing timestamp entry in disaggregated storage metadata");
+
+    *metadata_valuep = metadata_value;
+    *checkpoint_timestampp = checkpoint_timestamp;
+    metadata_value = NULL;
+
+err:
+    __wt_free(session, metadata_value);
+    return (ret);
+}
+
+/*
+ * __disagg_save_meta --
+ *     Update the local metadata entry with the supplied checkpoint configuration.
+ */
+static int
+__disagg_save_meta(WT_SESSION_IMPL *session, WT_SESSION_IMPL *internal_session,
+  WT_CURSOR *md_cursor, const char *metadata_value, char **metadata_value_cfgp,
+  size_t *metadata_value_cfg_lenp)
+{
+    WT_DECL_RET;
+    size_t len;
+    char *cfg_ret, *metadata_value_cfg;
+    const char *cfg[3], *current_value, *metadata_key;
+
+    cfg_ret = NULL;
     metadata_key = WT_DISAGG_METADATA_URI;
-    metadata_value = root = buf;
-
-    __wt_verbose_debug2(session, WT_VERB_DISAGGREGATED_STORAGE,
-      "Picking up disaggregated storage checkpoint: metadata_lsn=%" PRIu64 ", timestamp=%" PRIu64
-      " %s"
-      ", root=\"%s\"",
-      ckpt_meta->metadata_lsn, checkpoint_timestamp,
-      __wt_timestamp_to_string(checkpoint_timestamp, ts_string), root);
-
-    /* We need an internal session when modifying metadata. */
-    WT_ERR(__wt_open_internal_session(conn, "checkpoint-pick-up", false, 0, 0, &internal_session));
-
-    /* Open up a metadata cursor pointing at our table */
-    WT_ERR(__wt_metadata_cursor(internal_session, &md_cursor));
-    md_cursor->set_key(md_cursor, metadata_key);
-    WT_ERR(md_cursor->search(md_cursor));
+    metadata_value_cfg = *metadata_value_cfgp;
 
     /* Pull the value out. */
+    md_cursor->set_key(md_cursor, metadata_key);
+    WT_ERR(md_cursor->search(md_cursor));
     WT_ERR(md_cursor->get_value(md_cursor, &current_value));
-    len = strlen("checkpoint=") + strlen(metadata_value) + 1 /* for NUL */;
 
     /* Allocate/create a new config we're going to insert */
-    metadata_value_cfg_len = len;
-    WT_ERR(__wt_calloc_def(session, metadata_value_cfg_len, &metadata_value_cfg));
+    len = strlen("checkpoint=") + strlen(metadata_value) + 1 /* for NUL */;
+    WT_ERR(__wt_calloc_def(session, len, &metadata_value_cfg));
+    *metadata_value_cfg_lenp = len;
+    *metadata_value_cfgp = metadata_value_cfg;
+
     WT_ERR(__wt_snprintf(metadata_value_cfg, len, "checkpoint=%s", metadata_value));
+
     cfg[0] = current_value;
     cfg[1] = metadata_value_cfg;
     cfg[2] = NULL;
@@ -637,19 +638,44 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPOINT
 
     /* Put our new config in */
     WT_ERR(__wt_metadata_insert(internal_session, metadata_key, cfg_ret));
-    __wt_free(session, cfg_ret);
 
     __wt_verbose_debug2(session, WT_VERB_DISAGGREGATED_STORAGE,
       "Updated the local metadata for key \"%s\" to include the new checkpoint: \"%s\"",
       metadata_key, metadata_value);
 
-    /*
-     * Part 2: Get the metadata for other tables from the shared metadata table.
-     */
+err:
+    __wt_free(session, cfg_ret);
+    return (ret);
+}
+
+/*
+ * __disagg_process_checkpoint --
+ *     Process the metadata entries stored in the shared metadata table for a new checkpoint.
+ */
+static int
+__disagg_process_checkpoint(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPOINT_META *ckpt_meta,
+  WT_SESSION_IMPL *internal_session, WT_CURSOR *md_cursor, char **metadata_value_cfgp,
+  size_t *metadata_value_cfg_lenp)
+{
+    WT_CONFIG_ITEM cval;
+    WT_CURSOR *cursor;
+    WT_DECL_RET;
+    WT_SESSION_IMPL *shared_metadata_session;
+    size_t len, metadata_value_cfg_len;
+    uint32_t existing_tables, new_tables, new_ingest;
+    char *layered_ingest_uri, *cfg_ret, *metadata_value_cfg;
+    const char *cfg[3], *current_value, *metadata_key, *metadata_value;
+
+    cursor = NULL;
+    shared_metadata_session = NULL;
+    layered_ingest_uri = cfg_ret = NULL;
+    metadata_value_cfg = *metadata_value_cfgp;
+    metadata_value_cfg_len = *metadata_value_cfg_lenp;
+    existing_tables = new_tables = new_ingest = 0;
 
     /* We need a separate internal session to pick up the new checkpoint. */
     WT_ERR(__wt_open_internal_session(
-      conn, "checkpoint-pick-up-shared", false, 0, 0, &shared_metadata_session));
+      S2C(session), "checkpoint-pick-up-shared", false, 0, 0, &shared_metadata_session));
 
     /*
      * Throw away any references to the old disaggregated metadata table. This ensures that we are
@@ -711,6 +737,7 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPOINT
             WT_ERR_MSG_CHK(session, __wti_conn_dhandle_outdated(session, metadata_key),
               "Marking data handles outdated failed: \"%s\"", metadata_key);
             __wt_free(session, cfg_ret);
+            cfg_ret = NULL;
         } else if (ret == WT_NOTFOUND) {
             /* New table: Insert new metadata. */
             /* FIXME-WT-14730: verify that there is no btree ID conflict. */
@@ -733,6 +760,7 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPOINT
                         new_ingest++;
                     }
                     __wt_free(session, layered_ingest_uri);
+                    layered_ingest_uri = NULL;
                 }
                 new_tables++;
             }
@@ -755,9 +783,29 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPOINT
       " new ingest tables",
       existing_tables, new_tables, new_ingest);
 
-    /*
-     * Part 3: Do the bookkeeping.
-     */
+    *metadata_value_cfgp = metadata_value_cfg;
+    *metadata_value_cfg_lenp = metadata_value_cfg_len;
+
+err:
+    __wt_free(session, layered_ingest_uri);
+    __wt_free(session, cfg_ret);
+    if (cursor != NULL)
+        WT_TRET(cursor->close(cursor));
+    if (shared_metadata_session != NULL)
+        WT_TRET(__wt_session_close_internal(shared_metadata_session));
+    return (ret);
+}
+
+/*
+ * __disagg_update_checkpoint_meta --
+ *     Finalize checkpoint bookkeeping after processing shared metadata entries.
+ */
+static int
+__disagg_update_checkpoint_meta(WT_SESSION_IMPL *session,
+  const WT_DISAGG_CHECKPOINT_META *ckpt_meta, WT_SESSION_IMPL *internal_session,
+  WT_CONNECTION_IMPL *conn, char *root, uint64_t checkpoint_timestamp)
+{
+    WT_DECL_RET;
 
     /*
      * Update the checkpoint metadata LSN. This doesn't require further synchronization, because the
@@ -779,6 +827,98 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPOINT
       __layered_iterate_ingest_tables_for_gc_pruning(internal_session, checkpoint_timestamp),
       "Updating prune timestamp failed");
 
+err:
+    return (ret);
+}
+
+/*
+ * __disagg_pick_up_checkpoint --
+ *     Pick up a new checkpoint.
+ */
+static int
+__disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPOINT_META *ckpt_meta)
+{
+    WT_CONNECTION_IMPL *conn;
+    WT_CURSOR *md_cursor;
+    WT_DECL_RET;
+    WT_SESSION_IMPL *internal_session;
+    size_t metadata_value_cfg_len;
+    uint64_t checkpoint_timestamp, current_meta_lsn;
+    char *buf, *metadata_value, *metadata_value_cfg;
+    char ts_string[WT_TS_INT_STRING_SIZE];
+
+    conn = S2C(session);
+
+    buf = NULL;
+    internal_session = NULL;
+    md_cursor = NULL;
+    metadata_value = NULL;
+    metadata_value_cfg = NULL;
+    metadata_value_cfg_len = 0;
+    checkpoint_timestamp = WT_TS_NONE;
+
+    WT_ASSERT_SPINLOCK_OWNED(session, &conn->checkpoint_lock);
+
+    /* We should not pick up a checkpoint with an earlier LSN. */
+    current_meta_lsn =
+      __wt_atomic_load_uint64_acquire(&conn->disaggregated_storage.last_checkpoint_meta_lsn);
+    if (ckpt_meta->metadata_lsn < current_meta_lsn)
+        WT_RET_MSG(session, EINVAL,
+          "Attempting to pick up an older checkpoint: current metadata LSN = %" PRIu64
+          ", new metadata LSN = %" PRIu64,
+          current_meta_lsn, ckpt_meta->metadata_lsn);
+    /*
+     * Warn if we are picking up the same checkpoint again. There's nothing else to do here, goto
+     * err for cleanup.
+     */
+    if (ckpt_meta->metadata_lsn == current_meta_lsn) {
+        __wt_verbose_level(session, WT_VERB_LAYERED, WT_VERBOSE_WARNING,
+          "Picking up the same checkpoint again: metadata LSN = %" PRIu64, ckpt_meta->metadata_lsn);
+        /* Keep previous ret value to avoid overlapping error message */
+        goto err;
+    }
+
+    __wt_verbose_debug1(session, WT_VERB_DISAGGREGATED_STORAGE,
+      "Picking up disaggregated storage checkpoint: metadata_lsn=%" PRIu64,
+      ckpt_meta->metadata_lsn);
+
+    /*
+     * Part 1: Get the metadata of the shared metadata table and insert it into our metadata table.
+     */
+
+    WT_ERR(__disagg_read_meta(session, ckpt_meta, &buf));
+    WT_ERR(__disagg_load_checkpoint_meta(session, buf, &metadata_value, &checkpoint_timestamp));
+
+    __wt_verbose_debug2(session, WT_VERB_DISAGGREGATED_STORAGE,
+      "Picking up disaggregated storage checkpoint: metadata_lsn=%" PRIu64 ", timestamp=%" PRIu64
+      " %s"
+      ", root=\"%s\"",
+      ckpt_meta->metadata_lsn, checkpoint_timestamp,
+      __wt_timestamp_to_string(checkpoint_timestamp, ts_string), metadata_value);
+
+    /* We need an internal session when modifying metadata. */
+    WT_ERR(__wt_open_internal_session(conn, "checkpoint-pick-up", false, 0, 0, &internal_session));
+
+    /* Open up a metadata cursor pointing at our table */
+    WT_ERR(__wt_metadata_cursor(internal_session, &md_cursor));
+
+    WT_ERR(__disagg_save_meta(session, internal_session, md_cursor, metadata_value,
+      &metadata_value_cfg, &metadata_value_cfg_len));
+
+    /*
+     * Part 2: Get the metadata for other tables from the shared metadata table.
+     */
+
+    WT_ERR(__disagg_process_checkpoint(session, ckpt_meta, internal_session, md_cursor,
+      &metadata_value_cfg, &metadata_value_cfg_len));
+
+    /*
+     * Part 3: Do the bookkeeping.
+     */
+
+    WT_ERR(__disagg_update_checkpoint_meta(
+      session, ckpt_meta, internal_session, conn, metadata_value, checkpoint_timestamp));
+
     /* Log the completion of the checkpoint pick-up. */
     __wt_verbose_debug1(session, WT_VERB_DISAGGREGATED_STORAGE,
       "Finished picking up disaggregated storage checkpoint: metadata_lsn=%" PRIu64,
@@ -794,23 +934,15 @@ err:
           ckpt_meta->metadata_lsn, ret);
     }
 
-    /* Free memory allocated by the page log interface */
-    __wt_free(session, item.mem);
-
-    if (cursor != NULL)
-        WT_TRET(cursor->close(cursor));
     if (md_cursor != NULL)
         WT_TRET(__wt_metadata_cursor_release(internal_session, &md_cursor));
 
     if (internal_session != NULL)
         WT_TRET(__wt_session_close_internal(internal_session));
-    if (shared_metadata_session != NULL)
-        WT_TRET(__wt_session_close_internal(shared_metadata_session));
 
+    __wt_free(session, metadata_value);
     __wt_free(session, buf);
     __wt_free(session, metadata_value_cfg);
-    __wt_free(session, layered_ingest_uri);
-    __wt_free(session, cfg_ret);
 
     return (ret);
 }

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -34,7 +34,7 @@ static int __disagg_save_meta(WT_SESSION_IMPL *session, WT_SESSION_IMPL *interna
   size_t *metadata_value_cfg_lenp);
 static int __disagg_load_checkpoint_meta(WT_SESSION_IMPL *session, char *meta_buf,
   char **metadata_valuep, uint64_t *checkpoint_timestampp);
-static int __disagg_process_checkpoint(WT_SESSION_IMPL *session,
+static int __disagg_apply_checkpoint_meta(WT_SESSION_IMPL *session,
   const WT_DISAGG_CHECKPOINT_META *ckpt_meta, WT_SESSION_IMPL *internal_session,
   WT_CURSOR *md_cursor, char **metadata_value_cfgp, size_t *metadata_value_cfg_lenp);
 static int __disagg_update_checkpoint_meta(WT_SESSION_IMPL *session,
@@ -496,11 +496,11 @@ err:
 }
 
 /*
- * __disagg_read_meta --
+ * __disagg_fetch_shared_meta --
  *     Fetch the checkpoint metadata page, validate it, and return a zero-terminated buffer copy.
  */
 static int
-__disagg_read_meta(
+__disagg_fetch_shared_meta(
   WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPOINT_META *ckpt_meta, char **bufp)
 {
     WT_DECL_RET;
@@ -568,12 +568,13 @@ __disagg_load_checkpoint_meta(
           "Disaggregated checkpoint metadata item \"%.*s\"=\"%.*s\"", (int)cfg_key.len, cfg_key.str,
           (int)cfg_value.len, cfg_value.str);
         if (WT_CONFIG_LIT_MATCH("checkpoint", cfg_key)) {
-            if (checkpoint_found)
-                WT_ERR_MSG(
-                  session, EINVAL, "Duplicate checkpoint entry in disaggregated storage metadata");
+            WT_ASSERT_ALWAYS(session, !checkpoint_found,
+              "Duplicate checkpoint entry in disaggregated storage metadata");
             WT_ERR(__wt_strndup(session, cfg_value.str, cfg_value.len, &metadata_value));
             checkpoint_found = true;
         } else if (WT_CONFIG_LIT_MATCH("timestamp", cfg_key)) {
+            WT_ASSERT_ALWAYS(session, !timestamp_found,
+              "Duplicate timestamp entry in disaggregated storage metadata");
             if (cfg_value.len > 0 && cfg_value.val == 0)
                 checkpoint_timestamp = WT_TS_NONE;
             else
@@ -581,7 +582,7 @@ __disagg_load_checkpoint_meta(
                   session, "checkpoint timestamp", &checkpoint_timestamp, &cfg_value));
             timestamp_found = true;
         } else if (WT_CONFIG_LIT_MATCH("key_provider", cfg_key)) {
-            /* Logged above; no additional action required yet. */
+            /* FIXME-WT-16055 Implement KEK read path mechanism */
         }
     }
     WT_ERR_NOTFOUND_OK(ret, false);
@@ -649,11 +650,11 @@ err:
 }
 
 /*
- * __disagg_process_checkpoint --
+ * __disagg_apply_checkpoint_meta --
  *     Process the metadata entries stored in the shared metadata table for a new checkpoint.
  */
 static int
-__disagg_process_checkpoint(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPOINT_META *ckpt_meta,
+__disagg_apply_checkpoint_meta(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPOINT_META *ckpt_meta,
   WT_SESSION_IMPL *internal_session, WT_CURSOR *md_cursor, char **metadata_value_cfgp,
   size_t *metadata_value_cfg_lenp)
 {
@@ -886,7 +887,7 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPOINT
      * Part 1: Get the metadata of the shared metadata table and insert it into our metadata table.
      */
 
-    WT_ERR(__disagg_read_meta(session, ckpt_meta, &buf));
+    WT_ERR(__disagg_fetch_shared_meta(session, ckpt_meta, &buf));
     WT_ERR(__disagg_load_checkpoint_meta(session, buf, &metadata_value, &checkpoint_timestamp));
 
     __wt_verbose_debug2(session, WT_VERB_DISAGGREGATED_STORAGE,
@@ -906,10 +907,10 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPOINT
       &metadata_value_cfg, &metadata_value_cfg_len));
 
     /*
-     * Part 2: Get the metadata for other tables from the shared metadata table.
+     * Part 2: Apply the metadata for other tables from the shared metadata table.
      */
 
-    WT_ERR(__disagg_process_checkpoint(session, ckpt_meta, internal_session, md_cursor,
+    WT_ERR(__disagg_apply_checkpoint_meta(session, ckpt_meta, internal_session, md_cursor,
       &metadata_value_cfg, &metadata_value_cfg_len));
 
     /*

--- a/src/include/meta.h
+++ b/src/include/meta.h
@@ -134,13 +134,3 @@ struct __wt_blkincr {
                               /* AUTOMATIC FLAG VALUE GENERATION STOP 8 */
     uint8_t flags;
 };
-
-/*
- * Metadata configs extracted from the shared main metadata table.
- */
-typedef enum {
-    CHECKPOINT_CONFIG = 0,
-    TIMESTAMP_CONFIG,
-    KEY_PROVIDER_CONFIG,
-    MAX_NUM_CONFIG
-} WTI_SHARED_MAIN_CFG;


### PR DESCRIPTION
- Reinstate `checkpoint=` prefix for the checkpoint info in the turtle file.
- Ensure that turtle file contents follows configuration format.