### PR TITLE
WT-16406 Ensure ref addr and ref page are updated together in page rewrite

### DIFF
--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -2479,7 +2479,6 @@ __wt_split_rewrite(WT_SESSION_IMPL *session, WT_REF *ref, WT_MULTI *multi, bool 
 
     /* If there's an address, copy it. */
     if (multi->addr.block_cookie != NULL) {
-        WT_ASSERT(session, page->disagg_info != NULL);
         WT_ERR(__wt_calloc_one(session, &addr));
         WT_TIME_AGGREGATE_COPY(&addr->ta, &multi->addr.ta);
         WT_ERR(__wt_memdup(

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -502,7 +502,7 @@ __evict_page_dirty_update(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_
                 *addr = mod->mod_replace;
                 mod->mod_replace.block_cookie = NULL;
                 mod->mod_replace.block_cookie_size = 0;
-                ref->addr = addr;
+                __wt_tsan_suppress_store_wt_addr_ptr(&ref->addr, addr);
             } else
                 WT_ASSERT(
                   session, F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED) && ref->addr != NULL);

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -502,7 +502,7 @@ __evict_page_dirty_update(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_
                 *addr = mod->mod_replace;
                 mod->mod_replace.block_cookie = NULL;
                 mod->mod_replace.block_cookie_size = 0;
-                __wt_tsan_suppress_store_wt_addr_ptr(&ref->addr, addr);
+                ref->addr = addr;
             } else
                 WT_ASSERT(
                   session, F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED) && ref->addr != NULL);


### PR DESCRIPTION
In the old code, ref addr and ref page may become inconsistent if __wt_split_rewrite fail. Fix this issue by rely on __wt_split_rewrite to update the ref addr and ref page together instead of doing it separately.