### PR TITLE
WT-16292 Ensure that we read from the matching shared history store checkpoints after reading a stable table in standby

### DIFF
--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -272,7 +272,7 @@ __debug_config(WT_SESSION_IMPL *session, WT_DBG *ds, const char *ofile, uint32_t
     if (!F_ISSET(conn, WT_CONN_IN_MEMORY) && !WT_IS_HS(session->dhandle) &&
       !(WT_READING_CHECKPOINT(session) && session->hs_checkpoint == NULL)) {
         WT_ASSERT(session, session->dhandle != NULL);
-        WT_ERR(__wt_curhs_open(session, NULL, S2BT(session)->id, NULL, &ds->hs_cursor));
+        WT_ERR(__wt_curhs_open(session, S2BT(session)->id, NULL, NULL, &ds->hs_cursor));
     }
 
     if (ds->hs_cursor != NULL) {
@@ -1056,7 +1056,7 @@ __wt_debug_cursor_tree_hs(void *cursor_arg, const char *ofile)
         if (ret == WT_NOTFOUND)
             return (0);
 
-        WT_RET(__wt_curhs_open_ext(session, NULL, hs_id, 0, NULL, &hs_cursor));
+        WT_RET(__wt_curhs_open_ext(session, hs_id, 0, NULL, NULL, &hs_cursor));
         hs_btree = __wt_curhs_get_btree(hs_cursor);
         WT_WITH_BTREE(session, hs_btree, ret = __wt_debug_tree_all(session, NULL, NULL, ofile));
         WT_TRET(hs_cursor->close(hs_cursor));

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -272,7 +272,7 @@ __debug_config(WT_SESSION_IMPL *session, WT_DBG *ds, const char *ofile, uint32_t
     if (!F_ISSET(conn, WT_CONN_IN_MEMORY) && !WT_IS_HS(session->dhandle) &&
       !(WT_READING_CHECKPOINT(session) && session->hs_checkpoint == NULL)) {
         WT_ASSERT(session, session->dhandle != NULL);
-        WT_ERR(__wt_curhs_open(session, S2BT(session)->id, NULL, &ds->hs_cursor));
+        WT_ERR(__wt_curhs_open(session, NULL, S2BT(session)->id, NULL, &ds->hs_cursor));
     }
 
     if (ds->hs_cursor != NULL) {
@@ -1056,7 +1056,7 @@ __wt_debug_cursor_tree_hs(void *cursor_arg, const char *ofile)
         if (ret == WT_NOTFOUND)
             return (0);
 
-        WT_RET(__wt_curhs_open_ext(session, hs_id, 0, NULL, &hs_cursor));
+        WT_RET(__wt_curhs_open_ext(session, NULL, hs_id, 0, NULL, &hs_cursor));
         hs_btree = __wt_curhs_get_btree(hs_cursor);
         WT_WITH_BTREE(session, hs_btree, ret = __wt_debug_tree_all(session, NULL, NULL, ofile));
         WT_TRET(hs_cursor->close(hs_cursor));

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -52,28 +52,15 @@ __btree_clear(WT_SESSION_IMPL *session)
  *     Pin the history store dhandle for the stable btree.
  */
 static int
-__btree_pin_hs_dhandle(WT_SESSION_IMPL *session, WT_BTREE *btree, int64_t ds_checkpoint_order)
+__btree_pin_hs_dhandle(WT_SESSION_IMPL *session, WT_BTREE *btree)
 {
     WT_DECL_ITEM(hs_uri_buf);
     WT_DECL_RET;
-    int64_t hs_checkpoint_order;
     const char *hs_checkpoint_name;
 
     /* Look up the most recent history store checkpoint. This fetches the exact name to use. */
-    WT_RET(__wt_meta_checkpoint_last_name(
-      session, WT_HS_URI_SHARED, &hs_checkpoint_name, &hs_checkpoint_order, NULL));
-
-    /*
-     * The history store checkpoint is more recent than the data store table checkpoint, indicating
-     * a race condition while acquiring a new checkpoint. Respond with "busy" to prompt the caller
-     * to retry.
-     *
-     * TODO: how to ensure the order are consistent for checkpoints written by different nodes?
-     */
-    if (hs_checkpoint_order > ds_checkpoint_order) {
-        ret = __wt_set_return(session, EBUSY);
-        goto err;
-    }
+    WT_RET(
+      __wt_meta_checkpoint_last_name(session, WT_HS_URI_SHARED, &hs_checkpoint_name, NULL, NULL));
 
     WT_ERR(__wt_scr_alloc(session, 0, &hs_uri_buf));
     /*
@@ -81,16 +68,7 @@ __btree_pin_hs_dhandle(WT_SESSION_IMPL *session, WT_BTREE *btree, int64_t ds_che
      * checkpoint, but without it being a traditional checkpoint cursor.
      */
     WT_ERR(__wt_buf_fmt(session, hs_uri_buf, "%s/%s", WT_HS_URI_SHARED, hs_checkpoint_name));
-    WT_ERR_NOTFOUND_OK(__wt_session_get_dhandle(session, hs_uri_buf->data, NULL, NULL, 0), true);
-
-    /*
-     * A new checkpoint is promptly picked up, and the old checkpoint is removed. Respond with a
-     * "busy" status to prompt the caller to retry.
-     */
-    if (ret == WT_NOTFOUND) {
-        ret = __wt_set_return(session, EBUSY);
-        goto err;
-    }
+    WT_ERR(__wt_session_get_dhandle(session, hs_uri_buf->data, NULL, NULL, 0));
 
     (void)__wt_atomic_add_int32(&session->dhandle->session_inuse, 1);
     WT_ERR(__wt_session_release_dhandle(session));
@@ -102,6 +80,37 @@ __btree_pin_hs_dhandle(WT_SESSION_IMPL *session, WT_BTREE *btree, int64_t ds_che
 err:
     __wt_scr_free(session, &hs_uri_buf);
     __wt_free(session, hs_checkpoint_name);
+    return (ret);
+}
+
+/*
+ * __btree_pin_hs_dhandle_and_get_meta_checkpoint --
+ *     Pin the history store dhandle for the stable btree and get the stable btree checkpoint
+ *     information.
+ */
+static int
+__btree_pin_hs_dhandle_and_get_meta_checkpoint(WT_SESSION_IMPL *session, WT_BTREE *btree,
+  const char *dhandle_name, const char *checkpoint, WT_CKPT *ckpt,
+  WT_LIVE_RESTORE_FH_META *lr_fh_meta)
+{
+    WT_DECL_RET;
+
+    /* Pin the matching history store dhandle in the session. */
+    if (!WT_IS_URI_HS(dhandle_name))
+        WT_WITHOUT_DHANDLE(session, ret = __btree_pin_hs_dhandle(session, btree));
+    /* The shared history store might be empty and may not have been checkpointed before. */
+    WT_RET_NOTFOUND_OK(ret);
+    /*
+     * A race condition occurs while acquiring a new checkpoint, resulting in the intended
+     * checkpoint no longer being available. Respond with "busy" to prompt the caller to retry.
+     */
+    WT_ERR_NOTFOUND_OK(
+      __wt_meta_checkpoint(session, dhandle_name, checkpoint, ckpt, lr_fh_meta), true);
+    if (ret == WT_NOTFOUND)
+        return (__wt_set_return(session, EBUSY));
+    F_SET(btree, WT_BTREE_READONLY);
+
+err:
     return (ret);
 }
 
@@ -156,17 +165,11 @@ __wt_btree_open(WT_SESSION_IMPL *session, const char *op_cfg[])
 
     /* Get the checkpoint information for this name/checkpoint pair. */
     if (checkpoint != NULL) {
-        WT_ERR_NOTFOUND_OK(
-          __wt_meta_checkpoint(session, dhandle_name, checkpoint, &ckpt, &lr_fh_meta), true);
-        /*
-         * A new checkpoint is promptly picked up, and the old checkpoint is removed. Respond with a
-         * "busy" status to prompt the caller to retry.
-         */
-        if (ret == WT_NOTFOUND) {
-            ret = __wt_set_return(session, EBUSY);
-            goto err;
-        }
-        F_SET(btree, WT_BTREE_READONLY);
+        /* Acquiring the checkpoint lock to prevent racing with picking up a new checkpoint. */
+        WT_WITH_CHECKPOINT_LOCK(session,
+          ret = __btree_pin_hs_dhandle_and_get_meta_checkpoint(
+            session, btree, dhandle_name, checkpoint, &ckpt, &lr_fh_meta));
+        WT_ERR(ret);
     } else
         WT_ERR(
           __wt_meta_checkpoint(session, dhandle_name, dhandle->checkpoint, &ckpt, &lr_fh_meta));
@@ -175,13 +178,6 @@ __wt_btree_open(WT_SESSION_IMPL *session, const char *op_cfg[])
 
     /* Set the order number. */
     dhandle->checkpoint_order = ckpt.order;
-
-    /* Pin the matching history store dhandle in the session. */
-    if (checkpoint != NULL && !WT_IS_URI_HS(dhandle_name)) {
-        WT_WITHOUT_DHANDLE(session, ret = __btree_pin_hs_dhandle(session, btree, ckpt.order));
-        /* The shared history store might be empty and may not have been checkpointed before. */
-        WT_ERR_NOTFOUND_OK(ret, false);
-    }
 
     /*
      * Bulk-load is only permitted on newly created files, not any empty file -- see the checkpoint

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -168,7 +168,8 @@ __wt_btree_open(WT_SESSION_IMPL *session, const char *op_cfg[])
         /*
          * Acquiring the checkpoint lock to prevent racing with picking up a new checkpoint.
          *
-         * TODO: if we directly read from the shared metadata, we can avoid the lock here.
+         * FIXME-WT-16477: if we directly read from the shared metadata, we can avoid taking the
+         * checkpoint lock here.
          */
         WT_WITH_CHECKPOINT_LOCK(session,
           ret = __btree_pin_hs_dhandle_and_get_meta_checkpoint(

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -93,7 +93,7 @@ __btree_release_hs_dhandle(WT_SESSION_IMPL *session, WT_BTREE *btree)
     WT_DECL_ITEM(hs_uri_buf);
     WT_DECL_RET;
 
-    WT_RET_NOLOG(__wt_scr_alloc(session, 0, &hs_uri_buf));
+    WT_RET(__wt_scr_alloc(session, 0, &hs_uri_buf));
     /*
      * Use a URI with a "/<checkpoint name> suffix. This is interpreted as reading from the stable
      * checkpoint, but without it being a traditional checkpoint cursor.

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -84,6 +84,36 @@ err:
 }
 
 /*
+ * __btree_release_hs_dhandle --
+ *     Release the history store dhandle for the stable btree.
+ */
+static int
+__btree_release_hs_dhandle(WT_SESSION_IMPL *session, WT_BTREE *btree)
+{
+    WT_DECL_ITEM(hs_uri_buf);
+    WT_DECL_RET;
+
+    WT_ERR(__wt_scr_alloc(session, 0, &hs_uri_buf));
+    /*
+     * Use a URI with a "/<checkpoint name> suffix. This is interpreted as reading from the stable
+     * checkpoint, but without it being a traditional checkpoint cursor.
+     */
+    WT_ERR(__wt_buf_fmt(session, hs_uri_buf, "%s/%s", WT_HS_URI_SHARED, btree->hs_checkpoint_name));
+    WT_ERR(__wt_session_get_dhandle(session, hs_uri_buf->data, NULL, NULL, 0));
+
+    (void)__wt_atomic_sub_int32(&session->dhandle->session_inuse, 1);
+    WT_ERR(__wt_session_release_dhandle(session));
+    __wt_free(session, btree->hs_checkpoint_name);
+
+    __wt_scr_free(session, &hs_uri_buf);
+    return (0);
+
+err:
+    __wt_scr_free(session, &hs_uri_buf);
+    return (ret);
+}
+
+/*
  * __btree_pin_hs_dhandle_and_get_meta_checkpoint --
  *     Pin the history store dhandle for the stable btree and get the stable btree checkpoint
  *     information.
@@ -308,23 +338,8 @@ __wt_btree_close(WT_SESSION_IMPL *session)
     if (F_ISSET(btree, WT_BTREE_CLOSED))
         return (0);
 
-    if (btree->hs_checkpoint_name != NULL) {
-        WT_DECL_ITEM(hs_uri_buf);
-        WT_TRET(__wt_scr_alloc(session, 0, &hs_uri_buf));
-        /*
-         * Use a URI with a "/<checkpoint name> suffix. This is interpreted as reading from the
-         * stable checkpoint, but without it being a traditional checkpoint cursor.
-         */
-        WT_TRET(
-          __wt_buf_fmt(session, hs_uri_buf, "%s/%s", WT_HS_URI_SHARED, btree->hs_checkpoint_name));
-        WT_DATA_HANDLE *dhandle_save = session->dhandle;
-        WT_TRET(__wt_session_get_dhandle(session, hs_uri_buf->data, NULL, NULL, 0));
-        (void)__wt_atomic_sub_int32(&session->dhandle->session_inuse, 1);
-        WT_TRET(__wt_session_release_dhandle(session));
-        session->dhandle = dhandle_save;
-        __wt_scr_free(session, &hs_uri_buf);
-        __wt_free(session, btree->hs_checkpoint_name);
-    }
+    if (btree->hs_checkpoint_name != NULL)
+        WT_SAVE_DHANDLE(session, __btree_release_hs_dhandle(session, btree));
 
     F_SET(btree, WT_BTREE_CLOSED);
 

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -48,11 +48,11 @@ __btree_clear(WT_SESSION_IMPL *session)
 }
 
 /*
- * __btree_get_hs_dhandle --
+ * __btree_pin_hs_dhandle --
  *     Pin the history store dhandle for the stable btree.
  */
 static int
-__btree_get_hs_dhandle(WT_SESSION_IMPL *session, WT_BTREE *btree, int64_t ds_checkpoint_order)
+__btree_pin_hs_dhandle(WT_SESSION_IMPL *session, WT_BTREE *btree, int64_t ds_checkpoint_order)
 {
     WT_DECL_ITEM(hs_uri_buf);
     WT_DECL_RET;
@@ -178,7 +178,7 @@ __wt_btree_open(WT_SESSION_IMPL *session, const char *op_cfg[])
 
     /* Pin the matching history store dhandle in the session. */
     if (checkpoint != NULL && !WT_IS_URI_HS(dhandle_name)) {
-        WT_WITHOUT_DHANDLE(session, ret = __btree_get_hs_dhandle(session, btree, ckpt.order));
+        WT_WITHOUT_DHANDLE(session, ret = __btree_pin_hs_dhandle(session, btree, ckpt.order));
         /* The shared history store might be empty and may not have been checkpointed before. */
         WT_ERR_NOTFOUND_OK(ret, false);
     }

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -48,6 +48,64 @@ __btree_clear(WT_SESSION_IMPL *session)
 }
 
 /*
+ * __btree_get_hs_dhandle --
+ *     Pin the history store dhandle for the stable btree.
+ */
+static int
+__btree_get_hs_dhandle(WT_SESSION_IMPL *session, WT_BTREE *btree, int64_t ds_checkpoint_order)
+{
+    WT_DECL_ITEM(hs_uri_buf);
+    WT_DECL_RET;
+    int64_t hs_checkpoint_order;
+    const char *hs_checkpoint_name;
+
+    /* Look up the most recent history store checkpoint. This fetches the exact name to use. */
+    WT_RET(__wt_meta_checkpoint_last_name(
+      session, WT_HS_URI_SHARED, &hs_checkpoint_name, &hs_checkpoint_order, NULL));
+
+    /*
+     * The history store checkpoint is more recent than the data store table checkpoint, indicating
+     * a race condition while acquiring a new checkpoint. Respond with "busy" to prompt the caller
+     * to retry.
+     *
+     * TODO: how to ensure the order are consistent for checkpoints written by different nodes?
+     */
+    if (hs_checkpoint_order > ds_checkpoint_order) {
+        ret = __wt_set_return(session, EBUSY);
+        goto err;
+    }
+
+    WT_ERR(__wt_scr_alloc(session, 0, &hs_uri_buf));
+    /*
+     * Use a URI with a "/<checkpoint name> suffix. This is interpreted as reading from the stable
+     * checkpoint, but without it being a traditional checkpoint cursor.
+     */
+    WT_ERR(__wt_buf_fmt(session, hs_uri_buf, "%s/%s", WT_HS_URI_SHARED, hs_checkpoint_name));
+    WT_ERR_NOTFOUND_OK(__wt_session_get_dhandle(session, hs_uri_buf->data, NULL, NULL, 0), true);
+
+    /*
+     * A new checkpoint is promptly picked up, and the old checkpoint is removed. Respond with a
+     * "busy" status to prompt the caller to retry.
+     */
+    if (ret == WT_NOTFOUND) {
+        ret = __wt_set_return(session, EBUSY);
+        goto err;
+    }
+
+    (void)__wt_atomic_add_int32(&session->dhandle->session_inuse, 1);
+    WT_ERR(__wt_session_release_dhandle(session));
+    btree->hs_checkpoint_name = hs_checkpoint_name;
+
+    __wt_scr_free(session, &hs_uri_buf);
+    return (0);
+
+err:
+    __wt_scr_free(session, &hs_uri_buf);
+    __wt_free(session, hs_checkpoint_name);
+    return (ret);
+}
+
+/*
  * __wt_btree_open --
  *     Open a Btree.
  */
@@ -66,12 +124,13 @@ __wt_btree_open(WT_SESSION_IMPL *session, const char *op_cfg[])
     size_t root_addr_size;
     uint8_t root_addr[WT_ADDR_MAX_COOKIE];
     const char *dhandle_name, *checkpoint;
-    bool creation, forced_salvage;
+    bool creation, forced_salvage, has_ckpt;
 
     btree = S2BT(session);
     dhandle = session->dhandle;
     dhandle_name = dhandle->name;
     checkpoint = NULL;
+    has_ckpt = false;
     WT_CLEAR(lr_fh_meta);
 
     /*
@@ -97,14 +156,32 @@ __wt_btree_open(WT_SESSION_IMPL *session, const char *op_cfg[])
 
     /* Get the checkpoint information for this name/checkpoint pair. */
     if (checkpoint != NULL) {
-        WT_ERR(__wt_meta_checkpoint(session, dhandle_name, checkpoint, &ckpt, &lr_fh_meta));
+        WT_ERR_NOTFOUND_OK(
+          __wt_meta_checkpoint(session, dhandle_name, checkpoint, &ckpt, &lr_fh_meta), true);
+        /*
+         * A new checkpoint is promptly picked up, and the old checkpoint is removed. Respond with a
+         * "busy" status to prompt the caller to retry.
+         */
+        if (ret == WT_NOTFOUND) {
+            ret = __wt_set_return(session, EBUSY);
+            goto err;
+        }
         F_SET(btree, WT_BTREE_READONLY);
     } else
         WT_ERR(
           __wt_meta_checkpoint(session, dhandle_name, dhandle->checkpoint, &ckpt, &lr_fh_meta));
 
+    has_ckpt = true;
+
     /* Set the order number. */
     dhandle->checkpoint_order = ckpt.order;
+
+    /* Pin the matching history store dhandle in the session. */
+    if (checkpoint != NULL && !WT_IS_URI_HS(dhandle_name)) {
+        WT_WITHOUT_DHANDLE(session, ret = __btree_get_hs_dhandle(session, btree, ckpt.order));
+        /* The shared history store might be empty and may not have been checkpointed before. */
+        WT_ERR_NOTFOUND_OK(ret, false);
+    }
 
     /*
      * Bulk-load is only permitted on newly created files, not any empty file -- see the checkpoint
@@ -198,7 +275,8 @@ err:
         WT_TRET(__wt_btree_close(session));
     }
     __wt_free(session, lr_fh_meta.bitmap_str);
-    __wt_checkpoint_free(session, &ckpt);
+    if (has_ckpt)
+        __wt_checkpoint_free(session, &ckpt);
 
     __wt_scr_free(session, &name_buf);
     __wt_scr_free(session, &tmp);
@@ -228,6 +306,25 @@ __wt_btree_close(WT_SESSION_IMPL *session)
      */
     if (F_ISSET(btree, WT_BTREE_CLOSED))
         return (0);
+
+    if (btree->hs_checkpoint_name != NULL) {
+        WT_DECL_ITEM(hs_uri_buf);
+        WT_TRET(__wt_scr_alloc(session, 0, &hs_uri_buf));
+        /*
+         * Use a URI with a "/<checkpoint name> suffix. This is interpreted as reading from the
+         * stable checkpoint, but without it being a traditional checkpoint cursor.
+         */
+        WT_TRET(
+          __wt_buf_fmt(session, hs_uri_buf, "%s/%s", WT_HS_URI_SHARED, btree->hs_checkpoint_name));
+        WT_DATA_HANDLE *dhandle_save = session->dhandle;
+        WT_TRET(__wt_session_get_dhandle(session, hs_uri_buf->data, NULL, NULL, 0));
+        (void)__wt_atomic_sub_int32(&session->dhandle->session_inuse, 1);
+        WT_TRET(__wt_session_release_dhandle(session));
+        session->dhandle = dhandle_save;
+        __wt_scr_free(session, &hs_uri_buf);
+        __wt_free(session, btree->hs_checkpoint_name);
+    }
+
     F_SET(btree, WT_BTREE_CLOSED);
 
     /*

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -165,7 +165,11 @@ __wt_btree_open(WT_SESSION_IMPL *session, const char *op_cfg[])
 
     /* Get the checkpoint information for this name/checkpoint pair. */
     if (checkpoint != NULL) {
-        /* Acquiring the checkpoint lock to prevent racing with picking up a new checkpoint. */
+        /*
+         * Acquiring the checkpoint lock to prevent racing with picking up a new checkpoint.
+         *
+         * TODO: if we directly read from the shared metadata, we can avoid the lock here.
+         */
         WT_WITH_CHECKPOINT_LOCK(session,
           ret = __btree_pin_hs_dhandle_and_get_meta_checkpoint(
             session, btree, dhandle_name, checkpoint, &ckpt, &lr_fh_meta));

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -93,7 +93,7 @@ __btree_release_hs_dhandle(WT_SESSION_IMPL *session, WT_BTREE *btree)
     WT_DECL_ITEM(hs_uri_buf);
     WT_DECL_RET;
 
-    WT_ERR(__wt_scr_alloc(session, 0, &hs_uri_buf));
+    WT_RET_NOLOG(__wt_scr_alloc(session, 0, &hs_uri_buf));
     /*
      * Use a URI with a "/<checkpoint name> suffix. This is interpreted as reading from the stable
      * checkpoint, but without it being a traditional checkpoint cursor.

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -105,9 +105,6 @@ __btree_release_hs_dhandle(WT_SESSION_IMPL *session, WT_BTREE *btree)
     WT_ERR(__wt_session_release_dhandle(session));
     __wt_free(session, btree->hs_checkpoint_name);
 
-    __wt_scr_free(session, &hs_uri_buf);
-    return (0);
-
 err:
     __wt_scr_free(session, &hs_uri_buf);
     return (ret);

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1072,7 +1072,7 @@ __verify_key_hs(
 
     btree = S2BT(session);
     hs_btree_id = btree->id;
-    WT_RET(__wt_curhs_open(session, hs_btree_id, NULL, &hs_cursor));
+    WT_RET(__wt_curhs_open(session, NULL, hs_btree_id, NULL, &hs_cursor));
     F_SET(hs_cursor, WT_CURSTD_HS_READ_COMMITTED);
 
     /*

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1072,7 +1072,7 @@ __verify_key_hs(
 
     btree = S2BT(session);
     hs_btree_id = btree->id;
-    WT_RET(__wt_curhs_open(session, NULL, hs_btree_id, NULL, &hs_cursor));
+    WT_RET(__wt_curhs_open(session, hs_btree_id, NULL, NULL, &hs_cursor));
     F_SET(hs_cursor, WT_CURSTD_HS_READ_COMMITTED);
 
     /*

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -1008,12 +1008,12 @@ __disagg_apply_checkpoint_meta(WT_SESSION_IMPL *session, WT_SESSION_IMPL *intern
     cursor->set_key(cursor, WT_HS_URI_SHARED);
     WT_ERR_NOTFOUND_OK(cursor->search(cursor), true);
     if (ret == WT_NOTFOUND) {
-        WT_ERR(cursor->next(cursor));
+        WT_ERR_NOTFOUND_OK(cursor->next(cursor), true);
         is_shared_hs = false;
     } else
         is_shared_hs = true;
 
-    while (true) {
+    while (ret == 0) {
         WT_ERR(cursor->get_key(cursor, &metadata_key));
         WT_ERR(cursor->get_value(cursor, &metadata_value));
 
@@ -1091,10 +1091,10 @@ __disagg_apply_checkpoint_meta(WT_SESSION_IMPL *session, WT_SESSION_IMPL *intern
         }
 
         if (is_shared_hs) {
-            WT_ERR(cursor->reset(cursor));
             is_shared_hs = false;
-        } else
-            WT_ERR(cursor->next(cursor));
+            WT_ERR(cursor->reset(cursor));
+        }
+        WT_ERR_NOTFOUND_OK(cursor->next(cursor), true);
     }
     WT_ERR_NOTFOUND_OK(ret, false);
 

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -971,6 +971,7 @@ __disagg_apply_checkpoint_meta(WT_SESSION_IMPL *session, WT_SESSION_IMPL *intern
     uint32_t existing_tables, new_tables, new_ingest;
     char *layered_ingest_uri, *cfg_ret;
     const char *cfg[3], *current_value, *metadata_key, *metadata_value;
+    bool is_shared_hs;
 
     cursor = NULL;
     shared_metadata_session = NULL;
@@ -998,7 +999,21 @@ __disagg_apply_checkpoint_meta(WT_SESSION_IMPL *session, WT_SESSION_IMPL *intern
 
     WT_ERR(__wt_scr_alloc(session, 0, &metadata_cfg));
 
-    while ((ret = cursor->next(cursor)) == 0) {
+    /*
+     * TODO: Temporary workaround to ensure the shared history store is copied to the local metadata
+     * before other tables. This ensures detection of any race conditions between pinning a shared
+     * history store checkpoint while opening a stable table checkpoint and picking up a new
+     * checkpoint.
+     */
+    cursor->set_key(cursor, WT_HS_URI_SHARED);
+    WT_ERR_NOTFOUND_OK(cursor->search(cursor), true);
+    if (ret == WT_NOTFOUND) {
+        WT_ERR(cursor->next(cursor));
+        is_shared_hs = false;
+    } else
+        is_shared_hs = true;
+
+    while (true) {
         WT_ERR(cursor->get_key(cursor, &metadata_key));
         WT_ERR(cursor->get_value(cursor, &metadata_value));
 
@@ -1074,6 +1089,12 @@ __disagg_apply_checkpoint_meta(WT_SESSION_IMPL *session, WT_SESSION_IMPL *intern
               "Inserted new key to the local metadata \"%s\": \"%s\"", metadata_key,
               metadata_value);
         }
+
+        if (is_shared_hs) {
+            WT_ERR(cursor->reset(cursor));
+            is_shared_hs = false;
+        } else
+            WT_ERR(cursor->next(cursor));
     }
     WT_ERR_NOTFOUND_OK(ret, false);
 

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -971,7 +971,6 @@ __disagg_apply_checkpoint_meta(WT_SESSION_IMPL *session, WT_SESSION_IMPL *intern
     uint32_t existing_tables, new_tables, new_ingest;
     char *layered_ingest_uri, *cfg_ret;
     const char *cfg[3], *current_value, *metadata_key, *metadata_value;
-    bool is_shared_hs;
 
     cursor = NULL;
     shared_metadata_session = NULL;
@@ -999,21 +998,7 @@ __disagg_apply_checkpoint_meta(WT_SESSION_IMPL *session, WT_SESSION_IMPL *intern
 
     WT_ERR(__wt_scr_alloc(session, 0, &metadata_cfg));
 
-    /*
-     * TODO: Temporary workaround to ensure the shared history store is copied to the local metadata
-     * before other tables. This ensures detection of any race conditions between pinning a shared
-     * history store checkpoint while opening a stable table checkpoint and picking up a new
-     * checkpoint.
-     */
-    cursor->set_key(cursor, WT_HS_URI_SHARED);
-    WT_ERR_NOTFOUND_OK(cursor->search(cursor), true);
-    if (ret == WT_NOTFOUND) {
-        WT_ERR_NOTFOUND_OK(cursor->next(cursor), true);
-        is_shared_hs = false;
-    } else
-        is_shared_hs = true;
-
-    while (ret == 0) {
+    while ((ret = cursor->next(cursor)) == 0) {
         WT_ERR(cursor->get_key(cursor, &metadata_key));
         WT_ERR(cursor->get_value(cursor, &metadata_value));
 
@@ -1089,12 +1074,6 @@ __disagg_apply_checkpoint_meta(WT_SESSION_IMPL *session, WT_SESSION_IMPL *intern
               "Inserted new key to the local metadata \"%s\": \"%s\"", metadata_key,
               metadata_value);
         }
-
-        if (is_shared_hs) {
-            is_shared_hs = false;
-            WT_ERR(cursor->reset(cursor));
-        }
-        WT_ERR_NOTFOUND_OK(cursor->next(cursor), true);
     }
     WT_ERR_NOTFOUND_OK(ret, false);
 

--- a/src/cursor/cur_hs.c
+++ b/src/cursor/cur_hs.c
@@ -9,7 +9,8 @@
 #include "wt_internal.h"
 
 static int __curhs_file_cursor_next(WT_SESSION_IMPL *, WT_CURSOR *);
-static int __curhs_file_cursor_open(WT_SESSION_IMPL *, const char *, WT_CURSOR *, WT_CURSOR **);
+static int __curhs_file_cursor_open(
+  WT_SESSION_IMPL *, const char *, const char *, WT_CURSOR *, WT_CURSOR **);
 static int __curhs_file_cursor_prev(WT_SESSION_IMPL *, WT_CURSOR *);
 static int __curhs_file_cursor_search_near(WT_SESSION_IMPL *, WT_CURSOR *, int *);
 static int __curhs_prev_visible(WT_SESSION_IMPL *, WT_CURSOR_HS *);
@@ -21,16 +22,18 @@ static int __curhs_search_near_helper(WT_SESSION_IMPL *, WT_CURSOR *, bool);
  *     Open a new history store table cursor, internal function.
  */
 static int
-__curhs_file_cursor_open(
-  WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, WT_CURSOR **cursorp)
+__curhs_file_cursor_open(WT_SESSION_IMPL *session, const char *uri, const char *checkpoint_name,
+  WT_CURSOR *owner, WT_CURSOR **cursorp)
 {
     WT_CURSOR *cursor;
+    WT_DECL_ITEM(stable_uri_buf);
     WT_DECL_RET;
     size_t len;
     char *tmp;
 
     const char *open_cursor_cfg[] = {
       WT_CONFIG_BASE(session, WT_SESSION_open_cursor), "", NULL, NULL};
+    tmp = NULL;
 
     if (WT_READING_CHECKPOINT(session)) {
         /*
@@ -43,8 +46,17 @@ __curhs_file_cursor_open(
         WT_RET(__wt_malloc(session, len, &tmp));
         WT_ERR(__wt_snprintf(tmp, len, "checkpoint=%s", session->hs_checkpoint));
         open_cursor_cfg[2] = tmp;
-    } else
-        tmp = NULL;
+    } else if (checkpoint_name != NULL) {
+        WT_ASSERT(
+          session, __wt_conn_is_disagg(session) && !S2C(session)->layered_table_manager.leader);
+        WT_ERR(__wt_scr_alloc(session, 0, &stable_uri_buf));
+        /*
+         * Use a URI with a "/<checkpoint name> suffix. This is interpreted as reading from the
+         * stable checkpoint, but without it being a traditional checkpoint cursor.
+         */
+        WT_ERR(__wt_buf_fmt(session, stable_uri_buf, "%s/%s", uri, checkpoint_name));
+        uri = stable_uri_buf->data;
+    }
 
     WT_WITHOUT_DHANDLE(
       session, ret = __wt_open_cursor(session, uri, owner, open_cursor_cfg, &cursor));
@@ -57,6 +69,7 @@ __curhs_file_cursor_open(
 
 err:
     __wt_free(session, tmp);
+    __wt_scr_free(session, &stable_uri_buf);
     return (ret);
 }
 
@@ -138,11 +151,11 @@ __wt_curhs_cache(WT_SESSION_IMPL *session)
      * while still in use. However, history store dhandles are an exception as they are not subject
      * to sweeping.
      */
-    WT_RET(__curhs_file_cursor_open(session, WT_HS_URI, NULL, &cursor));
+    WT_RET(__curhs_file_cursor_open(session, WT_HS_URI, NULL, NULL, &cursor));
     WT_RET(cursor->close(cursor));
 
     if (__wt_conn_is_disagg(session)) {
-        WT_RET(__curhs_file_cursor_open(session, WT_HS_URI_SHARED, NULL, &cursor));
+        WT_RET(__curhs_file_cursor_open(session, WT_HS_URI_SHARED, NULL, NULL, &cursor));
         WT_RET(cursor->close(cursor));
     }
     return (0);
@@ -1394,12 +1407,13 @@ __wt_curhs_set_btree_id(WT_SESSION_IMPL *session, WT_CURSOR *cursor, uint32_t bt
  *     Initialize a history store cursor.
  */
 int
-__wt_curhs_open(WT_SESSION_IMPL *session, uint32_t btree_id, WT_CURSOR *owner, WT_CURSOR **cursorp)
+__wt_curhs_open(WT_SESSION_IMPL *session, const char *checkpoint_name, uint32_t btree_id,
+  WT_CURSOR *owner, WT_CURSOR **cursorp)
 {
     uint32_t hs_id;
 
     hs_id = __curhs_btree_id_to_hs_id(session, btree_id);
-    return (__wt_curhs_open_ext(session, hs_id, btree_id, owner, cursorp));
+    return (__wt_curhs_open_ext(session, checkpoint_name, hs_id, btree_id, owner, cursorp));
 }
 
 /*
@@ -1409,8 +1423,8 @@ __wt_curhs_open(WT_SESSION_IMPL *session, uint32_t btree_id, WT_CURSOR *owner, W
  *     the it.
  */
 int
-__wt_curhs_open_ext(WT_SESSION_IMPL *session, uint32_t hs_id, uint32_t btree_id, WT_CURSOR *owner,
-  WT_CURSOR **cursorp)
+__wt_curhs_open_ext(WT_SESSION_IMPL *session, const char *checkpoint_name, uint32_t hs_id,
+  uint32_t btree_id, WT_CURSOR *owner, WT_CURSOR **cursorp)
 {
     WT_CURSOR_STATIC_INIT(iface, __wt_cursor_get_key, /* get-key */
       __wt_cursor_get_value,                          /* get-value */
@@ -1457,7 +1471,7 @@ __wt_curhs_open_ext(WT_SESSION_IMPL *session, uint32_t hs_id, uint32_t btree_id,
     WT_ERR(__wt_strdup(session, uri, &cursor->uri));
 
     /* Open the file cursor for operations on the regular history store .*/
-    WT_ERR(__curhs_file_cursor_open(session, uri, owner, &hs_cursor->file_cursor));
+    WT_ERR(__curhs_file_cursor_open(session, uri, checkpoint_name, owner, &hs_cursor->file_cursor));
 
     WT_WITH_BTREE(session, CUR2BT(hs_cursor->file_cursor),
       ret = __wt_cursor_init(cursor, uri, owner, NULL, cursorp));

--- a/src/cursor/cur_hs.c
+++ b/src/cursor/cur_hs.c
@@ -1407,13 +1407,13 @@ __wt_curhs_set_btree_id(WT_SESSION_IMPL *session, WT_CURSOR *cursor, uint32_t bt
  *     Initialize a history store cursor.
  */
 int
-__wt_curhs_open(WT_SESSION_IMPL *session, const char *checkpoint_name, uint32_t btree_id,
+__wt_curhs_open(WT_SESSION_IMPL *session, uint32_t btree_id, const char *checkpoint_name,
   WT_CURSOR *owner, WT_CURSOR **cursorp)
 {
     uint32_t hs_id;
 
     hs_id = __curhs_btree_id_to_hs_id(session, btree_id);
-    return (__wt_curhs_open_ext(session, checkpoint_name, hs_id, btree_id, owner, cursorp));
+    return (__wt_curhs_open_ext(session, hs_id, btree_id, checkpoint_name, owner, cursorp));
 }
 
 /*
@@ -1423,8 +1423,8 @@ __wt_curhs_open(WT_SESSION_IMPL *session, const char *checkpoint_name, uint32_t 
  *     the it.
  */
 int
-__wt_curhs_open_ext(WT_SESSION_IMPL *session, const char *checkpoint_name, uint32_t hs_id,
-  uint32_t btree_id, WT_CURSOR *owner, WT_CURSOR **cursorp)
+__wt_curhs_open_ext(WT_SESSION_IMPL *session, uint32_t hs_id, uint32_t btree_id,
+  const char *checkpoint_name, WT_CURSOR *owner, WT_CURSOR **cursorp)
 {
     WT_CURSOR_STATIC_INIT(iface, __wt_cursor_get_key, /* get-key */
       __wt_cursor_get_value,                          /* get-value */

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -289,8 +289,8 @@ retry:
              * wasteful, but it's a corner case, it will be resolved at the next checkpoint, and it
              * keeps the code easy.
              *
-             * TODO: how to close this dhandle later as it is a live btree handle? We may get this
-             * dhandle when the node steps up.
+             * FIXME-WT-16476: how to close this dhandle later as it is a live btree handle? We may
+             * get this dhandle when the node steps up.
              */
             cfg[2] = "read_only=true";
             F_SET(clayered, WT_CLAYERED_STABLE_NO_CKPT);

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -256,7 +256,6 @@ __clayered_open_stable(WT_CURSOR_LAYERED *clayered, bool leader)
     session = CUR2S(clayered);
     c = &clayered->iface;
     layered = (WT_LAYERED_TABLE *)clayered->dhandle;
-    stable_uri = layered->stable_uri;
     checkpoint_name = NULL;
 
     WT_RET(__wt_scr_alloc(session, 0, &random_config));
@@ -266,6 +265,8 @@ __clayered_open_stable(WT_CURSOR_LAYERED *clayered, bool leader)
     if (random_config->size > 0)
         cfg[1] = random_config->data;
 
+retry:
+    stable_uri = layered->stable_uri;
     if (!leader) {
         /*
          * We may have a stable chunk with no checkpoint yet. If that's the case then open a cursor
@@ -287,11 +288,15 @@ __clayered_open_stable(WT_CURSOR_LAYERED *clayered, bool leader)
              * next checkpoint is picked up. So technically, opening this (empty) stable table is
              * wasteful, but it's a corner case, it will be resolved at the next checkpoint, and it
              * keeps the code easy.
+             *
+             * TODO: how to close this dhandle later as it is a live btree handle? We may get this
+             * dhandle when the node steps up.
              */
-            cfg[2] = "checkpoint_use_history=false";
+            cfg[2] = "read_only=true";
             F_SET(clayered, WT_CLAYERED_STABLE_NO_CKPT);
         } else {
-            WT_ERR(__wt_scr_alloc(session, 0, &stable_uri_buf));
+            if (stable_uri_buf == NULL)
+                WT_ERR(__wt_scr_alloc(session, 0, &stable_uri_buf));
             /*
              * Use a URI with a "/<checkpoint name> suffix. This is interpreted as reading from the
              * stable checkpoint, but without it being a traditional checkpoint cursor.
@@ -303,6 +308,12 @@ __clayered_open_stable(WT_CURSOR_LAYERED *clayered, bool leader)
     }
 
     ret = __wt_open_cursor(session, stable_uri, c, cfg, &clayered->stable_cursor);
+
+    if (ret == EBUSY && !leader) {
+        __wt_free(session, checkpoint_name);
+        goto retry;
+    }
+
     /* Opening a cursor can return both of these, unfortunately. FIXME-WT-15816. */
     if ((ret == ENOENT || ret == WT_NOTFOUND) && !leader)
         /*

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -311,6 +311,7 @@ retry:
 
     if (ret == EBUSY && !leader) {
         __wt_free(session, checkpoint_name);
+        /* FIXME-WT-16476: no need to yield if we no longer take the checkpoint lock. */
         __wt_yield();
         goto retry;
     }

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -311,6 +311,7 @@ retry:
 
     if (ret == EBUSY && !leader) {
         __wt_free(session, checkpoint_name);
+        __wt_yield();
         goto retry;
     }
 

--- a/src/cursor/cur_stat.c
+++ b/src/cursor/cur_stat.c
@@ -456,6 +456,7 @@ retry:
 
     ret = __wt_session_get_dhandle(session, stable_uri, NULL, NULL, 0);
     if (ret == EBUSY) {
+        /* FIXME-WT-16476: no need to yield if we no longer take the checkpoint lock. */
         __wt_yield();
         goto retry;
     }

--- a/src/cursor/cur_stat.c
+++ b/src/cursor/cur_stat.c
@@ -457,6 +457,7 @@ retry:
     ret = __wt_session_get_dhandle(session, stable_uri, NULL, NULL, 0);
     if (ret == EBUSY)
         goto retry;
+
     WT_ERR(ret);
 
     WT_ERR(__init_layered_constituent_stats(session, cst));

--- a/src/cursor/cur_stat.c
+++ b/src/cursor/cur_stat.c
@@ -430,6 +430,7 @@ __curstat_layered_init(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR_STAT
     WT_ERR(__init_layered_constituent_stats(session, cst));
     WT_ERR(__wt_session_release_dhandle(session));
 
+retry:
     stable_uri = layered->stable_uri;
     /* Now do the stable table. */
     if (!S2C(session)->layered_table_manager.leader) {
@@ -453,7 +454,11 @@ __curstat_layered_init(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR_STAT
         stable_uri = stable_uri_buf->data;
     }
 
-    WT_ERR(__wt_session_get_dhandle(session, stable_uri, NULL, NULL, 0));
+    ret = __wt_session_get_dhandle(session, stable_uri, NULL, NULL, 0);
+    if (ret == EBUSY)
+        goto retry;
+    WT_ERR(ret);
+
     WT_ERR(__init_layered_constituent_stats(session, cst));
     WT_ERR(__wt_session_release_dhandle(session));
 

--- a/src/cursor/cur_stat.c
+++ b/src/cursor/cur_stat.c
@@ -455,8 +455,10 @@ retry:
     }
 
     ret = __wt_session_get_dhandle(session, stable_uri, NULL, NULL, 0);
-    if (ret == EBUSY)
+    if (ret == EBUSY) {
+        __wt_yield();
         goto retry;
+    }
 
     WT_ERR(ret);
 

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -970,7 +970,7 @@ __wt_curversion_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner
     /* Open the history store cursor for btrees that may have data in the history store.*/
     file_btree = CUR2BT(version_cursor->file_cursor);
     if (F_ISSET_ATOMIC_32(conn, WT_CONN_HS_OPEN) && !F_ISSET(file_btree, WT_BTREE_IN_MEMORY)) {
-        WT_ERR(__wt_curhs_open(session, file_btree->id, cursor, &version_cursor->hs_cursor));
+        WT_ERR(__wt_curhs_open(session, NULL, file_btree->id, cursor, &version_cursor->hs_cursor));
         F_SET(version_cursor->hs_cursor, WT_CURSTD_HS_READ_COMMITTED);
     }
 

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -970,7 +970,7 @@ __wt_curversion_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner
     /* Open the history store cursor for btrees that may have data in the history store.*/
     file_btree = CUR2BT(version_cursor->file_cursor);
     if (F_ISSET_ATOMIC_32(conn, WT_CONN_HS_OPEN) && !F_ISSET(file_btree, WT_BTREE_IN_MEMORY)) {
-        WT_ERR(__wt_curhs_open(session, NULL, file_btree->id, cursor, &version_cursor->hs_cursor));
+        WT_ERR(__wt_curhs_open(session, file_btree->id, NULL, cursor, &version_cursor->hs_cursor));
         F_SET(version_cursor->hs_cursor, WT_CURSTD_HS_READ_COMMITTED);
     }
 

--- a/src/history/hs_conn.c
+++ b/src/history/hs_conn.c
@@ -43,7 +43,7 @@ __hs_get_btree(WT_SESSION_IMPL *session, uint32_t hs_id, WT_BTREE **hs_btreep)
 
     *hs_btreep = NULL;
 
-    WT_RET(__wt_curhs_open_ext(session, hs_id, 0, NULL, &hs_cursor));
+    WT_RET(__wt_curhs_open_ext(session, NULL, hs_id, 0, NULL, &hs_cursor));
     *hs_btreep = __wt_curhs_get_btree(hs_cursor);
     WT_ASSERT(session, *hs_btreep != NULL);
 

--- a/src/history/hs_conn.c
+++ b/src/history/hs_conn.c
@@ -43,7 +43,7 @@ __hs_get_btree(WT_SESSION_IMPL *session, uint32_t hs_id, WT_BTREE **hs_btreep)
 
     *hs_btreep = NULL;
 
-    WT_RET(__wt_curhs_open_ext(session, NULL, hs_id, 0, NULL, &hs_cursor));
+    WT_RET(__wt_curhs_open_ext(session, hs_id, 0, NULL, NULL, &hs_cursor));
     *hs_btreep = __wt_curhs_get_btree(hs_cursor);
     WT_ASSERT(session, *hs_btreep != NULL);
 

--- a/src/history/hs_cursor.c
+++ b/src/history/hs_cursor.c
@@ -50,9 +50,10 @@ __wt_hs_upd_time_window(WT_CURSOR *hs_cursor, WT_TIME_WINDOW **twp)
  *     for the record and return to the caller.
  */
 int
-__wt_hs_find_upd(WT_SESSION_IMPL *session, uint32_t btree_id, WT_ITEM *key,
-  const char *value_format, uint64_t recno, WT_UPDATE_VALUE *upd_value, WT_ITEM *base_value_buf)
+__wt_hs_find_upd(WT_SESSION_IMPL *session, WT_ITEM *key, const char *value_format, uint64_t recno,
+  WT_UPDATE_VALUE *upd_value, WT_ITEM *base_value_buf)
 {
+    WT_BTREE *btree;
     WT_CURSOR *hs_cursor;
     WT_DECL_ITEM(hs_value);
     WT_DECL_ITEM(orig_hs_value_buf);
@@ -68,6 +69,7 @@ __wt_hs_find_upd(WT_SESSION_IMPL *session, uint32_t btree_id, WT_ITEM *key,
     uint8_t *p, recno_key_buf[WT_INTPACK64_MAXSIZE], upd_type;
     bool upd_found;
 
+    btree = S2BT(session);
     hs_cursor = NULL;
     mod_upd = NULL;
     orig_hs_value_buf = NULL;
@@ -103,10 +105,17 @@ __wt_hs_find_upd(WT_SESSION_IMPL *session, uint32_t btree_id, WT_ITEM *key,
         goto done;
     }
 
-    WT_ERR_NOTFOUND_OK(__wt_curhs_open(session, btree_id, NULL, &hs_cursor), true);
+    /* No shared history store checkpoint matches the stable btree. Simply return without any data.
+     */
+    if (btree->hs_checkpoint_name == NULL && F_ISSET(btree, WT_BTREE_DISAGGREGATED) &&
+      F_ISSET(btree, WT_BTREE_READONLY)) {
+        ret = 0;
+        goto done;
+    }
+
+    WT_ERR(__wt_curhs_open(session, btree->hs_checkpoint_name, btree->id, NULL, &hs_cursor));
     /* Do this separately for now because the behavior below is confusing if it triggers. */
-    WT_ASSERT(session, ret != WT_NOTFOUND);
-    WT_ERR(ret);
+    WT_ASSERT_ALWAYS(session, ret == 0, "missing history store for existing btree");
 
     /*
      * After positioning our cursor, we're stepping backwards to find the correct update. Since the
@@ -123,7 +132,7 @@ __wt_hs_find_upd(WT_SESSION_IMPL *session, uint32_t btree_id, WT_ITEM *key,
                                                       txn_shared->read_timestamp;
     read_timestamp = read_timestamp == WT_TS_NONE ? WT_TS_MAX : read_timestamp;
 
-    hs_cursor->set_key(hs_cursor, 4, btree_id, key, read_timestamp, UINT64_MAX);
+    hs_cursor->set_key(hs_cursor, 4, btree->id, key, read_timestamp, UINT64_MAX);
     WT_ERR_NOTFOUND_OK(__wt_curhs_search_near_before(session, hs_cursor), true);
     if (ret == WT_NOTFOUND) {
         ret = 0;
@@ -277,7 +286,7 @@ __wt_hs_btree_truncate(WT_SESSION_IMPL *session, uint32_t btree_id)
     WT_RET(__wt_scr_alloc(session, 0, &hs_key));
 
     /* Open a history store start cursor. */
-    WT_ERR(__wt_curhs_open(session, btree_id, NULL, &hs_cursor_start));
+    WT_ERR(__wt_curhs_open(session, NULL, btree_id, NULL, &hs_cursor_start));
     F_SET(hs_cursor_start, WT_CURSTD_HS_READ_COMMITTED);
 
     hs_cursor_start->set_key(hs_cursor_start, 1, btree_id);
@@ -288,7 +297,7 @@ __wt_hs_btree_truncate(WT_SESSION_IMPL *session, uint32_t btree_id)
     }
 
     /* Open a history store stop cursor. */
-    WT_ERR(__wt_curhs_open(session, btree_id, NULL, &hs_cursor_stop));
+    WT_ERR(__wt_curhs_open(session, NULL, btree_id, NULL, &hs_cursor_stop));
     F_SET(hs_cursor_stop, WT_CURSTD_HS_READ_COMMITTED | WT_CURSTD_HS_READ_ACROSS_BTREE);
 
     hs_cursor_stop->set_key(hs_cursor_stop, 1, btree_id + 1);

--- a/src/history/hs_cursor.c
+++ b/src/history/hs_cursor.c
@@ -115,7 +115,7 @@ __wt_hs_find_upd(WT_SESSION_IMPL *session, WT_ITEM *key, const char *value_forma
         goto done;
     }
 
-    WT_ERR(__wt_curhs_open(session, btree->hs_checkpoint_name, btree->id, NULL, &hs_cursor));
+    WT_ERR(__wt_curhs_open(session, btree->id, btree->hs_checkpoint_name, NULL, &hs_cursor));
     /* Do this separately for now because the behavior below is confusing if it triggers. */
     WT_ASSERT_ALWAYS(session, ret == 0, "missing history store for existing btree");
 
@@ -288,7 +288,7 @@ __wt_hs_btree_truncate(WT_SESSION_IMPL *session, uint32_t btree_id)
     WT_RET(__wt_scr_alloc(session, 0, &hs_key));
 
     /* Open a history store start cursor. */
-    WT_ERR(__wt_curhs_open(session, NULL, btree_id, NULL, &hs_cursor_start));
+    WT_ERR(__wt_curhs_open(session, btree_id, NULL, NULL, &hs_cursor_start));
     F_SET(hs_cursor_start, WT_CURSTD_HS_READ_COMMITTED);
 
     hs_cursor_start->set_key(hs_cursor_start, 1, btree_id);
@@ -299,7 +299,7 @@ __wt_hs_btree_truncate(WT_SESSION_IMPL *session, uint32_t btree_id)
     }
 
     /* Open a history store stop cursor. */
-    WT_ERR(__wt_curhs_open(session, NULL, btree_id, NULL, &hs_cursor_stop));
+    WT_ERR(__wt_curhs_open(session, btree_id, NULL, NULL, &hs_cursor_stop));
     F_SET(hs_cursor_stop, WT_CURSTD_HS_READ_COMMITTED | WT_CURSTD_HS_READ_ACROSS_BTREE);
 
     hs_cursor_stop->set_key(hs_cursor_stop, 1, btree_id + 1);

--- a/src/history/hs_cursor.c
+++ b/src/history/hs_cursor.c
@@ -105,7 +105,9 @@ __wt_hs_find_upd(WT_SESSION_IMPL *session, WT_ITEM *key, const char *value_forma
         goto done;
     }
 
-    /* No shared history store checkpoint matches the stable btree. Simply return without any data.
+    /*
+     * No shared history store checkpoint that matches the stable btree. Simply return without any
+     * data.
      */
     if (btree->hs_checkpoint_name == NULL && F_ISSET(btree, WT_BTREE_DISAGGREGATED) &&
       F_ISSET(btree, WT_BTREE_READONLY)) {

--- a/src/history/hs_verify.c
+++ b/src/history/hs_verify.c
@@ -110,7 +110,7 @@ __wt_hs_verify_one(WT_SESSION_IMPL *session, uint32_t btree_id)
 
     hs_cursor = NULL;
 
-    WT_ERR(__wt_curhs_open(session, btree_id, NULL, &hs_cursor));
+    WT_ERR(__wt_curhs_open(session, NULL, btree_id, NULL, &hs_cursor));
     F_SET(hs_cursor, WT_CURSTD_HS_READ_COMMITTED);
 
     /* Position the hs cursor on the requested btree id, there could be nothing in the HS yet. */
@@ -165,7 +165,7 @@ __hs_verify(WT_SESSION_IMPL *session, uint32_t hs_id)
     uri_data = NULL;
 
     WT_ERR(__wt_scr_alloc(session, 0, &buf));
-    WT_ERR(__wt_curhs_open_ext(session, hs_id, 0, NULL, &hs_cursor));
+    WT_ERR(__wt_curhs_open_ext(session, NULL, hs_id, 0, NULL, &hs_cursor));
     F_SET(hs_cursor, WT_CURSTD_HS_READ_COMMITTED);
 
     /* Position the hs cursor on the first record. */

--- a/src/history/hs_verify.c
+++ b/src/history/hs_verify.c
@@ -110,7 +110,7 @@ __wt_hs_verify_one(WT_SESSION_IMPL *session, uint32_t btree_id)
 
     hs_cursor = NULL;
 
-    WT_ERR(__wt_curhs_open(session, NULL, btree_id, NULL, &hs_cursor));
+    WT_ERR(__wt_curhs_open(session, btree_id, NULL, NULL, &hs_cursor));
     F_SET(hs_cursor, WT_CURSTD_HS_READ_COMMITTED);
 
     /* Position the hs cursor on the requested btree id, there could be nothing in the HS yet. */
@@ -165,7 +165,7 @@ __hs_verify(WT_SESSION_IMPL *session, uint32_t hs_id)
     uri_data = NULL;
 
     WT_ERR(__wt_scr_alloc(session, 0, &buf));
-    WT_ERR(__wt_curhs_open_ext(session, NULL, hs_id, 0, NULL, &hs_cursor));
+    WT_ERR(__wt_curhs_open_ext(session, hs_id, 0, NULL, NULL, &hs_cursor));
     F_SET(hs_cursor, WT_CURSTD_HS_READ_COMMITTED);
 
     /* Position the hs cursor on the first record. */

--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -116,6 +116,8 @@ struct __wt_btree {
     WT_CKPT *ckpt;               /* Checkpoint information */
     size_t ckpt_bytes_allocated; /* Checkpoint information array allocation size */
 
+    const char *hs_checkpoint_name; /* History store checkpoint name. */
+
     WT_BTREE_TYPE type; /* Type */
 
     const char *key_format;   /* Key format */

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -312,15 +312,14 @@ __wt_btree_shared_base_name(
     /* Move the suffix to point to the slash */
     suffix += strlen(".wt_stable");
 
-    if (name_bufp != NULL) {
-        /* The returned name is the part before the suffix */
-        len = (size_t)(suffix - name);
-        WT_RET(__wt_scr_alloc(session, len + 1, name_bufp));
-        name_buf = *name_bufp;
-        WT_RET(__wt_buf_catfmt(session, name_buf, "%s", name));
-        ((char *)name_buf->data)[len] = '\0';
-        *namep = (const char *)name_buf->data;
-    }
+    /* The returned name is the part before the suffix */
+    len = (size_t)(suffix - name);
+    WT_RET(__wt_scr_alloc(session, len + 1, name_bufp));
+    name_buf = *name_bufp;
+    WT_RET(__wt_buf_catfmt(session, name_buf, "%s", name));
+    ((char *)name_buf->data)[len] = '\0';
+
+    *namep = (const char *)name_buf->data;
 
     /* The checkpoint id string, if needed, immediately follows the suffix. */
     if (checkpointp != NULL)

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -312,14 +312,15 @@ __wt_btree_shared_base_name(
     /* Move the suffix to point to the slash */
     suffix += strlen(".wt_stable");
 
-    /* The returned name is the part before the suffix */
-    len = (size_t)(suffix - name);
-    WT_RET(__wt_scr_alloc(session, len + 1, name_bufp));
-    name_buf = *name_bufp;
-    WT_RET(__wt_buf_catfmt(session, name_buf, "%s", name));
-    ((char *)name_buf->data)[len] = '\0';
-
-    *namep = (const char *)name_buf->data;
+    if (name_bufp != NULL) {
+        /* The returned name is the part before the suffix */
+        len = (size_t)(suffix - name);
+        WT_RET(__wt_scr_alloc(session, len + 1, name_bufp));
+        name_buf = *name_bufp;
+        WT_RET(__wt_buf_catfmt(session, name_buf, "%s", name));
+        ((char *)name_buf->data)[len] = '\0';
+        *namep = (const char *)name_buf->data;
+    }
 
     /* The checkpoint id string, if needed, immediately follows the suffix. */
     if (checkpointp != NULL)

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -455,10 +455,11 @@ extern int __wt_curhs_get_cached(WT_SESSION_IMPL *session, uint32_t hs_id, WT_BT
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_curhs_next_hs_id(WT_SESSION_IMPL *session, uint32_t hs_id, uint32_t *next_hs_idp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_curhs_open(WT_SESSION_IMPL *session, uint32_t btree_id, WT_CURSOR *owner,
-  WT_CURSOR **cursorp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_curhs_open_ext(WT_SESSION_IMPL *session, uint32_t hs_id, uint32_t btree_id,
+extern int __wt_curhs_open(WT_SESSION_IMPL *session, const char *checkpoint_name, uint32_t btree_id,
   WT_CURSOR *owner, WT_CURSOR **cursorp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_curhs_open_ext(WT_SESSION_IMPL *session, const char *checkpoint_name,
+  uint32_t hs_id, uint32_t btree_id, WT_CURSOR *owner, WT_CURSOR **cursorp)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_curhs_range_truncate(WT_TRUNCATE_INFO *trunc_info)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_curhs_search_near_after(WT_SESSION_IMPL *session, WT_CURSOR *cursor)
@@ -678,8 +679,8 @@ extern int __wt_hs_btree_truncate(WT_SESSION_IMPL *session, uint32_t btree_id)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_hs_config(WT_SESSION_IMPL *session, const char **cfg)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_hs_find_upd(WT_SESSION_IMPL *session, uint32_t btree_id, WT_ITEM *key,
-  const char *value_format, uint64_t recno, WT_UPDATE_VALUE *upd_value, WT_ITEM *base_value_buf)
+extern int __wt_hs_find_upd(WT_SESSION_IMPL *session, WT_ITEM *key, const char *value_format,
+  uint64_t recno, WT_UPDATE_VALUE *upd_value, WT_ITEM *base_value_buf)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_hs_modify(WT_CURSOR_BTREE *hs_cbt, WT_UPDATE *hs_upd)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -455,10 +455,10 @@ extern int __wt_curhs_get_cached(WT_SESSION_IMPL *session, uint32_t hs_id, WT_BT
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_curhs_next_hs_id(WT_SESSION_IMPL *session, uint32_t hs_id, uint32_t *next_hs_idp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_curhs_open(WT_SESSION_IMPL *session, const char *checkpoint_name, uint32_t btree_id,
+extern int __wt_curhs_open(WT_SESSION_IMPL *session, uint32_t btree_id, const char *checkpoint_name,
   WT_CURSOR *owner, WT_CURSOR **cursorp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_curhs_open_ext(WT_SESSION_IMPL *session, const char *checkpoint_name,
-  uint32_t hs_id, uint32_t btree_id, WT_CURSOR *owner, WT_CURSOR **cursorp)
+extern int __wt_curhs_open_ext(WT_SESSION_IMPL *session, uint32_t hs_id, uint32_t btree_id,
+  const char *checkpoint_name, WT_CURSOR *owner, WT_CURSOR **cursorp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_curhs_range_truncate(WT_TRUNCATE_INFO *trunc_info)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/meta.h
+++ b/src/include/meta.h
@@ -85,7 +85,9 @@
 /*
  * Other useful comparisons.
  */
-#define WT_IS_URI_HS(uri) (strcmp(uri, WT_HS_URI) == 0 || strcmp(uri, WT_HS_URI_SHARED) == 0)
+#define WT_IS_URI_HS(uri)                               \
+    (strncmp(uri, WT_HS_URI, strlen(WT_HS_URI)) == 0 || \
+      strncmp(uri, WT_HS_URI_SHARED, strlen(WT_HS_URI_SHARED)) == 0)
 
 #define WT_HS_ID_TO_URI(session, hs_id, uri)                                                   \
     do {                                                                                       \

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1736,8 +1736,8 @@ retry:
           __wt_random(&session->rnd_random) % 100 == 0)
             __wt_timing_stress(session, WT_TIMING_STRESS_HS_SEARCH, NULL);
 
-        WT_RET(__wt_hs_find_upd(session, S2BT(session)->id, key, cbt->iface.value_format, recno,
-          cbt->upd_value, &cbt->upd_value->buf));
+        WT_RET(__wt_hs_find_upd(
+          session, key, cbt->iface.value_format, recno, cbt->upd_value, &cbt->upd_value->buf));
     }
 
     /*

--- a/src/reconcile/rec_hs.c
+++ b/src/reconcile/rec_hs.c
@@ -168,7 +168,7 @@ __rec_hs_delete_reinsert_from_pos(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor
              * case, we'll never get here.
              */
             if (hs_insert_cursor == NULL)
-                WT_ERR(__wt_curhs_open(session, NULL, btree_id, NULL, &hs_insert_cursor));
+                WT_ERR(__wt_curhs_open(session, btree_id, NULL, NULL, &hs_insert_cursor));
 
             /*
              * If these history store records are resolved prepared updates, their durable
@@ -679,7 +679,7 @@ __wti_rec_hs_insert_updates(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_MULTI
     cache_hs_insert_full_update = cache_hs_insert_reverse_modify = cache_hs_write_squash = 0;
     cache_hs_key_processed = cache_hs_update_processed = 0;
 
-    WT_RET(__wt_curhs_open(session, NULL, btree->id, NULL, &hs_cursor));
+    WT_RET(__wt_curhs_open(session, btree->id, NULL, NULL, &hs_cursor));
     F_SET(hs_cursor, WT_CURSTD_HS_READ_COMMITTED);
 
     __wt_update_vector_init(session, &updates);
@@ -1268,13 +1268,13 @@ __rec_hs_delete_record(
      * matches the current btree and attempt to reuse it if it does not.
      */
     if (r->hs_cursor == NULL)
-        WT_RET(__wt_curhs_open(session, NULL, btree->id, NULL, &r->hs_cursor));
+        WT_RET(__wt_curhs_open(session, btree->id, NULL, NULL, &r->hs_cursor));
     else if (__wt_curhs_get_btree_id(session, r->hs_cursor) != btree->id) {
         WT_RET_ERROR_OK(ret = __wt_curhs_set_btree_id(session, r->hs_cursor, btree->id), EINVAL);
         if (ret == EINVAL) {
             WT_RET(r->hs_cursor->close(r->hs_cursor));
             r->hs_cursor = NULL;
-            WT_RET(__wt_curhs_open(session, NULL, btree->id, NULL, &r->hs_cursor));
+            WT_RET(__wt_curhs_open(session, btree->id, NULL, NULL, &r->hs_cursor));
         }
     }
 

--- a/src/reconcile/rec_hs.c
+++ b/src/reconcile/rec_hs.c
@@ -168,7 +168,7 @@ __rec_hs_delete_reinsert_from_pos(WT_SESSION_IMPL *session, WT_CURSOR *hs_cursor
              * case, we'll never get here.
              */
             if (hs_insert_cursor == NULL)
-                WT_ERR(__wt_curhs_open(session, btree_id, NULL, &hs_insert_cursor));
+                WT_ERR(__wt_curhs_open(session, NULL, btree_id, NULL, &hs_insert_cursor));
 
             /*
              * If these history store records are resolved prepared updates, their durable
@@ -679,7 +679,7 @@ __wti_rec_hs_insert_updates(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_MULTI
     cache_hs_insert_full_update = cache_hs_insert_reverse_modify = cache_hs_write_squash = 0;
     cache_hs_key_processed = cache_hs_update_processed = 0;
 
-    WT_RET(__wt_curhs_open(session, btree->id, NULL, &hs_cursor));
+    WT_RET(__wt_curhs_open(session, NULL, btree->id, NULL, &hs_cursor));
     F_SET(hs_cursor, WT_CURSTD_HS_READ_COMMITTED);
 
     __wt_update_vector_init(session, &updates);
@@ -1268,13 +1268,13 @@ __rec_hs_delete_record(
      * matches the current btree and attempt to reuse it if it does not.
      */
     if (r->hs_cursor == NULL)
-        WT_RET(__wt_curhs_open(session, btree->id, NULL, &r->hs_cursor));
+        WT_RET(__wt_curhs_open(session, NULL, btree->id, NULL, &r->hs_cursor));
     else if (__wt_curhs_get_btree_id(session, r->hs_cursor) != btree->id) {
         WT_RET_ERROR_OK(ret = __wt_curhs_set_btree_id(session, r->hs_cursor, btree->id), EINVAL);
         if (ret == EINVAL) {
             WT_RET(r->hs_cursor->close(r->hs_cursor));
             r->hs_cursor = NULL;
-            WT_RET(__wt_curhs_open(session, btree->id, NULL, &r->hs_cursor));
+            WT_RET(__wt_curhs_open(session, NULL, btree->id, NULL, &r->hs_cursor));
         }
     }
 

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -3319,13 +3319,13 @@ __wti_rec_hs_clear_on_tombstone(
      * matches the current btree and attempt to reuse it if it does not.
      */
     if (r->hs_cursor == NULL)
-        WT_RET(__wt_curhs_open(session, btree->id, NULL, &r->hs_cursor));
+        WT_RET(__wt_curhs_open(session, NULL, btree->id, NULL, &r->hs_cursor));
     else if (__wt_curhs_get_btree_id(session, r->hs_cursor) != btree->id) {
         WT_RET_ERROR_OK(ret = __wt_curhs_set_btree_id(session, r->hs_cursor, btree->id), EINVAL);
         if (ret == EINVAL) {
             WT_RET(r->hs_cursor->close(r->hs_cursor));
             r->hs_cursor = NULL;
-            WT_RET(__wt_curhs_open(session, btree->id, NULL, &r->hs_cursor));
+            WT_RET(__wt_curhs_open(session, NULL, btree->id, NULL, &r->hs_cursor));
         }
     }
 

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -3319,13 +3319,13 @@ __wti_rec_hs_clear_on_tombstone(
      * matches the current btree and attempt to reuse it if it does not.
      */
     if (r->hs_cursor == NULL)
-        WT_RET(__wt_curhs_open(session, NULL, btree->id, NULL, &r->hs_cursor));
+        WT_RET(__wt_curhs_open(session, btree->id, NULL, NULL, &r->hs_cursor));
     else if (__wt_curhs_get_btree_id(session, r->hs_cursor) != btree->id) {
         WT_RET_ERROR_OK(ret = __wt_curhs_set_btree_id(session, r->hs_cursor, btree->id), EINVAL);
         if (ret == EINVAL) {
             WT_RET(r->hs_cursor->close(r->hs_cursor));
             r->hs_cursor = NULL;
-            WT_RET(__wt_curhs_open(session, NULL, btree->id, NULL, &r->hs_cursor));
+            WT_RET(__wt_curhs_open(session, btree->id, NULL, NULL, &r->hs_cursor));
         }
     }
 

--- a/src/rollback_to_stable/rts_btree.c
+++ b/src/rollback_to_stable/rts_btree.c
@@ -380,7 +380,7 @@ __rts_btree_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_REF *ref, WT_ROW *rip,
     __wt_txn_pinned_timestamp(session, &pinned_ts);
 
     /* Open a history store table cursor. */
-    WT_ERR(__wt_curhs_open(session, hs_btree_id, NULL, &hs_cursor));
+    WT_ERR(__wt_curhs_open(session, NULL, hs_btree_id, NULL, &hs_cursor));
     /*
      * Rollback-to-stable operates exclusively (i.e., it is the only active operation in the system)
      * outside the constraints of transactions. Therefore, there is no need for snapshot based

--- a/src/rollback_to_stable/rts_btree.c
+++ b/src/rollback_to_stable/rts_btree.c
@@ -380,7 +380,7 @@ __rts_btree_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_REF *ref, WT_ROW *rip,
     __wt_txn_pinned_timestamp(session, &pinned_ts);
 
     /* Open a history store table cursor. */
-    WT_ERR(__wt_curhs_open(session, NULL, hs_btree_id, NULL, &hs_cursor));
+    WT_ERR(__wt_curhs_open(session, hs_btree_id, NULL, NULL, &hs_cursor));
     /*
      * Rollback-to-stable operates exclusively (i.e., it is the only active operation in the system)
      * outside the constraints of transactions. Therefore, there is no need for snapshot based

--- a/src/rollback_to_stable/rts_history.c
+++ b/src/rollback_to_stable/rts_history.c
@@ -30,7 +30,7 @@ __wti_rts_history_delete_hs(WT_SESSION_IMPL *session, WT_ITEM *key, wt_timestamp
     btree_id = S2BT(session)->id;
 
     /* Open a history store table cursor. */
-    WT_RET(__wt_curhs_open(session, btree_id, NULL, &hs_cursor));
+    WT_RET(__wt_curhs_open(session, NULL, btree_id, NULL, &hs_cursor));
     /*
      * Rollback-to-stable operates exclusively (i.e., it is the only active operation in the system)
      * outside the constraints of transactions. Therefore, there is no need for snapshot based

--- a/src/rollback_to_stable/rts_history.c
+++ b/src/rollback_to_stable/rts_history.c
@@ -30,7 +30,7 @@ __wti_rts_history_delete_hs(WT_SESSION_IMPL *session, WT_ITEM *key, wt_timestamp
     btree_id = S2BT(session)->id;
 
     /* Open a history store table cursor. */
-    WT_RET(__wt_curhs_open(session, NULL, btree_id, NULL, &hs_cursor));
+    WT_RET(__wt_curhs_open(session, btree_id, NULL, NULL, &hs_cursor));
     /*
      * Rollback-to-stable operates exclusively (i.e., it is the only active operation in the system)
      * outside the constraints of transactions. Therefore, there is no need for snapshot based

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -489,10 +489,9 @@ __wt_session_get_btree_ckpt(WT_SESSION_IMPL *session, const char *uri, const cha
      * call the underlying function directly.
      */
     WT_RET_NOTFOUND_OK(__wt_config_gets_def(session, cfg, "checkpoint", 0, &cval));
-    if (cval.len == 0) {
+    if (cval.len == 0)
         /* We are not opening a checkpoint. This is the simple case; retire it immediately. */
         return (__wt_session_get_dhandle(session, uri, NULL, cfg, flags));
-    }
 
     /*
      * Here and below is only for checkpoints.
@@ -968,7 +967,6 @@ __wt_session_get_dhandle(WT_SESSION_IMPL *session, const char *uri, const char *
             return (ret);
         }
 
-        /* Open the handle. */
         if ((ret = __wt_conn_dhandle_open(session, cfg, flags)) == 0 &&
           LF_ISSET(WT_DHANDLE_EXCLUSIVE))
             break;

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -429,7 +429,8 @@ static int
 __session_open_hs_ckpt(WT_SESSION_IMPL *session, const char *checkpoint, const char *cfg[],
   uint32_t flags, int64_t order_expected, WT_DATA_HANDLE **hs_dhandlep)
 {
-    WT_RET(__wt_session_get_dhandle(session, WT_HS_URI, checkpoint, cfg, flags));
+    WT_RET(__wt_session_get_dhandle(session,
+      __wt_conn_is_disagg(session) ? WT_HS_URI_SHARED : WT_HS_URI, checkpoint, cfg, flags));
 
     if (session->dhandle->checkpoint_order != order_expected) {
         /* Not what we were expecting; treat as EBUSY and let the caller retry. */
@@ -654,11 +655,13 @@ __wt_session_get_btree_ckpt(WT_SESSION_IMPL *session, const char *uri, const cha
         /* Look up the history store checkpoint. */
         if (hs_dhandlep != NULL) {
             if (is_unnamed_ckpt)
-                WT_RET_NOTFOUND_OK(__wt_meta_checkpoint_last_name(
-                  session, WT_HS_URI, &hs_checkpoint, &hs_order, &hs_time));
+                WT_RET_NOTFOUND_OK(__wt_meta_checkpoint_last_name(session,
+                  __wt_conn_is_disagg(session) ? WT_HS_URI_SHARED : WT_HS_URI, &hs_checkpoint,
+                  &hs_order, &hs_time));
             else {
-                ret =
-                  __wt_meta_checkpoint_by_name(session, WT_HS_URI, checkpoint, &hs_order, &hs_time);
+                ret = __wt_meta_checkpoint_by_name(session,
+                  __wt_conn_is_disagg(session) ? WT_HS_URI_SHARED : WT_HS_URI, checkpoint,
+                  &hs_order, &hs_time);
                 WT_RET_NOTFOUND_OK(ret);
                 if (ret == WT_NOTFOUND)
                     ret = 0;

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1251,7 +1251,7 @@ __txn_resolve_prepared_op(WT_SESSION_IMPL *session, WT_TXN_OP *op, bool commit, 
          * Open a history store table cursor and scan the history store for the given btree and key
          * with maximum start timestamp to let the search point to the last version of the key.
          */
-        WT_ERR(__wt_curhs_open(session, btree->id, NULL, &hs_cursor));
+        WT_ERR(__wt_curhs_open(session, NULL, btree->id, NULL, &hs_cursor));
         F_SET(hs_cursor, WT_CURSTD_HS_READ_COMMITTED);
         if (btree->type == BTREE_ROW)
             hs_cursor->set_key(hs_cursor, 4, btree->id, &cbt->iface.key, WT_TS_MAX, UINT64_MAX);

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1251,7 +1251,7 @@ __txn_resolve_prepared_op(WT_SESSION_IMPL *session, WT_TXN_OP *op, bool commit, 
          * Open a history store table cursor and scan the history store for the given btree and key
          * with maximum start timestamp to let the search point to the last version of the key.
          */
-        WT_ERR(__wt_curhs_open(session, NULL, btree->id, NULL, &hs_cursor));
+        WT_ERR(__wt_curhs_open(session, btree->id, NULL, NULL, &hs_cursor));
         F_SET(hs_cursor, WT_CURSTD_HS_READ_COMMITTED);
         if (btree->type == BTREE_ROW)
             hs_cursor->set_key(hs_cursor, 4, btree->id, &cbt->iface.key, WT_TS_MAX, UINT64_MAX);

--- a/test/format/hs.c
+++ b/test/format/hs.c
@@ -76,7 +76,7 @@ hs_cursor(void *arg)
             if (ret == WT_NOTFOUND)
                 break;
             testutil_check(
-              __wt_curhs_open_ext((WT_SESSION_IMPL *)session, hs_id, 0, NULL, &cursor));
+              __wt_curhs_open_ext((WT_SESSION_IMPL *)session, NULL, hs_id, 0, NULL, &cursor));
             F_SET(cursor, WT_CURSTD_HS_READ_COMMITTED);
 
             /*

--- a/test/format/hs.c
+++ b/test/format/hs.c
@@ -76,7 +76,7 @@ hs_cursor(void *arg)
             if (ret == WT_NOTFOUND)
                 break;
             testutil_check(
-              __wt_curhs_open_ext((WT_SESSION_IMPL *)session, NULL, hs_id, 0, NULL, &cursor));
+              __wt_curhs_open_ext((WT_SESSION_IMPL *)session, hs_id, 0, NULL, NULL, &cursor));
             F_SET(cursor, WT_CURSTD_HS_READ_COMMITTED);
 
             /*

--- a/test/suite/test_layered72.py
+++ b/test/suite/test_layered72.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import threading, time, wiredtiger, wttest
+from helper_disagg import disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
+
+# test_layered72.py
+#    Test reading the history store in standby.
+@disagg_test_class
+class test_layered72(wttest.WiredTigerTestCase):
+    conn_base_config = 'statistics=(all),' \
+                     + 'precise_checkpoint=true,'
+    conn_config = conn_base_config + 'disaggregated=(role="leader")'
+
+    create_session_config = 'key_format=S,value_format=S'
+
+    uri = "layered:test_layered72"
+    disagg_storages = gen_disagg_storages('test_layered72', disagg_only = True)
+    scenarios = make_scenarios(disagg_storages)
+
+    def test_layered72(self):
+        # Create the follower
+        conn_follow = self.wiredtiger_open('follower', self.extensionsConfig() + ',create,' +self.conn_base_config + 'disaggregated=(role="follower")')
+        session_follow = conn_follow.open_session('')
+
+        # Create a table
+        self.session.create(self.uri, self.create_session_config)
+
+        # Insert a value with timestamp 2
+        cursor = self.session.open_cursor(self.uri, None, None)
+        self.session.begin_transaction()
+        cursor["1"] = "value1"
+        self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(2)}')
+
+        # Update the value with timestamp 3
+        self.session.begin_transaction()
+        cursor["2"] = "value2"
+        self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(3)}')
+
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(3)}, oldest_timestamp={self.timestamp_str(1)}')
+        self.session.checkpoint()
+
+        # Advance to the latest checkpoint
+        self.disagg_advance_checkpoint(conn_follow)
+
+        cursor_follow = session_follow.open_cursor(self.uri, None, None)
+        session_follow.begin_transaction(f'read_timestamp={self.timestamp_str(2)}')
+        self.assertEqual(cursor_follow["1"], "value1")
+
+        # Update the value with timestamp 4
+        self.session.begin_transaction()
+        cursor["2"] = "value3"
+        self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(4)}')
+
+        # Make the first version obsolete
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(4)}, oldest_timestamp={self.timestamp_str(3)}')
+        self.session.checkpoint()
+
+        # Advance to the latest checkpoint
+        self.disagg_advance_checkpoint(conn_follow)
+
+        # Verify we can read the correct value from the history store
+        cursor_follow.reset()
+        # Cursor should still see the old value at timestamp 2 as it has the history store dhandle pinned
+        self.assertEqual(cursor_follow["1"], "value1")
+        session_follow.rollback_transaction()

--- a/test/suite/test_layered72.py
+++ b/test/suite/test_layered72.py
@@ -31,7 +31,7 @@ from helper_disagg import disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 
 # test_layered72.py
-#    Test reading the history store in standby.
+#    Test reading the pinned history store on standby.
 @disagg_test_class
 class test_layered72(wttest.WiredTigerTestCase):
     conn_base_config = 'statistics=(all),' \


### PR DESCRIPTION
This approach is inspired by how history store checkpoints are handled for checkpoint cursors. When opening a checkpoint cursor, the matching history store checkpoint is pinned in the btree cursor, preventing it from disappearing while data is being read.

For reading history in standby mode, a similar mechanism is implemented. A matching shared history store checkpoint dhandle is pinned when opening the data store dhandle. This pinning is done at the btree level to ensure it only needs to occur once, rather than every time a data store cursor is opened. However, to achieve this, a workaround is used to artificially increase the session_inuse count for the history store checkpoint dhandle.

Using this approach introduces the possibility that identifying the matching shared history store checkpoint may race with picking up a new checkpoint. To address this, we acquire the checkpoint lock to guarantee a consistent view of the local metadata. Additionally, we implement a retry mechanism to handle scenarios where the desired checkpoint is no longer available.