### PR TITLE
WT-15472 Remove truncate21 from hook_disagg.fail

### DIFF
--- a/test/suite/hook_disagg.fail
+++ b/test/suite/hook_disagg.fail
@@ -40,7 +40,6 @@ test_stat_log02.py
 test_sweep05
 test_timestamp26.py # FIXME: WT-16182
 test_truncate01.py # FIXME: WT-15474
-test_truncate21.py # FIXME: WT-15472
 test_truncate24.py # FIXME: WT-15473
 test_util01.py
 test_util02.py


### PR DESCRIPTION
This test no longer fails, and so this test should be removed from hook_disagg.fail along with its FIXME comment.