### PR TITLE
WT-16634 Removed skip test in test_rollback_to_stable01

### DIFF
--- a/test/suite/test_rollback_to_stable01.py
+++ b/test/suite/test_rollback_to_stable01.py
@@ -72,8 +72,6 @@ class test_rollback_to_stable01(test_rollback_to_stable_base):
         return config
 
     def test_rollback_to_stable(self):
-        # FIXME-WT-14937: not working with disagg.
-        self.skipTest("page delta")
         nrows = 10000
 
         # Create a table.


### PR DESCRIPTION
Removed the skip condition from the test test_rollback_to_stable01 to ensure the test runs.