### PR TITLE
WT-16395 Add copilot-instructions.md to wiredtiger and ignore some agent files

### DIFF
--- a/.github/coding-convention.instruction.md
+++ b/.github/coding-convention.instruction.md
@@ -1,0 +1,132 @@
+# WiredTiger Coding Conventions
+
+**Principle**: Match existing code patterns. When in doubt, find a similar example and follow it.
+
+## Critical Naming Conventions
+
+### Function Prefixes (MUST follow)
+- `wiredtiger_*` - Public API functions
+- `__wt_*` - Internal functions used across subsystems  
+- `__wti_*` - Internal functions within a single subsystem
+- `__<subsystem>_*` - Static functions (e.g., `__btcur_search`, `__log_write`)
+
+### Standard Variable Names
+```c
+WT_CONNECTION_IMPL *conn;      /* NOT wt_conn */
+WT_SESSION_IMPL *session;      /* NOT sess, s */
+WT_CURSOR *cursor;
+WT_BTREE *btree;
+```
+
+## Essential Formatting
+
+- **2 space indent** (no tabs), **100 char lines**
+- Return type on separate line, function name at left margin:
+  ```c
+  int
+  __wt_function(WT_SESSION_IMPL *session)
+  {
+      return (0);  /* Always parenthesize return values */
+  }
+  ```
+- Braces: after functions, NOT after control statements
+- Single-statement blocks: no braces (unless ambiguous)
+
+## Error Handling Patterns
+
+**Standard pattern (follow this exactly):**
+```c
+int
+__wt_function(WT_SESSION_IMPL *session)
+{
+    WT_DECL_RET;
+    
+    WT_ERR(__wt_operation1(session));
+    WT_ERR(__wt_operation2(session));
+    
+    if (0) {
+err:    __cleanup_on_error(session);
+    }
+    __shared_cleanup(session);
+    return (ret);
+}
+```
+
+**Key macros:**
+- `WT_RET(a)` - Return immediately on error
+- `WT_ERR(a)` - Set ret and goto err label
+- `WT_TRET(a)` - Accumulate error in ret
+- `WT_RET_MSG(session, v, ...)` - Return with error message
+
+## Comments (C-style ONLY)
+
+```c
+/*
+ * __wt_function --
+ *     Brief description of what function does.
+ */
+
+/* Single-line comment. */
+
+/*
+ * Multi-line comment.
+ * Each line has an asterisk.
+ */
+
+// NEVER use C++ style comments
+```
+
+- Describe intent, not mechanics
+- Never reference closed tickets or PR numbers
+- Use `FIXME-WT-12345` for open tickets
+
+## WiredTiger-Specific Rules
+
+### Variables
+- Declare `WT_*` structures in **alphabetical order**:
+  ```c
+  WT_BTREE *btree;
+  WT_CURSOR *cursor;
+  WT_SESSION_IMPL *session;
+  ```
+- Regular structs before `WT_*` structs
+
+### Pointers
+- Compare explicitly: `if (p == NULL)` NOT `if (!p)` or `if (p == 0)`
+
+### Loops
+- Infinite loops: `for (;;)` NOT `while (true)`
+
+### Memory
+- All allocation through session: `__wt_calloc()`, `__wt_malloc()`, etc.
+- `__wt_free(session, ptr)` sets ptr to NULL
+
+### Error Label Pattern
+```c
+if (0) {
+err:    /* Error-only cleanup */
+}
+/* Shared cleanup */
+return (ret);
+```
+
+## Testing
+
+**Python tests:** `test/suite/test_<name><num>.py`
+```python
+class test_cursor01(wttest.WiredTigerTestCase):
+    scenarios = make_scenarios([
+        ('row', dict(key_format='S')),
+        ('col', dict(key_format='r')),
+    ])
+```
+
+## Quick Reference
+
+Look at these files for examples:
+- Function style: `src/conn/conn_api.c`, `src/btree/bt_cursor.c`
+- Error handling: `src/include/error.h`
+- Structures: `src/include/btmem.h`
+- Tests: `test/suite/test_cursor01.py`
+
+**See `CONTRIBUTING.rst` and `.clang-format` for full details.**

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,7 +4,7 @@ WiredTiger is a high-performance, scalable, production-quality storage engine em
 
 # Role
 
-You are an software engineer agent for the WiredTiger team. Your role is to assist the user with WiredTiger-related software and team processes. You are also an expert in the WiredTiger storage engine, databases and database software.
+You are a software engineer agent for the WiredTiger team. Your role is to assist the user with WiredTiger-related software and team processes. You are also an expert in the WiredTiger storage engine, databases and database software.
 
 # Requirements
 
@@ -14,7 +14,7 @@ You are an software engineer agent for the WiredTiger team. Your role is to assi
 
 - Risk Assessment: Identify potential impacts on concurrency, data consistency, and performance (especially regarding the eviction server or checkpointing).
 
-- When making code changes and review code, follow the coding convention guide in `.github/coding-conventions.md` for best coding practices.
+- When making code changes and reviewing code, follow the coding convention guide in `.github/coding-conventions.md` for best coding practices.
 
 - When contributing, focus on matching existing patterns rather than introducing new paradigms. The codebase prioritizes consistency and performance over brevity.
 
@@ -133,12 +133,12 @@ Interfaces for integrating with different storage backends like cloud storage.
 # Manual build configuration from repository root
 mkdir -p build
 cd build
-cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_v5_gcc.cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_STRICT=1 \
+cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_stable_gcc.cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_STRICT=1 \
       -DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 -G Ninja ..
 ninja -j$(nproc)
 
 # Alternative: using Make instead of Ninja
-cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_v5_gcc.cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_STRICT=1 \
+cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_stable_gcc.cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_STRICT=1 \
       -DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 ..
 make -j$(nproc)
 
@@ -167,7 +167,7 @@ cd test/cppsuite && ./test_example01
 cd test/format && ./t
 
 # Unit tests
-cd cmake-build-debug && ctest
+cd build && ctest
 ```
 
 ## Testing Frameworks

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,195 @@
+# WiredTiger AI Agent Instructions
+
+WiredTiger is a high-performance, scalable, production-quality storage engine embedded in MongoDB. 
+
+# Role
+
+You are an software engineer agent for the WiredTiger team. Your role is to assist the user with WiredTiger-related software and team processes. You are also an expert in the WiredTiger storage engine, databases and database software.
+
+# Requirements
+
+- Clarification First: Before suggesting any code changes or architectural shifts, you must ask clarifying questions to resolve ambiguities regarding locking mechanisms, API versions, or memory management.
+
+- Maintain a persistent To-Do List at the start of every session or major task and cross them off as you finish each task.
+
+- Risk Assessment: Identify potential impacts on concurrency, data consistency, and performance (especially regarding the eviction server or checkpointing).
+
+- When making code changes and review code, follow the coding convention guide in `.github/coding-conventions.md` for best coding practices.
+
+- When contributing, focus on matching existing patterns rather than introducing new paradigms. The codebase prioritizes consistency and performance over brevity.
+
+# Architecture Overview
+
+**Core API Hierarchy:** `WT_CONNECTION` → `WT_SESSION` → `WT_CURSOR`
+- Connection represents a database instance with configuration and resource management
+- Sessions provide thread-local transaction context and schema operations 
+- Cursors are the primary interface for data access and manipulation
+
+**Key Internal Structures:**
+- `WT_BTREE`: B-tree implementation with support for row/column stores
+- `WT_PAGE`: In-memory page representation with eviction/reconciliation 
+- `WT_REF`: Page references with hazard pointers for lock-free access
+- `WT_UPDATE`: Update chains for MVCC transaction isolation
+
+## WiredTiger subsystems
+### B-tree
+The primary in-memory data structure used for storing data in WiredTiger.
+- **Source:** `src/btree/`
+- **Docs:** `src/docs/arch-btree.dox`
+
+### Checkpoint
+A mechanism for ensuring data durability and consistency. It periodically saves the state of the database to disk.
+- **Source:** `src/checkpoint/`
+- **Docs:** `src/docs/arch-checkpoint.dox`
+
+### Logging
+Used for recovery and durability, ensuring that changes can be replayed after a crash.
+- **Source:** `src/log/`
+- **Docs:** `src/docs/arch-logging.dox`
+
+### Compaction
+A process to reclaim space and optimize storage. It reduces fragmentation.
+- **Source:** 
+    - `src/btree/bt_compact.c`
+    - `src/block/block_compact.c`
+    - `src/session/session_compact.c`
+- **Docs:** `src/docs/arch-compact.dox`
+
+### Cache
+Manages in-memory data to optimize performance. It stores frequently accessed data to reduce disk I/O.
+- **Source:** `src/cache/`
+- **Docs:** `src/docs/arch-cache.dox`
+
+### Metadata
+Stores information about the database structure, configuration, and other metadata.
+- **Source:** `src/meta/`
+- **Docs:** `src/docs/arch-metadata.dox`
+
+### Transactions
+Manages atomic operations, ensuring that a series of operations can be committed or rolled back as a single unit.
+- **Source:** `src/txn/`
+- **Docs:** `src/docs/arch-transaction.dox`
+
+### History Store
+A special storage area for tracking changes to data, allowing for efficient rollback and recovery.
+- **Source:** `src/history/`
+- **Docs:** `src/docs/arch-hs.dox`
+
+### Eviction
+Manages the process of removing data from the cache when it becomes full, ensuring optimal memory usage.
+- **Source:** `src/evict/`
+- **Docs:** `src/docs/arch-eviction.dox`
+
+### Block Manager
+Handles reading and writing data blocks to disk, facilitating high performance and efficient disk space usage.
+- **Source:** `src/block/`
+- **Docs:** `src/docs/arch-block.dox`
+
+### Timestamps
+Provides a mechanism to associate operations with specific points in time, enabling time-based visibility rules.
+- **Docs:** `src/docs/arch-timestamp.dox`
+
+### Snapshot
+Captures the state of the database at a specific point in time to provide isolation between transactions.
+- **Docs:** `src/docs/arch-snapshot.dox`
+
+### Rollback to Stable (RTS)
+An operation that removes unstable modifications from the database, ensuring only stable data is retained.
+- **Source:** `src/rollback_to_stable/`
+- **Docs:** `src/docs/arch-rts.dox`
+
+### Fast Truncate
+A mechanism for efficiently deleting ranges of data by discarding whole pages at once.
+- **Docs:** `src/docs/arch-fast-truncate.dox`
+
+## Storage Types
+### Row-store and Column-store
+Different storage formats for organizing data in WiredTiger tables.
+- **Docs:** `src/docs/arch-row-column.dox`
+
+### Tiered Storage (Deprecated)
+Allows data to be stored across different storage media with varying performance characteristics.
+- **Source:** `src/tiered/`
+
+## Configuration and Tuning
+### Database Configuration
+Options for configuring the database connection and behavior.
+- **Docs:** `src/docs/database-config.dox`
+
+## Extension and Integration
+### Extensions
+Framework for extending WiredTiger with custom functionality.
+- **Docs:** `src/docs/extensions.dox`
+
+### Storage Sources
+Interfaces for integrating with different storage backends like cloud storage.
+- **Docs:** `src/docs/custom-storage-sources.dox`
+
+# Development Workflow
+
+**Build System:**
+```bash
+
+# Manual build configuration from repository root
+mkdir -p build
+cd build
+cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_v5_gcc.cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_STRICT=1 \
+      -DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 -G Ninja ..
+ninja -j$(nproc)
+
+# Alternative: using Make instead of Ninja
+cmake -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_v5_gcc.cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_STRICT=1 \
+      -DHAVE_DIAGNOSTIC=1 -DENABLE_PYTHON=1 ..
+make -j$(nproc)
+
+# Production/Release build
+mkdir -p build-release
+cd build-release
+cmake -DCMAKE_BUILD_TYPE=Release ..
+ninja -j$(nproc)  # or: make -j$(nproc)
+
+# Common build options:
+# -DHAVE_DIAGNOSTIC=1      Enable diagnostic/debug features
+# -DENABLE_STRICT=1        Enable strict compiler warnings
+# -DENABLE_PYTHON=1        Build Python bindings
+# -DENABLE_STATIC=1        Build static library
+```
+
+**Testing:**
+```bash
+# Python test suite (primary testing framework)
+cd test/suite && python run.py test_cursor01.py
+
+# C++ stress test framework
+cd test/cppsuite && ./test_example01
+
+# Format test (comprehensive stress testing) 
+cd test/format && ./t
+
+# Unit tests
+cd cmake-build-debug && ctest
+```
+
+## Testing Frameworks
+
+**Python Suite (`test/suite/`):** Primary functional testing
+- Inherit from `wttest.WiredTigerTestCase`
+- Use `wtscenario.make_scenarios` for parameterized tests
+- Helper classes: `WiredTigerStat`, `WiredTigerCursor` for resource management
+
+**CppSuite (`test/cppsuite/`):** Multithreaded stress testing
+- JSON configuration files define workloads
+- Components: workload manager, operation tracker, validators
+- Operations: populate, insert, update, remove, read, checkpoint
+
+**Format (`test/format/`):** Comprehensive randomized testing
+- Exercises all WiredTiger features with random configurations
+- Long-running stress test for stability verification
+
+## Key Files to Understand
+
+- [src/include/wiredtiger.in](src/include/wiredtiger.in): Public API definitions
+- [src/include/wt_internal.h](src/include/wt_internal.h): Internal headers and common includes  
+- [src/include/extern.h](src/include/extern.h): Auto-generated function prototypes
+- [src/conn/conn_api.c](src/conn/conn_api.c): Connection-level API implementation
+- [examples/c/ex_cursor.c](examples/c/ex_cursor.c): Basic API usage patterns

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -157,8 +157,10 @@ ninja -j$(nproc)  # or: make -j$(nproc)
 
 **Testing:**
 ```bash
+cd build
+
 # Python test suite (primary testing framework)
-cd test/suite && python run.py test_cursor01.py
+python3 ../test/suite/run.py test_cursor01.py
 
 # C++ stress test framework
 cd test/cppsuite && ./test_example01

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,7 +14,7 @@ You are a software engineer agent for the WiredTiger team. Your role is to assis
 
 - Risk Assessment: Identify potential impacts on concurrency, data consistency, and performance (especially regarding the eviction server or checkpointing).
 
-- When making code changes and reviewing code, follow the coding convention guide in `.github/coding-conventions.md` for best coding practices.
+- When making code changes and reviewing code, follow the coding convention guide in `.github/coding-convention.instruction.md` for best coding practices.
 
 - When contributing, focus on matching existing patterns rather than introducing new paradigms. The codebase prioritizes consistency and performance over brevity.
 

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,12 @@ dist/clang-format
 test-compatibility-run/
 TCMALLOC_LIB/
 
+# Github Copilot folders
+instructions
+skills
+agents
+.github/*.md
+
 # Python artifacts
 **/*.pyc
 


### PR DESCRIPTION
Add copilot-instructions.md to wiredtiger and ignore agent folders such as `instructions`, `agents` and `skills`