### PR TITLE
WT-17408 Move WT_IS_HS and WT_IS_DISAGG_META macros to meta.h

### DIFF
--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -159,11 +159,5 @@ struct __wt_cache_pool {
     uint8_t flags;
 };
 
-/*
- * Optimize comparisons against the history store URI, flag handles that reference the history store
- * file.
- */
-#define WT_IS_HS(dh) F_ISSET(dh, WT_DHANDLE_HS)
-
 /* Optimize comparisons against the shared metadata store for disaggregated storage. */
 #define WT_IS_DISAGG_META(dh) F_ISSET(dh, WT_DHANDLE_DISAGG_META)

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -158,4 +158,3 @@ struct __wt_cache_pool {
                                   /* AUTOMATIC FLAG VALUE GENERATION STOP 8 */
     uint8_t flags;
 };
-

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -159,5 +159,3 @@ struct __wt_cache_pool {
     uint8_t flags;
 };
 
-/* Optimize comparisons against the shared metadata store for disaggregated storage. */
-#define WT_IS_DISAGG_META(dh) F_ISSET(dh, WT_DHANDLE_DISAGG_META)

--- a/src/include/meta.h
+++ b/src/include/meta.h
@@ -87,6 +87,9 @@
  */
 #define WT_IS_HS(dh) F_ISSET(dh, WT_DHANDLE_HS)
 
+/* Optimize comparisons against the shared metadata store for disaggregated storage. */
+#define WT_IS_DISAGG_META(dh) F_ISSET(dh, WT_DHANDLE_DISAGG_META)
+
 #define WT_METAFILE_ID 0 /* Metadata file ID */
 
 #define WT_METADATA_COMPAT "Compatibility version"

--- a/src/include/meta.h
+++ b/src/include/meta.h
@@ -80,15 +80,13 @@
  * Optimize comparisons against the metafile URI, flag handles that reference the metadata file.
  */
 #define WT_IS_METADATA(dh) F_ISSET((dh), WT_DHANDLE_IS_METADATA)
+#define WT_IS_DISAGG_META(dh) F_ISSET(dh, WT_DHANDLE_DISAGG_META)
 
 /*
  * Optimize comparisons against the history store URI, flag handles that reference the history store
  * file.
  */
 #define WT_IS_HS(dh) F_ISSET(dh, WT_DHANDLE_HS)
-
-/* Optimize comparisons against the shared metadata store for disaggregated storage. */
-#define WT_IS_DISAGG_META(dh) F_ISSET(dh, WT_DHANDLE_DISAGG_META)
 
 #define WT_METAFILE_ID 0 /* Metadata file ID */
 

--- a/src/include/meta.h
+++ b/src/include/meta.h
@@ -80,6 +80,13 @@
  * Optimize comparisons against the metafile URI, flag handles that reference the metadata file.
  */
 #define WT_IS_METADATA(dh) F_ISSET((dh), WT_DHANDLE_IS_METADATA)
+
+/*
+ * Optimize comparisons against the history store URI, flag handles that reference the history store
+ * file.
+ */
+#define WT_IS_HS(dh) F_ISSET(dh, WT_DHANDLE_HS)
+
 #define WT_METAFILE_ID 0 /* Metadata file ID */
 
 #define WT_METADATA_COMPAT "Compatibility version"


### PR DESCRIPTION
## Summary
- `WT_IS_HS` and `WT_IS_DISAGG_META` are dhandle identity-check macros that follow the exact same pattern as `WT_IS_METADATA`, which already lives in `meta.h`
- Both macros were defined at the end of `cache.h` for historical reasons, with no logical connection to cache internals
- Moving them to `meta.h` groups all three dhandle identity checks together for consistency and discoverability
- No include-chain changes required: both headers are pulled in via `wt_internal.h`

## Testing
No test files touched — this is a pure header reorganisation with no behavioural change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)