### PR TITLE
Revert "WT-17347 Remove the queue-wide write lock when applying commit metadata to truncate entry"

### DIFF
--- a/src/include/schema.h
+++ b/src/include/schema.h
@@ -80,8 +80,6 @@ struct __wt_truncate {
     wt_timestamp_t prepare_ts; /* Not currently supported. */
     uint64_t prepare_id;       /* Not currently supported. */
 
-    wt_shared bool committed; /* Whether the truncate entry has been committed. */
-
     WT_ITEM start_key;
     WT_ITEM stop_key;
 
@@ -116,11 +114,7 @@ struct __wt_layered_table {
      */
     TAILQ_HEAD(__truncate_table_list_qh, __wt_truncate) truncateqh;
 
-    /*
-     * Protects truncate list membership (insert/remove/clear). Per-entry visibility is synchronized
-     * lock-free via WT_TRUNCATE.committed.
-     */
-    WT_RWLOCK truncate_lock;
+    WT_RWLOCK truncate_lock; /* Protects truncate list membership and entry visibility metadata. */
 
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */
 #define WT_LAYERED_TABLE_OPEN 0x1u

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -787,7 +787,6 @@ __wt_txn_truncate(WT_SESSION_IMPL *session, WT_TRUNCATE *t)
 
     WT_RET(__txn_next_op(session, &op));
     op->type = WT_TXN_OP_FOLLOWER_TRUNCATE;
-    WT_ASSERT(session, t->txn_id == WT_TXN_NONE);
     t->txn_id = session->txn->time_point.id;
 
     op->u.follower_truncate.t = t;

--- a/src/txn/txn_truncate.c
+++ b/src/txn/txn_truncate.c
@@ -163,23 +163,6 @@ err:
 }
 
 /*
- * __truncate_read_entry_timestamps --
- *     Read a stable snapshot of truncate entry's commit timestamps.
- */
-static void
-__truncate_read_entry_timestamps(
-  WT_TRUNCATE *entry, wt_timestamp_t *start_tsp, wt_timestamp_t *durable_tsp)
-{
-    const bool committed = __wt_atomic_load_bool_acquire(&entry->committed);
-
-    if (committed) {
-        *start_tsp = entry->start_ts;
-        *durable_tsp = entry->durable_ts;
-    } else
-        *start_tsp = *durable_tsp = WT_TS_NONE;
-}
-
-/*
  * __truncate_search --
  *     Walk the layered table truncate list looking for a committed or uncommitted entry (depending
  *     on the search mode) whose range covers the given key. The matched entry is returned through
@@ -190,7 +173,6 @@ __truncate_search(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered_table, con
   const WT_TRUNCATE_SEARCH_MODE mode, WT_TRUNCATE **tp, bool *is_foundp)
 {
     WT_ASSERT(session, is_foundp != NULL);
-    WT_ASSERT(session, __wt_rwlock_islocked(session, &layered_table->truncate_lock));
     *is_foundp = false;
 
     WT_STAT_CONN_INCR(session, layered_truncate_list_search_calls);
@@ -199,10 +181,8 @@ __truncate_search(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered_table, con
     WT_TRUNCATE *entry = NULL;
 
     TAILQ_FOREACH (entry, &layered_table->truncateqh, q) {
-        wt_timestamp_t start_ts, durable_ts;
         WT_STAT_CONN_INCR(session, layered_truncate_list_search_entries_walked);
 
-        __truncate_read_entry_timestamps(entry, &start_ts, &durable_ts);
         const bool is_visible =
           __wt_txn_visible(session, entry->txn_id, entry->start_ts, entry->durable_ts);
 
@@ -322,7 +302,9 @@ __disagg_truncate_apply(WT_SESSION_IMPL *session, WT_TXN_OP *op,
 
 /*
  * __wti_mark_committed_truncate_table_apply --
- *     Mark the entry as committed so it becomes visible to other transactions.
+ *     Stamp commit metadata onto a truncate entry in the provided layered table. The write lock
+ *     serializes readers that walk the truncate list under truncate_lock while checking the entry's
+ *     plain txn/timestamp fields for visibility.
  */
 void
 __wti_mark_committed_truncate_table_apply(
@@ -330,25 +312,15 @@ __wti_mark_committed_truncate_table_apply(
 {
     WT_TRUNCATE *entry = op->u.follower_truncate.t;
 
-    WT_ASSERT(session, __wt_process.disagg_fast_truncate_2026 == true);
-    WT_ASSERT(session, layered_table != NULL);
-    WT_ASSERT(session, entry != NULL);
-    WT_ASSERT(session, entry->txn_id == session->txn->time_point.id);
-    WT_UNUSED(layered_table);
-
-    WT_ASSERT(session, __wt_atomic_load_bool_relaxed(&entry->committed) == false);
-
-    /*-
-     * The transition to committed uses `release` ordering to:
-     * - fence the timestamp writes before the state change,
-     * - signal readers waiting on the state change that the entry is now committed.
-     *
-     * Readers must use `acquire` ordering when loading the committed flag to ensure they see
-     * the committed timestamps.
+    /*
+     * FIXME-WT-17347 Remove the queue-wide write lock when applying commit metadata to truncate
+     * entry
      */
+    __wt_writelock(session, &layered_table->truncate_lock);
+    entry->txn_id = session->txn->time_point.id;
     entry->start_ts = session->txn->time_point.commit_timestamp;
     entry->durable_ts = session->txn->time_point.durable_timestamp;
-    __wt_atomic_store_bool_release(&entry->committed, true);
+    __wt_writeunlock(session, &layered_table->truncate_lock);
 }
 
 /*

--- a/test/catch2/truncate/test_layered_truncate_visibility.cpp
+++ b/test/catch2/truncate/test_layered_truncate_visibility.cpp
@@ -47,6 +47,7 @@ public:
         REQUIRE(__wt_rwlock_init(session, &layered_table.truncate_lock) == 0);
 
         __wt_process.disagg_fast_truncate_2026 = true;
+        set_reader(50, WT_TS_NONE);
     }
 
     ~layered_truncate_visibility_fixture()
@@ -59,21 +60,19 @@ public:
     }
 
     /*
-     * Reset the mock transaction into a snapshot reader state for visibility checks. By default,
-     * snap_min/snap_max stay at 100/200 so tests can classify txn ids below 100 as already visible
-     * and ids at or above 200 as still in-flight without building an explicit snapshot array, while
-     * still allowing tests to override the snapshot window when needed.
+     * Reset the mock transaction into a snapshot reader state for visibility checks. The fixture
+     * keeps snap_min/snap_max fixed at 100/200 so tests can classify txn ids below 100 as already
+     * visible and ids at or above 200 as still in-flight without building an explicit snapshot
+     * array.
      */
     void
-    set_reader(uint64_t txn_id, wt_timestamp_t read_timestamp,
-      WT_TXN_ISOLATION isolation = WT_ISO_SNAPSHOT, uint64_t snap_min = 100,
-      uint64_t snap_max = 200)
+    set_reader(uint64_t txn_id, wt_timestamp_t read_timestamp)
     {
         WT_CLEAR(*session->txn);
 
-        session->txn->isolation = isolation;
-        session->txn->snapshot_data.snap_min = snap_min;
-        session->txn->snapshot_data.snap_max = snap_max;
+        session->txn->isolation = WT_ISO_SNAPSHOT;
+        session->txn->snapshot_data.snap_min = 100;
+        session->txn->snapshot_data.snap_max = 200;
         session->txn->snapshot_data.snapshot = nullptr;
         session->txn->snapshot_data.snapshot_count = 0;
         F_SET(session->txn, WT_TXN_HAS_SNAPSHOT);
@@ -119,10 +118,11 @@ public:
         entry->txn_id = txn_id;
         entry->start_ts = start_ts;
         entry->durable_ts = durable_ts;
-        entry->committed = (start_ts != WT_TS_NONE || durable_ts != WT_TS_NONE);
 
-        REQUIRE(__wt_buf_set(session, &entry->start_key, start, strlen(start)) == 0);
-        REQUIRE(__wt_buf_set(session, &entry->stop_key, stop, strlen(stop)) == 0);
+        if (start != nullptr)
+            REQUIRE(__wt_buf_set(session, &entry->start_key, start, strlen(start)) == 0);
+        if (stop != nullptr)
+            REQUIRE(__wt_buf_set(session, &entry->stop_key, stop, strlen(stop)) == 0);
 
         TAILQ_INSERT_TAIL(&layered_table.truncateqh, entry, q);
         return entry;
@@ -153,7 +153,6 @@ TEST_CASE_METHOD(
 
     WT_TRUNCATE *matched = nullptr;
     const char *key = "0150";
-    set_reader(txn_id, WT_TS_NONE);
     REQUIRE(truncate_visible(key, &matched) == 0);
     REQUIRE(matched != nullptr);
 
@@ -276,123 +275,52 @@ TEST_CASE_METHOD(layered_truncate_visibility_fixture, "truncate commit stamps th
     const wt_timestamp_t durable_ts = WT_TS_NONE;
     const char *start = "0100";
     const char *stop = "0200";
-    const char *key = "0125";
 
-    /* Truncate at txn 250: uncommitted. */
-    WT_TRUNCATE *committed = add_truncate(txn_id, start_ts, durable_ts, start, stop);
-
-    txn_id = 60;
-    wt_timestamp_t read_timestamp = 30;
-
-    /* Reader txn 60 sees no truncate yet: txn 250 is still uncommitted. */
-    set_reader(txn_id, read_timestamp);
-    REQUIRE(truncate_visible(key) == WT_NOTFOUND);
-
-    txn_id = 250;
-    const wt_timestamp_t commit_timestamp = 30;
-    const wt_timestamp_t durable_timestamp = 40;
-
-    /* Set txn 250's commit state so the entry can be stamped. */
-    set_committer(txn_id, commit_timestamp, durable_timestamp);
-
-    WT_TXN_OP op{};
-    op.u.follower_truncate.t = committed;
-
-    /* Publish the entry: commit_ts=30, durable_ts=40, committed. */
-    __wti_mark_committed_truncate_table_apply(session, &layered_table, &op);
-    REQUIRE(committed->txn_id == txn_id);
-    REQUIRE(committed->start_ts == commit_timestamp);
-    REQUIRE(committed->durable_ts == durable_timestamp);
-    REQUIRE(committed->committed);
-
-    txn_id = 60;
-    read_timestamp = 30;
-
-    /* Read ts 30 is below durable_ts=40, so the published truncate stays hidden. */
-    set_reader(txn_id, read_timestamp);
-    REQUIRE(truncate_visible(key) == WT_NOTFOUND);
-
-    read_timestamp = 40;
-
-    /* Read ts 40 reaches durability, but txn 250 is still in-flight to this snapshot (100-200). */
-    set_reader(txn_id, read_timestamp);
-    REQUIRE(truncate_visible(key) == WT_NOTFOUND);
-
-    txn_id = 300;
-
-    /* With snap_min=300, txn 250 is visible and its published truncate matches the key. */
-    set_reader(txn_id, read_timestamp, WT_ISO_SNAPSHOT, 300, 400);
-    WT_TRUNCATE *matched = nullptr;
-    REQUIRE(truncate_visible(key, &matched) == 0);
-    REQUIRE(matched == committed);
-}
-
-TEST_CASE_METHOD(layered_truncate_visibility_fixture,
-  "truncate commits that overlap honor visibility", "[layered][truncate]")
-{
-    uint64_t txn_id = 250;
-    const wt_timestamp_t start_ts = WT_TS_NONE;
-    const wt_timestamp_t durable_ts = WT_TS_NONE;
-    const char *start = "0100";
-    const char *stop = "0200";
-
-    /* Truncate at txn 250: uncommitted. */
     WT_TRUNCATE *committed = add_truncate(txn_id, start_ts, durable_ts, start, stop);
 
     const uint64_t overlapping_txn_id = 10;
     const wt_timestamp_t overlapping_start_ts = 40;
     const wt_timestamp_t overlapping_durable_ts = 40;
-
-    /* Truncate at txn 10: already committed, over 0150-0300. */
     WT_TRUNCATE *overlapping = add_truncate(
       overlapping_txn_id, overlapping_start_ts, overlapping_durable_ts, "0150", "0300");
 
     txn_id = 60;
     wt_timestamp_t read_timestamp = 30;
+    const char *target_only_key = "0125";
     const char *overlap_key = "0175";
     const char *overlap_only_key = "0250";
 
-    /* At read ts 30, the published overlap is too new and txn 250 is still uncommitted. */
     set_reader(txn_id, read_timestamp);
+    REQUIRE(truncate_visible(target_only_key) == WT_NOTFOUND);
     REQUIRE(truncate_visible(overlap_key) == WT_NOTFOUND);
     REQUIRE(truncate_visible(overlap_only_key) == WT_NOTFOUND);
 
-    txn_id = 250;
+    txn_id = 90;
     const wt_timestamp_t commit_timestamp = 30;
     const wt_timestamp_t durable_timestamp = 40;
 
-    /* Set txn 250's commit state so the entry can be stamped. */
     set_committer(txn_id, commit_timestamp, durable_timestamp);
 
     WT_TXN_OP op{};
     op.u.follower_truncate.t = committed;
 
-    /* Publish txn 250's entry; both truncates are now durable at ts 40. */
     __wti_mark_committed_truncate_table_apply(session, &layered_table, &op);
+    REQUIRE(committed->txn_id == 90);
+    REQUIRE(committed->start_ts == 30);
+    REQUIRE(committed->durable_ts == 40);
+    REQUIRE(overlapping->txn_id == overlapping_txn_id);
+    REQUIRE(overlapping->start_ts == overlapping_start_ts);
+    REQUIRE(overlapping->durable_ts == overlapping_durable_ts);
 
     txn_id = 60;
-    read_timestamp = 40;
-    const char *target_only_key = "0125";
-
-    /* At read ts 40, txn 250 is still in-flight, so only the older visible overlap can match. */
+    read_timestamp = 30;
     set_reader(txn_id, read_timestamp);
-    REQUIRE(truncate_visible(target_only_key) == WT_NOTFOUND);
+    REQUIRE(truncate_visible(target_only_key) == 0);
 
     WT_TRUNCATE *matched = nullptr;
     REQUIRE(truncate_visible(overlap_key, &matched) == 0);
-    REQUIRE(matched == overlapping);
-    REQUIRE(truncate_visible(overlap_only_key) == 0);
-
-    txn_id = 300;
-
-    /* With snap_min 300, txn 250 becomes visible and wins on the shared key range. */
-    set_reader(txn_id, read_timestamp, WT_ISO_SNAPSHOT, 300, 400);
-    REQUIRE(truncate_visible(target_only_key) == 0);
-
-    matched = nullptr;
-    REQUIRE(truncate_visible(overlap_key, &matched) == 0);
     REQUIRE(matched == committed);
-    REQUIRE(truncate_visible(overlap_only_key) == 0);
+    REQUIRE(truncate_visible(overlap_only_key) == WT_NOTFOUND);
 }
 
 TEST_CASE_METHOD(layered_truncate_visibility_fixture,
@@ -421,7 +349,6 @@ TEST_CASE_METHOD(layered_truncate_visibility_fixture,
     REQUIRE(TAILQ_NEXT(surviving, q) == nullptr);
 
     const char *key = "0125";
-    set_reader(50, WT_TS_NONE);
     REQUIRE(truncate_visible(key) == WT_NOTFOUND);
 
     WT_TRUNCATE *matched = nullptr;

--- a/test/suite/test_layered_fast_truncate09.py
+++ b/test/suite/test_layered_fast_truncate09.py
@@ -30,19 +30,19 @@ import wiredtiger, wttest
 from helper_disagg import disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 
-# test_layered_fast_truncate09.py
+# test_layered_fast_truncate07.py
 #   Follower truncate-list visibility coverage.
 @disagg_test_class
-class test_layered_fast_truncate09(wttest.WiredTigerTestCase):
+class test_layered_fast_truncate07(wttest.WiredTigerTestCase):
 
     conn_config = 'disaggregated=(role="leader"),'
 
     uris = [
-        ('layered', dict(uri='layered:test_layered_fast_truncate09')),
-        ('table', dict(uri='table:test_layered_fast_truncate09')),
+        ('layered', dict(uri='layered:test_layered_fast_truncate07')),
+        ('table', dict(uri='table:test_layered_fast_truncate07')),
     ]
 
-    disagg_storages = gen_disagg_storages('test_layered_fast_truncate09', disagg_only=True)
+    disagg_storages = gen_disagg_storages('test_layered_fast_truncate07', disagg_only=True)
     scenarios = make_scenarios(disagg_storages, uris)
 
     nitems = 1000


### PR DESCRIPTION
Reverts wiredtiger/wiredtiger#13688