### PR TITLE
WT-17298 page-in check eviction assist before yield on every retry iteration

### DIFF
--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -739,6 +739,20 @@ skip_evict:
         /*
          * We failed to get the page -- yield before retrying, and if we've yielded enough times,
          * start sleeping so we don't burn CPU to no purpose.
+         *
+         * First check if we can help with eviction -- this converts wasted wait time into
+         * productive work that clears cache space and directly addresses the root cause of page
+         * contention under out-of-cache workloads. Only fall through to yield/sleep if no
+         * eviction work is available.
+         */
+        if (!LF_ISSET(WT_READ_IGNORE_CACHE_SIZE)) {
+            WT_RET(__wt_evict_app_assist_worker_check(session, true, true, false, &cache_work));
+            if (cache_work)
+                continue;
+        }
+
+        /*
+         * No eviction work available -- yield or sleep as before.
          */
         if (yield_cnt < WT_THOUSAND) {
             if (!stalled) {
@@ -747,17 +761,6 @@ skip_evict:
                 continue;
             }
             yield_cnt = WT_THOUSAND;
-        }
-
-        /*
-         * If stalling and this thread is allowed to do eviction work, check if the cache needs help
-         * evicting clean pages (don't force a read to do dirty eviction). If we do work for the
-         * cache, substitute that for a sleep.
-         */
-        if (!LF_ISSET(WT_READ_IGNORE_CACHE_SIZE)) {
-            WT_RET(__wt_evict_app_assist_worker_check(session, true, true, false, &cache_work));
-            if (cache_work)
-                continue;
         }
         __wt_spin_backoff(&yield_cnt, &sleep_usecs);
         ++sleep_count;

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -737,10 +737,10 @@ skip_evict:
         }
 
         /*
-         * Before yielding, try to help with eviction: under cache-pressure workloads
-         * the stall is caused by a full cache, so assisting eviction clears the root
-         * cause instead of burning the retry on a yield. Skip dirty eviction -- we
-         * don't want to force a read to do write work.
+         * Before yielding, try to help with eviction: under cache-pressure workloads the stall is
+         * caused by a full cache, so assisting eviction clears the root cause instead of burning
+         * the retry on a yield. Skip dirty eviction -- we don't want to force a read to do write
+         * work.
          */
         if (!LF_ISSET(WT_READ_IGNORE_CACHE_SIZE)) {
             WT_RET(__wt_evict_app_assist_worker_check(session, true, true, false, &cache_work));

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -737,13 +737,10 @@ skip_evict:
         }
 
         /*
-         * We failed to get the page -- yield before retrying, and if we've yielded enough times,
-         * start sleeping so we don't burn CPU to no purpose.
-         *
-         * First check if we can help with eviction -- this converts wasted wait time into
-         * productive work that clears cache space and directly addresses the root cause of page
-         * contention under out-of-cache workloads. Only fall through to yield/sleep if no
-         * eviction work is available.
+         * Before yielding, try to help with eviction: under cache-pressure workloads
+         * the stall is caused by a full cache, so assisting eviction clears the root
+         * cause instead of burning the retry on a yield. Skip dirty eviction -- we
+         * don't want to force a read to do write work.
          */
         if (!LF_ISSET(WT_READ_IGNORE_CACHE_SIZE)) {
             WT_RET(__wt_evict_app_assist_worker_check(session, true, true, false, &cache_work));

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -751,9 +751,6 @@ skip_evict:
                 continue;
         }
 
-        /*
-         * No eviction work available -- yield or sleep as before.
-         */
         if (yield_cnt < WT_THOUSAND) {
             if (!stalled) {
                 ++yield_cnt;


### PR DESCRIPTION
[WT-17298](https://jira.mongodb.org/browse/WT-17298) page-in check eviction assist before yield on every retry iteration

## Summary

Move `__wt_evict_app_assist_worker_check` before the yield/sleep decision in `__wt_page_in_func` so it runs on every retry iteration regardless of `yield_cnt` or `stalled` state.

Previously, a thread that failed to acquire a page because the hazard pointer was busy would yield up to 1000 times before reaching the eviction-assist check. Under out-of-cache workloads with many threads, this produced a yield storm where threads burned context switches without making progress, while the root cause — full cache, pages pinned for eviction — went unaddressed.

This is pure code motion; the same function call with identical parameters runs earlier in the loop. When the cache is not under pressure the check returns quickly via its existing guards (no eviction server, prepared txn, prefetch thread, checkpoint cursor, in-memory conn, `!__wt_evict_needed`, lock held), and the thread falls through to the original yield/backoff logic unchanged. The yield / stalled / `__wt_spin_backoff` path is preserved as a fallback.

## Performance

Measured on `ycsb.out_of_cache.95read5update.2024-05` at 128 threads (N=5 sys-perf patches against mongo master, baseline CoV 2.75%):
- **+2.14%** `ops_per_sec`
- **−9.82%** p50 read latency
- No tail-latency regression at any measurable percentile (p95/p99/p99.9 all moved in the improvement direction; p99.99+ too noisy to claim signal at N=5).

## Testing

- mongo master `--alias=required` full required suite: PASS (all failures classified pre-existing).
- Targeted `jstests/disk/wt_*` (cache, repair, size storer): PASS.