### PR TITLE
WT-16756 Remove the shared metadata ID assertion

### DIFF
--- a/src/cursor/cur_hs.c
+++ b/src/cursor/cur_hs.c
@@ -1380,9 +1380,6 @@ __curhs_btree_id_to_hs_id(WT_SESSION_IMPL *session, uint32_t btree_id)
     if (!__wt_conn_is_disagg(session))
         return (1);
 
-    /* Shared metadata and history store should not have history store entries. */
-    WT_ASSERT(session, WT_BTREE_ID_NAMESPACE_ID(btree_id) != WT_BTREE_ID_NAMESPACE_SPECIAL);
-
     /*
      * Map the history store ID into the URI. The current implementation does this simply using
      * table ID namespaces, but keep the notion of HS ID and namespace ID separate to ensure that we


### PR DESCRIPTION
That's unclear why, but even after we moved the assertion under the disagg branch in [WT-16741](https://jira.mongodb.org/browse/WT-16741) we still see it failing in backward compatibility tests. Since we don't have time to debug it right now, the simplest solution is to remove the assertion.