### PR TITLE
WT-17142 Fix the test failure in test_checkpoint38

### DIFF
--- a/test/suite/test_checkpoint38.py
+++ b/test/suite/test_checkpoint38.py
@@ -44,10 +44,15 @@ class test_checkpoint38(wttest.WiredTigerTestCase):
 
     scenarios = make_scenarios(thread_values)
 
-    # Bump the eviction thresholds we want checkpoint reconcile pages.
+    # Use a large cache to ensure all dirty pages remain in cache during checkpoint, even when
+    # running with the tiered hook (which adds flush_tier overhead before the checkpoint walk).
+    # Without a large enough cache, eviction pressure during insertion can remove dirty leaf pages
+    # from cache before the checkpoint walk, leaving nothing for the parallel workers to reconcile.
+    # Set eviction_checkpoint_target=0 to disable pre-checkpoint scrubbing as well.
     def conn_config(self):
-        return ('eviction_dirty_target=95,eviction_dirty_trigger=99,statistics=(all)'
-                ',statistics_log=(json,on_close,wait=1)'
+        return ('cache_size=1GB,'
+                'eviction_dirty_target=95,eviction_dirty_trigger=99,eviction_checkpoint_target=0'
+                ',statistics=(all),statistics_log=(json,on_close,wait=1)'
                 f',checkpoint_threads={self.checkpoint_threads}')
 
     def get_stat(self, stat_key):
@@ -59,7 +64,7 @@ class test_checkpoint38(wttest.WiredTigerTestCase):
     def test_parallel_checkpoint(self):
         uri = 'table:checkpoint38'
         value_size = 10000
-        nrows = 110000
+        nrows = 55000
         value = 'a' * value_size
 
         self.session.create(uri, 'key_format=i,value_format=S,leaf_page_max=32KB')


### PR DESCRIPTION
Make sure that the cache in tests_checkpoint38 is large enough, and that eviction_checkpoint_target is small enough, to ensure that the checkpoint has always enough work to do, even when all the various hooks are enabled.