### PR TITLE
WT-15928 test/format (disagg.mode=follower) cache stuck issue

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1771,13 +1771,9 @@ variables:
       - name: compile
     commands:
       - func: "fetch artifacts"
-      - func: "format test script"
-        vars:
-          format_test_script_args: -t 180 -c ../../../test/format/CONFIG.disagg -- disagg.mode=follower runs.timer=5:10
-          num_jobs: 1 # Follower requires a larger cache; parallel execution may limit available cache and cause stalls.
       - func: "format test disagg"
         vars:
-          format_args: disagg.mode=follower runs.timer=5:10
+          format_args: disagg.mode=follower runs.ops=500000:2000000
           times: 5
 
   - &format-stress-test-disagg-switch


### PR DESCRIPTION
We've been having BFs on `format-stress-test-disagg-follower-1/2` due to the cache filling up and not being evicted. This is because these tests run follower as standalone without leader, so there are no checkpoints to pick up -> no eviction -> cache fills and becomes stuck until timeout.

The solution in this case is to remove the `format test script` subtask from these two tasks and instead just run `format test disagg` with a lower number of ops. We don't actually need such thorough in-memory testing on standalone follower, since without checkpoints it is effectively a subset of standalone leader which is has its own testing. This should greatly reduce the likelihood of the cache filling up and triggering this BF again. 