### PR TITLE
WT-17056 Update shared disk hash table entry destruction during page out

### DIFF
--- a/src/btree/bt_discard.c
+++ b/src/btree/bt_discard.c
@@ -149,9 +149,20 @@ __wt_page_out(WT_SESSION_IMPL *session, WT_PAGE **pagep)
         break;
     }
 
-    /* Discard any allocated disk image. */
-    if (F_ISSET_ATOMIC_16(page, WT_PAGE_DISK_ALLOC))
-        __wt_overwrite_and_free_len(session, dsk, dsk->mem_size);
+    /*
+     * Discard any allocated disk image. When the image is owned by the shared disk cache, release
+     * our reference instead of freeing the memory directly; the cache frees the data once the last
+     * reference is dropped.
+     */
+    if (F_ISSET_ATOMIC_16(page, WT_PAGE_DISK_ALLOC)) {
+        if (page->disagg_info != NULL && page->disagg_info->shared_dsk_item != NULL) {
+            WT_ASSERT(session, S2C(session)->cache->shared_dsk_cache.enabled);
+            WT_ASSERT(session, page->disagg_info->shared_dsk_item->data == dsk);
+            WT_ASSERT(session, page->disagg_info->shared_dsk_item->data_size == dsk->mem_size);
+            __wt_shared_dsk_cache_release(session, page->disagg_info->shared_dsk_item);
+        } else
+            __wt_overwrite_and_free_len(session, dsk, dsk->mem_size);
+    }
 
     __wt_overwrite_and_free(session, page);
 }

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -1258,10 +1258,6 @@ __wti_page_inmem(WT_SESSION_IMPL *session, WT_REF *ref, const void *image, uint3
     WT_RET(__wt_page_alloc(session, dsk->type, alloc_entries, true, &page, flags));
     __wt_tsan_suppress_store_wt_page_header_ptr(&page->dsk, dsk);
     F_SET_ATOMIC_16(page, flags);
-    /*
-     * FIXME-WT-17056: we should not free page->dsk during page out and handover the destruction to
-     * shared dsk hash table release function.
-     */
     WT_ASSERT(session, shared_dsk_item == NULL || page->disagg_info != NULL);
     if (page->disagg_info != NULL)
         page->disagg_info->shared_dsk_item = shared_dsk_item;

--- a/src/cache/shared_dsk.c
+++ b/src/cache/shared_dsk.c
@@ -206,7 +206,7 @@ __wt_shared_dsk_cache_release(WT_SESSION_IMPL *session, WT_SHARED_DSK_ITEM *shar
         __shared_dsk_cache_verbose(session, WT_VERBOSE_DEBUG_2,
           "release: disk image removed from shared dsk cache", hash, bucket, lock_idx,
           shared_dsk_item->addr, shared_dsk_item->addr_size);
-        __wt_free(session, shared_dsk_item->data);
+        __wt_overwrite_and_free_len(session, shared_dsk_item->data, shared_dsk_item->data_size);
         __wt_free(session, shared_dsk_item);
     } else {
         __wt_spin_unlock(session, &shared_dsk_cache->hash_locks[lock_idx]);
@@ -276,7 +276,7 @@ __wti_shared_dsk_cache_destroy(WT_SESSION_IMPL *session)
         while (!TAILQ_EMPTY(&shared_dsk_cache->hash[i])) {
             shared_dsk_item = TAILQ_FIRST(&shared_dsk_cache->hash[i]);
             TAILQ_REMOVE(&shared_dsk_cache->hash[i], shared_dsk_item, hashq);
-            __wt_free(session, shared_dsk_item->data);
+            __wt_overwrite_and_free_len(session, shared_dsk_item->data, shared_dsk_item->data_size);
             __wt_free(session, shared_dsk_item);
         }
     }


### PR DESCRIPTION
During page out, if shared disk cache is enabled, we should call __wt_shared_dsk_cache_release instead of just freeing the disk image, the release function will take care of the free logic -- only reduces the ref count and don't free disk image until the last page which shares the disk image is out.