### PR TITLE
WT-17385 WT_DISAGG_FAST_TRUNCATE_BUILD macro definition is misleading

### DIFF
--- a/cmake/configs/wiredtiger_config.h.in
+++ b/cmake/configs/wiredtiger_config.h.in
@@ -173,7 +173,7 @@
 #cmakedefine WT_STANDALONE_BUILD 1
 
 /* Define to 1 to build disaggregate fast truncate POC. */
-#cmakedefine WT_DISAGG_FAST_TRUNCATE_BUILD 0
+#cmakedefine WT_DISAGG_FAST_TRUNCATE_BUILD 1
 
 #ifndef _DARWIN_USE_64_BIT_INODE
 # define _DARWIN_USE_64_BIT_INODE 1


### PR DESCRIPTION
- The default value of `WT_DISAGG_FAST_TRUNCATE_BUILD` macro is 0. It is misleading because it looks as if it's disabled by default. However, `#cmakedefine` works differently:
  - CMake sees WT_DISAGG_FAST_TRUNCATE_BUILD=ON , then `#cmakedefine` will define a macro (optionally with provided value).
  - Otherwise, the macro stays undefined. The code is actually commented out.
 
Subsequent checks in code only check whether `WT_DISAGG_FAST_TRUNCATE_BUILD` is defined or not, and ignore the value.