### PR TITLE
WT-16906 Fix a race condition between pushing checkpoint work and waiting for completion

### DIFF
--- a/src/checkpoint/checkpoint_parallel.c
+++ b/src/checkpoint/checkpoint_parallel.c
@@ -395,7 +395,7 @@ __wt_checkpoint_parallel_finish(WT_SESSION_IMPL *session)
         __checkpoint_parallel_pop_done(session, &entry);
         if (entry == NULL) {
             /* We can get here if the semaphore was never posted. Try again. */
-            __wt_sleep(0, 10);
+            __wt_yield();
             continue;
         }
         done_popped++;

--- a/src/checkpoint/checkpoint_parallel.c
+++ b/src/checkpoint/checkpoint_parallel.c
@@ -393,8 +393,11 @@ __wt_checkpoint_parallel_finish(WT_SESSION_IMPL *session)
         WT_RET(__wt_semaphore_wait(session, &ckpt_threads->done_sem));
 
         __checkpoint_parallel_pop_done(session, &entry);
-        if (entry == NULL)
-            break;
+        if (entry == NULL) {
+            /* We can get here if the semaphore was never posted. Try again. */
+            __wt_sleep(0, 10);
+            continue;
+        }
         done_popped++;
 
         WT_TRET(entry->result);

--- a/test/suite/test_checkpoint38.py
+++ b/test/suite/test_checkpoint38.py
@@ -57,8 +57,6 @@ class test_checkpoint38(wttest.WiredTigerTestCase):
         return val
 
     def test_parallel_checkpoint(self):
-        if os.name == 'nt':
-            self.skipTest('Parallel checkpoint is not broken on Windows')
         uri = 'table:checkpoint38'
         value_size = 10000
         nrows = 110000


### PR DESCRIPTION
Fix the race condition that we can hit if we get to `__wt_checkpoint_parallel_finish` before any of the done items get added to the queue and the semaphore is posted.