### PR TITLE
WT-16716 Track leaf and total cache pages for FTDC visibility

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -337,6 +337,7 @@ conn_stats = [
     CacheStat('cache_pages_dirty_stable', 'tracked dirty pages in the cache from the stable btrees', 'no_clear,no_scale'),
     CacheStat('cache_pages_inuse', 'pages currently held in the cache', 'no_clear,no_scale'),
     CacheStat('cache_pages_inuse_ingest', 'pages currently held in the cache from the ingest btrees', 'no_clear,no_scale'),
+    CacheStat('cache_pages_inuse_leaf', 'leaf pages currently held in the cache', 'no_clear,no_scale'),
     CacheStat('cache_pages_inuse_stable', 'pages currently held in the cache from the stable btrees', 'no_clear,no_scale'),
     CacheStat('cache_read_app_count', 'application threads page read from disk to cache count'),
     CacheStat('cache_read_app_time', 'application threads page read from disk to cache time (usecs)'),

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -910,6 +910,8 @@ err:
     /* Increment the cache statistics. */
     __wt_cache_page_inmem_incr(session, page, size, false);
     (void)__wt_atomic_add_uint64_relaxed(&cache->pages_inmem, 1);
+    if (!WT_PAGE_IS_INTERNAL(page))
+        (void)__wt_atomic_add_uint64_relaxed(&cache->pages_inmem_leaf, 1);
     if (__wt_conn_is_disagg(session)) {
         if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
             (void)__wt_atomic_add_uint64_relaxed(&cache->pages_inmem_ingest, 1);

--- a/src/cache/cache.c
+++ b/src/cache/cache.c
@@ -148,6 +148,8 @@ __wt_cache_stats_update(WT_SESSION_IMPL *session)
     WT_STATP_CONN_SET(
       session, stats, cache_bytes_image_stable, __wt_cache_bytes_image_stable(cache));
     WT_STATP_CONN_SET(session, stats, cache_pages_inuse, __wt_cache_pages_inuse(cache));
+    WT_STATP_CONN_SET(session, stats, cache_pages_inuse_leaf, __wt_cache_pages_inuse_leaf(cache));
+    WT_STATP_CONN_SET(session, stats, cache_pages_inuse_leaf, __wt_cache_pages_inuse_leaf(cache));
     WT_STATP_CONN_SET(
       session, stats, cache_pages_inuse_ingest, __wt_cache_pages_inuse_ingest(cache));
     WT_STATP_CONN_SET(

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -378,6 +378,25 @@ err:
 }
 
 /*
+ * __raise_next_file_id --
+ *     Increase our next file ID if necessary. This value is only important for synchronizing
+ *     changes to the shared metadata table, which are made only by the leader. The increment only
+ *     happens on a follower, which will make tables only in response to the leader (via picking up
+ *     a checkpoint, or by oplog application). So it's OK if we've made new files since this
+ *     checkpoint was generated.
+ */
+static void
+__raise_next_file_id(WT_SESSION_IMPL *session, const WT_DISAGG_METADATA *metadata)
+{
+    WT_CONNECTION_IMPL *conn = S2C(session);
+
+    WT_ASSERT_SPINLOCK_OWNED(session, &conn->schema_lock);
+
+    if (conn->next_file_id < metadata->largest_file_id)
+        conn->next_file_id = metadata->largest_file_id;
+}
+
+/*
  * __disagg_update_checkpoint_meta --
  *     Finalize checkpoint bookkeeping after processing shared metadata entries.
  */
@@ -416,6 +435,8 @@ __disagg_update_checkpoint_meta(WT_SESSION_IMPL *session, WT_SESSION_IMPL *inter
       __wti_layered_iterate_ingest_tables_for_gc_pruning(
         internal_session, metadata->checkpoint_timestamp),
       "Updating prune timestamp failed");
+
+    WT_WITH_SCHEMA_LOCK(session, __raise_next_file_id(session, metadata));
 
 err:
     return (ret);
@@ -480,11 +501,11 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPOINT
     __wt_verbose_debug2(session, WT_VERB_DISAGGREGATED_STORAGE,
       "Picking up disaggregated storage checkpoint: metadata_lsn=%" PRIu64 ", timestamp=%" PRIu64
       " %s"
-      ", oldest_timestamp=%" PRIu64 " %s, root=\"%.*s\"",
+      ", oldest_timestamp=%" PRIu64 " %s, largest_file_id=%" PRIu32 ", root=\"%.*s\"",
       ckpt_meta->metadata_lsn, metadata.checkpoint_timestamp,
       __wt_timestamp_to_string(metadata.checkpoint_timestamp, ts_string[0]),
       metadata.oldest_timestamp, __wt_timestamp_to_string(metadata.oldest_timestamp, ts_string[1]),
-      (int)metadata.checkpoint_len, metadata.checkpoint);
+      metadata.largest_file_id, (int)metadata.checkpoint_len, metadata.checkpoint);
 
     /* Load crypt key data with the key provider extension, if any. */
     WT_ERR(__wti_disagg_load_crypt_key(session, &metadata));

--- a/src/conn/conn_layered_page_log.c
+++ b/src/conn/conn_layered_page_log.c
@@ -569,7 +569,7 @@ __wt_disagg_put_checkpoint_meta(WT_SESSION_IMPL *session, const char *checkpoint
     WT_DISAGGREGATED_STORAGE *disagg;
     wt_timestamp_t oldest_timestamp;
     uint64_t lsn;
-    uint32_t checksum;
+    uint32_t checksum, max_table_id;
     char *checkpoint_root_copy, ts_string[2][WT_TS_INT_STRING_SIZE];
 
     checkpoint_root_copy = NULL;
@@ -595,15 +595,18 @@ __wt_disagg_put_checkpoint_meta(WT_SESSION_IMPL *session, const char *checkpoint
      */
     WT_ERR(__wt_meta_read_checkpoint_oldest(session, NULL, &oldest_timestamp, NULL));
 
+    WT_WITH_SCHEMA_LOCK(session, max_table_id = conn->next_file_id);
+
     /* Format metadata settings. */
     WT_ERR(
       __wt_buf_fmt(session, metadata_buf,
         "version=%d,compatible_version=%d,\n"
         "checkpoint=%s,\n"
         "timestamp=%" PRIx64 ",\n"
-        "oldest_timestamp=%" PRIx64,
+        "oldest_timestamp=%" PRIx64 ",\n"
+        "largest_file_id=%" PRIu32,
         WT_DISAGG_CHECKPOINT_TURTLE_VERSION, WT_DISAGG_CHECKPOINT_TURTLE_COMPATIBLE_VERSION,
-        checkpoint_root_copy, checkpoint_timestamp, oldest_timestamp));
+        checkpoint_root_copy, checkpoint_timestamp, oldest_timestamp, max_table_id));
 
     /* Append key provider metadata, if available. */
     if (conn->key_provider != NULL) {
@@ -643,10 +646,11 @@ __wt_disagg_put_checkpoint_meta(WT_SESSION_IMPL *session, const char *checkpoint
 
     __wt_verbose_debug2(session, WT_VERB_DISAGGREGATED_STORAGE,
       "Wrote disaggregated checkpoint metadata: lsn=%" PRIu64 ", timestamp=%" PRIu64
-      " %s, oldest_timestamp=%" PRIu64 " %s, checksum=%" PRIx32 ", root=\"%s\"",
+      " %s, oldest_timestamp=%" PRIu64 " %s, largest_file_id=%" PRIu32 ", checksum=%" PRIx32
+      ", root=\"%s\"",
       lsn, checkpoint_timestamp, __wt_timestamp_to_string(checkpoint_timestamp, ts_string[0]),
-      oldest_timestamp, __wt_timestamp_to_string(oldest_timestamp, ts_string[1]), checksum,
-      checkpoint_root_copy);
+      oldest_timestamp, __wt_timestamp_to_string(oldest_timestamp, ts_string[1]), max_table_id,
+      checksum, checkpoint_root_copy);
 
     __wt_free(session, disagg->last_checkpoint_root);
     disagg->last_checkpoint_root = checkpoint_root_copy;
@@ -729,6 +733,7 @@ err:
  *     version=1,compatible_version=1,
  *     checkpoint=(WiredTigerCheckpoint.1=(addr="00c025808282bd21596019", order=1, ...)),
  *     timestamp=0,
+ *     largest_file_id=0,
  *     key_provider=(page.1=(page_id=1,lsn=123),version=1)
  */
 static int
@@ -777,6 +782,14 @@ __disagg_parse_meta(WT_SESSION_IMPL *session, const WT_ITEM *meta_buf, WT_DISAGG
             else
                 WT_ERR(__wt_txn_parse_timestamp(
                   session, "oldest timestamp", &metadata->oldest_timestamp, &cfg_value));
+        } else if (WT_CONFIG_LIT_MATCH("largest_file_id", cfg_key)) {
+            WT_ASSERT_ALWAYS(session, metadata->largest_file_id == 0,
+              "Duplicate largest file entry in disaggregated storage metadata: "
+              "metadata->largest_file_id=%" PRIu32,
+              metadata->largest_file_id);
+
+            if (cfg_value.len > 0)
+                metadata->largest_file_id = (uint32_t)cfg_value.val;
         } else if (WT_CONFIG_LIT_MATCH("key_provider", cfg_key)) {
             WT_ASSERT_ALWAYS(session, metadata->key_provider == NULL,
               "Duplicate key_provider entry in disaggregated storage metadata");

--- a/src/conn/conn_layered_table_manager.c
+++ b/src/conn/conn_layered_table_manager.c
@@ -28,7 +28,7 @@ __wti_layered_table_manager_init(WT_SESSION_IMPL *session)
     WT_RET(__wt_spin_init(session, &manager->layered_table_lock, "layered table manager"));
 
     /* Allow for up to 1000 files to be allocated at start. */
-    manager->open_layered_table_count = conn->next_file_id + 1000;
+    WT_WITH_SCHEMA_LOCK(session, manager->open_layered_table_count = conn->next_file_id + 1000);
     WT_ERR(__wt_calloc(session, sizeof(WT_LAYERED_TABLE_MANAGER_ENTRY *),
       manager->open_layered_table_count, &manager->entries));
     manager->entries_allocated_bytes =

--- a/src/evict/evict_inline.h
+++ b/src/evict/evict_inline.h
@@ -375,6 +375,8 @@ __wt_evict_page_cache_bytes_decr(WT_SESSION_IMPL *session, WT_PAGE *page)
     /* Update bytes and pages evicted. */
     (void)__wt_atomic_add_uint64_relaxed(&cache->bytes_evict, memory_footprint);
     (void)__wt_atomic_add_uint64_v_relaxed(&cache->pages_evicted, 1);
+    if (!WT_PAGE_IS_INTERNAL(page))
+        (void)__wt_atomic_add_uint64_v_relaxed(&cache->pages_evicted_leaf, 1);
     if (is_disagg) {
         if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
             (void)__wt_atomic_add_uint64_v_relaxed(&cache->pages_evicted_ingest, 1);

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -294,6 +294,10 @@ __wt_btree_shared(WT_SESSION_IMPL *session, const char *uri, const char **bt_cfg
     WT_RET(__wt_config_gets(session, bt_cfg, "block_manager", &cval));
     *shared = (WT_SUFFIX_MATCH(uri, ".wt_stable") || WT_CONFIG_LIT_MATCH("disagg", cval));
 
+    /* Ingest btrees must never be shared. */
+    WT_ASSERT_ALWAYS(session, !(*shared && WT_SUFFIX_MATCH(uri, ".wt_ingest")),
+      "Ingest btree incorrectly created as shared.");
+
     return (0);
 }
 

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -93,9 +93,11 @@ struct __wt_cache {
     wt_shared uint64_t pages_dirty_leaf_stable;
     wt_shared uint64_t pages_evicted;
     wt_shared uint64_t pages_evicted_ingest;
+    wt_shared uint64_t pages_evicted_leaf;
     wt_shared uint64_t pages_evicted_stable;
     wt_shared uint64_t pages_inmem;
     wt_shared uint64_t pages_inmem_ingest;
+    wt_shared uint64_t pages_inmem_leaf;
     wt_shared uint64_t pages_inmem_stable;
 
     u_int overhead_pct; /* Cache percent adjustment */

--- a/src/include/cache_inline.h
+++ b/src/include/cache_inline.h
@@ -20,6 +20,17 @@ __wt_cache_pages_inuse(WT_CACHE *cache)
 }
 
 /*
+ * __wt_cache_pages_inuse_leaf --
+ *     Return the number of leaf pages in use.
+ */
+static WT_INLINE uint64_t
+__wt_cache_pages_inuse_leaf(WT_CACHE *cache)
+{
+    return (__wt_atomic_load_uint64_relaxed(&cache->pages_inmem_leaf) -
+      __wt_atomic_load_uint64_relaxed(&cache->pages_evicted_leaf));
+}
+
+/*
  * __wt_cache_pages_inuse_ingest --
  *     Return the number of pages in use for the ingest btrees.
  */

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -167,7 +167,7 @@ struct __wt_layered_table_manager {
  * - COMPATIBLE_VERSION: The minimum reader version required to read what this code writes.
  */
 #define WT_DISAGG_CHECKPOINT_TURTLE_VERSION_DEFAULT 1
-#define WT_DISAGG_CHECKPOINT_TURTLE_VERSION 1
+#define WT_DISAGG_CHECKPOINT_TURTLE_VERSION 2
 #define WT_DISAGG_CHECKPOINT_TURTLE_COMPATIBLE_VERSION 1
 
 /*

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2411,6 +2411,8 @@ static WT_INLINE uint64_t __wt_cache_pages_inuse(WT_CACHE *cache)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE uint64_t __wt_cache_pages_inuse_ingest(WT_CACHE *cache)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static WT_INLINE uint64_t __wt_cache_pages_inuse_leaf(WT_CACHE *cache)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE uint64_t __wt_cache_pages_inuse_stable(WT_CACHE *cache)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE uint64_t __wt_cell_rle(WT_CELL_UNPACK_KV *unpack)

--- a/src/include/meta.h
+++ b/src/include/meta.h
@@ -145,6 +145,7 @@ typedef struct __wt_disagg_metadata {
     size_t checkpoint_len;         /* Length of checkpoint metadata string */
     uint64_t checkpoint_timestamp; /* Checkpoint timestamp */
     uint64_t oldest_timestamp;     /* Oldest timestamp */
+    uint32_t largest_file_id;      /* High water mark of allocated file IDs */
 
     const char *key_provider; /* Key provider metadata string */
     size_t key_provider_len;  /* Length of key provider metadata string */

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -677,6 +677,7 @@ struct __wt_connection_stats {
     int64_t eviction_internal_pages_seen;
     int64_t eviction_internal_pages_already_queued;
     int64_t cache_eviction_split_internal;
+    int64_t cache_pages_inuse_leaf;
     int64_t cache_eviction_split_leaf;
     int64_t cache_eviction_random_sample_inmem_root;
     int64_t cache_bytes_max;

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -6985,1928 +6985,1930 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_ALREADY_QUEUED	1253
 /*! cache: internal pages split during eviction */
 #define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_INTERNAL	1254
+/*! cache: leaf pages currently held in the cache */
+#define	WT_STAT_CONN_CACHE_PAGES_INUSE_LEAF		1255
 /*! cache: leaf pages split during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_LEAF		1255
+#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_LEAF		1256
 /*!
  * cache: locate a random in-mem ref by examining all entries on the root
  * page
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_RANDOM_SAMPLE_INMEM_ROOT	1256
+#define	WT_STAT_CONN_CACHE_EVICTION_RANDOM_SAMPLE_INMEM_ROOT	1257
 /*! cache: maximum bytes configured */
-#define	WT_STAT_CONN_CACHE_BYTES_MAX			1257
+#define	WT_STAT_CONN_CACHE_BYTES_MAX			1258
 /*! cache: maximum clean page size seen at eviction per checkpoint */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_CLEAN_PAGE_SIZE_PER_CHECKPOINT	1258
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_CLEAN_PAGE_SIZE_PER_CHECKPOINT	1259
 /*! cache: maximum dirty page size seen at eviction per checkpoint */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_DIRTY_PAGE_SIZE_PER_CHECKPOINT	1259
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_DIRTY_PAGE_SIZE_PER_CHECKPOINT	1260
 /*!
  * cache: maximum gap between unvisited page and connection evict pass
  * generation seen at eviction
  */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_UNVISITED_GEN_GAP	1260
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_UNVISITED_GEN_GAP	1261
 /*!
  * cache: maximum gap between unvisited page and connection evict pass
  * generation seen at eviction per checkpoint
  */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_UNVISITED_GEN_GAP_PER_CHECKPOINT	1261
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_UNVISITED_GEN_GAP_PER_CHECKPOINT	1262
 /*!
  * cache: maximum gap between visited page and connection evict pass
  * generation seen at eviction
  */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_VISITED_GEN_GAP	1262
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_VISITED_GEN_GAP	1263
 /*!
  * cache: maximum gap between visited page and connection evict pass
  * generation seen at eviction per checkpoint
  */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_VISITED_GEN_GAP_PER_CHECKPOINT	1263
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_VISITED_GEN_GAP_PER_CHECKPOINT	1264
 /*! cache: maximum milliseconds spent at a single eviction */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_MILLISECONDS	1264
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_MILLISECONDS	1265
 /*! cache: maximum milliseconds spent at a single eviction per checkpoint */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_MILLISECONDS_PER_CHECKPOINT	1265
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_MILLISECONDS_PER_CHECKPOINT	1266
 /*!
  * cache: maximum number of times a page tried to be added to eviction
  * queue but fail
  */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_ATTEMPTS_TO_QUEUE_PAGE	1266
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_ATTEMPTS_TO_QUEUE_PAGE	1267
 /*! cache: maximum number of times a page tried to be evicted */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_ATTEMPTS_TO_EVICT_PAGE	1267
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_ATTEMPTS_TO_EVICT_PAGE	1268
 /*! cache: maximum updates page size seen at eviction per checkpoint */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_UPDATES_PAGE_SIZE_PER_CHECKPOINT	1268
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_UPDATES_PAGE_SIZE_PER_CHECKPOINT	1269
 /*! cache: modified page evict attempts by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_DIRTY_ATTEMPT		1269
+#define	WT_STAT_CONN_EVICTION_APP_DIRTY_ATTEMPT		1270
 /*! cache: modified page evict failures by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_DIRTY_FAIL		1270
+#define	WT_STAT_CONN_EVICTION_APP_DIRTY_FAIL		1271
 /*! cache: modified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1271
+#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1272
 /*! cache: multi-block reconciliation blocked whilst checkpoint is running */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_MULTI_BLOCK_RECONCILIATION_DURING_CHECKPOINT	1272
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_MULTI_BLOCK_RECONCILIATION_DURING_CHECKPOINT	1273
 /*! cache: npos read - had to walk this many pages */
-#define	WT_STAT_CONN_NPOS_READ_WALK_MAX			1273
+#define	WT_STAT_CONN_NPOS_READ_WALK_MAX			1274
 /*! cache: number of internal pages read that had deltas attached */
-#define	WT_STAT_CONN_CACHE_READ_INTERNAL_DELTA		1274
+#define	WT_STAT_CONN_CACHE_READ_INTERNAL_DELTA		1275
 /*! cache: number of leaf pages read that had deltas attached */
-#define	WT_STAT_CONN_CACHE_READ_LEAF_DELTA		1275
+#define	WT_STAT_CONN_CACHE_READ_LEAF_DELTA		1276
 /*! cache: number of times dirty trigger was reached */
-#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_DIRTY_REACHED	1276
+#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_DIRTY_REACHED	1277
 /*! cache: number of times eviction trigger was reached */
-#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_REACHED	1277
+#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_REACHED	1278
 /*! cache: number of times updates trigger was reached */
-#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_UPDATES_REACHED	1278
+#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_UPDATES_REACHED	1279
 /*! cache: number of times when cas update the btree max_lsn failed */
-#define	WT_STAT_CONN_CACHE_CAS_BTREE_MAX_LSN_RACE	1279
+#define	WT_STAT_CONN_CACHE_CAS_BTREE_MAX_LSN_RACE	1280
 /*! cache: obsolete updates removed */
-#define	WT_STAT_CONN_CACHE_OBSOLETE_UPDATES_REMOVED	1280
+#define	WT_STAT_CONN_CACHE_OBSOLETE_UPDATES_REMOVED	1281
 /*! cache: operations timed out waiting for space in cache */
-#define	WT_STAT_CONN_EVICTION_TIMED_OUT_OPS		1281
+#define	WT_STAT_CONN_EVICTION_TIMED_OUT_OPS		1282
 /*!
  * cache: overflow keys on a multiblock row-store page blocked its
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_OVERFLOW_KEYS	1282
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_OVERFLOW_KEYS	1283
 /*! cache: overflow pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ_OVERFLOW		1283
+#define	WT_STAT_CONN_CACHE_READ_OVERFLOW		1284
 /*! cache: page evict attempts by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_ATTEMPT		1284
+#define	WT_STAT_CONN_EVICTION_APP_ATTEMPT		1285
 /*! cache: page evict failures by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_FAIL			1285
+#define	WT_STAT_CONN_EVICTION_APP_FAIL			1286
 /*! cache: page eviction blocked due to materialization frontier */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_MATERIALIZATION	1286
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_MATERIALIZATION	1287
 /*!
  * cache: page eviction blocked in disaggregated storage as it can only
  * be written by the next checkpoint
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_DISAGG_NEXT_CHECKPOINT	1287
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_DISAGG_NEXT_CHECKPOINT	1288
 /*! cache: page split during eviction deepened the tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1288
+#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1289
 /*! cache: page written requiring history store records */
-#define	WT_STAT_CONN_CACHE_WRITE_HS			1289
+#define	WT_STAT_CONN_CACHE_WRITE_HS			1290
 /*! cache: pages already in queue when topping up */
-#define	WT_STAT_CONN_EVICTION_PAGES_REMAINING_IN_QUEUE	1290
+#define	WT_STAT_CONN_EVICTION_PAGES_REMAINING_IN_QUEUE	1291
 /*! cache: pages considered for eviction that were brought in by pre-fetch */
-#define	WT_STAT_CONN_EVICTION_CONSIDER_PREFETCH		1291
+#define	WT_STAT_CONN_EVICTION_CONSIDER_PREFETCH		1292
 /*! cache: pages currently held in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_INUSE			1292
+#define	WT_STAT_CONN_CACHE_PAGES_INUSE			1293
 /*! cache: pages currently held in the cache from the ingest btrees */
-#define	WT_STAT_CONN_CACHE_PAGES_INUSE_INGEST		1293
+#define	WT_STAT_CONN_CACHE_PAGES_INUSE_INGEST		1294
 /*! cache: pages currently held in the cache from the stable btrees */
-#define	WT_STAT_CONN_CACHE_PAGES_INUSE_STABLE		1294
+#define	WT_STAT_CONN_CACHE_PAGES_INUSE_STABLE		1295
 /*! cache: pages dirtied due to obsolete time window by eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY_OBSOLETE_TW	1295
+#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY_OBSOLETE_TW	1296
 /*! cache: pages evicted ahead of the page materialization frontier */
-#define	WT_STAT_CONN_CACHE_EVICTION_AHEAD_OF_LAST_MATERIALIZED_LSN	1296
+#define	WT_STAT_CONN_CACHE_EVICTION_AHEAD_OF_LAST_MATERIALIZED_LSN	1297
 /*! cache: pages evicted in parallel with checkpoint */
-#define	WT_STAT_CONN_EVICTION_PAGES_IN_PARALLEL_WITH_CHECKPOINT	1297
+#define	WT_STAT_CONN_EVICTION_PAGES_IN_PARALLEL_WITH_CHECKPOINT	1298
 /*! cache: pages queued for eviction */
-#define	WT_STAT_CONN_EVICTION_PAGES_ORDINARY_QUEUED	1298
+#define	WT_STAT_CONN_EVICTION_PAGES_ORDINARY_QUEUED	1299
 /*! cache: pages queued for eviction post lru sorting */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_POST_LRU	1299
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_POST_LRU	1300
 /*! cache: pages queued for urgent eviction */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT	1300
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT	1301
 /*! cache: pages queued for urgent eviction during walk */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_OLDEST	1301
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_OLDEST	1302
 /*!
  * cache: pages queued for urgent eviction from history store due to high
  * dirty content
  */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT_HS_DIRTY	1302
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT_HS_DIRTY	1303
 /*! cache: pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ				1303
+#define	WT_STAT_CONN_CACHE_READ				1304
 /*! cache: pages read into cache after truncate */
-#define	WT_STAT_CONN_CACHE_READ_DELETED			1304
+#define	WT_STAT_CONN_CACHE_READ_DELETED			1305
 /*! cache: pages read into cache after truncate in prepare state */
-#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1305
+#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1306
 /*! cache: pages read into cache by checkpoint */
-#define	WT_STAT_CONN_CACHE_READ_CHECKPOINT		1306
+#define	WT_STAT_CONN_CACHE_READ_CHECKPOINT		1307
 /*!
  * cache: pages removed from the ordinary queue to be queued for urgent
  * eviction
  */
-#define	WT_STAT_CONN_EVICTION_CLEAR_ORDINARY		1307
+#define	WT_STAT_CONN_EVICTION_CLEAR_ORDINARY		1308
 /*! cache: pages requested from the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1308
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1309
 /*! cache: pages requested from the cache due to pre-fetch */
-#define	WT_STAT_CONN_CACHE_PAGES_PREFETCH		1309
+#define	WT_STAT_CONN_CACHE_PAGES_PREFETCH		1310
 /*! cache: pages requested from the cache internal */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_INTERNAL	1310
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_INTERNAL	1311
 /*! cache: pages requested from the cache leaf */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_LEAF		1311
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_LEAF		1312
 /*! cache: pages requested from the history store */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_HS		1312
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_HS		1313
 /*! cache: pages seen by eviction walk */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1313
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1314
 /*! cache: pages seen by eviction walk that are already queued */
-#define	WT_STAT_CONN_EVICTION_PAGES_ALREADY_QUEUED	1314
+#define	WT_STAT_CONN_EVICTION_PAGES_ALREADY_QUEUED	1315
 /*! cache: pages selected for eviction unable to be evicted */
-#define	WT_STAT_CONN_EVICTION_FAIL			1315
+#define	WT_STAT_CONN_EVICTION_FAIL			1316
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * active children on an internal page
  */
-#define	WT_STAT_CONN_EVICTION_FAIL_ACTIVE_CHILDREN_ON_AN_INTERNAL_PAGE	1316
+#define	WT_STAT_CONN_EVICTION_FAIL_ACTIVE_CHILDREN_ON_AN_INTERNAL_PAGE	1317
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * failure in reconciliation
  */
-#define	WT_STAT_CONN_EVICTION_FAIL_IN_RECONCILIATION	1317
+#define	WT_STAT_CONN_EVICTION_FAIL_IN_RECONCILIATION	1318
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * race between checkpoint and updates without timestamps
  */
-#define	WT_STAT_CONN_EVICTION_FAIL_CHECKPOINT_NO_TS	1318
+#define	WT_STAT_CONN_EVICTION_FAIL_CHECKPOINT_NO_TS	1319
 /*! cache: pages walked for eviction */
-#define	WT_STAT_CONN_EVICTION_WALK			1319
+#define	WT_STAT_CONN_EVICTION_WALK			1320
 /*! cache: pages written from cache */
-#define	WT_STAT_CONN_CACHE_WRITE			1320
+#define	WT_STAT_CONN_CACHE_WRITE			1321
 /*!
  * cache: pages written requiring in-memory restoration due to invisible
  * updates
  */
-#define	WT_STAT_CONN_CACHE_WRITE_RESTORE_INVISIBLE	1321
+#define	WT_STAT_CONN_CACHE_WRITE_RESTORE_INVISIBLE	1322
 /*!
  * cache: pages written requiring in-memory restoration due to scrub
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_WRITE_RESTORE_SCRUB		1322
+#define	WT_STAT_CONN_CACHE_WRITE_RESTORE_SCRUB		1323
 /*! cache: percentage overhead */
-#define	WT_STAT_CONN_CACHE_OVERHEAD			1323
+#define	WT_STAT_CONN_CACHE_OVERHEAD			1324
 /*!
  * cache: precise checkpoint caused an eviction to be skipped because any
  * dirty content needs to remain in cache
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_PRECISE_CHECKPOINT	1324
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_PRECISE_CHECKPOINT	1325
 /*!
  * cache: realizing in-memory split after reconciliation failed due to
  * internal lock busy
  */
-#define	WT_STAT_CONN_CACHE_EVICT_SPLIT_FAILED_LOCK	1325
+#define	WT_STAT_CONN_CACHE_EVICT_SPLIT_FAILED_LOCK	1326
 /*! cache: recent modification of a page blocked its eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	1326
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	1327
 /*! cache: reconciled pages scrubbed and added back to the cache clean */
-#define	WT_STAT_CONN_CACHE_SCRUB_RESTORE		1327
+#define	WT_STAT_CONN_CACHE_SCRUB_RESTORE		1328
 /*! cache: reverse splits performed */
-#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS		1328
+#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS		1329
 /*!
  * cache: reverse splits skipped because of VLCS namespace gap
  * restrictions
  */
-#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	1329
+#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	1330
 /*! cache: shared history store cursor not cached during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_HS_SHARED_CURSOR_NOT_CACHED	1330
+#define	WT_STAT_CONN_CACHE_EVICTION_HS_SHARED_CURSOR_NOT_CACHED	1331
 /*! cache: size of delta updates reconstructed on the base page */
-#define	WT_STAT_CONN_CACHE_READ_DELTA_UPDATES		1331
+#define	WT_STAT_CONN_CACHE_READ_DELTA_UPDATES		1332
 /*! cache: size of tombstones restored when reading a page */
-#define	WT_STAT_CONN_CACHE_READ_RESTORED_TOMBSTONE_BYTES	1332
+#define	WT_STAT_CONN_CACHE_READ_RESTORED_TOMBSTONE_BYTES	1333
 /*! cache: the number of times full update inserted to history store */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1333
+#define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1334
 /*! cache: the number of times reverse modify inserted to history store */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1334
+#define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1335
 /*! cache: time eviction worker threads spend waiting for locks (usecs) */
-#define	WT_STAT_CONN_EVICTION_WORKER_LOCK_WAIT_TIME	1335
+#define	WT_STAT_CONN_EVICTION_WORKER_LOCK_WAIT_TIME	1336
 /*!
  * cache: total milliseconds spent inside reentrant history store
  * evictions in a reconciliation
  */
-#define	WT_STAT_CONN_EVICTION_REENTRY_HS_EVICTION_MILLISECONDS	1336
+#define	WT_STAT_CONN_EVICTION_REENTRY_HS_EVICTION_MILLISECONDS	1337
 /*! cache: tracked bytes belonging to internal pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1337
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1338
 /*!
  * cache: tracked bytes belonging to internal pages in the cache from the
  * ingest btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL_INGEST	1338
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL_INGEST	1339
 /*!
  * cache: tracked bytes belonging to internal pages in the cache from the
  * stable btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL_STABLE	1339
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL_STABLE	1340
 /*! cache: tracked bytes belonging to leaf pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1340
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1341
 /*!
  * cache: tracked bytes belonging to leaf pages in the cache from the
  * ingest btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF_INGEST		1341
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF_INGEST		1342
 /*!
  * cache: tracked bytes belonging to leaf pages in the cache from the
  * stable btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF_STABLE		1342
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF_STABLE		1343
 /*! cache: tracked dirty bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1343
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1344
 /*! cache: tracked dirty bytes in the cache from the ingest btrees */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INGEST		1344
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INGEST		1345
 /*! cache: tracked dirty bytes in the cache from the stable btrees */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_STABLE		1345
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_STABLE		1346
 /*! cache: tracked dirty internal page bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL		1346
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL		1347
 /*!
  * cache: tracked dirty internal page bytes in the cache from the ingest
  * btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL_INGEST	1347
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL_INGEST	1348
 /*!
  * cache: tracked dirty internal page bytes in the cache from the stable
  * btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL_STABLE	1348
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL_STABLE	1349
 /*! cache: tracked dirty leaf page bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF		1349
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF		1350
 /*!
  * cache: tracked dirty leaf page bytes in the cache from the ingest
  * btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF_INGEST	1350
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF_INGEST	1351
 /*!
  * cache: tracked dirty leaf page bytes in the cache from the stable
  * btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF_STABLE	1351
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF_STABLE	1352
 /*! cache: tracked dirty pages in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1352
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1353
 /*! cache: tracked dirty pages in the cache from the ingest btrees */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY_INGEST		1353
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY_INGEST		1354
 /*! cache: tracked dirty pages in the cache from the stable btrees */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY_STABLE		1354
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY_STABLE		1355
 /*! cache: uncommitted truncate blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	1355
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	1356
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1356
+#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1357
 /*! cache: update bytes belonging to the history store table in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_HS_UPDATES		1357
+#define	WT_STAT_CONN_CACHE_BYTES_HS_UPDATES		1358
 /*! cache: updates in uncommitted txn - bytes */
-#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_BYTES	1358
+#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_BYTES	1359
 /*! cache: updates in uncommitted txn - count */
-#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_COUNT	1359
+#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_COUNT	1360
 /*! capacity: background fsync file handles considered */
-#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1360
+#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1361
 /*! capacity: background fsync file handles synced */
-#define	WT_STAT_CONN_FSYNC_ALL_FH			1361
+#define	WT_STAT_CONN_FSYNC_ALL_FH			1362
 /*! capacity: background fsync time (msecs) */
-#define	WT_STAT_CONN_FSYNC_ALL_TIME			1362
+#define	WT_STAT_CONN_FSYNC_ALL_TIME			1363
 /*! capacity: bytes read */
-#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1363
+#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1364
 /*! capacity: bytes written for checkpoint */
-#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1364
+#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1365
 /*! capacity: bytes written for chunk cache */
-#define	WT_STAT_CONN_CAPACITY_BYTES_CHUNKCACHE		1365
+#define	WT_STAT_CONN_CAPACITY_BYTES_CHUNKCACHE		1366
 /*! capacity: bytes written for eviction */
-#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1366
+#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1367
 /*! capacity: bytes written for log */
-#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1367
+#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1368
 /*! capacity: bytes written total */
-#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1368
+#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1369
 /*! capacity: threshold to call fsync */
-#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1369
+#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1370
 /*! capacity: time waiting due to total capacity (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1370
+#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1371
 /*! capacity: time waiting during checkpoint (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1371
+#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1372
 /*! capacity: time waiting during eviction (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1372
+#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1373
 /*! capacity: time waiting during logging (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1373
+#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1374
 /*! capacity: time waiting during read (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_READ			1374
+#define	WT_STAT_CONN_CAPACITY_TIME_READ			1375
 /*! capacity: time waiting for chunk cache IO bandwidth (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_CHUNKCACHE		1375
+#define	WT_STAT_CONN_CAPACITY_TIME_CHUNKCACHE		1376
 /*! checkpoint-cleanup: most recent duration on all eligible files (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_DURATION	1376
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_DURATION	1377
 /*! checkpoint-cleanup: most recent handles processed */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_HANDLE_PROCESSED	1377
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_HANDLE_PROCESSED	1378
 /*! checkpoint-cleanup: most recent in-memory pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_INMEM_PAGES_VISITED	1378
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_INMEM_PAGES_VISITED	1379
 /*! checkpoint-cleanup: pages added for eviction */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_EVICT	1379
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_EVICT	1380
 /*! checkpoint-cleanup: pages dirtied due to obsolete time window */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	1380
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	1381
 /*! checkpoint-cleanup: pages read into cache (reclaim_space) */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	1381
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	1382
 /*! checkpoint-cleanup: pages read into cache due to obsolete time window */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	1382
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	1383
 /*! checkpoint-cleanup: pages removed */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_REMOVED	1383
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_REMOVED	1384
 /*! checkpoint-cleanup: pages skipped during tree walk */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	1384
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	1385
 /*! checkpoint-cleanup: pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_VISITED	1385
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_VISITED	1386
 /*! checkpoint-cleanup: successful calls */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_SUCCESS		1386
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_SUCCESS		1387
 /*! checkpoint: checkpoint has acquired a snapshot for its transaction */
-#define	WT_STAT_CONN_CHECKPOINT_SNAPSHOT_ACQUIRED	1387
+#define	WT_STAT_CONN_CHECKPOINT_SNAPSHOT_ACQUIRED	1388
 /*! checkpoint: checkpoints skipped because database was clean */
-#define	WT_STAT_CONN_CHECKPOINT_SKIPPED			1388
+#define	WT_STAT_CONN_CHECKPOINT_SKIPPED			1389
 /*! checkpoint: fsync calls after allocating the transaction ID */
-#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST		1389
+#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST		1390
 /*! checkpoint: fsync duration after allocating the transaction ID (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST_DURATION	1390
+#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST_DURATION	1391
 /*! checkpoint: generation */
-#define	WT_STAT_CONN_CHECKPOINT_GENERATION		1391
+#define	WT_STAT_CONN_CHECKPOINT_GENERATION		1392
 /*! checkpoint: max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_MAX		1392
+#define	WT_STAT_CONN_CHECKPOINT_TIME_MAX		1393
 /*! checkpoint: min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_MIN		1393
+#define	WT_STAT_CONN_CHECKPOINT_TIME_MIN		1394
 /*!
  * checkpoint: most recent duration for checkpoint dropping all handles
  * (usecs)
  */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROP_DURATION	1394
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROP_DURATION	1395
 /*! checkpoint: most recent duration for gathering all handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION		1395
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION		1396
 /*! checkpoint: most recent duration for gathering applied handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLY_DURATION	1396
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLY_DURATION	1397
 /*! checkpoint: most recent duration for gathering skipped handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIP_DURATION	1397
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIP_DURATION	1398
 /*! checkpoint: most recent duration for handles metadata checked (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECK_DURATION	1398
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECK_DURATION	1399
 /*! checkpoint: most recent duration for locking the handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCK_DURATION	1399
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCK_DURATION	1400
 /*! checkpoint: most recent handles applied */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLIED		1400
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLIED		1401
 /*! checkpoint: most recent handles checkpoint dropped */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROPPED		1401
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROPPED		1402
 /*! checkpoint: most recent handles metadata checked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECKED	1402
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECKED	1403
 /*! checkpoint: most recent handles metadata locked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCKED		1403
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCKED		1404
 /*! checkpoint: most recent handles skipped */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIPPED		1404
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIPPED		1405
 /*! checkpoint: most recent handles walked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_WALKED		1405
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_WALKED		1406
 /*! checkpoint: most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_RECENT		1406
+#define	WT_STAT_CONN_CHECKPOINT_TIME_RECENT		1407
 /*! checkpoint: number of bytes caused to be reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED_BYTES	1407
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED_BYTES	1408
 /*! checkpoint: number of checkpoints started by api */
-#define	WT_STAT_CONN_CHECKPOINTS_API			1408
+#define	WT_STAT_CONN_CHECKPOINTS_API			1409
 /*! checkpoint: number of checkpoints started by compaction */
-#define	WT_STAT_CONN_CHECKPOINTS_COMPACT		1409
+#define	WT_STAT_CONN_CHECKPOINTS_COMPACT		1410
 /*! checkpoint: number of files synced */
-#define	WT_STAT_CONN_CHECKPOINT_SYNC			1410
+#define	WT_STAT_CONN_CHECKPOINT_SYNC			1411
 /*! checkpoint: number of handles visited after writes complete */
-#define	WT_STAT_CONN_CHECKPOINT_PRESYNC			1411
+#define	WT_STAT_CONN_CHECKPOINT_PRESYNC			1412
 /*! checkpoint: number of history store pages caused to be reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_HS_PAGES_RECONCILED	1412
+#define	WT_STAT_CONN_CHECKPOINT_HS_PAGES_RECONCILED	1413
 /*! checkpoint: number of internal pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_INTERNAL	1413
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_INTERNAL	1414
 /*! checkpoint: number of leaf pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_LEAF	1414
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_LEAF	1415
 /*! checkpoint: number of pages caused to be reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED	1415
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED	1416
 /*! checkpoint: prepare currently running */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1416
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1417
 /*! checkpoint: prepare max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1417
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1418
 /*! checkpoint: prepare min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1418
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1419
 /*! checkpoint: prepare most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1419
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1420
 /*! checkpoint: prepare total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1420
+#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1421
 /*! checkpoint: progress state */
-#define	WT_STAT_CONN_CHECKPOINT_STATE			1421
+#define	WT_STAT_CONN_CHECKPOINT_STATE			1422
 /*! checkpoint: scrub dirty target */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1422
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1423
 /*! checkpoint: scrub max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1423
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1424
 /*! checkpoint: scrub min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1424
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1425
 /*! checkpoint: scrub most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1425
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1426
 /*! checkpoint: scrub total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1426
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1427
 /*! checkpoint: stop timing stress active */
-#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1427
+#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1428
 /*! checkpoint: time spent on per-tree checkpoint work (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1428
+#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1429
 /*! checkpoint: total failed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1429
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1430
 /*! checkpoint: total succeed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1430
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1431
 /*! checkpoint: total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1431
+#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1432
 /*!
  * checkpoint: total time (msecs) writing pages to stable storage during
  * checkpoint reconciliation
  */
-#define	WT_STAT_CONN_CHECKPOINT_REC_BLKCACHE_WRITE	1432
+#define	WT_STAT_CONN_CHECKPOINT_REC_BLKCACHE_WRITE	1433
 /*! checkpoint: wait cycles while cache dirty level is decreasing */
-#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1433
+#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1434
 /*! chunk-cache: aggregate number of spanned chunks on read */
-#define	WT_STAT_CONN_CHUNKCACHE_SPANS_CHUNKS_READ	1434
+#define	WT_STAT_CONN_CHUNKCACHE_SPANS_CHUNKS_READ	1435
 /*! chunk-cache: chunks evicted */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_EVICTED		1435
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_EVICTED		1436
 /*! chunk-cache: could not allocate due to exceeding bitmap capacity */
-#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_BITMAP_CAPACITY	1436
+#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_BITMAP_CAPACITY	1437
 /*! chunk-cache: could not allocate due to exceeding capacity */
-#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_CAPACITY	1437
+#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_CAPACITY	1438
 /*! chunk-cache: lookups */
-#define	WT_STAT_CONN_CHUNKCACHE_LOOKUPS			1438
+#define	WT_STAT_CONN_CHUNKCACHE_LOOKUPS			1439
 /*!
  * chunk-cache: number of chunks loaded from flushed tables in chunk
  * cache
  */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_LOADED_FROM_FLUSHED_TABLES	1439
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_LOADED_FROM_FLUSHED_TABLES	1440
 /*! chunk-cache: number of metadata entries inserted */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_INSERTED	1440
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_INSERTED	1441
 /*! chunk-cache: number of metadata entries removed */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_REMOVED	1441
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_REMOVED	1442
 /*!
  * chunk-cache: number of metadata inserts/deletes dropped by the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DROPPED	1442
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DROPPED	1443
 /*!
  * chunk-cache: number of metadata inserts/deletes pushed to the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_CREATED	1443
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_CREATED	1444
 /*!
  * chunk-cache: number of metadata inserts/deletes read by the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DEQUEUED	1444
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DEQUEUED	1445
 /*! chunk-cache: number of misses */
-#define	WT_STAT_CONN_CHUNKCACHE_MISSES			1445
+#define	WT_STAT_CONN_CHUNKCACHE_MISSES			1446
 /*! chunk-cache: number of times a read from storage failed */
-#define	WT_STAT_CONN_CHUNKCACHE_IO_FAILED		1446
+#define	WT_STAT_CONN_CHUNKCACHE_IO_FAILED		1447
 /*! chunk-cache: retried accessing a chunk while I/O was in progress */
-#define	WT_STAT_CONN_CHUNKCACHE_RETRIES			1447
+#define	WT_STAT_CONN_CHUNKCACHE_RETRIES			1448
 /*! chunk-cache: retries from a chunk cache checksum mismatch */
-#define	WT_STAT_CONN_CHUNKCACHE_RETRIES_CHECKSUM_MISMATCH	1448
+#define	WT_STAT_CONN_CHUNKCACHE_RETRIES_CHECKSUM_MISMATCH	1449
 /*! chunk-cache: timed out due to too many retries */
-#define	WT_STAT_CONN_CHUNKCACHE_TOOMANY_RETRIES		1449
+#define	WT_STAT_CONN_CHUNKCACHE_TOOMANY_RETRIES		1450
 /*! chunk-cache: total bytes read from persistent content */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_READ_PERSISTENT	1450
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_READ_PERSISTENT	1451
 /*! chunk-cache: total bytes used by the cache */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE		1451
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE		1452
 /*! chunk-cache: total bytes used by the cache for pinned chunks */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE_PINNED	1452
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE_PINNED	1453
 /*! chunk-cache: total chunks held by the chunk cache */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_INUSE		1453
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_INUSE		1454
 /*!
  * chunk-cache: total number of chunks inserted on startup from persisted
  * metadata
  */
-#define	WT_STAT_CONN_CHUNKCACHE_CREATED_FROM_METADATA	1454
+#define	WT_STAT_CONN_CHUNKCACHE_CREATED_FROM_METADATA	1455
 /*! chunk-cache: total pinned chunks held by the chunk cache */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_PINNED		1455
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_PINNED		1456
 /*! connection: auto adjusting condition resets */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1456
+#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1457
 /*! connection: auto adjusting condition wait calls */
-#define	WT_STAT_CONN_COND_AUTO_WAIT			1457
+#define	WT_STAT_CONN_COND_AUTO_WAIT			1458
 /*!
  * connection: auto adjusting condition wait raced to update timeout and
  * skipped updating
  */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1458
+#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1459
 /*! connection: btrees currently open */
-#define	WT_STAT_CONN_BTREE_OPEN				1459
+#define	WT_STAT_CONN_BTREE_OPEN				1460
 /*! connection: detected system time went backwards */
-#define	WT_STAT_CONN_TIME_TRAVEL			1460
+#define	WT_STAT_CONN_TIME_TRAVEL			1461
 /*! connection: files currently open */
-#define	WT_STAT_CONN_FILE_OPEN				1461
+#define	WT_STAT_CONN_FILE_OPEN				1462
 /*! connection: hash bucket array size for data handles */
-#define	WT_STAT_CONN_BUCKETS_DH				1462
+#define	WT_STAT_CONN_BUCKETS_DH				1463
 /*! connection: hash bucket array size general */
-#define	WT_STAT_CONN_BUCKETS				1463
+#define	WT_STAT_CONN_BUCKETS				1464
 /*! connection: memory allocations */
-#define	WT_STAT_CONN_MEMORY_ALLOCATION			1464
+#define	WT_STAT_CONN_MEMORY_ALLOCATION			1465
 /*! connection: memory frees */
-#define	WT_STAT_CONN_MEMORY_FREE			1465
+#define	WT_STAT_CONN_MEMORY_FREE			1466
 /*! connection: memory re-allocations */
-#define	WT_STAT_CONN_MEMORY_GROW			1466
+#define	WT_STAT_CONN_MEMORY_GROW			1467
 /*! connection: number of sessions without a sweep for 5+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1467
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1468
 /*! connection: number of sessions without a sweep for 60+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1468
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1469
 /*! connection: pthread mutex condition wait calls */
-#define	WT_STAT_CONN_COND_WAIT				1469
+#define	WT_STAT_CONN_COND_WAIT				1470
 /*! connection: pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			1470
+#define	WT_STAT_CONN_RWLOCK_READ			1471
 /*! connection: pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			1471
+#define	WT_STAT_CONN_RWLOCK_WRITE			1472
 /*! connection: total fsync I/Os */
-#define	WT_STAT_CONN_FSYNC_IO				1472
+#define	WT_STAT_CONN_FSYNC_IO				1473
 /*! connection: total read I/Os */
-#define	WT_STAT_CONN_READ_IO				1473
+#define	WT_STAT_CONN_READ_IO				1474
 /*! connection: total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				1474
+#define	WT_STAT_CONN_WRITE_IO				1475
 /*! cursor: Total number of deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1475
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1476
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1476
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1477
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1477
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1478
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1478
+#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1479
 /*!
  * cursor: Total number of in-memory deleted pages skipped during tree
  * walk
  */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1479
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1480
 /*! cursor: Total number of on-disk deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1480
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1481
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1481
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1482
 /*!
  * cursor: Total number of times cursor fails to temporarily release
  * pinned page to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1482
+#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1483
 /*!
  * cursor: Total number of times cursor temporarily releases pinned page
  * to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION			1483
+#define	WT_STAT_CONN_CURSOR_REPOSITION			1484
 /*! cursor: bulk cursor count */
-#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1484
+#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1485
 /*! cursor: cached cursor count */
-#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1485
+#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1486
 /*! cursor: cursor bound calls that return an error */
-#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1486
+#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1487
 /*! cursor: cursor bounds cleared from reset */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1487
+#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1488
 /*! cursor: cursor bounds comparisons performed */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1488
+#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1489
 /*! cursor: cursor bounds next called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1489
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1490
 /*! cursor: cursor bounds next early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1490
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1491
 /*! cursor: cursor bounds prev called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1491
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1492
 /*! cursor: cursor bounds prev early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1492
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1493
 /*! cursor: cursor bounds search early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1493
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1494
 /*! cursor: cursor bounds search near call repositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1494
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1495
 /*! cursor: cursor bulk loaded cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1495
+#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1496
 /*! cursor: cursor cache calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1496
+#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1497
 /*! cursor: cursor close calls that result in cache */
-#define	WT_STAT_CONN_CURSOR_CACHE			1497
+#define	WT_STAT_CONN_CURSOR_CACHE			1498
 /*! cursor: cursor close calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1498
+#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1499
 /*! cursor: cursor compare calls that return an error */
-#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1499
+#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1500
 /*! cursor: cursor create calls */
-#define	WT_STAT_CONN_CURSOR_CREATE			1500
+#define	WT_STAT_CONN_CURSOR_CREATE			1501
 /*! cursor: cursor equals calls that return an error */
-#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1501
+#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1502
 /*! cursor: cursor get key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1502
+#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1503
 /*! cursor: cursor get value calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1503
+#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1504
 /*! cursor: cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT			1504
+#define	WT_STAT_CONN_CURSOR_INSERT			1505
 /*! cursor: cursor insert calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1505
+#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1506
 /*! cursor: cursor insert check calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1506
+#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1507
 /*! cursor: cursor insert key and value bytes */
-#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1507
+#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1508
 /*! cursor: cursor largest key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1508
+#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1509
 /*! cursor: cursor modify calls */
-#define	WT_STAT_CONN_CURSOR_MODIFY			1509
+#define	WT_STAT_CONN_CURSOR_MODIFY			1510
 /*! cursor: cursor modify calls that return an error */
-#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1510
+#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1511
 /*! cursor: cursor modify key and value bytes affected */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1511
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1512
 /*! cursor: cursor modify value bytes modified */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1512
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1513
 /*! cursor: cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT			1513
+#define	WT_STAT_CONN_CURSOR_NEXT			1514
 /*! cursor: cursor next calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1514
+#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1515
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1515
+#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1516
 /*!
  * cursor: cursor next calls that skip greater than 1 and fewer than 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1516
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1517
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1517
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1518
 /*! cursor: cursor next random calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1518
+#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1519
 /*! cursor: cursor operation restarted */
-#define	WT_STAT_CONN_CURSOR_RESTART			1519
+#define	WT_STAT_CONN_CURSOR_RESTART			1520
 /*! cursor: cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV			1520
+#define	WT_STAT_CONN_CURSOR_PREV			1521
 /*! cursor: cursor prev calls that return an error */
-#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1521
+#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1522
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1522
+#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1523
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1523
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1524
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1524
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1525
 /*! cursor: cursor reconfigure calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1525
+#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1526
 /*! cursor: cursor remove calls */
-#define	WT_STAT_CONN_CURSOR_REMOVE			1526
+#define	WT_STAT_CONN_CURSOR_REMOVE			1527
 /*! cursor: cursor remove calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1527
+#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1528
 /*! cursor: cursor remove key bytes removed */
-#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1528
+#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1529
 /*! cursor: cursor reopen calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1529
+#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1530
 /*! cursor: cursor reserve calls */
-#define	WT_STAT_CONN_CURSOR_RESERVE			1530
+#define	WT_STAT_CONN_CURSOR_RESERVE			1531
 /*! cursor: cursor reserve calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1531
+#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1532
 /*! cursor: cursor reset calls */
-#define	WT_STAT_CONN_CURSOR_RESET			1532
+#define	WT_STAT_CONN_CURSOR_RESET			1533
 /*! cursor: cursor reset calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1533
+#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1534
 /*! cursor: cursor search calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH			1534
+#define	WT_STAT_CONN_CURSOR_SEARCH			1535
 /*! cursor: cursor search calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1535
+#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1536
 /*! cursor: cursor search history store calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1536
+#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1537
 /*! cursor: cursor search near calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1537
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1538
 /*! cursor: cursor search near calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1538
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1539
 /*! cursor: cursor sweep buckets */
-#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1539
+#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1540
 /*! cursor: cursor sweep cursors closed */
-#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1540
+#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1541
 /*! cursor: cursor sweep cursors examined */
-#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1541
+#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1542
 /*! cursor: cursor sweeps */
-#define	WT_STAT_CONN_CURSOR_SWEEP			1542
+#define	WT_STAT_CONN_CURSOR_SWEEP			1543
 /*! cursor: cursor truncate calls */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE			1543
+#define	WT_STAT_CONN_CURSOR_TRUNCATE			1544
 /*! cursor: cursor truncates performed on individual keys */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1544
+#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1545
 /*! cursor: cursor update calls */
-#define	WT_STAT_CONN_CURSOR_UPDATE			1545
+#define	WT_STAT_CONN_CURSOR_UPDATE			1546
 /*! cursor: cursor update calls that return an error */
-#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1546
+#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1547
 /*! cursor: cursor update key and value bytes */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1547
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1548
 /*! cursor: cursor update value size change */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1548
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1549
 /*! cursor: cursors reused from cache */
-#define	WT_STAT_CONN_CURSOR_REOPEN			1549
+#define	WT_STAT_CONN_CURSOR_REOPEN			1550
 /*! cursor: open cursor count */
-#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1550
+#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1551
 /*! cursor: open cursor time application (usecs) */
-#define	WT_STAT_CONN_CURSOR_OPEN_TIME_USER_USECS	1551
+#define	WT_STAT_CONN_CURSOR_OPEN_TIME_USER_USECS	1552
 /*! cursor: open cursor time internal (usecs) */
-#define	WT_STAT_CONN_CURSOR_OPEN_TIME_INTERNAL_USECS	1552
+#define	WT_STAT_CONN_CURSOR_OPEN_TIME_INTERNAL_USECS	1553
 /*! data-handle: Layered connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_LAYERED_COUNT	1553
+#define	WT_STAT_CONN_DH_CONN_HANDLE_LAYERED_COUNT	1554
 /*! data-handle: Table connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TABLE_COUNT		1554
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TABLE_COUNT		1555
 /*! data-handle: Tiered connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_COUNT	1555
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_COUNT	1556
 /*! data-handle: Tiered_Tree connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_TREE_COUNT	1556
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_TREE_COUNT	1557
 /*! data-handle: btree connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_BTREE_COUNT		1557
+#define	WT_STAT_CONN_DH_CONN_HANDLE_BTREE_COUNT		1558
 /*! data-handle: checkpoint connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_CHECKPOINT_COUNT	1558
+#define	WT_STAT_CONN_DH_CONN_HANDLE_CHECKPOINT_COUNT	1559
 /*! data-handle: connection data handle size */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1559
+#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1560
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1560
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1561
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1561
+#define	WT_STAT_CONN_DH_SWEEP_REF			1562
 /*! data-handle: connection sweep dead dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_DEAD_CLOSE		1562
+#define	WT_STAT_CONN_DH_SWEEP_DEAD_CLOSE		1563
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1563
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1564
 /*! data-handle: connection sweep expired dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_EXPIRED_CLOSE		1564
+#define	WT_STAT_CONN_DH_SWEEP_EXPIRED_CLOSE		1565
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1565
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1566
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1566
+#define	WT_STAT_CONN_DH_SWEEPS				1567
 /*!
  * data-handle: connection sweeps skipped due to checkpoint gathering
  * handles
  */
-#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1567
+#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1568
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1568
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1569
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1569
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1570
 /*! disagg: database size */
-#define	WT_STAT_CONN_DISAGG_DATABASE_SIZE		1570
+#define	WT_STAT_CONN_DISAGG_DATABASE_SIZE		1571
 /*! disagg: role leader */
-#define	WT_STAT_CONN_DISAGG_ROLE_LEADER			1571
+#define	WT_STAT_CONN_DISAGG_ROLE_LEADER			1572
 /*! disagg: step down most recent time (msecs) */
-#define	WT_STAT_CONN_DISAGG_STEP_DOWN_TIME		1572
+#define	WT_STAT_CONN_DISAGG_STEP_DOWN_TIME		1573
 /*! disagg: step up most recent time (msecs) */
-#define	WT_STAT_CONN_DISAGG_STEP_UP_TIME		1573
+#define	WT_STAT_CONN_DISAGG_STEP_UP_TIME		1574
 /*!
  * layered: Layered table cursor advances to a newer checkpoint for the
  * stable btree
  */
-#define	WT_STAT_CONN_LAYERED_CURS_ADVANCE_STABLE	1574
+#define	WT_STAT_CONN_LAYERED_CURS_ADVANCE_STABLE	1575
 /*! layered: Layered table cursor insert operations */
-#define	WT_STAT_CONN_LAYERED_CURS_INSERT		1575
+#define	WT_STAT_CONN_LAYERED_CURS_INSERT		1576
 /*! layered: Layered table cursor modify operations */
-#define	WT_STAT_CONN_LAYERED_CURS_MODIFY		1576
+#define	WT_STAT_CONN_LAYERED_CURS_MODIFY		1577
 /*! layered: Layered table cursor next operations */
-#define	WT_STAT_CONN_LAYERED_CURS_NEXT			1577
+#define	WT_STAT_CONN_LAYERED_CURS_NEXT			1578
 /*! layered: Layered table cursor next operations from the ingest btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_NEXT_INGEST		1578
+#define	WT_STAT_CONN_LAYERED_CURS_NEXT_INGEST		1579
 /*! layered: Layered table cursor next operations from the stable btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_NEXT_STABLE		1579
+#define	WT_STAT_CONN_LAYERED_CURS_NEXT_STABLE		1580
 /*! layered: Layered table cursor prev operations */
-#define	WT_STAT_CONN_LAYERED_CURS_PREV			1580
+#define	WT_STAT_CONN_LAYERED_CURS_PREV			1581
 /*! layered: Layered table cursor prev operations from the ingest btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_PREV_INGEST		1581
+#define	WT_STAT_CONN_LAYERED_CURS_PREV_INGEST		1582
 /*! layered: Layered table cursor prev operations from the stable btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_PREV_STABLE		1582
+#define	WT_STAT_CONN_LAYERED_CURS_PREV_STABLE		1583
 /*! layered: Layered table cursor remove operations */
-#define	WT_STAT_CONN_LAYERED_CURS_REMOVE		1583
+#define	WT_STAT_CONN_LAYERED_CURS_REMOVE		1584
 /*! layered: Layered table cursor reopens ingest btree */
-#define	WT_STAT_CONN_LAYERED_CURS_REOPEN_INGEST		1584
+#define	WT_STAT_CONN_LAYERED_CURS_REOPEN_INGEST		1585
 /*! layered: Layered table cursor search near operations */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR		1585
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR		1586
 /*!
  * layered: Layered table cursor search near operations from the ingest
  * btrees
  */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_INGEST	1586
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_INGEST	1587
 /*!
  * layered: Layered table cursor search near operations from the stable
  * btrees
  */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_STABLE	1587
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_STABLE	1588
 /*! layered: Layered table cursor search operations */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH		1588
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH		1589
 /*! layered: Layered table cursor search operations from the ingest btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_INGEST		1589
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_INGEST		1590
 /*! layered: Layered table cursor search operations from the stable btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_STABLE		1590
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_STABLE		1591
 /*! layered: Layered table cursor update operations */
-#define	WT_STAT_CONN_LAYERED_CURS_UPDATE		1591
+#define	WT_STAT_CONN_LAYERED_CURS_UPDATE		1592
 /*!
  * layered: checkpoints performed on this table by the layered table
  * manager
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS	1592
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS	1593
 /*! layered: disagg pick up checkpoints failed */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FAILED	1593
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FAILED	1594
 /*! layered: disagg pick up checkpoints succeeded */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_SUCCEED	1594
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_SUCCEED	1595
 /*!
  * layered: how many log applications the layered table manager applied
  * on this tree
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_APPLIED	1595
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_APPLIED	1596
 /*!
  * layered: how many log applications the layered table manager skipped
  * on this tree
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_SKIPPED	1596
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_SKIPPED	1597
 /*!
  * layered: how many previously-applied LSNs the layered table manager
  * skipped on this tree
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_SKIP_LSN	1597
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_SKIP_LSN	1598
 /*! layered: number of checkpoints picked up by a follower */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FOLLOWER	1598
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FOLLOWER	1599
 /*! layered: the number of tables the layered table manager has open */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_TABLES	1599
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_TABLES	1600
 /*!
  * live-restore: number of bytes copied from the source to the
  * destination
  */
-#define	WT_STAT_CONN_LIVE_RESTORE_BYTES_COPIED		1600
+#define	WT_STAT_CONN_LIVE_RESTORE_BYTES_COPIED		1601
 /*! live-restore: number of files remaining for migration completion */
-#define	WT_STAT_CONN_LIVE_RESTORE_WORK_REMAINING	1601
+#define	WT_STAT_CONN_LIVE_RESTORE_WORK_REMAINING	1602
 /*! live-restore: number of reads from the source database */
-#define	WT_STAT_CONN_LIVE_RESTORE_SOURCE_READ_COUNT	1602
+#define	WT_STAT_CONN_LIVE_RESTORE_SOURCE_READ_COUNT	1603
 /*! live-restore: source read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT2	1603
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT2	1604
 /*! live-restore: source read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT5	1604
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT5	1605
 /*! live-restore: source read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT10	1605
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT10	1606
 /*! live-restore: source read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT50	1606
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT50	1607
 /*! live-restore: source read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT100	1607
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT100	1608
 /*! live-restore: source read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT250	1608
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT250	1609
 /*! live-restore: source read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT500	1609
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT500	1610
 /*! live-restore: source read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT1000	1610
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT1000	1611
 /*! live-restore: source read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_GT1000	1611
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_GT1000	1612
 /*! live-restore: source read latency histogram total (msecs) */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_TOTAL_MSECS	1612
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_TOTAL_MSECS	1613
 /*! live-restore: state */
-#define	WT_STAT_CONN_LIVE_RESTORE_STATE			1613
+#define	WT_STAT_CONN_LIVE_RESTORE_STATE			1614
 /*! lock: btree page lock acquisitions */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_COUNT		1614
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_COUNT		1615
 /*! lock: btree page lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_APPLICATION	1615
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_APPLICATION	1616
 /*! lock: btree page lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_INTERNAL	1616
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_INTERNAL	1617
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1617
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1618
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1618
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1619
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1619
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1620
 /*! lock: dhandle lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1620
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1621
 /*! lock: dhandle lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1621
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1622
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1622
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1623
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1623
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1624
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1624
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1625
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1625
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1626
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1626
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1627
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1627
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1628
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1628
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1629
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1629
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1630
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1630
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1631
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1631
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1632
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1632
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1633
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1633
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1634
 /*! lock: txn global lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1634
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1635
 /*! lock: txn global lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1635
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1636
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1636
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1637
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1637
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1638
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1638
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1639
 /*! log: force log remove time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1639
+#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1640
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1640
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1641
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1641
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1642
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1642
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1643
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1643
+#define	WT_STAT_CONN_LOG_FLUSH				1644
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1644
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1645
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1645
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1646
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1646
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1647
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1647
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1648
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1648
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1649
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1649
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1650
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1650
+#define	WT_STAT_CONN_LOG_SCANS				1651
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1651
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1652
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1652
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1653
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1653
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1654
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1654
+#define	WT_STAT_CONN_LOG_SYNC				1655
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1655
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1656
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1656
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1657
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1657
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1658
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1658
+#define	WT_STAT_CONN_LOG_WRITES				1659
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1659
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1660
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1660
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1661
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1661
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1662
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1662
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1663
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1663
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1664
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1664
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1665
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1665
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1666
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1666
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1667
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1667
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1668
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1668
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1669
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1669
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1670
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1670
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1671
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1671
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1672
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1672
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1673
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1673
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1674
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1674
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1675
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1675
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1676
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1676
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1677
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1677
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1678
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1678
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1679
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1679
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1680
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1680
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1681
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1681
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1682
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1682
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1683
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1683
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1684
 /*! perf: block manager read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT2	1684
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT2	1685
 /*! perf: block manager read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT5	1685
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT5	1686
 /*! perf: block manager read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT10	1686
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT10	1687
 /*! perf: block manager read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT50	1687
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT50	1688
 /*! perf: block manager read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT100	1688
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT100	1689
 /*! perf: block manager read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT250	1689
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT250	1690
 /*! perf: block manager read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT500	1690
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT500	1691
 /*! perf: block manager read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT1000	1691
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT1000	1692
 /*! perf: block manager read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_GT1000	1692
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_GT1000	1693
 /*! perf: block manager read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_TOTAL_MSECS	1693
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_TOTAL_MSECS	1694
 /*! perf: block manager write latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT2	1694
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT2	1695
 /*! perf: block manager write latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT5	1695
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT5	1696
 /*! perf: block manager write latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT10	1696
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT10	1697
 /*! perf: block manager write latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT50	1697
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT50	1698
 /*! perf: block manager write latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT100	1698
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT100	1699
 /*! perf: block manager write latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT250	1699
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT250	1700
 /*! perf: block manager write latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT500	1700
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT500	1701
 /*! perf: block manager write latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT1000	1701
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT1000	1702
 /*! perf: block manager write latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_GT1000	1702
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_GT1000	1703
 /*! perf: block manager write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_TOTAL_MSECS	1703
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_TOTAL_MSECS	1704
 /*! perf: disagg block manager read latency histogram (bucket 1) - 50-99us */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT100	1704
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT100	1705
 /*!
  * perf: disagg block manager read latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT250	1705
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT250	1706
 /*!
  * perf: disagg block manager read latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT500	1706
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT500	1707
 /*!
  * perf: disagg block manager read latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT1000	1707
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT1000	1708
 /*!
  * perf: disagg block manager read latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT2500	1708
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT2500	1709
 /*!
  * perf: disagg block manager read latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT5000	1709
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT5000	1710
 /*!
  * perf: disagg block manager read latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT10000	1710
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT10000	1711
 /*!
  * perf: disagg block manager read latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_GT10000	1711
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_GT10000	1712
 /*! perf: disagg block manager read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_TOTAL_USECS	1712
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_TOTAL_USECS	1713
 /*!
  * perf: disagg block manager write latency histogram (bucket 1) -
  * 50-99us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT100	1713
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT100	1714
 /*!
  * perf: disagg block manager write latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT250	1714
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT250	1715
 /*!
  * perf: disagg block manager write latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT500	1715
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT500	1716
 /*!
  * perf: disagg block manager write latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT1000	1716
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT1000	1717
 /*!
  * perf: disagg block manager write latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT2500	1717
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT2500	1718
 /*!
  * perf: disagg block manager write latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT5000	1718
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT5000	1719
 /*!
  * perf: disagg block manager write latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT10000	1719
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT10000	1720
 /*!
  * perf: disagg block manager write latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_GT10000	1720
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_GT10000	1721
 /*! perf: disagg block manager write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_TOTAL_USECS	1721
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_TOTAL_USECS	1722
 /*! perf: file system read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT2	1722
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT2	1723
 /*! perf: file system read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT5	1723
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT5	1724
 /*! perf: file system read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1724
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1725
 /*! perf: file system read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1725
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1726
 /*! perf: file system read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1726
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1727
 /*! perf: file system read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1727
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1728
 /*! perf: file system read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1728
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1729
 /*! perf: file system read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1729
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1730
 /*! perf: file system read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1730
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1731
 /*! perf: file system read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1731
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1732
 /*! perf: file system write latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT2	1732
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT2	1733
 /*! perf: file system write latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT5	1733
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT5	1734
 /*! perf: file system write latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1734
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1735
 /*! perf: file system write latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1735
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1736
 /*! perf: file system write latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1736
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1737
 /*! perf: file system write latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1737
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1738
 /*! perf: file system write latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1738
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1739
 /*! perf: file system write latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1739
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1740
 /*! perf: file system write latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1740
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1741
 /*! perf: file system write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1741
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1742
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 1) -
  * 0-100us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT100	1742
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT100	1743
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT250	1743
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT250	1744
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT500	1744
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT500	1745
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT1000	1745
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT1000	1746
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT2500	1746
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT2500	1747
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT5000	1747
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT5000	1748
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT10000	1748
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT10000	1749
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_GT10000	1749
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_GT10000	1750
 /*! perf: internal page deltas reconstruct latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_TOTAL_USECS	1750
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_TOTAL_USECS	1751
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 1) -
  * 0-100us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT100	1751
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT100	1752
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT250	1752
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT250	1753
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT500	1753
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT500	1754
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT1000	1754
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT1000	1755
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT2500	1755
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT2500	1756
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT5000	1756
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT5000	1757
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT10000	1757
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT10000	1758
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_GT10000	1758
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_GT10000	1759
 /*! perf: leaf page deltas reconstruct latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_TOTAL_USECS	1759
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_TOTAL_USECS	1760
 /*! perf: operation read latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1760
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1761
 /*! perf: operation read latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1761
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1762
 /*! perf: operation read latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1762
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1763
 /*! perf: operation read latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1763
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1764
 /*! perf: operation read latency histogram (bucket 5) - 1000-2499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT2500	1764
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT2500	1765
 /*! perf: operation read latency histogram (bucket 6) - 2500-4999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT5000	1765
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT5000	1766
 /*! perf: operation read latency histogram (bucket 7) - 5000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1766
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1767
 /*! perf: operation read latency histogram (bucket 8) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1767
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1768
 /*! perf: operation read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1768
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1769
 /*! perf: operation write latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1769
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1770
 /*! perf: operation write latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1770
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1771
 /*! perf: operation write latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1771
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1772
 /*! perf: operation write latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1772
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1773
 /*! perf: operation write latency histogram (bucket 5) - 1000-2499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT2500	1773
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT2500	1774
 /*! perf: operation write latency histogram (bucket 6) - 2500-4999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT5000	1774
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT5000	1775
 /*! perf: operation write latency histogram (bucket 7) - 5000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1775
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1776
 /*! perf: operation write latency histogram (bucket 8) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1776
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1777
 /*! perf: operation write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1777
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1778
 /*! prefetch: could not perform pre-fetch on internal page */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1778
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1779
 /*!
  * prefetch: could not perform pre-fetch on ref without the pre-fetch
  * flag set
  */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1779
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1780
 /*! prefetch: number of times pre-fetch failed to start */
-#define	WT_STAT_CONN_PREFETCH_FAILED_START		1780
+#define	WT_STAT_CONN_PREFETCH_FAILED_START		1781
 /*! prefetch: pre-fetch not repeating for recently pre-fetched ref */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1781
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1782
 /*! prefetch: pre-fetch not triggered after single disk read */
-#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1782
+#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1783
 /*! prefetch: pre-fetch not triggered as there is no valid dhandle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1783
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1784
 /*! prefetch: pre-fetch not triggered by page read */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED			1784
+#define	WT_STAT_CONN_PREFETCH_SKIPPED			1785
 /*! prefetch: pre-fetch not triggered due to disk read count */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1785
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1786
 /*! prefetch: pre-fetch not triggered due to internal session */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1786
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1787
 /*! prefetch: pre-fetch not triggered due to special btree handle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1787
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1788
 /*! prefetch: pre-fetch page not on disk when reading */
-#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1788
+#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1789
 /*! prefetch: pre-fetch pages queued */
-#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1789
+#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1790
 /*! prefetch: pre-fetch pages read in background */
-#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1790
+#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1791
 /*! prefetch: pre-fetch skipped reading in a page due to harmless error */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1791
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1792
 /*! prefetch: pre-fetch triggered by page read */
-#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1792
+#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1793
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1793
+#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1794
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1794
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1795
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1795
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1796
 /*!
  * reconciliation: average length of delta chain on internal page with
  * deltas
  */
-#define	WT_STAT_CONN_REC_AVERAGE_INTERNAL_PAGE_DELTA_CHAIN_LENGTH	1796
+#define	WT_STAT_CONN_REC_AVERAGE_INTERNAL_PAGE_DELTA_CHAIN_LENGTH	1797
 /*! reconciliation: average length of delta chain on leaf page with deltas */
-#define	WT_STAT_CONN_REC_AVERAGE_LEAF_PAGE_DELTA_CHAIN_LENGTH	1797
+#define	WT_STAT_CONN_REC_AVERAGE_LEAF_PAGE_DELTA_CHAIN_LENGTH	1798
 /*!
  * reconciliation: changes since prior reconciliation (bucket 1) between
  * 1 and 5
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE5			1798
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE5			1799
 /*!
  * reconciliation: changes since prior reconciliation (bucket 2) between
  * 6 and 10
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE10			1799
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE10			1800
 /*!
  * reconciliation: changes since prior reconciliation (bucket 3) between
  * 11 and 20
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE20			1800
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE20			1801
 /*!
  * reconciliation: changes since prior reconciliation (bucket 4) between
  * 21 and 50
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE50			1801
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE50			1802
 /*!
  * reconciliation: changes since prior reconciliation (bucket 5) between
  * 51 and 100
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE100		1802
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE100		1803
 /*!
  * reconciliation: changes since prior reconciliation (bucket 6) between
  * 101 and 200
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE200		1803
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE200		1804
 /*!
  * reconciliation: changes since prior reconciliation (bucket 7) between
  * 201 and 500
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE500		1804
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE500		1805
 /*!
  * reconciliation: changes since prior reconciliation (bucket 8) greater
  * than 500
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_GT500		1805
+#define	WT_STAT_CONN_REC_PAGE_MODS_GT500		1806
 /*! reconciliation: cursor next/prev calls during HS wrapup search_near */
-#define	WT_STAT_CONN_REC_HS_WRAPUP_NEXT_PREV_CALLS	1806
+#define	WT_STAT_CONN_REC_HS_WRAPUP_NEXT_PREV_CALLS	1807
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1807
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1808
 /*!
  * reconciliation: free page ID due to failed page replacement
  * reconciliation in disagg
  */
-#define	WT_STAT_CONN_REC_FREE_PAGE_ID_DUE_TO_FAILED_REPLACEMENT_RECONCILIATION	1808
+#define	WT_STAT_CONN_REC_FREE_PAGE_ID_DUE_TO_FAILED_REPLACEMENT_RECONCILIATION	1809
 /*! reconciliation: full internal pages written instead of a page delta */
-#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_INTERNAL	1809
+#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_INTERNAL	1810
 /*! reconciliation: full leaf pages written instead of a page delta */
-#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_LEAF		1810
+#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_LEAF		1811
 /*!
  * reconciliation: ingest btree reconciliation keeps the aborted prepare
  * updates
  */
-#define	WT_STAT_CONN_REC_INGEST_KEEP_PREPARE_ROLLBACK	1811
+#define	WT_STAT_CONN_REC_INGEST_KEEP_PREPARE_ROLLBACK	1812
 /*! reconciliation: internal page delta keys deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_DELETED	1812
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_DELETED	1813
 /*! reconciliation: internal page delta keys updated/inserted */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_UPDATED	1813
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_UPDATED	1814
 /*! reconciliation: internal page deltas written */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL		1814
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL		1815
 /*! reconciliation: internal page multi-block writes */
-#define	WT_STAT_CONN_REC_MULTIBLOCK_INTERNAL		1815
+#define	WT_STAT_CONN_REC_MULTIBLOCK_INTERNAL		1816
 /*! reconciliation: leaf page deltas written */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_LEAF		1816
+#define	WT_STAT_CONN_REC_PAGE_DELTA_LEAF		1817
 /*! reconciliation: leaf page multi-block writes */
-#define	WT_STAT_CONN_REC_MULTIBLOCK_LEAF		1817
+#define	WT_STAT_CONN_REC_MULTIBLOCK_LEAF		1818
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1818
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1819
 /*! reconciliation: max deltas seen on internal page during reconciliation */
-#define	WT_STAT_CONN_REC_MAX_INTERNAL_PAGE_DELTAS	1819
+#define	WT_STAT_CONN_REC_MAX_INTERNAL_PAGE_DELTAS	1820
 /*! reconciliation: max deltas seen on leaf page during reconciliation */
-#define	WT_STAT_CONN_REC_MAX_LEAF_PAGE_DELTAS		1820
+#define	WT_STAT_CONN_REC_MAX_LEAF_PAGE_DELTAS		1821
 /*! reconciliation: maximum milliseconds spent in a reconciliation call */
-#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1821
+#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1822
 /*!
  * reconciliation: maximum milliseconds spent in building a disk image in
  * a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1822
+#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1823
 /*!
  * reconciliation: maximum milliseconds spent in moving updates to the
  * history store in a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1823
+#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1824
 /*!
  * reconciliation: number of keys that are garbage collected from the
  * disk images in the ingest btrees for disaggregated storage
  */
-#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_DISK_IMAGE	1824
+#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_DISK_IMAGE	1825
 /*!
  * reconciliation: number of keys that are garbage collected from the
  * update chains in the ingest btrees for disaggregated storage
  */
-#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_UPDATE_CHAIN	1825
+#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_UPDATE_CHAIN	1826
 /*! reconciliation: overflow values written */
-#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1826
+#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1827
 /*! reconciliation: page deltas rejected due to invalid page ID */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_INVALID_PAGE_ID	1827
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_INVALID_PAGE_ID	1828
 /*! reconciliation: page deltas rejected due to max consecutive limit */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MAX_CONSECUTIVE_EXCEEDED	1828
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MAX_CONSECUTIVE_EXCEEDED	1829
 /*! reconciliation: page deltas rejected due to multiblock reconciliation */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MULTIBLOCK	1829
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MULTIBLOCK	1830
 /*!
  * reconciliation: page deltas rejected due to non-single page in
  * previous reconciliation
  */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_NON_SINGLE_PAGE	1830
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_NON_SINGLE_PAGE	1831
 /*! reconciliation: page deltas rejected due to size threshold */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_SIZE_THRESHOLD	1831
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_SIZE_THRESHOLD	1832
 /*! reconciliation: page deltas rejected due to zero entries */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_ZERO_ENTRIES	1832
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_ZERO_ENTRIES	1833
 /*!
  * reconciliation: page deltas rejected: build function returned false
  * (disabled, in-memory split, or internal page constraints not met)
  */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_BUILD_FAILED	1833
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_BUILD_FAILED	1834
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1834
+#define	WT_STAT_CONN_REC_PAGES				1835
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1835
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1836
 /*! reconciliation: page reconciliation calls for pages between 1 and 10MB */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_1MB_TO_10MB		1836
+#define	WT_STAT_CONN_REC_PAGES_SIZE_1MB_TO_10MB		1837
 /*!
  * reconciliation: page reconciliation calls for pages between 10 and
  * 100MB
  */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_10MB_TO_100MB	1837
+#define	WT_STAT_CONN_REC_PAGES_SIZE_10MB_TO_100MB	1838
 /*!
  * reconciliation: page reconciliation calls for pages between 100MB and
  * 1GB
  */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_100MB_TO_1GB	1838
+#define	WT_STAT_CONN_REC_PAGES_SIZE_100MB_TO_1GB	1839
 /*! reconciliation: page reconciliation calls for pages over 1GB */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_1GB_PLUS		1839
+#define	WT_STAT_CONN_REC_PAGES_SIZE_1GB_PLUS		1840
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * prepared transaction metadata
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1840
+#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1841
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * timestamps
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1841
+#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1842
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * transaction ids
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1842
+#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1843
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1843
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1844
 /*! reconciliation: pages eligible for delta generation */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_ELIGIBLE		1844
+#define	WT_STAT_CONN_REC_PAGE_DELTA_ELIGIBLE		1845
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1845
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1846
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1846
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1847
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1847
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1848
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1848
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1849
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1849
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1850
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1850
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1851
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1851
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1852
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1852
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1853
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1853
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1854
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1854
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1855
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1855
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1856
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1856
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1857
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1857
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1858
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1858
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1859
 /*! reconciliation: pages written with at least one internal page delta */
-#define	WT_STAT_CONN_REC_PAGES_WITH_INTERNAL_DELTAS	1859
+#define	WT_STAT_CONN_REC_PAGES_WITH_INTERNAL_DELTAS	1860
 /*! reconciliation: pages written with at least one leaf page delta */
-#define	WT_STAT_CONN_REC_PAGES_WITH_LEAF_DELTAS		1860
+#define	WT_STAT_CONN_REC_PAGES_WITH_LEAF_DELTAS		1861
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1861
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1862
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1862
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1863
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1863
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1864
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1864
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1865
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1865
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1866
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1866
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1867
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1867
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1868
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1868
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1869
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1869
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1870
 /*! reconciliation: writes skipped in disaggregated storage */
-#define	WT_STAT_CONN_REC_SKIP_WRITE			1870
+#define	WT_STAT_CONN_REC_SKIP_WRITE			1871
 /*! session: attempts to remove a local object and the object is in use */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1871
+#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1872
 /*! session: flush_tier failed calls */
-#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1872
+#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1873
 /*! session: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1873
+#define	WT_STAT_CONN_FLUSH_TIER				1874
 /*! session: flush_tier tables skipped due to no checkpoint */
-#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1874
+#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1875
 /*! session: flush_tier tables switched */
-#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1875
+#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1876
 /*! session: local objects removed */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1876
+#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1877
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1877
+#define	WT_STAT_CONN_SESSION_OPEN			1878
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1878
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1879
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1879
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1880
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1880
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1881
 /*! session: table alter triggering checkpoint calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1881
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1882
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1882
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1883
 /*! session: table compact conflicted with checkpoint */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1883
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1884
 /*! session: table compact dhandle successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1884
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1885
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1885
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1886
 /*! session: table compact failed calls due to cache pressure */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1886
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1887
 /*! session: table compact passes */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1887
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1888
 /*! session: table compact pulled into eviction */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1888
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1889
 /*! session: table compact running */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1889
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1890
 /*! session: table compact skipped as process would not reduce file size */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1890
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1891
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1891
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1892
 /*! session: table compact timeout */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1892
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1893
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1893
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1894
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1894
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1895
 /*! session: table create with import failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1895
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1896
 /*! session: table create with import repair calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1896
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1897
 /*! session: table create with import successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1897
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1898
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1898
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1899
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1899
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1900
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1900
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1901
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1901
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1902
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1902
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1903
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1903
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1904
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1904
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1905
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1905
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1906
 /*! session: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1906
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1907
 /*! session: tiered operations removed without processing */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1907
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1908
 /*! session: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1908
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1909
 /*! session: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1909
+#define	WT_STAT_CONN_TIERED_RETENTION			1910
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1910
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1911
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1911
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1912
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1912
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1913
 /*! thread-yield: application thread operations waiting for cache */
-#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1913
+#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1914
 /*!
  * thread-yield: application thread operations waiting for interruptible
  * cache eviction
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_OPS	1914
+#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_OPS	1915
 /*!
  * thread-yield: application thread operations waiting for mandatory
  * cache eviction
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_OPS	1915
+#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_OPS	1916
 /*! thread-yield: application thread snapshot refreshed for eviction */
-#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1916
+#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1917
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1917
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1918
 /*!
  * thread-yield: application thread time waiting for interruptible cache
  * eviction (usecs)
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_TIME	1918
+#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_TIME	1919
 /*!
  * thread-yield: application thread time waiting for mandatory cache
  * eviction (usecs)
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_TIME	1919
+#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_TIME	1920
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1920
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1921
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1921
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1922
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1922
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1923
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1923
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1924
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1924
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1925
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1925
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1926
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1926
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1927
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1927
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1928
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1928
+#define	WT_STAT_CONN_PAGE_SLEEP				1929
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1929
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1930
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1930
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1931
 /*! thread-yield: page split and restart read */
-#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1931
+#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1932
 /*! thread-yield: pages skipped during read due to deleted state */
-#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1932
+#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1933
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1933
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1934
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1934
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1935
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1935
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1936
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1936
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1937
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1937
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1938
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1938
+#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1939
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1939
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1940
 /*! transaction: oldest transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1940
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1941
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1941
+#define	WT_STAT_CONN_TXN_PREPARE			1942
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1942
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1943
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1943
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1944
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1944
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1945
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1945
+#define	WT_STAT_CONN_TXN_QUERY_TS			1946
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1946
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1947
 /*! transaction: rollback to stable applied btrees */
-#define	WT_STAT_CONN_TXN_RTS_BTREES_APPLIED		1947
+#define	WT_STAT_CONN_TXN_RTS_BTREES_APPLIED		1948
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1948
+#define	WT_STAT_CONN_TXN_RTS				1949
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1949
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1950
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1950
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1951
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1951
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1952
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1952
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1953
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1953
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1954
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1954
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1955
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1955
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1956
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1956
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1957
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1957
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1958
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1958
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1959
 /*! transaction: rollback to stable skipped btrees */
-#define	WT_STAT_CONN_TXN_RTS_BTREES_SKIPPED		1959
+#define	WT_STAT_CONN_TXN_RTS_BTREES_SKIPPED		1960
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1960
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1961
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1961
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1962
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1962
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1963
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1963
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1964
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1964
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1965
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1965
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1966
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1966
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1967
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1967
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1968
 /*!
  * transaction: rollback to stable updates that would have been aborted
  * in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1968
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1969
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1969
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1970
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1970
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1971
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1971
+#define	WT_STAT_CONN_TXN_SET_TS				1972
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1972
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1973
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1973
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1974
 /*! transaction: set timestamp force calls */
-#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1974
+#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1975
 /*!
  * transaction: set timestamp global oldest timestamp set to be more
  * recent than the global stable timestamp
  */
-#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1975
+#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1976
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1976
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1977
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1977
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1978
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1978
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1979
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1979
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1980
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1980
+#define	WT_STAT_CONN_TXN_BEGIN				1981
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1981
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1982
 /*! transaction: transaction global checkpoint timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_CHECKPOINT_TIMESTAMP	1982
+#define	WT_STAT_CONN_TXN_GLOBAL_CHECKPOINT_TIMESTAMP	1983
 /*! transaction: transaction global durable timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_DURABLE_TIMESTAMP	1983
+#define	WT_STAT_CONN_TXN_GLOBAL_DURABLE_TIMESTAMP	1984
 /*! transaction: transaction global last running timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_LAST_RUNNING_TIMESTAMP	1984
+#define	WT_STAT_CONN_TXN_GLOBAL_LAST_RUNNING_TIMESTAMP	1985
 /*! transaction: transaction global newest timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_NEWEST_TIMESTAMP	1985
+#define	WT_STAT_CONN_TXN_GLOBAL_NEWEST_TIMESTAMP	1986
 /*! transaction: transaction global oldest timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_OLDEST_TIMESTAMP	1986
+#define	WT_STAT_CONN_TXN_GLOBAL_OLDEST_TIMESTAMP	1987
 /*! transaction: transaction global pinned timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_PINNED_TIMESTAMP	1987
+#define	WT_STAT_CONN_TXN_GLOBAL_PINNED_TIMESTAMP	1988
 /*! transaction: transaction global stable timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_STABLE_TIMESTAMP	1988
+#define	WT_STAT_CONN_TXN_GLOBAL_STABLE_TIMESTAMP	1989
 /*! transaction: transaction global version cursor timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_VERSION_CURSOR_TIMESTAMP	1989
+#define	WT_STAT_CONN_TXN_GLOBAL_VERSION_CURSOR_TIMESTAMP	1990
 /*!
  * transaction: transaction number of older readers older than oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_READERS			1990
+#define	WT_STAT_CONN_TXN_PINNED_READERS			1991
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1991
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1992
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1992
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1993
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_LAG		1993
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_LAG		1994
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT_LAG	1994
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT_LAG	1995
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER_LAG	1995
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER_LAG	1996
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1996
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1997
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1997
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1998
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1998
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1999
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1999
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			2000
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				2000
+#define	WT_STAT_CONN_TXN_COMMIT				2001
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			2001
+#define	WT_STAT_CONN_TXN_ROLLBACK			2002
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		2002
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		2003
 
 /*!
  * @}

--- a/src/schema/schema_create.c
+++ b/src/schema/schema_create.c
@@ -162,6 +162,8 @@ __validate_file_id(WT_SESSION_IMPL *session, uint32_t namespaced_id)
 uint32_t
 __wt_generate_file_id(WT_SESSION_IMPL *session, const char *uri, bool is_shared)
 {
+    uint32_t file_id;
+
     typedef struct {
         uint32_t id;
         const char *uri;
@@ -188,7 +190,8 @@ __wt_generate_file_id(WT_SESSION_IMPL *session, const char *uri, bool is_shared)
 
     /* Use the counter if there is no predefined ID for the table. */
     uint32_t ns = is_shared ? WT_BTREE_ID_NAMESPACE_SHARED : WT_BTREE_ID_NAMESPACE_LOCAL;
-    uint32_t namespaced_id = WT_BTREE_ID_NAMESPACED(++S2C(session)->next_file_id, ns);
+    WT_WITH_SCHEMA_LOCK(session, file_id = ++S2C(session)->next_file_id);
+    uint32_t namespaced_id = WT_BTREE_ID_NAMESPACED(file_id, ns);
     __validate_file_id(session, namespaced_id);
     return (namespaced_id);
 }
@@ -1190,8 +1193,12 @@ __create_layered(WT_SESSION_IMPL *session, const char *uri, bool exclusive, cons
     WT_ERR(__wt_config_collapse(session, layered_cfg, &tablecfg));
     WT_ERR(__wt_metadata_insert(session, uri, tablecfg));
 
-    /* Disable logging on the ingest table to ensure we have timestamps. */
-    ingest_cfg[2] = "in_memory=true,log=(enabled=false),disaggregated=(page_log=none)";
+    /*
+     * Disable logging on the ingest table to ensure we have timestamps. Explicitly set
+     * block_manager=default so that the ingest btree is never mistakenly treated as shared.
+     */
+    ingest_cfg[2] =
+      "block_manager=default,in_memory=true,log=(enabled=false),disaggregated=(page_log=none)";
 
     /*
      * Pass the full merged configuration string through. Otherwise file-specific metadata will be
@@ -1300,6 +1307,7 @@ __create_tiered(WT_SESSION_IMPL *session, const char *uri, bool exclusive, const
     const char *cfg[5] = {WT_CONFIG_BASE(session, tiered_meta), NULL, NULL, NULL, NULL};
     const char *metadata;
     bool free_metadata, shared;
+    uint32_t incr_file_id;
 
     conn = S2C(session);
     metadata = NULL;
@@ -1341,11 +1349,13 @@ __create_tiered(WT_SESSION_IMPL *session, const char *uri, bool exclusive, const
              * By default use the connection level bucket and prefix. Then we add in any user
              * configuration that may override the system one.
              */
+            WT_WITH_SCHEMA_LOCK(session, incr_file_id = ++conn->next_file_id);
+
             WT_ERR(__wt_buf_fmt(session, tmp,
               ",tiered_storage=(bucket=%s,bucket_prefix=%s)"
               ",id=%" PRIu32 ",version=(major=%" PRIu16 ",minor=%" PRIu16 "),checkpoint_lsn=",
               conn->bstorage->bucket, conn->bstorage->bucket_prefix,
-              WT_BTREE_ID_NAMESPACED(++conn->next_file_id, WT_BTREE_ID_NAMESPACE_LOCAL),
+              WT_BTREE_ID_NAMESPACED(incr_file_id, WT_BTREE_ID_NAMESPACE_LOCAL),
               WT_BTREE_VERSION_MAX.major, WT_BTREE_VERSION_MAX.minor));
             cfg[1] = tmp->data;
             cfg[2] = config;
@@ -1474,6 +1484,7 @@ __create_fix_file_ids(WT_SESSION_IMPL *session, WT_IMPORT_LIST *import_list)
     int64_t new_file_id, prev_file_id;
     char *config_tmp, fileid_cfg[64];
     const char *cfg[3] = {NULL, NULL, NULL};
+    uint32_t next_raw_id;
 
     config_tmp = NULL;
     new_file_id = prev_file_id = -1;
@@ -1495,7 +1506,8 @@ __create_fix_file_ids(WT_SESSION_IMPL *session, WT_IMPORT_LIST *import_list)
             if (WT_BTREE_ID_SHARED(prev_file_id))
                 WT_RET_MSG(session, EINVAL, "TODO cannot import a shared table");
 
-            new_file_id = WT_BTREE_ID_NAMESPACED(++conn->next_file_id, WT_BTREE_ID_NAMESPACE_LOCAL);
+            WT_WITH_SCHEMA_LOCK(session, next_raw_id = ++conn->next_file_id);
+            new_file_id = WT_BTREE_ID_NAMESPACED(next_raw_id, WT_BTREE_ID_NAMESPACE_LOCAL);
         }
 
         /* Update config with the new file ID. */

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -2122,6 +2122,7 @@ static const char *const __stats_connection_desc[] = {
   "cache: internal pages seen by eviction walk",
   "cache: internal pages seen by eviction walk that are already queued",
   "cache: internal pages split during eviction",
+  "cache: leaf pages currently held in the cache",
   "cache: leaf pages split during eviction",
   "cache: locate a random in-mem ref by examining all entries on the root page",
   "cache: maximum bytes configured",
@@ -3184,6 +3185,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->eviction_internal_pages_seen = 0;
     stats->eviction_internal_pages_already_queued = 0;
     stats->cache_eviction_split_internal = 0;
+    /* not clearing cache_pages_inuse_leaf */
     stats->cache_eviction_split_leaf = 0;
     stats->cache_eviction_random_sample_inmem_root = 0;
     /* not clearing cache_bytes_max */
@@ -4294,6 +4296,7 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->eviction_internal_pages_already_queued +=
       WT_STAT_CONN_READ(from, eviction_internal_pages_already_queued);
     to->cache_eviction_split_internal += WT_STAT_CONN_READ(from, cache_eviction_split_internal);
+    to->cache_pages_inuse_leaf += WT_STAT_CONN_READ(from, cache_pages_inuse_leaf);
     to->cache_eviction_split_leaf += WT_STAT_CONN_READ(from, cache_eviction_split_leaf);
     to->cache_eviction_random_sample_inmem_root +=
       WT_STAT_CONN_READ(from, cache_eviction_random_sample_inmem_root);

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -964,7 +964,8 @@ __recovery_file_scan(WT_RECOVERY *r)
      * other annoyances, but they're all solvable problems. We can revisit this decision after using
      * the tracked namespace file IDs for a while.
      */
-    S2C(r->session)->next_file_id = WT_BTREE_ID_UNNAMESPACED(r->max_fileid);
+    uint32_t new_max = WT_BTREE_ID_UNNAMESPACED(r->max_fileid);
+    WT_WITH_SCHEMA_LOCK(r->session, S2C(r->session)->next_file_id = new_max);
 
     __wt_verbose_level_multi(r->session, WT_VERB_RECOVERY_ALL, WT_VERBOSE_INFO,
       "largest file ID found in the metadata %u", r->max_fileid);

--- a/test/catch2/misc_tests/test_disagg_meta_config.cpp
+++ b/test/catch2/misc_tests/test_disagg_meta_config.cpp
@@ -9,6 +9,7 @@
 #include <catch2/catch.hpp>
 #include <array>
 #include <utility>
+#include <sstream>
 #include <string_view>
 
 #include "wt_internal.h"
@@ -172,10 +173,11 @@ TEST_CASE_METHOD(disagg_fixture, "Parse metadata", "[disagg]")
 
     SECTION("Unknown keys ignored if version doesn't match")
     {
-        const std::string metadata_str =
-          "version=2,compatible_version=1,unknown_key=foo,checkpoint=(),timestamp=c0ffee12,another_"
-          "unknown="
-          "bar,";
+        std::stringstream metadata_stream;
+        metadata_stream << "version=" << WT_DISAGG_CHECKPOINT_TURTLE_VERSION + 1
+                        << ",compatible_version=1,unknown_key=foo,checkpoint=(),timestamp=c0ffee12,"
+                           "another_unknown=bar,";
+        const std::string metadata_str = metadata_stream.str();
 
         WT_ITEM metadata_buf{};
         metadata_buf.data = (const void *)metadata_str.data();
@@ -193,8 +195,10 @@ TEST_CASE_METHOD(disagg_fixture, "Parse metadata", "[disagg]")
 
     SECTION("Unknown keys are an error if version matches")
     {
-        const std::string metadata_str =
-          "version=1,compatible_version=1,unknown_key=foo,checkpoint=(),timestamp=c0ffee12,";
+        std::stringstream metadata_stream;
+        metadata_stream << "version=" << WT_DISAGG_CHECKPOINT_TURTLE_VERSION
+                        << "compatible_version=1,unknown_key=foo,checkpoint=(),timestamp=c0ffee12,";
+        const std::string metadata_str = metadata_stream.str();
 
         WT_ITEM metadata_buf{};
         metadata_buf.data = (const void *)metadata_str.data();

--- a/test/catch2/misc_tests/test_page_log_handle.cpp
+++ b/test/catch2/misc_tests/test_page_log_handle.cpp
@@ -73,6 +73,7 @@ TEST_CASE("Test disaggregated configuration logic", "[disagg_config]")
     REQUIRE(__wt_spin_init(session, &conn_impl->disaggregated_storage.shared_metadata_queue_lock,
               "update shared metadata") == 0);
     REQUIRE(__wt_spin_init(session, &conn_impl->api_lock, "api") == 0);
+    REQUIRE(__wt_spin_init(session, &conn_impl->schema_lock, "schema") == 0);
 
     /* Setup the page log queue. */
     setup_page_log_queue(session);

--- a/test/suite/metadata_helper.py
+++ b/test/suite/metadata_helper.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import re
+
+def extract_id(metadata_value):
+    """
+    Parse the file ID from the configuration string.
+    """
+
+    match = re.search(r',id=(\d+)', metadata_value)
+    return int(match.group(1))

--- a/test/suite/test_layered75.py
+++ b/test/suite/test_layered75.py
@@ -28,6 +28,7 @@
 
 import re
 import wttest
+from metadata_helper import extract_id
 from helper_disagg import disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 
@@ -42,7 +43,15 @@ TEST_NAMESPACE_BITS = 3
 @disagg_test_class
 class test_layered75(wttest.WiredTigerTestCase):
     disagg_storages = gen_disagg_storages('test_layered75', disagg_only = True)
-    scenarios = make_scenarios(disagg_storages)
+    creation_formats = [
+        ('layered-bare',       dict(prefix='layered:', extra_config='')),
+        ('layered-disagg',     dict(prefix='layered:', extra_config='block_manager=disagg')),
+        ('table-type-layered', dict(prefix='table:',   extra_config='block_manager=disagg,type=layered')),
+    ]
+    scenarios = make_scenarios(disagg_storages, creation_formats)
+
+    prefix = 'layered:'
+    extra_config = ''
 
     conn_config = 'disaggregated=(role="leader")'
     conn_config_follower = 'disaggregated=(role="follower")'
@@ -54,15 +63,6 @@ class test_layered75(wttest.WiredTigerTestCase):
         self.conn_follow = self.wiredtiger_open('follower', self.extensionsConfig() + ',create,' +
                                                 self.conn_config_follower)
         self.session_follow = self.conn_follow.open_session('')
-
-    def find_id(self, metadata_value):
-        """
-        Parse the file ID from the configuration string.
-        """
-
-        match = re.search(r',id=(\d+)', metadata_value)
-        self.assertTrue(match, "All `file:` or `metadata:` prefixed metadata entries are expected to have IDs")
-        return int(match.group(1))
 
     def check_prohibited_ids(self, file_id):
         """
@@ -110,7 +110,7 @@ class test_layered75(wttest.WiredTigerTestCase):
             if not key.startswith('file:') and not key == 'metadata:':
                 continue
 
-            file_id = self.find_id(value)
+            file_id = extract_id(value)
             self.check_prohibited_ids(file_id)
 
             self.assertTrue(key not in found_files, f"Duplicated table {key}")
@@ -159,8 +159,13 @@ class test_layered75(wttest.WiredTigerTestCase):
         # Check the follower
         self.check_metadata_ids(self.session_follow)
 
+    def make_create_config(self, base='key_format=S,value_format=S'):
+        if self.extra_config:
+            return base + ',' + self.extra_config
+        return base
+
     def test_populate_table_on_leader(self):
-        self.session.create("layered:test_layered75", 'key_format=S,value_format=S')
+        self.session.create(f"{self.prefix}test_layered75", self.make_create_config())
         # Check the leader
         expected_files = {"file:test_layered75.wt_stable": TEST_NAMESPACE_SHARED,
                           "file:test_layered75.wt_ingest": TEST_NAMESPACE_LOCAL}
@@ -174,7 +179,7 @@ class test_layered75(wttest.WiredTigerTestCase):
         expected_files = {"file:test_layered75.wt_stable": TEST_NAMESPACE_SHARED,
                           "file:test_layered75.wt_ingest": TEST_NAMESPACE_LOCAL}
 
-        self.session.create("layered:test_layered75", 'key_format=S,value_format=S')
+        self.session.create(f"{self.prefix}test_layered75", self.make_create_config())
         # Check the leader
         self.check_metadata_ids(self.session, expected_files)
 
@@ -189,7 +194,7 @@ class test_layered75(wttest.WiredTigerTestCase):
 
         for i in range(10):
             table_name = f"test_layered75_{i}"
-            self.session.create(f"layered:{table_name}", 'key_format=S,value_format=S')
+            self.session.create(f"{self.prefix}{table_name}", self.make_create_config())
             expected_files[f"file:{table_name}.wt_stable"] = TEST_NAMESPACE_SHARED
             expected_files[f"file:{table_name}.wt_ingest"] = TEST_NAMESPACE_LOCAL
 
@@ -200,4 +205,30 @@ class test_layered75(wttest.WiredTigerTestCase):
         self.session.checkpoint()
         self.disagg_advance_checkpoint(self.conn_follow)
         # Check the follower
+        self.check_metadata_ids(self.session_follow, expected_files)
+
+    def test_populate_10_tables_on_leader_and_follower(self):
+        # Verify that ingest btrees created on a follower always land in the
+        # local namespace, regardless of how the layered table was created.
+        expected_files = {}
+
+        for i in range(10):
+            table_name = f"test_layered75_{i}"
+            self.session.create(f"{self.prefix}{table_name}", self.make_create_config())
+            expected_files[f"file:{table_name}.wt_stable"] = TEST_NAMESPACE_SHARED
+            expected_files[f"file:{table_name}.wt_ingest"] = TEST_NAMESPACE_LOCAL
+        self.session.checkpoint()
+
+        # Open a follower and advance its view to pick up the shared metadata.
+        self.create_follower()
+        self.disagg_advance_checkpoint(self.conn_follow)
+
+        # Create the same tables on the follower. It should reuse the existing
+        # .wt_stable (shared namespace) and allocate a new .wt_ingest in the
+        # local namespace.
+        for i in range(10):
+            table_name = f"test_layered75_{i}"
+            self.session.create(f"{self.prefix}{table_name}", self.make_create_config())
+
+        # Confirm the follower's ingest table received a local namespace ID.
         self.check_metadata_ids(self.session_follow, expected_files)

--- a/test/suite/test_layered86.py
+++ b/test/suite/test_layered86.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import re
+import wiredtiger
+import wttest
+from metadata_helper import extract_id
+from helper_disagg import disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
+
+# test_layered86.py
+# Make sure that a follower picks up and applies new file IDs.
+@disagg_test_class
+class test_layered86(wttest.WiredTigerTestCase):
+    conn_config = 'disaggregated=(role="leader")'
+    conn_config_follower = 'disaggregated=(role="follower")'
+
+    uri = "layered:test_layered86"
+
+    disagg_storages = gen_disagg_storages('test_layered86', disagg_only = True)
+    scenarios = make_scenarios(disagg_storages)
+
+    def test_standby_uses_table_id_high_water_mark(self):
+        # Make 100 tables, then checkpoint.
+        for i in range(0, 100):
+            self.session.create(f"layered:test_layered86_{i}", 'key_format=S,value_format=S')
+        self.conn.set_timestamp('stable_timestamp=1') # Don't upset precise checkpoint
+        self.session.checkpoint()
+
+        # Record the highest file ID.
+        md_cursor = self.session.open_cursor('metadata:', None, None)
+        max_file_id = 0
+        for key, value in md_cursor:
+            if not key.startswith('file:') and not key == 'metadata:':
+                continue
+
+            curr_file_id = extract_id(value)
+            if curr_file_id > max_file_id:
+                max_file_id = curr_file_id
+
+        # Drop those tables, checkpoint again.
+        for i in range(0, 100):
+            self.session.drop(f"layered:test_layered86_{i}")
+        self.session.checkpoint()
+
+        # Make a follower and feed it the latest checkpoint.
+        self.conn_follow = self.wiredtiger_open('follower', self.extensionsConfig() + ',create,' +
+                                                self.conn_config_follower)
+        self.session_follow = self.conn_follow.open_session('')
+        self.disagg_advance_checkpoint(self.conn_follow)
+
+        # Kill the leader. Skip the closing checkpoint -- otherwise, when the follower connection
+        # is closed, we'll discard unclean pages twice. These pages can have the same ID, which
+        # makes PALite think it's seeing a double-free.
+        self.session.close()
+        self.conn.close('debug=(skip_checkpoint=true)')
+
+        # Follower step-up to leader.
+        self.conn_follow.reconfigure('disaggregated=(role="leader")')
+
+        # Make a new table on the (new) leader. Checkpoint.
+        self.conn_follow.set_timestamp('stable_timestamp=2') # Don't upset precise checkpoint
+        self.session_follow.create(f"layered:test_layered86_101", 'key_format=S,value_format=S')
+        self.session_follow.checkpoint()
+
+        # Make sure the table ID is higher than what we saw from the old leader
+        md_cursor = self.session_follow.open_cursor('metadata:', None, None)
+        follower_max_file_id = 0
+        for key, value in md_cursor:
+            if not key.startswith('file:') and not key == 'metadata:':
+                continue
+
+            curr_file_id = extract_id(value)
+            if curr_file_id > follower_max_file_id:
+                follower_max_file_id = curr_file_id
+        self.assertTrue(follower_max_file_id > max_file_id)

--- a/test/suite/test_stat15.py
+++ b/test/suite/test_stat15.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wttest
+from wiredtiger import stat
+
+# test_stat15.py
+# Check that cache_pages_inuse and cache_pages_inuse_leaf are correctly tracked
+class test_stat15(wttest.WiredTigerTestCase):
+    uri = 'table:test_stat15'
+
+    conn_config = 'statistics=(all),cache_size=100MB'
+
+    def get_conn_stat(self, stat_key):
+        stat_cursor = self.session.open_cursor('statistics:', None, None)
+        val = stat_cursor[stat_key][2]
+        stat_cursor.close()
+        return val
+
+    def test_cache_pages_inuse_leaf(self):
+        # Create a table and insert enough data to bring leaf pages into cache
+        self.session.create(self.uri, 'key_format=S,value_format=S')
+        cursor = self.session.open_cursor(self.uri, None, None)
+        for i in range(1000):
+            cursor[str(i).zfill(6)] = 'value_' + str(i)
+        cursor.close()
+
+        # Verify leaf pages are in cache
+        leaf_pages = self.get_conn_stat(stat.conn.cache_pages_inuse_leaf)
+        self.assertGreater(leaf_pages, 0,
+            'expected cache_pages_inuse_leaf > 0 after inserting data')
+
+        # Verify total pages >= leaf pages (total includes internal pages too)
+        total_pages = self.get_conn_stat(stat.conn.cache_pages_inuse)
+        self.assertGreaterEqual(total_pages, leaf_pages,
+            'expected cache_pages_inuse >= cache_pages_inuse_leaf')
+
+    def test_cache_pages_inuse_leaf_decreases_after_eviction(self):
+        # Create a table and insert enough data to populate multiple leaf pages
+        self.session.create(self.uri, 'key_format=S,value_format=S')
+        cursor = self.session.open_cursor(self.uri, None, None)
+        for i in range(10000):
+            cursor[str(i).zfill(6)] = 'x' * 1000
+        cursor.close()
+        self.session.checkpoint(None)
+
+        leaf_before = self.get_conn_stat(stat.conn.cache_pages_inuse_leaf)
+        self.assertGreater(leaf_before, 0)
+
+        # Force eviction by reopening the connection (clears cache).
+        self.reopen_conn()
+
+        leaf_after = self.get_conn_stat(stat.conn.cache_pages_inuse_leaf)
+        self.assertLess(leaf_after, leaf_before,
+            'expected cache_pages_inuse_leaf to decrease after cache cleared')


### PR DESCRIPTION
Adding page leaf stats for extra granularity in FTDC stream on T2
Internal page stats will be derived in T2 (total pages - leaf stats)
As mentioned on the ticket, we are still maintaining total pages for backwards compatibility
