### PR TITLE
WT-16559 On schema drop update the database size

### DIFF
--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -893,6 +893,7 @@ __checkpoint_update_disagg_database_size(WT_SESSION_IMPL *session, uint64_t drop
         int64_t delta;
 
         db = conn->disaggregated_storage.database_size;
+        /* Subtract the size of the dropped tables from our delta, we need to account for those. */
         delta = session->ckpt.ckpt_size_delta - (int64_t)drop_size;
 
         if (delta > 0) {

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -906,6 +906,18 @@ __checkpoint_update_disagg_database_size(WT_SESSION_IMPL *session, uint64_t drop
 }
 
 /*
+ * __checkpoint_process_disagg_metadata --
+ *     Compute the drop size from the shared metadata queue, then process the queue.
+ */
+static int
+__checkpoint_process_disagg_metadata(WT_SESSION_IMPL *session, uint64_t *drop_sizep)
+{
+    WT_RET(__wt_disagg_shared_metadata_queue_drop_size(session, drop_sizep));
+    WT_RET(__wt_disagg_shared_metadata_queue_process(session));
+    return (0);
+}
+
+/*
  * __checkpoint_fail_reset --
  *     Reset fields when a failure occurs.
  */
@@ -1591,11 +1603,12 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
     }
 
     /*
-     * Copy any updated metadata to the shared metadata table.
+     * Copy any updated metadata to the shared metadata table. Compute the drop size first so we can
+     * adjust the overall database size after the checkpoint completes.
      */
     if (__wt_conn_is_disagg(session) && conn->layered_table_manager.leader) {
         WT_WITH_SCHEMA_LOCK(
-          session, ret = __wt_disagg_shared_metadata_queue_process(session, &drop_size));
+          session, ret = __checkpoint_process_disagg_metadata(session, &drop_size));
         WT_ERR(ret);
     }
 

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -1355,7 +1355,8 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
     wt_off_t hs_size;
     wt_timestamp_t ckpt_tmp_ts;
     size_t namelen;
-    uint64_t ckpt_tree_duration_usecs, drop_size, fsync_duration_usecs, generation, hs_ckpt_duration_usecs;
+    uint64_t ckpt_tree_duration_usecs, drop_size, fsync_duration_usecs, generation,
+      hs_ckpt_duration_usecs;
     uint64_t time_start_ckpt_tree, time_start_fsync, time_start_hs, time_stop_ckpt_tree,
       time_stop_fsync, time_stop_hs;
     u_int i;
@@ -1593,7 +1594,8 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
      * Copy any updated metadata to the shared metadata table.
      */
     if (__wt_conn_is_disagg(session) && conn->layered_table_manager.leader) {
-        WT_WITH_SCHEMA_LOCK(session, ret = __wt_disagg_shared_metadata_queue_process(session, &drop_size));
+        WT_WITH_SCHEMA_LOCK(
+          session, ret = __wt_disagg_shared_metadata_queue_process(session, &drop_size));
         WT_ERR(ret);
     }
 

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -864,7 +864,7 @@ __checkpoint_verbose_track(WT_SESSION_IMPL *session, const char *msg)
  *     On completion of the checkpoint, update the database size in disaggregated storage.
  */
 static void
-__checkpoint_update_disagg_database_size(WT_SESSION_IMPL *session)
+__checkpoint_update_disagg_database_size(WT_SESSION_IMPL *session, uint64_t drop_size)
 {
     WT_CONNECTION_IMPL *conn;
 
@@ -893,7 +893,7 @@ __checkpoint_update_disagg_database_size(WT_SESSION_IMPL *session)
         int64_t delta;
 
         db = conn->disaggregated_storage.database_size;
-        delta = session->ckpt.ckpt_size_delta;
+        delta = session->ckpt.ckpt_size_delta - (int64_t)drop_size;
 
         if (delta > 0) {
             WT_ASSERT(session, UINT64_MAX - db >= (uint64_t)delta);
@@ -1355,7 +1355,7 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
     wt_off_t hs_size;
     wt_timestamp_t ckpt_tmp_ts;
     size_t namelen;
-    uint64_t ckpt_tree_duration_usecs, fsync_duration_usecs, generation, hs_ckpt_duration_usecs;
+    uint64_t ckpt_tree_duration_usecs, drop_size, fsync_duration_usecs, generation, hs_ckpt_duration_usecs;
     uint64_t time_start_ckpt_tree, time_start_fsync, time_start_hs, time_stop_ckpt_tree,
       time_stop_fsync, time_stop_hs;
     u_int i;
@@ -1368,6 +1368,7 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
     conn = S2C(session);
     ckpt_tmp_ts = WT_TS_NONE;
     evict = conn->evict;
+    drop_size = 0;
     hs_size = 0;
     hs_dhandle = hs_dhandle_shared = NULL;
     txn = session->txn;
@@ -1592,7 +1593,7 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
      * Copy any updated metadata to the shared metadata table.
      */
     if (__wt_conn_is_disagg(session) && conn->layered_table_manager.leader) {
-        WT_WITH_SCHEMA_LOCK(session, ret = __wt_disagg_shared_metadata_queue_process(session));
+        WT_WITH_SCHEMA_LOCK(session, ret = __wt_disagg_shared_metadata_queue_process(session, &drop_size));
         WT_ERR(ret);
     }
 
@@ -1783,7 +1784,7 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
         conn->txn_global.last_ckpt_timestamp = WT_TS_NONE;
 
     /* Disaggregated storage database size accounting. */
-    __checkpoint_update_disagg_database_size(session);
+    __checkpoint_update_disagg_database_size(session, drop_size);
 
     WT_STAT_CONN_INCR(session, checkpoints_total_succeed);
 

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -924,7 +924,8 @@ __wt_disagg_shared_metadata_queue_drop_size(WT_SESSION_IMPL *session, uint64_t *
     __wt_spin_lock(session, &conn->disaggregated_storage.shared_metadata_queue_lock);
 
     TAILQ_FOREACH (entry, &conn->disaggregated_storage.shared_metadata_qh, q) {
-        if (!entry->deferred && entry->metadata_op == WT_SHARED_METADATA_REMOVE && entry->stable_value != NULL) {
+        if (!entry->deferred && entry->metadata_op == WT_SHARED_METADATA_REMOVE &&
+          entry->stable_value != NULL) {
             uint64_t size;
             /*
              * A table that was created and dropped without ever being checkpointed won't have a

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -944,7 +944,11 @@ __wt_disagg_shared_metadata_queue_process(WT_SESSION_IMPL *session, uint64_t *dr
          */
         if (entry->metadata_op == WT_SHARED_METADATA_REMOVE && entry->stable_value != NULL) {
             uint64_t size;
-            WT_ERR(__wt_ckpt_last_size(session, entry->stable_value, &size));
+            /*
+             * A table that was created and dropped without ever being checkpointed won't have a
+             * checkpoint entry in its metadata, so WT_NOTFOUND is expected.
+             */
+            WT_ERR_NOTFOUND_OK(__wt_ckpt_last_size(session, entry->stable_value, &size), false);
             *drop_sizep += size;
         }
 

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -760,6 +760,14 @@ __wt_disagg_enqueue_metadata_operation(WT_SESSION_IMPL *session, const char *sta
     WT_ERR(__disagg_save_metadata(session, cursor, "", stable_uri, &entry->stable_value));
 
     /*
+     * For drop operations, extract the checkpoint size of the stable table so the database size can
+     * be adjusted when the drop is processed during checkpoint. We could do that work there but it
+     * would meaningfully add work to the checkpoint operations.
+     */
+    if (metadata_op == WT_SHARED_METADATA_REMOVE && entry->stable_value != NULL)
+        WT_ERR(__wt_ckpt_last_size(session, entry->stable_value, &entry->disagg_size));
+
+    /*
      * When WiredTiger is running a checkpoint, prevent drop updates from entering the shared
      * metadata table for that checkpoint. We defer these metadata operations to the next checkpoint
      * to keep the checkpoints metadata and table state consistent.
@@ -909,13 +917,14 @@ err:
  *     Process the update metadata list.
  */
 int
-__wt_disagg_shared_metadata_queue_process(WT_SESSION_IMPL *session)
+__wt_disagg_shared_metadata_queue_process(WT_SESSION_IMPL *session, uint64_t *drop_sizep)
 {
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
     WT_DISAGG_METADATA_OP *entry, *tmp;
 
     conn = S2C(session);
+    *drop_sizep = 0;
 
     /*
      * This requires schema lock to ensure that we capture a consistent snapshot of metadata entries
@@ -937,6 +946,8 @@ __wt_disagg_shared_metadata_queue_process(WT_SESSION_IMPL *session)
         }
 
         WT_ERR(__disagg_shared_metadata_op(session, entry));
+        if (entry->metadata_op == WT_SHARED_METADATA_REMOVE)
+            *drop_sizep += entry->disagg_size;
 
         TAILQ_REMOVE(&conn->disaggregated_storage.shared_metadata_qh, entry, q);
         __disagg_shared_metadata_queue_free(session, &entry);

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -905,18 +905,54 @@ err:
 }
 
 /*
+ * __wt_disagg_shared_metadata_queue_drop_size --
+ *     Walk the metadata queue and sum the checkpoint sizes of non-deferred drop operations. This is
+ *     a read-only operation on the queue.
+ */
+int
+__wt_disagg_shared_metadata_queue_drop_size(WT_SESSION_IMPL *session, uint64_t *drop_sizep)
+{
+    WT_CONNECTION_IMPL *conn;
+    WT_DECL_RET;
+    WT_DISAGG_METADATA_OP *entry;
+
+    conn = S2C(session);
+    *drop_sizep = 0;
+
+    WT_ASSERT_SPINLOCK_OWNED(session, &conn->schema_lock);
+
+    __wt_spin_lock(session, &conn->disaggregated_storage.shared_metadata_queue_lock);
+
+    TAILQ_FOREACH (entry, &conn->disaggregated_storage.shared_metadata_qh, q) {
+        if (!entry->deferred && entry->metadata_op == WT_SHARED_METADATA_REMOVE && entry->stable_value != NULL) {
+            uint64_t size;
+            /*
+             * A table that was created and dropped without ever being checkpointed won't have a
+             * checkpoint entry in its metadata, so WT_NOTFOUND is expected.
+             */
+            WT_ERR_NOTFOUND_OK(__wt_ckpt_last_size(session, entry->stable_value, &size), false);
+            *drop_sizep += size;
+        }
+    }
+
+err:
+    __wt_spin_unlock(session, &conn->disaggregated_storage.shared_metadata_queue_lock);
+
+    return (ret);
+}
+
+/*
  * __wt_disagg_shared_metadata_queue_process --
  *     Process the update metadata list.
  */
 int
-__wt_disagg_shared_metadata_queue_process(WT_SESSION_IMPL *session, uint64_t *drop_sizep)
+__wt_disagg_shared_metadata_queue_process(WT_SESSION_IMPL *session)
 {
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
     WT_DISAGG_METADATA_OP *entry, *tmp;
 
     conn = S2C(session);
-    *drop_sizep = 0;
 
     /*
      * This requires schema lock to ensure that we capture a consistent snapshot of metadata entries
@@ -938,19 +974,6 @@ __wt_disagg_shared_metadata_queue_process(WT_SESSION_IMPL *session, uint64_t *dr
         }
 
         WT_ERR(__disagg_shared_metadata_op(session, entry));
-        /*
-         * For drop operations, extract the checkpoint size of the stable table to adjust the
-         * overall database size.
-         */
-        if (entry->metadata_op == WT_SHARED_METADATA_REMOVE && entry->stable_value != NULL) {
-            uint64_t size;
-            /*
-             * A table that was created and dropped without ever being checkpointed won't have a
-             * checkpoint entry in its metadata, so WT_NOTFOUND is expected.
-             */
-            WT_ERR_NOTFOUND_OK(__wt_ckpt_last_size(session, entry->stable_value, &size), false);
-            *drop_sizep += size;
-        }
 
         TAILQ_REMOVE(&conn->disaggregated_storage.shared_metadata_qh, entry, q);
         __disagg_shared_metadata_queue_free(session, &entry);

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -760,14 +760,6 @@ __wt_disagg_enqueue_metadata_operation(WT_SESSION_IMPL *session, const char *sta
     WT_ERR(__disagg_save_metadata(session, cursor, "", stable_uri, &entry->stable_value));
 
     /*
-     * For drop operations, extract the checkpoint size of the stable table so the database size can
-     * be adjusted when the drop is processed during checkpoint. We could do that work there but it
-     * would meaningfully add work to the checkpoint operations.
-     */
-    if (metadata_op == WT_SHARED_METADATA_REMOVE && entry->stable_value != NULL)
-        WT_ERR(__wt_ckpt_last_size(session, entry->stable_value, &entry->disagg_size));
-
-    /*
      * When WiredTiger is running a checkpoint, prevent drop updates from entering the shared
      * metadata table for that checkpoint. We defer these metadata operations to the next checkpoint
      * to keep the checkpoints metadata and table state consistent.
@@ -946,8 +938,15 @@ __wt_disagg_shared_metadata_queue_process(WT_SESSION_IMPL *session, uint64_t *dr
         }
 
         WT_ERR(__disagg_shared_metadata_op(session, entry));
-        if (entry->metadata_op == WT_SHARED_METADATA_REMOVE)
-            *drop_sizep += entry->disagg_size;
+        /*
+         * For drop operations, extract the checkpoint size of the stable table to adjust the
+         * overall database size.
+         */
+        if (entry->metadata_op == WT_SHARED_METADATA_REMOVE && entry->stable_value != NULL) {
+            uint64_t size;
+            WT_ERR(__wt_ckpt_last_size(session, entry->stable_value, &size));
+            *drop_sizep += size;
+        }
 
         TAILQ_REMOVE(&conn->disaggregated_storage.shared_metadata_qh, entry, q);
         __disagg_shared_metadata_queue_free(session, &entry);

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -181,6 +181,7 @@ struct __wt_disagg_metadata_op {
     char *layered_value;  /* The value for the layered component. */
     char *stable_value;   /* The value for the stable component. */
     char *table_value;    /* The value for the table component. */
+    uint64_t disagg_size; /* The size of the stable table in shared storage. */
 
     /* Metadata type operation. */
     WT_SHARED_METADATA_OP metadata_op;

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -181,7 +181,6 @@ struct __wt_disagg_metadata_op {
     char *layered_value;  /* The value for the layered component. */
     char *stable_value;   /* The value for the stable component. */
     char *table_value;    /* The value for the table component. */
-    uint64_t disagg_size; /* The size of the stable table in shared storage. */
 
     /* Metadata type operation. */
     WT_SHARED_METADATA_OP metadata_op;

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -595,7 +595,9 @@ extern int __wt_disagg_put_checkpoint_meta(WT_SESSION_IMPL *session, const char 
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_disagg_put_crypt_helper(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_disagg_shared_metadata_queue_process(WT_SESSION_IMPL *session, uint64_t *drop_sizep)
+extern int __wt_disagg_shared_metadata_queue_drop_size(
+  WT_SESSION_IMPL *session, uint64_t *drop_sizep) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_disagg_shared_metadata_queue_process(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_encrypt(WT_SESSION_IMPL *session, WT_KEYED_ENCRYPTOR *kencryptor, size_t skip,
   WT_ITEM *in, WT_ITEM *out) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -595,8 +595,7 @@ extern int __wt_disagg_put_checkpoint_meta(WT_SESSION_IMPL *session, const char 
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_disagg_put_crypt_helper(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_disagg_shared_metadata_queue_process(
-  WT_SESSION_IMPL *session, uint64_t *drop_sizep)
+extern int __wt_disagg_shared_metadata_queue_process(WT_SESSION_IMPL *session, uint64_t *drop_sizep)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_encrypt(WT_SESSION_IMPL *session, WT_KEYED_ENCRYPTOR *kencryptor, size_t skip,
   WT_ITEM *in, WT_ITEM *out) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -354,6 +354,8 @@ extern int __wt_chunkcache_teardown(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_ckpt_last_name(WT_SESSION_IMPL *session, const char *config, const char **namep,
   int64_t *orderp, uint64_t *timep) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_ckpt_last_size(WT_SESSION_IMPL *session, const char *config, uint64_t *sizep)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_clayered_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner,
   const char *cfg[], WT_CURSOR **cursorp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_close(WT_SESSION_IMPL *session, WT_FH **fhp)
@@ -593,7 +595,8 @@ extern int __wt_disagg_put_checkpoint_meta(WT_SESSION_IMPL *session, const char 
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_disagg_put_crypt_helper(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_disagg_shared_metadata_queue_process(WT_SESSION_IMPL *session)
+extern int __wt_disagg_shared_metadata_queue_process(
+  WT_SESSION_IMPL *session, uint64_t *drop_sizep)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_encrypt(WT_SESSION_IMPL *session, WT_KEYED_ENCRYPTOR *kencryptor, size_t skip,
   WT_ITEM *in, WT_ITEM *out) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -453,6 +453,27 @@ err:
 }
 
 /*
+ * __wt_ckpt_last_size --
+ *     Return the size recorded in the most recent checkpoint in the given metadata config string.
+ */
+int
+__wt_ckpt_last_size(WT_SESSION_IMPL *session, const char *config, uint64_t *sizep)
+{
+    WT_CKPT ckpt;
+    WT_DECL_RET;
+
+    *sizep = 0;
+    WT_CLEAR(ckpt);
+
+    WT_RET(__ckpt_last(session, config, &ckpt));
+    *sizep = ckpt.size;
+
+    ret = 0;
+    __wt_checkpoint_free(session, &ckpt);
+    return (ret);
+}
+
+/*
  * __wt_meta_block_metadata --
  *     Build a version of the file's metadata for the block manager to store.
  */

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -460,17 +460,14 @@ int
 __wt_ckpt_last_size(WT_SESSION_IMPL *session, const char *config, uint64_t *sizep)
 {
     WT_CKPT ckpt;
-    WT_DECL_RET;
-
-    *sizep = 0;
     WT_CLEAR(ckpt);
 
+    *sizep = 0;
     WT_RET(__ckpt_last(session, config, &ckpt));
     *sizep = ckpt.size;
 
-    ret = 0;
     __wt_checkpoint_free(session, &ckpt);
-    return (ret);
+    return (0);
 }
 
 /*

--- a/test/suite/test_disagg_checkpoint_size04.py
+++ b/test/suite/test_disagg_checkpoint_size04.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import re, wttest
+from helper_disagg import disagg_test_class
+
+# test_disagg_checkpoint_size04.py
+#    Test that dropping a table reduces the database size in disaggregated storage.
+@disagg_test_class
+class test_disagg_checkpoint_size04(wttest.WiredTigerTestCase):
+    conn_config = 'disaggregated=(role="leader",lose_all_my_data=true)'
+
+    def get_database_size(self):
+        match = re.search(r'database_size=(\d+)', self.disagg_get_complete_checkpoint_meta())
+        assert(match)
+        return int(match.group(1))
+
+    def test_drop_reduces_database_size(self):
+        uri = "layered:test_table"
+        self.session.create(uri, 'key_format=i,value_format=S')
+
+        self.session.checkpoint()
+        size_empty = self.get_database_size()
+
+        cursor = self.session.open_cursor(uri)
+        for i in range(1000):
+            cursor[i] = 'a' * 500
+        cursor.close()
+
+        self.session.checkpoint()
+        size_with_data = self.get_database_size()
+
+        data_size = size_with_data - size_empty
+        self.assertGreater(data_size, 0,
+            f"Data insertion should increase size: {size_empty} -> {size_with_data}")
+
+        self.session.drop(uri)
+
+        # The drop is queued; it takes effect in the next checkpoint.
+        self.session.checkpoint()
+        size_after_drop = self.get_database_size()
+
+        self.pr(f"empty={size_empty}, with_data={size_with_data}, after_drop={size_after_drop}")
+        self.assertLess(size_after_drop, size_with_data,
+            f"Database size should decrease after drop: {size_with_data} -> {size_after_drop}")
+
+        # The size after dropping should be close to the empty-table size. Allow some slack for
+        # shared metadata overhead changes but the bulk of the data should be gone.
+        self.assertLess(size_after_drop, size_empty + data_size * 0.1,
+            f"Most of the data should be reclaimed: empty={size_empty}, "
+            f"after_drop={size_after_drop}, data_size={data_size}")
+
+    def test_drop_one_of_multiple_tables(self):
+        uri1 = "layered:test_keep"
+        uri2 = "layered:test_drop"
+        self.session.create(uri1, 'key_format=i,value_format=S')
+        self.session.create(uri2, 'key_format=i,value_format=S')
+
+        self.session.checkpoint()
+        size_empty = self.get_database_size()
+
+        # Insert roughly equal amounts of data into both tables.
+        for uri in [uri1, uri2]:
+            cursor = self.session.open_cursor(uri)
+            for i in range(1000):
+                cursor[i] = 'a' * 500
+            cursor.close()
+
+        self.session.checkpoint()
+        size_both = self.get_database_size()
+        total_data = size_both - size_empty
+        self.assertGreater(total_data, 0)
+
+        # Drop only the second table.
+        self.session.drop(uri2)
+        self.session.checkpoint()
+        size_after_drop = self.get_database_size()
+
+        self.pr(f"empty={size_empty}, both={size_both}, after_drop={size_after_drop}, "
+                f"total_data={total_data}")
+
+        # The size should decrease by roughly half the data (the dropped table's share).
+        removed = size_both - size_after_drop
+        self.assertGreater(removed, total_data * 0.3,
+            f"Drop should reclaim a significant portion: removed={removed}, total_data={total_data}")
+
+        # The surviving table's data should still be accounted for.
+        surviving_data = size_after_drop - size_empty
+        self.assertGreater(surviving_data, total_data * 0.3,
+            f"Surviving table data should remain: surviving={surviving_data}, total_data={total_data}")


### PR DESCRIPTION
This change pulls the metadata size, which is the size that we updated database size with out of the metadata for the table when it's metadata update is queued. The correctness here is provided via checkpoint, and therefore the same rollback mechanisms that apply to checkpoint are useful here too. 

Essentially a table's size is determined by it's last checkpoint size. Not the in memory btree size which could have changed since last checkpoint. The database size prior to the drop is also using the same metadata stored ckpt->size so it makes sense to pair the two.

If the checkpoint fails around this stage, then we'll never update the database->size and the rollback mechanisms that should exist for the metadata things would re-apply the decrement at a future stage. Note: I don't think those mechanisms actually exist.