### PR TITLE
WT-16332 Memory leak in __create_colgroup

### DIFF
--- a/src/schema/schema_create.c
+++ b/src/schema/schema_create.c
@@ -625,9 +625,11 @@ __create_colgroup(WT_SESSION_IMPL *session, const char *name, bool exclusive, co
             sourcecfg[config == NULL ? 0 : 1] = fmt.data;
         }
 
+        __wt_free(session, sourceconf);
         WT_ERR(__wt_config_merge(session, sourcecfg, NULL, &sourceconf));
         WT_ERR(__wt_schema_create(session, source, sourceconf));
 
+        __wt_free(session, cgconf);
         WT_ERR(__wt_config_collapse(session, cfg, &cgconf));
 
         /* FIXME-WT-12021 Replace this with a proper failpoint once the framework is available. */
@@ -646,9 +648,6 @@ __create_colgroup(WT_SESSION_IMPL *session, const char *name, bool exclusive, co
 
         /* Reset the last filled configuration for the next column group. */
         *--cfgp = NULL;
-
-        __wt_free(session, cgconf);
-        __wt_free(session, sourceconf);
     }
 
 err:

--- a/src/schema/schema_create.c
+++ b/src/schema/schema_create.c
@@ -646,6 +646,9 @@ __create_colgroup(WT_SESSION_IMPL *session, const char *name, bool exclusive, co
 
         /* Reset the last filled configuration for the next column group. */
         *--cfgp = NULL;
+
+        __wt_free(session, cgconf);
+        __wt_free(session, sourceconf);
     }
 
 err:

--- a/test/evergreen/asan_leaks.supp
+++ b/test/evergreen/asan_leaks.supp
@@ -30,9 +30,6 @@ leak:__schema_open_table
 # FIXME-WT-16331: test_tiered04
 leak:__tiered_name_str
 
-# FIXME-WT-16332: test_tiered18
-leak:__create_colgroup
-
 # FIXME-WT-16083: Resolve the warnings and remove the suppressions.
 leak:_PyBytes_FromSize
 leak:_wrap__wiredtiger_calc_modify


### PR DESCRIPTION
Free `sourceconf` and `cgconf` allocated in each `for (i = 0; i < ncolgroups; i++)` iteration in `__create_colgroup`