### PR TITLE
WT-17074 Add early exit in update obsolete check for short update chains

### DIFF
--- a/src/include/serial_inline.h
+++ b/src/include/serial_inline.h
@@ -341,10 +341,11 @@ __wt_update_serial(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_PAGE *page
 
     /*
      * If there are no subsequent WT_UPDATE structures we are done here.
-     * Also skip if the chain is very short (only one prior update): a recently
-     * committed update cannot yet be globally visible, so the obsolete check
-     * will never find anything to free and would only waste cycles on the
-     * page spinlock and global state reads.
+     * Also skip if the chain from upd has exactly one prior update (i.e.,
+     * upd->next is the only older update we'd scan). Even if that single
+     * prior update is globally visible, it is the last value on the chain
+     * and cannot be freed. The obsolete check would only waste cycles on
+     * the page spinlock and global state reads.
      */
     if (upd->next == NULL || exclusive || upd->next->next == NULL)
         return (0);

--- a/src/include/serial_inline.h
+++ b/src/include/serial_inline.h
@@ -339,8 +339,14 @@ __wt_update_serial(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_PAGE *page
     if (WT_IS_HS(session->dhandle))
         return (0);
 
-    /* If there are no subsequent WT_UPDATE structures we are done here. */
-    if (upd->next == NULL || exclusive)
+    /*
+     * If there are no subsequent WT_UPDATE structures we are done here.
+     * Also skip if the chain is very short (only one prior update): a recently
+     * committed update cannot yet be globally visible, so the obsolete check
+     * will never find anything to free and would only waste cycles on the
+     * page spinlock and global state reads.
+     */
+    if (upd->next == NULL || exclusive || upd->next->next == NULL)
         return (0);
 
     /*

--- a/src/include/serial_inline.h
+++ b/src/include/serial_inline.h
@@ -340,12 +340,13 @@ __wt_update_serial(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_PAGE *page
         return (0);
 
     /*
-     * If there are no subsequent WT_UPDATE structures we are done here.
-     * Also skip if the chain from upd has exactly one prior update (i.e.,
-     * upd->next is the only older update we'd scan). Even if that single
-     * prior update is globally visible, it is the last value on the chain
-     * and cannot be freed. The obsolete check would only waste cycles on
-     * the page spinlock and global state reads.
+     * Skip the obsolete update check in three cases: when there are no older updates on the chain
+     * (upd->next is NULL), when the caller already holds exclusive access to the page, or when
+     * there is exactly one older update (upd->next->next is NULL). In the last case, even if that
+     * single prior update is globally visible, the obsolete check only truncates updates that
+     * follow the last globally visible value, so a single older update has no successors to
+     * truncate. Calling the check would only waste cycles acquiring the page spinlock and reading
+     * global state.
      */
     if (upd->next == NULL || exclusive || upd->next->next == NULL)
         return (0);

--- a/test/suite/test_update_obsolete_short_chain.py
+++ b/test/suite/test_update_obsolete_short_chain.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wttest
+from wiredtiger import stat
+from wtdataset import SimpleDataSet
+
+# test_update_obsolete_short_chain.py
+# Regression test for short update chains in __wt_update_serial.
+class test_update_obsolete_short_chain(wttest.WiredTigerTestCase):
+    conn_config = 'statistics=(all)'
+
+    def get_stat(self, stat_id):
+        stat_cursor = self.session.open_cursor('statistics:')
+        value = stat_cursor[stat_id][2]
+        stat_cursor.close()
+        return value
+
+    def update_with_ts(self, uri, key, value, ts):
+        cursor = self.session.open_cursor(uri)
+        self.session.begin_transaction()
+        cursor[key] = value
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(ts))
+        cursor.close()
+
+    def pin_timestamps(self, ts):
+        self.conn.set_timestamp(
+            'oldest_timestamp=' + self.timestamp_str(ts) +
+            ',stable_timestamp=' + self.timestamp_str(ts))
+
+    def test_short_chain_no_prune_then_prune(self):
+        uri = 'table:update_obsolete_short_chain'
+
+        # Disable table logging so timestamped updates are valid.
+        ds = SimpleDataSet(self, uri, 0, key_format='i', value_format='S',
+            config='log=(enabled=false)')
+        ds.populate()
+
+        key = 1
+        self.update_with_ts(uri, key, 'value-a', 10)
+        self.pin_timestamps(10)
+
+        removed_start = self.get_stat(stat.conn.cache_obsolete_updates_removed)
+
+        # After this update, the chain is [new] -> [prior] -> NULL.
+        # There is nothing to prune.
+        self.update_with_ts(uri, key, 'value-b', 20)
+        self.pin_timestamps(20)
+        removed_after_second = self.get_stat(stat.conn.cache_obsolete_updates_removed)
+        self.assertEqual(removed_after_second, removed_start)
+
+        # Grow the chain to length >= 3. Obsolete updates are then eligible
+        # for cleanup during reconciliation.
+        self.update_with_ts(uri, key, 'value-c', 30)
+        self.pin_timestamps(30)
+
+        self.session.checkpoint()
+        removed_after_checkpoint = self.get_stat(stat.conn.cache_obsolete_updates_removed)
+        self.assertGreater(removed_after_checkpoint, removed_after_second)
+
+        cursor = self.session.open_cursor(uri)
+        self.assertEqual(cursor[key], 'value-c')
+        cursor.close()
+
+if __name__ == '__main__':
+    wttest.run()


### PR DESCRIPTION
## Background

`__wt_update_obsolete_check` runs on every update to an existing key via `__wt_update_serial`. It acquires a page spinlock (`WT_PAGE_TRYLOCK`), loads `oldest_id` and `prune_timestamp` from shared volatile state, then walks the update chain looking for obsolete entries to truncate.

After inserting a new update, the chain looks like `[new] → [prior1] → [prior2] → ...`. The function finds the oldest globally-visible entry and frees everything after it. But it can only free entries that have something *after* them — you can't free the last known value for a key. The existing guard in `__wt_free_obsolete_updates` enforces this: `if (first != NULL && first->next != NULL)`.

So for a chain with only one prior entry (`[new] → [prior] → NULL`), even if `prior` is globally visible, `first->next == NULL` — there's nothing after it to cut off. You need at least three entries in the chain before there's anything worth truncating. Yet the function still acquires the spinlock, reads globals, and walks the chain to discover this.

## Change

This adds `upd->next->next == NULL` to the early-exit condition in `__wt_update_serial`. When the chain behind the newly inserted update has only one entry, the function returns immediately. Chains of length >= 2 are unaffected. Obsolete updates on short chains are still cleaned up during page reconciliation/eviction.
