### PR TITLE
WT-15380 Implement a new logging API for Hardware Corruption Logs leveraging WiredTiger Unique IDs

### DIFF
--- a/src/block/block_read.c
+++ b/src/block/block_read.c
@@ -313,13 +313,13 @@ __wti_block_read_off(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_ITEM *buf, ui
 
     if (!F_ISSET(session, WT_SESSION_QUIET_CORRUPT_FILE)) {
         if (full_checksum_mismatch)
-            __wt_errx(session,
+            __wt_errx_id(session, 1538000,
               "%s: potential hardware corruption, read checksum error for %" PRIu32
               "B block at offset %" PRIuMAX ": calculated block checksum of %#" PRIx32
               " doesn't match expected checksum of %#" PRIx32,
               block->name, size, (uintmax_t)offset, __wt_checksum(buf->mem, check_size), checksum);
         else
-            __wt_errx(session,
+            __wt_errx_id(session, 1538001,
               "%s: potential hardware corruption, read checksum error for %" PRIu32
               "B block at offset %" PRIuMAX ": block header checksum of %#" PRIx32
               " doesn't match expected checksum of %#" PRIx32,

--- a/src/include/error.h
+++ b/src/include/error.h
@@ -29,6 +29,9 @@
       session, error, __PRETTY_FUNCTION__, __LINE__, WT_VERBOSE_CATEGORY_DEFAULT, __VA_ARGS__)
 #define __wt_errx(session, ...) \
     __wt_errx_func(session, __PRETTY_FUNCTION__, __LINE__, WT_VERBOSE_CATEGORY_DEFAULT, __VA_ARGS__)
+#define __wt_errx_id(session, log_id, ...) \
+    __wt_errx_func_id(                     \
+      session, log_id, __PRETTY_FUNCTION__, __LINE__, WT_VERBOSE_CATEGORY_DEFAULT, __VA_ARGS__)
 #define __wt_panic(session, error, ...) \
     __wt_panic_func(                    \
       session, error, __PRETTY_FUNCTION__, __LINE__, WT_VERBOSE_CATEGORY_DEFAULT, __VA_ARGS__)

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1753,6 +1753,10 @@ extern void __wt_errx_func(WT_SESSION_IMPL *session, const char *func, int line,
   WT_VERBOSE_CATEGORY category, const char *fmt, ...) WT_GCC_FUNC_DECL_ATTRIBUTE((cold))
   WT_GCC_FUNC_DECL_ATTRIBUTE((format(printf, 5, 6)))
     WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")));
+extern void __wt_errx_func_id(WT_SESSION_IMPL *session, uint32_t log_id, const char *func, int line,
+  WT_VERBOSE_CATEGORY category, const char *fmt, ...) WT_GCC_FUNC_DECL_ATTRIBUTE((cold))
+  WT_GCC_FUNC_DECL_ATTRIBUTE((format(printf, 6, 7)))
+    WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")));
 extern void __wt_event_handler_set(WT_SESSION_IMPL *session, WT_EVENT_HANDLER *handler);
 extern void __wt_ext_scr_free(WT_EXTENSION_API *wt_api, WT_SESSION *wt_session, void *p);
 extern void __wt_ext_spin_destroy(WT_EXTENSION_API *wt_api, WT_EXTENSION_SPINLOCK *ext_spinlock);

--- a/src/support/err.c
+++ b/src/support/err.c
@@ -556,6 +556,10 @@ __wt_errx_func(WT_SESSION_IMPL *session, const char *func, int line, WT_VERBOSE_
 {
     va_list ap;
 
+    /*
+     * Ignore error returns from underlying event handlers, we already have an error value to
+     * return.
+     */
     va_start(ap, fmt);
     WT_IGNORE_RET(__eventv(session,
       session ? FLD_ISSET(S2C(session)->json_output, WT_JSON_OUTPUT_ERROR) : false, 0,

--- a/src/support/err.c
+++ b/src/support/err.c
@@ -524,6 +524,28 @@ __wt_err_func(WT_SESSION_IMPL *session, int error, const char *func, int line,
 }
 
 /*
+ * __wt_errx_func_id --
+ *     Report an error with no error code and a unique log ID.
+ */
+void
+__wt_errx_func_id(WT_SESSION_IMPL *session, uint32_t log_id, const char *func, int line,
+  WT_VERBOSE_CATEGORY category, const char *fmt, ...) WT_GCC_FUNC_ATTRIBUTE((cold))
+  WT_GCC_FUNC_ATTRIBUTE((format(printf, 6, 7))) WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
+{
+    va_list ap;
+
+    /*
+     * Ignore error returns from underlying event handlers, we already have an error value to
+     * return.
+     */
+    va_start(ap, fmt);
+    WT_IGNORE_RET(__eventv(session,
+      session ? FLD_ISSET(S2C(session)->json_output, WT_JSON_OUTPUT_ERROR) : false, 0, log_id, func,
+      line, category, WT_VERBOSE_ERROR, fmt, ap));
+    va_end(ap);
+}
+
+/*
  * __wt_errx_func --
  *     Report an error with no error code.
  */
@@ -534,10 +556,6 @@ __wt_errx_func(WT_SESSION_IMPL *session, const char *func, int line, WT_VERBOSE_
 {
     va_list ap;
 
-    /*
-     * Ignore error returns from underlying event handlers, we already have an error value to
-     * return.
-     */
     va_start(ap, fmt);
     WT_IGNORE_RET(__eventv(session,
       session ? FLD_ISSET(S2C(session)->json_output, WT_JSON_OUTPUT_ERROR) : false, 0,


### PR DESCRIPTION
This pull request adds a new error logging API that attaches unique log IDs to hardware corruption messages in WiredTiger, and begins using it to tag block read checksum errors for easier detection in the Atlas fleet.

Summary
Introduce __wt_errx_id(session, log_id, ...), a new error macro that parallels the existing __wt_verbose_info_id pattern and lets callers associate a stable numeric ID with errors emitted via __wt_errx. This allows downstream Atlas systems to reliably match specific error conditions via log rules without parsing free-form message text.

The two “potential hardware corruption, read checksum error” messages in block_read.c are the first adopters, using IDs 1538000 (full block checksum mismatch) and 1538001 (block header checksum mismatch).