### PR TITLE
WT-16741 Make special namespace assertion backward compatible

### DIFF
--- a/src/cursor/cur_hs.c
+++ b/src/cursor/cur_hs.c
@@ -1380,6 +1380,9 @@ __curhs_btree_id_to_hs_id(WT_SESSION_IMPL *session, uint32_t btree_id)
     if (!__wt_conn_is_disagg(session))
         return (1);
 
+    /* Shared metadata and history store should not have history store entries. */
+    WT_ASSERT(session, WT_BTREE_ID_NAMESPACE_ID(btree_id) != WT_BTREE_ID_NAMESPACE_SPECIAL);
+
     /*
      * Map the history store ID into the URI. The current implementation does this simply using
      * table ID namespaces, but keep the notion of HS ID and namespace ID separate to ensure that we

--- a/src/cursor/cur_hs.c
+++ b/src/cursor/cur_hs.c
@@ -1375,8 +1375,6 @@ static uint32_t
 __curhs_btree_id_to_hs_id(WT_SESSION_IMPL *session, uint32_t btree_id)
 {
     WT_ASSERT(session, btree_id != 0);
-    /* Shared metadata and history store should not have history store entries. */
-    WT_ASSERT(session, WT_BTREE_ID_NAMESPACE_ID(btree_id) != WT_BTREE_ID_NAMESPACE_SPECIAL);
 
     /* No table ID namespaces. */
     if (!__wt_conn_is_disagg(session))


### PR DESCRIPTION
This assertion causes failures in backward compatibility testing. To fix it we can move it under the disagg branch.