### PR TITLE
WT-17041 Log the oldest transaction session details in the database

### DIFF
--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -222,6 +222,7 @@ struct __wt_txn_global {
     wt_shared volatile uint64_t debug_ops;       /* Debug mode op counter */
     uint64_t debug_rollback;                     /* Debug mode rollback */
     wt_shared volatile uint64_t metadata_pinned; /* Oldest ID for metadata */
+    uint64_t oldest_id_last_verbose; /* Oldest ID at last long-running txn verbose message */
 
     WT_TXN_SHARED *txn_shared_list; /* Per-session shared transaction states */
 

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -547,23 +547,25 @@ __wt_txn_update_oldest(WT_SESSION_IMPL *session, uint32_t flags)
         __wt_atomic_store_uint64_v_relaxed(&txn_global->metadata_pinned, metadata_pinned);
     if (__wt_atomic_load_uint64_v_relaxed(&txn_global->oldest_id) < oldest_id)
         __wt_atomic_store_uint64_v_relaxed(&txn_global->oldest_id, oldest_id);
-    if (__wt_atomic_load_uint64_v_relaxed(&txn_global->last_running) < last_running) {
+    if (__wt_atomic_load_uint64_v_relaxed(&txn_global->last_running) < last_running)
         __wt_atomic_store_uint64_v_relaxed(&txn_global->last_running, last_running);
 
-        /*
-         * Output a verbose message about long-running transactions, but only when some progress is
-         * being made.
-         */
-        current_id = __wt_atomic_load_uint64_v_relaxed(&txn_global->current);
-        WT_ASSERT(session, oldest_id <= current_id);
-        if (WT_VERBOSE_ISSET(session, WT_VERB_TRANSACTION) &&
-          current_id - oldest_id > (10 * WT_THOUSAND) && oldest_session != NULL) {
-            __wt_verbose(session, WT_VERB_TRANSACTION,
-              "oldest id %" PRIu64 " pinned in session %" PRIu32 " [%s] with snap_min %" PRIu64,
-              oldest_id, oldest_session->id,
-              __wt_tsan_suppress_load_const_char_ptr(&oldest_session->lastop),
-              oldest_session->txn->snapshot_data.snap_min);
-        }
+    /*
+     * When verbose transaction logging is enabled, output a message when a long-running
+     * transaction is pinning the oldest ID, but only when the pinning transaction changes to avoid
+     * spamming the log.
+     */
+    current_id = __wt_atomic_load_uint64_v_relaxed(&txn_global->current);
+    WT_ASSERT(session, oldest_id <= current_id);
+    if (WT_VERBOSE_ISSET(session, WT_VERB_TRANSACTION) &&
+      current_id - oldest_id > (10 * WT_THOUSAND) && oldest_session != NULL &&
+      oldest_id != txn_global->oldest_id_last_verbose) {
+        const char *lastop = __wt_tsan_suppress_load_const_char_ptr(&oldest_session->lastop);
+        txn_global->oldest_id_last_verbose = oldest_id;
+        __wt_verbose(session, WT_VERB_TRANSACTION,
+          "oldest id %" PRIu64 " pinned in session %" PRIu32 " [last_op: %s] (current_id %" PRIu64
+          ")",
+          oldest_id, oldest_session->id, lastop == NULL ? "NONE" : lastop, current_id);
     }
 
 done:

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -551,16 +551,15 @@ __wt_txn_update_oldest(WT_SESSION_IMPL *session, uint32_t flags)
         __wt_atomic_store_uint64_v_relaxed(&txn_global->last_running, last_running);
 
     /*
-     * When verbose transaction logging is enabled, output a message when a long-running transaction
+     * When verbose transaction logging is enabled, output a message when a long running transaction
      * is pinning the oldest ID, but only when the pinning transaction changes to avoid spamming the
      * log.
      */
     current_id = __wt_atomic_load_uint64_v_relaxed(&txn_global->current);
     WT_ASSERT(session, oldest_id <= current_id);
     if (WT_VERBOSE_ISSET(session, WT_VERB_TRANSACTION) &&
-      !F_ISSET_ATOMIC_32(S2C(session), WT_CONN_CLOSING) &&
-      current_id - oldest_id > (10 * WT_THOUSAND) && oldest_session != NULL &&
-      oldest_id != txn_global->oldest_id_last_verbose) {
+      !F_ISSET_ATOMIC_32(conn, WT_CONN_CLOSING) && current_id - oldest_id > (10 * WT_THOUSAND) &&
+      oldest_session != NULL && oldest_id != txn_global->oldest_id_last_verbose) {
         const char *lastop = __wt_tsan_suppress_load_const_char_ptr(&oldest_session->lastop);
         txn_global->oldest_id_last_verbose = oldest_id;
         __wt_verbose(session, WT_VERB_TRANSACTION,

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -551,13 +551,14 @@ __wt_txn_update_oldest(WT_SESSION_IMPL *session, uint32_t flags)
         __wt_atomic_store_uint64_v_relaxed(&txn_global->last_running, last_running);
 
     /*
-     * When verbose transaction logging is enabled, output a message when a long-running
-     * transaction is pinning the oldest ID, but only when the pinning transaction changes to avoid
-     * spamming the log.
+     * When verbose transaction logging is enabled, output a message when a long-running transaction
+     * is pinning the oldest ID, but only when the pinning transaction changes to avoid spamming the
+     * log.
      */
     current_id = __wt_atomic_load_uint64_v_relaxed(&txn_global->current);
     WT_ASSERT(session, oldest_id <= current_id);
     if (WT_VERBOSE_ISSET(session, WT_VERB_TRANSACTION) &&
+      !F_ISSET_ATOMIC_32(S2C(session), WT_CONN_CLOSING) &&
       current_id - oldest_id > (10 * WT_THOUSAND) && oldest_session != NULL &&
       oldest_id != txn_global->oldest_id_last_verbose) {
         const char *lastop = __wt_tsan_suppress_load_const_char_ptr(&oldest_session->lastop);

--- a/test/suite/test_txn24.py
+++ b/test/suite/test_txn24.py
@@ -45,8 +45,12 @@ class test_txn24(wttest.WiredTigerTestCase):
     # by setting rollbacks_allowed to 0 here.
     rollbacks_allowed = 0
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.ignoreStdoutPattern(r"oldest id .* pinned in session")
+
     def conn_config(self):
-        return 'cache_size=100MB,eviction=(threads_min=4,threads_max=4)'
+        return 'cache_size=100MB,eviction=(threads_min=4,threads_max=4),verbose=[transaction]'
 
     def get_stat(self, stat):
         stat_cursor = self.session.open_cursor('statistics:')
@@ -116,3 +120,47 @@ class test_txn24(wttest.WiredTigerTestCase):
         # Before committing the long running transaction check whether any bytes were written to disk s part of eviction.
         self.assertGreater((bytes_evicted_new - bytes_evicted), 0)
         self.session.commit_transaction()
+
+    def test_oldest_id_log(self):
+        # Create and populate a table.
+        uri = "table:test_txn24"
+        table_params = 'key_format={},value_format=S'.format(self.key_format)
+
+        default_val = 'ABCD' * 60
+        new_val = 'YYYY' * 60
+        n_rows = 480000
+
+        # Populate
+        self.session.create(uri, table_params + self.extraconfig)
+        cursor = self.session.open_cursor(uri, None)
+        for i in range(1, n_rows + 1):
+            cursor[i] = default_val
+        cursor.close()
+
+        # Perform a checkpoint. There should be no dirty content in the cache after this.
+        self.session.checkpoint()
+
+        # Start a long-running transaction, make an update and keep it running.
+        cursor = self.session.open_cursor(uri, None)
+        self.session.begin_transaction()
+        cursor[1] = new_val
+
+        # Start another long-running transaction, make an update and keep it running.
+        session2 = self.setUpSessionOpen(self.conn)
+        cursor2 = session2.open_cursor(uri)
+        session2.begin_transaction()
+        cursor2[2] = new_val
+
+        session3 = self.setUpSessionOpen(self.conn)
+        cursor3 = session3.open_cursor(uri)
+        for i in range(3, n_rows):
+            session3.begin_transaction()
+            cursor3[i] = new_val
+            session3.commit_transaction()
+
+        # After we close the oldest transaction, whenever it updates the next oldest transaction,
+        # a verbose log message about the oldest id being pinned should appear.
+        self.session.commit_transaction()
+        session3.checkpoint()
+        self.captureout.checkAdditionalPattern(self, r"oldest id .* pinned in session")
+        session2.commit_transaction()

--- a/test/suite/test_txn24.py
+++ b/test/suite/test_txn24.py
@@ -45,10 +45,6 @@ class test_txn24(wttest.WiredTigerTestCase):
     # by setting rollbacks_allowed to 0 here.
     rollbacks_allowed = 0
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.ignoreStdoutPattern(r"oldest id .* pinned in session")
-
     def conn_config(self):
         return 'cache_size=100MB,eviction=(threads_min=4,threads_max=4),verbose=[transaction]'
 
@@ -59,6 +55,10 @@ class test_txn24(wttest.WiredTigerTestCase):
         return val
 
     def test_snapshot_isolation_and_eviction(self):
+        # Verbose transaction logging is enabled; suppress the "oldest id pinned" messages that
+        # may appear from background eviction threads during the long-running transaction below.
+        self.ignoreStdoutPattern(r"oldest id .* pinned in session")
+
         # Create and populate a table.
         uri = "table:test_txn24"
         table_params = 'key_format={},value_format={}'.format(self.key_format, 'S')
@@ -158,14 +158,12 @@ class test_txn24(wttest.WiredTigerTestCase):
             cursor3[i] = new_val
             session3.commit_transaction()
 
-        # After we close the oldest transaction, whenever it updates the next oldest transaction,
-        # a verbose log message about the oldest id being pinned should appear.
+        # Committing the oldest transaction should cause a verbose message to appear when
+        # __wt_txn_update_oldest next runs, because the pinning session has changed.
         self.session.commit_transaction()
         session3.checkpoint()
         self.captureout.checkAdditionalPattern(self, r"oldest id .* pinned in session")
+        # Background eviction threads may continue emitting these messages; ignore trailing
+        # occurrences so tearDown does not flag them as unexpected output.
+        self.ignoreStdoutPattern(r"oldest id .* pinned in session")
         session2.commit_transaction()
-
-        # Additional "oldest id pinned" messages may appear after session2 commits (e.g. from the
-        # eviction server observing a new pinning session). Consume them so tearDown does not treat
-        # them as unexpected output.
-        self.captureout.check(self, ignore_pat=r"oldest id .* pinned in session")

--- a/test/suite/test_txn24.py
+++ b/test/suite/test_txn24.py
@@ -164,3 +164,8 @@ class test_txn24(wttest.WiredTigerTestCase):
         session3.checkpoint()
         self.captureout.checkAdditionalPattern(self, r"oldest id .* pinned in session")
         session2.commit_transaction()
+
+        # Additional "oldest id pinned" messages may appear after session2 commits (e.g. from the
+        # eviction server observing a new pinning session). Consume them so tearDown does not treat
+        # them as unexpected output.
+        self.captureout.check(self, ignore_pat=r"oldest id .* pinned in session")

--- a/test/suite/test_txn24.py
+++ b/test/suite/test_txn24.py
@@ -128,7 +128,9 @@ class test_txn24(wttest.WiredTigerTestCase):
 
         default_val = 'ABCD' * 60
         new_val = 'YYYY' * 60
-        n_rows = 480000
+        # Needs > 10,000 transactions from session3 to exceed the verbose-message threshold
+        # (current_id - oldest_id > 10 * WT_THOUSAND). Keep small enough to avoid cache pressure.
+        n_rows = 12000
 
         # Populate
         self.session.create(uri, table_params + self.extraconfig)


### PR DESCRIPTION
Log the oldest transaction when the oldest transaction to the current transaction is 
greater than 10000 transactions and it logs only when the transaction verbose logging
is enabled.