### PR TITLE
WT-16911 Remove bm->free layering violations

### DIFF
--- a/src/block_cache/block_mgr.c
+++ b/src/block_cache/block_mgr.c
@@ -505,6 +505,9 @@ __bm_free(WT_BM *bm, WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr_
     if (blkcache->type != WT_BLKCACHE_UNCONFIGURED)
         __wt_blkcache_remove(session, addr, addr_size);
 
+    /* We should never get here for salvage. */
+    WT_ASSERT(session, session->salvage_track == NULL);
+
     return (__wt_block_free(session, bm->block, addr, addr_size));
 }
 

--- a/src/btree/bt_ovfl.c
+++ b/src/btree/bt_ovfl.c
@@ -114,12 +114,10 @@ __wt_ovfl_remove(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_UNPACK_KV *unp
 int
 __wt_ovfl_discard(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL *cell)
 {
-    WT_BM *bm;
     WT_BTREE *btree;
     WT_CELL_UNPACK_KV *unpack, _unpack;
 
     btree = S2BT(session);
-    bm = btree->bm;
     unpack = &_unpack;
 
     __wt_cell_unpack_kv(session, page->dsk, cell, unpack);
@@ -149,5 +147,5 @@ __wt_ovfl_discard(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL *cell)
     __wt_writeunlock(session, &btree->ovfl_lock);
 
     /* Free the backing disk blocks. */
-    return (bm->free(bm, session, unpack->data, unpack->size));
+    return (__wt_btree_block_free(session, unpack->data, unpack->size));
 }

--- a/src/btree/bt_slvg.c
+++ b/src/btree/bt_slvg.c
@@ -134,7 +134,6 @@ static int __slvg_ovfl_reconcile(WT_SESSION_IMPL *, WT_STUFF *);
 static int __slvg_ovfl_ref(WT_SESSION_IMPL *, WT_TRACK *, bool);
 static int __slvg_ovfl_ref_all(WT_SESSION_IMPL *, WT_TRACK *);
 static int __slvg_read(WT_SESSION_IMPL *, WT_STUFF *);
-static int __slvg_reconcile_free(WT_BM *, WT_SESSION_IMPL *, const uint8_t *, size_t);
 static int __slvg_row_build_internal(WT_SESSION_IMPL *, uint32_t, WT_STUFF *);
 static int __slvg_row_build_leaf(WT_SESSION_IMPL *, WT_TRACK *, WT_REF *, WT_STUFF *);
 static int __slvg_row_ovfl(WT_SESSION_IMPL *, WT_TRACK *, WT_PAGE *, uint32_t, uint32_t);
@@ -473,7 +472,7 @@ __slvg_read(WT_SESSION_IMPL *session, WT_STUFF *ss)
         case WT_PAGE_ROW_INT:
             __wt_verbose(session, WT_VERB_SALVAGE, "%s page ignored %s",
               __wt_page_type_string(dsk->type), (const char *)as->data);
-            WT_ERR(bm->free(bm, session, addr, addr_size));
+            WT_ERR(__wt_btree_block_free(session, addr, addr_size));
             continue;
         }
 
@@ -487,7 +486,7 @@ __slvg_read(WT_SESSION_IMPL *session, WT_STUFF *ss)
         if (__wt_verify_dsk(session, as->data, buf) != 0) {
             __wt_verbose(session, WT_VERB_SALVAGE, "%s page failed verify %s",
               __wt_page_type_string(dsk->type), (const char *)as->data);
-            WT_ERR(bm->free(bm, session, addr, addr_size));
+            WT_ERR(__wt_btree_block_free(session, addr, addr_size));
             continue;
         }
 
@@ -1196,17 +1195,12 @@ err:
 static int
 __slvg_col_build_leaf(WT_SESSION_IMPL *session, WT_TRACK *trk, WT_REF *ref)
 {
-    WT_BTREE *btree;
     WT_COL *save_col_var;
     WT_DECL_RET;
     WT_PAGE *page;
     WT_SALVAGE_COOKIE *cookie, _cookie;
     uint64_t recno, skip, take;
     uint32_t save_entries;
-    int (*saved_free)(WT_BM *, WT_SESSION_IMPL *, const uint8_t *, size_t);
-
-    btree = S2BT(session);
-    saved_free = NULL;
 
     cookie = &_cookie;
     WT_CLEAR(*cookie);
@@ -1268,8 +1262,6 @@ __slvg_col_build_leaf(WT_SESSION_IMPL *session, WT_TRACK *trk, WT_REF *ref)
      * need to adjust our list of overflow blocks so we don't free the overflow item twice.
      * Intercept any attempt by reconciliation to free blocks.
      */
-    saved_free = btree->bm->free;
-    btree->bm->free = __slvg_reconcile_free;
     session->salvage_track = trk;
 
     /* Write the new version of the leaf page to disk. */
@@ -1289,10 +1281,7 @@ __slvg_col_build_leaf(WT_SESSION_IMPL *session, WT_TRACK *trk, WT_REF *ref)
 err:
         WT_TRET(__wt_page_release(session, ref, 0));
     }
-    if (saved_free != NULL) {
-        btree->bm->free = saved_free;
-        session->salvage_track = NULL;
-    }
+    session->salvage_track = NULL;
 
     return (ret);
 }
@@ -1823,11 +1812,10 @@ __slvg_row_build_leaf(WT_SESSION_IMPL *session, WT_TRACK *trk, WT_REF *ref, WT_S
     WT_ROW *rip;
     WT_SALVAGE_COOKIE *cookie, _cookie;
     uint32_t i, skip_start, skip_stop;
-    int cmp, (*saved_free)(WT_BM *, WT_SESSION_IMPL *, const uint8_t *, size_t);
+    int cmp;
 
     btree = S2BT(session);
     page = NULL;
-    saved_free = NULL;
 
     cookie = &_cookie;
     WT_CLEAR(*cookie);
@@ -1924,8 +1912,6 @@ __slvg_row_build_leaf(WT_SESSION_IMPL *session, WT_TRACK *trk, WT_REF *ref, WT_S
      * reconcile removes the overflow key, the second build/reconcile will fail when it can't read
      * the key. Intercept any attempt by reconciliation to free blocks.
      */
-    saved_free = btree->bm->free;
-    btree->bm->free = __slvg_reconcile_free;
     session->salvage_track = trk;
 
     /* Write the new version of the leaf page to disk. */
@@ -1944,10 +1930,7 @@ __slvg_row_build_leaf(WT_SESSION_IMPL *session, WT_TRACK *trk, WT_REF *ref, WT_S
 err:
         WT_TRET(__wt_page_release(session, ref, 0));
     }
-    if (saved_free != NULL) {
-        btree->bm->free = saved_free;
-        session->salvage_track = NULL;
-    }
+    session->salvage_track = NULL;
     __wt_scr_free(session, &key);
 
     return (ret);
@@ -2010,16 +1993,16 @@ __slvg_row_ovfl(
 }
 
 /*
- * __slvg_reconcile_free --
- *     Block manager replacement to update blocks reconciliation wants removed.
+ * __wt_slvg_reconcile_free --
+ *     Intercept block frees during salvage reconciliation, updating the overflow tracking list
+ *     rather than actually freeing blocks.
  */
-static int
-__slvg_reconcile_free(WT_BM *bm, WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr_size)
+int
+__wt_slvg_reconcile_free(WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr_size)
 {
     WT_TRACK *ovfl, *trk;
     uint32_t i;
 
-    WT_UNUSED(bm);
     trk = session->salvage_track;
 
     /*
@@ -2393,10 +2376,6 @@ __slvg_trk_free_addr(WT_SESSION_IMPL *session, WT_TRACK *trk)
 static int
 __slvg_trk_free_block(WT_SESSION_IMPL *session, WT_TRACK *trk)
 {
-    WT_BM *bm;
-
-    bm = S2BT(session)->bm;
-
     /*
      * If freeing underlying file blocks or overflow pages, this is a page we were tracking but
      * eventually decided not to use.
@@ -2404,7 +2383,7 @@ __slvg_trk_free_block(WT_SESSION_IMPL *session, WT_TRACK *trk)
     __wt_verbose(session, WT_VERB_SALVAGE, "%s blocks discarded: discard freed file bytes %" PRIu32,
       __wt_addr_string(session, trk->trk_addr, trk->trk_addr_size, trk->ss->tmp1), trk->trk_size);
 
-    return (bm->free(bm, session, trk->trk_addr, trk->trk_addr_size));
+    return (__wt_btree_block_free(session, trk->trk_addr, trk->trk_addr_size));
 }
 
 /*

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -2839,7 +2839,8 @@ err:
                  * the discard logic would also need to be reconsidered.
                  */
                 if (F_ISSET(ckpt_temp, WT_CKPT_DELETE) && ckpt_temp->raw.data)
-                    WT_TRET(bm->free(bm, session, ckpt_temp->raw.data, ckpt_temp->raw.size));
+                    WT_TRET(
+                      __wt_btree_block_free(session, ckpt_temp->raw.data, ckpt_temp->raw.size));
             }
         }
     }

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -153,6 +153,14 @@ __wt_btree_block_free(WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr
     WT_BM *bm;
     WT_BTREE *btree;
 
+    /*
+     * During salvage, reconciliation frees overflow blocks that need special tracking to avoid
+     * double frees. Intercept here rather than overriding the block manager's function pointer as
+     * the previous implementation did.
+     */
+    if (session->salvage_track != NULL)
+        return (__wt_slvg_reconcile_free(session, addr, addr_size));
+
     btree = S2BT(session);
     bm = btree->bm;
 

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1043,6 +1043,8 @@ extern int __wt_session_reset_cursors(WT_SESSION_IMPL *session, bool free_buffer
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_set_return_func(WT_SESSION_IMPL *session, const char *func, int line, int err,
   const char *strerr) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_slvg_reconcile_free(WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr_size)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_split_multi(WT_SESSION_IMPL *session, WT_REF *ref, int closing)

--- a/src/reconcile/rec_track.c
+++ b/src/reconcile/rec_track.c
@@ -297,12 +297,10 @@ __ovfl_reuse_skip_search_stack(
 static int
 __ovfl_reuse_wrapup(WT_SESSION_IMPL *session, WT_PAGE *page)
 {
-    WT_BM *bm;
     WT_OVFL_REUSE **e, **head, *reuse;
     size_t decr;
     int i;
 
-    bm = S2BT(session)->bm;
     head = page->modify->ovfl_track->ovfl_reuse;
 
     /*
@@ -343,7 +341,7 @@ __ovfl_reuse_wrapup(WT_SESSION_IMPL *session, WT_PAGE *page)
         if (WT_VERBOSE_LEVEL_ISSET(session, WT_VERB_OVERFLOW, WT_VERBOSE_DEBUG_2))
             WT_RET(__ovfl_reuse_verbose(session, page, reuse, "free"));
 
-        WT_RET(bm->free(bm, session, WT_OVFL_REUSE_ADDR(reuse), reuse->addr_size));
+        WT_RET(__wt_btree_block_free(session, WT_OVFL_REUSE_ADDR(reuse), reuse->addr_size));
         decr += WT_OVFL_SIZE(reuse, WT_OVFL_REUSE);
         __wt_free(session, reuse);
     }
@@ -360,13 +358,11 @@ __ovfl_reuse_wrapup(WT_SESSION_IMPL *session, WT_PAGE *page)
 static int
 __ovfl_reuse_wrapup_err(WT_SESSION_IMPL *session, WT_PAGE *page)
 {
-    WT_BM *bm;
     WT_DECL_RET;
     WT_OVFL_REUSE **e, **head, *reuse;
     size_t decr;
     int i;
 
-    bm = S2BT(session)->bm;
     head = page->modify->ovfl_track->ovfl_reuse;
 
     /*
@@ -398,7 +394,7 @@ __ovfl_reuse_wrapup_err(WT_SESSION_IMPL *session, WT_PAGE *page)
         if (WT_VERBOSE_LEVEL_ISSET(session, WT_VERB_OVERFLOW, WT_VERBOSE_DEBUG_2))
             WT_RET(__ovfl_reuse_verbose(session, page, reuse, "free"));
 
-        WT_TRET(bm->free(bm, session, WT_OVFL_REUSE_ADDR(reuse), reuse->addr_size));
+        WT_TRET(__wt_btree_block_free(session, WT_OVFL_REUSE_ADDR(reuse), reuse->addr_size));
         decr += WT_OVFL_SIZE(reuse, WT_OVFL_REUSE);
         __wt_free(session, reuse);
     }


### PR DESCRIPTION
Callers should go through `__wt_btree_block_free`, instead of calling `bm->free` directly.