### PR TITLE
WT-17357 update test format to honor the rules of rollback timestamp for prepared transactions

### DIFF
--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -684,9 +684,15 @@ prepare_transaction(TINFO *tinfo)
     ++tinfo->prepare;
 
     prepared_id = __wt_atomic_add_uint64_v(&g.prepared_id, 1);
-    if (GV(RUNS_PREDICTABLE_REPLAY))
+    if (GV(RUNS_PREDICTABLE_REPLAY)) {
         ts = replay_prepare_ts(tinfo);
-    else
+        /*
+         * WT_TS_NONE signals that there is no valid prepare timestamp for this transaction
+         * (e.g., the lane's last commit is too close to the current replay_ts). Skip prepare.
+         */
+        if (ts == WT_TS_NONE)
+            return (ENOTSUP);
+    } else
         /*
          * Prepare timestamps must be less than or equal to the eventual commit timestamp but larger
          * than the current stable timestamp. Increase the global value to ensure it is larger than
@@ -1400,11 +1406,14 @@ skip_operation:
          * timestamped world, which means we're in a snapshot-isolation transaction by definition.
          */
         if (GV(OPS_PREPARE) && mmrand(&tinfo->data_rnd, 1, 10) == 1) {
-            if ((ret = prepare_transaction(tinfo)) != 0) {
-                testutil_assert(ret == WT_ROLLBACK);
+            ret = prepare_transaction(tinfo);
+            if (ret == WT_ROLLBACK)
                 goto rollback;
+            else if (ret != ENOTSUP) {
+                testutil_assert(ret == 0);
+                prepared = true;
             }
-            prepared = true;
+            /* ENOTSUP: prepare was skipped (no valid timestamp), treat as unprepared. */
         }
 
         /*

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -687,8 +687,8 @@ prepare_transaction(TINFO *tinfo)
     if (GV(RUNS_PREDICTABLE_REPLAY)) {
         ts = replay_prepare_ts(tinfo);
         /*
-         * WT_TS_NONE signals that there is no valid prepare timestamp for this transaction
-         * (e.g., the lane's last commit is too close to the current replay_ts). Skip prepare.
+         * WT_TS_NONE signals that there is no valid prepare timestamp for this transaction (e.g.,
+         * the lane's last commit is too close to the current replay_ts). Skip prepare.
          */
         if (ts == WT_TS_NONE)
             return (ENOTSUP);

--- a/test/format/replay.c
+++ b/test/format/replay.c
@@ -383,9 +383,14 @@ replay_prepare_ts(TINFO *tinfo)
      * A prepare timestamp must be strictly greater than all active read timestamps.
      * replay_maximum_committed() is bounded from below by last_commit_ts for in-use lanes, so
      * prepare_ts must be > last_commit_ts. We also need prepare_ts < commit_ts (replay_ts) to
-     * satisfy the durable > prepare invariant. If there is no integer in that range (replay_ts ==
-     * last_commit_ts + 1), return WT_TS_NONE to signal that prepare must be skipped for this
-     * transaction.
+     * satisfy the durable > prepare invariant. If replay_ts is only 1 more than last_commit_ts,
+     * then we can only choose one timestamp for both prepare and commit/rollback, which violates
+     * the durable > prepare invariant. If replay_ts is not more than last_commit_ts, then we cannot
+     * even prepare this transaction. So in either of those cases, we return WT_TS_NONE to signal
+     * that we should skip preparing this transaction. The transaction will still be committed with
+     * replay_ts as its commit timestamp, but it won't be a prepared transaction. This is a safe
+     * fallback that allows the run to continue with some prepared transactions, rather than failing
+     * or having no prepared transactions at all.
      */
     if (tinfo->replay_ts <= last_commit_ts + 1)
         return (WT_TS_NONE);

--- a/test/format/replay.c
+++ b/test/format/replay.c
@@ -381,19 +381,19 @@ replay_prepare_ts(TINFO *tinfo)
 
     /*
      * A prepare timestamp must be strictly greater than all active read timestamps.
-     * replay_maximum_committed() is bounded from below by last_commit_ts for in-use lanes,
-     * so prepare_ts must be > last_commit_ts. We also need prepare_ts < commit_ts (replay_ts)
-     * to satisfy the durable > prepare invariant. If there is no integer in that range
-     * (replay_ts == last_commit_ts + 1), return WT_TS_NONE to signal that prepare must be
-     * skipped for this transaction.
+     * replay_maximum_committed() is bounded from below by last_commit_ts for in-use lanes, so
+     * prepare_ts must be > last_commit_ts. We also need prepare_ts < commit_ts (replay_ts) to
+     * satisfy the durable > prepare invariant. If there is no integer in that range (replay_ts ==
+     * last_commit_ts + 1), return WT_TS_NONE to signal that prepare must be skipped for this
+     * transaction.
      */
     if (tinfo->replay_ts <= last_commit_ts + 1)
         return (WT_TS_NONE);
 
     /*
-     * See if we're just starting a run (first LANE_COUNT timestamps after run-start).
-     * Use replay_ts - 1: since replay_ts > last_commit_ts + 1, replay_ts - 1 > last_commit_ts,
-     * and replay_ts - 1 < replay_ts (the commit timestamp).
+     * See if we're just starting a run (first LANE_COUNT timestamps after run-start). Use replay_ts
+     * - 1: since replay_ts > last_commit_ts + 1, replay_ts - 1 > last_commit_ts, and replay_ts - 1
+     * < replay_ts (the commit timestamp).
      */
     if (tinfo->replay_ts == WT_TS_NONE || tinfo->replay_ts <= g.replay_start_timestamp + LANE_COUNT)
         prepare_ts = tinfo->replay_ts - 1;

--- a/test/format/replay.c
+++ b/test/format/replay.c
@@ -301,9 +301,13 @@ replay_run_reset(void)
     uint64_t ts;
     uint32_t lane;
 
-    /* Set every lane's commit timestamp to the current timestamp. */
+    /*
+     * Record the run-start timestamp so the early-run guard in replay_prepare_ts fires correctly
+     * for the first LANE_COUNT timestamps of this run.
+     */
     ts = g.timestamp;
     g.timestamp_copy = ts;
+    g.replay_start_timestamp = ts;
     for (lane = 0; lane < LANE_COUNT; ++lane)
         g.lanes[lane].last_commit_ts = ts;
     g.replay_cached_committed = ts;
@@ -369,17 +373,30 @@ replay_read_ts(TINFO *tinfo)
 wt_timestamp_t
 replay_prepare_ts(TINFO *tinfo)
 {
-    wt_timestamp_t prepare_ts, ts;
+    wt_timestamp_t last_commit_ts, prepare_ts, ts;
 
     testutil_assert(GV(RUNS_PREDICTABLE_REPLAY));
 
-    /* See if we're just starting a run. */
+    last_commit_ts = g.lanes[tinfo->lane].last_commit_ts;
+
+    /*
+     * A prepare timestamp must be strictly greater than all active read timestamps.
+     * replay_maximum_committed() is bounded from below by last_commit_ts for in-use lanes,
+     * so prepare_ts must be > last_commit_ts. We also need prepare_ts < commit_ts (replay_ts)
+     * to satisfy the durable > prepare invariant. If there is no integer in that range
+     * (replay_ts == last_commit_ts + 1), return WT_TS_NONE to signal that prepare must be
+     * skipped for this transaction.
+     */
+    if (tinfo->replay_ts <= last_commit_ts + 1)
+        return (WT_TS_NONE);
+
+    /*
+     * See if we're just starting a run (first LANE_COUNT timestamps after run-start).
+     * Use replay_ts - 1: since replay_ts > last_commit_ts + 1, replay_ts - 1 > last_commit_ts,
+     * and replay_ts - 1 < replay_ts (the commit timestamp).
+     */
     if (tinfo->replay_ts == WT_TS_NONE || tinfo->replay_ts <= g.replay_start_timestamp + LANE_COUNT)
-        /*
-         * When we're starting a run, we'll just use the final commit timestamp for our prepare
-         * timestamp. We know that's safe.
-         */
-        prepare_ts = tinfo->replay_ts;
+        prepare_ts = tinfo->replay_ts - 1;
     else {
         /*
          * Our lane's current operation will have a commit timestamp tinfo->replay_ts. Our lane's
@@ -390,11 +407,14 @@ replay_prepare_ts(TINFO *tinfo)
          */
         ts = tinfo->replay_ts - LANE_COUNT / 2;
 
-        /* As a sanity check, make sure the timestamp hasn't completely aged out. */
-        if (ts < g.oldest_timestamp)
+        /*
+         * Use the midpoint if it is valid (not aged out and above the lane's last commit).
+         * Otherwise fall back to one less than the commit timestamp.
+         */
+        if (ts >= g.oldest_timestamp && ts > last_commit_ts)
             prepare_ts = ts;
         else
-            prepare_ts = tinfo->replay_ts;
+            prepare_ts = tinfo->replay_ts - 1;
     }
     return (prepare_ts);
 }


### PR DESCRIPTION
Test format is using the same timestamp as prepare timestamp and rollback timestamp.

Guard rail added as part of WT-17208 identified the issue in test format.

This change is for test format to honor the rollback timestamp rules.
