### PR TITLE
WT-16798 (Follower mode) Add test that validate sweep server can't sweep layered dhandles that still hold truncate state

### DIFF
--- a/src/schema/schema_list.c
+++ b/src/schema/schema_list.c
@@ -237,12 +237,7 @@ __wt_schema_close_layered(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered)
     /* Remove the ingest handle from layered table manager list */
     __wt_layered_table_manager_remove_table(session, layered->ingest_btree_id);
 
-    /*
-     * Clear truncate list.
-     *
-     * FIXME-WT-16798: In follower mode, layered dhandles with active truncates should not be
-     * removed.
-     */
+    /* Clear truncate list. */
     __wt_layered_table_truncate_clear(session, layered);
     __wt_rwlock_destroy(session, &layered->truncate_lock);
 

--- a/test/suite/test_layered80.py
+++ b/test/suite/test_layered80.py
@@ -62,7 +62,8 @@ class test_layered80(wttest.WiredTigerTestCase):
             stat_cursor = self.session.open_cursor('statistics:', None, None)
             sweeps = stat_cursor[stat.conn.dh_sweeps][2]
             stat_cursor.close()
-            if sweeps - baseline >= 2:
+            # Sweep server only closes after the handle goes through multiple phases.
+            if sweeps - baseline >= 3:
                 return
             time.sleep(1)
         self.assertTrue(False, 'sweep server did not run within 120s')
@@ -92,6 +93,7 @@ class test_layered80(wttest.WiredTigerTestCase):
         # to skip layered dhandles, it would mark and close them, causing gaps when
         # draining the ingest table at step-up.
         self.wait_for_sweep()
+        #time.sleep(30)
 
         # Step up to leader.
         self.conn.reconfigure('disaggregated=(role="leader")')

--- a/test/suite/test_layered80.py
+++ b/test/suite/test_layered80.py
@@ -30,6 +30,9 @@
 # Test that the sweep server does not close ingest table dhandles and layered dhandles on a follower
 # or during step-up. Closing the ingest dhandle discards all in-memory data for
 # that table (WT-16974, WT-16703).
+# Also tests that the sweep server does not close a layered dhandle that has pending follower
+# truncate state (entries in its in-memory truncate list), as doing so would discard the truncate
+# entries and corrupt visibility (WT-16798).
 
 import time, wttest, wiredtiger
 from helper_disagg import disagg_test_class, gen_disagg_storages
@@ -90,5 +93,57 @@ class test_layered80(wttest.WiredTigerTestCase):
         cursor.close()
         self.assertEqual(wiredtiger.WT_NOTFOUND, ret)
         self.assertEqual(count, self.nrows)
+
+        self.ignoreStdoutPattern('WT_VERB_SWEEP')
+
+    def test_layered_dhandle_not_swept_with_truncate_state(self):
+        """
+        Verify that the sweep server does not close the layered dhandle while it holds
+        pending follower truncate state (entries in its in-memory truncate list).
+        If the dhandle were closed during this window, the truncate entries are
+        discarded.
+        """
+        if wiredtiger.disagg_fast_truncate_build() == 0:
+            self.skipTest("fast truncate support is not enabled.")
+
+        self.session.create(self.uri, 'key_format=i,value_format=S')
+
+        # Write data as follower with timestamps.
+        self.session.begin_transaction()
+        cursor = self.session.open_cursor(self.uri)
+        for i in range(self.nrows):
+            cursor[i] = 'value' + str(i)
+        cursor.close()
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(self.nrows))
+
+        # Begin a truncate transaction. On follower, this inserts an entry into the
+        # layered dhandle's in-memory truncate list — state that must not be swept away.
+        c_start = self.session.open_cursor(self.uri)
+        c_start.set_key(100)
+        c_stop = self.session.open_cursor(self.uri)
+        c_stop.set_key(700)
+
+        self.session.begin_transaction()
+        self.session.truncate(None, c_start, c_stop, None)
+
+        # Give the aggressive sweep server time to run several cycles.
+        # If the layered dhandle is incorrectly swept while the truncate entry lives
+        # in its truncate list, the commit below will fail or the truncated range
+        # will reappear.
+        time.sleep(3)
+
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(self.nrows + 1))
+        c_start.close()
+        c_stop.close()
+
+        # Verify the truncate still exists: rows 100-700 should be gone.
+        cursor = self.session.open_cursor(self.uri)
+        count = 0
+        while (ret := cursor.next()) == 0:
+            count += 1
+        cursor.close()
+        self.assertEqual(wiredtiger.WT_NOTFOUND, ret)
+        # rows 0-99 = 100 rows, rows 701-999 = 299 rows
+        self.assertEqual(count, 100 + (self.nrows - 701))
 
         self.ignoreStdoutPattern('WT_VERB_SWEEP')

--- a/test/suite/test_layered80.py
+++ b/test/suite/test_layered80.py
@@ -93,7 +93,6 @@ class test_layered80(wttest.WiredTigerTestCase):
         # to skip layered dhandles, it would mark and close them, causing gaps when
         # draining the ingest table at step-up.
         self.wait_for_sweep()
-        #time.sleep(30)
 
         # Step up to leader.
         self.conn.reconfigure('disaggregated=(role="leader")')

--- a/test/suite/test_layered80.py
+++ b/test/suite/test_layered80.py
@@ -36,6 +36,7 @@
 
 import time, wttest, wiredtiger
 from helper_disagg import disagg_test_class, gen_disagg_storages
+from wiredtiger import stat
 from wtscenario import make_scenarios
 
 @disagg_test_class
@@ -52,6 +53,19 @@ class test_layered80(wttest.WiredTigerTestCase):
 
     disagg_storages = gen_disagg_storages('test_layered80', disagg_only=True)
     scenarios = make_scenarios(disagg_storages)
+
+    def wait_for_sweep(self):
+        stat_cursor = self.session.open_cursor('statistics:', None, None)
+        baseline = stat_cursor[stat.conn.dh_sweeps][2]
+        stat_cursor.close()
+        for _ in range(120):
+            stat_cursor = self.session.open_cursor('statistics:', None, None)
+            sweeps = stat_cursor[stat.conn.dh_sweeps][2]
+            stat_cursor.close()
+            if sweeps - baseline >= 2:
+                return
+            time.sleep(1)
+        self.assertTrue(False, 'sweep server did not run within 120s')
 
     def test_layered_dhandle_not_swept_during_stepup(self):
         """
@@ -74,11 +88,10 @@ class test_layered80(wttest.WiredTigerTestCase):
         # Pin the ingest table dhandle, so it doesn't get swept away on purpose.
         cursor = self.session.open_cursor("file:test_layered80.wt_ingest")
 
-        # Give the aggressive sweep server time to run several cycles.
-        # If the sweep server is not configured to skip layered dhandles,
-        # it would mark and close them, causing gaps when draining the
-        # ingest table at step-up.
-        time.sleep(3)
+        # Wait for the sweep server to run several cycles. If it is not configured
+        # to skip layered dhandles, it would mark and close them, causing gaps when
+        # draining the ingest table at step-up.
+        self.wait_for_sweep()
 
         # Step up to leader.
         self.conn.reconfigure('disaggregated=(role="leader")')
@@ -125,14 +138,13 @@ class test_layered80(wttest.WiredTigerTestCase):
 
         self.session.begin_transaction()
         self.session.truncate(None, c_start, c_stop, None)
-
-        # Give the aggressive sweep server time to run several cycles.
-        # If the layered dhandle is incorrectly swept while the truncate entry lives
-        # in its truncate list, the commit below will fail or the truncated range
-        # will reappear.
-        time.sleep(3)
-
         self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(self.nrows + 1))
+
+        # Wait for the sweep server to run several cycles. If the layered dhandle is
+        # incorrectly swept while the truncate entry lives in its truncate list,
+        # the truncated range will go missing.
+        self.wait_for_sweep()
+
         c_start.close()
         c_stop.close()
 

--- a/test/suite/test_layered80.py
+++ b/test/suite/test_layered80.py
@@ -117,7 +117,7 @@ class test_layered80(wttest.WiredTigerTestCase):
         self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(self.nrows))
 
         # Begin a truncate transaction. On follower, this inserts an entry into the
-        # layered dhandle's in-memory truncate list — state that must not be swept away.
+        # layered dhandle's in-memory truncate list  state that must not be swept away.
         c_start = self.session.open_cursor(self.uri)
         c_start.set_key(100)
         c_stop = self.session.open_cursor(self.uri)


### PR DESCRIPTION
Found through WT-16974, the WiredTiger sweep server can't sweep (close/evict) layered dhandles. I have added a scenario that validates that the sweep server can't drop the layered dhandle.

