### PR TITLE
WT-16939 Dump metadata page on error

### DIFF
--- a/src/conn/conn_layered_page_log.c
+++ b/src/conn/conn_layered_page_log.c
@@ -538,8 +538,8 @@ __wti_disagg_fetch_shared_meta(
         if (checksum == ckpt_meta->metadata_checksum) {
             WT_ERR(__wt_scr_alloc(session, 0, &hex_buf));
             WT_ERR_MSG(session, EIO,
-              "Checkpoint metadata corruption detected at lsn: %" PRIu64 ", expected: 0x%" PRIx32
-              ", got: 0x%" PRIx32 ", data: [%s]",
+              "Checkpoint metadata corruption detected: lsn=%" PRIu64 ", expected=0x%" PRIx32
+              ", got=0x%" PRIx32 ", data=[%s]",
               ckpt_meta->metadata_lsn, ckpt_meta->metadata_checksum, checksum,
               __wt_buf_set_printable(session, item->data, item->size, false, hex_buf));
         }

--- a/src/conn/conn_layered_page_log.c
+++ b/src/conn/conn_layered_page_log.c
@@ -535,7 +535,7 @@ __wti_disagg_fetch_shared_meta(
     /* Validate the checksum. */
     if (ckpt_meta->has_metadata_checksum) {
         const uint32_t checksum = __wt_checksum(item->data, item->size);
-        if (checksum == ckpt_meta->metadata_checksum) {
+        if (checksum != ckpt_meta->metadata_checksum) {
             WT_ERR(__wt_scr_alloc(session, 0, &hex_buf));
             WT_ERR_MSG(session, EIO,
               "Checkpoint metadata corruption detected: lsn=%" PRIu64 ", expected=0x%" PRIx32

--- a/src/conn/conn_layered_page_log.c
+++ b/src/conn/conn_layered_page_log.c
@@ -524,6 +524,7 @@ int
 __wti_disagg_fetch_shared_meta(
   WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPOINT_META *ckpt_meta, WT_ITEM *item)
 {
+    WT_DECL_ITEM(hex_buf);
     WT_DECL_RET;
 
     /* Read the checkpoint metadata of the shared metadata table from the special metadata page. */
@@ -534,14 +535,18 @@ __wti_disagg_fetch_shared_meta(
     /* Validate the checksum. */
     if (ckpt_meta->has_metadata_checksum) {
         const uint32_t checksum = __wt_checksum(item->data, item->size);
-        if (checksum != ckpt_meta->metadata_checksum) {
+        if (checksum == ckpt_meta->metadata_checksum) {
+            WT_ERR(__wt_scr_alloc(session, 0, &hex_buf));
             WT_ERR_MSG(session, EIO,
-              "Checkpoint metadata checksum mismatch: expected %" PRIx32 ", got %" PRIx32,
-              ckpt_meta->metadata_checksum, checksum);
+              "Checkpoint metadata corruption detected at lsn: %" PRIu64 ", expected: 0x%" PRIx32
+              ", got: 0x%" PRIx32 ", data: [%s]",
+              ckpt_meta->metadata_lsn, ckpt_meta->metadata_checksum, checksum,
+              __wt_buf_set_printable(session, item->data, item->size, false, hex_buf));
         }
     }
 
 err:
+    __wt_scr_free(session, &hex_buf);
     return (ret);
 }
 

--- a/src/conn/conn_layered_page_log.c
+++ b/src/conn/conn_layered_page_log.c
@@ -516,6 +516,9 @@ __disagg_put_meta(WT_SESSION_IMPL *session, uint64_t page_id, const WT_ITEM *ite
     return (0);
 }
 
+/* Limit the amount of bytes we dump in the metadata page dump. */
+#define WT_DISAGG_META_DUMP_MAX 1024
+
 /*
  * __wti_disagg_fetch_shared_meta --
  *     Fetch the checkpoint metadata page, validate it, and return a zero-terminated buffer copy.
@@ -536,12 +539,14 @@ __wti_disagg_fetch_shared_meta(
     if (ckpt_meta->has_metadata_checksum) {
         const uint32_t checksum = __wt_checksum(item->data, item->size);
         if (checksum != ckpt_meta->metadata_checksum) {
+            const size_t dump_size =
+              item->size > WT_DISAGG_META_DUMP_MAX ? WT_DISAGG_META_DUMP_MAX : item->size;
             WT_ERR(__wt_scr_alloc(session, 0, &hex_buf));
             WT_ERR_MSG(session, EIO,
               "Checkpoint metadata corruption detected: lsn=%" PRIu64 ", expected=0x%" PRIx32
               ", got=0x%" PRIx32 ", data=[%s]",
               ckpt_meta->metadata_lsn, ckpt_meta->metadata_checksum, checksum,
-              __wt_buf_set_printable(session, item->data, item->size, false, hex_buf));
+              __wt_buf_set_printable(session, item->data, dump_size, false, hex_buf));
         }
     }
 

--- a/test/suite/test_layered64.py
+++ b/test/suite/test_layered64.py
@@ -105,4 +105,4 @@ class test_layered64(wttest.WiredTigerTestCase):
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.conn.reconfigure(
                 f'disaggregated=(checkpoint_meta="{corrupted_checkpoint_meta}")'),
-            "/Checkpoint metadata checksum mismatch/")
+            "/Checkpoint metadata corruption detected/")


### PR DESCRIPTION
This dumps the metadata page as raw text on checksum mismatch. I've also added the lsn to the error message. Please let me know if you think there is any other useful metadata to include in this error.

I considered adding a verbose messages for a succesful read in the same function and an equivalent write message however there are already enough verbose messages for these higher up the stack.