### PR TITLE
WT-17098 Extract tree checkpointing from checkpoint_db_internal

### DIFF
--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -3062,9 +3062,9 @@ __checkpoint_selected_dhandles(WT_SESSION_IMPL *session, const char *cfg[])
 err:
     WT_STAT_CONN_SET(session, checkpoint_tree_duration,
       WT_CLOCKDIFF_US(__wt_clock(session), time_start_ckpt_tree));
-    if (ret == 0) {
+    if (ret == 0)
         __checkpoint_verbose_track(session, "checkpointing individual trees completed");
-    } else
+    else
         __checkpoint_verbose_track(session, "checkpointing individual trees failed");
 
     return (ret);

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -14,7 +14,7 @@ static int __checkpoint_fsync_post(
 static int __checkpoint_lock_dirty_tree(WT_SESSION_IMPL *, bool, bool, bool, const char *[]);
 static int __checkpoint_mark_skip(WT_SESSION_IMPL *, WT_CKPT *, bool);
 static int __checkpoint_presync(WT_SESSION_IMPL *, const char *[]);
-static int __checkpoint_selected_dhandles(WT_SESSION_IMPL *, const char *[], struct timespec);
+static int __checkpoint_selected_dhandles(WT_SESSION_IMPL *, const char *[]);
 static int __checkpoint_tree_helper(WT_SESSION_IMPL *, const char *[]);
 static uint64_t __checkpoint_running_time(WT_SESSION_IMPL *);
 static void __checkpoint_prepare_progress(WT_SESSION_IMPL *session, bool final);
@@ -1638,7 +1638,9 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
     /* Add a ten second wait to simulate checkpoint slowness. */
     tsp.tv_sec = 10;
     tsp.tv_nsec = 0;
-    WT_ERR(__checkpoint_selected_dhandles(session, cfg, tsp));
+    __checkpoint_timing_stress(session, WT_TIMING_STRESS_CHECKPOINT_SLOW, &tsp);
+
+    WT_ERR(__checkpoint_selected_dhandles(session, cfg));
 
     /* Wait prior to checkpointing the history store to simulate checkpoint slowness. */
     __checkpoint_timing_stress(session, WT_TIMING_STRESS_HS_CHECKPOINT_DELAY, &tsp);
@@ -3047,12 +3049,9 @@ err:
  *     Checkpoint all the trees in the database.
  */
 static int
-__checkpoint_selected_dhandles(WT_SESSION_IMPL *session, const char *cfg[], struct timespec tsp)
+__checkpoint_selected_dhandles(WT_SESSION_IMPL *session, const char *cfg[])
 {
     uint64_t time_start_ckpt_tree, time_stop_ckpt_tree, ckpt_tree_duration_usecs;
-
-    /* Wait to simulate checkpoint slowness. */
-    __checkpoint_timing_stress(session, WT_TIMING_STRESS_CHECKPOINT_SLOW, &tsp);
 
     WT_STAT_CONN_SET(session, checkpoint_state, WTI_CHECKPOINT_STATE_CKPT_TREE);
     __checkpoint_verbose_track(session, "checkpointing individual trees");

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -3062,6 +3062,10 @@ __checkpoint_selected_dhandles(WT_SESSION_IMPL *session, const char *cfg[])
 err:
     WT_STAT_CONN_SET(session, checkpoint_tree_duration,
       WT_CLOCKDIFF_US(__wt_clock(session), time_start_ckpt_tree));
+    if (ret == 0) {
+        __checkpoint_verbose_track(session, "checkpointing individual trees completed");
+    } else
+        __checkpoint_verbose_track(session, "checkpointing individual trees failed");
 
     return (ret);
 }

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -14,6 +14,7 @@ static int __checkpoint_fsync_post(
 static int __checkpoint_lock_dirty_tree(WT_SESSION_IMPL *, bool, bool, bool, const char *[]);
 static int __checkpoint_mark_skip(WT_SESSION_IMPL *, WT_CKPT *, bool);
 static int __checkpoint_presync(WT_SESSION_IMPL *, const char *[]);
+static int __checkpoint_selected_dhandles(WT_SESSION_IMPL *, const char *[], struct timespec);
 static int __checkpoint_tree_helper(WT_SESSION_IMPL *, const char *[]);
 static uint64_t __checkpoint_running_time(WT_SESSION_IMPL *);
 static void __checkpoint_prepare_progress(WT_SESSION_IMPL *session, bool final);
@@ -1489,8 +1490,7 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
     WT_TXN_ISOLATION saved_isolation;
     wt_off_t hs_size;
     wt_timestamp_t ckpt_tmp_ts;
-    uint64_t ckpt_tree_duration_usecs, drop_size, generation;
-    uint64_t time_start_ckpt_tree, time_stop_ckpt_tree;
+    uint64_t drop_size, generation;
     u_int i;
     char ts_string[WT_TS_INT_STRING_SIZE];
     bool failed, idle, logging, tracking;
@@ -1638,16 +1638,7 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
     /* Add a ten second wait to simulate checkpoint slowness. */
     tsp.tv_sec = 10;
     tsp.tv_nsec = 0;
-    __checkpoint_timing_stress(session, WT_TIMING_STRESS_CHECKPOINT_SLOW, &tsp);
-
-    WT_STAT_CONN_SET(session, checkpoint_state, WTI_CHECKPOINT_STATE_CKPT_TREE);
-    __checkpoint_verbose_track(session, "checkpointing individual trees");
-
-    time_start_ckpt_tree = __wt_clock(session);
-    WT_ERR(__checkpoint_apply_to_dhandles(session, cfg, __checkpoint_tree_helper));
-    time_stop_ckpt_tree = __wt_clock(session);
-    ckpt_tree_duration_usecs = WT_CLOCKDIFF_US(time_stop_ckpt_tree, time_start_ckpt_tree);
-    WT_STAT_CONN_SET(session, checkpoint_tree_duration, ckpt_tree_duration_usecs);
+    WT_ERR(__checkpoint_selected_dhandles(session, cfg, tsp));
 
     /* Wait prior to checkpointing the history store to simulate checkpoint slowness. */
     __checkpoint_timing_stress(session, WT_TIMING_STRESS_HS_CHECKPOINT_DELAY, &tsp);
@@ -3049,6 +3040,30 @@ err:
         __checkpoint_verbose_track(session, "sync failed");
 
     return (ret);
+}
+
+/*
+ * __checkpoint_selected_dhandles --
+ *     Checkpoint all the trees in the database.
+ */
+static int
+__checkpoint_selected_dhandles(WT_SESSION_IMPL *session, const char *cfg[], struct timespec tsp)
+{
+    uint64_t time_start_ckpt_tree, time_stop_ckpt_tree, ckpt_tree_duration_usecs;
+
+    /* Wait to simulate checkpoint slowness. */
+    __checkpoint_timing_stress(session, WT_TIMING_STRESS_CHECKPOINT_SLOW, &tsp);
+
+    WT_STAT_CONN_SET(session, checkpoint_state, WTI_CHECKPOINT_STATE_CKPT_TREE);
+    __checkpoint_verbose_track(session, "checkpointing individual trees");
+
+    time_start_ckpt_tree = __wt_clock(session);
+    WT_RET(__checkpoint_apply_to_dhandles(session, cfg, __checkpoint_tree_helper));
+    time_stop_ckpt_tree = __wt_clock(session);
+    ckpt_tree_duration_usecs = WT_CLOCKDIFF_US(time_stop_ckpt_tree, time_start_ckpt_tree);
+    WT_STAT_CONN_SET(session, checkpoint_tree_duration, ckpt_tree_duration_usecs);
+
+    return (0);
 }
 
 /*

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -3051,18 +3051,19 @@ err:
 static int
 __checkpoint_selected_dhandles(WT_SESSION_IMPL *session, const char *cfg[])
 {
-    uint64_t time_start_ckpt_tree, time_stop_ckpt_tree, ckpt_tree_duration_usecs;
+    WT_DECL_RET;
 
     WT_STAT_CONN_SET(session, checkpoint_state, WTI_CHECKPOINT_STATE_CKPT_TREE);
     __checkpoint_verbose_track(session, "checkpointing individual trees");
 
-    time_start_ckpt_tree = __wt_clock(session);
-    WT_RET(__checkpoint_apply_to_dhandles(session, cfg, __checkpoint_tree_helper));
-    time_stop_ckpt_tree = __wt_clock(session);
-    ckpt_tree_duration_usecs = WT_CLOCKDIFF_US(time_stop_ckpt_tree, time_start_ckpt_tree);
-    WT_STAT_CONN_SET(session, checkpoint_tree_duration, ckpt_tree_duration_usecs);
+    uint64_t time_start_ckpt_tree = __wt_clock(session);
+    WT_ERR(__checkpoint_apply_to_dhandles(session, cfg, __checkpoint_tree_helper));
 
-    return (0);
+err:
+    WT_STAT_CONN_SET(session, checkpoint_tree_duration,
+      WT_CLOCKDIFF_US(__wt_clock(session), time_start_ckpt_tree));
+
+    return (ret);
 }
 
 /*


### PR DESCRIPTION
Moved checkpointing trees block into a static helper `__checkpoint_selected_dhandles`