### PR TITLE
WT-16965 Fix bytes_total over-decrement in rec_write_err for failed delta block writes

### DIFF
--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -324,14 +324,8 @@ __wt_btree_increase_size(WT_SESSION_IMPL *session, uint64_t size)
 static WT_INLINE void
 __wt_btree_decrease_size(WT_SESSION_IMPL *session, uint64_t size)
 {
-    /*
-     * FIXME WT-16660: re-enable this assert once the disagg delta block size accounting bug is
-     * fixed.
-     */
-    if (__wt_atomic_load_uint64(&S2BT(session)->bytes_total) < size)
-        __wt_atomic_store_uint64(&S2BT(session)->bytes_total, 0);
-    else
-        (void)__wt_atomic_sub_uint64(&S2BT(session)->bytes_total, size);
+    WT_ASSERT(session, __wt_atomic_load_uint64(&S2BT(session)->bytes_total) >= size);
+    (void)__wt_atomic_sub_uint64(&S2BT(session)->bytes_total, size);
 }
 
 /*

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -3224,12 +3224,13 @@ __rec_write_err(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
         for (multi = r->multi, i = 0; i < r->multi_next; ++multi, ++i) {
             if (multi->addr.block_cookie != NULL) {
                 /*
-                 * For disaggregated delta writes, __wti_block_disagg_page_discard decrements
-                 * bytes_total by cookie.size, which is the cumulative chain size (old_cumulative +
-                 * this_delta_size). However, bytes_total was only incremented by this_delta_size
-                 * when the block was written. Compensate by adding back old_cumulative (stored in
-                 * page->disagg_info->block_meta.cumulative_size, which has not yet been updated for
-                 * this failed write) before freeing the block.
+                 * Disaggregated page discards track size cumulatively. The cookie encodes the full
+                 * chain size (base image plus all deltas), so a single discard correctly terminates
+                 * and accounts for the entire chain. On a reconciliation error however, only the
+                 * individual delta size was added when the block was written, not the full chain.
+                 * Discarding by the full chain size therefore over-decrements the total. Compensate
+                 * by adding back the prior cumulative size before the discard so the net effect is
+                 * zero.
                  */
                 if (multi->block_meta != NULL && multi->block_meta->delta_count > 0)
                     __wt_btree_increase_size(

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -3223,9 +3223,18 @@ __rec_write_err(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
     if (r->multi_next != 1 || !F_ISSET(r->multi, WT_MULTI_SKIP_WRITE)) {
         for (multi = r->multi, i = 0; i < r->multi_next; ++multi, ++i) {
             if (multi->addr.block_cookie != NULL) {
+                /*
+                 * For disaggregated delta writes, __wti_block_disagg_page_discard decrements
+                 * bytes_total by cookie.size, which is the cumulative chain size (old_cumulative +
+                 * this_delta_size). However, bytes_total was only incremented by this_delta_size
+                 * when the block was written. Compensate by adding back old_cumulative (stored in
+                 * page->disagg_info->block_meta.cumulative_size, which has not yet been updated for
+                 * this failed write) before freeing the block.
+                 */
                 if (multi->block_meta != NULL && multi->block_meta->delta_count > 0)
                     __wt_btree_increase_size(
                       session, page->disagg_info->block_meta.cumulative_size);
+
                 int ret_tmp = __wt_btree_block_free(
                   session, multi->addr.block_cookie, multi->addr.block_cookie_size);
                 if (ret_tmp != 0) {

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -3223,6 +3223,9 @@ __rec_write_err(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
     if (r->multi_next != 1 || !F_ISSET(r->multi, WT_MULTI_SKIP_WRITE)) {
         for (multi = r->multi, i = 0; i < r->multi_next; ++multi, ++i) {
             if (multi->addr.block_cookie != NULL) {
+                if (multi->block_meta != NULL && multi->block_meta->delta_count > 0)
+                    __wt_btree_increase_size(
+                      session, page->disagg_info->block_meta.cumulative_size);
                 int ret_tmp = __wt_btree_block_free(
                   session, multi->addr.block_cookie, multi->addr.block_cookie_size);
                 if (ret_tmp != 0) {


### PR DESCRIPTION
`__rec_write_err` over-decrements `bytes_total` when freeing a failed disagg delta block. `bytes_total` is incremented by `delta_size` on write, but `__wti_block_disagg_page_discard` decrements by cookie.size (`old_cumulative + delta_size`), netting `-old_cumulative`.

Fix: compensate by adding back `old_cumulative` before freeing. 

I've also re-enables the assert in `__wt_btree_decrease_size` disabled in [WT-16738](https://jira.mongodb.org/browse/WT-16738).