### PR TITLE
WT-16384 Fix MongoDB compilation evergreen hangs

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -220,11 +220,10 @@ functions:
         # the case of patch builds, it is possible that the developer has a branch name that doesn't
         # adhere to naming rules, therefore derive the base branch name from git.
         branch=$(git branch --contains | grep -e "mongodb" -e "develop" -e "evg-pr-test-")
+        mongo_repo=https://github.com/mongodb/mongo
         if [[ $branch =~ "mongodb-" ]]; then
-          mongo_repo=https://github.com/mongodb/mongo
           mongo_branch=v$(echo $branch | cut -d'-' -f 2)
         else
-          mongo_repo=https://github.com/mongodb/mongo
           mongo_branch=master
         fi
         popd
@@ -250,6 +249,11 @@ functions:
         virtualenv -p python3 venv
         source venv/bin/activate
         buildscripts/poetry_sync.sh
+
+        # Without this variable the bazel execution might be stalled for many hours.
+        # This is because evergreen is using a go Cmd.Wait and waiting for some file descriptors
+        # to be clean up. This setting helps to avoid using the extra file descriptors.
+        export MONGO_WRAPPER_OUTPUT_ALL=1
 
         # The bazel cache uses a substantial (>30GB) amount of data which causes our evergreen hosts
         # to run out of disk space. By default it's saved into ~/.cache, but we want it saved into


### PR DESCRIPTION
In WiredTiger CI, we have a job that builds MongoDB to run many-collection-test. I noticed that about 2 months ago, this build started taking 4 hours, compared to 1.5 hours previously.

This happens 100% reproducibly. When I run the same build locally on my system, it takes around *4 minutes* to complete. The code around this place hasn't been changed for a while on our side.The most interesting part is that there are *3 hours of waiting* between the "Build completed successfully" and "Finished command 'shell.exec' in function 'compile mongodb'" messages, which suggests that the system might just be waiting for some kind of timeout.

```
{noformat}
[2025/12/25 11:39:52.793] [8,050 / 8,051] MongoInstallRule install-mongod/bin/mongod; 1s local
[2025/12/25 11:39:52.793] INFO: Found 1 target...
[2025/12/25 11:39:53.126] Target //:install-mongod up-to-date:
[2025/12/25 11:39:53.126]   bazel-bin/install-mongod/bin/mongod
[2025/12/25 11:39:53.126] INFO: Elapsed time: 3891.063s, Critical Path: 104.50s
[2025/12/25 11:39:53.127] INFO: 8051 processes: 720 internal, 7327 linux-sandbox, 4 local.
[2025/12/25 11:39:53.127] INFO: Build completed successfully, 8051 total actions
[2025/12/25 14:39:53.815] Finished command 'shell.exec' in function 'compile mongodb' (step 6 of 13) in 4h6m49.80928292s.
{noformat}
```

It turned out that to fix it we should define `MONGO_WRAPPER_OUTPUT_ALL=1` since evergreen relies on some file descriptors that are not getting cleaned up without this setting.
