### PR TITLE
WT-16785 Improve WiredTigerStat and WiredTigerCursor

### DIFF
--- a/test/suite/helper.py
+++ b/test/suite/helper.py
@@ -153,31 +153,34 @@ def simulate_crash_restart(testcase, olddir, newdir):
     testcase.conn = testcase.setUpConnectionOpen(newdir)
     testcase.session = testcase.setUpSessionOpen(testcase.conn)
 
-class WiredTigerStat:
-
-    def __init__(self, session, uri = None):
+class WiredTigerCursor:
+    def __init__(self, session, uri, *args, **kwargs):
         self.session = session
-        self.uri = "statistics:"
-        if uri:
-            self.uri += uri
+        self.uri = uri
+        self.args = args
+        self.kwargs = kwargs
+        self.cursor = None
+
+    def __enter__(self):
+        # Get a cursor
+        self.cursor = self.session.open_cursor(self.uri, *self.args, **self.kwargs)
+        return self.cursor
+
+    def __exit__(self, exception_type, exception_value, exception_traceback):
+        # TODO: do something here to handle exceptions
+        # Close the cursor
+        if self.cursor is not None:
+            self.cursor.close()
+class WiredTigerStat:
+    def __init__(self, session, uri = None):
+        self.uri = 'statistics:'
+        self.cursor_wrapper = WiredTigerCursor(session, self.uri + uri if uri else self.uri)
 
     def __enter__(self):
         # Get a statistics cursor
-        self.stat_cursor = self.session.open_cursor(self.uri, None, None)
+        self.stat_cursor = self.cursor_wrapper.__enter__()
         return self.stat_cursor
 
     def __exit__(self, exception_type, exception_value, exception_traceback):
         # Close the statistics cursor
-        self.stat_cursor.close()
-
-class WiredTigerCursor:
-    def __init__(self, session, uri = 'statistics:', *args, **kwargs):
-        self.cursor = session.open_cursor(uri, *args, **kwargs)
-
-    def __enter__(self):
-        # Get the opened cursor
-        return self.cursor
-
-    def __exit__(self, exception_type, exception_value, exception_traceback):
-        # Close the cursor
-        self.cursor.close()
+        self.cursor_wrapper.__exit__(exception_type, exception_value, exception_traceback)

--- a/test/suite/helper.py
+++ b/test/suite/helper.py
@@ -153,6 +153,9 @@ def simulate_crash_restart(testcase, olddir, newdir):
     testcase.conn = testcase.setUpConnectionOpen(newdir)
     testcase.session = testcase.setUpSessionOpen(testcase.conn)
 
+def statistic_uri(uri = ''):
+    return 'statistics:' + uri
+
 class WiredTigerCursor:
     def __init__(self, session, uri, *args, **kwargs):
         self.session = session
@@ -170,16 +173,3 @@ class WiredTigerCursor:
         # Close the cursor
         if self.cursor is not None:
             self.cursor.close()
-
-class WiredTigerStat:
-    def __init__(self, session, uri = None):
-        self.uri = 'statistics:'
-        self.cursor_wrapper = WiredTigerCursor(session, self.uri + uri if uri else self.uri)
-
-    def __enter__(self):
-        # Get a statistics cursor
-        return self.cursor_wrapper.__enter__()
-
-    def __exit__(self, exception_type, exception_value, exception_traceback):
-        # Close the statistics cursor
-        self.cursor_wrapper.__exit__(exception_type, exception_value, exception_traceback)

--- a/test/suite/helper.py
+++ b/test/suite/helper.py
@@ -167,7 +167,6 @@ class WiredTigerCursor:
         return self.cursor
 
     def __exit__(self, exception_type, exception_value, exception_traceback):
-        # TODO: do something here to handle exceptions
         # Close the cursor
         if self.cursor is not None:
             self.cursor.close()

--- a/test/suite/helper.py
+++ b/test/suite/helper.py
@@ -171,6 +171,7 @@ class WiredTigerCursor:
         # Close the cursor
         if self.cursor is not None:
             self.cursor.close()
+
 class WiredTigerStat:
     def __init__(self, session, uri = None):
         self.uri = 'statistics:'
@@ -178,8 +179,7 @@ class WiredTigerStat:
 
     def __enter__(self):
         # Get a statistics cursor
-        self.stat_cursor = self.cursor_wrapper.__enter__()
-        return self.stat_cursor
+        return self.cursor_wrapper.__enter__()
 
     def __exit__(self, exception_type, exception_value, exception_traceback):
         # Close the statistics cursor

--- a/test/suite/test_layered67.py
+++ b/test/suite/test_layered67.py
@@ -29,7 +29,7 @@
 import wttest
 from helper_disagg import disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
-from helper import WiredTigerStat
+from helper import WiredTigerCursor, statistic_uri
 from wiredtiger import stat
 
 
@@ -55,7 +55,7 @@ class test_layered67(wttest.WiredTigerTestCase):
 
     def test_uncommit_eviction(self):
         self.session.create(self.uri, self.session_create_config())
-        with WiredTigerStat(self.session, self.uri) as stat_cursor:
+        with WiredTigerCursor(self.session, statistic_uri(self.uri)) as stat_cursor:
             cache_put_before = stat_cursor[stat.dsrc.cache_write][2]
         self.session.begin_transaction()
 
@@ -77,6 +77,6 @@ class test_layered67(wttest.WiredTigerTestCase):
         evict_cursor.close()
 
         # Monitor the status after eviction.
-        with WiredTigerStat(self.session, self.uri) as stat_cursor:
+        with WiredTigerCursor(self.session, statistic_uri(self.uri)) as stat_cursor:
             cache_put_after = stat_cursor[stat.dsrc.cache_write][2]
         self.assertGreater(cache_put_after, cache_put_before)

--- a/test/suite/test_rollback_to_stable03.py
+++ b/test/suite/test_rollback_to_stable03.py
@@ -31,7 +31,7 @@ from wtdataset import SimpleDataSet
 from wiredtiger import stat
 from wtscenario import make_scenarios
 from rollback_to_stable_util import test_rollback_to_stable_base
-from helper import WiredTigerStat
+from helper import WiredTigerCursor, statistic_uri
 
 # test_rollback_to_stable03.py
 # Test that rollback to stable clears the history store updates from reconciled pages.
@@ -112,7 +112,7 @@ class test_rollback_to_stable03(test_rollback_to_stable_base):
         self.check(valueb, uri, nrows, 20)
         self.check(valuea, uri, nrows, 10)
 
-        with WiredTigerStat(self.session) as stat_cursor:
+        with WiredTigerCursor(self.session, statistic_uri()) as stat_cursor:
             calls = stat_cursor[stat.conn.txn_rts][2]
             hs_removed = stat_cursor[stat.conn.txn_rts_hs_removed][2]
             keys_removed = stat_cursor[stat.conn.txn_rts_keys_removed][2]
@@ -136,7 +136,7 @@ class test_rollback_to_stable03(test_rollback_to_stable_base):
         self.assertGreater(pages_visited, 0)
 
         self.conn.rollback_to_stable('threads=' + str(self.threads))
-        with WiredTigerStat(self.session) as stat_cursor:
+        with WiredTigerCursor(self.session, statistic_uri()) as stat_cursor:
             rts_btrees_applied = stat_cursor[stat.conn.txn_rts_btrees_applied][2]
             rts_btrees_skipped = stat_cursor[stat.conn.txn_rts_btrees_skipped][2]
 

--- a/test/suite/test_stat14.py
+++ b/test/suite/test_stat14.py
@@ -30,7 +30,7 @@ import wiredtiger, wttest
 from wiredtiger import stat
 from wtdataset import SimpleDataSet, simple_key
 from wtscenario import make_scenarios
-from helper import WiredTigerStat
+from helper import WiredTigerCursor, statistic_uri
 
 # test_stat14.py
 # Check that eviction threshold stats are correctly updated.
@@ -73,30 +73,30 @@ class test_stat14(wttest.WiredTigerTestCase):
 
         # Test with integer value: Reconfigure eviction_target to 70
         self.conn.reconfigure("eviction_target=70")
-        with WiredTigerStat(self.session) as stat_cursor:
+        with WiredTigerCursor(self.session, statistic_uri()) as stat_cursor:
             self.assertEqual(stat_cursor[stat.conn.eviction_threshold_cache_full_target][2], 7000)
 
         # Test with integer value: Reconfigure eviction_trigger to 85
         self.conn.reconfigure("eviction_trigger=85")
-        with WiredTigerStat(self.session) as stat_cursor:
+        with WiredTigerCursor(self.session, statistic_uri()) as stat_cursor:
             self.assertEqual(stat_cursor[stat.conn.eviction_threshold_cache_full_trigger][2], 8500)
 
         # Test with integer value: Reconfigure eviction_dirty_target to 10
         self.conn.reconfigure("eviction_dirty_target=10")
-        with WiredTigerStat(self.session) as stat_cursor:
+        with WiredTigerCursor(self.session, statistic_uri()) as stat_cursor:
             self.assertEqual(stat_cursor[stat.conn.eviction_threshold_dirty_target][2], 1000)
 
         # Test with integer value: Reconfigure eviction_dirty_trigger to 25
         self.conn.reconfigure("eviction_dirty_trigger=25")
-        with WiredTigerStat(self.session) as stat_cursor:
+        with WiredTigerCursor(self.session, statistic_uri()) as stat_cursor:
             self.assertEqual(stat_cursor[stat.conn.eviction_threshold_dirty_trigger][2], 2500)
 
         # Test with integer value: Reconfigure eviction_updates_target to 8
         self.conn.reconfigure("eviction_updates_target=8")
-        with WiredTigerStat(self.session) as stat_cursor:
+        with WiredTigerCursor(self.session, statistic_uri()) as stat_cursor:
             self.assertEqual(stat_cursor[stat.conn.eviction_threshold_updates_target][2], 800)
 
         # Test with integer value: Reconfigure eviction_updates_trigger to 15
         self.conn.reconfigure("eviction_updates_trigger=15")
-        with WiredTigerStat(self.session) as stat_cursor:
+        with WiredTigerCursor(self.session, statistic_uri()) as stat_cursor:
             self.assertEqual(stat_cursor[stat.conn.eviction_threshold_updates_trigger][2], 1500)


### PR DESCRIPTION
Merged `WiredTigerStat` and `WiredTigerCursor` classes, so that `WiredTigerStat` now wraps `WiredTigerCursor`. 

`WiredTigerCursor` is changed to a general cursor class, and the uri is now required, rather than defaulting to `'statistics:'`