### PR TITLE
WT-13434 Skip read_timestamp when timestamps not yet initialised in cppsuite

### DIFF
--- a/test/cppsuite/tests/bounded_cursor_prefix_search_near.cpp
+++ b/test/cppsuite/tests/bounded_cursor_prefix_search_near.cpp
@@ -177,9 +177,9 @@ public:
             wt_timestamp_t ts = tc->tsm->get_valid_read_ts();
             /*
              * The oldest timestamp might move ahead and the reading timestamp might become invalid.
-             * To tackle this issue, we round the timestamp to the oldest timestamp value.
-             * Skip read_timestamp entirely when timestamps haven't been initialized yet (both
-             * oldest and stable are WT_TS_NONE), as WiredTiger rejects read_timestamp=0.
+             * To tackle this issue, we round the timestamp to the oldest timestamp value. Skip
+             * read_timestamp entirely when timestamps haven't been initialized yet (both oldest and
+             * stable are WT_TS_NONE), as WiredTiger rejects read_timestamp=0.
              */
             tc->begin("roundup_timestamps=(read=true)" +
               (ts != WT_TS_NONE ? ",read_timestamp=" + tc->tsm->decimal_to_hex(ts) : ""));

--- a/test/cppsuite/tests/bounded_cursor_prefix_search_near.cpp
+++ b/test/cppsuite/tests/bounded_cursor_prefix_search_near.cpp
@@ -178,9 +178,11 @@ public:
             /*
              * The oldest timestamp might move ahead and the reading timestamp might become invalid.
              * To tackle this issue, we round the timestamp to the oldest timestamp value.
+             * Skip read_timestamp entirely when timestamps haven't been initialised yet (both
+             * oldest and stable are WT_TS_NONE), as WiredTiger rejects read_timestamp=0.
              */
-            tc->begin(
-              "roundup_timestamps=(read=true),read_timestamp=" + tc->tsm->decimal_to_hex(ts));
+            tc->begin("roundup_timestamps=(read=true)" +
+              (ts != WT_TS_NONE ? ",read_timestamp=" + tc->tsm->decimal_to_hex(ts) : ""));
 
             while (tc->active() && tc->running()) {
                 /*

--- a/test/cppsuite/tests/bounded_cursor_prefix_search_near.cpp
+++ b/test/cppsuite/tests/bounded_cursor_prefix_search_near.cpp
@@ -178,7 +178,7 @@ public:
             /*
              * The oldest timestamp might move ahead and the reading timestamp might become invalid.
              * To tackle this issue, we round the timestamp to the oldest timestamp value.
-             * Skip read_timestamp entirely when timestamps haven't been initialised yet (both
+             * Skip read_timestamp entirely when timestamps haven't been initialized yet (both
              * oldest and stable are WT_TS_NONE), as WiredTiger rejects read_timestamp=0.
              */
             tc->begin("roundup_timestamps=(read=true)" +

--- a/test/cppsuite/tests/bounded_cursor_stress.cpp
+++ b/test/cppsuite/tests/bounded_cursor_stress.cpp
@@ -509,11 +509,9 @@ public:
             wt_timestamp_t ts = tc->tsm->get_valid_read_ts();
             /*
              * The oldest timestamp might move ahead and the reading timestamp might become invalid.
-             * To tackle this issue, we round the timestamp to the oldest timestamp value.
-             */
-            /*
-             * Skip read_timestamp entirely when timestamps haven't been initialised yet (both
-             * oldest and stable are WT_TS_NONE), as WiredTiger rejects read_timestamp=0.
+             * To tackle this issue, we round the timestamp to the oldest timestamp value. Skip
+             * read_timestamp entirely when timestamps haven't been initialised yet (both oldest and
+             * stable are WT_TS_NONE), as WiredTiger rejects read_timestamp=0.
              */
             tc->try_begin("roundup_timestamps=(read=true)" +
               (ts != WT_TS_NONE ? ",read_timestamp=" + tc->tsm->decimal_to_hex(ts) : ""));

--- a/test/cppsuite/tests/bounded_cursor_stress.cpp
+++ b/test/cppsuite/tests/bounded_cursor_stress.cpp
@@ -510,7 +510,7 @@ public:
             /*
              * The oldest timestamp might move ahead and the reading timestamp might become invalid.
              * To tackle this issue, we round the timestamp to the oldest timestamp value. Skip
-             * read_timestamp entirely when timestamps haven't been initialised yet (both oldest and
+             * read_timestamp entirely when timestamps haven't been initialized yet (both oldest and
              * stable are WT_TS_NONE), as WiredTiger rejects read_timestamp=0.
              */
             tc->try_begin("roundup_timestamps=(read=true)" +
@@ -746,7 +746,7 @@ public:
             /*
              * The oldest timestamp might move ahead and the reading timestamp might become invalid.
              * To tackle this issue, we round the timestamp to the oldest timestamp value.
-             * Skip read_timestamp entirely when timestamps haven't been initialised yet (both
+             * Skip read_timestamp entirely when timestamps haven't been initialized yet (both
              * oldest and stable are WT_TS_NONE), as WiredTiger rejects read_timestamp=0.
              */
             tc->begin("roundup_timestamps=(read=true)" +

--- a/test/cppsuite/tests/bounded_cursor_stress.cpp
+++ b/test/cppsuite/tests/bounded_cursor_stress.cpp
@@ -511,8 +511,12 @@ public:
              * The oldest timestamp might move ahead and the reading timestamp might become invalid.
              * To tackle this issue, we round the timestamp to the oldest timestamp value.
              */
-            tc->try_begin(
-              "roundup_timestamps=(read=true),read_timestamp=" + tc->tsm->decimal_to_hex(ts));
+            /*
+             * Skip read_timestamp entirely when timestamps haven't been initialised yet (both
+             * oldest and stable are WT_TS_NONE), as WiredTiger rejects read_timestamp=0.
+             */
+            tc->try_begin("roundup_timestamps=(read=true)" +
+              (ts != WT_TS_NONE ? ",read_timestamp=" + tc->tsm->decimal_to_hex(ts) : ""));
             while (tc->active() && tc->running()) {
                 /* Generate a random string. */
                 auto key_size = random_generator::instance().generate_integer(
@@ -744,9 +748,11 @@ public:
             /*
              * The oldest timestamp might move ahead and the reading timestamp might become invalid.
              * To tackle this issue, we round the timestamp to the oldest timestamp value.
+             * Skip read_timestamp entirely when timestamps haven't been initialised yet (both
+             * oldest and stable are WT_TS_NONE), as WiredTiger rejects read_timestamp=0.
              */
-            tc->begin(
-              "roundup_timestamps=(read=true),read_timestamp=" + tc->tsm->decimal_to_hex(ts));
+            tc->begin("roundup_timestamps=(read=true)" +
+              (ts != WT_TS_NONE ? ",read_timestamp=" + tc->tsm->decimal_to_hex(ts) : ""));
             while (tc->active() && tc->running()) {
                 int ret = cursor_traversal(bounded_cursor, normal_cursor, bound_pair.get_lower(),
                   bound_pair.get_upper(), true);

--- a/test/cppsuite/tests/bounded_cursor_stress.cpp
+++ b/test/cppsuite/tests/bounded_cursor_stress.cpp
@@ -745,9 +745,9 @@ public:
             wt_timestamp_t ts = tc->tsm->get_valid_read_ts();
             /*
              * The oldest timestamp might move ahead and the reading timestamp might become invalid.
-             * To tackle this issue, we round the timestamp to the oldest timestamp value.
-             * Skip read_timestamp entirely when timestamps haven't been initialized yet (both
-             * oldest and stable are WT_TS_NONE), as WiredTiger rejects read_timestamp=0.
+             * To tackle this issue, we round the timestamp to the oldest timestamp value. Skip
+             * read_timestamp entirely when timestamps haven't been initialized yet (both oldest and
+             * stable are WT_TS_NONE), as WiredTiger rejects read_timestamp=0.
              */
             tc->begin("roundup_timestamps=(read=true)" +
               (ts != WT_TS_NONE ? ",read_timestamp=" + tc->tsm->decimal_to_hex(ts) : ""));


### PR DESCRIPTION
## Summary
- `get_valid_read_ts()` returns `WT_TS_NONE` (0) when the timestamp manager hasn't advanced past its first tick (both `oldest_ts` and `stable_ts` are still 0 at test startup).
- Passing `read_timestamp=0` to `begin_transaction` is rejected by WiredTiger with `EINVAL: illegal read timestamp '0': zero not permitted`, crashing the test process.
- Fix the three affected call sites in `bounded_cursor_prefix_search_near` and `bounded_cursor_stress` to omit `read_timestamp` from the config string when `get_valid_read_ts()` returns `WT_TS_NONE`.

## Testing
Verified with a targeted reproducer that injects a 3-second stall on the timestamp manager's first tick, guaranteeing read threads call `get_valid_read_ts()` before any timestamp is set:
- **Before fix**: `bounded_cursor_prefix_search_near` crashes immediately with `EINVAL` (exit 134).
- **After fix**: same test runs cleanly to completion (exit 0).

Both `bounded_cursor_stress` call sites follow the identical pattern and were fixed in the same pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)