### PR TITLE
WT-17335 Document parallel checkpoints in the WT architecture guide

### DIFF
--- a/src/docs/arch-checkpoint.dox
+++ b/src/docs/arch-checkpoint.dox
@@ -83,6 +83,38 @@ A new entry into the metadata file is created for every data file checkpointed, 
 history store. As such the metadata file is the last file to be checkpointed. As WiredTiger
 maintains two checkpoints, the location of the most recent checkpoint is written to the turtle file.
 
+# Multi-threaded checkpoints #
+
+By default, WiredTiger checkpoints are single-threaded: they walk each B-tree
+one page at a time and reconcile dirty pages sequentially. Parallel checkpoints
+improve throughput by handing leaf pages off to a pool of worker threads that
+reconcile them concurrently, while the main checkpoint thread continues the tree
+walk and handles internal pages. Parallel checkpoints are enabled by setting
+the \c checkpoint_threads connection configuration option to a value greater
+than 1 when calling ::wiredtiger_open.
+
+The main checkpoint thread and the workers communicate through two queues:
+a work queue of pages to reconcile and a done queue of completed items.
+For each leaf page encountered during the B-tree walk, the main thread duplicates
+the walk position (giving the copy its own hazard pointer), wraps it in a work
+item, and pushes it onto the work queue. Workers pick up items, reconcile the
+page, and push the result onto the done queue, posting a semaphore.
+
+Internal pages are never handed to workers. Before checking whether an internal
+page is dirty, the main thread drains the done queue by waiting on the semaphore
+until every outstanding work item has completed. Only then does it reconcile the
+internal page, ensuring it can collect the correct on-disk address cookies of its
+children. The main thread also releases each page's hazard pointer as it drains,
+because hazard pointers cannot be transferred between sessions.
+
+Each worker uses its own session, since sessions are not thread-safe.
+Workers are identified by the session flags \c WT_SESSION_CHECKPOINT and
+\c WT_SESSION_CHECKPOINT_WORKER; the latter distinguishes them from the main
+checkpoint session. To produce a consistent checkpoint, each worker imports a
+private copy of the main checkpoint session's transaction snapshot before
+reconciling its first page. At the end of the checkpoint, the main thread commits
+each worker's transaction.
+
 \anchor skipping-checkpoints
 # Skipping checkpoints #
 

--- a/src/docs/arch-checkpoint.dox
+++ b/src/docs/arch-checkpoint.dox
@@ -98,14 +98,20 @@ a work queue of pages to reconcile and a done queue of completed items.
 For each leaf page encountered during the B-tree walk, the main thread duplicates
 the walk position (giving the copy of its own hazard pointer), wraps it in a work
 item, and pushes it onto the work queue. Workers pick up items, reconcile the
-page, and push the result onto the done queue, posting a semaphore.
+page, and push the result onto the done queue, posting a semaphore. Workers must
+return completed pages to the main thread via the done queue because hazard
+pointers cannot be transferred between sessions: a worker cannot release a hazard
+pointer that was acquired by the main checkpoint thread. The done queue also
+carries each worker's return code, allowing errors to propagate to the caller.
+A semaphore rather than a condition variable is used so that a post issued by a
+worker before the main thread calls wait is not lost.
 
 Internal pages are never handed to workers. Before checking whether an internal
 page is dirty, the main thread drains the done queue by waiting on the semaphore
 until every outstanding work item has completed. Only then does it reconcile the
 internal page, ensuring it can collect the correct on-disk address cookies of its
-children. The main thread also releases each page's hazard pointer as it drains,
-because hazard pointers cannot be transferred between sessions.
+children. The main thread releases each page's hazard pointer as it drains the
+done queue.
 
 Each worker uses its own session, since sessions are not thread-safe.
 Workers are identified by the session flags \c WT_SESSION_CHECKPOINT and

--- a/src/docs/arch-checkpoint.dox
+++ b/src/docs/arch-checkpoint.dox
@@ -96,7 +96,7 @@ than 1 when calling ::wiredtiger_open.
 The main checkpoint thread and the workers communicate through two queues:
 a work queue of pages to reconcile and a done queue of completed items.
 For each leaf page encountered during the B-tree walk, the main thread duplicates
-the walk position (giving the copy its own hazard pointer), wraps it in a work
+the walk position (giving the copy of its own hazard pointer), wraps it in a work
 item, and pushes it onto the work queue. Workers pick up items, reconcile the
 page, and push the result onto the done queue, posting a semaphore.
 


### PR DESCRIPTION
Add a short description of the algorithm for parallel (multi-threaded) checkpoints to the architecture guide.