### PR TITLE
WT-16912 Add more information to checkpoint progress messages

### DIFF
--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -289,7 +289,7 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
                 WT_STAT_CONN_INCR(session, checkpoint_pages_visited_internal);
             else
                 WT_STAT_CONN_INCR(session, checkpoint_pages_visited_leaf);
-            ++S2C(session)->ckpt.progress.pages_walked;
+            ++S2C(session)->ckpt.progress.pages_visited;
 
             /*
              * Check if the page is dirty. Add a barrier between the check and taking a reference to

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -289,7 +289,7 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
                 WT_STAT_CONN_INCR(session, checkpoint_pages_visited_internal);
             else
                 WT_STAT_CONN_INCR(session, checkpoint_pages_visited_leaf);
-            ++S2C(session)->ckpt.progress.pages_visited;
+            ++conn->ckpt.progress.pages_visited;
 
             /*
              * Check if the page is dirty. Add a barrier between the check and taking a reference to

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -289,6 +289,7 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
                 WT_STAT_CONN_INCR(session, checkpoint_pages_visited_internal);
             else
                 WT_STAT_CONN_INCR(session, checkpoint_pages_visited_leaf);
+            ++S2C(session)->ckpt.progress.pages_walked;
 
             /*
              * Check if the page is dirty. Add a barrier between the check and taking a reference to

--- a/src/checkpoint/checkpoint_private.h
+++ b/src/checkpoint/checkpoint_private.h
@@ -62,10 +62,10 @@ struct __wti_ckpt_handle_stats {
  */
 struct __wti_ckpt_progress {
     uint64_t files_checkpointed; /* files successfully checkpointed */
-    uint64_t msg_count;
-    uint64_t pages_visited; /* pages visited during checkpoint */
-    uint64_t write_bytes;
-    uint64_t write_pages;
+    uint64_t msg_count;          /* number of progress messages */
+    uint64_t pages_visited;      /* pages visited during checkpoint */
+    uint64_t write_bytes;        /* bytes written during checkpoint */
+    uint64_t write_pages;        /* pages written during checkpoint */
 };
 
 /*

--- a/src/checkpoint/checkpoint_private.h
+++ b/src/checkpoint/checkpoint_private.h
@@ -61,7 +61,9 @@ struct __wti_ckpt_handle_stats {
  *     Checkpoint progress.
  */
 struct __wti_ckpt_progress {
+    uint64_t files_checkpointed; /* files successfully checkpointed */
     uint64_t msg_count;
+    uint64_t pages_walked;  /* pages walked (visited) during checkpoint */
     uint64_t write_bytes;
     uint64_t write_pages;
 };

--- a/src/checkpoint/checkpoint_private.h
+++ b/src/checkpoint/checkpoint_private.h
@@ -63,7 +63,7 @@ struct __wti_ckpt_handle_stats {
 struct __wti_ckpt_progress {
     uint64_t files_checkpointed; /* files successfully checkpointed */
     uint64_t msg_count;
-    uint64_t pages_walked;  /* pages walked (visited) during checkpoint */
+    uint64_t pages_visited; /* pages visited during checkpoint */
     uint64_t write_bytes;
     uint64_t write_pages;
 };

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -721,8 +721,8 @@ __checkpoint_progress(WT_SESSION_IMPL *session, bool closing)
 
     if (closing || (time_diff / WT_PROGRESS_MSG_PERIOD) > conn->ckpt.progress.msg_count) {
         __wt_verbose_info(session, WT_VERB_CHECKPOINT_PROGRESS,
-          "Checkpoint %s for %" PRIu64 " seconds and wrote: %" PRIu64 " pages (%" PRIu64
-          " MB), walked %" PRIu64 " pages, checkpointed %" PRIu64 " files",
+          "Checkpoint %s for %" PRIu64 " seconds, wrote %" PRIu64 " pages (%" PRIu64
+          " MB), walked %" PRIu64 " pages and checkpointed %" PRIu64 " files",
           closing ? "ran" : "has been running", time_diff, conn->ckpt.progress.write_pages,
           conn->ckpt.progress.write_bytes / WT_MEGABYTE, conn->ckpt.progress.pages_visited,
           conn->ckpt.progress.files_checkpointed);

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -2934,6 +2934,10 @@ __checkpoint_tree_helper(WT_SESSION_IMPL *session, const char *cfg[])
      */
     __wt_atomic_store_uint32_relaxed(&btree->evict_walk_period, btree->evict_walk_saved);
 
+    /* Track the number of files successfully checkpointed for progress reporting. */
+    if (ret == 0)
+        ++S2C(session)->ckpt.progress.files_checkpointed;
+
     /*
      * Wake the eviction server, in case application threads have stalled while the eviction server
      * decided it couldn't make progress. Without this, application threads will be stalled until

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -723,10 +723,10 @@ __checkpoint_progress(WT_SESSION_IMPL *session, bool closing)
     if (closing || (time_diff / WT_PROGRESS_MSG_PERIOD) > conn->ckpt.progress.msg_count) {
         __wt_verbose_info(session, WT_VERB_CHECKPOINT_PROGRESS,
           "Checkpoint %s for %" PRIu64 " seconds and wrote: %" PRIu64 " pages (%" PRIu64
-          " MB), walked %" PRIu64 " pages, checkpointed %" PRIu64 " files, cache dirty: %"
-          PRIu64 " MB",
+          " MB), walked %" PRIu64 " pages, checkpointed %" PRIu64 " files, cache dirty: %" PRIu64
+          " MB",
           closing ? "ran" : "has been running", time_diff, conn->ckpt.progress.write_pages,
-          conn->ckpt.progress.write_bytes / WT_MEGABYTE, conn->ckpt.progress.pages_walked,
+          conn->ckpt.progress.write_bytes / WT_MEGABYTE, conn->ckpt.progress.pages_visited,
           conn->ckpt.progress.files_checkpointed,
           __wt_cache_dirty_leaf_inuse(conn->cache) / WT_MEGABYTE);
         conn->ckpt.progress.msg_count++;
@@ -746,7 +746,7 @@ __checkpoint_progress_clear(WT_SESSION_IMPL *session)
 
     conn->ckpt.progress.files_checkpointed = 0;
     conn->ckpt.progress.msg_count = 0;
-    conn->ckpt.progress.pages_walked = 0;
+    conn->ckpt.progress.pages_visited = 0;
     conn->ckpt.progress.write_bytes = 0;
     conn->ckpt.progress.write_pages = 0;
 }

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -721,14 +721,22 @@ __checkpoint_progress(WT_SESSION_IMPL *session, bool closing)
     time_diff = WT_TIMEDIFF_SEC(cur_time, conn->ckpt.ckpt_api.timer_start);
 
     if (closing || (time_diff / WT_PROGRESS_MSG_PERIOD) > conn->ckpt.progress.msg_count) {
-        __wt_verbose_info(session, WT_VERB_CHECKPOINT_PROGRESS,
-          "Checkpoint %s for %" PRIu64 " seconds and wrote: %" PRIu64 " pages (%" PRIu64
-          " MB), walked %" PRIu64 " pages, checkpointed %" PRIu64 " files, btree dirty: %" PRIu64
-          " MB",
-          closing ? "ran" : "has been running", time_diff, conn->ckpt.progress.write_pages,
-          conn->ckpt.progress.write_bytes / WT_MEGABYTE, conn->ckpt.progress.pages_visited,
-          conn->ckpt.progress.files_checkpointed,
-          __wt_btree_dirty_inuse(session) / WT_MEGABYTE);
+        if (closing)
+            __wt_verbose_info(session, WT_VERB_CHECKPOINT_PROGRESS,
+              "Checkpoint ran for %" PRIu64 " seconds and wrote: %" PRIu64 " pages (%" PRIu64
+              " MB), walked %" PRIu64 " pages, checkpointed %" PRIu64 " files",
+              time_diff, conn->ckpt.progress.write_pages,
+              conn->ckpt.progress.write_bytes / WT_MEGABYTE, conn->ckpt.progress.pages_visited,
+              conn->ckpt.progress.files_checkpointed);
+        else
+            __wt_verbose_info(session, WT_VERB_CHECKPOINT_PROGRESS,
+              "Checkpoint has been running for %" PRIu64 " seconds and wrote: %" PRIu64
+              " pages (%" PRIu64 " MB), walked %" PRIu64 " pages, checkpointed %" PRIu64
+              " files, btree dirty: %" PRIu64 " MB",
+              time_diff, conn->ckpt.progress.write_pages,
+              conn->ckpt.progress.write_bytes / WT_MEGABYTE, conn->ckpt.progress.pages_visited,
+              conn->ckpt.progress.files_checkpointed,
+              __wt_btree_dirty_inuse(session) / WT_MEGABYTE);
         conn->ckpt.progress.msg_count++;
     }
 }

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -744,7 +744,9 @@ __checkpoint_progress_clear(WT_SESSION_IMPL *session)
 
     conn = S2C(session);
 
+    conn->ckpt.progress.files_checkpointed = 0;
     conn->ckpt.progress.msg_count = 0;
+    conn->ckpt.progress.pages_walked = 0;
     conn->ckpt.progress.write_bytes = 0;
     conn->ckpt.progress.write_pages = 0;
 }

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -706,7 +706,7 @@ __checkpoint_prepare_progress(WT_SESSION_IMPL *session, bool final)
  * __checkpoint_progress --
  *     Output a checkpoint progress message.
  */
-void
+static void
 __checkpoint_progress(WT_SESSION_IMPL *session, bool closing)
 {
     struct timespec cur_time;

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -723,12 +723,12 @@ __checkpoint_progress(WT_SESSION_IMPL *session, bool closing)
     if (closing || (time_diff / WT_PROGRESS_MSG_PERIOD) > conn->ckpt.progress.msg_count) {
         __wt_verbose_info(session, WT_VERB_CHECKPOINT_PROGRESS,
           "Checkpoint %s for %" PRIu64 " seconds and wrote: %" PRIu64 " pages (%" PRIu64
-          " MB), walked %" PRIu64 " pages, checkpointed %" PRIu64 " files, cache dirty: %" PRIu64
+          " MB), walked %" PRIu64 " pages, checkpointed %" PRIu64 " files, btree dirty: %" PRIu64
           " MB",
           closing ? "ran" : "has been running", time_diff, conn->ckpt.progress.write_pages,
           conn->ckpt.progress.write_bytes / WT_MEGABYTE, conn->ckpt.progress.pages_visited,
           conn->ckpt.progress.files_checkpointed,
-          __wt_cache_dirty_leaf_inuse(conn->cache) / WT_MEGABYTE);
+          __wt_btree_dirty_inuse(session) / WT_MEGABYTE);
         conn->ckpt.progress.msg_count++;
     }
 }

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -722,12 +722,10 @@ __checkpoint_progress(WT_SESSION_IMPL *session, bool closing)
     if (closing || (time_diff / WT_PROGRESS_MSG_PERIOD) > conn->ckpt.progress.msg_count) {
         __wt_verbose_info(session, WT_VERB_CHECKPOINT_PROGRESS,
           "Checkpoint %s for %" PRIu64 " seconds and wrote: %" PRIu64 " pages (%" PRIu64
-          " MB), walked %" PRIu64 " pages, checkpointed %" PRIu64 " files, btree dirty: %" PRIu64
-          " MB",
+          " MB), walked %" PRIu64 " pages, checkpointed %" PRIu64 " files",
           closing ? "ran" : "has been running", time_diff, conn->ckpt.progress.write_pages,
           conn->ckpt.progress.write_bytes / WT_MEGABYTE, conn->ckpt.progress.pages_visited,
-          conn->ckpt.progress.files_checkpointed,
-          session->dhandle == NULL ? 0 : __wt_btree_dirty_inuse(session) / WT_MEGABYTE);
+          conn->ckpt.progress.files_checkpointed);
         conn->ckpt.progress.msg_count++;
     }
 }

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -722,9 +722,13 @@ __checkpoint_progress(WT_SESSION_IMPL *session, bool closing)
 
     if (closing || (time_diff / WT_PROGRESS_MSG_PERIOD) > conn->ckpt.progress.msg_count) {
         __wt_verbose_info(session, WT_VERB_CHECKPOINT_PROGRESS,
-          "Checkpoint %s for %" PRIu64 " seconds and wrote: %" PRIu64 " pages (%" PRIu64 " MB)",
+          "Checkpoint %s for %" PRIu64 " seconds and wrote: %" PRIu64 " pages (%" PRIu64
+          " MB), walked %" PRIu64 " pages, checkpointed %" PRIu64 " files, cache dirty: %"
+          PRIu64 " MB",
           closing ? "ran" : "has been running", time_diff, conn->ckpt.progress.write_pages,
-          conn->ckpt.progress.write_bytes / WT_MEGABYTE);
+          conn->ckpt.progress.write_bytes / WT_MEGABYTE, conn->ckpt.progress.pages_walked,
+          conn->ckpt.progress.files_checkpointed,
+          __wt_cache_dirty_leaf_inuse(conn->cache) / WT_MEGABYTE);
         conn->ckpt.progress.msg_count++;
     }
 }

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -721,22 +721,14 @@ __checkpoint_progress(WT_SESSION_IMPL *session, bool closing)
     time_diff = WT_TIMEDIFF_SEC(cur_time, conn->ckpt.ckpt_api.timer_start);
 
     if (closing || (time_diff / WT_PROGRESS_MSG_PERIOD) > conn->ckpt.progress.msg_count) {
-        if (closing)
-            __wt_verbose_info(session, WT_VERB_CHECKPOINT_PROGRESS,
-              "Checkpoint ran for %" PRIu64 " seconds and wrote: %" PRIu64 " pages (%" PRIu64
-              " MB), walked %" PRIu64 " pages, checkpointed %" PRIu64 " files",
-              time_diff, conn->ckpt.progress.write_pages,
-              conn->ckpt.progress.write_bytes / WT_MEGABYTE, conn->ckpt.progress.pages_visited,
-              conn->ckpt.progress.files_checkpointed);
-        else
-            __wt_verbose_info(session, WT_VERB_CHECKPOINT_PROGRESS,
-              "Checkpoint has been running for %" PRIu64 " seconds and wrote: %" PRIu64
-              " pages (%" PRIu64 " MB), walked %" PRIu64 " pages, checkpointed %" PRIu64
-              " files, btree dirty: %" PRIu64 " MB",
-              time_diff, conn->ckpt.progress.write_pages,
-              conn->ckpt.progress.write_bytes / WT_MEGABYTE, conn->ckpt.progress.pages_visited,
-              conn->ckpt.progress.files_checkpointed,
-              __wt_btree_dirty_inuse(session) / WT_MEGABYTE);
+        __wt_verbose_info(session, WT_VERB_CHECKPOINT_PROGRESS,
+          "Checkpoint %s for %" PRIu64 " seconds and wrote: %" PRIu64 " pages (%" PRIu64
+          " MB), walked %" PRIu64 " pages, checkpointed %" PRIu64 " files, btree dirty: %" PRIu64
+          " MB",
+          closing ? "ran" : "has been running", time_diff, conn->ckpt.progress.write_pages,
+          conn->ckpt.progress.write_bytes / WT_MEGABYTE, conn->ckpt.progress.pages_visited,
+          conn->ckpt.progress.files_checkpointed,
+          session->dhandle == NULL ? 0 : __wt_btree_dirty_inuse(session) / WT_MEGABYTE);
         conn->ckpt.progress.msg_count++;
     }
 }

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -15,7 +15,6 @@ static int __checkpoint_presync(WT_SESSION_IMPL *, const char *[]);
 static int __checkpoint_tree_helper(WT_SESSION_IMPL *, const char *[]);
 static void __checkpoint_prepare_progress(WT_SESSION_IMPL *session, bool final);
 static void __checkpoint_progress(WT_SESSION_IMPL *, bool);
-static void __checkpoint_progress_clear(WT_SESSION_IMPL *);
 static void __checkpoint_timing_stress(WT_SESSION_IMPL *, uint64_t, struct timespec *);
 
 typedef struct {
@@ -734,24 +733,6 @@ __checkpoint_progress(WT_SESSION_IMPL *session, bool closing)
 }
 
 /*
- * __checkpoint_progress_clear --
- *     Clear checkpoint progress data.
- */
-void
-__checkpoint_progress_clear(WT_SESSION_IMPL *session)
-{
-    WT_CONNECTION_IMPL *conn;
-
-    conn = S2C(session);
-
-    conn->ckpt.progress.files_checkpointed = 0;
-    conn->ckpt.progress.msg_count = 0;
-    conn->ckpt.progress.pages_visited = 0;
-    conn->ckpt.progress.write_bytes = 0;
-    conn->ckpt.progress.write_pages = 0;
-}
-
-/*
  * __wt_checkpoint_progress_stats --
  *     Update checkpoint progress data.
  */
@@ -1429,7 +1410,7 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
     __wt_epoch(session, &conn->ckpt.ckpt_api.timer_start);
 
     /* Initialize the checkpoint progress tracking data */
-    __checkpoint_progress_clear(session);
+    WT_CLEAR(S2C(session)->ckpt.progress);
 
     /*
      * Get a time (wall time, not a timestamp) for this checkpoint. This will be applied to all the

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -1408,7 +1408,7 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
     __wt_epoch(session, &conn->ckpt.ckpt_api.timer_start);
 
     /* Initialize the checkpoint progress tracking data */
-    WT_CLEAR(S2C(session)->ckpt.progress);
+    WT_CLEAR(conn->ckpt.progress);
 
     /*
      * Get a time (wall time, not a timestamp) for this checkpoint. This will be applied to all the


### PR DESCRIPTION
The changes add two new fields to `__wti_ckpt_progress`: `files_checkpointed` and `pages_visited`. The `__checkpoint_progress` function is updated to report on the new fields.