### PR TITLE
WT-17305 Checkpoint after step-up in test/format

### DIFF
--- a/test/format/format.h
+++ b/test/format/format.h
@@ -497,6 +497,7 @@ void table_verify(TABLE *, void *);
 void timestamp_init(void);
 wt_timestamp_t timestamp_minimum_committed(void);
 void timestamp_once(WT_SESSION *, bool, bool);
+void timestamp_sync_threads_commit_ts(void);
 void replay_adjust_key(TINFO *, uint64_t);
 wt_timestamp_t replay_commit_ts(TINFO *);
 wt_timestamp_t replay_rollback_ts(TINFO *);

--- a/test/format/format_disagg.c
+++ b/test/format/format_disagg.c
@@ -252,9 +252,17 @@ disagg_switch_roles(void)
         track("[role change] follower -> leader", 0ULL);
         testutil_check(g.wts_conn->reconfigure(g.wts_conn, "disaggregated=(role=leader)"));
 
-        /* Advance timestamps and take a checkpoint immediately after becoming leader. */
+        /*
+         * Advance timestamps to cover all in-memory commits from the follower phase before. During
+         * the follower phase, ops threads write to cache with commit timestamps up to g.timestamp,
+         * but those pages can't be evicted. With stable lagging behind, eviction gets permanently
+         * stuck. Setting stable_timestamp = g.timestamp here causes the subsequent timestamp_once
+         * call to advance stable all the way to g.timestamp, so eviction and the step-up checkpoint
+         * can proceed cleanly.
+         */
         memset(&sap, 0, sizeof(sap));
         wt_wrap_open_session(g.wts_conn, &sap, NULL, NULL, &session);
+        g.stable_timestamp = g.timestamp;
         timestamp_once(session, false, false);
         testutil_check(session->checkpoint(session, NULL));
         wt_wrap_close_session(session);

--- a/test/format/format_disagg.c
+++ b/test/format/format_disagg.c
@@ -252,17 +252,10 @@ disagg_switch_roles(void)
         track("[role change] follower -> leader", 0ULL);
         testutil_check(g.wts_conn->reconfigure(g.wts_conn, "disaggregated=(role=leader)"));
 
-        /*
-         * Advance timestamps to cover all in-memory commits from the follower phase before. During
-         * the follower phase, ops threads write to cache with commit timestamps up to g.timestamp,
-         * but those pages can't be evicted. With stable lagging behind, eviction gets permanently
-         * stuck. Setting stable_timestamp = g.timestamp here causes the subsequent timestamp_once
-         * call to advance stable all the way to g.timestamp, so eviction and the step-up checkpoint
-         * can proceed cleanly.
-         */
         memset(&sap, 0, sizeof(sap));
         wt_wrap_open_session(g.wts_conn, &sap, NULL, NULL, &session);
-        g.stable_timestamp = g.timestamp;
+        /* Advance timestamps to cover all in-memory commits from the follower phase. */
+        timestamp_sync_threads_commit_ts();
         timestamp_once(session, false, false);
         testutil_check(session->checkpoint(session, NULL));
         wt_wrap_close_session(session);

--- a/test/format/format_disagg.c
+++ b/test/format/format_disagg.c
@@ -246,8 +246,18 @@ disagg_switch_roles(void)
         wts_prepare_discover(g.wts_conn);
     } else {
         /* Stepping up: [follower -> leader] */
+        SAP sap;
+        WT_SESSION *session;
+
         track("[role change] follower -> leader", 0ULL);
         testutil_check(g.wts_conn->reconfigure(g.wts_conn, "disaggregated=(role=leader)"));
+
+        /* Advance timestamps and take a checkpoint immediately after becoming leader. */
+        memset(&sap, 0, sizeof(sap));
+        wt_wrap_open_session(g.wts_conn, &sap, NULL, NULL, &session);
+        timestamp_once(session, false, false);
+        testutil_check(session->checkpoint(session, NULL));
+        wt_wrap_close_session(session);
     }
 
     /* After every switch, verify the contents of each table */

--- a/test/format/format_prepare_discover.c
+++ b/test/format/format_prepare_discover.c
@@ -116,7 +116,7 @@ wts_prepare_discover(WT_CONNECTION *conn)
     }
     testutil_check(cursor->close(cursor));
 
-    session->checkpoint(session, NULL);
+    testutil_check(session->checkpoint(session, NULL));
     /* FIXME-WT-15357 Checkpoint cursors are not compatible with disagg for now. */
     wts_verify_mirrors(g.wts_conn, g.disagg_storage_config ? NULL : "WiredTigerCheckpoint", NULL);
     testutil_check(session->close(session, NULL));

--- a/test/format/format_timestamp.c
+++ b/test/format/format_timestamp.c
@@ -62,6 +62,26 @@ timestamp_minimum_committed(void)
 }
 
 /*
+ * timestamp_sync_threads_commit_ts --
+ *     Advance each ops thread's recorded last-used commit timestamp to g.timestamp. Callers must
+ *     ensure ops threads are quiescent (e.g. between operations() runs); this is used during disagg
+ *     role switch so the next timestamp_once advances stable past all in-memory follower commits.
+ */
+void
+timestamp_sync_threads_commit_ts(void)
+{
+    TINFO **tlp;
+    wt_timestamp_t ts;
+
+    if (tinfo_list == NULL)
+        return;
+
+    WT_ACQUIRE_READ_WITH_BARRIER(ts, g.timestamp);
+    for (tlp = tinfo_list; *tlp != NULL; ++tlp)
+        WT_RELEASE_WRITE_WITH_BARRIER((*tlp)->commit_ts, ts);
+}
+
+/*
  * timestamp_query --
  *     Query a timestamp.
  */
@@ -141,12 +161,6 @@ timestamp_once(WT_SESSION *session, bool allow_lag, bool final)
         if (allow_lag)
             oldest_timestamp -= (oldest_timestamp - g.oldest_timestamp) / 2;
     }
-
-    /*
-     * Never move timestamps backwards. This can happen after a disagg step-up sets
-     * g.stable_timestamp to g.timestamp (covering all in-memory follower commits).
-     */
-    stable_timestamp = WT_MAX(stable_timestamp, g.stable_timestamp);
 
     testutil_snprintf(buf, sizeof(buf), "%s%" PRIx64 ",%s%" PRIx64, oldest_timestamp_str,
       oldest_timestamp, stable_timestamp_str, stable_timestamp);

--- a/test/format/format_timestamp.c
+++ b/test/format/format_timestamp.c
@@ -143,8 +143,8 @@ timestamp_once(WT_SESSION *session, bool allow_lag, bool final)
     }
 
     /*
-     * Never move timestamps backwards. This can happen after a disagg step-up sets g.stable_timestamp
-     * to g.timestamp (covering all in-memory follower commits).
+     * Never move timestamps backwards. This can happen after a disagg step-up sets
+     * g.stable_timestamp to g.timestamp (covering all in-memory follower commits).
      */
     stable_timestamp = WT_MAX(stable_timestamp, g.stable_timestamp);
 

--- a/test/format/format_timestamp.c
+++ b/test/format/format_timestamp.c
@@ -142,6 +142,12 @@ timestamp_once(WT_SESSION *session, bool allow_lag, bool final)
             oldest_timestamp -= (oldest_timestamp - g.oldest_timestamp) / 2;
     }
 
+    /*
+     * Never move timestamps backwards. This can happen after a disagg step-up sets g.stable_timestamp
+     * to g.timestamp (covering all in-memory follower commits).
+     */
+    stable_timestamp = WT_MAX(stable_timestamp, g.stable_timestamp);
+
     testutil_snprintf(buf, sizeof(buf), "%s%" PRIx64 ",%s%" PRIx64, oldest_timestamp_str,
       oldest_timestamp, stable_timestamp_str, stable_timestamp);
 


### PR DESCRIPTION
## Summary

- In `disagg_switch_roles`, after reconfiguring to leader, advance timestamps and take a checkpoint before the test workload resumes — this anchors the new leader with a clean checkpoint on promotion, preventing old dirty pages from pinning the cache under the disagg switch stress workload
- During the follower phase, ops threads write to cache with commit timestamps up to `g.timestamp`, but those pages aren't evictable while stable lags behind. To make stable advance all the way on step-up, sync each ops thread's recorded `commit_ts` to `g.timestamp` before calling `timestamp_once` — `timestamp_minimum_committed()` then naturally returns `g.timestamp - 1` and stable advances cleanly. Safe because all ops threads are joined at this point; the bumped value is harmless and will be overwritten by strictly larger values on the next commit cycle
- Adds `timestamp_sync_threads_commit_ts()` helper in `format_timestamp.c`
- Fixes a latent bug in `wts_prepare_discover` where `session->checkpoint()` return value was silently dropped — now wrapped with `testutil_check`

## JIRA
https://jira.mongodb.org/browse/WT-17305

## Test plan
- [x] Run `format-stress-test-disagg-switch-data-validation-2` on `amazon2023-disagg-stress`
- [x] Verify no cache-stuck failures with `disagg.mode=switch`
- [x] Run `test/format` locally with `disagg.mode=switch` to confirm checkpoint fires on step-up