### PR TITLE
WT-16668 Resolve Palite indirect leak LSan failure

### DIFF
--- a/ext/page_log/palite/palite.cpp
+++ b/ext/page_log/palite/palite.cpp
@@ -942,7 +942,10 @@ protected:
 public:
     std::shared_mutex access; /* readers-writer mutex for table */
 
-    ~Table() = default;
+    ~Table()
+    {
+        close();
+    }
     Table(Config &cfg, std::shared_mutex &str_access, const std::filesystem::path &file)
         : config(cfg), store_access(str_access), table_file(file)
     {
@@ -1971,7 +1974,10 @@ class Storage {
     std::atomic_ullong object_gets; /* (What would be) network requests for data */
 
 public:
-    ~Storage() = default;
+    ~Storage()
+    {
+        close();
+    }
     Storage(Config &cfg, const std::filesystem::path &dbp)
         : config(cfg), db_home(dbp), globals(cfg, store_access, db_home),
           checkpoints(cfg, store_access, db_home)

--- a/test/evergreen/asan_leaks.supp
+++ b/test/evergreen/asan_leaks.supp
@@ -22,7 +22,3 @@ leak:__tiered_name_str
 leak:_PyBytes_FromSize
 leak:_wrap__wiredtiger_calc_modify
 leak:__cursor_prepared_discover_setup
-
-# FIXME-WT-16668: This leak seems to have occurred as a result of checkpoint size but that project
-# does not directly allocate memory.
-leak:palite_


### PR DESCRIPTION
Ensure that both storage and table destructors call the close method.

Table must close the connections that it owns, and Storage must close the table instances that it owns.