### PR TITLE
WT-17387 Fix incorrect early-return and tombstone visibility in reconciliation when writing prepared updates

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1153,6 +1153,7 @@ intr
 intrinsics
 ints
 inuse
+invariants
 io
 ip
 isalnum

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -92,9 +92,9 @@ __rec_append_orig_value(WT_SESSION_IMPL *session, WT_PAGE *page, WT_UPDATE *upd,
     WT_CONNECTION_IMPL *conn;
     WT_DECL_ITEM(tmp);
     WT_DECL_RET;
-    WT_UPDATE *append, *oldest_upd, *tombstone;
+    WT_UPDATE *append, *oldest_upd, *onpage_upd_or_tombstone, *tombstone;
     size_t size, total_size;
-    bool seen_resolved, tombstone_globally_visible;
+    bool seen_committed, tombstone_globally_visible;
 
     conn = S2C(session);
 
@@ -103,9 +103,9 @@ __rec_append_orig_value(WT_SESSION_IMPL *session, WT_PAGE *page, WT_UPDATE *upd,
       "__rec_append_orig_value requires an onpage, non-prepared update");
 
     append = tombstone = NULL;
-    oldest_upd = upd;
+    oldest_upd = onpage_upd_or_tombstone = upd;
     size = total_size = 0;
-    seen_resolved = tombstone_globally_visible = false;
+    seen_committed = tombstone_globally_visible = false;
 
     /* Review the current update list, checking conditions that mean no work is needed. */
     for (;; upd = upd->next) {
@@ -131,8 +131,18 @@ __rec_append_orig_value(WT_SESSION_IMPL *session, WT_PAGE *page, WT_UPDATE *upd,
          * levels, or when an application intentionally commits in out of timestamp order, it's
          * possible for an update on the chain to be globally visible and followed by an (earlier)
          * update that is not yet globally visible.
+         *
+         * Skip this shortcut when writing as prepared. The decision to write as prepared was taken
+         * against the pinned stable timestamp captured at reconcile start, which can lag the
+         * current global oldest. By the time we reach here, the chain may have become globally
+         * visible even though we still need to encode this entry as prepared. In that case we must
+         * not return early; the caller relies on the on-page value being available as a rollback
+         * fallback for the prepared update.
          */
-        if (WT_UPDATE_DATA_VALUE(upd) && __wt_txn_upd_visible_all(session, upd))
+        if (WT_UPDATE_DATA_VALUE(upd) &&
+          (onpage_upd_or_tombstone != upd || onpage_upd_or_tombstone->type != WT_UPDATE_TOMBSTONE ||
+            !write_prepared) &&
+          __wt_txn_upd_visible_all(session, upd))
             return (0);
 
         oldest_upd = upd;
@@ -142,8 +152,8 @@ __rec_append_orig_value(WT_SESSION_IMPL *session, WT_PAGE *page, WT_UPDATE *upd,
          */
         uint8_t prepare_state;
         WT_READ_ONCE(prepare_state, upd->prepare_state);
-        seen_resolved =
-          prepare_state != WT_PREPARE_INPROGRESS && prepare_state != WT_PREPARE_LOCKED;
+        if (prepare_state != WT_PREPARE_INPROGRESS && prepare_state != WT_PREPARE_LOCKED)
+            seen_committed = true;
 
         /* Leave reference pointing to the last item in the update list. */
         if (upd->next == NULL)
@@ -179,7 +189,7 @@ __rec_append_orig_value(WT_SESSION_IMPL *session, WT_PAGE *page, WT_UPDATE *upd,
                  * wrongly leave this key as prepared indefinitely if we rollback the prepared
                  * update.
                  */
-                if (seen_resolved || !write_prepared)
+                if (seen_committed || !write_prepared)
                     return (0);
             }
 
@@ -1297,8 +1307,17 @@ __rec_fill_tw_from_upd_select(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_U
          * move the updates from this btree to the history store, it is essential to identify the
          * update that the tombstone deletes. Failing to do so could lead to missed deletions of
          * related updates in the history store, potentially causing data inconsistencies.
+         *
+         * Force the tombstone to be treated as not globally visible when we are writing it as
+         * prepared. The decision to write as prepared was taken against the pinned stable timestamp
+         * captured at reconcile start, which can lag the current global oldest. If the tombstone
+         * has since become visible to all readers, the globally-visible branch below would skip
+         * selecting the value behind the tombstone, leaving the on-page value unset while the time
+         * window still carries a prepared stop. That combination breaks downstream invariants when
+         * the page is restored. Taking the not-globally-visible path ensures we walk past the
+         * tombstone and select the underlying value as the rollback fallback for the prepared cell.
          */
-        tombstone_globally_visible = __wt_txn_upd_visible_all(session, upd);
+        tombstone_globally_visible = !write_prepare && __wt_txn_upd_visible_all(session, upd);
         if (write_prepare || (F_ISSET(r, WT_REC_HS) && upd->upd_start_ts == WT_TS_NONE) ||
           !tombstone_globally_visible) {
             uint64_t next_txnid = WT_TXN_NONE;


### PR DESCRIPTION
## Summary

The `write_prepared`/`write_prepare` flag is set against the pinned stable timestamp captured at reconcile start, which can lag the current global pinned oldest timestamp. By the time visibility checks run later in reconciliation the update chain may have already become globally visible, causing two bugs in `src/reconcile/rec_visibility.c`:

- **`__rec_append_orig_value`**: The globally-visible early-return shortcut was incorrectly firing for on-page tombstones being written as prepared. The caller relies on the on-page value as a rollback fallback for the prepared update; skipping it leaves the prepared cell with no valid rollback target.
- **`__rec_fill_tw_from_upd_select`**: `tombstone_globally_visible` was set to `true` even when `write_prepare=true`. The globally-visible branch then skipped selecting the value behind the tombstone, leaving the on-page value unset while the time window still carried a prepared stop — breaking downstream invariants on page restore.

## Changes

- **`__rec_append_orig_value`**: Skip the globally-visible early-return when `write_prepared=true` and the candidate update is the on-page tombstone. Introduces `onpage_upd_or_tombstone` to identify the first on-page update.
- **`__rec_fill_tw_from_upd_select`**: Force `tombstone_globally_visible = false` when `write_prepare=true`, so the not-globally-visible path always selects the underlying value as the rollback fallback.
- Rename `seen_resolved` → `seen_committed` and fix its accumulation pattern (was overwriting with the last update's state rather than setting-to-true-and-keeping).
- Add `"invariants"` to `dist/s_string.ok` (spell-check allowlist) for the new comments.