### PR TITLE
WT-13807 Fix worker session description in api_data.py

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -759,7 +759,8 @@ connection_runtime_config = [
             Config('threads_max', '8', r'''
                 maximum number of threads WiredTiger will start to help evict pages from cache. The
                 number of threads started will vary depending on the current eviction load. Each
-                eviction worker thread uses a session from the configured session_max''',
+                eviction worker thread uses a session from a reserved pool of WT_EVICT_MAX_WORKERS
+                (64) sessions''',
                 min=1, max=64), # !!! Must match WT_EVICT_MAX_WORKERS
             Config('threads_min', '1', r'''
                 minimum number of threads WiredTiger will start to help evict pages from

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -2315,12 +2315,12 @@ struct __wt_connection {
      * @config{&nbsp;&nbsp;&nbsp;&nbsp;
      * threads_max, maximum number of threads WiredTiger will start to help evict pages from cache.
      * The number of threads started will vary depending on the current eviction load.  Each
-     * eviction worker thread uses a session from the configured session_max., an integer between \c
-     * 1 and \c 64; default \c 8.}
-     * @config{&nbsp;&nbsp;&nbsp;&nbsp;threads_min, minimum number of
-     * threads WiredTiger will start to help evict pages from cache.  The number of threads
-     * currently running will vary depending on the current eviction load., an integer between \c 1
-     * and \c 64; default \c 1.}
+     * eviction worker thread uses a session from a reserved pool of WT_EVICT_MAX_WORKERS (64)
+     * sessions., an integer between \c 1 and \c 64; default \c 8.}
+     * @config{&nbsp;&nbsp;&nbsp;&nbsp;
+     * threads_min, minimum number of threads WiredTiger will start to help evict pages from cache.
+     * The number of threads currently running will vary depending on the current eviction load., an
+     * integer between \c 1 and \c 64; default \c 1.}
      * @config{ ),,}
      * @config{eviction_checkpoint_target, perform eviction at the beginning of checkpoints to bring
      * the dirty content in cache to this level.  It is a percentage of the cache size if the value
@@ -3265,12 +3265,11 @@ struct __wt_connection {
  * \c false.}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;threads_max, maximum number of threads WiredTiger will
  * start to help evict pages from cache.  The number of threads started will vary depending on the
- * current eviction load.  Each eviction worker thread uses a session from the configured
- * session_max., an integer between \c 1 and \c 64; default \c 8.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;
- * threads_min, minimum number of threads WiredTiger will start to help evict pages from cache.  The
- * number of threads currently running will vary depending on the current eviction load., an integer
- * between \c 1 and \c 64; default \c 1.}
+ * current eviction load.  Each eviction worker thread uses a session from a reserved pool of
+ * WT_EVICT_MAX_WORKERS (64) sessions., an integer between \c 1 and \c 64; default \c 8.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;threads_min, minimum number of threads WiredTiger will start to
+ * help evict pages from cache.  The number of threads currently running will vary depending on the
+ * current eviction load., an integer between \c 1 and \c 64; default \c 1.}
  * @config{ ),,}
  * @config{eviction_checkpoint_target, perform eviction at the beginning of checkpoints to bring the
  * dirty content in cache to this level.  It is a percentage of the cache size if the value is


### PR DESCRIPTION
The `threads_max` eviction config description incorrectly stated sessions come from `session_max`. This PR has corrected that to reflect they are reserved via `WT_EVICT_MAX_WORKERS` (a reserved pool of 64 sessions)