### PR TITLE
WT-17011 Fix TSAN race in zstd_get_context

### DIFF
--- a/ext/compressors/zstd/zstd_compress.c
+++ b/ext/compressors/zstd/zstd_compress.c
@@ -132,9 +132,6 @@ zstd_get_context(
         ctx_pool = zcompressor->dctx_pool;
 
     *contextp = NULL;
-    if (ctx_pool->free_ctx_list == NULL)
-        return;
-
     wt_api->spin_lock(wt_api, session, &(ctx_pool->list_lock));
     if (ctx_pool->free_ctx_list == NULL) {
         wt_api->spin_unlock(wt_api, session, &(ctx_pool->list_lock));


### PR DESCRIPTION
## Summary
- `zstd_get_context` had an unsynchronized read of `ctx_pool->free_ctx_list` at line 135 as a pre-check before acquiring the lock
- This raced with `zstd_release_context` which writes `free_ctx_list` while holding the lock, causing a TSAN data race
- Fix: remove the pre-lock check — the locked double-check immediately after is sufficient and correct

## Testing
Covered by the existing `format-stress-test-tsan` task on `amazon2023-arm64-tsan` which caught the original race. No test files were modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)