### PR TITLE
WT-16881 Sort regions/functions by descending order of cyclomatic complexity in the Evergreen cyclomatic-complexity task

### DIFF
--- a/test/evergreen/cyclomatic-complexity.sh
+++ b/test/evergreen/cyclomatic-complexity.sh
@@ -11,12 +11,9 @@ cd src
 python3 "../metrixplusplus/metrix++.py" collect --std.code.lines.code --std.code.complexity.cyclomatic
 python3 "../metrixplusplus/metrix++.py" view
 
-# Find the top 5 functions with the highest cyclomatic complexity
-echo "Top 5 with the highest cyclomatic complexity:"
-python3 "../metrixplusplus/metrix++.py" limit --db-file=metrixpp.db --max-limit=std.code.complexity:cyclomatic:0 --hotspots=5
-
 # Set the cyclomatic complexity limit to 20
-python3 "../metrixplusplus/metrix++.py" limit --max-limit=std.code.complexity:cyclomatic:20
+# Set hotspots to 1000 to include all regions/functions above the limit, sorted by highest complexity.
+python3 "../metrixplusplus/metrix++.py" limit --max-limit=std.code.complexity:cyclomatic:20 --hotspots=1000
 
 # Fail if there are functions with cyclomatic complexity larger than 98
 python "../metrixplusplus/metrix++.py" limit --max-limit=std.code.complexity:cyclomatic:98 > $t

--- a/test/evergreen/cyclomatic-complexity.sh
+++ b/test/evergreen/cyclomatic-complexity.sh
@@ -12,7 +12,7 @@ python3 "../metrixplusplus/metrix++.py" collect --std.code.lines.code --std.code
 python3 "../metrixplusplus/metrix++.py" view
 
 # Set the cyclomatic complexity limit to 20
-# Set hotspots to 1000 to include all regions/functions above the limit, sorted by highest complexity.
+# Set hotspots to 1000 arbitrarily to include all regions/functions above the limit, sorted by highest complexity.
 python3 "../metrixplusplus/metrix++.py" limit --max-limit=std.code.complexity:cyclomatic:20 --hotspots=1000
 
 # Fail if there are functions with cyclomatic complexity larger than 98

--- a/test/evergreen/cyclomatic-complexity.sh
+++ b/test/evergreen/cyclomatic-complexity.sh
@@ -11,6 +11,10 @@ cd src
 python3 "../metrixplusplus/metrix++.py" collect --std.code.lines.code --std.code.complexity.cyclomatic
 python3 "../metrixplusplus/metrix++.py" view
 
+# Find the top 5 functions with the highest cyclomatic complexity
+echo "Top 5 with the highest cyclomatic complexity:"
+python3 "../metrixplusplus/metrix++.py" limit --db-file=metrixpp.db --max-limit=std.code.complexity:cyclomatic:0 --hotspots=5
+
 # Set the cyclomatic complexity limit to 20
 python3 "../metrixplusplus/metrix++.py" limit --max-limit=std.code.complexity:cyclomatic:20
 


### PR DESCRIPTION
All regions/functions with a cyclomatic complexity score above the soft limit (20) will now be shown in descending order of complexity as a part of the cyclomatic-complexity evergreen task.