### PR TITLE
WT-16450 Add flags and compatible version to header

### DIFF
--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -336,8 +336,7 @@ __disagg_validate_crypt(WT_SESSION_IMPL *session, const WT_ITEM *key_item, WT_CR
 
     if (header->header_size < sizeof(WT_CRYPT_HEADER)) {
         WT_ERR_MSG(session, EIO,
-          "Encryption key header is too small: expected at least %" WT_SIZET_FMT
-          ", got %" WT_SIZET_FMT,
+          "Encryption key header is too small: expected at least %" WT_SIZET_FMT ", got %" PRIu8,
           sizeof(WT_CRYPT_HEADER), header->header_size);
     }
 

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -3113,6 +3113,6 @@ __ut_disagg_validate_crypt(
 void
 __ut_disagg_get_crypt_header(const WT_ITEM *key_item, WT_CRYPT_HEADER *header)
 {
-    return (__disagg_get_crypt_header(key_item, header));
+    __disagg_get_crypt_header(key_item, header);
 }
 #endif

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -328,15 +328,14 @@ __disagg_validate_crypt(WT_SESSION_IMPL *session, const WT_ITEM *key_item, WT_CR
     WT_DECL_RET;
     uint32_t checksum = 0;
 
-    if (key_item->size < sizeof(WT_CRYPT_HEADER)) {
+    if (key_item->size < sizeof(WT_CRYPT_HEADER))
         WT_ERR_MSG(session, EIO,
           "Encryption key data too small: expected at least %" WT_SIZET_FMT ", got %" WT_SIZET_FMT,
           sizeof(WT_CRYPT_HEADER), key_item->size);
-    }
     __disagg_get_crypt_header(key_item, header);
 
     /* Check for compatibility versions before validating header fields. */
-    if (header->compatible_version > header->version)
+    if (header->compatible_version > WT_CRYPT_HEADER_COMPATIBLE_VERSION)
         WT_ERR_MSG(session, ENOTSUP,
           "Unsupported encryption key data version %" PRIu8 ", min %" PRIu8, header->version,
           header->compatible_version);
@@ -345,23 +344,20 @@ __disagg_validate_crypt(WT_SESSION_IMPL *session, const WT_ITEM *key_item, WT_CR
       "Invalid encryption key data signature: expected 0x%08" PRIx32 ", got 0x%08" PRIx32,
       WT_CRYPT_HEADER_SIGNATURE, header->signature);
 
-    if (header->header_size < sizeof(WT_CRYPT_HEADER)) {
+    if (header->header_size < sizeof(WT_CRYPT_HEADER))
         WT_ERR_MSG(session, EIO,
           "Encryption key header is too small: expected at least %" WT_SIZET_FMT ", got %" PRIu8,
           sizeof(WT_CRYPT_HEADER), header->header_size);
-    }
 
-    if (key_item->size - header->header_size != header->crypt_size) {
+    if (key_item->size - header->header_size != header->crypt_size)
         WT_ERR_MSG(session, EIO, "Encryption key data size mismatch: expected %u, got %u",
           header->crypt_size, (uint32_t)(key_item->size - header->header_size));
-    }
 
     checksum = __wt_checksum((uint8_t *)key_item->data + header->header_size, header->crypt_size);
-    if (checksum != header->checksum) {
+    if (checksum != header->checksum)
         WT_ERR_MSG(session, EIO,
           "Encryption key data checksum mismatch: expected %" PRIx32 ", got %" PRIx32,
           header->checksum, checksum);
-    }
 
 err:
     return (ret);

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -21,6 +21,7 @@ typedef struct __wt_disagg_checkpoint_meta {
 
 /* Function prototypes for disaggregated storage and layered tables. */
 static void __disagg_set_crypt_header(WT_SESSION_IMPL *session, WT_CRYPT_KEYS *crypt);
+static void __disagg_get_crypt_header(const WT_ITEM *key_item, WT_CRYPT_HEADER *header);
 static int __disagg_copy_shared_metadata_one(WT_SESSION_IMPL *session, const char *uri);
 static int __layered_drain_ingest_tables(WT_SESSION_IMPL *session);
 static void __layered_update_prune_timestamps_print_update_logs(WT_SESSION_IMPL *session,
@@ -307,6 +308,17 @@ __disagg_get_crypt_key(WT_SESSION_IMPL *session, uint64_t page_id, uint64_t lsn,
 }
 
 /*
+ * __disagg_get_crypt_header --
+ *     Copy and byte-swap the crypt header from the key item. Note: This function is not idempotent.
+ */
+static void
+__disagg_get_crypt_header(const WT_ITEM *key_item, WT_CRYPT_HEADER *header)
+{
+    memcpy(header, key_item->data, sizeof(WT_CRYPT_HEADER));
+    __wt_crypt_header_byteswap(header);
+}
+
+/*
  * __disagg_validate_crypt --
  *     Validate the crypt header and payload stored in key_item.
  */
@@ -321,8 +333,7 @@ __disagg_validate_crypt(WT_SESSION_IMPL *session, const WT_ITEM *key_item, WT_CR
           "Encryption key data too small: expected at least %" WT_SIZET_FMT ", got %" WT_SIZET_FMT,
           sizeof(WT_CRYPT_HEADER), key_item->size);
     }
-    memcpy(header, key_item->data, sizeof(WT_CRYPT_HEADER));
-    __wt_crypt_header_byteswap(header);
+    __disagg_get_crypt_header(key_item, header);
 
     /* Check for compatibility versions before validating header fields. */
     if (header->compatible_version > header->version)
@@ -431,7 +442,8 @@ __disagg_put_meta(WT_SESSION_IMPL *session, uint64_t page_id, const WT_ITEM *ite
 
 /*
  * __disagg_set_crypt_header --
- *     Pack the crypt header information into the struct.
+ *     Pack and byte-swap the crypt header information into the struct. Note: This function is not
+ *     idempotent.
  */
 static void
 __disagg_set_crypt_header(WT_SESSION_IMPL *session, WT_CRYPT_KEYS *crypt)

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -324,22 +324,29 @@ __disagg_validate_crypt(WT_SESSION_IMPL *session, const WT_ITEM *key_item, WT_CR
     memcpy(header, key_item->data, sizeof(WT_CRYPT_HEADER));
     __wt_crypt_header_byteswap(header);
 
-    WT_ASSERT_ALWAYS(session, header->signature == WT_CRYPT_HEADER_SIGNATURE,
-      "Invalid encryption key data signature: expected 0x%08" PRIx32 ", got 0x%08" PRIx32,
-      WT_CRYPT_HEADER_SIGNATURE, header->signature);
-
-    if (key_item->size - sizeof(WT_CRYPT_HEADER) != header->crypt_size) {
-        WT_ERR_MSG(session, EIO, "Encryption key data size mismatch: expected %u, got %u",
-          header->crypt_size, (uint32_t)(key_item->size - sizeof(WT_CRYPT_HEADER)));
-    }
-
+    /* Check for compatibility versions before validating header fields. */
     if (header->compatible_version > header->version)
         WT_ERR_MSG(session, ENOTSUP,
           "Unsupported encryption key data version %" PRIu8 ", min %" PRIu8, header->version,
           header->compatible_version);
 
-    checksum =
-      __wt_checksum((uint8_t *)key_item->data + sizeof(WT_CRYPT_HEADER), header->crypt_size);
+    WT_ASSERT_ALWAYS(session, header->signature == WT_CRYPT_HEADER_SIGNATURE,
+      "Invalid encryption key data signature: expected 0x%08" PRIx32 ", got 0x%08" PRIx32,
+      WT_CRYPT_HEADER_SIGNATURE, header->signature);
+
+    if (header->header_size < sizeof(WT_CRYPT_HEADER)) {
+        WT_ERR_MSG(session, EIO,
+          "Encryption key header is too small: expected at least %" WT_SIZET_FMT
+          ", got %" WT_SIZET_FMT,
+          sizeof(WT_CRYPT_HEADER), header->header_size);
+    }
+
+    if (key_item->size - header->header_size != header->crypt_size) {
+        WT_ERR_MSG(session, EIO, "Encryption key data size mismatch: expected %u, got %u",
+          header->crypt_size, (uint32_t)(key_item->size - header->header_size));
+    }
+
+    checksum = __wt_checksum((uint8_t *)key_item->data + header->header_size, header->crypt_size);
     if (checksum != header->checksum) {
         WT_ERR_MSG(session, EIO,
           "Encryption key data checksum mismatch: expected %" PRIx32 ", got %" PRIx32,
@@ -726,7 +733,7 @@ __disagg_load_crypt_key(WT_SESSION_IMPL *session, WT_DISAGG_METADATA *metadata)
     WT_ERR(__disagg_validate_crypt(session, &key_item, &crypt_header));
 
     /* Prepare the crypt keys for loading. */
-    crypt.keys.data = (uint8_t *)key_item.data + sizeof(WT_CRYPT_HEADER);
+    crypt.keys.data = (uint8_t *)key_item.data + crypt_header.header_size;
     crypt.keys.size = crypt_header.crypt_size;
     crypt.r.lsn = lsn;
 

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -335,6 +335,11 @@ __disagg_validate_crypt(WT_SESSION_IMPL *session, const WT_ITEM *key_item, WT_CR
           header->crypt_size, (uint32_t)(key_item->size - sizeof(WT_CRYPT_HEADER)));
     }
 
+    WT_ASSERT_ALWAYS(session, header->version >= WT_CRYPT_HEADER_COMPATIBLE_VERSION,
+      "Compatible version error, version %" PRIu8
+      "is lower than than compatible version of %" PRIu8,
+      header->version, WT_CRYPT_HEADER_COMPATIBLE_VERSION);
+
     checksum =
       __wt_checksum((uint8_t *)key_item->data + sizeof(WT_CRYPT_HEADER), header->crypt_size);
     if (checksum != header->checksum) {
@@ -465,9 +470,11 @@ __wt_disagg_put_crypt_helper(WT_SESSION_IMPL *session)
     /* Prepare the crypt header. */
     crypt_header.signature = WT_CRYPT_HEADER_SIGNATURE;
     crypt_header.version = WT_CRYPT_HEADER_VERSION;
+    crypt_header.compatible_version = WT_CRYPT_HEADER_COMPATIBLE_VERSION;
     crypt_header.header_size = sizeof(WT_CRYPT_HEADER);
     crypt_header.crypt_size = (uint32_t)crypt.keys.size;
     crypt_header.checksum = __wt_checksum(crypt.keys.data, crypt.keys.size);
+    crypt_header.flags = 0;
 
     __wt_crypt_header_byteswap(&crypt_header);
     memcpy(crypt.keys.mem, &crypt_header, sizeof(WT_CRYPT_HEADER));

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -3109,4 +3109,10 @@ __ut_disagg_validate_crypt(
 {
     return (__disagg_validate_crypt(session, key_item, header));
 }
+
+void
+__ut_disagg_get_crypt_header(const WT_ITEM *key_item, WT_CRYPT_HEADER *header)
+{
+    return (__disagg_get_crypt_header(key_item, header));
+}
 #endif

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -20,7 +20,7 @@ typedef struct __wt_disagg_checkpoint_meta {
 } WT_DISAGG_CHECKPOINT_META;
 
 /* Function prototypes for disaggregated storage and layered tables. */
-
+static void __disagg_set_crypt_header(WT_SESSION_IMPL *session, WT_CRYPT_KEYS *crypt);
 static int __disagg_copy_shared_metadata_one(WT_SESSION_IMPL *session, const char *uri);
 static int __layered_drain_ingest_tables(WT_SESSION_IMPL *session);
 static void __layered_update_prune_timestamps_print_update_logs(WT_SESSION_IMPL *session,
@@ -327,18 +327,16 @@ __disagg_validate_crypt(WT_SESSION_IMPL *session, const WT_ITEM *key_item, WT_CR
     WT_ASSERT_ALWAYS(session, header->signature == WT_CRYPT_HEADER_SIGNATURE,
       "Invalid encryption key data signature: expected 0x%08" PRIx32 ", got 0x%08" PRIx32,
       WT_CRYPT_HEADER_SIGNATURE, header->signature);
-    WT_ASSERT_ALWAYS(session, header->version == WT_CRYPT_HEADER_VERSION,
-      "Unsupported encryption key data version: expected %u, got %u", WT_CRYPT_HEADER_VERSION,
-      header->version);
+
     if (key_item->size - sizeof(WT_CRYPT_HEADER) != header->crypt_size) {
         WT_ERR_MSG(session, EIO, "Encryption key data size mismatch: expected %u, got %u",
           header->crypt_size, (uint32_t)(key_item->size - sizeof(WT_CRYPT_HEADER)));
     }
 
-    WT_ASSERT_ALWAYS(session, header->version >= WT_CRYPT_HEADER_COMPATIBLE_VERSION,
-      "Compatible version error, version %" PRIu8
-      "is lower than than compatible version of %" PRIu8,
-      header->version, WT_CRYPT_HEADER_COMPATIBLE_VERSION);
+    if (header->compatible_version > header->version)
+        WT_ERR_MSG(session, ENOTSUP,
+          "Unsupported encryption key data version %" PRIu8 ", min %" PRIu8, header->version,
+          header->compatible_version);
 
     checksum =
       __wt_checksum((uint8_t *)key_item->data + sizeof(WT_CRYPT_HEADER), header->crypt_size);
@@ -426,6 +424,30 @@ __disagg_put_meta(WT_SESSION_IMPL *session, uint64_t page_id, const WT_ITEM *ite
 }
 
 /*
+ * __disagg_set_crypt_header --
+ *     Pack the crypt header information into the struct.
+ */
+static void
+__disagg_set_crypt_header(WT_SESSION_IMPL *session, WT_CRYPT_KEYS *crypt)
+{
+    WT_CRYPT_HEADER crypt_header;
+
+    WT_CLEAR(crypt_header);
+    WT_ASSERT(session, crypt->keys.data != NULL);
+    /* Prepare the crypt header. */
+    crypt_header.signature = WT_CRYPT_HEADER_SIGNATURE;
+    crypt_header.version = WT_CRYPT_HEADER_VERSION;
+    crypt_header.compatible_version = WT_CRYPT_HEADER_COMPATIBLE_VERSION;
+    crypt_header.header_size = sizeof(WT_CRYPT_HEADER);
+    crypt_header.crypt_size = (uint32_t)crypt->keys.size;
+    crypt_header.checksum = __wt_checksum(crypt->keys.data, crypt->keys.size);
+
+    __wt_crypt_header_byteswap(&crypt_header);
+    memcpy(crypt->keys.mem, &crypt_header, sizeof(WT_CRYPT_HEADER));
+    crypt->keys.data = crypt->keys.mem;
+    crypt->keys.size += sizeof(WT_CRYPT_HEADER);
+}
+/*
  * __wt_disagg_put_crypt_helper --
  *     If new encryption key data information is detected, update the metadata page log and callback
  *     to the key provider upon completion.
@@ -434,7 +456,6 @@ int
 __wt_disagg_put_crypt_helper(WT_SESSION_IMPL *session)
 {
     WT_CONNECTION_IMPL *conn;
-    WT_CRYPT_HEADER crypt_header;
     WT_CRYPT_KEYS crypt;
     WT_DECL_ITEM(buf);
     WT_DECL_RET;
@@ -444,7 +465,6 @@ __wt_disagg_put_crypt_helper(WT_SESSION_IMPL *session)
     conn = S2C(session);
     key_provider = conn->key_provider;
     WT_CLEAR(crypt.keys);
-    WT_CLEAR(crypt_header);
     lsn = 0;
 
     WT_ASSERT_SPINLOCK_OWNED(session, &conn->checkpoint_lock);
@@ -467,19 +487,8 @@ __wt_disagg_put_crypt_helper(WT_SESSION_IMPL *session)
     WT_ERR(key_provider->get_key(key_provider, (WT_SESSION *)session, &crypt));
     WT_ASSERT(session, crypt.keys.size != 0 && crypt.keys.data != NULL);
 
-    /* Prepare the crypt header. */
-    crypt_header.signature = WT_CRYPT_HEADER_SIGNATURE;
-    crypt_header.version = WT_CRYPT_HEADER_VERSION;
-    crypt_header.compatible_version = WT_CRYPT_HEADER_COMPATIBLE_VERSION;
-    crypt_header.header_size = sizeof(WT_CRYPT_HEADER);
-    crypt_header.crypt_size = (uint32_t)crypt.keys.size;
-    crypt_header.checksum = __wt_checksum(crypt.keys.data, crypt.keys.size);
-    crypt_header.flags = 0;
-
-    __wt_crypt_header_byteswap(&crypt_header);
-    memcpy(crypt.keys.mem, &crypt_header, sizeof(WT_CRYPT_HEADER));
-    crypt.keys.data = crypt.keys.mem;
-    crypt.keys.size += sizeof(WT_CRYPT_HEADER);
+    /* Pack the crypt header information into the struct. */
+    __disagg_set_crypt_header(session, &crypt);
 
     /* Write the encryption key data to disaggregated storage. */
     ret = __disagg_put_crypt_key(session, WT_DISAGG_KEY_PROVIDER_MAIN_PAGE_ID, &crypt.keys, &lsn);
@@ -3068,3 +3077,18 @@ err:
 
     return (ret);
 }
+
+#ifdef HAVE_UNITTEST
+void
+__ut_disagg_set_crypt_header(WT_SESSION_IMPL *session, WT_CRYPT_KEYS *crypt)
+{
+    __disagg_set_crypt_header(session, crypt);
+}
+
+int
+__ut_disagg_validate_crypt(
+  WT_SESSION_IMPL *session, const WT_ITEM *key_item, WT_CRYPT_HEADER *header)
+{
+    return (__disagg_validate_crypt(session, key_item, header));
+}
+#endif

--- a/src/include/crypt_header.h
+++ b/src/include/crypt_header.h
@@ -18,11 +18,19 @@ WT_PACKED_STRUCT_BEGIN(__wt_crypt_header)
  */
 #define WT_CRYPT_HEADER_SIGNATURE 0x68637477u
     uint32_t signature; /* 00-03: Key header signature; always 'wtch' */
-#define WT_CRYPT_HEADER_VERSION 1u
-    uint8_t version;     /* 04: Header version */
-    uint8_t header_size; /* 05: Header size, in bytes */
-    uint32_t crypt_size; /* 06-09: Payload size, in bytes */
-    uint32_t checksum;   /* 10-13: Payload CRC32 checksum */
+
+    /*
+     * As we create new versions, we bump the version number here, and consider what previous
+     * versions are compatible with it.
+     */
+#define WT_CRYPT_HEADER_VERSION 0x1u
+    uint8_t version; /* 04: Header version */
+#define WT_CRYPT_HEADER_COMPATIBLE_VERSION 0x1u
+    uint8_t compatible_version; /* 05: Minimum compatibility version */
+    uint8_t header_size;        /* 06: Header size, in bytes */
+    uint32_t crypt_size;        /* 07-10: Payload size, in bytes */
+    uint32_t checksum;          /* 11-14: Payload CRC32 checksum */
+    uint8_t flags;              /* 15: Flags */
 WT_PACKED_STRUCT_END
 
 /*

--- a/src/include/crypt_header.h
+++ b/src/include/crypt_header.h
@@ -12,7 +12,7 @@
  * WT_CRYPT_HEADER --
  *	Header for encryption key data.
  */
-WT_PACKED_STRUCT_BEGIN(__wt_crypt_header)
+struct __wt_crypt_header {
 /*
  * Signature 'wtch' (WiredTiger Crypt Header)
  */
@@ -28,10 +28,10 @@ WT_PACKED_STRUCT_BEGIN(__wt_crypt_header)
 #define WT_CRYPT_HEADER_COMPATIBLE_VERSION 0x1u
     uint8_t compatible_version; /* 05: Minimum compatibility version */
     uint8_t header_size;        /* 06: Header size, in bytes */
-    uint32_t crypt_size;        /* 07-10: Payload size, in bytes */
-    uint32_t checksum;          /* 11-14: Payload CRC32 checksum */
-    uint8_t flags;              /* 15: Flags */
-WT_PACKED_STRUCT_END
+    uint8_t unused[1];          /* 07: Unused padding */
+    uint32_t crypt_size;        /* 08-11: Payload size, in bytes */
+    uint32_t checksum;          /* 12-15: Payload CRC32 checksum */
+};
 
 /*
  * __wt_crypt_header_byteswap --

--- a/src/include/crypt_header.h
+++ b/src/include/crypt_header.h
@@ -20,8 +20,8 @@ WT_PACKED_STRUCT_BEGIN(__wt_crypt_header)
     uint32_t signature; /* 00-03: Key header signature; always 'wtch' */
 
     /*
-     * As we create new versions, we bump the version number here, and consider what previous
-     * versions are compatible with it.
+     * As we create new versions, bump the version number here, and consider what previous versions
+     * are compatible with it.
      */
 #define WT_CRYPT_HEADER_VERSION 0x1u
     uint8_t version; /* 04: Header version */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2530,11 +2530,14 @@ extern int __ut_chunkcache_bitmap_alloc(WT_SESSION_IMPL *session, size_t *bit_in
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __ut_ckpt_mod_blkmod_entry(WT_SESSION_IMPL *session, WT_CKPT_BLOCK_MODS *blk_mod,
   wt_off_t offset, wt_off_t len) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __ut_disagg_validate_crypt(WT_SESSION_IMPL *session, const WT_ITEM *key_item,
+  WT_CRYPT_HEADER *header) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __ut_block_off_srch(WT_EXT **head, wt_off_t off, WT_EXT ***stack, bool skip_off);
 extern void __ut_block_off_srch_pair(
   WT_EXTLIST *el, wt_off_t off, WT_EXT **beforep, WT_EXT **afterp);
 extern void __ut_block_size_srch(WT_SIZE **head, wt_off_t size, WT_SIZE ***stack);
 extern void __ut_chunkcache_bitmap_free(WT_SESSION_IMPL *session, size_t bit_index);
+extern void __ut_disagg_set_crypt_header(WT_SESSION_IMPL *session, WT_CRYPT_KEYS *crypt);
 
 #endif
 

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2537,6 +2537,7 @@ extern void __ut_block_off_srch_pair(
   WT_EXTLIST *el, wt_off_t off, WT_EXT **beforep, WT_EXT **afterp);
 extern void __ut_block_size_srch(WT_SIZE **head, wt_off_t size, WT_SIZE ***stack);
 extern void __ut_chunkcache_bitmap_free(WT_SESSION_IMPL *session, size_t bit_index);
+extern void __ut_disagg_get_crypt_header(const WT_ITEM *key_item, WT_CRYPT_HEADER *header);
 extern void __ut_disagg_set_crypt_header(WT_SESSION_IMPL *session, WT_CRYPT_KEYS *crypt);
 
 #endif

--- a/test/catch2/CMakeLists.txt
+++ b/test/catch2/CMakeLists.txt
@@ -42,6 +42,7 @@ else()
         cursors/unit/test_bounds_restore.cpp
         cursors/unit/test_cursor_get_raw_key_value.cpp
         ext/test_key_provider.cpp
+        ext/test_key_provider_header.cpp
         sub_level_error/api/test_sub_level_error_session_get_last_error.cpp
         sub_level_error/api/test_sub_level_error_strerror.cpp
         sub_level_error/unit/test_sub_level_error_api_end.cpp
@@ -91,7 +92,6 @@ set(unittest_sources
     wrappers/mock_session.cpp
     ${unittests}
     ${live_restore_sources}
-    ${key_provider_sources}
 )
 
 create_test_executable(catch2-unittests

--- a/test/catch2/ext/test_key_provider_header.cpp
+++ b/test/catch2/ext/test_key_provider_header.cpp
@@ -44,7 +44,6 @@ TEST_CASE("Key provider set header function", "[key_provider_header]")
     uint32_t checksum = __wt_checksum(crypt.keys.data, crypt.keys.size);
     SECTION("Validate key provider pack")
     {
-
         __ut_disagg_set_crypt_header(session->get_wt_session_impl(), &crypt);
 
         /* Validate crypt header information. */

--- a/test/catch2/ext/test_key_provider_header.cpp
+++ b/test/catch2/ext/test_key_provider_header.cpp
@@ -113,9 +113,16 @@ TEST_CASE("Key provider: validate crypt function", "[key_provider_header]")
           __ut_disagg_validate_crypt(session_impl, &crypt.keys, &read_crypt_header) == ENOTSUP);
     }
 
-    SECTION("Test key provider header size smaller than header")
+    SECTION("Test key provider item size smaller than expected")
     {
         crypt.keys.size = 1;
+        REQUIRE(__ut_disagg_validate_crypt(session_impl, &crypt.keys, &read_crypt_header) == EIO);
+    }
+
+    SECTION("Test key provider header size smaller than expected")
+    {
+        WT_CRYPT_HEADER *header = (WT_CRYPT_HEADER *)crypt.keys.data;
+        header->header_size = 10;
         REQUIRE(__ut_disagg_validate_crypt(session_impl, &crypt.keys, &read_crypt_header) == EIO);
     }
 

--- a/test/catch2/ext/test_key_provider_header.cpp
+++ b/test/catch2/ext/test_key_provider_header.cpp
@@ -37,6 +37,7 @@ TEST_CASE("Key provider set header function", "[key_provider_header]")
     WT_CRYPT_KEYS crypt;
     std::shared_ptr<mock_session> session = mock_session::build_test_mock_session();
 
+    WT_CLEAR(crypt.keys);
     std::string test_string("hello");
 
     WT_SESSION_IMPL *session_impl = session->get_wt_session_impl();

--- a/test/catch2/ext/test_key_provider_header.cpp
+++ b/test/catch2/ext/test_key_provider_header.cpp
@@ -9,31 +9,45 @@
 
 #include <catch2/catch.hpp>
 #include "wrappers/mock_session.h"
-static void create_crypt_key_buffer(
-  WT_SESSION_IMPL *session, WT_CRYPT_KEYS *crypt, const std::string &str);
 
-/* Fixture to initialize the checksum function needed by __wt_checksum and __wt_checksum_match. */
-struct checksum_fixture {
-    checksum_fixture()
+/* Fixture to initialize the kp header. */
+struct kp_header_fixture {
+    WT_CRYPT_KEYS crypt;
+    std::shared_ptr<mock_session> session;
+    const std::string test_string;
+
+    WT_SESSION_IMPL *session_impl;
+
+    kp_header_fixture()
+        : crypt({}), session(mock_session::build_test_mock_session()), test_string("hello")
     {
         // Initialize the checksum function if not already initialized.
         if (__wt_process.checksum == nullptr)
             __wt_process.checksum = wiredtiger_crc32c_func();
+
+        session_impl = session->get_wt_session_impl();
+        kp_crypt_key_buffer(session_impl, test_string);
+    }
+
+    ~kp_header_fixture()
+    {
+        __wt_buf_free(session_impl, &crypt.keys);
+    }
+
+    void
+    kp_crypt_key_buffer(WT_SESSION_IMPL *session, const std::string &str)
+    {
+        /* Allocate a buffer and make sure we leave enough space for the header at the start. */
+        REQUIRE(
+          __wt_buf_initsize(session, &crypt.keys, sizeof(WT_CRYPT_HEADER) + str.size()) == 0);
+        memcpy(((uint8_t *)(crypt.keys.data) + sizeof(WT_CRYPT_HEADER)), str.data(), str.size());
+        crypt.keys.size = str.size();
+        crypt.keys.data = (uint8_t *)(crypt.keys.data) + sizeof(WT_CRYPT_HEADER);
     }
 };
 
-static void
-create_crypt_key_buffer(WT_SESSION_IMPL *session, WT_CRYPT_KEYS *crypt, const std::string &str)
-{
-    /* Allocate a buffer and make sure we leave enough space for the header at the start. */
-    REQUIRE(__wt_buf_initsize(session, &crypt->keys, 512) == 0);
-    memcpy(((uint8_t *)(crypt->keys.data) + sizeof(WT_CRYPT_HEADER)), str.data(), str.size());
-    crypt->keys.size = str.size();
-    crypt->keys.data = (uint8_t *)(crypt->keys.data) + sizeof(WT_CRYPT_HEADER);
-}
-
 TEST_CASE_METHOD(
-  checksum_fixture, "Validate crypt header offsets and size", "[key_provider_header]")
+  kp_header_fixture, "Validate crypt header offsets and size", "[key_provider_header]")
 {
     REQUIRE(sizeof(WT_CRYPT_HEADER) == 16);
     REQUIRE(offsetof(WT_CRYPT_HEADER, signature) == 0);
@@ -45,15 +59,8 @@ TEST_CASE_METHOD(
     REQUIRE(offsetof(WT_CRYPT_HEADER, checksum) == 12);
 }
 
-TEST_CASE_METHOD(checksum_fixture, "Key provider set header function", "[key_provider_header]")
+TEST_CASE_METHOD(kp_header_fixture, "Key provider set header function", "[key_provider_header]")
 {
-    WT_CRYPT_KEYS crypt = {};
-    std::shared_ptr<mock_session> session = mock_session::build_test_mock_session();
-
-    const std::string test_string("hello");
-
-    WT_SESSION_IMPL *session_impl = session->get_wt_session_impl();
-    create_crypt_key_buffer(session_impl, &crypt, test_string);
     uint32_t checksum = __wt_checksum(crypt.keys.data, crypt.keys.size);
     SECTION("Validate key provider pack")
     {
@@ -61,9 +68,7 @@ TEST_CASE_METHOD(checksum_fixture, "Key provider set header function", "[key_pro
 
         /* Validate crypt header information. */
         WT_CRYPT_HEADER write_crypt_header;
-        memcpy(&write_crypt_header, crypt.keys.data, sizeof(WT_CRYPT_HEADER));
-        /* Set function internally calls byteswap, swap it back to validate the header. */
-        __wt_crypt_header_byteswap(&write_crypt_header);
+        __ut_disagg_get_crypt_header(&crypt.keys, &write_crypt_header);
         REQUIRE(write_crypt_header.signature == WT_CRYPT_HEADER_SIGNATURE);
         REQUIRE(write_crypt_header.version == WT_CRYPT_HEADER_VERSION);
         REQUIRE(write_crypt_header.compatible_version == WT_CRYPT_HEADER_COMPATIBLE_VERSION);
@@ -75,16 +80,9 @@ TEST_CASE_METHOD(checksum_fixture, "Key provider set header function", "[key_pro
     __wt_buf_free(session_impl, &crypt.keys);
 }
 
-TEST_CASE_METHOD(checksum_fixture, "Key provider: validate crypt function", "[key_provider_header]")
+TEST_CASE_METHOD(kp_header_fixture, "Key provider: validate crypt function", "[key_provider_header]")
 {
-    WT_CRYPT_KEYS crypt = {};
-    std::shared_ptr<mock_session> session = mock_session::build_test_mock_session();
-
-    const std::string test_string("hello");
-    WT_SESSION_IMPL *session_impl = session->get_wt_session_impl();
-
     /* Set the header inside the crypt struct. */
-    create_crypt_key_buffer(session_impl, &crypt, test_string);
     __ut_disagg_set_crypt_header(session_impl, &crypt);
 
     WT_CRYPT_HEADER read_crypt_header;
@@ -92,9 +90,7 @@ TEST_CASE_METHOD(checksum_fixture, "Key provider: validate crypt function", "[ke
     {
         /* Fetch the baseline header before performing read. */
         WT_CRYPT_HEADER write_crypt_header;
-        memcpy(&write_crypt_header, crypt.keys.data, sizeof(WT_CRYPT_HEADER));
-        /* Set function internally calls byteswap, swap it back to validate the header. */
-        __wt_crypt_header_byteswap(&write_crypt_header);
+        __ut_disagg_get_crypt_header(&crypt.keys, &write_crypt_header);
         REQUIRE(__ut_disagg_validate_crypt(session_impl, &crypt.keys, &read_crypt_header) == 0);
 
         /* Validate that before and after validation should not change the header. */
@@ -105,9 +101,7 @@ TEST_CASE_METHOD(checksum_fixture, "Key provider: validate crypt function", "[ke
     {
         /* Fetch the baseline header before performing read. */
         WT_CRYPT_HEADER write_crypt_header;
-        memcpy(&write_crypt_header, crypt.keys.data, sizeof(WT_CRYPT_HEADER));
-        /* Set function internally calls byteswap, swap it back to validate the header. */
-        __wt_crypt_header_byteswap(&write_crypt_header);
+        __ut_disagg_get_crypt_header(&crypt.keys, &write_crypt_header);
         write_crypt_header.version = 2;
 
         WT_CRYPT_HEADER *header = (WT_CRYPT_HEADER *)crypt.keys.data;
@@ -153,5 +147,4 @@ TEST_CASE_METHOD(checksum_fixture, "Key provider: validate crypt function", "[ke
         header->checksum = 123;
         REQUIRE(__ut_disagg_validate_crypt(session_impl, &crypt.keys, &read_crypt_header) == EIO);
     }
-    __wt_buf_free(session_impl, &crypt.keys);
 }

--- a/test/catch2/ext/test_key_provider_header.cpp
+++ b/test/catch2/ext/test_key_provider_header.cpp
@@ -57,7 +57,7 @@ TEST_CASE("Key provider set header function", "[key_provider_header]")
         REQUIRE(write_crypt_header.checksum == checksum);
         REQUIRE(crypt.keys.size == test_string.size() + sizeof(WT_CRYPT_HEADER));
     }
-    __wt_buf_free(session->get_wt_session_impl(), &crypt.keys);
+    __wt_buf_free(session_impl, &crypt.keys);
 }
 
 TEST_CASE("Key provider: validate crypt function", "[key_provider_header]")

--- a/test/catch2/ext/test_key_provider_header.cpp
+++ b/test/catch2/ext/test_key_provider_header.cpp
@@ -32,7 +32,8 @@ create_crypt_key_buffer(WT_SESSION_IMPL *session, WT_CRYPT_KEYS *crypt, const st
     crypt->keys.data = (uint8_t *)(crypt->keys.data) + sizeof(WT_CRYPT_HEADER);
 }
 
-TEST_CASE_METHOD(checksum_fixture, "Validate crypt header offsets and size", "[key_provider_header]")
+TEST_CASE_METHOD(
+  checksum_fixture, "Validate crypt header offsets and size", "[key_provider_header]")
 {
     REQUIRE(sizeof(WT_CRYPT_HEADER) == 16);
     REQUIRE(offsetof(WT_CRYPT_HEADER, signature) == 0);

--- a/test/catch2/ext/test_key_provider_header.cpp
+++ b/test/catch2/ext/test_key_provider_header.cpp
@@ -8,8 +8,9 @@
 #include "wt_internal.h"
 
 #include <catch2/catch.hpp>
-#include "../wrappers/mock_session.h"
-void create_crypt_key_buffer(WT_SESSION_IMPL *session, WT_CRYPT_KEYS *crypt, std::string &str);
+#include "wrappers/mock_session.h"
+static void create_crypt_key_buffer(
+  WT_SESSION_IMPL *session, WT_CRYPT_KEYS *crypt, const std::string &str);
 
 /* Fixture to initialize the checksum function needed by __wt_checksum and __wt_checksum_match. */
 struct checksum_fixture {
@@ -21,8 +22,8 @@ struct checksum_fixture {
     }
 };
 
-void
-create_crypt_key_buffer(WT_SESSION_IMPL *session, WT_CRYPT_KEYS *crypt, std::string &str)
+static void
+create_crypt_key_buffer(WT_SESSION_IMPL *session, WT_CRYPT_KEYS *crypt, const std::string &str)
 {
     /* Allocate a buffer and make sure we leave enough space for the header at the start. */
     REQUIRE(__wt_buf_initsize(session, &crypt->keys, 512) == 0);
@@ -31,14 +32,12 @@ create_crypt_key_buffer(WT_SESSION_IMPL *session, WT_CRYPT_KEYS *crypt, std::str
     crypt->keys.data = (uint8_t *)(crypt->keys.data) + sizeof(WT_CRYPT_HEADER);
 }
 
-TEST_CASE("Key provider set header function", "[key_provider_header]")
+TEST_CASE_METHOD(checksum_fixture, "Key provider set header function", "[key_provider_header]")
 {
-    checksum_fixture fixture;
-    WT_CRYPT_KEYS crypt;
+    WT_CRYPT_KEYS crypt = {};
     std::shared_ptr<mock_session> session = mock_session::build_test_mock_session();
 
-    WT_CLEAR(crypt.keys);
-    std::string test_string("hello");
+    const std::string test_string("hello");
 
     WT_SESSION_IMPL *session_impl = session->get_wt_session_impl();
     create_crypt_key_buffer(session_impl, &crypt, test_string);
@@ -50,6 +49,8 @@ TEST_CASE("Key provider set header function", "[key_provider_header]")
         /* Validate crypt header information. */
         WT_CRYPT_HEADER write_crypt_header;
         memcpy(&write_crypt_header, crypt.keys.data, sizeof(WT_CRYPT_HEADER));
+        /* Set function internally calls byteswap, swap it back to validate the header. */
+        __wt_crypt_header_byteswap(&write_crypt_header);
         REQUIRE(write_crypt_header.signature == WT_CRYPT_HEADER_SIGNATURE);
         REQUIRE(write_crypt_header.version == WT_CRYPT_HEADER_VERSION);
         REQUIRE(write_crypt_header.compatible_version == WT_CRYPT_HEADER_COMPATIBLE_VERSION);
@@ -61,14 +62,12 @@ TEST_CASE("Key provider set header function", "[key_provider_header]")
     __wt_buf_free(session_impl, &crypt.keys);
 }
 
-TEST_CASE("Key provider: validate crypt function", "[key_provider_header]")
+TEST_CASE_METHOD(checksum_fixture, "Key provider: validate crypt function", "[key_provider_header]")
 {
-    checksum_fixture fixture;
-    WT_CRYPT_KEYS crypt;
+    WT_CRYPT_KEYS crypt = {};
     std::shared_ptr<mock_session> session = mock_session::build_test_mock_session();
 
-    WT_CLEAR(crypt.keys);
-    std::string test_string("hello");
+    const std::string test_string("hello");
     WT_SESSION_IMPL *session_impl = session->get_wt_session_impl();
 
     /* Set the header inside the crypt struct. */
@@ -81,7 +80,8 @@ TEST_CASE("Key provider: validate crypt function", "[key_provider_header]")
         /* Fetch the baseline header before performing read. */
         WT_CRYPT_HEADER write_crypt_header;
         memcpy(&write_crypt_header, crypt.keys.data, sizeof(WT_CRYPT_HEADER));
-
+        /* Set function internally calls byteswap, swap it back to validate the header. */
+        __wt_crypt_header_byteswap(&write_crypt_header);
         REQUIRE(__ut_disagg_validate_crypt(session_impl, &crypt.keys, &read_crypt_header) == 0);
 
         /* Validate that before and after validation should not change the header. */
@@ -93,6 +93,8 @@ TEST_CASE("Key provider: validate crypt function", "[key_provider_header]")
         /* Fetch the baseline header before performing read. */
         WT_CRYPT_HEADER write_crypt_header;
         memcpy(&write_crypt_header, crypt.keys.data, sizeof(WT_CRYPT_HEADER));
+        /* Set function internally calls byteswap, swap it back to validate the header. */
+        __wt_crypt_header_byteswap(&write_crypt_header);
         write_crypt_header.version = 2;
 
         WT_CRYPT_HEADER *header = (WT_CRYPT_HEADER *)crypt.keys.data;

--- a/test/catch2/ext/test_key_provider_header.cpp
+++ b/test/catch2/ext/test_key_provider_header.cpp
@@ -1,0 +1,135 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+#include "wt_internal.h"
+
+#include <catch2/catch.hpp>
+#include "../wrappers/mock_session.h"
+void create_crypt_key_buffer(WT_SESSION_IMPL *session, WT_CRYPT_KEYS *crypt, std::string &str);
+
+/* Fixture to initialize the checksum function needed by __wt_checksum and __wt_checksum_match. */
+struct checksum_fixture {
+    checksum_fixture()
+    {
+        // Initialize the checksum function if not already initialized.
+        if (__wt_process.checksum == nullptr)
+            __wt_process.checksum = wiredtiger_crc32c_func();
+    }
+};
+
+void
+create_crypt_key_buffer(WT_SESSION_IMPL *session, WT_CRYPT_KEYS *crypt, std::string &str)
+{
+    /* Allocate a buffer and make sure we leave enough space for the header at the start. */
+    REQUIRE(__wt_buf_initsize(session, &crypt->keys, 512) == 0);
+    memcpy(((uint8_t *)(crypt->keys.data) + sizeof(WT_CRYPT_HEADER)), str.data(), str.size());
+    crypt->keys.size = str.size();
+    crypt->keys.data = (uint8_t *)(crypt->keys.data) + sizeof(WT_CRYPT_HEADER);
+}
+
+TEST_CASE("Key provider set header function", "[key_provider_header]")
+{
+    checksum_fixture fixture;
+    WT_CRYPT_KEYS crypt;
+    std::shared_ptr<mock_session> session = mock_session::build_test_mock_session();
+
+    std::string test_string("hello");
+
+    WT_SESSION_IMPL *session_impl = session->get_wt_session_impl();
+    create_crypt_key_buffer(session_impl, &crypt, test_string);
+    uint32_t checksum = __wt_checksum(crypt.keys.data, crypt.keys.size);
+    SECTION("Validate key provider pack")
+    {
+
+        __ut_disagg_set_crypt_header(session->get_wt_session_impl(), &crypt);
+
+        /* Validate crypt header information. */
+        WT_CRYPT_HEADER write_crypt_header;
+        memcpy(&write_crypt_header, crypt.keys.data, sizeof(WT_CRYPT_HEADER));
+        REQUIRE(write_crypt_header.signature == WT_CRYPT_HEADER_SIGNATURE);
+        REQUIRE(write_crypt_header.version == WT_CRYPT_HEADER_VERSION);
+        REQUIRE(write_crypt_header.compatible_version == WT_CRYPT_HEADER_COMPATIBLE_VERSION);
+        REQUIRE(write_crypt_header.header_size == sizeof(WT_CRYPT_HEADER));
+        REQUIRE(write_crypt_header.crypt_size == test_string.size());
+        REQUIRE(write_crypt_header.checksum == checksum);
+        REQUIRE(crypt.keys.size == test_string.size() + sizeof(WT_CRYPT_HEADER));
+    }
+    __wt_buf_free(session->get_wt_session_impl(), &crypt.keys);
+}
+
+TEST_CASE("Key provider: validate crypt function", "[key_provider_header]")
+{
+    checksum_fixture fixture;
+    WT_CRYPT_KEYS crypt;
+    std::shared_ptr<mock_session> session = mock_session::build_test_mock_session();
+
+    WT_CLEAR(crypt.keys);
+    std::string test_string("hello");
+    WT_SESSION_IMPL *session_impl = session->get_wt_session_impl();
+
+    /* Set the header inside the crypt struct. */
+    create_crypt_key_buffer(session_impl, &crypt, test_string);
+    __ut_disagg_set_crypt_header(session_impl, &crypt);
+
+    WT_CRYPT_HEADER read_crypt_header;
+    SECTION("Test key provider basic unpack")
+    {
+        /* Fetch the baseline header before performing read. */
+        WT_CRYPT_HEADER write_crypt_header;
+        memcpy(&write_crypt_header, crypt.keys.data, sizeof(WT_CRYPT_HEADER));
+
+        REQUIRE(__ut_disagg_validate_crypt(session_impl, &crypt.keys, &read_crypt_header) == 0);
+
+        /* Validate that before and after validation should not change the header. */
+        REQUIRE(memcmp(&write_crypt_header, &read_crypt_header, sizeof(WT_CRYPT_HEADER)) == 0);
+    }
+
+    SECTION("Test key provider header version")
+    {
+        /* Fetch the baseline header before performing read. */
+        WT_CRYPT_HEADER write_crypt_header;
+        memcpy(&write_crypt_header, crypt.keys.data, sizeof(WT_CRYPT_HEADER));
+        write_crypt_header.version = 2;
+
+        WT_CRYPT_HEADER *header = (WT_CRYPT_HEADER *)crypt.keys.data;
+        header->compatible_version = 1;
+        header->version = 2;
+        REQUIRE(__ut_disagg_validate_crypt(session_impl, &crypt.keys, &read_crypt_header) == 0);
+
+        /* Validate that before and after validation should not change the header. */
+        REQUIRE(memcmp(&write_crypt_header, &read_crypt_header, sizeof(WT_CRYPT_HEADER)) == 0);
+    }
+
+    SECTION("Test key provider header compatibility issue")
+    {
+        WT_CRYPT_HEADER *header = (WT_CRYPT_HEADER *)crypt.keys.data;
+        header->compatible_version = 2;
+        header->version = 1;
+        REQUIRE(
+          __ut_disagg_validate_crypt(session_impl, &crypt.keys, &read_crypt_header) == ENOTSUP);
+    }
+
+    SECTION("Test key provider header size smaller than header")
+    {
+        crypt.keys.size = 1;
+        REQUIRE(__ut_disagg_validate_crypt(session_impl, &crypt.keys, &read_crypt_header) == EIO);
+    }
+
+    SECTION("Test key provider header mismatch size")
+    {
+        crypt.keys.size = 50;
+        REQUIRE(__ut_disagg_validate_crypt(session_impl, &crypt.keys, &read_crypt_header) == EIO);
+    }
+
+    SECTION("Test key provider header mismatch checksum")
+    {
+        WT_CRYPT_HEADER *header = (WT_CRYPT_HEADER *)crypt.keys.data;
+        header->checksum = 123;
+        REQUIRE(__ut_disagg_validate_crypt(session_impl, &crypt.keys, &read_crypt_header) == EIO);
+    }
+    __wt_buf_free(session_impl, &crypt.keys);
+}

--- a/test/catch2/ext/test_key_provider_header.cpp
+++ b/test/catch2/ext/test_key_provider_header.cpp
@@ -38,8 +38,7 @@ struct kp_header_fixture {
     kp_crypt_key_buffer(WT_SESSION_IMPL *session, const std::string &str)
     {
         /* Allocate a buffer and make sure we leave enough space for the header at the start. */
-        REQUIRE(
-          __wt_buf_initsize(session, &crypt.keys, sizeof(WT_CRYPT_HEADER) + str.size()) == 0);
+        REQUIRE(__wt_buf_initsize(session, &crypt.keys, sizeof(WT_CRYPT_HEADER) + str.size()) == 0);
         memcpy(((uint8_t *)(crypt.keys.data) + sizeof(WT_CRYPT_HEADER)), str.data(), str.size());
         crypt.keys.size = str.size();
         crypt.keys.data = (uint8_t *)(crypt.keys.data) + sizeof(WT_CRYPT_HEADER);
@@ -80,7 +79,8 @@ TEST_CASE_METHOD(kp_header_fixture, "Key provider set header function", "[key_pr
     __wt_buf_free(session_impl, &crypt.keys);
 }
 
-TEST_CASE_METHOD(kp_header_fixture, "Key provider: validate crypt function", "[key_provider_header]")
+TEST_CASE_METHOD(
+  kp_header_fixture, "Key provider: validate crypt function", "[key_provider_header]")
 {
     /* Set the header inside the crypt struct. */
     __ut_disagg_set_crypt_header(session_impl, &crypt);

--- a/test/catch2/ext/test_key_provider_header.cpp
+++ b/test/catch2/ext/test_key_provider_header.cpp
@@ -32,6 +32,18 @@ create_crypt_key_buffer(WT_SESSION_IMPL *session, WT_CRYPT_KEYS *crypt, const st
     crypt->keys.data = (uint8_t *)(crypt->keys.data) + sizeof(WT_CRYPT_HEADER);
 }
 
+TEST_CASE_METHOD(checksum_fixture, "Validate crypt header offsets and size", "[key_provider_header]")
+{
+    REQUIRE(sizeof(WT_CRYPT_HEADER) == 16);
+    REQUIRE(offsetof(WT_CRYPT_HEADER, signature) == 0);
+    REQUIRE(offsetof(WT_CRYPT_HEADER, version) == 4);
+    REQUIRE(offsetof(WT_CRYPT_HEADER, compatible_version) == 5);
+    REQUIRE(offsetof(WT_CRYPT_HEADER, header_size) == 6);
+    REQUIRE(offsetof(WT_CRYPT_HEADER, unused) == 7);
+    REQUIRE(offsetof(WT_CRYPT_HEADER, crypt_size) == 8);
+    REQUIRE(offsetof(WT_CRYPT_HEADER, checksum) == 12);
+}
+
 TEST_CASE_METHOD(checksum_fixture, "Key provider set header function", "[key_provider_header]")
 {
     WT_CRYPT_KEYS crypt = {};


### PR DESCRIPTION
In the future, if we need to downgrade our customer, we need to check whether we can go to a lower crypt header version. The minimum compatibility version will provide us information whether or not we can do this or not. Also placing a safeguard to ensure that this doesn't happen.