### PR TITLE
WT-15984 Add version numbers to "checkpoint_meta"

### DIFF
--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -3272,7 +3272,6 @@ int
 __ut_disagg_validate_checkpoint_meta_version(WT_SESSION_IMPL *session, const char *meta_str,
   uint32_t *out_version, uint32_t *out_compatible_version)
 {
-    WT_DECL_RET;
     WT_DISAGG_CHECKPOINT_META ckpt_meta;
 
     /* Set default test value */
@@ -3283,13 +3282,13 @@ __ut_disagg_validate_checkpoint_meta_version(WT_SESSION_IMPL *session, const cha
     memset(&ckpt_meta, 0, sizeof(ckpt_meta));
 
     /* Call the main version check function */
-    WT_TRET(__disagg_check_meta_version(session, meta_str, &ckpt_meta));
+    WT_RET(__disagg_check_meta_version(session, meta_str, &ckpt_meta));
 
     /* Return parsed values */
     *out_version = ckpt_meta.version;
     *out_compatible_version = ckpt_meta.compatible_version;
 
-    return (ret);
+    return (0);
 }
 
 void

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -1400,7 +1400,7 @@ __disagg_check_meta_version(
           ckpt_meta->compatible_version, WT_DISAGG_CHECKPOINT_META_VERSION);
 
     if (ckpt_meta->version < ckpt_meta->compatible_version)
-        WT_ERR_MSG(session, ENOTSUP,
+        WT_ERR_MSG(session, EINVAL,
           "Illegal version: Checkpoint meta version=%" PRIu32
           " is older than compatible_version=%" PRIu32,
           ckpt_meta->version, ckpt_meta->compatible_version);

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -23,9 +23,6 @@ typedef struct __wt_disagg_checkpoint_meta {
       compatible_version; /* The minimum version of the reader that can use this checkpoint_meta. */
 } WT_DISAGG_CHECKPOINT_META;
 
-/* Current version for checkpoint_meta. */
-#define WT_DISAGG_CHECKPOINT_META_VERSION 1
-#define WT_DISAGG_CHECKPOINT_META_COMPATIBLE_VERSION 1
 /* Function prototypes for disaggregated storage and layered tables. */
 static void __disagg_set_crypt_header(WT_SESSION_IMPL *session, WT_CRYPT_KEYS *crypt);
 static void __disagg_get_crypt_header(WT_ITEM *key_item, WT_CRYPT_HEADER **header);
@@ -1362,6 +1359,51 @@ err:
 }
 
 /*
+ * __disagg_check_meta_version --
+ *     Parse and validate version and compatible_version fields from checkpoint metadata config.
+ *     Populates the version and compatible_version fields in ckpt_meta struct.
+ */
+static int
+__disagg_check_meta_version(
+  WT_SESSION_IMPL *session, const char *meta_str, WT_DISAGG_CHECKPOINT_META *ckpt_meta)
+{
+    WT_CONFIG_ITEM cval;
+    WT_DECL_RET;
+
+    /* Initialize to defaults for backward compatibility (missing version fields). */
+    ckpt_meta->version = WT_DISAGG_CHECKPOINT_META_VERSION;
+    ckpt_meta->compatible_version = WT_DISAGG_CHECKPOINT_META_COMPATIBLE_VERSION;
+
+    WT_ERR_NOTFOUND_OK(__wt_config_getones(session, meta_str, "version", &cval), true);
+    if (ret == 0 && cval.len != 0) {
+        if (cval.val > UINT32_MAX)
+            WT_ERR_MSG(
+              session, EINVAL, "Invalid checkpoint_meta version: %" PRIu64, (uint64_t)cval.val);
+        ckpt_meta->version = (uint32_t)cval.val;
+    }
+
+    WT_ERR_NOTFOUND_OK(__wt_config_getones(session, meta_str, "compatible_version", &cval), true);
+    if (ret == 0 && cval.len != 0) {
+        if (cval.val > UINT32_MAX)
+            WT_ERR_MSG(session, EINVAL, "Invalid checkpoint_meta compatible_version: %" PRIu64,
+              (uint64_t)cval.val);
+        ckpt_meta->compatible_version = (uint32_t)cval.val;
+    }
+
+    /* Clear error status (WT_NOTFOUND is ok for optional fields, means use default). */
+    ret = 0;
+
+    /* Check if this checkpoint metadata is compatible with the current reader version. */
+    if (ckpt_meta->compatible_version > WT_DISAGG_CHECKPOINT_META_VERSION)
+        WT_ERR_MSG(session, ENOTSUP,
+          "Checkpoint meta compatible_version=%" PRIu32 " requires reader version >= %" PRIu32,
+          ckpt_meta->compatible_version, ckpt_meta->compatible_version);
+
+err:
+    return (ret);
+}
+
+/*
  * __disagg_pick_up_checkpoint_meta --
  *     Pick up a new checkpoint from metadata config.
  */
@@ -1376,9 +1418,6 @@ __disagg_pick_up_checkpoint_meta(
     char *meta_str;
 
     WT_CLEAR(ckpt_meta);
-    /* Initialize version fields to current defaults. */
-    ckpt_meta.version = WT_DISAGG_CHECKPOINT_META_VERSION;
-    ckpt_meta.compatible_version = WT_DISAGG_CHECKPOINT_META_COMPATIBLE_VERSION;
     meta_str = NULL;
 
     /* Extract the item into a string. */
@@ -1405,31 +1444,8 @@ __disagg_pick_up_checkpoint_meta(
         __wt_verbose_warning(session, WT_VERB_DISAGGREGATED_STORAGE, "%s\"%s\"",
           "Missing metadata_checksum from metadata: ", meta_str);
 
-    /*
-     * Parse optional version and compatible_version fields. If they're missing, keep the defaults
-     * initialized above.
-     */
-    WT_ERR_NOTFOUND_OK(__wt_config_getones(session, meta_str, "version", &cval), true);
-    if (ret == 0 && cval.len != 0) {
-        if (cval.val > UINT32_MAX)
-            WT_ERR_MSG(
-              session, EINVAL, "Invalid checkpoint_meta version: %" PRIu64, (uint64_t)cval.val);
-        ckpt_meta.version = (uint32_t)cval.val;
-    }
-
-    WT_ERR_NOTFOUND_OK(__wt_config_getones(session, meta_str, "compatible_version", &cval), true);
-    if (ret == 0 && cval.len != 0) {
-        if (cval.val > UINT32_MAX)
-            WT_ERR_MSG(session, EINVAL, "Invalid checkpoint_meta compatible_version: %" PRIu64,
-              (uint64_t)cval.val);
-        ckpt_meta.compatible_version = (uint32_t)cval.val;
-    }
-
-    /* Check if this checkpoint metadata is compatible with the current reader version. */
-    if (ckpt_meta.compatible_version > WT_DISAGG_CHECKPOINT_META_VERSION)
-        WT_ERR_MSG(session, ENOTSUP,
-          "Checkpoint meta compatible_version=%" PRIu32 " requires reader version >= %" PRIu32,
-          ckpt_meta.compatible_version, ckpt_meta.compatible_version);
+    /* Parse and validate version and compatible_version fields. */
+    WT_ERR(__disagg_check_meta_version(session, meta_str, &ckpt_meta));
 
     /* Now actually pick up the checkpoint. */
     WT_ERR(__disagg_pick_up_checkpoint(session, &ckpt_meta));
@@ -3244,6 +3260,26 @@ int
 __ut_disagg_validate_crypt(WT_SESSION_IMPL *session, WT_ITEM *key_item, WT_CRYPT_HEADER **header)
 {
     return (__disagg_validate_crypt(session, key_item, header));
+}
+
+int
+__ut_disagg_validate_checkpoint_meta_version(WT_SESSION_IMPL *session, const char *meta_str,
+  uint32_t *out_version, uint32_t *out_compatible_version)
+{
+    WT_DISAGG_CHECKPOINT_META ckpt_meta;
+    int ret;
+
+    /* Initialize struct with defaults */
+    memset(&ckpt_meta, 0, sizeof(ckpt_meta));
+
+    /* Call the main version check function */
+    ret = __disagg_check_meta_version(session, meta_str, &ckpt_meta);
+
+    /* Return parsed values */
+    *out_version = ckpt_meta.version;
+    *out_compatible_version = ckpt_meta.compatible_version;
+
+    return (ret);
 }
 
 void

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -17,8 +17,15 @@ typedef struct __wt_disagg_checkpoint_meta {
 
     bool has_metadata_checksum; /* Whether the metadata page checksum is present. */
     uint32_t metadata_checksum; /* The checksum of the metadata page. */
+
+    uint32_t version; /* The version of the checkpoint_meta. */
+    uint32_t
+      compatible_version; /* The minimum version of the reader that can use this checkpoint_meta. */
 } WT_DISAGG_CHECKPOINT_META;
 
+/* Current version for checkpoint_meta. */
+#define WT_DISAGG_CHECKPOINT_META_VERSION 1
+#define WT_DISAGG_CHECKPOINT_META_COMPATIBLE_VERSION 1
 /* Function prototypes for disaggregated storage and layered tables. */
 static void __disagg_set_crypt_header(WT_SESSION_IMPL *session, WT_CRYPT_KEYS *crypt);
 static void __disagg_get_crypt_header(WT_ITEM *key_item, WT_CRYPT_HEADER **header);
@@ -784,6 +791,13 @@ __disagg_fetch_shared_meta(
 {
     WT_DECL_RET;
 
+    /* Warn if checkpoint metadata requires a newer reader. */
+    if (ckpt_meta->compatible_version > WT_DISAGG_CHECKPOINT_META_VERSION) {
+        __wt_verbose_warning(session, WT_VERB_DISAGGREGATED_STORAGE,
+          "Checkpoint meta compatible_version=%" PRIu32 " > reader version=%d",
+          ckpt_meta->compatible_version, WT_DISAGG_CHECKPOINT_META_VERSION);
+    }
+
     /* Read the checkpoint metadata of the shared metadata table from the special metadata page. */
     WT_ERR_MSG_CHK(session,
       __disagg_get_meta(session, WT_DISAGG_METADATA_MAIN_PAGE_ID, ckpt_meta->metadata_lsn, item),
@@ -1042,6 +1056,13 @@ __disagg_apply_checkpoint_meta(WT_SESSION_IMPL *session, WT_SESSION_IMPL *intern
     layered_ingest_uri = cfg_ret = NULL;
     existing_tables = new_tables = new_ingest = 0;
 
+    /* Warn if checkpoint metadata requires a newer reader. */
+    if (ckpt_meta->compatible_version > WT_DISAGG_CHECKPOINT_META_VERSION) {
+        __wt_verbose_warning(session, WT_VERB_DISAGGREGATED_STORAGE,
+          "Checkpoint meta compatible_version=%" PRIu32 " > reader version=%d",
+          ckpt_meta->compatible_version, WT_DISAGG_CHECKPOINT_META_VERSION);
+    }
+
     /*
      * Throw away any references to the old disaggregated metadata table. This ensures that we are
      * on the most recent checkpoint from now on.
@@ -1206,6 +1227,13 @@ __disagg_update_checkpoint_meta(WT_SESSION_IMPL *session, WT_SESSION_IMPL *inter
     WT_DECL_RET;
     WT_CONNECTION_IMPL *conn = S2C(session);
 
+    /* Warn if checkpoint metadata requires a newer reader. */
+    if (ckpt_meta->compatible_version > WT_DISAGG_CHECKPOINT_META_VERSION) {
+        __wt_verbose_warning(session, WT_VERB_DISAGGREGATED_STORAGE,
+          "Checkpoint meta compatible_version=%" PRIu32 " > reader version=%d",
+          ckpt_meta->compatible_version, WT_DISAGG_CHECKPOINT_META_VERSION);
+    }
+
     /*
      * Update the checkpoint metadata LSN. This doesn't require further synchronization, because the
      * updates are protected by the checkpoint lock.
@@ -1369,6 +1397,9 @@ __disagg_pick_up_checkpoint_meta(
     char *meta_str;
 
     WT_CLEAR(ckpt_meta);
+    /* Initialize version fields to current defaults. */
+    ckpt_meta.version = WT_DISAGG_CHECKPOINT_META_VERSION;
+    ckpt_meta.compatible_version = WT_DISAGG_CHECKPOINT_META_COMPATIBLE_VERSION;
     meta_str = NULL;
 
     /* Extract the item into a string. */
@@ -1394,6 +1425,26 @@ __disagg_pick_up_checkpoint_meta(
         /* FIXME-WT-16000: Make the checksum parameter in "checkpoint_meta" required */
         __wt_verbose_warning(session, WT_VERB_DISAGGREGATED_STORAGE, "%s\"%s\"",
           "Missing metadata_checksum from metadata: ", meta_str);
+
+    /*
+     * Parse optional version and compatible_version fields. If they're missing, keep the defaults
+     * initialized above.
+     */
+    WT_ERR_NOTFOUND_OK(__wt_config_getones(session, meta_str, "version", &cval), true);
+    if (ret == 0 && cval.len != 0) {
+        if (cval.val > UINT32_MAX)
+            WT_ERR_MSG(
+              session, EINVAL, "Invalid checkpoint_meta version: %" PRIu64, (uint64_t)cval.val);
+        ckpt_meta.version = (uint32_t)cval.val;
+    }
+
+    WT_ERR_NOTFOUND_OK(__wt_config_getones(session, meta_str, "compatible_version", &cval), true);
+    if (ret == 0 && cval.len != 0) {
+        if (cval.val > UINT32_MAX)
+            WT_ERR_MSG(session, EINVAL, "Invalid checkpoint_meta compatible_version: %" PRIu64,
+              (uint64_t)cval.val);
+        ckpt_meta.compatible_version = (uint32_t)cval.val;
+    }
 
     /* Now actually pick up the checkpoint. */
     WT_ERR(__disagg_pick_up_checkpoint(session, &ckpt_meta));
@@ -2537,8 +2588,10 @@ __wt_disagg_advance_checkpoint(WT_SESSION_IMPL *session, bool ckpt_success)
          * Important: To keep testing simple, keep the metadata to be a valid configuration string
          * without quotation marks or escape characters.
          */
-        WT_ERR(__wt_buf_fmt(session, meta, "metadata_lsn=%" PRIu64 ",metadata_checksum=%" PRIx32,
-          meta_lsn, meta_checksum));
+        WT_ERR(__wt_buf_fmt(session, meta,
+          "metadata_lsn=%" PRIu64 ",metadata_checksum=%" PRIx32 ",version=%d,compatible_version=%d",
+          meta_lsn, meta_checksum, WT_DISAGG_CHECKPOINT_META_VERSION,
+          WT_DISAGG_CHECKPOINT_META_COMPATIBLE_VERSION));
         WT_ERR(disagg->npage_log->page_log->pl_complete_checkpoint_ext(disagg->npage_log->page_log,
           &session->iface, 0, (uint64_t)checkpoint_timestamp, meta, NULL));
         __wt_atomic_store_uint64_release(

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -1396,8 +1396,14 @@ __disagg_check_meta_version(
     /* Check if this checkpoint metadata is compatible with the current reader version. */
     if (ckpt_meta->compatible_version > WT_DISAGG_CHECKPOINT_META_VERSION)
         WT_ERR_MSG(session, ENOTSUP,
-          "Checkpoint meta compatible_version=%" PRIu32 " requires reader version >= %" PRIu32,
-          ckpt_meta->compatible_version, ckpt_meta->compatible_version);
+          "Checkpoint meta compatible_version=%" PRIu32 " requires reader version >= %d",
+          ckpt_meta->compatible_version, WT_DISAGG_CHECKPOINT_META_VERSION);
+
+    if (ckpt_meta->version < ckpt_meta->compatible_version)
+        WT_ERR_MSG(session, ENOTSUP,
+          "Illegal version: Checkpoint meta version=%" PRIu32
+          " is older than compatible_version=%" PRIu32,
+          ckpt_meta->version, ckpt_meta->compatible_version);
 
 err:
     return (ret);

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -3272,14 +3272,18 @@ int
 __ut_disagg_validate_checkpoint_meta_version(WT_SESSION_IMPL *session, const char *meta_str,
   uint32_t *out_version, uint32_t *out_compatible_version)
 {
+    WT_DECL_RET;
     WT_DISAGG_CHECKPOINT_META ckpt_meta;
-    int ret;
+
+    /* Set default test value */
+    *out_version = 0;
+    *out_compatible_version = 0;
 
     /* Initialize struct with defaults */
     memset(&ckpt_meta, 0, sizeof(ckpt_meta));
 
     /* Call the main version check function */
-    ret = __disagg_check_meta_version(session, meta_str, &ckpt_meta);
+    WT_RET(__disagg_check_meta_version(session, meta_str, &ckpt_meta));
 
     /* Return parsed values */
     *out_version = ckpt_meta.version;

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -1371,8 +1371,8 @@ __disagg_check_meta_version(
     WT_DECL_RET;
 
     /* Initialize to defaults for backward compatibility (missing version fields). */
-    ckpt_meta->version = WT_DISAGG_CHECKPOINT_META_VERSION;
-    ckpt_meta->compatible_version = WT_DISAGG_CHECKPOINT_META_COMPATIBLE_VERSION;
+    ckpt_meta->version = WT_DISAGG_CHECKPOINT_META_VERSION_DEFAULT;
+    ckpt_meta->compatible_version = WT_DISAGG_CHECKPOINT_META_VERSION_DEFAULT;
 
     WT_ERR_NOTFOUND_OK(__wt_config_getones(session, meta_str, "version", &cval), true);
     if (ret == 0 && cval.len != 0) {

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -3283,7 +3283,7 @@ __ut_disagg_validate_checkpoint_meta_version(WT_SESSION_IMPL *session, const cha
     memset(&ckpt_meta, 0, sizeof(ckpt_meta));
 
     /* Call the main version check function */
-    WT_RET(__disagg_check_meta_version(session, meta_str, &ckpt_meta));
+    WT_TRET(__disagg_check_meta_version(session, meta_str, &ckpt_meta));
 
     /* Return parsed values */
     *out_version = ckpt_meta.version;

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -791,13 +791,6 @@ __disagg_fetch_shared_meta(
 {
     WT_DECL_RET;
 
-    /* Warn if checkpoint metadata requires a newer reader. */
-    if (ckpt_meta->compatible_version > WT_DISAGG_CHECKPOINT_META_VERSION) {
-        __wt_verbose_warning(session, WT_VERB_DISAGGREGATED_STORAGE,
-          "Checkpoint meta compatible_version=%" PRIu32 " > reader version=%d",
-          ckpt_meta->compatible_version, WT_DISAGG_CHECKPOINT_META_VERSION);
-    }
-
     /* Read the checkpoint metadata of the shared metadata table from the special metadata page. */
     WT_ERR_MSG_CHK(session,
       __disagg_get_meta(session, WT_DISAGG_METADATA_MAIN_PAGE_ID, ckpt_meta->metadata_lsn, item),
@@ -1056,13 +1049,6 @@ __disagg_apply_checkpoint_meta(WT_SESSION_IMPL *session, WT_SESSION_IMPL *intern
     layered_ingest_uri = cfg_ret = NULL;
     existing_tables = new_tables = new_ingest = 0;
 
-    /* Warn if checkpoint metadata requires a newer reader. */
-    if (ckpt_meta->compatible_version > WT_DISAGG_CHECKPOINT_META_VERSION) {
-        __wt_verbose_warning(session, WT_VERB_DISAGGREGATED_STORAGE,
-          "Checkpoint meta compatible_version=%" PRIu32 " > reader version=%d",
-          ckpt_meta->compatible_version, WT_DISAGG_CHECKPOINT_META_VERSION);
-    }
-
     /*
      * Throw away any references to the old disaggregated metadata table. This ensures that we are
      * on the most recent checkpoint from now on.
@@ -1226,13 +1212,6 @@ __disagg_update_checkpoint_meta(WT_SESSION_IMPL *session, WT_SESSION_IMPL *inter
 {
     WT_DECL_RET;
     WT_CONNECTION_IMPL *conn = S2C(session);
-
-    /* Warn if checkpoint metadata requires a newer reader. */
-    if (ckpt_meta->compatible_version > WT_DISAGG_CHECKPOINT_META_VERSION) {
-        __wt_verbose_warning(session, WT_VERB_DISAGGREGATED_STORAGE,
-          "Checkpoint meta compatible_version=%" PRIu32 " > reader version=%d",
-          ckpt_meta->compatible_version, WT_DISAGG_CHECKPOINT_META_VERSION);
-    }
 
     /*
      * Update the checkpoint metadata LSN. This doesn't require further synchronization, because the
@@ -1445,6 +1424,12 @@ __disagg_pick_up_checkpoint_meta(
               (uint64_t)cval.val);
         ckpt_meta.compatible_version = (uint32_t)cval.val;
     }
+
+    /* Check if this checkpoint metadata is compatible with the current reader version. */
+    if (ckpt_meta.compatible_version > WT_DISAGG_CHECKPOINT_META_VERSION)
+        WT_ERR_MSG(session, ENOTSUP,
+          "Checkpoint meta compatible_version=%" PRIu32 " requires reader version >= %" PRIu32,
+          ckpt_meta.compatible_version, ckpt_meta.compatible_version);
 
     /* Now actually pick up the checkpoint. */
     WT_ERR(__disagg_pick_up_checkpoint(session, &ckpt_meta));

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -149,6 +149,14 @@ struct __wt_layered_table_manager {
 };
 
 /*
+ * Checkpoint metadata version constants:
+ * - VERSION: The version this code writes and the maximum version it can read.
+ * - COMPATIBLE_VERSION: The minimum reader version required to read what this code writes.
+ */
+#define WT_DISAGG_CHECKPOINT_META_VERSION 1
+#define WT_DISAGG_CHECKPOINT_META_COMPATIBLE_VERSION 1
+
+/*
  * WT_DISAGG_UPDATE_METADATA --
  *      Metadata about an object to be updated during the next checkpoint.
  */

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -150,9 +150,11 @@ struct __wt_layered_table_manager {
 
 /*
  * Checkpoint metadata version constants:
+ * - DEFAULT: Version defaulted to for old checkpoints without version fields (backward compatible).
  * - VERSION: The version this code writes and the maximum version it can read.
  * - COMPATIBLE_VERSION: The minimum reader version required to read what this code writes.
  */
+#define WT_DISAGG_CHECKPOINT_META_VERSION_DEFAULT 1
 #define WT_DISAGG_CHECKPOINT_META_VERSION 1
 #define WT_DISAGG_CHECKPOINT_META_COMPATIBLE_VERSION 1
 

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2530,6 +2530,9 @@ extern int __ut_chunkcache_bitmap_alloc(WT_SESSION_IMPL *session, size_t *bit_in
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __ut_ckpt_mod_blkmod_entry(WT_SESSION_IMPL *session, WT_CKPT_BLOCK_MODS *blk_mod,
   wt_off_t offset, wt_off_t len) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __ut_disagg_validate_checkpoint_meta_version(WT_SESSION_IMPL *session,
+  const char *meta_str, uint32_t *out_version, uint32_t *out_compatible_version)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __ut_disagg_validate_crypt(WT_SESSION_IMPL *session, WT_ITEM *key_item,
   WT_CRYPT_HEADER **header) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern void __ut_block_off_srch(WT_EXT **head, wt_off_t off, WT_EXT ***stack, bool skip_off);

--- a/test/catch2/CMakeLists.txt
+++ b/test/catch2/CMakeLists.txt
@@ -43,6 +43,7 @@ else()
         cursors/unit/test_cursor_get_raw_key_value.cpp
         ext/test_key_provider.cpp
         ext/test_key_provider_header.cpp
+        ext/test_checkpoint_meta_version.cpp
         sub_level_error/api/test_sub_level_error_session_get_last_error.cpp
         sub_level_error/api/test_sub_level_error_strerror.cpp
         sub_level_error/unit/test_sub_level_error_api_end.cpp

--- a/test/catch2/ext/test_checkpoint_meta_version.cpp
+++ b/test/catch2/ext/test_checkpoint_meta_version.cpp
@@ -56,8 +56,8 @@ TEST_CASE_METHOD(checkpoint_meta_version_fixture,
           session, meta_str, &version, &compatible_version);
 
         REQUIRE(ret == 0);
-        REQUIRE(version == WT_DISAGG_CHECKPOINT_META_VERSION);
-        REQUIRE(compatible_version == WT_DISAGG_CHECKPOINT_META_COMPATIBLE_VERSION);
+        REQUIRE(version == WT_DISAGG_CHECKPOINT_META_VERSION_DEFAULT);
+        REQUIRE(compatible_version == WT_DISAGG_CHECKPOINT_META_VERSION_DEFAULT);
     }
 
     SECTION("parse with only version field")
@@ -68,7 +68,7 @@ TEST_CASE_METHOD(checkpoint_meta_version_fixture,
           session, meta_str, &version, &compatible_version);
 
         REQUIRE(ret == 0);
-        REQUIRE(compatible_version == WT_DISAGG_CHECKPOINT_META_COMPATIBLE_VERSION);
+        REQUIRE(compatible_version == WT_DISAGG_CHECKPOINT_META_VERSION_DEFAULT);
     }
 
     SECTION("parse with only compatible_version field")
@@ -79,7 +79,7 @@ TEST_CASE_METHOD(checkpoint_meta_version_fixture,
           session, meta_str, &version, &compatible_version);
 
         REQUIRE(ret == 0);
-        REQUIRE(version == WT_DISAGG_CHECKPOINT_META_VERSION);
+        REQUIRE(version == WT_DISAGG_CHECKPOINT_META_VERSION_DEFAULT);
     }
 
     SECTION("forward compatibility error - incompatible version")

--- a/test/catch2/ext/test_checkpoint_meta_version.cpp
+++ b/test/catch2/ext/test_checkpoint_meta_version.cpp
@@ -45,6 +45,8 @@ TEST_CASE_METHOD(checkpoint_meta_version_fixture,
           session, meta_str, &version, &compatible_version);
 
         REQUIRE(ret == 0);
+        REQUIRE(version == 1);
+        REQUIRE(compatible_version == 1);
     }
 
     SECTION("backward compatibility - missing version fields defaults to 1,1")
@@ -86,7 +88,7 @@ TEST_CASE_METHOD(checkpoint_meta_version_fixture,
     {
         /* Version requires reader version 2 but we only have version 1 */
         const char *meta_str =
-          "metadata_lsn=111111,metadata_checksum=0xCAFEBABE,version=1,compatible_version=2";
+          "metadata_lsn=111111,metadata_checksum=0xCAFEBABE,version=2,compatible_version=2";
 
         ret = __ut_disagg_validate_checkpoint_meta_version(
           session, meta_str, &version, &compatible_version);
@@ -119,5 +121,17 @@ TEST_CASE_METHOD(checkpoint_meta_version_fixture,
           session, meta_str, &version, &compatible_version);
 
         REQUIRE(ret == 0);
+    }
+
+    SECTION("compatible_version newer than version is illegal")
+    {
+        /* compatible_version should never be greater than version */
+        const char *meta_str = "version=1,compatible_version=2,metadata_lsn=11111";
+
+        ret = __ut_disagg_validate_checkpoint_meta_version(
+          session, meta_str, &version, &compatible_version);
+
+        /* This is an invalid configuration that should fail */
+        REQUIRE(ret == ENOTSUP);
     }
 }

--- a/test/catch2/ext/test_checkpoint_meta_version.cpp
+++ b/test/catch2/ext/test_checkpoint_meta_version.cpp
@@ -102,20 +102,20 @@ TEST_CASE_METHOD(checkpoint_meta_version_fixture,
     SECTION("compatible_version newer than version is illegal")
     {
         /* compatible_version should never be greater than version */
-        const char *meta_str = "version=1,compatible_version=2,metadata_lsn=11111";
+        const char *meta_str = "version=0,compatible_version=1,metadata_lsn=11111";
 
         ret = __ut_disagg_validate_checkpoint_meta_version(
           session, meta_str, &version, &compatible_version);
 
         /* This is an invalid configuration that should fail */
-        REQUIRE(ret == ENOTSUP);
+        REQUIRE(ret == EINVAL);
     }
 
     SECTION("multiple incompatible versions all fail")
     {
         const char *incompatible_configs[] = {
           "version=3,compatible_version=3",
-          "version=2,compatible_version=3",
+          "version=6,compatible_version=3",
           "version=5,compatible_version=10",
         };
 

--- a/test/catch2/ext/test_checkpoint_meta_version.cpp
+++ b/test/catch2/ext/test_checkpoint_meta_version.cpp
@@ -1,0 +1,123 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+#include <catch2/catch.hpp>
+#include <cstdint>
+#include <memory>
+
+#include "wt_internal.h"
+
+#include "wrappers/mock_session.h"
+#include "utils.h"
+
+/*
+ * checkpoint_meta_version_fixture
+ *     Test fixture for checkpoint metadata version tests.
+ */
+struct checkpoint_meta_version_fixture {
+    std::shared_ptr<mock_session> session_wrapper;
+    WT_SESSION_IMPL *session = nullptr;
+
+    checkpoint_meta_version_fixture() : session_wrapper(mock_session::build_test_mock_session())
+    {
+        session = session_wrapper->get_wt_session_impl();
+        REQUIRE(session != nullptr);
+    }
+};
+
+TEST_CASE_METHOD(checkpoint_meta_version_fixture,
+  "checkpoint_meta_version: version number validation", "[checkpoint_meta_version]")
+{
+    uint32_t version, compatible_version;
+    int ret;
+
+    SECTION("parse version 1, compatible_version 1")
+    {
+        const char *meta_str =
+          "metadata_lsn=123456789,metadata_checksum=0xDEADBEEF,version=1,compatible_version=1";
+
+        ret = __ut_disagg_validate_checkpoint_meta_version(
+          session, meta_str, &version, &compatible_version);
+
+        REQUIRE(ret == 0);
+    }
+
+    SECTION("backward compatibility - missing version fields defaults to 1,1")
+    {
+        /* Old-style config string without version fields */
+        const char *meta_str = "metadata_lsn=9999,metadata_checksum=0xABCD";
+
+        ret = __ut_disagg_validate_checkpoint_meta_version(
+          session, meta_str, &version, &compatible_version);
+
+        REQUIRE(ret == 0);
+        REQUIRE(version == WT_DISAGG_CHECKPOINT_META_VERSION);
+        REQUIRE(compatible_version == WT_DISAGG_CHECKPOINT_META_COMPATIBLE_VERSION);
+    }
+
+    SECTION("parse with only version field")
+    {
+        const char *meta_str = "version=1,metadata_lsn=5555";
+
+        ret = __ut_disagg_validate_checkpoint_meta_version(
+          session, meta_str, &version, &compatible_version);
+
+        REQUIRE(ret == 0);
+        REQUIRE(compatible_version == WT_DISAGG_CHECKPOINT_META_COMPATIBLE_VERSION);
+    }
+
+    SECTION("parse with only compatible_version field")
+    {
+        const char *meta_str = "compatible_version=1,metadata_lsn=7777";
+
+        ret = __ut_disagg_validate_checkpoint_meta_version(
+          session, meta_str, &version, &compatible_version);
+
+        REQUIRE(ret == 0);
+        REQUIRE(version == WT_DISAGG_CHECKPOINT_META_VERSION);
+    }
+
+    SECTION("forward compatibility error - incompatible version")
+    {
+        /* Version requires reader version 2 but we only have version 1 */
+        const char *meta_str =
+          "metadata_lsn=111111,metadata_checksum=0xCAFEBABE,version=1,compatible_version=2";
+
+        ret = __ut_disagg_validate_checkpoint_meta_version(
+          session, meta_str, &version, &compatible_version);
+
+        /* Should fail with ENOTSUP - reader version is too old */
+        REQUIRE(ret == ENOTSUP);
+    }
+
+    SECTION("multiple incompatible versions all fail")
+    {
+        const char *incompatible_configs[] = {
+          "version=1,compatible_version=2",
+          "version=2,compatible_version=3",
+          "version=5,compatible_version=10",
+        };
+
+        for (size_t i = 0; i < sizeof(incompatible_configs) / sizeof(incompatible_configs[0]);
+             ++i) {
+            ret = __ut_disagg_validate_checkpoint_meta_version(
+              session, incompatible_configs[i], &version, &compatible_version);
+            REQUIRE(ret == ENOTSUP);
+        }
+    }
+
+    SECTION("compatible version equal to reader version is ok")
+    {
+        const char *meta_str = "version=1,compatible_version=1,metadata_lsn=55555";
+
+        ret = __ut_disagg_validate_checkpoint_meta_version(
+          session, meta_str, &version, &compatible_version);
+
+        REQUIRE(ret == 0);
+    }
+}

--- a/test/catch2/ext/test_checkpoint_meta_version.cpp
+++ b/test/catch2/ext/test_checkpoint_meta_version.cpp
@@ -70,6 +70,7 @@ TEST_CASE_METHOD(checkpoint_meta_version_fixture,
           session, meta_str, &version, &compatible_version);
 
         REQUIRE(ret == 0);
+        REQUIRE(version == 1);
         REQUIRE(compatible_version == WT_DISAGG_CHECKPOINT_META_VERSION_DEFAULT);
     }
 
@@ -82,6 +83,7 @@ TEST_CASE_METHOD(checkpoint_meta_version_fixture,
 
         REQUIRE(ret == 0);
         REQUIRE(version == WT_DISAGG_CHECKPOINT_META_VERSION_DEFAULT);
+        REQUIRE(compatible_version == 1);
     }
 
     SECTION("forward compatibility error - incompatible version")
@@ -97,32 +99,6 @@ TEST_CASE_METHOD(checkpoint_meta_version_fixture,
         REQUIRE(ret == ENOTSUP);
     }
 
-    SECTION("multiple incompatible versions all fail")
-    {
-        const char *incompatible_configs[] = {
-          "version=1,compatible_version=2",
-          "version=2,compatible_version=3",
-          "version=5,compatible_version=10",
-        };
-
-        for (size_t i = 0; i < sizeof(incompatible_configs) / sizeof(incompatible_configs[0]);
-             ++i) {
-            ret = __ut_disagg_validate_checkpoint_meta_version(
-              session, incompatible_configs[i], &version, &compatible_version);
-            REQUIRE(ret == ENOTSUP);
-        }
-    }
-
-    SECTION("compatible version equal to reader version is ok")
-    {
-        const char *meta_str = "version=1,compatible_version=1,metadata_lsn=55555";
-
-        ret = __ut_disagg_validate_checkpoint_meta_version(
-          session, meta_str, &version, &compatible_version);
-
-        REQUIRE(ret == 0);
-    }
-
     SECTION("compatible_version newer than version is illegal")
     {
         /* compatible_version should never be greater than version */
@@ -133,5 +109,21 @@ TEST_CASE_METHOD(checkpoint_meta_version_fixture,
 
         /* This is an invalid configuration that should fail */
         REQUIRE(ret == ENOTSUP);
+    }
+
+    SECTION("multiple incompatible versions all fail")
+    {
+        const char *incompatible_configs[] = {
+          "version=3,compatible_version=3",
+          "version=2,compatible_version=3",
+          "version=5,compatible_version=10",
+        };
+
+        for (size_t i = 0; i < sizeof(incompatible_configs) / sizeof(incompatible_configs[0]);
+             ++i) {
+            ret = __ut_disagg_validate_checkpoint_meta_version(
+              session, incompatible_configs[i], &version, &compatible_version);
+            REQUIRE(ret == ENOTSUP);
+        }
     }
 }


### PR DESCRIPTION
This PR adds a version and a compatibility version to the checkpoint_meta struct.

A new function, __disagg_check_meta_version, validates compatibility by reading both the version and compatibility version from checkpoint_meta. If these fields are not available (e.g. when reading older metadata), they default to 1 to preserve backwards compatibility.

Compatibility is then checked by comparing the compatibility version stored in checkpoint_meta with the current compatibility version supported by WiredTiger.