### PR TITLE
WT-16789 Harden follower fast truncate

### DIFF
--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1555,10 +1555,6 @@ extern int __wti_layered_table_manager_destroy(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_layered_table_manager_init(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wti_layered_table_truncate_rollback(WT_SESSION_IMPL *session, WT_TXN_OP *op)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wti_mark_committed_truncate_table(WT_SESSION_IMPL *session, WT_TXN_OP *op)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_meta_track_insert(WT_SESSION_IMPL *session, const char *key)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_meta_track_update(WT_SESSION_IMPL *session, const char *key)
@@ -1917,6 +1913,8 @@ extern void __wti_debug_crash_if_flag_set(
 extern void __wti_free_ref(WT_SESSION_IMPL *session, WT_REF *ref, int page_type, bool free_pages);
 extern void __wti_free_ref_index(
   WT_SESSION_IMPL *session, WT_PAGE *page, WT_PAGE_INDEX *pindex, bool free_pages);
+extern void __wti_layered_table_truncate_rollback(WT_SESSION_IMPL *session, WT_TXN_OP *op);
+extern void __wti_mark_committed_truncate_table(WT_SESSION_IMPL *session, WT_TXN_OP *op);
 extern void __wti_read_row_time_window(
   WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW *rip, WT_TIME_WINDOW *tw);
 extern void __wti_ref_addr_safe_free(WT_SESSION_IMPL *session, void *p, size_t len);

--- a/src/include/schema.h
+++ b/src/include/schema.h
@@ -74,11 +74,11 @@ struct __wt_table {
  */
 struct __wt_truncate {
     /*
-     * The uri is used to grab the layered table handle.
-     *
-     * FIXME-WT-16789: Investigate if there is more efficient way to get the dhandle.
+     * Pointer to the layered table data handle. A reference is held via WT_DHANDLE_ACQUIRE to
+     * prevent the sweep server from discarding the dhandle while truncate entries exist.
      */
-    const char *uri;
+    WT_DATA_HANDLE *dhandle;
+
     uint64_t txn_id;
     wt_timestamp_t start_ts;
     wt_timestamp_t durable_ts;

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1621,7 +1621,7 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
             /* Other operations don't need timestamps. */
             break;
         case WT_TXN_OP_FOLLOWER_TRUNCATE:
-            WT_ERR(__wti_mark_committed_truncate_table(session, op));
+            __wti_mark_committed_truncate_table(session, op);
             break;
         }
 
@@ -2124,7 +2124,7 @@ __wt_txn_rollback(WT_SESSION_IMPL *session, const char *cfg[], bool api_call)
             WT_TRET(__wt_delete_page_rollback(session, op));
             break;
         case WT_TXN_OP_FOLLOWER_TRUNCATE:
-            WT_RET(__wti_layered_table_truncate_rollback(session, op));
+            __wti_layered_table_truncate_rollback(session, op);
             break;
         case WT_TXN_OP_TRUNCATE_COL:
         case WT_TXN_OP_TRUNCATE_ROW:

--- a/src/txn/txn_truncate.c
+++ b/src/txn/txn_truncate.c
@@ -73,10 +73,10 @@ __wt_insert_truncate_entry(
      * FIXME-WT-16789: Disallow sweep server or follower mode to clean up the dhandle from the
      * dhandle list, if there are entries in the truncate list.
      */
-    WT_ASSERT(session, __wt_session_get_dhandle(session, uri, NULL, NULL, 0) == 0);
+    WT_RET(__wt_session_get_dhandle(session, uri, NULL, NULL, 0));
     layered_table = (WT_LAYERED_TABLE *)session->dhandle;
 
-    WT_RET(__wt_calloc_def(session, sizeof(WT_TRUNCATE), &t));
+    WT_ERR(__wt_calloc_def(session, sizeof(WT_TRUNCATE), &t));
     WT_ERR(__wt_strdup(session, uri, &t->uri));
     WT_ERR(__wt_buf_set(session, &t->start_key, start_key->data, start_key->size));
     /* A NULL stop key indicates a truncate to end of table. */

--- a/src/txn/txn_truncate.c
+++ b/src/txn/txn_truncate.c
@@ -89,6 +89,7 @@ __wt_insert_truncate_entry(
     WT_ERR(__wt_calloc_one(session, &t));
     WT_ERR(__wt_strdup(session, uri, &t->uri));
 
+    /* A NULL stop key indicates a truncate starts from the beginning of the table. */
     if (start_key != NULL)
         WT_ERR(__wt_buf_set(session, &t->start_key, start_key->data, start_key->size));
 

--- a/src/txn/txn_truncate.c
+++ b/src/txn/txn_truncate.c
@@ -278,8 +278,8 @@ __wti_layered_table_truncate_rollback(WT_SESSION_IMPL *session, WT_TXN_OP *op)
 
     __wt_writelock(session, &layered_table->truncate_lock);
     TAILQ_REMOVE(&layered_table->truncateqh, entry, q);
-    __disagg_truncate_free(session, &entry);
     __wt_writeunlock(session, &layered_table->truncate_lock);
+    __disagg_truncate_free(session, &entry);
 
     WT_TRET(__wt_session_release_dhandle(session));
     return (ret);

--- a/src/txn/txn_truncate.c
+++ b/src/txn/txn_truncate.c
@@ -17,7 +17,7 @@ __disagg_truncate_free(WT_SESSION_IMPL *session, WT_TRUNCATE **entry)
 {
     WT_ASSERT(session, __wt_process.disagg_fast_truncate_2026 == true);
 
-    if (entry == NULL)
+    if (entry == NULL || *entry == NULL)
         return;
 
     __wt_free(session, (*entry)->uri);
@@ -89,7 +89,7 @@ __wt_insert_truncate_entry(
     WT_ERR(__wt_calloc_one(session, &t));
     WT_ERR(__wt_strdup(session, uri, &t->uri));
 
-    /* A NULL stop key indicates a truncate starts from the beginning of the table. */
+    /* A NULL start key indicates a truncate starts from the beginning of the table. */
     if (start_key != NULL)
         WT_ERR(__wt_buf_set(session, &t->start_key, start_key->data, start_key->size));
 

--- a/src/txn/txn_truncate.c
+++ b/src/txn/txn_truncate.c
@@ -80,7 +80,7 @@ __wt_insert_truncate_entry(
      * FIXME-WT-16789: Disallow sweep server or follower mode to clean up the dhandle from the
      * dhandle list, if there are entries in the truncate list.
      */
-    WT_RET(__wt_session_get_dhandle(session, uri, NULL, NULL, 0));
+    WT_ASSERT(session, __wt_session_get_dhandle(session, uri, NULL, NULL, 0) == 0);
     layered_table = (WT_LAYERED_TABLE *)session->dhandle;
 
     WT_ERR(__wt_calloc_one(session, &t));
@@ -218,6 +218,7 @@ __wti_mark_committed_truncate_table(WT_SESSION_IMPL *session, WT_TXN_OP *op)
     WT_LAYERED_TABLE *layered_table;
     WT_TRUNCATE *entry;
 
+    layered_table = NULL;
     entry = op->u.follower_truncate.t;
 
     WT_ASSERT(session, __wt_process.disagg_fast_truncate_2026 == true);
@@ -229,7 +230,7 @@ __wti_mark_committed_truncate_table(WT_SESSION_IMPL *session, WT_TXN_OP *op)
      * FIXME-WT-16789: Disallow sweep server or follower mode to clean up the dhandle from the
      * dhandle list, if there are entries in the truncate list.
      */
-    WT_RET(__wt_session_get_dhandle(session, entry->uri, NULL, NULL, 0));
+    WT_ASSERT(session, __wt_session_get_dhandle(session, entry->uri, NULL, NULL, 0) == 0);
     layered_table = (WT_LAYERED_TABLE *)session->dhandle;
 
     __wt_writelock(session, &layered_table->truncate_lock);

--- a/src/txn/txn_truncate.c
+++ b/src/txn/txn_truncate.c
@@ -21,8 +21,8 @@ __disagg_truncate_free(WT_SESSION_IMPL *session, WT_TRUNCATE **entry)
         return;
 
     __wt_free(session, (*entry)->uri);
-    __wt_free(session, (*entry)->start_key);
-    __wt_free(session, (*entry)->stop_key);
+    __wt_buf_free(session, &(*entry)->start_key);
+    __wt_buf_free(session, &(*entry)->stop_key);
     __wt_free(session, *entry);
     *entry = NULL;
 }

--- a/src/txn/txn_truncate.c
+++ b/src/txn/txn_truncate.c
@@ -69,7 +69,7 @@ __wt_insert_truncate_entry(
 {
     WT_DECL_RET;
     WT_LAYERED_TABLE *layered_table;
-    WT_TRUNCATE *t;
+    WT_TRUNCATE *t = NULL;
 
     WT_ASSERT(session, __wt_process.disagg_fast_truncate_2026 == true);
 
@@ -83,7 +83,7 @@ __wt_insert_truncate_entry(
     WT_RET(__wt_session_get_dhandle(session, uri, NULL, NULL, 0));
     layered_table = (WT_LAYERED_TABLE *)session->dhandle;
 
-    WT_ERR(__wt_calloc_def(session, sizeof(WT_TRUNCATE), &t));
+    WT_ERR(__wt_calloc_one(session, &t));
     WT_ERR(__wt_strdup(session, uri, &t->uri));
     WT_ERR(__wt_buf_set(session, &t->start_key, start_key->data, start_key->size));
     /* A NULL stop key indicates a truncate to end of table. */
@@ -218,7 +218,6 @@ __wti_mark_committed_truncate_table(WT_SESSION_IMPL *session, WT_TXN_OP *op)
     WT_LAYERED_TABLE *layered_table;
     WT_TRUNCATE *entry;
 
-    layered_table = NULL;
     entry = op->u.follower_truncate.t;
 
     WT_ASSERT(session, __wt_process.disagg_fast_truncate_2026 == true);
@@ -230,7 +229,7 @@ __wti_mark_committed_truncate_table(WT_SESSION_IMPL *session, WT_TXN_OP *op)
      * FIXME-WT-16789: Disallow sweep server or follower mode to clean up the dhandle from the
      * dhandle list, if there are entries in the truncate list.
      */
-    WT_ASSERT(session, __wt_session_get_dhandle(session, entry->uri, NULL, NULL, 0) == 0);
+    WT_RET(__wt_session_get_dhandle(session, entry->uri, NULL, NULL, 0));
     layered_table = (WT_LAYERED_TABLE *)session->dhandle;
 
     __wt_writelock(session, &layered_table->truncate_lock);
@@ -239,7 +238,7 @@ __wti_mark_committed_truncate_table(WT_SESSION_IMPL *session, WT_TXN_OP *op)
     entry->durable_ts = session->txn->time_point.durable_timestamp;
     __wt_writeunlock(session, &layered_table->truncate_lock);
     WT_TRET(__wt_session_release_dhandle(session));
-    return (0);
+    return (ret);
 }
 
 /*

--- a/src/txn/txn_truncate.c
+++ b/src/txn/txn_truncate.c
@@ -161,7 +161,10 @@ __wt_layered_table_truncate_detect_write_conflict(
 
         if (is_within_range) {
             __wt_readunlock(session, &layered_table->truncate_lock);
-            return (WT_WRITE_CONFLICT);
+            WT_STAT_CONN_INCR(session, txn_update_conflict);
+            __wt_session_set_last_error(
+              session, WT_ROLLBACK, WT_WRITE_CONFLICT, WT_TXN_ROLLBACK_REASON_CONFLICT);
+            return (WT_ROLLBACK);
         }
     }
     __wt_readunlock(session, &layered_table->truncate_lock);

--- a/src/txn/txn_truncate.c
+++ b/src/txn/txn_truncate.c
@@ -271,10 +271,11 @@ __wti_layered_table_truncate_rollback(WT_SESSION_IMPL *session, WT_TXN_OP *op)
 
     __wt_writelock(session, &layered_table->truncate_lock);
     TAILQ_REMOVE(&layered_table->truncateqh, entry, q);
+    __disagg_truncate_free(session, &entry);
     __wt_writeunlock(session, &layered_table->truncate_lock);
 
     WT_TRET(__wt_session_release_dhandle(session));
-    return (0);
+    return (ret);
 }
 
 /*

--- a/src/txn/txn_truncate.c
+++ b/src/txn/txn_truncate.c
@@ -40,9 +40,12 @@ __key_within_truncate_range(WT_SESSION_IMPL *session, WT_COLLATOR *collator,
     WT_ASSERT(session, is_within_range != NULL);
     *is_within_range = false;
 
-    WT_RET(__wt_compare(session, collator, key, start_key, &compare_result));
-    if (compare_result < 0)
-        return (0);
+    /* If the start key size is not zero, there is a lower bound we need to check for. */
+    if (start_key->size != 0) {
+        WT_RET(__wt_compare(session, collator, key, start_key, &compare_result));
+        if (compare_result < 0)
+            return (0);
+    }
 
     /* A zeroed stop key indicates a truncate to end of table. */
     if (stop_key->size == 0) {
@@ -85,7 +88,10 @@ __wt_insert_truncate_entry(
 
     WT_ERR(__wt_calloc_one(session, &t));
     WT_ERR(__wt_strdup(session, uri, &t->uri));
-    WT_ERR(__wt_buf_set(session, &t->start_key, start_key->data, start_key->size));
+
+    if (start_key != NULL)
+        WT_ERR(__wt_buf_set(session, &t->start_key, start_key->data, start_key->size));
+
     /* A NULL stop key indicates a truncate to end of table. */
     if (stop_key != NULL)
         WT_ERR(__wt_buf_set(session, &t->stop_key, stop_key->data, stop_key->size));

--- a/src/txn/txn_truncate.c
+++ b/src/txn/txn_truncate.c
@@ -17,10 +17,12 @@ __disagg_truncate_free(WT_SESSION_IMPL *session, WT_TRUNCATE **entry)
 {
     WT_ASSERT(session, __wt_process.disagg_fast_truncate_2026 == true);
 
-    if (entry == NULL || *entry == NULL)
+    if ((entry == NULL) || (*entry == NULL))
         return;
 
-    __wt_free(session, (*entry)->uri);
+    if ((*entry)->dhandle != NULL)
+        WT_DHANDLE_RELEASE((*entry)->dhandle);
+
     __wt_buf_free(session, &(*entry)->start_key);
     __wt_buf_free(session, &(*entry)->stop_key);
     __wt_free(session, *entry);
@@ -76,18 +78,18 @@ __wt_insert_truncate_entry(
 
     WT_ASSERT(session, __wt_process.disagg_fast_truncate_2026 == true);
 
-    /*
-     * Get the layered table from the provided URI. We don't hold any global locks so that's
-     * possible that it was already removed.
-     *
-     * FIXME-WT-16789: Disallow sweep server or follower mode to clean up the dhandle from the
-     * dhandle list, if there are entries in the truncate list.
-     */
-    WT_ASSERT(session, __wt_session_get_dhandle(session, uri, NULL, NULL, 0) == 0);
-    layered_table = (WT_LAYERED_TABLE *)session->dhandle;
+    WT_RET(__wt_calloc_one(session, &t));
 
-    WT_ERR(__wt_calloc_one(session, &t));
-    WT_ERR(__wt_strdup(session, uri, &t->uri));
+    /*
+     * Resolve the URI to the layered table dhandle. Acquire a reference on the dhandle to prevent
+     * the sweep server from discarding it while the truncate entry exists.
+     */
+    WT_ERR(__wt_session_get_dhandle(session, uri, NULL, NULL, 0));
+    t->dhandle = (WT_DATA_HANDLE *)session->dhandle;
+    WT_DHANDLE_ACQUIRE(t->dhandle);
+
+    layered_table = (WT_LAYERED_TABLE *)t->dhandle;
+    WT_TRET(__wt_session_release_dhandle(session));
 
     /* A NULL start key indicates a truncate starts from the beginning of the table. */
     if (start_key != NULL)
@@ -103,9 +105,8 @@ __wt_insert_truncate_entry(
      */
     WT_ERR(__wt_session_get_dhandle(session, layered_table->ingest_uri, NULL, NULL, 0));
     WT_ERR(__wt_txn_truncate(session, t));
-    WT_ERR(__wt_session_release_dhandle(session));
+    WT_TRET(__wt_session_release_dhandle(session));
 
-    session->dhandle = (WT_DATA_HANDLE *)layered_table;
     __wt_writelock(session, &layered_table->truncate_lock);
     TAILQ_INSERT_TAIL(&layered_table->truncateqh, t, q);
     __wt_writeunlock(session, &layered_table->truncate_lock);
@@ -114,7 +115,6 @@ __wt_insert_truncate_entry(
 err:
         __disagg_truncate_free(session, &t);
     }
-    WT_TRET(__wt_session_release_dhandle(session));
 
     return (ret);
 }
@@ -221,35 +221,24 @@ __wt_truncate_delete_visible_check(
  * __wti_mark_committed_truncate_table --
  *     Mark a truncate table entry as committed, updating truncate entries timestamp information.
  */
-int
+void
 __wti_mark_committed_truncate_table(WT_SESSION_IMPL *session, WT_TXN_OP *op)
 {
-    WT_DECL_RET;
     WT_LAYERED_TABLE *layered_table;
     WT_TRUNCATE *entry;
 
-    layered_table = NULL;
     entry = op->u.follower_truncate.t;
 
     WT_ASSERT(session, __wt_process.disagg_fast_truncate_2026 == true);
 
-    /*
-     * Get the layered table from the provided URI. We don't hold any global locks so that's
-     * possible that it was already removed.
-     *
-     * FIXME-WT-16789: Disallow sweep server or follower mode to clean up the dhandle from the
-     * dhandle list, if there are entries in the truncate list.
-     */
-    WT_ASSERT(session, __wt_session_get_dhandle(session, entry->uri, NULL, NULL, 0) == 0);
-    layered_table = (WT_LAYERED_TABLE *)session->dhandle;
+    /* The truncate entry holds a reference on the dhandle, so it is safe to access directly. */
+    layered_table = (WT_LAYERED_TABLE *)entry->dhandle;
 
     __wt_writelock(session, &layered_table->truncate_lock);
     entry->txn_id = session->txn->time_point.id;
     entry->start_ts = session->txn->time_point.commit_timestamp;
     entry->durable_ts = session->txn->time_point.durable_timestamp;
     __wt_writeunlock(session, &layered_table->truncate_lock);
-    WT_TRET(__wt_session_release_dhandle(session));
-    return (ret);
 }
 
 /*
@@ -257,35 +246,23 @@ __wti_mark_committed_truncate_table(WT_SESSION_IMPL *session, WT_TXN_OP *op)
  *     Perform transaction rollback for a truncate operation, removing the truncate entry from the
  *     layered table truncate list.
  */
-int
+void
 __wti_layered_table_truncate_rollback(WT_SESSION_IMPL *session, WT_TXN_OP *op)
 {
-    WT_DECL_RET;
     WT_LAYERED_TABLE *layered_table;
     WT_TRUNCATE *entry;
 
-    layered_table = NULL;
     entry = op->u.follower_truncate.t;
 
     WT_ASSERT(session, __wt_process.disagg_fast_truncate_2026 == true);
 
-    /*
-     * Get the layered table from the provided URI. We don't hold any global locks so that's
-     * possible that it was already removed.
-     *
-     * FIXME-WT-16789: Disallow sweep server or follower mode to clean up the dhandle from the
-     * dhandle list, if there are entries in the truncate list.
-     */
-    WT_ASSERT(session, __wt_session_get_dhandle(session, entry->uri, NULL, NULL, 0) == 0);
-    layered_table = (WT_LAYERED_TABLE *)session->dhandle;
+    /* The truncate entry holds a reference on the dhandle, so it is safe to access directly. */
+    layered_table = (WT_LAYERED_TABLE *)entry->dhandle;
 
     __wt_writelock(session, &layered_table->truncate_lock);
     TAILQ_REMOVE(&layered_table->truncateqh, entry, q);
     __wt_writeunlock(session, &layered_table->truncate_lock);
     __disagg_truncate_free(session, &entry);
-
-    WT_TRET(__wt_session_release_dhandle(session));
-    return (ret);
 }
 
 /*

--- a/src/txn/txn_truncate.c
+++ b/src/txn/txn_truncate.c
@@ -31,25 +31,32 @@ __disagg_truncate_free(WT_SESSION_IMPL *session, WT_TRUNCATE **entry)
  * __key_within_truncate_range --
  *     Search if the key is within a truncate range.
  */
-static bool
+static int
 __key_within_truncate_range(WT_SESSION_IMPL *session, WT_COLLATOR *collator,
-  const WT_ITEM *start_key, const WT_ITEM *stop_key, const WT_ITEM *key)
+  const WT_ITEM *start_key, const WT_ITEM *stop_key, const WT_ITEM *key, bool *is_within_range)
 {
-    int start_cmp, stop_cmp;
+    int compare_result;
 
-    WT_RET(__wt_compare(session, collator, key, start_key, &start_cmp));
-    if (start_cmp < 0)
-        return (false);
+    WT_ASSERT(session, is_within_range != NULL);
+    *is_within_range = false;
+
+    WT_RET(__wt_compare(session, collator, key, start_key, &compare_result));
+    if (compare_result < 0)
+        return (0);
 
     /* A zeroed stop key indicates a truncate to end of table. */
-    if (stop_key->size == 0)
-        return (true);
+    if (stop_key->size == 0) {
+        *is_within_range = true;
+        return (0);
+    }
 
-    WT_RET(__wt_compare(session, collator, key, stop_key, &stop_cmp));
-    if (stop_cmp > 0)
-        return (false);
+    WT_RET(__wt_compare(session, collator, key, stop_key, &compare_result));
+    if (compare_result <= 0) {
+        *is_within_range = true;
+        return (0);
+    }
 
-    return (true);
+    return (0);
 }
 
 /*
@@ -117,7 +124,9 @@ int
 __wt_layered_table_truncate_detect_write_conflict(
   WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered_table, const WT_ITEM *key)
 {
+    WT_DECL_RET;
     WT_TRUNCATE *entry;
+    bool is_within_range;
 
     if (!__wt_process.disagg_fast_truncate_2026)
         return (0);
@@ -135,8 +144,15 @@ __wt_layered_table_truncate_detect_write_conflict(
         if (__wt_txn_visible(session, entry->txn_id, entry->start_ts, entry->durable_ts))
             continue;
 
-        if (__key_within_truncate_range(
-              session, collator, &entry->start_key, &entry->stop_key, key)) {
+        ret = __key_within_truncate_range(
+          session, collator, &entry->start_key, &entry->stop_key, key, &is_within_range);
+
+        if (ret != 0) {
+            __wt_readunlock(session, &layered_table->truncate_lock);
+            return (ret);
+        }
+
+        if (is_within_range) {
             __wt_readunlock(session, &layered_table->truncate_lock);
             return (WT_WRITE_CONFLICT);
         }
@@ -153,7 +169,9 @@ int
 __wt_truncate_delete_visible_check(
   WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered_table, WT_ITEM *key, WT_TRUNCATE **tp)
 {
+    WT_DECL_RET;
     WT_TRUNCATE *entry;
+    bool is_within_range;
 
     if (!__wt_process.disagg_fast_truncate_2026)
         return (WT_NOTFOUND);
@@ -170,8 +188,15 @@ __wt_truncate_delete_visible_check(
         if (!__wt_txn_visible(session, entry->txn_id, entry->start_ts, entry->durable_ts))
             continue;
 
-        if (__key_within_truncate_range(
-              session, collator, &entry->start_key, &entry->stop_key, key)) {
+        ret = __key_within_truncate_range(
+          session, collator, &entry->start_key, &entry->stop_key, key, &is_within_range);
+
+        if (ret != 0) {
+            __wt_readunlock(session, &layered_table->truncate_lock);
+            return (ret);
+        }
+
+        if (is_within_range) {
             if (tp != NULL)
                 *tp = entry;
             __wt_readunlock(session, &layered_table->truncate_lock);


### PR DESCRIPTION
Working through WT-16789, I went through the fast truncate list code to see if anything could be improved. This PR summarises the changes that were made.

- Use wt_buf_free as the keys are allocated with wt_buf_set
- Do not discard errors in __wti_layered_table_truncate_rollback and __wti_mark_committed_truncate_table
- Fix bug in __key_within_truncate_range where an error will always result in a "true" value
- Add missing memory free functions where applicable
- Add null checks where necessary
- Resolve FIX-ME: Prevent sweep server from discarding handles.