### PR TITLE
WT-17110 Replace reconfigure workaround with debug=(skip_checkpoint=true) in test_layered27

### DIFF
--- a/test/suite/test_layered27.py
+++ b/test/suite/test_layered27.py
@@ -104,8 +104,7 @@ class test_layered27(wttest.WiredTigerTestCase):
         self.disagg_advance_checkpoint(conn_follow)
         oplog.check(self, session_follow, 0, 400 * self.multiplier)
 
-        self.conn.reconfigure(f'disaggregated=(role=follower)') # Prevent checkpoint during close.
-        self.conn.close()
+        self.conn.close('debug=(skip_checkpoint=true)')
         conn_follow.reconfigure('disaggregated=(role="leader")')
 
         # Checkpoint after draining the ingest table
@@ -164,8 +163,7 @@ class test_layered27(wttest.WiredTigerTestCase):
         self.disagg_advance_checkpoint(conn_follow)
         oplog.check(self, session_follow, 0, 200 * self.multiplier)
 
-        self.conn.reconfigure(f'disaggregated=(role=follower)') # Prevent checkpoint during close.
-        self.conn.close()
+        self.conn.close('debug=(skip_checkpoint=true)')
         conn_follow.reconfigure('disaggregated=(role="leader")')
 
         # Checkpoint after draining the ingest table
@@ -285,8 +283,7 @@ class test_layered27(wttest.WiredTigerTestCase):
         self.disagg_advance_checkpoint(conn_follow)
         oplog.check(self, session_follow, 0, 300 * self.multiplier)
 
-        self.conn.reconfigure(f'disaggregated=(role=follower)') # Prevent checkpoint during close.
-        self.conn.close()
+        self.conn.close('debug=(skip_checkpoint=true)')
         conn_follow.reconfigure('disaggregated=(role="leader")')
 
         # Checkpoint after draining the ingest table


### PR DESCRIPTION
Replace the workaround of reconfiguring the connection to `disaggregated=(role=follower)` to prevent a checkpoint during close with the cleaner `debug=(skip_checkpoint=true)` close config option introduced in WT-16878.

The change is applied to all 3 occurrences in the test file.