### PR TITLE
WT-16888 Add per-btree stats for time spent in checkpoint

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -1011,6 +1011,7 @@ dsrc_stats = [
     ##########################################
     BlockStat('allocation_size', 'file allocation unit size', 'max_aggregate,no_scale,size'),
     BlockStat('block_alloc', 'blocks allocated'),
+    BlockStat('block_checkpoint_reconcile_duration', 'checkpoint reconciliation block manager duration (usecs)', 'no_clear,no_scale'),
     BlockStat('block_checkpoint_size', 'checkpoint size', 'no_scale,size'),
     BlockStat('block_extension', 'allocations requiring file extension'),
     BlockStat('block_free', 'blocks freed'),

--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -1012,7 +1012,6 @@ dsrc_stats = [
     ##########################################
     BlockStat('allocation_size', 'file allocation unit size', 'max_aggregate,no_scale,size'),
     BlockStat('block_alloc', 'blocks allocated'),
-    BlockStat('block_checkpoint_reconcile_duration', 'checkpoint reconciliation block manager duration (usecs)', 'no_clear,no_scale'),
     BlockStat('block_checkpoint_size', 'checkpoint size', 'no_scale,size'),
     BlockStat('block_extension', 'allocations requiring file extension'),
     BlockStat('block_free', 'blocks freed'),

--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -524,6 +524,7 @@ conn_stats = [
     CheckpointStat('checkpoint_prep_running', 'prepare currently running', 'no_clear,no_scale'),
     CheckpointStat('checkpoint_prep_total', 'prepare total time (msecs)', 'no_clear,no_scale'),
     CheckpointStat('checkpoint_presync', 'number of handles visited after writes complete'),
+    CheckpointStat('checkpoint_rec_blkcache_write', 'total time (msecs) writing pages to stable storage during checkpoint reconciliation'),
     CheckpointStat('checkpoint_scrub_max', 'scrub max time (msecs)', 'no_clear,no_scale'),
     CheckpointStat('checkpoint_scrub_min', 'scrub min time (msecs)', 'no_clear,no_scale'),
     CheckpointStat('checkpoint_scrub_recent', 'scrub most recent time (msecs)', 'no_clear,no_scale'),

--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -1025,7 +1025,7 @@ dsrc_stats = [
     ##########################################
     BtreeStat('btree_checkpoint_generation', 'btree checkpoint generation', 'no_clear,no_scale'),
     BtreeStat('btree_checkpoint_pages_reconciled', 'btree number of pages reconciled during checkpoint', 'no_clear,no_scale'),
-    BtreeStat('btree_checkpoint_reconcile_duration', 'checkpoint B-tree walk, construct and write duration (usecs)', 'no_clear,no_scale'),
+    BtreeStat('btree_checkpoint_reconcile_duration', 'checkpoint btree walk, construct and write duration (usecs)', 'no_clear,no_scale'),
     BtreeStat('btree_clean_checkpoint_timer', 'btree clean tree checkpoint expiration time', 'no_clear,no_scale'),
     BtreeStat('btree_column_deleted', 'column-store variable-size deleted values', 'no_scale,tree_walk'),
     BtreeStat('btree_column_internal', 'column-store internal pages', 'no_scale,tree_walk'),

--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -524,7 +524,7 @@ conn_stats = [
     CheckpointStat('checkpoint_prep_running', 'prepare currently running', 'no_clear,no_scale'),
     CheckpointStat('checkpoint_prep_total', 'prepare total time (msecs)', 'no_clear,no_scale'),
     CheckpointStat('checkpoint_presync', 'number of handles visited after writes complete'),
-    CheckpointStat('checkpoint_rec_blkcache_write', 'total time (usecs) writing pages to stable storage during checkpoint reconciliation'),
+    CheckpointStat('checkpoint_rec_blkcache_write', 'total time (msecs) writing pages to stable storage during checkpoint reconciliation'),
     CheckpointStat('checkpoint_scrub_max', 'scrub max time (msecs)', 'no_clear,no_scale'),
     CheckpointStat('checkpoint_scrub_min', 'scrub min time (msecs)', 'no_clear,no_scale'),
     CheckpointStat('checkpoint_scrub_recent', 'scrub most recent time (msecs)', 'no_clear,no_scale'),

--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -524,7 +524,7 @@ conn_stats = [
     CheckpointStat('checkpoint_prep_running', 'prepare currently running', 'no_clear,no_scale'),
     CheckpointStat('checkpoint_prep_total', 'prepare total time (msecs)', 'no_clear,no_scale'),
     CheckpointStat('checkpoint_presync', 'number of handles visited after writes complete'),
-    CheckpointStat('checkpoint_rec_blkcache_write', 'total time (msecs) writing pages to stable storage during checkpoint reconciliation'),
+    CheckpointStat('checkpoint_rec_blkcache_write', 'total time (usecs) writing pages to stable storage during checkpoint reconciliation'),
     CheckpointStat('checkpoint_scrub_max', 'scrub max time (msecs)', 'no_clear,no_scale'),
     CheckpointStat('checkpoint_scrub_min', 'scrub min time (msecs)', 'no_clear,no_scale'),
     CheckpointStat('checkpoint_scrub_recent', 'scrub most recent time (msecs)', 'no_clear,no_scale'),

--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -1025,6 +1025,7 @@ dsrc_stats = [
     ##########################################
     BtreeStat('btree_checkpoint_generation', 'btree checkpoint generation', 'no_clear,no_scale'),
     BtreeStat('btree_checkpoint_pages_reconciled', 'btree number of pages reconciled during checkpoint', 'no_clear,no_scale'),
+    BtreeStat('btree_checkpoint_reconcile_duration', 'checkpoint B-tree walk, construct and write duration (usecs)', 'no_clear,no_scale'),
     BtreeStat('btree_clean_checkpoint_timer', 'btree clean tree checkpoint expiration time', 'no_clear,no_scale'),
     BtreeStat('btree_column_deleted', 'column-store variable-size deleted values', 'no_scale,tree_walk'),
     BtreeStat('btree_column_internal', 'column-store internal pages', 'no_scale,tree_walk'),

--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -1026,7 +1026,7 @@ dsrc_stats = [
     ##########################################
     BtreeStat('btree_checkpoint_generation', 'btree checkpoint generation', 'no_clear,no_scale'),
     BtreeStat('btree_checkpoint_pages_reconciled', 'btree number of pages reconciled during checkpoint', 'no_clear,no_scale'),
-    BtreeStat('btree_checkpoint_reconcile_duration', 'checkpoint btree walk, construct and write duration (usecs)', 'no_clear,no_scale'),
+    BtreeStat('btree_checkpoint_reconcile_duration', 'time spent walking the tree for checkpoint including dirty page reconciliation time (usecs)', 'no_clear,no_scale'),
     BtreeStat('btree_clean_checkpoint_timer', 'btree clean tree checkpoint expiration time', 'no_clear,no_scale'),
     BtreeStat('btree_column_deleted', 'column-store variable-size deleted values', 'no_scale,tree_walk'),
     BtreeStat('btree_column_internal', 'column-store internal pages', 'no_scale,tree_walk'),

--- a/src/block_cache/block_io.c
+++ b/src/block_cache/block_io.c
@@ -839,8 +839,6 @@ __wt_blkcache_write(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *
         WT_STAT_CONN_INCR(session, cache_write_app_count);
         WT_STAT_CONN_INCRV(session, cache_write_app_time, time_diff);
         WT_STAT_SESSION_INCRV(session, write_time, time_diff);
-        if (checkpoint)
-            WT_STAT_DSRC_INCRV(session, block_checkpoint_reconcile_duration, time_diff);
     }
 
     /*

--- a/src/block_cache/block_io.c
+++ b/src/block_cache/block_io.c
@@ -839,6 +839,8 @@ __wt_blkcache_write(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *
         WT_STAT_CONN_INCR(session, cache_write_app_count);
         WT_STAT_CONN_INCRV(session, cache_write_app_time, time_diff);
         WT_STAT_SESSION_INCRV(session, write_time, time_diff);
+        if (checkpoint)
+            WT_STAT_DSRC_INCRV(session, block_checkpoint_reconcile_duration, time_diff);
     }
 
     /*

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -2850,7 +2850,7 @@ fake:
         stop_us = __wt_clock(session);
         diff_us = WT_CLOCKDIFF_US(stop_us, start_us);
 
-        WT_STAT_CONN_DSRC_INCRV(session, btree_checkpoint_reconcile_duration, diff_us);
+        WT_STAT_DSRC_INCRV(session, btree_checkpoint_reconcile_duration, diff_us);
     }
 
     /* Tell logging that the checkpoint is complete. */

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -2850,7 +2850,6 @@ fake:
         stop_us = __wt_clock(session);
         diff_us = WT_CLOCKDIFF_US(stop_us, start_us);
 
-        /* Perdhandle: btree stat */
         WT_STAT_CONN_DSRC_INCRV(session, btree_checkpoint_reconcile_duration, diff_us);
     }
 

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -2719,6 +2719,7 @@ __checkpoint_tree(WT_SESSION_IMPL *session, bool is_checkpoint, const char *cfg[
     WT_TIME_AGGREGATE ta;
     char ckptlsn_str[WT_MAX_LSN_STRING];
     bool fake_ckpt, resolve_bm;
+    uint64_t start_us = 0, stop_us, diff_us;
 
     WT_UNUSED(cfg);
 
@@ -2754,6 +2755,9 @@ __checkpoint_tree(WT_SESSION_IMPL *session, bool is_checkpoint, const char *cfg[
         __wt_checkpoint_update_generation(session, btree);
         goto fake;
     }
+
+    if (is_checkpoint)
+        start_us = __wt_clock(session);
 
     /*
      * Mark the root page dirty to ensure something gets written. (If the tree is modified, we must
@@ -2840,6 +2844,14 @@ fake:
             WT_ERR(__wt_meta_track_checkpoint(session));
         else
             WT_ERR(bm->checkpoint_resolve(bm, session, false));
+    }
+
+    if (is_checkpoint && start_us != 0) {
+        stop_us = __wt_clock(session);
+        diff_us = WT_CLOCKDIFF_US(stop_us, start_us);
+
+        /* Perdhandle: btree stat */
+        WT_STAT_CONN_DSRC_INCRV(session, btree_checkpoint_reconcile_duration, diff_us);
     }
 
     /* Tell logging that the checkpoint is complete. */

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -2719,7 +2719,7 @@ __checkpoint_tree(WT_SESSION_IMPL *session, bool is_checkpoint, const char *cfg[
     WT_TIME_AGGREGATE ta;
     char ckptlsn_str[WT_MAX_LSN_STRING];
     bool fake_ckpt, resolve_bm;
-    uint64_t start_us = 0, stop_us, diff_us;
+    uint64_t start_us = 0, diff_us;
 
     WT_UNUSED(cfg);
 
@@ -2756,9 +2756,6 @@ __checkpoint_tree(WT_SESSION_IMPL *session, bool is_checkpoint, const char *cfg[
         goto fake;
     }
 
-    if (is_checkpoint)
-        start_us = __wt_clock(session);
-
     /*
      * Mark the root page dirty to ensure something gets written. (If the tree is modified, we must
      * write the root page anyway, this doesn't add additional writes to the process. If the tree is
@@ -2793,9 +2790,14 @@ __checkpoint_tree(WT_SESSION_IMPL *session, bool is_checkpoint, const char *cfg[
 
     /* Flush the file from the cache, creating the checkpoint. */
     if (is_checkpoint) {
+        start_us = __wt_clock(session);
+
         if (WT_SESSION_IS_CHECKPOINT(session))
             WT_STAT_CONN_SET(session, checkpoint_state, WTI_CHECKPOINT_STATE_SYNC_FILE);
         WT_ERR(__wt_sync_file(session, WT_SYNC_CHECKPOINT));
+
+        diff_us = WT_CLOCKDIFF_US(__wt_clock(session), start_us);
+        WT_STAT_DSRC_INCRV(session, btree_checkpoint_reconcile_duration, diff_us);
     } else {
         if (WT_SESSION_IS_CHECKPOINT(session))
             WT_STAT_CONN_SET(session, checkpoint_state, WTI_CHECKPOINT_STATE_EVICT_FILE);
@@ -2844,13 +2846,6 @@ fake:
             WT_ERR(__wt_meta_track_checkpoint(session));
         else
             WT_ERR(bm->checkpoint_resolve(bm, session, false));
-    }
-
-    if (is_checkpoint && start_us != 0) {
-        stop_us = __wt_clock(session);
-        diff_us = WT_CLOCKDIFF_US(stop_us, start_us);
-
-        WT_STAT_DSRC_INCRV(session, btree_checkpoint_reconcile_duration, diff_us);
     }
 
     /* Tell logging that the checkpoint is complete. */

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -1465,7 +1465,6 @@ struct __wt_dsrc_stats {
     int64_t btree_compact_pages_rewritten_expected;
     int64_t btree_checkpoint_pages_reconciled;
     int64_t btree_compact_skipped;
-    int64_t btree_checkpoint_reconcile_duration;
     int64_t btree_column_internal;
     int64_t btree_column_rle;
     int64_t btree_column_deleted;
@@ -1481,6 +1480,7 @@ struct __wt_dsrc_stats {
     int64_t btree_row_empty_values;
     int64_t btree_row_internal;
     int64_t btree_row_leaf;
+    int64_t btree_checkpoint_reconcile_duration;
     int64_t cache_eviction_app_threads_fill_ratio_lt_25;
     int64_t cache_eviction_app_threads_fill_ratio_25_50;
     int64_t cache_eviction_app_threads_fill_ratio_50_75;

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -1448,6 +1448,7 @@ struct __wt_dsrc_stats {
     int64_t block_extension;
     int64_t block_alloc;
     int64_t block_free;
+    int64_t block_checkpoint_reconcile_duration;
     int64_t block_checkpoint_size;
     int64_t allocation_size;
     int64_t block_reuse_bytes;

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -1464,6 +1464,7 @@ struct __wt_dsrc_stats {
     int64_t btree_compact_pages_rewritten_expected;
     int64_t btree_checkpoint_pages_reconciled;
     int64_t btree_compact_skipped;
+    int64_t btree_checkpoint_reconcile_duration;
     int64_t btree_column_internal;
     int64_t btree_column_rle;
     int64_t btree_column_deleted;

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -854,6 +854,7 @@ struct __wt_connection_stats {
     int64_t checkpoints_total_failed;
     int64_t checkpoints_total_succeed;
     int64_t checkpoint_time_total;
+    int64_t checkpoint_rec_blkcache_write;
     int64_t checkpoint_wait_reduce_dirty;
     int64_t chunkcache_spans_chunks_read;
     int64_t chunkcache_chunks_evicted;

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -1449,7 +1449,6 @@ struct __wt_dsrc_stats {
     int64_t block_extension;
     int64_t block_alloc;
     int64_t block_free;
-    int64_t block_checkpoint_reconcile_duration;
     int64_t block_checkpoint_size;
     int64_t allocation_size;
     int64_t block_reuse_bytes;

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -8954,1176 +8954,1171 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_DSRC_BLOCK_ALLOC			2015
 /*! block-manager: blocks freed */
 #define	WT_STAT_DSRC_BLOCK_FREE				2016
-/*!
- * block-manager: checkpoint reconciliation block manager duration
- * (usecs)
- */
-#define	WT_STAT_DSRC_BLOCK_CHECKPOINT_RECONCILE_DURATION	2017
 /*! block-manager: checkpoint size */
-#define	WT_STAT_DSRC_BLOCK_CHECKPOINT_SIZE		2018
+#define	WT_STAT_DSRC_BLOCK_CHECKPOINT_SIZE		2017
 /*! block-manager: file allocation unit size */
-#define	WT_STAT_DSRC_ALLOCATION_SIZE			2019
+#define	WT_STAT_DSRC_ALLOCATION_SIZE			2018
 /*! block-manager: file bytes available for reuse */
-#define	WT_STAT_DSRC_BLOCK_REUSE_BYTES			2020
+#define	WT_STAT_DSRC_BLOCK_REUSE_BYTES			2019
 /*! block-manager: file magic number */
-#define	WT_STAT_DSRC_BLOCK_MAGIC			2021
+#define	WT_STAT_DSRC_BLOCK_MAGIC			2020
 /*! block-manager: file major version number */
-#define	WT_STAT_DSRC_BLOCK_MAJOR			2022
+#define	WT_STAT_DSRC_BLOCK_MAJOR			2021
 /*! block-manager: file size in bytes */
-#define	WT_STAT_DSRC_BLOCK_SIZE				2023
+#define	WT_STAT_DSRC_BLOCK_SIZE				2022
 /*! block-manager: minor version number */
-#define	WT_STAT_DSRC_BLOCK_MINOR			2024
+#define	WT_STAT_DSRC_BLOCK_MINOR			2023
 /*! btree: btree checkpoint generation */
-#define	WT_STAT_DSRC_BTREE_CHECKPOINT_GENERATION	2025
+#define	WT_STAT_DSRC_BTREE_CHECKPOINT_GENERATION	2024
 /*! btree: btree clean tree checkpoint expiration time */
-#define	WT_STAT_DSRC_BTREE_CLEAN_CHECKPOINT_TIMER	2026
+#define	WT_STAT_DSRC_BTREE_CLEAN_CHECKPOINT_TIMER	2025
 /*! btree: btree compact pages reviewed */
-#define	WT_STAT_DSRC_BTREE_COMPACT_PAGES_REVIEWED	2027
+#define	WT_STAT_DSRC_BTREE_COMPACT_PAGES_REVIEWED	2026
 /*! btree: btree compact pages rewritten */
-#define	WT_STAT_DSRC_BTREE_COMPACT_PAGES_REWRITTEN	2028
+#define	WT_STAT_DSRC_BTREE_COMPACT_PAGES_REWRITTEN	2027
 /*! btree: btree compact pages skipped */
-#define	WT_STAT_DSRC_BTREE_COMPACT_PAGES_SKIPPED	2029
+#define	WT_STAT_DSRC_BTREE_COMPACT_PAGES_SKIPPED	2028
 /*! btree: btree expected number of compact bytes rewritten */
-#define	WT_STAT_DSRC_BTREE_COMPACT_BYTES_REWRITTEN_EXPECTED	2030
+#define	WT_STAT_DSRC_BTREE_COMPACT_BYTES_REWRITTEN_EXPECTED	2029
 /*! btree: btree expected number of compact pages rewritten */
-#define	WT_STAT_DSRC_BTREE_COMPACT_PAGES_REWRITTEN_EXPECTED	2031
+#define	WT_STAT_DSRC_BTREE_COMPACT_PAGES_REWRITTEN_EXPECTED	2030
 /*! btree: btree number of pages reconciled during checkpoint */
-#define	WT_STAT_DSRC_BTREE_CHECKPOINT_PAGES_RECONCILED	2032
+#define	WT_STAT_DSRC_BTREE_CHECKPOINT_PAGES_RECONCILED	2031
 /*! btree: btree skipped by compaction as process would not reduce size */
-#define	WT_STAT_DSRC_BTREE_COMPACT_SKIPPED		2033
+#define	WT_STAT_DSRC_BTREE_COMPACT_SKIPPED		2032
 /*! btree: checkpoint btree walk, construct and write duration (usecs) */
-#define	WT_STAT_DSRC_BTREE_CHECKPOINT_RECONCILE_DURATION	2034
+#define	WT_STAT_DSRC_BTREE_CHECKPOINT_RECONCILE_DURATION	2033
 /*!
  * btree: column-store internal pages, only reported if tree_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_COLUMN_INTERNAL		2035
+#define	WT_STAT_DSRC_BTREE_COLUMN_INTERNAL		2034
 /*!
  * btree: column-store variable-size RLE encoded values, only reported if
  * tree_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_COLUMN_RLE			2036
+#define	WT_STAT_DSRC_BTREE_COLUMN_RLE			2035
 /*!
  * btree: column-store variable-size deleted values, only reported if
  * tree_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_COLUMN_DELETED		2037
+#define	WT_STAT_DSRC_BTREE_COLUMN_DELETED		2036
 /*!
  * btree: column-store variable-size leaf pages, only reported if
  * tree_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_COLUMN_VARIABLE		2038
+#define	WT_STAT_DSRC_BTREE_COLUMN_VARIABLE		2037
 /*! btree: fixed-record size */
-#define	WT_STAT_DSRC_BTREE_FIXED_LEN			2039
+#define	WT_STAT_DSRC_BTREE_FIXED_LEN			2038
 /*! btree: maximum internal page size */
-#define	WT_STAT_DSRC_BTREE_MAXINTLPAGE			2040
+#define	WT_STAT_DSRC_BTREE_MAXINTLPAGE			2039
 /*! btree: maximum leaf page key size */
-#define	WT_STAT_DSRC_BTREE_MAXLEAFKEY			2041
+#define	WT_STAT_DSRC_BTREE_MAXLEAFKEY			2040
 /*! btree: maximum leaf page size */
-#define	WT_STAT_DSRC_BTREE_MAXLEAFPAGE			2042
+#define	WT_STAT_DSRC_BTREE_MAXLEAFPAGE			2041
 /*! btree: maximum leaf page value size */
-#define	WT_STAT_DSRC_BTREE_MAXLEAFVALUE			2043
+#define	WT_STAT_DSRC_BTREE_MAXLEAFVALUE			2042
 /*! btree: maximum tree depth */
-#define	WT_STAT_DSRC_BTREE_MAXIMUM_DEPTH		2044
+#define	WT_STAT_DSRC_BTREE_MAXIMUM_DEPTH		2043
 /*!
  * btree: number of key/value pairs, only reported if tree_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_ENTRIES			2045
+#define	WT_STAT_DSRC_BTREE_ENTRIES			2044
 /*!
  * btree: overflow pages, only reported if tree_walk or all statistics
  * are enabled
  */
-#define	WT_STAT_DSRC_BTREE_OVERFLOW			2046
+#define	WT_STAT_DSRC_BTREE_OVERFLOW			2045
 /*!
  * btree: row-store empty values, only reported if tree_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_ROW_EMPTY_VALUES		2047
+#define	WT_STAT_DSRC_BTREE_ROW_EMPTY_VALUES		2046
 /*!
  * btree: row-store internal pages, only reported if tree_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_ROW_INTERNAL			2048
+#define	WT_STAT_DSRC_BTREE_ROW_INTERNAL			2047
 /*!
  * btree: row-store leaf pages, only reported if tree_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_ROW_LEAF			2049
+#define	WT_STAT_DSRC_BTREE_ROW_LEAF			2048
 /*!
  * cache: application threads eviction requested with cache fill ratio <
  * 25%
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_APP_THREADS_FILL_RATIO_LT_25	2050
+#define	WT_STAT_DSRC_CACHE_EVICTION_APP_THREADS_FILL_RATIO_LT_25	2049
 /*!
  * cache: application threads eviction requested with cache fill ratio >=
  * 25% and < 50%
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_APP_THREADS_FILL_RATIO_25_50	2051
+#define	WT_STAT_DSRC_CACHE_EVICTION_APP_THREADS_FILL_RATIO_25_50	2050
 /*!
  * cache: application threads eviction requested with cache fill ratio >=
  * 50% and < 75%
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_APP_THREADS_FILL_RATIO_50_75	2052
+#define	WT_STAT_DSRC_CACHE_EVICTION_APP_THREADS_FILL_RATIO_50_75	2051
 /*!
  * cache: application threads eviction requested with cache fill ratio >=
  * 75%
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_APP_THREADS_FILL_RATIO_GT_75	2053
+#define	WT_STAT_DSRC_CACHE_EVICTION_APP_THREADS_FILL_RATIO_GT_75	2052
 /*!
  * cache: application threads eviction skip page with updates or dirty
  * page
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_APP_THREADS_SKIP_UPDATES_DIRTY_PAGE	2054
+#define	WT_STAT_DSRC_CACHE_EVICTION_APP_THREADS_SKIP_UPDATES_DIRTY_PAGE	2053
 /*! cache: bytes currently in the cache */
-#define	WT_STAT_DSRC_CACHE_BYTES_INUSE			2055
+#define	WT_STAT_DSRC_CACHE_BYTES_INUSE			2054
 /*! cache: bytes dirty in the cache cumulative */
-#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY_TOTAL		2056
+#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY_TOTAL		2055
 /*! cache: bytes read into cache */
-#define	WT_STAT_DSRC_CACHE_BYTES_READ			2057
+#define	WT_STAT_DSRC_CACHE_BYTES_READ			2056
 /*! cache: bytes written from cache */
-#define	WT_STAT_DSRC_CACHE_BYTES_WRITE			2058
+#define	WT_STAT_DSRC_CACHE_BYTES_WRITE			2057
 /*! cache: checkpoint blocked page eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_CHECKPOINT	2059
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_CHECKPOINT	2058
 /*!
  * cache: checkpoint of history store file blocked non-history store page
  * eviction
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_CHECKPOINT_HS	2060
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_CHECKPOINT_HS	2059
 /*! cache: data source pages selected for eviction unable to be evicted */
-#define	WT_STAT_DSRC_EVICTION_FAIL			2061
+#define	WT_STAT_DSRC_EVICTION_FAIL			2060
 /*! cache: dirty internal page cannot be evicted in disaggregated storage */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_DISAGG_DIRTY_INTERNAL_PAGE	2062
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_DISAGG_DIRTY_INTERNAL_PAGE	2061
 /*!
  * cache: eviction gave up due to detecting a disk value without a
  * timestamp behind the last update on the chain
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_1	2063
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_1	2062
 /*!
  * cache: eviction gave up due to detecting a tombstone without a
  * timestamp ahead of the selected on disk update
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_2	2064
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_2	2063
 /*!
  * cache: eviction gave up due to detecting a tombstone without a
  * timestamp ahead of the selected on disk update after validating the
  * update chain
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_3	2065
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_3	2064
 /*!
  * cache: eviction gave up due to detecting update chain entries without
  * timestamps after the selected on disk update
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_4	2066
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_4	2065
 /*!
  * cache: eviction gave up due to needing to remove a record from the
  * history store but checkpoint is running
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_REMOVE_HS_RACE_WITH_CHECKPOINT	2067
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_REMOVE_HS_RACE_WITH_CHECKPOINT	2066
 /*! cache: eviction gave up due to no progress being made */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_NO_PROGRESS	2068
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_NO_PROGRESS	2067
 /*! cache: eviction server skipped the pages when prefetching */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_PREFETCHED	2069
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_PREFETCHED	2068
 /*! cache: eviction walk pages queued that had updates */
-#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_QUEUED_UPDATES	2070
+#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_QUEUED_UPDATES	2069
 /*! cache: eviction walk pages queued that were clean */
-#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_QUEUED_CLEAN	2071
+#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_QUEUED_CLEAN	2070
 /*! cache: eviction walk pages queued that were dirty */
-#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_QUEUED_DIRTY	2072
+#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_QUEUED_DIRTY	2071
 /*! cache: eviction walk pages seen that had updates */
-#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_SEEN_UPDATES	2073
+#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_SEEN_UPDATES	2072
 /*! cache: eviction walk pages seen that were clean */
-#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_SEEN_CLEAN	2074
+#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_SEEN_CLEAN	2073
 /*! cache: eviction walk pages seen that were dirty */
-#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_SEEN_DIRTY	2075
+#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_SEEN_DIRTY	2074
 /*! cache: eviction walk passes of a file */
-#define	WT_STAT_DSRC_EVICTION_WALK_PASSES		2076
+#define	WT_STAT_DSRC_EVICTION_WALK_PASSES		2075
 /*! cache: eviction walk target pages histogram - 0-9 */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT10	2077
+#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT10	2076
 /*! cache: eviction walk target pages histogram - 10-31 */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT32	2078
+#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT32	2077
 /*! cache: eviction walk target pages histogram - 128 and higher */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_GE128	2079
+#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_GE128	2078
 /*! cache: eviction walk target pages histogram - 32-63 */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT64	2080
+#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT64	2079
 /*! cache: eviction walk target pages histogram - 64-128 */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT128	2081
+#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT128	2080
 /*!
  * cache: eviction walk target pages reduced due to history store cache
  * pressure
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_REDUCED	2082
+#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_REDUCED	2081
 /*!
  * cache: garbage collection from the ingest btree page is skipped
  * because the prune timestamp has not moved
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_PRUNE_TIMESTAMP	2083
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_PRUNE_TIMESTAMP	2082
 /*! cache: hazard pointer blocked page eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_HAZARD	2084
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_HAZARD	2083
 /*! cache: history store cursor not cached during eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_HS_CURSOR_NOT_CACHED	2085
+#define	WT_STAT_DSRC_CACHE_EVICTION_HS_CURSOR_NOT_CACHED	2084
 /*! cache: history store table insert calls */
-#define	WT_STAT_DSRC_CACHE_HS_INSERT			2086
+#define	WT_STAT_DSRC_CACHE_HS_INSERT			2085
 /*! cache: history store table insert calls that returned restart */
-#define	WT_STAT_DSRC_CACHE_HS_INSERT_RESTART		2087
+#define	WT_STAT_DSRC_CACHE_HS_INSERT_RESTART		2086
 /*! cache: history store table key to be processed */
-#define	WT_STAT_DSRC_CACHE_HS_KEY_PROCESSED		2088
+#define	WT_STAT_DSRC_CACHE_HS_KEY_PROCESSED		2087
 /*! cache: history store table reads */
-#define	WT_STAT_DSRC_CACHE_HS_READ			2089
+#define	WT_STAT_DSRC_CACHE_HS_READ			2088
 /*! cache: history store table reads missed */
-#define	WT_STAT_DSRC_CACHE_HS_READ_MISS			2090
+#define	WT_STAT_DSRC_CACHE_HS_READ_MISS			2089
 /*! cache: history store table reads requiring squashed modifies */
-#define	WT_STAT_DSRC_CACHE_HS_READ_SQUASH		2091
+#define	WT_STAT_DSRC_CACHE_HS_READ_SQUASH		2090
 /*!
  * cache: history store table resolved updates without timestamps that
  * lose their durable timestamp
  */
-#define	WT_STAT_DSRC_CACHE_HS_ORDER_LOSE_DURABLE_TIMESTAMP	2092
+#define	WT_STAT_DSRC_CACHE_HS_ORDER_LOSE_DURABLE_TIMESTAMP	2091
 /*!
  * cache: history store table truncation by rollback to stable to remove
  * an unstable update
  */
-#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE	2093
+#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE	2092
 /*!
  * cache: history store table truncation by rollback to stable to remove
  * an update
  */
-#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_RTS		2094
+#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_RTS		2093
 /*!
  * cache: history store table truncation to remove all the keys of a
  * btree
  */
-#define	WT_STAT_DSRC_CACHE_HS_BTREE_TRUNCATE		2095
+#define	WT_STAT_DSRC_CACHE_HS_BTREE_TRUNCATE		2094
 /*! cache: history store table truncation to remove an update */
-#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE		2096
+#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE		2095
 /*!
  * cache: history store table truncation to remove range of updates due
  * to an update without a timestamp on data page
  */
-#define	WT_STAT_DSRC_CACHE_HS_ORDER_REMOVE		2097
+#define	WT_STAT_DSRC_CACHE_HS_ORDER_REMOVE		2096
 /*!
  * cache: history store table truncation to remove range of updates due
  * to key being removed from the data page during reconciliation
  */
-#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_ONPAGE_REMOVAL	2098
+#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_ONPAGE_REMOVAL	2097
 /*!
  * cache: history store table truncations that would have happened in
  * non-dryrun mode
  */
-#define	WT_STAT_DSRC_CACHE_HS_BTREE_TRUNCATE_DRYRUN	2099
+#define	WT_STAT_DSRC_CACHE_HS_BTREE_TRUNCATE_DRYRUN	2098
 /*!
  * cache: history store table truncations to remove an unstable update
  * that would have happened in non-dryrun mode
  */
-#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE_DRYRUN	2100
+#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE_DRYRUN	2099
 /*!
  * cache: history store table truncations to remove an update that would
  * have happened in non-dryrun mode
  */
-#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_RTS_DRYRUN	2101
+#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_RTS_DRYRUN	2100
 /*! cache: history store table update to be processed */
-#define	WT_STAT_DSRC_CACHE_HS_UPDATE_PROCESSED		2102
+#define	WT_STAT_DSRC_CACHE_HS_UPDATE_PROCESSED		2101
 /*!
  * cache: history store table updates without timestamps fixed up by
  * reinserting with the fixed timestamp
  */
-#define	WT_STAT_DSRC_CACHE_HS_ORDER_REINSERT		2103
+#define	WT_STAT_DSRC_CACHE_HS_ORDER_REINSERT		2102
 /*! cache: history store table writes requiring squashed modifies */
-#define	WT_STAT_DSRC_CACHE_HS_WRITE_SQUASH		2104
+#define	WT_STAT_DSRC_CACHE_HS_WRITE_SQUASH		2103
 /*! cache: in-memory page passed criteria to be split */
-#define	WT_STAT_DSRC_CACHE_INMEM_SPLITTABLE		2105
+#define	WT_STAT_DSRC_CACHE_INMEM_SPLITTABLE		2104
 /*! cache: in-memory page splits */
-#define	WT_STAT_DSRC_CACHE_INMEM_SPLIT			2106
+#define	WT_STAT_DSRC_CACHE_INMEM_SPLIT			2105
 /*! cache: internal page split blocked its eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_INTERNAL_PAGE_SPLIT	2107
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_INTERNAL_PAGE_SPLIT	2106
 /*! cache: internal pages evicted */
-#define	WT_STAT_DSRC_CACHE_EVICTION_INTERNAL		2108
+#define	WT_STAT_DSRC_CACHE_EVICTION_INTERNAL		2107
 /*! cache: internal pages split during eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_SPLIT_INTERNAL	2109
+#define	WT_STAT_DSRC_CACHE_EVICTION_SPLIT_INTERNAL	2108
 /*! cache: leaf pages split during eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_SPLIT_LEAF		2110
+#define	WT_STAT_DSRC_CACHE_EVICTION_SPLIT_LEAF		2109
 /*!
  * cache: locate a random in-mem ref by examining all entries on the root
  * page
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_RANDOM_SAMPLE_INMEM_ROOT	2111
+#define	WT_STAT_DSRC_CACHE_EVICTION_RANDOM_SAMPLE_INMEM_ROOT	2110
 /*! cache: modified pages evicted */
-#define	WT_STAT_DSRC_CACHE_EVICTION_DIRTY		2112
+#define	WT_STAT_DSRC_CACHE_EVICTION_DIRTY		2111
 /*! cache: multi-block reconciliation blocked whilst checkpoint is running */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_MULTI_BLOCK_RECONCILIATION_DURING_CHECKPOINT	2113
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_MULTI_BLOCK_RECONCILIATION_DURING_CHECKPOINT	2112
 /*! cache: number of internal pages read that had deltas attached */
-#define	WT_STAT_DSRC_CACHE_READ_INTERNAL_DELTA		2114
+#define	WT_STAT_DSRC_CACHE_READ_INTERNAL_DELTA		2113
 /*! cache: number of leaf pages read that had deltas attached */
-#define	WT_STAT_DSRC_CACHE_READ_LEAF_DELTA		2115
+#define	WT_STAT_DSRC_CACHE_READ_LEAF_DELTA		2114
 /*! cache: number of times dirty trigger was reached */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TRIGGER_DIRTY_REACHED	2116
+#define	WT_STAT_DSRC_CACHE_EVICTION_TRIGGER_DIRTY_REACHED	2115
 /*! cache: number of times eviction trigger was reached */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TRIGGER_REACHED	2117
+#define	WT_STAT_DSRC_CACHE_EVICTION_TRIGGER_REACHED	2116
 /*! cache: number of times updates trigger was reached */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TRIGGER_UPDATES_REACHED	2118
+#define	WT_STAT_DSRC_CACHE_EVICTION_TRIGGER_UPDATES_REACHED	2117
 /*! cache: number of times when cas update the btree max_lsn failed */
-#define	WT_STAT_DSRC_CACHE_CAS_BTREE_MAX_LSN_RACE	2119
+#define	WT_STAT_DSRC_CACHE_CAS_BTREE_MAX_LSN_RACE	2118
 /*! cache: obsolete updates removed */
-#define	WT_STAT_DSRC_CACHE_OBSOLETE_UPDATES_REMOVED	2120
+#define	WT_STAT_DSRC_CACHE_OBSOLETE_UPDATES_REMOVED	2119
 /*!
  * cache: overflow keys on a multiblock row-store page blocked its
  * eviction
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_OVERFLOW_KEYS	2121
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_OVERFLOW_KEYS	2120
 /*! cache: overflow pages read into cache */
-#define	WT_STAT_DSRC_CACHE_READ_OVERFLOW		2122
+#define	WT_STAT_DSRC_CACHE_READ_OVERFLOW		2121
 /*! cache: page eviction blocked due to materialization frontier */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_MATERIALIZATION	2123
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_MATERIALIZATION	2122
 /*!
  * cache: page eviction blocked in disaggregated storage as it can only
  * be written by the next checkpoint
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_DISAGG_NEXT_CHECKPOINT	2124
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_DISAGG_NEXT_CHECKPOINT	2123
 /*! cache: page split during eviction deepened the tree */
-#define	WT_STAT_DSRC_CACHE_EVICTION_DEEPEN		2125
+#define	WT_STAT_DSRC_CACHE_EVICTION_DEEPEN		2124
 /*! cache: page written requiring history store records */
-#define	WT_STAT_DSRC_CACHE_WRITE_HS			2126
+#define	WT_STAT_DSRC_CACHE_WRITE_HS			2125
 /*! cache: pages dirtied due to obsolete time window by eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_DIRTY_OBSOLETE_TW	2127
+#define	WT_STAT_DSRC_CACHE_EVICTION_DIRTY_OBSOLETE_TW	2126
 /*! cache: pages evicted ahead of the page materialization frontier */
-#define	WT_STAT_DSRC_CACHE_EVICTION_AHEAD_OF_LAST_MATERIALIZED_LSN	2128
+#define	WT_STAT_DSRC_CACHE_EVICTION_AHEAD_OF_LAST_MATERIALIZED_LSN	2127
 /*! cache: pages read into cache */
-#define	WT_STAT_DSRC_CACHE_READ				2129
+#define	WT_STAT_DSRC_CACHE_READ				2128
 /*! cache: pages read into cache after truncate */
-#define	WT_STAT_DSRC_CACHE_READ_DELETED			2130
+#define	WT_STAT_DSRC_CACHE_READ_DELETED			2129
 /*! cache: pages read into cache after truncate in prepare state */
-#define	WT_STAT_DSRC_CACHE_READ_DELETED_PREPARED	2131
+#define	WT_STAT_DSRC_CACHE_READ_DELETED_PREPARED	2130
 /*! cache: pages read into cache by checkpoint */
-#define	WT_STAT_DSRC_CACHE_READ_CHECKPOINT		2132
+#define	WT_STAT_DSRC_CACHE_READ_CHECKPOINT		2131
 /*! cache: pages requested from the cache */
-#define	WT_STAT_DSRC_CACHE_PAGES_REQUESTED		2133
+#define	WT_STAT_DSRC_CACHE_PAGES_REQUESTED		2132
 /*! cache: pages requested from the cache due to pre-fetch */
-#define	WT_STAT_DSRC_CACHE_PAGES_PREFETCH		2134
+#define	WT_STAT_DSRC_CACHE_PAGES_PREFETCH		2133
 /*! cache: pages requested from the cache internal */
-#define	WT_STAT_DSRC_CACHE_PAGES_REQUESTED_INTERNAL	2135
+#define	WT_STAT_DSRC_CACHE_PAGES_REQUESTED_INTERNAL	2134
 /*! cache: pages requested from the cache leaf */
-#define	WT_STAT_DSRC_CACHE_PAGES_REQUESTED_LEAF		2136
+#define	WT_STAT_DSRC_CACHE_PAGES_REQUESTED_LEAF		2135
 /*! cache: pages requested from the history store */
-#define	WT_STAT_DSRC_CACHE_PAGES_REQUESTED_HS		2137
+#define	WT_STAT_DSRC_CACHE_PAGES_REQUESTED_HS		2136
 /*! cache: pages seen by eviction walk */
-#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_SEEN		2138
+#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_SEEN		2137
 /*! cache: pages written from cache */
-#define	WT_STAT_DSRC_CACHE_WRITE			2139
+#define	WT_STAT_DSRC_CACHE_WRITE			2138
 /*!
  * cache: pages written requiring in-memory restoration due to invisible
  * updates
  */
-#define	WT_STAT_DSRC_CACHE_WRITE_RESTORE_INVISIBLE	2140
+#define	WT_STAT_DSRC_CACHE_WRITE_RESTORE_INVISIBLE	2139
 /*!
  * cache: pages written requiring in-memory restoration due to scrub
  * eviction
  */
-#define	WT_STAT_DSRC_CACHE_WRITE_RESTORE_SCRUB		2141
+#define	WT_STAT_DSRC_CACHE_WRITE_RESTORE_SCRUB		2140
 /*!
  * cache: precise checkpoint caused an eviction to be skipped because any
  * dirty content needs to remain in cache
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_PRECISE_CHECKPOINT	2142
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_PRECISE_CHECKPOINT	2141
 /*!
  * cache: realizing in-memory split after reconciliation failed due to
  * internal lock busy
  */
-#define	WT_STAT_DSRC_CACHE_EVICT_SPLIT_FAILED_LOCK	2143
+#define	WT_STAT_DSRC_CACHE_EVICT_SPLIT_FAILED_LOCK	2142
 /*! cache: recent modification of a page blocked its eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	2144
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	2143
 /*! cache: reconciled pages scrubbed and added back to the cache clean */
-#define	WT_STAT_DSRC_CACHE_SCRUB_RESTORE		2145
+#define	WT_STAT_DSRC_CACHE_SCRUB_RESTORE		2144
 /*! cache: reverse splits performed */
-#define	WT_STAT_DSRC_CACHE_REVERSE_SPLITS		2146
+#define	WT_STAT_DSRC_CACHE_REVERSE_SPLITS		2145
 /*!
  * cache: reverse splits skipped because of VLCS namespace gap
  * restrictions
  */
-#define	WT_STAT_DSRC_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	2147
+#define	WT_STAT_DSRC_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	2146
 /*! cache: shared history store cursor not cached during eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_HS_SHARED_CURSOR_NOT_CACHED	2148
+#define	WT_STAT_DSRC_CACHE_EVICTION_HS_SHARED_CURSOR_NOT_CACHED	2147
 /*! cache: size of delta updates reconstructed on the base page */
-#define	WT_STAT_DSRC_CACHE_READ_DELTA_UPDATES		2149
+#define	WT_STAT_DSRC_CACHE_READ_DELTA_UPDATES		2148
 /*! cache: size of tombstones restored when reading a page */
-#define	WT_STAT_DSRC_CACHE_READ_RESTORED_TOMBSTONE_BYTES	2150
+#define	WT_STAT_DSRC_CACHE_READ_RESTORED_TOMBSTONE_BYTES	2149
 /*! cache: the number of times full update inserted to history store */
-#define	WT_STAT_DSRC_CACHE_HS_INSERT_FULL_UPDATE	2151
+#define	WT_STAT_DSRC_CACHE_HS_INSERT_FULL_UPDATE	2150
 /*! cache: the number of times reverse modify inserted to history store */
-#define	WT_STAT_DSRC_CACHE_HS_INSERT_REVERSE_MODIFY	2152
+#define	WT_STAT_DSRC_CACHE_HS_INSERT_REVERSE_MODIFY	2151
 /*! cache: tracked dirty bytes in the cache */
-#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY			2153
+#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY			2152
 /*! cache: tracked dirty internal page bytes in the cache */
-#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY_INTERNAL		2154
+#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY_INTERNAL		2153
 /*! cache: tracked dirty leaf page bytes in the cache */
-#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY_LEAF		2155
+#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY_LEAF		2154
 /*! cache: uncommitted truncate blocked page eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	2156
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	2155
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_DSRC_CACHE_EVICTION_CLEAN		2157
+#define	WT_STAT_DSRC_CACHE_EVICTION_CLEAN		2156
 /*!
  * cache_walk: Average difference between current eviction generation
  * when the page was last considered, only reported if cache_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_GEN_AVG_GAP		2158
+#define	WT_STAT_DSRC_CACHE_STATE_GEN_AVG_GAP		2157
 /*!
  * cache_walk: Average on-disk page image size seen, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_AVG_WRITTEN_SIZE	2159
+#define	WT_STAT_DSRC_CACHE_STATE_AVG_WRITTEN_SIZE	2158
 /*!
  * cache_walk: Average time in cache for pages that have been visited by
  * the eviction server, only reported if cache_walk or all statistics are
  * enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_AVG_VISITED_AGE	2160
+#define	WT_STAT_DSRC_CACHE_STATE_AVG_VISITED_AGE	2159
 /*!
  * cache_walk: Average time in cache for pages that have not been visited
  * by the eviction server, only reported if cache_walk or all statistics
  * are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_AVG_UNVISITED_AGE	2161
+#define	WT_STAT_DSRC_CACHE_STATE_AVG_UNVISITED_AGE	2160
 /*!
  * cache_walk: Clean pages currently in cache, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES_CLEAN		2162
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES_CLEAN		2161
 /*!
  * cache_walk: Current eviction generation, only reported if cache_walk
  * or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_GEN_CURRENT		2163
+#define	WT_STAT_DSRC_CACHE_STATE_GEN_CURRENT		2162
 /*!
  * cache_walk: Dirty pages currently in cache, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES_DIRTY		2164
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES_DIRTY		2163
 /*!
  * cache_walk: Entries in the root page, only reported if cache_walk or
  * all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_ROOT_ENTRIES		2165
+#define	WT_STAT_DSRC_CACHE_STATE_ROOT_ENTRIES		2164
 /*!
  * cache_walk: Internal pages currently in cache, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES_INTERNAL		2166
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES_INTERNAL		2165
 /*!
  * cache_walk: Leaf pages currently in cache, only reported if cache_walk
  * or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES_LEAF		2167
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES_LEAF		2166
 /*!
  * cache_walk: Maximum difference between current eviction generation
  * when the page was last considered, only reported if cache_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_GEN_MAX_GAP		2168
+#define	WT_STAT_DSRC_CACHE_STATE_GEN_MAX_GAP		2167
 /*!
  * cache_walk: Maximum page size seen, only reported if cache_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_MAX_PAGESIZE		2169
+#define	WT_STAT_DSRC_CACHE_STATE_MAX_PAGESIZE		2168
 /*!
  * cache_walk: Minimum on-disk page image size seen, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_MIN_WRITTEN_SIZE	2170
+#define	WT_STAT_DSRC_CACHE_STATE_MIN_WRITTEN_SIZE	2169
 /*!
  * cache_walk: Number of pages never visited by eviction server, only
  * reported if cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_UNVISITED_COUNT	2171
+#define	WT_STAT_DSRC_CACHE_STATE_UNVISITED_COUNT	2170
 /*!
  * cache_walk: On-disk page image sizes smaller than a single allocation
  * unit, only reported if cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_SMALLER_ALLOC_SIZE	2172
+#define	WT_STAT_DSRC_CACHE_STATE_SMALLER_ALLOC_SIZE	2171
 /*!
  * cache_walk: Pages created in memory and never written, only reported
  * if cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_MEMORY			2173
+#define	WT_STAT_DSRC_CACHE_STATE_MEMORY			2172
 /*!
  * cache_walk: Pages currently queued for eviction, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_QUEUED			2174
+#define	WT_STAT_DSRC_CACHE_STATE_QUEUED			2173
 /*!
  * cache_walk: Pages that could not be queued for eviction, only reported
  * if cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_NOT_QUEUEABLE		2175
+#define	WT_STAT_DSRC_CACHE_STATE_NOT_QUEUEABLE		2174
 /*!
  * cache_walk: Refs skipped during cache traversal, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_REFS_SKIPPED		2176
+#define	WT_STAT_DSRC_CACHE_STATE_REFS_SKIPPED		2175
 /*!
  * cache_walk: Size of the root page, only reported if cache_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_ROOT_SIZE		2177
+#define	WT_STAT_DSRC_CACHE_STATE_ROOT_SIZE		2176
 /*!
  * cache_walk: Total number of pages currently in cache, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES			2178
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES			2177
 /*! checkpoint-cleanup: pages added for eviction */
-#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_EVICT	2179
+#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_EVICT	2178
 /*! checkpoint-cleanup: pages dirtied due to obsolete time window */
-#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	2180
+#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	2179
 /*! checkpoint-cleanup: pages read into cache (reclaim_space) */
-#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	2181
+#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	2180
 /*! checkpoint-cleanup: pages read into cache due to obsolete time window */
-#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	2182
+#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	2181
 /*! checkpoint-cleanup: pages removed */
-#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_REMOVED	2183
+#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_REMOVED	2182
 /*! checkpoint-cleanup: pages skipped during tree walk */
-#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	2184
+#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	2183
 /*! checkpoint-cleanup: pages visited */
-#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_VISITED	2185
+#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_VISITED	2184
 /*! checkpoint: checkpoint has acquired a snapshot for its transaction */
-#define	WT_STAT_DSRC_CHECKPOINT_SNAPSHOT_ACQUIRED	2186
+#define	WT_STAT_DSRC_CHECKPOINT_SNAPSHOT_ACQUIRED	2185
 /*!
  * compression: compressed page maximum internal page size prior to
  * compression
  */
-#define	WT_STAT_DSRC_COMPRESS_PRECOMP_INTL_MAX_PAGE_SIZE	2187
+#define	WT_STAT_DSRC_COMPRESS_PRECOMP_INTL_MAX_PAGE_SIZE	2186
 /*!
  * compression: compressed page maximum leaf page size prior to
  * compression
  */
-#define	WT_STAT_DSRC_COMPRESS_PRECOMP_LEAF_MAX_PAGE_SIZE	2188
+#define	WT_STAT_DSRC_COMPRESS_PRECOMP_LEAF_MAX_PAGE_SIZE	2187
 /*! compression: page written to disk failed to compress */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_FAIL		2189
+#define	WT_STAT_DSRC_COMPRESS_WRITE_FAIL		2188
 /*! compression: page written to disk was too small to compress */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_TOO_SMALL		2190
+#define	WT_STAT_DSRC_COMPRESS_WRITE_TOO_SMALL		2189
 /*! compression: pages read from disk */
-#define	WT_STAT_DSRC_COMPRESS_READ			2191
+#define	WT_STAT_DSRC_COMPRESS_READ			2190
 /*!
  * compression: pages read from disk with compression ratio greater than
  * 64
  */
-#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_MAX	2192
+#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_MAX	2191
 /*!
  * compression: pages read from disk with compression ratio smaller than
  * 2
  */
-#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_2		2193
+#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_2		2192
 /*!
  * compression: pages read from disk with compression ratio smaller than
  * 4
  */
-#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_4		2194
+#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_4		2193
 /*!
  * compression: pages read from disk with compression ratio smaller than
  * 8
  */
-#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_8		2195
+#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_8		2194
 /*!
  * compression: pages read from disk with compression ratio smaller than
  * 16
  */
-#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_16	2196
+#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_16	2195
 /*!
  * compression: pages read from disk with compression ratio smaller than
  * 32
  */
-#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_32	2197
+#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_32	2196
 /*!
  * compression: pages read from disk with compression ratio smaller than
  * 64
  */
-#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_64	2198
+#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_64	2197
 /*! compression: pages written to disk */
-#define	WT_STAT_DSRC_COMPRESS_WRITE			2199
+#define	WT_STAT_DSRC_COMPRESS_WRITE			2198
 /*!
  * compression: pages written to disk with compression ratio greater than
  * 64
  */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_MAX	2200
+#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_MAX	2199
 /*!
  * compression: pages written to disk with compression ratio smaller than
  * 2
  */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_2	2201
+#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_2	2200
 /*!
  * compression: pages written to disk with compression ratio smaller than
  * 4
  */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_4	2202
+#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_4	2201
 /*!
  * compression: pages written to disk with compression ratio smaller than
  * 8
  */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_8	2203
+#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_8	2202
 /*!
  * compression: pages written to disk with compression ratio smaller than
  * 16
  */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_16	2204
+#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_16	2203
 /*!
  * compression: pages written to disk with compression ratio smaller than
  * 32
  */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_32	2205
+#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_32	2204
 /*!
  * compression: pages written to disk with compression ratio smaller than
  * 64
  */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_64	2206
+#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_64	2205
 /*! cursor: Total number of deleted pages skipped during tree walk */
-#define	WT_STAT_DSRC_CURSOR_TREE_WALK_DEL_PAGE_SKIP	2207
+#define	WT_STAT_DSRC_CURSOR_TREE_WALK_DEL_PAGE_SKIP	2206
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_TOTAL		2208
+#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_TOTAL		2207
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_TOTAL		2209
+#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_TOTAL		2208
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_DSRC_CURSOR_SKIP_HS_CUR_POSITION	2210
+#define	WT_STAT_DSRC_CURSOR_SKIP_HS_CUR_POSITION	2209
 /*!
  * cursor: Total number of in-memory deleted pages skipped during tree
  * walk
  */
-#define	WT_STAT_DSRC_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	2211
+#define	WT_STAT_DSRC_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	2210
 /*! cursor: Total number of on-disk deleted pages skipped during tree walk */
-#define	WT_STAT_DSRC_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	2212
+#define	WT_STAT_DSRC_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	2211
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	2213
+#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	2212
 /*!
  * cursor: Total number of times cursor fails to temporarily release
  * pinned page to encourage eviction of hot or large page
  */
-#define	WT_STAT_DSRC_CURSOR_REPOSITION_FAILED		2214
+#define	WT_STAT_DSRC_CURSOR_REPOSITION_FAILED		2213
 /*!
  * cursor: Total number of times cursor temporarily releases pinned page
  * to encourage eviction of hot or large page
  */
-#define	WT_STAT_DSRC_CURSOR_REPOSITION			2215
+#define	WT_STAT_DSRC_CURSOR_REPOSITION			2214
 /*! cursor: bulk loaded cursor insert calls */
-#define	WT_STAT_DSRC_CURSOR_INSERT_BULK			2216
+#define	WT_STAT_DSRC_CURSOR_INSERT_BULK			2215
 /*! cursor: cache cursors reuse count */
-#define	WT_STAT_DSRC_CURSOR_REOPEN			2217
+#define	WT_STAT_DSRC_CURSOR_REOPEN			2216
 /*! cursor: close calls that result in cache */
-#define	WT_STAT_DSRC_CURSOR_CACHE			2218
+#define	WT_STAT_DSRC_CURSOR_CACHE			2217
 /*! cursor: create calls */
-#define	WT_STAT_DSRC_CURSOR_CREATE			2219
+#define	WT_STAT_DSRC_CURSOR_CREATE			2218
 /*! cursor: cursor bound calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_BOUND_ERROR			2220
+#define	WT_STAT_DSRC_CURSOR_BOUND_ERROR			2219
 /*! cursor: cursor bounds cleared from reset */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_RESET		2221
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_RESET		2220
 /*! cursor: cursor bounds comparisons performed */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_COMPARISONS		2222
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_COMPARISONS		2221
 /*! cursor: cursor bounds next called on an unpositioned cursor */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_NEXT_UNPOSITIONED	2223
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_NEXT_UNPOSITIONED	2222
 /*! cursor: cursor bounds next early exit */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_NEXT_EARLY_EXIT	2224
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_NEXT_EARLY_EXIT	2223
 /*! cursor: cursor bounds prev called on an unpositioned cursor */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_PREV_UNPOSITIONED	2225
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_PREV_UNPOSITIONED	2224
 /*! cursor: cursor bounds prev early exit */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_PREV_EARLY_EXIT	2226
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_PREV_EARLY_EXIT	2225
 /*! cursor: cursor bounds search early exit */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	2227
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	2226
 /*! cursor: cursor bounds search near call repositioned cursor */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	2228
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	2227
 /*! cursor: cursor cache calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_CACHE_ERROR			2229
+#define	WT_STAT_DSRC_CURSOR_CACHE_ERROR			2228
 /*! cursor: cursor close calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_CLOSE_ERROR			2230
+#define	WT_STAT_DSRC_CURSOR_CLOSE_ERROR			2229
 /*! cursor: cursor compare calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_COMPARE_ERROR		2231
+#define	WT_STAT_DSRC_CURSOR_COMPARE_ERROR		2230
 /*! cursor: cursor equals calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_EQUALS_ERROR		2232
+#define	WT_STAT_DSRC_CURSOR_EQUALS_ERROR		2231
 /*! cursor: cursor get key calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_GET_KEY_ERROR		2233
+#define	WT_STAT_DSRC_CURSOR_GET_KEY_ERROR		2232
 /*! cursor: cursor get value calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_GET_VALUE_ERROR		2234
+#define	WT_STAT_DSRC_CURSOR_GET_VALUE_ERROR		2233
 /*! cursor: cursor insert calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_INSERT_ERROR		2235
+#define	WT_STAT_DSRC_CURSOR_INSERT_ERROR		2234
 /*! cursor: cursor insert check calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_INSERT_CHECK_ERROR		2236
+#define	WT_STAT_DSRC_CURSOR_INSERT_CHECK_ERROR		2235
 /*! cursor: cursor largest key calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_LARGEST_KEY_ERROR		2237
+#define	WT_STAT_DSRC_CURSOR_LARGEST_KEY_ERROR		2236
 /*! cursor: cursor modify calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_MODIFY_ERROR		2238
+#define	WT_STAT_DSRC_CURSOR_MODIFY_ERROR		2237
 /*! cursor: cursor next calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_NEXT_ERROR			2239
+#define	WT_STAT_DSRC_CURSOR_NEXT_ERROR			2238
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_DSRC_CURSOR_NEXT_HS_TOMBSTONE		2240
+#define	WT_STAT_DSRC_CURSOR_NEXT_HS_TOMBSTONE		2239
 /*!
  * cursor: cursor next calls that skip greater than 1 and fewer than 100
  * entries
  */
-#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_LT_100		2241
+#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_LT_100		2240
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_GE_100		2242
+#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_GE_100		2241
 /*! cursor: cursor next random calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_NEXT_RANDOM_ERROR		2243
+#define	WT_STAT_DSRC_CURSOR_NEXT_RANDOM_ERROR		2242
 /*! cursor: cursor prev calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_PREV_ERROR			2244
+#define	WT_STAT_DSRC_CURSOR_PREV_ERROR			2243
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_DSRC_CURSOR_PREV_HS_TOMBSTONE		2245
+#define	WT_STAT_DSRC_CURSOR_PREV_HS_TOMBSTONE		2244
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_GE_100		2246
+#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_GE_100		2245
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_LT_100		2247
+#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_LT_100		2246
 /*! cursor: cursor reconfigure calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_RECONFIGURE_ERROR		2248
+#define	WT_STAT_DSRC_CURSOR_RECONFIGURE_ERROR		2247
 /*! cursor: cursor remove calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_REMOVE_ERROR		2249
+#define	WT_STAT_DSRC_CURSOR_REMOVE_ERROR		2248
 /*! cursor: cursor reopen calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_REOPEN_ERROR		2250
+#define	WT_STAT_DSRC_CURSOR_REOPEN_ERROR		2249
 /*! cursor: cursor reserve calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_RESERVE_ERROR		2251
+#define	WT_STAT_DSRC_CURSOR_RESERVE_ERROR		2250
 /*! cursor: cursor reset calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_RESET_ERROR			2252
+#define	WT_STAT_DSRC_CURSOR_RESET_ERROR			2251
 /*! cursor: cursor search calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_ERROR		2253
+#define	WT_STAT_DSRC_CURSOR_SEARCH_ERROR		2252
 /*! cursor: cursor search near calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR_ERROR		2254
+#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR_ERROR		2253
 /*! cursor: cursor update calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_UPDATE_ERROR		2255
+#define	WT_STAT_DSRC_CURSOR_UPDATE_ERROR		2254
 /*! cursor: insert calls */
-#define	WT_STAT_DSRC_CURSOR_INSERT			2256
+#define	WT_STAT_DSRC_CURSOR_INSERT			2255
 /*! cursor: insert key and value bytes */
-#define	WT_STAT_DSRC_CURSOR_INSERT_BYTES		2257
+#define	WT_STAT_DSRC_CURSOR_INSERT_BYTES		2256
 /*! cursor: modify */
-#define	WT_STAT_DSRC_CURSOR_MODIFY			2258
+#define	WT_STAT_DSRC_CURSOR_MODIFY			2257
 /*! cursor: modify key and value bytes affected */
-#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES		2259
+#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES		2258
 /*! cursor: modify value bytes modified */
-#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES_TOUCH		2260
+#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES_TOUCH		2259
 /*! cursor: next calls */
-#define	WT_STAT_DSRC_CURSOR_NEXT			2261
+#define	WT_STAT_DSRC_CURSOR_NEXT			2260
 /*! cursor: open cursor count */
-#define	WT_STAT_DSRC_CURSOR_OPEN_COUNT			2262
+#define	WT_STAT_DSRC_CURSOR_OPEN_COUNT			2261
 /*! cursor: open cursor time application (usecs) */
-#define	WT_STAT_DSRC_CURSOR_OPEN_TIME_USER_USECS	2263
+#define	WT_STAT_DSRC_CURSOR_OPEN_TIME_USER_USECS	2262
 /*! cursor: open cursor time internal (usecs) */
-#define	WT_STAT_DSRC_CURSOR_OPEN_TIME_INTERNAL_USECS	2264
+#define	WT_STAT_DSRC_CURSOR_OPEN_TIME_INTERNAL_USECS	2263
 /*! cursor: operation restarted */
-#define	WT_STAT_DSRC_CURSOR_RESTART			2265
+#define	WT_STAT_DSRC_CURSOR_RESTART			2264
 /*! cursor: prev calls */
-#define	WT_STAT_DSRC_CURSOR_PREV			2266
+#define	WT_STAT_DSRC_CURSOR_PREV			2265
 /*! cursor: remove calls */
-#define	WT_STAT_DSRC_CURSOR_REMOVE			2267
+#define	WT_STAT_DSRC_CURSOR_REMOVE			2266
 /*! cursor: remove key bytes removed */
-#define	WT_STAT_DSRC_CURSOR_REMOVE_BYTES		2268
+#define	WT_STAT_DSRC_CURSOR_REMOVE_BYTES		2267
 /*! cursor: reserve calls */
-#define	WT_STAT_DSRC_CURSOR_RESERVE			2269
+#define	WT_STAT_DSRC_CURSOR_RESERVE			2268
 /*! cursor: reset calls */
-#define	WT_STAT_DSRC_CURSOR_RESET			2270
+#define	WT_STAT_DSRC_CURSOR_RESET			2269
 /*! cursor: search calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH			2271
+#define	WT_STAT_DSRC_CURSOR_SEARCH			2270
 /*! cursor: search history store calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_HS			2272
+#define	WT_STAT_DSRC_CURSOR_SEARCH_HS			2271
 /*! cursor: search near calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR			2273
+#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR			2272
 /*! cursor: truncate calls */
-#define	WT_STAT_DSRC_CURSOR_TRUNCATE			2274
+#define	WT_STAT_DSRC_CURSOR_TRUNCATE			2273
 /*! cursor: update calls */
-#define	WT_STAT_DSRC_CURSOR_UPDATE			2275
+#define	WT_STAT_DSRC_CURSOR_UPDATE			2274
 /*! cursor: update key and value bytes */
-#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES		2276
+#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES		2275
 /*! cursor: update value size change */
-#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES_CHANGED	2277
+#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES_CHANGED	2276
 /*! layered: Layered table cursor insert operations */
-#define	WT_STAT_DSRC_LAYERED_CURS_INSERT		2278
+#define	WT_STAT_DSRC_LAYERED_CURS_INSERT		2277
 /*! layered: Layered table cursor modify operations */
-#define	WT_STAT_DSRC_LAYERED_CURS_MODIFY		2279
+#define	WT_STAT_DSRC_LAYERED_CURS_MODIFY		2278
 /*! layered: Layered table cursor next operations */
-#define	WT_STAT_DSRC_LAYERED_CURS_NEXT			2280
+#define	WT_STAT_DSRC_LAYERED_CURS_NEXT			2279
 /*! layered: Layered table cursor next operations from the ingest btrees */
-#define	WT_STAT_DSRC_LAYERED_CURS_NEXT_INGEST		2281
+#define	WT_STAT_DSRC_LAYERED_CURS_NEXT_INGEST		2280
 /*! layered: Layered table cursor next operations from the stable btrees */
-#define	WT_STAT_DSRC_LAYERED_CURS_NEXT_STABLE		2282
+#define	WT_STAT_DSRC_LAYERED_CURS_NEXT_STABLE		2281
 /*! layered: Layered table cursor prev operations */
-#define	WT_STAT_DSRC_LAYERED_CURS_PREV			2283
+#define	WT_STAT_DSRC_LAYERED_CURS_PREV			2282
 /*! layered: Layered table cursor prev operations from the ingest btrees */
-#define	WT_STAT_DSRC_LAYERED_CURS_PREV_INGEST		2284
+#define	WT_STAT_DSRC_LAYERED_CURS_PREV_INGEST		2283
 /*! layered: Layered table cursor prev operations from the stable btrees */
-#define	WT_STAT_DSRC_LAYERED_CURS_PREV_STABLE		2285
+#define	WT_STAT_DSRC_LAYERED_CURS_PREV_STABLE		2284
 /*! layered: Layered table cursor remove operations */
-#define	WT_STAT_DSRC_LAYERED_CURS_REMOVE		2286
+#define	WT_STAT_DSRC_LAYERED_CURS_REMOVE		2285
 /*! layered: Layered table cursor search near operations */
-#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH_NEAR		2287
+#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH_NEAR		2286
 /*!
  * layered: Layered table cursor search near operations from the ingest
  * btrees
  */
-#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH_NEAR_INGEST	2288
+#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH_NEAR_INGEST	2287
 /*!
  * layered: Layered table cursor search near operations from the stable
  * btrees
  */
-#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH_NEAR_STABLE	2289
+#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH_NEAR_STABLE	2288
 /*! layered: Layered table cursor search operations */
-#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH		2290
+#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH		2289
 /*! layered: Layered table cursor search operations from the ingest btrees */
-#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH_INGEST		2291
+#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH_INGEST		2290
 /*! layered: Layered table cursor search operations from the stable btrees */
-#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH_STABLE		2292
+#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH_STABLE		2291
 /*! layered: Layered table cursor update operations */
-#define	WT_STAT_DSRC_LAYERED_CURS_UPDATE		2293
+#define	WT_STAT_DSRC_LAYERED_CURS_UPDATE		2292
 /*! layered: Layered table cursor upgrade state for the ingest btrees */
-#define	WT_STAT_DSRC_LAYERED_CURS_UPGRADE_INGEST	2294
+#define	WT_STAT_DSRC_LAYERED_CURS_UPGRADE_INGEST	2293
 /*! layered: Layered table cursor upgrade state for the stable btrees */
-#define	WT_STAT_DSRC_LAYERED_CURS_UPGRADE_STABLE	2295
+#define	WT_STAT_DSRC_LAYERED_CURS_UPGRADE_STABLE	2294
 /*!
  * layered: checkpoints performed on this table by the layered table
  * manager
  */
-#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_CHECKPOINTS	2296
+#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_CHECKPOINTS	2295
 /*! layered: disagg pick up checkpoints failed */
-#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FAILED	2297
+#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FAILED	2296
 /*! layered: disagg pick up checkpoints succeeded */
-#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_SUCCEED	2298
+#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_SUCCEED	2297
 /*!
  * layered: how many log applications the layered table manager applied
  * on this tree
  */
-#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_LOGOPS_APPLIED	2299
+#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_LOGOPS_APPLIED	2298
 /*!
  * layered: how many log applications the layered table manager skipped
  * on this tree
  */
-#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_LOGOPS_SKIPPED	2300
+#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_LOGOPS_SKIPPED	2299
 /*!
  * layered: how many previously-applied LSNs the layered table manager
  * skipped on this tree
  */
-#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_SKIP_LSN	2301
+#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_SKIP_LSN	2300
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_DSRC_REC_VLCS_EMPTIED_PAGES		2302
+#define	WT_STAT_DSRC_REC_VLCS_EMPTIED_PAGES		2301
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TS		2303
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TS		2302
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TXN		2304
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TXN		2303
 /*!
  * reconciliation: average length of delta chain on internal page with
  * deltas
  */
-#define	WT_STAT_DSRC_REC_AVERAGE_INTERNAL_PAGE_DELTA_CHAIN_LENGTH	2305
+#define	WT_STAT_DSRC_REC_AVERAGE_INTERNAL_PAGE_DELTA_CHAIN_LENGTH	2304
 /*! reconciliation: average length of delta chain on leaf page with deltas */
-#define	WT_STAT_DSRC_REC_AVERAGE_LEAF_PAGE_DELTA_CHAIN_LENGTH	2306
+#define	WT_STAT_DSRC_REC_AVERAGE_LEAF_PAGE_DELTA_CHAIN_LENGTH	2305
 /*!
  * reconciliation: changes since prior reconciliation (bucket 1) between
  * 1 and 5
  */
-#define	WT_STAT_DSRC_REC_PAGE_MODS_LE5			2307
+#define	WT_STAT_DSRC_REC_PAGE_MODS_LE5			2306
 /*!
  * reconciliation: changes since prior reconciliation (bucket 2) between
  * 6 and 10
  */
-#define	WT_STAT_DSRC_REC_PAGE_MODS_LE10			2308
+#define	WT_STAT_DSRC_REC_PAGE_MODS_LE10			2307
 /*!
  * reconciliation: changes since prior reconciliation (bucket 3) between
  * 11 and 20
  */
-#define	WT_STAT_DSRC_REC_PAGE_MODS_LE20			2309
+#define	WT_STAT_DSRC_REC_PAGE_MODS_LE20			2308
 /*!
  * reconciliation: changes since prior reconciliation (bucket 4) between
  * 21 and 50
  */
-#define	WT_STAT_DSRC_REC_PAGE_MODS_LE50			2310
+#define	WT_STAT_DSRC_REC_PAGE_MODS_LE50			2309
 /*!
  * reconciliation: changes since prior reconciliation (bucket 5) between
  * 51 and 100
  */
-#define	WT_STAT_DSRC_REC_PAGE_MODS_LE100		2311
+#define	WT_STAT_DSRC_REC_PAGE_MODS_LE100		2310
 /*!
  * reconciliation: changes since prior reconciliation (bucket 6) between
  * 101 and 200
  */
-#define	WT_STAT_DSRC_REC_PAGE_MODS_LE200		2312
+#define	WT_STAT_DSRC_REC_PAGE_MODS_LE200		2311
 /*!
  * reconciliation: changes since prior reconciliation (bucket 7) between
  * 201 and 500
  */
-#define	WT_STAT_DSRC_REC_PAGE_MODS_LE500		2313
+#define	WT_STAT_DSRC_REC_PAGE_MODS_LE500		2312
 /*!
  * reconciliation: changes since prior reconciliation (bucket 8) greater
  * than 500
  */
-#define	WT_STAT_DSRC_REC_PAGE_MODS_GT500		2314
+#define	WT_STAT_DSRC_REC_PAGE_MODS_GT500		2313
 /*! reconciliation: cursor next/prev calls during HS wrapup search_near */
-#define	WT_STAT_DSRC_REC_HS_WRAPUP_NEXT_PREV_CALLS	2315
+#define	WT_STAT_DSRC_REC_HS_WRAPUP_NEXT_PREV_CALLS	2314
 /*! reconciliation: dictionary matches */
-#define	WT_STAT_DSRC_REC_DICTIONARY			2316
+#define	WT_STAT_DSRC_REC_DICTIONARY			2315
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELETE_FAST		2317
+#define	WT_STAT_DSRC_REC_PAGE_DELETE_FAST		2316
 /*!
  * reconciliation: free page ID due to failed page replacement
  * reconciliation in disagg
  */
-#define	WT_STAT_DSRC_REC_FREE_PAGE_ID_DUE_TO_FAILED_REPLACEMENT_RECONCILIATION	2318
+#define	WT_STAT_DSRC_REC_FREE_PAGE_ID_DUE_TO_FAILED_REPLACEMENT_RECONCILIATION	2317
 /*! reconciliation: full internal pages written instead of a page delta */
-#define	WT_STAT_DSRC_REC_PAGE_FULL_IMAGE_INTERNAL	2319
+#define	WT_STAT_DSRC_REC_PAGE_FULL_IMAGE_INTERNAL	2318
 /*! reconciliation: full leaf pages written instead of a page delta */
-#define	WT_STAT_DSRC_REC_PAGE_FULL_IMAGE_LEAF		2320
+#define	WT_STAT_DSRC_REC_PAGE_FULL_IMAGE_LEAF		2319
 /*!
  * reconciliation: ingest btree reconciliation keeps the aborted prepare
  * updates
  */
-#define	WT_STAT_DSRC_REC_INGEST_KEEP_PREPARE_ROLLBACK	2321
+#define	WT_STAT_DSRC_REC_INGEST_KEEP_PREPARE_ROLLBACK	2320
 /*! reconciliation: internal page delta keys deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELTA_INTERNAL_KEY_DELETED	2322
+#define	WT_STAT_DSRC_REC_PAGE_DELTA_INTERNAL_KEY_DELETED	2321
 /*! reconciliation: internal page delta keys updated/inserted */
-#define	WT_STAT_DSRC_REC_PAGE_DELTA_INTERNAL_KEY_UPDATED	2323
+#define	WT_STAT_DSRC_REC_PAGE_DELTA_INTERNAL_KEY_UPDATED	2322
 /*! reconciliation: internal page deltas written */
-#define	WT_STAT_DSRC_REC_PAGE_DELTA_INTERNAL		2324
+#define	WT_STAT_DSRC_REC_PAGE_DELTA_INTERNAL		2323
 /*!
  * reconciliation: internal page key bytes discarded using suffix
  * compression
  */
-#define	WT_STAT_DSRC_REC_SUFFIX_COMPRESSION		2325
+#define	WT_STAT_DSRC_REC_SUFFIX_COMPRESSION		2324
 /*! reconciliation: internal page multi-block writes */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_INTERNAL		2326
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_INTERNAL		2325
 /*!
  * reconciliation: leaf delta page key bytes discarded using prefix
  * compression
  */
-#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION_DELTA	2327
+#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION_DELTA	2326
 /*!
  * reconciliation: leaf full page key bytes discarded using prefix
  * compression
  */
-#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION_FULL	2328
+#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION_FULL	2327
 /*! reconciliation: leaf page deltas written */
-#define	WT_STAT_DSRC_REC_PAGE_DELTA_LEAF		2329
+#define	WT_STAT_DSRC_REC_PAGE_DELTA_LEAF		2328
 /*! reconciliation: leaf page multi-block writes */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_LEAF		2330
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_LEAF		2329
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_LEAF		2331
+#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_LEAF		2330
 /*! reconciliation: max deltas seen on internal page during reconciliation */
-#define	WT_STAT_DSRC_REC_MAX_INTERNAL_PAGE_DELTAS	2332
+#define	WT_STAT_DSRC_REC_MAX_INTERNAL_PAGE_DELTAS	2331
 /*! reconciliation: max deltas seen on leaf page during reconciliation */
-#define	WT_STAT_DSRC_REC_MAX_LEAF_PAGE_DELTAS		2333
+#define	WT_STAT_DSRC_REC_MAX_LEAF_PAGE_DELTAS		2332
 /*! reconciliation: maximum blocks required for a page */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_MAX			2334
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_MAX			2333
 /*!
  * reconciliation: number of keys that are garbage collected from the
  * disk images in the ingest btrees for disaggregated storage
  */
-#define	WT_STAT_DSRC_REC_INGEST_GARBAGE_COLLECTION_KEYS_DISK_IMAGE	2335
+#define	WT_STAT_DSRC_REC_INGEST_GARBAGE_COLLECTION_KEYS_DISK_IMAGE	2334
 /*!
  * reconciliation: number of keys that are garbage collected from the
  * update chains in the ingest btrees for disaggregated storage
  */
-#define	WT_STAT_DSRC_REC_INGEST_GARBAGE_COLLECTION_KEYS_UPDATE_CHAIN	2336
+#define	WT_STAT_DSRC_REC_INGEST_GARBAGE_COLLECTION_KEYS_UPDATE_CHAIN	2335
 /*! reconciliation: overflow values written */
-#define	WT_STAT_DSRC_REC_OVERFLOW_VALUE			2337
+#define	WT_STAT_DSRC_REC_OVERFLOW_VALUE			2336
 /*! reconciliation: page deltas rejected due to invalid page ID */
-#define	WT_STAT_DSRC_REC_PAGE_DELTA_REJECTED_INVALID_PAGE_ID	2338
+#define	WT_STAT_DSRC_REC_PAGE_DELTA_REJECTED_INVALID_PAGE_ID	2337
 /*! reconciliation: page deltas rejected due to max consecutive limit */
-#define	WT_STAT_DSRC_REC_PAGE_DELTA_REJECTED_MAX_CONSECUTIVE_EXCEEDED	2339
+#define	WT_STAT_DSRC_REC_PAGE_DELTA_REJECTED_MAX_CONSECUTIVE_EXCEEDED	2338
 /*! reconciliation: page deltas rejected due to multiblock reconciliation */
-#define	WT_STAT_DSRC_REC_PAGE_DELTA_REJECTED_MULTIBLOCK	2340
+#define	WT_STAT_DSRC_REC_PAGE_DELTA_REJECTED_MULTIBLOCK	2339
 /*!
  * reconciliation: page deltas rejected due to non-single page in
  * previous reconciliation
  */
-#define	WT_STAT_DSRC_REC_PAGE_DELTA_REJECTED_NON_SINGLE_PAGE	2341
+#define	WT_STAT_DSRC_REC_PAGE_DELTA_REJECTED_NON_SINGLE_PAGE	2340
 /*! reconciliation: page deltas rejected due to size threshold */
-#define	WT_STAT_DSRC_REC_PAGE_DELTA_REJECTED_SIZE_THRESHOLD	2342
+#define	WT_STAT_DSRC_REC_PAGE_DELTA_REJECTED_SIZE_THRESHOLD	2341
 /*! reconciliation: page deltas rejected due to zero entries */
-#define	WT_STAT_DSRC_REC_PAGE_DELTA_REJECTED_ZERO_ENTRIES	2343
+#define	WT_STAT_DSRC_REC_PAGE_DELTA_REJECTED_ZERO_ENTRIES	2342
 /*!
  * reconciliation: page deltas rejected: build function returned false
  * (disabled, in-memory split, or internal page constraints not met)
  */
-#define	WT_STAT_DSRC_REC_PAGE_DELTA_REJECTED_BUILD_FAILED	2344
+#define	WT_STAT_DSRC_REC_PAGE_DELTA_REJECTED_BUILD_FAILED	2343
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_DSRC_REC_PAGES				2345
+#define	WT_STAT_DSRC_REC_PAGES				2344
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_DSRC_REC_PAGES_EVICTION			2346
+#define	WT_STAT_DSRC_REC_PAGES_EVICTION			2345
 /*! reconciliation: page reconciliation calls for pages between 1 and 10MB */
-#define	WT_STAT_DSRC_REC_PAGES_SIZE_1MB_TO_10MB		2347
+#define	WT_STAT_DSRC_REC_PAGES_SIZE_1MB_TO_10MB		2346
 /*!
  * reconciliation: page reconciliation calls for pages between 10 and
  * 100MB
  */
-#define	WT_STAT_DSRC_REC_PAGES_SIZE_10MB_TO_100MB	2348
+#define	WT_STAT_DSRC_REC_PAGES_SIZE_10MB_TO_100MB	2347
 /*!
  * reconciliation: page reconciliation calls for pages between 100MB and
  * 1GB
  */
-#define	WT_STAT_DSRC_REC_PAGES_SIZE_100MB_TO_1GB	2349
+#define	WT_STAT_DSRC_REC_PAGES_SIZE_100MB_TO_1GB	2348
 /*! reconciliation: page reconciliation calls for pages over 1GB */
-#define	WT_STAT_DSRC_REC_PAGES_SIZE_1GB_PLUS		2350
+#define	WT_STAT_DSRC_REC_PAGES_SIZE_1GB_PLUS		2349
 /*! reconciliation: pages deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELETE			2351
+#define	WT_STAT_DSRC_REC_PAGE_DELETE			2350
 /*! reconciliation: pages eligible for delta generation */
-#define	WT_STAT_DSRC_REC_PAGE_DELTA_ELIGIBLE		2352
+#define	WT_STAT_DSRC_REC_PAGE_DELTA_ELIGIBLE		2351
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	2353
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	2352
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	2354
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	2353
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TS	2355
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TS	2354
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TXN	2356
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TXN	2355
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_TXN		2357
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_TXN		2356
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_OLDEST_START_TS	2358
+#define	WT_STAT_DSRC_REC_TIME_AGGR_OLDEST_START_TS	2357
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_PREPARED		2359
+#define	WT_STAT_DSRC_REC_TIME_AGGR_PREPARED		2358
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_PREPARED	2360
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_PREPARED	2359
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	2361
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	2360
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TS	2362
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TS	2361
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TXN	2363
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TXN	2362
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	2364
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	2363
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TS	2365
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TS	2364
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TXN	2366
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TXN	2365
 /*! reconciliation: pages written with at least one internal page delta */
-#define	WT_STAT_DSRC_REC_PAGES_WITH_INTERNAL_DELTAS	2367
+#define	WT_STAT_DSRC_REC_PAGES_WITH_INTERNAL_DELTAS	2366
 /*! reconciliation: pages written with at least one leaf page delta */
-#define	WT_STAT_DSRC_REC_PAGES_WITH_LEAF_DELTAS		2368
+#define	WT_STAT_DSRC_REC_PAGES_WITH_LEAF_DELTAS		2367
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PREPARED		2369
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PREPARED		2368
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_START_TS	2370
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_START_TS	2369
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TS		2371
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TS		2370
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TXN		2372
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TXN		2371
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_STOP_TS	2373
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_STOP_TS	2372
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TS		2374
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TS		2373
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TXN		2375
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TXN		2374
 /*! reconciliation: writes skipped in disaggregated storage */
-#define	WT_STAT_DSRC_REC_SKIP_WRITE			2376
+#define	WT_STAT_DSRC_REC_SKIP_WRITE			2375
 /*! session: object compaction */
-#define	WT_STAT_DSRC_SESSION_COMPACT			2377
+#define	WT_STAT_DSRC_SESSION_COMPACT			2376
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_COMMIT	2378
+#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_COMMIT	2377
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_DSRC_TXN_READ_OVERFLOW_REMOVE		2379
+#define	WT_STAT_DSRC_TXN_READ_OVERFLOW_REMOVE		2378
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_UPDATE	2380
+#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_UPDATE	2379
 /*! transaction: rollback to stable applied btrees */
-#define	WT_STAT_DSRC_TXN_RTS_BTREES_APPLIED		2381
+#define	WT_STAT_DSRC_TXN_RTS_BTREES_APPLIED		2380
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	2382
+#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	2381
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2383
+#define	WT_STAT_DSRC_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2382
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_DSRC_TXN_RTS_INCONSISTENT_CKPT		2384
+#define	WT_STAT_DSRC_TXN_RTS_INCONSISTENT_CKPT		2383
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED		2385
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED		2384
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED		2386
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED		2385
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED_DRYRUN	2387
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED_DRYRUN	2386
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED_DRYRUN	2388
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED_DRYRUN	2387
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES	2389
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES	2388
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES		2390
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES		2389
 /*! transaction: rollback to stable skipped btrees */
-#define	WT_STAT_DSRC_TXN_RTS_BTREES_SKIPPED		2391
+#define	WT_STAT_DSRC_TXN_RTS_BTREES_SKIPPED		2390
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_DSRC_TXN_RTS_DELETE_RLE_SKIPPED		2392
+#define	WT_STAT_DSRC_TXN_RTS_DELETE_RLE_SKIPPED		2391
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_DSRC_TXN_RTS_STABLE_RLE_SKIPPED		2393
+#define	WT_STAT_DSRC_TXN_RTS_STABLE_RLE_SKIPPED		2392
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS		2394
+#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS		2393
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	2395
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	2394
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	2396
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	2395
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED			2397
+#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED			2396
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED_DRYRUN		2398
+#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED_DRYRUN		2397
 /*! transaction: update conflicts */
-#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2399
+#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2398
 
 /*!
  * @}

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -8949,1171 +8949,1176 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_DSRC_BLOCK_ALLOC			2015
 /*! block-manager: blocks freed */
 #define	WT_STAT_DSRC_BLOCK_FREE				2016
+/*!
+ * block-manager: checkpoint reconciliation block manager duration
+ * (usecs)
+ */
+#define	WT_STAT_DSRC_BLOCK_CHECKPOINT_RECONCILE_DURATION	2017
 /*! block-manager: checkpoint size */
-#define	WT_STAT_DSRC_BLOCK_CHECKPOINT_SIZE		2017
+#define	WT_STAT_DSRC_BLOCK_CHECKPOINT_SIZE		2018
 /*! block-manager: file allocation unit size */
-#define	WT_STAT_DSRC_ALLOCATION_SIZE			2018
+#define	WT_STAT_DSRC_ALLOCATION_SIZE			2019
 /*! block-manager: file bytes available for reuse */
-#define	WT_STAT_DSRC_BLOCK_REUSE_BYTES			2019
+#define	WT_STAT_DSRC_BLOCK_REUSE_BYTES			2020
 /*! block-manager: file magic number */
-#define	WT_STAT_DSRC_BLOCK_MAGIC			2020
+#define	WT_STAT_DSRC_BLOCK_MAGIC			2021
 /*! block-manager: file major version number */
-#define	WT_STAT_DSRC_BLOCK_MAJOR			2021
+#define	WT_STAT_DSRC_BLOCK_MAJOR			2022
 /*! block-manager: file size in bytes */
-#define	WT_STAT_DSRC_BLOCK_SIZE				2022
+#define	WT_STAT_DSRC_BLOCK_SIZE				2023
 /*! block-manager: minor version number */
-#define	WT_STAT_DSRC_BLOCK_MINOR			2023
+#define	WT_STAT_DSRC_BLOCK_MINOR			2024
 /*! btree: btree checkpoint generation */
-#define	WT_STAT_DSRC_BTREE_CHECKPOINT_GENERATION	2024
+#define	WT_STAT_DSRC_BTREE_CHECKPOINT_GENERATION	2025
 /*! btree: btree clean tree checkpoint expiration time */
-#define	WT_STAT_DSRC_BTREE_CLEAN_CHECKPOINT_TIMER	2025
+#define	WT_STAT_DSRC_BTREE_CLEAN_CHECKPOINT_TIMER	2026
 /*! btree: btree compact pages reviewed */
-#define	WT_STAT_DSRC_BTREE_COMPACT_PAGES_REVIEWED	2026
+#define	WT_STAT_DSRC_BTREE_COMPACT_PAGES_REVIEWED	2027
 /*! btree: btree compact pages rewritten */
-#define	WT_STAT_DSRC_BTREE_COMPACT_PAGES_REWRITTEN	2027
+#define	WT_STAT_DSRC_BTREE_COMPACT_PAGES_REWRITTEN	2028
 /*! btree: btree compact pages skipped */
-#define	WT_STAT_DSRC_BTREE_COMPACT_PAGES_SKIPPED	2028
+#define	WT_STAT_DSRC_BTREE_COMPACT_PAGES_SKIPPED	2029
 /*! btree: btree expected number of compact bytes rewritten */
-#define	WT_STAT_DSRC_BTREE_COMPACT_BYTES_REWRITTEN_EXPECTED	2029
+#define	WT_STAT_DSRC_BTREE_COMPACT_BYTES_REWRITTEN_EXPECTED	2030
 /*! btree: btree expected number of compact pages rewritten */
-#define	WT_STAT_DSRC_BTREE_COMPACT_PAGES_REWRITTEN_EXPECTED	2030
+#define	WT_STAT_DSRC_BTREE_COMPACT_PAGES_REWRITTEN_EXPECTED	2031
 /*! btree: btree number of pages reconciled during checkpoint */
-#define	WT_STAT_DSRC_BTREE_CHECKPOINT_PAGES_RECONCILED	2031
+#define	WT_STAT_DSRC_BTREE_CHECKPOINT_PAGES_RECONCILED	2032
 /*! btree: btree skipped by compaction as process would not reduce size */
-#define	WT_STAT_DSRC_BTREE_COMPACT_SKIPPED		2032
+#define	WT_STAT_DSRC_BTREE_COMPACT_SKIPPED		2033
 /*! btree: checkpoint btree walk, construct and write duration (usecs) */
-#define	WT_STAT_DSRC_BTREE_CHECKPOINT_RECONCILE_DURATION	2033
+#define	WT_STAT_DSRC_BTREE_CHECKPOINT_RECONCILE_DURATION	2034
 /*!
  * btree: column-store internal pages, only reported if tree_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_COLUMN_INTERNAL		2034
+#define	WT_STAT_DSRC_BTREE_COLUMN_INTERNAL		2035
 /*!
  * btree: column-store variable-size RLE encoded values, only reported if
  * tree_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_COLUMN_RLE			2035
+#define	WT_STAT_DSRC_BTREE_COLUMN_RLE			2036
 /*!
  * btree: column-store variable-size deleted values, only reported if
  * tree_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_COLUMN_DELETED		2036
+#define	WT_STAT_DSRC_BTREE_COLUMN_DELETED		2037
 /*!
  * btree: column-store variable-size leaf pages, only reported if
  * tree_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_COLUMN_VARIABLE		2037
+#define	WT_STAT_DSRC_BTREE_COLUMN_VARIABLE		2038
 /*! btree: fixed-record size */
-#define	WT_STAT_DSRC_BTREE_FIXED_LEN			2038
+#define	WT_STAT_DSRC_BTREE_FIXED_LEN			2039
 /*! btree: maximum internal page size */
-#define	WT_STAT_DSRC_BTREE_MAXINTLPAGE			2039
+#define	WT_STAT_DSRC_BTREE_MAXINTLPAGE			2040
 /*! btree: maximum leaf page key size */
-#define	WT_STAT_DSRC_BTREE_MAXLEAFKEY			2040
+#define	WT_STAT_DSRC_BTREE_MAXLEAFKEY			2041
 /*! btree: maximum leaf page size */
-#define	WT_STAT_DSRC_BTREE_MAXLEAFPAGE			2041
+#define	WT_STAT_DSRC_BTREE_MAXLEAFPAGE			2042
 /*! btree: maximum leaf page value size */
-#define	WT_STAT_DSRC_BTREE_MAXLEAFVALUE			2042
+#define	WT_STAT_DSRC_BTREE_MAXLEAFVALUE			2043
 /*! btree: maximum tree depth */
-#define	WT_STAT_DSRC_BTREE_MAXIMUM_DEPTH		2043
+#define	WT_STAT_DSRC_BTREE_MAXIMUM_DEPTH		2044
 /*!
  * btree: number of key/value pairs, only reported if tree_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_ENTRIES			2044
+#define	WT_STAT_DSRC_BTREE_ENTRIES			2045
 /*!
  * btree: overflow pages, only reported if tree_walk or all statistics
  * are enabled
  */
-#define	WT_STAT_DSRC_BTREE_OVERFLOW			2045
+#define	WT_STAT_DSRC_BTREE_OVERFLOW			2046
 /*!
  * btree: row-store empty values, only reported if tree_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_ROW_EMPTY_VALUES		2046
+#define	WT_STAT_DSRC_BTREE_ROW_EMPTY_VALUES		2047
 /*!
  * btree: row-store internal pages, only reported if tree_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_ROW_INTERNAL			2047
+#define	WT_STAT_DSRC_BTREE_ROW_INTERNAL			2048
 /*!
  * btree: row-store leaf pages, only reported if tree_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_ROW_LEAF			2048
+#define	WT_STAT_DSRC_BTREE_ROW_LEAF			2049
 /*!
  * cache: application threads eviction requested with cache fill ratio <
  * 25%
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_APP_THREADS_FILL_RATIO_LT_25	2049
+#define	WT_STAT_DSRC_CACHE_EVICTION_APP_THREADS_FILL_RATIO_LT_25	2050
 /*!
  * cache: application threads eviction requested with cache fill ratio >=
  * 25% and < 50%
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_APP_THREADS_FILL_RATIO_25_50	2050
+#define	WT_STAT_DSRC_CACHE_EVICTION_APP_THREADS_FILL_RATIO_25_50	2051
 /*!
  * cache: application threads eviction requested with cache fill ratio >=
  * 50% and < 75%
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_APP_THREADS_FILL_RATIO_50_75	2051
+#define	WT_STAT_DSRC_CACHE_EVICTION_APP_THREADS_FILL_RATIO_50_75	2052
 /*!
  * cache: application threads eviction requested with cache fill ratio >=
  * 75%
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_APP_THREADS_FILL_RATIO_GT_75	2052
+#define	WT_STAT_DSRC_CACHE_EVICTION_APP_THREADS_FILL_RATIO_GT_75	2053
 /*!
  * cache: application threads eviction skip page with updates or dirty
  * page
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_APP_THREADS_SKIP_UPDATES_DIRTY_PAGE	2053
+#define	WT_STAT_DSRC_CACHE_EVICTION_APP_THREADS_SKIP_UPDATES_DIRTY_PAGE	2054
 /*! cache: bytes currently in the cache */
-#define	WT_STAT_DSRC_CACHE_BYTES_INUSE			2054
+#define	WT_STAT_DSRC_CACHE_BYTES_INUSE			2055
 /*! cache: bytes dirty in the cache cumulative */
-#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY_TOTAL		2055
+#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY_TOTAL		2056
 /*! cache: bytes read into cache */
-#define	WT_STAT_DSRC_CACHE_BYTES_READ			2056
+#define	WT_STAT_DSRC_CACHE_BYTES_READ			2057
 /*! cache: bytes written from cache */
-#define	WT_STAT_DSRC_CACHE_BYTES_WRITE			2057
+#define	WT_STAT_DSRC_CACHE_BYTES_WRITE			2058
 /*! cache: checkpoint blocked page eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_CHECKPOINT	2058
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_CHECKPOINT	2059
 /*!
  * cache: checkpoint of history store file blocked non-history store page
  * eviction
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_CHECKPOINT_HS	2059
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_CHECKPOINT_HS	2060
 /*! cache: data source pages selected for eviction unable to be evicted */
-#define	WT_STAT_DSRC_EVICTION_FAIL			2060
+#define	WT_STAT_DSRC_EVICTION_FAIL			2061
 /*! cache: dirty internal page cannot be evicted in disaggregated storage */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_DISAGG_DIRTY_INTERNAL_PAGE	2061
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_DISAGG_DIRTY_INTERNAL_PAGE	2062
 /*!
  * cache: eviction gave up due to detecting a disk value without a
  * timestamp behind the last update on the chain
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_1	2062
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_1	2063
 /*!
  * cache: eviction gave up due to detecting a tombstone without a
  * timestamp ahead of the selected on disk update
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_2	2063
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_2	2064
 /*!
  * cache: eviction gave up due to detecting a tombstone without a
  * timestamp ahead of the selected on disk update after validating the
  * update chain
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_3	2064
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_3	2065
 /*!
  * cache: eviction gave up due to detecting update chain entries without
  * timestamps after the selected on disk update
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_4	2065
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_4	2066
 /*!
  * cache: eviction gave up due to needing to remove a record from the
  * history store but checkpoint is running
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_REMOVE_HS_RACE_WITH_CHECKPOINT	2066
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_REMOVE_HS_RACE_WITH_CHECKPOINT	2067
 /*! cache: eviction gave up due to no progress being made */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_NO_PROGRESS	2067
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_NO_PROGRESS	2068
 /*! cache: eviction server skipped the pages when prefetching */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_PREFETCHED	2068
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_PREFETCHED	2069
 /*! cache: eviction walk pages queued that had updates */
-#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_QUEUED_UPDATES	2069
+#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_QUEUED_UPDATES	2070
 /*! cache: eviction walk pages queued that were clean */
-#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_QUEUED_CLEAN	2070
+#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_QUEUED_CLEAN	2071
 /*! cache: eviction walk pages queued that were dirty */
-#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_QUEUED_DIRTY	2071
+#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_QUEUED_DIRTY	2072
 /*! cache: eviction walk pages seen that had updates */
-#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_SEEN_UPDATES	2072
+#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_SEEN_UPDATES	2073
 /*! cache: eviction walk pages seen that were clean */
-#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_SEEN_CLEAN	2073
+#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_SEEN_CLEAN	2074
 /*! cache: eviction walk pages seen that were dirty */
-#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_SEEN_DIRTY	2074
+#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_SEEN_DIRTY	2075
 /*! cache: eviction walk passes of a file */
-#define	WT_STAT_DSRC_EVICTION_WALK_PASSES		2075
+#define	WT_STAT_DSRC_EVICTION_WALK_PASSES		2076
 /*! cache: eviction walk target pages histogram - 0-9 */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT10	2076
+#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT10	2077
 /*! cache: eviction walk target pages histogram - 10-31 */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT32	2077
+#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT32	2078
 /*! cache: eviction walk target pages histogram - 128 and higher */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_GE128	2078
+#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_GE128	2079
 /*! cache: eviction walk target pages histogram - 32-63 */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT64	2079
+#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT64	2080
 /*! cache: eviction walk target pages histogram - 64-128 */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT128	2080
+#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT128	2081
 /*!
  * cache: eviction walk target pages reduced due to history store cache
  * pressure
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_REDUCED	2081
+#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_REDUCED	2082
 /*!
  * cache: garbage collection from the ingest btree page is skipped
  * because the prune timestamp has not moved
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_PRUNE_TIMESTAMP	2082
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_PRUNE_TIMESTAMP	2083
 /*! cache: hazard pointer blocked page eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_HAZARD	2083
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_HAZARD	2084
 /*! cache: history store cursor not cached during eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_HS_CURSOR_NOT_CACHED	2084
+#define	WT_STAT_DSRC_CACHE_EVICTION_HS_CURSOR_NOT_CACHED	2085
 /*! cache: history store table insert calls */
-#define	WT_STAT_DSRC_CACHE_HS_INSERT			2085
+#define	WT_STAT_DSRC_CACHE_HS_INSERT			2086
 /*! cache: history store table insert calls that returned restart */
-#define	WT_STAT_DSRC_CACHE_HS_INSERT_RESTART		2086
+#define	WT_STAT_DSRC_CACHE_HS_INSERT_RESTART		2087
 /*! cache: history store table key to be processed */
-#define	WT_STAT_DSRC_CACHE_HS_KEY_PROCESSED		2087
+#define	WT_STAT_DSRC_CACHE_HS_KEY_PROCESSED		2088
 /*! cache: history store table reads */
-#define	WT_STAT_DSRC_CACHE_HS_READ			2088
+#define	WT_STAT_DSRC_CACHE_HS_READ			2089
 /*! cache: history store table reads missed */
-#define	WT_STAT_DSRC_CACHE_HS_READ_MISS			2089
+#define	WT_STAT_DSRC_CACHE_HS_READ_MISS			2090
 /*! cache: history store table reads requiring squashed modifies */
-#define	WT_STAT_DSRC_CACHE_HS_READ_SQUASH		2090
+#define	WT_STAT_DSRC_CACHE_HS_READ_SQUASH		2091
 /*!
  * cache: history store table resolved updates without timestamps that
  * lose their durable timestamp
  */
-#define	WT_STAT_DSRC_CACHE_HS_ORDER_LOSE_DURABLE_TIMESTAMP	2091
+#define	WT_STAT_DSRC_CACHE_HS_ORDER_LOSE_DURABLE_TIMESTAMP	2092
 /*!
  * cache: history store table truncation by rollback to stable to remove
  * an unstable update
  */
-#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE	2092
+#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE	2093
 /*!
  * cache: history store table truncation by rollback to stable to remove
  * an update
  */
-#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_RTS		2093
+#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_RTS		2094
 /*!
  * cache: history store table truncation to remove all the keys of a
  * btree
  */
-#define	WT_STAT_DSRC_CACHE_HS_BTREE_TRUNCATE		2094
+#define	WT_STAT_DSRC_CACHE_HS_BTREE_TRUNCATE		2095
 /*! cache: history store table truncation to remove an update */
-#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE		2095
+#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE		2096
 /*!
  * cache: history store table truncation to remove range of updates due
  * to an update without a timestamp on data page
  */
-#define	WT_STAT_DSRC_CACHE_HS_ORDER_REMOVE		2096
+#define	WT_STAT_DSRC_CACHE_HS_ORDER_REMOVE		2097
 /*!
  * cache: history store table truncation to remove range of updates due
  * to key being removed from the data page during reconciliation
  */
-#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_ONPAGE_REMOVAL	2097
+#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_ONPAGE_REMOVAL	2098
 /*!
  * cache: history store table truncations that would have happened in
  * non-dryrun mode
  */
-#define	WT_STAT_DSRC_CACHE_HS_BTREE_TRUNCATE_DRYRUN	2098
+#define	WT_STAT_DSRC_CACHE_HS_BTREE_TRUNCATE_DRYRUN	2099
 /*!
  * cache: history store table truncations to remove an unstable update
  * that would have happened in non-dryrun mode
  */
-#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE_DRYRUN	2099
+#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE_DRYRUN	2100
 /*!
  * cache: history store table truncations to remove an update that would
  * have happened in non-dryrun mode
  */
-#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_RTS_DRYRUN	2100
+#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_RTS_DRYRUN	2101
 /*! cache: history store table update to be processed */
-#define	WT_STAT_DSRC_CACHE_HS_UPDATE_PROCESSED		2101
+#define	WT_STAT_DSRC_CACHE_HS_UPDATE_PROCESSED		2102
 /*!
  * cache: history store table updates without timestamps fixed up by
  * reinserting with the fixed timestamp
  */
-#define	WT_STAT_DSRC_CACHE_HS_ORDER_REINSERT		2102
+#define	WT_STAT_DSRC_CACHE_HS_ORDER_REINSERT		2103
 /*! cache: history store table writes requiring squashed modifies */
-#define	WT_STAT_DSRC_CACHE_HS_WRITE_SQUASH		2103
+#define	WT_STAT_DSRC_CACHE_HS_WRITE_SQUASH		2104
 /*! cache: in-memory page passed criteria to be split */
-#define	WT_STAT_DSRC_CACHE_INMEM_SPLITTABLE		2104
+#define	WT_STAT_DSRC_CACHE_INMEM_SPLITTABLE		2105
 /*! cache: in-memory page splits */
-#define	WT_STAT_DSRC_CACHE_INMEM_SPLIT			2105
+#define	WT_STAT_DSRC_CACHE_INMEM_SPLIT			2106
 /*! cache: internal page split blocked its eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_INTERNAL_PAGE_SPLIT	2106
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_INTERNAL_PAGE_SPLIT	2107
 /*! cache: internal pages evicted */
-#define	WT_STAT_DSRC_CACHE_EVICTION_INTERNAL		2107
+#define	WT_STAT_DSRC_CACHE_EVICTION_INTERNAL		2108
 /*! cache: internal pages split during eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_SPLIT_INTERNAL	2108
+#define	WT_STAT_DSRC_CACHE_EVICTION_SPLIT_INTERNAL	2109
 /*! cache: leaf pages split during eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_SPLIT_LEAF		2109
+#define	WT_STAT_DSRC_CACHE_EVICTION_SPLIT_LEAF		2110
 /*!
  * cache: locate a random in-mem ref by examining all entries on the root
  * page
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_RANDOM_SAMPLE_INMEM_ROOT	2110
+#define	WT_STAT_DSRC_CACHE_EVICTION_RANDOM_SAMPLE_INMEM_ROOT	2111
 /*! cache: modified pages evicted */
-#define	WT_STAT_DSRC_CACHE_EVICTION_DIRTY		2111
+#define	WT_STAT_DSRC_CACHE_EVICTION_DIRTY		2112
 /*! cache: multi-block reconciliation blocked whilst checkpoint is running */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_MULTI_BLOCK_RECONCILIATION_DURING_CHECKPOINT	2112
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_MULTI_BLOCK_RECONCILIATION_DURING_CHECKPOINT	2113
 /*! cache: number of internal pages read that had deltas attached */
-#define	WT_STAT_DSRC_CACHE_READ_INTERNAL_DELTA		2113
+#define	WT_STAT_DSRC_CACHE_READ_INTERNAL_DELTA		2114
 /*! cache: number of leaf pages read that had deltas attached */
-#define	WT_STAT_DSRC_CACHE_READ_LEAF_DELTA		2114
+#define	WT_STAT_DSRC_CACHE_READ_LEAF_DELTA		2115
 /*! cache: number of times dirty trigger was reached */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TRIGGER_DIRTY_REACHED	2115
+#define	WT_STAT_DSRC_CACHE_EVICTION_TRIGGER_DIRTY_REACHED	2116
 /*! cache: number of times eviction trigger was reached */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TRIGGER_REACHED	2116
+#define	WT_STAT_DSRC_CACHE_EVICTION_TRIGGER_REACHED	2117
 /*! cache: number of times updates trigger was reached */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TRIGGER_UPDATES_REACHED	2117
+#define	WT_STAT_DSRC_CACHE_EVICTION_TRIGGER_UPDATES_REACHED	2118
 /*! cache: number of times when cas update the btree max_lsn failed */
-#define	WT_STAT_DSRC_CACHE_CAS_BTREE_MAX_LSN_RACE	2118
+#define	WT_STAT_DSRC_CACHE_CAS_BTREE_MAX_LSN_RACE	2119
 /*! cache: obsolete updates removed */
-#define	WT_STAT_DSRC_CACHE_OBSOLETE_UPDATES_REMOVED	2119
+#define	WT_STAT_DSRC_CACHE_OBSOLETE_UPDATES_REMOVED	2120
 /*!
  * cache: overflow keys on a multiblock row-store page blocked its
  * eviction
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_OVERFLOW_KEYS	2120
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_OVERFLOW_KEYS	2121
 /*! cache: overflow pages read into cache */
-#define	WT_STAT_DSRC_CACHE_READ_OVERFLOW		2121
+#define	WT_STAT_DSRC_CACHE_READ_OVERFLOW		2122
 /*! cache: page eviction blocked due to materialization frontier */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_MATERIALIZATION	2122
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_MATERIALIZATION	2123
 /*!
  * cache: page eviction blocked in disaggregated storage as it can only
  * be written by the next checkpoint
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_DISAGG_NEXT_CHECKPOINT	2123
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_DISAGG_NEXT_CHECKPOINT	2124
 /*! cache: page split during eviction deepened the tree */
-#define	WT_STAT_DSRC_CACHE_EVICTION_DEEPEN		2124
+#define	WT_STAT_DSRC_CACHE_EVICTION_DEEPEN		2125
 /*! cache: page written requiring history store records */
-#define	WT_STAT_DSRC_CACHE_WRITE_HS			2125
+#define	WT_STAT_DSRC_CACHE_WRITE_HS			2126
 /*! cache: pages dirtied due to obsolete time window by eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_DIRTY_OBSOLETE_TW	2126
+#define	WT_STAT_DSRC_CACHE_EVICTION_DIRTY_OBSOLETE_TW	2127
 /*! cache: pages evicted ahead of the page materialization frontier */
-#define	WT_STAT_DSRC_CACHE_EVICTION_AHEAD_OF_LAST_MATERIALIZED_LSN	2127
+#define	WT_STAT_DSRC_CACHE_EVICTION_AHEAD_OF_LAST_MATERIALIZED_LSN	2128
 /*! cache: pages read into cache */
-#define	WT_STAT_DSRC_CACHE_READ				2128
+#define	WT_STAT_DSRC_CACHE_READ				2129
 /*! cache: pages read into cache after truncate */
-#define	WT_STAT_DSRC_CACHE_READ_DELETED			2129
+#define	WT_STAT_DSRC_CACHE_READ_DELETED			2130
 /*! cache: pages read into cache after truncate in prepare state */
-#define	WT_STAT_DSRC_CACHE_READ_DELETED_PREPARED	2130
+#define	WT_STAT_DSRC_CACHE_READ_DELETED_PREPARED	2131
 /*! cache: pages read into cache by checkpoint */
-#define	WT_STAT_DSRC_CACHE_READ_CHECKPOINT		2131
+#define	WT_STAT_DSRC_CACHE_READ_CHECKPOINT		2132
 /*! cache: pages requested from the cache */
-#define	WT_STAT_DSRC_CACHE_PAGES_REQUESTED		2132
+#define	WT_STAT_DSRC_CACHE_PAGES_REQUESTED		2133
 /*! cache: pages requested from the cache due to pre-fetch */
-#define	WT_STAT_DSRC_CACHE_PAGES_PREFETCH		2133
+#define	WT_STAT_DSRC_CACHE_PAGES_PREFETCH		2134
 /*! cache: pages requested from the cache internal */
-#define	WT_STAT_DSRC_CACHE_PAGES_REQUESTED_INTERNAL	2134
+#define	WT_STAT_DSRC_CACHE_PAGES_REQUESTED_INTERNAL	2135
 /*! cache: pages requested from the cache leaf */
-#define	WT_STAT_DSRC_CACHE_PAGES_REQUESTED_LEAF		2135
+#define	WT_STAT_DSRC_CACHE_PAGES_REQUESTED_LEAF		2136
 /*! cache: pages requested from the history store */
-#define	WT_STAT_DSRC_CACHE_PAGES_REQUESTED_HS		2136
+#define	WT_STAT_DSRC_CACHE_PAGES_REQUESTED_HS		2137
 /*! cache: pages seen by eviction walk */
-#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_SEEN		2137
+#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_SEEN		2138
 /*! cache: pages written from cache */
-#define	WT_STAT_DSRC_CACHE_WRITE			2138
+#define	WT_STAT_DSRC_CACHE_WRITE			2139
 /*!
  * cache: pages written requiring in-memory restoration due to invisible
  * updates
  */
-#define	WT_STAT_DSRC_CACHE_WRITE_RESTORE_INVISIBLE	2139
+#define	WT_STAT_DSRC_CACHE_WRITE_RESTORE_INVISIBLE	2140
 /*!
  * cache: pages written requiring in-memory restoration due to scrub
  * eviction
  */
-#define	WT_STAT_DSRC_CACHE_WRITE_RESTORE_SCRUB		2140
+#define	WT_STAT_DSRC_CACHE_WRITE_RESTORE_SCRUB		2141
 /*!
  * cache: precise checkpoint caused an eviction to be skipped because any
  * dirty content needs to remain in cache
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_PRECISE_CHECKPOINT	2141
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_PRECISE_CHECKPOINT	2142
 /*!
  * cache: realizing in-memory split after reconciliation failed due to
  * internal lock busy
  */
-#define	WT_STAT_DSRC_CACHE_EVICT_SPLIT_FAILED_LOCK	2142
+#define	WT_STAT_DSRC_CACHE_EVICT_SPLIT_FAILED_LOCK	2143
 /*! cache: recent modification of a page blocked its eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	2143
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	2144
 /*! cache: reconciled pages scrubbed and added back to the cache clean */
-#define	WT_STAT_DSRC_CACHE_SCRUB_RESTORE		2144
+#define	WT_STAT_DSRC_CACHE_SCRUB_RESTORE		2145
 /*! cache: reverse splits performed */
-#define	WT_STAT_DSRC_CACHE_REVERSE_SPLITS		2145
+#define	WT_STAT_DSRC_CACHE_REVERSE_SPLITS		2146
 /*!
  * cache: reverse splits skipped because of VLCS namespace gap
  * restrictions
  */
-#define	WT_STAT_DSRC_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	2146
+#define	WT_STAT_DSRC_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	2147
 /*! cache: shared history store cursor not cached during eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_HS_SHARED_CURSOR_NOT_CACHED	2147
+#define	WT_STAT_DSRC_CACHE_EVICTION_HS_SHARED_CURSOR_NOT_CACHED	2148
 /*! cache: size of delta updates reconstructed on the base page */
-#define	WT_STAT_DSRC_CACHE_READ_DELTA_UPDATES		2148
+#define	WT_STAT_DSRC_CACHE_READ_DELTA_UPDATES		2149
 /*! cache: size of tombstones restored when reading a page */
-#define	WT_STAT_DSRC_CACHE_READ_RESTORED_TOMBSTONE_BYTES	2149
+#define	WT_STAT_DSRC_CACHE_READ_RESTORED_TOMBSTONE_BYTES	2150
 /*! cache: the number of times full update inserted to history store */
-#define	WT_STAT_DSRC_CACHE_HS_INSERT_FULL_UPDATE	2150
+#define	WT_STAT_DSRC_CACHE_HS_INSERT_FULL_UPDATE	2151
 /*! cache: the number of times reverse modify inserted to history store */
-#define	WT_STAT_DSRC_CACHE_HS_INSERT_REVERSE_MODIFY	2151
+#define	WT_STAT_DSRC_CACHE_HS_INSERT_REVERSE_MODIFY	2152
 /*! cache: tracked dirty bytes in the cache */
-#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY			2152
+#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY			2153
 /*! cache: tracked dirty internal page bytes in the cache */
-#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY_INTERNAL		2153
+#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY_INTERNAL		2154
 /*! cache: tracked dirty leaf page bytes in the cache */
-#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY_LEAF		2154
+#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY_LEAF		2155
 /*! cache: uncommitted truncate blocked page eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	2155
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	2156
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_DSRC_CACHE_EVICTION_CLEAN		2156
+#define	WT_STAT_DSRC_CACHE_EVICTION_CLEAN		2157
 /*!
  * cache_walk: Average difference between current eviction generation
  * when the page was last considered, only reported if cache_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_GEN_AVG_GAP		2157
+#define	WT_STAT_DSRC_CACHE_STATE_GEN_AVG_GAP		2158
 /*!
  * cache_walk: Average on-disk page image size seen, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_AVG_WRITTEN_SIZE	2158
+#define	WT_STAT_DSRC_CACHE_STATE_AVG_WRITTEN_SIZE	2159
 /*!
  * cache_walk: Average time in cache for pages that have been visited by
  * the eviction server, only reported if cache_walk or all statistics are
  * enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_AVG_VISITED_AGE	2159
+#define	WT_STAT_DSRC_CACHE_STATE_AVG_VISITED_AGE	2160
 /*!
  * cache_walk: Average time in cache for pages that have not been visited
  * by the eviction server, only reported if cache_walk or all statistics
  * are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_AVG_UNVISITED_AGE	2160
+#define	WT_STAT_DSRC_CACHE_STATE_AVG_UNVISITED_AGE	2161
 /*!
  * cache_walk: Clean pages currently in cache, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES_CLEAN		2161
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES_CLEAN		2162
 /*!
  * cache_walk: Current eviction generation, only reported if cache_walk
  * or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_GEN_CURRENT		2162
+#define	WT_STAT_DSRC_CACHE_STATE_GEN_CURRENT		2163
 /*!
  * cache_walk: Dirty pages currently in cache, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES_DIRTY		2163
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES_DIRTY		2164
 /*!
  * cache_walk: Entries in the root page, only reported if cache_walk or
  * all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_ROOT_ENTRIES		2164
+#define	WT_STAT_DSRC_CACHE_STATE_ROOT_ENTRIES		2165
 /*!
  * cache_walk: Internal pages currently in cache, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES_INTERNAL		2165
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES_INTERNAL		2166
 /*!
  * cache_walk: Leaf pages currently in cache, only reported if cache_walk
  * or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES_LEAF		2166
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES_LEAF		2167
 /*!
  * cache_walk: Maximum difference between current eviction generation
  * when the page was last considered, only reported if cache_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_GEN_MAX_GAP		2167
+#define	WT_STAT_DSRC_CACHE_STATE_GEN_MAX_GAP		2168
 /*!
  * cache_walk: Maximum page size seen, only reported if cache_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_MAX_PAGESIZE		2168
+#define	WT_STAT_DSRC_CACHE_STATE_MAX_PAGESIZE		2169
 /*!
  * cache_walk: Minimum on-disk page image size seen, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_MIN_WRITTEN_SIZE	2169
+#define	WT_STAT_DSRC_CACHE_STATE_MIN_WRITTEN_SIZE	2170
 /*!
  * cache_walk: Number of pages never visited by eviction server, only
  * reported if cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_UNVISITED_COUNT	2170
+#define	WT_STAT_DSRC_CACHE_STATE_UNVISITED_COUNT	2171
 /*!
  * cache_walk: On-disk page image sizes smaller than a single allocation
  * unit, only reported if cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_SMALLER_ALLOC_SIZE	2171
+#define	WT_STAT_DSRC_CACHE_STATE_SMALLER_ALLOC_SIZE	2172
 /*!
  * cache_walk: Pages created in memory and never written, only reported
  * if cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_MEMORY			2172
+#define	WT_STAT_DSRC_CACHE_STATE_MEMORY			2173
 /*!
  * cache_walk: Pages currently queued for eviction, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_QUEUED			2173
+#define	WT_STAT_DSRC_CACHE_STATE_QUEUED			2174
 /*!
  * cache_walk: Pages that could not be queued for eviction, only reported
  * if cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_NOT_QUEUEABLE		2174
+#define	WT_STAT_DSRC_CACHE_STATE_NOT_QUEUEABLE		2175
 /*!
  * cache_walk: Refs skipped during cache traversal, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_REFS_SKIPPED		2175
+#define	WT_STAT_DSRC_CACHE_STATE_REFS_SKIPPED		2176
 /*!
  * cache_walk: Size of the root page, only reported if cache_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_ROOT_SIZE		2176
+#define	WT_STAT_DSRC_CACHE_STATE_ROOT_SIZE		2177
 /*!
  * cache_walk: Total number of pages currently in cache, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES			2177
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES			2178
 /*! checkpoint-cleanup: pages added for eviction */
-#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_EVICT	2178
+#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_EVICT	2179
 /*! checkpoint-cleanup: pages dirtied due to obsolete time window */
-#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	2179
+#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	2180
 /*! checkpoint-cleanup: pages read into cache (reclaim_space) */
-#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	2180
+#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	2181
 /*! checkpoint-cleanup: pages read into cache due to obsolete time window */
-#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	2181
+#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	2182
 /*! checkpoint-cleanup: pages removed */
-#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_REMOVED	2182
+#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_REMOVED	2183
 /*! checkpoint-cleanup: pages skipped during tree walk */
-#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	2183
+#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	2184
 /*! checkpoint-cleanup: pages visited */
-#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_VISITED	2184
+#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_VISITED	2185
 /*! checkpoint: checkpoint has acquired a snapshot for its transaction */
-#define	WT_STAT_DSRC_CHECKPOINT_SNAPSHOT_ACQUIRED	2185
+#define	WT_STAT_DSRC_CHECKPOINT_SNAPSHOT_ACQUIRED	2186
 /*!
  * compression: compressed page maximum internal page size prior to
  * compression
  */
-#define	WT_STAT_DSRC_COMPRESS_PRECOMP_INTL_MAX_PAGE_SIZE	2186
+#define	WT_STAT_DSRC_COMPRESS_PRECOMP_INTL_MAX_PAGE_SIZE	2187
 /*!
  * compression: compressed page maximum leaf page size prior to
  * compression
  */
-#define	WT_STAT_DSRC_COMPRESS_PRECOMP_LEAF_MAX_PAGE_SIZE	2187
+#define	WT_STAT_DSRC_COMPRESS_PRECOMP_LEAF_MAX_PAGE_SIZE	2188
 /*! compression: page written to disk failed to compress */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_FAIL		2188
+#define	WT_STAT_DSRC_COMPRESS_WRITE_FAIL		2189
 /*! compression: page written to disk was too small to compress */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_TOO_SMALL		2189
+#define	WT_STAT_DSRC_COMPRESS_WRITE_TOO_SMALL		2190
 /*! compression: pages read from disk */
-#define	WT_STAT_DSRC_COMPRESS_READ			2190
+#define	WT_STAT_DSRC_COMPRESS_READ			2191
 /*!
  * compression: pages read from disk with compression ratio greater than
  * 64
  */
-#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_MAX	2191
+#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_MAX	2192
 /*!
  * compression: pages read from disk with compression ratio smaller than
  * 2
  */
-#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_2		2192
+#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_2		2193
 /*!
  * compression: pages read from disk with compression ratio smaller than
  * 4
  */
-#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_4		2193
+#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_4		2194
 /*!
  * compression: pages read from disk with compression ratio smaller than
  * 8
  */
-#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_8		2194
+#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_8		2195
 /*!
  * compression: pages read from disk with compression ratio smaller than
  * 16
  */
-#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_16	2195
+#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_16	2196
 /*!
  * compression: pages read from disk with compression ratio smaller than
  * 32
  */
-#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_32	2196
+#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_32	2197
 /*!
  * compression: pages read from disk with compression ratio smaller than
  * 64
  */
-#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_64	2197
+#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_64	2198
 /*! compression: pages written to disk */
-#define	WT_STAT_DSRC_COMPRESS_WRITE			2198
+#define	WT_STAT_DSRC_COMPRESS_WRITE			2199
 /*!
  * compression: pages written to disk with compression ratio greater than
  * 64
  */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_MAX	2199
+#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_MAX	2200
 /*!
  * compression: pages written to disk with compression ratio smaller than
  * 2
  */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_2	2200
+#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_2	2201
 /*!
  * compression: pages written to disk with compression ratio smaller than
  * 4
  */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_4	2201
+#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_4	2202
 /*!
  * compression: pages written to disk with compression ratio smaller than
  * 8
  */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_8	2202
+#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_8	2203
 /*!
  * compression: pages written to disk with compression ratio smaller than
  * 16
  */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_16	2203
+#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_16	2204
 /*!
  * compression: pages written to disk with compression ratio smaller than
  * 32
  */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_32	2204
+#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_32	2205
 /*!
  * compression: pages written to disk with compression ratio smaller than
  * 64
  */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_64	2205
+#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_64	2206
 /*! cursor: Total number of deleted pages skipped during tree walk */
-#define	WT_STAT_DSRC_CURSOR_TREE_WALK_DEL_PAGE_SKIP	2206
+#define	WT_STAT_DSRC_CURSOR_TREE_WALK_DEL_PAGE_SKIP	2207
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_TOTAL		2207
+#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_TOTAL		2208
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_TOTAL		2208
+#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_TOTAL		2209
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_DSRC_CURSOR_SKIP_HS_CUR_POSITION	2209
+#define	WT_STAT_DSRC_CURSOR_SKIP_HS_CUR_POSITION	2210
 /*!
  * cursor: Total number of in-memory deleted pages skipped during tree
  * walk
  */
-#define	WT_STAT_DSRC_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	2210
+#define	WT_STAT_DSRC_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	2211
 /*! cursor: Total number of on-disk deleted pages skipped during tree walk */
-#define	WT_STAT_DSRC_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	2211
+#define	WT_STAT_DSRC_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	2212
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	2212
+#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	2213
 /*!
  * cursor: Total number of times cursor fails to temporarily release
  * pinned page to encourage eviction of hot or large page
  */
-#define	WT_STAT_DSRC_CURSOR_REPOSITION_FAILED		2213
+#define	WT_STAT_DSRC_CURSOR_REPOSITION_FAILED		2214
 /*!
  * cursor: Total number of times cursor temporarily releases pinned page
  * to encourage eviction of hot or large page
  */
-#define	WT_STAT_DSRC_CURSOR_REPOSITION			2214
+#define	WT_STAT_DSRC_CURSOR_REPOSITION			2215
 /*! cursor: bulk loaded cursor insert calls */
-#define	WT_STAT_DSRC_CURSOR_INSERT_BULK			2215
+#define	WT_STAT_DSRC_CURSOR_INSERT_BULK			2216
 /*! cursor: cache cursors reuse count */
-#define	WT_STAT_DSRC_CURSOR_REOPEN			2216
+#define	WT_STAT_DSRC_CURSOR_REOPEN			2217
 /*! cursor: close calls that result in cache */
-#define	WT_STAT_DSRC_CURSOR_CACHE			2217
+#define	WT_STAT_DSRC_CURSOR_CACHE			2218
 /*! cursor: create calls */
-#define	WT_STAT_DSRC_CURSOR_CREATE			2218
+#define	WT_STAT_DSRC_CURSOR_CREATE			2219
 /*! cursor: cursor bound calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_BOUND_ERROR			2219
+#define	WT_STAT_DSRC_CURSOR_BOUND_ERROR			2220
 /*! cursor: cursor bounds cleared from reset */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_RESET		2220
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_RESET		2221
 /*! cursor: cursor bounds comparisons performed */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_COMPARISONS		2221
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_COMPARISONS		2222
 /*! cursor: cursor bounds next called on an unpositioned cursor */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_NEXT_UNPOSITIONED	2222
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_NEXT_UNPOSITIONED	2223
 /*! cursor: cursor bounds next early exit */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_NEXT_EARLY_EXIT	2223
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_NEXT_EARLY_EXIT	2224
 /*! cursor: cursor bounds prev called on an unpositioned cursor */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_PREV_UNPOSITIONED	2224
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_PREV_UNPOSITIONED	2225
 /*! cursor: cursor bounds prev early exit */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_PREV_EARLY_EXIT	2225
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_PREV_EARLY_EXIT	2226
 /*! cursor: cursor bounds search early exit */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	2226
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	2227
 /*! cursor: cursor bounds search near call repositioned cursor */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	2227
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	2228
 /*! cursor: cursor cache calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_CACHE_ERROR			2228
+#define	WT_STAT_DSRC_CURSOR_CACHE_ERROR			2229
 /*! cursor: cursor close calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_CLOSE_ERROR			2229
+#define	WT_STAT_DSRC_CURSOR_CLOSE_ERROR			2230
 /*! cursor: cursor compare calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_COMPARE_ERROR		2230
+#define	WT_STAT_DSRC_CURSOR_COMPARE_ERROR		2231
 /*! cursor: cursor equals calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_EQUALS_ERROR		2231
+#define	WT_STAT_DSRC_CURSOR_EQUALS_ERROR		2232
 /*! cursor: cursor get key calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_GET_KEY_ERROR		2232
+#define	WT_STAT_DSRC_CURSOR_GET_KEY_ERROR		2233
 /*! cursor: cursor get value calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_GET_VALUE_ERROR		2233
+#define	WT_STAT_DSRC_CURSOR_GET_VALUE_ERROR		2234
 /*! cursor: cursor insert calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_INSERT_ERROR		2234
+#define	WT_STAT_DSRC_CURSOR_INSERT_ERROR		2235
 /*! cursor: cursor insert check calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_INSERT_CHECK_ERROR		2235
+#define	WT_STAT_DSRC_CURSOR_INSERT_CHECK_ERROR		2236
 /*! cursor: cursor largest key calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_LARGEST_KEY_ERROR		2236
+#define	WT_STAT_DSRC_CURSOR_LARGEST_KEY_ERROR		2237
 /*! cursor: cursor modify calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_MODIFY_ERROR		2237
+#define	WT_STAT_DSRC_CURSOR_MODIFY_ERROR		2238
 /*! cursor: cursor next calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_NEXT_ERROR			2238
+#define	WT_STAT_DSRC_CURSOR_NEXT_ERROR			2239
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_DSRC_CURSOR_NEXT_HS_TOMBSTONE		2239
+#define	WT_STAT_DSRC_CURSOR_NEXT_HS_TOMBSTONE		2240
 /*!
  * cursor: cursor next calls that skip greater than 1 and fewer than 100
  * entries
  */
-#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_LT_100		2240
+#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_LT_100		2241
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_GE_100		2241
+#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_GE_100		2242
 /*! cursor: cursor next random calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_NEXT_RANDOM_ERROR		2242
+#define	WT_STAT_DSRC_CURSOR_NEXT_RANDOM_ERROR		2243
 /*! cursor: cursor prev calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_PREV_ERROR			2243
+#define	WT_STAT_DSRC_CURSOR_PREV_ERROR			2244
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_DSRC_CURSOR_PREV_HS_TOMBSTONE		2244
+#define	WT_STAT_DSRC_CURSOR_PREV_HS_TOMBSTONE		2245
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_GE_100		2245
+#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_GE_100		2246
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_LT_100		2246
+#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_LT_100		2247
 /*! cursor: cursor reconfigure calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_RECONFIGURE_ERROR		2247
+#define	WT_STAT_DSRC_CURSOR_RECONFIGURE_ERROR		2248
 /*! cursor: cursor remove calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_REMOVE_ERROR		2248
+#define	WT_STAT_DSRC_CURSOR_REMOVE_ERROR		2249
 /*! cursor: cursor reopen calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_REOPEN_ERROR		2249
+#define	WT_STAT_DSRC_CURSOR_REOPEN_ERROR		2250
 /*! cursor: cursor reserve calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_RESERVE_ERROR		2250
+#define	WT_STAT_DSRC_CURSOR_RESERVE_ERROR		2251
 /*! cursor: cursor reset calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_RESET_ERROR			2251
+#define	WT_STAT_DSRC_CURSOR_RESET_ERROR			2252
 /*! cursor: cursor search calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_ERROR		2252
+#define	WT_STAT_DSRC_CURSOR_SEARCH_ERROR		2253
 /*! cursor: cursor search near calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR_ERROR		2253
+#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR_ERROR		2254
 /*! cursor: cursor update calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_UPDATE_ERROR		2254
+#define	WT_STAT_DSRC_CURSOR_UPDATE_ERROR		2255
 /*! cursor: insert calls */
-#define	WT_STAT_DSRC_CURSOR_INSERT			2255
+#define	WT_STAT_DSRC_CURSOR_INSERT			2256
 /*! cursor: insert key and value bytes */
-#define	WT_STAT_DSRC_CURSOR_INSERT_BYTES		2256
+#define	WT_STAT_DSRC_CURSOR_INSERT_BYTES		2257
 /*! cursor: modify */
-#define	WT_STAT_DSRC_CURSOR_MODIFY			2257
+#define	WT_STAT_DSRC_CURSOR_MODIFY			2258
 /*! cursor: modify key and value bytes affected */
-#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES		2258
+#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES		2259
 /*! cursor: modify value bytes modified */
-#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES_TOUCH		2259
+#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES_TOUCH		2260
 /*! cursor: next calls */
-#define	WT_STAT_DSRC_CURSOR_NEXT			2260
+#define	WT_STAT_DSRC_CURSOR_NEXT			2261
 /*! cursor: open cursor count */
-#define	WT_STAT_DSRC_CURSOR_OPEN_COUNT			2261
+#define	WT_STAT_DSRC_CURSOR_OPEN_COUNT			2262
 /*! cursor: open cursor time application (usecs) */
-#define	WT_STAT_DSRC_CURSOR_OPEN_TIME_USER_USECS	2262
+#define	WT_STAT_DSRC_CURSOR_OPEN_TIME_USER_USECS	2263
 /*! cursor: open cursor time internal (usecs) */
-#define	WT_STAT_DSRC_CURSOR_OPEN_TIME_INTERNAL_USECS	2263
+#define	WT_STAT_DSRC_CURSOR_OPEN_TIME_INTERNAL_USECS	2264
 /*! cursor: operation restarted */
-#define	WT_STAT_DSRC_CURSOR_RESTART			2264
+#define	WT_STAT_DSRC_CURSOR_RESTART			2265
 /*! cursor: prev calls */
-#define	WT_STAT_DSRC_CURSOR_PREV			2265
+#define	WT_STAT_DSRC_CURSOR_PREV			2266
 /*! cursor: remove calls */
-#define	WT_STAT_DSRC_CURSOR_REMOVE			2266
+#define	WT_STAT_DSRC_CURSOR_REMOVE			2267
 /*! cursor: remove key bytes removed */
-#define	WT_STAT_DSRC_CURSOR_REMOVE_BYTES		2267
+#define	WT_STAT_DSRC_CURSOR_REMOVE_BYTES		2268
 /*! cursor: reserve calls */
-#define	WT_STAT_DSRC_CURSOR_RESERVE			2268
+#define	WT_STAT_DSRC_CURSOR_RESERVE			2269
 /*! cursor: reset calls */
-#define	WT_STAT_DSRC_CURSOR_RESET			2269
+#define	WT_STAT_DSRC_CURSOR_RESET			2270
 /*! cursor: search calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH			2270
+#define	WT_STAT_DSRC_CURSOR_SEARCH			2271
 /*! cursor: search history store calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_HS			2271
+#define	WT_STAT_DSRC_CURSOR_SEARCH_HS			2272
 /*! cursor: search near calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR			2272
+#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR			2273
 /*! cursor: truncate calls */
-#define	WT_STAT_DSRC_CURSOR_TRUNCATE			2273
+#define	WT_STAT_DSRC_CURSOR_TRUNCATE			2274
 /*! cursor: update calls */
-#define	WT_STAT_DSRC_CURSOR_UPDATE			2274
+#define	WT_STAT_DSRC_CURSOR_UPDATE			2275
 /*! cursor: update key and value bytes */
-#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES		2275
+#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES		2276
 /*! cursor: update value size change */
-#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES_CHANGED	2276
+#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES_CHANGED	2277
 /*! layered: Layered table cursor insert operations */
-#define	WT_STAT_DSRC_LAYERED_CURS_INSERT		2277
+#define	WT_STAT_DSRC_LAYERED_CURS_INSERT		2278
 /*! layered: Layered table cursor modify operations */
-#define	WT_STAT_DSRC_LAYERED_CURS_MODIFY		2278
+#define	WT_STAT_DSRC_LAYERED_CURS_MODIFY		2279
 /*! layered: Layered table cursor next operations */
-#define	WT_STAT_DSRC_LAYERED_CURS_NEXT			2279
+#define	WT_STAT_DSRC_LAYERED_CURS_NEXT			2280
 /*! layered: Layered table cursor next operations from the ingest btrees */
-#define	WT_STAT_DSRC_LAYERED_CURS_NEXT_INGEST		2280
+#define	WT_STAT_DSRC_LAYERED_CURS_NEXT_INGEST		2281
 /*! layered: Layered table cursor next operations from the stable btrees */
-#define	WT_STAT_DSRC_LAYERED_CURS_NEXT_STABLE		2281
+#define	WT_STAT_DSRC_LAYERED_CURS_NEXT_STABLE		2282
 /*! layered: Layered table cursor prev operations */
-#define	WT_STAT_DSRC_LAYERED_CURS_PREV			2282
+#define	WT_STAT_DSRC_LAYERED_CURS_PREV			2283
 /*! layered: Layered table cursor prev operations from the ingest btrees */
-#define	WT_STAT_DSRC_LAYERED_CURS_PREV_INGEST		2283
+#define	WT_STAT_DSRC_LAYERED_CURS_PREV_INGEST		2284
 /*! layered: Layered table cursor prev operations from the stable btrees */
-#define	WT_STAT_DSRC_LAYERED_CURS_PREV_STABLE		2284
+#define	WT_STAT_DSRC_LAYERED_CURS_PREV_STABLE		2285
 /*! layered: Layered table cursor remove operations */
-#define	WT_STAT_DSRC_LAYERED_CURS_REMOVE		2285
+#define	WT_STAT_DSRC_LAYERED_CURS_REMOVE		2286
 /*! layered: Layered table cursor search near operations */
-#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH_NEAR		2286
+#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH_NEAR		2287
 /*!
  * layered: Layered table cursor search near operations from the ingest
  * btrees
  */
-#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH_NEAR_INGEST	2287
+#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH_NEAR_INGEST	2288
 /*!
  * layered: Layered table cursor search near operations from the stable
  * btrees
  */
-#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH_NEAR_STABLE	2288
+#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH_NEAR_STABLE	2289
 /*! layered: Layered table cursor search operations */
-#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH		2289
+#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH		2290
 /*! layered: Layered table cursor search operations from the ingest btrees */
-#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH_INGEST		2290
+#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH_INGEST		2291
 /*! layered: Layered table cursor search operations from the stable btrees */
-#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH_STABLE		2291
+#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH_STABLE		2292
 /*! layered: Layered table cursor update operations */
-#define	WT_STAT_DSRC_LAYERED_CURS_UPDATE		2292
+#define	WT_STAT_DSRC_LAYERED_CURS_UPDATE		2293
 /*! layered: Layered table cursor upgrade state for the ingest btrees */
-#define	WT_STAT_DSRC_LAYERED_CURS_UPGRADE_INGEST	2293
+#define	WT_STAT_DSRC_LAYERED_CURS_UPGRADE_INGEST	2294
 /*! layered: Layered table cursor upgrade state for the stable btrees */
-#define	WT_STAT_DSRC_LAYERED_CURS_UPGRADE_STABLE	2294
+#define	WT_STAT_DSRC_LAYERED_CURS_UPGRADE_STABLE	2295
 /*!
  * layered: checkpoints performed on this table by the layered table
  * manager
  */
-#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_CHECKPOINTS	2295
+#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_CHECKPOINTS	2296
 /*! layered: disagg pick up checkpoints failed */
-#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FAILED	2296
+#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FAILED	2297
 /*! layered: disagg pick up checkpoints succeeded */
-#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_SUCCEED	2297
+#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_SUCCEED	2298
 /*!
  * layered: how many log applications the layered table manager applied
  * on this tree
  */
-#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_LOGOPS_APPLIED	2298
+#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_LOGOPS_APPLIED	2299
 /*!
  * layered: how many log applications the layered table manager skipped
  * on this tree
  */
-#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_LOGOPS_SKIPPED	2299
+#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_LOGOPS_SKIPPED	2300
 /*!
  * layered: how many previously-applied LSNs the layered table manager
  * skipped on this tree
  */
-#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_SKIP_LSN	2300
+#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_SKIP_LSN	2301
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_DSRC_REC_VLCS_EMPTIED_PAGES		2301
+#define	WT_STAT_DSRC_REC_VLCS_EMPTIED_PAGES		2302
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TS		2302
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TS		2303
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TXN		2303
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TXN		2304
 /*!
  * reconciliation: average length of delta chain on internal page with
  * deltas
  */
-#define	WT_STAT_DSRC_REC_AVERAGE_INTERNAL_PAGE_DELTA_CHAIN_LENGTH	2304
+#define	WT_STAT_DSRC_REC_AVERAGE_INTERNAL_PAGE_DELTA_CHAIN_LENGTH	2305
 /*! reconciliation: average length of delta chain on leaf page with deltas */
-#define	WT_STAT_DSRC_REC_AVERAGE_LEAF_PAGE_DELTA_CHAIN_LENGTH	2305
+#define	WT_STAT_DSRC_REC_AVERAGE_LEAF_PAGE_DELTA_CHAIN_LENGTH	2306
 /*!
  * reconciliation: changes since prior reconciliation (bucket 1) between
  * 1 and 5
  */
-#define	WT_STAT_DSRC_REC_PAGE_MODS_LE5			2306
+#define	WT_STAT_DSRC_REC_PAGE_MODS_LE5			2307
 /*!
  * reconciliation: changes since prior reconciliation (bucket 2) between
  * 6 and 10
  */
-#define	WT_STAT_DSRC_REC_PAGE_MODS_LE10			2307
+#define	WT_STAT_DSRC_REC_PAGE_MODS_LE10			2308
 /*!
  * reconciliation: changes since prior reconciliation (bucket 3) between
  * 11 and 20
  */
-#define	WT_STAT_DSRC_REC_PAGE_MODS_LE20			2308
+#define	WT_STAT_DSRC_REC_PAGE_MODS_LE20			2309
 /*!
  * reconciliation: changes since prior reconciliation (bucket 4) between
  * 21 and 50
  */
-#define	WT_STAT_DSRC_REC_PAGE_MODS_LE50			2309
+#define	WT_STAT_DSRC_REC_PAGE_MODS_LE50			2310
 /*!
  * reconciliation: changes since prior reconciliation (bucket 5) between
  * 51 and 100
  */
-#define	WT_STAT_DSRC_REC_PAGE_MODS_LE100		2310
+#define	WT_STAT_DSRC_REC_PAGE_MODS_LE100		2311
 /*!
  * reconciliation: changes since prior reconciliation (bucket 6) between
  * 101 and 200
  */
-#define	WT_STAT_DSRC_REC_PAGE_MODS_LE200		2311
+#define	WT_STAT_DSRC_REC_PAGE_MODS_LE200		2312
 /*!
  * reconciliation: changes since prior reconciliation (bucket 7) between
  * 201 and 500
  */
-#define	WT_STAT_DSRC_REC_PAGE_MODS_LE500		2312
+#define	WT_STAT_DSRC_REC_PAGE_MODS_LE500		2313
 /*!
  * reconciliation: changes since prior reconciliation (bucket 8) greater
  * than 500
  */
-#define	WT_STAT_DSRC_REC_PAGE_MODS_GT500		2313
+#define	WT_STAT_DSRC_REC_PAGE_MODS_GT500		2314
 /*! reconciliation: cursor next/prev calls during HS wrapup search_near */
-#define	WT_STAT_DSRC_REC_HS_WRAPUP_NEXT_PREV_CALLS	2314
+#define	WT_STAT_DSRC_REC_HS_WRAPUP_NEXT_PREV_CALLS	2315
 /*! reconciliation: dictionary matches */
-#define	WT_STAT_DSRC_REC_DICTIONARY			2315
+#define	WT_STAT_DSRC_REC_DICTIONARY			2316
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELETE_FAST		2316
+#define	WT_STAT_DSRC_REC_PAGE_DELETE_FAST		2317
 /*!
  * reconciliation: free page ID due to failed page replacement
  * reconciliation in disagg
  */
-#define	WT_STAT_DSRC_REC_FREE_PAGE_ID_DUE_TO_FAILED_REPLACEMENT_RECONCILIATION	2317
+#define	WT_STAT_DSRC_REC_FREE_PAGE_ID_DUE_TO_FAILED_REPLACEMENT_RECONCILIATION	2318
 /*! reconciliation: full internal pages written instead of a page delta */
-#define	WT_STAT_DSRC_REC_PAGE_FULL_IMAGE_INTERNAL	2318
+#define	WT_STAT_DSRC_REC_PAGE_FULL_IMAGE_INTERNAL	2319
 /*! reconciliation: full leaf pages written instead of a page delta */
-#define	WT_STAT_DSRC_REC_PAGE_FULL_IMAGE_LEAF		2319
+#define	WT_STAT_DSRC_REC_PAGE_FULL_IMAGE_LEAF		2320
 /*!
  * reconciliation: ingest btree reconciliation keeps the aborted prepare
  * updates
  */
-#define	WT_STAT_DSRC_REC_INGEST_KEEP_PREPARE_ROLLBACK	2320
+#define	WT_STAT_DSRC_REC_INGEST_KEEP_PREPARE_ROLLBACK	2321
 /*! reconciliation: internal page delta keys deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELTA_INTERNAL_KEY_DELETED	2321
+#define	WT_STAT_DSRC_REC_PAGE_DELTA_INTERNAL_KEY_DELETED	2322
 /*! reconciliation: internal page delta keys updated/inserted */
-#define	WT_STAT_DSRC_REC_PAGE_DELTA_INTERNAL_KEY_UPDATED	2322
+#define	WT_STAT_DSRC_REC_PAGE_DELTA_INTERNAL_KEY_UPDATED	2323
 /*! reconciliation: internal page deltas written */
-#define	WT_STAT_DSRC_REC_PAGE_DELTA_INTERNAL		2323
+#define	WT_STAT_DSRC_REC_PAGE_DELTA_INTERNAL		2324
 /*!
  * reconciliation: internal page key bytes discarded using suffix
  * compression
  */
-#define	WT_STAT_DSRC_REC_SUFFIX_COMPRESSION		2324
+#define	WT_STAT_DSRC_REC_SUFFIX_COMPRESSION		2325
 /*! reconciliation: internal page multi-block writes */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_INTERNAL		2325
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_INTERNAL		2326
 /*!
  * reconciliation: leaf delta page key bytes discarded using prefix
  * compression
  */
-#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION_DELTA	2326
+#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION_DELTA	2327
 /*!
  * reconciliation: leaf full page key bytes discarded using prefix
  * compression
  */
-#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION_FULL	2327
+#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION_FULL	2328
 /*! reconciliation: leaf page deltas written */
-#define	WT_STAT_DSRC_REC_PAGE_DELTA_LEAF		2328
+#define	WT_STAT_DSRC_REC_PAGE_DELTA_LEAF		2329
 /*! reconciliation: leaf page multi-block writes */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_LEAF		2329
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_LEAF		2330
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_LEAF		2330
+#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_LEAF		2331
 /*! reconciliation: max deltas seen on internal page during reconciliation */
-#define	WT_STAT_DSRC_REC_MAX_INTERNAL_PAGE_DELTAS	2331
+#define	WT_STAT_DSRC_REC_MAX_INTERNAL_PAGE_DELTAS	2332
 /*! reconciliation: max deltas seen on leaf page during reconciliation */
-#define	WT_STAT_DSRC_REC_MAX_LEAF_PAGE_DELTAS		2332
+#define	WT_STAT_DSRC_REC_MAX_LEAF_PAGE_DELTAS		2333
 /*! reconciliation: maximum blocks required for a page */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_MAX			2333
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_MAX			2334
 /*!
  * reconciliation: number of keys that are garbage collected from the
  * disk images in the ingest btrees for disaggregated storage
  */
-#define	WT_STAT_DSRC_REC_INGEST_GARBAGE_COLLECTION_KEYS_DISK_IMAGE	2334
+#define	WT_STAT_DSRC_REC_INGEST_GARBAGE_COLLECTION_KEYS_DISK_IMAGE	2335
 /*!
  * reconciliation: number of keys that are garbage collected from the
  * update chains in the ingest btrees for disaggregated storage
  */
-#define	WT_STAT_DSRC_REC_INGEST_GARBAGE_COLLECTION_KEYS_UPDATE_CHAIN	2335
+#define	WT_STAT_DSRC_REC_INGEST_GARBAGE_COLLECTION_KEYS_UPDATE_CHAIN	2336
 /*! reconciliation: overflow values written */
-#define	WT_STAT_DSRC_REC_OVERFLOW_VALUE			2336
+#define	WT_STAT_DSRC_REC_OVERFLOW_VALUE			2337
 /*! reconciliation: page deltas rejected due to invalid page ID */
-#define	WT_STAT_DSRC_REC_PAGE_DELTA_REJECTED_INVALID_PAGE_ID	2337
+#define	WT_STAT_DSRC_REC_PAGE_DELTA_REJECTED_INVALID_PAGE_ID	2338
 /*! reconciliation: page deltas rejected due to max consecutive limit */
-#define	WT_STAT_DSRC_REC_PAGE_DELTA_REJECTED_MAX_CONSECUTIVE_EXCEEDED	2338
+#define	WT_STAT_DSRC_REC_PAGE_DELTA_REJECTED_MAX_CONSECUTIVE_EXCEEDED	2339
 /*! reconciliation: page deltas rejected due to multiblock reconciliation */
-#define	WT_STAT_DSRC_REC_PAGE_DELTA_REJECTED_MULTIBLOCK	2339
+#define	WT_STAT_DSRC_REC_PAGE_DELTA_REJECTED_MULTIBLOCK	2340
 /*!
  * reconciliation: page deltas rejected due to non-single page in
  * previous reconciliation
  */
-#define	WT_STAT_DSRC_REC_PAGE_DELTA_REJECTED_NON_SINGLE_PAGE	2340
+#define	WT_STAT_DSRC_REC_PAGE_DELTA_REJECTED_NON_SINGLE_PAGE	2341
 /*! reconciliation: page deltas rejected due to size threshold */
-#define	WT_STAT_DSRC_REC_PAGE_DELTA_REJECTED_SIZE_THRESHOLD	2341
+#define	WT_STAT_DSRC_REC_PAGE_DELTA_REJECTED_SIZE_THRESHOLD	2342
 /*! reconciliation: page deltas rejected due to zero entries */
-#define	WT_STAT_DSRC_REC_PAGE_DELTA_REJECTED_ZERO_ENTRIES	2342
+#define	WT_STAT_DSRC_REC_PAGE_DELTA_REJECTED_ZERO_ENTRIES	2343
 /*!
  * reconciliation: page deltas rejected: build function returned false
  * (disabled, in-memory split, or internal page constraints not met)
  */
-#define	WT_STAT_DSRC_REC_PAGE_DELTA_REJECTED_BUILD_FAILED	2343
+#define	WT_STAT_DSRC_REC_PAGE_DELTA_REJECTED_BUILD_FAILED	2344
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_DSRC_REC_PAGES				2344
+#define	WT_STAT_DSRC_REC_PAGES				2345
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_DSRC_REC_PAGES_EVICTION			2345
+#define	WT_STAT_DSRC_REC_PAGES_EVICTION			2346
 /*! reconciliation: page reconciliation calls for pages between 1 and 10MB */
-#define	WT_STAT_DSRC_REC_PAGES_SIZE_1MB_TO_10MB		2346
+#define	WT_STAT_DSRC_REC_PAGES_SIZE_1MB_TO_10MB		2347
 /*!
  * reconciliation: page reconciliation calls for pages between 10 and
  * 100MB
  */
-#define	WT_STAT_DSRC_REC_PAGES_SIZE_10MB_TO_100MB	2347
+#define	WT_STAT_DSRC_REC_PAGES_SIZE_10MB_TO_100MB	2348
 /*!
  * reconciliation: page reconciliation calls for pages between 100MB and
  * 1GB
  */
-#define	WT_STAT_DSRC_REC_PAGES_SIZE_100MB_TO_1GB	2348
+#define	WT_STAT_DSRC_REC_PAGES_SIZE_100MB_TO_1GB	2349
 /*! reconciliation: page reconciliation calls for pages over 1GB */
-#define	WT_STAT_DSRC_REC_PAGES_SIZE_1GB_PLUS		2349
+#define	WT_STAT_DSRC_REC_PAGES_SIZE_1GB_PLUS		2350
 /*! reconciliation: pages deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELETE			2350
+#define	WT_STAT_DSRC_REC_PAGE_DELETE			2351
 /*! reconciliation: pages eligible for delta generation */
-#define	WT_STAT_DSRC_REC_PAGE_DELTA_ELIGIBLE		2351
+#define	WT_STAT_DSRC_REC_PAGE_DELTA_ELIGIBLE		2352
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	2352
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	2353
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	2353
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	2354
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TS	2354
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TS	2355
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TXN	2355
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TXN	2356
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_TXN		2356
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_TXN		2357
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_OLDEST_START_TS	2357
+#define	WT_STAT_DSRC_REC_TIME_AGGR_OLDEST_START_TS	2358
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_PREPARED		2358
+#define	WT_STAT_DSRC_REC_TIME_AGGR_PREPARED		2359
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_PREPARED	2359
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_PREPARED	2360
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	2360
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	2361
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TS	2361
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TS	2362
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TXN	2362
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TXN	2363
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	2363
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	2364
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TS	2364
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TS	2365
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TXN	2365
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TXN	2366
 /*! reconciliation: pages written with at least one internal page delta */
-#define	WT_STAT_DSRC_REC_PAGES_WITH_INTERNAL_DELTAS	2366
+#define	WT_STAT_DSRC_REC_PAGES_WITH_INTERNAL_DELTAS	2367
 /*! reconciliation: pages written with at least one leaf page delta */
-#define	WT_STAT_DSRC_REC_PAGES_WITH_LEAF_DELTAS		2367
+#define	WT_STAT_DSRC_REC_PAGES_WITH_LEAF_DELTAS		2368
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PREPARED		2368
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PREPARED		2369
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_START_TS	2369
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_START_TS	2370
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TS		2370
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TS		2371
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TXN		2371
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TXN		2372
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_STOP_TS	2372
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_STOP_TS	2373
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TS		2373
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TS		2374
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TXN		2374
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TXN		2375
 /*! reconciliation: writes skipped in disaggregated storage */
-#define	WT_STAT_DSRC_REC_SKIP_WRITE			2375
+#define	WT_STAT_DSRC_REC_SKIP_WRITE			2376
 /*! session: object compaction */
-#define	WT_STAT_DSRC_SESSION_COMPACT			2376
+#define	WT_STAT_DSRC_SESSION_COMPACT			2377
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_COMMIT	2377
+#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_COMMIT	2378
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_DSRC_TXN_READ_OVERFLOW_REMOVE		2378
+#define	WT_STAT_DSRC_TXN_READ_OVERFLOW_REMOVE		2379
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_UPDATE	2379
+#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_UPDATE	2380
 /*! transaction: rollback to stable applied btrees */
-#define	WT_STAT_DSRC_TXN_RTS_BTREES_APPLIED		2380
+#define	WT_STAT_DSRC_TXN_RTS_BTREES_APPLIED		2381
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	2381
+#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	2382
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2382
+#define	WT_STAT_DSRC_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2383
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_DSRC_TXN_RTS_INCONSISTENT_CKPT		2383
+#define	WT_STAT_DSRC_TXN_RTS_INCONSISTENT_CKPT		2384
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED		2384
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED		2385
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED		2385
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED		2386
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED_DRYRUN	2386
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED_DRYRUN	2387
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED_DRYRUN	2387
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED_DRYRUN	2388
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES	2388
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES	2389
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES		2389
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES		2390
 /*! transaction: rollback to stable skipped btrees */
-#define	WT_STAT_DSRC_TXN_RTS_BTREES_SKIPPED		2390
+#define	WT_STAT_DSRC_TXN_RTS_BTREES_SKIPPED		2391
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_DSRC_TXN_RTS_DELETE_RLE_SKIPPED		2391
+#define	WT_STAT_DSRC_TXN_RTS_DELETE_RLE_SKIPPED		2392
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_DSRC_TXN_RTS_STABLE_RLE_SKIPPED		2392
+#define	WT_STAT_DSRC_TXN_RTS_STABLE_RLE_SKIPPED		2393
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS		2393
+#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS		2394
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	2394
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	2395
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	2395
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	2396
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED			2396
+#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED			2397
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED_DRYRUN		2397
+#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED_DRYRUN		2398
 /*! transaction: update conflicts */
-#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2398
+#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2399
 
 /*!
  * @}

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -7423,400 +7423,405 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1430
 /*! checkpoint: total time (msecs) */
 #define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1431
+/*!
+ * checkpoint: total time (msecs) writing pages to stable storage during
+ * checkpoint reconciliation
+ */
+#define	WT_STAT_CONN_CHECKPOINT_REC_BLKCACHE_WRITE	1432
 /*! checkpoint: wait cycles while cache dirty level is decreasing */
-#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1432
+#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1433
 /*! chunk-cache: aggregate number of spanned chunks on read */
-#define	WT_STAT_CONN_CHUNKCACHE_SPANS_CHUNKS_READ	1433
+#define	WT_STAT_CONN_CHUNKCACHE_SPANS_CHUNKS_READ	1434
 /*! chunk-cache: chunks evicted */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_EVICTED		1434
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_EVICTED		1435
 /*! chunk-cache: could not allocate due to exceeding bitmap capacity */
-#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_BITMAP_CAPACITY	1435
+#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_BITMAP_CAPACITY	1436
 /*! chunk-cache: could not allocate due to exceeding capacity */
-#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_CAPACITY	1436
+#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_CAPACITY	1437
 /*! chunk-cache: lookups */
-#define	WT_STAT_CONN_CHUNKCACHE_LOOKUPS			1437
+#define	WT_STAT_CONN_CHUNKCACHE_LOOKUPS			1438
 /*!
  * chunk-cache: number of chunks loaded from flushed tables in chunk
  * cache
  */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_LOADED_FROM_FLUSHED_TABLES	1438
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_LOADED_FROM_FLUSHED_TABLES	1439
 /*! chunk-cache: number of metadata entries inserted */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_INSERTED	1439
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_INSERTED	1440
 /*! chunk-cache: number of metadata entries removed */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_REMOVED	1440
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_REMOVED	1441
 /*!
  * chunk-cache: number of metadata inserts/deletes dropped by the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DROPPED	1441
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DROPPED	1442
 /*!
  * chunk-cache: number of metadata inserts/deletes pushed to the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_CREATED	1442
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_CREATED	1443
 /*!
  * chunk-cache: number of metadata inserts/deletes read by the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DEQUEUED	1443
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DEQUEUED	1444
 /*! chunk-cache: number of misses */
-#define	WT_STAT_CONN_CHUNKCACHE_MISSES			1444
+#define	WT_STAT_CONN_CHUNKCACHE_MISSES			1445
 /*! chunk-cache: number of times a read from storage failed */
-#define	WT_STAT_CONN_CHUNKCACHE_IO_FAILED		1445
+#define	WT_STAT_CONN_CHUNKCACHE_IO_FAILED		1446
 /*! chunk-cache: retried accessing a chunk while I/O was in progress */
-#define	WT_STAT_CONN_CHUNKCACHE_RETRIES			1446
+#define	WT_STAT_CONN_CHUNKCACHE_RETRIES			1447
 /*! chunk-cache: retries from a chunk cache checksum mismatch */
-#define	WT_STAT_CONN_CHUNKCACHE_RETRIES_CHECKSUM_MISMATCH	1447
+#define	WT_STAT_CONN_CHUNKCACHE_RETRIES_CHECKSUM_MISMATCH	1448
 /*! chunk-cache: timed out due to too many retries */
-#define	WT_STAT_CONN_CHUNKCACHE_TOOMANY_RETRIES		1448
+#define	WT_STAT_CONN_CHUNKCACHE_TOOMANY_RETRIES		1449
 /*! chunk-cache: total bytes read from persistent content */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_READ_PERSISTENT	1449
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_READ_PERSISTENT	1450
 /*! chunk-cache: total bytes used by the cache */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE		1450
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE		1451
 /*! chunk-cache: total bytes used by the cache for pinned chunks */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE_PINNED	1451
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE_PINNED	1452
 /*! chunk-cache: total chunks held by the chunk cache */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_INUSE		1452
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_INUSE		1453
 /*!
  * chunk-cache: total number of chunks inserted on startup from persisted
  * metadata
  */
-#define	WT_STAT_CONN_CHUNKCACHE_CREATED_FROM_METADATA	1453
+#define	WT_STAT_CONN_CHUNKCACHE_CREATED_FROM_METADATA	1454
 /*! chunk-cache: total pinned chunks held by the chunk cache */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_PINNED		1454
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_PINNED		1455
 /*! connection: auto adjusting condition resets */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1455
+#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1456
 /*! connection: auto adjusting condition wait calls */
-#define	WT_STAT_CONN_COND_AUTO_WAIT			1456
+#define	WT_STAT_CONN_COND_AUTO_WAIT			1457
 /*!
  * connection: auto adjusting condition wait raced to update timeout and
  * skipped updating
  */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1457
+#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1458
 /*! connection: btrees currently open */
-#define	WT_STAT_CONN_BTREE_OPEN				1458
+#define	WT_STAT_CONN_BTREE_OPEN				1459
 /*! connection: detected system time went backwards */
-#define	WT_STAT_CONN_TIME_TRAVEL			1459
+#define	WT_STAT_CONN_TIME_TRAVEL			1460
 /*! connection: files currently open */
-#define	WT_STAT_CONN_FILE_OPEN				1460
+#define	WT_STAT_CONN_FILE_OPEN				1461
 /*! connection: hash bucket array size for data handles */
-#define	WT_STAT_CONN_BUCKETS_DH				1461
+#define	WT_STAT_CONN_BUCKETS_DH				1462
 /*! connection: hash bucket array size general */
-#define	WT_STAT_CONN_BUCKETS				1462
+#define	WT_STAT_CONN_BUCKETS				1463
 /*! connection: memory allocations */
-#define	WT_STAT_CONN_MEMORY_ALLOCATION			1463
+#define	WT_STAT_CONN_MEMORY_ALLOCATION			1464
 /*! connection: memory frees */
-#define	WT_STAT_CONN_MEMORY_FREE			1464
+#define	WT_STAT_CONN_MEMORY_FREE			1465
 /*! connection: memory re-allocations */
-#define	WT_STAT_CONN_MEMORY_GROW			1465
+#define	WT_STAT_CONN_MEMORY_GROW			1466
 /*! connection: number of sessions without a sweep for 5+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1466
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1467
 /*! connection: number of sessions without a sweep for 60+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1467
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1468
 /*! connection: pthread mutex condition wait calls */
-#define	WT_STAT_CONN_COND_WAIT				1468
+#define	WT_STAT_CONN_COND_WAIT				1469
 /*! connection: pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			1469
+#define	WT_STAT_CONN_RWLOCK_READ			1470
 /*! connection: pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			1470
+#define	WT_STAT_CONN_RWLOCK_WRITE			1471
 /*! connection: total fsync I/Os */
-#define	WT_STAT_CONN_FSYNC_IO				1471
+#define	WT_STAT_CONN_FSYNC_IO				1472
 /*! connection: total read I/Os */
-#define	WT_STAT_CONN_READ_IO				1472
+#define	WT_STAT_CONN_READ_IO				1473
 /*! connection: total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				1473
+#define	WT_STAT_CONN_WRITE_IO				1474
 /*! cursor: Total number of deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1474
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1475
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1475
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1476
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1476
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1477
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1477
+#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1478
 /*!
  * cursor: Total number of in-memory deleted pages skipped during tree
  * walk
  */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1478
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1479
 /*! cursor: Total number of on-disk deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1479
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1480
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1480
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1481
 /*!
  * cursor: Total number of times cursor fails to temporarily release
  * pinned page to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1481
+#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1482
 /*!
  * cursor: Total number of times cursor temporarily releases pinned page
  * to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION			1482
+#define	WT_STAT_CONN_CURSOR_REPOSITION			1483
 /*! cursor: bulk cursor count */
-#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1483
+#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1484
 /*! cursor: cached cursor count */
-#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1484
+#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1485
 /*! cursor: cursor bound calls that return an error */
-#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1485
+#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1486
 /*! cursor: cursor bounds cleared from reset */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1486
+#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1487
 /*! cursor: cursor bounds comparisons performed */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1487
+#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1488
 /*! cursor: cursor bounds next called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1488
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1489
 /*! cursor: cursor bounds next early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1489
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1490
 /*! cursor: cursor bounds prev called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1490
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1491
 /*! cursor: cursor bounds prev early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1491
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1492
 /*! cursor: cursor bounds search early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1492
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1493
 /*! cursor: cursor bounds search near call repositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1493
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1494
 /*! cursor: cursor bulk loaded cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1494
+#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1495
 /*! cursor: cursor cache calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1495
+#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1496
 /*! cursor: cursor close calls that result in cache */
-#define	WT_STAT_CONN_CURSOR_CACHE			1496
+#define	WT_STAT_CONN_CURSOR_CACHE			1497
 /*! cursor: cursor close calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1497
+#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1498
 /*! cursor: cursor compare calls that return an error */
-#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1498
+#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1499
 /*! cursor: cursor create calls */
-#define	WT_STAT_CONN_CURSOR_CREATE			1499
+#define	WT_STAT_CONN_CURSOR_CREATE			1500
 /*! cursor: cursor equals calls that return an error */
-#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1500
+#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1501
 /*! cursor: cursor get key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1501
+#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1502
 /*! cursor: cursor get value calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1502
+#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1503
 /*! cursor: cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT			1503
+#define	WT_STAT_CONN_CURSOR_INSERT			1504
 /*! cursor: cursor insert calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1504
+#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1505
 /*! cursor: cursor insert check calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1505
+#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1506
 /*! cursor: cursor insert key and value bytes */
-#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1506
+#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1507
 /*! cursor: cursor largest key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1507
+#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1508
 /*! cursor: cursor modify calls */
-#define	WT_STAT_CONN_CURSOR_MODIFY			1508
+#define	WT_STAT_CONN_CURSOR_MODIFY			1509
 /*! cursor: cursor modify calls that return an error */
-#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1509
+#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1510
 /*! cursor: cursor modify key and value bytes affected */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1510
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1511
 /*! cursor: cursor modify value bytes modified */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1511
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1512
 /*! cursor: cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT			1512
+#define	WT_STAT_CONN_CURSOR_NEXT			1513
 /*! cursor: cursor next calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1513
+#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1514
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1514
+#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1515
 /*!
  * cursor: cursor next calls that skip greater than 1 and fewer than 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1515
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1516
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1516
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1517
 /*! cursor: cursor next random calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1517
+#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1518
 /*! cursor: cursor operation restarted */
-#define	WT_STAT_CONN_CURSOR_RESTART			1518
+#define	WT_STAT_CONN_CURSOR_RESTART			1519
 /*! cursor: cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV			1519
+#define	WT_STAT_CONN_CURSOR_PREV			1520
 /*! cursor: cursor prev calls that return an error */
-#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1520
+#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1521
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1521
+#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1522
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1522
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1523
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1523
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1524
 /*! cursor: cursor reconfigure calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1524
+#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1525
 /*! cursor: cursor remove calls */
-#define	WT_STAT_CONN_CURSOR_REMOVE			1525
+#define	WT_STAT_CONN_CURSOR_REMOVE			1526
 /*! cursor: cursor remove calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1526
+#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1527
 /*! cursor: cursor remove key bytes removed */
-#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1527
+#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1528
 /*! cursor: cursor reopen calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1528
+#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1529
 /*! cursor: cursor reserve calls */
-#define	WT_STAT_CONN_CURSOR_RESERVE			1529
+#define	WT_STAT_CONN_CURSOR_RESERVE			1530
 /*! cursor: cursor reserve calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1530
+#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1531
 /*! cursor: cursor reset calls */
-#define	WT_STAT_CONN_CURSOR_RESET			1531
+#define	WT_STAT_CONN_CURSOR_RESET			1532
 /*! cursor: cursor reset calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1532
+#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1533
 /*! cursor: cursor search calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH			1533
+#define	WT_STAT_CONN_CURSOR_SEARCH			1534
 /*! cursor: cursor search calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1534
+#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1535
 /*! cursor: cursor search history store calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1535
+#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1536
 /*! cursor: cursor search near calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1536
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1537
 /*! cursor: cursor search near calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1537
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1538
 /*! cursor: cursor sweep buckets */
-#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1538
+#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1539
 /*! cursor: cursor sweep cursors closed */
-#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1539
+#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1540
 /*! cursor: cursor sweep cursors examined */
-#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1540
+#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1541
 /*! cursor: cursor sweeps */
-#define	WT_STAT_CONN_CURSOR_SWEEP			1541
+#define	WT_STAT_CONN_CURSOR_SWEEP			1542
 /*! cursor: cursor truncate calls */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE			1542
+#define	WT_STAT_CONN_CURSOR_TRUNCATE			1543
 /*! cursor: cursor truncates performed on individual keys */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1543
+#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1544
 /*! cursor: cursor update calls */
-#define	WT_STAT_CONN_CURSOR_UPDATE			1544
+#define	WT_STAT_CONN_CURSOR_UPDATE			1545
 /*! cursor: cursor update calls that return an error */
-#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1545
+#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1546
 /*! cursor: cursor update key and value bytes */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1546
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1547
 /*! cursor: cursor update value size change */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1547
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1548
 /*! cursor: cursors reused from cache */
-#define	WT_STAT_CONN_CURSOR_REOPEN			1548
+#define	WT_STAT_CONN_CURSOR_REOPEN			1549
 /*! cursor: open cursor count */
-#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1549
+#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1550
 /*! cursor: open cursor time application (usecs) */
-#define	WT_STAT_CONN_CURSOR_OPEN_TIME_USER_USECS	1550
+#define	WT_STAT_CONN_CURSOR_OPEN_TIME_USER_USECS	1551
 /*! cursor: open cursor time internal (usecs) */
-#define	WT_STAT_CONN_CURSOR_OPEN_TIME_INTERNAL_USECS	1551
+#define	WT_STAT_CONN_CURSOR_OPEN_TIME_INTERNAL_USECS	1552
 /*! data-handle: Layered connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_LAYERED_COUNT	1552
+#define	WT_STAT_CONN_DH_CONN_HANDLE_LAYERED_COUNT	1553
 /*! data-handle: Table connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TABLE_COUNT		1553
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TABLE_COUNT		1554
 /*! data-handle: Tiered connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_COUNT	1554
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_COUNT	1555
 /*! data-handle: Tiered_Tree connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_TREE_COUNT	1555
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_TREE_COUNT	1556
 /*! data-handle: btree connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_BTREE_COUNT		1556
+#define	WT_STAT_CONN_DH_CONN_HANDLE_BTREE_COUNT		1557
 /*! data-handle: checkpoint connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_CHECKPOINT_COUNT	1557
+#define	WT_STAT_CONN_DH_CONN_HANDLE_CHECKPOINT_COUNT	1558
 /*! data-handle: connection data handle size */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1558
+#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1559
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1559
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1560
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1560
+#define	WT_STAT_CONN_DH_SWEEP_REF			1561
 /*! data-handle: connection sweep dead dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_DEAD_CLOSE		1561
+#define	WT_STAT_CONN_DH_SWEEP_DEAD_CLOSE		1562
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1562
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1563
 /*! data-handle: connection sweep expired dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_EXPIRED_CLOSE		1563
+#define	WT_STAT_CONN_DH_SWEEP_EXPIRED_CLOSE		1564
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1564
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1565
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1565
+#define	WT_STAT_CONN_DH_SWEEPS				1566
 /*!
  * data-handle: connection sweeps skipped due to checkpoint gathering
  * handles
  */
-#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1566
+#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1567
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1567
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1568
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1568
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1569
 /*! disagg: database size */
-#define	WT_STAT_CONN_DISAGG_DATABASE_SIZE		1569
+#define	WT_STAT_CONN_DISAGG_DATABASE_SIZE		1570
 /*! disagg: role leader */
-#define	WT_STAT_CONN_DISAGG_ROLE_LEADER			1570
+#define	WT_STAT_CONN_DISAGG_ROLE_LEADER			1571
 /*! disagg: step down most recent time (msecs) */
-#define	WT_STAT_CONN_DISAGG_STEP_DOWN_TIME		1571
+#define	WT_STAT_CONN_DISAGG_STEP_DOWN_TIME		1572
 /*! disagg: step up most recent time (msecs) */
-#define	WT_STAT_CONN_DISAGG_STEP_UP_TIME		1572
+#define	WT_STAT_CONN_DISAGG_STEP_UP_TIME		1573
 /*! layered: Layered table cursor insert operations */
-#define	WT_STAT_CONN_LAYERED_CURS_INSERT		1573
+#define	WT_STAT_CONN_LAYERED_CURS_INSERT		1574
 /*! layered: Layered table cursor modify operations */
-#define	WT_STAT_CONN_LAYERED_CURS_MODIFY		1574
+#define	WT_STAT_CONN_LAYERED_CURS_MODIFY		1575
 /*! layered: Layered table cursor next operations */
-#define	WT_STAT_CONN_LAYERED_CURS_NEXT			1575
+#define	WT_STAT_CONN_LAYERED_CURS_NEXT			1576
 /*! layered: Layered table cursor next operations from the ingest btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_NEXT_INGEST		1576
+#define	WT_STAT_CONN_LAYERED_CURS_NEXT_INGEST		1577
 /*! layered: Layered table cursor next operations from the stable btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_NEXT_STABLE		1577
+#define	WT_STAT_CONN_LAYERED_CURS_NEXT_STABLE		1578
 /*! layered: Layered table cursor prev operations */
-#define	WT_STAT_CONN_LAYERED_CURS_PREV			1578
+#define	WT_STAT_CONN_LAYERED_CURS_PREV			1579
 /*! layered: Layered table cursor prev operations from the ingest btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_PREV_INGEST		1579
+#define	WT_STAT_CONN_LAYERED_CURS_PREV_INGEST		1580
 /*! layered: Layered table cursor prev operations from the stable btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_PREV_STABLE		1580
+#define	WT_STAT_CONN_LAYERED_CURS_PREV_STABLE		1581
 /*! layered: Layered table cursor remove operations */
-#define	WT_STAT_CONN_LAYERED_CURS_REMOVE		1581
+#define	WT_STAT_CONN_LAYERED_CURS_REMOVE		1582
 /*! layered: Layered table cursor search near operations */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR		1582
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR		1583
 /*!
  * layered: Layered table cursor search near operations from the ingest
  * btrees
  */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_INGEST	1583
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_INGEST	1584
 /*!
  * layered: Layered table cursor search near operations from the stable
  * btrees
  */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_STABLE	1584
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_STABLE	1585
 /*! layered: Layered table cursor search operations */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH		1585
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH		1586
 /*! layered: Layered table cursor search operations from the ingest btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_INGEST		1586
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_INGEST		1587
 /*! layered: Layered table cursor search operations from the stable btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_STABLE		1587
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_STABLE		1588
 /*! layered: Layered table cursor update operations */
-#define	WT_STAT_CONN_LAYERED_CURS_UPDATE		1588
+#define	WT_STAT_CONN_LAYERED_CURS_UPDATE		1589
 /*! layered: Layered table cursor upgrade state for the ingest btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_UPGRADE_INGEST	1589
+#define	WT_STAT_CONN_LAYERED_CURS_UPGRADE_INGEST	1590
 /*! layered: Layered table cursor upgrade state for the stable btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_UPGRADE_STABLE	1590
+#define	WT_STAT_CONN_LAYERED_CURS_UPGRADE_STABLE	1591
 /*!
  * layered: checkpoints performed on this table by the layered table
  * manager
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS	1591
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS	1592
 /*! layered: disagg pick up checkpoints failed */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FAILED	1592
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FAILED	1593
 /*! layered: disagg pick up checkpoints succeeded */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_SUCCEED	1593
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_SUCCEED	1594
 /*!
  * layered: how many log applications the layered table manager applied
  * on this tree
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_APPLIED	1594
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_APPLIED	1595
 /*!
  * layered: how many log applications the layered table manager skipped
  * on this tree
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_SKIPPED	1595
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_SKIPPED	1596
 /*!
  * layered: how many previously-applied LSNs the layered table manager
  * skipped on this tree

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -7424,7 +7424,7 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 /*! checkpoint: total time (msecs) */
 #define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1431
 /*!
- * checkpoint: total time (usecs) writing pages to stable storage during
+ * checkpoint: total time (msecs) writing pages to stable storage during
  * checkpoint reconciliation
  */
 #define	WT_STAT_CONN_CHECKPOINT_REC_BLKCACHE_WRITE	1432

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -8981,7 +8981,7 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_DSRC_BTREE_CHECKPOINT_PAGES_RECONCILED	2031
 /*! btree: btree skipped by compaction as process would not reduce size */
 #define	WT_STAT_DSRC_BTREE_COMPACT_SKIPPED		2032
-/*! btree: checkpoint B-tree walk, construct and write duration (usecs) */
+/*! btree: checkpoint btree walk, construct and write duration (usecs) */
 #define	WT_STAT_DSRC_BTREE_CHECKPOINT_RECONCILE_DURATION	2033
 /*!
  * btree: column-store internal pages, only reported if tree_walk or all

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -8981,1137 +8981,1139 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_DSRC_BTREE_CHECKPOINT_PAGES_RECONCILED	2031
 /*! btree: btree skipped by compaction as process would not reduce size */
 #define	WT_STAT_DSRC_BTREE_COMPACT_SKIPPED		2032
+/*! btree: checkpoint B-tree walk, construct and write duration (usecs) */
+#define	WT_STAT_DSRC_BTREE_CHECKPOINT_RECONCILE_DURATION	2033
 /*!
  * btree: column-store internal pages, only reported if tree_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_COLUMN_INTERNAL		2033
+#define	WT_STAT_DSRC_BTREE_COLUMN_INTERNAL		2034
 /*!
  * btree: column-store variable-size RLE encoded values, only reported if
  * tree_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_COLUMN_RLE			2034
+#define	WT_STAT_DSRC_BTREE_COLUMN_RLE			2035
 /*!
  * btree: column-store variable-size deleted values, only reported if
  * tree_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_COLUMN_DELETED		2035
+#define	WT_STAT_DSRC_BTREE_COLUMN_DELETED		2036
 /*!
  * btree: column-store variable-size leaf pages, only reported if
  * tree_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_COLUMN_VARIABLE		2036
+#define	WT_STAT_DSRC_BTREE_COLUMN_VARIABLE		2037
 /*! btree: fixed-record size */
-#define	WT_STAT_DSRC_BTREE_FIXED_LEN			2037
+#define	WT_STAT_DSRC_BTREE_FIXED_LEN			2038
 /*! btree: maximum internal page size */
-#define	WT_STAT_DSRC_BTREE_MAXINTLPAGE			2038
+#define	WT_STAT_DSRC_BTREE_MAXINTLPAGE			2039
 /*! btree: maximum leaf page key size */
-#define	WT_STAT_DSRC_BTREE_MAXLEAFKEY			2039
+#define	WT_STAT_DSRC_BTREE_MAXLEAFKEY			2040
 /*! btree: maximum leaf page size */
-#define	WT_STAT_DSRC_BTREE_MAXLEAFPAGE			2040
+#define	WT_STAT_DSRC_BTREE_MAXLEAFPAGE			2041
 /*! btree: maximum leaf page value size */
-#define	WT_STAT_DSRC_BTREE_MAXLEAFVALUE			2041
+#define	WT_STAT_DSRC_BTREE_MAXLEAFVALUE			2042
 /*! btree: maximum tree depth */
-#define	WT_STAT_DSRC_BTREE_MAXIMUM_DEPTH		2042
+#define	WT_STAT_DSRC_BTREE_MAXIMUM_DEPTH		2043
 /*!
  * btree: number of key/value pairs, only reported if tree_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_ENTRIES			2043
+#define	WT_STAT_DSRC_BTREE_ENTRIES			2044
 /*!
  * btree: overflow pages, only reported if tree_walk or all statistics
  * are enabled
  */
-#define	WT_STAT_DSRC_BTREE_OVERFLOW			2044
+#define	WT_STAT_DSRC_BTREE_OVERFLOW			2045
 /*!
  * btree: row-store empty values, only reported if tree_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_ROW_EMPTY_VALUES		2045
+#define	WT_STAT_DSRC_BTREE_ROW_EMPTY_VALUES		2046
 /*!
  * btree: row-store internal pages, only reported if tree_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_ROW_INTERNAL			2046
+#define	WT_STAT_DSRC_BTREE_ROW_INTERNAL			2047
 /*!
  * btree: row-store leaf pages, only reported if tree_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_ROW_LEAF			2047
+#define	WT_STAT_DSRC_BTREE_ROW_LEAF			2048
 /*!
  * cache: application threads eviction requested with cache fill ratio <
  * 25%
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_APP_THREADS_FILL_RATIO_LT_25	2048
+#define	WT_STAT_DSRC_CACHE_EVICTION_APP_THREADS_FILL_RATIO_LT_25	2049
 /*!
  * cache: application threads eviction requested with cache fill ratio >=
  * 25% and < 50%
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_APP_THREADS_FILL_RATIO_25_50	2049
+#define	WT_STAT_DSRC_CACHE_EVICTION_APP_THREADS_FILL_RATIO_25_50	2050
 /*!
  * cache: application threads eviction requested with cache fill ratio >=
  * 50% and < 75%
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_APP_THREADS_FILL_RATIO_50_75	2050
+#define	WT_STAT_DSRC_CACHE_EVICTION_APP_THREADS_FILL_RATIO_50_75	2051
 /*!
  * cache: application threads eviction requested with cache fill ratio >=
  * 75%
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_APP_THREADS_FILL_RATIO_GT_75	2051
+#define	WT_STAT_DSRC_CACHE_EVICTION_APP_THREADS_FILL_RATIO_GT_75	2052
 /*!
  * cache: application threads eviction skip page with updates or dirty
  * page
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_APP_THREADS_SKIP_UPDATES_DIRTY_PAGE	2052
+#define	WT_STAT_DSRC_CACHE_EVICTION_APP_THREADS_SKIP_UPDATES_DIRTY_PAGE	2053
 /*! cache: bytes currently in the cache */
-#define	WT_STAT_DSRC_CACHE_BYTES_INUSE			2053
+#define	WT_STAT_DSRC_CACHE_BYTES_INUSE			2054
 /*! cache: bytes dirty in the cache cumulative */
-#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY_TOTAL		2054
+#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY_TOTAL		2055
 /*! cache: bytes read into cache */
-#define	WT_STAT_DSRC_CACHE_BYTES_READ			2055
+#define	WT_STAT_DSRC_CACHE_BYTES_READ			2056
 /*! cache: bytes written from cache */
-#define	WT_STAT_DSRC_CACHE_BYTES_WRITE			2056
+#define	WT_STAT_DSRC_CACHE_BYTES_WRITE			2057
 /*! cache: checkpoint blocked page eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_CHECKPOINT	2057
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_CHECKPOINT	2058
 /*!
  * cache: checkpoint of history store file blocked non-history store page
  * eviction
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_CHECKPOINT_HS	2058
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_CHECKPOINT_HS	2059
 /*! cache: data source pages selected for eviction unable to be evicted */
-#define	WT_STAT_DSRC_EVICTION_FAIL			2059
+#define	WT_STAT_DSRC_EVICTION_FAIL			2060
 /*! cache: dirty internal page cannot be evicted in disaggregated storage */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_DISAGG_DIRTY_INTERNAL_PAGE	2060
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_DISAGG_DIRTY_INTERNAL_PAGE	2061
 /*!
  * cache: eviction gave up due to detecting a disk value without a
  * timestamp behind the last update on the chain
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_1	2061
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_1	2062
 /*!
  * cache: eviction gave up due to detecting a tombstone without a
  * timestamp ahead of the selected on disk update
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_2	2062
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_2	2063
 /*!
  * cache: eviction gave up due to detecting a tombstone without a
  * timestamp ahead of the selected on disk update after validating the
  * update chain
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_3	2063
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_3	2064
 /*!
  * cache: eviction gave up due to detecting update chain entries without
  * timestamps after the selected on disk update
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_4	2064
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_4	2065
 /*!
  * cache: eviction gave up due to needing to remove a record from the
  * history store but checkpoint is running
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_REMOVE_HS_RACE_WITH_CHECKPOINT	2065
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_REMOVE_HS_RACE_WITH_CHECKPOINT	2066
 /*! cache: eviction gave up due to no progress being made */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_NO_PROGRESS	2066
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_NO_PROGRESS	2067
 /*! cache: eviction server skipped the pages when prefetching */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_PREFETCHED	2067
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_PREFETCHED	2068
 /*! cache: eviction walk pages queued that had updates */
-#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_QUEUED_UPDATES	2068
+#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_QUEUED_UPDATES	2069
 /*! cache: eviction walk pages queued that were clean */
-#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_QUEUED_CLEAN	2069
+#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_QUEUED_CLEAN	2070
 /*! cache: eviction walk pages queued that were dirty */
-#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_QUEUED_DIRTY	2070
+#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_QUEUED_DIRTY	2071
 /*! cache: eviction walk pages seen that had updates */
-#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_SEEN_UPDATES	2071
+#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_SEEN_UPDATES	2072
 /*! cache: eviction walk pages seen that were clean */
-#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_SEEN_CLEAN	2072
+#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_SEEN_CLEAN	2073
 /*! cache: eviction walk pages seen that were dirty */
-#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_SEEN_DIRTY	2073
+#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_SEEN_DIRTY	2074
 /*! cache: eviction walk passes of a file */
-#define	WT_STAT_DSRC_EVICTION_WALK_PASSES		2074
+#define	WT_STAT_DSRC_EVICTION_WALK_PASSES		2075
 /*! cache: eviction walk target pages histogram - 0-9 */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT10	2075
+#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT10	2076
 /*! cache: eviction walk target pages histogram - 10-31 */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT32	2076
+#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT32	2077
 /*! cache: eviction walk target pages histogram - 128 and higher */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_GE128	2077
+#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_GE128	2078
 /*! cache: eviction walk target pages histogram - 32-63 */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT64	2078
+#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT64	2079
 /*! cache: eviction walk target pages histogram - 64-128 */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT128	2079
+#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_LT128	2080
 /*!
  * cache: eviction walk target pages reduced due to history store cache
  * pressure
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_REDUCED	2080
+#define	WT_STAT_DSRC_CACHE_EVICTION_TARGET_PAGE_REDUCED	2081
 /*!
  * cache: garbage collection from the ingest btree page is skipped
  * because the prune timestamp has not moved
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_PRUNE_TIMESTAMP	2081
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_PRUNE_TIMESTAMP	2082
 /*! cache: hazard pointer blocked page eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_HAZARD	2082
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_HAZARD	2083
 /*! cache: history store cursor not cached during eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_HS_CURSOR_NOT_CACHED	2083
+#define	WT_STAT_DSRC_CACHE_EVICTION_HS_CURSOR_NOT_CACHED	2084
 /*! cache: history store table insert calls */
-#define	WT_STAT_DSRC_CACHE_HS_INSERT			2084
+#define	WT_STAT_DSRC_CACHE_HS_INSERT			2085
 /*! cache: history store table insert calls that returned restart */
-#define	WT_STAT_DSRC_CACHE_HS_INSERT_RESTART		2085
+#define	WT_STAT_DSRC_CACHE_HS_INSERT_RESTART		2086
 /*! cache: history store table key to be processed */
-#define	WT_STAT_DSRC_CACHE_HS_KEY_PROCESSED		2086
+#define	WT_STAT_DSRC_CACHE_HS_KEY_PROCESSED		2087
 /*! cache: history store table reads */
-#define	WT_STAT_DSRC_CACHE_HS_READ			2087
+#define	WT_STAT_DSRC_CACHE_HS_READ			2088
 /*! cache: history store table reads missed */
-#define	WT_STAT_DSRC_CACHE_HS_READ_MISS			2088
+#define	WT_STAT_DSRC_CACHE_HS_READ_MISS			2089
 /*! cache: history store table reads requiring squashed modifies */
-#define	WT_STAT_DSRC_CACHE_HS_READ_SQUASH		2089
+#define	WT_STAT_DSRC_CACHE_HS_READ_SQUASH		2090
 /*!
  * cache: history store table resolved updates without timestamps that
  * lose their durable timestamp
  */
-#define	WT_STAT_DSRC_CACHE_HS_ORDER_LOSE_DURABLE_TIMESTAMP	2090
+#define	WT_STAT_DSRC_CACHE_HS_ORDER_LOSE_DURABLE_TIMESTAMP	2091
 /*!
  * cache: history store table truncation by rollback to stable to remove
  * an unstable update
  */
-#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE	2091
+#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE	2092
 /*!
  * cache: history store table truncation by rollback to stable to remove
  * an update
  */
-#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_RTS		2092
+#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_RTS		2093
 /*!
  * cache: history store table truncation to remove all the keys of a
  * btree
  */
-#define	WT_STAT_DSRC_CACHE_HS_BTREE_TRUNCATE		2093
+#define	WT_STAT_DSRC_CACHE_HS_BTREE_TRUNCATE		2094
 /*! cache: history store table truncation to remove an update */
-#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE		2094
+#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE		2095
 /*!
  * cache: history store table truncation to remove range of updates due
  * to an update without a timestamp on data page
  */
-#define	WT_STAT_DSRC_CACHE_HS_ORDER_REMOVE		2095
+#define	WT_STAT_DSRC_CACHE_HS_ORDER_REMOVE		2096
 /*!
  * cache: history store table truncation to remove range of updates due
  * to key being removed from the data page during reconciliation
  */
-#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_ONPAGE_REMOVAL	2096
+#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_ONPAGE_REMOVAL	2097
 /*!
  * cache: history store table truncations that would have happened in
  * non-dryrun mode
  */
-#define	WT_STAT_DSRC_CACHE_HS_BTREE_TRUNCATE_DRYRUN	2097
+#define	WT_STAT_DSRC_CACHE_HS_BTREE_TRUNCATE_DRYRUN	2098
 /*!
  * cache: history store table truncations to remove an unstable update
  * that would have happened in non-dryrun mode
  */
-#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE_DRYRUN	2098
+#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE_DRYRUN	2099
 /*!
  * cache: history store table truncations to remove an update that would
  * have happened in non-dryrun mode
  */
-#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_RTS_DRYRUN	2099
+#define	WT_STAT_DSRC_CACHE_HS_KEY_TRUNCATE_RTS_DRYRUN	2100
 /*! cache: history store table update to be processed */
-#define	WT_STAT_DSRC_CACHE_HS_UPDATE_PROCESSED		2100
+#define	WT_STAT_DSRC_CACHE_HS_UPDATE_PROCESSED		2101
 /*!
  * cache: history store table updates without timestamps fixed up by
  * reinserting with the fixed timestamp
  */
-#define	WT_STAT_DSRC_CACHE_HS_ORDER_REINSERT		2101
+#define	WT_STAT_DSRC_CACHE_HS_ORDER_REINSERT		2102
 /*! cache: history store table writes requiring squashed modifies */
-#define	WT_STAT_DSRC_CACHE_HS_WRITE_SQUASH		2102
+#define	WT_STAT_DSRC_CACHE_HS_WRITE_SQUASH		2103
 /*! cache: in-memory page passed criteria to be split */
-#define	WT_STAT_DSRC_CACHE_INMEM_SPLITTABLE		2103
+#define	WT_STAT_DSRC_CACHE_INMEM_SPLITTABLE		2104
 /*! cache: in-memory page splits */
-#define	WT_STAT_DSRC_CACHE_INMEM_SPLIT			2104
+#define	WT_STAT_DSRC_CACHE_INMEM_SPLIT			2105
 /*! cache: internal page split blocked its eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_INTERNAL_PAGE_SPLIT	2105
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_INTERNAL_PAGE_SPLIT	2106
 /*! cache: internal pages evicted */
-#define	WT_STAT_DSRC_CACHE_EVICTION_INTERNAL		2106
+#define	WT_STAT_DSRC_CACHE_EVICTION_INTERNAL		2107
 /*! cache: internal pages split during eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_SPLIT_INTERNAL	2107
+#define	WT_STAT_DSRC_CACHE_EVICTION_SPLIT_INTERNAL	2108
 /*! cache: leaf pages split during eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_SPLIT_LEAF		2108
+#define	WT_STAT_DSRC_CACHE_EVICTION_SPLIT_LEAF		2109
 /*!
  * cache: locate a random in-mem ref by examining all entries on the root
  * page
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_RANDOM_SAMPLE_INMEM_ROOT	2109
+#define	WT_STAT_DSRC_CACHE_EVICTION_RANDOM_SAMPLE_INMEM_ROOT	2110
 /*! cache: modified pages evicted */
-#define	WT_STAT_DSRC_CACHE_EVICTION_DIRTY		2110
+#define	WT_STAT_DSRC_CACHE_EVICTION_DIRTY		2111
 /*! cache: multi-block reconciliation blocked whilst checkpoint is running */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_MULTI_BLOCK_RECONCILIATION_DURING_CHECKPOINT	2111
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_MULTI_BLOCK_RECONCILIATION_DURING_CHECKPOINT	2112
 /*! cache: number of internal pages read that had deltas attached */
-#define	WT_STAT_DSRC_CACHE_READ_INTERNAL_DELTA		2112
+#define	WT_STAT_DSRC_CACHE_READ_INTERNAL_DELTA		2113
 /*! cache: number of leaf pages read that had deltas attached */
-#define	WT_STAT_DSRC_CACHE_READ_LEAF_DELTA		2113
+#define	WT_STAT_DSRC_CACHE_READ_LEAF_DELTA		2114
 /*! cache: number of times dirty trigger was reached */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TRIGGER_DIRTY_REACHED	2114
+#define	WT_STAT_DSRC_CACHE_EVICTION_TRIGGER_DIRTY_REACHED	2115
 /*! cache: number of times eviction trigger was reached */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TRIGGER_REACHED	2115
+#define	WT_STAT_DSRC_CACHE_EVICTION_TRIGGER_REACHED	2116
 /*! cache: number of times updates trigger was reached */
-#define	WT_STAT_DSRC_CACHE_EVICTION_TRIGGER_UPDATES_REACHED	2116
+#define	WT_STAT_DSRC_CACHE_EVICTION_TRIGGER_UPDATES_REACHED	2117
 /*! cache: number of times when cas update the btree max_lsn failed */
-#define	WT_STAT_DSRC_CACHE_CAS_BTREE_MAX_LSN_RACE	2117
+#define	WT_STAT_DSRC_CACHE_CAS_BTREE_MAX_LSN_RACE	2118
 /*! cache: obsolete updates removed */
-#define	WT_STAT_DSRC_CACHE_OBSOLETE_UPDATES_REMOVED	2118
+#define	WT_STAT_DSRC_CACHE_OBSOLETE_UPDATES_REMOVED	2119
 /*!
  * cache: overflow keys on a multiblock row-store page blocked its
  * eviction
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_OVERFLOW_KEYS	2119
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_OVERFLOW_KEYS	2120
 /*! cache: overflow pages read into cache */
-#define	WT_STAT_DSRC_CACHE_READ_OVERFLOW		2120
+#define	WT_STAT_DSRC_CACHE_READ_OVERFLOW		2121
 /*! cache: page eviction blocked due to materialization frontier */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_MATERIALIZATION	2121
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_MATERIALIZATION	2122
 /*!
  * cache: page eviction blocked in disaggregated storage as it can only
  * be written by the next checkpoint
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_DISAGG_NEXT_CHECKPOINT	2122
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_DISAGG_NEXT_CHECKPOINT	2123
 /*! cache: page split during eviction deepened the tree */
-#define	WT_STAT_DSRC_CACHE_EVICTION_DEEPEN		2123
+#define	WT_STAT_DSRC_CACHE_EVICTION_DEEPEN		2124
 /*! cache: page written requiring history store records */
-#define	WT_STAT_DSRC_CACHE_WRITE_HS			2124
+#define	WT_STAT_DSRC_CACHE_WRITE_HS			2125
 /*! cache: pages dirtied due to obsolete time window by eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_DIRTY_OBSOLETE_TW	2125
+#define	WT_STAT_DSRC_CACHE_EVICTION_DIRTY_OBSOLETE_TW	2126
 /*! cache: pages evicted ahead of the page materialization frontier */
-#define	WT_STAT_DSRC_CACHE_EVICTION_AHEAD_OF_LAST_MATERIALIZED_LSN	2126
+#define	WT_STAT_DSRC_CACHE_EVICTION_AHEAD_OF_LAST_MATERIALIZED_LSN	2127
 /*! cache: pages read into cache */
-#define	WT_STAT_DSRC_CACHE_READ				2127
+#define	WT_STAT_DSRC_CACHE_READ				2128
 /*! cache: pages read into cache after truncate */
-#define	WT_STAT_DSRC_CACHE_READ_DELETED			2128
+#define	WT_STAT_DSRC_CACHE_READ_DELETED			2129
 /*! cache: pages read into cache after truncate in prepare state */
-#define	WT_STAT_DSRC_CACHE_READ_DELETED_PREPARED	2129
+#define	WT_STAT_DSRC_CACHE_READ_DELETED_PREPARED	2130
 /*! cache: pages read into cache by checkpoint */
-#define	WT_STAT_DSRC_CACHE_READ_CHECKPOINT		2130
+#define	WT_STAT_DSRC_CACHE_READ_CHECKPOINT		2131
 /*! cache: pages requested from the cache */
-#define	WT_STAT_DSRC_CACHE_PAGES_REQUESTED		2131
+#define	WT_STAT_DSRC_CACHE_PAGES_REQUESTED		2132
 /*! cache: pages requested from the cache due to pre-fetch */
-#define	WT_STAT_DSRC_CACHE_PAGES_PREFETCH		2132
+#define	WT_STAT_DSRC_CACHE_PAGES_PREFETCH		2133
 /*! cache: pages requested from the cache internal */
-#define	WT_STAT_DSRC_CACHE_PAGES_REQUESTED_INTERNAL	2133
+#define	WT_STAT_DSRC_CACHE_PAGES_REQUESTED_INTERNAL	2134
 /*! cache: pages requested from the cache leaf */
-#define	WT_STAT_DSRC_CACHE_PAGES_REQUESTED_LEAF		2134
+#define	WT_STAT_DSRC_CACHE_PAGES_REQUESTED_LEAF		2135
 /*! cache: pages requested from the history store */
-#define	WT_STAT_DSRC_CACHE_PAGES_REQUESTED_HS		2135
+#define	WT_STAT_DSRC_CACHE_PAGES_REQUESTED_HS		2136
 /*! cache: pages seen by eviction walk */
-#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_SEEN		2136
+#define	WT_STAT_DSRC_CACHE_EVICTION_PAGES_SEEN		2137
 /*! cache: pages written from cache */
-#define	WT_STAT_DSRC_CACHE_WRITE			2137
+#define	WT_STAT_DSRC_CACHE_WRITE			2138
 /*!
  * cache: pages written requiring in-memory restoration due to invisible
  * updates
  */
-#define	WT_STAT_DSRC_CACHE_WRITE_RESTORE_INVISIBLE	2138
+#define	WT_STAT_DSRC_CACHE_WRITE_RESTORE_INVISIBLE	2139
 /*!
  * cache: pages written requiring in-memory restoration due to scrub
  * eviction
  */
-#define	WT_STAT_DSRC_CACHE_WRITE_RESTORE_SCRUB		2139
+#define	WT_STAT_DSRC_CACHE_WRITE_RESTORE_SCRUB		2140
 /*!
  * cache: precise checkpoint caused an eviction to be skipped because any
  * dirty content needs to remain in cache
  */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_PRECISE_CHECKPOINT	2140
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_PRECISE_CHECKPOINT	2141
 /*!
  * cache: realizing in-memory split after reconciliation failed due to
  * internal lock busy
  */
-#define	WT_STAT_DSRC_CACHE_EVICT_SPLIT_FAILED_LOCK	2141
+#define	WT_STAT_DSRC_CACHE_EVICT_SPLIT_FAILED_LOCK	2142
 /*! cache: recent modification of a page blocked its eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	2142
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	2143
 /*! cache: reconciled pages scrubbed and added back to the cache clean */
-#define	WT_STAT_DSRC_CACHE_SCRUB_RESTORE		2143
+#define	WT_STAT_DSRC_CACHE_SCRUB_RESTORE		2144
 /*! cache: reverse splits performed */
-#define	WT_STAT_DSRC_CACHE_REVERSE_SPLITS		2144
+#define	WT_STAT_DSRC_CACHE_REVERSE_SPLITS		2145
 /*!
  * cache: reverse splits skipped because of VLCS namespace gap
  * restrictions
  */
-#define	WT_STAT_DSRC_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	2145
+#define	WT_STAT_DSRC_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	2146
 /*! cache: shared history store cursor not cached during eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_HS_SHARED_CURSOR_NOT_CACHED	2146
+#define	WT_STAT_DSRC_CACHE_EVICTION_HS_SHARED_CURSOR_NOT_CACHED	2147
 /*! cache: size of delta updates reconstructed on the base page */
-#define	WT_STAT_DSRC_CACHE_READ_DELTA_UPDATES		2147
+#define	WT_STAT_DSRC_CACHE_READ_DELTA_UPDATES		2148
 /*! cache: size of tombstones restored when reading a page */
-#define	WT_STAT_DSRC_CACHE_READ_RESTORED_TOMBSTONE_BYTES	2148
+#define	WT_STAT_DSRC_CACHE_READ_RESTORED_TOMBSTONE_BYTES	2149
 /*! cache: the number of times full update inserted to history store */
-#define	WT_STAT_DSRC_CACHE_HS_INSERT_FULL_UPDATE	2149
+#define	WT_STAT_DSRC_CACHE_HS_INSERT_FULL_UPDATE	2150
 /*! cache: the number of times reverse modify inserted to history store */
-#define	WT_STAT_DSRC_CACHE_HS_INSERT_REVERSE_MODIFY	2150
+#define	WT_STAT_DSRC_CACHE_HS_INSERT_REVERSE_MODIFY	2151
 /*! cache: tracked dirty bytes in the cache */
-#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY			2151
+#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY			2152
 /*! cache: tracked dirty internal page bytes in the cache */
-#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY_INTERNAL		2152
+#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY_INTERNAL		2153
 /*! cache: tracked dirty leaf page bytes in the cache */
-#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY_LEAF		2153
+#define	WT_STAT_DSRC_CACHE_BYTES_DIRTY_LEAF		2154
 /*! cache: uncommitted truncate blocked page eviction */
-#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	2154
+#define	WT_STAT_DSRC_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	2155
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_DSRC_CACHE_EVICTION_CLEAN		2155
+#define	WT_STAT_DSRC_CACHE_EVICTION_CLEAN		2156
 /*!
  * cache_walk: Average difference between current eviction generation
  * when the page was last considered, only reported if cache_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_GEN_AVG_GAP		2156
+#define	WT_STAT_DSRC_CACHE_STATE_GEN_AVG_GAP		2157
 /*!
  * cache_walk: Average on-disk page image size seen, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_AVG_WRITTEN_SIZE	2157
+#define	WT_STAT_DSRC_CACHE_STATE_AVG_WRITTEN_SIZE	2158
 /*!
  * cache_walk: Average time in cache for pages that have been visited by
  * the eviction server, only reported if cache_walk or all statistics are
  * enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_AVG_VISITED_AGE	2158
+#define	WT_STAT_DSRC_CACHE_STATE_AVG_VISITED_AGE	2159
 /*!
  * cache_walk: Average time in cache for pages that have not been visited
  * by the eviction server, only reported if cache_walk or all statistics
  * are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_AVG_UNVISITED_AGE	2159
+#define	WT_STAT_DSRC_CACHE_STATE_AVG_UNVISITED_AGE	2160
 /*!
  * cache_walk: Clean pages currently in cache, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES_CLEAN		2160
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES_CLEAN		2161
 /*!
  * cache_walk: Current eviction generation, only reported if cache_walk
  * or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_GEN_CURRENT		2161
+#define	WT_STAT_DSRC_CACHE_STATE_GEN_CURRENT		2162
 /*!
  * cache_walk: Dirty pages currently in cache, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES_DIRTY		2162
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES_DIRTY		2163
 /*!
  * cache_walk: Entries in the root page, only reported if cache_walk or
  * all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_ROOT_ENTRIES		2163
+#define	WT_STAT_DSRC_CACHE_STATE_ROOT_ENTRIES		2164
 /*!
  * cache_walk: Internal pages currently in cache, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES_INTERNAL		2164
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES_INTERNAL		2165
 /*!
  * cache_walk: Leaf pages currently in cache, only reported if cache_walk
  * or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES_LEAF		2165
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES_LEAF		2166
 /*!
  * cache_walk: Maximum difference between current eviction generation
  * when the page was last considered, only reported if cache_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_GEN_MAX_GAP		2166
+#define	WT_STAT_DSRC_CACHE_STATE_GEN_MAX_GAP		2167
 /*!
  * cache_walk: Maximum page size seen, only reported if cache_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_MAX_PAGESIZE		2167
+#define	WT_STAT_DSRC_CACHE_STATE_MAX_PAGESIZE		2168
 /*!
  * cache_walk: Minimum on-disk page image size seen, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_MIN_WRITTEN_SIZE	2168
+#define	WT_STAT_DSRC_CACHE_STATE_MIN_WRITTEN_SIZE	2169
 /*!
  * cache_walk: Number of pages never visited by eviction server, only
  * reported if cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_UNVISITED_COUNT	2169
+#define	WT_STAT_DSRC_CACHE_STATE_UNVISITED_COUNT	2170
 /*!
  * cache_walk: On-disk page image sizes smaller than a single allocation
  * unit, only reported if cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_SMALLER_ALLOC_SIZE	2170
+#define	WT_STAT_DSRC_CACHE_STATE_SMALLER_ALLOC_SIZE	2171
 /*!
  * cache_walk: Pages created in memory and never written, only reported
  * if cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_MEMORY			2171
+#define	WT_STAT_DSRC_CACHE_STATE_MEMORY			2172
 /*!
  * cache_walk: Pages currently queued for eviction, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_QUEUED			2172
+#define	WT_STAT_DSRC_CACHE_STATE_QUEUED			2173
 /*!
  * cache_walk: Pages that could not be queued for eviction, only reported
  * if cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_NOT_QUEUEABLE		2173
+#define	WT_STAT_DSRC_CACHE_STATE_NOT_QUEUEABLE		2174
 /*!
  * cache_walk: Refs skipped during cache traversal, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_REFS_SKIPPED		2174
+#define	WT_STAT_DSRC_CACHE_STATE_REFS_SKIPPED		2175
 /*!
  * cache_walk: Size of the root page, only reported if cache_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_ROOT_SIZE		2175
+#define	WT_STAT_DSRC_CACHE_STATE_ROOT_SIZE		2176
 /*!
  * cache_walk: Total number of pages currently in cache, only reported if
  * cache_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_CACHE_STATE_PAGES			2176
+#define	WT_STAT_DSRC_CACHE_STATE_PAGES			2177
 /*! checkpoint-cleanup: pages added for eviction */
-#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_EVICT	2177
+#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_EVICT	2178
 /*! checkpoint-cleanup: pages dirtied due to obsolete time window */
-#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	2178
+#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	2179
 /*! checkpoint-cleanup: pages read into cache (reclaim_space) */
-#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	2179
+#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	2180
 /*! checkpoint-cleanup: pages read into cache due to obsolete time window */
-#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	2180
+#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	2181
 /*! checkpoint-cleanup: pages removed */
-#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_REMOVED	2181
+#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_REMOVED	2182
 /*! checkpoint-cleanup: pages skipped during tree walk */
-#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	2182
+#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	2183
 /*! checkpoint-cleanup: pages visited */
-#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_VISITED	2183
+#define	WT_STAT_DSRC_CHECKPOINT_CLEANUP_PAGES_VISITED	2184
 /*! checkpoint: checkpoint has acquired a snapshot for its transaction */
-#define	WT_STAT_DSRC_CHECKPOINT_SNAPSHOT_ACQUIRED	2184
+#define	WT_STAT_DSRC_CHECKPOINT_SNAPSHOT_ACQUIRED	2185
 /*!
  * compression: compressed page maximum internal page size prior to
  * compression
  */
-#define	WT_STAT_DSRC_COMPRESS_PRECOMP_INTL_MAX_PAGE_SIZE	2185
+#define	WT_STAT_DSRC_COMPRESS_PRECOMP_INTL_MAX_PAGE_SIZE	2186
 /*!
  * compression: compressed page maximum leaf page size prior to
  * compression
  */
-#define	WT_STAT_DSRC_COMPRESS_PRECOMP_LEAF_MAX_PAGE_SIZE	2186
+#define	WT_STAT_DSRC_COMPRESS_PRECOMP_LEAF_MAX_PAGE_SIZE	2187
 /*! compression: page written to disk failed to compress */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_FAIL		2187
+#define	WT_STAT_DSRC_COMPRESS_WRITE_FAIL		2188
 /*! compression: page written to disk was too small to compress */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_TOO_SMALL		2188
+#define	WT_STAT_DSRC_COMPRESS_WRITE_TOO_SMALL		2189
 /*! compression: pages read from disk */
-#define	WT_STAT_DSRC_COMPRESS_READ			2189
+#define	WT_STAT_DSRC_COMPRESS_READ			2190
 /*!
  * compression: pages read from disk with compression ratio greater than
  * 64
  */
-#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_MAX	2190
+#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_MAX	2191
 /*!
  * compression: pages read from disk with compression ratio smaller than
  * 2
  */
-#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_2		2191
+#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_2		2192
 /*!
  * compression: pages read from disk with compression ratio smaller than
  * 4
  */
-#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_4		2192
+#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_4		2193
 /*!
  * compression: pages read from disk with compression ratio smaller than
  * 8
  */
-#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_8		2193
+#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_8		2194
 /*!
  * compression: pages read from disk with compression ratio smaller than
  * 16
  */
-#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_16	2194
+#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_16	2195
 /*!
  * compression: pages read from disk with compression ratio smaller than
  * 32
  */
-#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_32	2195
+#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_32	2196
 /*!
  * compression: pages read from disk with compression ratio smaller than
  * 64
  */
-#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_64	2196
+#define	WT_STAT_DSRC_COMPRESS_READ_RATIO_HIST_64	2197
 /*! compression: pages written to disk */
-#define	WT_STAT_DSRC_COMPRESS_WRITE			2197
+#define	WT_STAT_DSRC_COMPRESS_WRITE			2198
 /*!
  * compression: pages written to disk with compression ratio greater than
  * 64
  */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_MAX	2198
+#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_MAX	2199
 /*!
  * compression: pages written to disk with compression ratio smaller than
  * 2
  */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_2	2199
+#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_2	2200
 /*!
  * compression: pages written to disk with compression ratio smaller than
  * 4
  */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_4	2200
+#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_4	2201
 /*!
  * compression: pages written to disk with compression ratio smaller than
  * 8
  */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_8	2201
+#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_8	2202
 /*!
  * compression: pages written to disk with compression ratio smaller than
  * 16
  */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_16	2202
+#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_16	2203
 /*!
  * compression: pages written to disk with compression ratio smaller than
  * 32
  */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_32	2203
+#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_32	2204
 /*!
  * compression: pages written to disk with compression ratio smaller than
  * 64
  */
-#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_64	2204
+#define	WT_STAT_DSRC_COMPRESS_WRITE_RATIO_HIST_64	2205
 /*! cursor: Total number of deleted pages skipped during tree walk */
-#define	WT_STAT_DSRC_CURSOR_TREE_WALK_DEL_PAGE_SKIP	2205
+#define	WT_STAT_DSRC_CURSOR_TREE_WALK_DEL_PAGE_SKIP	2206
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_TOTAL		2206
+#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_TOTAL		2207
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_TOTAL		2207
+#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_TOTAL		2208
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_DSRC_CURSOR_SKIP_HS_CUR_POSITION	2208
+#define	WT_STAT_DSRC_CURSOR_SKIP_HS_CUR_POSITION	2209
 /*!
  * cursor: Total number of in-memory deleted pages skipped during tree
  * walk
  */
-#define	WT_STAT_DSRC_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	2209
+#define	WT_STAT_DSRC_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	2210
 /*! cursor: Total number of on-disk deleted pages skipped during tree walk */
-#define	WT_STAT_DSRC_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	2210
+#define	WT_STAT_DSRC_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	2211
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	2211
+#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	2212
 /*!
  * cursor: Total number of times cursor fails to temporarily release
  * pinned page to encourage eviction of hot or large page
  */
-#define	WT_STAT_DSRC_CURSOR_REPOSITION_FAILED		2212
+#define	WT_STAT_DSRC_CURSOR_REPOSITION_FAILED		2213
 /*!
  * cursor: Total number of times cursor temporarily releases pinned page
  * to encourage eviction of hot or large page
  */
-#define	WT_STAT_DSRC_CURSOR_REPOSITION			2213
+#define	WT_STAT_DSRC_CURSOR_REPOSITION			2214
 /*! cursor: bulk loaded cursor insert calls */
-#define	WT_STAT_DSRC_CURSOR_INSERT_BULK			2214
+#define	WT_STAT_DSRC_CURSOR_INSERT_BULK			2215
 /*! cursor: cache cursors reuse count */
-#define	WT_STAT_DSRC_CURSOR_REOPEN			2215
+#define	WT_STAT_DSRC_CURSOR_REOPEN			2216
 /*! cursor: close calls that result in cache */
-#define	WT_STAT_DSRC_CURSOR_CACHE			2216
+#define	WT_STAT_DSRC_CURSOR_CACHE			2217
 /*! cursor: create calls */
-#define	WT_STAT_DSRC_CURSOR_CREATE			2217
+#define	WT_STAT_DSRC_CURSOR_CREATE			2218
 /*! cursor: cursor bound calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_BOUND_ERROR			2218
+#define	WT_STAT_DSRC_CURSOR_BOUND_ERROR			2219
 /*! cursor: cursor bounds cleared from reset */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_RESET		2219
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_RESET		2220
 /*! cursor: cursor bounds comparisons performed */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_COMPARISONS		2220
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_COMPARISONS		2221
 /*! cursor: cursor bounds next called on an unpositioned cursor */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_NEXT_UNPOSITIONED	2221
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_NEXT_UNPOSITIONED	2222
 /*! cursor: cursor bounds next early exit */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_NEXT_EARLY_EXIT	2222
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_NEXT_EARLY_EXIT	2223
 /*! cursor: cursor bounds prev called on an unpositioned cursor */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_PREV_UNPOSITIONED	2223
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_PREV_UNPOSITIONED	2224
 /*! cursor: cursor bounds prev early exit */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_PREV_EARLY_EXIT	2224
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_PREV_EARLY_EXIT	2225
 /*! cursor: cursor bounds search early exit */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	2225
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	2226
 /*! cursor: cursor bounds search near call repositioned cursor */
-#define	WT_STAT_DSRC_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	2226
+#define	WT_STAT_DSRC_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	2227
 /*! cursor: cursor cache calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_CACHE_ERROR			2227
+#define	WT_STAT_DSRC_CURSOR_CACHE_ERROR			2228
 /*! cursor: cursor close calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_CLOSE_ERROR			2228
+#define	WT_STAT_DSRC_CURSOR_CLOSE_ERROR			2229
 /*! cursor: cursor compare calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_COMPARE_ERROR		2229
+#define	WT_STAT_DSRC_CURSOR_COMPARE_ERROR		2230
 /*! cursor: cursor equals calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_EQUALS_ERROR		2230
+#define	WT_STAT_DSRC_CURSOR_EQUALS_ERROR		2231
 /*! cursor: cursor get key calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_GET_KEY_ERROR		2231
+#define	WT_STAT_DSRC_CURSOR_GET_KEY_ERROR		2232
 /*! cursor: cursor get value calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_GET_VALUE_ERROR		2232
+#define	WT_STAT_DSRC_CURSOR_GET_VALUE_ERROR		2233
 /*! cursor: cursor insert calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_INSERT_ERROR		2233
+#define	WT_STAT_DSRC_CURSOR_INSERT_ERROR		2234
 /*! cursor: cursor insert check calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_INSERT_CHECK_ERROR		2234
+#define	WT_STAT_DSRC_CURSOR_INSERT_CHECK_ERROR		2235
 /*! cursor: cursor largest key calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_LARGEST_KEY_ERROR		2235
+#define	WT_STAT_DSRC_CURSOR_LARGEST_KEY_ERROR		2236
 /*! cursor: cursor modify calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_MODIFY_ERROR		2236
+#define	WT_STAT_DSRC_CURSOR_MODIFY_ERROR		2237
 /*! cursor: cursor next calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_NEXT_ERROR			2237
+#define	WT_STAT_DSRC_CURSOR_NEXT_ERROR			2238
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_DSRC_CURSOR_NEXT_HS_TOMBSTONE		2238
+#define	WT_STAT_DSRC_CURSOR_NEXT_HS_TOMBSTONE		2239
 /*!
  * cursor: cursor next calls that skip greater than 1 and fewer than 100
  * entries
  */
-#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_LT_100		2239
+#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_LT_100		2240
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_GE_100		2240
+#define	WT_STAT_DSRC_CURSOR_NEXT_SKIP_GE_100		2241
 /*! cursor: cursor next random calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_NEXT_RANDOM_ERROR		2241
+#define	WT_STAT_DSRC_CURSOR_NEXT_RANDOM_ERROR		2242
 /*! cursor: cursor prev calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_PREV_ERROR			2242
+#define	WT_STAT_DSRC_CURSOR_PREV_ERROR			2243
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_DSRC_CURSOR_PREV_HS_TOMBSTONE		2243
+#define	WT_STAT_DSRC_CURSOR_PREV_HS_TOMBSTONE		2244
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_GE_100		2244
+#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_GE_100		2245
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_LT_100		2245
+#define	WT_STAT_DSRC_CURSOR_PREV_SKIP_LT_100		2246
 /*! cursor: cursor reconfigure calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_RECONFIGURE_ERROR		2246
+#define	WT_STAT_DSRC_CURSOR_RECONFIGURE_ERROR		2247
 /*! cursor: cursor remove calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_REMOVE_ERROR		2247
+#define	WT_STAT_DSRC_CURSOR_REMOVE_ERROR		2248
 /*! cursor: cursor reopen calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_REOPEN_ERROR		2248
+#define	WT_STAT_DSRC_CURSOR_REOPEN_ERROR		2249
 /*! cursor: cursor reserve calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_RESERVE_ERROR		2249
+#define	WT_STAT_DSRC_CURSOR_RESERVE_ERROR		2250
 /*! cursor: cursor reset calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_RESET_ERROR			2250
+#define	WT_STAT_DSRC_CURSOR_RESET_ERROR			2251
 /*! cursor: cursor search calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_ERROR		2251
+#define	WT_STAT_DSRC_CURSOR_SEARCH_ERROR		2252
 /*! cursor: cursor search near calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR_ERROR		2252
+#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR_ERROR		2253
 /*! cursor: cursor update calls that return an error */
-#define	WT_STAT_DSRC_CURSOR_UPDATE_ERROR		2253
+#define	WT_STAT_DSRC_CURSOR_UPDATE_ERROR		2254
 /*! cursor: insert calls */
-#define	WT_STAT_DSRC_CURSOR_INSERT			2254
+#define	WT_STAT_DSRC_CURSOR_INSERT			2255
 /*! cursor: insert key and value bytes */
-#define	WT_STAT_DSRC_CURSOR_INSERT_BYTES		2255
+#define	WT_STAT_DSRC_CURSOR_INSERT_BYTES		2256
 /*! cursor: modify */
-#define	WT_STAT_DSRC_CURSOR_MODIFY			2256
+#define	WT_STAT_DSRC_CURSOR_MODIFY			2257
 /*! cursor: modify key and value bytes affected */
-#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES		2257
+#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES		2258
 /*! cursor: modify value bytes modified */
-#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES_TOUCH		2258
+#define	WT_STAT_DSRC_CURSOR_MODIFY_BYTES_TOUCH		2259
 /*! cursor: next calls */
-#define	WT_STAT_DSRC_CURSOR_NEXT			2259
+#define	WT_STAT_DSRC_CURSOR_NEXT			2260
 /*! cursor: open cursor count */
-#define	WT_STAT_DSRC_CURSOR_OPEN_COUNT			2260
+#define	WT_STAT_DSRC_CURSOR_OPEN_COUNT			2261
 /*! cursor: open cursor time application (usecs) */
-#define	WT_STAT_DSRC_CURSOR_OPEN_TIME_USER_USECS	2261
+#define	WT_STAT_DSRC_CURSOR_OPEN_TIME_USER_USECS	2262
 /*! cursor: open cursor time internal (usecs) */
-#define	WT_STAT_DSRC_CURSOR_OPEN_TIME_INTERNAL_USECS	2262
+#define	WT_STAT_DSRC_CURSOR_OPEN_TIME_INTERNAL_USECS	2263
 /*! cursor: operation restarted */
-#define	WT_STAT_DSRC_CURSOR_RESTART			2263
+#define	WT_STAT_DSRC_CURSOR_RESTART			2264
 /*! cursor: prev calls */
-#define	WT_STAT_DSRC_CURSOR_PREV			2264
+#define	WT_STAT_DSRC_CURSOR_PREV			2265
 /*! cursor: remove calls */
-#define	WT_STAT_DSRC_CURSOR_REMOVE			2265
+#define	WT_STAT_DSRC_CURSOR_REMOVE			2266
 /*! cursor: remove key bytes removed */
-#define	WT_STAT_DSRC_CURSOR_REMOVE_BYTES		2266
+#define	WT_STAT_DSRC_CURSOR_REMOVE_BYTES		2267
 /*! cursor: reserve calls */
-#define	WT_STAT_DSRC_CURSOR_RESERVE			2267
+#define	WT_STAT_DSRC_CURSOR_RESERVE			2268
 /*! cursor: reset calls */
-#define	WT_STAT_DSRC_CURSOR_RESET			2268
+#define	WT_STAT_DSRC_CURSOR_RESET			2269
 /*! cursor: search calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH			2269
+#define	WT_STAT_DSRC_CURSOR_SEARCH			2270
 /*! cursor: search history store calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_HS			2270
+#define	WT_STAT_DSRC_CURSOR_SEARCH_HS			2271
 /*! cursor: search near calls */
-#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR			2271
+#define	WT_STAT_DSRC_CURSOR_SEARCH_NEAR			2272
 /*! cursor: truncate calls */
-#define	WT_STAT_DSRC_CURSOR_TRUNCATE			2272
+#define	WT_STAT_DSRC_CURSOR_TRUNCATE			2273
 /*! cursor: update calls */
-#define	WT_STAT_DSRC_CURSOR_UPDATE			2273
+#define	WT_STAT_DSRC_CURSOR_UPDATE			2274
 /*! cursor: update key and value bytes */
-#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES		2274
+#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES		2275
 /*! cursor: update value size change */
-#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES_CHANGED	2275
+#define	WT_STAT_DSRC_CURSOR_UPDATE_BYTES_CHANGED	2276
 /*! layered: Layered table cursor insert operations */
-#define	WT_STAT_DSRC_LAYERED_CURS_INSERT		2276
+#define	WT_STAT_DSRC_LAYERED_CURS_INSERT		2277
 /*! layered: Layered table cursor modify operations */
-#define	WT_STAT_DSRC_LAYERED_CURS_MODIFY		2277
+#define	WT_STAT_DSRC_LAYERED_CURS_MODIFY		2278
 /*! layered: Layered table cursor next operations */
-#define	WT_STAT_DSRC_LAYERED_CURS_NEXT			2278
+#define	WT_STAT_DSRC_LAYERED_CURS_NEXT			2279
 /*! layered: Layered table cursor next operations from the ingest btrees */
-#define	WT_STAT_DSRC_LAYERED_CURS_NEXT_INGEST		2279
+#define	WT_STAT_DSRC_LAYERED_CURS_NEXT_INGEST		2280
 /*! layered: Layered table cursor next operations from the stable btrees */
-#define	WT_STAT_DSRC_LAYERED_CURS_NEXT_STABLE		2280
+#define	WT_STAT_DSRC_LAYERED_CURS_NEXT_STABLE		2281
 /*! layered: Layered table cursor prev operations */
-#define	WT_STAT_DSRC_LAYERED_CURS_PREV			2281
+#define	WT_STAT_DSRC_LAYERED_CURS_PREV			2282
 /*! layered: Layered table cursor prev operations from the ingest btrees */
-#define	WT_STAT_DSRC_LAYERED_CURS_PREV_INGEST		2282
+#define	WT_STAT_DSRC_LAYERED_CURS_PREV_INGEST		2283
 /*! layered: Layered table cursor prev operations from the stable btrees */
-#define	WT_STAT_DSRC_LAYERED_CURS_PREV_STABLE		2283
+#define	WT_STAT_DSRC_LAYERED_CURS_PREV_STABLE		2284
 /*! layered: Layered table cursor remove operations */
-#define	WT_STAT_DSRC_LAYERED_CURS_REMOVE		2284
+#define	WT_STAT_DSRC_LAYERED_CURS_REMOVE		2285
 /*! layered: Layered table cursor search near operations */
-#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH_NEAR		2285
+#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH_NEAR		2286
 /*!
  * layered: Layered table cursor search near operations from the ingest
  * btrees
  */
-#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH_NEAR_INGEST	2286
+#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH_NEAR_INGEST	2287
 /*!
  * layered: Layered table cursor search near operations from the stable
  * btrees
  */
-#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH_NEAR_STABLE	2287
+#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH_NEAR_STABLE	2288
 /*! layered: Layered table cursor search operations */
-#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH		2288
+#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH		2289
 /*! layered: Layered table cursor search operations from the ingest btrees */
-#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH_INGEST		2289
+#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH_INGEST		2290
 /*! layered: Layered table cursor search operations from the stable btrees */
-#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH_STABLE		2290
+#define	WT_STAT_DSRC_LAYERED_CURS_SEARCH_STABLE		2291
 /*! layered: Layered table cursor update operations */
-#define	WT_STAT_DSRC_LAYERED_CURS_UPDATE		2291
+#define	WT_STAT_DSRC_LAYERED_CURS_UPDATE		2292
 /*! layered: Layered table cursor upgrade state for the ingest btrees */
-#define	WT_STAT_DSRC_LAYERED_CURS_UPGRADE_INGEST	2292
+#define	WT_STAT_DSRC_LAYERED_CURS_UPGRADE_INGEST	2293
 /*! layered: Layered table cursor upgrade state for the stable btrees */
-#define	WT_STAT_DSRC_LAYERED_CURS_UPGRADE_STABLE	2293
+#define	WT_STAT_DSRC_LAYERED_CURS_UPGRADE_STABLE	2294
 /*!
  * layered: checkpoints performed on this table by the layered table
  * manager
  */
-#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_CHECKPOINTS	2294
+#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_CHECKPOINTS	2295
 /*! layered: disagg pick up checkpoints failed */
-#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FAILED	2295
+#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FAILED	2296
 /*! layered: disagg pick up checkpoints succeeded */
-#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_SUCCEED	2296
+#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_SUCCEED	2297
 /*!
  * layered: how many log applications the layered table manager applied
  * on this tree
  */
-#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_LOGOPS_APPLIED	2297
+#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_LOGOPS_APPLIED	2298
 /*!
  * layered: how many log applications the layered table manager skipped
  * on this tree
  */
-#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_LOGOPS_SKIPPED	2298
+#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_LOGOPS_SKIPPED	2299
 /*!
  * layered: how many previously-applied LSNs the layered table manager
  * skipped on this tree
  */
-#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_SKIP_LSN	2299
+#define	WT_STAT_DSRC_LAYERED_TABLE_MANAGER_SKIP_LSN	2300
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_DSRC_REC_VLCS_EMPTIED_PAGES		2300
+#define	WT_STAT_DSRC_REC_VLCS_EMPTIED_PAGES		2301
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TS		2301
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TS		2302
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TXN		2302
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_BYTES_TXN		2303
 /*!
  * reconciliation: average length of delta chain on internal page with
  * deltas
  */
-#define	WT_STAT_DSRC_REC_AVERAGE_INTERNAL_PAGE_DELTA_CHAIN_LENGTH	2303
+#define	WT_STAT_DSRC_REC_AVERAGE_INTERNAL_PAGE_DELTA_CHAIN_LENGTH	2304
 /*! reconciliation: average length of delta chain on leaf page with deltas */
-#define	WT_STAT_DSRC_REC_AVERAGE_LEAF_PAGE_DELTA_CHAIN_LENGTH	2304
+#define	WT_STAT_DSRC_REC_AVERAGE_LEAF_PAGE_DELTA_CHAIN_LENGTH	2305
 /*!
  * reconciliation: changes since prior reconciliation (bucket 1) between
  * 1 and 5
  */
-#define	WT_STAT_DSRC_REC_PAGE_MODS_LE5			2305
+#define	WT_STAT_DSRC_REC_PAGE_MODS_LE5			2306
 /*!
  * reconciliation: changes since prior reconciliation (bucket 2) between
  * 6 and 10
  */
-#define	WT_STAT_DSRC_REC_PAGE_MODS_LE10			2306
+#define	WT_STAT_DSRC_REC_PAGE_MODS_LE10			2307
 /*!
  * reconciliation: changes since prior reconciliation (bucket 3) between
  * 11 and 20
  */
-#define	WT_STAT_DSRC_REC_PAGE_MODS_LE20			2307
+#define	WT_STAT_DSRC_REC_PAGE_MODS_LE20			2308
 /*!
  * reconciliation: changes since prior reconciliation (bucket 4) between
  * 21 and 50
  */
-#define	WT_STAT_DSRC_REC_PAGE_MODS_LE50			2308
+#define	WT_STAT_DSRC_REC_PAGE_MODS_LE50			2309
 /*!
  * reconciliation: changes since prior reconciliation (bucket 5) between
  * 51 and 100
  */
-#define	WT_STAT_DSRC_REC_PAGE_MODS_LE100		2309
+#define	WT_STAT_DSRC_REC_PAGE_MODS_LE100		2310
 /*!
  * reconciliation: changes since prior reconciliation (bucket 6) between
  * 101 and 200
  */
-#define	WT_STAT_DSRC_REC_PAGE_MODS_LE200		2310
+#define	WT_STAT_DSRC_REC_PAGE_MODS_LE200		2311
 /*!
  * reconciliation: changes since prior reconciliation (bucket 7) between
  * 201 and 500
  */
-#define	WT_STAT_DSRC_REC_PAGE_MODS_LE500		2311
+#define	WT_STAT_DSRC_REC_PAGE_MODS_LE500		2312
 /*!
  * reconciliation: changes since prior reconciliation (bucket 8) greater
  * than 500
  */
-#define	WT_STAT_DSRC_REC_PAGE_MODS_GT500		2312
+#define	WT_STAT_DSRC_REC_PAGE_MODS_GT500		2313
 /*! reconciliation: cursor next/prev calls during HS wrapup search_near */
-#define	WT_STAT_DSRC_REC_HS_WRAPUP_NEXT_PREV_CALLS	2313
+#define	WT_STAT_DSRC_REC_HS_WRAPUP_NEXT_PREV_CALLS	2314
 /*! reconciliation: dictionary matches */
-#define	WT_STAT_DSRC_REC_DICTIONARY			2314
+#define	WT_STAT_DSRC_REC_DICTIONARY			2315
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELETE_FAST		2315
+#define	WT_STAT_DSRC_REC_PAGE_DELETE_FAST		2316
 /*!
  * reconciliation: free page ID due to failed page replacement
  * reconciliation in disagg
  */
-#define	WT_STAT_DSRC_REC_FREE_PAGE_ID_DUE_TO_FAILED_REPLACEMENT_RECONCILIATION	2316
+#define	WT_STAT_DSRC_REC_FREE_PAGE_ID_DUE_TO_FAILED_REPLACEMENT_RECONCILIATION	2317
 /*! reconciliation: full internal pages written instead of a page delta */
-#define	WT_STAT_DSRC_REC_PAGE_FULL_IMAGE_INTERNAL	2317
+#define	WT_STAT_DSRC_REC_PAGE_FULL_IMAGE_INTERNAL	2318
 /*! reconciliation: full leaf pages written instead of a page delta */
-#define	WT_STAT_DSRC_REC_PAGE_FULL_IMAGE_LEAF		2318
+#define	WT_STAT_DSRC_REC_PAGE_FULL_IMAGE_LEAF		2319
 /*!
  * reconciliation: ingest btree reconciliation keeps the aborted prepare
  * updates
  */
-#define	WT_STAT_DSRC_REC_INGEST_KEEP_PREPARE_ROLLBACK	2319
+#define	WT_STAT_DSRC_REC_INGEST_KEEP_PREPARE_ROLLBACK	2320
 /*! reconciliation: internal page delta keys deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELTA_INTERNAL_KEY_DELETED	2320
+#define	WT_STAT_DSRC_REC_PAGE_DELTA_INTERNAL_KEY_DELETED	2321
 /*! reconciliation: internal page delta keys updated/inserted */
-#define	WT_STAT_DSRC_REC_PAGE_DELTA_INTERNAL_KEY_UPDATED	2321
+#define	WT_STAT_DSRC_REC_PAGE_DELTA_INTERNAL_KEY_UPDATED	2322
 /*! reconciliation: internal page deltas written */
-#define	WT_STAT_DSRC_REC_PAGE_DELTA_INTERNAL		2322
+#define	WT_STAT_DSRC_REC_PAGE_DELTA_INTERNAL		2323
 /*!
  * reconciliation: internal page key bytes discarded using suffix
  * compression
  */
-#define	WT_STAT_DSRC_REC_SUFFIX_COMPRESSION		2323
+#define	WT_STAT_DSRC_REC_SUFFIX_COMPRESSION		2324
 /*! reconciliation: internal page multi-block writes */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_INTERNAL		2324
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_INTERNAL		2325
 /*!
  * reconciliation: leaf delta page key bytes discarded using prefix
  * compression
  */
-#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION_DELTA	2325
+#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION_DELTA	2326
 /*!
  * reconciliation: leaf full page key bytes discarded using prefix
  * compression
  */
-#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION_FULL	2326
+#define	WT_STAT_DSRC_REC_PREFIX_COMPRESSION_FULL	2327
 /*! reconciliation: leaf page deltas written */
-#define	WT_STAT_DSRC_REC_PAGE_DELTA_LEAF		2327
+#define	WT_STAT_DSRC_REC_PAGE_DELTA_LEAF		2328
 /*! reconciliation: leaf page multi-block writes */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_LEAF		2328
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_LEAF		2329
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_LEAF		2329
+#define	WT_STAT_DSRC_REC_OVERFLOW_KEY_LEAF		2330
 /*! reconciliation: max deltas seen on internal page during reconciliation */
-#define	WT_STAT_DSRC_REC_MAX_INTERNAL_PAGE_DELTAS	2330
+#define	WT_STAT_DSRC_REC_MAX_INTERNAL_PAGE_DELTAS	2331
 /*! reconciliation: max deltas seen on leaf page during reconciliation */
-#define	WT_STAT_DSRC_REC_MAX_LEAF_PAGE_DELTAS		2331
+#define	WT_STAT_DSRC_REC_MAX_LEAF_PAGE_DELTAS		2332
 /*! reconciliation: maximum blocks required for a page */
-#define	WT_STAT_DSRC_REC_MULTIBLOCK_MAX			2332
+#define	WT_STAT_DSRC_REC_MULTIBLOCK_MAX			2333
 /*!
  * reconciliation: number of keys that are garbage collected from the
  * disk images in the ingest btrees for disaggregated storage
  */
-#define	WT_STAT_DSRC_REC_INGEST_GARBAGE_COLLECTION_KEYS_DISK_IMAGE	2333
+#define	WT_STAT_DSRC_REC_INGEST_GARBAGE_COLLECTION_KEYS_DISK_IMAGE	2334
 /*!
  * reconciliation: number of keys that are garbage collected from the
  * update chains in the ingest btrees for disaggregated storage
  */
-#define	WT_STAT_DSRC_REC_INGEST_GARBAGE_COLLECTION_KEYS_UPDATE_CHAIN	2334
+#define	WT_STAT_DSRC_REC_INGEST_GARBAGE_COLLECTION_KEYS_UPDATE_CHAIN	2335
 /*! reconciliation: overflow values written */
-#define	WT_STAT_DSRC_REC_OVERFLOW_VALUE			2335
+#define	WT_STAT_DSRC_REC_OVERFLOW_VALUE			2336
 /*! reconciliation: page deltas rejected due to invalid page ID */
-#define	WT_STAT_DSRC_REC_PAGE_DELTA_REJECTED_INVALID_PAGE_ID	2336
+#define	WT_STAT_DSRC_REC_PAGE_DELTA_REJECTED_INVALID_PAGE_ID	2337
 /*! reconciliation: page deltas rejected due to max consecutive limit */
-#define	WT_STAT_DSRC_REC_PAGE_DELTA_REJECTED_MAX_CONSECUTIVE_EXCEEDED	2337
+#define	WT_STAT_DSRC_REC_PAGE_DELTA_REJECTED_MAX_CONSECUTIVE_EXCEEDED	2338
 /*! reconciliation: page deltas rejected due to multiblock reconciliation */
-#define	WT_STAT_DSRC_REC_PAGE_DELTA_REJECTED_MULTIBLOCK	2338
+#define	WT_STAT_DSRC_REC_PAGE_DELTA_REJECTED_MULTIBLOCK	2339
 /*!
  * reconciliation: page deltas rejected due to non-single page in
  * previous reconciliation
  */
-#define	WT_STAT_DSRC_REC_PAGE_DELTA_REJECTED_NON_SINGLE_PAGE	2339
+#define	WT_STAT_DSRC_REC_PAGE_DELTA_REJECTED_NON_SINGLE_PAGE	2340
 /*! reconciliation: page deltas rejected due to size threshold */
-#define	WT_STAT_DSRC_REC_PAGE_DELTA_REJECTED_SIZE_THRESHOLD	2340
+#define	WT_STAT_DSRC_REC_PAGE_DELTA_REJECTED_SIZE_THRESHOLD	2341
 /*! reconciliation: page deltas rejected due to zero entries */
-#define	WT_STAT_DSRC_REC_PAGE_DELTA_REJECTED_ZERO_ENTRIES	2341
+#define	WT_STAT_DSRC_REC_PAGE_DELTA_REJECTED_ZERO_ENTRIES	2342
 /*!
  * reconciliation: page deltas rejected: build function returned false
  * (disabled, in-memory split, or internal page constraints not met)
  */
-#define	WT_STAT_DSRC_REC_PAGE_DELTA_REJECTED_BUILD_FAILED	2342
+#define	WT_STAT_DSRC_REC_PAGE_DELTA_REJECTED_BUILD_FAILED	2343
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_DSRC_REC_PAGES				2343
+#define	WT_STAT_DSRC_REC_PAGES				2344
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_DSRC_REC_PAGES_EVICTION			2344
+#define	WT_STAT_DSRC_REC_PAGES_EVICTION			2345
 /*! reconciliation: page reconciliation calls for pages between 1 and 10MB */
-#define	WT_STAT_DSRC_REC_PAGES_SIZE_1MB_TO_10MB		2345
+#define	WT_STAT_DSRC_REC_PAGES_SIZE_1MB_TO_10MB		2346
 /*!
  * reconciliation: page reconciliation calls for pages between 10 and
  * 100MB
  */
-#define	WT_STAT_DSRC_REC_PAGES_SIZE_10MB_TO_100MB	2346
+#define	WT_STAT_DSRC_REC_PAGES_SIZE_10MB_TO_100MB	2347
 /*!
  * reconciliation: page reconciliation calls for pages between 100MB and
  * 1GB
  */
-#define	WT_STAT_DSRC_REC_PAGES_SIZE_100MB_TO_1GB	2347
+#define	WT_STAT_DSRC_REC_PAGES_SIZE_100MB_TO_1GB	2348
 /*! reconciliation: page reconciliation calls for pages over 1GB */
-#define	WT_STAT_DSRC_REC_PAGES_SIZE_1GB_PLUS		2348
+#define	WT_STAT_DSRC_REC_PAGES_SIZE_1GB_PLUS		2349
 /*! reconciliation: pages deleted */
-#define	WT_STAT_DSRC_REC_PAGE_DELETE			2349
+#define	WT_STAT_DSRC_REC_PAGE_DELETE			2350
 /*! reconciliation: pages eligible for delta generation */
-#define	WT_STAT_DSRC_REC_PAGE_DELTA_ELIGIBLE		2350
+#define	WT_STAT_DSRC_REC_PAGE_DELTA_ELIGIBLE		2351
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	2351
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	2352
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	2352
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	2353
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TS	2353
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TS	2354
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TXN	2354
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_STOP_TXN	2355
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_TXN		2355
+#define	WT_STAT_DSRC_REC_TIME_AGGR_NEWEST_TXN		2356
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_OLDEST_START_TS	2356
+#define	WT_STAT_DSRC_REC_TIME_AGGR_OLDEST_START_TS	2357
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_DSRC_REC_TIME_AGGR_PREPARED		2357
+#define	WT_STAT_DSRC_REC_TIME_AGGR_PREPARED		2358
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_PREPARED	2358
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_PREPARED	2359
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	2359
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	2360
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TS	2360
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TS	2361
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TXN	2361
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_START_TXN	2362
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	2362
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	2363
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TS	2363
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TS	2364
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TXN	2364
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PAGES_STOP_TXN	2365
 /*! reconciliation: pages written with at least one internal page delta */
-#define	WT_STAT_DSRC_REC_PAGES_WITH_INTERNAL_DELTAS	2365
+#define	WT_STAT_DSRC_REC_PAGES_WITH_INTERNAL_DELTAS	2366
 /*! reconciliation: pages written with at least one leaf page delta */
-#define	WT_STAT_DSRC_REC_PAGES_WITH_LEAF_DELTAS		2366
+#define	WT_STAT_DSRC_REC_PAGES_WITH_LEAF_DELTAS		2367
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_PREPARED		2367
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_PREPARED		2368
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_START_TS	2368
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_START_TS	2369
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TS		2369
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TS		2370
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TXN		2370
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_START_TXN		2371
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_STOP_TS	2371
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_DURABLE_STOP_TS	2372
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TS		2372
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TS		2373
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TXN		2373
+#define	WT_STAT_DSRC_REC_TIME_WINDOW_STOP_TXN		2374
 /*! reconciliation: writes skipped in disaggregated storage */
-#define	WT_STAT_DSRC_REC_SKIP_WRITE			2374
+#define	WT_STAT_DSRC_REC_SKIP_WRITE			2375
 /*! session: object compaction */
-#define	WT_STAT_DSRC_SESSION_COMPACT			2375
+#define	WT_STAT_DSRC_SESSION_COMPACT			2376
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_COMMIT	2376
+#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_COMMIT	2377
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_DSRC_TXN_READ_OVERFLOW_REMOVE		2377
+#define	WT_STAT_DSRC_TXN_READ_OVERFLOW_REMOVE		2378
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_UPDATE	2378
+#define	WT_STAT_DSRC_TXN_READ_RACE_PREPARE_UPDATE	2379
 /*! transaction: rollback to stable applied btrees */
-#define	WT_STAT_DSRC_TXN_RTS_BTREES_APPLIED		2379
+#define	WT_STAT_DSRC_TXN_RTS_BTREES_APPLIED		2380
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	2380
+#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	2381
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2381
+#define	WT_STAT_DSRC_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2382
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_DSRC_TXN_RTS_INCONSISTENT_CKPT		2382
+#define	WT_STAT_DSRC_TXN_RTS_INCONSISTENT_CKPT		2383
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED		2383
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED		2384
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED		2384
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED		2385
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED_DRYRUN	2385
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_REMOVED_DRYRUN	2386
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED_DRYRUN	2386
+#define	WT_STAT_DSRC_TXN_RTS_KEYS_RESTORED_DRYRUN	2387
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES	2387
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES	2388
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES		2388
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES		2389
 /*! transaction: rollback to stable skipped btrees */
-#define	WT_STAT_DSRC_TXN_RTS_BTREES_SKIPPED		2389
+#define	WT_STAT_DSRC_TXN_RTS_BTREES_SKIPPED		2390
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_DSRC_TXN_RTS_DELETE_RLE_SKIPPED		2390
+#define	WT_STAT_DSRC_TXN_RTS_DELETE_RLE_SKIPPED		2391
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_DSRC_TXN_RTS_STABLE_RLE_SKIPPED		2391
+#define	WT_STAT_DSRC_TXN_RTS_STABLE_RLE_SKIPPED		2392
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS		2392
+#define	WT_STAT_DSRC_TXN_RTS_SWEEP_HS_KEYS		2393
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	2393
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	2394
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	2394
+#define	WT_STAT_DSRC_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	2395
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED			2395
+#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED			2396
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED_DRYRUN		2396
+#define	WT_STAT_DSRC_TXN_RTS_HS_REMOVED_DRYRUN		2397
 /*! transaction: update conflicts */
-#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2397
+#define	WT_STAT_DSRC_TXN_UPDATE_CONFLICT		2398
 
 /*!
  * @}

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -7826,1084 +7826,1084 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
  * layered: how many previously-applied LSNs the layered table manager
  * skipped on this tree
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_SKIP_LSN	1596
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_SKIP_LSN	1597
 /*! layered: number of checkpoints picked up by a follower */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FOLLOWER	1597
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FOLLOWER	1598
 /*! layered: the number of tables the layered table manager has open */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_TABLES	1598
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_TABLES	1599
 /*!
  * live-restore: number of bytes copied from the source to the
  * destination
  */
-#define	WT_STAT_CONN_LIVE_RESTORE_BYTES_COPIED		1599
+#define	WT_STAT_CONN_LIVE_RESTORE_BYTES_COPIED		1600
 /*! live-restore: number of files remaining for migration completion */
-#define	WT_STAT_CONN_LIVE_RESTORE_WORK_REMAINING	1600
+#define	WT_STAT_CONN_LIVE_RESTORE_WORK_REMAINING	1601
 /*! live-restore: number of reads from the source database */
-#define	WT_STAT_CONN_LIVE_RESTORE_SOURCE_READ_COUNT	1601
+#define	WT_STAT_CONN_LIVE_RESTORE_SOURCE_READ_COUNT	1602
 /*! live-restore: source read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT2	1602
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT2	1603
 /*! live-restore: source read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT5	1603
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT5	1604
 /*! live-restore: source read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT10	1604
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT10	1605
 /*! live-restore: source read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT50	1605
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT50	1606
 /*! live-restore: source read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT100	1606
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT100	1607
 /*! live-restore: source read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT250	1607
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT250	1608
 /*! live-restore: source read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT500	1608
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT500	1609
 /*! live-restore: source read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT1000	1609
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT1000	1610
 /*! live-restore: source read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_GT1000	1610
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_GT1000	1611
 /*! live-restore: source read latency histogram total (msecs) */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_TOTAL_MSECS	1611
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_TOTAL_MSECS	1612
 /*! live-restore: state */
-#define	WT_STAT_CONN_LIVE_RESTORE_STATE			1612
+#define	WT_STAT_CONN_LIVE_RESTORE_STATE			1613
 /*! lock: btree page lock acquisitions */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_COUNT		1613
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_COUNT		1614
 /*! lock: btree page lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_APPLICATION	1614
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_APPLICATION	1615
 /*! lock: btree page lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_INTERNAL	1615
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_INTERNAL	1616
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1616
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1617
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1617
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1618
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1618
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1619
 /*! lock: dhandle lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1619
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1620
 /*! lock: dhandle lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1620
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1621
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1621
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1622
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1622
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1623
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1623
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1624
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1624
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1625
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1625
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1626
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1626
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1627
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1627
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1628
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1628
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1629
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1629
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1630
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1630
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1631
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1631
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1632
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1632
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1633
 /*! lock: txn global lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1633
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1634
 /*! lock: txn global lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1634
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1635
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1635
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1636
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1636
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1637
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1637
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1638
 /*! log: force log remove time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1638
+#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1639
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1639
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1640
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1640
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1641
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1641
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1642
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1642
+#define	WT_STAT_CONN_LOG_FLUSH				1643
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1643
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1644
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1644
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1645
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1645
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1646
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1646
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1647
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1647
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1648
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1648
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1649
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1649
+#define	WT_STAT_CONN_LOG_SCANS				1650
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1650
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1651
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1651
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1652
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1652
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1653
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1653
+#define	WT_STAT_CONN_LOG_SYNC				1654
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1654
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1655
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1655
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1656
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1656
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1657
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1657
+#define	WT_STAT_CONN_LOG_WRITES				1658
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1658
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1659
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1659
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1660
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1660
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1661
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1661
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1662
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1662
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1663
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1663
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1664
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1664
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1665
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1665
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1666
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1666
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1667
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1667
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1668
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1668
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1669
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1669
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1670
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1670
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1671
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1671
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1672
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1672
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1673
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1673
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1674
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1674
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1675
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1675
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1676
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1676
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1677
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1677
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1678
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1678
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1679
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1679
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1680
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1680
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1681
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1681
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1682
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1682
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1683
 /*! perf: block manager read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT2	1683
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT2	1684
 /*! perf: block manager read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT5	1684
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT5	1685
 /*! perf: block manager read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT10	1685
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT10	1686
 /*! perf: block manager read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT50	1686
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT50	1687
 /*! perf: block manager read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT100	1687
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT100	1688
 /*! perf: block manager read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT250	1688
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT250	1689
 /*! perf: block manager read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT500	1689
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT500	1690
 /*! perf: block manager read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT1000	1690
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT1000	1691
 /*! perf: block manager read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_GT1000	1691
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_GT1000	1692
 /*! perf: block manager read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_TOTAL_MSECS	1692
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_TOTAL_MSECS	1693
 /*! perf: block manager write latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT2	1693
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT2	1694
 /*! perf: block manager write latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT5	1694
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT5	1695
 /*! perf: block manager write latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT10	1695
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT10	1696
 /*! perf: block manager write latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT50	1696
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT50	1697
 /*! perf: block manager write latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT100	1697
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT100	1698
 /*! perf: block manager write latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT250	1698
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT250	1699
 /*! perf: block manager write latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT500	1699
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT500	1700
 /*! perf: block manager write latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT1000	1700
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT1000	1701
 /*! perf: block manager write latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_GT1000	1701
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_GT1000	1702
 /*! perf: block manager write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_TOTAL_MSECS	1702
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_TOTAL_MSECS	1703
 /*! perf: disagg block manager read latency histogram (bucket 1) - 50-99us */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT100	1703
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT100	1704
 /*!
  * perf: disagg block manager read latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT250	1704
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT250	1705
 /*!
  * perf: disagg block manager read latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT500	1705
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT500	1706
 /*!
  * perf: disagg block manager read latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT1000	1706
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT1000	1707
 /*!
  * perf: disagg block manager read latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT2500	1707
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT2500	1708
 /*!
  * perf: disagg block manager read latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT5000	1708
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT5000	1709
 /*!
  * perf: disagg block manager read latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT10000	1709
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT10000	1710
 /*!
  * perf: disagg block manager read latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_GT10000	1710
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_GT10000	1711
 /*! perf: disagg block manager read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_TOTAL_USECS	1711
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_TOTAL_USECS	1712
 /*!
  * perf: disagg block manager write latency histogram (bucket 1) -
  * 50-99us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT100	1712
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT100	1713
 /*!
  * perf: disagg block manager write latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT250	1713
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT250	1714
 /*!
  * perf: disagg block manager write latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT500	1714
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT500	1715
 /*!
  * perf: disagg block manager write latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT1000	1715
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT1000	1716
 /*!
  * perf: disagg block manager write latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT2500	1716
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT2500	1717
 /*!
  * perf: disagg block manager write latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT5000	1717
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT5000	1718
 /*!
  * perf: disagg block manager write latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT10000	1718
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT10000	1719
 /*!
  * perf: disagg block manager write latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_GT10000	1719
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_GT10000	1720
 /*! perf: disagg block manager write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_TOTAL_USECS	1720
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_TOTAL_USECS	1721
 /*! perf: file system read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT2	1721
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT2	1722
 /*! perf: file system read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT5	1722
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT5	1723
 /*! perf: file system read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1723
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1724
 /*! perf: file system read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1724
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1725
 /*! perf: file system read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1725
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1726
 /*! perf: file system read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1726
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1727
 /*! perf: file system read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1727
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1728
 /*! perf: file system read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1728
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1729
 /*! perf: file system read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1729
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1730
 /*! perf: file system read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1730
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1731
 /*! perf: file system write latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT2	1731
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT2	1732
 /*! perf: file system write latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT5	1732
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT5	1733
 /*! perf: file system write latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1733
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1734
 /*! perf: file system write latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1734
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1735
 /*! perf: file system write latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1735
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1736
 /*! perf: file system write latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1736
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1737
 /*! perf: file system write latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1737
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1738
 /*! perf: file system write latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1738
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1739
 /*! perf: file system write latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1739
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1740
 /*! perf: file system write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1740
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1741
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 1) -
  * 0-100us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT100	1741
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT100	1742
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT250	1742
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT250	1743
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT500	1743
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT500	1744
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT1000	1744
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT1000	1745
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT2500	1745
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT2500	1746
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT5000	1746
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT5000	1747
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT10000	1747
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT10000	1748
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_GT10000	1748
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_GT10000	1749
 /*! perf: internal page deltas reconstruct latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_TOTAL_USECS	1749
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_TOTAL_USECS	1750
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 1) -
  * 0-100us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT100	1750
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT100	1751
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT250	1751
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT250	1752
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT500	1752
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT500	1753
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT1000	1753
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT1000	1754
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT2500	1754
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT2500	1755
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT5000	1755
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT5000	1756
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT10000	1756
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT10000	1757
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_GT10000	1757
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_GT10000	1758
 /*! perf: leaf page deltas reconstruct latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_TOTAL_USECS	1758
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_TOTAL_USECS	1759
 /*! perf: operation read latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1759
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1760
 /*! perf: operation read latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1760
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1761
 /*! perf: operation read latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1761
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1762
 /*! perf: operation read latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1762
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1763
 /*! perf: operation read latency histogram (bucket 5) - 1000-2499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT2500	1763
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT2500	1764
 /*! perf: operation read latency histogram (bucket 6) - 2500-4999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT5000	1764
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT5000	1765
 /*! perf: operation read latency histogram (bucket 7) - 5000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1765
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1766
 /*! perf: operation read latency histogram (bucket 8) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1766
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1767
 /*! perf: operation read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1767
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1768
 /*! perf: operation write latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1768
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1769
 /*! perf: operation write latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1769
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1770
 /*! perf: operation write latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1770
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1771
 /*! perf: operation write latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1771
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1772
 /*! perf: operation write latency histogram (bucket 5) - 1000-2499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT2500	1772
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT2500	1773
 /*! perf: operation write latency histogram (bucket 6) - 2500-4999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT5000	1773
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT5000	1774
 /*! perf: operation write latency histogram (bucket 7) - 5000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1774
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1775
 /*! perf: operation write latency histogram (bucket 8) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1775
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1776
 /*! perf: operation write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1776
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1777
 /*! prefetch: could not perform pre-fetch on internal page */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1777
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1778
 /*!
  * prefetch: could not perform pre-fetch on ref without the pre-fetch
  * flag set
  */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1778
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1779
 /*! prefetch: number of times pre-fetch failed to start */
-#define	WT_STAT_CONN_PREFETCH_FAILED_START		1779
+#define	WT_STAT_CONN_PREFETCH_FAILED_START		1780
 /*! prefetch: pre-fetch not repeating for recently pre-fetched ref */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1780
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1781
 /*! prefetch: pre-fetch not triggered after single disk read */
-#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1781
+#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1782
 /*! prefetch: pre-fetch not triggered as there is no valid dhandle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1782
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1783
 /*! prefetch: pre-fetch not triggered by page read */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED			1783
+#define	WT_STAT_CONN_PREFETCH_SKIPPED			1784
 /*! prefetch: pre-fetch not triggered due to disk read count */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1784
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1785
 /*! prefetch: pre-fetch not triggered due to internal session */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1785
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1786
 /*! prefetch: pre-fetch not triggered due to special btree handle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1786
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1787
 /*! prefetch: pre-fetch page not on disk when reading */
-#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1787
+#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1788
 /*! prefetch: pre-fetch pages queued */
-#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1788
+#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1789
 /*! prefetch: pre-fetch pages read in background */
-#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1789
+#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1790
 /*! prefetch: pre-fetch skipped reading in a page due to harmless error */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1790
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1791
 /*! prefetch: pre-fetch triggered by page read */
-#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1791
+#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1792
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1792
+#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1793
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1793
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1794
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1794
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1795
 /*!
  * reconciliation: average length of delta chain on internal page with
  * deltas
  */
-#define	WT_STAT_CONN_REC_AVERAGE_INTERNAL_PAGE_DELTA_CHAIN_LENGTH	1795
+#define	WT_STAT_CONN_REC_AVERAGE_INTERNAL_PAGE_DELTA_CHAIN_LENGTH	1796
 /*! reconciliation: average length of delta chain on leaf page with deltas */
-#define	WT_STAT_CONN_REC_AVERAGE_LEAF_PAGE_DELTA_CHAIN_LENGTH	1796
+#define	WT_STAT_CONN_REC_AVERAGE_LEAF_PAGE_DELTA_CHAIN_LENGTH	1797
 /*!
  * reconciliation: changes since prior reconciliation (bucket 1) between
  * 1 and 5
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE5			1797
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE5			1798
 /*!
  * reconciliation: changes since prior reconciliation (bucket 2) between
  * 6 and 10
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE10			1798
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE10			1799
 /*!
  * reconciliation: changes since prior reconciliation (bucket 3) between
  * 11 and 20
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE20			1799
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE20			1800
 /*!
  * reconciliation: changes since prior reconciliation (bucket 4) between
  * 21 and 50
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE50			1800
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE50			1801
 /*!
  * reconciliation: changes since prior reconciliation (bucket 5) between
  * 51 and 100
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE100		1801
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE100		1802
 /*!
  * reconciliation: changes since prior reconciliation (bucket 6) between
  * 101 and 200
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE200		1802
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE200		1803
 /*!
  * reconciliation: changes since prior reconciliation (bucket 7) between
  * 201 and 500
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE500		1803
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE500		1804
 /*!
  * reconciliation: changes since prior reconciliation (bucket 8) greater
  * than 500
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_GT500		1804
+#define	WT_STAT_CONN_REC_PAGE_MODS_GT500		1805
 /*! reconciliation: cursor next/prev calls during HS wrapup search_near */
-#define	WT_STAT_CONN_REC_HS_WRAPUP_NEXT_PREV_CALLS	1805
+#define	WT_STAT_CONN_REC_HS_WRAPUP_NEXT_PREV_CALLS	1806
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1806
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1807
 /*!
  * reconciliation: free page ID due to failed page replacement
  * reconciliation in disagg
  */
-#define	WT_STAT_CONN_REC_FREE_PAGE_ID_DUE_TO_FAILED_REPLACEMENT_RECONCILIATION	1807
+#define	WT_STAT_CONN_REC_FREE_PAGE_ID_DUE_TO_FAILED_REPLACEMENT_RECONCILIATION	1808
 /*! reconciliation: full internal pages written instead of a page delta */
-#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_INTERNAL	1808
+#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_INTERNAL	1809
 /*! reconciliation: full leaf pages written instead of a page delta */
-#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_LEAF		1809
+#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_LEAF		1810
 /*!
  * reconciliation: ingest btree reconciliation keeps the aborted prepare
  * updates
  */
-#define	WT_STAT_CONN_REC_INGEST_KEEP_PREPARE_ROLLBACK	1810
+#define	WT_STAT_CONN_REC_INGEST_KEEP_PREPARE_ROLLBACK	1811
 /*! reconciliation: internal page delta keys deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_DELETED	1811
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_DELETED	1812
 /*! reconciliation: internal page delta keys updated/inserted */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_UPDATED	1812
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_UPDATED	1813
 /*! reconciliation: internal page deltas written */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL		1813
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL		1814
 /*! reconciliation: internal page multi-block writes */
-#define	WT_STAT_CONN_REC_MULTIBLOCK_INTERNAL		1814
+#define	WT_STAT_CONN_REC_MULTIBLOCK_INTERNAL		1815
 /*! reconciliation: leaf page deltas written */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_LEAF		1815
+#define	WT_STAT_CONN_REC_PAGE_DELTA_LEAF		1816
 /*! reconciliation: leaf page multi-block writes */
-#define	WT_STAT_CONN_REC_MULTIBLOCK_LEAF		1816
+#define	WT_STAT_CONN_REC_MULTIBLOCK_LEAF		1817
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1817
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1818
 /*! reconciliation: max deltas seen on internal page during reconciliation */
-#define	WT_STAT_CONN_REC_MAX_INTERNAL_PAGE_DELTAS	1818
+#define	WT_STAT_CONN_REC_MAX_INTERNAL_PAGE_DELTAS	1819
 /*! reconciliation: max deltas seen on leaf page during reconciliation */
-#define	WT_STAT_CONN_REC_MAX_LEAF_PAGE_DELTAS		1819
+#define	WT_STAT_CONN_REC_MAX_LEAF_PAGE_DELTAS		1820
 /*! reconciliation: maximum milliseconds spent in a reconciliation call */
-#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1820
+#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1821
 /*!
  * reconciliation: maximum milliseconds spent in building a disk image in
  * a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1821
+#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1822
 /*!
  * reconciliation: maximum milliseconds spent in moving updates to the
  * history store in a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1822
+#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1823
 /*!
  * reconciliation: number of keys that are garbage collected from the
  * disk images in the ingest btrees for disaggregated storage
  */
-#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_DISK_IMAGE	1823
+#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_DISK_IMAGE	1824
 /*!
  * reconciliation: number of keys that are garbage collected from the
  * update chains in the ingest btrees for disaggregated storage
  */
-#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_UPDATE_CHAIN	1824
+#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_UPDATE_CHAIN	1825
 /*! reconciliation: overflow values written */
-#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1825
+#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1826
 /*! reconciliation: page deltas rejected due to invalid page ID */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_INVALID_PAGE_ID	1826
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_INVALID_PAGE_ID	1827
 /*! reconciliation: page deltas rejected due to max consecutive limit */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MAX_CONSECUTIVE_EXCEEDED	1827
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MAX_CONSECUTIVE_EXCEEDED	1828
 /*! reconciliation: page deltas rejected due to multiblock reconciliation */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MULTIBLOCK	1828
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MULTIBLOCK	1829
 /*!
  * reconciliation: page deltas rejected due to non-single page in
  * previous reconciliation
  */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_NON_SINGLE_PAGE	1829
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_NON_SINGLE_PAGE	1830
 /*! reconciliation: page deltas rejected due to size threshold */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_SIZE_THRESHOLD	1830
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_SIZE_THRESHOLD	1831
 /*! reconciliation: page deltas rejected due to zero entries */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_ZERO_ENTRIES	1831
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_ZERO_ENTRIES	1832
 /*!
  * reconciliation: page deltas rejected: build function returned false
  * (disabled, in-memory split, or internal page constraints not met)
  */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_BUILD_FAILED	1832
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_BUILD_FAILED	1833
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1833
+#define	WT_STAT_CONN_REC_PAGES				1834
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1834
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1835
 /*! reconciliation: page reconciliation calls for pages between 1 and 10MB */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_1MB_TO_10MB		1835
+#define	WT_STAT_CONN_REC_PAGES_SIZE_1MB_TO_10MB		1836
 /*!
  * reconciliation: page reconciliation calls for pages between 10 and
  * 100MB
  */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_10MB_TO_100MB	1836
+#define	WT_STAT_CONN_REC_PAGES_SIZE_10MB_TO_100MB	1837
 /*!
  * reconciliation: page reconciliation calls for pages between 100MB and
  * 1GB
  */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_100MB_TO_1GB	1837
+#define	WT_STAT_CONN_REC_PAGES_SIZE_100MB_TO_1GB	1838
 /*! reconciliation: page reconciliation calls for pages over 1GB */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_1GB_PLUS		1838
+#define	WT_STAT_CONN_REC_PAGES_SIZE_1GB_PLUS		1839
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * prepared transaction metadata
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1839
+#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1840
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * timestamps
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1840
+#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1841
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * transaction ids
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1841
+#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1842
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1842
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1843
 /*! reconciliation: pages eligible for delta generation */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_ELIGIBLE		1843
+#define	WT_STAT_CONN_REC_PAGE_DELTA_ELIGIBLE		1844
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1844
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1845
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1845
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1846
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1846
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1847
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1847
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1848
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1848
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1849
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1849
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1850
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1850
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1851
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1851
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1852
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1852
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1853
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1853
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1854
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1854
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1855
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1855
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1856
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1856
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1857
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1857
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1858
 /*! reconciliation: pages written with at least one internal page delta */
-#define	WT_STAT_CONN_REC_PAGES_WITH_INTERNAL_DELTAS	1858
+#define	WT_STAT_CONN_REC_PAGES_WITH_INTERNAL_DELTAS	1859
 /*! reconciliation: pages written with at least one leaf page delta */
-#define	WT_STAT_CONN_REC_PAGES_WITH_LEAF_DELTAS		1859
+#define	WT_STAT_CONN_REC_PAGES_WITH_LEAF_DELTAS		1860
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1860
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1861
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1861
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1862
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1862
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1863
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1863
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1864
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1864
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1865
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1865
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1866
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1866
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1867
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1867
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1868
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1868
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1869
 /*! reconciliation: writes skipped in disaggregated storage */
-#define	WT_STAT_CONN_REC_SKIP_WRITE			1869
+#define	WT_STAT_CONN_REC_SKIP_WRITE			1870
 /*! session: attempts to remove a local object and the object is in use */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1870
+#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1871
 /*! session: flush_tier failed calls */
-#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1871
+#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1872
 /*! session: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1872
+#define	WT_STAT_CONN_FLUSH_TIER				1873
 /*! session: flush_tier tables skipped due to no checkpoint */
-#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1873
+#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1874
 /*! session: flush_tier tables switched */
-#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1874
+#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1875
 /*! session: local objects removed */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1875
+#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1876
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1876
+#define	WT_STAT_CONN_SESSION_OPEN			1877
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1877
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1878
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1878
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1879
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1879
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1880
 /*! session: table alter triggering checkpoint calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1880
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1881
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1881
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1882
 /*! session: table compact conflicted with checkpoint */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1882
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1883
 /*! session: table compact dhandle successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1883
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1884
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1884
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1885
 /*! session: table compact failed calls due to cache pressure */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1885
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1886
 /*! session: table compact passes */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1886
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1887
 /*! session: table compact pulled into eviction */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1887
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1888
 /*! session: table compact running */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1888
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1889
 /*! session: table compact skipped as process would not reduce file size */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1889
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1890
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1890
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1891
 /*! session: table compact timeout */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1891
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1892
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1892
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1893
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1893
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1894
 /*! session: table create with import failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1894
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1895
 /*! session: table create with import repair calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1895
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1896
 /*! session: table create with import successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1896
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1897
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1897
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1898
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1898
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1899
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1899
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1900
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1900
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1901
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1901
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1902
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1902
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1903
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1903
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1904
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1904
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1905
 /*! session: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1905
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1906
 /*! session: tiered operations removed without processing */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1906
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1907
 /*! session: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1907
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1908
 /*! session: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1908
+#define	WT_STAT_CONN_TIERED_RETENTION			1909
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1909
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1910
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1910
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1911
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1911
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1912
 /*! thread-yield: application thread operations waiting for cache */
-#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1912
+#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1913
 /*!
  * thread-yield: application thread operations waiting for interruptible
  * cache eviction
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_OPS	1913
+#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_OPS	1914
 /*!
  * thread-yield: application thread operations waiting for mandatory
  * cache eviction
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_OPS	1914
+#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_OPS	1915
 /*! thread-yield: application thread snapshot refreshed for eviction */
-#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1915
+#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1916
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1916
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1917
 /*!
  * thread-yield: application thread time waiting for interruptible cache
  * eviction (usecs)
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_TIME	1917
+#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_TIME	1918
 /*!
  * thread-yield: application thread time waiting for mandatory cache
  * eviction (usecs)
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_TIME	1918
+#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_TIME	1919
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1919
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1920
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1920
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1921
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1921
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1922
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1922
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1923
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1923
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1924
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1924
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1925
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1925
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1926
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1926
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1927
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1927
+#define	WT_STAT_CONN_PAGE_SLEEP				1928
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1928
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1929
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1929
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1930
 /*! thread-yield: page split and restart read */
-#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1930
+#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1931
 /*! thread-yield: pages skipped during read due to deleted state */
-#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1931
+#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1932
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1932
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1933
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1933
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1934
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1934
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1935
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1935
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1936
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1936
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1937
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1937
+#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1938
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1938
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1939
 /*! transaction: oldest transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1939
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1940
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1940
+#define	WT_STAT_CONN_TXN_PREPARE			1941
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1941
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1942
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1942
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1943
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1943
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1944
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1944
+#define	WT_STAT_CONN_TXN_QUERY_TS			1945
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1945
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1946
 /*! transaction: rollback to stable applied btrees */
-#define	WT_STAT_CONN_TXN_RTS_BTREES_APPLIED		1946
+#define	WT_STAT_CONN_TXN_RTS_BTREES_APPLIED		1947
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1947
+#define	WT_STAT_CONN_TXN_RTS				1948
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1948
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1949
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1949
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1950
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1950
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1951
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1951
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1952
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1952
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1953
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1953
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1954
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1954
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1955
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1955
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1956
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1956
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1957
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1957
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1958
 /*! transaction: rollback to stable skipped btrees */
-#define	WT_STAT_CONN_TXN_RTS_BTREES_SKIPPED		1958
+#define	WT_STAT_CONN_TXN_RTS_BTREES_SKIPPED		1959
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1959
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1960
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1960
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1961
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1961
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1962
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1962
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1963
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1963
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1964
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1964
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1965
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1965
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1966
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1966
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1967
 /*!
  * transaction: rollback to stable updates that would have been aborted
  * in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1967
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1968
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1968
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1969
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1969
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1970
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1970
+#define	WT_STAT_CONN_TXN_SET_TS				1971
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1971
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1972
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1972
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1973
 /*! transaction: set timestamp force calls */
-#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1973
+#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1974
 /*!
  * transaction: set timestamp global oldest timestamp set to be more
  * recent than the global stable timestamp
  */
-#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1974
+#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1975
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1975
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1976
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1976
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1977
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1977
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1978
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1978
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1979
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1979
+#define	WT_STAT_CONN_TXN_BEGIN				1980
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1980
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1981
 /*! transaction: transaction global checkpoint timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_CHECKPOINT_TIMESTAMP	1981
+#define	WT_STAT_CONN_TXN_GLOBAL_CHECKPOINT_TIMESTAMP	1982
 /*! transaction: transaction global durable timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_DURABLE_TIMESTAMP	1982
+#define	WT_STAT_CONN_TXN_GLOBAL_DURABLE_TIMESTAMP	1983
 /*! transaction: transaction global last running timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_LAST_RUNNING_TIMESTAMP	1983
+#define	WT_STAT_CONN_TXN_GLOBAL_LAST_RUNNING_TIMESTAMP	1984
 /*! transaction: transaction global newest timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_NEWEST_TIMESTAMP	1984
+#define	WT_STAT_CONN_TXN_GLOBAL_NEWEST_TIMESTAMP	1985
 /*! transaction: transaction global oldest timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_OLDEST_TIMESTAMP	1985
+#define	WT_STAT_CONN_TXN_GLOBAL_OLDEST_TIMESTAMP	1986
 /*! transaction: transaction global pinned timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_PINNED_TIMESTAMP	1986
+#define	WT_STAT_CONN_TXN_GLOBAL_PINNED_TIMESTAMP	1987
 /*! transaction: transaction global stable timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_STABLE_TIMESTAMP	1987
+#define	WT_STAT_CONN_TXN_GLOBAL_STABLE_TIMESTAMP	1988
 /*! transaction: transaction global version cursor timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_VERSION_CURSOR_TIMESTAMP	1988
+#define	WT_STAT_CONN_TXN_GLOBAL_VERSION_CURSOR_TIMESTAMP	1989
 /*!
  * transaction: transaction number of older readers older than oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_READERS			1989
+#define	WT_STAT_CONN_TXN_PINNED_READERS			1990
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1990
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1991
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1991
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1992
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_LAG		1992
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_LAG		1993
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT_LAG	1993
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT_LAG	1994
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER_LAG	1994
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER_LAG	1995
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1995
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1996
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1996
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1997
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1997
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1998
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1998
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1999
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1999
+#define	WT_STAT_CONN_TXN_COMMIT				2000
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			2000
+#define	WT_STAT_CONN_TXN_ROLLBACK			2001
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		2001
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		2002
 
 /*!
  * @}
@@ -8986,65 +8986,68 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_DSRC_BTREE_CHECKPOINT_PAGES_RECONCILED	2031
 /*! btree: btree skipped by compaction as process would not reduce size */
 #define	WT_STAT_DSRC_BTREE_COMPACT_SKIPPED		2032
-/*! btree: checkpoint btree walk, construct and write duration (usecs) */
-#define	WT_STAT_DSRC_BTREE_CHECKPOINT_RECONCILE_DURATION	2033
 /*!
  * btree: column-store internal pages, only reported if tree_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_COLUMN_INTERNAL		2034
+#define	WT_STAT_DSRC_BTREE_COLUMN_INTERNAL		2033
 /*!
  * btree: column-store variable-size RLE encoded values, only reported if
  * tree_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_COLUMN_RLE			2035
+#define	WT_STAT_DSRC_BTREE_COLUMN_RLE			2034
 /*!
  * btree: column-store variable-size deleted values, only reported if
  * tree_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_COLUMN_DELETED		2036
+#define	WT_STAT_DSRC_BTREE_COLUMN_DELETED		2035
 /*!
  * btree: column-store variable-size leaf pages, only reported if
  * tree_walk or all statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_COLUMN_VARIABLE		2037
+#define	WT_STAT_DSRC_BTREE_COLUMN_VARIABLE		2036
 /*! btree: fixed-record size */
-#define	WT_STAT_DSRC_BTREE_FIXED_LEN			2038
+#define	WT_STAT_DSRC_BTREE_FIXED_LEN			2037
 /*! btree: maximum internal page size */
-#define	WT_STAT_DSRC_BTREE_MAXINTLPAGE			2039
+#define	WT_STAT_DSRC_BTREE_MAXINTLPAGE			2038
 /*! btree: maximum leaf page key size */
-#define	WT_STAT_DSRC_BTREE_MAXLEAFKEY			2040
+#define	WT_STAT_DSRC_BTREE_MAXLEAFKEY			2039
 /*! btree: maximum leaf page size */
-#define	WT_STAT_DSRC_BTREE_MAXLEAFPAGE			2041
+#define	WT_STAT_DSRC_BTREE_MAXLEAFPAGE			2040
 /*! btree: maximum leaf page value size */
-#define	WT_STAT_DSRC_BTREE_MAXLEAFVALUE			2042
+#define	WT_STAT_DSRC_BTREE_MAXLEAFVALUE			2041
 /*! btree: maximum tree depth */
-#define	WT_STAT_DSRC_BTREE_MAXIMUM_DEPTH		2043
+#define	WT_STAT_DSRC_BTREE_MAXIMUM_DEPTH		2042
 /*!
  * btree: number of key/value pairs, only reported if tree_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_ENTRIES			2044
+#define	WT_STAT_DSRC_BTREE_ENTRIES			2043
 /*!
  * btree: overflow pages, only reported if tree_walk or all statistics
  * are enabled
  */
-#define	WT_STAT_DSRC_BTREE_OVERFLOW			2045
+#define	WT_STAT_DSRC_BTREE_OVERFLOW			2044
 /*!
  * btree: row-store empty values, only reported if tree_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_ROW_EMPTY_VALUES		2046
+#define	WT_STAT_DSRC_BTREE_ROW_EMPTY_VALUES		2045
 /*!
  * btree: row-store internal pages, only reported if tree_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_ROW_INTERNAL			2047
+#define	WT_STAT_DSRC_BTREE_ROW_INTERNAL			2046
 /*!
  * btree: row-store leaf pages, only reported if tree_walk or all
  * statistics are enabled
  */
-#define	WT_STAT_DSRC_BTREE_ROW_LEAF			2048
+#define	WT_STAT_DSRC_BTREE_ROW_LEAF			2047
+/*!
+ * btree: time spent walking the tree for checkpoint including dirty page
+ * reconciliation time (usecs)
+ */
+#define	WT_STAT_DSRC_BTREE_CHECKPOINT_RECONCILE_DURATION	2048
 /*!
  * cache: application threads eviction requested with cache fill ratio <
  * 25%

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -7424,7 +7424,7 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 /*! checkpoint: total time (msecs) */
 #define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1431
 /*!
- * checkpoint: total time (msecs) writing pages to stable storage during
+ * checkpoint: total time (usecs) writing pages to stable storage during
  * checkpoint reconciliation
  */
 #define	WT_STAT_CONN_CHECKPOINT_REC_BLKCACHE_WRITE	1432

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -437,6 +437,10 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
         conn->evict->reentry_hs_eviction_ms =
           session->reconcile_timeline.total_reentry_hs_eviction_time;
 
+    if (F_ISSET(r, WT_REC_CHECKPOINT)) {
+        WT_STAT_CONN_INCRV(session, checkpoint_rec_blkcache_write, r->blkcache_write_time_accum);
+    }
+
 err:
     if (ret != 0)
         WT_RET_PANIC(session, ret, "reconciliation failed after building the disk image");
@@ -978,10 +982,12 @@ __rec_write(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *block_me
     WT_DECL_RET;
     WT_PAGE_HEADER *dsk;
     size_t result_len;
+    WTI_RECONCILE *r;
 
     dsk = buf->mem;
     btree = S2BT(session);
     result_len = 0;
+    r = session->reconcile;
 
     if (dsk->type == WT_PAGE_INVALID || dsk->type >= WT_PAGE_TYPE_COUNT)
         return (__wt_illegal_value(session, dsk->type));
@@ -1033,8 +1039,11 @@ __rec_write(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *block_me
         WT_RET(ret);
     }
 
-    return (__wt_blkcache_write(session, buf, block_meta, buf->size, addr, addr_sizep,
+    uint64_t _write_start = __wt_clock(session);
+    ret = (__wt_blkcache_write(session, buf, block_meta, buf->size, addr, addr_sizep,
       compressed_sizep, checkpoint, checkpoint_io, compressed));
+    r->blkcache_write_time_accum += WT_CLOCKDIFF_MS(__wt_clock(session), _write_start);
+    WT_RET(ret);
 }
 
 /*
@@ -2122,6 +2131,7 @@ __rec_write_delta(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_CHUNK *chu
   size_t *addr_sizep, size_t *compressed_sizep)
 {
     WT_CONNECTION_IMPL *conn;
+    WT_DECL_RET;
     WT_MULTI *multi;
     WT_PAGE_BLOCK_META *block_meta;
     uint64_t delta_pct;
@@ -2142,8 +2152,12 @@ __rec_write_delta(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_CHUNK *chu
     ++multi->block_meta->delta_count;
 
     /* Get the checkpoint ID. */
-    WT_RET(__wt_blkcache_write(session, &r->delta, multi->block_meta, chunk->image.size, addr,
+    uint64_t _write_start = __wt_clock(session);
+    ret = (__wt_blkcache_write(session, &r->delta, multi->block_meta, chunk->image.size, addr,
       addr_sizep, compressed_sizep, false, F_ISSET(r, WT_REC_CHECKPOINT), false));
+    r->blkcache_write_time_accum += WT_CLOCKDIFF_MS(__wt_clock(session), _write_start);
+    WT_RET(ret);
+
     /* Turn off compression adjustment for delta. */
     *compressed_sizep = 0;
 

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -437,9 +437,8 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
         conn->evict->reentry_hs_eviction_ms =
           session->reconcile_timeline.total_reentry_hs_eviction_time;
 
-    if (F_ISSET(r, WT_REC_CHECKPOINT)) {
-        WT_STAT_CONN_INCRV(session, checkpoint_rec_blkcache_write, r->blkcache_write_time_accum);
-    }
+    if (F_ISSET(r, WT_REC_CHECKPOINT))
+        WT_STAT_CONN_SET(session, checkpoint_rec_blkcache_write, r->blkcache_write_time);
 
 err:
     if (ret != 0)
@@ -983,6 +982,7 @@ __rec_write(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *block_me
     WT_PAGE_HEADER *dsk;
     size_t result_len;
     WTI_RECONCILE *r;
+    uint64_t _write_start = 0;
 
     dsk = buf->mem;
     btree = S2BT(session);
@@ -1039,10 +1039,15 @@ __rec_write(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *block_me
         WT_RET(ret);
     }
 
-    uint64_t _write_start = __wt_clock(session);
-    ret = (__wt_blkcache_write(session, buf, block_meta, buf->size, addr, addr_sizep,
-      compressed_sizep, checkpoint, checkpoint_io, compressed));
-    r->blkcache_write_time_accum += WT_CLOCKDIFF_MS(__wt_clock(session), _write_start);
+    if (F_ISSET(r, WT_REC_CHECKPOINT) && WT_STAT_ENABLED(session))
+        _write_start = __wt_clock(session);
+
+    ret = __wt_blkcache_write(session, buf, block_meta, buf->size, addr, addr_sizep,
+      compressed_sizep, checkpoint, checkpoint_io, compressed);
+
+    if (F_ISSET(r, WT_REC_CHECKPOINT) && WT_STAT_ENABLED(session)) {
+        r->blkcache_write_time += WT_CLOCKDIFF_MS(__wt_clock(session), _write_start);
+    }
     return (ret);
 }
 
@@ -2153,10 +2158,9 @@ __rec_write_delta(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_CHUNK *chu
 
     /* Get the checkpoint ID. */
     uint64_t _write_start = __wt_clock(session);
-    ret = (__wt_blkcache_write(session, &r->delta, multi->block_meta, chunk->image.size, addr,
+    WT_RET(__wt_blkcache_write(session, &r->delta, multi->block_meta, chunk->image.size, addr,
       addr_sizep, compressed_sizep, false, F_ISSET(r, WT_REC_CHECKPOINT), false));
-    r->blkcache_write_time_accum += WT_CLOCKDIFF_MS(__wt_clock(session), _write_start);
-    WT_RET(ret);
+    r->blkcache_write_time += WT_CLOCKDIFF_MS(__wt_clock(session), _write_start);
 
     /* Turn off compression adjustment for delta. */
     *compressed_sizep = 0;

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -757,6 +757,9 @@ __rec_init(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags, WT_SALVAGE_COO
     r->max_txn = WT_TXN_NONE;
     r->max_ts = WT_TS_NONE;
 
+    /* Track time spent writing to the block cache during checkpoints. */
+    r->blkcache_write_time = 0;
+
     /* Track if updates were used and/or uncommitted. */
     r->update_used = false;
 

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -1042,13 +1042,13 @@ __rec_write(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *block_me
     if (F_ISSET(r, WT_REC_CHECKPOINT) && WT_STAT_ENABLED(session))
         _write_start = __wt_clock(session);
 
-    ret = __wt_blkcache_write(session, buf, block_meta, buf->size, addr, addr_sizep,
-      compressed_sizep, checkpoint, checkpoint_io, compressed);
+    WT_RET(__wt_blkcache_write(session, buf, block_meta, buf->size, addr, addr_sizep,
+      compressed_sizep, checkpoint, checkpoint_io, compressed));
 
-    if (F_ISSET(r, WT_REC_CHECKPOINT) && WT_STAT_ENABLED(session)) {
-        r->blkcache_write_time += WT_CLOCKDIFF_MS(__wt_clock(session), _write_start);
-    }
-    return (ret);
+    if (F_ISSET(r, WT_REC_CHECKPOINT) && WT_STAT_ENABLED(session))
+        r->blkcache_write_time += WT_CLOCKDIFF_US(__wt_clock(session), _write_start);
+
+    return (0);
 }
 
 /*
@@ -2136,10 +2136,10 @@ __rec_write_delta(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_CHUNK *chu
   size_t *addr_sizep, size_t *compressed_sizep)
 {
     WT_CONNECTION_IMPL *conn;
-    WT_DECL_RET;
     WT_MULTI *multi;
     WT_PAGE_BLOCK_META *block_meta;
     uint64_t delta_pct;
+    uint64_t _write_start = 0;
 
     conn = S2C(session);
     multi = &r->multi[r->multi_next - 1];
@@ -2157,10 +2157,12 @@ __rec_write_delta(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_CHUNK *chu
     ++multi->block_meta->delta_count;
 
     /* Get the checkpoint ID. */
-    uint64_t _write_start = __wt_clock(session);
+    if (F_ISSET(r, WT_REC_CHECKPOINT) && WT_STAT_ENABLED(session))
+        _write_start = __wt_clock(session);
     WT_RET(__wt_blkcache_write(session, &r->delta, multi->block_meta, chunk->image.size, addr,
       addr_sizep, compressed_sizep, false, F_ISSET(r, WT_REC_CHECKPOINT), false));
-    r->blkcache_write_time += WT_CLOCKDIFF_MS(__wt_clock(session), _write_start);
+    if (F_ISSET(r, WT_REC_CHECKPOINT) && WT_STAT_ENABLED(session))
+        r->blkcache_write_time += WT_CLOCKDIFF_US(__wt_clock(session), _write_start);
 
     /* Turn off compression adjustment for delta. */
     *compressed_sizep = 0;

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -1043,7 +1043,7 @@ __rec_write(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *block_me
     ret = (__wt_blkcache_write(session, buf, block_meta, buf->size, addr, addr_sizep,
       compressed_sizep, checkpoint, checkpoint_io, compressed));
     r->blkcache_write_time_accum += WT_CLOCKDIFF_MS(__wt_clock(session), _write_start);
-    WT_RET(ret);
+    return (ret);
 }
 
 /*

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -1051,7 +1051,7 @@ __rec_write(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *block_me
       compressed_sizep, checkpoint, checkpoint_io, compressed));
 
     if (WT_REC_CKPT_TRACK_TIME(r))
-        r->blkcache_write_time += WT_CLOCKDIFF_US(__wt_clock(session), _write_start);
+        r->blkcache_write_time += WT_CLOCKDIFF_MS(__wt_clock(session), _write_start);
 
     return (0);
 }
@@ -2167,7 +2167,7 @@ __rec_write_delta(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_CHUNK *chu
     WT_RET(__wt_blkcache_write(session, &r->delta, multi->block_meta, chunk->image.size, addr,
       addr_sizep, compressed_sizep, false, F_ISSET(r, WT_REC_CHECKPOINT), false));
     if (WT_REC_CKPT_TRACK_TIME(r))
-        r->blkcache_write_time += WT_CLOCKDIFF_US(__wt_clock(session), _write_start);
+        r->blkcache_write_time += WT_CLOCKDIFF_MS(__wt_clock(session), _write_start);
 
     /* Turn off compression adjustment for delta. */
     *compressed_sizep = 0;

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -1039,13 +1039,13 @@ __rec_write(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *block_me
         WT_RET(ret);
     }
 
-    if (F_ISSET(r, WT_REC_CHECKPOINT) && WT_STAT_ENABLED(session))
+    if (r != NULL && F_ISSET(r, WT_REC_CHECKPOINT) && WT_STAT_ENABLED(session))
         _write_start = __wt_clock(session);
 
     WT_RET(__wt_blkcache_write(session, buf, block_meta, buf->size, addr, addr_sizep,
       compressed_sizep, checkpoint, checkpoint_io, compressed));
 
-    if (F_ISSET(r, WT_REC_CHECKPOINT) && WT_STAT_ENABLED(session))
+    if (r != NULL && F_ISSET(r, WT_REC_CHECKPOINT) && WT_STAT_ENABLED(session))
         r->blkcache_write_time += WT_CLOCKDIFF_US(__wt_clock(session), _write_start);
 
     return (0);
@@ -2157,11 +2157,11 @@ __rec_write_delta(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_CHUNK *chu
     ++multi->block_meta->delta_count;
 
     /* Get the checkpoint ID. */
-    if (F_ISSET(r, WT_REC_CHECKPOINT) && WT_STAT_ENABLED(session))
+    if (r != NULL && F_ISSET(r, WT_REC_CHECKPOINT) && WT_STAT_ENABLED(session))
         _write_start = __wt_clock(session);
     WT_RET(__wt_blkcache_write(session, &r->delta, multi->block_meta, chunk->image.size, addr,
       addr_sizep, compressed_sizep, false, F_ISSET(r, WT_REC_CHECKPOINT), false));
-    if (F_ISSET(r, WT_REC_CHECKPOINT) && WT_STAT_ENABLED(session))
+    if (r != NULL && F_ISSET(r, WT_REC_CHECKPOINT) && WT_STAT_ENABLED(session))
         r->blkcache_write_time += WT_CLOCKDIFF_US(__wt_clock(session), _write_start);
 
     /* Turn off compression adjustment for delta. */

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -970,6 +970,8 @@ __rec_destroy_session(WT_SESSION_IMPL *session)
     return (__rec_destroy(session, &session->reconcile));
 }
 
+#define WT_REC_CKPT_TRACK_TIME(r) ((r) != NULL && F_ISSET(r, WT_REC_CHECKPOINT))
+
 /*
  * __rec_write --
  *     Write a block, with optional diagnostic checks.
@@ -1042,13 +1044,13 @@ __rec_write(WT_SESSION_IMPL *session, WT_ITEM *buf, WT_PAGE_BLOCK_META *block_me
         WT_RET(ret);
     }
 
-    if (r != NULL && F_ISSET(r, WT_REC_CHECKPOINT) && WT_STAT_ENABLED(session))
+    if (WT_REC_CKPT_TRACK_TIME(r))
         _write_start = __wt_clock(session);
 
     WT_RET(__wt_blkcache_write(session, buf, block_meta, buf->size, addr, addr_sizep,
       compressed_sizep, checkpoint, checkpoint_io, compressed));
 
-    if (r != NULL && F_ISSET(r, WT_REC_CHECKPOINT) && WT_STAT_ENABLED(session))
+    if (WT_REC_CKPT_TRACK_TIME(r))
         r->blkcache_write_time += WT_CLOCKDIFF_US(__wt_clock(session), _write_start);
 
     return (0);
@@ -2160,11 +2162,11 @@ __rec_write_delta(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_CHUNK *chu
     ++multi->block_meta->delta_count;
 
     /* Get the checkpoint ID. */
-    if (r != NULL && F_ISSET(r, WT_REC_CHECKPOINT) && WT_STAT_ENABLED(session))
+    if (WT_REC_CKPT_TRACK_TIME(r))
         _write_start = __wt_clock(session);
     WT_RET(__wt_blkcache_write(session, &r->delta, multi->block_meta, chunk->image.size, addr,
       addr_sizep, compressed_sizep, false, F_ISSET(r, WT_REC_CHECKPOINT), false));
-    if (r != NULL && F_ISSET(r, WT_REC_CHECKPOINT) && WT_STAT_ENABLED(session))
+    if (WT_REC_CKPT_TRACK_TIME(r))
         r->blkcache_write_time += WT_CLOCKDIFF_US(__wt_clock(session), _write_start);
 
     /* Turn off compression adjustment for delta. */

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -316,6 +316,9 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
     if (!session->evict_timeline.reentry_hs_eviction)
         session->reconcile_timeline.image_build_finish = __wt_clock(session);
 
+    if (F_ISSET(r, WT_REC_CHECKPOINT))
+        WT_STAT_CONN_SET(session, checkpoint_rec_blkcache_write, r->blkcache_write_time);
+
     /*
      * If we failed, don't bail out yet; we still need to update stats and tidy up.
      */
@@ -436,9 +439,6 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
       conn->evict->reentry_hs_eviction_ms)
         conn->evict->reentry_hs_eviction_ms =
           session->reconcile_timeline.total_reentry_hs_eviction_time;
-
-    if (F_ISSET(r, WT_REC_CHECKPOINT))
-        WT_STAT_CONN_SET(session, checkpoint_rec_blkcache_write, r->blkcache_write_time);
 
 err:
     if (ret != 0)

--- a/src/reconcile/reconcile_private.h
+++ b/src/reconcile/reconcile_private.h
@@ -182,6 +182,9 @@ struct __wti_reconcile {
     uint64_t max_txn;
     wt_timestamp_t max_ts;
 
+    /* Track the total time in msecs spent in block writes */
+    uint64_t blkcache_write_time_accum;
+
     /*
      * When we do not find any update to be written for the whole page, we would like to mark
      * eviction failed in the case of update-restore unless all the updates for a key are found

--- a/src/reconcile/reconcile_private.h
+++ b/src/reconcile/reconcile_private.h
@@ -183,7 +183,7 @@ struct __wti_reconcile {
     wt_timestamp_t max_ts;
 
     /* Track the total time in msecs spent in block writes */
-    uint64_t blkcache_write_time_accum;
+    uint64_t blkcache_write_time;
 
     /*
      * When we do not find any update to be written for the whole page, we would like to mark

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -36,6 +36,7 @@ static const char *const __stats_dsrc_desc[] = {
   "btree: btree expected number of compact pages rewritten",
   "btree: btree number of pages reconciled during checkpoint",
   "btree: btree skipped by compaction as process would not reduce size",
+  "btree: checkpoint B-tree walk, construct and write duration (usecs)",
   "btree: column-store internal pages",
   "btree: column-store variable-size RLE encoded values",
   "btree: column-store variable-size deleted values",
@@ -500,6 +501,7 @@ __wt_stat_dsrc_clear_single(WT_DSRC_STATS *stats)
     /* not clearing btree_compact_pages_rewritten_expected */
     /* not clearing btree_checkpoint_pages_reconciled */
     /* not clearing btree_compact_skipped */
+    /* not clearing btree_checkpoint_reconcile_duration */
     stats->btree_column_internal = 0;
     stats->btree_column_rle = 0;
     stats->btree_column_deleted = 0;
@@ -916,6 +918,7 @@ __wt_stat_dsrc_aggregate_single(WT_DSRC_STATS *from, WT_DSRC_STATS *to)
     to->btree_compact_pages_rewritten_expected += from->btree_compact_pages_rewritten_expected;
     to->btree_checkpoint_pages_reconciled += from->btree_checkpoint_pages_reconciled;
     to->btree_compact_skipped += from->btree_compact_skipped;
+    to->btree_checkpoint_reconcile_duration += from->btree_checkpoint_reconcile_duration;
     to->btree_column_internal += from->btree_column_internal;
     to->btree_column_rle += from->btree_column_rle;
     to->btree_column_deleted += from->btree_column_deleted;
@@ -1365,6 +1368,8 @@ __wt_stat_dsrc_aggregate(WT_DSRC_STATS **from, WT_DSRC_STATS *to)
     to->btree_checkpoint_pages_reconciled +=
       WT_STAT_DSRC_READ(from, btree_checkpoint_pages_reconciled);
     to->btree_compact_skipped += WT_STAT_DSRC_READ(from, btree_compact_skipped);
+    to->btree_checkpoint_reconcile_duration +=
+      WT_STAT_DSRC_READ(from, btree_checkpoint_reconcile_duration);
     to->btree_column_internal += WT_STAT_DSRC_READ(from, btree_column_internal);
     to->btree_column_rle += WT_STAT_DSRC_READ(from, btree_column_rle);
     to->btree_column_deleted += WT_STAT_DSRC_READ(from, btree_column_deleted);

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -2309,7 +2309,7 @@ static const char *const __stats_connection_desc[] = {
   "checkpoint: total failed number of checkpoints",
   "checkpoint: total succeed number of checkpoints",
   "checkpoint: total time (msecs)",
-  "checkpoint: total time (msecs) writing pages to stable storage during checkpoint reconciliation",
+  "checkpoint: total time (usecs) writing pages to stable storage during checkpoint reconciliation",
   "checkpoint: wait cycles while cache dirty level is decreasing",
   "chunk-cache: aggregate number of spanned chunks on read",
   "chunk-cache: chunks evicted",

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -36,7 +36,7 @@ static const char *const __stats_dsrc_desc[] = {
   "btree: btree expected number of compact pages rewritten",
   "btree: btree number of pages reconciled during checkpoint",
   "btree: btree skipped by compaction as process would not reduce size",
-  "btree: checkpoint B-tree walk, construct and write duration (usecs)",
+  "btree: checkpoint btree walk, construct and write duration (usecs)",
   "btree: column-store internal pages",
   "btree: column-store variable-size RLE encoded values",
   "btree: column-store variable-size deleted values",

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -20,6 +20,7 @@ static const char *const __stats_dsrc_desc[] = {
   "block-manager: allocations requiring file extension",
   "block-manager: blocks allocated",
   "block-manager: blocks freed",
+  "block-manager: checkpoint reconciliation block manager duration (usecs)",
   "block-manager: checkpoint size",
   "block-manager: file allocation unit size",
   "block-manager: file bytes available for reuse",
@@ -485,6 +486,7 @@ __wt_stat_dsrc_clear_single(WT_DSRC_STATS *stats)
     stats->block_extension = 0;
     stats->block_alloc = 0;
     stats->block_free = 0;
+    /* not clearing block_checkpoint_reconcile_duration */
     stats->block_checkpoint_size = 0;
     stats->allocation_size = 0;
     stats->block_reuse_bytes = 0;
@@ -898,6 +900,7 @@ __wt_stat_dsrc_aggregate_single(WT_DSRC_STATS *from, WT_DSRC_STATS *to)
     to->block_extension += from->block_extension;
     to->block_alloc += from->block_alloc;
     to->block_free += from->block_free;
+    to->block_checkpoint_reconcile_duration += from->block_checkpoint_reconcile_duration;
     to->block_checkpoint_size += from->block_checkpoint_size;
     if (from->allocation_size > to->allocation_size)
         to->allocation_size = from->allocation_size;
@@ -1345,6 +1348,8 @@ __wt_stat_dsrc_aggregate(WT_DSRC_STATS **from, WT_DSRC_STATS *to)
     to->block_extension += WT_STAT_DSRC_READ(from, block_extension);
     to->block_alloc += WT_STAT_DSRC_READ(from, block_alloc);
     to->block_free += WT_STAT_DSRC_READ(from, block_free);
+    to->block_checkpoint_reconcile_duration +=
+      WT_STAT_DSRC_READ(from, block_checkpoint_reconcile_duration);
     to->block_checkpoint_size += WT_STAT_DSRC_READ(from, block_checkpoint_size);
     if ((v = WT_STAT_DSRC_READ(from, allocation_size)) > to->allocation_size)
         to->allocation_size = v;

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -20,7 +20,6 @@ static const char *const __stats_dsrc_desc[] = {
   "block-manager: allocations requiring file extension",
   "block-manager: blocks allocated",
   "block-manager: blocks freed",
-  "block-manager: checkpoint reconciliation block manager duration (usecs)",
   "block-manager: checkpoint size",
   "block-manager: file allocation unit size",
   "block-manager: file bytes available for reuse",
@@ -486,7 +485,6 @@ __wt_stat_dsrc_clear_single(WT_DSRC_STATS *stats)
     stats->block_extension = 0;
     stats->block_alloc = 0;
     stats->block_free = 0;
-    /* not clearing block_checkpoint_reconcile_duration */
     stats->block_checkpoint_size = 0;
     stats->allocation_size = 0;
     stats->block_reuse_bytes = 0;
@@ -900,7 +898,6 @@ __wt_stat_dsrc_aggregate_single(WT_DSRC_STATS *from, WT_DSRC_STATS *to)
     to->block_extension += from->block_extension;
     to->block_alloc += from->block_alloc;
     to->block_free += from->block_free;
-    to->block_checkpoint_reconcile_duration += from->block_checkpoint_reconcile_duration;
     to->block_checkpoint_size += from->block_checkpoint_size;
     if (from->allocation_size > to->allocation_size)
         to->allocation_size = from->allocation_size;
@@ -1348,8 +1345,6 @@ __wt_stat_dsrc_aggregate(WT_DSRC_STATS **from, WT_DSRC_STATS *to)
     to->block_extension += WT_STAT_DSRC_READ(from, block_extension);
     to->block_alloc += WT_STAT_DSRC_READ(from, block_alloc);
     to->block_free += WT_STAT_DSRC_READ(from, block_free);
-    to->block_checkpoint_reconcile_duration +=
-      WT_STAT_DSRC_READ(from, block_checkpoint_reconcile_duration);
     to->block_checkpoint_size += WT_STAT_DSRC_READ(from, block_checkpoint_size);
     if ((v = WT_STAT_DSRC_READ(from, allocation_size)) > to->allocation_size)
         to->allocation_size = v;

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -2309,6 +2309,7 @@ static const char *const __stats_connection_desc[] = {
   "checkpoint: total failed number of checkpoints",
   "checkpoint: total succeed number of checkpoints",
   "checkpoint: total time (msecs)",
+  "checkpoint: total time (msecs) writing pages to stable storage during checkpoint reconciliation",
   "checkpoint: wait cycles while cache dirty level is decreasing",
   "chunk-cache: aggregate number of spanned chunks on read",
   "chunk-cache: chunks evicted",
@@ -3364,6 +3365,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->checkpoints_total_failed = 0;
     stats->checkpoints_total_succeed = 0;
     /* not clearing checkpoint_time_total */
+    stats->checkpoint_rec_blkcache_write = 0;
     stats->checkpoint_wait_reduce_dirty = 0;
     stats->chunkcache_spans_chunks_read = 0;
     stats->chunkcache_chunks_evicted = 0;
@@ -4520,6 +4522,7 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->checkpoints_total_failed += WT_STAT_CONN_READ(from, checkpoints_total_failed);
     to->checkpoints_total_succeed += WT_STAT_CONN_READ(from, checkpoints_total_succeed);
     to->checkpoint_time_total += WT_STAT_CONN_READ(from, checkpoint_time_total);
+    to->checkpoint_rec_blkcache_write += WT_STAT_CONN_READ(from, checkpoint_rec_blkcache_write);
     to->checkpoint_wait_reduce_dirty += WT_STAT_CONN_READ(from, checkpoint_wait_reduce_dirty);
     to->chunkcache_spans_chunks_read += WT_STAT_CONN_READ(from, chunkcache_spans_chunks_read);
     to->chunkcache_chunks_evicted += WT_STAT_CONN_READ(from, chunkcache_chunks_evicted);

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -2305,7 +2305,7 @@ static const char *const __stats_connection_desc[] = {
   "checkpoint: total failed number of checkpoints",
   "checkpoint: total succeed number of checkpoints",
   "checkpoint: total time (msecs)",
-  "checkpoint: total time (usecs) writing pages to stable storage during checkpoint reconciliation",
+  "checkpoint: total time (msecs) writing pages to stable storage during checkpoint reconciliation",
   "checkpoint: wait cycles while cache dirty level is decreasing",
   "chunk-cache: aggregate number of spanned chunks on read",
   "chunk-cache: chunks evicted",

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -36,7 +36,6 @@ static const char *const __stats_dsrc_desc[] = {
   "btree: btree expected number of compact pages rewritten",
   "btree: btree number of pages reconciled during checkpoint",
   "btree: btree skipped by compaction as process would not reduce size",
-  "btree: checkpoint btree walk, construct and write duration (usecs)",
   "btree: column-store internal pages",
   "btree: column-store variable-size RLE encoded values",
   "btree: column-store variable-size deleted values",
@@ -52,6 +51,8 @@ static const char *const __stats_dsrc_desc[] = {
   "btree: row-store empty values",
   "btree: row-store internal pages",
   "btree: row-store leaf pages",
+  "btree: time spent walking the tree for checkpoint including dirty page reconciliation time "
+  "(usecs)",
   "cache: application threads eviction requested with cache fill ratio < 25%",
   "cache: application threads eviction requested with cache fill ratio >= 25% and < 50%",
   "cache: application threads eviction requested with cache fill ratio >= 50% and < 75%",
@@ -501,7 +502,6 @@ __wt_stat_dsrc_clear_single(WT_DSRC_STATS *stats)
     /* not clearing btree_compact_pages_rewritten_expected */
     /* not clearing btree_checkpoint_pages_reconciled */
     /* not clearing btree_compact_skipped */
-    /* not clearing btree_checkpoint_reconcile_duration */
     stats->btree_column_internal = 0;
     stats->btree_column_rle = 0;
     stats->btree_column_deleted = 0;
@@ -517,6 +517,7 @@ __wt_stat_dsrc_clear_single(WT_DSRC_STATS *stats)
     stats->btree_row_empty_values = 0;
     stats->btree_row_internal = 0;
     stats->btree_row_leaf = 0;
+    /* not clearing btree_checkpoint_reconcile_duration */
     stats->cache_eviction_app_threads_fill_ratio_lt_25 = 0;
     stats->cache_eviction_app_threads_fill_ratio_25_50 = 0;
     stats->cache_eviction_app_threads_fill_ratio_50_75 = 0;
@@ -918,7 +919,6 @@ __wt_stat_dsrc_aggregate_single(WT_DSRC_STATS *from, WT_DSRC_STATS *to)
     to->btree_compact_pages_rewritten_expected += from->btree_compact_pages_rewritten_expected;
     to->btree_checkpoint_pages_reconciled += from->btree_checkpoint_pages_reconciled;
     to->btree_compact_skipped += from->btree_compact_skipped;
-    to->btree_checkpoint_reconcile_duration += from->btree_checkpoint_reconcile_duration;
     to->btree_column_internal += from->btree_column_internal;
     to->btree_column_rle += from->btree_column_rle;
     to->btree_column_deleted += from->btree_column_deleted;
@@ -940,6 +940,7 @@ __wt_stat_dsrc_aggregate_single(WT_DSRC_STATS *from, WT_DSRC_STATS *to)
     to->btree_row_empty_values += from->btree_row_empty_values;
     to->btree_row_internal += from->btree_row_internal;
     to->btree_row_leaf += from->btree_row_leaf;
+    to->btree_checkpoint_reconcile_duration += from->btree_checkpoint_reconcile_duration;
     to->cache_eviction_app_threads_fill_ratio_lt_25 +=
       from->cache_eviction_app_threads_fill_ratio_lt_25;
     to->cache_eviction_app_threads_fill_ratio_25_50 +=
@@ -1368,8 +1369,6 @@ __wt_stat_dsrc_aggregate(WT_DSRC_STATS **from, WT_DSRC_STATS *to)
     to->btree_checkpoint_pages_reconciled +=
       WT_STAT_DSRC_READ(from, btree_checkpoint_pages_reconciled);
     to->btree_compact_skipped += WT_STAT_DSRC_READ(from, btree_compact_skipped);
-    to->btree_checkpoint_reconcile_duration +=
-      WT_STAT_DSRC_READ(from, btree_checkpoint_reconcile_duration);
     to->btree_column_internal += WT_STAT_DSRC_READ(from, btree_column_internal);
     to->btree_column_rle += WT_STAT_DSRC_READ(from, btree_column_rle);
     to->btree_column_deleted += WT_STAT_DSRC_READ(from, btree_column_deleted);
@@ -1391,6 +1390,8 @@ __wt_stat_dsrc_aggregate(WT_DSRC_STATS **from, WT_DSRC_STATS *to)
     to->btree_row_empty_values += WT_STAT_DSRC_READ(from, btree_row_empty_values);
     to->btree_row_internal += WT_STAT_DSRC_READ(from, btree_row_internal);
     to->btree_row_leaf += WT_STAT_DSRC_READ(from, btree_row_leaf);
+    to->btree_checkpoint_reconcile_duration +=
+      WT_STAT_DSRC_READ(from, btree_checkpoint_reconcile_duration);
     to->cache_eviction_app_threads_fill_ratio_lt_25 +=
       WT_STAT_DSRC_READ(from, cache_eviction_app_threads_fill_ratio_lt_25);
     to->cache_eviction_app_threads_fill_ratio_25_50 +=


### PR DESCRIPTION
We currently have aggregated timing statistics for checkpoints prepare, handle walk, and overall time spent in tree. This PR adds per btree level statistics for how long we spend doing checkpoints on each data source.

Here is a [patch build](https://spruce.corp.mongodb.com/version/69b222a4b4772000078bc912/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) with per-table enabled showing the new statistics.

<img width="1632" height="423" alt="image" src="https://github.com/user-attachments/assets/5595e939-55bc-4752-8955-75c3e9aff900" />