### PR TITLE
WT-16813 Implement garbage collection checkpoint pick-up with fast truncate design

### DIFF
--- a/src/conn/conn_layered_ingest.c
+++ b/src/conn/conn_layered_ingest.c
@@ -710,7 +710,7 @@ err:
 
 /*
  * __layered_update_ingest_table_prune_timestamp --
- *     Update the prune timestamp of the specified ingest table.
+ *     Update the prune timestamp and clean up the truncate list of the specified ingest table.
  *
  * We want to see what is the oldest checkpoint on the provided table that is in use by any open
  *     cursor. Even if there are no open cursors on it, the most recent checkpoint on the table is
@@ -725,30 +725,19 @@ err:
  *     calls.
  */
 static int
-__layered_update_ingest_table_prune_timestamp(WT_SESSION_IMPL *session, const char *layered_uri,
-  wt_timestamp_t checkpoint_timestamp, WT_ITEM *uri_at_checkpoint_buf)
+__layered_update_ingest_table_prune_timestamp(WT_SESSION_IMPL *session,
+  WT_LAYERED_TABLE *layered_table, wt_timestamp_t checkpoint_timestamp,
+  WT_ITEM *uri_at_checkpoint_buf, wt_timestamp_t *prune_tsp)
 {
     WT_BTREE *btree;
     WT_DECL_RET;
-    WT_LAYERED_TABLE *layered_table;
     wt_timestamp_t btree_prune_timestamp, prune_timestamp;
     int64_t ckpt_inuse, last_ckpt;
     int32_t layered_dhandle_inuse, stable_dhandle_inuse;
 
-    layered_table = NULL;
+    WT_ASSERT(session, prune_tsp != NULL);
     prune_timestamp = WT_TS_NONE;
-
-    /*
-     * Get the layered table from the provided URI. We don't hold any global locks so that's
-     * possible that it was already removed.
-     */
-    WT_ERR_NOTFOUND_OK(__wt_session_get_dhandle(session, layered_uri, NULL, NULL, 0), true);
-    if (ret == WT_NOTFOUND) {
-        __wt_verbose_level(session, WT_VERB_LAYERED, WT_VERBOSE_DEBUG_5,
-          "GC %s: Layered table was not found.", layered_uri);
-        return (0);
-    }
-    layered_table = (WT_LAYERED_TABLE *)session->dhandle;
+    *prune_tsp = WT_TS_NONE;
 
     /*
      * Get the last existing checkpoint. If we've never seen a checkpoint, then there's nothing in
@@ -852,15 +841,46 @@ __layered_update_ingest_table_prune_timestamp(WT_SESSION_IMPL *session, const ch
      * obsolete value. Therefore, no synchronization is required.
      */
     __wt_atomic_store_uint64_relaxed(&btree->prune_timestamp, prune_timestamp);
+    *prune_tsp = prune_timestamp;
     layered_table->last_ckpt_inuse = ckpt_inuse;
 
     WT_ERR(__wt_session_release_dhandle(session));
 
 err:
-    WT_ASSERT(session, layered_table != NULL);
     session->dhandle = (WT_DATA_HANDLE *)layered_table;
-    WT_TRET(__wt_session_release_dhandle(session));
+    return (ret);
+}
 
+/*
+ * __layered_single_ingest_table_gc_prune --
+ *     Update the prune timestamps and garbage collect the truncate list for a given ingest table.
+ */
+static int
+__layered_single_ingest_table_gc_prune(WT_SESSION_IMPL *session, const char *layered_uri,
+  wt_timestamp_t checkpoint_timestamp, WT_ITEM *uri_at_checkpoint_buf)
+{
+    WT_DECL_RET;
+    WT_LAYERED_TABLE *layered_table = NULL;
+
+    ret = __wt_session_get_dhandle(session, layered_uri, NULL, NULL, 0);
+
+    if (ret == WT_NOTFOUND) {
+        __wt_verbose_level(session, WT_VERB_LAYERED, WT_VERBOSE_DEBUG_5,
+          "GC %s: Layered table was not found.", layered_uri);
+        return (0);
+    }
+
+    WT_RET(ret);
+    layered_table = (WT_LAYERED_TABLE *)session->dhandle;
+    wt_timestamp_t prune_timestamp = WT_TS_NONE;
+
+    WT_ERR(__layered_update_ingest_table_prune_timestamp(
+      session, layered_table, checkpoint_timestamp, uri_at_checkpoint_buf, &prune_timestamp));
+
+    __wt_layered_table_truncate_gc(session, layered_table, prune_timestamp);
+
+err:
+    WT_TRET(__wt_session_release_dhandle(session));
     return (ret);
 }
 
@@ -906,7 +926,7 @@ __wti_layered_iterate_ingest_tables_for_gc_pruning(
         /* Check the buffer-copy result here to avoid returning with the mutex held. */
         WT_ERR(ret);
 
-        WT_ERR(__layered_update_ingest_table_prune_timestamp(
+        WT_ERR(__layered_single_ingest_table_gc_prune(
           session, layered_table_uri_buf->data, checkpoint_timestamp, uri_at_checkpoint_buf));
 
         __wt_spin_lock(session, &manager->layered_table_lock);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1781,6 +1781,8 @@ extern void __wt_json_close(WT_SESSION_IMPL *session, WT_CURSOR *cursor);
 extern void __wt_layered_table_manager_remove_table(WT_SESSION_IMPL *session, uint32_t ingest_id);
 extern void __wt_layered_table_truncate_clear(
   WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered_table);
+extern void __wt_layered_table_truncate_gc(WT_SESSION_IMPL *const session,
+  WT_LAYERED_TABLE *const layered_table, const wt_timestamp_t prune_ts);
 extern void __wt_log_data_dump(
   WT_SESSION_IMPL *session, const void *data, size_t size, const char *fmt, ...)
   WT_GCC_FUNC_DECL_ATTRIBUTE((cold)) WT_GCC_FUNC_DECL_ATTRIBUTE((format(printf, 4, 5)));

--- a/src/txn/txn_truncate.c
+++ b/src/txn/txn_truncate.c
@@ -374,23 +374,23 @@ __truncate_entry_eligible_for_gc(const WT_TRUNCATE *const entry, const wt_timest
  * __wt_layered_table_truncate_gc --
  *     Reap truncate-list entries whose effect is now durable in the picked-up checkpoint.
  */
-int
+void
 __wt_layered_table_truncate_gc(WT_SESSION_IMPL *const session,
   WT_LAYERED_TABLE *const layered_table, const wt_timestamp_t prune_ts)
 {
     if (!__wt_process.disagg_fast_truncate_2026)
-        return (0);
+        return;
 
     WT_ASSERT(session, layered_table != NULL);
     WT_ASSERT(session, WT_PREFIX_MATCH(layered_table->iface.name, "layered:"));
 
     if (prune_ts == WT_TS_NONE)
-        return (0);
-
-    __wt_writelock(session, &layered_table->truncate_lock);
+        return;
 
     WT_TRUNCATE *entry = NULL;
     WT_TRUNCATE *next = NULL;
+
+    __wt_writelock(session, &layered_table->truncate_lock);
 
     TAILQ_FOREACH_SAFE(entry, &layered_table->truncateqh, q, next)
     {
@@ -402,6 +402,4 @@ __wt_layered_table_truncate_gc(WT_SESSION_IMPL *const session,
     }
 
     __wt_writeunlock(session, &layered_table->truncate_lock);
-
-    return (0);
 }

--- a/src/txn/txn_truncate.c
+++ b/src/txn/txn_truncate.c
@@ -356,7 +356,7 @@ __wt_layered_table_truncate_clear(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *la
 
 /*
  * __truncate_entry_eligible_for_gc --
- *     A committed entry whose effect is now in the picked-up checkpoint.
+ *     Determine if an entry is redundant and should be removed from the list.
  */
 static bool
 __truncate_entry_eligible_for_gc(const WT_TRUNCATE *const entry, const wt_timestamp_t prune_ts)

--- a/src/txn/txn_truncate.c
+++ b/src/txn/txn_truncate.c
@@ -353,3 +353,55 @@ __wt_layered_table_truncate_clear(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *la
     }
     __wt_writeunlock(session, &layered_table->truncate_lock);
 }
+
+/*
+ * __truncate_entry_eligible_for_gc --
+ *     A committed, non-prepared entry whose effect is now in the picked-up checkpoint.
+ */
+static bool
+__truncate_entry_eligible_for_gc(const WT_TRUNCATE *const entry, const wt_timestamp_t prune_ts)
+{
+    if (prune_ts == WT_TS_NONE)
+        return (false);
+
+    if (entry->durable_ts == WT_TS_NONE)
+        return (false);
+
+    return (entry->durable_ts <= prune_ts);
+}
+
+/*
+ * __wt_layered_table_truncate_gc --
+ *     Reap truncate-list entries whose effect is now durable in the picked-up checkpoint.
+ */
+int
+__wt_layered_table_truncate_gc(WT_SESSION_IMPL *const session,
+  WT_LAYERED_TABLE *const layered_table, const wt_timestamp_t prune_ts)
+{
+    if (!__wt_process.disagg_fast_truncate_2026)
+        return (0);
+
+    WT_ASSERT(session, layered_table != NULL);
+    WT_ASSERT(session, WT_PREFIX_MATCH(layered_table->iface.name, "layered:"));
+
+    if (prune_ts == WT_TS_NONE)
+        return (0);
+
+    __wt_writelock(session, &layered_table->truncate_lock);
+
+    WT_TRUNCATE *entry = NULL;
+    WT_TRUNCATE *next = NULL;
+
+    TAILQ_FOREACH_SAFE(entry, &layered_table->truncateqh, q, next)
+    {
+        if (!__truncate_entry_eligible_for_gc(entry, prune_ts))
+            continue;
+
+        TAILQ_REMOVE(&layered_table->truncateqh, entry, q);
+        __disagg_truncate_free(session, &entry);
+    }
+
+    __wt_writeunlock(session, &layered_table->truncate_lock);
+
+    return (0);
+}

--- a/src/txn/txn_truncate.c
+++ b/src/txn/txn_truncate.c
@@ -356,7 +356,7 @@ __wt_layered_table_truncate_clear(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *la
 
 /*
  * __truncate_entry_eligible_for_gc --
- *     A committed, non-prepared entry whose effect is now in the picked-up checkpoint.
+ *     A committed entry whose effect is now in the picked-up checkpoint.
  */
 static bool
 __truncate_entry_eligible_for_gc(const WT_TRUNCATE *const entry, const wt_timestamp_t prune_ts)


### PR DESCRIPTION
To do:
- Return a copy in __wt_truncate_delete_visible_check. Returning a raw pointer and then having garbage collection run would be catastrophic...
- Catch2 and Python unit tests