### PR TITLE
WT-17191 Add evergreen support for fast truncate build flag

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -330,7 +330,8 @@ functions:
           ${IMPORT_S3_SDK|} \
           ${SPINLOCK_TYPE|} \
           ${ENABLE_COLORIZE_OUTPUT|-DENABLE_COLORIZE_OUTPUT=0} \
-          ${CC_OPTIMIZE_LEVEL|}"
+          ${CC_OPTIMIZE_LEVEL|} \
+          ${WT_DISAGG_FAST_TRUNCATE_BUILD|}"
 
         # The RHEL PPC platform does not have ZSTD. Strip it out.
         if [ "${build_variant|}" = "rhel8-ppc" ] && [[ "$DEFINED_EVERGREEN_CONFIG_FLAGS" =~ (\-DHAVE_BUILTIN_EXTENSION_ZSTD=1) ]]; then


### PR DESCRIPTION
This just provides a mechanism to allow any evergreen project to override the fast truncate flag at the project level. I think this is faster and cleaner than creating a completely new YAML.

The plan is to point the new project at develop, but set the flag to true.

Here is a patch that tests it: https://spruce.corp.mongodb.com/version/69e05e0ddc2bd5000759660b/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC