### PR TITLE
WT-16809 (Follower mode) validate fast truncate transaction visibility semantics

### DIFF
--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1906,6 +1906,10 @@ extern void __wti_debug_crash_if_flag_set(
 extern void __wti_free_ref(WT_SESSION_IMPL *session, WT_REF *ref, int page_type, bool free_pages);
 extern void __wti_free_ref_index(
   WT_SESSION_IMPL *session, WT_PAGE *page, WT_PAGE_INDEX *pindex, bool free_pages);
+extern void __wti_layered_table_truncate_rollback_apply(
+  WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered_table, WT_TXN_OP *op);
+extern void __wti_mark_committed_truncate_table_apply(
+  WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered_table, WT_TXN_OP *op);
 extern void __wti_read_row_time_window(
   WT_SESSION_IMPL *session, WT_PAGE *page, WT_ROW *rip, WT_TIME_WINDOW *tw);
 extern void __wti_ref_addr_safe_free(WT_SESSION_IMPL *session, void *p, size_t len);

--- a/src/include/schema.h
+++ b/src/include/schema.h
@@ -120,7 +120,7 @@ struct __wt_layered_table {
      */
     TAILQ_HEAD(__truncate_table_list_qh, __wt_truncate) truncateqh;
 
-    WT_RWLOCK truncate_lock; /* R/W Lock used for managing changes to truncate list.*/
+    WT_RWLOCK truncate_lock; /* Protects truncate list membership and entry visibility metadata. */
 
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */
 #define WT_LAYERED_TABLE_OPEN 0x1u

--- a/src/txn/txn_truncate.c
+++ b/src/txn/txn_truncate.c
@@ -261,6 +261,33 @@ __wt_truncate_delete_visible_check(
 }
 
 /*
+ * __wti_mark_committed_truncate_table_apply --
+ *     Stamp commit metadata onto a truncate entry in the provided layered table. The write lock
+ *     serializes readers that walk the truncate list under truncate_lock while checking the entry's
+ *     plain txn/timestamp fields for visibility.
+ */
+void
+__wti_mark_committed_truncate_table_apply(
+  WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered_table, WT_TXN_OP *op)
+{
+    WT_TRUNCATE *entry = op->u.follower_truncate.t;
+
+    WT_ASSERT(session, __wt_process.disagg_fast_truncate_2026 == true);
+    WT_ASSERT(session, layered_table != NULL);
+    WT_ASSERT(session, entry != NULL);
+
+    /*
+     * FIXME-WT-17347 Remove the queue-wide write lock when applying commit metadata to truncate
+     * entry
+     */
+    __wt_writelock(session, &layered_table->truncate_lock);
+    entry->txn_id = session->txn->time_point.id;
+    entry->start_ts = session->txn->time_point.commit_timestamp;
+    entry->durable_ts = session->txn->time_point.durable_timestamp;
+    __wt_writeunlock(session, &layered_table->truncate_lock);
+}
+
+/*
  * __wti_mark_committed_truncate_table --
  *     Mark a truncate table entry as committed, updating truncate entries timestamp information.
  */
@@ -286,15 +313,31 @@ __wti_mark_committed_truncate_table(WT_SESSION_IMPL *session, WT_TXN_OP *op)
     WT_ASSERT_ALWAYS(session, __wt_session_get_dhandle(session, entry->uri, NULL, NULL, 0) == 0,
       "failed to get layered dhandle when marking truncate committed");
     layered_table = (WT_LAYERED_TABLE *)session->dhandle;
-
-    __wt_writelock(session, &layered_table->truncate_lock);
-    entry->txn_id = session->txn->time_point.id;
-    entry->start_ts = session->txn->time_point.commit_timestamp;
-    entry->durable_ts = session->txn->time_point.durable_timestamp;
-    __wt_writeunlock(session, &layered_table->truncate_lock);
+    __wti_mark_committed_truncate_table_apply(session, layered_table, op);
 
     WT_TRET(__wt_session_release_dhandle(session));
     return (ret);
+}
+
+/*
+ * __wti_layered_table_truncate_rollback_apply --
+ *     Remove a truncate entry from a layered table as part of rollback processing.
+ */
+void
+__wti_layered_table_truncate_rollback_apply(
+  WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered_table, WT_TXN_OP *op)
+{
+    WT_TRUNCATE *entry = op->u.follower_truncate.t;
+
+    WT_ASSERT(session, __wt_process.disagg_fast_truncate_2026 == true);
+    WT_ASSERT(session, layered_table != NULL);
+    WT_ASSERT(session, entry != NULL);
+
+    __wt_writelock(session, &layered_table->truncate_lock);
+    TAILQ_REMOVE(&layered_table->truncateqh, entry, q);
+    __wt_writeunlock(session, &layered_table->truncate_lock);
+    op->u.follower_truncate.t = NULL;
+    __disagg_truncate_free(session, &entry);
 }
 
 /*
@@ -324,12 +367,7 @@ __wti_layered_table_truncate_rollback(WT_SESSION_IMPL *session, WT_TXN_OP *op)
     WT_ASSERT_ALWAYS(session, __wt_session_get_dhandle(session, entry->uri, NULL, NULL, 0) == 0,
       "failed to get layered dhandle during truncate rollback");
     layered_table = (WT_LAYERED_TABLE *)session->dhandle;
-
-    __wt_writelock(session, &layered_table->truncate_lock);
-    TAILQ_REMOVE(&layered_table->truncateqh, entry, q);
-    __wt_writeunlock(session, &layered_table->truncate_lock);
-    __disagg_truncate_free(session, &entry);
-    op->u.follower_truncate.t = NULL;
+    __wti_layered_table_truncate_rollback_apply(session, layered_table, op);
 
     WT_TRET(__wt_session_release_dhandle(session));
     return (ret);

--- a/src/txn/txn_truncate.c
+++ b/src/txn/txn_truncate.c
@@ -261,6 +261,37 @@ __wt_truncate_delete_visible_check(
 }
 
 /*
+ * __disagg_truncate_apply --
+ *     Helper function to apply a truncate operation to the layered table. The actual application
+ *     logic is passed in through the apply_func parameter.
+ */
+static int
+__disagg_truncate_apply(WT_SESSION_IMPL *session, WT_TXN_OP *op,
+  void (*apply_func)(WT_SESSION_IMPL *, WT_LAYERED_TABLE *, WT_TXN_OP *))
+{
+    WT_DECL_RET;
+    WT_LAYERED_TABLE *layered_table = NULL;
+    WT_TRUNCATE *entry = op->u.follower_truncate.t;
+
+    WT_ASSERT(session, __wt_process.disagg_fast_truncate_2026 == true);
+
+    /*
+     * Get the layered table from the provided URI. We don't hold any global locks so that's
+     * possible that it was already removed.
+     *
+     * FIXME-WT-16789: Disallow sweep server or follower mode to clean up the dhandle from the
+     * dhandle list, if there are entries in the truncate list.
+     */
+    WT_ASSERT_ALWAYS(session, __wt_session_get_dhandle(session, entry->uri, NULL, NULL, 0) == 0,
+      "failed to get layered dhandle when marking truncate committed");
+    layered_table = (WT_LAYERED_TABLE *)session->dhandle;
+    apply_func(session, layered_table, op);
+
+    WT_TRET(__wt_session_release_dhandle(session));
+    return (ret);
+}
+
+/*
  * __wti_mark_committed_truncate_table_apply --
  *     Stamp commit metadata onto a truncate entry in the provided layered table. The write lock
  *     serializes readers that walk the truncate list under truncate_lock while checking the entry's
@@ -294,29 +325,7 @@ __wti_mark_committed_truncate_table_apply(
 int
 __wti_mark_committed_truncate_table(WT_SESSION_IMPL *session, WT_TXN_OP *op)
 {
-    WT_DECL_RET;
-    WT_LAYERED_TABLE *layered_table;
-    WT_TRUNCATE *entry;
-
-    layered_table = NULL;
-    entry = op->u.follower_truncate.t;
-
-    WT_ASSERT(session, __wt_process.disagg_fast_truncate_2026 == true);
-
-    /*
-     * Get the layered table from the provided URI. We don't hold any global locks so that's
-     * possible that it was already removed.
-     *
-     * FIXME-WT-16789: Disallow sweep server or follower mode to clean up the dhandle from the
-     * dhandle list, if there are entries in the truncate list.
-     */
-    WT_ASSERT_ALWAYS(session, __wt_session_get_dhandle(session, entry->uri, NULL, NULL, 0) == 0,
-      "failed to get layered dhandle when marking truncate committed");
-    layered_table = (WT_LAYERED_TABLE *)session->dhandle;
-    __wti_mark_committed_truncate_table_apply(session, layered_table, op);
-
-    WT_TRET(__wt_session_release_dhandle(session));
-    return (ret);
+    return (__disagg_truncate_apply(session, op, __wti_mark_committed_truncate_table_apply));
 }
 
 /*
@@ -348,29 +357,7 @@ __wti_layered_table_truncate_rollback_apply(
 int
 __wti_layered_table_truncate_rollback(WT_SESSION_IMPL *session, WT_TXN_OP *op)
 {
-    WT_DECL_RET;
-    WT_LAYERED_TABLE *layered_table;
-    WT_TRUNCATE *entry;
-
-    layered_table = NULL;
-    entry = op->u.follower_truncate.t;
-
-    WT_ASSERT(session, __wt_process.disagg_fast_truncate_2026 == true);
-
-    /*
-     * Get the layered table from the provided URI. We don't hold any global locks so that's
-     * possible that it was already removed.
-     *
-     * FIXME-WT-16789: Disallow sweep server or follower mode to clean up the dhandle from the
-     * dhandle list, if there are entries in the truncate list.
-     */
-    WT_ASSERT_ALWAYS(session, __wt_session_get_dhandle(session, entry->uri, NULL, NULL, 0) == 0,
-      "failed to get layered dhandle during truncate rollback");
-    layered_table = (WT_LAYERED_TABLE *)session->dhandle;
-    __wti_layered_table_truncate_rollback_apply(session, layered_table, op);
-
-    WT_TRET(__wt_session_release_dhandle(session));
-    return (ret);
+    return (__disagg_truncate_apply(session, op, __wti_layered_table_truncate_rollback_apply));
 }
 
 /*

--- a/test/catch2/CMakeLists.txt
+++ b/test/catch2/CMakeLists.txt
@@ -20,6 +20,7 @@ else()
         misc_tests/test_rec_upd_select.cpp
         misc_tests/test_reconciliation_tracking.cpp
         misc_tests/test_layered_incomplete_table.cpp
+        misc_tests/test_layered_truncate_visibility.cpp
         misc_tests/test_semaphore.cpp
         misc_tests/test_session_config.cpp
         misc_tests/test_string_match.cpp

--- a/test/catch2/CMakeLists.txt
+++ b/test/catch2/CMakeLists.txt
@@ -20,7 +20,6 @@ else()
         misc_tests/test_rec_upd_select.cpp
         misc_tests/test_reconciliation_tracking.cpp
         misc_tests/test_layered_incomplete_table.cpp
-        misc_tests/test_layered_truncate_visibility.cpp
         misc_tests/test_semaphore.cpp
         misc_tests/test_session_config.cpp
         misc_tests/test_string_match.cpp
@@ -44,7 +43,6 @@ else()
         cursors/api/test_bulk_cursor.cpp
         cursors/unit/test_bounds_restore.cpp
         cursors/unit/test_cursor_get_raw_key_value.cpp
-        disagg_fast_truncate/unit/test_truncate_visible_check.cpp
         ext/test_key_provider.cpp
         ext/test_key_provider_header.cpp
         ext/test_checkpoint_meta_version.cpp
@@ -59,6 +57,8 @@ else()
         sub_level_error/unit/test_sub_level_error_msg_macros.cpp
         sub_level_error/unit/test_sub_level_error_rollback.cpp
         sub_level_error/unit/test_sub_level_error_session_set_last_error.cpp
+        truncate/test_truncate_visible_check.cpp
+        truncate/test_layered_truncate_visibility.cpp
     )
 endif()
 

--- a/test/catch2/misc_tests/test_layered_truncate_visibility.cpp
+++ b/test/catch2/misc_tests/test_layered_truncate_visibility.cpp
@@ -1,0 +1,326 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *      All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+#include <string_view>
+
+#include <catch2/catch.hpp>
+
+#include "wt_internal.h"
+#include "wrappers/mock_session.h"
+
+/*
+ * test_layered_truncate_visibility.cpp
+ *
+ * Focused unit coverage for the follower layered-table truncate list visibility helpers.
+ */
+
+namespace {
+
+class layered_truncate_visibility_fixture {
+    WT_TXN_SHARED *txn_shared_list;
+    bool fast_truncate_enabled;
+
+public:
+    std::shared_ptr<mock_session> session_wrapper;
+    WT_SESSION_IMPL *session;
+    WT_LAYERED_TABLE layered_table{};
+
+    layered_truncate_visibility_fixture()
+        : session_wrapper(mock_session::build_test_mock_session()),
+          session(session_wrapper->get_wt_session_impl()),
+          fast_truncate_enabled(__wt_process.disagg_fast_truncate_2026)
+    {
+        session->id = 0;
+
+        REQUIRE(__wt_calloc(session, 1, sizeof(WT_TXN_SHARED), &txn_shared_list) == 0);
+        S2C(session)->txn_global.txn_shared_list = txn_shared_list;
+
+        REQUIRE(__wt_calloc(session, 1, sizeof(WT_TXN), &session->txn) == 0);
+
+        layered_table.iface.name = "layered:test_layered_truncate_visibility";
+        TAILQ_INIT(&layered_table.truncateqh);
+        REQUIRE(__wt_rwlock_init(session, &layered_table.truncate_lock) == 0);
+
+        __wt_process.disagg_fast_truncate_2026 = true;
+        set_reader(50, WT_TS_NONE);
+    }
+
+    ~layered_truncate_visibility_fixture()
+    {
+        __wt_layered_table_truncate_clear(session, &layered_table);
+        __wt_rwlock_destroy(session, &layered_table.truncate_lock);
+        __wt_free(session, session->txn);
+        __wt_free(session, txn_shared_list);
+        __wt_process.disagg_fast_truncate_2026 = fast_truncate_enabled;
+    }
+
+    void
+    set_reader(uint64_t txn_id, wt_timestamp_t read_timestamp)
+    {
+        WT_CLEAR(*session->txn);
+
+        session->txn->isolation = WT_ISO_SNAPSHOT;
+        session->txn->snapshot_data.snap_min = 100;
+        session->txn->snapshot_data.snap_max = 200;
+        session->txn->snapshot_data.snapshot = nullptr;
+        session->txn->snapshot_data.snapshot_count = 0;
+        F_SET(session->txn, WT_TXN_HAS_SNAPSHOT);
+
+        session->txn->time_point.id = txn_id;
+        F_SET(&session->txn->time_point, WT_TXN_TIME_POINT_HAS_ID);
+
+        WT_SESSION_TXN_SHARED(session)->read_timestamp = read_timestamp;
+        if (read_timestamp == WT_TS_NONE)
+            F_CLR(session->txn, WT_TXN_SHARED_TS_READ);
+        else
+            F_SET(session->txn, WT_TXN_SHARED_TS_READ);
+    }
+
+    void
+    set_committer(
+      uint64_t txn_id, wt_timestamp_t commit_timestamp, wt_timestamp_t durable_timestamp)
+    {
+        WT_CLEAR(*session->txn);
+
+        session->txn->time_point.id = txn_id;
+        session->txn->time_point.commit_timestamp = commit_timestamp;
+        session->txn->time_point.durable_timestamp = durable_timestamp;
+        F_SET(&session->txn->time_point,
+          WT_TXN_TIME_POINT_HAS_ID | WT_TXN_TIME_POINT_HAS_TS_COMMIT |
+            WT_TXN_TIME_POINT_HAS_TS_DURABLE);
+    }
+
+    WT_TRUNCATE *
+    add_truncate(uint64_t txn_id, wt_timestamp_t start_ts, wt_timestamp_t durable_ts,
+      const char *start, const char *stop)
+    {
+        WT_TRUNCATE *entry = nullptr;
+
+        REQUIRE(__wt_calloc_one(session, &entry) == 0);
+        REQUIRE(__wt_strdup(session, layered_table.iface.name, &entry->uri) == 0);
+        entry->txn_id = txn_id;
+        entry->start_ts = start_ts;
+        entry->durable_ts = durable_ts;
+
+        if (start != nullptr)
+            REQUIRE(__wt_buf_set(session, &entry->start_key, start, strlen(start)) == 0);
+        if (stop != nullptr)
+            REQUIRE(__wt_buf_set(session, &entry->stop_key, stop, strlen(stop)) == 0);
+
+        TAILQ_INSERT_TAIL(&layered_table.truncateqh, entry, q);
+        return entry;
+    }
+
+    int
+    truncate_visible(std::string_view key, WT_TRUNCATE **matched = nullptr)
+    {
+        WT_ITEM item{};
+        item.data = key.data();
+        item.size = key.size();
+        return (__wt_truncate_delete_visible_check(session, &layered_table, &item, matched));
+    }
+};
+
+} // namespace
+
+TEST_CASE_METHOD(
+  layered_truncate_visibility_fixture, "own uncommitted truncate is visible", "[layered][truncate]")
+{
+    const uint64_t txn_id = 50;
+    const wt_timestamp_t start_ts = WT_TS_NONE;
+    const wt_timestamp_t durable_ts = WT_TS_NONE;
+    const char *start = "0100";
+    const char *stop = "0700";
+
+    add_truncate(txn_id, start_ts, durable_ts, start, stop);
+
+    WT_TRUNCATE *matched = nullptr;
+    const char *key = "0150";
+    REQUIRE(truncate_visible(key, &matched) == 0);
+    REQUIRE(matched != nullptr);
+
+    const std::string_view matched_start{
+      static_cast<const char *>(matched->start_key.data), matched->start_key.size};
+    REQUIRE(matched_start == start);
+}
+
+TEST_CASE_METHOD(layered_truncate_visibility_fixture,
+  "other transaction uncommitted truncate is invisible", "[layered][truncate]")
+{
+    uint64_t txn_id = 250;
+    const wt_timestamp_t start_ts = WT_TS_NONE;
+    const wt_timestamp_t durable_ts = WT_TS_NONE;
+    const char *start = "0100";
+    const char *stop = "0700";
+
+    add_truncate(txn_id, start_ts, durable_ts, start, stop);
+
+    txn_id = 60;
+    const wt_timestamp_t read_timestamp = WT_TS_NONE;
+
+    set_reader(txn_id, read_timestamp);
+
+    const char *key = "0150";
+    REQUIRE(truncate_visible(key) == WT_NOTFOUND);
+}
+
+TEST_CASE_METHOD(layered_truncate_visibility_fixture, "read timestamp gates committed truncate",
+  "[layered][truncate]")
+{
+    const uint64_t txn_id = 10;
+    const wt_timestamp_t start_ts = 30;
+    const wt_timestamp_t durable_ts = 30;
+    const char *start = "0100";
+    const char *stop = "0700";
+
+    add_truncate(txn_id, start_ts, durable_ts, start, stop);
+
+    SECTION("older read timestamp still sees the key")
+    {
+        const uint64_t txn_id = 60;
+        const wt_timestamp_t read_timestamp = 20;
+
+        set_reader(txn_id, read_timestamp);
+
+        const char *key = "0150";
+        REQUIRE(truncate_visible(key) == WT_NOTFOUND);
+    }
+
+    SECTION("equal or newer read timestamp sees the truncate")
+    {
+        const uint64_t txn_id = 60;
+        wt_timestamp_t read_timestamp = 30;
+
+        set_reader(txn_id, read_timestamp);
+
+        const char *key = "0150";
+        REQUIRE(truncate_visible(key) == 0);
+
+        read_timestamp = 40;
+        set_reader(txn_id, read_timestamp);
+        REQUIRE(truncate_visible(key) == 0);
+    }
+}
+
+TEST_CASE_METHOD(layered_truncate_visibility_fixture, "overlapping ranges honor visible timestamps",
+  "[layered][truncate]")
+{
+    uint64_t txn_id = 10;
+    wt_timestamp_t start_ts = 20;
+    wt_timestamp_t durable_ts = 20;
+    const char *start = "0100";
+    const char *stop = "0400";
+
+    add_truncate(txn_id, start_ts, durable_ts, start, stop);
+
+    txn_id = 11;
+    start_ts = 40;
+    durable_ts = 40;
+    start = "0300";
+    stop = "0700";
+
+    add_truncate(txn_id, start_ts, durable_ts, start, stop);
+
+    SECTION("only the older truncate is visible")
+    {
+        const uint64_t txn_id = 60;
+        const wt_timestamp_t read_timestamp = 30;
+
+        set_reader(txn_id, read_timestamp);
+
+        const char *key = "0350";
+        REQUIRE(truncate_visible(key) == 0);
+
+        key = "0500";
+        REQUIRE(truncate_visible(key) == WT_NOTFOUND);
+    }
+
+    SECTION("both truncates are visible")
+    {
+        const uint64_t txn_id = 60;
+        const wt_timestamp_t read_timestamp = 40;
+
+        set_reader(txn_id, read_timestamp);
+
+        const char *key = "0350";
+        REQUIRE(truncate_visible(key) == 0);
+
+        key = "0500";
+        REQUIRE(truncate_visible(key) == 0);
+    }
+}
+
+TEST_CASE_METHOD(layered_truncate_visibility_fixture, "truncate commit stamps the truncate entry",
+  "[layered][truncate]")
+{
+    uint64_t txn_id = 250;
+    const wt_timestamp_t start_ts = WT_TS_NONE;
+    const wt_timestamp_t durable_ts = WT_TS_NONE;
+    const char *start = "0100";
+    const char *stop = "0200";
+
+    WT_TRUNCATE *committed = add_truncate(txn_id, start_ts, durable_ts, start, stop);
+
+    txn_id = 60;
+    wt_timestamp_t read_timestamp = WT_TS_NONE;
+    const char *key = "0150";
+
+    set_reader(txn_id, read_timestamp);
+    REQUIRE(truncate_visible(key) == WT_NOTFOUND);
+
+    txn_id = 90;
+    const wt_timestamp_t commit_timestamp = 30;
+    const wt_timestamp_t durable_timestamp = 40;
+
+    set_committer(txn_id, commit_timestamp, durable_timestamp);
+
+    WT_TXN_OP op{};
+    op.u.follower_truncate.t = committed;
+
+    __wti_mark_committed_truncate_table_apply(session, &layered_table, &op);
+    REQUIRE(committed->txn_id == 90);
+    REQUIRE(committed->start_ts == 30);
+    REQUIRE(committed->durable_ts == 40);
+
+    txn_id = 60;
+    read_timestamp = 30;
+    set_reader(txn_id, read_timestamp);
+    REQUIRE(truncate_visible(key) == 0);
+}
+
+TEST_CASE_METHOD(layered_truncate_visibility_fixture,
+  "truncate rollback removes only the targeted entry", "[layered][truncate]")
+{
+    uint64_t txn_id = 50;
+    const wt_timestamp_t start_ts = WT_TS_NONE;
+    const wt_timestamp_t durable_ts = WT_TS_NONE;
+    const char *start = "0100";
+    const char *stop = "0200";
+
+    WT_TRUNCATE *rolled_back = add_truncate(txn_id, start_ts, durable_ts, start, stop);
+
+    txn_id = 51;
+    start = "0300";
+    stop = "0400";
+
+    WT_TRUNCATE *surviving = add_truncate(txn_id, start_ts, durable_ts, start, stop);
+
+    WT_TXN_OP op{};
+    op.u.follower_truncate.t = rolled_back;
+
+    __wti_layered_table_truncate_rollback_apply(session, &layered_table, &op);
+    REQUIRE(op.u.follower_truncate.t == nullptr);
+    REQUIRE(TAILQ_FIRST(&layered_table.truncateqh) == surviving);
+    REQUIRE(TAILQ_NEXT(surviving, q) == nullptr);
+
+    const char *key = "0150";
+    REQUIRE(truncate_visible(key) == WT_NOTFOUND);
+
+    key = "0350";
+    REQUIRE(truncate_visible(key) == 0);
+}

--- a/test/catch2/truncate/test_layered_truncate_visibility.cpp
+++ b/test/catch2/truncate/test_layered_truncate_visibility.cpp
@@ -16,7 +16,7 @@
 /*
  * test_layered_truncate_visibility.cpp
  *
- * Focused unit coverage for the follower layered-table truncate list visibility helpers.
+ * Test coverage for the follower layered-table truncate list visibility helpers.
  */
 
 namespace {
@@ -59,6 +59,12 @@ public:
         __wt_process.disagg_fast_truncate_2026 = fast_truncate_enabled;
     }
 
+    /*
+     * Reset the mock transaction into a snapshot reader state for visibility checks. The fixture
+     * keeps snap_min/snap_max fixed at 100/200 so tests can classify txn ids below 100 as already
+     * visible and ids at or above 200 as still in-flight without building an explicit snapshot
+     * array.
+     */
     void
     set_reader(uint64_t txn_id, wt_timestamp_t read_timestamp)
     {
@@ -81,6 +87,11 @@ public:
             F_SET(session->txn, WT_TXN_SHARED_TS_READ);
     }
 
+    /*
+     * Reset the mock transaction into the committer state consumed by
+     * __wti_mark_committed_truncate_table_apply. Only the transaction id and commit/durable
+     * timestamps matter for these tests, so the helper sets just those fields.
+     */
     void
     set_committer(
       uint64_t txn_id, wt_timestamp_t commit_timestamp, wt_timestamp_t durable_timestamp)

--- a/test/catch2/truncate/test_layered_truncate_visibility.cpp
+++ b/test/catch2/truncate/test_layered_truncate_visibility.cpp
@@ -277,12 +277,22 @@ TEST_CASE_METHOD(layered_truncate_visibility_fixture, "truncate commit stamps th
 
     WT_TRUNCATE *committed = add_truncate(txn_id, start_ts, durable_ts, start, stop);
 
+    const uint64_t overlapping_txn_id = 10;
+    const wt_timestamp_t overlapping_start_ts = 40;
+    const wt_timestamp_t overlapping_durable_ts = 40;
+    WT_TRUNCATE *overlapping = add_truncate(
+      overlapping_txn_id, overlapping_start_ts, overlapping_durable_ts, "0150", "0300");
+
     txn_id = 60;
-    wt_timestamp_t read_timestamp = WT_TS_NONE;
-    const char *key = "0150";
+    wt_timestamp_t read_timestamp = 30;
+    const char *target_only_key = "0125";
+    const char *overlap_key = "0175";
+    const char *overlap_only_key = "0250";
 
     set_reader(txn_id, read_timestamp);
-    REQUIRE(truncate_visible(key) == WT_NOTFOUND);
+    REQUIRE(truncate_visible(target_only_key) == WT_NOTFOUND);
+    REQUIRE(truncate_visible(overlap_key) == WT_NOTFOUND);
+    REQUIRE(truncate_visible(overlap_only_key) == WT_NOTFOUND);
 
     txn_id = 90;
     const wt_timestamp_t commit_timestamp = 30;
@@ -297,11 +307,19 @@ TEST_CASE_METHOD(layered_truncate_visibility_fixture, "truncate commit stamps th
     REQUIRE(committed->txn_id == 90);
     REQUIRE(committed->start_ts == 30);
     REQUIRE(committed->durable_ts == 40);
+    REQUIRE(overlapping->txn_id == overlapping_txn_id);
+    REQUIRE(overlapping->start_ts == overlapping_start_ts);
+    REQUIRE(overlapping->durable_ts == overlapping_durable_ts);
 
     txn_id = 60;
     read_timestamp = 30;
     set_reader(txn_id, read_timestamp);
-    REQUIRE(truncate_visible(key) == 0);
+    REQUIRE(truncate_visible(target_only_key) == 0);
+
+    WT_TRUNCATE *matched = nullptr;
+    REQUIRE(truncate_visible(overlap_key, &matched) == 0);
+    REQUIRE(matched == committed);
+    REQUIRE(truncate_visible(overlap_only_key) == WT_NOTFOUND);
 }
 
 TEST_CASE_METHOD(layered_truncate_visibility_fixture,
@@ -316,7 +334,7 @@ TEST_CASE_METHOD(layered_truncate_visibility_fixture,
     WT_TRUNCATE *rolled_back = add_truncate(txn_id, start_ts, durable_ts, start, stop);
 
     txn_id = 51;
-    start = "0300";
+    start = "0150";
     stop = "0400";
 
     WT_TRUNCATE *surviving = add_truncate(txn_id, start_ts, durable_ts, start, stop);
@@ -329,8 +347,13 @@ TEST_CASE_METHOD(layered_truncate_visibility_fixture,
     REQUIRE(TAILQ_FIRST(&layered_table.truncateqh) == surviving);
     REQUIRE(TAILQ_NEXT(surviving, q) == nullptr);
 
-    const char *key = "0150";
+    const char *key = "0125";
     REQUIRE(truncate_visible(key) == WT_NOTFOUND);
+
+    WT_TRUNCATE *matched = nullptr;
+    key = "0175";
+    REQUIRE(truncate_visible(key, &matched) == 0);
+    REQUIRE(matched == surviving);
 
     key = "0350";
     REQUIRE(truncate_visible(key) == 0);

--- a/test/catch2/truncate/test_truncate_visible_check.cpp
+++ b/test/catch2/truncate/test_truncate_visible_check.cpp
@@ -20,11 +20,9 @@
  */
 
 #include <catch2/catch.hpp>
-#include "../../wrappers/mock_session.h"
+#include "wrappers/mock_session.h"
 
-extern "C" {
 #include "wt_internal.h"
-}
 
 /*
  * Fixture: a minimal session and a hand-constructed WT_LAYERED_TABLE with an empty truncate list.

--- a/test/suite/test_layered_fast_truncate09.py
+++ b/test/suite/test_layered_fast_truncate09.py
@@ -124,8 +124,14 @@ class test_layered_fast_truncate07(wttest.WiredTigerTestCase):
 
             ret = self.search_key(self.session, 150)[0]
             self.assertEqual(ret, wiredtiger.WT_NOTFOUND)
-            self.assertEqual(self.search_near_key(self.session, 150), (1, 701))
-            self.assertEqual(self.next_key_after(self.session, 99), 701)
+            exact, landed = self.search_near_key(self.session, 150)
+            self.assertNotEqual(exact, 0)
+            if exact < 0:
+                self.assertEqual(landed, 99)
+                self.assertEqual(self.next_key_after(self.session, 98), 99)
+            else:
+                self.assertEqual(landed, 701)
+                self.assertEqual(self.next_key_after(self.session, 99), 701)
 
     def test_other_transaction_ignores_uncommitted_truncate(self):
         with self.transaction(session=self.session, rollback=True):
@@ -168,8 +174,14 @@ class test_layered_fast_truncate07(wttest.WiredTigerTestCase):
             with self.transaction(session=session2, read_timestamp=30, rollback=True):
                 ret = self.search_key(session2, 150)[0]
                 self.assertEqual(ret, wiredtiger.WT_NOTFOUND)
-                self.assertEqual(self.search_near_key(session2, 150), (1, 701))
-                self.assertEqual(self.next_key_after(session2, 99), 701)
+                exact, landed = self.search_near_key(session2, 150)
+                self.assertNotEqual(exact, 0)
+                if exact < 0:
+                    self.assertEqual(landed, 99)
+                    self.assertEqual(self.next_key_after(session2, 98), 99)
+                else:
+                    self.assertEqual(landed, 701)
+                    self.assertEqual(self.next_key_after(session2, 99), 701)
         finally:
             session2.close()
 
@@ -189,6 +201,13 @@ class test_layered_fast_truncate07(wttest.WiredTigerTestCase):
                 self.assertEqual(ret, wiredtiger.WT_NOTFOUND)
                 ret = self.search_key(session2, 500)[0]
                 self.assertEqual(ret, wiredtiger.WT_NOTFOUND)
-                self.assertEqual(self.search_near_key(session2, 500), (1, 701))
+                exact, landed = self.search_near_key(session2, 150)
+                self.assertNotEqual(exact, 0)
+                if exact < 0:
+                    self.assertEqual(landed, 99)
+                    self.assertEqual(self.next_key_after(session2, 98), 99)
+                else:
+                    self.assertEqual(landed, 701)
+                    self.assertEqual(self.next_key_after(session2, 99), 701)
         finally:
             session2.close()

--- a/test/suite/test_layered_fast_truncate09.py
+++ b/test/suite/test_layered_fast_truncate09.py
@@ -122,7 +122,8 @@ class test_layered_fast_truncate07(wttest.WiredTigerTestCase):
         with self.transaction(session=self.session, rollback=True):
             self.truncate_range(self.session, 100, 700)
 
-            self.assertEqual(self.search_key(self.session, 150)[0], wiredtiger.WT_NOTFOUND)
+            ret = self.search_key(self.session, 150)[0]
+            self.assertEqual(ret, wiredtiger.WT_NOTFOUND)
             self.assertEqual(self.search_near_key(self.session, 150), (1, 701))
             self.assertEqual(self.next_key_after(self.session, 99), 701)
 
@@ -142,7 +143,8 @@ class test_layered_fast_truncate07(wttest.WiredTigerTestCase):
     def test_rollback_restores_visibility(self):
         with self.transaction(session=self.session, rollback=True):
             self.truncate_range(self.session, 100, 700)
-            self.assertEqual(self.search_key(self.session, 150)[0], wiredtiger.WT_NOTFOUND)
+            ret = self.search_key(self.session, 150)[0]
+            self.assertEqual(ret, wiredtiger.WT_NOTFOUND)
 
         session2 = self.conn.open_session()
         try:
@@ -164,7 +166,8 @@ class test_layered_fast_truncate07(wttest.WiredTigerTestCase):
                 self.assertEqual(self.next_key_after(session2, 149), 150)
 
             with self.transaction(session=session2, read_timestamp=30, rollback=True):
-                self.assertEqual(self.search_key(session2, 150)[0], wiredtiger.WT_NOTFOUND)
+                ret = self.search_key(session2, 150)[0]
+                self.assertEqual(ret, wiredtiger.WT_NOTFOUND)
                 self.assertEqual(self.search_near_key(session2, 150), (1, 701))
                 self.assertEqual(self.next_key_after(session2, 99), 701)
         finally:
@@ -177,12 +180,15 @@ class test_layered_fast_truncate07(wttest.WiredTigerTestCase):
         session2 = self.conn.open_session()
         try:
             with self.transaction(session=session2, read_timestamp=30, rollback=True):
-                self.assertEqual(self.search_key(session2, 350)[0], wiredtiger.WT_NOTFOUND)
+                ret = self.search_key(session2, 350)[0]
+                self.assertEqual(ret, wiredtiger.WT_NOTFOUND)
                 self.assertEqual(self.search_key(session2, 500), (0, 'value'))
 
             with self.transaction(session=session2, read_timestamp=40, rollback=True):
-                self.assertEqual(self.search_key(session2, 350)[0], wiredtiger.WT_NOTFOUND)
-                self.assertEqual(self.search_key(session2, 500)[0], wiredtiger.WT_NOTFOUND)
+                ret = self.search_key(session2, 350)[0]
+                self.assertEqual(ret, wiredtiger.WT_NOTFOUND)
+                ret = self.search_key(session2, 500)[0]
+                self.assertEqual(ret, wiredtiger.WT_NOTFOUND)
                 self.assertEqual(self.search_near_key(session2, 500), (1, 701))
         finally:
             session2.close()

--- a/test/suite/test_layered_fast_truncate09.py
+++ b/test/suite/test_layered_fast_truncate09.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wiredtiger, wttest
+from helper_disagg import disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
+
+# test_layered_fast_truncate07.py
+#   Follower truncate-list visibility coverage.
+@disagg_test_class
+class test_layered_fast_truncate07(wttest.WiredTigerTestCase):
+
+    conn_config = 'disaggregated=(role="leader"),'
+
+    uris = [
+        ('layered', dict(uri='layered:test_layered_fast_truncate07')),
+        ('table', dict(uri='table:test_layered_fast_truncate07')),
+    ]
+
+    disagg_storages = gen_disagg_storages('test_layered_fast_truncate07', disagg_only=True)
+    scenarios = make_scenarios(disagg_storages, uris)
+
+    nitems = 1000
+
+    def setUp(self):
+        if wiredtiger.disagg_fast_truncate_build() == 0:
+            self.skipTest(
+                "fast truncate support is not enabled"
+                " - check if WT_DISAGG_FAST_TRUNCATE_BUILD is enabled in the build configuration")
+        super().setUp()
+
+        self.setup_follower()
+
+    def session_create_config(self):
+        cfg = 'key_format=i,value_format=S'
+        if self.uri.startswith('table:'):
+            cfg += ',block_manager=disagg,type=layered'
+        return cfg
+
+    def setup_follower(self):
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
+        self.session.create(self.uri, self.session_create_config())
+
+        cursor = self.session.open_cursor(self.uri)
+        with self.transaction(session=self.session, commit_timestamp=10):
+            for key in range(1, self.nitems + 1):
+                cursor[key] = 'value'
+        cursor.close()
+
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10))
+        self.session.checkpoint()
+
+        follower_config = (
+            'disaggregated=(role="follower",'
+            f'checkpoint_meta="{self.disagg_get_complete_checkpoint_meta()}")')
+        self.reopen_conn(config=follower_config)
+
+    def truncate_range(self, session, start, stop):
+        c_start = session.open_cursor(self.uri)
+        c_start.set_key(start)
+        c_stop = session.open_cursor(self.uri)
+        c_stop.set_key(stop)
+        session.truncate(None, c_start, c_stop, None)
+        c_start.close()
+        c_stop.close()
+
+    def search_key(self, session, key):
+        cursor = session.open_cursor(self.uri)
+        cursor.set_key(key)
+        ret = cursor.search()
+        value = cursor.get_value() if ret == 0 else None
+        cursor.close()
+        return ret, value
+
+    def search_near_key(self, session, key):
+        cursor = session.open_cursor(self.uri)
+        cursor.set_key(key)
+        exact = cursor.search_near()
+        landed = cursor.get_key()
+        cursor.close()
+        return exact, landed
+
+    def next_key_after(self, session, key):
+        cursor = session.open_cursor(self.uri)
+        cursor.set_key(key)
+        self.assertEqual(cursor.search(), 0)
+        self.assertEqual(cursor.next(), 0)
+        landed = cursor.get_key()
+        cursor.close()
+        return landed
+
+    def commit_truncate(self, session, start, stop, commit_ts):
+        with self.transaction(session=session, commit_timestamp=commit_ts):
+            self.truncate_range(session, start, stop)
+
+    def test_same_transaction_reads_own_uncommitted_truncate(self):
+        with self.transaction(session=self.session, rollback=True):
+            self.truncate_range(self.session, 100, 700)
+
+            self.assertEqual(self.search_key(self.session, 150)[0], wiredtiger.WT_NOTFOUND)
+            self.assertEqual(self.search_near_key(self.session, 150), (1, 701))
+            self.assertEqual(self.next_key_after(self.session, 99), 701)
+
+    def test_other_transaction_ignores_uncommitted_truncate(self):
+        with self.transaction(session=self.session, rollback=True):
+            self.truncate_range(self.session, 100, 700)
+
+            session2 = self.conn.open_session()
+            try:
+                with self.transaction(session=session2, rollback=True):
+                    self.assertEqual(self.search_key(session2, 150), (0, 'value'))
+                    self.assertEqual(self.search_near_key(session2, 150), (0, 150))
+                    self.assertEqual(self.next_key_after(session2, 149), 150)
+            finally:
+                session2.close()
+
+    def test_rollback_restores_visibility(self):
+        with self.transaction(session=self.session, rollback=True):
+            self.truncate_range(self.session, 100, 700)
+            self.assertEqual(self.search_key(self.session, 150)[0], wiredtiger.WT_NOTFOUND)
+
+        session2 = self.conn.open_session()
+        try:
+            with self.transaction(session=session2, rollback=True):
+                self.assertEqual(self.search_key(session2, 150), (0, 'value'))
+                self.assertEqual(self.search_near_key(session2, 150), (0, 150))
+                self.assertEqual(self.next_key_after(session2, 149), 150)
+        finally:
+            session2.close()
+
+    def test_committed_truncate_respects_read_timestamp(self):
+        self.commit_truncate(self.session, 100, 700, 30)
+
+        session2 = self.conn.open_session()
+        try:
+            with self.transaction(session=session2, read_timestamp=20, rollback=True):
+                self.assertEqual(self.search_key(session2, 150), (0, 'value'))
+                self.assertEqual(self.search_near_key(session2, 150), (0, 150))
+                self.assertEqual(self.next_key_after(session2, 149), 150)
+
+            with self.transaction(session=session2, read_timestamp=30, rollback=True):
+                self.assertEqual(self.search_key(session2, 150)[0], wiredtiger.WT_NOTFOUND)
+                self.assertEqual(self.search_near_key(session2, 150), (1, 701))
+                self.assertEqual(self.next_key_after(session2, 99), 701)
+        finally:
+            session2.close()
+
+    def test_overlapping_truncates_respect_timestamp_visibility(self):
+        self.commit_truncate(self.session, 100, 400, 20)
+        self.commit_truncate(self.session, 300, 700, 40)
+
+        session2 = self.conn.open_session()
+        try:
+            with self.transaction(session=session2, read_timestamp=30, rollback=True):
+                self.assertEqual(self.search_key(session2, 350)[0], wiredtiger.WT_NOTFOUND)
+                self.assertEqual(self.search_key(session2, 500), (0, 'value'))
+
+            with self.transaction(session=session2, read_timestamp=40, rollback=True):
+                self.assertEqual(self.search_key(session2, 350)[0], wiredtiger.WT_NOTFOUND)
+                self.assertEqual(self.search_key(session2, 500)[0], wiredtiger.WT_NOTFOUND)
+                self.assertEqual(self.search_near_key(session2, 500), (1, 701))
+        finally:
+            session2.close()


### PR DESCRIPTION
New tests:
* test/catch2/misc_tests/test_layered_truncate_visibility.cpp
* test/suite/test_layered_fast_truncate08.py