### PR TITLE
WT-15369 disagg: Fix layered python tests cursor13, cursor21 that fail stats check

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -689,7 +689,8 @@ connection_runtime_config = [
             if true, for operations with snapshot isolation the cursor temporarily releases any page
             that requires force eviction, then repositions back to the page for further operations.
             A page release encourages eviction of hot or large pages, which is more likely to
-            succeed without a cursor keeping the page pinned.''',
+            succeed without a cursor keeping the page pinned. Note: This setting is not compatible
+            with disaggregated storage.''',
             type='boolean'),
         Config('disagg_address_cookie_upgrade', 'none', r'''
             modify the disaggregated block manager to pretend that it is a newer version to test

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -2921,11 +2921,14 @@ __wt_clayered_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, 
 
     WT_RET(__wt_config_gets_def(session, cfg, "checkpoint", 0, &cval));
     if (cval.len != 0)
-        WT_RET_MSG(session, EINVAL, "Layered trees do not support opening by checkpoint");
+        WT_RET_MSG(session, ENOTSUP, "Layered trees do not support opening by checkpoint");
 
     WT_RET(__wt_config_gets_def(session, cfg, "bulk", 0, &cval));
     if (cval.val != 0)
-        WT_RET_MSG(session, EINVAL, "Layered trees do not support bulk loading");
+        WT_RET_MSG(session, ENOTSUP, "Layered trees do not support bulk loading");
+
+    if (FLD_ISSET(S2C(session)->debug.flags, WT_CONN_DEBUG_CURSOR_REPOSITION))
+        WT_RET_MSG(session, ENOTSUP, "Layered trees do not support cursor reposition");
 
     /* Get the layered tree, and hold a reference to it until the cursor is closed. */
     WT_RET(__wt_session_get_dhandle(session, uri, NULL, cfg, 0));

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -2258,11 +2258,12 @@ struct __wt_connection {
      * isolation the cursor temporarily releases any page that requires force eviction\, then
      * repositions back to the page for further operations.  A page release encourages eviction of
      * hot or large pages\, which is more likely to succeed without a cursor keeping the page
-     * pinned., a boolean flag; default \c false.}
-     * @config{&nbsp;&nbsp;&nbsp;&nbsp;eviction, if
-     * true\, modify internal algorithms to change skew to force history store eviction to happen
-     * more aggressively.  This includes but is not limited to not skewing newest\, not favoring
-     * leaf pages\, and modifying the eviction score mechanism., a boolean flag; default \c false.}
+     * pinned.  Note: This setting is not compatible with disaggregated storage., a boolean flag;
+     * default \c false.}
+     * @config{&nbsp;&nbsp;&nbsp;&nbsp;eviction, if true\, modify internal
+     * algorithms to change skew to force history store eviction to happen more aggressively.  This
+     * includes but is not limited to not skewing newest\, not favoring leaf pages\, and modifying
+     * the eviction score mechanism., a boolean flag; default \c false.}
      * @config{&nbsp;&nbsp;&nbsp;&nbsp;eviction_checkpoint_ts_ordering, if true\, act as if eviction
      * is being run in parallel to checkpoint.  We should return EBUSY in eviction if we detect any
      * timestamp ordering issue., a boolean flag; default \c false.}
@@ -3190,26 +3191,27 @@ struct __wt_connection {
  * cursor_reposition, if true\, for operations with snapshot isolation the cursor temporarily
  * releases any page that requires force eviction\, then repositions back to the page for further
  * operations.  A page release encourages eviction of hot or large pages\, which is more likely to
- * succeed without a cursor keeping the page pinned., a boolean flag; default \c false.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;eviction, if true\, modify internal algorithms to change skew to
- * force history store eviction to happen more aggressively.  This includes but is not limited to
- * not skewing newest\, not favoring leaf pages\, and modifying the eviction score mechanism., a
- * boolean flag; default \c false.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;eviction_checkpoint_ts_ordering,
- * if true\, act as if eviction is being run in parallel to checkpoint.  We should return EBUSY in
- * eviction if we detect any timestamp ordering issue., a boolean flag; default \c false.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;log_retention, adjust log removal to retain at least this number
- * of log files.  (Warning: this option can remove log files required for recovery if no checkpoints
- * have yet been done and the number of log files exceeds the configured value.  As WiredTiger
- * cannot detect the difference between a system that has not yet checkpointed and one that will
- * never checkpoint\, it might discard log files before any checkpoint is done.) Ignored if set to
- * 0., an integer between \c 0 and \c 1024; default \c 0.}
+ * succeed without a cursor keeping the page pinned.  Note: This setting is not compatible with
+ * disaggregated storage., a boolean flag; default \c false.}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;
- * realloc_exact, if true\, reallocation of memory will only provide the exact amount requested.
- * This will help with spotting memory allocation issues more easily., a boolean flag; default \c
- * false.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;realloc_malloc, if true\, every realloc call will force a
- * new memory allocation by using malloc., a boolean flag; default \c false.}
+ * eviction, if true\, modify internal algorithms to change skew to force history store eviction to
+ * happen more aggressively.  This includes but is not limited to not skewing newest\, not favoring
+ * leaf pages\, and modifying the eviction score mechanism., a boolean flag; default \c false.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;eviction_checkpoint_ts_ordering, if true\, act as if eviction is
+ * being run in parallel to checkpoint.  We should return EBUSY in eviction if we detect any
+ * timestamp ordering issue., a boolean flag; default \c false.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;
+ * log_retention, adjust log removal to retain at least this number of log files.  (Warning: this
+ * option can remove log files required for recovery if no checkpoints have yet been done and the
+ * number of log files exceeds the configured value.  As WiredTiger cannot detect the difference
+ * between a system that has not yet checkpointed and one that will never checkpoint\, it might
+ * discard log files before any checkpoint is done.) Ignored if set to 0., an integer between \c 0
+ * and \c 1024; default \c 0.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;realloc_exact, if true\, reallocation
+ * of memory will only provide the exact amount requested.  This will help with spotting memory
+ * allocation issues more easily., a boolean flag; default \c false.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;realloc_malloc, if true\, every realloc call will force a new
+ * memory allocation by using malloc., a boolean flag; default \c false.}
  * @config{&nbsp;&nbsp;&nbsp;&nbsp;rollback_error, return a WT_ROLLBACK error from a transaction
  * operation about every Nth operation to simulate a collision., an integer between \c 0 and \c 10M;
  * default \c 0.}

--- a/test/format/format_config.c
+++ b/test/format/format_config.c
@@ -1489,6 +1489,10 @@ config_disagg_storage(void)
     config_off(NULL, "ops.compaction");
     config_off(NULL, "background_compact");
 
+    /* Cursor reposition is not supported for disaggregated storage. */
+    config_off(NULL, "debug.cursor_reposition");
+    config_off(NULL, "stress.evict_reposition");
+
     /*  Tiered storage is not supported with disagg */
     config_single(NULL, "tiered_storage.storage_source=off", true);
 }

--- a/test/suite/hook_disagg.fail
+++ b/test/suite/hook_disagg.fail
@@ -4,8 +4,6 @@
 test_autoclose.py
 test_config02.py
 test_config09.py
-test_cursor13.py  # FIXME: WT-15369
-test_cursor21.py  # FIXME: WT-15369
 test_drop03.py
 test_dump.py
 test_dump01.py

--- a/test/suite/test_cursor13.py
+++ b/test/suite/test_cursor13.py
@@ -56,7 +56,15 @@ class test_cursor13_base(wttest.WiredTigerTestCase):
     def caching_stats(self):
         hs_stats_uri = 'statistics:file:WiredTigerHS.wt'
         max_tries = 100
+        # Cursor cache/reopen stats are updated with plain (non-atomic) int64 add/subtract
+        # operations.
+        # A recent increment by another core may not yet be visible to this reader. Re-reading
+        # in a tight Python loop cannot force coherence; the fix is to pause briefly on retry
+        # so store buffers drain and cache lines propagate.
+        retry_sleep = 0.005  # seconds
         for i in range(max_tries):
+            if i > 0:
+                time.sleep(retry_sleep)
             hs_stats_before = self.session.open_cursor(hs_stats_uri, None, None)
             conn_stats = self.session.open_cursor('statistics:', None, None)
             hs_stats_after = self.session.open_cursor(hs_stats_uri, None, None)
@@ -78,7 +86,14 @@ class test_cursor13_base(wttest.WiredTigerTestCase):
                 hs_after[0] += hs_disagg_stat_after[stat.dsrc.cursor_cache][2]
                 hs_after[1] += hs_disagg_stat_after[stat.dsrc.cursor_reopen][2]
 
-                self.pr(str(totals[0]) + " " + str(hs_before[0]) + " " + str(hs_disagg_stat_before[stat.dsrc.cursor_cache][2]) + " " + str(hs_stats_before[stat.dsrc.cursor_cache][2]))
+                report = [totals[0],
+                          hs_before[0],
+                          hs_disagg_stat_before[stat.dsrc.cursor_cache][2],
+                          hs_stats_before[stat.dsrc.cursor_cache][2]]
+                self.pr(' '.join(map(str, report)))
+
+                hs_disagg_stat_before.close()
+                hs_disagg_stat_after.close()
 
             hs_stats_before.close()
             hs_stats_after.close()
@@ -511,6 +526,7 @@ class test_cursor13_big(test_cursor13_big_base):
         self.assertEqual(end_stats[0] - begin_stats[0], self.closecount)
         self.assertEqual(end_stats[1] - begin_stats[1], self.opencount)
 
+@wttest.skip_for_hook("disagg", "layered dhandles are never swept: FIXME-WT-16982")
 class test_cursor13_sweep(test_cursor13_big_base):
     # Set dhandle sweep configuration so that dhandles should be closed within
     # two seconds of all the cursors for the dhandle being closed (cached).

--- a/test/suite/test_cursor21.py
+++ b/test/suite/test_cursor21.py
@@ -31,7 +31,7 @@
 
 import wttest
 from wtscenario import make_scenarios
-from wiredtiger import stat
+from wiredtiger import stat, WiredTigerError
 
 class test_cursor21(wttest.WiredTigerTestCase):
     uri = "table:test_cursor21"
@@ -71,6 +71,7 @@ class test_cursor21(wttest.WiredTigerTestCase):
             self.assertEqual(reposition_count, 0)
         return reposition_count
 
+    @wttest.skip_for_hook("disagg", "layered tables don't support cursor reposition")
     def test_cursor21(self):
         format = 'key_format={},value_format={}'.format(self.key_format, self.value_format)
         reposition_count = 0
@@ -125,3 +126,15 @@ class test_cursor21(wttest.WiredTigerTestCase):
         reposition_count += self.check_reposition(reposition_count)
         cursor.close()
         self.session.close()
+
+    @wttest.only_for_hook("disagg", "check reposition is disabled for disaggregated storage")
+    def test_cursor21_dsc(self):
+        # Skip the test if reposition is disabled or it's column store (unsupported in disagg).
+        if not self.reposition or self.scenario_name == 'column.reposition':
+            return
+
+        format = 'key_format={},value_format={}'.format(self.key_format, self.value_format)
+        self.session.create(self.uri, format)
+        msg = '/Operation not supported/'
+        self.assertRaisesWithMessage(WiredTigerError,
+            lambda: self.session.open_cursor(self.uri), msg)


### PR DESCRIPTION
- Disable repositioning for layered cursors:
    - Repositioning of attached storage cursors was developed for MongoDB resource yields.
    - Eventually, cursor repositioning was never used by MongoDB and currently is OFF by default. 
    - It is considered to be an experimental feature.
    - There is no MongoDB requirement for cursor repositioning in layered tables.
- Add a test to check that opening a layered cursor with repositioning enabled fails with the expected error.