### PR TITLE
WT-16970 Fix bug for enabling prefetch in open_session

### DIFF
--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -480,16 +480,11 @@ __session_config_prefetch(WT_SESSION_IMPL *session, WT_CONF *conf)
 {
     WT_CONFIG_ITEM cval;
 
-    if (S2C(session)->prefetch_auto_on)
-        F_SET(session, WT_SESSION_PREFETCH_ENABLED);
-    else
-        F_CLR(session, WT_SESSION_PREFETCH_ENABLED);
-
     /*
      * Override any connection-level pre-fetch settings if a specific session-level setting was
      * provided.
      */
-    if (__wt_conf_gets(session, conf, Prefetch.enabled, &cval) == 0) {
+    if (__wt_conf_getones(session, conf, Prefetch.enabled, &cval) == 0) {
         if (cval.val) {
             if (!S2C(session)->prefetch_available) {
                 F_CLR(session, WT_SESSION_PREFETCH_ENABLED);
@@ -2676,6 +2671,9 @@ __open_session(WT_CONNECTION_IMPL *conn, WT_EVENT_HANDLER *event_handler, const 
     /* Set the default value for session flags. */
     if (F_ISSET(conn, WT_CONN_CACHE_CURSORS))
         F_SET(session_ret, WT_SESSION_CACHE_CURSORS);
+
+    if (conn->prefetch_auto_on)
+        F_SET(session_ret, WT_SESSION_PREFETCH_ENABLED);
 
     /*
      * Configuration: currently, the configuration for open_session is the same as

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -2674,6 +2674,8 @@ __open_session(WT_CONNECTION_IMPL *conn, WT_EVENT_HANDLER *event_handler, const 
 
     if (conn->prefetch_auto_on)
         F_SET(session_ret, WT_SESSION_PREFETCH_ENABLED);
+    else
+        F_CLR(session_ret, WT_SESSION_PREFETCH_ENABLED);
 
     /*
      * Configuration: currently, the configuration for open_session is the same as

--- a/test/suite/test_prefetch01.py
+++ b/test/suite/test_prefetch01.py
@@ -42,8 +42,8 @@ class test_prefetch01(wttest.WiredTigerTestCase):
     ]
 
     conn_default = [
-        ('default-off', dict(default=True)),
-        ('default-on', dict(default=False)),
+        ('default-off', dict(default=False)),
+        ('default-on', dict(default=True)),
     ]
 
     session_cfg = [

--- a/test/suite/test_prefetch02.py
+++ b/test/suite/test_prefetch02.py
@@ -48,7 +48,7 @@ class test_prefetch02(wttest.WiredTigerTestCase, suite_subprocess):
     ]
 
     value_format = 'i'
-    
+
     stats_cfg = 'statistics=(all),cache_size=2GB'
 
     config_options = [

--- a/test/suite/test_prefetch02.py
+++ b/test/suite/test_prefetch02.py
@@ -56,6 +56,8 @@ class test_prefetch02(wttest.WiredTigerTestCase, suite_subprocess):
                             session_cfg='prefetch=(enabled=true)', prefetch=True)),
         ('config_c', dict(conn_cfg='prefetch=(available=false,default=false),statistics=(all),cache_size=2GB',
                             session_cfg='', prefetch=False)),
+        ('config_d', dict(conn_cfg='prefetch=(available=true,default=true),statistics=(all),cache_size=2GB',
+                            session_cfg=None, prefetch=True)),
     ]
 
     prefetch_scenarios = [
@@ -86,6 +88,11 @@ class test_prefetch02(wttest.WiredTigerTestCase, suite_subprocess):
     def check_prefetching_activity(self, session_name, pages_queued, prefetch_attempts, prefetch_pages_read):
         new_pages_queued, new_prefetch_attempts, new_prefetch_pages_read = self.get_prefetch_activity_stats(session_name)
 
+        # Sanity check that the statistics aren't 0.
+        self.assertGreater(new_pages_queued, 0)
+        self.assertGreater(new_prefetch_attempts, 0)
+        self.assertGreater(new_prefetch_pages_read, 0)
+
         # FIXME-WT-12193 Change some of these statistic checks to use assertGreaterEqual instead if possible.
         self.assertGreaterEqual(new_pages_queued, pages_queued)
         self.assertGreaterEqual(new_prefetch_attempts, prefetch_attempts)
@@ -105,8 +112,8 @@ class test_prefetch02(wttest.WiredTigerTestCase, suite_subprocess):
         os.mkdir(self.new_dir)
         helper.copy_wiredtiger_home(self, '.', self.new_dir)
 
-        new_conn = self.wiredtiger_open(self.new_dir, self.conn_cfg)
-        s = new_conn.open_session(self.session_cfg)
+        setup_conn = self.wiredtiger_open(self.new_dir, self.conn_cfg)
+        s = setup_conn.open_session(self.session_cfg)
         s.create(self.uri, 'allocation_size=512,leaf_page_max=512,'
                         'key_format={},value_format={}'.format(self.key_format, self.value_format))
         c1 = s.open_cursor(self.uri)
@@ -116,6 +123,11 @@ class test_prefetch02(wttest.WiredTigerTestCase, suite_subprocess):
         c1.close()
         s.commit_transaction()
         s.checkpoint()
+
+        setup_conn.close()
+
+        new_conn = self.wiredtiger_open(self.new_dir, self.conn_cfg)
+        s = new_conn.open_session(self.session_cfg)
 
         if self.scenario_type == 'traversal':
             c2 = s.open_cursor(self.uri)

--- a/test/suite/test_prefetch02.py
+++ b/test/suite/test_prefetch02.py
@@ -48,15 +48,17 @@ class test_prefetch02(wttest.WiredTigerTestCase, suite_subprocess):
     ]
 
     value_format = 'i'
+    
+    stats_cfg = 'statistics=(all),cache_size=2GB'
 
     config_options = [
-        ('config_a', dict(conn_cfg='prefetch=(available=true,default=true),statistics=(all),cache_size=2GB',
+        ('conn_default_on', dict(conn_cfg=f'prefetch=(available=true,default=true),{self.stats_cfg}',
                             session_cfg='', prefetch=True)),
-        ('config_b', dict(conn_cfg='prefetch=(available=true,default=false),statistics=(all),cache_size=2GB',
+        ('session_cfg', dict(conn_cfg=f'prefetch=(available=true,default=false),{self.stats_cfg}',
                             session_cfg='prefetch=(enabled=true)', prefetch=True)),
-        ('config_c', dict(conn_cfg='prefetch=(available=false,default=false),statistics=(all),cache_size=2GB',
+        ('prefetch_unavailable', dict(conn_cfg=f'prefetch=(available=false,default=false),{self.stats_cfg}',
                             session_cfg='', prefetch=False)),
-        ('config_d', dict(conn_cfg='prefetch=(available=true,default=true),statistics=(all),cache_size=2GB',
+        ('conn_default_on_null_session_cfg', dict(conn_cfg=f'prefetch=(available=true,default=true),{self.stats_cfg}',
                             session_cfg=None, prefetch=True)),
     ]
 
@@ -124,8 +126,9 @@ class test_prefetch02(wttest.WiredTigerTestCase, suite_subprocess):
         s.commit_transaction()
         s.checkpoint()
 
+        # Close and reopen the connection to evict all cached pages, so the subsequent
+        # traversal reads from disk and triggers pre-fetching rather than serving from cache.
         setup_conn.close()
-
         new_conn = self.wiredtiger_open(self.new_dir, self.conn_cfg)
         s = new_conn.open_session(self.session_cfg)
 

--- a/test/suite/test_prefetch02.py
+++ b/test/suite/test_prefetch02.py
@@ -52,13 +52,13 @@ class test_prefetch02(wttest.WiredTigerTestCase, suite_subprocess):
     conn_base_cfg = 'statistics=(all),cache_size=2GB,'
 
     config_options = [
-        ('conn_default_on', dict(prefetch_cfg=f'prefetch=(available=true,default=true)',
+        ('conn_default_on', dict(prefetch_cfg='prefetch=(available=true,default=true)',
                             session_cfg='', prefetch=True)),
-        ('session_cfg', dict(prefetch_cfg=f'prefetch=(available=true,default=false)',
+        ('session_cfg', dict(prefetch_cfg='prefetch=(available=true,default=false)',
                             session_cfg='prefetch=(enabled=true)', prefetch=True)),
-        ('prefetch_unavailable', dict(prefetch_cfg=f'prefetch=(available=false,default=false)',
+        ('prefetch_unavailable', dict(prefetch_cfg='prefetch=(available=false,default=false)',
                             session_cfg='', prefetch=False)),
-        ('conn_default_on_null_session_cfg', dict(prefetch_cfg=f'prefetch=(available=true,default=true)',
+        ('conn_default_on_null_session_cfg', dict(prefetch_cfg='prefetch=(available=true,default=true)',
                             session_cfg=None, prefetch=True)),
     ]
 

--- a/test/suite/test_prefetch02.py
+++ b/test/suite/test_prefetch02.py
@@ -52,13 +52,13 @@ class test_prefetch02(wttest.WiredTigerTestCase, suite_subprocess):
     stats_cfg = 'statistics=(all),cache_size=2GB'
 
     config_options = [
-        ('conn_default_on', dict(conn_cfg=f'prefetch=(available=true,default=true),{self.stats_cfg}',
+        ('conn_default_on', dict(conn_cfg=f'prefetch=(available=true,default=true),{stats_cfg}',
                             session_cfg='', prefetch=True)),
-        ('session_cfg', dict(conn_cfg=f'prefetch=(available=true,default=false),{self.stats_cfg}',
+        ('session_cfg', dict(conn_cfg=f'prefetch=(available=true,default=false),{stats_cfg}',
                             session_cfg='prefetch=(enabled=true)', prefetch=True)),
-        ('prefetch_unavailable', dict(conn_cfg=f'prefetch=(available=false,default=false),{self.stats_cfg}',
+        ('prefetch_unavailable', dict(conn_cfg=f'prefetch=(available=false,default=false),{stats_cfg}',
                             session_cfg='', prefetch=False)),
-        ('conn_default_on_null_session_cfg', dict(conn_cfg=f'prefetch=(available=true,default=true),{self.stats_cfg}',
+        ('conn_default_on_null_session_cfg', dict(conn_cfg=f'prefetch=(available=true,default=true),{stats_cfg}',
                             session_cfg=None, prefetch=True)),
     ]
 

--- a/test/suite/test_prefetch02.py
+++ b/test/suite/test_prefetch02.py
@@ -49,16 +49,16 @@ class test_prefetch02(wttest.WiredTigerTestCase, suite_subprocess):
 
     value_format = 'i'
 
-    stats_cfg = 'statistics=(all),cache_size=2GB'
+    conn_base_cfg = 'statistics=(all),cache_size=2GB,'
 
     config_options = [
-        ('conn_default_on', dict(conn_cfg=f'prefetch=(available=true,default=true),{stats_cfg}',
+        ('conn_default_on', dict(prefetch_cfg=f'prefetch=(available=true,default=true)',
                             session_cfg='', prefetch=True)),
-        ('session_cfg', dict(conn_cfg=f'prefetch=(available=true,default=false),{stats_cfg}',
+        ('session_cfg', dict(prefetch_cfg=f'prefetch=(available=true,default=false)',
                             session_cfg='prefetch=(enabled=true)', prefetch=True)),
-        ('prefetch_unavailable', dict(conn_cfg=f'prefetch=(available=false,default=false),{stats_cfg}',
+        ('prefetch_unavailable', dict(prefetch_cfg=f'prefetch=(available=false,default=false)',
                             session_cfg='', prefetch=False)),
-        ('conn_default_on_null_session_cfg', dict(conn_cfg=f'prefetch=(available=true,default=true),{stats_cfg}',
+        ('conn_default_on_null_session_cfg', dict(prefetch_cfg=f'prefetch=(available=true,default=true)',
                             session_cfg=None, prefetch=True)),
     ]
 
@@ -69,6 +69,9 @@ class test_prefetch02(wttest.WiredTigerTestCase, suite_subprocess):
     ]
 
     scenarios = make_scenarios(format_values, config_options, prefetch_scenarios)
+
+    def conn_cfg(self):
+        return self.conn_base_cfg + self.prefetch_cfg
 
     def get_stat(self, stat, session_name):
         stat_cursor = session_name.open_cursor('statistics:')
@@ -114,7 +117,7 @@ class test_prefetch02(wttest.WiredTigerTestCase, suite_subprocess):
         os.mkdir(self.new_dir)
         helper.copy_wiredtiger_home(self, '.', self.new_dir)
 
-        setup_conn = self.wiredtiger_open(self.new_dir, self.conn_cfg)
+        setup_conn = self.wiredtiger_open(self.new_dir, self.conn_cfg())
         s = setup_conn.open_session(self.session_cfg)
         s.create(self.uri, 'allocation_size=512,leaf_page_max=512,'
                         'key_format={},value_format={}'.format(self.key_format, self.value_format))
@@ -129,7 +132,7 @@ class test_prefetch02(wttest.WiredTigerTestCase, suite_subprocess):
         # Close and reopen the connection to evict all cached pages, so the subsequent
         # traversal reads from disk and triggers pre-fetching rather than serving from cache.
         setup_conn.close()
-        new_conn = self.wiredtiger_open(self.new_dir, self.conn_cfg)
+        new_conn = self.wiredtiger_open(self.new_dir, self.conn_cfg())
         s = new_conn.open_session(self.session_cfg)
 
         if self.scenario_type == 'traversal':

--- a/test/suite/test_prefetch02.py
+++ b/test/suite/test_prefetch02.py
@@ -93,11 +93,6 @@ class test_prefetch02(wttest.WiredTigerTestCase, suite_subprocess):
     def check_prefetching_activity(self, session_name, pages_queued, prefetch_attempts, prefetch_pages_read):
         new_pages_queued, new_prefetch_attempts, new_prefetch_pages_read = self.get_prefetch_activity_stats(session_name)
 
-        # Sanity check that the statistics aren't 0.
-        self.assertGreater(new_pages_queued, 0)
-        self.assertGreater(new_prefetch_attempts, 0)
-        self.assertGreater(new_prefetch_pages_read, 0)
-
         # FIXME-WT-12193 Change some of these statistic checks to use assertGreaterEqual instead if possible.
         self.assertGreaterEqual(new_pages_queued, pages_queued)
         self.assertGreaterEqual(new_prefetch_attempts, prefetch_attempts)

--- a/test/suite/test_prefetch02.py
+++ b/test/suite/test_prefetch02.py
@@ -93,7 +93,7 @@ class test_prefetch02(wttest.WiredTigerTestCase, suite_subprocess):
     def check_prefetching_activity(self, session_name, pages_queued, prefetch_attempts, prefetch_pages_read):
         new_pages_queued, new_prefetch_attempts, new_prefetch_pages_read = self.get_prefetch_activity_stats(session_name)
 
-        # FIXME-WT-12193 Change some of these statistic checks to use assertGreaterEqual instead if possible.
+        # FIXME-WT-12193 Change some of these statistic checks to use assertGreater instead if possible.
         self.assertGreaterEqual(new_pages_queued, pages_queued)
         self.assertGreaterEqual(new_prefetch_attempts, prefetch_attempts)
         self.assertGreaterEqual(new_prefetch_pages_read, prefetch_pages_read)


### PR DESCRIPTION
Added check before __session_reconfigure to use default prefetch conn configuration in case session config == NULL.
Changed __session_config_prefetch to only parse user specified config string (not auto compiled string) when overriding the default prefetch conn configuration.


Added test case to test_prefetch04.py to test for a NULL session config.

~~Adjusted test_prefetch04.py to check that any prefetching was actually done.~~ (Removed in [f26932a](https://github.com/wiredtiger/wiredtiger/pull/13531/commits/f26932a24431bfc84fbef197ef04ed5684a9ac76) as prefetch is opportunistic, and won't always happen even when enabled) 