### PR TITLE
WT-16725 Skip shared metadata for RTS

### DIFF
--- a/src/cursor/cur_hs.c
+++ b/src/cursor/cur_hs.c
@@ -1376,7 +1376,7 @@ __curhs_btree_id_to_hs_id(WT_SESSION_IMPL *session, uint32_t btree_id)
 {
     WT_ASSERT(session, btree_id != 0);
     /* Neither shared metadata nor the shared HS tables should have entries in HS. */
-    WT_ASSERT(session, WT_BTREE_ID_NAMESPACE_ID(btree_id) == WT_BTREE_ID_NAMESPACE_SPECIAL);
+    WT_ASSERT(session, WT_BTREE_ID_NAMESPACE_ID(btree_id) != WT_BTREE_ID_NAMESPACE_SPECIAL);
 
     /* No table ID namespaces. */
     if (!__wt_conn_is_disagg(session))

--- a/src/cursor/cur_hs.c
+++ b/src/cursor/cur_hs.c
@@ -1375,6 +1375,8 @@ static uint32_t
 __curhs_btree_id_to_hs_id(WT_SESSION_IMPL *session, uint32_t btree_id)
 {
     WT_ASSERT(session, btree_id != 0);
+    /* Neither shared metadata nor the shared HS tables should have entries in HS. */
+    WT_ASSERT(session, WT_BTREE_ID_NAMESPACE_ID(btree_id) == WT_BTREE_ID_NAMESPACE_SPECIAL);
 
     /* No table ID namespaces. */
     if (!__wt_conn_is_disagg(session))

--- a/src/cursor/cur_hs.c
+++ b/src/cursor/cur_hs.c
@@ -1375,7 +1375,7 @@ static uint32_t
 __curhs_btree_id_to_hs_id(WT_SESSION_IMPL *session, uint32_t btree_id)
 {
     WT_ASSERT(session, btree_id != 0);
-    /* Neither shared metadata nor the shared HS tables should have entries in HS. */
+    /* Shared metadata and history store should not have history store entries. */
     WT_ASSERT(session, WT_BTREE_ID_NAMESPACE_ID(btree_id) != WT_BTREE_ID_NAMESPACE_SPECIAL);
 
     /* No table ID namespaces. */

--- a/src/rollback_to_stable/rts_btree_walk.c
+++ b/src/rollback_to_stable/rts_btree_walk.c
@@ -292,7 +292,7 @@ __wti_rts_btree_walk_btree_apply(
     WT_ASSERT(session, rollback_timestamp != WT_TS_NONE);
 
     /* Ignore non-btree objects as well as the metadata and history store files. */
-    if (!WT_BTREE_PREFIX(uri) || WT_IS_URI_HS(uri) || strcmp(uri, WT_METAFILE_URI) == 0)
+    if (!WT_BTREE_PREFIX(uri) || WT_IS_URI_HS(uri) || WT_IS_URI_METADATA(uri))
         return (0);
 
     addr_size = 0;


### PR DESCRIPTION
Currently we skip shared and local HS and local metadata, but shared metadata is not getting skipped and proceed down the code flow that cause some extra work that might be avoided.