### PR TITLE
WT-17143 Explicitly disable read-only connections with disagg

### DIFF
--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -1414,6 +1414,12 @@ __wti_disagg_conn_config(WT_SESSION_IMPL *session, const char **cfg, bool reconf
     bool leader, picked_up, was_leader;
 
     conn = S2C(session);
+
+    /* FIXME-WT-17177: Read-only connections are currently not supported for disagg. */
+    if (F_ISSET(conn, WT_CONN_READONLY))
+        WT_RET_MSG(session, ENOTSUP,
+          "disaggregated storage is not supported with read-only connections");
+
     leader = was_leader = conn->layered_table_manager.leader;
     npage_log = NULL;
     picked_up = false;

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -1414,12 +1414,6 @@ __wti_disagg_conn_config(WT_SESSION_IMPL *session, const char **cfg, bool reconf
     bool leader, picked_up, was_leader;
 
     conn = S2C(session);
-
-    /* FIXME-WT-17177: Read-only connections are currently not supported for disagg. */
-    if (F_ISSET(conn, WT_CONN_READONLY))
-        WT_RET_MSG(session, ENOTSUP,
-          "disaggregated storage is not supported with read-only connections");
-
     leader = was_leader = conn->layered_table_manager.leader;
     npage_log = NULL;
     picked_up = false;
@@ -1511,6 +1505,14 @@ __wti_disagg_conn_config(WT_SESSION_IMPL *session, const char **cfg, bool reconf
 
     /* FIXME-WT-14965: Exit the function immediately if this check returns false. */
     if (__wt_conn_is_disagg(session)) {
+        /*
+         * FIXME-WT-17177: Read-only connections are currently not supported with disaggregated
+         * storage.
+         */
+        if (F_ISSET(conn, WT_CONN_READONLY))
+            WT_ERR_MSG(session, ENOTSUP,
+              "disaggregated storage is not supported with read-only connections");
+
         WT_ERR(__wti_layered_table_manager_init(session));
 
         /* If we are starting as a primary, abandon a previous incomplete checkpoint. */

--- a/test/suite/hook_disagg.py
+++ b/test/suite/hook_disagg.py
@@ -89,6 +89,10 @@ def wiredtiger_open_replace(orig_wiredtiger_open, homedir, conn_config):
     if 'in_memory=true' in conn_config:
         skip_test("cannot run disagg hook on a test that is in-memory")
 
+    # FIXME-WT-17177: Read-only connections are currently not supported for disagg.
+    if 'readonly=true' in conn_config or conn_config.strip() == 'readonly':
+        skip_test("cannot run disagg hook on a test that uses read-only connections")
+
     if 'compatibility=' in conn_config:
         skip_test("cannot run disagg hook on a test that requires compatibility in the config string")
 

--- a/test/suite/test_layered88.py
+++ b/test/suite/test_layered88.py
@@ -48,6 +48,15 @@ class test_layered88(wttest.WiredTigerTestCase):
         extlist.extension('collators', 'reverse')
         self.disagg_conn_extensions(extlist)
 
+    def test_readonly(self):
+        # FIXME-WT-17177: Opening a read-only connection with disagg must be rejected.
+        self.close_conn()
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.wiredtiger_open(self.home,
+                self.extensionsConfig() + ',readonly=true,' + self.conn_config),
+            '/disaggregated storage is not supported with read-only connections/')
+        self.open_conn()
+
     def test_reverse_collator(self):
         # Opening a cursor on a layered table with a custom collator must be rejected.
         # The create succeeds (metadata is written), but opening the layered dhandle checks

--- a/test/suite/test_util23.py
+++ b/test/suite/test_util23.py
@@ -31,6 +31,8 @@ from suite_subprocess import suite_subprocess
 
 # test_util23.py
 # Test that wt verify properly handles scratch buffers on usage path.
+# FIXME-WT-17177: Read-only connections are currently not supported for disagg (-r flag for commands).
+@wttest.skip_for_hook("disagg", "Disaggregated storage does not support read-only connections")
 class test_util23(wttest.WiredTigerTestCase, suite_subprocess):
     tablename = 'test_util23.wt'
     uri = 'file:' + tablename


### PR DESCRIPTION
Read-only connections are currently incompatible with disagg, as picking up a checkpoint requires modifying local metadata, which is not supported in read-only mode. This leads to failures in test_util23 and test_stat_log01_readonly.

This PR explicitly disables read-only connection support with disagg + skips all the affected tests.