### PR TITLE
WT-16958 Fix many-collection-test python version

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -256,7 +256,7 @@ functions:
         set -o errexit
         set -o verbose
         ${PREPARE_PATH}
-        virtualenv -p python3 venv
+        virtualenv -p python3.13 venv
         source venv/bin/activate
         buildscripts/poetry_sync.sh
 


### PR DESCRIPTION
poetry sync now requires python 3.13 and the default python3 points to 3.10 which is insufficient 