### PR TITLE
WT-15370 Skip test_durable_ts01 under --hook disagg

### DIFF
--- a/test/suite/hook_disagg.fail
+++ b/test/suite/hook_disagg.fail
@@ -15,7 +15,6 @@ test_dump03.py
 test_dump04.py
 test_dump05.py
 test_dupc.py
-test_durable_ts01.py  # FIXME: WT-15370
 test_durable_ts03.py
 test_empty.py
 test_encrypt06.py

--- a/test/suite/test_durable_ts01.py
+++ b/test/suite/test_durable_ts01.py
@@ -33,6 +33,7 @@ from wtscenario import make_scenarios
 # test_durable_ts01.py
 #    Checking visibility and durability of updates with durable_timestamp and
 #    with restart.
+@wttest.skip_for_hook("disagg", "RTS does not run during recovery for disaggregated storage")
 class test_durable_ts01(wttest.WiredTigerTestCase):
 
     format_values = [


### PR DESCRIPTION
## Summary
- `test_durable_ts01` verifies that RTS rolls back updates whose `durable_timestamp` exceeds `stable_timestamp` at recovery time
- Under `--hook disagg`, RTS is skipped during recovery because `__wt_conn_is_disagg()` returns false at that point — disagg infrastructure (`__wti_disagg_conn_config`) is initialized after recovery completes
- Skip the test with `@wttest.skip_for_hook("disagg", ...)`, consistent with how other hook-incompatible tests are handled (e.g. `test_rollback_to_stable09`)