### PR TITLE
WT-16922 Improve RTS reporting

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -57,6 +57,7 @@ BqRv
 Brueckner
 Bsearch
 Btree
+Btrees
 Buf
 Buildvariants
 Bxxx

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1923,9 +1923,6 @@ extern void __wti_read_row_time_window(
   WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW *rip, WT_TIME_WINDOW *tw);
 extern void __wti_ref_addr_safe_free(WT_SESSION_IMPL *session, void *p, size_t len);
 extern void __wti_rts_pop_work(WT_SESSION_IMPL *session, WT_RTS_WORK_UNIT **entryp);
-extern void __wti_rts_progress_init(WT_SESSION_IMPL *session);
-extern void __wti_rts_progress_msg(
-  WT_SESSION_IMPL *session, WT_TIMER *rollback_start, uint64_t *msg_count);
 extern void __wti_rts_progress_msg_walk(WT_SESSION_IMPL *session, WT_TIMER *btree_start,
   uint64_t *msg_count, double npos, uint64_t btree_pages);
 extern void __wti_rts_work_free(WT_SESSION_IMPL *session, WT_RTS_WORK_UNIT *entry);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1924,8 +1924,8 @@ extern void __wti_read_row_time_window(
 extern void __wti_ref_addr_safe_free(WT_SESSION_IMPL *session, void *p, size_t len);
 extern void __wti_rts_pop_work(WT_SESSION_IMPL *session, WT_RTS_WORK_UNIT **entryp);
 extern void __wti_rts_progress_init(WT_SESSION_IMPL *session);
-extern void __wti_rts_progress_msg(WT_SESSION_IMPL *session, WT_TIMER *rollback_start,
-  uint64_t rollback_count, uint64_t max_count, uint64_t *rollback_msg_count, bool walk);
+extern void __wti_rts_progress_msg(
+  WT_SESSION_IMPL *session, WT_TIMER *rollback_start, uint64_t *msg_count);
 extern void __wti_rts_progress_msg_walk(WT_SESSION_IMPL *session, WT_TIMER *btree_start,
   uint64_t *msg_count, double npos, uint64_t btree_pages);
 extern void __wti_rts_work_free(WT_SESSION_IMPL *session, WT_RTS_WORK_UNIT *entry);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1923,8 +1923,8 @@ extern void __wti_read_row_time_window(
   WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW *rip, WT_TIME_WINDOW *tw);
 extern void __wti_ref_addr_safe_free(WT_SESSION_IMPL *session, void *p, size_t len);
 extern void __wti_rts_pop_work(WT_SESSION_IMPL *session, WT_RTS_WORK_UNIT **entryp);
-extern void __wti_rts_progress_msg_walk(WT_SESSION_IMPL *session, WT_TIMER *btree_start,
-  uint64_t *msg_count, double npos, uint64_t btree_pages);
+extern void __wti_rts_progress_msg_walk(
+  WT_SESSION_IMPL *session, uint64_t *last_report_clock, double npos, uint64_t btree_pages);
 extern void __wti_rts_work_free(WT_SESSION_IMPL *session, WT_RTS_WORK_UNIT *entry);
 extern void __wti_schema_destroy_colgroup(WT_SESSION_IMPL *session, WT_COLGROUP **colgroupp);
 extern void __wti_tiered_get_remove_shared(WT_SESSION_IMPL *session, WT_TIERED_WORK_UNIT **entryp);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1926,8 +1926,8 @@ extern void __wti_rts_pop_work(WT_SESSION_IMPL *session, WT_RTS_WORK_UNIT **entr
 extern void __wti_rts_progress_init(WT_SESSION_IMPL *session);
 extern void __wti_rts_progress_msg(WT_SESSION_IMPL *session, WT_TIMER *rollback_start,
   uint64_t rollback_count, uint64_t max_count, uint64_t *rollback_msg_count, bool walk);
-extern void __wti_rts_progress_msg_walk(
-  WT_SESSION_IMPL *session, WT_TIMER *btree_start, uint64_t *msg_count, double npos);
+extern void __wti_rts_progress_msg_walk(WT_SESSION_IMPL *session, WT_TIMER *btree_start,
+  uint64_t *msg_count, double npos, uint64_t btree_pages);
 extern void __wti_rts_work_free(WT_SESSION_IMPL *session, WT_RTS_WORK_UNIT *entry);
 extern void __wti_schema_destroy_colgroup(WT_SESSION_IMPL *session, WT_COLGROUP **colgroupp);
 extern void __wti_tiered_get_remove_shared(WT_SESSION_IMPL *session, WT_TIERED_WORK_UNIT **entryp);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1926,6 +1926,8 @@ extern void __wti_rts_pop_work(WT_SESSION_IMPL *session, WT_RTS_WORK_UNIT **entr
 extern void __wti_rts_progress_init(WT_SESSION_IMPL *session);
 extern void __wti_rts_progress_msg(WT_SESSION_IMPL *session, WT_TIMER *rollback_start,
   uint64_t rollback_count, uint64_t max_count, uint64_t *rollback_msg_count, bool walk);
+extern void __wti_rts_progress_msg_walk(
+  WT_SESSION_IMPL *session, WT_TIMER *btree_start, uint64_t *msg_count, double npos);
 extern void __wti_rts_work_free(WT_SESSION_IMPL *session, WT_RTS_WORK_UNIT *entry);
 extern void __wti_schema_destroy_colgroup(WT_SESSION_IMPL *session, WT_COLGROUP **colgroupp);
 extern void __wti_tiered_get_remove_shared(WT_SESSION_IMPL *session, WT_TIERED_WORK_UNIT **entryp);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1923,6 +1923,7 @@ extern void __wti_read_row_time_window(
   WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW *rip, WT_TIME_WINDOW *tw);
 extern void __wti_ref_addr_safe_free(WT_SESSION_IMPL *session, void *p, size_t len);
 extern void __wti_rts_pop_work(WT_SESSION_IMPL *session, WT_RTS_WORK_UNIT **entryp);
+extern void __wti_rts_progress_init(WT_SESSION_IMPL *session);
 extern void __wti_rts_progress_msg(WT_SESSION_IMPL *session, WT_TIMER *rollback_start,
   uint64_t rollback_count, uint64_t max_count, uint64_t *rollback_msg_count, bool walk);
 extern void __wti_rts_work_free(WT_SESSION_IMPL *session, WT_RTS_WORK_UNIT *entry);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1923,8 +1923,8 @@ extern void __wti_read_row_time_window(
   WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW *rip, WT_TIME_WINDOW *tw);
 extern void __wti_ref_addr_safe_free(WT_SESSION_IMPL *session, void *p, size_t len);
 extern void __wti_rts_pop_work(WT_SESSION_IMPL *session, WT_RTS_WORK_UNIT **entryp);
-extern void __wti_rts_progress_msg_walk(
-  WT_SESSION_IMPL *session, uint64_t *last_report_clock, double npos, uint64_t btree_pages);
+extern void __wti_rts_progress_msg_walk(WT_SESSION_IMPL *session, uint64_t btree_start_clock,
+  uint64_t *last_report_clock, double npos, uint64_t btree_pages);
 extern void __wti_rts_work_free(WT_SESSION_IMPL *session, WT_RTS_WORK_UNIT *entry);
 extern void __wti_schema_destroy_colgroup(WT_SESSION_IMPL *session, WT_COLGROUP **colgroupp);
 extern void __wti_tiered_get_remove_shared(WT_SESSION_IMPL *session, WT_TIERED_WORK_UNIT **entryp);

--- a/src/include/rollback_to_stable.h
+++ b/src/include/rollback_to_stable.h
@@ -130,14 +130,12 @@ struct __wt_rollback_to_stable {
     /* RTS progress tracking. */
     struct {
         WT_TIMER start_timer;                    /* Overall RTS start time. */
-        WT_TIMER btree_apply_timer;              /* When btree-apply phase began. */
         uint64_t total_btrees;                   /* From metadata count pass (set once). */
         wt_shared uint32_t phase;                /* Current RTS phase (WT_RTS_PHASE_*). */
         wt_shared uint64_t overall_report_count; /* CAS-guarded overall report throttle. */
         wt_shared uint64_t btrees_processed;     /* Btrees fully processed (atomic). */
         wt_shared uint64_t btrees_skipped;       /* Btrees skipped, no work needed (atomic). */
         wt_shared uint64_t pages_walked;         /* Pages walked across all btrees (atomic). */
-        wt_shared uint64_t max_btree_eta_sec;    /* Largest per-btree ETA seen (atomic). */
     } progress;
 };
 

--- a/src/include/rollback_to_stable.h
+++ b/src/include/rollback_to_stable.h
@@ -137,6 +137,7 @@ struct __wt_rollback_to_stable {
         wt_shared uint64_t btrees_processed;     /* Btrees fully processed (atomic). */
         wt_shared uint64_t btrees_skipped;       /* Btrees skipped, no work needed (atomic). */
         wt_shared uint64_t pages_walked;         /* Pages walked across all btrees (atomic). */
+        wt_shared uint64_t max_btree_eta_sec;    /* Largest per-btree ETA seen (atomic). */
     } progress;
 };
 

--- a/src/include/rollback_to_stable.h
+++ b/src/include/rollback_to_stable.h
@@ -129,14 +129,14 @@ struct __wt_rollback_to_stable {
 
     /* RTS progress tracking. */
     struct {
-        WT_TIMER start_timer;                /* Overall RTS start time. */
-        WT_TIMER btree_apply_timer;          /* When btree-apply phase began. */
-        WT_SESSION_IMPL *main_session;       /* Main thread session, for overall progress. */
-        uint64_t total_btrees;               /* From metadata count pass (set once). */
-        wt_shared uint32_t phase;            /* Current RTS phase (WT_RTS_PHASE_*). */
-        wt_shared uint64_t btrees_processed; /* Btrees fully processed (atomic). */
-        wt_shared uint64_t btrees_skipped;   /* Btrees skipped, no work needed (atomic). */
-        wt_shared uint64_t pages_walked;     /* Pages walked across all btrees (atomic). */
+        WT_TIMER start_timer;                     /* Overall RTS start time. */
+        WT_TIMER btree_apply_timer;               /* When btree-apply phase began. */
+        uint64_t total_btrees;                    /* From metadata count pass (set once). */
+        wt_shared uint32_t phase;                 /* Current RTS phase (WT_RTS_PHASE_*). */
+        wt_shared uint64_t overall_report_count;  /* CAS-guarded overall report throttle. */
+        wt_shared uint64_t btrees_processed;      /* Btrees fully processed (atomic). */
+        wt_shared uint64_t btrees_skipped;        /* Btrees skipped, no work needed (atomic). */
+        wt_shared uint64_t pages_walked;          /* Pages walked across all btrees (atomic). */
     } progress;
 };
 

--- a/src/include/rollback_to_stable.h
+++ b/src/include/rollback_to_stable.h
@@ -129,14 +129,14 @@ struct __wt_rollback_to_stable {
 
     /* RTS progress tracking. */
     struct {
-        WT_TIMER start_timer;                     /* Overall RTS start time. */
-        WT_TIMER btree_apply_timer;               /* When btree-apply phase began. */
-        uint64_t total_btrees;                    /* From metadata count pass (set once). */
-        wt_shared uint32_t phase;                 /* Current RTS phase (WT_RTS_PHASE_*). */
-        wt_shared uint64_t overall_report_count;  /* CAS-guarded overall report throttle. */
-        wt_shared uint64_t btrees_processed;      /* Btrees fully processed (atomic). */
-        wt_shared uint64_t btrees_skipped;        /* Btrees skipped, no work needed (atomic). */
-        wt_shared uint64_t pages_walked;          /* Pages walked across all btrees (atomic). */
+        WT_TIMER start_timer;                    /* Overall RTS start time. */
+        WT_TIMER btree_apply_timer;              /* When btree-apply phase began. */
+        uint64_t total_btrees;                   /* From metadata count pass (set once). */
+        wt_shared uint32_t phase;                /* Current RTS phase (WT_RTS_PHASE_*). */
+        wt_shared uint64_t overall_report_count; /* CAS-guarded overall report throttle. */
+        wt_shared uint64_t btrees_processed;     /* Btrees fully processed (atomic). */
+        wt_shared uint64_t btrees_skipped;       /* Btrees skipped, no work needed (atomic). */
+        wt_shared uint64_t pages_walked;         /* Pages walked across all btrees (atomic). */
     } progress;
 };
 

--- a/src/include/rollback_to_stable.h
+++ b/src/include/rollback_to_stable.h
@@ -132,7 +132,6 @@ struct __wt_rollback_to_stable {
         WT_TIMER start_timer;                /* Overall RTS start time. */
         WT_TIMER btree_apply_timer;          /* When btree-apply phase began. */
         WT_SESSION_IMPL *main_session;       /* Main thread session, for overall progress. */
-        uint64_t msg_count;                  /* Throttle counter for overall messages. */
         uint64_t total_btrees;               /* From metadata count pass (set once). */
         wt_shared uint32_t phase;            /* Current RTS phase (WT_RTS_PHASE_*). */
         wt_shared uint64_t btrees_processed; /* Btrees fully processed (atomic). */

--- a/src/include/rollback_to_stable.h
+++ b/src/include/rollback_to_stable.h
@@ -84,6 +84,14 @@
             WT_STAT_CONN_DSRC_INCR(session, stat##_dryrun); \
     } while (0)
 
+/* RTS phase identifiers for progress reporting. */
+#define WT_RTS_PHASE_INACTIVE 0
+#define WT_RTS_PHASE_METADATA_COUNT 1
+#define WT_RTS_PHASE_BTREE_APPLY 2
+#define WT_RTS_PHASE_QUEUE_DRAIN 3
+#define WT_RTS_PHASE_HS_FINAL_PASS 4
+#define WT_RTS_PHASE_COMPLETE 5
+
 #define WT_RTS_MAX_WORKERS 10
 /*
  * WT_RTS_WORK_UNIT --
@@ -125,6 +133,7 @@ struct __wt_rollback_to_stable {
         WT_TIMER btree_apply_timer;               /* When btree-apply phase began. */
         uint64_t msg_count;                       /* Throttle counter for periodic messages. */
         uint64_t total_btrees;                    /* From metadata count pass (set once). */
+        wt_shared uint32_t phase;                 /* Current RTS phase (WT_RTS_PHASE_*). */
         wt_shared uint64_t btrees_processed;      /* Btrees fully processed (atomic). */
         wt_shared uint64_t btrees_skipped;        /* Btrees skipped, no work needed (atomic). */
         wt_shared uint64_t pages_walked;          /* Pages walked across all btrees (atomic). */

--- a/src/include/rollback_to_stable.h
+++ b/src/include/rollback_to_stable.h
@@ -118,6 +118,17 @@ struct __wt_rollback_to_stable {
 
     /* Configuration. */
     bool dryrun;
+
+    /* RTS progress tracking. */
+    struct {
+        WT_TIMER start_timer;                     /* Overall RTS start time. */
+        WT_TIMER btree_apply_timer;               /* When btree-apply phase began. */
+        uint64_t msg_count;                       /* Throttle counter for periodic messages. */
+        uint64_t total_btrees;                    /* From metadata count pass (set once). */
+        wt_shared uint64_t btrees_processed;      /* Btrees fully processed (atomic). */
+        wt_shared uint64_t btrees_skipped;        /* Btrees skipped, no work needed (atomic). */
+        wt_shared uint64_t pages_walked;          /* Pages walked across all btrees (atomic). */
+    } progress;
 };
 
 /*

--- a/src/include/rollback_to_stable.h
+++ b/src/include/rollback_to_stable.h
@@ -131,7 +131,8 @@ struct __wt_rollback_to_stable {
     struct {
         WT_TIMER start_timer;                /* Overall RTS start time. */
         WT_TIMER btree_apply_timer;          /* When btree-apply phase began. */
-        uint64_t msg_count;                  /* Throttle counter for periodic messages. */
+        WT_SESSION_IMPL *main_session;       /* Main thread session, for overall progress. */
+        uint64_t msg_count;                  /* Throttle counter for overall messages. */
         uint64_t total_btrees;               /* From metadata count pass (set once). */
         wt_shared uint32_t phase;            /* Current RTS phase (WT_RTS_PHASE_*). */
         wt_shared uint64_t btrees_processed; /* Btrees fully processed (atomic). */

--- a/src/include/rollback_to_stable.h
+++ b/src/include/rollback_to_stable.h
@@ -129,13 +129,13 @@ struct __wt_rollback_to_stable {
 
     /* RTS progress tracking. */
     struct {
-        WT_TIMER start_timer;                    /* Overall RTS start time. */
-        uint64_t total_btrees;                   /* From metadata count pass (set once). */
-        wt_shared uint32_t phase;                /* Current RTS phase (WT_RTS_PHASE_*). */
-        wt_shared uint64_t overall_last_report;  /* CAS-guarded clock of last overall report. */
-        wt_shared uint64_t btrees_processed;     /* Btrees fully processed (atomic). */
-        wt_shared uint64_t btrees_skipped;       /* Btrees skipped, no work needed (atomic). */
-        wt_shared uint64_t pages_walked;         /* Pages walked across all btrees (atomic). */
+        WT_TIMER start_timer;                   /* Overall RTS start time. */
+        uint64_t total_btrees;                  /* From metadata count pass (set once). */
+        wt_shared uint32_t phase;               /* Current RTS phase (WT_RTS_PHASE_*). */
+        wt_shared uint64_t overall_last_report; /* CAS-guarded clock of last overall report. */
+        wt_shared uint64_t btrees_processed;    /* Btrees fully processed (atomic). */
+        wt_shared uint64_t btrees_skipped;      /* Btrees skipped, no work needed (atomic). */
+        wt_shared uint64_t pages_walked;        /* Pages walked across all btrees (atomic). */
     } progress;
 };
 

--- a/src/include/rollback_to_stable.h
+++ b/src/include/rollback_to_stable.h
@@ -132,7 +132,7 @@ struct __wt_rollback_to_stable {
         WT_TIMER start_timer;                    /* Overall RTS start time. */
         uint64_t total_btrees;                   /* From metadata count pass (set once). */
         wt_shared uint32_t phase;                /* Current RTS phase (WT_RTS_PHASE_*). */
-        wt_shared uint64_t overall_report_count; /* CAS-guarded overall report throttle. */
+        wt_shared uint64_t overall_last_report;  /* CAS-guarded clock of last overall report. */
         wt_shared uint64_t btrees_processed;     /* Btrees fully processed (atomic). */
         wt_shared uint64_t btrees_skipped;       /* Btrees skipped, no work needed (atomic). */
         wt_shared uint64_t pages_walked;         /* Pages walked across all btrees (atomic). */

--- a/src/include/rollback_to_stable.h
+++ b/src/include/rollback_to_stable.h
@@ -129,14 +129,14 @@ struct __wt_rollback_to_stable {
 
     /* RTS progress tracking. */
     struct {
-        WT_TIMER start_timer;                     /* Overall RTS start time. */
-        WT_TIMER btree_apply_timer;               /* When btree-apply phase began. */
-        uint64_t msg_count;                       /* Throttle counter for periodic messages. */
-        uint64_t total_btrees;                    /* From metadata count pass (set once). */
-        wt_shared uint32_t phase;                 /* Current RTS phase (WT_RTS_PHASE_*). */
-        wt_shared uint64_t btrees_processed;      /* Btrees fully processed (atomic). */
-        wt_shared uint64_t btrees_skipped;        /* Btrees skipped, no work needed (atomic). */
-        wt_shared uint64_t pages_walked;          /* Pages walked across all btrees (atomic). */
+        WT_TIMER start_timer;                /* Overall RTS start time. */
+        WT_TIMER btree_apply_timer;          /* When btree-apply phase began. */
+        uint64_t msg_count;                  /* Throttle counter for periodic messages. */
+        uint64_t total_btrees;               /* From metadata count pass (set once). */
+        wt_shared uint32_t phase;            /* Current RTS phase (WT_RTS_PHASE_*). */
+        wt_shared uint64_t btrees_processed; /* Btrees fully processed (atomic). */
+        wt_shared uint64_t btrees_skipped;   /* Btrees skipped, no work needed (atomic). */
+        wt_shared uint64_t pages_walked;     /* Pages walked across all btrees (atomic). */
     } progress;
 };
 

--- a/src/rollback_to_stable/rts.c
+++ b/src/rollback_to_stable/rts.c
@@ -75,16 +75,15 @@ __rts_emit_overall_progress(WT_SESSION_IMPL *session)
  *     metadata walk loop in __wti_rts_btree_apply_all.
  */
 static void
-__rts_progress_msg(WT_SESSION_IMPL *session, WT_TIMER *rollback_start, uint64_t *msg_count)
+__rts_progress_msg(WT_SESSION_IMPL *session, uint64_t *last_report_clock)
 {
-    uint64_t time_diff_ms;
+    uint64_t clock_now, elapsed_ns;
 
-    /* Time since the rollback started. */
-    __wt_timer_evaluate_ms(session, rollback_start, &time_diff_ms);
-
-    if ((time_diff_ms / (WT_THOUSAND * WT_PROGRESS_MSG_PERIOD)) > *msg_count) {
+    clock_now = __wt_clock(session);
+    elapsed_ns = __wt_clock_to_nsec(clock_now, *last_report_clock);
+    if (elapsed_ns >= (uint64_t)WT_BILLION * WT_PROGRESS_MSG_PERIOD) {
         __rts_emit_overall_progress(session);
-        *msg_count = time_diff_ms / (WT_THOUSAND * WT_PROGRESS_MSG_PERIOD);
+        *last_report_clock = clock_now;
     }
 }
 
@@ -95,54 +94,55 @@ __rts_progress_msg(WT_SESSION_IMPL *session, WT_TIMER *rollback_start, uint64_t 
  *     tree and estimate time remaining for this btree.
  */
 void
-__wti_rts_progress_msg_walk(WT_SESSION_IMPL *session, WT_TIMER *btree_start, uint64_t *msg_count,
-  double npos, uint64_t btree_pages)
+__wti_rts_progress_msg_walk(
+  WT_SESSION_IMPL *session, uint64_t *last_report_clock, double npos, uint64_t btree_pages)
 {
     WT_ROLLBACK_TO_STABLE *rts;
-    uint64_t btree_eta_sec, btree_pct, btree_pages_per_sec, elapsed_ms, overall_elapsed_ms,
-      overall_report_count;
+    uint64_t btree_eta_sec, btree_pct, btree_pages_per_sec, clock_now, elapsed_ns, elapsed_sec,
+      overall_last;
     uint32_t phase;
 
     rts = S2C(session)->rts;
 
     /* The caller has already verified it's time to report; compute values for the message. */
-    __wt_timer_evaluate_ms(session, btree_start, &elapsed_ms);
+    clock_now = __wt_clock(session);
+    elapsed_ns = __wt_clock_to_nsec(clock_now, *last_report_clock);
+    elapsed_sec = elapsed_ns / WT_BILLION;
 
     phase = __wt_atomic_load_uint32_relaxed(&rts->progress.phase);
     btree_pct = (uint64_t)(npos * 100);
-    btree_pages_per_sec = elapsed_ms > 0 ? (btree_pages * WT_THOUSAND / elapsed_ms) : 0;
+    btree_pages_per_sec = elapsed_sec > 0 ? (btree_pages / elapsed_sec) : 0;
 
     /* Estimate time remaining for this btree based on npos progression. */
     btree_eta_sec = 0;
     if (npos > 0.05 && npos < 1.0)
-        btree_eta_sec = (uint64_t)((1.0 - npos) * (double)elapsed_ms / (npos * WT_THOUSAND));
+        btree_eta_sec = (uint64_t)((1.0 - npos) * (double)elapsed_sec / npos);
 
     if (btree_eta_sec > 0)
         __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
           "Rollback to stable [%s] btree walk on %s for %" PRIu64 " seconds, %" PRIu64
           "%% through btree, %" PRIu64 " pages walked (%" PRIu64 " pages/sec), btree ETA %" PRIu64
           " seconds",
-          __rts_phase_string(phase), session->dhandle->name, elapsed_ms / WT_THOUSAND, btree_pct,
-          btree_pages, btree_pages_per_sec, btree_eta_sec);
+          __rts_phase_string(phase), session->dhandle->name, elapsed_sec, btree_pct, btree_pages,
+          btree_pages_per_sec, btree_eta_sec);
     else
         __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
           "Rollback to stable [%s] btree walk on %s for %" PRIu64 " seconds, %" PRIu64
           "%% through btree, %" PRIu64 " pages walked (%" PRIu64 " pages/sec)",
-          __rts_phase_string(phase), session->dhandle->name, elapsed_ms / WT_THOUSAND, btree_pct,
-          btree_pages, btree_pages_per_sec);
+          __rts_phase_string(phase), session->dhandle->name, elapsed_sec, btree_pct, btree_pages,
+          btree_pages_per_sec);
 
     /*
-     * Emit an overall progress line. Use CAS on overall_report_count so that exactly one thread
+     * Emit an overall progress line. Use CAS on overall_last_report so that exactly one thread
      * wins per reporting period, regardless of which thread it is.
      */
-    __wt_timer_evaluate_ms(session, &rts->progress.start_timer, &overall_elapsed_ms);
-    overall_report_count = __wt_atomic_load_uint64_relaxed(&rts->progress.overall_report_count);
-    if ((overall_elapsed_ms / (WT_THOUSAND * WT_PROGRESS_MSG_PERIOD)) > overall_report_count &&
-      __wt_atomic_cas_uint64(
-        &rts->progress.overall_report_count, overall_report_count, overall_report_count + 1))
+    overall_last = __wt_atomic_load_uint64_relaxed(&rts->progress.overall_last_report);
+    if (__wt_clock_to_nsec(clock_now, overall_last) >=
+        (uint64_t)WT_BILLION * WT_PROGRESS_MSG_PERIOD &&
+      __wt_atomic_cas_uint64(&rts->progress.overall_last_report, overall_last, clock_now))
         __rts_emit_overall_progress(session);
 
-    *msg_count = elapsed_ms / (WT_THOUSAND * WT_PROGRESS_MSG_PERIOD);
+    *last_report_clock = clock_now;
 }
 
 /*
@@ -157,6 +157,7 @@ __rts_progress_init(WT_SESSION_IMPL *session)
     rts = S2C(session)->rts;
     WT_CLEAR(rts->progress);
     __wt_timer_start(session, &rts->progress.start_timer);
+    __wt_atomic_store_uint64_relaxed(&rts->progress.overall_last_report, __wt_clock(session));
 }
 
 /*
@@ -294,8 +295,7 @@ __wti_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_time
     WT_CURSOR *cursor;
     WT_DECL_RET;
     WT_RTS_WORK_UNIT *entry;
-    WT_TIMER timer;
-    uint64_t max_count, rollback_msg_count;
+    uint64_t last_report_clock, max_count;
     char ts_string[WT_TS_INT_STRING_SIZE];
     const char *config, *saved_session_name, *uri;
     bool have_cursor, rts_threads_started;
@@ -304,10 +304,9 @@ __wti_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_time
     __wt_atomic_store_uint32_relaxed(
       &S2C(session)->rts->progress.phase, WT_RTS_PHASE_METADATA_COUNT);
 
-    __wt_timer_start(session, &timer);
+    last_report_clock = __wt_clock(session);
     max_count = 0;
     saved_session_name = session->name;
-    rollback_msg_count = 0;
     rts_threads_started = false;
 
     /*
@@ -340,7 +339,7 @@ __wti_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_time
         /* Log a progress message. */
         WT_ERR(cursor->get_key(cursor, &uri));
         WT_ERR(cursor->get_value(cursor, &config));
-        __rts_progress_msg(session, &timer, &rollback_msg_count);
+        __rts_progress_msg(session, &last_report_clock);
 
         F_SET(session, WT_SESSION_QUIET_CORRUPT_FILE);
         ret = __wti_rts_btree_walk_btree_apply(session, uri, config, rollback_timestamp);

--- a/src/rollback_to_stable/rts.c
+++ b/src/rollback_to_stable/rts.c
@@ -92,20 +92,19 @@ __wti_rts_progress_msg(WT_SESSION_IMPL *session, WT_TIMER *rollback_start, uint6
         eta_sec = __rts_compute_eta_sec(session, rollback_count);
         if (eta_sec > 0)
             __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
-              "Rollback to stable [%s] running for %" PRIu64
-              " seconds, inspected %" PRIu64 " of %" PRIu64 " btrees (%" PRIu64
-              "%%), %" PRIu64 " processed, %" PRIu64 " skipped, %" PRIu64
-              " total pages walked (%" PRIu64 " pages/sec), ETA %" PRIu64 " seconds",
-              __rts_phase_string(phase), time_diff_ms / WT_THOUSAND, rollback_count, max_count,
-              pct, btrees_processed, btrees_skipped, pages_walked, pages_per_sec, eta_sec);
+              "Rollback to stable [%s] running for %" PRIu64 " seconds, inspected %" PRIu64
+              " of %" PRIu64 " btrees (%" PRIu64 "%%), %" PRIu64 " processed, %" PRIu64
+              " skipped, %" PRIu64 " total pages walked (%" PRIu64 " pages/sec), ETA %" PRIu64
+              " seconds",
+              __rts_phase_string(phase), time_diff_ms / WT_THOUSAND, rollback_count, max_count, pct,
+              btrees_processed, btrees_skipped, pages_walked, pages_per_sec, eta_sec);
         else
             __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
-              "Rollback to stable [%s] running for %" PRIu64
-              " seconds, inspected %" PRIu64 " of %" PRIu64 " btrees (%" PRIu64
-              "%%), %" PRIu64 " processed, %" PRIu64 " skipped, %" PRIu64
-              " total pages walked (%" PRIu64 " pages/sec)",
-              __rts_phase_string(phase), time_diff_ms / WT_THOUSAND, rollback_count, max_count,
-              pct, btrees_processed, btrees_skipped, pages_walked, pages_per_sec);
+              "Rollback to stable [%s] running for %" PRIu64 " seconds, inspected %" PRIu64
+              " of %" PRIu64 " btrees (%" PRIu64 "%%), %" PRIu64 " processed, %" PRIu64
+              " skipped, %" PRIu64 " total pages walked (%" PRIu64 " pages/sec)",
+              __rts_phase_string(phase), time_diff_ms / WT_THOUSAND, rollback_count, max_count, pct,
+              btrees_processed, btrees_skipped, pages_walked, pages_per_sec);
 
         /* Notify the application via the progress callback. */
         WT_IGNORE_RET(__wt_progress(session, "rollback to stable", btrees_processed));
@@ -145,16 +144,15 @@ __wti_rts_progress_msg_walk(
 
         if (btree_eta_sec > 0)
             __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
-              "Rollback to stable [%s] btree walk on %s for %" PRIu64
-              " seconds, %" PRIu64 "%% through btree, %" PRIu64
-              " pages walked (%" PRIu64 " pages/sec), btree ETA %" PRIu64 " seconds",
+              "Rollback to stable [%s] btree walk on %s for %" PRIu64 " seconds, %" PRIu64
+              "%% through btree, %" PRIu64 " pages walked (%" PRIu64
+              " pages/sec), btree ETA %" PRIu64 " seconds",
               __rts_phase_string(phase), session->dhandle->name, elapsed_ms / WT_THOUSAND,
               btree_pct, pages_walked, pages_per_sec, btree_eta_sec);
         else
             __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
-              "Rollback to stable [%s] btree walk on %s for %" PRIu64
-              " seconds, %" PRIu64 "%% through btree, %" PRIu64
-              " pages walked (%" PRIu64 " pages/sec)",
+              "Rollback to stable [%s] btree walk on %s for %" PRIu64 " seconds, %" PRIu64
+              "%% through btree, %" PRIu64 " pages walked (%" PRIu64 " pages/sec)",
               __rts_phase_string(phase), session->dhandle->name, elapsed_ms / WT_THOUSAND,
               btree_pct, pages_walked, pages_per_sec);
 

--- a/src/rollback_to_stable/rts.c
+++ b/src/rollback_to_stable/rts.c
@@ -412,7 +412,7 @@ __wti_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_time
 
         /* Rename session while joining workers so log messages identify us as a worker. */
         saved_session_name = session->name;
-        session->name = "rts-main-wkr";
+        session->name = "rts-main-wk";
         while (!TAILQ_EMPTY(&S2C(session)->rts->rtsqh)) {
             __wti_rts_pop_work(session, &entry);
             if (entry == NULL)

--- a/src/rollback_to_stable/rts.c
+++ b/src/rollback_to_stable/rts.c
@@ -133,8 +133,8 @@ __wti_rts_progress_msg_walk(
           btree_pages_per_sec);
 
     /*
-     * Emit an overall progress line. Use CAS on overall_last_report so that exactly one thread
-     * wins per reporting period, regardless of which thread it is.
+     * Emit an overall progress line. Use CAS on overall_last_report so that exactly one thread wins
+     * per reporting period, regardless of which thread it is.
      */
     overall_last = __wt_atomic_load_uint64_relaxed(&rts->progress.overall_last_report);
     if (__wt_clock_to_nsec(clock_now, overall_last) >=

--- a/src/rollback_to_stable/rts.c
+++ b/src/rollback_to_stable/rts.c
@@ -134,7 +134,7 @@ __wti_rts_progress_msg_walk(WT_SESSION_IMPL *session, WT_TIMER *btree_start, uin
     WT_ROLLBACK_TO_STABLE *rts;
     uint64_t btree_eta_sec, btree_pct, btree_pages_per_sec, btrees_completed, btrees_processed,
       btrees_skipped, elapsed_ms, eta_sec, overall_elapsed_ms, overall_pages_per_sec, overall_pct,
-      pages_walked, total_btrees;
+      overall_report_count, pages_walked, total_btrees;
     uint32_t phase;
 
     rts = S2C(session)->rts;
@@ -165,15 +165,22 @@ __wti_rts_progress_msg_walk(WT_SESSION_IMPL *session, WT_TIMER *btree_start, uin
               __rts_phase_string(phase), session->dhandle->name, elapsed_ms / WT_THOUSAND,
               btree_pct, btree_pages, btree_pages_per_sec);
 
-        /* Emit an overall progress line, but only from the main thread. */
-        if (session == rts->progress.main_session) {
+        /*
+         * Emit an overall progress line. Use CAS on overall_report_count so that exactly one
+         * thread wins per reporting period, regardless of which thread it is.
+         */
+        __wt_timer_evaluate_ms(session, &rts->progress.start_timer, &overall_elapsed_ms);
+        overall_report_count =
+          __wt_atomic_load_uint64_relaxed(&rts->progress.overall_report_count);
+        if ((overall_elapsed_ms / (WT_THOUSAND * WT_PROGRESS_MSG_PERIOD)) > overall_report_count &&
+          __wt_atomic_cas_uint64(
+            &rts->progress.overall_report_count, overall_report_count, overall_report_count + 1)) {
             btrees_processed = __wt_atomic_load_uint64_relaxed(&rts->progress.btrees_processed);
             btrees_skipped = __wt_atomic_load_uint64_relaxed(&rts->progress.btrees_skipped);
             pages_walked = __wt_atomic_load_uint64_relaxed(&rts->progress.pages_walked);
             total_btrees = rts->progress.total_btrees;
             btrees_completed = btrees_processed + btrees_skipped;
             overall_pct = total_btrees > 0 ? (100 * btrees_completed / total_btrees) : 0;
-            __wt_timer_evaluate_ms(session, &rts->progress.start_timer, &overall_elapsed_ms);
             overall_pages_per_sec =
               overall_elapsed_ms > 0 ? (pages_walked * WT_THOUSAND / overall_elapsed_ms) : 0;
             eta_sec = __rts_compute_eta_sec(session);
@@ -211,7 +218,6 @@ __wti_rts_progress_init(WT_SESSION_IMPL *session)
 
     rts = S2C(session)->rts;
     memset(&rts->progress, 0, sizeof(rts->progress));
-    rts->progress.main_session = session;
     __wt_timer_start(session, &rts->progress.start_timer);
 }
 
@@ -353,7 +359,7 @@ __wti_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_time
     WT_TIMER timer;
     uint64_t max_count, rollback_count, rollback_msg_count;
     char ts_string[WT_TS_INT_STRING_SIZE];
-    const char *config, *uri;
+    const char *config, *saved_session_name, *uri;
     bool have_cursor, rts_threads_started;
 
     __wti_rts_progress_init(session);
@@ -361,6 +367,7 @@ __wti_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_time
 
     __wt_timer_start(session, &timer);
     max_count = rollback_count = 0;
+    saved_session_name = session->name;
     rollback_msg_count = 0;
     rts_threads_started = false;
 
@@ -417,6 +424,10 @@ __wti_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_time
         __wt_atomic_store_uint32(&S2C(session)->rts->progress.phase, WT_RTS_PHASE_QUEUE_DRAIN);
         __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS, "%s",
           "Rollback to stable finished metadata walk, draining worker queue");
+
+        /* Rename session while joining workers so log messages identify us as a worker. */
+        saved_session_name = session->name;
+        session->name = "rts-worker (main)";
         while (!TAILQ_EMPTY(&S2C(session)->rts->rtsqh)) {
             __wti_rts_pop_work(session, &entry);
             if (entry == NULL)
@@ -425,6 +436,7 @@ __wti_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_time
             __wti_rts_work_free(session, entry);
             WT_ERR(ret);
         }
+        session->name = saved_session_name;
     }
 
     WT_ERR(__rts_thread_destroy(session));
@@ -453,6 +465,7 @@ __wti_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_time
 
     __wt_atomic_store_uint32(&S2C(session)->rts->progress.phase, WT_RTS_PHASE_COMPLETE);
 err:
+    session->name = saved_session_name;
     if (have_cursor)
         WT_TRET(__wt_metadata_cursor_release(session, &cursor));
     if (rts_threads_started)

--- a/src/rollback_to_stable/rts.c
+++ b/src/rollback_to_stable/rts.c
@@ -94,8 +94,8 @@ __rts_progress_msg(WT_SESSION_IMPL *session, uint64_t *last_report_clock)
  *     tree and estimate time remaining for this btree.
  */
 void
-__wti_rts_progress_msg_walk(
-  WT_SESSION_IMPL *session, uint64_t *last_report_clock, double npos, uint64_t btree_pages)
+__wti_rts_progress_msg_walk(WT_SESSION_IMPL *session, uint64_t btree_start_clock,
+  uint64_t *last_report_clock, double npos, uint64_t btree_pages)
 {
     WT_ROLLBACK_TO_STABLE *rts;
     uint64_t btree_eta_sec, btree_pct, btree_pages_per_sec, clock_now, elapsed_ns, elapsed_sec,
@@ -104,9 +104,9 @@ __wti_rts_progress_msg_walk(
 
     rts = S2C(session)->rts;
 
-    /* The caller has already verified it's time to report; compute values for the message. */
+    /* Use total btree walk time (not interval) for pages/sec and ETA calculations. */
     clock_now = __wt_clock(session);
-    elapsed_ns = __wt_clock_to_nsec(clock_now, *last_report_clock);
+    elapsed_ns = __wt_clock_to_nsec(clock_now, btree_start_clock);
     elapsed_sec = elapsed_ns / WT_BILLION;
 
     phase = __wt_atomic_load_uint32_relaxed(&rts->progress.phase);

--- a/src/rollback_to_stable/rts.c
+++ b/src/rollback_to_stable/rts.c
@@ -120,11 +120,12 @@ __wti_rts_progress_msg(WT_SESSION_IMPL *session, WT_TIMER *rollback_start, uint6
  *     tree and estimate time remaining for this btree.
  */
 void
-__wti_rts_progress_msg_walk(
-  WT_SESSION_IMPL *session, WT_TIMER *btree_start, uint64_t *msg_count, double npos)
+__wti_rts_progress_msg_walk(WT_SESSION_IMPL *session, WT_TIMER *btree_start, uint64_t *msg_count,
+  double npos, uint64_t btree_pages)
 {
     WT_ROLLBACK_TO_STABLE *rts;
-    uint64_t btree_eta_sec, btree_pct, elapsed_ms, pages_per_sec, pages_walked;
+    uint64_t btree_eta_sec, btree_pct, btree_pages_per_sec, btrees_processed, btrees_skipped,
+      elapsed_ms, overall_elapsed_ms, overall_pages_per_sec, pages_walked, total_btrees;
     uint32_t phase;
 
     rts = S2C(session)->rts;
@@ -132,10 +133,9 @@ __wti_rts_progress_msg_walk(
     __wt_timer_evaluate_ms(session, btree_start, &elapsed_ms);
 
     if ((elapsed_ms / (WT_THOUSAND * WT_PROGRESS_MSG_PERIOD)) > *msg_count) {
-        pages_walked = __wt_atomic_load_uint64_relaxed(&rts->progress.pages_walked);
         phase = __wt_atomic_load_uint32(&rts->progress.phase);
         btree_pct = (uint64_t)(npos * 100);
-        pages_per_sec = elapsed_ms > 0 ? (pages_walked * WT_THOUSAND / elapsed_ms) : 0;
+        btree_pages_per_sec = elapsed_ms > 0 ? (btree_pages * WT_THOUSAND / elapsed_ms) : 0;
 
         /* Estimate time remaining for this btree based on npos progression. */
         btree_eta_sec = 0;
@@ -148,13 +148,30 @@ __wti_rts_progress_msg_walk(
               "%% through btree, %" PRIu64 " pages walked (%" PRIu64
               " pages/sec), btree ETA %" PRIu64 " seconds",
               __rts_phase_string(phase), session->dhandle->name, elapsed_ms / WT_THOUSAND,
-              btree_pct, pages_walked, pages_per_sec, btree_eta_sec);
+              btree_pct, btree_pages, btree_pages_per_sec, btree_eta_sec);
         else
             __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
               "Rollback to stable [%s] btree walk on %s for %" PRIu64 " seconds, %" PRIu64
               "%% through btree, %" PRIu64 " pages walked (%" PRIu64 " pages/sec)",
               __rts_phase_string(phase), session->dhandle->name, elapsed_ms / WT_THOUSAND,
-              btree_pct, pages_walked, pages_per_sec);
+              btree_pct, btree_pages, btree_pages_per_sec);
+
+        /* Emit an overall progress line, but only from the main thread. */
+        if (session == rts->progress.main_session) {
+            btrees_processed = __wt_atomic_load_uint64_relaxed(&rts->progress.btrees_processed);
+            btrees_skipped = __wt_atomic_load_uint64_relaxed(&rts->progress.btrees_skipped);
+            pages_walked = __wt_atomic_load_uint64_relaxed(&rts->progress.pages_walked);
+            total_btrees = rts->progress.total_btrees;
+            __wt_timer_evaluate_ms(session, &rts->progress.start_timer, &overall_elapsed_ms);
+            overall_pages_per_sec =
+              overall_elapsed_ms > 0 ? (pages_walked * WT_THOUSAND / overall_elapsed_ms) : 0;
+            __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
+              "Rollback to stable [%s] overall: running for %" PRIu64 " seconds, %" PRIu64
+              " of %" PRIu64 " btrees processed, %" PRIu64 " skipped, %" PRIu64
+              " total pages walked (%" PRIu64 " pages/sec)",
+              __rts_phase_string(phase), overall_elapsed_ms / WT_THOUSAND, btrees_processed,
+              total_btrees, btrees_skipped, pages_walked, overall_pages_per_sec);
+        }
 
         *msg_count = elapsed_ms / (WT_THOUSAND * WT_PROGRESS_MSG_PERIOD);
     }
@@ -171,6 +188,7 @@ __wti_rts_progress_init(WT_SESSION_IMPL *session)
 
     rts = S2C(session)->rts;
     memset(&rts->progress, 0, sizeof(rts->progress));
+    rts->progress.main_session = session;
     __wt_timer_start(session, &rts->progress.start_timer);
 }
 

--- a/src/rollback_to_stable/rts.c
+++ b/src/rollback_to_stable/rts.c
@@ -16,7 +16,7 @@ void
 __wti_rts_progress_msg(WT_SESSION_IMPL *session, WT_TIMER *rollback_start, uint64_t rollback_count,
   uint64_t max_count, uint64_t *rollback_msg_count, bool walk)
 {
-    uint64_t time_diff_ms;
+    uint64_t pct, time_diff_ms;
 
     /* Time since the rollback started. */
     __wt_timer_evaluate_ms(session, rollback_start, &time_diff_ms);
@@ -24,15 +24,15 @@ __wti_rts_progress_msg(WT_SESSION_IMPL *session, WT_TIMER *rollback_start, uint6
     if ((time_diff_ms / (WT_THOUSAND * WT_PROGRESS_MSG_PERIOD)) > *rollback_msg_count) {
         if (walk)
             __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
-              "Rollback to stable has been performing on %s for %" PRIu64
-              " milliseconds. For more detailed logging, enable WT_VERB_RTS ",
-              session->dhandle->name, time_diff_ms);
-        else
+              "Rollback to stable performing btree walk on %s for %" PRIu64 " seconds",
+              session->dhandle->name, time_diff_ms / WT_THOUSAND);
+        else {
+            pct = max_count > 0 ? (100 * rollback_count / max_count) : 0;
             __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
               "Rollback to stable has been running for %" PRIu64
-              " milliseconds and has inspected %" PRIu64 " files of %" PRIu64
-              ". For more detailed logging, enable WT_VERB_RTS",
-              time_diff_ms, rollback_count, max_count);
+              " seconds and has inspected %" PRIu64 " of %" PRIu64 " files (%" PRIu64 "%%)",
+              time_diff_ms / WT_THOUSAND, rollback_count, max_count, pct);
+        }
         *rollback_msg_count = time_diff_ms / (WT_THOUSAND * WT_PROGRESS_MSG_PERIOD);
     }
 }
@@ -198,6 +198,9 @@ __wti_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_time
     WT_ERR(__wt_metadata_cursor_release(session, &cursor));
     have_cursor = false;
 
+    __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
+      "Rollback to stable found %" PRIu64 " btrees to process", max_count);
+
     WT_ERR(__rts_thread_create(session));
     rts_threads_started = true;
 
@@ -226,6 +229,8 @@ __wti_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_time
      * workers alone to complete the task.
      */
     if (S2C(session)->rts->threads_num != 0) {
+        __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS, "%s",
+          "Rollback to stable finished metadata walk, draining worker queue");
         while (!TAILQ_EMPTY(&S2C(session)->rts->rtsqh)) {
             __wti_rts_pop_work(session, &entry);
             if (entry == NULL)
@@ -249,6 +254,8 @@ __wti_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_time
      * doesn't exist.
      */
     if (!F_ISSET(S2C(session), WT_CONN_IN_MEMORY)) {
+        __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS, "%s",
+          "Rollback to stable beginning history store final pass");
         __wt_verbose_level_multi(session, WT_VERB_RECOVERY_RTS(session), WT_VERBOSE_DEBUG_3,
           WT_RTS_VERB_TAG_HS_TREE_FINAL_PASS
           "performing final pass of the history store to remove unstable entries with "

--- a/src/rollback_to_stable/rts.c
+++ b/src/rollback_to_stable/rts.c
@@ -9,10 +9,6 @@
 #include "wt_internal.h"
 
 /*
- * __wti_rts_progress_msg --
- *     Log a verbose message about the progress of the current rollback to stable.
- */
-/*
  * __rts_phase_string --
  *     Return a human-readable string for an RTS phase.
  */
@@ -305,7 +301,8 @@ __wti_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_time
     bool have_cursor, rts_threads_started;
 
     __wti_rts_progress_init(session);
-    __wt_atomic_store_uint32_relaxed(&S2C(session)->rts->progress.phase, WT_RTS_PHASE_METADATA_COUNT);
+    __wt_atomic_store_uint32_relaxed(
+      &S2C(session)->rts->progress.phase, WT_RTS_PHASE_METADATA_COUNT);
 
     __wt_timer_start(session, &timer);
     max_count = 0;
@@ -359,7 +356,8 @@ __wti_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_time
      * workers alone to complete the task.
      */
     if (S2C(session)->rts->threads_num != 0) {
-        __wt_atomic_store_uint32_relaxed(&S2C(session)->rts->progress.phase, WT_RTS_PHASE_QUEUE_DRAIN);
+        __wt_atomic_store_uint32_relaxed(
+          &S2C(session)->rts->progress.phase, WT_RTS_PHASE_QUEUE_DRAIN);
         __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS, "%s",
           "Rollback to stable finished metadata walk, draining worker queue");
 
@@ -389,7 +387,8 @@ __wti_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_time
      * doesn't exist.
      */
     if (!F_ISSET(S2C(session), WT_CONN_IN_MEMORY)) {
-        __wt_atomic_store_uint32_relaxed(&S2C(session)->rts->progress.phase, WT_RTS_PHASE_HS_FINAL_PASS);
+        __wt_atomic_store_uint32_relaxed(
+          &S2C(session)->rts->progress.phase, WT_RTS_PHASE_HS_FINAL_PASS);
         __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS, "%s",
           "Rollback to stable beginning history store final pass");
         __wt_verbose_level_multi(session, WT_VERB_RECOVERY_RTS(session), WT_VERBOSE_DEBUG_3,

--- a/src/rollback_to_stable/rts.c
+++ b/src/rollback_to_stable/rts.c
@@ -38,54 +38,15 @@ __rts_phase_string(uint32_t phase)
 }
 
 /*
- * __rts_compute_eta_sec --
- *     Estimate remaining time for the btree-apply phase. Uses page-based throughput rather than
- *     btree count to handle the common case where a few large btrees dominate the runtime.
- *     Estimates total pages as (pages_walked_so_far / btrees_completed) * total_btrees, then
- *     computes remaining pages / pages_per_second. Returns 0 if there is insufficient data.
- */
-static uint64_t
-__rts_compute_eta_sec(WT_SESSION_IMPL *session)
-{
-    WT_ROLLBACK_TO_STABLE *rts;
-    uint64_t completed, elapsed_ms, estimated_total_pages, pages_walked, remaining_pages, total;
-
-    rts = S2C(session)->rts;
-    total = rts->progress.total_btrees;
-    completed = __wt_atomic_load_uint64_relaxed(&rts->progress.btrees_processed) +
-      __wt_atomic_load_uint64_relaxed(&rts->progress.btrees_skipped);
-    pages_walked = __wt_atomic_load_uint64_relaxed(&rts->progress.pages_walked);
-
-    /* Require some completed btrees and pages for a meaningful estimate. */
-    if (completed < 5 || completed >= total || pages_walked == 0)
-        return (0);
-
-    __wt_timer_evaluate_ms(session, &rts->progress.btree_apply_timer, &elapsed_ms);
-    if (elapsed_ms == 0)
-        return (0);
-
-    /* Estimate total pages based on average pages per btree so far. */
-    estimated_total_pages = (pages_walked * total) / completed;
-    if (pages_walked >= estimated_total_pages)
-        return (0);
-
-    remaining_pages = estimated_total_pages - pages_walked;
-
-    /* ETA = remaining_pages / (pages_walked / elapsed_sec) = remaining_pages * elapsed_ms /
-     * (pages_walked * 1000) */
-    return ((remaining_pages * elapsed_ms) / (pages_walked * WT_THOUSAND));
-}
-
-/*
  * __rts_emit_overall_progress --
- *     Emit an overall RTS progress message with counters, percentage, throughput, and ETA.
+ *     Emit an overall RTS progress message with counters, percentage, and throughput.
  */
 static void
 __rts_emit_overall_progress(WT_SESSION_IMPL *session)
 {
     WT_ROLLBACK_TO_STABLE *rts;
-    uint64_t btrees_completed, btrees_processed, btrees_skipped, elapsed_ms, eta_sec, max_btree_eta,
-      pages_per_sec, pages_walked, pct, total_btrees;
+    uint64_t btrees_completed, btrees_processed, btrees_skipped, elapsed_ms, pages_per_sec,
+      pages_walked, pct, total_btrees;
     uint32_t phase;
 
     rts = S2C(session)->rts;
@@ -100,29 +61,13 @@ __rts_emit_overall_progress(WT_SESSION_IMPL *session)
     __wt_timer_evaluate_ms(session, &rts->progress.start_timer, &elapsed_ms);
     pct = total_btrees > 0 ? (100 * btrees_completed / total_btrees) : 0;
     pages_per_sec = elapsed_ms > 0 ? (pages_walked * WT_THOUSAND / elapsed_ms) : 0;
-    eta_sec = __rts_compute_eta_sec(session);
 
-    /* Overall ETA can't be less than the largest per-btree ETA currently in progress. */
-    max_btree_eta = __wt_atomic_load_uint64_relaxed(&rts->progress.max_btree_eta_sec);
-    if (eta_sec < max_btree_eta)
-        eta_sec = max_btree_eta;
-    /* Reset for next reporting period so stale values don't persist. */
-    __wt_atomic_store_uint64_relaxed(&rts->progress.max_btree_eta_sec, 0);
-    if (eta_sec > 0)
-        __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
-          "Rollback to stable [%s] overall: running for %" PRIu64 " seconds, %" PRIu64
-          " of %" PRIu64 " btrees done (%" PRIu64 "%%), %" PRIu64 " processed, %" PRIu64
-          " skipped, %" PRIu64 " total pages walked (%" PRIu64 " pages/sec), ETA %" PRIu64
-          " seconds",
-          __rts_phase_string(phase), elapsed_ms / WT_THOUSAND, btrees_completed, total_btrees, pct,
-          btrees_processed, btrees_skipped, pages_walked, pages_per_sec, eta_sec);
-    else
-        __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
-          "Rollback to stable [%s] overall: running for %" PRIu64 " seconds, %" PRIu64
-          " of %" PRIu64 " btrees done (%" PRIu64 "%%), %" PRIu64 " processed, %" PRIu64
-          " skipped, %" PRIu64 " total pages walked (%" PRIu64 " pages/sec)",
-          __rts_phase_string(phase), elapsed_ms / WT_THOUSAND, btrees_completed, total_btrees, pct,
-          btrees_processed, btrees_skipped, pages_walked, pages_per_sec);
+    __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
+      "Rollback to stable [%s] overall: running for %" PRIu64 " seconds, %" PRIu64 " of %" PRIu64
+      " btrees done (%" PRIu64 "%%), %" PRIu64 " processed, %" PRIu64 " skipped, %" PRIu64
+      " total pages walked (%" PRIu64 " pages/sec)",
+      __rts_phase_string(phase), elapsed_ms / WT_THOUSAND, btrees_completed, total_btrees, pct,
+      btrees_processed, btrees_skipped, pages_walked, pages_per_sec);
 
     /* Notify the application via the progress callback. */
     WT_IGNORE_RET(__wt_progress(session, "rollback to stable", btrees_completed));
@@ -175,10 +120,6 @@ __wti_rts_progress_msg_walk(WT_SESSION_IMPL *session, WT_TIMER *btree_start, uin
     btree_eta_sec = 0;
     if (npos > 0.05 && npos < 1.0)
         btree_eta_sec = (uint64_t)((1.0 - npos) * (double)elapsed_ms / (npos * WT_THOUSAND));
-
-    /* Update the global max btree ETA so overall ETA can use it as a floor. */
-    if (btree_eta_sec > __wt_atomic_load_uint64_relaxed(&rts->progress.max_btree_eta_sec))
-        __wt_atomic_store_uint64_relaxed(&rts->progress.max_btree_eta_sec, btree_eta_sec);
 
     if (btree_eta_sec > 0)
         __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
@@ -392,7 +333,6 @@ __wti_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_time
       "Rollback to stable found %" PRIu64 " btrees to process", max_count);
 
     __wt_atomic_store_uint32_relaxed(&S2C(session)->rts->progress.phase, WT_RTS_PHASE_BTREE_APPLY);
-    __wt_timer_start(session, &S2C(session)->rts->progress.btree_apply_timer);
 
     WT_ERR(__rts_thread_create(session));
     rts_threads_started = true;

--- a/src/rollback_to_stable/rts.c
+++ b/src/rollback_to_stable/rts.c
@@ -20,6 +20,8 @@ static const char *
 __rts_phase_string(uint32_t phase)
 {
     switch (phase) {
+    case WT_RTS_PHASE_INACTIVE:
+        return ("INACTIVE");
     case WT_RTS_PHASE_METADATA_COUNT:
         return ("METADATA_COUNT");
     case WT_RTS_PHASE_BTREE_APPLY:
@@ -31,34 +33,37 @@ __rts_phase_string(uint32_t phase)
     case WT_RTS_PHASE_COMPLETE:
         return ("COMPLETE");
     default:
-        return ("INACTIVE");
+        return ("UNKNOWN");
     }
 }
 
 /*
  * __rts_compute_eta_sec --
- *     Estimate remaining time for the btree-apply phase based on the rate of btrees inspected so
- *     far. Returns 0 if there is insufficient data for a meaningful estimate.
+ *     Estimate remaining time for the btree-apply phase based on the rate of btrees completed
+ *     (processed + skipped) so far. Returns 0 if there is insufficient data for a meaningful
+ *     estimate.
  */
 static uint64_t
-__rts_compute_eta_sec(WT_SESSION_IMPL *session, uint64_t inspected)
+__rts_compute_eta_sec(WT_SESSION_IMPL *session)
 {
     WT_ROLLBACK_TO_STABLE *rts;
-    uint64_t elapsed_ms, remaining, total;
+    uint64_t completed, elapsed_ms, remaining, total;
 
     rts = S2C(session)->rts;
     total = rts->progress.total_btrees;
+    completed = __wt_atomic_load_uint64_relaxed(&rts->progress.btrees_processed) +
+      __wt_atomic_load_uint64_relaxed(&rts->progress.btrees_skipped);
 
-    /* Require a minimum number of inspected btrees for a meaningful estimate. */
-    if (inspected < 5 || inspected >= total)
+    /* Require a minimum number of completed btrees for a meaningful estimate. */
+    if (completed < 5 || completed >= total)
         return (0);
 
-    remaining = total - inspected;
+    remaining = total - completed;
     __wt_timer_evaluate_ms(session, &rts->progress.btree_apply_timer, &elapsed_ms);
     if (elapsed_ms == 0)
         return (0);
 
-    return ((remaining * elapsed_ms) / (inspected * WT_THOUSAND));
+    return ((remaining * elapsed_ms) / (completed * WT_THOUSAND));
 }
 
 /*
@@ -70,11 +75,13 @@ __wti_rts_progress_msg(WT_SESSION_IMPL *session, WT_TIMER *rollback_start, uint6
   uint64_t max_count, uint64_t *rollback_msg_count, bool walk)
 {
     WT_ROLLBACK_TO_STABLE *rts;
-    uint64_t btrees_processed, btrees_skipped, eta_sec, pages_per_sec, pages_walked, pct,
-      time_diff_ms;
+    uint64_t btrees_completed, btrees_processed, btrees_skipped, eta_sec, pages_per_sec,
+      pages_walked, pct, time_diff_ms, total_btrees;
     uint32_t phase;
 
     WT_UNUSED(walk);
+    WT_UNUSED(rollback_count);
+    WT_UNUSED(max_count);
     rts = S2C(session)->rts;
 
     /* Time since the rollback started. */
@@ -86,28 +93,29 @@ __wti_rts_progress_msg(WT_SESSION_IMPL *session, WT_TIMER *rollback_start, uint6
         btrees_skipped = __wt_atomic_load_uint64_relaxed(&rts->progress.btrees_skipped);
         pages_walked = __wt_atomic_load_uint64_relaxed(&rts->progress.pages_walked);
         phase = __wt_atomic_load_uint32(&rts->progress.phase);
+        total_btrees = rts->progress.total_btrees;
 
-        pct = max_count > 0 ? (100 * rollback_count / max_count) : 0;
+        btrees_completed = btrees_processed + btrees_skipped;
+        pct = total_btrees > 0 ? (100 * btrees_completed / total_btrees) : 0;
         pages_per_sec = time_diff_ms > 0 ? (pages_walked * WT_THOUSAND / time_diff_ms) : 0;
-        eta_sec = __rts_compute_eta_sec(session, rollback_count);
+        eta_sec = __rts_compute_eta_sec(session);
         if (eta_sec > 0)
             __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
-              "Rollback to stable [%s] running for %" PRIu64 " seconds, inspected %" PRIu64
-              " of %" PRIu64 " btrees (%" PRIu64 "%%), %" PRIu64 " processed, %" PRIu64
-              " skipped, %" PRIu64 " total pages walked (%" PRIu64 " pages/sec), ETA %" PRIu64
-              " seconds",
-              __rts_phase_string(phase), time_diff_ms / WT_THOUSAND, rollback_count, max_count, pct,
-              btrees_processed, btrees_skipped, pages_walked, pages_per_sec, eta_sec);
+              "Rollback to stable [%s] running for %" PRIu64 " seconds, %" PRIu64 " of %" PRIu64
+              " btrees done (%" PRIu64 "%%), %" PRIu64 " processed, %" PRIu64 " skipped, %" PRIu64
+              " total pages walked (%" PRIu64 " pages/sec), ETA %" PRIu64 " seconds",
+              __rts_phase_string(phase), time_diff_ms / WT_THOUSAND, btrees_completed, total_btrees,
+              pct, btrees_processed, btrees_skipped, pages_walked, pages_per_sec, eta_sec);
         else
             __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
-              "Rollback to stable [%s] running for %" PRIu64 " seconds, inspected %" PRIu64
-              " of %" PRIu64 " btrees (%" PRIu64 "%%), %" PRIu64 " processed, %" PRIu64
-              " skipped, %" PRIu64 " total pages walked (%" PRIu64 " pages/sec)",
-              __rts_phase_string(phase), time_diff_ms / WT_THOUSAND, rollback_count, max_count, pct,
-              btrees_processed, btrees_skipped, pages_walked, pages_per_sec);
+              "Rollback to stable [%s] running for %" PRIu64 " seconds, %" PRIu64 " of %" PRIu64
+              " btrees done (%" PRIu64 "%%), %" PRIu64 " processed, %" PRIu64 " skipped, %" PRIu64
+              " total pages walked (%" PRIu64 " pages/sec)",
+              __rts_phase_string(phase), time_diff_ms / WT_THOUSAND, btrees_completed, total_btrees,
+              pct, btrees_processed, btrees_skipped, pages_walked, pages_per_sec);
 
         /* Notify the application via the progress callback. */
-        WT_IGNORE_RET(__wt_progress(session, "rollback to stable", btrees_processed));
+        WT_IGNORE_RET(__wt_progress(session, "rollback to stable", btrees_completed));
 
         *rollback_msg_count = time_diff_ms / (WT_THOUSAND * WT_PROGRESS_MSG_PERIOD);
     }
@@ -124,8 +132,9 @@ __wti_rts_progress_msg_walk(WT_SESSION_IMPL *session, WT_TIMER *btree_start, uin
   double npos, uint64_t btree_pages)
 {
     WT_ROLLBACK_TO_STABLE *rts;
-    uint64_t btree_eta_sec, btree_pct, btree_pages_per_sec, btrees_processed, btrees_skipped,
-      elapsed_ms, overall_elapsed_ms, overall_pages_per_sec, pages_walked, total_btrees;
+    uint64_t btree_eta_sec, btree_pct, btree_pages_per_sec, btrees_completed, btrees_processed,
+      btrees_skipped, elapsed_ms, eta_sec, overall_elapsed_ms, overall_pages_per_sec, overall_pct,
+      pages_walked, total_btrees;
     uint32_t phase;
 
     rts = S2C(session)->rts;
@@ -162,15 +171,29 @@ __wti_rts_progress_msg_walk(WT_SESSION_IMPL *session, WT_TIMER *btree_start, uin
             btrees_skipped = __wt_atomic_load_uint64_relaxed(&rts->progress.btrees_skipped);
             pages_walked = __wt_atomic_load_uint64_relaxed(&rts->progress.pages_walked);
             total_btrees = rts->progress.total_btrees;
+            btrees_completed = btrees_processed + btrees_skipped;
+            overall_pct = total_btrees > 0 ? (100 * btrees_completed / total_btrees) : 0;
             __wt_timer_evaluate_ms(session, &rts->progress.start_timer, &overall_elapsed_ms);
             overall_pages_per_sec =
               overall_elapsed_ms > 0 ? (pages_walked * WT_THOUSAND / overall_elapsed_ms) : 0;
-            __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
-              "Rollback to stable [%s] overall: running for %" PRIu64 " seconds, %" PRIu64
-              " of %" PRIu64 " btrees processed, %" PRIu64 " skipped, %" PRIu64
-              " total pages walked (%" PRIu64 " pages/sec)",
-              __rts_phase_string(phase), overall_elapsed_ms / WT_THOUSAND, btrees_processed,
-              total_btrees, btrees_skipped, pages_walked, overall_pages_per_sec);
+            eta_sec = __rts_compute_eta_sec(session);
+            if (eta_sec > 0)
+                __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
+                  "Rollback to stable [%s] overall: running for %" PRIu64 " seconds, %" PRIu64
+                  " of %" PRIu64 " btrees done (%" PRIu64 "%%), %" PRIu64 " processed, %" PRIu64
+                  " skipped, %" PRIu64 " total pages walked (%" PRIu64 " pages/sec), ETA %" PRIu64
+                  " seconds",
+                  __rts_phase_string(phase), overall_elapsed_ms / WT_THOUSAND, btrees_completed,
+                  total_btrees, overall_pct, btrees_processed, btrees_skipped, pages_walked,
+                  overall_pages_per_sec, eta_sec);
+            else
+                __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
+                  "Rollback to stable [%s] overall: running for %" PRIu64 " seconds, %" PRIu64
+                  " of %" PRIu64 " btrees done (%" PRIu64 "%%), %" PRIu64 " processed, %" PRIu64
+                  " skipped, %" PRIu64 " total pages walked (%" PRIu64 " pages/sec)",
+                  __rts_phase_string(phase), overall_elapsed_ms / WT_THOUSAND, btrees_completed,
+                  total_btrees, overall_pct, btrees_processed, btrees_skipped, pages_walked,
+                  overall_pages_per_sec);
         }
 
         *msg_count = elapsed_ms / (WT_THOUSAND * WT_PROGRESS_MSG_PERIOD);
@@ -427,6 +450,8 @@ __wti_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_time
           __wt_timestamp_to_string(rollback_timestamp, ts_string));
         WT_ERR(__wti_rts_history_final_pass(session, rollback_timestamp));
     }
+
+    __wt_atomic_store_uint32(&S2C(session)->rts->progress.phase, WT_RTS_PHASE_COMPLETE);
 err:
     if (have_cursor)
         WT_TRET(__wt_metadata_cursor_release(session, &cursor));

--- a/src/rollback_to_stable/rts.c
+++ b/src/rollback_to_stable/rts.c
@@ -71,7 +71,8 @@ __rts_compute_eta_sec(WT_SESSION_IMPL *session)
 
     remaining_pages = estimated_total_pages - pages_walked;
 
-    /* ETA = remaining_pages / (pages_walked / elapsed_sec) = remaining_pages * elapsed_ms / (pages_walked * 1000) */
+    /* ETA = remaining_pages / (pages_walked / elapsed_sec) = remaining_pages * elapsed_ms /
+     * (pages_walked * 1000) */
     return ((remaining_pages * elapsed_ms) / (pages_walked * WT_THOUSAND));
 }
 
@@ -83,8 +84,8 @@ static void
 __rts_emit_overall_progress(WT_SESSION_IMPL *session)
 {
     WT_ROLLBACK_TO_STABLE *rts;
-    uint64_t btrees_completed, btrees_processed, btrees_skipped, elapsed_ms, eta_sec,
-      max_btree_eta, pages_per_sec, pages_walked, pct, total_btrees;
+    uint64_t btrees_completed, btrees_processed, btrees_skipped, elapsed_ms, eta_sec, max_btree_eta,
+      pages_per_sec, pages_walked, pct, total_btrees;
     uint32_t phase;
 
     rts = S2C(session)->rts;
@@ -133,21 +134,16 @@ __rts_emit_overall_progress(WT_SESSION_IMPL *session)
  *     metadata walk loop in __wti_rts_btree_apply_all.
  */
 void
-__wti_rts_progress_msg(WT_SESSION_IMPL *session, WT_TIMER *rollback_start, uint64_t rollback_count,
-  uint64_t max_count, uint64_t *rollback_msg_count, bool walk)
+__wti_rts_progress_msg(WT_SESSION_IMPL *session, WT_TIMER *rollback_start, uint64_t *msg_count)
 {
     uint64_t time_diff_ms;
-
-    WT_UNUSED(walk);
-    WT_UNUSED(rollback_count);
-    WT_UNUSED(max_count);
 
     /* Time since the rollback started. */
     __wt_timer_evaluate_ms(session, rollback_start, &time_diff_ms);
 
-    if ((time_diff_ms / (WT_THOUSAND * WT_PROGRESS_MSG_PERIOD)) > *rollback_msg_count) {
+    if ((time_diff_ms / (WT_THOUSAND * WT_PROGRESS_MSG_PERIOD)) > *msg_count) {
         __rts_emit_overall_progress(session);
-        *rollback_msg_count = time_diff_ms / (WT_THOUSAND * WT_PROGRESS_MSG_PERIOD);
+        *msg_count = time_diff_ms / (WT_THOUSAND * WT_PROGRESS_MSG_PERIOD);
     }
 }
 
@@ -362,7 +358,7 @@ __wti_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_time
     WT_DECL_RET;
     WT_RTS_WORK_UNIT *entry;
     WT_TIMER timer;
-    uint64_t max_count, rollback_count, rollback_msg_count;
+    uint64_t max_count, rollback_msg_count;
     char ts_string[WT_TS_INT_STRING_SIZE];
     const char *config, *saved_session_name, *uri;
     bool have_cursor, rts_threads_started;
@@ -371,7 +367,7 @@ __wti_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_time
     __wt_atomic_store_uint32(&S2C(session)->rts->progress.phase, WT_RTS_PHASE_METADATA_COUNT);
 
     __wt_timer_start(session, &timer);
-    max_count = rollback_count = 0;
+    max_count = 0;
     saved_session_name = session->name;
     rollback_msg_count = 0;
     rts_threads_started = false;
@@ -407,10 +403,7 @@ __wti_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_time
         /* Log a progress message. */
         WT_ERR(cursor->get_key(cursor, &uri));
         WT_ERR(cursor->get_value(cursor, &config));
-        if (WT_BTREE_PREFIX(uri) && !WT_IS_URI_HS(uri) && !WT_IS_URI_METADATA(uri))
-            ++rollback_count;
-        __wti_rts_progress_msg(
-          session, &timer, rollback_count, max_count, &rollback_msg_count, false);
+        __wti_rts_progress_msg(session, &timer, &rollback_msg_count);
 
         F_SET(session, WT_SESSION_QUIET_CORRUPT_FILE);
         ret = __wti_rts_btree_walk_btree_apply(session, uri, config, rollback_timestamp);
@@ -431,7 +424,6 @@ __wti_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_time
           "Rollback to stable finished metadata walk, draining worker queue");
 
         /* Rename session while joining workers so log messages identify us as a worker. */
-        saved_session_name = session->name;
         session->name = "rts-main-wk";
         while (!TAILQ_EMPTY(&S2C(session)->rts->rtsqh)) {
             __wti_rts_pop_work(session, &entry);

--- a/src/rollback_to_stable/rts.c
+++ b/src/rollback_to_stable/rts.c
@@ -16,25 +16,51 @@ void
 __wti_rts_progress_msg(WT_SESSION_IMPL *session, WT_TIMER *rollback_start, uint64_t rollback_count,
   uint64_t max_count, uint64_t *rollback_msg_count, bool walk)
 {
-    uint64_t pct, time_diff_ms;
+    WT_ROLLBACK_TO_STABLE *rts;
+    uint64_t btrees_processed, btrees_skipped, pages_walked, pct, time_diff_ms;
+
+    rts = S2C(session)->rts;
 
     /* Time since the rollback started. */
     __wt_timer_evaluate_ms(session, rollback_start, &time_diff_ms);
 
     if ((time_diff_ms / (WT_THOUSAND * WT_PROGRESS_MSG_PERIOD)) > *rollback_msg_count) {
+        /* Read atomic counters from the progress struct. */
+        btrees_processed = __wt_atomic_load_uint64_relaxed(&rts->progress.btrees_processed);
+        btrees_skipped = __wt_atomic_load_uint64_relaxed(&rts->progress.btrees_skipped);
+        pages_walked = __wt_atomic_load_uint64_relaxed(&rts->progress.pages_walked);
+
         if (walk)
             __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
-              "Rollback to stable performing btree walk on %s for %" PRIu64 " seconds",
-              session->dhandle->name, time_diff_ms / WT_THOUSAND);
+              "Rollback to stable performing btree walk on %s for %" PRIu64
+              " seconds, %" PRIu64 " total pages walked",
+              session->dhandle->name, time_diff_ms / WT_THOUSAND, pages_walked);
         else {
             pct = max_count > 0 ? (100 * rollback_count / max_count) : 0;
             __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
               "Rollback to stable has been running for %" PRIu64
-              " seconds and has inspected %" PRIu64 " of %" PRIu64 " files (%" PRIu64 "%%)",
-              time_diff_ms / WT_THOUSAND, rollback_count, max_count, pct);
+              " seconds, inspected %" PRIu64 " of %" PRIu64 " btrees (%" PRIu64
+              "%%), %" PRIu64 " btrees processed, %" PRIu64 " btrees skipped, %" PRIu64
+              " pages walked",
+              time_diff_ms / WT_THOUSAND, rollback_count, max_count, pct, btrees_processed,
+              btrees_skipped, pages_walked);
         }
         *rollback_msg_count = time_diff_ms / (WT_THOUSAND * WT_PROGRESS_MSG_PERIOD);
     }
+}
+
+/*
+ * __wti_rts_progress_init --
+ *     Initialize the RTS progress tracking fields.
+ */
+void
+__wti_rts_progress_init(WT_SESSION_IMPL *session)
+{
+    WT_ROLLBACK_TO_STABLE *rts;
+
+    rts = S2C(session)->rts;
+    memset(&rts->progress, 0, sizeof(rts->progress));
+    __wt_timer_start(session, &rts->progress.start_timer);
 }
 
 /*
@@ -178,6 +204,8 @@ __wti_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_time
     const char *config, *uri;
     bool have_cursor, rts_threads_started;
 
+    __wti_rts_progress_init(session);
+
     __wt_timer_start(session, &timer);
     max_count = rollback_count = 0;
     rollback_msg_count = 0;
@@ -198,8 +226,11 @@ __wti_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_time
     WT_ERR(__wt_metadata_cursor_release(session, &cursor));
     have_cursor = false;
 
+    S2C(session)->rts->progress.total_btrees = max_count;
     __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
       "Rollback to stable found %" PRIu64 " btrees to process", max_count);
+
+    __wt_timer_start(session, &S2C(session)->rts->progress.btree_apply_timer);
 
     WT_ERR(__rts_thread_create(session));
     rts_threads_started = true;

--- a/src/rollback_to_stable/rts.c
+++ b/src/rollback_to_stable/rts.c
@@ -39,31 +39,40 @@ __rts_phase_string(uint32_t phase)
 
 /*
  * __rts_compute_eta_sec --
- *     Estimate remaining time for the btree-apply phase based on the rate of btrees completed
- *     (processed + skipped) so far. Returns 0 if there is insufficient data for a meaningful
- *     estimate.
+ *     Estimate remaining time for the btree-apply phase. Uses page-based throughput rather than
+ *     btree count to handle the common case where a few large btrees dominate the runtime.
+ *     Estimates total pages as (pages_walked_so_far / btrees_completed) * total_btrees, then
+ *     computes remaining pages / pages_per_second. Returns 0 if there is insufficient data.
  */
 static uint64_t
 __rts_compute_eta_sec(WT_SESSION_IMPL *session)
 {
     WT_ROLLBACK_TO_STABLE *rts;
-    uint64_t completed, elapsed_ms, remaining, total;
+    uint64_t completed, elapsed_ms, estimated_total_pages, pages_walked, remaining_pages, total;
 
     rts = S2C(session)->rts;
     total = rts->progress.total_btrees;
     completed = __wt_atomic_load_uint64_relaxed(&rts->progress.btrees_processed) +
       __wt_atomic_load_uint64_relaxed(&rts->progress.btrees_skipped);
+    pages_walked = __wt_atomic_load_uint64_relaxed(&rts->progress.pages_walked);
 
-    /* Require a minimum number of completed btrees for a meaningful estimate. */
-    if (completed < 5 || completed >= total)
+    /* Require some completed btrees and pages for a meaningful estimate. */
+    if (completed < 5 || completed >= total || pages_walked == 0)
         return (0);
 
-    remaining = total - completed;
     __wt_timer_evaluate_ms(session, &rts->progress.btree_apply_timer, &elapsed_ms);
     if (elapsed_ms == 0)
         return (0);
 
-    return ((remaining * elapsed_ms) / (completed * WT_THOUSAND));
+    /* Estimate total pages based on average pages per btree so far. */
+    estimated_total_pages = (pages_walked * total) / completed;
+    if (pages_walked >= estimated_total_pages)
+        return (0);
+
+    remaining_pages = estimated_total_pages - pages_walked;
+
+    /* ETA = remaining_pages / (pages_walked / elapsed_sec) = remaining_pages * elapsed_ms / (pages_walked * 1000) */
+    return ((remaining_pages * elapsed_ms) / (pages_walked * WT_THOUSAND));
 }
 
 /*

--- a/src/rollback_to_stable/rts.c
+++ b/src/rollback_to_stable/rts.c
@@ -412,7 +412,7 @@ __wti_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_time
 
         /* Rename session while joining workers so log messages identify us as a worker. */
         saved_session_name = session->name;
-        session->name = "rts-worker (main)";
+        session->name = "rts-main-wkr";
         while (!TAILQ_EMPTY(&S2C(session)->rts->rtsqh)) {
             __wti_rts_pop_work(session, &entry);
             if (entry == NULL)

--- a/src/rollback_to_stable/rts.c
+++ b/src/rollback_to_stable/rts.c
@@ -118,19 +118,20 @@ __wti_rts_progress_msg_walk(WT_SESSION_IMPL *session, uint64_t btree_start_clock
     if (npos > 0.05 && npos < 1.0)
         btree_eta_sec = (uint64_t)((1.0 - npos) * (double)elapsed_sec / npos);
 
+#define WT_RTS_BTREE_WALK_PROGRESS_FMT                                           \
+    "Rollback to stable [%s] btree walk on %s for %" PRIu64 " seconds, %" PRIu64 \
+    "%% through btree, %" PRIu64 " pages walked (%" PRIu64 " pages/sec)"
+#define WT_RTS_BTREE_WALK_PROGRESS_ARGS                                                     \
+    __rts_phase_string(phase), session->dhandle->name, elapsed_sec, btree_pct, btree_pages, \
+      btree_pages_per_sec
+
     if (btree_eta_sec > 0)
         __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
-          "Rollback to stable [%s] btree walk on %s for %" PRIu64 " seconds, %" PRIu64
-          "%% through btree, %" PRIu64 " pages walked (%" PRIu64 " pages/sec), btree ETA %" PRIu64
-          " seconds",
-          __rts_phase_string(phase), session->dhandle->name, elapsed_sec, btree_pct, btree_pages,
-          btree_pages_per_sec, btree_eta_sec);
+          WT_RTS_BTREE_WALK_PROGRESS_FMT ", btree ETA %" PRIu64 " seconds",
+          WT_RTS_BTREE_WALK_PROGRESS_ARGS, btree_eta_sec);
     else
-        __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
-          "Rollback to stable [%s] btree walk on %s for %" PRIu64 " seconds, %" PRIu64
-          "%% through btree, %" PRIu64 " pages walked (%" PRIu64 " pages/sec)",
-          __rts_phase_string(phase), session->dhandle->name, elapsed_sec, btree_pct, btree_pages,
-          btree_pages_per_sec);
+        __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS, WT_RTS_BTREE_WALK_PROGRESS_FMT,
+          WT_RTS_BTREE_WALK_PROGRESS_ARGS);
 
     /*
      * Emit an overall progress line. Use CAS on overall_last_report so that exactly one thread wins

--- a/src/rollback_to_stable/rts.c
+++ b/src/rollback_to_stable/rts.c
@@ -37,28 +37,28 @@ __rts_phase_string(uint32_t phase)
 
 /*
  * __rts_compute_eta_sec --
- *     Estimate remaining time for the btree-apply phase based on the rate of btrees processed so
+ *     Estimate remaining time for the btree-apply phase based on the rate of btrees inspected so
  *     far. Returns 0 if there is insufficient data for a meaningful estimate.
  */
 static uint64_t
-__rts_compute_eta_sec(WT_SESSION_IMPL *session)
+__rts_compute_eta_sec(WT_SESSION_IMPL *session, uint64_t inspected)
 {
     WT_ROLLBACK_TO_STABLE *rts;
-    uint64_t elapsed_ms, processed, remaining;
+    uint64_t elapsed_ms, remaining, total;
 
     rts = S2C(session)->rts;
-    processed = __wt_atomic_load_uint64_relaxed(&rts->progress.btrees_processed);
+    total = rts->progress.total_btrees;
 
-    /* Require a minimum number of processed btrees for a meaningful estimate. */
-    if (processed < 5 || processed >= rts->progress.total_btrees)
+    /* Require a minimum number of inspected btrees for a meaningful estimate. */
+    if (inspected < 5 || inspected >= total)
         return (0);
 
-    remaining = rts->progress.total_btrees - processed;
+    remaining = total - inspected;
     __wt_timer_evaluate_ms(session, &rts->progress.btree_apply_timer, &elapsed_ms);
     if (elapsed_ms == 0)
         return (0);
 
-    return ((remaining * elapsed_ms) / (processed * WT_THOUSAND));
+    return ((remaining * elapsed_ms) / (inspected * WT_THOUSAND));
 }
 
 /*
@@ -93,7 +93,7 @@ __wti_rts_progress_msg(WT_SESSION_IMPL *session, WT_TIMER *rollback_start, uint6
               pages_walked);
         else {
             pct = max_count > 0 ? (100 * rollback_count / max_count) : 0;
-            eta_sec = __rts_compute_eta_sec(session);
+            eta_sec = __rts_compute_eta_sec(session, rollback_count);
             if (eta_sec > 0)
                 __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
                   "Rollback to stable [%s] running for %" PRIu64

--- a/src/rollback_to_stable/rts.c
+++ b/src/rollback_to_stable/rts.c
@@ -118,20 +118,20 @@ __wti_rts_progress_msg_walk(WT_SESSION_IMPL *session, uint64_t btree_start_clock
     if (npos > 0.05 && npos < 1.0)
         btree_eta_sec = (uint64_t)((1.0 - npos) * (double)elapsed_sec / npos);
 
-#define WT_RTS_BTREE_WALK_PROGRESS_FMT                                           \
-    "Rollback to stable [%s] btree walk on %s for %" PRIu64 " seconds, %" PRIu64 \
-    "%% through btree, %" PRIu64 " pages walked (%" PRIu64 " pages/sec)"
-#define WT_RTS_BTREE_WALK_PROGRESS_ARGS                                                     \
-    __rts_phase_string(phase), session->dhandle->name, elapsed_sec, btree_pct, btree_pages, \
-      btree_pages_per_sec
-
     if (btree_eta_sec > 0)
         __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
-          WT_RTS_BTREE_WALK_PROGRESS_FMT ", btree ETA %" PRIu64 " seconds",
-          WT_RTS_BTREE_WALK_PROGRESS_ARGS, btree_eta_sec);
+          "Rollback to stable [%s] btree walk on %s for %" PRIu64 " seconds, %" PRIu64
+          "%% through btree, %" PRIu64 " pages walked (%" PRIu64
+          " pages/sec)"
+          ", btree ETA %" PRIu64 " seconds",
+          __rts_phase_string(phase), session->dhandle->name, elapsed_sec, btree_pct, btree_pages,
+          btree_pages_per_sec, btree_eta_sec);
     else
-        __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS, WT_RTS_BTREE_WALK_PROGRESS_FMT,
-          WT_RTS_BTREE_WALK_PROGRESS_ARGS);
+        __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
+          "Rollback to stable [%s] btree walk on %s for %" PRIu64 " seconds, %" PRIu64
+          "%% through btree, %" PRIu64 " pages walked (%" PRIu64 " pages/sec)",
+          __rts_phase_string(phase), session->dhandle->name, elapsed_sec, btree_pct, btree_pages,
+          btree_pages_per_sec);
 
     /*
      * Emit an overall progress line. Use CAS on overall_last_report so that exactly one thread wins

--- a/src/rollback_to_stable/rts.c
+++ b/src/rollback_to_stable/rts.c
@@ -12,12 +12,66 @@
  * __wti_rts_progress_msg --
  *     Log a verbose message about the progress of the current rollback to stable.
  */
+/*
+ * __rts_phase_string --
+ *     Return a human-readable string for an RTS phase.
+ */
+static const char *
+__rts_phase_string(uint32_t phase)
+{
+    switch (phase) {
+    case WT_RTS_PHASE_METADATA_COUNT:
+        return ("METADATA_COUNT");
+    case WT_RTS_PHASE_BTREE_APPLY:
+        return ("BTREE_APPLY");
+    case WT_RTS_PHASE_QUEUE_DRAIN:
+        return ("QUEUE_DRAIN");
+    case WT_RTS_PHASE_HS_FINAL_PASS:
+        return ("HS_FINAL_PASS");
+    case WT_RTS_PHASE_COMPLETE:
+        return ("COMPLETE");
+    default:
+        return ("INACTIVE");
+    }
+}
+
+/*
+ * __rts_compute_eta_sec --
+ *     Estimate remaining time for the btree-apply phase based on the rate of btrees processed so
+ *     far. Returns 0 if there is insufficient data for a meaningful estimate.
+ */
+static uint64_t
+__rts_compute_eta_sec(WT_SESSION_IMPL *session)
+{
+    WT_ROLLBACK_TO_STABLE *rts;
+    uint64_t elapsed_ms, processed, remaining;
+
+    rts = S2C(session)->rts;
+    processed = __wt_atomic_load_uint64_relaxed(&rts->progress.btrees_processed);
+
+    /* Require a minimum number of processed btrees for a meaningful estimate. */
+    if (processed < 5 || processed >= rts->progress.total_btrees)
+        return (0);
+
+    remaining = rts->progress.total_btrees - processed;
+    __wt_timer_evaluate_ms(session, &rts->progress.btree_apply_timer, &elapsed_ms);
+    if (elapsed_ms == 0)
+        return (0);
+
+    return ((remaining * elapsed_ms) / (processed * WT_THOUSAND));
+}
+
+/*
+ * __wti_rts_progress_msg --
+ *     Log a verbose message about the progress of the current rollback to stable.
+ */
 void
 __wti_rts_progress_msg(WT_SESSION_IMPL *session, WT_TIMER *rollback_start, uint64_t rollback_count,
   uint64_t max_count, uint64_t *rollback_msg_count, bool walk)
 {
     WT_ROLLBACK_TO_STABLE *rts;
-    uint64_t btrees_processed, btrees_skipped, pages_walked, pct, time_diff_ms;
+    uint64_t btrees_processed, btrees_skipped, eta_sec, pages_walked, pct, time_diff_ms;
+    uint32_t phase;
 
     rts = S2C(session)->rts;
 
@@ -29,21 +83,32 @@ __wti_rts_progress_msg(WT_SESSION_IMPL *session, WT_TIMER *rollback_start, uint6
         btrees_processed = __wt_atomic_load_uint64_relaxed(&rts->progress.btrees_processed);
         btrees_skipped = __wt_atomic_load_uint64_relaxed(&rts->progress.btrees_skipped);
         pages_walked = __wt_atomic_load_uint64_relaxed(&rts->progress.pages_walked);
+        phase = __wt_atomic_load_uint32(&rts->progress.phase);
 
         if (walk)
             __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
-              "Rollback to stable performing btree walk on %s for %" PRIu64
+              "Rollback to stable [%s] performing btree walk on %s for %" PRIu64
               " seconds, %" PRIu64 " total pages walked",
-              session->dhandle->name, time_diff_ms / WT_THOUSAND, pages_walked);
+              __rts_phase_string(phase), session->dhandle->name, time_diff_ms / WT_THOUSAND,
+              pages_walked);
         else {
             pct = max_count > 0 ? (100 * rollback_count / max_count) : 0;
-            __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
-              "Rollback to stable has been running for %" PRIu64
-              " seconds, inspected %" PRIu64 " of %" PRIu64 " btrees (%" PRIu64
-              "%%), %" PRIu64 " btrees processed, %" PRIu64 " btrees skipped, %" PRIu64
-              " pages walked",
-              time_diff_ms / WT_THOUSAND, rollback_count, max_count, pct, btrees_processed,
-              btrees_skipped, pages_walked);
+            eta_sec = __rts_compute_eta_sec(session);
+            if (eta_sec > 0)
+                __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
+                  "Rollback to stable [%s] running for %" PRIu64
+                  " seconds, inspected %" PRIu64 " of %" PRIu64 " btrees (%" PRIu64
+                  "%%), %" PRIu64 " processed, %" PRIu64 " skipped, %" PRIu64
+                  " pages walked, ETA %" PRIu64 " seconds",
+                  __rts_phase_string(phase), time_diff_ms / WT_THOUSAND, rollback_count, max_count,
+                  pct, btrees_processed, btrees_skipped, pages_walked, eta_sec);
+            else
+                __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
+                  "Rollback to stable [%s] running for %" PRIu64
+                  " seconds, inspected %" PRIu64 " of %" PRIu64 " btrees (%" PRIu64
+                  "%%), %" PRIu64 " processed, %" PRIu64 " skipped, %" PRIu64 " pages walked",
+                  __rts_phase_string(phase), time_diff_ms / WT_THOUSAND, rollback_count, max_count,
+                  pct, btrees_processed, btrees_skipped, pages_walked);
         }
         *rollback_msg_count = time_diff_ms / (WT_THOUSAND * WT_PROGRESS_MSG_PERIOD);
     }
@@ -205,6 +270,7 @@ __wti_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_time
     bool have_cursor, rts_threads_started;
 
     __wti_rts_progress_init(session);
+    __wt_atomic_store_uint32(&S2C(session)->rts->progress.phase, WT_RTS_PHASE_METADATA_COUNT);
 
     __wt_timer_start(session, &timer);
     max_count = rollback_count = 0;
@@ -230,6 +296,7 @@ __wti_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_time
     __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
       "Rollback to stable found %" PRIu64 " btrees to process", max_count);
 
+    __wt_atomic_store_uint32(&S2C(session)->rts->progress.phase, WT_RTS_PHASE_BTREE_APPLY);
     __wt_timer_start(session, &S2C(session)->rts->progress.btree_apply_timer);
 
     WT_ERR(__rts_thread_create(session));
@@ -260,6 +327,7 @@ __wti_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_time
      * workers alone to complete the task.
      */
     if (S2C(session)->rts->threads_num != 0) {
+        __wt_atomic_store_uint32(&S2C(session)->rts->progress.phase, WT_RTS_PHASE_QUEUE_DRAIN);
         __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS, "%s",
           "Rollback to stable finished metadata walk, draining worker queue");
         while (!TAILQ_EMPTY(&S2C(session)->rts->rtsqh)) {
@@ -285,6 +353,7 @@ __wti_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_time
      * doesn't exist.
      */
     if (!F_ISSET(S2C(session), WT_CONN_IN_MEMORY)) {
+        __wt_atomic_store_uint32(&S2C(session)->rts->progress.phase, WT_RTS_PHASE_HS_FINAL_PASS);
         __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS, "%s",
           "Rollback to stable beginning history store final pass");
         __wt_verbose_level_multi(session, WT_VERB_RECOVERY_RTS(session), WT_VERBOSE_DEBUG_3,

--- a/src/rollback_to_stable/rts.c
+++ b/src/rollback_to_stable/rts.c
@@ -84,7 +84,7 @@ __rts_emit_overall_progress(WT_SESSION_IMPL *session)
 {
     WT_ROLLBACK_TO_STABLE *rts;
     uint64_t btrees_completed, btrees_processed, btrees_skipped, elapsed_ms, eta_sec,
-      pages_per_sec, pages_walked, pct, total_btrees;
+      max_btree_eta, pages_per_sec, pages_walked, pct, total_btrees;
     uint32_t phase;
 
     rts = S2C(session)->rts;
@@ -100,6 +100,13 @@ __rts_emit_overall_progress(WT_SESSION_IMPL *session)
     pct = total_btrees > 0 ? (100 * btrees_completed / total_btrees) : 0;
     pages_per_sec = elapsed_ms > 0 ? (pages_walked * WT_THOUSAND / elapsed_ms) : 0;
     eta_sec = __rts_compute_eta_sec(session);
+
+    /* Overall ETA can't be less than the largest per-btree ETA currently in progress. */
+    max_btree_eta = __wt_atomic_load_uint64_relaxed(&rts->progress.max_btree_eta_sec);
+    if (eta_sec < max_btree_eta)
+        eta_sec = max_btree_eta;
+    /* Reset for next reporting period so stale values don't persist. */
+    __wt_atomic_store_uint64_relaxed(&rts->progress.max_btree_eta_sec, 0);
     if (eta_sec > 0)
         __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
           "Rollback to stable [%s] overall: running for %" PRIu64 " seconds, %" PRIu64
@@ -172,6 +179,10 @@ __wti_rts_progress_msg_walk(WT_SESSION_IMPL *session, WT_TIMER *btree_start, uin
     btree_eta_sec = 0;
     if (npos > 0.05 && npos < 1.0)
         btree_eta_sec = (uint64_t)((1.0 - npos) * (double)elapsed_ms / (npos * WT_THOUSAND));
+
+    /* Update the global max btree ETA so overall ETA can use it as a floor. */
+    if (btree_eta_sec > __wt_atomic_load_uint64_relaxed(&rts->progress.max_btree_eta_sec))
+        __wt_atomic_store_uint64_relaxed(&rts->progress.max_btree_eta_sec, btree_eta_sec);
 
     if (btree_eta_sec > 0)
         __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,

--- a/src/rollback_to_stable/rts.c
+++ b/src/rollback_to_stable/rts.c
@@ -215,7 +215,7 @@ __wti_rts_progress_init(WT_SESSION_IMPL *session)
     WT_ROLLBACK_TO_STABLE *rts;
 
     rts = S2C(session)->rts;
-    memset(&rts->progress, 0, sizeof(rts->progress));
+    WT_CLEAR(rts->progress);
     __wt_timer_start(session, &rts->progress.start_timer);
 }
 

--- a/src/rollback_to_stable/rts.c
+++ b/src/rollback_to_stable/rts.c
@@ -70,12 +70,12 @@ __rts_emit_overall_progress(WT_SESSION_IMPL *session)
 }
 
 /*
- * __wti_rts_progress_msg --
+ * __rts_progress_msg --
  *     Log a verbose message about the overall progress of rollback to stable. Called from the
  *     metadata walk loop in __wti_rts_btree_apply_all.
  */
-void
-__wti_rts_progress_msg(WT_SESSION_IMPL *session, WT_TIMER *rollback_start, uint64_t *msg_count)
+static void
+__rts_progress_msg(WT_SESSION_IMPL *session, WT_TIMER *rollback_start, uint64_t *msg_count)
 {
     uint64_t time_diff_ms;
 
@@ -146,11 +146,11 @@ __wti_rts_progress_msg_walk(WT_SESSION_IMPL *session, WT_TIMER *btree_start, uin
 }
 
 /*
- * __wti_rts_progress_init --
+ * __rts_progress_init --
  *     Initialize the RTS progress tracking fields.
  */
-void
-__wti_rts_progress_init(WT_SESSION_IMPL *session)
+static void
+__rts_progress_init(WT_SESSION_IMPL *session)
 {
     WT_ROLLBACK_TO_STABLE *rts;
 
@@ -300,7 +300,7 @@ __wti_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_time
     const char *config, *saved_session_name, *uri;
     bool have_cursor, rts_threads_started;
 
-    __wti_rts_progress_init(session);
+    __rts_progress_init(session);
     __wt_atomic_store_uint32_relaxed(
       &S2C(session)->rts->progress.phase, WT_RTS_PHASE_METADATA_COUNT);
 
@@ -340,7 +340,7 @@ __wti_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_time
         /* Log a progress message. */
         WT_ERR(cursor->get_key(cursor, &uri));
         WT_ERR(cursor->get_value(cursor, &config));
-        __wti_rts_progress_msg(session, &timer, &rollback_msg_count);
+        __rts_progress_msg(session, &timer, &rollback_msg_count);
 
         F_SET(session, WT_SESSION_QUIET_CORRUPT_FILE);
         ret = __wti_rts_btree_walk_btree_apply(session, uri, config, rollback_timestamp);

--- a/src/rollback_to_stable/rts.c
+++ b/src/rollback_to_stable/rts.c
@@ -67,56 +67,70 @@ __rts_compute_eta_sec(WT_SESSION_IMPL *session)
 }
 
 /*
+ * __rts_emit_overall_progress --
+ *     Emit an overall RTS progress message with counters, percentage, throughput, and ETA.
+ */
+static void
+__rts_emit_overall_progress(WT_SESSION_IMPL *session)
+{
+    WT_ROLLBACK_TO_STABLE *rts;
+    uint64_t btrees_completed, btrees_processed, btrees_skipped, elapsed_ms, eta_sec,
+      pages_per_sec, pages_walked, pct, total_btrees;
+    uint32_t phase;
+
+    rts = S2C(session)->rts;
+
+    btrees_processed = __wt_atomic_load_uint64_relaxed(&rts->progress.btrees_processed);
+    btrees_skipped = __wt_atomic_load_uint64_relaxed(&rts->progress.btrees_skipped);
+    pages_walked = __wt_atomic_load_uint64_relaxed(&rts->progress.pages_walked);
+    phase = __wt_atomic_load_uint32(&rts->progress.phase);
+    total_btrees = rts->progress.total_btrees;
+
+    btrees_completed = btrees_processed + btrees_skipped;
+    __wt_timer_evaluate_ms(session, &rts->progress.start_timer, &elapsed_ms);
+    pct = total_btrees > 0 ? (100 * btrees_completed / total_btrees) : 0;
+    pages_per_sec = elapsed_ms > 0 ? (pages_walked * WT_THOUSAND / elapsed_ms) : 0;
+    eta_sec = __rts_compute_eta_sec(session);
+    if (eta_sec > 0)
+        __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
+          "Rollback to stable [%s] overall: running for %" PRIu64 " seconds, %" PRIu64
+          " of %" PRIu64 " btrees done (%" PRIu64 "%%), %" PRIu64 " processed, %" PRIu64
+          " skipped, %" PRIu64 " total pages walked (%" PRIu64 " pages/sec), ETA %" PRIu64
+          " seconds",
+          __rts_phase_string(phase), elapsed_ms / WT_THOUSAND, btrees_completed, total_btrees, pct,
+          btrees_processed, btrees_skipped, pages_walked, pages_per_sec, eta_sec);
+    else
+        __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
+          "Rollback to stable [%s] overall: running for %" PRIu64 " seconds, %" PRIu64
+          " of %" PRIu64 " btrees done (%" PRIu64 "%%), %" PRIu64 " processed, %" PRIu64
+          " skipped, %" PRIu64 " total pages walked (%" PRIu64 " pages/sec)",
+          __rts_phase_string(phase), elapsed_ms / WT_THOUSAND, btrees_completed, total_btrees, pct,
+          btrees_processed, btrees_skipped, pages_walked, pages_per_sec);
+
+    /* Notify the application via the progress callback. */
+    WT_IGNORE_RET(__wt_progress(session, "rollback to stable", btrees_completed));
+}
+
+/*
  * __wti_rts_progress_msg --
- *     Log a verbose message about the overall progress of rollback to stable.
+ *     Log a verbose message about the overall progress of rollback to stable. Called from the
+ *     metadata walk loop in __wti_rts_btree_apply_all.
  */
 void
 __wti_rts_progress_msg(WT_SESSION_IMPL *session, WT_TIMER *rollback_start, uint64_t rollback_count,
   uint64_t max_count, uint64_t *rollback_msg_count, bool walk)
 {
-    WT_ROLLBACK_TO_STABLE *rts;
-    uint64_t btrees_completed, btrees_processed, btrees_skipped, eta_sec, pages_per_sec,
-      pages_walked, pct, time_diff_ms, total_btrees;
-    uint32_t phase;
+    uint64_t time_diff_ms;
 
     WT_UNUSED(walk);
     WT_UNUSED(rollback_count);
     WT_UNUSED(max_count);
-    rts = S2C(session)->rts;
 
     /* Time since the rollback started. */
     __wt_timer_evaluate_ms(session, rollback_start, &time_diff_ms);
 
     if ((time_diff_ms / (WT_THOUSAND * WT_PROGRESS_MSG_PERIOD)) > *rollback_msg_count) {
-        /* Read atomic counters from the progress struct. */
-        btrees_processed = __wt_atomic_load_uint64_relaxed(&rts->progress.btrees_processed);
-        btrees_skipped = __wt_atomic_load_uint64_relaxed(&rts->progress.btrees_skipped);
-        pages_walked = __wt_atomic_load_uint64_relaxed(&rts->progress.pages_walked);
-        phase = __wt_atomic_load_uint32(&rts->progress.phase);
-        total_btrees = rts->progress.total_btrees;
-
-        btrees_completed = btrees_processed + btrees_skipped;
-        pct = total_btrees > 0 ? (100 * btrees_completed / total_btrees) : 0;
-        pages_per_sec = time_diff_ms > 0 ? (pages_walked * WT_THOUSAND / time_diff_ms) : 0;
-        eta_sec = __rts_compute_eta_sec(session);
-        if (eta_sec > 0)
-            __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
-              "Rollback to stable [%s] running for %" PRIu64 " seconds, %" PRIu64 " of %" PRIu64
-              " btrees done (%" PRIu64 "%%), %" PRIu64 " processed, %" PRIu64 " skipped, %" PRIu64
-              " total pages walked (%" PRIu64 " pages/sec), ETA %" PRIu64 " seconds",
-              __rts_phase_string(phase), time_diff_ms / WT_THOUSAND, btrees_completed, total_btrees,
-              pct, btrees_processed, btrees_skipped, pages_walked, pages_per_sec, eta_sec);
-        else
-            __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
-              "Rollback to stable [%s] running for %" PRIu64 " seconds, %" PRIu64 " of %" PRIu64
-              " btrees done (%" PRIu64 "%%), %" PRIu64 " processed, %" PRIu64 " skipped, %" PRIu64
-              " total pages walked (%" PRIu64 " pages/sec)",
-              __rts_phase_string(phase), time_diff_ms / WT_THOUSAND, btrees_completed, total_btrees,
-              pct, btrees_processed, btrees_skipped, pages_walked, pages_per_sec);
-
-        /* Notify the application via the progress callback. */
-        WT_IGNORE_RET(__wt_progress(session, "rollback to stable", btrees_completed));
-
+        __rts_emit_overall_progress(session);
         *rollback_msg_count = time_diff_ms / (WT_THOUSAND * WT_PROGRESS_MSG_PERIOD);
     }
 }
@@ -132,9 +146,8 @@ __wti_rts_progress_msg_walk(WT_SESSION_IMPL *session, WT_TIMER *btree_start, uin
   double npos, uint64_t btree_pages)
 {
     WT_ROLLBACK_TO_STABLE *rts;
-    uint64_t btree_eta_sec, btree_pct, btree_pages_per_sec, btrees_completed, btrees_processed,
-      btrees_skipped, elapsed_ms, eta_sec, overall_elapsed_ms, overall_pages_per_sec, overall_pct,
-      overall_report_count, pages_walked, total_btrees;
+    uint64_t btree_eta_sec, btree_pct, btree_pages_per_sec, elapsed_ms, overall_elapsed_ms,
+      overall_report_count;
     uint32_t phase;
 
     rts = S2C(session)->rts;
@@ -173,34 +186,8 @@ __wti_rts_progress_msg_walk(WT_SESSION_IMPL *session, WT_TIMER *btree_start, uin
     overall_report_count = __wt_atomic_load_uint64_relaxed(&rts->progress.overall_report_count);
     if ((overall_elapsed_ms / (WT_THOUSAND * WT_PROGRESS_MSG_PERIOD)) > overall_report_count &&
       __wt_atomic_cas_uint64(
-        &rts->progress.overall_report_count, overall_report_count, overall_report_count + 1)) {
-        btrees_processed = __wt_atomic_load_uint64_relaxed(&rts->progress.btrees_processed);
-        btrees_skipped = __wt_atomic_load_uint64_relaxed(&rts->progress.btrees_skipped);
-        pages_walked = __wt_atomic_load_uint64_relaxed(&rts->progress.pages_walked);
-        total_btrees = rts->progress.total_btrees;
-        btrees_completed = btrees_processed + btrees_skipped;
-        overall_pct = total_btrees > 0 ? (100 * btrees_completed / total_btrees) : 0;
-        overall_pages_per_sec =
-          overall_elapsed_ms > 0 ? (pages_walked * WT_THOUSAND / overall_elapsed_ms) : 0;
-        eta_sec = __rts_compute_eta_sec(session);
-        if (eta_sec > 0)
-            __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
-              "Rollback to stable [%s] overall: running for %" PRIu64 " seconds, %" PRIu64
-              " of %" PRIu64 " btrees done (%" PRIu64 "%%), %" PRIu64 " processed, %" PRIu64
-              " skipped, %" PRIu64 " total pages walked (%" PRIu64 " pages/sec), ETA %" PRIu64
-              " seconds",
-              __rts_phase_string(phase), overall_elapsed_ms / WT_THOUSAND, btrees_completed,
-              total_btrees, overall_pct, btrees_processed, btrees_skipped, pages_walked,
-              overall_pages_per_sec, eta_sec);
-        else
-            __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
-              "Rollback to stable [%s] overall: running for %" PRIu64 " seconds, %" PRIu64
-              " of %" PRIu64 " btrees done (%" PRIu64 "%%), %" PRIu64 " processed, %" PRIu64
-              " skipped, %" PRIu64 " total pages walked (%" PRIu64 " pages/sec)",
-              __rts_phase_string(phase), overall_elapsed_ms / WT_THOUSAND, btrees_completed,
-              total_btrees, overall_pct, btrees_processed, btrees_skipped, pages_walked,
-              overall_pages_per_sec);
-    }
+        &rts->progress.overall_report_count, overall_report_count, overall_report_count + 1))
+        __rts_emit_overall_progress(session);
 
     *msg_count = elapsed_ms / (WT_THOUSAND * WT_PROGRESS_MSG_PERIOD);
 }

--- a/src/rollback_to_stable/rts.c
+++ b/src/rollback_to_stable/rts.c
@@ -110,6 +110,10 @@ __wti_rts_progress_msg(WT_SESSION_IMPL *session, WT_TIMER *rollback_start, uint6
                   __rts_phase_string(phase), time_diff_ms / WT_THOUSAND, rollback_count, max_count,
                   pct, btrees_processed, btrees_skipped, pages_walked);
         }
+
+        /* Notify the application via the progress callback. */
+        WT_IGNORE_RET(__wt_progress(session, "rollback to stable", btrees_processed));
+
         *rollback_msg_count = time_diff_ms / (WT_THOUSAND * WT_PROGRESS_MSG_PERIOD);
     }
 }

--- a/src/rollback_to_stable/rts.c
+++ b/src/rollback_to_stable/rts.c
@@ -139,72 +139,70 @@ __wti_rts_progress_msg_walk(WT_SESSION_IMPL *session, WT_TIMER *btree_start, uin
 
     rts = S2C(session)->rts;
 
+    /* The caller has already verified it's time to report; compute values for the message. */
     __wt_timer_evaluate_ms(session, btree_start, &elapsed_ms);
 
-    if ((elapsed_ms / (WT_THOUSAND * WT_PROGRESS_MSG_PERIOD)) > *msg_count) {
-        phase = __wt_atomic_load_uint32(&rts->progress.phase);
-        btree_pct = (uint64_t)(npos * 100);
-        btree_pages_per_sec = elapsed_ms > 0 ? (btree_pages * WT_THOUSAND / elapsed_ms) : 0;
+    phase = __wt_atomic_load_uint32(&rts->progress.phase);
+    btree_pct = (uint64_t)(npos * 100);
+    btree_pages_per_sec = elapsed_ms > 0 ? (btree_pages * WT_THOUSAND / elapsed_ms) : 0;
 
-        /* Estimate time remaining for this btree based on npos progression. */
-        btree_eta_sec = 0;
-        if (npos > 0.05 && npos < 1.0)
-            btree_eta_sec = (uint64_t)((1.0 - npos) * (double)elapsed_ms / (npos * WT_THOUSAND));
+    /* Estimate time remaining for this btree based on npos progression. */
+    btree_eta_sec = 0;
+    if (npos > 0.05 && npos < 1.0)
+        btree_eta_sec = (uint64_t)((1.0 - npos) * (double)elapsed_ms / (npos * WT_THOUSAND));
 
-        if (btree_eta_sec > 0)
+    if (btree_eta_sec > 0)
+        __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
+          "Rollback to stable [%s] btree walk on %s for %" PRIu64 " seconds, %" PRIu64
+          "%% through btree, %" PRIu64 " pages walked (%" PRIu64 " pages/sec), btree ETA %" PRIu64
+          " seconds",
+          __rts_phase_string(phase), session->dhandle->name, elapsed_ms / WT_THOUSAND, btree_pct,
+          btree_pages, btree_pages_per_sec, btree_eta_sec);
+    else
+        __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
+          "Rollback to stable [%s] btree walk on %s for %" PRIu64 " seconds, %" PRIu64
+          "%% through btree, %" PRIu64 " pages walked (%" PRIu64 " pages/sec)",
+          __rts_phase_string(phase), session->dhandle->name, elapsed_ms / WT_THOUSAND, btree_pct,
+          btree_pages, btree_pages_per_sec);
+
+    /*
+     * Emit an overall progress line. Use CAS on overall_report_count so that exactly one thread
+     * wins per reporting period, regardless of which thread it is.
+     */
+    __wt_timer_evaluate_ms(session, &rts->progress.start_timer, &overall_elapsed_ms);
+    overall_report_count = __wt_atomic_load_uint64_relaxed(&rts->progress.overall_report_count);
+    if ((overall_elapsed_ms / (WT_THOUSAND * WT_PROGRESS_MSG_PERIOD)) > overall_report_count &&
+      __wt_atomic_cas_uint64(
+        &rts->progress.overall_report_count, overall_report_count, overall_report_count + 1)) {
+        btrees_processed = __wt_atomic_load_uint64_relaxed(&rts->progress.btrees_processed);
+        btrees_skipped = __wt_atomic_load_uint64_relaxed(&rts->progress.btrees_skipped);
+        pages_walked = __wt_atomic_load_uint64_relaxed(&rts->progress.pages_walked);
+        total_btrees = rts->progress.total_btrees;
+        btrees_completed = btrees_processed + btrees_skipped;
+        overall_pct = total_btrees > 0 ? (100 * btrees_completed / total_btrees) : 0;
+        overall_pages_per_sec =
+          overall_elapsed_ms > 0 ? (pages_walked * WT_THOUSAND / overall_elapsed_ms) : 0;
+        eta_sec = __rts_compute_eta_sec(session);
+        if (eta_sec > 0)
             __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
-              "Rollback to stable [%s] btree walk on %s for %" PRIu64 " seconds, %" PRIu64
-              "%% through btree, %" PRIu64 " pages walked (%" PRIu64
-              " pages/sec), btree ETA %" PRIu64 " seconds",
-              __rts_phase_string(phase), session->dhandle->name, elapsed_ms / WT_THOUSAND,
-              btree_pct, btree_pages, btree_pages_per_sec, btree_eta_sec);
+              "Rollback to stable [%s] overall: running for %" PRIu64 " seconds, %" PRIu64
+              " of %" PRIu64 " btrees done (%" PRIu64 "%%), %" PRIu64 " processed, %" PRIu64
+              " skipped, %" PRIu64 " total pages walked (%" PRIu64 " pages/sec), ETA %" PRIu64
+              " seconds",
+              __rts_phase_string(phase), overall_elapsed_ms / WT_THOUSAND, btrees_completed,
+              total_btrees, overall_pct, btrees_processed, btrees_skipped, pages_walked,
+              overall_pages_per_sec, eta_sec);
         else
             __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
-              "Rollback to stable [%s] btree walk on %s for %" PRIu64 " seconds, %" PRIu64
-              "%% through btree, %" PRIu64 " pages walked (%" PRIu64 " pages/sec)",
-              __rts_phase_string(phase), session->dhandle->name, elapsed_ms / WT_THOUSAND,
-              btree_pct, btree_pages, btree_pages_per_sec);
-
-        /*
-         * Emit an overall progress line. Use CAS on overall_report_count so that exactly one
-         * thread wins per reporting period, regardless of which thread it is.
-         */
-        __wt_timer_evaluate_ms(session, &rts->progress.start_timer, &overall_elapsed_ms);
-        overall_report_count =
-          __wt_atomic_load_uint64_relaxed(&rts->progress.overall_report_count);
-        if ((overall_elapsed_ms / (WT_THOUSAND * WT_PROGRESS_MSG_PERIOD)) > overall_report_count &&
-          __wt_atomic_cas_uint64(
-            &rts->progress.overall_report_count, overall_report_count, overall_report_count + 1)) {
-            btrees_processed = __wt_atomic_load_uint64_relaxed(&rts->progress.btrees_processed);
-            btrees_skipped = __wt_atomic_load_uint64_relaxed(&rts->progress.btrees_skipped);
-            pages_walked = __wt_atomic_load_uint64_relaxed(&rts->progress.pages_walked);
-            total_btrees = rts->progress.total_btrees;
-            btrees_completed = btrees_processed + btrees_skipped;
-            overall_pct = total_btrees > 0 ? (100 * btrees_completed / total_btrees) : 0;
-            overall_pages_per_sec =
-              overall_elapsed_ms > 0 ? (pages_walked * WT_THOUSAND / overall_elapsed_ms) : 0;
-            eta_sec = __rts_compute_eta_sec(session);
-            if (eta_sec > 0)
-                __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
-                  "Rollback to stable [%s] overall: running for %" PRIu64 " seconds, %" PRIu64
-                  " of %" PRIu64 " btrees done (%" PRIu64 "%%), %" PRIu64 " processed, %" PRIu64
-                  " skipped, %" PRIu64 " total pages walked (%" PRIu64 " pages/sec), ETA %" PRIu64
-                  " seconds",
-                  __rts_phase_string(phase), overall_elapsed_ms / WT_THOUSAND, btrees_completed,
-                  total_btrees, overall_pct, btrees_processed, btrees_skipped, pages_walked,
-                  overall_pages_per_sec, eta_sec);
-            else
-                __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
-                  "Rollback to stable [%s] overall: running for %" PRIu64 " seconds, %" PRIu64
-                  " of %" PRIu64 " btrees done (%" PRIu64 "%%), %" PRIu64 " processed, %" PRIu64
-                  " skipped, %" PRIu64 " total pages walked (%" PRIu64 " pages/sec)",
-                  __rts_phase_string(phase), overall_elapsed_ms / WT_THOUSAND, btrees_completed,
-                  total_btrees, overall_pct, btrees_processed, btrees_skipped, pages_walked,
-                  overall_pages_per_sec);
-        }
-
-        *msg_count = elapsed_ms / (WT_THOUSAND * WT_PROGRESS_MSG_PERIOD);
+              "Rollback to stable [%s] overall: running for %" PRIu64 " seconds, %" PRIu64
+              " of %" PRIu64 " btrees done (%" PRIu64 "%%), %" PRIu64 " processed, %" PRIu64
+              " skipped, %" PRIu64 " total pages walked (%" PRIu64 " pages/sec)",
+              __rts_phase_string(phase), overall_elapsed_ms / WT_THOUSAND, btrees_completed,
+              total_btrees, overall_pct, btrees_processed, btrees_skipped, pages_walked,
+              overall_pages_per_sec);
     }
+
+    *msg_count = elapsed_ms / (WT_THOUSAND * WT_PROGRESS_MSG_PERIOD);
 }
 
 /*

--- a/src/rollback_to_stable/rts.c
+++ b/src/rollback_to_stable/rts.c
@@ -63,16 +63,18 @@ __rts_compute_eta_sec(WT_SESSION_IMPL *session, uint64_t inspected)
 
 /*
  * __wti_rts_progress_msg --
- *     Log a verbose message about the progress of the current rollback to stable.
+ *     Log a verbose message about the overall progress of rollback to stable.
  */
 void
 __wti_rts_progress_msg(WT_SESSION_IMPL *session, WT_TIMER *rollback_start, uint64_t rollback_count,
   uint64_t max_count, uint64_t *rollback_msg_count, bool walk)
 {
     WT_ROLLBACK_TO_STABLE *rts;
-    uint64_t btrees_processed, btrees_skipped, eta_sec, pages_walked, pct, time_diff_ms;
+    uint64_t btrees_processed, btrees_skipped, eta_sec, pages_per_sec, pages_walked, pct,
+      time_diff_ms;
     uint32_t phase;
 
+    WT_UNUSED(walk);
     rts = S2C(session)->rts;
 
     /* Time since the rollback started. */
@@ -85,36 +87,78 @@ __wti_rts_progress_msg(WT_SESSION_IMPL *session, WT_TIMER *rollback_start, uint6
         pages_walked = __wt_atomic_load_uint64_relaxed(&rts->progress.pages_walked);
         phase = __wt_atomic_load_uint32(&rts->progress.phase);
 
-        if (walk)
+        pct = max_count > 0 ? (100 * rollback_count / max_count) : 0;
+        pages_per_sec = time_diff_ms > 0 ? (pages_walked * WT_THOUSAND / time_diff_ms) : 0;
+        eta_sec = __rts_compute_eta_sec(session, rollback_count);
+        if (eta_sec > 0)
             __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
-              "Rollback to stable [%s] performing btree walk on %s for %" PRIu64
-              " seconds, %" PRIu64 " total pages walked",
-              __rts_phase_string(phase), session->dhandle->name, time_diff_ms / WT_THOUSAND,
-              pages_walked);
-        else {
-            pct = max_count > 0 ? (100 * rollback_count / max_count) : 0;
-            eta_sec = __rts_compute_eta_sec(session, rollback_count);
-            if (eta_sec > 0)
-                __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
-                  "Rollback to stable [%s] running for %" PRIu64
-                  " seconds, inspected %" PRIu64 " of %" PRIu64 " btrees (%" PRIu64
-                  "%%), %" PRIu64 " processed, %" PRIu64 " skipped, %" PRIu64
-                  " pages walked, ETA %" PRIu64 " seconds",
-                  __rts_phase_string(phase), time_diff_ms / WT_THOUSAND, rollback_count, max_count,
-                  pct, btrees_processed, btrees_skipped, pages_walked, eta_sec);
-            else
-                __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
-                  "Rollback to stable [%s] running for %" PRIu64
-                  " seconds, inspected %" PRIu64 " of %" PRIu64 " btrees (%" PRIu64
-                  "%%), %" PRIu64 " processed, %" PRIu64 " skipped, %" PRIu64 " pages walked",
-                  __rts_phase_string(phase), time_diff_ms / WT_THOUSAND, rollback_count, max_count,
-                  pct, btrees_processed, btrees_skipped, pages_walked);
-        }
+              "Rollback to stable [%s] running for %" PRIu64
+              " seconds, inspected %" PRIu64 " of %" PRIu64 " btrees (%" PRIu64
+              "%%), %" PRIu64 " processed, %" PRIu64 " skipped, %" PRIu64
+              " total pages walked (%" PRIu64 " pages/sec), ETA %" PRIu64 " seconds",
+              __rts_phase_string(phase), time_diff_ms / WT_THOUSAND, rollback_count, max_count,
+              pct, btrees_processed, btrees_skipped, pages_walked, pages_per_sec, eta_sec);
+        else
+            __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
+              "Rollback to stable [%s] running for %" PRIu64
+              " seconds, inspected %" PRIu64 " of %" PRIu64 " btrees (%" PRIu64
+              "%%), %" PRIu64 " processed, %" PRIu64 " skipped, %" PRIu64
+              " total pages walked (%" PRIu64 " pages/sec)",
+              __rts_phase_string(phase), time_diff_ms / WT_THOUSAND, rollback_count, max_count,
+              pct, btrees_processed, btrees_skipped, pages_walked, pages_per_sec);
 
         /* Notify the application via the progress callback. */
         WT_IGNORE_RET(__wt_progress(session, "rollback to stable", btrees_processed));
 
         *rollback_msg_count = time_diff_ms / (WT_THOUSAND * WT_PROGRESS_MSG_PERIOD);
+    }
+}
+
+/*
+ * __wti_rts_progress_msg_walk --
+ *     Log a verbose message about the progress of a per-btree page walk during rollback to stable.
+ *     Uses the normalized position (npos) of the current page to compute a percentage within the
+ *     tree and estimate time remaining for this btree.
+ */
+void
+__wti_rts_progress_msg_walk(
+  WT_SESSION_IMPL *session, WT_TIMER *btree_start, uint64_t *msg_count, double npos)
+{
+    WT_ROLLBACK_TO_STABLE *rts;
+    uint64_t btree_eta_sec, btree_pct, elapsed_ms, pages_per_sec, pages_walked;
+    uint32_t phase;
+
+    rts = S2C(session)->rts;
+
+    __wt_timer_evaluate_ms(session, btree_start, &elapsed_ms);
+
+    if ((elapsed_ms / (WT_THOUSAND * WT_PROGRESS_MSG_PERIOD)) > *msg_count) {
+        pages_walked = __wt_atomic_load_uint64_relaxed(&rts->progress.pages_walked);
+        phase = __wt_atomic_load_uint32(&rts->progress.phase);
+        btree_pct = (uint64_t)(npos * 100);
+        pages_per_sec = elapsed_ms > 0 ? (pages_walked * WT_THOUSAND / elapsed_ms) : 0;
+
+        /* Estimate time remaining for this btree based on npos progression. */
+        btree_eta_sec = 0;
+        if (npos > 0.05 && npos < 1.0)
+            btree_eta_sec = (uint64_t)((1.0 - npos) * (double)elapsed_ms / (npos * WT_THOUSAND));
+
+        if (btree_eta_sec > 0)
+            __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
+              "Rollback to stable [%s] btree walk on %s for %" PRIu64
+              " seconds, %" PRIu64 "%% through btree, %" PRIu64
+              " pages walked (%" PRIu64 " pages/sec), btree ETA %" PRIu64 " seconds",
+              __rts_phase_string(phase), session->dhandle->name, elapsed_ms / WT_THOUSAND,
+              btree_pct, pages_walked, pages_per_sec, btree_eta_sec);
+        else
+            __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
+              "Rollback to stable [%s] btree walk on %s for %" PRIu64
+              " seconds, %" PRIu64 "%% through btree, %" PRIu64
+              " pages walked (%" PRIu64 " pages/sec)",
+              __rts_phase_string(phase), session->dhandle->name, elapsed_ms / WT_THOUSAND,
+              btree_pct, pages_walked, pages_per_sec);
+
+        *msg_count = elapsed_ms / (WT_THOUSAND * WT_PROGRESS_MSG_PERIOD);
     }
 }
 

--- a/src/rollback_to_stable/rts.c
+++ b/src/rollback_to_stable/rts.c
@@ -93,7 +93,7 @@ __rts_emit_overall_progress(WT_SESSION_IMPL *session)
     btrees_processed = __wt_atomic_load_uint64_relaxed(&rts->progress.btrees_processed);
     btrees_skipped = __wt_atomic_load_uint64_relaxed(&rts->progress.btrees_skipped);
     pages_walked = __wt_atomic_load_uint64_relaxed(&rts->progress.pages_walked);
-    phase = __wt_atomic_load_uint32(&rts->progress.phase);
+    phase = __wt_atomic_load_uint32_relaxed(&rts->progress.phase);
     total_btrees = rts->progress.total_btrees;
 
     btrees_completed = btrees_processed + btrees_skipped;
@@ -167,7 +167,7 @@ __wti_rts_progress_msg_walk(WT_SESSION_IMPL *session, WT_TIMER *btree_start, uin
     /* The caller has already verified it's time to report; compute values for the message. */
     __wt_timer_evaluate_ms(session, btree_start, &elapsed_ms);
 
-    phase = __wt_atomic_load_uint32(&rts->progress.phase);
+    phase = __wt_atomic_load_uint32_relaxed(&rts->progress.phase);
     btree_pct = (uint64_t)(npos * 100);
     btree_pages_per_sec = elapsed_ms > 0 ? (btree_pages * WT_THOUSAND / elapsed_ms) : 0;
 
@@ -364,7 +364,7 @@ __wti_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_time
     bool have_cursor, rts_threads_started;
 
     __wti_rts_progress_init(session);
-    __wt_atomic_store_uint32(&S2C(session)->rts->progress.phase, WT_RTS_PHASE_METADATA_COUNT);
+    __wt_atomic_store_uint32_relaxed(&S2C(session)->rts->progress.phase, WT_RTS_PHASE_METADATA_COUNT);
 
     __wt_timer_start(session, &timer);
     max_count = 0;
@@ -391,7 +391,7 @@ __wti_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_time
     __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
       "Rollback to stable found %" PRIu64 " btrees to process", max_count);
 
-    __wt_atomic_store_uint32(&S2C(session)->rts->progress.phase, WT_RTS_PHASE_BTREE_APPLY);
+    __wt_atomic_store_uint32_relaxed(&S2C(session)->rts->progress.phase, WT_RTS_PHASE_BTREE_APPLY);
     __wt_timer_start(session, &S2C(session)->rts->progress.btree_apply_timer);
 
     WT_ERR(__rts_thread_create(session));
@@ -419,7 +419,7 @@ __wti_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_time
      * workers alone to complete the task.
      */
     if (S2C(session)->rts->threads_num != 0) {
-        __wt_atomic_store_uint32(&S2C(session)->rts->progress.phase, WT_RTS_PHASE_QUEUE_DRAIN);
+        __wt_atomic_store_uint32_relaxed(&S2C(session)->rts->progress.phase, WT_RTS_PHASE_QUEUE_DRAIN);
         __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS, "%s",
           "Rollback to stable finished metadata walk, draining worker queue");
 
@@ -449,7 +449,7 @@ __wti_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_time
      * doesn't exist.
      */
     if (!F_ISSET(S2C(session), WT_CONN_IN_MEMORY)) {
-        __wt_atomic_store_uint32(&S2C(session)->rts->progress.phase, WT_RTS_PHASE_HS_FINAL_PASS);
+        __wt_atomic_store_uint32_relaxed(&S2C(session)->rts->progress.phase, WT_RTS_PHASE_HS_FINAL_PASS);
         __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS, "%s",
           "Rollback to stable beginning history store final pass");
         __wt_verbose_level_multi(session, WT_VERB_RECOVERY_RTS(session), WT_VERBOSE_DEBUG_3,
@@ -460,7 +460,7 @@ __wti_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_time
         WT_ERR(__wti_rts_history_final_pass(session, rollback_timestamp));
     }
 
-    __wt_atomic_store_uint32(&S2C(session)->rts->progress.phase, WT_RTS_PHASE_COMPLETE);
+    __wt_atomic_store_uint32_relaxed(&S2C(session)->rts->progress.phase, WT_RTS_PHASE_COMPLETE);
 err:
     session->name = saved_session_name;
     if (have_cursor)

--- a/src/rollback_to_stable/rts.c
+++ b/src/rollback_to_stable/rts.c
@@ -75,16 +75,18 @@ __rts_emit_overall_progress(WT_SESSION_IMPL *session)
  *     metadata walk loop in __wti_rts_btree_apply_all.
  */
 static void
-__rts_progress_msg(WT_SESSION_IMPL *session, uint64_t *last_report_clock)
+__rts_progress_msg(WT_SESSION_IMPL *session)
 {
-    uint64_t clock_now, elapsed_ns;
+    WT_ROLLBACK_TO_STABLE *rts;
+    uint64_t clock_now, overall_last;
 
+    rts = S2C(session)->rts;
     clock_now = __wt_clock(session);
-    elapsed_ns = __wt_clock_to_nsec(clock_now, *last_report_clock);
-    if (elapsed_ns >= (uint64_t)WT_BILLION * WT_PROGRESS_MSG_PERIOD) {
+    overall_last = __wt_atomic_load_uint64_relaxed(&rts->progress.overall_last_report);
+    if (__wt_clock_to_nsec(clock_now, overall_last) >=
+        (uint64_t)WT_BILLION * WT_PROGRESS_MSG_PERIOD &&
+      __wt_atomic_cas_uint64(&rts->progress.overall_last_report, overall_last, clock_now))
         __rts_emit_overall_progress(session);
-        *last_report_clock = clock_now;
-    }
 }
 
 /*
@@ -135,13 +137,16 @@ __wti_rts_progress_msg_walk(WT_SESSION_IMPL *session, uint64_t btree_start_clock
 
     /*
      * Emit an overall progress line. Use CAS on overall_last_report so that exactly one thread wins
-     * per reporting period, regardless of which thread it is.
+     * per reporting period, regardless of which thread it is. Skip if progress was not initialized
+     * (e.g., single-file RTS via rollback_to_stable_one).
      */
-    overall_last = __wt_atomic_load_uint64_relaxed(&rts->progress.overall_last_report);
-    if (__wt_clock_to_nsec(clock_now, overall_last) >=
-        (uint64_t)WT_BILLION * WT_PROGRESS_MSG_PERIOD &&
-      __wt_atomic_cas_uint64(&rts->progress.overall_last_report, overall_last, clock_now))
-        __rts_emit_overall_progress(session);
+    if (rts->progress.total_btrees > 0) {
+        overall_last = __wt_atomic_load_uint64_relaxed(&rts->progress.overall_last_report);
+        if (__wt_clock_to_nsec(clock_now, overall_last) >=
+            (uint64_t)WT_BILLION * WT_PROGRESS_MSG_PERIOD &&
+          __wt_atomic_cas_uint64(&rts->progress.overall_last_report, overall_last, clock_now))
+            __rts_emit_overall_progress(session);
+    }
 
     *last_report_clock = clock_now;
 }
@@ -296,7 +301,7 @@ __wti_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_time
     WT_CURSOR *cursor;
     WT_DECL_RET;
     WT_RTS_WORK_UNIT *entry;
-    uint64_t last_report_clock, max_count;
+    uint64_t max_count;
     char ts_string[WT_TS_INT_STRING_SIZE];
     const char *config, *saved_session_name, *uri;
     bool have_cursor, rts_threads_started;
@@ -305,7 +310,6 @@ __wti_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_time
     __wt_atomic_store_uint32_relaxed(
       &S2C(session)->rts->progress.phase, WT_RTS_PHASE_METADATA_COUNT);
 
-    last_report_clock = __wt_clock(session);
     max_count = 0;
     saved_session_name = session->name;
     rts_threads_started = false;
@@ -340,7 +344,7 @@ __wti_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_time
         /* Log a progress message. */
         WT_ERR(cursor->get_key(cursor, &uri));
         WT_ERR(cursor->get_value(cursor, &config));
-        __rts_progress_msg(session, &last_report_clock);
+        __rts_progress_msg(session);
 
         F_SET(session, WT_SESSION_QUIET_CORRUPT_FILE);
         ret = __wti_rts_btree_walk_btree_apply(session, uri, config, rollback_timestamp);

--- a/src/rollback_to_stable/rts_api.c
+++ b/src/rollback_to_stable/rts_api.c
@@ -316,8 +316,9 @@ __rollback_to_stable(WT_SESSION_IMPL *session, const char *cfg[], bool no_ckpt)
     /* Time since the RTS started. */
     __wt_timer_evaluate_ms(session, &timer, &time_diff_ms);
     __wt_verbose_multi(session, WT_VERB_RECOVERY_RTS(session),
-      WT_RTS_VERB_TAG_END "finished rollback to stable%s and has ran for %" PRIu64 " milliseconds",
-      dryrun ? " dryrun" : "", time_diff_ms);
+      WT_RTS_VERB_TAG_END "finished rollback to stable%s with %" PRIu32
+                          " worker threads and has ran for %" PRIu64 " milliseconds",
+      dryrun ? " dryrun" : "", threads, time_diff_ms);
     WT_STAT_CONN_SET(session, txn_rollback_to_stable_running, 0);
 
     /* Reset the RTS configuration to default. */

--- a/src/rollback_to_stable/rts_api.c
+++ b/src/rollback_to_stable/rts_api.c
@@ -262,7 +262,7 @@ __rollback_to_stable_finalize(WT_ROLLBACK_TO_STABLE *rts)
 {
     rts->dryrun = false;
     rts->threads_num = 0;
-    memset(&rts->progress, 0, sizeof(rts->progress));
+    WT_CLEAR(rts->progress);
 }
 
 /*

--- a/src/rollback_to_stable/rts_api.c
+++ b/src/rollback_to_stable/rts_api.c
@@ -328,7 +328,7 @@ __rollback_to_stable(WT_SESSION_IMPL *session, const char *cfg[], bool no_ckpt)
 
     __wt_verbose_multi(session, WT_VERB_RECOVERY_RTS(session),
       WT_RTS_VERB_TAG_END "finished rollback to stable%s with %" PRIu32
-                          " worker threads and has ran for %" PRIu64 " milliseconds",
+                          " worker threads, ran for %" PRIu64 " milliseconds",
       dryrun ? " dryrun" : "", threads, time_diff_ms);
     WT_STAT_CONN_SET(session, txn_rollback_to_stable_running, 0);
 

--- a/src/rollback_to_stable/rts_api.c
+++ b/src/rollback_to_stable/rts_api.c
@@ -316,6 +316,16 @@ __rollback_to_stable(WT_SESSION_IMPL *session, const char *cfg[], bool no_ckpt)
 
     /* Time since the RTS started. */
     __wt_timer_evaluate_ms(session, &timer, &time_diff_ms);
+
+    /* Log a summary of RTS work before the final end message. */
+    __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
+      "Rollback to stable summary: total_btrees=%" PRIu64 ", processed=%" PRIu64
+      ", skipped=%" PRIu64 ", pages_walked=%" PRIu64 ", elapsed_ms=%" PRIu64,
+      S2C(session)->rts->progress.total_btrees,
+      __wt_atomic_load_uint64_relaxed(&S2C(session)->rts->progress.btrees_processed),
+      __wt_atomic_load_uint64_relaxed(&S2C(session)->rts->progress.btrees_skipped),
+      __wt_atomic_load_uint64_relaxed(&S2C(session)->rts->progress.pages_walked), time_diff_ms);
+
     __wt_verbose_multi(session, WT_VERB_RECOVERY_RTS(session),
       WT_RTS_VERB_TAG_END "finished rollback to stable%s with %" PRIu32
                           " worker threads and has ran for %" PRIu64 " milliseconds",

--- a/src/rollback_to_stable/rts_api.c
+++ b/src/rollback_to_stable/rts_api.c
@@ -262,6 +262,7 @@ __rollback_to_stable_finalize(WT_ROLLBACK_TO_STABLE *rts)
 {
     rts->dryrun = false;
     rts->threads_num = 0;
+    memset(&rts->progress, 0, sizeof(rts->progress));
 }
 
 /*

--- a/src/rollback_to_stable/rts_btree_walk.c
+++ b/src/rollback_to_stable/rts_btree_walk.c
@@ -122,23 +122,25 @@ __rts_btree_walk(WT_SESSION_IMPL *session, wt_timestamp_t rollback_timestamp)
     WT_REF *ref;
     WT_TIMER timer;
     double npos;
-    uint64_t msg_count;
+    uint64_t btree_pages, msg_count;
     uint32_t flags;
 
     __wt_timer_start(session, &timer);
     flags = WT_READ_NO_EVICT | WT_READ_VISIBLE_ALL | WT_READ_WONT_NEED | WT_READ_SEE_DELETED;
     msg_count = 0;
+    btree_pages = 0;
 
     /* Walk the tree, marking commits aborted where appropriate. */
     ref = NULL;
     while ((ret = __wt_tree_walk_custom_skip(
               session, &ref, __rts_btree_walk_page_skip, &rollback_timestamp, flags)) == 0 &&
       ref != NULL) {
+        ++btree_pages;
         (void)__wt_atomic_add_uint64_relaxed(&S2C(session)->rts->progress.pages_walked, 1);
 
         /* Compute the normalized position (0..1) of this page in the tree for progress. */
         npos = __wt_page_npos(session, ref, 0.5, NULL, NULL, 0);
-        __wti_rts_progress_msg_walk(session, &timer, &msg_count, npos);
+        __wti_rts_progress_msg_walk(session, &timer, &msg_count, npos, btree_pages);
 
         if (F_ISSET(ref, WT_REF_FLAG_LEAF))
             WT_ERR(__wti_rts_btree_abort_updates(session, ref, rollback_timestamp));

--- a/src/rollback_to_stable/rts_btree_walk.c
+++ b/src/rollback_to_stable/rts_btree_walk.c
@@ -277,7 +277,7 @@ __rts_btree(WT_SESSION_IMPL *session, const char *uri, wt_timestamp_t rollback_t
           uri, ret == ENOENT ? "does not exist" : "is corrupted.");
         (void)__wt_atomic_add_uint64_relaxed(&S2C(session)->rts->progress.btrees_skipped, 1);
         ret = 0;
-    } else
+    } else if (ret == 0)
         (void)__wt_atomic_add_uint64_relaxed(&S2C(session)->rts->progress.btrees_processed, 1);
     return (ret);
 }

--- a/src/rollback_to_stable/rts_btree_walk.c
+++ b/src/rollback_to_stable/rts_btree_walk.c
@@ -140,8 +140,8 @@ __rts_btree_walk(WT_SESSION_IMPL *session, wt_timestamp_t rollback_timestamp)
         (void)__wt_atomic_add_uint64_relaxed(&S2C(session)->rts->progress.pages_walked, 1);
 
         /*
-         * Use the cheap rdtsc-based clock to check if a progress message is due. Only compute
-         * npos (which walks parent indexes) and emit the message when the period has elapsed.
+         * Use the cheap rdtsc-based clock to check if a progress message is due. Only compute npos
+         * (which walks parent indexes) and emit the message when the period has elapsed.
          */
         clock_now = __wt_clock(session);
         elapsed_ns = __wt_clock_to_nsec(clock_now, clock_start);

--- a/src/rollback_to_stable/rts_btree_walk.c
+++ b/src/rollback_to_stable/rts_btree_walk.c
@@ -122,7 +122,7 @@ __rts_btree_walk(WT_SESSION_IMPL *session, wt_timestamp_t rollback_timestamp)
     WT_REF *ref;
     WT_TIMER timer;
     double npos;
-    uint64_t btree_pages, msg_count;
+    uint64_t btree_pages, elapsed_ms, msg_count;
     uint32_t flags;
 
     __wt_timer_start(session, &timer);
@@ -138,9 +138,12 @@ __rts_btree_walk(WT_SESSION_IMPL *session, wt_timestamp_t rollback_timestamp)
         ++btree_pages;
         (void)__wt_atomic_add_uint64_relaxed(&S2C(session)->rts->progress.pages_walked, 1);
 
-        /* Compute the normalized position (0..1) of this page in the tree for progress. */
-        npos = __wt_page_npos(session, ref, 0.5, NULL, NULL, 0);
-        __wti_rts_progress_msg_walk(session, &timer, &msg_count, npos, btree_pages);
+        /* Only compute npos (which walks parent indexes) when a progress message is due. */
+        __wt_timer_evaluate_ms(session, &timer, &elapsed_ms);
+        if ((elapsed_ms / (WT_THOUSAND * WT_PROGRESS_MSG_PERIOD)) > msg_count) {
+            npos = __wt_page_npos(session, ref, 0.5, NULL, NULL, 0);
+            __wti_rts_progress_msg_walk(session, &timer, &msg_count, npos, btree_pages);
+        }
 
         if (F_ISSET(ref, WT_REF_FLAG_LEAF))
             WT_ERR(__wti_rts_btree_abort_updates(session, ref, rollback_timestamp));
@@ -253,7 +256,6 @@ __rts_btree(WT_SESSION_IMPL *session, const char *uri, wt_timestamp_t rollback_t
 
     ret = __rts_btree_int(session, uri, rollback_timestamp);
     WT_STAT_CONN_DSRC_INCR(session, txn_rts_btrees_applied);
-    (void)__wt_atomic_add_uint64_relaxed(&S2C(session)->rts->progress.btrees_processed, 1);
     /*
      * Ignore rollback to stable failures on files that don't exist or files where corruption is
      * detected.
@@ -264,8 +266,10 @@ __rts_btree(WT_SESSION_IMPL *session, const char *uri, wt_timestamp_t rollback_t
           WT_RTS_VERB_TAG_SKIP_DAMAGE
           "%s: skipped performing rollback to stable because the file %s",
           uri, ret == ENOENT ? "does not exist" : "is corrupted.");
+        (void)__wt_atomic_add_uint64_relaxed(&S2C(session)->rts->progress.btrees_skipped, 1);
         ret = 0;
-    }
+    } else
+        (void)__wt_atomic_add_uint64_relaxed(&S2C(session)->rts->progress.btrees_processed, 1);
     return (ret);
 }
 
@@ -373,6 +377,7 @@ __wti_rts_btree_walk_btree_apply(
           WT_RTS_VERB_TAG_FILE_SKIP
           "skipping rollback to stable on file=%s because has never been checkpointed",
           uri);
+        (void)__wt_atomic_add_uint64_relaxed(&S2C(session)->rts->progress.btrees_skipped, 1);
         return (0);
     }
 

--- a/src/rollback_to_stable/rts_btree_walk.c
+++ b/src/rollback_to_stable/rts_btree_walk.c
@@ -121,10 +121,11 @@ __rts_btree_walk(WT_SESSION_IMPL *session, wt_timestamp_t rollback_timestamp)
     WT_DECL_RET;
     WT_REF *ref;
     double max_npos, npos;
-    uint64_t btree_pages, clock_now, elapsed_ns, last_report_clock;
+    uint64_t btree_pages, btree_start_clock, clock_now, elapsed_ns, last_report_clock;
     uint32_t flags;
 
-    last_report_clock = __wt_clock(session);
+    btree_start_clock = __wt_clock(session);
+    last_report_clock = btree_start_clock;
     flags = WT_READ_NO_EVICT | WT_READ_VISIBLE_ALL | WT_READ_WONT_NEED | WT_READ_SEE_DELETED;
     btree_pages = 0;
     max_npos = 0.0;
@@ -151,7 +152,8 @@ __rts_btree_walk(WT_SESSION_IMPL *session, wt_timestamp_t rollback_timestamp)
              */
             if (npos > max_npos)
                 max_npos = npos;
-            __wti_rts_progress_msg_walk(session, &last_report_clock, max_npos, btree_pages);
+            __wti_rts_progress_msg_walk(
+              session, btree_start_clock, &last_report_clock, max_npos, btree_pages);
         }
 
         if (F_ISSET(ref, WT_REF_FLAG_LEAF))

--- a/src/rollback_to_stable/rts_btree_walk.c
+++ b/src/rollback_to_stable/rts_btree_walk.c
@@ -149,8 +149,8 @@ __rts_btree_walk(WT_SESSION_IMPL *session, wt_timestamp_t rollback_timestamp)
         if ((elapsed_ns / ((uint64_t)WT_BILLION * WT_PROGRESS_MSG_PERIOD)) > msg_count) {
             npos = __wt_page_npos(session, ref, 0.5, NULL, NULL, 0);
             /*
-             * npos can fluctuate due to unbalanced trees, so track the maximum seen so far to get
-             * a monotonically increasing progress indicator.
+             * npos can fluctuate due to unbalanced trees, so track the maximum seen so far to get a
+             * monotonically increasing progress indicator.
              */
             if (npos > max_npos)
                 max_npos = npos;

--- a/src/rollback_to_stable/rts_btree_walk.c
+++ b/src/rollback_to_stable/rts_btree_walk.c
@@ -121,7 +121,7 @@ __rts_btree_walk(WT_SESSION_IMPL *session, wt_timestamp_t rollback_timestamp)
     WT_DECL_RET;
     WT_REF *ref;
     WT_TIMER timer;
-    double npos;
+    double max_npos, npos;
     uint64_t btree_pages, clock_now, clock_start, elapsed_ns, msg_count;
     uint32_t flags;
 
@@ -130,6 +130,7 @@ __rts_btree_walk(WT_SESSION_IMPL *session, wt_timestamp_t rollback_timestamp)
     flags = WT_READ_NO_EVICT | WT_READ_VISIBLE_ALL | WT_READ_WONT_NEED | WT_READ_SEE_DELETED;
     msg_count = 0;
     btree_pages = 0;
+    max_npos = 0.0;
 
     /* Walk the tree, marking commits aborted where appropriate. */
     ref = NULL;
@@ -147,7 +148,13 @@ __rts_btree_walk(WT_SESSION_IMPL *session, wt_timestamp_t rollback_timestamp)
         elapsed_ns = __wt_clock_to_nsec(clock_now, clock_start);
         if ((elapsed_ns / ((uint64_t)WT_BILLION * WT_PROGRESS_MSG_PERIOD)) > msg_count) {
             npos = __wt_page_npos(session, ref, 0.5, NULL, NULL, 0);
-            __wti_rts_progress_msg_walk(session, &timer, &msg_count, npos, btree_pages);
+            /*
+             * npos can fluctuate due to unbalanced trees, so track the maximum seen so far to get
+             * a monotonically increasing progress indicator.
+             */
+            if (npos > max_npos)
+                max_npos = npos;
+            __wti_rts_progress_msg_walk(session, &timer, &msg_count, max_npos, btree_pages);
         }
 
         if (F_ISSET(ref, WT_REF_FLAG_LEAF))

--- a/src/rollback_to_stable/rts_btree_walk.c
+++ b/src/rollback_to_stable/rts_btree_walk.c
@@ -277,6 +277,7 @@ __rts_btree(WT_SESSION_IMPL *session, const char *uri, wt_timestamp_t rollback_t
           WT_RTS_VERB_TAG_SKIP_DAMAGE
           "%s: skipped performing rollback to stable because the file %s",
           uri, ret == ENOENT ? "does not exist" : "is corrupted.");
+        WT_STAT_CONN_INCR(session, txn_rts_btrees_skipped);
         (void)__wt_atomic_add_uint64_relaxed(&S2C(session)->rts->progress.btrees_skipped, 1);
         ret = 0;
     } else if (ret == 0)
@@ -388,6 +389,7 @@ __wti_rts_btree_walk_btree_apply(
           WT_RTS_VERB_TAG_FILE_SKIP
           "skipping rollback to stable on file=%s because has never been checkpointed",
           uri);
+        WT_STAT_CONN_INCR(session, txn_rts_btrees_skipped);
         (void)__wt_atomic_add_uint64_relaxed(&S2C(session)->rts->progress.btrees_skipped, 1);
         return (0);
     }

--- a/src/rollback_to_stable/rts_btree_walk.c
+++ b/src/rollback_to_stable/rts_btree_walk.c
@@ -120,15 +120,12 @@ __rts_btree_walk(WT_SESSION_IMPL *session, wt_timestamp_t rollback_timestamp)
 {
     WT_DECL_RET;
     WT_REF *ref;
-    WT_TIMER timer;
     double max_npos, npos;
-    uint64_t btree_pages, clock_now, clock_start, elapsed_ns, msg_count;
+    uint64_t btree_pages, clock_now, elapsed_ns, last_report_clock;
     uint32_t flags;
 
-    __wt_timer_start(session, &timer);
-    clock_start = __wt_clock(session);
+    last_report_clock = __wt_clock(session);
     flags = WT_READ_NO_EVICT | WT_READ_VISIBLE_ALL | WT_READ_WONT_NEED | WT_READ_SEE_DELETED;
-    msg_count = 0;
     btree_pages = 0;
     max_npos = 0.0;
 
@@ -145,8 +142,8 @@ __rts_btree_walk(WT_SESSION_IMPL *session, wt_timestamp_t rollback_timestamp)
          * (which walks parent indexes) and emit the message when the period has elapsed.
          */
         clock_now = __wt_clock(session);
-        elapsed_ns = __wt_clock_to_nsec(clock_now, clock_start);
-        if ((elapsed_ns / ((uint64_t)WT_BILLION * WT_PROGRESS_MSG_PERIOD)) > msg_count) {
+        elapsed_ns = __wt_clock_to_nsec(clock_now, last_report_clock);
+        if (elapsed_ns >= (uint64_t)WT_BILLION * WT_PROGRESS_MSG_PERIOD) {
             npos = __wt_page_npos(session, ref, 0.5, NULL, NULL, 0);
             /*
              * npos can fluctuate due to unbalanced trees, so track the maximum seen so far to get a
@@ -154,7 +151,7 @@ __rts_btree_walk(WT_SESSION_IMPL *session, wt_timestamp_t rollback_timestamp)
              */
             if (npos > max_npos)
                 max_npos = npos;
-            __wti_rts_progress_msg_walk(session, &timer, &msg_count, max_npos, btree_pages);
+            __wti_rts_progress_msg_walk(session, &last_report_clock, max_npos, btree_pages);
         }
 
         if (F_ISSET(ref, WT_REF_FLAG_LEAF))

--- a/src/rollback_to_stable/rts_btree_walk.c
+++ b/src/rollback_to_stable/rts_btree_walk.c
@@ -121,6 +121,7 @@ __rts_btree_walk(WT_SESSION_IMPL *session, wt_timestamp_t rollback_timestamp)
     WT_DECL_RET;
     WT_REF *ref;
     WT_TIMER timer;
+    double npos;
     uint64_t msg_count;
     uint32_t flags;
 
@@ -134,7 +135,10 @@ __rts_btree_walk(WT_SESSION_IMPL *session, wt_timestamp_t rollback_timestamp)
               session, &ref, __rts_btree_walk_page_skip, &rollback_timestamp, flags)) == 0 &&
       ref != NULL) {
         (void)__wt_atomic_add_uint64_relaxed(&S2C(session)->rts->progress.pages_walked, 1);
-        __wti_rts_progress_msg(session, &timer, 0, 0, &msg_count, true);
+
+        /* Compute the normalized position (0..1) of this page in the tree for progress. */
+        npos = __wt_page_npos(session, ref, 0.5, NULL, NULL, 0);
+        __wti_rts_progress_msg_walk(session, &timer, &msg_count, npos);
 
         if (F_ISSET(ref, WT_REF_FLAG_LEAF))
             WT_ERR(__wti_rts_btree_abort_updates(session, ref, rollback_timestamp));

--- a/src/rollback_to_stable/rts_btree_walk.c
+++ b/src/rollback_to_stable/rts_btree_walk.c
@@ -133,6 +133,7 @@ __rts_btree_walk(WT_SESSION_IMPL *session, wt_timestamp_t rollback_timestamp)
     while ((ret = __wt_tree_walk_custom_skip(
               session, &ref, __rts_btree_walk_page_skip, &rollback_timestamp, flags)) == 0 &&
       ref != NULL) {
+        (void)__wt_atomic_add_uint64_relaxed(&S2C(session)->rts->progress.pages_walked, 1);
         __wti_rts_progress_msg(session, &timer, 0, 0, &msg_count, true);
 
         if (F_ISSET(ref, WT_REF_FLAG_LEAF))
@@ -246,6 +247,7 @@ __rts_btree(WT_SESSION_IMPL *session, const char *uri, wt_timestamp_t rollback_t
 
     ret = __rts_btree_int(session, uri, rollback_timestamp);
     WT_STAT_CONN_DSRC_INCR(session, txn_rts_btrees_applied);
+    (void)__wt_atomic_add_uint64_relaxed(&S2C(session)->rts->progress.btrees_processed, 1);
     /*
      * Ignore rollback to stable failures on files that don't exist or files where corruption is
      * detected.
@@ -411,8 +413,10 @@ __wti_rts_btree_walk_btree_apply(
           prepared_updates ? "true" : "false", rollback_txnid, S2C(session)->recovery_ckpt_snap_min,
           has_txn_updates_gt_than_ckpt_snap ? "true" : "false");
 
-    if (file_skipped)
+    if (file_skipped) {
         WT_STAT_CONN_INCR(session, txn_rts_btrees_skipped);
+        (void)__wt_atomic_add_uint64_relaxed(&S2C(session)->rts->progress.btrees_skipped, 1);
+    }
 
     /*
      * Truncate history store entries for the non-timestamped table.

--- a/src/rollback_to_stable/rts_btree_walk.c
+++ b/src/rollback_to_stable/rts_btree_walk.c
@@ -122,10 +122,11 @@ __rts_btree_walk(WT_SESSION_IMPL *session, wt_timestamp_t rollback_timestamp)
     WT_REF *ref;
     WT_TIMER timer;
     double npos;
-    uint64_t btree_pages, elapsed_ms, msg_count;
+    uint64_t btree_pages, clock_now, clock_start, elapsed_ns, msg_count;
     uint32_t flags;
 
     __wt_timer_start(session, &timer);
+    clock_start = __wt_clock(session);
     flags = WT_READ_NO_EVICT | WT_READ_VISIBLE_ALL | WT_READ_WONT_NEED | WT_READ_SEE_DELETED;
     msg_count = 0;
     btree_pages = 0;
@@ -138,9 +139,13 @@ __rts_btree_walk(WT_SESSION_IMPL *session, wt_timestamp_t rollback_timestamp)
         ++btree_pages;
         (void)__wt_atomic_add_uint64_relaxed(&S2C(session)->rts->progress.pages_walked, 1);
 
-        /* Only compute npos (which walks parent indexes) when a progress message is due. */
-        __wt_timer_evaluate_ms(session, &timer, &elapsed_ms);
-        if ((elapsed_ms / (WT_THOUSAND * WT_PROGRESS_MSG_PERIOD)) > msg_count) {
+        /*
+         * Use the cheap rdtsc-based clock to check if a progress message is due. Only compute
+         * npos (which walks parent indexes) and emit the message when the period has elapsed.
+         */
+        clock_now = __wt_clock(session);
+        elapsed_ns = __wt_clock_to_nsec(clock_now, clock_start);
+        if ((elapsed_ns / ((uint64_t)WT_BILLION * WT_PROGRESS_MSG_PERIOD)) > msg_count) {
             npos = __wt_page_npos(session, ref, 0.5, NULL, NULL, 0);
             __wti_rts_progress_msg_walk(session, &timer, &msg_count, npos, btree_pages);
         }

--- a/src/rollback_to_stable/rts_history.c
+++ b/src/rollback_to_stable/rts_history.c
@@ -174,16 +174,23 @@ __wti_rts_history_final_pass(WT_SESSION_IMPL *session, wt_timestamp_t rollback_t
      */
     if ((S2BT(session)->modified || max_durable_ts > rollback_timestamp) &&
       rollback_timestamp != WT_TS_NONE) {
+        __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
+          "Rollback to stable history store final pass: rolling back with durable_timestamp=%s",
+          __wt_timestamp_to_string(max_durable_ts, ts_string[0]));
         __wt_verbose_multi(session, WT_VERB_RECOVERY_RTS(session),
           WT_RTS_VERB_TAG_HS_TREE_ROLLBACK "tree rolled back with durable_timestamp=%s",
           __wt_timestamp_to_string(max_durable_ts, ts_string[0]));
         WT_TRET(__wti_rts_btree_walk_btree(session, rollback_timestamp));
-    } else
+    } else {
+        __wt_verbose(session, WT_VERB_RECOVERY_PROGRESS,
+          "Rollback to stable history store final pass: skipped with durable_timestamp=%s",
+          __wt_timestamp_to_string(max_durable_ts, ts_string[0]));
         __wt_verbose_multi(session, WT_VERB_RECOVERY_RTS(session),
           WT_RTS_VERB_TAG_HS_TREE_SKIP
           "tree skipped with durable_timestamp=%s and stable_timestamp=%s",
           __wt_timestamp_to_string(max_durable_ts, ts_string[0]),
           __wt_timestamp_to_string(rollback_timestamp, ts_string[1]));
+    }
 
     /*
      * Truncate history store entries from the partial backup remove list. The list holds all of the


### PR DESCRIPTION
Improve RTS progress reporting so users have visibility into long-running rollback-to-stable operations (which can take 10+ minutes during recovery).

- Add phase-tagged overall and per-btree progress messages with percentage, throughput and ETA at WT_VERB_RECOVERY_PROGRESS level
- Track btrees processed/skipped and pages walked via atomic counters in a new progress struct on WT_ROLLBACK_TO_STABLE
- Use CAS-based throttling so exactly one thread emits overall progress per reporting period
- Use rdtsc-based clock for per-page timer checks to minimize hot-path overhead
- Integrate with __wt_progress callback for application-level notifications

See ticket for details.