### PR TITLE
WT-16601 Fix dash incompatible Evergreen code

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -83,11 +83,11 @@ functions:
 
             # Set extensions to load
             EXT="extensions=["
-            EXT+="ext/compressors/snappy/libwiredtiger_snappy.so,"
-            EXT+="ext/collators/reverse/libwiredtiger_reverse_collator.so,"
-            EXT+="ext/encryptors/rotn/libwiredtiger_rotn.so,"
-            EXT+="ext/page_log/palite/libwiredtiger_palite.so,"
-            EXT+="]"
+            EXT="$EXT ext/compressors/snappy/libwiredtiger_snappy.so,"
+            EXT="$EXT ext/collators/reverse/libwiredtiger_reverse_collator.so,"
+            EXT="$EXT ext/encryptors/rotn/libwiredtiger_rotn.so,"
+            EXT="$EXT ext/page_log/palite/libwiredtiger_palite.so,"
+            EXT="$EXT ]"
             export EXT
 
             ${additional_env_vars}


### PR DESCRIPTION
The env variable setting code introduced in WT-16466 recently led to testing fallout on an Evergreen task that runs `shell.exec` command with **dash**. The same code runs fine if `shell.exec` commands are configured to run with **bash**. 

The fix is to apply a more portable way of setting environment variables, i.e. `EXT="$EXT /path/to/lib"`.