### PR TITLE
WT-16812 Validate fast truncate write conflict semantics on followers

### DIFF
--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -2083,7 +2083,7 @@ __clayered_put(WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, const WT_I
 
     if (!leader) {
         /*
-         * FIXME-WT-16812: Investigate whether this function can be called below the cursor layer.
+         * FIXME-WT-17425: Investigate whether this function can be called below the cursor layer.
          * Doing so would remove the cursor write operation dependency on the truncate list.
          */
         WT_RET(__wt_layered_table_truncate_detect_write_conflict(
@@ -2165,7 +2165,7 @@ __clayered_remove_follower(
         WT_RET(__clayered_reset_cursors(clayered, true));
 
     /*
-     * FIXME-WT-16812: Investigate whether this function can be called below the cursor layer. Doing
+     * FIXME-WT-17425: Investigate whether this function can be called below the cursor layer. Doing
      * so would remove the write cursor operations dependency on the truncate list.
      */
     WT_RET(__wt_layered_table_truncate_detect_write_conflict(

--- a/src/txn/txn_truncate.c
+++ b/src/txn/txn_truncate.c
@@ -229,7 +229,7 @@ __truncate_search(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered_table, con
  *     Search if the current key we are modifying conflicts with any uncommitted truncates in the
  *     layered table truncate list.
  *
- * FIXME-WT-16812: Investigate whether this function can be called below the cursor layer. Doing so
+ * FIXME-WT-17425: Investigate whether this function can be called below the cursor layer. Doing so
  *     would remove the write cursor operations dependency on the truncate list.
  */
 int

--- a/src/txn/txn_truncate.c
+++ b/src/txn/txn_truncate.c
@@ -10,8 +10,8 @@
 
 /*
  * Selects which truncate-list entries __truncate_search considers: those visible to the calling
- * transaction (committed truncates we may need to honor) or those not visible (uncommitted
- * truncates that may conflict with our writes).
+ * transaction (committed and within its read timestamp) or those not visible (uncommitted, or
+ * committed at a timestamp beyond its read timestamp) that may conflict with our writes.
  */
 typedef enum { WT_TRUNCATE_SEARCH_VISIBLE, WT_TRUNCATE_SEARCH_NOT_VISIBLE } WT_TRUNCATE_SEARCH_MODE;
 
@@ -201,15 +201,12 @@ __truncate_search(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered_table, con
     TAILQ_FOREACH (entry, &layered_table->truncateqh, q) {
         WT_STAT_CONN_INCR(session, layered_truncate_list_search_entries_walked);
 
-        if (mode == WT_TRUNCATE_SEARCH_VISIBLE) {
-            wt_timestamp_t start_ts, durable_ts;
-            __truncate_read_entry_timestamps(entry, &start_ts, &durable_ts);
-            if (!__wt_txn_visible(session, entry->txn_id, start_ts, durable_ts))
-                continue;
-        } else if (mode == WT_TRUNCATE_SEARCH_NOT_VISIBLE) {
-            if (__wt_txn_visible_id(session, entry->txn_id))
-                continue;
-        }
+        wt_timestamp_t start_ts, durable_ts;
+        __truncate_read_entry_timestamps(entry, &start_ts, &durable_ts);
+
+        const bool visible = __wt_txn_visible(session, entry->txn_id, start_ts, durable_ts);
+        if (visible != (mode == WT_TRUNCATE_SEARCH_VISIBLE))
+            continue;
 
         WT_RET(__key_within_truncate_range(
           session, collator, &entry->start_key, &entry->stop_key, key, is_foundp));
@@ -289,7 +286,10 @@ __wt_layered_table_truncate_detect_non_ingest_write_conflict(WT_SESSION_IMPL *se
     TAILQ_FOREACH (entry, &layered_table->truncateqh, q) {
         WT_STAT_CONN_INCR(session, layered_truncate_list_search_entries_walked);
 
-        if (__wt_txn_visible_id(session, entry->txn_id))
+        wt_timestamp_t start_ts, durable_ts;
+        __truncate_read_entry_timestamps(entry, &start_ts, &durable_ts);
+
+        if (__wt_txn_visible(session, entry->txn_id, start_ts, durable_ts))
             continue;
 
         /* Does the new range start within an existing range? */

--- a/src/txn/txn_truncate.c
+++ b/src/txn/txn_truncate.c
@@ -205,7 +205,9 @@ __truncate_search(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered_table, con
         __truncate_read_entry_timestamps(entry, &start_ts, &durable_ts);
 
         const bool visible = __wt_txn_visible(session, entry->txn_id, start_ts, durable_ts);
-        if (visible != (mode == WT_TRUNCATE_SEARCH_VISIBLE))
+        const bool want_visible = (mode == WT_TRUNCATE_SEARCH_VISIBLE);
+
+        if (visible != want_visible)
             continue;
 
         WT_RET(__key_within_truncate_range(

--- a/test/catch2/CMakeLists.txt
+++ b/test/catch2/CMakeLists.txt
@@ -63,7 +63,6 @@ else()
         truncate/test_layered_truncate_visibility.cpp
         truncate/test_layered_table_truncate_clear.cpp
         truncate/test_layered_table_truncate_rollback.cpp
-        truncate/test_truncate_write_conflict.cpp
     )
 endif()
 
@@ -88,6 +87,7 @@ if(NOT WT_WIN)
         live_restore/unit/test_live_restore_fill_hole.cpp
         sub_level_error/unit/test_sub_level_error_live_restore_conflict.cpp
         truncate/test_insert_truncate_entry.cpp
+        truncate/test_truncate_write_conflict.cpp
     )
 endif()
 

--- a/test/catch2/CMakeLists.txt
+++ b/test/catch2/CMakeLists.txt
@@ -63,6 +63,7 @@ else()
         truncate/test_layered_truncate_visibility.cpp
         truncate/test_layered_table_truncate_clear.cpp
         truncate/test_layered_table_truncate_rollback.cpp
+        truncate/test_truncate_write_conflict.cpp
     )
 endif()
 

--- a/test/catch2/truncate/test_truncate_write_conflict.cpp
+++ b/test/catch2/truncate/test_truncate_write_conflict.cpp
@@ -169,7 +169,6 @@ private:
       "extensions=[./ext/page_log/palite/libwiredtiger_palite.so],"
       "disaggregated=(role=follower,page_log=palite)";
 
-    scoped_fast_truncate_enable _enable;
     home_directory _home{"WT_TEST.truncate_write_conflict"};
     connection_wrapper _conn{_home.path(), conn_config};
     WT_SESSION_IMPL *_session{_conn.create_session()};

--- a/test/catch2/truncate/test_truncate_write_conflict.cpp
+++ b/test/catch2/truncate/test_truncate_write_conflict.cpp
@@ -10,6 +10,7 @@
 #include <iomanip>
 #include <sstream>
 #include <string_view>
+#include <tuple>
 
 #include <catch2/catch.hpp>
 
@@ -33,34 +34,52 @@ format_key(const int num)
 // Calls the provided functor/lambda, wrapped in a transaction.
 template <typename Op>
 int
-do_in_transaction(WT_SESSION_IMPL *s, const Op operation, const bool commit)
+do_in_committed_transaction(WT_SESSION_IMPL *session, const Op operation)
 {
-    auto *iface = &s->iface;
+    auto *iface = &session->iface;
+
     REQUIRE(iface->begin_transaction(iface, nullptr) == 0);
-
     const int ret = operation();
-
-    if (commit)
-        REQUIRE(iface->commit_transaction(iface, nullptr) == 0);
+    REQUIRE(iface->commit_transaction(iface, nullptr) == 0);
 
     return ret;
 }
 
+// Calls the provided functor/lambda in a transaction, but rolls back afterwards.
+template <typename Op>
+int
+do_in_rolled_back_transaction(WT_SESSION_IMPL *session, const Op operation)
+{
+    auto *iface = &session->iface;
+
+    CHECK(iface->begin_transaction(iface, nullptr) == 0);
+    const int ret = operation();
+    CHECK(iface->rollback_transaction(iface, nullptr) == 0);
+
+    return ret;
+}
+
+// Calls the provided functor/lambda, but leaves the transaction open.
 template <typename Op>
 int
 do_in_uncommitted_transaction(WT_SESSION_IMPL *session, const Op operation)
 {
-    return do_in_transaction(session, operation, /* commit = */ false);
+    auto *iface = &session->iface;
+    CHECK(iface->begin_transaction(iface, nullptr) == 0);
+    return operation();
 }
 
-template <typename Op>
-int
-do_in_committed_transaction(WT_SESSION_IMPL *session, const Op operation)
+// Scope guard that ensures that transactions are always rolled back.
+[[nodiscard]] auto
+rollback_on_exit(WT_SESSION_IMPL *session)
 {
-    return do_in_transaction(session, operation, /* commit = */ true);
+    auto *iface = &session->iface;
+    const auto deleter = [](WT_SESSION *s) { std::ignore = s->rollback_transaction(s, nullptr); };
+
+    return std::unique_ptr<WT_SESSION, decltype(deleter)>(iface, deleter);
 }
 
-// Ensures the given test directory is removed at the beginning of the test.
+// Ensures the given test directory is removed between tests.
 class home_directory {
 public:
     explicit home_directory(const std::string_view path) : _path(path)
@@ -68,10 +87,15 @@ public:
         std::filesystem::remove_all(path);
     }
 
-    [[nodiscard]] std::string_view
+    ~home_directory()
+    {
+        std::filesystem::remove_all(_path);
+    }
+
+    [[nodiscard]] const char *
     path() const
     {
-        return _path;
+        return _path.c_str();
     }
 
 private:
@@ -88,8 +112,8 @@ public:
           "key_format=S,value_format=S,block_manager=disagg,type=layered";
 
         auto &session = _session->iface;
-        REQUIRE(session.create(&session, uri, config) == 0);
-        REQUIRE(session.open_cursor(&session, uri, nullptr, nullptr, &_cursor) == 0);
+        CHECK(session.create(&session, uri, config) == 0);
+        CHECK(session.open_cursor(&session, uri, nullptr, nullptr, &_cursor) == 0);
     }
 
     [[nodiscard]] WT_SESSION_IMPL *
@@ -140,7 +164,7 @@ private:
 
     scoped_fast_truncate_enable _enable;
     home_directory _home{"WT_TEST.truncate_write_conflict"};
-    connection_wrapper _conn{_home.path().data(), conn_config};
+    connection_wrapper _conn{_home.path(), conn_config};
     WT_SESSION_IMPL *_session{_conn.create_session()};
     WT_CURSOR *_cursor{};
 };
@@ -155,7 +179,7 @@ SCENARIO("write conflict returns 0 for an empty truncate list", "[truncate_list]
 
         WHEN("the conflict check is called for any key")
         {
-            const auto result = do_in_uncommitted_transaction(
+            const auto result = do_in_rolled_back_transaction(
               f.session(), [&] { return f.detect_conflict(f.session(), 150); });
 
             THEN("it returns 0 (no conflict)")
@@ -172,13 +196,17 @@ SCENARIO("write conflict returns 0 when the key is outside all uncommitted range
     GIVEN("one uncommitted truncate range [100, 200]")
     {
         write_conflict_fixture f;
+
         do_in_uncommitted_transaction(
           f.session(), [&] { return f.insert_truncate_entry(f.session(), 100, 200); });
+
+        const auto cleanup = rollback_on_exit(f.session());
 
         WHEN("the conflict check is called for a key before the range")
         {
             auto *session_2 = f.create_session();
-            const auto result = do_in_uncommitted_transaction(
+
+            const auto result = do_in_rolled_back_transaction(
               session_2, [&] { return f.detect_conflict(session_2, 50); });
 
             THEN("it returns 0 (no conflict)")
@@ -190,7 +218,8 @@ SCENARIO("write conflict returns 0 when the key is outside all uncommitted range
         WHEN("the conflict check is called for a key after the range")
         {
             auto *session_2 = f.create_session();
-            const auto result = do_in_uncommitted_transaction(
+
+            const auto result = do_in_rolled_back_transaction(
               session_2, [&] { return f.detect_conflict(session_2, 250); });
 
             THEN("it returns 0 (no conflict)")
@@ -203,16 +232,20 @@ SCENARIO("write conflict returns 0 when the key is outside all uncommitted range
     GIVEN("two non-overlapping uncommitted ranges [100, 200] and [400, 500]")
     {
         write_conflict_fixture f;
+
         do_in_uncommitted_transaction(f.session(), [&] {
             REQUIRE(f.insert_truncate_entry(f.session(), 100, 200) == 0);
             REQUIRE(f.insert_truncate_entry(f.session(), 400, 500) == 0);
             return 0;
         });
 
+        const auto cleanup = rollback_on_exit(f.session());
+
         WHEN("the conflict check is called for a key between the ranges")
         {
             auto *session_2 = f.create_session();
-            const auto result = do_in_uncommitted_transaction(
+
+            const auto result = do_in_rolled_back_transaction(
               session_2, [&] { return f.detect_conflict(session_2, 300); });
 
             THEN("it returns 0 (no conflict)")
@@ -229,13 +262,17 @@ SCENARIO("write conflict returns WT_ROLLBACK when the key is inside an uncommitt
     GIVEN("one uncommitted truncate range [100, 200]")
     {
         write_conflict_fixture f;
+
         do_in_uncommitted_transaction(
           f.session(), [&] { return f.insert_truncate_entry(f.session(), 100, 200); });
+
+        const auto cleanup = rollback_on_exit(f.session());
 
         WHEN("the conflict check is called for a key strictly inside the range")
         {
             auto *session_2 = f.create_session();
-            const auto result = do_in_uncommitted_transaction(
+
+            const auto result = do_in_rolled_back_transaction(
               session_2, [&] { return f.detect_conflict(session_2, 150); });
 
             THEN("it returns WT_ROLLBACK")
@@ -247,7 +284,8 @@ SCENARIO("write conflict returns WT_ROLLBACK when the key is inside an uncommitt
         WHEN("the conflict check is called for the start boundary key")
         {
             auto *session_2 = f.create_session();
-            const auto result = do_in_uncommitted_transaction(
+
+            const auto result = do_in_rolled_back_transaction(
               session_2, [&] { return f.detect_conflict(session_2, 100); });
 
             THEN("it returns WT_ROLLBACK (start boundary is inclusive)")
@@ -259,7 +297,8 @@ SCENARIO("write conflict returns WT_ROLLBACK when the key is inside an uncommitt
         WHEN("the conflict check is called for the stop boundary key")
         {
             auto *session_2 = f.create_session();
-            const auto result = do_in_uncommitted_transaction(
+
+            const auto result = do_in_rolled_back_transaction(
               session_2, [&] { return f.detect_conflict(session_2, 200); });
 
             THEN("it returns WT_ROLLBACK (stop boundary is inclusive)")
@@ -275,13 +314,17 @@ SCENARIO("write conflict with a single-key uncommitted range", "[truncate_list][
     GIVEN("a single-key uncommitted range [100, 100]")
     {
         write_conflict_fixture f;
+
         do_in_uncommitted_transaction(
           f.session(), [&] { return f.insert_truncate_entry(f.session(), 100, 100); });
+
+        const auto cleanup = rollback_on_exit(f.session());
 
         WHEN("the conflict check is called for the exact key")
         {
             auto *session_2 = f.create_session();
-            const auto result = do_in_uncommitted_transaction(
+
+            const auto result = do_in_rolled_back_transaction(
               session_2, [&] { return f.detect_conflict(session_2, 100); });
 
             THEN("it returns WT_ROLLBACK")
@@ -293,7 +336,8 @@ SCENARIO("write conflict with a single-key uncommitted range", "[truncate_list][
         WHEN("the conflict check is called for a key just before the range")
         {
             auto *session_2 = f.create_session();
-            const auto result = do_in_uncommitted_transaction(
+
+            const auto result = do_in_rolled_back_transaction(
               session_2, [&] { return f.detect_conflict(session_2, 99); });
 
             THEN("it returns 0 (no conflict)")
@@ -305,7 +349,8 @@ SCENARIO("write conflict with a single-key uncommitted range", "[truncate_list][
         WHEN("the conflict check is called for a key just after the range")
         {
             auto *session_2 = f.create_session();
-            const auto result = do_in_uncommitted_transaction(
+
+            const auto result = do_in_rolled_back_transaction(
               session_2, [&] { return f.detect_conflict(session_2, 101); });
 
             THEN("it returns 0 (no conflict)")
@@ -322,16 +367,20 @@ SCENARIO(
     GIVEN("uncommitted ranges [100, 200] and [400, 500]")
     {
         write_conflict_fixture f;
+
         do_in_uncommitted_transaction(f.session(), [&] {
-            REQUIRE(f.insert_truncate_entry(f.session(), 100, 200) == 0);
-            REQUIRE(f.insert_truncate_entry(f.session(), 400, 500) == 0);
+            f.insert_truncate_entry(f.session(), 100, 200);
+            f.insert_truncate_entry(f.session(), 400, 500);
             return 0;
         });
+
+        const auto cleanup = rollback_on_exit(f.session());
 
         WHEN("the conflict check is called for a key in the first range")
         {
             auto *session_2 = f.create_session();
-            const auto result = do_in_uncommitted_transaction(
+
+            const auto result = do_in_rolled_back_transaction(
               session_2, [&] { return f.detect_conflict(session_2, 150); });
 
             THEN("it returns WT_ROLLBACK")
@@ -343,7 +392,8 @@ SCENARIO(
         WHEN("the conflict check is called for a key in the second range")
         {
             auto *session_2 = f.create_session();
-            const auto result = do_in_uncommitted_transaction(
+
+            const auto result = do_in_rolled_back_transaction(
               session_2, [&] { return f.detect_conflict(session_2, 450); });
 
             THEN("it returns WT_ROLLBACK")
@@ -360,13 +410,15 @@ SCENARIO("write conflict does not trigger for a committed truncate range",
     GIVEN("one committed (globally visible) truncate range [100, 200]")
     {
         write_conflict_fixture f;
+
         do_in_committed_transaction(
           f.session(), [&] { return f.insert_truncate_entry(f.session(), 100, 200); });
 
         WHEN("the conflict check is called for a key inside the committed range")
         {
             auto *session_2 = f.create_session();
-            const auto result = do_in_uncommitted_transaction(
+
+            const auto result = do_in_rolled_back_transaction(
               session_2, [&] { return f.detect_conflict(session_2, 150); });
 
             THEN("it returns 0 (no conflict)")
@@ -386,7 +438,7 @@ SCENARIO("write conflict does not trigger for the reader's own uncommitted range
 
         WHEN("the conflict check is called for a key inside that range")
         {
-            const auto result = do_in_uncommitted_transaction(f.session(), [&] {
+            const auto result = do_in_rolled_back_transaction(f.session(), [&] {
                 f.insert_truncate_entry(f.session(), 100, 200);
                 return f.detect_conflict(f.session(), 150);
             });
@@ -405,18 +457,22 @@ SCENARIO("write conflict with overlapping committed and uncommitted ranges",
     GIVEN("a committed range [100, 300] and an uncommitted range [200, 400]")
     {
         write_conflict_fixture f;
-        auto *session_2 = f.create_session();
 
         do_in_committed_transaction(
           f.session(), [&] { return f.insert_truncate_entry(f.session(), 100, 300); });
 
+        auto *session_2 = f.create_session();
+
         do_in_uncommitted_transaction(
           session_2, [&] { return f.insert_truncate_entry(session_2, 200, 400); });
+
+        const auto cleanup = rollback_on_exit(session_2);
 
         WHEN("the conflict check is called for a key covered only by the committed range")
         {
             auto *session_3 = f.create_session();
-            const auto result = do_in_uncommitted_transaction(
+
+            const auto result = do_in_rolled_back_transaction(
               session_3, [&] { return f.detect_conflict(session_3, 150); });
 
             THEN("it returns 0 (no conflict)")
@@ -428,7 +484,8 @@ SCENARIO("write conflict with overlapping committed and uncommitted ranges",
         WHEN("the conflict check is called for a key in the overlap region")
         {
             auto *session_3 = f.create_session();
-            const auto result = do_in_uncommitted_transaction(
+
+            const auto result = do_in_rolled_back_transaction(
               session_3, [&] { return f.detect_conflict(session_3, 250); });
 
             THEN("it returns WT_ROLLBACK (uncommitted range covers the key)")
@@ -440,7 +497,8 @@ SCENARIO("write conflict with overlapping committed and uncommitted ranges",
         WHEN("the conflict check is called for a key covered only by the uncommitted range")
         {
             auto *session_3 = f.create_session();
-            const auto result = do_in_uncommitted_transaction(
+
+            const auto result = do_in_rolled_back_transaction(
               session_3, [&] { return f.detect_conflict(session_3, 350); });
 
             THEN("it returns WT_ROLLBACK")
@@ -459,7 +517,8 @@ SCENARIO("write conflict read lock is always released", "[truncate_list][write_c
 
         WHEN("the conflict check is called")
         {
-            f.detect_conflict(f.session(), 150);
+            do_in_rolled_back_transaction(
+              f.session(), [&] { return f.detect_conflict(f.session(), 150); });
 
             THEN("the truncate lock is not held")
             {

--- a/test/catch2/truncate/test_truncate_write_conflict.cpp
+++ b/test/catch2/truncate/test_truncate_write_conflict.cpp
@@ -457,7 +457,7 @@ SCENARIO("write conflict does not trigger for the caller's own uncommitted range
         WHEN("the conflict check is called for a key inside that range")
         {
             const auto result = do_in_rolled_back_transaction(f.session(), [&] {
-                f.insert_truncate_entry(f.session(), 100, 200);
+                CHECK(f.insert_truncate_entry(f.session(), 100, 200) == 0);
                 return f.detect_conflict(f.session(), 150);
             });
 
@@ -801,7 +801,7 @@ SCENARIO("non-ingest write conflict does not trigger for the caller's own uncomm
           "transaction")
         {
             const auto result = do_in_rolled_back_transaction(f.session(), [&] {
-                f.insert_truncate_entry(f.session(), 100, 300);
+                CHECK(f.insert_truncate_entry(f.session(), 100, 300) == 0);
                 return f.detect_non_ingest_conflict(f.session(), 200, 400);
             });
 

--- a/test/catch2/truncate/test_truncate_write_conflict.cpp
+++ b/test/catch2/truncate/test_truncate_write_conflict.cpp
@@ -21,7 +21,7 @@ using namespace truncate_list_helpers;
 
 namespace {
 
-// Converts an integer to a string in the form "keyNNN", where NNN is zero-padded.
+// Converts an integer to a string in the form "key" + "NNN", where NNN is zero-padded.
 std::string
 format_key(const int num)
 {

--- a/test/catch2/truncate/test_truncate_write_conflict.cpp
+++ b/test/catch2/truncate/test_truncate_write_conflict.cpp
@@ -69,6 +69,13 @@ do_in_uncommitted_transaction(WT_SESSION_IMPL *session, const Op operation)
     return operation();
 }
 
+void
+set_read_timestamp(WT_SESSION_IMPL *session, const wt_timestamp_t ts)
+{
+    WT_SESSION_TXN_SHARED(session)->read_timestamp = ts;
+    F_SET(session->txn, WT_TXN_SHARED_TS_READ);
+}
+
 // Scope guard that ensures that transactions are always rolled back.
 [[nodiscard]] auto
 rollback_on_exit(WT_SESSION_IMPL *session)
@@ -523,6 +530,52 @@ SCENARIO("write conflict read lock is always released", "[truncate_list][write_c
             THEN("the truncate lock is not held")
             {
                 REQUIRE(lock_is_released(*f.session(), *f.layered_table()));
+            }
+        }
+    }
+}
+
+SCENARIO("write conflict returns WT_ROLLBACK when read_timestamp predates a committed truncate",
+  "[truncate_list][write_conflict]")
+{
+    GIVEN("a committed truncate range [100, 200] with timestamp 30")
+    {
+        write_conflict_fixture f;
+
+        do_in_committed_transaction(
+          f.session(), [&] { return f.insert_truncate_entry(f.session(), 100, 200); });
+
+        WT_TRUNCATE *entry = truncate_list_head(*f.layered_table());
+        entry->start_ts = 30;
+        entry->durable_ts = 30;
+
+        WHEN("the conflict check is called with read_timestamp before the truncate timestamp")
+        {
+            auto *session_2 = f.create_session();
+
+            const auto result = do_in_rolled_back_transaction(session_2, [&] {
+                set_read_timestamp(session_2, 29);
+                return f.detect_conflict(session_2, 150);
+            });
+
+            THEN("it returns WT_ROLLBACK (truncate is not visible at this read timestamp)")
+            {
+                REQUIRE(result == WT_ROLLBACK);
+            }
+        }
+
+        WHEN("the conflict check is called with read_timestamp equal to the truncate timestamp")
+        {
+            auto *session_2 = f.create_session();
+
+            const auto result = do_in_rolled_back_transaction(session_2, [&] {
+                set_read_timestamp(session_2, 30);
+                return f.detect_conflict(session_2, 150);
+            });
+
+            THEN("it returns 0 (truncate is visible at this read timestamp)")
+            {
+                REQUIRE(result == 0);
             }
         }
     }

--- a/test/catch2/truncate/test_truncate_write_conflict.cpp
+++ b/test/catch2/truncate/test_truncate_write_conflict.cpp
@@ -38,9 +38,9 @@ do_in_committed_transaction(WT_SESSION_IMPL *session, const Op operation)
 {
     auto *iface = &session->iface;
 
-    REQUIRE(iface->begin_transaction(iface, nullptr) == 0);
+    CHECK(iface->begin_transaction(iface, nullptr) == 0);
     const int ret = operation();
-    REQUIRE(iface->commit_transaction(iface, nullptr) == 0);
+    CHECK(iface->commit_transaction(iface, nullptr) == 0);
 
     return ret;
 }

--- a/test/catch2/truncate/test_truncate_write_conflict.cpp
+++ b/test/catch2/truncate/test_truncate_write_conflict.cpp
@@ -1,0 +1,470 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+#include <filesystem>
+#include <iomanip>
+#include <sstream>
+#include <string_view>
+
+#include <catch2/catch.hpp>
+
+#include "wt_internal.h"
+#include "wrappers/connection_wrapper.h"
+#include "truncate_list_helpers.hpp"
+
+using namespace truncate_list_helpers;
+
+namespace {
+
+// Converts an integer to a string in the form "keyNNN", where NNN is zero-padded.
+std::string
+format_key(const int num)
+{
+    std::ostringstream oss;
+    oss << "key" << std::setfill('0') << std::setw(3) << num;
+    return oss.str();
+}
+
+// Calls the provided functor/lambda, wrapped in a transaction.
+template <typename Op>
+int
+do_in_transaction(WT_SESSION_IMPL *s, const Op operation, const bool commit)
+{
+    auto *iface = &s->iface;
+    REQUIRE(iface->begin_transaction(iface, nullptr) == 0);
+
+    const int ret = operation();
+
+    if (commit)
+        REQUIRE(iface->commit_transaction(iface, nullptr) == 0);
+
+    return ret;
+}
+
+template <typename Op>
+int
+do_in_uncommitted_transaction(WT_SESSION_IMPL *session, const Op operation)
+{
+    return do_in_transaction(session, operation, /* commit = */ false);
+}
+
+template <typename Op>
+int
+do_in_committed_transaction(WT_SESSION_IMPL *session, const Op operation)
+{
+    return do_in_transaction(session, operation, /* commit = */ true);
+}
+
+// Ensures the given test directory is removed at the beginning of the test.
+class home_directory {
+public:
+    explicit home_directory(const std::string_view path) : _path(path)
+    {
+        std::filesystem::remove_all(path);
+    }
+
+    [[nodiscard]] std::string_view
+    path() const
+    {
+        return _path;
+    }
+
+private:
+    std::string _path;
+};
+
+class write_conflict_fixture {
+public:
+    write_conflict_fixture()
+    {
+        constexpr auto uri = "layered:write_conflict";
+
+        static constexpr auto config =
+          "key_format=S,value_format=S,block_manager=disagg,type=layered";
+
+        auto &session = _session->iface;
+        REQUIRE(session.create(&session, uri, config) == 0);
+        REQUIRE(session.open_cursor(&session, uri, nullptr, nullptr, &_cursor) == 0);
+    }
+
+    [[nodiscard]] WT_SESSION_IMPL *
+    session() const
+    {
+        return _session;
+    }
+
+    [[nodiscard]] WT_SESSION_IMPL *
+    create_session()
+    {
+        return _conn.create_session();
+    }
+
+    [[nodiscard]] WT_LAYERED_TABLE *
+    layered_table() const
+    {
+        auto *layered_cursor = reinterpret_cast<WT_CURSOR_LAYERED *>(_cursor);
+        return reinterpret_cast<WT_LAYERED_TABLE *>(layered_cursor->dhandle);
+    }
+
+    int
+    insert_truncate_entry(WT_SESSION_IMPL *session, const int start, const int stop)
+    {
+        const auto start_str = format_key(start);
+        const auto stop_str = format_key(stop);
+        auto start_item = make_item(start_str);
+        auto stop_item = make_item(stop_str);
+
+        return __wt_insert_truncate_entry(session, layered_table(), &start_item, &stop_item);
+    }
+
+    int
+    detect_conflict(WT_SESSION_IMPL *session, const int key)
+    {
+        const auto key_str = format_key(key);
+        auto key_item = make_item(key_str);
+
+        return __wt_layered_table_truncate_detect_write_conflict(
+          session, layered_table(), &key_item);
+    }
+
+private:
+    static constexpr auto conn_config =
+      "create,"
+      "extensions=[./ext/page_log/palite/libwiredtiger_palite.so],"
+      "disaggregated=(role=follower,page_log=palite)";
+
+    scoped_fast_truncate_enable _enable;
+    home_directory _home{"WT_TEST.truncate_write_conflict"};
+    connection_wrapper _conn{_home.path().data(), conn_config};
+    WT_SESSION_IMPL *_session{_conn.create_session()};
+    WT_CURSOR *_cursor{};
+};
+
+} // namespace
+
+SCENARIO("write conflict returns 0 for an empty truncate list", "[truncate_list][write_conflict]")
+{
+    GIVEN("a layered table with an empty truncate list")
+    {
+        write_conflict_fixture f;
+
+        WHEN("the conflict check is called for any key")
+        {
+            const auto result = do_in_uncommitted_transaction(
+              f.session(), [&] { return f.detect_conflict(f.session(), 150); });
+
+            THEN("it returns 0 (no conflict)")
+            {
+                REQUIRE(result == 0);
+            }
+        }
+    }
+}
+
+SCENARIO("write conflict returns 0 when the key is outside all uncommitted ranges",
+  "[truncate_list][write_conflict]")
+{
+    GIVEN("one uncommitted truncate range [100, 200]")
+    {
+        write_conflict_fixture f;
+        do_in_uncommitted_transaction(
+          f.session(), [&] { return f.insert_truncate_entry(f.session(), 100, 200); });
+
+        WHEN("the conflict check is called for a key before the range")
+        {
+            auto *session_2 = f.create_session();
+            const auto result = do_in_uncommitted_transaction(
+              session_2, [&] { return f.detect_conflict(session_2, 50); });
+
+            THEN("it returns 0 (no conflict)")
+            {
+                REQUIRE(result == 0);
+            }
+        }
+
+        WHEN("the conflict check is called for a key after the range")
+        {
+            auto *session_2 = f.create_session();
+            const auto result = do_in_uncommitted_transaction(
+              session_2, [&] { return f.detect_conflict(session_2, 250); });
+
+            THEN("it returns 0 (no conflict)")
+            {
+                REQUIRE(result == 0);
+            }
+        }
+    }
+
+    GIVEN("two non-overlapping uncommitted ranges [100, 200] and [400, 500]")
+    {
+        write_conflict_fixture f;
+        do_in_uncommitted_transaction(f.session(), [&] {
+            REQUIRE(f.insert_truncate_entry(f.session(), 100, 200) == 0);
+            REQUIRE(f.insert_truncate_entry(f.session(), 400, 500) == 0);
+            return 0;
+        });
+
+        WHEN("the conflict check is called for a key between the ranges")
+        {
+            auto *session_2 = f.create_session();
+            const auto result = do_in_uncommitted_transaction(
+              session_2, [&] { return f.detect_conflict(session_2, 300); });
+
+            THEN("it returns 0 (no conflict)")
+            {
+                REQUIRE(result == 0);
+            }
+        }
+    }
+}
+
+SCENARIO("write conflict returns WT_ROLLBACK when the key is inside an uncommitted range",
+  "[truncate_list][write_conflict]")
+{
+    GIVEN("one uncommitted truncate range [100, 200]")
+    {
+        write_conflict_fixture f;
+        do_in_uncommitted_transaction(
+          f.session(), [&] { return f.insert_truncate_entry(f.session(), 100, 200); });
+
+        WHEN("the conflict check is called for a key strictly inside the range")
+        {
+            auto *session_2 = f.create_session();
+            const auto result = do_in_uncommitted_transaction(
+              session_2, [&] { return f.detect_conflict(session_2, 150); });
+
+            THEN("it returns WT_ROLLBACK")
+            {
+                REQUIRE(result == WT_ROLLBACK);
+            }
+        }
+
+        WHEN("the conflict check is called for the start boundary key")
+        {
+            auto *session_2 = f.create_session();
+            const auto result = do_in_uncommitted_transaction(
+              session_2, [&] { return f.detect_conflict(session_2, 100); });
+
+            THEN("it returns WT_ROLLBACK (start boundary is inclusive)")
+            {
+                REQUIRE(result == WT_ROLLBACK);
+            }
+        }
+
+        WHEN("the conflict check is called for the stop boundary key")
+        {
+            auto *session_2 = f.create_session();
+            const auto result = do_in_uncommitted_transaction(
+              session_2, [&] { return f.detect_conflict(session_2, 200); });
+
+            THEN("it returns WT_ROLLBACK (stop boundary is inclusive)")
+            {
+                REQUIRE(result == WT_ROLLBACK);
+            }
+        }
+    }
+}
+
+SCENARIO("write conflict with a single-key uncommitted range", "[truncate_list][write_conflict]")
+{
+    GIVEN("a single-key uncommitted range [100, 100]")
+    {
+        write_conflict_fixture f;
+        do_in_uncommitted_transaction(
+          f.session(), [&] { return f.insert_truncate_entry(f.session(), 100, 100); });
+
+        WHEN("the conflict check is called for the exact key")
+        {
+            auto *session_2 = f.create_session();
+            const auto result = do_in_uncommitted_transaction(
+              session_2, [&] { return f.detect_conflict(session_2, 100); });
+
+            THEN("it returns WT_ROLLBACK")
+            {
+                REQUIRE(result == WT_ROLLBACK);
+            }
+        }
+
+        WHEN("the conflict check is called for a key just before the range")
+        {
+            auto *session_2 = f.create_session();
+            const auto result = do_in_uncommitted_transaction(
+              session_2, [&] { return f.detect_conflict(session_2, 99); });
+
+            THEN("it returns 0 (no conflict)")
+            {
+                REQUIRE(result == 0);
+            }
+        }
+
+        WHEN("the conflict check is called for a key just after the range")
+        {
+            auto *session_2 = f.create_session();
+            const auto result = do_in_uncommitted_transaction(
+              session_2, [&] { return f.detect_conflict(session_2, 101); });
+
+            THEN("it returns 0 (no conflict)")
+            {
+                REQUIRE(result == 0);
+            }
+        }
+    }
+}
+
+SCENARIO(
+  "write conflict with two non-overlapping uncommitted ranges", "[truncate_list][write_conflict]")
+{
+    GIVEN("uncommitted ranges [100, 200] and [400, 500]")
+    {
+        write_conflict_fixture f;
+        do_in_uncommitted_transaction(f.session(), [&] {
+            REQUIRE(f.insert_truncate_entry(f.session(), 100, 200) == 0);
+            REQUIRE(f.insert_truncate_entry(f.session(), 400, 500) == 0);
+            return 0;
+        });
+
+        WHEN("the conflict check is called for a key in the first range")
+        {
+            auto *session_2 = f.create_session();
+            const auto result = do_in_uncommitted_transaction(
+              session_2, [&] { return f.detect_conflict(session_2, 150); });
+
+            THEN("it returns WT_ROLLBACK")
+            {
+                REQUIRE(result == WT_ROLLBACK);
+            }
+        }
+
+        WHEN("the conflict check is called for a key in the second range")
+        {
+            auto *session_2 = f.create_session();
+            const auto result = do_in_uncommitted_transaction(
+              session_2, [&] { return f.detect_conflict(session_2, 450); });
+
+            THEN("it returns WT_ROLLBACK")
+            {
+                REQUIRE(result == WT_ROLLBACK);
+            }
+        }
+    }
+}
+
+SCENARIO("write conflict does not trigger for a committed truncate range",
+  "[truncate_list][write_conflict]")
+{
+    GIVEN("one committed (globally visible) truncate range [100, 200]")
+    {
+        write_conflict_fixture f;
+        do_in_committed_transaction(
+          f.session(), [&] { return f.insert_truncate_entry(f.session(), 100, 200); });
+
+        WHEN("the conflict check is called for a key inside the committed range")
+        {
+            auto *session_2 = f.create_session();
+            const auto result = do_in_uncommitted_transaction(
+              session_2, [&] { return f.detect_conflict(session_2, 150); });
+
+            THEN("it returns 0 (no conflict)")
+            {
+                REQUIRE(result == 0);
+            }
+        }
+    }
+}
+
+SCENARIO("write conflict does not trigger for the reader's own uncommitted range",
+  "[truncate_list][write_conflict]")
+{
+    GIVEN("an uncommitted truncate range owned by the current transaction")
+    {
+        write_conflict_fixture f;
+
+        WHEN("the conflict check is called for a key inside that range")
+        {
+            const auto result = do_in_uncommitted_transaction(f.session(), [&] {
+                f.insert_truncate_entry(f.session(), 100, 200);
+                return f.detect_conflict(f.session(), 150);
+            });
+
+            THEN("it returns 0 (no conflict)")
+            {
+                REQUIRE(result == 0);
+            }
+        }
+    }
+}
+
+SCENARIO("write conflict with overlapping committed and uncommitted ranges",
+  "[truncate_list][write_conflict]")
+{
+    GIVEN("a committed range [100, 300] and an uncommitted range [200, 400]")
+    {
+        write_conflict_fixture f;
+        auto *session_2 = f.create_session();
+
+        do_in_committed_transaction(
+          f.session(), [&] { return f.insert_truncate_entry(f.session(), 100, 300); });
+
+        do_in_uncommitted_transaction(
+          session_2, [&] { return f.insert_truncate_entry(session_2, 200, 400); });
+
+        WHEN("the conflict check is called for a key covered only by the committed range")
+        {
+            auto *session_3 = f.create_session();
+            const auto result = do_in_uncommitted_transaction(
+              session_3, [&] { return f.detect_conflict(session_3, 150); });
+
+            THEN("it returns 0 (no conflict)")
+            {
+                REQUIRE(result == 0);
+            }
+        }
+
+        WHEN("the conflict check is called for a key in the overlap region")
+        {
+            auto *session_3 = f.create_session();
+            const auto result = do_in_uncommitted_transaction(
+              session_3, [&] { return f.detect_conflict(session_3, 250); });
+
+            THEN("it returns WT_ROLLBACK (uncommitted range covers the key)")
+            {
+                REQUIRE(result == WT_ROLLBACK);
+            }
+        }
+
+        WHEN("the conflict check is called for a key covered only by the uncommitted range")
+        {
+            auto *session_3 = f.create_session();
+            const auto result = do_in_uncommitted_transaction(
+              session_3, [&] { return f.detect_conflict(session_3, 350); });
+
+            THEN("it returns WT_ROLLBACK")
+            {
+                REQUIRE(result == WT_ROLLBACK);
+            }
+        }
+    }
+}
+
+SCENARIO("write conflict read lock is always released", "[truncate_list][write_conflict]")
+{
+    GIVEN("a layered table")
+    {
+        write_conflict_fixture f;
+
+        WHEN("the conflict check is called")
+        {
+            f.detect_conflict(f.session(), 150);
+
+            THEN("the truncate lock is not held")
+            {
+                REQUIRE(lock_is_released(*f.session(), *f.layered_table()));
+            }
+        }
+    }
+}

--- a/test/catch2/truncate/test_truncate_write_conflict.cpp
+++ b/test/catch2/truncate/test_truncate_write_conflict.cpp
@@ -163,6 +163,18 @@ public:
           session, layered_table(), &key_item);
     }
 
+    int
+    detect_non_ingest_conflict(WT_SESSION_IMPL *session, const int start, const int stop)
+    {
+        const auto start_str = format_key(start);
+        const auto stop_str = format_key(stop);
+        auto start_item = make_item(start_str);
+        auto stop_item = make_item(stop_str);
+
+        return __wt_layered_table_truncate_detect_non_ingest_write_conflict(
+          session, layered_table(), &start_item, &stop_item);
+    }
+
 private:
     static constexpr auto conn_config =
       "create,"
@@ -240,8 +252,8 @@ SCENARIO("write conflict returns 0 when the key is outside all uncommitted range
         write_conflict_fixture f;
 
         do_in_uncommitted_transaction(f.session(), [&] {
-            REQUIRE(f.insert_truncate_entry(f.session(), 100, 200) == 0);
-            REQUIRE(f.insert_truncate_entry(f.session(), 400, 500) == 0);
+            CHECK(f.insert_truncate_entry(f.session(), 100, 200) == 0);
+            CHECK(f.insert_truncate_entry(f.session(), 400, 500) == 0);
             return 0;
         });
 
@@ -375,8 +387,8 @@ SCENARIO(
         write_conflict_fixture f;
 
         do_in_uncommitted_transaction(f.session(), [&] {
-            f.insert_truncate_entry(f.session(), 100, 200);
-            f.insert_truncate_entry(f.session(), 400, 500);
+            CHECK(f.insert_truncate_entry(f.session(), 100, 200) == 0);
+            CHECK(f.insert_truncate_entry(f.session(), 400, 500) == 0);
             return 0;
         });
 
@@ -435,7 +447,7 @@ SCENARIO("write conflict does not trigger for a committed truncate range",
     }
 }
 
-SCENARIO("write conflict does not trigger for the reader's own uncommitted range",
+SCENARIO("write conflict does not trigger for the caller's own uncommitted range",
   "[truncate_list][write_conflict]")
 {
     GIVEN("an uncommitted truncate range owned by the current transaction")
@@ -449,7 +461,7 @@ SCENARIO("write conflict does not trigger for the reader's own uncommitted range
                 return f.detect_conflict(f.session(), 150);
             });
 
-            THEN("it returns 0 (no conflict)")
+            THEN("it returns 0 (no self-conflict)")
             {
                 REQUIRE(result == 0);
             }
@@ -508,6 +520,58 @@ SCENARIO("write conflict with overlapping committed and uncommitted ranges",
               session_3, [&] { return f.detect_conflict(session_3, 350); });
 
             THEN("it returns WT_ROLLBACK")
+            {
+                REQUIRE(result == WT_ROLLBACK);
+            }
+        }
+
+        WHEN("the conflict check is called for the start boundary of the committed range")
+        {
+            auto *session_3 = f.create_session();
+
+            const auto result = do_in_rolled_back_transaction(
+              session_3, [&] { return f.detect_conflict(session_3, 100); });
+
+            THEN("it returns 0 (committed range is visible; key is not in uncommitted range)")
+            {
+                REQUIRE(result == 0);
+            }
+        }
+
+        WHEN("the conflict check is called for the start boundary of the uncommitted range")
+        {
+            auto *session_3 = f.create_session();
+
+            const auto result = do_in_rolled_back_transaction(
+              session_3, [&] { return f.detect_conflict(session_3, 200); });
+
+            THEN("it returns WT_ROLLBACK (uncommitted range covers the key)")
+            {
+                REQUIRE(result == WT_ROLLBACK);
+            }
+        }
+
+        WHEN("the conflict check is called for the stop boundary of the committed range")
+        {
+            auto *session_3 = f.create_session();
+
+            const auto result = do_in_rolled_back_transaction(
+              session_3, [&] { return f.detect_conflict(session_3, 300); });
+
+            THEN("it returns WT_ROLLBACK (uncommitted range covers the key)")
+            {
+                REQUIRE(result == WT_ROLLBACK);
+            }
+        }
+
+        WHEN("the conflict check is called for the stop boundary of the uncommitted range")
+        {
+            auto *session_3 = f.create_session();
+
+            const auto result = do_in_rolled_back_transaction(
+              session_3, [&] { return f.detect_conflict(session_3, 400); });
+
+            THEN("it returns WT_ROLLBACK (uncommitted range covers the key)")
             {
                 REQUIRE(result == WT_ROLLBACK);
             }
@@ -575,6 +639,430 @@ SCENARIO("write conflict returns WT_ROLLBACK when read_timestamp predates a comm
             THEN("it returns 0 (truncate is visible at this read timestamp)")
             {
                 REQUIRE(result == 0);
+            }
+        }
+
+        WHEN("the conflict check is called with read_timestamp after the truncate timestamp")
+        {
+            auto *session_2 = f.create_session();
+
+            const auto result = do_in_rolled_back_transaction(session_2, [&] {
+                set_read_timestamp(session_2, 31);
+                return f.detect_conflict(session_2, 150);
+            });
+
+            THEN("it returns 0 (truncate is visible at this read timestamp)")
+            {
+                REQUIRE(result == 0);
+            }
+        }
+    }
+}
+
+SCENARIO("non-ingest write conflict returns 0 for an empty truncate list",
+  "[truncate_list][write_conflict]")
+{
+    GIVEN("a layered table with an empty truncate list")
+    {
+        write_conflict_fixture f;
+
+        WHEN("the non-ingest conflict check is called for any range")
+        {
+            const auto result = do_in_rolled_back_transaction(
+              f.session(), [&] { return f.detect_non_ingest_conflict(f.session(), 100, 200); });
+
+            THEN("it returns 0 (no conflict)")
+            {
+                REQUIRE(result == 0);
+            }
+        }
+    }
+}
+
+SCENARIO("non-ingest write conflict returns 0 when ranges do not overlap",
+  "[truncate_list][write_conflict]")
+{
+    GIVEN("one uncommitted truncate range [100, 200]")
+    {
+        write_conflict_fixture f;
+
+        do_in_uncommitted_transaction(
+          f.session(), [&] { return f.insert_truncate_entry(f.session(), 100, 200); });
+
+        const auto cleanup = rollback_on_exit(f.session());
+
+        WHEN("the new range ends just before the existing start")
+        {
+            auto *session_2 = f.create_session();
+
+            // new [10, 99]: 99 < 100 so neither overlap check fires
+            const auto result = do_in_rolled_back_transaction(
+              session_2, [&] { return f.detect_non_ingest_conflict(session_2, 10, 99); });
+
+            THEN("it returns 0 (no conflict)")
+            {
+                REQUIRE(result == 0);
+            }
+        }
+
+        WHEN("the new range starts just after the existing stop")
+        {
+            auto *session_2 = f.create_session();
+
+            // new [201, 400]: 201 > 200 so neither overlap check fires
+            const auto result = do_in_rolled_back_transaction(
+              session_2, [&] { return f.detect_non_ingest_conflict(session_2, 201, 400); });
+
+            THEN("it returns 0 (no conflict)")
+            {
+                REQUIRE(result == 0);
+            }
+        }
+    }
+}
+
+SCENARIO(
+  "non-ingest write conflict returns WT_ROLLBACK when ranges overlap with an uncommitted truncate",
+  "[truncate_list][write_conflict]")
+{
+    GIVEN("one uncommitted truncate range [100, 300]")
+    {
+        write_conflict_fixture f;
+
+        do_in_uncommitted_transaction(
+          f.session(), [&] { return f.insert_truncate_entry(f.session(), 100, 300); });
+
+        const auto cleanup = rollback_on_exit(f.session());
+
+        WHEN("the new range starts at the existing stop boundary")
+        {
+            auto *session_2 = f.create_session();
+
+            // new [300, 400]: new_start(300) falls within existing [100, 300]
+            const auto result = do_in_rolled_back_transaction(
+              session_2, [&] { return f.detect_non_ingest_conflict(session_2, 300, 400); });
+
+            THEN("it returns WT_ROLLBACK (stop boundary is inclusive)")
+            {
+                REQUIRE(result == WT_ROLLBACK);
+            }
+        }
+
+        WHEN("the new range ends at the existing start boundary")
+        {
+            auto *session_2 = f.create_session();
+
+            // new [50, 100]: existing_start(100) falls within new [50, 100]
+            const auto result = do_in_rolled_back_transaction(
+              session_2, [&] { return f.detect_non_ingest_conflict(session_2, 50, 100); });
+
+            THEN("it returns WT_ROLLBACK (start boundary is inclusive)")
+            {
+                REQUIRE(result == WT_ROLLBACK);
+            }
+        }
+    }
+}
+
+SCENARIO("non-ingest write conflict does not trigger for a committed truncate range",
+  "[truncate_list][write_conflict]")
+{
+    GIVEN("one committed (globally visible) truncate range [100, 300]")
+    {
+        write_conflict_fixture f;
+
+        do_in_committed_transaction(
+          f.session(), [&] { return f.insert_truncate_entry(f.session(), 100, 300); });
+
+        WHEN("the non-ingest conflict check is called for an overlapping range")
+        {
+            auto *session_2 = f.create_session();
+
+            const auto result = do_in_rolled_back_transaction(
+              session_2, [&] { return f.detect_non_ingest_conflict(session_2, 200, 400); });
+
+            THEN("it returns 0 (no conflict)")
+            {
+                REQUIRE(result == 0);
+            }
+        }
+    }
+}
+
+SCENARIO("non-ingest write conflict does not trigger for the caller's own uncommitted range",
+  "[truncate_list][write_conflict]")
+{
+    GIVEN("an uncommitted truncate range owned by the current transaction")
+    {
+        write_conflict_fixture f;
+
+        WHEN(
+          "the non-ingest conflict check is called for an overlapping range in the same "
+          "transaction")
+        {
+            const auto result = do_in_rolled_back_transaction(f.session(), [&] {
+                f.insert_truncate_entry(f.session(), 100, 300);
+                return f.detect_non_ingest_conflict(f.session(), 200, 400);
+            });
+
+            THEN("it returns 0 (no self-conflict)")
+            {
+                REQUIRE(result == 0);
+            }
+        }
+    }
+}
+
+SCENARIO(
+  "non-ingest write conflict read lock is always released", "[truncate_list][write_conflict]")
+{
+    GIVEN("a layered table")
+    {
+        write_conflict_fixture f;
+
+        WHEN("the non-ingest conflict check is called")
+        {
+            do_in_rolled_back_transaction(
+              f.session(), [&] { return f.detect_non_ingest_conflict(f.session(), 100, 200); });
+
+            THEN("the truncate lock is not held")
+            {
+                REQUIRE(lock_is_released(*f.session(), *f.layered_table()));
+            }
+        }
+    }
+}
+
+SCENARIO(
+  "non-ingest write conflict returns WT_ROLLBACK when read_timestamp predates a committed truncate",
+  "[truncate_list][write_conflict]")
+{
+    GIVEN("a committed truncate range [100, 300] with timestamp 30")
+    {
+        write_conflict_fixture f;
+
+        do_in_committed_transaction(
+          f.session(), [&] { return f.insert_truncate_entry(f.session(), 100, 300); });
+
+        WT_TRUNCATE *entry = truncate_list_head(*f.layered_table());
+        entry->start_ts = 30;
+        entry->durable_ts = 30;
+
+        WHEN(
+          "the non-ingest conflict check is called with read_timestamp before the truncate "
+          "timestamp")
+        {
+            auto *session_2 = f.create_session();
+
+            const auto result = do_in_rolled_back_transaction(session_2, [&] {
+                set_read_timestamp(session_2, 29);
+                return f.detect_non_ingest_conflict(session_2, 200, 400);
+            });
+
+            THEN("it returns WT_ROLLBACK (truncate is not visible at this read timestamp)")
+            {
+                REQUIRE(result == WT_ROLLBACK);
+            }
+        }
+
+        WHEN(
+          "the non-ingest conflict check is called with read_timestamp equal to the truncate "
+          "timestamp")
+        {
+            auto *session_2 = f.create_session();
+
+            const auto result = do_in_rolled_back_transaction(session_2, [&] {
+                set_read_timestamp(session_2, 30);
+                return f.detect_non_ingest_conflict(session_2, 200, 400);
+            });
+
+            THEN("it returns 0 (truncate is visible at this read timestamp)")
+            {
+                REQUIRE(result == 0);
+            }
+        }
+
+        WHEN(
+          "the non-ingest conflict check is called with read_timestamp after the truncate "
+          "timestamp")
+        {
+            auto *session_2 = f.create_session();
+
+            const auto result = do_in_rolled_back_transaction(session_2, [&] {
+                set_read_timestamp(session_2, 31);
+                return f.detect_non_ingest_conflict(session_2, 200, 400);
+            });
+
+            THEN("it returns 0 (truncate is visible at this read timestamp)")
+            {
+                REQUIRE(result == 0);
+            }
+        }
+    }
+}
+
+SCENARIO("non-ingest write conflict with a single-key uncommitted range",
+  "[truncate_list][write_conflict]")
+{
+    GIVEN("a single-key uncommitted range [100, 100]")
+    {
+        write_conflict_fixture f;
+
+        do_in_uncommitted_transaction(
+          f.session(), [&] { return f.insert_truncate_entry(f.session(), 100, 100); });
+
+        const auto cleanup = rollback_on_exit(f.session());
+
+        WHEN("the new range exactly matches the existing range")
+        {
+            auto *session_2 = f.create_session();
+
+            const auto result = do_in_rolled_back_transaction(
+              session_2, [&] { return f.detect_non_ingest_conflict(session_2, 100, 100); });
+
+            THEN("it returns WT_ROLLBACK")
+            {
+                REQUIRE(result == WT_ROLLBACK);
+            }
+        }
+
+        WHEN("the new range ends just before the existing range")
+        {
+            auto *session_2 = f.create_session();
+
+            const auto result = do_in_rolled_back_transaction(
+              session_2, [&] { return f.detect_non_ingest_conflict(session_2, 99, 99); });
+
+            THEN("it returns 0 (no overlap)")
+            {
+                REQUIRE(result == 0);
+            }
+        }
+
+        WHEN("the new range starts just after the existing range")
+        {
+            auto *session_2 = f.create_session();
+
+            const auto result = do_in_rolled_back_transaction(
+              session_2, [&] { return f.detect_non_ingest_conflict(session_2, 101, 101); });
+
+            THEN("it returns 0 (no overlap)")
+            {
+                REQUIRE(result == 0);
+            }
+        }
+    }
+}
+
+SCENARIO("non-ingest write conflict with two non-overlapping uncommitted ranges",
+  "[truncate_list][write_conflict]")
+{
+    GIVEN("uncommitted ranges [100, 200] and [400, 500]")
+    {
+        write_conflict_fixture f;
+
+        do_in_uncommitted_transaction(f.session(), [&] {
+            CHECK(f.insert_truncate_entry(f.session(), 100, 200) == 0);
+            CHECK(f.insert_truncate_entry(f.session(), 400, 500) == 0);
+            return 0;
+        });
+
+        const auto cleanup = rollback_on_exit(f.session());
+
+        WHEN("the new range is inside the first existing range")
+        {
+            auto *session_2 = f.create_session();
+
+            const auto result = do_in_rolled_back_transaction(
+              session_2, [&] { return f.detect_non_ingest_conflict(session_2, 150, 175); });
+
+            THEN("it returns WT_ROLLBACK")
+            {
+                REQUIRE(result == WT_ROLLBACK);
+            }
+        }
+
+        WHEN("the new range is inside the second existing range")
+        {
+            auto *session_2 = f.create_session();
+
+            const auto result = do_in_rolled_back_transaction(
+              session_2, [&] { return f.detect_non_ingest_conflict(session_2, 450, 475); });
+
+            THEN("it returns WT_ROLLBACK")
+            {
+                REQUIRE(result == WT_ROLLBACK);
+            }
+        }
+
+        WHEN("the new range falls between the two existing ranges")
+        {
+            auto *session_2 = f.create_session();
+
+            const auto result = do_in_rolled_back_transaction(
+              session_2, [&] { return f.detect_non_ingest_conflict(session_2, 250, 350); });
+
+            THEN("it returns 0 (no overlap)")
+            {
+                REQUIRE(result == 0);
+            }
+        }
+    }
+}
+
+SCENARIO("non-ingest write conflict with overlapping committed and uncommitted ranges",
+  "[truncate_list][write_conflict]")
+{
+    GIVEN("a committed range [100, 300] and an uncommitted range [200, 400]")
+    {
+        write_conflict_fixture f;
+
+        do_in_committed_transaction(
+          f.session(), [&] { return f.insert_truncate_entry(f.session(), 100, 300); });
+
+        auto *session_2 = f.create_session();
+
+        do_in_uncommitted_transaction(
+          session_2, [&] { return f.insert_truncate_entry(session_2, 200, 400); });
+
+        const auto cleanup = rollback_on_exit(session_2);
+
+        WHEN("the new range overlaps only the committed range")
+        {
+            auto *session_3 = f.create_session();
+
+            const auto result = do_in_rolled_back_transaction(
+              session_3, [&] { return f.detect_non_ingest_conflict(session_3, 50, 150); });
+
+            THEN("it returns 0 (committed range is visible)")
+            {
+                REQUIRE(result == 0);
+            }
+        }
+
+        WHEN("the new range overlaps the uncommitted range")
+        {
+            auto *session_3 = f.create_session();
+
+            const auto result = do_in_rolled_back_transaction(
+              session_3, [&] { return f.detect_non_ingest_conflict(session_3, 250, 350); });
+
+            THEN("it returns WT_ROLLBACK (uncommitted range covers the overlap)")
+            {
+                REQUIRE(result == WT_ROLLBACK);
+            }
+        }
+
+        WHEN("the new range overlaps only the uncommitted range")
+        {
+            auto *session_3 = f.create_session();
+
+            const auto result = do_in_rolled_back_transaction(
+              session_3, [&] { return f.detect_non_ingest_conflict(session_3, 350, 450); });
+
+            THEN("it returns WT_ROLLBACK")
+            {
+                REQUIRE(result == WT_ROLLBACK);
             }
         }
     }

--- a/test/suite/test_layered_fast_truncate18.py
+++ b/test/suite/test_layered_fast_truncate18.py
@@ -1,27 +1,30 @@
 #!/usr/bin/env python3
 #
-# Public Domain 2014-present MongoDB, Inc. Public Domain 2008-2014 WiredTiger,
-# Inc.
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
 #
 # This is free and unencumbered software released into the public domain.
 #
-# Anyone is free to copy, modify, publish, use, compile, sell, or distribute
-# this software, either in source code form or as a compiled binary, for any
-# purpose, commercial or non-commercial, and by any means.
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
 #
-# In jurisdictions that recognize copyright laws, the author or authors of this
-# software dedicate any and all copyright interest in the software to the
-# public domain. We make this dedication for the benefit of the public at large
-# and to the detriment of our heirs and successors. We intend this dedication
-# to be an overt act of relinquishment in perpetuity of all present and future
-# rights to this software under copyright law.
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
 #
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
-# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
 
 # test_layered_fast_truncate18.py
 #   Write conflict detection for follower fast truncate (truncate-truncate

--- a/test/suite/test_layered_fast_truncate18.py
+++ b/test/suite/test_layered_fast_truncate18.py
@@ -131,9 +131,8 @@ class test_layered_fast_truncate18(wttest.WiredTigerTestCase):
 
         # The transaction committed; no WT_ROLLBACK raised.
 
-    # FIXME-WT-17272: There needs to be a write-conflict check inside
-    # `__txn_insert_truncate_entry_helper` when inserting into the truncate
-    # list.
+    # FIXME-WT-17272: Overlapping uncommitted truncates are not detected as
+    # write conflicts even when ingest keys exist in the truncated range.
     @unittest.skip("FIXME-WT-17272")
     def test_overlapping_truncates_conflict_with_ingest(self):
         # A follower with stable keys 1-100 and ingest key 45.
@@ -156,9 +155,8 @@ class test_layered_fast_truncate18(wttest.WiredTigerTestCase):
                 self.CONFLICT_MSG,
             )
 
-    # FIXME-WT-17272: There needs to be a write-conflict check inside
-    # `__txn_insert_truncate_entry_helper` when inserting into the truncate
-    # list.
+    # FIXME-WT-17272: Overlapping uncommitted truncates are not detected as
+    # write conflicts when there are no ingest keys in the truncated range.
     @unittest.skip("FIXME-WT-17272")
     def test_overlapping_truncates_conflict_no_ingest(self):
         # A follower with stable keys 1-100 and an empty ingest table.
@@ -215,9 +213,8 @@ class test_layered_fast_truncate18(wttest.WiredTigerTestCase):
         ):
             self.truncate(session_b, 30, 60)
 
-    # FIXME-WT-17272: There needs to be a write-conflict check inside
-    # `__txn_insert_truncate_entry_helper` when inserting into the truncate
-    # list.
+    # FIXME-WT-17272: Truncates that are committed but invisible due to
+    # read-timestamp differences are not detected as write conflicts.
     @unittest.skip("FIXME-WT-17272")
     def test_invisible_committed_truncate_conflicts(self):
         # A follower with stable keys 1-100.

--- a/test/suite/test_layered_fast_truncate18.py
+++ b/test/suite/test_layered_fast_truncate18.py
@@ -34,7 +34,7 @@ import unittest
 from contextlib import closing, nullcontext
 from typing import Iterable
 from helper_disagg import disagg_test_class, gen_disagg_storages
-from wiredtiger import disagg_fast_truncate_build, WiredTigerError
+from wiredtiger import WiredTigerError
 from wtscenario import make_scenarios
 import wttest
 
@@ -61,11 +61,6 @@ class test_layered_fast_truncate18(wttest.WiredTigerTestCase):
     conn_config = 'disaggregated=(role="leader"),'
 
     CONFLICT_MSG = "/conflict between concurrent operations/"
-
-    def setUp(self):
-        if disagg_fast_truncate_build() == 0:
-            self.skipTest("fast truncate support is not enabled")
-        super().setUp()
 
     def session_create_config(self) -> str:
         """Return a config string for session.create() based on table URI."""
@@ -131,9 +126,6 @@ class test_layered_fast_truncate18(wttest.WiredTigerTestCase):
 
         # The transaction committed; no WT_ROLLBACK raised.
 
-    # FIXME-WT-17272: Overlapping uncommitted truncates are not detected as
-    # write conflicts even when ingest keys exist in the truncated range.
-    @unittest.skip("FIXME-WT-17272")
     def test_overlapping_truncates_conflict_with_ingest(self):
         # A follower with stable keys 1-100 and ingest key 45.
         self.setup_leader(keys=range_inclusive(1, 100))
@@ -155,9 +147,6 @@ class test_layered_fast_truncate18(wttest.WiredTigerTestCase):
                 self.CONFLICT_MSG,
             )
 
-    # FIXME-WT-17272: Overlapping uncommitted truncates are not detected as
-    # write conflicts when there are no ingest keys in the truncated range.
-    @unittest.skip("FIXME-WT-17272")
     def test_overlapping_truncates_conflict_no_ingest(self):
         # A follower with stable keys 1-100 and an empty ingest table.
         self.setup_leader(keys=range_inclusive(1, 100))
@@ -213,9 +202,6 @@ class test_layered_fast_truncate18(wttest.WiredTigerTestCase):
         ):
             self.truncate(session_b, 30, 60)
 
-    # FIXME-WT-17272: Truncates that are committed but invisible due to
-    # read-timestamp differences are not detected as write conflicts.
-    @unittest.skip("FIXME-WT-17272")
     def test_invisible_committed_truncate_conflicts(self):
         # A follower with stable keys 1-100.
         self.setup_leader(keys=range_inclusive(1, 100))

--- a/test/suite/test_layered_fast_truncate18.py
+++ b/test/suite/test_layered_fast_truncate18.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc. Public Domain 2008-2014 WiredTiger,
+# Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or distribute
+# this software, either in source code form or as a compiled binary, for any
+# purpose, commercial or non-commercial, and by any means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors of this
+# software dedicate any and all copyright interest in the software to the
+# public domain. We make this dedication for the benefit of the public at large
+# and to the detriment of our heirs and successors. We intend this dedication
+# to be an overt act of relinquishment in perpetuity of all present and future
+# rights to this software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+# test_layered_fast_truncate18.py
+#   Write conflict detection for follower fast truncate (truncate-truncate
+#   conflicts only).
+
+import unittest
+from contextlib import closing, nullcontext
+from typing import Iterable
+from helper_disagg import disagg_test_class, gen_disagg_storages
+from wiredtiger import disagg_fast_truncate_build, WiredTigerError
+from wtscenario import make_scenarios
+import wttest
+
+
+def range_inclusive(start: int, stop: int) -> range:
+    """Return a range covering [start, stop] inclusive."""
+    return range(start, stop + 1)
+
+
+@disagg_test_class
+class test_layered_fast_truncate18(wttest.WiredTigerTestCase):
+    """
+    Write conflict detection for follower fast truncate (truncate-truncate
+    conflicts only).
+    """
+
+    uris = [
+        ("layered", {"uri": "layered:fast_truncate"}),
+        ("table", {"uri": "table:fast_truncate"}),
+    ]
+
+    disagg_storages = gen_disagg_storages(disagg_only=True)
+    scenarios = make_scenarios(disagg_storages, uris)
+    conn_config = 'disaggregated=(role="leader"),'
+
+    CONFLICT_MSG = "/conflict between concurrent operations/"
+
+    def setUp(self):
+        if disagg_fast_truncate_build() == 0:
+            self.skipTest("fast truncate support is not enabled")
+        super().setUp()
+
+    def session_create_config(self) -> str:
+        """Return a config string for session.create() based on table URI."""
+        cfg = "key_format=i,value_format=S"
+        if self.uri.startswith("table"):
+            cfg += ",block_manager=disagg,type=layered"
+        return cfg
+
+    def auto_closing_cursor(self, session) -> closing:
+        """Return a cursor that auto-closes as it goes out of scope."""
+        return closing(session.open_cursor(self.uri))
+
+    def auto_closing_session(self) -> closing:
+        """Return a session that auto-closes as it goes out of scope."""
+        return closing(self.conn.open_session())
+
+    def populate(self, keys: Iterable[int]):
+        """Insert each key with a placeholder value in a single transaction."""
+        with self.auto_closing_cursor(self.session) as cursor:
+            with self.transaction():
+                for key in keys:
+                    cursor[key] = "v"
+
+    def setup_leader(self, keys: Iterable[int] | None = None):
+        """Create the table on the leader and optionally populate stable."""
+        self.session.create(self.uri, self.session_create_config())
+        if keys is not None:
+            self.populate(keys)
+        self.session.checkpoint()
+
+    def setup_follower(self, keys: Iterable[int] | None = None):
+        """Switch to follower role and optionally write keys to ingest."""
+        self.reopen_disagg_conn('disaggregated=(role="follower"),')
+        if keys is not None:
+            self.populate(keys)
+
+    def cursor_for_key(self, key: int | None, session):
+        """Return a cursor with its key set, or None if key is None."""
+        if key is None:
+            return nullcontext(None)
+        cursor = self.auto_closing_cursor(session)
+        cursor.thing.set_key(key)
+        return cursor
+
+    def truncate(self, session, start_key: int | None, stop_key: int | None):
+        """Execute a truncate from start to stop key inclusive."""
+        with (
+            self.cursor_for_key(start_key, session) as start,
+            self.cursor_for_key(stop_key, session) as stop,
+        ):
+            uri = self.uri if (start is None and stop is None) else None
+            session.truncate(uri, start, stop, None)
+
+    def test_same_txn_truncates_no_self_conflict(self):
+        # A follower with stable keys 1-100.
+        self.setup_leader(keys=range_inclusive(1, 100))
+        self.setup_follower()
+
+        # Within a single transaction: truncate 30-60, then truncate 40-80.
+        with self.transaction():
+            self.truncate(self.session, 30, 60)
+            self.truncate(self.session, 40, 80)
+
+        # The transaction committed; no WT_ROLLBACK raised.
+
+    # FIXME-WT-17272: There needs to be a write-conflict check inside
+    # `__txn_insert_truncate_entry_helper` when inserting into the truncate
+    # list.
+    @unittest.skip("FIXME-WT-17272")
+    def test_overlapping_truncates_conflict_with_ingest(self):
+        # A follower with stable keys 1-100 and ingest key 45.
+        self.setup_leader(keys=range_inclusive(1, 100))
+        self.setup_follower(keys=[45])
+
+        # txn A begins a truncate over 30-60 and leaves it uncommitted.
+        session_a = self.session
+        session_a.begin_transaction()
+        self.truncate(session_a, 30, 60)
+
+        # txn B truncates overlapping range 40-70 and gets WT_ROLLBACK.
+        with (
+            self.auto_closing_session() as session_b,
+            self.transaction(session=session_b, rollback=True),
+        ):
+            self.assertRaisesException(
+                WiredTigerError,
+                lambda: self.truncate(session_b, 40, 70),
+                self.CONFLICT_MSG,
+            )
+
+    # FIXME-WT-17272: There needs to be a write-conflict check inside
+    # `__txn_insert_truncate_entry_helper` when inserting into the truncate
+    # list.
+    @unittest.skip("FIXME-WT-17272")
+    def test_overlapping_truncates_conflict_no_ingest(self):
+        # A follower with stable keys 1-100 and an empty ingest table.
+        self.setup_leader(keys=range_inclusive(1, 100))
+        self.setup_follower()
+
+        # txn A begins a truncate over 30-60 and leaves it uncommitted.
+        session_a = self.session
+        session_a.begin_transaction()
+        self.truncate(session_a, 30, 60)
+
+        # txn B truncates overlapping range 40-70 and gets WT_ROLLBACK.
+        with (
+            self.auto_closing_session() as session_b,
+            self.transaction(session=session_b, rollback=True),
+        ):
+            self.assertRaisesException(
+                WiredTigerError,
+                lambda: self.truncate(session_b, 40, 70),
+                self.CONFLICT_MSG,
+            )
+
+    def test_non_overlapping_truncates_no_conflict(self):
+        # A follower with stable keys 1-100.
+        self.setup_leader(keys=range_inclusive(1, 100))
+        self.setup_follower()
+
+        # txn A truncates 10-30 and leaves it uncommitted.
+        session_a = self.session
+        session_a.begin_transaction()
+        self.truncate(session_a, 10, 30)
+
+        # txn B truncates 50-70 (no overlap) and commits successfully.
+        with (
+            self.auto_closing_session() as session_b,
+            self.transaction(session=session_b),
+        ):
+            self.truncate(session_b, 50, 70)
+
+    def test_rolled_back_truncate_no_residual(self):
+        # A follower with stable keys 1-100.
+        self.setup_leader(keys=range_inclusive(1, 100))
+        self.setup_follower()
+
+        # txn A truncates 30-60 then explicitly rolls back.
+        session_a = self.session
+        with self.transaction(session=session_a, rollback=True):
+            self.truncate(session_a, 30, 60)
+
+        # txn B truncates the same range 30-60 and commits without WT_ROLLBACK.
+        with (
+            self.auto_closing_session() as session_b,
+            self.transaction(session=session_b),
+        ):
+            self.truncate(session_b, 30, 60)
+
+    # FIXME-WT-17272: There needs to be a write-conflict check inside
+    # `__txn_insert_truncate_entry_helper` when inserting into the truncate
+    # list.
+    @unittest.skip("FIXME-WT-17272")
+    def test_invisible_committed_truncate_conflicts(self):
+        # A follower with stable keys 1-100.
+        self.setup_leader(keys=range_inclusive(1, 100))
+        self.setup_follower()
+
+        # txn A commits a truncate over 30-60 at ts=10 (invisible to txn B).
+        self.conn.set_timestamp("oldest_timestamp=" + self.timestamp_str(1))
+        with self.transaction(commit_timestamp=10):
+            self.truncate(self.session, 30, 60)
+
+        # txn B (read_ts=5) truncates overlapping range 40-70 and gets
+        # WT_ROLLBACK.
+        with (
+            self.auto_closing_session() as session_b,
+            self.transaction(
+                session=session_b, read_timestamp=5, rollback=True
+            ),
+        ):
+            self.assertRaisesException(
+                WiredTigerError,
+                lambda: self.truncate(session_b, 40, 70),
+                self.CONFLICT_MSG,
+            )
+
+    def test_visible_committed_truncate_no_conflict(self):
+        # A follower with stable keys 1-100.
+        self.setup_leader(keys=range_inclusive(1, 100))
+        self.setup_follower()
+
+        # txn A commits a truncate over 30-60 at ts=5 (visible to txn B).
+        self.conn.set_timestamp("oldest_timestamp=" + self.timestamp_str(1))
+        with self.transaction(commit_timestamp=5):
+            self.truncate(self.session, 30, 60)
+
+        # txn B (read_ts=10) truncates overlapping range 40-70 without
+        # WT_ROLLBACK.
+        with (
+            self.auto_closing_session() as session_b,
+            self.transaction(session=session_b, read_timestamp=10),
+        ):
+            self.truncate(session_b, 40, 70)
+
+
+if __name__ == "__main__":
+    wttest.run()


### PR DESCRIPTION
Added Python test to check write conflicts at the public API. Added catch2 test to test low-level functions.