### PR TITLE
WT-16403 Rename rec_state to dirty_state in WT_REF

### DIFF
--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -1219,7 +1219,7 @@ __debug_page_metadata(WT_DBG *ds, WT_REF *ref)
     }
 
     if (mod != NULL) {
-        WT_RET(ds->f(ds, " | rec_state: "));
+        WT_RET(ds->f(ds, " | rec_result: "));
         switch (mod->rec_result) {
         case WT_PM_REC_EMPTY:
             WT_RET(ds->f(ds, "empty"));

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -201,7 +201,7 @@ __wti_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
     WT_STAT_CONN_DSRC_INCR(session, rec_page_delete_fast);
 
     if (WT_DELTA_INT_ENABLED(btree, S2C(session)))
-        __wt_atomic_store_uint8_v_release(&ref->rec_state, WT_REF_REC_DIRTY);
+        __wt_atomic_store_uint8_v_release(&ref->dirty_state, WT_REF_DIRTY_DIRTY);
 
     /* Set the page to its new state. */
     WT_REF_SET_STATE(ref, WT_REF_DELETED);
@@ -317,7 +317,7 @@ __wt_delete_page_rollback(WT_SESSION_IMPL *session, WT_TXN_OP *op)
     }
 
     if (WT_DELTA_INT_ENABLED(op->btree, S2C(session)))
-        __wt_atomic_store_uint8_v_release(&ref->rec_state, WT_REF_REC_DIRTY);
+        __wt_atomic_store_uint8_v_release(&ref->dirty_state, WT_REF_DIRTY_DIRTY);
 
     WT_REF_SET_STATE(ref, current_state);
     return (0);

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -201,7 +201,7 @@ __wti_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
     WT_STAT_CONN_DSRC_INCR(session, rec_page_delete_fast);
 
     if (WT_DELTA_INT_ENABLED(btree, S2C(session)))
-        __wt_atomic_store_uint8_v_release(&ref->dirty_state, WT_REF_DIRTY_DIRTY);
+        __wt_atomic_store_uint8_v_release(&ref->dirty_state, WT_REF_DIRTY);
 
     /* Set the page to its new state. */
     WT_REF_SET_STATE(ref, WT_REF_DELETED);
@@ -317,7 +317,7 @@ __wt_delete_page_rollback(WT_SESSION_IMPL *session, WT_TXN_OP *op)
     }
 
     if (WT_DELTA_INT_ENABLED(op->btree, S2C(session)))
-        __wt_atomic_store_uint8_v_release(&ref->dirty_state, WT_REF_DIRTY_DIRTY);
+        __wt_atomic_store_uint8_v_release(&ref->dirty_state, WT_REF_DIRTY);
 
     WT_REF_SET_STATE(ref, current_state);
     return (0);

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -717,8 +717,8 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new, uint32_t
             if (WT_DELTA_INT_ENABLED(btree, S2C(session)))
                 dirty_state = __wt_atomic_load_uint8_v_acquire(&next_ref->dirty_state);
             else
-                dirty_state = WT_REF_DIRTY_CLEAN;
-            if (dirty_state == WT_REF_DIRTY_CLEAN && next_ref != ref &&
+                dirty_state = WT_REF_CLEAN;
+            if (dirty_state == WT_REF_CLEAN && next_ref != ref &&
               WT_REF_GET_STATE(next_ref) == WT_REF_DELETED &&
               (btree->type != BTREE_COL_VAR || i != 0) &&
               !F_ISSET_ATOMIC_8(next_ref, WT_REF_FLAG_PREFETCH) &&
@@ -823,7 +823,7 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new, uint32_t
      * cannot split during checkpoint.
      */
     if (WT_DELTA_INT_ENABLED(btree, S2C(session)))
-        __wt_atomic_store_uint8_v_release(&ref->dirty_state, WT_REF_DIRTY_DIRTY);
+        __wt_atomic_store_uint8_v_release(&ref->dirty_state, WT_REF_DIRTY);
 
     /* Disable building delta for the parent page if we split. */
     F_SET_ATOMIC_16(parent, WT_PAGE_INTL_PINDEX_UPDATE);
@@ -1041,7 +1041,7 @@ __split_internal(WT_SESSION_IMPL *session, WT_PAGE *parent, WT_PAGE *page)
         F_SET(ref, WT_REF_FLAG_INTERNAL);
 
         if (WT_DELTA_INT_ENABLED(btree, S2C(session)))
-            __wt_atomic_store_uint8_v_relaxed(&ref->dirty_state, WT_REF_DIRTY_DIRTY);
+            __wt_atomic_store_uint8_v_relaxed(&ref->dirty_state, WT_REF_DIRTY);
 
         WT_REF_SET_STATE(ref, WT_REF_MEM);
 
@@ -1901,7 +1901,7 @@ __wt_multi_to_ref(WT_SESSION_IMPL *session, WT_REF *old_ref, WT_PAGE *page, WT_M
     }
 
     if (WT_DELTA_INT_ENABLED(S2BT(session), S2C(session)))
-        __wt_atomic_store_uint8_v_release(&ref->dirty_state, WT_REF_DIRTY_DIRTY);
+        __wt_atomic_store_uint8_v_release(&ref->dirty_state, WT_REF_DIRTY);
 
     switch (page->type) {
     case WT_PAGE_COL_INT:
@@ -1949,7 +1949,7 @@ __wt_multi_to_ref(WT_SESSION_IMPL *session, WT_REF *old_ref, WT_PAGE *page, WT_M
     }
 
     if (WT_DELTA_INT_ENABLED(S2BT(session), S2C(session)))
-        __wt_atomic_store_uint8_v_relaxed(&ref->dirty_state, WT_REF_DIRTY_DIRTY);
+        __wt_atomic_store_uint8_v_relaxed(&ref->dirty_state, WT_REF_DIRTY);
 
     /*
      * If we have a disk image and we're not closing the file, re-instantiate the page.
@@ -2059,7 +2059,7 @@ __split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
     F_SET(child, WT_REF_FLAG_LEAF);
 
     if (WT_DELTA_INT_ENABLED(S2BT(session), S2C(session)))
-        __wt_atomic_store_uint8_v_relaxed(&child->dirty_state, WT_REF_DIRTY_DIRTY);
+        __wt_atomic_store_uint8_v_relaxed(&child->dirty_state, WT_REF_DIRTY);
 
     WT_REF_SET_STATE(child, WT_REF_MEM); /* Visible as soon as the split completes. */
     if (type == WT_PAGE_ROW_LEAF) {
@@ -2512,7 +2512,7 @@ __wt_split_rewrite(WT_SESSION_IMPL *session, WT_REF *ref, WT_MULTI *multi, bool 
 
     /* Swap the new page into place. */
     if (WT_DELTA_INT_ENABLED(S2BT(session), S2C(session)))
-        __wt_atomic_store_uint8_v_release(&ref->dirty_state, WT_REF_DIRTY_DIRTY);
+        __wt_atomic_store_uint8_v_release(&ref->dirty_state, WT_REF_DIRTY);
     ref->page = new->page;
 
     if (change_ref_state)

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -664,7 +664,7 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new, uint32_t
     size_t parent_decr, size;
     uint64_t split_gen;
     uint32_t deleted_entries, *deleted_refs, hint, i, j, parent_entries, result_entries;
-    uint8_t rec_state;
+    uint8_t dirty_state;
     bool empty_parent;
 
 #ifdef HAVE_DIAGNOSTIC
@@ -715,10 +715,10 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new, uint32_t
              * the prefetch thread would crash if it sees a freed ref.
              */
             if (WT_DELTA_INT_ENABLED(btree, S2C(session)))
-                rec_state = __wt_atomic_load_uint8_v_acquire(&next_ref->rec_state);
+                dirty_state = __wt_atomic_load_uint8_v_acquire(&next_ref->dirty_state);
             else
-                rec_state = WT_REF_REC_CLEAN;
-            if (rec_state == WT_REF_REC_CLEAN && next_ref != ref &&
+                dirty_state = WT_REF_DIRTY_CLEAN;
+            if (dirty_state == WT_REF_DIRTY_CLEAN && next_ref != ref &&
               WT_REF_GET_STATE(next_ref) == WT_REF_DELETED &&
               (btree->type != BTREE_COL_VAR || i != 0) &&
               !F_ISSET_ATOMIC_8(next_ref, WT_REF_FLAG_PREFETCH) &&
@@ -819,11 +819,11 @@ __split_parent(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF **ref_new, uint32_t
     parent->pg_intl_split_gen = split_gen;
 
     /*
-     * Mark the page ref's rec_state as dirty. We cannot race with checkpoint as internal page
+     * Mark the page ref's dirty_state as dirty. We cannot race with checkpoint as internal page
      * cannot split during checkpoint.
      */
     if (WT_DELTA_INT_ENABLED(btree, S2C(session)))
-        __wt_atomic_store_uint8_v_release(&ref->rec_state, WT_REF_REC_DIRTY);
+        __wt_atomic_store_uint8_v_release(&ref->dirty_state, WT_REF_DIRTY_DIRTY);
 
     /* Disable building delta for the parent page if we split. */
     F_SET_ATOMIC_16(parent, WT_PAGE_INTL_PINDEX_UPDATE);
@@ -1041,7 +1041,7 @@ __split_internal(WT_SESSION_IMPL *session, WT_PAGE *parent, WT_PAGE *page)
         F_SET(ref, WT_REF_FLAG_INTERNAL);
 
         if (WT_DELTA_INT_ENABLED(btree, S2C(session)))
-            __wt_atomic_store_uint8_v_relaxed(&ref->rec_state, WT_REF_REC_DIRTY);
+            __wt_atomic_store_uint8_v_relaxed(&ref->dirty_state, WT_REF_DIRTY_DIRTY);
 
         WT_REF_SET_STATE(ref, WT_REF_MEM);
 
@@ -1901,7 +1901,7 @@ __wt_multi_to_ref(WT_SESSION_IMPL *session, WT_REF *old_ref, WT_PAGE *page, WT_M
     }
 
     if (WT_DELTA_INT_ENABLED(S2BT(session), S2C(session)))
-        __wt_atomic_store_uint8_v_release(&ref->rec_state, WT_REF_REC_DIRTY);
+        __wt_atomic_store_uint8_v_release(&ref->dirty_state, WT_REF_DIRTY_DIRTY);
 
     switch (page->type) {
     case WT_PAGE_COL_INT:
@@ -1949,7 +1949,7 @@ __wt_multi_to_ref(WT_SESSION_IMPL *session, WT_REF *old_ref, WT_PAGE *page, WT_M
     }
 
     if (WT_DELTA_INT_ENABLED(S2BT(session), S2C(session)))
-        __wt_atomic_store_uint8_v_relaxed(&ref->rec_state, WT_REF_REC_DIRTY);
+        __wt_atomic_store_uint8_v_relaxed(&ref->dirty_state, WT_REF_DIRTY_DIRTY);
 
     /*
      * If we have a disk image and we're not closing the file, re-instantiate the page.
@@ -2059,7 +2059,7 @@ __split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
     F_SET(child, WT_REF_FLAG_LEAF);
 
     if (WT_DELTA_INT_ENABLED(S2BT(session), S2C(session)))
-        __wt_atomic_store_uint8_v_relaxed(&child->rec_state, WT_REF_REC_DIRTY);
+        __wt_atomic_store_uint8_v_relaxed(&child->dirty_state, WT_REF_DIRTY_DIRTY);
 
     WT_REF_SET_STATE(child, WT_REF_MEM); /* Visible as soon as the split completes. */
     if (type == WT_PAGE_ROW_LEAF) {
@@ -2512,7 +2512,7 @@ __wt_split_rewrite(WT_SESSION_IMPL *session, WT_REF *ref, WT_MULTI *multi, bool 
 
     /* Swap the new page into place. */
     if (WT_DELTA_INT_ENABLED(S2BT(session), S2C(session)))
-        __wt_atomic_store_uint8_v_release(&ref->rec_state, WT_REF_REC_DIRTY);
+        __wt_atomic_store_uint8_v_release(&ref->dirty_state, WT_REF_DIRTY_DIRTY);
     ref->page = new->page;
 
     if (change_ref_state)

--- a/src/btree/bt_sync_obsolete.c
+++ b/src/btree/bt_sync_obsolete.c
@@ -331,7 +331,7 @@ __sync_obsolete_cleanup_one(WT_SESSION_IMPL *session, WT_REF *ref)
          * ref's state. There's nothing to do for in-memory pages as we don't change those.
          */
         if (WT_DELTA_INT_ENABLED(S2BT(session), S2C(session)) && previous_state != new_state)
-            __wt_atomic_store_uint8_v_release(&ref->rec_state, WT_REF_REC_DIRTY);
+            __wt_atomic_store_uint8_v_release(&ref->dirty_state, WT_REF_DIRTY_DIRTY);
         WT_REF_UNLOCK(ref, new_state);
         WT_RET(ret);
     } else

--- a/src/btree/bt_sync_obsolete.c
+++ b/src/btree/bt_sync_obsolete.c
@@ -331,7 +331,7 @@ __sync_obsolete_cleanup_one(WT_SESSION_IMPL *session, WT_REF *ref)
          * ref's state. There's nothing to do for in-memory pages as we don't change those.
          */
         if (WT_DELTA_INT_ENABLED(S2BT(session), S2C(session)) && previous_state != new_state)
-            __wt_atomic_store_uint8_v_release(&ref->dirty_state, WT_REF_DIRTY_DIRTY);
+            __wt_atomic_store_uint8_v_release(&ref->dirty_state, WT_REF_DIRTY);
         WT_REF_UNLOCK(ref, new_state);
         WT_RET(ret);
     } else

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -1161,18 +1161,18 @@ struct __wt_ref {
     wt_shared volatile uint32_t pindex_hint; /* Reference page index hint */
 
 /*
- * A flag used to track a ref has changed during internal page reconciliation. The value is compared
- * and swapped to WT_REF_REC_CLEAN for each internal page reconciliation. If the flag becomes
- * WT_REF_REC_DIRTY, this implies that the ref has been changed concurrently and that the ref
- * remains dirty after internal page reconciliation. It is possible for other operations such as
- * page splits and fast-truncate to concurrently mark WT_REF_REC_DIRTY to the ref, but depending on
- * timing or race conditions, it cannot be guaranteed that the new change is included as part of the
+ * A flag used to track whether a ref has been dirtied while reconciling an internal page. The value
+ * is compared and swapped to WT_REF_DIRTY_CLEAN for each internal page reconciliation. If the flag
+ * becomes WT_REF_DIRTY_DIRTY, this implies that the ref has been changed concurrently and remains
+ * dirty after internal page reconciliation. Other operations, such as page splits and
+ * fast-truncate, can also concurrently mark the ref WT_REF_DIRTY_DIRTY, but depending on timing or
+ * race conditions, it cannot be guaranteed that the new change is included as part of the
  * reconciliation. The page would need to be reconciled again to ensure that these modifications are
  * included.
  */
-#define WT_REF_REC_CLEAN 0
-#define WT_REF_REC_DIRTY 1
-    wt_shared volatile uint8_t rec_state;
+#define WT_REF_DIRTY_CLEAN 0
+#define WT_REF_DIRTY_DIRTY 1
+    wt_shared volatile uint8_t dirty_state;
 
 /*
  * Define both internal- and leaf-page flags for now: we only need one, but it provides an easy way

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -1162,16 +1162,15 @@ struct __wt_ref {
 
 /*
  * A flag used to track whether a ref has been dirtied while reconciling an internal page. The value
- * is compared and swapped to WT_REF_DIRTY_CLEAN for each internal page reconciliation. If the flag
- * becomes WT_REF_DIRTY_DIRTY, this implies that the ref has been changed concurrently and remains
- * dirty after internal page reconciliation. Other operations, such as page splits and
- * fast-truncate, can also concurrently mark the ref WT_REF_DIRTY_DIRTY, but depending on timing or
- * race conditions, it cannot be guaranteed that the new change is included as part of the
- * reconciliation. The page would need to be reconciled again to ensure that these modifications are
- * included.
+ * is compared and swapped to WT_REF_CLEAN for each internal page reconciliation. If the flag
+ * becomes WT_REF_DIRTY, this implies that the ref has been changed concurrently and remains dirty
+ * after internal page reconciliation. Other operations, such as page splits and fast-truncate, can
+ * also concurrently mark the ref WT_REF_DIRTY, but depending on timing or race conditions, it
+ * cannot be guaranteed that the new change is included as part of the reconciliation. The page
+ * would need to be reconciled again to ensure that these modifications are included.
  */
-#define WT_REF_DIRTY_CLEAN 0
-#define WT_REF_DIRTY_DIRTY 1
+#define WT_REF_CLEAN 0
+#define WT_REF_DIRTY 1
     wt_shared volatile uint8_t dirty_state;
 
 /*

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -427,7 +427,7 @@ __wt_txn_op_delete_apply_prepare_state(WT_SESSION_IMPL *session, WT_TXN_OP *op, 
         __txn_apply_prepare_state_page_del(session, page_del, commit);
 
     if (WT_DELTA_INT_ENABLED(op->btree, S2C(session)))
-        __wt_atomic_store_uint8_v_release(&ref->dirty_state, WT_REF_DIRTY_DIRTY);
+        __wt_atomic_store_uint8_v_release(&ref->dirty_state, WT_REF_DIRTY);
 
     WT_REF_UNLOCK(ref, previous_state);
 }
@@ -555,7 +555,7 @@ __wt_txn_op_delete_commit(
         __txn_op_delete_commit_apply_page_del_timestamp(session, op);
 
     if (WT_DELTA_INT_ENABLED(op->btree, S2C(session)))
-        __wt_atomic_store_uint8_v_release(&ref->dirty_state, WT_REF_DIRTY_DIRTY);
+        __wt_atomic_store_uint8_v_release(&ref->dirty_state, WT_REF_DIRTY);
 
 err:
     WT_REF_UNLOCK(ref, previous_state);

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -427,7 +427,7 @@ __wt_txn_op_delete_apply_prepare_state(WT_SESSION_IMPL *session, WT_TXN_OP *op, 
         __txn_apply_prepare_state_page_del(session, page_del, commit);
 
     if (WT_DELTA_INT_ENABLED(op->btree, S2C(session)))
-        __wt_atomic_store_uint8_v_release(&ref->rec_state, WT_REF_REC_DIRTY);
+        __wt_atomic_store_uint8_v_release(&ref->dirty_state, WT_REF_DIRTY_DIRTY);
 
     WT_REF_UNLOCK(ref, previous_state);
 }
@@ -555,7 +555,7 @@ __wt_txn_op_delete_commit(
         __txn_op_delete_commit_apply_page_del_timestamp(session, op);
 
     if (WT_DELTA_INT_ENABLED(op->btree, S2C(session)))
-        __wt_atomic_store_uint8_v_release(&ref->rec_state, WT_REF_REC_DIRTY);
+        __wt_atomic_store_uint8_v_release(&ref->dirty_state, WT_REF_DIRTY_DIRTY);
 
 err:
     WT_REF_UNLOCK(ref, previous_state);

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -126,7 +126,7 @@ __wti_rec_col_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_REF *pageref)
 
     /* For each entry in the in-memory page... */
     WT_INTL_FOREACH_BEGIN (session, page, ref) {
-        __wt_atomic_cas_uint8_v(&ref->dirty_state, WT_REF_DIRTY_DIRTY, WT_REF_DIRTY_CLEAN);
+        __wt_atomic_cas_uint8_v(&ref->dirty_state, WT_REF_DIRTY, WT_REF_CLEAN);
 
         /* Update the starting record number in case we split. */
         r->recno = ref->ref_recno;

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -126,7 +126,7 @@ __wti_rec_col_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_REF *pageref)
 
     /* For each entry in the in-memory page... */
     WT_INTL_FOREACH_BEGIN (session, page, ref) {
-        __wt_atomic_cas_uint8_v(&ref->rec_state, WT_REF_REC_DIRTY, WT_REF_REC_CLEAN);
+        __wt_atomic_cas_uint8_v(&ref->dirty_state, WT_REF_DIRTY_DIRTY, WT_REF_DIRTY_CLEAN);
 
         /* Update the starting record number in case we split. */
         r->recno = ref->ref_recno;

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -571,8 +571,7 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
 
     /* For each entry in the in-memory page... */
     WT_INTL_FOREACH_BEGIN (session, page, ref) {
-        prev_dirty =
-          __wt_atomic_cas_uint8_v(&ref->dirty_state, WT_REF_DIRTY_DIRTY, WT_REF_DIRTY_CLEAN);
+        prev_dirty = __wt_atomic_cas_uint8_v(&ref->dirty_state, WT_REF_DIRTY, WT_REF_CLEAN);
 
         /*
          * FIXME-WT-15709: build delta for split pages.
@@ -634,7 +633,7 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
              */
             if (WT_DELTA_INT_ENABLED(btree, S2C(session))) {
                 /* If there are concurrent changes to the first child, abort delta creation. */
-                if (__wt_atomic_load_uint8_v_acquire(&ref->dirty_state) == WT_REF_DIRTY_DIRTY &&
+                if (__wt_atomic_load_uint8_v_acquire(&ref->dirty_state) == WT_REF_DIRTY &&
                   build_delta && r->cell_zero)
                     __rec_stop_build_delta_int(r, &build_delta);
             }
@@ -660,7 +659,7 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
                  */
                 if (WT_DELTA_INT_ENABLED(btree, S2C(session))) {
                     /* If there are concurrent changes to the first child, abort delta creation. */
-                    if (__wt_atomic_load_uint8_v_acquire(&ref->dirty_state) == WT_REF_DIRTY_DIRTY &&
+                    if (__wt_atomic_load_uint8_v_acquire(&ref->dirty_state) == WT_REF_DIRTY &&
                       build_delta && r->cell_zero)
                         __rec_stop_build_delta_int(r, &build_delta);
                 }
@@ -678,7 +677,7 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
                  */
                 if (WT_DELTA_INT_ENABLED(btree, S2C(session))) {
                     /* If there are concurrent changes to the first child, abort delta creation. */
-                    if (__wt_atomic_load_uint8_v_acquire(&ref->dirty_state) == WT_REF_DIRTY_DIRTY &&
+                    if (__wt_atomic_load_uint8_v_acquire(&ref->dirty_state) == WT_REF_DIRTY &&
                       build_delta && cell_zero_tmp)
                         __rec_stop_build_delta_int(r, &build_delta);
                 }
@@ -811,7 +810,7 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
          */
         if (WT_DELTA_INT_ENABLED(btree, S2C(session))) {
             /* If there are concurrent changes to the first child, abort delta creation. */
-            if (__wt_atomic_load_uint8_v_acquire(&ref->dirty_state) == WT_REF_DIRTY_DIRTY &&
+            if (__wt_atomic_load_uint8_v_acquire(&ref->dirty_state) == WT_REF_DIRTY &&
               build_delta && r->cell_zero)
                 __rec_stop_build_delta_int(r, &build_delta);
         }

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -571,7 +571,8 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
 
     /* For each entry in the in-memory page... */
     WT_INTL_FOREACH_BEGIN (session, page, ref) {
-        prev_dirty = __wt_atomic_cas_uint8_v(&ref->rec_state, WT_REF_REC_DIRTY, WT_REF_REC_CLEAN);
+        prev_dirty =
+          __wt_atomic_cas_uint8_v(&ref->dirty_state, WT_REF_DIRTY_DIRTY, WT_REF_DIRTY_CLEAN);
 
         /*
          * FIXME-WT-15709: build delta for split pages.
@@ -628,12 +629,12 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
             }
 
             /*
-             * Set the ref_changes state to zero if there were no concurrent changes while
+             * Set the ref dirty state to clean if there were no concurrent changes while
              * reconciling the internal page.
              */
             if (WT_DELTA_INT_ENABLED(btree, S2C(session))) {
                 /* If there are concurrent changes to the first child, abort delta creation. */
-                if (__wt_atomic_load_uint8_v_acquire(&ref->rec_state) == WT_REF_REC_DIRTY &&
+                if (__wt_atomic_load_uint8_v_acquire(&ref->dirty_state) == WT_REF_DIRTY_DIRTY &&
                   build_delta && r->cell_zero)
                     __rec_stop_build_delta_int(r, &build_delta);
             }
@@ -654,12 +655,12 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
                 }
 
                 /*
-                 * Set the ref_changes state to zero if there were no concurrent changes while
+                 * Set the ref dirty state to clean if there were no concurrent changes while
                  * reconciling the internal page.
                  */
                 if (WT_DELTA_INT_ENABLED(btree, S2C(session))) {
                     /* If there are concurrent changes to the first child, abort delta creation. */
-                    if (__wt_atomic_load_uint8_v_acquire(&ref->rec_state) == WT_REF_REC_DIRTY &&
+                    if (__wt_atomic_load_uint8_v_acquire(&ref->dirty_state) == WT_REF_DIRTY_DIRTY &&
                       build_delta && r->cell_zero)
                         __rec_stop_build_delta_int(r, &build_delta);
                 }
@@ -672,12 +673,12 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
                 WT_ERR(__rec_row_merge(session, r, ref, prev_dirty, &build_delta));
 
                 /*
-                 * Set the ref_changes state to zero if there were no concurrent changes while
+                 * Set the ref dirty state to clean if there were no concurrent changes while
                  * reconciling the internal page.
                  */
                 if (WT_DELTA_INT_ENABLED(btree, S2C(session))) {
                     /* If there are concurrent changes to the first child, abort delta creation. */
-                    if (__wt_atomic_load_uint8_v_acquire(&ref->rec_state) == WT_REF_REC_DIRTY &&
+                    if (__wt_atomic_load_uint8_v_acquire(&ref->dirty_state) == WT_REF_DIRTY_DIRTY &&
                       build_delta && cell_zero_tmp)
                         __rec_stop_build_delta_int(r, &build_delta);
                 }
@@ -805,12 +806,12 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
             WT_ERR(__rec_pack_delta_row_int(session, r, key, val, &ta));
 
         /*
-         * Set the ref_changes state to zero if there were no concurrent changes while reconciling
+         * Set the ref dirty state to clean if there were no concurrent changes while reconciling
          * the internal page.
          */
         if (WT_DELTA_INT_ENABLED(btree, S2C(session))) {
             /* If there are concurrent changes to the first child, abort delta creation. */
-            if (__wt_atomic_load_uint8_v_acquire(&ref->rec_state) == WT_REF_REC_DIRTY &&
+            if (__wt_atomic_load_uint8_v_acquire(&ref->dirty_state) == WT_REF_DIRTY_DIRTY &&
               build_delta && r->cell_zero)
                 __rec_stop_build_delta_int(r, &build_delta);
         }

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -3156,7 +3156,7 @@ split:
     }
 
     if (WT_DELTA_INT_ENABLED(btree, S2C(session)))
-        __wt_atomic_store_uint8_v_release(&ref->dirty_state, WT_REF_DIRTY_DIRTY);
+        __wt_atomic_store_uint8_v_release(&ref->dirty_state, WT_REF_DIRTY);
 
     /*
      * If the page has post-instantiation delete information, we don't need it any more. Note: this

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -3156,7 +3156,7 @@ split:
     }
 
     if (WT_DELTA_INT_ENABLED(btree, S2C(session)))
-        __wt_atomic_store_uint8_v_release(&ref->rec_state, WT_REF_REC_DIRTY);
+        __wt_atomic_store_uint8_v_release(&ref->dirty_state, WT_REF_DIRTY_DIRTY);
 
     /*
      * If the page has post-instantiation delete information, we don't need it any more. Note: this


### PR DESCRIPTION
Rename `WT_REF::rec_state` to `dirty_state` to better reflect that the flag can be marked dirty outside of reconciliation as well.

This also renames the associated constants from `WT_REF_REC_CLEAN` / `WT_REF_REC_DIRTY` to `WT_REF_CLEAN` / `WT_REF_DIRTY`, updates the related comments, and fixes the debug output label in `bt_debug.c` from `rec_state` to `rec_result` to accurately reflect the field being printed (`mod->rec_result`).