### PR TITLE
WT-16531 Fix ingest btree garbage collection on the update list not clearing the on-page value

### DIFF
--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -1226,7 +1226,7 @@ __rec_upd_select_inmem(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_CELL_UNPAC
     if (max_ts > r->max_ts)
         r->max_ts = max_ts;
 
-    if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT) && !*has_newer_updatesp && upd_select->upd == NULL)
+    if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT) && upd_select->upd == &upd_tombstone)
         WT_STAT_CONN_DSRC_INCR(session, rec_ingest_garbage_collection_keys_update_chain);
 
     return (0);

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -1226,7 +1226,9 @@ __rec_upd_select_inmem(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_CELL_UNPAC
     if (max_ts > r->max_ts)
         r->max_ts = max_ts;
 
-    if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT) && upd_select->upd == &upd_tombstone)
+    if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT) &&
+      (upd_select->upd == &upd_tombstone ||
+        (!*has_newer_updatesp && upd_select->upd == NULL && !WT_REC_HAS_ON_DISK(vpack))))
         WT_STAT_CONN_DSRC_INCR(session, rec_ingest_garbage_collection_keys_update_chain);
 
     return (0);

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -1206,7 +1206,7 @@ __rec_upd_select_inmem(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_CELL_UNPAC
      * If there's an on-page value, we only want to write upd_select if the oldest update is
      * globally visible, otherwise we will lose the on-page update. Check if there's an on-page
      * update and reset upd_select if the update is not visible.
-     * 
+     *
      * If we want to prune the entire key, don't reset upd_select.
      */
     if (WT_REC_HAS_ON_DISK(vpack) && !found_last_upd_to_keep && first_pruned_update == NULL) {

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -1227,8 +1227,7 @@ __rec_upd_select_inmem(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_CELL_UNPAC
         r->max_ts = max_ts;
 
     if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT) &&
-      (upd_select->upd == &upd_tombstone ||
-        (!*has_newer_updatesp && upd_select->upd == NULL && !WT_REC_HAS_ON_DISK(vpack))))
+      (upd_select->upd == &upd_tombstone || (!*has_newer_updatesp && upd_select->upd == NULL)))
         WT_STAT_CONN_DSRC_INCR(session, rec_ingest_garbage_collection_keys_update_chain);
 
     return (0);

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -1207,7 +1207,7 @@ __rec_upd_select_inmem(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_CELL_UNPAC
      * globally visible, otherwise we will lose the on-page update. Check if there's an on-page
      * update and reset upd_select if the update is not visible.
      *
-     * If we want to prune the entire key, don't reset upd_select.
+     * If the goal is to prune the entire key, avoid resetting upd_select.
      */
     if (WT_REC_HAS_ON_DISK(vpack) && !found_last_upd_to_keep && first_pruned_update == NULL) {
         *has_newer_updatesp |= (upd_select->upd != NULL);

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -1045,6 +1045,7 @@ __rec_upd_select_inmem(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_CELL_UNPAC
   WT_UPDATE *first_upd, WTI_UPDATE_SELECT *upd_select, WT_UPDATE **first_txn_updp,
   bool *has_newer_updatesp, size_t *upd_memsizep)
 {
+    static WT_UPDATE upd_tombstone = {.txnid = WT_TXN_NONE, .type = WT_UPDATE_TOMBSTONE};
     WT_BTREE *btree;
     WT_UPDATE *upd, *first_pruned_update;
     wt_timestamp_t max_ts;
@@ -1191,6 +1192,12 @@ __rec_upd_select_inmem(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_CELL_UNPAC
         } else if (first_pruned_update != NULL) {
             if (*first_txn_updp != first_pruned_update)
                 *has_newer_updatesp = true;
+            else if (WT_REC_HAS_ON_DISK(vpack))
+                /*
+                 * If we choose to garbage collect the key and it has an associated on-page value,
+                 * ensure that the on-page value is forcefully deleted as well.
+                 */
+                upd_select->upd = &upd_tombstone;
         } else
             *has_newer_updatesp = true;
     }
@@ -1199,8 +1206,10 @@ __rec_upd_select_inmem(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_CELL_UNPAC
      * If there's an on-page value, we only want to write upd_select if the oldest update is
      * globally visible, otherwise we will lose the on-page update. Check if there's an on-page
      * update and reset upd_select if the update is not visible.
+     * 
+     * If we want to prune the entire key, don't reset upd_select.
      */
-    if (WT_REC_HAS_ON_DISK(vpack) && !found_last_upd_to_keep) {
+    if (WT_REC_HAS_ON_DISK(vpack) && !found_last_upd_to_keep && first_pruned_update == NULL) {
         *has_newer_updatesp |= (upd_select->upd != NULL);
         upd_select->upd = NULL;
     }

--- a/test/suite/test_layered79.py
+++ b/test/suite/test_layered79.py
@@ -206,7 +206,7 @@ class test_layered79(wttest.WiredTigerTestCase):
         """
         Scenario:
           ts=10  insert key 1  -> eviction -> key is on disk image
-          ts=0  delete key 1
+          ts=0   delete key 1
           advance checkpoint   -> insert is not prunable
           eviction             -> GC path must write tombstone to clear on-disk entry
           verify               -> key 1 must NOT be found

--- a/test/suite/test_layered79.py
+++ b/test/suite/test_layered79.py
@@ -206,8 +206,9 @@ class test_layered79(wttest.WiredTigerTestCase):
         """
         Scenario:
           ts=10  insert key 1  -> eviction -> key is on disk image
-          ts=0  delete key 1   -> eviction -> delete on the ingest btree on follower
+          ts=0  delete key 1
           advance checkpoint   -> insert is not prunable
+          eviction             -> GC path must write tombstone to clear on-disk entry
           verify               -> key 1 must NOT be found
         """
         self.create_follower()

--- a/test/suite/test_layered79.py
+++ b/test/suite/test_layered79.py
@@ -33,6 +33,7 @@
 import wiredtiger, wttest
 from helper_disagg import disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
+from wiredtiger import stat
 
 @disagg_test_class
 class test_layered79(wttest.WiredTigerTestCase):
@@ -65,9 +66,6 @@ class test_layered79(wttest.WiredTigerTestCase):
           verify               -> key 1 must NOT be found
         """
         self.create_follower()
-
-        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(1)}')
-        self.conn_follow.set_timestamp(f'stable_timestamp={self.timestamp_str(1)}')
 
         self.session.create(self.uri, self.create_config)
         self.session_follow.create(self.uri, self.create_config)
@@ -126,6 +124,10 @@ class test_layered79(wttest.WiredTigerTestCase):
         self.assertEqual(cursor_check.search(), wiredtiger.WT_NOTFOUND)
         cursor_check.close()
 
+        stat_cursor = self.session_follow.open_cursor('statistics:' + self.uri)
+        garbage_collected = stat_cursor[stat.dsrc.rec_ingest_garbage_collection_keys_update_chain][2]
+        self.assertEqual(garbage_collected, 1)
+
     def test_deleted_key_on_disk_value_removed_after_gc(self):
         """
         Scenario:
@@ -136,9 +138,6 @@ class test_layered79(wttest.WiredTigerTestCase):
           verify               -> key 1 must NOT be found
         """
         self.create_follower()
-
-        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(1)}')
-        self.conn_follow.set_timestamp(f'stable_timestamp={self.timestamp_str(1)}')
 
         self.session.create(self.uri, self.create_config)
         self.session_follow.create(self.uri, self.create_config)
@@ -198,3 +197,7 @@ class test_layered79(wttest.WiredTigerTestCase):
         cursor_check.set_key(1)
         self.assertEqual(cursor_check.search(), wiredtiger.WT_NOTFOUND)
         cursor_check.close()
+
+        stat_cursor = self.session_follow.open_cursor('statistics:' + self.uri)
+        garbage_collected = stat_cursor[stat.dsrc.rec_ingest_garbage_collection_keys_update_chain][2]
+        self.assertEqual(garbage_collected, 1)

--- a/test/suite/test_layered79.py
+++ b/test/suite/test_layered79.py
@@ -163,7 +163,7 @@ class test_layered79(wttest.WiredTigerTestCase):
         evict_cursor.search()
         evict_cursor.close()
 
-        # --- Step 3: update key 1 at ts=20, propagate to follower ---
+        # --- Step 3: remove key 1 at ts=20, propagate to follower ---
         cursor = self.session.open_cursor(self.uri)
         self.session.begin_transaction()
         cursor.set_key(1)
@@ -171,7 +171,7 @@ class test_layered79(wttest.WiredTigerTestCase):
         self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(20)}')
         cursor.close()
 
-        # Mirror the update on the follower.
+        # Mirror the remove on the follower.
         cursor_follow = self.session_follow.open_cursor(self.uri)
         self.session_follow.begin_transaction()
         cursor_follow.set_key(1)
@@ -201,3 +201,72 @@ class test_layered79(wttest.WiredTigerTestCase):
         stat_cursor = self.session_follow.open_cursor('statistics:' + self.uri)
         garbage_collected = stat_cursor[stat.dsrc.rec_ingest_garbage_collection_keys_update_chain][2]
         self.assertEqual(garbage_collected, 1)
+
+    def test_global_visible_tombstone_clears_update_chain_and_on_disk_value(self):
+        """
+        Scenario:
+          ts=10  insert key 1  -> eviction -> key is on disk image
+          ts=0  delete key 1   -> eviction -> delete on the ingest btree on follower
+          advance checkpoint   -> insert is not prunable
+          verify               -> key 1 must NOT be found
+        """
+        self.create_follower()
+
+        self.session.create(self.uri, self.create_config)
+        self.session_follow.create(self.uri, self.create_config)
+
+        # --- Step 1: insert key 1 at ts=10, propagate to follower ---
+        cursor = self.session.open_cursor(self.uri)
+        self.session.begin_transaction()
+        cursor[1] = 'value1'
+        self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(10)}')
+        cursor.close()
+
+        # Mirror the insert on the follower ingest btree.
+        cursor_follow = self.session_follow.open_cursor(self.uri)
+        self.session_follow.begin_transaction()
+        cursor_follow[1] = 'value1'
+        self.session_follow.commit_transaction(f'commit_timestamp={self.timestamp_str(10)}')
+        cursor_follow.close()
+
+        # --- Step 2: force eviction of key 1 on the follower to build a disk image ---
+        session_evict = self.conn_follow.open_session('debug=(release_evict_page)')
+        evict_cursor = session_evict.open_cursor(self.uri)
+        evict_cursor.set_key(1)
+        evict_cursor.search()
+        evict_cursor.close()
+
+        # --- Step 3: remove key 1 at ts=0 on the ingest btree on follower ---
+        cursor_follow_ingest = self.session_follow.open_cursor(self.ingest_uri)
+        self.session_follow.begin_transaction('no_timestamp=true')
+        cursor_follow_ingest.set_key(1)
+        cursor_follow_ingest.remove()
+        self.session_follow.commit_transaction()
+        cursor_follow_ingest.close()
+
+        # Ensure the on-page value is not prnable
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(1)}')
+        self.conn_follow.set_timestamp(f'stable_timestamp={self.timestamp_str(1)}')
+
+        self.session.checkpoint()
+        self.disagg_advance_checkpoint(self.conn_follow)
+
+        # --- Step 4: force eviction of key 1 on the follower ---
+        evict_cursor = session_evict.open_cursor(self.uri)
+        evict_cursor.set_key(1)
+        evict_cursor.search()
+        evict_cursor.close()
+        session_evict.close()
+
+        # --- Step 5: verify key 1 is not visible in the ingest btree after GC ---
+        cursor_check = self.session_follow.open_cursor(self.ingest_uri)
+        cursor_check.set_key(1)
+        self.assertEqual(cursor_check.search(), wiredtiger.WT_NOTFOUND)
+        cursor_check.close()
+
+        stat_cursor = self.session_follow.open_cursor('statistics:' + self.uri)
+        garbage_collected = stat_cursor[stat.dsrc.rec_ingest_garbage_collection_keys_update_chain][2]
+        self.assertEqual(garbage_collected, 1)
+
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(10)}')
+        self.conn_follow.set_timestamp(f'stable_timestamp={self.timestamp_str(10)}')

--- a/test/suite/test_layered79.py
+++ b/test/suite/test_layered79.py
@@ -55,76 +55,76 @@ class test_layered79(wttest.WiredTigerTestCase):
                                                 self.conn_config_follower)
         self.session_follow = self.conn_follow.open_session()
 
-    # def test_updated_key_on_disk_value_removed_after_gc(self):
-    #     """
-    #     Scenario:
-    #       ts=10  insert key 1  -> eviction -> key is on disk image
-    #       ts=20  update key 1  -> checkpoint -> update propagated to follower
-    #       advance checkpoint   -> update is prunable
-    #       eviction             -> GC path must write tombstone to clear on-disk entry
-    #       verify               -> key 1 must NOT be found
-    #     """
-    #     self.create_follower()
+    def test_updated_key_on_disk_value_removed_after_gc(self):
+        """
+        Scenario:
+          ts=10  insert key 1  -> eviction -> key is on disk image
+          ts=20  update key 1  -> checkpoint -> update propagated to follower
+          advance checkpoint   -> update is prunable
+          eviction             -> GC path must write tombstone to clear on-disk entry
+          verify               -> key 1 must NOT be found
+        """
+        self.create_follower()
 
-    #     self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(1)}')
-    #     self.conn_follow.set_timestamp(f'stable_timestamp={self.timestamp_str(1)}')
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(1)}')
+        self.conn_follow.set_timestamp(f'stable_timestamp={self.timestamp_str(1)}')
 
-    #     self.session.create(self.uri, self.create_config)
-    #     self.session_follow.create(self.uri, self.create_config)
+        self.session.create(self.uri, self.create_config)
+        self.session_follow.create(self.uri, self.create_config)
 
-    #     # --- Step 1: insert key 1 at ts=10, propagate to follower ---
-    #     cursor = self.session.open_cursor(self.uri)
-    #     self.session.begin_transaction()
-    #     cursor[1] = 'value1'
-    #     self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(10)}')
-    #     cursor.close()
+        # --- Step 1: insert key 1 at ts=10, propagate to follower ---
+        cursor = self.session.open_cursor(self.uri)
+        self.session.begin_transaction()
+        cursor[1] = 'value1'
+        self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(10)}')
+        cursor.close()
 
-    #     # Mirror the insert on the follower ingest layer.
-    #     cursor_follow = self.session_follow.open_cursor(self.uri)
-    #     self.session_follow.begin_transaction()
-    #     cursor_follow[1] = 'value1'
-    #     self.session_follow.commit_transaction(f'commit_timestamp={self.timestamp_str(10)}')
-    #     cursor_follow.close()
+        # Mirror the insert on the follower ingest btree.
+        cursor_follow = self.session_follow.open_cursor(self.uri)
+        self.session_follow.begin_transaction()
+        cursor_follow[1] = 'value1'
+        self.session_follow.commit_transaction(f'commit_timestamp={self.timestamp_str(10)}')
+        cursor_follow.close()
 
-    #     # --- Step 2: force eviction of key 1 on the follower to build a disk image ---
-    #     session_evict = self.conn_follow.open_session('debug=(release_evict_page)')
-    #     evict_cursor = session_evict.open_cursor(self.uri)
-    #     evict_cursor.set_key(1)
-    #     evict_cursor.search()
-    #     evict_cursor.close()
+        # --- Step 2: force eviction of key 1 on the follower to build a disk image ---
+        session_evict = self.conn_follow.open_session('debug=(release_evict_page)')
+        evict_cursor = session_evict.open_cursor(self.uri)
+        evict_cursor.set_key(1)
+        evict_cursor.search()
+        evict_cursor.close()
 
-    #     # --- Step 3: update key 1 at ts=20, propagate to follower ---
-    #     cursor = self.session.open_cursor(self.uri)
-    #     self.session.begin_transaction()
-    #     cursor[1] = 'value2'
-    #     self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(20)}')
-    #     cursor.close()
+        # --- Step 3: update key 1 at ts=20, propagate to follower ---
+        cursor = self.session.open_cursor(self.uri)
+        self.session.begin_transaction()
+        cursor[1] = 'value2'
+        self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(20)}')
+        cursor.close()
 
-    #     # Mirror the update on the follower.
-    #     cursor_follow = self.session_follow.open_cursor(self.uri)
-    #     self.session_follow.begin_transaction()
-    #     cursor_follow[1] = 'value2'
-    #     self.session_follow.commit_transaction(f'commit_timestamp={self.timestamp_str(20)}')
-    #     cursor_follow.close()
+        # Mirror the update on the follower.
+        cursor_follow = self.session_follow.open_cursor(self.uri)
+        self.session_follow.begin_transaction()
+        cursor_follow[1] = 'value2'
+        self.session_follow.commit_transaction(f'commit_timestamp={self.timestamp_str(20)}')
+        cursor_follow.close()
 
-    #     self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(20)}')
-    #     self.conn_follow.set_timestamp(f'stable_timestamp={self.timestamp_str(20)}')
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(20)}')
+        self.conn_follow.set_timestamp(f'stable_timestamp={self.timestamp_str(20)}')
 
-    #     self.session.checkpoint()
-    #     self.disagg_advance_checkpoint(self.conn_follow)
+        self.session.checkpoint()
+        self.disagg_advance_checkpoint(self.conn_follow)
 
-    #     # --- Step 4: force eviction of key 1 on the follower ---
-    #     evict_cursor = session_evict.open_cursor(self.uri)
-    #     evict_cursor.set_key(1)
-    #     evict_cursor.search()
-    #     evict_cursor.close()
-    #     session_evict.close()
+        # --- Step 4: force eviction of key 1 on the follower ---
+        evict_cursor = session_evict.open_cursor(self.uri)
+        evict_cursor.set_key(1)
+        evict_cursor.search()
+        evict_cursor.close()
+        session_evict.close()
 
-    #     # --- Step 5: verify key 1 is not visible in the ingest layer after GC ---
-    #     cursor_check = self.session_follow.open_cursor(self.ingest_uri)
-    #     cursor_check.set_key(1)
-    #     self.assertEqual(cursor_check.search(), wiredtiger.WT_NOTFOUND)
-    #     cursor_check.close()
+        # --- Step 5: verify key 1 is not visible in the ingest btree after GC ---
+        cursor_check = self.session_follow.open_cursor(self.ingest_uri)
+        cursor_check.set_key(1)
+        self.assertEqual(cursor_check.search(), wiredtiger.WT_NOTFOUND)
+        cursor_check.close()
 
     def test_deleted_key_on_disk_value_removed_after_gc(self):
         """
@@ -150,7 +150,7 @@ class test_layered79(wttest.WiredTigerTestCase):
         self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(10)}')
         cursor.close()
 
-        # Mirror the insert on the follower ingest layer.
+        # Mirror the insert on the follower ingest btree.
         cursor_follow = self.session_follow.open_cursor(self.uri)
         self.session_follow.begin_transaction()
         cursor_follow[1] = 'value1'
@@ -193,7 +193,7 @@ class test_layered79(wttest.WiredTigerTestCase):
         evict_cursor.close()
         session_evict.close()
 
-        # --- Step 5: verify key 1 is not visible in the ingest layer after GC ---
+        # --- Step 5: verify key 1 is not visible in the ingest btree after GC ---
         cursor_check = self.session_follow.open_cursor(self.ingest_uri)
         cursor_check.set_key(1)
         self.assertEqual(cursor_check.search(), wiredtiger.WT_NOTFOUND)

--- a/test/suite/test_layered79.py
+++ b/test/suite/test_layered79.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# test_layered79.py
+#   Test that when a key is garbage collected during eviction on an ingest
+#   btree, its associated on-disk value is also deleted.
+
+import wiredtiger, wttest
+from helper_disagg import disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
+
+@disagg_test_class
+class test_layered79(wttest.WiredTigerTestCase):
+    base_config = 'statistics=(all),precise_checkpoint=true,'
+    conn_config = base_config + 'disaggregated=(role="leader")'
+    conn_config_follower = base_config + 'disaggregated=(role="follower")'
+
+    uri = 'layered:test_layered79'
+    ingest_uri = 'file:test_layered79.wt_ingest'
+    create_config = 'key_format=i,value_format=S'
+
+    disagg_storages = gen_disagg_storages('test_layered79', disagg_only=True)
+    scenarios = make_scenarios(disagg_storages)
+
+    conn_follow = None
+    session_follow = None
+
+    def create_follower(self):
+        self.conn_follow = self.wiredtiger_open('follower', self.extensionsConfig() + ',create,' +
+                                                self.conn_config_follower)
+        self.session_follow = self.conn_follow.open_session()
+
+    # def test_updated_key_on_disk_value_removed_after_gc(self):
+    #     """
+    #     Scenario:
+    #       ts=10  insert key 1  -> eviction -> key is on disk image
+    #       ts=20  update key 1  -> checkpoint -> update propagated to follower
+    #       advance checkpoint   -> update is prunable
+    #       eviction             -> GC path must write tombstone to clear on-disk entry
+    #       verify               -> key 1 must NOT be found
+    #     """
+    #     self.create_follower()
+
+    #     self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(1)}')
+    #     self.conn_follow.set_timestamp(f'stable_timestamp={self.timestamp_str(1)}')
+
+    #     self.session.create(self.uri, self.create_config)
+    #     self.session_follow.create(self.uri, self.create_config)
+
+    #     # --- Step 1: insert key 1 at ts=10, propagate to follower ---
+    #     cursor = self.session.open_cursor(self.uri)
+    #     self.session.begin_transaction()
+    #     cursor[1] = 'value1'
+    #     self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(10)}')
+    #     cursor.close()
+
+    #     # Mirror the insert on the follower ingest layer.
+    #     cursor_follow = self.session_follow.open_cursor(self.uri)
+    #     self.session_follow.begin_transaction()
+    #     cursor_follow[1] = 'value1'
+    #     self.session_follow.commit_transaction(f'commit_timestamp={self.timestamp_str(10)}')
+    #     cursor_follow.close()
+
+    #     # --- Step 2: force eviction of key 1 on the follower to build a disk image ---
+    #     session_evict = self.conn_follow.open_session('debug=(release_evict_page)')
+    #     evict_cursor = session_evict.open_cursor(self.uri)
+    #     evict_cursor.set_key(1)
+    #     evict_cursor.search()
+    #     evict_cursor.close()
+
+    #     # --- Step 3: update key 1 at ts=20, propagate to follower ---
+    #     cursor = self.session.open_cursor(self.uri)
+    #     self.session.begin_transaction()
+    #     cursor[1] = 'value2'
+    #     self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(20)}')
+    #     cursor.close()
+
+    #     # Mirror the update on the follower.
+    #     cursor_follow = self.session_follow.open_cursor(self.uri)
+    #     self.session_follow.begin_transaction()
+    #     cursor_follow[1] = 'value2'
+    #     self.session_follow.commit_transaction(f'commit_timestamp={self.timestamp_str(20)}')
+    #     cursor_follow.close()
+
+    #     self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(20)}')
+    #     self.conn_follow.set_timestamp(f'stable_timestamp={self.timestamp_str(20)}')
+
+    #     self.session.checkpoint()
+    #     self.disagg_advance_checkpoint(self.conn_follow)
+
+    #     # --- Step 4: force eviction of key 1 on the follower ---
+    #     evict_cursor = session_evict.open_cursor(self.uri)
+    #     evict_cursor.set_key(1)
+    #     evict_cursor.search()
+    #     evict_cursor.close()
+    #     session_evict.close()
+
+    #     # --- Step 5: verify key 1 is not visible in the ingest layer after GC ---
+    #     cursor_check = self.session_follow.open_cursor(self.ingest_uri)
+    #     cursor_check.set_key(1)
+    #     self.assertEqual(cursor_check.search(), wiredtiger.WT_NOTFOUND)
+    #     cursor_check.close()
+
+    def test_deleted_key_on_disk_value_removed_after_gc(self):
+        """
+        Scenario:
+          ts=10  insert key 1  -> eviction -> key is on disk image
+          ts=20  delete key 1  -> checkpoint -> delete propagated to follower
+          advance checkpoint   -> delete is prunable
+          eviction             -> GC path must write tombstone to clear on-disk entry
+          verify               -> key 1 must NOT be found
+        """
+        self.create_follower()
+
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(1)}')
+        self.conn_follow.set_timestamp(f'stable_timestamp={self.timestamp_str(1)}')
+
+        self.session.create(self.uri, self.create_config)
+        self.session_follow.create(self.uri, self.create_config)
+
+        # --- Step 1: insert key 1 at ts=10, propagate to follower ---
+        cursor = self.session.open_cursor(self.uri)
+        self.session.begin_transaction()
+        cursor[1] = 'value1'
+        self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(10)}')
+        cursor.close()
+
+        # Mirror the insert on the follower ingest layer.
+        cursor_follow = self.session_follow.open_cursor(self.uri)
+        self.session_follow.begin_transaction()
+        cursor_follow[1] = 'value1'
+        self.session_follow.commit_transaction(f'commit_timestamp={self.timestamp_str(10)}')
+        cursor_follow.close()
+
+        # --- Step 2: force eviction of key 1 on the follower to build a disk image ---
+        session_evict = self.conn_follow.open_session('debug=(release_evict_page)')
+        evict_cursor = session_evict.open_cursor(self.uri)
+        evict_cursor.set_key(1)
+        evict_cursor.search()
+        evict_cursor.close()
+
+        # --- Step 3: update key 1 at ts=20, propagate to follower ---
+        cursor = self.session.open_cursor(self.uri)
+        self.session.begin_transaction()
+        cursor.set_key(1)
+        cursor.remove()
+        self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(20)}')
+        cursor.close()
+
+        # Mirror the update on the follower.
+        cursor_follow = self.session_follow.open_cursor(self.uri)
+        self.session_follow.begin_transaction()
+        cursor_follow.set_key(1)
+        cursor_follow.remove()
+        self.session_follow.commit_transaction(f'commit_timestamp={self.timestamp_str(20)}')
+        cursor_follow.close()
+
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(20)}')
+        self.conn_follow.set_timestamp(f'stable_timestamp={self.timestamp_str(20)}')
+
+        self.session.checkpoint()
+        self.disagg_advance_checkpoint(self.conn_follow)
+
+        # --- Step 4: force eviction of key 1 on the follower ---
+        evict_cursor = session_evict.open_cursor(self.uri)
+        evict_cursor.set_key(1)
+        evict_cursor.search()
+        evict_cursor.close()
+        session_evict.close()
+
+        # --- Step 5: verify key 1 is not visible in the ingest layer after GC ---
+        cursor_check = self.session_follow.open_cursor(self.ingest_uri)
+        cursor_check.set_key(1)
+        self.assertEqual(cursor_check.search(), wiredtiger.WT_NOTFOUND)
+        cursor_check.close()


### PR DESCRIPTION
When garbage collect a key from the ingest btree with an update chain and an on-page value, simply not selecting any update to write to the new disk image is not enough. We need to explicitly delete the key. Otherwise, the on-page value is not garbage collected and reappears in read. 
