### PR TITLE
WT-15738 Error type cast from cursor_layered to cursor_btree in cursor_dump_page

### DIFF
--- a/dist/s_funcs.list
+++ b/dist/s_funcs.list
@@ -25,7 +25,9 @@ __wt_debug_addr_print
 __wt_debug_btree_cursor_page
 __wt_debug_btree_cursor_tree_hs
 __wt_debug_cursor_page
+__wt_debug_cursor_tree_hs
 __wt_debug_layered_cursor_page
+__wt_debug_layered_cursor_tree_hs
 __wt_debug_offset
 __wt_debug_set_verbose
 __wt_debug_tree

--- a/dist/s_funcs.list
+++ b/dist/s_funcs.list
@@ -22,8 +22,10 @@ __wt_curhs_open
 __wt_cursor_get_raw_value
 __wt_debug_addr
 __wt_debug_addr_print
+__wt_debug_btree_cursor_page
+__wt_debug_btree_cursor_tree_hs
 __wt_debug_cursor_page
-__wt_debug_cursor_tree_hs
+__wt_debug_layered_cursor_page
 __wt_debug_offset
 __wt_debug_set_verbose
 __wt_debug_tree

--- a/dist/s_void
+++ b/dist/s_void
@@ -83,6 +83,7 @@ func_ok()
         -e '/int __wt_curhs_search_near_after$/d' \
         -e '/int __wt_curhs_search_near_before$/d' \
         -e '/int __wt_debug_layered_cursor_page$/d' \
+        -e '/int __wt_debug_layered_cursor_tree_hs$/d' \
         -e '/int __wt_epoch$/d' \
         -e '/int __wt_errno$/d' \
         -e '/int __wt_error_log_add$/d' \

--- a/dist/s_void
+++ b/dist/s_void
@@ -82,6 +82,7 @@ func_ok()
         -e '/int __wt_count_birthmarks$/d' \
         -e '/int __wt_curhs_search_near_after$/d' \
         -e '/int __wt_curhs_search_near_before$/d' \
+        -e '/int __wt_debug_layered_cursor_page$/d' \
         -e '/int __wt_epoch$/d' \
         -e '/int __wt_errno$/d' \
         -e '/int __wt_error_log_add$/d' \

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -998,11 +998,11 @@ err:
 }
 
 /*
- * __wt_debug_cursor_page --
+ * __wt_debug_btree_cursor_page --
  *     Dump the in-memory information for a cursor-referenced page.
  */
 int
-__wt_debug_cursor_page(void *cursor_arg, const char *ofile)
+__wt_debug_btree_cursor_page(void *cursor_arg, const char *ofile)
   WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
 {
     WT_CURSOR_BTREE *cbt;
@@ -1034,11 +1034,11 @@ __wt_debug_cursor_page(void *cursor_arg, const char *ofile)
 }
 
 /*
- * __wt_debug_cursor_tree_hs --
+ * __wt_debug_btree_cursor_tree_hs --
  *     Dump the history store tree given a user cursor.
  */
 int
-__wt_debug_cursor_tree_hs(void *cursor_arg, const char *ofile)
+__wt_debug_btree_cursor_tree_hs(void *cursor_arg, const char *ofile)
   WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
 {
     WT_BTREE *hs_btree;

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -2305,3 +2305,20 @@ err:
 
     return (ret);
 }
+
+/*
+ * __wt_debug_layered_cursor_page --
+ *     Dump the in-memory information for a cursor-referenced page.
+ */
+int
+__wt_debug_layered_cursor_page(void *cursor_arg, const char *ofile)
+  WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
+{
+    const WT_CURSOR *cursor = (const WT_CURSOR *)cursor_arg;
+    WT_UNUSED(ofile);
+
+    __wt_verbose_debug1(
+      CUR2S(cursor), WT_VERB_DEFAULT, "%s: unsupported cursor type for debug dump", cursor->uri);
+
+    return (0);
+}

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -2322,3 +2322,20 @@ __wt_debug_layered_cursor_page(void *cursor_arg, const char *ofile)
 
     return (0);
 }
+
+/*
+ * __wt_debug_layered_cursor_tree_hs --
+ *     Dump the in-memory information for a cursor-referenced tree's history store page.
+ */
+int
+__wt_debug_layered_cursor_tree_hs(void *cursor_arg, const char *ofile)
+  WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
+{
+    const WT_CURSOR *cursor = (const WT_CURSOR *)cursor_arg;
+    WT_UNUSED(ofile);
+
+    __wt_verbose_debug1(
+      CUR2S(cursor), WT_VERB_DEFAULT, "%s: unsupported cursor type for debug dump", cursor->uri);
+
+    return (0);
+}

--- a/src/cursor/cur_std.c
+++ b/src/cursor/cur_std.c
@@ -1559,6 +1559,29 @@ err:
 
 #ifdef HAVE_DIAGNOSTIC
 
+typedef int (*fn_debug_cursor)(void *, const char *);
+
+/*
+ * __cursor_debug_dispatch --
+ *     Dispatch a debug operation based on the cursor type.
+ */
+static int
+__cursor_debug_dispatch(void *cursor_arg, const char *ofile, fn_debug_cursor fn_btree,
+  fn_debug_cursor fn_layered) WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
+{
+    const WT_CURSOR *cursor = (const WT_CURSOR *)cursor_arg;
+
+    if (WT_PREFIX_MATCH(cursor->uri, "file:"))
+        WT_RET(fn_btree(cursor_arg, ofile));
+    else if (WT_PREFIX_MATCH(cursor->uri, "table:"))
+        WT_RET(fn_layered(cursor_arg, ofile));
+    else
+        __wt_verbose_debug1(CUR2S(cursor), WT_VERB_DEFAULT,
+          "%s: unsupported cursor type for debug dump", cursor->uri);
+
+    return (0);
+}
+
 /*
  * __wt_debug_cursor_page --
  *     Dump the in-memory information for a cursor-referenced page.
@@ -1567,17 +1590,20 @@ int
 __wt_debug_cursor_page(void *cursor_arg, const char *ofile)
   WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
 {
-    const WT_CURSOR *cursor = (const WT_CURSOR *)cursor_arg;
+    return (__cursor_debug_dispatch(
+      cursor_arg, ofile, __wt_debug_btree_cursor_page, __wt_debug_layered_cursor_page));
+}
 
-    if (WT_PREFIX_MATCH(cursor->uri, "file:"))
-        WT_RET(__wt_debug_btree_cursor_page(cursor_arg, ofile));
-    else if (WT_PREFIX_MATCH(cursor->uri, "table:"))
-        WT_RET(__wt_debug_layered_cursor_page(cursor_arg, ofile));
-    else
-        __wt_verbose_debug1(CUR2S(cursor), WT_VERB_DEFAULT,
-          "%s: unsupported cursor type for debug dump", cursor->uri);
-
-    return (0);
+/*
+ * __wt_debug_cursor_tree_hs --
+ *     Dump the history store tree given a user cursor.
+ */
+int
+__wt_debug_cursor_tree_hs(void *cursor_arg, const char *ofile)
+  WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
+{
+    return (__cursor_debug_dispatch(
+      cursor_arg, ofile, __wt_debug_btree_cursor_tree_hs, __wt_debug_layered_cursor_tree_hs));
 }
 
 #endif /* HAVE_DIAGNOSTIC */

--- a/src/cursor/cur_std.c
+++ b/src/cursor/cur_std.c
@@ -1556,3 +1556,28 @@ err:
     }
     return (ret);
 }
+
+#ifdef HAVE_DIAGNOSTIC
+
+/*
+ * __wt_debug_cursor_page --
+ *     Dump the in-memory information for a cursor-referenced page.
+ */
+int
+__wt_debug_cursor_page(void *cursor_arg, const char *ofile)
+  WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
+{
+    const WT_CURSOR *cursor = (const WT_CURSOR *)cursor_arg;
+
+    if (WT_STRING_MATCH(cursor->uri, "file:", strlen("file:")))
+        WT_RET(__wt_debug_btree_cursor_page(cursor_arg, ofile));
+    else if (WT_STRING_MATCH(cursor->uri, "table:", strlen("table:")))
+        WT_RET(__wt_debug_layered_cursor_page(cursor_arg, ofile));
+    else
+        __wt_verbose_debug1(CUR2S(cursor), WT_VERB_DEFAULT,
+          "%s: unsupported cursor type for debug dump", cursor->uri);
+
+    return (0);
+}
+
+#endif /* HAVE_DIAGNOSTIC */

--- a/src/cursor/cur_std.c
+++ b/src/cursor/cur_std.c
@@ -1569,9 +1569,9 @@ __wt_debug_cursor_page(void *cursor_arg, const char *ofile)
 {
     const WT_CURSOR *cursor = (const WT_CURSOR *)cursor_arg;
 
-    if (WT_STRING_MATCH(cursor->uri, "file:", strlen("file:")))
+    if (WT_PREFIX_MATCH(cursor->uri, "file:"))
         WT_RET(__wt_debug_btree_cursor_page(cursor_arg, ofile));
-    else if (WT_STRING_MATCH(cursor->uri, "table:", strlen("table:")))
+    else if (WT_PREFIX_MATCH(cursor->uri, "table:"))
         WT_RET(__wt_debug_layered_cursor_page(cursor_arg, ofile));
     else
         __wt_verbose_debug1(CUR2S(cursor), WT_VERB_DEFAULT,

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -547,7 +547,13 @@ extern int __wt_debug_btree_cursor_tree_hs(void *cursor_arg, const char *ofile)
     WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_debug_cursor_page(void *cursor_arg, const char *ofile) WT_GCC_FUNC_DECL_ATTRIBUTE(
   (visibility("default"))) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_debug_cursor_tree_hs(void *cursor_arg, const char *ofile)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")))
+    WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_debug_layered_cursor_page(void *cursor_arg, const char *ofile)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")))
+    WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_debug_layered_cursor_tree_hs(void *cursor_arg, const char *ofile)
   WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")))
     WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_debug_offset(WT_SESSION_IMPL *session, wt_off_t offset, uint32_t size,

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -539,9 +539,15 @@ extern int __wt_debug_addr(WT_SESSION_IMPL *session, const uint8_t *addr, size_t
   const char *ofile) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_debug_addr_print(WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr_size)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_debug_btree_cursor_page(void *cursor_arg, const char *ofile)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")))
+    WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_debug_btree_cursor_tree_hs(void *cursor_arg, const char *ofile)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")))
+    WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_debug_cursor_page(void *cursor_arg, const char *ofile) WT_GCC_FUNC_DECL_ATTRIBUTE(
   (visibility("default"))) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_debug_cursor_tree_hs(void *cursor_arg, const char *ofile)
+extern int __wt_debug_layered_cursor_page(void *cursor_arg, const char *ofile)
   WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")))
     WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_debug_offset(WT_SESSION_IMPL *session, wt_off_t offset, uint32_t size,


### PR DESCRIPTION
This change prevents segmentation faults in `test/format` when disagg test attempts to dump a page.

Split `__wt_debug_cursor_page` into variants:
- `__wt_debug_btree_cursor_page` - classic mode
- `__wt_debug_layered_cursor_page` - disagg mode (effectively, noop)