### PR TITLE
WT-16282 test/format (disagg multi node) Synchronise leader and follower

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1681,6 +1681,27 @@ variables:
           format_args: disagg.mode=switch ops.verify=1 runs.mirror=1 table1.runs.source=table table1.disagg.enabled=0 runs.timer=5:10
           times: 5
 
+  - &format-stress-test-disagg-multi
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "format test disagg"
+        vars:
+          format_args: disagg.multi=1 runs.predictable_replay=1 runs.ops=500000:2000000
+          times: 5
+
+  - &format-stress-test-disagg-multi-data-validation
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "format test disagg"
+        vars:
+          # Validate data with a non-layered table.
+          format_args: disagg.multi=1 runs.predictable_replay=1 ops.verify=1 disagg.multi_validation=1 runs.ops=500000:2000000
+          times: 5
+
 #######################################
 #               Tasks                 #
 #######################################
@@ -4758,6 +4779,18 @@ tasks:
     tags: ["stress-test-disagg-fail"]
   - <<: *format-stress-test-disagg-switch-data-validation
     name: format-stress-test-disagg-switch-data-validation-3
+    tags: ["stress-test-disagg-fail"]
+  - <<: *format-stress-test-disagg-multi
+    name: format-stress-test-disagg-multi-1
+    tags: ["stress-test-disagg-fail", "stress-test-disagg-san-fail"]
+  - <<: *format-stress-test-disagg-multi
+    name: format-stress-test-disagg-multi-2
+    tags: ["stress-test-disagg-fail"]
+  - <<: *format-stress-test-disagg-multi-data-validation
+    name: format-stress-test-disagg-multi-validation-1
+    tags: ["stress-test-disagg-fail"]
+  - <<: *format-stress-test-disagg-multi-data-validation
+    name: format-stress-test-disagg-multi-validation-2
     tags: ["stress-test-disagg-fail"]
 
   - name: format-stress-test-disagg-leader-pull-request

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -35,6 +35,7 @@
 #include <sys/resource.h>
 #endif
 #include <signal.h>
+#include <sys/socket.h>
 
 #define BUILDDIR "../../"
 #define EXTPATH BUILDDIR "ext/" /* Extensions path */
@@ -211,8 +212,8 @@ extern u_int ntables;
 #define DATASOURCE(table, ds) (strcmp((table)->v[V_TABLE_RUNS_SOURCE].vstr, ds) == 0)
 
 typedef struct {
-    wt_shared volatile uint64_t leader_hash;
-    wt_shared volatile uint64_t follower_hash;
+    uint64_t leader_hash;
+    uint64_t follower_hash;
 } DISAGG_MULTI_DB_HASH;
 
 typedef struct {
@@ -311,6 +312,7 @@ typedef struct {
     pid_t follower_pid; /* For multi-node disagg follower process */
     char checkpoint_metadata[FILENAME_MAX]; /* Last checkpoint metadata picked up by follower. */
     DISAGG_MULTI_DB_HASH *disagg_multi_db_hash; /* Leader and follower database hash */
+    int disagg_multi_sync_socket;               /* Socket for leader-follower sync */
 
     bool column_store_config;           /* At least one column-store table configured */
     bool disagg_storage_config;         /* If disaggregated storage is configured */
@@ -462,7 +464,7 @@ bool disagg_is_multi_node(void);
 void disagg_setup_multi_node(void);
 void disagg_switch_roles(void);
 void disagg_teardown_multi_node(void);
-void disagg_validate_multi_node(WT_SESSION *);
+void disagg_sync_multi_node(WT_SESSION *);
 bool enable_session_prefetch(void);
 void fclose_and_clear(FILE **);
 void follower_read_latest_checkpoint(void);

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -212,8 +212,8 @@ extern u_int ntables;
 #define DATASOURCE(table, ds) (strcmp((table)->v[V_TABLE_RUNS_SOURCE].vstr, ds) == 0)
 
 typedef struct {
-    uint64_t leader_hash;
-    uint64_t follower_hash;
+    wt_shared uint64_t leader_hash;
+    wt_shared uint64_t follower_hash;
 } DISAGG_MULTI_DB_HASH;
 
 typedef struct {

--- a/test/format/format_disagg.c
+++ b/test/format/format_disagg.c
@@ -148,6 +148,7 @@ disagg_multi_sync_point(void)
     /* Signal from leader or follower to synchronize. */
     if (write(g.disagg_multi_sync_socket, &send, 1) != 1)
         testutil_die(errno, "disagg_multi_sync_point: write");
+
     track("Reached sync point. Waiting for other process...", 0ULL);
 
     /* Wait for synchronization signal from the other process. */
@@ -162,28 +163,30 @@ disagg_multi_sync_point(void)
 void
 disagg_sync_multi_node(WT_SESSION *session)
 {
+    uint64_t hash = 0;
     if (!disagg_is_multi_node())
         return;
 
-    uint64_t *hash = NULL;
     if (GV(DISAGG_MULTI_VALIDATION)) {
-        hash = g.disagg_leader ? &g.disagg_multi_db_hash->leader_hash :
-                                 &g.disagg_multi_db_hash->follower_hash;
-        *hash = checksum_database(session);
+        hash = checksum_database(session);
+        if (g.disagg_leader)
+            g.disagg_multi_db_hash->leader_hash = hash;
+        else
+            g.disagg_multi_db_hash->follower_hash = hash;
     }
 
     /* Initial synchronization between leader and follower processes. */
     disagg_multi_sync_point();
 
-    if (!GV(DISAGG_MULTI_VALIDATION))
-        return;
+    if (GV(DISAGG_MULTI_VALIDATION)) {
+        if (g.disagg_leader)
+            testutil_assert(hash == g.disagg_multi_db_hash->follower_hash);
+        else
+            testutil_assert(hash == g.disagg_multi_db_hash->leader_hash);
 
-    testutil_assert(*hash ==
-      (g.disagg_leader ? g.disagg_multi_db_hash->follower_hash :
-                         g.disagg_multi_db_hash->leader_hash));
-
-    /* Exit synchronization between leader and follower processes. */
-    disagg_multi_sync_point();
+        /* Exit synchronization between leader and follower processes. */
+        disagg_multi_sync_point();
+    }
 }
 
 /*

--- a/test/format/format_disagg.c
+++ b/test/format/format_disagg.c
@@ -65,9 +65,11 @@ disagg_teardown_multi_node(void)
 
     if (g.follower_pid > 0) { /* Parent: leader */
         /* Wait for the follower process to exit. */
+        track("Waiting for follower to finish execution.", 0ULL);
         testutil_timeout_wait(120, g.follower_pid);
         g.follower_pid = 0;
     }
+    close(g.disagg_multi_sync_socket);
     testutil_check(munmap(g.disagg_multi_db_hash, sizeof(DISAGG_MULTI_DB_HASH)));
     g.disagg_multi_db_hash = NULL;
 }
@@ -80,6 +82,7 @@ void
 disagg_setup_multi_node(void)
 {
     pid_t pid;
+    int sv[2];
     char follower_home[256];
 
     if (!disagg_is_multi_node())
@@ -107,6 +110,10 @@ disagg_setup_multi_node(void)
       MAP_SHARED | MAP_ANONYMOUS, -1, 0);
     testutil_assert_errno(g.disagg_multi_db_hash != MAP_FAILED);
 
+    /* Create a socket pair for leader-follower synchronization.*/
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) == -1)
+        testutil_die(errno, "Failed to create socket pair for leader-follower sync");
+
     fflush(NULL);
     pid = fork();
     testutil_assert_errno(pid >= 0);
@@ -115,38 +122,68 @@ disagg_setup_multi_node(void)
         config_single(NULL, "disagg.mode=follower", true);
         path_setup(follower_home);
         disagg_redirect_output("follower.out");
+        close(sv[0]);
+        g.disagg_multi_sync_socket = sv[1];
     } else { /* Parent: leader */
         progname = "t[leader]";
         config_single(NULL, "disagg.mode=leader", true);
         disagg_redirect_output("leader.out");
+        close(sv[1]);
+        g.disagg_multi_sync_socket = sv[0];
     }
 
     g.follower_pid = pid;
 }
 
 /*
- * disagg_validate_multi_node --
- *     Validate the data between leader and follower in multi-node disagg mode.
+ * disagg_multi_sync_point --
+ *     Synchronization point in disagg multi-node setup for leader-follower.
+ */
+static void
+disagg_multi_sync_point(void)
+{
+    char send = 'S'; /* S for sync */
+    char recv;
+
+    /* Signal from leader or follower to synchronize. */
+    if (write(g.disagg_multi_sync_socket, &send, 1) != 1)
+        testutil_die(errno, "disagg_multi_sync_point: write");
+    track("Reached sync point. Waiting for other process...", 0ULL);
+
+    /* Wait for synchronization signal from the other process. */
+    if (read(g.disagg_multi_sync_socket, &recv, 1) != 1)
+        testutil_die(errno, "disagg_multi_sync_point: read");
+}
+
+/*
+ * disagg_sync_multi_node --
+ *     Synchronization point in disagg multi-node setup for leader-follower data validation.
  */
 void
-disagg_validate_multi_node(WT_SESSION *session)
+disagg_sync_multi_node(WT_SESSION *session)
 {
     if (!disagg_is_multi_node())
         return;
 
+    uint64_t *hash = NULL;
+    if (GV(DISAGG_MULTI_VALIDATION)) {
+        hash = g.disagg_leader ? &g.disagg_multi_db_hash->leader_hash :
+                                 &g.disagg_multi_db_hash->follower_hash;
+        *hash = checksum_database(session);
+    }
+
+    /* Initial synchronization between leader and follower processes. */
+    disagg_multi_sync_point();
+
     if (!GV(DISAGG_MULTI_VALIDATION))
         return;
 
-    volatile uint64_t *hash = g.disagg_leader ? &g.disagg_multi_db_hash->leader_hash :
-                                                &g.disagg_multi_db_hash->follower_hash;
-    *hash = checksum_database(session);
+    testutil_assert(*hash ==
+      (g.disagg_leader ? g.disagg_multi_db_hash->follower_hash :
+                         g.disagg_multi_db_hash->leader_hash));
 
-    /* FIXME-WT-16282 Synchronize leader and follower and validate hashes. */
-    if (g.disagg_leader)
-        printf(
-          "Leader received follower hash: %" PRIu64 "\n", g.disagg_multi_db_hash->follower_hash);
-    else
-        printf("Follower received leader hash: %" PRIu64 "\n", g.disagg_multi_db_hash->leader_hash);
+    /* Exit synchronization between leader and follower processes. */
+    disagg_multi_sync_point();
 }
 
 /*

--- a/test/format/format_disagg_multi.sh
+++ b/test/format/format_disagg_multi.sh
@@ -13,11 +13,11 @@ trap 'onintr' 2
 
 usage() {
     echo "usage: $0"
-    echo "    -h home      run directory (defaults to RUNDIR)"
+    echo "    -h home      run directory (defaults to $home_dir)"
     echo "    -c config    custom config file (defaults to CONFIG.disagg)"
-    echo "    -v           enable multi-node validation"
-    echo "    -r rows      rows range for multi-node disagg (default:100000:500000)"
-    echo "    -o ops       ops range for multi-node disagg (default:500000:2000000)"
+    echo "    -v           enable multi-node validation (default: disabled)"
+    echo "    -r rows      rows range for multi-node disagg (default:$rows_val)"
+    echo "    -o ops       ops range for multi-node disagg (default:$ops_val)"
     exit 1
 }
 

--- a/test/format/format_disagg_multi.sh
+++ b/test/format/format_disagg_multi.sh
@@ -14,15 +14,35 @@ trap 'onintr' 2
 usage() {
     echo "usage: $0"
     echo "    -h home      run directory (defaults to RUNDIR)"
+    echo "    -c config    custom config file (defaults to CONFIG.disagg)"
+    echo "    -v           enable multi-node validation"
+    echo "    -r rows      rows range for multi-node disagg (default:100000:500000)"
+    echo "    -o ops       ops range for multi-node disagg (default:500000:2000000)"
     exit 1
 }
 
 home_dir="RUNDIR"
+custom_config=""
+multi_validation_val=0
+rows_val="100000:500000"
+ops_val="500000:2000000"
 
 while :; do
     case $1 in
     -h | --home)
         home_dir="$2"
+        shift ; shift ;;
+    -c | --config)
+        custom_config="$2"
+        shift ; shift ;;
+    -v | --validation)
+        multi_validation_val=1
+        shift ;;
+    -r | --rows)
+        rows_val="$2"
+        shift ; shift ;;
+    -o | --ops)
+        ops_val="$2"
         shift ; shift ;;
     -?*)
         usage
@@ -38,9 +58,15 @@ if [ $# -ne 0 ]; then
     usage
 fi
 
+if [ -n "$custom_config" ]; then
+    CONFIG="$custom_config"
+    DISAGG_MULTI_CONFIG=""
+else
+    CONFIG="../../../test/format/CONFIG.disagg"
+    DISAGG_MULTI_CONFIG="disagg.multi=1 runs.predictable_replay=1 disagg.multi_validation=$multi_validation_val runs.rows=$rows_val runs.ops=$ops_val "
+fi
+
 PROG="./t"
-CONFIG="../../../test/format/CONFIG.disagg"
-DISAGG_MULTI_CONFIG="disagg.multi=1 disagg.multi_validation=1 runs.predictable_replay=1 runs.rows=100000:500000 runs.ops=5000000:20000000 "
 LEADER_LOG="$home_dir/leader.out"
 FOLLOWER_LOG="$home_dir/follower/follower.out"
 SESSION_NAME="format_disagg_multi_node"
@@ -62,8 +88,8 @@ msg "Database directory: $home_dir"
 # Run the test in background
 tmux new-session -d -s "$SESSION_NAME" -n "run" \
     "clear; \
-     echo '${CYAN}Running: $PROG -h $home_dir -c $CONFIG $DISAGG_MULTI_CONFIG $LIMIT_CONFIG${RESET}'; echo; \
-     $PROG -h $home_dir -c $CONFIG $DISAGG_MULTI_CONFIG $LIMIT_CONFIG; \
+     echo '${CYAN}Running: $PROG -h $home_dir -c $CONFIG $DISAGG_MULTI_CONFIG${RESET}'; echo; \
+     $PROG -h $home_dir -c $CONFIG $DISAGG_MULTI_CONFIG; \
      echo; \
      echo '${GREEN}Program finished. Press Ctrl-c :kill-session to close.${RESET}'; \
      read -p 'Press Enter to exit...'"

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -500,7 +500,7 @@ operations(u_int ops_seconds, u_int run_current, u_int run_total)
      */
     rollback_to_stable(session);
 
-    disagg_validate_multi_node(session);
+    disagg_sync_multi_node(session);
 
     replay_run_end(session);
 

--- a/test/format/t.c
+++ b/test/format/t.c
@@ -431,14 +431,14 @@ skip_operations:
 
     trace_teardown();
 
+    disagg_teardown_multi_node();
+
     /* Overwrite the progress line with a completion line. */
     if (!GV(QUIET))
         printf("\r%78s\r", " ");
     __wt_seconds(NULL, &now);
     printf("%s: successful run completed (%" PRIu64 " seconds)\n ", progname, now - start);
     fflush(stdout);
-
-    disagg_teardown_multi_node();
 
     config_clear();
 


### PR DESCRIPTION
I used socketpair for synchronisation (signal) and shared memory for hashes. The logic implements a double-barrier synchronisation. I initially attempted to use named semaphores, but faced compatibility issues on macOS. I also considered using shared murexes, but they introduced too much complexity for this specific requirement.

I ultimately settled on socketpair as it is offers system compatbility, much simpler to implmented and is pretty lightweight.