### PR TITLE
WT-17164 Add diagnostic assert in __hazard_check_callback

### DIFF
--- a/src/session/session_helper.c
+++ b/src/session/session_helper.c
@@ -58,7 +58,6 @@ __wt_session_array_walk(WT_SESSION_IMPL *session,
         if (skip_internal && F_ISSET(array_session, WT_SESSION_INTERNAL))
             continue;
 
-        WT_ASSERT(session, array_session->id == i);
         WT_ASSERT(session, array_session->hazards.arr != NULL);
         WT_RET(walk_func(session, array_session, &exit_walk, cookiep));
         /* Early exit the walk if possible. */

--- a/src/session/session_helper.c
+++ b/src/session/session_helper.c
@@ -38,6 +38,8 @@ __wt_session_array_walk(WT_SESSION_IMPL *session,
      * array usage pattern in the architecture guide for more details.
      */
     WT_READ_ONCE(session_cnt, conn->session_array.cnt);
+    WT_ASSERT(session, session_cnt <= conn->session_array.size);
+    WT_ASSERT(session, WT_CONN_SESSIONS_GET(conn) != NULL);
 
     for (i = 0, array_session = WT_CONN_SESSIONS_GET(conn); i < session_cnt; i++, array_session++) {
         /*
@@ -56,6 +58,8 @@ __wt_session_array_walk(WT_SESSION_IMPL *session,
         if (skip_internal && F_ISSET(array_session, WT_SESSION_INTERNAL))
             continue;
 
+        WT_ASSERT(session, array_session->id == i);
+        WT_ASSERT(session, array_session->hazards.arr != NULL);
         WT_RET(walk_func(session, array_session, &exit_walk, cookiep));
         /* Early exit the walk if possible. */
         if (exit_walk)

--- a/src/support/hazard.c
+++ b/src/support/hazard.c
@@ -318,6 +318,7 @@ __hazard_check_callback(
     }
 
     WT_ASSERT(session, hazard_inuse == 0 || *(uint8_t *)cookie->ret_hp != WT_DEBUG_BYTE);
+    WT_ASSERT(session, hazard_inuse <= array_session->hazards.size);
     for (i = 0; i < hazard_inuse; ++cookie->ret_hp, ++i) {
         ++cookie->walk_cnt;
         if (cookie->ret_hp->ref == cookie->search_ref) {

--- a/src/support/hazard.c
+++ b/src/support/hazard.c
@@ -317,6 +317,7 @@ __hazard_check_callback(
         WT_STAT_CONN_SET(session, cache_hazard_max, cookie->max);
     }
 
+    WT_ASSERT(session, hazard_inuse == 0 || *(uint8_t *)cookie->ret_hp != WT_DEBUG_BYTE);
     for (i = 0; i < hazard_inuse; ++cookie->ret_hp, ++i) {
         ++cookie->walk_cnt;
         if (cookie->ret_hp->ref == cookie->search_ref) {


### PR DESCRIPTION
This PR is to add a diagnostic assert so we can identify if we have use-after-free bug for `session->hazards.arr->ref`. There's another failure showing the issue may come from the caller `__wt_session_array_walk`, so I also added some more diagnostic asserts in that function.