### PR TITLE
WT-16976 Clarify mirrored-truncate verification behavior in test/format

### DIFF
--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -1403,31 +1403,30 @@ skip_operation:
             snap_repeat_update(tinfo, true);
             break;
         case 5: /* 10% */
-rollback : {
-    bool verify_rollback = attempted_mirrored_truncate && !mirrored_truncate;
-    if (GV(RUNS_PREDICTABLE_REPLAY)) {
-        if (tinfo->quit)
-            goto loop_exit;
-        /* Force a rollback */
-        testutil_assert(intxn);
-        rollback_transaction(tinfo, prepared);
-        if (verify_rollback)
-            /* verify post-rollback */
-            wts_verify_mirrored_truncate(tinfo);
-        intxn = false;
-        ++ntries;
-        replay_pause_after_rollback(tinfo, ntries);
-        ret = 0;
-        goto rollback_retry;
-    }
-    __wt_yield(); /* Encourage races */
-    rollback_transaction(tinfo, prepared);
-    snap_repeat_update(tinfo, false);
-    if (verify_rollback)
-        /* verify post-rollback */
-        wts_verify_mirrored_truncate(tinfo);
-    break;
-}
+rollback:
+            bool verify_rollback = attempted_mirrored_truncate && !mirrored_truncate;
+            if (GV(RUNS_PREDICTABLE_REPLAY)) {
+                if (tinfo->quit)
+                    goto loop_exit;
+                /* Force a rollback */
+                testutil_assert(intxn);
+                rollback_transaction(tinfo, prepared);
+                if (verify_rollback)
+                    /* verify post-rollback */
+                    wts_verify_mirrored_truncate(tinfo);
+                intxn = false;
+                ++ntries;
+                replay_pause_after_rollback(tinfo, ntries);
+                ret = 0;
+                goto rollback_retry;
+            }
+            __wt_yield(); /* Encourage races */
+            rollback_transaction(tinfo, prepared);
+            snap_repeat_update(tinfo, false);
+            if (verify_rollback)
+                /* verify post-rollback */
+                wts_verify_mirrored_truncate(tinfo);
+            break;
         }
 
         if (mirrored_truncate)

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -998,11 +998,10 @@ ops(void *arg)
     uint32_t max_rows, ntries, range, rnd;
     u_int i, throttle_delay_max;
     const char *iso_config;
-    bool greater_than, intxn, prepared, mirrored_truncate, attempted_mirrored_truncate;
+    bool greater_than, intxn, prepared, mirrored_truncate;
 
     tinfo = arg;
     mirrored_truncate = false;
-    attempted_mirrored_truncate = false;
 
     /*
      * Characterize the per-thread random number generator. Normally we want independent behavior so
@@ -1049,7 +1048,6 @@ ops(void *arg)
 rollback_retry:
         prepared = false;
         mirrored_truncate = false;
-        attempted_mirrored_truncate = false;
         if (tinfo->quit)
             break;
 
@@ -1307,9 +1305,16 @@ rollback_retry:
             skip2 = table;
         }
         if (ret == 0 && table->mirror) {
+            /*
+             * For mirrored truncates, remember that we executed a truncate in this transaction.
+             * Note: mirrored_truncate is set before we know whether any of the truncate calls will
+             * return WT_ROLLBACK. If a rollback happens later in this transaction,
+             * mirrored_truncate remains true and we will still run wts_verify_mirrored_truncate
+             * after the rollback, so mirrored truncates are verified in both the commit and
+             * rollback cases.
+             */
             if (op == TRUNCATE)
-                /* We started a mirrored truncate */
-                attempted_mirrored_truncate = true;
+                mirrored_truncate = true;
             for (i = 1; i <= ntables; ++i)
                 if (tables[i] != skip1 && tables[i] != skip2 && tables[i]->mirror) {
                     tinfo->table = tables[i];
@@ -1320,13 +1325,6 @@ rollback_retry:
                     if (ret == WT_ROLLBACK)
                         break;
                 }
-            /*
-             * Only treat this as a mirrored truncate if all mirror table truncates succeeded. This
-             * avoids calling wts_verify_mirrored_truncate after a truncate that ultimately rolled
-             * back.
-             */
-            if (op == TRUNCATE && ret == 0)
-                mirrored_truncate = true;
         }
 skip_operation:
         table = tinfo->table = NULL;
@@ -1404,16 +1402,12 @@ skip_operation:
             break;
         case 5: /* 10% */
 rollback:
-            bool verify_rollback = attempted_mirrored_truncate && !mirrored_truncate;
             if (GV(RUNS_PREDICTABLE_REPLAY)) {
                 if (tinfo->quit)
                     goto loop_exit;
                 /* Force a rollback */
                 testutil_assert(intxn);
                 rollback_transaction(tinfo, prepared);
-                if (verify_rollback)
-                    /* verify post-rollback */
-                    wts_verify_mirrored_truncate(tinfo);
                 intxn = false;
                 ++ntries;
                 replay_pause_after_rollback(tinfo, ntries);
@@ -1423,12 +1417,13 @@ rollback:
             __wt_yield(); /* Encourage races */
             rollback_transaction(tinfo, prepared);
             snap_repeat_update(tinfo, false);
-            if (verify_rollback)
-                /* verify post-rollback */
-                wts_verify_mirrored_truncate(tinfo);
             break;
         }
 
+        /*
+         * If this operation was a mirrored truncate, verify the mirrors. This runs after both
+         * successfully committed truncates and truncates that were rolled back.
+         */
         if (mirrored_truncate)
             wts_verify_mirrored_truncate(tinfo);
 

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -1305,8 +1305,6 @@ rollback_retry:
             skip2 = table;
         }
         if (ret == 0 && table->mirror) {
-            if (op == TRUNCATE)
-                mirrored_truncate = true;
             for (i = 1; i <= ntables; ++i)
                 if (tables[i] != skip1 && tables[i] != skip2 && tables[i]->mirror) {
                     tinfo->table = tables[i];
@@ -1317,6 +1315,13 @@ rollback_retry:
                     if (ret == WT_ROLLBACK)
                         break;
                 }
+            /*
+             * Only treat this as a mirrored truncate if all mirror table truncates succeeded. This
+             * avoids calling wts_verify_mirrored_truncate after a truncate that ultimately rolled
+             * back.
+             */
+            if (op == TRUNCATE && ret == 0)
+                mirrored_truncate = true;
         }
 skip_operation:
         table = tinfo->table = NULL;

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -1306,12 +1306,11 @@ rollback_retry:
         }
         if (ret == 0 && table->mirror) {
             /*
-             * For mirrored truncates, remember that we executed a truncate in this transaction.
-             * Note: mirrored_truncate is set before we know whether any of the truncate calls will
-             * return WT_ROLLBACK. If a rollback happens later in this transaction,
-             * mirrored_truncate remains true and we will still run wts_verify_mirrored_truncate
-             * after the rollback, so mirrored truncates are verified in both the commit and
-             * rollback cases.
+             * For mirrored truncates, we record that a truncate was executed in this transaction.
+             * That record is set before we know whether any of the truncate calls will return
+             * WT_ROLLBACK. If the transaction later rolls back, the record remains set and we still
+             * run the mirrored-truncate verification at the end, so this path is checked for both
+             * committed and rolled-back truncates.
              */
             if (op == TRUNCATE)
                 mirrored_truncate = true;

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -998,10 +998,11 @@ ops(void *arg)
     uint32_t max_rows, ntries, range, rnd;
     u_int i, throttle_delay_max;
     const char *iso_config;
-    bool greater_than, intxn, prepared, mirrored_truncate;
+    bool greater_than, intxn, prepared, mirrored_truncate, attempted_mirrored_truncate;
 
     tinfo = arg;
     mirrored_truncate = false;
+    attempted_mirrored_truncate = false;
 
     /*
      * Characterize the per-thread random number generator. Normally we want independent behavior so
@@ -1048,6 +1049,7 @@ ops(void *arg)
 rollback_retry:
         prepared = false;
         mirrored_truncate = false;
+        attempted_mirrored_truncate = false;
         if (tinfo->quit)
             break;
 
@@ -1305,6 +1307,9 @@ rollback_retry:
             skip2 = table;
         }
         if (ret == 0 && table->mirror) {
+            if (op == TRUNCATE)
+                /* We started a mirrored truncate */
+                attempted_mirrored_truncate = true;
             for (i = 1; i <= ntables; ++i)
                 if (tables[i] != skip1 && tables[i] != skip2 && tables[i]->mirror) {
                     tinfo->table = tables[i];
@@ -1398,23 +1403,31 @@ skip_operation:
             snap_repeat_update(tinfo, true);
             break;
         case 5: /* 10% */
-rollback:
-            if (GV(RUNS_PREDICTABLE_REPLAY)) {
-                if (tinfo->quit)
-                    goto loop_exit;
-                /* Force a rollback */
-                testutil_assert(intxn);
-                rollback_transaction(tinfo, prepared);
-                intxn = false;
-                ++ntries;
-                replay_pause_after_rollback(tinfo, ntries);
-                ret = 0;
-                goto rollback_retry;
-            }
-            __wt_yield(); /* Encourage races */
-            rollback_transaction(tinfo, prepared);
-            snap_repeat_update(tinfo, false);
-            break;
+rollback : {
+    bool verify_rollback = attempted_mirrored_truncate && !mirrored_truncate;
+    if (GV(RUNS_PREDICTABLE_REPLAY)) {
+        if (tinfo->quit)
+            goto loop_exit;
+        /* Force a rollback */
+        testutil_assert(intxn);
+        rollback_transaction(tinfo, prepared);
+        if (verify_rollback)
+            /* verify post-rollback */
+            wts_verify_mirrored_truncate(tinfo);
+        intxn = false;
+        ++ntries;
+        replay_pause_after_rollback(tinfo, ntries);
+        ret = 0;
+        goto rollback_retry;
+    }
+    __wt_yield(); /* Encourage races */
+    rollback_transaction(tinfo, prepared);
+    snap_repeat_update(tinfo, false);
+    if (verify_rollback)
+        /* verify post-rollback */
+        wts_verify_mirrored_truncate(tinfo);
+    break;
+}
         }
 
         if (mirrored_truncate)


### PR DESCRIPTION
This PR updates comments in test/format/ops.c to accurately describe the existing behavior of mirrored-truncate verification:

- mirrored_truncate is set as soon as we start a TRUNCATE on a mirrored table, before we know whether any mirror truncate will return WT_ROLLBACK.
- At the end of the loop, we call wts_verify_mirrored_truncate(tinfo) whenever mirrored_truncate is true, regardless of whether the transaction committed or rolled back.
- As a result, mirrored-truncate verification already runs in both the success and rollback cases.