### PR TITLE
WT-16494 Fix fake point check failure when apply disagg checkpoint metadata

### DIFF
--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -262,6 +262,8 @@ __disagg_apply_checkpoint_meta(
             uint64_t time, time_new;
             bool current_is_fake;
 
+            order = 0;
+            time = 0;
             /*
              * Determine whether the current checkpoint in the metadata is a fake. A fake checkpoint
              * has an empty addr (len == 0), as established in __ckpt_load in meta_ckpt.c. Parse

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -173,11 +173,11 @@ __disagg_discard_old_checkpoint_check(WT_SESSION_IMPL *session, const char * uri
     current_is_fake = false;
 
     /*
-     * Determine whether the current checkpoint in the metadata is a fake. A fake checkpoint has an
-     * empty addr (len == 0), as established in __ckpt_load in meta_ckpt.c. Parse current_value
-     * directly to avoid a redundant metadata lookup; track the highest order to identify the last
-     * checkpoint entry.
-     */
+    * Determine whether the current checkpoint in the metadata is a fake. A fake checkpoint has an
+    * empty addr (len == 0), as established in __ckpt_load in meta_ckpt.c. Parse current_value
+    * directly to avoid a redundant metadata lookup; track the highest order to identify the last
+    * checkpoint entry.
+    */
     WT_ERR(__wt_config_getones(session, cfg_current, "checkpoint", &ckpt_v));
     __wt_config_subinit(session, &ckptconf, &ckpt_v);
     while (__wt_config_next(&ckptconf, &k, &v) == 0) {
@@ -218,9 +218,9 @@ __disagg_discard_old_checkpoint_check(WT_SESSION_IMPL *session, const char * uri
               "We're facing a checkpoint with the same order but different time, which should "
               "never happen. File: %s, Current metadata: %s, new checkpoint metadata: %s",
               uri, cfg_current, cfg_new);
-        *discardp = true;
-    } else
         *discardp = false;
+    } else
+        *discardp = true;
 
 #ifdef HAVE_DIAGNOSTIC
     if (!*discardp)

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -156,8 +156,8 @@ __wt_disagg_set_database_size(WT_SESSION_IMPL *session, uint64_t database_size)
  *     same checkpoint. If the checkpoint has advanced, the old one can be discarded.
  */
 static int
-__disagg_discard_old_checkpoint_check(WT_SESSION_IMPL *session, const char * uri, const char *cfg_current,
-  const char *cfg_new, const char **checkpoint_name, bool *discardp)
+__disagg_discard_old_checkpoint_check(WT_SESSION_IMPL *session, const char *uri,
+  const char *cfg_current, const char *cfg_new, const char **checkpoint_name, bool *discardp)
 {
     WT_CONFIG ckptconf;
     WT_CONFIG_ITEM ckpt_v, k, v, addr_a;
@@ -173,11 +173,11 @@ __disagg_discard_old_checkpoint_check(WT_SESSION_IMPL *session, const char * uri
     current_is_fake = false;
 
     /*
-    * Determine whether the current checkpoint in the metadata is a fake. A fake checkpoint has an
-    * empty addr (len == 0), as established in __ckpt_load in meta_ckpt.c. Parse current_value
-    * directly to avoid a redundant metadata lookup; track the highest order to identify the last
-    * checkpoint entry.
-    */
+     * Determine whether the current checkpoint in the metadata is a fake. A fake checkpoint has an
+     * empty addr (len == 0), as established in __ckpt_load in meta_ckpt.c. Parse current_value
+     * directly to avoid a redundant metadata lookup; track the highest order to identify the last
+     * checkpoint entry.
+     */
     WT_ERR(__wt_config_getones(session, cfg_current, "checkpoint", &ckpt_v));
     __wt_config_subinit(session, &ckptconf, &ckpt_v);
     while (__wt_config_next(&ckptconf, &k, &v) == 0) {
@@ -209,16 +209,24 @@ __disagg_discard_old_checkpoint_check(WT_SESSION_IMPL *session, const char * uri
     }
 
     /*
-     * Treat the checkpoint order and time configurations as the source of truth when determining
-     * whether the checkpoint has changed.
+     * If order is the same but time is not, and it's not a local fake checkpoint, then we can face
+     * a data corruption.
      */
-    if (checkpoint_order == checkpoint_order_new && checkpoint_time == checkpoint_time_new) {
-        if (!current_is_fake)
+    if (checkpoint_order == checkpoint_order_new && checkpoint_time != checkpoint_time_new) {
+        if (!current_is_fake) {
             WT_ERR_MSG(session, EINVAL,
               "We're facing a checkpoint with the same order but different time, which should "
               "never happen. File: %s, Current metadata: %s, new checkpoint metadata: %s",
               uri, cfg_current, cfg_new);
-        *discardp = false;
+        }
+    }
+    
+    /*
+     * Treat the checkpoint order and time configurations as the source of truth when determining
+     * whether the checkpoint has changed.
+     */
+    if (checkpoint_order == checkpoint_order_new && checkpoint_time == checkpoint_time_new) {
+        *discardp = current_is_fake;
     } else
         *discardp = true;
 

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -220,7 +220,7 @@ __disagg_discard_old_checkpoint_check(WT_SESSION_IMPL *session, const char *uri,
               uri, cfg_current, cfg_new);
         }
     }
-    
+
     /*
      * Treat the checkpoint order and time configurations as the source of truth when determining
      * whether the checkpoint has changed.

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -260,6 +260,27 @@ __disagg_apply_checkpoint_meta(
 
             int64_t order, order_new;
             uint64_t time, time_new;
+            bool current_is_fake;
+
+            /*
+             * Determine whether the current checkpoint in the metadata is a fake. A fake checkpoint
+             * has an empty addr (len == 0), as established in __ckpt_load in meta_ckpt.c. Parse
+             * current_value directly to avoid a redundant metadata lookup; track the highest order
+             * to identify the last checkpoint entry.
+             */
+            {
+                WT_CONFIG ckptconf;
+                WT_CONFIG_ITEM ckpt_v, k, v, addr_a;
+
+                current_is_fake = false;
+                WT_ERR(__wt_config_getones(session, current_value, "checkpoint", &ckpt_v));
+                __wt_config_subinit(session, &ckptconf, &ckpt_v);
+                while (__wt_config_next(&ckptconf, &k, &v) == 0) {
+                    WT_ERR(__wt_config_subgets(session, &v, "addr", &addr_a));
+                    current_is_fake = addr_a.len == 0;
+                }
+            }
+
             /*
              * Before inserting the new value, get the checkpoint name of the file at the previous
              * checkpoint.
@@ -279,13 +300,15 @@ __disagg_apply_checkpoint_meta(
               "Retrieving the last checkpoint name failed for key \"%s\"", metadata_key);
 
             /* FIXME-WT-14730: check that the other parts of the metadata are identical. */
-            /*
-             * FIXME-WT-16494: how to decide two checkpoints are different if they are written by
-             * different nodes.
-             */
-            bool same_checkpoint = checkpoint_name != NULL && checkpoint_name_new != NULL &&
-              strcmp(checkpoint_name, checkpoint_name_new) == 0 && order == order_new &&
-              time == time_new;
+            bool same_checkpoint = !current_is_fake && checkpoint_name != NULL &&
+              checkpoint_name_new != NULL && strcmp(checkpoint_name, checkpoint_name_new) == 0 &&
+              order == order_new && time == time_new;
+
+            if (!current_is_fake && order == order_new && time != time_new)
+                __wt_errx(session,
+                  "We're facing a checkpoint with the same order but different time, which should "
+                  "never happen. File: %s, Current metadata: %s, new checkpoint metadata: %s",
+                  metadata_key, current_value, metadata_value);
 
             /* Put our new config in */
             md_cursor->set_value(md_cursor, cfg_ret);


### PR DESCRIPTION
Always drop a local fake checkpoint when apply remote checkpoint metadata.