### PR TITLE
WT-14976 Remove reference to pl_get_package_part or update the API

### DIFF
--- a/lang/python/wiredtiger.i
+++ b/lang/python/wiredtiger.i
@@ -724,8 +724,11 @@ NOTFOUND_OK(__wt_cursor::largest_key)
 ANY_OK(__wt_modify::__wt_modify)
 ANY_OK(__wt_modify::~__wt_modify)
 ANY_OK(__wt_page_log_discard_args::__wt_page_log_discard_args)
-ANY_OK(__wt_page_log_get_args::__wt_page_log_get_args)
+ANY_OK(__wt_page_log_discard_args::~__wt_page_log_discard_args)
 ANY_OK(__wt_page_log_put_args::__wt_page_log_put_args)
+ANY_OK(__wt_page_log_put_args::~__wt_page_log_put_args)
+ANY_OK(__wt_page_log_get_args::__wt_page_log_get_args)
+ANY_OK(__wt_page_log_get_args::~__wt_page_log_get_args)
 
 COMPARE_OK(__wt_cursor::_compare)
 COMPARE_OK(__wt_cursor::_equals)
@@ -767,26 +770,6 @@ COMPARE_NOTFOUND_OK(__wt_cursor::_search_near)
 %ignore __wt_cursor::search_near(WT_CURSOR *, int *);
 %ignore __wt_page_log::get_complete_checkpoint(WT_PAGE_LOG *, int *);
 %ignore __wt_page_log::get_open_checkpoint(WT_PAGE_LOG *, int *);
-
-/* TODO: workaround for issues with getting a Python version of structs working. */
-%ignore __wt_page_log_discard_args::lsn;
-%ignore __wt_page_log_discard_args::backlink_lsn;
-%ignore __wt_page_log_discard_args::base_lsn;
-%ignore __wt_page_log_discard_args::backlink_checkpoint_id;
-%ignore __wt_page_log_discard_args::base_checkpoint_id;
-%ignore __wt_page_log_discard_args::lsn_frontier;
-%ignore __wt_page_log_put_args::backlink_lsn;
-%ignore __wt_page_log_put_args::base_lsn;
-%ignore __wt_page_log_put_args::backlink_checkpoint_id;
-%ignore __wt_page_log_put_args::base_checkpoint_id;
-%ignore __wt_page_log_put_args::flags;
-%ignore __wt_page_log_put_args::lsn;
-%ignore __wt_page_log_get_args::lsn;
-%ignore __wt_page_log_get_args::backlink_lsn;
-%ignore __wt_page_log_get_args::base_lsn;
-%ignore __wt_page_log_get_args::backlink_checkpoint_id;
-%ignore __wt_page_log_get_args::base_checkpoint_id;
-%ignore __wt_page_log_get_args::lsn_frontier;
 
 OVERRIDE_METHOD(__wt_cursor, WT_CURSOR, compare, (self, other))
 OVERRIDE_METHOD(__wt_cursor, WT_CURSOR, equals, (self, other))
@@ -1503,6 +1486,33 @@ OVERRIDE_METHOD(__wt_session, WT_SESSION, log_printf, (self, msg))
 %rename(FileSystem) __wt_file_system;
 
 %include "wiredtiger.h"
+
+%extend __wt_page_log_discard_args {
+	__wt_page_log_discard_args() {
+		return (struct __wt_page_log_discard_args *)calloc(1, sizeof(struct __wt_page_log_discard_args));
+	}
+	~__wt_page_log_discard_args() {
+		free($self);
+	}
+}
+
+%extend __wt_page_log_put_args {
+	__wt_page_log_put_args() {
+		return (struct __wt_page_log_put_args *)calloc(1, sizeof(struct __wt_page_log_put_args));
+	}
+	~__wt_page_log_put_args() {
+		free($self);
+	}
+}
+
+%extend __wt_page_log_get_args {
+	__wt_page_log_get_args() {
+		return (struct __wt_page_log_get_args *)calloc(1, sizeof(struct __wt_page_log_get_args));
+	}
+	~__wt_page_log_get_args() {
+		free($self);
+	}
+}
 
 /*
  * The original wiredtiger_calc_modify was ignored, now we define our own.

--- a/test/suite/test_disagg01.py
+++ b/test/suite/test_disagg01.py
@@ -49,32 +49,14 @@ class test_disagg01(wttest.WiredTigerTestCase, DisaggConfigMixin):
     def conn_extensions(self, extlist):
         DisaggConfigMixin.conn_extensions(self, extlist)
 
-    def breakpoint(self):
-        import pdb, sys
-        sys.stdin = open('/dev/tty', 'r')
-        sys.stdout = open('/dev/tty', 'w')
-        sys.stderr = open('/dev/tty', 'w')
-        pdb.set_trace()
-
-    def check_package(self, page_log, package, values):
-        i = 0
-        while True:
-            returns = page_log.pl_get_package_part(self.session, package, i)
-            if len(returns) == 0:
-                break
-            self.assertEquals(returns, values[i])
-            i += 1
-        self.assertEquals(len(values), i)
-
     def test_disagg_basic(self):
         # Test some basic functionality of the page log API, calling
         # each supported method in the API at least once.
-        self.skipTest('Disagg test is broken until PageLogPutArgs, PageLogGetArgs work')
         session = self.session
         page_log = self.conn.get_page_log('palite')
 
         page_log.pl_begin_checkpoint(session, 1)
-        page_log.pl_complete_checkpoint(session, 1)
+        page_log.pl_complete_checkpoint_ext(session, 1, 0, 'Checkpoint')
 
         page_log.pl_begin_checkpoint(session, 2)
         handle = page_log.pl_open_handle(session, 1)
@@ -94,17 +76,41 @@ class test_disagg01(wttest.WiredTigerTestCase, DisaggConfigMixin):
         put_args_delta.flags = flags_delta
 
         handle.plh_put(session, 20, 2, put_args_main, page20_full)
+        page20_full_lsn = put_args_main.lsn
+        put_args_delta.base_lsn = page20_full_lsn
+        put_args_delta.backlink_lsn = page20_full_lsn
         handle.plh_put(session, 20, 2, put_args_delta, page20_delta1)
+        page20_delta1_lsn = put_args_delta.lsn
+
+        put_args_main.backlink_lsn = 0
+        put_args_main.base_lsn = 0
         handle.plh_put(session, 21, 2, put_args_main, page21_full)
+        page21_full_lsn = put_args_main.lsn
+        put_args_delta.base_lsn = page21_full_lsn
+        put_args_delta.backlink_lsn = page21_full_lsn
         handle.plh_put(session, 21, 2, put_args_delta, page21_delta1)
+        page21_delta1_lsn = put_args_delta.lsn
+
+        put_args_delta.base_lsn = page20_full_lsn
+        put_args_delta.backlink_lsn = page20_delta1_lsn
         handle.plh_put(session, 20, 2, put_args_delta, page20_delta2)
 
         get_args = wiredtiger.PageLogGetArgs()
-
+        get_args.lsn = put_args_delta.lsn
         page20_results = handle.plh_get(session, 20, 2, get_args)
+
+        get_args.lsn = page21_delta1_lsn
         page21_results = handle.plh_get(session, 21, 2, get_args)
 
-        self.assertEquals(page20_results, [page20_full, page20_delta1, page20_delta2])
-        self.assertEquals(page21_results, [page21_full, page21_delta1])
+        self.assertEqual(page20_results, [page20_full, page20_delta1, page20_delta2])
+        self.assertEqual(page21_results, [page21_full, page21_delta1])
+
+        discard_args = wiredtiger.PageLogDiscardArgs()
+        discard_args.flags = 0
+        discard_args.base_lsn = page20_full_lsn
+        discard_args.backlink_lsn = put_args_delta.lsn
+        handle.plh_discard(session, 20, 2, discard_args)
+
+        self.assertGreater(discard_args.lsn, put_args_delta.lsn)
 
         page_log.terminate(session) # dereference


### PR DESCRIPTION
I fixed this ticket as a result of removing PALM and reviewing related issues.
This ticket looks like a low effort fix that re-enables a useful test.

- Fix Python bindings for get/put/discard page args structs
- Re-enable the test for page log extension API