### PR TITLE
WT-15507 Fix test_checkpoint06 on disagg

### DIFF
--- a/src/rollback_to_stable/rts_btree.c
+++ b/src/rollback_to_stable/rts_btree.c
@@ -789,8 +789,6 @@ __rts_btree_abort_ondisk_kv(WT_SESSION_IMPL *session, WT_REF *ref, WT_ROW *rip, 
             upd->prepare_ts = tw->start_prepare_ts;
             upd->prepared_id = tw->start_prepared_id;
             F_SET(upd, WT_UPDATE_RESTORED_FROM_DS);
-            if (F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED))
-                F_SET(upd, WT_UPDATE_DURABLE);
             WT_RTS_STAT_CONN_DATA_INCR(session, txn_rts_keys_restored);
             __wt_verbose_multi(session, WT_VERB_RECOVERY_RTS(session),
               WT_RTS_VERB_TAG_KEY_CLEAR_REMOVE

--- a/test/suite/hook_disagg.fail
+++ b/test/suite/hook_disagg.fail
@@ -2,7 +2,6 @@
 # This list are test files that are not run, they are known failures. The reasons for the failures are not known,
 # they'll need to be triaged. When we know something about the failure, they are commented.
 test_autoclose.py
-test_checkpoint06.py # FIXME: WT-15507
 test_config02.py
 test_config09.py
 test_cursor13.py  # FIXME: WT-15369


### PR DESCRIPTION
Summary
Remove incorrect WT_UPDATE_DURABLE flag from RTS-restored updates in disaggregated btrees
Remove test_checkpoint06.py from the disagg hook known-failures list

Root cause
When rollback-to-stable (RTS) rolls back a tombstone on a disaggregated btree (e.g., from a range truncation committed above stable timestamp), it creates a WT_UPDATE_STANDARD update to restore the original value. The prior code set WT_UPDATE_DURABLE on this update, which means "already persisted to the page log." This is incorrect: the restored value has not been written to SLS yet.

The consequence: when background eviction subsequently reconciles the now-dirty page, __rec_selected_key_changed sees WT_UPDATE_DURABLE on the restored update and returns false (key "unchanged"), triggering skip_write = true. The old palite page address — which still contains the tombstone — is retained. The restored value is silently discarded. After the page is evicted, cursor reads load from palite and observe the tombstone, so keys appear deleted even after RTS completes.

Fix
Remove the two lines that set WT_UPDATE_DURABLE in the KEY_CLEAR_REMOVE path of __rts_btree_abort_ondisk_kv. Without this flag, the next reconciliation detects the restored update as a genuine change (__rec_selected_key_changed returns true), writes a new palite delta that supersedes the tombstone, and then correctly marks the update WT_UPDATE_DURABLE via __rec_set_updates_durable after the write completes.