### PR TITLE
WT-16709 Improve time window string formatting

### DIFF
--- a/src/include/timestamp.h
+++ b/src/include/timestamp.h
@@ -20,11 +20,11 @@
 /*
  * We need an appropriately sized buffer for formatted time points, aggregates and windows. This is
  * for time windows with 6 timestamps, 2 transaction IDs, 2 prepared IDs, prepare state and
- * formatting. The formatting is currently about 64 characters - enough space that we don't need to
- * think about it. Time points have less information that time aggregate windows - cater for the
- * larger here.
+ * formatting. The formatting overhead is currently under 192 characters (field labels, etc.) -
+ * enough space that we don't need to think about it. Time points have less information that time
+ * aggregate windows - cater for the larger here.
  */
-#define WT_TIME_STRING_SIZE (WT_TS_INT_STRING_SIZE * 6 + 20 * 4 + 64)
+#define WT_TIME_STRING_SIZE (WT_TS_INT_STRING_SIZE * 6 + 20 * 4 + 192)
 
 /* The time points that define a value's time window and associated prepare information. */
 struct __wt_time_window {

--- a/src/support/timestamp.c
+++ b/src/support/timestamp.c
@@ -47,7 +47,9 @@ __wt_time_window_to_string(WT_TIME_WINDOW *tw, char *tw_string)
     char ts_string[6][WT_TS_INT_STRING_SIZE];
 
     WT_IGNORE_RET(__wt_snprintf(tw_string, WT_TIME_STRING_SIZE,
-      "start: %s/%s/%s/%" PRIu64 "/%" PRIu64 " | stop: %s/%s/%s/%" PRIu64 "/%" PRIu64 "%s",
+      "start: durable_timestamp=%s timestamp=%s prepare_timestamp=%s prepared_id=%" PRIu64
+      " transaction=%" PRIu64 " | stop: durable_timestamp=%s timestamp=%s prepare_timestamp=%s "
+      "prepared_id=%" PRIu64 " transaction=%" PRIu64 "%s",
       __wt_timestamp_to_string(tw->durable_start_ts, ts_string[0]),
       __wt_timestamp_to_string(tw->start_ts, ts_string[1]),
       __wt_timestamp_to_string(tw->start_prepare_ts, ts_string[2]), tw->start_prepared_id,

--- a/src/support/timestamp.c
+++ b/src/support/timestamp.c
@@ -46,17 +46,18 @@ __wt_time_window_to_string(WT_TIME_WINDOW *tw, char *tw_string)
 {
     char ts_string[6][WT_TS_INT_STRING_SIZE];
 
-    WT_IGNORE_RET(__wt_snprintf(tw_string, WT_TIME_STRING_SIZE,
-      "start: durable_timestamp=%s timestamp=%s prepare_timestamp=%s prepared_id=%" PRIu64
-      " transaction=%" PRIu64 " | stop: durable_timestamp=%s timestamp=%s prepare_timestamp=%s "
-      "prepared_id=%" PRIu64 " transaction=%" PRIu64 "%s",
-      __wt_timestamp_to_string(tw->durable_start_ts, ts_string[0]),
-      __wt_timestamp_to_string(tw->start_ts, ts_string[1]),
-      __wt_timestamp_to_string(tw->start_prepare_ts, ts_string[2]), tw->start_prepared_id,
-      tw->start_txn, __wt_timestamp_to_string(tw->durable_stop_ts, ts_string[3]),
-      __wt_timestamp_to_string(tw->stop_ts, ts_string[4]),
-      __wt_timestamp_to_string(tw->stop_prepare_ts, ts_string[5]), tw->stop_prepared_id,
-      tw->stop_txn, WT_TIME_WINDOW_HAS_PREPARE(tw) ? ", prepared" : ""));
+    WT_IGNORE_RET(
+      __wt_snprintf(tw_string, WT_TIME_STRING_SIZE,
+        "start: durable_timestamp=%s timestamp=%s prepare_timestamp=%s prepared_id=%" PRIu64
+        " transaction=%" PRIu64 " | stop: durable_timestamp=%s timestamp=%s prepare_timestamp=%s "
+        "prepared_id=%" PRIu64 " transaction=%" PRIu64 "%s",
+        __wt_timestamp_to_string(tw->durable_start_ts, ts_string[0]),
+        __wt_timestamp_to_string(tw->start_ts, ts_string[1]),
+        __wt_timestamp_to_string(tw->start_prepare_ts, ts_string[2]), tw->start_prepared_id,
+        tw->start_txn, __wt_timestamp_to_string(tw->durable_stop_ts, ts_string[3]),
+        __wt_timestamp_to_string(tw->stop_ts, ts_string[4]),
+        __wt_timestamp_to_string(tw->stop_prepare_ts, ts_string[5]), tw->stop_prepared_id,
+        tw->stop_txn, WT_TIME_WINDOW_HAS_PREPARE(tw) ? ", prepared" : ""));
     return (tw_string);
 }
 

--- a/tools/rts_verifier/operation.py
+++ b/tools/rts_verifier/operation.py
@@ -54,6 +54,21 @@ class OpType(Enum):
     SKIP_DEL = 45,
     NO_STABLE = 46
 
+_TIME_WINDOW_REGEX = (
+    r'start: '
+    r'durable_timestamp=\((\d+), (\d+)\) '
+    r'timestamp=\((\d+), (\d+)\) '
+    r'prepare_timestamp=\((\d+), (\d+)\) '
+    r'prepared_id=(\d+) '
+    r'transaction=(\d+) '
+    r'\| stop: '
+    r'durable_timestamp=\((\d+), (\d+)\) '
+    r'timestamp=\((\d+), (\d+)\) '
+    r'prepare_timestamp=\((\d+), (\d+)\) '
+    r'prepared_id=(\d+) '
+    r'transaction=(\d+)'
+)
+
 class Operation:
     def __init__(self, line):
         self.line = line
@@ -297,7 +312,7 @@ class Operation:
         self.type = OpType.HS_UPDATE_ABORT
         self.file = self.__extract_file(line)
 
-        matches = re.search('start: \((\d+), (\d+)\)/\((\d+), (\d+)\)/\((\d+), (\d+)\)/(\d+)/(\d+) \| stop: \((\d+), (\d+)\)/\((\d+), (\d+)\)/\((\d+), (\d+)\)/(\d+)/(\d+)', line)
+        matches = re.search(_TIME_WINDOW_REGEX, line)
 
         durable_start_start = int(matches.group(1))
         durable_start_end = int(matches.group(2))
@@ -332,7 +347,7 @@ class Operation:
         self.type = OpType.HS_UPDATE_VALID
         self.file = self.__extract_file(line)
 
-        matches = re.search('start: \((\d+), (\d+)\)/\((\d+), (\d+)\)/\((\d+), (\d+)\)/(\d+)/(\d+) \| stop: \((\d+), (\d+)\)/\((\d+), (\d+)\)/\((\d+), (\d+)\)/(\d+)/(\d+)', line)
+        matches = re.search(_TIME_WINDOW_REGEX, line)
 
         durable_start_start = int(matches.group(1))
         durable_start_end = int(matches.group(2))
@@ -391,7 +406,7 @@ class Operation:
         self.type = OpType.HS_GT_ONDISK
         self.file = self.__extract_file(line)
 
-        matches = re.search('start: \((\d+), (\d+)\)/\((\d+), (\d+)\)/\((\d+), (\d+)\)/(\d+)/(\d+) \| stop: \((\d+), (\d+)\)/\((\d+), (\d+)\)/\((\d+), (\d+)\)/(\d+)/(\d+)', line)
+        matches = re.search(_TIME_WINDOW_REGEX, line)
 
         durable_start_start = int(matches.group(1))
         durable_start_end = int(matches.group(2))
@@ -430,7 +445,7 @@ class Operation:
         self.type = OpType.HS_STOP_OBSOLETE
         self.file = self.__extract_file(line)
 
-        matches = re.search('start: \((\d+), (\d+)\)/\((\d+), (\d+)\)/\((\d+), (\d+)\)/(\d+)/(\d+) \| stop: \((\d+), (\d+)\)/\((\d+), (\d+)\)/\((\d+), (\d+)\)/(\d+)/(\d+)', line)
+        matches = re.search(_TIME_WINDOW_REGEX, line)
         durable_start_start = int(matches.group(1))
         durable_start_end = int(matches.group(2))
         self.durable_start = Timestamp(durable_start_start, durable_start_end)
@@ -518,7 +533,7 @@ class Operation:
         self.stop = self.__extract_simple_timestamp('stop_timestamp', line)
         self.stable = self.__extract_simple_timestamp('stable_timestamp', line)
 
-        matches = re.search('start: \((\d+), (\d+)\)/\((\d+), (\d+)\)/\((\d+), (\d+)\)/(\d+)/(\d+) \| stop: \((\d+), (\d+)\)/\((\d+), (\d+)\)/\((\d+), (\d+)\)/(\d+)/(\d+)', line)
+        matches = re.search(_TIME_WINDOW_REGEX, line)
 
         durable_start_start = int(matches.group(1))
         durable_start_end = int(matches.group(2))


### PR DESCRIPTION
I've chosen to make the string quite verbose because I saw from other string formatting that long property names were often used. It's possible to shorten 'timestamp' -> 'ts' or remove it altogether if we want it to be less verbose.

The extra characters introduced in the formatting is the following 174 characters, so I've rounded up to 192 (64 * 3)
`start: durable_timestamp= timestamp= prepare_timestamp= prepared_id= transaction= | stop: durable_timestamp= timestamp= prepare_timestamp= prepared_id= transaction=, prepared`

This is the old format
`start: (0, 5)/(0, 3)/(0, 0)/0/42 | stop: (0, 0)/(4294967295, 4294967295)/(0, 0)/0/18446744073709551615`

This is the new format
`start: durable_timestamp=(0, 5) timestamp=(0, 3) prepare_timestamp=(0, 0) prepared_id=0 transaction=42 | stop: durable_timestamp=(0, 0) timestamp=(4294967295, 4294967295) prepare_timestamp=(0, 0) prepared_id=0 transaction=18446744073709551615`