### PR TITLE
WT-16460 Add sequentially consistent load and store atomics to WT

### DIFF
--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -2636,10 +2636,7 @@ __layered_drain_ingest_tables(WT_SESSION_IMPL *session)
     WT_RET(__wt_spin_init(
       session, &conn->layered_drain_data.queue_lock, "layered drain work queue lock"));
 
-    __wt_spin_lock(session, &conn->layered_drain_data.queue_lock);
-    /* WiredTiger doesn't have sequentially consistent stores so we lock around this store. */
-    __wt_atomic_store_bool_relaxed(&conn->layered_drain_data.running, true);
-    __wt_spin_unlock(session, &conn->layered_drain_data.queue_lock);
+    __wt_atomic_store_bool(&conn->layered_drain_data.running, true);
 
     /* Open the internal session early so we can close it on error. */
     bool multithreaded = conn->layered_drain_data.thread_count > 1;

--- a/src/include/gcc.h
+++ b/src/include/gcc.h
@@ -303,6 +303,14 @@
     {                                                                                      \
         RELEASE_WRITE(*(vp), v);                                                           \
     }                                                                                      \
+    static inline _type __wt_atomic_load_##suffix(_type *vp)                               \
+    {                                                                                      \
+        return (__atomic_load_n(vp, __ATOMIC_SEQ_CST));                                    \
+    }                                                                                      \
+    static inline void __wt_atomic_store_##suffix(_type *vp, _type v)                      \
+    {                                                                                      \
+        __atomic_store_n(vp, v, __ATOMIC_SEQ_CST);                                         \
+    }                                                                                      \
     static inline _type __wt_atomic_load_##suffix##_v_relaxed(volatile _type *vp)          \
     {                                                                                      \
         return (__atomic_load_n(vp, __ATOMIC_RELAXED));                                    \
@@ -320,6 +328,14 @@
     static inline void __wt_atomic_store_##suffix##_v_release(volatile _type *vp, _type v) \
     {                                                                                      \
         RELEASE_WRITE(*(vp), v);                                                           \
+    }                                                                                      \
+    static inline void __wt_atomic_store_##suffix##_v(volatile _type *vp, _type v)         \
+    {                                                                                      \
+        __atomic_store_n(vp, v, __ATOMIC_SEQ_CST);                                         \
+    }                                                                                      \
+    static inline _type __wt_atomic_load_##suffix##_v(volatile _type *vp)                  \
+    {                                                                                      \
+        return (__atomic_load_n(vp, __ATOMIC_SEQ_CST));                                    \
     }
 
 #define WT_ATOMIC_CAS_FUNC(suffix, _type)                                                      \

--- a/src/include/gcc.h
+++ b/src/include/gcc.h
@@ -329,13 +329,13 @@
     {                                                                                      \
         RELEASE_WRITE(*(vp), v);                                                           \
     }                                                                                      \
-    static inline void __wt_atomic_store_##suffix##_v(volatile _type *vp, _type v)         \
-    {                                                                                      \
-        __atomic_store_n(vp, v, __ATOMIC_SEQ_CST);                                         \
-    }                                                                                      \
     static inline _type __wt_atomic_load_##suffix##_v(volatile _type *vp)                  \
     {                                                                                      \
         return (__atomic_load_n(vp, __ATOMIC_SEQ_CST));                                    \
+    }                                                                                      \
+    static inline void __wt_atomic_store_##suffix##_v(volatile _type *vp, _type v)         \
+    {                                                                                      \
+        __atomic_store_n(vp, v, __ATOMIC_SEQ_CST);                                         \
     }
 
 #define WT_ATOMIC_CAS_FUNC(suffix, _type)                                                      \

--- a/src/include/msvc.h
+++ b/src/include/msvc.h
@@ -119,7 +119,7 @@ WT_RELEASE_BARRIER(void)
     }                                                                                       \
     static inline _type __wt_atomic_load_##suffix(_type *vp)                                \
     {                                                                                       \
-        return (_type)(_InterlockedCompareExchange##s((t *)(vp), (t)(0), (t)(0)));          \
+        return (*(vp));                                                                     \
     }                                                                                       \
     static inline void __wt_atomic_store_##suffix(_type *vp, _type v)                       \
     {                                                                                       \
@@ -146,7 +146,7 @@ WT_RELEASE_BARRIER(void)
     }                                                                                       \
     static inline _type __wt_atomic_load_##suffix##_v(volatile _type *vp)                   \
     {                                                                                       \
-        return (_type)(_InterlockedCompareExchange##s((volatile t *)(vp), (t)(0), (t)(0))); \
+        return (*(vp));                                                                     \
     }                                                                                       \
     static inline void __wt_atomic_store_##suffix##_v(volatile _type *vp, _type v)          \
     {                                                                                       \

--- a/src/include/msvc.h
+++ b/src/include/msvc.h
@@ -97,60 +97,60 @@ WT_RELEASE_BARRIER(void)
  * prior the addition of atomic load and store.
  */
 
-#define WT_ATOMIC_FUNC_STORE_LOAD(suffix, _type, s, t)                                      \
-    static inline _type __wt_atomic_load_##suffix##_relaxed(_type *vp)                      \
-    {                                                                                       \
-        return (*(vp));                                                                     \
-    }                                                                                       \
-    static inline void __wt_atomic_store_##suffix##_relaxed(_type *vp, _type v)             \
-    {                                                                                       \
-        *(vp) = (v);                                                                        \
-    }                                                                                       \
-    static inline _type __wt_atomic_load_##suffix##_acquire(_type *vp)                      \
-    {                                                                                       \
-        _type result = *vp;                                                                 \
-        WT_ACQUIRE_BARRIER();                                                               \
-        return (result);                                                                    \
-    }                                                                                       \
-    static inline void __wt_atomic_store_##suffix##_release(_type *vp, _type v)             \
-    {                                                                                       \
-        WT_RELEASE_BARRIER();                                                               \
-        *vp = v;                                                                            \
-    }                                                                                       \
-    static inline _type __wt_atomic_load_##suffix(_type *vp)                                \
-    {                                                                                       \
-        return (*(vp));                                                                     \
-    }                                                                                       \
-    static inline void __wt_atomic_store_##suffix(_type *vp, _type v)                       \
-    {                                                                                       \
-        _InterlockedExchange##s((t *)(vp), (t)(v));                                         \
-    }                                                                                       \
-    static inline _type __wt_atomic_load_##suffix##_v_relaxed(volatile _type *vp)           \
-    {                                                                                       \
-        return (*(vp));                                                                     \
-    }                                                                                       \
-    static inline void __wt_atomic_store_##suffix##_v_relaxed(volatile _type *vp, _type v)  \
-    {                                                                                       \
-        *(vp) = (v);                                                                        \
-    }                                                                                       \
-    static inline _type __wt_atomic_load_##suffix##_v_acquire(volatile _type *vp)           \
-    {                                                                                       \
-        _type result = *vp;                                                                 \
-        WT_ACQUIRE_BARRIER();                                                               \
-        return (result);                                                                    \
-    }                                                                                       \
-    static inline void __wt_atomic_store_##suffix##_v_release(volatile _type *vp, _type v)  \
-    {                                                                                       \
-        WT_RELEASE_BARRIER();                                                               \
-        *vp = v;                                                                            \
-    }                                                                                       \
-    static inline _type __wt_atomic_load_##suffix##_v(volatile _type *vp)                   \
-    {                                                                                       \
-        return (*(vp));                                                                     \
-    }                                                                                       \
-    static inline void __wt_atomic_store_##suffix##_v(volatile _type *vp, _type v)          \
-    {                                                                                       \
-        _InterlockedExchange##s((volatile t *)(vp), (t)(v));                                \
+#define WT_ATOMIC_FUNC_STORE_LOAD(suffix, _type, s, t)                                     \
+    static inline _type __wt_atomic_load_##suffix##_relaxed(_type *vp)                     \
+    {                                                                                      \
+        return (*(vp));                                                                    \
+    }                                                                                      \
+    static inline void __wt_atomic_store_##suffix##_relaxed(_type *vp, _type v)            \
+    {                                                                                      \
+        *(vp) = (v);                                                                       \
+    }                                                                                      \
+    static inline _type __wt_atomic_load_##suffix##_acquire(_type *vp)                     \
+    {                                                                                      \
+        _type result = *vp;                                                                \
+        WT_ACQUIRE_BARRIER();                                                              \
+        return (result);                                                                   \
+    }                                                                                      \
+    static inline void __wt_atomic_store_##suffix##_release(_type *vp, _type v)            \
+    {                                                                                      \
+        WT_RELEASE_BARRIER();                                                              \
+        *vp = v;                                                                           \
+    }                                                                                      \
+    static inline _type __wt_atomic_load_##suffix(_type *vp)                               \
+    {                                                                                      \
+        return (*(vp));                                                                    \
+    }                                                                                      \
+    static inline void __wt_atomic_store_##suffix(_type *vp, _type v)                      \
+    {                                                                                      \
+        _InterlockedExchange##s((t *)(vp), (t)(v));                                        \
+    }                                                                                      \
+    static inline _type __wt_atomic_load_##suffix##_v_relaxed(volatile _type *vp)          \
+    {                                                                                      \
+        return (*(vp));                                                                    \
+    }                                                                                      \
+    static inline void __wt_atomic_store_##suffix##_v_relaxed(volatile _type *vp, _type v) \
+    {                                                                                      \
+        *(vp) = (v);                                                                       \
+    }                                                                                      \
+    static inline _type __wt_atomic_load_##suffix##_v_acquire(volatile _type *vp)          \
+    {                                                                                      \
+        _type result = *vp;                                                                \
+        WT_ACQUIRE_BARRIER();                                                              \
+        return (result);                                                                   \
+    }                                                                                      \
+    static inline void __wt_atomic_store_##suffix##_v_release(volatile _type *vp, _type v) \
+    {                                                                                      \
+        WT_RELEASE_BARRIER();                                                              \
+        *vp = v;                                                                           \
+    }                                                                                      \
+    static inline _type __wt_atomic_load_##suffix##_v(volatile _type *vp)                  \
+    {                                                                                      \
+        return (*(vp));                                                                    \
+    }                                                                                      \
+    static inline void __wt_atomic_store_##suffix##_v(volatile _type *vp, _type v)         \
+    {                                                                                      \
+        _InterlockedExchange##s((volatile t *)(vp), (t)(v));                               \
     }
 
 #define WT_ATOMIC_CAS_FUNC(suffix, _type, s, t)                                                \

--- a/src/include/msvc.h
+++ b/src/include/msvc.h
@@ -117,6 +117,14 @@ WT_RELEASE_BARRIER(void)
         WT_RELEASE_BARRIER();                                                              \
         *vp = v;                                                                           \
     }                                                                                      \
+    static inline _type __wt_atomic_load_##suffix(_type *vp)                               \
+    {                                                                                      \
+        return (*(vp));                                                                    \
+    }                                                                                      \
+    static inline void __wt_atomic_store_##suffix(_type *vp, _type v)                      \
+    {                                                                                      \
+        *vp = v;                                                                           \
+    }                                                                                      \
     static inline _type __wt_atomic_load_##suffix##_v_relaxed(volatile _type *vp)          \
     {                                                                                      \
         return (*(vp));                                                                    \
@@ -134,6 +142,14 @@ WT_RELEASE_BARRIER(void)
     static inline void __wt_atomic_store_##suffix##_v_release(volatile _type *vp, _type v) \
     {                                                                                      \
         WT_RELEASE_BARRIER();                                                              \
+        *vp = v;                                                                           \
+    }                                                                                      \
+    static inline _type __wt_atomic_load_##suffix##_v(volatile _type *vp)                  \
+    {                                                                                      \
+        return (*(vp));                                                                    \
+    }                                                                                      \
+    static inline void __wt_atomic_store_##suffix##_v(volatile _type *vp, _type v)         \
+    {                                                                                      \
         *vp = v;                                                                           \
     }
 

--- a/src/include/msvc.h
+++ b/src/include/msvc.h
@@ -97,60 +97,60 @@ WT_RELEASE_BARRIER(void)
  * prior the addition of atomic load and store.
  */
 
-#define WT_ATOMIC_FUNC_STORE_LOAD(suffix, _type)                                           \
-    static inline _type __wt_atomic_load_##suffix##_relaxed(_type *vp)                     \
-    {                                                                                      \
-        return (*(vp));                                                                    \
-    }                                                                                      \
-    static inline void __wt_atomic_store_##suffix##_relaxed(_type *vp, _type v)            \
-    {                                                                                      \
-        *(vp) = (v);                                                                       \
-    }                                                                                      \
-    static inline _type __wt_atomic_load_##suffix##_acquire(_type *vp)                     \
-    {                                                                                      \
-        _type result = *vp;                                                                \
-        WT_ACQUIRE_BARRIER();                                                              \
-        return (result);                                                                   \
-    }                                                                                      \
-    static inline void __wt_atomic_store_##suffix##_release(_type *vp, _type v)            \
-    {                                                                                      \
-        WT_RELEASE_BARRIER();                                                              \
-        *vp = v;                                                                           \
-    }                                                                                      \
-    static inline _type __wt_atomic_load_##suffix(_type *vp)                               \
-    {                                                                                      \
-        return (*(vp));                                                                    \
-    }                                                                                      \
-    static inline void __wt_atomic_store_##suffix(_type *vp, _type v)                      \
-    {                                                                                      \
-        *vp = v;                                                                           \
-    }                                                                                      \
-    static inline _type __wt_atomic_load_##suffix##_v_relaxed(volatile _type *vp)          \
-    {                                                                                      \
-        return (*(vp));                                                                    \
-    }                                                                                      \
-    static inline void __wt_atomic_store_##suffix##_v_relaxed(volatile _type *vp, _type v) \
-    {                                                                                      \
-        *(vp) = (v);                                                                       \
-    }                                                                                      \
-    static inline _type __wt_atomic_load_##suffix##_v_acquire(volatile _type *vp)          \
-    {                                                                                      \
-        _type result = *vp;                                                                \
-        WT_ACQUIRE_BARRIER();                                                              \
-        return (result);                                                                   \
-    }                                                                                      \
-    static inline void __wt_atomic_store_##suffix##_v_release(volatile _type *vp, _type v) \
-    {                                                                                      \
-        WT_RELEASE_BARRIER();                                                              \
-        *vp = v;                                                                           \
-    }                                                                                      \
-    static inline _type __wt_atomic_load_##suffix##_v(volatile _type *vp)                  \
-    {                                                                                      \
-        return (*(vp));                                                                    \
-    }                                                                                      \
-    static inline void __wt_atomic_store_##suffix##_v(volatile _type *vp, _type v)         \
-    {                                                                                      \
-        *vp = v;                                                                           \
+#define WT_ATOMIC_FUNC_STORE_LOAD(suffix, _type, s, t)                                      \
+    static inline _type __wt_atomic_load_##suffix##_relaxed(_type *vp)                      \
+    {                                                                                       \
+        return (*(vp));                                                                     \
+    }                                                                                       \
+    static inline void __wt_atomic_store_##suffix##_relaxed(_type *vp, _type v)             \
+    {                                                                                       \
+        *(vp) = (v);                                                                        \
+    }                                                                                       \
+    static inline _type __wt_atomic_load_##suffix##_acquire(_type *vp)                      \
+    {                                                                                       \
+        _type result = *vp;                                                                 \
+        WT_ACQUIRE_BARRIER();                                                               \
+        return (result);                                                                    \
+    }                                                                                       \
+    static inline void __wt_atomic_store_##suffix##_release(_type *vp, _type v)             \
+    {                                                                                       \
+        WT_RELEASE_BARRIER();                                                               \
+        *vp = v;                                                                            \
+    }                                                                                       \
+    static inline _type __wt_atomic_load_##suffix(_type *vp)                                \
+    {                                                                                       \
+        return (_type)(_InterlockedCompareExchange##s((t *)(vp), (t)(0), (t)(0)));          \
+    }                                                                                       \
+    static inline void __wt_atomic_store_##suffix(_type *vp, _type v)                       \
+    {                                                                                       \
+        _InterlockedExchange##s((t *)(vp), (t)(v));                                         \
+    }                                                                                       \
+    static inline _type __wt_atomic_load_##suffix##_v_relaxed(volatile _type *vp)           \
+    {                                                                                       \
+        return (*(vp));                                                                     \
+    }                                                                                       \
+    static inline void __wt_atomic_store_##suffix##_v_relaxed(volatile _type *vp, _type v)  \
+    {                                                                                       \
+        *(vp) = (v);                                                                        \
+    }                                                                                       \
+    static inline _type __wt_atomic_load_##suffix##_v_acquire(volatile _type *vp)           \
+    {                                                                                       \
+        _type result = *vp;                                                                 \
+        WT_ACQUIRE_BARRIER();                                                               \
+        return (result);                                                                    \
+    }                                                                                       \
+    static inline void __wt_atomic_store_##suffix##_v_release(volatile _type *vp, _type v)  \
+    {                                                                                       \
+        WT_RELEASE_BARRIER();                                                               \
+        *vp = v;                                                                            \
+    }                                                                                       \
+    static inline _type __wt_atomic_load_##suffix##_v(volatile _type *vp)                   \
+    {                                                                                       \
+        return (_type)(_InterlockedCompareExchange##s((volatile t *)(vp), (t)(0), (t)(0))); \
+    }                                                                                       \
+    static inline void __wt_atomic_store_##suffix##_v(volatile _type *vp, _type v)          \
+    {                                                                                       \
+        _InterlockedExchange##s((volatile t *)(vp), (t)(v));                                \
     }
 
 #define WT_ATOMIC_CAS_FUNC(suffix, _type, s, t)                                                \
@@ -215,7 +215,7 @@ WT_RELEASE_BARRIER(void)
         return (                                                                                  \
           _InterlockedCompareExchange##s((t *)(vp), (t)(new_val), (t)(old_val)) == (t)(old_val)); \
     }                                                                                             \
-    WT_ATOMIC_FUNC_STORE_LOAD(suffix, _type)
+    WT_ATOMIC_FUNC_STORE_LOAD(suffix, _type, s, _type)
 
 WT_ATOMIC_FUNC(uint8, uint8_t, 8, char)
 WT_ATOMIC_FUNC(uint16, uint16_t, 16, short)
@@ -227,7 +227,7 @@ WT_ATOMIC_FUNC(int32, int32_t, , long)
 WT_ATOMIC_FUNC(int64, int64_t, 64, __int64)
 WT_ATOMIC_FUNC(size, size_t, 64, __int64)
 
-WT_ATOMIC_FUNC_STORE_LOAD(bool, bool)
+WT_ATOMIC_FUNC_STORE_LOAD(bool, bool, 8, char)
 
 /*
  * __wt_atomic_load_double_relaxed --

--- a/src/include/msvc.h
+++ b/src/include/msvc.h
@@ -215,7 +215,7 @@ WT_RELEASE_BARRIER(void)
         return (                                                                                  \
           _InterlockedCompareExchange##s((t *)(vp), (t)(new_val), (t)(old_val)) == (t)(old_val)); \
     }                                                                                             \
-    WT_ATOMIC_FUNC_STORE_LOAD(suffix, _type, s, _type)
+    WT_ATOMIC_FUNC_STORE_LOAD(suffix, _type, s, t)
 
 WT_ATOMIC_FUNC(uint8, uint8_t, 8, char)
 WT_ATOMIC_FUNC(uint16, uint16_t, 16, short)


### PR DESCRIPTION
Addressing a gap in our atomics API, where we have needed sequentially consistent for some time but have been either not using it or achieving it using lock / unlock.