### PR TITLE
WT-17336 Decode value in __clayered_modify before returning to caller

### DIFF
--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -2705,6 +2705,7 @@ __clayered_modify(WT_CURSOR *cursor, WT_MODIFY *entries, int nentries)
      */
     WT_ITEM_SET(cursor->key, current->key);
     WT_ITEM_SET(cursor->value, current->value);
+    __clayered_deleted_decode(&cursor->value);
     WT_ASSERT(session, F_MASK(current, WT_CURSTD_KEY_SET) == WT_CURSTD_KEY_INT);
     F_SET(cursor, WT_CURSTD_KEY_INT);
 


### PR DESCRIPTION
## Summary
`__clayered_modify` copied the constituent cursor's value out to the user-facing layered cursor without calling `__clayered_deleted_decode`. When the post-modify value begins with the tombstone marker, the constituent stores the deleted-encoded form (the user value with one suffix byte appended), so `WT_CURSOR.get_value` returned a value one byte longer than what the caller's modify produced. Every other layered read path (`__clayered_search`, `__clayered_next`, `__clayered_prev`, `__clayered_search_near_int`) already decodes — modify was the lone outlier.

This caused the modify self-check at `test/format/ops.c:1806` to fail whenever a post-modify value happened to start with the tombstone byte.

## Test plan
- [x] Reproduces with `./t -c ../../../test/format/CONFIG.disagg ops.pct.modify=90 random.data_seed=8742732 random.extra_seed=1584194` before the fix
- [x] Same command no longer asserts after the fix