### PR TITLE
WT-16704 Check multi before check block meta

### DIFF
--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2976,7 +2976,8 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
                      * the one held on page->disagg_info appears to be from the previous block, and
                      * the one on the multi->block_meta appears to be from the current block.
                      */
-                    if (r->multi->block_meta != NULL && r->multi->block_meta->delta_count == 0 &&
+                    if (r->multi != NULL && r->multi->block_meta != NULL &&
+                      r->multi->block_meta->delta_count == 0 &&
                       !F_ISSET(r->multi, WT_MULTI_SKIP_WRITE)) {
 
 #ifdef HAVE_DIAGNOSTIC

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2976,7 +2976,7 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
                      * the one held on page->disagg_info appears to be from the previous block, and
                      * the one on the multi->block_meta appears to be from the current block.
                      */
-                    if (r->multi != NULL && r->multi->block_meta != NULL &&
+                    if (r->multi_next > 0 && r->multi->block_meta != NULL &&
                       r->multi->block_meta->delta_count == 0 &&
                       !F_ISSET(r->multi, WT_MULTI_SKIP_WRITE)) {
 

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2976,7 +2976,7 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
                      * the one held on page->disagg_info appears to be from the previous block, and
                      * the one on the multi->block_meta appears to be from the current block.
                      */
-                    if (r->multi_next > 0 && r->multi->block_meta != NULL &&
+                    if (r->multi_next == 1 && r->multi->block_meta != NULL &&
                       r->multi->block_meta->delta_count == 0 &&
                       !F_ISSET(r->multi, WT_MULTI_SKIP_WRITE)) {
 


### PR DESCRIPTION
r->multi is able to be `NULL` here, so we need to check it before fetch deeper. 
@luke-pearson @mariammojid Need to double confirm whether this will skip some known scenarios.