### PR TITLE
WT-17255 Fix SIGSEGV in __wti_blkcache_tiered_open

### DIFF
--- a/src/block_cache/block_tier.c
+++ b/src/block_cache/block_tier.c
@@ -93,8 +93,8 @@ __wti_blkcache_tiered_open(
         WT_WITH_BUCKET_STORAGE(bstorage, session,
           ret =
             __wt_block_open(session, tmp->mem, objectid, cfg, false, true, true, 0, NULL, &block));
-        block->remote = true;
         WT_ERR(ret);
+        block->remote = true;
     }
 
     *blockp = block;


### PR DESCRIPTION
## Summary
- `__wti_blkcache_tiered_open` dereferenced `block->remote` before checking the return value of `__wt_block_open`
- If `__wt_block_open` fails, it leaves `*blockp = NULL`; accessing `block->remote` then causes a SIGSEGV
- Fix: move `block->remote = true` after `WT_ERR(ret)` so it is only reached on success

🤖 Generated with [Claude Code](https://claude.com/claude-code)