### PR TITLE
WT-17258 Add assertion to protect from race with checkpoint

### DIFF
--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -230,12 +230,13 @@ __clayered_open_stable(WT_CURSOR_LAYERED *clayered, bool leader)
     WT_LAYERED_TABLE *layered;
     WT_SESSION_IMPL *session;
     const char *cfg[4] = {WT_CONFIG_BASE(CUR2S(clayered), WT_SESSION_open_cursor), "", NULL, NULL};
-    const char *checkpoint_name, *stable_uri;
+    const char *checkpoint_name, *checkpoint_name_chk, *stable_uri;
 
     session = CUR2S(clayered);
     c = &clayered->iface;
     layered = (WT_LAYERED_TABLE *)clayered->dhandle;
     checkpoint_name = NULL;
+    checkpoint_name_chk = NULL;
 
     WT_RET(__wt_scr_alloc(session, 0, &random_config));
     /* Get the configuration for random cursors, if any. */
@@ -305,6 +306,22 @@ retry:
         ret = 0;
     WT_ERR(ret);
 
+    /*
+     * The first checkpoint might have arrived while we were opening a live btree and this situation
+     * might lead to opening a live btree for a stable table on a follower which could lead to
+     * writing a data from an old checkpoint during the step-up.
+     *
+     * FIXME-WT-17244: This is a temporary protection and we should avoid having this situation
+     * later.
+     */
+    WT_ERR_NOTFOUND_OK(
+      __wt_meta_checkpoint_last_name(session, stable_uri, &checkpoint_name_chk, NULL, NULL), true);
+    WT_ASSERT_ALWAYS(session,
+      !F_ISSET(clayered, WT_CLAYERED_STABLE_NO_CKPT) || (ret == WT_NOTFOUND),
+      "Open a shared live btree on a follower on a checkpoint.");
+    if (ret == WT_NOTFOUND)
+        ret = 0;
+
     if (clayered->stable_cursor != NULL) {
         F_SET(clayered->stable_cursor, WT_CURSTD_OVERWRITE | WT_CURSTD_RAW);
 
@@ -316,6 +333,7 @@ err:
     __wt_scr_free(session, &random_config);
     __wt_scr_free(session, &stable_uri_buf);
     __wt_free(session, checkpoint_name);
+    __wt_free(session, checkpoint_name_chk);
 
     return (ret);
 }

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -230,13 +230,13 @@ __clayered_open_stable(WT_CURSOR_LAYERED *clayered, bool leader)
     WT_LAYERED_TABLE *layered;
     WT_SESSION_IMPL *session;
     const char *cfg[4] = {WT_CONFIG_BASE(CUR2S(clayered), WT_SESSION_open_cursor), "", NULL, NULL};
-    const char *checkpoint_name, *checkpoint_name_chk, *stable_uri;
+    const char *checkpoint_name, *stable_uri;
 
     session = CUR2S(clayered);
     c = &clayered->iface;
     layered = (WT_LAYERED_TABLE *)clayered->dhandle;
     checkpoint_name = NULL;
-    checkpoint_name_chk = NULL;
+    stable_uri = layered->stable_uri;
 
     WT_RET(__wt_scr_alloc(session, 0, &random_config));
     /* Get the configuration for random cursors, if any. */
@@ -306,22 +306,6 @@ retry:
         ret = 0;
     WT_ERR(ret);
 
-    /*
-     * The first checkpoint might have arrived while we were opening a live btree and this situation
-     * might lead to opening a live btree for a stable table on a follower which could lead to
-     * writing a data from an old checkpoint during the step-up.
-     *
-     * FIXME-WT-17244: This is a temporary protection and we should avoid having this situation
-     * later.
-     */
-    WT_ERR_NOTFOUND_OK(
-      __wt_meta_checkpoint_last_name(session, stable_uri, &checkpoint_name_chk, NULL, NULL), true);
-    WT_ASSERT_ALWAYS(session,
-      !F_ISSET(clayered, WT_CLAYERED_STABLE_NO_CKPT) || (ret == WT_NOTFOUND),
-      "Open a shared live btree on a follower on a checkpoint.");
-    if (ret == WT_NOTFOUND)
-        ret = 0;
-
     if (clayered->stable_cursor != NULL) {
         F_SET(clayered->stable_cursor, WT_CURSTD_OVERWRITE | WT_CURSTD_RAW);
 
@@ -330,10 +314,26 @@ retry:
     }
 
 err:
+    /*
+     * The first checkpoint might have arrived while we were opening a live btree and this situation
+     * might lead to opening a live btree for a stable table on a follower which could lead to
+     * writing a data from an old checkpoint during the step-up.
+     *
+     * FIXME-WT-17244: This is a temporary protection and we should avoid having this situation
+     * later.
+     */
+    if (F_ISSET(clayered, WT_CLAYERED_STABLE_NO_CKPT)) {
+        const char *checkpoint_name_chk = NULL;
+        int tmp_ret =
+          __wt_meta_checkpoint_last_name(session, stable_uri, &checkpoint_name_chk, NULL, NULL);
+        WT_ASSERT_ALWAYS(session, tmp_ret == WT_NOTFOUND,
+          "Opened a live stable btree on a follower after a checkpoint arrived.");
+        __wt_free(session, checkpoint_name_chk);
+    }
+
     __wt_scr_free(session, &random_config);
     __wt_scr_free(session, &stable_uri_buf);
     __wt_free(session, checkpoint_name);
-    __wt_free(session, checkpoint_name_chk);
 
     return (ret);
 }

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -323,6 +323,8 @@ err:
      * later.
      */
     if (F_ISSET(clayered, WT_CLAYERED_STABLE_NO_CKPT)) {
+        WT_ASSERT_ALWAYS(session, !leader, "Leader should never have NO_CKPT flag.");
+
         const char *checkpoint_name_chk = NULL;
         int tmp_ret =
           __wt_meta_checkpoint_last_name(session, stable_uri, &checkpoint_name_chk, NULL, NULL);


### PR DESCRIPTION
When we open a layered cursor on a follower we check for the last checkpoint and if there hasn't been any checkpoint yet we open a live btree for an empty stable table which is fine. The logic looks like:

```c
WT_ERR_NOTFOUND_OK(
    __wt_meta_checkpoint_last_name(session, stable_uri, &checkpoint_name, NULL, NULL), true);

if (ret == WT_NOTFOUND) {
    // open live btree
}
```

However there might be a race when a checkpoint arrives right after __wt_meta_checkpoint_last_name so we end up opening a shared live btree for a checkpoint on a follower which could lead to a data corruption, if we have a step up event right after we do this so we then write this old checkpoint to the disk.

The assertion that we add in this PR should protect us from having this issue in production. It'll just abort the process so it won't lead to a DC.