### PR TITLE
WT-17273 Support reading prepared fast truncate from disk cell

### DIFF
--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -1103,9 +1103,9 @@ __wt_cell_unpack_safe(WT_SESSION_IMPL *session, const WT_PAGE_HEADER *dsk, WT_CE
     uint64_t v;
     const uint8_t *p;
     uint8_t flags;
-    bool copy_cell;
+    bool copy_cell, has_prepare_fast_truncate, prepare_fast_truncate;
 
-    copy_cell = false;
+    copy_cell = has_prepare_fast_truncate = prepare_fast_truncate = false;
     copy.len = 0; /* [-Wconditional-uninitialized] */
     copy.v = 0;   /* [-Wconditional-uninitialized] */
 
@@ -1198,8 +1198,19 @@ copy_cell_restart:
         flags = *p++; /* skip second descriptor byte */
         WT_CELL_LEN_CHK(p, 0, dsk, end);
 
-        if (LF_ISSET(WT_CELL_PREPARE))
-            ta->prepare = 1;
+        has_prepare_fast_truncate =
+          unpack->raw == WT_CELL_ADDR_DEL && F_ISSET(dsk, WT_PAGE_FT_UPDATE);
+        if (LF_ISSET(WT_CELL_PREPARE)) {
+            /*
+             * For a prepared fast-truncate, the prepare state is recorded in the time aggregate. We
+             * cannot have a prepared fast-truncate and a prepared time aggregate at the same time.
+             * Otherwise, it would be a write conflict.
+             */
+            if (has_prepare_fast_truncate)
+                prepare_fast_truncate = true;
+            else
+                ta->prepare = 1;
+        }
         if (LF_ISSET(WT_CELL_TS_START))
             WT_RET(
               __wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &ta->oldest_start_ts));
@@ -1360,16 +1371,34 @@ copy_cell_restart:
     }
 
     /* Unpack any fast-truncate information. */
-    if (unpack->raw == WT_CELL_ADDR_DEL && F_ISSET(dsk, WT_PAGE_FT_UPDATE)) {
+    if (has_prepare_fast_truncate) {
         page_del = &unpack_addr->page_del;
         WT_RET(__wt_vunpack_uint(
           &p, end == NULL ? 0 : WT_PTRDIFF(end, p), (uint64_t *)&page_del->txnid));
-        WT_RET(
-          __wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &page_del->pg_del_start_ts));
-        WT_RET(__wt_vunpack_uint(
-          &p, end == NULL ? 0 : WT_PTRDIFF(end, p), &page_del->pg_del_durable_ts));
-        page_del->prepare_state = 0; /* No prepare can have been in progress. */
-        page_del->committed = true;  /* There is no running transaction. */
+        if (prepare_fast_truncate) {
+            page_del->prepare_state = WT_PREPARE_INPROGRESS;
+            page_del->committed = false;
+            /*
+             * For prepared fast-truncates, the prepared state is shared with the time aggregate but
+             * the prepare timestamp and the prepared id are stored in the page_del block.
+             */
+            WT_RET(
+              __wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &page_del->prepare_ts));
+            page_del->pg_del_start_ts = page_del->prepare_ts;
+            WT_RET(
+              __wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &page_del->prepared_id));
+            WT_ASSERT_ALWAYS(session,
+              !F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED) ||
+                page_del->prepared_id != WT_PREPARED_ID_NONE,
+              "Read prepared record with no prepared id when preserve prepared is enabled.");
+        } else {
+            page_del->prepare_state = WT_PREPARE_INIT;
+            page_del->committed = true;
+            WT_RET(__wt_vunpack_uint(
+              &p, end == NULL ? 0 : WT_PTRDIFF(end, p), &page_del->pg_del_start_ts));
+            WT_RET(__wt_vunpack_uint(
+              &p, end == NULL ? 0 : WT_PTRDIFF(end, p), &page_del->pg_del_durable_ts));
+        }
         page_del->selected_for_write = true;
     }
 

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -1392,6 +1392,8 @@ copy_cell_restart:
             page_del->pg_del_start_ts = page_del->prepare_ts;
             WT_RET(
               __wt_vunpack_uint(&p, end == NULL ? 0 : WT_PTRDIFF(end, p), &page_del->prepared_id));
+            /* Explicitly initialize the durable timestamp to WT_TS_NONE. */
+            page_del->pg_del_durable_ts = WT_TS_NONE;
             WT_ASSERT_ALWAYS(session,
               !F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED) ||
                 page_del->prepared_id != WT_PREPARED_ID_NONE,

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -1103,9 +1103,9 @@ __wt_cell_unpack_safe(WT_SESSION_IMPL *session, const WT_PAGE_HEADER *dsk, WT_CE
     uint64_t v;
     const uint8_t *p;
     uint8_t flags;
-    bool copy_cell, has_prepare_fast_truncate, prepare_fast_truncate;
+    bool copy_cell, has_fast_truncate, prepare_fast_truncate;
 
-    copy_cell = has_prepare_fast_truncate = prepare_fast_truncate = false;
+    copy_cell = has_fast_truncate = prepare_fast_truncate = false;
     copy.len = 0; /* [-Wconditional-uninitialized] */
     copy.v = 0;   /* [-Wconditional-uninitialized] */
 
@@ -1193,20 +1193,25 @@ copy_cell_restart:
         if (unpack_addr == NULL)
             return (WT_ERROR);
 
+        /*
+         * A committed fast-truncate cell may be written without WT_CELL_SECOND_DESC when its time
+         * aggregate is globally visible. Compute this flag before the SECOND_DESC early-exit so the
+         * page_del block is always unpacked for fast-truncate addr-del cells.
+         */
+        has_fast_truncate = unpack->raw == WT_CELL_ADDR_DEL && F_ISSET(dsk, WT_PAGE_FT_UPDATE);
+
         if ((cell->__chunk[0] & WT_CELL_SECOND_DESC) == 0)
             break;
         flags = *p++; /* skip second descriptor byte */
         WT_CELL_LEN_CHK(p, 0, dsk, end);
 
-        has_prepare_fast_truncate =
-          unpack->raw == WT_CELL_ADDR_DEL && F_ISSET(dsk, WT_PAGE_FT_UPDATE);
         if (LF_ISSET(WT_CELL_PREPARE)) {
             /*
              * For a prepared fast-truncate, the prepare state is recorded in the time aggregate. We
              * cannot have a prepared fast-truncate and a prepared time aggregate at the same time.
              * Otherwise, it would be a write conflict.
              */
-            if (has_prepare_fast_truncate)
+            if (has_fast_truncate)
                 prepare_fast_truncate = true;
             else
                 ta->prepare = 1;
@@ -1371,7 +1376,7 @@ copy_cell_restart:
     }
 
     /* Unpack any fast-truncate information. */
-    if (has_prepare_fast_truncate) {
+    if (has_fast_truncate) {
         page_del = &unpack_addr->page_del;
         WT_RET(__wt_vunpack_uint(
           &p, end == NULL ? 0 : WT_PTRDIFF(end, p), (uint64_t *)&page_del->txnid));

--- a/test/catch2/CMakeLists.txt
+++ b/test/catch2/CMakeLists.txt
@@ -5,6 +5,7 @@ if(HAVE_UNITTEST_ASSERTS)
 else()
     set(unittests
         misc_tests/test_acquire_release_macros.cpp
+        misc_tests/test_cell_fast_truncate_unpack.cpp
         misc_tests/test_cell_prepared_time_window.cpp
         misc_tests/test_config.cpp
         misc_tests/test_crc32.cpp

--- a/test/catch2/misc_tests/test_cell_fast_truncate_unpack.cpp
+++ b/test/catch2/misc_tests/test_cell_fast_truncate_unpack.cpp
@@ -34,14 +34,14 @@ build_ft_addr_del_cell(WT_CELL *cell, bool is_prepared, uint64_t txnid, uint64_t
 
 /*
  * build_prepared_addr_cell --
- *     Build an addr-del cell marked as prepared but without any fast-truncate deletion data. This
- *     represents an internal page whose time aggregate spans a prepared transaction.
+ *     Build a regular addr cell marked as prepared. Used to verify that the prepare flag on a
+ *     non-fast-truncate addr cell propagates to the time aggregate.
  */
 static void
 build_prepared_addr_cell(WT_CELL *cell)
 {
     uint8_t *p = cell->__chunk;
-    *p++ = WT_CELL_ADDR_DEL | WT_CELL_SECOND_DESC;
+    *p++ = WT_CELL_ADDR_LEAF | WT_CELL_SECOND_DESC;
     *p++ = WT_CELL_PREPARE;
     WT_IGNORE_RET(__wt_vpack_uint(&p, 0, 0)); /* zero-length address cookie */
 }

--- a/test/catch2/misc_tests/test_cell_fast_truncate_unpack.cpp
+++ b/test/catch2/misc_tests/test_cell_fast_truncate_unpack.cpp
@@ -1,0 +1,149 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+/* Unit tests for reading fast-truncate page deletion info from addr-del cells. */
+#include <catch2/catch.hpp>
+#include <cstring>
+#include "../wrappers/mock_session.h"
+#include "wt_internal.h"
+
+/*
+ * build_ft_addr_del_cell --
+ *     Build a fast-truncate addr-del cell for unpacking. When is_prepared is true, ts1 is the
+ *     prepare timestamp and ts2 is the prepared transaction ID; when false, ts1 is the start commit
+ *     timestamp and ts2 is the durable commit timestamp.
+ */
+static void
+build_ft_addr_del_cell(WT_CELL *cell, bool is_prepared, uint64_t txnid, uint64_t ts1, uint64_t ts2)
+{
+    uint8_t *p = cell->__chunk;
+
+    *p++ = WT_CELL_ADDR_DEL | WT_CELL_SECOND_DESC;
+    *p++ = is_prepared ? WT_CELL_PREPARE : 0;
+
+    WT_IGNORE_RET(__wt_vpack_uint(&p, 0, txnid));
+    WT_IGNORE_RET(__wt_vpack_uint(&p, 0, ts1));
+    WT_IGNORE_RET(__wt_vpack_uint(&p, 0, ts2));
+    WT_IGNORE_RET(__wt_vpack_uint(&p, 0, 0)); /* zero-length address cookie */
+}
+
+/*
+ * build_prepared_addr_cell --
+ *     Build an addr-del cell marked as prepared but without any fast-truncate deletion data. This
+ *     represents an internal page whose time aggregate spans a prepared transaction.
+ */
+static void
+build_prepared_addr_cell(WT_CELL *cell)
+{
+    uint8_t *p = cell->__chunk;
+    *p++ = WT_CELL_ADDR_DEL | WT_CELL_SECOND_DESC;
+    *p++ = WT_CELL_PREPARE;
+    WT_IGNORE_RET(__wt_vpack_uint(&p, 0, 0)); /* zero-length address cookie */
+}
+
+static std::shared_ptr<mock_session>
+setup_mock_session()
+{
+    std::shared_ptr<mock_session> session_mock = mock_session::build_test_mock_session();
+    session_mock->setup_block_manager_file_operations();
+    S2BT(session_mock->get_wt_session_impl())->base_write_gen = 1;
+    return session_mock;
+}
+
+static WT_PAGE_HEADER
+make_ft_page_header()
+{
+    WT_PAGE_HEADER dsk;
+    memset(&dsk, 0, sizeof(dsk));
+    dsk.write_gen = 2;
+    F_SET(&dsk, WT_PAGE_FT_UPDATE);
+    return dsk;
+}
+
+TEST_CASE("Cell Fast Truncate: committed deletion unpacks start and durable timestamps",
+  "[cell][fast_truncate]")
+{
+    auto session_mock = setup_mock_session();
+    WT_SESSION_IMPL *session = session_mock->get_wt_session_impl();
+
+    WT_CELL cell;
+    memset(&cell, 0, sizeof(cell));
+    build_ft_addr_del_cell(&cell, /*is_prepared=*/false, /*txnid=*/10, /*start_ts=*/20,
+      /*durable_ts=*/30);
+
+    WT_PAGE_HEADER dsk = make_ft_page_header();
+    WT_CELL_UNPACK_ADDR unpack;
+    memset(&unpack, 0, sizeof(unpack));
+    __wt_cell_unpack_addr(session, &dsk, &cell, &unpack);
+
+    const WT_PAGE_DELETED &pd = unpack.page_del;
+    CHECK(pd.txnid == 10);
+    CHECK(pd.pg_del_start_ts == 20);
+    CHECK(pd.pg_del_durable_ts == 30);
+    /* A committed deletion is not in a prepare state. */
+    CHECK(pd.prepare_state == WT_PREPARE_INIT);
+    CHECK(pd.committed == true);
+    CHECK(pd.selected_for_write == true);
+    /* A committed fast-truncate does not mark the page as having prepared content. */
+    CHECK(unpack.ta.prepare == 0);
+}
+
+TEST_CASE(
+  "Cell Fast Truncate: prepared deletion unpacks prepare timestamp and ID, not commit timestamps",
+  "[cell][fast_truncate]")
+{
+    auto session_mock = setup_mock_session();
+    WT_SESSION_IMPL *session = session_mock->get_wt_session_impl();
+
+    WT_CELL cell;
+    memset(&cell, 0, sizeof(cell));
+    build_ft_addr_del_cell(
+      &cell, /*is_prepared=*/true, /*txnid=*/10, /*prepare_ts=*/15, /*prepared_id=*/5);
+
+    WT_PAGE_HEADER dsk = make_ft_page_header();
+    WT_CELL_UNPACK_ADDR unpack;
+    memset(&unpack, 0, sizeof(unpack));
+    __wt_cell_unpack_addr(session, &dsk, &cell, &unpack);
+
+    const WT_PAGE_DELETED &pd = unpack.page_del;
+    CHECK(pd.txnid == 10);
+    CHECK(pd.prepare_ts == 15);
+    /* Before commit, start_ts reflects the prepare timestamp. */
+    CHECK(pd.pg_del_start_ts == 15);
+    CHECK(pd.prepared_id == 5);
+    CHECK(pd.prepare_state == WT_PREPARE_INPROGRESS);
+    CHECK(pd.committed == false);
+    CHECK(pd.selected_for_write == true);
+    /* A prepared fast-truncate does not propagate prepare to the page-level visibility window. */
+    CHECK(unpack.ta.prepare == 0);
+}
+
+TEST_CASE("Cell Fast Truncate: prepare flag on non-fast-truncate addr cell marks page as prepared",
+  "[cell][fast_truncate]")
+{
+    auto session_mock = setup_mock_session();
+    WT_SESSION_IMPL *session = session_mock->get_wt_session_impl();
+
+    WT_CELL cell;
+    memset(&cell, 0, sizeof(cell));
+    build_prepared_addr_cell(&cell);
+
+    WT_PAGE_HEADER dsk;
+    memset(&dsk, 0, sizeof(dsk));
+    dsk.write_gen = 2;
+    /* Not a fast-truncate page, so no deletion info is expected. */
+
+    WT_CELL_UNPACK_ADDR unpack;
+    memset(&unpack, 0, sizeof(unpack));
+    __wt_cell_unpack_addr(session, &dsk, &cell, &unpack);
+
+    /* The page-level visibility window must be marked as containing a prepared transaction. */
+    CHECK(unpack.ta.prepare == 1);
+    CHECK(unpack.page_del.txnid == 0);
+    CHECK(unpack.page_del.selected_for_write == false);
+}


### PR DESCRIPTION
## Summary

Extends `__wt_cell_unpack_safe` to decode fast-truncate addr-del cells that were written in a prepared state. A prepared fast-truncate encodes `txnid | prepare_ts | prepared_id` instead of the committed format `txnid | pg_del_start_ts | pg_del_durable_ts`; the `WT_CELL_PREPARE` flag in the second descriptor byte distinguishes the two.

For prepared cells, `page_del->prepare_state` is set to `WT_PREPARE_INPROGRESS` and `committed = false`; `pg_del_start_ts` is aliased from `prepare_ts` as a placeholder until commit. `ta->prepare` is intentionally left unset — prepare state lives in `page_del`, not the time aggregate. The write side (`__wt_cell_pack_addr`) is unchanged; this PR is read-side only.

## Test plan

New Catch2 unit tests in `test/catch2/misc_tests/test_cell_fast_truncate_unpack.cpp` covering three cases: committed fast-truncate, prepared fast-truncate, and a non-fast-truncate addr cell with the prepare flag set.