### PR TITLE
WT-16587 Fix the checkpoint clean-up and background compact not using WT_ISO_READ_UNCOMMITTED issue

### DIFF
--- a/src/btree/bt_sync_obsolete.c
+++ b/src/btree/bt_sync_obsolete.c
@@ -680,6 +680,9 @@ __checkpoint_cleanup_get_uri(WT_SESSION_IMPL *session, WT_ITEM *uri)
     /* Position the cursor on the given URI. */
     cursor->set_key(cursor, (const char *)uri->data);
 
+    /*
+     * FIXME-WT-15259: here should be adjusted when this ticket is done.
+     */
     WT_WITH_TXN_ISOLATION(
       session, WT_ISO_READ_UNCOMMITTED, ret = cursor->search_near(cursor, &exact));
     WT_ERR(ret);

--- a/src/btree/bt_sync_obsolete.c
+++ b/src/btree/bt_sync_obsolete.c
@@ -679,14 +679,19 @@ __checkpoint_cleanup_get_uri(WT_SESSION_IMPL *session, WT_ITEM *uri)
 
     /* Position the cursor on the given URI. */
     cursor->set_key(cursor, (const char *)uri->data);
-    WT_ERR(cursor->search_near(cursor, &exact));
+
+    WT_WITH_TXN_ISOLATION(
+      session, WT_ISO_READ_UNCOMMITTED, ret = cursor->search_near(cursor, &exact));
+    WT_ERR(ret);
 
     /*
      * The given URI may not exist in the metadata file. Since we always want to return a URI that
      * is lexicographically larger the given one, make sure not to go backwards.
      */
-    if (exact <= 0)
-        WT_ERR(cursor->next(cursor));
+    if (exact <= 0) {
+        WT_WITH_TXN_ISOLATION(session, WT_ISO_READ_UNCOMMITTED, ret = cursor->next(cursor));
+        WT_ERR(ret);
+    }
 
     /* Loop through the eligible candidates. */
     do {
@@ -702,7 +707,8 @@ __checkpoint_cleanup_get_uri(WT_SESSION_IMPL *session, WT_ITEM *uri)
         /* Check the given uri needs checkpoint cleanup. */
         if (__checkpoint_cleanup_eligibility(session, key, value))
             break;
-    } while ((ret = cursor->next(cursor)) == 0);
+        WT_WITH_TXN_ISOLATION(session, WT_ISO_READ_UNCOMMITTED, ret = cursor->next(cursor));
+    } while (ret == 0);
     WT_ERR(ret);
 
     /* Save the selected uri. */

--- a/src/btree/bt_sync_obsolete.c
+++ b/src/btree/bt_sync_obsolete.c
@@ -680,9 +680,7 @@ __checkpoint_cleanup_get_uri(WT_SESSION_IMPL *session, WT_ITEM *uri)
     /* Position the cursor on the given URI. */
     cursor->set_key(cursor, (const char *)uri->data);
 
-    /*
-     * FIXME-WT-15259: here should be adjusted when this ticket is done.
-     */
+    /* FIXME-WT-15259: here should be adjusted when this ticket is done. */
     WT_WITH_TXN_ISOLATION(
       session, WT_ISO_READ_UNCOMMITTED, ret = cursor->search_near(cursor, &exact));
     WT_ERR(ret);
@@ -692,6 +690,7 @@ __checkpoint_cleanup_get_uri(WT_SESSION_IMPL *session, WT_ITEM *uri)
      * is lexicographically larger the given one, make sure not to go backwards.
      */
     if (exact <= 0) {
+        /* FIXME-WT-15259: here should be adjusted when this ticket is done. */
         WT_WITH_TXN_ISOLATION(session, WT_ISO_READ_UNCOMMITTED, ret = cursor->next(cursor));
         WT_ERR(ret);
     }
@@ -710,6 +709,8 @@ __checkpoint_cleanup_get_uri(WT_SESSION_IMPL *session, WT_ITEM *uri)
         /* Check the given uri needs checkpoint cleanup. */
         if (__checkpoint_cleanup_eligibility(session, key, value))
             break;
+
+        /* FIXME-WT-15259: here should be adjusted when this ticket is done. */
         WT_WITH_TXN_ISOLATION(session, WT_ISO_READ_UNCOMMITTED, ret = cursor->next(cursor));
     } while (ret == 0);
     WT_ERR(ret);

--- a/src/conn/conn_compact.c
+++ b/src/conn/conn_compact.c
@@ -475,6 +475,9 @@ __background_compact_find_next_uri(WT_SESSION_IMPL *session, WT_ITEM *uri, WT_IT
     /* Position the cursor on the given URI. */
     cursor->set_key(cursor, (const char *)uri->data);
 
+    /*
+     * FIXME-WT-15259: here should be adjusted when this ticket is done.
+     */
     WT_WITH_TXN_ISOLATION(
       session, WT_ISO_READ_UNCOMMITTED, ret = cursor->search_near(cursor, &exact));
     WT_ERR(ret);

--- a/src/conn/conn_compact.c
+++ b/src/conn/conn_compact.c
@@ -474,14 +474,19 @@ __background_compact_find_next_uri(WT_SESSION_IMPL *session, WT_ITEM *uri, WT_IT
 
     /* Position the cursor on the given URI. */
     cursor->set_key(cursor, (const char *)uri->data);
-    WT_ERR(cursor->search_near(cursor, &exact));
+
+    WT_WITH_TXN_ISOLATION(
+      session, WT_ISO_READ_UNCOMMITTED, ret = cursor->search_near(cursor, &exact));
+    WT_ERR(ret);
 
     /*
      * The given URI may not exist in the metadata file. Since we always want to return a URI that
      * is lexicographically larger the given one, make sure not to go backwards.
      */
-    if (exact <= 0)
-        WT_ERR(cursor->next(cursor));
+    if (exact <= 0) {
+        WT_WITH_TXN_ISOLATION(session, WT_ISO_READ_UNCOMMITTED, ret = cursor->next(cursor));
+        WT_ERR(ret);
+    }
 
     /* Loop through the eligible candidates. */
     do {
@@ -506,7 +511,8 @@ __background_compact_find_next_uri(WT_SESSION_IMPL *session, WT_ITEM *uri, WT_IT
                 break;
             WT_STAT_CONN_INCR(session, background_compact_skipped);
         }
-    } while ((ret = cursor->next(cursor)) == 0);
+        WT_WITH_TXN_ISOLATION(session, WT_ISO_READ_UNCOMMITTED, ret = cursor->next(cursor));
+    } while (ret == 0);
     WT_ERR(ret);
 
     /* Save the selected uri. */

--- a/src/conn/conn_compact.c
+++ b/src/conn/conn_compact.c
@@ -475,9 +475,7 @@ __background_compact_find_next_uri(WT_SESSION_IMPL *session, WT_ITEM *uri, WT_IT
     /* Position the cursor on the given URI. */
     cursor->set_key(cursor, (const char *)uri->data);
 
-    /*
-     * FIXME-WT-15259: here should be adjusted when this ticket is done.
-     */
+    /* FIXME-WT-15259: here should be adjusted when this ticket is done. */
     WT_WITH_TXN_ISOLATION(
       session, WT_ISO_READ_UNCOMMITTED, ret = cursor->search_near(cursor, &exact));
     WT_ERR(ret);
@@ -487,6 +485,7 @@ __background_compact_find_next_uri(WT_SESSION_IMPL *session, WT_ITEM *uri, WT_IT
      * is lexicographically larger the given one, make sure not to go backwards.
      */
     if (exact <= 0) {
+        /* FIXME-WT-15259: here should be adjusted when this ticket is done. */
         WT_WITH_TXN_ISOLATION(session, WT_ISO_READ_UNCOMMITTED, ret = cursor->next(cursor));
         WT_ERR(ret);
     }
@@ -514,6 +513,8 @@ __background_compact_find_next_uri(WT_SESSION_IMPL *session, WT_ITEM *uri, WT_IT
                 break;
             WT_STAT_CONN_INCR(session, background_compact_skipped);
         }
+
+        /* FIXME-WT-15259: here should be adjusted when this ticket is done. */
         WT_WITH_TXN_ISOLATION(session, WT_ISO_READ_UNCOMMITTED, ret = cursor->next(cursor));
     } while (ret == 0);
     WT_ERR(ret);

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1717,7 +1717,7 @@ retry:
     /* If there's no visible update in the update chain or ondisk, check the history store file. */
     if (!F_ISSET(S2BT(session), WT_BTREE_IN_MEMORY) &&
       F_ISSET_ATOMIC_32(S2C(session), WT_CONN_HS_OPEN) &&
-      !F_ISSET(session->dhandle, WT_DHANDLE_HS)) {
+      !F_ISSET(session->dhandle, WT_DHANDLE_HS) && !WT_IS_METADATA(session->dhandle)) {
         /*
          * Stressing this code path may slow down the system too much. To minimize the impact, sleep
          * on every random 100th iteration when this is enabled.


### PR DESCRIPTION
__checkpoint_cleanup_get_uri and __background_compact_find_next_uri iterate the metadata file (WiredTiger.wt) under snapshot isolation, violating the metadata access contract. 

Two fixes: 
(1) wrap all metadata cursor reads in both callers with WT_ISO_READ_UNCOMMITTED, aligning them with the documented metadata access contract and preventing the HS lookup path from ever being reached; 
(2) add !WT_IS_METADATA(session->dhandle) to the HS lookup guard in __wt_txn_read as a defensive layer, consistent with existing metadata exclusions throughout txn_inline.h.