### PR TITLE
WT-15371 Exclude shared metadata from WT_REC_HS in evict_file close path

### DIFF
--- a/src/evict/evict_file.c
+++ b/src/evict/evict_file.c
@@ -83,12 +83,13 @@ __wt_evict_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
         if (syncop == WT_SYNC_CLOSE && __wt_page_is_modified(page)) {
             /*
              * When setting the reconciliation flags, remember to not enable history store eviction
-             * for the history store file itself. Also metadata file doesn't have any associated
-             * history.
+             * for the history store file itself. Also metadata file and disaggregated shared
+             * metadata don't have any associated history.
              */
             rec_flags = WT_REC_EVICT | WT_REC_EVICT_CALL_CLOSING | WT_REC_CLEAN_AFTER_REC |
               WT_REC_VISIBLE_NO_SNAPSHOT;
-            if (!WT_IS_HS(btree->dhandle) && !WT_IS_METADATA(dhandle))
+            if (!WT_IS_HS(btree->dhandle) && !WT_IS_METADATA(dhandle) &&
+              !WT_IS_DISAGG_META(dhandle))
                 rec_flags |= WT_REC_HS;
             WT_ERR(__wt_reconcile(session, ref, NULL, rec_flags));
         }

--- a/test/suite/hook_disagg.fail
+++ b/test/suite/hook_disagg.fail
@@ -21,7 +21,6 @@ test_encrypt06.py
 test_env01.py
 test_error_info01.py
 test_error_info03.py    # FIXME: WT-16872
-test_hs01.py  # FIXME: WT-15371
 test_hs24.py    # FIXME: WT-16872
 test_hs_evict_race01.py # FIXME: WT-16872
 test_log03.py

--- a/test/suite/hook_disagg.fail
+++ b/test/suite/hook_disagg.fail
@@ -21,6 +21,7 @@ test_encrypt06.py
 test_env01.py
 test_error_info01.py
 test_error_info03.py    # FIXME: WT-16872
+test_hs01.py  # FIXME: WT-15371 Scenario 3 durable_check fails: disagg skips recovery RTS but doesn't use precise checkpoint (FIXME-WT-14721), so unstable updates (ts > stable) survive on disk
 test_hs24.py    # FIXME: WT-16872
 test_hs_evict_race01.py # FIXME: WT-16872
 test_log03.py

--- a/test/suite/hook_disagg.fail
+++ b/test/suite/hook_disagg.fail
@@ -21,7 +21,6 @@ test_encrypt06.py
 test_env01.py
 test_error_info01.py
 test_error_info03.py    # FIXME: WT-16872
-test_hs01.py  # FIXME: WT-15371 Scenario 3 durable_check fails: disagg skips recovery RTS but doesn't use precise checkpoint (FIXME-WT-14721), so unstable updates (ts > stable) survive on disk
 test_hs24.py    # FIXME: WT-16872
 test_hs_evict_race01.py # FIXME: WT-16872
 test_log03.py

--- a/test/suite/test_hs01.py
+++ b/test/suite/test_hs01.py
@@ -111,7 +111,7 @@ class test_hs01(wttest.WiredTigerTestCase):
     def test_hs(self):
         # disagg skips recovery RTS; without precise_checkpoint the stable btree checkpoint
         # writes unstable updates to disk, so durable_check would return the wrong value.
-        if hasattr(self, 'disagg_leader') and not self.precise_checkpoint:
+        if getattr(self, 'disagg_leader', False) and not self.precise_checkpoint:
             self.skipTest('disagg mode requires precise_checkpoint for durable_check')
 
         # Create a small table.

--- a/test/suite/test_hs01.py
+++ b/test/suite/test_hs01.py
@@ -36,14 +36,24 @@ from wtscenario import make_scenarios
 # Test that update and modify operations are durable across crash and recovery.
 # Additionally test that checkpoint inserts content into the history store.
 class test_hs01(wttest.WiredTigerTestCase):
-    conn_config = 'cache_size=200MB,statistics=(all),precise_checkpoint=true'
     format_values = [
         ('column', dict(key_format='r')),
         ('row_integer', dict(key_format='i')),
         ('row_string', dict(key_format='S'))
     ]
+    precise_checkpoint_values = [
+        ('precise_checkpoint', dict(precise_checkpoint=True)),
+        ('no_precise_checkpoint', dict(precise_checkpoint=False)),
+    ]
     value_format='u'
-    scenarios = make_scenarios(format_values)
+    scenarios = make_scenarios(format_values, precise_checkpoint_values)
+
+    @property
+    def conn_config(self):
+        config = 'cache_size=200MB,statistics=(all)'
+        if self.precise_checkpoint:
+            config += ',precise_checkpoint=true'
+        return config
 
     def get_stat(self, stat):
         stat_cursor = self.session.open_cursor('statistics:')
@@ -99,6 +109,11 @@ class test_hs01(wttest.WiredTigerTestCase):
         conn.close()
 
     def test_hs(self):
+        # disagg skips recovery RTS; without precise_checkpoint the stable btree checkpoint
+        # writes unstable updates to disk, so durable_check would return the wrong value.
+        if hasattr(self, 'disagg_leader') and not self.precise_checkpoint:
+            self.skipTest('disagg mode requires precise_checkpoint for durable_check')
+
         # Create a small table.
         uri = "table:test_hs01"
         ds = SimpleDataSet(self, uri, 0, key_format=self.key_format, value_format=self.value_format)
@@ -171,10 +186,16 @@ class test_hs01(wttest.WiredTigerTestCase):
         self.large_updates(self.session, uri, bigvalue4, ds, nrows, timestamp=True)
 
         self.session.checkpoint()
-        # precise_checkpoint keeps unstable updates (bigvalue4, ts > stable=1) in memory,
-        # so no new HS inserts. Count stays at (nrows-1)*3 from the previous scenario.
         hs_writes = self.get_stat(stat.conn.cache_hs_insert)
-        self.assertEqual(hs_writes, (nrows-1) * 3)
+        if self.precise_checkpoint:
+            # Unstable updates (bigvalue4, ts > stable=1) stay in memory; no new HS inserts.
+            # Count stays at (nrows-1)*3 from the previous scenario.
+            self.assertEqual(hs_writes, (nrows-1) * 3)
+        else:
+            # Unstable updates are moved to HS to preserve them for readers at stable_timestamp.
+            # The stats was already set at: (nrows-1)*3 (previous hs stats)
+            # Total: (nrows-1)*4
+            self.assertEqual(hs_writes, (nrows-1) * 4)
 
         # Check to see data can be see only till the stable_timestamp.
         self.durable_check(bigvalue3, uri, ds)

--- a/test/suite/test_hs01.py
+++ b/test/suite/test_hs01.py
@@ -43,7 +43,7 @@ class test_hs01(wttest.WiredTigerTestCase):
     ]
     precise_checkpoint_values = [
         ('precise_checkpoint', dict(precise_checkpoint=True)),
-        ('no_precise_checkpoint', dict(precise_checkpoint=False)),
+        ('fuzzy_checkpoint', dict(precise_checkpoint=False)),
     ]
     value_format='u'
     scenarios = make_scenarios(format_values, precise_checkpoint_values)

--- a/test/suite/test_hs01.py
+++ b/test/suite/test_hs01.py
@@ -111,7 +111,7 @@ class test_hs01(wttest.WiredTigerTestCase):
     def test_hs(self):
         # disagg skips recovery RTS; without precise_checkpoint the stable btree checkpoint
         # writes unstable updates to disk, so durable_check would return the wrong value.
-        if getattr(self, 'disagg_leader', False) and not self.precise_checkpoint:
+        if self.runningHook('disagg') and not self.precise_checkpoint:
             self.skipTest('disagg mode requires precise_checkpoint for durable_check')
 
         # Create a small table.

--- a/test/suite/test_hs01.py
+++ b/test/suite/test_hs01.py
@@ -133,6 +133,9 @@ class test_hs01(wttest.WiredTigerTestCase):
             cursor.set_value(bigvalue)
             self.assertEqual(cursor.insert(), 0)
         cursor.close()
+        # precise_checkpoint requires stable_timestamp to be set before any checkpoint.
+        # All writes above are no-timestamp so stable=1 is safe here.
+        self.conn.set_timestamp('stable_timestamp=1')
         self.session.checkpoint()
 
         # Scenario: 1

--- a/test/suite/test_hs01.py
+++ b/test/suite/test_hs01.py
@@ -171,11 +171,8 @@ class test_hs01(wttest.WiredTigerTestCase):
         self.large_updates(self.session, uri, bigvalue4, ds, nrows, timestamp=True)
 
         self.session.checkpoint()
-        # With precise_checkpoint enabled, updates with commit_timestamp > stable_timestamp stay
-        # in memory rather than being moved to the history store. bigvalue4 (timestamp i+1 for
-        # key i, all > stable=1) is not written to disk, so no new HS inserts happen here.
-        # The stats was already set at: (nrows-1)*3 (previous hs stats)
-        # Total: (nrows-1)*3 (unchanged)
+        # precise_checkpoint keeps unstable updates (bigvalue4, ts > stable=1) in memory,
+        # so no new HS inserts. Count stays at (nrows-1)*3 from the previous scenario.
         hs_writes = self.get_stat(stat.conn.cache_hs_insert)
         self.assertEqual(hs_writes, (nrows-1) * 3)
 

--- a/test/suite/test_hs01.py
+++ b/test/suite/test_hs01.py
@@ -36,7 +36,7 @@ from wtscenario import make_scenarios
 # Test that update and modify operations are durable across crash and recovery.
 # Additionally test that checkpoint inserts content into the history store.
 class test_hs01(wttest.WiredTigerTestCase):
-    conn_config = 'cache_size=200MB,statistics=(all)'
+    conn_config = 'cache_size=200MB,statistics=(all),precise_checkpoint=true'
     format_values = [
         ('column', dict(key_format='r')),
         ('row_integer', dict(key_format='i')),
@@ -171,11 +171,13 @@ class test_hs01(wttest.WiredTigerTestCase):
         self.large_updates(self.session, uri, bigvalue4, ds, nrows, timestamp=True)
 
         self.session.checkpoint()
-        # Check if the (nrows-1) modifications were moved to history store from data store.
+        # With precise_checkpoint enabled, updates with commit_timestamp > stable_timestamp stay
+        # in memory rather than being moved to the history store. bigvalue4 (timestamp i+1 for
+        # key i, all > stable=1) is not written to disk, so no new HS inserts happen here.
         # The stats was already set at: (nrows-1)*3 (previous hs stats)
-        # Total: (nrows-1)*4
+        # Total: (nrows-1)*3 (unchanged)
         hs_writes = self.get_stat(stat.conn.cache_hs_insert)
-        self.assertEqual(hs_writes, (nrows-1) * 4)
+        self.assertEqual(hs_writes, (nrows-1) * 3)
 
         # Check to see data can be see only till the stable_timestamp.
         self.durable_check(bigvalue3, uri, ds)


### PR DESCRIPTION
## Summary

- **Root cause**: `bt_sync.c` was missing `!WT_IS_DISAGG_META` in the `WT_REC_HS` gate, so the disagg shared metadata (`WiredTigerShared.wt_stable`) had `WT_REC_HS` set during checkpoint. With a pinning reader open, its 2 updated entries generated 2 extra HS inserts, producing `cache_hs_insert = 10001` instead of the expected `9999`. That was fixed by WT-15117.

- **This PR** fixes the same missing guard in `evict_file.c` (`WT_SYNC_CLOSE` path), which was also overlooked by WT-15117. Without it, closing a disagg metadata btree with dirty pages sets `WT_REC_HS`, which triggers the `WT_ASSERT_ALWAYS` in `__rec_hs_wrapup` and panics. `evict_page.c` already had the guard; `evict_file.c` did not.

- Removes `test_hs01.py` from `hook_disagg.fail` now that WT-15117 (merged Feb 2026) fixed the checkpoint-time gate.