### PR TITLE
WT-11456 format.sh: respect job count when timeout provided

### DIFF
--- a/test/format/format.sh
+++ b/test/format/format.sh
@@ -677,10 +677,10 @@ while :; do
 	# Check if the total number of jobs has been reached.
 	[[ $total_jobs -ne 0 ]] && [[ $count_jobs -ge $total_jobs ]] && quit=1
 
-	# Check if less than 60 seconds left on any timer. The goal is to avoid killing jobs that
+	# Check if less than 20 seconds left on any timer. The goal is to avoid killing jobs that
 	# haven't yet configured signal handlers, because we rely on handler output to determine
 	# their final status.
-	[[ $seconds -ne 0 ]] && [[ $(($seconds - $elapsed)) -lt 60 ]] && quit=1
+	[[ $seconds -ne 0 ]] && [[ $(($seconds - $elapsed)) -lt 20 ]] && quit=1
 
 	# Start another job if we're not quitting for any reason and the maximum number of jobs
 	# in parallel has not yet been reached.


### PR DESCRIPTION
The issue reproducer in WT-11456 is as follows:

    ./format.sh -j $(nproc --all) -t 1

Where the number of jobs is greater than one, and the timeout is one minute.

Before this change, the script would quit when less than 60 seconds remained on the timer. With `-t 1` (60 seconds), this exit condition is met immediately at startup, preventing additional jobs from starting regardless of the `-j` parameter.

60 seconds is an overly generous time for the last job to start and configure its signal handler, so reduce it to 20 seconds. This means that when the timeout is one minute, it allows 60 - 20 = 40 seconds for all jobs to be created.