### PR TITLE
WT-17358 Open shared HS and data store from stable checkpoint in __hs_verify on followers

### DIFF
--- a/src/history/hs_verify.c
+++ b/src/history/hs_verify.c
@@ -182,13 +182,15 @@ __hs_verify(WT_SESSION_IMPL *session, uint32_t hs_id)
     if (is_follower) {
         WT_HS_ID_TO_URI(session, hs_id, hs_uri);
         if (WT_URI_IS_STABLE(hs_uri)) {
-            ret = __wt_meta_checkpoint_last_name(session, hs_uri, &hs_checkpoint_name, NULL, NULL);
-            WT_ERR_NOTFOUND_OK(ret, false);
+            WT_ERR_NOTFOUND_OK(
+              __wt_meta_checkpoint_last_name(session, hs_uri, &hs_checkpoint_name, NULL, NULL),
+              true);
             /* No checkpoint yet means the history store is empty; nothing to verify. */
             if (ret == WT_NOTFOUND) {
                 ret = 0;
                 goto err;
             }
+            /* Only needed when verifying the shared history store on the follower. */
             WT_ERR(__wt_scr_alloc(session, 0, &ds_uri_buf));
         }
     }

--- a/src/history/hs_verify.c
+++ b/src/history/hs_verify.c
@@ -246,9 +246,9 @@ __hs_verify(WT_SESSION_IMPL *session, uint32_t hs_id)
 err:
     __wt_scr_free(session, &buf);
     __wt_scr_free(session, &ds_uri_buf);
-    __wt_free(session, uri_data);
-    __wt_free(session, hs_checkpoint_name);
     __wt_free(session, ds_checkpoint_name);
+    __wt_free(session, hs_checkpoint_name);
+    __wt_free(session, uri_data);
     if (ds_cursor != NULL)
         WT_TRET(ds_cursor->close(ds_cursor));
     if (hs_cursor != NULL)

--- a/src/history/hs_verify.c
+++ b/src/history/hs_verify.c
@@ -148,24 +148,53 @@ err:
 static int
 __hs_verify(WT_SESSION_IMPL *session, uint32_t hs_id)
 {
+    WT_CONNECTION_IMPL *conn;
     WT_CURSOR *ds_cursor, *hs_cursor;
     WT_DECL_ITEM(buf);
+    WT_DECL_ITEM(ds_uri_buf);
     WT_DECL_RET;
     WT_ITEM key;
     wt_timestamp_t hs_start_ts;
     uint64_t hs_counter;
     uint32_t btree_id;
+    const char *ds_checkpoint_name, *hs_checkpoint_name, *hs_uri;
     char *uri_data;
+    bool is_follower;
 
     WT_CLEAR(key);
+    conn = S2C(session);
     ds_cursor = hs_cursor = NULL;
     hs_start_ts = WT_TS_NONE;
     hs_counter = 0;
     btree_id = WT_BTREE_ID_INVALID;
     uri_data = NULL;
+    ds_checkpoint_name = hs_checkpoint_name = NULL;
+    is_follower = __wt_conn_is_disagg(session) && !conn->layered_table_manager.leader;
 
     WT_ERR(__wt_scr_alloc(session, 0, &buf));
-    WT_ERR(__wt_curhs_open_ext(session, hs_id, 0, NULL, NULL, &hs_cursor));
+
+    /*
+     * On a disaggregated follower, open both the history store and data store from their latest
+     * stable checkpoints. A follower cannot dirty pages, so opening live disaggregated handles
+     * would trigger the leader-only assertion when page-read re-instantiates stop-timestamp
+     * records.
+     */
+    if (is_follower) {
+        WT_HS_ID_TO_URI(session, hs_id, hs_uri);
+        if (WT_URI_IS_STABLE(hs_uri)) {
+            ret =
+              __wt_meta_checkpoint_last_name(session, hs_uri, &hs_checkpoint_name, NULL, NULL);
+            WT_ERR_NOTFOUND_OK(ret, false);
+            /* No checkpoint yet means the history store is empty; nothing to verify. */
+            if (ret == WT_NOTFOUND) {
+                ret = 0;
+                goto err;
+            }
+            WT_ERR(__wt_scr_alloc(session, 0, &ds_uri_buf));
+        }
+    }
+
+    WT_ERR(__wt_curhs_open_ext(session, hs_id, 0, hs_checkpoint_name, NULL, &hs_cursor));
     F_SET(hs_cursor, WT_CURSTD_HS_READ_COMMITTED);
 
     /* Position the hs cursor on the first record. */
@@ -178,6 +207,7 @@ __hs_verify(WT_SESSION_IMPL *session, uint32_t hs_id)
     /* Go through the history store and validate each btree. */
     while (ret == 0) {
         __wt_free(session, uri_data);
+        __wt_free(session, ds_checkpoint_name);
         /*
          * The cursor is positioned either from above or left over from the internal call on the
          * first key of a new btree id.
@@ -191,7 +221,13 @@ __hs_verify(WT_SESSION_IMPL *session, uint32_t hs_id)
               btree_id, __wt_buf_set_printable(session, key.data, key.size, false, buf));
         }
 
-        WT_ERR(__wt_open_cursor(session, uri_data, NULL, NULL, &ds_cursor));
+        if (is_follower && WT_URI_IS_STABLE(uri_data)) {
+            WT_ERR(__wt_meta_checkpoint_last_name(
+              session, uri_data, &ds_checkpoint_name, NULL, NULL));
+            WT_ERR(__wt_buf_fmt(session, ds_uri_buf, "%s/%s", uri_data, ds_checkpoint_name));
+            WT_ERR(__wt_open_cursor(session, ds_uri_buf->data, NULL, NULL, &ds_cursor));
+        } else
+            WT_ERR(__wt_open_cursor(session, uri_data, NULL, NULL, &ds_cursor));
         F_SET(ds_cursor, WT_CURSOR_RAW_OK);
 
         /* Note that the following call moves the hs cursor internally. */
@@ -208,7 +244,10 @@ __hs_verify(WT_SESSION_IMPL *session, uint32_t hs_id)
     }
 err:
     __wt_scr_free(session, &buf);
+    __wt_scr_free(session, &ds_uri_buf);
     __wt_free(session, uri_data);
+    __wt_free(session, hs_checkpoint_name);
+    __wt_free(session, ds_checkpoint_name);
     if (ds_cursor != NULL)
         WT_TRET(ds_cursor->close(ds_cursor));
     if (hs_cursor != NULL)

--- a/src/history/hs_verify.c
+++ b/src/history/hs_verify.c
@@ -157,8 +157,8 @@ __hs_verify(WT_SESSION_IMPL *session, uint32_t hs_id)
     wt_timestamp_t hs_start_ts;
     uint64_t hs_counter;
     uint32_t btree_id;
-    const char *ds_checkpoint_name, *hs_checkpoint_name, *hs_uri;
     char *uri_data;
+    const char *ds_checkpoint_name, *hs_checkpoint_name, *hs_uri;
     bool is_follower;
 
     WT_CLEAR(key);
@@ -168,7 +168,7 @@ __hs_verify(WT_SESSION_IMPL *session, uint32_t hs_id)
     hs_counter = 0;
     btree_id = WT_BTREE_ID_INVALID;
     uri_data = NULL;
-    ds_checkpoint_name = hs_checkpoint_name = NULL;
+    ds_checkpoint_name = hs_checkpoint_name = hs_uri = NULL;
     is_follower = __wt_conn_is_disagg(session) && !conn->layered_table_manager.leader;
 
     WT_ERR(__wt_scr_alloc(session, 0, &buf));
@@ -182,8 +182,7 @@ __hs_verify(WT_SESSION_IMPL *session, uint32_t hs_id)
     if (is_follower) {
         WT_HS_ID_TO_URI(session, hs_id, hs_uri);
         if (WT_URI_IS_STABLE(hs_uri)) {
-            ret =
-              __wt_meta_checkpoint_last_name(session, hs_uri, &hs_checkpoint_name, NULL, NULL);
+            ret = __wt_meta_checkpoint_last_name(session, hs_uri, &hs_checkpoint_name, NULL, NULL);
             WT_ERR_NOTFOUND_OK(ret, false);
             /* No checkpoint yet means the history store is empty; nothing to verify. */
             if (ret == WT_NOTFOUND) {
@@ -214,7 +213,7 @@ __hs_verify(WT_SESSION_IMPL *session, uint32_t hs_id)
          */
         WT_ERR(hs_cursor->get_key(hs_cursor, &btree_id, &key, &hs_start_ts, &hs_counter));
         if ((ret = __wt_metadata_btree_id_to_uri(session, btree_id, &uri_data)) != 0) {
-            F_SET_ATOMIC_32(S2C(session), WT_CONN_DATA_CORRUPTION);
+            F_SET_ATOMIC_32(conn, WT_CONN_DATA_CORRUPTION);
             WT_ERR_PANIC(session, ret,
               "Unable to find btree id %" PRIu32
               " in the metadata file for the associated key '%s'.",
@@ -222,8 +221,8 @@ __hs_verify(WT_SESSION_IMPL *session, uint32_t hs_id)
         }
 
         if (is_follower && WT_URI_IS_STABLE(uri_data)) {
-            WT_ERR(__wt_meta_checkpoint_last_name(
-              session, uri_data, &ds_checkpoint_name, NULL, NULL));
+            WT_ERR(
+              __wt_meta_checkpoint_last_name(session, uri_data, &ds_checkpoint_name, NULL, NULL));
             WT_ERR(__wt_buf_fmt(session, ds_uri_buf, "%s/%s", uri_data, ds_checkpoint_name));
             WT_ERR(__wt_open_cursor(session, ds_uri_buf->data, NULL, NULL, &ds_cursor));
         } else

--- a/src/history/hs_verify.c
+++ b/src/history/hs_verify.c
@@ -181,7 +181,7 @@ __hs_verify(WT_SESSION_IMPL *session, uint32_t hs_id)
      */
     if (is_follower) {
         WT_HS_ID_TO_URI(session, hs_id, hs_uri);
-        /* Only the shared history store require checkpoint-based access on follower. */
+        /* The local history store does not require checkpoint-based access on follower. */
         if (WT_URI_IS_STABLE(hs_uri)) {
             WT_ERR_NOTFOUND_OK(
               __wt_meta_checkpoint_last_name(session, hs_uri, &hs_checkpoint_name, NULL, NULL),

--- a/src/history/hs_verify.c
+++ b/src/history/hs_verify.c
@@ -181,6 +181,7 @@ __hs_verify(WT_SESSION_IMPL *session, uint32_t hs_id)
      */
     if (is_follower) {
         WT_HS_ID_TO_URI(session, hs_id, hs_uri);
+        /* Only the shared history store require checkpoint-based access on follower. */
         if (WT_URI_IS_STABLE(hs_uri)) {
             WT_ERR_NOTFOUND_OK(
               __wt_meta_checkpoint_last_name(session, hs_uri, &hs_checkpoint_name, NULL, NULL),

--- a/test/suite/test_hs_verify_disagg_follower.py
+++ b/test/suite/test_hs_verify_disagg_follower.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wttest
+from helper_disagg import disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
+
+# test_hs_verify_disagg_follower.py
+#    Opening a disaggregated follower with verify_metadata=true must succeed when
+#    the database contains keys whose deletion was committed at a later timestamp
+#    than an earlier write.
+
+@disagg_test_class
+class test_hs_verify_disagg_follower(wttest.WiredTigerTestCase):
+    disagg_storages = gen_disagg_storages('test_hs_verify_disagg_follower', disagg_only=True)
+    scenarios = make_scenarios(disagg_storages)
+
+    conn_config = 'disaggregated=(role="leader")'
+    uri = 'layered:test_hs_verify_disagg_follower'
+    table_cfg = 'key_format=S,value_format=S,block_manager=disagg'
+    nitems = 100
+
+    def test_verify_metadata_follower_with_deletions(self):
+        # Set up a database where some keys have both a committed write at an earlier
+        # timestamp and a committed deletion at a later timestamp, then verify that
+        # reopening as a follower with verify_metadata=true succeeds without error.
+
+        self.session.create(self.uri, self.table_cfg)
+        cursor = self.session.open_cursor(self.uri)
+
+        # Write all keys at ts=5 and checkpoint.
+        for i in range(self.nitems):
+            self.session.begin_transaction()
+            cursor[str(i)] = 'v1_' + str(i)
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(5))
+        self.session.checkpoint()
+
+        # Overwrite all keys at ts=10 and checkpoint.
+        # Keys now have two committed versions retained across checkpoints.
+        for i in range(self.nitems):
+            self.session.begin_transaction()
+            cursor[str(i)] = 'v2_' + str(i)
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
+        self.session.checkpoint()
+
+        # Delete every other key at ts=15 and checkpoint.
+        # Each deleted key now has a committed write at ts=10 and a committed
+        # deletion at ts=15, both of which are visible in the checkpointed state.
+        for i in range(0, self.nitems, 2):
+            self.session.begin_transaction()
+            cursor.set_key(str(i))
+            cursor.remove()
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(15))
+        self.session.checkpoint()
+        cursor.close()
+
+        checkpoint_meta = self.disagg_get_complete_checkpoint_meta()
+
+        # Step down before closing so WiredTiger skips the shutdown checkpoint.
+        self.conn.reconfigure('disaggregated=(role="follower")')
+        self.close_conn()
+
+        # Reopen as a follower with verify_metadata=true. A follower may only read
+        # the checkpointed state  it must not modify data. The verify must succeed.
+        follower_config = (
+            f'disaggregated=(role="follower",checkpoint_meta="{checkpoint_meta}"),'
+            f'verify_metadata=true'
+        )
+        self.open_conn(config=follower_config)

--- a/test/suite/test_verify_disagg03.py
+++ b/test/suite/test_verify_disagg03.py
@@ -30,18 +30,18 @@ import wttest
 from helper_disagg import disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 
-# test_hs_verify_disagg_follower.py
+# test_verify_disagg03.py
 #    Opening a disaggregated follower with verify_metadata=true must succeed when
 #    the database contains keys whose deletion was committed at a later timestamp
 #    than an earlier write.
 
 @disagg_test_class
-class test_hs_verify_disagg_follower(wttest.WiredTigerTestCase):
-    disagg_storages = gen_disagg_storages('test_hs_verify_disagg_follower', disagg_only=True)
+class test_verify_disagg03(wttest.WiredTigerTestCase):
+    disagg_storages = gen_disagg_storages('test_verify_disagg03', disagg_only=True)
     scenarios = make_scenarios(disagg_storages)
 
     conn_config = 'disaggregated=(role="leader")'
-    uri = 'layered:test_hs_verify_disagg_follower'
+    uri = 'layered:test_verify_disagg03'
     table_cfg = 'key_format=S,value_format=S,block_manager=disagg'
     nitems = 100
 


### PR DESCRIPTION
## Summary

- `__hs_verify` was opening live handles for shared (`.wt_stable`) btrees on disaggregated followers, triggering a leader-only assertion in `__wt_page_modify_set` when page-read re-instantiated stop-timestamp records via `__wti_page_inmem_updates`
- On a disaggregated follower, detect shared btrees via `WT_URI_IS_STABLE` and open both the history store and data store cursors from their latest stable checkpoint using the `uri/checkpoint_name` URI form — which flows through the existing `checkpoint_name != NULL` branch in `__curhs_file_cursor_open`
- Local (non-shared) btrees and non-follower connections are unaffected

## Root cause

`__hs_verify` called `__wt_curhs_open_ext(..., NULL, ...)` and `__wt_open_cursor(session, uri_data, ...)` with no checkpoint config, opening live writable handles. For disaggregated btrees, `__inmem_row_leaf` sets `instantiate_upd = true` for records with stop timestamps, causing `__page_read` to call `__wti_page_inmem_updates`, which tries to dirty the page. `__wt_page_modify_set` then asserts `!DISAGG || leader` — which fails on a follower.