### PR TITLE
WT-16250 Enable truncate operations on disagg test/format

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1743,7 +1743,8 @@ variables:
       - func: "fetch artifacts"
       - func: "format test disagg"
         vars:
-          format_args: disagg.mode=switch runs.timer=10:15
+          # FIXME-WT-16695 Enable truncate on mode = switch when test failure is resolved.
+          format_args: disagg.mode=switch ops.truncate=0 runs.timer=10:15
           times: 5
 
   # FIXME-WT-16113: Consolidate this logic in test/format itself.
@@ -1755,7 +1756,8 @@ variables:
       - func: "format test disagg"
         vars:
           # Validate data with a non-layered table.
-          format_args: disagg.mode=switch ops.verify=1 runs.mirror=1 table1.runs.source=table table1.disagg.enabled=0 runs.timer=5:10
+          # FIXME-WT-16695 Enable truncate on mode = switch when test failure is resolved.
+          format_args: disagg.mode=switch ops.truncate=0 ops.verify=1 runs.mirror=1 table1.runs.source=table table1.disagg.enabled=0 runs.timer=5:10
           times: 5
 
   - &format-stress-test-disagg-multi
@@ -1765,7 +1767,8 @@ variables:
       - func: "fetch artifacts"
       - func: "format test disagg"
         vars:
-          format_args: disagg.multi=1 runs.predictable_replay=1 runs.ops=500000:2000000
+          # FIXME-WT-16695 Enable truncate on mode = multi when test failure is resolved.
+          format_args: disagg.multi=1 ops.truncate=0 runs.predictable_replay=1 runs.ops=500000:2000000
           times: 5
           reopen: false # FIXME-WT-16481 Reopen currently causes failures in disagg multi mode.
 
@@ -1777,7 +1780,8 @@ variables:
       - func: "format test disagg"
         vars:
           # Validate data with a non-layered table.
-          format_args: disagg.multi=1 runs.predictable_replay=1 ops.verify=1 disagg.multi_validation=1 runs.ops=500000:2000000
+          # FIXME-WT-16695 Enable truncate on mode = multi when test failure is resolved.
+          format_args: disagg.multi=1 runs.predictable_replay=1 ops.truncate=0 ops.verify=1 disagg.multi_validation=1 runs.ops=500000:2000000
           times: 5
           reopen: false # FIXME-WT-16481 Reopen currently causes failures in disagg multi mode.
 

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1767,8 +1767,7 @@ variables:
       - func: "fetch artifacts"
       - func: "format test disagg"
         vars:
-          # FIXME-WT-16695 Enable truncate on mode = multi when test failure is resolved.
-          format_args: disagg.multi=1 ops.truncate=0 runs.predictable_replay=1 runs.ops=500000:2000000
+          format_args: disagg.multi=1 runs.predictable_replay=1 runs.ops=500000:2000000
           times: 5
           reopen: false # FIXME-WT-16481 Reopen currently causes failures in disagg multi mode.
 
@@ -1780,8 +1779,7 @@ variables:
       - func: "format test disagg"
         vars:
           # Validate data with a non-layered table.
-          # FIXME-WT-16695 Enable truncate on mode = multi when test failure is resolved.
-          format_args: disagg.multi=1 runs.predictable_replay=1 ops.truncate=0 ops.verify=1 disagg.multi_validation=1 runs.ops=500000:2000000
+          format_args: disagg.multi=1 runs.predictable_replay=1 ops.verify=1 disagg.multi_validation=1 runs.ops=500000:2000000
           times: 5
           reopen: false # FIXME-WT-16481 Reopen currently causes failures in disagg multi mode.
 

--- a/test/format/CONFIG.disagg
+++ b/test/format/CONFIG.disagg
@@ -22,7 +22,6 @@ ops.pct.modify=0
 ops.compaction=0
 ops.salvage=0
 ops.throttle=0
-ops.truncate=0
 # FIXME-WT-15795 should allow prepared operations for layered tables.
 ops.prepare=0
 quiet=0


### PR DESCRIPTION
Enable truncate operations for test/format leader and follower runs.
Note that switch and multi are excluded for now - see WT-16695 FIXME.