### PR TITLE
WT-15430 Validate behaviour for layered fast truncates (leader mode)

### DIFF
--- a/test/suite/test_checkpoint34.py
+++ b/test/suite/test_checkpoint34.py
@@ -29,14 +29,12 @@
 import wttest
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
-from wiredtiger import stat
+from wiredtiger import disagg_fast_truncate_build, stat
 from helper import simulate_crash_restart
 
 # test_checkpoint34.py
 #
 # Test precise checkpoint with fast truncate
-# FIXME-WT-15430: Re-enable once disaggregated storage works with fast truncate tests.
-@wttest.skip_for_hook("disagg", "FIXME-WT-15430: fast truncate is not supported for disagg yet")
 @wttest.skip_for_hook("tiered", "fast truncate is not supported for tiered yet")
 class test_checkpoint34(wttest.WiredTigerTestCase):
 
@@ -48,6 +46,11 @@ class test_checkpoint34(wttest.WiredTigerTestCase):
     conn_config = "precise_checkpoint=true"
 
     scenarios = make_scenarios(format_values)
+
+    def setUp(self):
+        if self.runningHook('disagg') and disagg_fast_truncate_build() == 0:
+            self.skipTest("fast truncate support in not enabled")
+        super().setUp()
 
     def get_fast_truncated_pages(self):
         stat_cursor = self.session.open_cursor('statistics:', None, None)

--- a/test/suite/test_checkpoint34.py
+++ b/test/suite/test_checkpoint34.py
@@ -49,7 +49,7 @@ class test_checkpoint34(wttest.WiredTigerTestCase):
 
     def setUp(self):
         if self.runningHook('disagg') and disagg_fast_truncate_build() == 0:
-            self.skipTest("fast truncate support in not enabled")
+            self.skipTest("fast truncate support is not enabled")
         super().setUp()
 
     def get_fast_truncated_pages(self):

--- a/test/suite/test_layered_fast_truncate01.py
+++ b/test/suite/test_layered_fast_truncate01.py
@@ -48,6 +48,11 @@ class test_layered_fast_truncate01(wttest.WiredTigerTestCase):
 
     nitems = 1000
 
+    def setUp(self):
+        if wiredtiger.disagg_fast_truncate_build() == 0:
+            self.skipTest("fast truncate support is not enabled.")
+        super().setUp()
+
     def session_create_config(self):
         cfg = 'key_format=S,value_format=S'
         if self.uri.startswith('table'):
@@ -55,8 +60,6 @@ class test_layered_fast_truncate01(wttest.WiredTigerTestCase):
         return cfg
 
     def test_truncate_basic(self):
-        if (wiredtiger.disagg_fast_truncate_build() == 0):
-            self.skipTest("fast truncate support is not enabled.")
         self.session.create(self.uri, self.session_create_config())
 
         cursor = self.session.open_cursor(self.uri)
@@ -110,8 +113,6 @@ class test_layered_fast_truncate01(wttest.WiredTigerTestCase):
 
 
     def test_truncate_rollback(self):
-        if (wiredtiger.disagg_fast_truncate_build() == 0):
-            self.skipTest("fast truncate support is not enabled.")
         self.session.create(self.uri, self.session_create_config())
 
         cursor = self.session.open_cursor(self.uri)
@@ -152,8 +153,6 @@ class test_layered_fast_truncate01(wttest.WiredTigerTestCase):
         c2.close()
 
     def test_truncate_write_conflict_1(self):
-        if (wiredtiger.disagg_fast_truncate_build() == 0):
-            self.skipTest("fast truncate support is not enabled.")
         self.session.create(self.uri, self.session_create_config())
 
         cursor = self.session.open_cursor(self.uri)
@@ -198,8 +197,6 @@ class test_layered_fast_truncate01(wttest.WiredTigerTestCase):
         c2.close()
 
     def test_truncate_write_conflict_2(self):
-        if (wiredtiger.disagg_fast_truncate_build() == 0):
-            self.skipTest("fast truncate support is not enabled.")
         self.session.create(self.uri, self.session_create_config())
 
         cursor = self.session.open_cursor(self.uri)

--- a/test/suite/test_truncate02.py
+++ b/test/suite/test_truncate02.py
@@ -98,7 +98,7 @@ class test_truncate_fast_delete(test_truncate_base):
 
     def setUp(self):
         if self.runningHook('disagg') and disagg_fast_truncate_build() == 0:
-            self.skipTest("fast truncate support in not enabled")
+            self.skipTest("fast truncate support is not enabled")
         super().setUp()
 
     # Return the number of records visible to the cursor; test both forward

--- a/test/suite/test_truncate02.py
+++ b/test/suite/test_truncate02.py
@@ -31,6 +31,7 @@
 #
 
 from test_truncate01 import test_truncate_base
+from wiredtiger import disagg_fast_truncate_build
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 import wttest
@@ -39,8 +40,6 @@ import wttest
 #       When deleting leaf pages that aren't in memory, we set transactional
 # information in the page's WT_REF structure, which results in interesting
 # issues.
-# FIXME-WT-15430: Re-enable once disaggregated storage works with fast truncate tests.
-@wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_truncate_fast_delete(test_truncate_base):
     name = 'test_truncate'
     nentries = 10000
@@ -50,11 +49,13 @@ class test_truncate_fast_delete(test_truncate_base):
     types = [
         ('file', dict(type='file:', config=\
             'allocation_size=512,leaf_page_max=512')),
-        # FIXME-WT-15430 Re-enable the layered table scenario once disaggregated storage works with fast truncate tests.
-        # Consider whether we need this scenario here if the scenario is already defined in the test truncate base test.
-        # ('layered', dict(type='layered:', config=\
-        #     'allocation_size=512,leaf_page_max=512'))
     ]
+
+    if 'disagg' in wttest.WiredTigerTestCase.hook_names:
+        types += [
+            ('layered', dict(type='layered:',
+             config='allocation_size=512,leaf_page_max=512')),
+        ]
 
     # This is all about testing the btree layer, not the schema layer, test
     # files and ignore tables.
@@ -94,6 +95,11 @@ class test_truncate_fast_delete(test_truncate_base):
 
     scenarios = make_scenarios(types, keyfmt, overflow, reads, writes, txn,
                                prune=20, prunelong=1000)
+
+    def setUp(self):
+        if self.runningHook('disagg') and disagg_fast_truncate_build() == 0:
+            self.skipTest("fast truncate support in not enabled")
+        super().setUp()
 
     # Return the number of records visible to the cursor; test both forward
     # and backward iteration, they are different code paths in this case.

--- a/test/suite/test_truncate05.py
+++ b/test/suite/test_truncate05.py
@@ -64,7 +64,7 @@ class test_truncate05(wttest.WiredTigerTestCase):
 
         # Reopen the connection to force all content to disk.
         self.reopen_conn()
-        self.session.create(uri, 'key_format=i,value_format=S')
+        self.session.create(uri, format + self.extraconfig)
         cursor = self.session.open_cursor(uri)
 
         # Insert a single update at a later timestamp.

--- a/test/suite/test_truncate05.py
+++ b/test/suite/test_truncate05.py
@@ -50,7 +50,7 @@ class test_truncate05(wttest.WiredTigerTestCase):
     def test_truncate_read_older_than_newest(self):
         uri = 'table:test_truncate05'
         format = 'key_format={},value_format={}'.format(self.key_format, 'S')
-        self.session.create(uri, format + self.extraconfig)
+        self.session.create(uri, format)
         cursor = self.session.open_cursor(uri)
 
         value1 = 'a' * 500
@@ -64,7 +64,7 @@ class test_truncate05(wttest.WiredTigerTestCase):
 
         # Reopen the connection to force all content to disk.
         self.reopen_conn()
-        self.session.create(uri, format + self.extraconfig)
+        self.session.create(uri, format)
         cursor = self.session.open_cursor(uri)
 
         # Insert a single update at a later timestamp.

--- a/test/suite/test_truncate05.py
+++ b/test/suite/test_truncate05.py
@@ -26,13 +26,12 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import wiredtiger, wttest
+import wttest
+from wiredtiger import disagg_fast_truncate_build, WiredTigerError
 from wtscenario import make_scenarios
 
 # test_truncate05.py
 # Test various fast truncate visibility scenarios
-# FIXME-WT-15430: Re-enable once disaggregated storage works with fast truncate tests.
-@wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_truncate05(wttest.WiredTigerTestCase):
     conn_config = 'cache_size=2MB'
 
@@ -42,6 +41,11 @@ class test_truncate05(wttest.WiredTigerTestCase):
     ]
 
     scenarios = make_scenarios(format_values)
+
+    def setUp(self):
+        if self.runningHook('disagg') and disagg_fast_truncate_build() == 0:
+            self.skipTest("fast truncate support in not enabled")
+        super().setUp()
 
     def test_truncate_read_older_than_newest(self):
         uri = 'table:test_truncate05'
@@ -86,5 +90,5 @@ class test_truncate05(wttest.WiredTigerTestCase):
 
         # Call the truncate and expect failure.
         self.assertRaisesException(
-            wiredtiger.WiredTigerError,lambda: self.session.truncate(None, start, end, None))
+            WiredTigerError,lambda: self.session.truncate(None, start, end, None))
         self.session.rollback_transaction()

--- a/test/suite/test_truncate05.py
+++ b/test/suite/test_truncate05.py
@@ -44,7 +44,7 @@ class test_truncate05(wttest.WiredTigerTestCase):
 
     def setUp(self):
         if self.runningHook('disagg') and disagg_fast_truncate_build() == 0:
-            self.skipTest("fast truncate support in not enabled")
+            self.skipTest("fast truncate support is not enabled")
         super().setUp()
 
     def test_truncate_read_older_than_newest(self):

--- a/test/suite/test_truncate08.py
+++ b/test/suite/test_truncate08.py
@@ -45,7 +45,7 @@ class test_truncate08(wttest.WiredTigerTestCase):
 
     def setUp(self):
         if self.runningHook('disagg') and disagg_fast_truncate_build() == 0:
-            self.skipTest("fast truncate support in not enabled")
+            self.skipTest("fast truncate support is not enabled")
         super().setUp()
 
     def test_truncate08(self):

--- a/test/suite/test_truncate08.py
+++ b/test/suite/test_truncate08.py
@@ -31,10 +31,10 @@
 #
 
 import wttest
+from wiredtiger import disagg_fast_truncate_build
 from wtdataset import simple_key, simple_value
 from wtscenario import make_scenarios
-# FIXME-WT-15430: Re-enable once disaggregated storage works with fast truncate tests.
-@wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
+
 class test_truncate08(wttest.WiredTigerTestCase):
     format_values = [
         ('column', dict(key_format='r')),
@@ -42,6 +42,11 @@ class test_truncate08(wttest.WiredTigerTestCase):
     ]
 
     scenarios = make_scenarios(format_values)
+
+    def setUp(self):
+        if self.runningHook('disagg') and disagg_fast_truncate_build() == 0:
+            self.skipTest("fast truncate support in not enabled")
+        super().setUp()
 
     def test_truncate08(self):
         # Create a large table with lots of pages.

--- a/test/suite/test_truncate08.py
+++ b/test/suite/test_truncate08.py
@@ -57,7 +57,7 @@ class test_truncate08(wttest.WiredTigerTestCase):
         replacement_value = "replacement_value"
 
         cursor = self.session.open_cursor(uri)
-        for i in range(1, 80000):
+        for i in range(1, 8000):
             cursor[simple_key(cursor, i)] = simple_value(cursor, i)
         cursor.close()
 
@@ -69,16 +69,16 @@ class test_truncate08(wttest.WiredTigerTestCase):
 
         # Truncate the middle chunk.
         c1 = self.session.open_cursor(uri, None)
-        c1.set_key(simple_key(c1, 10000))
+        c1.set_key(simple_key(c1, 1000))
         c2 = self.session.open_cursor(uri, None)
-        c2.set_key(simple_key(c1, 70000))
+        c2.set_key(simple_key(c1, 7000))
         self.session.truncate(None, c1, c2, None)
         c1.close()
         c2.close()
 
         # Modify a record on a fast-truncate page.
         cursor = self.session.open_cursor(uri)
-        cursor[simple_key(cursor, 40000)] = replacement_value
+        cursor[simple_key(cursor, 4000)] = replacement_value
         cursor.close()
 
         # Prepare and commit the transaction.

--- a/test/suite/test_truncate08.py
+++ b/test/suite/test_truncate08.py
@@ -57,7 +57,7 @@ class test_truncate08(wttest.WiredTigerTestCase):
         replacement_value = "replacement_value"
 
         cursor = self.session.open_cursor(uri)
-        for i in range(1, 8000):
+        for i in range(1, 80000):
             cursor[simple_key(cursor, i)] = simple_value(cursor, i)
         cursor.close()
 
@@ -69,16 +69,16 @@ class test_truncate08(wttest.WiredTigerTestCase):
 
         # Truncate the middle chunk.
         c1 = self.session.open_cursor(uri, None)
-        c1.set_key(simple_key(c1, 1000))
+        c1.set_key(simple_key(c1, 10000))
         c2 = self.session.open_cursor(uri, None)
-        c2.set_key(simple_key(c1, 7000))
+        c2.set_key(simple_key(c1, 70000))
         self.session.truncate(None, c1, c2, None)
         c1.close()
         c2.close()
 
         # Modify a record on a fast-truncate page.
         cursor = self.session.open_cursor(uri)
-        cursor[simple_key(cursor, 4000)] = replacement_value
+        cursor[simple_key(cursor, 40000)] = replacement_value
         cursor.close()
 
         # Prepare and commit the transaction.

--- a/test/suite/test_truncate09.py
+++ b/test/suite/test_truncate09.py
@@ -33,8 +33,10 @@ import wttest
 from helper import simulate_crash_restart
 from wtdataset import simple_key, simple_value
 from wtscenario import make_scenarios
-# FIXME-WT-15430: Re-enable once disaggregated storage works with fast truncate tests.
-@wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
+
+# FIXME-WT-14721: Re-enable once precise checkpoint is automatically enabled for
+# disaggregated storage.
+@wttest.skip_for_hook("disagg", "precise checkpoint not yet auto-enabled for disagg")
 class test_truncate09(wttest.WiredTigerTestCase):
     format_values = [
         ('column', dict(key_format='r')),

--- a/test/suite/test_truncate09.py
+++ b/test/suite/test_truncate09.py
@@ -34,9 +34,7 @@ from helper import simulate_crash_restart
 from wtdataset import simple_key, simple_value
 from wtscenario import make_scenarios
 
-# FIXME-WT-14721: Re-enable once precise checkpoint is automatically enabled for
-# disaggregated storage.
-@wttest.skip_for_hook("disagg", "precise checkpoint not yet auto-enabled for disagg")
+@wttest.skip_for_hook("disagg", "Disagg does not support RTS")
 class test_truncate09(wttest.WiredTigerTestCase):
     format_values = [
         ('column', dict(key_format='r')),

--- a/test/suite/test_truncate10.py
+++ b/test/suite/test_truncate10.py
@@ -68,7 +68,7 @@ class test_truncate10(wttest.WiredTigerTestCase):
 
     def setUp(self):
         if self.runningHook('disagg') and disagg_fast_truncate_build() == 0:
-            self.skipTest("fast truncate support in not enabled")
+            self.skipTest("fast truncate support is not enabled")
         super().setUp()
 
     def truncate(self, uri, make_key, keynum1, keynum2):

--- a/test/suite/test_truncate10.py
+++ b/test/suite/test_truncate10.py
@@ -27,15 +27,13 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 import wttest
-from wiredtiger import stat, WiredTigerError, wiredtiger_strerror, WT_ROLLBACK
+from wiredtiger import disagg_fast_truncate_build, stat, WiredTigerError, wiredtiger_strerror, WT_ROLLBACK
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 
 # test_truncate10.py
 #
 # Check that nothing comes unstuck if we commit a truncate with durable > commit.
-# FIXME-WT-15430: Re-enable once disaggregated storage works with fast truncate tests.
-@wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_truncate10(wttest.WiredTigerTestCase):
     conn_config = 'statistics=(all)'
     session_config = 'isolation=snapshot'
@@ -67,6 +65,11 @@ class test_truncate10(wttest.WiredTigerTestCase):
     ]
 
     scenarios = make_scenarios(trunc_values, format_values, stable_values, checkpoint_values)
+
+    def setUp(self):
+        if self.runningHook('disagg') and disagg_fast_truncate_build() == 0:
+            self.skipTest("fast truncate support in not enabled")
+        super().setUp()
 
     def truncate(self, uri, make_key, keynum1, keynum2):
         if self.trunc_with_remove:

--- a/test/suite/test_truncate11.py
+++ b/test/suite/test_truncate11.py
@@ -48,7 +48,7 @@ class test_truncate11(wttest.WiredTigerTestCase):
 
     def setUp(self):
         if self.runningHook('disagg') and disagg_fast_truncate_build() == 0:
-            self.skipTest("fast truncate support in not enabled")
+            self.skipTest("fast truncate support is not enabled")
         super().setUp()
 
     @wttest.skip_for_hook("tiered", "test depends on regular checkpoints running")

--- a/test/suite/test_truncate11.py
+++ b/test/suite/test_truncate11.py
@@ -33,10 +33,9 @@
 import threading, time, wttest
 from wtdataset import simple_key, simple_value
 from wtscenario import make_scenarios
-from wiredtiger import stat
+from wiredtiger import disagg_fast_truncate_build, stat
 from wtthread import checkpoint_thread
-# FIXME-WT-15430: Re-enable once disaggregated storage works with fast truncate tests.
-@wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
+
 class test_truncate11(wttest.WiredTigerTestCase):
     conn_config = 'cache_size=50MB,statistics=(all),statistics_log=(json,on_close,wait=1),timing_stress_for_test=[checkpoint_slow]'
 
@@ -46,6 +45,11 @@ class test_truncate11(wttest.WiredTigerTestCase):
     ]
 
     scenarios = make_scenarios(format_values)
+
+    def setUp(self):
+        if self.runningHook('disagg') and disagg_fast_truncate_build() == 0:
+            self.skipTest("fast truncate support in not enabled")
+        super().setUp()
 
     @wttest.skip_for_hook("tiered", "test depends on regular checkpoints running")
     def test_truncate11(self):

--- a/test/suite/test_truncate12.py
+++ b/test/suite/test_truncate12.py
@@ -28,7 +28,7 @@
 
 import wttest
 from helper import simulate_crash_restart
-from wiredtiger import stat, WiredTigerError, wiredtiger_strerror, WT_NOTFOUND, WT_ROLLBACK
+from wiredtiger import disagg_fast_truncate_build, stat, WiredTigerError, wiredtiger_strerror, WT_NOTFOUND, WT_ROLLBACK
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 
@@ -38,8 +38,6 @@ from wtscenario import make_scenarios
 # even if the truncate information is loaded during recovery and stays in cache.
 #
 # This version uses timestamps and no logging.
-# FIXME-WT-15430: Re-enable once disaggregated storage works with fast truncate tests.
-@wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_truncate12(wttest.WiredTigerTestCase):
     conn_config = 'statistics=(all)'
     session_config = 'isolation=snapshot'
@@ -57,6 +55,11 @@ class test_truncate12(wttest.WiredTigerTestCase):
         ('integer_row', dict(key_format='i', value_format='S', extraconfig='')),
     ]
     scenarios = make_scenarios(trunc_values, format_values)
+
+    def setUp(self):
+        if self.runningHook('disagg') and disagg_fast_truncate_build() == 0:
+            self.skipTest("fast truncate support in not enabled")
+        super().setUp()
 
     def truncate(self, uri, make_key, keynum1, keynum2):
         if self.trunc_with_remove:

--- a/test/suite/test_truncate12.py
+++ b/test/suite/test_truncate12.py
@@ -58,7 +58,7 @@ class test_truncate12(wttest.WiredTigerTestCase):
 
     def setUp(self):
         if self.runningHook('disagg') and disagg_fast_truncate_build() == 0:
-            self.skipTest("fast truncate support in not enabled")
+            self.skipTest("fast truncate support is not enabled")
         super().setUp()
 
     def truncate(self, uri, make_key, keynum1, keynum2):

--- a/test/suite/test_truncate13.py
+++ b/test/suite/test_truncate13.py
@@ -67,7 +67,7 @@ class test_truncate13(wttest.WiredTigerTestCase):
 
     def setUp(self):
         if self.runningHook('disagg') and disagg_fast_truncate_build() == 0:
-            self.skipTest("fast truncate support in not enabled")
+            self.skipTest("fast truncate support is not enabled")
         super().setUp()
 
     # Make all the values different to avoid having VLCS RLE condense the table.

--- a/test/suite/test_truncate13.py
+++ b/test/suite/test_truncate13.py
@@ -27,14 +27,12 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 import wttest
-from wiredtiger import stat
+from wiredtiger import disagg_fast_truncate_build, stat
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 
 # test_truncate13.py
 # Test reading in the gaps created by a fast-delete.
-# FIXME-WT-15430: Re-enable once disaggregated storage works with fast truncate tests.
-@wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_truncate13(wttest.WiredTigerTestCase):
     session_config = 'isolation=snapshot'
     conn_config = 'cache_size=50MB,statistics=(all),log=(enabled=false)'
@@ -66,6 +64,11 @@ class test_truncate13(wttest.WiredTigerTestCase):
         ('noadd', dict(add_data=False)),
     ]
     scenarios = make_scenarios(trunc_values, format_values, range_values, ts_values, add_values)
+
+    def setUp(self):
+        if self.runningHook('disagg') and disagg_fast_truncate_build() == 0:
+            self.skipTest("fast truncate support in not enabled")
+        super().setUp()
 
     # Make all the values different to avoid having VLCS RLE condense the table.
     def mkdata(self, basevalue, i):

--- a/test/suite/test_truncate14.py
+++ b/test/suite/test_truncate14.py
@@ -59,7 +59,7 @@ class test_truncate14(wttest.WiredTigerTestCase):
 
     def setUp(self):
         if self.runningHook('disagg') and disagg_fast_truncate_build() == 0:
-            self.skipTest("fast truncate support in not enabled")
+            self.skipTest("fast truncate support is not enabled")
         super().setUp()
 
     # Make all the values different to avoid having VLCS RLE condense the table.

--- a/test/suite/test_truncate14.py
+++ b/test/suite/test_truncate14.py
@@ -28,14 +28,12 @@
 
 import wttest
 from helper import simulate_crash_restart
-from wiredtiger import stat, WT_NOTFOUND
+from wiredtiger import disagg_fast_truncate_build, stat, WT_NOTFOUND
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 
 # test_truncate14.py
 # Generate very large namespace gaps with truncate.
-# FIXME-WT-15430: Re-enable once disaggregated storage works with fast truncate tests.
-@wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_truncate14(wttest.WiredTigerTestCase):
     session_config = 'isolation=snapshot'
     conn_config = 'cache_size=50MB,statistics=(all),log=(enabled=false)'
@@ -58,6 +56,11 @@ class test_truncate14(wttest.WiredTigerTestCase):
         ('checkpoint-visible', dict(action='checkpoint-visible')),
     ]
     scenarios = make_scenarios(trunc_values, format_values, action_values)
+
+    def setUp(self):
+        if self.runningHook('disagg') and disagg_fast_truncate_build() == 0:
+            self.skipTest("fast truncate support in not enabled")
+        super().setUp()
 
     # Make all the values different to avoid having VLCS RLE condense the table.
     def mkdata(self, basevalue, i):

--- a/test/suite/test_truncate15.py
+++ b/test/suite/test_truncate15.py
@@ -34,8 +34,8 @@ from wtscenario import make_scenarios
 # test_truncate15.py
 #
 # Check that readonly database reading fast truncated pages doesn't lead to cache stuck.
-# FIXME-WT-15430: Re-enable once disaggregated storage works with fast truncate tests.
-@wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
+# FIXME-WT-14582: Re-enable once disagg supports readonly connections.
+@wttest.skip_for_hook("disagg", "readonly connections not supported yet")
 class test_truncate15(wttest.WiredTigerTestCase):
     conn_config = 'statistics=(all)'
     session_config = 'isolation=snapshot'

--- a/test/suite/test_truncate16.py
+++ b/test/suite/test_truncate16.py
@@ -27,7 +27,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 import wttest
-from wiredtiger import stat, WiredTigerError, wiredtiger_strerror, WT_ROLLBACK
+from wiredtiger import disagg_fast_truncate_build, stat, WiredTigerError, wiredtiger_strerror, WT_ROLLBACK
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 
@@ -35,8 +35,6 @@ from wtscenario import make_scenarios
 #
 # Make sure that no shenanigans occur if we try to read from a page that's been
 # fast-truncated by a prepared transaction.
-# FIXME-WT-15430: Re-enable once disaggregated storage works with fast truncate tests.
-@wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_truncate16(wttest.WiredTigerTestCase):
     conn_config = 'statistics=(all)'
     session_config = 'isolation=snapshot'
@@ -58,6 +56,11 @@ class test_truncate16(wttest.WiredTigerTestCase):
         ('checkpoint', dict(do_checkpoint=True)),
     ]
     scenarios = make_scenarios(trunc_values, format_values, checkpoint_values)
+
+    def setUp(self):
+        if self.runningHook('disagg') and disagg_fast_truncate_build() == 0:
+            self.skipTest("fast truncate support in not enabled")
+        super().setUp()
 
     def truncate(self, session, uri, make_key, keynum1, keynum2):
         if self.trunc_with_remove:

--- a/test/suite/test_truncate16.py
+++ b/test/suite/test_truncate16.py
@@ -59,7 +59,7 @@ class test_truncate16(wttest.WiredTigerTestCase):
 
     def setUp(self):
         if self.runningHook('disagg') and disagg_fast_truncate_build() == 0:
-            self.skipTest("fast truncate support in not enabled")
+            self.skipTest("fast truncate support is not enabled")
         super().setUp()
 
     def truncate(self, session, uri, make_key, keynum1, keynum2):

--- a/test/suite/test_truncate17.py
+++ b/test/suite/test_truncate17.py
@@ -27,7 +27,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 import wttest
-from wiredtiger import stat, WiredTigerError, wiredtiger_strerror, WT_ROLLBACK
+from wiredtiger import disagg_fast_truncate_build, stat, WiredTigerError, wiredtiger_strerror, WT_ROLLBACK
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 
@@ -35,8 +35,6 @@ from wtscenario import make_scenarios
 #
 # Make sure that no shenanigans occur if we try to read from a page that's been
 # fast-truncated by a prepared transaction.
-# FIXME-WT-15430: Re-enable once disaggregated storage works with fast truncate tests.
-@wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_truncate17(wttest.WiredTigerTestCase):
     conn_config = 'statistics=(all)'
     session_config = 'isolation=snapshot'
@@ -58,6 +56,11 @@ class test_truncate17(wttest.WiredTigerTestCase):
         ('checkpoint', dict(do_checkpoint=True)),
     ]
     scenarios = make_scenarios(trunc_values, format_values, checkpoint_values)
+
+    def setUp(self):
+        if self.runningHook('disagg') and disagg_fast_truncate_build() == 0:
+            self.skipTest("fast truncate support in not enabled")
+        super().setUp()
 
     def stat_tree(self, uri):
         statscursor = self.session.open_cursor('statistics:' + uri, None, 'statistics=(all)')

--- a/test/suite/test_truncate17.py
+++ b/test/suite/test_truncate17.py
@@ -59,7 +59,7 @@ class test_truncate17(wttest.WiredTigerTestCase):
 
     def setUp(self):
         if self.runningHook('disagg') and disagg_fast_truncate_build() == 0:
-            self.skipTest("fast truncate support in not enabled")
+            self.skipTest("fast truncate support is not enabled")
         super().setUp()
 
     def stat_tree(self, uri):

--- a/test/suite/test_truncate18.py
+++ b/test/suite/test_truncate18.py
@@ -27,7 +27,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 import wttest
-from wiredtiger import stat, WiredTigerError, wiredtiger_strerror, WT_ROLLBACK
+from wiredtiger import disagg_fast_truncate_build, stat, WiredTigerError, wiredtiger_strerror, WT_ROLLBACK
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 
@@ -58,8 +58,6 @@ from wtscenario import make_scenarios
 # That currently asserts. The fix for this is likely to disable the optimization when in
 # verify, so the only real purpose of this test is to prevent the behavior from regressing.
 # It is therefore not full of scenarios but specific to this one problem.
-# FIXME-WT-15430: Re-enable once disaggregated storage works with fast truncate tests.
-@wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_truncate18(wttest.WiredTigerTestCase):
     conn_config = 'statistics=(all)'
     session_config = 'isolation=snapshot'
@@ -81,6 +79,11 @@ class test_truncate18(wttest.WiredTigerTestCase):
         ('back', dict(truncate_front=False)),
     ]
     scenarios = make_scenarios(trunc_values, format_values, trunc_range_values)
+
+    def setUp(self):
+        if self.runningHook('disagg') and disagg_fast_truncate_build() == 0:
+            self.skipTest("fast truncate support in not enabled")
+        super().setUp()
 
     # Truncate, from keynum1 to keynum2, inclusive.
     def truncate(self, uri, make_key, keynum1, keynum2, read_ts, commit_ts):

--- a/test/suite/test_truncate18.py
+++ b/test/suite/test_truncate18.py
@@ -82,7 +82,7 @@ class test_truncate18(wttest.WiredTigerTestCase):
 
     def setUp(self):
         if self.runningHook('disagg') and disagg_fast_truncate_build() == 0:
-            self.skipTest("fast truncate support in not enabled")
+            self.skipTest("fast truncate support is not enabled")
         super().setUp()
 
     # Truncate, from keynum1 to keynum2, inclusive.

--- a/test/suite/test_truncate19.py
+++ b/test/suite/test_truncate19.py
@@ -34,8 +34,6 @@ from wtscenario import make_scenarios
 #
 # Test to mimic oplog workload in MongoDB. Ensure the deleted pages are
 # cleaned up on disk and we are not using excessive disk space.
-# FIXME-WT-15430: Re-enable once disaggregated storage works with fast truncate tests.
-@wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_truncate19(wttest.WiredTigerTestCase):
     conn_config = 'statistics=(all)'
 
@@ -59,6 +57,7 @@ class test_truncate19(wttest.WiredTigerTestCase):
         self.session.commit_transaction()
 
     @wttest.skip_for_hook("tiered", "test depends of sizes of associated file objects")
+    @wttest.skip_for_hook("disagg", "test depends of sizes of associated file objects")
     def test_truncate19(self):
         uri = 'table:oplog'
         nrows = 1000000

--- a/test/suite/test_truncate20.py
+++ b/test/suite/test_truncate20.py
@@ -27,7 +27,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 import os, wttest
 from test_cc01 import test_cc_base
-from wiredtiger import stat
+from wiredtiger import disagg_fast_truncate_build, stat
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 
@@ -35,8 +35,6 @@ from wtscenario import make_scenarios
 #
 # Test to mimic oplog workload in MongoDB. Ensure the deleted pages are
 # cleaned up on disk and we are not using excessive disk space.
-# FIXME-WT-15430: Re-enable once disaggregated storage works with fast truncate tests.
-@wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_truncate20(test_cc_base):
     conn_config = 'statistics=(all),log=(enabled=true)'
 
@@ -46,6 +44,11 @@ class test_truncate20(test_cc_base):
         ('row_string', dict(key_format='S', value_format='S')),
     ]
     scenarios = make_scenarios(format_values)
+
+    def setUp(self):
+        if self.runningHook('disagg') and disagg_fast_truncate_build() == 0:
+            self.skipTest("fast truncate support in not enabled")
+        super().setUp()
 
     def append_rows(self, uri, ds, start_row, nrows, value):
         cursor = self.session.open_cursor(uri)

--- a/test/suite/test_truncate20.py
+++ b/test/suite/test_truncate20.py
@@ -47,7 +47,7 @@ class test_truncate20(test_cc_base):
 
     def setUp(self):
         if self.runningHook('disagg') and disagg_fast_truncate_build() == 0:
-            self.skipTest("fast truncate support in not enabled")
+            self.skipTest("fast truncate support is not enabled")
         super().setUp()
 
     def append_rows(self, uri, ds, start_row, nrows, value):

--- a/test/suite/test_truncate22.py
+++ b/test/suite/test_truncate22.py
@@ -45,7 +45,7 @@ class test_truncate22(wttest.WiredTigerTestCase):
 
     def setUp(self):
         if self.runningHook('disagg') and disagg_fast_truncate_build() == 0:
-            self.skipTest("fast truncate support in not enabled")
+            self.skipTest("fast truncate support is not enabled")
         super().setUp()
 
     def test_truncate22(self):

--- a/test/suite/test_truncate22.py
+++ b/test/suite/test_truncate22.py
@@ -26,14 +26,13 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import wiredtiger, wttest
+import wttest
+from wiredtiger import disagg_fast_truncate_build
 from wtscenario import make_scenarios
 from wtdataset import SimpleDataSet
 
 # test_truncate22.py
 # Test that we can set the commit timestamp before performing fast truncate.
-# FIXME-WT-15430: Re-enable once disaggregated storage works with fast truncate tests.
-@wttest.skip_for_hook("disagg", "fast truncate is not supported yet")
 class test_truncate22(wttest.WiredTigerTestCase):
     uri = 'table:test_truncate22'
     conn_config = 'statistics=(all)'
@@ -43,6 +42,11 @@ class test_truncate22(wttest.WiredTigerTestCase):
     )
     scenarios = make_scenarios(key_format_values)
     nrows = 10000
+
+    def setUp(self):
+        if self.runningHook('disagg') and disagg_fast_truncate_build() == 0:
+            self.skipTest("fast truncate support in not enabled")
+        super().setUp()
 
     def test_truncate22(self):
         # Create a table.

--- a/test/suite/tsan.fail
+++ b/test/suite/tsan.fail
@@ -1,4 +1,4 @@
-# This file is used by evergreen.yml when running the  python test suite under TSAN.
+# This file is used by evergreen.yml when running the python test suite under TSAN.
 # This list are test files that are not run, they are known failures. The reasons for the failures are not known,
 # they'll need to be triaged. When we know something about the failure, they are commented.
 test_alter01.py
@@ -60,6 +60,7 @@ test_tiered08.py
 test_tiered14.py
 test_timestamp04.py
 test_truncate01.py
+test_truncate08.py
 test_truncate11.py
 test_truncate15.py
 test_truncate19.py


### PR DESCRIPTION
Fast truncate support in leader mode has been implemented (see https://github.com/wiredtiger/wiredtiger/pull/13250).

This PR removes the FIXME-WT-15430 lines that skipped fast truncate testing. Tests that still have legitimate blocking reasons are re-annotated with new ticket references.