### PR TITLE
WT-17010 Supress the Clang 21 compiler allocator wrapper warnings

### DIFF
--- a/cmake/strict/strict_flags_helpers.cmake
+++ b/cmake/strict/strict_flags_helpers.cmake
@@ -178,6 +178,14 @@ function(get_clang_base_flags flags)
         list(APPEND clang_flags "-Wno-maybe-uninitialized")
     endif()
 
+    if(${cmake_compiler_version} VERSION_GREATER_EQUAL 21)
+        # Clang 21+ warns when a function returns a result from an allocator
+        # call but isn't itself annotated as an allocator. WiredTiger has
+        # several thin wrappers around malloc/calloc/realloc that intentionally
+        # follow this pattern.
+        list(APPEND clang_flags "-Wno-allocator-wrappers")
+    endif()
+
     set(${flags} ${clang_flags} PARENT_SCOPE)
 
 endfunction()


### PR DESCRIPTION
Clang 21 compiler started producing the allocator wrapper warnings in the WiredTiger code base whenever a wrapper function returns a void *. WiredTiger have a couple of functions like these.
