### PR TITLE
WT-15721 Fix operations from the same transaction being squashed in step up and leading to consecutive tombstones on the shared table

### DIFF
--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -1563,10 +1563,11 @@ __clayered_remove_follower(
   WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, const WT_ITEM *key, bool positioned)
 {
     WT_CURSOR *const c = clayered->ingest_cursor;
-    WT_ITEM value;
 
     if (positioned) {
         if (clayered->current_cursor == c) {
+            WT_ITEM value;
+
             WT_ASSERT(session, F_ISSET(c, WT_CURSTD_KEY_INT));
             /*
              * If we are erasing a record that is already a tombstone, don't write another one: we
@@ -1576,11 +1577,8 @@ __clayered_remove_follower(
             if (__wt_clayered_deleted(&value))
                 return (WT_NOTFOUND);
         }
-    } else {
+    } else
         WT_ASSERT(session, F_ISSET(&clayered->iface, WT_CURSTD_KEY_EXT));
-        /* Lookup will return WT_NOTFOUND if a tombstone is present. */
-        WT_RET(__clayered_lookup(session, clayered, &value));
-    }
 
     /* If we are positioned on the stable table, we need to set the key. */
     if (clayered->current_cursor != c) {

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -1555,6 +1555,78 @@ __clayered_put(WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, const WT_I
 }
 
 /*
+ * __clayered_remove_ingest --
+ *     Remove an entry from the ingest table.
+ */
+static WT_INLINE int
+__clayered_remove_ingest(
+  WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, const WT_ITEM *key, bool positioned)
+{
+    WT_CURSOR *const c = clayered->ingest_cursor;
+    WT_ITEM value;
+
+    if (positioned && clayered->current_cursor == c) {
+        WT_ASSERT(session, F_ISSET(c, WT_CURSTD_KEY_INT));
+        /*
+         * If we are erasing a record that is already a tombstone, don't write another one: we don't
+         * ever want consecutive tombstones on an update chain.
+         */
+        WT_RET(c->get_value(c, &value));
+        if (__wt_clayered_deleted(&value))
+            return (WT_NOTFOUND);
+    } else {
+        WT_ASSERT(session, F_ISSET(&clayered->iface, WT_CURSTD_KEY_EXT));
+        /* Lookup will return WT_NOTFOUND if a tombstone is present. */
+        WT_RET(__clayered_lookup(session, clayered, &value));
+    }
+
+    /* If we are positioned on the stable table, we need to set the key. */
+    if (clayered->current_cursor != c) {
+        /*
+         * Clear the existing cursor position. Don't clear the primary cursor: we're about to use it
+         * anyway. No need to do another search if we are already positioned.
+         */
+        WT_RET(__clayered_reset_cursors(clayered, true));
+        c->set_key(c, key);
+    }
+
+    c->set_value(c, &__wt_tombstone);
+    WT_RET(c->update(c));
+    clayered->current_cursor = c;
+
+    return (0);
+}
+
+/*
+ * __clayered_remove_stable --
+ *     Remove an entry from the stable table.
+ */
+static WT_INLINE int
+__clayered_remove_stable(
+  WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, const WT_ITEM *key, bool positioned)
+{
+    WT_CURSOR *const c = clayered->stable_cursor;
+
+    /* There is no content on the ingest table. We must be positioned on the stable table. */
+    if (!positioned) {
+        /*
+         * Clear the existing cursor position. Don't clear the primary cursor: we're about to use it
+         * anyway. We need the cursor still be positioned after the remove. Don't release the cursor
+         * if that is the case. Remove only retains the cursor position if it is positioned at the
+         * start.
+         */
+        WT_RET(__clayered_reset_cursors(clayered, true));
+        c->set_key(c, key);
+    } else
+        WT_ASSERT(session, F_ISSET(c, WT_CURSTD_KEY_INT));
+
+    WT_RET(c->remove(c));
+    clayered->current_cursor = c;
+
+    return (0);
+}
+
+/*
  * __clayered_remove_int --
  *     Remove an entry from the desired tree.
  */
@@ -1562,41 +1634,9 @@ static WT_INLINE int
 __clayered_remove_int(
   WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, const WT_ITEM *key, bool positioned)
 {
-    WT_CURSOR *c;
-
-    if (S2C(session)->layered_table_manager.leader) {
-        c = clayered->stable_cursor;
-        /* There is no content on the ingest table. We must be positioned on the stable table. */
-        if (!positioned) {
-            /*
-             * Clear the existing cursor position. Don't clear the primary cursor: we're about to
-             * use it anyway. We need the cursor still be positioned after the remove. Don't release
-             * the cursor if that is the case. Remove only retains the cursor position if it is
-             * positioned at the start.
-             */
-            WT_RET(__clayered_reset_cursors(clayered, true));
-            c->set_key(c, key);
-        } else
-            WT_ASSERT(session, F_ISSET(c, WT_CURSTD_KEY_INT));
-        WT_RET(c->remove(c));
-    } else {
-        c = clayered->ingest_cursor;
-        /* If we are positioned on the stable table, we need to set the key. */
-        if (!positioned || clayered->current_cursor != c) {
-            /*
-             * Clear the existing cursor position. Don't clear the primary cursor: we're about to
-             * use it anyway. No need to do another search if we are already positioned.
-             */
-            WT_RET(__clayered_reset_cursors(clayered, true));
-            c->set_key(c, key);
-        } else
-            WT_ASSERT(session, F_ISSET(c, WT_CURSTD_KEY_INT));
-        c->set_value(c, &__wt_tombstone);
-        WT_RET(c->update(c));
-    }
-
-    clayered->current_cursor = c;
-    return (0);
+    return (S2C(session)->layered_table_manager.leader ?
+        __clayered_remove_stable(session, clayered, key, positioned) :
+        __clayered_remove_ingest(session, clayered, key, positioned));
 }
 
 /*

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -1555,25 +1555,27 @@ __clayered_put(WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, const WT_I
 }
 
 /*
- * __clayered_remove_ingest --
+ * __clayered_remove_follower --
  *     Remove an entry from the ingest table.
  */
 static WT_INLINE int
-__clayered_remove_ingest(
+__clayered_remove_follower(
   WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, const WT_ITEM *key, bool positioned)
 {
     WT_CURSOR *const c = clayered->ingest_cursor;
     WT_ITEM value;
 
-    if (positioned && clayered->current_cursor == c) {
-        WT_ASSERT(session, F_ISSET(c, WT_CURSTD_KEY_INT));
-        /*
-         * If we are erasing a record that is already a tombstone, don't write another one: we don't
-         * ever want consecutive tombstones on an update chain.
-         */
-        WT_RET(c->get_value(c, &value));
-        if (__wt_clayered_deleted(&value))
-            return (WT_NOTFOUND);
+    if (positioned) {
+        if (clayered->current_cursor == c) {
+            WT_ASSERT(session, F_ISSET(c, WT_CURSTD_KEY_INT));
+            /*
+             * If we are erasing a record that is already a tombstone, don't write another one: we
+             * don't ever want consecutive tombstones on an update chain.
+             */
+            WT_RET(c->get_value(c, &value));
+            if (__wt_clayered_deleted(&value))
+                return (WT_NOTFOUND);
+        }
     } else {
         WT_ASSERT(session, F_ISSET(&clayered->iface, WT_CURSTD_KEY_EXT));
         /* Lookup will return WT_NOTFOUND if a tombstone is present. */
@@ -1598,11 +1600,11 @@ __clayered_remove_ingest(
 }
 
 /*
- * __clayered_remove_stable --
+ * __clayered_remove_leader --
  *     Remove an entry from the stable table.
  */
 static WT_INLINE int
-__clayered_remove_stable(
+__clayered_remove_leader(
   WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, const WT_ITEM *key, bool positioned)
 {
     WT_CURSOR *const c = clayered->stable_cursor;
@@ -1635,8 +1637,8 @@ __clayered_remove_int(
   WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, const WT_ITEM *key, bool positioned)
 {
     return (S2C(session)->layered_table_manager.leader ?
-        __clayered_remove_stable(session, clayered, key, positioned) :
-        __clayered_remove_ingest(session, clayered, key, positioned));
+        __clayered_remove_leader(session, clayered, key, positioned) :
+        __clayered_remove_follower(session, clayered, key, positioned));
 }
 
 /*

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -1780,7 +1780,6 @@ __clayered_remove(WT_CURSOR *cursor)
 {
     WT_CURSOR_LAYERED *clayered;
     WT_DECL_RET;
-    WT_ITEM value;
     WT_SESSION_IMPL *session;
     bool positioned;
 
@@ -1792,17 +1791,6 @@ __clayered_remove(WT_CURSOR *cursor)
     CURSOR_REMOVE_API_CALL(cursor, session, ret, clayered->dhandle);
     WT_ERR(__cursor_needkey(cursor));
     __cursor_novalue(cursor);
-
-    /*
-     * Remove fails if the key doesn't exist, do a search first. This requires a second pair of
-     * layered enter/leave calls as we search the full stack, but updates are limited to the
-     * top-level.
-     */
-    if (!positioned) {
-        WT_ERR(__clayered_enter(clayered, false, false, false));
-        WT_ERR(__clayered_lookup(session, clayered, &value));
-        __clayered_leave(clayered);
-    }
 
     WT_ERR(__clayered_enter(clayered, false, true, false));
     /*

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -295,15 +295,6 @@ __curversion_next_single_key(WT_CURSOR *cursor)
                         WT_ASSERT(session,
                           !__wt_txn_visible_all(session, version_cursor->upd_stop_txnid,
                             version_cursor->upd_durable_stop_ts));
-
-                        /* Ignore the update with the same transaction id and timestamps. */
-                        if (F_ISSET(version_cursor, WT_CURVERSION_TIMESTAMP_ORDER) &&
-                          next_upd->txnid == version_cursor->upd_stop_txnid &&
-                          next_upd->prepare_ts == version_cursor->upd_stop_prepare_ts &&
-                          next_upd->upd_start_ts == version_cursor->upd_stop_ts &&
-                          next_upd->upd_durable_ts == version_cursor->upd_durable_stop_ts)
-                            continue;
-
                         break;
                     }
                 }
@@ -375,12 +366,6 @@ __curversion_next_single_key(WT_CURSOR *cursor)
                           cbt->upd_value->tw.start_ts > version_cursor->upd_stop_ts)
                             goto skip_on_page;
                     }
-
-                    if (cbt->upd_value->tw.start_txn == version_cursor->upd_stop_txnid &&
-                      cbt->upd_value->tw.start_prepare_ts == version_cursor->upd_stop_prepare_ts &&
-                      cbt->upd_value->tw.start_ts == version_cursor->upd_stop_ts &&
-                      cbt->upd_value->tw.durable_start_ts == version_cursor->upd_durable_stop_ts)
-                        goto skip_on_page;
                 }
                 durable_stop_ts = version_cursor->upd_durable_stop_ts;
                 stop_prepare_ts = version_cursor->upd_stop_prepare_ts;

--- a/test/suite/test_layered27.py
+++ b/test/suite/test_layered27.py
@@ -194,19 +194,16 @@ class test_layered27(wttest.WiredTigerTestCase):
         session_follow.create(self.uri, "key_format=S,value_format=S")
         cursor = session_follow.open_cursor(self.uri)
 
-        def set_txn_ts(ts):
-            session_follow.commit_transaction(f'commit_timestamp={self.timestamp_str(ts)}')
-
         # 1. Insert the key at T1.
         session_follow.begin_transaction()
         cursor[key] = str(ts1)
-        set_txn_ts(ts1)
+        session_follow.commit_transaction(f'commit_timestamp={self.timestamp_str(ts1)}')
 
         # 2. Delete the key at T2.
         session_follow.begin_transaction()
         cursor.set_key(key)
         cursor.remove()
-        set_txn_ts(ts2)
+        session_follow.commit_transaction(f'commit_timestamp={self.timestamp_str(ts2)}')
 
         # 3. Start inserting the key again.
         session_follow.begin_transaction()
@@ -217,16 +214,17 @@ class test_layered27(wttest.WiredTigerTestCase):
         cursor.remove()
 
         # 5. Commit that transaction at T3.
-        set_txn_ts(ts3)
+        session_follow.commit_transaction(f'commit_timestamp={self.timestamp_str(ts3)}')
 
         # 6. Insert the key at T4.
         session_follow.begin_transaction()
         cursor[key] = str(ts4)
-        set_txn_ts(ts4)
+        session_follow.commit_transaction(f'commit_timestamp={self.timestamp_str(ts4)}')
 
+        # 7. Insert the key again at T5.
         session_follow.begin_transaction()
         cursor[key] = str(ts5)
-        set_txn_ts(ts5)
+        session_follow.commit_transaction(f'commit_timestamp={self.timestamp_str(ts5)}')
 
         cursor.close()
 
@@ -234,14 +232,14 @@ class test_layered27(wttest.WiredTigerTestCase):
         self.conn.reconfigure('disaggregated=(role="follower")')
         self.conn.close()
 
-        # 7. Step up: promote the follower connection to leader so ingest state drains.
+        # 8. Step up: promote the follower connection to leader so ingest state drains.
         conn_follow.reconfigure('disaggregated=(role="leader")')
 
-        # 8. Make T5 stable on the stepped-up connection.
+        # 9. Make T5 stable on the stepped-up connection.
         ts5_str = self.timestamp_str(ts5)
         conn_follow.set_timestamp(f'stable_timestamp={ts5_str}')
 
-        # 9. Checkpoint to drain the ingest table into the base table.
+        # 10. Checkpoint to drain the ingest table into the base table.
         session_follow.checkpoint()
 
         # End of test.

--- a/test/suite/test_layered27.py
+++ b/test/suite/test_layered27.py
@@ -189,24 +189,23 @@ class test_layered27(wttest.WiredTigerTestCase):
 
         # Create the layered table on both leader and follower.
         self.session.create(self.uri, "key_format=S,value_format=S")
-        conn_follow = self.wiredtiger_open('follower', self.conn_follower_config)
-        session_follow = conn_follow.open_session('')
-        session_follow.create(self.uri, "key_format=S,value_format=S")
-        cursor = session_follow.open_cursor(self.uri)
+        self.conn.reconfigure('disaggregated=(role="follower")')
+        self.session = self.conn.open_session('')
+        cursor = self.session.open_cursor(self.uri)
 
         # 1. Insert the key at T1.
-        session_follow.begin_transaction()
+        self.session.begin_transaction()
         cursor[key] = str(ts1)
-        session_follow.commit_transaction(f'commit_timestamp={self.timestamp_str(ts1)}')
+        self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(ts1)}')
 
         # 2. Delete the key at T2.
-        session_follow.begin_transaction()
+        self.session.begin_transaction()
         cursor.set_key(key)
         cursor.remove()
-        session_follow.commit_transaction(f'commit_timestamp={self.timestamp_str(ts2)}')
+        self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(ts2)}')
 
         # 3. Start inserting the key again.
-        session_follow.begin_transaction()
+        self.session.begin_transaction()
         cursor[key] = str(ts3)
 
         # 4. Delete the key inside the same transaction.
@@ -214,36 +213,32 @@ class test_layered27(wttest.WiredTigerTestCase):
         cursor.remove()
 
         # 5. Commit that transaction at T3.
-        session_follow.commit_transaction(f'commit_timestamp={self.timestamp_str(ts3)}')
+        self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(ts3)}')
 
         # 6. Insert the key at T4.
-        session_follow.begin_transaction()
+        self.session.begin_transaction()
         cursor[key] = str(ts4)
-        session_follow.commit_transaction(f'commit_timestamp={self.timestamp_str(ts4)}')
+        self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(ts4)}')
 
         # 7. Insert the key again at T5.
-        session_follow.begin_transaction()
+        self.session.begin_transaction()
         cursor[key] = str(ts5)
-        session_follow.commit_transaction(f'commit_timestamp={self.timestamp_str(ts5)}')
+        self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(ts5)}')
 
         cursor.close()
 
-        # Prevent the current leader from checkpointing as we prepare to step up the follower.
-        self.conn.reconfigure('disaggregated=(role="follower")')
-        self.conn.close()
-
         # 8. Step up: promote the follower connection to leader so ingest state drains.
-        conn_follow.reconfigure('disaggregated=(role="leader")')
+        self.conn.reconfigure('disaggregated=(role="leader")')
 
         # 9. Make T5 stable on the stepped-up connection.
         ts5_str = self.timestamp_str(ts5)
-        conn_follow.set_timestamp(f'stable_timestamp={ts5_str}')
+        self.conn.set_timestamp(f'stable_timestamp={ts5_str}')
 
         # 10. Checkpoint to drain the ingest table into the base table.
-        session_follow.checkpoint()
+        self.session.checkpoint()
 
         # End of test.
-        conn_follow.close()
+        self.conn.close()
 
     def test_drain_remove_insert(self):
         # Create the oplog

--- a/test/suite/test_layered27.py
+++ b/test/suite/test_layered27.py
@@ -183,7 +183,7 @@ class test_layered27(wttest.WiredTigerTestCase):
     # This test ensures there are no consecutive tombstones in the update chain
     # when draining the ingest table.
     # See also: WT-15721, WT-16085.
-    def test_drain_remove_several(self):
+    def test_drain_insert_remove_within_same_transaction(self):
         key = 'key1'
         ts1, ts2, ts3, ts4, ts5 = 10, 20, 30, 40, 50
 

--- a/test/suite/test_layered27.py
+++ b/test/suite/test_layered27.py
@@ -27,8 +27,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 import platform, wttest
-from helper_disagg import disagg_test_class, gen_disagg_storages
-from test_layered23 import Oplog
+from helper_disagg import disagg_test_class, gen_disagg_storages, Oplog
 from wtscenario import make_scenarios
 
 # test_layered27.py
@@ -49,8 +48,16 @@ class test_layered27(wttest.WiredTigerTestCase):
 
     uri = 'layered:test_layered27'
 
+    @property
+    def base_config(self):
+        return self.extensionsConfig() + self.conn_base_config
+
     def conn_config(self):
-        return self.extensionsConfig() + self.conn_base_config + 'disaggregated=(role="leader")'
+        return self.base_config + 'disaggregated=(role="leader")'
+
+    @property
+    def conn_follower_config(self):
+        return self.base_config + 'disaggregated=(role="follower")'
 
     def test_drain_insert_update(self):
         # Create the oplog
@@ -62,7 +69,7 @@ class test_layered27(wttest.WiredTigerTestCase):
 
         # Create the follower and create its table
         # To keep this test relatively easy, we're only using a single URI.
-        conn_follow = self.wiredtiger_open('follower', self.extensionsConfig() + self.conn_base_config + 'disaggregated=(role="follower")')
+        conn_follow = self.wiredtiger_open('follower', self.conn_follower_config)
         session_follow = conn_follow.open_session('')
         session_follow.create(self.uri, "key_format=S,value_format=S")
 
@@ -107,7 +114,7 @@ class test_layered27(wttest.WiredTigerTestCase):
 
         # Reopen the new leader as follower to get rid of the content in the ingest table
         conn_follow.close()
-        conn_follow = self.wiredtiger_open('follower', self.extensionsConfig() + self.conn_base_config + 'disaggregated=(role="follower")')
+        conn_follow = self.wiredtiger_open('follower', self.conn_follower_config)
         session_follow = conn_follow.open_session('')
 
         # Ensure everything is in the new checkpoint
@@ -123,7 +130,7 @@ class test_layered27(wttest.WiredTigerTestCase):
 
         # Create the follower and create its table
         # To keep this test relatively easy, we're only using a single URI.
-        conn_follow = self.wiredtiger_open('follower', self.extensionsConfig() + self.conn_base_config + 'disaggregated=(role="follower")')
+        conn_follow = self.wiredtiger_open('follower', self.conn_follower_config)
         session_follow = conn_follow.open_session('')
         session_follow.create(self.uri, "key_format=S,value_format=S")
 
@@ -167,11 +174,78 @@ class test_layered27(wttest.WiredTigerTestCase):
 
         # Reopen the new leader as follower to get rid of the content in the ingest table
         conn_follow.close()
-        conn_follow = self.wiredtiger_open('follower', self.extensionsConfig() + self.conn_base_config + 'disaggregated=(role="follower")')
+        conn_follow = self.wiredtiger_open('follower', self.conn_follower_config)
         session_follow = conn_follow.open_session('')
 
         # Ensure everything is in the new checkpoint
         oplog.check(self, session_follow, 0, 200 * self.multiplier)
+
+    # This test ensures there are no consecutive tombstones in the update chain
+    # when draining the ingest table.
+    # See also: WT-15721, WT-16085.
+    def test_drain_remove_several(self):
+        key = 'key1'
+        ts1, ts2, ts3, ts4, ts5 = 10, 20, 30, 40, 50
+
+        # Create the layered table on both leader and follower.
+        self.session.create(self.uri, "key_format=S,value_format=S")
+        conn_follow = self.wiredtiger_open('follower', self.conn_follower_config)
+        session_follow = conn_follow.open_session('')
+        session_follow.create(self.uri, "key_format=S,value_format=S")
+        cursor = session_follow.open_cursor(self.uri)
+
+        def set_txn_ts(ts):
+            session_follow.commit_transaction(f'commit_timestamp={self.timestamp_str(ts)}')
+
+        # 1. Insert the key at T1.
+        session_follow.begin_transaction()
+        cursor[key] = str(ts1)
+        set_txn_ts(ts1)
+
+        # 2. Delete the key at T2.
+        session_follow.begin_transaction()
+        cursor.set_key(key)
+        cursor.remove()
+        set_txn_ts(ts2)
+
+        # 3. Start inserting the key again.
+        session_follow.begin_transaction()
+        cursor[key] = str(ts3)
+
+        # 4. Delete the key inside the same transaction.
+        cursor.set_key(key)
+        cursor.remove()
+
+        # 5. Commit that transaction at T3.
+        set_txn_ts(ts3)
+
+        # 6. Insert the key at T4.
+        session_follow.begin_transaction()
+        cursor[key] = str(ts4)
+        set_txn_ts(ts4)
+
+        session_follow.begin_transaction()
+        cursor[key] = str(ts5)
+        set_txn_ts(ts5)
+
+        cursor.close()
+
+        # Prevent the current leader from checkpointing as we prepare to step up the follower.
+        self.conn.reconfigure('disaggregated=(role="follower")')
+        self.conn.close()
+
+        # 7. Step up: promote the follower connection to leader so ingest state drains.
+        conn_follow.reconfigure('disaggregated=(role="leader")')
+
+        # 8. Make T5 stable on the stepped-up connection.
+        ts5_str = self.timestamp_str(ts5)
+        conn_follow.set_timestamp(f'stable_timestamp={ts5_str}')
+
+        # 9. Checkpoint to drain the ingest table into the base table.
+        session_follow.checkpoint()
+
+        # End of test.
+        conn_follow.close()
 
     def test_drain_remove_insert(self):
         # Create the oplog
@@ -183,7 +257,7 @@ class test_layered27(wttest.WiredTigerTestCase):
 
         # Create the follower and create its table
         # To keep this test relatively easy, we're only using a single URI.
-        conn_follow = self.wiredtiger_open('follower', self.extensionsConfig() + self.conn_base_config + 'disaggregated=(role="follower")')
+        conn_follow = self.wiredtiger_open('follower', self.conn_follower_config)
         session_follow = conn_follow.open_session('')
         session_follow.create(self.uri, "key_format=S,value_format=S")
 
@@ -228,7 +302,7 @@ class test_layered27(wttest.WiredTigerTestCase):
 
         # Reopen the new leader as follower to get rid of the content in the ingest table
         conn_follow.close()
-        conn_follow = self.wiredtiger_open('follower', self.extensionsConfig() + self.conn_base_config + 'disaggregated=(role="follower")')
+        conn_follow = self.wiredtiger_open('follower', self.conn_follower_config)
         session_follow = conn_follow.open_session('')
 
         # Ensure everything is in the new checkpoint


### PR DESCRIPTION
* Prevent consecutive tombstone updates in the update chain.
* Modify `__clayered_remove_int` to ensure that both ingest and stable tables won't contain consecutive tombstones
* Add Python test to ensure no consecutive tombstones in update chain.