### PR TITLE
WT-17243 Deprecate per_thread_connections (revert WT-16992)

### DIFF
--- a/ext/page_log/palite/palite.cpp
+++ b/ext/page_log/palite/palite.cpp
@@ -153,7 +153,6 @@
 #include <format>
 #include <functional>
 #include <iostream>
-#include <list>
 #include <memory>
 #include <mutex>
 #include <random>
@@ -363,7 +362,6 @@ struct Config {
     uint64_t last_materialized_lsn = 0;    /* The last materialized LSN (0 if not set) */
     int32_t verbose = WT_VERBOSE_INFO;     /* Verbose level */
     bool verbose_msg = true;               /* Send verbose messages to msg callback interface */
-    bool per_thread_connections = true;    /* Use per-thread connections to SQLite databases */
     bool sql_trace = false;                /* Trace all SQLite calls */
     bool verify = true;                    /* Verify integrity of page delta chains */
 
@@ -385,7 +383,6 @@ struct Config {
         configure_value(parser.get(), config, "materialization_delay_ms", materialization_delay_ms);
         configure_value(parser.get(), config, "verbose", verbose);
         configure_value(parser.get(), config, "verbose_msg", verbose_msg);
-        configure_value(parser.get(), config, "per_thread_connections", per_thread_connections);
         configure_value(parser.get(), config, "sql_trace", sql_trace);
         configure_value(parser.get(), config, "verify", verify);
     }
@@ -947,40 +944,23 @@ protected:
     std::filesystem::path table_file;
 
     std::once_flag create_table;
-    std::shared_mutex conn_state; /* protects 'connections' list and map */
-    std::list<Connection *> connections_shared_list;
-    std::unordered_map<std::thread::id, Connection *> connections_per_thread;
+    std::shared_mutex conn_state; /* protects 'connections' map */
+    std::unordered_map<std::thread::id, std::unique_ptr<Connection>> connections;
 
 public:
     std::shared_mutex access; /* readers-writer mutex for table */
 
+    ~Table() = default;
     Table(Config &cfg, std::shared_mutex &str_access, const std::filesystem::path &file)
         : config(cfg), store_access(str_access), table_file(file)
     {
     }
 
-    ~Table()
-    {
-        /* Close all connections, in case they have not been closed already. */
-        close();
-    }
-
     void
     close()
     {
-        std::unique_lock write_lock(conn_state);
-
-        std::ranges::for_each(connections_per_thread, [](auto &kv) {
-            kv.second->close();
-            delete kv.second;
-        });
-        std::ranges::for_each(connections_shared_list, [](auto &conn) {
-            conn->close();
-            delete conn;
-        });
-
-        connections_per_thread.clear();
-        connections_shared_list.clear();
+        std::ranges::for_each(connections, [](auto &kv) { kv.second->close(); });
+        connections.clear();
     }
 
     enum AccessMode { READ, WRITE, BYPASS };
@@ -990,15 +970,14 @@ protected:
         std::shared_lock<std::shared_mutex> store_lock;
         std::shared_lock<std::shared_mutex> table_read_lock;
         std::unique_lock<std::shared_mutex> table_write_lock;
-        Connection *_conn;
-        Table *_table;
 
     public:
         Connection &conn;
 
-        Access(AccessMode mode, Connection *cn, std::shared_mutex &store_access,
-          std::shared_mutex &table_access, Table *table)
-            : _conn(cn), conn(*cn), _table(table)
+        ~Access() = default;
+        Access(AccessMode mode, Connection &cn, std::shared_mutex &store_access,
+          std::shared_mutex &table_access)
+            : conn(cn)
         {
             switch (mode) {
             case AccessMode::READ:
@@ -1017,14 +996,6 @@ protected:
             }
         }
 
-        ~Access()
-        {
-            if (!_table->config.per_thread_connections) {
-                std::lock_guard lock(_table->conn_state);
-                _table->connections_shared_list.push_back(_conn);
-            }
-        }
-
         Access(const Access &) = delete;
         Access &operator=(const Access &) = delete;
     };
@@ -1032,57 +1003,30 @@ protected:
     Access
     request(AccessMode mode)
     {
-        return Access{mode, get_connection(), store_access, access, this};
+        return Access{mode, conn(), store_access, access};
     }
 
 private:
-    Connection *
-    get_connection_from_shared_list()
-    {
-        {
-            std::unique_lock write_lock(conn_state);
-            if (!connections_shared_list.empty()) {
-                Connection *conn = connections_shared_list.front();
-                connections_shared_list.pop_front();
-                return conn;
-            }
-        }
-
-        Connection *new_conn = new Connection(config, table_file);
-        new_conn->configure(static_cast<Traits *>(this)->conn_config());
-
-        std::call_once(
-          create_table,
-          [this](Connection &c) {
-              c.configure(Traits::create_statements);
-              LOG_DEBUG("SQLite database schema initialized: {}", c.db_instance());
-          },
-          *new_conn);
-
-        new_conn->prepare_statements(Traits::sql_statements);
-        return new_conn;
-    }
-
-    Connection *
-    get_connection_from_per_thread_map()
+    Connection &
+    conn()
     {
         {
             std::shared_lock read_lock(conn_state);
-            auto it = connections_per_thread.find(std::this_thread::get_id());
-            if (it != connections_per_thread.end())
-                return it->second;
+            auto it = connections.find(std::this_thread::get_id());
+            if (it != connections.end())
+                return *(it->second);
         }
 
         {
             std::unique_lock write_lock(conn_state);
-            auto [it, inserted] = connections_per_thread.try_emplace(
-              std::this_thread::get_id(), new Connection(config, table_file));
+            auto [it, inserted] = connections.try_emplace(
+              std::this_thread::get_id(), std::make_unique<Connection>(config, table_file));
 
             if (!inserted)
                 LOG_AND_THROW("Connection already exists for this thread");
 
-            Connection *new_conn = it->second;
-            new_conn->configure(static_cast<Traits *>(this)->conn_config());
+            Connection &new_conn = *(it->second);
+            new_conn.configure(static_cast<Traits *>(this)->conn_config());
 
             std::call_once(
               create_table,
@@ -1090,21 +1034,12 @@ private:
                   c.configure(Traits::create_statements);
                   LOG_DEBUG("SQLite database schema initialized: {}", c.db_instance());
               },
-              *new_conn);
+              new_conn);
 
-            new_conn->prepare_statements(Traits::sql_statements);
+            new_conn.prepare_statements(Traits::sql_statements);
 
             return new_conn;
         }
-    }
-
-    Connection *
-    get_connection()
-    {
-        if (config.per_thread_connections)
-            return get_connection_from_per_thread_map();
-        else
-            return get_connection_from_shared_list();
     }
 };
 

--- a/test/suite/hook_disagg.py
+++ b/test/suite/hook_disagg.py
@@ -165,24 +165,11 @@ def wiredtiger_open_replace(orig_wiredtiger_open, homedir, conn_config):
         }
         return str(test_class) in bump_tests
 
-    def should_minimize_fds(test) -> (bool):
-        test_class = str(test).strip().split('.', 1)[0]
-        tests = {
-            'test_schema07', # Creates many tables, which creates many file handles
-        }
-        return str(test_class) in tests
-
     if should_bump_cache(testcase): # bump for specific tests
         if not page_log_config:
             page_log_config = "cache_size_mb=2048"
         elif "cache_size_mb=" not in page_log_config: # don't override user-specified size
             page_log_config = f"cache_size_mb=2048,{page_log_config}"
-
-    if should_minimize_fds(testcase): # minimize file descriptors for specific tests
-        if not page_log_config:
-            page_log_config = "per_thread_connections=false"
-        elif "per_thread_connections=" not in page_log_config: # don't override user-specified field
-            page_log_config = f"per_thread_connections=false,{page_log_config}"
 
     if page_log_config == None:
         ext_lib = f'\"{page_log_extension[0]}\"'


### PR DESCRIPTION
## Summary
- Removes the `per_thread_connections` config option and the associated connection pool implementation introduced by WT-16992
- With WT-17018's new PALite sharding mechanism, this feature is no longer needed
- Restores the simpler per-thread `unique_ptr` connection map in `palite.cpp`
- Removes `should_minimize_fds()` helper and the `per_thread_connections=false` injection for `test_schema07` from `hook_disagg.py`
- Verified that a direct `git revert` of WT-16992 would conflict (WT-17018 modified the same code); checked out develop's file versions instead

## Testing
No test files were modified. The removed code path (`per_thread_connections=false`) was only exercised by `test_schema07` via `hook_disagg.py`, which no longer injects that config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)