### PR TITLE
WT-17166 Exclude checkpoint_threads from the base config (to allow downgrade)

### DIFF
--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -2701,6 +2701,7 @@ __conn_write_base_config(WT_SESSION_IMPL *session, const char *cfg[])
      * now, and merge the rest to be written.
      */
     WT_ERR(__wt_config_merge(session, cfg + 1,
+      "checkpoint_threads=,"
       "compatibility=(release=),"
       "config_base=,"
       "create=,"


### PR DESCRIPTION
Strip the new checkpoint_threads config parameter from the base config, since it does not affect the on-disk state, and so that the database can be safely downgraded.