### PR TITLE
WT-16396 Log a warning if metadata_checksum is missing

### DIFF
--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -1281,6 +1281,7 @@ __disagg_pick_up_checkpoint_meta(
         ckpt_meta.has_metadata_checksum = true;
         ckpt_meta.metadata_checksum = (uint32_t)metadata_checksum;
     } else
+        /* FIXME-WT-16000: Make the checksum parameter in "checkpoint_meta" required */
         __wt_verbose_warning(session, WT_VERB_DISAGGREGATED_STORAGE, "%s\"%s\"",
           "Missing metadata_checksum from metadata: ", meta_str);
 

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -1273,7 +1273,7 @@ __disagg_pick_up_checkpoint_meta(
      * treat it as optional, in order to support clusters with an earlier data format.
      */
     WT_ERR_NOTFOUND_OK(__wt_config_getones(session, meta_str, "metadata_checksum", &cval), true);
-    if (!WT_CHECK_AND_RESET(ret, WT_NOTFOUND) && cval.len != 0) {
+    if (ret == 0 && cval.len != 0) {
         WT_ERR(__wt_conf_parse_hex(session, "metadata_checksum", &metadata_checksum, &cval));
         if (metadata_checksum > UINT32_MAX)
             WT_ERR_MSG(

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -1273,17 +1273,16 @@ __disagg_pick_up_checkpoint_meta(
      * treat it as optional, in order to support clusters with an earlier data format.
      */
     WT_ERR_NOTFOUND_OK(__wt_config_getones(session, meta_str, "metadata_checksum", &cval), true);
-    if (ret == 0 && cval.len != 0) {
+    if (!WT_CHECK_AND_RESET(ret, WT_NOTFOUND) && cval.len != 0) {
         WT_ERR(__wt_conf_parse_hex(session, "metadata_checksum", &metadata_checksum, &cval));
         if (metadata_checksum > UINT32_MAX)
             WT_ERR_MSG(
               session, EINVAL, "Invalid metadata checksum value: %" PRIx64, metadata_checksum);
         ckpt_meta.has_metadata_checksum = true;
         ckpt_meta.metadata_checksum = (uint32_t)metadata_checksum;
-    } else if (ret == WT_NOTFOUND) {
+    } else {
         __wt_verbose_warning(
           session, WT_VERB_DISAGGREGATED_STORAGE, "%s", "Missing metadata_checksum");
-        ret = 0;
     }
 
     /* Now actually pick up the checkpoint. */

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -1273,13 +1273,17 @@ __disagg_pick_up_checkpoint_meta(
      * treat it as optional, in order to support clusters with an earlier data format.
      */
     WT_ERR_NOTFOUND_OK(__wt_config_getones(session, meta_str, "metadata_checksum", &cval), true);
-    if (WT_CHECK_AND_RESET(ret, 0) && cval.len != 0) {
+    if (ret == 0 && cval.len != 0) {
         WT_ERR(__wt_conf_parse_hex(session, "metadata_checksum", &metadata_checksum, &cval));
         if (metadata_checksum > UINT32_MAX)
             WT_ERR_MSG(
               session, EINVAL, "Invalid metadata checksum value: %" PRIx64, metadata_checksum);
         ckpt_meta.has_metadata_checksum = true;
         ckpt_meta.metadata_checksum = (uint32_t)metadata_checksum;
+    } else if (ret == WT_NOTFOUND) {
+        __wt_verbose_warning(
+          session, WT_VERB_DISAGGREGATED_STORAGE, "%s", "Missing metadata_checksum");
+        ret = 0;
     }
 
     /* Now actually pick up the checkpoint. */

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -1281,8 +1281,8 @@ __disagg_pick_up_checkpoint_meta(
         ckpt_meta.has_metadata_checksum = true;
         ckpt_meta.metadata_checksum = (uint32_t)metadata_checksum;
     } else
-        __wt_verbose_warning(
-          session, WT_VERB_DISAGGREGATED_STORAGE, "%s", "Missing metadata_checksum");
+        __wt_verbose_warning(session, WT_VERB_DISAGGREGATED_STORAGE, "%s\"%s\"",
+          "Missing metadata_checksum from metadata: ", meta_str);
 
     /* Now actually pick up the checkpoint. */
     WT_ERR(__disagg_pick_up_checkpoint(session, &ckpt_meta));

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -1280,10 +1280,9 @@ __disagg_pick_up_checkpoint_meta(
               session, EINVAL, "Invalid metadata checksum value: %" PRIx64, metadata_checksum);
         ckpt_meta.has_metadata_checksum = true;
         ckpt_meta.metadata_checksum = (uint32_t)metadata_checksum;
-    } else {
+    } else
         __wt_verbose_warning(
           session, WT_VERB_DISAGGREGATED_STORAGE, "%s", "Missing metadata_checksum");
-    }
 
     /* Now actually pick up the checkpoint. */
     WT_ERR(__disagg_pick_up_checkpoint(session, &ckpt_meta));

--- a/test/suite/test_layered64.py
+++ b/test/suite/test_layered64.py
@@ -79,11 +79,12 @@ class test_layered64(wttest.WiredTigerTestCase):
         self.restart_without_local_files(pickup_checkpoint=False)
 
         # Ensure that we can pick up the checkpoint without a checksum.
+        # FIXME-WT-16000: Make the checksum parameter in "checkpoint_meta" required
         checkpoint_meta_no_checksum = re.sub(r',metadata_checksum=[0-9a-fA-F]+', '', checkpoint_meta)
         self.pr(f'Checkpoint metadata without a checksum: {checkpoint_meta_no_checksum}')
         self.conn.reconfigure(f'disaggregated=(checkpoint_meta="{checkpoint_meta_no_checksum}")')
         self.captureout.checkAdditionalPattern(self,
-            'Missing metadata_checksum')
+            'Missing metadata_checksum from metadata: ')
 
         # Check that all the data is present.
         cursor = self.session.open_cursor(self.uri, None, None)

--- a/test/suite/test_layered64.py
+++ b/test/suite/test_layered64.py
@@ -82,6 +82,8 @@ class test_layered64(wttest.WiredTigerTestCase):
         checkpoint_meta_no_checksum = re.sub(r',metadata_checksum=[0-9a-fA-F]+', '', checkpoint_meta)
         self.pr(f'Checkpoint metadata without a checksum: {checkpoint_meta_no_checksum}')
         self.conn.reconfigure(f'disaggregated=(checkpoint_meta="{checkpoint_meta_no_checksum}")')
+        self.captureout.checkAdditionalPattern(self,
+            'Missing metadata_checksum')
 
         # Check that all the data is present.
         cursor = self.session.open_cursor(self.uri, None, None)


### PR DESCRIPTION
[WT-15982](https://jira.mongodb.org/browse/WT-15982) added a new optional metadata_checksum parameter to checkpoint_meta, which is used by a follower when picking up a checkpoint. Before making it required in [WT-16000](https://jira.mongodb.org/browse/WT-16000), we want to log a warning first.

I added the warning log in `conn_layered.c` and also made sure that `ret` was set to 0 so that `WT_NOTFOUND` doesn't leak outside of the `__disagg_pick_up_checkpoint_meta` function.