### PR TITLE
WT-16681 Centralize disagg args configuration for csuite-tests in test utility

### DIFF
--- a/test/checkpoint/CMakeLists.txt
+++ b/test/checkpoint/CMakeLists.txt
@@ -62,22 +62,22 @@ define_test_variants(test_checkpoint
 # Define test variants for the disagg test
 define_test_variants(test_checkpoint
     VARIANTS
-        "disagg_leader_6_row|-d leader -e -t r -T 6 -x"
+        "disagg_leader_6_row|-G -e -t r -T 6 -x"
         # FIXME-WT-16228: Re-evaluate whether setting large cache size is needed after PALI.
-        "disagg_leader_6_row_long_running|-d leader -e -t r -W 3 -x -n 1000000 -k 1000000 -C cache_size=4000MB"
+        "disagg_leader_6_row_long_running|-G -e -t r -W 3 -x -n 1000000 -k 1000000 -C cache_size=4000MB"
         # Prepare operations is not supported on Disagg yet.
-        #"disagg_6_row_prepare|-d leader -e -t r -T 6 -p -x"
-        "disagg_leader_row_stress_sweep|-d leader -e -t r -W 3 -r 2 -s 1 -x -n 100000 -k 100000 -D"
-        "disagg_leader_row_sweep|-d leader -e -t r -W 3 -r 2 -s 1 -x -n 100000 -k 100000"
-        "disagg_leader_row_failpoint_hs_delete_key_from_ts|-d leader -e -t r -W 3 -r 2 -s 2 -x -n 100000 -k 100000"
-        "disagg_leader_row_hs_checkpoint_timing_stress|-d leader -e -t r -W 3 -r 2 -s 3 -x -n 100000 -k 100000"
-        "disagg_leader_row_checkpoint_slow_timing_stress|-d leader -e -t r -W 3 -r 2 -s 5 -x -n 100000 -k 100000"
-        "disagg_leader_row_evict_reposition_timing_stress|-d leader -e -t r -W 3 -r 2 -s 6 -x -n 100000 -k 100000"
-        "disagg_leader_row_failpoint_eviction_split|-d leader -e -t r -W 3 -r 2 -s 7 -x -n 100000 -k 100000"
-        "disagg_leader_row_failpoint_rec_before_wrapup|-d leader -e -t r -W 3 -r 2 -s 8 -x -n 100000 -k 100000"
+        #"disagg_6_row_prepare|-G -e -t r -T 6 -p -x"
+        "disagg_leader_row_stress_sweep|-G -e -t r -W 3 -r 2 -s 1 -x -n 100000 -k 100000 -D"
+        "disagg_leader_row_sweep|-G -e -t r -W 3 -r 2 -s 1 -x -n 100000 -k 100000"
+        "disagg_leader_row_failpoint_hs_delete_key_from_ts|-G -e -t r -W 3 -r 2 -s 2 -x -n 100000 -k 100000"
+        "disagg_leader_row_hs_checkpoint_timing_stress|-G -e -t r -W 3 -r 2 -s 3 -x -n 100000 -k 100000"
+        "disagg_leader_row_checkpoint_slow_timing_stress|-G -e -t r -W 3 -r 2 -s 5 -x -n 100000 -k 100000"
+        "disagg_leader_row_evict_reposition_timing_stress|-G -e -t r -W 3 -r 2 -s 6 -x -n 100000 -k 100000"
+        "disagg_leader_row_failpoint_eviction_split|-G -e -t r -W 3 -r 2 -s 7 -x -n 100000 -k 100000"
+        "disagg_leader_row_failpoint_rec_before_wrapup|-G -e -t r -W 3 -r 2 -s 8 -x -n 100000 -k 100000"
 
         # FIXME-WT-16228: Re-evaluate whether setting large cache size is needed after PALI.
-        "disagg_leader_row_server_93028|-d leader -e -t r -W 50 -r 2 -s 1 -x -n 100000 -k 100000 -C cache_size=1500MB"
+        "disagg_leader_row_server_93028|-G -e -t r -W 50 -r 2 -s 1 -x -n 100000 -k 100000 -C cache_size=1500MB"
     LABELS
         check_disagg
         test_checkpoint

--- a/test/checkpoint/recovery-test.sh
+++ b/test/checkpoint/recovery-test.sh
@@ -24,9 +24,6 @@ fi
 backup=$home.backup
 recovery=$home.recovery
 
-# Extract the disagg config if any.
-disagg_config=$(echo $config | sed -n -r 's/.*(-d \w+).*/\1/p')
-
 # Extract the -e flag if present.
 precise_checkpoint=$(echo $config | grep -o '\-e')
 
@@ -49,11 +46,7 @@ while kill -STOP $pid ; do
 	kill -CONT $pid
 	cp $backup/* $recovery
 
-	# Timestamp must be set for disaggregate configuration.
 	recovery_flags=""
-	if [ -n "$disagg_config" ]; then
-		recovery_flags="$disagg_config -e -x"
-	fi
 
 	# Include -e and -x flags if -e is present in original config.
 	if [ -n "$precise_checkpoint" ]; then

--- a/test/checkpoint/test_checkpoint.c
+++ b/test/checkpoint/test_checkpoint.c
@@ -28,14 +28,13 @@
 
 #include "test_checkpoint.h"
 
-#define SHARED_PARSE_OPTIONS "b:P:h:"
+#define SHARED_PARSE_OPTIONS "b:GP:h:"
 
 GLOBAL g;
 
 static int handle_error(WT_EVENT_HANDLER *, WT_SESSION *, int, const char *);
 static int handle_message(WT_EVENT_HANDLER *, WT_SESSION *, const char *);
 static void onint(int) WT_GCC_FUNC_DECL_ATTRIBUTE((noreturn));
-static int enable_disagg(const char *);
 static void cleanup(bool);
 static int usage(void);
 static void wt_connect(const char *);
@@ -115,18 +114,14 @@ main(int argc, char *argv[])
 
     testutil_parse_begin_opt(argc, argv, SHARED_PARSE_OPTIONS, &g.opts);
 
-    while ((ch = __wt_getopt(progname, argc, argv,
-              "C:c:d:Dk:l:mn:per:Rs:S:T:t:vW:xX" SHARED_PARSE_OPTIONS)) != EOF)
+    while ((ch = __wt_getopt(
+              progname, argc, argv, "C:c:Dk:l:mn:per:Rs:S:T:t:vW:xX" SHARED_PARSE_OPTIONS)) != EOF)
         switch (ch) {
         case 'c':
             g.checkpoint_name = __wt_optarg;
             break;
         case 'C': /* wiredtiger_open config */
             strncpy(config_open, __wt_optarg, sizeof(config_open) - 1);
-            break;
-        case 'd': /* disaggregated storage options */
-            g.opts.disagg.is_enabled = true;
-            g.opts.disagg.mode = __wt_optarg;
             break;
         case 'D':
             g.debug_mode = true;
@@ -255,9 +250,6 @@ main(int argc, char *argv[])
     testutil_work_dir_from_path(g.home, 512, (&g.opts)->home);
 
     if (g.opts.disagg.is_enabled) {
-        if (enable_disagg(g.opts.disagg.mode) != 0)
-            return (usage());
-
         if (!g.use_timestamps) {
             WARN("%s", "Timestamps automatically enabled for disaggregated storage (-x/-X).");
             g.use_timestamps = true;
@@ -267,7 +259,6 @@ main(int argc, char *argv[])
             WARN("%s", "Precise checkpoint automatically enabled for disaggregated storage (-e).");
             g.precise_checkpoint = true;
         }
-
         if (ttype != ROW) {
             fprintf(
               stderr, "disaggregated storage feature only supports row store table types (-r)");
@@ -284,6 +275,7 @@ main(int argc, char *argv[])
               stderr, "disaggregated storage feature doesn't supports prepare operations (-p)");
             return (EXIT_FAILURE);
         }
+        g.opts.disagg.page_log_home = g.home;
     }
 
     /*
@@ -385,40 +377,6 @@ run_complete:
     testutil_cleanup(&g.opts);
 
     return (g.status);
-}
-
-/*
- * enable_disagg --
- *     Enable disaggregated storage with given mode.
- */
-static int
-enable_disagg(const char *mode)
-{
-    if (strcmp(mode, "leader") == 0) {
-        g.opts.disagg.switch_mode = false;
-        g.opts.disagg.mode = "leader";
-        g.opts.disagg.page_log = "palite";
-    } else if (strcmp(mode, "follower") == 0) {
-        g.opts.disagg.mode = "follower";
-        g.opts.disagg.switch_mode = false;
-        g.opts.disagg.page_log = "palite";
-    } else if (strcmp(mode, "switch") == 0) {
-        g.opts.disagg.switch_mode = true;
-        /* For switch mode, randomly pick initial role */
-        bool disagg_leader = (__wt_random(&g.opts.extra_rnd) % 2) == 0;
-        g.opts.disagg.mode = disagg_leader ? "leader" : "follower";
-        g.opts.disagg.page_log = "palite";
-        printf("Switch mode: starting as %s\n", g.opts.disagg.mode);
-    } else {
-        fprintf(stderr, "Invalid disaggregated mode: %s\n", mode);
-        return EINVAL;
-    }
-
-    g.opts.disagg.page_log_map_size_mb = 2048;    /* Set 2GB map size for palm by default. */
-    g.opts.disagg.page_log_home = (char *)g.home; /* Set home directory for page log. */
-    g.opts.disagg.drain_threads = 8;              /* Set number of drain threads, 8 by default. */
-
-    return 0;
 }
 
 #define DEBUG_MODE_CFG ",debug_mode=(eviction=true,table_logging=true),verbose=(recovery)"
@@ -610,23 +568,6 @@ log_print_err_worker(const char *func, int line, const char *m, int e, int fatal
 }
 
 /*
- * disagg_switch_roles --
- *     Toggle the current disagg role between "leader" and "follower".
- */
-int
-disagg_switch_roles(void)
-{
-    testutil_assert(g.opts.disagg.is_enabled);
-    testutil_assert(g.opts.disagg.switch_mode);
-
-    const char *disagg_role = strcmp(g.opts.disagg.mode, "leader") == 0 ? "follower" : "leader";
-    char disagg_cfg[64];
-    testutil_snprintf(disagg_cfg, sizeof(disagg_cfg), "disaggregated=(role=\"%s\")", disagg_role);
-
-    return (g.conn->reconfigure(g.conn, disagg_cfg));
-}
-
-/*
  * type_to_string --
  *     Return the string name of a table type.
  */
@@ -650,17 +591,16 @@ static int
 usage(void)
 {
     fprintf(stderr,
-      "usage: %s\n"
-      "    [-DmpeRkvXx] [-C wiredtiger-config] [-c checkpoint] [-d disagg-mode] [-h home] [-k "
+      "usage: %s%s\n"
+      "    [-DmpeRkvXx] [-C wiredtiger-config] [-c checkpoint] [-h home] [-k "
       "keys] "
       "[-l log]\n"
       "    [-n ops] [-r runs] [-s 1|2|3|4|5] [-T table-config] [-t r|v]\n"
       "    [-W workers]\n",
-      progname);
+      progname, g.opts.usage);
     fprintf(stderr, "%s",
       "\t-C specify wiredtiger_open configuration arguments\n"
       "\t-c checkpoint name to used named checkpoints\n"
-      "\t-d disaggregated storage mode (leader | follower | switch)\n"
       "\t-D debug mode\n"
       "\t-h set a database home directory\n"
       "\t-k set number of keys to load\n"

--- a/test/checkpoint/test_checkpoint.h
+++ b/test/checkpoint/test_checkpoint.h
@@ -122,7 +122,6 @@ extern GLOBAL g;
 #define WARN(fmt, ...) fprintf(stderr, "%s: WARNING: " fmt "\n", progname, __VA_ARGS__)
 
 void end_threads(void);
-int disagg_switch_roles(void);
 int log_print_err_worker(const char *, int, const char *, int, int);
 void set_flush_tier_delay(WT_RAND_STATE *);
 void start_threads(void);

--- a/test/format/wts.c
+++ b/test/format/wts.c
@@ -319,7 +319,6 @@ configure_disagg_storage(const char *home, char **p, size_t max, char *ext_cfg, 
     }
 
     memset(&opts, 0, sizeof(opts));
-    opts.disagg.is_enabled = true;
 
     /*
      * We need to cast these values. Normally, testutil allocates and fills these strings based on
@@ -327,19 +326,19 @@ configure_disagg_storage(const char *home, char **p, size_t max, char *ext_cfg, 
      * line parser and doesn't rely on testutil to free anything in this struct. We're only using
      * the options struct on a temporary basis to help create the disagg configuration.
      */
-    opts.disagg.page_log = (char *)GVS(DISAGG_PAGE_LOG);
-    opts.disagg.page_log_home = disagg_is_multi_node() ? g.home_page_log : (char *)home;
-    opts.disagg.mode = (char *)(g.disagg_leader ? "leader" : "follower");
-    opts.disagg.key_provider = GV(DISAGG_KEY_PROVIDER);
-    opts.disagg.drain_threads = GV(DISAGG_DRAIN_THREADS);
     opts.home = (char *)home;
     opts.build_dir = (char *)BUILDDIR;
-    opts.disagg.page_log_map_size_mb = 2048; /* 2 Gigabytes for PALM map */
-    opts.disagg.page_log_verbose = GV(DISAGG_PAGE_LOG_VERBOSE);
-
-    /* Set page deltas. */
-    opts.disagg.internal_page_delta = (bool)GV(DISAGG_INTERNAL_PAGE_DELTA);
-    opts.disagg.leaf_page_delta = (bool)GV(DISAGG_LEAF_PAGE_DELTA);
+    TESTUTIL_DISAGG_INIT(&opts,
+      /* is_enabled           */ true,
+      /* key_provider         */ GV(DISAGG_KEY_PROVIDER),
+      /* internal_page_delta  */ (bool)GV(DISAGG_INTERNAL_PAGE_DELTA),
+      /* leaf_page_delta      */ (bool)GV(DISAGG_LEAF_PAGE_DELTA),
+      /* mode                 */ (char *)(g.disagg_leader ? "leader" : "follower"),
+      /* page_log             */ (char *)GVS(DISAGG_PAGE_LOG),
+      /* page_log_home        */ disagg_is_multi_node() ? g.home_page_log : (char *)home,
+      /* drain_threads        */ GV(DISAGG_DRAIN_THREADS),
+      /* page_log_map_size_mb */ 2048, /* 2 Gigabytes for PALM map */
+      /* page_log_verbose     */ GV(DISAGG_PAGE_LOG_VERBOSE));
 
     testutil_disagg_storage_configuration(
       &opts, home, disagg_cfg, sizeof(disagg_cfg), ext_cfg, ext_cfg_size);

--- a/test/utility/parse_opts.c
+++ b/test/utility/parse_opts.c
@@ -173,6 +173,26 @@ parse_tiered_random_seeds(TEST_OPTS *opts, const char *seed_str)
 }
 
 /*
+ * parse_disagg_opt --
+ *     Parse a command line option for the disaggregated storage configurations.
+ */
+static void
+parse_disagg_opt(TEST_OPTS *opts)
+{
+    TESTUTIL_DISAGG_INIT(opts,
+      /* is_enabled           */ true,
+      /* key_provider         */ true,
+      /* internal_page_delta  */ true,
+      /* leaf_page_delta      */ true,
+      /* mode                 */ "leader",
+      /* page_log             */ "palite",
+      /* page_log_home        */ ".",
+      /* drain_threads        */ 8,
+      /* page_log_map_size_mb */ 2048,
+      /* page_log_verbose     */ 0);
+}
+
+/*
  * parse_tiered_opt --
  *     Parse a command line option for the tiered storage configurations.
  */
@@ -243,11 +263,11 @@ testutil_parse_begin_opt(int argc, char *const *argv, const char *getopts_string
 
 #define USAGE_STR(ch, usage) ((strchr(getopts_string, (ch)) == NULL) ? "" : (usage))
 
-    testutil_snprintf(opts->usage, sizeof(opts->usage), "%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s",
+    testutil_snprintf(opts->usage, sizeof(opts->usage), "%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s%s",
       USAGE_STR('A', " [-A append thread count]"), USAGE_STR('b', " [-b build directory]"),
       USAGE_STR('C', " [-C]"), USAGE_STR('d', " [-d add data]"), USAGE_STR('h', " [-h home]"),
-      USAGE_STR('m', " [-m]"), USAGE_STR('n', " [-n record count]"),
-      USAGE_STR('o', " [-o op count]"),
+      USAGE_STR('G', " [-G Enable disaggregated storage]"), USAGE_STR('m', " [-m]"),
+      USAGE_STR('n', " [-n record count]"), USAGE_STR('o', " [-o op count]"),
       USAGE_STR('P',
         " [-PT] [-PSD<data_seed>,E<extra_seed>] [-Pd <force_delay>,<delay_ms>]"
         " [-Pe <force_error>,<error_ms>] [-Po storage source]"),
@@ -324,6 +344,9 @@ testutil_parse_single_opt(TEST_OPTS *opts, int ch)
         break;
     case 'd': /* Use data in multi-threaded test programs */
         opts->do_data_ops = true;
+        break;
+    case 'G': /* Disaggregated storage options */
+        parse_disagg_opt(opts);
         break;
     case 'h': /* Home directory */
         opts->home = dstrdup(__wt_optarg);

--- a/test/utility/parse_opts.c
+++ b/test/utility/parse_opts.c
@@ -173,11 +173,11 @@ parse_tiered_random_seeds(TEST_OPTS *opts, const char *seed_str)
 }
 
 /*
- * parse_disagg_opt --
- *     Parse a command line option for the disaggregated storage configurations.
+ * parse_and_set_disagg_opt --
+ *     Parse and set opts for the disaggregated storage configurations.
  */
 static void
-parse_disagg_opt(TEST_OPTS *opts)
+parse_and_set_disagg_opt(TEST_OPTS *opts)
 {
     TESTUTIL_DISAGG_INIT(opts,
       /* is_enabled           */ true,
@@ -346,7 +346,7 @@ testutil_parse_single_opt(TEST_OPTS *opts, int ch)
         opts->do_data_ops = true;
         break;
     case 'G': /* Disaggregated storage options */
-        parse_disagg_opt(opts);
+        parse_and_set_disagg_opt(opts);
         break;
     case 'h': /* Home directory */
         opts->home = dstrdup(__wt_optarg);

--- a/test/utility/test_util.h
+++ b/test/utility/test_util.h
@@ -178,7 +178,6 @@ typedef struct {
          */
         bool is_enabled;          /* Uses disaggregated storage */
         bool key_provider;        /* Uses key provider testing module for disaggregated storage */
-        bool switch_mode;         /* Switching disaggregated storage mode during the test */
         bool internal_page_delta; /* Use internal page deltas */
         bool leaf_page_delta;     /* Use leaf page deltas */
 

--- a/test/utility/test_util.h
+++ b/test/utility/test_util.h
@@ -103,6 +103,22 @@ extern "C" {
 
 #define TESTUTIL_SEED_FORMAT "-PSD%" PRIu64 ",E%" PRIu64
 
+#define TESTUTIL_DISAGG_INIT(_opts, _is_enabled, _key_provider, _internal_page_delta,        \
+  _leaf_page_delta, _mode, _page_log, _page_log_home, _drain_threads, _page_log_map_size_mb, \
+  _page_log_verbose)                                                                         \
+    do {                                                                                     \
+        (_opts)->disagg.is_enabled = (_is_enabled);                                          \
+        (_opts)->disagg.key_provider = (_key_provider);                                      \
+        (_opts)->disagg.internal_page_delta = (_internal_page_delta);                        \
+        (_opts)->disagg.leaf_page_delta = (_leaf_page_delta);                                \
+        (_opts)->disagg.mode = (_mode);                                                      \
+        (_opts)->disagg.page_log = (_page_log);                                              \
+        (_opts)->disagg.page_log_home = (_page_log_home);                                    \
+        (_opts)->disagg.drain_threads = (_drain_threads);                                    \
+        (_opts)->disagg.page_log_map_size_mb = (_page_log_map_size_mb);                      \
+        (_opts)->disagg.page_log_verbose = (_page_log_verbose);                              \
+    } while (0)
+
 /* Generic option parsing structure shared by all test cases. */
 typedef struct {
     char *home;
@@ -154,6 +170,12 @@ typedef struct {
 
     /* Fields used for testing disaggregated storage. */
     struct {
+        /*
+         * These fields must be explicitly initialized in `TESTUTIL_DISAGG_INIT()`.
+         *
+         * If you add a new field, update the constructor and all relevant tests to avoid incomplete
+         * setup.
+         */
         bool is_enabled;          /* Uses disaggregated storage */
         bool key_provider;        /* Uses key provider testing module for disaggregated storage */
         bool switch_mode;         /* Switching disaggregated storage mode during the test */


### PR DESCRIPTION
Centralizes disagg configuration and prevents silent misconfiguration when new options are introduced.

I’ve added a constructor for disagg test options (in test_util.h) so that every option must be explicitly considered wherever it’s introduced. For example, internal and leaf page deltas and KEK were previously always disabled in test_checkpoint. With the constructor in place, developers must now review any new option inreoduced for everywhere the constructor is used, helping maintain consistency across tests.