### PR TITLE
WT-16667 Re-enable assert catching mismatch between cookie.size and delta chain

### DIFF
--- a/src/block_disagg/block_disagg_read.c
+++ b/src/block_disagg/block_disagg_read.c
@@ -273,8 +273,7 @@ corrupt:
     }
 
     /* The cumulative size from the cookie must match the sum of all individual block sizes. */
-    /* FIXME-WT-16667: Re-enable this assertion. */
-    WT_ASSERT(session, true);
+    WT_ASSERT(session, block_meta->cumulative_size == block_size_sum);
 
 err:
     time_stop = __wt_clock(session);


### PR DESCRIPTION
This change re-enables an assert that catches discrepancies between the delta chain and the cookie.size on read.