### PR TITLE
WT-16970 Bug fix for prefetch configuration not being processed properly

### DIFF
--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -480,16 +480,11 @@ __session_config_prefetch(WT_SESSION_IMPL *session, WT_CONF *conf)
 {
     WT_CONFIG_ITEM cval;
 
-    if (S2C(session)->prefetch_auto_on)
-        F_SET(session, WT_SESSION_PREFETCH_ENABLED);
-    else
-        F_CLR(session, WT_SESSION_PREFETCH_ENABLED);
-
     /*
      * Override any connection-level pre-fetch settings if a specific session-level setting was
      * provided.
      */
-    if (__wt_conf_gets(session, conf, Prefetch.enabled, &cval) == 0) {
+    if (__wt_conf_getones(session, conf, Prefetch.enabled, &cval) == 0) {
         if (cval.val) {
             if (!S2C(session)->prefetch_available) {
                 F_CLR(session, WT_SESSION_PREFETCH_ENABLED);
@@ -2676,6 +2671,9 @@ __open_session(WT_CONNECTION_IMPL *conn, WT_EVENT_HANDLER *event_handler, const 
     /* Set the default value for session flags. */
     if (F_ISSET(conn, WT_CONN_CACHE_CURSORS))
         F_SET(session_ret, WT_SESSION_CACHE_CURSORS);
+
+    if (conn->prefetch_auto_on)
+        F_SET(session_ret, WT_SESSION_PREFETCH_ENABLED);
 
     /*
      * Configuration: currently, the configuration for open_session is the same as

--- a/test/suite/test_prefetch02.py
+++ b/test/suite/test_prefetch02.py
@@ -56,6 +56,8 @@ class test_prefetch02(wttest.WiredTigerTestCase, suite_subprocess):
                             session_cfg='prefetch=(enabled=true)', prefetch=True)),
         ('config_c', dict(conn_cfg='prefetch=(available=false,default=false),statistics=(all),cache_size=2GB',
                             session_cfg='', prefetch=False)),
+        ('config_d', dict(conn_cfg='prefetch=(available=true,default=true),statistics=(all),cache_size=2GB',
+                            session_cfg=None, prefetch=True)),
     ]
 
     prefetch_scenarios = [
@@ -86,6 +88,11 @@ class test_prefetch02(wttest.WiredTigerTestCase, suite_subprocess):
     def check_prefetching_activity(self, session_name, pages_queued, prefetch_attempts, prefetch_pages_read):
         new_pages_queued, new_prefetch_attempts, new_prefetch_pages_read = self.get_prefetch_activity_stats(session_name)
 
+        # Sanity check that the statistics aren't 0.
+        self.assertGreater(new_pages_queued, 0)
+        self.assertGreater(new_prefetch_attempts, 0)
+        self.assertGreater(new_prefetch_pages_read, 0)
+
         # FIXME-WT-12193 Change some of these statistic checks to use assertGreaterEqual instead if possible.
         self.assertGreaterEqual(new_pages_queued, pages_queued)
         self.assertGreaterEqual(new_prefetch_attempts, prefetch_attempts)
@@ -105,8 +112,8 @@ class test_prefetch02(wttest.WiredTigerTestCase, suite_subprocess):
         os.mkdir(self.new_dir)
         helper.copy_wiredtiger_home(self, '.', self.new_dir)
 
-        new_conn = self.wiredtiger_open(self.new_dir, self.conn_cfg)
-        s = new_conn.open_session(self.session_cfg)
+        setup_conn = self.wiredtiger_open(self.new_dir, self.conn_cfg)
+        s = setup_conn.open_session(self.session_cfg)
         s.create(self.uri, 'allocation_size=512,leaf_page_max=512,'
                         'key_format={},value_format={}'.format(self.key_format, self.value_format))
         c1 = s.open_cursor(self.uri)
@@ -116,6 +123,11 @@ class test_prefetch02(wttest.WiredTigerTestCase, suite_subprocess):
         c1.close()
         s.commit_transaction()
         s.checkpoint()
+
+        setup_conn.close()
+
+        new_conn = self.wiredtiger_open(self.new_dir, self.conn_cfg)
+        s = new_conn.open_session(self.session_cfg)
 
         if self.scenario_type == 'traversal':
             c2 = s.open_cursor(self.uri)


### PR DESCRIPTION
Added check before `__session_reconfigure` to use default prefetch conn configuration in case session `config == NULL`.
Changed `__session_config_prefetch` to only parse user specified config string (not auto compiled string) when overriding the default prefetch conn configuration.

Adjusted `test_prefetch04.py` to check that any prefetching was actually done.
Added test case to `test_prefetch04.py` to test for a `NULL` session config.