### PR TITLE
WT-16513 Claim the unused page header field for future extensibility

### DIFF
--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -383,7 +383,7 @@ __page_merge_base_internal_deltas(WT_SESSION_IMPL *session, WT_CELL_UNPACK_ADDR 
 
     hdr->write_gen = latest_write_gen;
     hdr->type = WT_PAGE_ROW_INT;
-    hdr->unused = 0;
+    hdr->reserved = 0;
     hdr->version = WT_PAGE_VERSION_TS;
 
     *ref_entriesp = final_entries;
@@ -640,7 +640,7 @@ __wti_page_merge_deltas_with_base_image_leaf(WT_SESSION_IMPL *session, WT_ITEM *
     dsk->mem_size = WT_STORE_SIZE(new_image->size);
 
     dsk->write_gen = ((WT_PAGE_HEADER *)deltas[delta_size - 1].data)->write_gen;
-    dsk->unused = 0;
+    dsk->reserved = 0;
     dsk->version = WT_PAGE_VERSION_TS;
 
     /* Clear the memory owned by the block manager. */

--- a/src/btree/bt_vrfy_dsk.c
+++ b/src/btree/bt_vrfy_dsk.c
@@ -132,9 +132,9 @@ __wt_verify_dsk_image(WT_SESSION_IMPL *session, const char *tag, const WT_PAGE_H
     if (flags != 0)
         WT_RET_VRFY(session, "page at %s has invalid flags set: 0x%" PRIx8, tag, flags);
 
-    /* Check the unused byte. */
-    if (dsk->unused != 0)
-        WT_RET_VRFY(session, "page at %s has non-zero unused page header bytes", tag);
+    /* Check the reserved byte. */
+    if (dsk->reserved != 0)
+        WT_RET_VRFY(session, "page at %s has non-zero reserved page header bytes", tag);
 
     /* Check the page version. */
     switch (dsk->version) {

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -81,8 +81,8 @@ struct __wt_page_header {
 #define WT_PAGE_FT_UPDATE 0x20u    /* Page contains updated fast-truncate information */
     uint8_t flags;                 /* 25: flags */
 
-    /* A byte of padding, positioned to be added to the flags. */
-    uint8_t unused; /* 26: unused padding */
+    /* FIXME-WT-16512: A byte of padding, reserved to make the header extensible in the future. */
+    uint8_t reserved; /* 26: padding, used for future use (until then, please always set to 0) */
 
 #define WT_PAGE_VERSION_ORIG 0 /* Original version */
 #define WT_PAGE_VERSION_TS 1   /* Timestamps added */

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -1858,7 +1858,7 @@ __rec_split_write_header(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_CHU
     if ((page->type == WT_PAGE_COL_INT || page->type == WT_PAGE_ROW_INT))
         F_SET(dsk, WT_PAGE_FT_UPDATE);
 
-    dsk->unused = 0;
+    dsk->reserved = 0;
     dsk->version = WT_PAGE_VERSION_TS;
 
     /* Clear the memory owned by the block manager. */


### PR DESCRIPTION
Reserve the unused field in the page header to support future extensibility.