### PR TITLE
WT-16685 Coverity analysis defect 202305: Unintentional integer overflow

### DIFF
--- a/ext/test/key_provider/key_provider.c
+++ b/ext/test/key_provider/key_provider.c
@@ -199,7 +199,7 @@ kp_key_expired(KEY_PROVIDER *kp)
 
     const uint64_t now = kp_timestamp();
     const uint64_t elapsed_usec = CLOCK_USECS(now - kp->state.key_time);
-    return (elapsed_usec >= kp->key_expires * USEC_PER_SEC);
+    return (elapsed_usec >= (uint64_t)kp->key_expires * USEC_PER_SEC);
 }
 
 /*


### PR DESCRIPTION
Coverity complains about a uint64 comparison with int, the fix is to cast the int to `uint64_t`.
Cast to unsigned is safe because we've already checked that `kp->key_expires` is positive in `KEY_NEVER_USED(kp)`.