### PR TITLE
WT-17028 Fix missing histogram bucket in WT_STAT_USECS_HIST_INCR_FUNC.

### DIFF
--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -366,6 +366,10 @@ __wt_stats_clear_dsrc(void *stats_arg, int slot)
             WT_STAT_CONN_INCR(session, stat##_lt500);           \
         else if (usecs < WT_THOUSAND)                           \
             WT_STAT_CONN_INCR(session, stat##_lt1000);          \
+        else if (usecs < 2500)                                  \
+            WT_STAT_CONN_INCR(session, stat##_lt2500);          \
+        else if (usecs < 5 * WT_THOUSAND)                       \
+            WT_STAT_CONN_INCR(session, stat##_lt5000);          \
         else if (usecs < 10 * WT_THOUSAND)                      \
             WT_STAT_CONN_INCR(session, stat##_lt10000);         \
         else                                                    \


### PR DESCRIPTION
Add the missing histogram bucket in WT_STAT_USECS_HIST_INCR_FUNC, otherwise for some data points the wrong bucket would be incremented.