### PR TITLE
WT-17249 Fix TSAN data race on session->name by using atomic stores

### DIFF
--- a/src/rollback_to_stable/rts.c
+++ b/src/rollback_to_stable/rts.c
@@ -366,7 +366,7 @@ __wti_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_time
           "Rollback to stable finished metadata walk, draining worker queue");
 
         /* Rename session while joining workers so log messages identify us as a worker. */
-        session->name = "rts-main-wk";
+        __wt_atomic_store_ptr_relaxed(&session->name, "rts-main-wk");
         while (!TAILQ_EMPTY(&S2C(session)->rts->rtsqh)) {
             __wti_rts_pop_work(session, &entry);
             if (entry == NULL)
@@ -375,7 +375,7 @@ __wti_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_time
             __wti_rts_work_free(session, entry);
             WT_ERR(ret);
         }
-        session->name = saved_session_name;
+        __wt_atomic_store_ptr_relaxed(&session->name, saved_session_name);
     }
 
     WT_ERR(__rts_thread_destroy(session));
@@ -405,7 +405,7 @@ __wti_rts_btree_apply_all(WT_SESSION_IMPL *session, wt_timestamp_t rollback_time
 
     __wt_atomic_store_uint32_relaxed(&S2C(session)->rts->progress.phase, WT_RTS_PHASE_COMPLETE);
 err:
-    session->name = saved_session_name;
+    __wt_atomic_store_ptr_relaxed(&session->name, saved_session_name);
     if (have_cursor)
         WT_TRET(__wt_metadata_cursor_release(session, &cursor));
     if (rts_threads_started)

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -2759,7 +2759,7 @@ __wt_open_internal_session(WT_CONNECTION_IMPL *conn, const char *name, bool open
 
     /* Acquire a session. */
     WT_RET(__wt_open_session(conn, NULL, NULL, open_metadata, &session));
-    session->name = name;
+    __wt_atomic_store_ptr_relaxed(&session->name, name);
 
     /*
      * Internal sessions should not save error info unless they are spawned by an external session,


### PR DESCRIPTION
## Summary

Fixes a TSAN data race on `session->name`.

The sweep server reads `session->name` via `__wt_atomic_load_ptr_relaxed` in `__sweep_check_session_callback` (`conn_sweep.c:369`). However, several write sites used plain (non-atomic) stores, which TSAN correctly flags as a data race. Making both sides atomic eliminates the race.

Changes:
- `src/session/session_api.c`: atomic store after session is inserted into the connection array by `__wt_open_session`
- `src/rollback_to_stable/rts.c`: three stores that rename/restore the session name while the sweep server is running

Relaxed ordering is sufficient because `session->name` is diagnostic-only (used only to format log messages), no thread branches on its value, and no ordering relative to other fields is required. This is consistent with `API_SESSION_PUSH`/`API_SESSION_POP` in `src/include/api.h` which already use `__wt_atomic_store_ptr_relaxed` for the same field.