### PR TITLE
WT-16500 Final review for the delta data format

### DIFF
--- a/src/include/cell.h
+++ b/src/include/cell.h
@@ -227,7 +227,7 @@ struct __wt_cell_unpack_delta_int {
     WT_CELL_UNPACK_ADDR value;
 };
 
-#define WT_DELTA_LEAF_VALUE_FORMAT WT_UNCHECKED_STRING(uB)
+#define WT_DELTA_LEAF_VALUE_FORMAT WT_UNCHECKED_STRING(Bu)
 
 /*
  * WT_CELL_UNPACK_DELTA_LEAF_KV --

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -1746,7 +1746,7 @@ __wt_cell_unpack_delta_leaf_value(WT_SESSION_IMPL *session, const WT_PAGE_HEADER
 
     /* Extract the delta metadata and then the actual delta value from the custom value format. */
     ret = __wt_struct_unpack(session, unpack->delta_value.data, unpack->delta_value.size,
-      WT_DELTA_LEAF_VALUE_FORMAT, &unpack->delta_value_data, &unpack->flags);
+      WT_DELTA_LEAF_VALUE_FORMAT, &unpack->flags, &unpack->delta_value_data);
 
     WT_ASSERT_ALWAYS(session, ret == 0, "Failed to decode the delta leaf value.");
 }

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -372,11 +372,11 @@ __wti_rec_pack_delta_row_leaf(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_SAV
 
     /* Pack the flags and delta value into a custom value. */
     WT_ERR(
-      __wt_struct_size(session, &custom_value_size, WT_DELTA_LEAF_VALUE_FORMAT, &value, flags));
+      __wt_struct_size(session, &custom_value_size, WT_DELTA_LEAF_VALUE_FORMAT, flags, &value));
     WT_ERR(__wt_scr_alloc(session, custom_value_size, &custom_value));
     custom_value->size = custom_value_size;
     WT_ERR(__wt_struct_pack(session, (void *)custom_value->data, custom_value_size,
-      WT_DELTA_LEAF_VALUE_FORMAT, &value, flags));
+      WT_DELTA_LEAF_VALUE_FORMAT, flags, &value));
 
     /* Pack the custom value into a standard cell structure. */
     WT_ERR(


### PR DESCRIPTION
Align leaf delta custom value layout with the “flag, then value” convention by changing WT_DELTA_LEAF_VALUE_FORMAT from uB to Bu, and updating all struct pack/unpack call sites accordingly. This reorders the on-disk encoding of leaf delta values to store the 1-byte flags field before the variable-length delta blob, without changing the fields’ types or overall size.