### PR TITLE
WT-17134 Avoid using metadata values memory that we don't own

### DIFF
--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -217,11 +217,11 @@ __disagg_save_checkpoint_meta_local(
     WT_DECL_ITEM(metadata_cfg);
     WT_DECL_ITEM(old_uri_buf);
     WT_DECL_RET;
-    char *cfg_new;
+    char *cfg_current_copy, *cfg_new;
     const char *cfg[3], *checkpoint_name, *cfg_current, *metadata_key;
     bool discard;
 
-    cfg_new = NULL;
+    cfg_current_copy = cfg_new = NULL;
     checkpoint_name = NULL;
     discard = false;
     metadata_key = WT_DISAGG_METADATA_URI;
@@ -230,13 +230,15 @@ __disagg_save_checkpoint_meta_local(
     md_cursor->set_key(md_cursor, metadata_key);
     WT_ERR(md_cursor->search(md_cursor));
     WT_ERR(md_cursor->get_value(md_cursor, &cfg_current));
+    /* Copy the value since we don't own the memory after calling get_value(). */
+    WT_ERR(__wt_strdup(session, cfg_current, &cfg_current_copy));
 
     /* Create the new checkpoint config string. */
     WT_ERR(__wt_scr_alloc(session, 0, &metadata_cfg));
     WT_ERR(__wt_buf_fmt(session, metadata_cfg, "checkpoint=%.*s", (int)metadata->checkpoint_len,
       metadata->checkpoint));
 
-    cfg[0] = cfg_current;
+    cfg[0] = cfg_current_copy;
     cfg[1] = metadata_cfg->data;
     cfg[2] = NULL;
     WT_ERR(__wt_config_collapse(session, cfg, &cfg_new));
@@ -250,7 +252,7 @@ __disagg_save_checkpoint_meta_local(
 
     /* Throw away any references to the old disaggregated metadata table checkpoint. */
     WT_ERR(__disagg_discard_old_checkpoint_check(
-      session, cfg_current, cfg_new, &checkpoint_name, &discard));
+      session, cfg_current_copy, cfg_new, &checkpoint_name, &discard));
     if (discard) {
         WT_ERR(__wt_scr_alloc(session, 0, &old_uri_buf));
         WT_ERR(__wt_buf_fmt(session, old_uri_buf, "%s/%s", metadata_key, checkpoint_name));
@@ -259,6 +261,7 @@ __disagg_save_checkpoint_meta_local(
           (const char *)old_uri_buf->data);
     }
 err:
+    __wt_free(session, cfg_current_copy);
     __wt_free(session, cfg_new);
     __wt_free(session, checkpoint_name);
     __wt_scr_free(session, &metadata_cfg);
@@ -281,7 +284,7 @@ __disagg_apply_checkpoint_meta(
     WT_DECL_ITEM(old_uri_buf);
     WT_DECL_RET;
     uint32_t existing_tables, new_tables, new_ingest;
-    char *layered_ingest_uri, *cfg_ret;
+    char *current_value_copy, *layered_ingest_uri, *cfg_ret;
     const char *cfg[3], *checkpoint_name, *current_value, *metadata_checkpoint_name, *metadata_key,
       *metadata_value;
     bool discard;
@@ -289,7 +292,7 @@ __disagg_apply_checkpoint_meta(
     cursor = NULL;
     discard = false;
     checkpoint_name = metadata_checkpoint_name = NULL;
-    layered_ingest_uri = cfg_ret = NULL;
+    current_value_copy = layered_ingest_uri = cfg_ret = NULL;
     existing_tables = new_tables = new_ingest = 0;
 
     WT_ASSERT_SPINLOCK_OWNED(session, &S2C(session)->schema_lock);
@@ -335,7 +338,10 @@ __disagg_apply_checkpoint_meta(
 
             /* Merge the new checkpoint metadata into the current table metadata. */
             WT_ERR(md_cursor->get_value(md_cursor, &current_value));
-            cfg[0] = current_value;
+            /* Copy the value since we don't own the memory after calling get_value(). */
+            WT_ERR(__wt_strdup(session, current_value, &current_value_copy));
+
+            cfg[0] = current_value_copy;
             cfg[1] = metadata_cfg->data;
             cfg[2] = NULL;
             WT_ERR(__wt_config_collapse(session, cfg, &cfg_ret));
@@ -359,7 +365,7 @@ __disagg_apply_checkpoint_meta(
              * different nodes.
              */
             WT_ERR(__disagg_discard_old_checkpoint_check(
-              session, current_value, cfg_ret, &checkpoint_name, &discard));
+              session, current_value_copy, cfg_ret, &checkpoint_name, &discard));
             if (discard) {
                 WT_ERR(__wt_buf_fmt(session, old_uri_buf, "%s/%s", metadata_key, checkpoint_name));
                 WT_WITHOUT_DHANDLE(
@@ -377,6 +383,7 @@ __disagg_apply_checkpoint_meta(
             WT_WITHOUT_DHANDLE(session, ret = __wti_conn_dhandle_outdated(session, metadata_key));
             WT_ERR_MSG_CHK(session, ret, "Marking data handles outdated failed: \"%s\"",
               (const char *)metadata_key);
+            __wt_free(session, current_value_copy);
             __wt_free(session, cfg_ret);
             __wt_free(session, checkpoint_name);
         } else if (ret == WT_NOTFOUND) {
@@ -426,6 +433,7 @@ __disagg_apply_checkpoint_meta(
 
 done:
 err:
+    __wt_free(session, current_value_copy);
     __wt_free(session, cfg_ret);
     __wt_free(session, checkpoint_name);
     __wt_free(session, metadata_checkpoint_name);

--- a/test/suite/test_layered90.py
+++ b/test/suite/test_layered90.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wttest
+from helper_disagg import disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
+
+# test_layered90.py
+#     Test that a follower correctly picks up multiple checkpoints for the same table.
+#     Includes a cursor_copy variant to catch use-after-free bugs in accessing metadata cursor values.
+
+@disagg_test_class
+class test_layered90(wttest.WiredTigerTestCase):
+    nitems = 100
+
+    conn_base_config = 'statistics=(all),'
+    conn_config = conn_base_config + 'disaggregated=(role="leader")'
+
+    # cursor_copy variant: enables debug_mode=(cursor_copy=true) on the follower to
+    # exercise the fixed code path under ASAN.
+    cursor_copy_values = [
+        ('no_cursor_copy', dict(cursor_copy=False)),
+        ('cursor_copy',    dict(cursor_copy=True)),
+    ]
+
+    disagg_storages = gen_disagg_storages('test_layered90', disagg_only=True)
+    scenarios = make_scenarios(disagg_storages, cursor_copy_values)
+
+    uri = 'layered:test_layered90'
+
+    def follower_conn_config(self):
+        cfg = self.extensionsConfig() + ',create,' + self.conn_base_config
+        cfg += 'disaggregated=(role="follower")'
+        if self.cursor_copy:
+            cfg += ',debug_mode=(cursor_copy=true)'
+        return cfg
+
+    def insert_data(self, session, value_prefix):
+        cursor = session.open_cursor(self.uri)
+        for i in range(self.nitems):
+            cursor[str(i)] = value_prefix + str(i)
+        cursor.close()
+
+    def check_data(self, session, value_prefix):
+        cursor = session.open_cursor(self.uri)
+        for i in range(self.nitems):
+            self.assertEqual(cursor[str(i)], value_prefix + str(i))
+        cursor.close()
+
+    def test_follower_picks_up_updated_checkpoint(self):
+        # Create the table on the leader and write initial data.
+        self.session.create(self.uri, 'key_format=S,value_format=S')
+        self.insert_data(self.session, 'v1-')
+        self.session.checkpoint()
+
+        # Open the follower.
+        conn_follow = self.wiredtiger_open('follower', self.follower_conn_config())
+        session_follow = conn_follow.open_session('')
+
+        # Checkpoint 1: follower picks up for the first time.
+        self.disagg_advance_checkpoint(conn_follow)
+        self.check_data(session_follow, 'v1-')
+
+        # Write new data and take a second checkpoint on the leader.
+        self.insert_data(self.session, 'v2-')
+        self.session.checkpoint()
+
+        # Checkpoint 2: follower picks up for the same table a second time.
+        self.disagg_advance_checkpoint(conn_follow)
+        self.check_data(session_follow, 'v2-')
+
+        # A third round to verify repeated pickups remain correct.
+        self.insert_data(self.session, 'v3-')
+        self.session.checkpoint()
+        self.disagg_advance_checkpoint(conn_follow)
+        self.check_data(session_follow, 'v3-')
+
+        session_follow.close()
+        conn_follow.close()


### PR DESCRIPTION
Currently, when we call `md_cursor->get_value()`, we continue using the returned value even after making subsequent cursor calls. However, since we do not own the memory returned by `get_value()`, it may be modified or freed by those subsequent calls, which is unsafe.

To address this, this PR copies the value into a local buffer and uses that copy instead.

The test includes a variant with `debug_mode=(cursor_copy=true)` to make it easier to detect this type of failures through ASAN.