### PR TITLE
WT-16568 Remove the redundant and wrong read only config when opening the stable cursor on standby

### DIFF
--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -283,7 +283,6 @@ retry:
               __wt_buf_fmt(session, stable_uri_buf, "%s/%s", layered->stable_uri, checkpoint_name));
             stable_uri = stable_uri_buf->data;
         }
-        cfg[2] = "read_only=true";
     }
 
     ret = __wt_open_cursor(session, stable_uri, c, cfg, &clayered->stable_cursor);

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -272,6 +272,8 @@ retry:
              * get this dhandle when the node steps up.
              */
             F_SET(clayered, WT_CLAYERED_STABLE_NO_CKPT);
+
+            cfg[2] = "readonly=true";
         } else {
             if (stable_uri_buf == NULL)
                 WT_ERR(__wt_scr_alloc(session, 0, &stable_uri_buf));


### PR DESCRIPTION
The config is redundant and the usage is also wrong. It should be "readonly" instead of "read_only".