### PR TITLE
WT-16503 Track b-tree size using the aggregrate size on the address cookie.

### DIFF
--- a/src/block_disagg/block_disagg_write.c
+++ b/src/block_disagg/block_disagg_write.c
@@ -213,6 +213,9 @@ __wti_block_disagg_write_internal(WT_SESSION_IMPL *session, WT_BLOCK_DISAGG *blo
     *sizep = WT_STORE_SIZE(buf->size);
     *checksump = checksum;
 
+    /* Update the btree's running total of bytes. */
+    (void)__wt_atomic_add_uint64(&btree->bytes_total, *sizep);
+
     return (0);
 }
 
@@ -291,6 +294,12 @@ __wti_block_disagg_page_discard(
 
     /* Create the discard request. */
     WT_PAGE_LOG_HANDLE *plhandle = block_disagg->plhandle;
+
+    /*
+     * Decrement the btree's running total of compressed bytes. The cookie.size field represents the
+     * cumulative size of the block chain (base + deltas).
+     */
+    (void)__wt_atomic_sub_uint64(&S2BT(session)->bytes_total, cookie.size);
 
     /* Ignore the call if the function is not implemented. */
     if (plhandle->plh_discard == NULL) {

--- a/src/block_disagg/block_disagg_write.c
+++ b/src/block_disagg/block_disagg_write.c
@@ -296,8 +296,8 @@ __wti_block_disagg_page_discard(
     WT_PAGE_LOG_HANDLE *plhandle = block_disagg->plhandle;
 
     /*
-     * Decrement the btree's running total of compressed bytes. The cookie.size field represents the
-     * cumulative size of the block chain (base + deltas).
+     * Decrement the btree's running total of bytes. The cookie.size field represents the cumulative
+     * size of the block chain (base + deltas).
      */
     (void)__wt_atomic_sub_uint64(&S2BT(session)->bytes_total, cookie.size);
 

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -798,6 +798,10 @@ __btree_conf(WT_SESSION_IMPL *session, WT_CKPT *ckpt, bool is_ckpt)
     else
         btree->next_page_id = ckpt->next_page_id;
 
+    /* Load the total bytes for disaggregated storage. */
+    if (__wt_conn_is_disagg(session))
+        btree->bytes_total = ckpt->size;
+
     /*
      * We've just overwritten the runtime write generation based off the fact that know that we're
      * importing and therefore, the checkpoint data's runtime write generation is meaningless. We

--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -140,6 +140,9 @@ struct __wt_btree {
 
     WT_BTREE_CHECKSUM checksum; /* Checksum configuration */
 
+    /* Total size of all blocks in this btree. Tracked for disaggregated storage. */
+    wt_shared uint64_t bytes_total;
+
     /*
      * Reconciliation...
      */

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -1319,20 +1319,30 @@ int
 __wt_meta_ckptlist_set(
   WT_SESSION_IMPL *session, WT_DATA_HANDLE *dhandle, WT_CKPT *ckptbase, const char *ckptlsn_str)
 {
+    WT_BTREE *btree;
     WT_CKPT *ckpt;
     WT_DECL_ITEM(buf);
     WT_DECL_RET;
     const char *fname;
     bool has_lsn;
 
+    btree = S2BT(session);
     fname = dhandle->name;
 
     WT_ERR(__wt_scr_alloc(session, 1024, &buf));
 
-    /* Add B-tree metadata to any added checkpoint. */
-    WT_CKPT_FOREACH (ckptbase, ckpt)
-        if (F_ISSET(ckpt, WT_CKPT_ADD))
-            ckpt->next_page_id = S2BT(session)->next_page_id;
+    /*
+     * Add B-tree metadata to any added checkpoint. Track the previous checkpoint's size as we
+     * iterate so we can compute the delta for disaggregated storage.
+     */
+    WT_CKPT_FOREACH (ckptbase, ckpt) {
+        if (F_ISSET(ckpt, WT_CKPT_ADD)) {
+            ckpt->next_page_id = btree->next_page_id;
+            /* For disaggregated storage, save the current total bytes to ckpt->size. */
+            if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))
+                ckpt->size = __wt_atomic_load_uint64(&btree->bytes_total);
+        }
+    }
 
     WT_ERR(__wt_meta_ckptlist_to_meta(session, ckptbase, buf));
 

--- a/test/suite/test_disagg_checkpoint_size01.py
+++ b/test/suite/test_disagg_checkpoint_size01.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import re, wttest
+from helper_disagg import DisaggConfigMixin, disagg_test_class
+
+# test_disagg_checkpoint_size.py
+#    Test that the checkpoint size field is stored to the metadata for stable tables.
+@disagg_test_class
+class test_disagg_checkpoint_size(wttest.WiredTigerTestCase):
+
+    uri_base = "test_disagg_checkpoint_size"
+    conn_config = 'disaggregated=(role="leader"),disaggregated=(lose_all_my_data=true)'
+    uri = "layered:" + uri_base
+
+    def conn_extensions(self, extlist):
+        extlist.skip_if_missing = True
+        extlist.extension('compressors', 'zstd')
+        DisaggConfigMixin.conn_extensions(self, extlist)  # Load disagg extensions
+
+    # Find all the size values in the checkpoint metadata string. Return the latest.
+    def find_checkpoint_size(self, metadata_value):
+        sizes = re.findall(r',size=(\d+),', metadata_value)
+        assert(len(sizes) > 0)
+        return int(sizes[-1])
+
+    # Insert data without compression and validate that the checkpoint size is greater than the
+    # amount of data inserted.
+    def test_checkpoint_size_populated_non_compressed(self):
+        # Create a layered table.
+        self.session.create(self.uri, 'key_format=S,value_format=S')
+
+        # Insert some data.
+        cursor = self.session.open_cursor(self.uri)
+        nrows = 1000
+        value_size = 100  # Each value is 100 bytes.
+        for i in range(nrows):
+            value = 'x' * value_size
+            cursor[str(i)] = value
+        cursor.close()
+
+        # Take a checkpoint to persist the data.
+        self.session.checkpoint()
+
+        # Open metadata cursor to read the stable btree's metadata.
+        stable_uri = f'file:{self.uri_base}.wt_stable'
+        meta_cursor = self.session.open_cursor('metadata:')
+        meta_cursor.set_key(stable_uri)
+        ret = meta_cursor.search()
+        self.assertEqual(ret, 0, f"Failed to find metadata for {stable_uri}")
+
+        # The last checkpoint should have a size >100000 (nrows * value_size) as compression is not
+        # enabled.
+        size = self.find_checkpoint_size(meta_cursor.get_value())
+        self.assertGreater(size, 100000,
+            f"Checkpoint size should be greater than 100000, got {size}")
+        meta_cursor.close()
+
+    # Insert data with compression enabled and validate that the checkpoint size is smaller than the
+    # above test case's size.
+    def test_checkpoint_size_populated_compressed(self):
+        # Create a layered table.
+        self.session.create(self.uri, 'key_format=S,value_format=S,block_compressor=zstd')
+
+
+        # Insert some data.
+        cursor = self.session.open_cursor(self.uri)
+        nrows = 1000
+        value_size = 100  # Each value is 100 bytes.
+        for i in range(nrows):
+            value = 'x' * value_size
+            cursor[str(i)] = value
+        cursor.close()
+
+        # Take a checkpoint to persist the data.
+        self.session.checkpoint()
+
+        # Open metadata cursor to read the stable btree's metadata.
+        stable_uri = f'file:{self.uri_base}.wt_stable'
+        meta_cursor = self.session.open_cursor('metadata:')
+        meta_cursor.set_key(stable_uri)
+        ret = meta_cursor.search()
+        self.assertEqual(ret, 0, f"Failed to find metadata for {stable_uri}")
+
+        # The last checkpoint should have a size < 100000 (nrows * value_size).
+        size = self.find_checkpoint_size(meta_cursor.get_value())
+        self.assertLess(size, 100000,
+            f"Checkpoint size should be less than 100000, got {size}")
+        meta_cursor.close()
+
+    # Test that checkpoint size increases after adding data and taking another checkpoint.
+    def test_checkpoint_size_increases(self):
+        # Create a layered table.
+        self.session.create(self.uri, 'key_format=S,value_format=S')
+
+        # Insert some initial data.
+        cursor = self.session.open_cursor(self.uri)
+        for i in range(500):
+            cursor[str(i)] = 'x' * 100
+        cursor.close()
+
+        # Take a checkpoint.
+        self.session.checkpoint()
+
+        # Get the checkpoint size after first batch.
+        stable_uri = f'file:{self.uri_base}.wt_stable'
+        meta_cursor = self.session.open_cursor('metadata:')
+        meta_cursor.set_key(stable_uri)
+        ret = meta_cursor.search()
+        self.assertEqual(ret, 0, f"Failed to find metadata for {stable_uri}")
+        first_size = self.find_checkpoint_size(meta_cursor.get_value())
+        meta_cursor.close()
+
+        # Insert more data
+        cursor = self.session.open_cursor(self.uri)
+        for i in range(500, 1500):
+            cursor[str(i)] = 'y' * 100
+        cursor.close()
+
+        # Take another checkpoint.
+        self.session.checkpoint()
+
+        # Get the checkpoint size after second batch.
+        meta_cursor = self.session.open_cursor('metadata:')
+        meta_cursor.set_key(stable_uri)
+        meta_cursor.search()
+        second_size = self.find_checkpoint_size(meta_cursor.get_value())
+
+        # The size should have increased.
+        self.assertGreater(second_size, first_size,
+            f"Checkpoint size should increase: {first_size} -> {second_size}")
+        meta_cursor.close()
+
+    # Test that the checkpoint size is preserved across database restart.
+    def test_checkpoint_size_persists_across_restart(self):
+        # Create a layered table and insert data.
+        self.session.create(self.uri, 'key_format=S,value_format=S')
+
+        cursor = self.session.open_cursor(self.uri)
+        for i in range(1000):
+            cursor[f'key{i:06d}'] = 'x' * 100
+        cursor.close()
+
+        # Take a checkpoint.
+        self.session.checkpoint()
+
+        # Get the checkpoint size before restart.
+        stable_uri = f'file:{self.uri_base}.wt_stable'
+        meta_cursor = self.session.open_cursor('metadata:')
+        meta_cursor.set_key(stable_uri)
+        ret = meta_cursor.search()
+        self.assertEqual(ret, 0, f"Failed to find metadata for {stable_uri}")
+        size_before = self.find_checkpoint_size(meta_cursor.get_value())
+        meta_cursor.close()
+
+        # Reopen the connection.
+        with self.expectedStdoutPattern("Removing local file"):
+            self.reopen_conn()
+
+        # Get the checkpoint size after restart.
+        meta_cursor = self.session.open_cursor('metadata:')
+        meta_cursor.set_key(stable_uri)
+        ret = meta_cursor.search()
+        self.assertEqual(ret, 0, f"Failed to find metadata for {stable_uri}")
+        size_after = self.find_checkpoint_size(meta_cursor.get_value())
+        meta_cursor.close()
+
+        # The sizes should match.
+        self.assertEqual(size_before, size_after,
+            f"Checkpoint size should persist: before={size_before}, after={size_after}")


### PR DESCRIPTION
Track btree size for disagg and store in checkpoint metadata.

- Add `bytes_total` to `__wt_btree` to maintain a running total of block bytes
- Increment on block write, decrement on block discard
- Save total bytes to `ckpt->size` at checkpoint
- Restore the value at open btree