### PR TITLE
WT-14353 Print full extent list in wt verify dump_layout command

### DIFF
--- a/src/block/block_ext.c
+++ b/src/block/block_ext.c
@@ -1502,11 +1502,13 @@ __block_extlist_dump_buckets(
 
     __wt_verbose_level(session, WT_VERB_BLOCK, level, "%s", (char *)t1->data);
 
-    /* Print each extent with its offset and size. */
+    /* Print each extent with its offset and size when block verbosity is enabled. */
+    __wt_verbose_level(
+        session, WT_VERB_BLOCK, WT_VERBOSE_DEBUG_1, "%s", "Extent Number:   Offset, Size");
     i = 0;
     WT_EXT_FOREACH (ext, el->off)
-        __wt_verbose_level(session, WT_VERB_BLOCK, level, "%" PRIu32 ":   %" PRIdMAX ", %" PRIdMAX,
-          ++i, (intmax_t)ext->off, (intmax_t)ext->size);
+        __wt_verbose_level(session, WT_VERB_BLOCK, WT_VERBOSE_DEBUG_1,
+            "%u:   %" PRIdMAX ", %" PRIdMAX, ++i, (intmax_t)ext->off, (intmax_t)ext->size);
 
 done:
 err:

--- a/src/block/block_ext.c
+++ b/src/block/block_ext.c
@@ -1459,7 +1459,6 @@ __block_extlist_dump_buckets(
 {
     WT_DECL_ITEM(t1);
     WT_DECL_ITEM(t2);
-    WT_DECL_ITEM(t3);
     WT_DECL_RET;
     WT_EXT *ext;
     WT_VERBOSE_LEVEL level;
@@ -1504,14 +1503,10 @@ __block_extlist_dump_buckets(
     __wt_verbose_level(session, WT_VERB_BLOCK, level, "%s", (char *)t1->data);
 
     /* Print each extent with its offset and size. */
-    WT_ERR(__wt_scr_alloc(session, 0, &t3));
     i = 0;
-    WT_EXT_FOREACH (ext, el->off) {
-        ++i;
-        WT_ERR(__wt_buf_catfmt(session, t3, "%s%" PRIu32 ":   %" PRIdMAX ", %" PRIdMAX,
-          i == 1 ? "extent lists:\n" : "\n", i, (intmax_t)ext->off, (intmax_t)ext->size));
-    }
-    __wt_verbose_level(session, WT_VERB_BLOCK, level, "%s", (char *)t3->data);
+    WT_EXT_FOREACH (ext, el->off)
+        __wt_verbose_level(session, WT_VERB_BLOCK, level, "%" PRIu32 ":   %" PRIdMAX ", %" PRIdMAX,
+          ++i, (intmax_t)ext->off, (intmax_t)ext->size);
 
 done:
 err:

--- a/src/block/block_ext.c
+++ b/src/block/block_ext.c
@@ -1459,6 +1459,7 @@ __block_extlist_dump_buckets(
 {
     WT_DECL_ITEM(t1);
     WT_DECL_ITEM(t2);
+    WT_DECL_ITEM(t3);
     WT_DECL_RET;
     WT_EXT *ext;
     WT_VERBOSE_LEVEL level;
@@ -1473,7 +1474,7 @@ __block_extlist_dump_buckets(
     if (block->verify_layout)
         level = WT_VERBOSE_NOTICE;
     else
-        level = WT_VERBOSE_DEBUG_2;
+        level = S2C(session)->verbose[WT_VERB_BLOCK];
 
     WT_ERR(__wt_scr_alloc(session, 0, &t1));
     __wt_verbose_level(session, WT_VERB_BLOCK, level,
@@ -1502,10 +1503,21 @@ __block_extlist_dump_buckets(
 
     __wt_verbose_level(session, WT_VERB_BLOCK, level, "%s", (char *)t1->data);
 
+    /* Print each extent with its offset and size. */
+    WT_ERR(__wt_scr_alloc(session, 0, &t3));
+    i = 0;
+    WT_EXT_FOREACH (ext, el->off) {
+        ++i;
+        WT_ERR(__wt_buf_catfmt(session, t3, "%s%" PRIu32 ":   %" PRIdMAX ", %" PRIdMAX,
+          i == 1 ? "extent lists:\n" : "\n", i, (intmax_t)ext->off, (intmax_t)ext->size));
+    }
+    __wt_verbose_level(session, WT_VERB_BLOCK, level, "%s", (char *)t3->data);
+
 done:
 err:
     __wt_scr_free(session, &t1);
     __wt_scr_free(session, &t2);
+    __wt_scr_free(session, &t3);
     return (ret);
 }
 

--- a/src/block/block_ext.c
+++ b/src/block/block_ext.c
@@ -1504,10 +1504,10 @@ __block_extlist_dump_buckets(
 
     /* Print each extent with its offset and size when block verbosity is enabled. */
     __wt_verbose_level(
-        session, WT_VERB_BLOCK, WT_VERBOSE_DEBUG_1, "%s", "Extent Number:   Offset, Size");
+        session, WT_VERB_BLOCK, WT_VERBOSE_DEBUG_3, "%s", "Extent Number:   Offset, Size");
     i = 0;
     WT_EXT_FOREACH (ext, el->off)
-        __wt_verbose_level(session, WT_VERB_BLOCK, WT_VERBOSE_DEBUG_1,
+        __wt_verbose_level(session, WT_VERB_BLOCK, WT_VERBOSE_DEBUG_3,
             "%u:   %" PRIdMAX ", %" PRIdMAX, ++i, (intmax_t)ext->off, (intmax_t)ext->size);
 
 done:

--- a/src/block/block_ext.c
+++ b/src/block/block_ext.c
@@ -1504,11 +1504,11 @@ __block_extlist_dump_buckets(
 
     /* Print each extent with its offset and size when block verbosity is enabled. */
     __wt_verbose_level(
-        session, WT_VERB_BLOCK, WT_VERBOSE_DEBUG_3, "%s", "Extent Number:   Offset, Size");
+      session, WT_VERB_BLOCK, WT_VERBOSE_DEBUG_3, "%s", "Extent Number:   Offset, Size");
     i = 0;
     WT_EXT_FOREACH (ext, el->off)
         __wt_verbose_level(session, WT_VERB_BLOCK, WT_VERBOSE_DEBUG_3,
-            "%u:   %" PRIdMAX ", %" PRIdMAX, ++i, (intmax_t)ext->off, (intmax_t)ext->size);
+          "%u:   %" PRIdMAX ", %" PRIdMAX, ++i, (intmax_t)ext->off, (intmax_t)ext->size);
 
 done:
 err:

--- a/src/block/block_ext.c
+++ b/src/block/block_ext.c
@@ -1512,7 +1512,6 @@ done:
 err:
     __wt_scr_free(session, &t1);
     __wt_scr_free(session, &t2);
-    __wt_scr_free(session, &t3);
     return (ret);
 }
 


### PR DESCRIPTION
This change adds a complete listing of every extent (offset and size) after the bucket summary, and also fixes the verbosity level to respect the user-configured level rather than hardcoding `WT_VERBOSE_DEBUG_2`.