### PR TITLE
WT-13290 Handle fast truncated pages during RTS for VLCS (8.0)

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1181,6 +1181,7 @@ recurse
 reentrant
 refp
 regionp
+reinstantiated
 relocked
 repl
 repositioned

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -70,11 +70,14 @@ static int
 __rec_append_orig_value(
   WT_SESSION_IMPL *session, WT_PAGE *page, WT_UPDATE *upd, WT_CELL_UNPACK_KV *unpack)
 {
+    WT_CONNECTION_IMPL *conn;
     WT_DECL_ITEM(tmp);
     WT_DECL_RET;
     WT_UPDATE *append, *oldest_upd, *tombstone;
     size_t size, total_size;
     bool tombstone_globally_visible;
+
+    conn = S2C(session);
 
     WT_ASSERT_ALWAYS(session,
       upd != NULL && unpack != NULL && unpack->type != WT_CELL_DEL && !unpack->tw.prepare,
@@ -105,7 +108,7 @@ __rec_append_orig_value(
          * its transaction id to WT_TXN_NONE and its timestamps to WT_TS_NONE when we write the
          * update to the time window.
          */
-        if (F_ISSET(S2C(session), WT_CONN_IN_MEMORY) && unpack->tw.start_ts == upd->start_ts &&
+        if (F_ISSET(conn, WT_CONN_IN_MEMORY) && unpack->tw.start_ts == upd->start_ts &&
           unpack->tw.start_txn == upd->txnid && upd->type != WT_UPDATE_TOMBSTONE)
             return (0);
 
@@ -160,7 +163,15 @@ __rec_append_orig_value(
 
             WT_ERR(__wt_upd_alloc_tombstone(session, &tombstone, &size));
             total_size += size;
-            tombstone->txnid = unpack->tw.stop_txn;
+            /*
+             * When reconciling during recovery, we need to clear the transaction id as we haven't
+             * done so when we read the page into memory to avoid using the transaction id from the
+             * previous run.
+             */
+            if (F_ISSET(conn, WT_CONN_RECOVERING))
+                tombstone->txnid = WT_TXN_NONE;
+            else
+                tombstone->txnid = unpack->tw.stop_txn;
             tombstone->start_ts = unpack->tw.stop_ts;
             tombstone->durable_ts = unpack->tw.durable_stop_ts;
             F_SET(tombstone, WT_UPDATE_RESTORED_FROM_DS);
@@ -190,7 +201,15 @@ __rec_append_orig_value(
           unpack->cell == NULL || __wt_cell_type_raw(unpack->cell) != WT_CELL_VALUE_OVFL_RM);
         WT_ERR(__wt_upd_alloc(session, tmp, WT_UPDATE_STANDARD, &append, &size));
         total_size += size;
-        append->txnid = unpack->tw.start_txn;
+        /*
+         * When reconciling during recovery, we need to clear the transaction id as we haven't done
+         * so when we read the page into memory to avoid using the transaction id from the previous
+         * run.
+         */
+        if (F_ISSET(conn, WT_CONN_RECOVERING))
+            append->txnid = WT_TXN_NONE;
+        else
+            append->txnid = unpack->tw.start_txn;
         append->start_ts = unpack->tw.start_ts;
         append->durable_ts = unpack->tw.durable_start_ts;
         F_SET(append, WT_UPDATE_RESTORED_FROM_DS);
@@ -832,7 +851,8 @@ __rec_fill_tw_from_upd_select(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_U
          */
         if (last_upd->next != NULL) {
             WT_ASSERT_ALWAYS(session,
-              last_upd->next->txnid == vpack->tw.start_txn &&
+              last_upd->next->txnid ==
+                  (F_ISSET(S2C(session), WT_CONN_RECOVERING) ? WT_TXN_NONE : vpack->tw.start_txn) &&
                 last_upd->next->start_ts == vpack->tw.start_ts &&
                 last_upd->next->type == WT_UPDATE_STANDARD && last_upd->next->next == NULL,
               "Tombstone is globally visible, but the tombstoned update is on the update "

--- a/src/rollback_to_stable/rts_btree.c
+++ b/src/rollback_to_stable/rts_btree.c
@@ -85,16 +85,17 @@ __rts_btree_abort_update(WT_SESSION_IMPL *session, WT_ITEM *key, WT_UPDATE *firs
     if (stable_upd != NULL) {
         /*
          * During recovery, there shouldn't be any updates in the update chain except when the
-         * updates are from a prepared transaction. Reset the transaction ID of the stable update
-         * that was restored as part of the unstable prepared tombstone. Ignore the history store as
-         * we cannot have a prepared transaction operating on it.
+         * updates are from a prepared transaction or from a reinstantiated fast deleted page. Reset
+         * the transaction ID of the stable update that was restored. Ignore the history store as we
+         * cannot have a prepared transaction on it and a fast deleted page in the history store
+         * should never be reinstantiated as it is globally visible.
          */
         if (F_ISSET(S2C(session), WT_CONN_RECOVERING) && !WT_IS_HS(session->dhandle)) {
             WT_ASSERT(session, first_upd->type == WT_UPDATE_TOMBSTONE);
-            WT_ASSERT(session, first_upd->prepare_state == WT_PREPARE_INPROGRESS);
-            WT_ASSERT(session, F_ISSET(first_upd, WT_UPDATE_PREPARE_RESTORED_FROM_DS));
+            WT_ASSERT(session,
+              F_ISSET(
+                first_upd, WT_UPDATE_PREPARE_RESTORED_FROM_DS | WT_UPDATE_RESTORED_FAST_TRUNCATE));
             WT_ASSERT(session, stable_upd->next == NULL);
-            WT_ASSERT(session, F_ISSET(upd, WT_UPDATE_RESTORED_FROM_DS));
             stable_upd->txnid = WT_TXN_NONE;
         }
 

--- a/test/suite/test_truncate27.py
+++ b/test/suite/test_truncate27.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wttest
+from helper import simulate_crash_restart
+from wiredtiger import stat
+
+# test_truncate27.py
+# Test that unstable updates preceding a stable fast truncate operation are restored with the correct
+# transaction IDs.
+class test_truncate27(wttest.WiredTigerTestCase):
+
+    def evict_cursor(self, uri, nrows):
+        # Configure debug behavior on a cursor to evict the page positioned on when the reset API is used.
+        evict_cursor = self.session.open_cursor(uri, None, "debug=(release_evict)")
+        self.session.begin_transaction("ignore_prepare=true")
+        for i in range(1, nrows + 1):
+            evict_cursor.set_key(i)
+            if i % 10 == 0:
+                evict_cursor.reset()
+        evict_cursor.close()
+        self.session.rollback_transaction()
+
+    def get_fast_truncated_pages(self):
+        stat_cursor = self.session.open_cursor('statistics:', None, None)
+        pages = stat_cursor[stat.conn.rec_page_delete_fast][2]
+        stat_cursor.close()
+        return pages
+
+    def test_truncate27(self):
+        nrows = 100000
+        uri = 'table:test_truncate27'
+        self.session.create(uri, 'key_format=r,value_format=S')
+
+        value = 'a' * 5
+
+        # Pin oldest timestamp.
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
+
+        cursor = self.session.open_cursor(uri)
+        for i in range(1, nrows + 1):
+            # Insert some data.
+            self.session.begin_transaction()
+            cursor[i] = value
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(i))
+        cursor.close()
+
+        # Update stable timestamp and checkpoint.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(nrows))
+        self.session.checkpoint()
+
+        # Evict everything.
+        self.evict_cursor(uri, nrows)
+        self.session.checkpoint()
+
+        # Do a fast truncate.
+        ts = nrows + 1
+        truncate_session = self.conn.open_session()
+        truncate_session.begin_transaction()
+        cursor_start = truncate_session.open_cursor(uri)
+        cursor_start.set_key(nrows // 2)
+        truncate_session.truncate(None, cursor_start, None, None)
+        truncate_session.commit_transaction('commit_timestamp=' + self.timestamp_str(ts))
+        fast_truncates_pages = self.get_fast_truncated_pages()
+        self.assertGreater(fast_truncates_pages, 0)
+        cursor_start.close()
+
+        # Make the fast truncate stable.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(ts + 1))
+
+        # Insert unstable data.
+        self.session.begin_transaction()
+        cursor = self.session.open_cursor(uri)
+        cursor[100] = value
+        cursor.close()
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(ts + 2))
+
+        self.session.checkpoint()
+
+        simulate_crash_restart(self, ".", "RESTART")


### PR DESCRIPTION

Cherrypick from 7ab835732d.

During reconciliation recovery, clear the transaction ID when restoring updates to the update chain to avoid using stale transaction IDs from the previous run. Also relaxes the RTS recovery assertion to allow both prepared-transaction and fast-truncate reinstantiated updates.