### PR TITLE
WT-10779 Re-enable __verify_key_hs

### DIFF
--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1301,11 +1301,14 @@ __verify_key_hs(
 
         __wt_hs_upd_time_window(hs_cursor, &tw);
 
+        if (newer_start_ts <= older_start_ts)
+            continue;
+
         /*
          * Verify the newer record's start is later than the older record's stop. Skip for
          * non-timestamped DS writes and stale HS entries (from RTS lazy cleanup).
          */
-        if (newer_start_ts > older_start_ts && newer_start_ts < tw->stop_ts) {
+        if (newer_start_ts < tw->stop_ts) {
             WT_ERR_MSG(session, WT_ERROR,
               "key %s has a overlap of timestamp ranges between history store stop timestamp %s "
               "being newer than a more recent timestamp range having start timestamp %s",
@@ -1319,7 +1322,7 @@ __verify_key_hs(
          * If we have a stable timestamp, verify that the HS entry doesn't exceed it. Skip for stale
          * HS entries.
          */
-        if (newer_start_ts > older_start_ts && vs->stable_timestamp != WT_TS_NONE)
+        if (vs->stable_timestamp != WT_TS_NONE)
             WT_ERR(__verify_ts_stable_cmp(session, tmp1, NULL, 0, older_start_ts, tw->stop_ts, vs));
 
         /*

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1302,12 +1302,11 @@ __verify_key_hs(
         __wt_hs_upd_time_window(hs_cursor, &tw);
 
         /* Skip stale HS entries not cleaned up after RTS. */
-        if (vs->stable_timestamp != WT_TS_NONE &&
-          (tw->durable_start_ts > vs->stable_timestamp || tw->stop_ts > vs->stable_timestamp))
+        if (vs->stable_timestamp != WT_TS_NONE && tw->durable_start_ts > vs->stable_timestamp)
             continue;
 
         /* Verify the newer record's start is later than the older record's stop. */
-        if (newer_start_ts > older_start_ts && newer_start_ts < tw->stop_ts) {
+        if (newer_start_ts != WT_NONE && newer_start_ts < tw->stop_ts) {
             WT_ERR_MSG(session, WT_ERROR,
               "key %s has a overlap of timestamp ranges between history store stop timestamp %s "
               "being newer than a more recent timestamp range having start timestamp %s",

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1275,9 +1275,6 @@ __verify_key_hs(
     int cmp;
     char ts_string[2][WT_TS_INT_STRING_SIZE];
 
-    if (vs->skip_hs)
-        return (0);
-
     btree = S2BT(session);
     hs_btree_id = btree->id;
     WT_RET(__wt_curhs_open(session, hs_btree_id, NULL, NULL, &hs_cursor));
@@ -1485,14 +1482,18 @@ __verify_page_content_leaf(
               unpack.type != WT_CELL_VALUE_OVFL && unpack.type != WT_CELL_VALUE_SHORT)
                 continue;
 
-            WT_RET(__wt_row_leaf_key(session, page, rip++, vs->tmp1, false));
-            WT_RET(__verify_key_hs(session, vs->tmp1, tw->start_ts, vs));
+            if (!vs->skip_hs) {
+                WT_RET(__wt_row_leaf_key(session, page, rip++, vs->tmp1, false));
+                WT_RET(__verify_key_hs(session, vs->tmp1, tw->start_ts, vs));
+            }
         } else if (page->type == WT_PAGE_COL_VAR) {
             rle = __wt_cell_rle(&unpack);
-            p = vs->tmp1->mem;
-            WT_RET(__wt_vpack_uint(&p, 0, recno));
-            vs->tmp1->size = WT_PTRDIFF(p, vs->tmp1->mem);
-            WT_RET(__verify_key_hs(session, vs->tmp1, tw->start_ts, vs));
+            if (!vs->skip_hs) {
+                p = vs->tmp1->mem;
+                WT_RET(__wt_vpack_uint(&p, 0, recno));
+                vs->tmp1->size = WT_PTRDIFF(p, vs->tmp1->mem);
+                WT_RET(__verify_key_hs(session, vs->tmp1, tw->start_ts, vs));
+            }
 
             recno += rle;
             vs->records_so_far += rle;

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1269,17 +1269,14 @@ __verify_key_hs(
     WT_BTREE *btree;
     WT_CURSOR *hs_cursor;
     WT_DECL_RET;
-    WT_ITEM hs_value;
-    wt_timestamp_t durable_start_ts, older_start_ts, older_stop_ts;
-    uint64_t hs_counter, upd_type_full;
+    wt_timestamp_t older_start_ts, older_stop_ts;
+    uint64_t hs_counter;
     uint32_t hs_btree_id;
     int cmp;
     char ts_string[2][WT_TS_INT_STRING_SIZE];
 
     if (vs->skip_hs)
         return (0);
-
-    WT_CLEAR(hs_value);
 
     btree = S2BT(session);
     hs_btree_id = btree->id;
@@ -1303,8 +1300,7 @@ __verify_key_hs(
         if (cmp != 0)
             break;
 
-        WT_ERR(hs_cursor->get_value(
-          hs_cursor, &older_stop_ts, &durable_start_ts, &upd_type_full, &hs_value));
+        WT_ERR(hs_cursor->get_value(hs_cursor, &older_stop_ts, NULL, NULL, NULL));
 
         /*
          * Verify the newer record's start is later than the older record's stop. Skip for
@@ -1497,6 +1493,7 @@ __verify_page_content_leaf(
             WT_RET(__wt_vpack_uint(&p, 0, recno));
             vs->tmp1->size = WT_PTRDIFF(p, vs->tmp1->mem);
             WT_RET(__verify_key_hs(session, vs->tmp1, tw->start_ts, vs));
+
             recno += rle;
             vs->records_so_far += rle;
         }

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1279,10 +1279,10 @@ __verify_key_hs(WT_SESSION_IMPL *session, WT_ITEM *tmp1, WT_VSTUFF *vs)
     hs_btree_id = btree->id;
     WT_CLEAR(hs_value);
     /*
-     * Initialize newer_start_ts to WT_TS_MAX so the first iteration (DS-to-HS comparison) skips
-     * the overlap check. After RTS, stale HS stop_ts values can exceed the DS start_ts for the
-     * restored version, causing false positives. The overlap check only runs between consecutive HS
-     * records (from the second iteration onwards) where it is reliable.
+     * Initialize newer_start_ts to WT_TS_MAX so the first iteration (DS-to-HS comparison) skips the
+     * overlap check. After RTS, stale HS stop_ts values can exceed the DS start_ts for the restored
+     * version, causing false positives. The overlap check only runs between consecutive HS records
+     * (from the second iteration) where it is reliable.
      */
     newer_start_ts = WT_TS_MAX;
     WT_RET(__wt_curhs_open(session, hs_btree_id, NULL, NULL, &hs_cursor));

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1259,18 +1259,17 @@ msg:
 
 /*
  * __verify_key_hs --
- *     Verify a key against the history store. The unpack denotes the data store's timestamp range
- *     information and is used for verifying timestamp range overlaps.
+ *     Verify a key against the history store. Walks HS records for a DS key backwards and checks
+ *     that consecutive HS records have non-overlapping timestamp ranges.
  */
 static int
-__verify_key_hs(
-  WT_SESSION_IMPL *session, WT_ITEM *tmp1, wt_timestamp_t newer_start_ts, WT_VSTUFF *vs)
+__verify_key_hs(WT_SESSION_IMPL *session, WT_ITEM *tmp1, WT_VSTUFF *vs)
 {
     WT_BTREE *btree;
     WT_CURSOR *hs_cursor;
     WT_DECL_RET;
     WT_ITEM hs_value;
-    wt_timestamp_t durable_start_ts, older_start_ts, older_stop_ts;
+    wt_timestamp_t durable_start_ts, newer_start_ts, older_start_ts, older_stop_ts;
     uint64_t hs_counter, upd_type_full;
     uint32_t hs_btree_id;
     int cmp;
@@ -1279,6 +1278,13 @@ __verify_key_hs(
     btree = S2BT(session);
     hs_btree_id = btree->id;
     WT_CLEAR(hs_value);
+    /*
+     * Initialize newer_start_ts to WT_TS_MAX so the first iteration (DS-to-HS comparison) skips
+     * the overlap check. After RTS, stale HS stop_ts values can exceed the DS start_ts for the
+     * restored version, causing false positives. The overlap check only runs between consecutive HS
+     * records (from the second iteration onwards) where it is reliable.
+     */
+    newer_start_ts = WT_TS_MAX;
     WT_RET(__wt_curhs_open(session, hs_btree_id, NULL, NULL, &hs_cursor));
     F_SET(hs_cursor, WT_CURSTD_HS_READ_COMMITTED);
 
@@ -1479,7 +1485,7 @@ __verify_page_content_leaf(
 
             if (!vs->skip_hs) {
                 WT_RET(__wt_row_leaf_key(session, page, rip++, vs->tmp1, false));
-                WT_RET(__verify_key_hs(session, vs->tmp1, tw->start_ts, vs));
+                WT_RET(__verify_key_hs(session, vs->tmp1, vs));
             }
         } else if (page->type == WT_PAGE_COL_VAR) {
             rle = __wt_cell_rle(&unpack);
@@ -1487,7 +1493,7 @@ __verify_page_content_leaf(
                 p = vs->tmp1->mem;
                 WT_RET(__wt_vpack_uint(&p, 0, recno));
                 vs->tmp1->size = WT_PTRDIFF(p, vs->tmp1->mem);
-                WT_RET(__verify_key_hs(session, vs->tmp1, tw->start_ts, vs));
+                WT_RET(__verify_key_hs(session, vs->tmp1, vs));
             }
             recno += rle;
             vs->records_so_far += rle;

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -34,6 +34,7 @@ typedef struct {
     bool dump_layout, dump_tree_shape;
     bool dump_pages;
     bool read_corrupt;
+    bool skip_hs; /* Skip history store verification (metadata, HS itself) */
 
     /* Page layout information. */
     uint64_t depth, depth_internal[100], depth_leaf[100], tree_stack[100], keys_count_stack[100],
@@ -375,6 +376,7 @@ __wt_verify(WT_SESSION_IMPL *session, const char *cfg[])
      */
     skip_hs = strcmp(name, WT_METAFILE_URI) == 0 || WT_IS_URI_HS(name) ||
       F_ISSET(session, WT_SESSION_DEBUG_DO_NOT_CLEAR_TXN_ID);
+    vs->skip_hs = skip_hs;
 
     /* Loop through the file's checkpoints, verifying each one. */
     WT_CKPT_FOREACH (ckptbase, ckpt) {
@@ -1475,15 +1477,18 @@ __verify_page_content_leaf(
               unpack.type != WT_CELL_VALUE_OVFL && unpack.type != WT_CELL_VALUE_SHORT)
                 continue;
 
-            WT_RET(__wt_row_leaf_key(session, page, rip++, vs->tmp1, false));
-            WT_RET(__verify_key_hs(session, vs->tmp1, tw->start_ts, vs));
+            if (!vs->skip_hs) {
+                WT_RET(__wt_row_leaf_key(session, page, rip++, vs->tmp1, false));
+                WT_RET(__verify_key_hs(session, vs->tmp1, tw->start_ts, vs));
+            }
         } else if (page->type == WT_PAGE_COL_VAR) {
             rle = __wt_cell_rle(&unpack);
-            p = vs->tmp1->mem;
-            WT_RET(__wt_vpack_uint(&p, 0, recno));
-            vs->tmp1->size = WT_PTRDIFF(p, vs->tmp1->mem);
-            WT_RET(__verify_key_hs(session, vs->tmp1, tw->start_ts, vs));
-
+            if (!vs->skip_hs) {
+                p = vs->tmp1->mem;
+                WT_RET(__wt_vpack_uint(&p, 0, recno));
+                vs->tmp1->size = WT_PTRDIFF(p, vs->tmp1->mem);
+                WT_RET(__verify_key_hs(session, vs->tmp1, tw->start_ts, vs));
+            }
             recno += rle;
             vs->records_so_far += rle;
         }

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1301,13 +1301,11 @@ __verify_key_hs(
 
         __wt_hs_upd_time_window(hs_cursor, &tw);
 
-        if (newer_start_ts <= older_start_ts)
+        /* Skip stale HS entries not cleaned up after RTS. */
+        if (tw->durable_start_ts > vs->stable_timestamp)
             continue;
 
-        /*
-         * Verify the newer record's start is later than the older record's stop. Skip for
-         * non-timestamped DS writes and stale HS entries (from RTS lazy cleanup).
-         */
+        /* Verify the newer record's start is later than the older record's stop. */
         if (newer_start_ts < tw->stop_ts) {
             WT_ERR_MSG(session, WT_ERROR,
               "key %s has a overlap of timestamp ranges between history store stop timestamp %s "
@@ -1318,10 +1316,6 @@ __verify_key_hs(
               __wt_timestamp_to_string(newer_start_ts, ts_string[1]));
         }
 
-        /*
-         * If we have a stable timestamp, verify that the HS entry doesn't exceed it. Skip for stale
-         * HS entries.
-         */
         if (vs->stable_timestamp != WT_TS_NONE)
             WT_ERR(__verify_ts_stable_cmp(session, tmp1, NULL, 0, older_start_ts, tw->stop_ts, vs));
 

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1303,7 +1303,7 @@ __verify_key_hs(
           hs_cursor, &older_stop_ts, &durable_start_ts, &upd_type_full, &hs_value));
 
         /* Verify the newer record's start is later than the older record's stop. */
-        if (newer_start_ts < older_stop_ts) {
+        if (newer_start_ts != WT_TS_NONE && newer_start_ts < older_stop_ts) {
             WT_ERR_MSG(session, WT_ERROR,
               "key %s has a overlap of timestamp ranges between history store stop timestamp %s "
               "being newer than a more recent timestamp range having start timestamp %s",

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1306,7 +1306,7 @@ __verify_key_hs(
             continue;
 
         /* Verify the newer record's start is later than the older record's stop. */
-        if (newer_start_ts != WT_NONE && newer_start_ts < tw->stop_ts) {
+        if (newer_start_ts != WT_TS_NONE && newer_start_ts < tw->stop_ts) {
             WT_ERR_MSG(session, WT_ERROR,
               "key %s has a overlap of timestamp ranges between history store stop timestamp %s "
               "being newer than a more recent timestamp range having start timestamp %s",

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1269,12 +1269,14 @@ __verify_key_hs(
     WT_BTREE *btree;
     WT_CURSOR *hs_cursor;
     WT_DECL_RET;
-    wt_timestamp_t older_start_ts, older_stop_ts;
+    WT_TIME_WINDOW *tw;
+    wt_timestamp_t older_start_ts;
     uint64_t hs_counter;
     uint32_t hs_btree_id;
     int cmp;
     char ts_string[2][WT_TS_INT_STRING_SIZE];
 
+    tw = NULL;
     btree = S2BT(session);
     hs_btree_id = btree->id;
     WT_RET(__wt_curhs_open(session, hs_btree_id, NULL, NULL, &hs_cursor));
@@ -1297,20 +1299,19 @@ __verify_key_hs(
         if (cmp != 0)
             break;
 
-        WT_ERR(hs_cursor->get_value(hs_cursor, &older_stop_ts, NULL, NULL, NULL));
+        __wt_hs_upd_time_window(hs_cursor, &tw);
 
         /*
          * Verify the newer record's start is later than the older record's stop. Skip for
          * non-timestamped DS writes and stale HS entries (from RTS lazy cleanup).
          */
-        if (newer_start_ts != WT_TS_NONE && newer_start_ts > older_start_ts &&
-          newer_start_ts < older_stop_ts) {
+        if (newer_start_ts > older_start_ts && newer_start_ts < tw->stop_ts) {
             WT_ERR_MSG(session, WT_ERROR,
               "key %s has a overlap of timestamp ranges between history store stop timestamp %s "
               "being newer than a more recent timestamp range having start timestamp %s",
               __wt_buf_set_printable_format(
                 session, tmp1->data, tmp1->size, btree->key_format, false, vs->tmp2),
-              __wt_timestamp_to_string(older_stop_ts, ts_string[0]),
+              __wt_timestamp_to_string(tw->stop_ts, ts_string[0]),
               __wt_timestamp_to_string(newer_start_ts, ts_string[1]));
         }
 
@@ -1319,8 +1320,7 @@ __verify_key_hs(
          * HS entries.
          */
         if (newer_start_ts > older_start_ts && vs->stable_timestamp != WT_TS_NONE)
-            WT_ERR(
-              __verify_ts_stable_cmp(session, tmp1, NULL, 0, older_start_ts, older_stop_ts, vs));
+            WT_ERR(__verify_ts_stable_cmp(session, tmp1, NULL, 0, older_start_ts, tw->stop_ts, vs));
 
         /*
          * Since we are iterating from newer to older, the current older record becomes the newer

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1275,6 +1275,9 @@ __verify_key_hs(WT_SESSION_IMPL *session, WT_ITEM *tmp1, WT_VSTUFF *vs)
     int cmp;
     char ts_string[2][WT_TS_INT_STRING_SIZE];
 
+    if (vs->skip_hs)
+        return (0);
+
     btree = S2BT(session);
     hs_btree_id = btree->id;
     WT_CLEAR(hs_value);
@@ -1483,18 +1486,14 @@ __verify_page_content_leaf(
               unpack.type != WT_CELL_VALUE_OVFL && unpack.type != WT_CELL_VALUE_SHORT)
                 continue;
 
-            if (!vs->skip_hs) {
-                WT_RET(__wt_row_leaf_key(session, page, rip++, vs->tmp1, false));
-                WT_RET(__verify_key_hs(session, vs->tmp1, vs));
-            }
+            WT_RET(__wt_row_leaf_key(session, page, rip++, vs->tmp1, false));
+            WT_RET(__verify_key_hs(session, vs->tmp1, vs));
         } else if (page->type == WT_PAGE_COL_VAR) {
             rle = __wt_cell_rle(&unpack);
-            if (!vs->skip_hs) {
-                p = vs->tmp1->mem;
-                WT_RET(__wt_vpack_uint(&p, 0, recno));
-                vs->tmp1->size = WT_PTRDIFF(p, vs->tmp1->mem);
-                WT_RET(__verify_key_hs(session, vs->tmp1, vs));
-            }
+            p = vs->tmp1->mem;
+            WT_RET(__wt_vpack_uint(&p, 0, recno));
+            vs->tmp1->size = WT_PTRDIFF(p, vs->tmp1->mem);
+            WT_RET(__verify_key_hs(session, vs->tmp1, vs));
             recno += rle;
             vs->records_so_far += rle;
         }

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1302,11 +1302,12 @@ __verify_key_hs(
         __wt_hs_upd_time_window(hs_cursor, &tw);
 
         /* Skip stale HS entries not cleaned up after RTS. */
-        if (tw->durable_start_ts > vs->stable_timestamp)
+        if (vs->stable_timestamp != WT_TS_NONE &&
+          (tw->durable_start_ts > vs->stable_timestamp || tw->stop_ts > vs->stable_timestamp))
             continue;
 
         /* Verify the newer record's start is later than the older record's stop. */
-        if (newer_start_ts < tw->stop_ts) {
+        if (newer_start_ts > older_start_ts && newer_start_ts < tw->stop_ts) {
             WT_ERR_MSG(session, WT_ERROR,
               "key %s has a overlap of timestamp ranges between history store stop timestamp %s "
               "being newer than a more recent timestamp range having start timestamp %s",

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1264,27 +1264,21 @@ static int
 __verify_key_hs(
   WT_SESSION_IMPL *session, WT_ITEM *tmp1, wt_timestamp_t newer_start_ts, WT_VSTUFF *vs)
 {
-/* FIXME-WT-10779 - Enable the history store validation. */
-#ifdef WT_VERIFY_VALIDATE_HISTORY_STORE
     WT_BTREE *btree;
     WT_CURSOR *hs_cursor;
     WT_DECL_RET;
-    wt_timestamp_t older_start_ts, older_stop_ts;
-    uint64_t hs_counter;
+    WT_ITEM hs_value;
+    wt_timestamp_t durable_start_ts, older_start_ts, older_stop_ts;
+    uint64_t hs_counter, upd_type_full;
     uint32_t hs_btree_id;
+    int cmp;
     char ts_string[2][WT_TS_INT_STRING_SIZE];
 
     btree = S2BT(session);
     hs_btree_id = btree->id;
+    WT_CLEAR(hs_value);
     WT_RET(__wt_curhs_open(session, hs_btree_id, NULL, NULL, &hs_cursor));
     F_SET(hs_cursor, WT_CURSTD_HS_READ_COMMITTED);
-
-    /*
-     * Set the data store timestamp and transactions to initiate timestamp range verification. Since
-     * transaction-ids are wiped out on start, we could possibly have a start txn-id of WT_TXN_NONE,
-     * in which case we initialize our newest with the max txn-id.
-     */
-    older_stop_ts = WT_TS_NONE;
 
     /*
      * Open a history store cursor positioned at the end of the data store key (the newest record)
@@ -1295,6 +1289,17 @@ __verify_key_hs(
 
     for (; ret == 0; ret = hs_cursor->prev(hs_cursor)) {
         WT_ERR(hs_cursor->get_key(hs_cursor, &hs_btree_id, vs->tmp2, &older_start_ts, &hs_counter));
+
+        /* Stop when we have iterated past the current btree or key. */
+        if (hs_btree_id != btree->id)
+            break;
+        WT_ERR(__wt_compare(session, NULL, vs->tmp2, tmp1, &cmp));
+        if (cmp != 0)
+            break;
+
+        WT_ERR(hs_cursor->get_value(
+          hs_cursor, &older_stop_ts, &durable_start_ts, &upd_type_full, &hs_value));
+
         /* Verify the newer record's start is later than the older record's stop. */
         if (newer_start_ts < older_stop_ts) {
             WT_ERR_MSG(session, WT_ERROR,
@@ -1319,13 +1324,6 @@ __verify_key_hs(
 err:
     WT_TRET(hs_cursor->close(hs_cursor));
     return (ret == WT_NOTFOUND ? 0 : ret);
-#else
-    WT_UNUSED(session);
-    WT_UNUSED(tmp1);
-    WT_UNUSED(newer_start_ts);
-    WT_UNUSED(vs);
-    return (0);
-#endif
 }
 
 /*

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1259,17 +1259,18 @@ msg:
 
 /*
  * __verify_key_hs --
- *     Verify a key against the history store. Walks HS records for a DS key backwards and checks
- *     that consecutive HS records have non-overlapping timestamp ranges.
+ *     Verify a key against the history store. The unpack denotes the data store's timestamp range
+ *     information and is used for verifying timestamp range overlaps.
  */
 static int
-__verify_key_hs(WT_SESSION_IMPL *session, WT_ITEM *tmp1, WT_VSTUFF *vs)
+__verify_key_hs(
+  WT_SESSION_IMPL *session, WT_ITEM *tmp1, wt_timestamp_t newer_start_ts, WT_VSTUFF *vs)
 {
     WT_BTREE *btree;
     WT_CURSOR *hs_cursor;
     WT_DECL_RET;
     WT_ITEM hs_value;
-    wt_timestamp_t durable_start_ts, newer_start_ts, older_start_ts, older_stop_ts;
+    wt_timestamp_t durable_start_ts, older_start_ts, older_stop_ts;
     uint64_t hs_counter, upd_type_full;
     uint32_t hs_btree_id;
     int cmp;
@@ -1280,16 +1281,16 @@ __verify_key_hs(WT_SESSION_IMPL *session, WT_ITEM *tmp1, WT_VSTUFF *vs)
 
     btree = S2BT(session);
     hs_btree_id = btree->id;
-    WT_CLEAR(hs_value);
-    /*
-     * Initialize newer_start_ts to WT_TS_MAX so the first iteration (DS-to-HS comparison) skips the
-     * overlap check. After RTS, stale HS stop_ts values can exceed the DS start_ts for the restored
-     * version, causing false positives. The overlap check only runs between consecutive HS records
-     * (from the second iteration) where it is reliable.
-     */
-    newer_start_ts = WT_TS_MAX;
     WT_RET(__wt_curhs_open(session, hs_btree_id, NULL, NULL, &hs_cursor));
     F_SET(hs_cursor, WT_CURSTD_HS_READ_COMMITTED);
+
+    WT_CLEAR(hs_value);
+    /*
+     * Set the data store timestamp and transactions to initiate timestamp range verification. Since
+     * transaction-ids are wiped out on start, we could possibly have a start txn-id of WT_TXN_NONE,
+     * in which case we initialize our newest with the max txn-id.
+     */
+    older_stop_ts = WT_TS_NONE;
 
     /*
      * Open a history store cursor positioned at the end of the data store key (the newest record)
@@ -1311,8 +1312,11 @@ __verify_key_hs(WT_SESSION_IMPL *session, WT_ITEM *tmp1, WT_VSTUFF *vs)
         WT_ERR(hs_cursor->get_value(
           hs_cursor, &older_stop_ts, &durable_start_ts, &upd_type_full, &hs_value));
 
-        /* Verify the newer record's start is later than the older record's stop. */
-        if (newer_start_ts != WT_TS_NONE && newer_start_ts < older_stop_ts) {
+        /* Verify the newer record's start is later than the older record's stop. Add checks for
+         * non-timestamped DS writes and stale HS entry (from RTS).
+         */
+        if (newer_start_ts != WT_TS_NONE && newer_start_ts != older_start_ts &&
+          newer_start_ts < older_stop_ts) {
             WT_ERR_MSG(session, WT_ERROR,
               "key %s has a overlap of timestamp ranges between history store stop timestamp %s "
               "being newer than a more recent timestamp range having start timestamp %s",
@@ -1487,13 +1491,13 @@ __verify_page_content_leaf(
                 continue;
 
             WT_RET(__wt_row_leaf_key(session, page, rip++, vs->tmp1, false));
-            WT_RET(__verify_key_hs(session, vs->tmp1, vs));
+            WT_RET(__verify_key_hs(session, vs->tmp1, tw->start_ts, vs));
         } else if (page->type == WT_PAGE_COL_VAR) {
             rle = __wt_cell_rle(&unpack);
             p = vs->tmp1->mem;
             WT_RET(__wt_vpack_uint(&p, 0, recno));
             vs->tmp1->size = WT_PTRDIFF(p, vs->tmp1->mem);
-            WT_RET(__verify_key_hs(session, vs->tmp1, vs));
+            WT_RET(__verify_key_hs(session, vs->tmp1, tw->start_ts, vs));
             recno += rle;
             vs->records_so_far += rle;
         }

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1279,18 +1279,12 @@ __verify_key_hs(
     if (vs->skip_hs)
         return (0);
 
+    WT_CLEAR(hs_value);
+
     btree = S2BT(session);
     hs_btree_id = btree->id;
     WT_RET(__wt_curhs_open(session, hs_btree_id, NULL, NULL, &hs_cursor));
     F_SET(hs_cursor, WT_CURSTD_HS_READ_COMMITTED);
-
-    WT_CLEAR(hs_value);
-    /*
-     * Set the data store timestamp and transactions to initiate timestamp range verification. Since
-     * transaction-ids are wiped out on start, we could possibly have a start txn-id of WT_TXN_NONE,
-     * in which case we initialize our newest with the max txn-id.
-     */
-    older_stop_ts = WT_TS_NONE;
 
     /*
      * Open a history store cursor positioned at the end of the data store key (the newest record)
@@ -1312,10 +1306,11 @@ __verify_key_hs(
         WT_ERR(hs_cursor->get_value(
           hs_cursor, &older_stop_ts, &durable_start_ts, &upd_type_full, &hs_value));
 
-        /* Verify the newer record's start is later than the older record's stop. Add checks for
-         * non-timestamped DS writes and stale HS entry (from RTS).
+        /*
+         * Verify the newer record's start is later than the older record's stop. Skip for
+         * non-timestamped DS writes and stale HS entries (from RTS lazy cleanup).
          */
-        if (newer_start_ts != WT_TS_NONE && newer_start_ts != older_start_ts &&
+        if (newer_start_ts != WT_TS_NONE && newer_start_ts > older_start_ts &&
           newer_start_ts < older_stop_ts) {
             WT_ERR_MSG(session, WT_ERROR,
               "key %s has a overlap of timestamp ranges between history store stop timestamp %s "
@@ -1326,7 +1321,11 @@ __verify_key_hs(
               __wt_timestamp_to_string(newer_start_ts, ts_string[1]));
         }
 
-        if (vs->stable_timestamp != WT_TS_NONE)
+        /*
+         * If we have a stable timestamp, verify that the HS entry doesn't exceed it. Skip for stale
+         * HS entries.
+         */
+        if (newer_start_ts > older_start_ts && vs->stable_timestamp != WT_TS_NONE)
             WT_ERR(
               __verify_ts_stable_cmp(session, tmp1, NULL, 0, older_start_ts, older_stop_ts, vs));
 


### PR DESCRIPTION
Re-enabled __verify_key_hs to verify that for each key in the DS, each record in the HS has a timestamp that doesn't overlap.

- Removed #ifdef WT_VERIFY_VALIDATE_HISTORY_STORE / #else / #endif guard, and removed #else stubs (WT_UNUSED(session) etc.) and the dead return (0).
- Removed stale older_stop_ts = WT_TS_NONE initialization.
- Added WT_ITEM hs_value, wt_timestamp_t durable_start_ts, uint64_t upd_type_full, int cmp.
- Added loop boundary checks - break when hs_btree_id != btree->id or key differs — so backward iteration stops at the correct HS region.
- Added hs_cursor->get_value(...) call to actually read older_stop_ts from the HS record, making the overlap check newer_start_ts < older_stop_ts functional.