### PR TITLE
WT-17333 Update log string expected by test_layered_fast_truncate07

### DIFF
--- a/test/suite/test_layered_fast_truncate07.py
+++ b/test/suite/test_layered_fast_truncate07.py
@@ -116,7 +116,8 @@ class test_layered_fast_truncate06(wttest.WiredTigerTestCase):
     # Assert the single truncate log line emitted with the concrete bounded range.
     def assert_trunc_log(self, start, stop):
         self.captureout.checkAdditionalPattern(self,
-            f'truncate {self.uri}: start={self.key_str(start)} stop={self.key_str(stop)}')
+            f'insert entry into truncate list on table {self.uri}: '
+            f'start={self.key_str(start)} stop={self.key_str(stop)}')
         self.cleanStdout()
 
     def test_bounded_range(self):


### PR DESCRIPTION
In PR #13607, the format of the message logged in wt_insert_truncate_entry was
changed. This causes the Python test layered_fast_truncate07, which still
expects the old format, to fail.

Update the test to match what the implementation actually logs.