### PR TITLE
WT-17446 Fix tombstone handling in wt_debug_script_update.py

### DIFF
--- a/tools/gdb/gdb_scripts/wt_debug_script_update.py
+++ b/tools/gdb/gdb_scripts/wt_debug_script_update.py
@@ -99,11 +99,13 @@ def dump_update_chain(update_chain):
         if not update_chain:
             print('  λ')
             break
-        #dbg('update', update_chain)
         wt_val = update_chain.dereference()
         obj = None
-        #dbg('wt_val', wt_val)
-        val_bytes = gdb.selected_inferior().read_memory(wt_val['data'], wt_val['size'])
+        # TOMBSTONE/RESERVE entries carry no value: size is 0 and the data
+        # pointer is uninitialized, so skip the read in those cases.
+        val_size = int(wt_val['size'])
+        if val_size > 0:
+            val_bytes = gdb.selected_inferior().read_memory(wt_val['data'], val_size)
         can_bson = wt_val['type'] == 3
         if can_bson:
             try:


### PR DESCRIPTION
### Summary

Fix tombstone (and reserve) handling in `tools/gdb/gdb_scripts/wt_debug_script_update.py`.

Previously, `dump_update_chain()` unconditionally attempted to read `wt_val['data']` regardless of the update type. TOMBSTONE and RESERVE updates carry no value (`size == 0`) and their `data` pointer is uninitialized, causing a crash or garbage read during GDB debugging.

### Changes

- Guard the `read_memory` call with `if val_size > 0` so TOMBSTONE and RESERVE entries are skipped cleanly.

### Testing

Manually verified in a GDB session against a WiredTiger core dump containing update chains with TOMBSTONE entries — script no longer crashes.