### PR TITLE
WT-17120 Ensure we always ingore prepared on the disk image

### DIFF
--- a/src/cursor/cur_hs.c
+++ b/src/cursor/cur_hs.c
@@ -585,10 +585,7 @@ __curhs_prev_visible(WT_SESSION_IMPL *session, WT_CURSOR_HS *hs_cursor)
          */
         WT_ASSERT(session, F_ISSET(session->txn, WT_TXN_HAS_SNAPSHOT));
 
-        WT_VISIBLE_TYPE visible_type = __wt_txn_tw_stop_visible(session, &cbt->upd_value->tw);
-        /* There is no prepared update in the history store. */
-        WT_ASSERT(session, visible_type != WT_VISIBLE_PREPARE);
-        if (visible_type == WT_VISIBLE_TRUE) {
+        if (__wt_txn_tw_stop_visible(session, &cbt->upd_value->tw)) {
             /*
              * If the stop time point of a record is visible to us, we won't be able to see anything
              * for this entire key.
@@ -601,10 +598,7 @@ __curhs_prev_visible(WT_SESSION_IMPL *session, WT_CURSOR_HS *hs_cursor)
         }
 
         /* If the start time point is visible to us, let's return that record. */
-        visible_type = __wt_txn_tw_start_visible(session, &cbt->upd_value->tw);
-        /* There is no prepared update in the history store. */
-        WT_ASSERT(session, visible_type != WT_VISIBLE_PREPARE);
-        if (visible_type == WT_VISIBLE_TRUE)
+        if (__wt_txn_tw_start_visible(session, &cbt->upd_value->tw))
             break;
     }
 

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -1373,12 +1373,11 @@ __clayered_lookup(WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, WT_ITEM
     WT_CONNECTION_IMPL *conn;
     WT_CURSOR *c;
     WT_DECL_RET;
-    bool found, reset_ignore_prepare;
+    bool found;
 
     c = NULL;
     conn = S2C(session);
     found = false;
-    reset_ignore_prepare = false;
 
     if (!conn->layered_table_manager.leader) {
         c = clayered->ingest_cursor;
@@ -1399,23 +1398,10 @@ __clayered_lookup(WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, WT_ITEM
      */
     if (!found && F_ISSET(clayered, WT_CLAYERED_READ_STABLE) && clayered->stable_cursor != NULL) {
         c = clayered->stable_cursor;
-        /*
-         * Temporarily set ignore prepared flag when searching for update in the stable cursor. In
-         * disaggregated storage, the stable table may contain prepared updates that is rolled back
-         * on ingest table. If reading this prepared update on stable table, it will cause prepared
-         * conflict issue. Therefore for layered cursor operations, we need to ignore these prepared
-         * updates to allow reading through to committed data.
-         */
-        if (!conn->layered_table_manager.leader && !F_ISSET(session->txn, WT_TXN_IGNORE_PREPARE)) {
-            reset_ignore_prepare = true;
-            F_SET(session->txn, WT_TXN_IGNORE_PREPARE);
-        }
         WT_ERR_NOTFOUND_OK(__clayered_lookup_constituent(c, clayered, value), true);
     }
 
 err:
-    if (reset_ignore_prepare)
-        F_CLR(session->txn, WT_TXN_IGNORE_PREPARE);
     if (ret != 0 && ret != WT_PREPARE_CONFLICT)
         WT_TRET(__clayered_reset_cursors(clayered, false));
 

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -1371,17 +1371,15 @@ static int
 __clayered_lookup(WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, WT_ITEM *value)
 {
     WT_CONNECTION_IMPL *conn;
-    WT_CURSOR *c;
     WT_DECL_RET;
     bool found;
 
-    c = NULL;
     conn = S2C(session);
     found = false;
 
     if (!conn->layered_table_manager.leader) {
-        c = clayered->ingest_cursor;
-        WT_ERR_NOTFOUND_OK(__clayered_lookup_constituent(c, clayered, value), true);
+        WT_ERR_NOTFOUND_OK(
+          __clayered_lookup_constituent(clayered->ingest_cursor, clayered, value), true);
         if (ret == 0) {
             found = true;
             if (__wt_clayered_deleted(value))
@@ -1396,10 +1394,9 @@ __clayered_lookup(WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, WT_ITEM
      * If the key didn't exist in the ingest constituent and the cursor is setup for reading, check
      * the stable constituent.
      */
-    if (!found && F_ISSET(clayered, WT_CLAYERED_READ_STABLE) && clayered->stable_cursor != NULL) {
-        c = clayered->stable_cursor;
-        WT_ERR_NOTFOUND_OK(__clayered_lookup_constituent(c, clayered, value), true);
-    }
+    if (!found && F_ISSET(clayered, WT_CLAYERED_READ_STABLE) && clayered->stable_cursor != NULL)
+        WT_ERR_NOTFOUND_OK(
+          __clayered_lookup_constituent(clayered->stable_cursor, clayered, value), true);
 
 err:
     if (ret != 0 && ret != WT_PREPARE_CONFLICT)

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1920,10 +1920,6 @@ static WT_INLINE WT_FILE_SYSTEM *__wt_fs_file_system(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE WT_IKEY *__wt_ref_key_instantiated(WT_REF *ref)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-static WT_INLINE WT_VISIBLE_TYPE __wt_txn_tw_start_visible(
-  WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-static WT_INLINE WT_VISIBLE_TYPE __wt_txn_tw_stop_visible(
-  WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE WT_VISIBLE_TYPE __wt_txn_upd_visible_type(WT_SESSION_IMPL *session, WT_UPDATE *upd)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wt_block_eligible_for_sweep(WT_BM *bm, WT_BLOCK *block)
@@ -2011,7 +2007,11 @@ static WT_INLINE bool __wt_txn_timestamp_visible(WT_SESSION_IMPL *session, wt_ti
   wt_timestamp_t durable_timestamp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wt_txn_timestamp_visible_all(WT_SESSION_IMPL *session,
   wt_timestamp_t timestamp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static WT_INLINE bool __wt_txn_tw_start_visible(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wt_txn_tw_start_visible_all(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static WT_INLINE bool __wt_txn_tw_stop_visible(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wt_txn_tw_stop_visible_all(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1117,57 +1117,29 @@ __wt_txn_upd_value_visible_all(WT_SESSION_IMPL *session, WT_UPDATE_VALUE *upd_va
  * __wt_txn_tw_stop_visible --
  *     Is the given stop time window visible?
  */
-static WT_INLINE WT_VISIBLE_TYPE
+static WT_INLINE bool
 __wt_txn_tw_stop_visible(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw)
 {
     if (!WT_TIME_WINDOW_HAS_STOP(tw))
-        return (WT_VISIBLE_FALSE);
+        return (false);
 
-    if (WT_TIME_WINDOW_HAS_STOP_PREPARE(tw)) {
-        /*
-         * For btrees that are not read-only, we must have seen the prepared update on the update
-         * chain and returned visible prepare if it is visible. For a checkpoint, prepared update is
-         * always not visible.
-         */
-        if (F_ISSET(S2BT(session), WT_BTREE_READONLY) &&
-          !WT_DHANDLE_IS_CHECKPOINT(session->dhandle) &&
-          __wt_txn_visible(session, tw->stop_txn, tw->stop_prepare_ts, tw->stop_prepare_ts))
-            return (WT_VISIBLE_PREPARE);
+    if (WT_TIME_WINDOW_HAS_STOP_PREPARE(tw))
+        return (false);
 
-        return (WT_VISIBLE_FALSE);
-    }
-
-    if (__wt_txn_visible(session, tw->stop_txn, tw->stop_ts, tw->durable_stop_ts))
-        return (WT_VISIBLE_TRUE);
-
-    return (WT_VISIBLE_FALSE);
+    return (__wt_txn_visible(session, tw->stop_txn, tw->stop_ts, tw->durable_stop_ts));
 }
 
 /*
  * __wt_txn_tw_start_visible --
  *     Is the given start time window visible?
  */
-static WT_INLINE WT_VISIBLE_TYPE
+static WT_INLINE bool
 __wt_txn_tw_start_visible(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw)
 {
-    if (WT_TIME_WINDOW_HAS_START_PREPARE(tw)) {
-        /*
-         * For btrees that are not read-only, we must have seen the prepared update on the update
-         * chain and returned visible prepare if it is visible. For a checkpoint, prepared update is
-         * always not visible.
-         */
-        if (F_ISSET(S2BT(session), WT_BTREE_READONLY) &&
-          !WT_DHANDLE_IS_CHECKPOINT(session->dhandle) &&
-          __wt_txn_visible(session, tw->start_txn, tw->start_prepare_ts, tw->start_prepare_ts))
-            return (WT_VISIBLE_PREPARE);
+    if (WT_TIME_WINDOW_HAS_START_PREPARE(tw))
+        return (false);
 
-        return (WT_VISIBLE_FALSE);
-    }
-
-    if (__wt_txn_visible(session, tw->start_txn, tw->start_ts, tw->durable_start_ts))
-        return (WT_VISIBLE_TRUE);
-
-    return (WT_VISIBLE_FALSE);
+    return (__wt_txn_visible(session, tw->start_txn, tw->start_ts, tw->durable_start_ts));
 }
 
 /*
@@ -1663,7 +1635,7 @@ retry:
              * rollback to stable and when we are told to ignore non-globally visible tombstones.
              */
             if (!have_stop_tw) {
-                if (__wt_txn_tw_stop_visible(session, &tw) == WT_VISIBLE_TRUE &&
+                if (__wt_txn_tw_stop_visible(session, &tw) &&
                   !F_ISSET(&cbt->iface, WT_CURSTD_IGNORE_TOMBSTONE)) {
                     cbt->upd_value->buf.data = NULL;
                     cbt->upd_value->buf.size = 0;
@@ -1693,7 +1665,7 @@ retry:
                 return (0);
             }
 
-            if (__wt_txn_tw_start_visible(session, &tw) == WT_VISIBLE_TRUE) {
+            if (__wt_txn_tw_start_visible(session, &tw)) {
                 if (cbt->upd_value->skip_buf) {
                     cbt->upd_value->buf.data = NULL;
                     cbt->upd_value->buf.size = 0;

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1663,11 +1663,7 @@ retry:
              * rollback to stable and when we are told to ignore non-globally visible tombstones.
              */
             if (!have_stop_tw) {
-                WT_VISIBLE_TYPE visible_type = __wt_txn_tw_stop_visible(session, &tw);
-                if (visible_type == WT_VISIBLE_PREPARE) {
-                    if (!F_ISSET(session->txn, WT_TXN_IGNORE_PREPARE))
-                        return (WT_PREPARE_CONFLICT);
-                } else if (visible_type == WT_VISIBLE_TRUE &&
+                if (__wt_txn_tw_stop_visible(session, &tw) == WT_VISIBLE_TRUE &&
                   !F_ISSET(&cbt->iface, WT_CURSTD_IGNORE_TOMBSTONE)) {
                     cbt->upd_value->buf.data = NULL;
                     cbt->upd_value->buf.size = 0;
@@ -1697,11 +1693,7 @@ retry:
                 return (0);
             }
 
-            WT_VISIBLE_TYPE visible_type = __wt_txn_tw_start_visible(session, &tw);
-            if (visible_type == WT_VISIBLE_PREPARE) {
-                if (!F_ISSET(session->txn, WT_TXN_IGNORE_PREPARE))
-                    return (WT_PREPARE_CONFLICT);
-            } else if (visible_type == WT_VISIBLE_TRUE) {
+            if (__wt_txn_tw_start_visible(session, &tw) == WT_VISIBLE_TRUE) {
                 if (cbt->upd_value->skip_buf) {
                     cbt->upd_value->buf.data = NULL;
                     cbt->upd_value->buf.size = 0;

--- a/test/suite/test_layered89.py
+++ b/test/suite/test_layered89.py
@@ -324,11 +324,11 @@ class test_layered89(wttest.WiredTigerTestCase):
             walk_func=self.collect_keys_prev, delete=True)
         self.assertEqual(sorted(keys), all_keys)
 
-    def test_search_prepared_update(self):
+    def test_search_and_search_near_prepared_update(self):
         """
-        cursor.search() on a follower must return the committed value without
-        WT_PREPARE_CONFLICT when the primary has checkpointed a prepared update
-        for that key.
+        cursor.search() and cursor.search_near() on a follower must both return the
+        committed value without WT_PREPARE_CONFLICT when the primary has checkpointed
+        a prepared update for that key.
         """
         all_keys = [1, 2, 3]
         prepare_keys = [2]
@@ -346,15 +346,21 @@ class test_layered89(wttest.WiredTigerTestCase):
         cursor = session_follow.open_cursor(self.uri)
         session_follow.begin_transaction()
 
-        # Key 1: no prepared update; returns the committed value.
+        # Key 1: no prepared update; both lookups return the committed value.
         cursor.set_key(1)
         self.assertEqual(cursor.search(), 0)
         self.assertEqual(cursor.get_value(), 'committed_1')
+        cursor.set_key(1)
+        self.assertEqual(cursor.search_near(), 0)
+        self.assertEqual(cursor.get_value(), 'committed_1')
 
         # Key 2: primary checkpointed a prepared update; follower rolled back its copy.
-        # cursor.search() must return the committed value without WT_PREPARE_CONFLICT.
+        # Both lookups must return the committed value without WT_PREPARE_CONFLICT.
         cursor.set_key(2)
         self.assertEqual(cursor.search(), 0)
+        self.assertEqual(cursor.get_value(), 'committed_2')
+        cursor.set_key(2)
+        self.assertEqual(cursor.search_near(), 0)
         self.assertEqual(cursor.get_value(), 'committed_2')
 
         session_follow.rollback_transaction()

--- a/test/suite/test_layered89.py
+++ b/test/suite/test_layered89.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# test_layered89.py
+#   Test that cursor.next(), cursor.prev(), and cursor.search() on a follower
+#   return committed values and do not raise WT_PREPARE_CONFLICT when the primary
+#   has checkpointed a prepared (uncommitted) transaction.
+#
+#   Setup: the primary and follower both commit initial values, then prepare the same
+#   update (same prepared_id, simulating oplog replay). The primary checkpoints with
+#   preserve_prepared=true so the snapshot includes the pending update. The follower
+#   advances its checkpoint to pick up the primary's snapshot, then rolls back its
+#   own copy of the prepare.
+#
+#   Expected: all cursor operations return the committed values without error.
+
+import wiredtiger
+import wttest
+from helper_disagg import disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
+
+@disagg_test_class
+class test_layered89(wttest.WiredTigerTestCase):
+    tablename = 'test_layered89'
+    uri = 'layered:' + tablename
+
+    disagg_storages = gen_disagg_storages('test_layered89', disagg_only=True)
+    scenarios = make_scenarios(disagg_storages)
+
+    conn_base_config = ',create,statistics=(all),precise_checkpoint=true,preserve_prepared=true,'
+
+    def conn_config(self):
+        return self.extensionsConfig() + self.conn_base_config + 'disaggregated=(role="leader")'
+
+    def setup_with_prepared_updates(self, all_keys, prepare_keys, commit_ts=10, prepare_ts=20):
+        """
+        Both the primary and follower commit initial values for all_keys, then prepare
+        updates for prepare_keys using the same prepared_id (simulating oplog replay).
+        The primary checkpoints with the prepare still active (preserve_prepared=true)
+        so the snapshot includes the pending update. The follower advances its checkpoint
+        to pick up the primary's snapshot.
+
+        Returns (conn_follow, session_follow, prepare_session_primary, prepare_session_follow).
+        The caller must rollback prepare_session_follow before walking the cursor, then call
+        resolve_prepared(prepare_session_primary) for cleanup.
+        """
+        self.session.create(self.uri, 'key_format=i,value_format=S')
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
+
+        conn_follow = self.wiredtiger_open('follower',
+            self.extensionsConfig() + self.conn_base_config +
+            'disaggregated=(role="follower")')
+        session_follow = conn_follow.open_session('')
+        session_follow.create(self.uri, 'key_format=i,value_format=S')
+        conn_follow.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
+
+        cursor = self.session.open_cursor(self.uri)
+        for key in all_keys:
+            self.session.begin_transaction()
+            cursor[key] = 'committed_' + str(key)
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
+        cursor.close()
+
+        # Replay the same committed writes on the follower (simulating oplog replay).
+        cursor_follow = session_follow.open_cursor(self.uri)
+        for key in all_keys:
+            session_follow.begin_transaction()
+            cursor_follow[key] = 'committed_' + str(key)
+            session_follow.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
+        cursor_follow.close()
+
+        # Checkpoint the committed writes before introducing the prepare so that when the
+        # primary later checkpoints with the prepare active, both the pending update and
+        # the committed values are accessible in the snapshot.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(commit_ts))
+        self.session.checkpoint()
+        conn_follow.set_timestamp('stable_timestamp=' + self.timestamp_str(commit_ts))
+        self.disagg_advance_checkpoint(conn_follow)
+
+        # Prepare updates on the primary.
+        prepare_session_primary = self.conn.open_session()
+        prepare_cursor_primary = prepare_session_primary.open_cursor(self.uri)
+        prepare_session_primary.begin_transaction()
+        for key in prepare_keys:
+            prepare_cursor_primary[key] = 'prepared_' + str(key)
+        prepare_session_primary.prepare_transaction(
+            'prepare_timestamp=' + self.timestamp_str(prepare_ts) +
+            ',prepared_id=' + self.prepared_id_str(1))
+        prepare_cursor_primary.close()
+
+        # Replay the same prepared transaction on the follower (simulating oplog replay).
+        prepare_session_follow = conn_follow.open_session()
+        prepare_cursor_follow = prepare_session_follow.open_cursor(self.uri)
+        prepare_session_follow.begin_transaction()
+        for key in prepare_keys:
+            prepare_cursor_follow[key] = 'prepared_' + str(key)
+        prepare_session_follow.prepare_transaction(
+            'prepare_timestamp=' + self.timestamp_str(prepare_ts) +
+            ',prepared_id=' + self.prepared_id_str(1))
+        prepare_cursor_follow.close()
+
+        # Checkpoint the primary while the prepare is still active; with
+        # preserve_prepared=true the pending update is included in the snapshot.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(prepare_ts))
+        chkpt_session = self.conn.open_session()
+        chkpt_session.checkpoint()
+        chkpt_session.close()
+
+        # Advance the follower checkpoint to pick up the primary's snapshot.
+        conn_follow.set_timestamp('stable_timestamp=' + self.timestamp_str(prepare_ts))
+        self.disagg_advance_checkpoint(conn_follow)
+
+        return conn_follow, session_follow, prepare_session_primary, prepare_session_follow
+
+    def setup_with_prepared_tombstones(self, all_keys, delete_keys, commit_ts=10, prepare_ts=20):
+        """
+        Same as setup_with_prepared_updates but prepares deletes for delete_keys instead
+        of value updates. Both primary and follower apply the same committed writes and
+        the same prepared deletes (same prepared_id).
+
+        Returns (conn_follow, session_follow, prepare_session_primary, prepare_session_follow).
+        """
+        self.session.create(self.uri, 'key_format=i,value_format=S')
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
+
+        conn_follow = self.wiredtiger_open('follower',
+            self.extensionsConfig() + self.conn_base_config +
+            'disaggregated=(role="follower")')
+        session_follow = conn_follow.open_session('')
+        session_follow.create(self.uri, 'key_format=i,value_format=S')
+        conn_follow.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
+
+        cursor = self.session.open_cursor(self.uri)
+        for key in all_keys:
+            self.session.begin_transaction()
+            cursor[key] = 'committed_' + str(key)
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
+        cursor.close()
+
+        # Replay the same committed writes on the follower (simulating oplog replay).
+        cursor_follow = session_follow.open_cursor(self.uri)
+        for key in all_keys:
+            session_follow.begin_transaction()
+            cursor_follow[key] = 'committed_' + str(key)
+            session_follow.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
+        cursor_follow.close()
+
+        # Prepare deletes on the primary.
+        prepare_session_primary = self.conn.open_session()
+        prepare_cursor_primary = prepare_session_primary.open_cursor(self.uri)
+        prepare_session_primary.begin_transaction()
+        for key in delete_keys:
+            prepare_cursor_primary.set_key(key)
+            prepare_cursor_primary.remove()
+        prepare_session_primary.prepare_transaction(
+            'prepare_timestamp=' + self.timestamp_str(prepare_ts) +
+            ',prepared_id=' + self.prepared_id_str(1))
+        prepare_cursor_primary.close()
+
+        # Replay the same prepared deletes on the follower (simulating oplog replay).
+        prepare_session_follow = conn_follow.open_session()
+        prepare_cursor_follow = prepare_session_follow.open_cursor(self.uri)
+        prepare_session_follow.begin_transaction()
+        for key in delete_keys:
+            prepare_cursor_follow.set_key(key)
+            prepare_cursor_follow.remove()
+        prepare_session_follow.prepare_transaction(
+            'prepare_timestamp=' + self.timestamp_str(prepare_ts) +
+            ',prepared_id=' + self.prepared_id_str(1))
+        prepare_cursor_follow.close()
+
+        # Checkpoint the primary while the prepare is still active.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(prepare_ts))
+        chkpt_session = self.conn.open_session()
+        chkpt_session.checkpoint()
+        chkpt_session.close()
+
+        # Advance the follower checkpoint to pick up the primary's snapshot.
+        conn_follow.set_timestamp('stable_timestamp=' + self.timestamp_str(prepare_ts))
+        self.disagg_advance_checkpoint(conn_follow)
+
+        return conn_follow, session_follow, prepare_session_primary, prepare_session_follow
+
+    def evict_page(self, session, key):
+        """Release the cached page so the next access reads from the checkpoint."""
+        evict_session = session.connection.open_session('debug=(release_evict_page)')
+        evict_cursor = evict_session.open_cursor(self.uri)
+        evict_cursor.set_key(key)
+        evict_cursor.search()
+        evict_cursor.close()
+        evict_session.close()
+
+    def collect_keys_next(self, session):
+        """Walk forward and return all visible keys."""
+        cursor = session.open_cursor(self.uri)
+        session.begin_transaction()
+        keys = []
+        while cursor.next() != wiredtiger.WT_NOTFOUND:
+            keys.append(cursor.get_key())
+        session.rollback_transaction()
+        cursor.close()
+        return keys
+
+    def collect_keys_prev(self, session):
+        """Walk backward and return all visible keys."""
+        cursor = session.open_cursor(self.uri)
+        session.begin_transaction()
+        keys = []
+        while cursor.prev() != wiredtiger.WT_NOTFOUND:
+            keys.append(cursor.get_key())
+        session.rollback_transaction()
+        cursor.close()
+        return keys
+
+    def resolve_prepared(self, prepare_session_primary, rollback_ts):
+        """
+        Roll back the primary's prepared transaction and create a clean checkpoint
+        so that test teardown can verify the table without error.
+        """
+        prepare_session_primary.rollback_transaction(
+            'rollback_timestamp=' + self.timestamp_str(rollback_ts))
+        prepare_session_primary.close()
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(rollback_ts))
+        self.session.checkpoint()
+
+    def run_walk_test(self, all_keys, prepare_keys, walk_func, delete=False):
+        """
+        Common harness for cursor-walk tests on a follower whose checkpoint contains
+        prepared updates (or tombstones). Returns the keys returned by walk_func.
+        """
+        if delete:
+            conn_follow, session_follow, prepare_session_primary, prepare_session_follow = \
+                self.setup_with_prepared_tombstones(all_keys, prepare_keys)
+        else:
+            conn_follow, session_follow, prepare_session_primary, prepare_session_follow = \
+                self.setup_with_prepared_updates(all_keys, prepare_keys)
+
+        # Roll back the follower's prepared transaction; the prior committed value
+        # is now the most recent visible version on the follower.
+        prepare_session_follow.rollback_transaction(
+            'rollback_timestamp=' + self.timestamp_str(30))
+        prepare_session_follow.close()
+
+        # Evict cached pages so the next access reads from the checkpointed snapshot.
+        self.evict_page(session_follow, all_keys[0])
+
+        keys = walk_func(session_follow)
+
+        session_follow.close()
+        conn_follow.close()
+
+        self.resolve_prepared(prepare_session_primary, rollback_ts=30)
+
+        return keys
+
+    def test_next_walk_prepared_update(self):
+        """
+        cursor.next() on a follower must return all committed keys without
+        WT_PREPARE_CONFLICT when the primary has checkpointed a prepared update
+        for a subset of keys.
+        """
+        all_keys = [1, 2, 3, 4, 5]
+        keys = self.run_walk_test(all_keys, prepare_keys=[2, 4],
+            walk_func=self.collect_keys_next)
+        self.assertEqual(sorted(keys), all_keys)
+
+    def test_prev_walk_prepared_update(self):
+        """
+        cursor.prev() on a follower must return all committed keys without
+        WT_PREPARE_CONFLICT when the primary has checkpointed a prepared update
+        for a subset of keys.
+        """
+        all_keys = [1, 2, 3, 4, 5]
+        keys = self.run_walk_test(all_keys, prepare_keys=[2, 4],
+            walk_func=self.collect_keys_prev)
+        self.assertEqual(sorted(keys), all_keys)
+
+    def test_next_walk_prepared_tombstone(self):
+        """
+        cursor.next() on a follower must return all committed keys without
+        WT_PREPARE_CONFLICT when the primary has checkpointed a prepared delete
+        for a subset of keys. The uncommitted delete must be invisible, so all
+        keys must still be returned.
+        """
+        all_keys = [1, 2, 3, 4, 5]
+        keys = self.run_walk_test(all_keys, prepare_keys=[2, 4],
+            walk_func=self.collect_keys_next, delete=True)
+        self.assertEqual(sorted(keys), all_keys)
+
+    def test_prev_walk_prepared_tombstone(self):
+        """
+        cursor.prev() on a follower must return all committed keys without
+        WT_PREPARE_CONFLICT when the primary has checkpointed a prepared delete
+        for a subset of keys. The uncommitted delete must be invisible, so all
+        keys must still be returned.
+        """
+        all_keys = [1, 2, 3, 4, 5]
+        keys = self.run_walk_test(all_keys, prepare_keys=[2, 4],
+            walk_func=self.collect_keys_prev, delete=True)
+        self.assertEqual(sorted(keys), all_keys)
+
+    def test_search_prepared_update(self):
+        """
+        cursor.search() on a follower must return the committed value without
+        WT_PREPARE_CONFLICT when the primary has checkpointed a prepared update
+        for that key.
+        """
+        all_keys = [1, 2, 3]
+        prepare_keys = [2]
+
+        conn_follow, session_follow, prepare_session_primary, prepare_session_follow = \
+            self.setup_with_prepared_updates(all_keys, prepare_keys)
+
+        # Roll back the follower's prepared transaction.
+        prepare_session_follow.rollback_transaction(
+            'rollback_timestamp=' + self.timestamp_str(30))
+        prepare_session_follow.close()
+
+        self.evict_page(session_follow, 1)
+
+        cursor = session_follow.open_cursor(self.uri)
+        session_follow.begin_transaction()
+
+        # Key 1: no prepared update; returns the committed value.
+        cursor.set_key(1)
+        self.assertEqual(cursor.search(), 0)
+        self.assertEqual(cursor.get_value(), 'committed_1')
+
+        # Key 2: primary checkpointed a prepared update; follower rolled back its copy.
+        # cursor.search() must return the committed value without WT_PREPARE_CONFLICT.
+        cursor.set_key(2)
+        self.assertEqual(cursor.search(), 0)
+        self.assertEqual(cursor.get_value(), 'committed_2')
+
+        session_follow.rollback_transaction()
+        cursor.close()
+
+        session_follow.close()
+        conn_follow.close()
+        self.resolve_prepared(prepare_session_primary, rollback_ts=30)

--- a/test/suite/test_layered89.py
+++ b/test/suite/test_layered89.py
@@ -200,6 +200,10 @@ class test_layered89(wttest.WiredTigerTestCase):
         session_follow.close()
         conn_follow.close()
 
+        # Roll back the primary's prepare and take a clean checkpoint so that test teardown
+        # (which verifies the table) does not encounter a dangling prepared transaction.
+        # stable_timestamp must be advanced past the prepare_timestamp first so the
+        # checkpoint can move past the prepared update.
         self.resolve_prepared(prepare_session_primary, rollback_ts=30)
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(30))
         self.session.checkpoint()
@@ -295,6 +299,10 @@ class test_layered89(wttest.WiredTigerTestCase):
 
         session_follow.close()
         conn_follow.close()
+        # Roll back the primary's prepare and take a clean checkpoint so that test teardown
+        # (which verifies the table) does not encounter a dangling prepared transaction.
+        # stable_timestamp must be advanced past the prepare_timestamp first so the
+        # checkpoint can move past the prepared update.
         self.resolve_prepared(prepare_session_primary, rollback_ts=30)
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(30))
         self.session.checkpoint()

--- a/test/suite/test_layered89.py
+++ b/test/suite/test_layered89.py
@@ -106,9 +106,7 @@ class test_layered89(wttest.WiredTigerTestCase):
         then advance the follower checkpoint to pick up the primary's snapshot.
         """
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(prepare_ts))
-        chkpt_session = self.conn.open_session()
-        chkpt_session.checkpoint()
-        chkpt_session.close()
+        self.session.checkpoint()
 
         conn_follow.set_timestamp('stable_timestamp=' + self.timestamp_str(prepare_ts))
         self.disagg_advance_checkpoint(conn_follow)
@@ -173,16 +171,11 @@ class test_layered89(wttest.WiredTigerTestCase):
         cursor.close()
         return keys
 
-    def resolve_prepared(self, prepare_session_primary, rollback_ts):
-        """
-        Roll back the primary's prepared transaction and create a clean checkpoint
-        so that test teardown can verify the table without error.
-        """
-        prepare_session_primary.rollback_transaction(
+    def resolve_prepared(self, prepare_session, rollback_ts):
+        """Roll back a prepared transaction and close its session."""
+        prepare_session.rollback_transaction(
             'rollback_timestamp=' + self.timestamp_str(rollback_ts))
-        prepare_session_primary.close()
-        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(rollback_ts))
-        self.session.checkpoint()
+        prepare_session.close()
 
     def run_walk_test(self, all_keys, prepare_keys, walk_func, delete=False):
         """
@@ -194,12 +187,13 @@ class test_layered89(wttest.WiredTigerTestCase):
 
         # Roll back the follower's prepared transaction so the committed value
         # is what the cursor returns on the follower.
-        prepare_session_follow.rollback_transaction(
-            'rollback_timestamp=' + self.timestamp_str(30))
-        prepare_session_follow.close()
+        self.resolve_prepared(prepare_session_follow, rollback_ts=30)
 
-        # Force the follower to reload from its checkpoint on the next cursor access.
-        self.evict_page(session_follow, all_keys[0])
+        # Force the follower to reload the pages with prepared cells from the checkpoint.
+        # Without eviction the cursor would read the in-memory update chain (which already
+        # reflects the rollback), bypassing the on-disk prepared cells we need to exercise.
+        for key in prepare_keys:
+            self.evict_page(session_follow, key)
 
         keys = walk_func(session_follow)
 
@@ -207,6 +201,8 @@ class test_layered89(wttest.WiredTigerTestCase):
         conn_follow.close()
 
         self.resolve_prepared(prepare_session_primary, rollback_ts=30)
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(30))
+        self.session.checkpoint()
 
         return keys
 
@@ -269,11 +265,10 @@ class test_layered89(wttest.WiredTigerTestCase):
             self.setup_with_prepare(all_keys, prepare_keys)
 
         # Roll back the follower's prepared transaction.
-        prepare_session_follow.rollback_transaction(
-            'rollback_timestamp=' + self.timestamp_str(30))
-        prepare_session_follow.close()
+        self.resolve_prepared(prepare_session_follow, rollback_ts=30)
 
-        self.evict_page(session_follow, 1)
+        # Evict the page for the prepared key so the cursor reads from the on-disk checkpoint.
+        self.evict_page(session_follow, 2)
 
         cursor = session_follow.open_cursor(self.uri)
         session_follow.begin_transaction()
@@ -301,3 +296,5 @@ class test_layered89(wttest.WiredTigerTestCase):
         session_follow.close()
         conn_follow.close()
         self.resolve_prepared(prepare_session_primary, rollback_ts=30)
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(30))
+        self.session.checkpoint()

--- a/test/suite/test_layered89.py
+++ b/test/suite/test_layered89.py
@@ -57,17 +57,13 @@ class test_layered89(wttest.WiredTigerTestCase):
     def conn_config(self):
         return self.extensionsConfig() + self.conn_base_config + 'disaggregated=(role="leader")'
 
-    def setup_with_prepared_updates(self, all_keys, prepare_keys, commit_ts=10, prepare_ts=20):
+    def setup_primary_and_follower(self, all_keys, commit_ts=10):
         """
-        Both the primary and follower commit initial values for all_keys, then prepare
-        updates for prepare_keys using the same prepared_id (simulating oplog replay).
-        The primary checkpoints with the prepare still active (preserve_prepared=true)
-        so the snapshot includes the pending update. The follower advances its checkpoint
-        to pick up the primary's snapshot.
+        Open a follower, commit initial values for all_keys on both the primary and
+        follower (simulating oplog replay), then checkpoint both so the committed values
+        are in the snapshot before any prepare is introduced.
 
-        Returns (conn_follow, session_follow, prepare_session_primary, prepare_session_follow).
-        The caller must rollback prepare_session_follow before walking the cursor, then call
-        resolve_prepared(prepare_session_primary) for cleanup.
+        Returns (conn_follow, session_follow).
         """
         self.session.create(self.uri, 'key_format=i,value_format=S')
         self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
@@ -95,119 +91,69 @@ class test_layered89(wttest.WiredTigerTestCase):
         cursor_follow.close()
 
         # Checkpoint the committed writes before introducing the prepare so that when the
-        # primary later checkpoints with the prepare active, both the pending update and
-        # the committed values are accessible in the snapshot.
+        # primary later checkpoints with the prepare active, the committed values remain
+        # readable on the follower after the prepare is rolled back.
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(commit_ts))
         self.session.checkpoint()
         conn_follow.set_timestamp('stable_timestamp=' + self.timestamp_str(commit_ts))
         self.disagg_advance_checkpoint(conn_follow)
 
-        # Prepare updates on the primary.
-        prepare_session_primary = self.conn.open_session()
-        prepare_cursor_primary = prepare_session_primary.open_cursor(self.uri)
-        prepare_session_primary.begin_transaction()
-        for key in prepare_keys:
-            prepare_cursor_primary[key] = 'prepared_' + str(key)
-        prepare_session_primary.prepare_transaction(
-            'prepare_timestamp=' + self.timestamp_str(prepare_ts) +
-            ',prepared_id=' + self.prepared_id_str(1))
-        prepare_cursor_primary.close()
+        return conn_follow, session_follow
 
-        # Replay the same prepared transaction on the follower (simulating oplog replay).
-        prepare_session_follow = conn_follow.open_session()
-        prepare_cursor_follow = prepare_session_follow.open_cursor(self.uri)
-        prepare_session_follow.begin_transaction()
-        for key in prepare_keys:
-            prepare_cursor_follow[key] = 'prepared_' + str(key)
-        prepare_session_follow.prepare_transaction(
-            'prepare_timestamp=' + self.timestamp_str(prepare_ts) +
-            ',prepared_id=' + self.prepared_id_str(1))
-        prepare_cursor_follow.close()
-
-        # Checkpoint the primary while the prepare is still active; with
-        # preserve_prepared=true the pending update is included in the snapshot.
+    def checkpoint_with_prepare(self, conn_follow, prepare_ts):
+        """
+        Checkpoint the primary with the prepare still active (preserve_prepared=true),
+        then advance the follower checkpoint to pick up the primary's snapshot.
+        """
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(prepare_ts))
         chkpt_session = self.conn.open_session()
         chkpt_session.checkpoint()
         chkpt_session.close()
 
-        # Advance the follower checkpoint to pick up the primary's snapshot.
         conn_follow.set_timestamp('stable_timestamp=' + self.timestamp_str(prepare_ts))
         self.disagg_advance_checkpoint(conn_follow)
 
-        return conn_follow, session_follow, prepare_session_primary, prepare_session_follow
+    def prepare_on_conn(self, conn, keys, prepare_ts, delete=False):
+        """Open a session on conn, prepare updates (or deletes) for keys, and return the session."""
+        session = conn.open_session()
+        cursor = session.open_cursor(self.uri)
+        session.begin_transaction()
+        for key in keys:
+            if delete:
+                cursor.set_key(key)
+                cursor.remove()
+            else:
+                cursor[key] = 'prepared_' + str(key)
+        session.prepare_transaction(
+            'prepare_timestamp=' + self.timestamp_str(prepare_ts) +
+            ',prepared_id=' + self.prepared_id_str(1))
+        cursor.close()
+        return session
 
-    def setup_with_prepared_tombstones(self, all_keys, delete_keys, commit_ts=10, prepare_ts=20):
+    def setup_with_prepare(self, all_keys, prepare_keys, commit_ts=10, prepare_ts=20, delete=False):
         """
-        Same as setup_with_prepared_updates but prepares deletes for delete_keys instead
-        of value updates. Both primary and follower apply the same committed writes and
-        the same prepared deletes (same prepared_id).
+        Both the primary and follower commit initial values for all_keys, then prepare
+        the same updates (or deletes if delete=True) for prepare_keys using the same
+        prepared_id (simulating oplog replay). The primary checkpoints with the prepare
+        still active (preserve_prepared=true) so the snapshot includes the pending update.
+        The follower advances its checkpoint to pick up the primary's snapshot.
 
         Returns (conn_follow, session_follow, prepare_session_primary, prepare_session_follow).
+        The caller must rollback prepare_session_follow before walking the cursor, then call
+        resolve_prepared(prepare_session_primary) for cleanup.
         """
-        self.session.create(self.uri, 'key_format=i,value_format=S')
-        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
+        conn_follow, session_follow = self.setup_primary_and_follower(all_keys, commit_ts)
 
-        conn_follow = self.wiredtiger_open('follower',
-            self.extensionsConfig() + self.conn_base_config +
-            'disaggregated=(role="follower")')
-        session_follow = conn_follow.open_session('')
-        session_follow.create(self.uri, 'key_format=i,value_format=S')
-        conn_follow.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
+        prepare_session_primary = self.prepare_on_conn(self.conn, prepare_keys, prepare_ts, delete)
+        # Replay the same prepared transaction on the follower (simulating oplog replay).
+        prepare_session_follow = self.prepare_on_conn(conn_follow, prepare_keys, prepare_ts, delete)
 
-        cursor = self.session.open_cursor(self.uri)
-        for key in all_keys:
-            self.session.begin_transaction()
-            cursor[key] = 'committed_' + str(key)
-            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
-        cursor.close()
-
-        # Replay the same committed writes on the follower (simulating oplog replay).
-        cursor_follow = session_follow.open_cursor(self.uri)
-        for key in all_keys:
-            session_follow.begin_transaction()
-            cursor_follow[key] = 'committed_' + str(key)
-            session_follow.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
-        cursor_follow.close()
-
-        # Prepare deletes on the primary.
-        prepare_session_primary = self.conn.open_session()
-        prepare_cursor_primary = prepare_session_primary.open_cursor(self.uri)
-        prepare_session_primary.begin_transaction()
-        for key in delete_keys:
-            prepare_cursor_primary.set_key(key)
-            prepare_cursor_primary.remove()
-        prepare_session_primary.prepare_transaction(
-            'prepare_timestamp=' + self.timestamp_str(prepare_ts) +
-            ',prepared_id=' + self.prepared_id_str(1))
-        prepare_cursor_primary.close()
-
-        # Replay the same prepared deletes on the follower (simulating oplog replay).
-        prepare_session_follow = conn_follow.open_session()
-        prepare_cursor_follow = prepare_session_follow.open_cursor(self.uri)
-        prepare_session_follow.begin_transaction()
-        for key in delete_keys:
-            prepare_cursor_follow.set_key(key)
-            prepare_cursor_follow.remove()
-        prepare_session_follow.prepare_transaction(
-            'prepare_timestamp=' + self.timestamp_str(prepare_ts) +
-            ',prepared_id=' + self.prepared_id_str(1))
-        prepare_cursor_follow.close()
-
-        # Checkpoint the primary while the prepare is still active.
-        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(prepare_ts))
-        chkpt_session = self.conn.open_session()
-        chkpt_session.checkpoint()
-        chkpt_session.close()
-
-        # Advance the follower checkpoint to pick up the primary's snapshot.
-        conn_follow.set_timestamp('stable_timestamp=' + self.timestamp_str(prepare_ts))
-        self.disagg_advance_checkpoint(conn_follow)
+        self.checkpoint_with_prepare(conn_follow, prepare_ts)
 
         return conn_follow, session_follow, prepare_session_primary, prepare_session_follow
 
     def evict_page(self, session, key):
-        """Release the cached page so the next access reads from the checkpoint."""
+        """Force the follower to reload data from its checkpoint on the next cursor access."""
         evict_session = session.connection.open_session('debug=(release_evict_page)')
         evict_cursor = evict_session.open_cursor(self.uri)
         evict_cursor.set_key(key)
@@ -215,23 +161,13 @@ class test_layered89(wttest.WiredTigerTestCase):
         evict_cursor.close()
         evict_session.close()
 
-    def collect_keys_next(self, session):
-        """Walk forward and return all visible keys."""
+    def collect_keys(self, session, forward=True):
+        """Walk the cursor and return all visible keys. forward=True uses next(), False uses prev()."""
         cursor = session.open_cursor(self.uri)
         session.begin_transaction()
+        step = cursor.next if forward else cursor.prev
         keys = []
-        while cursor.next() != wiredtiger.WT_NOTFOUND:
-            keys.append(cursor.get_key())
-        session.rollback_transaction()
-        cursor.close()
-        return keys
-
-    def collect_keys_prev(self, session):
-        """Walk backward and return all visible keys."""
-        cursor = session.open_cursor(self.uri)
-        session.begin_transaction()
-        keys = []
-        while cursor.prev() != wiredtiger.WT_NOTFOUND:
+        while step() != wiredtiger.WT_NOTFOUND:
             keys.append(cursor.get_key())
         session.rollback_transaction()
         cursor.close()
@@ -253,20 +189,16 @@ class test_layered89(wttest.WiredTigerTestCase):
         Common harness for cursor-walk tests on a follower whose checkpoint contains
         prepared updates (or tombstones). Returns the keys returned by walk_func.
         """
-        if delete:
-            conn_follow, session_follow, prepare_session_primary, prepare_session_follow = \
-                self.setup_with_prepared_tombstones(all_keys, prepare_keys)
-        else:
-            conn_follow, session_follow, prepare_session_primary, prepare_session_follow = \
-                self.setup_with_prepared_updates(all_keys, prepare_keys)
+        conn_follow, session_follow, prepare_session_primary, prepare_session_follow = \
+            self.setup_with_prepare(all_keys, prepare_keys, delete=delete)
 
-        # Roll back the follower's prepared transaction; the prior committed value
-        # is now the most recent visible version on the follower.
+        # Roll back the follower's prepared transaction so the committed value
+        # is what the cursor returns on the follower.
         prepare_session_follow.rollback_transaction(
             'rollback_timestamp=' + self.timestamp_str(30))
         prepare_session_follow.close()
 
-        # Evict cached pages so the next access reads from the checkpointed snapshot.
+        # Force the follower to reload from its checkpoint on the next cursor access.
         self.evict_page(session_follow, all_keys[0])
 
         keys = walk_func(session_follow)
@@ -286,7 +218,7 @@ class test_layered89(wttest.WiredTigerTestCase):
         """
         all_keys = [1, 2, 3, 4, 5]
         keys = self.run_walk_test(all_keys, prepare_keys=[2, 4],
-            walk_func=self.collect_keys_next)
+            walk_func=lambda s: self.collect_keys(s, forward=True))
         self.assertEqual(sorted(keys), all_keys)
 
     def test_prev_walk_prepared_update(self):
@@ -297,7 +229,7 @@ class test_layered89(wttest.WiredTigerTestCase):
         """
         all_keys = [1, 2, 3, 4, 5]
         keys = self.run_walk_test(all_keys, prepare_keys=[2, 4],
-            walk_func=self.collect_keys_prev)
+            walk_func=lambda s: self.collect_keys(s, forward=False))
         self.assertEqual(sorted(keys), all_keys)
 
     def test_next_walk_prepared_tombstone(self):
@@ -309,7 +241,7 @@ class test_layered89(wttest.WiredTigerTestCase):
         """
         all_keys = [1, 2, 3, 4, 5]
         keys = self.run_walk_test(all_keys, prepare_keys=[2, 4],
-            walk_func=self.collect_keys_next, delete=True)
+            walk_func=lambda s: self.collect_keys(s, forward=True), delete=True)
         self.assertEqual(sorted(keys), all_keys)
 
     def test_prev_walk_prepared_tombstone(self):
@@ -321,7 +253,7 @@ class test_layered89(wttest.WiredTigerTestCase):
         """
         all_keys = [1, 2, 3, 4, 5]
         keys = self.run_walk_test(all_keys, prepare_keys=[2, 4],
-            walk_func=self.collect_keys_prev, delete=True)
+            walk_func=lambda s: self.collect_keys(s, forward=False), delete=True)
         self.assertEqual(sorted(keys), all_keys)
 
     def test_search_and_search_near_prepared_update(self):
@@ -334,7 +266,7 @@ class test_layered89(wttest.WiredTigerTestCase):
         prepare_keys = [2]
 
         conn_follow, session_follow, prepare_session_primary, prepare_session_follow = \
-            self.setup_with_prepared_updates(all_keys, prepare_keys)
+            self.setup_with_prepare(all_keys, prepare_keys)
 
         # Roll back the follower's prepared transaction.
         prepare_session_follow.rollback_transaction(


### PR DESCRIPTION
When a follower reads a checkpoint that includes a prepared transaction, on-disk cells carry a prepare flag. Previously this caused WT_PREPARE_CONFLICT on cursor walks and lookups. The fix makes prepared on-disk cells invisible instead, so the cursor falls through to the prior committed value. The WT_TXN_IGNORE_PREPARE workaround in __clayered_lookup and the "no prepared entries in HS" assertions in __curhs_prev_visible are removed as they are no longer correct with this read path.

test_layered89 adds a regression test covering cursor.next(), cursor.prev(), and cursor.search() in this scenario.

We will revisit this decision if we start to remove the stable prepared update from the ingest btree.