### PR TITLE
WT-17055 Integrate shared disk hash table during page read

### DIFF
--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -906,7 +906,7 @@ __wti_btree_tree_open(WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr
      * the disk image on return, the in-memory object steals it.
      */
     WT_ERR(__wti_page_inmem(session, NULL, dsk.data,
-      WT_DATA_IN_ITEM(&dsk) ? WT_PAGE_DISK_ALLOC : WT_PAGE_DISK_MAPPED, &page, NULL));
+      WT_DATA_IN_ITEM(&dsk) ? WT_PAGE_DISK_ALLOC : WT_PAGE_DISK_MAPPED, &page, NULL, NULL));
     dsk.mem = NULL;
     if (page->disagg_info != NULL)
         page->disagg_info->block_meta = block_meta;

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -906,7 +906,7 @@ __wti_btree_tree_open(WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr
      * the disk image on return, the in-memory object steals it.
      */
     WT_ERR(__wti_page_inmem(session, NULL, dsk.data,
-      WT_DATA_IN_ITEM(&dsk) ? WT_PAGE_DISK_ALLOC : WT_PAGE_DISK_MAPPED, &page, NULL, NULL));
+      WT_DATA_IN_ITEM(&dsk) ? WT_PAGE_DISK_ALLOC : WT_PAGE_DISK_MAPPED, NULL, &page, NULL));
     dsk.mem = NULL;
     if (page->disagg_info != NULL)
         page->disagg_info->block_meta = block_meta;

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -1258,6 +1258,10 @@ __wti_page_inmem(WT_SESSION_IMPL *session, WT_REF *ref, const void *image, uint3
     WT_RET(__wt_page_alloc(session, dsk->type, alloc_entries, true, &page, flags));
     __wt_tsan_suppress_store_wt_page_header_ptr(&page->dsk, dsk);
     F_SET_ATOMIC_16(page, flags);
+    /*
+     * FIXME-WT-17056: we should not free page->dsk during page out and handover the destruction to
+     * shared dsk hash table release function.
+     */
     page->shared_dsk_item = shared_dsk_item;
 
     /*

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -1182,7 +1182,7 @@ err:
  */
 int
 __wti_page_inmem(WT_SESSION_IMPL *session, WT_REF *ref, const void *image, uint32_t flags,
-  WT_PAGE **pagep, bool *instantiate_updp)
+  WT_PAGE **pagep, bool *instantiate_updp, WT_SHARED_DSK_ITEM *shared_dsk_item)
 {
     WT_CELL_UNPACK_ADDR unpack_addr;
     WT_DECL_RET;
@@ -1258,6 +1258,7 @@ __wti_page_inmem(WT_SESSION_IMPL *session, WT_REF *ref, const void *image, uint3
     WT_RET(__wt_page_alloc(session, dsk->type, alloc_entries, true, &page, flags));
     __wt_tsan_suppress_store_wt_page_header_ptr(&page->dsk, dsk);
     F_SET_ATOMIC_16(page, flags);
+    page->shared_dsk_item = shared_dsk_item;
 
     /*
      * Track the memory allocated to build this page so we can update the cache statistics in a

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -1182,7 +1182,7 @@ err:
  */
 int
 __wti_page_inmem(WT_SESSION_IMPL *session, WT_REF *ref, const void *image, uint32_t flags,
-  WT_PAGE **pagep, bool *instantiate_updp, WT_SHARED_DSK_ITEM *shared_dsk_item)
+  WT_SHARED_DSK_ITEM *shared_dsk_item, WT_PAGE **pagep, bool *instantiate_updp)
 {
     WT_CELL_UNPACK_ADDR unpack_addr;
     WT_DECL_RET;
@@ -1262,7 +1262,9 @@ __wti_page_inmem(WT_SESSION_IMPL *session, WT_REF *ref, const void *image, uint3
      * FIXME-WT-17056: we should not free page->dsk during page out and handover the destruction to
      * shared dsk hash table release function.
      */
-    page->shared_dsk_item = shared_dsk_item;
+    WT_ASSERT(session, shared_dsk_item == NULL || page->disagg_info != NULL);
+    if (page->disagg_info != NULL)
+        page->disagg_info->shared_dsk_item = shared_dsk_item;
 
     /*
      * Track the memory allocated to build this page so we can update the cache statistics in a

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -327,9 +327,10 @@ __page_read(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
     if (shared_dsk_cache->enabled) {
         __wt_shared_dsk_cache_get(session, addr.addr, addr.size, &shared_dsk_item);
         if (shared_dsk_item != NULL) {
-            FLD_SET(page_flags, shared_dsk_item->dsk_flags);
-            WT_ERR(__wti_page_inmem(session, ref, shared_dsk_item->data, page_flags, &page,
-              &instantiate_upd, shared_dsk_item));
+            /* Disagg always owns the disk image, so stamp the ownership flag directly. */
+            FLD_SET(page_flags, WT_PAGE_DISK_ALLOC);
+            WT_ERR(__wti_page_inmem(session, ref, shared_dsk_item->data, page_flags,
+              shared_dsk_item, &page, &instantiate_upd));
             goto skip_disk_read;
         }
     }
@@ -412,13 +413,8 @@ __page_read(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
         WT_ASSERT(session, shared_dsk_item == NULL);
         /* Disagg should never use mmap, so the image must be an owned allocation. */
         WT_ASSERT(session, FLD_ISSET(page_flags, WT_PAGE_DISK_ALLOC));
-        /*
-         * Store only the image-ownership flag in the cache entry. Per-read flags
-         * (WT_PAGE_EVICT_NO_PROGRESS / WT_PAGE_PREFETCH) are reapplied per-caller on cache hit.
-         */
         WT_ERR(__wt_shared_dsk_cache_put(session, disk_image_buf->mem, disk_image_buf->size,
-          addr.addr, addr.size, page_flags & (WT_PAGE_DISK_ALLOC | WT_PAGE_DISK_MAPPED),
-          &block_meta, &shared_dsk_item, &shared_dsk_inserted));
+          addr.addr, addr.size, &block_meta, &shared_dsk_item, &shared_dsk_inserted));
         if (shared_dsk_inserted) {
             /* The cache took ownership of the data; clear our local reference. */
             disk_image_buf->mem = NULL;
@@ -428,7 +424,6 @@ __page_read(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
              * the shared dsk instead.
              */
             __wt_buf_free(session, disk_image_buf);
-            FLD_SET(page_flags, shared_dsk_item->dsk_flags);
             /*
              * The collided entry was populated from the same on-disk address, so the stored
              * block_meta must match our own.
@@ -441,8 +436,8 @@ __page_read(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
     WT_ASSERT(
       session, shared_dsk_cache->enabled ? shared_dsk_item != NULL : shared_dsk_item == NULL);
     WT_ERR(__wti_page_inmem(session, ref,
-      shared_dsk_item != NULL ? shared_dsk_item->data : disk_image_buf->data, page_flags, &page,
-      &instantiate_upd, shared_dsk_item));
+      shared_dsk_item != NULL ? shared_dsk_item->data : disk_image_buf->data, page_flags,
+      shared_dsk_item, &page, &instantiate_upd));
     if (!build_full_disk_image_from_deltas) {
         WT_ASSERT(session, ref->page == page);
         tmp[0].mem = NULL;
@@ -507,10 +502,9 @@ err:
         disk_image_set = page->dsk != NULL;
         __wt_page_modify_clear(session, page);
         __wt_ref_out(session, ref);
-    } else if (shared_dsk_item != NULL) {
+    } else if (shared_dsk_item != NULL)
         /* If the page build failed, then we need release the shared dsk item. */
         __wt_shared_dsk_cache_release(session, shared_dsk_item);
-    }
 
     /* Free any disk images or delta buffers we allocated or read. */
     if (tmp != NULL) {

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -436,7 +436,6 @@ __page_read(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
             WT_ASSERT(
               session, memcmp(&shared_dsk_item->block_meta, &block_meta, sizeof(block_meta)) == 0);
         }
-        WT_ASSERT(session, shared_dsk_item != NULL);
     }
 
     WT_ASSERT(

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -223,16 +223,14 @@ __page_read(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
     WT_SHARED_DSK_ITEM *shared_dsk_item;
     size_t count, i;
     uint32_t page_flags;
-    bool instantiate_upd, disk_image_freed, page_change, shared_dsk_inserted,
-      build_full_disk_image_from_deltas;
+    bool instantiate_upd, disk_image_set, page_change, build_full_disk_image_from_deltas;
 
     shared_dsk_cache = &S2C(session)->cache->shared_dsk_cache;
     btree = S2BT(session);
     WT_CLEAR(block_meta);
     tmp = NULL;
     count = 0;
-    disk_image_freed = page_change = shared_dsk_inserted = build_full_disk_image_from_deltas =
-      false;
+    disk_image_set = page_change = build_full_disk_image_from_deltas = false;
     shared_dsk_item = NULL;
     page = NULL;
     WT_CLEAR(new_image);
@@ -329,7 +327,7 @@ __page_read(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
     if (shared_dsk_cache->enabled) {
         __wt_shared_dsk_cache_get(session, addr.addr, addr.size, &shared_dsk_item);
         if (shared_dsk_item != NULL) {
-            FLD_SET(page_flags, shared_dsk_item->page_flags);
+            FLD_SET(page_flags, shared_dsk_item->dsk_flags);
             WT_ERR(__wti_page_inmem(session, ref, shared_dsk_item->data, page_flags, &page,
               &instantiate_upd, shared_dsk_item));
             goto skip_disk_read;
@@ -408,6 +406,8 @@ __page_read(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
     disk_image_buf = build_full_disk_image_from_deltas ? &new_image_copy : &tmp[0];
 
     if (shared_dsk_cache->enabled) {
+        bool shared_dsk_inserted = false;
+
         /* A cache hit takes the skip_disk_read path, so we can't already have an item here. */
         WT_ASSERT(session, shared_dsk_item == NULL);
         /* Disagg should never use mmap, so the image must be an owned allocation. */
@@ -424,14 +424,23 @@ __page_read(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
             disk_image_buf->mem = NULL;
         } else {
             /*
-             * Another thread cached this image concurrently. Drop our redundant local copy and
-             * use the shared image instead, matching the cache-hit path.
+             * Another thread cached this image concurrently. Drop our redundant local copy and use
+             * the shared dsk instead.
              */
             __wt_buf_free(session, disk_image_buf);
-            FLD_SET(page_flags, shared_dsk_item->page_flags);
+            FLD_SET(page_flags, shared_dsk_item->dsk_flags);
+            /*
+             * The collided entry was populated from the same on-disk address, so the stored
+             * block_meta must match our own.
+             */
+            WT_ASSERT(
+              session, memcmp(&shared_dsk_item->block_meta, &block_meta, sizeof(block_meta)) == 0);
         }
         WT_ASSERT(session, shared_dsk_item != NULL);
     }
+
+    WT_ASSERT(
+      session, shared_dsk_cache->enabled ? shared_dsk_item != NULL : shared_dsk_item == NULL);
     WT_ERR(__wti_page_inmem(session, ref,
       shared_dsk_item != NULL ? shared_dsk_item->data : disk_image_buf->data, page_flags, &page,
       &instantiate_upd, shared_dsk_item));
@@ -496,11 +505,11 @@ err:
      * page took ownership of the disk image so we avoid double-freeing it below.
      */
     if (page != NULL) {
-        disk_image_freed = page->dsk != NULL;
+        disk_image_set = page->dsk != NULL;
         __wt_page_modify_clear(session, page);
         __wt_ref_out(session, ref);
     } else if (shared_dsk_item != NULL) {
-        /* The page build failed; release the shared dsk ref we acquired. */
+        /* If the page build failed, then we need release the shared dsk item. */
         __wt_shared_dsk_cache_release(session, shared_dsk_item);
     }
 
@@ -512,7 +521,7 @@ err:
     }
 
     __wt_buf_free(session, &new_image);
-    if (!disk_image_freed)
+    if (!disk_image_set)
         __wt_buf_free(session, &new_image_copy);
     F_CLR_ATOMIC_8(ref, WT_REF_FLAG_READING);
     WT_REF_SET_STATE(ref, previous_state);

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -213,23 +213,42 @@ __page_read(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
     WT_BTREE *btree;
     WT_DECL_RET;
     WT_ITEM *deltas;
+    WT_ITEM *disk_image_buf;
     WT_ITEM new_image, new_image_copy;
     WT_ITEM *tmp;
     WT_PAGE *page;
     WT_PAGE_BLOCK_META block_meta;
     WT_REF_STATE previous_state;
+    WT_SHARED_DSK_CACHE *shared_dsk_cache;
+    WT_SHARED_DSK_ITEM *shared_dsk_item;
     size_t count, i;
     uint32_t page_flags;
-    bool instantiate_upd, disk_image_freed, page_change, build_full_disk_image_from_deltas;
+    bool instantiate_upd, disk_image_freed, page_change, shared_dsk_inserted,
+      build_full_disk_image_from_deltas;
 
+    shared_dsk_cache = &S2C(session)->cache->shared_dsk_cache;
     btree = S2BT(session);
     WT_CLEAR(block_meta);
     tmp = NULL;
     count = 0;
-    disk_image_freed = page_change = build_full_disk_image_from_deltas = false;
+    disk_image_freed = page_change = shared_dsk_inserted = build_full_disk_image_from_deltas =
+      false;
+    shared_dsk_item = NULL;
     page = NULL;
     WT_CLEAR(new_image);
     WT_CLEAR(new_image_copy);
+
+    page_flags = 0;
+    /*
+     * If a page is read with eviction disabled, we don't count evicting it as progress. Since
+     * disabling eviction allows pages to be read even when the cache is full, we want to avoid
+     * workloads repeatedly reading a page with eviction disabled (e.g., a metadata page), then
+     * evicting that page and deciding that is a sign that eviction is unstuck.
+     */
+    if (LF_ISSET(WT_READ_IGNORE_CACHE_SIZE))
+        FLD_SET(page_flags, WT_PAGE_EVICT_NO_PROGRESS);
+    if (LF_ISSET(WT_READ_PREFETCH))
+        FLD_SET(page_flags, WT_PAGE_PREFETCH);
 
     /* Lock the WT_REF. */
     switch (previous_state = WT_REF_GET_STATE(ref)) {
@@ -307,6 +326,16 @@ __page_read(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
         }
     }
 
+    if (shared_dsk_cache->enabled) {
+        __wt_shared_dsk_cache_get(session, addr.addr, addr.size, &shared_dsk_item);
+        if (shared_dsk_item != NULL) {
+            FLD_SET(page_flags, shared_dsk_item->page_flags);
+            WT_ERR(__wti_page_inmem(session, ref, shared_dsk_item->data, page_flags, &page,
+              &instantiate_upd, shared_dsk_item));
+            goto skip_disk_read;
+        }
+    }
+
     /* There's an address, read the backing disk page and build an in-memory version of the page. */
     WT_ERR(__wt_blkcache_read_multi(session, &tmp, &count, &block_meta, addr.addr, addr.size));
 
@@ -317,17 +346,7 @@ __page_read(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
     else
         deltas = NULL;
 
-    /*
-     * If a page is read with eviction disabled, we don't count evicting it as progress. Since
-     * disabling eviction allows pages to be read even when the cache is full, we want to avoid
-     * workloads repeatedly reading a page with eviction disabled (e.g., a metadata page), then
-     * evicting that page and deciding that is a sign that eviction is unstuck.
-     */
-    page_flags = WT_DATA_IN_ITEM(&tmp[0]) ? WT_PAGE_DISK_ALLOC : WT_PAGE_DISK_MAPPED;
-    if (LF_ISSET(WT_READ_IGNORE_CACHE_SIZE))
-        FLD_SET(page_flags, WT_PAGE_EVICT_NO_PROGRESS);
-    if (LF_ISSET(WT_READ_PREFETCH))
-        FLD_SET(page_flags, WT_PAGE_PREFETCH);
+    FLD_SET(page_flags, WT_DATA_IN_ITEM(&tmp[0]) ? WT_PAGE_DISK_ALLOC : WT_PAGE_DISK_MAPPED);
 
     /* After reading the page from disk, construct a full disk image. */
     if (count > 1) {
@@ -385,27 +404,51 @@ __page_read(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags)
 
         WT_ERR(ret);
     }
-    /*
-     * Build the in-memory version of the page. Clear our local reference to the allocated copy of
-     * the disk image on return, the in-memory object steals it.
-     */
-    if (build_full_disk_image_from_deltas)
-        /* Pass the newly built full disk image data to build in-memory page information. */
-        WT_ERR(
-          __wti_page_inmem(session, ref, new_image_copy.data, page_flags, &page, &instantiate_upd));
-    else {
-        WT_ERR(__wti_page_inmem(session, ref, tmp[0].data, page_flags, &page, &instantiate_upd));
+
+    disk_image_buf = build_full_disk_image_from_deltas ? &new_image_copy : &tmp[0];
+
+    if (shared_dsk_cache->enabled) {
+        /* A cache hit takes the skip_disk_read path, so we can't already have an item here. */
+        WT_ASSERT(session, shared_dsk_item == NULL);
+        /* Disagg should never use mmap, so the image must be an owned allocation. */
+        WT_ASSERT(session, FLD_ISSET(page_flags, WT_PAGE_DISK_ALLOC));
+        /*
+         * Store only the image-ownership flag in the cache entry. Per-read flags
+         * (WT_PAGE_EVICT_NO_PROGRESS / WT_PAGE_PREFETCH) are reapplied per-caller on cache hit.
+         */
+        WT_ERR(__wt_shared_dsk_cache_put(session, disk_image_buf->mem, disk_image_buf->size,
+          addr.addr, addr.size, page_flags & (WT_PAGE_DISK_ALLOC | WT_PAGE_DISK_MAPPED),
+          &block_meta, &shared_dsk_item, &shared_dsk_inserted));
+        if (shared_dsk_inserted) {
+            /* The cache took ownership of the data; clear our local reference. */
+            disk_image_buf->mem = NULL;
+        } else {
+            /*
+             * Another thread cached this image concurrently. Drop our redundant local copy and
+             * use the shared image instead, matching the cache-hit path.
+             */
+            __wt_buf_free(session, disk_image_buf);
+            FLD_SET(page_flags, shared_dsk_item->page_flags);
+        }
+        WT_ASSERT(session, shared_dsk_item != NULL);
+    }
+    WT_ERR(__wti_page_inmem(session, ref,
+      shared_dsk_item != NULL ? shared_dsk_item->data : disk_image_buf->data, page_flags, &page,
+      &instantiate_upd, shared_dsk_item));
+    if (!build_full_disk_image_from_deltas) {
         WT_ASSERT(session, ref->page == page);
         tmp[0].mem = NULL;
     }
+    __wt_free(session, tmp);
+
+skip_disk_read:
     if (page->disagg_info != NULL) {
+        if (shared_dsk_item != NULL)
+            block_meta = shared_dsk_item->block_meta;
         page->disagg_info->block_meta = block_meta;
         page->disagg_info->old_rec_lsn_max = block_meta.disagg_lsn;
         page->disagg_info->rec_lsn_max = block_meta.disagg_lsn;
     }
-
-    __wt_free(session, tmp);
-
     if (!page_change && instantiate_upd && !WT_IS_HS(session->dhandle))
         WT_ERR(__wti_page_inmem_updates(session, ref));
 
@@ -449,13 +492,16 @@ skip_read:
 
 err:
     /*
-     * If the function building an in-memory version of the page failed, it discarded the page, but
-     * not the disk image. Discard the page and separately discard the disk image in all cases.
+     * If the page was successfully built but a later step failed, discard it. Track whether the
+     * page took ownership of the disk image so we avoid double-freeing it below.
      */
     if (page != NULL) {
         disk_image_freed = page->dsk != NULL;
         __wt_page_modify_clear(session, page);
         __wt_ref_out(session, ref);
+    } else if (shared_dsk_item != NULL) {
+        /* The page build failed; release the shared dsk ref we acquired. */
+        __wt_shared_dsk_cache_release(session, shared_dsk_item);
     }
 
     /* Free any disk images or delta buffers we allocated or read. */

--- a/src/btree/bt_slvg.c
+++ b/src/btree/bt_slvg.c
@@ -615,7 +615,7 @@ __slvg_trk_leaf(WT_SESSION_IMPL *session, const WT_PAGE_HEADER *dsk, uint8_t *ad
          * Page flags are 0 because we aren't releasing the memory used to read the page into memory
          * and we don't want page discard to free it.
          */
-        WT_ERR(__wti_page_inmem(session, NULL, dsk, 0, &page, NULL));
+        WT_ERR(__wti_page_inmem(session, NULL, dsk, 0, &page, NULL, NULL));
         WT_ERR(__wt_row_leaf_key_copy(session, page, &page->pg_row[0], &trk->row_start));
         WT_ERR(
           __wt_row_leaf_key_copy(session, page, &page->pg_row[page->entries - 1], &trk->row_stop));
@@ -1665,7 +1665,7 @@ __slvg_row_trk_update_start(WT_SESSION_IMPL *session, WT_ITEM *stop, uint32_t sl
      */
     WT_RET(__wt_scr_alloc(session, trk->trk_size, &dsk));
     WT_ERR(__wt_blkcache_read(session, dsk, NULL, trk->trk_addr, trk->trk_addr_size));
-    WT_ERR(__wti_page_inmem(session, NULL, dsk->data, 0, &page, NULL));
+    WT_ERR(__wti_page_inmem(session, NULL, dsk->data, 0, &page, NULL, NULL));
 
     /*
      * Walk the page, looking for a key sorting greater than the specified stop key -- that's our

--- a/src/btree/bt_slvg.c
+++ b/src/btree/bt_slvg.c
@@ -615,7 +615,7 @@ __slvg_trk_leaf(WT_SESSION_IMPL *session, const WT_PAGE_HEADER *dsk, uint8_t *ad
          * Page flags are 0 because we aren't releasing the memory used to read the page into memory
          * and we don't want page discard to free it.
          */
-        WT_ERR(__wti_page_inmem(session, NULL, dsk, 0, &page, NULL, NULL));
+        WT_ERR(__wti_page_inmem(session, NULL, dsk, 0, NULL, &page, NULL));
         WT_ERR(__wt_row_leaf_key_copy(session, page, &page->pg_row[0], &trk->row_start));
         WT_ERR(
           __wt_row_leaf_key_copy(session, page, &page->pg_row[page->entries - 1], &trk->row_stop));
@@ -1665,7 +1665,7 @@ __slvg_row_trk_update_start(WT_SESSION_IMPL *session, WT_ITEM *stop, uint32_t sl
      */
     WT_RET(__wt_scr_alloc(session, trk->trk_size, &dsk));
     WT_ERR(__wt_blkcache_read(session, dsk, NULL, trk->trk_addr, trk->trk_addr_size));
-    WT_ERR(__wti_page_inmem(session, NULL, dsk->data, 0, &page, NULL, NULL));
+    WT_ERR(__wti_page_inmem(session, NULL, dsk->data, 0, NULL, &page, NULL));
 
     /*
      * Walk the page, looking for a key sorting greater than the specified stop key -- that's our

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1489,7 +1489,7 @@ __split_multi_inmem(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *multi, WT
      * will discard the allocated page on error, when discarding the allocated WT_REF.
      */
     WT_RET(__wti_page_inmem(
-      session, ref, multi->disk_image, WT_PAGE_DISK_ALLOC, &page, &instantiate_upd));
+      session, ref, multi->disk_image, WT_PAGE_DISK_ALLOC, &page, &instantiate_upd, NULL));
     multi->disk_image = NULL;
 
     /* Preserve the relevant metadata. */

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -1489,7 +1489,7 @@ __split_multi_inmem(WT_SESSION_IMPL *session, WT_PAGE *orig, WT_MULTI *multi, WT
      * will discard the allocated page on error, when discarding the allocated WT_REF.
      */
     WT_RET(__wti_page_inmem(
-      session, ref, multi->disk_image, WT_PAGE_DISK_ALLOC, &page, &instantiate_upd, NULL));
+      session, ref, multi->disk_image, WT_PAGE_DISK_ALLOC, NULL, &page, &instantiate_upd));
     multi->disk_image = NULL;
 
     /* Preserve the relevant metadata. */

--- a/src/cache/shared_dsk.c
+++ b/src/cache/shared_dsk.c
@@ -89,7 +89,7 @@ __wt_shared_dsk_cache_get(WT_SESSION_IMPL *session, const uint8_t *addr, size_t 
  */
 int
 __wt_shared_dsk_cache_put(WT_SESSION_IMPL *session, void *data, size_t data_size,
-  const uint8_t *addr, size_t addr_size, uint32_t dsk_flags, WT_PAGE_BLOCK_META *block_meta,
+  const uint8_t *addr, size_t addr_size, WT_PAGE_BLOCK_META *block_meta,
   WT_SHARED_DSK_ITEM **shared_dsk_retp, bool *insertedp)
 {
     WT_DECL_RET;
@@ -115,7 +115,6 @@ __wt_shared_dsk_cache_put(WT_SESSION_IMPL *session, void *data, size_t data_size
     WT_ERR(__wt_calloc(session, 1, sizeof(*shared_dsk_store) + addr_size, &shared_dsk_store));
     shared_dsk_store->data = data;
     shared_dsk_store->data_size = WT_STORE_SIZE(data_size);
-    shared_dsk_store->dsk_flags = dsk_flags;
     shared_dsk_store->block_meta = *block_meta;
     shared_dsk_store->fid = S2BT(session)->id;
     shared_dsk_store->addr_size = (uint8_t)addr_size;

--- a/src/cache/shared_dsk.c
+++ b/src/cache/shared_dsk.c
@@ -89,7 +89,7 @@ __wt_shared_dsk_cache_get(WT_SESSION_IMPL *session, const uint8_t *addr, size_t 
  */
 int
 __wt_shared_dsk_cache_put(WT_SESSION_IMPL *session, void *data, size_t data_size,
-  const uint8_t *addr, size_t addr_size, uint32_t page_flags, WT_PAGE_BLOCK_META *block_meta,
+  const uint8_t *addr, size_t addr_size, uint32_t dsk_flags, WT_PAGE_BLOCK_META *block_meta,
   WT_SHARED_DSK_ITEM **shared_dsk_retp, bool *insertedp)
 {
     WT_DECL_RET;
@@ -108,12 +108,14 @@ __wt_shared_dsk_cache_put(WT_SESSION_IMPL *session, void *data, size_t data_size
     shared_dsk_store = NULL;
     *shared_dsk_retp = NULL;
 
+    WT_ASSERT(session, data != NULL);
+    WT_ASSERT(session, data_size != 0);
     WT_ASSERT(session, block_meta != NULL);
 
     WT_ERR(__wt_calloc(session, 1, sizeof(*shared_dsk_store) + addr_size, &shared_dsk_store));
     shared_dsk_store->data = data;
     shared_dsk_store->data_size = WT_STORE_SIZE(data_size);
-    shared_dsk_store->page_flags = page_flags;
+    shared_dsk_store->dsk_flags = dsk_flags;
     shared_dsk_store->block_meta = *block_meta;
     shared_dsk_store->fid = S2BT(session)->id;
     shared_dsk_store->addr_size = (uint8_t)addr_size;

--- a/src/cache/shared_dsk.c
+++ b/src/cache/shared_dsk.c
@@ -36,14 +36,13 @@ __shared_dsk_cache_verbose(WT_SESSION_IMPL *session, WT_VERBOSE_LEVEL level, con
  */
 void
 __wt_shared_dsk_cache_get(WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr_size,
-  WT_SHARED_DSK_ITEM **shared_dsk_retp, bool *foundp)
+  WT_SHARED_DSK_ITEM **shared_dsk_retp)
 {
     WT_SHARED_DSK_CACHE *shared_dsk_cache;
     WT_SHARED_DSK_ITEM *shared_dsk_item;
     uint64_t hash;
     u_int bucket, lock_idx;
 
-    *foundp = false;
     *shared_dsk_retp = NULL;
 
     shared_dsk_cache = &S2C(session)->cache->shared_dsk_cache;
@@ -71,7 +70,6 @@ __wt_shared_dsk_cache_get(WT_SESSION_IMPL *session, const uint8_t *addr, size_t 
 
     if (shared_dsk_item != NULL) {
         *shared_dsk_retp = shared_dsk_item;
-        *foundp = true;
         WT_STAT_CONN_INCR(session, cache_shared_dsk_hit);
         __shared_dsk_cache_verbose(session, WT_VERBOSE_DEBUG_2,
           "get: disk image found in shared dsk cache", hash, bucket, lock_idx, addr, addr_size);
@@ -91,7 +89,8 @@ __wt_shared_dsk_cache_get(WT_SESSION_IMPL *session, const uint8_t *addr, size_t 
  */
 int
 __wt_shared_dsk_cache_put(WT_SESSION_IMPL *session, void *data, size_t data_size,
-  const uint8_t *addr, size_t addr_size, WT_SHARED_DSK_ITEM **shared_dsk_retp, bool *insertedp)
+  const uint8_t *addr, size_t addr_size, uint32_t page_flags, WT_PAGE_BLOCK_META *block_meta,
+  WT_SHARED_DSK_ITEM **shared_dsk_retp, bool *insertedp)
 {
     WT_DECL_RET;
     WT_SHARED_DSK_CACHE *shared_dsk_cache;
@@ -109,9 +108,13 @@ __wt_shared_dsk_cache_put(WT_SESSION_IMPL *session, void *data, size_t data_size
     shared_dsk_store = NULL;
     *shared_dsk_retp = NULL;
 
+    WT_ASSERT(session, block_meta != NULL);
+
     WT_ERR(__wt_calloc(session, 1, sizeof(*shared_dsk_store) + addr_size, &shared_dsk_store));
     shared_dsk_store->data = data;
     shared_dsk_store->data_size = WT_STORE_SIZE(data_size);
+    shared_dsk_store->page_flags = page_flags;
+    shared_dsk_store->block_meta = *block_meta;
     shared_dsk_store->fid = S2BT(session)->id;
     shared_dsk_store->addr_size = (uint8_t)addr_size;
     shared_dsk_store->ref_count = 1;

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -281,6 +281,12 @@ struct __wt_page_disagg_info {
     uint64_t rec_lsn_max;     /* The LSN associated with the page's most recent reconciliation */
 
     WT_PAGE_BLOCK_META block_meta;
+
+    /*
+     * When the shared disk cache is enabled, points at the cache entry that owns page->dsk. NULL on
+     * cache miss before insertion, or when the shared disk cache is disabled.
+     */
+    WT_SHARED_DSK_ITEM *shared_dsk_item;
 };
 
 /*
@@ -832,7 +838,6 @@ struct __wt_page {
 #else
 #define WT_SPLIT_PAGE_SAVE_STATE(page, session, e, g)
 #endif
-    WT_SHARED_DSK_ITEM *shared_dsk_item;
 };
 
 /*

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -832,6 +832,7 @@ struct __wt_page {
 #else
 #define WT_SPLIT_PAGE_SAVE_STATE(page, session, e, g)
 #endif
+    WT_SHARED_DSK_ITEM *shared_dsk_item;
 };
 
 /*

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -52,9 +52,9 @@ struct __wt_shared_dsk_item {
     int32_t ref_count;
 
     WT_PAGE_BLOCK_META block_meta; /* Block metadata, used for page disagg_info. */
-    uint32_t page_flags;           /* Page flags, used by page_inmem on cache hit */
-    uint32_t fid;                  /* File ID */
-    uint8_t addr_size;             /* Address cookie */
+    uint32_t dsk_flags; /* Disk-image ownership flags reapplied to the page flags on cache hit. */
+    uint32_t fid;       /* File ID */
+    uint8_t addr_size;  /* Address cookie */
     uint8_t addr[];
 };
 

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -51,8 +51,10 @@ struct __wt_shared_dsk_item {
      */
     int32_t ref_count;
 
-    uint32_t fid;      /* File ID */
-    uint8_t addr_size; /* Address cookie */
+    WT_PAGE_BLOCK_META block_meta; /* Block metadata, used for page disagg_info. */
+    uint32_t page_flags;           /* Page flags, used by page_inmem on cache hit */
+    uint32_t fid;                  /* File ID */
+    uint8_t addr_size;             /* Address cookie */
     uint8_t addr[];
 };
 

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -52,9 +52,8 @@ struct __wt_shared_dsk_item {
     int32_t ref_count;
 
     WT_PAGE_BLOCK_META block_meta; /* Block metadata, used for page disagg_info. */
-    uint32_t dsk_flags; /* Disk-image ownership flags reapplied to the page flags on cache hit. */
-    uint32_t fid;       /* File ID */
-    uint8_t addr_size;  /* Address cookie */
+    uint32_t fid;                  /* File ID */
+    uint8_t addr_size;             /* Address cookie */
     uint8_t addr[];
 };
 

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1050,7 +1050,7 @@ extern int __wt_session_reset_cursors(WT_SESSION_IMPL *session, bool free_buffer
 extern int __wt_set_return_func(WT_SESSION_IMPL *session, const char *func, int line, int err,
   const char *strerr) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_shared_dsk_cache_put(WT_SESSION_IMPL *session, void *data, size_t data_size,
-  const uint8_t *addr, size_t addr_size, uint32_t dsk_flags, WT_PAGE_BLOCK_META *block_meta,
+  const uint8_t *addr, size_t addr_size, WT_PAGE_BLOCK_META *block_meta,
   WT_SHARED_DSK_ITEM **shared_dsk_retp, bool *insertedp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_slvg_reconcile_free(WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr_size)
@@ -1554,7 +1554,7 @@ extern int __wti_meta_track_insert(WT_SESSION_IMPL *session, const char *key)
 extern int __wti_meta_track_update(WT_SESSION_IMPL *session, const char *key)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_page_inmem(WT_SESSION_IMPL *session, WT_REF *ref, const void *image,
-  uint32_t flags, WT_PAGE **pagep, bool *instantiate_updp, WT_SHARED_DSK_ITEM *shared_dsk_item)
+  uint32_t flags, WT_SHARED_DSK_ITEM *shared_dsk_item, WT_PAGE **pagep, bool *instantiate_updp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_page_inmem_updates(WT_SESSION_IMPL *session, WT_REF *ref)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1050,7 +1050,8 @@ extern int __wt_session_reset_cursors(WT_SESSION_IMPL *session, bool free_buffer
 extern int __wt_set_return_func(WT_SESSION_IMPL *session, const char *func, int line, int err,
   const char *strerr) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_shared_dsk_cache_put(WT_SESSION_IMPL *session, void *data, size_t data_size,
-  const uint8_t *addr, size_t addr_size, WT_SHARED_DSK_ITEM **shared_dsk_retp, bool *insertedp)
+  const uint8_t *addr, size_t addr_size, uint32_t page_flags, WT_PAGE_BLOCK_META *block_meta,
+  WT_SHARED_DSK_ITEM **shared_dsk_retp, bool *insertedp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_slvg_reconcile_free(WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr_size)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -1553,7 +1554,7 @@ extern int __wti_meta_track_insert(WT_SESSION_IMPL *session, const char *key)
 extern int __wti_meta_track_update(WT_SESSION_IMPL *session, const char *key)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_page_inmem(WT_SESSION_IMPL *session, WT_REF *ref, const void *image,
-  uint32_t flags, WT_PAGE **pagep, bool *instantiate_updp)
+  uint32_t flags, WT_PAGE **pagep, bool *instantiate_updp, WT_SHARED_DSK_ITEM *shared_dsk_item)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_page_inmem_updates(WT_SESSION_IMPL *session, WT_REF *ref)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -1824,7 +1825,7 @@ extern void __wt_session_rng_init_once(WT_SESSION_IMPL *session)
 extern void __wt_session_set_last_error(
   WT_SESSION_IMPL *session, int err, int sub_level_err, const char *fmt, ...);
 extern void __wt_shared_dsk_cache_get(WT_SESSION_IMPL *session, const uint8_t *addr,
-  size_t addr_size, WT_SHARED_DSK_ITEM **shared_dsk_retp, bool *foundp);
+  size_t addr_size, WT_SHARED_DSK_ITEM **shared_dsk_retp);
 extern void __wt_shared_dsk_cache_release(
   WT_SESSION_IMPL *session, WT_SHARED_DSK_ITEM *shared_dsk_item);
 extern void __wt_stash_discard(WT_SESSION_IMPL *session);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1050,7 +1050,7 @@ extern int __wt_session_reset_cursors(WT_SESSION_IMPL *session, bool free_buffer
 extern int __wt_set_return_func(WT_SESSION_IMPL *session, const char *func, int line, int err,
   const char *strerr) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_shared_dsk_cache_put(WT_SESSION_IMPL *session, void *data, size_t data_size,
-  const uint8_t *addr, size_t addr_size, uint32_t page_flags, WT_PAGE_BLOCK_META *block_meta,
+  const uint8_t *addr, size_t addr_size, uint32_t dsk_flags, WT_PAGE_BLOCK_META *block_meta,
   WT_SHARED_DSK_ITEM **shared_dsk_retp, bool *insertedp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_slvg_reconcile_free(WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr_size)


### PR DESCRIPTION
The PR is to integrate the shared disk hash table during `__page_read`, including:
1. Lookup the hashtable before sending the request to the block manager.
2. Cache the disk image when it is returned by the block manager.
3. Handover the ownership of disk image to shared dsk hash table, but need to handle disk image discard correctly on error path.