### PR TITLE
WT-17245 Introduce wiredtiger_ext umbrella target for MODULE extension deps

### DIFF
--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -44,3 +44,23 @@ if(WT_POSIX)
 endif()
 
 add_subdirectory(test/key_provider)
+
+# Umbrella target: depends on every MODULE extension library built in this tree.
+# Consumers that load extensions via dlopen() at runtime (e.g. test_format, wiredtiger_python)
+# can add_dependencies on this target instead of maintaining their own per-consumer lists.
+add_custom_target(wiredtiger_ext)
+foreach(_ext
+        wiredtiger_lz4 wiredtiger_snappy wiredtiger_zlib wiredtiger_zstd
+        wiredtiger_reverse_collator wiredtiger_reverse_int_collator
+        wiredtiger_rotn wiredtiger_sodium
+        wiredtiger_palite
+        wiredtiger_dir_store
+        wiredtiger_fail_fs
+        wiredtiger_key_provider)
+    if(TARGET ${_ext})
+        get_target_property(_type ${_ext} TYPE)
+        if(_type STREQUAL "MODULE_LIBRARY")
+            add_dependencies(wiredtiger_ext ${_ext})
+        endif()
+    endif()
+endforeach()

--- a/lang/python/CMakeLists.txt
+++ b/lang/python/CMakeLists.txt
@@ -144,6 +144,10 @@ if(WT_DARWIN)
     set_target_properties(wiredtiger_python PROPERTIES SUFFIX ".so")
 endif()
 
+# Python tests load extension MODULE libraries via dlopen() at runtime; pull in the umbrella
+# target so they are built whenever wiredtiger_python is built.
+add_dependencies(wiredtiger_python wiredtiger_ext)
+
 # Define a simple smoke test to check the Python API can be used.
 if(WT_POSIX)
     add_test(NAME test_ex_access

--- a/test/format/CMakeLists.txt
+++ b/test/format/CMakeLists.txt
@@ -45,22 +45,9 @@ create_test_executable(test_format
 set_target_properties(test_format PROPERTIES LINKER_LANGUAGE CXX)
 target_compile_options(test_format PRIVATE -DEXT_LIBPATH="")
 
-# t uses dlopen() at runtime to load extension MODULE libraries from ../../ext/ (relative to the
-# binary). Those libraries have no link-time dependency on test_format, so they would not be built
-# as part of this target without an explicit dependency declared here. Only MODULE libraries are
-# added — builtin extensions are OBJECT libraries already compiled into libwiredtiger and do not
-# need a separate dlopen().
-foreach(ext_target
-        wiredtiger_reverse_collator
-        wiredtiger_lz4 wiredtiger_snappy wiredtiger_zlib wiredtiger_zstd
-        wiredtiger_rotn wiredtiger_sodium)
-    if(TARGET ${ext_target})
-        get_target_property(_ext_type ${ext_target} TYPE)
-        if(_ext_type STREQUAL "MODULE_LIBRARY")
-            add_dependencies(test_format ${ext_target})
-        endif()
-    endif()
-endforeach()
+# t loads extension MODULE libraries via dlopen() at runtime; pull in the umbrella target so
+# they are built whenever test_format is built.
+add_dependencies(test_format wiredtiger_ext)
 
 add_test(NAME test_format COMMAND ${CMAKE_CURRENT_BINARY_DIR}/smoke.sh)
 set_tests_properties(test_format PROPERTIES LABELS "check")


### PR DESCRIPTION
## Summary
- Fixes Python tests failing with \"no extensions library found\" when building only `ninja wiredtiger_python`
- Extension `.so` libraries (palite, lz4, rotn, etc.) are loaded via `dlopen()` at runtime and have no link-time dependency, so they weren't built when targeting `wiredtiger_python` alone
- Introduces a `wiredtiger_ext` custom CMake target in `ext/CMakeLists.txt` that depends on every MODULE extension library, guarded by `if(TARGET ...)` and `MODULE_LIBRARY` type checks so disabled/builtin extensions are safely skipped
- Replaces the duplicated per-consumer `foreach` loops (originally added to `test_format` in WT-17227) with a single source of truth — both `test_format` and `wiredtiger_python` now depend on `wiredtiger_ext`

## Testing
CMake configured cleanly with `ENABLE_PALITE=ON`. No C/C++ files were changed.
To reproduce the original failure: `cmake -DPYTHON3_REQUIRED_VERSION=3.10 -G Ninja .. && ninja wiredtiger_python` then run `test_layered85.py` — it would fail with `page_log/palite: no extensions library found`. After this fix the same `ninja wiredtiger_python` also builds the extensions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)