### PR TITLE
WT-17195 Fix misattributed txn_rts_btrees_skipped DSRC stat

### DIFF
--- a/src/rollback_to_stable/rts_btree_walk.c
+++ b/src/rollback_to_stable/rts_btree_walk.c
@@ -412,7 +412,7 @@ __wti_rts_btree_walk_btree_apply(
           has_txn_updates_gt_than_ckpt_snap ? "true" : "false");
 
     if (file_skipped)
-        WT_STAT_CONN_DSRC_INCR(session, txn_rts_btrees_skipped);
+        WT_STAT_CONN_INCR(session, txn_rts_btrees_skipped);
 
     /*
      * Truncate history store entries for the non-timestamped table.


### PR DESCRIPTION
## Summary

- In `__wti_rts_btree_walk_btree_apply`, when `file_skipped=true` the btree's dhandle has never been opened. `WT_STAT_CONN_DSRC_INCR` uses `session->dhandle` for the per-datasource half of the increment, which at that point is the metadata cursor's dhandle — so the stat is attributed to the metadata file instead of the skipped btree.
- Fix: replace `WT_STAT_CONN_DSRC_INCR` with `WT_STAT_CONN_INCR`, which only increments the connection-level counter where there is no valid data-source target.
- This makes the three skip paths in RTS consistent: the never-checkpointed early-return path (line 392) and the `ENOENT`/corruption path in `__rts_btree` (line 280) already use `WT_STAT_CONN_INCR` for the same reason.

## Testing

No test files were modified. The change is a one-line stat macro correction with no behavioural impact on the rollback path itself; the connection-level counter value is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)