### PR TITLE
WT-12878 Add lock guard to test/model kv_transaction::empty()

### DIFF
--- a/test/model/src/include/model/kv_transaction.h
+++ b/test/model/src/include/model/kv_transaction.h
@@ -94,6 +94,7 @@ public:
     inline bool
     empty() const noexcept
     {
+        std::lock_guard lock_guard(_lock); /* So that Coverity does not complain. */
         return _updates.empty();
     }
 


### PR DESCRIPTION
Add lock guard to test/model kv_transaction::empty() function.
