### PR TITLE
WT-16515 Fix statistics for clean pages seen and queued by eviction (8.0)

### DIFF
--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -1391,10 +1391,11 @@ __evict_lru_walk(WT_SESSION_IMPL *session)
         WT_PAGE *page = queue->evict_queue[candidates].ref->page;
         if (__wt_page_is_modified(page))
             WT_STAT_CONN_DATA_INCR(session, cache_eviction_pages_queued_dirty);
-        else if (page->modify != NULL)
-            WT_STAT_CONN_DATA_INCR(session, cache_eviction_pages_queued_updates);
         else
             WT_STAT_CONN_DATA_INCR(session, cache_eviction_pages_queued_clean);
+
+        if (page->modify != NULL)
+            WT_STAT_CONN_DATA_INCR(session, cache_eviction_pages_queued_updates);
     }
 
     queue->evict_current = queue->evict_queue;
@@ -2145,10 +2146,11 @@ rand_next:
 
         if (__wt_page_is_modified(page))
             ++pages_seen_dirty;
-        else if (page->modify != NULL)
-            ++pages_seen_updates;
         else
             ++pages_seen_clean;
+
+        if (page->modify != NULL)
+            ++pages_seen_updates;
 
         /* Count internal pages seen. */
         if (F_ISSET(ref, WT_REF_FLAG_INTERNAL))


### PR DESCRIPTION

Cherrypick from 2d171ad06786e6c16d04865429e732958af3dd2e (mongodb-8.2).

The `cache_eviction_pages_seen_updates` and `cache_eviction_pages_queued_updates` stats were
only counting pages with `modify != NULL` that were *not* dirty. Since a dirty page can also
have `modify != NULL`, these stats were undercounting. The fix decouples the updates check
into its own independent `if` so all three categories are no longer mutually exclusive.