### PR TITLE
WT-16714 Fix in-memory btrees not allowed to do updates eviction

### DIFF
--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1905,7 +1905,7 @@ retry:
             continue;
         }
 
-        if (F_ISSET(btree, WT_BTREE_IN_MEMORY) && !F_ISSET(evict, WT_EVICT_CACHE_DIRTY)) {
+        if (F_ISSET(btree, WT_BTREE_IN_MEMORY) && !F_ISSET(evict, WT_EVICT_CACHE_DIRTY | WT_EVICT_CACHE_UPDATES)) {
             __evict_disagg_btree_skip_count(session, btree);
             continue;
         }
@@ -2557,8 +2557,7 @@ __evict_try_queue_page(WT_SESSION_IMPL *session, WTI_EVICT_QUEUE *queue, WT_REF 
     want_page =
       (F_ISSET(evict, WT_EVICT_CACHE_CLEAN) && !F_ISSET(btree, WT_BTREE_IN_MEMORY) && !modified) ||
       (F_ISSET(evict, WT_EVICT_CACHE_DIRTY) && modified) ||
-      (F_ISSET(evict, WT_EVICT_CACHE_UPDATES) && !F_ISSET(btree, WT_BTREE_IN_MEMORY) &&
-        page->modify != NULL);
+      (F_ISSET(evict, WT_EVICT_CACHE_UPDATES) && page->modify != NULL);
     if (!want_page) {
         WT_STAT_CONN_INCR(session, eviction_server_skip_unwanted_pages);
         return;

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1905,7 +1905,8 @@ retry:
             continue;
         }
 
-        if (F_ISSET(btree, WT_BTREE_IN_MEMORY) && !F_ISSET(evict, WT_EVICT_CACHE_DIRTY | WT_EVICT_CACHE_UPDATES)) {
+        if (F_ISSET(btree, WT_BTREE_IN_MEMORY) &&
+          !F_ISSET(evict, WT_EVICT_CACHE_DIRTY | WT_EVICT_CACHE_UPDATES)) {
             __evict_disagg_btree_skip_count(session, btree);
             continue;
         }

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1905,6 +1905,11 @@ retry:
             continue;
         }
 
+        /*
+         * For in-memory btrees, if we are not evicting dirty pages or pages with active updates,
+         * walking them serves no purpose. Such pages are not eligible for clean eviction, making
+         * the operation unnecessary.
+         */
         if (F_ISSET(btree, WT_BTREE_IN_MEMORY) &&
           !F_ISSET(evict, WT_EVICT_CACHE_DIRTY | WT_EVICT_CACHE_UPDATES)) {
             __evict_disagg_btree_skip_count(session, btree);


### PR DESCRIPTION
In-memory btrees should be allowed to do updates eviction as reconciliation can remove the updates from the update chains for in-memory btrees as well. Not allowing updates eviction for in-memory btrees leads to performance regression for some high value workloads for in-memory databases in MongoDB.