### PR TITLE
WT-16521 Loosen the log files count check

### DIFF
--- a/test/suite/test_log05.py
+++ b/test/suite/test_log05.py
@@ -94,4 +94,5 @@ class test_log05(wttest.WiredTigerTestCase):
                 logs_count += 1
 
         # This assert aims to make sure no redundant log file is generated.
+        # Due to log file rotation timing, two log files may temporarily coexist.
         self.assertLessEqual(logs_count, 2, "We should have at most 2 log files")

--- a/test/suite/test_log05.py
+++ b/test/suite/test_log05.py
@@ -94,4 +94,4 @@ class test_log05(wttest.WiredTigerTestCase):
                 logs_count += 1
 
         # This assert aims to make sure no redundant log file is generated.
-        self.assertLessEqual(logs_count, 1, "We should have at most 1 log file")
+        self.assertLessEqual(logs_count, 2, "We should have at most 2 log files")


### PR DESCRIPTION
Relax the log file count assertion to tolerate rare race conditions. Limiting the system to at most one log file is not a strict design guarantee. The primary objective of this test is to prevent unbounded disk usage growth, and allowing this flexibility does not compromise that intent.