### PR TITLE
WT-16686 Change the disagg db size check from ASSERT_ALWAYS to just ASSERT

### DIFF
--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -898,12 +898,10 @@ __checkpoint_update_disagg_database_size(WT_SESSION_IMPL *session)
         delta = session->ckpt.ckpt_size_delta;
 
         if (delta > 0) {
-            WT_ASSERT_ALWAYS(session, UINT64_MAX - db >= (uint64_t)delta,
-              "Disaggregated storage database size too large");
+            WT_ASSERT(session, UINT64_MAX - db >= (uint64_t)delta);
             __wt_disagg_set_database_size(session, db + (uint64_t)delta);
         } else {
-            WT_ASSERT_ALWAYS(
-              session, db >= (uint64_t)(-delta), "Disaggregated storage database size too small");
+            WT_ASSERT(session, db >= (uint64_t)(-delta));
             __wt_disagg_set_database_size(session, db - (uint64_t)(-delta));
         }
     }


### PR DESCRIPTION
`WT_ASSERT_ALWAYS` can be triggered whether we are in debug or release build, while `WT_ASSERT` is only in debug build. We are not ready yet to have the assertions enabled in both builds.