### PR TITLE
WT-16850 Workgen Fix stopping-flag concurrency bug that prematurely halts the timestamp thread

### DIFF
--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -214,6 +214,9 @@ thread_tables_drop_workload(void *arg)
  */
 volatile std::sig_atomic_t signal_raised = 0;
 
+/* Separate control for the timestamp thread. */
+static volatile bool stop_timestamp_thread = false;
+
 void
 signal_handler(int signum)
 {
@@ -771,7 +774,7 @@ WorkloadRunner::increment_timestamp(WT_CONNECTION *conn)
     char buf[BUF_SIZE];
 
     ContextInternal *icontext = _workload->_context->_internal;
-    while (!stopping) {
+    while (!stop_timestamp_thread) {
         if (_workload->options.oldest_timestamp_lag > 0) {
             const std::lock_guard<std::shared_mutex> lock(*icontext->_ts_mutex);
             time_us = WorkgenTimeStamp::get_timestamp_lag(_workload->options.oldest_timestamp_lag);
@@ -3684,6 +3687,8 @@ WorkloadRunner::run_all(WT_CONNECTION *conn)
 
     // Wait for the time increment thread
     if (runnerConnection != nullptr) {
+        // Tell the timestamp thread to exit now that we are truly done.
+        stop_timestamp_thread = true;
         WT_TRET(pthread_join(time_thandle, &status));
         delete runnerConnection;
     }


### PR DESCRIPTION

This change decouples Workgen’s timestamp thread shutdown from the global stopping flag (WT-16850). Previously, increment_timestamp exited as soon as stopping was set, which could happen while worker threads were still active. That caused stable/oldest timestamps to stop advancing prematurely, creating artificial “stuck timestamp” behavior driven by Workgen rather than WiredTiger.

We introduce a dedicated stop_timestamp_thread flag for the timestamp thread. Worker threads still use stopping, but the timestamp thread now runs independently in the background and is only stopped explicitly at the end of the run. This makes timestamp advancement closer to MongoDB’s model and avoids harness‑induced timestamp stalls.
