### PR TITLE
WT-13762 Pin package versions in modularity_check/requirements.txt

### DIFF
--- a/tools/modularity_check/README.md
+++ b/tools/modularity_check/README.md
@@ -8,7 +8,7 @@ Tool to review the modularity of components in WiredTiger.
 ## Getting started:
 ```sh
 virtualenv venv
-(venv) pip install -r requirement.txt
+(venv) pip install -r requirements.txt
 ```
 
 ## Using the tool:

--- a/tools/modularity_check/requirements.txt
+++ b/tools/modularity_check/requirements.txt
@@ -1,3 +1,3 @@
-networkx
-tree-sitter
-tree-sitter-c
+networkx==3.4.2
+tree-sitter==0.25.2
+tree-sitter-c==0.24.1


### PR DESCRIPTION
Lock versions of Python packages to ensure consistent builds even when there are upstream updates. Additionally, fix a typo in the README where requirements.txt is missing an "s".