### PR TITLE
WT-16936 update checkpoint progress with checkpoint session only

### DIFF
--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -368,7 +368,10 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
 
             WT_ERR(__wt_reconcile(session, walk, NULL, rec_flags));
 
-            /* Update checkpoint IO tracking data. */
+            /*
+             * Update checkpoint IO tracking data. This sync can be executed by a non-checkpoint
+             * session, so we need a identify the session before update the checkpoint progress.
+             */
             if (WT_SESSION_IS_CHECKPOINT(session) && __wt_checkpoint_verbose_timer_started(session))
                 __wt_checkpoint_progress_stats(
                   session, __wt_atomic_load_size_relaxed(&page->memory_footprint));

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -369,7 +369,7 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
             WT_ERR(__wt_reconcile(session, walk, NULL, rec_flags));
 
             /* Update checkpoint IO tracking data. */
-            if (__wt_checkpoint_verbose_timer_started(session))
+            if (WT_SESSION_IS_CHECKPOINT(session) && __wt_checkpoint_verbose_timer_started(session))
                 __wt_checkpoint_progress_stats(
                   session, __wt_atomic_load_size_relaxed(&page->memory_footprint));
         }

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -369,8 +369,8 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
             WT_ERR(__wt_reconcile(session, walk, NULL, rec_flags));
 
             /*
-             * Update checkpoint IO tracking data. This sync can be executed by a non-checkpoint
-             * session, so we need a identify the session before update the checkpoint progress.
+             * Update checkpoint IO tracking data for the session running the checkpoint. Other
+             * session can execute this code but we are not tracking their progress.
              */
             if (WT_SESSION_IS_CHECKPOINT(session) && __wt_checkpoint_verbose_timer_started(session))
                 __wt_checkpoint_progress_stats(


### PR DESCRIPTION
Merging these changes to fix TSAN failures on feature branch `feature-chunk-cache-delete`.
