### PR TITLE
WT-15051 Fix search near fails due to unset key in layered cursor

### DIFF
--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -893,10 +893,10 @@ err:
     if (ret == 0)
         __clayered_deleted_decode(&cursor->value);
     else {
-        __clayered_reset_cursors(clayered, false);
         F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
+        if (ret != WT_PREPARE_CONFLICT)
+            __clayered_reset_cursors(clayered, false);
     }
-
     return (ret);
 }
 
@@ -1323,8 +1323,9 @@ err:
 
         if (value == &cursor->value)
             F_SET(cursor, WT_CURSTD_VALUE_INT);
-    } else {
+    } else if (ret != WT_PREPARE_CONFLICT) {
         WT_TRET(__clayered_reset_cursors(clayered, false));
+        F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
     }
 
     return (ret);
@@ -1507,11 +1508,13 @@ err:
     if (closest != NULL)
         WT_TRET(closest->reset(closest));
 
-    F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
     if (ret == 0) {
+        F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
         F_SET(cursor, WT_CURSTD_KEY_INT | WT_CURSTD_VALUE_INT);
-    } else
+    } else if (ret != WT_PREPARE_CONFLICT) {
+        F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
         clayered->current_cursor = NULL;
+    }
 
     API_END_RET(session, ret);
 }

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -1325,7 +1325,6 @@ err:
             F_SET(cursor, WT_CURSTD_VALUE_INT);
     } else if (ret != WT_PREPARE_CONFLICT) {
         WT_TRET(__clayered_reset_cursors(clayered, false));
-        F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
     }
 
     return (ret);

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -1323,9 +1323,8 @@ err:
 
         if (value == &cursor->value)
             F_SET(cursor, WT_CURSTD_VALUE_INT);
-    } else if (ret != WT_PREPARE_CONFLICT) {
+    } else if (ret != WT_PREPARE_CONFLICT)
         WT_TRET(__clayered_reset_cursors(clayered, false));
-    }
 
     return (ret);
 }

--- a/test/checkpoint/test_checkpoint.c
+++ b/test/checkpoint/test_checkpoint.c
@@ -278,7 +278,7 @@ main(int argc, char *argv[])
               stderr, "disaggregated storage feature doesn't supports named checkpoints (-c)");
             return (EXIT_FAILURE);
         }
-        /* FIXME-WT-15051 Disagg is not support prepared operations yet. */
+        /* FIXME-WT-15795 Disagg is not support prepared operations yet. */
         if (g.prepare == true) {
             fprintf(
               stderr, "disaggregated storage feature doesn't supports prepare operations (-p)");

--- a/test/format/CONFIG.disagg
+++ b/test/format/CONFIG.disagg
@@ -21,6 +21,7 @@ ops.compaction=0
 ops.salvage=0
 ops.throttle=0
 ops.truncate=0
+# FIXME-WT-15795 should allow prepared operations for layered tables.
 ops.prepare=0
 quiet=0
 runs.in_memory=0

--- a/test/format/CONFIG.disagg
+++ b/test/format/CONFIG.disagg
@@ -21,7 +21,6 @@ ops.compaction=0
 ops.salvage=0
 ops.throttle=0
 ops.truncate=0
-# FIXME-WT-15051 should allow prepared operations for layered tables.
 ops.prepare=0
 quiet=0
 runs.in_memory=0

--- a/test/suite/test_layered73.py
+++ b/test/suite/test_layered73.py
@@ -116,7 +116,7 @@ class test_layered73(wttest.WiredTigerTestCase):
 
         # next() should encounter the prepared key 2 and return prepare conflict
         self.assertRaisesException(wiredtiger.WiredTigerError, lambda: cursor.next())
-        self.assertRaisesException(wiredtiger.WiredTigerError, lambda: cursor.get_key())
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda: cursor.get_key(),  "/requires key be set/")
 
         # After prepare conflict, key state should be preserved
         # Calling prev() should return the previous key
@@ -151,6 +151,7 @@ class test_layered73(wttest.WiredTigerTestCase):
 
         # prev() should encounter the prepared key 4
         self.assertRaisesException(wiredtiger.WiredTigerError, lambda: cursor.prev())
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError, lambda: cursor.get_key(),  "/requires key be set/")
 
         # After prepare conflict, key state should be preserved
         # Calling next() should return the next key

--- a/test/suite/test_layered73.py
+++ b/test/suite/test_layered73.py
@@ -42,8 +42,13 @@ class test_layered73(wttest.WiredTigerTestCase):
     tablename = 'test_layered73'
     uri = 'layered:' + tablename
 
+    resolve_scenarios = [
+        ('commit', dict(commit = True)),
+        ('rollback', dict(commit = False)),
+    ]
+
     disagg_storages = gen_disagg_storages('test_layered73', disagg_only=True)
-    scenarios = make_scenarios(disagg_storages)
+    scenarios = make_scenarios(disagg_storages, resolve_scenarios)
 
     conn_base_config = 'cache_size=10MB,statistics=(all),precise_checkpoint=true,preserve_prepared=true,'
 
@@ -51,7 +56,6 @@ class test_layered73(wttest.WiredTigerTestCase):
         return self.conn_base_config + 'disaggregated=(role="follower")'
 
     def setup_table_with_data(self, keys):
-        """Create table and insert committed data at the given keys."""
         self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10))
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10))
 
@@ -90,12 +94,21 @@ class test_layered73(wttest.WiredTigerTestCase):
         self.session.begin_transaction('read_timestamp=' + self.timestamp_str(60))
 
         cursor.set_key(2)
-        # Assert that search_near should return a prepare conflict and the key is persisted
+        # Assert that search_near should return a prepare conflict and the cursor position doesn't reset
         self.assertRaisesException(wiredtiger.WiredTigerError, lambda: cursor.search_near())
         retrieved_key = cursor.get_key()
         self.assertEqual(retrieved_key, 2,
                 "Key should be preserved after WT_PREPARE_CONFLICT")
-        prepare_session.rollback_transaction()
+
+        if self.commit:
+            prepare_session.breakpoint()
+            prepare_session.commit_transaction('commit_timestamp=' + self.timestamp_str(60)+',durable_timestamp='+self.timestamp_str(60))
+            # Key 2 is now committed so calling search_near() again should return the committed value
+            self.assertEqual(cursor.search_near(), 0)
+            self.assertEqual(cursor.get_key(), 2)
+            self.assertEqual(cursor.get_value(), "prepared_value")
+        else:
+            prepare_session.rollback_transaction()
         prepare_cursor.close()
 
     def test_next_key_preserved_on_prepare_conflict(self):
@@ -125,15 +138,19 @@ class test_layered73(wttest.WiredTigerTestCase):
         self.assertEqual(retrieved_key, 1,
                 "Key should be preserved after WT_PREPARE_CONFLICT on next()")
 
-        prepare_session.rollback_transaction()
+        if self.commit:
+            prepare_session.breakpoint()
+            prepare_session.commit_transaction('commit_timestamp=' + self.timestamp_str(60)+',durable_timestamp='+self.timestamp_str(60))
+            # Key 2 is now committed so calling next() should return key 2
+            self.assertEqual(cursor.next(), 0)
+            self.assertEqual(cursor.get_key(), 2)
+            self.assertEqual(cursor.get_value(), "prepared_value")
+        else:
+            prepare_session.rollback_transaction()
+
         prepare_cursor.close()
 
     def test_prev_key_preserved_on_prepare_conflict(self):
-        """
-        Test that prev() preserves key state when WT_PREPARE_CONFLICT is returned.
-
-        This tests cursor positioning after encountering a prepared key during reverse traversal.
-        """
         # Setup: keys 1, 3, 5 committed
         self.setup_table_with_data([1, 3, 5])
 
@@ -160,5 +177,13 @@ class test_layered73(wttest.WiredTigerTestCase):
         self.assertEqual(retrieved_key, 5,
                 "Key should be preserved after WT_PREPARE_CONFLICT on prev()")
 
-        prepare_session.rollback_transaction()
+        if self.commit:
+            prepare_session.commit_transaction('commit_timestamp=' + self.timestamp_str(60)+',durable_timestamp='+self.timestamp_str(60))
+            # Key 4 is now committed so calling prev() should return key 4
+            self.assertEqual(cursor.prev(), 0)
+            self.assertEqual(cursor.get_key(), 4)
+            self.assertEqual(cursor.get_value(), "prepared_value")
+        else:
+            prepare_session.rollback_transaction()
+
         prepare_cursor.close()

--- a/test/suite/test_layered73.py
+++ b/test/suite/test_layered73.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# test_layered73.py
+#   Test layered cursor prepare conflict handling
+#   - Verify cursor key state is preserved when WT_PREPARE_CONFLICT is returned
+#   - Ensure retry loops work correctly after prepare conflicts
+#   - Test search, search_near, next, and prev operations
+
+import wiredtiger
+import wttest
+from helper_disagg import disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
+
+@disagg_test_class
+class test_layered73(wttest.WiredTigerTestCase):
+    tablename = 'test_layered73'
+    uri = 'layered:' + tablename
+
+    disagg_storages = gen_disagg_storages('test_layered73', disagg_only=True)
+    scenarios = make_scenarios(disagg_storages)
+
+    conn_base_config = 'cache_size=10MB,statistics=(all),precise_checkpoint=true,preserve_prepared=true,'
+
+    def conn_config(self):
+        return self.conn_base_config + 'disaggregated=(role="follower")'
+
+    def setup_table_with_data(self, keys):
+        """Create table and insert committed data at the given keys."""
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10))
+
+        self.session.create(self.uri, 'key_format=i,value_format=S')
+        cursor = self.session.open_cursor(self.uri)
+
+        self.session.begin_transaction()
+        for key in keys:
+            cursor[key] = f"value_{key}"
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(20))
+
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(20))
+        cursor.close()
+
+    def prepare_key_in_separate_session(self, key, value, prepare_ts=50):
+        prepare_session = self.conn.open_session()
+        prepare_cursor = prepare_session.open_cursor(self.uri)
+
+        prepare_session.begin_transaction()
+        prepare_cursor[key] = value
+        prepare_session.prepare_transaction(
+            'prepare_timestamp=' + self.timestamp_str(prepare_ts) +
+            ',prepared_id=' + self.prepared_id_str(1))
+
+        return prepare_session, prepare_cursor
+
+    def test_search_near_key_preserved_on_prepare_conflict(self):
+        # Setup: keys 1, 3, 5 committed
+        self.setup_table_with_data([1, 3, 5])
+
+        # Prepare a transaction on key 2 (between 1 and 3)
+        prepare_session, prepare_cursor = self.prepare_key_in_separate_session(2, "prepared_value")
+
+        # Open cursor and set key to search for prepared key
+        cursor = self.session.open_cursor(self.uri)
+        self.session.begin_transaction('read_timestamp=' + self.timestamp_str(60))
+
+        cursor.set_key(2)
+        # Assert that search_near should return a prepare conflict and the key is persisted
+        self.assertRaisesException(wiredtiger.WiredTigerError, lambda: cursor.search_near())
+        retrieved_key = cursor.get_key()
+        self.assertEqual(retrieved_key, 2,
+                "Key should be preserved after WT_PREPARE_CONFLICT")
+        prepare_session.rollback_transaction()
+        prepare_cursor.close()
+
+    def test_next_key_preserved_on_prepare_conflict(self):
+        # Setup: keys 1, 3, 5 committed
+        self.setup_table_with_data([1, 3, 5])
+
+        # Prepare a transaction on key 2 (between 1 and 3)
+        prepare_session, prepare_cursor = self.prepare_key_in_separate_session(2, "prepared_value")
+
+        # Open cursor and position at key 1, then try to move next (should hit prepared key 2)
+        cursor = self.session.open_cursor(self.uri)
+        self.session.begin_transaction('read_timestamp=' + self.timestamp_str(60))
+
+        cursor.set_key(1)
+        self.assertEqual(cursor.search(), 0)
+        retrieved_key = cursor.get_key()
+        self.assertEqual(retrieved_key, 1, "Should be positioned at key 1")
+
+        # next() should encounter the prepared key 2 and return prepare conflict
+        self.assertRaisesException(wiredtiger.WiredTigerError, lambda: cursor.next())
+        self.assertRaisesException(wiredtiger.WiredTigerError, lambda: cursor.get_key())
+
+        # After prepare conflict, key state should be preserved
+        # Calling prev() should return the previous key
+        self.assertEqual(cursor.prev(), 0)
+        retrieved_key = cursor.get_key()
+        self.assertEqual(retrieved_key, 1,
+                "Key should be preserved after WT_PREPARE_CONFLICT on next()")
+
+        prepare_session.rollback_transaction()
+        prepare_cursor.close()
+
+    def test_prev_key_preserved_on_prepare_conflict(self):
+        """
+        Test that prev() preserves key state when WT_PREPARE_CONFLICT is returned.
+
+        This tests cursor positioning after encountering a prepared key during reverse traversal.
+        """
+        # Setup: keys 1, 3, 5 committed
+        self.setup_table_with_data([1, 3, 5])
+
+        # Prepare a transaction on key 4 (between 3 and 5)
+        prepare_session, prepare_cursor = self.prepare_key_in_separate_session(4, "prepared_value")
+
+        # Open cursor and position at key 5, then try to move prev (should hit prepared key 4)
+        cursor = self.session.open_cursor(self.uri)
+        self.session.begin_transaction('read_timestamp=' + self.timestamp_str(60))
+
+        cursor.set_key(5)
+        self.assertEqual(cursor.search(), 0)
+        retrieved_key = cursor.get_key()
+        self.assertEqual(retrieved_key, 5, "Should be positioned at key 5")
+
+        # prev() should encounter the prepared key 4
+        self.assertRaisesException(wiredtiger.WiredTigerError, lambda: cursor.prev())
+
+        # After prepare conflict, key state should be preserved
+        # Calling next() should return the next key
+        self.assertEqual(cursor.next(), 0)
+        retrieved_key = cursor.get_key()
+        self.assertEqual(retrieved_key, 5,
+                "Key should be preserved after WT_PREPARE_CONFLICT on prev()")
+
+        prepare_session.rollback_transaction()
+        prepare_cursor.close()

--- a/test/suite/test_prepare_discover07.py
+++ b/test/suite/test_prepare_discover07.py
@@ -44,7 +44,7 @@ class test_prepare_discover07(wttest.WiredTigerTestCase):
     uri = 'layered:' + tablename
 
     resolve_scenarios = [
-        # FIXME-WT-15051 handle searching for committed prepared tombstone on standby
+        # FIXME-WT-16530 handle searching for committed prepared tombstone on standby
         # ('commit', dict(commit=True)),
         ('rollback', dict(commit=False)),
     ]


### PR DESCRIPTION
Currently, if an iteration or search_near operation in layered cursor return a `PREPARE_CONFLICT` error, the cursor position will be reset, which is an inconsistent behaviour comparing to the normal cursor. This PR fixes the issue by only resetting cursor position if the return error is `PREPARE_CONFLICT`.