### PR TITLE
WT-16913 Fix a memory leak in parallel checkpoint related to thread pool management

### DIFF
--- a/src/checkpoint/checkpoint_parallel.c
+++ b/src/checkpoint/checkpoint_parallel.c
@@ -364,9 +364,8 @@ __wt_checkpoint_parallel_thread_destroy(WT_SESSION_IMPL *session)
     ret = __wt_checkpoint_parallel_finish(session);
     if (ret != 0) {
         __wt_verbose_warning(session, WT_VERB_CHECKPOINT,
-          "Error finishing checkpoint page reconciliation work: %s",
-          __wt_strerror(session, ret, NULL, 0));
-        ret = 0; /* We don't care if finishing the work failed. */
+          "Checkpoint page reconciliation failed: %s", __wt_strerror(session, ret, NULL, 0));
+        ret = 0; /* We don't need to communicate this error to the caller. */
     }
 
     /*

--- a/src/checkpoint/checkpoint_parallel.c
+++ b/src/checkpoint/checkpoint_parallel.c
@@ -276,6 +276,7 @@ __wt_checkpoint_parallel_thread_create(WT_SESSION_IMPL *session, const char *cfg
     WT_CHECKPOINT_RECONCILE_THREADS *ckpt_threads;
     WT_CONFIG_ITEM cval;
     WT_CONNECTION_IMPL *conn;
+    WT_DECL_RET;
     uint32_t session_flags;
     int checkpoint_threads;
 
@@ -314,12 +315,16 @@ __wt_checkpoint_parallel_thread_create(WT_SESSION_IMPL *session, const char *cfg
 
     /* Create the checkpoint thread group. */
     session_flags = WT_THREAD_CAN_WAIT | WT_THREAD_PANIC_FAIL;
-    WT_RET(__wt_thread_group_create(session, &ckpt_threads->thread_group,
+    WT_ERR(__wt_thread_group_create(session, &ckpt_threads->thread_group,
       "checkpoint-page-reconciliation-threads", ckpt_threads->num_threads,
       ckpt_threads->num_threads, session_flags, __checkpoint_parallel_thread_chk,
       __checkpoint_parallel_thread_run, __checkpoint_parallel_thread_stop));
 
-    return (0);
+    if (0) {
+err:
+        WT_TRET(__wt_checkpoint_parallel_thread_destroy(session));
+    }
+    return (ret);
 }
 
 /*
@@ -352,6 +357,17 @@ __wt_checkpoint_parallel_thread_destroy(WT_SESSION_IMPL *session)
     __wt_cond_signal(session, ckpt_threads->work_cond);
 
     __wt_verbose(session, WT_VERB_CHECKPOINT, "%s", "Waiting for helper threads");
+
+    /*
+     * Process the done queue to release the relevant pages and free the queue entries.
+     */
+    ret = __wt_checkpoint_parallel_finish(session);
+    if (ret != 0) {
+        __wt_verbose_warning(session, WT_VERB_CHECKPOINT,
+          "Error finishing checkpoint page reconciliation work: %s",
+          __wt_strerror(session, ret, NULL, 0));
+        ret = 0; /* We don't care if finishing the work failed. */
+    }
 
     /*
      * We call the destroy function still holding the write lock. It assumes it is called locked.

--- a/src/support/thread_group.c
+++ b/src/support/thread_group.c
@@ -138,7 +138,6 @@ __thread_group_resize(WT_SESSION_IMPL *session, WT_THREAD_GROUP *group, uint32_t
 {
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
-    WT_SESSION *wt_session;
     WT_THREAD *thread;
     size_t alloc;
     uint32_t i, session_flags;
@@ -223,10 +222,8 @@ err:
      * memory situation. Do real cleanup just in case that changes in the future.
      */
     if (thread != NULL) {
-        if (thread->session != NULL) {
-            wt_session = (WT_SESSION *)thread->session;
-            WT_TRET(wt_session->close(wt_session, NULL));
-        }
+        if (thread->session != NULL)
+            WT_TRET(__wt_session_close_internal(thread->session));
         __wt_cond_destroy(session, &thread->pause_cond);
         __wt_free(session, thread);
     }

--- a/src/support/thread_group.c
+++ b/src/support/thread_group.c
@@ -71,7 +71,6 @@ static int
 __thread_group_shrink(WT_SESSION_IMPL *session, WT_THREAD_GROUP *group, uint32_t new_count)
 {
     WT_DECL_RET;
-    WT_SESSION *wt_session;
     WT_THREAD *thread;
     uint32_t current_slot;
 
@@ -120,8 +119,7 @@ __thread_group_shrink(WT_SESSION_IMPL *session, WT_THREAD_GROUP *group, uint32_t
         if (thread == NULL)
             continue;
         WT_ASSERT(session, thread->session != NULL);
-        wt_session = (WT_SESSION *)thread->session;
-        WT_TRET(wt_session->close(wt_session, NULL));
+        WT_TRET(__wt_session_close_internal(thread->session));
         thread->session = NULL;
         __wt_free(session, thread);
         group->threads[current_slot] = NULL;


### PR DESCRIPTION
Address memory leaks through the following ways:
* Change thread groups to close sessions as internal sessions, since they were created as internal sessions to begin with.
* Clean up the checkpoint thread group on the error path.
* Process the "done" queue during cleanup to free any underlying resources.