### PR TITLE
WT-17064 Update cache usage accounting for in memory pages

### DIFF
--- a/src/btree/bt_discard.c
+++ b/src/btree/bt_discard.c
@@ -118,9 +118,9 @@ __wt_page_out(WT_SESSION_IMPL *session, WT_PAGE **pagep)
 
     dsk = (WT_PAGE_HEADER *)page->dsk;
     /*
-     * For shared dsk pages the bytes_image_* statistics are owned by the shared dsk cache layer and
+     * For shared disk pages the bytes image statistics are owned by the shared disk cache layer and
      * are drained on the matching last release at the bottom of this function. Skip the per-page
-     * image decrement to avoid double-draining.
+     * image decrement to avoid double draining.
      */
     if (F_ISSET_ATOMIC_16(page, WT_PAGE_DISK_ALLOC) && !WT_PAGE_IS_SHARED_DSK(page))
         __wt_cache_page_image_decr(session, page);
@@ -155,11 +155,12 @@ __wt_page_out(WT_SESSION_IMPL *session, WT_PAGE **pagep)
     }
 
     /*
-     * Discard any allocated disk image. If the page owns shared disk reference, we release it from
-     * shared disk cache. Otherwise free the disk image if it is not a shared disk page.
+     * Discard any allocated disk image. If the page holds a reference to a shared disk image,
+     * release it from the shared disk cache. Otherwise free the disk image if it is not a shared
+     * disk page.
      */
     if (F_ISSET_ATOMIC_16(page, WT_PAGE_DISK_ALLOC)) {
-        if (WT_PAGE_OWNS_SHARED_DSK_REF(page)) {
+        if (WT_PAGE_HAS_SHARED_DSK_REF(page)) {
             WT_ASSERT(session, WT_PAGE_IS_SHARED_DSK(page));
             WT_ASSERT(session, S2C(session)->cache->shared_dsk_cache.enabled);
             WT_ASSERT(session, page->disagg_info->shared_dsk_item->data == dsk);

--- a/src/btree/bt_discard.c
+++ b/src/btree/bt_discard.c
@@ -117,7 +117,12 @@ __wt_page_out(WT_SESSION_IMPL *session, WT_PAGE **pagep)
     __wt_evict_page_cache_bytes_decr(session, page);
 
     dsk = (WT_PAGE_HEADER *)page->dsk;
-    if (F_ISSET_ATOMIC_16(page, WT_PAGE_DISK_ALLOC))
+    /*
+     * For shared dsk pages the bytes_image_* statistics are owned by the shared dsk cache layer and
+     * are drained on the matching last release at the bottom of this function. Skip the per-page
+     * image decrement to avoid double-draining.
+     */
+    if (F_ISSET_ATOMIC_16(page, WT_PAGE_DISK_ALLOC) && !WT_PAGE_IS_SHARED_DSK(page))
         __wt_cache_page_image_decr(session, page);
 
     /* Discard any mapped image. */
@@ -150,17 +155,17 @@ __wt_page_out(WT_SESSION_IMPL *session, WT_PAGE **pagep)
     }
 
     /*
-     * Discard any allocated disk image. When the image is owned by the shared disk cache, release
-     * our reference instead of freeing the memory directly; the cache frees the data once the last
-     * reference is dropped.
+     * Discard any allocated disk image. If the page owns shared disk reference, we release it from
+     * shared disk cache. Otherwise free the disk image if it is not a shared disk page.
      */
     if (F_ISSET_ATOMIC_16(page, WT_PAGE_DISK_ALLOC)) {
-        if (page->disagg_info != NULL && page->disagg_info->shared_dsk_item != NULL) {
+        if (WT_PAGE_OWNS_SHARED_DSK_REF(page)) {
+            WT_ASSERT(session, WT_PAGE_IS_SHARED_DSK(page));
             WT_ASSERT(session, S2C(session)->cache->shared_dsk_cache.enabled);
             WT_ASSERT(session, page->disagg_info->shared_dsk_item->data == dsk);
             WT_ASSERT(session, page->disagg_info->shared_dsk_item->data_size == dsk->mem_size);
             __wt_shared_dsk_cache_release(session, page->disagg_info->shared_dsk_item);
-        } else
+        } else if (!WT_PAGE_IS_SHARED_DSK(page))
             __wt_overwrite_and_free_len(session, dsk, dsk->mem_size);
     }
 

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -1261,9 +1261,9 @@ __wti_page_inmem(WT_SESSION_IMPL *session, WT_REF *ref, const void *image, uint3
     }
 
     /*
-     * Mark the page as tied to the shared dsk cache layer if a shared dsk item was supplied. Set
-     * the local flag before any failure point so if we succeed on __wt_page_alloc and fail later,
-     * __wt_page_out's accounting can identify shared disk pages on the error path.
+     * Mark the page as tied to the shared disk cache layer if a shared disk item was supplied. Set
+     * the local flag before any failure point so if we succeed on page alloc and fail later, page
+     * out accounting can identify shared disk pages on the error path.
      */
     if (shared_dsk_item != NULL)
         LF_SET(WT_PAGE_DISK_SHARED);
@@ -1309,8 +1309,8 @@ __wti_page_inmem(WT_SESSION_IMPL *session, WT_REF *ref, const void *image, uint3
     }
 
     /*
-     * Update the page's cache statistics. For shared dsk pages, cache totals exclude the dsk size
-     * as it is owned by the shared dsk cache layer.
+     * Update the page's cache statistics. For shared disk pages, cache totals exclude the disk size
+     * as it is owned by the shared disk cache layer.
      */
     if (!LF_ISSET(WT_PAGE_DISK_SHARED))
         __wt_cache_page_inmem_incr(session, page, size, false);
@@ -1330,15 +1330,10 @@ __wti_page_inmem(WT_SESSION_IMPL *session, WT_REF *ref, const void *image, uint3
         ref->page = page;
     }
 
-    /*
-     * Hand ownership of shared_dsk_item to the page only on success. If we fail above this point,
-     * the page never owns the reference and the caller's error path is responsible for releasing
-     * it.
-     */
     WT_ASSERT(session, shared_dsk_item == NULL || page->disagg_info != NULL);
     if (page->disagg_info != NULL) {
         page->disagg_info->shared_dsk_item = shared_dsk_item;
-        /* memory_footprint still includes dsk size so per-page eviction logic stays unchanged.*/
+        /* memory footprint still includes disk size so per-page eviction logic stays unchanged. */
         if (LF_ISSET(WT_PAGE_DISK_SHARED))
             __wt_cache_page_footprint_incr(session, page, dsk->mem_size);
     }

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -1262,8 +1262,8 @@ __wti_page_inmem(WT_SESSION_IMPL *session, WT_REF *ref, const void *image, uint3
 
     /*
      * Mark the page as tied to the shared dsk cache layer if a shared dsk item was supplied. Set
-     * the flag before any failure point so __wt_page_out's accounting can identify shared disk
-     * pages on the error path.
+     * the local flag before any failure point so if we succeed on __wt_page_alloc and fail later,
+     * __wt_page_out's accounting can identify shared disk pages on the error path.
      */
     if (shared_dsk_item != NULL)
         LF_SET(WT_PAGE_DISK_SHARED);

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -1260,16 +1260,21 @@ __wti_page_inmem(WT_SESSION_IMPL *session, WT_REF *ref, const void *image, uint3
         return (__wt_illegal_value(session, dsk->type));
     }
 
+    /*
+     * Mark the page as tied to the shared dsk cache layer if a shared dsk item was supplied. Set
+     * the flag before any failure point so __wt_page_out's accounting can identify shared disk
+     * pages on the error path.
+     */
+    if (shared_dsk_item != NULL)
+        LF_SET(WT_PAGE_DISK_SHARED);
+
     /* Allocate and initialize a new WT_PAGE. */
     WT_RET(__wt_page_alloc(session, dsk->type, alloc_entries, true, &page, flags));
     __wt_tsan_suppress_store_wt_page_header_ptr(&page->dsk, dsk);
     F_SET_ATOMIC_16(page, flags);
-    WT_ASSERT(session, shared_dsk_item == NULL || page->disagg_info != NULL);
-    if (page->disagg_info != NULL)
-        page->disagg_info->shared_dsk_item = shared_dsk_item;
 
     /* Update image stats early so it's balanced with __wt_page_out decr if an error fires below. */
-    if (LF_ISSET(WT_PAGE_DISK_ALLOC))
+    if (LF_ISSET(WT_PAGE_DISK_ALLOC) && !LF_ISSET(WT_PAGE_DISK_SHARED))
         __wt_cache_page_image_incr(session, page);
 
     /*
@@ -1303,8 +1308,16 @@ __wti_page_inmem(WT_SESSION_IMPL *session, WT_REF *ref, const void *image, uint3
         WT_ERR(__wt_illegal_value(session, page->type));
     }
 
-    /* Update the page's cache statistics. */
-    __wt_cache_page_inmem_incr(session, page, size, false);
+    /*
+     * Update the page's cache statistics. For shared dsk pages, cache totals exclude the dsk size
+     * as it is owned by the shared dsk cache layer.
+     */
+    if (!LF_ISSET(WT_PAGE_DISK_SHARED))
+        __wt_cache_page_inmem_incr(session, page, size, false);
+    else {
+        WT_ASSERT(session, size >= dsk->mem_size);
+        __wt_cache_page_inmem_incr(session, page, size - dsk->mem_size, false);
+    }
 
     /* Link the new internal page to the parent. */
     if (ref != NULL) {
@@ -1315,6 +1328,19 @@ __wti_page_inmem(WT_SESSION_IMPL *session, WT_REF *ref, const void *image, uint3
             break;
         }
         ref->page = page;
+    }
+
+    /*
+     * Hand ownership of shared_dsk_item to the page only on success. If we fail above this point,
+     * the page never owns the reference and the caller's error path is responsible for releasing
+     * it.
+     */
+    WT_ASSERT(session, shared_dsk_item == NULL || page->disagg_info != NULL);
+    if (page->disagg_info != NULL) {
+        page->disagg_info->shared_dsk_item = shared_dsk_item;
+        /* memory_footprint still includes dsk size so per-page eviction logic stays unchanged.*/
+        if (LF_ISSET(WT_PAGE_DISK_SHARED))
+            __wt_cache_page_footprint_incr(session, page, dsk->mem_size);
     }
 
     *pagep = page;

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -503,7 +503,7 @@ err:
         __wt_page_modify_clear(session, page);
         __wt_ref_out(session, ref);
     } else if (shared_dsk_item != NULL)
-        /* If the page build failed, release our reference to the shared dsk item. */
+        /* If the page build failed, release our reference to the shared disk item. */
         __wt_shared_dsk_cache_release(session, shared_dsk_item);
 
     /* Free any disk images or delta buffers we allocated or read. */

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -503,7 +503,7 @@ err:
         __wt_page_modify_clear(session, page);
         __wt_ref_out(session, ref);
     } else if (shared_dsk_item != NULL)
-        /* If the page build failed, then we need release the shared dsk item. */
+        /* If the page build failed, release our reference to the shared dsk item. */
         __wt_shared_dsk_cache_release(session, shared_dsk_item);
 
     /* Free any disk images or delta buffers we allocated or read. */

--- a/src/cache/shared_dsk.c
+++ b/src/cache/shared_dsk.c
@@ -216,7 +216,7 @@ __wt_shared_dsk_cache_release(WT_SESSION_IMPL *session, WT_SHARED_DSK_ITEM *shar
         __wt_spin_unlock(session, &shared_dsk_cache->hash_locks[lock_idx]);
 
         /* Symmetrically drain the cache on last release. */
-        __wt_cache_inmem_decr(session, dsk_type, data_size);
+        __wt_evict_shared_dsk_cache_bytes_decr(session, dsk_type, data_size);
         __wt_cache_image_decr(session, dsk_type, data_size);
 
         __shared_dsk_cache_verbose(session, WT_VERBOSE_DEBUG_2,

--- a/src/cache/shared_dsk.c
+++ b/src/cache/shared_dsk.c
@@ -203,9 +203,6 @@ __wt_shared_dsk_cache_release(WT_SESSION_IMPL *session, WT_SHARED_DSK_ITEM *shar
     bucket = hash % shared_dsk_cache->hash_size;
     lock_idx = bucket % shared_dsk_cache->hash_lock_size;
 
-    data_size = 0;
-    dsk_type = 0;
-
     __wt_spin_lock(session, &shared_dsk_cache->hash_locks[lock_idx]);
     WT_ASSERT(session, shared_dsk_item->ref_count > 0);
     /* Remove the shared dsk item when ref count is reduced to 0. */

--- a/src/cache/shared_dsk.c
+++ b/src/cache/shared_dsk.c
@@ -162,6 +162,11 @@ __wt_shared_dsk_cache_put(WT_SESSION_IMPL *session, void *data, size_t data_size
 
     *shared_dsk_retp = shared_dsk_store;
     cache_inserted = true;
+
+    /* Update disk image statistics.*/
+    __wt_cache_inmem_incr(session, ((WT_PAGE_HEADER *)data)->type, data_size);
+    __wt_cache_image_incr(session, ((WT_PAGE_HEADER *)data)->type, WT_STORE_SIZE(data_size));
+
     __shared_dsk_cache_verbose(session, WT_VERBOSE_DEBUG_2,
       "put: disk image inserted in shared dsk cache", hash, bucket, lock_idx, addr, addr_size);
 done:
@@ -186,6 +191,8 @@ __wt_shared_dsk_cache_release(WT_SESSION_IMPL *session, WT_SHARED_DSK_ITEM *shar
 {
     WT_SHARED_DSK_CACHE *shared_dsk_cache;
     uint64_t hash;
+    uint32_t data_size;
+    uint8_t dsk_type;
     u_int bucket, lock_idx;
 
     WT_ASSERT(session, shared_dsk_item != NULL);
@@ -196,12 +203,21 @@ __wt_shared_dsk_cache_release(WT_SESSION_IMPL *session, WT_SHARED_DSK_ITEM *shar
     bucket = hash % shared_dsk_cache->hash_size;
     lock_idx = bucket % shared_dsk_cache->hash_lock_size;
 
+    data_size = 0;
+    dsk_type = 0;
+
     __wt_spin_lock(session, &shared_dsk_cache->hash_locks[lock_idx]);
     WT_ASSERT(session, shared_dsk_item->ref_count > 0);
     /* Remove the shared dsk item when ref count is reduced to 0. */
     if (--shared_dsk_item->ref_count == 0) {
         TAILQ_REMOVE(&shared_dsk_cache->hash[bucket], shared_dsk_item, hashq);
+        data_size = shared_dsk_item->data_size;
+        dsk_type = ((WT_PAGE_HEADER *)shared_dsk_item->data)->type;
         __wt_spin_unlock(session, &shared_dsk_cache->hash_locks[lock_idx]);
+
+        /* Symmetrically drain the cache on last release. */
+        __wt_cache_inmem_decr(session, dsk_type, data_size);
+        __wt_cache_image_decr(session, dsk_type, data_size);
 
         __shared_dsk_cache_verbose(session, WT_VERBOSE_DEBUG_2,
           "release: disk image removed from shared dsk cache", hash, bucket, lock_idx,

--- a/src/evict/evict.h
+++ b/src/evict/evict.h
@@ -215,6 +215,8 @@ static WT_INLINE void __wt_evict_page_cache_bytes_decr(WT_SESSION_IMPL *session,
 static WT_INLINE void __wt_evict_page_first_dirty(WT_SESSION_IMPL *session, WT_PAGE *page);
 static WT_INLINE void __wt_evict_page_init(WT_PAGE *page);
 static WT_INLINE void __wt_evict_page_soon(WT_SESSION_IMPL *session, WT_REF *ref);
+static WT_INLINE void __wt_evict_shared_dsk_cache_bytes_decr(
+  WT_SESSION_IMPL *session, uint8_t dsk_type, uint32_t dsk_size);
 static WT_INLINE void __wt_evict_touch_page(
   WT_SESSION_IMPL *session, WT_PAGE *page, bool internal_only, bool wont_need);
 

--- a/src/evict/evict_inline.h
+++ b/src/evict/evict_inline.h
@@ -308,11 +308,11 @@ __wt_evict_page_cache_bytes_decr(WT_SESSION_IMPL *session, WT_PAGE *page)
     is_disagg = __wt_conn_is_disagg(session);
 
     /*
-     * For shared dsk pages, page->memory_footprint includes dsk_size that is tracked by the shared
-     * dsk cache layer. Subtract the dsk_size from the drain amount, let the shared dsk cache layer
-     * drain the dsk_size on the matching last release.
+     * For shared disk pages, page memory footprint includes disk size that is tracked by the shared
+     * disk cache layer. Subtract the disk size from the drain amount, let the shared disk cache
+     * layer drain the disk size on the matching last release.
      */
-    if (WT_PAGE_OWNS_SHARED_DSK_REF(page)) {
+    if (WT_PAGE_HAS_SHARED_DSK_REF(page)) {
         WT_ASSERT(session, page->dsk != NULL);
         WT_ASSERT(session, memory_footprint >= page->dsk->mem_size);
         memory_footprint -= page->dsk->mem_size;

--- a/src/evict/evict_inline.h
+++ b/src/evict/evict_inline.h
@@ -270,6 +270,18 @@ __wt_evict_inherit_page_state(WT_PAGE *orig_page, WT_PAGE *new_page)
         __wt_atomic_store_uint64_relaxed(&new_page->read_gen, orig_read_gen);
 }
 
+/*
+ * __wt_evict_shared_dsk_cache_bytes_decr --
+ *     Account for a shared disk image leaving the cache on its last release.
+ */
+static WT_INLINE void
+__wt_evict_shared_dsk_cache_bytes_decr(
+  WT_SESSION_IMPL *session, uint8_t dsk_type, uint32_t dsk_size)
+{
+    (void)__wt_atomic_add_uint64_relaxed(&S2C(session)->cache->bytes_evict, dsk_size);
+    __wt_cache_inmem_decr(session, dsk_type, dsk_size);
+}
+
 /* !!!
  * __wt_evict_page_cache_bytes_decr --
  *     Decrement the in-memory byte count for the cache, B-tree, and page to reflect the eviction

--- a/src/evict/evict_inline.h
+++ b/src/evict/evict_inline.h
@@ -295,6 +295,17 @@ __wt_evict_page_cache_bytes_decr(WT_SESSION_IMPL *session, WT_PAGE *page)
     memory_footprint = __wt_atomic_load_size_relaxed(&page->memory_footprint);
     is_disagg = __wt_conn_is_disagg(session);
 
+    /*
+     * For shared dsk pages, page->memory_footprint includes dsk_size that is tracked by the shared
+     * dsk cache layer. Subtract the dsk_size from the drain amount, let the shared dsk cache layer
+     * drain the dsk_size on the matching last release.
+     */
+    if (WT_PAGE_OWNS_SHARED_DSK_REF(page)) {
+        WT_ASSERT(session, page->dsk != NULL);
+        WT_ASSERT(session, memory_footprint >= page->dsk->mem_size);
+        memory_footprint -= page->dsk->mem_size;
+    }
+
     /* Update the bytes in-memory to reflect the eviction. */
     __wt_cache_decr_check_uint64(
       session, &btree->bytes_inmem, memory_footprint, "WT_BTREE.bytes_inmem");

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -758,7 +758,7 @@ struct __wt_page {
 
 #define WT_PAGE_IS_INTERNAL(page) WT_PAGE_TYPE_IS_INTERNAL((page)->type)
 #define WT_PAGE_IS_SHARED_DSK(page) F_ISSET_ATOMIC_16((page), WT_PAGE_DISK_SHARED)
-#define WT_PAGE_OWNS_SHARED_DSK_REF(page) \
+#define WT_PAGE_HAS_SHARED_DSK_REF(page) \
     ((page)->disagg_info != NULL && (page)->disagg_info->shared_dsk_item != NULL)
 #define WT_PAGE_TYPE_IS_INTERNAL(type) ((type) == WT_PAGE_COL_INT || (type) == WT_PAGE_ROW_INT)
 #define WT_PAGE_INVALID 0            /* Invalid page */

--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -742,21 +742,25 @@ struct __wt_page {
 #define WT_PAGE_COMPACTION_WRITE 0x0002u  /* Writing the page for compaction */
 #define WT_PAGE_DISK_ALLOC 0x0004u        /* Disk image in allocated memory */
 #define WT_PAGE_DISK_MAPPED 0x0008u       /* Disk image in mapped memory */
-#define WT_PAGE_EVICT_LRU 0x0010u         /* Page is on the LRU queue */
-#define WT_PAGE_EVICT_LRU_URGENT 0x0020u  /* Page is in the urgent queue */
-#define WT_PAGE_EVICT_NO_PROGRESS 0x0040u /* Eviction doesn't count as progress */
-#define WT_PAGE_INMEM_SPLIT 0x0080u
-#define WT_PAGE_INTL_OVERFLOW_KEYS 0x0100u /* Internal page has overflow keys (historic only) */
-#define WT_PAGE_INTL_PINDEX_UPDATE 0x0200u /* Page index updated */
-#define WT_PAGE_PREFETCH 0x0400u           /* The page is being pre-fetched */
-#define WT_PAGE_REC_FAIL 0x0800u           /* The previous reconciliation failed on the page. */
-#define WT_PAGE_SPLIT_INSERT 0x1000u       /* A leaf page was split for append */
-#define WT_PAGE_UPDATE_IGNORE 0x2000u      /* Ignore updates on page discard */
+#define WT_PAGE_DISK_SHARED 0x0010u       /* Disk image is from shared dsk cache */
+#define WT_PAGE_EVICT_LRU 0x0020u         /* Page is on the LRU queue */
+#define WT_PAGE_EVICT_LRU_URGENT 0x0040u  /* Page is in the urgent queue */
+#define WT_PAGE_EVICT_NO_PROGRESS 0x0080u /* Eviction doesn't count as progress */
+#define WT_PAGE_INMEM_SPLIT 0x0100u
+#define WT_PAGE_INTL_OVERFLOW_KEYS 0x0200u /* Internal page has overflow keys (historic only) */
+#define WT_PAGE_INTL_PINDEX_UPDATE 0x0400u /* Page index updated */
+#define WT_PAGE_PREFETCH 0x0800u           /* The page is being pre-fetched */
+#define WT_PAGE_REC_FAIL 0x1000u           /* The previous reconciliation failed on the page. */
+#define WT_PAGE_SPLIT_INSERT 0x2000u       /* A leaf page was split for append */
+#define WT_PAGE_UPDATE_IGNORE 0x4000u      /* Ignore updates on page discard */
                                            /* AUTOMATIC FLAG VALUE GENERATION STOP 16 */
     wt_shared uint16_t flags_atomic;       /* Atomic flags, use F_*_ATOMIC_16 */
 
-#define WT_PAGE_IS_INTERNAL(page) \
-    ((page)->type == WT_PAGE_COL_INT || (page)->type == WT_PAGE_ROW_INT)
+#define WT_PAGE_IS_INTERNAL(page) WT_PAGE_TYPE_IS_INTERNAL((page)->type)
+#define WT_PAGE_IS_SHARED_DSK(page) F_ISSET_ATOMIC_16((page), WT_PAGE_DISK_SHARED)
+#define WT_PAGE_OWNS_SHARED_DSK_REF(page) \
+    ((page)->disagg_info != NULL && (page)->disagg_info->shared_dsk_item != NULL)
+#define WT_PAGE_TYPE_IS_INTERNAL(type) ((type) == WT_PAGE_COL_INT || (type) == WT_PAGE_ROW_INT)
 #define WT_PAGE_INVALID 0            /* Invalid page */
 #define WT_PAGE_BLOCK_MANAGER 1      /* Block-manager page */
 #define WT_PAGE_COL_FIX_DEPRECATED 2 /* Col-store fixed-len leaf */

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -620,6 +620,7 @@ __wt_cache_page_byte_updates_decr(WT_SESSION_IMPL *session, WT_PAGE *page, size_
               session, &cache->bytes_updates_stable, decr, "WT_CACHE.bytes_updates_ingest");
     }
 }
+
 /*
  * __wt_cache_page_inmem_decr --
  *     Decrement a page's memory footprint in the cache.
@@ -815,11 +816,11 @@ __wt_cache_dirty_decr(WT_SESSION_IMPL *session, WT_PAGE *page)
 }
 
 /*
- * __wt_cache_page_image_decr --
- *     Decrement a page image's size to the cache.
+ * __wt_cache_image_decr --
+ *     Decrement an image's size to the cache.
  */
 static WT_INLINE void
-__wt_cache_page_image_decr(WT_SESSION_IMPL *session, WT_PAGE *page)
+__wt_cache_image_decr(WT_SESSION_IMPL *session, uint8_t image_type, uint32_t image_size)
 {
     WT_BTREE *btree;
     WT_CACHE *cache;
@@ -829,29 +830,73 @@ __wt_cache_page_image_decr(WT_SESSION_IMPL *session, WT_PAGE *page)
     cache = S2C(session)->cache;
     is_disagg = __wt_conn_is_disagg(session);
 
-    if (WT_PAGE_IS_INTERNAL(page)) {
+    if (WT_PAGE_TYPE_IS_INTERNAL(image_type)) {
         __wt_cache_decr_check_uint64(
-          session, &cache->bytes_image_intl, page->dsk->mem_size, "WT_CACHE.bytes_image");
+          session, &cache->bytes_image_intl, image_size, "WT_CACHE.bytes_image");
         if (is_disagg) {
             if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
-                __wt_cache_decr_check_uint64(session, &cache->bytes_image_intl_ingest,
-                  page->dsk->mem_size, "WT_CACHE.bytes_intl_image_ingest");
+                __wt_cache_decr_check_uint64(session, &cache->bytes_image_intl_ingest, image_size,
+                  "WT_CACHE.bytes_intl_image_ingest");
             else if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))
-                __wt_cache_decr_check_uint64(session, &cache->bytes_image_intl_stable,
-                  page->dsk->mem_size, "WT_CACHE.bytes_intl_image_stable");
+                __wt_cache_decr_check_uint64(session, &cache->bytes_image_intl_stable, image_size,
+                  "WT_CACHE.bytes_intl_image_stable");
         }
     } else {
         __wt_cache_decr_check_uint64(
-          session, &cache->bytes_image_leaf, page->dsk->mem_size, "WT_CACHE.bytes_image");
+          session, &cache->bytes_image_leaf, image_size, "WT_CACHE.bytes_image");
         if (is_disagg) {
             if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
-                __wt_cache_decr_check_uint64(session, &cache->bytes_image_leaf_ingest,
-                  page->dsk->mem_size, "WT_CACHE.bytes_leaf_image_ingest");
+                __wt_cache_decr_check_uint64(session, &cache->bytes_image_leaf_ingest, image_size,
+                  "WT_CACHE.bytes_leaf_image_ingest");
             else if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))
-                __wt_cache_decr_check_uint64(session, &cache->bytes_image_leaf_stable,
-                  page->dsk->mem_size, "WT_CACHE.bytes_leaf_image_stable");
+                __wt_cache_decr_check_uint64(session, &cache->bytes_image_leaf_stable, image_size,
+                  "WT_CACHE.bytes_leaf_image_stable");
         }
     }
+}
+
+/*
+ * __wt_cache_image_incr --
+ *     Increment an image's size to the cache.
+ */
+static WT_INLINE void
+__wt_cache_image_incr(WT_SESSION_IMPL *session, uint8_t image_type, uint32_t image_size)
+{
+    WT_BTREE *btree;
+    WT_CACHE *cache;
+    bool is_disagg;
+
+    btree = S2BT(session);
+    cache = S2C(session)->cache;
+    is_disagg = __wt_conn_is_disagg(session);
+
+    if (WT_PAGE_TYPE_IS_INTERNAL(image_type)) {
+        (void)__wt_atomic_add_uint64_relaxed(&cache->bytes_image_intl, image_size);
+        if (is_disagg) {
+            if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
+                (void)__wt_atomic_add_uint64_relaxed(&cache->bytes_image_intl_ingest, image_size);
+            else if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))
+                (void)__wt_atomic_add_uint64_relaxed(&cache->bytes_image_intl_stable, image_size);
+        }
+    } else {
+        (void)__wt_atomic_add_uint64_relaxed(&cache->bytes_image_leaf, image_size);
+        if (is_disagg) {
+            if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
+                (void)__wt_atomic_add_uint64_relaxed(&cache->bytes_image_leaf_ingest, image_size);
+            else if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))
+                (void)__wt_atomic_add_uint64_relaxed(&cache->bytes_image_leaf_stable, image_size);
+        }
+    }
+}
+
+/*
+ * __wt_cache_page_image_decr --
+ *     Decrement a page image's size to the cache.
+ */
+static WT_INLINE void
+__wt_cache_page_image_decr(WT_SESSION_IMPL *session, WT_PAGE *page)
+{
+    __wt_cache_image_decr(session, page->type, page->dsk->mem_size);
 }
 
 /*
@@ -861,35 +906,7 @@ __wt_cache_page_image_decr(WT_SESSION_IMPL *session, WT_PAGE *page)
 static WT_INLINE void
 __wt_cache_page_image_incr(WT_SESSION_IMPL *session, WT_PAGE *page)
 {
-    WT_BTREE *btree;
-    WT_CACHE *cache;
-    bool is_disagg;
-
-    btree = S2BT(session);
-    cache = S2C(session)->cache;
-    is_disagg = __wt_conn_is_disagg(session);
-
-    if (WT_PAGE_IS_INTERNAL(page)) {
-        (void)__wt_atomic_add_uint64_relaxed(&cache->bytes_image_intl, page->dsk->mem_size);
-        if (is_disagg) {
-            if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
-                (void)__wt_atomic_add_uint64_relaxed(
-                  &cache->bytes_image_intl_ingest, page->dsk->mem_size);
-            else if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))
-                (void)__wt_atomic_add_uint64_relaxed(
-                  &cache->bytes_image_intl_stable, page->dsk->mem_size);
-        }
-    } else {
-        (void)__wt_atomic_add_uint64_relaxed(&cache->bytes_image_leaf, page->dsk->mem_size);
-        if (is_disagg) {
-            if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
-                (void)__wt_atomic_add_uint64_relaxed(
-                  &cache->bytes_image_leaf_ingest, page->dsk->mem_size);
-            else if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))
-                (void)__wt_atomic_add_uint64_relaxed(
-                  &cache->bytes_image_leaf_stable, page->dsk->mem_size);
-        }
-    }
+    __wt_cache_image_incr(session, page->type, page->dsk->mem_size);
 }
 
 /*
@@ -2951,4 +2968,101 @@ __wt_ref_ascend(WT_SESSION_IMPL *session, WT_REF **refp, WT_PAGE_INDEX **pindexp
     }
 
     *refp = parent_ref;
+}
+
+/*
+ * __wt_cache_page_footprint_incr --
+ *     Increment a page's memory_footprint without touching cache or btree totals.
+ */
+static WT_INLINE void
+__wt_cache_page_footprint_incr(WT_SESSION_IMPL *session, WT_PAGE *page, size_t size)
+{
+    WT_ASSERT(session, size < WT_EXABYTE);
+    if (size == 0)
+        return;
+    (void)__wt_atomic_add_size_relaxed(&page->memory_footprint, size);
+}
+
+/*
+ * __wt_cache_inmem_incr --
+ *     Increment the in memory cache statistics.
+ */
+static WT_INLINE void
+__wt_cache_inmem_incr(WT_SESSION_IMPL *session, uint8_t image_type, size_t size)
+{
+    WT_BTREE *btree;
+    WT_CACHE *cache;
+
+    WT_ASSERT(session, size < WT_EXABYTE);
+    btree = S2BT(session);
+    cache = S2C(session)->cache;
+
+    if (size == 0)
+        return;
+
+    bool is_disagg = __wt_conn_is_disagg(session);
+
+    (void)__wt_atomic_add_uint64_relaxed(&cache->bytes_inmem, size);
+    if (is_disagg) {
+        if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
+            (void)__wt_atomic_add_uint64_relaxed(&cache->bytes_inmem_ingest, size);
+        else if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))
+            (void)__wt_atomic_add_uint64_relaxed(&cache->bytes_inmem_stable, size);
+    }
+    (void)__wt_atomic_add_uint64_relaxed(&btree->bytes_inmem, size);
+    if (WT_PAGE_TYPE_IS_INTERNAL(image_type)) {
+        (void)__wt_atomic_add_uint64_relaxed(&cache->bytes_internal, size);
+        if (is_disagg) {
+            if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
+                (void)__wt_atomic_add_uint64_relaxed(&cache->bytes_internal_ingest, size);
+            else if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))
+                (void)__wt_atomic_add_uint64_relaxed(&cache->bytes_internal_stable, size);
+        }
+        (void)__wt_atomic_add_uint64_relaxed(&btree->bytes_internal, size);
+    }
+}
+
+/*
+ * __wt_cache_inmem_decr --
+ *     Decrement the in memory cache statistics.
+ */
+static WT_INLINE void
+__wt_cache_inmem_decr(WT_SESSION_IMPL *session, uint8_t image_type, size_t size)
+{
+    WT_BTREE *btree;
+    WT_CACHE *cache;
+
+    WT_ASSERT(session, size < WT_EXABYTE);
+    btree = S2BT(session);
+    cache = S2C(session)->cache;
+
+    if (size == 0)
+        return;
+
+    bool is_disagg = __wt_conn_is_disagg(session);
+
+    __wt_cache_decr_check_uint64(session, &btree->bytes_inmem, size, "WT_BTREE.bytes_inmem");
+    __wt_cache_decr_check_uint64(session, &cache->bytes_inmem, size, "WT_CACHE.bytes_inmem");
+    if (is_disagg) {
+        if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
+            __wt_cache_decr_check_uint64(
+              session, &cache->bytes_inmem_ingest, size, "WT_CACHE.bytes_inmem_ingest");
+        else if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))
+            __wt_cache_decr_check_uint64(
+              session, &cache->bytes_inmem_stable, size, "WT_CACHE.bytes_inmem_stable");
+    }
+    if (WT_PAGE_TYPE_IS_INTERNAL(image_type)) {
+        __wt_cache_decr_check_uint64(
+          session, &btree->bytes_internal, size, "WT_BTREE.bytes_internal");
+        __wt_cache_decr_check_uint64(
+          session, &cache->bytes_internal, size, "WT_CACHE.bytes_internal");
+        if (is_disagg) {
+            if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
+                __wt_cache_decr_check_uint64(
+                  session, &cache->bytes_internal_ingest, size, "WT_CACHE.bytes_internal_ingest");
+            else if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))
+                __wt_cache_decr_check_uint64(
+                  session, &cache->bytes_internal_stable, size, "WT_CACHE.bytes_internal_stable");
+        }
+    }
 }

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -2972,7 +2972,7 @@ __wt_ref_ascend(WT_SESSION_IMPL *session, WT_REF **refp, WT_PAGE_INDEX **pindexp
 
 /*
  * __wt_cache_page_footprint_incr --
- *     Increment a page's memory_footprint without touching cache or btree totals.
+ *     Increment a page's memory footprint without touching cache or btree totals.
  */
 static WT_INLINE void
 __wt_cache_page_footprint_incr(WT_SESSION_IMPL *session, WT_PAGE *page, size_t size)

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -817,7 +817,7 @@ __wt_cache_dirty_decr(WT_SESSION_IMPL *session, WT_PAGE *page)
 
 /*
  * __wt_cache_image_decr --
- *     Decrement an image's size to the cache.
+ *     Decrement an image's size in the cache.
  */
 static WT_INLINE void
 __wt_cache_image_decr(WT_SESSION_IMPL *session, uint8_t image_type, uint32_t image_size)
@@ -857,7 +857,7 @@ __wt_cache_image_decr(WT_SESSION_IMPL *session, uint8_t image_type, uint32_t ima
 
 /*
  * __wt_cache_image_incr --
- *     Increment an image's size to the cache.
+ *     Increment an image's size in the cache.
  */
 static WT_INLINE void
 __wt_cache_image_incr(WT_SESSION_IMPL *session, uint8_t image_type, uint32_t image_size)
@@ -891,7 +891,7 @@ __wt_cache_image_incr(WT_SESSION_IMPL *session, uint8_t image_type, uint32_t ima
 
 /*
  * __wt_cache_page_image_decr --
- *     Decrement a page image's size to the cache.
+ *     Decrement a page image's size in the cache.
  */
 static WT_INLINE void
 __wt_cache_page_image_decr(WT_SESSION_IMPL *session, WT_PAGE *page)
@@ -901,7 +901,7 @@ __wt_cache_page_image_decr(WT_SESSION_IMPL *session, WT_PAGE *page)
 
 /*
  * __wt_cache_page_image_incr --
- *     Increment a page image's size to the cache.
+ *     Increment a page image's size in the cache.
  */
 static WT_INLINE void
 __wt_cache_page_image_incr(WT_SESSION_IMPL *session, WT_PAGE *page)

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2475,6 +2475,8 @@ static WT_INLINE void __wt_cache_page_byte_dirty_decr(
   WT_SESSION_IMPL *session, WT_PAGE *page, size_t size);
 static WT_INLINE void __wt_cache_page_byte_updates_decr(
   WT_SESSION_IMPL *session, WT_PAGE *page, size_t size);
+static WT_INLINE void __wt_cache_page_footprint_incr(
+  WT_SESSION_IMPL *session, WT_PAGE *page, size_t size);
 static WT_INLINE void __wt_cache_page_image_decr(WT_SESSION_IMPL *session, WT_PAGE *page);
 static WT_INLINE void __wt_cache_page_image_incr(WT_SESSION_IMPL *session, WT_PAGE *page);
 static WT_INLINE void __wt_cache_page_inmem_decr(

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2471,6 +2471,14 @@ static WT_INLINE void __wt_cache_dirty_decr_size(
   WT_SESSION_IMPL *session, size_t size, bool is_internal);
 static WT_INLINE void __wt_cache_dirty_incr_size(
   WT_SESSION_IMPL *session, size_t size, bool is_internal);
+static WT_INLINE void __wt_cache_image_decr(
+  WT_SESSION_IMPL *session, uint8_t image_type, uint32_t image_size);
+static WT_INLINE void __wt_cache_image_incr(
+  WT_SESSION_IMPL *session, uint8_t image_type, uint32_t image_size);
+static WT_INLINE void __wt_cache_inmem_decr(
+  WT_SESSION_IMPL *session, uint8_t image_type, size_t size);
+static WT_INLINE void __wt_cache_inmem_incr(
+  WT_SESSION_IMPL *session, uint8_t image_type, size_t size);
 static WT_INLINE void __wt_cache_page_byte_dirty_decr(
   WT_SESSION_IMPL *session, WT_PAGE *page, size_t size);
 static WT_INLINE void __wt_cache_page_byte_updates_decr(

--- a/test/catch2/cross_checkpoint_caching/cross_checkpoint_caching_test_env.h
+++ b/test/catch2/cross_checkpoint_caching/cross_checkpoint_caching_test_env.h
@@ -19,7 +19,7 @@ extern "C" {
 namespace utils {
 
 constexpr u_int CROSS_CHECKPOINT_CACHING_TEST_HASH_SIZE = 16;
-constexpr size_t CROSS_CHECKPOINT_CACHING_TEST_DATA_SIZE = 16;
+constexpr size_t CROSS_CHECKPOINT_CACHING_TEST_DATA_SIZE = WT_PAGE_HEADER_SIZE;
 
 /*
  * Stands up the minimum state needed to exercise the cross-checkpoint cache against a real


### PR DESCRIPTION
For shared disk cache when it's enabled in disagg, multiple pages sharing same disk image should account cache usage only once. The changes include:
1. Per-page memory_footprint stays unchanged — each page still counts the full disk image size, for shared disk page the memory footprint will be shared disk size + extra size used by the page.
2. Total cache in-memory usage is de-duplicated — when multiple pages share the same disk image, that image is only counted once in the total memory usage, regardless of how many pages reference it, the PR moves the accounting of shared disk size to shared disk cache layer, it is incremented when put into the shared disk table, and is decremented once the last reference is released from the table.