### PR TITLE
WT-16455 Fix verbose config being overwritten by the disagg hook in test_txn06

### DIFF
--- a/test/suite/hook_disagg.py
+++ b/test/suite/hook_disagg.py
@@ -106,7 +106,22 @@ def wiredtiger_open_replace(orig_wiredtiger_open, homedir, conn_config):
             raise RuntimeError(key_provider_extension[0] + ' key provider extension not found')
 
     WiredTigerTestCase.verbose(None, 3, f'role={disagg_parameters.role}')
-    disagg_config = ',verbose=[layered]' \
+
+    # Merge verbose=[layered] with any existing verbose settings in conn_config.
+    # WiredTiger's config parser takes the last occurrence of a duplicate key in a single
+    # config string, so naively appending ',verbose=[layered]' would override any verbose
+    # categories the test already set.
+    # Instead, inject 'layered' into the existing list, or add a fresh verbose=[layered].
+    verbose_re = re.compile(r'verbose=\[([^\]]*)\]')
+    verbose_match = verbose_re.search(conn_config)
+    if verbose_match:
+        existing_verbose = verbose_match.group(1)
+        conn_config = verbose_re.sub(f'verbose=[{existing_verbose},layered]', conn_config, count=1)
+        disagg_verbose_config = ''
+    else:
+        disagg_verbose_config = ',verbose=[layered]'
+
+    disagg_config = disagg_verbose_config \
         + f',disaggregated=(role="{disagg_parameters.role}"' \
         + f',page_log={page_log_name})'
 

--- a/test/suite/test_txn06.py
+++ b/test/suite/test_txn06.py
@@ -65,3 +65,6 @@ class test_txn06(wttest.WiredTigerTestCase, suite_subprocess):
 
         # We were trying to generate a message matching this pattern.
         self.captureout.checkAdditionalPattern(self, "pinned in session")
+        # The eviction server may continue emitting these messages after the assertion;
+        # ignore any trailing occurrences so teardown does not flag them as unexpected.
+        self.ignoreStdoutPattern("pinned in session")

--- a/test/suite/test_txn06.py
+++ b/test/suite/test_txn06.py
@@ -34,8 +34,6 @@ from wtdataset import SimpleDataSet
 import wttest
 from wtscenario import make_scenarios
 
-# FIXME-WT-16455: Re-enable once disaggregated storage works with long-running snapshots.
-@wttest.skip_for_hook("disagg", "Fails with disaggregated storage.")
 class test_txn06(wttest.WiredTigerTestCase, suite_subprocess):
     conn_config = 'verbose=[transaction]'
     tablename = 'test_txn06'


### PR DESCRIPTION
wiredtiger_open_replace in hook_disagg.py appended ,verbose=[layered] to the connection config string. WiredTiger's config parser takes the last occurrence of a duplicate key, so this silently overrode any verbose=[...] the test had set (e.g. verbose=[transaction]), causing test_txn06 to fail when its expected verbose output was never produced.

Fix: when the incoming conn_config already contains a verbose=[...] setting, inject layered into the existing list instead of appending a duplicate key. Also removes the skip_for_hook workaround from test_txn06.