### PR TITLE
WT-16518 Fix discarding a page multiple times in disagg

### DIFF
--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -3273,6 +3273,13 @@ __rec_write_err(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
       r->multi->block_meta->page_id == page->disagg_info->block_meta.page_id) {
         page->disagg_info->block_meta.page_id = WT_BLOCK_INVALID_PAGE_ID;
         WT_STAT_CONN_DSRC_INCR(session, rec_free_page_id_due_to_failed_replacement_reconciliation);
+        /*
+         * The discard above terminates the delta chain for this page id. ref->addr still carries a
+         * cookie with that now-dead page id; a later wrapup that tries to free it would produce a
+         * second discard in the chain and fail. Clear the stale reference so the next
+         * reconciliation's wrapup sees no address to free.
+         */
+        __wt_ref_addr_free(session, r->ref);
     }
 
     WT_TRET(__wti_ovfl_track_wrapup_err(session, page));


### PR DESCRIPTION
Fix WT-16518: disagg reconciliation panics with "Multiple discarded pages in chain" when the failpoint_rec_before_wrapup failpoint fires on a single-block rec that reused a page id.

On failure, __rec_write_err discards the newly-written block (terminating the delta chain for that page id) and invalidates the in-memory page id — but leaves ref->addr pointing at a cookie with the now-dead id. A later wrapup that frees ref->addr issues a second discard and panics. Fix: also clear ref->addr in __rec_write_err; the chain is already dead, so drop the stale pointer.