### PR TITLE
WT-16427 Fix unit test palm on develop

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -6603,6 +6603,7 @@ buildvariants:
     - name: csuite-long-running
       batchtime: 1440 # once a day
     - name: live-restore-long
+    - name: unit-test-palm
 
 - name: ubuntu2004-asan
   display_name: "! Ubuntu 20.04 ASAN"
@@ -6777,7 +6778,6 @@ buildvariants:
     - name: compile-production-disable-static
     - name: examples-c-production-disable-shared-test
     - name: examples-c-production-disable-static-test
-    - name: unit-test-palm
     - name: format-msan-test
     - name: format-stress-test-disagg-leader-msan-palm
     - name: format-stress-test-disagg-follower-msan-palm
@@ -7391,6 +7391,7 @@ buildvariants:
       distros: amazon2023-arm64-latest-large-m8g
     - name: make-check-test
     - name: unit-test
+    - name: unit-test-palm
     - name: unit-test-extra-long
       distros: amazon2023-arm64-latest-large-m8g
     - name: unit-test-hook-disagg-leader-extra-long


### PR DESCRIPTION
Python test suite running under MSAN is not supported yet. The amount of work to support warrants its own ticket. For now I will revert back unit-test palm to be run the way it was before.