### PR TITLE
WT-16562 Checkpoint size tech debt cleanup

### DIFF
--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -499,8 +499,7 @@ __disagg_finalize_checkpoint_meta(WT_SESSION_IMPL *session,
     conn->txn_global.last_ckpt_timestamp = metadata->checkpoint_timestamp;
 
     /* Set the database size. */
-    if (ckpt_meta->has_database_size)
-        __wt_disagg_set_database_size(session, ckpt_meta->database_size);
+    __wt_disagg_set_database_size(session, ckpt_meta->database_size);
 
     /* Remember the root config of the last checkpoint. */
     __wt_free(session, conn->disaggregated_storage.last_checkpoint_root);
@@ -732,18 +731,9 @@ __disagg_pick_up_checkpoint_meta(
         __wt_verbose_warning(session, WT_VERB_DISAGGREGATED_STORAGE, "%s\"%s\"",
           "Missing metadata_checksum from metadata: ", meta_str);
 
-    /* Extract the database size, if it exists. */
-    WT_ERR_NOTFOUND_OK(__wt_config_getones(session, meta_str, "database_size", &cval), true);
-    if (WT_CHECK_AND_RESET(ret, 0) && cval.len != 0) {
-        /*
-         * FIXME-WT-16562 Checkpoint size tech debt cleanup. Disagg checkpoint metadata may be
-         * received without database_size. For now we treat this field as optional to avoid crashing
-         * when size information is missing. Once checkpoint size support is fully established, this
-         * fallback path should be removed and database_size made mandatory.
-         */
-        ckpt_meta.has_database_size = true;
-        ckpt_meta.database_size = (uint64_t)cval.val;
-    }
+    /* Extract the database size. */
+    WT_ERR(__wt_config_getones(session, meta_str, "database_size", &cval));
+    ckpt_meta.database_size = (uint64_t)cval.val;
     /* Parse and validate version and compatible_version fields. */
     WT_ERR(__disagg_check_meta_version(session, meta_str, &ckpt_meta));
 

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -237,7 +237,6 @@ typedef struct __wt_disagg_checkpoint_meta {
     uint32_t metadata_checksum; /* The checksum of the metadata page. */
 
     uint64_t database_size; /* The total database size. */
-    bool has_database_size; /* Whether the database size is present. */
     uint32_t version;       /* The version of the checkpoint_meta. */
     uint32_t
       compatible_version; /* The minimum version of the reader that can use this checkpoint_meta. */


### PR DESCRIPTION
Drop the optional parse fallback for `database_size` in `__disagg_pick_up_checkpoint_meta` and make it a required field. Also remove the now redundant `has_database_size` flag from `WT_DISAGG_CHECKPOINT_META` strcut and the conditional in `__disagg_finalize_checkpoint_meta`.