### PR TITLE
WT-16711 timestamp_abort: enable disagg mode

### DIFF
--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -969,7 +969,7 @@ run_workload(uint32_t workload_iteration)
      * In disaggregated mode, discard local-only WT files (turtle, WiredTiger.wt, log) on every
      * open. The disaggregated tables are reconstructed from the shared page log, which is the
      * source of truth for a leader; the local turtle file can lag behind after a crash between the
-     * metadata btree checkpoint and the page-log checkpoint commit (see WT-16711).
+     * metadata btree checkpoint and the page-log checkpoint commit.
      */
     if (opts->disagg.is_enabled)
         strcat(envconf, ",disaggregated=(lose_all_my_data=true)");

--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -968,8 +968,8 @@ run_workload(uint32_t workload_iteration)
     /*
      * In disaggregated mode, discard local-only WT files (turtle, WiredTiger.wt, log) on every
      * open. The disaggregated tables are reconstructed from the shared page log, which is the
-     * source of truth for a leader; the local turtle file can lag behind after a SIGKILL between
-     * the metadata btree checkpoint and the page-log checkpoint commit (see WT-16711).
+     * source of truth for a leader; the local turtle file can lag behind after a crash between the
+     * metadata btree checkpoint and the page-log checkpoint commit (see WT-16711).
      */
     if (opts->disagg.is_enabled)
         strcat(envconf, ",disaggregated=(lose_all_my_data=true)");

--- a/test/csuite/timestamp_abort/main.c
+++ b/test/csuite/timestamp_abort/main.c
@@ -664,6 +664,7 @@ thread_run(void *arg)
     memset(kname, 0, sizeof(kname));
 
     prepared_session = NULL;
+    cur_local = cur_oplog = NULL;
     td = (THREAD_DATA *)arg;
 
     /*
@@ -713,14 +714,16 @@ thread_run(void *arg)
     else
         testutil_check(session->open_cursor(session, uri, NULL, NULL, &cur_shadow));
 
-    testutil_snprintf(uri, sizeof(uri), "%s:%s", table_pfx, uri_local);
-    if (use_prep)
-        testutil_check(
-          prepared_session->open_cursor(prepared_session, uri, NULL, NULL, &cur_local));
-    else
-        testutil_check(session->open_cursor(session, uri, NULL, NULL, &cur_local));
-    testutil_snprintf(uri, sizeof(uri), "%s:%s", table_pfx, uri_oplog);
-    testutil_check(session->open_cursor(session, uri, NULL, NULL, &cur_oplog));
+    if (!opts->disagg.is_enabled) {
+        testutil_snprintf(uri, sizeof(uri), "%s:%s", table_pfx, uri_local);
+        if (use_prep)
+            testutil_check(
+              prepared_session->open_cursor(prepared_session, uri, NULL, NULL, &cur_local));
+        else
+            testutil_check(session->open_cursor(session, uri, NULL, NULL, &cur_local));
+        testutil_snprintf(uri, sizeof(uri), "%s:%s", table_pfx, uri_oplog);
+        testutil_check(session->open_cursor(session, uri, NULL, NULL, &cur_oplog));
+    }
 
     /*
      * Write our portion of the key space until we're killed.
@@ -749,15 +752,19 @@ thread_run(void *arg)
 
         if (columns) {
             cur_coll->set_key(cur_coll, i + 1);
-            cur_local->set_key(cur_local, i + 1);
-            cur_oplog->set_key(cur_oplog, i + 1);
             cur_shadow->set_key(cur_shadow, i + 1);
+            if (!opts->disagg.is_enabled) {
+                cur_local->set_key(cur_local, i + 1);
+                cur_oplog->set_key(cur_oplog, i + 1);
+            }
         } else {
             testutil_snprintf(kname, sizeof(kname), KEY_STRINGFORMAT, i);
             cur_coll->set_key(cur_coll, kname);
-            cur_local->set_key(cur_local, kname);
-            cur_oplog->set_key(cur_oplog, kname);
             cur_shadow->set_key(cur_shadow, kname);
+            if (!opts->disagg.is_enabled) {
+                cur_local->set_key(cur_local, kname);
+                cur_oplog->set_key(cur_oplog, kname);
+            }
         }
         /*
          * Put an informative string into the value so that it can be viewed well in a binary dump.
@@ -787,12 +794,14 @@ thread_run(void *arg)
         if ((ret = cur_shadow->insert(cur_shadow)) == WT_ROLLBACK)
             goto rollback;
         testutil_check(ret);
-        data.size = __wt_random(&td->data_rnd) % MAX_VAL;
-        data.data = obuf;
-        cur_oplog->set_value(cur_oplog, &data);
-        if ((ret = cur_oplog->insert(cur_oplog)) == WT_ROLLBACK)
-            goto rollback;
-        testutil_check(ret);
+        if (!opts->disagg.is_enabled) {
+            data.size = __wt_random(&td->data_rnd) % MAX_VAL;
+            data.data = obuf;
+            cur_oplog->set_value(cur_oplog, &data);
+            if ((ret = cur_oplog->insert(cur_oplog)) == WT_ROLLBACK)
+                goto rollback;
+            testutil_check(ret);
+        }
         if (use_prep) {
             /*
              * Run with prepare every once in a while. And also yield after prepare sometimes too.
@@ -826,10 +835,12 @@ thread_run(void *arg)
          * timestamp transaction, not before, because of the possibility of rollback in the
          * transaction. The local table must stay in sync with the other tables.
          */
-        data.size = __wt_random(&td->data_rnd) % MAX_VAL;
-        data.data = lbuf;
-        cur_local->set_value(cur_local, &data);
-        testutil_check(cur_local->insert(cur_local));
+        if (!opts->disagg.is_enabled) {
+            data.size = __wt_random(&td->data_rnd) % MAX_VAL;
+            data.data = lbuf;
+            cur_local->set_value(cur_local, &data);
+            testutil_check(cur_local->insert(cur_local));
+        }
 
         /*
          * Save the timestamps and key separately for checking later. Optionally use our third
@@ -954,6 +965,15 @@ run_workload(uint32_t workload_iteration)
     if (!opts->compat && !opts->inmem)
         strcat(envconf, ENV_CONFIG_ADD_EVICT_DIRTY);
 
+    /*
+     * In disaggregated mode, discard local-only WT files (turtle, WiredTiger.wt, log) on every
+     * open. The disaggregated tables are reconstructed from the shared page log, which is the
+     * source of truth for a leader; the local turtle file can lag behind after a SIGKILL between
+     * the metadata btree checkpoint and the page-log checkpoint commit (see WT-16711).
+     */
+    if (opts->disagg.is_enabled)
+        strcat(envconf, ",disaggregated=(lose_all_my_data=true)");
+
     testutil_wiredtiger_open(opts, WT_HOME_DIR, envconf, &other_event, &conn, false, false);
     testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
@@ -978,10 +998,17 @@ run_workload(uint32_t workload_iteration)
         testutil_check(session->create(session, uri, table_config_nolog));
         testutil_snprintf(uri, sizeof(uri), "%s:%s", table_pfx, uri_shadow);
         testutil_check(session->create(session, uri, table_config_nolog));
-        testutil_snprintf(uri, sizeof(uri), "%s:%s", table_pfx, uri_local);
-        testutil_check(session->create(session, uri, table_config));
-        testutil_snprintf(uri, sizeof(uri), "%s:%s", table_pfx, uri_oplog);
-        testutil_check(session->create(session, uri, table_config));
+        /*
+         * The local and oplog tables live on local disk; in disaggregated mode the lose_all_my_data
+         * option wipes them on every open, so they would not survive across iterations. Skip
+         * creating them in that case.
+         */
+        if (!opts->disagg.is_enabled) {
+            testutil_snprintf(uri, sizeof(uri), "%s:%s", table_pfx, uri_local);
+            testutil_check(session->create(session, uri, table_config));
+            testutil_snprintf(uri, sizeof(uri), "%s:%s", table_pfx, uri_oplog);
+            testutil_check(session->create(session, uri, table_config));
+        }
     }
 
     /*
@@ -1167,7 +1194,15 @@ recover_and_verify(uint32_t backup_index, uint32_t workload_iteration)
      */
     if (backup_index == 0) {
         testutil_snprintf(verify_dir, sizeof(verify_dir), "%s", WT_HOME_DIR);
-        testutil_wiredtiger_open(opts, verify_dir, NULL, &reopen_event, &conn, true, false);
+        /*
+         * In disaggregated mode, wipe local-only WT files on this open as well, so recovery derives
+         * state from the page log rather than a possibly stale local turtle file. Pass create=true
+         * so the connection can rebuild the local catalog from the page log after the wipe
+         * (lose_all_my_data deletes WiredTiger.wt and the turtle file).
+         */
+        testutil_wiredtiger_open(opts, verify_dir,
+          opts->disagg.is_enabled ? "create=true,disaggregated=(lose_all_my_data=true)" : NULL,
+          &reopen_event, &conn, true, false);
         printf("Connection open and recovery complete. Verify content\n");
         /*
          * Only call this when index is 0 because it calls back into here to verify a specific
@@ -1203,23 +1238,30 @@ recover_and_verify(uint32_t backup_index, uint32_t workload_iteration)
     testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
     /*
-     * Open a cursor on all the tables.
+     * Open a cursor on all the tables. The local and oplog tables are not present in disaggregated
+     * mode (see run_workload).
      */
+    cur_local = cur_oplog = NULL;
     testutil_snprintf(buf, sizeof(buf), "%s:%s", table_pfx, uri_collection);
     testutil_check(session->open_cursor(session, buf, NULL, NULL, &cur_coll));
     testutil_snprintf(buf, sizeof(buf), "%s:%s", table_pfx, uri_shadow);
     testutil_check(session->open_cursor(session, buf, NULL, NULL, &cur_shadow));
-    testutil_snprintf(buf, sizeof(buf), "%s:%s", table_pfx, uri_local);
-    testutil_check(session->open_cursor(session, buf, NULL, NULL, &cur_local));
-    testutil_snprintf(buf, sizeof(buf), "%s:%s", table_pfx, uri_oplog);
-    testutil_check(session->open_cursor(session, buf, NULL, NULL, &cur_oplog));
+    if (!opts->disagg.is_enabled) {
+        testutil_snprintf(buf, sizeof(buf), "%s:%s", table_pfx, uri_local);
+        testutil_check(session->open_cursor(session, buf, NULL, NULL, &cur_local));
+        testutil_snprintf(buf, sizeof(buf), "%s:%s", table_pfx, uri_oplog);
+        testutil_check(session->open_cursor(session, buf, NULL, NULL, &cur_oplog));
+    }
 
     /*
-     * Find the biggest stable timestamp value that was saved.
+     * Find the biggest stable timestamp value that was saved. In disaggregated mode,
+     * lose_all_my_data wipes WAL state, so "get=recovery" returns zero. The page-log recovery path
+     * sets last_ckpt_timestamp from the disagg checkpoint metadata, so use that instead.
      */
     stable_val = WT_TS_NONE;
     if (use_ts) {
-        testutil_check(conn->query_timestamp(conn, ts_string, "get=recovery"));
+        testutil_check(conn->query_timestamp(
+          conn, ts_string, opts->disagg.is_enabled ? "get=last_checkpoint" : "get=recovery"));
         testutil_assert(sscanf(ts_string, "%" SCNx64, &stable_val) == 1);
         printf("Got stable_val %" PRIu64 "\n", stable_val);
     }
@@ -1276,15 +1318,19 @@ recover_and_verify(uint32_t backup_index, uint32_t workload_iteration)
 
             if (columns) {
                 cur_coll->set_key(cur_coll, key + 1);
-                cur_local->set_key(cur_local, key + 1);
-                cur_oplog->set_key(cur_oplog, key + 1);
                 cur_shadow->set_key(cur_shadow, key + 1);
+                if (!opts->disagg.is_enabled) {
+                    cur_local->set_key(cur_local, key + 1);
+                    cur_oplog->set_key(cur_oplog, key + 1);
+                }
             } else {
                 testutil_snprintf(kname, sizeof(kname), KEY_STRINGFORMAT, key);
                 cur_coll->set_key(cur_coll, kname);
-                cur_local->set_key(cur_local, kname);
-                cur_oplog->set_key(cur_oplog, kname);
                 cur_shadow->set_key(cur_shadow, kname);
+                if (!opts->disagg.is_enabled) {
+                    cur_local->set_key(cur_local, kname);
+                    cur_oplog->set_key(cur_oplog, kname);
+                }
             }
 
             /*
@@ -1344,42 +1390,44 @@ recover_and_verify(uint32_t backup_index, uint32_t workload_iteration)
                 testutil_die(ret, "shadow search failure");
 
             /*
-             * The local table should always have all data.
+             * The local and oplog tables should always have all data, but they are not present in
+             * disaggregated mode (lose_all_my_data wipes them on every open).
              */
-            if ((ret = cur_local->search(cur_local)) != 0) {
-                if (ret != WT_NOTFOUND)
-                    testutil_die(ret, "search");
-                if (!opts->inmem)
-                    printf("%s: LOCAL no record with key %" PRIu64 "\n", fname, key);
-                absent_local++;
-                if (l_rep[i].first_miss == INVALID_KEY)
-                    l_rep[i].first_miss = key;
-                l_rep[i].absent_key = key;
-            } else if (l_rep[i].absent_key != INVALID_KEY && l_rep[i].exist_key == INVALID_KEY) {
-                /*
-                 * We should never find an existing key after we have detected one missing.
-                 */
-                l_rep[i].exist_key = key;
-                fatal = true;
-            }
-            /*
-             * The oplog table should always have all data.
-             */
-            if ((ret = cur_oplog->search(cur_oplog)) != 0) {
-                if (ret != WT_NOTFOUND)
-                    testutil_die(ret, "search");
-                if (!opts->inmem)
-                    printf("%s: OPLOG no record with key %" PRIu64 "\n", fname, key);
-                absent_oplog++;
-                if (o_rep[i].first_miss == INVALID_KEY)
-                    o_rep[i].first_miss = key;
-                o_rep[i].absent_key = key;
-            } else if (o_rep[i].absent_key != INVALID_KEY && o_rep[i].exist_key == INVALID_KEY) {
-                /*
-                 * We should never find an existing key after we have detected one missing.
-                 */
-                o_rep[i].exist_key = key;
-                fatal = true;
+            if (!opts->disagg.is_enabled) {
+                if ((ret = cur_local->search(cur_local)) != 0) {
+                    if (ret != WT_NOTFOUND)
+                        testutil_die(ret, "search");
+                    if (!opts->inmem)
+                        printf("%s: LOCAL no record with key %" PRIu64 "\n", fname, key);
+                    absent_local++;
+                    if (l_rep[i].first_miss == INVALID_KEY)
+                        l_rep[i].first_miss = key;
+                    l_rep[i].absent_key = key;
+                } else if (l_rep[i].absent_key != INVALID_KEY &&
+                  l_rep[i].exist_key == INVALID_KEY) {
+                    /*
+                     * We should never find an existing key after we have detected one missing.
+                     */
+                    l_rep[i].exist_key = key;
+                    fatal = true;
+                }
+                if ((ret = cur_oplog->search(cur_oplog)) != 0) {
+                    if (ret != WT_NOTFOUND)
+                        testutil_die(ret, "search");
+                    if (!opts->inmem)
+                        printf("%s: OPLOG no record with key %" PRIu64 "\n", fname, key);
+                    absent_oplog++;
+                    if (o_rep[i].first_miss == INVALID_KEY)
+                        o_rep[i].first_miss = key;
+                    o_rep[i].absent_key = key;
+                } else if (o_rep[i].absent_key != INVALID_KEY &&
+                  o_rep[i].exist_key == INVALID_KEY) {
+                    /*
+                     * We should never find an existing key after we have detected one missing.
+                     */
+                    o_rep[i].exist_key = key;
+                    fatal = true;
+                }
             }
         }
         c_rep[i].last_key = last_key;
@@ -1390,7 +1438,14 @@ recover_and_verify(uint32_t backup_index, uint32_t workload_iteration)
         print_missing(&l_rep[i], fname, "LOCAL");
         print_missing(&o_rep[i], fname, "OPLOG");
     }
-    testutil_check(conn->close(conn, NULL));
+    /*
+     * In disaggregated mode, skip the shutdown checkpoint. After lose_all_my_data wipes local
+     * state, the connection's stable timestamp is reset to zero, but precise_checkpoint (which is
+     * always on for disagg) requires a non-zero stable. The verifier does not write data, so the
+     * shutdown checkpoint adds no value here.
+     */
+    testutil_check(
+      conn->close(conn, opts->disagg.is_enabled ? "debug=(skip_checkpoint=true)" : NULL));
     if (!opts->inmem && absent_coll) {
         printf("COLLECTION: %" PRIu64 " record(s) absent from %" PRIu64 "\n", absent_coll, count);
         fatal = true;


### PR DESCRIPTION
Fix `timestamp_abort` test to run in both disagg and non-disagg modes.

Eliminate race condition leading to timestamp divergence across disagg and local state. Open with `lose_all_my_data=true` and skip the local/oplog tables.