### PR TITLE
WT-16641 bytes_total leak in disagg during 1-for-1 page swap

### DIFF
--- a/src/block_disagg/block_disagg_addr.c
+++ b/src/block_disagg/block_disagg_addr.c
@@ -128,12 +128,12 @@ __wti_block_disagg_addr_pack(
 }
 
 /*
- * __wti_block_disagg_addr_unpack --
+ * __wt_block_disagg_addr_unpack --
  *     Convert a disaggregated address cookie into its components UPDATING the caller's buffer
  *     reference.
  */
 int
-__wti_block_disagg_addr_unpack(WT_SESSION_IMPL *session, const uint8_t **buf, size_t buf_size,
+__wt_block_disagg_addr_unpack(WT_SESSION_IMPL *session, const uint8_t **buf, size_t buf_size,
   WT_BLOCK_DISAGG_ADDRESS_COOKIE *cookie)
 {
     uint64_t base_lsn, base_lsn_delta, debug_field, flags, lsn, page_id, size, unsupported_flags;
@@ -247,7 +247,7 @@ __wti_block_disagg_addr_invalid(WT_SESSION_IMPL *session, const uint8_t *addr, s
     WT_BLOCK_DISAGG_ADDRESS_COOKIE cookie;
 
     /* Crack the cookie - there aren't further checks for object blocks. */
-    WT_RET(__wti_block_disagg_addr_unpack(session, &addr, addr_size, &cookie));
+    WT_RET(__wt_block_disagg_addr_unpack(session, &addr, addr_size, &cookie));
 
     return (0);
 }
@@ -265,7 +265,7 @@ __wti_block_disagg_addr_string(
     WT_UNUSED(bm);
 
     /* Crack the cookie. */
-    WT_RET(__wti_block_disagg_addr_unpack(session, &addr, addr_size, &cookie));
+    WT_RET(__wt_block_disagg_addr_unpack(session, &addr, addr_size, &cookie));
 
     /* Printable representation. */
     WT_RET(__wt_buf_fmt(session, buf,
@@ -304,7 +304,7 @@ __wti_block_disagg_ckpt_unpack(WT_SESSION_IMPL *session, WT_BLOCK_DISAGG *block_
     WT_UNUSED(block_disagg);
 
     /* Retrieve the root page information */
-    WT_RET(__wti_block_disagg_addr_unpack(session, &buf, buf_size, root_cookie));
+    WT_RET(__wt_block_disagg_addr_unpack(session, &buf, buf_size, root_cookie));
 
     return (0);
 }

--- a/src/block_disagg/block_disagg_read.c
+++ b/src/block_disagg/block_disagg_read.c
@@ -26,7 +26,7 @@ __wti_block_disagg_corrupt(
     WT_ERR(__wti_block_disagg_read(bm, session, tmp, &block_meta, addr, addr_size));
 
     /* Crack the cookie, dump the block. */
-    WT_ERR(__wti_block_disagg_addr_unpack(session, &addr, addr_size, &root_cookie));
+    WT_ERR(__wt_block_disagg_addr_unpack(session, &addr, addr_size, &root_cookie));
     WT_ERR(__wt_bm_corrupt_dump(
       session, tmp, 0, (wt_off_t)root_cookie.page_id, root_cookie.size, root_cookie.checksum));
 
@@ -306,7 +306,7 @@ __wti_block_disagg_read_multiple(WT_BM *bm, WT_SESSION_IMPL *session,
     block_disagg = (WT_BLOCK_DISAGG *)bm->block;
 
     /* Crack the cookie. */
-    WT_RET(__wti_block_disagg_addr_unpack(session, &addr, addr_size, &cookie));
+    WT_RET(__wt_block_disagg_addr_unpack(session, &addr, addr_size, &cookie));
 
     /* Read the block. */
     WT_RET(

--- a/src/block_disagg/block_disagg_write.c
+++ b/src/block_disagg/block_disagg_write.c
@@ -258,11 +258,6 @@ __wti_block_disagg_write(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_ITEM *buf
     cookie.base_lsn = block_meta->base_lsn;
     cookie.checksum = checksum;
 
-    if (strstr(S2BT(session)->dhandle->name, "file:test_disagg_ckpt_size03.wt_stable") &&
-      block_meta->delta_count == 0) {
-        printf("break here 5\n");
-    }
-
     /* Calculate the cumulative size and store it in cookie.size. */
     if (block_meta->delta_count == 0)
         cookie.size = size;

--- a/src/block_disagg/block_disagg_write.c
+++ b/src/block_disagg/block_disagg_write.c
@@ -258,6 +258,10 @@ __wti_block_disagg_write(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_ITEM *buf
     cookie.base_lsn = block_meta->base_lsn;
     cookie.checksum = checksum;
 
+    if (strstr(S2BT(session)->dhandle->name, "file:test_disagg_ckpt_size03.wt_stable") && block_meta->delta_count == 0) {
+        printf("break here 5\n");
+    }
+
     /* Calculate the cumulative size and store it in cookie.size. */
     if (block_meta->delta_count == 0)
         cookie.size = size;

--- a/src/block_disagg/block_disagg_write.c
+++ b/src/block_disagg/block_disagg_write.c
@@ -258,7 +258,8 @@ __wti_block_disagg_write(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_ITEM *buf
     cookie.base_lsn = block_meta->base_lsn;
     cookie.checksum = checksum;
 
-    if (strstr(S2BT(session)->dhandle->name, "file:test_disagg_ckpt_size03.wt_stable") && block_meta->delta_count == 0) {
+    if (strstr(S2BT(session)->dhandle->name, "file:test_disagg_ckpt_size03.wt_stable") &&
+      block_meta->delta_count == 0) {
         printf("break here 5\n");
     }
 
@@ -288,7 +289,7 @@ __wti_block_disagg_page_discard(
 {
     /* Crack the cookie. */
     WT_BLOCK_DISAGG_ADDRESS_COOKIE cookie;
-    WT_RET(__wti_block_disagg_addr_unpack(session, &addr, addr_size, &cookie));
+    WT_RET(__wt_block_disagg_addr_unpack(session, &addr, addr_size, &cookie));
 
     __wt_verbose(session, WT_VERB_BLOCK,
       "block free: page_id %" PRIu64 ", flags %" PRIx64 ", lsn %" PRIu64 ", base_lsn %" PRIu64

--- a/src/block_disagg/block_disagg_write.c
+++ b/src/block_disagg/block_disagg_write.c
@@ -213,7 +213,7 @@ __wti_block_disagg_write_internal(WT_SESSION_IMPL *session, WT_BLOCK_DISAGG *blo
     *checksump = checksum;
 
     /* Update the btree's running total of bytes. */
-    (void)__wt_atomic_add_uint64(&btree->bytes_total, *sizep);
+    __wt_btree_increase_size(session, *sizep);
 
     return (0);
 }
@@ -298,7 +298,7 @@ __wti_block_disagg_page_discard(
      * Decrement the btree's running total of bytes. The cookie.size field represents the cumulative
      * size of the block chain (base + deltas).
      */
-    (void)__wt_atomic_sub_uint64(&S2BT(session)->bytes_total, cookie.size);
+    __wt_btree_decrease_size(session, cookie.size);
 
     /* Ignore the call if the function is not implemented. */
     if (plhandle->plh_discard == NULL) {

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -800,7 +800,7 @@ __btree_conf(WT_SESSION_IMPL *session, WT_CKPT *ckpt, bool is_ckpt)
 
     /* Load the total bytes for disaggregated storage. */
     if (__wt_conn_is_disagg(session))
-        btree->bytes_total = ckpt->size;
+        __wt_btree_set_size(session, ckpt->size);
 
     /*
      * We've just overwritten the runtime write generation based off the fact that know that we're

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -1745,9 +1745,6 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
         db = conn->disaggregated_storage.database_size;
         delta = session->ckpt.ckpt_size_delta;
 
-        printf("Database size before: %" PRIu64 "\n", db);
-        printf("Delta: %" PRIi64 "\n", delta);
-
         if (delta > 0) {
             WT_ASSERT_ALWAYS(session, UINT64_MAX - db >= (uint64_t)delta,
               "Disaggregated storage database size too large");
@@ -1757,7 +1754,6 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
               session, db >= (uint64_t)(-delta), "Disaggregated storage database size too small");
             conn->disaggregated_storage.database_size = db - (uint64_t)(-delta);
         }
-        printf("Database size after: %" PRIu64 "\n", conn->disaggregated_storage.database_size);
     }
     WT_STAT_CONN_INCR(session, checkpoints_total_succeed);
 

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -1746,12 +1746,10 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
         delta = session->ckpt.ckpt_size_delta;
 
         if (delta > 0) {
-            WT_ASSERT_ALWAYS(session, UINT64_MAX - db >= (uint64_t)delta,
-              "Disaggregated storage database size too large");
+            WT_ASSERT(session, UINT64_MAX - db >= (uint64_t)delta);
             conn->disaggregated_storage.database_size = db + (uint64_t)delta;
         } else {
-            WT_ASSERT_ALWAYS(
-              session, db >= (uint64_t)(-delta), "Disaggregated storage database size too small");
+            WT_ASSERT(session, db >= (uint64_t)(-delta));
             conn->disaggregated_storage.database_size = db - (uint64_t)(-delta);
         }
     }

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -1745,6 +1745,9 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
         db = conn->disaggregated_storage.database_size;
         delta = session->ckpt.ckpt_size_delta;
 
+        printf("Database size before: %" PRIu64 "\n", db);
+        printf("Delta: %" PRIi64 "\n", delta);
+
         if (delta > 0) {
             WT_ASSERT_ALWAYS(session, UINT64_MAX - db >= (uint64_t)delta,
               "Disaggregated storage database size too large");
@@ -1754,6 +1757,7 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
               session, db >= (uint64_t)(-delta), "Disaggregated storage database size too small");
             conn->disaggregated_storage.database_size = db - (uint64_t)(-delta);
         }
+        printf("Database size after: %" PRIu64 "\n", conn->disaggregated_storage.database_size);
     }
     WT_STAT_CONN_INCR(session, checkpoints_total_succeed);
 

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -290,6 +290,45 @@ __wt_btree_shared(WT_SESSION_IMPL *session, const char *uri, const char **bt_cfg
 }
 
 /*
+ * __wt_btree_set_size --
+ *     Set the size of the tree.
+ */
+static WT_INLINE void
+__wt_btree_set_size(WT_SESSION_IMPL *session, uint64_t size)
+{
+    printf("Setting btree %s to size %" PRIu64 "\n", S2BT(session)->dhandle->name, size);
+    (void)__wt_atomic_store_uint64(&S2BT(session)->bytes_total, size);
+}
+
+/*
+ * __wt_btree_increase_size --
+ *     Increase the size of the tree.
+ */
+static WT_INLINE void
+__wt_btree_increase_size(WT_SESSION_IMPL *session, uint64_t size)
+{
+    if (strstr(S2BT(session)->dhandle->name, "file:WiredTigerShared.wt_stable")) {
+        printf("break here 2\n");
+    }
+    printf("Increasing btree %s by %" PRIu64 "\n", S2BT(session)->dhandle->name, size);
+    (void)__wt_atomic_add_uint64(&S2BT(session)->bytes_total, size);
+}
+
+/*
+ * __wt_btree_decrease_size --
+ *     Decrease the size of the tree.
+ */
+static WT_INLINE void
+__wt_btree_decrease_size(WT_SESSION_IMPL *session, uint64_t size)
+{
+    if (strstr(S2BT(session)->dhandle->name, "file:WiredTigerShared.wt_stable")) {
+        printf("break here\n");
+    }
+    printf("Decreasing btree %s by %" PRIu64 "\n", S2BT(session)->dhandle->name, size);
+    (void)__wt_atomic_sub_uint64(&S2BT(session)->bytes_total, size);
+}
+
+/*
  * __wt_btree_shared_base_name --
  *     Given a tree's URI, break it down into its base name, in a returned buffer, and the
  *     checkpoint id string.

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -296,7 +296,6 @@ __wt_btree_shared(WT_SESSION_IMPL *session, const char *uri, const char **bt_cfg
 static WT_INLINE void
 __wt_btree_set_size(WT_SESSION_IMPL *session, uint64_t size)
 {
-    printf("Setting btree %s to size %" PRIu64 "\n", S2BT(session)->dhandle->name, size);
     (void)__wt_atomic_store_uint64(&S2BT(session)->bytes_total, size);
 }
 
@@ -307,10 +306,6 @@ __wt_btree_set_size(WT_SESSION_IMPL *session, uint64_t size)
 static WT_INLINE void
 __wt_btree_increase_size(WT_SESSION_IMPL *session, uint64_t size)
 {
-    if (strstr(S2BT(session)->dhandle->name, "file:test_disagg_ckpt_size03.wt_stable")) {
-        printf("break here 2\n");
-    }
-    printf("Increasing btree %s by %" PRIu64 "\n", S2BT(session)->dhandle->name, size);
     (void)__wt_atomic_add_uint64(&S2BT(session)->bytes_total, size);
 }
 
@@ -321,10 +316,6 @@ __wt_btree_increase_size(WT_SESSION_IMPL *session, uint64_t size)
 static WT_INLINE void
 __wt_btree_decrease_size(WT_SESSION_IMPL *session, uint64_t size)
 {
-    if (strstr(S2BT(session)->dhandle->name, "file:test_disagg_ckpt_size03.wt_stable")) {
-        printf("break here\n");
-    }
-    printf("Decreasing btree %s by %" PRIu64 "\n", S2BT(session)->dhandle->name, size);
     (void)__wt_atomic_sub_uint64(&S2BT(session)->bytes_total, size);
 }
 

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -307,7 +307,7 @@ __wt_btree_set_size(WT_SESSION_IMPL *session, uint64_t size)
 static WT_INLINE void
 __wt_btree_increase_size(WT_SESSION_IMPL *session, uint64_t size)
 {
-    if (strstr(S2BT(session)->dhandle->name, "file:WiredTigerShared.wt_stable")) {
+    if (strstr(S2BT(session)->dhandle->name, "file:test_disagg_ckpt_size03.wt_stable")) {
         printf("break here 2\n");
     }
     printf("Increasing btree %s by %" PRIu64 "\n", S2BT(session)->dhandle->name, size);
@@ -321,7 +321,7 @@ __wt_btree_increase_size(WT_SESSION_IMPL *session, uint64_t size)
 static WT_INLINE void
 __wt_btree_decrease_size(WT_SESSION_IMPL *session, uint64_t size)
 {
-    if (strstr(S2BT(session)->dhandle->name, "file:WiredTigerShared.wt_stable")) {
+    if (strstr(S2BT(session)->dhandle->name, "file:test_disagg_ckpt_size03.wt_stable")) {
         printf("break here\n");
     }
     printf("Decreasing btree %s by %" PRIu64 "\n", S2BT(session)->dhandle->name, size);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2390,7 +2390,10 @@ static WT_INLINE uint64_t __wt_txn_oldest_id(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE void __wt_block_header_byteswap(WT_BLOCK_HEADER *blk);
 static WT_INLINE void __wt_block_header_byteswap_copy(WT_BLOCK_HEADER *from, WT_BLOCK_HEADER *to);
+static WT_INLINE void __wt_btree_decrease_size(WT_SESSION_IMPL *session, uint64_t size);
 static WT_INLINE void __wt_btree_disable_bulk(WT_SESSION_IMPL *session);
+static WT_INLINE void __wt_btree_increase_size(WT_SESSION_IMPL *session, uint64_t size);
+static WT_INLINE void __wt_btree_set_size(WT_SESSION_IMPL *session, uint64_t size);
 static WT_INLINE void __wt_buf_free(WT_SESSION_IMPL *session, WT_ITEM *buf);
 static WT_INLINE void __wt_cache_decr_check_size(
   WT_SESSION_IMPL *session, size_t *vp, size_t v, const char *fld);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -171,6 +171,9 @@ extern int __wt_block_compact_skip(WT_SESSION_IMPL *session, WT_BLOCK *block, bo
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_block_compact_start(WT_SESSION_IMPL *session, WT_BLOCK *block)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_block_disagg_addr_unpack(WT_SESSION_IMPL *session, const uint8_t **buf,
+  size_t buf_size, WT_BLOCK_DISAGG_ADDRESS_COOKIE *cookie)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_block_disagg_manager_create(WT_SESSION_IMPL *session, WT_BUCKET_STORAGE *bstorage,
   const char *filename) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_block_disagg_manager_open(WT_SESSION_IMPL *session, const char *uri,
@@ -1235,9 +1238,6 @@ extern int __wti_block_disagg_addr_pack(WT_SESSION_IMPL *session, uint8_t **pp,
   const WT_BLOCK_DISAGG_ADDRESS_COOKIE *cookie) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_block_disagg_addr_string(WT_BM *bm, WT_SESSION_IMPL *session, WT_ITEM *buf,
   const uint8_t *addr, size_t addr_size) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wti_block_disagg_addr_unpack(WT_SESSION_IMPL *session, const uint8_t **buf,
-  size_t buf_size, WT_BLOCK_DISAGG_ADDRESS_COOKIE *cookie)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_block_disagg_checkpoint(WT_BM *bm, WT_SESSION_IMPL *session, WT_ITEM *root_image,
   WT_PAGE_BLOCK_META *block_meta, WT_CKPT *ckptbase, bool data_checksum)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2135,10 +2135,6 @@ __rec_write_delta(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_CHUNK *chu
     multi->block_meta->backlink_lsn = block_meta->disagg_lsn;
     ++multi->block_meta->delta_count;
 
-    if (strstr(S2BT(session)->dhandle->name, "file:test_disagg_ckpt_size03.wt_stable")) {
-        printf("break here 3\n");
-    }
-
     /* Get the checkpoint ID. */
     WT_RET(__wt_blkcache_write(session, &r->delta, multi->block_meta, chunk->image.size, addr,
       addr_sizep, compressed_sizep, false, F_ISSET(r, WT_REC_CHECKPOINT), false));
@@ -2964,11 +2960,7 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
                      * the one on the multi->block_meta appears to be from the current block.
                      */
                     if (r->multi->block_meta != NULL && r->multi->block_meta->delta_count == 0) {
-                        if (strstr(btree->dhandle->name,
-                              "file:test_disagg_ckpt_size03.wt_stable")) {
-                            printf("break here 4\n");
-                        }
-                        printf("Not freeing block cookie\n");
+
 #ifdef HAVE_DIAGNOSTIC
                         /*
                          * The previous cookie has the size we want but it should be also the

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2949,6 +2949,23 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
                     WT_RET(__wt_btree_block_free(
                       session, mod->mod_replace.block_cookie, mod->mod_replace.block_cookie_size));
                     page->disagg_info->block_meta.page_id = WT_BLOCK_INVALID_PAGE_ID;
+                } else {
+                    // Crack the cookie here and decrement the checkpoint size with the cookie size  
+                    /* Because we are tracking cookie sizes cumulatively, we only decrease the size
+                     * if the page being written is a full page image. 
+                     * This would indicate the delta chain has ended.
+                     */
+                    if (page->disagg_info != NULL && page->disagg_info->block_meta.delta_count == 0) {
+                        printf("Not freeing block cookie\n");
+                        WT_BLOCK_DISAGG_ADDRESS_COOKIE cookie;
+                        const uint8_t *buf = mod->mod_replace.block_cookie;
+                        WT_RET(__wti_block_disagg_addr_unpack(session,
+                            &buf,
+                            mod->mod_replace.block_cookie_size,
+                            &cookie));
+                        __wt_btree_decrease_size(session, cookie.size);
+                    }
+
                 }
             }
         }

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2959,7 +2959,8 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
                      * the one held on page->disagg_info appears to be from the previous block, and
                      * the one on the multi->block_meta appears to be from the current block.
                      */
-                    if (r->multi->block_meta != NULL && r->multi->block_meta->delta_count == 0) {
+                    if (r->multi->block_meta != NULL && r->multi->block_meta->delta_count == 0 &&
+                      !F_ISSET(r->multi, WT_MULTI_SKIP_WRITE)) {
 
 #ifdef HAVE_DIAGNOSTIC
                         /*

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2963,17 +2963,27 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
                      * the one held on page->disagg_info appears to be from the previous block, and
                      * the one on the multi->block_meta appears to be from the current block.
                      */
-                    if (r->multi->block_meta != NULL &&
-                      r->multi->block_meta->delta_count == 0) {
-                        if (strstr(S2BT(session)->dhandle->name, "file:test_disagg_ckpt_size03.wt_stable")) {
+                    if (r->multi->block_meta != NULL && r->multi->block_meta->delta_count == 0) {
+                        if (strstr(btree->dhandle->name,
+                              "file:test_disagg_ckpt_size03.wt_stable")) {
                             printf("break here 4\n");
                         }
                         printf("Not freeing block cookie\n");
+#ifdef HAVE_DIAGNOSTIC
+                        /*
+                         * The previous cookie has the size we want but it should be also the
+                         * previous cumulative size. Sanity check this is the case in diagnostics
+                         * build.
+                         */
                         WT_BLOCK_DISAGG_ADDRESS_COOKIE cookie;
                         const uint8_t *buf = mod->mod_replace.block_cookie;
-                        WT_RET(__wti_block_disagg_addr_unpack(
+                        WT_RET(__wt_block_disagg_addr_unpack(
                           session, &buf, mod->mod_replace.block_cookie_size, &cookie));
-                        __wt_btree_decrease_size(session, cookie.size);
+                        WT_ASSERT(
+                          session, cookie.size == page->disagg_info->block_meta.cumulative_size);
+#endif
+                        __wt_btree_decrease_size(
+                          session, page->disagg_info->block_meta.cumulative_size);
                     }
                 }
             }

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2135,6 +2135,10 @@ __rec_write_delta(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_CHUNK *chu
     multi->block_meta->backlink_lsn = block_meta->disagg_lsn;
     ++multi->block_meta->delta_count;
 
+    if (strstr(S2BT(session)->dhandle->name, "file:test_disagg_ckpt_size03.wt_stable")) {
+        printf("break here 3\n");
+    }
+
     /* Get the checkpoint ID. */
     WT_RET(__wt_blkcache_write(session, &r->delta, multi->block_meta, chunk->image.size, addr,
       addr_sizep, compressed_sizep, false, F_ISSET(r, WT_REC_CHECKPOINT), false));
@@ -2950,12 +2954,20 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
                       session, mod->mod_replace.block_cookie, mod->mod_replace.block_cookie_size));
                     page->disagg_info->block_meta.page_id = WT_BLOCK_INVALID_PAGE_ID;
                 } else {
-                    /* Because we are tracking cookie sizes cumulatively, we only decrease the size
-                     * if the page being written is a full page image.
-                     * This would indicate the delta chain has ended.
+                    /*
+                     * Because we are tracking cookie sizes cumulatively, we only decrease the size
+                     * if the page being written is a full page image. This would indicate the delta
+                     * chain has ended.
+                     *
+                     * Interestingly we need to make sure we utilize the newest block meta structure
+                     * the one held on page->disagg_info appears to be from the previous block, and
+                     * the one on the multi->block_meta appears to be from the current block.
                      */
-                    if (page->disagg_info != NULL &&
-                      page->disagg_info->block_meta.delta_count == 0) {
+                    if (r->multi->block_meta != NULL &&
+                      r->multi->block_meta->delta_count == 0) {
+                        if (strstr(S2BT(session)->dhandle->name, "file:test_disagg_ckpt_size03.wt_stable")) {
+                            printf("break here 4\n");
+                        }
                         printf("Not freeing block cookie\n");
                         WT_BLOCK_DISAGG_ADDRESS_COOKIE cookie;
                         const uint8_t *buf = mod->mod_replace.block_cookie;

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2950,22 +2950,19 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
                       session, mod->mod_replace.block_cookie, mod->mod_replace.block_cookie_size));
                     page->disagg_info->block_meta.page_id = WT_BLOCK_INVALID_PAGE_ID;
                 } else {
-                    // Crack the cookie here and decrement the checkpoint size with the cookie size  
                     /* Because we are tracking cookie sizes cumulatively, we only decrease the size
-                     * if the page being written is a full page image. 
+                     * if the page being written is a full page image.
                      * This would indicate the delta chain has ended.
                      */
-                    if (page->disagg_info != NULL && page->disagg_info->block_meta.delta_count == 0) {
+                    if (page->disagg_info != NULL &&
+                      page->disagg_info->block_meta.delta_count == 0) {
                         printf("Not freeing block cookie\n");
                         WT_BLOCK_DISAGG_ADDRESS_COOKIE cookie;
                         const uint8_t *buf = mod->mod_replace.block_cookie;
-                        WT_RET(__wti_block_disagg_addr_unpack(session,
-                            &buf,
-                            mod->mod_replace.block_cookie_size,
-                            &cookie));
+                        WT_RET(__wti_block_disagg_addr_unpack(
+                          session, &buf, mod->mod_replace.block_cookie_size, &cookie));
                         __wt_btree_decrease_size(session, cookie.size);
                     }
-
                 }
             }
         }

--- a/test/suite/test_disagg_checkpoint_size03.py
+++ b/test/suite/test_disagg_checkpoint_size03.py
@@ -109,27 +109,86 @@ class test_disagg_checkpoint_size03(wttest.WiredTigerTestCase):
 
     def test_bytes_total_leak_delta(self):  
         self.session.create(self.uri, 'key_format=S,value_format=S')
-        
-        # Write initial page with multiple keys  
-        c = self.session.open_cursor(self.uri)  
-        for i in range(10):  
-            c[f'key{i:02d}'] = f'value{i}'  
-        c.close()  
-        self.session.checkpoint()  
-        baseline = self.get_checkpoint_size()  
-        
-        # Multiple iterations updating existing keys to create deltas  
-        for cycle, ch in enumerate(['b', 'c', 'd', 'e', 'f'], start=1):  
-            c = self.session.open_cursor(self.uri)  
-            # Update existing keys instead of inserting new ones  
-            for i in range(0, 10, 2):  # Update every other key  
-                c[f'key{i:02d}'] = f'newvalue{cycle}{i}'  
-            c.close()  
-            self.session.checkpoint()  
+
+        # Write initial page with multiple keys
+        c = self.session.open_cursor(self.uri)
+        for i in range(10):
+            c[f'key{i:02d}'] = f'value{i}'
+        c.close()
+        self.session.checkpoint()
+        baseline = self.get_checkpoint_size()
+
+        # Track statistics across cycles
+        total_deltas = 0
+        total_full_pages = 0
+        sizes = [baseline]
+
+        # Multiple iterations: first create deltas, then force full page writes
+        for cycle, ch in enumerate(['b', 'c', 'd', 'e', 'f'], start=1):
+            c = self.session.open_cursor(self.uri)
+            # Update existing keys to create deltas
+            for i in range(0, 10, 2):
+                c[f'key{i:02d}'] = f'newvalue{cycle}{i}'
+            c.close()
+            self.session.checkpoint()
+
+            # Check statistics
+            stat_cursor = self.session.open_cursor('statistics:' + self.uri)
+            cycle_deltas = stat_cursor[stat.dsrc.rec_page_delta_leaf][2]
+            cycle_full_pages = stat_cursor[stat.dsrc.rec_page_full_image_leaf][2]
+            stat_cursor.close()
+
+            # Track cumulative counts
+            total_deltas = cycle_deltas
+            total_full_pages = cycle_full_pages
+
+            current_size = self.get_checkpoint_size()
+            sizes.append(current_size)
             
-            # Verify deltas were created  
-            stat_cursor = self.session.open_cursor('statistics:' + self.uri)  
-            delta_count = stat_cursor[stat.dsrc.rec_page_delta_leaf][2]  
-            stat_cursor.close()  
-            self.assertGreater(delta_count, 0,  
+            self.pr(f"Cycle {cycle}: deltas={cycle_deltas}, full_pages={cycle_full_pages}, size={current_size}")
+
+            # Verify we're creating deltas initially
+            if cycle <= 3:
+                self.assertGreater(cycle_deltas, 0,
+                    f"Cycle {cycle}: Expected leaf page deltas but got {cycle_deltas}")  
+
+        final = self.get_checkpoint_size()
+
+        # Report results
+        self.pr(f"Final: {final}, Baseline: {baseline}, multiple: {final/baseline:.1f}x")
+        self.pr(f"Total: {total_deltas} deltas, {total_full_pages} full pages written")
+
+        # Size should not grow excessively even with delta->full page transitions
+        self.assertLess(final, baseline * 2,
+            f"Size leak detected: baseline={baseline}, final={final} ({final/baseline:.1f}x). "
+            f"Check delta chain termination handling in rec_write.c")
+
+        # Verify we actually created deltas during the test
+        self.assertGreater(total_deltas, 0, "No deltas were created during test")
+
+    def test_bytes_total_leak_delta_normal_ops(self):
+        self.session.create(self.uri, 'key_format=S,value_format=S')
+
+        # Write initial page with multiple keys
+        c = self.session.open_cursor(self.uri)
+        for i in range(10):
+            c[f'key{i:02d}'] = f'value{i}'
+        c.close()
+        self.session.checkpoint()
+        baseline = self.get_checkpoint_size()
+
+        # Multiple iterations updating existing keys to create deltas
+        for cycle, ch in enumerate(['b', 'c', 'd', 'e', 'f'], start=1):
+            c = self.session.open_cursor(self.uri)
+            # Update existing keys instead of inserting new ones
+            for i in range(0, 10, 2):  # Update every other key
+                c[f'key{i:02d}'] = f'newvalue{cycle}{i}'
+            c.close()
+            self.session.checkpoint()
+
+            # Verify deltas were created
+            stat_cursor = self.session.open_cursor('statistics:' + self.uri)
+            delta_count = stat_cursor[stat.dsrc.rec_page_delta_leaf][2]
+            stat_cursor.close()
+            self.assertGreater(delta_count, 0,
                 f"Cycle {cycle}: Expected leaf page deltas but got {delta_count}")

--- a/test/suite/test_disagg_checkpoint_size03.py
+++ b/test/suite/test_disagg_checkpoint_size03.py
@@ -28,6 +28,7 @@
 
 import re, wttest
 from wiredtiger import stat
+import unittest
 from helper_disagg import DisaggConfigMixin, disagg_test_class
 
 # test_disagg_checkpoint_size03.py
@@ -36,7 +37,7 @@ from helper_disagg import DisaggConfigMixin, disagg_test_class
 class test_disagg_checkpoint_size03(wttest.WiredTigerTestCase):
 
     uri_base = "test_disagg_ckpt_size03"
-    conn_config = 'disaggregated=(role="leader",lose_all_my_data=true), page_delta=(delta_pct=100,internal_page_delta=true,leaf_page_delta=true)'
+    conn_config = 'disaggregated=(role="leader",lose_all_my_data=true), page_delta=(delta_pct=90,internal_page_delta=true,leaf_page_delta=true,max_consecutive_delta=5)'
     uri = "layered:" + uri_base
 
     def conn_extensions(self, extlist):
@@ -48,11 +49,11 @@ class test_disagg_checkpoint_size03(wttest.WiredTigerTestCase):
         mc = self.session.open_cursor('metadata:')
         mc.set_key(stable_uri)
         mc.search()
-        self.pr(f"Metadata: {mc.get_value()}")
         size = int(re.findall(r',size=(\d+),', mc.get_value())[-1])
         mc.close()
         return size
 
+    @unittest.skip("Skipping test_bytes_total_leak")   
     def test_bytes_total_leak(self):
         self.session.create(self.uri, 'key_format=S,value_format=S')
         nrows = 1
@@ -73,7 +74,7 @@ class test_disagg_checkpoint_size03(wttest.WiredTigerTestCase):
         # Rewrite every row three times, checkpointing each time.
         # Each cycle rewrites all leaf, internal, and root pages.
         # for cycle, ch in enumerate(['b', 'c', 'd', 'e', 'f'], start=1):
-        for cycle, ch in enumerate(['b', 'c', 'd', 'e', 'f'], start=1):
+        for cycle, ch in enumerate(['b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm'], start=1):
             c = self.session.open_cursor(self.uri)
             for i in range(nrows):
                 c[f'key{i:06d}'] = ch * val_size
@@ -116,15 +117,20 @@ class test_disagg_checkpoint_size03(wttest.WiredTigerTestCase):
             c[f'key{i:02d}'] = f'value{i}'
         c.close()
         self.session.checkpoint()
+
+        # The size of the first page we wrote + its root page.
         baseline = self.get_checkpoint_size()
 
         # Track statistics across cycles
         total_deltas = 0
         total_full_pages = 0
         sizes = [baseline]
+        expected_table_size = 0
+        prev_full_pages = 0 
+        cur_deltas = 0
 
         # Multiple iterations: first create deltas, then force full page writes
-        for cycle, ch in enumerate(['b', 'c', 'd', 'e', 'f'], start=1):
+        for cycle, ch in enumerate(['b', 'c', 'd', 'e', 'f', 'g', 'h'], start=1):#, 'h', 'i', 'j', 'k', 'l', 'm'], start=1):
             c = self.session.open_cursor(self.uri)
             # Update existing keys to create deltas
             for i in range(0, 10, 2):
@@ -140,32 +146,43 @@ class test_disagg_checkpoint_size03(wttest.WiredTigerTestCase):
 
             # Track cumulative counts
             total_deltas = cycle_deltas
+            if (cycle_full_pages != prev_full_pages):
+                self.pr(f"Cycle {cycle}: full pages changed from {prev_full_pages} to {cycle_full_pages}")
+                cur_deltas = 0
+            else:
+                cur_deltas += 1
+
+            
+            expected_table_size = baseline * (cur_deltas + 1)
             total_full_pages = cycle_full_pages
+            self.pr(f"Expected delta size: {expected_table_size} & cycle_deltas: {cycle_deltas}")
+
 
             current_size = self.get_checkpoint_size()
             sizes.append(current_size)
             
             self.pr(f"Cycle {cycle}: deltas={cycle_deltas}, full_pages={cycle_full_pages}, size={current_size}")
-
-            # Verify we're creating deltas initially
-            if cycle <= 3:
-                self.assertGreater(cycle_deltas, 0,
-                    f"Cycle {cycle}: Expected leaf page deltas but got {cycle_deltas}")  
+            prev_full_pages = cycle_full_pages
 
         final = self.get_checkpoint_size()
 
         # Report results
         self.pr(f"Final: {final}, Baseline: {baseline}, multiple: {final/baseline:.1f}x")
         self.pr(f"Total: {total_deltas} deltas, {total_full_pages} full pages written")
+        self.pr(f"Expected delta size: {expected_table_size}")
 
         # Size should not grow excessively even with delta->full page transitions
-        self.assertLess(final, baseline * 2,
+        # The final size should be less than the baseline + the expected delta size.
+        self.pr(f"Expected final size: {expected_table_size}")
+        self.assertLess(final, expected_table_size * 1.10,
             f"Size leak detected: baseline={baseline}, final={final} ({final/baseline:.1f}x). "
             f"Check delta chain termination handling in rec_write.c")
 
         # Verify we actually created deltas during the test
         self.assertGreater(total_deltas, 0, "No deltas were created during test")
 
+
+    @unittest.skip("Skipping test_bytes_total_leak_delta_normal_ops")   
     def test_bytes_total_leak_delta_normal_ops(self):
         self.session.create(self.uri, 'key_format=S,value_format=S')
 

--- a/test/suite/test_disagg_checkpoint_size03.py
+++ b/test/suite/test_disagg_checkpoint_size03.py
@@ -53,8 +53,11 @@ class test_disagg_checkpoint_size03(wttest.WiredTigerTestCase):
         mc.close()
         return size
 
-    @unittest.skip("Skipping test_bytes_total_leak")
+
+    # Reconfigure to the default delta_pct (20%) for this test. The class-level
+    # conn_config uses delta_pct=90 for the delta tests.
     def test_bytes_total_leak(self):
+        self.conn.reconfigure('page_delta=(delta_pct=20)')
         self.session.create(self.uri, 'key_format=S,value_format=S')
         nrows = 1
         val_size = 10
@@ -98,6 +101,11 @@ class test_disagg_checkpoint_size03(wttest.WiredTigerTestCase):
         # Report what type of writes occurred
         self.pr(f"Total: {delta_count} deltas, {full_page_count} full pages written")
 
+        # With delta_pct=20 and this workload (rewriting every row each cycle),
+        # no deltas should ever be emitted -- only full page images.
+        self.assertEqual(delta_count, 0,
+            f"Expected no deltas with delta_pct=20, but got {delta_count}")
+
         # The data volume hasn't changed  same nrows, same val_size.
         # The checkpoint size should stay near the baseline, not grow to ~3x.
         self.pr(f"Final: {final}, Baseline: {baseline}, multiple of baseline: {final/baseline:.1f}x")
@@ -108,6 +116,7 @@ class test_disagg_checkpoint_size03(wttest.WiredTigerTestCase):
             f"and disagg_free_block in __wt_ref_block_free().")
 
 
+    # Uses the class-level delta_pct=90 -- no reconfigure needed.
     def test_bytes_total_leak_delta(self):
         self.session.create(self.uri, 'key_format=S,value_format=S')
 
@@ -182,7 +191,7 @@ class test_disagg_checkpoint_size03(wttest.WiredTigerTestCase):
         self.assertGreater(total_deltas, 0, "No deltas were created during test")
 
 
-    @unittest.skip("Skipping test_bytes_total_leak_delta_normal_ops")
+    # Uses the class-level delta_pct=90 -- no reconfigure needed.
     def test_bytes_total_leak_delta_normal_ops(self):
         self.session.create(self.uri, 'key_format=S,value_format=S')
 

--- a/test/suite/test_disagg_checkpoint_size03.py
+++ b/test/suite/test_disagg_checkpoint_size03.py
@@ -53,7 +53,7 @@ class test_disagg_checkpoint_size03(wttest.WiredTigerTestCase):
         mc.close()
         return size
 
-    @unittest.skip("Skipping test_bytes_total_leak")   
+    @unittest.skip("Skipping test_bytes_total_leak")
     def test_bytes_total_leak(self):
         self.session.create(self.uri, 'key_format=S,value_format=S')
         nrows = 1
@@ -98,17 +98,17 @@ class test_disagg_checkpoint_size03(wttest.WiredTigerTestCase):
         # Report what type of writes occurred
         self.pr(f"Total: {delta_count} deltas, {full_page_count} full pages written")
 
-        # The data volume hasn't changed — same nrows, same val_size.
+        # The data volume hasn't changed  same nrows, same val_size.
         # The checkpoint size should stay near the baseline, not grow to ~3x.
         self.pr(f"Final: {final}, Baseline: {baseline}, multiple of baseline: {final/baseline:.1f}x")
         self.assertLess(final, baseline * 2,
             f"bytes_total is leaking: baseline={baseline}, after 3 rewrite cycles={final} "
             f"({final/baseline:.1f}x). Old disagg page blocks are not being freed during "
-            f"single-page reconciliation — see disagg_page_free_required in rec_write.c "
+            f"single-page reconciliation  see disagg_page_free_required in rec_write.c "
             f"and disagg_free_block in __wt_ref_block_free().")
 
 
-    def test_bytes_total_leak_delta(self):  
+    def test_bytes_total_leak_delta(self):
         self.session.create(self.uri, 'key_format=S,value_format=S')
 
         # Write initial page with multiple keys
@@ -126,7 +126,7 @@ class test_disagg_checkpoint_size03(wttest.WiredTigerTestCase):
         total_full_pages = 0
         sizes = [baseline]
         expected_table_size = 0
-        prev_full_pages = 0 
+        prev_full_pages = 0
         cur_deltas = 0
 
         # Multiple iterations: first create deltas, then force full page writes
@@ -152,7 +152,7 @@ class test_disagg_checkpoint_size03(wttest.WiredTigerTestCase):
             else:
                 cur_deltas += 1
 
-            
+
             expected_table_size = baseline * (cur_deltas + 1)
             total_full_pages = cycle_full_pages
             self.pr(f"Expected delta size: {expected_table_size} & cycle_deltas: {cycle_deltas}")
@@ -160,7 +160,7 @@ class test_disagg_checkpoint_size03(wttest.WiredTigerTestCase):
 
             current_size = self.get_checkpoint_size()
             sizes.append(current_size)
-            
+
             self.pr(f"Cycle {cycle}: deltas={cycle_deltas}, full_pages={cycle_full_pages}, size={current_size}")
             prev_full_pages = cycle_full_pages
 
@@ -182,7 +182,7 @@ class test_disagg_checkpoint_size03(wttest.WiredTigerTestCase):
         self.assertGreater(total_deltas, 0, "No deltas were created during test")
 
 
-    @unittest.skip("Skipping test_bytes_total_leak_delta_normal_ops")   
+    @unittest.skip("Skipping test_bytes_total_leak_delta_normal_ops")
     def test_bytes_total_leak_delta_normal_ops(self):
         self.session.create(self.uri, 'key_format=S,value_format=S')
 

--- a/test/suite/test_disagg_checkpoint_size03.py
+++ b/test/suite/test_disagg_checkpoint_size03.py
@@ -28,11 +28,11 @@
 
 import re, wttest
 from wiredtiger import stat
-import unittest
 from helper_disagg import DisaggConfigMixin, disagg_test_class
 
 # test_disagg_checkpoint_size03.py
-
+#   Test that the checkpoint size does not grow excessively due to a bytes_total
+#   leak in the disaggregated checkpoint code.
 @disagg_test_class
 class test_disagg_checkpoint_size03(wttest.WiredTigerTestCase):
 
@@ -53,7 +53,6 @@ class test_disagg_checkpoint_size03(wttest.WiredTigerTestCase):
         mc.close()
         return size
 
-
     # Reconfigure to the default delta_pct (20%) for this test. The class-level
     # conn_config uses delta_pct=90 for the delta tests.
     def test_bytes_total_leak(self):
@@ -70,13 +69,8 @@ class test_disagg_checkpoint_size03(wttest.WiredTigerTestCase):
         self.session.checkpoint()
         baseline = self.get_checkpoint_size()
 
-        # Track delta vs full page statistics
-        delta_count = 0
-        full_page_count = 0
-
         # Rewrite every row three times, checkpointing each time.
         # Each cycle rewrites all leaf, internal, and root pages.
-        # for cycle, ch in enumerate(['b', 'c', 'd', 'e', 'f'], start=1):
         for cycle, ch in enumerate(['b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm'], start=1):
             c = self.session.open_cursor(self.uri)
             for i in range(nrows):
@@ -84,25 +78,13 @@ class test_disagg_checkpoint_size03(wttest.WiredTigerTestCase):
             c.close()
             self.session.checkpoint()
 
-            # Check if this rewrite created a delta or full page
-            stat_cursor = self.session.open_cursor('statistics:' + self.uri)
-            cycle_deltas = stat_cursor[stat.dsrc.rec_page_delta_leaf][2]
-            cycle_full_pages = stat_cursor[stat.dsrc.rec_page_full_image_leaf][2]
-            stat_cursor.close()
-
-            # Track cumulative counts
-            delta_count = cycle_deltas
-            full_page_count = cycle_full_pages
-
-            self.pr(f"Cycle {cycle}: deltas={cycle_deltas}, full_pages={cycle_full_pages}")
-
         final = self.get_checkpoint_size()
 
-        # Report what type of writes occurred
-        self.pr(f"Total: {delta_count} deltas, {full_page_count} full pages written")
-
         # With delta_pct=20 and this workload (rewriting every row each cycle),
-        # no deltas should ever be emitted -- only full page images.
+        # no deltas should ever be emitted, only full page images.
+        stat_cursor = self.session.open_cursor('statistics:' + self.uri)
+        delta_count = stat_cursor[stat.dsrc.rec_page_delta_leaf][2]
+        stat_cursor.close()
         self.assertEqual(delta_count, 0,
             f"Expected no deltas with delta_pct=20, but got {delta_count}")
 
@@ -130,14 +112,6 @@ class test_disagg_checkpoint_size03(wttest.WiredTigerTestCase):
         # The size of the first page we wrote + its root page.
         baseline = self.get_checkpoint_size()
 
-        # Track statistics across cycles
-        total_deltas = 0
-        total_full_pages = 0
-        sizes = [baseline]
-        expected_table_size = 0
-        prev_full_pages = 0
-        cur_deltas = 0
-
         # Multiple iterations: first create deltas, then force full page writes
         for cycle, ch in enumerate(['b', 'c', 'd', 'e', 'f', 'g', 'h'], start=1):#, 'h', 'i', 'j', 'k', 'l', 'm'], start=1):
             c = self.session.open_cursor(self.uri)
@@ -147,49 +121,18 @@ class test_disagg_checkpoint_size03(wttest.WiredTigerTestCase):
             c.close()
             self.session.checkpoint()
 
-            # Check statistics
-            stat_cursor = self.session.open_cursor('statistics:' + self.uri)
-            cycle_deltas = stat_cursor[stat.dsrc.rec_page_delta_leaf][2]
-            cycle_full_pages = stat_cursor[stat.dsrc.rec_page_full_image_leaf][2]
-            stat_cursor.close()
-
-            # Track cumulative counts
-            total_deltas = cycle_deltas
-            if (cycle_full_pages != prev_full_pages):
-                self.pr(f"Cycle {cycle}: full pages changed from {prev_full_pages} to {cycle_full_pages}")
-                cur_deltas = 0
-            else:
-                cur_deltas += 1
-
-
-            expected_table_size = baseline * (cur_deltas + 1)
-            total_full_pages = cycle_full_pages
-            self.pr(f"Expected delta size: {expected_table_size} & cycle_deltas: {cycle_deltas}")
-
-
-            current_size = self.get_checkpoint_size()
-            sizes.append(current_size)
-
-            self.pr(f"Cycle {cycle}: deltas={cycle_deltas}, full_pages={cycle_full_pages}, size={current_size}")
-            prev_full_pages = cycle_full_pages
-
         final = self.get_checkpoint_size()
 
-        # Report results
-        self.pr(f"Final: {final}, Baseline: {baseline}, multiple: {final/baseline:.1f}x")
-        self.pr(f"Total: {total_deltas} deltas, {total_full_pages} full pages written")
-        self.pr(f"Expected delta size: {expected_table_size}")
-
-        # Size should not grow excessively even with delta->full page transitions
-        # The final size should be less than the baseline + the expected delta size.
-        self.pr(f"Expected final size: {expected_table_size}")
-        self.assertLess(final, expected_table_size * 1.10,
+        # Size should not grow excessively even with delta operations
+        self.assertLess(final, baseline * 2,
             f"Size leak detected: baseline={baseline}, final={final} ({final/baseline:.1f}x). "
             f"Check delta chain termination handling in rec_write.c")
 
         # Verify we actually created deltas during the test
+        stat_cursor = self.session.open_cursor('statistics:' + self.uri)
+        total_deltas = stat_cursor[stat.dsrc.rec_page_delta_leaf][2]
+        stat_cursor.close()
         self.assertGreater(total_deltas, 0, "No deltas were created during test")
-
 
     # Uses the class-level delta_pct=90 -- no reconfigure needed.
     def test_bytes_total_leak_delta_normal_ops(self):

--- a/test/suite/test_disagg_checkpoint_size03.py
+++ b/test/suite/test_disagg_checkpoint_size03.py
@@ -66,19 +66,36 @@ class test_disagg_checkpoint_size03(wttest.WiredTigerTestCase):
         self.session.checkpoint()
         baseline = self.get_checkpoint_size()
 
+        # Track delta vs full page statistics
+        delta_count = 0
+        full_page_count = 0
+
         # Rewrite every row three times, checkpointing each time.
         # Each cycle rewrites all leaf, internal, and root pages.
         # for cycle, ch in enumerate(['b', 'c', 'd', 'e', 'f'], start=1):
-
-        for cycle, ch in enumerate(['b', 'c'], start=1):
-            # self.pr(f"Before checkpoint {cycle}: Metadata: {self.get_checkpoint_size()}")
+        for cycle, ch in enumerate(['b', 'c', 'd', 'e', 'f'], start=1):
             c = self.session.open_cursor(self.uri)
             for i in range(nrows):
                 c[f'key{i:06d}'] = ch * val_size
             c.close()
             self.session.checkpoint()
 
+            # Check if this rewrite created a delta or full page
+            stat_cursor = self.session.open_cursor('statistics:' + self.uri)
+            cycle_deltas = stat_cursor[stat.dsrc.rec_page_delta_leaf][2]
+            cycle_full_pages = stat_cursor[stat.dsrc.rec_page_full_image_leaf][2]
+            stat_cursor.close()
+
+            # Track cumulative counts
+            delta_count = cycle_deltas
+            full_page_count = cycle_full_pages
+
+            self.pr(f"Cycle {cycle}: deltas={cycle_deltas}, full_pages={cycle_full_pages}")
+
         final = self.get_checkpoint_size()
+
+        # Report what type of writes occurred
+        self.pr(f"Total: {delta_count} deltas, {full_page_count} full pages written")
 
         # The data volume hasn't changed — same nrows, same val_size.
         # The checkpoint size should stay near the baseline, not grow to ~3x.

--- a/test/suite/test_disagg_checkpoint_size03.py
+++ b/test/suite/test_disagg_checkpoint_size03.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import re, wttest
+from wiredtiger import stat
+from helper_disagg import DisaggConfigMixin, disagg_test_class
+
+# test_disagg_checkpoint_size03.py
+
+@disagg_test_class
+class test_disagg_checkpoint_size03(wttest.WiredTigerTestCase):
+
+    uri_base = "test_disagg_ckpt_size03"
+    conn_config = 'disaggregated=(role="leader",lose_all_my_data=true), page_delta=(delta_pct=100,internal_page_delta=true,leaf_page_delta=true)'
+    uri = "layered:" + uri_base
+
+    def conn_extensions(self, extlist):
+        extlist.skip_if_missing = True
+        DisaggConfigMixin.conn_extensions(self, extlist)
+
+    def get_checkpoint_size(self):
+        stable_uri = f'file:{self.uri_base}.wt_stable'
+        mc = self.session.open_cursor('metadata:')
+        mc.set_key(stable_uri)
+        mc.search()
+        self.pr(f"Metadata: {mc.get_value()}")
+        size = int(re.findall(r',size=(\d+),', mc.get_value())[-1])
+        mc.close()
+        return size
+
+    def test_bytes_total_leak(self):
+        self.session.create(self.uri, 'key_format=S,value_format=S')
+        nrows = 1
+        val_size = 10
+
+        # Insert data and take the baseline checkpoint.
+        c = self.session.open_cursor(self.uri)
+        for i in range(nrows):
+            c[f'key{i:06d}'] = 'a' * val_size
+        c.close()
+        self.session.checkpoint()
+        baseline = self.get_checkpoint_size()
+
+        # Rewrite every row three times, checkpointing each time.
+        # Each cycle rewrites all leaf, internal, and root pages.
+        # for cycle, ch in enumerate(['b', 'c', 'd', 'e', 'f'], start=1):
+
+        for cycle, ch in enumerate(['b', 'c'], start=1):
+            # self.pr(f"Before checkpoint {cycle}: Metadata: {self.get_checkpoint_size()}")
+            c = self.session.open_cursor(self.uri)
+            for i in range(nrows):
+                c[f'key{i:06d}'] = ch * val_size
+            c.close()
+            self.session.checkpoint()
+
+        final = self.get_checkpoint_size()
+
+        # The data volume hasn't changed — same nrows, same val_size.
+        # The checkpoint size should stay near the baseline, not grow to ~3x.
+        self.pr(f"Final: {final}, Baseline: {baseline}, multiple of baseline: {final/baseline:.1f}x")
+        self.assertLess(final, baseline * 2,
+            f"bytes_total is leaking: baseline={baseline}, after 3 rewrite cycles={final} "
+            f"({final/baseline:.1f}x). Old disagg page blocks are not being freed during "
+            f"single-page reconciliation — see disagg_page_free_required in rec_write.c "
+            f"and disagg_free_block in __wt_ref_block_free().")
+
+
+    def test_bytes_total_leak_delta(self):  
+        self.session.create(self.uri, 'key_format=S,value_format=S')
+        
+        # Write initial page with multiple keys  
+        c = self.session.open_cursor(self.uri)  
+        for i in range(10):  
+            c[f'key{i:02d}'] = f'value{i}'  
+        c.close()  
+        self.session.checkpoint()  
+        baseline = self.get_checkpoint_size()  
+        
+        # Multiple iterations updating existing keys to create deltas  
+        for cycle, ch in enumerate(['b', 'c', 'd', 'e', 'f'], start=1):  
+            c = self.session.open_cursor(self.uri)  
+            # Update existing keys instead of inserting new ones  
+            for i in range(0, 10, 2):  # Update every other key  
+                c[f'key{i:02d}'] = f'newvalue{cycle}{i}'  
+            c.close()  
+            self.session.checkpoint()  
+            
+            # Verify deltas were created  
+            stat_cursor = self.session.open_cursor('statistics:' + self.uri)  
+            delta_count = stat_cursor[stat.dsrc.rec_page_delta_leaf][2]  
+            stat_cursor.close()  
+            self.assertGreater(delta_count, 0,  
+                f"Cycle {cycle}: Expected leaf page deltas but got {delta_count}")


### PR DESCRIPTION
Fix `bytes_total` leak during 1:1 page swaps by properly decrementing the size counter when old page versions are retained as part of disagg perf optimisations. In the `WT_PM_REC_REPLACE` path, we optimise 1:1 swaps by retaining old blocks instead of freeing them. This meant that `bytes_total` was only incremented during writes, never decremented during replacements.

This PR:

- Uses `page->disagg_info->block_meta.cumulative_size` for size, and sanity checks this by cracking the cookie and comparing to `cookie.size` under `HAVE_DIAGNOSTIC` flag.
- Decrement the size when blocks are not freed. When we do call free, it funnels down to `__wti_block_disagg_page_discard`, where it is properly decremented.
- `__wti_block_disagg_addr_unpack` -> `__wt_block_disagg_addr_unpack` , made public so that `s_all` stops complaining about this func being used outside the `block_disagg` module