### PR TITLE
WT-16959 Fix ref->home and ref->addr race in __wt_ref_addr_copy during split deepening

### DIFF
--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -269,9 +269,9 @@ __split_ref_move(WT_SESSION_IMPL *session, WT_PAGE *from_home, WT_REF **from_ref
             WT_ERR(__wt_illegal_value(session, unpack.raw));
         }
         /*
-         * Use a seq-cst CAS to swap the on-page cell pointer to the off-page addr. This ensures the
-         * addr conversion is visible to readers before ref->home is later updated to the new child
-         * page during split. Pairs with the acquire barrier on the read side.
+         * Use a sequentially consistent CAS to swap the on-page cell pointer to the off-page addr.
+         * This ensures the addr conversion is visible to readers before ref->home is later updated
+         * to the new child page during split. Pairs with the acquire barrier on the read side.
          */
         if (__wt_atomic_cas_ptr(&ref->addr, ref_addr, addr))
             addr = NULL;

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -268,7 +268,11 @@ __split_ref_move(WT_SESSION_IMPL *session, WT_PAGE *from_home, WT_REF **from_ref
         default:
             WT_ERR(__wt_illegal_value(session, unpack.raw));
         }
-        /* If the compare-and-swap is successful, clear addr to skip the free at the end. */
+        /*
+         * Use a seq-cst CAS to swap the on-page cell pointer to the off-page addr. This ensures the
+         * addr conversion is visible to readers before ref->home is later updated to the new child
+         * page during split. Pairs with the acquire barrier on the read side.
+         */
         if (__wt_atomic_cas_ptr(&ref->addr, ref_addr, addr))
             addr = NULL;
     }
@@ -363,13 +367,6 @@ __split_ref_prepare(
         locked[cnt++] = child;
 
         WT_PAGE_LOCK(session, child);
-
-        /*
-         * Ensure addr conversions from on-page to off-page (done in __split_ref_move) are visible
-         * to other threads before we update ref->home to this new child page. Pairs with the
-         * acquire barrier in __wt_ref_addr_copy.
-         */
-        WT_RELEASE_BARRIER();
 
         /* Switch the WT_REF's to their new page. */
         j = 0;

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -364,6 +364,13 @@ __split_ref_prepare(
 
         WT_PAGE_LOCK(session, child);
 
+        /*
+         * Ensure addr conversions from on-page to off-page (done in __split_ref_move) are visible
+         * to other threads before we update ref->home to this new child page. Pairs with the
+         * acquire barrier in __wt_ref_addr_copy.
+         */
+        WT_RELEASE_BARRIER();
+
         /* Switch the WT_REF's to their new page. */
         j = 0;
         WT_INTL_FOREACH_BEGIN (session, child, child_ref) {

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -1843,11 +1843,10 @@ __wt_ref_addr_copy(WT_SESSION_IMPL *session, WT_REF *ref, WT_ADDR_COPY *copy)
      * dangerous. The problem is if the parent page splits, deepening the tree. As part of that
      * process, the WT_REF WT_ADDRs pointing into the parent's disk image are copied into off-page
      * WT_ADDRs and swapped into place before ref->home is updated to the new child page. Read
-     * ref->home before ref->addr with an acquire barrier in between, pairing with the release
-     * barrier in __split_ref_prepare before the home update. This ensures that if we observe a new
-     * child page as home, we also observe the corresponding off-page addr. The content of the two
-     * WT_ADDRs are identical, and we don't care which version we get as long as we don't
-     * mix-and-match the two.
+     * ref->home before ref->addr with an acquire barrier in between, pairing with the seq-cst CAS
+     * on ref->addr during split. This ensures that if we observe a new child page as home, we also
+     * observe the corresponding off-page addr. The content of the two WT_ADDRs are identical, and
+     * we don't care which version we get as long as we don't mix-and-match the two.
      */
     page = ref->home;
     WT_ACQUIRE_BARRIER();

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -1845,13 +1845,13 @@ __wt_ref_addr_copy(WT_SESSION_IMPL *session, WT_REF *ref, WT_ADDR_COPY *copy)
      * WT_ADDRs and swapped into place before ref->home is updated to the new child page. Read
      * ref->home before ref->addr with an acquire barrier in between, pairing with the sequentially
      * consistent CAS on ref->addr during split. This ensures that if we observe a new child page as
-     * home, we also observe the corresponding off-page addr. The content of the two WT_ADDRs are
-     * identical, and we don't care which version we get as long as we don't mix-and-match the two.
+     * home, we also observe the corresponding off-page addr. The dangerous combination is reading a
+     * new home with an old addr, as the on-page cell would be misinterpreted as an off-page
+     * address.
      */
-    page = ref->home;
-    WT_ACQUIRE_BARRIER();
-    addr = (WT_ADDR *)ref->addr;
+    page = (WT_PAGE *)__wt_atomic_load_ptr_relaxed(&ref->home);
 
+    addr = (WT_ADDR *)__wt_atomic_load_ptr_acquire(&ref->addr);
     /* If NULL, there is no information. */
     if (addr == NULL)
         return (false);

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -1833,7 +1833,6 @@ __wt_ref_addr_copy(WT_SESSION_IMPL *session, WT_REF *ref, WT_ADDR_COPY *copy)
     WT_PAGE *page;
 
     unpack = &_unpack;
-    page = ref->home;
     copy->del_set = false;
 
     WT_ASSERT_ALWAYS(session, __wt_session_gen(session, WT_GEN_SPLIT) != 0,
@@ -1843,11 +1842,16 @@ __wt_ref_addr_copy(WT_SESSION_IMPL *session, WT_REF *ref, WT_ADDR_COPY *copy)
      * To look at an on-page cell, we need to look at the parent page's disk image, and that can be
      * dangerous. The problem is if the parent page splits, deepening the tree. As part of that
      * process, the WT_REF WT_ADDRs pointing into the parent's disk image are copied into off-page
-     * WT_ADDRs and swapped into place. The content of the two WT_ADDRs are identical, and we don't
-     * care which version we get as long as we don't mix-and-match the two.
+     * WT_ADDRs and swapped into place before ref->home is updated to the new child page. Read
+     * ref->home before ref->addr with an acquire barrier in between, pairing with the release
+     * barrier in __split_ref_prepare before the home update. This ensures that if we observe a new
+     * child page as home, we also observe the corresponding off-page addr. The content of the two
+     * WT_ADDRs are identical, and we don't care which version we get as long as we don't
+     * mix-and-match the two.
      */
-    addr = (WT_ADDR *)ref->addr;
+    page = ref->home;
     WT_ACQUIRE_BARRIER();
+    addr = (WT_ADDR *)ref->addr;
 
     /* If NULL, there is no information. */
     if (addr == NULL)

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -1843,10 +1843,10 @@ __wt_ref_addr_copy(WT_SESSION_IMPL *session, WT_REF *ref, WT_ADDR_COPY *copy)
      * dangerous. The problem is if the parent page splits, deepening the tree. As part of that
      * process, the WT_REF WT_ADDRs pointing into the parent's disk image are copied into off-page
      * WT_ADDRs and swapped into place before ref->home is updated to the new child page. Read
-     * ref->home before ref->addr with an acquire barrier in between, pairing with the seq-cst CAS
-     * on ref->addr during split. This ensures that if we observe a new child page as home, we also
-     * observe the corresponding off-page addr. The content of the two WT_ADDRs are identical, and
-     * we don't care which version we get as long as we don't mix-and-match the two.
+     * ref->home before ref->addr with an acquire barrier in between, pairing with the sequentially
+     * consistent CAS on ref->addr during split. This ensures that if we observe a new child page as
+     * home, we also observe the corresponding off-page addr. The content of the two WT_ADDRs are
+     * identical, and we don't care which version we get as long as we don't mix-and-match the two.
      */
     page = ref->home;
     WT_ACQUIRE_BARRIER();


### PR DESCRIPTION
## Summary

During internal page split deepening, `__split_ref_move` converts `ref->addr` from an on-page cell pointer to an off-page `WT_ADDR`, and then `__split_ref_prepare` updates `ref->home` to the new child page. Without proper memory barriers, a concurrent reader in `__wt_ref_addr_copy` could observe an inconsistent pair: the **new** `ref->home` (child page) with the **old** `ref->addr` (on-page cell still pointing into the original parent's disk image).

When this happens, `__wt_off_page(new_child, old_cell)` incorrectly returns `true` because the old cell is not within the new child's disk image. The code then interprets raw on-page cell bytes as a `WT_ADDR` struct, reads a garbage pointer, and passes it to `memcpy` — resulting in a **SIGSEGV**.

The fix adds a **release-acquire barrier pair** to enforce ordering between the two fields:

- **Writer** (`bt_split.c`): `WT_RELEASE_BARRIER()` after addr conversion, before `ref->home` update — ensures the new off-page addr is globally visible before the new home pointer.
- **Reader** (`btree_inline.h`): read `ref->home` first → `WT_ACQUIRE_BARRIER()` → read `ref->addr` — guarantees that if the new home is observed, the corresponding new addr must also be observed.
