### PR TITLE
WT-16475 Application layer is responsible for setting the oldest timestamp (test/model)

### DIFF
--- a/test/model/src/driver/kv_workload_runner_wt.cpp
+++ b/test/model/src/driver/kv_workload_runner_wt.cpp
@@ -714,9 +714,8 @@ kv_workload_runner_wt::wiredtiger_open_nolock()
             stable_config << "stable_timestamp=" << std::hex << checkpoint_timestamp;
 
             /*
-             * FIXME-WT-16475: WiredTiger may set the oldest timestamp internally when picking up
-             * the first checkpoint. If this is the case, we don't have to set the oldest timestamp
-             * here inside test/model.
+             * The application layer is responsible for setting the oldest timestamp after picking
+             * up a checkpoint; WiredTiger does not set it internally.
              */
             model::timestamp_t oldest_timestamp =
               model::timestamp_t(((WT_CONNECTION_IMPL *)_connection)


### PR DESCRIPTION
## Summary
- Resolves the `FIXME-WT-16475` comment in `kv_workload_runner_wt.cpp`
- Documents the decided behavior: WiredTiger does **not** set the oldest timestamp internally when picking up a checkpoint
- The application layer (test/model in this case) is responsible for reading the oldest timestamp from the checkpoint metadata and applying it via `set_timestamp`

## Testing
Comment-only change — no functional behavior is modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)