### PR TITLE
WT-16840 Fix the naming of a relaxed TAILQ empty check

### DIFF
--- a/src/checkpoint/checkpoint_parallel.c
+++ b/src/checkpoint/checkpoint_parallel.c
@@ -77,13 +77,13 @@ __checkpoint_parallel_pop_work(WT_SESSION_IMPL *session, WT_CHECKPOINT_PAGE_TO_R
     conn = S2C(session);
     ckpt_threads = conn->ckpt_reconcile_threads;
 
-    /* FIXME-WT-16480: Do we need this? If so rename it. */
-    if (WT_TAILQ_EMPTY_TSAN_SUPPRESS(&ckpt_threads->work_qh))
+    /* Optimization: Check if the work queue is empty without acquiring the lock. */
+    if (WT_TAILQ_EMPTY_RELAXED(&ckpt_threads->work_qh))
         return;
 
     __wt_spin_lock(session, &ckpt_threads->work_lock);
 
-    /* Recheck again to confirm whether the queue is empty or not? */
+    /* Recheck again to confirm whether the queue is empty or not. */
     if (TAILQ_EMPTY(&ckpt_threads->work_qh)) {
         __wt_spin_unlock(session, &ckpt_threads->work_lock);
         return;
@@ -170,13 +170,13 @@ __checkpoint_parallel_pop_done(WT_SESSION_IMPL *session, WT_CHECKPOINT_PAGE_TO_R
     conn = S2C(session);
     ckpt_threads = conn->ckpt_reconcile_threads;
 
-    /* FIXME-WT-16480: Do we need this? If so rename it. */
-    if (WT_TAILQ_EMPTY_TSAN_SUPPRESS(&ckpt_threads->done_qh))
+    /* Optimization: Check if the done queue is empty without acquiring the lock. */
+    if (WT_TAILQ_EMPTY_RELAXED(&ckpt_threads->done_qh))
         return;
 
     __wt_spin_lock(session, &ckpt_threads->done_lock);
 
-    /* Recheck again to confirm whether the queue is empty or not? */
+    /* Recheck again to confirm whether the queue is empty or not. */
     if (TAILQ_EMPTY(&ckpt_threads->done_qh)) {
         __wt_spin_unlock(session, &ckpt_threads->done_lock);
         return;

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -413,7 +413,7 @@ union __wt_rand_state {
 
 /*
  * WT_TAILQ_EMPTY_RELAXED --
- *	Check if the queue is empty without acquiring the lock.
+ *	Check if the queue is empty, if the caller doesn't need a consistent view.
  */
 #define WT_TAILQ_EMPTY_RELAXED(head) (__wt_atomic_load_ptr_relaxed(&(head)->tqh_first) == NULL)
 

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -413,7 +413,7 @@ union __wt_rand_state {
 
 /*
  * WT_TAILQ_EMPTY_RELAXED --
- *	Check if the queue is empty, suppressing TSAN warnings.
+ *	Check if the queue is empty without acquiring the lock.
  */
 #define WT_TAILQ_EMPTY_RELAXED(head) (__wt_atomic_load_ptr_relaxed(&(head)->tqh_first) == NULL)
 

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -412,11 +412,10 @@ union __wt_rand_state {
 };
 
 /*
- * WT_TAILQ_EMPTY_TSAN_SUPPRESS --
+ * WT_TAILQ_EMPTY_RELAXED --
  *	Check if the queue is empty, suppressing TSAN warnings.
  */
-#define WT_TAILQ_EMPTY_TSAN_SUPPRESS(head) \
-    (__wt_tsan_suppress_load_pointer((void **)&(head)->tqh_first) == NULL)
+#define WT_TAILQ_EMPTY_RELAXED(head) (__wt_atomic_load_ptr_relaxed(&(head)->tqh_first) == NULL)
 
 /*
  * WT_TAILQ_SAFE_REMOVE_BEGIN/END --

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -413,7 +413,7 @@ union __wt_rand_state {
 
 /*
  * WT_TAILQ_EMPTY_RELAXED --
- *	Check if the queue is empty, if the caller doesn't need a consistent view.
+ *	Check if the queue is empty without synchronization.
  */
 #define WT_TAILQ_EMPTY_RELAXED(head) (__wt_atomic_load_ptr_relaxed(&(head)->tqh_first) == NULL)
 


### PR DESCRIPTION
Rename the TAILQ check to WT_TAILQ_EMPTY_RELAXED and update comments accordingly.