### PR TITLE
WT-16375 Turn off failpoint when calling cursor->close()  (#13023)

### DIFF
--- a/test/suite/test_ovfl01.py
+++ b/test/suite/test_ovfl01.py
@@ -61,14 +61,9 @@ class test_ovfl01(wttest.WiredTigerTestCase):
                     raise e
 
         # Closing the cursor might hit the failpoint if the page needs to split during
-        # reconciliation, try again if this occurs.
-        while True:
-            try:
-                c.close()
-                return
-            except wiredtiger.WiredTigerError as e:
-                if str(e) != os.strerror(errno.EBUSY):
-                    raise e
+        # reconciliation, therefore turn off the failpoint.
+        self.conn.reconfigure('timing_stress_for_test=()')
+        c.close()
 
     def test_ovfl01(self):
         # Create and populate a table.


### PR DESCRIPTION
The issue was introduced from
[WT-15739](https://jira.mongodb.org/browse/WT-15739) which mentions a fix behind dangling overflow items due to an EBUSY returned from __rec_split_write.

The resolution of WT-15739 was that the origin of errors returned from reconciliation, and overflow items during bulk is unclear. The EBUSY returned is added through the failpoint. There are no theoretical case that we do encounter an error during cursor->close(). Therefore turn off the failpoint while performing cursor close in the python test.

(cherry picked from commit e8860651bd8ff0d88b6179223f3ca34a99c6c3c8)
