### PR TITLE
WT-14739 Remove stale FIXME on shutdown checkpoint follower guard

### DIFF
--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -2639,9 +2639,6 @@ __wt_txn_global_shutdown(WT_SESSION_IMPL *session, const char **cfg)
          * disaggregated storage and the node still consider itself the leader. If it is not the
          * real leader, the storage layer services should return an error as it is not allowed to
          * write.
-         *
-         * FIXME-WT-14739: we should be able to do shutdown checkpoint for followers as well when we
-         * are able to skip the shared tables in checkpoint.
          */
         if (!skip_checkpoint && (!conn_is_disagg || conn->layered_table_manager.leader)) {
             WT_TRET(__wt_open_internal_session(conn, "close_ckpt", true, 0, 0, &s));


### PR DESCRIPTION
The FIXME suggested we'd eventually enable shutdown checkpoint for disaggregated followers. Per WT-14739 discussion, secondaries should never checkpoint (already a no-op), so the FIXME is removed. Comment-only change; no behavior change.