### PR TITLE
WT-15369 disagg: Fix layered python tests cursor13, cursor21 that fail stats check

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -689,7 +689,8 @@ connection_runtime_config = [
             if true, for operations with snapshot isolation the cursor temporarily releases any page
             that requires force eviction, then repositions back to the page for further operations.
             A page release encourages eviction of hot or large pages, which is more likely to
-            succeed without a cursor keeping the page pinned.''',
+            succeed without a cursor keeping the page pinned. Note: This setting is not compatible
+            with disaggregated storage.''',
             type='boolean'),
         Config('disagg_address_cookie_upgrade', 'none', r'''
             modify the disaggregated block manager to pretend that it is a newer version to test

--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -649,6 +649,10 @@ __wt_conn_dhandle_open(WT_SESSION_IMPL *session, const char *cfg[], uint32_t fla
         WT_ERR(__wt_btree_open(session, cfg));
         break;
     case WT_DHANDLE_TYPE_LAYERED:
+        /* Layered cursor operations maintain data-source statistics on the layered handle. */
+        if (dhandle->stat_array == NULL)
+            WT_ERR(__wt_stat_dsrc_init(session, dhandle));
+
         WT_ERR(__wt_schema_open_layered(session));
         break;
     case WT_DHANDLE_TYPE_TABLE:

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -2744,6 +2744,9 @@ __wt_clayered_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, 
     if (cval.val != 0)
         WT_RET_MSG(session, EINVAL, "Layered trees do not support bulk loading");
 
+    if (FLD_ISSET(S2C(session)->debug_flags, WT_CONN_DEBUG_CURSOR_REPOSITION))
+        WT_RET_MSG(session, EINVAL, "Layered trees do not support cursor reposition");
+
     /* Get the layered tree, and hold a reference to it until the cursor is closed. */
     WT_RET(__wt_session_get_dhandle(session, uri, NULL, cfg, 0));
 

--- a/src/cursor/cur_stat.c
+++ b/src/cursor/cur_stat.c
@@ -425,6 +425,15 @@ __curstat_layered_init(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR_STAT
 
     __wt_stat_dsrc_init_single(&cst->u.dsrc_stats);
 
+    /*
+     * Layered cursor operations are recorded on the layered handle itself rather than one of its
+     * constituent tables, so include the layered dhandle stats before aggregating the stable and
+     * ingest constituents.
+     */
+    __wt_stat_dsrc_aggregate(dhandle->stats, &cst->u.dsrc_stats);
+    if (F_ISSET(cst, WT_STAT_CLEAR))
+        __wt_stat_dsrc_clear_all(dhandle->stats);
+
     /* Do the ingest table. */
     WT_ERR(__wt_session_get_dhandle(session, layered->ingest_uri, NULL, NULL, 0));
     WT_ERR(__init_layered_constituent_stats(session, cst));

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -2229,11 +2229,12 @@ struct __wt_connection {
      * isolation the cursor temporarily releases any page that requires force eviction\, then
      * repositions back to the page for further operations.  A page release encourages eviction of
      * hot or large pages\, which is more likely to succeed without a cursor keeping the page
-     * pinned., a boolean flag; default \c false.}
-     * @config{&nbsp;&nbsp;&nbsp;&nbsp;eviction, if
-     * true\, modify internal algorithms to change skew to force history store eviction to happen
-     * more aggressively.  This includes but is not limited to not skewing newest\, not favoring
-     * leaf pages\, and modifying the eviction score mechanism., a boolean flag; default \c false.}
+     * pinned.  Note: This setting is not compatible with disaggregated storage., a boolean flag;
+     * default \c false.}
+     * @config{&nbsp;&nbsp;&nbsp;&nbsp;eviction, if true\, modify internal
+     * algorithms to change skew to force history store eviction to happen more aggressively.  This
+     * includes but is not limited to not skewing newest\, not favoring leaf pages\, and modifying
+     * the eviction score mechanism., a boolean flag; default \c false.}
      * @config{&nbsp;&nbsp;&nbsp;&nbsp;eviction_checkpoint_ts_ordering, if true\, act as if eviction
      * is being run in parallel to checkpoint.  We should return EBUSY in eviction if we detect any
      * timestamp ordering issue., a boolean flag; default \c false.}
@@ -3142,26 +3143,27 @@ struct __wt_connection {
  * cursor_reposition, if true\, for operations with snapshot isolation the cursor temporarily
  * releases any page that requires force eviction\, then repositions back to the page for further
  * operations.  A page release encourages eviction of hot or large pages\, which is more likely to
- * succeed without a cursor keeping the page pinned., a boolean flag; default \c false.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;eviction, if true\, modify internal algorithms to change skew to
- * force history store eviction to happen more aggressively.  This includes but is not limited to
- * not skewing newest\, not favoring leaf pages\, and modifying the eviction score mechanism., a
- * boolean flag; default \c false.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;eviction_checkpoint_ts_ordering,
- * if true\, act as if eviction is being run in parallel to checkpoint.  We should return EBUSY in
- * eviction if we detect any timestamp ordering issue., a boolean flag; default \c false.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;log_retention, adjust log removal to retain at least this number
- * of log files.  (Warning: this option can remove log files required for recovery if no checkpoints
- * have yet been done and the number of log files exceeds the configured value.  As WiredTiger
- * cannot detect the difference between a system that has not yet checkpointed and one that will
- * never checkpoint\, it might discard log files before any checkpoint is done.) Ignored if set to
- * 0., an integer between \c 0 and \c 1024; default \c 0.}
+ * succeed without a cursor keeping the page pinned.  Note: This setting is not compatible with
+ * disaggregated storage., a boolean flag; default \c false.}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;
- * realloc_exact, if true\, reallocation of memory will only provide the exact amount requested.
- * This will help with spotting memory allocation issues more easily., a boolean flag; default \c
- * false.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;realloc_malloc, if true\, every realloc call will force a
- * new memory allocation by using malloc., a boolean flag; default \c false.}
+ * eviction, if true\, modify internal algorithms to change skew to force history store eviction to
+ * happen more aggressively.  This includes but is not limited to not skewing newest\, not favoring
+ * leaf pages\, and modifying the eviction score mechanism., a boolean flag; default \c false.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;eviction_checkpoint_ts_ordering, if true\, act as if eviction is
+ * being run in parallel to checkpoint.  We should return EBUSY in eviction if we detect any
+ * timestamp ordering issue., a boolean flag; default \c false.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;
+ * log_retention, adjust log removal to retain at least this number of log files.  (Warning: this
+ * option can remove log files required for recovery if no checkpoints have yet been done and the
+ * number of log files exceeds the configured value.  As WiredTiger cannot detect the difference
+ * between a system that has not yet checkpointed and one that will never checkpoint\, it might
+ * discard log files before any checkpoint is done.) Ignored if set to 0., an integer between \c 0
+ * and \c 1024; default \c 0.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;realloc_exact, if true\, reallocation
+ * of memory will only provide the exact amount requested.  This will help with spotting memory
+ * allocation issues more easily., a boolean flag; default \c false.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;realloc_malloc, if true\, every realloc call will force a new
+ * memory allocation by using malloc., a boolean flag; default \c false.}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;rollback_error, return a WT_ROLLBACK error from a transaction
  * operation about every Nth operation to simulate a collision., an integer between \c 0 and \c 10M;
  * default \c 0.}

--- a/test/format/format_config.c
+++ b/test/format/format_config.c
@@ -1463,6 +1463,10 @@ config_disagg_storage(void)
     config_off(NULL, "ops.compaction");
     config_off(NULL, "background_compact");
 
+    /* Cursor reposition is not supported for disaggregated storage. */
+    config_off(NULL, "debug.cursor_reposition");
+    config_off(NULL, "stress.evict_reposition");
+
     /*  Tiered storage is not supported with disagg */
     config_single(NULL, "tiered_storage.storage_source=off", true);
 }

--- a/test/suite/hook_disagg.fail
+++ b/test/suite/hook_disagg.fail
@@ -5,8 +5,6 @@ test_autoclose.py
 test_checkpoint06.py # FIXME: WT-15507
 test_config02.py
 test_config09.py
-test_cursor13.py  # FIXME: WT-15369
-test_cursor21.py  # FIXME: WT-15369
 test_cursor_random.py # FIXME: WT-15189
 test_drop03.py
 test_dump.py

--- a/test/suite/test_cursor13.py
+++ b/test/suite/test_cursor13.py
@@ -78,7 +78,14 @@ class test_cursor13_base(wttest.WiredTigerTestCase):
                 hs_after[0] += hs_disagg_stat_after[stat.dsrc.cursor_cache][2]
                 hs_after[1] += hs_disagg_stat_after[stat.dsrc.cursor_reopen][2]
 
-                self.pr(str(totals[0]) + " " + str(hs_before[0]) + " " + str(hs_disagg_stat_before[stat.dsrc.cursor_cache][2]) + " " + str(hs_stats_before[stat.dsrc.cursor_cache][2]))
+                report = [totals[0],
+                          hs_before[0],
+                          hs_disagg_stat_before[stat.dsrc.cursor_cache][2],
+                          hs_stats_before[stat.dsrc.cursor_cache][2]]
+                self.pr(' '.join(map(str, report)))
+
+                hs_disagg_stat_before.close()
+                hs_disagg_stat_after.close()
 
             hs_stats_before.close()
             hs_stats_after.close()
@@ -511,6 +518,7 @@ class test_cursor13_big(test_cursor13_big_base):
         self.assertEqual(end_stats[0] - begin_stats[0], self.closecount)
         self.assertEqual(end_stats[1] - begin_stats[1], self.opencount)
 
+@wttest.skip_for_hook("disagg", "layered dhandles are never swept: FIXME-WT-16982")
 class test_cursor13_sweep(test_cursor13_big_base):
     # Set dhandle sweep configuration so that dhandles should be closed within
     # two seconds of all the cursors for the dhandle being closed (cached).

--- a/test/suite/test_cursor21.py
+++ b/test/suite/test_cursor21.py
@@ -31,7 +31,7 @@
 
 import wttest
 from wtscenario import make_scenarios
-from wiredtiger import stat
+from wiredtiger import stat, WiredTigerError
 
 class test_cursor21(wttest.WiredTigerTestCase):
     uri = "table:test_cursor21"
@@ -71,6 +71,7 @@ class test_cursor21(wttest.WiredTigerTestCase):
             self.assertEqual(reposition_count, 0)
         return reposition_count
 
+    @wttest.skip_for_hook("disagg", "layered tables don't support cursor reposition")
     def test_cursor21(self):
         format = 'key_format={},value_format={}'.format(self.key_format, self.value_format)
         reposition_count = 0
@@ -125,3 +126,15 @@ class test_cursor21(wttest.WiredTigerTestCase):
         reposition_count += self.check_reposition(reposition_count)
         cursor.close()
         self.session.close()
+
+    @wttest.only_for_hook("disagg", "check reposition is disabled for disaggregated storage")
+    def test_cursor21_dsc(self):
+        # Skip the test if reposition is disabled or it's column store (unsupported in disagg).
+        if not self.reposition or self.scenario_name == 'column.reposition':
+            return
+
+        format = 'key_format={},value_format={}'.format(self.key_format, self.value_format)
+        self.session.create(self.uri, format)
+        msg = '/Invalid argument/'
+        self.assertRaisesWithMessage(WiredTigerError,
+            lambda: self.session.open_cursor(self.uri), msg)


### PR DESCRIPTION
- Disable repositioning for layered cursors.
- Add a test to check that opening a layered cursor with repositioning enabled fails with the expected error.