### PR TITLE
WT-15535 Skip running checkpoint cleanup for read-only btrees (8.0)

### DIFF
--- a/src/btree/bt_sync_obsolete.c
+++ b/src/btree/bt_sync_obsolete.c
@@ -503,6 +503,11 @@ __checkpoint_cleanup_walk_btree(WT_SESSION_IMPL *session, WT_ITEM *uri)
     }
 
     btree = S2BT(session);
+
+    /* Skip read-only btrees. */
+    if (F_ISSET(btree, WT_BTREE_READONLY))
+        goto err;
+
     /* There is nothing to do on an empty tree. */
     if (btree->root.page == NULL)
         goto err;


### PR DESCRIPTION
We should skip all the read-only btrees for checkpoint cleanup.