### PR TITLE
WT-16751 Fix test_prepare28 under TSAN

### DIFF
--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1092,9 +1092,9 @@ __txn_resolve_prepared_update_chain(
     /* Resolve the prepared update to be a committed update. */
     __txn_apply_prepare_state_update(session, upd, true);
 
-    /* Sleep for 100ms in the prepared resolution path if configured. */
+    /* Sleep for 1 second in the prepared resolution path if configured. */
     if (FLD_ISSET(S2C(session)->timing_stress_flags, WT_TIMING_STRESS_PREPARE_RESOLUTION_2))
-        __wt_sleep(0, 100 * WT_THOUSAND);
+        __wt_sleep(0, 1000 * WT_THOUSAND);
     WT_STAT_CONN_INCR(session, txn_prepared_updates_committed);
 }
 

--- a/test/suite/test_prepare28.py
+++ b/test/suite/test_prepare28.py
@@ -27,6 +27,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 from time import sleep
+import wiredtiger
 import wttest, threading
 
 # Prior to a bugfix in WiredTiger it was possible to read a partial transaction if the config
@@ -60,6 +61,11 @@ class test_prepare28(wttest.WiredTigerTestCase):
         self.session.commit_transaction('commit_timestamp=6,durable_timestamp=6')
 
         ooo_thread.join()
+
+        stat_cursor = self.session.open_cursor('statistics:')
+        race_prepare_commit = stat_cursor[wiredtiger.stat.conn.txn_read_race_prepare_commit][2]
+        self.assertGreater(race_prepare_commit, 0)
+        stat_cursor.close()
 
     def read_update(self):
         sleep(0.1)

--- a/test/suite/test_prepare28.py
+++ b/test/suite/test_prepare28.py
@@ -54,7 +54,12 @@ class test_prepare28(wttest.WiredTigerTestCase):
         ooo_thread = threading.Thread(target=self.read_update)
         # Start the thread
         ooo_thread.start()
+        # `prepare_resolution_2` injects a sleep before assigning WT_PREPARE_RESOLVED to the updates
+        # so when we read entries from self.read_update() we read the update list in it's intermediate state
+        # where some updates have WT_PREPARE_INPROGRESS and others have WT_PREPARE_RESOLVED
         self.session.commit_transaction('commit_timestamp=6,durable_timestamp=6')
+
+        ooo_thread.join()
 
     def read_update(self):
         sleep(0.1)
@@ -66,5 +71,5 @@ class test_prepare28(wttest.WiredTigerTestCase):
         # Read here
         ret = cursor.search()
         # Assert it didn't find anything, i.e. not WT_NOTFOUND
-        assert(ret == -31803)
+        self.assertEqual(ret, -31803)
         session.commit_transaction()


### PR DESCRIPTION
Recently, we started seeing many TSAN warnings reported from test_prepare28. Trying to identify the commit after which these warnings started occurring didn’t help, since that commit modified unrelated code, which is quite strange.

After a deeper investigation and a better understanding of the test case, we found a couple of places that could lead to test failures under certain conditions:

**thread_ooo.join() absence**

The test didn’t call join() for the user thread created there. As a result, in some environments the main thread completed the test function body before the user thread finished its cursor operations. After completing the test body, the main thread runs teardown code that destroys the connection (which destroys all cursors in all sessions). Doing this in parallel with other cursor operations is illegal.

**order of events while running under TSAN**

The test heavily relies on sleep calls inserted in specific places. The `commit_transaction` function with `prepare_resolution_2` had a 100 ms sleep after assigning `WT_PREPARE_RESOLVED` to an update, and `read_update` was supposed to wait 100 ms until the first `WT_PREPARE_RESOLVED` assignment occurred, then search for a key while commit_transaction was in its first sleep.

However, in some environments (such as TSAN), scheduling likely works differently. With the existing sleeps, `commit_transaction` could run fast enough to assign `WT_PREPARE_RESOLVED `to all updates before `read_update` started searching, allowing it to see the value. By increasing the sleep in `commit_transaction` to 1 second, we avoid these scheduling inconsistencies.