### PR TITLE
WT-17354 Fix Assertion failed '(vpack != ((void*)0) && vpack->type != (4 << 4))'. No on-disk value is found" on Step Up

### DIFF
--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -40,17 +40,19 @@ __cell_assert_tw_has_ts_for_garbage_collection_table(WT_SESSION_IMPL *session, W
     WT_UNUSED(tw);
 
     /*
-     * A GC btree cell must have a start timestamp unless it is a tombstone. For tombstone cells on
-     * ingest btrees, only the stop-side time window is recorded; GC only needs stop_durable_ts to
-     * make the prune decision, making start_ts irrelevant for this case.
+     * For tombstone-only chains on ingest btrees the start side is unknown, so
+     * WT_TIME_WINDOW_HAS_STOP allows the start side to be empty provided the stop side carries
+     * identity.
      */
     WT_ASSERT_ALWAYS(session,
       tw->start_ts != WT_TS_NONE || tw->start_prepare_ts != WT_TS_NONE ||
-        !F_ISSET(S2BT(session), WT_BTREE_GARBAGE_COLLECT) || WT_TIME_WINDOW_HAS_STOP(tw),
+        tw->start_txn != WT_TXN_NONE || !F_ISSET(S2BT(session), WT_BTREE_GARBAGE_COLLECT) ||
+        WT_TIME_WINDOW_HAS_STOP(tw),
       "GC btree cell missing timestamp");
     WT_ASSERT_ALWAYS(session,
       !WT_TIME_WINDOW_HAS_STOP(tw) || tw->stop_ts != WT_TS_NONE ||
-        tw->stop_prepare_ts != WT_TS_NONE || !F_ISSET(S2BT(session), WT_BTREE_GARBAGE_COLLECT),
+        tw->stop_prepare_ts != WT_TS_NONE || tw->stop_txn != WT_TXN_NONE ||
+        !F_ISSET(S2BT(session), WT_BTREE_GARBAGE_COLLECT),
       "GC btree cell missing stop timestamp");
 }
 

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -39,12 +39,19 @@ __cell_assert_tw_has_ts_for_garbage_collection_table(WT_SESSION_IMPL *session, W
     WT_UNUSED(session);
     WT_UNUSED(tw);
 
-    WT_ASSERT(session,
+    /*
+     * A GC btree cell must have a start timestamp unless it is a tombstone. For tombstone cells on
+     * ingest btrees, only the stop-side time window is recorded; GC only needs stop_durable_ts to
+     * make the prune decision, making start_ts irrelevant for this case.
+     */
+    WT_ASSERT_ALWAYS(session,
       tw->start_ts != WT_TS_NONE || tw->start_prepare_ts != WT_TS_NONE ||
-        !F_ISSET(S2BT(session), WT_BTREE_GARBAGE_COLLECT));
-    WT_ASSERT(session,
+        !F_ISSET(S2BT(session), WT_BTREE_GARBAGE_COLLECT) || WT_TIME_WINDOW_HAS_STOP(tw),
+      "GC btree cell missing timestamp");
+    WT_ASSERT_ALWAYS(session,
       !WT_TIME_WINDOW_HAS_STOP(tw) || tw->stop_ts != WT_TS_NONE ||
-        tw->stop_prepare_ts != WT_TS_NONE || !F_ISSET(S2BT(session), WT_BTREE_GARBAGE_COLLECT));
+        tw->stop_prepare_ts != WT_TS_NONE || !F_ISSET(S2BT(session), WT_BTREE_GARBAGE_COLLECT),
+      "GC btree cell missing stop timestamp");
 }
 
 /*

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -36,9 +36,6 @@ __cell_check_value_validity(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw, bool e
 static WT_INLINE void
 __cell_assert_tw_has_ts_for_garbage_collection_table(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw)
 {
-    WT_UNUSED(session);
-    WT_UNUSED(tw);
-
     /*
      * For tombstone-only chains on ingest btrees the start side is unknown, so
      * WT_TIME_WINDOW_HAS_STOP allows the start side to be empty provided the stop side carries

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -951,6 +951,13 @@ __rec_row_leaf_insert(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_INSERT *ins
                 WT_ERR(__wti_rec_cell_build_val(session, r, upd->data, upd->size, &tw, 0, NULL));
             break;
         case WT_UPDATE_TOMBSTONE:
+            if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
+                /*
+                 * Ingest btree: value lives in the stable btree. Write a delete cell so the
+                 * tombstone survives GC re-instantiation. Once the tombstone becomes globally
+                 * visible, subsequent GC drops the key.
+                 */
+                WT_ERR(__wti_rec_cell_build_val(session, r, NULL, 0, &tw, 0, NULL));
             break;
         default:
             WT_ERR(__wt_illegal_value(session, upd->type));
@@ -967,7 +974,7 @@ __rec_row_leaf_insert(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_INSERT *ins
               session, r, WT_RECNO_OOB, tmpkey, upd->type == WT_UPDATE_TOMBSTONE ? false : true));
         }
 
-        if (upd->type == WT_UPDATE_TOMBSTONE)
+        if (upd->type == WT_UPDATE_TOMBSTONE && !F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
             continue;
 
         /* Build key cell. */

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -953,9 +953,9 @@ __rec_row_leaf_insert(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_INSERT *ins
         case WT_UPDATE_TOMBSTONE:
             if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
                 /*
-                 * Ingest btree: value lives in the stable btree. Write a delete cell so the
-                 * tombstone survives GC re-instantiation. Once the tombstone becomes globally
-                 * visible, subsequent GC drops the key.
+                 * Ingest btree: value lives in the stable btree. Write a zero-length value cell to
+                 * anchor the tombstone on disk so it survives GC re-instantiation. Once the
+                 * tombstone becomes globally visible, subsequent GC pass drops the key.
                  */
                 WT_ERR(__wti_rec_cell_build_val(session, r, NULL, 0, &tw, 0, NULL));
             break;

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -1416,6 +1416,8 @@ __rec_fill_tw_from_upd_select(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_U
         if (!WT_REC_HAS_ON_DISK(vpack)) {
             WT_ASSERT_ALWAYS(session, F_ISSET(S2BT(session), WT_BTREE_GARBAGE_COLLECT),
               "No on-disk value is found for a non-ingest tombstone-only chain");
+            /* Populate tw from the tombstone so the cell carries a valid timestamp on the ingest btree. */
+            WT_TIME_WINDOW_SET_START(select_tw, tombstone, write_prepare);
             upd_select->upd = tombstone;
             return (0);
         }

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -1416,8 +1416,6 @@ __rec_fill_tw_from_upd_select(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_U
         if (!WT_REC_HAS_ON_DISK(vpack)) {
             WT_ASSERT_ALWAYS(session, F_ISSET(S2BT(session), WT_BTREE_GARBAGE_COLLECT),
               "No on-disk value is found for a non-ingest tombstone-only chain");
-            /* Populate tw from the tombstone so the cell carries a valid timestamp on the ingest btree. */
-            WT_TIME_WINDOW_SET_START(select_tw, tombstone, write_prepare);
             upd_select->upd = tombstone;
             return (0);
         }

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -1412,7 +1412,13 @@ __rec_fill_tw_from_upd_select(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_U
     } else if (select_tw->stop_ts != WT_TS_NONE || select_tw->stop_txn != WT_TXN_NONE) {
         WT_ASSERT_ALWAYS(
           session, tombstone != NULL, "The only contents of the update list is a single tombstone");
-        WT_ASSERT_ALWAYS(session, WT_REC_HAS_ON_DISK(vpack), "No on-disk value is found");
+
+        if (!WT_REC_HAS_ON_DISK(vpack)) {
+            WT_ASSERT_ALWAYS(session, F_ISSET(S2BT(session), WT_BTREE_GARBAGE_COLLECT),
+              "No on-disk value is found for a non-ingest tombstone-only chain");
+            upd_select->upd = tombstone;
+            return (0);
+        }
 
         /* Move the pointer to the last update on the update chain. */
         for (last_upd = tombstone; last_upd->next != NULL; last_upd = last_upd->next)

--- a/test/suite/test_layered27.py
+++ b/test/suite/test_layered27.py
@@ -26,7 +26,9 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import platform, wttest
+import platform
+import wiredtiger
+import wttest
 from helper_disagg import disagg_test_class, gen_disagg_storages, Oplog
 from wtscenario import make_scenarios
 
@@ -237,6 +239,118 @@ class test_layered27(wttest.WiredTigerTestCase):
 
         # End of test.
         self.conn.close()
+
+    def test_tombstone_only_gc_cycle(self):
+        # Regression test for WT-17354. The bug is not load-sensitive; run once.
+        if self.multiplier != 1:
+            return
+
+        # When a key is inserted via the leader and then deleted on the follower,
+        # the ingest btree's insert list holds a tombstone with no preceding on-disk cell
+        # GC reconciliation of the ingest btree used to crash in
+        # __rec_fill_tw_from_upd_select with "No on-disk value is found".
+        # The fix writes an empty cell so the tombstone survives
+        # re-instantiation. This test verifies that fix:
+        #   1. Insert via leader -> key in stable btree only
+        #   2. Delete on follower -> tombstone-only chain in ingest insert list
+        #   3. First GC reconciliation pass (forced eviction  the crash site)
+        #   4. Verify deletion survives re-instantiation
+        #   5. Second GC reconciliation pass (delete cell from pass 1 as input)
+        #   6. Verify deletion survives second re-instantiation
+        #   7. Step-up / drain and final verification
+
+        key = 'key1'
+        ts_insert = 10
+        ts_delete = 20
+        ingest_uri = 'file:test_layered27.wt_ingest'
+
+        self.session.create(self.uri, "key_format=S,value_format=S")
+
+        conn_follow = self.wiredtiger_open('follower', self.conn_follower_config)
+        session_follow = conn_follow.open_session('')
+        session_follow.create(self.uri, "key_format=S,value_format=S")
+
+        # Step 1: insert via leader, checkpoint, advance follower.
+        # After this the key's value lives in the stable btree only.
+        cursor = self.session.open_cursor(self.uri)
+        self.session.begin_transaction()
+        cursor[key] = 'value'
+        self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(ts_insert)}')
+        cursor.close()
+
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(ts_insert)}')
+        self.session.checkpoint()
+        self.disagg_advance_checkpoint(conn_follow)
+
+        # Step 2: delete the key on the follower.
+        # The ingest btree insert list now contains a single tombstone
+        # there is no on-disk value in the ingest btree.
+        cursor_follow = session_follow.open_cursor(self.uri)
+        session_follow.begin_transaction()
+        cursor_follow.set_key(key)
+        self.assertEqual(cursor_follow.remove(), 0)
+        session_follow.commit_transaction(f'commit_timestamp={self.timestamp_str(ts_delete)}')
+        cursor_follow.close()
+
+        def assert_present(label):
+            c = session_follow.open_cursor(self.uri)
+            session_follow.begin_transaction(
+                f'read_timestamp={self.timestamp_str(ts_insert)}')
+            c.set_key(key)
+            self.assertEqual(c.search(), 0,
+                f'{label}: key should be present but was not found')
+            session_follow.rollback_transaction()
+            c.close()
+
+        def assert_deleted(label):
+            c = session_follow.open_cursor(self.uri)
+            session_follow.begin_transaction(
+                f'read_timestamp={self.timestamp_str(ts_delete)}')
+            c.set_key(key)
+            self.assertEqual(c.search(), wiredtiger.WT_NOTFOUND,
+                f'{label}: key should be absent but was found')
+            session_follow.rollback_transaction()
+            c.close()
+
+        assert_present('before eviction')
+        assert_deleted('before eviction')
+
+        # Steps 3-6: two GC reconciliation passes driven by forced eviction.
+        # Pass 1 exercises the fixed __rec_fill_tw_from_upd_select path and
+        # writes a delete cell.  Pass 2 exercises that same delete cell as the
+        # on-disk input to the next reconciliation.
+        for pass_num in (1, 2):
+            evict_cursor = session_follow.open_cursor(
+                ingest_uri, None, 'debug=(release_evict)')
+            session_follow.begin_transaction(
+                f'read_timestamp={self.timestamp_str(ts_delete)}')
+            evict_cursor.set_key(key)
+            ret = evict_cursor.search()
+            self.assertTrue(ret == 0 or ret == wiredtiger.WT_NOTFOUND,
+                f'GC pass {pass_num}: unexpected eviction search return {ret}')
+            evict_cursor.reset()
+            session_follow.rollback_transaction()
+            evict_cursor.close()
+
+            # Both checks together: tombstone must survive (deletion still
+            # visible) and the stable btree value must be intact (key visible
+            # before the delete).
+            assert_present(f'after GC pass {pass_num}')
+            assert_deleted(f'after GC pass {pass_num}')
+
+        # Step 7: step up, drain ingest table into stable btree, verify.
+        # Use ts_delete + 1 as the stable timestamp so the tombstone's durable
+        # timestamp (ts_delete) is unambiguously within the drain window.
+        self.conn.close('debug=(skip_checkpoint=true)')
+        conn_follow.reconfigure('disaggregated=(role="leader")')
+        conn_follow.set_timestamp(f'stable_timestamp={self.timestamp_str(ts_delete + 1)}')
+        session_follow.checkpoint()
+
+        assert_present('after step-up and drain')
+        assert_deleted('after step-up and drain')
+
+        session_follow.close()
+        conn_follow.close()
 
     def test_drain_remove_insert(self):
         # Create the oplog

--- a/test/suite/test_layered27.py
+++ b/test/suite/test_layered27.py
@@ -240,6 +240,75 @@ class test_layered27(wttest.WiredTigerTestCase):
         # End of test.
         self.conn.close()
 
+    def test_tombstone_only_chain_no_on_disk_value(self):
+        """
+        Regression reproducer for the original WT-17354 crash.
+        The tombstone must NOT be globally visible when reconciliation fires —
+        oldest_timestamp is deliberately held below ts_delete.
+        """
+        key = 'key1'
+        ts_insert = 10
+        ts_delete = 20
+        ingest_uri = 'file:test_layered27.wt_ingest'
+
+        self.session.create(self.uri, "key_format=S,value_format=S")
+
+        conn_follow = self.wiredtiger_open('follower', self.conn_follower_config)
+        session_follow = conn_follow.open_session('')
+        session_follow.create(self.uri, "key_format=S,value_format=S")
+
+        # Step 1: Insert via leader. Value lands in stable btree only.
+        cursor = self.session.open_cursor(self.uri)
+        self.session.begin_transaction()
+        cursor[key] = 'value'
+        self.session.commit_transaction(
+            f'commit_timestamp={self.timestamp_str(ts_insert)}')
+        cursor.close()
+        self.conn.set_timestamp(
+            f'stable_timestamp={self.timestamp_str(ts_insert)}')
+        self.session.checkpoint()
+
+        # Step 2: Follower picks up the checkpoint.
+        self.disagg_advance_checkpoint(conn_follow)
+
+        # Step 3: Delete the key on the follower.
+        # Ingest btree now has a tombstone-only chain; no on-disk value.
+        cursor_follow = session_follow.open_cursor(self.uri)
+        session_follow.begin_transaction()
+        cursor_follow.set_key(key)
+        self.assertEqual(cursor_follow.remove(), 0)
+        session_follow.commit_transaction(
+            f'commit_timestamp={self.timestamp_str(ts_delete)}')
+        cursor_follow.close()
+
+        # Step 4: Trigger reconciliation.
+        # oldest_timestamp is NOT advanced past ts_delete — tombstone is
+        # not globally visible. The original assertion fires here without
+        # the fix; with the fix, this should complete cleanly.
+        evict_cursor = session_follow.open_cursor(
+            ingest_uri, None, 'debug=(release_evict)')
+        session_follow.begin_transaction(
+            f'read_timestamp={self.timestamp_str(ts_delete)}')
+        evict_cursor.set_key(key)
+        ret = evict_cursor.search()
+        self.assertTrue(ret == 0 or ret == wiredtiger.WT_NOTFOUND)
+        evict_cursor.reset()
+        session_follow.rollback_transaction()
+        evict_cursor.close()
+
+        # After the fix: deletion should be visible at ts_delete.
+        c = session_follow.open_cursor(self.uri)
+        session_follow.begin_transaction(
+            f'read_timestamp={self.timestamp_str(ts_delete)}')
+        c.set_key(key)
+        self.assertEqual(c.search(), wiredtiger.WT_NOTFOUND,
+            'key should be absent at ts_delete after fix')
+        session_follow.rollback_transaction()
+        c.close()
+
+        session_follow.close()
+        conn_follow.close()
+
     def test_tombstone_only_gc_cycle(self):
         # Regression test for WT-17354. The bug is not load-sensitive; run once.
         if self.multiplier != 1:
@@ -262,7 +331,6 @@ class test_layered27(wttest.WiredTigerTestCase):
         key = 'key1'
         ts_insert = 10
         ts_delete = 20
-        ingest_uri = 'file:test_layered27.wt_ingest'
 
         self.session.create(self.uri, "key_format=S,value_format=S")
 
@@ -312,31 +380,28 @@ class test_layered27(wttest.WiredTigerTestCase):
             session_follow.rollback_transaction()
             c.close()
 
-        assert_present('before eviction')
-        assert_deleted('before eviction')
+        assert_present('before checkpoint')
+        assert_deleted('before checkpoint')
 
-        # Steps 3-6: two GC reconciliation passes driven by forced eviction.
-        # Pass 1 exercises the fixed __rec_fill_tw_from_upd_select path and
-        # writes a delete cell.  Pass 2 exercises that same delete cell as the
-        # on-disk input to the next reconciliation.
+        # Steps 3-4: two GC reconciliation passes driven by checkpoint.
+        # Checkpoint reconciles the ingest btree with WT_REC_CHECKPOINT|WT_REC_HS
+        # (no scrub), so the tombstone MUST be written to disk.
+        #
+        # rec_visibility.c forces the tombstone to be selected (upd_select->upd =
+        # tombstone) even when the checkpoint stable_timestamp is below ts_delete,
+        # because the ingest btree has no on-disk value for the key.
+        #
+        # Without the fix: __rec_row_leaf_insert writes the key cell but no value
+        # cell (val->len stays 0, __rec_row_zero_len returns false for a tombstone
+        # time window).  entries=2 but only 1 physical cell is on the page.
+        # __wt_verify_dsk_image (HAVE_DIAGNOSTIC) detects the mismatch and aborts.
+        #
+        # With the fix: __wti_rec_cell_build_val writes a proper zero-length delete
+        # cell anchored by the tombstone time window.  verify passes.
         for pass_num in (1, 2):
-            evict_cursor = session_follow.open_cursor(
-                ingest_uri, None, 'debug=(release_evict)')
-            session_follow.begin_transaction(
-                f'read_timestamp={self.timestamp_str(ts_delete)}')
-            evict_cursor.set_key(key)
-            ret = evict_cursor.search()
-            self.assertTrue(ret == 0 or ret == wiredtiger.WT_NOTFOUND,
-                f'GC pass {pass_num}: unexpected eviction search return {ret}')
-            evict_cursor.reset()
-            session_follow.rollback_transaction()
-            evict_cursor.close()
-
-            # Both checks together: tombstone must survive (deletion still
-            # visible) and the stable btree value must be intact (key visible
-            # before the delete).
-            assert_present(f'after GC pass {pass_num}')
-            assert_deleted(f'after GC pass {pass_num}')
+            session_follow.checkpoint()
+            assert_present(f'after checkpoint pass {pass_num}')
+            assert_deleted(f'after checkpoint pass {pass_num}')
 
         # Step 7: step up, drain ingest table into stable btree, verify.
         # Use ts_delete + 1 as the stable timestamp so the tombstone's durable


### PR DESCRIPTION
This fix handles an error where there is a tombstone-only update chain on the ingest btree. When a tombstone is selected, the original code asserts that a prior on-disk value exists. On an ingest btree, a key can be inserted and deleted in memory without a prior reconciled image (the value exists only in the stable btree). 

This fix adds an extra condition in __rec_fill_tw_from_upd_select, if there is no on-disk value, it asserts that it is valid on a GC-enabled ingest btree, sets upd_select->upd = tombstone, and returns early to skip the logic that requires an on-disk value. 

The change in rec_row.c gets back the tombstone as the selected update and writes the delete cell. Previously a tombstone on the ingest btree could be lost during reconciliation. This makes it so that the tombstone survives GC reinstantiation, and once it becomes globally visible a subsequent GC pass drops the key. 

The assertion in __cell_assert_tw_has_ts_for_garbage_collection_table is asserting that the GC has timestamp information to determine what is safe to prune. But I think it is safe to relax the assertion because, it is still gated on (txnid) < (r)->rec_start_oldest_id . In a non-timestamped tombstone, stop_ts is WT_TS_NONE. On a tombstone-only update chain start_ts cannot be known because the original insert lives in the stable btree. However as long as stop_txn is defined WT_REC_CAN_PRUNE_UPD can correctly handle it. I changed it from ASSERT to ASSERT_ALWAYS so this invariant is enforced in production
