### PR TITLE
WT-16321 Fix memory leak from test_backup11

### DIFF
--- a/src/cursor/cur_backup.c
+++ b/src/cursor/cur_backup.c
@@ -717,6 +717,7 @@ err:
         F_CLR(cb, WT_CURBACKUP_CONSOLIDATE);
         F_SET(cb, consolidate);
     }
+    __backup_free(session, cb);
     __wt_scr_free(session, &tmp);
     return (ret);
 }

--- a/src/cursor/cur_backup.c
+++ b/src/cursor/cur_backup.c
@@ -712,12 +712,14 @@ __backup_config(WT_SESSION_IMPL *session, WT_CURSOR_BACKUP *cb, const char *cfg[
     }
 
 err:
-    if (ret != 0 && cb->incr_src != NULL) {
-        F_CLR(cb->incr_src, WT_BLKINCR_INUSE);
-        F_CLR(cb, WT_CURBACKUP_CONSOLIDATE);
-        F_SET(cb, consolidate);
+    if (ret != 0) {
+        WT_TRET(__backup_free(session, cb));
+        if (cb->incr_src != NULL) {
+            F_CLR(cb->incr_src, WT_BLKINCR_INUSE);
+            F_CLR(cb, WT_CURBACKUP_CONSOLIDATE);
+            F_SET(cb, consolidate);
+        }
     }
-    __backup_free(session, cb);
     __wt_scr_free(session, &tmp);
     return (ret);
 }

--- a/test/evergreen/asan_leaks.supp
+++ b/test/evergreen/asan_leaks.supp
@@ -10,10 +10,6 @@ leak:__tiered_open
 # FIXME-WT-16291: test_verify.test_verify.test_verify_api_75pct_null
 leak:__wt_blkcache_read_multi
 
-# FIXME-WT-16321: test_backup11
-leak:__backup_list_append
-leak:__backup_config
-
 # FIXME-WT-16325: test_bug035
 leak:__wt_metadata_btree_id_to_uri
 


### PR DESCRIPTION
Fix an asan leak by calling free in `backup_config` error path. 