### PR TITLE
WT-16995 Clarify comment on excluding salvage from block_free stat increment

### DIFF
--- a/src/block/block_ext.c
+++ b/src/block/block_ext.c
@@ -700,7 +700,10 @@ __wti_block_off_free(
     else if (ret == WT_NOTFOUND)
         ret = __block_merge(session, block, &block->live.discard, offset, size);
 
-    /* Increment the free block statistic when not running salvage. */
+    /* Salvage is a corruption repair operation. Including it in the block_free stat would create
+     * misleading spikes unrelated to workload behavior, making the stat unreliable for monitoring
+     * normal user driven activity.
+     */
     if (!F_ISSET(S2BT(session), WT_BTREE_SALVAGE)) {
         WT_STAT_DSRC_INCR(session, block_free);
     }

--- a/src/block/block_ext.c
+++ b/src/block/block_ext.c
@@ -700,7 +700,7 @@ __wti_block_off_free(
     else if (ret == WT_NOTFOUND)
         ret = __block_merge(session, block, &block->live.discard, offset, size);
 
-    /* 
+    /*
      * Salvage is a corruption repair operation. Including it in the block_free stat would create
      * misleading spikes unrelated to workload behavior, making the stat unreliable for monitoring
      * normal user driven activity.

--- a/src/block/block_ext.c
+++ b/src/block/block_ext.c
@@ -700,7 +700,8 @@ __wti_block_off_free(
     else if (ret == WT_NOTFOUND)
         ret = __block_merge(session, block, &block->live.discard, offset, size);
 
-    /* Salvage is a corruption repair operation. Including it in the block_free stat would create
+    /* 
+     * Salvage is a corruption repair operation. Including it in the block_free stat would create
      * misleading spikes unrelated to workload behavior, making the stat unreliable for monitoring
      * normal user driven activity.
      */


### PR DESCRIPTION
Change comment to explain why salvage is excluded from block_free stat increment.