### PR TITLE
WT-17447 Clean up s3_store references missed in WT-17399

### DIFF
--- a/test/evergreen/evg_cfg.py
+++ b/test/evergreen/evg_cfg.py
@@ -27,7 +27,6 @@ make_check_subdir_skips = [
     "test/cppsuite",
     "test/fuzz",
     "test/syscall",
-    "ext/storage_sources/s3_store/test"
 ]
 
 prog=sys.argv[0]

--- a/test/format/config.sh
+++ b/test/format/config.sh
@@ -377,7 +377,7 @@ CONFIG configuration_list[] = {
 
 {"tiered_storage.flush_frequency", "calls to checkpoint that are flush_tier, if tiered storage enabled (percentage)", 0x0, 0, 50, 100 }
 
-{"tiered_storage.storage_source", "storage source used (dir_store | none | off | s3_store)", C_IGNORE | C_STRING, 0, 0, 0}
+{"tiered_storage.storage_source", "storage source used (dir_store | none | off)", C_IGNORE | C_STRING, 0, 0, 0}
 
 {"transaction.implicit", "implicit, without timestamps, transactions (percentage)", 0, 0, 100, 100}
 

--- a/test/format/format_config_def.c
+++ b/test/format/format_config_def.c
@@ -425,7 +425,7 @@ CONFIG configuration_list[] = {{"assert.read_timestamp", "assert read_timestamp"
     "calls to checkpoint that are flush_tier, if tiered storage enabled (percentage)", 0x0, 0, 50,
     100, V_GLOBAL_TIERED_STORAGE_FLUSH_FREQUENCY},
 
-  {"tiered_storage.storage_source", "storage source used (dir_store | none | off | s3_store)",
+  {"tiered_storage.storage_source", "storage source used (dir_store | none | off)",
     C_IGNORE | C_STRING, 0, 0, 0, V_GLOBAL_TIERED_STORAGE_STORAGE_SOURCE},
 
   {"transaction.implicit", "implicit, without timestamps, transactions (percentage)", 0, 0, 100,


### PR DESCRIPTION
## Summary

- Remove `"ext/storage_sources/s3_store/test"` from `make_check_subdir_skips` in `test/evergreen/evg_cfg.py`
- Drop `s3_store` from the `tiered_storage.storage_source` help string in `test/format/config.sh`
- Regenerate `test/format/format_config_def.c` via `bash config.sh`

These three references to the deleted `s3_store` extension were missed when WT-17399 merged.

## Test plan

- [ ] Evergreen patch green: https://evergreen.corp.mongodb.com/version/69fd8008ee76790007352489
- [ ] Full build clean (617/617 targets, no errors)
- [ ] `grep -rn "s3_store" test/evergreen/evg_cfg.py test/format/config.sh test/format/format_config_def.c` returns empty