### PR TITLE
WT-16889 Expand version cursor format to include prepare id and prepare ts

### DIFF
--- a/examples/c/ex_cursor.c
+++ b/examples/c/ex_cursor.c
@@ -171,14 +171,16 @@ cursor_remove(WT_CURSOR *cursor)
 int
 version_cursor_dump(WT_CURSOR *cursor)
 {
-    wt_timestamp_t start_ts, start_durable_ts, stop_ts, stop_durable_ts;
-    uint64_t start_txnid, stop_txnid;
+    wt_timestamp_t start_ts, start_durable_ts, start_prepare_ts, stop_ts, stop_durable_ts,
+      stop_prepare_ts;
+    uint64_t start_txnid, start_prepared_id, stop_txnid, stop_prepared_id;
     uint8_t flags, location, prepare, type;
     const char *value;
     cursor->set_key(cursor, "foo");
     error_check(cursor->search(cursor));
-    error_check(cursor->get_value(cursor, &start_txnid, &start_ts, &start_durable_ts, &stop_txnid,
-      &stop_ts, &stop_durable_ts, &type, &prepare, &flags, &location, &value));
+    error_check(cursor->get_value(cursor, &start_txnid, &start_ts, &start_durable_ts,
+      &start_prepare_ts, &start_prepared_id, &stop_txnid, &stop_ts, &stop_durable_ts,
+      &stop_prepare_ts, &stop_prepared_id, &type, &prepare, &flags, &location, &value));
 
     return (0);
 }

--- a/lang/python/wiredtiger.i
+++ b/lang/python/wiredtiger.i
@@ -1084,8 +1084,8 @@ typedef int int_void;
 			return [self._get_json_value()]
 		elif self.is_version_cursor:
 			result = self._get_version_cursor_value()
-			metadata = unpack("QQQQQQBBBB", result[0])
-			data = unpack(self.value_format[10:], result[1])
+			metadata = unpack("QQQQQQQQQQBBBB", result[0])
+			data = unpack(self.value_format[14:], result[1])
 			return metadata + data
 		else:
 			return unpack(self.value_format, self._get_value())

--- a/src/conn/conn_layered_ingest.c
+++ b/src/conn/conn_layered_ingest.c
@@ -177,10 +177,10 @@ __layered_copy_ingest_table(WT_SESSION_IMPL *session, WT_LAYERED_TABLE_MANAGER_E
         }
 
         WT_ERR(version_cursor->get_value(version_cursor, &tw.start_txn, &tw.start_ts,
-          &tw.durable_start_ts, &tw.stop_txn, &tw.stop_ts, &tw.durable_stop_ts, &type, &prepare,
-          &flags, &location, value));
-        /* We shouldn't see any prepared updates. */
-        WT_ASSERT(session, prepare == 0);
+          &tw.durable_start_ts, &tw.start_prepare_ts, &tw.start_prepared_id, &tw.stop_txn,
+          &tw.stop_ts, &tw.durable_stop_ts, &tw.stop_prepare_ts, &tw.stop_prepared_id, &type,
+          &prepare, &flags, &location, value));
+        WT_UNUSED(prepare);
 
         /* We assume the updates returned will be in timestamp order. */
         if (prev_upd != NULL) {

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -9,10 +9,11 @@
 #include "wt_internal.h"
 
 /*
- * Format: txn ID, start ts, start durable ts, stop txn ID, stop ts, stop durable ts, type, prepare,
- * flags, location, value.
+ * Format: txn ID, start ts, start durable ts, start prepare ts, start prepared id, stop txn ID,
+ * stop ts, stop durable ts, stop prepare ts, stop prepared id, type, prepare, flags, location,
+ * value.
  */
-#define WT_CURVERSION_METADATA_FORMAT WT_UNCHECKED_STRING(QQQQQQBBBB)
+#define WT_CURVERSION_METADATA_FORMAT WT_UNCHECKED_STRING(QQQQQQQQQQBBBB)
 
 /*
  * __curversion_set_key --
@@ -168,7 +169,7 @@ __curversion_next_single_key(WT_CURSOR *cursor)
     WT_UPDATE *first_globally_visible, *next_upd, *tombstone, *upd;
     wt_timestamp_t durable_start_ts, durable_stop_ts, stop_prepare_ts, stop_ts;
     size_t max_memsize;
-    uint64_t hs_upd_type, raw, stop_txn;
+    uint64_t hs_upd_type, raw, stop_prepared_id, stop_txn;
     uint8_t *p, prepare_state;
     bool stop_prepared, upd_found, version_prepared;
 
@@ -219,6 +220,7 @@ __curversion_next_single_key(WT_CURSOR *cursor)
                 version_cursor->upd_durable_stop_ts = upd->upd_durable_ts;
                 version_cursor->upd_stop_ts = upd->upd_start_ts;
                 version_cursor->upd_stop_prepare_ts = upd->prepare_ts;
+                version_cursor->upd_stop_prepared_id = upd->prepared_id;
                 version_cursor->upd_stop_prepared = version_prepared;
 
                 /* No need to check the next update if the tombstone is globally visible. */
@@ -256,16 +258,19 @@ __curversion_next_single_key(WT_CURSOR *cursor)
                  */
                 WT_ERR(__curversion_set_value_with_format(cursor, WT_CURVERSION_METADATA_FORMAT,
                   upd->txnid, version_prepared ? upd->prepare_ts : upd->upd_start_ts,
-                  upd->upd_durable_ts, version_cursor->upd_stop_txnid,
+                  upd->upd_durable_ts, (uint64_t)upd->prepare_ts, (uint64_t)upd->prepared_id,
+                  version_cursor->upd_stop_txnid,
                   version_cursor->upd_stop_prepared ? version_cursor->upd_stop_prepare_ts :
                                                       version_cursor->upd_stop_ts,
-                  version_cursor->upd_durable_stop_ts, upd->type, version_prepared, upd->flags,
-                  WT_CURVERSION_UPDATE_CHAIN));
+                  version_cursor->upd_durable_stop_ts, (uint64_t)version_cursor->upd_stop_prepare_ts,
+                  (uint64_t)version_cursor->upd_stop_prepared_id, upd->type, version_prepared,
+                  upd->flags, WT_CURVERSION_UPDATE_CHAIN));
 
                 version_cursor->upd_stop_txnid = upd->txnid;
                 version_cursor->upd_durable_stop_ts = upd->upd_durable_ts;
                 version_cursor->upd_stop_ts = upd->upd_start_ts;
                 version_cursor->upd_stop_prepare_ts = upd->prepare_ts;
+                version_cursor->upd_stop_prepared_id = upd->prepared_id;
                 version_cursor->upd_stop_prepared = version_prepared;
 
                 upd_found = true;
@@ -369,6 +374,7 @@ __curversion_next_single_key(WT_CURSOR *cursor)
                 }
                 durable_stop_ts = version_cursor->upd_durable_stop_ts;
                 stop_prepare_ts = version_cursor->upd_stop_prepare_ts;
+                stop_prepared_id = version_cursor->upd_stop_prepared_id;
                 stop_ts = version_cursor->upd_stop_ts;
                 stop_txn = version_cursor->upd_stop_txnid;
                 stop_prepared = version_cursor->upd_stop_prepared;
@@ -399,6 +405,7 @@ __curversion_next_single_key(WT_CURSOR *cursor)
                 }
                 durable_stop_ts = cbt->upd_value->tw.durable_stop_ts;
                 stop_prepare_ts = cbt->upd_value->tw.stop_prepare_ts;
+                stop_prepared_id = cbt->upd_value->tw.stop_prepared_id;
                 stop_ts = cbt->upd_value->tw.stop_ts;
                 stop_txn = cbt->upd_value->tw.stop_txn;
                 stop_prepared = WT_TIME_WINDOW_HAS_STOP_PREPARE(&cbt->upd_value->tw);
@@ -440,6 +447,7 @@ __curversion_next_single_key(WT_CURSOR *cursor)
 
                     stop_txn = WT_TXN_MAX;
                     stop_prepare_ts = WT_TS_MAX;
+                    stop_prepared_id = WT_PREPARED_ID_NONE;
                     stop_ts = WT_TS_MAX;
                     durable_stop_ts = WT_TS_NONE;
                     stop_prepared = false;
@@ -456,8 +464,11 @@ __curversion_next_single_key(WT_CURSOR *cursor)
               WT_TIME_WINDOW_HAS_START_PREPARE(&(cbt->upd_value->tw)) ?
                 cbt->upd_value->tw.start_prepare_ts :
                 cbt->upd_value->tw.durable_start_ts,
-              stop_txn, stop_prepared ? stop_prepare_ts : stop_ts, durable_stop_ts,
-              WT_UPDATE_STANDARD, version_prepared, 0, WT_CURVERSION_DISK_IMAGE));
+              (uint64_t)cbt->upd_value->tw.start_prepare_ts,
+              (uint64_t)cbt->upd_value->tw.start_prepared_id, stop_txn,
+              stop_prepared ? stop_prepare_ts : stop_ts, durable_stop_ts, (uint64_t)stop_prepare_ts,
+              (uint64_t)stop_prepared_id, WT_UPDATE_STANDARD, version_prepared, 0,
+              WT_CURVERSION_DISK_IMAGE));
 
             version_cursor->upd_stop_txnid = cbt->upd_value->tw.start_txn;
             version_cursor->upd_durable_stop_ts =
@@ -467,6 +478,8 @@ __curversion_next_single_key(WT_CURSOR *cursor)
             version_cursor->upd_stop_ts = WT_TIME_WINDOW_HAS_START_PREPARE(&(cbt->upd_value->tw)) ?
               cbt->upd_value->tw.start_prepare_ts :
               cbt->upd_value->tw.start_ts;
+            version_cursor->upd_stop_prepare_ts = cbt->upd_value->tw.start_prepare_ts;
+            version_cursor->upd_stop_prepared_id = cbt->upd_value->tw.start_prepared_id;
 
             upd_found = true;
         } else
@@ -568,19 +581,23 @@ skip_on_page:
                 goto done;
         }
 
-        WT_ERR(__curversion_set_value_with_format(cursor, WT_CURVERSION_METADATA_FORMAT,
-          twp->start_txn,
-          WT_TIME_WINDOW_HAS_START_PREPARE(twp) ? twp->start_prepare_ts : twp->start_ts,
-          WT_TIME_WINDOW_HAS_START_PREPARE(twp) ? twp->start_prepare_ts : twp->durable_start_ts,
-          twp->stop_txn, WT_TIME_WINDOW_HAS_STOP_PREPARE(twp) ? twp->stop_prepare_ts : twp->stop_ts,
-          WT_TIME_WINDOW_HAS_STOP_PREPARE(twp) ? twp->stop_prepare_ts : twp->durable_stop_ts,
-          hs_upd_type, 0, 0, WT_CURVERSION_HISTORY_STORE));
+        WT_ERR(
+          __curversion_set_value_with_format(cursor, WT_CURVERSION_METADATA_FORMAT, twp->start_txn,
+            WT_TIME_WINDOW_HAS_START_PREPARE(twp) ? twp->start_prepare_ts : twp->start_ts,
+            WT_TIME_WINDOW_HAS_START_PREPARE(twp) ? twp->start_prepare_ts : twp->durable_start_ts,
+            (uint64_t)twp->start_prepare_ts, (uint64_t)twp->start_prepared_id, twp->stop_txn,
+            WT_TIME_WINDOW_HAS_STOP_PREPARE(twp) ? twp->stop_prepare_ts : twp->stop_ts,
+            WT_TIME_WINDOW_HAS_STOP_PREPARE(twp) ? twp->stop_prepare_ts : twp->durable_stop_ts,
+            (uint64_t)twp->stop_prepare_ts, (uint64_t)twp->stop_prepared_id, hs_upd_type, 0, 0,
+            WT_CURVERSION_HISTORY_STORE));
 
         version_cursor->upd_stop_txnid = twp->start_txn;
         version_cursor->upd_durable_stop_ts =
           WT_TIME_WINDOW_HAS_START_PREPARE(twp) ? twp->start_prepare_ts : twp->durable_start_ts;
         version_cursor->upd_stop_ts =
           WT_TIME_WINDOW_HAS_START_PREPARE(twp) ? twp->start_prepare_ts : twp->start_ts;
+        version_cursor->upd_stop_prepare_ts = twp->start_prepare_ts;
+        version_cursor->upd_stop_prepared_id = twp->start_prepared_id;
 
         upd_found = true;
     }
@@ -621,6 +638,7 @@ __curversion_version_reset(WT_CURSOR_VERSION *version_cursor)
     version_cursor->upd_durable_stop_ts = WT_TS_NONE;
     version_cursor->upd_stop_ts = WT_TS_MAX;
     version_cursor->upd_stop_prepare_ts = WT_TS_MAX;
+    version_cursor->upd_stop_prepared_id = WT_PREPARED_ID_NONE;
     version_cursor->upd_stop_prepared = false;
 
     F_CLR(version_cursor,
@@ -692,6 +710,7 @@ __curversion_skip_starting_updates(WT_SESSION_IMPL *session, WT_CURSOR_VERSION *
     version_cursor->upd_durable_stop_ts = WT_TS_NONE;
     version_cursor->upd_stop_ts = WT_TS_MAX;
     version_cursor->upd_stop_prepare_ts = WT_TS_MAX;
+    version_cursor->upd_stop_prepared_id = WT_PREPARED_ID_NONE;
     version_cursor->upd_stop_prepared = false;
 
     if (version_cursor->next_upd == NULL)
@@ -961,6 +980,8 @@ __wt_curversion_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner
     version_cursor->upd_stop_txnid = WT_TXN_MAX;
     version_cursor->upd_durable_stop_ts = WT_TS_MAX;
     version_cursor->upd_stop_ts = WT_TS_MAX;
+    version_cursor->upd_stop_prepare_ts = WT_TS_MAX;
+    version_cursor->upd_stop_prepared_id = WT_PREPARED_ID_NONE;
 
     WT_ERR_NOTFOUND_OK(
       __wt_config_gets_def(session, cfg, "debug.dump_version.visible_only", 0, &cval), true);
@@ -1001,6 +1022,8 @@ __wt_curversion_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner
     version_cursor->upd_stop_txnid = WT_TXN_MAX;
     version_cursor->upd_durable_stop_ts = WT_TS_MAX;
     version_cursor->upd_stop_ts = WT_TS_MAX;
+    version_cursor->upd_stop_prepare_ts = WT_TS_MAX;
+    version_cursor->upd_stop_prepared_id = WT_PREPARED_ID_NONE;
 
     /* Mark the cursor as version cursor for python api. */
     F_SET(cursor, WT_CURSTD_VERSION_CURSOR);

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -262,7 +262,8 @@ __curversion_next_single_key(WT_CURSOR *cursor)
                   version_cursor->upd_stop_txnid,
                   version_cursor->upd_stop_prepared ? version_cursor->upd_stop_prepare_ts :
                                                       version_cursor->upd_stop_ts,
-                  version_cursor->upd_durable_stop_ts, (uint64_t)version_cursor->upd_stop_prepare_ts,
+                  version_cursor->upd_durable_stop_ts,
+                  (uint64_t)version_cursor->upd_stop_prepare_ts,
                   (uint64_t)version_cursor->upd_stop_prepared_id, upd->type, version_prepared,
                   upd->flags, WT_CURVERSION_UPDATE_CHAIN));
 

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -258,14 +258,13 @@ __curversion_next_single_key(WT_CURSOR *cursor)
                  */
                 WT_ERR(__curversion_set_value_with_format(cursor, WT_CURVERSION_METADATA_FORMAT,
                   upd->txnid, version_prepared ? upd->prepare_ts : upd->upd_start_ts,
-                  upd->upd_durable_ts, (uint64_t)upd->prepare_ts, (uint64_t)upd->prepared_id,
+                  upd->upd_durable_ts, upd->prepare_ts, upd->prepared_id,
                   version_cursor->upd_stop_txnid,
                   version_cursor->upd_stop_prepared ? version_cursor->upd_stop_prepare_ts :
                                                       version_cursor->upd_stop_ts,
-                  version_cursor->upd_durable_stop_ts,
-                  (uint64_t)version_cursor->upd_stop_prepare_ts,
-                  (uint64_t)version_cursor->upd_stop_prepared_id, upd->type, version_prepared,
-                  upd->flags, WT_CURVERSION_UPDATE_CHAIN));
+                  version_cursor->upd_durable_stop_ts, version_cursor->upd_stop_prepare_ts,
+                  version_cursor->upd_stop_prepared_id, upd->type, version_prepared, upd->flags,
+                  WT_CURVERSION_UPDATE_CHAIN));
 
                 version_cursor->upd_stop_txnid = upd->txnid;
                 version_cursor->upd_durable_stop_ts = upd->upd_durable_ts;
@@ -465,11 +464,9 @@ __curversion_next_single_key(WT_CURSOR *cursor)
               WT_TIME_WINDOW_HAS_START_PREPARE(&(cbt->upd_value->tw)) ?
                 cbt->upd_value->tw.start_prepare_ts :
                 cbt->upd_value->tw.durable_start_ts,
-              (uint64_t)cbt->upd_value->tw.start_prepare_ts,
-              (uint64_t)cbt->upd_value->tw.start_prepared_id, stop_txn,
-              stop_prepared ? stop_prepare_ts : stop_ts, durable_stop_ts, (uint64_t)stop_prepare_ts,
-              (uint64_t)stop_prepared_id, WT_UPDATE_STANDARD, version_prepared, 0,
-              WT_CURVERSION_DISK_IMAGE));
+              cbt->upd_value->tw.start_prepare_ts, cbt->upd_value->tw.start_prepared_id, stop_txn,
+              stop_prepared ? stop_prepare_ts : stop_ts, durable_stop_ts, stop_prepare_ts,
+              stop_prepared_id, WT_UPDATE_STANDARD, version_prepared, 0, WT_CURVERSION_DISK_IMAGE));
 
             version_cursor->upd_stop_txnid = cbt->upd_value->tw.start_txn;
             version_cursor->upd_durable_stop_ts =
@@ -586,10 +583,10 @@ skip_on_page:
           __curversion_set_value_with_format(cursor, WT_CURVERSION_METADATA_FORMAT, twp->start_txn,
             WT_TIME_WINDOW_HAS_START_PREPARE(twp) ? twp->start_prepare_ts : twp->start_ts,
             WT_TIME_WINDOW_HAS_START_PREPARE(twp) ? twp->start_prepare_ts : twp->durable_start_ts,
-            (uint64_t)twp->start_prepare_ts, (uint64_t)twp->start_prepared_id, twp->stop_txn,
+            twp->start_prepare_ts, twp->start_prepared_id, twp->stop_txn,
             WT_TIME_WINDOW_HAS_STOP_PREPARE(twp) ? twp->stop_prepare_ts : twp->stop_ts,
             WT_TIME_WINDOW_HAS_STOP_PREPARE(twp) ? twp->stop_prepare_ts : twp->durable_stop_ts,
-            (uint64_t)twp->stop_prepare_ts, (uint64_t)twp->stop_prepared_id, hs_upd_type, 0, 0,
+            twp->stop_prepare_ts, twp->stop_prepared_id, hs_upd_type, 0, 0,
             WT_CURVERSION_HISTORY_STORE));
 
         version_cursor->upd_stop_txnid = twp->start_txn;

--- a/src/include/cursor.h
+++ b/src/include/cursor.h
@@ -471,7 +471,9 @@ struct __wt_cursor_version {
     wt_timestamp_t upd_stop_ts;
     /* The previous traversed update's prepare_ts will become the stop_prepare_ts. */
     wt_timestamp_t upd_stop_prepare_ts;
-    /* Whether The previous traversed update is prepared. */
+    /* The previous traversed update's prepared_id will become the stop_prepared_id. */
+    uint64_t upd_stop_prepared_id;
+    /* Whether the previous traversed update is prepared. */
     uint8_t upd_stop_prepared;
 
     /* Don't show the user any keys from before this time. */

--- a/test/suite/test_cursor18.py
+++ b/test/suite/test_cursor18.py
@@ -55,16 +55,25 @@ class test_cursor18(wttest.WiredTigerTestCase):
 
     def verify_value(self, version_cursor, expected_start_ts, expected_start_durable_ts, expected_stop_ts, expected_stop_durable_ts, expected_type, expected_prepare_state, expected_flags, expected_location, expected_value):
         values = version_cursor.get_values()
-        # Ignore the transaction ids from the value in the verification
+        # Ignore the transaction ids from the value in the verification.
+        # Format: start_txn(0), start_ts(1), start_durable_ts(2), start_prepare_ts(3),
+        #   start_prepared_id(4), stop_txn(5), stop_ts(6), stop_durable_ts(7),
+        #   stop_prepare_ts(8), stop_prepared_id(9), type(10), prepare(11),
+        #   flags(12), location(13), value(14)
         self.assertEqual(values[1], expected_start_ts)
         self.assertEqual(values[2], expected_start_durable_ts)
-        self.assertEqual(values[4], expected_stop_ts)
-        self.assertEqual(values[5], expected_stop_durable_ts)
-        self.assertEqual(values[6], expected_type)
-        self.assertEqual(values[7], expected_prepare_state)
-        self.assertEqual(values[8], expected_flags)
-        self.assertEqual(values[9], expected_location)
-        self.assertEqual(values[10], expected_value)
+        self.assertEqual(values[6], expected_stop_ts)
+        self.assertEqual(values[7], expected_stop_durable_ts)
+        self.assertEqual(values[10], expected_type)
+        self.assertEqual(values[11], expected_prepare_state)
+        self.assertEqual(values[12], expected_flags)
+        self.assertEqual(values[13], expected_location)
+        self.assertEqual(values[14], expected_value)
+
+    def verify_prepare_fields(self, version_cursor, expected_start_prepare_ts, expected_stop_prepare_ts):
+        values = version_cursor.get_values()
+        self.assertEqual(values[3], expected_start_prepare_ts)
+        self.assertEqual(values[8], expected_stop_prepare_ts)
 
     def open_version_cursor(self, visible_only=False, start_ts=None):
         internal_config = ["enabled=true", self.cross_key_config]
@@ -98,9 +107,11 @@ class test_cursor18(wttest.WiredTigerTestCase):
         self.assertEqual(version_cursor.search(), 0)
         self.assertEqual(version_cursor.get_key(), 1)
         self.verify_value(version_cursor, 5, 5, WT_TS_MAX, 0, 3, 0, 0, 0, 1)
+        self.verify_prepare_fields(version_cursor, 0, WT_TS_MAX)
         self.assertEqual(version_cursor.next(), 0)
         self.assertEqual(version_cursor.get_key(), 1)
         self.verify_value(version_cursor, 1, 1, 5, 5, 3, 0, 0, 0, 0)
+        self.verify_prepare_fields(version_cursor, 0, 0)
         self.assertEqual(version_cursor.next(), wiredtiger.WT_NOTFOUND)
 
     def test_ondisk_only(self):
@@ -323,9 +334,11 @@ class test_cursor18(wttest.WiredTigerTestCase):
         self.assertEqual(version_cursor.get_key(), 1)
 
         self.verify_value(version_cursor, 1, 0, WT_TS_MAX, 0, 3, 1, 64, 0, 0)
+        self.verify_prepare_fields(version_cursor, 1, WT_TS_MAX)
         self.assertEqual(version_cursor.next(), 0)
         self.assertEqual(version_cursor.get_key(), 1)
         self.verify_value(version_cursor, 1, 1, 1, 0, 3, 1, 0, 1, 0)
+        self.verify_prepare_fields(version_cursor, 1, 1)
         self.assertEqual(version_cursor.next(), wiredtiger.WT_NOTFOUND)
 
     def test_reuse_version_cursor(self):
@@ -390,6 +403,7 @@ class test_cursor18(wttest.WiredTigerTestCase):
         self.assertEqual(version_cursor.search(), 0)
         self.assertEqual(version_cursor.get_key(), 1)
         self.verify_value(version_cursor, 1, 1, 2, 0, 3, 1, 0, 1, 0)
+        self.verify_prepare_fields(version_cursor, 0, 2)
         self.assertEqual(version_cursor.next(), wiredtiger.WT_NOTFOUND)
 
     def test_search_when_positioned(self):
@@ -570,8 +584,10 @@ class test_cursor18(wttest.WiredTigerTestCase):
         self.assertEqual(version_cursor.search(), 0)
         self.assertEqual(version_cursor.get_key(), 1)
         self.verify_value(version_cursor, 1, 1, WT_TS_MAX, 0, 3, 0, 0, 0, 0)
+        self.verify_prepare_fields(version_cursor, 0, WT_TS_MAX)
         self.assertEqual(version_cursor.next(), 0)
         self.verify_value(version_cursor, 1, 1, WT_TS_MAX, 0, 3, 0, 0, 1, 0)
+        self.verify_prepare_fields(version_cursor, 0, WT_TS_MAX)
         self.assertEqual(version_cursor.next(), wiredtiger.WT_NOTFOUND)
 
     def test_unpositioned_cursor(self):

--- a/test/suite/test_cursor19.py
+++ b/test/suite/test_cursor19.py
@@ -50,16 +50,20 @@ class test_cursor19(wttest.WiredTigerTestCase):
 
     def verify_value(self, version_cursor, expected_start_ts, expected_start_durable_ts, expected_stop_ts, expected_stop_durable_ts, expected_type, expected_prepare_state, expected_flags, expected_location, expected_value):
         values = version_cursor.get_values()
-        # Ignore the transaction ids from the value in the verification
+        # Ignore the transaction ids from the value in the verification.
+        # Format: start_txn(0), start_ts(1), start_durable_ts(2), start_prepare_ts(3),
+        #   start_prepared_id(4), stop_txn(5), stop_ts(6), stop_durable_ts(7),
+        #   stop_prepare_ts(8), stop_prepared_id(9), type(10), prepare(11),
+        #   flags(12), location(13), value(14)
         self.assertEqual(values[1], expected_start_ts)
         self.assertEqual(values[2], expected_start_durable_ts)
-        self.assertEqual(values[4], expected_stop_ts)
-        self.assertEqual(values[5], expected_stop_durable_ts)
-        self.assertEqual(values[6], expected_type)
-        self.assertEqual(values[7], expected_prepare_state)
-        self.assertEqual(values[8], expected_flags)
-        self.assertEqual(values[9], expected_location)
-        self.assertEqual(values[10], expected_value)
+        self.assertEqual(values[6], expected_stop_ts)
+        self.assertEqual(values[7], expected_stop_durable_ts)
+        self.assertEqual(values[10], expected_type)
+        self.assertEqual(values[11], expected_prepare_state)
+        self.assertEqual(values[12], expected_flags)
+        self.assertEqual(values[13], expected_location)
+        self.assertEqual(values[14], expected_value)
 
     def test_modify(self):
         self.create()

--- a/test/suite/test_cursor24.py
+++ b/test/suite/test_cursor24.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# test_cursor24.py
+#   Test version cursor prepare metadata fields and rollback visibility.
+#
+import wttest
+import wiredtiger
+from wtscenario import make_scenarios
+
+WT_TS_MAX = 2**64 - 1
+WT_UPDATE_PREPARE_ROLLBACK = 0x080
+
+class test_cursor24(wttest.WiredTigerTestCase):
+    uri = 'file:test_cursor24.wt'
+
+    types = [
+        ('row', dict(keyformat='i', valueformat='i')),
+        ('var', dict(keyformat='r', valueformat='i')),
+    ]
+
+    scenarios = make_scenarios(types)
+
+    def create(self):
+        self.session.create(self.uri,
+            'key_format={},value_format={}'.format(self.keyformat, self.valueformat))
+
+    # Format: start_txn(0), start_ts(1), start_durable_ts(2), start_prepare_ts(3),
+    #   start_prepared_id(4), stop_txn(5), stop_ts(6), stop_durable_ts(7),
+    #   stop_prepare_ts(8), stop_prepared_id(9), type(10), prepare(11),
+    #   flags(12), location(13), value(14)
+    def get_values(self, version_cursor):
+        return version_cursor.get_values()
+
+    def verify_value(self, version_cursor, expected_start_ts, expected_start_durable_ts,
+                     expected_stop_ts, expected_stop_durable_ts, expected_type,
+                     expected_prepare_state, expected_flags, expected_location, expected_value):
+        values = self.get_values(version_cursor)
+        self.assertEqual(values[1], expected_start_ts)
+        self.assertEqual(values[2], expected_start_durable_ts)
+        self.assertEqual(values[6], expected_stop_ts)
+        self.assertEqual(values[7], expected_stop_durable_ts)
+        self.assertEqual(values[10], expected_type)
+        self.assertEqual(values[11], expected_prepare_state)
+        self.assertEqual(values[12], expected_flags)
+        self.assertEqual(values[13], expected_location)
+        self.assertEqual(values[14], expected_value)
+
+    def verify_prepare_fields(self, version_cursor, expected_start_prepare_ts,
+                              expected_stop_prepare_ts):
+        values = self.get_values(version_cursor)
+        self.assertEqual(values[3], expected_start_prepare_ts)
+        self.assertEqual(values[8], expected_stop_prepare_ts)
+
+    def open_version_cursor(self, visible_only=False):
+        internal_config = ["enabled=true"]
+        if visible_only:
+            internal_config.append("visible_only=true")
+        config = "debug=(dump_version=(" + ",".join(internal_config) + "))"
+        return self.session.open_cursor(self.uri, None, config)
+
+    def test_prepare_commit_metadata(self):
+        """Verify start_prepare_ts and start_ts/start_durable_ts after prepare + commit."""
+        self.create()
+
+        session2 = self.conn.open_session()
+        cursor = session2.open_cursor(self.uri, None)
+
+        session2.begin_transaction()
+        cursor[1] = 0
+        session2.prepare_transaction("prepare_timestamp=" + self.timestamp_str(5))
+        session2.commit_transaction(
+            "commit_timestamp=" + self.timestamp_str(10) +
+            ",durable_timestamp=" + self.timestamp_str(15))
+
+        self.session.begin_transaction()
+        version_cursor = self.open_version_cursor()
+        version_cursor.set_key(1)
+        self.assertEqual(version_cursor.search(), 0)
+        self.assertEqual(version_cursor.get_key(), 1)
+
+        # start_ts=10 (commit), start_durable_ts=15 (durable), start_prepare_ts=5
+        self.verify_value(version_cursor, 10, 15, WT_TS_MAX, 0, 3, 0, 0, 0, 0)
+        self.verify_prepare_fields(version_cursor, 5, WT_TS_MAX)
+        self.assertEqual(version_cursor.next(), wiredtiger.WT_NOTFOUND)
+
+    def test_prepare_commit_tombstone_metadata(self):
+        """Verify stop_prepare_ts is set when a prepared tombstone stops a value."""
+        self.create()
+
+        cursor = self.session.open_cursor(self.uri, None)
+        self.session.begin_transaction()
+        cursor[1] = 0
+        self.session.commit_transaction("commit_timestamp=" + self.timestamp_str(1))
+
+        # Evict to disk so the value is on-disk.
+        evict_cursor = self.session.open_cursor(self.uri, None, "debug=(release_evict)")
+        self.session.begin_transaction()
+        self.assertEqual(evict_cursor[1], 0)
+        evict_cursor.reset()
+        self.session.rollback_transaction()
+
+        # Delete the value via a prepared transaction, then commit it.
+        session2 = self.conn.open_session()
+        cursor2 = session2.open_cursor(self.uri, None)
+        session2.begin_transaction()
+        cursor2.set_key(1)
+        self.assertEqual(cursor2.remove(), 0)
+        session2.prepare_transaction("prepare_timestamp=" + self.timestamp_str(5))
+        session2.commit_transaction(
+            "commit_timestamp=" + self.timestamp_str(10) +
+            ",durable_timestamp=" + self.timestamp_str(15))
+
+        self.session.begin_transaction()
+        version_cursor = self.open_version_cursor()
+        version_cursor.set_key(1)
+        self.assertEqual(version_cursor.search(), 0)
+        self.assertEqual(version_cursor.get_key(), 1)
+
+        # The ondisk value at ts=1 is stopped by the committed prepared tombstone.
+        # stop_ts=10 (commit), stop_durable_ts=15 (durable), stop_prepare_ts=5
+        self.verify_value(version_cursor, 1, 1, 10, 15, 3, 0, 0, 1, 0)
+        self.verify_prepare_fields(version_cursor, 0, 5)
+        self.assertEqual(version_cursor.next(), wiredtiger.WT_NOTFOUND)
+
+    def test_prepare_rollback_key_not_found(self):
+        """
+        When the only update on a key was via a prepare that got rolled back, the version
+        cursor should return NOTFOUND since the rollback tombstone is globally visible and
+        there is no committed value underneath.
+        """
+        self.create()
+
+        # Insert via prepare only (no prior committed value), then roll back.
+        session2 = self.conn.open_session()
+        cursor2 = session2.open_cursor(self.uri, None)
+        session2.begin_transaction()
+        cursor2[1] = 99
+        session2.prepare_transaction("prepare_timestamp=" + self.timestamp_str(5))
+        session2.rollback_transaction()
+
+        self.session.begin_transaction()
+        version_cursor = self.open_version_cursor()
+        version_cursor.set_key(1)
+        self.assertEqual(version_cursor.search(), wiredtiger.WT_NOTFOUND)
+
+    def test_prepare_rollback_then_update(self):
+        """
+        After prepare rollback on a key with no prior committed value, a subsequent committed
+        insert should be the only version visible via the version cursor since the rollback
+        tombstone (globally visible) acts as a terminal stop.
+        """
+        self.create()
+
+        # Insert via prepare only (no prior committed value), then roll back.
+        session2 = self.conn.open_session()
+        cursor2 = session2.open_cursor(self.uri, None)
+        session2.begin_transaction()
+        cursor2[1] = 99
+        session2.prepare_transaction("prepare_timestamp=" + self.timestamp_str(5))
+        session2.rollback_transaction()
+
+        # Write a new committed value on the same key.
+        cursor = self.session.open_cursor(self.uri, None)
+        self.session.begin_transaction()
+        cursor[1] = 2
+        self.session.commit_transaction("commit_timestamp=" + self.timestamp_str(10))
+
+        self.session.begin_transaction()
+        version_cursor = self.open_version_cursor()
+        version_cursor.set_key(1)
+        self.assertEqual(version_cursor.search(), 0)
+
+        # Only the committed value at ts=10 should be visible.
+        self.assertEqual(version_cursor.get_key(), 1)
+        self.verify_value(version_cursor, 10, 10, WT_TS_MAX, 0, 3, 0, 0, 0, 2)
+        self.verify_prepare_fields(version_cursor, 0, WT_TS_MAX)
+
+        # The rollback tombstone terminates the chain; no more versions.
+        self.assertEqual(version_cursor.next(), wiredtiger.WT_NOTFOUND)
+
+    def test_non_prepared_zero_fields(self):
+        """Non-prepared updates should have start_prepare_ts=0 and appropriate stop_prepare_ts."""
+        self.create()
+
+        cursor = self.session.open_cursor(self.uri, None)
+        self.session.begin_transaction()
+        cursor[1] = 0
+        self.session.commit_transaction("commit_timestamp=" + self.timestamp_str(1))
+
+        self.session.begin_transaction()
+        cursor[1] = 1
+        self.session.commit_transaction("commit_timestamp=" + self.timestamp_str(5))
+
+        self.session.begin_transaction()
+        version_cursor = self.open_version_cursor()
+        version_cursor.set_key(1)
+        self.assertEqual(version_cursor.search(), 0)
+
+        # Newest value: start_prepare_ts=0, stop_prepare_ts=WT_TS_MAX (no stop)
+        self.verify_value(version_cursor, 5, 5, WT_TS_MAX, 0, 3, 0, 0, 0, 1)
+        self.verify_prepare_fields(version_cursor, 0, WT_TS_MAX)
+
+        # Older value: start_prepare_ts=0, stop_prepare_ts=0 (stopped by non-prepared update)
+        self.assertEqual(version_cursor.next(), 0)
+        self.verify_value(version_cursor, 1, 1, 5, 5, 3, 0, 0, 0, 0)
+        self.verify_prepare_fields(version_cursor, 0, 0)
+
+        self.assertEqual(version_cursor.next(), wiredtiger.WT_NOTFOUND)


### PR DESCRIPTION
Add start_prepare_ts, start_prepared_id, stop_prepare_ts, and stop_prepared_id to the version cursor metadata format.

This is a pure API format change with no behavioral modifications. However, this might cause the version cursor in MongoDB to parse garbage value at runtime until the server change (SERVER-121371) is merged. We only use version cursor to dump the data when there's invalidation errors so this should not affect normal behaviour.

This is pre-requisite change for WT-16742 ([PR](https://github.com/wiredtiger/wiredtiger/pull/13319/changes#diff-b1b2a401e7b5cbc33ed3bdd20b6f76dc7520974918a680acb4de1627f4209acb))