### PR TITLE
WT-15840 Improve flags.py to accept more delimiters

### DIFF
--- a/dist/flags.py
+++ b/dist/flags.py
@@ -40,7 +40,7 @@ def flag_declare(name):
                         print("Flag stop value of " + str(max_flags) \
                                 + " is larger than field size " + str(fld_size))
                         sys.exit(1)
-            if line.find('AUTOMATIC FLAG VALUE GENERATION START') != -1:
+            if re.search(r"AUTOMATIC.*FLAG.*GENERATION START", line) != None:
                 m = re.search(r"\d+", line)
                 if m == None:
                     print(name + ": automatic flag generation start at line " +
@@ -51,7 +51,7 @@ def flag_declare(name):
                 header = line
                 defines = []
                 parsing = True
-            elif line.find('AUTOMATIC FLAG VALUE GENERATION STOP') != -1:
+            elif re.search(r"AUTOMATIC.*FLAG.*GENERATION STOP", line) != None:
                 m = re.search(r"\d+", line)
                 if m == None:
                     print(name + ": automatic flag generation stop at line " +

--- a/dist/flags.py
+++ b/dist/flags.py
@@ -40,7 +40,7 @@ def flag_declare(name):
                         print("Flag stop value of " + str(max_flags) \
                                 + " is larger than field size " + str(fld_size))
                         sys.exit(1)
-            if re.search(r"AUTOMATIC.*FLAG.*GENERATION START", line) != None:
+            if re.search(r"/\*[A-Z ]*AUTOMATIC[A-Z ]+FLAG[A-Z ]+GENERATION START", line) != None:
                 m = re.search(r"\d+", line)
                 if m == None:
                     print(name + ": automatic flag generation start at line " +
@@ -51,7 +51,7 @@ def flag_declare(name):
                 header = line
                 defines = []
                 parsing = True
-            elif re.search(r"AUTOMATIC.*FLAG.*GENERATION STOP", line) != None:
+            elif re.search(r"/\*[A-Z ]*AUTOMATIC[A-Z ]+FLAG[A-Z ]+GENERATION STOP", line) != None:
                 m = re.search(r"\d+", line)
                 if m == None:
                     print(name + ": automatic flag generation stop at line " +


### PR DESCRIPTION
Relaxed conditions for automatic flag generation. To start and end automatic flag generation it's required that:

start of group has "AUTOMATIC", "FLAG", "GENERATION START" in order on the line
end of group has "AUTOMATIC", "FLAG", "GENERATION END" in order on the line