### PR TITLE
WT-16871 Minor python tests OpLog improvements

### DIFF
--- a/test/suite/helper_disagg.py
+++ b/test/suite/helper_disagg.py
@@ -463,19 +463,26 @@ class Oplog(object):
             if cursor:
                 cursor.close()
 
-    def get_table_snapshot(self, table):
-        entlist = self._uris[table - 1][1]
+    def get_table_snapshot(self, table, pos_limit = -1):
+        uri = self._uris[table - 1]
+        prev = -1
         result = dict()
 
-        for entindex in entlist:
+        for entindex in uri[1]:
+            if entindex < prev:
+                raise Exception(f'oplog: entindex for URI {uri[0]} is out of order')
+            if pos_limit > 0 and entindex >= pos_limit:
+                break
+
             (_,k,v) = self._entries[entindex]
             if v == self._tombstone_value:
                 result.pop(self.gen_key(k), None)  # Remove if exists
             else:
                 result[self.gen_key(k)] = self.gen_value(v)
 
-        # Sort by keys as strings (lexicographic order: "1", "10", "11", "2", "21", ...)
-        return sorted(result.items(), key=lambda x: x[0])
+            prev = entindex
+
+        return result
 
     def check(self, testcase, session, pos, count):
         # Keep a cache of open cursors
@@ -515,29 +522,19 @@ class Oplog(object):
                 cursor.close()
 
         # Do a cursor scan, compare against most recent.
-        for uri, entlist in self._uris:
-            # Set up the values we think should be present for this table
-            values = dict()        # key -> value for most recent value
-            prev = -1
-            for entindex in entlist:
-                if entindex < prev:
-                    raise Exception(f'oplog: entindex for URI {uri} is out of order')
-                if entindex >= pos_limit:
-                    break
-                (_,k,v) = self._entries[entindex]
-                values[k] = v    # overwrites in time order, so we end up with most recent
-                prev = entindex
+        for table, (uri, _) in enumerate(self._uris, 1):
+            # Build expected unencoded key/value pairs through pos_limit.
+            values = self.get_table_snapshot(table, pos_limit = pos_limit)
 
             # Walk the cursor and check
             cursor = session.open_cursor(uri)
             for k,v in cursor:
-                kint = self.decode_key(k)
-                if not kint in values:
-                    testcase.pr(f'FAILURE got unexpected key {kint}, value {v} from cursor')
-                elif v != self.gen_value(values[kint]):
-                    testcase.pr(f'FAILURE at key {kint}, got value {v} want {values[kint]}')
-                testcase.assertEqual(v, self.gen_value(values[kint]))
-                del values[kint]
+                if not k in values:
+                    testcase.pr(f'FAILURE got unexpected key {k}, value {v} from cursor')
+                elif v != values[k]:
+                    testcase.pr(f'FAILURE at key {k}, got value {v} want {values[k]}')
+                testcase.assertEqual(v, values[k])
+                del values[k]
             cursor.close()
 
             testcase.assertEqual(

--- a/test/suite/helper_disagg.py
+++ b/test/suite/helper_disagg.py
@@ -297,7 +297,7 @@ class Oplog(object):
     def __init__(self, key_size=-1, value_size=-1):
         self._timestamp = 0       # last (1-based) timestamp used
         self._entries = []        # list of (table,k,v) triples.
-        self._uris = []           # list of (uri,entlist) pairs.  Each entlist is an ordered list of
+        self._uris = []           # list of (uri,entlist) pairs. Each entlist is an ordered list of
                                   # offsets into _entries that apply to this table.
         self._lookup = dict()     # lookup keyed by (table,k) pairs, gives a list of (ts,v) pairs.
         self._tombstone_value = 'tombstone'
@@ -308,13 +308,19 @@ class Oplog(object):
         self.key_size = key_size
         self.value_size = value_size
 
-    # Generate the key from an int, by default a simple string.
-    # The key size can be modified to make this longer.
-    def gen_key(self, i):
+    def gen_entry(self, i, size):
+        """
+        Generate the key from an int, by default a simple string.
+        The key size can be modified to make this longer.
+        """
         result = str(i)
-        if self.key_size > 0 and self.key_size > len(result):
-            result += '.' * (self.key_size - len(result))
+        if size > len(result):
+            result += '.' * (size - len(result))
         return result
+
+    # Generate the key
+    def gen_key(self, i):
+        return self.gen_entry(i, self.key_size)
 
     # Generate the key integer, the reverse of gen_key.
     def decode_key(self, s):
@@ -332,13 +338,10 @@ class Oplog(object):
             raise Exception(f'Oplog key returned: {s}, unexpected format for key_size={self.key_size}')
         return result
 
-    # Generate the value from an int, by default a simple string.
+    # Generate the value
     # Note: this can be overridden, as long as decode_value is as well
     def gen_value(self, i):
-        result = str(i)
-        if self.value_size > 0 and self.value_size > len(result):
-            result += '.' * (self.value_size - len(result))
-        return result
+        return self.gen_entry(i, self.value_size)
 
     def add_uri(self, uri):
         self._uris.append((uri,[]))
@@ -518,11 +521,12 @@ class Oplog(object):
             prev = -1
             for entindex in entlist:
                 if entindex < prev:
-                    raise Exception(f'oplog: intindex for {table} is out of order')
+                    raise Exception(f'oplog: entindex for URI {uri} is out of order')
                 if entindex >= pos_limit:
                     break
                 (_,k,v) = self._entries[entindex]
                 values[k] = v    # overwrites in time order, so we end up with most recent
+                prev = entindex
 
             # Walk the cursor and check
             cursor = session.open_cursor(uri)
@@ -535,6 +539,9 @@ class Oplog(object):
                 testcase.assertEqual(v, self.gen_value(values[kint]))
                 del values[kint]
             cursor.close()
+
+            testcase.assertEqual(
+                values, {}, f'FAILURE URI {uri} missing keys after scan: {sorted(values.keys())}')
 
     def __str__(self):
         return 'Oplog:' + \

--- a/test/suite/test_layered_cursor01.py
+++ b/test/suite/test_layered_cursor01.py
@@ -169,7 +169,8 @@ class test_layered_cursor01(wttest.WiredTigerTestCase):
 
     def check_cursor_ops(self):
         # Get the table expected content and turn it to an array of (key, value) tuples
-        table = self.oplog.get_table_snapshot(self.table_oplog_id)
+        # Sort by keys as strings (lexicographic order: "1", "10", "11", "2", "21", ...)
+        table = sorted(self.oplog.get_table_snapshot(self.table_oplog_id).items(), key=lambda x: x[0])
 
         # Check on the beginning, 25%, 50%, 75%, 100%.
         positions_to_check = [0, len(table) // 4, len(table) // 2, (3 * len(table)) // 4]


### PR DESCRIPTION
OpLog implementation in helper_dissagg.py has some minor places for improvements:
- check() doesn't update prev
- gen_key() and gen_value() can be unified
- get_table_snapshot() can be used as a part of check with minor changes
