### PR TITLE
Revert "WT-17053 Extract fsync block into __checkpoint_fsync helper"

### DIFF
--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -9,8 +9,6 @@
 #include "wt_internal.h"
 
 static int __checkpoint_drop_list_execute(WT_SESSION_IMPL *session, WT_ITEM *drop_list);
-static int __checkpoint_fsync_post(
-  WT_SESSION_IMPL *, const char *[], WT_DATA_HANDLE *, WT_DATA_HANDLE *);
 static int __checkpoint_lock_dirty_tree(WT_SESSION_IMPL *, bool, bool, bool, const char *[]);
 static int __checkpoint_mark_skip(WT_SESSION_IMPL *, WT_CKPT *, bool);
 static int __checkpoint_presync(WT_SESSION_IMPL *, const char *[]);
@@ -1489,8 +1487,8 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
     WT_TXN_ISOLATION saved_isolation;
     wt_off_t hs_size;
     wt_timestamp_t ckpt_tmp_ts;
-    uint64_t ckpt_tree_duration_usecs, drop_size, generation;
-    uint64_t time_start_ckpt_tree, time_stop_ckpt_tree;
+    uint64_t ckpt_tree_duration_usecs, drop_size, fsync_duration_usecs, generation;
+    uint64_t time_start_ckpt_tree, time_start_fsync, time_stop_ckpt_tree, time_stop_fsync;
     u_int i;
     char ts_string[WT_TS_INT_STRING_SIZE];
     bool failed, idle, logging, tracking;
@@ -1715,7 +1713,33 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
 
     __checkpoint_verbose_track(session, "committing transaction");
 
-    WT_ERR(__checkpoint_fsync_post(session, cfg, hs_dhandle, hs_dhandle_shared));
+    /*
+     * Checkpoints have to hit disk (it would be reasonable to configure for lazy checkpoints, but
+     * we don't support them yet).
+     */
+    time_start_fsync = __wt_clock(session);
+
+    WT_STAT_CONN_SET(session, checkpoint_state, WTI_CHECKPOINT_STATE_BM_SYNC);
+    WT_ERR(__checkpoint_apply_to_dhandles(session, cfg, __wt_checkpoint_sync));
+
+    /* Sync the history store file. */
+    if (F_ISSET(hs_dhandle, WT_DHANDLE_OPEN)) {
+        WT_STAT_CONN_SET(session, checkpoint_state, WTI_CHECKPOINT_STATE_HS_SYNC);
+        WT_WITH_DHANDLE(session, hs_dhandle, ret = __wt_checkpoint_sync(session, NULL));
+        WT_ERR(ret);
+    }
+    if (hs_dhandle_shared != NULL && F_ISSET(hs_dhandle_shared, WT_DHANDLE_OPEN)) {
+        WT_STAT_CONN_SET(session, checkpoint_state, WTI_CHECKPOINT_STATE_HS_SYNC);
+        WT_WITH_DHANDLE(session, hs_dhandle_shared, ret = __wt_checkpoint_sync(session, NULL));
+        WT_ERR(ret);
+    }
+
+    time_stop_fsync = __wt_clock(session);
+    fsync_duration_usecs = WT_CLOCKDIFF_US(time_stop_fsync, time_start_fsync);
+    WT_STAT_CONN_INCR(session, checkpoint_fsync_post);
+    WT_STAT_CONN_SET(session, checkpoint_fsync_post_duration, fsync_duration_usecs);
+
+    __checkpoint_verbose_track(session, "sync completed");
 
     /* If the history store file exists on disk, update its statistic. */
     if (F_ISSET(hs_dhandle, WT_DHANDLE_OPEN)) {
@@ -3004,50 +3028,6 @@ __checkpoint_tree_helper(WT_SESSION_IMPL *session, const char *cfg[])
      * the eviction server next wakes.
      */
     __wt_evict_server_wake(session);
-
-    return (ret);
-}
-
-/*
- * __checkpoint_fsync_post --
- *     Sync the checkpoint to disk.
- */
-static int
-__checkpoint_fsync_post(WT_SESSION_IMPL *session, const char *cfg[], WT_DATA_HANDLE *hs_dhandle,
-  WT_DATA_HANDLE *hs_dhandle_shared)
-{
-    WT_DECL_RET;
-
-    /*
-     * Checkpoints have to hit disk (it would be reasonable to configure for lazy checkpoints, but
-     * we don't support them yet).
-     */
-    uint64_t time_start_fsync = __wt_clock(session);
-
-    WT_STAT_CONN_SET(session, checkpoint_state, WTI_CHECKPOINT_STATE_BM_SYNC);
-    WT_ERR(__checkpoint_apply_to_dhandles(session, cfg, __wt_checkpoint_sync));
-
-    /* Sync the history store files. */
-    if (F_ISSET(hs_dhandle, WT_DHANDLE_OPEN)) {
-        WT_STAT_CONN_SET(session, checkpoint_state, WTI_CHECKPOINT_STATE_HS_SYNC);
-        WT_WITH_DHANDLE(session, hs_dhandle, ret = __wt_checkpoint_sync(session, NULL));
-        WT_ERR(ret);
-    }
-    if (hs_dhandle_shared != NULL && F_ISSET(hs_dhandle_shared, WT_DHANDLE_OPEN)) {
-        WT_STAT_CONN_SET(session, checkpoint_state, WTI_CHECKPOINT_STATE_HS_SYNC);
-        WT_WITH_DHANDLE(session, hs_dhandle_shared, ret = __wt_checkpoint_sync(session, NULL));
-        WT_ERR(ret);
-    }
-
-err:
-    uint64_t time_stop_fsync = __wt_clock(session);
-    uint64_t fsync_duration_usecs = WT_CLOCKDIFF_US(time_stop_fsync, time_start_fsync);
-    WT_STAT_CONN_SET(session, checkpoint_fsync_post_duration, fsync_duration_usecs);
-    if (ret == 0) {
-        WT_STAT_CONN_INCR(session, checkpoint_fsync_post);
-        __checkpoint_verbose_track(session, "sync completed");
-    } else
-        __checkpoint_verbose_track(session, "sync failed");
 
     return (ret);
 }


### PR DESCRIPTION
Reverts wiredtiger/wiredtiger#13445

Compile error - declaration after `err:` label.