### PR TITLE
WT-17184 Fix spell check failure in s_all on mainline

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -427,7 +427,6 @@ Runtime
 RuntimeError
 SCons
 SDK
-SDKROOT
 SIGABRT
 SIMD
 SLS
@@ -1187,9 +1186,7 @@ kvraw
 kvs
 lang
 las
-latencies
 latin
-layeredp
 lazyfs
 lbrace
 lbracket

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -888,6 +888,7 @@ destructor
 dev
 dh
 dhandle
+dhandle's
 dhandles
 dicts
 didworkp


### PR DESCRIPTION
Update to s_string.ok needed after WT-16986 added the python tests to our s_string spell check.