### PR TITLE
WT-17113 s_outdated_fixme Remove fixme for closed tickets

### DIFF
--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -580,10 +580,7 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPOINT
     /* Update our local metadata with the new checkpoint entry. */
     WT_ERR(__disagg_save_checkpoint_meta_local(session, md_cursor, &metadata));
 
-    /*
-     * Part 2: Apply the metadata for other tables from the shared metadata table. FIXME-WT-16528
-     * Investigate whether we need a separate internal session to pick up the new checkpoint.
-     */
+    /* Part 2: Apply the metadata for other tables from the shared metadata table. */
     WT_WITH_SCHEMA_LOCK(
       session, ret = __disagg_apply_checkpoint_meta(session, md_cursor, ckpt_meta));
     WT_ERR(ret);
@@ -728,10 +725,6 @@ __disagg_pick_up_checkpoint_meta(
     /* Parse and validate version and compatible_version fields. */
     WT_ERR(__disagg_check_meta_version(session, meta_str, &ckpt_meta));
 
-    /*
-     * FIXME-WT-16528: Investigate why a separate internal session is necessary here pick up a new
-     * checkpoint.
-     */
     WT_ERR(__wt_open_internal_session(
       S2C(session), "checkpoint-pick-up", false, 0, 0, &internal_session));
     /* Now actually pick up the checkpoint. */


### PR DESCRIPTION
There were three tickets in the list (s_outdated_fixme), and we had to reopen the other two. For the remaining one [WT-16528](https://jira.mongodb.org/browse/WT-16528), I forgot to remove the FIXME. The ticket was previously closed as “won’t do” because it was resolved by WT-15527, which introduced using a single session for checkpoint pickup.