### PR TITLE
WT-16111 Remove format-stress-test-no-barrier evergreen task and delete NON_BARRIER_DIAGNOSTIC_YIELDS flag

### DIFF
--- a/cmake/configs/base.cmake
+++ b/cmake/configs/base.cmake
@@ -122,12 +122,6 @@ config_bool(
 )
 
 config_bool(
-    NON_BARRIER_DIAGNOSTIC_YIELDS
-    "Don't set a full barrier when yielding threads in diagnostic mode. Requires diagnostic mode to be enabled."
-    DEFAULT OFF
-)
-
-config_bool(
     HAVE_UNITTEST
     "Enable C++ Catch2 based WiredTiger unit tests"
     DEFAULT OFF
@@ -508,10 +502,6 @@ endif()
 # Error logging is always enabled in diagnostic build.
 if (HAVE_DIAGNOSTIC AND NOT HAVE_ERROR_LOG)
     set(HAVE_ERROR_LOG ON CACHE BOOL "" FORCE)
-endif()
-
-if (NON_BARRIER_DIAGNOSTIC_YIELDS AND NOT HAVE_DIAGNOSTIC)
-    message(FATAL_ERROR "`NON_BARRIER_DIAGNOSTIC_YIELDS` can only be enabled when `HAVE_DIAGNOSTIC` is enabled.")
 endif()
 
 if (HAVE_UNITTEST_ASSERTS AND NOT HAVE_UNITTEST)

--- a/cmake/configs/wiredtiger_config.h.in
+++ b/cmake/configs/wiredtiger_config.h.in
@@ -45,9 +45,6 @@
 /* Define to 1 for ref tracking */
 #cmakedefine HAVE_REF_TRACK 1
 
-/* Define to 1 to remove full memory barriers on diagnostic yields. */
-#cmakedefine NON_BARRIER_DIAGNOSTIC_YIELDS 0
-
 /* Define to 1 for unit tests. */
 #cmakedefine HAVE_UNITTEST 0
 

--- a/src/docs/build-posix.dox
+++ b/src/docs/build-posix.dox
@@ -109,11 +109,6 @@ Configure WiredTiger to sleep and wait for a debugger to attach on failure.
 Configure WiredTiger to perform various run-time diagnostic tests (enabled by default for non Release build types).
 <b>DO NOT</b> configure this option in production environments.
 
-@par \c -DNON_BARRIER_DIAGNOSTIC_YIELDS=1
-Configure WiredTiger to not use memory barriers when yielding threads for diagnostic purposes.
-Requires that HAVE_DIAGNOSTIC is also enabled.
-<b>DO NOT</b> configure this option in production environments.
-
 @par \c -DENABLE_LZ4=1
 Configure WiredTiger for <a href="https://github.com/Cyan4973/lz4">LZ4</a>
 compression (enabled by default if the LZ4 library is present); see @ref compression for more information.

--- a/src/docs/build-windows.dox
+++ b/src/docs/build-windows.dox
@@ -97,11 +97,6 @@ Configure WiredTiger to sleep and wait for a debugger to attach on failure.
 Configure WiredTiger to perform various run-time diagnostic tests (enabled by default for non Release build types).
 <b>DO NOT</b> configure this option in production environments.
 
-@par \c -DNON_BARRIER_DIAGNOSTIC_YIELDS=1
-Configure WiredTiger to not use memory barriers when yielding threads for diagnostic purposes.
-Requires that HAVE_DIAGNOSTIC is also enabled.
-<b>DO NOT</b> configure this option in production environments.
-
 @par \c -DENABLE_LZ4=1
 Configure WiredTiger for <a href="https://github.com/Cyan4973/lz4">LZ4</a>
 compression (enabled by default if the LZ4 library is present); see @ref compression for more information.

--- a/src/include/error.h
+++ b/src/include/error.h
@@ -15,13 +15,7 @@
 
 /* In DIAGNOSTIC mode, yield in places where we want to encourage races (except for with
  * antithesis). */
-#if defined HAVE_DIAGNOSTIC && defined NON_BARRIER_DIAGNOSTIC_YIELDS && !defined ENABLE_ANTITHESIS
-#define WT_DIAGNOSTIC_YIELD      \
-    do {                         \
-        __wt_yield_no_barrier(); \
-    } while (0)
-#elif defined HAVE_DIAGNOSTIC && !defined NON_BARRIER_DIAGNOSTIC_YIELDS && \
-  !defined ENABLE_ANTITHESIS
+#if defined HAVE_DIAGNOSTIC && !defined ENABLE_ANTITHESIS
 #define WT_DIAGNOSTIC_YIELD \
     do {                    \
         __wt_yield();       \

--- a/src/include/extern_posix.h
+++ b/src/include/extern_posix.h
@@ -65,7 +65,6 @@ extern void __wt_stream_set_line_buffer(FILE *fp)
 extern void __wt_stream_set_no_buffer(FILE *fp) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")));
 extern void __wt_thread_id(uintmax_t *id) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")));
 extern void __wt_yield(void) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")));
-extern void __wt_yield_no_barrier(void) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")));
 extern void __wti_posix_prepare_remap_resize_file(
   WT_FILE_HANDLE *file_handle, WT_SESSION *wt_session, wt_off_t len, bool *remap);
 extern void __wti_posix_release_without_remap(WT_FILE_HANDLE *file_handle);

--- a/src/include/extern_win.h
+++ b/src/include/extern_win.h
@@ -66,7 +66,6 @@ extern void __wt_stream_set_line_buffer(FILE *fp);
 extern void __wt_stream_set_no_buffer(FILE *fp);
 extern void __wt_thread_id(uintmax_t *id);
 extern void __wt_yield(void);
-extern void __wt_yield_no_barrier(void) WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")));
 
 #ifdef HAVE_UNITTEST
 

--- a/src/os_posix/os_yield.c
+++ b/src/os_posix/os_yield.c
@@ -24,29 +24,3 @@ __wt_yield(void) WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
 
     sched_yield();
 }
-
-/*
- * If HAVE_DIAGNOSTIC is 0 clang will raise an error when the noreturn attribute is missing, and if
- * HAVE_DIAGNOSTIC is 1 clang will raise an error when the noreturn attribute is present. This
- * function should never be called when HAVE_DIAGNOSTIC is 0 so we can ignore the missing-noreturn
- * warning here.
- */
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmissing-noreturn"
-/*
- * __wt_yield_no_barrier --
- *     Yield the thread of control. Don't set any memory barriers as this may hide memory
- *     synchronization errors in the surrounding code. It's not explicitly documented that yielding
- *     without a memory barrier is safe, so this function should only be used for testing in
- *     diagnostic mode.
- */
-void
-__wt_yield_no_barrier(void) WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
-{
-#ifndef HAVE_DIAGNOSTIC
-    __wt_abort(NULL);
-#else
-    sched_yield();
-#endif
-}
-#pragma GCC diagnostic pop

--- a/src/os_win/os_yield.c
+++ b/src/os_win/os_yield.c
@@ -24,20 +24,3 @@ __wt_yield(void)
 
     SwitchToThread();
 }
-
-/*
- * __wt_yield_no_barrier --
- *     Yield the thread of control. Don't set any memory barriers as this may hide memory
- *     synchronization errors in the surrounding code. It's not explicitly documented that yielding
- *     without a memory barrier is safe, so this function should only be used for testing in
- *     diagnostic mode.
- */
-void
-__wt_yield_no_barrier(void) WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
-{
-#ifndef HAVE_DIAGNOSTIC
-    __wt_abort(NULL);
-#else
-    SwitchToThread();
-#endif
-}

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -292,7 +292,6 @@ functions:
           ${HAVE_BUILTIN_EXTENSION_ZSTD|} \
           ${HAVE_UNITTEST} \
           ${CODE_COVERAGE_FLAGS} \
-          ${NON_BARRIER_DIAGNOSTIC_YIELDS|} \
           ${HAVE_DIAGNOSTIC|} \
           ${WORDS_BIGENDIAN|} \
           ${GNU_C_VERSION|} \
@@ -5120,61 +5119,6 @@ tasks:
           format_args: disagg.mode=leader runs.timer=30:45 cache=10000 cache.eviction_dirty_trigger=50 cache.eviction_updates_trigger=50
           times: 1
 
-  - name: format-stress-test-no-barrier
-    tags: ["stress-test-no-barrier"]
-    exec_timeout_secs: 25200
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
-        vars:
-          <<: *configure_flags_with_builtins
-          NON_BARRIER_DIAGNOSTIC_YIELDS: -DNON_BARRIER_DIAGNOSTIC_YIELDS=1
-      - func: "format test script"
-        vars:
-          format_test_script_args: -e "SEGFAULT_SIGNALS=all" -b "catchsegv ./t" -t 360
-
-  - name: format-stress-asan-test-no-barrier
-    tags: ["stress-test-asan"]
-    exec_timeout_secs: 25200
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
-        vars:
-          <<: *configure_flags_asan_mongodb_stable_clang_with_builtins
-          NON_BARRIER_DIAGNOSTIC_YIELDS: -DNON_BARRIER_DIAGNOSTIC_YIELDS=1
-      - func: "format test script"
-        vars:
-          additional_san_vars: export ASAN_OPTIONS="$COMMON_SAN_OPTIONS:unmap_shadow_on_exit=1"
-          format_test_script_args: -t 360
-
-  - name: race-condition-stress-asan-test-no-barrier
-    tags: ["stress-test-asan"]
-    exec_timeout_secs: 25200
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
-        vars:
-          <<: *configure_flags_asan_mongodb_stable_clang_with_builtins
-          NON_BARRIER_DIAGNOSTIC_YIELDS: -DNON_BARRIER_DIAGNOSTIC_YIELDS=1
-      - func: "format test script"
-        vars:
-          additional_san_vars: export ASAN_OPTIONS="$COMMON_SAN_OPTIONS:unmap_shadow_on_exit=1"
-          format_test_script_args: -R -t 360
-
-  - name: recovery-stress-test-no-barrier
-    tags: ["stress-test-no-barrier"]
-    exec_timeout_secs: 25200
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
-        vars:
-          <<: *configure_flags_with_builtins
-          NON_BARRIER_DIAGNOSTIC_YIELDS: -DNON_BARRIER_DIAGNOSTIC_YIELDS=1
-          CC_OPTIMIZE_LEVEL: -DCC_OPTIMIZE_LEVEL=-O0
-      - func: "recovery stress test script"
-        vars:
-          times: 25
-
   - name: format-abort-recovery-stress-test
     commands:
       # Allow 30 minutes beyond test runtime because recovery under load can cause the test to
@@ -7065,8 +7009,6 @@ buildvariants:
     - name: ".stress-test-4"
     - name: ".stress-test-disagg"
       distros: ubuntu2004-large
-    - name: ".stress-test-no-barrier"
-      distros: ubuntu2004-medium
     - name: format-abort-recovery-stress-test
     - name: format-predictable-test
     - name: schema-abort-predictable-test
@@ -7420,8 +7362,6 @@ buildvariants:
     - name: ".stress-test-4"
     - name: ".stress-test-disagg"
       distros: ubuntu2004-large
-    - name: ".stress-test-no-barrier"
-      distros: ubuntu2004-medium
     - name: format-abort-recovery-stress-test
     - name: ".cppsuite-stress-test"
       batchtime: 720 # 12 hours
@@ -7472,7 +7412,6 @@ buildvariants:
     - name: ".stress-test-2"
     - name: ".stress-test-3"
     - name: ".stress-test-4"
-    - name: ".stress-test-no-barrier"
     - name: ".stress-test-disagg"
     - name: format-stress-disagg-leader-long-running
     - name: format-abort-recovery-stress-test
@@ -7560,7 +7499,6 @@ buildvariants:
     - name: ".stress-test-2"
     - name: ".stress-test-3"
     - name: ".stress-test-4"
-    - name: ".stress-test-no-barrier"
     - name: ".stress-test-disagg"
     - name: format-stress-disagg-leader-long-running
     - name: format-abort-recovery-stress-test
@@ -7660,7 +7598,6 @@ buildvariants:
     - name: ".stress-test-3"
     - name: ".stress-test-4"
     - name: ".stress-test-disagg"
-    - name: ".stress-test-no-barrier"
     - name: format-abort-recovery-stress-test
     - name: format-predictable-test
     - name: schema-abort-predictable-test
@@ -7821,7 +7758,6 @@ buildvariants:
     - name: ".stress-test-3"
     - name: ".stress-test-4"
     - name: ".stress-test-disagg"
-    - name: ".stress-test-no-barrier"
     - name: format-abort-recovery-stress-test
     - name: ".cppsuite-stress-test"
       batchtime: 720 # 12 hours


### PR DESCRIPTION
During review of the format-stress-test-no-barrier task, we confirmed that the NON_BARRIER_DIAGNOSTIC_YIELDS flag and the associated evergreen task are no longer needed. The flag was originally added while chasing [WT-10461](https://jira.mongodb.org/browse/WT-10461), but it has not produced any useful diagnostic failures for a long time.
@ajmorton confirmed that both the flag and the evergreen task can be removed. No replacement disagg variant is required.

I removed all tasks such as `format-stress-test-no-barrier` from `evergreen.yml` that set the `NON_BARRIER_DIAGNOSTIC_YIELDS` flag. I deleted the flag in WiredTiger, along with all mentions of it in code and documentation, including the underlying `__wt_yield_no_barrier` function that isn't otherwise used.