### PR TITLE
WT-16401 Remove redundant allocation while parsing metadata

### DIFF
--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -729,13 +729,6 @@ __disagg_fetch_shared_meta(
         }
     }
 
-    /* !!!
-     * FIXME-WT-16386 Config parser reads beyond config length limit
-     * Add a zero terminator to the metadata buffer for safe parsing.
-     */
-    WT_ERR(__wt_buf_grow(session, item, item->size + 1));
-    ((char *)item->data)[item->size] = '\0';
-
 err:
     return (ret);
 }


### PR DESCRIPTION
- Once WT-16386 is fixed, remove unnecessary allocations.
- Metadata buffer does not have to be zero-terminated to be parsed correctly.