### PR TITLE
WT-17248 Fix error handling for chunk cache config check in __conn_config_file

### DIFF
--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1719,9 +1719,15 @@ __conn_config_file(
     WT_ERR(__conn_config_check_version(session, cbuf->data));
 
     /*
-     * Check for deprecated chunk cache configuration before validating the config string.
+     * Check for deprecated chunk cache configuration before validating the config string. Handle
+     * its error explicitly so the "basecfg EINVAL == corruption" mapping below does not turn a
+     * clean deprecation rejection into a misleading WT_TRY_SALVAGE.
      */
-    WT_ERR(__conn_chunk_cache_check(session, cbuf->data, is_user ? WT_USERCONFIG : WT_BASECONFIG));
+    if ((ret = __conn_chunk_cache_check(
+           session, cbuf->data, is_user ? WT_USERCONFIG : WT_BASECONFIG)) != 0) {
+        WT_TRET(__wt_close(session, &fh));
+        return (ret);
+    }
 
     /* Check the configuration information. */
     WT_ERR(__wt_config_check(session,

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1589,7 +1589,7 @@ __conn_chunk_cache_check(WT_SESSION_IMPL *session, const char *config, const cha
     cc_enabled = cval.val != 0;
 
     if (cc_enabled)
-        WT_RET_MSG(session, EINVAL,
+        WT_RET_MSG(session, ENOTSUP,
           "chunk cache has been deprecated and is no longer supported, chunk_cache "
           "configuration should be removed%s%s",
           source != NULL ? " from " : "", source != NULL ? source : "");
@@ -1719,15 +1719,9 @@ __conn_config_file(
     WT_ERR(__conn_config_check_version(session, cbuf->data));
 
     /*
-     * Check for deprecated chunk cache configuration before validating the config string. Handle
-     * its error explicitly so the "basecfg EINVAL == corruption" mapping below does not turn a
-     * clean deprecation rejection into a misleading WT_TRY_SALVAGE.
+     * Check for deprecated chunk cache configuration before validating the config string.
      */
-    if ((ret = __conn_chunk_cache_check(
-           session, cbuf->data, is_user ? WT_USERCONFIG : WT_BASECONFIG)) != 0) {
-        WT_TRET(__wt_close(session, &fh));
-        return (ret);
-    }
+    WT_ERR(__conn_chunk_cache_check(session, cbuf->data, is_user ? WT_USERCONFIG : WT_BASECONFIG));
 
     /* Check the configuration information. */
     WT_ERR(__wt_config_check(session,


### PR DESCRIPTION
When chunk cache was enabled on an older WT version, `chunk_cache=(enabled=true,...)` gets persisted into `WiredTiger.basecfg`. On upgrade to a version where chunk cache is deprecated, `__conn_chunk_cache_check` correctly returns `EINVAL` with a message explaining the user should remove the option. But the `err:` block in `__conn_config_file` treats any `EINVAL` from a basecfg read as corruption, sets `WT_CONN_DATA_CORRUPTION`, and escalates to `WT_TRY_SALVAGE`, which could be misleading. This PR routes the deprecation error around that corruption mapping block so the `EINVAL` returns cleanly with the chunk cache deprecation message.