### PR TITLE
WT-16883 Ensure database size is never less than the WT_DISAGG_CHECKPOINT_SIZE_BUFFER

### DIFF
--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -905,8 +905,8 @@ __checkpoint_update_disagg_database_size(WT_SESSION_IMPL *session)
     }
 
     /*
-     * The database size must never drop below the checkpoint buffer because the checkpoint
-     * metadata itself occupies space that must always be accounted for.
+     * The database size must never drop below the checkpoint buffer because the checkpoint metadata
+     * itself occupies space that must always be accounted for.
      */
     WT_ASSERT(
       session, conn->disaggregated_storage.database_size >= WT_DISAGG_CHECKPOINT_SIZE_BUFFER);

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -904,6 +904,10 @@ __checkpoint_update_disagg_database_size(WT_SESSION_IMPL *session)
         }
     }
 
+    /*
+     * Ensure that the database size never drops below the 1MB checkpoint buffer. Catches bugs where
+     * size incorrectly goes to zero or below the buffer.
+     */
     WT_ASSERT(
       session, conn->disaggregated_storage.database_size >= WT_DISAGG_CHECKPOINT_SIZE_BUFFER);
 }

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -905,7 +905,7 @@ __checkpoint_update_disagg_database_size(WT_SESSION_IMPL *session)
     }
 
     /*
-     * The database size must never drop below the 1MB checkpoint buffer because the checkpoint
+     * The database size must never drop below the checkpoint buffer because the checkpoint
      * metadata itself occupies space that must always be accounted for.
      */
     WT_ASSERT(

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -905,8 +905,8 @@ __checkpoint_update_disagg_database_size(WT_SESSION_IMPL *session)
     }
 
     /*
-     * Ensure that the database size never drops below the 1MB checkpoint buffer. Catches bugs where
-     * size incorrectly goes to zero or below the buffer.
+     * The database size must never drop below the 1MB checkpoint buffer because the checkpoint
+     * metadata itself occupies space that must always be accounted for.
      */
     WT_ASSERT(
       session, conn->disaggregated_storage.database_size >= WT_DISAGG_CHECKPOINT_SIZE_BUFFER);

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -903,6 +903,9 @@ __checkpoint_update_disagg_database_size(WT_SESSION_IMPL *session)
             __wt_disagg_set_database_size(session, db - (uint64_t)(-delta));
         }
     }
+
+    WT_ASSERT(
+      session, conn->disaggregated_storage.database_size >= WT_DISAGG_CHECKPOINT_SIZE_BUFFER);
 }
 
 /*


### PR DESCRIPTION
Add an assertion to ensure that the database size never drops below the 1MB checkpoint buffer in order to catch bugs where size incorrectly goes to zero or below the buffer.