### PR TITLE
WT-16375 Turn off failpoint when calling cursor->close() 

### DIFF
--- a/test/suite/test_ovfl01.py
+++ b/test/suite/test_ovfl01.py
@@ -39,7 +39,8 @@ class test_ovfl01(wttest.WiredTigerTestCase):
     #     - Set a very small leaf_key_max. Keys larger than this will be stored as overflow keys.
     #.    - Set a small leaf_page_max to create more leaf pages and page splits.
     table_config = 'key_format=S,value_format=S,leaf_key_max=10B,leaf_value_max=10B,leaf_page_max=4KB'
-    conn_config = 'cache_size=100MB,statistics=(all),timing_stress_for_test=(failpoint_rec_split_write)'
+    base_conn_config = 'cache_size=100MB,statistics=(all)'
+    conn_config = base_conn_config + ',timing_stress_for_test=(failpoint_rec_split_write)'
     uri = 'table:test_ovfl01'
 
     num_keys = 10 * 1000
@@ -61,16 +62,10 @@ class test_ovfl01(wttest.WiredTigerTestCase):
                     raise e
 
         # Closing the cursor might hit the failpoint if the page needs to split during
-        # reconciliation, try again if this occurs.
-        while True:
-            try:
-                c.close()
-                return
-            except wiredtiger.WiredTigerError as e:
-                self.pr(f'close error: {str(e)}')
-                if str(e) != os.strerror(errno.EBUSY):
-                    raise e
-
+        # reconciliation, therefore turn off the failpoint.
+        self.conn.reconfigure(self.base_conn_config)
+        c.close()
+            
     def test_ovfl01(self):
         # Create and populate a table.
         self.session.create(self.uri, self.table_config)

--- a/test/suite/test_ovfl01.py
+++ b/test/suite/test_ovfl01.py
@@ -39,8 +39,7 @@ class test_ovfl01(wttest.WiredTigerTestCase):
     #     - Set a very small leaf_key_max. Keys larger than this will be stored as overflow keys.
     #.    - Set a small leaf_page_max to create more leaf pages and page splits.
     table_config = 'key_format=S,value_format=S,leaf_key_max=10B,leaf_value_max=10B,leaf_page_max=4KB'
-    base_conn_config = 'cache_size=100MB,statistics=(all)'
-    conn_config = base_conn_config + ',timing_stress_for_test=(failpoint_rec_split_write)'
+    conn_config = 'cache_size=100MB,statistics=(all),timing_stress_for_test=(failpoint_rec_split_write)'
     uri = 'table:test_ovfl01'
 
     num_keys = 10 * 1000
@@ -63,7 +62,7 @@ class test_ovfl01(wttest.WiredTigerTestCase):
 
         # Closing the cursor might hit the failpoint if the page needs to split during
         # reconciliation, therefore turn off the failpoint.
-        self.conn.reconfigure(self.base_conn_config + ',timing_stress_for_test=()')
+        self.conn.reconfigure('timing_stress_for_test=()')
         c.close()
 
     def test_ovfl01(self):

--- a/test/suite/test_ovfl01.py
+++ b/test/suite/test_ovfl01.py
@@ -63,7 +63,7 @@ class test_ovfl01(wttest.WiredTigerTestCase):
 
         # Closing the cursor might hit the failpoint if the page needs to split during
         # reconciliation, therefore turn off the failpoint.
-        self.conn.reconfigure(self.base_conn_config)
+        self.conn.reconfigure(self.base_conn_config + ',timing_stress_for_test=()')
         c.close()
 
     def test_ovfl01(self):

--- a/test/suite/test_ovfl01.py
+++ b/test/suite/test_ovfl01.py
@@ -65,7 +65,7 @@ class test_ovfl01(wttest.WiredTigerTestCase):
         # reconciliation, therefore turn off the failpoint.
         self.conn.reconfigure(self.base_conn_config)
         c.close()
-            
+
     def test_ovfl01(self):
         # Create and populate a table.
         self.session.create(self.uri, self.table_config)


### PR DESCRIPTION
The issue was introduced from [WT-15739](https://jira.mongodb.org/browse/WT-15739) which mentions a fix behind dangling overflow items due to an EBUSY returned from __rec_split_write. 

The resolution of WT-15739 was that the origin of errors returned from reconciliation, and overflow items during bulk is unclear. The EBUSY returned is added through the failpoint. There are no theoretical case that we do encounter an error during cursor->close(). Therefore turn off the failpoint while performing cursor close in the python test.