### PR TITLE
WT-17227 ninja t now builds extension MODULE libs needed at runtime

### DIFF
--- a/test/format/CMakeLists.txt
+++ b/test/format/CMakeLists.txt
@@ -44,5 +44,22 @@ create_test_executable(test_format
 # for sanitizers to work correctly.
 set_target_properties(test_format PROPERTIES LINKER_LANGUAGE CXX)
 target_compile_options(test_format PRIVATE -DEXT_LIBPATH="")
+
+# t uses dlopen() at runtime to load extension MODULE libraries from ../../ext/ (relative to the
+# binary). Those libraries are not link-time dependencies, so ninja t won't build them unless we
+# declare them here. Only add MODULE libraries — builtin extensions are OBJECT libraries already
+# compiled into libwiredtiger and don't need a separate dlopen().
+foreach(ext_target
+        wiredtiger_reverse_collator
+        wiredtiger_lz4 wiredtiger_snappy wiredtiger_zlib wiredtiger_zstd
+        wiredtiger_rotn wiredtiger_sodium)
+    if(TARGET ${ext_target})
+        get_target_property(_ext_type ${ext_target} TYPE)
+        if(_ext_type STREQUAL "MODULE_LIBRARY")
+            add_dependencies(test_format ${ext_target})
+        endif()
+    endif()
+endforeach()
+
 add_test(NAME test_format COMMAND ${CMAKE_CURRENT_BINARY_DIR}/smoke.sh)
 set_tests_properties(test_format PROPERTIES LABELS "check")

--- a/test/format/CMakeLists.txt
+++ b/test/format/CMakeLists.txt
@@ -46,9 +46,10 @@ set_target_properties(test_format PROPERTIES LINKER_LANGUAGE CXX)
 target_compile_options(test_format PRIVATE -DEXT_LIBPATH="")
 
 # t uses dlopen() at runtime to load extension MODULE libraries from ../../ext/ (relative to the
-# binary). Those libraries are not link-time dependencies, so ninja t won't build them unless we
-# declare them here. Only add MODULE libraries — builtin extensions are OBJECT libraries already
-# compiled into libwiredtiger and don't need a separate dlopen().
+# binary). Those libraries have no link-time dependency on test_format, so they would not be built
+# as part of this target without an explicit dependency declared here. Only MODULE libraries are
+# added — builtin extensions are OBJECT libraries already compiled into libwiredtiger and do not
+# need a separate dlopen().
 foreach(ext_target
         wiredtiger_reverse_collator
         wiredtiger_lz4 wiredtiger_snappy wiredtiger_zlib wiredtiger_zstd


### PR DESCRIPTION
## Summary
- `test_format` (`t`) uses `dlopen()` at startup to load extension libraries (collators, compressors, encryptors) from a hardcoded relative path `../../ext/` next to the binary.
- These extension targets (`wiredtiger_lz4`, `wiredtiger_reverse_collator`, etc.) have no link-time relationship with `test_format`, so `ninja t` never triggered their build.
- A first-time `ninja t` would succeed at compile/link but immediately crash on startup with `dlopen` failures. Only after a full `ninja` build (which includes all targets) would `ninja t` work.
- Fixed by adding `add_dependencies(test_format <ext>)` for each MODULE extension `t` loads at runtime. Builtin extensions (type `OBJECT_LIBRARY`, compiled into `libwiredtiger`) are excluded since they don't require a separate `dlopen`.
- No impact on incremental builds: ninja skips already up-to-date extension targets instantly.

## Testing
Verified with a fresh build directory: `ninja t` now builds all required extension `.so` files (280 steps vs 268 before) and `./t` starts successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)