### PR TITLE
WT-17163 Remove silent from doc-update

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -690,19 +690,6 @@ functions:
             fi
 
           done
-    - command: shell.exec
-      type: setup
-      params:
-        shell: bash
-        silent: true
-        script: |
-          set -o errexit
-
-          # We could have exited the previous command for the same reason.
-          if [[ "${branch_name}" != "develop" ]]; then
-            echo "We only run the documentation update task on the WiredTiger (develop) Evergreen project."
-            exit 0
-          fi
 
           # Push the above-generated commit
           ${PREPARE_PATH}


### PR DESCRIPTION
That's is a pre work ticket for [WT-16969](https://jira.mongodb.org/browse/WT-16969). We cannot see what is the issue that cause doc-update to fail since we have the `silent: true` setting for this job. This setting disables logging and that was done to avoid exposing GITHUB_APP_ID and  GITHUB_APP_PRIVATE_KEY that we set there to evergreen logs.

However since then it seems like project variables like this started to be automatically redacted by evergreen, so it should be fine to turn the logic on that should help us to better understand the root cause for [WT-16969](https://jira.mongodb.org/browse/WT-16969).