### PR TITLE
WT-17256 Make assertions for writing to shared btree on follower work in production

### DIFF
--- a/src/cursor/cur_hs.c
+++ b/src/cursor/cur_hs.c
@@ -1039,9 +1039,10 @@ __curhs_insert(WT_CURSOR *cursor)
     CURSOR_API_CALL_PREPARE_ALLOWED(
       cursor, session, insert, ((WT_CURSOR_BTREE *)file_cursor)->dhandle);
 
-    WT_ASSERT(session,
+    WT_ASSERT_ALWAYS(session,
       !__wt_conn_is_disagg(session) || !F_ISSET(CUR2BT(file_cursor), WT_BTREE_DISAGGREGATED) ||
-        S2C(session)->layered_table_manager.leader);
+        S2C(session)->layered_table_manager.leader,
+      "Follower attempting to insert into shared history store");
 
     /*
      * Disable bulk loads into history store. This would normally occur when updating a record with
@@ -1178,9 +1179,10 @@ __curhs_remove(WT_CURSOR *cursor)
     CURSOR_API_CALL_PREPARE_ALLOWED(
       cursor, session, remove, ((WT_CURSOR_BTREE *)file_cursor)->dhandle);
 
-    WT_ASSERT(session,
+    WT_ASSERT_ALWAYS(session,
       !__wt_conn_is_disagg(session) || !F_ISSET(CUR2BT(file_cursor), WT_BTREE_DISAGGREGATED) ||
-        S2C(session)->layered_table_manager.leader);
+        S2C(session)->layered_table_manager.leader,
+      "Follower attempting to remove from shared history store");
 
     /* Remove must be called with cursor positioned. */
     WT_ASSERT(session, F_ISSET(file_cursor, WT_CURSTD_KEY_INT));
@@ -1224,9 +1226,10 @@ __curhs_update(WT_CURSOR *cursor)
     CURSOR_API_CALL_PREPARE_ALLOWED(
       cursor, session, update, ((WT_CURSOR_BTREE *)file_cursor)->dhandle);
 
-    WT_ASSERT(session,
+    WT_ASSERT_ALWAYS(session,
       !__wt_conn_is_disagg(session) || !F_ISSET(CUR2BT(file_cursor), WT_BTREE_DISAGGREGATED) ||
-        S2C(session)->layered_table_manager.leader);
+        S2C(session)->layered_table_manager.leader,
+      "Follower attempting to update shared history store");
 
     /* Update must be called with cursor positioned. */
     WT_ASSERT(session, F_ISSET(file_cursor, WT_CURSTD_KEY_INT));
@@ -1297,10 +1300,11 @@ __curhs_range_truncate(WT_TRUNCATE_INFO *trunc_info)
     start_file_cursor = ((WT_CURSOR_HS *)trunc_info->start)->file_cursor;
     stop_file_cursor = NULL;
 
-    WT_ASSERT(session,
+    WT_ASSERT_ALWAYS(session,
       !__wt_conn_is_disagg(session) ||
         !F_ISSET(CUR2BT(start_file_cursor), WT_BTREE_DISAGGREGATED) ||
-        S2C(session)->layered_table_manager.leader);
+        S2C(session)->layered_table_manager.leader,
+      "Follower attempting to truncate shared history store");
 
     WT_STAT_DSRC_INCR(session, cursor_truncate);
 

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -439,7 +439,8 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF_STATE previous_state, u
      * follower are never modified, and should never be reconciled.
      */
     if (!tree_dead && is_dirty) {
-        WT_ASSERT_ALWAYS(session, ref->page->disagg_info == NULL || conn->layered_table_manager.leader,
+        WT_ASSERT_ALWAYS(session,
+          ref->page->disagg_info == NULL || conn->layered_table_manager.leader,
           "Follower attempting to reconcile shared page");
         WT_ERR(__evict_reconcile(session, ref, flags));
     }

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -439,7 +439,8 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF_STATE previous_state, u
      * follower are never modified, and should never be reconciled.
      */
     if (!tree_dead && is_dirty) {
-        WT_ASSERT(session, ref->page->disagg_info == NULL || conn->layered_table_manager.leader);
+        WT_ASSERT_ALWAYS(session, ref->page->disagg_info == NULL || conn->layered_table_manager.leader,
+          "Follower attempting to reconcile shared page");
         WT_ERR(__evict_reconcile(session, ref, flags));
     }
 

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -936,8 +936,9 @@ __wt_page_only_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page)
     if (F_ISSET(btree, WT_BTREE_READONLY))
         return;
 
-    WT_ASSERT(session,
-      !F_ISSET(btree, WT_BTREE_DISAGGREGATED) || S2C(session)->layered_table_manager.leader);
+    WT_ASSERT_ALWAYS(session,
+      !F_ISSET(btree, WT_BTREE_DISAGGREGATED) || S2C(session)->layered_table_manager.leader,
+      "Follower attempting to modify page in shared btree");
 
     /*
      * This is a relatively complex dance of operations so pay attention prior to modifying the code
@@ -1048,8 +1049,9 @@ __wt_tree_modify_set(WT_SESSION_IMPL *session)
     if (F_ISSET(btree, WT_BTREE_READONLY))
         return;
 
-    WT_ASSERT(
-      session, !F_ISSET(btree, WT_BTREE_DISAGGREGATED) || conn->layered_table_manager.leader);
+    WT_ASSERT_ALWAYS(session,
+      !F_ISSET(btree, WT_BTREE_DISAGGREGATED) || conn->layered_table_manager.leader,
+      "Follower attempting to modify shared btree");
 
     /*
      * Test before setting the dirty flag, it's a hot cache line.
@@ -1149,8 +1151,9 @@ __wt_page_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page)
     if (F_ISSET(btree, WT_BTREE_READONLY))
         return;
 
-    WT_ASSERT(session,
-      !F_ISSET(btree, WT_BTREE_DISAGGREGATED) || S2C(session)->layered_table_manager.leader);
+    WT_ASSERT_ALWAYS(session,
+      !F_ISSET(btree, WT_BTREE_DISAGGREGATED) || S2C(session)->layered_table_manager.leader,
+      "Follower attempting to set page modify in shared btree");
 
     /*
      * Mark the tree dirty (even if the page is already marked dirty), newly created pages to
@@ -1189,8 +1192,9 @@ __wt_page_parent_modify_set(WT_SESSION_IMPL *session, WT_REF *ref, bool page_onl
     if (F_ISSET(btree, WT_BTREE_READONLY))
         return (0);
 
-    WT_ASSERT(session,
-      !F_ISSET(btree, WT_BTREE_DISAGGREGATED) || S2C(session)->layered_table_manager.leader);
+    WT_ASSERT_ALWAYS(session,
+      !F_ISSET(btree, WT_BTREE_DISAGGREGATED) || S2C(session)->layered_table_manager.leader,
+      "Follower attempting to modify parent page in shared btree");
 
     /*
      * This function exists as a place to stash this comment. There are a few places where we need


### PR DESCRIPTION
[WT-15800](https://jira.mongodb.org/browse/WT-15800) introduced new assertions that help protect WT from situations where we write to shared B-trees. Since such situations can lead to serious consequences like data corruption, we should convert these assertions to WT_ASSERT_ALWAYS so they are enforced in the production environment as well.