### PR TITLE
WT-15800 Prevent follower from writing pages to shared btrees.

### DIFF
--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -246,11 +246,6 @@ __wt_btree_open(WT_SESSION_IMPL *session, const char *op_cfg[])
     WT_ERR(__btree_conf(session, &ckpt, WT_DHANDLE_IS_CHECKPOINT(dhandle)));
     lr_fh_meta.allocsize = btree->allocsize;
 
-    /* Ensure that followers will not write to shared tables. */
-    if (__wt_conn_is_disagg(session) && !S2C(session)->layered_table_manager.leader &&
-      btree->page_log != NULL)
-        F_SET(btree, WT_BTREE_READONLY);
-
     /* Connect to the underlying block manager. */
     WT_ERR(__wt_blkcache_open(session, dhandle_name, dhandle->cfg, forced_salvage, false,
       btree->allocsize, &lr_fh_meta, &btree->bm));

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -246,6 +246,11 @@ __wt_btree_open(WT_SESSION_IMPL *session, const char *op_cfg[])
     WT_ERR(__btree_conf(session, &ckpt, WT_DHANDLE_IS_CHECKPOINT(dhandle)));
     lr_fh_meta.allocsize = btree->allocsize;
 
+    /* Ensure that followers will not write to shared tables. */
+    if (__wt_conn_is_disagg(session) && !S2C(session)->layered_table_manager.leader &&
+      btree->page_log != NULL)
+        F_SET(btree, WT_BTREE_READONLY);
+
     /* Connect to the underlying block manager. */
     WT_ERR(__wt_blkcache_open(session, dhandle_name, dhandle->cfg, forced_salvage, false,
       btree->allocsize, &lr_fh_meta, &btree->bm));

--- a/src/cursor/cur_hs.c
+++ b/src/cursor/cur_hs.c
@@ -1040,6 +1040,11 @@ __curhs_insert(WT_CURSOR *cursor)
     CURSOR_API_CALL_PREPARE_ALLOWED(
       cursor, session, insert, ((WT_CURSOR_BTREE *)file_cursor)->dhandle);
 
+    WT_ASSERT_ALWAYS(session,
+      !__wt_conn_is_disagg(session) || !F_ISSET(CUR2BT(file_cursor), WT_BTREE_DISAGGREGATED) ||
+        S2C(session)->layered_table_manager.leader,
+      "insert applied to hs on standby");
+
     /*
      * Disable bulk loads into history store. This would normally occur when updating a record with
      * a cursor however the history store doesn't use cursor update, so we do it here.
@@ -1175,6 +1180,11 @@ __curhs_remove(WT_CURSOR *cursor)
     CURSOR_API_CALL_PREPARE_ALLOWED(
       cursor, session, remove, ((WT_CURSOR_BTREE *)file_cursor)->dhandle);
 
+    WT_ASSERT_ALWAYS(session,
+      !__wt_conn_is_disagg(session) || !F_ISSET(CUR2BT(file_cursor), WT_BTREE_DISAGGREGATED) ||
+        S2C(session)->layered_table_manager.leader,
+      "remove applied to hs on standby");
+
     /* Remove must be called with cursor positioned. */
     WT_ASSERT(session, F_ISSET(file_cursor, WT_CURSTD_KEY_INT));
 
@@ -1216,6 +1226,11 @@ __curhs_update(WT_CURSOR *cursor)
 
     CURSOR_API_CALL_PREPARE_ALLOWED(
       cursor, session, update, ((WT_CURSOR_BTREE *)file_cursor)->dhandle);
+
+    WT_ASSERT_ALWAYS(session,
+      !__wt_conn_is_disagg(session) || !F_ISSET(CUR2BT(file_cursor), WT_BTREE_DISAGGREGATED) ||
+        S2C(session)->layered_table_manager.leader,
+      "update applied to hs on standby");
 
     /* Update must be called with cursor positioned. */
     WT_ASSERT(session, F_ISSET(file_cursor, WT_CURSTD_KEY_INT));
@@ -1285,6 +1300,11 @@ __curhs_range_truncate(WT_TRUNCATE_INFO *trunc_info)
     session = trunc_info->session;
     start_file_cursor = ((WT_CURSOR_HS *)trunc_info->start)->file_cursor;
     stop_file_cursor = NULL;
+
+    WT_ASSERT_ALWAYS(session,
+      !__wt_conn_is_disagg(session) || !F_ISSET(CUR2BT(file_cursor), WT_BTREE_DISAGGREGATED) ||
+        S2C(session)->layered_table_manager.leader,
+      "truncate applied to hs on standby");
 
     WT_STAT_DSRC_INCR(session, cursor_truncate);
 

--- a/src/cursor/cur_hs.c
+++ b/src/cursor/cur_hs.c
@@ -1302,7 +1302,8 @@ __curhs_range_truncate(WT_TRUNCATE_INFO *trunc_info)
     stop_file_cursor = NULL;
 
     WT_ASSERT_ALWAYS(session,
-      !__wt_conn_is_disagg(session) || !F_ISSET(CUR2BT(file_cursor), WT_BTREE_DISAGGREGATED) ||
+      !__wt_conn_is_disagg(session) ||
+        !F_ISSET(CUR2BT(start_file_cursor), WT_BTREE_DISAGGREGATED) ||
         S2C(session)->layered_table_manager.leader,
       "truncate applied to hs on standby");
 

--- a/src/cursor/cur_hs.c
+++ b/src/cursor/cur_hs.c
@@ -56,7 +56,6 @@ __curhs_file_cursor_open(WT_SESSION_IMPL *session, const char *uri, const char *
          */
         WT_ERR(__wt_buf_fmt(session, stable_uri_buf, "%s/%s", uri, checkpoint_name));
         uri = stable_uri_buf->data;
-        open_cursor_cfg[2] = "readonly";
     }
 
     WT_WITHOUT_DHANDLE(
@@ -1040,10 +1039,9 @@ __curhs_insert(WT_CURSOR *cursor)
     CURSOR_API_CALL_PREPARE_ALLOWED(
       cursor, session, insert, ((WT_CURSOR_BTREE *)file_cursor)->dhandle);
 
-    WT_ASSERT_ALWAYS(session,
+    WT_ASSERT(session,
       !__wt_conn_is_disagg(session) || !F_ISSET(CUR2BT(file_cursor), WT_BTREE_DISAGGREGATED) ||
-        S2C(session)->layered_table_manager.leader,
-      "insert applied to hs on standby");
+        S2C(session)->layered_table_manager.leader);
 
     /*
      * Disable bulk loads into history store. This would normally occur when updating a record with
@@ -1180,10 +1178,9 @@ __curhs_remove(WT_CURSOR *cursor)
     CURSOR_API_CALL_PREPARE_ALLOWED(
       cursor, session, remove, ((WT_CURSOR_BTREE *)file_cursor)->dhandle);
 
-    WT_ASSERT_ALWAYS(session,
+    WT_ASSERT(session,
       !__wt_conn_is_disagg(session) || !F_ISSET(CUR2BT(file_cursor), WT_BTREE_DISAGGREGATED) ||
-        S2C(session)->layered_table_manager.leader,
-      "remove applied to hs on standby");
+        S2C(session)->layered_table_manager.leader);
 
     /* Remove must be called with cursor positioned. */
     WT_ASSERT(session, F_ISSET(file_cursor, WT_CURSTD_KEY_INT));
@@ -1227,10 +1224,9 @@ __curhs_update(WT_CURSOR *cursor)
     CURSOR_API_CALL_PREPARE_ALLOWED(
       cursor, session, update, ((WT_CURSOR_BTREE *)file_cursor)->dhandle);
 
-    WT_ASSERT_ALWAYS(session,
+    WT_ASSERT(session,
       !__wt_conn_is_disagg(session) || !F_ISSET(CUR2BT(file_cursor), WT_BTREE_DISAGGREGATED) ||
-        S2C(session)->layered_table_manager.leader,
-      "update applied to hs on standby");
+        S2C(session)->layered_table_manager.leader);
 
     /* Update must be called with cursor positioned. */
     WT_ASSERT(session, F_ISSET(file_cursor, WT_CURSTD_KEY_INT));
@@ -1301,11 +1297,10 @@ __curhs_range_truncate(WT_TRUNCATE_INFO *trunc_info)
     start_file_cursor = ((WT_CURSOR_HS *)trunc_info->start)->file_cursor;
     stop_file_cursor = NULL;
 
-    WT_ASSERT_ALWAYS(session,
+    WT_ASSERT(session,
       !__wt_conn_is_disagg(session) ||
         !F_ISSET(CUR2BT(start_file_cursor), WT_BTREE_DISAGGREGATED) ||
-        S2C(session)->layered_table_manager.leader,
-      "truncate applied to hs on standby");
+        S2C(session)->layered_table_manager.leader);
 
     WT_STAT_DSRC_INCR(session, cursor_truncate);
 

--- a/src/cursor/cur_hs.c
+++ b/src/cursor/cur_hs.c
@@ -56,6 +56,7 @@ __curhs_file_cursor_open(WT_SESSION_IMPL *session, const char *uri, const char *
          */
         WT_ERR(__wt_buf_fmt(session, stable_uri_buf, "%s/%s", uri, checkpoint_name));
         uri = stable_uri_buf->data;
+        open_cursor_cfg[2] = "readonly";
     }
 
     WT_WITHOUT_DHANDLE(

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -292,7 +292,6 @@ retry:
              * FIXME-WT-16476: how to close this dhandle later as it is a live btree handle? We may
              * get this dhandle when the node steps up.
              */
-            cfg[2] = "read_only=true";
             F_SET(clayered, WT_CLAYERED_STABLE_NO_CKPT);
         } else {
             if (stable_uri_buf == NULL)
@@ -305,6 +304,7 @@ retry:
               __wt_buf_fmt(session, stable_uri_buf, "%s/%s", layered->stable_uri, checkpoint_name));
             stable_uri = stable_uri_buf->data;
         }
+        cfg[2] = "read_only=true";
     }
 
     ret = __wt_open_cursor(session, stable_uri, c, cfg, &clayered->stable_cursor);

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -236,14 +236,14 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF_STATE previous_state, u
     if (__wt_page_is_modified(page))
         is_dirty = true;
 
-    is_follower_stable = (ref->page->disagg_info != NULL && !conn->layered_table_manager.leader);
-
     /*
      * No need to reconcile the page if it is from a dead tree or it is clean. Stable tables on the
      * follower are never modified, and should never be reconciled.
      */
-    if (!tree_dead && is_dirty && !is_follower_stable)
+    if (!tree_dead && is_dirty) {
+        WT_ASSERT(session, ref->page->disagg_info == NULL || conn->layered_table_manager.leader);
         WT_ERR(__evict_reconcile(session, ref, flags));
+    }
 
     /* After this spot, the only recoverable failure is EBUSY. */
     ebusy_only = true;

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -151,7 +151,7 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF_STATE previous_state, u
     WT_PAGE *page;
     uint64_t page_size;
     uint8_t stats_flags;
-    bool clean_page, closing, ebusy_only, inmem_split, is_dirty, is_follower_stable, tree_dead;
+    bool clean_page, closing, ebusy_only, inmem_split, is_dirty, tree_dead;
 
     conn = S2C(session);
     page = ref->page;

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -151,7 +151,7 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF_STATE previous_state, u
     WT_PAGE *page;
     uint64_t page_size;
     uint8_t stats_flags;
-    bool clean_page, closing, ebusy_only, inmem_split, is_dirty, tree_dead;
+    bool clean_page, closing, ebusy_only, inmem_split, is_dirty, is_follower_stable, tree_dead;
 
     conn = S2C(session);
     page = ref->page;
@@ -236,8 +236,13 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF_STATE previous_state, u
     if (__wt_page_is_modified(page))
         is_dirty = true;
 
-    /* No need to reconcile the page if it is from a dead tree or it is clean. */
-    if (!tree_dead && is_dirty)
+    is_follower_stable = (ref->page->disagg_info != NULL && !conn->layered_table_manager.leader);
+
+    /*
+     * No need to reconcile the page if it is from a dead tree or it is clean. Stable tables on the
+     * follower are never modified, and should never be reconciled.
+     */
+    if (!tree_dead && is_dirty && !is_follower_stable)
         WT_ERR(__evict_reconcile(session, ref, flags));
 
     /* After this spot, the only recoverable failure is EBUSY. */

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -891,10 +891,11 @@ __wt_page_only_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page)
 
     /*
      * At the moment, disaggregated shared btrees on the follower are not marked as read-only,
-     * although they effectively are.
+     * although they effectively are. Make sure we're not trying to modify such a tree.
      */
-    if (F_ISSET(btree, WT_BTREE_DISAGGREGATED) && !conn->layered_table_manager.leader)
-        return;
+    WT_ASSERT_ALWAYS(
+      session, !F_ISSET(btree, WT_BTREE_DISAGGREGATED) || conn->layered_table_manager.leader);
+
     /*
      * This is a relatively complex dance of operations so pay attention prior to modifying the code
      * further. Firstly, the atomic increment on page state to mark the page as dirty is effectively

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -907,12 +907,6 @@ __wt_page_only_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page)
     if (__wt_btree_never_written(session, btree))
         return;
 
-<<<<<<< Updated upstream
-=======
-    WT_ASSERT(
-      session, !F_ISSET(btree, WT_BTREE_DISAGGREGATED) || conn->layered_table_manager.leader);
-
->>>>>>> Stashed changes
     /*
      * This is a relatively complex dance of operations so pay attention prior to modifying the code
      * further. Firstly, the atomic increment on page state to mark the page as dirty is effectively
@@ -1014,23 +1008,12 @@ static WT_INLINE void
 __wt_tree_modify_set(WT_SESSION_IMPL *session)
 {
     WT_BTREE *btree;
-<<<<<<< Updated upstream
 
     btree = S2BT(session);
 
     if (__wt_btree_never_written(session, btree))
-=======
-    WT_CONNECTION_IMPL *conn;
-
-    btree = S2BT(session);
-    conn = S2C(session);
-
-    if (F_ISSET(btree, WT_BTREE_READONLY))
->>>>>>> Stashed changes
         return;
 
-    WT_ASSERT(
-      session, !F_ISSET(btree, WT_BTREE_DISAGGREGATED) || conn->layered_table_manager.leader);
     /*
      * Test before setting the dirty flag, it's a hot cache line.
      *
@@ -1074,8 +1057,8 @@ __wt_tree_modify_set(WT_SESSION_IMPL *session)
      * The btree may already be marked dirty while the connection is still clean; mark the
      * connection dirty outside the test of the btree state.
      */
-    if (!conn->modified)
-        conn->modified = true;
+    if (!S2C(session)->modified)
+        S2C(session)->modified = true;
 }
 
 /*
@@ -1121,23 +1104,13 @@ __wt_page_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page)
     WT_BTREE *btree;
 
     btree = S2BT(session);
-<<<<<<< Updated upstream
 
-=======
->>>>>>> Stashed changes
     /*
      * Prepared records in the datastore require page updates, even for read-only handles, don't
      * mark the tree or page dirty.
      */
-<<<<<<< Updated upstream
     if (__wt_btree_never_written(session, btree))
-=======
-    if (F_ISSET(btree, WT_BTREE_READONLY))
->>>>>>> Stashed changes
         return;
-
-    WT_ASSERT(session,
-      !F_ISSET(btree, WT_BTREE_DISAGGREGATED) || S2C(session)->layered_table_manager.leader);
 
     /*
      * Mark the tree dirty (even if the page is already marked dirty), newly created pages to

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -891,11 +891,10 @@ __wt_page_only_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page)
 
     /*
      * At the moment, disaggregated shared btrees on the follower are not marked as read-only,
-     * although they effectively are. Make sure we're not trying to modify such a tree.
+     * although they effectively are.
      */
-    WT_ASSERT_ALWAYS(session,
-      !F_ISSET(btree, WT_BTREE_DISAGGREGATED) || conn->layered_table_manager.leader,
-      "Attempt to modify a shared btree on a follower");
+    if (F_ISSET(btree, WT_BTREE_DISAGGREGATED) && !conn->layered_table_manager.leader)
+        return;
 
     /*
      * This is a relatively complex dance of operations so pay attention prior to modifying the code

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -37,26 +37,6 @@ __wt_btree_disable_bulk(WT_SESSION_IMPL *session)
 }
 
 /*
- * __wt_btree_never_written --
- *     Return whether this btree should never be written.
- */
-static bool
-__wt_btree_never_written(WT_SESSION_IMPL *session, WT_BTREE *btree)
-{
-    if (F_ISSET(btree, WT_BTREE_READONLY))
-        return (true);
-
-    /*
-     * At the moment, disaggregated shared btrees on the follower are not marked as read-only,
-     * although they effectively are.
-     */
-    if (F_ISSET(btree, WT_BTREE_DISAGGREGATED) && !S2C(session)->layered_table_manager.leader)
-        return (true);
-
-    return (false);
-}
-
-/*
  * __wt_page_is_empty --
  *     Return if the page is empty.
  */
@@ -904,8 +884,11 @@ __wt_page_only_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page)
     WT_ASSERT_ALWAYS(session, !F_ISSET(page->modify, WT_PAGE_MODIFY_EXCLUSIVE),
       "Illegal attempt to modify a page that is being exclusively reconciled");
 
-    if (__wt_btree_never_written(session, btree))
+    if (F_ISSET(btree, WT_BTREE_READONLY))
         return;
+
+    WT_ASSERT(
+      session, !F_ISSET(btree, WT_BTREE_DISAGGREGATED) || S2C(session)->layered_table_manager.leader);
 
     /*
      * This is a relatively complex dance of operations so pay attention prior to modifying the code
@@ -1008,11 +991,16 @@ static WT_INLINE void
 __wt_tree_modify_set(WT_SESSION_IMPL *session)
 {
     WT_BTREE *btree;
+    WT_CONNECTION_IMPL *conn;
 
     btree = S2BT(session);
+    conn = S2C(session);
 
-    if (__wt_btree_never_written(session, btree))
+    if (F_ISSET(btree, WT_BTREE_READONLY))
         return;
+
+    WT_ASSERT(
+      session, !F_ISSET(btree, WT_BTREE_DISAGGREGATED) || conn->layered_table_manager.leader);
 
     /*
      * Test before setting the dirty flag, it's a hot cache line.
@@ -1034,12 +1022,12 @@ __wt_tree_modify_set(WT_SESSION_IMPL *session)
          */
         if (WT_SESSION_BTREE_SYNC(session) && !WT_IS_METADATA(session->dhandle) &&
           !WT_IS_DISAGG_META(session->dhandle) &&
-          !FLD_ISSET(S2C(session)->timing_stress_flags, WT_TIMING_STRESS_CHECKPOINT_EVICT_PAGE)) {
+          !FLD_ISSET(conn->timing_stress_flags, WT_TIMING_STRESS_CHECKPOINT_EVICT_PAGE)) {
             WT_ASSERT_ALWAYS(session, !F_ISSET(session, WT_SESSION_ROLLBACK_TO_STABLE), "%s",
               "A btree is marked dirty during RTS");
             WT_ASSERT_ALWAYS(session,
-              !F_ISSET(S2C(session), WT_CONN_RECOVERING) &&
-                !F_ISSET_ATOMIC_32(S2C(session), WT_CONN_CLOSING_CHECKPOINT),
+              !F_ISSET(conn, WT_CONN_RECOVERING) &&
+                !F_ISSET_ATOMIC_32(conn, WT_CONN_CLOSING_CHECKPOINT),
               "%s", "A btree is marked dirty during recovery or shutdown");
         }
         btree->modified = true;
@@ -1057,8 +1045,8 @@ __wt_tree_modify_set(WT_SESSION_IMPL *session)
      * The btree may already be marked dirty while the connection is still clean; mark the
      * connection dirty outside the test of the btree state.
      */
-    if (!S2C(session)->modified)
-        S2C(session)->modified = true;
+    if (!conn->modified)
+        conn->modified = true;
 }
 
 /*
@@ -1109,8 +1097,11 @@ __wt_page_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page)
      * Prepared records in the datastore require page updates, even for read-only handles, don't
      * mark the tree or page dirty.
      */
-    if (__wt_btree_never_written(session, btree))
+    if (F_ISSET(btree, WT_BTREE_READONLY))
         return;
+
+    WT_ASSERT(session,
+      !F_ISSET(btree, WT_BTREE_DISAGGREGATED) || S2C(session)->layered_table_manager.leader);
 
     /*
      * Mark the tree dirty (even if the page is already marked dirty), newly created pages to
@@ -1146,8 +1137,11 @@ __wt_page_parent_modify_set(WT_SESSION_IMPL *session, WT_REF *ref, bool page_onl
 
     btree = S2BT(session);
 
-    if (__wt_btree_never_written(session, btree))
+    if (F_ISSET(btree, WT_BTREE_READONLY))
         return (0);
+
+    WT_ASSERT(session,
+      !F_ISSET(btree, WT_BTREE_DISAGGREGATED) || S2C(session)->layered_table_manager.leader);
 
     /*
      * This function exists as a place to stash this comment. There are a few places where we need

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -37,6 +37,26 @@ __wt_btree_disable_bulk(WT_SESSION_IMPL *session)
 }
 
 /*
+ * __wt_btree_never_written --
+ *     Return whether this btree should never be written.
+ */
+static bool
+__wt_btree_never_written(WT_SESSION_IMPL *session, WT_BTREE *btree)
+{
+    if (F_ISSET(btree, WT_BTREE_READONLY))
+        return (true);
+
+    /*
+     * At the moment, disaggregated shared btrees on the follower are not marked as read-only,
+     * although they effectively are.
+     */
+    if (F_ISSET(btree, WT_BTREE_DISAGGREGATED) && !S2C(session)->layered_table_manager.leader)
+        return (true);
+
+    return (false);
+}
+
+/*
  * __wt_page_is_empty --
  *     Return if the page is empty.
  */
@@ -876,24 +896,15 @@ static WT_INLINE void
 __wt_page_only_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page)
 {
     WT_BTREE *btree;
-    WT_CONNECTION_IMPL *conn;
 
     btree = S2BT(session);
-    conn = S2C(session);
 
     WT_ASSERT(session, !F_ISSET(session->dhandle, WT_DHANDLE_DEAD));
 
     WT_ASSERT_ALWAYS(session, !F_ISSET(page->modify, WT_PAGE_MODIFY_EXCLUSIVE),
       "Illegal attempt to modify a page that is being exclusively reconciled");
 
-    if (F_ISSET(btree, WT_BTREE_READONLY))
-        return;
-
-    /*
-     * At the moment, disaggregated shared btrees on the follower are not marked as read-only,
-     * although they effectively are.
-     */
-    if (F_ISSET(btree, WT_BTREE_DISAGGREGATED) && !conn->layered_table_manager.leader)
+    if (__wt_btree_never_written(session, btree))
         return;
 
     /*
@@ -928,12 +939,12 @@ __wt_page_only_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page)
     uint32_t page_state = __wt_atomic_load_uint32_acquire(&page->modify->page_state);
     uint64_t last_running = WT_TXN_NONE;
     if (page_state == WT_PAGE_CLEAN)
-        last_running = __wt_atomic_load_uint64_v_relaxed(&conn->txn_global.last_running);
+        last_running = __wt_atomic_load_uint64_v_relaxed(&S2C(session)->txn_global.last_running);
 
     bool increase_dirty_size_first = false;
     size_t page_memory_footprint = __wt_atomic_load_size_relaxed(&page->memory_footprint);
     uint64_t dirty_leaf_pages_total =
-      __wt_atomic_load_uint64_relaxed(&conn->cache->pages_dirty_leaf);
+      __wt_atomic_load_uint64_relaxed(&S2C(session)->cache->pages_dirty_leaf);
     if (!WT_PAGE_IS_INTERNAL(page) && page_state == WT_PAGE_CLEAN && dirty_leaf_pages_total < 10 &&
       (WT_IS_METADATA(session->dhandle) || WT_IS_DISAGG_META(session->dhandle) ||
         WT_IS_HS(session->dhandle))) {
@@ -954,7 +965,7 @@ __wt_page_only_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page)
          * performing the compare-and-swap operation.
          */
         (void)__wt_atomic_add_uint64_relaxed(
-          &conn->cache->bytes_dirty_total, page_memory_footprint);
+          &S2C(session)->cache->bytes_dirty_total, page_memory_footprint);
         (void)__wt_atomic_add_uint64_relaxed(&btree->bytes_dirty_total, page_memory_footprint);
         /*
          * The bytes dirty count for a page is decreased later when the page is marked clean, so
@@ -996,7 +1007,11 @@ __wt_page_only_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page)
 static WT_INLINE void
 __wt_tree_modify_set(WT_SESSION_IMPL *session)
 {
-    if (F_ISSET(S2BT(session), WT_BTREE_READONLY))
+    WT_BTREE *btree;
+
+    btree = S2BT(session);
+
+    if (__wt_btree_never_written(session, btree))
         return;
 
     /*
@@ -1007,7 +1022,7 @@ __wt_tree_modify_set(WT_SESSION_IMPL *session)
      * the pages clean, it might result in an extra checkpoint that doesn't do any work but it
      * shouldn't cause problems; regardless, let's play it safe.)
      */
-    if (!S2BT(session)->modified) {
+    if (!btree->modified) {
         /* Assert we never dirty a checkpoint handle. */
         WT_ASSERT(session, !WT_READING_CHECKPOINT(session));
 
@@ -1027,7 +1042,7 @@ __wt_tree_modify_set(WT_SESSION_IMPL *session)
                 !F_ISSET_ATOMIC_32(S2C(session), WT_CONN_CLOSING_CHECKPOINT),
               "%s", "A btree is marked dirty during recovery or shutdown");
         }
-        S2BT(session)->modified = true;
+        btree->modified = true;
         WT_FULL_BARRIER();
 
         /*
@@ -1086,11 +1101,15 @@ __wt_page_modify_clear(WT_SESSION_IMPL *session, WT_PAGE *page)
 static WT_INLINE void
 __wt_page_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page)
 {
+    WT_BTREE *btree;
+
+    btree = S2BT(session);
+
     /*
      * Prepared records in the datastore require page updates, even for read-only handles, don't
      * mark the tree or page dirty.
      */
-    if (F_ISSET(S2BT(session), WT_BTREE_READONLY))
+    if (__wt_btree_never_written(session, btree))
         return;
 
     /*
@@ -1122,9 +1141,12 @@ __wt_page_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page)
 static WT_INLINE int
 __wt_page_parent_modify_set(WT_SESSION_IMPL *session, WT_REF *ref, bool page_only)
 {
+    WT_BTREE *btree;
     WT_PAGE *parent;
 
-    if (F_ISSET(S2BT(session), WT_BTREE_READONLY))
+    btree = S2BT(session);
+
+    if (__wt_btree_never_written(session, btree))
         return (0);
 
     /*

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -907,6 +907,12 @@ __wt_page_only_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page)
     if (__wt_btree_never_written(session, btree))
         return;
 
+<<<<<<< Updated upstream
+=======
+    WT_ASSERT(
+      session, !F_ISSET(btree, WT_BTREE_DISAGGREGATED) || conn->layered_table_manager.leader);
+
+>>>>>>> Stashed changes
     /*
      * This is a relatively complex dance of operations so pay attention prior to modifying the code
      * further. Firstly, the atomic increment on page state to mark the page as dirty is effectively
@@ -1008,12 +1014,23 @@ static WT_INLINE void
 __wt_tree_modify_set(WT_SESSION_IMPL *session)
 {
     WT_BTREE *btree;
+<<<<<<< Updated upstream
 
     btree = S2BT(session);
 
     if (__wt_btree_never_written(session, btree))
+=======
+    WT_CONNECTION_IMPL *conn;
+
+    btree = S2BT(session);
+    conn = S2C(session);
+
+    if (F_ISSET(btree, WT_BTREE_READONLY))
+>>>>>>> Stashed changes
         return;
 
+    WT_ASSERT(
+      session, !F_ISSET(btree, WT_BTREE_DISAGGREGATED) || conn->layered_table_manager.leader);
     /*
      * Test before setting the dirty flag, it's a hot cache line.
      *
@@ -1057,8 +1074,8 @@ __wt_tree_modify_set(WT_SESSION_IMPL *session)
      * The btree may already be marked dirty while the connection is still clean; mark the
      * connection dirty outside the test of the btree state.
      */
-    if (!S2C(session)->modified)
-        S2C(session)->modified = true;
+    if (!conn->modified)
+        conn->modified = true;
 }
 
 /*
@@ -1104,13 +1121,23 @@ __wt_page_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page)
     WT_BTREE *btree;
 
     btree = S2BT(session);
+<<<<<<< Updated upstream
 
+=======
+>>>>>>> Stashed changes
     /*
      * Prepared records in the datastore require page updates, even for read-only handles, don't
      * mark the tree or page dirty.
      */
+<<<<<<< Updated upstream
     if (__wt_btree_never_written(session, btree))
+=======
+    if (F_ISSET(btree, WT_BTREE_READONLY))
+>>>>>>> Stashed changes
         return;
+
+    WT_ASSERT(session,
+      !F_ISSET(btree, WT_BTREE_DISAGGREGATED) || S2C(session)->layered_table_manager.leader);
 
     /*
      * Mark the tree dirty (even if the page is already marked dirty), newly created pages to

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -875,12 +875,25 @@ __wt_page_modify_init(WT_SESSION_IMPL *session, WT_PAGE *page)
 static WT_INLINE void
 __wt_page_only_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page)
 {
+    WT_BTREE *btree;
+    WT_CONNECTION_IMPL *conn;
+
+    btree = S2BT(session);
+    conn = S2C(session);
+
     WT_ASSERT(session, !F_ISSET(session->dhandle, WT_DHANDLE_DEAD));
 
     WT_ASSERT_ALWAYS(session, !F_ISSET(page->modify, WT_PAGE_MODIFY_EXCLUSIVE),
       "Illegal attempt to modify a page that is being exclusively reconciled");
 
-    if (F_ISSET(S2BT(session), WT_BTREE_READONLY))
+    if (F_ISSET(btree, WT_BTREE_READONLY))
+        return;
+
+    /*
+     * At the moment, disaggregated shared btrees on the follower are not marked as read-only,
+     * although they effectively are.
+     */
+    if (F_ISSET(btree, WT_BTREE_DISAGGREGATED) && !conn->layered_table_manager.leader)
         return;
     /*
      * This is a relatively complex dance of operations so pay attention prior to modifying the code
@@ -914,12 +927,12 @@ __wt_page_only_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page)
     uint32_t page_state = __wt_atomic_load_uint32_acquire(&page->modify->page_state);
     uint64_t last_running = WT_TXN_NONE;
     if (page_state == WT_PAGE_CLEAN)
-        last_running = __wt_atomic_load_uint64_v_relaxed(&S2C(session)->txn_global.last_running);
+        last_running = __wt_atomic_load_uint64_v_relaxed(&conn->txn_global.last_running);
 
     bool increase_dirty_size_first = false;
     size_t page_memory_footprint = __wt_atomic_load_size_relaxed(&page->memory_footprint);
     uint64_t dirty_leaf_pages_total =
-      __wt_atomic_load_uint64_relaxed(&S2C(session)->cache->pages_dirty_leaf);
+      __wt_atomic_load_uint64_relaxed(&conn->cache->pages_dirty_leaf);
     if (!WT_PAGE_IS_INTERNAL(page) && page_state == WT_PAGE_CLEAN && dirty_leaf_pages_total < 10 &&
       (WT_IS_METADATA(session->dhandle) || WT_IS_DISAGG_META(session->dhandle) ||
         WT_IS_HS(session->dhandle))) {
@@ -940,9 +953,8 @@ __wt_page_only_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page)
          * performing the compare-and-swap operation.
          */
         (void)__wt_atomic_add_uint64_relaxed(
-          &S2C(session)->cache->bytes_dirty_total, page_memory_footprint);
-        (void)__wt_atomic_add_uint64_relaxed(
-          &S2BT(session)->bytes_dirty_total, page_memory_footprint);
+          &conn->cache->bytes_dirty_total, page_memory_footprint);
+        (void)__wt_atomic_add_uint64_relaxed(&btree->bytes_dirty_total, page_memory_footprint);
         /*
          * The bytes dirty count for a page is decreased later when the page is marked clean, so
          * there's no need to decrease it within this function. As a result, it also doesn't need to

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -893,8 +893,9 @@ __wt_page_only_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page)
      * At the moment, disaggregated shared btrees on the follower are not marked as read-only,
      * although they effectively are. Make sure we're not trying to modify such a tree.
      */
-    WT_ASSERT_ALWAYS(
-      session, !F_ISSET(btree, WT_BTREE_DISAGGREGATED) || conn->layered_table_manager.leader);
+    WT_ASSERT_ALWAYS(session,
+      !F_ISSET(btree, WT_BTREE_DISAGGREGATED) || conn->layered_table_manager.leader,
+      "Attempt to modify a shared btree on a follower");
 
     /*
      * This is a relatively complex dance of operations so pay attention prior to modifying the code

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -887,8 +887,8 @@ __wt_page_only_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page)
     if (F_ISSET(btree, WT_BTREE_READONLY))
         return;
 
-    WT_ASSERT(
-      session, !F_ISSET(btree, WT_BTREE_DISAGGREGATED) || S2C(session)->layered_table_manager.leader);
+    WT_ASSERT(session,
+      !F_ISSET(btree, WT_BTREE_DISAGGREGATED) || S2C(session)->layered_table_manager.leader);
 
     /*
      * This is a relatively complex dance of operations so pay attention prior to modifying the code

--- a/test/suite/test_layered09.py
+++ b/test/suite/test_layered09.py
@@ -66,8 +66,7 @@ class test_layered09(wttest.WiredTigerTestCase):
     def session_create_config(self):
         # The delta percentage of 100 is an arbitrary large value, intended to produce
         # deltas a lot of the time.
-        cfg = 'key_format=S,value_format=S,block_compressor={}'.format(self.block_compress)
-        return cfg
+        return 'key_format=S,value_format=S,block_compressor={}'.format(self.block_compress)
 
     def conn_config(self):
         enc_conf = 'encryption=(name={0},{1})'.format(self.encryptor, self.encrypt_args)

--- a/test/suite/test_layered09.py
+++ b/test/suite/test_layered09.py
@@ -48,11 +48,6 @@ class test_layered09(wttest.WiredTigerTestCase):
         ('snappy', dict(block_compress='snappy')),
     ]
 
-    uris = [
-        ('layered', dict(uri='layered:test_layered09')),
-        ('btree', dict(uri='file:test_layered09')),
-    ]
-
     ts = [
         ('ts', dict(ts=True)),
         ('non-ts', dict(ts=False)),
@@ -61,9 +56,10 @@ class test_layered09(wttest.WiredTigerTestCase):
     conn_base_config = 'transaction_sync=(enabled,method=fsync),statistics=(all),statistics_log=(wait=1,json=true,on_close=true),' \
                      + 'page_delta=(delta_pct=100),,'
     disagg_storages = gen_disagg_storages('test_layered09', disagg_only = True)
+    uri='layered:test_layered09'
 
     # Make scenarios for different cloud service providers
-    scenarios = make_scenarios(encrypt, compress, disagg_storages, uris, ts)
+    scenarios = make_scenarios(encrypt, compress, disagg_storages, ts)
 
     nitems = 100
 
@@ -71,8 +67,6 @@ class test_layered09(wttest.WiredTigerTestCase):
         # The delta percentage of 100 is an arbitrary large value, intended to produce
         # deltas a lot of the time.
         cfg = 'key_format=S,value_format=S,block_compressor={}'.format(self.block_compress)
-        if self.uri.startswith('file'):
-            cfg += ',block_manager=disagg'
         return cfg
 
     def conn_config(self):

--- a/test/suite/test_layered09.py
+++ b/test/suite/test_layered09.py
@@ -53,6 +53,8 @@ class test_layered09(wttest.WiredTigerTestCase):
         ('non-ts', dict(ts=False)),
     ]
 
+    # The delta percentage of 100 is an arbitrary large value, intended to produce
+    # deltas a lot of the time.
     conn_base_config = 'transaction_sync=(enabled,method=fsync),statistics=(all),statistics_log=(wait=1,json=true,on_close=true),' \
                      + 'page_delta=(delta_pct=100),,'
     disagg_storages = gen_disagg_storages('test_layered09', disagg_only = True)
@@ -64,8 +66,6 @@ class test_layered09(wttest.WiredTigerTestCase):
     nitems = 100
 
     def session_create_config(self):
-        # The delta percentage of 100 is an arbitrary large value, intended to produce
-        # deltas a lot of the time.
         return 'key_format=S,value_format=S,block_compressor={}'.format(self.block_compress)
 
     def conn_config(self):

--- a/test/suite/test_layered09.py
+++ b/test/suite/test_layered09.py
@@ -48,6 +48,11 @@ class test_layered09(wttest.WiredTigerTestCase):
         ('snappy', dict(block_compress='snappy')),
     ]
 
+    uris = [
+        ('layered', dict(uri='layered:test_layered09')),
+        ('btree', dict(uri='file:test_layered09')),
+    ]
+
     ts = [
         ('ts', dict(ts=True)),
         ('non-ts', dict(ts=False)),
@@ -56,10 +61,9 @@ class test_layered09(wttest.WiredTigerTestCase):
     conn_base_config = 'transaction_sync=(enabled,method=fsync),statistics=(all),statistics_log=(wait=1,json=true,on_close=true),' \
                      + 'page_delta=(delta_pct=100),,'
     disagg_storages = gen_disagg_storages('test_layered09', disagg_only = True)
-    uri='layered:test_layered09'
 
     # Make scenarios for different cloud service providers
-    scenarios = make_scenarios(encrypt, compress, disagg_storages, ts)
+    scenarios = make_scenarios(encrypt, compress, disagg_storages, uris, ts)
 
     nitems = 100
 
@@ -67,6 +71,8 @@ class test_layered09(wttest.WiredTigerTestCase):
         # The delta percentage of 100 is an arbitrary large value, intended to produce
         # deltas a lot of the time.
         cfg = 'key_format=S,value_format=S,block_compressor={}'.format(self.block_compress)
+        if self.uri.startswith('file'):
+            cfg += ',block_manager=disagg'
         return cfg
 
     def conn_config(self):


### PR DESCRIPTION
- Assert all cursors on shared btrees are now readonly.
- Don't do truncate on history store on the standby.