### PR TITLE
WT-16869 Fix sub-level error message when closing dhandle

### DIFF
--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -3043,7 +3043,7 @@ __wt_checkpoint_close(WT_SESSION_IMPL *session, bool final)
     if (btree->modified && !bulk && !metadata) {
         ret = __wt_set_return(session, EBUSY);
         WT_RET_SUB(
-          session, ret, WT_DIRTY_DATA, "the table has dirty data and can not be closed yet");
+          session, ret, WT_DIRTY_DATA, "the table has dirty data and cannot be closed yet");
     }
 
     /*

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -3043,7 +3043,7 @@ __wt_checkpoint_close(WT_SESSION_IMPL *session, bool final)
     if (btree->modified && !bulk && !metadata) {
         ret = __wt_set_return(session, EBUSY);
         WT_RET_SUB(
-          session, ret, WT_DIRTY_DATA, "the table has dirty data and can not be dropped yet");
+          session, ret, WT_DIRTY_DATA, "the table has dirty data and can not be closed yet");
     }
 
     /*

--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -393,7 +393,7 @@ __wt_conn_dhandle_close(WT_SESSION_IMPL *session, bool final, bool mark_dead, bo
             WT_RET(__wt_txn_update_oldest(session, WT_TXN_OLDEST_STRICT | WT_TXN_OLDEST_WAIT));
             if (!__wt_txn_visible_all(session, btree->max_upd_txn, WT_TS_NONE))
                 WT_RET_SUB(session, EBUSY, WT_UNCOMMITTED_DATA,
-                  "the table has uncommitted data and can not be closed yet");
+                  "the table has uncommitted data and cannot be closed yet");
         }
 
         /* Turn off eviction. */

--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -393,7 +393,7 @@ __wt_conn_dhandle_close(WT_SESSION_IMPL *session, bool final, bool mark_dead, bo
             WT_RET(__wt_txn_update_oldest(session, WT_TXN_OLDEST_STRICT | WT_TXN_OLDEST_WAIT));
             if (!__wt_txn_visible_all(session, btree->max_upd_txn, WT_TS_NONE))
                 WT_RET_SUB(session, EBUSY, WT_UNCOMMITTED_DATA,
-                  "the table has uncommitted data and cannot be dropped yet");
+                  "the table has uncommitted data and can not be closed yet");
         }
 
         /* Turn off eviction. */

--- a/test/catch2/sub_level_error/unit/test_sub_level_error_drop_uncommitted_dirty.cpp
+++ b/test/catch2/sub_level_error/unit/test_sub_level_error_drop_uncommitted_dirty.cpp
@@ -20,8 +20,8 @@
 
 #define URI "table:test_drop_uncommitted_dirty"
 #define FILE_URI "file:test_drop_uncommitted_dirty.wt"
-#define UNCOMMITTED_DATA_MSG "the table has uncommitted data and cannot be dropped yet"
-#define DIRTY_DATA_MSG "the table has dirty data and can not be dropped yet"
+#define UNCOMMITTED_DATA_MSG "the table has uncommitted data and can not be closed yet"
+#define DIRTY_DATA_MSG "the table has dirty data and can not be closed yet"
 
 /*
  * This test case covers EBUSY errors resulting from drop before committing/checkpointing changes.

--- a/test/catch2/sub_level_error/unit/test_sub_level_error_drop_uncommitted_dirty.cpp
+++ b/test/catch2/sub_level_error/unit/test_sub_level_error_drop_uncommitted_dirty.cpp
@@ -20,8 +20,8 @@
 
 #define URI "table:test_drop_uncommitted_dirty"
 #define FILE_URI "file:test_drop_uncommitted_dirty.wt"
-#define UNCOMMITTED_DATA_MSG "the table has uncommitted data and can not be closed yet"
-#define DIRTY_DATA_MSG "the table has dirty data and can not be closed yet"
+#define UNCOMMITTED_DATA_MSG "the table has uncommitted data and cannot be closed yet"
+#define DIRTY_DATA_MSG "the table has dirty data and cannot be closed yet"
 
 /*
  * This test case covers EBUSY errors resulting from drop before committing/checkpointing changes.

--- a/test/suite/test_error_info01.py
+++ b/test/suite/test_error_info01.py
@@ -96,14 +96,14 @@ class test_error_info01(error_info_util, compact_util):
 
     def test_ebusy_wt_uncommitted_data(self):
         self.api_call_with_ebusy_wt_uncommitted_data()
-        self.assert_error_equal(errno.EBUSY, wiredtiger.WT_UNCOMMITTED_DATA, "the table has uncommitted data and can not be closed yet")
+        self.assert_error_equal(errno.EBUSY, wiredtiger.WT_UNCOMMITTED_DATA, "the table has uncommitted data and cannot be closed yet")
         self.assertEqual(self.session.rollback_transaction(), 0)
         self.assertEqual(self.session.checkpoint(), 0)
         self.assertEqual(self.session.drop(self.uri, None), 0)
 
     def test_ebusy_wt_dirty_data(self):
         self.api_call_with_ebusy_wt_dirty_data()
-        self.assert_error_equal(errno.EBUSY, wiredtiger.WT_DIRTY_DATA, "the table has dirty data and can not be closed yet")
+        self.assert_error_equal(errno.EBUSY, wiredtiger.WT_DIRTY_DATA, "the table has dirty data and cannot be closed yet")
         self.assertEqual(self.session.checkpoint(), 0)
         self.assertEqual(self.session.drop(self.uri, None), 0)
 

--- a/test/suite/test_error_info01.py
+++ b/test/suite/test_error_info01.py
@@ -96,14 +96,14 @@ class test_error_info01(error_info_util, compact_util):
 
     def test_ebusy_wt_uncommitted_data(self):
         self.api_call_with_ebusy_wt_uncommitted_data()
-        self.assert_error_equal(errno.EBUSY, wiredtiger.WT_UNCOMMITTED_DATA, "the table has uncommitted data and cannot be dropped yet")
+        self.assert_error_equal(errno.EBUSY, wiredtiger.WT_UNCOMMITTED_DATA, "the table has uncommitted data and can not be closed yet")
         self.assertEqual(self.session.rollback_transaction(), 0)
         self.assertEqual(self.session.checkpoint(), 0)
         self.assertEqual(self.session.drop(self.uri, None), 0)
 
     def test_ebusy_wt_dirty_data(self):
         self.api_call_with_ebusy_wt_dirty_data()
-        self.assert_error_equal(errno.EBUSY, wiredtiger.WT_DIRTY_DATA, "the table has dirty data and can not be dropped yet")
+        self.assert_error_equal(errno.EBUSY, wiredtiger.WT_DIRTY_DATA, "the table has dirty data and can not be closed yet")
         self.assertEqual(self.session.checkpoint(), 0)
         self.assertEqual(self.session.drop(self.uri, None), 0)
 

--- a/test/suite/test_error_info03.py
+++ b/test/suite/test_error_info03.py
@@ -149,7 +149,7 @@ class test_error_info03(error_info_util):
             cursor.set_value('value')
             self.assertEqual(cursor.update(), 0)
         self.assertTrue(self.raisesBusy(lambda: self.session.drop(self.uri, None)), "was expecting drop call to fail with EBUSY")
-        self.assert_error_equal(errno.EBUSY, wiredtiger.WT_UNCOMMITTED_DATA, "the table has uncommitted data and cannot be dropped yet")
+        self.assert_error_equal(errno.EBUSY, wiredtiger.WT_UNCOMMITTED_DATA, "the table has uncommitted data and can not be closed yet")
 
     def test_dirty_data(self):
         """
@@ -166,4 +166,4 @@ class test_error_info03(error_info_util):
         # Give time for the oldest id to update before dropping the table.
         time.sleep(1)
         self.assertTrue(self.raisesBusy(lambda: self.session.drop(self.uri, None)), "was expecting drop call to fail with EBUSY")
-        self.assert_error_equal(errno.EBUSY, wiredtiger.WT_DIRTY_DATA, "the table has dirty data and can not be dropped yet")
+        self.assert_error_equal(errno.EBUSY, wiredtiger.WT_DIRTY_DATA, "the table has dirty data and can not be closed yet")

--- a/test/suite/test_error_info03.py
+++ b/test/suite/test_error_info03.py
@@ -149,7 +149,7 @@ class test_error_info03(error_info_util):
             cursor.set_value('value')
             self.assertEqual(cursor.update(), 0)
         self.assertTrue(self.raisesBusy(lambda: self.session.drop(self.uri, None)), "was expecting drop call to fail with EBUSY")
-        self.assert_error_equal(errno.EBUSY, wiredtiger.WT_UNCOMMITTED_DATA, "the table has uncommitted data and can not be closed yet")
+        self.assert_error_equal(errno.EBUSY, wiredtiger.WT_UNCOMMITTED_DATA, "the table has uncommitted data and cannot be closed yet")
 
     def test_dirty_data(self):
         """
@@ -166,4 +166,4 @@ class test_error_info03(error_info_util):
         # Give time for the oldest id to update before dropping the table.
         time.sleep(1)
         self.assertTrue(self.raisesBusy(lambda: self.session.drop(self.uri, None)), "was expecting drop call to fail with EBUSY")
-        self.assert_error_equal(errno.EBUSY, wiredtiger.WT_DIRTY_DATA, "the table has dirty data and can not be closed yet")
+        self.assert_error_equal(errno.EBUSY, wiredtiger.WT_DIRTY_DATA, "the table has dirty data and cannot be closed yet")


### PR DESCRIPTION
Fixed sub-level error message when closing dhandle for uncommitted data and dirty data. Originally, the message states "table ... can not be dropped yet", but these error messages can come from closing the dhandle generally, rather than dropping a table.