### PR TITLE
WT-16904 Remove pull_request tag from intermittent tiered_storage test

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -4275,7 +4275,7 @@ tasks:
           python_binary: $(pwd)/venv/bin/python3
           tiered_storage_test_name: tiered
   - name: azure-gcp-tiered-catch2-unittest-test
-    tags: ["pull_request", "tiered_unittest"]
+    tags: ["tiered_unittest"]
     commands:
       - func: "get project"
       - func: "install gcp dependencies"


### PR DESCRIPTION
This pull request has the changes to remove the pull_request tag from the azure-gcp-tiered-catch2-unittest-test Evergreen task so it no longer runs as part of PR testing.
