### PR TITLE
WT-10570 Allow remove operations in test/format running with predictable replay

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -235,7 +235,6 @@ INCR
 INIT
 INMEM
 INPROGRESS
-INSERTs
 INSN
 INTL
 INTRINSICS
@@ -522,7 +521,6 @@ UnmapViewOfFile
 Unmount
 Unpositioned
 Unreferenced
-Upd
 Uryyb
 VARCHAR
 VLCS
@@ -632,7 +630,6 @@ asan
 ascii
 assertEqual
 assertGreater
-assertGreaterEqual
 assertTrue
 assertfmt
 asymptote
@@ -887,7 +884,6 @@ designator
 dest
 destSize
 destructor
-deterministically
 dev
 dh
 dhandle
@@ -1369,6 +1365,7 @@ nop
 nopos
 nops
 noraw
+notfound
 nothex
 notransaction
 notsup
@@ -1694,7 +1691,6 @@ subtest
 subtests
 subtree
 subtrees
-suffixp
 sumv
 sunique
 sunused

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -884,6 +884,7 @@ designator
 dest
 destSize
 destructor
+deterministically
 dev
 dh
 dhandle

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1177,7 +1177,6 @@ keyedness
 keyid
 keyids
 keylen
-keyno
 keynum
 keystr
 keyv

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -235,6 +235,7 @@ INCR
 INIT
 INMEM
 INPROGRESS
+INSERTs
 INSN
 INTL
 INTRINSICS
@@ -1693,6 +1694,7 @@ subtest
 subtests
 subtree
 subtrees
+suffixp
 sumv
 sunique
 sunused

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1365,7 +1365,6 @@ nop
 nopos
 nops
 noraw
-notfound
 nothex
 notransaction
 notsup
@@ -1714,7 +1713,6 @@ tIf
 tV
 tabconfig
 tablename
-tbl
 tc
 tcmalloc
 td

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -886,6 +886,7 @@ designator
 dest
 destSize
 destructor
+deterministically
 dev
 dh
 dhandle
@@ -1179,6 +1180,7 @@ keyedness
 keyid
 keyids
 keylen
+keyno
 keynum
 keystr
 keyv
@@ -1714,6 +1716,7 @@ tIf
 tV
 tabconfig
 tablename
+tbl
 tc
 tcmalloc
 td

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -280,8 +280,6 @@ typedef struct {
     uint64_t stop_timestamp;             /* If non-zero, stop when stable reaches this */
     uint64_t timestamp_copy;             /* A copy of the timestamp, for safety checks */
 
-    FILE *replay_op_log; /* Per-run log of INSERT/UPDATE/REMOVE operations */
-
     uint32_t operation_timeout_ms; /* Requested limit to complete operations in transaction */
 
     /*

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -126,6 +126,7 @@ typedef struct {
     uint64_t last_commit_ts;
     bool in_use;
 } LANE;
+
 #define LANE_NONE UINT32_MAX /* A lane number guaranteed to be illegal */
 #define LANE_COUNT 1024u
 
@@ -279,6 +280,8 @@ typedef struct {
     uint64_t stop_timestamp;             /* If non-zero, stop when stable reaches this */
     uint64_t timestamp_copy;             /* A copy of the timestamp, for safety checks */
 
+    FILE *replay_op_log; /* Per-run log of INSERT/UPDATE/REMOVE operations (lane 1) */
+
     uint32_t operation_timeout_ms; /* Requested limit to complete operations in transaction */
 
     /*
@@ -338,6 +341,12 @@ extern GLOBAL g;
 
 /* Worker thread operations. */
 typedef enum { INSERT = 1, MODIFY, READ, REMOVE, TRUNCATE, UPDATE } thread_op;
+typedef enum {
+    REPLAY_REMOVE_OK = 0,       /* remove fired */
+    REPLAY_REMOVE_SKIP_HISTORY, /* replay_ts too early */
+    REPLAY_REMOVE_SKIP_READ,    /* target_ts was a read */
+    REPLAY_REMOVE_SKIP_PRIOR,   /* target_ts was a remove */
+} replay_remove_result;
 
 /* Worker read operations. */
 typedef enum { NEXT, PREV, SEARCH, SEARCH_NEAR } read_operation;
@@ -391,6 +400,12 @@ typedef struct {
     uint64_t search;
     uint64_t truncate;
     uint64_t update;
+
+    /* Predictable replay remove outcome counters. */
+    uint64_t replay_remove_ok;           /* target was a write; cursor->remove() fired */
+    uint64_t replay_remove_skip_history; /* skipped: not enough history yet */
+    uint64_t replay_remove_skip_read;    /* skipped: target_ts was a read */
+    uint64_t replay_remove_skip_prior;   /* skipped: target_ts was itself a remove */
 
     WT_SESSION *session; /* WiredTiger session */
     WT_CURSOR **cursors; /* WiredTiger cursors, maps one-to-one to tables */
@@ -496,6 +511,7 @@ void timestamp_init(void);
 uint64_t timestamp_minimum_committed(void);
 void timestamp_once(WT_SESSION *, bool, bool);
 void replay_adjust_key(TINFO *, uint64_t);
+replay_remove_result replay_target_remove(TINFO *, TABLE **, uint64_t *, uint64_t *);
 uint64_t replay_commit_ts(TINFO *);
 uint64_t replay_rollback_ts(TINFO *);
 void replay_committed(TINFO *);

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -513,7 +513,7 @@ void timestamp_init(void);
 uint64_t timestamp_minimum_committed(void);
 void timestamp_once(WT_SESSION *, bool, bool);
 void replay_adjust_key(TINFO *, uint64_t);
-replay_remove_result replay_target_remove(TINFO *, TABLE **, uint64_t *, uint64_t *);
+replay_remove_result replay_target_remove(TINFO *, TABLE **, uint64_t *, uint64_t *, const char **);
 uint64_t replay_commit_ts(TINFO *);
 uint64_t replay_rollback_ts(TINFO *);
 void replay_committed(TINFO *);

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -126,7 +126,6 @@ typedef struct {
     uint64_t last_commit_ts;
     bool in_use;
 } LANE;
-
 #define LANE_NONE UINT32_MAX /* A lane number guaranteed to be illegal */
 #define LANE_COUNT 1024u
 

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -341,12 +341,6 @@ extern GLOBAL g;
 
 /* Worker thread operations. */
 typedef enum { INSERT = 1, MODIFY, READ, REMOVE, TRUNCATE, UPDATE } thread_op;
-typedef enum {
-    REPLAY_REMOVE_OK = 0,       /* remove fired */
-    REPLAY_REMOVE_SKIP_HISTORY, /* replay_ts too early */
-    REPLAY_REMOVE_SKIP_READ,    /* target_ts was a read */
-    REPLAY_REMOVE_SKIP_PRIOR,   /* target_ts was a remove */
-} replay_remove_result;
 
 /* Worker read operations. */
 typedef enum { NEXT, PREV, SEARCH, SEARCH_NEAR } read_operation;
@@ -402,12 +396,9 @@ typedef struct {
     uint64_t update;
 
     /* Predictable replay remove outcome counters. */
-    uint64_t replay_remove_ok;           /* target was a write; cursor->remove() fired */
-    uint64_t replay_remove_skip_history; /* skipped: not enough history yet */
-    uint64_t replay_remove_skip_read;    /* skipped: target_ts was a read */
-    uint64_t replay_remove_skip_prior;   /* skipped: target_ts was itself a remove */
-    uint64_t replay_remove_actual;       /* key existed at read_ts; tombstone meaningful */
-    uint64_t replay_remove_dup;          /* key already absent at read_ts; redundant tombstone */
+    uint64_t replay_remove_ok;       /* cursor->remove succeeded */
+    uint64_t replay_remove_notfound; /* cursor->remove returned WT_NOTFOUND */
+    uint64_t replay_remove_rollback; /* cursor->remove returned WT_ROLLBACK */
 
     WT_SESSION *session; /* WiredTiger session */
     WT_CURSOR **cursors; /* WiredTiger cursors, maps one-to-one to tables */
@@ -513,7 +504,7 @@ void timestamp_init(void);
 uint64_t timestamp_minimum_committed(void);
 void timestamp_once(WT_SESSION *, bool, bool);
 void replay_adjust_key(TINFO *, uint64_t);
-replay_remove_result replay_target_remove(TINFO *, TABLE **, uint64_t *, uint64_t *, const char **);
+void replay_pick_bulk_key(TINFO *, TABLE **, uint64_t *);
 uint64_t replay_commit_ts(TINFO *);
 uint64_t replay_rollback_ts(TINFO *);
 void replay_committed(TINFO *);

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -280,7 +280,7 @@ typedef struct {
     uint64_t stop_timestamp;             /* If non-zero, stop when stable reaches this */
     uint64_t timestamp_copy;             /* A copy of the timestamp, for safety checks */
 
-    FILE *replay_op_log; /* Per-run log of INSERT/UPDATE/REMOVE operations (lane 1) */
+    FILE *replay_op_log; /* Per-run log of INSERT/UPDATE/REMOVE operations */
 
     uint32_t operation_timeout_ms; /* Requested limit to complete operations in transaction */
 
@@ -394,11 +394,6 @@ typedef struct {
     uint64_t search;
     uint64_t truncate;
     uint64_t update;
-
-    /* Predictable replay remove outcome counters. */
-    uint64_t replay_remove_ok;       /* cursor->remove succeeded */
-    uint64_t replay_remove_notfound; /* cursor->remove returned WT_NOTFOUND */
-    uint64_t replay_remove_rollback; /* cursor->remove returned WT_ROLLBACK */
 
     WT_SESSION *session; /* WiredTiger session */
     WT_CURSOR **cursors; /* WiredTiger cursors, maps one-to-one to tables */

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -504,7 +504,6 @@ void timestamp_init(void);
 uint64_t timestamp_minimum_committed(void);
 void timestamp_once(WT_SESSION *, bool, bool);
 void replay_adjust_key(TINFO *, uint64_t);
-void replay_pick_bulk_key(TINFO *, TABLE **, uint64_t *);
 uint64_t replay_commit_ts(TINFO *);
 uint64_t replay_rollback_ts(TINFO *);
 void replay_committed(TINFO *);

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -406,6 +406,8 @@ typedef struct {
     uint64_t replay_remove_skip_history; /* skipped: not enough history yet */
     uint64_t replay_remove_skip_read;    /* skipped: target_ts was a read */
     uint64_t replay_remove_skip_prior;   /* skipped: target_ts was itself a remove */
+    uint64_t replay_remove_actual;       /* key existed at read_ts; tombstone meaningful */
+    uint64_t replay_remove_dup;          /* key already absent at read_ts; redundant tombstone */
 
     WT_SESSION *session; /* WiredTiger session */
     WT_CURSOR **cursors; /* WiredTiger cursors, maps one-to-one to tables */

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -356,14 +356,6 @@ operations(u_int ops_seconds, u_int run_current, u_int run_total)
 
     replay_run_begin(session);
 
-    if (GV(RUNS_PREDICTABLE_REPLAY)) {
-        char replay_log_path[MAX_FORMAT_PATH];
-        testutil_snprintf(
-          replay_log_path, sizeof(replay_log_path), "%s/replay_ops_%u.log", g.home, run_current);
-        g.replay_op_log = fopen(replay_log_path, "w");
-        testutil_assertfmt(g.replay_op_log != NULL, "failed to open %s", replay_log_path);
-    }
-
     for (i = 0; i < GV(RUNS_THREADS); ++i) {
         tinfo = tinfo_list[i];
         testutil_check(__wt_thread_create(NULL, &tinfo->tid, ops, tinfo));
@@ -508,11 +500,6 @@ operations(u_int ops_seconds, u_int run_current, u_int run_total)
     rollback_to_stable(session);
 
     disagg_sync_multi_node(session);
-
-    if (g.replay_op_log != NULL) {
-        fclose(g.replay_op_log);
-        g.replay_op_log = NULL;
-    }
 
     replay_run_end(session);
 
@@ -1022,11 +1009,9 @@ ops(void *arg)
     iso_level_t iso_level;
     thread_op op;
     uint64_t reset_op, session_op, throttle_delay, truncate_op;
-    uint64_t rlog_keyno, rlog_lane, rlog_read_ts, rlog_ts;
     uint32_t max_rows, ntries, range, rnd;
-    u_int i, rlog_table_id, throttle_delay_max;
-    int rlog_ret;
-    const char *iso_config, *rlog_op_name;
+    u_int i, throttle_delay_max;
+    const char *iso_config;
     bool greater_than, intxn, prepared, mirrored_truncate;
 
     tinfo = arg;
@@ -1049,10 +1034,6 @@ ops(void *arg)
     iso_level = ISOLATION_SNAPSHOT; /* -Wconditional-uninitialized */
     tinfo->replay_again = false;
     tinfo->lane = LANE_NONE;
-    rlog_keyno = rlog_lane = rlog_read_ts = rlog_ts = 0;
-    rlog_table_id = 0;
-    rlog_ret = 0;
-    rlog_op_name = NULL;
 
     /*
      * Calculate max delay so that per-table ops/sec is as set. We use 2* here as our random
@@ -1086,15 +1067,13 @@ rollback_retry:
 
         ++tinfo->ops;
 
-        if (!tinfo->replay_again) {
+        if (!tinfo->replay_again)
             /*
              * Number of failures so far for the current operation and key. In predictable replay,
              * unless we have a read operation, we cannot give up on any operation and maintain the
              * integrity of the replay.
              */
             ntries = 0;
-            rlog_op_name = NULL;
-        }
 
         /* Number of tries only gets incremented during predictable replay. */
         testutil_assert(ntries == 0 || (!intxn && tinfo->replay_again));
@@ -1234,35 +1213,6 @@ rollback_retry:
         }
         replay_adjust_key(tinfo, max_rows);
 
-        if (GV(RUNS_PREDICTABLE_REPLAY)) {
-            rlog_lane = tinfo->lane;
-            rlog_ts = tinfo->replay_ts;
-            rlog_read_ts = tinfo->read_ts;
-            rlog_keyno = tinfo->keyno;
-            rlog_table_id = table->id;
-            rlog_ret = 0;
-            switch (op) {
-            case REMOVE:
-                rlog_op_name = "REMOVE";
-                break;
-            case INSERT:
-                rlog_op_name = "INSERT";
-                break;
-            case READ:
-                rlog_op_name = "READ";
-                break;
-            case UPDATE:
-                rlog_op_name = "UPDATE";
-                break;
-            case MODIFY:
-                rlog_op_name = "MODIFY";
-                break;
-            case TRUNCATE:
-                rlog_op_name = "TRUNCATE";
-                break;
-            }
-        }
-
         /*
          * If the operation is a truncate, select a range.
          *
@@ -1387,8 +1337,6 @@ rollback_retry:
                         __wt_yield();
                     goto rollback;
                 }
-                if (op == REMOVE)
-                    rlog_ret = tinfo->op_ret;
             }
             skip2 = table;
         }
@@ -1474,16 +1422,6 @@ skip_operation:
             prepared = true;
         }
 
-/*
- * Emit a replay log line to the per-run log file. Defined here so it can be used in the commit case
- * below.
- */
-#define rlog_emit(fmt, ...)                             \
-    do {                                                \
-        if (g.replay_op_log != NULL)                    \
-            fprintf(g.replay_op_log, fmt, __VA_ARGS__); \
-    } while (0)
-
         /*
          * If we're in a transaction, commit 40% of the time and rollback 10% of the time (we
          * already continued to add operations to the transaction the remaining half of the time).
@@ -1496,13 +1434,6 @@ skip_operation:
             __wt_yield(); /* Encourage races */
             commit_transaction(tinfo, prepared);
             snap_repeat_update(tinfo, true);
-            if (rlog_op_name != NULL) {
-                rlog_emit("%s lane=%" PRIu64 " ts=%" PRIu64 " read_ts=%" PRIu64 " keyno=%" PRIu64
-                          " tbl=%u ret=%d\n",
-                  rlog_op_name, rlog_lane, rlog_ts, rlog_read_ts, rlog_keyno, rlog_table_id,
-                  rlog_ret);
-                rlog_op_name = NULL;
-            }
             break;
         case 5: /* 10% */
 rollback:
@@ -1523,7 +1454,6 @@ rollback:
             snap_repeat_update(tinfo, false);
             break;
         }
-#undef rlog_emit
 
         /*
          * If this operation was a mirrored truncate, verify the mirrors. This runs after both

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -2143,6 +2143,11 @@ row_remove(TINFO *tinfo, bool positioned)
         cursor->set_key(cursor, tinfo->key);
     }
 
+    /*
+     * Call cursor->remove() directly. A prior search guard was removed because overwrite mode does
+     * not affect cursor->remove() (it always checks read_ts visibility), and the search result
+     * would (with an old read_ts) incorrectly return WT_NOTFOUND when we actually want WT_ROLLBACK.
+     */
     ret = cursor->remove(cursor);
 
     if (ret != 0 && ret != WT_NOTFOUND)
@@ -2169,6 +2174,7 @@ col_remove(TINFO *tinfo, bool positioned)
     if (!positioned)
         cursor->set_key(cursor, tinfo->keyno);
 
+    /* See row_remove for the rationale behind calling cursor->remove() directly. */
     ret = cursor->remove(cursor);
 
     if (ret != 0 && ret != WT_NOTFOUND)

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -772,20 +772,20 @@ table_op(TINFO *tinfo, bool intxn, iso_level_t iso_level, thread_op op)
      * For this reason, always insert new records (or update previously inserted new records), when
      * inserting into a mirror group. For the same reason, don't reserve a row, that will position
      * the cursor and lead us into an update.
+     *
+     * Both pre-positioning and reserve are skipped for predictable replay because their success
+     * depends on key visibility at the non-deterministic read timestamp. If either succeeds in one
+     * run but fails in another, positioned differs, which changes whether key_gen_insert consumes
+     * data_rnd, causing the commit/rollback decision to diverge.
      */
     positioned = false;
-    if (op != TRUNCATE && (op != INSERT || !table->mirror)) {
+    if (op != TRUNCATE && (op != INSERT || !table->mirror) && !GV(RUNS_PREDICTABLE_REPLAY)) {
         /*
          * Inserts, removes and updates can be done following a cursor set-key, or based on a cursor
          * position taken from a previous search. If not already doing a read, position the cursor
          * at an existing point in the tree 20% of the time.
-         *
-         * For predictable replay, skip the pre-positioning search. read_row() depends on key
-         * visibility at the non-deterministic read timestamp. If it succeeds in one run but fails
-         * in another, positioned differs, which changes whether key_gen_insert consumes data_rnd,
-         * causing all subsequent random decisions to diverge.
          */
-        if (!GV(RUNS_PREDICTABLE_REPLAY) && op != READ && mmrand(&tinfo->data_rnd, 1, 5) == 1) {
+        if (op != READ && mmrand(&tinfo->data_rnd, 1, 5) == 1) {
             ++tinfo->search;
             ret = read_row(tinfo);
             if (ret == 0) {
@@ -800,14 +800,9 @@ table_op(TINFO *tinfo, bool intxn, iso_level_t iso_level, thread_op op)
          * can't be done at lower isolation levels). Reserving a row in an implicit transaction will
          * work, but doesn't make sense. Reserving a row before a read won't be useful but it's not
          * unexpected. A row cannot be reserved with ignore prepare.
-         *
-         * For predictable replay, skip the reserve. cursor->reserve() depends on key visibility at
-         * the non-deterministic read timestamp. If it succeeds in one run but fails in another,
-         * positioned differs, which changes whether key_gen_insert consumes data_rnd, causing all
-         * subsequent random decisions to diverge.
          */
-        if (!GV(RUNS_PREDICTABLE_REPLAY) && intxn && iso_level == ISOLATION_SNAPSHOT &&
-          tinfo->ignore_prepare == false && mmrand(&tinfo->data_rnd, 0, 100) < GV(OPS_RESERVE)) {
+        if (intxn && iso_level == ISOLATION_SNAPSHOT && tinfo->ignore_prepare == false &&
+          mmrand(&tinfo->data_rnd, 0, 100) < GV(OPS_RESERVE)) {
             switch (table->type) {
             case ROW:
                 ret = row_reserve(tinfo, positioned);

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -511,17 +511,27 @@ operations(u_int ops_seconds, u_int run_current, u_int run_total)
 
     if (g.replay_op_log != NULL) {
         uint64_t ok = 0, skip_history = 0, skip_read = 0, skip_prior = 0;
+        uint64_t actual = 0, dup = 0;
         TINFO **tlp;
         for (tlp = tinfo_list; *tlp != NULL; ++tlp) {
             ok += (*tlp)->replay_remove_ok;
             skip_history += (*tlp)->replay_remove_skip_history;
             skip_read += (*tlp)->replay_remove_skip_read;
             skip_prior += (*tlp)->replay_remove_skip_prior;
+            actual += (*tlp)->replay_remove_actual;
+            dup += (*tlp)->replay_remove_dup;
         }
-        fprintf(g.replay_op_log,
-          "REMOVE summary: fired=%" PRIu64 " skipped=%" PRIu64 " (no-history=%" PRIu64
-          " target-read=%" PRIu64 " target-remove=%" PRIu64 ")\n",
+#define summary_print(fmt, ...)                          \
+    do {                                                 \
+        fprintf(stderr, fmt, __VA_ARGS__);               \
+        fprintf(g.replay_op_log, fmt, __VA_ARGS__);      \
+    } while (0)
+        summary_print("REMOVE summary: fired=%" PRIu64 " skipped=%" PRIu64 " (no-history=%"
+          PRIu64 " target-read=%" PRIu64 " target-remove=%" PRIu64 ")\n",
           ok, skip_history + skip_read + skip_prior, skip_history, skip_read, skip_prior);
+        summary_print("REMOVE tombstones: actual=%" PRIu64 " dup=%" PRIu64 " (%.1f%% redundant)\n",
+          actual, dup, (actual + dup) > 0 ? 100.0 * dup / (actual + dup) : 0.0);
+#undef summary_print
         fclose(g.replay_op_log);
         g.replay_op_log = NULL;
     }
@@ -2264,12 +2274,18 @@ row_remove(TINFO *tinfo, bool positioned)
 
     /*
      * We use the cursor in overwrite mode, check for existence. For predictable replay, skip the
-     * search and call remove directly overwrite mode writes a tombstone at commit_ts regardless of
-     * key visibility at read_ts, making the outcome deterministic across runs.
+     * search and call remove directly — overwrite mode writes a tombstone at commit_ts regardless
+     * of key visibility at read_ts, making the outcome deterministic across runs.
+     *
+     * Do a probe search first to count actual vs redundant tombstones.
      */
-    if (GV(RUNS_PREDICTABLE_REPLAY))
+    if (GV(RUNS_PREDICTABLE_REPLAY)) {
+        if (read_op(cursor, SEARCH, NULL) == 0)
+            ++tinfo->replay_remove_actual;
+        else
+            ++tinfo->replay_remove_dup;
         ret = cursor->remove(cursor);
-    else if ((ret = read_op(cursor, SEARCH, NULL)) == 0)
+    } else if ((ret = read_op(cursor, SEARCH, NULL)) == 0)
         ret = cursor->remove(cursor);
 
     if (ret != 0 && ret != WT_NOTFOUND)
@@ -2296,10 +2312,14 @@ col_remove(TINFO *tinfo, bool positioned)
     if (!positioned)
         cursor->set_key(cursor, tinfo->keyno);
 
-    /* See row_remove for the predictable replay rationale. */
-    if (GV(RUNS_PREDICTABLE_REPLAY))
+    /* See row_remove for the predictable replay rationale and probe-search counting. */
+    if (GV(RUNS_PREDICTABLE_REPLAY)) {
+        if (read_op(cursor, SEARCH, NULL) == 0)
+            ++tinfo->replay_remove_actual;
+        else
+            ++tinfo->replay_remove_dup;
         ret = cursor->remove(cursor);
-    else if ((ret = read_op(cursor, SEARCH, NULL)) == 0)
+    } else if ((ret = read_op(cursor, SEARCH, NULL)) == 0)
         ret = cursor->remove(cursor);
 
     if (ret != 0 && ret != WT_NOTFOUND)

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -356,6 +356,14 @@ operations(u_int ops_seconds, u_int run_current, u_int run_total)
 
     replay_run_begin(session);
 
+    if (GV(RUNS_PREDICTABLE_REPLAY)) {
+        char replay_log_path[MAX_FORMAT_PATH];
+        testutil_snprintf(
+          replay_log_path, sizeof(replay_log_path), "%s/replay_ops_%u.log", g.home, run_current);
+        g.replay_op_log = fopen(replay_log_path, "w");
+        testutil_assertfmt(g.replay_op_log != NULL, "failed to open %s", replay_log_path);
+    }
+
     for (i = 0; i < GV(RUNS_THREADS); ++i) {
         tinfo = tinfo_list[i];
         testutil_check(__wt_thread_create(NULL, &tinfo->tid, ops, tinfo));
@@ -500,6 +508,23 @@ operations(u_int ops_seconds, u_int run_current, u_int run_total)
     rollback_to_stable(session);
 
     disagg_sync_multi_node(session);
+
+    if (g.replay_op_log != NULL) {
+        uint64_t ok = 0, skip_history = 0, skip_read = 0, skip_prior = 0;
+        TINFO **tlp;
+        for (tlp = tinfo_list; *tlp != NULL; ++tlp) {
+            ok += (*tlp)->replay_remove_ok;
+            skip_history += (*tlp)->replay_remove_skip_history;
+            skip_read += (*tlp)->replay_remove_skip_read;
+            skip_prior += (*tlp)->replay_remove_skip_prior;
+        }
+        fprintf(g.replay_op_log,
+          "REMOVE summary: fired=%" PRIu64 " skipped=%" PRIu64 " (no-history=%" PRIu64
+          " target-read=%" PRIu64 " target-remove=%" PRIu64 ")\n",
+          ok, skip_history + skip_read + skip_prior, skip_history, skip_read, skip_prior);
+        fclose(g.replay_op_log);
+        g.replay_op_log = NULL;
+    }
 
     replay_run_end(session);
 
@@ -779,8 +804,12 @@ table_op(TINFO *tinfo, bool intxn, iso_level_t iso_level, thread_op op)
          * Inserts, removes and updates can be done following a cursor set-key, or based on a cursor
          * position taken from a previous search. If not already doing a read, position the cursor
          * at an existing point in the tree 20% of the time.
+         *
+         * For predictable replay, don't pre-position the cursor. Each operation must be
+         * independent, always using the explicit set-key path with the key derived from the replay
+         * timestamp.
          */
-        if (op != READ && mmrand(&tinfo->data_rnd, 1, 5) == 1) {
+        if (!GV(RUNS_PREDICTABLE_REPLAY) && op != READ && mmrand(&tinfo->data_rnd, 1, 5) == 1) {
             ++tinfo->search;
             ret = read_row(tinfo);
             if (ret == 0) {
@@ -795,9 +824,14 @@ table_op(TINFO *tinfo, bool intxn, iso_level_t iso_level, thread_op op)
          * can't be done at lower isolation levels). Reserving a row in an implicit transaction will
          * work, but doesn't make sense. Reserving a row before a read won't be useful but it's not
          * unexpected. A row cannot be reserved with ignore prepare.
+         *
+         * For predictable replay, skip the reserve. cursor->reserve() depends on key visibility at
+         * the non-deterministic read timestamp. If it succeeds in one run but fails in another,
+         * positioned differs, which changes whether key_gen_insert consumes data_rnd, causing all
+         * subsequent random decisions to diverge.
          */
-        if (intxn && iso_level == ISOLATION_SNAPSHOT && tinfo->ignore_prepare == false &&
-          mmrand(&tinfo->data_rnd, 0, 100) < GV(OPS_RESERVE)) {
+        if (!GV(RUNS_PREDICTABLE_REPLAY) && intxn && iso_level == ISOLATION_SNAPSHOT &&
+          tinfo->ignore_prepare == false && mmrand(&tinfo->data_rnd, 0, 100) < GV(OPS_RESERVE)) {
             switch (table->type) {
             case ROW:
                 ret = row_reserve(tinfo, positioned);
@@ -996,10 +1030,12 @@ ops(void *arg)
     iso_level_t iso_level;
     thread_op op;
     uint64_t reset_op, session_op, throttle_delay, truncate_op;
+    uint64_t rlog_keyno, rlog_lane, rlog_read_ts, rlog_ts, rlog_write_ts;
     uint32_t max_rows, ntries, range, rnd;
-    u_int i, throttle_delay_max;
-    const char *iso_config;
+    u_int i, rlog_table_id, throttle_delay_max;
+    const char *iso_config, *rlog_skip_reason, *rlog_op_name;
     bool greater_than, intxn, prepared, mirrored_truncate;
+    bool rlog_remove, rlog_to_update, rlog_write;
 
     tinfo = arg;
     mirrored_truncate = false;
@@ -1021,6 +1057,10 @@ ops(void *arg)
     iso_level = ISOLATION_SNAPSHOT; /* -Wconditional-uninitialized */
     tinfo->replay_again = false;
     tinfo->lane = LANE_NONE;
+    rlog_remove = rlog_to_update = rlog_write = false;
+    rlog_keyno = rlog_lane = rlog_read_ts = rlog_ts = rlog_write_ts = 0;
+    rlog_table_id = 0;
+    rlog_skip_reason = rlog_op_name = NULL;
 
     /*
      * Calculate max delay so that per-table ops/sec is as set. We use 2* here as our random
@@ -1199,6 +1239,66 @@ rollback_retry:
                 tinfo->keyno++;
         }
         replay_adjust_key(tinfo, max_rows);
+
+        /*
+         * For predictable replay removes: derive the target key deterministically from replay_ts by
+         * re-simulating the data_rnd state at a randomly chosen earlier timestamp in the same lane.
+         * The cursor uses overwrite mode so remove() writes a tombstone at commit_ts regardless of
+         * key visibility at read_ts.
+         */
+        if (GV(RUNS_PREDICTABLE_REPLAY)) {
+            if (op == REMOVE) {
+                TABLE *target_table;
+                uint64_t target_keyno, target_ts;
+                replay_remove_result remove_result;
+
+                remove_result =
+                  replay_target_remove(tinfo, &target_table, &target_keyno, &target_ts);
+                if (remove_result == REPLAY_REMOVE_OK) {
+                    ++tinfo->replay_remove_ok;
+                    if (tinfo->lane == 1) {
+                        rlog_remove = true;
+                        rlog_lane = tinfo->lane;
+                        rlog_ts = tinfo->replay_ts;
+                        rlog_read_ts = tinfo->read_ts;
+                        rlog_keyno = target_keyno;
+                        rlog_write_ts = target_ts;
+                        rlog_table_id = target_table->id;
+                    }
+                    tinfo->keyno = target_keyno;
+                    table = tinfo->table = target_table;
+                } else {
+                    if (remove_result == REPLAY_REMOVE_SKIP_HISTORY)
+                        ++tinfo->replay_remove_skip_history;
+                    else if (remove_result == REPLAY_REMOVE_SKIP_READ)
+                        ++tinfo->replay_remove_skip_read;
+                    else
+                        ++tinfo->replay_remove_skip_prior;
+                    if (tinfo->lane == 1) {
+                        static const char *const skip_names[] = {
+                          [REPLAY_REMOVE_SKIP_HISTORY] = "not enough history",
+                          [REPLAY_REMOVE_SKIP_READ] = "target was a read",
+                          [REPLAY_REMOVE_SKIP_PRIOR] = "target was a remove",
+                        };
+                        rlog_to_update = true;
+                        rlog_skip_reason = skip_names[remove_result];
+                        rlog_lane = tinfo->lane;
+                        rlog_ts = tinfo->replay_ts;
+                    }
+                    op = UPDATE;
+                }
+            }
+            /* Log all non-remove operations for lane 1. */
+            if (tinfo->lane == 1 && (op == INSERT || op == READ || op == UPDATE)) {
+                rlog_write = true;
+                rlog_op_name = op == INSERT ? "INSERT" : (op == READ ? "READ" : "UPDATE");
+                rlog_lane = tinfo->lane;
+                rlog_ts = tinfo->replay_ts;
+                rlog_read_ts = tinfo->read_ts;
+                rlog_keyno = tinfo->keyno;
+                rlog_table_id = table->id;
+            }
+        }
 
         /*
          * If the operation is a truncate, select a range.
@@ -1387,6 +1487,17 @@ skip_operation:
             prepared = true;
         }
 
+/*
+ * Emit a replay log line to stderr and to the per-run log file. Defined here so it can be used in
+ * the commit case below.
+ */
+#define rlog_emit(fmt, ...)                             \
+    do {                                                \
+        fprintf(stderr, fmt, __VA_ARGS__);              \
+        if (g.replay_op_log != NULL)                    \
+            fprintf(g.replay_op_log, fmt, __VA_ARGS__); \
+    } while (0)
+
         /*
          * If we're in a transaction, commit 40% of the time and rollback 10% of the time (we
          * already continued to add operations to the transaction the remaining half of the time).
@@ -1399,6 +1510,23 @@ skip_operation:
             __wt_yield(); /* Encourage races */
             commit_transaction(tinfo, prepared);
             snap_repeat_update(tinfo, true);
+            if (rlog_remove) {
+                rlog_emit("REMOVE lane=%" PRIu64 " ts=%" PRIu64 " read_ts=%" PRIu64
+                          " -> remove keyno=%" PRIu64 " target_ts=%" PRIu64 " tbl=%u\n",
+                  rlog_lane, rlog_ts, rlog_read_ts, rlog_keyno, rlog_write_ts, rlog_table_id);
+                rlog_remove = false;
+            }
+            if (rlog_to_update) {
+                rlog_emit("REMOVE lane=%" PRIu64 " ts=%" PRIu64 " -> UPDATE (%s)\n", rlog_lane,
+                  rlog_ts, rlog_skip_reason);
+                rlog_to_update = false;
+            }
+            if (rlog_write) {
+                rlog_emit("%s lane=%" PRIu64 " ts=%" PRIu64 " read_ts=%" PRIu64 " keyno=%" PRIu64
+                          " tbl=%u\n",
+                  rlog_op_name, rlog_lane, rlog_ts, rlog_read_ts, rlog_keyno, rlog_table_id);
+                rlog_write = false;
+            }
             break;
         case 5: /* 10% */
 rollback:
@@ -1419,6 +1547,7 @@ rollback:
             snap_repeat_update(tinfo, false);
             break;
         }
+#undef rlog_emit
 
         /*
          * If this operation was a mirrored truncate, verify the mirrors. This runs after both
@@ -2133,8 +2262,14 @@ row_remove(TINFO *tinfo, bool positioned)
         cursor->set_key(cursor, tinfo->key);
     }
 
-    /* We use the cursor in overwrite mode, check for existence. */
-    if ((ret = read_op(cursor, SEARCH, NULL)) == 0)
+    /*
+     * We use the cursor in overwrite mode, check for existence. For predictable replay, skip the
+     * search and call remove directly overwrite mode writes a tombstone at commit_ts regardless of
+     * key visibility at read_ts, making the outcome deterministic across runs.
+     */
+    if (GV(RUNS_PREDICTABLE_REPLAY))
+        ret = cursor->remove(cursor);
+    else if ((ret = read_op(cursor, SEARCH, NULL)) == 0)
         ret = cursor->remove(cursor);
 
     if (ret != 0 && ret != WT_NOTFOUND)
@@ -2161,8 +2296,10 @@ col_remove(TINFO *tinfo, bool positioned)
     if (!positioned)
         cursor->set_key(cursor, tinfo->keyno);
 
-    /* We use the cursor in overwrite mode, check for existence. */
-    if ((ret = read_op(cursor, SEARCH, NULL)) == 0)
+    /* See row_remove for the predictable replay rationale. */
+    if (GV(RUNS_PREDICTABLE_REPLAY))
+        ret = cursor->remove(cursor);
+    else if ((ret = read_op(cursor, SEARCH, NULL)) == 0)
         ret = cursor->remove(cursor);
 
     if (ret != 0 && ret != WT_NOTFOUND)

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -784,6 +784,8 @@ table_op(TINFO *tinfo, bool intxn, iso_level_t iso_level, thread_op op)
          * Inserts, removes and updates can be done following a cursor set-key, or based on a cursor
          * position taken from a previous search. If not already doing a read, position the cursor
          * at an existing point in the tree 20% of the time.
+         *
+         * FIXME-WT-17260: Enable pre-positioning the cursor in predictable replay mode.
          */
         if (op != READ && mmrand(&tinfo->data_rnd, 1, 5) == 1) {
             ++tinfo->search;
@@ -2139,9 +2141,15 @@ row_remove(TINFO *tinfo, bool positioned)
     }
 
     /*
-     * Call cursor->remove() directly. A prior search guard was removed because overwrite mode does
-     * not affect cursor->remove() (it always checks read_ts visibility), and the search result
-     * would (with an old read_ts) incorrectly return WT_NOTFOUND when we actually want WT_ROLLBACK.
+     * Call cursor->remove() directly. A prior search guard was removed because overwrite mode no
+     * longer has any effect on cursor->remove(), and the search result sometimes incorrectly
+     * returns WT_NOTFOUND when we actually want WT_ROLLBACK. This can happen when the search sees a
+     * tombstone, but there are newer invisible updates. Whether the search succeeds or not depends
+     * on the current read_ts, which varies non-deterministically across runs.
+     *
+     * In predictable replay mode, this violates our assumption that every operation succeeds or
+     * fails deterministically, since the remove could fail with WT_NOTFOUND in one run and
+     * succeeded in another after rolling back and retrying with a higher read_ts.
      */
     ret = cursor->remove(cursor);
 

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -510,7 +510,7 @@ operations(u_int ops_seconds, u_int run_current, u_int run_total)
     disagg_sync_multi_node(session);
 
     if (g.replay_op_log != NULL) {
-        uint64_t ok = 0, skip_history = 0, skip_read = 0, skip_prior = 0;
+        uint64_t ok = 0, skip_history = 0, skip_read = 0, skip_prior = 0, skipped;
         uint64_t actual = 0, dup = 0;
         TINFO **tlp;
         for (tlp = tinfo_list; *tlp != NULL; ++tlp) {
@@ -521,14 +521,18 @@ operations(u_int ops_seconds, u_int run_current, u_int run_total)
             actual += (*tlp)->replay_remove_actual;
             dup += (*tlp)->replay_remove_dup;
         }
+        skipped = skip_history + skip_read + skip_prior;
 #define summary_print(fmt, ...)                     \
     do {                                            \
         fprintf(stderr, fmt, __VA_ARGS__);          \
         fprintf(g.replay_op_log, fmt, __VA_ARGS__); \
     } while (0)
-        summary_print("REMOVE summary: fired=%" PRIu64 " skipped=%" PRIu64 " (no-history=%" PRIu64
-                      " target-read=%" PRIu64 " target-remove=%" PRIu64 ")\n",
-          ok, skip_history + skip_read + skip_prior, skip_history, skip_read, skip_prior);
+        summary_print("REMOVE summary: fired=%" PRIu64 " skipped=%" PRIu64
+                      " (%.1f%% skipped)"
+                      " (no-history=%" PRIu64 " target-read=%" PRIu64 " target-remove=%" PRIu64
+                      ")\n",
+          ok, skipped, (ok + skipped) > 0 ? 100.0 * skipped / (ok + skipped) : 0.0, skip_history,
+          skip_read, skip_prior);
         summary_print("REMOVE tombstones: actual=%" PRIu64 " dup=%" PRIu64 " (%.1f%% redundant)\n",
           actual, dup, (actual + dup) > 0 ? 100.0 * dup / (actual + dup) : 0.0);
 #undef summary_print
@@ -931,8 +935,12 @@ table_op(TINFO *tinfo, bool intxn, iso_level_t iso_level, thread_op op)
             /*
              * Don't set positioned: it's unchanged from the previous state, but not necessarily
              * set.
+             *
+             * Skip snap tracking for predictable replay removes: the tombstone is at commit_ts
+             * (replay_ts) which is above read_ts, so the key is not visibly deleted at read_ts.
              */
-            SNAP_TRACK(tinfo, REMOVE);
+            if (!GV(RUNS_PREDICTABLE_REPLAY))
+                SNAP_TRACK(tinfo, REMOVE);
         } else
             OP_FAILED(true);
         break;
@@ -1043,7 +1051,7 @@ ops(void *arg)
     uint64_t rlog_keyno, rlog_lane, rlog_read_ts, rlog_ts, rlog_write_ts;
     uint32_t max_rows, ntries, range, rnd;
     u_int i, rlog_table_id, throttle_delay_max;
-    const char *iso_config, *rlog_skip_reason, *rlog_op_name;
+    const char *iso_config, *rlog_skip_reason, *rlog_op_name, *rlog_suffix;
     bool greater_than, intxn, prepared, mirrored_truncate;
     bool rlog_remove, rlog_to_update, rlog_write;
 
@@ -1071,6 +1079,7 @@ ops(void *arg)
     rlog_keyno = rlog_lane = rlog_read_ts = rlog_ts = rlog_write_ts = 0;
     rlog_table_id = 0;
     rlog_skip_reason = rlog_op_name = NULL;
+    rlog_suffix = "00";
 
     /*
      * Calculate max delay so that per-table ops/sec is as set. We use 2* here as our random
@@ -1260,10 +1269,11 @@ rollback_retry:
             if (op == REMOVE) {
                 TABLE *target_table;
                 uint64_t target_keyno, target_ts;
+                const char *target_suffix;
                 replay_remove_result remove_result;
 
-                remove_result =
-                  replay_target_remove(tinfo, &target_table, &target_keyno, &target_ts);
+                remove_result = replay_target_remove(
+                  tinfo, &target_table, &target_keyno, &target_ts, &target_suffix);
                 if (remove_result == REPLAY_REMOVE_OK) {
                     ++tinfo->replay_remove_ok;
                     if (tinfo->lane == 1) {
@@ -1274,9 +1284,12 @@ rollback_retry:
                         rlog_keyno = target_keyno;
                         rlog_write_ts = target_ts;
                         rlog_table_id = target_table->id;
+                        rlog_suffix = target_suffix;
                     }
                     tinfo->keyno = target_keyno;
                     table = tinfo->table = target_table;
+                    if (target_table->type == ROW)
+                        key_gen_common(target_table, tinfo->key, target_keyno, target_suffix);
                 } else {
                     if (remove_result == REPLAY_REMOVE_SKIP_HISTORY)
                         ++tinfo->replay_remove_skip_history;
@@ -1302,6 +1315,8 @@ rollback_retry:
             if (tinfo->lane == 1 && (op == INSERT || op == READ || op == UPDATE)) {
                 rlog_write = true;
                 rlog_op_name = op == INSERT ? "INSERT" : (op == READ ? "READ" : "UPDATE");
+                /* INSERT suffix is determined inside row_insert; unknown here. */
+                rlog_suffix = (op == INSERT && table->type == ROW) ? "??" : "00";
                 rlog_lane = tinfo->lane;
                 rlog_ts = tinfo->replay_ts;
                 rlog_read_ts = tinfo->read_ts;
@@ -1522,8 +1537,9 @@ skip_operation:
             snap_repeat_update(tinfo, true);
             if (rlog_remove) {
                 rlog_emit("REMOVE lane=%" PRIu64 " ts=%" PRIu64 " read_ts=%" PRIu64
-                          " -> remove keyno=%" PRIu64 " target_ts=%" PRIu64 " tbl=%u\n",
-                  rlog_lane, rlog_ts, rlog_read_ts, rlog_keyno, rlog_write_ts, rlog_table_id);
+                          " -> remove keyno=%" PRIu64 ".%s target_ts=%" PRIu64 " tbl=%u\n",
+                  rlog_lane, rlog_ts, rlog_read_ts, rlog_keyno, rlog_suffix, rlog_write_ts,
+                  rlog_table_id);
                 rlog_remove = false;
             }
             if (rlog_to_update) {
@@ -1533,8 +1549,9 @@ skip_operation:
             }
             if (rlog_write) {
                 rlog_emit("%s lane=%" PRIu64 " ts=%" PRIu64 " read_ts=%" PRIu64 " keyno=%" PRIu64
-                          " tbl=%u\n",
-                  rlog_op_name, rlog_lane, rlog_ts, rlog_read_ts, rlog_keyno, rlog_table_id);
+                          ".%s tbl=%u\n",
+                  rlog_op_name, rlog_lane, rlog_ts, rlog_read_ts, rlog_keyno, rlog_suffix,
+                  rlog_table_id);
                 rlog_write = false;
             }
             break;
@@ -2268,7 +2285,9 @@ row_remove(TINFO *tinfo, bool positioned)
     cursor = tinfo->cursor;
 
     if (!positioned) {
-        key_gen(tinfo->table, tinfo->key, tinfo->keyno);
+        /* For predictable replay, the key was pre-generated in ops() with the correct suffix. */
+        if (!GV(RUNS_PREDICTABLE_REPLAY))
+            key_gen(tinfo->table, tinfo->key, tinfo->keyno);
         cursor->set_key(cursor, tinfo->key);
     }
 

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -1256,20 +1256,9 @@ rollback_retry:
         }
         replay_adjust_key(tinfo, max_rows);
 
-        /* For predictable replay removes, target a bulk-loaded key (suffix "00"). */
         if (GV(RUNS_PREDICTABLE_REPLAY)) {
-            if (op == REMOVE) {
-                TABLE *target_table;
-                uint64_t target_keyno;
-
-                replay_pick_bulk_key(tinfo, &target_table, &target_keyno);
-                if (tinfo->lane == 1)
-                    rlog_remove = true;
-                tinfo->keyno = target_keyno;
-                table = tinfo->table = target_table;
-                if (target_table->type == ROW)
-                    key_gen_common(target_table, tinfo->key, target_keyno, "00");
-            }
+            if (op == REMOVE && tinfo->lane == 1)
+                rlog_remove = true;
             if (tinfo->lane == 1) {
                 rlog_ts = tinfo->replay_ts;
                 rlog_read_ts = tinfo->read_ts;
@@ -2238,9 +2227,7 @@ row_remove(TINFO *tinfo, bool positioned)
     cursor = tinfo->cursor;
 
     if (!positioned) {
-        /* For predictable replay, the key was pre-generated in ops() with the correct suffix. */
-        if (!GV(RUNS_PREDICTABLE_REPLAY))
-            key_gen(tinfo->table, tinfo->key, tinfo->keyno);
+        key_gen(tinfo->table, tinfo->key, tinfo->keyno);
         cursor->set_key(cursor, tinfo->key);
     }
 

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -510,28 +510,6 @@ operations(u_int ops_seconds, u_int run_current, u_int run_total)
     disagg_sync_multi_node(session);
 
     if (g.replay_op_log != NULL) {
-        uint64_t ok = 0, notfound = 0, rollback = 0, remove_total;
-        TINFO **tlp;
-        for (tlp = tinfo_list; *tlp != NULL; ++tlp) {
-            ok += (*tlp)->replay_remove_ok;
-            notfound += (*tlp)->replay_remove_notfound;
-            rollback += (*tlp)->replay_remove_rollback;
-        }
-        remove_total = ok + notfound + rollback;
-#define summary_print(fmt, ...)                     \
-    do {                                            \
-        fprintf(stderr, fmt, __VA_ARGS__);          \
-        fprintf(g.replay_op_log, fmt, __VA_ARGS__); \
-    } while (0)
-        summary_print("REMOVE results: ok=%" PRIu64
-                      " (%.1f%%)"
-                      " notfound=%" PRIu64
-                      " (%.1f%%)"
-                      " rollback=%" PRIu64 " (%.1f%%)\n",
-          ok, remove_total > 0 ? 100.0 * ok / remove_total : 0.0, notfound,
-          remove_total > 0 ? 100.0 * notfound / remove_total : 0.0, rollback,
-          remove_total > 0 ? 100.0 * rollback / remove_total : 0.0);
-#undef summary_print
         fclose(g.replay_op_log);
         g.replay_op_log = NULL;
     }
@@ -1044,13 +1022,12 @@ ops(void *arg)
     iso_level_t iso_level;
     thread_op op;
     uint64_t reset_op, session_op, throttle_delay, truncate_op;
-    uint64_t rlog_keyno, rlog_read_ts, rlog_ts;
+    uint64_t rlog_keyno, rlog_lane, rlog_read_ts, rlog_ts;
     uint32_t max_rows, ntries, range, rnd;
     u_int i, rlog_table_id, throttle_delay_max;
     int rlog_ret;
     const char *iso_config, *rlog_op_name;
     bool greater_than, intxn, prepared, mirrored_truncate;
-    bool rlog_remove, rlog_write;
 
     tinfo = arg;
     mirrored_truncate = false;
@@ -1072,8 +1049,7 @@ ops(void *arg)
     iso_level = ISOLATION_SNAPSHOT; /* -Wconditional-uninitialized */
     tinfo->replay_again = false;
     tinfo->lane = LANE_NONE;
-    rlog_remove = rlog_write = false;
-    rlog_keyno = rlog_read_ts = rlog_ts = 0;
+    rlog_keyno = rlog_lane = rlog_read_ts = rlog_ts = 0;
     rlog_table_id = 0;
     rlog_ret = 0;
     rlog_op_name = NULL;
@@ -1110,13 +1086,15 @@ rollback_retry:
 
         ++tinfo->ops;
 
-        if (!tinfo->replay_again)
+        if (!tinfo->replay_again) {
             /*
              * Number of failures so far for the current operation and key. In predictable replay,
              * unless we have a read operation, we cannot give up on any operation and maintain the
              * integrity of the replay.
              */
             ntries = 0;
+            rlog_op_name = NULL;
+        }
 
         /* Number of tries only gets incremented during predictable replay. */
         testutil_assert(ntries == 0 || (!intxn && tinfo->replay_again));
@@ -1257,17 +1235,31 @@ rollback_retry:
         replay_adjust_key(tinfo, max_rows);
 
         if (GV(RUNS_PREDICTABLE_REPLAY)) {
-            if (op == REMOVE && tinfo->lane == 1)
-                rlog_remove = true;
-            if (tinfo->lane == 1) {
-                rlog_ts = tinfo->replay_ts;
-                rlog_read_ts = tinfo->read_ts;
-                rlog_keyno = tinfo->keyno;
-                rlog_table_id = table->id;
-                if (op == INSERT || op == READ || op == UPDATE) {
-                    rlog_write = true;
-                    rlog_op_name = op == INSERT ? "INSERT" : (op == READ ? "READ" : "UPDATE");
-                }
+            rlog_lane = tinfo->lane;
+            rlog_ts = tinfo->replay_ts;
+            rlog_read_ts = tinfo->read_ts;
+            rlog_keyno = tinfo->keyno;
+            rlog_table_id = table->id;
+            rlog_ret = 0;
+            switch (op) {
+            case REMOVE:
+                rlog_op_name = "REMOVE";
+                break;
+            case INSERT:
+                rlog_op_name = "INSERT";
+                break;
+            case READ:
+                rlog_op_name = "READ";
+                break;
+            case UPDATE:
+                rlog_op_name = "UPDATE";
+                break;
+            case MODIFY:
+                rlog_op_name = "MODIFY";
+                break;
+            case TRUNCATE:
+                rlog_op_name = "TRUNCATE";
+                break;
             }
         }
 
@@ -1375,7 +1367,27 @@ rollback_retry:
             if (GV(RUNS_PREDICTABLE_REPLAY)) {
                 if (ret == WT_ROLLBACK)
                     goto rollback;
-                if (rlog_remove)
+                /*
+                 * The key exists but its write_ts exceeds the current read_ts so it isn't visible
+                 * yet. Each keyno is exclusively owned by one lane, so last_commit_ts is the
+                 * write_ts of our key's latest write. Once read_ts reaches that value the key is
+                 * visible; if we still get WT_NOTFOUND the key is genuinely absent.
+                 *
+                 * Spin-yield until replay_maximum_committed reaches last_commit_ts before retrying,
+                 * ensuring the next read_ts will be >= last_commit_ts. That makes the condition
+                 * false on the retry, so at most one retry per WT_NOTFOUND event is needed.
+                 *
+                 * The acquire-release pair on in_use (release in replay_committed, acquire in
+                 * replay_pick_timestamp) orders the write to last_commit_ts before this read,
+                 * regardless of which thread previously occupied this lane.
+                 */
+                if (op == REMOVE && tinfo->op_ret == WT_NOTFOUND &&
+                  tinfo->read_ts < g.lanes[tinfo->lane].last_commit_ts) {
+                    while (replay_maximum_committed() < g.lanes[tinfo->lane].last_commit_ts)
+                        __wt_yield();
+                    goto rollback;
+                }
+                if (op == REMOVE)
                     rlog_ret = tinfo->op_ret;
             }
             skip2 = table;
@@ -1463,12 +1475,11 @@ skip_operation:
         }
 
 /*
- * Emit a replay log line to stderr and to the per-run log file. Defined here so it can be used in
- * the commit case below.
+ * Emit a replay log line to the per-run log file. Defined here so it can be used in the commit case
+ * below.
  */
 #define rlog_emit(fmt, ...)                             \
     do {                                                \
-        fprintf(stderr, fmt, __VA_ARGS__);              \
         if (g.replay_op_log != NULL)                    \
             fprintf(g.replay_op_log, fmt, __VA_ARGS__); \
     } while (0)
@@ -1485,16 +1496,12 @@ skip_operation:
             __wt_yield(); /* Encourage races */
             commit_transaction(tinfo, prepared);
             snap_repeat_update(tinfo, true);
-            if (rlog_remove) {
-                rlog_emit("REMOVE lane=1 ts=%" PRIu64 " read_ts=%" PRIu64 " keyno=%" PRIu64
+            if (rlog_op_name != NULL) {
+                rlog_emit("%s lane=%" PRIu64 " ts=%" PRIu64 " read_ts=%" PRIu64 " keyno=%" PRIu64
                           " tbl=%u ret=%d\n",
-                  rlog_ts, rlog_read_ts, rlog_keyno, rlog_table_id, rlog_ret);
-                rlog_remove = false;
-            }
-            if (rlog_write) {
-                rlog_emit("%s lane=1 ts=%" PRIu64 " read_ts=%" PRIu64 " keyno=%" PRIu64 " tbl=%u\n",
-                  rlog_op_name, rlog_ts, rlog_read_ts, rlog_keyno, rlog_table_id);
-                rlog_write = false;
+                  rlog_op_name, rlog_lane, rlog_ts, rlog_read_ts, rlog_keyno, rlog_table_id,
+                  rlog_ret);
+                rlog_op_name = NULL;
             }
             break;
         case 5: /* 10% */
@@ -2231,20 +2238,7 @@ row_remove(TINFO *tinfo, bool positioned)
         cursor->set_key(cursor, tinfo->key);
     }
 
-    /*
-     * For predictable replay, call remove directly and track the result. Otherwise check for
-     * existence first.
-     */
-    if (GV(RUNS_PREDICTABLE_REPLAY)) {
-        ret = cursor->remove(cursor);
-        if (ret == 0)
-            ++tinfo->replay_remove_ok;
-        else if (ret == WT_NOTFOUND)
-            ++tinfo->replay_remove_notfound;
-        else if (ret == WT_ROLLBACK)
-            ++tinfo->replay_remove_rollback;
-    } else if ((ret = read_op(cursor, SEARCH, NULL)) == 0)
-        ret = cursor->remove(cursor);
+    ret = cursor->remove(cursor);
 
     if (ret != 0 && ret != WT_NOTFOUND)
         return (ret);
@@ -2270,17 +2264,7 @@ col_remove(TINFO *tinfo, bool positioned)
     if (!positioned)
         cursor->set_key(cursor, tinfo->keyno);
 
-    /* See row_remove for the predictable replay rationale. */
-    if (GV(RUNS_PREDICTABLE_REPLAY)) {
-        ret = cursor->remove(cursor);
-        if (ret == 0)
-            ++tinfo->replay_remove_ok;
-        else if (ret == WT_NOTFOUND)
-            ++tinfo->replay_remove_notfound;
-        else if (ret == WT_ROLLBACK)
-            ++tinfo->replay_remove_rollback;
-    } else if ((ret = read_op(cursor, SEARCH, NULL)) == 0)
-        ret = cursor->remove(cursor);
+    ret = cursor->remove(cursor);
 
     if (ret != 0 && ret != WT_NOTFOUND)
         return (ret);

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -896,12 +896,8 @@ table_op(TINFO *tinfo, bool intxn, iso_level_t iso_level, thread_op op)
             /*
              * Don't set positioned: it's unchanged from the previous state, but not necessarily
              * set.
-             *
-             * Skip snap tracking for predictable replay removes: the tombstone is at commit_ts
-             * (replay_ts) which is above read_ts, so the key is not visibly deleted at read_ts.
              */
-            if (!GV(RUNS_PREDICTABLE_REPLAY))
-                SNAP_TRACK(tinfo, REMOVE);
+            SNAP_TRACK(tinfo, REMOVE);
         } else
             OP_FAILED(true);
         break;

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -780,9 +780,10 @@ table_op(TINFO *tinfo, bool intxn, iso_level_t iso_level, thread_op op)
          * position taken from a previous search. If not already doing a read, position the cursor
          * at an existing point in the tree 20% of the time.
          *
-         * For predictable replay, don't pre-position the cursor. Each operation must be
-         * independent, always using the explicit set-key path with the key derived from the replay
-         * timestamp.
+         * For predictable replay, skip the pre-positioning search. read_row() depends on key
+         * visibility at the non-deterministic read timestamp. If it succeeds in one run but fails
+         * in another, positioned differs, which changes whether key_gen_insert consumes data_rnd,
+         * causing all subsequent random decisions to diverge.
          */
         if (!GV(RUNS_PREDICTABLE_REPLAY) && op != READ && mmrand(&tinfo->data_rnd, 1, 5) == 1) {
             ++tinfo->search;

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -521,13 +521,13 @@ operations(u_int ops_seconds, u_int run_current, u_int run_total)
             actual += (*tlp)->replay_remove_actual;
             dup += (*tlp)->replay_remove_dup;
         }
-#define summary_print(fmt, ...)                          \
-    do {                                                 \
-        fprintf(stderr, fmt, __VA_ARGS__);               \
-        fprintf(g.replay_op_log, fmt, __VA_ARGS__);      \
+#define summary_print(fmt, ...)                     \
+    do {                                            \
+        fprintf(stderr, fmt, __VA_ARGS__);          \
+        fprintf(g.replay_op_log, fmt, __VA_ARGS__); \
     } while (0)
-        summary_print("REMOVE summary: fired=%" PRIu64 " skipped=%" PRIu64 " (no-history=%"
-          PRIu64 " target-read=%" PRIu64 " target-remove=%" PRIu64 ")\n",
+        summary_print("REMOVE summary: fired=%" PRIu64 " skipped=%" PRIu64 " (no-history=%" PRIu64
+                      " target-read=%" PRIu64 " target-remove=%" PRIu64 ")\n",
           ok, skip_history + skip_read + skip_prior, skip_history, skip_read, skip_prior);
         summary_print("REMOVE tombstones: actual=%" PRIu64 " dup=%" PRIu64 " (%.1f%% redundant)\n",
           actual, dup, (actual + dup) > 0 ? 100.0 * dup / (actual + dup) : 0.0);
@@ -2274,8 +2274,8 @@ row_remove(TINFO *tinfo, bool positioned)
 
     /*
      * We use the cursor in overwrite mode, check for existence. For predictable replay, skip the
-     * search and call remove directly — overwrite mode writes a tombstone at commit_ts regardless
-     * of key visibility at read_ts, making the outcome deterministic across runs.
+     * search and call remove directly. Overwrite mode writes a tombstone at commit_ts regardless of
+     * key visibility at read_ts, making the outcome deterministic across runs.
      *
      * Do a probe search first to count actual vs redundant tombstones.
      */

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -1283,6 +1283,20 @@ rollback_retry:
         if (op == MODIFY)
             modify_build(tinfo);
 
+        /*
+         * For REMOVE in predictable replay, the key's latest possible write_ts is last_commit_ts
+         * for this lane (each keyno is exclusively owned by its lane). Spin-yield before the first
+         * attempt so that read_ts >= last_commit_ts, ensuring the key's latest value is definitely
+         * visible. Without this, one run may see a write that the other cannot, causing a REMOVE op
+         * to succeed in one but fail in the other leading to a data mismatch.
+         */
+        if (GV(RUNS_PREDICTABLE_REPLAY) && op == REMOVE &&
+          tinfo->read_ts < g.lanes[tinfo->lane].last_commit_ts) {
+            while (replay_maximum_committed() < g.lanes[tinfo->lane].last_commit_ts)
+                __wt_yield();
+            goto rollback;
+        }
+
         ret = 0;
         skip1 = skip2 = NULL;
         if (op == MODIFY && table->mirror) {
@@ -1310,30 +1324,8 @@ rollback_retry:
             tinfo->table = table;
             ret = table_op(tinfo, intxn, iso_level, op);
             testutil_assert(ret == 0 || ret == WT_ROLLBACK);
-            if (GV(RUNS_PREDICTABLE_REPLAY)) {
-                if (ret == WT_ROLLBACK)
-                    goto rollback;
-                /*
-                 * The key exists but its write_ts exceeds the current read_ts so it isn't visible
-                 * yet. Each keyno is exclusively owned by one lane, so last_commit_ts is the
-                 * write_ts of our key's latest write. Once read_ts reaches that value the key is
-                 * visible; if we still get WT_NOTFOUND the key is genuinely absent.
-                 *
-                 * Spin-yield until replay_maximum_committed reaches last_commit_ts before retrying,
-                 * ensuring the next read_ts will be >= last_commit_ts. That makes the condition
-                 * false on the retry, so at most one retry per WT_NOTFOUND event is needed.
-                 *
-                 * The acquire-release pair on in_use (release in replay_committed, acquire in
-                 * replay_pick_timestamp) orders the write to last_commit_ts before this read,
-                 * regardless of which thread previously occupied this lane.
-                 */
-                if (op == REMOVE && tinfo->op_ret == WT_NOTFOUND &&
-                  tinfo->read_ts < g.lanes[tinfo->lane].last_commit_ts) {
-                    while (replay_maximum_committed() < g.lanes[tinfo->lane].last_commit_ts)
-                        __wt_yield();
-                    goto rollback;
-                }
-            }
+            if (GV(RUNS_PREDICTABLE_REPLAY) && ret == WT_ROLLBACK)
+                goto rollback;
             skip2 = table;
         }
         if (ret == 0 && table->mirror) {

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -510,31 +510,27 @@ operations(u_int ops_seconds, u_int run_current, u_int run_total)
     disagg_sync_multi_node(session);
 
     if (g.replay_op_log != NULL) {
-        uint64_t ok = 0, skip_history = 0, skip_read = 0, skip_prior = 0, skipped;
-        uint64_t actual = 0, dup = 0;
+        uint64_t ok = 0, notfound = 0, rollback = 0, remove_total;
         TINFO **tlp;
         for (tlp = tinfo_list; *tlp != NULL; ++tlp) {
             ok += (*tlp)->replay_remove_ok;
-            skip_history += (*tlp)->replay_remove_skip_history;
-            skip_read += (*tlp)->replay_remove_skip_read;
-            skip_prior += (*tlp)->replay_remove_skip_prior;
-            actual += (*tlp)->replay_remove_actual;
-            dup += (*tlp)->replay_remove_dup;
+            notfound += (*tlp)->replay_remove_notfound;
+            rollback += (*tlp)->replay_remove_rollback;
         }
-        skipped = skip_history + skip_read + skip_prior;
+        remove_total = ok + notfound + rollback;
 #define summary_print(fmt, ...)                     \
     do {                                            \
         fprintf(stderr, fmt, __VA_ARGS__);          \
         fprintf(g.replay_op_log, fmt, __VA_ARGS__); \
     } while (0)
-        summary_print("REMOVE summary: fired=%" PRIu64 " skipped=%" PRIu64
-                      " (%.1f%% skipped)"
-                      " (no-history=%" PRIu64 " target-read=%" PRIu64 " target-remove=%" PRIu64
-                      ")\n",
-          ok, skipped, (ok + skipped) > 0 ? 100.0 * skipped / (ok + skipped) : 0.0, skip_history,
-          skip_read, skip_prior);
-        summary_print("REMOVE tombstones: actual=%" PRIu64 " dup=%" PRIu64 " (%.1f%% redundant)\n",
-          actual, dup, (actual + dup) > 0 ? 100.0 * dup / (actual + dup) : 0.0);
+        summary_print("REMOVE results: ok=%" PRIu64
+                      " (%.1f%%)"
+                      " notfound=%" PRIu64
+                      " (%.1f%%)"
+                      " rollback=%" PRIu64 " (%.1f%%)\n",
+          ok, remove_total > 0 ? 100.0 * ok / remove_total : 0.0, notfound,
+          remove_total > 0 ? 100.0 * notfound / remove_total : 0.0, rollback,
+          remove_total > 0 ? 100.0 * rollback / remove_total : 0.0);
 #undef summary_print
         fclose(g.replay_op_log);
         g.replay_op_log = NULL;
@@ -1048,12 +1044,13 @@ ops(void *arg)
     iso_level_t iso_level;
     thread_op op;
     uint64_t reset_op, session_op, throttle_delay, truncate_op;
-    uint64_t rlog_keyno, rlog_lane, rlog_read_ts, rlog_ts, rlog_write_ts;
+    uint64_t rlog_keyno, rlog_read_ts, rlog_ts;
     uint32_t max_rows, ntries, range, rnd;
     u_int i, rlog_table_id, throttle_delay_max;
-    const char *iso_config, *rlog_skip_reason, *rlog_op_name, *rlog_suffix;
+    int rlog_ret;
+    const char *iso_config, *rlog_op_name;
     bool greater_than, intxn, prepared, mirrored_truncate;
-    bool rlog_remove, rlog_to_update, rlog_write;
+    bool rlog_remove, rlog_write;
 
     tinfo = arg;
     mirrored_truncate = false;
@@ -1075,11 +1072,11 @@ ops(void *arg)
     iso_level = ISOLATION_SNAPSHOT; /* -Wconditional-uninitialized */
     tinfo->replay_again = false;
     tinfo->lane = LANE_NONE;
-    rlog_remove = rlog_to_update = rlog_write = false;
-    rlog_keyno = rlog_lane = rlog_read_ts = rlog_ts = rlog_write_ts = 0;
+    rlog_remove = rlog_write = false;
+    rlog_keyno = rlog_read_ts = rlog_ts = 0;
     rlog_table_id = 0;
-    rlog_skip_reason = rlog_op_name = NULL;
-    rlog_suffix = "00";
+    rlog_ret = 0;
+    rlog_op_name = NULL;
 
     /*
      * Calculate max delay so that per-table ops/sec is as set. We use 2* here as our random
@@ -1259,69 +1256,29 @@ rollback_retry:
         }
         replay_adjust_key(tinfo, max_rows);
 
-        /*
-         * For predictable replay removes: derive the target key deterministically from replay_ts by
-         * re-simulating the data_rnd state at a randomly chosen earlier timestamp in the same lane.
-         * The cursor uses overwrite mode so remove() writes a tombstone at commit_ts regardless of
-         * key visibility at read_ts.
-         */
+        /* For predictable replay removes, target a bulk-loaded key (suffix "00"). */
         if (GV(RUNS_PREDICTABLE_REPLAY)) {
             if (op == REMOVE) {
                 TABLE *target_table;
-                uint64_t target_keyno, target_ts;
-                const char *target_suffix;
-                replay_remove_result remove_result;
+                uint64_t target_keyno;
 
-                remove_result = replay_target_remove(
-                  tinfo, &target_table, &target_keyno, &target_ts, &target_suffix);
-                if (remove_result == REPLAY_REMOVE_OK) {
-                    ++tinfo->replay_remove_ok;
-                    if (tinfo->lane == 1) {
-                        rlog_remove = true;
-                        rlog_lane = tinfo->lane;
-                        rlog_ts = tinfo->replay_ts;
-                        rlog_read_ts = tinfo->read_ts;
-                        rlog_keyno = target_keyno;
-                        rlog_write_ts = target_ts;
-                        rlog_table_id = target_table->id;
-                        rlog_suffix = target_suffix;
-                    }
-                    tinfo->keyno = target_keyno;
-                    table = tinfo->table = target_table;
-                    if (target_table->type == ROW)
-                        key_gen_common(target_table, tinfo->key, target_keyno, target_suffix);
-                } else {
-                    if (remove_result == REPLAY_REMOVE_SKIP_HISTORY)
-                        ++tinfo->replay_remove_skip_history;
-                    else if (remove_result == REPLAY_REMOVE_SKIP_READ)
-                        ++tinfo->replay_remove_skip_read;
-                    else
-                        ++tinfo->replay_remove_skip_prior;
-                    if (tinfo->lane == 1) {
-                        static const char *const skip_names[] = {
-                          [REPLAY_REMOVE_SKIP_HISTORY] = "not enough history",
-                          [REPLAY_REMOVE_SKIP_READ] = "target was a read",
-                          [REPLAY_REMOVE_SKIP_PRIOR] = "target was a remove",
-                        };
-                        rlog_to_update = true;
-                        rlog_skip_reason = skip_names[remove_result];
-                        rlog_lane = tinfo->lane;
-                        rlog_ts = tinfo->replay_ts;
-                    }
-                    op = UPDATE;
-                }
+                replay_pick_bulk_key(tinfo, &target_table, &target_keyno);
+                if (tinfo->lane == 1)
+                    rlog_remove = true;
+                tinfo->keyno = target_keyno;
+                table = tinfo->table = target_table;
+                if (target_table->type == ROW)
+                    key_gen_common(target_table, tinfo->key, target_keyno, "00");
             }
-            /* Log all non-remove operations for lane 1. */
-            if (tinfo->lane == 1 && (op == INSERT || op == READ || op == UPDATE)) {
-                rlog_write = true;
-                rlog_op_name = op == INSERT ? "INSERT" : (op == READ ? "READ" : "UPDATE");
-                /* INSERT suffix is determined inside row_insert; unknown here. */
-                rlog_suffix = (op == INSERT && table->type == ROW) ? "??" : "00";
-                rlog_lane = tinfo->lane;
+            if (tinfo->lane == 1) {
                 rlog_ts = tinfo->replay_ts;
                 rlog_read_ts = tinfo->read_ts;
                 rlog_keyno = tinfo->keyno;
                 rlog_table_id = table->id;
+                if (op == INSERT || op == READ || op == UPDATE) {
+                    rlog_write = true;
+                    rlog_op_name = op == INSERT ? "INSERT" : (op == READ ? "READ" : "UPDATE");
+                }
             }
         }
 
@@ -1426,8 +1383,12 @@ rollback_retry:
             tinfo->table = table;
             ret = table_op(tinfo, intxn, iso_level, op);
             testutil_assert(ret == 0 || ret == WT_ROLLBACK);
-            if (GV(RUNS_PREDICTABLE_REPLAY) && ret == WT_ROLLBACK)
-                goto rollback;
+            if (GV(RUNS_PREDICTABLE_REPLAY)) {
+                if (ret == WT_ROLLBACK)
+                    goto rollback;
+                if (rlog_remove)
+                    rlog_ret = tinfo->op_ret;
+            }
             skip2 = table;
         }
         if (ret == 0 && table->mirror) {
@@ -1536,22 +1497,14 @@ skip_operation:
             commit_transaction(tinfo, prepared);
             snap_repeat_update(tinfo, true);
             if (rlog_remove) {
-                rlog_emit("REMOVE lane=%" PRIu64 " ts=%" PRIu64 " read_ts=%" PRIu64
-                          " -> remove keyno=%" PRIu64 ".%s target_ts=%" PRIu64 " tbl=%u\n",
-                  rlog_lane, rlog_ts, rlog_read_ts, rlog_keyno, rlog_suffix, rlog_write_ts,
-                  rlog_table_id);
+                rlog_emit("REMOVE lane=1 ts=%" PRIu64 " read_ts=%" PRIu64 " keyno=%" PRIu64
+                          " tbl=%u ret=%d\n",
+                  rlog_ts, rlog_read_ts, rlog_keyno, rlog_table_id, rlog_ret);
                 rlog_remove = false;
             }
-            if (rlog_to_update) {
-                rlog_emit("REMOVE lane=%" PRIu64 " ts=%" PRIu64 " -> UPDATE (%s)\n", rlog_lane,
-                  rlog_ts, rlog_skip_reason);
-                rlog_to_update = false;
-            }
             if (rlog_write) {
-                rlog_emit("%s lane=%" PRIu64 " ts=%" PRIu64 " read_ts=%" PRIu64 " keyno=%" PRIu64
-                          ".%s tbl=%u\n",
-                  rlog_op_name, rlog_lane, rlog_ts, rlog_read_ts, rlog_keyno, rlog_suffix,
-                  rlog_table_id);
+                rlog_emit("%s lane=1 ts=%" PRIu64 " read_ts=%" PRIu64 " keyno=%" PRIu64 " tbl=%u\n",
+                  rlog_op_name, rlog_ts, rlog_read_ts, rlog_keyno, rlog_table_id);
                 rlog_write = false;
             }
             break;
@@ -2292,18 +2245,17 @@ row_remove(TINFO *tinfo, bool positioned)
     }
 
     /*
-     * We use the cursor in overwrite mode, check for existence. For predictable replay, skip the
-     * search and call remove directly. Overwrite mode writes a tombstone at commit_ts regardless of
-     * key visibility at read_ts, making the outcome deterministic across runs.
-     *
-     * Do a probe search first to count actual vs redundant tombstones.
+     * For predictable replay, call remove directly and track the result. Otherwise check for
+     * existence first.
      */
     if (GV(RUNS_PREDICTABLE_REPLAY)) {
-        if (read_op(cursor, SEARCH, NULL) == 0)
-            ++tinfo->replay_remove_actual;
-        else
-            ++tinfo->replay_remove_dup;
         ret = cursor->remove(cursor);
+        if (ret == 0)
+            ++tinfo->replay_remove_ok;
+        else if (ret == WT_NOTFOUND)
+            ++tinfo->replay_remove_notfound;
+        else if (ret == WT_ROLLBACK)
+            ++tinfo->replay_remove_rollback;
     } else if ((ret = read_op(cursor, SEARCH, NULL)) == 0)
         ret = cursor->remove(cursor);
 
@@ -2331,13 +2283,15 @@ col_remove(TINFO *tinfo, bool positioned)
     if (!positioned)
         cursor->set_key(cursor, tinfo->keyno);
 
-    /* See row_remove for the predictable replay rationale and probe-search counting. */
+    /* See row_remove for the predictable replay rationale. */
     if (GV(RUNS_PREDICTABLE_REPLAY)) {
-        if (read_op(cursor, SEARCH, NULL) == 0)
-            ++tinfo->replay_remove_actual;
-        else
-            ++tinfo->replay_remove_dup;
         ret = cursor->remove(cursor);
+        if (ret == 0)
+            ++tinfo->replay_remove_ok;
+        else if (ret == WT_NOTFOUND)
+            ++tinfo->replay_remove_notfound;
+        else if (ret == WT_ROLLBACK)
+            ++tinfo->replay_remove_rollback;
     } else if ((ret = read_op(cursor, SEARCH, NULL)) == 0)
         ret = cursor->remove(cursor);
 

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -1283,20 +1283,6 @@ rollback_retry:
         if (op == MODIFY)
             modify_build(tinfo);
 
-        /*
-         * For REMOVE in predictable replay, the key's latest possible write_ts is last_commit_ts
-         * for this lane (each keyno is exclusively owned by its lane). Spin-yield before the first
-         * attempt so that read_ts >= last_commit_ts, ensuring the key's latest value is definitely
-         * visible. Without this, one run may see a write that the other cannot, causing a REMOVE op
-         * to succeed in one but fail in the other leading to a data mismatch.
-         */
-        if (GV(RUNS_PREDICTABLE_REPLAY) && op == REMOVE &&
-          tinfo->read_ts < g.lanes[tinfo->lane].last_commit_ts) {
-            while (replay_maximum_committed() < g.lanes[tinfo->lane].last_commit_ts)
-                __wt_yield();
-            goto rollback;
-        }
-
         ret = 0;
         skip1 = skip2 = NULL;
         if (op == MODIFY && table->mirror) {

--- a/test/format/replay.c
+++ b/test/format/replay.c
@@ -502,7 +502,7 @@ replay_target_remove(TINFO *tinfo, TABLE **tablep, uint64_t *keynop, uint64_t *t
     uint32_t bucket, lane, max_rows, target_op_pct;
 
     max_cycles = tinfo->replay_ts / LANE_COUNT;
-    bucket = mmrand(&tinfo->data_rnd, 0, 2);
+    bucket = mmrand(&tinfo->data_rnd, 0, 3);
 
     if (bucket == 3) {
         /* Bucket 3: remove a bulk-loaded key. */

--- a/test/format/replay.c
+++ b/test/format/replay.c
@@ -491,15 +491,22 @@ replay_adjust_key_for_lane(uint64_t *keynop, uint32_t lane, uint64_t max_rows)
  *     Derive a deterministic remove target from one of four equally likely buckets: key from the
  *     initial bulk load; key from ops history, 1 to 10 cycles back; key from ops history, 1 to 100
  *     cycles back; key from ops history, 1 to 1000 cycles back. Sets target_ts to the source
- *     timestamp (0 for bulk-load targets). Returns a skip result if no suitable target exists.
+ *     timestamp (0 for bulk-load targets). Sets *suffixp to the key suffix that was used at
+ *     target_ts ("00" for non-INSERT ops and bulk-load targets; "01"-"15" for row-store INSERTs).
+ *     Returns a skip result if no suitable target exists.
  */
 replay_remove_result
-replay_target_remove(TINFO *tinfo, TABLE **tablep, uint64_t *keynop, uint64_t *target_tsp)
+replay_target_remove(
+  TINFO *tinfo, TABLE **tablep, uint64_t *keynop, uint64_t *target_tsp, const char **suffixp)
 {
+    static const char *const insert_suffixes[15] = {
+      "01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12", "13", "14", "15"};
     WT_RAND_STATE temp_rnd;
     TABLE *target_table;
     uint64_t cycles, keyno, max_cycles, range_max, target_ts;
     uint32_t bucket, lane, max_rows, target_op_pct;
+
+    *suffixp = "00"; /* default: bulk-loaded key variant */
 
     max_cycles = tinfo->replay_ts / LANE_COUNT;
     bucket = mmrand(&tinfo->data_rnd, 0, 3);
@@ -578,10 +585,23 @@ replay_target_remove(TINFO *tinfo, TABLE **tablep, uint64_t *keynop, uint64_t *t
             keyno++;
     }
 
-    /* Adjust key for lane target_ts is always in the same lane as replay_ts. */
+    /* Adjust key for lane; target_ts is always in the same lane as replay_ts. */
     lane = LANE_NUMBER(target_ts);
     testutil_assert(lane == tinfo->lane);
     replay_adjust_key_for_lane(&keyno, lane, max_rows);
+
+    /*
+     * For row-store INSERT, recover the key suffix ("01"-"15") by simulating the remaining data_rnd
+     * calls: val_gen (0 or 1 call depending on keyno%63), then key_gen_insert's mmrand(0,14).
+     * INSERT in predictable replay has no pre-positioning mmrand call.
+     */
+    if (target_table->type == ROW &&
+      target_op_pct <
+        target_table->v[V_TABLE_OPS_PCT_DELETE].v + target_table->v[V_TABLE_OPS_PCT_INSERT].v) {
+        if (keyno % 63 != 0)
+            (void)mmrand(&temp_rnd, 0, 1); /* val_gen: one call for val_len */
+        *suffixp = insert_suffixes[mmrand(&temp_rnd, 0, 14)];
+    }
 
     *tablep = target_table;
     *keynop = keyno;

--- a/test/format/replay.c
+++ b/test/format/replay.c
@@ -161,37 +161,12 @@ replay_operation_enabled(thread_op op)
         return (true);
 
     /*
-     * We don't permit modify operations with predictable replay.
-     *
-     * The problem is read timestamps. As currently implemented, the read timestamp selected is
-     * variable, based on the state of other threads and their progress with other timestamped
-     * operations. And if two changes are made to the same key in a short amount of time, if the
-     * second operation were to be performed sometimes with a read timestamp before the first
-     * operation, and sometimes with a read timestamp after the first operation, then the results
-     * would be variable.
-     *
-     * We could track recent operations on a key (in its lane, for instance), but when we realize
-     * the read timestamp isn't recent enough, we would need to wait for the stable timestamp to
-     * move forward (and our waiting can affect/delay other thread's operations as well). Having the
-     * stable timestamp move forward is the only way our read timestamp can progress.
-     *
-     * Another possibility that also involves tracking recent operations on a key would be to
-     * disallow modifies that occur within, say 10000 timestamps of a previous write operation on
-     * the same key. Those modifies could be silently converted to reads, for instance. If our read
-     * timestamp was greater than 10000 timestamps behind, we'd still need to wait for the stable
-     * timestamp to catch up.
+     * We don't permit modify operations with predictable replay. A modify applies a delta on top of
+     * the existing value read at the transaction's read timestamp. The read timestamp is
+     * non-deterministic, so a modify can produce different results across runs if the read
+     * timestamp straddles a prior write to the same key.
      */
     if (op == MODIFY)
-        return (false);
-
-    /*
-     * FIXME-WT-10570. We don't permit remove operations with predictable replay.
-     *
-     * This should be something we can and should fix. The problem may be similar to the problem
-     * with modify, where having a varying read timestamp can cause different results for different
-     * runs.
-     */
-    if (op == REMOVE)
         return (false);
 
     /*
@@ -482,6 +457,7 @@ replay_committed(TINFO *tinfo)
      * timestamps to advance.
      */
     WT_RELEASE_WRITE_WITH_BARRIER(g.lanes[lane].last_commit_ts, tinfo->replay_ts);
+
     if (g.timestamp <= tinfo->replay_ts + LANE_COUNT) {
         WT_RELEASE_WRITE_WITH_BARRIER(g.lanes[lane].in_use, false);
         tinfo->lane = LANE_NONE;
@@ -491,6 +467,126 @@ replay_committed(TINFO *tinfo)
         tinfo->replay_again = true;
     }
     testutil_check(pthread_rwlock_unlock(&g.lane_lock));
+}
+
+/*
+ * replay_adjust_key_for_lane --
+ *     Force the bottom lane bits of keyno to match the given lane, with boundary clamping.
+ */
+static void
+replay_adjust_key_for_lane(uint64_t *keynop, uint32_t lane, uint64_t max_rows)
+{
+    uint64_t keyno;
+
+    keyno = (*keynop & ~(uint64_t)(LANE_COUNT - 1)) | lane;
+    if (keyno == 0)
+        keyno = LANE_COUNT;
+    else if (keyno >= max_rows)
+        keyno -= LANE_COUNT;
+    *keynop = keyno;
+}
+
+/*
+ * replay_target_remove --
+ *     Derive a deterministic remove target from one of four equally likely buckets: key from the
+ *     initial bulk load; key from ops history, 1 to 10 cycles back; key from ops history, 1 to 100
+ *     cycles back; key from ops history, 1 to 1000 cycles back. Sets target_ts to the source
+ *     timestamp (0 for bulk-load targets). Returns a skip result if no suitable target exists.
+ */
+replay_remove_result
+replay_target_remove(TINFO *tinfo, TABLE **tablep, uint64_t *keynop, uint64_t *target_tsp)
+{
+    WT_RAND_STATE temp_rnd;
+    TABLE *target_table;
+    uint64_t cycles, keyno, max_cycles, range_max, target_ts;
+    uint32_t bucket, lane, max_rows, target_op_pct;
+
+    max_cycles = tinfo->replay_ts / LANE_COUNT;
+    bucket = mmrand(&tinfo->data_rnd, 0, 2);
+
+    if (bucket == 3) {
+        /* Bucket 3: remove a bulk-loaded key. */
+        if (ntables == 0)
+            target_table = tables[0];
+        else
+            target_table = tables[mmrand(&tinfo->data_rnd, 1, ntables)];
+
+        max_rows = target_table->v[V_TABLE_RUNS_ROWS].v;
+        keyno = mmrand(&tinfo->data_rnd, 1, (u_int)max_rows);
+        if (target_table->v[V_TABLE_OPS_PARETO].v) {
+            keyno =
+              testutil_pareto(keyno, (u_int)max_rows, target_table->v[V_TABLE_OPS_PARETO_SKEW].v);
+            if (keyno == 0)
+                keyno++;
+        }
+        replay_adjust_key_for_lane(&keyno, tinfo->lane, max_rows);
+
+        *tablep = target_table;
+        *keynop = keyno;
+        *target_tsp = 0; /* bulk-loaded, no source timestamp */
+        return (REPLAY_REMOVE_OK);
+    }
+
+    /*
+     * Buckets 0-2: look back a random number of lane cycles and target the key that was written (if
+     * it was a write) at that earlier timestamp. Need at least one cycle of history.
+     */
+    if (max_cycles == 0)
+        return (REPLAY_REMOVE_SKIP_HISTORY);
+
+    range_max = 10;
+    for (uint32_t b = 0; b < bucket; ++b)
+        range_max *= 10;
+    range_max = WT_MIN(range_max, max_cycles);
+    cycles = mmrand(&tinfo->data_rnd, 1, (u_int)range_max);
+    target_ts = tinfo->replay_ts - cycles * LANE_COUNT;
+
+    /*
+     * Seed a temporary data RNG and replay the exact call sequence from ops_worker at target_ts:
+     * table_select, prepare check, op selection, key selection.
+     */
+    testutil_random_from_seed(&temp_rnd, target_ts ^ GV(RANDOM_DATA_SEED));
+
+    /* Table selection: matches table_select(tinfo, true). */
+    if (ntables == 0)
+        target_table = tables[0];
+    else
+        target_table = tables[mmrand(&temp_rnd, 1, ntables)];
+
+    /* Prepare check: only consumes an RNG call if OPS_PREPARE is configured. */
+    if (GV(OPS_PREPARE))
+        (void)mmrand(&temp_rnd, 1, 10);
+
+    /*
+     * Op selection: if the operation at target_ts was not a write, no key was written there.
+     * Removing it would create a redundant tombstone, so skip to avoid history store bloat.
+     */
+    target_op_pct = mmrand(&temp_rnd, 1, 100);
+    if (target_op_pct < target_table->v[V_TABLE_OPS_PCT_DELETE].v)
+        return (REPLAY_REMOVE_SKIP_PRIOR);
+    if (target_op_pct >= target_table->v[V_TABLE_OPS_PCT_DELETE].v +
+        target_table->v[V_TABLE_OPS_PCT_INSERT].v + target_table->v[V_TABLE_OPS_PCT_MODIFY].v +
+        target_table->v[V_TABLE_OPS_PCT_WRITE].v)
+        return (REPLAY_REMOVE_SKIP_READ);
+
+    /* Key selection: use configured RUNS_ROWS (not rows_current) for cross-run consistency. */
+    max_rows = target_table->v[V_TABLE_RUNS_ROWS].v;
+    keyno = mmrand(&temp_rnd, 1, (u_int)max_rows);
+    if (target_table->v[V_TABLE_OPS_PARETO].v) {
+        keyno = testutil_pareto(keyno, (u_int)max_rows, target_table->v[V_TABLE_OPS_PARETO_SKEW].v);
+        if (keyno == 0)
+            keyno++;
+    }
+
+    /* Adjust key for lane target_ts is always in the same lane as replay_ts. */
+    lane = LANE_NUMBER(target_ts);
+    testutil_assert(lane == tinfo->lane);
+    replay_adjust_key_for_lane(&keyno, lane, max_rows);
+
+    *tablep = target_table;
+    *keynop = keyno;
+    *target_tsp = target_ts;
+    return (REPLAY_REMOVE_OK);
 }
 
 /*

--- a/test/format/replay.c
+++ b/test/format/replay.c
@@ -470,143 +470,40 @@ replay_committed(TINFO *tinfo)
 }
 
 /*
- * replay_adjust_key_for_lane --
- *     Force the bottom lane bits of keyno to match the given lane, with boundary clamping.
+ * replay_pick_bulk_key --
+ *     Pick a deterministic target key from the bulk-loaded key space. Bulk-loaded keys use the "00"
+ *     suffix and are always present at any read_ts > 0, making them safe targets for both removes
+ *     and modifies without any history or visibility checks.
  */
-static void
-replay_adjust_key_for_lane(uint64_t *keynop, uint32_t lane, uint64_t max_rows)
+void
+replay_pick_bulk_key(TINFO *tinfo, TABLE **tablep, uint64_t *keynop)
 {
-    uint64_t keyno;
-
-    keyno = (*keynop & ~(uint64_t)(LANE_COUNT - 1)) | lane;
-    if (keyno == 0)
-        keyno = LANE_COUNT;
-    else if (keyno >= max_rows)
-        keyno -= LANE_COUNT;
-    *keynop = keyno;
-}
-
-/*
- * replay_target_remove --
- *     Derive a deterministic remove target from one of four equally likely buckets: key from the
- *     initial bulk load; key from ops history, 1 to 10 cycles back; key from ops history, 1 to 100
- *     cycles back; key from ops history, 1 to 1000 cycles back. Sets target_ts to the source
- *     timestamp (0 for bulk-load targets). Sets *suffixp to the key suffix that was used at
- *     target_ts ("00" for non-INSERT ops and bulk-load targets; "01"-"15" for row-store INSERTs).
- *     Returns a skip result if no suitable target exists.
- */
-replay_remove_result
-replay_target_remove(
-  TINFO *tinfo, TABLE **tablep, uint64_t *keynop, uint64_t *target_tsp, const char **suffixp)
-{
-    static const char *const insert_suffixes[15] = {
-      "01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12", "13", "14", "15"};
-    WT_RAND_STATE temp_rnd;
     TABLE *target_table;
-    uint64_t cycles, keyno, max_cycles, range_max, target_ts;
-    uint32_t bucket, lane, max_rows, target_op_pct;
+    uint64_t keyno;
+    uint32_t max_rows;
 
-    *suffixp = "00"; /* default: bulk-loaded key variant */
-
-    max_cycles = tinfo->replay_ts / LANE_COUNT;
-    bucket = mmrand(&tinfo->data_rnd, 0, 3);
-
-    if (bucket == 3) {
-        /* Bucket 3: remove a bulk-loaded key. */
-        if (ntables == 0)
-            target_table = tables[0];
-        else
-            target_table = tables[mmrand(&tinfo->data_rnd, 1, ntables)];
-
-        max_rows = target_table->v[V_TABLE_RUNS_ROWS].v;
-        keyno = mmrand(&tinfo->data_rnd, 1, (u_int)max_rows);
-        if (target_table->v[V_TABLE_OPS_PARETO].v) {
-            keyno =
-              testutil_pareto(keyno, (u_int)max_rows, target_table->v[V_TABLE_OPS_PARETO_SKEW].v);
-            if (keyno == 0)
-                keyno++;
-        }
-        replay_adjust_key_for_lane(&keyno, tinfo->lane, max_rows);
-
-        *tablep = target_table;
-        *keynop = keyno;
-        *target_tsp = 0; /* bulk-loaded, no source timestamp */
-        return (REPLAY_REMOVE_OK);
-    }
-
-    /*
-     * Buckets 0-2: look back a random number of lane cycles and target the key that was written (if
-     * it was a write) at that earlier timestamp. Need at least one cycle of history.
-     */
-    if (max_cycles == 0)
-        return (REPLAY_REMOVE_SKIP_HISTORY);
-
-    range_max = 10;
-    for (uint32_t b = 0; b < bucket; ++b)
-        range_max *= 10;
-    range_max = WT_MIN(range_max, max_cycles);
-    cycles = mmrand(&tinfo->data_rnd, 1, (u_int)range_max);
-    target_ts = tinfo->replay_ts - cycles * LANE_COUNT;
-
-    /*
-     * Seed a temporary data RNG and replay the exact call sequence from ops_worker at target_ts:
-     * table_select, prepare check, op selection, key selection.
-     */
-    testutil_random_from_seed(&temp_rnd, target_ts ^ GV(RANDOM_DATA_SEED));
-
-    /* Table selection: matches table_select(tinfo, true). */
     if (ntables == 0)
         target_table = tables[0];
     else
-        target_table = tables[mmrand(&temp_rnd, 1, ntables)];
+        target_table = tables[mmrand(&tinfo->data_rnd, 1, ntables)];
 
-    /* Prepare check: only consumes an RNG call if OPS_PREPARE is configured. */
-    if (GV(OPS_PREPARE))
-        (void)mmrand(&temp_rnd, 1, 10);
-
-    /*
-     * Op selection: if the operation at target_ts was not a write, no key was written there.
-     * Removing it would create a redundant tombstone, so skip to avoid history store bloat.
-     */
-    target_op_pct = mmrand(&temp_rnd, 1, 100);
-    if (target_op_pct < target_table->v[V_TABLE_OPS_PCT_DELETE].v)
-        return (REPLAY_REMOVE_SKIP_PRIOR);
-    if (target_op_pct >= target_table->v[V_TABLE_OPS_PCT_DELETE].v +
-        target_table->v[V_TABLE_OPS_PCT_INSERT].v + target_table->v[V_TABLE_OPS_PCT_MODIFY].v +
-        target_table->v[V_TABLE_OPS_PCT_WRITE].v)
-        return (REPLAY_REMOVE_SKIP_READ);
-
-    /* Key selection: use configured RUNS_ROWS (not rows_current) for cross-run consistency. */
     max_rows = target_table->v[V_TABLE_RUNS_ROWS].v;
-    keyno = mmrand(&temp_rnd, 1, (u_int)max_rows);
+    keyno = mmrand(&tinfo->data_rnd, 1, (u_int)max_rows);
     if (target_table->v[V_TABLE_OPS_PARETO].v) {
         keyno = testutil_pareto(keyno, (u_int)max_rows, target_table->v[V_TABLE_OPS_PARETO_SKEW].v);
         if (keyno == 0)
             keyno++;
     }
 
-    /* Adjust key for lane; target_ts is always in the same lane as replay_ts. */
-    lane = LANE_NUMBER(target_ts);
-    testutil_assert(lane == tinfo->lane);
-    replay_adjust_key_for_lane(&keyno, lane, max_rows);
-
-    /*
-     * For row-store INSERT, recover the key suffix ("01"-"15") by simulating the remaining data_rnd
-     * calls: val_gen (0 or 1 call depending on keyno%63), then key_gen_insert's mmrand(0,14).
-     * INSERT in predictable replay has no pre-positioning mmrand call.
-     */
-    if (target_table->type == ROW &&
-      target_op_pct <
-        target_table->v[V_TABLE_OPS_PCT_DELETE].v + target_table->v[V_TABLE_OPS_PCT_INSERT].v) {
-        if (keyno % 63 != 0)
-            (void)mmrand(&temp_rnd, 0, 1); /* val_gen: one call for val_len */
-        *suffixp = insert_suffixes[mmrand(&temp_rnd, 0, 14)];
-    }
+    /* Set the bottom lane bits so only this lane can own the key. */
+    keyno = (keyno & ~(uint64_t)(LANE_COUNT - 1)) | tinfo->lane;
+    if (keyno == 0)
+        keyno = LANE_COUNT;
+    else if (keyno >= max_rows)
+        keyno -= LANE_COUNT;
 
     *tablep = target_table;
     *keynop = keyno;
-    *target_tsp = target_ts;
-    return (REPLAY_REMOVE_OK);
 }
 
 /*

--- a/test/format/replay.c
+++ b/test/format/replay.c
@@ -161,10 +161,25 @@ replay_operation_enabled(thread_op op)
         return (true);
 
     /*
-     * We don't permit modify operations with predictable replay. A modify applies a delta on top of
-     * the existing value read at the transaction's read timestamp. The read timestamp is
-     * non-deterministic, so a modify can produce different results across runs if the read
-     * timestamp straddles a prior write to the same key.
+     * We don't permit modify operations with predictable replay.
+     *
+     * The problem is read timestamps. As currently implemented, the read timestamp selected is
+     * variable, based on the state of other threads and their progress with other timestamped
+     * operations. And if two changes are made to the same key in a short amount of time, if the
+     * second operation were to be performed sometimes with a read timestamp before the first
+     * operation, and sometimes with a read timestamp after the first operation, then the results
+     * would be variable.
+     *
+     * We could track recent operations on a key (in its lane, for instance), but when we realize
+     * the read timestamp isn't recent enough, we would need to wait for the stable timestamp to
+     * move forward (and our waiting can affect/delay other thread's operations as well). Having the
+     * stable timestamp move forward is the only way our read timestamp can progress.
+     *
+     * Another possibility that also involves tracking recent operations on a key would be to
+     * disallow modifies that occur within, say 10000 timestamps of a previous write operation on
+     * the same key. Those modifies could be silently converted to reads, for instance. If our read
+     * timestamp was greater than 10000 timestamps behind, we'd still need to wait for the stable
+     * timestamp to catch up.
      */
     if (op == MODIFY)
         return (false);

--- a/test/format/replay.c
+++ b/test/format/replay.c
@@ -457,7 +457,6 @@ replay_committed(TINFO *tinfo)
      * timestamps to advance.
      */
     WT_RELEASE_WRITE_WITH_BARRIER(g.lanes[lane].last_commit_ts, tinfo->replay_ts);
-
     if (g.timestamp <= tinfo->replay_ts + LANE_COUNT) {
         WT_RELEASE_WRITE_WITH_BARRIER(g.lanes[lane].in_use, false);
         tinfo->lane = LANE_NONE;
@@ -467,43 +466,6 @@ replay_committed(TINFO *tinfo)
         tinfo->replay_again = true;
     }
     testutil_check(pthread_rwlock_unlock(&g.lane_lock));
-}
-
-/*
- * replay_pick_bulk_key --
- *     Pick a deterministic target key from the bulk-loaded key space. Bulk-loaded keys use the "00"
- *     suffix and are always present at any read_ts > 0, making them safe targets for both removes
- *     and modifies without any history or visibility checks.
- */
-void
-replay_pick_bulk_key(TINFO *tinfo, TABLE **tablep, uint64_t *keynop)
-{
-    TABLE *target_table;
-    uint64_t keyno;
-    uint32_t max_rows;
-
-    if (ntables == 0)
-        target_table = tables[0];
-    else
-        target_table = tables[mmrand(&tinfo->data_rnd, 1, ntables)];
-
-    max_rows = target_table->v[V_TABLE_RUNS_ROWS].v;
-    keyno = mmrand(&tinfo->data_rnd, 1, (u_int)max_rows);
-    if (target_table->v[V_TABLE_OPS_PARETO].v) {
-        keyno = testutil_pareto(keyno, (u_int)max_rows, target_table->v[V_TABLE_OPS_PARETO_SKEW].v);
-        if (keyno == 0)
-            keyno++;
-    }
-
-    /* Set the bottom lane bits so only this lane can own the key. */
-    keyno = (keyno & ~(uint64_t)(LANE_COUNT - 1)) | tinfo->lane;
-    if (keyno == 0)
-        keyno = LANE_COUNT;
-    else if (keyno >= max_rows)
-        keyno -= LANE_COUNT;
-
-    *tablep = target_table;
-    *keynop = keyno;
 }
 
 /*


### PR DESCRIPTION
In [WT-9915](https://jira.mongodb.org/browse/WT-9915), test/format was extended to allow predictable replay - the ability to run the same configuration over again and get identical results on disk.  For an unknown reason, runs using remove operations did not consistently get identical results.  This ticket should explore this, and ~optionally look at modify operations, which also do not give consistent results, and may suffer from the same underlying problem~ (moved into [WT-17117](https://jira.mongodb.org/browse/WT-17117)).

In this PR I have fixed the issue of non-deterministic removes, by removing the read guard that would previously fail remove ops that should have been rolled back and retried with a later read timestamp. 

I have also disabled pre-positioning and reserves for predictable replay, since this would lead to non-deterministic inserts. This was not a problem before, as reads/searches on bulk inserted keys would previously always succeed whereas now they may fail if the key has been deleted. Created a FIXME ticket [WT-17294](https://jira.mongodb.org/browse/WT-17294) since we do still want coverage for pre-positioning.

To reduce the complexity of the PR, the logging functionality has been moved into [WT-17251](https://jira.mongodb.org/browse/WT-17251), and the extra support for operating on newly non-bulk inserted keys has been moved to [WT-17260](https://jira.mongodb.org/browse/WT-17260).