### PR TITLE
WT-16254 Disable reversed B-trees in disagg tests

### DIFF
--- a/test/format/CONFIG.disagg
+++ b/test/format/CONFIG.disagg
@@ -5,6 +5,7 @@
 backup=0
 background_compact=0
 block_cache=0
+btree.reverse=0
 checkpoint=on
 precise_checkpoint=1
 disagg.page_log=palite

--- a/test/format/CONFIG.disagg
+++ b/test/format/CONFIG.disagg
@@ -5,6 +5,7 @@
 backup=0
 background_compact=0
 block_cache=0
+# FIXME-WT-14738: Enable reverse collator once it is available for layered tables.
 btree.reverse=0
 checkpoint=on
 precise_checkpoint=1


### PR DESCRIPTION
Reversed B-trees require `collator=reverse` in the config, but this is not implemented for layered tables. See FIXME-WT-14738 comment in src/schema/schema_open.c.