### PR TITLE
WT-16267 Revert atomic statistics for performance

### DIFF
--- a/src/os_common/os_alloc.c
+++ b/src/os_common/os_alloc.c
@@ -63,7 +63,7 @@ __wt_calloc(WT_SESSION_IMPL *session, size_t number, size_t size, void *retp)
     WT_ASSERT(session, number != 0 && size != 0);
 
     if (session != NULL)
-        WT_STAT_CONN_INCR_ATOMIC(session, memory_allocation);
+        WT_STAT_CONN_INCR(session, memory_allocation);
 
     if ((p = calloc(number, size)) == NULL)
         WT_RET_MSG(session, __wt_errno(), "memory allocation of %" WT_SIZET_FMT " bytes failed",
@@ -94,7 +94,7 @@ __wt_malloc(WT_SESSION_IMPL *session, size_t bytes_to_allocate, void *retp)
     WT_ASSERT(session, bytes_to_allocate != 0);
 
     if (session != NULL)
-        WT_STAT_CONN_INCR_ATOMIC(session, memory_allocation);
+        WT_STAT_CONN_INCR(session, memory_allocation);
 
     if ((p = malloc(bytes_to_allocate)) == NULL)
         WT_RET_MSG(session, __wt_errno(), "memory allocation of %" WT_SIZET_FMT " bytes failed",

--- a/src/os_posix/os_mtx_cond.c
+++ b/src/os_posix/os_mtx_cond.c
@@ -73,7 +73,7 @@ __wt_cond_wait_signal(WT_SESSION_IMPL *session, WT_CONDVAR *cond, uint64_t usecs
     }
 
     __wt_verbose_debug2(session, WT_VERB_MUTEX, "wait %s", cond->name);
-    WT_STAT_CONN_INCR_ATOMIC(session, cond_wait);
+    WT_STAT_CONN_INCR(session, cond_wait);
 
     WT_ERR(pthread_mutex_lock(&cond->mtx));
     locked = true;

--- a/src/os_win/os_mtx_cond.c
+++ b/src/os_win/os_mtx_cond.c
@@ -53,7 +53,7 @@ __wt_cond_wait_signal(WT_SESSION_IMPL *session, WT_CONDVAR *cond, uint64_t usecs
         return;
 
     __wt_verbose_debug2(session, WT_VERB_MUTEX, "wait %s", cond->name);
-    WT_STAT_CONN_INCR_ATOMIC(session, cond_wait);
+    WT_STAT_CONN_INCR(session, cond_wait);
 
     EnterCriticalSection(&cond->mtx);
     locked = true;

--- a/src/support/mtx_rw.c
+++ b/src/support/mtx_rw.c
@@ -127,7 +127,7 @@ __wt_try_readlock(WT_SESSION_IMPL *session, WT_RWLOCK *l)
     WT_RWLOCK new, old;
     int64_t **stats;
 
-    WT_STAT_CONN_INCR_ATOMIC(session, rwlock_read);
+    WT_STAT_CONN_INCR(session, rwlock_read);
     if (l->stat_read_count_off != -1 && WT_STAT_ENABLED(session)) {
         stats = (int64_t **)S2C(session)->stats;
         __wt_atomic_add_int64_relaxed(&stats[session->stat_conn_bucket][l->stat_read_count_off], 1);
@@ -183,7 +183,7 @@ __wt_readlock(WT_SESSION_IMPL *session, WT_RWLOCK *l)
     uint8_t ticket;
     int pause_cnt;
 
-    WT_STAT_CONN_INCR_ATOMIC(session, rwlock_read);
+    WT_STAT_CONN_INCR(session, rwlock_read);
 
     WT_DIAGNOSTIC_YIELD;
 
@@ -332,7 +332,7 @@ __wt_try_writelock(WT_SESSION_IMPL *session, WT_RWLOCK *l)
     WT_RWLOCK new, old;
     int64_t **stats;
 
-    WT_STAT_CONN_INCR_ATOMIC(session, rwlock_write);
+    WT_STAT_CONN_INCR(session, rwlock_write);
     if (l->stat_write_count_off != -1 && WT_STAT_ENABLED(session)) {
         stats = (int64_t **)S2C(session)->stats;
         __wt_atomic_add_int64_relaxed(

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -237,7 +237,7 @@ __txn_get_snapshot_int(WT_SESSION_IMPL *session, bool update_shared_state)
 
     /* Walk the array of concurrent transactions. */
     WT_ACQUIRE_READ_WITH_BARRIER(session_cnt, conn->session_array.cnt);
-    WT_STAT_CONN_INCR_ATOMIC(session, txn_walk_sessions);
+    WT_STAT_CONN_INCR(session, txn_walk_sessions);
     for (i = 0, s = txn_global->txn_shared_list; i < session_cnt; i++, s++) {
         /*
          * Build our snapshot of any concurrent transaction IDs.
@@ -278,7 +278,7 @@ __txn_get_snapshot_int(WT_SESSION_IMPL *session, bool update_shared_state)
             WT_PAUSE();
         }
     }
-    WT_STAT_CONN_INCRV_ATOMIC(session, txn_sessions_walked, i);
+    WT_STAT_CONN_INCRV(session, txn_sessions_walked, i);
 
     /*
      * If we got a new snapshot, update the published pinned ID for this session.
@@ -399,7 +399,7 @@ __txn_oldest_scan(WT_SESSION_IMPL *session, uint64_t *oldest_idp, uint64_t *last
 
     /* Walk the array of concurrent transactions. */
     WT_ACQUIRE_READ_WITH_BARRIER(session_cnt, conn->session_array.cnt);
-    WT_STAT_CONN_INCR_ATOMIC(session, txn_walk_sessions);
+    WT_STAT_CONN_INCR(session, txn_walk_sessions);
     for (i = 0, s = txn_global->txn_shared_list; i < session_cnt; i++, s++) {
         /* Update the last running transaction ID. */
         while ((id = __wt_atomic_load_uint64_v_relaxed(&s->id)) != WT_TXN_NONE &&
@@ -444,7 +444,7 @@ __txn_oldest_scan(WT_SESSION_IMPL *session, uint64_t *oldest_idp, uint64_t *last
             oldest_session = &WT_CONN_SESSIONS_GET(conn)[i];
         }
     }
-    WT_STAT_CONN_INCRV_ATOMIC(session, txn_sessions_walked, i);
+    WT_STAT_CONN_INCRV(session, txn_sessions_walked, i);
 
     if (last_running < oldest_id)
         oldest_id = last_running;


### PR DESCRIPTION
Found from multiple performance analyses the added suppressions for multiple data races in statistics WT-15345 introduced a small performance regression evident in our performance changepoint. 

From WT-15345, i have reverted all connection atomic increments and reverted it to use relaxed vses sequential consistency. As a result the performance has come back.