### PR TITLE
WT-17006 disagg: propagate stable and oldest timestamps when follower picks up checkpoint

### DIFF
--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -402,6 +402,24 @@ __disagg_update_checkpoint_meta(WT_SESSION_IMPL *session, WT_SESSION_IMPL *inter
       &conn->disaggregated_storage.last_checkpoint_oldest_timestamp, metadata->oldest_timestamp);
     conn->txn_global.last_ckpt_timestamp = metadata->checkpoint_timestamp;
 
+    /*
+     * Propagate the leader's stable and oldest timestamps from the checkpoint metadata into the
+     * global transaction state. On a follower, these are never set during recovery because the
+     * local metadata has no system:checkpoint entry. Update the pinned timestamp afterwards using
+     * the same approach as RTS.
+     */
+    if (metadata->checkpoint_timestamp != WT_TS_NONE) {
+        __wt_atomic_store_uint64_relaxed(
+          &conn->txn_global.stable_timestamp, metadata->checkpoint_timestamp);
+        __wt_atomic_store_bool_release(&conn->txn_global.has_stable_timestamp, true);
+    }
+    if (metadata->oldest_timestamp != WT_TS_NONE) {
+        __wt_atomic_store_uint64_relaxed(
+          &conn->txn_global.oldest_timestamp, metadata->oldest_timestamp);
+        __wt_atomic_store_bool_release(&conn->txn_global.has_oldest_timestamp, true);
+    }
+    WT_ERR(__wt_txn_update_oldest(session, WT_TXN_OLDEST_STRICT | WT_TXN_OLDEST_WAIT));
+
     /* Set the database size. */
     if (ckpt_meta->has_database_size)
         __wt_disagg_set_database_size(session, ckpt_meta->database_size);

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -414,25 +414,22 @@ __disagg_update_checkpoint_meta(WT_SESSION_IMPL *session, WT_SESSION_IMPL *inter
      * Only advance each timestamp, never move it backwards. The application layer may have already
      * set higher values via the public timestamp API, and rolling them back would break the rule
      * that timestamps only move forward and violate the oldest <= stable invariant.
+     *
+     * Skip acquiring the write lock if neither timestamp needs updating.
      */
-    __wt_writelock(session, &conn->txn_global.rwlock);
-    if (metadata->checkpoint_timestamp != WT_TS_NONE &&
-      metadata->checkpoint_timestamp >
-        __wt_atomic_load_uint64_relaxed(&conn->txn_global.stable_timestamp)) {
-        __wt_atomic_store_uint64_relaxed(
-          &conn->txn_global.stable_timestamp, metadata->checkpoint_timestamp);
-        __wt_atomic_store_bool_relaxed(&conn->txn_global.stable_is_pinned, false);
-        __wt_atomic_store_bool_release(&conn->txn_global.has_stable_timestamp, true);
+    if ((metadata->checkpoint_timestamp != WT_TS_NONE &&
+          (!__wt_atomic_load_bool_relaxed(&conn->txn_global.has_stable_timestamp) ||
+            metadata->checkpoint_timestamp >
+              __wt_atomic_load_uint64_relaxed(&conn->txn_global.stable_timestamp))) ||
+      (metadata->oldest_timestamp != WT_TS_NONE &&
+        (!__wt_atomic_load_bool_relaxed(&conn->txn_global.has_oldest_timestamp) ||
+          metadata->oldest_timestamp >
+            __wt_atomic_load_uint64_relaxed(&conn->txn_global.oldest_timestamp)))) {
+        __wt_writelock(session, &conn->txn_global.rwlock);
+        __wt_txn_advance_stable_oldest(
+          session, metadata->checkpoint_timestamp, metadata->oldest_timestamp, false, NULL, NULL);
+        __wt_writeunlock(session, &conn->txn_global.rwlock);
     }
-    if (metadata->oldest_timestamp != WT_TS_NONE &&
-      metadata->oldest_timestamp >
-        __wt_atomic_load_uint64_relaxed(&conn->txn_global.oldest_timestamp)) {
-        __wt_atomic_store_uint64_relaxed(
-          &conn->txn_global.oldest_timestamp, metadata->oldest_timestamp);
-        __wt_atomic_store_bool_relaxed(&conn->txn_global.oldest_is_pinned, false);
-        __wt_atomic_store_bool_release(&conn->txn_global.has_oldest_timestamp, true);
-    }
-    __wt_writeunlock(session, &conn->txn_global.rwlock);
     WT_ERR(__wt_txn_update_oldest(session, WT_TXN_OLDEST_STRICT | WT_TXN_OLDEST_WAIT));
 
     /* Set the database size. */

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -378,6 +378,32 @@ err:
 }
 
 /*
+ * __disagg_propagate_timestamps --
+ *     Advance the global stable and oldest timestamps from the leader's checkpoint metadata. The
+ *     update is advance-only: higher values already set by the application are preserved.
+ */
+static void
+__disagg_propagate_timestamps(
+  WT_SESSION_IMPL *session, wt_timestamp_t new_stable, wt_timestamp_t new_oldest)
+{
+    WT_CONNECTION_IMPL *conn;
+    bool oldest_changed, stable_changed;
+
+    conn = S2C(session);
+    oldest_changed = stable_changed = false;
+
+    if ((new_stable != WT_TS_NONE && new_stable > __wt_get_stable_timestamp(session)) ||
+      (new_oldest != WT_TS_NONE && new_oldest > __wt_get_oldest_timestamp(session))) {
+        __wt_writelock(session, &conn->txn_global.rwlock);
+        __wt_txn_update_stable_oldest(
+          session, new_stable, new_oldest, false, &stable_changed, &oldest_changed);
+        __wt_writeunlock(session, &conn->txn_global.rwlock);
+        if (stable_changed || oldest_changed)
+            __wt_txn_update_pinned_timestamp(session, false);
+    }
+}
+
+/*
  * __disagg_update_checkpoint_meta --
  *     Finalize checkpoint bookkeeping after processing shared metadata entries.
  */
@@ -386,10 +412,7 @@ __disagg_update_checkpoint_meta(WT_SESSION_IMPL *session, WT_SESSION_IMPL *inter
   const WT_DISAGG_CHECKPOINT_META *ckpt_meta, const WT_DISAGG_METADATA *metadata)
 {
     WT_DECL_RET;
-    bool oldest_changed, stable_changed;
     WT_CONNECTION_IMPL *conn = S2C(session);
-
-    oldest_changed = stable_changed = false;
 
     /*
      * Update the checkpoint metadata LSN. This doesn't require further synchronization, because the
@@ -405,32 +428,8 @@ __disagg_update_checkpoint_meta(WT_SESSION_IMPL *session, WT_SESSION_IMPL *inter
       &conn->disaggregated_storage.last_checkpoint_oldest_timestamp, metadata->oldest_timestamp);
     conn->txn_global.last_ckpt_timestamp = metadata->checkpoint_timestamp;
 
-    /*
-     * Propagate the leader's stable and oldest timestamps from the checkpoint metadata into the
-     * global transaction state. On a follower, these are never set during recovery because the
-     * local metadata has no system:checkpoint entry. The stable timestamp is needed so that data
-     * validation and rollback-to-stable can correctly validate time aggregates. The oldest
-     * timestamp establishes the lower bound for read timestamps on the follower: since the
-     * follower's data comes entirely from the leader's checkpoint, it cannot contain versions older
-     * than the leader's oldest at the time of that checkpoint.
-     *
-     * Only advance each timestamp, never move it backwards. The application layer may have already
-     * set higher values via the public timestamp API, and rolling them back would break the rule
-     * that timestamps only move forward and violate the oldest <= stable invariant.
-     *
-     * Skip acquiring the write lock if neither timestamp needs updating.
-     */
-    if ((metadata->checkpoint_timestamp != WT_TS_NONE &&
-          metadata->checkpoint_timestamp > __wt_get_stable_timestamp(session)) ||
-      (metadata->oldest_timestamp != WT_TS_NONE &&
-        metadata->oldest_timestamp > __wt_get_oldest_timestamp(session))) {
-        __wt_writelock(session, &conn->txn_global.rwlock);
-        __wt_txn_update_stable_oldest(session, metadata->checkpoint_timestamp,
-          metadata->oldest_timestamp, false, &stable_changed, &oldest_changed);
-        __wt_writeunlock(session, &conn->txn_global.rwlock);
-        if (stable_changed || oldest_changed)
-            __wt_txn_update_pinned_timestamp(session, false);
-    }
+    __disagg_propagate_timestamps(
+      session, metadata->checkpoint_timestamp, metadata->oldest_timestamp);
 
     /* Set the database size. */
     if (ckpt_meta->has_database_size)

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -421,15 +421,11 @@ __disagg_update_checkpoint_meta(WT_SESSION_IMPL *session, WT_SESSION_IMPL *inter
      * Skip acquiring the write lock if neither timestamp needs updating.
      */
     if ((metadata->checkpoint_timestamp != WT_TS_NONE &&
-          (!__wt_atomic_load_bool_relaxed(&conn->txn_global.has_stable_timestamp) ||
-            metadata->checkpoint_timestamp >
-              __wt_atomic_load_uint64_relaxed(&conn->txn_global.stable_timestamp))) ||
+          metadata->checkpoint_timestamp > __wt_get_stable_timestamp(session)) ||
       (metadata->oldest_timestamp != WT_TS_NONE &&
-        (!__wt_atomic_load_bool_relaxed(&conn->txn_global.has_oldest_timestamp) ||
-          metadata->oldest_timestamp >
-            __wt_atomic_load_uint64_relaxed(&conn->txn_global.oldest_timestamp)))) {
+        metadata->oldest_timestamp > __wt_get_oldest_timestamp(session))) {
         __wt_writelock(session, &conn->txn_global.rwlock);
-        __wt_txn_advance_stable_oldest(session, metadata->checkpoint_timestamp,
+        __wt_txn_update_stable_oldest(session, metadata->checkpoint_timestamp,
           metadata->oldest_timestamp, false, &stable_changed, &oldest_changed);
         __wt_writeunlock(session, &conn->txn_global.rwlock);
         if (stable_changed || oldest_changed)

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -405,19 +405,34 @@ __disagg_update_checkpoint_meta(WT_SESSION_IMPL *session, WT_SESSION_IMPL *inter
     /*
      * Propagate the leader's stable and oldest timestamps from the checkpoint metadata into the
      * global transaction state. On a follower, these are never set during recovery because the
-     * local metadata has no system:checkpoint entry. Update the pinned timestamp afterwards using
-     * the same approach as RTS.
+     * local metadata has no system:checkpoint entry. The stable timestamp is needed so that data
+     * validation and rollback-to-stable can correctly validate time aggregates. The oldest
+     * timestamp establishes the lower bound for read timestamps on the follower: since the
+     * follower's data comes entirely from the leader's checkpoint, it cannot contain versions older
+     * than the leader's oldest at the time of that checkpoint.
+     *
+     * Only advance each timestamp, never move it backwards. The application layer may have already
+     * set higher values via the public timestamp API, and rolling them back would break the rule
+     * that timestamps only move forward and violate the oldest <= stable invariant.
      */
-    if (metadata->checkpoint_timestamp != WT_TS_NONE) {
+    __wt_writelock(session, &conn->txn_global.rwlock);
+    if (metadata->checkpoint_timestamp != WT_TS_NONE &&
+      metadata->checkpoint_timestamp >
+        __wt_atomic_load_uint64_relaxed(&conn->txn_global.stable_timestamp)) {
         __wt_atomic_store_uint64_relaxed(
           &conn->txn_global.stable_timestamp, metadata->checkpoint_timestamp);
+        __wt_atomic_store_bool_relaxed(&conn->txn_global.stable_is_pinned, false);
         __wt_atomic_store_bool_release(&conn->txn_global.has_stable_timestamp, true);
     }
-    if (metadata->oldest_timestamp != WT_TS_NONE) {
+    if (metadata->oldest_timestamp != WT_TS_NONE &&
+      metadata->oldest_timestamp >
+        __wt_atomic_load_uint64_relaxed(&conn->txn_global.oldest_timestamp)) {
         __wt_atomic_store_uint64_relaxed(
           &conn->txn_global.oldest_timestamp, metadata->oldest_timestamp);
+        __wt_atomic_store_bool_relaxed(&conn->txn_global.oldest_is_pinned, false);
         __wt_atomic_store_bool_release(&conn->txn_global.has_oldest_timestamp, true);
     }
+    __wt_writeunlock(session, &conn->txn_global.rwlock);
     WT_ERR(__wt_txn_update_oldest(session, WT_TXN_OLDEST_STRICT | WT_TXN_OLDEST_WAIT));
 
     /* Set the database size. */

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -386,7 +386,10 @@ __disagg_update_checkpoint_meta(WT_SESSION_IMPL *session, WT_SESSION_IMPL *inter
   const WT_DISAGG_CHECKPOINT_META *ckpt_meta, const WT_DISAGG_METADATA *metadata)
 {
     WT_DECL_RET;
+    bool oldest_changed, stable_changed;
     WT_CONNECTION_IMPL *conn = S2C(session);
+
+    oldest_changed = stable_changed = false;
 
     /*
      * Update the checkpoint metadata LSN. This doesn't require further synchronization, because the
@@ -426,11 +429,12 @@ __disagg_update_checkpoint_meta(WT_SESSION_IMPL *session, WT_SESSION_IMPL *inter
           metadata->oldest_timestamp >
             __wt_atomic_load_uint64_relaxed(&conn->txn_global.oldest_timestamp)))) {
         __wt_writelock(session, &conn->txn_global.rwlock);
-        __wt_txn_advance_stable_oldest(
-          session, metadata->checkpoint_timestamp, metadata->oldest_timestamp, false, NULL, NULL);
+        __wt_txn_advance_stable_oldest(session, metadata->checkpoint_timestamp,
+          metadata->oldest_timestamp, false, &stable_changed, &oldest_changed);
         __wt_writeunlock(session, &conn->txn_global.rwlock);
+        if (stable_changed || oldest_changed)
+            __wt_txn_update_pinned_timestamp(session, false);
     }
-    WT_ERR(__wt_txn_update_oldest(session, WT_TXN_OLDEST_STRICT | WT_TXN_OLDEST_WAIT));
 
     /* Set the database size. */
     if (ckpt_meta->has_database_size)

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1854,6 +1854,7 @@ extern void __wt_txn_release_snapshot(WT_SESSION_IMPL *session);
 extern void __wt_txn_snapshot_release_and_restore(WT_SESSION_IMPL *session);
 extern void __wt_txn_stats_update(WT_SESSION_IMPL *session);
 extern void __wt_txn_truncate_end(WT_SESSION_IMPL *session);
+extern void __wt_txn_update_pinned_timestamp(WT_SESSION_IMPL *session, bool force);
 extern void __wt_update_obsolete_check(
   WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd);
 extern void __wt_update_vector_clear(WT_UPDATE_VECTOR *updates);
@@ -1911,7 +1912,6 @@ extern void __wti_txn_clear_durable_timestamp(WT_SESSION_IMPL *session);
 extern void __wti_txn_clear_read_timestamp(WT_SESSION_IMPL *session);
 extern void __wti_txn_get_pinned_timestamp(
   WT_SESSION_IMPL *session, wt_timestamp_t *tsp, uint32_t flags);
-extern void __wti_txn_update_pinned_timestamp(WT_SESSION_IMPL *session, bool force);
 static WT_INLINE WT_BTREE *__wt_curhs_get_btree(WT_CURSOR *cursor)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE WT_CELL *__wt_cell_leaf_value_parse(WT_PAGE *page, WT_CELL *cell)

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1841,6 +1841,8 @@ extern void __wt_tiered_remove_work(WT_SESSION_IMPL *session, WT_TIERED *tiered,
 extern void __wt_tiered_requeue_work(WT_SESSION_IMPL *session, WT_TIERED_WORK_UNIT *entry);
 extern void __wt_tiered_work_free(WT_SESSION_IMPL *session, WT_TIERED_WORK_UNIT *entry);
 extern void __wt_timestamp_to_hex_string(wt_timestamp_t ts, char *hex_timestamp);
+extern void __wt_txn_advance_stable_oldest(WT_SESSION_IMPL *session, wt_timestamp_t new_stable,
+  wt_timestamp_t new_oldest, bool force, bool *stable_changed, bool *oldest_changed);
 extern void __wt_txn_bump_snapshot(WT_SESSION_IMPL *session);
 extern void __wt_txn_close_checkpoint_cursor(WT_SESSION_IMPL *session, WT_TXN **txn_arg);
 extern void __wt_txn_destroy(WT_SESSION_IMPL *session);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1841,8 +1841,6 @@ extern void __wt_tiered_remove_work(WT_SESSION_IMPL *session, WT_TIERED *tiered,
 extern void __wt_tiered_requeue_work(WT_SESSION_IMPL *session, WT_TIERED_WORK_UNIT *entry);
 extern void __wt_tiered_work_free(WT_SESSION_IMPL *session, WT_TIERED_WORK_UNIT *entry);
 extern void __wt_timestamp_to_hex_string(wt_timestamp_t ts, char *hex_timestamp);
-extern void __wt_txn_advance_stable_oldest(WT_SESSION_IMPL *session, wt_timestamp_t new_stable,
-  wt_timestamp_t new_oldest, bool force, bool *stable_changed, bool *oldest_changed);
 extern void __wt_txn_bump_snapshot(WT_SESSION_IMPL *session);
 extern void __wt_txn_close_checkpoint_cursor(WT_SESSION_IMPL *session, WT_TXN **txn_arg);
 extern void __wt_txn_destroy(WT_SESSION_IMPL *session);
@@ -1855,6 +1853,8 @@ extern void __wt_txn_snapshot_release_and_restore(WT_SESSION_IMPL *session);
 extern void __wt_txn_stats_update(WT_SESSION_IMPL *session);
 extern void __wt_txn_truncate_end(WT_SESSION_IMPL *session);
 extern void __wt_txn_update_pinned_timestamp(WT_SESSION_IMPL *session, bool force);
+extern void __wt_txn_update_stable_oldest(WT_SESSION_IMPL *session, wt_timestamp_t new_stable,
+  wt_timestamp_t new_oldest, bool force, bool *stable_changed, bool *oldest_changed);
 extern void __wt_update_obsolete_check(
   WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd);
 extern void __wt_update_vector_clear(WT_UPDATE_VECTOR *updates);

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -493,7 +493,7 @@ __wt_txn_update_oldest(WT_SESSION_IMPL *session, uint32_t flags)
 
     /* Try to move the pinned timestamp forward. */
     if (strict)
-        __wti_txn_update_pinned_timestamp(session, false);
+        __wt_txn_update_pinned_timestamp(session, false);
 
     /*
      * For pure read-only workloads, or if the update isn't forced and the oldest ID isn't too far

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -689,7 +689,7 @@ __recovery_txn_setup_initial_state(WT_SESSION_IMPL *session, WT_RECOVERY *r)
      * Now that timestamps extracted from the checkpoint metadata have been configured, configure
      * the pinned timestamp.
      */
-    __wti_txn_update_pinned_timestamp(session, true);
+    __wt_txn_update_pinned_timestamp(session, true);
 
     WT_ASSERT(session,
       !__wt_atomic_load_bool_relaxed(&conn->txn_global.has_stable_timestamp) &&

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -317,6 +317,68 @@ __wti_txn_update_pinned_timestamp(WT_SESSION_IMPL *session, bool force)
 }
 
 /*
+ * __txn_advance_one_timestamp --
+ *     Advance a single global timestamp (stable or oldest) to a new value. When force is false the
+ *     update is advance-only. When force is true the value is stored unconditionally. The caller
+ *     must hold the txn_global write lock. Returns true if the timestamp was actually written.
+ */
+static bool
+__txn_advance_one_timestamp(
+  WT_SESSION_IMPL *session, wt_timestamp_t new_ts, bool force, bool is_stable)
+{
+    WT_TXN_GLOBAL *txn_global;
+    wt_timestamp_t *tsp;
+    bool *has_tsp, *is_pinnedp;
+
+    txn_global = &S2C(session)->txn_global;
+
+    if (is_stable) {
+        tsp = &txn_global->stable_timestamp;
+        has_tsp = &txn_global->has_stable_timestamp;
+        is_pinnedp = &txn_global->stable_is_pinned;
+    } else {
+        tsp = &txn_global->oldest_timestamp;
+        has_tsp = &txn_global->has_oldest_timestamp;
+        is_pinnedp = &txn_global->oldest_is_pinned;
+    }
+
+    if (new_ts == WT_TS_NONE ||
+      (!force && __wt_atomic_load_bool_relaxed(has_tsp) &&
+        new_ts <= __wt_atomic_load_uint64_relaxed(tsp)))
+        return (false);
+
+    __wt_atomic_store_uint64_relaxed(tsp, new_ts);
+    __wt_atomic_store_bool_relaxed(is_pinnedp, false);
+    __wt_atomic_store_bool_release(has_tsp, true);
+    __wt_verbose_timestamp(session, new_ts,
+      is_stable ? "Updated global stable timestamp" : "Updated global oldest timestamp");
+    return (true);
+}
+
+/*
+ * __wt_txn_advance_stable_oldest --
+ *     Update the global stable and oldest timestamps to the given values. When force is false the
+ *     update is advance-only: a timestamp is skipped if the current value is already higher. When
+ *     force is true the values are stored unconditionally, allowing the caller to move timestamps
+ *     backwards. The caller must hold the txn_global write lock. The optional output parameters
+ *     stable_changed and oldest_changed are set to indicate whether each timestamp was actually
+ *     written.
+ */
+void
+__wt_txn_advance_stable_oldest(WT_SESSION_IMPL *session, wt_timestamp_t new_stable,
+  wt_timestamp_t new_oldest, bool force, bool *stable_changed, bool *oldest_changed)
+{
+    if (stable_changed != NULL)
+        *stable_changed = __txn_advance_one_timestamp(session, new_stable, force, true);
+    else
+        (void)__txn_advance_one_timestamp(session, new_stable, force, true);
+    if (oldest_changed != NULL)
+        *oldest_changed = __txn_advance_one_timestamp(session, new_oldest, force, false);
+    else
+        (void)__txn_advance_one_timestamp(session, new_oldest, force, false);
+}
+
+/*
  * __wt_txn_global_set_timestamp --
  *     Set a global transaction timestamp.
  */
@@ -329,7 +391,7 @@ __wt_txn_global_set_timestamp(WT_SESSION_IMPL *session, const char *cfg[])
     wt_timestamp_t durable_ts, oldest_ts, stable_ts;
     wt_timestamp_t last_oldest_ts, last_stable_ts;
     char ts_string[2][WT_TS_INT_STRING_SIZE];
-    bool force, has_durable, has_oldest, has_stable;
+    bool force, has_durable, has_oldest, has_stable, oldest_changed, stable_changed;
 
     txn_global = &S2C(session)->txn_global;
 
@@ -438,25 +500,13 @@ set:
         __wt_verbose_timestamp(session, durable_ts, "Updated global durable timestamp");
     }
 
-    if (has_oldest &&
-      (!__wt_atomic_load_bool_relaxed(&txn_global->has_oldest_timestamp) || force ||
-        oldest_ts > __wt_atomic_load_uint64_relaxed(&txn_global->oldest_timestamp))) {
-        __wt_atomic_store_uint64_relaxed(&txn_global->oldest_timestamp, oldest_ts);
-        __wt_atomic_store_bool_relaxed(&txn_global->oldest_is_pinned, false);
-        __wt_atomic_store_bool_release(&txn_global->has_oldest_timestamp, true);
+    oldest_changed = stable_changed = false;
+    __wt_txn_advance_stable_oldest(session, has_stable ? stable_ts : WT_TS_NONE,
+      has_oldest ? oldest_ts : WT_TS_NONE, force, &stable_changed, &oldest_changed);
+    if (oldest_changed)
         WT_STAT_CONN_INCR(session, txn_set_ts_oldest_upd);
-        __wt_verbose_timestamp(session, oldest_ts, "Updated global oldest timestamp");
-    }
-
-    if (has_stable &&
-      (!__wt_atomic_load_bool_relaxed(&txn_global->has_stable_timestamp) || force ||
-        stable_ts > __wt_atomic_load_uint64_relaxed(&txn_global->stable_timestamp))) {
-        __wt_atomic_store_uint64_relaxed(&txn_global->stable_timestamp, stable_ts);
-        __wt_atomic_store_bool_relaxed(&txn_global->stable_is_pinned, false);
-        __wt_atomic_store_bool_release(&txn_global->has_stable_timestamp, true);
+    if (stable_changed)
         WT_STAT_CONN_INCR(session, txn_set_ts_stable_upd);
-        __wt_verbose_timestamp(session, stable_ts, "Updated global stable timestamp");
-    }
 
     /*
      * Even if the timestamps have been forcibly set, they must always satisfy the condition that

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -317,13 +317,12 @@ __wt_txn_update_pinned_timestamp(WT_SESSION_IMPL *session, bool force)
 }
 
 /*
- * __txn_advance_one_timestamp --
- *     Advance a single global timestamp (stable or oldest) to a new value. When force is false the
- *     update is advance-only. When force is true the value is stored unconditionally. The caller
- *     must hold the txn_global write lock. Returns true if the timestamp was actually written.
+ * __txn_update_one_timestamp --
+ *     Advance a single global timestamp. When force is false, skipped if the current value is
+ *     already higher. Returns true if the timestamp was written. Caller must hold the write lock.
  */
 static bool
-__txn_advance_one_timestamp(
+__txn_update_one_timestamp(
   WT_SESSION_IMPL *session, wt_timestamp_t new_ts, bool force, bool is_stable)
 {
     WT_TXN_GLOBAL *txn_global;
@@ -356,26 +355,22 @@ __txn_advance_one_timestamp(
 }
 
 /*
- * __wt_txn_advance_stable_oldest --
- *     Update the global stable and oldest timestamps to the given values. When force is false the
- *     update is advance-only: a timestamp is skipped if the current value is already higher. When
- *     force is true the values are stored unconditionally, allowing the caller to move timestamps
- *     backwards. The caller must hold the txn_global write lock. The optional output parameters
- *     stable_changed and oldest_changed are set to indicate whether each timestamp was actually
- *     written.
+ * __wt_txn_update_stable_oldest --
+ *     Advance the global stable and oldest timestamps. When force is false, a timestamp is skipped
+ *     if the current value is already higher. The caller must hold the txn_global write lock.
  */
 void
-__wt_txn_advance_stable_oldest(WT_SESSION_IMPL *session, wt_timestamp_t new_stable,
+__wt_txn_update_stable_oldest(WT_SESSION_IMPL *session, wt_timestamp_t new_stable,
   wt_timestamp_t new_oldest, bool force, bool *stable_changed, bool *oldest_changed)
 {
     if (stable_changed != NULL)
-        *stable_changed = __txn_advance_one_timestamp(session, new_stable, force, true);
+        *stable_changed = __txn_update_one_timestamp(session, new_stable, force, true);
     else
-        (void)__txn_advance_one_timestamp(session, new_stable, force, true);
+        (void)__txn_update_one_timestamp(session, new_stable, force, true);
     if (oldest_changed != NULL)
-        *oldest_changed = __txn_advance_one_timestamp(session, new_oldest, force, false);
+        *oldest_changed = __txn_update_one_timestamp(session, new_oldest, force, false);
     else
-        (void)__txn_advance_one_timestamp(session, new_oldest, force, false);
+        (void)__txn_update_one_timestamp(session, new_oldest, force, false);
 }
 
 /*
@@ -501,7 +496,7 @@ set:
     }
 
     oldest_changed = stable_changed = false;
-    __wt_txn_advance_stable_oldest(session, has_stable ? stable_ts : WT_TS_NONE,
+    __wt_txn_update_stable_oldest(session, has_stable ? stable_ts : WT_TS_NONE,
       has_oldest ? oldest_ts : WT_TS_NONE, force, &stable_changed, &oldest_changed);
     if (oldest_changed)
         WT_STAT_CONN_INCR(session, txn_set_ts_oldest_upd);

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -261,12 +261,12 @@ __wt_txn_query_timestamp(
 }
 
 /*
- * __wti_txn_update_pinned_timestamp --
+ * __wt_txn_update_pinned_timestamp --
  *     Update the pinned timestamp (the oldest timestamp that has to be maintained for current or
  *     future readers).
  */
 void
-__wti_txn_update_pinned_timestamp(WT_SESSION_IMPL *session, bool force)
+__wt_txn_update_pinned_timestamp(WT_SESSION_IMPL *session, bool force)
 {
     WT_TXN_GLOBAL *txn_global;
     wt_timestamp_t last_pinned_timestamp, pinned_timestamp;
@@ -528,7 +528,7 @@ set:
     __wt_writeunlock(session, &txn_global->rwlock);
 
     if (has_oldest || has_stable)
-        __wti_txn_update_pinned_timestamp(session, force);
+        __wt_txn_update_pinned_timestamp(session, force);
 
     return (0);
 }

--- a/test/evergreen/tsan_warnings.supp
+++ b/test/evergreen/tsan_warnings.supp
@@ -56,7 +56,7 @@ race:__wt_reconcile
 # FIXME-WT-14856 Unresolved warnings for ex_all
 race:__wti_conn_reconfig
 race:__wt_session_cursor_cache_sweep
-race:__wti_txn_update_pinned_timestamp
+race:__wt_txn_update_pinned_timestamp
 race:__capacity_config
 
 # FIXME-WT-15772 Issues caused by lack of atomics synchornization for double-checked locking pattern in the TAILQ implementation.

--- a/test/suite/test_layered37.py
+++ b/test/suite/test_layered37.py
@@ -107,7 +107,7 @@ class test_layered37(wttest.WiredTigerTestCase):
         # Trigger eviction on the ingest table
         evict_cursor = session_follow.open_cursor("file:test_layered37.wt_ingest", None, "debug=(release_evict)")
         for i in range(1, self.nitems):
-            session_follow.begin_transaction(f'read_timestamp={self.timestamp_str(ts)}')
+            session_follow.begin_transaction(f'read_timestamp={self.timestamp_str(ts)},roundup_timestamps=(read=true)')
             evict_cursor.set_key(str(i))
             self.assertEqual(evict_cursor.search(), 0)
             evict_cursor.reset()

--- a/test/suite/test_layered68.py
+++ b/test/suite/test_layered68.py
@@ -139,6 +139,8 @@ class test_layered68(wttest.WiredTigerTestCase):
             self.conn.reconfigure('disaggregated=(role="leader")')
 
             # Modify some data to make sure we can keep writing.
+            # Use timestamp 3 since the picked-up checkpoint has stable_timestamp=2,
+            # and commit_timestamp must be strictly greater than stable_timestamp.
             self.session.begin_transaction()
             cursor = self.session.open_cursor(self.uri, None, None)
             num_modified = self.num_modify * 2
@@ -146,9 +148,9 @@ class test_layered68(wttest.WiredTigerTestCase):
                 key = f'key{i:04}'
                 cursor[key] = f'value_mod{i:04}' + 'abcd' * 100
             cursor.close()
-            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(2))
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(3))
 
-            self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(2))
+            self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(3))
             self.session.checkpoint()
 
         #

--- a/test/suite/test_layered82.py
+++ b/test/suite/test_layered82.py
@@ -31,430 +31,64 @@ from helper_disagg import disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 
 # test_layered82.py
-#   Test cursor bounds on layered cursors with a 1000-key dataset.
-
+#    Verify that session.verify() on a follower with no stable timestamp
+#    set does not produce a false positive error. Before the fix, the
+#    verify timestamp validation compared cell timestamps against
+#    stable=0 and incorrectly reported corruption.
 @disagg_test_class
 class test_layered82(wttest.WiredTigerTestCase):
-    conn_base_config = ',create,statistics=(all),statistics_log=(wait=1,json=true,on_close=true),'
+    conn_base_config = ',create,statistics=(all),'
+    conn_config = 'disaggregated=(role="leader")'
+    create_session_config = 'key_format=i,value_format=S'
     uri = 'layered:test_layered82'
-    nkeys = 1000
 
     disagg_storages = gen_disagg_storages('test_layered82', disagg_only=True)
-
     scenarios = make_scenarios(disagg_storages)
 
-    def conn_config(self):
-        return self.extensionsConfig() + self.conn_base_config + 'disaggregated=(role="leader")'
+    def test_follower_verify_no_stable_timestamp(self):
+        # Leader: write timestamped data and checkpoint.
+        self.session.create(self.uri, self.create_session_config)
 
-    def setUp(self):
-        super().setUp()
-        self.ts = 1
-        self.conn_follow = self.wiredtiger_open('follower',
-            self.extensionsConfig() + self.conn_base_config + 'disaggregated=(role="follower")')
-        self.session_follow = self.conn_follow.open_session('')
-        config = "key_format=S,value_format=S"
-        self.session.create(self.uri, config)
-        self.session_follow.create(self.uri, config)
-
-    def next_ts(self):
-        self.ts += 1
-        return self.ts
-
-    @staticmethod
-    def fmt_key(i):
-        return f"{i:06d}"
-
-    @staticmethod
-    def fmt_val(i):
-        return f"val_{i:06d}"
-
-    # -----------------------------------------------------------------------
-    # Low-level insert/remove helpers (accept lists of ints).
-    # -----------------------------------------------------------------------
-
-    def insert_stable(self, keys, values=None):
-        """Insert keys (list of ints) into stable via leader checkpoint."""
+        self.session.begin_transaction()
         cursor = self.session.open_cursor(self.uri)
-        for idx, i in enumerate(keys):
-            key = self.fmt_key(i)
-            val = values[idx] if values else self.fmt_val(i)
-            self.session.begin_transaction()
-            cursor[key] = val
-            self.session.commit_transaction(f"commit_timestamp={self.timestamp_str(self.next_ts())}")
+        cursor[1] = 'value1'
         cursor.close()
-        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(self.ts)}')
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
+
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10) +
+                                ',oldest_timestamp=' + self.timestamp_str(5))
         self.session.checkpoint()
-        self.disagg_advance_checkpoint(self.conn_follow)
 
-    def insert_ingest(self, keys, values=None):
-        """Insert keys (list of ints) into the follower's local table."""
-        session = self.session_follow
-        cursor = session.open_cursor(self.uri)
-        for idx, i in enumerate(keys):
-            key = self.fmt_key(i)
-            val = values[idx] if values else self.fmt_val(i)
-            session.begin_transaction()
-            cursor[key] = val
-            session.commit_transaction(f"commit_timestamp={self.timestamp_str(self.next_ts())}")
-        cursor.close()
-
-    def remove_ingest(self, keys):
-        """Remove keys (list of ints) from the follower's local table."""
-        session = self.session_follow
-        cursor = session.open_cursor(self.uri)
-        for i in keys:
-            key = self.fmt_key(i)
-            session.begin_transaction()
-            cursor.set_key(key)
-            cursor.remove()
-            session.commit_transaction(f"commit_timestamp={self.timestamp_str(self.next_ts())}")
-        cursor.close()
-
-    # -----------------------------------------------------------------------
-    # Data population helpers  each creates a common data layout.
-    # -----------------------------------------------------------------------
-
-    def populate_interleaved(self):
-        """Checkpointed even keys and locally-written odd keys. Returns all expected keys."""
-        self.insert_stable(list(range(0, self.nkeys, 2)))
-        self.insert_ingest(list(range(1, self.nkeys, 2)))
-        return [self.fmt_key(i) for i in range(self.nkeys)]
-
-    def populate_all_stable(self):
-        """All keys checkpointed. Returns all expected keys."""
-        self.insert_stable(list(range(self.nkeys)))
-        return [self.fmt_key(i) for i in range(self.nkeys)]
-
-    def populate_all_ingest(self):
-        """All keys written locally (no checkpoint). Returns all expected keys."""
-        self.insert_ingest(list(range(self.nkeys)))
-        return [self.fmt_key(i) for i in range(self.nkeys)]
-
-    # -----------------------------------------------------------------------
-    # Cursor helpers.
-    # -----------------------------------------------------------------------
-
-    def set_bounds(self, cursor, lower=None, upper=None,
-                   lower_inclusive=True, upper_inclusive=True):
-        """Set bounds on a cursor. Pass None to skip a bound."""
-        if lower is not None:
-            cursor.set_key(lower)
-            incl = "true" if lower_inclusive else "false"
-            cursor.bound(f"bound=lower,inclusive={incl}")
-        if upper is not None:
-            cursor.set_key(upper)
-            incl = "true" if upper_inclusive else "false"
-            cursor.bound(f"bound=upper,inclusive={incl}")
-
-    def scan_forward(self, cursor):
-        """Scan forward and return list of keys."""
-        keys = []
-        while cursor.next() == 0:
-            keys.append(cursor.get_key())
-        return keys
-
-    def scan_backward(self, cursor):
-        """Scan backward and return list of keys."""
-        keys = []
-        while cursor.prev() == 0:
-            keys.append(cursor.get_key())
-        return keys
-
-    def open_bounded_cursor(self, lower=None, upper=None,
-                            lower_inclusive=True, upper_inclusive=True):
-        """Open a cursor on the session under test and set bounds."""
-        cursor = self.session_follow.open_cursor(self.uri)
-        self.set_bounds(cursor, lower, upper, lower_inclusive, upper_inclusive)
-        return cursor
-
-    def expected_range(self, lo, hi):
-        """Return list of formatted keys for range [lo, hi] inclusive."""
-        return [self.fmt_key(i) for i in range(lo, hi + 1)]
-
-    # =====================================================================
-    # Tests
-    # =====================================================================
-
-    def test_bounds_ingest_only(self):
-        """Bounds with all data written locally (no checkpoint)."""
-        self.populate_all_ingest()
-
-        cursor = self.open_bounded_cursor(lower=self.fmt_key(200), upper=self.fmt_key(800))
-        self.assertEqual(self.scan_forward(cursor), self.expected_range(200, 800))
-        cursor.close()
-
-    def test_bounds_stable_only(self):
-        """Bounds with all data checkpointed."""
-        self.populate_all_stable()
-
-        cursor = self.open_bounded_cursor(lower=self.fmt_key(200), upper=self.fmt_key(800))
-        self.assertEqual(self.scan_forward(cursor), self.expected_range(200, 800))
-        cursor.close()
-
-    def test_bounds_split_data(self):
-        """Bounds with interleaved data (checkpointed even keys, locally-written odd keys)."""
-        self.populate_interleaved()
-
-        cursor = self.open_bounded_cursor(lower=self.fmt_key(200), upper=self.fmt_key(800))
-        self.assertEqual(self.scan_forward(cursor), self.expected_range(200, 800))
-        cursor.close()
-
-    def test_bounds_split_data_prev(self):
-        """Bounds with interleaved data, reverse iteration."""
-        self.populate_interleaved()
-
-        cursor = self.open_bounded_cursor(lower=self.fmt_key(200), upper=self.fmt_key(800))
-        expected = [self.fmt_key(i) for i in range(800, 199, -1)]
-        self.assertEqual(self.scan_backward(cursor), expected)
-        cursor.close()
-
-    def test_bounds_lower_only(self):
-        """Lower bound only at 500. Expected: 500-999."""
-        self.populate_interleaved()
-
-        cursor = self.open_bounded_cursor(lower=self.fmt_key(500))
-        self.assertEqual(self.scan_forward(cursor), self.expected_range(500, 999))
-        cursor.close()
-
-    def test_bounds_upper_only(self):
-        """Upper bound only at 500. Expected: 0-500."""
-        self.populate_interleaved()
-
-        cursor = self.open_bounded_cursor(upper=self.fmt_key(500))
-        self.assertEqual(self.scan_forward(cursor), self.expected_range(0, 500))
-        cursor.close()
-
-    def test_bounds_exclusive_lower(self):
-        """Exclusive lower bound at 200. Expected: 201-999."""
-        self.populate_interleaved()
-
-        cursor = self.open_bounded_cursor(lower=self.fmt_key(200), lower_inclusive=False)
-        self.assertEqual(self.scan_forward(cursor), self.expected_range(201, 999))
-        cursor.close()
-
-    def test_bounds_exclusive_upper(self):
-        """Exclusive upper bound at 800. Expected: 0-799."""
-        self.populate_interleaved()
-
-        cursor = self.open_bounded_cursor(upper=self.fmt_key(800), upper_inclusive=False)
-        self.assertEqual(self.scan_forward(cursor), self.expected_range(0, 799))
-        cursor.close()
-
-    def test_bounds_both_exclusive(self):
-        """Both bounds exclusive: (200, 800). Expected: 201-799."""
-        self.populate_interleaved()
-
-        cursor = self.open_bounded_cursor(
-            lower=self.fmt_key(200), upper=self.fmt_key(800),
-            lower_inclusive=False, upper_inclusive=False)
-        self.assertEqual(self.scan_forward(cursor), self.expected_range(201, 799))
-        cursor.close()
-
-    def test_bounds_nonexistent_keys(self):
-        """Bounds at keys that don't exist. Even keys only, bounds [201, 799]."""
-        self.insert_stable(list(range(0, self.nkeys, 2)))
-
-        cursor = self.open_bounded_cursor(lower=self.fmt_key(201), upper=self.fmt_key(799))
-        expected = [self.fmt_key(i) for i in range(202, 800, 2)]
-        self.assertEqual(self.scan_forward(cursor), expected)
-        cursor.close()
-
-    def test_bounds_no_data_in_range(self):
-        """Bounds [1500, 2000] beyond all data. Expected: empty."""
-        self.populate_interleaved()
-
-        cursor = self.open_bounded_cursor(lower=self.fmt_key(1500), upper=self.fmt_key(2000))
-        self.assertEqual(self.scan_forward(cursor), [])
-        cursor.close()
-
-    def test_bounds_tombstone_inside(self):
-        """Tombstone every 3rd key in [200, 800]. Bounds [200, 800]."""
-        self.populate_all_stable()
-        self.remove_ingest([i for i in range(200, 801) if i % 3 == 0])
-
-        cursor = self.open_bounded_cursor(lower=self.fmt_key(200), upper=self.fmt_key(800))
-        expected = [self.fmt_key(i) for i in range(200, 801) if i % 3 != 0]
-        self.assertEqual(self.scan_forward(cursor), expected)
-        cursor.close()
-
-    def test_bounds_tombstone_at_bounds(self):
-        """Tombstone the bound keys 200 and 800. Bounds [200, 800]. Expected: 201-799."""
-        self.populate_all_stable()
-        self.remove_ingest([200, 800])
-
-        cursor = self.open_bounded_cursor(lower=self.fmt_key(200), upper=self.fmt_key(800))
-        self.assertEqual(self.scan_forward(cursor), self.expected_range(201, 799))
-        cursor.close()
-
-    def test_bounds_all_tombstoned_in_range(self):
-        """Tombstone everything in [200, 800]. Bounds [200, 800]. Expected: empty."""
-        self.populate_all_stable()
-        self.remove_ingest(list(range(200, 801)))
-
-        cursor = self.open_bounded_cursor(lower=self.fmt_key(200), upper=self.fmt_key(800))
-        self.assertEqual(self.scan_forward(cursor), [])
-        cursor.close()
-
-    def test_bounds_tombstone_outside(self):
-        """Tombstone keys outside [200, 800]. Bounds [200, 800]. Range intact."""
-        self.populate_all_stable()
-        self.remove_ingest(list(range(0, 200)) + list(range(801, self.nkeys)))
-
-        cursor = self.open_bounded_cursor(lower=self.fmt_key(200), upper=self.fmt_key(800))
-        self.assertEqual(self.scan_forward(cursor), self.expected_range(200, 800))
-        cursor.close()
-
-    def test_bounds_clear(self):
-        """Set bounds, scan, clear bounds, rescan sees all keys."""
-        all_keys = self.populate_interleaved()
-
-        cursor = self.open_bounded_cursor(lower=self.fmt_key(200), upper=self.fmt_key(800))
-        self.assertEqual(self.scan_forward(cursor), self.expected_range(200, 800))
-
-        cursor.reset()
-        cursor.bound("action=clear")
-
-        self.assertEqual(self.scan_forward(cursor), all_keys)
-        cursor.close()
-
-    def test_bounds_search_near(self):
-        """search_near below bounds [300, 700]: nearest key within bounds is 300 (cmp=1)."""
-        self.populate_interleaved()
-
-        cursor = self.open_bounded_cursor(lower=self.fmt_key(300), upper=self.fmt_key(700))
-        cursor.set_key(self.fmt_key(100))
-        exact = cursor.search_near()
-        self.assertEqual(cursor.get_key(), self.fmt_key(300))
-        self.assertEqual(exact, 1)
-        cursor.close()
-
-    def test_bounds_search_near_upper(self):
-        """search_near above bounds [300, 700]: nearest key within bounds is 700 (cmp=-1)."""
-        self.populate_interleaved()
-
-        cursor = self.open_bounded_cursor(lower=self.fmt_key(300), upper=self.fmt_key(700))
-        cursor.set_key(self.fmt_key(900))
-        exact = cursor.search_near()
-        self.assertEqual(cursor.get_key(), self.fmt_key(700))
-        self.assertEqual(exact, -1)
-        cursor.close()
-
-    def test_bounds_set_before_data(self):
-        """Bounds set before any data is inserted."""
-
-        cursor = self.open_bounded_cursor(lower=self.fmt_key(200), upper=self.fmt_key(800))
-        self.assertEqual(self.scan_forward(cursor), [])
-        cursor.close()
-
-        self.insert_ingest(list(range(self.nkeys)))
-        cursor = self.open_bounded_cursor(lower=self.fmt_key(200), upper=self.fmt_key(800))
-        self.assertEqual(self.scan_forward(cursor), self.expected_range(200, 800))
-        cursor.close()
-
-    def test_bounds_ingest_overrides_stable(self):
-        """Local write overrides checkpointed value within bounds."""
-        self.populate_all_stable()
-        self.insert_ingest([500], values=["new_500"])
-
-        cursor = self.open_bounded_cursor(lower=self.fmt_key(500), upper=self.fmt_key(500))
-        self.assertEqual(cursor.next(), 0)
-        self.assertEqual(cursor.get_key(), self.fmt_key(500))
-        self.assertEqual(cursor.get_value(), "new_500")
-        self.assertEqual(cursor.next(), wiredtiger.WT_NOTFOUND)
-        cursor.close()
-
-    def test_bounds_adjacent_exclusive(self):
-        """Exclusive bounds (199, 201). Expected: only key 200."""
-        self.populate_interleaved()
-
-        cursor = self.open_bounded_cursor(
-            lower=self.fmt_key(199), upper=self.fmt_key(201),
-            lower_inclusive=False, upper_inclusive=False)
-        self.assertEqual(self.scan_forward(cursor), [self.fmt_key(200)])
-        cursor.close()
-
-    def test_bounds_single_point(self):
-        """Single-point bounds [500, 500]. Expected: only key 500."""
-        self.populate_interleaved()
-
-        cursor = self.open_bounded_cursor(lower=self.fmt_key(500), upper=self.fmt_key(500))
-        self.assertEqual(self.scan_forward(cursor), [self.fmt_key(500)])
-
-        # Also test prev.
-        cursor.reset()
-        self.set_bounds(cursor, lower=self.fmt_key(500), upper=self.fmt_key(500))
-        self.assertEqual(self.scan_backward(cursor), [self.fmt_key(500)])
-        cursor.close()
-
-    def test_bounds_search(self):
-        """search inside bounds succeeds, outside bounds fails."""
-        self.populate_interleaved()
-
-        cursor = self.open_bounded_cursor(lower=self.fmt_key(200), upper=self.fmt_key(800))
-
-        cursor.set_key(self.fmt_key(500))
-        self.assertEqual(cursor.search(), 0)
-        self.assertEqual(cursor.get_value(), self.fmt_val(500))
-
-        cursor.set_key(self.fmt_key(100))
-        self.assertEqual(cursor.search(), wiredtiger.WT_NOTFOUND)
-
-        cursor.set_key(self.fmt_key(900))
-        self.assertEqual(cursor.search(), wiredtiger.WT_NOTFOUND)
-        cursor.close()
-
-    def test_bounds_rebind(self):
-        """Rebind to narrower bounds without clearing first."""
-        all_keys = self.populate_interleaved()
-
-        cursor = self.open_bounded_cursor(lower=self.fmt_key(0), upper=self.fmt_key(999))
-        self.assertEqual(self.scan_forward(cursor), all_keys)
-
-        # Reset the bounds.
-        cursor.reset()
-
-        self.set_bounds(cursor, lower=self.fmt_key(400), upper=self.fmt_key(600))
-        self.assertEqual(self.scan_forward(cursor), self.expected_range(400, 600))
-        cursor.close()
-
-    def test_bounds_positioned_update_mid_scan(self):
-        """
-        Bounded scan, positioned update mid-scan, continue scanning. Verifies
-        that a write while the cursor is positioned within a bounded scan does
-        not disrupt iteration order, and that all returned keys stay within bounds.
-        """
-
-        # Interleaved: even keys checkpointed, odd keys written locally.
-        self.insert_stable(list(range(0, self.nkeys, 2)))
-        self.insert_ingest(list(range(1, self.nkeys, 2)))
-
-        lo, hi = 200, 800
-        cursor = self.session_follow.open_cursor(self.uri)
-        self.set_bounds(cursor, lower=self.fmt_key(lo), upper=self.fmt_key(hi))
-
-        keys_before = []
-        for _ in range(100):
-            self.assertEqual(cursor.next(), 0)
-            keys_before.append(cursor.get_key())
-
-        # Positioned update at the current cursor position mid-scan.
-        self.session_follow.begin_transaction()
-        cursor.set_value("updated")
-        cursor.update()
-        self.session_follow.commit_transaction(
-            f"commit_timestamp={self.timestamp_str(self.next_ts())}")
-
-        keys_after = []
-        while cursor.next() == 0:
-            keys_after.append(cursor.get_key())
-
-        all_keys = keys_before + keys_after
-        for i in range(len(all_keys) - 1):
-            self.assertLess(all_keys[i], all_keys[i + 1],
-                f"Out of order at {i}: {all_keys[i]} >= {all_keys[i + 1]}")
-
-        # All keys must stay within the declared bounds.
-        for k in all_keys:
-            self.assertGreaterEqual(k, self.fmt_key(lo))
-            self.assertLessEqual(k, self.fmt_key(hi))
-        cursor.close()
+        # The follower starts without any local WiredTiger metadata, so its
+        # recovery_timestamp stays WT_TS_NONE and has_stable_timestamp remains
+        # false after recovery. The stable and oldest timestamps are only set
+        # when the follower picks up the leader's checkpoint via reconfigure().
+        conn_follow = self.wiredtiger_open(
+            'follower',
+            self.extensionsConfig() + self.conn_base_config +
+            'disaggregated=(role="follower")')
+        session_follow = conn_follow.open_session('')
+
+        # Create the table on the follower so the stable file exists.
+        session_follow.create(self.uri, self.create_session_config)
+
+        # After recovery but before picking up the checkpoint, the follower's stable and
+        # oldest timestamps are both 0 because the local WiredTiger.wt has no
+        # system:checkpoint entry.
+        self.assertTimestampsEqual("0", conn_follow.query_timestamp('get=stable_timestamp'))
+        self.assertTimestampsEqual("0", conn_follow.query_timestamp('get=oldest_timestamp'))
+
+        # Follower picks up the leader's checkpoint. The stable and oldest timestamps
+        # from the checkpoint metadata are propagated into the global transaction state,
+        # so verify() can use the correct stable point.
+        self.disagg_advance_checkpoint(conn_follow)
+
+        # After picking up the checkpoint, the follower should have the leader's stable,
+        # oldest and pinned timestamps propagated from the checkpoint metadata.
+        self.assertTimestampsEqual(self.timestamp_str(10), conn_follow.query_timestamp('get=stable_timestamp'))
+        self.assertTimestampsEqual(self.timestamp_str(5), conn_follow.query_timestamp('get=oldest_timestamp'))
+        self.assertTimestampsEqual(self.timestamp_str(5), conn_follow.query_timestamp('get=pinned'))
+        self.verifyUntilSuccess(session_follow, self.uri)
+
+        session_follow.close()
+        conn_follow.close()

--- a/test/suite/test_layered82.py
+++ b/test/suite/test_layered82.py
@@ -31,64 +31,430 @@ from helper_disagg import disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 
 # test_layered82.py
-#    Verify that session.verify() on a follower with no stable timestamp
-#    set does not produce a false positive error. Before the fix, the
-#    verify timestamp validation compared cell timestamps against
-#    stable=0 and incorrectly reported corruption.
+#   Test cursor bounds on layered cursors with a 1000-key dataset.
+
 @disagg_test_class
 class test_layered82(wttest.WiredTigerTestCase):
-    conn_base_config = ',create,statistics=(all),'
-    conn_config = 'disaggregated=(role="leader")'
-    create_session_config = 'key_format=i,value_format=S'
+    conn_base_config = ',create,statistics=(all),statistics_log=(wait=1,json=true,on_close=true),'
     uri = 'layered:test_layered82'
+    nkeys = 1000
 
     disagg_storages = gen_disagg_storages('test_layered82', disagg_only=True)
+
     scenarios = make_scenarios(disagg_storages)
 
-    def test_follower_verify_no_stable_timestamp(self):
-        # Leader: write timestamped data and checkpoint.
-        self.session.create(self.uri, self.create_session_config)
+    def conn_config(self):
+        return self.extensionsConfig() + self.conn_base_config + 'disaggregated=(role="leader")'
 
-        self.session.begin_transaction()
+    def setUp(self):
+        super().setUp()
+        self.ts = 1
+        self.conn_follow = self.wiredtiger_open('follower',
+            self.extensionsConfig() + self.conn_base_config + 'disaggregated=(role="follower")')
+        self.session_follow = self.conn_follow.open_session('')
+        config = "key_format=S,value_format=S"
+        self.session.create(self.uri, config)
+        self.session_follow.create(self.uri, config)
+
+    def next_ts(self):
+        self.ts += 1
+        return self.ts
+
+    @staticmethod
+    def fmt_key(i):
+        return f"{i:06d}"
+
+    @staticmethod
+    def fmt_val(i):
+        return f"val_{i:06d}"
+
+    # -----------------------------------------------------------------------
+    # Low-level insert/remove helpers (accept lists of ints).
+    # -----------------------------------------------------------------------
+
+    def insert_stable(self, keys, values=None):
+        """Insert keys (list of ints) into stable via leader checkpoint."""
         cursor = self.session.open_cursor(self.uri)
-        cursor[1] = 'value1'
+        for idx, i in enumerate(keys):
+            key = self.fmt_key(i)
+            val = values[idx] if values else self.fmt_val(i)
+            self.session.begin_transaction()
+            cursor[key] = val
+            self.session.commit_transaction(f"commit_timestamp={self.timestamp_str(self.next_ts())}")
         cursor.close()
-        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
-
-        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10) +
-                                ',oldest_timestamp=' + self.timestamp_str(5))
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(self.ts)}')
         self.session.checkpoint()
+        self.disagg_advance_checkpoint(self.conn_follow)
 
-        # The follower starts without any local WiredTiger metadata, so its
-        # recovery_timestamp stays WT_TS_NONE and has_stable_timestamp remains
-        # false after recovery. The stable and oldest timestamps are only set
-        # when the follower picks up the leader's checkpoint via reconfigure().
-        conn_follow = self.wiredtiger_open(
-            'follower',
-            self.extensionsConfig() + self.conn_base_config +
-            'disaggregated=(role="follower")')
-        session_follow = conn_follow.open_session('')
+    def insert_ingest(self, keys, values=None):
+        """Insert keys (list of ints) into the follower's local table."""
+        session = self.session_follow
+        cursor = session.open_cursor(self.uri)
+        for idx, i in enumerate(keys):
+            key = self.fmt_key(i)
+            val = values[idx] if values else self.fmt_val(i)
+            session.begin_transaction()
+            cursor[key] = val
+            session.commit_transaction(f"commit_timestamp={self.timestamp_str(self.next_ts())}")
+        cursor.close()
 
-        # Create the table on the follower so the stable file exists.
-        session_follow.create(self.uri, self.create_session_config)
+    def remove_ingest(self, keys):
+        """Remove keys (list of ints) from the follower's local table."""
+        session = self.session_follow
+        cursor = session.open_cursor(self.uri)
+        for i in keys:
+            key = self.fmt_key(i)
+            session.begin_transaction()
+            cursor.set_key(key)
+            cursor.remove()
+            session.commit_transaction(f"commit_timestamp={self.timestamp_str(self.next_ts())}")
+        cursor.close()
 
-        # After recovery but before picking up the checkpoint, the follower's stable and
-        # oldest timestamps are both 0 because the local WiredTiger.wt has no
-        # system:checkpoint entry.
-        self.assertTimestampsEqual("0", conn_follow.query_timestamp('get=stable_timestamp'))
-        self.assertTimestampsEqual("0", conn_follow.query_timestamp('get=oldest_timestamp'))
+    # -----------------------------------------------------------------------
+    # Data population helpers  each creates a common data layout.
+    # -----------------------------------------------------------------------
 
-        # Follower picks up the leader's checkpoint. The stable and oldest timestamps
-        # from the checkpoint metadata are propagated into the global transaction state,
-        # so verify() can use the correct stable point.
-        self.disagg_advance_checkpoint(conn_follow)
+    def populate_interleaved(self):
+        """Checkpointed even keys and locally-written odd keys. Returns all expected keys."""
+        self.insert_stable(list(range(0, self.nkeys, 2)))
+        self.insert_ingest(list(range(1, self.nkeys, 2)))
+        return [self.fmt_key(i) for i in range(self.nkeys)]
 
-        # After picking up the checkpoint, the follower should have the leader's stable,
-        # oldest and pinned timestamps propagated from the checkpoint metadata.
-        self.assertTimestampsEqual(self.timestamp_str(10), conn_follow.query_timestamp('get=stable_timestamp'))
-        self.assertTimestampsEqual(self.timestamp_str(5), conn_follow.query_timestamp('get=oldest_timestamp'))
-        self.assertTimestampsEqual(self.timestamp_str(5), conn_follow.query_timestamp('get=pinned'))
-        self.verifyUntilSuccess(session_follow, self.uri)
+    def populate_all_stable(self):
+        """All keys checkpointed. Returns all expected keys."""
+        self.insert_stable(list(range(self.nkeys)))
+        return [self.fmt_key(i) for i in range(self.nkeys)]
 
-        session_follow.close()
-        conn_follow.close()
+    def populate_all_ingest(self):
+        """All keys written locally (no checkpoint). Returns all expected keys."""
+        self.insert_ingest(list(range(self.nkeys)))
+        return [self.fmt_key(i) for i in range(self.nkeys)]
+
+    # -----------------------------------------------------------------------
+    # Cursor helpers.
+    # -----------------------------------------------------------------------
+
+    def set_bounds(self, cursor, lower=None, upper=None,
+                   lower_inclusive=True, upper_inclusive=True):
+        """Set bounds on a cursor. Pass None to skip a bound."""
+        if lower is not None:
+            cursor.set_key(lower)
+            incl = "true" if lower_inclusive else "false"
+            cursor.bound(f"bound=lower,inclusive={incl}")
+        if upper is not None:
+            cursor.set_key(upper)
+            incl = "true" if upper_inclusive else "false"
+            cursor.bound(f"bound=upper,inclusive={incl}")
+
+    def scan_forward(self, cursor):
+        """Scan forward and return list of keys."""
+        keys = []
+        while cursor.next() == 0:
+            keys.append(cursor.get_key())
+        return keys
+
+    def scan_backward(self, cursor):
+        """Scan backward and return list of keys."""
+        keys = []
+        while cursor.prev() == 0:
+            keys.append(cursor.get_key())
+        return keys
+
+    def open_bounded_cursor(self, lower=None, upper=None,
+                            lower_inclusive=True, upper_inclusive=True):
+        """Open a cursor on the session under test and set bounds."""
+        cursor = self.session_follow.open_cursor(self.uri)
+        self.set_bounds(cursor, lower, upper, lower_inclusive, upper_inclusive)
+        return cursor
+
+    def expected_range(self, lo, hi):
+        """Return list of formatted keys for range [lo, hi] inclusive."""
+        return [self.fmt_key(i) for i in range(lo, hi + 1)]
+
+    # =====================================================================
+    # Tests
+    # =====================================================================
+
+    def test_bounds_ingest_only(self):
+        """Bounds with all data written locally (no checkpoint)."""
+        self.populate_all_ingest()
+
+        cursor = self.open_bounded_cursor(lower=self.fmt_key(200), upper=self.fmt_key(800))
+        self.assertEqual(self.scan_forward(cursor), self.expected_range(200, 800))
+        cursor.close()
+
+    def test_bounds_stable_only(self):
+        """Bounds with all data checkpointed."""
+        self.populate_all_stable()
+
+        cursor = self.open_bounded_cursor(lower=self.fmt_key(200), upper=self.fmt_key(800))
+        self.assertEqual(self.scan_forward(cursor), self.expected_range(200, 800))
+        cursor.close()
+
+    def test_bounds_split_data(self):
+        """Bounds with interleaved data (checkpointed even keys, locally-written odd keys)."""
+        self.populate_interleaved()
+
+        cursor = self.open_bounded_cursor(lower=self.fmt_key(200), upper=self.fmt_key(800))
+        self.assertEqual(self.scan_forward(cursor), self.expected_range(200, 800))
+        cursor.close()
+
+    def test_bounds_split_data_prev(self):
+        """Bounds with interleaved data, reverse iteration."""
+        self.populate_interleaved()
+
+        cursor = self.open_bounded_cursor(lower=self.fmt_key(200), upper=self.fmt_key(800))
+        expected = [self.fmt_key(i) for i in range(800, 199, -1)]
+        self.assertEqual(self.scan_backward(cursor), expected)
+        cursor.close()
+
+    def test_bounds_lower_only(self):
+        """Lower bound only at 500. Expected: 500-999."""
+        self.populate_interleaved()
+
+        cursor = self.open_bounded_cursor(lower=self.fmt_key(500))
+        self.assertEqual(self.scan_forward(cursor), self.expected_range(500, 999))
+        cursor.close()
+
+    def test_bounds_upper_only(self):
+        """Upper bound only at 500. Expected: 0-500."""
+        self.populate_interleaved()
+
+        cursor = self.open_bounded_cursor(upper=self.fmt_key(500))
+        self.assertEqual(self.scan_forward(cursor), self.expected_range(0, 500))
+        cursor.close()
+
+    def test_bounds_exclusive_lower(self):
+        """Exclusive lower bound at 200. Expected: 201-999."""
+        self.populate_interleaved()
+
+        cursor = self.open_bounded_cursor(lower=self.fmt_key(200), lower_inclusive=False)
+        self.assertEqual(self.scan_forward(cursor), self.expected_range(201, 999))
+        cursor.close()
+
+    def test_bounds_exclusive_upper(self):
+        """Exclusive upper bound at 800. Expected: 0-799."""
+        self.populate_interleaved()
+
+        cursor = self.open_bounded_cursor(upper=self.fmt_key(800), upper_inclusive=False)
+        self.assertEqual(self.scan_forward(cursor), self.expected_range(0, 799))
+        cursor.close()
+
+    def test_bounds_both_exclusive(self):
+        """Both bounds exclusive: (200, 800). Expected: 201-799."""
+        self.populate_interleaved()
+
+        cursor = self.open_bounded_cursor(
+            lower=self.fmt_key(200), upper=self.fmt_key(800),
+            lower_inclusive=False, upper_inclusive=False)
+        self.assertEqual(self.scan_forward(cursor), self.expected_range(201, 799))
+        cursor.close()
+
+    def test_bounds_nonexistent_keys(self):
+        """Bounds at keys that don't exist. Even keys only, bounds [201, 799]."""
+        self.insert_stable(list(range(0, self.nkeys, 2)))
+
+        cursor = self.open_bounded_cursor(lower=self.fmt_key(201), upper=self.fmt_key(799))
+        expected = [self.fmt_key(i) for i in range(202, 800, 2)]
+        self.assertEqual(self.scan_forward(cursor), expected)
+        cursor.close()
+
+    def test_bounds_no_data_in_range(self):
+        """Bounds [1500, 2000] beyond all data. Expected: empty."""
+        self.populate_interleaved()
+
+        cursor = self.open_bounded_cursor(lower=self.fmt_key(1500), upper=self.fmt_key(2000))
+        self.assertEqual(self.scan_forward(cursor), [])
+        cursor.close()
+
+    def test_bounds_tombstone_inside(self):
+        """Tombstone every 3rd key in [200, 800]. Bounds [200, 800]."""
+        self.populate_all_stable()
+        self.remove_ingest([i for i in range(200, 801) if i % 3 == 0])
+
+        cursor = self.open_bounded_cursor(lower=self.fmt_key(200), upper=self.fmt_key(800))
+        expected = [self.fmt_key(i) for i in range(200, 801) if i % 3 != 0]
+        self.assertEqual(self.scan_forward(cursor), expected)
+        cursor.close()
+
+    def test_bounds_tombstone_at_bounds(self):
+        """Tombstone the bound keys 200 and 800. Bounds [200, 800]. Expected: 201-799."""
+        self.populate_all_stable()
+        self.remove_ingest([200, 800])
+
+        cursor = self.open_bounded_cursor(lower=self.fmt_key(200), upper=self.fmt_key(800))
+        self.assertEqual(self.scan_forward(cursor), self.expected_range(201, 799))
+        cursor.close()
+
+    def test_bounds_all_tombstoned_in_range(self):
+        """Tombstone everything in [200, 800]. Bounds [200, 800]. Expected: empty."""
+        self.populate_all_stable()
+        self.remove_ingest(list(range(200, 801)))
+
+        cursor = self.open_bounded_cursor(lower=self.fmt_key(200), upper=self.fmt_key(800))
+        self.assertEqual(self.scan_forward(cursor), [])
+        cursor.close()
+
+    def test_bounds_tombstone_outside(self):
+        """Tombstone keys outside [200, 800]. Bounds [200, 800]. Range intact."""
+        self.populate_all_stable()
+        self.remove_ingest(list(range(0, 200)) + list(range(801, self.nkeys)))
+
+        cursor = self.open_bounded_cursor(lower=self.fmt_key(200), upper=self.fmt_key(800))
+        self.assertEqual(self.scan_forward(cursor), self.expected_range(200, 800))
+        cursor.close()
+
+    def test_bounds_clear(self):
+        """Set bounds, scan, clear bounds, rescan sees all keys."""
+        all_keys = self.populate_interleaved()
+
+        cursor = self.open_bounded_cursor(lower=self.fmt_key(200), upper=self.fmt_key(800))
+        self.assertEqual(self.scan_forward(cursor), self.expected_range(200, 800))
+
+        cursor.reset()
+        cursor.bound("action=clear")
+
+        self.assertEqual(self.scan_forward(cursor), all_keys)
+        cursor.close()
+
+    def test_bounds_search_near(self):
+        """search_near below bounds [300, 700]: nearest key within bounds is 300 (cmp=1)."""
+        self.populate_interleaved()
+
+        cursor = self.open_bounded_cursor(lower=self.fmt_key(300), upper=self.fmt_key(700))
+        cursor.set_key(self.fmt_key(100))
+        exact = cursor.search_near()
+        self.assertEqual(cursor.get_key(), self.fmt_key(300))
+        self.assertEqual(exact, 1)
+        cursor.close()
+
+    def test_bounds_search_near_upper(self):
+        """search_near above bounds [300, 700]: nearest key within bounds is 700 (cmp=-1)."""
+        self.populate_interleaved()
+
+        cursor = self.open_bounded_cursor(lower=self.fmt_key(300), upper=self.fmt_key(700))
+        cursor.set_key(self.fmt_key(900))
+        exact = cursor.search_near()
+        self.assertEqual(cursor.get_key(), self.fmt_key(700))
+        self.assertEqual(exact, -1)
+        cursor.close()
+
+    def test_bounds_set_before_data(self):
+        """Bounds set before any data is inserted."""
+
+        cursor = self.open_bounded_cursor(lower=self.fmt_key(200), upper=self.fmt_key(800))
+        self.assertEqual(self.scan_forward(cursor), [])
+        cursor.close()
+
+        self.insert_ingest(list(range(self.nkeys)))
+        cursor = self.open_bounded_cursor(lower=self.fmt_key(200), upper=self.fmt_key(800))
+        self.assertEqual(self.scan_forward(cursor), self.expected_range(200, 800))
+        cursor.close()
+
+    def test_bounds_ingest_overrides_stable(self):
+        """Local write overrides checkpointed value within bounds."""
+        self.populate_all_stable()
+        self.insert_ingest([500], values=["new_500"])
+
+        cursor = self.open_bounded_cursor(lower=self.fmt_key(500), upper=self.fmt_key(500))
+        self.assertEqual(cursor.next(), 0)
+        self.assertEqual(cursor.get_key(), self.fmt_key(500))
+        self.assertEqual(cursor.get_value(), "new_500")
+        self.assertEqual(cursor.next(), wiredtiger.WT_NOTFOUND)
+        cursor.close()
+
+    def test_bounds_adjacent_exclusive(self):
+        """Exclusive bounds (199, 201). Expected: only key 200."""
+        self.populate_interleaved()
+
+        cursor = self.open_bounded_cursor(
+            lower=self.fmt_key(199), upper=self.fmt_key(201),
+            lower_inclusive=False, upper_inclusive=False)
+        self.assertEqual(self.scan_forward(cursor), [self.fmt_key(200)])
+        cursor.close()
+
+    def test_bounds_single_point(self):
+        """Single-point bounds [500, 500]. Expected: only key 500."""
+        self.populate_interleaved()
+
+        cursor = self.open_bounded_cursor(lower=self.fmt_key(500), upper=self.fmt_key(500))
+        self.assertEqual(self.scan_forward(cursor), [self.fmt_key(500)])
+
+        # Also test prev.
+        cursor.reset()
+        self.set_bounds(cursor, lower=self.fmt_key(500), upper=self.fmt_key(500))
+        self.assertEqual(self.scan_backward(cursor), [self.fmt_key(500)])
+        cursor.close()
+
+    def test_bounds_search(self):
+        """search inside bounds succeeds, outside bounds fails."""
+        self.populate_interleaved()
+
+        cursor = self.open_bounded_cursor(lower=self.fmt_key(200), upper=self.fmt_key(800))
+
+        cursor.set_key(self.fmt_key(500))
+        self.assertEqual(cursor.search(), 0)
+        self.assertEqual(cursor.get_value(), self.fmt_val(500))
+
+        cursor.set_key(self.fmt_key(100))
+        self.assertEqual(cursor.search(), wiredtiger.WT_NOTFOUND)
+
+        cursor.set_key(self.fmt_key(900))
+        self.assertEqual(cursor.search(), wiredtiger.WT_NOTFOUND)
+        cursor.close()
+
+    def test_bounds_rebind(self):
+        """Rebind to narrower bounds without clearing first."""
+        all_keys = self.populate_interleaved()
+
+        cursor = self.open_bounded_cursor(lower=self.fmt_key(0), upper=self.fmt_key(999))
+        self.assertEqual(self.scan_forward(cursor), all_keys)
+
+        # Reset the bounds.
+        cursor.reset()
+
+        self.set_bounds(cursor, lower=self.fmt_key(400), upper=self.fmt_key(600))
+        self.assertEqual(self.scan_forward(cursor), self.expected_range(400, 600))
+        cursor.close()
+
+    def test_bounds_positioned_update_mid_scan(self):
+        """
+        Bounded scan, positioned update mid-scan, continue scanning. Verifies
+        that a write while the cursor is positioned within a bounded scan does
+        not disrupt iteration order, and that all returned keys stay within bounds.
+        """
+
+        # Interleaved: even keys checkpointed, odd keys written locally.
+        self.insert_stable(list(range(0, self.nkeys, 2)))
+        self.insert_ingest(list(range(1, self.nkeys, 2)))
+
+        lo, hi = 200, 800
+        cursor = self.session_follow.open_cursor(self.uri)
+        self.set_bounds(cursor, lower=self.fmt_key(lo), upper=self.fmt_key(hi))
+
+        keys_before = []
+        for _ in range(100):
+            self.assertEqual(cursor.next(), 0)
+            keys_before.append(cursor.get_key())
+
+        # Positioned update at the current cursor position mid-scan.
+        self.session_follow.begin_transaction()
+        cursor.set_value("updated")
+        cursor.update()
+        self.session_follow.commit_transaction(
+            f"commit_timestamp={self.timestamp_str(self.next_ts())}")
+
+        keys_after = []
+        while cursor.next() == 0:
+            keys_after.append(cursor.get_key())
+
+        all_keys = keys_before + keys_after
+        for i in range(len(all_keys) - 1):
+            self.assertLess(all_keys[i], all_keys[i + 1],
+                f"Out of order at {i}: {all_keys[i]} >= {all_keys[i + 1]}")
+
+        # All keys must stay within the declared bounds.
+        for k in all_keys:
+            self.assertGreaterEqual(k, self.fmt_key(lo))
+            self.assertLessEqual(k, self.fmt_key(hi))
+        cursor.close()

--- a/test/suite/test_layered85.py
+++ b/test/suite/test_layered85.py
@@ -145,7 +145,11 @@ class test_layered85(wttest.WiredTigerTestCase):
     def begin_read_ts_txn(self):
         """Begin a transaction with a read timestamp on the follower."""
         read_ts = self.ts
-        self.conn_follow.set_timestamp(f'oldest_timestamp={self.timestamp_str(read_ts)}')
+        # stable_timestamp must be set alongside oldest_timestamp: follower writes
+        # may have advanced self.ts beyond the last checkpoint's stable value, and
+        # oldest must not exceed stable.
+        self.conn_follow.set_timestamp(f'stable_timestamp={self.timestamp_str(read_ts)},'
+                                       f'oldest_timestamp={self.timestamp_str(read_ts)}')
         self.session_follow.begin_transaction(
             f'read_timestamp={self.timestamp_str(read_ts)}')
 
@@ -445,7 +449,11 @@ class test_layered85(wttest.WiredTigerTestCase):
 
         # Begin transaction with read timestamp so the cursor can pick up
         # a new checkpoint mid-scan.
-        self.conn_follow.set_timestamp(f'oldest_timestamp={self.timestamp_str(read_ts)}')
+        # stable_timestamp must be set alongside oldest_timestamp: follower writes
+        # may have advanced self.ts beyond the last checkpoint's stable value, and
+        # oldest must not exceed stable.
+        self.conn_follow.set_timestamp(f'stable_timestamp={self.timestamp_str(read_ts)},'
+                                       f'oldest_timestamp={self.timestamp_str(read_ts)}')
         self.session_follow.begin_transaction(
             f'read_timestamp={self.timestamp_str(read_ts)}')
 
@@ -472,7 +480,11 @@ class test_layered85(wttest.WiredTigerTestCase):
         # Start a new transaction with a read timestamp after the remove,
         # so the deleted key is not visible in the new scan.
         new_read_ts = self.ts
-        self.conn_follow.set_timestamp(f'oldest_timestamp={self.timestamp_str(new_read_ts)}')
+        # stable_timestamp must be set alongside oldest_timestamp: follower writes
+        # may have advanced self.ts beyond the last checkpoint's stable value, and
+        # oldest must not exceed stable.
+        self.conn_follow.set_timestamp(f'stable_timestamp={self.timestamp_str(new_read_ts)},'
+                                       f'oldest_timestamp={self.timestamp_str(new_read_ts)}')
         self.session_follow.begin_transaction(
             f'read_timestamp={self.timestamp_str(new_read_ts)}')
 

--- a/test/suite/test_layered86.py
+++ b/test/suite/test_layered86.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wiredtiger, wttest
+from helper_disagg import disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
+
+# test_layered86.py
+#    Verify that follower verify with no stable timestamp
+#    does not produce a false positive error. Before the fix, the
+#    verify timestamp validation compared cell timestamps against
+#    stable=0 and incorrectly reported corruption.
+@disagg_test_class
+class test_layered86(wttest.WiredTigerTestCase):
+    conn_base_config = ',create,statistics=(all),'
+    conn_config = 'disaggregated=(role="leader")'
+    create_session_config = 'key_format=i,value_format=S'
+    uri = 'layered:test_layered86'
+
+    disagg_storages = gen_disagg_storages('test_layered86', disagg_only=True)
+    scenarios = make_scenarios(disagg_storages)
+
+    def test_follower_verify_no_stable_timestamp(self):
+        # Leader: write timestamped data and checkpoint.
+        self.session.create(self.uri, self.create_session_config)
+
+        self.session.begin_transaction()
+        cursor = self.session.open_cursor(self.uri)
+        cursor[1] = 'value1'
+        cursor.close()
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
+
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10) +
+                                ',oldest_timestamp=' + self.timestamp_str(5))
+        self.session.checkpoint()
+
+        # The follower starts without any local WiredTiger metadata, so its
+        # recovery_timestamp stays WT_TS_NONE and has_stable_timestamp remains
+        # false after recovery. The stable and oldest timestamps are only set
+        # when the follower picks up the leader's checkpoint via reconfigure().
+        conn_follow = self.wiredtiger_open(
+            'follower',
+            self.extensionsConfig() + self.conn_base_config +
+            'disaggregated=(role="follower")')
+        session_follow = conn_follow.open_session('')
+
+        # Create the table on the follower so the stable file exists.
+        session_follow.create(self.uri, self.create_session_config)
+
+        # After recovery but before picking up the checkpoint, the follower's stable and
+        # oldest timestamps are both 0 because the local WiredTiger.wt has no
+        # system:checkpoint entry.
+        self.assertTimestampsEqual("0", conn_follow.query_timestamp('get=stable_timestamp'))
+        self.assertTimestampsEqual("0", conn_follow.query_timestamp('get=oldest_timestamp'))
+
+        # Follower picks up the leader's checkpoint. The stable and oldest timestamps
+        # from the checkpoint metadata are propagated into the global transaction state,
+        # so the follower has the correct stable point for data validation.
+        self.disagg_advance_checkpoint(conn_follow)
+
+        # After picking up the checkpoint, the follower should have the leader's stable,
+        # oldest and pinned timestamps propagated from the checkpoint metadata.
+        self.assertTimestampsEqual(self.timestamp_str(10), conn_follow.query_timestamp('get=stable_timestamp'))
+        self.assertTimestampsEqual(self.timestamp_str(5), conn_follow.query_timestamp('get=oldest_timestamp'))
+        self.assertTimestampsEqual(self.timestamp_str(5), conn_follow.query_timestamp('get=pinned'))
+        self.verifyUntilSuccess(session_follow, self.uri)
+
+        session_follow.close()
+        conn_follow.close()


### PR DESCRIPTION
On a disaggregated follower, `stable_timestamp` and `oldest_timestamp` are never propagated into `txn_global` when picking up a checkpoint from the leader. This caused offline validation to run `verify()` with `stable=0`, producing false positive EINVAL errors.

Fix `__disagg_update_checkpoint_meta()` to propagate the leader's stable and oldest timestamps from the checkpoint metadata into `txn_global`, then update the pinned timestamp using the same approach as RTS.

Test added in `test/suite/test_layered82.py`.