### PR TITLE
WT-16028 Fix data race on prefetch_queue_count in session_prefetch_check

### DIFF
--- a/src/session/session_prefetch.c
+++ b/src/session/session_prefetch.c
@@ -32,7 +32,7 @@ __wt_session_prefetch_check(WT_SESSION_IMPL *session, WT_REF *ref)
       __wt_atomic_load_enum_relaxed(&session->dhandle->type) == WT_DHANDLE_TYPE_TIERED_TREE)
         return (false);
 
-    if (S2C(session)->prefetch_queue_count > WT_MAX_PREFETCH_QUEUE)
+    if (__wt_tsan_suppress_load_uint64(&S2C(session)->prefetch_queue_count) > WT_MAX_PREFETCH_QUEUE)
         return (false);
 
     if (F_ISSET(session, WT_SESSION_INTERNAL)) {


### PR DESCRIPTION
## Summary
- `prefetch_queue_count` was read in `__wt_session_prefetch_check` without any synchronization, causing a lock-inconsistency data race flagged by Coverity (defect 177376).
- Writes to `prefetch_queue_count` always happen under `prefetch_lock`; reads are intentionally lockless (benign race — the check is a heuristic throttle).
- Replace the bare read with `__wt_tsan_suppress_load_uint64()`, matching the identical pattern already used in `bt_prefetch.c:64`.

## Testing
No dedicated test files were modified. The fix is a one-line change to silence the Coverity/TSan data-race report. The existing prefetch test suite covers the affected code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)