### PR TITLE
WT-16302 Introduce more buckets for ASAN python testing

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3030,6 +3030,248 @@ tasks:
         vars:
           unit_test_args: -v 2 -b 11/12
 
+# XSAN testing runs longer and needs more buckets to keep individual task turnaround time reasonable.
+
+  - name: unit-test-xsan-bucket00
+    tags: ["python","unit_test_xsan"]
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+        vars:
+          unit_test_args: -v 2 -b 0/24
+
+  - name: unit-test-xsan-bucket01
+    tags: ["python","unit_test_xsan"]
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+        vars:
+          unit_test_args: -v 2 -b 1/24
+
+  - name: unit-test-xsan-bucket02
+    tags: ["python","pull_request","unit_test_xsan"]
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+        vars:
+          unit_test_args: -v 2 -b 2/24
+
+  - name: unit-test-xsan-bucket03
+    tags: ["python","pull_request","unit_test_xsan"]
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+        vars:
+          unit_test_args: -v 2 -b 3/24
+
+  - name: unit-test-xsan-bucket04
+    tags: ["python","pull_request","unit_test_xsan"]
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+        vars:
+          unit_test_args: -v 2 -b 4/24
+
+  - name: unit-test-xsan-bucket05
+    tags: ["python","pull_request","unit_test_xsan"]
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+        vars:
+          unit_test_args: -v 2 -b 5/24
+
+  - name: unit-test-xsan-bucket06
+    tags: ["python","pull_request","unit_test_xsan"]
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+        vars:
+          unit_test_args: -v 2 -b 6/24
+
+  - name: unit-test-xsan-bucket07
+    tags: ["python","pull_request","unit_test_xsan"]
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+        vars:
+          unit_test_args: -v 2 -b 7/24
+
+  - name: unit-test-xsan-bucket08
+    tags: ["python","pull_request","unit_test_xsan"]
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+        vars:
+          unit_test_args: -v 2 -b 8/24
+
+  - name: unit-test-xsan-bucket09
+    tags: ["python","pull_request","unit_test_xsan"]
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+        vars:
+          unit_test_args: -v 2 -b 9/24
+
+  - name: unit-test-xsan-bucket10
+    tags: ["python","pull_request","unit_test_xsan"]
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+        vars:
+          unit_test_args: -v 2 -b 10/24
+
+  - name: unit-test-xsan-bucket11
+    tags: ["python","pull_request","unit_test_xsan"]
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+        vars:
+          unit_test_args: -v 2 -b 11/24
+
+  - name: unit-test-xsan-bucket12
+    tags: ["python","pull_request","unit_test_xsan"]
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+        vars:
+          unit_test_args: -v 2 -b 12/24
+
+  - name: unit-test-xsan-bucket13
+    tags: ["python","pull_request","unit_test_xsan"]
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+        vars:
+          unit_test_args: -v 2 -b 13/24
+
+  - name: unit-test-xsan-bucket14
+    tags: ["python","pull_request","unit_test_xsan"]
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+        vars:
+          unit_test_args: -v 2 -b 14/24
+
+  - name: unit-test-xsan-bucket15
+    tags: ["python","pull_request","unit_test_xsan"]
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+        vars:
+          unit_test_args: -v 2 -b 15/24
+
+  - name: unit-test-xsan-bucket16
+    tags: ["python","pull_request","unit_test_xsan"]
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+        vars:
+          unit_test_args: -v 2 -b 16/24
+
+  - name: unit-test-xsan-bucket17
+    tags: ["python","pull_request","unit_test_xsan"]
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+        vars:
+          unit_test_args: -v 2 -b 17/24
+
+  - name: unit-test-xsan-bucket18
+    tags: ["python","pull_request","unit_test_xsan"]
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+        vars:
+          unit_test_args: -v 2 -b 18/24
+
+  - name: unit-test-xsan-bucket19
+    tags: ["python","pull_request","unit_test_xsan"]
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+        vars:
+          unit_test_args: -v 2 -b 19/24
+
+  - name: unit-test-xsan-bucket20
+    tags: ["python","pull_request","unit_test_xsan"]
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+        vars:
+          unit_test_args: -v 2 -b 20/24
+
+  - name: unit-test-xsan-bucket21
+    tags: ["python","pull_request","unit_test_xsan"]
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+        vars:
+          unit_test_args: -v 2 -b 21/24
+
+  - name: unit-test-xsan-bucket22
+    tags: ["python","pull_request","unit_test_xsan"]
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+        vars:
+          unit_test_args: -v 2 -b 22/24
+
+  - name: unit-test-xsan-bucket23
+    tags: ["python","pull_request","unit_test_xsan"]
+    depends_on:
+    - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+        vars:
+          unit_test_args: -v 2 -b 23/24
+
   - name: unit-test-long-bucket00
     tags: ["python", "unit_test_long"]
     patch_only: true
@@ -6676,7 +6918,7 @@ buildvariants:
     - name: ".stress-test-disagg"
       distros: ubuntu2004-large
     # FIXME-WT-16302: Split unit tests into more buckets
-    - name: ".unit_test"
+    - name: ".unit_test_xsan"
     - name: ".unit_test_disagg"
     - name: ".unit_test_long"
 

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -3030,10 +3030,10 @@ tasks:
         vars:
           unit_test_args: -v 2 -b 11/12
 
-# XSAN testing runs longer and needs more buckets to keep individual task turnaround time reasonable.
+  # XSAN testing runs longer and needs more buckets to keep individual task turnaround time reasonable.
 
   - name: unit-test-xsan-bucket00
-    tags: ["python","unit_test_xsan"]
+    tags: ["python","pull_request","unit_test_xsan"]
     depends_on:
     - name: compile
     commands:
@@ -3043,7 +3043,7 @@ tasks:
           unit_test_args: -v 2 -b 0/24
 
   - name: unit-test-xsan-bucket01
-    tags: ["python","unit_test_xsan"]
+    tags: ["python","pull_request","unit_test_xsan"]
     depends_on:
     - name: compile
     commands:
@@ -3271,6 +3271,9 @@ tasks:
       - func: "unit test"
         vars:
           unit_test_args: -v 2 -b 23/24
+
+  # Long running tests are broken out into their own buckets/tasks so that they can be scheduled
+  # to run at a later testing stage, e.g. merge queue testing.
 
   - name: unit-test-long-bucket00
     tags: ["python", "unit_test_long"]
@@ -6917,7 +6920,6 @@ buildvariants:
     - name: ".stress-test-asan"
     - name: ".stress-test-disagg"
       distros: ubuntu2004-large
-    # FIXME-WT-16302: Split unit tests into more buckets
     - name: ".unit_test_xsan"
     - name: ".unit_test_disagg"
     - name: ".unit_test_long"
@@ -7803,7 +7805,6 @@ buildvariants:
     - name: ".stress-test-asan"
     - name: ".stress-test-disagg"
       distros: amazon2023-arm64-latest-large-m8g
-    # FIXME-WT-16302: Split unit tests into more buckets
     - name: ".unit_test"
     - name: ".unit_test_disagg"
     - name: ".unit_test_long"

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -6826,7 +6826,7 @@ buildvariants:
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo` / 2" | bc)
   tags: ["pull_request"]
   tasks:
-    - name: ".pull_request !.pull_request_compilers !.unit_test_tsan"
+    - name: ".pull_request !.pull_request_compilers !.unit_test_tsan !.unit_test_xsan"
     - name: ".lint"
     - name: ".unit_test_long"
       distros: ubuntu2004-large
@@ -6905,7 +6905,7 @@ buildvariants:
     additional_san_vars: export ASAN_OPTIONS="$COMMON_SAN_OPTIONS:unmap_shadow_on_exit=1"
   tags: ["pull_request", "sanitizer"]
   tasks:
-    - name: ".pull_request !.pull_request_compilers !.python !.tiered_unittest !csuite-wt12015-backup-corruption-test !.unit_test_tsan !syscall-linux !chunkcache-test"
+    - name: ".pull_request !.pull_request_compilers !.python !.tiered_unittest !csuite-wt12015-backup-corruption-test !.unit_test_tsan !syscall-linux !chunkcache-test !format-mirror-test"
     - name: examples-c-test
     - name: format-asan-smoke-test
     - name: model-test-long
@@ -7375,7 +7375,7 @@ buildvariants:
     CMAKE_BUILD_TYPE: -DCMAKE_BUILD_TYPE=RelWithDebInfo
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo` * 2" | bc)
   tasks:
-    - name: ".pull_request !.pull_request_compilers !.unit_test_tsan"
+    - name: ".pull_request !.pull_request_compilers !.unit_test_tsan !.unit_test_xsan"
     - name: compile
     - name: make-check-test
     - name: unit-test
@@ -7463,7 +7463,7 @@ buildvariants:
     NONSTANDALONE: -DWT_STANDALONE_BUILD=0
     unit_test_variant_args: "--hook nonstandalone"
   tasks:
-    - name: ".pull_request !.pull_request_compilers !.unit_test_tsan"
+    - name: ".pull_request !.pull_request_compilers !.unit_test_tsan !.unit_test_xsan"
     - name: compile
     - name: make-check-test
     - name: unit-test-extra-long
@@ -7790,7 +7790,7 @@ buildvariants:
     additional_san_vars: export ASAN_OPTIONS="$COMMON_SAN_OPTIONS:unmap_shadow_on_exit=1"
     ctest_extra_args: -E "wt12015_backup_corruption"
   tasks:
-    - name: ".pull_request !.pull_request_compilers !.python !.tiered_unittest !csuite-wt12015-backup-corruption-test !.unit_test_tsan !.unit_test_tsan !syscall-linux !chunkcache-test"
+    - name: ".pull_request !.pull_request_compilers !.unit_test_xsan !.python !.tiered_unittest !csuite-wt12015-backup-corruption-test !.unit_test_tsan !syscall-linux !chunkcache-test"
     - name: examples-c-test
     - name: format-asan-smoke-test
     - name: model-test-long


### PR DESCRIPTION
This PR doubles the number of buckets from 12 to 24 for ASAN Python testing, aiming to bring down the PR testing turnaround time. 

Naming the new tasks as "xsan" for ease of extension later for other XSAN testing if needed.
