### PR TITLE
WT-17029 Add missing checkpoint state when resolving tree

### DIFF
--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -2871,6 +2871,8 @@ fake:
 err:
     /* Resolved the checkpoint for the block manager in the error path. */
     if (resolve_bm) {
+        if (WT_SESSION_IS_CHECKPOINT(session))
+            WT_STAT_CONN_SET(session, checkpoint_state, WTI_CHECKPOINT_STATE_RESOLVE);
         WT_TRET(bm->checkpoint_resolve(bm, session, ret != 0));
 
         /*


### PR DESCRIPTION
The change updates the state of the checkpoint when resolving a tree in the error path. Before this change, it is possible to call this function and still have the state reflecting the previous checkpoint stage.