### PR TITLE
WT-14784 Disagg python testing: triage test_hs*.py tests

### DIFF
--- a/test/suite/hook_disagg.fail
+++ b/test/suite/hook_disagg.fail
@@ -24,10 +24,7 @@ test_env01.py
 test_error_info01.py
 test_error_info03.py    # FIXME: WT-16872
 test_hs01.py  # FIXME: WT-15371
-test_hs18.py
-test_hs21.py
 test_hs24.py    # FIXME: WT-16872
-test_hs30.py
 test_hs_evict_race01.py # FIXME: WT-16872
 test_log03.py
 test_metadata_cursor01.py

--- a/test/suite/test_hs21.py
+++ b/test/suite/test_hs21.py
@@ -108,6 +108,8 @@ class test_hs21(wttest.WiredTigerTestCase):
         for f in range(self.numfiles):
             table_uri = 'table:%s.%d' % (self.file_name, f)
             file_uri = 'file:%s.%d.wt' % (self.file_name, f)
+            if self.key_format == 'S' and self.runningHook('disagg'):
+                file_uri += '_stable'
             # Create a small table.
             ds = SimpleDataSet(
                 self, table_uri, 0, key_format=self.key_format, value_format=self.value_format,
@@ -204,6 +206,8 @@ class test_hs21(wttest.WiredTigerTestCase):
             # Check that the most recent transaction has the correct data.
             self.check(self.session, value2, ds.uri, self.nrows, 100)
             file_uri = 'file:%s.%d.wt' % (self.file_name, idx)
+            if self.key_format == 'S' and self.runningHook('disagg'):
+                file_uri += '_stable'
             # Get the current base_write_gen and ensure it hasn't changed since being
             # closed.
             base_write_gen = self.parse_run_write_gen(file_uri)


### PR DESCRIPTION
The `test/suite/hook_disagg.fail` list has a number of failures that happen when running `test_hs*.py` files with the disagg hook.  
In this PR I've triaged these failures, two of which are no longer occurring and one of which I've fixed in this PR.

Results:
- `test_hs18.py`: Couldn't reproduce, already fixed.
- `test_hs21.py`: Failed due to not finding a `.wt` file metadata entry, changing the uri suffix to `.wt_stable` fixed the test.
- `test_hs30.py`: Couldn't reproduce, already fixed.