### PR TITLE
WT-17267 Close on a layered dhandle destroys truncate_lock and truncate_list

### DIFF
--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -160,7 +160,7 @@ __conn_dhandle_destroy(WT_SESSION_IMPL *session, WT_DATA_HANDLE *dhandle, bool f
         WT_WITH_DHANDLE(session, dhandle, ret = __wt_btree_discard(session));
         break;
     case WT_DHANDLE_TYPE_LAYERED:
-        __wt_schema_close_layered(session, (WT_LAYERED_TABLE *)dhandle);
+        __wt_schema_destroy_layered(session, (WT_LAYERED_TABLE *)dhandle);
         break;
     case WT_DHANDLE_TYPE_TABLE:
         ret = __wt_schema_close_table(session, (WT_TABLE *)dhandle);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1805,6 +1805,7 @@ extern void __wt_root_ref_init(
   WT_SESSION_IMPL *session, WT_REF *root_ref, WT_PAGE *root, bool is_recno);
 extern void __wt_rwlock_destroy(WT_SESSION_IMPL *session, WT_RWLOCK *l);
 extern void __wt_schema_close_layered(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered);
+extern void __wt_schema_destroy_layered(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered);
 extern void __wt_scr_discard(WT_SESSION_IMPL *session);
 extern void __wt_session_close_cache(WT_SESSION_IMPL *session);
 extern void __wt_session_dhandle_sweep(WT_SESSION_IMPL *session);

--- a/src/include/schema.h
+++ b/src/include/schema.h
@@ -121,6 +121,11 @@ struct __wt_layered_table {
     TAILQ_HEAD(__truncate_table_list_qh, __wt_truncate) truncateqh;
 
     WT_RWLOCK truncate_lock; /* R/W Lock used for managing changes to truncate list.*/
+
+/* AUTOMATIC FLAG VALUE GENERATION START 0 */
+#define WT_LAYERED_TABLE_CLOSED 0x1u
+    /* AUTOMATIC FLAG VALUE GENERATION STOP 8 */
+    uint8_t flags;
 };
 
 /* Holds metadata entry name and the associated config string. */

--- a/src/include/schema.h
+++ b/src/include/schema.h
@@ -123,7 +123,7 @@ struct __wt_layered_table {
     WT_RWLOCK truncate_lock; /* R/W Lock used for managing changes to truncate list.*/
 
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */
-#define WT_LAYERED_TABLE_CLOSED 0x1u
+#define WT_LAYERED_TABLE_OPEN 0x1u
     /* AUTOMATIC FLAG VALUE GENERATION STOP 8 */
     uint8_t flags;
 };

--- a/src/schema/schema_list.c
+++ b/src/schema/schema_list.c
@@ -229,21 +229,35 @@ __wt_schema_close_table(WT_SESSION_IMPL *session, WT_TABLE *table)
 
 /*
  * __wt_schema_close_layered --
- *     Close a layered handle.
+ *     Close a layered handle. The dhandle may be reopened after this, so per-dhandle state (the
+ *     truncate list and its rwlock) must remain intact.
  */
 void
 __wt_schema_close_layered(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered)
 {
+    if (F_ISSET(layered, WT_LAYERED_TABLE_CLOSED))
+        return;
+
     /* Remove the ingest handle from layered table manager list */
     __wt_layered_table_manager_remove_table(session, layered->ingest_btree_id);
-
-    /* Clear truncate list. */
-    __wt_layered_table_truncate_clear(session, layered);
-    __wt_rwlock_destroy(session, &layered->truncate_lock);
 
     /* Free copies of copied configuration items. */
     __wt_free(session, layered->key_format);
     __wt_free(session, layered->value_format);
     __wt_free(session, layered->ingest_uri);
     __wt_free(session, layered->stable_uri);
+
+    F_SET(layered, WT_LAYERED_TABLE_CLOSED);
+}
+
+/*
+ * __wt_schema_destroy_layered --
+ *     Destroy a layered handle. Called only when the dhandle is being freed.
+ */
+void
+__wt_schema_destroy_layered(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered)
+{
+    __wt_schema_close_layered(session, layered);
+    __wt_layered_table_truncate_clear(session, layered);
+    __wt_rwlock_destroy(session, &layered->truncate_lock);
 }

--- a/src/schema/schema_list.c
+++ b/src/schema/schema_list.c
@@ -235,7 +235,7 @@ __wt_schema_close_table(WT_SESSION_IMPL *session, WT_TABLE *table)
 void
 __wt_schema_close_layered(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered)
 {
-    if (F_ISSET(layered, WT_LAYERED_TABLE_CLOSED))
+    if (!F_ISSET(layered, WT_LAYERED_TABLE_OPEN))
         return;
 
     /* Remove the ingest handle from layered table manager list */
@@ -247,7 +247,7 @@ __wt_schema_close_layered(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered)
     __wt_free(session, layered->ingest_uri);
     __wt_free(session, layered->stable_uri);
 
-    F_SET(layered, WT_LAYERED_TABLE_CLOSED);
+    F_CLR(layered, WT_LAYERED_TABLE_OPEN);
 }
 
 /*

--- a/src/schema/schema_open.c
+++ b/src/schema/schema_open.c
@@ -656,6 +656,9 @@ __schema_open_layered(WT_SESSION_IMPL *session)
 
     WT_ASSERT(session, FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_TABLE));
 
+    /* The handle is being opened; clear the closed flag. */
+    F_CLR(layered, WT_LAYERED_TABLE_CLOSED);
+
     /* FIXME-WT-14738: Setup collator information. */
     WT_RET_NOTFOUND_OK(__wt_config_gets(session, layered_cfg, "collator", &cval));
     if (cval.len != 0) {

--- a/src/schema/schema_open.c
+++ b/src/schema/schema_open.c
@@ -656,9 +656,6 @@ __schema_open_layered(WT_SESSION_IMPL *session)
 
     WT_ASSERT(session, FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_TABLE));
 
-    /* The handle is being opened; clear the closed flag. */
-    F_CLR(layered, WT_LAYERED_TABLE_CLOSED);
-
     /* FIXME-WT-14738: Setup collator information. */
     WT_RET_NOTFOUND_OK(__wt_config_gets(session, layered_cfg, "collator", &cval));
     if (cval.len != 0) {
@@ -713,6 +710,8 @@ __wt_schema_open_layered(WT_SESSION_IMPL *session)
     WT_RET(ret);
 
     WT_RET(__wt_layered_table_manager_add_table(session, layered->ingest_btree_id));
+
+    F_SET(layered, WT_LAYERED_TABLE_OPEN);
 
     return (0);
 }

--- a/test/suite/test_layered_fast_truncate06.py
+++ b/test/suite/test_layered_fast_truncate06.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# test_layered_fast_truncate06.py
+#   Regression test for WT-17267. Verify on a layered URI forces a close/reopen of the
+#   layered dhandle. The follower's in-memory truncate list must survive that cycle;
+#   before the fix it was discarded, causing truncated rows to reappear and the truncate
+#   to be torn down.
+
+import wttest, wiredtiger
+from helper_disagg import disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
+
+@disagg_test_class
+class test_layered_fast_truncate06(wttest.WiredTigerTestCase):
+    conn_config = 'disaggregated=(role="leader"),'
+    nrows = 100
+
+    uris = [
+        ('layered', dict(uri='layered:test_layered_fast_truncate06')),
+        ('table', dict(uri='table:test_layered_fast_truncate06')),
+    ]
+
+    disagg_storages = gen_disagg_storages(
+        'test_layered_fast_truncate06', disagg_only=True)
+    scenarios = make_scenarios(disagg_storages, uris)
+
+    def setUp(self):
+        if wiredtiger.disagg_fast_truncate_build() == 0:
+            self.skipTest("fast truncate support is not enabled")
+        super().setUp()
+
+    def create_config(self):
+        cfg = 'key_format=i,value_format=S'
+        # Disagg table: URIs need the layered block-manager/type hints on create.
+        if self.uri.startswith('table:'):
+            cfg += ',block_manager=disagg,type=layered'
+        return cfg
+
+    def visible_keys(self):
+        c = self.session.open_cursor(self.uri)
+        keys = []
+        while c.next() == 0:
+            keys.append(c.get_key())
+        c.close()
+        return keys
+
+    def setup_follower(self):
+        # Create the table on the leader, load nrows, checkpoint, then reopen the
+        # connection as a follower picking up that checkpoint.
+        self.session.create(self.uri, self.create_config())
+
+        cursor = self.session.open_cursor(self.uri)
+        for i in range(1, self.nrows + 1):
+            self.session.begin_transaction()
+            cursor[i] = 'v'
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(i))
+        cursor.close()
+        self.session.checkpoint()
+
+        follower_config = ('disaggregated=(role="follower",'
+            f'checkpoint_meta="{self.disagg_get_complete_checkpoint_meta()}")')
+        self.reopen_conn(config=follower_config)
+
+    def follower_truncate(self, start, stop):
+        c_start = self.session.open_cursor(self.uri)
+        c_start.set_key(start)
+        c_stop = self.session.open_cursor(self.uri)
+        c_stop.set_key(stop)
+        self.session.begin_transaction()
+        self.session.truncate(None, c_start, c_stop, None)
+        self.session.commit_transaction()
+        c_start.close()
+        c_stop.close()
+
+    def test_verify_preserves_follower_truncate(self):
+        self.setup_follower()
+        self.follower_truncate(30, 60)
+
+        expected = [i for i in range(1, self.nrows + 1) if i < 30 or i > 60]
+
+        # Before verify: a scan does not return the truncated rows.
+        self.assertEqual(self.visible_keys(), expected)
+
+        # Verify the layered URI. This triggers a close + reopen of the dhandle.
+        self.session.verify(self.uri)
+
+        # After verify: a scan must still not return the truncated rows.
+        self.assertEqual(self.visible_keys(), expected)


### PR DESCRIPTION
**Summary**
A layered table's in-memory state (a lock and a truncate-tracking list) was being torn down whenever the handle was closed, even in cases where the handle would be reopened shortly after — for example, when running verify on the table. Another thread could then try to take the torn-down lock and crash.

**Fix**
Split close from destroy. Close now only releases resources that should not survive a reopen (configuration strings and the ingest manager entry). The lock and truncate list are released only on final destruction of the handle, so they remain valid across close/reopen cycles.

Test plan
 - New python test that runs verify on a follower after a truncate and asserts truncated rows stay hidden.
 