### PR TITLE
WT-17107 Streamline layered cursors's caching of constituent cursors.

### DIFF
--- a/src/cursor/cur_file.c
+++ b/src/cursor/cur_file.c
@@ -616,8 +616,14 @@ __curfile_close(WT_CURSOR *cursor)
     WT_ERR(__cursor_copy_release(cursor));
 err:
 
-    /* Only try to cache the cursor if there's no error. */
-    if (ret == 0) {
+    dead = F_ISSET(cursor, WT_CURSTD_DEAD);
+
+    /*
+     * Only try to cache the cursor if there's no error and the cursor is not dead. A dead cursor
+     * did not acquire a read lock on its data handle, so caching it would release a lock that was
+     * never held.
+     */
+    if (ret == 0 && !dead) {
         /*
          * If releasing the cursor fails in any way, it will be left in a state that allows it to be
          * normally closed.
@@ -626,8 +632,6 @@ err:
         if (released)
             goto done;
     }
-
-    dead = F_ISSET(cursor, WT_CURSTD_DEAD);
 
     /* For cached cursors, free any extra buffers retained now. */
     __wt_cursor_free_cached_memory(cursor);

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -175,10 +175,14 @@ __clayered_close_cursors(WT_CURSOR_LAYERED *clayered)
 
     clayered->current_cursor = NULL;
     if ((c = clayered->ingest_cursor) != NULL) {
+        if (F_ISSET(c, WT_CURSTD_CACHED))
+            c->reopen(c, false);
         WT_RET(c->close(c));
         clayered->ingest_cursor = NULL;
     }
     if ((c = clayered->stable_cursor) != NULL) {
+        if (F_ISSET(c, WT_CURSTD_CACHED))
+            c->reopen(c, false);
         WT_RET(c->close(c));
         clayered->stable_cursor = NULL;
     }
@@ -205,6 +209,24 @@ __clayered_cache_cursors(WT_CURSOR_LAYERED *clayered)
 
     /* Some flags persist across caching of constituents. */
     F_CLR(clayered, ~(WT_CLAYERED_ACTIVE | WT_CLAYERED_RANDOM));
+    return (0);
+}
+
+/*
+ * __clayered_reopen_cursors --
+ *     Reopen any constituent btree cursors.
+ */
+static int
+__clayered_reopen_cursors(WT_CURSOR_LAYERED *clayered)
+{
+    WT_CURSOR *c;
+
+    clayered->current_cursor = NULL;
+    if ((c = clayered->ingest_cursor) != NULL)
+        WT_RET(c->reopen(c, false));
+    if ((c = clayered->stable_cursor) != NULL)
+        WT_RET(c->reopen(c, false));
+
     return (0);
 }
 
@@ -642,12 +664,18 @@ static int
 __clayered_open_cursors(WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered)
 {
     WT_CONNECTION_IMPL *conn;
+    WT_CURSOR *c;
     bool leader;
 
     conn = S2C(session);
 
-    if (clayered->ingest_cursor != NULL && clayered->stable_cursor != NULL)
+    if (clayered->ingest_cursor != NULL && clayered->stable_cursor != NULL) {
+        if ((c = clayered->ingest_cursor) != NULL && F_ISSET(c, WT_CURSTD_CACHED))
+            c->reopen(c, false);
+        if ((c = clayered->stable_cursor) != NULL && F_ISSET(c, WT_CURSTD_CACHED))
+            c->reopen(c, false);
         return (0);
+    }
 
     F_CLR(clayered, WT_CLAYERED_ITERATE_NEXT | WT_CLAYERED_ITERATE_PREV);
 
@@ -1280,7 +1308,6 @@ __clayered_cache(WT_CURSOR *cursor)
 static int
 __clayered_reopen_int(WT_CURSOR *cursor)
 {
-    WT_CURSOR *c;
     WT_CURSOR_LAYERED *clayered;
     WT_DATA_HANDLE *dhandle;
     WT_DECL_RET;
@@ -1321,16 +1348,12 @@ __clayered_reopen_int(WT_CURSOR *cursor)
         cursor->key_format = layered->key_format;
         cursor->value_format = layered->value_format;
 
-        if (!F_ISSET(cursor, WT_CURSTD_CONSTITUENT_DEAD)) {
-            if ((c = clayered->ingest_cursor) != NULL)
-                WT_TRET(c->reopen(c, false));
-            if ((c = clayered->stable_cursor) != NULL)
-                WT_TRET(c->reopen(c, false));
-        }
+        if (!F_ISSET(cursor, WT_CURSTD_CONSTITUENT_DEAD))
+            WT_RET(__clayered_reopen_cursors(clayered));
         WT_STAT_CONN_DSRC_INCR(session, cursor_reopen);
     }
     if (ret != 0)
-        WT_TRET(__clayered_close_cursors(clayered));
+        WT_RET(__clayered_close_cursors(clayered));
 
     return (ret);
 }

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -189,6 +189,26 @@ __clayered_close_cursors(WT_CURSOR_LAYERED *clayered)
 }
 
 /*
+ * __clayered_cache_cursors --
+ *     Cache any constituent btree cursors.
+ */
+static int
+__clayered_cache_cursors(WT_CURSOR_LAYERED *clayered)
+{
+    WT_CURSOR *c;
+
+    clayered->current_cursor = NULL;
+    if ((c = clayered->ingest_cursor) != NULL)
+        WT_RET(c->cache(c));
+    if ((c = clayered->stable_cursor) != NULL)
+        WT_RET(c->cache(c));
+
+    /* Some flags persist across caching of constituents. */
+    F_CLR(clayered, ~(WT_CLAYERED_ACTIVE | WT_CLAYERED_RANDOM));
+    return (0);
+}
+
+/*
  * __clayered_configure_random --
  *     Make a configuration string that either empty or includes any random configuration as
  *     appropriate.
@@ -1260,6 +1280,8 @@ __clayered_cache(WT_CURSOR *cursor)
 static int
 __clayered_reopen_int(WT_CURSOR *cursor)
 {
+    WT_CURSOR *c;
+    WT_CURSOR_LAYERED *clayered;
     WT_DATA_HANDLE *dhandle;
     WT_DECL_RET;
     WT_SESSION_IMPL *session;
@@ -1267,6 +1289,7 @@ __clayered_reopen_int(WT_CURSOR *cursor)
 
     session = CUR2S(cursor);
     dhandle = session->dhandle;
+    clayered = (WT_CURSOR_LAYERED *)cursor;
 
     /*
      * Lock the handle: we're only interested in open handles, any other state disqualifies the
@@ -1298,8 +1321,17 @@ __clayered_reopen_int(WT_CURSOR *cursor)
         cursor->key_format = layered->key_format;
         cursor->value_format = layered->value_format;
 
+        if (!F_ISSET(cursor, WT_CURSTD_CONSTITUENT_DEAD)) {
+            if ((c = clayered->ingest_cursor) != NULL)
+                WT_TRET(c->reopen(c, false));
+            if ((c = clayered->stable_cursor) != NULL)
+                WT_TRET(c->reopen(c, false));
+        }
         WT_STAT_CONN_DSRC_INCR(session, cursor_reopen);
     }
+    if (ret != 0)
+        WT_TRET(__clayered_close_cursors(clayered));
+
     return (ret);
 }
 
@@ -2266,7 +2298,7 @@ err:
              * during connection->close performing a close of all cursors in the session.
              */
             if (!F_ISSET(cursor, WT_CURSTD_CONSTITUENT_DEAD))
-                WT_TRET(__clayered_close_cursors(clayered));
+                WT_TRET(__clayered_cache_cursors(clayered));
 
             goto done;
         }

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -261,6 +261,8 @@ __session_close_cursors(WT_SESSION_IMPL *session, WT_CURSOR_LIST *cursors)
     /* Close all open cursors. */
     WT_TAILQ_SAFE_REMOVE_BEGIN(cursor, cursors, q, cursor_tmp)
     {
+        if (WT_PREFIX_MATCH(cursor->internal_uri, "layered:"))
+            F_SET(cursor, WT_CURSTD_CONSTITUENT_DEAD);
         if (F_ISSET(cursor, WT_CURSTD_CACHED))
             /*
              * Put the cached cursor in an open state that allows it to be closed.
@@ -275,8 +277,6 @@ __session_close_cursors(WT_SESSION_IMPL *session, WT_CURSOR_LIST *cursors)
             WT_TRET(session->event_handler->handle_close(
               session->event_handler, &session->iface, cursor));
 
-        if (WT_PREFIX_MATCH(cursor->internal_uri, "layered:"))
-            F_SET(cursor, WT_CURSTD_CONSTITUENT_DEAD);
         WT_TRET(cursor->close(cursor));
     }
     WT_TAILQ_SAFE_REMOVE_END


### PR DESCRIPTION
Use internal cache and reopen functions for constituent cursors, rather than "user-level" close/open functions.