### PR TITLE
WT-16379 Introduce sentinel for new log file during connection open

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -462,6 +462,7 @@ WiredTigerCC
 WiredTigerCheckpoint
 WiredTigerChunkCache
 WiredTigerHS
+WiredTigerInitlog
 WiredTigerLAS
 WiredTigerLog
 WiredTigerPreplog

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -3568,6 +3568,7 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler, const char *c
     __wt_verbose_info(
       session, WT_VERB_RECOVERY, "%s", "the WiredTiger library has successfully opened");
 
+    WT_ERR(__wt_logmgr_initialized(session));
 err:
     /* Discard the scratch buffers. */
     __wt_scr_free(session, &encbuf);

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -13,6 +13,8 @@ static int __log_newfile(WT_SESSION_IMPL *, bool, bool *, bool *);
 static int __log_openfile(WT_SESSION_IMPL *, uint32_t, uint32_t, WT_FH **);
 static int __log_truncate(WT_SESSION_IMPL *, WT_LSN *, bool, bool);
 static int __log_write_internal(WT_SESSION_IMPL *, WT_ITEM *, WT_LSN *, uint32_t);
+static int __log_touch(WT_SESSION_IMPL *, const char *, uint32_t);
+static int __log_exist(WT_SESSION_IMPL *, const char *, uint32_t, bool *);
 
 #define WT_LOG_COMPRESS_SKIP (offsetof(WT_LOG_RECORD, record))
 #define WT_LOG_ENCRYPT_SKIP (offsetof(WT_LOG_RECORD, record))
@@ -1579,6 +1581,56 @@ err:
 }
 
 /*
+ * __log_touch --
+ *     Touch a file, used as flag only.
+ */
+int
+__log_touch(WT_SESSION_IMPL *session, const char *file_prefix, uint32_t lognum)
+{
+    WT_DECL_ITEM(path);
+    WT_DECL_RET;
+    WT_FH *fh;
+    u_int wtopen_flags;
+    bool exist;
+
+    exist = false;
+    wtopen_flags = 0;
+    fh = NULL;
+
+    WT_RET(__wt_scr_alloc(session, 0, &path));
+    WT_ERR(__wt_log_filename(session, lognum, file_prefix, path));
+    __wt_verbose(session, WT_VERB_LOG, "log_touch: touch log %s", (const char *)path->data);
+    WT_ERR(__wt_fs_exist(session, path->data, &exist));
+    if (!exist) {
+        wtopen_flags = WT_FS_OPEN_CREATE;
+        WT_ERR(__wt_open(session, path->data, WT_FS_OPEN_FILE_TYPE_LOG, wtopen_flags, &fh));
+        WT_ERR(__wt_close(session, &fh));
+    }
+err:
+    __wt_scr_free(session, &path);
+    return (ret);
+}
+
+/*
+ * __log_exist --
+ *     Given a log number, check the existence of a log file.
+ */
+int
+__log_exist(WT_SESSION_IMPL *session, const char *file_prefix, uint32_t lognum, bool *existp)
+{
+    WT_DECL_ITEM(path);
+    WT_DECL_RET;
+
+    WT_RET(__wt_scr_alloc(session, 0, &path));
+    WT_ERR(__wt_log_filename(session, lognum, file_prefix, path));
+    __wt_verbose(session, WT_VERB_LOG, "log_exist: check log %s", (const char *)path->data);
+    WT_ERR(__wt_fs_exist(session, path->data, existp));
+err:
+    __wt_scr_free(session, &path);
+    return (ret);
+}
+
+/*
  * __wti_log_remove --
  *     Given a log number, remove that log file.
  */
@@ -1683,11 +1735,19 @@ again:
         WT_INIT_LSN(&log->first_lsn);
     } else {
         WT_SET_LSN(&log->first_lsn, firstlog, 0);
-        /*
-         * If we have existing log files, check the last log now before we create a new log file so
-         * that we can detect an unsupported version before modifying the file space.
-         */
-        WT_ERR(__log_open_verify(session, lastlog, NULL, NULL, &version, &need_salvage));
+        /* Check if the file is half initialized. */
+        WT_ERR(__log_exist(session, WTI_LOG_INITNAME, log->fileid, &need_salvage));
+
+        if (need_salvage) {
+            WT_ERR(__wti_log_remove(session, WTI_LOG_INITNAME, log->fileid));
+            __wt_verbose_warning(
+              session, WT_VERB_LOG, "salvage: log file %" PRIu32 " removed", log->fileid);
+        } else
+            /*
+             * If we have existing log files, check the last log now before we create a new log file
+             * so that we can detect an unsupported version before modifying the file space.
+             */
+            WT_ERR(__log_open_verify(session, lastlog, NULL, NULL, &version, &need_salvage));
 
         /*
          * If we were asked to salvage and the last log file was indeed corrupt, remove it and try
@@ -1710,6 +1770,8 @@ again:
     if (!F_ISSET(conn, WT_CONN_READONLY)) {
         WTI_WITH_SLOT_LOCK(session, log, ret = __log_newfile(session, true, NULL, NULL));
         WT_ERR(ret);
+        /* Touch the new file */
+        WT_ERR(__log_touch(session, WTI_LOG_INITNAME, log->fileid));
     }
 
     /* If we found log files, save the new state. */

--- a/src/log/log.h
+++ b/src/log/log.h
@@ -220,6 +220,8 @@ extern int __wt_logmgr_create(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_logmgr_destroy(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_logmgr_initialized(WT_SESSION_IMPL *session)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_logmgr_open(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_logmgr_reconfig(WT_SESSION_IMPL *session, const char **cfg)

--- a/src/log/log_mgr.c
+++ b/src/log/log_mgr.c
@@ -1028,6 +1028,26 @@ err:
 }
 
 /*
+ * __wt_logmgr_initialized --
+ *     Finish initializing the log subsystem.
+ */
+int
+__wt_logmgr_initialized(WT_SESSION_IMPL *session)
+{
+    WT_CONNECTION_IMPL *conn;
+    WTI_LOG *log;
+    WT_LOG_MANAGER *log_mgr;
+
+    conn = S2C(session);
+    log_mgr = &conn->log_mgr;
+    log = log_mgr->log;
+
+    WT_RET(__wti_log_remove(session, WTI_LOG_INITNAME, log->fileid));
+
+    return (0);
+}
+
+/*
  * __wt_logmgr_create --
  *     Initialize the log subsystem (before running recovery).
  */

--- a/src/log/log_mgr.c
+++ b/src/log/log_mgr.c
@@ -1039,7 +1039,7 @@ __wt_logmgr_initialized(WT_SESSION_IMPL *session)
     WT_LOG_MANAGER *log_mgr;
 
     conn = S2C(session);
-    
+
     if ((log_mgr = &conn->log_mgr) == NULL)
         return (0);
 

--- a/src/log/log_mgr.c
+++ b/src/log/log_mgr.c
@@ -1039,8 +1039,12 @@ __wt_logmgr_initialized(WT_SESSION_IMPL *session)
     WT_LOG_MANAGER *log_mgr;
 
     conn = S2C(session);
-    log_mgr = &conn->log_mgr;
-    log = log_mgr->log;
+    
+    if ((log_mgr = &conn->log_mgr) == NULL)
+        return (0);
+
+    if ((log = log_mgr->log) == NULL)
+        return (0);
 
     WT_RET(__wti_log_remove(session, WTI_LOG_INITNAME, log->fileid));
 

--- a/src/log/log_mgr.c
+++ b/src/log/log_mgr.c
@@ -1040,8 +1040,7 @@ __wt_logmgr_initialized(WT_SESSION_IMPL *session)
 
     conn = S2C(session);
 
-    if ((log_mgr = &conn->log_mgr) == NULL)
-        return (0);
+    log_mgr = &conn->log_mgr;
 
     if ((log = log_mgr->log) == NULL)
         return (0);

--- a/src/log/log_private.h
+++ b/src/log/log_private.h
@@ -10,6 +10,7 @@
 
 #define WTI_LOG_PREPNAME "WiredTigerPreplog" /* Log pre-allocated name */
 #define WTI_LOG_TMPNAME "WiredTigerTmplog"   /* Log temporary name */
+#define WTI_LOG_INITNAME "WiredTigerInitlog" /* Log initialize name */
 
 /* Logging subsystem declarations. */
 #define WTI_LOG_ALIGN 128


### PR DESCRIPTION
This is used to avoid the scenario that if core dump happened, then the newly created log file will remain, and will keep on the disk until a successful start. When data corruption happened and the startup jump into a infinite loop, the disk space will be exhausted at some time point.

The fix including:
- Introduce `sentinel file` (thanks @etienneptl to point the term) mechanism for newly created log file.
- Drop partial created log file, which is happened in unsuccessful connection open, first before create new log file.

As the test required to inject a segment fault for unclean connection open, so the test code and process are attached in the ticket.