### PR TITLE
WT-16752 Fix version_cursor_count data race

### DIFF
--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -2382,7 +2382,7 @@ __wt_txn_stats_update(WT_SESSION_IMPL *session)
     WT_STAT_CONN_SET(session, txn_global_stable_timestamp,
       __wt_atomic_load_uint64_relaxed(&txn_global->stable_timestamp));
 
-    if (conn->version_cursor_count == 0)
+    if (__wt_atomic_load_uint32_relaxed(&conn->version_cursor_count) == 0)
         WT_STAT_CONN_SET(session, txn_global_version_cursor_timestamp, WT_TS_NONE);
     else
         WT_STAT_CONN_SET(session, txn_global_version_cursor_timestamp,


### PR DESCRIPTION
`test_layered27` started to produce the following race that was introduced by https://github.com/wiredtiger/wiredtiger/commit/c3d0e64dc0dfb36469e5bc5fb5d2ebcec9b016a5. 

This PR fixes the race.

```
==================
WARNING: ThreadSanitizer: data race (pid=564687)
  Atomic write of size 4 at 0x72940051a178 by thread T20:
    #0 __wt_atomic_add_uint32 /home/ubuntu/work/git/wiredtiger2/src/include/gcc.h:397 (libwiredtiger.so.12.0.0+0x4e26cf)
    #1 __wt_curversion_open /home/ubuntu/work/git/wiredtiger2/src/cursor/cur_version.c:932 (libwiredtiger.so.12.0.0+0x4da2c3)
    #2 __session_open_cursor_int /home/ubuntu/work/git/wiredtiger2/src/session/session_api.c:699 (libwiredtiger.so.12.0.0+0x71beea)
    #3 __wt_open_cursor /home/ubuntu/work/git/wiredtiger2/src/session/session_api.c:810 (libwiredtiger.so.12.0.0+0x71b43b)
    #4 __layered_copy_ingest_table /home/ubuntu/work/git/wiredtiger2/src/conn/conn_layered_ingest.c:139 (libwiredtiger.so.12.0.0+0x37a156)
    #5 __layered_drain_worker_run /home/ubuntu/work/git/wiredtiger2/src/conn/conn_layered_ingest.c:297 (libwiredtiger.so.12.0.0+0x3773fd)
    #6 __thread_run /home/ubuntu/work/git/wiredtiger2/src/support/thread_group.c:32 (libwiredtiger.so.12.0.0+0x840059)
    #7 <null> <null> (libtsan.so.2+0x4eb39) (BuildId: 42b5aaa136fc79e0bafafdb560e4a5bb0c885482)

  Previous read of size 4 at 0x72940051a178 by thread T1:
    #0 __wt_txn_stats_update /home/ubuntu/work/git/wiredtiger2/src/txn/txn.c:2385 (libwiredtiger.so.12.0.0+0x862fe3)
    #1 __wt_conn_stat_init /home/ubuntu/work/git/wiredtiger2/src/conn/conn_stat.c:79 (libwiredtiger.so.12.0.0+0x3aa279)
    #2 __curstat_conn_init /home/ubuntu/work/git/wiredtiger2/src/cursor/cur_stat.c:374 (libwiredtiger.so.12.0.0+0x48ea69)
    #3 __wt_curstat_init /home/ubuntu/work/git/wiredtiger2/src/cursor/cur_stat.c:597 (libwiredtiger.so.12.0.0+0x48e55d)
    #4 __wt_curstat_open /home/ubuntu/work/git/wiredtiger2/src/cursor/cur_stat.c:769 (libwiredtiger.so.12.0.0+0x490ab2)
    #5 __statlog_dump /home/ubuntu/work/git/wiredtiger2/src/conn/conn_stat.c:351 (libwiredtiger.so.12.0.0+0x3ae12b)
    #6 __statlog_log_one /home/ubuntu/work/git/wiredtiger2/src/conn/conn_stat.c:452 (libwiredtiger.so.12.0.0+0x3ad860)
    #7 __statlog_server /home/ubuntu/work/git/wiredtiger2/src/conn/conn_stat.c:545 (libwiredtiger.so.12.0.0+0x3acfbc)
    #8 <null> <null> (libtsan.so.2+0x4eb39) (BuildId: 42b5aaa136fc79e0bafafdb560e4a5bb0c885482)

  Location is heap block of size 8760 at 0x729400519000 allocated by main thread:
    #0 calloc <null> (libtsan.so.2+0x543de) (BuildId: 42b5aaa136fc79e0bafafdb560e4a5bb0c885482)
    #1 __wt_calloc /home/ubuntu/work/git/wiredtiger2/src/os_common/os_alloc.c:68 (libwiredtiger.so.12.0.0+0x5d35d4)
    #2 wiredtiger_open /home/ubuntu/work/git/wiredtiger2/src/conn/conn_api.c:3116 (libwiredtiger.so.12.0.0+0x32ff4e)
    #3 _wrap_wiredtiger_open CMakeFiles/wiredtiger_python.dir/wiredtigerPYTHON_wrap.c:10270 (_wiredtiger.so+0x3423a)
    #4 cfunction_call ../src/Python-3.10.4/Objects/methodobject.c:552 (libpython3.10.so.1.0+0x13cee7) (BuildId: f02f0dfb3961695da49bec28c02414ff4e5ea733)

  Thread T20 'disagg-drain 1' (tid=564713, running) created by main thread at:
    #0 pthread_create <null> (libtsan.so.2+0x594e6) (BuildId: 42b5aaa136fc79e0bafafdb560e4a5bb0c885482)
    #1 __wt_thread_create /home/ubuntu/work/git/wiredtiger2/src/os_posix/os_thread.c:71 (libwiredtiger.so.12.0.0+0x5f0127)
    #2 __thread_group_resize /home/ubuntu/work/git/wiredtiger2/src/support/thread_group.c:209 (libwiredtiger.so.12.0.0+0x83db89)
    #3 __wt_thread_group_create /home/ubuntu/work/git/wiredtiger2/src/support/thread_group.c:295 (libwiredtiger.so.12.0.0+0x83e46d)
    #4 __wti_layered_drain_ingest_tables /home/ubuntu/work/git/wiredtiger2/src/conn/conn_layered_ingest.c:390 (libwiredtiger.so.12.0.0+0x37676a)
    #5 __disagg_step_up /home/ubuntu/work/git/wiredtiger2/src/conn/conn_layered.c:1153 (libwiredtiger.so.12.0.0+0x39065f)
    #6 __wti_disagg_conn_config /home/ubuntu/work/git/wiredtiger2/src/conn/conn_layered.c:1254 (libwiredtiger.so.12.0.0+0x38d618)
    #7 __wti_conn_reconfig /home/ubuntu/work/git/wiredtiger2/src/conn/conn_reconfig.c:450 (libwiredtiger.so.12.0.0+0x3a8edb)
    #8 __conn_reconfigure /home/ubuntu/work/git/wiredtiger2/src/conn/conn_api.c:1368 (libwiredtiger.so.12.0.0+0x33a64c)
    #9 _wrap_Connection_reconfigure CMakeFiles/wiredtiger_python.dir/wiredtigerPYTHON_wrap.c:8956 (_wiredtiger.so+0x3009c)
    #10 cfunction_call ../src/Python-3.10.4/Objects/methodobject.c:552 (libpython3.10.so.1.0+0x13cee7) (BuildId: f02f0dfb3961695da49bec28c02414ff4e5ea733)

  Thread T1 'statlog-server' (tid=564694, running) created by main thread at:
    #0 pthread_create <null> (libtsan.so.2+0x594e6) (BuildId: 42b5aaa136fc79e0bafafdb560e4a5bb0c885482)
    #1 __wt_thread_create /home/ubuntu/work/git/wiredtiger2/src/os_posix/os_thread.c:71 (libwiredtiger.so.12.0.0+0x5f0127)
    #2 __statlog_start /home/ubuntu/work/git/wiredtiger2/src/conn/conn_stat.c:587 (libwiredtiger.so.12.0.0+0x3ac512)
    #3 __wti_statlog_create /home/ubuntu/work/git/wiredtiger2/src/conn/conn_stat.c:627 (libwiredtiger.so.12.0.0+0x3ab40e)
    #4 __wti_connection_workers /home/ubuntu/work/git/wiredtiger2/src/conn/conn_open.c:241 (libwiredtiger.so.12.0.0+0x39d99d)
    #5 wiredtiger_open /home/ubuntu/work/git/wiredtiger2/src/conn/conn_api.c:3549 (libwiredtiger.so.12.0.0+0x334a44)
    #6 _wrap_wiredtiger_open CMakeFiles/wiredtiger_python.dir/wiredtigerPYTHON_wrap.c:10270 (_wiredtiger.so+0x3423a)
    #7 cfunction_call ../src/Python-3.10.4/Objects/methodobject.c:552 (libpython3.10.so.1.0+0x13cee7) (BuildId: f02f0dfb3961695da49bec28c02414ff4e5ea733)

SUMMARY: ThreadSanitizer: data race /home/ubuntu/work/git/wiredtiger2/src/include/gcc.h:397 in __wt_atomic_add_uint32
==================
```