### PR TITLE
WT-17271 Spin briefly before yielding in __ref_lock to reduce sched_yield overhead

### DIFF
--- a/src/include/ref_inline.h
+++ b/src/include/ref_inline.h
@@ -132,6 +132,14 @@ __ref_cas_state(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF_STATE old_state,
     __ref_cas_state(session, ref, old_state, new_state, __PRETTY_FUNCTION__, __LINE__)
 
 /*
+ * Default to spinning 100 times before yielding in __ref_lock. One-tenth of WT_SPIN_COUNT because
+ * __ref_lock protects a single CAS, not a general-purpose spinlock region.
+ */
+#ifndef WT_REF_SPIN_COUNT
+#define WT_REF_SPIN_COUNT WT_HUNDRED
+#endif
+
+/*
  * __ref_lock --
  *     Spin until successfully locking the ref. Return the previous state to the caller.
  */
@@ -139,11 +147,17 @@ static WT_INLINE void
 __ref_lock(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF_STATE *previous_statep)
 {
     WT_REF_STATE previous_state;
-    for (;; __wt_yield()) {
+    int i;
+
+    for (;;) {
         previous_state = WT_REF_GET_STATE(ref);
         if (previous_state != WT_REF_LOCKED &&
           WT_REF_CAS_STATE(session, ref, previous_state, WT_REF_LOCKED))
             break;
+        for (i = 0; WT_REF_GET_STATE(ref) == WT_REF_LOCKED && i < WT_REF_SPIN_COUNT; i++)
+            WT_PAUSE();
+        if (WT_REF_GET_STATE(ref) == WT_REF_LOCKED)
+            __wt_yield();
     }
     *(previous_statep) = previous_state;
 }

--- a/src/include/ref_inline.h
+++ b/src/include/ref_inline.h
@@ -131,13 +131,7 @@ __ref_cas_state(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF_STATE old_state,
 #define WT_REF_CAS_STATE(session, ref, old_state, new_state) \
     __ref_cas_state(session, ref, old_state, new_state, __PRETTY_FUNCTION__, __LINE__)
 
-/*
- * Default to spinning 100 times before yielding in __ref_lock. One-tenth of WT_SPIN_COUNT because
- * __ref_lock protects a single CAS, not a general-purpose spinlock region.
- */
-#ifndef WT_REF_SPIN_COUNT
 #define WT_REF_SPIN_COUNT WT_HUNDRED
-#endif
 
 /*
  * __ref_lock --
@@ -147,16 +141,20 @@ static WT_INLINE void
 __ref_lock(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF_STATE *previous_statep)
 {
     WT_REF_STATE previous_state;
-    int i;
-
     for (;;) {
         previous_state = WT_REF_GET_STATE(ref);
         if (previous_state != WT_REF_LOCKED &&
           WT_REF_CAS_STATE(session, ref, previous_state, WT_REF_LOCKED))
             break;
-        for (i = 0; WT_REF_GET_STATE(ref) == WT_REF_LOCKED && i < WT_REF_SPIN_COUNT; i++)
+
+        /*
+         * Default to spinning 100 times before yielding in __ref_lock. One-tenth of WT_SPIN_COUNT
+         * because __ref_lock protects a single CAS, not a general-purpose spinlock region.
+         */
+        int i;
+        for (i = 0; i < WT_REF_SPIN_COUNT && WT_REF_GET_STATE(ref) == WT_REF_LOCKED; i++)
             WT_PAUSE();
-        if (WT_REF_GET_STATE(ref) == WT_REF_LOCKED)
+        if (i == WT_REF_SPIN_COUNT)
             __wt_yield();
     }
     *(previous_statep) = previous_state;


### PR DESCRIPTION
Off-CPU profiling of a 100%-read MongoDB workload at 128 threads on ARM shows 48.5% of total blocked time in sched_yield, reached via WiredTiger contention paths. The source is __ref_lock, which guards WT_REF state transitions on every page-in, eviction, btree walk, compaction, and reconciliation.

Unlike __wt_spin_lock — which spins WT_SPIN_COUNT (1000) iterations of WT_PAUSE() before falling back to the kernel — __ref_lock yields on the first failed CAS. The critical section is a single atomic CAS on WT_REF.state, typically held for tens of nanoseconds, but every contention event generates a sched_yield syscall (~10-20 us on ARM) — orders of magnitude more expensive than the work being waited on.

Add a short WT_PAUSE() spin (100 iterations) to __ref_lock before it falls back to __wt_yield(), mirroring the established pattern in __wt_spin_lock. The inner loop polls WT_REF_GET_STATE so it exits as soon as the ref is released; only after 100 iterations does the thread yield. The 100-iteration count (vs 1000 in __wt_spin_lock) is deliberate: __ref_lock protects a single CAS, not a general-purpose spinlock region, so a shorter window is sufficient.

No change to locking semantics — __ref_lock still returns only after a successful CAS. Measured +1.19% on ycsb.out_of_cache.100read and broad improvements across TPC-C, ecommerce, upsert, bulk-insert, and ycsb 95read5update workloads on perf-3-node-replSet.arm.