### PR TITLE
WT-14785 Disagg python testing: triage test_prepare*.py tests

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1431,7 +1431,6 @@ unmodify
 unmount
 unpackv
 unpositioned
-unpositioning
 unredact
 unredacts
 unreferenced

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1431,6 +1431,7 @@ unmodify
 unmount
 unpackv
 unpositioned
+unpositioning
 unredact
 unredacts
 unreferenced

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -1510,7 +1510,7 @@ err:
         F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
         F_SET(cursor, WT_CURSTD_KEY_INT | WT_CURSTD_VALUE_INT);
     } else if (ret != WT_PREPARE_CONFLICT) {
-        /* FIXME-WT-16880: Fix layered search_near() incorrectly unpositioning the cursor. */
+        /* FIXME-WT-16880: Fix layered search_near() incorrectly resetting the cursor. */
         F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
         clayered->current_cursor = NULL;
     }

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -1510,6 +1510,7 @@ err:
         F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
         F_SET(cursor, WT_CURSTD_KEY_INT | WT_CURSTD_VALUE_INT);
     } else if (ret != WT_PREPARE_CONFLICT) {
+        /* FIXME-WT-16880: Fix layered search_near() incorrectly unpositioning the cursor. */
         F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
         clayered->current_cursor = NULL;
     }

--- a/test/suite/hook_disagg.fail
+++ b/test/suite/hook_disagg.fail
@@ -22,24 +22,19 @@ test_empty.py
 test_encrypt06.py
 test_env01.py
 test_error_info01.py
-test_error_info03.py
+test_error_info03.py    # FIXME: WT-16872
 test_hs01.py  # FIXME: WT-15371
 test_hs18.py
 test_hs21.py
-test_hs24.py
+test_hs24.py    # FIXME: WT-16872
 test_hs30.py
-test_hs_evict_race01.py
+test_hs_evict_race01.py # FIXME: WT-16872
 test_log03.py
 test_metadata_cursor01.py
 test_metadata_cursor04.py
-test_prepare03.py
-test_prepare28.py
-test_prepare29.py
-test_prepare_cursor01.py
-test_prepare_hs03.py
-test_prepare_hs04.py
+test_prepare28.py   # FIXME: WT-16872
 test_readonly01.py
-test_readonly03.py  # WT-14582
+test_readonly03.py  # FIXME: WT-14582
 test_shared_cache01.py
 test_stat01.py
 test_stat_log02.py

--- a/test/suite/test_prepare03.py
+++ b/test/suite/test_prepare03.py
@@ -77,7 +77,12 @@ class test_prepare03(wttest.WiredTigerTestCase):
         self.pr('creating cursor')
         cursor = self.session.open_cursor(tablearg, None, None)
         self.assertCursorHasNoKeyValue(cursor)
-        if not self.runningHook('disagg'):
+
+        if self.runningHook('disagg') and self.tablekind == 'row' and self.uri == 'table':
+            # If we're running disagg, the hook will have created a "layered:" table for this
+            # scenario; tablearg will still have a "table:" prefix, so we need a custom comparison.
+            self.assertEqual(cursor.uri, "layered" + ':' + self.table_name)
+        else:
             self.assertEqual(cursor.uri, tablearg)
 
         # Check insert operation
@@ -177,17 +182,16 @@ class test_prepare03(wttest.WiredTigerTestCase):
         cursor.update()
         cursor.remove()
 
-        # Check search_near operation
-        cursor.set_key(self.genkey(self.nentries))
-        self.session.begin_transaction()
-        self.session.prepare_transaction("prepare_timestamp=2a")
-        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
-            lambda:cursor.search_near(), preparemsg)
-        self.session.timestamp_transaction("commit_timestamp=2b")
-        self.session.timestamp_transaction("durable_timestamp=2b")
-        self.session.commit_transaction()
-        if (self.runningHook('disagg')):
-            # In disagg, a failed search_near will unposition the cursor, so we need to reposition it before trying again.
+        # FIXME-WT-16880: Fix layered search_near() incorrectly unpositioning the cursor.
+        if not self.runningHook('disagg'):
+            # Check search_near operation
             cursor.set_key(self.genkey(self.nentries))
-        cursor.search_near()
-        cursor.close()
+            self.session.begin_transaction()
+            self.session.prepare_transaction("prepare_timestamp=2a")
+            self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+                lambda:cursor.search_near(), preparemsg)
+            self.session.timestamp_transaction("commit_timestamp=2b")
+            self.session.timestamp_transaction("durable_timestamp=2b")
+            self.session.commit_transaction()
+            cursor.search_near()
+            cursor.close()

--- a/test/suite/test_prepare03.py
+++ b/test/suite/test_prepare03.py
@@ -78,11 +78,9 @@ class test_prepare03(wttest.WiredTigerTestCase):
         cursor = self.session.open_cursor(tablearg, None, None)
         self.assertCursorHasNoKeyValue(cursor)
 
-        if self.runningHook('disagg') and self.tablekind == 'row' and self.uri == 'table':
-            # If we're running disagg, the hook will have created a "layered:" table for this
-            # scenario; tablearg will still have a "table:" prefix, so we need a custom comparison.
-            self.assertEqual(cursor.uri, "layered" + ':' + self.table_name)
-        else:
+        # If we're running the disagg hook then the actual uri might start with 'layered:' instead
+        # of "table:", so we skip this check.
+        if not self.runningHook('disagg'):
             self.assertEqual(cursor.uri, tablearg)
 
         # Check insert operation

--- a/test/suite/test_prepare03.py
+++ b/test/suite/test_prepare03.py
@@ -77,7 +77,8 @@ class test_prepare03(wttest.WiredTigerTestCase):
         self.pr('creating cursor')
         cursor = self.session.open_cursor(tablearg, None, None)
         self.assertCursorHasNoKeyValue(cursor)
-        self.assertEqual(cursor.uri, tablearg)
+        if not self.runningHook('disagg'):
+            self.assertEqual(cursor.uri, tablearg)
 
         # Check insert operation
         for i in range(0, self.nentries):
@@ -185,5 +186,8 @@ class test_prepare03(wttest.WiredTigerTestCase):
         self.session.timestamp_transaction("commit_timestamp=2b")
         self.session.timestamp_transaction("durable_timestamp=2b")
         self.session.commit_transaction()
+        if (self.runningHook('disagg')):
+            # In disagg, a failed search_near will unposition the cursor, so we need to reposition it before trying again.
+            cursor.set_key(self.genkey(self.nentries))
         cursor.search_near()
         cursor.close()

--- a/test/suite/test_prepare29.py
+++ b/test/suite/test_prepare29.py
@@ -33,6 +33,7 @@ from wtscenario import make_scenarios
 # test_prepare29.py
 # Test that updates preceding an unstable prepared tombstone are restored with the correct
 # transaction IDs.
+@wttest.skip_for_hook("disagg", "This test relies on RTS, which is not used in disagg.")
 class test_prepare29(wttest.WiredTigerTestCase):
 
     format_values = [

--- a/test/suite/test_prepare_hs03.py
+++ b/test/suite/test_prepare_hs03.py
@@ -41,6 +41,7 @@ from wiredtiger import stat
 # test_prepare_hs03.py
 # test to ensure salvage, verify & simulating crash are working for prepared transactions.
 @wttest.skip_for_hook("tiered", "Fails with tiered storage")
+@wttest.skip_for_hook("disagg", "Salvage on disagg tables not yet implemented") # FIXME-WT-14740: Re-enable salvage once implemented.
 class test_prepare_hs03(wttest.WiredTigerTestCase):
     # Force a small cache.
     conn_config = ('cache_size=50MB,statistics=(fast),'

--- a/test/suite/test_prepare_hs04.py
+++ b/test/suite/test_prepare_hs04.py
@@ -35,7 +35,7 @@ from wiredtiger import stat
 # test_prepare_hs04.py
 # Read prepared updates from on-disk with ignore_prepare.
 # Committing or aborting a prepared update when there exists a tombstone for that key already.
-#
+@wttest.skip_for_hook("disagg", "This test relies on RTS, which is not used in disagg.")
 class test_prepare_hs04(wttest.WiredTigerTestCase):
     # Force a small cache.
     conn_config = 'cache_size=5MB,statistics=(fast)'

--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -836,6 +836,9 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
         except BaseException as err:
             self.pr('Exception raised shown as string: "' + \
                     str(err) + '"')
+            if isinstance(err, unittest.case.SkipTest):
+                # Bypass the assert if the test is being skipped.
+                raise err
             if not isinstance(err, exceptionType):
                 self.fail('Exception of incorrect type raised, got type: ' + \
                     str(type(err)))


### PR DESCRIPTION
The `test/suite/hook_disagg.fail` list has a number of failures that happen when running `test_prepare*.py` files with the disagg hook.  
In this PR I've triaged these failures, along with a few other tests that I noticed were failing for the same reasons. 

Results:
- `test_prepare03.py`: Created a ticket [WT-16880](https://jira.mongodb.org/browse/WT-16880)
- `test_prepare28.py`: Created a ticket [WT-16872](https://jira.mongodb.org/browse/WT-16872)
- `test_prepare29.py`: Skipped because it relies on RTS (not used in disagg)
- `test_prepare_cursor01.py`: Couldn't repro, assume it's since been fixed
- `test_prepare_hs03.py`: Skipped because it relies on salvage (not yet supported in disagg)
- `test_prepare_hs04.py`: Skipped because it relies on RTS (not used in disagg)

Additional ticket created: [WT-16873](https://jira.mongodb.org/browse/WT-16873) to fix non-tiered tests being unintentionally skipped by the disagg hook.