### PR TITLE
WT-16020 Fix the stats report race for the extlist bytes field

### DIFF
--- a/src/block/block_ext.c
+++ b/src/block/block_ext.c
@@ -975,7 +975,8 @@ __wti_block_extlist_merge(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_EXTLIST 
     if (a->track_size == b->track_size && a->entries > b->entries) {
         tmp = *a;
         a->bytes = b->bytes;
-        b->bytes = tmp.bytes;
+        /* This assignment can run concurrently with `block_reuse_bytes` stats collection. */
+        __wt_atomic_store_uint64_relaxed(&b->bytes, tmp.bytes);
         a->entries = b->entries;
         b->entries = tmp.entries;
         for (i = 0; i < WT_SKIP_MAXDEPTH; i++) {


### PR DESCRIPTION
The PR fixes the following race reported by TSAN:


<details>
  <summary>Warning text</summary>

```
WARNING: ThreadSanitizer: data race (pid=40087)
Write of size 8 at 0x7270000171b8 by thread T12 (mutexes: write M0, write M1, write M2):
#0 __wti_block_extlist_merge /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/block/block_ext.c:978 (libwiredtiger.so.12.0.0+0x6b9ea)
#1 __wt_block_checkpoint_resolve /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/block/block_ckpt.c:1066 (libwiredtiger.so.12.0.0+0x51ad7)
#2 __bm_checkpoint_resolve /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/block_cache/block_mgr.c:269 (libwiredtiger.so.12.0.0+0xaad61)
#3 __meta_track_apply /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/meta/meta_track.c:146 (libwiredtiger.so.12.0.0+0x5a884d)
#4 __wt_meta_track_off /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/meta/meta_track.c:319 (libwiredtiger.so.12.0.0+0x5a74b3)
#5 __checkpoint_db_internal /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/checkpoint/checkpoint_txn.c:1631 (libwiredtiger.so.12.0.0+0x2fbcc8)
#6 __checkpoint_db_wrapper /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/checkpoint/checkpoint_txn.c:1745 (libwiredtiger.so.12.0.0+0x2f3116)
#7 __wt_checkpoint_db /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/checkpoint/checkpoint_txn.c:1824 (libwiredtiger.so.12.0.0+0x2f275f)
#8 __compact_checkpoint /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/session/session_compact.c:278 (libwiredtiger.so.12.0.0+0x756e52)
#9 __compact_worker /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/session/session_compact.c:365 (libwiredtiger.so.12.0.0+0x755325)
#10 __wti_session_compact /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/session/session_compact.c:518 (libwiredtiger.so.12.0.0+0x7520d6)
#11 __background_compact_server /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/conn/conn_compact.c:654 (libwiredtiger.so.12.0.0+0x3596e9)
#12 <null> <null> (libtsan.so.2+0x4eaf9) (BuildId: 0e59ee62729803eb7d2dd8c4ccba16ef40d8a633)
Previous atomic read of size 8 at 0x7270000171b8 by main thread (mutexes: write M3):
#0 __wt_atomic_load_uint64_relaxed /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/include/gcc.h:374 (libwiredtiger.so.12.0.0+0x7568b)
#1 __wt_block_stat /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/block/block_open.c:470 (libwiredtiger.so.12.0.0+0x7556b)
#2 __bm_stat /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/block_cache/block_mgr.c:658 (libwiredtiger.so.12.0.0+0xabbd8)
#3 __wt_btree_stat_init /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/btree/bt_stat.c:34 (libwiredtiger.so.12.0.0+0x23081d)
#4 __curstat_file_init /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/cursor/cur_stat.c:515 (libwiredtiger.so.12.0.0+0x47ab5e)
#5 __wt_curstat_init /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/cursor/cur_stat.c:602 (libwiredtiger.so.12.0.0+0x47a1a6)
#6 __wt_curstat_colgroup_init /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/schema/schema_stat.c:27 (libwiredtiger.so.12.0.0+0x6ff6f8)
#7 __wt_curstat_init /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/cursor/cur_stat.c:600 (libwiredtiger.so.12.0.0+0x47a129)
#8 __wt_curstat_table_init /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/schema/schema_stat.c:160 (libwiredtiger.so.12.0.0+0x6ffe9f)
#9 __wt_curstat_init /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/cursor/cur_stat.c:608 (libwiredtiger.so.12.0.0+0x47a319)
#10 __wt_curstat_open /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/cursor/cur_stat.c:760 (libwiredtiger.so.12.0.0+0x47c492)
#11 __session_open_cursor_int /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/session/session_api.c:723 (libwiredtiger.so.12.0.0+0x70c977)
#12 __session_open_cursor /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/session/session_api.c:904 (libwiredtiger.so.12.0.0+0x710423)
#13 _wrap_Session_open_cursor lang/python/CMakeFiles/wiredtiger_python.dir/wiredtigerPYTHON_wrap.c:6111 (_wiredtiger.so+0x254f7)
#14 cfunction_call ../src/Python-3.10.4/Objects/methodobject.c:552 (libpython3.10.so.1.0+0x13ca57) (BuildId: 41f1903bec218f8017b90255aaeb46526c3ef6ff)
Location is heap block of size 1912 at 0x727000017000 allocated by main thread:
#0 calloc <null> (libtsan.so.2+0x5439e) (BuildId: 0e59ee62729803eb7d2dd8c4ccba16ef40d8a633)
#1 __wt_calloc /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/os_common/os_alloc.c:68 (libwiredtiger.so.12.0.0+0x5bac44)
#2 __wt_block_open /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/block/block_open.c:201 (libwiredtiger.so.12.0.0+0x72f0c)
#3 __wt_blkcache_open /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/block_cache/block_cache.c:817 (libwiredtiger.so.12.0.0+0x8d27e)
#4 __wt_btree_open /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/btree/bt_handle.c:129 (libwiredtiger.so.12.0.0+0x172195)
#5 __wt_conn_dhandle_open /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/conn/conn_dhandle.c:624 (libwiredtiger.so.12.0.0+0x3621d7)
#6 __wt_session_get_dhandle /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/session/session_dhandle.c:949 (libwiredtiger.so.12.0.0+0x75e249)
#7 __create_file /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/schema/schema_create.c:307 (libwiredtiger.so.12.0.0+0x6d88de)
#8 __schema_create /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/schema/schema_create.c:1534 (libwiredtiger.so.12.0.0+0x6d57a7)
#9 __wt_schema_create /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/schema/schema_create.c:1594 (libwiredtiger.so.12.0.0+0x6d4fbe)
#10 __create_colgroup /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/schema/schema_create.c:620 (libwiredtiger.so.12.0.0+0x6d74be)
#11 __create_table /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/schema/schema_create.c:980 (libwiredtiger.so.12.0.0+0x6dc307)
#12 __schema_create /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/schema/schema_create.c:1542 (libwiredtiger.so.12.0.0+0x6d589f)
#13 __wt_schema_create /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/schema/schema_create.c:1594 (libwiredtiger.so.12.0.0+0x6d4fbe)
#14 __wt_session_create /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/session/session_api.c:1105 (libwiredtiger.so.12.0.0+0x70d50c)
#15 __session_create /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/session/session_api.c:1147 (libwiredtiger.so.12.0.0+0x71918a)
#16 _wrap_Session_create lang/python/CMakeFiles/wiredtiger_python.dir/wiredtigerPYTHON_wrap.c:6403 (_wiredtiger.so+0x2630c)
#17 cfunction_call ../src/Python-3.10.4/Objects/methodobject.c:552 (libpython3.10.so.1.0+0x13ca57) (BuildId: 41f1903bec218f8017b90255aaeb46526c3ef6ff)
Mutex M0 (0x7f3d465a10a8) created at:
#0 pthread_mutex_init <null> (libtsan.so.2+0x5811f) (BuildId: 0e59ee62729803eb7d2dd8c4ccba16ef40d8a633)
#1 __wt_spin_init /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/include/mutex_inline.h:142 (libwiredtiger.so.12.0.0+0x748fd1)
#2 __open_session /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/session/session_api.c:2593 (libwiredtiger.so.12.0.0+0x712124)
#3 __wt_open_session /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/session/session_api.c:2716 (libwiredtiger.so.12.0.0+0x7118d8)
#4 __wt_open_internal_session /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/session/session_api.c:2750 (libwiredtiger.so.12.0.0+0x712fe3)
#5 __wti_background_compact_server_create /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/conn/conn_compact.c:744 (libwiredtiger.so.12.0.0+0x358664)
#6 __wti_connection_workers /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/conn/conn_open.c:305 (libwiredtiger.so.12.0.0+0x3896bd)
#7 wiredtiger_open /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/conn/conn_api.c:3436 (libwiredtiger.so.12.0.0+0x32c71b)
#8 _wrap_wiredtiger_open lang/python/CMakeFiles/wiredtiger_python.dir/wiredtigerPYTHON_wrap.c:9560 (_wiredtiger.so+0x2ffda)
#9 cfunction_call ../src/Python-3.10.4/Objects/methodobject.c:552 (libpython3.10.so.1.0+0x13ca57) (BuildId: 41f1903bec218f8017b90255aaeb46526c3ef6ff)
Mutex M1 (0x729400165fc8) created at:
#0 pthread_mutex_init <null> (libtsan.so.2+0x5811f) (BuildId: 0e59ee62729803eb7d2dd8c4ccba16ef40d8a633)
#1 __wt_spin_init /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/include/mutex_inline.h:142 (libwiredtiger.so.12.0.0+0x36bce1)
#2 __wti_connection_init /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/conn/conn_handle.c:50 (libwiredtiger.so.12.0.0+0x36a776)
#3 wiredtiger_open /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/conn/conn_api.c:3026 (libwiredtiger.so.12.0.0+0x328033)
#4 _wrap_wiredtiger_open lang/python/CMakeFiles/wiredtiger_python.dir/wiredtigerPYTHON_wrap.c:9560 (_wiredtiger.so+0x2ffda)
#5 cfunction_call ../src/Python-3.10.4/Objects/methodobject.c:552 (libpython3.10.so.1.0+0x13ca57) (BuildId: 41f1903bec218f8017b90255aaeb46526c3ef6ff)
Mutex M2 (0x727000017080) created at:
#0 pthread_mutex_init <null> (libtsan.so.2+0x5811f) (BuildId: 0e59ee62729803eb7d2dd8c4ccba16ef40d8a633)
#1 __wt_spin_init /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/include/mutex_inline.h:142 (libwiredtiger.so.12.0.0+0x740b1)
#2 __wt_block_open /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/block/block_open.c:268 (libwiredtiger.so.12.0.0+0x736f8)
#3 __wt_blkcache_open /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/block_cache/block_cache.c:817 (libwiredtiger.so.12.0.0+0x8d27e)
#4 __wt_btree_open /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/btree/bt_handle.c:129 (libwiredtiger.so.12.0.0+0x172195)
#5 __wt_conn_dhandle_open /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/conn/conn_dhandle.c:624 (libwiredtiger.so.12.0.0+0x3621d7)
#6 __wt_session_get_dhandle /data/mci/e089564ec3a9e4f6350cc14aa6a0eb14/wiredtiger/src/session/session_dhandle.c:949 (libwiredtiger.so.12.0.0+0x75e249)
#7 __create_file /data/mci/e089564ec3a9e4f6350
```

</details>

Since the race is happening between the assignment and the stats collection it's fine to use relaxed ordering.