### PR TITLE
WT-16577 Fix stable timestamp regression in predictable replay

### DIFF
--- a/test/format/replay.c
+++ b/test/format/replay.c
@@ -136,6 +136,14 @@ replay_maximum_committed(void)
         }
         if (ts == 0)
             ts = 1;
+        /*
+         * Only update the cached value when we've moved forward. A reclaimed lane's stale
+         * last_commit_ts can produce a lower minimum, but everything up to the previously cached
+         * value is already committed and safe to use as the stable timestamp.
+         */
+        if (ts < g.replay_cached_committed)
+            ts = g.replay_cached_committed;
+
         g.replay_cached_committed = ts;
         testutil_check(pthread_rwlock_unlock(&g.lane_lock));
     }


### PR DESCRIPTION
In predictable replay with `runs.threads=1`, the stable timestamp could go backward, causing set_timestamp to fail with "stable timestamp must not be older than current stable timestamp." When a lane is reclaimed, its `last_commit_ts` is stale from ~1024 timestamps ago. `replay_maximum_committed()` would use this stale value to compute a minimum lower than the previously set stable. The fix ensures the cached committed value only moves forward -- once a timestamp is known to be committed, that fact never changes.