### PR TITLE
WT-16436 Skip the page discard verify logic if get_page_ids is not implemented

### DIFF
--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -322,7 +322,7 @@ __wt_verify(WT_SESSION_IMPL *session, const char *cfg[])
                      * implemented.
                      */
                     WT_BLOCK_DISAGG * block_disagg = (WT_BLOCK_DISAGG *)bm->block;
-                    if(block_disagg->plhandle->plh_get_page_ids != NULL && ckpt->raw.data)
+                    if(block_disagg->plhandle->plh_get_page_ids != NULL && ckpt->raw.data != NULL)
                         WT_TRET(__verify_page_discard(session, bm));
                 }
 

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -316,8 +316,15 @@ __wt_verify(WT_SESSION_IMPL *session, const char *cfg[])
              * page discard function if we're in disagg mode.
              */
             if (ret == 0 && (ckpt + 1)->name == NULL) {
-                if (F_ISSET(btree, WT_BTREE_DISAGGREGATED) && ckpt->raw.data)
-                    WT_TRET(__verify_page_discard(session, bm));
+                if (F_ISSET(btree, WT_BTREE_DISAGGREGATED)) {
+                    /*
+                     * The page discard verification routine depends on get_page_ids being
+                     * implemented.
+                     */
+                    WT_BLOCK_DISAGG * block_disagg = (WT_BLOCK_DISAGG *)bm->block;
+                    if(block_disagg->plhandle->plh_get_page_ids != NULL && ckpt->raw.data)
+                        WT_TRET(__verify_page_discard(session, bm));
+                }
 
                 if (!skip_hs) {
                     __wt_verbose(session, WT_VERB_VERIFY, "%s: verify against history store", name);

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -321,8 +321,8 @@ __wt_verify(WT_SESSION_IMPL *session, const char *cfg[])
                      * The page discard verification routine depends on get_page_ids being
                      * implemented.
                      */
-                    WT_BLOCK_DISAGG * block_disagg = (WT_BLOCK_DISAGG *)bm->block;
-                    if(block_disagg->plhandle->plh_get_page_ids != NULL && ckpt->raw.data != NULL)
+                    WT_BLOCK_DISAGG *block_disagg = (WT_BLOCK_DISAGG *)bm->block;
+                    if (block_disagg->plhandle->plh_get_page_ids != NULL && ckpt->raw.data != NULL)
                         WT_TRET(__verify_page_discard(session, bm));
                 }
 


### PR DESCRIPTION
The page discard verification routine depends on `plh_get_page_ids` being implemented, which is not necessarily the case. Make sure it is before proceeding with further checks.