### PR TITLE
WT-17094 Remove duplicate verify() in C tests

### DIFF
--- a/test/thread/file.c
+++ b/test/thread/file.c
@@ -90,23 +90,3 @@ load(const char *name)
 
     testutil_check(session->close(session, NULL));
 }
-
-/*
- * verify --
- *     TODO: Add a comment describing this function.
- */
-void
-verify(const char *name)
-{
-    WT_DECL_RET;
-    WT_SESSION *session;
-
-    testutil_check(conn->open_session(conn, NULL, NULL, &session));
-
-    while ((ret = session->verify(session, name, NULL)) == EBUSY)
-        testutil_check(session->checkpoint(session, NULL));
-
-    testutil_check(ret);
-
-    testutil_check(session->close(session, NULL));
-}

--- a/test/thread/rw.c
+++ b/test/thread/rw.c
@@ -53,6 +53,7 @@ void
 rw_start(u_int readers, u_int writers)
 {
     struct timeval start, stop;
+    WT_SESSION *session;
     wt_thread_t *tids;
     double seconds;
     u_int i, name_index, offset, total_nops;
@@ -123,7 +124,9 @@ rw_start(u_int readers, u_int writers)
 
     /* Verify the files. */
     for (i = 0; i < readers + writers; ++i) {
-        verify(run_info[i].name);
+        testutil_check(conn->open_session(conn, NULL, NULL, &session));
+        testutil_verify(session, run_info[i].name, NULL);
+        testutil_check(session->close(session, NULL));
         if (!multiple_files)
             break;
     }

--- a/test/thread/thread.h
+++ b/test/thread/thread.h
@@ -50,4 +50,3 @@ extern int session_per_op; /* New session per operation */
 void load(const char *);
 void rw_start(u_int, u_int);
 void stats(void);
-void verify(const char *);


### PR DESCRIPTION
Removed unecessary `verify` in `test/thread/file.c` and replaced it with `testutil_verify` utility in `test_util.h`
