### PR TITLE
WT-16747 Exclude sessions without a read timestamp from older readers metrics

### DIFF
--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -105,9 +105,7 @@ __wti_txn_get_pinned_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t *tsp, ui
     for (i = 0, s = txn_global->txn_shared_list; i < session_cnt; i++, s++) {
         __txn_get_read_timestamp(s, &tmp_read_ts);
 
-        /*
-         * Don't consider the sessions without a read timestamp.
-         */
+        /* Don't consider the sessions without a read timestamp. */
         if (tmp_read_ts == WT_TS_NONE)
             continue;
 

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -104,10 +104,17 @@ __wti_txn_get_pinned_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t *tsp, ui
     WT_ACQUIRE_READ_WITH_BARRIER(session_cnt, conn->session_array.cnt);
     for (i = 0, s = txn_global->txn_shared_list; i < session_cnt; i++, s++) {
         __txn_get_read_timestamp(s, &tmp_read_ts);
+
+        /*
+         * Don't consider the sessions without a read timestamp.
+         */
+        if (tmp_read_ts == WT_TS_NONE)
+            continue;
+
         /*
          * A zero timestamp is possible here only when the oldest timestamp is not accounted for.
          */
-        if (tmp_ts == WT_TS_NONE || (tmp_read_ts != WT_TS_NONE && tmp_read_ts < tmp_ts))
+        if (tmp_ts == WT_TS_NONE || tmp_read_ts < tmp_ts)
             tmp_ts = tmp_read_ts;
 
         if (tmp_read_ts < old_ts)


### PR DESCRIPTION
The metric "transaction number of older readers older than oldest timestamp" should exclude the readers without a read timestamp.
