### PR TITLE
WT-16530 Replace pending prepared tombstone with special update value

### DIFF
--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -876,8 +876,8 @@ err:
  *     Create the actual update for a tombstone.
  */
 static int
-__page_inmem_tombstone(WT_SESSION_IMPL *session, WT_CELL_UNPACK_KV *unpack, WT_UPDATE **updp,
-  size_t *sizep, bool tombstone_allowed)
+__page_inmem_tombstone(
+  WT_SESSION_IMPL *session, WT_CELL_UNPACK_KV *unpack, WT_UPDATE **updp, size_t *sizep)
 {
     WT_UPDATE *tombstone;
     size_t size, total_size;
@@ -890,15 +890,7 @@ __page_inmem_tombstone(WT_SESSION_IMPL *session, WT_CELL_UNPACK_KV *unpack, WT_U
     total_size = 0;
 
     WT_ASSERT(session, WT_TIME_WINDOW_HAS_STOP(&unpack->tw));
-    if (tombstone_allowed)
-        WT_RET(__wt_upd_alloc_tombstone(session, &tombstone, &size));
-    else
-        /*
-         *  If tombstone_allowed is false, create a standard update with a special tombstone value
-         * instead of a tombstone. This is used when a prepared delete on is restored to the ingest
-         * table in disaggregated storage.
-         */
-        WT_RET(__wt_upd_alloc(session, &__wt_tombstone, WT_UPDATE_STANDARD, &tombstone, &size));
+    WT_RET(__wt_upd_alloc_tombstone(session, &tombstone, &size));
 
     total_size += size;
     tombstone->upd_durable_ts = unpack->tw.durable_stop_ts;
@@ -921,7 +913,7 @@ __page_inmem_tombstone(WT_SESSION_IMPL *session, WT_CELL_UNPACK_KV *unpack, WT_U
  */
 static int
 __page_inmem_prepare_update(WT_SESSION_IMPL *session, WT_ITEM *value, WT_CELL_UNPACK_KV *unpack,
-  WT_UPDATE **updp, size_t *sizep, bool tombstone_allowed)
+  WT_UPDATE **updp, size_t *sizep)
 {
     WT_DECL_RET;
     WT_UPDATE *upd, *tombstone;
@@ -961,15 +953,7 @@ __page_inmem_prepare_update(WT_SESSION_IMPL *session, WT_ITEM *value, WT_CELL_UN
             F_SET(upd, WT_UPDATE_DURABLE);
     }
     if (WT_TIME_WINDOW_HAS_STOP_PREPARE(&(unpack->tw))) {
-        if (tombstone_allowed)
-            WT_ERR(__wt_upd_alloc_tombstone(session, &tombstone, &size));
-        else
-            /*
-             *  If tombstone_allowed is false, create a standard update with a special tombstone
-             * value instead of a tombstone. This is used when a prepared delete on is restored to
-             * the ingest table in disaggregated storage.
-             */
-            WT_RET(__wt_upd_alloc(session, &__wt_tombstone, WT_UPDATE_STANDARD, &tombstone, &size));
+        WT_ERR(__wt_upd_alloc_tombstone(session, &tombstone, &size));
         total_size += size;
         tombstone->upd_durable_ts = WT_TS_NONE;
         tombstone->txnid = unpack->tw.stop_txn;
@@ -997,19 +981,18 @@ err:
 }
 
 /*
- * __wt_page_inmem_update --
+ * __wti_page_inmem_update --
  *     Create the actual update.
  */
 int
-__wt_page_inmem_update(WT_SESSION_IMPL *session, WT_ITEM *value, WT_CELL_UNPACK_KV *unpack,
-  WT_UPDATE **updp, size_t *sizep, bool tombstone_allowed)
+__wti_page_inmem_update(WT_SESSION_IMPL *session, WT_ITEM *value, WT_CELL_UNPACK_KV *unpack,
+  WT_UPDATE **updp, size_t *sizep)
 {
     if (WT_TIME_WINDOW_HAS_PREPARE(&unpack->tw))
-        return (
-          __page_inmem_prepare_update(session, value, unpack, updp, sizep, tombstone_allowed));
+        return (__page_inmem_prepare_update(session, value, unpack, updp, sizep));
 
     WT_ASSERT(session, WT_TIME_WINDOW_HAS_STOP(&unpack->tw));
-    return (__page_inmem_tombstone(session, unpack, updp, sizep, tombstone_allowed));
+    return (__page_inmem_tombstone(session, unpack, updp, sizep));
 }
 
 /*
@@ -1020,7 +1003,7 @@ static int
 __page_inmem_update_col(WT_SESSION_IMPL *session, WT_REF *ref, WT_CURSOR_BTREE *cbt, uint64_t recno,
   WT_ITEM *value, WT_CELL_UNPACK_KV *unpack, WT_UPDATE **updp, size_t *sizep)
 {
-    WT_RET(__wt_page_inmem_update(session, value, unpack, updp, sizep, true));
+    WT_RET(__wti_page_inmem_update(session, value, unpack, updp, sizep));
 
     /* Search the page and apply the modification. */
     WT_RET(__wt_col_search(cbt, recno, ref, true, NULL));
@@ -1116,7 +1099,7 @@ __wti_page_inmem_updates(WT_SESSION_IMPL *session, WT_REF *ref)
             WT_ASSERT_ALWAYS(session, __wt_cell_type_raw(unpack.cell) != WT_CELL_VALUE_OVFL_RM,
               "Should never read an overflow removed value for a prepared update");
 
-            WT_ERR(__wt_page_inmem_update(session, value, &unpack, &upd, &size, true));
+            WT_ERR(__wti_page_inmem_update(session, value, &unpack, &upd, &size));
             total_size += size;
 
             /* Search the page and apply the modification. */

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -981,11 +981,11 @@ err:
 }
 
 /*
- * __wti_page_inmem_update --
+ * __page_inmem_update --
  *     Create the actual update.
  */
-int
-__wti_page_inmem_update(WT_SESSION_IMPL *session, WT_ITEM *value, WT_CELL_UNPACK_KV *unpack,
+static int
+__page_inmem_update(WT_SESSION_IMPL *session, WT_ITEM *value, WT_CELL_UNPACK_KV *unpack,
   WT_UPDATE **updp, size_t *sizep)
 {
     if (WT_TIME_WINDOW_HAS_PREPARE(&unpack->tw))
@@ -1003,7 +1003,7 @@ static int
 __page_inmem_update_col(WT_SESSION_IMPL *session, WT_REF *ref, WT_CURSOR_BTREE *cbt, uint64_t recno,
   WT_ITEM *value, WT_CELL_UNPACK_KV *unpack, WT_UPDATE **updp, size_t *sizep)
 {
-    WT_RET(__wti_page_inmem_update(session, value, unpack, updp, sizep));
+    WT_RET(__page_inmem_update(session, value, unpack, updp, sizep));
 
     /* Search the page and apply the modification. */
     WT_RET(__wt_col_search(cbt, recno, ref, true, NULL));
@@ -1099,7 +1099,7 @@ __wti_page_inmem_updates(WT_SESSION_IMPL *session, WT_REF *ref)
             WT_ASSERT_ALWAYS(session, __wt_cell_type_raw(unpack.cell) != WT_CELL_VALUE_OVFL_RM,
               "Should never read an overflow removed value for a prepared update");
 
-            WT_ERR(__wti_page_inmem_update(session, value, &unpack, &upd, &size));
+            WT_ERR(__page_inmem_update(session, value, &unpack, &upd, &size));
             total_size += size;
 
             /* Search the page and apply the modification. */

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -890,8 +890,8 @@ __page_inmem_tombstone(
     total_size = 0;
 
     WT_ASSERT(session, WT_TIME_WINDOW_HAS_STOP(&unpack->tw));
+    
     WT_RET(__wt_upd_alloc_tombstone(session, &tombstone, &size));
-
     total_size += size;
     tombstone->upd_durable_ts = unpack->tw.durable_stop_ts;
     tombstone->upd_start_ts = unpack->tw.stop_ts;

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -876,8 +876,8 @@ err:
  *     Create the actual update for a tombstone.
  */
 static int
-__page_inmem_tombstone(
-  WT_SESSION_IMPL *session, WT_CELL_UNPACK_KV *unpack, WT_UPDATE **updp, size_t *sizep)
+__page_inmem_tombstone(WT_SESSION_IMPL *session, WT_CELL_UNPACK_KV *unpack, WT_UPDATE **updp,
+  size_t *sizep, bool tombstone_allowed)
 {
     WT_UPDATE *tombstone;
     size_t size, total_size;
@@ -890,8 +890,16 @@ __page_inmem_tombstone(
     total_size = 0;
 
     WT_ASSERT(session, WT_TIME_WINDOW_HAS_STOP(&unpack->tw));
+    if (tombstone_allowed)
+        WT_RET(__wt_upd_alloc_tombstone(session, &tombstone, &size));
+    else
+        /*
+         *  If tombstone_allowed is false, create a standard update with a special tombstone value
+         * instead of a tombstone. This is used when a prepared delete on is restored to the ingest
+         * table in disaggregated storage.
+         */
+        WT_RET(__wt_upd_alloc(session, &__wt_tombstone, WT_UPDATE_STANDARD, &tombstone, &size));
 
-    WT_RET(__wt_upd_alloc_tombstone(session, &tombstone, &size));
     total_size += size;
     tombstone->upd_durable_ts = unpack->tw.durable_stop_ts;
     tombstone->upd_start_ts = unpack->tw.stop_ts;
@@ -913,7 +921,7 @@ __page_inmem_tombstone(
  */
 static int
 __page_inmem_prepare_update(WT_SESSION_IMPL *session, WT_ITEM *value, WT_CELL_UNPACK_KV *unpack,
-  WT_UPDATE **updp, size_t *sizep)
+  WT_UPDATE **updp, size_t *sizep, bool tombstone_allowed)
 {
     WT_DECL_RET;
     WT_UPDATE *upd, *tombstone;
@@ -953,7 +961,15 @@ __page_inmem_prepare_update(WT_SESSION_IMPL *session, WT_ITEM *value, WT_CELL_UN
             F_SET(upd, WT_UPDATE_DURABLE);
     }
     if (WT_TIME_WINDOW_HAS_STOP_PREPARE(&(unpack->tw))) {
-        WT_ERR(__wt_upd_alloc_tombstone(session, &tombstone, &size));
+        if (tombstone_allowed)
+            WT_ERR(__wt_upd_alloc_tombstone(session, &tombstone, &size));
+        else
+            /*
+             *  If tombstone_allowed is false, create a standard update with a special tombstone
+             * value instead of a tombstone. This is used when a prepared delete on is restored to
+             * the ingest table in disaggregated storage.
+             */
+            WT_RET(__wt_upd_alloc(session, &__wt_tombstone, WT_UPDATE_STANDARD, &tombstone, &size));
         total_size += size;
         tombstone->upd_durable_ts = WT_TS_NONE;
         tombstone->txnid = unpack->tw.stop_txn;
@@ -986,13 +1002,14 @@ err:
  */
 int
 __wt_page_inmem_update(WT_SESSION_IMPL *session, WT_ITEM *value, WT_CELL_UNPACK_KV *unpack,
-  WT_UPDATE **updp, size_t *sizep)
+  WT_UPDATE **updp, size_t *sizep, bool tombstone_allowed)
 {
     if (WT_TIME_WINDOW_HAS_PREPARE(&unpack->tw))
-        return (__page_inmem_prepare_update(session, value, unpack, updp, sizep));
+        return (
+          __page_inmem_prepare_update(session, value, unpack, updp, sizep, tombstone_allowed));
 
     WT_ASSERT(session, WT_TIME_WINDOW_HAS_STOP(&unpack->tw));
-    return (__page_inmem_tombstone(session, unpack, updp, sizep));
+    return (__page_inmem_tombstone(session, unpack, updp, sizep, tombstone_allowed));
 }
 
 /*
@@ -1003,7 +1020,7 @@ static int
 __page_inmem_update_col(WT_SESSION_IMPL *session, WT_REF *ref, WT_CURSOR_BTREE *cbt, uint64_t recno,
   WT_ITEM *value, WT_CELL_UNPACK_KV *unpack, WT_UPDATE **updp, size_t *sizep)
 {
-    WT_RET(__wt_page_inmem_update(session, value, unpack, updp, sizep));
+    WT_RET(__wt_page_inmem_update(session, value, unpack, updp, sizep, true));
 
     /* Search the page and apply the modification. */
     WT_RET(__wt_col_search(cbt, recno, ref, true, NULL));
@@ -1099,7 +1116,7 @@ __wti_page_inmem_updates(WT_SESSION_IMPL *session, WT_REF *ref)
             WT_ASSERT_ALWAYS(session, __wt_cell_type_raw(unpack.cell) != WT_CELL_VALUE_OVFL_RM,
               "Should never read an overflow removed value for a prepared update");
 
-            WT_ERR(__wt_page_inmem_update(session, value, &unpack, &upd, &size));
+            WT_ERR(__wt_page_inmem_update(session, value, &unpack, &upd, &size, true));
             total_size += size;
 
             /* Search the page and apply the modification. */

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -890,7 +890,7 @@ __page_inmem_tombstone(
     total_size = 0;
 
     WT_ASSERT(session, WT_TIME_WINDOW_HAS_STOP(&unpack->tw));
-    
+
     WT_RET(__wt_upd_alloc_tombstone(session, &tombstone, &size));
     total_size += size;
     tombstone->upd_durable_ts = unpack->tw.durable_stop_ts;

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1517,9 +1517,6 @@ extern int __wti_meta_track_update(WT_SESSION_IMPL *session, const char *key)
 extern int __wti_page_inmem(WT_SESSION_IMPL *session, WT_REF *ref, const void *image,
   uint32_t flags, WT_PAGE **pagep, bool *instantiate_updp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wti_page_inmem_update(WT_SESSION_IMPL *session, WT_ITEM *value,
-  WT_CELL_UNPACK_KV *unpack, WT_UPDATE **updp, size_t *sizep)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_page_inmem_updates(WT_SESSION_IMPL *session, WT_REF *ref)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_page_merge_deltas_with_base_image_int(WT_SESSION_IMPL *session, WT_ITEM *deltas,

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -866,7 +866,7 @@ extern int __wt_page_in_func(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t fla
 #endif
   ) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_page_inmem_update(WT_SESSION_IMPL *session, WT_ITEM *value,
-  WT_CELL_UNPACK_KV *unpack, WT_UPDATE **updp, size_t *sizep)
+  WT_CELL_UNPACK_KV *unpack, WT_UPDATE **updp, size_t *sizep, bool tombstone_allowed)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_page_modify_alloc(WT_SESSION_IMPL *session, WT_PAGE *page)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -865,9 +865,6 @@ extern int __wt_page_in_func(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t fla
   const char *func, int line
 #endif
   ) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_page_inmem_update(WT_SESSION_IMPL *session, WT_ITEM *value,
-  WT_CELL_UNPACK_KV *unpack, WT_UPDATE **updp, size_t *sizep, bool tombstone_allowed)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_page_modify_alloc(WT_SESSION_IMPL *session, WT_PAGE *page)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_page_release_evict(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
@@ -1519,6 +1516,9 @@ extern int __wti_meta_track_update(WT_SESSION_IMPL *session, const char *key)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_page_inmem(WT_SESSION_IMPL *session, WT_REF *ref, const void *image,
   uint32_t flags, WT_PAGE **pagep, bool *instantiate_updp)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wti_page_inmem_update(WT_SESSION_IMPL *session, WT_ITEM *value,
+  WT_CELL_UNPACK_KV *unpack, WT_UPDATE **updp, size_t *sizep)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_page_inmem_updates(WT_SESSION_IMPL *session, WT_REF *ref)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/prepared_discover/prepared_discover_txn.c
+++ b/src/prepared_discover/prepared_discover_txn.c
@@ -143,16 +143,6 @@ __wti_prepared_discover_add_artifact_upd(WT_SESSION_IMPL *session, WT_UPDATE *up
      * txn.
      */
     WT_RET(__wt_pending_prepared_next_op(session, &op, prepared_item, key));
-    /*
-     * Special case - If the pending update is a tombstone, since we're restoring the update into
-     * ingest table with no tombstone allowed, convert the tombstone to a special tombstone value
-     * instead of a real tombstone update structure.
-     */
-    if (upd->type == WT_UPDATE_TOMBSTONE) {
-        memcpy(upd->data, __wt_tombstone.data, __wt_tombstone.size);
-        upd->size = __wt_tombstone.size;
-        upd->type = WT_UPDATE_STANDARD;
-    }
     WT_RET(__wt_op_modify(session, upd, op));
 
     WT_ASSERT(session, op->type == WT_TXN_OP_BASIC_ROW || op->type == WT_TXN_OP_INMEM_ROW);
@@ -206,7 +196,7 @@ __wti_prepared_discover_restore_and_add_artifact_upd(WT_SESSION_IMPL *session,
 
     cbt = (WT_CURSOR_BTREE *)cursor;
     size_t size;
-    WT_ERR(__wt_page_inmem_update(session, value, unpack, &upd, &size));
+    WT_ERR(__wt_page_inmem_update(session, value, unpack, &upd, &size, false));
 
     /* Search the page and apply the modification. */
     WT_WITH_PAGE_INDEX(session, ret = __wt_row_search(cbt, key, true, NULL, false, NULL));

--- a/src/prepared_discover/prepared_discover_txn.c
+++ b/src/prepared_discover/prepared_discover_txn.c
@@ -47,12 +47,11 @@ __prepare_discover_alloc_upd(WT_SESSION_IMPL *session, WT_ITEM *value, WT_CELL_U
   WT_UPDATE **updp, size_t *sizep)
 {
     WT_UPDATE *upd;
-    size_t size, total_size;
+    size_t size;
 
     size = 0;
     *sizep = 0;
     upd = NULL;
-    total_size = 0;
     if (WT_TIME_WINDOW_HAS_STOP_PREPARE(&(unpack->tw))) {
         /*
          * Usually we would allocate a tombstone update when seeing a stop timestamp. However in
@@ -78,10 +77,8 @@ __prepare_discover_alloc_upd(WT_SESSION_IMPL *session, WT_ITEM *value, WT_CELL_U
         upd->upd_start_ts = unpack->tw.start_prepare_ts;
         upd->prepare_state = WT_PREPARE_INPROGRESS;
     }
-    total_size += size;
-
     *updp = upd;
-    *sizep = total_size;
+    *sizep = size;
     return (0);
 }
 

--- a/src/prepared_discover/prepared_discover_txn.c
+++ b/src/prepared_discover/prepared_discover_txn.c
@@ -143,6 +143,16 @@ __wti_prepared_discover_add_artifact_upd(WT_SESSION_IMPL *session, WT_UPDATE *up
      * txn.
      */
     WT_RET(__wt_pending_prepared_next_op(session, &op, prepared_item, key));
+    /*
+     * Special case - If the pending update is a tombstone, since we're restoring the update into
+     * ingest table with no tombstone allowed, convert the tombstone to a special tombstone value
+     * instead of a real tombstone update structure.
+     */
+    if (upd->type == WT_UPDATE_TOMBSTONE) {
+        memcpy(upd->data, __wt_tombstone.data, __wt_tombstone.size);
+        upd->size = __wt_tombstone.size;
+        upd->type = WT_UPDATE_STANDARD;
+    }
     WT_RET(__wt_op_modify(session, upd, op));
 
     WT_ASSERT(session, op->type == WT_TXN_OP_BASIC_ROW || op->type == WT_TXN_OP_INMEM_ROW);

--- a/src/prepared_discover/prepared_discover_txn.c
+++ b/src/prepared_discover/prepared_discover_txn.c
@@ -39,6 +39,77 @@ __wt_prepared_discover_find_item(
 }
 
 /*
+ * __prepare_discover_alloc_upd --
+ *     Create the actual update for a prepared value.
+ */
+static int
+__prepare_discover_alloc_upd(WT_SESSION_IMPL *session, WT_ITEM *value, WT_CELL_UNPACK_KV *unpack,
+  WT_UPDATE **updp, size_t *sizep)
+{
+    WT_DECL_RET;
+    WT_UPDATE *upd, *tombstone;
+    size_t size, total_size;
+
+    size = 0;
+    *sizep = 0;
+
+    tombstone = upd = NULL;
+    total_size = 0;
+    WT_RET(__wt_upd_alloc(session, value, WT_UPDATE_STANDARD, &upd, &size));
+    total_size += size;
+
+    /*
+     * Instantiate both update and tombstone if the prepared update is a tombstone. This is required
+     * to ensure that written prepared delete operation must be removed from the data store, when
+     * the prepared transaction gets rollback.
+     */
+    upd->txnid = unpack->tw.start_txn;
+    if (WT_TIME_WINDOW_HAS_START_PREPARE(&(unpack->tw))) {
+        upd->prepared_id = unpack->tw.start_prepared_id;
+        upd->prepare_ts = unpack->tw.start_prepare_ts;
+        upd->upd_durable_ts = WT_TS_NONE;
+        upd->upd_start_ts = unpack->tw.start_prepare_ts;
+        upd->prepare_state = WT_PREPARE_INPROGRESS;
+        F_SET(upd, WT_UPDATE_PREPARE_RESTORED_FROM_DS);
+    } else {
+        upd->upd_durable_ts = unpack->tw.durable_start_ts;
+        upd->upd_start_ts = unpack->tw.start_ts;
+        F_SET(upd, WT_UPDATE_RESTORED_FROM_DS);
+        F_SET(upd, WT_UPDATE_DURABLE);
+    }
+    if (WT_TIME_WINDOW_HAS_STOP_PREPARE(&(unpack->tw))) {
+        /*
+         * Usually we would allocate a tombstone update when seeing a stop timestamp. However in
+         * this code flow, we're restoring the update into ingest table with no tombstone allowed,
+         * create a standard update with a special tombstone value instead of a tombstone.
+         */
+        WT_ERR(__wt_upd_alloc(session, &__wt_tombstone, WT_UPDATE_STANDARD, &tombstone, &size));
+        total_size += size;
+        tombstone->upd_durable_ts = WT_TS_NONE;
+        tombstone->txnid = unpack->tw.stop_txn;
+        tombstone->prepare_state = WT_PREPARE_INPROGRESS;
+        tombstone->upd_start_ts = unpack->tw.stop_prepare_ts;
+        tombstone->prepare_ts = unpack->tw.stop_prepare_ts;
+        tombstone->prepared_id = unpack->tw.stop_prepared_id;
+        tombstone->prepare_state = WT_PREPARE_INPROGRESS;
+        F_SET(tombstone, WT_UPDATE_PREPARE_RESTORED_FROM_DS);
+        F_SET(tombstone, WT_UPDATE_PREPARE_DURABLE);
+        tombstone->next = upd;
+        *updp = tombstone;
+    } else
+        *updp = upd;
+
+    *sizep = total_size;
+    return (0);
+
+err:
+    __wt_free(session, upd);
+    __wt_free(session, tombstone);
+
+    return (ret);
+}
+
+/*
  * __pending_prepare_items_init --
  *     Initialize pending prepared txn hash map.
  */
@@ -196,13 +267,7 @@ __wti_prepared_discover_restore_and_add_artifact_upd(WT_SESSION_IMPL *session,
 
     cbt = (WT_CURSOR_BTREE *)cursor;
     size_t size;
-    /*
-     * Special case - since we're restoring the update into ingest table with no tombstone allowed,
-     * pass tombstone_allowed = false to convert a pending prepared tombstone to a standard update
-     * with tombstone value.
-     */
-    WT_ERR(
-      __wt_page_inmem_update(session, value, unpack, &upd, &size, false /* tombstone_allowed */));
+    WT_ERR(__prepare_discover_alloc_upd(session, value, unpack, &upd, &size));
 
     /* Search the page and apply the modification. */
     WT_WITH_PAGE_INDEX(session, ret = __wt_row_search(cbt, key, true, NULL, false, NULL));

--- a/src/prepared_discover/prepared_discover_txn.c
+++ b/src/prepared_discover/prepared_discover_txn.c
@@ -40,73 +40,49 @@ __wt_prepared_discover_find_item(
 
 /*
  * __prepare_discover_alloc_upd --
- *     Create the actual update for a prepared value.
+ *     Create the actual update for a pending prepared value.
  */
 static int
 __prepare_discover_alloc_upd(WT_SESSION_IMPL *session, WT_ITEM *value, WT_CELL_UNPACK_KV *unpack,
   WT_UPDATE **updp, size_t *sizep)
 {
-    WT_DECL_RET;
-    WT_UPDATE *upd, *tombstone;
+    WT_UPDATE *upd;
     size_t size, total_size;
 
     size = 0;
     *sizep = 0;
-
-    tombstone = upd = NULL;
+    upd = NULL;
     total_size = 0;
-    WT_RET(__wt_upd_alloc(session, value, WT_UPDATE_STANDARD, &upd, &size));
-    total_size += size;
-
-    /*
-     * Instantiate both update and tombstone if the prepared update is a tombstone. This is required
-     * to ensure that written prepared delete operation must be removed from the data store, when
-     * the prepared transaction gets rollback.
-     */
-    upd->txnid = unpack->tw.start_txn;
-    if (WT_TIME_WINDOW_HAS_START_PREPARE(&(unpack->tw))) {
+    if (WT_TIME_WINDOW_HAS_STOP_PREPARE(&(unpack->tw))) {
+        /*
+         * Usually we would allocate a tombstone update when seeing a stop timestamp. However in
+         * this code flow, we're restoring the update into ingest table with no tombstone allowed,
+         * create a standard update with a special tombstone value instead of a tombstone. In the
+         * case where the update has both start and stop prepared, no need to restore the start
+         * prepared.
+         */
+        WT_RET(__wt_upd_alloc(session, &__wt_tombstone, WT_UPDATE_STANDARD, &upd, &size));
+        upd->txnid = unpack->tw.stop_txn;
+        upd->prepared_id = unpack->tw.stop_prepared_id;
+        upd->prepare_ts = unpack->tw.stop_prepare_ts;
+        upd->upd_durable_ts = WT_TS_NONE;
+        upd->upd_start_ts = unpack->tw.stop_prepare_ts;
+        upd->prepare_state = WT_PREPARE_INPROGRESS;
+    } else {
+        WT_ASSERT(session, WT_TIME_WINDOW_HAS_START_PREPARE(&(unpack->tw)));
+        WT_RET(__wt_upd_alloc(session, value, WT_UPDATE_STANDARD, &upd, &size));
+        upd->txnid = unpack->tw.start_txn;
         upd->prepared_id = unpack->tw.start_prepared_id;
         upd->prepare_ts = unpack->tw.start_prepare_ts;
         upd->upd_durable_ts = WT_TS_NONE;
         upd->upd_start_ts = unpack->tw.start_prepare_ts;
         upd->prepare_state = WT_PREPARE_INPROGRESS;
-        F_SET(upd, WT_UPDATE_PREPARE_RESTORED_FROM_DS);
-    } else {
-        upd->upd_durable_ts = unpack->tw.durable_start_ts;
-        upd->upd_start_ts = unpack->tw.start_ts;
-        F_SET(upd, WT_UPDATE_RESTORED_FROM_DS);
-        F_SET(upd, WT_UPDATE_DURABLE);
     }
-    if (WT_TIME_WINDOW_HAS_STOP_PREPARE(&(unpack->tw))) {
-        /*
-         * Usually we would allocate a tombstone update when seeing a stop timestamp. However in
-         * this code flow, we're restoring the update into ingest table with no tombstone allowed,
-         * create a standard update with a special tombstone value instead of a tombstone.
-         */
-        WT_ERR(__wt_upd_alloc(session, &__wt_tombstone, WT_UPDATE_STANDARD, &tombstone, &size));
-        total_size += size;
-        tombstone->upd_durable_ts = WT_TS_NONE;
-        tombstone->txnid = unpack->tw.stop_txn;
-        tombstone->prepare_state = WT_PREPARE_INPROGRESS;
-        tombstone->upd_start_ts = unpack->tw.stop_prepare_ts;
-        tombstone->prepare_ts = unpack->tw.stop_prepare_ts;
-        tombstone->prepared_id = unpack->tw.stop_prepared_id;
-        tombstone->prepare_state = WT_PREPARE_INPROGRESS;
-        F_SET(tombstone, WT_UPDATE_PREPARE_RESTORED_FROM_DS);
-        F_SET(tombstone, WT_UPDATE_PREPARE_DURABLE);
-        tombstone->next = upd;
-        *updp = tombstone;
-    } else
-        *updp = upd;
+    total_size += size;
 
+    *updp = upd;
     *sizep = total_size;
     return (0);
-
-err:
-    __wt_free(session, upd);
-    __wt_free(session, tombstone);
-
-    return (ret);
 }
 
 /*

--- a/src/prepared_discover/prepared_discover_txn.c
+++ b/src/prepared_discover/prepared_discover_txn.c
@@ -196,7 +196,13 @@ __wti_prepared_discover_restore_and_add_artifact_upd(WT_SESSION_IMPL *session,
 
     cbt = (WT_CURSOR_BTREE *)cursor;
     size_t size;
-    WT_ERR(__wt_page_inmem_update(session, value, unpack, &upd, &size, false));
+    /*
+     * Special case - since we're restoring the update into ingest table with no tombstone allowed,
+     * pass tombstone_allowed = false to convert a pending prepared tombstone to a standard update
+     * with tombstone value.
+     */
+    WT_ERR(
+      __wt_page_inmem_update(session, value, unpack, &upd, &size, false /* tombstone_allowed */));
 
     /* Search the page and apply the modification. */
     WT_WITH_PAGE_INDEX(session, ret = __wt_row_search(cbt, key, true, NULL, false, NULL));

--- a/src/prepared_discover/prepared_discover_txn.c
+++ b/src/prepared_discover/prepared_discover_txn.c
@@ -47,9 +47,7 @@ __prepare_discover_alloc_upd(WT_SESSION_IMPL *session, WT_ITEM *value, WT_CELL_U
   WT_UPDATE **updp, size_t *sizep)
 {
     WT_UPDATE *upd;
-    size_t size;
 
-    size = 0;
     *sizep = 0;
     upd = NULL;
     if (WT_TIME_WINDOW_HAS_STOP_PREPARE(&(unpack->tw))) {
@@ -60,7 +58,7 @@ __prepare_discover_alloc_upd(WT_SESSION_IMPL *session, WT_ITEM *value, WT_CELL_U
          * case where the update has both start and stop prepared, no need to restore the start
          * prepared.
          */
-        WT_RET(__wt_upd_alloc(session, &__wt_tombstone, WT_UPDATE_STANDARD, &upd, &size));
+        WT_RET(__wt_upd_alloc(session, &__wt_tombstone, WT_UPDATE_STANDARD, &upd, sizep));
         upd->txnid = unpack->tw.stop_txn;
         upd->prepared_id = unpack->tw.stop_prepared_id;
         upd->prepare_ts = unpack->tw.stop_prepare_ts;
@@ -69,7 +67,7 @@ __prepare_discover_alloc_upd(WT_SESSION_IMPL *session, WT_ITEM *value, WT_CELL_U
         upd->prepare_state = WT_PREPARE_INPROGRESS;
     } else {
         WT_ASSERT(session, WT_TIME_WINDOW_HAS_START_PREPARE(&(unpack->tw)));
-        WT_RET(__wt_upd_alloc(session, value, WT_UPDATE_STANDARD, &upd, &size));
+        WT_RET(__wt_upd_alloc(session, value, WT_UPDATE_STANDARD, &upd, sizep));
         upd->txnid = unpack->tw.start_txn;
         upd->prepared_id = unpack->tw.start_prepared_id;
         upd->prepare_ts = unpack->tw.start_prepare_ts;
@@ -78,7 +76,6 @@ __prepare_discover_alloc_upd(WT_SESSION_IMPL *session, WT_ITEM *value, WT_CELL_U
         upd->prepare_state = WT_PREPARE_INPROGRESS;
     }
     *updp = upd;
-    *sizep = size;
     return (0);
 }
 

--- a/test/suite/test_prepare_discover07.py
+++ b/test/suite/test_prepare_discover07.py
@@ -44,8 +44,7 @@ class test_prepare_discover07(wttest.WiredTigerTestCase):
     uri = 'layered:' + tablename
 
     resolve_scenarios = [
-        # FIXME-WT-16530 handle searching for committed prepared tombstone on standby
-        # ('commit', dict(commit=True)),
+        ('commit', dict(commit=True)),
         ('rollback', dict(commit=False)),
     ]
     # Use disaggregated storage scenarios


### PR DESCRIPTION
In disagg, ingest tables don't use tombstones, but use a special wt_tombstone value instead.
This causes a problem because during step up, we perform prepare discover process and can claim a prepared tombstone value, causes a tombstone to be accidentally committed on the ingest table.

This PR fixes the issue by replacing the tombstone to an update with special tombstone value instead of a real tombstone update structure when finding pending prepared items.