### PR TITLE
WT-16501 Remove dek from disagg block header

### DIFF
--- a/ext/page_log/palite/palite.cpp
+++ b/ext/page_log/palite/palite.cpp
@@ -1508,6 +1508,7 @@ struct Pages : public Table<Pages> {
              flags INTEGER NOT NULL,
              delta INTEGER AS ((flags & 0x2) != 0) VIRTUAL, -- WT_PAGE_LOG_DELTA
              discarded INTEGER AS ((flags & 0x10000) != 0) VIRTUAL, -- WT_PAGE_LOG_DISCARDED
+             encryption STRING, -- Deprecated, can be NULL
              timestamp_materialized_us INTEGER NOT NULL,
              page_data BLOB,
          PRIMARY KEY (table_id, page_id, lsn));)",

--- a/ext/page_log/palite/palite.cpp
+++ b/ext/page_log/palite/palite.cpp
@@ -1314,7 +1314,6 @@ struct PageInfo {
     uint64_t backlink_lsn;
     uint64_t base_lsn;
     uint32_t flags;
-    WT_PAGE_LOG_ENCRYPTION encryption;
 };
 
 template <> struct std::formatter<PageInfo> {
@@ -1636,11 +1635,9 @@ struct Pages : public Table<Pages> {
               sqlite3_bind_int64, stmt.get(), 4, static_cast<sqlite3_int64>(args->backlink_lsn));
             SQ_CHECK(sqlite3_bind_int64, stmt.get(), 5, static_cast<sqlite3_int64>(args->base_lsn));
             SQ_CHECK(sqlite3_bind_int64, stmt.get(), 6, static_cast<sqlite3_int64>(args->flags));
-            SQ_CHECK(sqlite3_bind_text, stmt.get(), 7, args->encryption.dek,
-              strlen(args->encryption.dek), SQLITE_STATIC);
-            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 8,
+            SQ_CHECK(sqlite3_bind_int64, stmt.get(), 7,
               static_cast<sqlite3_int64>(now_us() + (config.materialization_delay_ms * 1ms / 1us)));
-            SQ_CHECK(sqlite3_bind_blob, stmt.get(), 9, buf->data, buf->size, SQLITE_STATIC);
+            SQ_CHECK(sqlite3_bind_blob, stmt.get(), 8, buf->data, buf->size, SQLITE_STATIC);
             SQ_CHECK(sqlite3_step, stmt.get());
         }
 
@@ -1650,8 +1647,7 @@ struct Pages : public Table<Pages> {
               .lsn = lsn,
               .backlink_lsn = args->backlink_lsn,
               .base_lsn = args->base_lsn,
-              .flags = args->flags,
-              .encryption = args->encryption};
+              .flags = args->flags};
             auto acc_r = request(AccessMode::READ);
             verify_chain(acc_r.conn, start_page);
         }
@@ -1676,11 +1672,7 @@ struct Pages : public Table<Pages> {
               .lsn = static_cast<uint64_t>(sqlite3_column_int64(stmt, 0)),
               .backlink_lsn = static_cast<uint64_t>(sqlite3_column_int64(stmt, 1)),
               .base_lsn = static_cast<uint64_t>(sqlite3_column_int64(stmt, 2)),
-              .flags = static_cast<uint32_t>(sqlite3_column_int64(stmt, 3)),
-              .encryption = WT_PAGE_LOG_ENCRYPTION{}};
-
-            const char *enc = reinterpret_cast<const char *>(sqlite3_column_text(stmt, 4));
-            strncpy(page.encryption.dek, enc ? enc : "", sizeof(page.encryption.dek));
+              .flags = static_cast<uint32_t>(sqlite3_column_int64(stmt, 3))};
 
             return std::move(page);
         };
@@ -1738,7 +1730,6 @@ struct Pages : public Table<Pages> {
             const PageInfo &page = pages.front();
             args->backlink_lsn = page.backlink_lsn;
             args->base_lsn = page.base_lsn;
-            args->encryption = page.encryption;
             assert(flags != nullptr);
             *flags = page.flags;
         }
@@ -1930,8 +1921,7 @@ private:
                 .lsn = static_cast<uint64_t>(sqlite3_column_int64(stmt.get(), 2)),
                 .backlink_lsn = static_cast<uint64_t>(sqlite3_column_int64(stmt.get(), 3)),
                 .base_lsn = static_cast<uint64_t>(sqlite3_column_int64(stmt.get(), 4)),
-                .flags = static_cast<uint32_t>(sqlite3_column_int64(stmt.get(), 5)),
-                .encryption = WT_PAGE_LOG_ENCRYPTION{}});
+                .flags = static_cast<uint32_t>(sqlite3_column_int64(stmt.get(), 5))});
         }
     }
 

--- a/ext/page_log/palite/palite.cpp
+++ b/ext/page_log/palite/palite.cpp
@@ -1326,7 +1326,6 @@ template <> struct std::formatter<PageInfo> {
     auto
     format(const PageInfo &page, format_context &ctx) const
     {
-        /* TODO: print encryption if special formatting is given, e.g. {:e} */
         return std::format_to(ctx.out(),
           "{{table_id={}, page_id={}, lsn={}, backlink_lsn={}, base_lsn={}, "
           "flags={:#x}}}",
@@ -1374,10 +1373,9 @@ struct Pages : public Table<Pages> {
                   backlink_lsn,
                   base_lsn,
                   flags,
-                  encryption,
                   timestamp_materialized_us,
                   page_data)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?);)";
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?);)";
 
         /*
          * Get all unique page IDs for a given table that have their latest page record with LSN <=
@@ -1475,7 +1473,6 @@ struct Pages : public Table<Pages> {
                   backlink_lsn,
                   base_lsn,
                   flags,
-                  encryption,
                   page_data
              FROM pages
              WHERE table_id = ?
@@ -1511,7 +1508,6 @@ struct Pages : public Table<Pages> {
              flags INTEGER NOT NULL,
              delta INTEGER AS ((flags & 0x2) != 0) VIRTUAL, -- WT_PAGE_LOG_DELTA
              discarded INTEGER AS ((flags & 0x10000) != 0) VIRTUAL, -- WT_PAGE_LOG_DISCARDED
-             encryption STRING NOT NULL,
              timestamp_materialized_us INTEGER NOT NULL,
              page_data BLOB,
          PRIMARY KEY (table_id, page_id, lsn));)",
@@ -2183,8 +2179,6 @@ public:
     put(uint64_t page_id, uint64_t checkpoint_id, WT_PAGE_LOG_PUT_ARGS *args, const WT_ITEM *buf)
     {
         storage.simulate_unstable_network();
-
-        /* TODO: handle dek encryption */
 
         const uint64_t lsn = storage.make_next_lsn();
         storage.put_page(table_id, page_id, lsn, args, buf);

--- a/ext/page_log/palite/palite.cpp
+++ b/ext/page_log/palite/palite.cpp
@@ -1508,7 +1508,6 @@ struct Pages : public Table<Pages> {
              flags INTEGER NOT NULL,
              delta INTEGER AS ((flags & 0x2) != 0) VIRTUAL, -- WT_PAGE_LOG_DELTA
              discarded INTEGER AS ((flags & 0x10000) != 0) VIRTUAL, -- WT_PAGE_LOG_DISCARDED
-             encryption STRING, -- Deprecated, can be NULL
              timestamp_materialized_us INTEGER NOT NULL,
              page_data BLOB,
          PRIMARY KEY (table_id, page_id, lsn));)",

--- a/ext/page_log/palite/palite.cpp
+++ b/ext/page_log/palite/palite.cpp
@@ -1692,8 +1692,8 @@ struct Pages : public Table<Pages> {
                 LOG_AND_THROW("Got discarded page: {}", page);
             }
 
-            const void *blob = sqlite3_column_blob(stmt.get(), 5);
-            int size = sqlite3_column_bytes(stmt.get(), 5);
+            const void *blob = sqlite3_column_blob(stmt.get(), 4);
+            int size = sqlite3_column_bytes(stmt.get(), 4);
             fill_item(&results_array[count], blob, static_cast<size_t>(size));
 
             /* Continue to next row */

--- a/ext/page_log/palm/palm_kv.h
+++ b/ext/page_log/palm/palm_kv.h
@@ -82,7 +82,6 @@ typedef struct PALM_KV_PAGE_MATCHES {
 
     uint64_t backlink_lsn;
     uint64_t base_lsn;
-    WT_PAGE_LOG_ENCRYPTION encryption;
     uint32_t flags;
 } PALM_KV_PAGE_MATCHES;
 
@@ -104,8 +103,7 @@ int palm_kv_abandon_after(PALM_KV_CONTEXT *context, uint64_t abandon_after_lsn);
 int palm_kv_get_page_ids(PALM_KV_CONTEXT *context, WT_ITEM *item, uint64_t checkpoint_lsn,
   uint64_t table_id, size_t *size);
 int palm_kv_put_page(PALM_KV_CONTEXT *context, uint64_t table_id, uint64_t page_id, uint64_t lsn,
-  bool is_delta, uint64_t backlink_lsn, uint64_t base_lsn, const WT_PAGE_LOG_ENCRYPTION *encryption,
-  uint32_t flags, const WT_ITEM *buf);
+  bool is_delta, uint64_t backlink_lsn, uint64_t base_lsn, uint32_t flags, const WT_ITEM *buf);
 int palm_kv_get_page_matches(PALM_KV_CONTEXT *context, uint64_t table_id, uint64_t page_id,
   uint64_t lsn, bool ignore_materialization, PALM_KV_PAGE_MATCHES *matchesp);
 bool palm_kv_next_page_match(PALM_KV_PAGE_MATCHES *matches);

--- a/lang/python/wiredtiger.i
+++ b/lang/python/wiredtiger.i
@@ -779,7 +779,6 @@ COMPARE_NOTFOUND_OK(__wt_cursor::_search_near)
 %ignore __wt_page_log_put_args::base_lsn;
 %ignore __wt_page_log_put_args::backlink_checkpoint_id;
 %ignore __wt_page_log_put_args::base_checkpoint_id;
-%ignore __wt_page_log_put_args::encryption;
 %ignore __wt_page_log_put_args::flags;
 %ignore __wt_page_log_put_args::lsn;
 %ignore __wt_page_log_get_args::lsn;
@@ -787,7 +786,6 @@ COMPARE_NOTFOUND_OK(__wt_cursor::_search_near)
 %ignore __wt_page_log_get_args::base_lsn;
 %ignore __wt_page_log_get_args::backlink_checkpoint_id;
 %ignore __wt_page_log_get_args::base_checkpoint_id;
-%ignore __wt_page_log_get_args::encryption;
 %ignore __wt_page_log_get_args::lsn_frontier;
 
 OVERRIDE_METHOD(__wt_cursor, WT_CURSOR, compare, (self, other))

--- a/lang/python/wiredtiger.i
+++ b/lang/python/wiredtiger.i
@@ -775,7 +775,6 @@ COMPARE_NOTFOUND_OK(__wt_cursor::_search_near)
 %ignore __wt_page_log_discard_args::backlink_checkpoint_id;
 %ignore __wt_page_log_discard_args::base_checkpoint_id;
 %ignore __wt_page_log_discard_args::lsn_frontier;
-%ignore __wt_page_log_encryption::dek;
 %ignore __wt_page_log_put_args::backlink_lsn;
 %ignore __wt_page_log_put_args::base_lsn;
 %ignore __wt_page_log_put_args::backlink_checkpoint_id;

--- a/src/block_disagg/block_disagg_read.c
+++ b/src/block_disagg/block_disagg_read.c
@@ -227,7 +227,6 @@ __block_disagg_read_multiple(WT_SESSION_IMPL *session, WT_BLOCK_DISAGG *block_di
                     block_meta->disagg_lsn = get_args.lsn;
                     block_meta->delta_count = (uint8_t)(*results_count - 1);
                     block_meta->checksum = checksum;
-                    block_meta->encryption = get_args.encryption;
                     if (block_meta->delta_count > 0)
                         WT_ASSERT(session, get_args.base_lsn > 0);
                     else

--- a/src/block_disagg/block_disagg_write.c
+++ b/src/block_disagg/block_disagg_write.c
@@ -173,7 +173,6 @@ __wti_block_disagg_write_internal(WT_SESSION_IMPL *session, WT_BLOCK_DISAGG *blo
 
     put_args.backlink_lsn = block_meta->backlink_lsn;
     put_args.base_lsn = block_meta->base_lsn;
-    put_args.encryption = block_meta->encryption;
     put_args.image_size = page_image_size;
 
     if (F_ISSET(blk, WT_BLOCK_DISAGG_COMPRESSED))

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -263,8 +263,6 @@ struct __wt_page_block_meta {
     uint64_t backlink_lsn;
     uint64_t base_lsn;
 
-    WT_PAGE_LOG_ENCRYPTION encryption;
-
     uint32_t checksum;
 
     uint8_t delta_count;

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -83,7 +83,6 @@ struct __wt_modify;     typedef struct __wt_modify WT_MODIFY;
 struct __wt_page_log; typedef struct __wt_page_log WT_PAGE_LOG;
 struct __wt_page_log_discard_args;
 typedef struct __wt_page_log_discard_args WT_PAGE_LOG_DISCARD_ARGS;
-struct __wt_page_log_encryption; typedef struct __wt_page_log_encryption WT_PAGE_LOG_ENCRYPTION;
 struct __wt_page_log_get_args; typedef struct __wt_page_log_get_args WT_PAGE_LOG_GET_ARGS;
 struct __wt_page_log_put_args; typedef struct __wt_page_log_put_args WT_PAGE_LOG_PUT_ARGS;
 struct __wt_key_provider;    typedef struct __wt_key_provider WT_KEY_PROVIDER;
@@ -5810,13 +5809,6 @@ struct __wt_key_provider {
 #endif
 
 /*!
- * Encryption data used by the WT_PAGE_LOG_HANDLE interfaces.
- */
-struct __wt_page_log_encryption {
-       char dek[32]; /* an encrypted version of the key used to encrypt data */
-};
-
-/*!
  * Btree disaggregated storage tier types
  */
 typedef enum {
@@ -5854,8 +5846,6 @@ struct __wt_page_log_put_args {
        uint64_t base_checkpoint_id;
        size_t image_size;
 
-       WT_PAGE_LOG_ENCRYPTION encryption;
-
        uint32_t flags;
 
        /*
@@ -5885,8 +5875,6 @@ struct __wt_page_log_get_args {
        uint64_t base_lsn;
        uint64_t backlink_checkpoint_id;
        uint64_t base_checkpoint_id;
-
-       WT_PAGE_LOG_ENCRYPTION encryption;
 };
 
 /*!


### PR DESCRIPTION
The security team used the DEK information to verify a delta is correctly matching the same base page. This is now deprecated and not needed anymore because the security team uses backlink lsn to verify this behaviour. As such we can remove this struct from WT code.

I deleted the  `__wt_page_log_encryption` struct along with all mentions of it in WT.