### PR TITLE
WT-16914 Exclude checkpoint workers from participating in app-assisted eviction

### DIFF
--- a/src/checkpoint/checkpoint_parallel.c
+++ b/src/checkpoint/checkpoint_parallel.c
@@ -217,7 +217,11 @@ __checkpoint_parallel_thread_run(WT_SESSION_IMPL *session, WT_THREAD *thread)
         if (entry == NULL)
             break;
 
-        /* Begin a transaction, if we don't already have one. */
+        /*
+         * Begin a transaction, if we don't already have one. This transaction will be used for the
+         * entire checkpoint, similarly as in the single-threaded checkpoint case. The main
+         * checkpoint thread is responsible for committing or rolling back this transaction.
+         */
         if (!F_ISSET(session->txn, WT_TXN_RUNNING)) {
             WT_ERR(__wt_txn_begin(session, NULL));
             F_SET(session, WT_SESSION_CHECKPOINT);

--- a/src/evict/evict_inline.h
+++ b/src/evict/evict_inline.h
@@ -842,6 +842,10 @@ __wt_evict_app_assist_worker_check(
     if (!__wt_atomic_load_bool_relaxed(&conn->evict_server_running))
         return (0);
 
+    /* Checkpoint reconciliation workers cannot participate in eviction. */
+    if (F_ISSET(session, WT_SESSION_CHECKPOINT_WORKER))
+        return (0);
+
     /* Eviction causes reconciliation. So don't evict if we can't reconcile */
     if (F_ISSET(session, WT_SESSION_NO_RECONCILE))
         return (0);


### PR DESCRIPTION
Prevent checkpoint worker threads from participating in app-assisted eviction, which, if happens, causes the application to hang.