### PR TITLE
WT-17383 Fix reconciliation selecting rollback tombstone when rollback timestamp is not yet stable

### DIFF
--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -803,6 +803,7 @@ __rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_CELL_UNPACK_KV *
           session_txnid != WT_TXN_NONE && txnid == session_txnid) {
             *upd_memsizep += WT_UPDATE_MEMSIZE(upd);
             *has_newer_updatesp = true;
+            WT_ASSERT(session, prepare_rollback_tombstone == NULL);
             continue;
         }
         /*

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -837,12 +837,13 @@ __rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_CELL_UNPACK_KV *
             *upd_memsizep += WT_UPDATE_MEMSIZE(upd);
             *has_newer_updatesp = true;
             /*
-             * If we have already seen a rollback tombstone, the update we are now skipping is the
-             * aborted prepared update that the tombstone rolled back, and its rollback is not yet
-             * stable (otherwise we would have broken out of the loop above). The rollback decision
-             * is not durable, so the rollback tombstone is not safe to write to disk. Drop it from
-             * consideration so the fallback after the loop does not select it for write; we will
-             * revisit this key in a later reconcile once the rollback becomes stable.
+             * If we have already seen a globally visible tombstone from prepared rollback, the
+             * update we are now skipping is the aborted prepared update that the tombstone rolled
+             * back, and its rollback is not yet stable (otherwise we would have broken out of the
+             * loop above). The rollback decision is not durable, so the rollback tombstone is not
+             * safe to write to disk. Drop it from consideration so the fallback after the loop does
+             * not select it for write; we will revisit this key in a later reconcile once the
+             * rollback becomes stable.
              */
             prepare_rollback_tombstone = NULL;
 

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -835,6 +835,16 @@ __rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_CELL_UNPACK_KV *
 
             *upd_memsizep += WT_UPDATE_MEMSIZE(upd);
             *has_newer_updatesp = true;
+            /*
+             * If we have already seen a rollback tombstone, the update we are now skipping is the
+             * aborted prepared update that the tombstone rolled back, and its rollback is not yet
+             * stable (otherwise we would have broken out of the loop above). The rollback decision
+             * is not durable, so the rollback tombstone is not safe to write to disk. Drop it from
+             * consideration so the fallback after the loop does not select it for write; we will
+             * revisit this key in a later reconcile once the rollback becomes stable.
+             */
+            prepare_rollback_tombstone = NULL;
+
             continue;
         }
 
@@ -862,8 +872,7 @@ __rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_CELL_UNPACK_KV *
                     *upd_memsizep += WT_UPDATE_MEMSIZE(upd);
                     *has_newer_updatesp = true;
                     /* We should write nothing to disk. */
-                    if (prepare_rollback_tombstone != NULL)
-                        prepare_rollback_tombstone = NULL;
+                    prepare_rollback_tombstone = NULL;
                     continue;
                 }
 

--- a/test/suite/test_prepare46.py
+++ b/test/suite/test_prepare46.py
@@ -27,16 +27,28 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 # test_prepare46.py
-# Regression test for a bug in reconciliation where a prepare rollback tombstone was
-# incorrectly selected for disk write when the rollback timestamp was not yet stable.
+# Regression test: a prepare rollback whose prepare timestamp is not yet stable
+# at the time of eviction should leave the prepared cell available for the next
+# checkpoint. Once the prepare timestamp becomes stable, the checkpoint must
+# write the preserved prepared cell to disk, not a tombstone.
 #
-# Update chain for the key under test:
-#   [rollback_tombstone] -> [aborted_prepare(rollback_ts=50)] -> [committed_value(ts=20)]
+# Update chain for key 2 (fresh insert, no prior committed value):
+#   [rollback tombstone] -> [aborted prepare (prepare_ts=30, rollback_ts=50)]
 #
-# When stable_ts < prepare_ts, reconciliation must skip both the tombstone and the aborted
-# prepare and select the committed value instead.  Without the fix, prepare_rollback_tombstone
-# remained set after skipping the aborted prepared update, causing an assertion failure (in
-# diagnostic builds) when reconciliation tried to select the following committed value.
+# Step 1: eviction at stable=25 (prepare_ts=30 not yet stable):
+#   Reconciliation must not write the rollback tombstone because the rollback
+#   decision is not yet stable. The page stays dirty for a later reconcile.
+#
+#   Without the fix, the tombstone is incorrectly selected and marked as already
+#   written to disk, poisoning subsequent reconciliations.
+#
+# Step 2: checkpoint at stable=35 (prepare_ts=30 now stable, rollback_ts=50 not):
+#   Reconciliation should write the preserved prepared cell to disk.
+#
+#   Without the fix, the poisoned tombstone is re-selected and the prepared cell
+#   is never written.
+#   With the fix, step 1 correctly defers the tombstone and step 2 writes the
+#   prepared cell.
 
 import wiredtiger
 import wttest
@@ -46,25 +58,42 @@ class test_prepare46(wttest.WiredTigerTestCase):
     conn_config = 'precise_checkpoint=true,preserve_prepared=true'
     uri = 'table:test_prepare46'
 
-    def test_rollback_tombstone_skipped_when_rollback_not_stable(self):
+    def test_prepared_cell_preserved_after_eviction_at_unstable_prepare_ts(self):
         self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10))
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10))
         self.session.create(self.uri, 'key_format=i,value_format=S')
         cursor = self.session.open_cursor(self.uri)
 
-        # Commit a value for key 1 at ts=20.
+        # Commit a value for key 1 at ts=20 so the page has something to evict.
         self.session.begin_transaction()
         cursor[1] = 'committed_value'
         self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(20))
 
+        # stable=25 is intentionally below prepare_ts=30 so that the prepare is
+        # not yet stable when eviction runs.
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(25))
 
-        # Prepare an update at ts=30, then roll it back at rollback_ts=50.
-        # This creates: [tombstone] -> [aborted_prepare(rollback_ts=50)] -> [committed_value(ts=20)]
+        # session_blocker holds an active write transaction started before
+        # session_prep and kept open through eviction. Its presence as a
+        # concurrent writer is what places reconciliation on the code path where
+        # the tombstone must be deferred, the exact path where the bug manifests.
+        session_blocker = self.conn.open_session()
+        cursor_blocker = session_blocker.open_cursor(self.uri)
+        session_blocker.begin_transaction()
+        cursor_blocker[3] = 'blocker_value'
+        cursor_blocker.close()
+
+        session_evict = self.conn.open_session()
+        session_evict.begin_transaction('ignore_prepare=true')
+
+        # Fresh insert on key 2 at prepare_ts=30, rolled back at rollback_ts=50.
+        # Because key 2 has no prior committed value the rollback prepends a
+        # globally visible tombstone:
+        #   [rollback tombstone] -> [aborted prepare (rollback_ts=50)]
         session_prep = self.conn.open_session()
         cursor_prep = session_prep.open_cursor(self.uri)
         session_prep.begin_transaction()
-        cursor_prep[1] = 'prepared_value'
+        cursor_prep[2] = 'prepared_value'
         session_prep.prepare_transaction(
             'prepare_timestamp=' + self.timestamp_str(30) +
             ',prepared_id=' + self.prepared_id_str(1))
@@ -72,13 +101,9 @@ class test_prepare46(wttest.WiredTigerTestCase):
         session_prep.rollback_transaction('rollback_timestamp=' + self.timestamp_str(50))
         session_prep.close()
 
-        # stable=35 is below rollback_ts=50  rollback not yet stable.
-        # Reconciliation must not select the tombstone; committed_value must be preserved.
-        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(35))
-
-        # Without the fix this triggers an assertion failure in diagnostic builds.
-        session_evict = self.conn.open_session()
-        session_evict.begin_transaction('ignore_prepare=true')
+        # Evict at stable=25: prepare_ts=30 is not yet stable.
+        # Without the fix the tombstone is incorrectly written to disk,
+        # preventing the prepared cell from being written at the next checkpoint.
         evict_cursor = session_evict.open_cursor(self.uri, None, 'debug=(release_evict)')
         evict_cursor.set_key(1)
         self.assertEqual(evict_cursor.search(), 0)
@@ -88,25 +113,32 @@ class test_prepare46(wttest.WiredTigerTestCase):
         session_evict.rollback_transaction()
         session_evict.close()
 
+        session_blocker.rollback_transaction()
+        session_blocker.close()
+
+        # stable=35: prepare_ts=30 is now stable but rollback_ts=50 is not.
+        # The checkpoint must write the preserved prepared cell to disk.
+        # Without the fix the tombstone is re-selected and no prepared cell is written.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(35))
+        self.checkpoint_and_verify_stats({
+            wiredtiger.stat.dsrc.rec_time_window_prepared: True,
+        }, self.uri)
+
         self.session.begin_transaction('read_timestamp=' + self.timestamp_str(20))
         cursor.set_key(1)
         self.assertEqual(cursor.search(), 0)
         self.assertEqual(cursor.get_value(), 'committed_value')
         self.session.rollback_transaction()
 
-        # Now the rollback is stable; the tombstone can be written safely on the next reconciliation.
+        # stable=55: rollback_ts=50 is now stable; the tombstone should be written
+        # cleanly with no preserved prepared cell.
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(55))
-        session_evict2 = self.conn.open_session()
-        session_evict2.begin_transaction('ignore_prepare=true')
-        evict_cursor2 = session_evict2.open_cursor(self.uri, None, 'debug=(release_evict)')
-        evict_cursor2.set_key(1)
-        self.assertIn(evict_cursor2.search(), [0, wiredtiger.WT_NOTFOUND])
-        evict_cursor2.reset()
-        evict_cursor2.close()
-        session_evict2.rollback_transaction()
-        session_evict2.close()
+        self.checkpoint_and_verify_stats({
+            wiredtiger.stat.dsrc.rec_time_window_prepared: False,
+        }, self.uri)
 
-        # After the tombstone is written, reads at ts=20 must still resolve via the history store.
+        # After the tombstone is written, reads at ts=20 must still resolve via
+        # the history store.
         self.session.begin_transaction('read_timestamp=' + self.timestamp_str(20))
         cursor.set_key(1)
         self.assertEqual(cursor.search(), 0)

--- a/test/suite/test_prepare46.py
+++ b/test/suite/test_prepare46.py
@@ -33,7 +33,7 @@
 # Update chain for the key under test:
 #   [rollback_tombstone] -> [aborted_prepare(rollback_ts=50)] -> [committed_value(ts=20)]
 #
-# When stable_ts < rollback_ts, reconciliation must skip both the tombstone and the aborted
+# When stable_ts < prepare_ts, reconciliation must skip both the tombstone and the aborted
 # prepare and select the committed value instead.  Without the fix, prepare_rollback_tombstone
 # remained set after skipping the aborted prepared update, causing an assertion failure (in
 # diagnostic builds) when reconciliation tried to select the following committed value.

--- a/test/suite/test_prepare46.py
+++ b/test/suite/test_prepare46.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# test_prepare46.py
+# Regression test for a bug in reconciliation where a prepare rollback tombstone was
+# incorrectly selected for disk write when the rollback timestamp was not yet stable.
+#
+# Update chain for the key under test:
+#   [rollback_tombstone] -> [aborted_prepare(rollback_ts=50)] -> [committed_value(ts=20)]
+#
+# When stable_ts < rollback_ts, reconciliation must skip both the tombstone and the aborted
+# prepare and select the committed value instead.  Without the fix, prepare_rollback_tombstone
+# remained set after skipping the aborted prepared update, causing an assertion failure (in
+# diagnostic builds) when reconciliation tried to select the following committed value.
+
+import wiredtiger
+import wttest
+
+class test_prepare46(wttest.WiredTigerTestCase):
+
+    conn_config = 'precise_checkpoint=true,preserve_prepared=true'
+    uri = 'table:test_prepare46'
+
+    def test_rollback_tombstone_skipped_when_rollback_not_stable(self):
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(10))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10))
+        self.session.create(self.uri, 'key_format=i,value_format=S')
+        cursor = self.session.open_cursor(self.uri)
+
+        # Commit a value for key 1 at ts=20.
+        self.session.begin_transaction()
+        cursor[1] = 'committed_value'
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(20))
+
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(25))
+
+        # Prepare an update at ts=30, then roll it back at rollback_ts=50.
+        # This creates: [tombstone] -> [aborted_prepare(rollback_ts=50)] -> [committed_value(ts=20)]
+        session_prep = self.conn.open_session()
+        cursor_prep = session_prep.open_cursor(self.uri)
+        session_prep.begin_transaction()
+        cursor_prep[1] = 'prepared_value'
+        session_prep.prepare_transaction(
+            'prepare_timestamp=' + self.timestamp_str(30) +
+            ',prepared_id=' + self.prepared_id_str(1))
+        cursor_prep.close()
+        session_prep.rollback_transaction('rollback_timestamp=' + self.timestamp_str(50))
+        session_prep.close()
+
+        # stable=35 is below rollback_ts=50  rollback not yet stable.
+        # Reconciliation must not select the tombstone; committed_value must be preserved.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(35))
+
+        # Without the fix this triggers an assertion failure in diagnostic builds.
+        session_evict = self.conn.open_session()
+        session_evict.begin_transaction('ignore_prepare=true')
+        evict_cursor = session_evict.open_cursor(self.uri, None, 'debug=(release_evict)')
+        evict_cursor.set_key(1)
+        self.assertEqual(evict_cursor.search(), 0)
+        self.assertEqual(evict_cursor.get_value(), 'committed_value')
+        evict_cursor.reset()
+        evict_cursor.close()
+        session_evict.rollback_transaction()
+        session_evict.close()
+
+        self.session.begin_transaction('read_timestamp=' + self.timestamp_str(20))
+        cursor.set_key(1)
+        self.assertEqual(cursor.search(), 0)
+        self.assertEqual(cursor.get_value(), 'committed_value')
+        self.session.rollback_transaction()
+
+        # Now the rollback is stable; the tombstone can be written safely on the next reconciliation.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(55))
+        session_evict2 = self.conn.open_session()
+        session_evict2.begin_transaction('ignore_prepare=true')
+        evict_cursor2 = session_evict2.open_cursor(self.uri, None, 'debug=(release_evict)')
+        evict_cursor2.set_key(1)
+        self.assertIn(evict_cursor2.search(), [0, wiredtiger.WT_NOTFOUND])
+        evict_cursor2.reset()
+        evict_cursor2.close()
+        session_evict2.rollback_transaction()
+        session_evict2.close()
+
+        # After the tombstone is written, reads at ts=20 must still resolve via the history store.
+        self.session.begin_transaction('read_timestamp=' + self.timestamp_str(20))
+        cursor.set_key(1)
+        self.assertEqual(cursor.search(), 0)
+        self.assertEqual(cursor.get_value(), 'committed_value')
+        self.session.rollback_transaction()
+
+        cursor.close()


### PR DESCRIPTION
## Summary

With `preserve_prepared=true` and `precise_checkpoint=true`, when a prepared transaction is rolled back before its prepare timestamp is stable, eviction can incorrectly write the rollback tombstone to disk and mark it as already on disk. This poisons subsequent reconciliations: when the prepare timestamp later becomes stable, the second reconciliation re-selects the tombstone instead of writing the preserved prepared cell.

**Root cause:** the skip block in `__rec_upd_select` skips the aborted prepare (because its rollback is not yet stable) but does not clear `prepare_rollback_tombstone`. The post-loop fallback then selects the tombstone and marks it as written to disk. In a later reconciliation the tombstone's on-disk flag bypasses the skip block and suppresses the `prepare_rollback_tombstone` mechanism, so the preserved prepared cell is never written.

**Fix:** clear `prepare_rollback_tombstone` inside the skip block so the tombstone is not selected before the rollback decision is stable. The page stays dirty and is revisited in a later reconciliation once the rollback timestamp becomes stable.

**Test:** `test_prepare46.py` reproduces the scenario end-to-end: eviction at a stable timestamp below the prepare timestamp, followed by a checkpoint once the prepare timestamp becomes stable, asserting the preserved prepared cell is written at the second checkpoint and not before.