### PR TITLE
WT-5340 Create evergreen configuration to run test format in asan with new realloc exact debug mode

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5149,10 +5149,7 @@ tasks:
     name: format-stress-asan-test-4
     tags: ["stress-test-asan"]
   - <<: *format-stress-asan-realloc-exact-test
-    name: format-stress-asan-realloc-exact-test-1
-    tags: ["stress-test-asan"]
-  - <<: *format-stress-asan-realloc-exact-test
-    name: format-stress-asan-realloc-exact-test-2
+    name: format-stress-asan-realloc-exact-test
     tags: ["stress-test-asan"]
   - <<: *race-condition-stress-asan-test
     name: race-condition-stress-asan-test-1

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1698,6 +1698,18 @@ variables:
           additional_san_vars: export ASAN_OPTIONS="$COMMON_SAN_OPTIONS:unmap_shadow_on_exit=1"
           format_test_script_args: -t 360
 
+  - &format-stress-asan-realloc-exact-test
+    exec_timeout_secs: 25200
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+        vars:
+          <<: *configure_flags_asan_mongodb_stable_clang_with_builtins
+      - func: "format test script"
+        vars:
+          additional_san_vars: export ASAN_OPTIONS="$COMMON_SAN_OPTIONS:unmap_shadow_on_exit=1"
+          format_test_script_args: -t 360 -- -C "debug_mode=(realloc_exact=true)"
+
   - &race-condition-stress-asan-test
     exec_timeout_secs: 25200
     commands:
@@ -5135,6 +5147,12 @@ tasks:
     tags: ["stress-test-asan"]
   - <<: *format-stress-asan-test
     name: format-stress-asan-test-4
+    tags: ["stress-test-asan"]
+  - <<: *format-stress-asan-realloc-exact-test
+    name: format-stress-asan-realloc-exact-test-1
+    tags: ["stress-test-asan"]
+  - <<: *format-stress-asan-realloc-exact-test
+    name: format-stress-asan-realloc-exact-test-2
     tags: ["stress-test-asan"]
   - <<: *race-condition-stress-asan-test
     name: race-condition-stress-asan-test-1


### PR DESCRIPTION
Follow on work from [WT-4919](https://jira.mongodb.org/browse/WT-4919), we should use the new debug mode in asan with test/format to try and detect any potential memory leaks / issues that we would've missed using the original __wt_realloc_def.

I have created a new task `format-stress-asan-realloc-exact-test` that runs test format with the new debug mode, and added it to the list of ASAN stress tests.