### PR TITLE
WT-17320 Exclude deleting stat file with lose_all_my_data set to true

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -575,6 +575,7 @@ WiredTigerLog
 WiredTigerPreplog
 WiredTigerShared
 WiredTigerSharedHS
+WiredTigerStat
 WiredTigerTestCase
 WiredTigerTimestamp
 WiredTigerTmplog

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -1693,8 +1693,11 @@ __ensure_clean_startup_dir(WT_SESSION_IMPL *session, const char *dir, bool fail)
         /*
          * Delete any WiredTiger files to prevent reading them during startup. But keep
          * WiredTiger.lock as a safety mechanism.
+         *
+         * Prevent deleting stat files since they can be useful for debugging.
          */
-        if (WT_PREFIX_MATCH(files[i], "WiredTiger") && !WT_STREQ(files[i], WT_SINGLETHREAD))
+        if (WT_PREFIX_MATCH(files[i], "WiredTiger") && !WT_STREQ(files[i], WT_SINGLETHREAD) &&
+          !WT_PREFIX_MATCH(files[i], "WiredTigerStat"))
             WT_ERR(__on_file_in_wt_dir(session, full_path, fail));
         else if (WT_SUFFIX_MATCH(files[i], ".wt") || WT_SUFFIX_MATCH(files[i], ".wt_ingest") ||
           WT_SUFFIX_MATCH(files[i], ".wt_stable"))


### PR DESCRIPTION
When the lose_all_my_data configuration flag is enabled (set to true), the system removes all associated data as expected. However, this process also deletes the stat file.

This behavior appears to be incorrect. The stat file is intended to support diagnostic and troubleshooting efforts, and removing it eliminates potentially valuable information needed for post-issue analysis.
