### PR TITLE
WT-16716 Track leaf and total pages in cache with test coverage

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -337,6 +337,7 @@ conn_stats = [
     CacheStat('cache_pages_dirty_stable', 'tracked dirty pages in the cache from the stable btrees', 'no_clear,no_scale'),
     CacheStat('cache_pages_inuse', 'pages currently held in the cache', 'no_clear,no_scale'),
     CacheStat('cache_pages_inuse_ingest', 'pages currently held in the cache from the ingest btrees', 'no_clear,no_scale'),
+    CacheStat('cache_pages_inuse_leaf', 'leaf pages currently held in the cache', 'no_clear,no_scale'),
     CacheStat('cache_pages_inuse_stable', 'pages currently held in the cache from the stable btrees', 'no_clear,no_scale'),
     CacheStat('cache_read_app_count', 'application threads page read from disk to cache count'),
     CacheStat('cache_read_app_time', 'application threads page read from disk to cache time (usecs)'),

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -910,6 +910,8 @@ err:
     /* Increment the cache statistics. */
     __wt_cache_page_inmem_incr(session, page, size, false);
     (void)__wt_atomic_add_uint64_relaxed(&cache->pages_inmem, 1);
+    if (!WT_PAGE_IS_INTERNAL(page))
+        (void)__wt_atomic_add_uint64_relaxed(&cache->pages_inmem_leaf, 1);
     if (__wt_conn_is_disagg(session)) {
         if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
             (void)__wt_atomic_add_uint64_relaxed(&cache->pages_inmem_ingest, 1);

--- a/src/cache/cache.c
+++ b/src/cache/cache.c
@@ -148,6 +148,7 @@ __wt_cache_stats_update(WT_SESSION_IMPL *session)
     WT_STATP_CONN_SET(
       session, stats, cache_bytes_image_stable, __wt_cache_bytes_image_stable(cache));
     WT_STATP_CONN_SET(session, stats, cache_pages_inuse, __wt_cache_pages_inuse(cache));
+    WT_STATP_CONN_SET(session, stats, cache_pages_inuse_leaf, __wt_cache_pages_inuse_leaf(cache));
     WT_STATP_CONN_SET(
       session, stats, cache_pages_inuse_ingest, __wt_cache_pages_inuse_ingest(cache));
     WT_STATP_CONN_SET(

--- a/src/evict/evict_inline.h
+++ b/src/evict/evict_inline.h
@@ -375,6 +375,8 @@ __wt_evict_page_cache_bytes_decr(WT_SESSION_IMPL *session, WT_PAGE *page)
     /* Update bytes and pages evicted. */
     (void)__wt_atomic_add_uint64_relaxed(&cache->bytes_evict, memory_footprint);
     (void)__wt_atomic_add_uint64_v_relaxed(&cache->pages_evicted, 1);
+    if (!WT_PAGE_IS_INTERNAL(page))
+        (void)__wt_atomic_add_uint64_v_relaxed(&cache->pages_evicted_leaf, 1);
     if (is_disagg) {
         if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
             (void)__wt_atomic_add_uint64_v_relaxed(&cache->pages_evicted_ingest, 1);

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -93,9 +93,11 @@ struct __wt_cache {
     wt_shared uint64_t pages_dirty_leaf_stable;
     wt_shared uint64_t pages_evicted;
     wt_shared uint64_t pages_evicted_ingest;
+    wt_shared uint64_t pages_evicted_leaf;
     wt_shared uint64_t pages_evicted_stable;
     wt_shared uint64_t pages_inmem;
     wt_shared uint64_t pages_inmem_ingest;
+    wt_shared uint64_t pages_inmem_leaf;
     wt_shared uint64_t pages_inmem_stable;
 
     u_int overhead_pct; /* Cache percent adjustment */

--- a/src/include/cache_inline.h
+++ b/src/include/cache_inline.h
@@ -20,6 +20,17 @@ __wt_cache_pages_inuse(WT_CACHE *cache)
 }
 
 /*
+ * __wt_cache_pages_inuse_leaf --
+ *     Return the number of leaf pages in use.
+ */
+static WT_INLINE uint64_t
+__wt_cache_pages_inuse_leaf(WT_CACHE *cache)
+{
+    return (__wt_atomic_load_uint64_relaxed(&cache->pages_inmem_leaf) -
+      __wt_atomic_load_uint64_relaxed(&cache->pages_evicted_leaf));
+}
+
+/*
  * __wt_cache_pages_inuse_ingest --
  *     Return the number of pages in use for the ingest btrees.
  */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2434,6 +2434,8 @@ static WT_INLINE uint64_t __wt_cache_pages_inuse(WT_CACHE *cache)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE uint64_t __wt_cache_pages_inuse_ingest(WT_CACHE *cache)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static WT_INLINE uint64_t __wt_cache_pages_inuse_leaf(WT_CACHE *cache)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE uint64_t __wt_cache_pages_inuse_stable(WT_CACHE *cache)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE uint64_t __wt_cell_rle(WT_CELL_UNPACK_KV *unpack)

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -685,6 +685,7 @@ struct __wt_connection_stats {
     int64_t eviction_internal_pages_seen;
     int64_t eviction_internal_pages_already_queued;
     int64_t cache_eviction_split_internal;
+    int64_t cache_pages_inuse_leaf;
     int64_t cache_eviction_split_leaf;
     int64_t cache_eviction_random_sample_inmem_root;
     int64_t cache_bytes_max;

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -6978,1938 +6978,1940 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_ALREADY_QUEUED	1257
 /*! cache: internal pages split during eviction */
 #define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_INTERNAL	1258
+/*! cache: leaf pages currently held in the cache */
+#define	WT_STAT_CONN_CACHE_PAGES_INUSE_LEAF		1259
 /*! cache: leaf pages split during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_LEAF		1259
+#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_LEAF		1260
 /*!
  * cache: locate a random in-mem ref by examining all entries on the root
  * page
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_RANDOM_SAMPLE_INMEM_ROOT	1260
+#define	WT_STAT_CONN_CACHE_EVICTION_RANDOM_SAMPLE_INMEM_ROOT	1261
 /*! cache: maximum bytes configured */
-#define	WT_STAT_CONN_CACHE_BYTES_MAX			1261
+#define	WT_STAT_CONN_CACHE_BYTES_MAX			1262
 /*! cache: maximum clean page size seen at eviction per checkpoint */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_CLEAN_PAGE_SIZE_PER_CHECKPOINT	1262
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_CLEAN_PAGE_SIZE_PER_CHECKPOINT	1263
 /*! cache: maximum dirty page size seen at eviction per checkpoint */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_DIRTY_PAGE_SIZE_PER_CHECKPOINT	1263
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_DIRTY_PAGE_SIZE_PER_CHECKPOINT	1264
 /*!
  * cache: maximum gap between unvisited page and connection evict pass
  * generation seen at eviction
  */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_UNVISITED_GEN_GAP	1264
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_UNVISITED_GEN_GAP	1265
 /*!
  * cache: maximum gap between unvisited page and connection evict pass
  * generation seen at eviction per checkpoint
  */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_UNVISITED_GEN_GAP_PER_CHECKPOINT	1265
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_UNVISITED_GEN_GAP_PER_CHECKPOINT	1266
 /*!
  * cache: maximum gap between visited page and connection evict pass
  * generation seen at eviction
  */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_VISITED_GEN_GAP	1266
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_VISITED_GEN_GAP	1267
 /*!
  * cache: maximum gap between visited page and connection evict pass
  * generation seen at eviction per checkpoint
  */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_VISITED_GEN_GAP_PER_CHECKPOINT	1267
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_VISITED_GEN_GAP_PER_CHECKPOINT	1268
 /*! cache: maximum milliseconds spent at a single eviction */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_MILLISECONDS	1268
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_MILLISECONDS	1269
 /*! cache: maximum milliseconds spent at a single eviction per checkpoint */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_MILLISECONDS_PER_CHECKPOINT	1269
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_MILLISECONDS_PER_CHECKPOINT	1270
 /*!
  * cache: maximum number of times a page tried to be added to eviction
  * queue but fail
  */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_ATTEMPTS_TO_QUEUE_PAGE	1270
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_ATTEMPTS_TO_QUEUE_PAGE	1271
 /*! cache: maximum number of times a page tried to be evicted */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_ATTEMPTS_TO_EVICT_PAGE	1271
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_ATTEMPTS_TO_EVICT_PAGE	1272
 /*! cache: maximum updates page size seen at eviction per checkpoint */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_UPDATES_PAGE_SIZE_PER_CHECKPOINT	1272
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_UPDATES_PAGE_SIZE_PER_CHECKPOINT	1273
 /*! cache: modified page evict attempts by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_DIRTY_ATTEMPT		1273
+#define	WT_STAT_CONN_EVICTION_APP_DIRTY_ATTEMPT		1274
 /*! cache: modified page evict failures by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_DIRTY_FAIL		1274
+#define	WT_STAT_CONN_EVICTION_APP_DIRTY_FAIL		1275
 /*! cache: modified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1275
+#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1276
 /*! cache: multi-block reconciliation blocked whilst checkpoint is running */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_MULTI_BLOCK_RECONCILIATION_DURING_CHECKPOINT	1276
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_MULTI_BLOCK_RECONCILIATION_DURING_CHECKPOINT	1277
 /*! cache: npos read - had to walk this many pages */
-#define	WT_STAT_CONN_NPOS_READ_WALK_MAX			1277
+#define	WT_STAT_CONN_NPOS_READ_WALK_MAX			1278
 /*! cache: number of internal pages read that had deltas attached */
-#define	WT_STAT_CONN_CACHE_READ_INTERNAL_DELTA		1278
+#define	WT_STAT_CONN_CACHE_READ_INTERNAL_DELTA		1279
 /*! cache: number of leaf pages read that had deltas attached */
-#define	WT_STAT_CONN_CACHE_READ_LEAF_DELTA		1279
+#define	WT_STAT_CONN_CACHE_READ_LEAF_DELTA		1280
 /*! cache: number of times dirty trigger was reached */
-#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_DIRTY_REACHED	1280
+#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_DIRTY_REACHED	1281
 /*! cache: number of times eviction trigger was reached */
-#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_REACHED	1281
+#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_REACHED	1282
 /*! cache: number of times updates trigger was reached */
-#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_UPDATES_REACHED	1282
+#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_UPDATES_REACHED	1283
 /*! cache: number of times when cas update the btree max_lsn failed */
-#define	WT_STAT_CONN_CACHE_CAS_BTREE_MAX_LSN_RACE	1283
+#define	WT_STAT_CONN_CACHE_CAS_BTREE_MAX_LSN_RACE	1284
 /*! cache: obsolete updates removed */
-#define	WT_STAT_CONN_CACHE_OBSOLETE_UPDATES_REMOVED	1284
+#define	WT_STAT_CONN_CACHE_OBSOLETE_UPDATES_REMOVED	1285
 /*! cache: operations timed out waiting for space in cache */
-#define	WT_STAT_CONN_EVICTION_TIMED_OUT_OPS		1285
+#define	WT_STAT_CONN_EVICTION_TIMED_OUT_OPS		1286
 /*!
  * cache: overflow keys on a multiblock row-store page blocked its
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_OVERFLOW_KEYS	1286
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_OVERFLOW_KEYS	1287
 /*! cache: overflow pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ_OVERFLOW		1287
+#define	WT_STAT_CONN_CACHE_READ_OVERFLOW		1288
 /*! cache: page evict attempts by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_ATTEMPT		1288
+#define	WT_STAT_CONN_EVICTION_APP_ATTEMPT		1289
 /*! cache: page evict failures by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_FAIL			1289
+#define	WT_STAT_CONN_EVICTION_APP_FAIL			1290
 /*! cache: page eviction blocked due to materialization frontier */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_MATERIALIZATION	1290
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_MATERIALIZATION	1291
 /*!
  * cache: page eviction blocked in disaggregated storage as it can only
  * be written by the next checkpoint
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_DISAGG_NEXT_CHECKPOINT	1291
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_DISAGG_NEXT_CHECKPOINT	1292
 /*! cache: page split during eviction deepened the tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1292
+#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1293
 /*! cache: page written requiring history store records */
-#define	WT_STAT_CONN_CACHE_WRITE_HS			1293
+#define	WT_STAT_CONN_CACHE_WRITE_HS			1294
 /*! cache: pages already in queue when topping up */
-#define	WT_STAT_CONN_EVICTION_PAGES_REMAINING_IN_QUEUE	1294
+#define	WT_STAT_CONN_EVICTION_PAGES_REMAINING_IN_QUEUE	1295
 /*! cache: pages considered for eviction that were brought in by pre-fetch */
-#define	WT_STAT_CONN_EVICTION_CONSIDER_PREFETCH		1295
+#define	WT_STAT_CONN_EVICTION_CONSIDER_PREFETCH		1296
 /*! cache: pages currently held in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_INUSE			1296
+#define	WT_STAT_CONN_CACHE_PAGES_INUSE			1297
 /*! cache: pages currently held in the cache from the ingest btrees */
-#define	WT_STAT_CONN_CACHE_PAGES_INUSE_INGEST		1297
+#define	WT_STAT_CONN_CACHE_PAGES_INUSE_INGEST		1298
 /*! cache: pages currently held in the cache from the stable btrees */
-#define	WT_STAT_CONN_CACHE_PAGES_INUSE_STABLE		1298
+#define	WT_STAT_CONN_CACHE_PAGES_INUSE_STABLE		1299
 /*! cache: pages dirtied due to obsolete time window by eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY_OBSOLETE_TW	1299
+#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY_OBSOLETE_TW	1300
 /*! cache: pages evicted ahead of the page materialization frontier */
-#define	WT_STAT_CONN_CACHE_EVICTION_AHEAD_OF_LAST_MATERIALIZED_LSN	1300
+#define	WT_STAT_CONN_CACHE_EVICTION_AHEAD_OF_LAST_MATERIALIZED_LSN	1301
 /*! cache: pages evicted in parallel with checkpoint */
-#define	WT_STAT_CONN_EVICTION_PAGES_IN_PARALLEL_WITH_CHECKPOINT	1301
+#define	WT_STAT_CONN_EVICTION_PAGES_IN_PARALLEL_WITH_CHECKPOINT	1302
 /*! cache: pages queued for eviction */
-#define	WT_STAT_CONN_EVICTION_PAGES_ORDINARY_QUEUED	1302
+#define	WT_STAT_CONN_EVICTION_PAGES_ORDINARY_QUEUED	1303
 /*! cache: pages queued for eviction post lru sorting */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_POST_LRU	1303
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_POST_LRU	1304
 /*! cache: pages queued for urgent eviction */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT	1304
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT	1305
 /*! cache: pages queued for urgent eviction during walk */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_OLDEST	1305
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_OLDEST	1306
 /*!
  * cache: pages queued for urgent eviction from history store due to high
  * dirty content
  */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT_HS_DIRTY	1306
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT_HS_DIRTY	1307
 /*! cache: pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ				1307
+#define	WT_STAT_CONN_CACHE_READ				1308
 /*! cache: pages read into cache after truncate */
-#define	WT_STAT_CONN_CACHE_READ_DELETED			1308
+#define	WT_STAT_CONN_CACHE_READ_DELETED			1309
 /*! cache: pages read into cache after truncate in prepare state */
-#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1309
+#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1310
 /*! cache: pages read into cache by checkpoint */
-#define	WT_STAT_CONN_CACHE_READ_CHECKPOINT		1310
+#define	WT_STAT_CONN_CACHE_READ_CHECKPOINT		1311
 /*!
  * cache: pages removed from the ordinary queue to be queued for urgent
  * eviction
  */
-#define	WT_STAT_CONN_EVICTION_CLEAR_ORDINARY		1311
+#define	WT_STAT_CONN_EVICTION_CLEAR_ORDINARY		1312
 /*! cache: pages requested from the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1312
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1313
 /*! cache: pages requested from the cache due to pre-fetch */
-#define	WT_STAT_CONN_CACHE_PAGES_PREFETCH		1313
+#define	WT_STAT_CONN_CACHE_PAGES_PREFETCH		1314
 /*! cache: pages requested from the cache internal */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_INTERNAL	1314
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_INTERNAL	1315
 /*! cache: pages requested from the cache leaf */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_LEAF		1315
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_LEAF		1316
 /*! cache: pages requested from the history store */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_HS		1316
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_HS		1317
 /*! cache: pages seen by eviction walk */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1317
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1318
 /*! cache: pages seen by eviction walk that are already queued */
-#define	WT_STAT_CONN_EVICTION_PAGES_ALREADY_QUEUED	1318
+#define	WT_STAT_CONN_EVICTION_PAGES_ALREADY_QUEUED	1319
 /*! cache: pages selected for eviction unable to be evicted */
-#define	WT_STAT_CONN_EVICTION_FAIL			1319
+#define	WT_STAT_CONN_EVICTION_FAIL			1320
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * active children on an internal page
  */
-#define	WT_STAT_CONN_EVICTION_FAIL_ACTIVE_CHILDREN_ON_AN_INTERNAL_PAGE	1320
+#define	WT_STAT_CONN_EVICTION_FAIL_ACTIVE_CHILDREN_ON_AN_INTERNAL_PAGE	1321
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * failure in reconciliation
  */
-#define	WT_STAT_CONN_EVICTION_FAIL_IN_RECONCILIATION	1321
+#define	WT_STAT_CONN_EVICTION_FAIL_IN_RECONCILIATION	1322
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * race between checkpoint and updates without timestamps
  */
-#define	WT_STAT_CONN_EVICTION_FAIL_CHECKPOINT_NO_TS	1322
+#define	WT_STAT_CONN_EVICTION_FAIL_CHECKPOINT_NO_TS	1323
 /*!
  * cache: pages selected for eviction unable to be evicted belonging to
  * ingest btrees
  */
-#define	WT_STAT_CONN_EVICTION_FAIL_INGEST		1323
+#define	WT_STAT_CONN_EVICTION_FAIL_INGEST		1324
 /*! cache: pages walked for eviction */
-#define	WT_STAT_CONN_EVICTION_WALK			1324
+#define	WT_STAT_CONN_EVICTION_WALK			1325
 /*! cache: pages written from cache */
-#define	WT_STAT_CONN_CACHE_WRITE			1325
+#define	WT_STAT_CONN_CACHE_WRITE			1326
 /*!
  * cache: pages written requiring in-memory restoration due to invisible
  * updates
  */
-#define	WT_STAT_CONN_CACHE_WRITE_RESTORE_INVISIBLE	1326
+#define	WT_STAT_CONN_CACHE_WRITE_RESTORE_INVISIBLE	1327
 /*!
  * cache: pages written requiring in-memory restoration due to scrub
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_WRITE_RESTORE_SCRUB		1327
+#define	WT_STAT_CONN_CACHE_WRITE_RESTORE_SCRUB		1328
 /*! cache: percentage overhead */
-#define	WT_STAT_CONN_CACHE_OVERHEAD			1328
+#define	WT_STAT_CONN_CACHE_OVERHEAD			1329
 /*!
  * cache: precise checkpoint caused an eviction to be skipped because any
  * dirty content needs to remain in cache
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_PRECISE_CHECKPOINT	1329
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_PRECISE_CHECKPOINT	1330
 /*!
  * cache: realizing in-memory split after reconciliation failed due to
  * internal lock busy
  */
-#define	WT_STAT_CONN_CACHE_EVICT_SPLIT_FAILED_LOCK	1330
+#define	WT_STAT_CONN_CACHE_EVICT_SPLIT_FAILED_LOCK	1331
 /*! cache: recent modification of a page blocked its eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	1331
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	1332
 /*! cache: reconciled pages scrubbed and added back to the cache clean */
-#define	WT_STAT_CONN_CACHE_SCRUB_RESTORE		1332
+#define	WT_STAT_CONN_CACHE_SCRUB_RESTORE		1333
 /*! cache: reverse splits performed */
-#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS		1333
+#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS		1334
 /*!
  * cache: reverse splits skipped because of VLCS namespace gap
  * restrictions
  */
-#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	1334
+#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	1335
 /*! cache: shared history store cursor not cached during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_HS_SHARED_CURSOR_NOT_CACHED	1335
+#define	WT_STAT_CONN_CACHE_EVICTION_HS_SHARED_CURSOR_NOT_CACHED	1336
 /*! cache: size of delta updates reconstructed on the base page */
-#define	WT_STAT_CONN_CACHE_READ_DELTA_UPDATES		1336
+#define	WT_STAT_CONN_CACHE_READ_DELTA_UPDATES		1337
 /*! cache: size of tombstones restored when reading a page */
-#define	WT_STAT_CONN_CACHE_READ_RESTORED_TOMBSTONE_BYTES	1337
+#define	WT_STAT_CONN_CACHE_READ_RESTORED_TOMBSTONE_BYTES	1338
 /*! cache: the number of times full update inserted to history store */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1338
+#define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1339
 /*! cache: the number of times reverse modify inserted to history store */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1339
+#define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1340
 /*! cache: time eviction worker threads spend waiting for locks (usecs) */
-#define	WT_STAT_CONN_EVICTION_WORKER_LOCK_WAIT_TIME	1340
+#define	WT_STAT_CONN_EVICTION_WORKER_LOCK_WAIT_TIME	1341
 /*!
  * cache: total milliseconds spent inside reentrant history store
  * evictions in a reconciliation
  */
-#define	WT_STAT_CONN_EVICTION_REENTRY_HS_EVICTION_MILLISECONDS	1341
+#define	WT_STAT_CONN_EVICTION_REENTRY_HS_EVICTION_MILLISECONDS	1342
 /*! cache: tracked bytes belonging to internal pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1342
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1343
 /*!
  * cache: tracked bytes belonging to internal pages in the cache from the
  * ingest btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL_INGEST	1343
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL_INGEST	1344
 /*!
  * cache: tracked bytes belonging to internal pages in the cache from the
  * stable btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL_STABLE	1344
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL_STABLE	1345
 /*! cache: tracked bytes belonging to leaf pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1345
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1346
 /*!
  * cache: tracked bytes belonging to leaf pages in the cache from the
  * ingest btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF_INGEST		1346
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF_INGEST		1347
 /*!
  * cache: tracked bytes belonging to leaf pages in the cache from the
  * stable btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF_STABLE		1347
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF_STABLE		1348
 /*! cache: tracked dirty bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1348
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1349
 /*! cache: tracked dirty bytes in the cache from the ingest btrees */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INGEST		1349
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INGEST		1350
 /*! cache: tracked dirty bytes in the cache from the stable btrees */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_STABLE		1350
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_STABLE		1351
 /*! cache: tracked dirty internal page bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL		1351
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL		1352
 /*!
  * cache: tracked dirty internal page bytes in the cache from the ingest
  * btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL_INGEST	1352
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL_INGEST	1353
 /*!
  * cache: tracked dirty internal page bytes in the cache from the stable
  * btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL_STABLE	1353
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL_STABLE	1354
 /*! cache: tracked dirty leaf page bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF		1354
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF		1355
 /*!
  * cache: tracked dirty leaf page bytes in the cache from the ingest
  * btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF_INGEST	1355
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF_INGEST	1356
 /*!
  * cache: tracked dirty leaf page bytes in the cache from the stable
  * btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF_STABLE	1356
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF_STABLE	1357
 /*! cache: tracked dirty pages in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1357
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1358
 /*! cache: tracked dirty pages in the cache from the ingest btrees */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY_INGEST		1358
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY_INGEST		1359
 /*! cache: tracked dirty pages in the cache from the stable btrees */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY_STABLE		1359
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY_STABLE		1360
 /*! cache: uncommitted truncate blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	1360
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	1361
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1361
+#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1362
 /*! cache: update bytes belonging to the history store table in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_HS_UPDATES		1362
+#define	WT_STAT_CONN_CACHE_BYTES_HS_UPDATES		1363
 /*! cache: updates in uncommitted txn - bytes */
-#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_BYTES	1363
+#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_BYTES	1364
 /*! cache: updates in uncommitted txn - count */
-#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_COUNT	1364
+#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_COUNT	1365
 /*! capacity: background fsync file handles considered */
-#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1365
+#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1366
 /*! capacity: background fsync file handles synced */
-#define	WT_STAT_CONN_FSYNC_ALL_FH			1366
+#define	WT_STAT_CONN_FSYNC_ALL_FH			1367
 /*! capacity: background fsync time (msecs) */
-#define	WT_STAT_CONN_FSYNC_ALL_TIME			1367
+#define	WT_STAT_CONN_FSYNC_ALL_TIME			1368
 /*! capacity: bytes read */
-#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1368
+#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1369
 /*! capacity: bytes written for checkpoint */
-#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1369
+#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1370
 /*! capacity: bytes written for chunk cache */
-#define	WT_STAT_CONN_CAPACITY_BYTES_CHUNKCACHE		1370
+#define	WT_STAT_CONN_CAPACITY_BYTES_CHUNKCACHE		1371
 /*! capacity: bytes written for eviction */
-#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1371
+#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1372
 /*! capacity: bytes written for log */
-#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1372
+#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1373
 /*! capacity: bytes written total */
-#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1373
+#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1374
 /*! capacity: threshold to call fsync */
-#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1374
+#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1375
 /*! capacity: time waiting due to total capacity (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1375
+#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1376
 /*! capacity: time waiting during checkpoint (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1376
+#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1377
 /*! capacity: time waiting during eviction (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1377
+#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1378
 /*! capacity: time waiting during logging (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1378
+#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1379
 /*! capacity: time waiting during read (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_READ			1379
+#define	WT_STAT_CONN_CAPACITY_TIME_READ			1380
 /*! capacity: time waiting for chunk cache IO bandwidth (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_CHUNKCACHE		1380
+#define	WT_STAT_CONN_CAPACITY_TIME_CHUNKCACHE		1381
 /*! checkpoint-cleanup: most recent duration on all eligible files (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_DURATION	1381
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_DURATION	1382
 /*! checkpoint-cleanup: most recent handles processed */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_HANDLE_PROCESSED	1382
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_HANDLE_PROCESSED	1383
 /*! checkpoint-cleanup: most recent in-memory pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_INMEM_PAGES_VISITED	1383
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_INMEM_PAGES_VISITED	1384
 /*! checkpoint-cleanup: pages added for eviction */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_EVICT	1384
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_EVICT	1385
 /*! checkpoint-cleanup: pages dirtied due to obsolete time window */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	1385
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	1386
 /*! checkpoint-cleanup: pages read into cache (reclaim_space) */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	1386
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	1387
 /*! checkpoint-cleanup: pages read into cache due to obsolete time window */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	1387
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	1388
 /*! checkpoint-cleanup: pages removed */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_REMOVED	1388
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_REMOVED	1389
 /*! checkpoint-cleanup: pages skipped during tree walk */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	1389
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	1390
 /*! checkpoint-cleanup: pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_VISITED	1390
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_VISITED	1391
 /*! checkpoint-cleanup: successful calls */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_SUCCESS		1391
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_SUCCESS		1392
 /*! checkpoint: checkpoint has acquired a snapshot for its transaction */
-#define	WT_STAT_CONN_CHECKPOINT_SNAPSHOT_ACQUIRED	1392
+#define	WT_STAT_CONN_CHECKPOINT_SNAPSHOT_ACQUIRED	1393
 /*! checkpoint: checkpoints skipped because database was clean */
-#define	WT_STAT_CONN_CHECKPOINT_SKIPPED			1393
+#define	WT_STAT_CONN_CHECKPOINT_SKIPPED			1394
 /*! checkpoint: fsync calls after allocating the transaction ID */
-#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST		1394
+#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST		1395
 /*! checkpoint: fsync duration after allocating the transaction ID (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST_DURATION	1395
+#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST_DURATION	1396
 /*! checkpoint: generation */
-#define	WT_STAT_CONN_CHECKPOINT_GENERATION		1396
+#define	WT_STAT_CONN_CHECKPOINT_GENERATION		1397
 /*! checkpoint: max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_MAX		1397
+#define	WT_STAT_CONN_CHECKPOINT_TIME_MAX		1398
 /*! checkpoint: min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_MIN		1398
+#define	WT_STAT_CONN_CHECKPOINT_TIME_MIN		1399
 /*!
  * checkpoint: most recent duration for checkpoint dropping all handles
  * (usecs)
  */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROP_DURATION	1399
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROP_DURATION	1400
 /*! checkpoint: most recent duration for gathering all handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION		1400
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION		1401
 /*! checkpoint: most recent duration for gathering applied handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLY_DURATION	1401
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLY_DURATION	1402
 /*! checkpoint: most recent duration for gathering skipped handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIP_DURATION	1402
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIP_DURATION	1403
 /*! checkpoint: most recent duration for handles metadata checked (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECK_DURATION	1403
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECK_DURATION	1404
 /*! checkpoint: most recent duration for locking the handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCK_DURATION	1404
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCK_DURATION	1405
 /*! checkpoint: most recent handles applied */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLIED		1405
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLIED		1406
 /*! checkpoint: most recent handles checkpoint dropped */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROPPED		1406
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROPPED		1407
 /*! checkpoint: most recent handles metadata checked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECKED	1407
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECKED	1408
 /*! checkpoint: most recent handles metadata locked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCKED		1408
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCKED		1409
 /*! checkpoint: most recent handles skipped */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIPPED		1409
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIPPED		1410
 /*! checkpoint: most recent handles walked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_WALKED		1410
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_WALKED		1411
 /*! checkpoint: most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_RECENT		1411
+#define	WT_STAT_CONN_CHECKPOINT_TIME_RECENT		1412
 /*! checkpoint: number of bytes caused to be reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED_BYTES	1412
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED_BYTES	1413
 /*! checkpoint: number of checkpoints started by api */
-#define	WT_STAT_CONN_CHECKPOINTS_API			1413
+#define	WT_STAT_CONN_CHECKPOINTS_API			1414
 /*! checkpoint: number of checkpoints started by compaction */
-#define	WT_STAT_CONN_CHECKPOINTS_COMPACT		1414
+#define	WT_STAT_CONN_CHECKPOINTS_COMPACT		1415
 /*! checkpoint: number of files synced */
-#define	WT_STAT_CONN_CHECKPOINT_SYNC			1415
+#define	WT_STAT_CONN_CHECKPOINT_SYNC			1416
 /*! checkpoint: number of handles visited after writes complete */
-#define	WT_STAT_CONN_CHECKPOINT_PRESYNC			1416
+#define	WT_STAT_CONN_CHECKPOINT_PRESYNC			1417
 /*! checkpoint: number of history store pages caused to be reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_HS_PAGES_RECONCILED	1417
+#define	WT_STAT_CONN_CHECKPOINT_HS_PAGES_RECONCILED	1418
 /*! checkpoint: number of internal pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_INTERNAL	1418
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_INTERNAL	1419
 /*! checkpoint: number of leaf pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_LEAF	1419
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_LEAF	1420
 /*! checkpoint: number of pages caused to be reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED	1420
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED	1421
 /*! checkpoint: prepare currently running */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1421
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1422
 /*! checkpoint: prepare max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1422
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1423
 /*! checkpoint: prepare min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1423
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1424
 /*! checkpoint: prepare most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1424
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1425
 /*! checkpoint: prepare total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1425
+#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1426
 /*! checkpoint: progress state */
-#define	WT_STAT_CONN_CHECKPOINT_STATE			1426
+#define	WT_STAT_CONN_CHECKPOINT_STATE			1427
 /*! checkpoint: scrub dirty target */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1427
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1428
 /*! checkpoint: scrub max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1428
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1429
 /*! checkpoint: scrub min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1429
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1430
 /*! checkpoint: scrub most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1430
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1431
 /*! checkpoint: scrub total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1431
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1432
 /*! checkpoint: stop timing stress active */
-#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1432
+#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1433
 /*! checkpoint: time spent on per-tree checkpoint work (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1433
+#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1434
 /*! checkpoint: total failed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1434
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1435
 /*! checkpoint: total succeed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1435
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1436
 /*! checkpoint: total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1436
+#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1437
 /*!
  * checkpoint: total time (msecs) writing pages to stable storage during
  * checkpoint reconciliation
  */
-#define	WT_STAT_CONN_CHECKPOINT_REC_BLKCACHE_WRITE	1437
+#define	WT_STAT_CONN_CHECKPOINT_REC_BLKCACHE_WRITE	1438
 /*! checkpoint: wait cycles while cache dirty level is decreasing */
-#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1438
+#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1439
 /*! chunk-cache: aggregate number of spanned chunks on read */
-#define	WT_STAT_CONN_CHUNKCACHE_SPANS_CHUNKS_READ	1439
+#define	WT_STAT_CONN_CHUNKCACHE_SPANS_CHUNKS_READ	1440
 /*! chunk-cache: chunks evicted */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_EVICTED		1440
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_EVICTED		1441
 /*! chunk-cache: could not allocate due to exceeding bitmap capacity */
-#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_BITMAP_CAPACITY	1441
+#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_BITMAP_CAPACITY	1442
 /*! chunk-cache: could not allocate due to exceeding capacity */
-#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_CAPACITY	1442
+#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_CAPACITY	1443
 /*! chunk-cache: lookups */
-#define	WT_STAT_CONN_CHUNKCACHE_LOOKUPS			1443
+#define	WT_STAT_CONN_CHUNKCACHE_LOOKUPS			1444
 /*!
  * chunk-cache: number of chunks loaded from flushed tables in chunk
  * cache
  */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_LOADED_FROM_FLUSHED_TABLES	1444
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_LOADED_FROM_FLUSHED_TABLES	1445
 /*! chunk-cache: number of metadata entries inserted */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_INSERTED	1445
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_INSERTED	1446
 /*! chunk-cache: number of metadata entries removed */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_REMOVED	1446
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_REMOVED	1447
 /*!
  * chunk-cache: number of metadata inserts/deletes dropped by the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DROPPED	1447
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DROPPED	1448
 /*!
  * chunk-cache: number of metadata inserts/deletes pushed to the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_CREATED	1448
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_CREATED	1449
 /*!
  * chunk-cache: number of metadata inserts/deletes read by the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DEQUEUED	1449
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DEQUEUED	1450
 /*! chunk-cache: number of misses */
-#define	WT_STAT_CONN_CHUNKCACHE_MISSES			1450
+#define	WT_STAT_CONN_CHUNKCACHE_MISSES			1451
 /*! chunk-cache: number of times a read from storage failed */
-#define	WT_STAT_CONN_CHUNKCACHE_IO_FAILED		1451
+#define	WT_STAT_CONN_CHUNKCACHE_IO_FAILED		1452
 /*! chunk-cache: retried accessing a chunk while I/O was in progress */
-#define	WT_STAT_CONN_CHUNKCACHE_RETRIES			1452
+#define	WT_STAT_CONN_CHUNKCACHE_RETRIES			1453
 /*! chunk-cache: retries from a chunk cache checksum mismatch */
-#define	WT_STAT_CONN_CHUNKCACHE_RETRIES_CHECKSUM_MISMATCH	1453
+#define	WT_STAT_CONN_CHUNKCACHE_RETRIES_CHECKSUM_MISMATCH	1454
 /*! chunk-cache: timed out due to too many retries */
-#define	WT_STAT_CONN_CHUNKCACHE_TOOMANY_RETRIES		1454
+#define	WT_STAT_CONN_CHUNKCACHE_TOOMANY_RETRIES		1455
 /*! chunk-cache: total bytes read from persistent content */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_READ_PERSISTENT	1455
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_READ_PERSISTENT	1456
 /*! chunk-cache: total bytes used by the cache */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE		1456
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE		1457
 /*! chunk-cache: total bytes used by the cache for pinned chunks */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE_PINNED	1457
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE_PINNED	1458
 /*! chunk-cache: total chunks held by the chunk cache */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_INUSE		1458
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_INUSE		1459
 /*!
  * chunk-cache: total number of chunks inserted on startup from persisted
  * metadata
  */
-#define	WT_STAT_CONN_CHUNKCACHE_CREATED_FROM_METADATA	1459
+#define	WT_STAT_CONN_CHUNKCACHE_CREATED_FROM_METADATA	1460
 /*! chunk-cache: total pinned chunks held by the chunk cache */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_PINNED		1460
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_PINNED		1461
 /*! connection: auto adjusting condition resets */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1461
+#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1462
 /*! connection: auto adjusting condition wait calls */
-#define	WT_STAT_CONN_COND_AUTO_WAIT			1462
+#define	WT_STAT_CONN_COND_AUTO_WAIT			1463
 /*!
  * connection: auto adjusting condition wait raced to update timeout and
  * skipped updating
  */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1463
+#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1464
 /*! connection: btrees currently open */
-#define	WT_STAT_CONN_BTREE_OPEN				1464
+#define	WT_STAT_CONN_BTREE_OPEN				1465
 /*! connection: detected system time went backwards */
-#define	WT_STAT_CONN_TIME_TRAVEL			1465
+#define	WT_STAT_CONN_TIME_TRAVEL			1466
 /*! connection: files currently open */
-#define	WT_STAT_CONN_FILE_OPEN				1466
+#define	WT_STAT_CONN_FILE_OPEN				1467
 /*! connection: hash bucket array size for data handles */
-#define	WT_STAT_CONN_BUCKETS_DH				1467
+#define	WT_STAT_CONN_BUCKETS_DH				1468
 /*! connection: hash bucket array size general */
-#define	WT_STAT_CONN_BUCKETS				1468
+#define	WT_STAT_CONN_BUCKETS				1469
 /*! connection: memory allocations */
-#define	WT_STAT_CONN_MEMORY_ALLOCATION			1469
+#define	WT_STAT_CONN_MEMORY_ALLOCATION			1470
 /*! connection: memory frees */
-#define	WT_STAT_CONN_MEMORY_FREE			1470
+#define	WT_STAT_CONN_MEMORY_FREE			1471
 /*! connection: memory re-allocations */
-#define	WT_STAT_CONN_MEMORY_GROW			1471
+#define	WT_STAT_CONN_MEMORY_GROW			1472
 /*! connection: number of sessions without a sweep for 5+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1472
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1473
 /*! connection: number of sessions without a sweep for 60+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1473
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1474
 /*! connection: pthread mutex condition wait calls */
-#define	WT_STAT_CONN_COND_WAIT				1474
+#define	WT_STAT_CONN_COND_WAIT				1475
 /*! connection: pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			1475
+#define	WT_STAT_CONN_RWLOCK_READ			1476
 /*! connection: pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			1476
+#define	WT_STAT_CONN_RWLOCK_WRITE			1477
 /*! connection: total fsync I/Os */
-#define	WT_STAT_CONN_FSYNC_IO				1477
+#define	WT_STAT_CONN_FSYNC_IO				1478
 /*! connection: total read I/Os */
-#define	WT_STAT_CONN_READ_IO				1478
+#define	WT_STAT_CONN_READ_IO				1479
 /*! connection: total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				1479
+#define	WT_STAT_CONN_WRITE_IO				1480
 /*! cursor: Total number of deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1480
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1481
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1481
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1482
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1482
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1483
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1483
+#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1484
 /*!
  * cursor: Total number of in-memory deleted pages skipped during tree
  * walk
  */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1484
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1485
 /*! cursor: Total number of on-disk deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1485
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1486
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1486
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1487
 /*!
  * cursor: Total number of times cursor fails to temporarily release
  * pinned page to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1487
+#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1488
 /*!
  * cursor: Total number of times cursor temporarily releases pinned page
  * to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION			1488
+#define	WT_STAT_CONN_CURSOR_REPOSITION			1489
 /*! cursor: bulk cursor count */
-#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1489
+#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1490
 /*! cursor: cached cursor count */
-#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1490
+#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1491
 /*! cursor: cursor bound calls that return an error */
-#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1491
+#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1492
 /*! cursor: cursor bounds cleared from reset */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1492
+#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1493
 /*! cursor: cursor bounds comparisons performed */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1493
+#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1494
 /*! cursor: cursor bounds next called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1494
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1495
 /*! cursor: cursor bounds next early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1495
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1496
 /*! cursor: cursor bounds prev called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1496
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1497
 /*! cursor: cursor bounds prev early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1497
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1498
 /*! cursor: cursor bounds search early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1498
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1499
 /*! cursor: cursor bounds search near call repositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1499
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1500
 /*! cursor: cursor bulk loaded cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1500
+#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1501
 /*! cursor: cursor cache calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1501
+#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1502
 /*! cursor: cursor close calls that result in cache */
-#define	WT_STAT_CONN_CURSOR_CACHE			1502
+#define	WT_STAT_CONN_CURSOR_CACHE			1503
 /*! cursor: cursor close calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1503
+#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1504
 /*! cursor: cursor compare calls that return an error */
-#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1504
+#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1505
 /*! cursor: cursor create calls */
-#define	WT_STAT_CONN_CURSOR_CREATE			1505
+#define	WT_STAT_CONN_CURSOR_CREATE			1506
 /*! cursor: cursor equals calls that return an error */
-#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1506
+#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1507
 /*! cursor: cursor get key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1507
+#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1508
 /*! cursor: cursor get value calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1508
+#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1509
 /*! cursor: cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT			1509
+#define	WT_STAT_CONN_CURSOR_INSERT			1510
 /*! cursor: cursor insert calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1510
+#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1511
 /*! cursor: cursor insert check calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1511
+#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1512
 /*! cursor: cursor insert key and value bytes */
-#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1512
+#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1513
 /*! cursor: cursor largest key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1513
+#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1514
 /*! cursor: cursor modify calls */
-#define	WT_STAT_CONN_CURSOR_MODIFY			1514
+#define	WT_STAT_CONN_CURSOR_MODIFY			1515
 /*! cursor: cursor modify calls that return an error */
-#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1515
+#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1516
 /*! cursor: cursor modify key and value bytes affected */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1516
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1517
 /*! cursor: cursor modify value bytes modified */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1517
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1518
 /*! cursor: cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT			1518
+#define	WT_STAT_CONN_CURSOR_NEXT			1519
 /*! cursor: cursor next calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1519
+#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1520
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1520
+#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1521
 /*!
  * cursor: cursor next calls that skip greater than 1 and fewer than 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1521
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1522
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1522
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1523
 /*! cursor: cursor next random calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1523
+#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1524
 /*! cursor: cursor operation restarted */
-#define	WT_STAT_CONN_CURSOR_RESTART			1524
+#define	WT_STAT_CONN_CURSOR_RESTART			1525
 /*! cursor: cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV			1525
+#define	WT_STAT_CONN_CURSOR_PREV			1526
 /*! cursor: cursor prev calls that return an error */
-#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1526
+#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1527
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1527
+#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1528
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1528
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1529
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1529
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1530
 /*! cursor: cursor reconfigure calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1530
+#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1531
 /*! cursor: cursor remove calls */
-#define	WT_STAT_CONN_CURSOR_REMOVE			1531
+#define	WT_STAT_CONN_CURSOR_REMOVE			1532
 /*! cursor: cursor remove calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1532
+#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1533
 /*! cursor: cursor remove key bytes removed */
-#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1533
+#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1534
 /*! cursor: cursor reopen calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1534
+#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1535
 /*! cursor: cursor reserve calls */
-#define	WT_STAT_CONN_CURSOR_RESERVE			1535
+#define	WT_STAT_CONN_CURSOR_RESERVE			1536
 /*! cursor: cursor reserve calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1536
+#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1537
 /*! cursor: cursor reset calls */
-#define	WT_STAT_CONN_CURSOR_RESET			1537
+#define	WT_STAT_CONN_CURSOR_RESET			1538
 /*! cursor: cursor reset calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1538
+#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1539
 /*! cursor: cursor search calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH			1539
+#define	WT_STAT_CONN_CURSOR_SEARCH			1540
 /*! cursor: cursor search calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1540
+#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1541
 /*! cursor: cursor search history store calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1541
+#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1542
 /*! cursor: cursor search near calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1542
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1543
 /*! cursor: cursor search near calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1543
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1544
 /*! cursor: cursor sweep buckets */
-#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1544
+#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1545
 /*! cursor: cursor sweep cursors closed */
-#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1545
+#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1546
 /*! cursor: cursor sweep cursors examined */
-#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1546
+#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1547
 /*! cursor: cursor sweeps */
-#define	WT_STAT_CONN_CURSOR_SWEEP			1547
+#define	WT_STAT_CONN_CURSOR_SWEEP			1548
 /*! cursor: cursor truncate calls */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE			1548
+#define	WT_STAT_CONN_CURSOR_TRUNCATE			1549
 /*! cursor: cursor truncates performed on individual keys */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1549
+#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1550
 /*! cursor: cursor update calls */
-#define	WT_STAT_CONN_CURSOR_UPDATE			1550
+#define	WT_STAT_CONN_CURSOR_UPDATE			1551
 /*! cursor: cursor update calls that return an error */
-#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1551
+#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1552
 /*! cursor: cursor update key and value bytes */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1552
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1553
 /*! cursor: cursor update value size change */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1553
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1554
 /*! cursor: cursors reused from cache */
-#define	WT_STAT_CONN_CURSOR_REOPEN			1554
+#define	WT_STAT_CONN_CURSOR_REOPEN			1555
 /*! cursor: open cursor count */
-#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1555
+#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1556
 /*! cursor: open cursor time application (usecs) */
-#define	WT_STAT_CONN_CURSOR_OPEN_TIME_USER_USECS	1556
+#define	WT_STAT_CONN_CURSOR_OPEN_TIME_USER_USECS	1557
 /*! cursor: open cursor time internal (usecs) */
-#define	WT_STAT_CONN_CURSOR_OPEN_TIME_INTERNAL_USECS	1557
+#define	WT_STAT_CONN_CURSOR_OPEN_TIME_INTERNAL_USECS	1558
 /*! data-handle: Layered connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_LAYERED_COUNT	1558
+#define	WT_STAT_CONN_DH_CONN_HANDLE_LAYERED_COUNT	1559
 /*! data-handle: Table connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TABLE_COUNT		1559
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TABLE_COUNT		1560
 /*! data-handle: Tiered connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_COUNT	1560
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_COUNT	1561
 /*! data-handle: Tiered_Tree connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_TREE_COUNT	1561
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_TREE_COUNT	1562
 /*! data-handle: btree connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_BTREE_COUNT		1562
+#define	WT_STAT_CONN_DH_CONN_HANDLE_BTREE_COUNT		1563
 /*! data-handle: checkpoint connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_CHECKPOINT_COUNT	1563
+#define	WT_STAT_CONN_DH_CONN_HANDLE_CHECKPOINT_COUNT	1564
 /*! data-handle: connection data handle size */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1564
+#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1565
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1565
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1566
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1566
+#define	WT_STAT_CONN_DH_SWEEP_REF			1567
 /*! data-handle: connection sweep dead dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_DEAD_CLOSE		1567
+#define	WT_STAT_CONN_DH_SWEEP_DEAD_CLOSE		1568
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1568
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1569
 /*! data-handle: connection sweep expired dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_EXPIRED_CLOSE		1569
+#define	WT_STAT_CONN_DH_SWEEP_EXPIRED_CLOSE		1570
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1570
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1571
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1571
+#define	WT_STAT_CONN_DH_SWEEPS				1572
 /*!
  * data-handle: connection sweeps skipped due to checkpoint gathering
  * handles
  */
-#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1572
+#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1573
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1573
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1574
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1574
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1575
 /*! disagg: connection reconfiguration */
-#define	WT_STAT_CONN_DISAGG_CONN_RECONFIG		1575
+#define	WT_STAT_CONN_DISAGG_CONN_RECONFIG		1576
 /*! disagg: database size */
-#define	WT_STAT_CONN_DISAGG_DATABASE_SIZE		1576
+#define	WT_STAT_CONN_DISAGG_DATABASE_SIZE		1577
 /*! disagg: role leader */
-#define	WT_STAT_CONN_DISAGG_ROLE_LEADER			1577
+#define	WT_STAT_CONN_DISAGG_ROLE_LEADER			1578
 /*! disagg: step down most recent time (msecs) */
-#define	WT_STAT_CONN_DISAGG_STEP_DOWN_TIME		1578
+#define	WT_STAT_CONN_DISAGG_STEP_DOWN_TIME		1579
 /*! disagg: step up most recent time (msecs) */
-#define	WT_STAT_CONN_DISAGG_STEP_UP_TIME		1579
+#define	WT_STAT_CONN_DISAGG_STEP_UP_TIME		1580
 /*!
  * layered: Layered table cursor advances to a newer checkpoint for the
  * stable btree
  */
-#define	WT_STAT_CONN_LAYERED_CURS_ADVANCE_STABLE	1580
+#define	WT_STAT_CONN_LAYERED_CURS_ADVANCE_STABLE	1581
 /*! layered: Layered table cursor insert operations */
-#define	WT_STAT_CONN_LAYERED_CURS_INSERT		1581
+#define	WT_STAT_CONN_LAYERED_CURS_INSERT		1582
 /*! layered: Layered table cursor modify operations */
-#define	WT_STAT_CONN_LAYERED_CURS_MODIFY		1582
+#define	WT_STAT_CONN_LAYERED_CURS_MODIFY		1583
 /*! layered: Layered table cursor next operations */
-#define	WT_STAT_CONN_LAYERED_CURS_NEXT			1583
+#define	WT_STAT_CONN_LAYERED_CURS_NEXT			1584
 /*! layered: Layered table cursor next operations from the ingest btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_NEXT_INGEST		1584
+#define	WT_STAT_CONN_LAYERED_CURS_NEXT_INGEST		1585
 /*! layered: Layered table cursor next operations from the stable btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_NEXT_STABLE		1585
+#define	WT_STAT_CONN_LAYERED_CURS_NEXT_STABLE		1586
 /*! layered: Layered table cursor prev operations */
-#define	WT_STAT_CONN_LAYERED_CURS_PREV			1586
+#define	WT_STAT_CONN_LAYERED_CURS_PREV			1587
 /*! layered: Layered table cursor prev operations from the ingest btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_PREV_INGEST		1587
+#define	WT_STAT_CONN_LAYERED_CURS_PREV_INGEST		1588
 /*! layered: Layered table cursor prev operations from the stable btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_PREV_STABLE		1588
+#define	WT_STAT_CONN_LAYERED_CURS_PREV_STABLE		1589
 /*! layered: Layered table cursor remove operations */
-#define	WT_STAT_CONN_LAYERED_CURS_REMOVE		1589
+#define	WT_STAT_CONN_LAYERED_CURS_REMOVE		1590
 /*! layered: Layered table cursor reopens ingest btree */
-#define	WT_STAT_CONN_LAYERED_CURS_REOPEN_INGEST		1590
+#define	WT_STAT_CONN_LAYERED_CURS_REOPEN_INGEST		1591
 /*! layered: Layered table cursor search near operations */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR		1591
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR		1592
 /*!
  * layered: Layered table cursor search near operations from the ingest
  * btrees
  */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_INGEST	1592
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_INGEST	1593
 /*!
  * layered: Layered table cursor search near operations from the stable
  * btrees
  */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_STABLE	1593
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_STABLE	1594
 /*! layered: Layered table cursor search operations */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH		1594
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH		1595
 /*! layered: Layered table cursor search operations from the ingest btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_INGEST		1595
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_INGEST		1596
 /*! layered: Layered table cursor search operations from the stable btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_STABLE		1596
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_STABLE		1597
 /*! layered: Layered table cursor update operations */
-#define	WT_STAT_CONN_LAYERED_CURS_UPDATE		1597
+#define	WT_STAT_CONN_LAYERED_CURS_UPDATE		1598
 /*!
  * layered: checkpoints performed on this table by the layered table
  * manager
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS	1598
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS	1599
 /*! layered: disagg pick up checkpoints failed */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FAILED	1599
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FAILED	1600
 /*! layered: disagg pick up checkpoints succeeded */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_SUCCEED	1600
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_SUCCEED	1601
 /*!
  * layered: how many log applications the layered table manager applied
  * on this tree
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_APPLIED	1601
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_APPLIED	1602
 /*!
  * layered: how many log applications the layered table manager skipped
  * on this tree
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_SKIPPED	1602
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_SKIPPED	1603
 /*!
  * layered: how many previously-applied LSNs the layered table manager
  * skipped on this tree
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_SKIP_LSN	1603
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_SKIP_LSN	1604
 /*! layered: number of checkpoints picked up by a follower */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FOLLOWER	1604
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FOLLOWER	1605
 /*! layered: the number of tables the layered table manager has open */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_TABLES	1605
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_TABLES	1606
 /*!
  * live-restore: number of bytes copied from the source to the
  * destination
  */
-#define	WT_STAT_CONN_LIVE_RESTORE_BYTES_COPIED		1606
+#define	WT_STAT_CONN_LIVE_RESTORE_BYTES_COPIED		1607
 /*! live-restore: number of files remaining for migration completion */
-#define	WT_STAT_CONN_LIVE_RESTORE_WORK_REMAINING	1607
+#define	WT_STAT_CONN_LIVE_RESTORE_WORK_REMAINING	1608
 /*! live-restore: number of reads from the source database */
-#define	WT_STAT_CONN_LIVE_RESTORE_SOURCE_READ_COUNT	1608
+#define	WT_STAT_CONN_LIVE_RESTORE_SOURCE_READ_COUNT	1609
 /*! live-restore: source read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT2	1609
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT2	1610
 /*! live-restore: source read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT5	1610
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT5	1611
 /*! live-restore: source read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT10	1611
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT10	1612
 /*! live-restore: source read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT50	1612
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT50	1613
 /*! live-restore: source read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT100	1613
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT100	1614
 /*! live-restore: source read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT250	1614
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT250	1615
 /*! live-restore: source read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT500	1615
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT500	1616
 /*! live-restore: source read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT1000	1616
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT1000	1617
 /*! live-restore: source read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_GT1000	1617
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_GT1000	1618
 /*! live-restore: source read latency histogram total (msecs) */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_TOTAL_MSECS	1618
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_TOTAL_MSECS	1619
 /*! live-restore: state */
-#define	WT_STAT_CONN_LIVE_RESTORE_STATE			1619
+#define	WT_STAT_CONN_LIVE_RESTORE_STATE			1620
 /*! lock: btree page lock acquisitions */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_COUNT		1620
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_COUNT		1621
 /*! lock: btree page lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_APPLICATION	1621
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_APPLICATION	1622
 /*! lock: btree page lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_INTERNAL	1622
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_INTERNAL	1623
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1623
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1624
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1624
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1625
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1625
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1626
 /*! lock: dhandle lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1626
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1627
 /*! lock: dhandle lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1627
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1628
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1628
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1629
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1629
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1630
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1630
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1631
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1631
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1632
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1632
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1633
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1633
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1634
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1634
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1635
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1635
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1636
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1636
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1637
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1637
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1638
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1638
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1639
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1639
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1640
 /*! lock: txn global lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1640
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1641
 /*! lock: txn global lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1641
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1642
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1642
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1643
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1643
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1644
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1644
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1645
 /*! log: force log remove time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1645
+#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1646
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1646
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1647
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1647
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1648
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1648
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1649
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1649
+#define	WT_STAT_CONN_LOG_FLUSH				1650
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1650
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1651
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1651
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1652
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1652
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1653
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1653
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1654
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1654
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1655
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1655
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1656
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1656
+#define	WT_STAT_CONN_LOG_SCANS				1657
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1657
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1658
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1658
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1659
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1659
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1660
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1660
+#define	WT_STAT_CONN_LOG_SYNC				1661
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1661
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1662
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1662
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1663
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1663
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1664
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1664
+#define	WT_STAT_CONN_LOG_WRITES				1665
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1665
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1666
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1666
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1667
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1667
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1668
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1668
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1669
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1669
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1670
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1670
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1671
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1671
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1672
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1672
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1673
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1673
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1674
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1674
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1675
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1675
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1676
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1676
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1677
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1677
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1678
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1678
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1679
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1679
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1680
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1680
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1681
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1681
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1682
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1682
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1683
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1683
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1684
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1684
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1685
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1685
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1686
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1686
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1687
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1687
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1688
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1688
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1689
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1689
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1690
 /*! perf: block manager read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT2	1690
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT2	1691
 /*! perf: block manager read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT5	1691
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT5	1692
 /*! perf: block manager read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT10	1692
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT10	1693
 /*! perf: block manager read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT50	1693
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT50	1694
 /*! perf: block manager read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT100	1694
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT100	1695
 /*! perf: block manager read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT250	1695
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT250	1696
 /*! perf: block manager read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT500	1696
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT500	1697
 /*! perf: block manager read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT1000	1697
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT1000	1698
 /*! perf: block manager read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_GT1000	1698
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_GT1000	1699
 /*! perf: block manager read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_TOTAL_MSECS	1699
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_TOTAL_MSECS	1700
 /*! perf: block manager write latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT2	1700
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT2	1701
 /*! perf: block manager write latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT5	1701
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT5	1702
 /*! perf: block manager write latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT10	1702
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT10	1703
 /*! perf: block manager write latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT50	1703
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT50	1704
 /*! perf: block manager write latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT100	1704
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT100	1705
 /*! perf: block manager write latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT250	1705
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT250	1706
 /*! perf: block manager write latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT500	1706
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT500	1707
 /*! perf: block manager write latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT1000	1707
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT1000	1708
 /*! perf: block manager write latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_GT1000	1708
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_GT1000	1709
 /*! perf: block manager write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_TOTAL_MSECS	1709
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_TOTAL_MSECS	1710
 /*! perf: disagg block manager read latency histogram (bucket 1) - 50-99us */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT100	1710
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT100	1711
 /*!
  * perf: disagg block manager read latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT250	1711
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT250	1712
 /*!
  * perf: disagg block manager read latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT500	1712
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT500	1713
 /*!
  * perf: disagg block manager read latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT1000	1713
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT1000	1714
 /*!
  * perf: disagg block manager read latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT2500	1714
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT2500	1715
 /*!
  * perf: disagg block manager read latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT5000	1715
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT5000	1716
 /*!
  * perf: disagg block manager read latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT10000	1716
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT10000	1717
 /*!
  * perf: disagg block manager read latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_GT10000	1717
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_GT10000	1718
 /*! perf: disagg block manager read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_TOTAL_USECS	1718
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_TOTAL_USECS	1719
 /*!
  * perf: disagg block manager write latency histogram (bucket 1) -
  * 50-99us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT100	1719
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT100	1720
 /*!
  * perf: disagg block manager write latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT250	1720
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT250	1721
 /*!
  * perf: disagg block manager write latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT500	1721
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT500	1722
 /*!
  * perf: disagg block manager write latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT1000	1722
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT1000	1723
 /*!
  * perf: disagg block manager write latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT2500	1723
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT2500	1724
 /*!
  * perf: disagg block manager write latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT5000	1724
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT5000	1725
 /*!
  * perf: disagg block manager write latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT10000	1725
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT10000	1726
 /*!
  * perf: disagg block manager write latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_GT10000	1726
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_GT10000	1727
 /*! perf: disagg block manager write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_TOTAL_USECS	1727
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_TOTAL_USECS	1728
 /*! perf: file system read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT2	1728
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT2	1729
 /*! perf: file system read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT5	1729
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT5	1730
 /*! perf: file system read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1730
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1731
 /*! perf: file system read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1731
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1732
 /*! perf: file system read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1732
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1733
 /*! perf: file system read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1733
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1734
 /*! perf: file system read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1734
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1735
 /*! perf: file system read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1735
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1736
 /*! perf: file system read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1736
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1737
 /*! perf: file system read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1737
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1738
 /*! perf: file system write latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT2	1738
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT2	1739
 /*! perf: file system write latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT5	1739
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT5	1740
 /*! perf: file system write latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1740
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1741
 /*! perf: file system write latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1741
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1742
 /*! perf: file system write latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1742
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1743
 /*! perf: file system write latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1743
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1744
 /*! perf: file system write latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1744
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1745
 /*! perf: file system write latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1745
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1746
 /*! perf: file system write latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1746
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1747
 /*! perf: file system write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1747
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1748
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 1) -
  * 0-100us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT100	1748
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT100	1749
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT250	1749
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT250	1750
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT500	1750
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT500	1751
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT1000	1751
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT1000	1752
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT2500	1752
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT2500	1753
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT5000	1753
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT5000	1754
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT10000	1754
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT10000	1755
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_GT10000	1755
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_GT10000	1756
 /*! perf: internal page deltas reconstruct latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_TOTAL_USECS	1756
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_TOTAL_USECS	1757
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 1) -
  * 0-100us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT100	1757
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT100	1758
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT250	1758
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT250	1759
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT500	1759
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT500	1760
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT1000	1760
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT1000	1761
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT2500	1761
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT2500	1762
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT5000	1762
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT5000	1763
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT10000	1763
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT10000	1764
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_GT10000	1764
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_GT10000	1765
 /*! perf: leaf page deltas reconstruct latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_TOTAL_USECS	1765
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_TOTAL_USECS	1766
 /*! perf: operation read latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1766
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1767
 /*! perf: operation read latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1767
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1768
 /*! perf: operation read latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1768
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1769
 /*! perf: operation read latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1769
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1770
 /*! perf: operation read latency histogram (bucket 5) - 1000-2499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT2500	1770
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT2500	1771
 /*! perf: operation read latency histogram (bucket 6) - 2500-4999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT5000	1771
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT5000	1772
 /*! perf: operation read latency histogram (bucket 7) - 5000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1772
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1773
 /*! perf: operation read latency histogram (bucket 8) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1773
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1774
 /*! perf: operation read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1774
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1775
 /*! perf: operation write latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1775
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1776
 /*! perf: operation write latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1776
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1777
 /*! perf: operation write latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1777
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1778
 /*! perf: operation write latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1778
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1779
 /*! perf: operation write latency histogram (bucket 5) - 1000-2499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT2500	1779
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT2500	1780
 /*! perf: operation write latency histogram (bucket 6) - 2500-4999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT5000	1780
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT5000	1781
 /*! perf: operation write latency histogram (bucket 7) - 5000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1781
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1782
 /*! perf: operation write latency histogram (bucket 8) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1782
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1783
 /*! perf: operation write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1783
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1784
 /*! prefetch: could not perform pre-fetch on internal page */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1784
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1785
 /*!
  * prefetch: could not perform pre-fetch on ref without the pre-fetch
  * flag set
  */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1785
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1786
 /*! prefetch: number of times pre-fetch failed to start */
-#define	WT_STAT_CONN_PREFETCH_FAILED_START		1786
+#define	WT_STAT_CONN_PREFETCH_FAILED_START		1787
 /*! prefetch: pre-fetch not repeating for recently pre-fetched ref */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1787
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1788
 /*! prefetch: pre-fetch not triggered after single disk read */
-#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1788
+#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1789
 /*! prefetch: pre-fetch not triggered as there is no valid dhandle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1789
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1790
 /*! prefetch: pre-fetch not triggered by page read */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED			1790
+#define	WT_STAT_CONN_PREFETCH_SKIPPED			1791
 /*! prefetch: pre-fetch not triggered due to disk read count */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1791
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1792
 /*! prefetch: pre-fetch not triggered due to internal session */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1792
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1793
 /*! prefetch: pre-fetch not triggered due to special btree handle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1793
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1794
 /*! prefetch: pre-fetch page not on disk when reading */
-#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1794
+#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1795
 /*! prefetch: pre-fetch pages queued */
-#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1795
+#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1796
 /*! prefetch: pre-fetch pages read in background */
-#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1796
+#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1797
 /*! prefetch: pre-fetch skipped reading in a page due to harmless error */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1797
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1798
 /*! prefetch: pre-fetch triggered by page read */
-#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1798
+#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1799
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1799
+#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1800
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1800
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1801
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1801
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1802
 /*!
  * reconciliation: average length of delta chain on internal page with
  * deltas
  */
-#define	WT_STAT_CONN_REC_AVERAGE_INTERNAL_PAGE_DELTA_CHAIN_LENGTH	1802
+#define	WT_STAT_CONN_REC_AVERAGE_INTERNAL_PAGE_DELTA_CHAIN_LENGTH	1803
 /*! reconciliation: average length of delta chain on leaf page with deltas */
-#define	WT_STAT_CONN_REC_AVERAGE_LEAF_PAGE_DELTA_CHAIN_LENGTH	1803
+#define	WT_STAT_CONN_REC_AVERAGE_LEAF_PAGE_DELTA_CHAIN_LENGTH	1804
 /*!
  * reconciliation: changes since prior reconciliation (bucket 1) between
  * 1 and 5
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE5			1804
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE5			1805
 /*!
  * reconciliation: changes since prior reconciliation (bucket 2) between
  * 6 and 10
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE10			1805
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE10			1806
 /*!
  * reconciliation: changes since prior reconciliation (bucket 3) between
  * 11 and 20
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE20			1806
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE20			1807
 /*!
  * reconciliation: changes since prior reconciliation (bucket 4) between
  * 21 and 50
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE50			1807
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE50			1808
 /*!
  * reconciliation: changes since prior reconciliation (bucket 5) between
  * 51 and 100
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE100		1808
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE100		1809
 /*!
  * reconciliation: changes since prior reconciliation (bucket 6) between
  * 101 and 200
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE200		1809
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE200		1810
 /*!
  * reconciliation: changes since prior reconciliation (bucket 7) between
  * 201 and 500
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE500		1810
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE500		1811
 /*!
  * reconciliation: changes since prior reconciliation (bucket 8) greater
  * than 500
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_GT500		1811
+#define	WT_STAT_CONN_REC_PAGE_MODS_GT500		1812
 /*! reconciliation: cursor next/prev calls during HS wrapup search_near */
-#define	WT_STAT_CONN_REC_HS_WRAPUP_NEXT_PREV_CALLS	1812
+#define	WT_STAT_CONN_REC_HS_WRAPUP_NEXT_PREV_CALLS	1813
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1813
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1814
 /*!
  * reconciliation: free page ID due to failed page replacement
  * reconciliation in disagg
  */
-#define	WT_STAT_CONN_REC_FREE_PAGE_ID_DUE_TO_FAILED_REPLACEMENT_RECONCILIATION	1814
+#define	WT_STAT_CONN_REC_FREE_PAGE_ID_DUE_TO_FAILED_REPLACEMENT_RECONCILIATION	1815
 /*! reconciliation: full internal pages written instead of a page delta */
-#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_INTERNAL	1815
+#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_INTERNAL	1816
 /*! reconciliation: full leaf pages written instead of a page delta */
-#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_LEAF		1816
+#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_LEAF		1817
 /*!
  * reconciliation: ingest btree reconciliation keeps the aborted prepare
  * updates
  */
-#define	WT_STAT_CONN_REC_INGEST_KEEP_PREPARE_ROLLBACK	1817
+#define	WT_STAT_CONN_REC_INGEST_KEEP_PREPARE_ROLLBACK	1818
 /*! reconciliation: internal page delta keys deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_DELETED	1818
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_DELETED	1819
 /*! reconciliation: internal page delta keys updated/inserted */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_UPDATED	1819
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_UPDATED	1820
 /*! reconciliation: internal page deltas written */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL		1820
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL		1821
 /*! reconciliation: internal page multi-block writes */
-#define	WT_STAT_CONN_REC_MULTIBLOCK_INTERNAL		1821
+#define	WT_STAT_CONN_REC_MULTIBLOCK_INTERNAL		1822
 /*! reconciliation: leaf page deltas written */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_LEAF		1822
+#define	WT_STAT_CONN_REC_PAGE_DELTA_LEAF		1823
 /*! reconciliation: leaf page multi-block writes */
-#define	WT_STAT_CONN_REC_MULTIBLOCK_LEAF		1823
+#define	WT_STAT_CONN_REC_MULTIBLOCK_LEAF		1824
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1824
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1825
 /*! reconciliation: max deltas seen on internal page during reconciliation */
-#define	WT_STAT_CONN_REC_MAX_INTERNAL_PAGE_DELTAS	1825
+#define	WT_STAT_CONN_REC_MAX_INTERNAL_PAGE_DELTAS	1826
 /*! reconciliation: max deltas seen on leaf page during reconciliation */
-#define	WT_STAT_CONN_REC_MAX_LEAF_PAGE_DELTAS		1826
+#define	WT_STAT_CONN_REC_MAX_LEAF_PAGE_DELTAS		1827
 /*! reconciliation: maximum milliseconds spent in a reconciliation call */
-#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1827
+#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1828
 /*!
  * reconciliation: maximum milliseconds spent in building a disk image in
  * a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1828
+#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1829
 /*!
  * reconciliation: maximum milliseconds spent in moving updates to the
  * history store in a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1829
+#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1830
 /*!
  * reconciliation: number of keys that are garbage collected from the
  * disk images in the ingest btrees for disaggregated storage
  */
-#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_DISK_IMAGE	1830
+#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_DISK_IMAGE	1831
 /*!
  * reconciliation: number of keys that are garbage collected from the
  * update chains in the ingest btrees for disaggregated storage
  */
-#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_UPDATE_CHAIN	1831
+#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_UPDATE_CHAIN	1832
 /*! reconciliation: overflow values written */
-#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1832
+#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1833
 /*! reconciliation: page deltas rejected due to invalid page ID */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_INVALID_PAGE_ID	1833
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_INVALID_PAGE_ID	1834
 /*! reconciliation: page deltas rejected due to max consecutive limit */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MAX_CONSECUTIVE_EXCEEDED	1834
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MAX_CONSECUTIVE_EXCEEDED	1835
 /*! reconciliation: page deltas rejected due to multiblock reconciliation */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MULTIBLOCK	1835
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MULTIBLOCK	1836
 /*!
  * reconciliation: page deltas rejected due to non-single page in
  * previous reconciliation
  */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_NON_SINGLE_PAGE	1836
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_NON_SINGLE_PAGE	1837
 /*! reconciliation: page deltas rejected due to size threshold */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_SIZE_THRESHOLD	1837
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_SIZE_THRESHOLD	1838
 /*! reconciliation: page deltas rejected due to zero entries */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_ZERO_ENTRIES	1838
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_ZERO_ENTRIES	1839
 /*!
  * reconciliation: page deltas rejected: build function returned false
  * (disabled, in-memory split, or internal page constraints not met)
  */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_BUILD_FAILED	1839
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_BUILD_FAILED	1840
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1840
+#define	WT_STAT_CONN_REC_PAGES				1841
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1841
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1842
 /*! reconciliation: page reconciliation calls for pages between 1 and 10MB */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_1MB_TO_10MB		1842
+#define	WT_STAT_CONN_REC_PAGES_SIZE_1MB_TO_10MB		1843
 /*!
  * reconciliation: page reconciliation calls for pages between 10 and
  * 100MB
  */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_10MB_TO_100MB	1843
+#define	WT_STAT_CONN_REC_PAGES_SIZE_10MB_TO_100MB	1844
 /*!
  * reconciliation: page reconciliation calls for pages between 100MB and
  * 1GB
  */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_100MB_TO_1GB	1844
+#define	WT_STAT_CONN_REC_PAGES_SIZE_100MB_TO_1GB	1845
 /*! reconciliation: page reconciliation calls for pages over 1GB */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_1GB_PLUS		1845
+#define	WT_STAT_CONN_REC_PAGES_SIZE_1GB_PLUS		1846
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * prepared transaction metadata
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1846
+#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1847
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * timestamps
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1847
+#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1848
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * transaction ids
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1848
+#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1849
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1849
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1850
 /*! reconciliation: pages eligible for delta generation */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_ELIGIBLE		1850
+#define	WT_STAT_CONN_REC_PAGE_DELTA_ELIGIBLE		1851
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1851
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1852
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1852
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1853
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1853
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1854
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1854
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1855
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1855
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1856
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1856
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1857
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1857
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1858
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1858
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1859
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1859
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1860
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1860
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1861
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1861
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1862
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1862
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1863
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1863
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1864
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1864
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1865
 /*! reconciliation: pages written with at least one internal page delta */
-#define	WT_STAT_CONN_REC_PAGES_WITH_INTERNAL_DELTAS	1865
+#define	WT_STAT_CONN_REC_PAGES_WITH_INTERNAL_DELTAS	1866
 /*! reconciliation: pages written with at least one leaf page delta */
-#define	WT_STAT_CONN_REC_PAGES_WITH_LEAF_DELTAS		1866
+#define	WT_STAT_CONN_REC_PAGES_WITH_LEAF_DELTAS		1867
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1867
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1868
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1868
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1869
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1869
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1870
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1870
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1871
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1871
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1872
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1872
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1873
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1873
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1874
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1874
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1875
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1875
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1876
 /*! reconciliation: writes skipped in disaggregated storage */
-#define	WT_STAT_CONN_REC_SKIP_WRITE			1876
+#define	WT_STAT_CONN_REC_SKIP_WRITE			1877
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1877
+#define	WT_STAT_CONN_SESSION_OPEN			1878
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1878
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1879
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1879
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1880
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1880
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1881
 /*! session: table alter triggering checkpoint calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1881
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1882
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1882
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1883
 /*! session: table compact conflicted with checkpoint */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1883
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1884
 /*! session: table compact dhandle successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1884
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1885
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1885
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1886
 /*! session: table compact failed calls due to cache pressure */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1886
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1887
 /*! session: table compact passes */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1887
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1888
 /*! session: table compact pulled into eviction */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1888
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1889
 /*! session: table compact running */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1889
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1890
 /*! session: table compact skipped as process would not reduce file size */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1890
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1891
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1891
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1892
 /*! session: table compact timeout */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1892
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1893
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1893
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1894
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1894
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1895
 /*! session: table create with import failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1895
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1896
 /*! session: table create with import repair calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1896
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1897
 /*! session: table create with import successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1897
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1898
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1898
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1899
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1899
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1900
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1900
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1901
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1901
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1902
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1902
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1903
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1903
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1904
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1904
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1905
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1905
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1906
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1906
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1907
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1907
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1908
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1908
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1909
 /*! thread-yield: application thread operations waiting for cache */
-#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1909
+#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1910
 /*!
  * thread-yield: application thread operations waiting for interruptible
  * cache eviction
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_OPS	1910
+#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_OPS	1911
 /*!
  * thread-yield: application thread operations waiting for mandatory
  * cache eviction
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_OPS	1911
+#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_OPS	1912
 /*! thread-yield: application thread snapshot refreshed for eviction */
-#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1912
+#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1913
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1913
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1914
 /*!
  * thread-yield: application thread time waiting for interruptible cache
  * eviction (usecs)
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_TIME	1914
+#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_TIME	1915
 /*!
  * thread-yield: application thread time waiting for mandatory cache
  * eviction (usecs)
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_TIME	1915
+#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_TIME	1916
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1916
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1917
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1917
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1918
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1918
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1919
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1919
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1920
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1920
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1921
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1921
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1922
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1922
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1923
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1923
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1924
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1924
+#define	WT_STAT_CONN_PAGE_SLEEP				1925
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1925
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1926
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1926
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1927
 /*! thread-yield: page split and restart read */
-#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1927
+#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1928
 /*! thread-yield: pages skipped during read due to deleted state */
-#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1928
+#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1929
 /*!
  * tiered-storage: attempts to remove a local object and the object is in
  * use
  */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1929
+#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1930
 /*! tiered-storage: flush_tier failed calls */
-#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1930
+#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1931
 /*! tiered-storage: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1931
+#define	WT_STAT_CONN_FLUSH_TIER				1932
 /*! tiered-storage: flush_tier tables skipped due to no checkpoint */
-#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1932
+#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1933
 /*! tiered-storage: flush_tier tables switched */
-#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1933
+#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1934
 /*! tiered-storage: local objects removed */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1934
+#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1935
 /*! tiered-storage: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1935
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1936
 /*! tiered-storage: tiered operations removed without processing */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1936
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1937
 /*! tiered-storage: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1937
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1938
 /*! tiered-storage: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1938
+#define	WT_STAT_CONN_TIERED_RETENTION			1939
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1939
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1940
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1940
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1941
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1941
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1942
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1942
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1943
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1943
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1944
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1944
+#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1945
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1945
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1946
 /*! transaction: oldest transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1946
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1947
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1947
+#define	WT_STAT_CONN_TXN_PREPARE			1948
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1948
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1949
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1949
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1950
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1950
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1951
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1951
+#define	WT_STAT_CONN_TXN_QUERY_TS			1952
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1952
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1953
 /*! transaction: rollback to stable applied btrees */
-#define	WT_STAT_CONN_TXN_RTS_BTREES_APPLIED		1953
+#define	WT_STAT_CONN_TXN_RTS_BTREES_APPLIED		1954
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1954
+#define	WT_STAT_CONN_TXN_RTS				1955
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1955
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1956
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1956
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1957
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1957
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1958
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1958
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1959
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1959
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1960
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1960
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1961
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1961
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1962
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1962
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1963
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1963
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1964
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1964
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1965
 /*! transaction: rollback to stable skipped btrees */
-#define	WT_STAT_CONN_TXN_RTS_BTREES_SKIPPED		1965
+#define	WT_STAT_CONN_TXN_RTS_BTREES_SKIPPED		1966
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1966
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1967
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1967
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1968
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1968
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1969
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1969
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1970
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1970
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1971
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1971
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1972
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1972
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1973
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1973
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1974
 /*!
  * transaction: rollback to stable updates that would have been aborted
  * in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1974
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1975
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1975
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1976
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1976
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1977
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1977
+#define	WT_STAT_CONN_TXN_SET_TS				1978
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1978
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1979
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1979
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1980
 /*! transaction: set timestamp force calls */
-#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1980
+#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1981
 /*!
  * transaction: set timestamp global oldest timestamp set to be more
  * recent than the global stable timestamp
  */
-#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1981
+#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1982
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1982
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1983
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1983
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1984
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1984
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1985
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1985
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1986
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1986
+#define	WT_STAT_CONN_TXN_BEGIN				1987
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1987
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1988
 /*! transaction: transaction global checkpoint timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_CHECKPOINT_TIMESTAMP	1988
+#define	WT_STAT_CONN_TXN_GLOBAL_CHECKPOINT_TIMESTAMP	1989
 /*! transaction: transaction global durable timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_DURABLE_TIMESTAMP	1989
+#define	WT_STAT_CONN_TXN_GLOBAL_DURABLE_TIMESTAMP	1990
 /*! transaction: transaction global last running timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_LAST_RUNNING_TIMESTAMP	1990
+#define	WT_STAT_CONN_TXN_GLOBAL_LAST_RUNNING_TIMESTAMP	1991
 /*! transaction: transaction global newest timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_NEWEST_TIMESTAMP	1991
+#define	WT_STAT_CONN_TXN_GLOBAL_NEWEST_TIMESTAMP	1992
 /*! transaction: transaction global oldest timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_OLDEST_TIMESTAMP	1992
+#define	WT_STAT_CONN_TXN_GLOBAL_OLDEST_TIMESTAMP	1993
 /*! transaction: transaction global pinned timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_PINNED_TIMESTAMP	1993
+#define	WT_STAT_CONN_TXN_GLOBAL_PINNED_TIMESTAMP	1994
 /*! transaction: transaction global stable timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_STABLE_TIMESTAMP	1994
+#define	WT_STAT_CONN_TXN_GLOBAL_STABLE_TIMESTAMP	1995
 /*! transaction: transaction global version cursor timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_VERSION_CURSOR_TIMESTAMP	1995
+#define	WT_STAT_CONN_TXN_GLOBAL_VERSION_CURSOR_TIMESTAMP	1996
 /*!
  * transaction: transaction number of older readers older than oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_READERS			1996
+#define	WT_STAT_CONN_TXN_PINNED_READERS			1997
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1997
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1998
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1998
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1999
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_LAG		1999
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_LAG		2000
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT_LAG	2000
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT_LAG	2001
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER_LAG	2001
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER_LAG	2002
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	2002
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	2003
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	2003
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	2004
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	2004
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	2005
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			2005
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			2006
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				2006
+#define	WT_STAT_CONN_TXN_COMMIT				2007
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			2007
+#define	WT_STAT_CONN_TXN_ROLLBACK			2008
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		2008
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		2009
 
 /*!
  * @}

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -2130,6 +2130,7 @@ static const char *const __stats_connection_desc[] = {
   "cache: internal pages seen by eviction walk",
   "cache: internal pages seen by eviction walk that are already queued",
   "cache: internal pages split during eviction",
+  "cache: leaf pages currently held in the cache",
   "cache: leaf pages split during eviction",
   "cache: locate a random in-mem ref by examining all entries on the root page",
   "cache: maximum bytes configured",
@@ -3198,6 +3199,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->eviction_internal_pages_seen = 0;
     stats->eviction_internal_pages_already_queued = 0;
     stats->cache_eviction_split_internal = 0;
+    /* not clearing cache_pages_inuse_leaf */
     stats->cache_eviction_split_leaf = 0;
     stats->cache_eviction_random_sample_inmem_root = 0;
     /* not clearing cache_bytes_max */
@@ -4314,6 +4316,7 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->eviction_internal_pages_already_queued +=
       WT_STAT_CONN_READ(from, eviction_internal_pages_already_queued);
     to->cache_eviction_split_internal += WT_STAT_CONN_READ(from, cache_eviction_split_internal);
+    to->cache_pages_inuse_leaf += WT_STAT_CONN_READ(from, cache_pages_inuse_leaf);
     to->cache_eviction_split_leaf += WT_STAT_CONN_READ(from, cache_eviction_split_leaf);
     to->cache_eviction_random_sample_inmem_root +=
       WT_STAT_CONN_READ(from, cache_eviction_random_sample_inmem_root);

--- a/test/suite/test_stat15.py
+++ b/test/suite/test_stat15.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wttest
+from wiredtiger import stat
+
+# test_stat15.py
+# Check that cache_pages_inuse and cache_pages_inuse_leaf are correctly tracked
+class test_stat15(wttest.WiredTigerTestCase):
+    uri = 'table:test_stat15'
+
+    conn_config = 'statistics=(all),cache_size=100MB'
+
+    def get_conn_stat(self, stat_key):
+        stat_cursor = self.session.open_cursor('statistics:', None, None)
+        val = stat_cursor[stat_key][2]
+        stat_cursor.close()
+        return val
+
+    def test_cache_pages_inuse_leaf(self):
+        # Create a table and insert enough data to bring leaf pages into cache
+        self.session.create(self.uri, 'key_format=S,value_format=S')
+        cursor = self.session.open_cursor(self.uri, None, None)
+        for i in range(1000):
+            cursor[str(i).zfill(6)] = 'value_' + str(i)
+        cursor.close()
+
+        # Verify leaf pages are in cache
+        leaf_pages = self.get_conn_stat(stat.conn.cache_pages_inuse_leaf)
+        self.assertGreater(leaf_pages, 0,
+            'expected cache_pages_inuse_leaf > 0 after inserting data')
+
+        # Verify total pages >= leaf pages (total includes internal pages too)
+        total_pages = self.get_conn_stat(stat.conn.cache_pages_inuse)
+        self.assertGreaterEqual(total_pages, leaf_pages,
+            'expected cache_pages_inuse >= cache_pages_inuse_leaf')
+
+    def test_cache_pages_inuse_leaf_decreases_after_eviction(self):
+        # Create a table and insert enough data to populate multiple leaf pages
+        self.session.create(self.uri, 'key_format=S,value_format=S')
+        cursor = self.session.open_cursor(self.uri, None, None)
+        for i in range(10000):
+            cursor[str(i).zfill(6)] = 'x' * 1000
+        cursor.close()
+        self.session.checkpoint(None)
+
+        leaf_before = self.get_conn_stat(stat.conn.cache_pages_inuse_leaf)
+        self.assertGreater(leaf_before, 0)
+
+        # Force eviction by reopening the connection (clears cache).
+        self.reopen_conn()
+
+        leaf_after = self.get_conn_stat(stat.conn.cache_pages_inuse_leaf)
+        self.assertLess(leaf_after, leaf_before,
+            'expected cache_pages_inuse_leaf to decrease after cache cleared')


### PR DESCRIPTION
Adding page leaf stats for extra granularity in FTDC stream on T2
Internal page stats will be derived in T2 (total pages - leaf stats)
As mentioned on the ticket, we are still maintaining total pages for backwards compatibility