### PR TITLE
WT-16903 Decouple options parsing in decode tool

### DIFF
--- a/tools/py_common/btree_format.py
+++ b/tools/py_common/btree_format.py
@@ -642,23 +642,23 @@ class Cell(object):
         if self.extra_descriptor == 0:
             return
 
-        p.rint_v('cell has timestamps:')
+        p.rint('cell has timestamps:')
         if self.prepared:
-            p.rint_v(' prepared')
+            p.rint(' prepared')
 
         if self.start_ts is not None:
-            p.rint_v(' start ts: ' + binary_data.ts(self.start_ts))
+            p.rint(' start ts: ' + binary_data.ts(self.start_ts))
         if self.start_txn is not None:
-            p.rint_v(' start txn: ' + binary_data.txn(self.start_txn))
+            p.rint(' start txn: ' + binary_data.txn(self.start_txn))
         if self.durable_start_ts is not None:
-            p.rint_v(' durable start ts: ' + binary_data.ts(self.durable_start_ts))
+            p.rint(' durable start ts: ' + binary_data.ts(self.durable_start_ts))
 
         if self.stop_ts is not None:
-            p.rint_v(' stop ts: ' + binary_data.ts(self.stop_ts))
+            p.rint(' stop ts: ' + binary_data.ts(self.stop_ts))
         if self.stop_txn is not None:
-            p.rint_v(' stop txn: ' + binary_data.txn(self.stop_txn))
+            p.rint(' stop txn: ' + binary_data.txn(self.stop_txn))
         if self.durable_stop_ts is not None:
-            p.rint_v(' durable stop ts: ' + binary_data.ts(self.durable_stop_ts))
+            p.rint(' durable stop ts: ' + binary_data.ts(self.durable_stop_ts))
 
     def process_timestamps(self, pagestats: PageStats):
         pagestats.process_timestamps(self)
@@ -875,25 +875,27 @@ class WTPage:
         if self.page_header.type == PageType.WT_PAGE_INVALID:
             pass    # a blank page: TODO maybe should check that it's all zeros?
         elif self.page_header.type == PageType.WT_PAGE_BLOCK_MANAGER:
-            self.print_extents(p)
+            if self.extents is not None:
+                self.print_extents(p)
         elif self.page_header.type == PageType.WT_PAGE_ROW_INT or \
             self.page_header.type == PageType.WT_PAGE_ROW_LEAF:
-            self.print_cells(p, decode_as_bson=decode_as_bson, disagg=disagg)
+            if self.cells is not None:
+                self.print_cells(p, decode_as_bson=decode_as_bson, disagg=disagg)
         elif self.page_header.type == PageType.WT_PAGE_OVFL:
             # Use b_page.read() so that we can also print the raw bytes in the split mode
             b_page = self.raw_bytes
-            p.rint_v(raw_bytes(b_page.read(len(self.raw_bytes))))
+            p.rint(raw_bytes(b_page.read(len(self.raw_bytes))))
         else:
             logger.warning(f'? unimplemented decode for page type {self.page_header.type}')
-            p.rint_v(binary_to_pretty_string(self.raw_bytes))
+            p.rint(binary_to_pretty_string(self.raw_bytes))
 
         return
 
     def print_cells(self, p, *, decode_as_bson: bool = False, disagg: bool = False):
         for cellnum, cell in enumerate(self.cells):
             p.begin_cell(cellnum)
-            p.rint_v(cell.descriptor_string())
-            p.rint_v(cell.type_string())
+            p.rint(cell.descriptor_string())
+            p.rint(cell.type_string())
             cell.print_timestamps(p)
 
             # Print the contents of the cell.
@@ -901,31 +903,31 @@ class WTPage:
                 # Attempt the decode the cell as BSON.
                 if (cell.is_value and decode_as_bson and HAVE_BSON):
                     decoded_data = bson.BSON(cell.data).decode()
-                    p.rint_v(pprint.pformat(decoded_data, indent=2))
+                    p.rint(pprint.pformat(decoded_data, indent=2))
                 # If the cell is an address and we're in disagg mode, print the cell as a DisaggAddr
                 # type.
                 elif cell.is_address and disagg:
                     addr = DisaggAddr.parse(cell.data)
                     p.rint(json.dumps(addr.__dict__))
                 else:
-                    p.rint_v(raw_bytes(cell.data))
+                    p.rint(raw_bytes(cell.data))
             except (IndexError, ValueError):
                 # FIXME-WT-13000 theres a bug in raw_bytes
                 pass
             except Exception as e:
                 if HAVE_BSON and isinstance(e, bson.InvalidBSON):
-                    p.rint_v(f"cannot decode cell as BSON: {e}")
-                    p.rint_v(raw_bytes(cell.data))
+                    p.rint(f"cannot decode cell as BSON: {e}")
+                    p.rint(raw_bytes(cell.data))
                 else:
                     raise
 
             p.end_cell()
 
     def print_extents(self, p):
-        p.rint_ext('extent list follows:')
+        p.rint('extent list follows:')
         for extnum, extent in enumerate(self.extents):
             p.begin_cell(extnum)
-            p.rint_ext(f'  {extent.offset}, {extent.size}{extent.extra_stuff}')
+            p.rint(f'  {extent.offset}, {extent.size}{extent.extra_stuff}')
 
     def is_delta(self):
         if not isinstance(self.block_header, BlockDisaggHeader):
@@ -964,7 +966,7 @@ class WTPage:
         okay = True
         cellnum = -1
         lastoff = 0
-        # p.rint_ext('extent list follows:')
+        # p.rint('extent list follows:')
         while True:
             cellnum += 1
             cellpos = b.tell()

--- a/tools/py_common/btree_format.py
+++ b/tools/py_common/btree_format.py
@@ -826,14 +826,13 @@ class WTPage:
             # The disk size is too small
             return page
 
-        pagestats = PageStats()
+        page.pagestats = PageStats()
 
         if not verify_block_checksum(b, disk_pos, disk_size, page, disagg=disagg, cont=cont):
             return page
 
         if skip_data:
             b.seek(disk_pos + disk_size)
-            page.pagestats = pagestats
             page.success = True
             return page
 
@@ -859,17 +858,16 @@ class WTPage:
             page.extents = extents
         elif page.page_header.type == PageType.WT_PAGE_ROW_INT or \
             page.page_header.type == PageType.WT_PAGE_ROW_LEAF:
-            cells = page.decode_rows(b_page, pagestats)
+            cells = page.decode_rows(b_page, page.pagestats)
             page.cells = cells
         else:
             logger.warning('? unimplemented decode for page type {}'.format(page.page_header.type))
 
-        page.pagestats = pagestats
         page.success = True
         return page
 
     def print_page(self, *, split: bool = False,
-                   bson: bool = False, disagg: bool = False):
+                   decode_as_bson: bool = False, disagg: bool = False):
         p = Printer(self.raw_bytes, split=split)
         p.rint(self.page_header)
         p.rint(self.block_header)
@@ -880,7 +878,7 @@ class WTPage:
             self.print_extents(p)
         elif self.page_header.type == PageType.WT_PAGE_ROW_INT or \
             self.page_header.type == PageType.WT_PAGE_ROW_LEAF:
-            self.print_cells(p, decode_as_bson=bson, disagg=disagg)
+            self.print_cells(p, decode_as_bson=decode_as_bson, disagg=disagg)
         elif self.page_header.type == PageType.WT_PAGE_OVFL:
             # Use b_page.read() so that we can also print the raw bytes in the split mode
             b_page = self.raw_bytes

--- a/tools/py_common/btree_format.py
+++ b/tools/py_common/btree_format.py
@@ -38,7 +38,7 @@ from typing import Optional, List, Union, Final
 # Tools and data structures for reading and decoding the on-disk format of WiredTiger's files.
 from py_common import binary_data
 from py_common.stats import PageStats
-from py_common.printer import Printer, binary_to_pretty_string, raw_bytes, dumpraw, dumpraw_to_log
+from py_common.printer import Printer, binary_to_pretty_string, raw_bytes, dumpraw_to_log
 from py_common.snappy_util import snappy_decompress_page
 
 logger = logging.getLogger(__name__)
@@ -870,7 +870,7 @@ class WTPage:
 
     def print_page(self, *, split: bool = False,
                    bson: bool = False, disagg: bool = False):
-        p = Printer(self.raw_bytes, split=split, verbose=1)
+        p = Printer(self.raw_bytes, split=split)
         p.rint(self.page_header)
         p.rint(self.block_header)
 
@@ -880,7 +880,7 @@ class WTPage:
             self.print_extents(p)
         elif self.page_header.type == PageType.WT_PAGE_ROW_INT or \
             self.page_header.type == PageType.WT_PAGE_ROW_LEAF:
-            self.print_cells(p, bson=bson, disagg=disagg)
+            self.print_cells(p, decode_as_bson=bson, disagg=disagg)
         elif self.page_header.type == PageType.WT_PAGE_OVFL:
             # Use b_page.read() so that we can also print the raw bytes in the split mode
             b_page = self.raw_bytes
@@ -891,7 +891,7 @@ class WTPage:
 
         return
 
-    def print_cells(self, p, *, bson: bool = False, disagg: bool = False):
+    def print_cells(self, p, *, decode_as_bson: bool = False, disagg: bool = False):
         for cellnum, cell in enumerate(self.cells):
             p.begin_cell(cellnum)
             p.rint_v(cell.descriptor_string())
@@ -901,7 +901,7 @@ class WTPage:
             # Print the contents of the cell.
             try:
                 # Attempt the decode the cell as BSON.
-                if (cell.is_value and bson and HAVE_BSON):
+                if (cell.is_value and decode_as_bson and HAVE_BSON):
                     decoded_data = bson.BSON(cell.data).decode()
                     p.rint_v(pprint.pformat(decoded_data, indent=2))
                 # If the cell is an address and we're in disagg mode, print the cell as a DisaggAddr

--- a/tools/py_common/btree_format.py
+++ b/tools/py_common/btree_format.py
@@ -38,7 +38,7 @@ from typing import Optional, List, Union, Final
 # Tools and data structures for reading and decoding the on-disk format of WiredTiger's files.
 from py_common import binary_data
 from py_common.stats import PageStats
-from py_common.printer import Printer, binary_to_pretty_string, raw_bytes, dumpraw
+from py_common.printer import Printer, binary_to_pretty_string, raw_bytes, dumpraw, dumpraw_to_log
 from py_common.snappy_util import snappy_decompress_page
 
 logger = logging.getLogger(__name__)
@@ -732,15 +732,16 @@ class DisaggAddr(object):
         return addr_string
 
 
-def verify_block_checksum(b: binary_data.BinaryFile, disk_pos: int, disk_size: int, page, opts) -> bool:
+def verify_block_checksum(b: binary_data.BinaryFile, disk_pos: int, disk_size: int, page,
+                          *, disagg: bool = False, cont: bool = False) -> bool:
     """Validate block checksum using crc32c when available."""
     if not HAVE_CRC32C:
         return True
 
     savepos = b.tell()
     b.seek(disk_pos)
-    if (opts.disagg and page.block_header.flags & BlockDisaggFlags.WT_BLOCK_DISAGG_DATA_CKSUM) \
-        or (not opts.disagg and page.block_header.flags & BlockFlags.WT_BLOCK_DATA_CKSUM):
+    if (disagg and page.block_header.flags & BlockDisaggFlags.WT_BLOCK_DISAGG_DATA_CKSUM) \
+        or (not disagg and page.block_header.flags & BlockFlags.WT_BLOCK_DATA_CKSUM):
         check_size = disk_size
     else:
         check_size = 64
@@ -757,7 +758,7 @@ def verify_block_checksum(b: binary_data.BinaryFile, disk_pos: int, disk_size: i
     checksum = crc32c.crc32c(data)
     if checksum != page.block_header.checksum:
         logger.error(f'? the calculated checksum {hex(checksum)} does not match header checksum {page.block_header.checksum}')
-        return opts.cont
+        return cont
 
     return True
 
@@ -774,18 +775,20 @@ class WTPage:
     block_header: Optional[Union[BlockHeader, BlockDisaggHeader]] = None
     cells: Optional[List[Cell]] = None
     extents: Optional[List[ExtentItem]] = None
+    pagestats: Optional[PageStats] = None
 
     raw_bytes: binary_data.BinaryFile = None
 
     @staticmethod
-    def parse(b: binary_data.BinaryFile, nbytes: int, opts) -> 'WTPage':
+    def parse(b: binary_data.BinaryFile, nbytes: int,
+              *, disagg: bool = False, skip_data: bool = False, cont: bool = False) -> 'WTPage':
         page = WTPage(success=False)
 
         page.raw_bytes = b
 
         disk_pos = b.tell()
 
-        if opts.disagg:
+        if disagg:
             # Size of WT_PAGE_HEADER
             page_data = bytearray(b.read(44))
         else:
@@ -794,12 +797,10 @@ class WTPage:
         b.saved_bytes()
         b_page = binary_data.BinaryFile(io.BytesIO(page_data))
 
-        p = Printer(b_page, opts)
-
         # WT_PAGE_HEADER in btmem.h (28 bytes)
         page.page_header = PageHeader.parse(b_page)
         # WT_BLOCK_HEADER in block.h (12 bytes or 44 bytes)
-        if opts.disagg:
+        if disagg:
             page.block_header = BlockDisaggHeader.parse(b_page)
         else:
             page.block_header = BlockHeader.parse(b_page)
@@ -815,26 +816,24 @@ class WTPage:
             logger.error('garbage in unused bytes')
             return page
 
-        disk_size = nbytes if opts.disagg else page.block_header.disk_size
+        disk_size = nbytes if disagg else page.block_header.disk_size
 
         if disk_size > 17 * 1024 * 1024:
             # The maximum document size in MongoDB is 16MB. Larger block sizes are suspect.
             logger.error('the block is too big')
             return page
-        if disk_size < 40 and not opts.disagg:
+        if disk_size < 40 and not disagg:
             # The disk size is too small
             return page
 
         pagestats = PageStats()
 
-        if not verify_block_checksum(b, disk_pos, disk_size, page, opts):
+        if not verify_block_checksum(b, disk_pos, disk_size, page, disagg=disagg, cont=cont):
             return page
-
-        # Skip the rest if we don't want to display the data
-        skip_data = opts.skip_data
 
         if skip_data:
             b.seek(disk_pos + disk_size)
+            page.pagestats = pagestats
             page.success = True
             return page
 
@@ -842,16 +841,15 @@ class WTPage:
         payload_pos = b.tell()
         header_length = payload_pos - disk_pos
         if page.page_header.flags & PageFlags.WT_PAGE_COMPRESSED:
-            payload_data = snappy_decompress_page(b, page.page_header, header_length, disk_size, disk_pos, opts)
+            payload_data = snappy_decompress_page(b, page.page_header, header_length, disk_size, disk_pos)
         else:
             payload_data = b.read(page.page_header.mem_size - header_length)
             b.seek(disk_pos + disk_size)
 
-        # Add the payload to the page data & reinitialize the stream and the printer
+        # Add the payload to the page data & reinitialize the stream
         page_data.extend(payload_data)
         b_page = binary_data.BinaryFile(io.BytesIO(page_data))
         b_page.seek(header_length)
-        p = Printer(b_page, opts)
 
         # Parse the block contents
         if page.page_header.type == PageType.WT_PAGE_INVALID:
@@ -861,31 +859,28 @@ class WTPage:
             page.extents = extents
         elif page.page_header.type == PageType.WT_PAGE_ROW_INT or \
             page.page_header.type == PageType.WT_PAGE_ROW_LEAF:
-            cells = page.decode_rows(b_page, p, pagestats)
+            cells = page.decode_rows(b_page, pagestats)
             page.cells = cells
         else:
             logger.warning('? unimplemented decode for page type {}'.format(page.page_header.type))
 
-        PageStats.outfile_stats_end(opts, page.page_header, page.block_header, pagestats)
+        page.pagestats = pagestats
         page.success = True
         return page
 
-    def print_page(self, opts):
-        p = Printer(self.raw_bytes, opts)
+    def print_page(self, *, split: bool = False,
+                   bson: bool = False, disagg: bool = False):
+        p = Printer(self.raw_bytes, split=split, verbose=1)
         p.rint(self.page_header)
         p.rint(self.block_header)
-
-        # Don't print the cell data unless configured.
-        if not opts.verbose:
-            return
 
         if self.page_header.type == PageType.WT_PAGE_INVALID:
             pass    # a blank page: TODO maybe should check that it's all zeros?
         elif self.page_header.type == PageType.WT_PAGE_BLOCK_MANAGER:
-            self.print_extents(p, opts)
+            self.print_extents(p)
         elif self.page_header.type == PageType.WT_PAGE_ROW_INT or \
             self.page_header.type == PageType.WT_PAGE_ROW_LEAF:
-            self.print_cells(p, opts)
+            self.print_cells(p, bson=bson, disagg=disagg)
         elif self.page_header.type == PageType.WT_PAGE_OVFL:
             # Use b_page.read() so that we can also print the raw bytes in the split mode
             b_page = self.raw_bytes
@@ -896,7 +891,7 @@ class WTPage:
 
         return
 
-    def print_cells(self, p, opts):
+    def print_cells(self, p, *, bson: bool = False, disagg: bool = False):
         for cellnum, cell in enumerate(self.cells):
             p.begin_cell(cellnum)
             p.rint_v(cell.descriptor_string())
@@ -906,12 +901,12 @@ class WTPage:
             # Print the contents of the cell.
             try:
                 # Attempt the decode the cell as BSON.
-                if (cell.is_value and opts.bson and HAVE_BSON):
+                if (cell.is_value and bson and HAVE_BSON):
                     decoded_data = bson.BSON(cell.data).decode()
                     p.rint_v(pprint.pformat(decoded_data, indent=2))
                 # If the cell is an address and we're in disagg mode, print the cell as a DisaggAddr
                 # type.
-                elif cell.is_address and opts.disagg:
+                elif cell.is_address and disagg:
                     addr = DisaggAddr.parse(cell.data)
                     p.rint(json.dumps(addr.__dict__))
                 else:
@@ -928,7 +923,7 @@ class WTPage:
 
             p.end_cell()
 
-    def print_extents(self, p, opts):
+    def print_extents(self, p):
         p.rint_ext('extent list follows:')
         for extnum, extent in enumerate(self.extents):
             p.begin_cell(extnum)
@@ -940,7 +935,7 @@ class WTPage:
 
         return self.block_header.magic == BlockDisaggHeader.WT_BLOCK_DISAGG_MAGIC_DELTA
 
-    def decode_rows(self, b, p , pagestats) -> List[Cell]:
+    def decode_rows(self, b, pagestats) -> List[Cell]:
         cells = []
         for cellnum in range(0, self.page_header.entries):
             cellpos = b.tell()
@@ -960,7 +955,7 @@ class WTPage:
 
             # If the cell cannot be decoded as a valid type, dump the raw bytes and raise an error.
             if not cell.is_valid_type():
-                dumpraw(p, b, cellpos)
+                dumpraw_to_log(b, cellpos)
                 raise ValueError('Unexpected cell type')
 
         return cells

--- a/tools/py_common/btree_format.py
+++ b/tools/py_common/btree_format.py
@@ -31,7 +31,6 @@ import enum
 import io
 import json
 import logging
-
 from dataclasses import dataclass
 from typing import Optional, List, Union, Final
 
@@ -966,7 +965,6 @@ class WTPage:
         okay = True
         cellnum = -1
         lastoff = 0
-        # p.rint('extent list follows:')
         while True:
             cellnum += 1
             cellpos = b.tell()

--- a/tools/py_common/decode_opts.py
+++ b/tools/py_common/decode_opts.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any own all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+
+@dataclass
+class DecodeOptions:
+    """Options controlling how WiredTiger binary data is decoded and printed.
+
+    Instances are passed through the high-level decode pipeline rather than
+    threading individual keyword arguments across every call boundary.
+    Low-level functions (WTPage.parse, load_disagg_pages, …) keep explicit
+    keyword arguments because they expose stable, focused APIs used directly
+    by tests and other callers.
+    """
+
+    # --- Input routing ---
+    # True when the input file is a hex dump embedded in log messages.
+    dumpin: bool = False
+    # True when the input is a full disagg table from the GetTableAtLSN endpoint.
+    disagg_table: bool = False
+
+    # --- Decode behaviour ---
+    # True when the input comes from disaggregated storage.
+    disagg: bool = False
+    # Skip reading/processing cell data (print headers only).
+    skip_data: bool = False
+    # Continue decoding past checksum failures instead of stopping.
+    cont: bool = False
+
+    # --- Output formatting ---
+    # Show raw input bytes interleaved with decoded output.
+    split: bool = False
+    # Decode cell values as BSON and pretty-print them.
+    bson: bool = False
+    # Writable file-like object for CSV page-statistics output, or None.
+    output: Any = None
+
+    # --- Seek / page-limit ---
+    # Byte offset in the file to start decoding from.
+    offset: int = 0
+    # Treat the input as a fragment with no WT file header.
+    fragment: bool = False
+    # Maximum number of pages to decode (0 = unlimited).
+    pages: int = 0
+
+    # --- Storage-specific ---
+    # Path to the encryption key file used by the pagedecryptor tool.
+    keyfile: Optional[str] = None
+    # For SQLite input: decode only the record with this LSN.
+    lsn: Optional[int] = None
+    # For SQLite input: decode only pages for this page_id.
+    page_id: Optional[int] = None

--- a/tools/py_common/decode_opts.py
+++ b/tools/py_common/decode_opts.py
@@ -26,31 +26,21 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 from typing import Any, Optional
 
-
 @dataclass
 class DecodeOptions:
-    """Options controlling how WiredTiger binary data is decoded and printed.
-
-    Instances are passed through the high-level decode pipeline rather than
-    threading individual keyword arguments across every call boundary.
-    Low-level functions (WTPage.parse, load_disagg_pages, …) keep explicit
-    keyword arguments because they expose stable, focused APIs used directly
-    by tests and other callers.
-    """
-
     # --- Input routing ---
-    # True when the input file is a hex dump embedded in log messages.
+    # Input file is a hex dump embedded in log messages.
     dumpin: bool = False
-    # True when the input is a full disagg table from the GetTableAtLSN endpoint.
+    # Input is a full disagg table from the GetTableAtLSN endpoint.
     disagg_table: bool = False
+    # Treat the input as a fragment with no WT file header.
+    fragment: bool = False
 
     # --- Decode behaviour ---
-    # True when the input comes from disaggregated storage.
+    # Input comes from disaggregated storage.
     disagg: bool = False
     # Skip reading/processing cell data (print headers only).
     skip_data: bool = False
@@ -68,12 +58,10 @@ class DecodeOptions:
     # --- Seek / page-limit ---
     # Byte offset in the file to start decoding from.
     offset: int = 0
-    # Treat the input as a fragment with no WT file header.
-    fragment: bool = False
     # Maximum number of pages to decode (0 = unlimited).
     pages: int = 0
 
-    # --- Storage-specific ---
+    # --- Disagg ---
     # Path to the encryption key file used by the pagedecryptor tool.
     keyfile: Optional[str] = None
     # For SQLite input: decode only the record with this LSN.

--- a/tools/py_common/disagg.py
+++ b/tools/py_common/disagg.py
@@ -146,7 +146,7 @@ def process_disagg_pages(disagg_pages, opts: DecodeOptions) -> DisaggTableSummar
                 p.rint(page.block_header)
             else:
                 page.print_page(split=opts.split,
-                                bson=opts.bson,
+                                decode_as_bson=opts.bson,
                                 disagg=True)
             p.rint('')
 

--- a/tools/py_common/disagg.py
+++ b/tools/py_common/disagg.py
@@ -74,7 +74,9 @@ class DisaggPage:
     page_bytes: bytes
 
 
-def process_disagg_pages(disagg_pages, opts) -> DisaggTableSummary:
+def process_disagg_pages(disagg_pages, *,
+                         skip_data: bool = False, cont: bool = False,
+                         split: bool = False, bson: bool = False) -> DisaggTableSummary:
     table_summary = DisaggTableSummary()
 
     for pages in disagg_pages:
@@ -84,7 +86,7 @@ def process_disagg_pages(disagg_pages, opts) -> DisaggTableSummary:
             metadata = disagg_page.metadata
             page_bytes = disagg_page.page_bytes
             b = binary_data.BinaryFile(io.BytesIO(page_bytes))
-            p = Printer(b, opts)
+            p = Printer(b, split=split)
 
             p.rint(metadata)
 
@@ -101,7 +103,10 @@ def process_disagg_pages(disagg_pages, opts) -> DisaggTableSummary:
                 continue
 
             page = btree_format.WTPage()
-            page = page.parse(b, len(page_bytes), opts)
+            page = page.parse(b, len(page_bytes),
+                              disagg=True,
+                              skip_data=skip_data,
+                              cont=cont)
 
             if metadata.is_delta():
                 if page.block_header.magic != btree_format.BlockDisaggHeader.WT_BLOCK_DISAGG_MAGIC_DELTA:
@@ -137,11 +142,13 @@ def process_disagg_pages(disagg_pages, opts) -> DisaggTableSummary:
                 delta_chain = []
 
             table_summary.update_with_page(metadata)
-            if opts.skip_data:
+            if skip_data:
                 p.rint(page.page_header)
                 p.rint(page.block_header)
             else:
-                page.print_page(opts)
+                page.print_page(split=split,
+                                bson=bson,
+                                disagg=True)
             p.rint('')
 
     return table_summary

--- a/tools/py_common/disagg.py
+++ b/tools/py_common/disagg.py
@@ -12,6 +12,7 @@ import logging
 from typing import List, Optional
 
 from py_common import binary_data, btree_format
+from py_common.decode_opts import DecodeOptions
 from py_common.printer import Printer
 
 
@@ -74,9 +75,7 @@ class DisaggPage:
     page_bytes: bytes
 
 
-def process_disagg_pages(disagg_pages, *,
-                         skip_data: bool = False, cont: bool = False,
-                         split: bool = False, bson: bool = False) -> DisaggTableSummary:
+def process_disagg_pages(disagg_pages, opts: DecodeOptions) -> DisaggTableSummary:
     table_summary = DisaggTableSummary()
 
     for pages in disagg_pages:
@@ -86,7 +85,7 @@ def process_disagg_pages(disagg_pages, *,
             metadata = disagg_page.metadata
             page_bytes = disagg_page.page_bytes
             b = binary_data.BinaryFile(io.BytesIO(page_bytes))
-            p = Printer(b, split=split)
+            p = Printer(b, split=opts.split)
 
             p.rint(metadata)
 
@@ -105,8 +104,8 @@ def process_disagg_pages(disagg_pages, *,
             page = btree_format.WTPage()
             page = page.parse(b, len(page_bytes),
                               disagg=True,
-                              skip_data=skip_data,
-                              cont=cont)
+                              skip_data=opts.skip_data,
+                              cont=opts.cont)
 
             if metadata.is_delta():
                 if page.block_header.magic != btree_format.BlockDisaggHeader.WT_BLOCK_DISAGG_MAGIC_DELTA:
@@ -142,12 +141,12 @@ def process_disagg_pages(disagg_pages, *,
                 delta_chain = []
 
             table_summary.update_with_page(metadata)
-            if skip_data:
+            if opts.skip_data:
                 p.rint(page.page_header)
                 p.rint(page.block_header)
             else:
-                page.print_page(split=split,
-                                bson=bson,
+                page.print_page(split=opts.split,
+                                bson=opts.bson,
                                 disagg=True)
             p.rint('')
 

--- a/tools/py_common/file_format.py
+++ b/tools/py_common/file_format.py
@@ -1,6 +1,7 @@
 import logging
 
 from py_common import binary_data, btree_format
+from py_common.decode_opts import DecodeOptions
 from py_common.printer import Printer
 from py_common.stats import PageStats
 
@@ -49,37 +50,33 @@ def outfile_header(output):
         ]
         output.write(",".join(fields))
 
-def wtdecode_file_object(b, nbytes, *,
-                         disagg: bool = False, skip_data: bool = False, cont: bool = False,
-                         split: bool = False,
-                         bson: bool = False, output=None, offset: int = 0,
-                         fragment: bool = False, pages: int = 0):
-    p = Printer(b, split=split)
+def wtdecode_file_object(b, nbytes, opts: DecodeOptions):
+    p = Printer(b, split=opts.split)
     pagecount = 0
-    if offset == 0 and not fragment:
+    if opts.offset == 0 and not opts.fragment:
         file_header_decode(p, b)
         startblock = (b.tell() + 0x1ff) & ~(0x1FF)
     else:
-        startblock = offset
+        startblock = opts.offset
 
-    outfile_header(output)
+    outfile_header(opts.output)
 
-    while (nbytes == 0 or startblock < nbytes) and (pages == 0 or pagecount < pages):
+    while (nbytes == 0 or startblock < nbytes) and (opts.pages == 0 or pagecount < opts.pages):
         d_h = binary_data.d_and_h(startblock)
-        PageStats.outfile_stats_start(output, d_h)
+        PageStats.outfile_stats_start(opts.output, d_h)
         print('Decode at ' + d_h)
         b.seek(startblock)
         try:
             page = btree_format.WTPage.parse(b, nbytes,
-                                             disagg=disagg,
-                                             skip_data=skip_data,
-                                             cont=cont)
+                                             disagg=opts.disagg,
+                                             skip_data=opts.skip_data,
+                                             cont=opts.cont)
             if page.success:
-                page.print_page(split=split,
-                                bson=bson,
-                                disagg=disagg)
+                page.print_page(split=opts.split,
+                                bson=opts.bson,
+                                disagg=opts.disagg)
                 if page.pagestats:
-                    PageStats.outfile_stats_end(output,
+                    PageStats.outfile_stats_end(opts.output,
                                                page.page_header,
                                                page.block_header,
                                                page.pagestats)
@@ -96,7 +93,7 @@ def wtdecode_file_object(b, nbytes, *,
         pos = b.tell()
 
         # If we're in attached storage mode align the file pointer on a 512 byte boundary.
-        if not disagg:
+        if not opts.disagg:
             pos = (pos + 0x1FF) & ~(0x1FF)
 
         if startblock == pos:

--- a/tools/py_common/file_format.py
+++ b/tools/py_common/file_format.py
@@ -53,11 +53,10 @@ def outfile_header(output):
 def wtdecode_file_object(b, nbytes, opts: DecodeOptions):
     p = Printer(b, split=opts.split)
     pagecount = 0
+    startblock = opts.offset
     if opts.offset == 0 and not opts.fragment:
         file_header_decode(p, b)
         startblock = (b.tell() + 0x1ff) & ~(0x1FF)
-    else:
-        startblock = opts.offset
 
     outfile_header(opts.output)
 
@@ -73,7 +72,7 @@ def wtdecode_file_object(b, nbytes, opts: DecodeOptions):
                                              cont=opts.cont)
             if page.success:
                 page.print_page(split=opts.split,
-                                bson=opts.bson,
+                                decode_as_bson=opts.bson,
                                 disagg=opts.disagg)
                 if page.pagestats:
                     PageStats.outfile_stats_end(opts.output,

--- a/tools/py_common/file_format.py
+++ b/tools/py_common/file_format.py
@@ -30,8 +30,8 @@ def file_header_decode(p, b):
     p.rint('')
 
 
-def outfile_header(opts):
-    if opts.output != None:
+def outfile_header(output):
+    if output != None:
         fields = [
             "block id",
 
@@ -47,28 +47,42 @@ def outfile_header(opts):
             # page stats
             *PageStats.csv_cols(),
         ]
-        opts.output.write(",".join(fields))
+        output.write(",".join(fields))
 
-def wtdecode_file_object(b, opts, nbytes):
-    p = Printer(b, opts)
+def wtdecode_file_object(b, nbytes, *,
+                         disagg: bool = False, skip_data: bool = False, cont: bool = False,
+                         split: bool = False,
+                         bson: bool = False, output=None, offset: int = 0,
+                         fragment: bool = False, pages: int = 0):
+    p = Printer(b, split=split)
     pagecount = 0
-    if opts.offset == 0 and not opts.fragment:
+    if offset == 0 and not fragment:
         file_header_decode(p, b)
         startblock = (b.tell() + 0x1ff) & ~(0x1FF)
     else:
-        startblock = opts.offset
+        startblock = offset
 
-    outfile_header(opts)
+    outfile_header(output)
 
-    while (nbytes == 0 or startblock < nbytes) and (opts.pages == 0 or pagecount < opts.pages):
+    while (nbytes == 0 or startblock < nbytes) and (pages == 0 or pagecount < pages):
         d_h = binary_data.d_and_h(startblock)
-        PageStats.outfile_stats_start(opts, d_h)
+        PageStats.outfile_stats_start(output, d_h)
         print('Decode at ' + d_h)
         b.seek(startblock)
         try:
-            page = btree_format.WTPage.parse(b, nbytes, opts)
+            page = btree_format.WTPage.parse(b, nbytes,
+                                             disagg=disagg,
+                                             skip_data=skip_data,
+                                             cont=cont)
             if page.success:
-                page.print_page(opts)
+                page.print_page(split=split,
+                                bson=bson,
+                                disagg=disagg)
+                if page.pagestats:
+                    PageStats.outfile_stats_end(output,
+                                               page.page_header,
+                                               page.block_header,
+                                               page.pagestats)
             p.rint('')
         except BrokenPipeError:
             break
@@ -82,7 +96,7 @@ def wtdecode_file_object(b, opts, nbytes):
         pos = b.tell()
 
         # If we're in attached storage mode align the file pointer on a 512 byte boundary.
-        if not opts.disagg:
+        if not disagg:
             pos = (pos + 0x1FF) & ~(0x1FF)
 
         if startblock == pos:

--- a/tools/py_common/file_format.py
+++ b/tools/py_common/file_format.py
@@ -1,3 +1,31 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
 import logging
 
 from py_common import binary_data, btree_format

--- a/tools/py_common/mdb_log_parse.py
+++ b/tools/py_common/mdb_log_parse.py
@@ -31,7 +31,6 @@ import io
 import logging
 import re
 import json
-
 import dataclasses
 
 from py_common import binary_data

--- a/tools/py_common/mdb_log_parse.py
+++ b/tools/py_common/mdb_log_parse.py
@@ -39,39 +39,58 @@ from py_common.file_format import wtdecode_file_object
 logger = logging.getLogger(__name__)
 
 
-def process_logs(f, opts):
+def process_logs(f, *,
+                 disagg: bool = False, skip_data: bool = False, cont: bool = False,
+                 split: bool = False,
+                 bson: bool = False, output=None, pages: int = 0):
     '''
     Extract the byte dump from mongo or wiredtiger logs.
     '''
     first_line = f.readline()
     f.seek(0)
     if is_mongo_log(first_line):
-        return process_mongod_log(f, opts)
+        return process_mongod_log(f, disagg=disagg, skip_data=skip_data, cont=cont,
+                                  split=split,
+                                  bson=bson, output=output, pages=pages)
     else:
         logger.info('Non MongoDB log format detected, defaulting to WiredTiger log parsing')
-        return process_wiredtiger_log(f, opts)
+        return process_wiredtiger_log(f, disagg=disagg, skip_data=skip_data, cont=cont,
+                                      split=split,
+                                      bson=bson, output=output, pages=pages)
 
 def is_mongo_log(line):
     return line and line.startswith('{')
 
-def process_mongod_log(f, opts):
-    byte_dump = extract_mongodb_log_hex(f, opts)
+def process_mongod_log(f, *,
+                       disagg: bool = False, skip_data: bool = False, cont: bool = False,
+                       split: bool = False,
+                       bson: bool = False, output=None, pages: int = 0):
+    byte_dump = extract_mongodb_log_hex(f)
     if not byte_dump:
         logger.info('No valid byte dump found in MongoDB log')
         return
 
     b = binary_data.BinaryFile(io.BytesIO(byte_dump))
-    wtdecode_file_object(b, opts, len(byte_dump))
+    wtdecode_file_object(b, len(byte_dump),
+                         disagg=disagg, skip_data=skip_data, cont=cont,
+                         split=split,
+                         bson=bson, output=output, fragment=True, pages=pages)
 
-def process_wiredtiger_log(f, opts):
+def process_wiredtiger_log(f, *,
+                           disagg: bool = False, skip_data: bool = False, cont: bool = False,
+                           split: bool = False,
+                           bson: bool = False, output=None, pages: int = 0):
     while True:
-        byte_dump = encode_bytes(f, opts)
+        byte_dump = encode_bytes(f)
         if not byte_dump:
             logger.info('No (more) byte dumps found in WiredTiger log')
             break
 
         b = binary_data.BinaryFile(io.BytesIO(byte_dump))
-        wtdecode_file_object(b, opts, len(byte_dump))
+        wtdecode_file_object(b, len(byte_dump),
+                             disagg=disagg, skip_data=skip_data, cont=cont,
+                             split=split,
+                             bson=bson, output=output, fragment=True, pages=pages)
 
 # Specific exceptions for hex dump validation errors, to distinguish from other parsing errors
 # and to provide more specific error messages about what is wrong with the hex dump.
@@ -93,7 +112,7 @@ def validate_hex_block_size(chunks, expected_size):
     if collected_size != expected_size:
         raise HexDumpCorruptError(f'Block size mismatch: expected {expected_size}, got {collected_size}')
 
-def extract_mongodb_log_hex(f, opts):
+def extract_mongodb_log_hex(f):
     """
     Extract hex dump from MongoDB log file containing checksum mismatch errors.
     Looks for __wt_bm_corrupt_dump messages and extracts all hex chunks.
@@ -162,7 +181,7 @@ def extract_mongodb_log_hex(f, opts):
             # If we don't have a JSON log line, then this isn't a MongoDB log. Reset the file
             # pointer to the start to read all the bytes again.
             f.seek(0)
-            return encode_bytes(f, opts)
+            return encode_bytes(f)
         except HexDumpCorruptError as e:
             logger.error(f'Hex dump is corrupt - {e}')
             logger.info('Stopping parsing')
@@ -180,7 +199,7 @@ def extract_mongodb_log_hex(f, opts):
     logger.error('No checksum mismatch found in log file')
     return bytearray()
 
-def encode_bytes(f, opts):
+def encode_bytes(f):
     """
     Encode a text hex dump into raw bytes.
 

--- a/tools/py_common/mdb_log_parse.py
+++ b/tools/py_common/mdb_log_parse.py
@@ -32,39 +32,32 @@ import logging
 import re
 import json
 
+import dataclasses
+
 from py_common import binary_data
+from py_common.decode_opts import DecodeOptions
 from py_common.file_format import wtdecode_file_object
 
 
 logger = logging.getLogger(__name__)
 
 
-def process_logs(f, *,
-                 disagg: bool = False, skip_data: bool = False, cont: bool = False,
-                 split: bool = False,
-                 bson: bool = False, output=None, pages: int = 0):
+def process_logs(f, opts: DecodeOptions):
     '''
     Extract the byte dump from mongo or wiredtiger logs.
     '''
     first_line = f.readline()
     f.seek(0)
     if is_mongo_log(first_line):
-        return process_mongod_log(f, disagg=disagg, skip_data=skip_data, cont=cont,
-                                  split=split,
-                                  bson=bson, output=output, pages=pages)
+        return process_mongod_log(f, opts)
     else:
         logger.info('Non MongoDB log format detected, defaulting to WiredTiger log parsing')
-        return process_wiredtiger_log(f, disagg=disagg, skip_data=skip_data, cont=cont,
-                                      split=split,
-                                      bson=bson, output=output, pages=pages)
+        return process_wiredtiger_log(f, opts)
 
 def is_mongo_log(line):
     return line and line.startswith('{')
 
-def process_mongod_log(f, *,
-                       disagg: bool = False, skip_data: bool = False, cont: bool = False,
-                       split: bool = False,
-                       bson: bool = False, output=None, pages: int = 0):
+def process_mongod_log(f, opts: DecodeOptions):
     byte_dump = extract_mongodb_log_hex(f)
     if not byte_dump:
         logger.info('No valid byte dump found in MongoDB log')
@@ -72,14 +65,9 @@ def process_mongod_log(f, *,
 
     b = binary_data.BinaryFile(io.BytesIO(byte_dump))
     wtdecode_file_object(b, len(byte_dump),
-                         disagg=disagg, skip_data=skip_data, cont=cont,
-                         split=split,
-                         bson=bson, output=output, fragment=True, pages=pages)
+                         dataclasses.replace(opts, fragment=True))
 
-def process_wiredtiger_log(f, *,
-                           disagg: bool = False, skip_data: bool = False, cont: bool = False,
-                           split: bool = False,
-                           bson: bool = False, output=None, pages: int = 0):
+def process_wiredtiger_log(f, opts: DecodeOptions):
     while True:
         byte_dump = encode_bytes(f)
         if not byte_dump:
@@ -88,9 +76,7 @@ def process_wiredtiger_log(f, *,
 
         b = binary_data.BinaryFile(io.BytesIO(byte_dump))
         wtdecode_file_object(b, len(byte_dump),
-                             disagg=disagg, skip_data=skip_data, cont=cont,
-                             split=split,
-                             bson=bson, output=output, fragment=True, pages=pages)
+                             dataclasses.replace(opts, fragment=True))
 
 # Specific exceptions for hex dump validation errors, to distinguish from other parsing errors
 # and to provide more specific error messages about what is wrong with the hex dump.

--- a/tools/py_common/page_service.py
+++ b/tools/py_common/page_service.py
@@ -37,6 +37,7 @@ import tempfile
 from typing import Dict, List, Optional
 
 from py_common import disagg
+from py_common.decode_opts import DecodeOptions
 
 
 logger = logging.getLogger(__name__)
@@ -143,10 +144,7 @@ def decrypt_page(page, page_metadata, keyfile):
 
     return decrypted_bytes
 
-def process_disagg_table(disagg_table, *,
-                         keyfile=None, skip_data: bool = False,
-                         cont: bool = False, split: bool = False,
-                         bson: bool = False) -> disagg.DisaggTableSummary:
+def process_disagg_table(disagg_table, opts: DecodeOptions) -> disagg.DisaggTableSummary:
     '''
     Extract pages as json objects from the GetTableAtLSN API on the Object Read Proxy.
 
@@ -171,12 +169,10 @@ def process_disagg_table(disagg_table, *,
                 logger.info(f'page_id: {page_metadata.page_id} - empty page')
                 continue
 
-            decrypted_page_bytes = decrypt_page(page, page_metadata, keyfile)
+            decrypted_page_bytes = decrypt_page(page, page_metadata, opts.keyfile)
             page_disagg_pages.append(disagg.DisaggPage(page_metadata,
                                                        decrypted_page_bytes))
 
         disagg_pages.append(page_disagg_pages)
 
-    return disagg.process_disagg_pages(disagg_pages,
-                                       skip_data=skip_data, cont=cont,
-                                       split=split, bson=bson)
+    return disagg.process_disagg_pages(disagg_pages, opts)

--- a/tools/py_common/page_service.py
+++ b/tools/py_common/page_service.py
@@ -75,7 +75,7 @@ def parse_metadata(page: Dict) -> disagg.Metadata:
     )
 
 
-def decrypt_page(page, page_metadata, opts):
+def decrypt_page(page, page_metadata, keyfile):
     """
     Call the pagedecryptor tool from the mongo repo.
     """
@@ -89,7 +89,7 @@ def decrypt_page(page, page_metadata, opts):
             "bazel build //src/mongo/db/modules/atlas/src/disagg_storage/encryption:pagedecryptor"
         )
 
-    if not opts.keyfile or not os.path.exists(opts.keyfile):
+    if not keyfile or not os.path.exists(keyfile):
         raise FileNotFoundError(
             "keyfile not found: Decryption requires the test_keyfile for the KEK."
         )
@@ -116,7 +116,7 @@ def decrypt_page(page, page_metadata, opts):
             'pagedecryptor',
             '--inputPath', temp_input.name,
             '--outputPath', temp_output.name,
-            '--keyFile', opts.keyfile,
+            '--keyFile', keyfile,
             '--lsn', str(lsn),
             '--tableId', str(table_id),
             '--pageId', str(page_id),
@@ -143,7 +143,10 @@ def decrypt_page(page, page_metadata, opts):
 
     return decrypted_bytes
 
-def process_disagg_table(disagg_table, opts) -> disagg.DisaggTableSummary:
+def process_disagg_table(disagg_table, *,
+                         keyfile=None, skip_data: bool = False,
+                         cont: bool = False, split: bool = False,
+                         bson: bool = False) -> disagg.DisaggTableSummary:
     '''
     Extract pages as json objects from the GetTableAtLSN API on the Object Read Proxy.
 
@@ -168,10 +171,12 @@ def process_disagg_table(disagg_table, opts) -> disagg.DisaggTableSummary:
                 logger.info(f'page_id: {page_metadata.page_id} - empty page')
                 continue
 
-            decrypted_page_bytes = decrypt_page(page, page_metadata, opts)
+            decrypted_page_bytes = decrypt_page(page, page_metadata, keyfile)
             page_disagg_pages.append(disagg.DisaggPage(page_metadata,
                                                        decrypted_page_bytes))
 
         disagg_pages.append(page_disagg_pages)
 
-    return disagg.process_disagg_pages(disagg_pages, opts)
+    return disagg.process_disagg_pages(disagg_pages,
+                                       skip_data=skip_data, cont=cont,
+                                       split=split, bson=bson)

--- a/tools/py_common/printer.py
+++ b/tools/py_common/printer.py
@@ -26,7 +26,11 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
+import logging
+
 from py_common import binary_data
+
+logger = logging.getLogger(__name__)
 
 # Manages printing to output.
 # We keep track of cells, the first line printed for a new cell
@@ -35,11 +39,11 @@ from py_common import binary_data
 # in decoding before the regular decoding output appears.
 # Those 'input bytes' are shown shifted to the right.
 class Printer(object):
-    def __init__(self, binfile, opts):
+    def __init__(self, binfile, *, split=False, verbose=0, ext=False):
         self.binfile = binfile
-        self.issplit = opts.split
-        self.verbose = opts.verbose
-        self.ext = opts.ext
+        self.issplit = split
+        self.verbose = verbose
+        self.ext = ext
         self.cellpfx = ''
         self.in_cell = False
 
@@ -165,5 +169,17 @@ def dumpraw(p, b, pos):
     s = binary_to_pretty_string(b.read(256), per_line=per_line, line_prefix='')
     for line in s.splitlines():
         p.rint_v(hex(pos + i) + ':  ' + line)
+        i += per_line
+    b.seek(savepos)
+
+def dumpraw_to_log(b, pos):
+    """Dump raw bytes around a position to the logger for debugging (no Printer needed)."""
+    savepos = b.tell()
+    b.seek(pos)
+    i = 0
+    per_line = 16
+    s = binary_to_pretty_string(b.read(256), per_line=per_line, line_prefix='')
+    for line in s.splitlines():
+        logger.error(hex(pos + i) + ':  ' + line)
         i += per_line
     b.seek(savepos)

--- a/tools/py_common/printer.py
+++ b/tools/py_common/printer.py
@@ -90,13 +90,6 @@ class Printer(object):
             pfx = '  '
         print(pfx + str(s))
 
-    # Aliases kept for readability at call sites.
-    def rint_v(self, s):
-        self.rint(s)
-
-    def rint_ext(self, s):
-        self.rint(s)
-            
 def raw_bytes(b):
     if type(b) != type(b''):
         # Not bytes, it's already a string.

--- a/tools/py_common/printer.py
+++ b/tools/py_common/printer.py
@@ -39,11 +39,9 @@ logger = logging.getLogger(__name__)
 # in decoding before the regular decoding output appears.
 # Those 'input bytes' are shown shifted to the right.
 class Printer(object):
-    def __init__(self, binfile, *, split=False, verbose=0, ext=False):
+    def __init__(self, binfile, *, split=False):
         self.binfile = binfile
         self.issplit = split
-        self.verbose = verbose
-        self.ext = ext
         self.cellpfx = ''
         self.in_cell = False
 
@@ -92,13 +90,12 @@ class Printer(object):
             pfx = '  '
         print(pfx + str(s))
 
+    # Aliases kept for readability at call sites.
     def rint_v(self, s):
-        if self.verbose:
-            self.rint(s)
+        self.rint(s)
 
     def rint_ext(self, s):
-        if self.ext:
-            self.rint(s)
+        self.rint(s)
             
 def raw_bytes(b):
     if type(b) != type(b''):
@@ -160,17 +157,6 @@ def binary_to_pretty_string(b, per_line=16, line_prefix='  ', start_with_line_pr
             result += '   '
     result += '  ' + printable
     return result
-
-def dumpraw(p, b, pos):
-    savepos = b.tell()
-    b.seek(pos)
-    i = 0
-    per_line = 16
-    s = binary_to_pretty_string(b.read(256), per_line=per_line, line_prefix='')
-    for line in s.splitlines():
-        p.rint_v(hex(pos + i) + ':  ' + line)
-        i += per_line
-    b.seek(savepos)
 
 def dumpraw_to_log(b, pos):
     """Dump raw bytes around a position to the logger for debugging (no Printer needed)."""

--- a/tools/py_common/snappy_util.py
+++ b/tools/py_common/snappy_util.py
@@ -40,7 +40,7 @@ except:
     HAVE_SNAPPY = False
 
 
-def snappy_decompress_page(b: binary_data.BinaryFile, page_header, header_length, disk_size, disk_pos, opts) -> bytearray:
+def snappy_decompress_page(b: binary_data.BinaryFile, page_header, header_length, disk_size, disk_pos) -> bytearray:
     if not HAVE_SNAPPY:
         raise ModuleNotFoundError('python-snappy is required to decode compressed pages')
 

--- a/tools/py_common/sqlite_format.py
+++ b/tools/py_common/sqlite_format.py
@@ -12,6 +12,7 @@ import sys
 from typing import Iterable, List, Optional
 
 from py_common import disagg
+from py_common.decode_opts import DecodeOptions
 
 
 SQLITE3_SIGNATURE = b'SQLite format 3\x00'
@@ -193,12 +194,6 @@ def load_disagg_pages(filename: str, *, lsn=None, page_id=None, pages: int = 0) 
         return _load_disagg_pages_all(conn, pages_limit)
 
 
-def process_sqlite_file(filename: str, *,
-                        lsn=None, page_id=None, pages: int = 0,
-                        skip_data: bool = False, cont: bool = False,
-                        split: bool = False,
-                        bson: bool = False) -> disagg.DisaggTableSummary:
-    disagg_pages = load_disagg_pages(filename, lsn=lsn, page_id=page_id, pages=pages)
-    return disagg.process_disagg_pages(disagg_pages,
-                                       skip_data=skip_data, cont=cont,
-                                       split=split, bson=bson)
+def process_sqlite_file(filename: str, opts: DecodeOptions) -> disagg.DisaggTableSummary:
+    disagg_pages = load_disagg_pages(filename, lsn=opts.lsn, page_id=opts.page_id, pages=opts.pages)
+    return disagg.process_disagg_pages(disagg_pages, opts)

--- a/tools/py_common/sqlite_format.py
+++ b/tools/py_common/sqlite_format.py
@@ -175,24 +175,30 @@ def _load_disagg_pages_for_page_id(
     return [_rows_to_disagg_pages(rows)]
 
 
-def load_disagg_pages(filename: str, opts) -> List[List[disagg.DisaggPage]]:
+def load_disagg_pages(filename: str, *, lsn=None, page_id=None, pages: int = 0) -> List[List[disagg.DisaggPage]]:
     with sqlite3.connect(filename) as conn:
         conn.row_factory = sqlite3.Row
 
         # Specific lsn takes precedence over page_id selection,
         # since it provides a more precise selection of the page to decode.
-        if opts.lsn is not None:
-            return _load_disagg_pages_for_lsn(conn, opts.lsn, opts.page_id)
+        if lsn is not None:
+            return _load_disagg_pages_for_lsn(conn, lsn, page_id)
 
         # Select entire page chain for given page_id.
-        if opts.page_id is not None:
-            return _load_disagg_pages_for_page_id(conn, opts.page_id)
+        if page_id is not None:
+            return _load_disagg_pages_for_page_id(conn, page_id)
 
         # No specific selection criteria provided; return all pages up to the limit.
-        pages_limit = opts.pages if opts.pages > 0 else sys.maxsize
+        pages_limit = pages if pages > 0 else sys.maxsize
         return _load_disagg_pages_all(conn, pages_limit)
 
 
-def process_sqlite_file(filename: str, opts) -> disagg.DisaggTableSummary:
-    disagg_pages = load_disagg_pages(filename, opts)
-    return disagg.process_disagg_pages(disagg_pages, opts)
+def process_sqlite_file(filename: str, *,
+                        lsn=None, page_id=None, pages: int = 0,
+                        skip_data: bool = False, cont: bool = False,
+                        split: bool = False,
+                        bson: bool = False) -> disagg.DisaggTableSummary:
+    disagg_pages = load_disagg_pages(filename, lsn=lsn, page_id=page_id, pages=pages)
+    return disagg.process_disagg_pages(disagg_pages,
+                                       skip_data=skip_data, cont=cont,
+                                       split=split, bson=bson)

--- a/tools/py_common/stats.py
+++ b/tools/py_common/stats.py
@@ -113,13 +113,13 @@ class PageStats:
         ]
         
     @staticmethod
-    def outfile_stats_start(opts, blockid):
-        if opts.output != None:
-            opts.output.write("\n" + blockid + ",")
+    def outfile_stats_start(output, blockid):
+        if output != None:
+            output.write("\n" + blockid + ",")
     
     @staticmethod
-    def outfile_stats_end(opts, pagehead, blockhead, pagestats):
-        if opts.output != None:
+    def outfile_stats_end(output, pagehead, blockhead, pagestats):
+        if output != None:
             line = [
                 # page head
                 pagehead.write_gen,
@@ -132,7 +132,7 @@ class PageStats:
                 # page_stats
                 *pagestats.to_csv_cols(),
             ]
-            opts.output.write(",".join(str(x) for x in line))
+            output.write(",".join(str(x) for x in line))
 
     def process_timestamps(self, cell) -> None:
         """

--- a/tools/test/test_decode_disagg_delta_chain.py
+++ b/tools/test/test_decode_disagg_delta_chain.py
@@ -35,6 +35,7 @@ import unittest
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import wt_binary_decode
+from py_common.decode_opts import DecodeOptions
 
 
 class TestDecodeDisaggDeltaChain(unittest.TestCase):
@@ -47,7 +48,7 @@ class TestDecodeDisaggDeltaChain(unittest.TestCase):
 
         buffer = io.StringIO()
         with contextlib.redirect_stdout(buffer):
-            wt_binary_decode.wtdecode(log_path, disagg=True, dumpin=True, verbose=1)
+            wt_binary_decode.wtdecode(log_path, DecodeOptions(disagg=True, dumpin=True))
         output = buffer.getvalue()
 
         self.assertGreater(len(output), 0, "Decoder output should not be empty")

--- a/tools/test/test_decode_disagg_delta_chain.py
+++ b/tools/test/test_decode_disagg_delta_chain.py
@@ -45,17 +45,9 @@ class TestDecodeDisaggDeltaChain(unittest.TestCase):
         log_path = os.path.join(cur_dir, "binary_files", "disagg_delta_chain.log")
         self.assertTrue(os.path.exists(log_path), f"Missing delta chain log at {log_path}")
 
-        parser = wt_binary_decode.get_arg_parser()
-        opts = parser.parse_args([
-            "--disagg",
-            "--dumpin",
-            "--verbose",
-            log_path,
-        ])
-
         buffer = io.StringIO()
         with contextlib.redirect_stdout(buffer):
-            wt_binary_decode.wtdecode(opts)
+            wt_binary_decode.wtdecode(log_path, disagg=True, dumpin=True, verbose=1)
         output = buffer.getvalue()
 
         self.assertGreater(len(output), 0, "Decoder output should not be empty")

--- a/tools/test/test_decode_disagg_delta_page.py
+++ b/tools/test/test_decode_disagg_delta_page.py
@@ -29,7 +29,6 @@
 import os
 import sys
 import unittest
-from types import SimpleNamespace
 
 # Add tools directory to sys.path so we can import py_common
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -39,27 +38,8 @@ from py_common import binary_data, btree_format
 class TestDecodeDeltaPage(unittest.TestCase):
     """Unit tests for decoding a delta page from disaggregated storage."""
 
-    def make_opts(self) -> SimpleNamespace:
-        """Create an opts object required for decoding a disagg page."""
-        return SimpleNamespace(
-            # Disagg / decoding options
-            disagg=True,
-            disagg_table=False,
-            bson=True,
-            # General decode options
-            skip_data=False,
-            cont=False,
-            debug=False,
-            # Printer options
-            split=False,
-            verbose=True,
-            ext=False,
-            output=None,
-        )
-
     def test_decode_disagg_delta_page(self):
         """Decode delta page from MongoDB oplog."""
-        opts = self.make_opts()
         cur_dir = os.path.dirname(os.path.abspath(__file__))
         page_path = os.path.join(cur_dir, "binary_files", "disagg_delta_oplog.bin")
 
@@ -72,9 +52,9 @@ class TestDecodeDeltaPage(unittest.TestCase):
             b = binary_data.BinaryFile(disagg_file)
             nbytes = os.path.getsize(page_path)
 
-            page = btree_format.WTPage.parse(b, nbytes, opts)
+            page = btree_format.WTPage.parse(b, nbytes, disagg=True)
 
-            page.print_page(opts)
+            page.print_page(bson=True, disagg=True)
 
             # Verify the parse succeeded and we can inspect the page
             self.assertTrue(getattr(page, 'success', True), 'WTPage.parse failed')

--- a/tools/test/test_decode_disagg_delta_page.py
+++ b/tools/test/test_decode_disagg_delta_page.py
@@ -54,7 +54,7 @@ class TestDecodeDeltaPage(unittest.TestCase):
 
             page = btree_format.WTPage.parse(b, nbytes, disagg=True)
 
-            page.print_page(bson=True, disagg=True)
+            page.print_page(decode_as_bson=True, disagg=True)
 
             # Verify the parse succeeded and we can inspect the page
             self.assertTrue(getattr(page, 'success', True), 'WTPage.parse failed')

--- a/tools/test/test_decode_disagg_table.py
+++ b/tools/test/test_decode_disagg_table.py
@@ -29,7 +29,6 @@
 import os
 import sys
 import unittest
-from types import SimpleNamespace
 
 # Add tools directory to sys.path so we can import py_common
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -39,34 +38,13 @@ from py_common import page_service
 class TestDecodeDisaggTable(unittest.TestCase):
     """Unit tests for decoding a table from disaggregated storage."""
 
-    def make_opts(self) -> SimpleNamespace:
-        """Create an opts object required for decoding a disagg table."""
+    def test_decode_disagg_table_bson(self):
+        """Decode the disagg table in JSONL format."""
         keyfile = os.environ.get("DISAGG_KEYFILE")
         if not keyfile:
             self.skipTest(
                 f"Environment variable DISAGG_KEYFILE must be set to the encryption keyfile path"
             )
-
-        return SimpleNamespace(
-            # Disagg / decoding options
-            disagg=True,
-            disagg_table=True,
-            bson=True,
-            keyfile=keyfile,
-            # General decode options
-            skip_data=False,
-            cont=False,
-            debug=False,
-            # Printer options
-            split=False,
-            verbose=True,
-            ext=False,
-            output=None,
-        )
-
-    def test_decode_disagg_table_bson(self):
-        """Decode the disagg table in JSONL format."""
-        opts = self.make_opts()
         cur_dir = os.path.dirname(os.path.abspath(__file__))
         table_path = os.path.join(cur_dir, "binary_files", "disagg_oplog.jsonl")
 
@@ -76,7 +54,11 @@ class TestDecodeDisaggTable(unittest.TestCase):
         )
 
         with open(table_path, "r", encoding="utf-8") as disagg_file:
-            table_summary = page_service.process_disagg_table(disagg_file, opts)
+            table_summary = page_service.process_disagg_table(
+                disagg_file,
+                keyfile=keyfile,
+                bson=True,
+            )
 
             self.assertEqual(table_summary.delta_pages, 2)
             self.assertEqual(table_summary.full_pages, 6)

--- a/tools/test/test_decode_disagg_table.py
+++ b/tools/test/test_decode_disagg_table.py
@@ -56,8 +56,7 @@ class TestDecodeDisaggTable(unittest.TestCase):
         with open(table_path, "r", encoding="utf-8") as disagg_file:
             table_summary = page_service.process_disagg_table(
                 disagg_file,
-                keyfile=keyfile,
-                bson=True,
+                DecodeOptions(keyfile=keyfile, bson=True),
             )
 
             self.assertEqual(table_summary.delta_pages, 2)

--- a/tools/test/test_decode_log_mongodb.py
+++ b/tools/test/test_decode_log_mongodb.py
@@ -36,6 +36,7 @@ import unittest
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import wt_binary_decode
+from py_common.decode_opts import DecodeOptions
 
 
 class TestDecodeMongoDBLog(unittest.TestCase):
@@ -52,7 +53,7 @@ class TestDecodeMongoDBLog(unittest.TestCase):
         buffer = io.StringIO()
         with self.assertLogs("py_common.mdb_log_parse", level=logging.INFO) as logs:
             with contextlib.redirect_stdout(buffer):
-                wt_binary_decode.wtdecode(log_path, dumpin=True)
+                wt_binary_decode.wtdecode(log_path, DecodeOptions(dumpin=True))
         return buffer.getvalue(), "\n".join(logs.output)
 
     def test_decode_log_mongodb_valid(self):

--- a/tools/test/test_decode_log_mongodb.py
+++ b/tools/test/test_decode_log_mongodb.py
@@ -44,21 +44,15 @@ class TestDecodeMongoDBLog(unittest.TestCase):
     def setUp(self):
         self.cur_dir = os.path.dirname(os.path.abspath(__file__))
         self.binary_files_dir = os.path.join(self.cur_dir, "binary_files")
-        self.parser = wt_binary_decode.get_arg_parser()
 
     def run_decode(self, filename):
         log_path = os.path.join(self.binary_files_dir, filename)
         self.assertTrue(os.path.exists(log_path), f"Missing log file at {log_path}")
 
-        opts = self.parser.parse_args([
-            "--dumpin",
-            log_path,
-        ])
-
         buffer = io.StringIO()
         with self.assertLogs("py_common.mdb_log_parse", level=logging.INFO) as logs:
             with contextlib.redirect_stdout(buffer):
-                wt_binary_decode.wtdecode(opts)
+                wt_binary_decode.wtdecode(log_path, dumpin=True)
         return buffer.getvalue(), "\n".join(logs.output)
 
     def test_decode_log_mongodb_valid(self):

--- a/tools/test/test_decode_page.py
+++ b/tools/test/test_decode_page.py
@@ -30,7 +30,6 @@ import io
 import os
 import sys
 import unittest
-from types import SimpleNamespace
 
 # Add tools directory to sys.path so we can import py_common
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -42,37 +41,21 @@ import py_common.mdb_log_parse as log_parse
 class Test(unittest.TestCase):
     """Unit tests for decoding a single WT pages using only."""
 
-    def make_opts(self):
-        """Mock an opts object used by WTPage/Printer/PageStats."""
-        return SimpleNamespace(
-            disagg=False,
-            skip_data=True,  # only check the headers
-            cont=False,
-            debug=False,
-            # Printer options
-            split=False,
-            verbose=False,
-            ext=False,
-            output=None,
-        )
-
-    def load_page_bytes(self, opts):
+    def load_page_bytes(self):
         """Read WiredTiger01.txt and convert its hex dump into raw bytes."""
         cur_dir = os.path.dirname(os.path.abspath(__file__))
         file_path = os.path.join(cur_dir, "binary_files", "WiredTiger01.txt")
         with open(file_path, "r", encoding="utf-8") as f:
-            return log_parse.encode_bytes(f, opts)
+            return log_parse.encode_bytes(f)
 
     def test_wtpage_headers_from_wiredtiger01(self):
         """Decode WiredTiger01.txt and verify page and block header fields."""
-        opts = self.make_opts()
-        
-        page_bytes = self.load_page_bytes(opts)
+        page_bytes = self.load_page_bytes()
         self.assertGreater(len(page_bytes), 0, "Encoded page bytes should not be empty")
 
         b = binary_data.BinaryFile(io.BytesIO(page_bytes))
 
-        page = btree_format.WTPage.parse(b, len(page_bytes), opts)
+        page = btree_format.WTPage.parse(b, len(page_bytes), skip_data=True)
         self.assertTrue(page.success, "WTPage parsing failed")
 
         # Validate Page Header fields

--- a/tools/test/test_sqlite_format.py
+++ b/tools/test/test_sqlite_format.py
@@ -11,7 +11,6 @@ import sys
 import tempfile
 import unittest
 import logging
-from types import SimpleNamespace
 
 # Add tools directory to sys.path so we can import py_common
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -20,11 +19,6 @@ from py_common import sqlite_format
 
 
 class TestSqliteFormat(unittest.TestCase):
-    def _make_opts(self, **overrides):
-        defaults = dict(page_id=None, lsn=None, pages=0)
-        defaults.update(overrides)
-        return SimpleNamespace(**defaults)
-
 
     def _create_test_db(self):
         temp_file = tempfile.NamedTemporaryFile(delete=False, suffix='.db')
@@ -101,9 +95,8 @@ class TestSqliteFormat(unittest.TestCase):
 
 
     def test_page_id_latest_lsn(self):
-        opts = self._make_opts(page_id=10)
         with self.assertLogs('py_common.sqlite_format', level=logging.WARNING) as logs:
-            pages = sqlite_format.load_disagg_pages(self.db_path, opts)
+            pages = sqlite_format.load_disagg_pages(self.db_path, page_id=10)
 
         self.assertEqual(len(pages), 1)
         self.assertEqual([entry.metadata.lsn for entry in pages[0]], [11, 9])
@@ -111,32 +104,28 @@ class TestSqliteFormat(unittest.TestCase):
 
 
     def test_page_id_specific_lsn(self):
-        opts = self._make_opts(page_id=10, lsn=5)
-        pages = sqlite_format.load_disagg_pages(self.db_path, opts)
+        pages = sqlite_format.load_disagg_pages(self.db_path, page_id=10, lsn=5)
 
         self.assertEqual(len(pages), 1)
         self.assertEqual([entry.metadata.lsn for entry in pages[0]], [5])
 
 
     def test_page_id_single_base_no_warning(self):
-        opts = self._make_opts(page_id=11)
-        pages = sqlite_format.load_disagg_pages(self.db_path, opts)
+        pages = sqlite_format.load_disagg_pages(self.db_path, page_id=11)
 
         self.assertEqual(len(pages), 1)
         self.assertEqual([entry.metadata.lsn for entry in pages[0]], [17])
 
 
     def test_without_page_id_respects_pages_limit(self):
-        opts = self._make_opts(pages=1)
-        pages = sqlite_format.load_disagg_pages(self.db_path, opts)
+        pages = sqlite_format.load_disagg_pages(self.db_path, pages=1)
 
         self.assertEqual(len(pages), 1)
         self.assertEqual([entry.metadata.page_id for entry in pages[0]], [10, 10])
 
 
     def test_lsn_without_page_id(self):
-        opts = self._make_opts(lsn=7)
-        pages = sqlite_format.load_disagg_pages(self.db_path, opts)
+        pages = sqlite_format.load_disagg_pages(self.db_path, lsn=7)
 
         self.assertEqual(len(pages), 1)
         self.assertEqual(len(pages[0]), 1)
@@ -153,8 +142,7 @@ class TestSqliteFormat(unittest.TestCase):
 
 
     def test_page_id_returns_base_page_chain(self):
-        opts = self._make_opts(page_id=12)
-        pages = sqlite_format.load_disagg_pages(self.db_path, opts)
+        pages = sqlite_format.load_disagg_pages(self.db_path, page_id=12)
 
         self.assertEqual(len(pages), 1)
         self.assertEqual([page.metadata.lsn for page in pages[0]], [30, 25, 20])
@@ -163,9 +151,8 @@ class TestSqliteFormat(unittest.TestCase):
 
 
     def test_lsn_and_page_id_mismatch(self):
-        opts = self._make_opts(page_id=11, lsn=7)
         with self.assertRaises(ValueError):
-            sqlite_format.load_disagg_pages(self.db_path, opts)
+            sqlite_format.load_disagg_pages(self.db_path, page_id=11, lsn=7)
 
 
 if __name__ == "__main__":

--- a/tools/wt_binary_decode.py
+++ b/tools/wt_binary_decode.py
@@ -41,6 +41,7 @@ import collections
 from contextlib import nullcontext
 from py_common import mdb_log_parse
 from py_common import binary_data
+from py_common.decode_opts import DecodeOptions
 from py_common import btree_format
 from py_common import snappy_util
 from py_common import file_format
@@ -64,53 +65,24 @@ def open_output_file(filename, mode):
     return open(filename, mode) if filename else nullcontext()
 
 
-def decode_dumpin_input(filename, opts, output):
-    with open_input_file(filename, 'r') as infile:
-        mdb_log_parse.process_logs(infile,
-                                   disagg=opts.disagg, skip_data=opts.skip_data, cont=opts.cont,
-                                   split=opts.split,
-                                   bson=opts.bson, output=output, pages=opts.pages)
-
-
-def decode_disagg_table_input(filename, opts):
-    with open_input_file(filename, 'r') as infile:
-        page_service.process_disagg_table(infile,
-                                          keyfile=opts.keyfile,
-                                          skip_data=opts.skip_data, cont=opts.cont,
-                                          split=opts.split, bson=opts.bson)
-
-
-def decode_sqlite_input(filename, opts):
-    logger.info('Detected SQLite3 input format.')
-    sqlite_format.process_sqlite_file(filename,
-                                      lsn=opts.lsn, page_id=opts.page_id, pages=opts.pages,
-                                      skip_data=opts.skip_data, cont=opts.cont,
-                                      split=opts.split, bson=opts.bson)
-
-
-def decode_wt_binary_input(filename, opts, output):
-    nbytes = 0 if filename == '-' else os.path.getsize(filename)
-    input_name = 'stdin' if filename == '-' else filename
-    input_size = 'unknown' if filename == '-' else hex(nbytes)
-    print(f'{input_name}, position {hex(opts.offset)}, size {input_size}, '
-          f'pagelimit {opts.pages}')
-    with open_input_file(filename, 'rb') as fileobj:
-        file_format.wtdecode_file_object(binary_data.BinaryFile(fileobj), nbytes,
-                                         disagg=opts.disagg, skip_data=opts.skip_data, cont=opts.cont,
-                                         split=opts.split,
-                                         bson=opts.bson, output=output,
-                                         offset=opts.offset, fragment=opts.fragment, pages=opts.pages)
-
-
-def wtdecode(filename, opts, *, output=None):
+def wtdecode(filename, opts: DecodeOptions):
     if opts.dumpin:
-        decode_dumpin_input(filename, opts, output)
+        with open_input_file(filename, 'r') as infile:
+            mdb_log_parse.process_logs(infile, opts)
     elif opts.disagg_table:
-        decode_disagg_table_input(filename, opts)
+        with open_input_file(filename, 'r') as infile:
+            page_service.process_disagg_table(infile, opts)
     elif sqlite_format.is_sqlite3_file(filename):
-        decode_sqlite_input(filename, opts)
+        logger.info('Detected SQLite3 input format.')
+        sqlite_format.process_sqlite_file(filename, opts)
     else:
-        decode_wt_binary_input(filename, opts, output)
+        nbytes = 0 if filename == '-' else os.path.getsize(filename)
+        input_name = 'stdin' if filename == '-' else filename
+        input_size = 'unknown' if filename == '-' else hex(nbytes)
+        print(f'{input_name}, position {hex(opts.offset)}, size {input_size}, '
+              f'pagelimit {opts.pages}')
+        with open_input_file(filename, 'rb') as fileobj:
+            file_format.wtdecode_file_object(binary_data.BinaryFile(fileobj), nbytes, opts)
 
 
 def feature_check(*, bson: bool = False):
@@ -232,6 +204,22 @@ if __name__ == '__main__':
 
     try:
         with open_output_file(args.output, 'w') as output_file:
-            wtdecode(args.filename, args, output=output_file)
+            opts = DecodeOptions(
+                dumpin=args.dumpin,
+                disagg_table=args.disagg_table,
+                disagg=args.disagg,
+                skip_data=args.skip_data,
+                cont=args.cont,
+                split=args.split,
+                bson=args.bson,
+                output=output_file,
+                offset=args.offset,
+                fragment=args.fragment,
+                pages=args.pages,
+                keyfile=getattr(args, 'keyfile', None),
+                lsn=args.lsn,
+                page_id=args.page_id,
+            )
+            wtdecode(args.filename, opts)
     except (KeyboardInterrupt, BrokenPipeError):
         pass

--- a/tools/wt_binary_decode.py
+++ b/tools/wt_binary_decode.py
@@ -64,54 +64,60 @@ def open_output_file(filename, mode):
     return open(filename, mode) if filename else nullcontext()
 
 
-def decode_dumpin_input(opts):
-    opts.fragment = True
-    with open_input_file(opts.filename, 'r') as infile:
-        mdb_log_parse.process_logs(infile, opts)
+def decode_dumpin_input(filename, opts, output):
+    with open_input_file(filename, 'r') as infile:
+        mdb_log_parse.process_logs(infile,
+                                   disagg=opts.disagg, skip_data=opts.skip_data, cont=opts.cont,
+                                   split=opts.split,
+                                   bson=opts.bson, output=output, pages=opts.pages)
 
 
-def decode_disagg_table_input(opts):
-    opts.disagg = True
-    opts.fragment = True
-    with open_input_file(opts.filename, 'r') as infile:
-        page_service.process_disagg_table(infile, opts)
+def decode_disagg_table_input(filename, opts):
+    with open_input_file(filename, 'r') as infile:
+        page_service.process_disagg_table(infile,
+                                          keyfile=opts.keyfile,
+                                          skip_data=opts.skip_data, cont=opts.cont,
+                                          split=opts.split, bson=opts.bson)
 
 
-def decode_sqlite_input(opts):
+def decode_sqlite_input(filename, opts):
     logger.info('Detected SQLite3 input format.')
-    opts.disagg = True
-    opts.fragment = True
-    sqlite_format.process_sqlite_file(opts.filename, opts)
+    sqlite_format.process_sqlite_file(filename,
+                                      lsn=opts.lsn, page_id=opts.page_id, pages=opts.pages,
+                                      skip_data=opts.skip_data, cont=opts.cont,
+                                      split=opts.split, bson=opts.bson)
 
 
-def decode_wt_binary_input(opts):
-    nbytes = 0 if opts.filename == '-' else os.path.getsize(opts.filename)
-    input_name = 'stdin' if opts.filename == '-' else opts.filename
-    input_size = 'unknown' if opts.filename == '-' else hex(nbytes)
+def decode_wt_binary_input(filename, opts, output):
+    nbytes = 0 if filename == '-' else os.path.getsize(filename)
+    input_name = 'stdin' if filename == '-' else filename
+    input_size = 'unknown' if filename == '-' else hex(nbytes)
     print(f'{input_name}, position {hex(opts.offset)}, size {input_size}, '
           f'pagelimit {opts.pages}')
-    with open_input_file(opts.filename, 'rb') as fileobj:
-        file_format.wtdecode_file_object(binary_data.BinaryFile(fileobj),
-                                         opts,
-                                         nbytes)
+    with open_input_file(filename, 'rb') as fileobj:
+        file_format.wtdecode_file_object(binary_data.BinaryFile(fileobj), nbytes,
+                                         disagg=opts.disagg, skip_data=opts.skip_data, cont=opts.cont,
+                                         split=opts.split,
+                                         bson=opts.bson, output=output,
+                                         offset=opts.offset, fragment=opts.fragment, pages=opts.pages)
 
 
-def wtdecode(opts):
+def wtdecode(filename, opts, *, output=None):
     if opts.dumpin:
-        decode_dumpin_input(opts)
+        decode_dumpin_input(filename, opts, output)
     elif opts.disagg_table:
-        decode_disagg_table_input(opts)
-    elif sqlite_format.is_sqlite3_file(opts.filename):
-        decode_sqlite_input(opts)
+        decode_disagg_table_input(filename, opts)
+    elif sqlite_format.is_sqlite3_file(filename):
+        decode_sqlite_input(filename, opts)
     else:
-        decode_wt_binary_input(opts)
+        decode_wt_binary_input(filename, opts, output)
 
 
-def feature_check(opts):
+def feature_check(*, bson: bool = False):
     Feature = collections.namedtuple('Feature',
                                      ['available', 'requested', 'message'])
     features = [
-        Feature(btree_format.HAVE_BSON, opts.bson,
+        Feature(btree_format.HAVE_BSON, bson,
                 'BSON decoding (--bson) is not available. '
                 'BSON-encoded cell values will be shown as raw bytes. '
                 'Please install the bson library (pip install pymongo).'),
@@ -193,7 +199,7 @@ def get_arg_parser():
     outargs.add_argument('-v', '--verbose',
         action='count',
         default=0,
-        help='verbose output (repeat for more verbosity: -v, -vv)')
+        help='verbose logging output (repeat for more verbosity: -v, -vv)')
     outargs.add_argument('-b', '--bytes',
         action='store_true',
         help='show bytes alongside decoding')
@@ -206,9 +212,6 @@ def get_arg_parser():
         dest='cont',
         action='store_true',
         help='continue on checksum failure')
-    outargs.add_argument('--ext',
-        action='store_true',
-        help='dump only the extent lists')
     outargs.add_argument('-s', '--split',
         action='store_true',
         help='split output to also show raw bytes')
@@ -219,17 +222,16 @@ def get_arg_parser():
 # Only run the main code if this file is not imported.
 if __name__ == '__main__':
     parser = get_arg_parser()
-    opts = parser.parse_args()
+    args = parser.parse_args()
 
     log_levels = [logging.WARNING, logging.INFO, logging.DEBUG]
-    level = log_levels[min(opts.verbose, len(log_levels) - 1)]
+    level = log_levels[min(args.verbose, len(log_levels) - 1)]
     logging.basicConfig(level=level, format='[%(levelname)s] %(message)s')
 
-    feature_check(opts)
+    feature_check(bson=args.bson)
 
     try:
-        with open_output_file(opts.output, 'w') as output_file:
-            opts.output = output_file
-            wtdecode(opts)
+        with open_output_file(args.output, 'w') as output_file:
+            wtdecode(args.filename, args, output=output_file)
     except (KeyboardInterrupt, BrokenPipeError):
         pass

--- a/tools/wt_binary_decode.py
+++ b/tools/wt_binary_decode.py
@@ -65,24 +65,40 @@ def open_output_file(filename, mode):
     return open(filename, mode) if filename else nullcontext()
 
 
+def decode_dumpin_input(filename, opts: DecodeOptions):
+    with open_input_file(filename, 'r') as infile:
+        mdb_log_parse.process_logs(infile, opts)
+
+
+def decode_disagg_table_input(filename, opts: DecodeOptions):
+    with open_input_file(filename, 'r') as infile:
+        page_service.process_disagg_table(infile, opts)
+
+
+def decode_sqlite_input(filename, opts: DecodeOptions):
+    logger.info('Detected SQLite3 input format.')
+    sqlite_format.process_sqlite_file(filename, opts)
+
+
+def decode_wt_binary_input(filename, opts: DecodeOptions):
+    nbytes = 0 if filename == '-' else os.path.getsize(filename)
+    input_name = 'stdin' if filename == '-' else filename
+    input_size = 'unknown' if filename == '-' else hex(nbytes)
+    print(f'{input_name}, position {hex(opts.offset)}, size {input_size}, '
+          f'pagelimit {opts.pages}')
+    with open_input_file(filename, 'rb') as fileobj:
+        file_format.wtdecode_file_object(binary_data.BinaryFile(fileobj), nbytes, opts)
+
+
 def wtdecode(filename, opts: DecodeOptions):
     if opts.dumpin:
-        with open_input_file(filename, 'r') as infile:
-            mdb_log_parse.process_logs(infile, opts)
+        decode_dumpin_input(filename, opts)
     elif opts.disagg_table:
-        with open_input_file(filename, 'r') as infile:
-            page_service.process_disagg_table(infile, opts)
+        decode_disagg_table_input(filename, opts)
     elif sqlite_format.is_sqlite3_file(filename):
-        logger.info('Detected SQLite3 input format.')
-        sqlite_format.process_sqlite_file(filename, opts)
+        decode_sqlite_input(filename, opts)
     else:
-        nbytes = 0 if filename == '-' else os.path.getsize(filename)
-        input_name = 'stdin' if filename == '-' else filename
-        input_size = 'unknown' if filename == '-' else hex(nbytes)
-        print(f'{input_name}, position {hex(opts.offset)}, size {input_size}, '
-              f'pagelimit {opts.pages}')
-        with open_input_file(filename, 'rb') as fileobj:
-            file_format.wtdecode_file_object(binary_data.BinaryFile(fileobj), nbytes, opts)
+        decode_wt_binary_input(filename, opts)
 
 
 def feature_check(*, bson: bool = False):


### PR DESCRIPTION
The goal of this PR is to decouple the options parsing between the CLI tool and the decoding modules. Please let me know if you have better ideas on how to do this. I've decided to:
- Use a dataclass to pass the options around the file parsing and decode functions, for example, in `wtdecode_file_object` and `process_logs`. These have a lot of common configs.
- Use separate args for the core low-level decoding modules, such as those in `btree_format.py`. These are the most important to decouple for reusability.
- Remove `--ext` and `--verbose` options for printing cells. Instead, `--skip-data` will skip over the cells in the blocks if they shouldn't be parsed or printed. `--verbose` is only used for logging now.