### PR TITLE
WT-17122 State that WT lock-free APIs are C11 compatible

### DIFF
--- a/src/docs/arch-concurrency.dox
+++ b/src/docs/arch-concurrency.dox
@@ -44,83 +44,43 @@ the stashed object with the generation indicating the point at which it was adde
 no reader in the system holds a generation which is older than or equal to the stashed object's
 generation it can be freed.
 
-@section atomics Atomics
+@section lock-free Lock-free synchronisation primitives
 
-As mentioned in @ref portability WiredTiger expects loads and stores of specific sizes to be atomic
-and prevent tearing. WiredTiger also relies on atomic RMW operations, these include:
-- Compare and Swap
-- Fetch add / sub
-- Add / sub fetch
+WiredTiger defines a set of APIs, such as atomic-marked accesses and standalone memory fences
+(memory barriers), and uses them in many places to ensure lock-free memory synchronisation.
+Most of these interfaces are expected to behave exactly the same as their equivalents in the
+C standard library.
 
-@section memory-barriers Memory Barriers
+For example:
 
-WiredTiger utilizes memory barriers in a number of places to manage CPU instruction reordering and
-compiler reordering. Specifically CPUs are allowed to reorder load and store instructions. If this
-occurs when two threads are reading or writing to the same shared memory locations it can result in
-those threads seeing what would otherwise be incorrect state.
+<table>
+@hrow{WiredTiger API, C standard library equivalent}
+@row{`WT_ACQUIRE_BARRIER`, `atomic_thread_fence(memory_order_acquire)`}
+@row{`__wt_atomic_load_<type>_<order>`, `atomic_load_explicit(..., <order>)`}
+@row{`__wt_atomic_cas_<type>`, `atomic_compare_exchange_strong(..., memory_order_seq_cst)`}
+@row{`__wt_atomic_sub_<type>`, `atomic_fetch_sub(..., <order>)`}
+@row{`__wt_atomic_or_generic_relaxed`, `atomic_fetch_or_explicit(..., memory_order_relaxed)`}
+</table>
 
-WiredTiger defines barriers by describing which kind of reordering they prevent, for example a
-LoadLoad barrier prevents load instructions before the barrier from being reordered with load
-instructions after the barrier. Using this definition we can define 4 types of reorderings,
-LoadLoad, StoreStore, LoadStore and StoreLoad. To simplify the barrier semantics further
-WiredTiger defines acquire and release barriers.
+Given that all WiredTiger lock-free primitives behave in accordance with the C standard library
+primitives, any data races in WiredTiger constitute undefined behavior and must be avoided.
 
-@subsection acq-bar Acquire barrier
+Some WiredTiger interfaces do not explicitly mirror any API from the C standard library, but can be
+implemented through a combination of C-compatible API calls. There are only two types of such
+interfaces: `WT_READ/WRITE_ONCE` and `WT_ACQUIRE_READ/RELEASE_WRITE_WITH_BARRIER`.
 
-The acquire barrier prevents LoadLoad and LoadStore reorderings. It is accessible through two
-macros.
+`WT_READ/WRITE_ONCE` is effectively a relaxed atomic load or store, combined with a cast to
+`volatile` to prevent unsafe compiler optimisations. It is described in more detail earlier in
+@ref volatile.
 
-Firstly \c WT_ACQUIRE_BARRIER which is a standalone barrier. This barrier enforces an ordering
-between all reads prior to the barrier, and all reads or writes following the barrier. Oftentimes
-this barrier is used to provide ordering between a single prior read and all subsequent read and
-writes, in which case \c WT_ACQUIRE_READ_WITH_BARRIER can be used. While
-\c WT_ACQUIRE_READ_WITH_BARRIER can be thought of as ordering a single read with all subsequent
-instructions, mechanically it is still a \c WT_ACQUIRE_BARRIER and has the same semantics. It is
-better to use \c WT_ACQUIRE_READ to order a single prior read, described below.
-
-@subsection rel-bar Release barrier
-
-The release barrier prevents StoreStore and LoadStore reorderings. \c WT_RELEASE_BARRIER behaves
-similarly to \c WT_ACQUIRE_BARRIER, but orders all subsequent writes against all prior reads and
-writes. \c WT_RELEASE_WRITE_WITH_BARRIER has a similar intent to the
-\c WT_ACQUIRE_READ_WITH_BARRIER. It can be thought of as ordering a single write with respect to all
-prior reads and writes. However it is semantically the same as the \c WT_RELEASE_BARRIER. These
-barriers should be used as pairs. If one location requires an acquire barrier then there must be
-another location that requires a release barrier.  It is better to use \c WT_RELEASE_WRITE to order
-a single write, described below.
-
-Previously WiredTiger defined a \c WT_PUBLISH macro which prevented StoreStore reordering, this
-macro has since been removed however the term publish still exists in the code base. The term
-publish is used to refer to writing a value to a shared memory location. It doesn't define any
-memory ordering semantics.
-
-@subsection full-bar Full barrier
-
-The full barrier prevents all 4 described types of reorderings and is accessible via the
-\c WT_FULL_BARRIER macro. It is the only way to prevent StoreLoad reordering.
+`WT_ACQUIRE_READ/RELEASE_WRITE_WITH_BARRIER` is a relaxed atomic load or store combined with an
+acquire or release barrier. However, note that these interfaces have been deprecated and should not
+be used in newly developed code.
 
 @subsection com-bar Compiler barrier
 
-The compiler barrier prevents compiler optimization and reordering across the compiler barrier. This
-barrier is accessed via the \c WT_COMPILER_BARRIER. It does not impact CPU reordering. Additionally
-all memory barriers described are also compiler barriers.
+A compiler barrier prevents compiler optimisations and code reordering across the barrier point.
+It is invoked via the \c WT_COMPILER_BARRIER macro and does not affect CPU reordering.
 
-@section marked-access Marked Access
-Barriers are a heavy hammer for situations that only need to prevent reordering of instructions
-on one side of a load or store. To reduce the amount of reorderings prevented WiredTiger defines two
-marked access macros. These are loads and stores that prevent reordering from one direction across
-that load or store. The macro then achieve the intended semantics of \c WT_ACQUIRE_READ_WITH_BARRIER
-and \c WT_RELEASE_WRITE_WITH_BARRIER without added side effects.
-
-@subsection acq-marked Acquire
-
-\c WT_ACQUIRE_READ, this macro prevents loads and stores following the load from being reordered
-with it. Ensuring they happen after the marked load.
-
-@subsection rel-marked Release
-
-\c The WT_RELEASE_WRITE macro prevents loads and stores prior to the store from being reordered
-with it. Ensuring the store happens after the given loads and stores. As with the acquire and
-release barriers these marked access macros should be paired together to function correctly.
-
-*/
+This is the only lock-free synchronisation primitive in WiredTiger that has no equivalent and cannot
+be implemented through the C standard library.

--- a/src/docs/arch-concurrency.dox
+++ b/src/docs/arch-concurrency.dox
@@ -76,8 +76,8 @@ WiredTiger utilizes volatile for one reason, managing compiler optimization. Lev
 definitions from "Is Parallel Programming Hard, And, If So, What Can You Do About It?", Paul E.
 McKenney, WiredTiger utilizes volatile to prevent the following type of compiler optimizations: Load
 fusing, store fusing, invented loads, invented stores and code reordering. WiredTiger defines the
-following macros WT_READ_ONCE and WT_WRITE_ONCE which, if used correctly, prevent the prescribed
-forms of compiler optimization. Additionally some variables in WiredTiger are defined with the
-volatile keyword if it is known that they will be frequently accessed in a concurrent context.
+`WT_X_ONCE` macros which, if used correctly, prevent the prescribed forms of compiler optimization.
+Additionally some variables in WiredTiger are defined with the volatile keyword if it is known that
+they will be frequently accessed in a concurrent context.
 
 */

--- a/src/docs/arch-concurrency.dox
+++ b/src/docs/arch-concurrency.dox
@@ -1,7 +1,7 @@
 /*! @arch_page arch-concurrency Concurrency management
 
 WiredTiger supports multi-threaded execution: application threads may call its APIs concurrently,
-and WiredTiger creates internal threads for operations such as checkpointing and eviction. This
+and WiredTiger utilizes internal threads for operations such as checkpointing and eviction. This
 page describes the mechanisms WiredTiger defines to safely manage concurrent access to shared memory.
 The @ref locking and @ref generations sections cover mutual exclusion and shared-object lifecycle
 management. The @ref lock-free section covers atomic operations and memory barriers used for
@@ -58,15 +58,14 @@ For example:
 
 Some WiredTiger interfaces do not explicitly mirror any API from the C standard library, but can be
 implemented through a combination of C-compatible API calls. There are only two types of such
-interfaces: `WT_READ/WRITE_ONCE` and `WT_ACQUIRE_READ/RELEASE_WRITE_WITH_BARRIER`.
+interfaces: `WT_[READ|WRITE]_ONCE` and `WT_[ACQUIRE_READ|RELEASE_WRITE]_WITH_BARRIER`.
 
-`WT_READ/WRITE_ONCE` is effectively a relaxed atomic load or store, combined with a cast to
-`volatile` to prevent unsafe compiler optimizations. It is described in more detail earlier in
-@ref volatile.
+`WT_X_ONCE` is effectively a relaxed atomic load or store, combined with a cast to `volatile`
+to prevent unsafe compiler optimizations. It is described in more detail earlier in @ref volatile.
 
-`WT_ACQUIRE_READ/RELEASE_WRITE_WITH_BARRIER` is a relaxed atomic load or store combined with an
-acquire or release barrier. However, note that these interfaces have been deprecated and should not
-be used in newly developed code.
+`WT_X_WITH_BARRIER` is a relaxed atomic load or store combined with an acquire or release barrier.
+However, note that these interfaces have been deprecated and should not be used in newly developed
+code.
 
 Given that all WiredTiger lock-free primitives behave in accordance with the C standard library
 primitives, any data races in WiredTiger constitute undefined behavior and must be avoided.

--- a/src/docs/arch-concurrency.dox
+++ b/src/docs/arch-concurrency.dox
@@ -77,5 +77,4 @@ be used in newly developed code.
 Given that all WiredTiger lock-free primitives behave in accordance with the C standard library
 primitives, any data races in WiredTiger constitute undefined behavior and must be avoided.
 
-
 */

--- a/src/docs/arch-concurrency.dox
+++ b/src/docs/arch-concurrency.dox
@@ -1,19 +1,13 @@
 /*! @arch_page arch-concurrency Concurrency management
 
-WiredTiger is a multi-threaded application and needs to manage concurrent access to memory
-locations. Many mechanisms are defined in WiredTiger to allow for safe concurrent access to memory
-locations. This page describes what those mechanisms are and the intended usage of them in the code
-base.
-
-@section volatile Volatile
-
-WiredTiger utilizes volatile for one reason, managing compiler optimization. Leveraging the
-definitions from "Is Parallel Programming Hard, And, If So, What Can You Do About It?", Paul E.
-McKenney, WiredTiger utilizes volatile to prevent the following type of compiler optimizations: Load
-fusing, store fusing, invented loads, invented stores and code reordering. WiredTiger defines the
-following macros WT_READ_ONCE and WT_WRITE_ONCE which, if used correctly, prevent the prescribed
-forms of compiler optimization. Additionally some variables in WiredTiger are defined with the
-volatile keyword if it is known that they will be frequently accessed in a concurrent context.
+WiredTiger supports multi-threaded execution: application threads may call its APIs concurrently,
+and WiredTiger creates internal threads for operations such as checkpointing and eviction. This
+page describes the mechanisms WiredTiger defines to safely manage concurrent access to shared memory.
+The @ref locking and @ref generations sections cover mutual exclusion and shared-object lifecycle
+management. The @ref lock-free section covers atomic operations and memory barriers used for
+synchronization without locks. The @ref volatile section covers the use of the \c volatile qualifier
+and related macros to prevent the compiler from applying optimizations that are unsafe in a
+concurrent context.
 
 @section locking Locking
 
@@ -76,5 +70,15 @@ be used in newly developed code.
 
 Given that all WiredTiger lock-free primitives behave in accordance with the C standard library
 primitives, any data races in WiredTiger constitute undefined behavior and must be avoided.
+
+@section volatile Volatile
+
+WiredTiger utilizes volatile for one reason, managing compiler optimization. Leveraging the
+definitions from "Is Parallel Programming Hard, And, If So, What Can You Do About It?", Paul E.
+McKenney, WiredTiger utilizes volatile to prevent the following type of compiler optimizations: Load
+fusing, store fusing, invented loads, invented stores and code reordering. WiredTiger defines the
+following macros WT_READ_ONCE and WT_WRITE_ONCE which, if used correctly, prevent the prescribed
+forms of compiler optimization. Additionally some variables in WiredTiger are defined with the
+volatile keyword if it is known that they will be frequently accessed in a concurrent context.
 
 */

--- a/src/docs/arch-concurrency.dox
+++ b/src/docs/arch-concurrency.dox
@@ -60,12 +60,12 @@ Some WiredTiger interfaces do not explicitly mirror any API from the C standard 
 implemented through a combination of C-compatible API calls. There are only two types of such
 interfaces: `WT_[READ|WRITE]_ONCE` and `WT_[ACQUIRE_READ|RELEASE_WRITE]_WITH_BARRIER`.
 
-`WT_X_ONCE` is effectively a relaxed atomic load or store, combined with a cast to `volatile`
+`WT_[READ|WRITE]_ONCE` is effectively a relaxed atomic load or store, combined with a cast to `volatile`
 to prevent unsafe compiler optimizations. It is described in more detail earlier in @ref volatile.
 
-`WT_X_WITH_BARRIER` is a relaxed atomic load or store combined with an acquire or release barrier.
-However, note that these interfaces have been deprecated and should not be used in newly developed
-code.
+`WT_[ACQUIRE_READ|RELEASE_WRITE]_WITH_BARRIER` is a relaxed atomic load or store combined with an
+acquire or release barrier. However, note that these interfaces have been deprecated and should not
+be used in newly developed code.
 
 Given that all WiredTiger lock-free primitives behave in accordance with the C standard library
 primitives, any data races in WiredTiger constitute undefined behavior and must be avoided.
@@ -76,7 +76,7 @@ WiredTiger utilizes volatile for one reason, managing compiler optimization. Lev
 definitions from "Is Parallel Programming Hard, And, If So, What Can You Do About It?", Paul E.
 McKenney, WiredTiger utilizes volatile to prevent the following type of compiler optimizations: Load
 fusing, store fusing, invented loads, invented stores and code reordering. WiredTiger defines the
-`WT_X_ONCE` macros which, if used correctly, prevent the prescribed forms of compiler optimization.
+`WT_[READ|WRITE]_ONCE` macros which, if used correctly, prevent the prescribed forms of compiler optimization.
 Additionally some variables in WiredTiger are defined with the volatile keyword if it is known that
 they will be frequently accessed in a concurrent context.
 

--- a/src/docs/arch-concurrency.dox
+++ b/src/docs/arch-concurrency.dox
@@ -84,3 +84,5 @@ It is invoked via the \c WT_COMPILER_BARRIER macro and does not affect CPU reord
 
 This is the only lock-free synchronization primitive in WiredTiger that has no equivalent and cannot
 be implemented through the C standard library.
+
+*/

--- a/src/docs/arch-concurrency.dox
+++ b/src/docs/arch-concurrency.dox
@@ -44,10 +44,10 @@ the stashed object with the generation indicating the point at which it was adde
 no reader in the system holds a generation which is older than or equal to the stashed object's
 generation it can be freed.
 
-@section lock-free Lock-free synchronisation primitives
+@section lock-free Lock-free synchronization primitives
 
 WiredTiger defines a set of APIs, such as atomic-marked accesses and standalone memory fences
-(memory barriers), and uses them in many places to ensure lock-free memory synchronisation.
+(memory barriers), and uses them in many places to ensure lock-free memory synchronization.
 Most of these interfaces are expected to behave exactly the same as their equivalents in the
 C standard library.
 
@@ -70,7 +70,7 @@ implemented through a combination of C-compatible API calls. There are only two 
 interfaces: `WT_READ/WRITE_ONCE` and `WT_ACQUIRE_READ/RELEASE_WRITE_WITH_BARRIER`.
 
 `WT_READ/WRITE_ONCE` is effectively a relaxed atomic load or store, combined with a cast to
-`volatile` to prevent unsafe compiler optimisations. It is described in more detail earlier in
+`volatile` to prevent unsafe compiler optimizations. It is described in more detail earlier in
 @ref volatile.
 
 `WT_ACQUIRE_READ/RELEASE_WRITE_WITH_BARRIER` is a relaxed atomic load or store combined with an
@@ -79,8 +79,8 @@ be used in newly developed code.
 
 @subsection com-bar Compiler barrier
 
-A compiler barrier prevents compiler optimisations and code reordering across the barrier point.
+A compiler barrier prevents compiler optimizations and code reordering across the barrier point.
 It is invoked via the \c WT_COMPILER_BARRIER macro and does not affect CPU reordering.
 
-This is the only lock-free synchronisation primitive in WiredTiger that has no equivalent and cannot
+This is the only lock-free synchronization primitive in WiredTiger that has no equivalent and cannot
 be implemented through the C standard library.

--- a/src/docs/arch-concurrency.dox
+++ b/src/docs/arch-concurrency.dox
@@ -56,10 +56,10 @@ For example:
 <table>
 @hrow{WiredTiger API, C standard library equivalent}
 @row{`WT_ACQUIRE_BARRIER`, `atomic_thread_fence(memory_order_acquire)`}
-@row{`__wt_atomic_load_<type>_<order>`, `atomic_load_explicit(..., <order>)`}
-@row{`__wt_atomic_cas_<type>`, `atomic_compare_exchange_strong(..., memory_order_seq_cst)`}
-@row{`__wt_atomic_sub_<type>`, `atomic_fetch_sub(..., <order>)`}
-@row{`__wt_atomic_or_generic_relaxed`, `atomic_fetch_or_explicit(..., memory_order_relaxed)`}
+@row{`WT_COMPILER_BARRIER`, `atomic_signal_fence(memory_order_seq_cst)`}
+@row{`__wt_atomic_load_<type>_<order>`, `atomic_load_explicit(<order>)`}
+@row{`__wt_atomic_cas_<type>`, `atomic_compare_exchange_strong_explicit(memory_order_seq_cst)`}
+@row{`__wt_atomic_or_generic_relaxed`, `atomic_fetch_or_explicit(memory_order_relaxed)`}
 </table>
 
 Given that all WiredTiger lock-free primitives behave in accordance with the C standard library
@@ -76,13 +76,5 @@ interfaces: `WT_READ/WRITE_ONCE` and `WT_ACQUIRE_READ/RELEASE_WRITE_WITH_BARRIER
 `WT_ACQUIRE_READ/RELEASE_WRITE_WITH_BARRIER` is a relaxed atomic load or store combined with an
 acquire or release barrier. However, note that these interfaces have been deprecated and should not
 be used in newly developed code.
-
-@subsection com-bar Compiler barrier
-
-A compiler barrier prevents compiler optimizations and code reordering across the barrier point.
-It is invoked via the \c WT_COMPILER_BARRIER macro and does not affect CPU reordering.
-
-This is the only lock-free synchronization primitive in WiredTiger that has no equivalent and cannot
-be implemented through the C standard library.
 
 */

--- a/src/docs/arch-concurrency.dox
+++ b/src/docs/arch-concurrency.dox
@@ -62,9 +62,6 @@ For example:
 @row{`__wt_atomic_or_generic_relaxed`, `atomic_fetch_or_explicit(memory_order_relaxed)`}
 </table>
 
-Given that all WiredTiger lock-free primitives behave in accordance with the C standard library
-primitives, any data races in WiredTiger constitute undefined behavior and must be avoided.
-
 Some WiredTiger interfaces do not explicitly mirror any API from the C standard library, but can be
 implemented through a combination of C-compatible API calls. There are only two types of such
 interfaces: `WT_READ/WRITE_ONCE` and `WT_ACQUIRE_READ/RELEASE_WRITE_WITH_BARRIER`.
@@ -76,5 +73,9 @@ interfaces: `WT_READ/WRITE_ONCE` and `WT_ACQUIRE_READ/RELEASE_WRITE_WITH_BARRIER
 `WT_ACQUIRE_READ/RELEASE_WRITE_WITH_BARRIER` is a relaxed atomic load or store combined with an
 acquire or release barrier. However, note that these interfaces have been deprecated and should not
 be used in newly developed code.
+
+Given that all WiredTiger lock-free primitives behave in accordance with the C standard library
+primitives, any data races in WiredTiger constitute undefined behavior and must be avoided.
+
 
 */

--- a/src/docs/arch-usage-patterns.dox
+++ b/src/docs/arch-usage-patterns.dox
@@ -109,11 +109,11 @@ that will not be covered here.
 If a new slot is required in the array, but all slots are in use and \c slot_count is equal to the
 size \c Z of the array then the array must grow. The variable \c slot_count has additional ordering
 defined when swapping in the array. The array pointer swap must happen before \c slot_count is
-incremented. This requires a @ref rel-marked.
+incremented. This requires a release store.
 
 @subsubsection growable-arrays-reading Reading
 Readers must respect the writer side ordering. The \c slot_count must be read prior to reading the
-array pointer. This requires an @ref acq-marked. If this ordering is not respected the reader could
+array pointer. This requires an acquire read. If this ordering is not respected the reader could
 read an old array pointer but a new \c slot_count and encounter an array index out of bounds
 exception.
 

--- a/src/docs/arch-usage-patterns.dox
+++ b/src/docs/arch-usage-patterns.dox
@@ -19,13 +19,14 @@ is the data being shared, and a "signal" variable. The payload could be a number
 
 For the writer to share this payload with readers it needs to perform two steps in the correct
 order. Firstly it writes the payload, then writes a signal variable with a release write. The reader
-threads will read the signal variable to know if the payload is safe to read. The release write must
-use the \c WT_RELEASE_WRITE macro described in @ref rel-marked.
+threads will read the signal variable to know if the payload is safe to read.
 
 The reader threads must read with the opposite order, to do so they read the signal variable using
-the acquire read macro \c WT_ACQUIRE_READ. Then they read the payload, the \c WT_ACQUIRE_READ macro
-provides the required ordering semantics. The macro is described in @ref acq-marked. If the signal
-variable indicates the payload is safe to read the reader thread can read the payload.
+an acquire read. Then they read the payload, the acquire read provides the required ordering semantics.
+If the signal variable indicates the payload is safe to read the reader thread can read the payload.
+
+Acquire/release semantics in WiredTiger work in exactly the same way as the acquire/release semantics
+provided by C standard library atomics. Read more about WiredTiger atomics in @ref lock-free.
 
 This pattern is used in many places in WiredTiger but they are not listed here as the list will
 become stale.
@@ -149,7 +150,7 @@ used as it provides a much simpler interface for developers when reading and deb
         // we re-read the contents of S to verify it hasn't changed.
         FULL_BARRIER();
 
-        if(*S != initial_s) {
+        if(*S != initial_s_value) {
             // The write was unsuccessful. Rollback or retry.
         }
     }
@@ -159,7 +160,7 @@ used as it provides a much simpler interface for developers when reading and deb
 
 __Note:__ The following example assumes familiarity with WiredTiger's @ref generations.
 
-In the generation code the \c __wt_session_gen_enter function the current value of the
+In the generation code, the \c __wt_session_gen_enter function reads the current value of the
 \c connection->generation (\c S) and writes it to \c session->generation (\c W). Independently a second
 thread executing \c __gen_oldest will first read \c connection->generation and then walk all
 \c session->generations, reporting the smallest generation seen.

--- a/src/docs/spell.ok
+++ b/src/docs/spell.ok
@@ -288,6 +288,7 @@ crashless
 crc
 cryptographic
 cryptographically
+cst
 csuite
 ctest
 curfile


### PR DESCRIPTION
Recently, we conducted research and discovered that the current lock-free APIs provided in WT follow the same rules as the APIs provided by the C11 standard library atomics. Based on this, it was decided to update our documentation to state that we expect the same behavior from our APIs as from C11 atomics.

This change allows us to leverage existing materials and literature written for C11 when reasoning about our atomic usage, and also avoids the unnecessary cost of maintaining our own software memory model through WT atomics.
