### PR TITLE
WT-17005 Fix heap-use-after-free due to metadata pages being evicted early

### DIFF
--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -802,7 +802,7 @@ __txn_release(WT_SESSION_IMPL *session)
     WT_ASSERT(session, txn->mod_count == 0);
 
     /* Clear the transaction's ID from the global table. */
-    if (WT_SESSION_IS_CHECKPOINT(session)) {
+    if (WT_SESSION_IS_CHECKPOINT(session) && !F_ISSET(session, WT_SESSION_CHECKPOINT_WORKER)) {
         WT_ASSERT(session,
           __wt_atomic_load_uint64_v_relaxed(&WT_SESSION_TXN_SHARED(session)->id) == WT_TXN_NONE);
         txn->time_point.id = WT_TXN_NONE;


### PR DESCRIPTION
Committing checkpoint worker threads caused the checkpoint transaction ID to be released early, thus allowing eviction to evict metadata pages needed by the main checkpoint transaction early. The transaction's ID should be freed only by the main transaction thread.