### PR TITLE
WT-17396 Fix TSan data races: non-atomic reads of wt_shared fields modified atomically

### DIFF
--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -1038,7 +1038,7 @@ __wt_curversion_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner
 
     /* Freeze pinned timestamp when we open the first version cursor. */
     __wt_writelock(session, &txn_global->rwlock);
-    if (conn->version_cursor_count == 0) {
+    if (__wt_atomic_load_uint32_relaxed(&conn->version_cursor_count) == 0) {
         __wt_txn_pinned_timestamp(session, &pinned_ts);
         txn_global->version_cursor_pinned_timestamp = pinned_ts;
     }

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -23,7 +23,7 @@ __wt_btree_disable_bulk(WT_SESSION_IMPL *session)
      * Once a tree is no longer empty, eviction should pay attention to it, and it's no longer
      * possible to bulk-load into it.
      */
-    if (!btree->original)
+    if (!__wt_atomic_load_uint8_relaxed(&btree->original))
         return;
 
     /*

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -23,7 +23,7 @@ __wt_btree_disable_bulk(WT_SESSION_IMPL *session)
      * Once a tree is no longer empty, eviction should pay attention to it, and it's no longer
      * possible to bulk-load into it.
      */
-    if (!__wt_atomic_load_uint8_relaxed(&btree->original))
+    if (!__wt_atomic_load_uint8_acquire(&btree->original))
         return;
 
     /*

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -959,7 +959,7 @@ __wt_txn_pinned_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t *pinned_tsp)
     }
 
     /* If we have a version cursor open, use the pinned timestamp when it is opened. */
-    if (__wt_atomic_load_uint32_relaxed(&S2C(session)->version_cursor_count) > 0) {
+    if (__wt_atomic_load_uint32_acquire(&S2C(session)->version_cursor_count) > 0) {
         *pinned_tsp = txn_global->version_cursor_pinned_timestamp;
         return;
     }

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -959,7 +959,7 @@ __wt_txn_pinned_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t *pinned_tsp)
     }
 
     /* If we have a version cursor open, use the pinned timestamp when it is opened. */
-    if (S2C(session)->version_cursor_count > 0) {
+    if (__wt_atomic_load_uint32_relaxed(&S2C(session)->version_cursor_count) > 0) {
         *pinned_tsp = txn_global->version_cursor_pinned_timestamp;
         return;
     }


### PR DESCRIPTION
## JIRA
[WT-17396](https://jira.mongodb.org/browse/WT-17396)

## Summary

Fixes three TSan data races caught in the `switch-mode` / layered-storage TSan variant of the format test. All three share the same root cause: a `wt_shared` field written exclusively via atomic primitives was read with a plain (non-atomic) load.

### Race 1 — `btree->original` in `__wt_btree_disable_bulk` ([btree_inline.h:26](src/include/btree_inline.h))

`btree->original` is a `wt_shared uint8_t`. The early-exit guard used a plain read while another thread could simultaneously perform `__wt_atomic_cas_uint8` on the same byte — the one-shot CAS that transitions a freshly-opened B-Tree out of bulk-load mode. Two layered insert threads racing on the same tree trigger this.

**Fix:** `!__wt_atomic_load_uint8_relaxed(&btree->original)`

### Race 2 — `version_cursor_count` in `__wt_txn_pinned_timestamp` ([txn_inline.h:962](src/include/txn_inline.h))

`conn->version_cursor_count` is a `wt_shared uint32_t` updated atomically (`__wt_atomic_add/sub_uint32`) from open and close paths. The advisory fast-path check in `__wt_txn_pinned_timestamp` used a plain load while a drain-worker thread performed a concurrent atomic add/sub.

**Fix:** `__wt_atomic_load_uint32_relaxed(&S2C(session)->version_cursor_count) > 0`

### Race 3 — `version_cursor_count` in `__wt_curversion_open` ([cur_version.c:1041](src/cursor/cur_version.c))

Same field as Race 2. The check inside the txn-global write-lock section of `__wt_curversion_open` used a plain load, but `__curversion_close` decrements the counter atomically **without** holding that lock, so the open-side lock provides no protection against a concurrent close.

**Fix:** `__wt_atomic_load_uint32_relaxed(&conn->version_cursor_count) == 0`

### Ordering justification

Relaxed ordering is sufficient in all three cases. The checks are either:
- Advisory fast-paths (Races 2 & 3): no ordering requirements on dependent reads/writes — just need to see a consistent value of the counter.
- One-shot transition guards (Race 1): the subsequent `__wt_atomic_cas_uint8` (SEQ_CST) and `__wt_evict_file_exclusive_off` provide the necessary acquire/release ordering for side-effects.

## Test plan
- [x] Run the `switch-tsan` format test variant to verify TSan no longer reports these races
- [x] Confirm no functional regression in layered/version-cursor tests