### PR TITLE
WT-16428 Parse jsonl from getTableAtLSN response

### DIFF
--- a/tools/py_common/page_service.py
+++ b/tools/py_common/page_service.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# Data structures for decoding pages from the page service.
+import enum
+
+class UpdateTypeFlags(enum.IntFlag):
+    '''
+    Update types as defined in page_service.proto
+    '''
+    UPDATE_TYPE_DELTA = 0
+    UPDATE_TYPE_FULL_IMAGE = 1
+    UPDATE_TYPE_TOMBSTONE = 2
+    UPDATE_TYPE_CHECKPOINT_END = 3

--- a/tools/wt_binary_decode.py
+++ b/tools/wt_binary_decode.py
@@ -815,7 +815,9 @@ def decrypt_page(page):
         raise FileNotFoundError(
             "pagedecryptor not found: Decryption requires the 'pagedecryptor' tool from the MongoDB "
             "encryption module. Please install the tool and ensure the 'pagedecryptor' binary is on your "
-            "PATH."
+            "PATH.\n"
+            "Hint - compile from the mongo repo with:\n"
+            "bazel build //src/mongo/db/modules/atlas/src/disagg_storage/encryption:pagedecryptor"
         )
         
     if not opts.keyfile or not os.path.exists(opts.keyfile):

--- a/tools/wt_binary_decode.py
+++ b/tools/wt_binary_decode.py
@@ -1047,7 +1047,8 @@ def get_arg_parser():
     parser.add_argument('--continue', help="continue on checksum failure", dest='cont', action='store_true')
     parser.add_argument('-D', '--debug', help="debug this tool", action='store_true')
     parser.add_argument('-d', '--dumpin', help="input is hex dump (may be embedded in log messages)", action='store_true')
-    parser.add_argument('--disagg_table', help="input is a full disagg table", action='store_true')
+    parser.add_argument('--disagg_table', help="input is a full disagg table from the GetTableAtLSN endpoint on the Object Read Proxy (ORP). \
+        The table can be downloaded from S3 as a jsonl file containing all of the pages linked to a table_id. ", action='store_true')
     parser.add_argument('--disagg', help="input comes from disaggregated storage", action='store_true')
     parser.add_argument('--ext', help="dump only the extent lists", action='store_true')
     parser.add_argument('-f', '--fragment', help="input file is a fragment, does not have a WT file header", action='store_true')

--- a/tools/wt_binary_decode.py
+++ b/tools/wt_binary_decode.py
@@ -892,7 +892,7 @@ def disagg_metadata_string(page):
         f"  table_id: {metadata.get('table_id', {}).get('val', {}).get('IntVal', 'None')}\n"
         f"  lsn: {page.get('lsn', {}).get('lsn', 'None')}\n"
         f"  base_lsn: {metadata.get('base_lsn', {}).get('val', {}).get('LongVal', 'None')}\n"
-        f"  backlinkLsn: {metadata.get('backlink_lsn', {}).get('val', {}).get('LongVal', 'None')}"
+        f"  backlink_lsn: {metadata.get('backlink_lsn', {}).get('val', {}).get('LongVal', 'None')}"
     )
     
     return meta_string

--- a/tools/wt_binary_decode.py
+++ b/tools/wt_binary_decode.py
@@ -839,46 +839,46 @@ def decrypt_page(page):
     base_lsn = metadata.get('base_lsn', {}).get('val', {}).get('LongVal')
     backlink_lsn = metadata.get('backlink_lsn', {}).get('val', {}).get('LongVal')
     
-    temp_input = tempfile.NamedTemporaryFile(mode='w', delete=True, suffix='.in')
-    temp_output = tempfile.NamedTemporaryFile(mode='rb', delete=True, suffix='.out')
+    with tempfile.NamedTemporaryFile(mode='w', delete=True, suffix='.in') as temp_input, \
+         tempfile.NamedTemporaryFile(mode='rb', delete=True, suffix='.out') as temp_output:
     
-    # Write the page bytes to the temporary input file. The decrypt tool expects a file containing a
-    # base64 encoded byte string.
-    entry_bytes = page.get('entry', [])
-    raw_bytes = bytes(entry_bytes)
-    base64_encoded = base64.b64encode(raw_bytes)
-    temp_input.write(base64_encoded.decode('ascii'))
-    temp_input.flush()
-    
-    cmd = [
-        'pagedecryptor',
-        '--inputPath', temp_input.name,
-        '--outputPath', temp_output.name,
-        '--keyFile', opts.keyfile,
-        '--lsn', str(lsn),
-        '--tableId', str(table_id),
-        '--pageId', str(page_id),
-    ]
-    
-    if base_lsn is not None:
-        cmd.extend(['--baseLsn', str(base_lsn)])
-    if backlink_lsn is not None:
-        cmd.extend(['--backlinkLsn', str(backlink_lsn)])
+        # Write the page bytes to the temporary input file. The decrypt tool expects a file containing a
+        # base64 encoded byte string.
+        entry_bytes = page.get('entry', [])
+        raw_bytes = bytes(entry_bytes)
+        base64_encoded = base64.b64encode(raw_bytes)
+        temp_input.write(base64_encoded.decode('ascii'))
+        temp_input.flush()
         
-    if metadata.get('flags', {}).get("val", {}).get("IntVal", {}) == page_service.UpdateTypeFlags.UPDATE_TYPE_DELTA:
-        cmd.extend(['--isDelta'])
-    
-    try:
-        decrypt_result = subprocess.run(cmd, capture_output=True, text=True, check=True)
-        if (opts.debug):
-            print(f'pagedecryptor stdout: {decrypt_result.stdout}')
-            print(f'pagedecryptor stderr: {decrypt_result.stderr}')
-    except subprocess.CalledProcessError as e:
-        print(f"Error decrypting page {page_id}: {e}", file=sys.stderr)
-        print(f"pagedecryptor stderr: {e.stderr}", file=sys.stderr)
-        raise
+        cmd = [
+            'pagedecryptor',
+            '--inputPath', temp_input.name,
+            '--outputPath', temp_output.name,
+            '--keyFile', opts.keyfile,
+            '--lsn', str(lsn),
+            '--tableId', str(table_id),
+            '--pageId', str(page_id),
+        ]
         
-    decrypted_bytes = temp_output.read()
+        if base_lsn is not None:
+            cmd.extend(['--baseLsn', str(base_lsn)])
+        if backlink_lsn is not None:
+            cmd.extend(['--backlinkLsn', str(backlink_lsn)])
+            
+        if metadata.get('flags', {}).get("val", {}).get("IntVal", {}) == page_service.UpdateTypeFlags.UPDATE_TYPE_DELTA:
+            cmd.extend(['--isDelta'])
+        
+        try:
+            decrypt_result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+            if (opts.debug):
+                print(f'pagedecryptor stdout: {decrypt_result.stdout}')
+                print(f'pagedecryptor stderr: {decrypt_result.stderr}')
+        except subprocess.CalledProcessError as e:
+            print(f"Error decrypting page {page_id}: {e}", file=sys.stderr)
+            print(f"pagedecryptor stderr: {e.stderr}", file=sys.stderr)
+            raise
+        
+        decrypted_bytes = temp_output.read()
     
     return decrypted_bytes
 

--- a/tools/wt_binary_decode.py
+++ b/tools/wt_binary_decode.py
@@ -32,8 +32,8 @@
 # see "wt dump" for that.  But this is standalone (doesn't require linkage with any WT
 # libraries), and may be useful as 1) a learning tool 2) quick way to hack/extend dumping.
 
-import codecs, io, os, re, sys, traceback, pprint, json
-from py_common import binary_data, btree_format
+import codecs, io, os, re, sys, traceback, pprint, json, shutil, tempfile, subprocess, base64
+from py_common import binary_data, btree_format, page_service
 from dataclasses import dataclass
 import typing
 binary_to_pretty_string = binary_data.binary_to_pretty_string  # a convenient function nam
@@ -806,6 +806,136 @@ def encode_bytes(f):
             allbytes += b
     return allbytes
 
+def decrypt_page(page):
+    """
+    Call the pagedecryptor tool from the mongo repo.
+    """
+    
+    if not shutil.which('pagedecryptor'):
+        raise FileNotFoundError(
+            "pagedecryptor not found: Decryption requires the 'pagedecryptor' tool from the MongoDB "
+            "encryption module. Please install the tool and ensure the 'pagedecryptor' binary is on your "
+            "PATH."
+        )
+        
+    if not opts.keyfile or not os.path.exists(opts.keyfile):
+        raise FileNotFoundError(
+            "keyfile not found: Decryption requires the test_keyfile for the KEK."
+        )
+        
+    # Mandatory fields for decryption
+    metadata = page.get('metadata', {})
+    page_id = metadata.get('page_id', {}).get('val', {}).get('LongVal')
+    if page_id is None:
+        raise ValueError(f"Missing 'page_id' in page: {page}")
+    lsn = page.get('lsn', {}).get('lsn')
+    if lsn is None:
+        raise ValueError(f"Missing 'lsn' in page: {page_id}")
+    table_id = metadata.get('table_id', {}).get('val', {}).get('IntVal')
+    if table_id is None:
+        raise ValueError(f"Missing 'table_id' in page: {page_id}")
+    
+    # Optional fields depending on the page type.
+    base_lsn = metadata.get('base_lsn', {}).get('val', {}).get('LongVal')
+    backlink_lsn = metadata.get('backlink_lsn', {}).get('val', {}).get('LongVal')
+    
+    temp_input = tempfile.NamedTemporaryFile(mode='w', delete=True, suffix='.in')
+    temp_output = tempfile.NamedTemporaryFile(mode='rb', delete=True, suffix='.out')
+    
+    # Write the page bytes to the temporary input file. The decrypt tool expects a file containing a
+    # base64 encoded byte string.
+    entry_bytes = page.get('entry', [])
+    raw_bytes = bytes(entry_bytes)
+    base64_encoded = base64.b64encode(raw_bytes)
+    temp_input.write(base64_encoded.decode('ascii'))
+    temp_input.flush()
+    
+    cmd = [
+        'pagedecryptor',
+        '--inputPath', temp_input.name,
+        '--outputPath', temp_output.name,
+        '--keyFile', opts.keyfile,
+        '--lsn', str(lsn),
+        '--tableId', str(table_id),
+        '--pageId', str(page_id),
+    ]
+    
+    if base_lsn is not None:
+        cmd.extend(['--baseLsn', str(base_lsn)])
+    if backlink_lsn is not None:
+        cmd.extend(['--backlinkLsn', str(backlink_lsn)])
+        
+    if metadata.get('flags', {}).get("val", {}).get("IntVal", {}) == page_service.UpdateTypeFlags.UPDATE_TYPE_DELTA:
+        cmd.extend(['--isDelta'])
+    
+    try:
+        decrypt_result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        if (opts.debug):
+            print(f'pagedecryptor stdout: {decrypt_result.stdout}')
+            print(f'pagedecryptor stderr: {decrypt_result.stderr}')
+    except subprocess.CalledProcessError as e:
+        print(f"Error decrypting page {page_id}: {e}", file=sys.stderr)
+        print(f"pagedecryptor stderr: {e.stderr}", file=sys.stderr)
+        raise
+        
+    decrypted_bytes = temp_output.read()
+    
+    return decrypted_bytes
+
+def disagg_metadata_string(page):
+    metadata = page.get('metadata', {})
+    meta_string = (
+        f"Disagg Page Metadata:\n"
+        f"  page_id: {metadata.get('page_id', {}).get('val', {}).get('LongVal', 'None')}\n"
+        f"  table_id: {metadata.get('table_id', {}).get('val', {}).get('IntVal', 'None')}\n"
+        f"  lsn: {page.get('lsn', {}).get('lsn', 'None')}\n"
+        f"  base_lsn: {metadata.get('base_lsn', {}).get('val', {}).get('LongVal', 'None')}\n"
+        f"  backlinkLsn: {metadata.get('backlink_lsn', {}).get('val', {}).get('LongVal', 'None')}"
+    )
+    
+    return meta_string
+    
+def extract_disagg_pages(disagg_table, opts):
+    for line in disagg_table:
+        # Parse each line as a separate json object containing the page entries associated with a 
+        # page id.
+        pages = json.loads(line.strip())
+        page_entries = pages.get('entries', [])
+        
+        # Each page_id can have a number of entries associated with it. 
+        for page in page_entries:
+            print(disagg_metadata_string(page))
+            
+            # If the page entry is empty do not try and decrypt/decode it. SLS sometimes stores
+            # empty pages.
+            if not page['entry']:
+                print('empty page')
+                print('')
+                continue
+            
+            decrypted_page_bytes = decrypt_page(page)
+            
+            # The disagg metadata page is plaintext, print it as such.
+            if page['metadata']['table_id']['val']['IntVal'] == 1:
+                print('Disagg Metadata File:')
+                page_string = decrypted_page_bytes.decode('ascii')
+                print(f'  {page_string}')
+                
+                # The metadata table root page address cookie is stored as plaintext hex in the addr 
+                # field of the checkpoint string. Extract it and decode it to print the disagg
+                # page metadata.
+                print('Metadata Table Root Page:')
+                addr_string = page_string.split('addr="')[1].split('"')[0]
+                addr = btree_format.DisaggAddr.parse(bytes.fromhex(addr_string))
+                print(addr)
+                print('')
+                continue
+                
+            b = binary_data.BinaryFile(io.BytesIO(decrypted_page_bytes))
+            p = Printer(b, opts)
+            block_decode(p, b, len(decrypted_page_bytes), opts)
+            p.rint('')
+
 def extract_mongodb_log_hex(f):
     """
     Extract hex dump from MongoDB log file containing checksum mismatch errors.
@@ -887,6 +1017,15 @@ def wtdecode(opts):
                 allbytes = extract_mongodb_log_hex(infile)
         b = binary_data.BinaryFile(io.BytesIO(allbytes))
         wtdecode_file_object(b, opts, len(allbytes))
+    elif opts.disagg_table:
+        opts.disagg = True
+        opts.fragment = True
+        if opts.filename == '-':
+            extract_disagg_pages(sys.stdin, opts)
+        else:
+            with open(opts.filename, "r") as infile:
+                extract_disagg_pages(infile, opts)
+        
     elif opts.filename == '-':
         nbytes = 0      # unknown length
         print('stdin, position ' + hex(opts.offset) + ', pagelimit ' +  str(opts.pages))
@@ -906,9 +1045,11 @@ def get_arg_parser():
     parser.add_argument('--continue', help="continue on checksum failure", dest='cont', action='store_true')
     parser.add_argument('-D', '--debug', help="debug this tool", action='store_true')
     parser.add_argument('-d', '--dumpin', help="input is hex dump (may be embedded in log messages)", action='store_true')
+    parser.add_argument('--disagg_table', help="input is a full disagg table", action='store_true')
     parser.add_argument('--disagg', help="input comes from disaggregated storage", action='store_true')
     parser.add_argument('--ext', help="dump only the extent lists", action='store_true')
     parser.add_argument('-f', '--fragment', help="input file is a fragment, does not have a WT file header", action='store_true')
+    parser.add_argument('--keyfile', help="Keyfile path used for mongodb encryption", type=str)
     parser.add_argument('-o', '--offset', help="seek offset before decoding", type=int, default=0)
     parser.add_argument('-p', '--pages', help="number of pages to decode", type=int, default=0)
     parser.add_argument('-v', '--verbose', help="print things about data, not just the headers", action='store_true')


### PR DESCRIPTION
Adds --disagg_table to input the jsonl file downloaded from getTableAtLSN response. The json objects are parsed and the `entry` bytes are passed to the `pagedecryptor` for decryption. This requires the pagedecryptor to be compiled and in the system PATH. Example output is in the ticket.