### PR TITLE
WT-14769 Various smaller PALI and PALM cleanups

### DIFF
--- a/lang/python/wiredtiger.i
+++ b/lang/python/wiredtiger.i
@@ -205,14 +205,6 @@ from packing import pack, unpack
 	$1 = &val;
 }
 
-/* Why do we need an explicit conversion for plh_put - doesn't the previous typemap cover this? */
-%typemap(in) struct __wt_item *buf (WT_ITEM item) {
-	if (unpackBytesOrString($input, &item.data, &item.size) != 0)
-		SWIG_exception_fail(SWIG_AttributeError,
-		  "bad string value for WT_ITEM");
-	$1 = &item;
-}
-
 /*
  * This typemap removes the three last arguments for plh_get, and uses local variables for them instead.
  * The local variables will be used in the matching argout typemap.
@@ -1255,7 +1247,7 @@ SIDESTEP_METHOD(__wt_page_log, terminate,
   (self, session))
 
 SIDESTEP_METHOD(__wt_page_log_handle, plh_put,
-  (WT_SESSION *session, int page_id, int checkpoint_id, WT_PAGE_LOG_PUT_ARGS *put_args, WT_ITEM *buf),
+  (WT_SESSION *session, int page_id, int checkpoint_id, WT_PAGE_LOG_PUT_ARGS *put_args, const WT_ITEM *buf),
   (self, session, page_id, checkpoint_id, put_args, buf))
 
 SIDESTEP_METHOD(__wt_page_log_handle, plh_get,

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -605,7 +605,7 @@ __conn_get_page_log(WT_CONNECTION *wt_conn, const char *name, WT_PAGE_LOG **page
 
 /*
  * __wti_conn_remove_page_log --
- *     Remove page_log added by WT_CONNECTION->add_page_log, only used internally.
+ *     Remove all page_log instances added by WT_CONNECTION->add_page_log, only used internally.
  */
 int
 __wti_conn_remove_page_log(WT_SESSION_IMPL *session)


### PR DESCRIPTION
- Remove redundant SWIG typemap for `__wt_item`
- Fix comments for `__wti_conn_remove_page_log`
- Relevant test: `test_disagg01.py`
- The rest of items in the ticket relevant to PALM only, and therefore not applicable to PALite