### PR TITLE
WT-17080 Remove verbosity flags for sanitisers

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -60,10 +60,10 @@ functions:
               export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$(dirname $(/opt/mongodbtoolchain/v5/bin/clang -print-file-name=libclang_rt.asan.so))"
               export TESTUTIL_BYPASS_ASAN=1
             elif [[ "${CMAKE_BUILD_TYPE|}" =~ MSan ]]; then
-              export MSAN_OPTIONS="$COMMON_SAN_OPTIONS:verbosity=3"
+              export MSAN_OPTIONS="$COMMON_SAN_OPTIONS"
               export TESTUTIL_MSAN=1
             elif [[ "${CMAKE_BUILD_TYPE|}" =~ TSan ]]; then
-              export TSAN_OPTIONS="$COMMON_SAN_OPTIONS:verbosity=3"
+              export TSAN_OPTIONS="$COMMON_SAN_OPTIONS"
               export TESTUTIL_TSAN=1
             elif [[ "${CMAKE_BUILD_TYPE|}" =~ UBSan ]]; then
               export UBSAN_OPTIONS="$COMMON_SAN_OPTIONS:print_stacktrace=1"


### PR DESCRIPTION
MSan can easily produce logs that are so large that we cannot even download them, which makes them useless!

Most of such logs look like this:
```
[2026/03/26 12:26:27.262] ==179902==__tls_get_addr: DTLS_Find 0x7f060c2666e0 2
[2026/03/26 12:26:27.262] ==179902==__tls_get_addr: DTLS_Find 0x7f060b7616e0 2
[2026/03/26 12:26:27.262] ==179902==__tls_get_addr: DTLS_Find 0x7f060b7616e0 2
[2026/03/26 12:26:27.262] ==179902==__tls_get_addr: DTLS_Find 0x7f060b7616e0 2
[2026/03/26 12:26:27.262] ==179902==__tls_get_addr: DTLS_Find 0x7f060b7616e0 2
[2026/03/26 12:26:27.262] ==179902==__tls_get_addr: DTLS_Find 0x7f060b7616e0 2
[2026/03/26 12:26:27.262] ==179902==__tls_get_addr: DTLS_Find 0x7f060b7616e0 2
[2026/03/26 12:26:27.262] ==179902==__tls_get_addr: DTLS_Find 0x7f060b7616e0 2
[2026/03/26 12:26:27.262] ==179902==__tls_get_addr: DTLS_Find 0x7f060b7616e0 2
```

And TSAN verbosity is not producing any logs.