### PR TITLE
WT-16540 If the capacity server thread is not running, we should not broadcast the capacity signal.

### DIFF
--- a/src/conn/conn_capacity.c
+++ b/src/conn/conn_capacity.c
@@ -257,6 +257,9 @@ __capacity_signal(WT_SESSION_IMPL *session)
     WT_CONNECTION_IMPL *conn;
 
     conn = S2C(session);
+    if (!__capacity_server_run_chk(session) || conn->capacity_cond == NULL)
+        return;
+
     cap = &conn->capacity;
     if (cap->written >= cap->threshold && !cap->signalled) {
         __wt_cond_signal(session, conn->capacity_cond);


### PR DESCRIPTION

mongod.log:{"t":{"$date":"2025-05-22T21:03:23.249+08:00"},"s":"I",  "c":"REPL_HB",  "id":23974,   "ctx":"ReplCoord-14","msg":"Heartbeat failed after max retries","attr":{"target":"10.59.158.136:7014","maxHeartbeatRetries":2,"error":{"code":6,"codeName":"HostUnreachable","errmsg":"Error connecting to 10.59.158.136:7014 :: caused by :: onInvoke :: caused by :: Connection refused"}}}
mongod.log:{"t":{"$date":"2025-05-22T21:03:23.941+08:00"},"s":"I",  "c":"CONNPOOL", "id":22576,   "ctx":"ReplNetwork","msg":"Connecting","attr":{"hostAndPort":"10.59.158.136:7014"}}
mongod.log:{"t":{"$date":"2025-05-22T21:03:24.180+08:00"},"s":"I",  "c":"STORAGE",  "id":22376,   "ctx":"conn28229","msg":"Reconfiguring WiredTiger storage engine","attr":{"config":"io_capacity=[total=200M]"}}
mongod.log:{"t":{"$date":"2025-05-22T21:03:24.181+08:00"},"s":"F",  "c":"CONTROL",  "id":6384300, "ctx":"thread28311","msg":"Writing fatal message","attr":{"message":"Invalid access at address: 0x60\n"}}
mongod.log:{"t":{"$date":"2025-05-22T21:03:24.181+08:00"},"s":"F",  "c":"CONTROL",  "id":6384300, "ctx":"thread28311","msg":"Writing fatal message","attr":{"message":"Got signal: 11 (Segmentation fault).\n"}}
mongod.log:{"t":{"$date":"2025-05-22T21:03:24.182+08:00"},"s":"I",  "c":"COMMAND",  "id":23435,   "ctx":"conn28229","msg":"Successfully set parameter to new value","attr":{"parameterName":"wiredTigerEngineRuntimeConfig","newValue":"\"io_capacity=[total=200M]\"","oldValue":"\"io_capacity=[total=2000M]\""}}
mongod.log:{"t":{"$date":"2025-05-22T21:03:24.227+08:00"},"s":"I",  "c":"CONTROL",  "id":31380,   "ctx":"thread28311","msg":"BACKTRACE","attr":{"bt":{"backtrace":[{"a":"555811879DF8","b":"55580B3A3000","o":"64D6DF8","s":"_ZN5mongo15printStackTraceEv","C":"mongo::printStackTrace()","s+":"38"},{"a":"5558118752A6","b":"55580B3A3000","o":"64D22A6","s":"abruptQuitWithAddrSignal","s+":"E6"},{"a":"7FD0C772D630","b":"7FD0C771E000","o":"F630","s":"_L_unlock_13","s+":"34"},{"a":"55580EF3BAD4","b":"55580B3A3000","o":"3B98AD4","s":"__wt_cond_signal","s+":"24"},{"a":"55580EEDF7CA","b":"55580B3A3000","o":"3B3C7CA","s":"__wt_capacity_throttle","s+":"4CA"},{"a":"55580F094F1F","b":"55580B3A3000","o":"3CF1F1F","s":"__wt_block_write_off","s+":"34F"},{"a":"55580EFA830D","b":"55580B3A3000","o":"3C0530D","s":"__wt_blkcache_write","s+":"59D"},{"a":"55580EF44928","b":"55580B3A3000","o":"3BA1928","s":"__wt_ext_unpack_uint","s+":"2318"},{"a":"55580EF452F4","b":"55580B3A3000","o":"3BA22F4","s":"__wt_ext_unpack_uint","s+":"2CE4"},{"a":"55580EF4B033","b":"55580B3A3000","o":"3BA8033","s":"__wt_rec_split","s+":"113"},{"a":"55580F073AF7","b":"55580B3A3000","o":"3CD0AF7","s":"__wt_rec_dictionary_lookup","s+":"3667"},{"a":"55580F07776A","b":"55580B3A3000","o":"3CD476A","s":"__wt_rec_row_leaf","s+":"CA"},{"a":"55580EF48EDB","b":"55580B3A3000","o":"3BA5EDB","s":"__wt_reconcile","s+":"4DB"},{"a":"55580EF13294","b":"55580B3A3000","o":"3B70294","s":"__wt_evict","s+":"784"},{"a":"55580EF0B3D3","b":"55580B3A3000","o":"3B683D3","s":"__wt_evict_thread_chk","s+":"1883"},{"a":"55580EF0BE23","b":"55580B3A3000","o":"3B68E23","s":"__wt_evict_thread_chk","s+":"22D3"},{"a":"55580EF0E34E","b":"55580B3A3000","o":"3B6B34E","s":"__wt_evict_thread_run","s+":"8E"},{"a":"55580EF88319","b":"55580B3A3000","o":"3BE5319","s":"__wt_stat_session_clear_single","s+":"79"},{"a":"7FD0C7725EA5","b":"7FD0C771E000","o":"7EA5","s":"start_thread","s+":"C5"},{"a":"7FD0C744E9FD","b":"7FD0C7350000","o":"FE9FD","s":"clone","s+":"6D"}],"processInfo":{"mongodbVersion":"7.0.12","gitVersion":"5a63266ab797911bbcb06d2687f5890cf1ec79eb-77","compiledModules":[],"uname":{"sysname":"Linux","release":"4.14.105-1-tlinux3-0023.1","version":"#1 SMP Tue Mar 1 15:50:11 CST 2022","machine":"x86_64"},"somap":[{"b":"55580B3A3000","elfType":3,"buildId":"6FB684BFB4FC430F6FE8A9D2C6E3F1202677CA65"},{"b":"7FD0C771E000","path":"/lib64/libpthread.so.0","elfType":3,"buildId":"E10CC8F2B932FC3DAEDA22F8DAC5EBB969524E5B"},{"b":"7FD0C7350000","path":"/lib64/libc.so.6","elfType":3,"buildId":"3604F44EAF58B24C443806EAA831876C1F096F6E"}]}}},"tags":[]}
mongod.log:{"t":{"$date":"2025-05-22T21:03:24.227+08:00"},"s":"I",  "c":"CONTROL",  "id":31445,   "ctx":"thread28311","msg":"Frame","attr":{"frame":{"a":"555811879DF8","b":"55580B3A3000","o":"64D6DF8","s":"_ZN5mongo15printStackTraceEv","C":"mongo::printStackTrace()","s+":"38"}}}
mongod.log:{"t":{"$date":"2025-05-22T21:03:24.227+08:00"},"s":"I",  "c":"CONTROL",  "id":31445,   "ctx":"thread28311","msg":"Frame","attr":{"frame":{"a":"5558118752A6","b":"55580B3A3000","o":"64D22A6","s":"abruptQuitWithAddrSignal","s+":"E6"}}}
mongod.log:{"t":{"$date":"2025-05-22T21:03:24.227+08:00"},"s":"I",  "c":"CONTROL",  "id":31445,   "ctx":"thread28311","msg":"Frame","attr":{"frame":{"a":"7FD0C772D630","b":"7FD0C771E000","o":"F630","s":"_L_unlock_13","s+":"34"}}}
mongod.log:{"t":{"$date":"2025-05-22T21:03:24.227+08:00"},"s":"I",  "c":"CONTROL",  "id":31445,   "ctx":"thread28311","msg":"Frame","attr":{"frame":{"a":"55580EF3BAD4","b":"55580B3A3000","o":"3B98AD4","s":"__wt_cond_signal","s+":"24"}}}
mongod.log:{"t":{"$date":"2025-05-22T21:03:24.227+08:00"},"s":"I",  "c":"CONTROL",  "id":31445,   "ctx":"thread28311","msg":"Frame","attr":{"frame":{"a":"55580EEDF7CA","b":"55580B3A3000","o":"3B3C7CA","s":"__wt_capacity_throttle","s+":"4CA"}}}
mongod.log:{"t":{"$date":"2025-05-22T21:03:24.227+08:00"},"s":"I",  "c":"CONTROL",  "id":31445,   "ctx":"thread28311","msg":"Frame","attr":{"frame":{"a":"55580F094F1F","b":"55580B3A3000","o":"3CF1F1F","s":"__wt_block_write_off","s+":"34F"}}}
mongod.log:{"t":{"$date":"2025-05-22T21:03:24.227+08:00"},"s":"I",  "c":"CONTROL",  "id":31445,   "ctx":"thread28311","msg":"Frame","attr":{"frame":{"a":"55580EFA830D","b":"55580B3A3000","o":"3C0530D","s":"__wt_blkcache_write","s+":"59D"}}}
mongod.log:{"t":{"$date":"2025-05-22T21:03:24.227+08:00"},"s":"I",  "c":"CONTROL",  "id":31445,   "ctx":"thread28311","msg":"Frame","attr":{"frame":{"a":"55580EF44928","b":"55580B3A3000","o":"3BA1928","s":"__wt_ext_unpack_uint","s+":"2318"}}}
mongod.log:{"t":{"$date":"2025-05-22T21:03:24.227+08:00"},"s":"I",  "c":"CONTROL",  "id":31445,   "ctx":"thread28311","msg":"Frame","attr":{"frame":{"a":"55580EF452F4","b":"55580B3A3000","o":"3BA22F4","s":"__wt_ext_unpack_uint","s+":"2CE4"}}}
mongod.log:{"t":{"$date":"2025-05-22T21:03:24.227+08:00"},"s":"I",  "c":"CONTROL",  "id":31445,   "ctx":"thread28311","msg":"Frame","attr":{"frame":{"a":"55580EF4B033","b":"55580B3A3000","o":"3BA8033","s":"__wt_rec_split","s+":"113"}}}
mongod.log:{"t":{"$date":"2025-05-22T21:03:24.227+08:00"},"s":"I",  "c":"CONTROL",  "id":31445,   "ctx":"thread28311","msg":"Frame","attr":{"frame":{"a":"55580F073AF7","b":"55580B3A3000","o":"3CD0AF7","s":"__wt_rec_dictionary_lookup","s+":"3667"}}}
mongod.log:{"t":{"$date":"2025-05-22T21:03:24.227+08:00"},"s":"I",  "c":"CONTROL",  "id":31445,   "ctx":"thread28311","msg":"Frame","attr":{"frame":{"a":"55580F07776A","b":"55580B3A3000","o":"3CD476A","s":"__wt_rec_row_leaf","s+":"CA"}}}
mongod.log:{"t":{"$date":"2025-05-22T21:03:24.227+08:00"},"s":"I",  "c":"CONTROL",  "id":31445,   "ctx":"thread28311","msg":"Frame","attr":{"frame":{"a":"55580EF48EDB","b":"55580B3A3000","o":"3BA5EDB","s":"__wt_reconcile","s+":"4DB"}}}
mongod.log:{"t":{"$date":"2025-05-22T21:03:24.227+08:00"},"s":"I",  "c":"CONTROL",  "id":31445,   "ctx":"thread28311","msg":"Frame","attr":{"frame":{"a":"55580EF13294","b":"55580B3A3000","o":"3B70294","s":"__wt_evict","s+":"784"}}}
mongod.log:{"t":{"$date":"2025-05-22T21:03:24.227+08:00"},"s":"I",  "c":"CONTROL",  "id":31445,   "ctx":"thread28311","msg":"Frame","attr":{"frame":{"a":"55580EF0B3D3","b":"55580B3A3000","o":"3B683D3","s":"__wt_evict_thread_chk","s+":"1883"}}}
mongod.log:{"t":{"$date":"2025-05-22T21:03:24.227+08:00"},"s":"I",  "c":"CONTROL",  "id":31445,   "ctx":"thread28311","msg":"Frame","attr":{"frame":{"a":"55580EF0BE23","b":"55580B3A3000","o":"3B68E23","s":"__wt_evict_thread_chk","s+":"22D3"}}}
mongod.log:{"t":{"$date":"2025-05-22T21:03:24.227+08:00"},"s":"I",  "c":"CONTROL",  "id":31445,   "ctx":"thread28311","msg":"Frame","attr":{"frame":{"a":"55580EF0E34E","b":"55580B3A3000","o":"3B6B34E","s":"__wt_evict_thread_run","s+":"8E"}}}
mongod.log:{"t":{"$date":"2025-05-22T21:03:24.227+08:00"},"s":"I",  "c":"CONTROL",  "id":31445,   "ctx":"thread28311","msg":"Frame","attr":{"frame":{"a":"55580EF88319","b":"55580B3A3000","o":"3BE5319","s":"__wt_stat_session_clear_single","s+":"79"}}}
mongod.log:{"t":{"$date":"2025-05-22T21:03:24.227+08:00"},"s":"I",  "c":"CONTROL",  "id":31445,   "ctx":"thread28311","msg":"Frame","attr":{"frame":{"a":"7FD0C7725EA5","b":"7FD0C771E000","o":"7EA5","s":"start_thread","s+":"C5"}}}
mongod.log:{"t":{"$date":"2025-05-22T21:03:24.227+08:00"},"s":"I",  "c":"CONTROL",  "id":31445,   "ctx":"thread28311","msg":"Frame","attr":{"frame":{"a":"7FD0C744E9FD","b":"7FD0C7350000","o":"FE9FD","s":"clone","s+":"6D"}}}

