### PR TITLE
WT-16203 Suppress the log->log_fh TSAN warning

### DIFF
--- a/src/include/tsan_suppress.h
+++ b/src/include/tsan_suppress.h
@@ -262,6 +262,16 @@ __wt_tsan_suppress_memset(void *ptr, int val, size_t size)
 }
 
 /*
+ * __wt_tsan_suppress_load_wt_fh_ptr --
+ *     TSAN warnings suppression for WT_FH pointer load.
+ */
+static WT_INLINE WT_FH *
+__wt_tsan_suppress_load_wt_fh_ptr(WT_FH **vp)
+{
+    return (WT_FH *)(__wt_atomic_load_ptr_relaxed(vp));
+}
+
+/*
  * __wt_tsan_suppress_store_wt_page_ptr_v --
  *     TSAN warnings suppression for WT_PAGE pointer store.
  */

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -276,7 +276,7 @@ __log_fsync_file(WT_SESSION_IMPL *session, WT_LSN *min_lsn, const char *method, 
         if (use_own_fh)
             WT_ERR(__log_openfile(session, min_lsn->l.file, 0, &log_fh));
         else
-            log_fh = log->log_fh;
+            log_fh = __wt_tsan_suppress_load_wt_fh_ptr(&log->log_fh);
         __wt_verbose(session, WT_VERB_LOG, "%s: sync %s to LSN %" PRIu32 "/%" PRIu32, method,
           log_fh->name, min_lsn->l.file, __wt_lsn_offset(min_lsn));
         time_start = __wt_clock(session);


### PR DESCRIPTION
The affected access causes TSAN warnings in CI. According to the current progress, all warnings generated by an old code could be suppressed to be solved later, so suppressing this warning for now.