### PR TITLE
WT-17393 Skip disagg database size verify when no checkpoint has been picked up

### DIFF
--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -304,6 +304,14 @@ __wt_verify_disagg_database_size(WT_SESSION_IMPL *session)
     uint64_t database_size, ckpt_size, total_size;
     const char *uri, *value;
 
+    /*
+     * Skip the check when no checkpoint has been picked up yet: the in-memory database size is
+     * populated only by checkpoint pickup, so a follower that opens before its first reconfigure
+     * would otherwise see database size as 0 against a non-empty local metadata.
+     */
+    if (!__wt_disagg_has_picked_up_checkpoint(session))
+        return (0);
+
     conn = S2C(session);
     cursor = NULL;
     total_size = 0;

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -3643,8 +3643,13 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler, const char *c
      * which is where disaggregated storage is initialized. The earlier metadata verify (above) does
      * not need to wait because it only verifies the local metadata file, which is not a shared
      * table and has no dependency on disagg initialization.
+     *
+     * Skip the check when no checkpoint has been picked up yet: the in-memory database size is
+     * populated only by checkpoint pickup, so a follower that opens before its first reconfigure
+     * would otherwise see database size as 0 against a non-empty local metadata.
      */
-    if (verify_meta && __wt_conn_is_disagg(session))
+    if (verify_meta && __wt_conn_is_disagg(session) &&
+      __wti_disagg_has_picked_up_checkpoint(session))
         WT_ERR(__wt_verify_disagg_database_size(session));
 
     /*

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -3643,12 +3643,8 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler, const char *c
      * which is where disaggregated storage is initialized. The earlier metadata verify (above) does
      * not need to wait because it only verifies the local metadata file, which is not a shared
      * table and has no dependency on disagg initialization.
-     *
-     * Skip the check when no checkpoint has been picked up yet: the in-memory database size is
-     * populated only by checkpoint pickup, so a follower that opens before its first reconfigure
-     * would otherwise see database size as 0 against a non-empty local metadata.
      */
-    if (verify_meta && __wti_disagg_has_picked_up_checkpoint(session))
+    if (verify_meta)
         WT_ERR(__wt_verify_disagg_database_size(session));
 
     /*

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -3648,8 +3648,7 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler, const char *c
      * populated only by checkpoint pickup, so a follower that opens before its first reconfigure
      * would otherwise see database size as 0 against a non-empty local metadata.
      */
-    if (verify_meta && __wt_conn_is_disagg(session) &&
-      __wti_disagg_has_picked_up_checkpoint(session))
+    if (verify_meta && __wti_disagg_has_picked_up_checkpoint(session))
         WT_ERR(__wt_verify_disagg_database_size(session));
 
     /*

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -1630,6 +1630,19 @@ __wt_conn_is_disagg(WT_SESSION_IMPL *session)
 }
 
 /*
+ * __wti_disagg_has_picked_up_checkpoint --
+ *     Return whether this connection has picked up a disaggregated checkpoint.
+ */
+bool
+__wti_disagg_has_picked_up_checkpoint(WT_SESSION_IMPL *session)
+{
+    WT_DISAGGREGATED_STORAGE *disagg = &S2C(session)->disaggregated_storage;
+
+    return (
+      __wt_atomic_load_uint64_acquire(&disagg->last_checkpoint_meta_lsn) != WT_DISAGG_LSN_NONE);
+}
+
+/*
  * __remove_or_fail_local_wt_file --
  *     Remove a local WiredTiger file or fail with EEXIST, depending on the configured action.
  */

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -1631,14 +1631,14 @@ __wt_conn_is_disagg(WT_SESSION_IMPL *session)
 
 /*
  * __wti_disagg_has_picked_up_checkpoint --
- *     Return whether this connection has picked up a disaggregated checkpoint.
+ *     Return whether this connection is using disaggregated storage and has picked up a checkpoint.
  */
 bool
 __wti_disagg_has_picked_up_checkpoint(WT_SESSION_IMPL *session)
 {
     WT_DISAGGREGATED_STORAGE *disagg = &S2C(session)->disaggregated_storage;
 
-    return (
+    return (__wt_conn_is_disagg(session) &&
       __wt_atomic_load_uint64_acquire(&disagg->last_checkpoint_meta_lsn) != WT_DISAGG_LSN_NONE);
 }
 

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -1630,11 +1630,11 @@ __wt_conn_is_disagg(WT_SESSION_IMPL *session)
 }
 
 /*
- * __wti_disagg_has_picked_up_checkpoint --
+ * __wt_disagg_has_picked_up_checkpoint --
  *     Return whether this connection is using disaggregated storage and has picked up a checkpoint.
  */
 bool
-__wti_disagg_has_picked_up_checkpoint(WT_SESSION_IMPL *session)
+__wt_disagg_has_picked_up_checkpoint(WT_SESSION_IMPL *session)
 {
     WT_DISAGGREGATED_STORAGE *disagg = &S2C(session)->disaggregated_storage;
 

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -51,6 +51,8 @@ extern bool __wti_cell_type_check(uint8_t cell_type, uint8_t dsk_type)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wti_delete_page_skip(WT_SESSION_IMPL *session, WT_REF *ref, bool visible_all)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern bool __wti_disagg_has_picked_up_checkpoint(WT_SESSION_IMPL *session)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wti_rts_visibility_has_stable_update(WT_UPDATE *upd)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wti_rts_visibility_page_needs_abort(WT_SESSION_IMPL *session, WT_REF *ref,

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -22,6 +22,8 @@ extern bool __wt_conn_is_disagg(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wt_counter_backoff(uint64_t v, uint64_t accuracy)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern bool __wt_disagg_has_picked_up_checkpoint(WT_SESSION_IMPL *session)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wt_fsync_background_chk(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wt_gen_active(WT_SESSION_IMPL *session, int which, uint64_t generation)
@@ -50,8 +52,6 @@ extern bool __wti_block_offset_invalid(WT_BLOCK *block, wt_off_t offset, uint32_
 extern bool __wti_cell_type_check(uint8_t cell_type, uint8_t dsk_type)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wti_delete_page_skip(WT_SESSION_IMPL *session, WT_REF *ref, bool visible_all)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern bool __wti_disagg_has_picked_up_checkpoint(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __wti_rts_visibility_has_stable_update(WT_UPDATE *upd)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/test/suite/test_layered76.py
+++ b/test/suite/test_layered76.py
@@ -181,6 +181,23 @@ class test_layered76(wttest.WiredTigerTestCase):
         # plus the sum of btree checkpoint sizes.
         self.reopen_conn(config=self.conn_config + ',verify_metadata=true')
 
+    def test_verify_db_size_follower_no_pickup(self):
+        self.session.create(self.uri, self.create_session_config)
+
+        cursor = self.session.open_cursor(self.uri)
+        for i in range(100):
+            cursor[i] = 'value' + str(i)
+        cursor.close()
+        self.session.checkpoint()
+        self.close_conn()
+
+        # Reopen as follower without supplying checkpoint meta. No pickup happens during
+        # open, so the in-memory database size stays 0 while the local metadata still
+        # records the checkpoint just taken. The verify call must be skipped until a
+        # pickup populates database size, otherwise it reports a spurious size mismatch.
+        self.open_conn(
+          config=self.conn_config + ',disaggregated=(role="follower"),verify_metadata=true')
+
     def test_verify_db_size_multi_table(self):
         uris = [
             'layered:test_layered76_a',


### PR DESCRIPTION
Gate the call on `last_checkpoint_meta_lsn != WT_DISAGG_LSN_NONE` so db size verify check only runs once a pickup has populated `database_size`. Leaders are unaffected. Followers with `checkpoint_meta` config at open unaffected. Followers without it (i.e. through `test/format`) skip the check, eliminating the false positive.