### PR TITLE
WT-16605 Set WT_BTREE_IN_MEMORY for all the btrees in the in-memory database

### DIFF
--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -1252,7 +1252,7 @@ __btree_page_sizes(WT_SESSION_IMPL *session)
      * items are stored on a different page within the same tree, which cannot be handled by
      * disaggregated storage.
      */
-    if (F_ISSET(btree, WT_BTREE_IN_MEMORY) || F_ISSET(btree, WT_BTREE_DISAGGREGATED)) {
+    if (F_ISSET(btree, WT_BTREE_IN_MEMORY | WT_BTREE_DISAGGREGATED)) {
         btree->maxleafkey = WT_BTREE_MAX_OBJECT_SIZE;
         btree->maxleafvalue = WT_BTREE_MAX_OBJECT_SIZE;
         return (0);

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -573,12 +573,12 @@ __btree_conf(WT_SESSION_IMPL *session, WT_CKPT *ckpt, bool is_ckpt)
      * to the history store. Checkpoint will also skip this tree.
      */
     WT_RET(__wt_config_gets(session, cfg, "in_memory", &cval));
-    if (cval.val)
+    if (cval.val || F_ISSET(conn, WT_CONN_IN_MEMORY))
         F_SET(btree, WT_BTREE_IN_MEMORY);
     else
         F_CLR(btree, WT_BTREE_IN_MEMORY);
 
-    if (F_ISSET(conn, WT_CONN_IN_MEMORY) || F_ISSET(btree, WT_BTREE_IN_MEMORY)) {
+    if (F_ISSET(btree, WT_BTREE_IN_MEMORY)) {
         F_SET(btree, WT_BTREE_LOGGED);
         WT_RET(__wt_config_gets(session, cfg, "log.enabled", &cval));
         if (!cval.val)
@@ -1252,8 +1252,7 @@ __btree_page_sizes(WT_SESSION_IMPL *session)
      * items are stored on a different page within the same tree, which cannot be handled by
      * disaggregated storage.
      */
-    if (F_ISSET(conn, WT_CONN_IN_MEMORY) || F_ISSET(btree, WT_BTREE_IN_MEMORY) ||
-      F_ISSET(btree, WT_BTREE_DISAGGREGATED)) {
+    if (F_ISSET(btree, WT_BTREE_IN_MEMORY) || F_ISSET(btree, WT_BTREE_DISAGGREGATED)) {
         btree->maxleafkey = WT_BTREE_MAX_OBJECT_SIZE;
         btree->maxleafvalue = WT_BTREE_MAX_OBJECT_SIZE;
         return (0);

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -1094,8 +1094,7 @@ __wti_page_inmem_updates(WT_SESSION_IMPL *session, WT_REF *ref)
     WT_ASSERT(session, !F_ISSET(btree, WT_BTREE_READONLY));
 
     /* We don't handle in-memory prepare resolution here. */
-    WT_ASSERT(
-      session, !F_ISSET(S2C(session), WT_CONN_IN_MEMORY) && !F_ISSET(btree, WT_BTREE_IN_MEMORY));
+    WT_ASSERT(session, !F_ISSET(btree, WT_BTREE_IN_MEMORY));
 
     __wt_btcur_init(session, &cbt);
     __wt_btcur_open(&cbt);

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1478,8 +1478,8 @@ __split_multi_inmem(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *multi, WT
      * garbage collect the history store pages at the page level since all its content has a stop
      * timestamp.
      */
-    if (instantiate_upd && !F_ISSET(S2C(session), WT_CONN_IN_MEMORY) &&
-      !F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY) && !WT_IS_HS(session->dhandle))
+    if (instantiate_upd && !F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY) &&
+      !WT_IS_HS(session->dhandle))
         WT_RET(__wti_page_inmem_updates(session, ref));
 
     __wt_evict_inherit_page_state(orig, page);
@@ -1774,7 +1774,7 @@ __split_multi_inmem_fail(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *mult
     WT_UPDATE *upd;
     uint32_t i, slot;
 
-    if (!F_ISSET(S2C(session), WT_CONN_IN_MEMORY) && !F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY))
+    if (!F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY))
         /* Append the onpage values back to the original update chains. */
         for (i = 0, supd = multi->supd; i < multi->supd_entries; ++i, ++supd) {
             /*

--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -465,8 +465,7 @@ __wt_conn_dhandle_close(WT_SESSION_IMPL *session, bool final, bool mark_dead, bo
          *
          */
         if (!discard && !marked_dead) {
-            if (F_ISSET(conn, WT_CONN_IN_MEMORY) ||
-              F_ISSET(btree, WT_BTREE_NO_CHECKPOINT | WT_BTREE_IN_MEMORY))
+            if (F_ISSET(btree, WT_BTREE_NO_CHECKPOINT | WT_BTREE_IN_MEMORY))
                 discard = true;
             else {
                 WT_TRET(__wt_checkpoint_close(session, final));

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -292,9 +292,7 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF_STATE previous_state, u
     /* Update the reference and discard the page. */
     if (__wt_ref_is_root(ref))
         __wt_ref_out(session, ref);
-    else if ((clean_page && !F_ISSET(conn, WT_CONN_IN_MEMORY) &&
-               !F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY)) ||
-      tree_dead)
+    else if ((clean_page && !F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY)) || tree_dead)
         /*
          * Pages that belong to dead trees never write back to disk and can't support page splits.
          */
@@ -852,8 +850,7 @@ __evict_review(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_flags, bool
      * Clean pages can't be evicted when running in memory only. This should be uncommon - we don't
      * add clean pages to the queue.
      */
-    if ((F_ISSET(conn, WT_CONN_IN_MEMORY) || F_ISSET(btree, WT_BTREE_IN_MEMORY)) && !modified &&
-      !closing)
+    if (F_ISSET(btree, WT_BTREE_IN_MEMORY) && !modified && !closing)
         return (__wt_set_return(session, EBUSY));
 
     /* Check if the page can be evicted. */
@@ -959,7 +956,7 @@ __evict_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_flags)
     else if (F_ISSET(ref, WT_REF_FLAG_INTERNAL) || WT_IS_HS(btree->dhandle))
         ;
     /* Always do update restore for in-memory database. */
-    else if (F_ISSET(conn, WT_CONN_IN_MEMORY) || F_ISSET(btree, WT_BTREE_IN_MEMORY))
+    else if (F_ISSET(btree, WT_BTREE_IN_MEMORY))
         LF_SET(WT_REC_IN_MEMORY | WT_REC_SCRUB);
     /* For data store leaf pages, write the history to history store except for metadata. */
     else if (!WT_IS_METADATA(btree->dhandle) && !WT_IS_DISAGG_META(btree->dhandle)) {

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -1139,8 +1139,8 @@ __wti_rec_row_leaf(
              * onpage prepared update. Otherwise, we leak the prepared update.
              */
             WT_ASSERT_ALWAYS(session,
-              !F_ISSET(conn, WT_CONN_PRESERVE_PREPARED) || F_ISSET(conn, WT_CONN_IN_MEMORY) ||
-                F_ISSET(btree, WT_BTREE_IN_MEMORY) || !WT_TIME_WINDOW_HAS_PREPARE(twp),
+              !F_ISSET(conn, WT_CONN_PRESERVE_PREPARED) || F_ISSET(btree, WT_BTREE_IN_MEMORY) ||
+                !WT_TIME_WINDOW_HAS_PREPARE(twp),
               "leaked prepared update.");
         } else
             twp = &upd_select.tw;

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -392,7 +392,7 @@ __rec_need_save_upd(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_UPDATE_SELEC
 
     btree = S2BT(session);
 
-    if (F_ISSET(S2C(session), WT_CONN_IN_MEMORY) || F_ISSET(btree, WT_BTREE_IN_MEMORY))
+    if (F_ISSET(btree, WT_BTREE_IN_MEMORY))
         return (false);
     /*
      * We need to save the update chain to check whether the reconciliation makes progress for
@@ -1424,7 +1424,7 @@ __wti_rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_INSERT *ins,
     WT_PAGE *page;
     WT_UPDATE *first_txn_upd, *first_upd, *onpage_upd, *upd;
     size_t upd_memsize;
-    bool has_newer_updates, write_prepare, is_inmem;
+    bool has_newer_updates, write_prepare;
 
     /*
      * The "saved updates" return value is used independently of returning an update we can write,
@@ -1450,9 +1450,8 @@ __wti_rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_INSERT *ins,
         if ((first_upd = WT_ROW_UPDATE(page, rip)) == NULL)
             return (0);
     }
-    is_inmem =
-      F_ISSET(S2C(session), WT_CONN_IN_MEMORY) || F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY);
-    if (is_inmem) {
+
+    if (F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY)) {
         /* Never write prepared updates for in-memory btree */
         write_prepare = false;
         WT_RET(__rec_upd_select_inmem(session, r, vpack, first_upd, upd_select, &first_txn_upd,

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -987,10 +987,9 @@ __rec_write(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *block_me
             (checkpoint && addr == NULL && addr_sizep == NULL),
           "Incorrect arguments passed to rec_write for a checkpoint call");
 
-        /* In-memory databases shouldn't write pages. */
-        WT_ASSERT_ALWAYS(session,
-          !F_ISSET(S2C(session), WT_CONN_IN_MEMORY) && !F_ISSET(btree, WT_BTREE_IN_MEMORY),
-          "Attempted to write page to disk when WiredTiger is configured to be in-memory");
+        /* In-memory btrees shouldn't write pages. */
+        WT_ASSERT_ALWAYS(session, !F_ISSET(btree, WT_BTREE_IN_MEMORY),
+          "Attempted to write page to disk when the btree is configured to be in-memory");
 
         /*
          * We're passed a table's disk image. Decompress if necessary and verify the image. Always

--- a/src/rollback_to_stable/rts_btree.c
+++ b/src/rollback_to_stable/rts_btree.c
@@ -728,8 +728,7 @@ __rts_btree_abort_ondisk_kv(WT_SESSION_IMPL *session, WT_REF *ref, WT_ROW *rip, 
           tw->durable_start_ts > rollback_timestamp ? "true" : "false",
           !__wti_rts_visibility_txn_visible_id(session, tw->start_txn) ? "true" : "false",
           !WT_TIME_WINDOW_HAS_STOP(tw) && prepared ? "true" : "false");
-        if (!F_ISSET(S2C(session), WT_CONN_IN_MEMORY) &&
-          !F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY))
+        if (!F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY))
             return (__rts_btree_ondisk_fixup_key(
               session, ref, rip, recno, row_key, vpack, rollback_timestamp));
         else {
@@ -753,8 +752,7 @@ __rts_btree_abort_ondisk_kv(WT_SESSION_IMPL *session, WT_REF *ref, WT_ROW *rip, 
         if (WT_TIME_WINDOW_HAS_START_PREPARE(tw) && tw->start_prepared_id == tw->stop_prepared_id &&
           tw->start_prepare_ts == tw->stop_prepare_ts && tw->start_txn == tw->stop_txn) {
             WT_ASSERT(session, prepared);
-            if (!F_ISSET(S2C(session), WT_CONN_IN_MEMORY) &&
-              !F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY))
+            if (!F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY))
                 return (__rts_btree_ondisk_fixup_key(
                   session, ref, rip, recno, row_key, vpack, rollback_timestamp));
             else {

--- a/src/rollback_to_stable/rts_visibility.c
+++ b/src/rollback_to_stable/rts_visibility.c
@@ -112,7 +112,7 @@ __wti_rts_visibility_page_needs_abort(
      *    - The on page address max durable timestamp.
      *    - The off page address max durable timestamp.
      */
-    if (F_ISSET(S2C(session), WT_CONN_IN_MEMORY) || F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY)) {
+    if (F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY)) {
         tag = "in-memory";
         result = true;
     } else if (mod != NULL && mod->rec_result == WT_PM_REC_REPLACE) {

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1226,7 +1226,7 @@ __txn_resolve_prepared_op(WT_SESSION_IMPL *session, WT_TXN_OP *op, bool commit, 
     if (F_ISSET(upd, WT_UPDATE_PREPARE_RESTORED_FROM_DS) &&
       (upd->type != WT_UPDATE_TOMBSTONE || (upd->next != NULL && upd->txnid == upd->next->txnid)))
         resolve_case = RESOLVE_PREPARE_ON_DISK;
-    else if (F_ISSET(S2C(session), WT_CONN_IN_MEMORY) || F_ISSET(btree, WT_BTREE_IN_MEMORY))
+    else if (F_ISSET(btree, WT_BTREE_IN_MEMORY))
         resolve_case = RESOLVE_IN_MEMORY;
     else
         resolve_case = RESOLVE_UPDATE_CHAIN;

--- a/test/catch2/misc_tests/test_rec_upd_select.cpp
+++ b/test/catch2/misc_tests/test_rec_upd_select.cpp
@@ -244,7 +244,7 @@ TEST_CASE_METHOD(RecUpdSelectFixture, "rec_upd_select: Basic visible update sele
 
     SECTION("In memory, should write oldest update in the list")
     {
-        F_SET(S2C(session), WT_CONN_IN_MEMORY);
+        F_SET(S2BT(session), WT_BTREE_IN_MEMORY);
         WTI_UPDATE_SELECT upd_select;
         WTI_UPDATE_SELECT_INIT(&upd_select);
 
@@ -259,7 +259,7 @@ TEST_CASE_METHOD(RecUpdSelectFixture, "rec_upd_select: Basic visible update sele
     }
     SECTION("Not in-memory, should write newest update in the list")
     {
-        F_CLR(S2C(session), WT_CONN_IN_MEMORY);
+        F_CLR(S2BT(session), WT_BTREE_IN_MEMORY);
         WTI_UPDATE_SELECT upd_select;
         WTI_UPDATE_SELECT_INIT(&upd_select);
 
@@ -309,7 +309,7 @@ TEST_CASE_METHOD(
 
     SECTION("In-memory, should write oldest update with timestamp > prune timestamp in the list")
     {
-        F_SET(S2C(session), WT_CONN_IN_MEMORY);
+        F_SET(S2BT(session), WT_BTREE_IN_MEMORY);
         WTI_UPDATE_SELECT upd_select;
         WTI_UPDATE_SELECT_INIT(&upd_select);
 
@@ -359,7 +359,7 @@ TEST_CASE_METHOD(RecUpdSelectFixture, "rec_upd_select: Skip writing aborted and 
 
     SECTION("In-memory, should write oldest update with timestamp > prune timestamp in the list")
     {
-        F_SET(S2C(session), WT_CONN_IN_MEMORY);
+        F_SET(S2BT(session), WT_BTREE_IN_MEMORY);
         WTI_UPDATE_SELECT upd_select;
         WTI_UPDATE_SELECT_INIT(&upd_select);
 
@@ -375,7 +375,7 @@ TEST_CASE_METHOD(RecUpdSelectFixture, "rec_upd_select: Skip writing aborted and 
 
     SECTION("Not In-memory, should write newest update")
     {
-        F_CLR(S2C(session), WT_CONN_IN_MEMORY);
+        F_CLR(S2BT(session), WT_BTREE_IN_MEMORY);
         F_SET(&r, WT_REC_EVICT);
         WTI_UPDATE_SELECT upd_select;
         WTI_UPDATE_SELECT_INIT(&upd_select);


### PR DESCRIPTION
Set WT_BTREE_IN_MEMORY for all the btrees in the in-memory database. Therefore, we only need to check the WT_BTREE_IN_MEMORY flag in the code.
