### PR TITLE
WT-16573 Enable strict verify option in verifyUntilSuccess

### DIFF
--- a/test/suite/wttest.py
+++ b/test/suite/wttest.py
@@ -943,7 +943,7 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
         uri = self.uri if uri is None else uri
         return self.retryEBUSY(session, lambda: session.drop(uri, config), **kwargs)
 
-    def verifyUntilSuccess(self, session=None, uri=None, config=None, **kwargs):
+    def verifyUntilSuccess(self, session=None, uri=None, config="strict=true", **kwargs):
         session = self.session if session is None else session
         uri = self.uri if uri is None else uri
         return self.retryEBUSY(session, lambda: session.verify(uri, config), **kwargs)


### PR DESCRIPTION
Changed default config to enable strict verify in verifyUntilSuccess. Now the framework isn't relied on when catching errors.
