### PR TITLE
WT-17404 Fix prepare state store ordering on weakly-ordered architectures

### DIFF
--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -204,7 +204,15 @@ __txn_apply_prepare_state_update(
          *
          * As updating timestamp might not be an atomic operation, we will manage using state.
          */
-        __wt_atomic_store_uint8_v_release(&upd->prepare_state, WT_PREPARE_LOCKED);
+        __wt_atomic_store_uint8_v_relaxed(&upd->prepare_state, WT_PREPARE_LOCKED);
+        /*
+         * A release store would only prevent prior writes from being reordered after it; it would
+         * not prevent the subsequent timestamp writes from being reordered before it on
+         * weakly-ordered architectures. The explicit release barrier ensures this prepare state
+         * write is ordered before any timestamp field is modified, so a concurrent reader can never
+         * observe updated timestamps while the prepare state appears unchanged.
+         */
+        WT_RELEASE_BARRIER();
         /*
          * Ensure the transaction id from the prepared update in the ingest btree is propagated
          * during step-up in disagg to maintain correct transaction visibility both during and after

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1099,6 +1099,13 @@ __txn_resolve_prepared_update_chain(
     if (!commit) {
         /* As updating timestamp might not be an atomic operation, we will manage using state. */
         __wt_atomic_store_uint8_v_relaxed(&upd->prepare_state, WT_PREPARE_LOCKED);
+        /*
+         * A release store would only prevent prior writes from being reordered after it; it would
+         * not prevent the subsequent timestamp writes from being reordered before it on
+         * weakly-ordered architectures. The explicit release barrier ensures this prepare state
+         * write is ordered before any timestamp field is modified, so a concurrent reader can never
+         * observe updated timestamps while the prepare state appears unchanged.
+         */
         WT_RELEASE_BARRIER();
         if (F_ISSET(txn_time_point, WT_TXN_TIME_POINT_HAS_TS_ROLLBACK))
             __wt_atomic_store_uint64_relaxed(


### PR DESCRIPTION
## Summary

- Replace `__wt_atomic_store_uint8_v_release` of `WT_PREPARE_LOCKED` with a relaxed store + explicit `WT_RELEASE_BARRIER()` in both `txn_inline.h` and `txn.c`
- A release store only prevents prior writes from being reordered after it; on weakly-ordered architectures (ARM, POWER) subsequent timestamp writes could still be reordered before the prepare state store
- The explicit barrier ensures the prepare state write is ordered before any timestamp field is modified, so a concurrent reader cannot observe updated timestamps while the prepare state appears unchanged
- Add comment explaining the ordering rationale