### PR TITLE
WT-16436 Skip page discard verify if get_page_ids is not implemented

### DIFF
--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -316,7 +316,8 @@ __wt_verify(WT_SESSION_IMPL *session, const char *cfg[])
              * page discard function if we're in disagg mode.
              */
             if (ret == 0 && (ckpt + 1)->name == NULL) {
-                /* The page discard verification routine depends on get_page_ids being implemented. */
+                /* The page discard verification routine depends on get_page_ids being implemented.
+                 */
                 if (F_ISSET(btree, WT_BTREE_DISAGGREGATED) && ckpt->raw.data &&
                   bm->get_page_ids != NULL)
                     WT_TRET(__verify_page_discard(session, bm));

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -316,6 +316,7 @@ __wt_verify(WT_SESSION_IMPL *session, const char *cfg[])
              * page discard function if we're in disagg mode.
              */
             if (ret == 0 && (ckpt + 1)->name == NULL) {
+                /* The page discard verification routine depends on get_page_ids being implemented. */
                 if (F_ISSET(btree, WT_BTREE_DISAGGREGATED) && ckpt->raw.data &&
                   bm->get_page_ids != NULL)
                     WT_TRET(__verify_page_discard(session, bm));

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -316,7 +316,8 @@ __wt_verify(WT_SESSION_IMPL *session, const char *cfg[])
              * page discard function if we're in disagg mode.
              */
             if (ret == 0 && (ckpt + 1)->name == NULL) {
-                if (F_ISSET(btree, WT_BTREE_DISAGGREGATED) && ckpt->raw.data)
+                if (F_ISSET(btree, WT_BTREE_DISAGGREGATED) && ckpt->raw.data &&
+                  bm->get_page_ids != NULL)
                     WT_TRET(__verify_page_discard(session, bm));
 
                 if (!skip_hs) {


### PR DESCRIPTION
Check get_page_ids is implemented before running verify to prevent unnecessary tree walk and assert failure.  