### PR TITLE
WT-17044 Resolve hangs and spurious failures in TSan tests

### DIFF
--- a/lang/python/wiredtiger/init.py
+++ b/lang/python/wiredtiger/init.py
@@ -44,8 +44,12 @@ if sys.version_info[0] <= 2:
 
 # Restart this instance of python so it uses the most recent os.environ values
 def restart_python():
+    # Restart the current Python process with the same arguments, using the updated environment
+    # variables. Note that the first argument to os.execl is the path to the executable, and the
+    # second argument is the name of the program as it will appear in the process list and in
+    # sys.executable.
     python = sys.executable
-    os.execl(python, os.path.abspath(__file__), *sys.argv)
+    os.execl(python, python, *sys.argv)
 
 # After importing the SWIG-generated file, copy all symbols from it
 # to this module so they will appear in the wiredtiger namespace.
@@ -86,7 +90,7 @@ if os.environ.get("TESTUTIL_TSAN") == "1":
         restart_python()
     else:
         # Python already has TSan linking, but if python calls ./wt in a subprocess this breaks ./wt
-        # Remove the TSan libs from LD_PRELOAD but *don't* restart python so we still have TSan linking in the current running process. 
+        # Remove the TSan libs from LD_PRELOAD but *don't* restart python so we still have TSan linking in the current running process.
         paths = os.environ["LD_PRELOAD"].split(":")
         os.environ["LD_PRELOAD"] = ":".join([p for p in paths if p != tsan_so_path])
 

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -929,6 +929,7 @@ functions:
         set -o errexit
         set -o verbose
         ${PREPARE_TEST_ENV}
+        ${additional_san_vars}
         # no_run will contain a list of files we don't want to run,
         # do_run will contain a list of files we want to run.
         no_run=$(mktemp)
@@ -971,6 +972,7 @@ functions:
         set -o errexit
         set -o verbose
         ${PREPARE_TEST_ENV}
+        ${additional_san_vars}
         # no_run will contain a list of files we don't want to run,
         # do_run will contain a list of files we want to run.
         no_run=$(mktemp)
@@ -2635,6 +2637,9 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test tsan parallel"
         vars:
+          # FIXME-WT-16313: Disable deadlock detection in TSAN as it causes false positives when
+          # used with parallel checkpoints.
+          additional_san_vars: export TSAN_OPTIONS="$TSAN_OPTIONS:detect_deadlocks=0"
           # Run the set of tests that are not in the fail list.
           unit_test_parallel_ignore: test/suite/tsan.fail
           unit_test_parallel_args: -v 2 --timeout 300
@@ -2651,6 +2656,9 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test tsan parallel"
         vars:
+          # FIXME-WT-16313: Disable deadlock detection in TSAN as it causes false positives when
+          # used with parallel checkpoints.
+          additional_san_vars: export TSAN_OPTIONS="$TSAN_OPTIONS:detect_deadlocks=0"
           # Run the set of tests that are not in the fail list.
           unit_test_parallel_ignore: test/suite/tsan.fail test/suite/hook_disagg.fail
           # The timeout for this command is on a test file basis. Make the timeouts long,
@@ -2669,6 +2677,9 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test"
         vars:
+          # FIXME-WT-16313: Disable deadlock detection in TSAN as it causes false positives when
+          # used with parallel checkpoints.
+          additional_san_vars: export TSAN_OPTIONS="$TSAN_OPTIONS:detect_deadlocks=0"
           # As leader, run the set of tests that are not in the fail list.
           unit_test_ignore: test/suite/tsan.fail test/suite/hook_disagg.fail
           # The timeout for this command is on a test file basis. Make the timeouts long,
@@ -2683,6 +2694,9 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test"
         vars:
+          # FIXME-WT-16313: Disable deadlock detection in TSAN as it causes false positives when
+          # used with parallel checkpoints.
+          additional_san_vars: export TSAN_OPTIONS="$TSAN_OPTIONS:detect_deadlocks=0"
           # As leader, run the set of tests that are not in the fail list.
           unit_test_ignore: test/suite/tsan.fail test/suite/hook_disagg.fail
           # The timeout for this command is on a test file basis. Make the timeouts long,
@@ -2697,6 +2711,9 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test"
         vars:
+          # FIXME-WT-16313: Disable deadlock detection in TSAN as it causes false positives when
+          # used with parallel checkpoints.
+          additional_san_vars: export TSAN_OPTIONS="$TSAN_OPTIONS:detect_deadlocks=0"
           # As leader, run the set of tests that are not in the fail list.
           unit_test_ignore: test/suite/tsan.fail test/suite/hook_disagg.fail
           # The timeout for this command is on a test file basis. Make the timeouts long,
@@ -2711,6 +2728,9 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test"
         vars:
+          # FIXME-WT-16313: Disable deadlock detection in TSAN as it causes false positives when
+          # used with parallel checkpoints.
+          additional_san_vars: export TSAN_OPTIONS="$TSAN_OPTIONS:detect_deadlocks=0"
           # As leader, run the set of tests that are not in the fail list.
           unit_test_ignore: test/suite/tsan.fail test/suite/hook_disagg.fail
           # The timeout for this command is on a test file basis. Make the timeouts long,
@@ -2725,6 +2745,9 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test"
         vars:
+          # FIXME-WT-16313: Disable deadlock detection in TSAN as it causes false positives when
+          # used with parallel checkpoints.
+          additional_san_vars: export TSAN_OPTIONS="$TSAN_OPTIONS:detect_deadlocks=0"
           # As leader, run the set of tests that are not in the fail list.
           unit_test_ignore: test/suite/tsan.fail test/suite/hook_disagg.fail
           # The timeout for this command is on a test file basis. Make the timeouts long,


### PR DESCRIPTION
Fix TSan failures due to misconfigurations:
* Fix a bug in `restart_python` that replaced `sys.executable` by a wrong value.
* Disable deadlock detection, due to parallel checkpoints taking more mutexes, which exceeds TSan's limit.