### PR TITLE
WT-17103 Allow leader reading checkpoint dhandle to acquire checkpoint lock

### DIFF
--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -966,7 +966,7 @@ __wt_session_get_dhandle(WT_SESSION_IMPL *session, const char *uri, const char *
              * the schema lock.
              */
             bool checkpoint_lock_needed = false;
-            if (__wt_conn_is_disagg(session) && !S2C(session)->layered_table_manager.leader) {
+            if (__wt_conn_is_disagg(session)) {
                 const char *suffix = strstr(uri, ".wt_stable/");
                 if (suffix != NULL)
                     checkpoint_lock_needed = true;

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -967,6 +967,15 @@ __wt_session_get_dhandle(WT_SESSION_IMPL *session, const char *uri, const char *
              */
             bool checkpoint_lock_needed = false;
             if (__wt_conn_is_disagg(session)) {
+                /*
+                 * When reading checkpointed dhandles, we must hold the checkpoint lock. On
+                 * followers, this is required for the stable constituent of a layered table.
+                 *
+                 * For leaders, this is generally unnecessary. However, leaders are currently
+                 * allowed to read checkpoints during startup for internal testing. In cases where a
+                 * leader reads a checkpoint from shared metadata, it must also acquire the
+                 * checkpoint lock.
+                 */
                 const char *suffix = strstr(uri, ".wt_stable/");
                 if (suffix != NULL)
                     checkpoint_lock_needed = true;


### PR DESCRIPTION
The issue is that the leader reads a checkpoint-prefixed file (metadata in this case from checkpoint pickup). If the dhandle dead by the sweep server, we need to read it again, but that requires the correct locks, checkpoint and schema. For now, the simplest fix is for the leader to take these locks before doing the read.