### PR TITLE
WT-16386 Config parser reads beyond config length limit

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -663,6 +663,7 @@ curversion
 cust
 customizable
 customp
+cutlim
 cv
 cval
 cx
@@ -679,6 +680,7 @@ dbar
 dbs
 dcalloc
 ddd
+dec
 decile
 deciles
 decl

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -483,6 +483,7 @@ Zstd
 Zstd's
 aa
 aaa
+abc
 abcdef
 abcdefghijklmnopqrstuvwxyz
 ackSstu
@@ -749,6 +750,7 @@ encodings
 encryptor
 encryptors
 endian
+endptr
 enomem
 enum
 env

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -9,17 +9,25 @@
 #include "wt_internal.h"
 
 /* !!!
- * __config_parse_dec --
+ * __wti_config_parse_dec --
  *     Parse a decimal number from a string up to a specified length.
  *
+ *     This function is designed to be a drop-in replacement for strtoll, but
+ *     with a length argument.
+ *
  *     Return value:
- *      - If successful, an integer value corresponding to the contents of str is returned.
- *      - If the converted value falls out of range, a range error occurs (setting errno to ERANGE)
- *          and INT64_MAX or INT64_MIN is returned.
+ *      - If successful, an integer value corresponding to the contents of str
+ *        is returned.
+ *      - If the converted value falls out of range, a range error occurs
+ *        (setting errno to ERANGE) and INT64_MAX or INT64_MIN is returned.
  *      - If no conversion can be performed, 0 is returned.
+ *
+ *     The endptr is updated to point to the character after the last character
+ *     used in the conversion.
+ *     If no conversion is performed, endptr is set to str.
  */
-static int64_t
-__config_parse_dec(const char *str, size_t len, char **endptr)
+int64_t
+__wti_config_parse_dec(const char *str, size_t len, char **endptr)
 {
     const char *cur = str;
     const char *end = str + len;
@@ -39,6 +47,9 @@ __config_parse_dec(const char *str, size_t len, char **endptr)
             ++cur;
     }
 
+    /* Parsing state */
+    typedef enum { S_NAN, S_DIGITS, S_ERANGE } STATE;
+
     /*
      * Calculate:
      *  - cutoff: largest valid number without last digit,
@@ -50,7 +61,7 @@ __config_parse_dec(const char *str, size_t len, char **endptr)
     const int cutlim = maxval % 10;
 
     uint64_t acc = 0;
-    int flag = 0;
+    STATE state = S_NAN;
     while (cur < end) {
         int c = *cur;
 
@@ -60,28 +71,27 @@ __config_parse_dec(const char *str, size_t len, char **endptr)
         } else
             break;
 
-        if (flag < 0 || acc > cutoff || (acc == cutoff && c > cutlim)) {
+        if (state == S_ERANGE || acc > cutoff || (acc == cutoff && c > cutlim)) {
             /*
              * Overflow or underflow. No stopping here, keep parsing to find the end of the number.
              */
-            flag = -1;
+            state = S_ERANGE;
         } else {
-            flag = 1;
+            state = S_DIGITS;
             acc *= 10;
             acc += (uint64_t)c;
         }
     }
 
     int64_t value = 0;
-    if (flag == -1) {
+    if (state == S_ERANGE) {
         value = neg ? INT64_MIN : INT64_MAX;
         errno = ERANGE;
-    } else {
+    } else
         value = neg ? -(int64_t)acc : (int64_t)acc;
-    }
 
     if (endptr != NULL)
-        *endptr = (char *)(flag != 0 ? cur : str);
+        *endptr = (char *)(state != S_NAN ? cur : str);
 
     return (value);
 }
@@ -544,7 +554,7 @@ __config_process_value(WT_CONFIG_ITEM *value)
         }
     } else if (value->type == WT_CONFIG_ITEM_NUM) {
         errno = 0;
-        value->val = __config_parse_dec(value->str, value->len, &endptr);
+        value->val = __wti_config_parse_dec(value->str, value->len, &endptr);
 
         /*
          * If we parsed the string but the number is out of range, treat the value as an identifier.

--- a/src/config/config.c
+++ b/src/config/config.c
@@ -8,6 +8,84 @@
 
 #include "wt_internal.h"
 
+/* !!!
+ * __config_parse_dec --
+ *     Parse a decimal number from a string up to a specified length.
+ *
+ *     Return value:
+ *      - If successful, an integer value corresponding to the contents of str is returned.
+ *      - If the converted value falls out of range, a range error occurs (setting errno to ERANGE)
+ *          and INT64_MAX or INT64_MIN is returned.
+ *      - If no conversion can be performed, 0 is returned.
+ */
+static int64_t
+__config_parse_dec(const char *str, size_t len, char **endptr)
+{
+    const char *cur = str;
+    const char *end = str + len;
+    bool neg = false;
+
+    /*
+     * Skip leading spaces and pick up optional sign.
+     */
+    while (cur < end && __wt_isspace((u_char)*cur))
+        ++cur;
+
+    if (cur < end) {
+        if (*cur == '-') {
+            neg = true;
+            ++cur;
+        } else if (*cur == '+')
+            ++cur;
+    }
+
+    /*
+     * Calculate:
+     *  - cutoff: largest valid number without last digit,
+     *  - cutlim: last digit limit.
+     * All numbers are positive.
+     */
+    const uint64_t maxval = neg ? -(uint64_t)INT64_MIN : INT64_MAX;
+    const uint64_t cutoff = maxval / 10;
+    const int cutlim = maxval % 10;
+
+    uint64_t acc = 0;
+    int flag = 0;
+    while (cur < end) {
+        int c = *cur;
+
+        if (__wt_isdigit((u_char)c)) {
+            c -= '0';
+            ++cur;
+        } else
+            break;
+
+        if (flag < 0 || acc > cutoff || (acc == cutoff && c > cutlim)) {
+            /*
+             * Overflow or underflow. No stopping here, keep parsing to find the end of the number.
+             */
+            flag = -1;
+        } else {
+            flag = 1;
+            acc *= 10;
+            acc += (uint64_t)c;
+        }
+    }
+
+    int64_t value = 0;
+    if (flag == -1) {
+        value = neg ? INT64_MIN : INT64_MAX;
+        errno = ERANGE;
+    } else {
+        value = neg ? -(int64_t)acc : (int64_t)acc;
+    }
+
+    if (endptr != NULL)
+        *endptr = (char *)(flag != 0 ? cur : str);
+
+    return (value);
+}
+
 /*
  * __config_err --
  *     Error message and return for config string parse failures.
@@ -466,7 +544,7 @@ __config_process_value(WT_CONFIG_ITEM *value)
         }
     } else if (value->type == WT_CONFIG_ITEM_NUM) {
         errno = 0;
-        value->val = strtoll(value->str, &endptr, 10);
+        value->val = __config_parse_dec(value->str, value->len, &endptr);
 
         /*
          * If we parsed the string but the number is out of range, treat the value as an identifier.

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1617,6 +1617,8 @@ extern int __wti_verify_ckpt_load(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_verify_ckpt_unload(WT_SESSION_IMPL *session, WT_BLOCK *block, bool skip_verify)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int64_t __wti_config_parse_dec(const char *str, size_t len, char **endptr)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern size_t __wt_json_unpack_str(u_char *dest, size_t dest_len, const u_char *src, size_t src_len)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern ssize_t __wt_json_strlen(const char *src, size_t srclen) WT_GCC_FUNC_DECL_ATTRIBUTE(

--- a/test/catch2/CMakeLists.txt
+++ b/test/catch2/CMakeLists.txt
@@ -8,6 +8,7 @@ else()
         misc_tests/test_binary_search_string.cpp
         misc_tests/test_bitmap.cpp
         misc_tests/test_cell_prepared_time_window.cpp
+        misc_tests/test_config.cpp
         misc_tests/test_crc32.cpp
         misc_tests/test_error.cpp
         misc_tests/test_futex.cpp

--- a/test/catch2/misc_tests/test_config.cpp
+++ b/test/catch2/misc_tests/test_config.cpp
@@ -41,6 +41,21 @@ TEST_CASE("Parse integer", "[config][parse_int]")
         REQUIRE(endptr_min == min_s + strlen(min_s));
     }
 
+    SECTION("Boundary conditions less than one")
+    {
+        const char *max_s = "9223372036854775806"; /* INT64_MAX - 1 */
+        char *endptr_max = nullptr;
+        const int64_t max_val = __wti_config_parse_dec(max_s, strlen(max_s), &endptr_max);
+        REQUIRE(max_val == INT64_MAX - 1);
+        REQUIRE(endptr_max == max_s + strlen(max_s));
+
+        const char *min_s = "-9223372036854775807"; /* INT64_MIN + 1 */
+        char *endptr_min = nullptr;
+        const int64_t min_val = __wti_config_parse_dec(min_s, strlen(min_s), &endptr_min);
+        REQUIRE(min_val == INT64_MIN + 1);
+        REQUIRE(endptr_min == min_s + strlen(min_s));
+    }
+
     SECTION("Out of range")
     {
         const char *overflow_s = "9223372036854775808"; /* INT64_MAX + 1 */

--- a/test/catch2/misc_tests/test_config.cpp
+++ b/test/catch2/misc_tests/test_config.cpp
@@ -1,0 +1,44 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+#include "wiredtiger.h"
+#include "wt_internal.h"
+
+#include "wrappers/connection_wrapper.h"
+#include "utils.h"
+
+#include <catch2/catch.hpp>
+
+TEST_CASE("Config tests", "[config]")
+{
+    connection_wrapper conn{DB_HOME, "create,in_memory"};
+    WT_SESSION_IMPL *session = conn.create_session();
+    WT_CONFIG cfg{};
+
+    SECTION("Limited length")
+    {
+        const char *s = "key=123";
+        __wt_config_initn(session, &cfg, s, strlen(s) - 2); /* Exclude last two chars "23" */
+
+        WT_CONFIG_ITEM key{};
+        WT_CONFIG_ITEM val{};
+        int ret = __wt_config_next(&cfg, &key, &val);
+        REQUIRE(ret == 0);
+
+        REQUIRE(key.len == 3);
+        REQUIRE(WT_CONFIG_LIT_MATCH("key", key));
+
+        REQUIRE(val.len == 1); /* Only "1" is included */
+        REQUIRE(WT_CONFIG_LIT_MATCH("1", val));
+        REQUIRE(val.type == WT_CONFIG_ITEM::WT_CONFIG_ITEM_NUM);
+        REQUIRE(val.val == 1);
+
+        ret = __wt_config_next(&cfg, &key, &val);
+        REQUIRE(ret == WT_NOTFOUND);
+    }
+}

--- a/test/catch2/misc_tests/test_config.cpp
+++ b/test/catch2/misc_tests/test_config.cpp
@@ -6,39 +6,131 @@
  * See the file LICENSE for redistribution information.
  */
 
+#include <catch2/catch.hpp>
+
 #include "wiredtiger.h"
 #include "wt_internal.h"
 
-#include "wrappers/connection_wrapper.h"
-#include "utils.h"
+/*
+ * Unit tests for config-related functions.
+ */
 
-#include <catch2/catch.hpp>
-
-TEST_CASE("Config tests", "[config]")
+TEST_CASE("Parse integer", "[config][parse_int]")
 {
-    connection_wrapper conn{DB_HOME, "create,in_memory"};
-    WT_SESSION_IMPL *session = conn.create_session();
-    WT_CONFIG cfg{};
+    SECTION("No conversion")
+    {
+        const char *s = "abc";
+        char *endptr = nullptr;
+        int64_t val = __wti_config_parse_dec(s, strlen(s), &endptr);
+        REQUIRE(val == 0);
+        REQUIRE(endptr == s);
+    }
+
+    SECTION("Boundary conditions")
+    {
+        const char *max_s = "9223372036854775807"; /* INT64_MAX */
+        char *endptr_max = nullptr;
+        const int64_t max_val = __wti_config_parse_dec(max_s, strlen(max_s), &endptr_max);
+        REQUIRE(max_val == INT64_MAX);
+        REQUIRE(endptr_max == max_s + strlen(max_s));
+
+        const char *min_s = "-9223372036854775808"; /* INT64_MIN */
+        char *endptr_min = nullptr;
+        const int64_t min_val = __wti_config_parse_dec(min_s, strlen(min_s), &endptr_min);
+        REQUIRE(min_val == INT64_MIN);
+        REQUIRE(endptr_min == min_s + strlen(min_s));
+    }
+
+    SECTION("Out of range")
+    {
+        const char *overflow_s = "9223372036854775808"; /* INT64_MAX + 1 */
+        char *endptr_overflow = nullptr;
+        errno = 0;
+        const int64_t overflow_val =
+          __wti_config_parse_dec(overflow_s, strlen(overflow_s), &endptr_overflow);
+        REQUIRE(errno == ERANGE);
+        REQUIRE(overflow_val == INT64_MAX);
+        REQUIRE(endptr_overflow == overflow_s + strlen(overflow_s));
+
+        const char *underflow_s = "-9223372036854775809"; /* INT64_MIN - 1 */
+        char *endptr_underflow = nullptr;
+        errno = 0;
+        const int64_t underflow_val =
+          __wti_config_parse_dec(underflow_s, strlen(underflow_s), &endptr_underflow);
+        REQUIRE(errno == ERANGE);
+        REQUIRE(underflow_val == INT64_MIN);
+        REQUIRE(endptr_underflow == underflow_s + strlen(underflow_s));
+
+        const char *longer_s = "123456789012345678901"; /* Longer than INT64_MAX */
+        char *endptr_longer = nullptr;
+        errno = 0;
+        const int64_t longer_val =
+          __wti_config_parse_dec(longer_s, strlen(longer_s), &endptr_longer);
+        REQUIRE(errno == ERANGE);
+        REQUIRE(longer_val == INT64_MAX);
+        REQUIRE(endptr_longer == longer_s + strlen(longer_s));
+    }
 
     SECTION("Limited length")
     {
-        const char *s = "key=123";
-        __wt_config_initn(session, &cfg, s, strlen(s) - 2); /* Exclude last two chars "23" */
+        const char *s = "123";
+        char *endptr = nullptr;
+        int64_t val = __wti_config_parse_dec(s, 2, &endptr);
+        REQUIRE(val == 12);
+        REQUIRE(endptr == s + 2);
+    }
 
-        WT_CONFIG_ITEM key{};
-        WT_CONFIG_ITEM val{};
-        int ret = __wt_config_next(&cfg, &key, &val);
-        REQUIRE(ret == 0);
+    SECTION("Stopping at non-digit")
+    {
+        const char *s = "123abc";
+        char *endptr = nullptr;
+        int64_t val = __wti_config_parse_dec(s, strlen(s), &endptr);
+        REQUIRE(val == 123);
+        REQUIRE(endptr == s + 3);
 
-        REQUIRE(key.len == 3);
-        REQUIRE(WT_CONFIG_LIT_MATCH("key", key));
+        const char *blank_s = "   789 ";
+        char *endptr_blank = nullptr;
+        int64_t val_blank = __wti_config_parse_dec(blank_s, strlen(blank_s), &endptr_blank);
+        REQUIRE(val_blank == 789);
+        REQUIRE(endptr_blank == blank_s + 6);
 
-        REQUIRE(val.len == 1); /* Only "1" is included */
-        REQUIRE(WT_CONFIG_LIT_MATCH("1", val));
-        REQUIRE(val.type == WT_CONFIG_ITEM::WT_CONFIG_ITEM_NUM);
-        REQUIRE(val.val == 1);
+        const char *pos_s = "   +123 ";
+        char *endptr_pos = nullptr;
+        int64_t pos_val = __wti_config_parse_dec(pos_s, strlen(pos_s), &endptr_pos);
+        REQUIRE(pos_val == 123);
+        REQUIRE(endptr_pos == pos_s + 7);
 
-        ret = __wt_config_next(&cfg, &key, &val);
-        REQUIRE(ret == WT_NOTFOUND);
+        const char *neg_s = "   -456 ";
+        char *endptr_neg = nullptr;
+        int64_t neg_val = __wti_config_parse_dec(neg_s, strlen(neg_s), &endptr_neg);
+        REQUIRE(neg_val == -456);
+        REQUIRE(endptr_neg == neg_s + 7);
+    }
+
+    SECTION("Explicit positive and negative")
+    {
+        const char *pos_s = "+456";
+        char *endptr_pos = nullptr;
+        int64_t pos_val = __wti_config_parse_dec(pos_s, strlen(pos_s), &endptr_pos);
+        REQUIRE(pos_val == 456);
+        REQUIRE(endptr_pos == pos_s + strlen(pos_s));
+
+        const char *neg_s = "-789";
+        char *endptr_neg = nullptr;
+        int64_t neg_val = __wti_config_parse_dec(neg_s, strlen(neg_s), &endptr_neg);
+        REQUIRE(neg_val == -789);
+        REQUIRE(endptr_neg == neg_s + strlen(neg_s));
+
+        const char *posz_s = "+0";
+        char *endptr_posz = nullptr;
+        int64_t posz_val = __wti_config_parse_dec(posz_s, strlen(posz_s), &endptr_posz);
+        REQUIRE(posz_val == 0);
+        REQUIRE(endptr_posz == posz_s + strlen(posz_s));
+
+        const char *negz_s = "-0";
+        char *endptr_negz = nullptr;
+        int64_t negz_val = __wti_config_parse_dec(negz_s, strlen(negz_s), &endptr_negz);
+        REQUIRE(negz_val == 0);
+        REQUIRE(endptr_negz == negz_s + strlen(negz_s));
     }
 }


### PR DESCRIPTION
- Replace `strtoll` with custom implementation. `strtoll` expects null-terminated strings (which may not be the case for configs) and reads beyond the valid buffer.