### PR TITLE
WT-16977 Finish implementing the config cursor API

### DIFF
--- a/src/cursor/cur_config.c
+++ b/src/cursor/cur_config.c
@@ -34,7 +34,6 @@ int
 __wt_curconfig_open(
   WT_SESSION_IMPL *session, const char *uri, const char *cfg[], WT_CURSOR **cursorp)
 {
-    /* FIXME-WT-16977: Finish implementing the config cursor API. */
     WT_CURSOR_STATIC_INIT(iface, __wt_cursor_get_key, /* get-key */
       __wt_cursor_get_value,                          /* get-value */
       __wt_cursor_get_raw_key_value,                  /* get-raw-key-value */


### PR DESCRIPTION
We have [decided not to implement the config cursor API](https://github.com/wiredtiger/wiredtiger/pull/13332#discussion_r2963295346), this PR is to remove the outdated FIXME comment.
