### PR TITLE
WT-16325 Memory leak from test_bug035

### DIFF
--- a/src/history/hs_verify.c
+++ b/src/history/hs_verify.c
@@ -204,6 +204,7 @@ __hs_verify(WT_SESSION_IMPL *session, uint32_t hs_id)
         }
 
         WT_ERR(ds_cursor->close(ds_cursor));
+        __wt_free(session, uri_data);
     }
 err:
     __wt_scr_free(session, &buf);

--- a/src/history/hs_verify.c
+++ b/src/history/hs_verify.c
@@ -177,6 +177,8 @@ __hs_verify(WT_SESSION_IMPL *session, uint32_t hs_id)
 
     /* Go through the history store and validate each btree. */
     while (ret == 0) {
+        if (uri_data)
+            __wt_free(session, uri_data);
         /*
          * The cursor is positioned either from above or left over from the internal call on the
          * first key of a new btree id.
@@ -204,7 +206,6 @@ __hs_verify(WT_SESSION_IMPL *session, uint32_t hs_id)
         }
 
         WT_ERR(ds_cursor->close(ds_cursor));
-        __wt_free(session, uri_data);
     }
 err:
     __wt_scr_free(session, &buf);

--- a/src/history/hs_verify.c
+++ b/src/history/hs_verify.c
@@ -177,8 +177,7 @@ __hs_verify(WT_SESSION_IMPL *session, uint32_t hs_id)
 
     /* Go through the history store and validate each btree. */
     while (ret == 0) {
-        if (uri_data)
-            __wt_free(session, uri_data);
+        __wt_free(session, uri_data);
         /*
          * The cursor is positioned either from above or left over from the internal call on the
          * first key of a new btree id.

--- a/test/evergreen/asan_leaks.supp
+++ b/test/evergreen/asan_leaks.supp
@@ -11,9 +11,6 @@ leak:__tiered_open
 leak:__backup_list_append
 leak:__backup_config
 
-# FIXME-WT-16325: test_bug035
-leak:__wt_metadata_btree_id_to_uri
-
 # FIXME-WT-16322: test_checkpoint13
 leak:__curfile_create
 

--- a/test/evergreen/asan_leaks.supp
+++ b/test/evergreen/asan_leaks.supp
@@ -11,9 +11,6 @@ leak:__tiered_open
 leak:__backup_list_append
 leak:__backup_config
 
-# FIXME-WT-16322: test_checkpoint13
-leak:__curfile_create
-
 # FIXME-WT-16326: test_chunkcache01
 leak:__tier_do_operation
 leak:__create_and_populate_chunk


### PR DESCRIPTION
This PR fixes a memory leak caused by memory allocated inside a loop not being freed after each iteration.