### PR TITLE
WT-17262 Derive ingest URI from stable URI during prepare discover restoration

### DIFF
--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1568,7 +1568,7 @@ extern int __wti_prefetch_destroy(WT_SESSION_IMPL *session)
 extern int __wti_prepared_discover_add_artifact_upd(WT_SESSION_IMPL *session, WT_UPDATE *upd,
   WT_ITEM *key) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_prepared_discover_restore_and_add_artifact_upd(WT_SESSION_IMPL *session,
-  const char *stable_uri, WT_ITEM *key, WT_ITEM *value, WT_CELL_UNPACK_KV *unpack)
+  WT_CURSOR *ingest_cursor, WT_ITEM *key, WT_ITEM *value, WT_CELL_UNPACK_KV *unpack)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_row_ikey(WT_SESSION_IMPL *session, uint32_t cell_offset, const void *key,
   size_t size, WT_REF *ref) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/prepared_discover/prepared_discover_txn.c
+++ b/src/prepared_discover/prepared_discover_txn.c
@@ -205,38 +205,34 @@ int
 __wti_prepared_discover_restore_and_add_artifact_upd(WT_SESSION_IMPL *session,
   const char *stable_uri, WT_ITEM *key, WT_ITEM *value, WT_CELL_UNPACK_KV *unpack)
 {
-    WT_CONNECTION_IMPL *conn;
     WT_CURSOR *cursor;
     WT_CURSOR_BTREE *cbt;
+    WT_DECL_ITEM(ingest_uri_buf);
     WT_DECL_RET;
-    WT_LAYERED_TABLE_MANAGER *manager;
-    WT_LAYERED_TABLE_MANAGER_ENTRY *entry;
     WT_UPDATE *upd;
-    uint32_t i, table_count;
+    size_t prefix_len, size;
+    const char *stable_suffix;
 
     const char *cfg[] = {WT_CONFIG_BASE(session, WT_SESSION_open_cursor), "overwrite", NULL, NULL};
 
     cursor = NULL;
-    entry = NULL;
-    conn = S2C(session);
-    manager = &conn->layered_table_manager;
-    table_count = manager->open_layered_table_count;
-    for (i = 0; i < table_count; i++) {
-        /* Find the entry with stable uri that matches the currently opened dhandle. */
-        if (manager->entries[i] != NULL) {
-            if (WT_PREFIX_MATCH(stable_uri, manager->entries[i]->stable_uri)) {
-                entry = manager->entries[i];
-                break;
-            }
-        }
-    }
-    WT_ASSERT_ALWAYS(
-      session, entry != NULL, "Unable to find matching ingest table to restore prepared update");
-    /* Open cursor on the ingest table */
-    WT_ERR(__wt_open_cursor(session, entry->ingest_uri, NULL, cfg, &cursor));
+
+    /*
+     * Derive the ingest URI from the stable URI by the schema_create convention: layered:X has
+     * stable component file:X.wt_stable and ingest component file:X.wt_ingest. The stable_uri
+     * passed in also carries a /<checkpoint> suffix that is dropped here.
+     */
+    stable_suffix = strstr(stable_uri, ".wt_stable");
+    WT_ASSERT_ALWAYS(session, stable_suffix != NULL,
+      "prepared update restoration expected stable btree URI, got %s", stable_uri);
+    prefix_len = (size_t)(stable_suffix - stable_uri);
+
+    WT_ERR(__wt_scr_alloc(session, 0, &ingest_uri_buf));
+    WT_ERR(__wt_buf_fmt(session, ingest_uri_buf, "%.*s.wt_ingest", (int)prefix_len, stable_uri));
+
+    WT_ERR(__wt_open_cursor(session, ingest_uri_buf->data, NULL, cfg, &cursor));
 
     cbt = (WT_CURSOR_BTREE *)cursor;
-    size_t size;
     WT_ERR(__prepare_discover_alloc_upd(session, value, unpack, &upd, &size));
 
     /* Search the page and apply the modification. */
@@ -247,5 +243,6 @@ __wti_prepared_discover_restore_and_add_artifact_upd(WT_SESSION_IMPL *session,
 err:
     if (cursor != NULL)
         WT_TRET(cursor->close(cursor));
+    __wt_scr_free(session, &ingest_uri_buf);
     return (ret);
 }

--- a/src/prepared_discover/prepared_discover_txn.c
+++ b/src/prepared_discover/prepared_discover_txn.c
@@ -195,54 +195,50 @@ __wti_prepared_discover_add_artifact_upd(WT_SESSION_IMPL *session, WT_UPDATE *up
 }
 
 /*
+ * __prepared_discover_apply_upd_on_ingest --
+ *     Search the ingest btree for the key, write the update, and register the prepared artifact.
+ *     Must be called with session->dhandle set to the ingest btree.
+ *
+ * The cursor is reused across keys in the same walk: the row search overwrites cbt->ref without
+ *     releasing the prior hazard pointer, so it must be released here before each search.
+ *
+ * Artifact registration must run with the ingest dhandle active so that op->btree is captured as
+ *     the ingest btree; the prepared transaction commit searches that btree to resolve the op.
+ */
+static int
+__prepared_discover_apply_upd_on_ingest(
+  WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_ITEM *key, WT_UPDATE *upd)
+{
+    WT_DECL_RET;
+
+    if (cbt->ref != NULL) {
+        WT_RET(__wt_page_release(session, cbt->ref, 0));
+        cbt->ref = NULL;
+    }
+    WT_WITH_PAGE_INDEX(session, ret = __wt_row_search(cbt, key, true, NULL, false, NULL));
+    WT_RET(ret);
+    WT_RET(__wt_row_modify(cbt, key, NULL, &upd, WT_UPDATE_INVALID, true, true));
+    return (__wti_prepared_discover_add_artifact_upd(session, upd, key));
+}
+
+/*
  * __wti_prepared_discover_restore_and_add_artifact_upd --
- *     In disaggregated storage, in follower mode, stable table cannot be modified, therefore a
- *     prepared update needs to be restored onto ingest table so that the follower node can then
- *     commit the prepared transaction. This function opens the ingest table and inserts the update
- *     restored from disk onto the ingest table.
+ *     In disaggregated storage, follower nodes cannot modify the stable table, so a prepared update
+ *     found on disk must be restored onto the ingest table for later commit. The ingest cursor is
+ *     supplied by the caller and reused across all prepared keys in the same btree walk.
  */
 int
 __wti_prepared_discover_restore_and_add_artifact_upd(WT_SESSION_IMPL *session,
-  const char *stable_uri, WT_ITEM *key, WT_ITEM *value, WT_CELL_UNPACK_KV *unpack)
+  WT_CURSOR *ingest_cursor, WT_ITEM *key, WT_ITEM *value, WT_CELL_UNPACK_KV *unpack)
 {
-    WT_CURSOR *cursor;
     WT_CURSOR_BTREE *cbt;
-    WT_DECL_ITEM(ingest_uri_buf);
     WT_DECL_RET;
     WT_UPDATE *upd;
-    size_t prefix_len, size;
-    const char *stable_suffix;
+    size_t size;
 
-    const char *cfg[] = {WT_CONFIG_BASE(session, WT_SESSION_open_cursor), "overwrite", NULL, NULL};
-
-    cursor = NULL;
-
-    /*
-     * Derive the ingest URI from the stable URI by the schema_create convention: layered:X has
-     * stable component file:X.wt_stable and ingest component file:X.wt_ingest. The stable_uri
-     * passed in also carries a /<checkpoint> suffix that is dropped here.
-     */
-    stable_suffix = strstr(stable_uri, ".wt_stable");
-    WT_ASSERT_ALWAYS(session, stable_suffix != NULL,
-      "prepared update restoration expected stable btree URI, got %s", stable_uri);
-    prefix_len = (size_t)(stable_suffix - stable_uri);
-
-    WT_ERR(__wt_scr_alloc(session, 0, &ingest_uri_buf));
-    WT_ERR(__wt_buf_fmt(session, ingest_uri_buf, "%.*s.wt_ingest", (int)prefix_len, stable_uri));
-
-    WT_ERR(__wt_open_cursor(session, ingest_uri_buf->data, NULL, cfg, &cursor));
-
-    cbt = (WT_CURSOR_BTREE *)cursor;
-    WT_ERR(__prepare_discover_alloc_upd(session, value, unpack, &upd, &size));
-
-    /* Search the page and apply the modification. */
-    WT_WITH_PAGE_INDEX(session, ret = __wt_row_search(cbt, key, true, NULL, false, NULL));
-    WT_ERR(ret);
-    WT_ERR(__wt_row_modify(cbt, key, NULL, &upd, WT_UPDATE_INVALID, true, true));
-    WT_ERR(__wti_prepared_discover_add_artifact_upd(session, upd, key));
-err:
-    if (cursor != NULL)
-        WT_TRET(cursor->close(cursor));
-    __wt_scr_free(session, &ingest_uri_buf);
+    cbt = (WT_CURSOR_BTREE *)ingest_cursor;
+    WT_RET(__prepare_discover_alloc_upd(session, value, unpack, &upd, &size));
+    WT_WITH_DHANDLE(
+      session, cbt->dhandle, ret = __prepared_discover_apply_upd_on_ingest(session, cbt, key, upd));
     return (ret);
 }

--- a/src/prepared_discover/prepared_discover_walk.c
+++ b/src/prepared_discover/prepared_discover_walk.c
@@ -36,12 +36,48 @@ __prepared_discover_btree_has_prepare(WT_SESSION_IMPL *session, const char *conf
 }
 
 /*
+ * __prepared_discover_open_ingest_cursor --
+ *     Open the ingest cursor for the current stable btree. Called lazily the first time a prepared
+ *     on-disk key is found during a follower walk, so the open is skipped entirely when no prepared
+ *     content exists.
+ */
+static int
+__prepared_discover_open_ingest_cursor(WT_SESSION_IMPL *session, WT_CURSOR **ingest_cursorp)
+{
+    WT_DECL_ITEM(ingest_uri_buf);
+    WT_DECL_RET;
+    size_t prefix_len;
+    const char *stable_suffix, *stable_uri;
+
+    const char *cfg[] = {WT_CONFIG_BASE(session, WT_SESSION_open_cursor), "overwrite", NULL, NULL};
+
+    stable_uri = session->dhandle->name;
+    stable_suffix = strstr(stable_uri, ".wt_stable");
+    WT_ASSERT_ALWAYS(session, stable_suffix != NULL,
+      "prepared update restoration expected stable btree URI, got %s", stable_uri);
+    prefix_len = (size_t)(stable_suffix - stable_uri);
+
+    WT_ERR(__wt_scr_alloc(session, 0, &ingest_uri_buf));
+    WT_ERR(__wt_buf_fmt(session, ingest_uri_buf, "%.*s.wt_ingest", (int)prefix_len, stable_uri));
+    /*
+     * Preserve the stable btree as session->dhandle for the ongoing walk by saving and restoring it
+     * around the cursor open.
+     */
+    WT_SAVE_DHANDLE(
+      session, ret = __wt_open_cursor(session, ingest_uri_buf->data, NULL, cfg, ingest_cursorp));
+    WT_ERR(ret);
+err:
+    __wt_scr_free(session, &ingest_uri_buf);
+    return (ret);
+}
+
+/*
  * __prepared_discover_process_ondisk_kv --
  *     Found an on-disk prepared value, process it into a transaction structure.
  */
 static int
 __prepared_discover_process_ondisk_kv(WT_SESSION_IMPL *session, WT_REF *ref, WT_ROW *rip,
-  uint64_t recno, WT_ITEM *row_key, WT_CELL_UNPACK_KV *vpack)
+  uint64_t recno, WT_ITEM *row_key, WT_CELL_UNPACK_KV *vpack, WT_CURSOR **ingest_cursorp)
 {
     WT_DECL_ITEM(value);
     WT_DECL_RET;
@@ -79,12 +115,14 @@ __prepared_discover_process_ondisk_kv(WT_SESSION_IMPL *session, WT_REF *ref, WT_
           __wt_conn_is_disagg(session) && !S2C(session)->layered_table_manager.leader,
           "prepared update restoration should only happen on disaggregated follower nodes");
 
+        /* Open the ingest cursor on first use. */
+        if (*ingest_cursorp == NULL)
+            WT_ERR(__prepared_discover_open_ingest_cursor(session, ingest_cursorp));
+
         WT_ERR(__wt_scr_alloc(session, 0, &value));
         WT_ERR(__wt_page_cell_data_ref_kv(session, page, vpack, value));
-        const char *stable_uri = session->dhandle->name;
-        WT_SAVE_DHANDLE(session,
-          ret = __wti_prepared_discover_restore_and_add_artifact_upd(
-            session, stable_uri, key, value, vpack));
+        WT_ERR(__wti_prepared_discover_restore_and_add_artifact_upd(
+          session, *ingest_cursorp, key, value, vpack));
     } else
         WT_ASSERT_ALWAYS(
           session, false, "Column store prepared transaction discovery not supported");
@@ -101,7 +139,7 @@ err:
  */
 static int
 __prepared_discover_check_ondisk_kv(WT_SESSION_IMPL *session, WT_REF *ref, WT_ROW *rip,
-  uint64_t recno, WT_ITEM *row_key, WT_CELL_UNPACK_KV *vpack)
+  uint64_t recno, WT_ITEM *row_key, WT_CELL_UNPACK_KV *vpack, WT_CURSOR **ingest_cursorp)
 {
     WT_TIME_WINDOW *tw;
 
@@ -119,7 +157,8 @@ __prepared_discover_check_ondisk_kv(WT_SESSION_IMPL *session, WT_REF *ref, WT_RO
     if (!WT_TIME_WINDOW_HAS_PREPARE(tw))
         return (0);
 
-    WT_RET(__prepared_discover_process_ondisk_kv(session, ref, rip, recno, row_key, vpack));
+    WT_RET(__prepared_discover_process_ondisk_kv(
+      session, ref, rip, recno, row_key, vpack, ingest_cursorp));
 
     return (0);
 }
@@ -210,7 +249,8 @@ err:
  *     or have been modified. So handle the full possible page structure, not just a clean image.
  */
 static int
-__prepared_discover_process_row_store_leaf_page(WT_SESSION_IMPL *session, WT_REF *ref)
+__prepared_discover_process_row_store_leaf_page(
+  WT_SESSION_IMPL *session, WT_REF *ref, WT_CURSOR **ingest_cursorp)
 {
     WT_CELL_UNPACK_KV *vpack, _vpack;
     WT_DECL_ITEM(key);
@@ -246,7 +286,8 @@ __prepared_discover_process_row_store_leaf_page(WT_SESSION_IMPL *session, WT_REF
             vpack = &_vpack;
             __wt_row_leaf_value_cell(session, page, rip, vpack);
 
-            WT_ERR(__prepared_discover_check_ondisk_kv(session, ref, rip, 0, NULL, vpack));
+            WT_ERR(__prepared_discover_check_ondisk_kv(
+              session, ref, rip, 0, NULL, vpack, ingest_cursorp));
         }
 
         /* Walk through any intermediate insert list. */
@@ -265,7 +306,8 @@ err:
  *     Review the content of a leaf page discovering and processing prepared updates.
  */
 static int
-__prepared_discover_process_leaf_page(WT_SESSION_IMPL *session, WT_REF *ref)
+__prepared_discover_process_leaf_page(
+  WT_SESSION_IMPL *session, WT_REF *ref, WT_CURSOR **ingest_cursorp)
 {
     WT_PAGE *page;
 
@@ -273,7 +315,7 @@ __prepared_discover_process_leaf_page(WT_SESSION_IMPL *session, WT_REF *ref)
 
     switch (page->type) {
     case WT_PAGE_ROW_LEAF:
-        WT_RET(__prepared_discover_process_row_store_leaf_page(session, ref));
+        WT_RET(__prepared_discover_process_row_store_leaf_page(session, ref, ingest_cursorp));
         break;
     case WT_PAGE_COL_VAR:
         WT_ASSERT_ALWAYS(session, false, "Prepared discovery does not support column stores");
@@ -369,9 +411,12 @@ static int
 __prepared_discover_walk_one_tree(WT_SESSION_IMPL *session, const char *uri)
 {
     WT_BTREE *btree;
+    WT_CURSOR *ingest_cursor;
     WT_DECL_RET;
     WT_REF *ref;
     uint32_t flags;
+
+    ingest_cursor = NULL;
 
     /* Open a handle for processing. */
     ret = __wt_session_get_dhandle(session, uri, NULL, NULL, 0);
@@ -389,10 +434,12 @@ __prepared_discover_walk_one_tree(WT_SESSION_IMPL *session, const char *uri)
           ref != NULL) {
 
             if (F_ISSET(ref, WT_REF_FLAG_LEAF))
-                WT_ERR(__prepared_discover_process_leaf_page(session, ref));
+                WT_ERR(__prepared_discover_process_leaf_page(session, ref, &ingest_cursor));
         }
     }
 err:
+    if (ingest_cursor != NULL)
+        WT_TRET(ingest_cursor->close(ingest_cursor));
     WT_TRET(__wt_session_release_dhandle(session));
     return (ret);
 }

--- a/src/prepared_discover/prepared_discover_walk.c
+++ b/src/prepared_discover/prepared_discover_walk.c
@@ -398,6 +398,47 @@ err:
 }
 
 /*
+ * __prepared_discover_open_paired_layered --
+ *     If the btree URI is the stable component of a layered table, open (and release) the paired
+ *     layered dhandle. Opening a layered dhandle registers its stable-to-ingest mapping in the
+ *     layered table manager, which the restoration path relies on to locate the ingest table for
+ *     each prepared update pulled from the stable btree. The mapping is populated lazily when a
+ *     layered dhandle is opened; nothing else in this code path opens one.
+ */
+static int
+__prepared_discover_open_paired_layered(WT_SESSION_IMPL *session, const char *stable_uri)
+{
+    WT_DECL_ITEM(layered_uri_buf);
+    WT_DECL_RET;
+    size_t table_name_len;
+    const char *table_name;
+
+    if (!WT_PREFIX_MATCH(stable_uri, "file:") || !WT_SUFFIX_MATCH(stable_uri, ".wt_stable"))
+        return (0);
+
+    table_name = stable_uri + strlen("file:");
+    table_name_len = strlen(table_name) - strlen(".wt_stable");
+
+    WT_ERR(__wt_scr_alloc(session, 0, &layered_uri_buf));
+    WT_ERR(
+      __wt_buf_fmt(session, layered_uri_buf, "layered:%.*s", (int)table_name_len, table_name));
+
+    /*
+     * The stable suffix is also used by a handful of non-layered system files (shared metadata,
+     * shared history store). Treat "no matching layered entry" as a normal outcome and move on.
+     */
+    WT_ERR_NOTFOUND_OK(
+      __wt_session_get_dhandle(session, layered_uri_buf->data, NULL, NULL, 0), false);
+    if (ret == 0)
+        WT_ERR(__wt_session_release_dhandle(session));
+    ret = 0;
+
+err:
+    __wt_scr_free(session, &layered_uri_buf);
+    return (ret);
+}
+
+/*
  * __wt_prepared_discover_filter_apply_handles --
  *     Review the metadata and identify btrees that have prepared content that needs to be
  *     discovered
@@ -429,6 +470,13 @@ __wt_prepared_discover_filter_apply_handles(WT_SESSION_IMPL *session)
         WT_ERR(__prepared_discover_btree_has_prepare(session, config, &has_prepare));
         if (!has_prepare)
             continue;
+        /*
+         * FIXME-WT-16982: The dhandle is released here but the scan of the stable btree that
+         * follows relies on the layered table manager entry still being present. That holds only
+         * while the dhandle sweeper does not close the layered handle; if it does, the entry is
+         * removed and the restore lookup below fails.
+         */
+        WT_ERR(__prepared_discover_open_paired_layered(session, uri));
         /* If this is a follower node, open the stable table and search for prepared update there */
         if (__wt_conn_is_disagg(session) && !S2C(session)->layered_table_manager.leader) {
             /* Look up the most recent data store checkpoint. This fetches the exact name to use. */

--- a/src/prepared_discover/prepared_discover_walk.c
+++ b/src/prepared_discover/prepared_discover_walk.c
@@ -398,47 +398,6 @@ err:
 }
 
 /*
- * __prepared_discover_open_paired_layered --
- *     If the btree URI is the stable component of a layered table, open (and release) the paired
- *     layered dhandle. Opening a layered dhandle registers its stable-to-ingest mapping in the
- *     layered table manager, which the restoration path relies on to locate the ingest table for
- *     each prepared update pulled from the stable btree. The mapping is populated lazily when a
- *     layered dhandle is opened; nothing else in this code path opens one.
- */
-static int
-__prepared_discover_open_paired_layered(WT_SESSION_IMPL *session, const char *stable_uri)
-{
-    WT_DECL_ITEM(layered_uri_buf);
-    WT_DECL_RET;
-    size_t table_name_len;
-    const char *table_name;
-
-    if (!WT_PREFIX_MATCH(stable_uri, "file:") || !WT_SUFFIX_MATCH(stable_uri, ".wt_stable"))
-        return (0);
-
-    table_name = stable_uri + strlen("file:");
-    table_name_len = strlen(table_name) - strlen(".wt_stable");
-
-    WT_ERR(__wt_scr_alloc(session, 0, &layered_uri_buf));
-    WT_ERR(
-      __wt_buf_fmt(session, layered_uri_buf, "layered:%.*s", (int)table_name_len, table_name));
-
-    /*
-     * The stable suffix is also used by a handful of non-layered system files (shared metadata,
-     * shared history store). Treat "no matching layered entry" as a normal outcome and move on.
-     */
-    WT_ERR_NOTFOUND_OK(
-      __wt_session_get_dhandle(session, layered_uri_buf->data, NULL, NULL, 0), false);
-    if (ret == 0)
-        WT_ERR(__wt_session_release_dhandle(session));
-    ret = 0;
-
-err:
-    __wt_scr_free(session, &layered_uri_buf);
-    return (ret);
-}
-
-/*
  * __wt_prepared_discover_filter_apply_handles --
  *     Review the metadata and identify btrees that have prepared content that needs to be
  *     discovered
@@ -470,13 +429,6 @@ __wt_prepared_discover_filter_apply_handles(WT_SESSION_IMPL *session)
         WT_ERR(__prepared_discover_btree_has_prepare(session, config, &has_prepare));
         if (!has_prepare)
             continue;
-        /*
-         * FIXME-WT-16982: The dhandle is released here but the scan of the stable btree that
-         * follows relies on the layered table manager entry still being present. That holds only
-         * while the dhandle sweeper does not close the layered handle; if it does, the entry is
-         * removed and the restore lookup below fails.
-         */
-        WT_ERR(__prepared_discover_open_paired_layered(session, uri));
         /* If this is a follower node, open the stable table and search for prepared update there */
         if (__wt_conn_is_disagg(session) && !S2C(session)->layered_table_manager.leader) {
             /* Look up the most recent data store checkpoint. This fetches the exact name to use. */

--- a/src/prepared_discover/prepared_discover_walk.c
+++ b/src/prepared_discover/prepared_discover_walk.c
@@ -37,9 +37,8 @@ __prepared_discover_btree_has_prepare(WT_SESSION_IMPL *session, const char *conf
 
 /*
  * __prepared_discover_open_ingest_cursor --
- *     Open the ingest cursor for the current stable btree. Called lazily the first time a prepared
- *     on-disk key is found during a follower walk, so the open is skipped entirely when no prepared
- *     content exists.
+ *     Derive the ingest URI from the current stable btree handle and open a cursor on it. The
+ *     stable btree is preserved as session->dhandle across the open.
  */
 static int
 __prepared_discover_open_ingest_cursor(WT_SESSION_IMPL *session, WT_CURSOR **ingest_cursorp)
@@ -48,7 +47,6 @@ __prepared_discover_open_ingest_cursor(WT_SESSION_IMPL *session, WT_CURSOR **ing
     WT_DECL_RET;
     size_t prefix_len;
     const char *stable_suffix, *stable_uri;
-
     const char *cfg[] = {WT_CONFIG_BASE(session, WT_SESSION_open_cursor), "overwrite", NULL, NULL};
 
     stable_uri = session->dhandle->name;
@@ -56,13 +54,8 @@ __prepared_discover_open_ingest_cursor(WT_SESSION_IMPL *session, WT_CURSOR **ing
     WT_ASSERT_ALWAYS(session, stable_suffix != NULL,
       "prepared update restoration expected stable btree URI, got %s", stable_uri);
     prefix_len = (size_t)(stable_suffix - stable_uri);
-
     WT_ERR(__wt_scr_alloc(session, 0, &ingest_uri_buf));
     WT_ERR(__wt_buf_fmt(session, ingest_uri_buf, "%.*s.wt_ingest", (int)prefix_len, stable_uri));
-    /*
-     * Preserve the stable btree as session->dhandle for the ongoing walk by saving and restoring it
-     * around the cursor open.
-     */
     WT_SAVE_DHANDLE(
       session, ret = __wt_open_cursor(session, ingest_uri_buf->data, NULL, cfg, ingest_cursorp));
     WT_ERR(ret);
@@ -77,7 +70,7 @@ err:
  */
 static int
 __prepared_discover_process_ondisk_kv(WT_SESSION_IMPL *session, WT_REF *ref, WT_ROW *rip,
-  uint64_t recno, WT_ITEM *row_key, WT_CELL_UNPACK_KV *vpack, WT_CURSOR **ingest_cursorp)
+  uint64_t recno, WT_ITEM *row_key, WT_CELL_UNPACK_KV *vpack, WT_CURSOR *ingest_cursor)
 {
     WT_DECL_ITEM(value);
     WT_DECL_RET;
@@ -115,14 +108,10 @@ __prepared_discover_process_ondisk_kv(WT_SESSION_IMPL *session, WT_REF *ref, WT_
           __wt_conn_is_disagg(session) && !S2C(session)->layered_table_manager.leader,
           "prepared update restoration should only happen on disaggregated follower nodes");
 
-        /* Open the ingest cursor on first use. */
-        if (*ingest_cursorp == NULL)
-            WT_ERR(__prepared_discover_open_ingest_cursor(session, ingest_cursorp));
-
         WT_ERR(__wt_scr_alloc(session, 0, &value));
         WT_ERR(__wt_page_cell_data_ref_kv(session, page, vpack, value));
         WT_ERR(__wti_prepared_discover_restore_and_add_artifact_upd(
-          session, *ingest_cursorp, key, value, vpack));
+          session, ingest_cursor, key, value, vpack));
     } else
         WT_ASSERT_ALWAYS(
           session, false, "Column store prepared transaction discovery not supported");
@@ -139,7 +128,7 @@ err:
  */
 static int
 __prepared_discover_check_ondisk_kv(WT_SESSION_IMPL *session, WT_REF *ref, WT_ROW *rip,
-  uint64_t recno, WT_ITEM *row_key, WT_CELL_UNPACK_KV *vpack, WT_CURSOR **ingest_cursorp)
+  uint64_t recno, WT_ITEM *row_key, WT_CELL_UNPACK_KV *vpack, WT_CURSOR *ingest_cursor)
 {
     WT_TIME_WINDOW *tw;
 
@@ -158,7 +147,7 @@ __prepared_discover_check_ondisk_kv(WT_SESSION_IMPL *session, WT_REF *ref, WT_RO
         return (0);
 
     WT_RET(__prepared_discover_process_ondisk_kv(
-      session, ref, rip, recno, row_key, vpack, ingest_cursorp));
+      session, ref, rip, recno, row_key, vpack, ingest_cursor));
 
     return (0);
 }
@@ -250,7 +239,7 @@ err:
  */
 static int
 __prepared_discover_process_row_store_leaf_page(
-  WT_SESSION_IMPL *session, WT_REF *ref, WT_CURSOR **ingest_cursorp)
+  WT_SESSION_IMPL *session, WT_REF *ref, WT_CURSOR *ingest_cursor)
 {
     WT_CELL_UNPACK_KV *vpack, _vpack;
     WT_DECL_ITEM(key);
@@ -287,7 +276,7 @@ __prepared_discover_process_row_store_leaf_page(
             __wt_row_leaf_value_cell(session, page, rip, vpack);
 
             WT_ERR(__prepared_discover_check_ondisk_kv(
-              session, ref, rip, 0, NULL, vpack, ingest_cursorp));
+              session, ref, rip, 0, NULL, vpack, ingest_cursor));
         }
 
         /* Walk through any intermediate insert list. */
@@ -307,7 +296,7 @@ err:
  */
 static int
 __prepared_discover_process_leaf_page(
-  WT_SESSION_IMPL *session, WT_REF *ref, WT_CURSOR **ingest_cursorp)
+  WT_SESSION_IMPL *session, WT_REF *ref, WT_CURSOR *ingest_cursor)
 {
     WT_PAGE *page;
 
@@ -315,7 +304,7 @@ __prepared_discover_process_leaf_page(
 
     switch (page->type) {
     case WT_PAGE_ROW_LEAF:
-        WT_RET(__prepared_discover_process_row_store_leaf_page(session, ref, ingest_cursorp));
+        WT_RET(__prepared_discover_process_row_store_leaf_page(session, ref, ingest_cursor));
         break;
     case WT_PAGE_COL_VAR:
         WT_ASSERT_ALWAYS(session, false, "Prepared discovery does not support column stores");
@@ -427,6 +416,13 @@ __prepared_discover_walk_one_tree(WT_SESSION_IMPL *session, const char *uri)
     btree = S2BT(session);
     /* There is nothing to do on an empty tree. */
     if (btree->root.page != NULL) {
+        /*
+         * On a follower, open the ingest cursor before walking so it is ready for every prepared
+         * key encountered in the stable checkpoint.
+         */
+        if (__wt_conn_is_disagg(session) && !S2C(session)->layered_table_manager.leader)
+            WT_ERR(__prepared_discover_open_ingest_cursor(session, &ingest_cursor));
+
         flags = WT_READ_NO_EVICT | WT_READ_VISIBLE_ALL | WT_READ_WONT_NEED | WT_READ_SEE_DELETED;
         ref = NULL;
         while ((ret = __wt_tree_walk_custom_skip(
@@ -434,7 +430,7 @@ __prepared_discover_walk_one_tree(WT_SESSION_IMPL *session, const char *uri)
           ref != NULL) {
 
             if (F_ISSET(ref, WT_REF_FLAG_LEAF))
-                WT_ERR(__prepared_discover_process_leaf_page(session, ref, &ingest_cursor));
+                WT_ERR(__prepared_discover_process_leaf_page(session, ref, ingest_cursor));
         }
     }
 err:

--- a/test/suite/test_prepare_discover08.py
+++ b/test/suite/test_prepare_discover08.py
@@ -27,9 +27,10 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 # test_prepare_discover08.py
-#   After reopening as a follower, "prepared_discover:" must discover and
-#   allow claims of on-disk prepared transactions even when no cursor has
-#   yet been opened on the layered table on the new connection.
+#   After reopening the connection, "prepared_discover:" must discover and
+#   allow claims of the persisted prepared transaction even when no cursor
+#   has yet been opened on the layered table on the new connection. Exercised
+#   for both roles the connection can come back as.
 
 import wttest
 from helper_disagg import disagg_test_class, gen_disagg_storages
@@ -40,8 +41,12 @@ class test_prepare_discover08(wttest.WiredTigerTestCase):
     tablename = 'test_prepare_discover08'
     uri = 'layered:' + tablename
 
+    role_scenarios = [
+        ('standby', dict(reopen_role='follower')),
+        ('primary', dict(reopen_role='leader')),
+    ]
     disagg_storages = gen_disagg_storages('test_prepare_discover08', disagg_only=True)
-    scenarios = make_scenarios(disagg_storages)
+    scenarios = make_scenarios(disagg_storages, role_scenarios)
 
     conn_base_config = ('cache_size=10MB,statistics=(all),'
                         'precise_checkpoint=true,preserve_prepared=true,')
@@ -82,18 +87,20 @@ class test_prepare_discover08(wttest.WiredTigerTestCase):
 
         cursor.close()
 
-        # Capture checkpoint metadata while the leader connection is still open,
-        # then reopen as a follower that picks up that checkpoint.
+        # Capture checkpoint metadata while the original leader connection is
+        # still open, then reopen in the role this scenario targets.
         checkpoint_meta = self.disagg_get_complete_checkpoint_meta()
-        follower_config = (self.conn_base_config +
-                           'disaggregated=(role="follower",'
-                           f'checkpoint_meta="{checkpoint_meta}")')
-        self.reopen_conn(config=follower_config)
+        if self.reopen_role == 'follower':
+            reopen_config = (self.conn_base_config +
+                             'disaggregated=(role="follower",'
+                             f'checkpoint_meta="{checkpoint_meta}")')
+        else:
+            reopen_config = self.conn_base_config + 'disaggregated=(role="leader")'
+        self.reopen_conn(config=reopen_config)
 
         # Opening "prepared_discover:" must work as the first cursor on the
-        # reopened connection — prior to this test, successful discovery on a
-        # follower relied on the caller having already opened a cursor on the
-        # layered table.
+        # reopened connection — successful discovery must not depend on a
+        # prior cursor having been opened on the layered table.
         prepared_discover_cursor = self.session.open_cursor('prepared_discover:')
 
         claim_session = self.conn.open_session()

--- a/test/suite/test_prepare_discover08.py
+++ b/test/suite/test_prepare_discover08.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# test_prepare_discover08.py
+#   After reopening as a follower, "prepared_discover:" must discover and
+#   allow claims of on-disk prepared transactions even when no cursor has
+#   yet been opened on the layered table on the new connection.
+
+import wttest
+from helper_disagg import disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
+
+@disagg_test_class
+class test_prepare_discover08(wttest.WiredTigerTestCase):
+    tablename = 'test_prepare_discover08'
+    uri = 'layered:' + tablename
+
+    disagg_storages = gen_disagg_storages('test_prepare_discover08', disagg_only=True)
+    scenarios = make_scenarios(disagg_storages)
+
+    conn_base_config = ('cache_size=10MB,statistics=(all),'
+                        'precise_checkpoint=true,preserve_prepared=true,')
+
+    def conn_config(self):
+        return self.conn_base_config + 'disaggregated=(role="leader")'
+
+    def test_prepare_discover_first_cursor_on_connection(self):
+        prepared_id = 123
+
+        # Leader: commit some data, prepare a later transaction, advance stable
+        # past the prepare, then checkpoint so the prepared update is included.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(50))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(50))
+
+        self.session.create(self.uri, 'key_format=i,value_format=S')
+        cursor = self.session.open_cursor(self.uri)
+
+        self.session.begin_transaction()
+        for i in range(1, 4):
+            cursor[i] = f'committed_value_{i}'
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(60))
+
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(70))
+
+        self.session.begin_transaction()
+        for i in range(4, 7):
+            cursor[i] = f'prepared_value_{i}'
+        self.session.prepare_transaction(
+            'prepare_timestamp=' + self.timestamp_str(100) +
+            ',prepared_id=' + self.prepared_id_str(prepared_id))
+
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(150))
+
+        ckpt_session = self.conn.open_session()
+        ckpt_session.checkpoint()
+        ckpt_session.close()
+
+        cursor.close()
+
+        # Capture checkpoint metadata while the leader connection is still open,
+        # then reopen as a follower that picks up that checkpoint.
+        checkpoint_meta = self.disagg_get_complete_checkpoint_meta()
+        follower_config = (self.conn_base_config +
+                           'disaggregated=(role="follower",'
+                           f'checkpoint_meta="{checkpoint_meta}")')
+        self.reopen_conn(config=follower_config)
+
+        # Opening "prepared_discover:" must work as the first cursor on the
+        # reopened connection — prior to this test, successful discovery on a
+        # follower relied on the caller having already opened a cursor on the
+        # layered table.
+        prepared_discover_cursor = self.session.open_cursor('prepared_discover:')
+
+        claim_session = self.conn.open_session()
+        discovered = []
+        while prepared_discover_cursor.next() == 0:
+            discovered_id = prepared_discover_cursor.get_key()
+            discovered.append(discovered_id)
+            # Every prepared transaction found by the cursor must be claimed
+            # before the cursor is closed; claim it and commit here.
+            claim_session.begin_transaction(
+                'claim_prepared_id=' + self.prepared_id_str(discovered_id))
+            claim_session.commit_transaction(
+                'commit_timestamp=' + self.timestamp_str(200) +
+                ',durable_timestamp=' + self.timestamp_str(210))
+
+        self.assertEqual(discovered, [prepared_id])
+        prepared_discover_cursor.close()
+        claim_session.close()

--- a/test/suite/test_prepare_discover08.py
+++ b/test/suite/test_prepare_discover08.py
@@ -99,7 +99,7 @@ class test_prepare_discover08(wttest.WiredTigerTestCase):
         self.reopen_conn(config=reopen_config)
 
         # Opening "prepared_discover:" must work as the first cursor on the
-        # reopened connection  successful discovery must not depend on a
+        # reopened connection; successful discovery must not depend on a
         # prior cursor having been opened on the layered table.
         prepared_discover_cursor = self.session.open_cursor('prepared_discover:')
 

--- a/test/suite/test_prepare_discover08.py
+++ b/test/suite/test_prepare_discover08.py
@@ -99,7 +99,7 @@ class test_prepare_discover08(wttest.WiredTigerTestCase):
         self.reopen_conn(config=reopen_config)
 
         # Opening "prepared_discover:" must work as the first cursor on the
-        # reopened connection — successful discovery must not depend on a
+        # reopened connection  successful discovery must not depend on a
         # prior cursor having been opened on the layered table.
         prepared_discover_cursor = self.session.open_cursor('prepared_discover:')
 


### PR DESCRIPTION
Problem

When prepared_discover: is opened as the first cursor on a freshly reopened follower connection, it panics with an assertion failure. The restore path looked up the ingest URI via layered_table_manager.entries[], which is empty until a layered dhandle has been opened on the connection.

Solution

Derive the ingest URI directly from the stable URI using the naming convention (file:X.wt_stable/ckpt → file:X.wt_ingest), removing the dependency on the layered table manager entirely.

The ingest cursor is opened once per stable btree walk and reused across all prepared keys found, rather than once per key.