### PR TITLE
WT-16219 Fix version cursor wrongly skips the on-page value because version_cursor->upd_durable_stop_ts is initialized to WT_TS_NONE

### DIFF
--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -2417,6 +2417,8 @@ __layered_move_updates(
 {
     WT_DECL_RET;
 
+    __wt_btree_disable_bulk(session);
+
     /* Search the page. */
     WT_WITH_PAGE_INDEX(session, ret = __wt_row_search(cbt, key, true, NULL, false, NULL));
     WT_ERR(ret);

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -2417,6 +2417,10 @@ __layered_move_updates(
 {
     WT_DECL_RET;
 
+    /*
+     * Disable bulk load if the btree is empty. Otherwise, checkpoint may skip this btree if it has
+     * never been checkpointed.
+     */
     __wt_btree_disable_bulk(session);
 
     /* Search the page. */

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -372,8 +372,7 @@ __curversion_next_single_key(WT_CURSOR *cursor)
                             goto skip_on_page;
                     } else {
                         if (cbt->upd_value->tw.start_txn > version_cursor->upd_stop_txnid ||
-                          cbt->upd_value->tw.start_ts > version_cursor->upd_stop_ts ||
-                          cbt->upd_value->tw.durable_start_ts > version_cursor->upd_durable_stop_ts)
+                          cbt->upd_value->tw.start_ts > version_cursor->upd_stop_ts)
                             goto skip_on_page;
                     }
 
@@ -402,8 +401,7 @@ __curversion_next_single_key(WT_CURSOR *cursor)
                             goto skip_on_page;
                     } else {
                         if (cbt->upd_value->tw.stop_txn > version_cursor->upd_stop_txnid ||
-                          cbt->upd_value->tw.stop_ts > version_cursor->upd_stop_ts ||
-                          cbt->upd_value->tw.durable_stop_ts > version_cursor->upd_durable_stop_ts)
+                          cbt->upd_value->tw.stop_ts > version_cursor->upd_stop_ts)
                             goto skip_on_page;
                     }
 

--- a/test/suite/test_layered61.py
+++ b/test/suite/test_layered61.py
@@ -69,3 +69,6 @@ class test_layered61(wttest.WiredTigerTestCase):
 
         # Step up
         self.conn.reconfigure('disaggregated=(role="leader")')
+        cursor = self.session.open_cursor(self.uri, None, None)
+        self.assertEqual(cursor['a'], 'b')
+        cursor.close()


### PR DESCRIPTION
version_cursor->upd_durable_stop_ts is initialized to WT_TS_NONE. Comparing it with the durable timestamp will always return true and skips the on-page value.