### PR TITLE
WT-16329 Remove suppression

### DIFF
--- a/test/evergreen/asan_leaks.supp
+++ b/test/evergreen/asan_leaks.supp
@@ -31,9 +31,6 @@ leak:__chunkcache_metadata_queue_internal
 # FIXME-WT-16328: test_layered08
 leak:__wt_dlopen
 
-# FIXME-WT-16329: test_layered44
-leak:__wt_meta_ckptlist_set
-
 # FIXME-WT-16323: test_prefetch01
 leak:__wt_txn_init
 


### PR DESCRIPTION
I tried to get a warning from this function running many tests including test_layered44 but it seems like it's gone away somehow so I am removing the suppression.