### PR TITLE
WT-17394 Use internal session during connection startup for cleanup and verifications

### DIFF
--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1577,26 +1577,22 @@ __conn_startup_cleanup_and_verify(WT_CONNECTION_IMPL *conn, bool verify_meta)
     WT_DECL_RET;
     WT_SESSION_IMPL *session = NULL;
 
-    WT_ERR(__wt_open_internal_session(conn, "startup-cleanup-and-verify", false, 0, 0, &session));
-
-    /* The chunk cache metadata table may exist on upgrade. Discard it. */
-    WT_ERR(__conn_cleanup_chunk_cache(session));
+    WT_ERR(
+      __wt_open_internal_session(conn, "startup-cleanup-and-verify", verify_meta, 0, 0, &session));
 
     if (verify_meta) {
+        /* Database verification must happen as the first step before any potential changes. */
+        WT_ERR(__wt_verify_disagg_database_size(session));
+
         /*
          * If the user wants to verify WiredTiger metadata, verify the history store now that the
          * metadata table may have been salvaged and eviction has been started and recovery run.
          */
         WT_ERR(__wt_hs_verify(session));
-
-        /*
-         * Verify the disaggregated database size. This must happen after __wti_connection_workers,
-         * which is where disaggregated storage is initialized. The earlier metadata verify (above)
-         * does not need to wait because it only verifies the local metadata file, which is not a
-         * shared table and has no dependency on disagg initialization.
-         */
-        WT_ERR(__wt_verify_disagg_database_size(session));
     }
+
+    /* The chunk cache metadata table may exist on upgrade. Discard it. */
+    WT_ERR(__conn_cleanup_chunk_cache(session));
 
 err:
     if (session != NULL)

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1568,6 +1568,43 @@ __conn_cleanup_chunk_cache(WT_SESSION_IMPL *session)
 }
 
 /*
+ * __conn_startup_cleanup_and_verify --
+ *     Perform cleanup and verification that must run after recovery and worker startup.
+ */
+static int
+__conn_startup_cleanup_and_verify(WT_CONNECTION_IMPL *conn, bool verify_meta)
+{
+    WT_DECL_RET;
+    WT_SESSION_IMPL *session = NULL;
+
+    WT_ERR(__wt_open_internal_session(conn, "startup-cleanup-and-verify", false, 0, 0, &session));
+
+    /* The chunk cache metadata table may exist on upgrade. Discard it. */
+    WT_ERR(__conn_cleanup_chunk_cache(session));
+
+    if (verify_meta) {
+        /*
+         * If the user wants to verify WiredTiger metadata, verify the history store now that the
+         * metadata table may have been salvaged and eviction has been started and recovery run.
+         */
+        WT_ERR(__wt_hs_verify(session));
+
+        /*
+         * Verify the disaggregated database size. This must happen after __wti_connection_workers,
+         * which is where disaggregated storage is initialized. The earlier metadata verify (above)
+         * does not need to wait because it only verifies the local metadata file, which is not a
+         * shared table and has no dependency on disagg initialization.
+         */
+        WT_ERR(__wt_verify_disagg_database_size(session));
+    }
+
+err:
+    if (session != NULL)
+        WT_TRET(__wt_session_close_internal(session));
+    return (ret);
+}
+
+/*
  * __conn_chunk_cache_check --
  *     Check for deprecated chunk cache configuration. If chunk_cache is enabled, return an error.
  *     If chunk_cache is present but disabled, issue a deprecation warning.
@@ -3161,7 +3198,7 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler, const char *c
     WT_DECL_RET;
     const WT_NAME_FLAG *ft;
     WT_SESSION *wt_session;
-    WT_SESSION_IMPL *chunk_cache_cleanup_session, *session, *verify_session;
+    WT_SESSION_IMPL *session;
     bool config_base_set, try_salvage, verify_meta;
     const char *enc_cfg[] = {NULL, NULL}, *merge_cfg;
     char version[64];
@@ -3174,7 +3211,7 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler, const char *c
     *connectionp = NULL;
 
     conn = NULL;
-    session = verify_session = NULL;
+    session = NULL;
     merge_cfg = NULL;
     try_salvage = false;
     WT_NOT_READ(config_base_set, false);
@@ -3620,32 +3657,17 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler, const char *c
     /* Start the worker threads, run recovery, and initialize the disaggregated storage. */
     WT_ERR(__wti_connection_workers(session, cfg));
 
-    /* The chunk cache metadata table may exist on upgrade. Discard it. */
-    WT_ERR(__wt_open_internal_session(
-      conn, "chunk-cache-cleanup", false, 0, 0, &chunk_cache_cleanup_session));
-    ret = __conn_cleanup_chunk_cache(chunk_cache_cleanup_session);
-    WT_TRET(__wt_session_close_internal(chunk_cache_cleanup_session));
-    WT_ERR(ret);
+    /*
+     * The default session should not open data handles after this point: since it can be shared
+     * between threads, relying on session->dhandle is not safe.
+     */
+    F_SET(session, WT_SESSION_NO_DATA_HANDLES);
 
     /*
-     * If the user wants to verify WiredTiger metadata, verify the history store now that the
-     * metadata table may have been salvaged and eviction has been started and recovery run.
+     * Finish startup cleanup and run verification that depends on completed recovery and
+     * disaggregated storage initialization.
      */
-    if (verify_meta) {
-        WT_ERR(__wt_open_internal_session(conn, "verify hs", false, 0, 0, &verify_session));
-        ret = __wt_hs_verify(verify_session);
-        WT_TRET(__wt_session_close_internal(verify_session));
-        WT_ERR(ret);
-    }
-
-    /*
-     * Verify the disaggregated database size. This must happen after __wti_connection_workers,
-     * which is where disaggregated storage is initialized. The earlier metadata verify (above) does
-     * not need to wait because it only verifies the local metadata file, which is not a shared
-     * table and has no dependency on disagg initialization.
-     */
-    if (verify_meta)
-        WT_ERR(__wt_verify_disagg_database_size(session));
+    WT_ERR(__conn_startup_cleanup_and_verify(conn, verify_meta));
 
     /*
      * The hash array sizes needed to be set up very early. Set them in the statistics here. Setting
@@ -3653,12 +3675,6 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler, const char *c
      */
     WT_STAT_CONN_SET(session, buckets, conn->hash_size);
     WT_STAT_CONN_SET(session, buckets_dh, conn->dh_hash_size);
-
-    /*
-     * The default session should not open data handles after this point: since it can be shared
-     * between threads, relying on session->dhandle is not safe.
-     */
-    F_SET(session, WT_SESSION_NO_DATA_HANDLES);
 
     F_SET_ATOMIC_32(conn, WT_CONN_READY);
     F_CLR_ATOMIC_32(conn, WT_CONN_MINIMAL);

--- a/test/suite/test_chunkcache_cleanup.py
+++ b/test/suite/test_chunkcache_cleanup.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wiredtiger, wttest
+
+# Test startup cleanup on reopen.
+class test_chunkcache_cleanup(wttest.WiredTigerTestCase):
+    uri = 'file:WiredTigerCC.wt'
+
+    def metadata_search(self):
+        meta = self.session.open_cursor('metadata:', None, None)
+        meta.set_key(self.uri)
+        ret = meta.search()
+        meta.close()
+        return ret
+
+    def test_startup_cleanup_runs_on_reopen(self):
+        # Seed the chunk cache metafile so reopen has cleanup work to do.
+        self.session.create(self.uri, 'key_format=u,value_format=u')
+        self.assertEqual(self.metadata_search(), 0)
+        self.reopen_conn()
+
+        # Confirm that startup cleanup removed the chunk cache metadata entry.
+        self.assertEqual(self.metadata_search(), wiredtiger.WT_NOTFOUND)

--- a/test/suite/test_layered102.py
+++ b/test/suite/test_layered102.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wttest
+from helper_disagg import disagg_test_class
+
+# test_layered102.py
+# Verify that startup database-size verification waits until checkpoint pickup.
+
+@disagg_test_class
+class test_layered102(wttest.WiredTigerTestCase):
+    uri = 'layered:test_layered102'
+    create_session_config = 'key_format=i,value_format=S'
+
+    def conn_config(self):
+        return f'verbose=[verify:3],disaggregated=(role="leader")'
+
+    def _follower_config(self, checkpoint_meta=None):
+        config = f'verbose=[verify:3],verify_metadata=true,' \
+            f'disaggregated=(role="follower"'
+        if checkpoint_meta is not None:
+            config += f',checkpoint_meta="{checkpoint_meta}"'
+        config += ')'
+        return config
+
+    def test_startup_verify_db_size(self):
+        self.session.create(self.uri, self.create_session_config)
+
+        cursor = self.session.open_cursor(self.uri)
+        for i in range(100):
+            cursor[i] = 'value' + str(i)
+        cursor.close()
+
+        self.session.checkpoint()
+        checkpoint_meta = self.disagg_get_complete_checkpoint_meta()
+
+        # Reopen as a follower without checkpoint metadata first. The startup
+        # verify path should skip the database-size check until pickup occurs.
+        # Step down before close so close does not create a shutdown checkpoint.
+        # That keeps this reopen on the no-pickup path until checkpoint_meta is supplied.
+        self.conn.reconfigure('disaggregated=(role="follower")')
+        self.close_conn()
+        with self.customStdoutPattern(
+            lambda output: self.assertNotRegex(
+                output, r'disagg database size verify: .*checkpoint size')):
+            self.open_conn(config=self._follower_config())
+
+        # Reopen again with checkpoint metadata so startup picks up the latest
+        # checkpoint and runs the database-size verification branch.
+        with self.expectedStdoutPattern(
+            r'disagg database size verify: .*checkpoint size', maxchars=30000):
+            self.reopen_conn(config=self._follower_config(checkpoint_meta))
+
+        # test_layered*.py modules run layered verify during teardown. Ignore the
+        # resulting verify verbosity so teardown only checks this test's output.
+        self.ignoreStdoutPattern(r'WT_SESSION\.verify: \[WT_VERB_VERIFY\]')


### PR DESCRIPTION
This change is a follow up work, stemming from [WT-17362](https://jira.mongodb.org/browse/WT-17362).
- refactor startup cleanup and verification into separate function
- make sure to use internal session for cleanup and verifications
- add unit tests