### PR TITLE
WT-16379 Add record length check to avoid overflow in round up

### DIFF
--- a/src/log/log.c
+++ b/src/log/log.c
@@ -2279,6 +2279,12 @@ advance:
             /*
              * The situation is designed to perform salvage to avoid a infinite restart loop. Point
              * bad offset to the record offset.
+             * Salvage will perform following actions:
+             *   Use error code of WT_ERROR jump to the err branch.
+             *   Skip this log record and any further log records of the file.
+             *   Truncate this log file to release the unused space.
+             *   Reset the ret code to 0 as actions of drop commits after this lsn.
+             *     The consistent here is aligned to minimum to latest checkpoint.
              */
             WT_ERR(__log_salvage_message(
               session, log_fh->name, " record length oversize", __wt_lsn_offset(&rd_lsn)));

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -2270,6 +2270,20 @@ advance:
         reclen = __wt_bswap32(reclen);
 #endif
         /*
+         * Overflow behavior: __wt_rduppo2 returns 0 if rounding up would overflow uint32_t, i.e.,
+         * when n == UINT32_MAX the return is 0. WT_LOG_FILE_MAX bounds the maximum log record
+         * length below this threshold, so a 0 return is not expected in normal operation.
+         */
+        if (reclen > WT_LOG_FILE_MAX) {
+            need_salvage = true;
+            /*
+             * The situation is designed to perform salvage to avoid a infinite restart loop. Point
+             * bad offset to the record offset.
+             */
+            WT_ERR(__log_salvage_message(
+              session, log_fh->name, " record length oversize", __wt_lsn_offset(&rd_lsn)));
+        }
+        /*
          * Log files are pre-allocated. We need to detect the difference between a hole in the file
          * (where this location would be considered the end of log) and the last record in the log
          * and we're at the zeroed part of the file. If we find a zeroed record, scan forward in the

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -2270,26 +2270,6 @@ advance:
         reclen = __wt_bswap32(reclen);
 #endif
         /*
-         * Overflow behavior: __wt_rduppo2 returns 0 if rounding up would overflow uint32_t, i.e.,
-         * when n == UINT32_MAX the return is 0. WT_LOG_FILE_MAX bounds the maximum log record
-         * length below this threshold, so a 0 return is not expected in normal operation.
-         */
-        if (reclen > log_size - __wt_lsn_offset(&rd_lsn)) {
-            need_salvage = true;
-            /*
-             * The situation is designed to perform salvage to avoid a infinite restart loop. Point
-             * bad offset to the record offset.
-             * Salvage will perform following actions:
-             *   Use error code of WT_ERROR jump to the err branch.
-             *   Skip this log record and any further log records of the file.
-             *   Truncate this log file to release the unused space.
-             *   Reset the ret code to 0 as actions of drop commits after this lsn.
-             *     The consistent here is aligned to minimum to latest checkpoint.
-             */
-            WT_ERR(__log_salvage_message(
-              session, log_fh->name, " record length oversize", __wt_lsn_offset(&rd_lsn)));
-        }
-        /*
          * Log files are pre-allocated. We need to detect the difference between a hole in the file
          * (where this location would be considered the end of log) and the last record in the log
          * and we're at the zeroed part of the file. If we find a zeroed record, scan forward in the
@@ -2327,6 +2307,15 @@ advance:
             WT_ERR(
               __log_fs_read(session, log_fh, __wt_lsn_offset(&rd_lsn), (size_t)rdup_len, buf->mem));
             WT_STAT_CONN_INCR(session, log_scan_rereads);
+        }
+        /*
+         * If the record length is larger than the remaining bytes to EOF from the records offset,
+         * flag log file corruption.
+         */
+        if (reclen > log_size - __wt_lsn_offset(&rd_lsn)) {
+            need_salvage = true;
+            WT_ERR(__log_salvage_message(
+              session, log_fh->name, " record length oversize", __wt_lsn_offset(&rd_lsn)));
         }
         /*
          * We read in the record, now verify the checksum. A failed checksum does not imply

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -2274,7 +2274,7 @@ advance:
          * when n == UINT32_MAX the return is 0. WT_LOG_FILE_MAX bounds the maximum log record
          * length below this threshold, so a 0 return is not expected in normal operation.
          */
-        if (reclen > WT_LOG_FILE_MAX) {
+        if (reclen > log_size - __wt_lsn_offset(&rd_lsn)) {
             need_salvage = true;
             /*
              * The situation is designed to perform salvage to avoid a infinite restart loop. Point

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -2270,6 +2270,15 @@ advance:
         reclen = __wt_bswap32(reclen);
 #endif
         /*
+         * If the record length is larger than the remaining bytes to EOF from the records offset,
+         * flag log file corruption.
+         */
+        if (reclen > log_size - __wt_lsn_offset(&rd_lsn)) {
+            need_salvage = true;
+            WT_ERR(__log_salvage_message(
+              session, log_fh->name, " record length oversize", __wt_lsn_offset(&rd_lsn)));
+        }
+        /*
          * Log files are pre-allocated. We need to detect the difference between a hole in the file
          * (where this location would be considered the end of log) and the last record in the log
          * and we're at the zeroed part of the file. If we find a zeroed record, scan forward in the
@@ -2307,15 +2316,6 @@ advance:
             WT_ERR(
               __log_fs_read(session, log_fh, __wt_lsn_offset(&rd_lsn), (size_t)rdup_len, buf->mem));
             WT_STAT_CONN_INCR(session, log_scan_rereads);
-        }
-        /*
-         * If the record length is larger than the remaining bytes to EOF from the records offset,
-         * flag log file corruption.
-         */
-        if (reclen > log_size - __wt_lsn_offset(&rd_lsn)) {
-            need_salvage = true;
-            WT_ERR(__log_salvage_message(
-              session, log_fh->name, " record length oversize", __wt_lsn_offset(&rd_lsn)));
         }
         /*
          * We read in the record, now verify the checksum. A failed checksum does not imply

--- a/src/support/pow.c
+++ b/src/support/pow.c
@@ -121,9 +121,11 @@ __wt_rduppo2(uint32_t n, uint32_t po2)
     if (__wt_ispo2(po2)) {
         bits = __wt_log2_int(po2);
         res = (((n - 1) >> bits) + 1) << bits;
+        /*
+         * This assert is designed to avoid overflow for large values.
+         */
+        WT_ASSERT(NULL, res >= n);
     } else
         res = 0;
-    /* This assert is designed to avoid overflow for large values. */
-    WT_ASSERT(NULL, res >= n);
     return (res);
 }

--- a/src/support/pow.c
+++ b/src/support/pow.c
@@ -124,6 +124,6 @@ __wt_rduppo2(uint32_t n, uint32_t po2)
     } else
         res = 0;
     /* This assert is designed to avoid overflow for large values. */
-    WT_ASSERT(NULL, res > n);
+    WT_ASSERT(NULL, res >= n);
     return (res);
 }

--- a/src/support/pow.c
+++ b/src/support/pow.c
@@ -123,5 +123,7 @@ __wt_rduppo2(uint32_t n, uint32_t po2)
         res = (((n - 1) >> bits) + 1) << bits;
     } else
         res = 0;
+    /* This assert is designed to avoid overflow for large values. */
+    WT_ASSERT(NULL, res > n);
     return (res);
 }

--- a/src/support/pow.c
+++ b/src/support/pow.c
@@ -121,9 +121,7 @@ __wt_rduppo2(uint32_t n, uint32_t po2)
     if (__wt_ispo2(po2)) {
         bits = __wt_log2_int(po2);
         res = (((n - 1) >> bits) + 1) << bits;
-        /*
-         * This assert is designed to avoid overflow for large values.
-         */
+        /* This assert is designed to avoid overflow for large values. */
         WT_ASSERT(NULL, res >= n);
     } else
         res = 0;

--- a/test/suite/test_log05.py
+++ b/test/suite/test_log05.py
@@ -30,16 +30,16 @@ import os, re, struct
 import wttest
 from helper import WiredTigerCursor
 
-# test_verify03.py
+# test_log05.py
 #    This test simulates log file corruption by manually setting
 #    a log records length field to UINT32_MAX. The expected behavior is that
 #    the record-length validation fails, salvage is invoked, and recovery
-#    completes successfully. By repeating this corruptrecover cycle,
+#    completes successfully. By repeating this recovery cycle,
 #    the test also verifies that recovery does not create additional log files
 #    and that disk space usage remains stable.
-class test_verify03(wttest.WiredTigerTestCase):
+class test_log05(wttest.WiredTigerTestCase):
 
-    uri = 'table:verify03'
+    uri = 'table:log05'
 
     conn_config = 'log=(enabled=true)'
 

--- a/test/suite/test_txn19.py
+++ b/test/suite/test_txn19.py
@@ -299,7 +299,7 @@ class test_txn19(wttest.WiredTigerTestCase, suite_subprocess):
                     self.reopen_conn(newdir, self.base_config)
             else:
                 self.reopen_conn(newdir, self.base_config)
-                # Check corrupted by invalid record length
+                # The test may corrupt logs, ignore the error messages.
                 out_text = self.readStdout()
                 if re.search('log file .* corrupted record length oversize', out_text):
                     self.cleanStdout()

--- a/test/suite/test_txn19.py
+++ b/test/suite/test_txn19.py
@@ -34,7 +34,7 @@
 #   Transactions: test recovery with corrupted log files
 #
 
-import os
+import os, re
 from wtscenario import make_scenarios
 from suite_subprocess import suite_subprocess
 import helper, wiredtiger, wttest
@@ -299,6 +299,10 @@ class test_txn19(wttest.WiredTigerTestCase, suite_subprocess):
                     self.reopen_conn(newdir, self.base_config)
             else:
                 self.reopen_conn(newdir, self.base_config)
+                # Check corrupted by invalid record length
+                out_text = self.readStdout()
+                if re.search('log file .* corrupted record length oversize', out_text):
+                    self.cleanStdout()
             self.close_conn()
 
         found_records = self.recovered_records()

--- a/test/suite/test_verify03.py
+++ b/test/suite/test_verify03.py
@@ -26,7 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import re, struct
+import os, re, struct
 import wttest
 from helper import WiredTigerCursor
 
@@ -40,6 +40,8 @@ class test_verify(wttest.WiredTigerTestCase):
 
     WT_TURTLE_FILE_NAME = "WiredTiger.turtle"
     WT_LOG_FILE = "WiredTigerLog.0000000%03d"
+
+    test_round = 20
 
     def extract_key_from_turtle(self, line, key):
         m = re.search(key + r'=\(\s*(\d+)\s*,\s*(\d+)\s*\)', line)
@@ -70,12 +72,17 @@ class test_verify(wttest.WiredTigerTestCase):
             for i in range(1000):
                 c[f'key_{i}'] = f'val_{i}'
         self.session.commit_transaction()
-        
-        for i in range(10):
-            try:
-                self.close_conn()
-                self.inject_faulty_to_log(i+1)
-                with self.expectedStdoutPattern("orrupted record length oversize at position"):
-                    self.open_conn()
-            except Exception as e:
-                print(e)
+
+        for i in range(self.test_round):
+            self.close_conn()
+            self.inject_faulty_to_log(i+1)
+            with self.expectedStdoutPattern("orrupted record length oversize at position"):
+                self.open_conn()
+
+        logs_count = 0
+        for i in range(self.test_round):
+            if os.path.exists(self.WT_LOG_FILE % (i+1)):
+                logs_count += 1
+
+        # This assert aims to make sure no redundant log file is generated.
+        self.assertEqual(logs_count, 1, "We should only have 1 log")

--- a/test/suite/test_verify03.py
+++ b/test/suite/test_verify03.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import re, struct
+import wttest
+from helper import WiredTigerCursor
+
+# test_verify.py
+#    Utilities: wt verify
+class test_verify(wttest.WiredTigerTestCase):
+
+    uri = 'table:verify03'
+
+    conn_config = 'log=(enabled=true),statistics=(all),statistics_log=(json,wait=1,on_close=true,sources=[file:])'
+
+    WT_TURTLE_FILE_NAME = "WiredTiger.turtle"
+    WT_LOG_FILE = "WiredTigerLog.0000000%03d"
+
+    def extract_key_from_turtle(self, line, key):
+        m = re.search(key + r'=\(\s*(\d+)\s*,\s*(\d+)\s*\)', line)
+        if not m:
+            return None
+        file_num, offset = map(int, m.groups())
+        return (file_num, offset)
+
+    def inject_faulty_to_log(self, id):
+        # Read checkpoint lsn
+        with open(self.WT_TURTLE_FILE_NAME, 'r') as f:
+            lines = f.read().splitlines()
+            self.turtle_file = lines
+        for line in lines:
+            value = self.extract_key_from_turtle(line, 'checkpoint_lsn')
+            if value is not None:
+                break
+        self.assertTrue(value is not None, "Checkpoint lsn is missing in turtle file")
+        _, offset = value
+        with open(self.WT_LOG_FILE % id, 'r+b') as f:
+            f.seek(offset)
+            f.write(struct.pack('<I', 0xFFFFFFFF))
+
+    def test_duplicate_logs(self):
+        self.session.create(self.uri, "key_format=S,value_format=S")
+        self.session.begin_transaction()
+        with WiredTigerCursor(self.session, self.uri) as c:
+            for i in range(1000):
+                c[f'key_{i}'] = f'val_{i}'
+        self.session.commit_transaction()
+        
+        for i in range(10):
+            try:
+                self.close_conn()
+                self.inject_faulty_to_log(i+1)
+                with self.expectedStdoutPattern("orrupted record length oversize at position"):
+                    self.open_conn()
+            except Exception as e:
+                print(e)

--- a/test/suite/test_verify03.py
+++ b/test/suite/test_verify03.py
@@ -30,13 +30,18 @@ import os, re, struct
 import wttest
 from helper import WiredTigerCursor
 
-# test_verify.py
-#    Utilities: wt verify
-class test_verify(wttest.WiredTigerTestCase):
+# test_verify03.py
+#    This test simulates log file corruption by manually setting
+#    a log records length field to UINT32_MAX. The expected behavior is that
+#    the record-length validation fails, salvage is invoked, and recovery
+#    completes successfully. By repeating this corruptrecover cycle,
+#    the test also verifies that recovery does not create additional log files
+#    and that disk space usage remains stable.
+class test_verify03(wttest.WiredTigerTestCase):
 
     uri = 'table:verify03'
 
-    conn_config = 'log=(enabled=true),statistics=(all),statistics_log=(json,wait=1,on_close=true,sources=[file:])'
+    conn_config = 'log=(enabled=true)'
 
     WT_TURTLE_FILE_NAME = "WiredTiger.turtle"
     WT_LOG_FILE = "WiredTigerLog.0000000%03d"
@@ -50,8 +55,10 @@ class test_verify(wttest.WiredTigerTestCase):
         file_num, offset = map(int, m.groups())
         return (file_num, offset)
 
-    def inject_faulty_to_log(self, id):
-        # Read checkpoint lsn
+    def inject_fault_to_log(self, id):
+        # Read checkpoint_lsn from turtle file.
+        # The checkpoint_lsn points to the byte offset (in its log file)
+        # of the checkpoint log record structure.
         with open(self.WT_TURTLE_FILE_NAME, 'r') as f:
             lines = f.read().splitlines()
             self.turtle_file = lines
@@ -61,6 +68,8 @@ class test_verify(wttest.WiredTigerTestCase):
                 break
         self.assertTrue(value is not None, "Checkpoint lsn is missing in turtle file")
         _, offset = value
+        # The first four bytes of each log record are parsed as a 32-bit unsigned length.
+        # To simulate corruption, overwrite these bytes to UINT32_MAX.
         with open(self.WT_LOG_FILE % id, 'r+b') as f:
             f.seek(offset)
             f.write(struct.pack('<I', 0xFFFFFFFF))
@@ -75,8 +84,8 @@ class test_verify(wttest.WiredTigerTestCase):
 
         for i in range(self.test_round):
             self.close_conn()
-            self.inject_faulty_to_log(i+1)
-            with self.expectedStdoutPattern("orrupted record length oversize at position"):
+            self.inject_fault_to_log(i+1)
+            with self.expectedStdoutPattern("corrupted record length oversize at position"):
                 self.open_conn()
 
         logs_count = 0
@@ -85,4 +94,4 @@ class test_verify(wttest.WiredTigerTestCase):
                 logs_count += 1
 
         # This assert aims to make sure no redundant log file is generated.
-        self.assertLessEqual(logs_count, 1, "We should have utmost 1 log file")
+        self.assertLessEqual(logs_count, 1, "We should have at most 1 log file")

--- a/test/suite/test_verify03.py
+++ b/test/suite/test_verify03.py
@@ -85,4 +85,4 @@ class test_verify(wttest.WiredTigerTestCase):
                 logs_count += 1
 
         # This assert aims to make sure no redundant log file is generated.
-        self.assertEqual(logs_count, 1, "We should only have 1 log")
+        self.assertLessEqual(logs_count, 1, "We should have utmost 1 log file")


### PR DESCRIPTION
Add a record length check to avoid `overflow` with roundup operation, also add assert to the function to identify potential overflow in the future.

Also add a new test case to modify the record length binary directly to trigger the check. 