### PR TITLE
WT-16328 Remove layered08 suppression from asan leaks file

### DIFF
--- a/test/evergreen/asan_leaks.supp
+++ b/test/evergreen/asan_leaks.supp
@@ -15,9 +15,6 @@ leak:__wt_chunkcache_setup
 # FIXME-WT-16327: test_chunkcache02
 leak:__chunkcache_metadata_queue_internal
 
-# FIXME-WT-16328: test_layered08
-leak:__wt_dlopen
-
 # FIXME-WT-16331: test_tiered04
 leak:__tiered_name_str
 


### PR DESCRIPTION
Remove layered08 suppression from asan leaks file as the leak is not happening anymore.
