### PR TITLE
WT-16715 Add TSAN test format to PR testing

### DIFF
--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -992,7 +992,8 @@ __txn_set_rollback_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t rollback_t
     __txn_assert_after_reads(session, "rollback", rollback_ts);
 
     /* Check whether the rollback timestamp is less than the stable timestamp. */
-    stable_ts = txn_global->stable_timestamp;
+    /* FIXME-WT-16717: Fix the race. */
+    stable_ts = __wt_tsan_suppress_load_uint64(&txn_global->stable_timestamp);
     if (rollback_ts <= stable_ts) {
         WT_RET_MSG(session, EINVAL,
           "rollback timestamp %s is not newer than the stable timestamp %s",

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4558,6 +4558,7 @@ tasks:
           test_format_extra_args: -C "verbose=(checkpoint_cleanup:1)"
 
   - name: format-stress-test-tsan
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -5271,6 +5272,7 @@ tasks:
           num_jobs: 1  # MSAN builds (with PALM) can cause OOM issues if multiple jobs are run in parallel.
 
   - name: format-stress-test-disagg-leader-tsan
+    tags: ["pull_request"]
     depends_on:
       - name: compile
     commands:
@@ -7620,7 +7622,6 @@ buildvariants:
     additional_env_vars: |
       export TSAN_OPTIONS="$COMMON_SAN_OPTIONS:history_size=7:print_suppressions=0:suppressions=$(git rev-parse --show-toplevel)/test/evergreen/tsan_warnings.supp"
     num_jobs: 2
-  tags: ["sanitizer", "pull_request"]
   tasks:
     - name: compile
     - name: examples-c-test

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -7620,6 +7620,7 @@ buildvariants:
     additional_env_vars: |
       export TSAN_OPTIONS="$COMMON_SAN_OPTIONS:history_size=7:print_suppressions=0:suppressions=$(git rev-parse --show-toplevel)/test/evergreen/tsan_warnings.supp"
     num_jobs: 2
+  tags: ["sanitizer", "pull_request"]
   tasks:
     - name: compile
     - name: examples-c-test


### PR DESCRIPTION
Currently, we run only TSAN Python tests as part of per-commit testing. The format test is another critical test that has found many bugs. To improve the developer experience, we should add it either to per-commit testing or to merge-queue testing.