### PR TITLE
WT-16546 Enable layered table drop on python tests

### DIFF
--- a/test/suite/hook_disagg.py
+++ b/test/suite/hook_disagg.py
@@ -320,8 +320,6 @@ def session_open_cursor_replace(orig_session_open_cursor, session_self, uri, dup
 
 # Called to replace Session.salvage
 def session_salvage_replace(orig_session_salvage, session_self, uri, config):
-    # uri = replace_uri(uri)
-    # return orig_session_salvage(session_self, uri, config)
     skip_test("salvage on disagg tables not yet implemented")
 
 # Called to replace Session.truncate.

--- a/test/suite/hook_disagg.py
+++ b/test/suite/hook_disagg.py
@@ -298,9 +298,9 @@ def session_create_replace(orig_session_create, session_self, uri, config):
 
 # Called to replace Session.drop
 def session_drop_replace(orig_session_drop, session_self, uri, config):
-    # uri = replace_uri(uri)
-    # return orig_session_drop(session_self, uri, config)
-    skip_test("drop on disagg tables not yet implemented")
+    if uri.startswith("table:"):
+        uri = replace_uri(uri)
+    return orig_session_drop(session_self, uri, config)
 
 # Called to replace Session.open_cursor.  We skip calls that do backup
 # as that is not yet supported in disaggregated storage.
@@ -320,8 +320,9 @@ def session_open_cursor_replace(orig_session_open_cursor, session_self, uri, dup
 
 # Called to replace Session.salvage
 def session_salvage_replace(orig_session_salvage, session_self, uri, config):
-    uri = replace_uri(uri)
-    return orig_session_salvage(session_self, uri, config)
+    # uri = replace_uri(uri)
+    # return orig_session_salvage(session_self, uri, config)
+    skip_test("salvage on disagg tables not yet implemented")
 
 # Called to replace Session.truncate.
 def session_truncate_replace(orig_session_truncate, session_self, uri, start, stop, config):

--- a/test/suite/hook_disagg.py
+++ b/test/suite/hook_disagg.py
@@ -320,6 +320,7 @@ def session_open_cursor_replace(orig_session_open_cursor, session_self, uri, dup
 
 # Called to replace Session.salvage
 def session_salvage_replace(orig_session_salvage, session_self, uri, config):
+    # FIXME-WT-14740: Re-enable salvage once implemented.
     skip_test("salvage on disagg tables not yet implemented")
 
 # Called to replace Session.truncate.

--- a/test/suite/test_metadata_cursor02.py
+++ b/test/suite/test_metadata_cursor02.py
@@ -35,7 +35,7 @@ from wtscenario import make_scenarios
 # Test metadata cursor semantics when the underlying metadata is invalid.
 # This can happen after a crash, or if part of a table is dropped separate
 # from dropping the whole table.
-@wttest.skip_for_hook("disagg", "Test is specific to non-disaggregated storage function")
+@wttest.skip_for_hook("disagg", "Test is specific to non-disaggregated storage")
 @wttest.skip_for_hook("tiered", "Fails with tiered storage")
 class test_metadata_cursor02(wttest.WiredTigerTestCase):
     """

--- a/test/suite/test_metadata_cursor02.py
+++ b/test/suite/test_metadata_cursor02.py
@@ -35,6 +35,7 @@ from wtscenario import make_scenarios
 # Test metadata cursor semantics when the underlying metadata is invalid.
 # This can happen after a crash, or if part of a table is dropped separate
 # from dropping the whole table.
+@wttest.skip_for_hook("disagg", "Test is specific to non-disaggregated storage function")
 @wttest.skip_for_hook("tiered", "Fails with tiered storage")
 class test_metadata_cursor02(wttest.WiredTigerTestCase):
     """

--- a/test/suite/test_metadata_cursor02.py
+++ b/test/suite/test_metadata_cursor02.py
@@ -35,7 +35,7 @@ from wtscenario import make_scenarios
 # Test metadata cursor semantics when the underlying metadata is invalid.
 # This can happen after a crash, or if part of a table is dropped separate
 # from dropping the whole table.
-@wttest.skip_for_hook("disagg", "Test is specific to non-disaggregated storage")
+@wttest.skip_for_hook("disagg", "Test is specific to attached storage")
 @wttest.skip_for_hook("tiered", "Fails with tiered storage")
 class test_metadata_cursor02(wttest.WiredTigerTestCase):
     """

--- a/test/suite/test_sweep03.py
+++ b/test/suite/test_sweep03.py
@@ -138,7 +138,12 @@ class test_sweep03(wttest.WiredTigerTestCase, suite_subprocess):
         stat_cursor.close()
 
         # Ensure that the handle has been closed after the drop.
-        self.assertEqual(close2, 1)
+        if self.runningHook('disagg') and self.tabletype == 'row':
+            # In disaggregated mode, both the stable and ingest files are dropped,
+            # so two handles are closed.
+            self.assertEqual(close2, 2)
+        else:
+            self.assertEqual(close2, 1)
         # Ensure that any space was reclaimed from cache.
         self.assertLess(cache2, cache1)
 


### PR DESCRIPTION
The ticket aims to enable table drop on hook disagg testing. There are two relevant tests that caused failures:
- test_metadata_cursor02.py: The file tests what would happen if we have dangling metadata entries. It makes lots assumptions on how normal tables are created. Therefore I skipped it here, as it's not relevant.
- test_sweep03.py: Fixed the test to accommodate for 2 file handles being swept due to disagg.
- Disabled salvage as it is not supported right now.