### PR TITLE
WT-16673 Address performance regression from in-memory databases changes

### DIFF
--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -573,12 +573,12 @@ __btree_conf(WT_SESSION_IMPL *session, WT_CKPT *ckpt, bool is_ckpt)
      * to the history store. Checkpoint will also skip this tree.
      */
     WT_RET(__wt_config_gets(session, cfg, "in_memory", &cval));
-    if (cval.val || F_ISSET(conn, WT_CONN_IN_MEMORY))
+    if (cval.val)
         F_SET(btree, WT_BTREE_IN_MEMORY);
     else
         F_CLR(btree, WT_BTREE_IN_MEMORY);
 
-    if (F_ISSET(btree, WT_BTREE_IN_MEMORY)) {
+    if (F_ISSET(conn, WT_CONN_IN_MEMORY) || F_ISSET(btree, WT_BTREE_IN_MEMORY)) {
         F_SET(btree, WT_BTREE_LOGGED);
         WT_RET(__wt_config_gets(session, cfg, "log.enabled", &cval));
         if (!cval.val)
@@ -1256,7 +1256,8 @@ __btree_page_sizes(WT_SESSION_IMPL *session)
      * items are stored on a different page within the same tree, which cannot be handled by
      * disaggregated storage.
      */
-    if (F_ISSET(btree, WT_BTREE_IN_MEMORY | WT_BTREE_DISAGGREGATED)) {
+    if (F_ISSET(conn, WT_CONN_IN_MEMORY) || F_ISSET(btree, WT_BTREE_IN_MEMORY) ||
+      F_ISSET(btree, WT_BTREE_DISAGGREGATED)) {
         btree->maxleafkey = WT_BTREE_MAX_OBJECT_SIZE;
         btree->maxleafvalue = WT_BTREE_MAX_OBJECT_SIZE;
         return (0);

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -573,12 +573,12 @@ __btree_conf(WT_SESSION_IMPL *session, WT_CKPT *ckpt, bool is_ckpt)
      * to the history store. Checkpoint will also skip this tree.
      */
     WT_RET(__wt_config_gets(session, cfg, "in_memory", &cval));
-    if (cval.val)
+    if (cval.val || F_ISSET(conn, WT_CONN_IN_MEMORY))
         F_SET(btree, WT_BTREE_IN_MEMORY);
     else
         F_CLR(btree, WT_BTREE_IN_MEMORY);
 
-    if (F_ISSET(conn, WT_CONN_IN_MEMORY) || F_ISSET(btree, WT_BTREE_IN_MEMORY)) {
+    if (WT_IS_BTREE_IN_MEMORY(conn, btree)) {
         F_SET(btree, WT_BTREE_LOGGED);
         WT_RET(__wt_config_gets(session, cfg, "log.enabled", &cval));
         if (!cval.val)
@@ -1256,8 +1256,7 @@ __btree_page_sizes(WT_SESSION_IMPL *session)
      * items are stored on a different page within the same tree, which cannot be handled by
      * disaggregated storage.
      */
-    if (F_ISSET(conn, WT_CONN_IN_MEMORY) || F_ISSET(btree, WT_BTREE_IN_MEMORY) ||
-      F_ISSET(btree, WT_BTREE_DISAGGREGATED)) {
+    if (WT_IS_BTREE_IN_MEMORY(conn, btree) || F_ISSET(btree, WT_BTREE_DISAGGREGATED)) {
         btree->maxleafkey = WT_BTREE_MAX_OBJECT_SIZE;
         btree->maxleafvalue = WT_BTREE_MAX_OBJECT_SIZE;
         return (0);

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -1094,7 +1094,8 @@ __wti_page_inmem_updates(WT_SESSION_IMPL *session, WT_REF *ref)
     WT_ASSERT(session, !F_ISSET(btree, WT_BTREE_READONLY));
 
     /* We don't handle in-memory prepare resolution here. */
-    WT_ASSERT(session, !F_ISSET(btree, WT_BTREE_IN_MEMORY));
+    WT_ASSERT(
+      session, !F_ISSET(S2C(session), WT_CONN_IN_MEMORY) && !F_ISSET(btree, WT_BTREE_IN_MEMORY));
 
     __wt_btcur_init(session, &cbt);
     __wt_btcur_open(&cbt);

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -1094,8 +1094,7 @@ __wti_page_inmem_updates(WT_SESSION_IMPL *session, WT_REF *ref)
     WT_ASSERT(session, !F_ISSET(btree, WT_BTREE_READONLY));
 
     /* We don't handle in-memory prepare resolution here. */
-    WT_ASSERT(
-      session, !F_ISSET(S2C(session), WT_CONN_IN_MEMORY) && !F_ISSET(btree, WT_BTREE_IN_MEMORY));
+    WT_ASSERT(session, !WT_IS_BTREE_IN_MEMORY(S2C(session), btree));
 
     __wt_btcur_init(session, &cbt);
     __wt_btcur_open(&cbt);

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1478,8 +1478,8 @@ __split_multi_inmem(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *multi, WT
      * garbage collect the history store pages at the page level since all its content has a stop
      * timestamp.
      */
-    if (instantiate_upd && !F_ISSET(S2C(session), WT_CONN_IN_MEMORY) &&
-      !F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY) && !WT_IS_HS(session->dhandle))
+    if (instantiate_upd && !WT_IS_BTREE_IN_MEMORY(S2C(session), S2BT(session)) &&
+      !WT_IS_HS(session->dhandle))
         WT_RET(__wti_page_inmem_updates(session, ref));
 
     __wt_evict_inherit_page_state(orig, page);
@@ -1774,7 +1774,7 @@ __split_multi_inmem_fail(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *mult
     WT_UPDATE *upd;
     uint32_t i, slot;
 
-    if (!F_ISSET(S2C(session), WT_CONN_IN_MEMORY) && !F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY))
+    if (!WT_IS_BTREE_IN_MEMORY(S2C(session), S2BT(session)))
         /* Append the onpage values back to the original update chains. */
         for (i = 0, supd = multi->supd; i < multi->supd_entries; ++i, ++supd) {
             /*

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1478,8 +1478,8 @@ __split_multi_inmem(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *multi, WT
      * garbage collect the history store pages at the page level since all its content has a stop
      * timestamp.
      */
-    if (instantiate_upd && !F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY) &&
-      !WT_IS_HS(session->dhandle))
+    if (instantiate_upd && !F_ISSET(S2C(session), WT_CONN_IN_MEMORY) &&
+      !F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY) && !WT_IS_HS(session->dhandle))
         WT_RET(__wti_page_inmem_updates(session, ref));
 
     __wt_evict_inherit_page_state(orig, page);
@@ -1774,7 +1774,7 @@ __split_multi_inmem_fail(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *mult
     WT_UPDATE *upd;
     uint32_t i, slot;
 
-    if (!F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY))
+    if (!F_ISSET(S2C(session), WT_CONN_IN_MEMORY) && !F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY))
         /* Append the onpage values back to the original update chains. */
         for (i = 0, supd = multi->supd; i < multi->supd_entries; ++i, ++supd) {
             /*

--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -465,8 +465,7 @@ __wt_conn_dhandle_close(WT_SESSION_IMPL *session, bool final, bool mark_dead, bo
          *
          */
         if (!discard && !marked_dead) {
-            if (F_ISSET(conn, WT_CONN_IN_MEMORY) ||
-              F_ISSET(btree, WT_BTREE_NO_CHECKPOINT | WT_BTREE_IN_MEMORY))
+            if (WT_IS_BTREE_IN_MEMORY(conn, btree) || F_ISSET(btree, WT_BTREE_NO_CHECKPOINT))
                 discard = true;
             else {
                 WT_TRET(__wt_checkpoint_close(session, final));

--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -465,7 +465,8 @@ __wt_conn_dhandle_close(WT_SESSION_IMPL *session, bool final, bool mark_dead, bo
          *
          */
         if (!discard && !marked_dead) {
-            if (F_ISSET(btree, WT_BTREE_NO_CHECKPOINT | WT_BTREE_IN_MEMORY))
+            if (F_ISSET(conn, WT_CONN_IN_MEMORY) ||
+              F_ISSET(btree, WT_BTREE_NO_CHECKPOINT | WT_BTREE_IN_MEMORY))
                 discard = true;
             else {
                 WT_TRET(__wt_checkpoint_close(session, final));

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -952,7 +952,7 @@ __wt_curversion_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner
 
     /* Open the history store cursor for btrees that may have data in the history store.*/
     file_btree = CUR2BT(version_cursor->file_cursor);
-    if (F_ISSET_ATOMIC_32(conn, WT_CONN_HS_OPEN) && !F_ISSET(file_btree, WT_BTREE_IN_MEMORY)) {
+    if (F_ISSET_ATOMIC_32(conn, WT_CONN_HS_OPEN) && !WT_IS_BTREE_IN_MEMORY(conn, file_btree)) {
         WT_ERR(__wt_curhs_open(session, file_btree->id, NULL, cursor, &version_cursor->hs_cursor));
         F_SET(version_cursor->hs_cursor, WT_CURSTD_HS_READ_COMMITTED);
     }

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1904,7 +1904,7 @@ retry:
             continue;
         }
 
-        if (F_ISSET(btree, WT_BTREE_IN_MEMORY) && !F_ISSET(evict, WT_EVICT_CACHE_DIRTY)) {
+        if (WT_IS_BTREE_IN_MEMORY(conn, btree) && !F_ISSET(evict, WT_EVICT_CACHE_DIRTY)) {
             __evict_disagg_btree_skip_count(session, btree);
             continue;
         }
@@ -2484,7 +2484,7 @@ __evict_try_queue_page(WT_SESSION_IMPL *session, WTI_EVICT_QUEUE *queue, WT_REF 
     WT_CONNECTION_IMPL *conn;
     WT_EVICT *evict;
     WT_PAGE *page;
-    bool modified, want_page;
+    bool is_inmem, modified, want_page;
 
     btree = S2BT(session);
     conn = S2C(session);
@@ -2548,12 +2548,11 @@ __evict_try_queue_page(WT_SESSION_IMPL *session, WTI_EVICT_QUEUE *queue, WT_REF 
     if (__wt_page_is_empty(page) || F_ISSET(session->dhandle, WT_DHANDLE_DEAD))
         goto fast;
 
+    is_inmem = WT_IS_BTREE_IN_MEMORY(conn, btree);
     /* Skip pages we don't want. */
-    want_page =
-      (F_ISSET(evict, WT_EVICT_CACHE_CLEAN) && !F_ISSET(btree, WT_BTREE_IN_MEMORY) && !modified) ||
+    want_page = (F_ISSET(evict, WT_EVICT_CACHE_CLEAN) && !is_inmem && !modified) ||
       (F_ISSET(evict, WT_EVICT_CACHE_DIRTY) && modified) ||
-      (F_ISSET(evict, WT_EVICT_CACHE_UPDATES) && !F_ISSET(btree, WT_BTREE_IN_MEMORY) &&
-        page->modify != NULL);
+      (F_ISSET(evict, WT_EVICT_CACHE_UPDATES) && !is_inmem && page->modify != NULL);
     if (!want_page) {
         WT_STAT_CONN_INCR(session, eviction_server_skip_unwanted_pages);
         return;

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -292,9 +292,7 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF_STATE previous_state, u
     /* Update the reference and discard the page. */
     if (__wt_ref_is_root(ref))
         __wt_ref_out(session, ref);
-    else if ((clean_page && !F_ISSET(conn, WT_CONN_IN_MEMORY) &&
-               !F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY)) ||
-      tree_dead)
+    else if ((clean_page && !WT_IS_BTREE_IN_MEMORY(conn, S2BT(session))) || tree_dead)
         /*
          * Pages that belong to dead trees never write back to disk and can't support page splits.
          */
@@ -852,8 +850,7 @@ __evict_review(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_flags, bool
      * Clean pages can't be evicted when running in memory only. This should be uncommon - we don't
      * add clean pages to the queue.
      */
-    if ((F_ISSET(conn, WT_CONN_IN_MEMORY) || F_ISSET(btree, WT_BTREE_IN_MEMORY)) && !modified &&
-      !closing)
+    if (WT_IS_BTREE_IN_MEMORY(conn, btree) && !modified && !closing)
         return (__wt_set_return(session, EBUSY));
 
     /* Check if the page can be evicted. */
@@ -959,7 +956,7 @@ __evict_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_flags)
     else if (F_ISSET(ref, WT_REF_FLAG_INTERNAL) || WT_IS_HS(btree->dhandle))
         ;
     /* Always do update restore for in-memory database. */
-    else if (F_ISSET(conn, WT_CONN_IN_MEMORY) || F_ISSET(btree, WT_BTREE_IN_MEMORY))
+    else if (WT_IS_BTREE_IN_MEMORY(conn, btree))
         LF_SET(WT_REC_IN_MEMORY | WT_REC_SCRUB);
     /* For data store leaf pages, write the history to history store except for metadata. */
     else if (!WT_IS_METADATA(btree->dhandle) && !WT_IS_DISAGG_META(btree->dhandle)) {
@@ -1033,7 +1030,7 @@ __evict_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_flags)
          * being processed. Therefore, we use snapshot API that doesn't publish shared IDs to the
          * outside world.
          */
-        if (F_ISSET(conn, WT_CONN_PRECISE_CHECKPOINT) && !F_ISSET(btree, WT_BTREE_IN_MEMORY)) {
+        if (F_ISSET(conn, WT_CONN_PRECISE_CHECKPOINT) && !WT_IS_BTREE_IN_MEMORY(conn, btree)) {
             uint64_t btree_ckpt_gen, ckpt_gen;
             /*
              * If precise checkpoint is configured, only evict the updates that visible to the

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -292,7 +292,9 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF_STATE previous_state, u
     /* Update the reference and discard the page. */
     if (__wt_ref_is_root(ref))
         __wt_ref_out(session, ref);
-    else if ((clean_page && !F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY)) || tree_dead)
+    else if ((clean_page && !F_ISSET(conn, WT_CONN_IN_MEMORY) &&
+               !F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY)) ||
+      tree_dead)
         /*
          * Pages that belong to dead trees never write back to disk and can't support page splits.
          */
@@ -850,7 +852,8 @@ __evict_review(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_flags, bool
      * Clean pages can't be evicted when running in memory only. This should be uncommon - we don't
      * add clean pages to the queue.
      */
-    if (F_ISSET(btree, WT_BTREE_IN_MEMORY) && !modified && !closing)
+    if ((F_ISSET(conn, WT_CONN_IN_MEMORY) || F_ISSET(btree, WT_BTREE_IN_MEMORY)) && !modified &&
+      !closing)
         return (__wt_set_return(session, EBUSY));
 
     /* Check if the page can be evicted. */
@@ -956,7 +959,7 @@ __evict_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_flags)
     else if (F_ISSET(ref, WT_REF_FLAG_INTERNAL) || WT_IS_HS(btree->dhandle))
         ;
     /* Always do update restore for in-memory database. */
-    else if (F_ISSET(btree, WT_BTREE_IN_MEMORY))
+    else if (F_ISSET(conn, WT_CONN_IN_MEMORY) || F_ISSET(btree, WT_BTREE_IN_MEMORY))
         LF_SET(WT_REC_IN_MEMORY | WT_REC_SCRUB);
     /* For data store leaf pages, write the history to history store except for metadata. */
     else if (!WT_IS_METADATA(btree->dhandle) && !WT_IS_DISAGG_META(btree->dhandle)) {

--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -57,6 +57,13 @@
 #define WT_BTREE_MIN_SPLIT_PCT 50
 
 /*
+ * Check both flags, as WT_CONN_IN_MEMORY enhances CPU branch prediction, leading to improved
+ * performance.
+ */
+#define WT_IS_BTREE_IN_MEMORY(conn, btree) \
+    (F_ISSET(conn, WT_CONN_IN_MEMORY) || F_ISSET(btree, WT_BTREE_IN_MEMORY))
+
+/*
  * Normalized position constants for "start" when calculating the page's position.
  */
 #define WT_NPOS_MID 0.5           /* Middle of the current page */

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1601,11 +1601,13 @@ static WT_INLINE int
 __wt_txn_read(
   WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_ITEM *key, uint64_t recno, WT_UPDATE *upd)
 {
+    WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
     WT_TIME_WINDOW tw;
     WT_UPDATE *prepare_upd, *restored_upd;
     bool have_stop_tw, prepare_retry, read_onpage;
 
+    conn = S2C(session);
     prepare_upd = restored_upd = NULL;
     read_onpage = prepare_retry = true;
 
@@ -1714,8 +1716,7 @@ retry:
     }
 
     /* If there's no visible update in the update chain or ondisk, check the history store file. */
-    if (!F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY) &&
-      F_ISSET_ATOMIC_32(S2C(session), WT_CONN_HS_OPEN) &&
+    if (!WT_IS_BTREE_IN_MEMORY(conn, S2BT(session)) && F_ISSET_ATOMIC_32(conn, WT_CONN_HS_OPEN) &&
       !F_ISSET(session->dhandle, WT_DHANDLE_HS)) {
         /*
          * Stressing this code path may slow down the system too much. To minimize the impact, sleep

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1722,7 +1722,7 @@ retry:
          * Stressing this code path may slow down the system too much. To minimize the impact, sleep
          * on every random 100th iteration when this is enabled.
          */
-        if (FLD_ISSET(S2C(session)->timing_stress_flags, WT_TIMING_STRESS_HS_SEARCH) &&
+        if (FLD_ISSET(conn->timing_stress_flags, WT_TIMING_STRESS_HS_SEARCH) &&
           __wt_random(&session->rnd_random) % 100 == 0)
             __wt_timing_stress(session, WT_TIMING_STRESS_HS_SEARCH, NULL);
 

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -1139,8 +1139,8 @@ __wti_rec_row_leaf(
              * onpage prepared update. Otherwise, we leak the prepared update.
              */
             WT_ASSERT_ALWAYS(session,
-              !F_ISSET(conn, WT_CONN_PRESERVE_PREPARED) || F_ISSET(conn, WT_CONN_IN_MEMORY) ||
-                F_ISSET(btree, WT_BTREE_IN_MEMORY) || !WT_TIME_WINDOW_HAS_PREPARE(twp),
+              !F_ISSET(conn, WT_CONN_PRESERVE_PREPARED) || WT_IS_BTREE_IN_MEMORY(conn, btree) ||
+                !WT_TIME_WINDOW_HAS_PREPARE(twp),
               "leaked prepared update.");
         } else
             twp = &upd_select.tw;

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -1139,8 +1139,8 @@ __wti_rec_row_leaf(
              * onpage prepared update. Otherwise, we leak the prepared update.
              */
             WT_ASSERT_ALWAYS(session,
-              !F_ISSET(conn, WT_CONN_PRESERVE_PREPARED) || F_ISSET(btree, WT_BTREE_IN_MEMORY) ||
-                !WT_TIME_WINDOW_HAS_PREPARE(twp),
+              !F_ISSET(conn, WT_CONN_PRESERVE_PREPARED) || F_ISSET(conn, WT_CONN_IN_MEMORY) ||
+                F_ISSET(btree, WT_BTREE_IN_MEMORY) || !WT_TIME_WINDOW_HAS_PREPARE(twp),
               "leaked prepared update.");
         } else
             twp = &upd_select.tw;

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -392,7 +392,7 @@ __rec_need_save_upd(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_UPDATE_SELEC
 
     btree = S2BT(session);
 
-    if (F_ISSET(btree, WT_BTREE_IN_MEMORY))
+    if (F_ISSET(S2C(session), WT_CONN_IN_MEMORY) || F_ISSET(btree, WT_BTREE_IN_MEMORY))
         return (false);
     /*
      * We need to save the update chain to check whether the reconciliation makes progress for
@@ -1424,7 +1424,7 @@ __wti_rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_INSERT *ins,
     WT_PAGE *page;
     WT_UPDATE *first_txn_upd, *first_upd, *onpage_upd, *upd;
     size_t upd_memsize;
-    bool has_newer_updates, write_prepare;
+    bool has_newer_updates, write_prepare, is_inmem;
 
     /*
      * The "saved updates" return value is used independently of returning an update we can write,
@@ -1450,8 +1450,9 @@ __wti_rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_INSERT *ins,
         if ((first_upd = WT_ROW_UPDATE(page, rip)) == NULL)
             return (0);
     }
-
-    if (F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY)) {
+    is_inmem =
+      F_ISSET(S2C(session), WT_CONN_IN_MEMORY) || F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY);
+    if (is_inmem) {
         /* Never write prepared updates for in-memory btree */
         write_prepare = false;
         WT_RET(__rec_upd_select_inmem(session, r, vpack, first_upd, upd_select, &first_txn_upd,

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -392,7 +392,7 @@ __rec_need_save_upd(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_UPDATE_SELEC
 
     btree = S2BT(session);
 
-    if (F_ISSET(S2C(session), WT_CONN_IN_MEMORY) || F_ISSET(btree, WT_BTREE_IN_MEMORY))
+    if (WT_IS_BTREE_IN_MEMORY(S2C(session), btree))
         return (false);
     /*
      * We need to save the update chain to check whether the reconciliation makes progress for
@@ -1424,7 +1424,7 @@ __wti_rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_INSERT *ins,
     WT_PAGE *page;
     WT_UPDATE *first_txn_upd, *first_upd, *onpage_upd, *upd;
     size_t upd_memsize;
-    bool has_newer_updates, write_prepare, is_inmem;
+    bool has_newer_updates, write_prepare;
 
     /*
      * The "saved updates" return value is used independently of returning an update we can write,
@@ -1450,9 +1450,8 @@ __wti_rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_INSERT *ins,
         if ((first_upd = WT_ROW_UPDATE(page, rip)) == NULL)
             return (0);
     }
-    is_inmem =
-      F_ISSET(S2C(session), WT_CONN_IN_MEMORY) || F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY);
-    if (is_inmem) {
+
+    if (WT_IS_BTREE_IN_MEMORY(S2C(session), S2BT(session))) {
         /* Never write prepared updates for in-memory btree */
         write_prepare = false;
         WT_RET(__rec_upd_select_inmem(session, r, vpack, first_upd, upd_select, &first_txn_upd,

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -989,7 +989,7 @@ __rec_write(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *block_me
 
         /* In-memory btrees shouldn't write pages. */
         WT_ASSERT_ALWAYS(session, !WT_IS_BTREE_IN_MEMORY(S2C(session), btree),
-          "Attempted to write page to disk when WiredTiger is configured to be in-memory");
+          "Attempted to write page to disk when the btree is configured to be in-memory");
 
         /*
          * We're passed a table's disk image. Decompress if necessary and verify the image. Always

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -987,9 +987,10 @@ __rec_write(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *block_me
             (checkpoint && addr == NULL && addr_sizep == NULL),
           "Incorrect arguments passed to rec_write for a checkpoint call");
 
-        /* In-memory btrees shouldn't write pages. */
-        WT_ASSERT_ALWAYS(session, !F_ISSET(btree, WT_BTREE_IN_MEMORY),
-          "Attempted to write page to disk when the btree is configured to be in-memory");
+        /* In-memory databases shouldn't write pages. */
+        WT_ASSERT_ALWAYS(session,
+          !F_ISSET(S2C(session), WT_CONN_IN_MEMORY) && !F_ISSET(btree, WT_BTREE_IN_MEMORY),
+          "Attempted to write page to disk when WiredTiger is configured to be in-memory");
 
         /*
          * We're passed a table's disk image. Decompress if necessary and verify the image. Always

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -987,9 +987,8 @@ __rec_write(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *block_me
             (checkpoint && addr == NULL && addr_sizep == NULL),
           "Incorrect arguments passed to rec_write for a checkpoint call");
 
-        /* In-memory databases shouldn't write pages. */
-        WT_ASSERT_ALWAYS(session,
-          !F_ISSET(S2C(session), WT_CONN_IN_MEMORY) && !F_ISSET(btree, WT_BTREE_IN_MEMORY),
+        /* In-memory btrees shouldn't write pages. */
+        WT_ASSERT_ALWAYS(session, !WT_IS_BTREE_IN_MEMORY(S2C(session), btree),
           "Attempted to write page to disk when WiredTiger is configured to be in-memory");
 
         /*

--- a/src/reconcile/reconcile_inline.h
+++ b/src/reconcile/reconcile_inline.h
@@ -445,7 +445,12 @@ __wti_rec_time_window_clear_obsolete(WT_SESSION_IMPL *session, WTI_UPDATE_SELECT
     if (!WT_TIME_WINDOW_HAS_START(tw))
         return;
 
-    if (!WT_TIME_WINDOW_HAS_PREPARE(tw)) {
+    /*
+     * If timestamps are not being used, there's no need to clear time points for in-memory btrees,
+     * as it typically results in unnecessary overhead.
+     */
+    if (!WT_TIME_WINDOW_HAS_PREPARE(tw) &&
+      (!WT_IS_BTREE_IN_MEMORY(S2C(session), btree) || !F_ISSET(btree, WT_BTREE_LOGGED))) {
         /*
          * Check if the start of the time window is globally visible, and if so remove unnecessary
          * values.

--- a/src/rollback_to_stable/rts_btree.c
+++ b/src/rollback_to_stable/rts_btree.c
@@ -728,7 +728,8 @@ __rts_btree_abort_ondisk_kv(WT_SESSION_IMPL *session, WT_REF *ref, WT_ROW *rip, 
           tw->durable_start_ts > rollback_timestamp ? "true" : "false",
           !__wti_rts_visibility_txn_visible_id(session, tw->start_txn) ? "true" : "false",
           !WT_TIME_WINDOW_HAS_STOP(tw) && prepared ? "true" : "false");
-        if (!F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY))
+        if (!F_ISSET(S2C(session), WT_CONN_IN_MEMORY) &&
+          !F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY))
             return (__rts_btree_ondisk_fixup_key(
               session, ref, rip, recno, row_key, vpack, rollback_timestamp));
         else {
@@ -752,7 +753,8 @@ __rts_btree_abort_ondisk_kv(WT_SESSION_IMPL *session, WT_REF *ref, WT_ROW *rip, 
         if (WT_TIME_WINDOW_HAS_START_PREPARE(tw) && tw->start_prepared_id == tw->stop_prepared_id &&
           tw->start_prepare_ts == tw->stop_prepare_ts && tw->start_txn == tw->stop_txn) {
             WT_ASSERT(session, prepared);
-            if (!F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY))
+            if (!F_ISSET(S2C(session), WT_CONN_IN_MEMORY) &&
+              !F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY))
                 return (__rts_btree_ondisk_fixup_key(
                   session, ref, rip, recno, row_key, vpack, rollback_timestamp));
             else {

--- a/src/rollback_to_stable/rts_btree.c
+++ b/src/rollback_to_stable/rts_btree.c
@@ -728,8 +728,7 @@ __rts_btree_abort_ondisk_kv(WT_SESSION_IMPL *session, WT_REF *ref, WT_ROW *rip, 
           tw->durable_start_ts > rollback_timestamp ? "true" : "false",
           !__wti_rts_visibility_txn_visible_id(session, tw->start_txn) ? "true" : "false",
           !WT_TIME_WINDOW_HAS_STOP(tw) && prepared ? "true" : "false");
-        if (!F_ISSET(S2C(session), WT_CONN_IN_MEMORY) &&
-          !F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY))
+        if (!WT_IS_BTREE_IN_MEMORY(S2C(session), S2BT(session)))
             return (__rts_btree_ondisk_fixup_key(
               session, ref, rip, recno, row_key, vpack, rollback_timestamp));
         else {
@@ -753,8 +752,7 @@ __rts_btree_abort_ondisk_kv(WT_SESSION_IMPL *session, WT_REF *ref, WT_ROW *rip, 
         if (WT_TIME_WINDOW_HAS_START_PREPARE(tw) && tw->start_prepared_id == tw->stop_prepared_id &&
           tw->start_prepare_ts == tw->stop_prepare_ts && tw->start_txn == tw->stop_txn) {
             WT_ASSERT(session, prepared);
-            if (!F_ISSET(S2C(session), WT_CONN_IN_MEMORY) &&
-              !F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY))
+            if (!WT_IS_BTREE_IN_MEMORY(S2C(session), S2BT(session)))
                 return (__rts_btree_ondisk_fixup_key(
                   session, ref, rip, recno, row_key, vpack, rollback_timestamp));
             else {

--- a/src/rollback_to_stable/rts_visibility.c
+++ b/src/rollback_to_stable/rts_visibility.c
@@ -112,7 +112,7 @@ __wti_rts_visibility_page_needs_abort(
      *    - The on page address max durable timestamp.
      *    - The off page address max durable timestamp.
      */
-    if (F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY)) {
+    if (F_ISSET(S2C(session), WT_CONN_IN_MEMORY) || F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY)) {
         tag = "in-memory";
         result = true;
     } else if (mod != NULL && mod->rec_result == WT_PM_REC_REPLACE) {

--- a/src/rollback_to_stable/rts_visibility.c
+++ b/src/rollback_to_stable/rts_visibility.c
@@ -112,7 +112,7 @@ __wti_rts_visibility_page_needs_abort(
      *    - The on page address max durable timestamp.
      *    - The off page address max durable timestamp.
      */
-    if (F_ISSET(S2C(session), WT_CONN_IN_MEMORY) || F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY)) {
+    if (WT_IS_BTREE_IN_MEMORY(S2C(session), S2BT(session))) {
         tag = "in-memory";
         result = true;
     } else if (mod != NULL && mod->rec_result == WT_PM_REC_REPLACE) {

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1226,7 +1226,7 @@ __txn_resolve_prepared_op(WT_SESSION_IMPL *session, WT_TXN_OP *op, bool commit, 
     if (F_ISSET(upd, WT_UPDATE_PREPARE_RESTORED_FROM_DS) &&
       (upd->type != WT_UPDATE_TOMBSTONE || (upd->next != NULL && upd->txnid == upd->next->txnid)))
         resolve_case = RESOLVE_PREPARE_ON_DISK;
-    else if (F_ISSET(btree, WT_BTREE_IN_MEMORY))
+    else if (F_ISSET(S2C(session), WT_CONN_IN_MEMORY) || F_ISSET(btree, WT_BTREE_IN_MEMORY))
         resolve_case = RESOLVE_IN_MEMORY;
     else
         resolve_case = RESOLVE_UPDATE_CHAIN;

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1226,7 +1226,7 @@ __txn_resolve_prepared_op(WT_SESSION_IMPL *session, WT_TXN_OP *op, bool commit, 
     if (F_ISSET(upd, WT_UPDATE_PREPARE_RESTORED_FROM_DS) &&
       (upd->type != WT_UPDATE_TOMBSTONE || (upd->next != NULL && upd->txnid == upd->next->txnid)))
         resolve_case = RESOLVE_PREPARE_ON_DISK;
-    else if (F_ISSET(S2C(session), WT_CONN_IN_MEMORY) || F_ISSET(btree, WT_BTREE_IN_MEMORY))
+    else if (WT_IS_BTREE_IN_MEMORY(S2C(session), btree))
         resolve_case = RESOLVE_IN_MEMORY;
     else
         resolve_case = RESOLVE_UPDATE_CHAIN;

--- a/test/catch2/misc_tests/test_rec_upd_select.cpp
+++ b/test/catch2/misc_tests/test_rec_upd_select.cpp
@@ -244,7 +244,7 @@ TEST_CASE_METHOD(RecUpdSelectFixture, "rec_upd_select: Basic visible update sele
 
     SECTION("In memory, should write oldest update in the list")
     {
-        F_SET(S2BT(session), WT_BTREE_IN_MEMORY);
+        F_SET(S2C(session), WT_CONN_IN_MEMORY);
         WTI_UPDATE_SELECT upd_select;
         WTI_UPDATE_SELECT_INIT(&upd_select);
 
@@ -259,7 +259,7 @@ TEST_CASE_METHOD(RecUpdSelectFixture, "rec_upd_select: Basic visible update sele
     }
     SECTION("Not in-memory, should write newest update in the list")
     {
-        F_CLR(S2BT(session), WT_BTREE_IN_MEMORY);
+        F_CLR(S2C(session), WT_CONN_IN_MEMORY);
         WTI_UPDATE_SELECT upd_select;
         WTI_UPDATE_SELECT_INIT(&upd_select);
 
@@ -309,7 +309,7 @@ TEST_CASE_METHOD(
 
     SECTION("In-memory, should write oldest update with timestamp > prune timestamp in the list")
     {
-        F_SET(S2BT(session), WT_BTREE_IN_MEMORY);
+        F_SET(S2C(session), WT_CONN_IN_MEMORY);
         WTI_UPDATE_SELECT upd_select;
         WTI_UPDATE_SELECT_INIT(&upd_select);
 
@@ -359,7 +359,7 @@ TEST_CASE_METHOD(RecUpdSelectFixture, "rec_upd_select: Skip writing aborted and 
 
     SECTION("In-memory, should write oldest update with timestamp > prune timestamp in the list")
     {
-        F_SET(S2BT(session), WT_BTREE_IN_MEMORY);
+        F_SET(S2C(session), WT_CONN_IN_MEMORY);
         WTI_UPDATE_SELECT upd_select;
         WTI_UPDATE_SELECT_INIT(&upd_select);
 
@@ -375,7 +375,7 @@ TEST_CASE_METHOD(RecUpdSelectFixture, "rec_upd_select: Skip writing aborted and 
 
     SECTION("Not In-memory, should write newest update")
     {
-        F_CLR(S2BT(session), WT_BTREE_IN_MEMORY);
+        F_CLR(S2C(session), WT_CONN_IN_MEMORY);
         F_SET(&r, WT_REC_EVICT);
         WTI_UPDATE_SELECT upd_select;
         WTI_UPDATE_SELECT_INIT(&upd_select);


### PR DESCRIPTION
[WT-16567](https://jira.mongodb.org/browse/WT-16567) allows clearing timestamps on the in-memory database. However, for the standalone case, timestamps are not used. Therefore, this becomes a wasted work and leading to regression.

Disallow clearing the timepoints if timestamps are not used.

[WT-16605](https://jira.mongodb.org/browse/WT-16605) is a refactoring change that consolidates the check for the WT_CONN_IN_MEMORY flag and the WT_BTREE_IN_MEMORY flag to a single check of the WT_BTREE_IN_MEMORY flag. However, for in-memory databases, checking WT_CONN_IN_MEMORY is faster than WT_BTREE_IN_MEMORY as the CPU predicts the branch more accurately for the check WT_CONN_IN_MEMORY.

Consolidate the way we check in-memory btree to a single macro with optimized performance.