### PR TITLE
WT-16379 Add record length check to avoid overflow in round up (8.0)

### DIFF
--- a/src/log/log.c
+++ b/src/log/log.c
@@ -2271,6 +2271,15 @@ advance:
         reclen = __wt_bswap32(reclen);
 #endif
         /*
+         * If the record length is larger than the remaining bytes to EOF from the records offset,
+         * flag log file corruption.
+         */
+        if (reclen > log_size - __wt_lsn_offset(&rd_lsn)) {
+            need_salvage = true;
+            WT_ERR(__log_salvage_message(
+              session, log_fh->name, " record length oversize", __wt_lsn_offset(&rd_lsn)));
+        }
+        /*
          * Log files are pre-allocated. We need to detect the difference between a hole in the file
          * (where this location would be considered the end of log) and the last record in the log
          * and we're at the zeroed part of the file. If we find a zeroed record, scan forward in the

--- a/src/support/pow.c
+++ b/src/support/pow.c
@@ -121,6 +121,8 @@ __wt_rduppo2(uint32_t n, uint32_t po2)
     if (__wt_ispo2(po2)) {
         bits = __wt_log2_int(po2);
         res = (((n - 1) >> bits) + 1) << bits;
+        /* This assert is designed to avoid overflow for large values. */
+        WT_ASSERT(NULL, res >= n);
     } else
         res = 0;
     return (res);

--- a/test/suite/helper.py
+++ b/test/suite/helper.py
@@ -156,3 +156,19 @@ def simulate_crash_restart(testcase, olddir, newdir):
     testcase.close_conn()
     testcase.conn = testcase.setUpConnectionOpen(newdir)
     testcase.session = testcase.setUpSessionOpen(testcase.conn)
+
+class WiredTigerCursor:
+    def __init__(self, session, uri, *args, **kwargs):
+        self.session = session
+        self.uri = uri
+        self.args = args
+        self.kwargs = kwargs
+        self.cursor = None
+
+    def __enter__(self):
+        self.cursor = self.session.open_cursor(self.uri, *self.args, **self.kwargs)
+        return self.cursor
+
+    def __exit__(self, exception_type, exception_value, exception_traceback):
+        if self.cursor is not None:
+            self.cursor.close()

--- a/test/suite/test_log05.py
+++ b/test/suite/test_log05.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import os, re, struct
+import wttest
+from helper import WiredTigerCursor
+
+# test_log05.py
+#    This test simulates log file corruption by manually setting
+#    a log records length field to UINT32_MAX. The expected behavior is that
+#    the record-length validation fails, salvage is invoked, and recovery
+#    completes successfully. By repeating this recovery cycle,
+#    the test also verifies that recovery does not create additional log files
+#    and that disk space usage remains stable.
+class test_log05(wttest.WiredTigerTestCase):
+
+    uri = 'table:log05'
+
+    conn_config = 'log=(enabled=true)'
+
+    WT_TURTLE_FILE_NAME = "WiredTiger.turtle"
+    WT_LOG_FILE = "WiredTigerLog.0000000%03d"
+
+    test_round = 20
+
+    def extract_key_from_turtle(self, line, key):
+        m = re.search(key + r'=\(\s*(\d+)\s*,\s*(\d+)\s*\)', line)
+        if not m:
+            return None
+        file_num, offset = map(int, m.groups())
+        return (file_num, offset)
+
+    def inject_fault_to_log(self, id):
+        # Read checkpoint_lsn from turtle file.
+        # The checkpoint_lsn points to the byte offset (in its log file)
+        # of the checkpoint log record structure.
+        with open(self.WT_TURTLE_FILE_NAME, 'r') as f:
+            lines = f.read().splitlines()
+            self.turtle_file = lines
+        for line in lines:
+            value = self.extract_key_from_turtle(line, 'checkpoint_lsn')
+            if value is not None:
+                break
+        self.assertTrue(value is not None, "Checkpoint lsn is missing in turtle file")
+        _, offset = value
+        # The first four bytes of each log record are parsed as a 32-bit unsigned length.
+        # To simulate corruption, overwrite these bytes to UINT32_MAX.
+        with open(self.WT_LOG_FILE % id, 'r+b') as f:
+            f.seek(offset)
+            f.write(struct.pack('<I', 0xFFFFFFFF))
+
+    def test_duplicate_logs(self):
+        self.session.create(self.uri, "key_format=S,value_format=S")
+        self.session.begin_transaction()
+        with WiredTigerCursor(self.session, self.uri) as c:
+            for i in range(1000):
+                c[f'key_{i}'] = f'val_{i}'
+        self.session.commit_transaction()
+
+        for i in range(self.test_round):
+            self.close_conn()
+            self.inject_fault_to_log(i+1)
+            with self.expectedStdoutPattern("corrupted record length oversize at position"):
+                self.open_conn()
+
+        logs_count = 0
+        for i in range(self.test_round):
+            if os.path.exists(self.WT_LOG_FILE % (i+1)):
+                logs_count += 1
+
+        # This assert aims to make sure no redundant log file is generated.
+        self.assertLessEqual(logs_count, 1, "We should have at most 1 log file")

--- a/test/suite/test_txn19.py
+++ b/test/suite/test_txn19.py
@@ -34,7 +34,7 @@
 #   Transactions: test recovery with corrupted log files
 #
 
-import os
+import os, re
 from wtscenario import make_scenarios
 from suite_subprocess import suite_subprocess
 import helper, wiredtiger, wttest
@@ -298,6 +298,10 @@ class test_txn19(wttest.WiredTigerTestCase, suite_subprocess):
                     self.reopen_conn(newdir, self.base_config)
             else:
                 self.reopen_conn(newdir, self.base_config)
+                # The test may corrupt logs, ignore the error messages.
+                out_text = self.readStdout()
+                if re.search('log file .* corrupted record length oversize', out_text):
+                    self.cleanStdout()
             self.close_conn()
 
         found_records = self.recovered_records()


### PR DESCRIPTION
Add a record length check to avoid `overflow` with roundup operation, also add assert to the function to identify potential overflow in the future.

Also add a new test case to modify the record length binary directly to trigger the check.