### PR TITLE
WT-17021 Fix syntax error in the TSan suppressions file

### DIFF
--- a/test/evergreen/tsan_warnings.supp
+++ b/test/evergreen/tsan_warnings.supp
@@ -101,7 +101,7 @@ race:snap_track
 race:snap_verify_callback
 
 # FIXME-WT-16783: Statistic logging flags have concurrent accesses
-race: __statlog_config
+race:__statlog_config
 
 # Recently introduced issues.
 # FIXME-WT-16312: Check synchornization for __cell_unpack_window_cleanup_kv


### PR DESCRIPTION
Fix a syntax error in the TSan suppressions file; there should not be any space after "race:"