### PR TITLE
WT-16926 Don't set the clayered cursor key for searches in write operations

### DIFF
--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -871,20 +871,17 @@ __clayered_iterate(WT_CURSOR_LAYERED *clayered, bool forward, uint32_t iter_flag
         WT_ERR(__clayered_get_current(session, clayered, forward));
         deleted = __clayered_deleted(clayered, &clayered->current_cursor->value);
     } while (deleted);
-    WT_ERR_NOTFOUND_OK(ret, true);
 
-    F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
-    if (ret == 0) {
-        F_SET(cursor, WT_CURSTD_KEY_INT | WT_CURSTD_VALUE_INT);
-        WT_ERR(clayered->current_cursor->get_key(clayered->current_cursor, &cursor->key));
-        WT_ERR(clayered->current_cursor->get_value(clayered->current_cursor, &cursor->value));
-    }
+    WT_ERR(clayered->current_cursor->get_key(clayered->current_cursor, &cursor->key));
+    WT_ERR(clayered->current_cursor->get_value(clayered->current_cursor, &cursor->value));
 
 err:
     __clayered_leave(clayered);
-    if (ret == 0)
+    if (ret == 0) {
         __clayered_deleted_decode(&cursor->value);
-    else {
+        F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
+        F_SET(cursor, WT_CURSTD_KEY_INT | WT_CURSTD_VALUE_INT);
+    } else {
         F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
         if (ret != WT_PREPARE_CONFLICT)
             __clayered_reset_cursors(clayered, false);

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -1313,14 +1313,9 @@ __clayered_lookup(WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, WT_ITEM
 err:
     if (reset_ignore_prepare)
         F_CLR(session->txn, WT_TXN_IGNORE_PREPARE);
-    if (ret == 0) {
-        F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
-        F_SET(cursor, WT_CURSTD_KEY_INT);
+    if (ret == 0)
         clayered->current_cursor = c;
-
-        if (value == &cursor->value)
-            F_SET(cursor, WT_CURSTD_VALUE_INT);
-    } else if (ret != WT_PREPARE_CONFLICT)
+    else if (ret != WT_PREPARE_CONFLICT)
         WT_TRET(__clayered_reset_cursors(clayered, false));
 
     return (ret);

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -868,10 +868,9 @@ __clayered_iterate(WT_CURSOR_LAYERED *clayered, bool forward, uint32_t iter_flag
      */
     do {
         WT_ERR(__clayered_iterate_constituents(clayered, iter_flag, deleted));
-        ret = __clayered_get_current(session, clayered, forward);
-        if (ret == 0)
-            deleted = __clayered_deleted(clayered, &clayered->current_cursor->value);
-    } while (ret == 0 && deleted);
+        WT_ERR(__clayered_get_current(session, clayered, forward));
+        deleted = __clayered_deleted(clayered, &clayered->current_cursor->value);
+    } while (deleted);
     WT_ERR_NOTFOUND_OK(ret, true);
 
     F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -906,6 +906,7 @@ __clayered_next(WT_CURSOR *cursor)
     clayered = (WT_CURSOR_LAYERED *)cursor;
 
     CURSOR_API_CALL(cursor, session, ret, next, clayered->dhandle);
+    WT_ERR(__cursor_copy_release(cursor));
 
     WT_STAT_CONN_DSRC_INCR(session, layered_curs_next);
 
@@ -934,6 +935,7 @@ __layered_prev(WT_CURSOR *cursor)
     clayered = (WT_CURSOR_LAYERED *)cursor;
 
     CURSOR_API_CALL(cursor, session, ret, prev, clayered->dhandle);
+    WT_ERR(__cursor_copy_release(cursor));
 
     WT_STAT_CONN_DSRC_INCR(session, layered_curs_prev);
 
@@ -995,12 +997,6 @@ __clayered_reset(WT_CURSOR *cursor)
      */
     clayered = (WT_CURSOR_LAYERED *)cursor;
     CURSOR_API_CALL_PREPARE_ALLOWED(cursor, session, reset, clayered->dhandle);
-
-    /*
-     * Release any cursor copy debug state before resetting constituent cursors. The layered
-     * cursor's key/value may point into constituent cursor memory; if we reset constituents first,
-     * that memory is freed and the subsequent copy release would access freed memory.
-     */
     WT_ERR(__cursor_copy_release(cursor));
 
     /* Reset any bounds on the top level cursor, and propagate that to constituents */
@@ -1349,6 +1345,7 @@ __clayered_search(WT_CURSOR *cursor)
     clayered = (WT_CURSOR_LAYERED *)cursor;
 
     CURSOR_API_CALL(cursor, session, ret, search, clayered->dhandle);
+    WT_ERR(__cursor_copy_release(cursor));
     WT_ERR(__cursor_needkey(cursor));
     __cursor_novalue(cursor);
     WT_ERR(__clayered_enter(clayered, true, true, false));
@@ -1393,6 +1390,7 @@ __clayered_search_near(WT_CURSOR *cursor, int *exactp)
     stable_found = false;
 
     CURSOR_API_CALL(cursor, session, ret, search_near, clayered->dhandle);
+    WT_ERR(__cursor_copy_release(cursor));
     WT_ERR(__cursor_needkey(cursor));
     __cursor_novalue(cursor);
     WT_ERR(__clayered_enter(clayered, true, true, false));
@@ -1702,6 +1700,7 @@ __clayered_insert(WT_CURSOR *cursor)
     clayered = (WT_CURSOR_LAYERED *)cursor;
 
     CURSOR_UPDATE_API_CALL(cursor, session, ret, insert, clayered->dhandle);
+    WT_ERR(__cursor_copy_release(cursor));
     WT_ERR(__cursor_needkey(cursor));
     WT_ERR(__cursor_needvalue(cursor));
     WT_ERR(__clayered_enter(clayered, false,
@@ -1756,6 +1755,7 @@ __clayered_update(WT_CURSOR *cursor)
     clayered = (WT_CURSOR_LAYERED *)cursor;
 
     CURSOR_UPDATE_API_CALL(cursor, session, ret, update, clayered->dhandle);
+    WT_ERR(__cursor_copy_release(cursor));
     WT_ERR(__cursor_needkey(cursor));
     WT_ERR(__cursor_needvalue(cursor));
     WT_ERR(__clayered_enter(clayered, false,
@@ -1811,6 +1811,7 @@ __clayered_remove(WT_CURSOR *cursor)
     positioned = F_ISSET(cursor, WT_CURSTD_KEY_INT);
 
     CURSOR_REMOVE_API_CALL(cursor, session, ret, clayered->dhandle);
+    WT_ERR(__cursor_copy_release(cursor));
     WT_ERR(__cursor_needkey(cursor));
     __cursor_novalue(cursor);
 
@@ -1857,6 +1858,7 @@ __clayered_reserve(WT_CURSOR *cursor)
     overwrite = F_ISSET(cursor, WT_CURSTD_OVERWRITE);
 
     CURSOR_UPDATE_API_CALL(cursor, session, ret, reserve, clayered->dhandle);
+    WT_ERR(__cursor_copy_release(cursor));
     WT_ERR(__cursor_needkey(cursor));
     __cursor_novalue(cursor);
     WT_ERR(__wt_txn_context_check(session, true));
@@ -1909,6 +1911,7 @@ __clayered_largest_key(WT_CURSOR *cursor)
 
     CURSOR_API_CALL(cursor, session, ret, largest_key, clayered->dhandle);
     __cursor_novalue(cursor);
+    WT_ERR(__cursor_copy_release(cursor));
     WT_ERR(__clayered_enter(clayered, false, true, false));
 
     ingest_cursor = clayered->ingest_cursor;
@@ -2024,6 +2027,7 @@ __clayered_close(WT_CURSOR *cursor)
      */
     clayered = (WT_CURSOR_LAYERED *)cursor;
     CURSOR_API_CALL_PREPARE_ALLOWED(cursor, session, close, clayered->dhandle);
+    WT_ERR(__cursor_copy_release(cursor));
 err:
     if (ret == 0) {
         /*
@@ -2076,6 +2080,7 @@ __clayered_next_random(WT_CURSOR *cursor)
 
     CURSOR_API_CALL(cursor, session, ret, next, clayered->dhandle);
     __cursor_novalue(cursor);
+    WT_ERR(__cursor_copy_release(cursor));
     WT_ERR(__clayered_enter(clayered, false, true, true));
 
     for (;;) {
@@ -2190,7 +2195,7 @@ __clayered_modify(WT_CURSOR *cursor, WT_MODIFY *entries, int nentries)
     WT_CURSOR_LAYERED *clayered = (WT_CURSOR_LAYERED *)cursor;
 
     CURSOR_UPDATE_API_CALL(cursor, session, ret, modify, clayered->dhandle);
-
+    WT_ERR(__cursor_copy_release(cursor));
     WT_ERR(__cursor_needkey(cursor));
     WT_ERR(__clayered_enter(clayered, false, true, false));
 

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -869,7 +869,8 @@ __clayered_iterate(WT_CURSOR_LAYERED *clayered, bool forward, uint32_t iter_flag
     do {
         WT_ERR(__clayered_iterate_constituents(clayered, iter_flag, deleted));
         ret = __clayered_get_current(session, clayered, forward);
-        deleted = __clayered_deleted(clayered, &clayered->current_cursor->value);
+        if (ret == 0)
+            deleted = __clayered_deleted(clayered, &clayered->current_cursor->value);
     } while (ret == 0 && deleted);
     WT_ERR_NOTFOUND_OK(ret, true);
 

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -9,7 +9,7 @@
 #include "wt_internal.h"
 
 static int __clayered_copy_bounds(WT_CURSOR_LAYERED *);
-static int __clayered_lookup(WT_SESSION_IMPL *, WT_CURSOR_LAYERED *, WT_ITEM *);
+static int __clayered_lookup(WT_SESSION_IMPL *, WT_CURSOR_LAYERED *, WT_ITEM *, bool);
 static int __clayered_open_cursors(WT_SESSION_IMPL *, WT_CURSOR_LAYERED *);
 static int __clayered_reset_cursors(WT_CURSOR_LAYERED *, bool);
 static int __clayered_search_near(WT_CURSOR *, int *);
@@ -1234,7 +1234,7 @@ __clayered_reopen(WT_CURSOR *cursor, bool sweep_check_only)
  *     The cursor-agnostic parts of layered table lookups.
  */
 static int
-__clayered_lookup_constituent(WT_CURSOR *c, WT_CURSOR_LAYERED *clayered, WT_ITEM *value)
+__clayered_lookup_constituent(WT_CURSOR *c, WT_CURSOR_LAYERED *clayered, WT_ITEM *value, bool set_layered_key)
 {
     WT_CURSOR *cursor;
     WT_DECL_RET;
@@ -1243,7 +1243,8 @@ __clayered_lookup_constituent(WT_CURSOR *c, WT_CURSOR_LAYERED *clayered, WT_ITEM
 
     c->set_key(c, &cursor->key);
     if ((ret = c->search(c)) == 0) {
-        WT_RET(c->get_key(c, &cursor->key));
+        if (set_layered_key)
+            WT_RET(c->get_key(c, &cursor->key));
         WT_RET(c->get_value(c, value));
         clayered->current_cursor = c;
     }
@@ -1256,7 +1257,7 @@ __clayered_lookup_constituent(WT_CURSOR *c, WT_CURSOR_LAYERED *clayered, WT_ITEM
  *     Position a layered cursor.
  */
 static int
-__clayered_lookup(WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, WT_ITEM *value)
+__clayered_lookup(WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, WT_ITEM *value, bool set_layered_key)
 {
     WT_CONNECTION_IMPL *conn;
     WT_CURSOR *c, *cursor;
@@ -1271,7 +1272,7 @@ __clayered_lookup(WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, WT_ITEM
 
     if (!conn->layered_table_manager.leader) {
         c = clayered->ingest_cursor;
-        WT_ERR_NOTFOUND_OK(__clayered_lookup_constituent(c, clayered, value), true);
+        WT_ERR_NOTFOUND_OK(__clayered_lookup_constituent(c, clayered, value, set_layered_key), true);
         if (ret == 0) {
             found = true;
             if (__clayered_deleted(clayered, value))
@@ -1299,7 +1300,7 @@ __clayered_lookup(WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, WT_ITEM
             reset_ignore_prepare = true;
             F_SET(session->txn, WT_TXN_IGNORE_PREPARE);
         }
-        WT_ERR_NOTFOUND_OK(__clayered_lookup_constituent(c, clayered, value), true);
+        WT_ERR_NOTFOUND_OK(__clayered_lookup_constituent(c, clayered, value, set_layered_key), true);
         if (ret == 0)
             found = true;
     }
@@ -1342,7 +1343,7 @@ __clayered_search(WT_CURSOR *cursor)
     WT_ERR(__clayered_enter(clayered, true, true, false));
     F_CLR(clayered, WT_CLAYERED_ITERATE_NEXT | WT_CLAYERED_ITERATE_PREV);
 
-    ret = __clayered_lookup(session, clayered, &cursor->value);
+    ret = __clayered_lookup(session, clayered, &cursor->value, true);
 
     WT_STAT_CONN_DSRC_INCR(session, layered_curs_search);
     /* FIXME-WT-15545: Handle the case of current_cursor being NULL */
@@ -1580,7 +1581,7 @@ __clayered_remove_follower(
         }
     } else {
         WT_ASSERT(session, F_ISSET(&clayered->iface, WT_CURSTD_KEY_EXT));
-        WT_RET(__clayered_lookup(session, clayered, &value));
+        WT_RET(__clayered_lookup(session, clayered, &value, false));
     }
 
     /* If we are positioned on the stable table, we need to set the key. */
@@ -1698,7 +1699,7 @@ __clayered_insert(WT_CURSOR *cursor)
      * lookup results in an error, and a failed lookup leaves the original key intact.
      */
     if (!F_ISSET(cursor, WT_CURSTD_OVERWRITE) &&
-      (ret = __clayered_lookup(session, clayered, &value)) != WT_NOTFOUND) {
+      (ret = __clayered_lookup(session, clayered, &value, false)) != WT_NOTFOUND) {
         if (ret == 0) {
             WT_ERR(__clayered_copy_duplicate_kv(cursor));
             WT_ERR(WT_DUPLICATE_KEY);
@@ -1748,7 +1749,7 @@ __clayered_update(WT_CURSOR *cursor)
       false));
 
     if (!F_ISSET(cursor, WT_CURSTD_OVERWRITE)) {
-        WT_ERR(__clayered_lookup(session, clayered, &value));
+        WT_ERR(__clayered_lookup(session, clayered, &value, false));
         /*
          * Copy the key out, since the insert resets non-primary chunk cursors which our lookup may
          * have landed on.
@@ -1849,7 +1850,7 @@ __clayered_reserve(WT_CURSOR *cursor)
     /* WT_CURSOR.reserve is update-without-overwrite and a special value. */
     F_CLR(cursor, WT_CURSTD_OVERWRITE);
     WT_ERR(__clayered_enter(clayered, false, S2C(session)->layered_table_manager.leader, false));
-    WT_ERR(__clayered_lookup(session, clayered, &value));
+    WT_ERR(__clayered_lookup(session, clayered, &value, false));
     /*
      * Copy the key out, since the insert resets non-primary chunk cursors which our lookup may have
      * landed on.

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -1234,7 +1234,8 @@ __clayered_reopen(WT_CURSOR *cursor, bool sweep_check_only)
  *     The cursor-agnostic parts of layered table lookups.
  */
 static int
-__clayered_lookup_constituent(WT_CURSOR *c, WT_CURSOR_LAYERED *clayered, WT_ITEM *value, bool set_layered_key)
+__clayered_lookup_constituent(
+  WT_CURSOR *c, WT_CURSOR_LAYERED *clayered, WT_ITEM *value, bool set_layered_key)
 {
     WT_CURSOR *cursor;
     WT_DECL_RET;
@@ -1257,7 +1258,8 @@ __clayered_lookup_constituent(WT_CURSOR *c, WT_CURSOR_LAYERED *clayered, WT_ITEM
  *     Position a layered cursor.
  */
 static int
-__clayered_lookup(WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, WT_ITEM *value, bool set_layered_key)
+__clayered_lookup(
+  WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, WT_ITEM *value, bool set_layered_key)
 {
     WT_CONNECTION_IMPL *conn;
     WT_CURSOR *c, *cursor;
@@ -1272,7 +1274,8 @@ __clayered_lookup(WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, WT_ITEM
 
     if (!conn->layered_table_manager.leader) {
         c = clayered->ingest_cursor;
-        WT_ERR_NOTFOUND_OK(__clayered_lookup_constituent(c, clayered, value, set_layered_key), true);
+        WT_ERR_NOTFOUND_OK(
+          __clayered_lookup_constituent(c, clayered, value, set_layered_key), true);
         if (ret == 0) {
             found = true;
             if (__clayered_deleted(clayered, value))
@@ -1300,7 +1303,8 @@ __clayered_lookup(WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, WT_ITEM
             reset_ignore_prepare = true;
             F_SET(session->txn, WT_TXN_IGNORE_PREPARE);
         }
-        WT_ERR_NOTFOUND_OK(__clayered_lookup_constituent(c, clayered, value, set_layered_key), true);
+        WT_ERR_NOTFOUND_OK(
+          __clayered_lookup_constituent(c, clayered, value, set_layered_key), true);
         if (ret == 0)
             found = true;
     }

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -1362,11 +1362,8 @@ err:
         __clayered_deleted_decode(&cursor->value);
         F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
         F_SET(cursor, WT_CURSTD_KEY_INT | WT_CURSTD_VALUE_INT);
-    } else if (ret != WT_PREPARE_CONFLICT) {
-        /* FIXME-WT-16880: Fix layered search_near() incorrectly resetting the cursor. */
-        F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
-        clayered->current_cursor = NULL;
-    }
+    } else
+        WT_ASSERT(session, F_ISSET(cursor, WT_CURSTD_KEY_SET));
     API_END_RET(session, ret);
 }
 

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -1262,13 +1262,12 @@ static int
 __clayered_lookup(WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, WT_ITEM *value)
 {
     WT_CONNECTION_IMPL *conn;
-    WT_CURSOR *c, *cursor;
+    WT_CURSOR *c;
     WT_DECL_RET;
     bool found, reset_ignore_prepare;
 
     c = NULL;
     conn = S2C(session);
-    cursor = &clayered->iface;
     found = false;
     reset_ignore_prepare = false;
 

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -9,7 +9,7 @@
 #include "wt_internal.h"
 
 static int __clayered_copy_bounds(WT_CURSOR_LAYERED *);
-static int __clayered_lookup(WT_SESSION_IMPL *, WT_CURSOR_LAYERED *, WT_ITEM *, bool);
+static int __clayered_lookup(WT_SESSION_IMPL *, WT_CURSOR_LAYERED *, WT_ITEM *);
 static int __clayered_open_cursors(WT_SESSION_IMPL *, WT_CURSOR_LAYERED *);
 static int __clayered_reset_cursors(WT_CURSOR_LAYERED *, bool);
 static int __clayered_search_near(WT_CURSOR *, int *);
@@ -1238,8 +1238,7 @@ __clayered_reopen(WT_CURSOR *cursor, bool sweep_check_only)
  *     The cursor-agnostic parts of layered table lookups.
  */
 static int
-__clayered_lookup_constituent(
-  WT_CURSOR *c, WT_CURSOR_LAYERED *clayered, WT_ITEM *value, bool set_layered_key)
+__clayered_lookup_constituent(WT_CURSOR *c, WT_CURSOR_LAYERED *clayered, WT_ITEM *value)
 {
     WT_CURSOR *cursor;
     WT_DECL_RET;
@@ -1248,8 +1247,6 @@ __clayered_lookup_constituent(
 
     c->set_key(c, &cursor->key);
     if ((ret = c->search(c)) == 0) {
-        if (set_layered_key)
-            WT_RET(c->get_key(c, &cursor->key));
         WT_RET(c->get_value(c, value));
         clayered->current_cursor = c;
     }
@@ -1262,8 +1259,7 @@ __clayered_lookup_constituent(
  *     Position a layered cursor.
  */
 static int
-__clayered_lookup(
-  WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, WT_ITEM *value, bool set_layered_key)
+__clayered_lookup(WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, WT_ITEM *value)
 {
     WT_CONNECTION_IMPL *conn;
     WT_CURSOR *c, *cursor;
@@ -1278,8 +1274,7 @@ __clayered_lookup(
 
     if (!conn->layered_table_manager.leader) {
         c = clayered->ingest_cursor;
-        WT_ERR_NOTFOUND_OK(
-          __clayered_lookup_constituent(c, clayered, value, set_layered_key), true);
+        WT_ERR_NOTFOUND_OK(__clayered_lookup_constituent(c, clayered, value), true);
         if (ret == 0) {
             found = true;
             if (__clayered_deleted(clayered, value))
@@ -1307,8 +1302,7 @@ __clayered_lookup(
             reset_ignore_prepare = true;
             F_SET(session->txn, WT_TXN_IGNORE_PREPARE);
         }
-        WT_ERR_NOTFOUND_OK(
-          __clayered_lookup_constituent(c, clayered, value, set_layered_key), true);
+        WT_ERR_NOTFOUND_OK(__clayered_lookup_constituent(c, clayered, value), true);
         if (ret == 0)
             found = true;
     }
@@ -1352,14 +1346,15 @@ __clayered_search(WT_CURSOR *cursor)
     WT_ERR(__clayered_enter(clayered, true, true, false));
     F_CLR(clayered, WT_CLAYERED_ITERATE_NEXT | WT_CLAYERED_ITERATE_PREV);
 
-    ret = __clayered_lookup(session, clayered, &cursor->value, true);
-
     WT_STAT_CONN_DSRC_INCR(session, layered_curs_search);
-    /* FIXME-WT-15545: Handle the case of current_cursor being NULL */
+    WT_ERR(__clayered_lookup(session, clayered, &cursor->value));
+    WT_ERR(clayered->current_cursor->get_key(clayered->current_cursor, &cursor->key));
     if (clayered->current_cursor == clayered->ingest_cursor)
         WT_STAT_CONN_DSRC_INCR(session, layered_curs_search_ingest);
-    else
+    else {
+        WT_ASSERT(session, clayered->current_cursor == clayered->stable_cursor);
         WT_STAT_CONN_DSRC_INCR(session, layered_curs_search_stable);
+    }
 
 err:
     __clayered_leave(clayered);
@@ -1594,7 +1589,7 @@ __clayered_remove_follower(
         }
     } else {
         WT_ASSERT(session, F_ISSET(&clayered->iface, WT_CURSTD_KEY_EXT));
-        WT_RET(__clayered_lookup(session, clayered, &value, false));
+        WT_RET(__clayered_lookup(session, clayered, &value));
     }
 
     /* If we are positioned on the stable table, we need to set the key. */
@@ -1713,7 +1708,7 @@ __clayered_insert(WT_CURSOR *cursor)
      * lookup results in an error, and a failed lookup leaves the original key intact.
      */
     if (!F_ISSET(cursor, WT_CURSTD_OVERWRITE) &&
-      (ret = __clayered_lookup(session, clayered, &value, false)) != WT_NOTFOUND) {
+      (ret = __clayered_lookup(session, clayered, &value)) != WT_NOTFOUND) {
         if (ret == 0) {
             WT_ERR(__clayered_copy_duplicate_kv(cursor));
             WT_ERR(WT_DUPLICATE_KEY);
@@ -1764,7 +1759,7 @@ __clayered_update(WT_CURSOR *cursor)
       false));
 
     if (!F_ISSET(cursor, WT_CURSTD_OVERWRITE)) {
-        WT_ERR(__clayered_lookup(session, clayered, &value, false));
+        WT_ERR(__clayered_lookup(session, clayered, &value));
         /*
          * Copy the key out, since the insert resets non-primary chunk cursors which our lookup may
          * have landed on.
@@ -1867,7 +1862,7 @@ __clayered_reserve(WT_CURSOR *cursor)
     /* WT_CURSOR.reserve is update-without-overwrite and a special value. */
     F_CLR(cursor, WT_CURSTD_OVERWRITE);
     WT_ERR(__clayered_enter(clayered, false, S2C(session)->layered_table_manager.leader, false));
-    WT_ERR(__clayered_lookup(session, clayered, &value, false));
+    WT_ERR(__clayered_lookup(session, clayered, &value));
     /*
      * Copy the key out, since the insert resets non-primary chunk cursors which our lookup may have
      * landed on.

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -1362,7 +1362,8 @@ err:
         __clayered_deleted_decode(&cursor->value);
         F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
         F_SET(cursor, WT_CURSTD_KEY_INT | WT_CURSTD_VALUE_INT);
-    } else {
+    } else if (ret != WT_PREPARE_CONFLICT) {
+        /* FIXME-WT-16880: Fix layered search_near() incorrectly resetting the cursor. */
         F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
         clayered->current_cursor = NULL;
     }

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -911,8 +911,10 @@ __clayered_next(WT_CURSOR *cursor)
 
     if (clayered->current_cursor == clayered->ingest_cursor)
         WT_STAT_CONN_DSRC_INCR(session, layered_curs_next_ingest);
-    else
+    else {
+        WT_ASSERT(session, clayered->current_cursor == clayered->stable_cursor);
         WT_STAT_CONN_DSRC_INCR(session, layered_curs_next_stable);
+    }
 
 err:
     API_END_RET(session, ret);
@@ -940,8 +942,10 @@ __layered_prev(WT_CURSOR *cursor)
 
     if (clayered->current_cursor == clayered->ingest_cursor)
         WT_STAT_CONN_DSRC_INCR(session, layered_curs_prev_ingest);
-    else
+    else {
+        WT_ASSERT(session, clayered->current_cursor == clayered->stable_cursor);
         WT_STAT_CONN_DSRC_INCR(session, layered_curs_prev_stable);
+    }
 
 err:
     API_END_RET(session, ret);

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -996,6 +996,13 @@ __clayered_reset(WT_CURSOR *cursor)
     clayered = (WT_CURSOR_LAYERED *)cursor;
     CURSOR_API_CALL_PREPARE_ALLOWED(cursor, session, reset, clayered->dhandle);
 
+    /*
+     * Release any cursor copy debug state before resetting constituent cursors. The layered
+     * cursor's key/value may point into constituent cursor memory; if we reset constituents first,
+     * that memory is freed and the subsequent copy release would access freed memory.
+     */
+    WT_ERR(__cursor_copy_release(cursor));
+
     /* Reset any bounds on the top level cursor, and propagate that to constituents */
     __wt_cursor_bound_reset(cursor);
     WT_ERR(__clayered_copy_bounds(clayered));

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -1354,8 +1354,14 @@ __clayered_search(WT_CURSOR *cursor)
 
 err:
     __clayered_leave(clayered);
-    if (ret == 0)
+    if (ret == 0) {
         __clayered_deleted_decode(&cursor->value);
+        F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
+        F_SET(cursor, WT_CURSTD_KEY_INT | WT_CURSTD_VALUE_INT);
+    } else {
+        F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
+        clayered->current_cursor = NULL;
+    }
     API_END_RET(session, ret);
 }
 

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -1362,8 +1362,7 @@ err:
         __clayered_deleted_decode(&cursor->value);
         F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
         F_SET(cursor, WT_CURSTD_KEY_INT | WT_CURSTD_VALUE_INT);
-    } else
-        WT_ASSERT(session, F_ISSET(cursor, WT_CURSTD_KEY_SET));
+    }
     API_END_RET(session, ret);
 }
 

--- a/test/suite/test_layered22.py
+++ b/test/suite/test_layered22.py
@@ -115,6 +115,7 @@ class test_layered22(wttest.WiredTigerTestCase):
 
         cursor.set_key("nonexistent")
         self.assertEqual(cursor.search(), wiredtiger.WT_NOTFOUND)
+        cursor.set_key("nonexistent")
         self.assertEqual(cursor.search_near(), wiredtiger.WT_NOTFOUND)
 
         self.session.begin_transaction()

--- a/test/suite/test_layered22.py
+++ b/test/suite/test_layered22.py
@@ -115,7 +115,6 @@ class test_layered22(wttest.WiredTigerTestCase):
 
         cursor.set_key("nonexistent")
         self.assertEqual(cursor.search(), wiredtiger.WT_NOTFOUND)
-        cursor.set_key("nonexistent")
         self.assertEqual(cursor.search_near(), wiredtiger.WT_NOTFOUND)
 
         self.session.begin_transaction()


### PR DESCRIPTION
There are three distinct issues to address:

* As outlined in the ticket, __layered_put should not set the layered key in certain cases.
* Additionally, we need to ensure __cursor_copy_release is invoked for layered cursors when debug copy is enabled. Otherwise, resetting the cursor can lead to a heap-use-after-free error.
* Lastly, there is undefined behavior where __clayered_deleted is called on the cursor value, even when the cursor returns "not found."