### PR TITLE
WT-16753 Disable realloc_exact for format stress ASAN task

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1696,7 +1696,7 @@ variables:
       - func: "format test script"
         vars:
           additional_san_vars: export ASAN_OPTIONS="$COMMON_SAN_OPTIONS:unmap_shadow_on_exit=1"
-          format_test_script_args: -t 360
+          format_test_script_args: -t 360 -- debug.realloc_exact=0
 
   - &race-condition-stress-asan-test
     exec_timeout_secs: 25200


### PR DESCRIPTION
Disable `debug.realloc_exact` only for the `format-stress-asan-test` Evergreen task.

The timeout investigation showed that `format-stress-asan-test` becomes pathologically slow under ASAN when `debug_mode.realloc_exact=true`. The exact realloc behavior is still useful for targeted manual debugging, so this change keeps the broader behavior unchanged and applies a narrow runtime override only to the affected Evergreen task.