### PR TITLE
WT-17072 Treat busy-blocked page-in as stall for earlier eviction assist

### DIFF
--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -528,7 +528,7 @@ __wt_page_in_func(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags
     if (FLD_ISSET(S2C(session)->timing_stress_flags, WT_TIMING_STRESS_AGGRESSIVE_STASH_FREE))
         __wt_stash_discard(session);
 
-    for (evict_skip = read_from_disk = stalled = wont_need = false, force_attempts = 0,
+    for (evict_skip = read_from_disk = wont_need = false, force_attempts = 0,
         sleep_usecs = yield_cnt = 0;
          ;) {
         switch (current_state = WT_REF_GET_STATE(ref)) {

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -610,6 +610,12 @@ read:
             WT_RET(__wt_hazard_set_func(session, ref, &busy));
 #endif
             if (busy) {
+                /*
+                 * Treat a busy page-in as a stall so we skip the yield loop and proceed directly to
+                 * eviction assistance or adaptive backoff. The page is busy because it's being
+                 * evicted; yielding won't help and wastes CPU spinning when the thread could be
+                 * doing useful eviction work instead.
+                 */
                 stalled = true;
                 WT_STAT_CONN_INCR(session, page_busy_blocked);
                 break;

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -610,6 +610,7 @@ read:
             WT_RET(__wt_hazard_set_func(session, ref, &busy));
 #endif
             if (busy) {
+                stalled = true;
                 WT_STAT_CONN_INCR(session, page_busy_blocked);
                 break;
             }


### PR DESCRIPTION
In __wt_page_in_func, when __wt_hazard_set_func returns busy (the page is being evicted), the thread enters a __wt_yield() loop for up to 1000 iterations before progressing to adaptive backoff. The WT_REF_LOCKED case already sets stalled = true to skip this loop, but the busy case was missed.

On ARM64 at 128 threads with an out-of-cache workload, sched_yield() forces a full context switch. Threads spin through 1000 yields waiting for an eviction that typically takes milliseconds, far longer than the yield window. Setting stalled = true lets the thread skip to the adaptive backoff path, where it either helps with eviction (__wt_evict_app_assist_worker_check) or sleeps with incremental backoff (__wt_spin_backoff).

The stalled flag is a local variable that only affects retry strategy, not page access logic. The eviction assist path already has guards for reconcile, prepared transactions, prefetch, and checkpoint cursors.