### PR TITLE
WT-16515 Fix stats for clean pages seen and queued by eviction

### DIFF
--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1589,10 +1589,11 @@ __evict_lru_walk(WT_SESSION_IMPL *session)
         WT_PAGE *page = queue->evict_queue[candidates].ref->page;
         if (__wt_page_is_modified(page))
             WT_STAT_CONN_DSRC_INCR(session, cache_eviction_pages_queued_dirty);
-        else if (page->modify != NULL)
-            WT_STAT_CONN_DSRC_INCR(session, cache_eviction_pages_queued_updates);
         else
             WT_STAT_CONN_DSRC_INCR(session, cache_eviction_pages_queued_clean);
+
+        if (page->modify != NULL)
+            WT_STAT_CONN_DSRC_INCR(session, cache_eviction_pages_queued_updates);
     }
     queue->evict_current = queue->evict_queue;
     __wt_spin_unlock(session, &queue->evict_lock);
@@ -2735,10 +2736,11 @@ __evict_walk_tree(WT_SESSION_IMPL *session, WTI_EVICT_QUEUE *queue, u_int max_en
 
         if (__wt_page_is_modified(page))
             ++pages_seen_dirty;
-        else if (page->modify != NULL)
-            ++pages_seen_updates;
         else
             ++pages_seen_clean;
+
+        if (page->modify != NULL)
+            ++pages_seen_updates;
 
         /* Count internal pages seen. */
         if (F_ISSET(ref, WT_REF_FLAG_INTERNAL))

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1461,9 +1461,7 @@ __evict_lru_walk(WT_SESSION_IMPL *session)
     if (__evict_queue_full(queue) && !__evict_queue_full(other_queue))
         queue = other_queue;
 
-    /*
-     * If both queues are full and haven't been empty on recent refills, we're done.
-     */
+    /* If both queues are full and haven't been empty on recent refills, we're done. */
     if (__evict_queue_full(queue) && evict->evict_empty_score < WT_EVICT_SCORE_CUTOFF) {
         WT_STAT_CONN_INCR(session, eviction_queue_not_empty);
         goto err;
@@ -1582,9 +1580,8 @@ __evict_lru_walk(WT_SESSION_IMPL *session)
     }
 
     WT_STAT_CONN_INCRV(session, eviction_pages_queued_post_lru, queue->evict_candidates);
-    /*
-     * Add stats about pages that have been queued.
-     */
+
+    /* Add stats about pages that have been queued. */
     for (candidates = 0; candidates < queue->evict_candidates; ++candidates) {
         WT_PAGE *page = queue->evict_queue[candidates].ref->page;
         if (__wt_page_is_modified(page))
@@ -1598,9 +1595,7 @@ __evict_lru_walk(WT_SESSION_IMPL *session)
     queue->evict_current = queue->evict_queue;
     __wt_spin_unlock(session, &queue->evict_lock);
 
-    /*
-     * Signal any application or helper threads that may be waiting to help with eviction.
-     */
+    /* Signal any application or helper threads that may be waiting to help with eviction. */
     __wt_cond_signal(session, conn->evict_threads.wait_cond);
 
 err:


### PR DESCRIPTION
The stats for tracking the clean/dirty/updated pages seen and queued by eviction treated these three categories as mutually exclusive. But these categories are *not* mutually exclusive. Pages are either clean and dirty. And pages with updates can be either clean or dirty.

This PR updates how WT computes these statistics:

- `cache_eviction_pages_seen_clean`
- `cache_eviction_pages_seen_dirty`
- `cache_eviction_pages_seen_updates`
- `cache_eviction_pages_queued_clean`
- `cache_eviction_pages_queued_dirty`
- `cache_eviction_pages_queued_updates`
