### PR TITLE
WT-16839 Set the last checkpoint timestamp upon checkpoint pick up

### DIFF
--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -400,6 +400,7 @@ __disagg_update_checkpoint_meta(WT_SESSION_IMPL *session, WT_SESSION_IMPL *inter
       &conn->disaggregated_storage.last_checkpoint_timestamp, metadata->checkpoint_timestamp);
     __wt_atomic_store_uint64_release(
       &conn->disaggregated_storage.last_checkpoint_oldest_timestamp, metadata->oldest_timestamp);
+    conn->txn_global.last_ckpt_timestamp = metadata->checkpoint_timestamp;
 
     /* Set the database size. */
     if (ckpt_meta->has_database_size)

--- a/test/suite/test_layered17.py
+++ b/test/suite/test_layered17.py
@@ -86,6 +86,10 @@ class test_layered17(wttest.WiredTigerTestCase):
         self.disagg_advance_checkpoint(conn_follow)
         session_follow = conn_follow.open_session('')
 
+        # Check the last checkpoint timestamp in the follower
+        self.assertTimestampsEqual(conn_follow.query_timestamp('get=last_checkpoint'),
+                                   self.timestamp_str(checkpoint_timestamp))
+
         # Check the table in the follower
         cursor = session_follow.open_cursor(self.uri, None, None)
         for i in range(self.nitems):
@@ -116,6 +120,10 @@ class test_layered17(wttest.WiredTigerTestCase):
 
         # Pick up the new checkpoint
         self.disagg_advance_checkpoint(conn_follow)
+
+        # Check the last checkpoint timestamp in the follower
+        self.assertTimestampsEqual(conn_follow.query_timestamp('get=last_checkpoint'),
+                                   self.timestamp_str(checkpoint_timestamp))
 
         # Check the table in the follower
         cursor = session_follow.open_cursor(self.uri, None, None)
@@ -151,6 +159,10 @@ class test_layered17(wttest.WiredTigerTestCase):
 
         # Pick up the new checkpoint
         self.disagg_advance_checkpoint(conn_follow)
+
+        # Check the last checkpoint timestamp in the follower
+        self.assertTimestampsEqual(conn_follow.query_timestamp('get=last_checkpoint'),
+                                   self.timestamp_str(checkpoint_timestamp))
 
         # Check the table in the follower (should not see the latest changes)
         cursor = session_follow.open_cursor(self.uri, None, None)

--- a/test/suite/test_layered53.py
+++ b/test/suite/test_layered53.py
@@ -76,6 +76,10 @@ class test_layered53(wttest.WiredTigerTestCase):
         # Advance the checkpoint on the follower.
         self.disagg_advance_checkpoint(self.conn_follow)
 
+        # Check the last checkpoint timestamp in the follower
+        self.assertTimestampsEqual(self.conn_follow.query_timestamp('get=last_checkpoint'),
+                                   self.timestamp_str(checkpoint_timestamp))
+
         # Advance the stable timestamp on the leader without dirtying anything, check that we indeed
         # created a checkpoint.
         self.conn.set_timestamp(f"stable_timestamp={self.timestamp_str(20)}")
@@ -85,6 +89,10 @@ class test_layered53(wttest.WiredTigerTestCase):
 
         # Advance the checkpoint on the follower.
         self.disagg_advance_checkpoint(self.conn_follow)
+
+        # Check the last checkpoint timestamp in the follower
+        self.assertTimestampsEqual(self.conn_follow.query_timestamp('get=last_checkpoint'),
+                                   self.timestamp_str(checkpoint_timestamp))
 
         # Check that the follower cannot do the same thing.
         cursor = self.session_follow.open_cursor(uri, None, None)
@@ -98,6 +106,8 @@ class test_layered53(wttest.WiredTigerTestCase):
         self.session_follow.checkpoint()
         _, _, checkpoint_timestamp, _ = self.disagg_get_complete_checkpoint_ext()
         self.assertEqual(checkpoint_timestamp, 20)
+        self.assertTimestampsEqual(self.conn_follow.query_timestamp('get=last_checkpoint'),
+                                   self.timestamp_str(checkpoint_timestamp))
 
         # Idempotence check: advancing the follower again should *not* change state.
         # It should simply log that the same checkpoint is being picked up again.


### PR DESCRIPTION
Update the last checkpoint timestamp when picking up a new checkpoint in disaggregated storage, so that it can be later retrieved via `conn->query_timestamp("get=last_checkpoint")`.