### PR TITLE
WT-15039 Allow a higher number of eviction threads (8.0)

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -646,12 +646,12 @@ connection_runtime_config = [
                 maximum number of threads WiredTiger will start to help evict pages from cache. The
                 number of threads started will vary depending on the current eviction load. Each
                 eviction worker thread uses a session from the configured session_max''',
-                min=1, max=20),
+                min=1, max=64),
             Config('threads_min', '1', r'''
                 minimum number of threads WiredTiger will start to help evict pages from
                 cache. The number of threads currently running will vary depending on the
                 current eviction load''',
-                min=1, max=20),
+                min=1, max=64),
             Config('evict_sample_inmem', 'true', r'''
                 If no in-memory ref is found on the root page, attempt to locate a random 
                 in-memory page by examining all entries on the root page.''',

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -287,10 +287,10 @@ static const WT_CONFIG_CHECK confchk_wiredtiger_open_eviction_subconfigs[] = {
     224, INT64_MIN, INT64_MAX, NULL},
   {"skip_update_obsolete_check", "boolean", NULL, NULL, NULL, 0, NULL,
     WT_CONFIG_COMPILED_TYPE_BOOLEAN, 226, INT64_MIN, INT64_MAX, NULL},
-  {"threads_max", "int", NULL, "min=1,max=20", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 220, 1,
-    20, NULL},
-  {"threads_min", "int", NULL, "min=1,max=20", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 221, 1,
-    20, NULL},
+  {"threads_max", "int", NULL, "min=1,max=64", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 220, 1,
+    64, NULL},
+  {"threads_min", "int", NULL, "min=1,max=64", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT, 221, 1,
+    64, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
 static const uint8_t confchk_wiredtiger_open_eviction_subconfigs_jump[WT_CONFIG_JUMP_TABLE_SIZE] = {

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -2336,11 +2336,11 @@ struct __wt_connection {
      * threads_max, maximum number of threads WiredTiger will start to help evict pages from cache.
      * The number of threads started will vary depending on the current eviction load.  Each
      * eviction worker thread uses a session from the configured session_max., an integer between \c
-     * 1 and \c 20; default \c 8.}
+     * 1 and \c 64; default \c 8.}
      * @config{&nbsp;&nbsp;&nbsp;&nbsp;threads_min, minimum number of
      * threads WiredTiger will start to help evict pages from cache.  The number of threads
      * currently running will vary depending on the current eviction load., an integer between \c 1
-     * and \c 20; default \c 1.}
+     * and \c 64; default \c 1.}
      * @config{ ),,}
      * @config{eviction_checkpoint_target, perform eviction at the beginning of checkpoints to bring
      * the dirty content in cache to this level.  It is a percentage of the cache size if the value
@@ -3222,11 +3222,11 @@ struct __wt_connection {
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;threads_max, maximum number of threads WiredTiger will start to
  * help evict pages from cache.  The number of threads started will vary depending on the current
  * eviction load.  Each eviction worker thread uses a session from the configured session_max., an
- * integer between \c 1 and \c 20; default \c 8.}
+ * integer between \c 1 and \c 64; default \c 8.}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;threads_min,
  * minimum number of threads WiredTiger will start to help evict pages from cache.  The number of
  * threads currently running will vary depending on the current eviction load., an integer between
- * \c 1 and \c 20; default \c 1.}
+ * \c 1 and \c 64; default \c 1.}
  * @config{ ),,}
  * @config{eviction_checkpoint_target, perform eviction at the beginning of checkpoints to bring the
  * dirty content in cache to this level.  It is a percentage of the cache size if the value is


### PR DESCRIPTION
Backport of WT-15039 to mongodb-8.0 for BACKPORT-26326.

Cherrypick from 4d091cc55f.

Increases the maximum allowed eviction threads from 20 to 64. On larger instances, this allows more eviction workers to keep up with cache management and reduces application thread participation in eviction.

Note: `src/evict/evict.h` (which held `WT_EVICT_MAX_WORKERS`) does not exist in 8.0, so only `dist/api_data.py` was updated and `src/config/config_def.c` / `src/include/wiredtiger.in` were regenerated via `dist/api_config.py`.