### PR TITLE
WT-16211 Re-enable verify in test/format with deltas

### DIFF
--- a/test/format/verify.c
+++ b/test/format/verify.c
@@ -43,18 +43,6 @@ table_verify(TABLE *table, void *arg)
     conn = (WT_CONNECTION *)arg;
     testutil_assert(table != NULL);
 
-    /*
-     * FIXME-WT-16211: We can run verify on layered tables when deltas are written as a full image.
-     *
-     * Remove this check once both tickets are resolved.
-     */
-    if (TV(DISAGG_ENABLED) && (GV(DISAGG_LEAF_PAGE_DELTA) || GV(DISAGG_INTERNAL_PAGE_DELTA))) {
-        printf("table.%u skipped verify because verify does not support disagg delta pages.\n",
-          table->id);
-        fflush(stdout);
-        return;
-    }
-
     memset(&sap, 0, sizeof(sap));
     wt_wrap_open_session(conn, &sap, table->track_prefix,
       enable_session_prefetch() ? SESSION_PREFETCH_CFG_ON : NULL, &session);

--- a/test/model/src/core/verify.cpp
+++ b/test/model/src/core/verify.cpp
@@ -181,7 +181,7 @@ kv_table_verifier::verify(WT_CONNECTION *connection, kv_checkpoint_ptr ckpt)
          * calling verify to avoid EBUSY. We don't need to tolerate non-fatal errors for the final
          * step.
          *
-         * FIXME-WT-16211: The disaggregated check should go away once it's ready.
+         * FIXME-WT-16404: The disaggregated check should go away once it's ready.
          */
         if (!_table.is_disaggregated()) {
             ret = session->verify(session, uri.c_str(), "strict");


### PR DESCRIPTION
Test/format disagg runs can now trigger verify whether deltas are enabled or not.