### PR TITLE
WT-17388 Replace WT_ACQUIRE_BARRIER with explicit atomic loads in WT_TIME_WINDOW_SET_START/STOP macros

### DIFF
--- a/src/include/timestamp_inline.h
+++ b/src/include/timestamp_inline.h
@@ -73,20 +73,19 @@
  * prepared rollback. If we read an aborted transaction id in the first attempt, get the transaction
  * id from the saved transaction id.
  */
-#define WT_TIME_WINDOW_SET_START(tw, upd, write_prepare)    \
-    do {                                                    \
-        (tw)->start_txn = (upd)->txnid;                     \
-        if (write_prepare) {                                \
-            (tw)->start_prepare_ts = (upd)->prepare_ts;     \
-            (tw)->start_prepared_id = (upd)->prepared_id;   \
-            if ((tw)->start_txn == WT_TXN_ABORTED) {        \
-                WT_ACQUIRE_BARRIER();                       \
-                (tw)->start_txn = (upd)->upd_saved_txnid;   \
-            }                                               \
-        } else {                                            \
-            (tw)->start_ts = (upd)->upd_start_ts;           \
-            (tw)->durable_start_ts = (upd)->upd_durable_ts; \
-        }                                                   \
+#define WT_TIME_WINDOW_SET_START(tw, upd, write_prepare)                                    \
+    do {                                                                                    \
+        if (write_prepare) {                                                                \
+            (tw)->start_txn = __wt_atomic_load_uint64_v_acquire(&(upd)->txnid);             \
+            (tw)->start_prepare_ts = (upd)->prepare_ts;                                     \
+            (tw)->start_prepared_id = (upd)->prepared_id;                                   \
+            if ((tw)->start_txn == WT_TXN_ABORTED)                                          \
+                (tw)->start_txn = __wt_atomic_load_uint64_relaxed(&(upd)->upd_saved_txnid); \
+        } else {                                                                            \
+            (tw)->start_txn = __wt_atomic_load_uint64_v_relaxed(&(upd)->txnid);             \
+            (tw)->start_ts = (upd)->upd_start_ts;                                           \
+            (tw)->durable_start_ts = (upd)->upd_durable_ts;                                 \
+        }                                                                                   \
     } while (0)
 
 /*
@@ -94,20 +93,19 @@
  * rollback. If we read an aborted transaction id in the first attempt, get the transaction id from
  * the saved transaction id.
  */
-#define WT_TIME_WINDOW_SET_STOP(tw, upd, write_prepare)    \
-    do {                                                   \
-        (tw)->stop_txn = (upd)->txnid;                     \
-        if (write_prepare) {                               \
-            (tw)->stop_prepare_ts = (upd)->prepare_ts;     \
-            (tw)->stop_prepared_id = (upd)->prepared_id;   \
-            if ((tw)->stop_txn == WT_TXN_ABORTED) {        \
-                WT_ACQUIRE_BARRIER();                      \
-                (tw)->stop_txn = (upd)->upd_saved_txnid;   \
-            }                                              \
-        } else {                                           \
-            (tw)->stop_ts = (upd)->upd_start_ts;           \
-            (tw)->durable_stop_ts = (upd)->upd_durable_ts; \
-        }                                                  \
+#define WT_TIME_WINDOW_SET_STOP(tw, upd, write_prepare)                                    \
+    do {                                                                                   \
+        if (write_prepare) {                                                               \
+            (tw)->stop_txn = __wt_atomic_load_uint64_v_acquire(&(upd)->txnid);             \
+            (tw)->stop_prepare_ts = (upd)->prepare_ts;                                     \
+            (tw)->stop_prepared_id = (upd)->prepared_id;                                   \
+            if ((tw)->stop_txn == WT_TXN_ABORTED)                                          \
+                (tw)->stop_txn = __wt_atomic_load_uint64_relaxed(&(upd)->upd_saved_txnid); \
+        } else {                                                                           \
+            (tw)->stop_txn = __wt_atomic_load_uint64_v_relaxed(&(upd)->txnid);             \
+            (tw)->stop_ts = (upd)->upd_start_ts;                                           \
+            (tw)->durable_stop_ts = (upd)->upd_durable_ts;                                 \
+        }                                                                                  \
     } while (0)
 
 /* Copy the start values of a time window from another time window. */


### PR DESCRIPTION
## Summary
- `WT_TIME_WINDOW_SET_START` and `WT_TIME_WINDOW_SET_STOP` macros previously read `txnid` unconditionally before the `write_prepare` branch, then applied a `WT_ACQUIRE_BARRIER()` only in the aborted-transaction fallback path.
- This moves the `txnid` read inside the branch so each code path uses the appropriate atomic load: `__wt_atomic_load_uint64_v_acquire` for the prepare path (requires acquire semantics) and `__wt_atomic_load_uint64_v_relaxed` for the non-prepare path.
- The aborted-txn fallback now uses `__wt_atomic_load_uint64_relaxed` for `upd_saved_txnid` in place of a plain read after a barrier.
- Removes ad-hoc `WT_ACQUIRE_BARRIER()` calls and makes memory ordering intent explicit.