### PR TITLE
WT-16954 Eviction thread panic due to buffer overflow in transaction state dump

### DIFF
--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -2759,6 +2759,8 @@ __wt_verbose_dump_txn_one(
           session, snapshot_buf, "%s%" PRIu64, i == 0 ? "" : ", ", txn->snapshot_data.snapshot[i]));
     WT_ERR(__wt_buf_catfmt(session, snapshot_buf, "%s", "]\0"));
     buf_len = (uint32_t)snapshot_buf->size + 512;
+    if (txn_err_info->err_msg != NULL)
+        buf_len += strlen(txn_err_info->err_msg);
     WT_ERR(__wt_scr_alloc(session, buf_len, &buf));
 
     WT_ERR(__wt_lsn_string(&txn->ckpt_lsn, sizeof(ckpt_lsn_str), ckpt_lsn_str));


### PR DESCRIPTION
During __wt_verbose_dump_txn_one we don't alloc enough buf size for __wt_snprintf, which will cause ERANGE error if the reserved 512 bytes is not large enough to fit the dump message.
This PR is to increase the buffer length by strlen(txn_err_info->err_msg) so the buffer can have enough length for the dumping message.
