### PR TITLE
WT-16842 add assert for snapshot size

### DIFF
--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -95,8 +95,11 @@ __wt_txn_import_snapshot(WT_SESSION_IMPL *session, const WT_TXN_SNAPSHOT *snapsh
 
     txn = session->txn;
 
-    WT_ASSERT_ALWAYS(session, txn->snapshot_data.snapshot != NULL, "Snapshot data must be allocated before importing a snapshot");
-    WT_ASSERT_ALWAYS(session, snapshot->snapshot_count <= (uint32_t)S2C(session)->session_array.size, "Snapshot count exceeds session array size");
+    WT_ASSERT_ALWAYS(session, txn->snapshot_data.snapshot != NULL,
+      "Snapshot data must be allocated before importing a snapshot");
+    WT_ASSERT_ALWAYS(session,
+      snapshot->snapshot_count <= (uint32_t)S2C(session)->session_array.size,
+      "Snapshot count exceeds session array size");
 
     txn->snapshot_data.snapshot_count = snapshot->snapshot_count;
     txn->snapshot_data.snap_max = snapshot->snap_max;

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -95,7 +95,8 @@ __wt_txn_import_snapshot(WT_SESSION_IMPL *session, const WT_TXN_SNAPSHOT *snapsh
 
     txn = session->txn;
 
-    /* FIXME-WT-16842: Check that the array capacity is sufficient. */
+    WT_ASSERT(session, txn->snapshot_data.snapshot != NULL);
+    WT_ASSERT(session, snapshot->snapshot_count <= (uint32_t)S2C(session)->session_array.size);
 
     txn->snapshot_data.snapshot_count = snapshot->snapshot_count;
     txn->snapshot_data.snap_max = snapshot->snap_max;

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -95,8 +95,8 @@ __wt_txn_import_snapshot(WT_SESSION_IMPL *session, const WT_TXN_SNAPSHOT *snapsh
 
     txn = session->txn;
 
-    WT_ASSERT(session, txn->snapshot_data.snapshot != NULL);
-    WT_ASSERT(session, snapshot->snapshot_count <= (uint32_t)S2C(session)->session_array.size);
+    WT_ASSERT_ALWAYS(session, txn->snapshot_data.snapshot != NULL, "Snapshot data must be allocated before importing a snapshot");
+    WT_ASSERT_ALWAYS(session, snapshot->snapshot_count <= (uint32_t)S2C(session)->session_array.size, "Snapshot count exceeds session array size");
 
     txn->snapshot_data.snapshot_count = snapshot->snapshot_count;
     txn->snapshot_data.snap_max = snapshot->snap_max;


### PR DESCRIPTION
Currently we read from shared checkpoint snapshot for parallel checkpoints where dst->snapshot is explicitly sized to conn->session_array.size. In the worker thread we copy snapshot->snapshot_count entries from a buffer whose capacity is conn->session_array.size into another buffer also of conn->session_array.size that's defined in __wt_txn_init for the worker’s txn->snapshot_data.snapshot.

I think the code here is correct. The array capacity should always be sufficient if we can assume that conn->session_array.size is a per-connection maximum that does not shrink. If we are concerned about snapshot code changes here in the future, then I think we can add an assertion here that snapshot->snapshot_count <= S2C(session)->session_array.size. Otherwise we can just remove the fixme.