### PR TITLE
WT-16967 Add 8.3 into the compatibility tests

### DIFF
--- a/test/compatibility/compatibility_test_for_releases.sh
+++ b/test/compatibility/compatibility_test_for_releases.sh
@@ -30,6 +30,7 @@ bflag()
 {
     # Return if the branch's format command takes the -B flag for backward compatibility.
     test "$1" = "develop" && echo "-B "
+    test "$1" = "mongodb-8.3" && echo "-B"
     test "$1" = "mongodb-8.2" && echo "-B"
     test "$1" = "mongodb-8.0" && echo "-B"
     test "$1" = "mongodb-7.0" && echo "-B "
@@ -806,6 +807,7 @@ upgrade_to_latest=false
 # then the branch name itself will be used for the checkout
 declare -A gittags
 gittags['develop']="develop"
+gittags['mongodb-8.3']="mongodb-8.3"
 gittags['mongodb-8.0']="mongodb-8.0"
 gittags['mongodb-7.0']="mongodb-7.0"
 gittags['mongodb-6.0']="mongodb-6.0"

--- a/test/compatibility/meta/versions.sh
+++ b/test/compatibility/meta/versions.sh
@@ -6,12 +6,12 @@
 
 # Currently this is a temporary setup for python testsuite
 # This will be merged with the following variables in the future
-export SUITE_RELEASE_BRANCHES="develop mongodb-8.2 mongodb-8.0 mongodb-7.0 mongodb-6.0"
+export SUITE_RELEASE_BRANCHES="develop mongodb-8.3 mongodb-8.2 mongodb-8.0 mongodb-7.0 mongodb-6.0"
 
 # This array is used to configure the release branches we'd like to use for testing the importing
 # of files created in previous versions of WiredTiger. Go all the way back to mongodb-4.2 since
 # that's the first release where we don't support live import.
-export IMPORT_RELEASE_BRANCHES="develop mongodb-8.2 mongodb-8.0 mongodb-7.0 mongodb-6.0"
+export IMPORT_RELEASE_BRANCHES="develop mongodb-8.3 mongodb-8.2 mongodb-8.0 mongodb-7.0 mongodb-6.0"
 
 # Branches in below 2 arrays should be put in newer-to-older order.
 #
@@ -20,7 +20,7 @@ export IMPORT_RELEASE_BRANCHES="develop mongodb-8.2 mongodb-8.0 mongodb-7.0 mong
 #
 # The 2 arrays should be adjusted over time when newer branches are created,
 # or older branches are EOL.
-export NEWER_RELEASE_BRANCHES="develop mongodb-8.2 mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-5.0 mongodb-4.4"
+export NEWER_RELEASE_BRANCHES="develop mongodb-8.3 mongodb-8.2 mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-5.0 mongodb-4.4"
 export OLDER_RELEASE_BRANCHES="mongodb-4.4 mongodb-4.2"
 
 # This array is used to generate compatible configuration files between releases, because
@@ -30,11 +30,11 @@ export COMPATIBLE_UPGRADE_DOWNGRADE_RELEASE_BRANCHES="mongodb-4.4 mongodb-4.2"
 
 # This array is used to configure the release branches we'd like to run patch version
 # upgrade/downgrade test.
-export PATCH_VERSION_UPGRADE_DOWNGRADE_RELEASE_BRANCHES="mongodb-8.2 mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-5.0 mongodb-4.4"
+export PATCH_VERSION_UPGRADE_DOWNGRADE_RELEASE_BRANCHES="mongodb-8.3 mongodb-8.2 mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-5.0 mongodb-4.4"
 
 # This array is used to configure the release branches we'd like to run test checkpoint
 # upgrade/downgrade test.
-export TEST_CHECKPOINT_RELEASE_BRANCHES="develop mongodb-8.2 mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-5.0 mongodb-4.4"
+export TEST_CHECKPOINT_RELEASE_BRANCHES="develop mongodb-8.3 mongodb-8.2 mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-5.0 mongodb-4.4"
 
 # This array is used to configure the release branches we'd like to run upgrade to latest test.
-export UPGRADE_TO_LATEST_UPGRADE_DOWNGRADE_RELEASE_BRANCHES="mongodb-8.2 mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-5.0 mongodb-4.4"
+export UPGRADE_TO_LATEST_UPGRADE_DOWNGRADE_RELEASE_BRANCHES="mongodb-8.3 mongodb-8.2 mongodb-8.0 mongodb-7.0 mongodb-6.0 mongodb-5.0 mongodb-4.4"

--- a/test/evergreen_develop.yml
+++ b/test/evergreen_develop.yml
@@ -71,7 +71,7 @@ buildvariants:
   - ubuntu2004-test
   expansions:
     ENABLE_TCMALLOC: 0
-    doc_update_branches: develop,mongodb-8.0,mongodb-7.0,mongodb-6.0,mongodb-5.0,mongodb-4.4,mongodb-4.2
+    doc_update_branches: develop,mongodb-8.3,mongodb-8.2,mongodb-8.0,mongodb-7.0,mongodb-6.0,mongodb-5.0,mongodb-4.4,mongodb-4.2
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
   tasks:
     - name: doc-update


### PR DESCRIPTION
## Summary
- Add `mongodb-8.3` branch to all compatibility test branch lists in `versions.sh`
- Add `mongodb-8.3` to `bflag()` and `gittags` in `compatibility_test_for_releases.sh`
- Add `mongodb-8.3` and `mongodb-8.2` to `doc_update_branches` in `evergreen_develop.yml`

## Test plan
- [x] Verify compatibility tests run against the `mongodb-8.3` branch
- [ ] Check that `doc-update` task in Evergreen picks up the new branches (post merge)

Generated with [Claude Code](https://claude.com/claude-code)