### PR TITLE
WT-16875 Relax turtle metadata parsing to ignore unknown fields

### DIFF
--- a/src/conn/conn_layered_page_log.c
+++ b/src/conn/conn_layered_page_log.c
@@ -334,9 +334,7 @@ __wti_disagg_parse_crypt_meta(
                       session, *lsnp == 0, "Duplicate lsn entry in key_provider metadata");
                     *lsnp = (uint64_t)cfg_value.val;
                 } else {
-                    WT_ERR_MSG(session, EINVAL,
-                      "Unknown or invalid entry \"%.*s\"=\"%.*s\" in key_provider page metadata",
-                      (int)cfg_key.len, cfg_key.str, (int)cfg_value.len, cfg_value.str);
+                    /* Ignore unknown or unsupported page metadata entries. */
                 }
             }
             WT_ERR_NOTFOUND_OK(ret, false);
@@ -344,9 +342,7 @@ __wti_disagg_parse_crypt_meta(
           cfg_value.type == WT_CONFIG_ITEM_NUM) {
             version = (unsigned int)cfg_value.val;
         } else {
-            WT_ERR_MSG(session, EINVAL,
-              "Unknown or invalid entry \"%.*s\"=\"%.*s\" in key_provider metadata",
-              (int)cfg_key.len, cfg_key.str, (int)cfg_value.len, cfg_value.str);
+            /* Ignore unknown or unsupported metadata entries. */
         }
     }
     WT_ERR_NOTFOUND_OK(ret, false);

--- a/src/conn/conn_layered_page_log.c
+++ b/src/conn/conn_layered_page_log.c
@@ -334,7 +334,9 @@ __wti_disagg_parse_crypt_meta(
                       session, *lsnp == 0, "Duplicate lsn entry in key_provider metadata");
                     *lsnp = (uint64_t)cfg_value.val;
                 } else {
-                    /* Ignore unknown or unsupported page metadata entries. */
+                    WT_ERR_MSG(session, EINVAL,
+                      "Unknown or invalid entry \"%.*s\"=\"%.*s\" in key_provider page metadata",
+                      (int)cfg_key.len, cfg_key.str, (int)cfg_value.len, cfg_value.str);
                 }
             }
             WT_ERR_NOTFOUND_OK(ret, false);
@@ -342,7 +344,9 @@ __wti_disagg_parse_crypt_meta(
           cfg_value.type == WT_CONFIG_ITEM_NUM) {
             version = (unsigned int)cfg_value.val;
         } else {
-            /* Ignore unknown or unsupported metadata entries. */
+            WT_ERR_MSG(session, EINVAL,
+              "Unknown or invalid entry \"%.*s\"=\"%.*s\" in key_provider metadata",
+              (int)cfg_key.len, cfg_key.str, (int)cfg_value.len, cfg_value.str);
         }
     }
     WT_ERR_NOTFOUND_OK(ret, false);
@@ -762,8 +766,7 @@ __disagg_parse_meta(WT_SESSION_IMPL *session, const WT_ITEM *meta_buf, WT_DISAGG
             metadata->key_provider = cfg_value.str;
             metadata->key_provider_len = cfg_value.len;
         } else {
-            WT_ERR_MSG(session, EINVAL, "Unknown entry \"%.*s\" in disaggregated storage metadata",
-              (int)cfg_key.len, cfg_key.str);
+            /* Ignore unknown or unsupported metadata entries. */
         }
     }
     WT_ERR_NOTFOUND_OK(ret, false);
@@ -782,6 +785,9 @@ __wt_disagg_parse_meta(
   WT_SESSION_IMPL *session, const WT_ITEM *meta_buf, WT_DISAGG_METADATA *metadata)
 {
     WT_DECL_RET;
+    char *meta_str;
+
+    meta_str = NULL;
 
     if (meta_buf->size == 0)
         WT_ERR_MSG(session, EINVAL, "Disaggregated checkpoint metadata is empty");
@@ -789,16 +795,18 @@ __wt_disagg_parse_meta(
     WT_CLEAR(*metadata);
     metadata->checkpoint_timestamp = WT_TS_MAX; /* Invalid timestamp by default. */
 
-    if (WT_PREFIX_MATCH((const char *)meta_buf->data, "checkpoint=")) {
+    WT_ERR(__wt_strndup(session, meta_buf->data, meta_buf->size, &meta_str));
+
+    if (strstr(meta_str, "checkpoint=") != NULL) {
         __wt_verbose_debug2(session, WT_VERB_DISAGGREGATED_STORAGE,
-          "Disaggregated checkpoint metadata starts with \"checkpoint=\";"
+          "Disaggregated checkpoint metadata contains \"checkpoint=\";"
           "Parsing regular format. Found \"%.*s\"",
           (int)meta_buf->size, (const char *)meta_buf->data);
         WT_ERR(__disagg_parse_meta(session, meta_buf, metadata));
 
     } else {
         __wt_verbose_debug2(session, WT_VERB_DISAGGREGATED_STORAGE,
-          "Disaggregated checkpoint metadata does not start with \"checkpoint=\";"
+          "Disaggregated checkpoint metadata does not contain \"checkpoint=\";"
           "Parsing legacy format. Found \"%.*s\"",
           (int)meta_buf->size, (const char *)meta_buf->data);
         WT_ERR(__disagg_parse_legacy_meta(session, meta_buf, metadata));
@@ -811,6 +819,7 @@ __wt_disagg_parse_meta(
     /* Key provider entry is optional. */
 
 err:
+    __wt_free(session, meta_str);
     return (ret);
 }
 

--- a/src/conn/conn_layered_page_log.c
+++ b/src/conn/conn_layered_page_log.c
@@ -788,6 +788,7 @@ __wt_disagg_parse_meta(
   WT_SESSION_IMPL *session, const WT_ITEM *meta_buf, WT_DISAGG_METADATA *metadata)
 {
     WT_DECL_RET;
+    static const char *legacy_ckpt_prefix = "(WiredTigerCheckpoint.";
 
     if (meta_buf->size == 0)
         WT_ERR_MSG(session, EINVAL, "Disaggregated checkpoint metadata is empty");
@@ -799,18 +800,18 @@ __wt_disagg_parse_meta(
      * Detect format by checking for the legacy prefix. The legacy format always starts with
      * "(WiredTigerCheckpoint.", while the regular config format does not.
      */
-    if (WT_PREFIX_MATCH((const char *)meta_buf->data, "(WiredTigerCheckpoint.")) {
+    if (WT_PREFIX_MATCH((const char *)meta_buf->data, legacy_ckpt_prefix)) {
         __wt_verbose_debug2(session, WT_VERB_DISAGGREGATED_STORAGE,
-          "Disaggregated checkpoint metadata starts with \"(WiredTigerCheckpoint.\";"
+          "Disaggregated checkpoint metadata starts with \"%s\";"
           "Parsing legacy format. Found \"%.*s\"",
-          (int)meta_buf->size, (const char *)meta_buf->data);
+          legacy_ckpt_prefix, (int)meta_buf->size, (const char *)meta_buf->data);
         WT_ERR(__disagg_parse_legacy_meta(session, meta_buf, metadata));
 
     } else {
         __wt_verbose_debug2(session, WT_VERB_DISAGGREGATED_STORAGE,
-          "Disaggregated checkpoint metadata does not start with \"(WiredTigerCheckpoint.\";"
+          "Disaggregated checkpoint metadata does not start with \"%s\";"
           "Parsing regular format. Found \"%.*s\"",
-          (int)meta_buf->size, (const char *)meta_buf->data);
+          legacy_ckpt_prefix, (int)meta_buf->size, (const char *)meta_buf->data);
         WT_ERR(__disagg_parse_meta(session, meta_buf, metadata));
     }
 

--- a/src/conn/conn_layered_page_log.c
+++ b/src/conn/conn_layered_page_log.c
@@ -766,7 +766,10 @@ __disagg_parse_meta(WT_SESSION_IMPL *session, const WT_ITEM *meta_buf, WT_DISAGG
             metadata->key_provider = cfg_value.str;
             metadata->key_provider_len = cfg_value.len;
         } else {
-            /* Ignore unknown or unsupported metadata entries. */
+            __wt_verbose_info(session, WT_VERB_DISAGGREGATED_STORAGE,
+              "Ignoring unknown or unsupported disaggregated checkpoint metadata entry "
+              "\"%.*s\"=\"%.*s\"",
+              (int)cfg_key.len, cfg_key.str, (int)cfg_value.len, cfg_value.str);
         }
     }
     WT_ERR_NOTFOUND_OK(ret, false);
@@ -785,9 +788,6 @@ __wt_disagg_parse_meta(
   WT_SESSION_IMPL *session, const WT_ITEM *meta_buf, WT_DISAGG_METADATA *metadata)
 {
     WT_DECL_RET;
-    char *meta_str;
-
-    meta_str = NULL;
 
     if (meta_buf->size == 0)
         WT_ERR_MSG(session, EINVAL, "Disaggregated checkpoint metadata is empty");
@@ -795,21 +795,23 @@ __wt_disagg_parse_meta(
     WT_CLEAR(*metadata);
     metadata->checkpoint_timestamp = WT_TS_MAX; /* Invalid timestamp by default. */
 
-    WT_ERR(__wt_strndup(session, meta_buf->data, meta_buf->size, &meta_str));
-
-    if (strstr(meta_str, "checkpoint=") != NULL) {
+    /*
+     * Detect format by checking for the legacy prefix. The legacy format always starts with
+     * "(WiredTigerCheckpoint.", while the regular config format does not.
+     */
+    if (WT_PREFIX_MATCH((const char *)meta_buf->data, "(WiredTigerCheckpoint.")) {
         __wt_verbose_debug2(session, WT_VERB_DISAGGREGATED_STORAGE,
-          "Disaggregated checkpoint metadata contains \"checkpoint=\";"
-          "Parsing regular format. Found \"%.*s\"",
-          (int)meta_buf->size, (const char *)meta_buf->data);
-        WT_ERR(__disagg_parse_meta(session, meta_buf, metadata));
-
-    } else {
-        __wt_verbose_debug2(session, WT_VERB_DISAGGREGATED_STORAGE,
-          "Disaggregated checkpoint metadata does not contain \"checkpoint=\";"
+          "Disaggregated checkpoint metadata starts with \"(WiredTigerCheckpoint.\";"
           "Parsing legacy format. Found \"%.*s\"",
           (int)meta_buf->size, (const char *)meta_buf->data);
         WT_ERR(__disagg_parse_legacy_meta(session, meta_buf, metadata));
+
+    } else {
+        __wt_verbose_debug2(session, WT_VERB_DISAGGREGATED_STORAGE,
+          "Disaggregated checkpoint metadata does not start with \"(WiredTigerCheckpoint.\";"
+          "Parsing regular format. Found \"%.*s\"",
+          (int)meta_buf->size, (const char *)meta_buf->data);
+        WT_ERR(__disagg_parse_meta(session, meta_buf, metadata));
     }
 
     if (metadata->checkpoint == NULL)
@@ -819,7 +821,6 @@ __wt_disagg_parse_meta(
     /* Key provider entry is optional. */
 
 err:
-    __wt_free(session, meta_str);
     return (ret);
 }
 

--- a/test/catch2/misc_tests/test_disagg_meta_config.cpp
+++ b/test/catch2/misc_tests/test_disagg_meta_config.cpp
@@ -169,6 +169,26 @@ TEST_CASE_METHOD(disagg_fixture, "Parse metadata", "[disagg]")
         REQUIRE(metadata.key_provider == nullptr);
         REQUIRE(metadata.key_provider_len == 0);
     }
+
+    SECTION("Unknown keys ignored")
+    {
+        const std::string metadata_str =
+          "version=1,compatible=1,unknown_key=foo,checkpoint=(),timestamp=c0ffee12,another_unknown="
+          "bar,";
+
+        WT_ITEM metadata_buf{};
+        metadata_buf.data = (const void *)metadata_str.data();
+        metadata_buf.size = metadata_str.length();
+        WT_DISAGG_METADATA metadata{};
+
+        const auto ret = __wt_disagg_parse_meta(session, &metadata_buf, &metadata);
+        REQUIRE(ret == 0);
+
+        REQUIRE(std::string_view("()", 2) ==
+          std::string_view(metadata.checkpoint, metadata.checkpoint_len));
+        const uint64_t expected_timestamp = std::stoull("c0ffee12", nullptr, 16);
+        REQUIRE(expected_timestamp == metadata.checkpoint_timestamp);
+    }
 }
 
 TEST_CASE_METHOD(disagg_fixture, "Parse crypt key metadata", "[disagg]")


### PR DESCRIPTION
Relax the turtle data format parsing requirements to support versioning in a future change. This also adjusts the current logic used to distinguish between new and legacy data parsing.

Allowing unknown fields is a temporary measure to ensure that older versions do not break when encountering newer data formats once versioning is introduced.