### PR TITLE
WT-16323 Memory leak from test_prefetch01

### DIFF
--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -2560,15 +2560,19 @@ __open_session(WT_CONNECTION_IMPL *conn, WT_EVENT_HANDLER *event_handler, const 
      */
     WT_ASSERT(session, !F_ISSET_ATOMIC_32(conn, WT_CONN_CLOSING));
 
+    bool out_of_sessions = false;
+
     /* Find the first inactive session slot. */
     for (session_ret = WT_CONN_SESSIONS_GET(conn), i = 0; i < conn->session_array.size;
          ++session_ret, ++i)
         if (!session_ret->active)
             break;
-    if (i == conn->session_array.size)
+    if (i == conn->session_array.size) {
+        out_of_sessions = true;
         WT_ERR_MSG(session, WT_ERROR,
           "out of sessions, configured for %" PRIu32 " (including internal sessions)",
           conn->session_array.size);
+    }
 
     /*
      * If the active session count is increasing, update it. We don't worry about correcting the
@@ -2700,7 +2704,7 @@ err:
 #ifdef HAVE_DIAGNOSTIC
     __wt_spin_destroy(session, &session->thread_check.lock);
 #endif
-    if (ret != 0 && session_ret != NULL)
+    if (ret != 0 && session_ret != NULL && !out_of_sessions)
         __wt_txn_destroy(session_ret);
     __wt_spin_unlock(session, &conn->api_lock);
     return (ret);

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -2701,6 +2701,8 @@ err:
     __wt_spin_destroy(session, &session->thread_check.lock);
 #endif
     __wt_spin_unlock(session, &conn->api_lock);
+    if (ret != 0 && session_ret != NULL)
+        __wt_txn_destroy(session_ret);
     return (ret);
 }
 

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -2700,9 +2700,9 @@ err:
 #ifdef HAVE_DIAGNOSTIC
     __wt_spin_destroy(session, &session->thread_check.lock);
 #endif
-    __wt_spin_unlock(session, &conn->api_lock);
     if (ret != 0 && session_ret != NULL)
         __wt_txn_destroy(session_ret);
+    __wt_spin_unlock(session, &conn->api_lock);
     return (ret);
 }
 

--- a/test/evergreen/asan_leaks.supp
+++ b/test/evergreen/asan_leaks.supp
@@ -34,9 +34,6 @@ leak:__wt_dlopen
 # FIXME-WT-16329: test_layered44
 leak:__wt_meta_ckptlist_set
 
-# FIXME-WT-16323: test_prefetch01
-leak:__wt_txn_init
-
 # FIXME-WT-16330: test_schema02
 leak:__schema_open_table
 


### PR DESCRIPTION
We initialise the transaction before checking whether the config is valid during reconfiguration, and when reconfiguration fails we didn't free the initialised transaction, causing a memory leak. This pR fixes this issue and frees the transaction when we fail to create a session.