### PR TITLE
WT-16502 Re-use the size field in the disagg address cookie to track aggregate size.

### DIFF
--- a/src/block_disagg/block_disagg_read.c
+++ b/src/block_disagg/block_disagg_read.c
@@ -229,6 +229,7 @@ __block_disagg_read_multiple(WT_SESSION_IMPL *session, WT_BLOCK_DISAGG *block_di
                     block_meta->disagg_lsn = get_args.lsn;
                     block_meta->delta_count = (uint8_t)(*results_count - 1);
                     block_meta->checksum = checksum;
+                    block_meta->cumulative_size = size;
                     block_meta->encryption = get_args.encryption;
                     if (block_meta->delta_count > 0)
                         WT_ASSERT(session, get_args.base_lsn > 0);

--- a/src/block_disagg/block_disagg_write.c
+++ b/src/block_disagg/block_disagg_write.c
@@ -254,8 +254,16 @@ __wti_block_disagg_write(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_ITEM *buf
     cookie.flags = __block_disagg_addr_flags(block_meta);
     cookie.lsn = block_meta->disagg_lsn;
     cookie.base_lsn = block_meta->base_lsn;
-    cookie.size = size;
     cookie.checksum = checksum;
+
+    /* Calculate the cumulative size and store it in cookie.size. */
+    if (block_meta->delta_count == 0)
+        cookie.size = size;
+    else
+        cookie.size = block_meta->cumulative_size + size;
+
+    /* Update the block_meta for future delta writes. */
+    block_meta->cumulative_size = cookie.size;
 
     endp = addr;
     WT_RET(__wti_block_disagg_addr_pack(session, &endp, &cookie));

--- a/src/include/block.h
+++ b/src/include/block.h
@@ -557,6 +557,6 @@ struct __wt_block_disagg_address_cookie {
     uint64_t lsn;      /* Log sequence number */
     uint64_t base_lsn; /* Base log sequence number */
 
-    uint32_t size;     /* Size of the data */
+    uint32_t size;     /* Cumulative size (base + deltas) */
     uint32_t checksum; /* Checksum of the data */
 };

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -267,6 +267,9 @@ struct __wt_page_block_meta {
 
     uint32_t checksum;
 
+    /* The cumulative size of the page + delta chain. */
+    uint32_t cumulative_size;
+
     uint8_t delta_count;
 };
 


### PR DESCRIPTION
Reuse the disagg addr cookie size field to track cumulative compressed size (base image + all deltas)