### PR TITLE
WT-17068 Add test/suite hook for parallel checkpoints

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2878,7 +2878,7 @@ tasks:
           unit_test_args: -v 2 --timeout 60 --hook "disagg=(role=follower,table_prefix=table)" base01
 
   - name: unit-test-hook-parallel-checkpoint
-    tags: ["python", "unit_test_xsan"]
+    tags: ["python"]
     depends_on:
       - name: compile
     commands:
@@ -2898,6 +2898,126 @@ tasks:
       additional_san_vars: export TSAN_OPTIONS="$TSAN_OPTIONS:detect_deadlocks=0"
       unit_test_parallel_ignore: test/suite/tsan.fail
       unit_test_parallel_args: -v 2 --timeout 300 --hook "parallel_checkpoint"
+
+  - name: unit-test-hook-parallel-checkpoint-bucket00
+    tags: ["python", "unit_test_xsan"]
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+    vars:
+      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 0/12
+
+  - name: unit-test-hook-parallel-checkpoint-bucket01
+    tags: ["python", "unit_test_xsan"]
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+    vars:
+      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 1/12
+
+  - name: unit-test-hook-parallel-checkpoint-bucket02
+    tags: ["python", "unit_test_xsan"]
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+    vars:
+      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 2/12
+
+  - name: unit-test-hook-parallel-checkpoint-bucket03
+    tags: ["python", "unit_test_xsan"]
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+    vars:
+      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 3/12
+
+  - name: unit-test-hook-parallel-checkpoint-bucket04
+    tags: ["python", "unit_test_xsan"]
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+    vars:
+      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 4/12
+
+  - name: unit-test-hook-parallel-checkpoint-bucket05
+    tags: ["python", "unit_test_xsan"]
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+    vars:
+      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 5/12
+
+  - name: unit-test-hook-parallel-checkpoint-bucket06
+    tags: ["python", "unit_test_xsan"]
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+    vars:
+      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 6/12
+
+  - name: unit-test-hook-parallel-checkpoint-bucket07
+    tags: ["python", "unit_test_xsan"]
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+    vars:
+      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 7/12
+
+  - name: unit-test-hook-parallel-checkpoint-bucket08
+    tags: ["python", "unit_test_xsan"]
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+    vars:
+      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 8/12
+
+  - name: unit-test-hook-parallel-checkpoint-bucket09
+    tags: ["python", "unit_test_xsan"]
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+    vars:
+      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 9/12
+
+  - name: unit-test-hook-parallel-checkpoint-bucket10
+    tags: ["python", "unit_test_xsan"]
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+    vars:
+      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 10/12
+
+  - name: unit-test-hook-parallel-checkpoint-bucket11
+    tags: ["python", "unit_test_xsan"]
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+    vars:
+      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 11/12
 
   - name: unit-test-hook-timing-stress-log
     tags: ["python"]

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2895,6 +2895,8 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test tsan parallel"
         vars:
+          # FIXME-WT-16313: Disable deadlock detection in TSAN as it causes false positives when
+          # used with parallel checkpoints.
           additional_san_vars: export TSAN_OPTIONS="$TSAN_OPTIONS:detect_deadlocks=0"
           unit_test_parallel_ignore: test/suite/tsan.fail
           unit_test_parallel_args: -v 2 --timeout 300 --hook "parallel_checkpoint"

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2884,8 +2884,8 @@ tasks:
     commands:
       - func: "fetch artifacts"
       - func: "unit test"
-    vars:
-      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint"
+        vars:
+          unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint"
 
   - name: unit-test-hook-parallel-checkpoint-tsan
     tags: ["python"]
@@ -2894,10 +2894,10 @@ tasks:
     commands:
       - func: "fetch artifacts"
       - func: "unit test tsan parallel"
-    vars:
-      additional_san_vars: export TSAN_OPTIONS="$TSAN_OPTIONS:detect_deadlocks=0"
-      unit_test_parallel_ignore: test/suite/tsan.fail
-      unit_test_parallel_args: -v 2 --timeout 300 --hook "parallel_checkpoint"
+        vars:
+          additional_san_vars: export TSAN_OPTIONS="$TSAN_OPTIONS:detect_deadlocks=0"
+          unit_test_parallel_ignore: test/suite/tsan.fail
+          unit_test_parallel_args: -v 2 --timeout 300 --hook "parallel_checkpoint"
 
   - name: unit-test-hook-parallel-checkpoint-bucket00
     tags: ["python", "unit_test_xsan"]
@@ -2906,8 +2906,8 @@ tasks:
     commands:
       - func: "fetch artifacts"
       - func: "unit test"
-    vars:
-      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 0/24
+        vars:
+          unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 0/24
 
   - name: unit-test-hook-parallel-checkpoint-bucket01
     tags: ["python", "unit_test_xsan"]
@@ -2916,8 +2916,8 @@ tasks:
     commands:
       - func: "fetch artifacts"
       - func: "unit test"
-    vars:
-      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 1/24
+        vars:
+          unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 1/24
 
   - name: unit-test-hook-parallel-checkpoint-bucket02
     tags: ["python", "unit_test_xsan"]
@@ -2926,8 +2926,8 @@ tasks:
     commands:
       - func: "fetch artifacts"
       - func: "unit test"
-    vars:
-      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 2/24
+        vars:
+          unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 2/24
 
   - name: unit-test-hook-parallel-checkpoint-bucket03
     tags: ["python", "unit_test_xsan"]
@@ -2936,8 +2936,8 @@ tasks:
     commands:
       - func: "fetch artifacts"
       - func: "unit test"
-    vars:
-      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 3/24
+        vars:
+          unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 3/24
 
   - name: unit-test-hook-parallel-checkpoint-bucket04
     tags: ["python", "unit_test_xsan"]
@@ -2946,8 +2946,8 @@ tasks:
     commands:
       - func: "fetch artifacts"
       - func: "unit test"
-    vars:
-      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 4/24
+        vars:
+          unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 4/24
 
   - name: unit-test-hook-parallel-checkpoint-bucket05
     tags: ["python", "unit_test_xsan"]
@@ -2956,8 +2956,8 @@ tasks:
     commands:
       - func: "fetch artifacts"
       - func: "unit test"
-    vars:
-      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 5/24
+        vars:
+          unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 5/24
 
   - name: unit-test-hook-parallel-checkpoint-bucket06
     tags: ["python", "unit_test_xsan"]
@@ -2966,8 +2966,8 @@ tasks:
     commands:
       - func: "fetch artifacts"
       - func: "unit test"
-    vars:
-      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 6/24
+        vars:
+          unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 6/24
 
   - name: unit-test-hook-parallel-checkpoint-bucket07
     tags: ["python", "unit_test_xsan"]
@@ -2976,8 +2976,8 @@ tasks:
     commands:
       - func: "fetch artifacts"
       - func: "unit test"
-    vars:
-      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 7/24
+        vars:
+          unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 7/24
 
   - name: unit-test-hook-parallel-checkpoint-bucket08
     tags: ["python", "unit_test_xsan"]
@@ -2986,8 +2986,8 @@ tasks:
     commands:
       - func: "fetch artifacts"
       - func: "unit test"
-    vars:
-      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 8/24
+        vars:
+          unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 8/24
 
   - name: unit-test-hook-parallel-checkpoint-bucket09
     tags: ["python", "unit_test_xsan"]
@@ -2996,8 +2996,8 @@ tasks:
     commands:
       - func: "fetch artifacts"
       - func: "unit test"
-    vars:
-      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 9/24
+        vars:
+          unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 9/24
 
   - name: unit-test-hook-parallel-checkpoint-bucket10
     tags: ["python", "unit_test_xsan"]
@@ -3006,8 +3006,8 @@ tasks:
     commands:
       - func: "fetch artifacts"
       - func: "unit test"
-    vars:
-      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 10/24
+        vars:
+          unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 10/24
 
   - name: unit-test-hook-parallel-checkpoint-bucket11
     tags: ["python", "unit_test_xsan"]
@@ -3016,8 +3016,8 @@ tasks:
     commands:
       - func: "fetch artifacts"
       - func: "unit test"
-    vars:
-      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 11/24
+        vars:
+          unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 11/24
 
   - name: unit-test-hook-parallel-checkpoint-bucket12
     tags: ["python", "unit_test_xsan"]
@@ -3026,8 +3026,8 @@ tasks:
     commands:
       - func: "fetch artifacts"
       - func: "unit test"
-    vars:
-      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 12/24
+        vars:
+          unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 12/24
 
   - name: unit-test-hook-parallel-checkpoint-bucket13
     tags: ["python", "unit_test_xsan"]
@@ -3036,8 +3036,8 @@ tasks:
     commands:
       - func: "fetch artifacts"
       - func: "unit test"
-    vars:
-      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 13/24
+        vars:
+          unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 13/24
 
   - name: unit-test-hook-parallel-checkpoint-bucket14
     tags: ["python", "unit_test_xsan"]
@@ -3046,8 +3046,8 @@ tasks:
     commands:
       - func: "fetch artifacts"
       - func: "unit test"
-    vars:
-      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 14/24
+        vars:
+          unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 14/24
 
   - name: unit-test-hook-parallel-checkpoint-bucket15
     tags: ["python", "unit_test_xsan"]
@@ -3056,8 +3056,8 @@ tasks:
     commands:
       - func: "fetch artifacts"
       - func: "unit test"
-    vars:
-      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 15/24
+        vars:
+          unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 15/24
 
   - name: unit-test-hook-parallel-checkpoint-bucket16
     tags: ["python", "unit_test_xsan"]
@@ -3066,8 +3066,8 @@ tasks:
     commands:
       - func: "fetch artifacts"
       - func: "unit test"
-    vars:
-      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 16/24
+        vars:
+          unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 16/24
 
   - name: unit-test-hook-parallel-checkpoint-bucket17
     tags: ["python", "unit_test_xsan"]
@@ -3076,8 +3076,8 @@ tasks:
     commands:
       - func: "fetch artifacts"
       - func: "unit test"
-    vars:
-      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 17/24
+        vars:
+          unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 17/24
 
   - name: unit-test-hook-parallel-checkpoint-bucket18
     tags: ["python", "unit_test_xsan"]
@@ -3086,8 +3086,8 @@ tasks:
     commands:
       - func: "fetch artifacts"
       - func: "unit test"
-    vars:
-      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 18/24
+        vars:
+          unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 18/24
 
   - name: unit-test-hook-parallel-checkpoint-bucket19
     tags: ["python", "unit_test_xsan"]
@@ -3096,8 +3096,8 @@ tasks:
     commands:
       - func: "fetch artifacts"
       - func: "unit test"
-    vars:
-      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 19/24
+        vars:
+          unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 19/24
 
   - name: unit-test-hook-parallel-checkpoint-bucket20
     tags: ["python", "unit_test_xsan"]
@@ -3106,8 +3106,8 @@ tasks:
     commands:
       - func: "fetch artifacts"
       - func: "unit test"
-    vars:
-      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 20/24
+        vars:
+          unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 20/24
 
   - name: unit-test-hook-parallel-checkpoint-bucket21
     tags: ["python", "unit_test_xsan"]
@@ -3116,8 +3116,8 @@ tasks:
     commands:
       - func: "fetch artifacts"
       - func: "unit test"
-    vars:
-      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 21/24
+        vars:
+          unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 21/24
 
   - name: unit-test-hook-parallel-checkpoint-bucket22
     tags: ["python", "unit_test_xsan"]
@@ -3126,8 +3126,8 @@ tasks:
     commands:
       - func: "fetch artifacts"
       - func: "unit test"
-    vars:
-      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 22/24
+        vars:
+          unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 22/24
 
   - name: unit-test-hook-parallel-checkpoint-bucket23
     tags: ["python", "unit_test_xsan"]
@@ -3136,8 +3136,8 @@ tasks:
     commands:
       - func: "fetch artifacts"
       - func: "unit test"
-    vars:
-      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 23/24
+        vars:
+          unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 23/24
 
   - name: unit-test-hook-timing-stress-log
     tags: ["python"]

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2878,7 +2878,7 @@ tasks:
           unit_test_args: -v 2 --timeout 60 --hook "disagg=(role=follower,table_prefix=table)" base01
 
   - name: unit-test-hook-parallel-checkpoint
-    tags: ["python"]
+    tags: ["python", "unit_test_xsan"]
     depends_on:
       - name: compile
     commands:

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2877,6 +2877,28 @@ tasks:
           # As follower, run a minimal functionality test
           unit_test_args: -v 2 --timeout 60 --hook "disagg=(role=follower,table_prefix=table)" base01
 
+  - name: unit-test-hook-parallel-checkpoint
+    tags: ["python"]
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+    vars:
+      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint"
+
+  - name: unit-test-hook-parallel-checkpoint-tsan
+    tags: ["python"]
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test tsan parallel"
+    vars:
+      additional_san_vars: export TSAN_OPTIONS="$TSAN_OPTIONS:detect_deadlocks=0"
+      unit_test_parallel_ignore: test/suite/tsan.fail
+      unit_test_parallel_args: -v 2 --timeout 300 --hook "parallel_checkpoint"
+
   - name: unit-test-hook-timing-stress-log
     tags: ["python"]
     depends_on:
@@ -6624,6 +6646,7 @@ buildvariants:
     - name: configure-combinations
     - name: unit-test-zstd
     - name: unit-test-hook-disagg-leader-key-provider
+    - name: unit-test-hook-parallel-checkpoint
     - name: unit-test-hook-tiered
     - name: unit-test-hook-tiered-with-delays
     - name: unit-test-hook-tiered-timestamp
@@ -6735,6 +6758,7 @@ buildvariants:
     - name: unit-test-hook-disagg-follower-tsan
       distros: ubuntu2004-large
     # FIXME-WT-16309: Remove TSAN-specific jobs once the common tag works
+    - name: unit-test-hook-parallel-checkpoint-tsan
     - name: format-stress-test-disagg-leader-tsan
       distros: ubuntu2004-large
     - name: format-stress-test-tsan
@@ -7504,6 +7528,7 @@ buildvariants:
     # FIXME-WT-16309: Remove TSAN-specific jobs once the common tag works
     - name: format-stress-test-disagg-leader-tsan
       distros: amazon2023.3-arm64-large
+    - name: unit-test-hook-parallel-checkpoint-tsan
     - name: format-stress-test-tsan
       distros: amazon2023.3-arm64-large
     # FIXME-WT-16309: Enable the common test format tag for TSAN

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -2907,7 +2907,7 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test"
     vars:
-      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 0/12
+      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 0/24
 
   - name: unit-test-hook-parallel-checkpoint-bucket01
     tags: ["python", "unit_test_xsan"]
@@ -2917,7 +2917,7 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test"
     vars:
-      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 1/12
+      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 1/24
 
   - name: unit-test-hook-parallel-checkpoint-bucket02
     tags: ["python", "unit_test_xsan"]
@@ -2927,7 +2927,7 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test"
     vars:
-      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 2/12
+      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 2/24
 
   - name: unit-test-hook-parallel-checkpoint-bucket03
     tags: ["python", "unit_test_xsan"]
@@ -2937,7 +2937,7 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test"
     vars:
-      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 3/12
+      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 3/24
 
   - name: unit-test-hook-parallel-checkpoint-bucket04
     tags: ["python", "unit_test_xsan"]
@@ -2947,7 +2947,7 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test"
     vars:
-      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 4/12
+      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 4/24
 
   - name: unit-test-hook-parallel-checkpoint-bucket05
     tags: ["python", "unit_test_xsan"]
@@ -2957,7 +2957,7 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test"
     vars:
-      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 5/12
+      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 5/24
 
   - name: unit-test-hook-parallel-checkpoint-bucket06
     tags: ["python", "unit_test_xsan"]
@@ -2967,7 +2967,7 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test"
     vars:
-      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 6/12
+      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 6/24
 
   - name: unit-test-hook-parallel-checkpoint-bucket07
     tags: ["python", "unit_test_xsan"]
@@ -2977,7 +2977,7 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test"
     vars:
-      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 7/12
+      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 7/24
 
   - name: unit-test-hook-parallel-checkpoint-bucket08
     tags: ["python", "unit_test_xsan"]
@@ -2987,7 +2987,7 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test"
     vars:
-      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 8/12
+      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 8/24
 
   - name: unit-test-hook-parallel-checkpoint-bucket09
     tags: ["python", "unit_test_xsan"]
@@ -2997,7 +2997,7 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test"
     vars:
-      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 9/12
+      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 9/24
 
   - name: unit-test-hook-parallel-checkpoint-bucket10
     tags: ["python", "unit_test_xsan"]
@@ -3007,7 +3007,7 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test"
     vars:
-      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 10/12
+      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 10/24
 
   - name: unit-test-hook-parallel-checkpoint-bucket11
     tags: ["python", "unit_test_xsan"]
@@ -3017,7 +3017,127 @@ tasks:
       - func: "fetch artifacts"
       - func: "unit test"
     vars:
-      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 11/12
+      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 11/24
+
+  - name: unit-test-hook-parallel-checkpoint-bucket12
+    tags: ["python", "unit_test_xsan"]
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+    vars:
+      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 12/24
+
+  - name: unit-test-hook-parallel-checkpoint-bucket13
+    tags: ["python", "unit_test_xsan"]
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+    vars:
+      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 13/24
+
+  - name: unit-test-hook-parallel-checkpoint-bucket14
+    tags: ["python", "unit_test_xsan"]
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+    vars:
+      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 14/24
+
+  - name: unit-test-hook-parallel-checkpoint-bucket15
+    tags: ["python", "unit_test_xsan"]
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+    vars:
+      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 15/24
+
+  - name: unit-test-hook-parallel-checkpoint-bucket16
+    tags: ["python", "unit_test_xsan"]
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+    vars:
+      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 16/24
+
+  - name: unit-test-hook-parallel-checkpoint-bucket17
+    tags: ["python", "unit_test_xsan"]
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+    vars:
+      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 17/24
+
+  - name: unit-test-hook-parallel-checkpoint-bucket18
+    tags: ["python", "unit_test_xsan"]
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+    vars:
+      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 18/24
+
+  - name: unit-test-hook-parallel-checkpoint-bucket19
+    tags: ["python", "unit_test_xsan"]
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+    vars:
+      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 19/24
+
+  - name: unit-test-hook-parallel-checkpoint-bucket20
+    tags: ["python", "unit_test_xsan"]
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+    vars:
+      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 20/24
+
+  - name: unit-test-hook-parallel-checkpoint-bucket21
+    tags: ["python", "unit_test_xsan"]
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+    vars:
+      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 21/24
+
+  - name: unit-test-hook-parallel-checkpoint-bucket22
+    tags: ["python", "unit_test_xsan"]
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+    vars:
+      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 22/24
+
+  - name: unit-test-hook-parallel-checkpoint-bucket23
+    tags: ["python", "unit_test_xsan"]
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "unit test"
+    vars:
+      unit_test_args: -v 2 --timeout 1800 --hook "parallel_checkpoint" --batch 23/24
 
   - name: unit-test-hook-timing-stress-log
     tags: ["python"]

--- a/test/suite/hook_parallel_checkpoint.py
+++ b/test/suite/hook_parallel_checkpoint.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# [TEST_TAGS]
+# ignored_file
+# [END_TAGS]
+
+# hook_parallel_checkpoint.py
+#
+# Enable parallel checkpoints for all Python unit tests by appending a
+# checkpoint_threads=... configuration to wiredtiger_open().
+#
+# Usage examples:
+#   ../test/suite/run.py --hook parallel_checkpoint
+#   ../test/suite/run.py --hook "parallel_checkpoint=(threads=8)"
+#
+# The hook will not override tests with explicit checkpoint_threads= in the
+# connection configuration string.
+
+from __future__ import print_function
+
+import re, wthooks
+from wttest import WiredTigerTestCase
+
+def strip_matching_parens(s):
+    if len(s) >= 2 and s[0] == '(' and s[-1] == ')':
+        return s[1:-1]
+    return s
+
+def config_split(config):
+    pos = config.find('=')
+    if pos >= 0:
+        left = config[:pos]
+        right = config[pos + 1:]
+    else:
+        left = config
+        right = ''
+    return left, strip_matching_parens(right)
+
+def parse_hook_args(arg):
+    """
+    Parse the hook argument string into a dict of key->value.
+
+    Accepts:
+      --hook parallel_checkpoint
+      --hook parallel_checkpoint=8
+      --hook "parallel_checkpoint=(threads=8)"
+    """
+    params = {}
+
+    if not arg:
+        return params
+
+    arg = strip_matching_parens(str(arg).strip())
+    if not arg:
+        return params
+
+    if re.fullmatch(r'[0-9]+', arg):
+        params['threads'] = arg
+        return params
+
+    config_list = re.split(r",(?=(?:[^(]*[(][^)]*[)])*[^)]*$)", arg)
+    for cfg in config_list:
+        cfg = cfg.strip()
+        if not cfg:
+            continue
+        key, val = config_split(cfg)
+        if not key:
+            continue
+        params[key] = val
+
+    return params
+
+def wiredtiger_open_replace(orig_wiredtiger_open, homedir, conn_config, threads):
+    """
+    HOOK_REPLACE implementation for wiredtiger_open.
+
+    If the config already sets checkpoint_threads=..., leave it alone.
+    Otherwise append ",checkpoint_threads=<threads>".
+    """
+    if conn_config is None:
+        conn_config = ''
+
+    # Don't override tests that explicitly set checkpoint_threads.
+    if 'checkpoint_threads=' in conn_config:
+        WiredTigerTestCase.verbose(
+            None, 3,
+            'parallel_checkpoint hook: existing checkpoint_threads config found, '
+            'leaving configuration unchanged')
+        return orig_wiredtiger_open(homedir, conn_config)
+
+    extra = ',checkpoint_threads={}'.format(threads)
+    new_config = conn_config + extra
+
+    WiredTigerTestCase.verbose(
+        None, 3,
+        'parallel_checkpoint hook: calling wiredtiger_open({}, {})'
+        .format(homedir, new_config))
+
+    return orig_wiredtiger_open(homedir, new_config)
+
+class ParallelCheckpointHookCreator(wthooks.WiredTigerHookCreator):
+    def __init__(self, arg=0):
+        # Default to 4 parallel checkpoint threads
+        self.threads = 4
+
+        params = parse_hook_args(arg)
+        if 'threads' in params:
+            try:
+                self.threads = int(params['threads'])
+            except ValueError:
+                raise Exception(
+                    'hook_parallel_checkpoint: invalid threads value "{}"'
+                    .format(params['threads']))
+        # Reject unknown parameters
+        for key in params:
+            if key != 'threads':
+                raise Exception(
+                    'hook_parallel_checkpoint: unknown parameter "{}"'
+                    .format(key))
+
+        self.platform_api = wthooks.DefaultPlatformAPI()
+
+    def get_platform_api(self):
+        return self.platform_api
+
+    def register_skipped_tests(self, tests):
+        # No tests skipped; add entries here if needed
+        pass
+
+    def setup_hooks(self):
+        # Replace wiredtiger_open with a wrapper that appends checkpoint_threads
+        orig_wiredtiger_open = self.wiredtiger['wiredtiger_open']
+
+        self.wiredtiger['wiredtiger_open'] = (
+            wthooks.HOOK_REPLACE,
+            lambda homedir, config:
+                wiredtiger_open_replace(orig_wiredtiger_open, homedir, config, self.threads)
+        )
+
+def initialize(arg):
+    return [ParallelCheckpointHookCreator(arg)]

--- a/test/suite/hook_parallel_checkpoint.py
+++ b/test/suite/hook_parallel_checkpoint.py
@@ -37,6 +37,7 @@
 #
 # Usage examples:
 #   ../test/suite/run.py --hook parallel_checkpoint
+#   ../test/suite/run.py --hook parallel_checkpoint=8
 #   ../test/suite/run.py --hook "parallel_checkpoint=(threads=8)"
 #
 # The hook will not override tests with explicit checkpoint_threads= in the
@@ -45,123 +46,61 @@
 from __future__ import print_function
 
 import re, wthooks
-from wttest import WiredTigerTestCase
 
-def strip_matching_parens(s):
-    if len(s) >= 2 and s[0] == '(' and s[-1] == ')':
-        return s[1:-1]
-    return s
+def _parse_threads(arg):
+    # Default to 4 threads if no argument is provided
+    if not arg:
+        return 4
 
-def config_split(config):
-    pos = config.find('=')
-    if pos >= 0:
-        left = config[:pos]
-        right = config[pos + 1:]
+    s = str(arg).strip()
+    if s.startswith('(') and s.endswith(')'):
+        s = s[1:-1]
+
+    threads = None
+    if re.fullmatch(r'[0-9]+', s):
+        threads = int(s)
     else:
-        left = config
-        right = ''
-    return left, strip_matching_parens(right)
-
-def parse_hook_args(arg):
-    """
-    Parse the hook argument string into a dict of key->value.
-
-    Accepts:
-      --hook parallel_checkpoint
-      --hook parallel_checkpoint=8
-      --hook "parallel_checkpoint=(threads=8)"
-    """
-    params = {}
-
-    if not arg:
-        return params
-
-    arg = strip_matching_parens(str(arg).strip())
-    if not arg:
-        return params
-
-    if re.fullmatch(r'[0-9]+', arg):
-        params['threads'] = arg
-        return params
-
-    config_list = re.split(r",(?=(?:[^(]*[(][^)]*[)])*[^)]*$)", arg)
-    for cfg in config_list:
-        cfg = cfg.strip()
-        if not cfg:
-            continue
-        key, val = config_split(cfg)
-        if not key:
-            continue
-        params[key] = val
-
-    return params
-
-def wiredtiger_open_replace(orig_wiredtiger_open, homedir, conn_config, threads):
-    """
-    HOOK_REPLACE implementation for wiredtiger_open.
-
-    If the config already sets checkpoint_threads=..., leave it alone.
-    Otherwise append ",checkpoint_threads=<threads>".
-    """
-    if conn_config is None:
-        conn_config = ''
-
-    # Don't override tests that explicitly set checkpoint_threads.
-    if 'checkpoint_threads=' in conn_config:
-        WiredTigerTestCase.verbose(
-            None, 3,
-            'parallel_checkpoint hook: existing checkpoint_threads config found, '
-            'leaving configuration unchanged')
-        return orig_wiredtiger_open(homedir, conn_config)
-
-    extra = ',checkpoint_threads={}'.format(threads)
-    new_config = conn_config + extra
-
-    WiredTigerTestCase.verbose(
-        None, 3,
-        'parallel_checkpoint hook: calling wiredtiger_open({}, {})'
-        .format(homedir, new_config))
-
-    return orig_wiredtiger_open(homedir, new_config)
+        m = re.fullmatch(r'threads=([0-9]+)', s)
+        if m:
+            threads = int(m.group(1))
+    if threads is None:
+        raise Exception(
+            'hook_parallel_checkpoint: invalid argument "{}"'.format(arg)
+        )
+    if threads <= 0:
+        raise Exception(
+            'hook_parallel_checkpoint: threads must be > 0, got {}'.format(threads)
+        )
+    return threads
 
 class ParallelCheckpointHookCreator(wthooks.WiredTigerHookCreator):
     def __init__(self, arg=0):
-        # Default to 4 parallel checkpoint threads
-        self.threads = 4
-
-        params = parse_hook_args(arg)
-        if 'threads' in params:
-            try:
-                self.threads = int(params['threads'])
-            except ValueError:
-                raise Exception(
-                    'hook_parallel_checkpoint: invalid threads value "{}"'
-                    .format(params['threads']))
-        # Reject unknown parameters
-        for key in params:
-            if key != 'threads':
-                raise Exception(
-                    'hook_parallel_checkpoint: unknown parameter "{}"'
-                    .format(key))
-
+        self.threads = _parse_threads(arg)
         self.platform_api = wthooks.DefaultPlatformAPI()
 
     def get_platform_api(self):
         return self.platform_api
 
     def register_skipped_tests(self, tests):
-        # No tests skipped; add entries here if needed
         pass
 
     def setup_hooks(self):
-        # Replace wiredtiger_open with a wrapper that appends checkpoint_threads
-        orig_wiredtiger_open = self.wiredtiger['wiredtiger_open']
+        threads = self.threads
 
-        self.wiredtiger['wiredtiger_open'] = (
-            wthooks.HOOK_REPLACE,
-            lambda homedir, config=None:
-                wiredtiger_open_replace(orig_wiredtiger_open, homedir, config, self.threads)
-        )
+        def wiredtiger_open_args(ignored_self, args):
+            args = list(args)
+            config = args[1] if len(args) >= 2 else ''
+            if config is None:
+                config = ''
+            if 'checkpoint_threads=' in config:
+                return args
+            if len(args) >= 2:
+                args[1] = config + ',checkpoint_threads={}'.format(threads)
+            else:
+                args.append(',checkpoint_threads={}'.format(threads))
+            return args
+
+        self.wiredtiger['wiredtiger_open'] = (wthooks.HOOK_ARGS, wiredtiger_open_args)
 
 def initialize(arg):
     return [ParallelCheckpointHookCreator(arg)]

--- a/test/suite/hook_parallel_checkpoint.py
+++ b/test/suite/hook_parallel_checkpoint.py
@@ -159,7 +159,7 @@ class ParallelCheckpointHookCreator(wthooks.WiredTigerHookCreator):
 
         self.wiredtiger['wiredtiger_open'] = (
             wthooks.HOOK_REPLACE,
-            lambda homedir, config:
+            lambda homedir, config=None:
                 wiredtiger_open_replace(orig_wiredtiger_open, homedir, config, self.threads)
         )
 

--- a/test/suite/hook_parallel_checkpoint.py
+++ b/test/suite/hook_parallel_checkpoint.py
@@ -74,7 +74,7 @@ def _parse_threads(arg):
     return threads
 
 class ParallelCheckpointHookCreator(wthooks.WiredTigerHookCreator):
-    def __init__(self, arg=0):
+    def __init__(self, arg=None):
         self.threads = _parse_threads(arg)
         self.platform_api = wthooks.DefaultPlatformAPI()
 


### PR DESCRIPTION
This adds a hook for running all the unit tests and tsan tests with parallel checkpoints.

[Evergreen patch build](https://spruce.corp.mongodb.com/version/69dc7957f971330007ce366b/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)