### PR TITLE
WT-16642 Evaluate wtperf/workgen for Disaggregated Storage and local cache-stuck simulations

### DIFF
--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -999,8 +999,8 @@ populate_thread(void *arg)
 
     /* Do bulk loads if populate is single-threaded. */
     cursor_config = NULL;
-    if (opts->populate_threads == 1 && !opts->index && opts->tiered_flush_interval == 0)
-        cursor_config = "bulk";
+    // if (opts->populate_threads == 1 && !opts->index && opts->tiered_flush_interval == 0)
+    //     cursor_config = "bulk";
 
     /* Create the cursors. */
     cursors = dcalloc(total_table_count, sizeof(WT_CURSOR *));


### PR DESCRIPTION

Summarize the reason behind this change (this might be the problem you're solving, or the context around the request) and the solution you have chosen.
