### PR TITLE
WT-15042 Remove redundant -D disagg config in test/model

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5020,7 +5020,7 @@ tasks:
       - func: "compile wiredtiger"
       - func: "model test"
         vars:
-          model_test_args: -D -l 2000-3000 -t 3600
+          model_test_args: -G disaggregated=1 -l 2000-3000 -t 3600
 
   - name: model-test-long-random-config
     tags: ["model_checking"]
@@ -5038,7 +5038,7 @@ tasks:
       - func: "compile wiredtiger"
       - func: "model test"
         vars:
-          model_test_args: -D -l 100-200 -g -t 3600
+          model_test_args: -G disaggregated=1 -l 100-200 -g -t 3600
 
   - name: model-test-long-with-coverage
     tags: ["model_checking"]

--- a/test/model/src/driver/kv_workload_generator.cpp
+++ b/test/model/src/driver/kv_workload_generator.cpp
@@ -39,7 +39,7 @@ namespace model {
  */
 kv_workload_generator_spec::kv_workload_generator_spec()
 {
-    disaggregated = 0;  
+    disaggregated = 0;
 
     min_tables = 3;
     max_tables = 10;

--- a/test/model/src/driver/kv_workload_generator.cpp
+++ b/test/model/src/driver/kv_workload_generator.cpp
@@ -39,6 +39,7 @@ namespace model {
  */
 kv_workload_generator_spec::kv_workload_generator_spec()
 {
+    /* Disagg may be enabled by adding -G disaggregated=1 as a command line argument. */
     disaggregated = 0;
 
     min_tables = 3;

--- a/test/model/src/driver/kv_workload_generator.cpp
+++ b/test/model/src/driver/kv_workload_generator.cpp
@@ -39,7 +39,7 @@ namespace model {
  */
 kv_workload_generator_spec::kv_workload_generator_spec()
 {
-    disaggregated = 0; /* FIXME-WT-15042 Enable this when ready. */
+    disaggregated = 0;  
 
     min_tables = 3;
     max_tables = 10;

--- a/test/model/src/include/model/driver/kv_workload_generator.h
+++ b/test/model/src/include/model/driver/kv_workload_generator.h
@@ -47,7 +47,7 @@ namespace model {
  */
 struct kv_workload_generator_spec {
 
-    /* Top-level database configuration. */
+    /* Probability of running with disagg mode enabled*/
     float disaggregated;
 
     /* The minimum and maximum number of tables. */

--- a/test/model/tools/model_test/main.cpp
+++ b/test/model/tools/model_test/main.cpp
@@ -714,7 +714,6 @@ usage(const char *progname)
     fprintf(stderr, "usage: %s [OPTIONS]\n\n", progname);
     fprintf(stderr, "Options:\n");
     fprintf(stderr, "  -C CONFIG  specify WiredTiger's connection configuration\n");
-    fprintf(stderr, "  -D         use disaggregated storage (equivalent to -G disaggregated=1)\n");
     fprintf(stderr, "  -G CONFIG  specify the workload generator's configuration\n");
     fprintf(stderr, "  -g         generate random timing stress configuration\n");
     fprintf(stderr, "  -h HOME    specify the database directory\n");
@@ -763,13 +762,10 @@ main(int argc, char *argv[])
         int ch;
 
         __wt_optwt = 1;
-        while ((ch = __wt_getopt(progname, argc, argv, "C:DG:h:I:i:l:M:gnpRS:T:t:w:?")) != EOF)
+        while ((ch = __wt_getopt(progname, argc, argv, "C:G:h:I:i:l:M:gnpRS:T:t:w:?")) != EOF)
             switch (ch) {
             case 'C':
                 conn_config = model::join(conn_config, __wt_optarg);
-                break;
-            case 'D':
-                spec.disaggregated = 1;
                 break;
             case 'G':
                 update_spec(spec, conn_config, table_config, __wt_optarg);


### PR DESCRIPTION
We have two ways to enable disaggregate feature on model/test. From [WT-15103](https://jira.mongodb.org/browse/WT-15103) there is a -D option that enables disaggregate. But instead we can just do -G disaggregated=1.

I have removed the -D option and substituted -G disaggregated=1 in the corresponding evergreen tasks.