### PR TITLE
WT-16698 Measure time taken by checkpoint cleanup (v8.0 backport) (#13280)

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -73,6 +73,10 @@ class CapacityStat(Stat):
     prefix = 'capacity'
     def __init__(self, name, desc, flags=''):
         Stat.__init__(self, name, CapacityStat.prefix, desc, flags)
+class CheckpointCleanupStat(Stat):
+    prefix = 'checkpoint-cleanup'
+    def __init__(self, name, desc, flags=''):
+        Stat.__init__(self, name, CheckpointCleanupStat.prefix, desc, flags)
 class CheckpointStat(Stat):
     prefix = 'checkpoint'
     def __init__(self, name, desc, flags=''):
@@ -409,9 +413,16 @@ conn_stats = [
     CapacityStat('fsync_all_time', 'background fsync time (msecs)', 'no_clear,no_scale'),
 
     ##########################################
+    # Checkpoint Cleanup statistics
+    ##########################################
+    CheckpointCleanupStat('checkpoint_cleanup_duration', 'most recent duration on all eligible files (usecs)', 'no_clear,no_scale'),
+    CheckpointCleanupStat('checkpoint_cleanup_handle_processed', 'most recent handles processed'),
+    CheckpointCleanupStat('checkpoint_cleanup_inmem_pages_visited', 'most recent in-memory pages visited'),
+    CheckpointCleanupStat('checkpoint_cleanup_success', 'successful calls'),
+
+    ##########################################
     # Checkpoint statistics
     ##########################################
-    CheckpointStat('checkpoint_cleanup_success', 'checkpoint cleanup successful calls'),
     CheckpointStat('checkpoint_fsync_post', 'fsync calls after allocating the transaction ID'),
     CheckpointStat('checkpoint_fsync_post_duration', 'fsync duration after allocating the transaction ID (usecs)', 'no_clear,no_scale'),
     CheckpointStat('checkpoint_generation', 'generation', 'no_clear,no_scale'),
@@ -1095,15 +1106,19 @@ conn_dsrc_stats = [
     CacheStat('cache_write_restore', 'pages written requiring in-memory restoration'),
 
     ##########################################
+    # Checkpoint Cleanup statistics
+    ##########################################
+    CheckpointCleanupStat('checkpoint_cleanup_pages_evict', 'pages added for eviction'),
+    CheckpointCleanupStat('checkpoint_cleanup_pages_obsolete_tw', 'pages dirtied due to obsolete time window'),
+    CheckpointCleanupStat('checkpoint_cleanup_pages_read_obsolete_tw', 'pages read into cache due to obsolete time window'),
+    CheckpointCleanupStat('checkpoint_cleanup_pages_read_reclaim_space', 'pages read into cache (reclaim_space)'),
+    CheckpointCleanupStat('checkpoint_cleanup_pages_removed', 'pages removed'),
+    CheckpointCleanupStat('checkpoint_cleanup_pages_visited', 'pages visited'),
+    CheckpointCleanupStat('checkpoint_cleanup_pages_walk_skipped', 'pages skipped during tree walk'),
+
+    ##########################################
     # Checkpoint statistics
     ##########################################
-    CheckpointStat('checkpoint_cleanup_pages_evict', 'pages added for eviction during checkpoint cleanup'),
-    CheckpointStat('checkpoint_cleanup_pages_obsolete_tw', 'pages dirtied due to obsolete time window by checkpoint cleanup'),
-    CheckpointStat('checkpoint_cleanup_pages_read_obsolete_tw', 'pages read into cache during checkpoint cleanup due to obsolete time window'),
-    CheckpointStat('checkpoint_cleanup_pages_read_reclaim_space', 'pages read into cache during checkpoint cleanup (reclaim_space)'),
-    CheckpointStat('checkpoint_cleanup_pages_removed', 'pages removed during checkpoint cleanup'),
-    CheckpointStat('checkpoint_cleanup_pages_visited', 'pages visited during checkpoint cleanup'),
-    CheckpointStat('checkpoint_cleanup_pages_walk_skipped', 'pages skipped during checkpoint cleanup tree walk'),
     CheckpointStat('checkpoint_obsolete_applied', 'transaction checkpoints due to obsolete pages'),
     CheckpointStat('checkpoint_snapshot_acquired', 'checkpoint has acquired a snapshot for its transaction'),
 

--- a/src/btree/bt_sync_obsolete.c
+++ b/src/btree/bt_sync_obsolete.c
@@ -484,10 +484,14 @@ __checkpoint_cleanup_walk_btree(WT_SESSION_IMPL *session, WT_ITEM *uri)
     WT_BTREE *btree;
     WT_DECL_RET;
     WT_REF *ref;
+    uint64_t elapsed_us, end_time, start_time;
     uint32_t flags;
+    uint32_t pages_visited;
 
     ref = NULL;
     flags = WT_READ_NO_EVICT | WT_READ_VISIBLE_ALL;
+    pages_visited = 0;
+    start_time = __wt_clock(session);
 
     /* Open a handle for processing. */
     ret = __wt_session_get_dhandle(session, uri->data, NULL, NULL, 0);
@@ -517,6 +521,7 @@ __checkpoint_cleanup_walk_btree(WT_SESSION_IMPL *session, WT_ITEM *uri)
     while ((ret = __wt_tree_walk_custom_skip(
               session, &ref, __checkpoint_cleanup_page_skip, NULL, flags)) == 0 &&
       ref != NULL) {
+        ++pages_visited;
         if (F_ISSET(ref, WT_REF_FLAG_INTERNAL)) {
             WT_WITH_PAGE_INDEX(session, ret = __checkpoint_cleanup_obsolete_cleanup(session, ref));
         } else {
@@ -532,6 +537,14 @@ __checkpoint_cleanup_walk_btree(WT_SESSION_IMPL *session, WT_ITEM *uri)
     }
 
 err:
+    end_time = __wt_clock(session);
+    elapsed_us = WT_CLOCKDIFF_US(end_time, start_time);
+    __wt_verbose_debug1(session, WT_VERB_CHECKPOINT_CLEANUP,
+      "checkpoint cleanup btree walk completed (ret=%d), pages_visited=%" PRIu32
+      ", elapsed_us=%" PRIu64,
+      ret, pages_visited, elapsed_us);
+    WT_STAT_CONN_SET(session, checkpoint_cleanup_inmem_pages_visited, pages_visited);
+
     /* On error, clear any left-over tree walk. */
     WT_TRET(__wt_page_release(session, ref, flags));
     WT_TRET(__wt_session_release_dhandle(session));
@@ -709,6 +722,9 @@ __checkpoint_cleanup_int(WT_SESSION_IMPL *session)
     WT_DECL_ITEM(uri);
     WT_DECL_RET;
 
+    uint32_t tables_processed = 0;
+    uint64_t elapsed_us, end_time, start_time = __wt_clock(session);
+
     WT_RET(__wt_scr_alloc(session, 1024, &uri));
     WT_ERR(__wt_buf_set(session, uri, WT_URI_FILE_PREFIX, strlen(WT_URI_FILE_PREFIX) + 1));
 
@@ -721,6 +737,7 @@ __checkpoint_cleanup_int(WT_SESSION_IMPL *session)
             continue;
         }
         WT_ERR(ret);
+        ++tables_processed;
 
         /* Check if we need to wait before continuing with the next file to minimize impact. */
         if (S2C(session)->cc_cleanup.file_wait_ms > 0) {
@@ -740,6 +757,15 @@ __checkpoint_cleanup_int(WT_SESSION_IMPL *session)
     WT_ERR_NOTFOUND_OK(ret, false);
 
 err:
+    end_time = __wt_clock(session);
+    elapsed_us = WT_CLOCKDIFF_US(end_time, start_time);
+    __wt_verbose_debug1(session, WT_VERB_CHECKPOINT_CLEANUP,
+      "checkpoint cleanup full iteration completed (ret=%d), tables_processed=%" PRIu32
+      " elapsed_us=%" PRIu64,
+      ret, tables_processed, elapsed_us);
+    WT_STAT_CONN_SET(session, checkpoint_cleanup_duration, elapsed_us);
+    WT_STAT_CONN_SET(session, checkpoint_cleanup_handle_processed, tables_processed);
+
     __wt_scr_free(session, &uri);
     return (ret);
 }

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -649,6 +649,16 @@ struct __wt_connection_stats {
     int64_t capacity_time_log;
     int64_t capacity_time_read;
     int64_t capacity_time_chunkcache;
+    int64_t checkpoint_cleanup_duration;
+    int64_t checkpoint_cleanup_handle_processed;
+    int64_t checkpoint_cleanup_inmem_pages_visited;
+    int64_t checkpoint_cleanup_pages_evict;
+    int64_t checkpoint_cleanup_pages_obsolete_tw;
+    int64_t checkpoint_cleanup_pages_read_reclaim_space;
+    int64_t checkpoint_cleanup_pages_read_obsolete_tw;
+    int64_t checkpoint_cleanup_pages_removed;
+    int64_t checkpoint_cleanup_pages_walk_skipped;
+    int64_t checkpoint_cleanup_pages_visited;
     int64_t checkpoint_cleanup_success;
     int64_t checkpoint_snapshot_acquired;
     int64_t checkpoint_skipped;
@@ -678,13 +688,6 @@ struct __wt_connection_stats {
     int64_t checkpoint_pages_visited_internal;
     int64_t checkpoint_pages_visited_leaf;
     int64_t checkpoint_pages_reconciled;
-    int64_t checkpoint_cleanup_pages_evict;
-    int64_t checkpoint_cleanup_pages_obsolete_tw;
-    int64_t checkpoint_cleanup_pages_read_reclaim_space;
-    int64_t checkpoint_cleanup_pages_read_obsolete_tw;
-    int64_t checkpoint_cleanup_pages_removed;
-    int64_t checkpoint_cleanup_pages_walk_skipped;
-    int64_t checkpoint_cleanup_pages_visited;
     int64_t checkpoint_prep_running;
     int64_t checkpoint_prep_max;
     int64_t checkpoint_prep_min;
@@ -1275,7 +1278,6 @@ struct __wt_dsrc_stats {
     int64_t cache_state_refs_skipped;
     int64_t cache_state_root_size;
     int64_t cache_state_pages;
-    int64_t checkpoint_snapshot_acquired;
     int64_t checkpoint_cleanup_pages_evict;
     int64_t checkpoint_cleanup_pages_obsolete_tw;
     int64_t checkpoint_cleanup_pages_read_reclaim_space;
@@ -1283,6 +1285,7 @@ struct __wt_dsrc_stats {
     int64_t checkpoint_cleanup_pages_removed;
     int64_t checkpoint_cleanup_pages_walk_skipped;
     int64_t checkpoint_cleanup_pages_visited;
+    int64_t checkpoint_snapshot_acquired;
     int64_t checkpoint_obsolete_applied;
     int64_t compress_precomp_intl_max_page_size;
     int64_t compress_precomp_leaf_max_page_size;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -6286,1076 +6286,1073 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_CAPACITY_TIME_READ			1282
 /*! capacity: time waiting for chunk cache IO bandwidth (usecs) */
 #define	WT_STAT_CONN_CAPACITY_TIME_CHUNKCACHE		1283
-/*! checkpoint: checkpoint cleanup successful calls */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_SUCCESS		1284
+/*! checkpoint-cleanup: most recent duration on all eligible files (usecs) */
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_DURATION	1284
+/*! checkpoint-cleanup: most recent handles processed */
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_HANDLE_PROCESSED	1285
+/*! checkpoint-cleanup: most recent in-memory pages visited */
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_INMEM_PAGES_VISITED	1286
+/*! checkpoint-cleanup: pages added for eviction */
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_EVICT	1287
+/*! checkpoint-cleanup: pages dirtied due to obsolete time window */
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	1288
+/*! checkpoint-cleanup: pages read into cache (reclaim_space) */
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	1289
+/*! checkpoint-cleanup: pages read into cache due to obsolete time window */
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	1290
+/*! checkpoint-cleanup: pages removed */
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_REMOVED	1291
+/*! checkpoint-cleanup: pages skipped during tree walk */
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	1292
+/*! checkpoint-cleanup: pages visited */
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_VISITED	1293
+/*! checkpoint-cleanup: successful calls */
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_SUCCESS		1294
 /*! checkpoint: checkpoint has acquired a snapshot for its transaction */
-#define	WT_STAT_CONN_CHECKPOINT_SNAPSHOT_ACQUIRED	1285
+#define	WT_STAT_CONN_CHECKPOINT_SNAPSHOT_ACQUIRED	1295
 /*! checkpoint: checkpoints skipped because database was clean */
-#define	WT_STAT_CONN_CHECKPOINT_SKIPPED			1286
+#define	WT_STAT_CONN_CHECKPOINT_SKIPPED			1296
 /*! checkpoint: fsync calls after allocating the transaction ID */
-#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST		1287
+#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST		1297
 /*! checkpoint: fsync duration after allocating the transaction ID (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST_DURATION	1288
+#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST_DURATION	1298
 /*! checkpoint: generation */
-#define	WT_STAT_CONN_CHECKPOINT_GENERATION		1289
+#define	WT_STAT_CONN_CHECKPOINT_GENERATION		1299
 /*! checkpoint: max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_MAX		1290
+#define	WT_STAT_CONN_CHECKPOINT_TIME_MAX		1300
 /*! checkpoint: min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_MIN		1291
+#define	WT_STAT_CONN_CHECKPOINT_TIME_MIN		1301
 /*!
  * checkpoint: most recent duration for checkpoint dropping all handles
  * (usecs)
  */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROP_DURATION	1292
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROP_DURATION	1302
 /*! checkpoint: most recent duration for gathering all handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION		1293
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION		1303
 /*! checkpoint: most recent duration for gathering applied handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLY_DURATION	1294
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLY_DURATION	1304
 /*! checkpoint: most recent duration for gathering skipped handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIP_DURATION	1295
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIP_DURATION	1305
 /*! checkpoint: most recent duration for handles metadata checked (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECK_DURATION	1296
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECK_DURATION	1306
 /*! checkpoint: most recent duration for locking the handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCK_DURATION	1297
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCK_DURATION	1307
 /*! checkpoint: most recent handles applied */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLIED		1298
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLIED		1308
 /*! checkpoint: most recent handles checkpoint dropped */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROPPED		1299
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROPPED		1309
 /*! checkpoint: most recent handles metadata checked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECKED	1300
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECKED	1310
 /*! checkpoint: most recent handles metadata locked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCKED		1301
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCKED		1311
 /*! checkpoint: most recent handles skipped */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIPPED		1302
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIPPED		1312
 /*! checkpoint: most recent handles walked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_WALKED		1303
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_WALKED		1313
 /*! checkpoint: most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_RECENT		1304
+#define	WT_STAT_CONN_CHECKPOINT_TIME_RECENT		1314
 /*! checkpoint: number of checkpoints started by api */
-#define	WT_STAT_CONN_CHECKPOINTS_API			1305
+#define	WT_STAT_CONN_CHECKPOINTS_API			1315
 /*! checkpoint: number of checkpoints started by compaction */
-#define	WT_STAT_CONN_CHECKPOINTS_COMPACT		1306
+#define	WT_STAT_CONN_CHECKPOINTS_COMPACT		1316
 /*! checkpoint: number of files synced */
-#define	WT_STAT_CONN_CHECKPOINT_SYNC			1307
+#define	WT_STAT_CONN_CHECKPOINT_SYNC			1317
 /*! checkpoint: number of handles visited after writes complete */
-#define	WT_STAT_CONN_CHECKPOINT_PRESYNC			1308
+#define	WT_STAT_CONN_CHECKPOINT_PRESYNC			1318
 /*! checkpoint: number of history store pages caused to be reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_HS_PAGES_RECONCILED	1309
+#define	WT_STAT_CONN_CHECKPOINT_HS_PAGES_RECONCILED	1319
 /*! checkpoint: number of internal pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_INTERNAL	1310
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_INTERNAL	1320
 /*! checkpoint: number of leaf pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_LEAF	1311
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_LEAF	1321
 /*! checkpoint: number of pages caused to be reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED	1312
-/*! checkpoint: pages added for eviction during checkpoint cleanup */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_EVICT	1313
-/*!
- * checkpoint: pages dirtied due to obsolete time window by checkpoint
- * cleanup
- */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	1314
-/*!
- * checkpoint: pages read into cache during checkpoint cleanup
- * (reclaim_space)
- */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	1315
-/*!
- * checkpoint: pages read into cache during checkpoint cleanup due to
- * obsolete time window
- */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	1316
-/*! checkpoint: pages removed during checkpoint cleanup */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_REMOVED	1317
-/*! checkpoint: pages skipped during checkpoint cleanup tree walk */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	1318
-/*! checkpoint: pages visited during checkpoint cleanup */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_VISITED	1319
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED	1322
 /*! checkpoint: prepare currently running */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1320
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1323
 /*! checkpoint: prepare max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1321
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1324
 /*! checkpoint: prepare min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1322
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1325
 /*! checkpoint: prepare most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1323
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1326
 /*! checkpoint: prepare total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1324
+#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1327
 /*! checkpoint: progress state */
-#define	WT_STAT_CONN_CHECKPOINT_STATE			1325
+#define	WT_STAT_CONN_CHECKPOINT_STATE			1328
 /*! checkpoint: scrub dirty target */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1326
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1329
 /*! checkpoint: scrub max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1327
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1330
 /*! checkpoint: scrub min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1328
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1331
 /*! checkpoint: scrub most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1329
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1332
 /*! checkpoint: scrub total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1330
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1333
 /*! checkpoint: stop timing stress active */
-#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1331
+#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1334
 /*! checkpoint: time spent on per-tree checkpoint work (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1332
+#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1335
 /*! checkpoint: total failed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1333
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1336
 /*! checkpoint: total succeed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1334
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1337
 /*! checkpoint: total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1335
+#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1338
 /*! checkpoint: transaction checkpoints due to obsolete pages */
-#define	WT_STAT_CONN_CHECKPOINT_OBSOLETE_APPLIED	1336
+#define	WT_STAT_CONN_CHECKPOINT_OBSOLETE_APPLIED	1339
 /*! checkpoint: wait cycles while cache dirty level is decreasing */
-#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1337
+#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1340
 /*! chunk-cache: aggregate number of spanned chunks on read */
-#define	WT_STAT_CONN_CHUNKCACHE_SPANS_CHUNKS_READ	1338
+#define	WT_STAT_CONN_CHUNKCACHE_SPANS_CHUNKS_READ	1341
 /*! chunk-cache: chunks evicted */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_EVICTED		1339
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_EVICTED		1342
 /*! chunk-cache: could not allocate due to exceeding bitmap capacity */
-#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_BITMAP_CAPACITY	1340
+#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_BITMAP_CAPACITY	1343
 /*! chunk-cache: could not allocate due to exceeding capacity */
-#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_CAPACITY	1341
+#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_CAPACITY	1344
 /*! chunk-cache: lookups */
-#define	WT_STAT_CONN_CHUNKCACHE_LOOKUPS			1342
+#define	WT_STAT_CONN_CHUNKCACHE_LOOKUPS			1345
 /*!
  * chunk-cache: number of chunks loaded from flushed tables in chunk
  * cache
  */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_LOADED_FROM_FLUSHED_TABLES	1343
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_LOADED_FROM_FLUSHED_TABLES	1346
 /*! chunk-cache: number of metadata entries inserted */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_INSERTED	1344
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_INSERTED	1347
 /*! chunk-cache: number of metadata entries removed */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_REMOVED	1345
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_REMOVED	1348
 /*!
  * chunk-cache: number of metadata inserts/deletes dropped by the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DROPPED	1346
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DROPPED	1349
 /*!
  * chunk-cache: number of metadata inserts/deletes pushed to the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_CREATED	1347
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_CREATED	1350
 /*!
  * chunk-cache: number of metadata inserts/deletes read by the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DEQUEUED	1348
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DEQUEUED	1351
 /*! chunk-cache: number of misses */
-#define	WT_STAT_CONN_CHUNKCACHE_MISSES			1349
+#define	WT_STAT_CONN_CHUNKCACHE_MISSES			1352
 /*! chunk-cache: number of times a read from storage failed */
-#define	WT_STAT_CONN_CHUNKCACHE_IO_FAILED		1350
+#define	WT_STAT_CONN_CHUNKCACHE_IO_FAILED		1353
 /*! chunk-cache: retried accessing a chunk while I/O was in progress */
-#define	WT_STAT_CONN_CHUNKCACHE_RETRIES			1351
+#define	WT_STAT_CONN_CHUNKCACHE_RETRIES			1354
 /*! chunk-cache: retries from a chunk cache checksum mismatch */
-#define	WT_STAT_CONN_CHUNKCACHE_RETRIES_CHECKSUM_MISMATCH	1352
+#define	WT_STAT_CONN_CHUNKCACHE_RETRIES_CHECKSUM_MISMATCH	1355
 /*! chunk-cache: timed out due to too many retries */
-#define	WT_STAT_CONN_CHUNKCACHE_TOOMANY_RETRIES		1353
+#define	WT_STAT_CONN_CHUNKCACHE_TOOMANY_RETRIES		1356
 /*! chunk-cache: total bytes read from persistent content */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_READ_PERSISTENT	1354
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_READ_PERSISTENT	1357
 /*! chunk-cache: total bytes used by the cache */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE		1355
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE		1358
 /*! chunk-cache: total bytes used by the cache for pinned chunks */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE_PINNED	1356
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE_PINNED	1359
 /*! chunk-cache: total chunks held by the chunk cache */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_INUSE		1357
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_INUSE		1360
 /*!
  * chunk-cache: total number of chunks inserted on startup from persisted
  * metadata.
  */
-#define	WT_STAT_CONN_CHUNKCACHE_CREATED_FROM_METADATA	1358
+#define	WT_STAT_CONN_CHUNKCACHE_CREATED_FROM_METADATA	1361
 /*! chunk-cache: total pinned chunks held by the chunk cache */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_PINNED		1359
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_PINNED		1362
 /*! connection: auto adjusting condition resets */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1360
+#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1363
 /*! connection: auto adjusting condition wait calls */
-#define	WT_STAT_CONN_COND_AUTO_WAIT			1361
+#define	WT_STAT_CONN_COND_AUTO_WAIT			1364
 /*!
  * connection: auto adjusting condition wait raced to update timeout and
  * skipped updating
  */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1362
+#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1365
 /*! connection: detected system time went backwards */
-#define	WT_STAT_CONN_TIME_TRAVEL			1363
+#define	WT_STAT_CONN_TIME_TRAVEL			1366
 /*! connection: files currently open */
-#define	WT_STAT_CONN_FILE_OPEN				1364
+#define	WT_STAT_CONN_FILE_OPEN				1367
 /*! connection: hash bucket array size for data handles */
-#define	WT_STAT_CONN_BUCKETS_DH				1365
+#define	WT_STAT_CONN_BUCKETS_DH				1368
 /*! connection: hash bucket array size general */
-#define	WT_STAT_CONN_BUCKETS				1366
+#define	WT_STAT_CONN_BUCKETS				1369
 /*! connection: memory allocations */
-#define	WT_STAT_CONN_MEMORY_ALLOCATION			1367
+#define	WT_STAT_CONN_MEMORY_ALLOCATION			1370
 /*! connection: memory frees */
-#define	WT_STAT_CONN_MEMORY_FREE			1368
+#define	WT_STAT_CONN_MEMORY_FREE			1371
 /*! connection: memory re-allocations */
-#define	WT_STAT_CONN_MEMORY_GROW			1369
+#define	WT_STAT_CONN_MEMORY_GROW			1372
 /*! connection: number of sessions without a sweep for 5+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1370
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1373
 /*! connection: number of sessions without a sweep for 60+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1371
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1374
 /*! connection: pthread mutex condition wait calls */
-#define	WT_STAT_CONN_COND_WAIT				1372
+#define	WT_STAT_CONN_COND_WAIT				1375
 /*! connection: pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			1373
+#define	WT_STAT_CONN_RWLOCK_READ			1376
 /*! connection: pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			1374
+#define	WT_STAT_CONN_RWLOCK_WRITE			1377
 /*! connection: total fsync I/Os */
-#define	WT_STAT_CONN_FSYNC_IO				1375
+#define	WT_STAT_CONN_FSYNC_IO				1378
 /*! connection: total read I/Os */
-#define	WT_STAT_CONN_READ_IO				1376
+#define	WT_STAT_CONN_READ_IO				1379
 /*! connection: total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				1377
+#define	WT_STAT_CONN_WRITE_IO				1380
 /*! cursor: Total number of deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1378
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1381
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1379
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1382
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1380
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1383
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1381
+#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1384
 /*!
  * cursor: Total number of in-memory deleted pages skipped during tree
  * walk
  */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1382
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1385
 /*! cursor: Total number of on-disk deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1383
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1386
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1384
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1387
 /*!
  * cursor: Total number of times cursor fails to temporarily release
  * pinned page to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1385
+#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1388
 /*!
  * cursor: Total number of times cursor temporarily releases pinned page
  * to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION			1386
+#define	WT_STAT_CONN_CURSOR_REPOSITION			1389
 /*! cursor: bulk cursor count */
-#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1387
+#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1390
 /*! cursor: cached cursor count */
-#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1388
+#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1391
 /*! cursor: cursor bound calls that return an error */
-#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1389
+#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1392
 /*! cursor: cursor bounds cleared from reset */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1390
+#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1393
 /*! cursor: cursor bounds comparisons performed */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1391
+#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1394
 /*! cursor: cursor bounds next called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1392
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1395
 /*! cursor: cursor bounds next early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1393
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1396
 /*! cursor: cursor bounds prev called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1394
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1397
 /*! cursor: cursor bounds prev early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1395
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1398
 /*! cursor: cursor bounds search early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1396
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1399
 /*! cursor: cursor bounds search near call repositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1397
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1400
 /*! cursor: cursor bulk loaded cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1398
+#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1401
 /*! cursor: cursor cache calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1399
+#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1402
 /*! cursor: cursor close calls that result in cache */
-#define	WT_STAT_CONN_CURSOR_CACHE			1400
+#define	WT_STAT_CONN_CURSOR_CACHE			1403
 /*! cursor: cursor close calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1401
+#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1404
 /*! cursor: cursor compare calls that return an error */
-#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1402
+#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1405
 /*! cursor: cursor create calls */
-#define	WT_STAT_CONN_CURSOR_CREATE			1403
+#define	WT_STAT_CONN_CURSOR_CREATE			1406
 /*! cursor: cursor equals calls that return an error */
-#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1404
+#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1407
 /*! cursor: cursor get key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1405
+#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1408
 /*! cursor: cursor get value calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1406
+#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1409
 /*! cursor: cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT			1407
+#define	WT_STAT_CONN_CURSOR_INSERT			1410
 /*! cursor: cursor insert calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1408
+#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1411
 /*! cursor: cursor insert check calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1409
+#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1412
 /*! cursor: cursor insert key and value bytes */
-#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1410
+#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1413
 /*! cursor: cursor largest key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1411
+#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1414
 /*! cursor: cursor modify calls */
-#define	WT_STAT_CONN_CURSOR_MODIFY			1412
+#define	WT_STAT_CONN_CURSOR_MODIFY			1415
 /*! cursor: cursor modify calls that return an error */
-#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1413
+#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1416
 /*! cursor: cursor modify key and value bytes affected */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1414
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1417
 /*! cursor: cursor modify value bytes modified */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1415
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1418
 /*! cursor: cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT			1416
+#define	WT_STAT_CONN_CURSOR_NEXT			1419
 /*! cursor: cursor next calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1417
+#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1420
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1418
+#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1421
 /*!
  * cursor: cursor next calls that skip greater than 1 and fewer than 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1419
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1422
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1420
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1423
 /*! cursor: cursor next random calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1421
+#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1424
 /*! cursor: cursor operation restarted */
-#define	WT_STAT_CONN_CURSOR_RESTART			1422
+#define	WT_STAT_CONN_CURSOR_RESTART			1425
 /*! cursor: cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV			1423
+#define	WT_STAT_CONN_CURSOR_PREV			1426
 /*! cursor: cursor prev calls that return an error */
-#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1424
+#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1427
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1425
+#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1428
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1426
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1429
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1427
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1430
 /*! cursor: cursor reconfigure calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1428
+#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1431
 /*! cursor: cursor remove calls */
-#define	WT_STAT_CONN_CURSOR_REMOVE			1429
+#define	WT_STAT_CONN_CURSOR_REMOVE			1432
 /*! cursor: cursor remove calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1430
+#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1433
 /*! cursor: cursor remove key bytes removed */
-#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1431
+#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1434
 /*! cursor: cursor reopen calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1432
+#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1435
 /*! cursor: cursor reserve calls */
-#define	WT_STAT_CONN_CURSOR_RESERVE			1433
+#define	WT_STAT_CONN_CURSOR_RESERVE			1436
 /*! cursor: cursor reserve calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1434
+#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1437
 /*! cursor: cursor reset calls */
-#define	WT_STAT_CONN_CURSOR_RESET			1435
+#define	WT_STAT_CONN_CURSOR_RESET			1438
 /*! cursor: cursor reset calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1436
+#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1439
 /*! cursor: cursor search calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH			1437
+#define	WT_STAT_CONN_CURSOR_SEARCH			1440
 /*! cursor: cursor search calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1438
+#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1441
 /*! cursor: cursor search history store calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1439
+#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1442
 /*! cursor: cursor search near calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1440
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1443
 /*! cursor: cursor search near calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1441
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1444
 /*! cursor: cursor sweep buckets */
-#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1442
+#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1445
 /*! cursor: cursor sweep cursors closed */
-#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1443
+#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1446
 /*! cursor: cursor sweep cursors examined */
-#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1444
+#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1447
 /*! cursor: cursor sweeps */
-#define	WT_STAT_CONN_CURSOR_SWEEP			1445
+#define	WT_STAT_CONN_CURSOR_SWEEP			1448
 /*! cursor: cursor truncate calls */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE			1446
+#define	WT_STAT_CONN_CURSOR_TRUNCATE			1449
 /*! cursor: cursor truncates performed on individual keys */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1447
+#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1450
 /*! cursor: cursor update calls */
-#define	WT_STAT_CONN_CURSOR_UPDATE			1448
+#define	WT_STAT_CONN_CURSOR_UPDATE			1451
 /*! cursor: cursor update calls that return an error */
-#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1449
+#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1452
 /*! cursor: cursor update key and value bytes */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1450
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1453
 /*! cursor: cursor update value size change */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1451
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1454
 /*! cursor: cursors reused from cache */
-#define	WT_STAT_CONN_CURSOR_REOPEN			1452
+#define	WT_STAT_CONN_CURSOR_REOPEN			1455
 /*! cursor: open cursor count */
-#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1453
+#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1456
 /*! data-handle: connection data handle size */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1454
+#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1457
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1455
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1458
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1456
+#define	WT_STAT_CONN_DH_SWEEP_REF			1459
 /*! data-handle: connection sweep dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1457
+#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1460
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1458
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1461
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1459
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1462
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1460
+#define	WT_STAT_CONN_DH_SWEEPS				1463
 /*!
  * data-handle: connection sweeps skipped due to checkpoint gathering
  * handles
  */
-#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1461
+#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1464
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1462
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1465
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1463
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1466
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1464
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1467
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1465
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1468
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1466
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1469
 /*! lock: dhandle lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1467
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1470
 /*! lock: dhandle lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1468
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1471
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1469
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1472
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1470
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1473
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1471
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1474
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1472
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1475
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1473
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1476
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1474
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1477
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1475
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1478
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1476
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1479
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1477
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1480
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1478
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1481
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1479
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1482
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1480
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1483
 /*! lock: txn global lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1481
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1484
 /*! lock: txn global lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1482
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1485
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1483
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1486
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1484
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1487
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1485
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1488
 /*! log: force log remove time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1486
+#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1489
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1487
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1490
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1488
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1491
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1489
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1492
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1490
+#define	WT_STAT_CONN_LOG_FLUSH				1493
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1491
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1494
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1492
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1495
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1493
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1496
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1494
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1497
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1495
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1498
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1496
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1499
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1497
+#define	WT_STAT_CONN_LOG_SCANS				1500
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1498
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1501
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1499
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1502
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1500
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1503
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1501
+#define	WT_STAT_CONN_LOG_SYNC				1504
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1502
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1505
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1503
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1506
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1504
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1507
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1505
+#define	WT_STAT_CONN_LOG_WRITES				1508
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1506
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1509
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1507
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1510
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1508
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1511
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1509
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1512
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1510
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1513
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1511
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1514
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1512
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1515
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1513
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1516
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1514
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1517
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1515
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1518
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1516
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1519
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1517
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1520
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1518
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1521
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1519
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1522
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1520
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1523
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1521
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1524
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1522
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1525
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1523
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1526
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1524
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1527
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1525
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1528
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1526
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1529
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1527
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1530
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1528
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1531
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1529
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1532
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1530
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1533
 /*! perf: file system read latency histogram (bucket 1) - 0-10ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1531
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1534
 /*! perf: file system read latency histogram (bucket 2) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1532
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1535
 /*! perf: file system read latency histogram (bucket 3) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1533
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1536
 /*! perf: file system read latency histogram (bucket 4) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1534
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1537
 /*! perf: file system read latency histogram (bucket 5) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1535
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1538
 /*! perf: file system read latency histogram (bucket 6) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1536
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1539
 /*! perf: file system read latency histogram (bucket 7) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1537
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1540
 /*! perf: file system read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1538
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1541
 /*! perf: file system write latency histogram (bucket 1) - 0-10ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1539
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1542
 /*! perf: file system write latency histogram (bucket 2) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1540
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1543
 /*! perf: file system write latency histogram (bucket 3) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1541
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1544
 /*! perf: file system write latency histogram (bucket 4) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1542
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1545
 /*! perf: file system write latency histogram (bucket 5) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1543
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1546
 /*! perf: file system write latency histogram (bucket 6) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1544
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1547
 /*! perf: file system write latency histogram (bucket 7) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1545
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1548
 /*! perf: file system write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1546
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1549
 /*! perf: operation read latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1547
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1550
 /*! perf: operation read latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1548
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1551
 /*! perf: operation read latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1549
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1552
 /*! perf: operation read latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1550
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1553
 /*! perf: operation read latency histogram (bucket 5) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1551
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1554
 /*! perf: operation read latency histogram (bucket 6) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1552
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1555
 /*! perf: operation read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1553
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1556
 /*! perf: operation write latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1554
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1557
 /*! perf: operation write latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1555
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1558
 /*! perf: operation write latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1556
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1559
 /*! perf: operation write latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1557
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1560
 /*! perf: operation write latency histogram (bucket 5) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1558
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1561
 /*! perf: operation write latency histogram (bucket 6) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1559
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1562
 /*! perf: operation write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1560
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1563
 /*! prefetch: could not perform pre-fetch on internal page */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1561
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1564
 /*!
  * prefetch: could not perform pre-fetch on ref without the pre-fetch
  * flag set
  */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1562
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1565
 /*! prefetch: number of times pre-fetch failed to start */
-#define	WT_STAT_CONN_PREFETCH_FAILED_START		1563
+#define	WT_STAT_CONN_PREFETCH_FAILED_START		1566
 /*! prefetch: pre-fetch not repeating for recently pre-fetched ref */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1564
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1567
 /*! prefetch: pre-fetch not triggered after single disk read */
-#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1565
+#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1568
 /*! prefetch: pre-fetch not triggered as there is no valid dhandle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1566
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1569
 /*! prefetch: pre-fetch not triggered by page read */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED			1567
+#define	WT_STAT_CONN_PREFETCH_SKIPPED			1570
 /*! prefetch: pre-fetch not triggered due to disk read count */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1568
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1571
 /*! prefetch: pre-fetch not triggered due to internal session */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1569
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1572
 /*! prefetch: pre-fetch not triggered due to special btree handle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1570
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1573
 /*! prefetch: pre-fetch page not on disk when reading */
-#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1571
+#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1574
 /*! prefetch: pre-fetch pages queued */
-#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1572
+#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1575
 /*! prefetch: pre-fetch pages read in background */
-#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1573
+#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1576
 /*! prefetch: pre-fetch skipped reading in a page due to harmless error */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1574
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1577
 /*! prefetch: pre-fetch triggered by page read */
-#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1575
+#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1578
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1576
+#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1579
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1577
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1580
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1578
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1581
 /*! reconciliation: cursor next/prev calls during HS wrapup search_near */
-#define	WT_STAT_CONN_REC_HS_WRAPUP_NEXT_PREV_CALLS	1579
+#define	WT_STAT_CONN_REC_HS_WRAPUP_NEXT_PREV_CALLS	1582
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1580
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1583
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1581
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1584
 /*! reconciliation: maximum milliseconds spent in a reconciliation call */
-#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1582
+#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1585
 /*!
  * reconciliation: maximum milliseconds spent in building a disk image in
  * a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1583
+#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1586
 /*!
  * reconciliation: maximum milliseconds spent in moving updates to the
  * history store in a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1584
+#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1587
 /*! reconciliation: overflow values written */
-#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1585
+#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1588
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1586
+#define	WT_STAT_CONN_REC_PAGES				1589
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1587
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1590
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * prepared transaction metadata
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1588
+#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1591
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * timestamps
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1589
+#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1592
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * transaction ids
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1590
+#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1593
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1591
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1594
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1592
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1595
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1593
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1596
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1594
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1597
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1595
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1598
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1596
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1599
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1597
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1600
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1598
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1601
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1599
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1602
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1600
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1603
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1601
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1604
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1602
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1605
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1603
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1606
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1604
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1607
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1605
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1608
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1606
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1609
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1607
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1610
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1608
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1611
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1609
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1612
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1610
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1613
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1611
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1614
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1612
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1615
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1613
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1616
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1614
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1617
 /*! session: attempts to remove a local object and the object is in use */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1615
+#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1618
 /*! session: flush_tier failed calls */
-#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1616
+#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1619
 /*! session: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1617
+#define	WT_STAT_CONN_FLUSH_TIER				1620
 /*! session: flush_tier tables skipped due to no checkpoint */
-#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1618
+#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1621
 /*! session: flush_tier tables switched */
-#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1619
+#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1622
 /*! session: local objects removed */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1620
+#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1623
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1621
+#define	WT_STAT_CONN_SESSION_OPEN			1624
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1622
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1625
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1623
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1626
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1624
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1627
 /*! session: table alter triggering checkpoint calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1625
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1628
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1626
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1629
 /*! session: table compact conflicted with checkpoint */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1627
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1630
 /*! session: table compact dhandle successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1628
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1631
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1629
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1632
 /*! session: table compact failed calls due to cache pressure */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1630
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1633
 /*! session: table compact passes */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1631
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1634
 /*! session: table compact pulled into eviction */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1632
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1635
 /*! session: table compact running */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1633
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1636
 /*! session: table compact skipped as process would not reduce file size */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1634
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1637
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1635
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1638
 /*! session: table compact timeout */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1636
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1639
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1637
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1640
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1638
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1641
 /*! session: table create with import failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1639
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1642
 /*! session: table create with import repair calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1640
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1643
 /*! session: table create with import successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1641
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1644
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1642
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1645
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1643
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1646
 /*! session: table rename failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1644
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1647
 /*! session: table rename successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1645
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1648
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1646
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1649
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1647
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1650
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1648
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1651
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1649
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1652
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1650
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1653
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1651
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1654
 /*! session: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1652
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1655
 /*! session: tiered operations removed without processing */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1653
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1656
 /*! session: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1654
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1657
 /*! session: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1655
+#define	WT_STAT_CONN_TIERED_RETENTION			1658
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1656
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1659
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1657
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1660
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1658
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1661
 /*! thread-yield: application thread operations waiting for cache */
-#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1659
+#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1662
 /*! thread-yield: application thread snapshot refreshed for eviction */
-#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1660
+#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1663
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1661
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1664
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1662
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1665
 /*! thread-yield: connection close yielded for lsm manager shutdown */
-#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1663
+#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1666
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1664
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1667
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1665
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1668
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1666
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1669
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1667
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1670
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1668
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1671
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1669
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1672
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1670
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1673
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1671
+#define	WT_STAT_CONN_PAGE_SLEEP				1674
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1672
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1675
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1673
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1676
 /*! thread-yield: page split and restart read */
-#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1674
+#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1677
 /*! thread-yield: pages skipped during read due to deleted state */
-#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1675
+#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1678
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1676
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1679
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1677
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1680
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1678
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1681
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1679
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1682
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1680
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1683
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1681
+#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1684
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1682
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1685
 /*! transaction: oldest transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1683
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1686
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1684
+#define	WT_STAT_CONN_TXN_PREPARE			1687
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1685
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1688
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1686
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1689
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1687
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1690
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1688
+#define	WT_STAT_CONN_TXN_QUERY_TS			1691
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1689
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1692
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1690
+#define	WT_STAT_CONN_TXN_RTS				1693
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1691
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1694
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1692
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1695
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1693
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1696
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1694
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1697
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1695
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1698
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1696
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1699
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1697
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1700
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1698
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1701
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1699
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1702
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1700
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1703
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1701
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1704
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1702
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1705
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1703
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1706
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1704
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1707
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1705
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1708
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1706
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1709
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1707
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1710
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1708
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1711
 /*!
  * transaction: rollback to stable updates that would have been aborted
  * in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1709
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1712
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1710
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1713
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1711
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1714
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1712
+#define	WT_STAT_CONN_TXN_SET_TS				1715
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1713
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1716
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1714
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1717
 /*! transaction: set timestamp force calls */
-#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1715
+#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1718
 /*!
  * transaction: set timestamp global oldest timestamp set to be more
  * recent than the global stable timestamp
  */
-#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1716
+#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1719
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1717
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1720
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1718
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1721
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1719
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1722
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1720
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1723
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1721
+#define	WT_STAT_CONN_TXN_BEGIN				1724
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1722
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1725
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1723
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1726
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1724
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1727
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1725
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1728
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1726
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1729
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1727
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1730
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1728
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1731
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1729
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1732
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1730
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1733
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1731
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1734
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1732
+#define	WT_STAT_CONN_TXN_COMMIT				1735
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1733
+#define	WT_STAT_CONN_TXN_ROLLBACK			1736
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1734
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1737
 
 /*!
  * @}
@@ -7884,31 +7881,22 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
  * cache_walk or all statistics are enabled
  */
 #define	WT_STAT_DSRC_CACHE_STATE_PAGES			2167
+/*! checkpoint-cleanup: pages added for eviction */
+#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_EVICT	2168
+/*! checkpoint-cleanup: pages dirtied due to obsolete time window */
+#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	2169
+/*! checkpoint-cleanup: pages read into cache (reclaim_space) */
+#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	2170
+/*! checkpoint-cleanup: pages read into cache due to obsolete time window */
+#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	2171
+/*! checkpoint-cleanup: pages removed */
+#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_REMOVED	2172
+/*! checkpoint-cleanup: pages skipped during tree walk */
+#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	2173
+/*! checkpoint-cleanup: pages visited */
+#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_VISITED	2174
 /*! checkpoint: checkpoint has acquired a snapshot for its transaction */
-#define	WT_STAT_DSRC_CHECKPOINT_SNAPSHOT_ACQUIRED	2168
-/*! checkpoint: pages added for eviction during checkpoint cleanup */
-#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_EVICT	2169
-/*!
- * checkpoint: pages dirtied due to obsolete time window by checkpoint
- * cleanup
- */
-#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	2170
-/*!
- * checkpoint: pages read into cache during checkpoint cleanup
- * (reclaim_space)
- */
-#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	2171
-/*!
- * checkpoint: pages read into cache during checkpoint cleanup due to
- * obsolete time window
- */
-#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	2172
-/*! checkpoint: pages removed during checkpoint cleanup */
-#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_REMOVED	2173
-/*! checkpoint: pages skipped during checkpoint cleanup tree walk */
-#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	2174
-/*! checkpoint: pages visited during checkpoint cleanup */
-#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_VISITED	2175
+#define	WT_STAT_DSRC_CHECKPOINT_SNAPSHOT_ACQUIRED	2175
 /*! checkpoint: transaction checkpoints due to obsolete pages */
 #define	WT_STAT_DSRC_CHECKPOINT_OBSOLETE_APPLIED	2176
 /*!

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -184,14 +184,14 @@ static const char *const __stats_dsrc_desc[] = {
   "cache_walk: Refs skipped during cache traversal",
   "cache_walk: Size of the root page",
   "cache_walk: Total number of pages currently in cache",
+  "checkpoint-cleanup: pages added for eviction",
+  "checkpoint-cleanup: pages dirtied due to obsolete time window",
+  "checkpoint-cleanup: pages read into cache (reclaim_space)",
+  "checkpoint-cleanup: pages read into cache due to obsolete time window",
+  "checkpoint-cleanup: pages removed",
+  "checkpoint-cleanup: pages skipped during tree walk",
+  "checkpoint-cleanup: pages visited",
   "checkpoint: checkpoint has acquired a snapshot for its transaction",
-  "checkpoint: pages added for eviction during checkpoint cleanup",
-  "checkpoint: pages dirtied due to obsolete time window by checkpoint cleanup",
-  "checkpoint: pages read into cache during checkpoint cleanup (reclaim_space)",
-  "checkpoint: pages read into cache during checkpoint cleanup due to obsolete time window",
-  "checkpoint: pages removed during checkpoint cleanup",
-  "checkpoint: pages skipped during checkpoint cleanup tree walk",
-  "checkpoint: pages visited during checkpoint cleanup",
   "checkpoint: transaction checkpoints due to obsolete pages",
   "compression: compressed page maximum internal page size prior to compression",
   "compression: compressed page maximum leaf page size prior to compression ",
@@ -555,7 +555,6 @@ __wt_stat_dsrc_clear_single(WT_DSRC_STATS *stats)
     /* not clearing cache_state_refs_skipped */
     /* not clearing cache_state_root_size */
     /* not clearing cache_state_pages */
-    stats->checkpoint_snapshot_acquired = 0;
     stats->checkpoint_cleanup_pages_evict = 0;
     stats->checkpoint_cleanup_pages_obsolete_tw = 0;
     stats->checkpoint_cleanup_pages_read_reclaim_space = 0;
@@ -563,6 +562,7 @@ __wt_stat_dsrc_clear_single(WT_DSRC_STATS *stats)
     stats->checkpoint_cleanup_pages_removed = 0;
     stats->checkpoint_cleanup_pages_walk_skipped = 0;
     stats->checkpoint_cleanup_pages_visited = 0;
+    stats->checkpoint_snapshot_acquired = 0;
     stats->checkpoint_obsolete_applied = 0;
     /* not clearing compress_precomp_intl_max_page_size */
     /* not clearing compress_precomp_leaf_max_page_size */
@@ -918,7 +918,6 @@ __wt_stat_dsrc_aggregate_single(WT_DSRC_STATS *from, WT_DSRC_STATS *to)
     to->cache_state_refs_skipped += from->cache_state_refs_skipped;
     to->cache_state_root_size += from->cache_state_root_size;
     to->cache_state_pages += from->cache_state_pages;
-    to->checkpoint_snapshot_acquired += from->checkpoint_snapshot_acquired;
     to->checkpoint_cleanup_pages_evict += from->checkpoint_cleanup_pages_evict;
     to->checkpoint_cleanup_pages_obsolete_tw += from->checkpoint_cleanup_pages_obsolete_tw;
     to->checkpoint_cleanup_pages_read_reclaim_space +=
@@ -928,6 +927,7 @@ __wt_stat_dsrc_aggregate_single(WT_DSRC_STATS *from, WT_DSRC_STATS *to)
     to->checkpoint_cleanup_pages_removed += from->checkpoint_cleanup_pages_removed;
     to->checkpoint_cleanup_pages_walk_skipped += from->checkpoint_cleanup_pages_walk_skipped;
     to->checkpoint_cleanup_pages_visited += from->checkpoint_cleanup_pages_visited;
+    to->checkpoint_snapshot_acquired += from->checkpoint_snapshot_acquired;
     to->checkpoint_obsolete_applied += from->checkpoint_obsolete_applied;
     to->compress_precomp_intl_max_page_size += from->compress_precomp_intl_max_page_size;
     to->compress_precomp_leaf_max_page_size += from->compress_precomp_leaf_max_page_size;
@@ -1294,7 +1294,6 @@ __wt_stat_dsrc_aggregate(WT_DSRC_STATS **from, WT_DSRC_STATS *to)
     to->cache_state_refs_skipped += WT_STAT_READ(from, cache_state_refs_skipped);
     to->cache_state_root_size += WT_STAT_READ(from, cache_state_root_size);
     to->cache_state_pages += WT_STAT_READ(from, cache_state_pages);
-    to->checkpoint_snapshot_acquired += WT_STAT_READ(from, checkpoint_snapshot_acquired);
     to->checkpoint_cleanup_pages_evict += WT_STAT_READ(from, checkpoint_cleanup_pages_evict);
     to->checkpoint_cleanup_pages_obsolete_tw +=
       WT_STAT_READ(from, checkpoint_cleanup_pages_obsolete_tw);
@@ -1306,6 +1305,7 @@ __wt_stat_dsrc_aggregate(WT_DSRC_STATS **from, WT_DSRC_STATS *to)
     to->checkpoint_cleanup_pages_walk_skipped +=
       WT_STAT_READ(from, checkpoint_cleanup_pages_walk_skipped);
     to->checkpoint_cleanup_pages_visited += WT_STAT_READ(from, checkpoint_cleanup_pages_visited);
+    to->checkpoint_snapshot_acquired += WT_STAT_READ(from, checkpoint_snapshot_acquired);
     to->checkpoint_obsolete_applied += WT_STAT_READ(from, checkpoint_obsolete_applied);
     to->compress_precomp_intl_max_page_size +=
       WT_STAT_READ(from, compress_precomp_intl_max_page_size);
@@ -1776,7 +1776,17 @@ static const char *const __stats_connection_desc[] = {
   "capacity: time waiting during logging (usecs)",
   "capacity: time waiting during read (usecs)",
   "capacity: time waiting for chunk cache IO bandwidth (usecs)",
-  "checkpoint: checkpoint cleanup successful calls",
+  "checkpoint-cleanup: most recent duration on all eligible files (usecs)",
+  "checkpoint-cleanup: most recent handles processed",
+  "checkpoint-cleanup: most recent in-memory pages visited",
+  "checkpoint-cleanup: pages added for eviction",
+  "checkpoint-cleanup: pages dirtied due to obsolete time window",
+  "checkpoint-cleanup: pages read into cache (reclaim_space)",
+  "checkpoint-cleanup: pages read into cache due to obsolete time window",
+  "checkpoint-cleanup: pages removed",
+  "checkpoint-cleanup: pages skipped during tree walk",
+  "checkpoint-cleanup: pages visited",
+  "checkpoint-cleanup: successful calls",
   "checkpoint: checkpoint has acquired a snapshot for its transaction",
   "checkpoint: checkpoints skipped because database was clean",
   "checkpoint: fsync calls after allocating the transaction ID",
@@ -1805,13 +1815,6 @@ static const char *const __stats_connection_desc[] = {
   "checkpoint: number of internal pages visited",
   "checkpoint: number of leaf pages visited",
   "checkpoint: number of pages caused to be reconciled",
-  "checkpoint: pages added for eviction during checkpoint cleanup",
-  "checkpoint: pages dirtied due to obsolete time window by checkpoint cleanup",
-  "checkpoint: pages read into cache during checkpoint cleanup (reclaim_space)",
-  "checkpoint: pages read into cache during checkpoint cleanup due to obsolete time window",
-  "checkpoint: pages removed during checkpoint cleanup",
-  "checkpoint: pages skipped during checkpoint cleanup tree walk",
-  "checkpoint: pages visited during checkpoint cleanup",
   "checkpoint: prepare currently running",
   "checkpoint: prepare max time (msecs)",
   "checkpoint: prepare min time (msecs)",
@@ -2561,6 +2564,16 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->capacity_time_log = 0;
     stats->capacity_time_read = 0;
     stats->capacity_time_chunkcache = 0;
+    /* not clearing checkpoint_cleanup_duration */
+    stats->checkpoint_cleanup_handle_processed = 0;
+    stats->checkpoint_cleanup_inmem_pages_visited = 0;
+    stats->checkpoint_cleanup_pages_evict = 0;
+    stats->checkpoint_cleanup_pages_obsolete_tw = 0;
+    stats->checkpoint_cleanup_pages_read_reclaim_space = 0;
+    stats->checkpoint_cleanup_pages_read_obsolete_tw = 0;
+    stats->checkpoint_cleanup_pages_removed = 0;
+    stats->checkpoint_cleanup_pages_walk_skipped = 0;
+    stats->checkpoint_cleanup_pages_visited = 0;
     stats->checkpoint_cleanup_success = 0;
     stats->checkpoint_snapshot_acquired = 0;
     stats->checkpoint_skipped = 0;
@@ -2590,13 +2603,6 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->checkpoint_pages_visited_internal = 0;
     stats->checkpoint_pages_visited_leaf = 0;
     stats->checkpoint_pages_reconciled = 0;
-    stats->checkpoint_cleanup_pages_evict = 0;
-    stats->checkpoint_cleanup_pages_obsolete_tw = 0;
-    stats->checkpoint_cleanup_pages_read_reclaim_space = 0;
-    stats->checkpoint_cleanup_pages_read_obsolete_tw = 0;
-    stats->checkpoint_cleanup_pages_removed = 0;
-    stats->checkpoint_cleanup_pages_walk_skipped = 0;
-    stats->checkpoint_cleanup_pages_visited = 0;
     /* not clearing checkpoint_prep_running */
     /* not clearing checkpoint_prep_max */
     /* not clearing checkpoint_prep_min */
@@ -3384,6 +3390,22 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->capacity_time_log += WT_STAT_READ(from, capacity_time_log);
     to->capacity_time_read += WT_STAT_READ(from, capacity_time_read);
     to->capacity_time_chunkcache += WT_STAT_READ(from, capacity_time_chunkcache);
+    to->checkpoint_cleanup_duration += WT_STAT_READ(from, checkpoint_cleanup_duration);
+    to->checkpoint_cleanup_handle_processed +=
+      WT_STAT_READ(from, checkpoint_cleanup_handle_processed);
+    to->checkpoint_cleanup_inmem_pages_visited +=
+      WT_STAT_READ(from, checkpoint_cleanup_inmem_pages_visited);
+    to->checkpoint_cleanup_pages_evict += WT_STAT_READ(from, checkpoint_cleanup_pages_evict);
+    to->checkpoint_cleanup_pages_obsolete_tw +=
+      WT_STAT_READ(from, checkpoint_cleanup_pages_obsolete_tw);
+    to->checkpoint_cleanup_pages_read_reclaim_space +=
+      WT_STAT_READ(from, checkpoint_cleanup_pages_read_reclaim_space);
+    to->checkpoint_cleanup_pages_read_obsolete_tw +=
+      WT_STAT_READ(from, checkpoint_cleanup_pages_read_obsolete_tw);
+    to->checkpoint_cleanup_pages_removed += WT_STAT_READ(from, checkpoint_cleanup_pages_removed);
+    to->checkpoint_cleanup_pages_walk_skipped +=
+      WT_STAT_READ(from, checkpoint_cleanup_pages_walk_skipped);
+    to->checkpoint_cleanup_pages_visited += WT_STAT_READ(from, checkpoint_cleanup_pages_visited);
     to->checkpoint_cleanup_success += WT_STAT_READ(from, checkpoint_cleanup_success);
     to->checkpoint_snapshot_acquired += WT_STAT_READ(from, checkpoint_snapshot_acquired);
     to->checkpoint_skipped += WT_STAT_READ(from, checkpoint_skipped);
@@ -3414,17 +3436,6 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->checkpoint_pages_visited_internal += WT_STAT_READ(from, checkpoint_pages_visited_internal);
     to->checkpoint_pages_visited_leaf += WT_STAT_READ(from, checkpoint_pages_visited_leaf);
     to->checkpoint_pages_reconciled += WT_STAT_READ(from, checkpoint_pages_reconciled);
-    to->checkpoint_cleanup_pages_evict += WT_STAT_READ(from, checkpoint_cleanup_pages_evict);
-    to->checkpoint_cleanup_pages_obsolete_tw +=
-      WT_STAT_READ(from, checkpoint_cleanup_pages_obsolete_tw);
-    to->checkpoint_cleanup_pages_read_reclaim_space +=
-      WT_STAT_READ(from, checkpoint_cleanup_pages_read_reclaim_space);
-    to->checkpoint_cleanup_pages_read_obsolete_tw +=
-      WT_STAT_READ(from, checkpoint_cleanup_pages_read_obsolete_tw);
-    to->checkpoint_cleanup_pages_removed += WT_STAT_READ(from, checkpoint_cleanup_pages_removed);
-    to->checkpoint_cleanup_pages_walk_skipped +=
-      WT_STAT_READ(from, checkpoint_cleanup_pages_walk_skipped);
-    to->checkpoint_cleanup_pages_visited += WT_STAT_READ(from, checkpoint_cleanup_pages_visited);
     to->checkpoint_prep_running += WT_STAT_READ(from, checkpoint_prep_running);
     to->checkpoint_prep_max += WT_STAT_READ(from, checkpoint_prep_max);
     to->checkpoint_prep_min += WT_STAT_READ(from, checkpoint_prep_min);

--- a/test/suite/test_cc02.py
+++ b/test/suite/test_cc02.py
@@ -26,6 +26,8 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
+import os
+
 from test_cc01 import test_cc_base
 from wiredtiger import stat
 from wtdataset import SimpleDataSet
@@ -116,9 +118,12 @@ class test_cc02(test_cc_base):
         # Trigger checkpoint cleanup and wait until it is done. This should clean the history store.
         self.check_cc_stats()
         c = self.session.open_cursor('statistics:')
-        self.assertGreater(c[stat.conn.checkpoint_cleanup_duration][2], 0)
         self.assertGreater(c[stat.conn.checkpoint_cleanup_handle_processed][2], 0)
         self.assertGreater(c[stat.conn.checkpoint_cleanup_inmem_pages_visited][2], 0)
+        # Some Windows machines lack the time granularity to detect microseconds.
+        # Skip the time check on Windows.
+        if not os.name == "nt":
+            self.assertGreater(c[stat.conn.checkpoint_cleanup_duration][2], 0)
         c.close()
 
         # Check that the new updates are only seen after the update timestamp.

--- a/test/suite/test_cc02.py
+++ b/test/suite/test_cc02.py
@@ -115,6 +115,11 @@ class test_cc02(test_cc_base):
 
         # Trigger checkpoint cleanup and wait until it is done. This should clean the history store.
         self.check_cc_stats()
+        c = self.session.open_cursor('statistics:')
+        self.assertGreater(c[stat.conn.checkpoint_cleanup_duration][2], 0)
+        self.assertGreater(c[stat.conn.checkpoint_cleanup_handle_processed][2], 0)
+        self.assertGreater(c[stat.conn.checkpoint_cleanup_inmem_pages_visited][2], 0)
+        c.close()
 
         # Check that the new updates are only seen after the update timestamp.
         self.check(bigvalue, uri, nrows, 200)


### PR DESCRIPTION
Cherry-pick of a827bdf6915dfac477acb8116eea4c21058a6cd7 for BACKPORT-26923
(cherry picked from commit 95eebbd51045b1b64e654a68ab7289479c84c9db)
