### PR TITLE
WT-17033 Refactor Page Eviction Booleans

### DIFF
--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2492,7 +2492,7 @@ __evict_try_queue_page(WT_SESSION_IMPL *session, WTI_EVICT_QUEUE *queue, WT_REF 
     WT_CONNECTION_IMPL *conn;
     WT_EVICT *evict;
     WT_PAGE *page;
-    bool modified, want_page;
+    bool modified, should_evict_page;
 
     btree = S2BT(session);
     conn = S2C(session);
@@ -2557,11 +2557,11 @@ __evict_try_queue_page(WT_SESSION_IMPL *session, WTI_EVICT_QUEUE *queue, WT_REF 
         goto fast;
 
     /* Skip pages we don't want. */
-    want_page =
+    should_evict_page =
       (F_ISSET(evict, WT_EVICT_CACHE_CLEAN) && !F_ISSET(btree, WT_BTREE_IN_MEMORY) && !modified) ||
       (F_ISSET(evict, WT_EVICT_CACHE_DIRTY) && modified) ||
       (F_ISSET(evict, WT_EVICT_CACHE_UPDATES) && page->modify != NULL);
-    if (!want_page) {
+    if (!should_evict_page) {
         WT_STAT_CONN_INCR(session, eviction_server_skip_unwanted_pages);
         return;
     }

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -2492,7 +2492,7 @@ __evict_try_queue_page(WT_SESSION_IMPL *session, WTI_EVICT_QUEUE *queue, WT_REF 
     WT_CONNECTION_IMPL *conn;
     WT_EVICT *evict;
     WT_PAGE *page;
-    bool modified, should_evict_page;
+    bool evict_clean, evict_dirty, evict_updates, modified, should_evict_page;
 
     btree = S2BT(session);
     conn = S2C(session);
@@ -2556,11 +2556,12 @@ __evict_try_queue_page(WT_SESSION_IMPL *session, WTI_EVICT_QUEUE *queue, WT_REF 
     if (__wt_page_is_empty(page) || F_ISSET(session->dhandle, WT_DHANDLE_DEAD))
         goto fast;
 
+    evict_clean =
+      F_ISSET(evict, WT_EVICT_CACHE_CLEAN) && !F_ISSET(btree, WT_BTREE_IN_MEMORY) && !modified;
+    evict_dirty = F_ISSET(evict, WT_EVICT_CACHE_DIRTY) && modified;
+    evict_updates = F_ISSET(evict, WT_EVICT_CACHE_UPDATES) && page->modify != NULL;
+    should_evict_page = evict_clean || evict_dirty || evict_updates;
     /* Skip pages we don't want. */
-    should_evict_page =
-      (F_ISSET(evict, WT_EVICT_CACHE_CLEAN) && !F_ISSET(btree, WT_BTREE_IN_MEMORY) && !modified) ||
-      (F_ISSET(evict, WT_EVICT_CACHE_DIRTY) && modified) ||
-      (F_ISSET(evict, WT_EVICT_CACHE_UPDATES) && page->modify != NULL);
     if (!should_evict_page) {
         WT_STAT_CONN_INCR(session, eviction_server_skip_unwanted_pages);
         return;


### PR DESCRIPTION
The code in evict_lru.c responsible for determining whether a page should be considered for eviction is currently implemented as a single complex boolean expression. This changes breaks down each eviction check (clean, dirty, or pending updates) into separate ones for better readability.

Also changes `want_page` to `should_evict_page` for more clarity.