### PR TITLE
WT-17092 Fix metadata cursor advance loop under read-uncommitted isolation

### DIFF
--- a/src/btree/bt_sync_obsolete.c
+++ b/src/btree/bt_sync_obsolete.c
@@ -667,11 +667,11 @@ __checkpoint_cleanup_get_uri(WT_SESSION_IMPL *session, WT_ITEM *uri)
 {
     WT_CURSOR *cursor;
     WT_DECL_RET;
-    int exact;
+    int cmp, exact;
     const char *key, *value;
 
     cursor = NULL;
-    exact = 0;
+    cmp = exact = 0;
     key = value = NULL;
 
     /* Use a metadata cursor to have access to the existing URIs. */
@@ -688,11 +688,18 @@ __checkpoint_cleanup_get_uri(WT_SESSION_IMPL *session, WT_ITEM *uri)
     /*
      * The given URI may not exist in the metadata file. Since we always want to return a URI that
      * is lexicographically larger the given one, make sure not to go backwards.
+     *
+     * With read-uncommitted isolation, new records can appear between the search and stepping
+     * forward. Loop until we advance past the given URI.
      */
     if (exact <= 0) {
-        /* FIXME-WT-15259: here should be adjusted when this ticket is done. */
-        WT_WITH_TXN_ISOLATION(session, WT_ISO_READ_UNCOMMITTED, ret = cursor->next(cursor));
-        WT_ERR(ret);
+        do {
+            /* FIXME-WT-15259: here should be adjusted when this ticket is done. */
+            WT_WITH_TXN_ISOLATION(session, WT_ISO_READ_UNCOMMITTED, ret = cursor->next(cursor));
+            WT_ERR(ret);
+            WT_ERR(cursor->get_key(cursor, &key));
+            WT_ERR(__wt_compare(session, CUR2BT(cursor)->collator, &cursor->key, uri, &cmp));
+        } while (cmp <= 0);
     }
 
     /* Loop through the eligible candidates. */

--- a/src/btree/bt_sync_obsolete.c
+++ b/src/btree/bt_sync_obsolete.c
@@ -680,7 +680,10 @@ __checkpoint_cleanup_get_uri(WT_SESSION_IMPL *session, WT_ITEM *uri)
     /* Position the cursor on the given URI. */
     cursor->set_key(cursor, (const char *)uri->data);
 
-    /* FIXME-WT-15259: here should be adjusted when this ticket is done. */
+    /* FIXME-WT-15259: will wrap the metadata forward-traversal logic (including the
+     * read-uncommitted isolation and the loop to advance past the target URI) into a proper
+     * internal API. Once that lands, this function can call that API directly.
+     */
     WT_WITH_TXN_ISOLATION(
       session, WT_ISO_READ_UNCOMMITTED, ret = cursor->search_near(cursor, &exact));
     WT_ERR(ret);
@@ -694,10 +697,15 @@ __checkpoint_cleanup_get_uri(WT_SESSION_IMPL *session, WT_ITEM *uri)
      */
     if (exact <= 0) {
         do {
-            /* FIXME-WT-15259: here should be adjusted when this ticket is done. */
+            /* FIXME-WT-15259: will wrap the metadata forward-traversal logic (including the
+             * read-uncommitted isolation and the loop to advance past the target URI) into a proper
+             * internal API. Once that lands, this function can call that API directly and this loop
+             * can be removed.
+             */
             WT_WITH_TXN_ISOLATION(session, WT_ISO_READ_UNCOMMITTED, ret = cursor->next(cursor));
             WT_ERR(ret);
             WT_ERR(cursor->get_key(cursor, &key));
+            /* Both cursor->key and uri include the NUL terminator, so they can be compared. */
             WT_ERR(__wt_compare(session, CUR2BT(cursor)->collator, &cursor->key, uri, &cmp));
         } while (cmp <= 0);
     }
@@ -717,7 +725,11 @@ __checkpoint_cleanup_get_uri(WT_SESSION_IMPL *session, WT_ITEM *uri)
         if (__checkpoint_cleanup_eligibility(session, key, value))
             break;
 
-        /* FIXME-WT-15259: here should be adjusted when this ticket is done. */
+        /* FIXME-WT-15259: will wrap the metadata forward-traversal logic (including the
+         * read-uncommitted isolation and the loop to advance past the target URI) into a proper
+         * internal API. Once that lands, this function can call that API directly and this loop
+         * can be removed.
+         */
         WT_WITH_TXN_ISOLATION(session, WT_ISO_READ_UNCOMMITTED, ret = cursor->next(cursor));
     } while (ret == 0);
     WT_ERR(ret);

--- a/src/btree/bt_sync_obsolete.c
+++ b/src/btree/bt_sync_obsolete.c
@@ -680,7 +680,8 @@ __checkpoint_cleanup_get_uri(WT_SESSION_IMPL *session, WT_ITEM *uri)
     /* Position the cursor on the given URI. */
     cursor->set_key(cursor, (const char *)uri->data);
 
-    /* FIXME-WT-15259: will wrap the metadata forward-traversal logic (including the
+    /*
+     * FIXME-WT-15259: will wrap the metadata forward-traversal logic (including the
      * read-uncommitted isolation and the loop to advance past the target URI) into a proper
      * internal API. Once that lands, this function can call that API directly.
      */
@@ -697,7 +698,8 @@ __checkpoint_cleanup_get_uri(WT_SESSION_IMPL *session, WT_ITEM *uri)
      */
     if (exact <= 0) {
         do {
-            /* FIXME-WT-15259: will wrap the metadata forward-traversal logic (including the
+            /*
+             * FIXME-WT-15259: will wrap the metadata forward-traversal logic (including the
              * read-uncommitted isolation and the loop to advance past the target URI) into a proper
              * internal API. Once that lands, this function can call that API directly and this loop
              * can be removed.
@@ -725,10 +727,11 @@ __checkpoint_cleanup_get_uri(WT_SESSION_IMPL *session, WT_ITEM *uri)
         if (__checkpoint_cleanup_eligibility(session, key, value))
             break;
 
-        /* FIXME-WT-15259: will wrap the metadata forward-traversal logic (including the
+        /*
+         * FIXME-WT-15259: will wrap the metadata forward-traversal logic (including the
          * read-uncommitted isolation and the loop to advance past the target URI) into a proper
-         * internal API. Once that lands, this function can call that API directly and this loop
-         * can be removed.
+         * internal API. Once that lands, this function can call that API directly and this loop can
+         * be removed.
          */
         WT_WITH_TXN_ISOLATION(session, WT_ISO_READ_UNCOMMITTED, ret = cursor->next(cursor));
     } while (ret == 0);

--- a/src/conn/conn_compact.c
+++ b/src/conn/conn_compact.c
@@ -475,7 +475,8 @@ __background_compact_find_next_uri(WT_SESSION_IMPL *session, WT_ITEM *uri, WT_IT
     /* Position the cursor on the given URI. */
     cursor->set_key(cursor, (const char *)uri->data);
 
-    /* FIXME-WT-15259: will wrap the metadata forward-traversal logic (including the
+    /*
+     * FIXME-WT-15259: will wrap the metadata forward-traversal logic (including the
      * read-uncommitted isolation and the loop to advance past the target URI) into a proper
      * internal API. Once that lands, this function can call that API directly.
      */
@@ -492,7 +493,8 @@ __background_compact_find_next_uri(WT_SESSION_IMPL *session, WT_ITEM *uri, WT_IT
      */
     if (exact <= 0) {
         do {
-            /* FIXME-WT-15259: will wrap the metadata forward-traversal logic (including the
+            /*
+             * FIXME-WT-15259: will wrap the metadata forward-traversal logic (including the
              * read-uncommitted isolation and the loop to advance past the target URI) into a proper
              * internal API. Once that lands, this function can call that API directly and this loop
              * can be removed.
@@ -529,10 +531,11 @@ __background_compact_find_next_uri(WT_SESSION_IMPL *session, WT_ITEM *uri, WT_IT
             WT_STAT_CONN_INCR(session, background_compact_skipped);
         }
 
-        /* FIXME-WT-15259: will wrap the metadata forward-traversal logic (including the
+        /*
+         * FIXME-WT-15259: will wrap the metadata forward-traversal logic (including the
          * read-uncommitted isolation and the loop to advance past the target URI) into a proper
-         * internal API. Once that lands, this function can call that API directly and this loop
-         * can be removed.
+         * internal API. Once that lands, this function can call that API directly and this loop can
+         * be removed.
          */
         WT_WITH_TXN_ISOLATION(session, WT_ISO_READ_UNCOMMITTED, ret = cursor->next(cursor));
     } while (ret == 0);

--- a/src/conn/conn_compact.c
+++ b/src/conn/conn_compact.c
@@ -460,12 +460,12 @@ __background_compact_find_next_uri(WT_SESSION_IMPL *session, WT_ITEM *uri, WT_IT
     WT_CONFIG_ITEM id;
     WT_CURSOR *cursor;
     WT_DECL_RET;
-    int exact;
+    int cmp, exact;
     const char *key, *value;
     bool skip;
 
     cursor = NULL;
-    exact = 0;
+    cmp = exact = 0;
     key = NULL;
     value = NULL;
 
@@ -483,11 +483,18 @@ __background_compact_find_next_uri(WT_SESSION_IMPL *session, WT_ITEM *uri, WT_IT
     /*
      * The given URI may not exist in the metadata file. Since we always want to return a URI that
      * is lexicographically larger the given one, make sure not to go backwards.
+     *
+     * With read-uncommitted isolation, new records can appear between the search and stepping
+     * forward. Loop until we advance past the given URI.
      */
     if (exact <= 0) {
-        /* FIXME-WT-15259: here should be adjusted when this ticket is done. */
-        WT_WITH_TXN_ISOLATION(session, WT_ISO_READ_UNCOMMITTED, ret = cursor->next(cursor));
-        WT_ERR(ret);
+        do {
+            /* FIXME-WT-15259: here should be adjusted when this ticket is done. */
+            WT_WITH_TXN_ISOLATION(session, WT_ISO_READ_UNCOMMITTED, ret = cursor->next(cursor));
+            WT_ERR(ret);
+            WT_ERR(cursor->get_key(cursor, &key));
+            WT_ERR(__wt_compare(session, CUR2BT(cursor)->collator, &cursor->key, uri, &cmp));
+        } while (cmp <= 0);
     }
 
     /* Loop through the eligible candidates. */

--- a/src/conn/conn_compact.c
+++ b/src/conn/conn_compact.c
@@ -475,7 +475,10 @@ __background_compact_find_next_uri(WT_SESSION_IMPL *session, WT_ITEM *uri, WT_IT
     /* Position the cursor on the given URI. */
     cursor->set_key(cursor, (const char *)uri->data);
 
-    /* FIXME-WT-15259: here should be adjusted when this ticket is done. */
+    /* FIXME-WT-15259: will wrap the metadata forward-traversal logic (including the
+     * read-uncommitted isolation and the loop to advance past the target URI) into a proper
+     * internal API. Once that lands, this function can call that API directly.
+     */
     WT_WITH_TXN_ISOLATION(
       session, WT_ISO_READ_UNCOMMITTED, ret = cursor->search_near(cursor, &exact));
     WT_ERR(ret);
@@ -489,10 +492,15 @@ __background_compact_find_next_uri(WT_SESSION_IMPL *session, WT_ITEM *uri, WT_IT
      */
     if (exact <= 0) {
         do {
-            /* FIXME-WT-15259: here should be adjusted when this ticket is done. */
+            /* FIXME-WT-15259: will wrap the metadata forward-traversal logic (including the
+             * read-uncommitted isolation and the loop to advance past the target URI) into a proper
+             * internal API. Once that lands, this function can call that API directly and this loop
+             * can be removed.
+             */
             WT_WITH_TXN_ISOLATION(session, WT_ISO_READ_UNCOMMITTED, ret = cursor->next(cursor));
             WT_ERR(ret);
             WT_ERR(cursor->get_key(cursor, &key));
+            /* Both cursor->key and uri include the NUL terminator, so they can be compared. */
             WT_ERR(__wt_compare(session, CUR2BT(cursor)->collator, &cursor->key, uri, &cmp));
         } while (cmp <= 0);
     }
@@ -521,7 +529,11 @@ __background_compact_find_next_uri(WT_SESSION_IMPL *session, WT_ITEM *uri, WT_IT
             WT_STAT_CONN_INCR(session, background_compact_skipped);
         }
 
-        /* FIXME-WT-15259: here should be adjusted when this ticket is done. */
+        /* FIXME-WT-15259: will wrap the metadata forward-traversal logic (including the
+         * read-uncommitted isolation and the loop to advance past the target URI) into a proper
+         * internal API. Once that lands, this function can call that API directly and this loop
+         * can be removed.
+         */
         WT_WITH_TXN_ISOLATION(session, WT_ISO_READ_UNCOMMITTED, ret = cursor->next(cursor));
     } while (ret == 0);
     WT_ERR(ret);


### PR DESCRIPTION
When search_near returns exact <= 0 under WT_ISO_READ_UNCOMMITTED, a single
cursor->next call is not sufficient: new metadata entries inserted between
the search and the step forward can cause the cursor to land on a key that
is still <= the target URI.

Replace the single cursor->next with a do-while loop that keeps advancing
until the cursor is strictly past the given URI. Use __wt_compare with the
cursor's btree collator instead of strcmp to match the btree's internal
comparison semantics.

Applies to __checkpoint_cleanup_get_uri and __background_compact_find_next_uri.