### PR TITLE
WT-17475 Refactor __curversion_next_single_key to reduce cyclomatic complexity (refactor-bot)

### DIFF
--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -661,6 +661,37 @@ __curversion_process_on_disk(
 }
 
 /*
+ * __curversion_value_return_from_hs --
+ *     Pack the metadata for the history-store value and record it as the previously-returned stop
+ *     state.
+ */
+static int
+__curversion_value_return_from_hs(WT_CURSOR *cursor, WT_TIME_WINDOW *twp, uint64_t hs_upd_type)
+{
+    WT_CURSOR_VERSION *version_cursor;
+    wt_timestamp_t durable_start_meta, start_meta;
+    bool has_start_prepare;
+
+    version_cursor = (WT_CURSOR_VERSION *)cursor;
+    has_start_prepare = WT_TIME_WINDOW_HAS_START_PREPARE(twp);
+    start_meta = has_start_prepare ? twp->start_prepare_ts : twp->start_ts;
+    durable_start_meta = has_start_prepare ? twp->start_prepare_ts : twp->durable_start_ts;
+
+    WT_RET(__curversion_set_value_with_format(cursor, WT_CURVERSION_METADATA_FORMAT, twp->start_txn,
+      start_meta, durable_start_meta, twp->start_prepare_ts, twp->start_prepared_id, twp->stop_txn,
+      WT_TIME_WINDOW_HAS_STOP_PREPARE(twp) ? twp->stop_prepare_ts : twp->stop_ts,
+      WT_TIME_WINDOW_HAS_STOP_PREPARE(twp) ? twp->stop_prepare_ts : twp->durable_stop_ts,
+      twp->stop_prepare_ts, twp->stop_prepared_id, hs_upd_type, 0, 0, WT_CURVERSION_HISTORY_STORE));
+
+    version_cursor->upd_stop_txnid = twp->start_txn;
+    version_cursor->curversion_durable_stop_ts = durable_start_meta;
+    version_cursor->curversion_stop_ts = start_meta;
+    version_cursor->upd_stop_prepare_ts = twp->start_prepare_ts;
+    version_cursor->upd_stop_prepared_id = twp->start_prepared_id;
+    return (0);
+}
+
+/*
  * __curversion_next_single_key --
  *     Iterate the updates of a single key.
  */

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -231,6 +231,31 @@ __curversion_record_stop_time_point(
 }
 
 /*
+ * __curversion_value_return_from_upd --
+ *     Pack the metadata for an update returned from the in-memory update chain.
+ */
+static int
+__curversion_value_return_from_upd(
+  WT_CURSOR *cursor, WT_CURSOR_VERSION *version_cursor, WT_UPDATE *upd, bool version_prepared)
+{
+    uint64_t durable_meta, start_meta;
+    bool aborted;
+
+    /* Aborted updates encode rollback metadata in the start slots. */
+    aborted = (upd->txnid == WT_TXN_ABORTED);
+    start_meta = aborted ? upd->upd_saved_txnid : (uint64_t)upd->upd_start_ts;
+    durable_meta = aborted ? (uint64_t)upd->upd_rollback_ts : (uint64_t)upd->upd_durable_ts;
+
+    return (__curversion_set_value_with_format(cursor, WT_CURVERSION_METADATA_FORMAT, upd->txnid,
+      start_meta, durable_meta, upd->prepare_ts, upd->prepared_id, version_cursor->upd_stop_txnid,
+      __curversion_stop_uses_prepare_ts(version_cursor) ? version_cursor->upd_stop_prepare_ts :
+                                                          version_cursor->curversion_stop_ts,
+      version_cursor->curversion_durable_stop_ts, version_cursor->upd_stop_prepare_ts,
+      version_cursor->upd_stop_prepared_id, upd->type, version_prepared, upd->flags,
+      WT_CURVERSION_UPDATE_CHAIN));
+}
+
+/*
  * __curversion_next_single_key --
  *     Iterate the updates of a single key.
  */

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -692,27 +692,22 @@ __curversion_value_return_from_hs(WT_CURSOR *cursor, WT_TIME_WINDOW *twp, uint64
 }
 
 /*
- * __curversion_next_single_key --
- *     Iterate the updates of a single key.
+ * __curversion_process_hs --
+ *     Return the next version from the history store, if any.
  */
 static int
-__curversion_next_single_key(WT_CURSOR *cursor)
+__curversion_process_hs(WT_CURSOR *cursor, WT_PAGE *page, WT_ITEM **keyp, WT_ITEM **hs_valuep,
+  bool *upd_foundp, bool *donep)
 {
     WT_CURSOR *file_cursor, *hs_cursor;
     WT_CURSOR_BTREE *cbt;
     WT_CURSOR_VERSION *version_cursor;
-    WT_DECL_ITEM(hs_value);
-    WT_DECL_ITEM(key);
-    WT_DECL_RET;
-    WT_PAGE *page;
     WT_SESSION_IMPL *session;
     WT_TIME_WINDOW *twp;
-    WT_UPDATE *tombstone;
     wt_timestamp_t durable_start_ts, durable_stop_ts;
     size_t max_memsize;
-    uint64_t hs_upd_type, raw;
+    uint64_t hs_upd_type;
     uint8_t *p;
-    bool done, upd_found;
 
     session = CUR2S(cursor);
     version_cursor = (WT_CURSOR_VERSION *)cursor;
@@ -720,9 +715,127 @@ __curversion_next_single_key(WT_CURSOR *cursor)
     hs_cursor = version_cursor->hs_cursor;
     cbt = (WT_CURSOR_BTREE *)file_cursor;
     twp = NULL;
-    upd_found = false;
-    done = false;
+
+    if (*upd_foundp || hs_cursor == NULL || F_ISSET(version_cursor, WT_CURVERSION_HS_EXHAUSTED))
+        return (0);
+
+    /*
+     * Stop once we hit a globally visible record on the update chain; no need to return more
+     * updates. Aborted updates are never globally visible.
+     */
+    if (F_ISSET(version_cursor, WT_CURVERSION_TIMESTAMP_ORDER) &&
+      !version_cursor->upd_stop_prepared && version_cursor->upd_stop_txnid != WT_TXN_ABORTED &&
+      __wt_txn_visible_all(
+        session, version_cursor->upd_stop_txnid, version_cursor->curversion_durable_stop_ts)) {
+        *donep = true;
+        return (0);
+    }
+
+    /* Ensure we can see all the content in the history store. */
+    F_SET(hs_cursor, WT_CURSTD_HS_READ_COMMITTED);
+
+    if (!F_ISSET(hs_cursor, WT_CURSTD_KEY_INT)) {
+        if (page->type == WT_PAGE_ROW_LEAF)
+            hs_cursor->set_key(
+              hs_cursor, 4, S2BT(session)->id, &file_cursor->key, WT_TS_MAX, UINT64_MAX);
+        else {
+            /* Ensure enough room for a column-store key without checking. */
+            WT_RET(__wt_scr_alloc(session, WT_INTPACK64_MAXSIZE, keyp));
+
+            p = (*keyp)->mem;
+            WT_RET(__wt_vpack_uint(&p, 0, cbt->recno));
+            (*keyp)->size = WT_PTRDIFF(p, (*keyp)->data);
+            hs_cursor->set_key(hs_cursor, 4, S2BT(session)->id, *keyp, WT_TS_MAX, UINT64_MAX);
+        }
+        WT_RET(__wt_curhs_search_near_before(session, hs_cursor));
+    } else
+        WT_RET(hs_cursor->prev(hs_cursor));
+
+    WT_RET(__wt_scr_alloc(session, 0, hs_valuep));
+
+    for (;;) {
+        __wt_hs_upd_time_window(hs_cursor, &twp);
+        WT_RET(hs_cursor->get_value(
+          hs_cursor, &durable_stop_ts, &durable_start_ts, &hs_upd_type, *hs_valuep));
+
+        /*
+         * Reconstruct the history store value if needed. Because the current value is preserved
+         * across iterations, modifies can be applied on top of it.
+         */
+        if (hs_upd_type == WT_UPDATE_MODIFY) {
+            __wt_modify_max_memsize_format((*hs_valuep)->data, file_cursor->value_format,
+              cbt->upd_value->buf.size, &max_memsize);
+            WT_RET(__wt_buf_set_and_grow(session, &cbt->upd_value->buf, cbt->upd_value->buf.data,
+              cbt->upd_value->buf.size, max_memsize));
+            WT_RET(__wt_modify_apply_item(
+              session, file_cursor->value_format, &cbt->upd_value->buf, (*hs_valuep)->data));
+        } else {
+            WT_ASSERT(session, hs_upd_type == WT_UPDATE_STANDARD);
+            cbt->upd_value->buf.data = (*hs_valuep)->data;
+            cbt->upd_value->buf.size = (*hs_valuep)->size;
+        }
+
+        if (!F_ISSET(version_cursor, WT_CURVERSION_TIMESTAMP_ORDER))
+            break;
+
+        /* Skip all non-aborted updates that are duplicate to the previous updates returned. */
+        if (version_cursor->upd_stop_txnid != WT_TXN_ABORTED &&
+          twp->stop_txn <= version_cursor->upd_stop_txnid &&
+          twp->stop_ts <= version_cursor->curversion_stop_ts &&
+          twp->durable_stop_ts <= version_cursor->curversion_durable_stop_ts)
+            break;
+
+        WT_RET(hs_cursor->prev(hs_cursor));
+    }
+
+    if (version_cursor->start_timestamp != WT_TS_NONE) {
+        /* Done if the durable stop timestamp is at or before the end timestamp. */
+        if (twp->stop_ts != WT_TS_MAX && twp->durable_stop_ts <= version_cursor->start_timestamp) {
+            *donep = true;
+            return (0);
+        }
+        /*
+         * FIXME-WT-16136: for the history store it is hard to tell whether a stop durable timestamp
+         * belongs to a tombstone or to the previous full value. For now, always return the value
+         * when its stop durable timestamp is past the end timestamp.
+         */
+        if (twp->stop_ts == WT_TS_MAX && twp->durable_start_ts <= version_cursor->start_timestamp) {
+            *donep = true;
+            return (0);
+        }
+    }
+
+    WT_RET(__curversion_value_return_from_hs(cursor, twp, hs_upd_type));
+    *upd_foundp = true;
+    return (0);
+}
+
+/*
+ * __curversion_next_single_key --
+ *     Iterate the updates of a single key.
+ */
+static int
+__curversion_next_single_key(WT_CURSOR *cursor)
+{
+    WT_CURSOR *file_cursor;
+    WT_CURSOR_BTREE *cbt;
+    WT_CURSOR_VERSION *version_cursor;
+    WT_DECL_ITEM(hs_value);
+    WT_DECL_ITEM(key);
+    WT_DECL_RET;
+    WT_PAGE *page;
+    WT_SESSION_IMPL *session;
+    WT_UPDATE *tombstone;
+    uint64_t raw;
+    bool done, upd_found;
+
+    session = CUR2S(cursor);
+    version_cursor = (WT_CURSOR_VERSION *)cursor;
+    file_cursor = version_cursor->file_cursor;
+    cbt = (WT_CURSOR_BTREE *)file_cursor;
     tombstone = NULL;
+    done = false;
+    upd_found = false;
 
     /* Temporarily clear the raw flag. We need to pack the data according to the format. */
     raw = F_MASK(cursor, WT_CURSTD_RAW);
@@ -737,130 +850,11 @@ __curversion_next_single_key(WT_CURSOR *cursor)
     page = cbt->ref->page;
 
     WT_ERR(__curversion_process_chain(cursor, &tombstone, &upd_found, &done));
-    if (done)
-        goto done;
+    if (!done)
+        WT_ERR(__curversion_process_on_disk(cursor, tombstone, page, &upd_found, &done));
+    if (!done)
+        WT_ERR(__curversion_process_hs(cursor, page, &key, &hs_value, &upd_found, &done));
 
-    WT_ERR(__curversion_process_on_disk(cursor, tombstone, page, &upd_found, &done));
-    if (done)
-        goto done;
-
-
-    if (!upd_found && version_cursor->hs_cursor != NULL &&
-      !F_ISSET(version_cursor, WT_CURVERSION_HS_EXHAUSTED)) {
-        /*
-         * We have already seen an update that is globally visible on the update chain. No need to
-         * return more updates. Aborted updates are never globally visible.
-         */
-        if (F_ISSET(version_cursor, WT_CURVERSION_TIMESTAMP_ORDER) &&
-          !version_cursor->upd_stop_prepared && version_cursor->upd_stop_txnid != WT_TXN_ABORTED &&
-          __wt_txn_visible_all(
-            session, version_cursor->upd_stop_txnid, version_cursor->curversion_durable_stop_ts))
-            goto done;
-
-        /* Ensure we can see all the content in the history store. */
-        F_SET(hs_cursor, WT_CURSTD_HS_READ_COMMITTED);
-
-        if (!F_ISSET(hs_cursor, WT_CURSTD_KEY_INT)) {
-            if (page->type == WT_PAGE_ROW_LEAF)
-                hs_cursor->set_key(
-                  hs_cursor, 4, S2BT(session)->id, &file_cursor->key, WT_TS_MAX, UINT64_MAX);
-            else {
-                /* Ensure enough room for a column-store key without checking. */
-                WT_ERR(__wt_scr_alloc(session, WT_INTPACK64_MAXSIZE, &key));
-
-                p = key->mem;
-                WT_ERR(__wt_vpack_uint(&p, 0, cbt->recno));
-                key->size = WT_PTRDIFF(p, key->data);
-                hs_cursor->set_key(hs_cursor, 4, S2BT(session)->id, key, WT_TS_MAX, UINT64_MAX);
-            }
-            WT_ERR(__wt_curhs_search_near_before(session, hs_cursor));
-        } else
-            WT_ERR(hs_cursor->prev(hs_cursor));
-
-        WT_ERR(__wt_scr_alloc(session, 0, &hs_value));
-
-        /*
-         * If there are no history store records for the given key or if we have iterated through
-         * all the records already, we have exhausted the history store.
-         */
-        WT_ASSERT(session, ret == 0);
-
-        for (;;) {
-            __wt_hs_upd_time_window(hs_cursor, &twp);
-            WT_ERR(hs_cursor->get_value(
-              hs_cursor, &durable_stop_ts, &durable_start_ts, &hs_upd_type, hs_value));
-
-            /*
-             * Reconstruct the history store value if needed. Since we save the value inside the
-             * version cursor every time we traverse a version, we can simply apply the modify onto
-             * the latest value.
-             */
-            if (hs_upd_type == WT_UPDATE_MODIFY) {
-                __wt_modify_max_memsize_format(hs_value->data, file_cursor->value_format,
-                  cbt->upd_value->buf.size, &max_memsize);
-                WT_ERR(__wt_buf_set_and_grow(session, &cbt->upd_value->buf,
-                  cbt->upd_value->buf.data, cbt->upd_value->buf.size, max_memsize));
-                WT_ERR(__wt_modify_apply_item(
-                  session, file_cursor->value_format, &cbt->upd_value->buf, hs_value->data));
-            } else {
-                WT_ASSERT(session, hs_upd_type == WT_UPDATE_STANDARD);
-                cbt->upd_value->buf.data = hs_value->data;
-                cbt->upd_value->buf.size = hs_value->size;
-            }
-
-            if (!F_ISSET(version_cursor, WT_CURVERSION_TIMESTAMP_ORDER))
-                break;
-
-            /* Skip all non-aborted updates that are duplicate to the previous updates returned. */
-            if (version_cursor->upd_stop_txnid != WT_TXN_ABORTED &&
-              twp->stop_txn <= version_cursor->upd_stop_txnid &&
-              twp->stop_ts <= version_cursor->curversion_stop_ts &&
-              twp->durable_stop_ts <= version_cursor->curversion_durable_stop_ts)
-                break;
-
-            WT_ERR(hs_cursor->prev(hs_cursor));
-        }
-
-        if (version_cursor->start_timestamp != WT_TS_NONE) {
-            /*
-             * We are done if the durable stop timestamp is smaller or equal to the end timestamp.
-             */
-            if (twp->stop_ts != WT_TS_MAX &&
-              twp->durable_stop_ts <= version_cursor->start_timestamp)
-                goto done;
-
-            /*
-             * FIXME-WT-16136: for history store, it is hard to determine if the stop durable
-             * timestamp is from a tombstone or the previous full value. Always return the value for
-             * now if its stop durable timestamp is larger than the end timestamp.
-             */
-            if (twp->stop_ts == WT_TS_MAX &&
-              twp->durable_start_ts <= version_cursor->start_timestamp)
-                goto done;
-        }
-
-        WT_ERR(
-          __curversion_set_value_with_format(cursor, WT_CURVERSION_METADATA_FORMAT, twp->start_txn,
-            WT_TIME_WINDOW_HAS_START_PREPARE(twp) ? twp->start_prepare_ts : twp->start_ts,
-            WT_TIME_WINDOW_HAS_START_PREPARE(twp) ? twp->start_prepare_ts : twp->durable_start_ts,
-            twp->start_prepare_ts, twp->start_prepared_id, twp->stop_txn,
-            WT_TIME_WINDOW_HAS_STOP_PREPARE(twp) ? twp->stop_prepare_ts : twp->stop_ts,
-            WT_TIME_WINDOW_HAS_STOP_PREPARE(twp) ? twp->stop_prepare_ts : twp->durable_stop_ts,
-            twp->stop_prepare_ts, twp->stop_prepared_id, hs_upd_type, 0, 0,
-            WT_CURVERSION_HISTORY_STORE));
-
-        version_cursor->upd_stop_txnid = twp->start_txn;
-        version_cursor->curversion_durable_stop_ts =
-          WT_TIME_WINDOW_HAS_START_PREPARE(twp) ? twp->start_prepare_ts : twp->durable_start_ts;
-        version_cursor->curversion_stop_ts =
-          WT_TIME_WINDOW_HAS_START_PREPARE(twp) ? twp->start_prepare_ts : twp->start_ts;
-        version_cursor->upd_stop_prepare_ts = twp->start_prepare_ts;
-        version_cursor->upd_stop_prepared_id = twp->start_prepared_id;
-
-        upd_found = true;
-    }
-
-done:
     if (!upd_found)
         ret = WT_NOTFOUND;
     else {

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -178,7 +178,7 @@ __curversion_set_value_with_format(WT_CURSOR *cursor, const char *fmt, ...)
 
 /*
  * __curversion_tombstone_next_upd --
- *     After recording stop metadata from a tombstone, advance past it to find the value to emit.
+ *     After recording stop metadata from a tombstone, advance past it to find the value to return.
  *     Handles both the normal case (skip all aborted updates) and show_prepared_rollback mode
  *     (include rolled-back prepared value updates).
  */

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -210,6 +210,27 @@ __curversion_tombstone_next_upd(
 }
 
 /*
+ * __curversion_record_stop_time_point --
+ *     Save an update's metadata as the previously-returned stop state.
+ */
+static void
+__curversion_record_stop_time_point(
+  WT_CURSOR_VERSION *version_cursor, WT_UPDATE *upd, bool version_prepared)
+{
+    version_cursor->upd_stop_txnid = upd->txnid;
+    if (upd->txnid == WT_TXN_ABORTED) {
+        version_cursor->curversion_stop_rollback_ts = upd->upd_rollback_ts;
+        version_cursor->curversion_stop_saved_txnid = upd->upd_saved_txnid;
+    } else {
+        version_cursor->curversion_durable_stop_ts = upd->upd_durable_ts;
+        version_cursor->curversion_stop_ts = upd->upd_start_ts;
+    }
+    version_cursor->upd_stop_prepare_ts = upd->prepare_ts;
+    version_cursor->upd_stop_prepared_id = upd->prepared_id;
+    version_cursor->upd_stop_prepared = version_prepared;
+}
+
+/*
  * __curversion_next_single_key --
  *     Iterate the updates of a single key.
  */

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -256,6 +256,53 @@ __curversion_value_return_from_upd(
 }
 
 /*
+ * __curversion_walk_to_next_update --
+ *     Locate the next update worth returning after the one just returned. Returns NULL if the chain
+ *     is exhausted or if the just-returned update was globally visible.
+ */
+static WT_UPDATE *
+__curversion_walk_to_next_update(
+  WT_SESSION_IMPL *session, WT_CURSOR_VERSION *version_cursor, WT_UPDATE *upd)
+{
+    WT_UPDATE *first_globally_visible, *next_upd;
+
+    first_globally_visible = NULL;
+
+    for (next_upd = upd; next_upd != NULL; next_upd = next_upd->next) {
+        /* Skip aborted updates unless showing prepared rollbacks. */
+        if (next_upd->txnid == WT_TXN_ABORTED &&
+          (!F_ISSET(version_cursor, WT_CURVERSION_SHOW_PREPARED_ROLLBACK) ||
+            !__curversion_is_prepare_rollback_update(next_upd)))
+            continue;
+
+        if (first_globally_visible != NULL) {
+            next_upd = NULL;
+            break;
+        }
+
+        /* We have traversed all the non-obsolete updates. */
+        if ((F_ISSET(version_cursor, WT_CURVERSION_TIMESTAMP_ORDER) ||
+              WT_UPDATE_DATA_VALUE(next_upd)) &&
+          __wt_txn_upd_visible_all(session, next_upd))
+            first_globally_visible = next_upd;
+
+        if (next_upd != upd) {
+            /*
+             * The previously returned update is not globally visible: snapshot isolation plus the
+             * pinned global timestamp guarantee this. Aborted updates are never globally visible.
+             */
+            WT_ASSERT(session,
+              version_cursor->upd_stop_txnid == WT_TXN_ABORTED ||
+                !__wt_txn_visible_all(session, version_cursor->upd_stop_txnid,
+                  version_cursor->curversion_durable_stop_ts));
+            break;
+        }
+    }
+
+    return (next_upd);
+}
+
+/*
  * __curversion_next_single_key --
  *     Iterate the updates of a single key.
  */

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -303,6 +303,93 @@ __curversion_walk_to_next_update(
 }
 
 /*
+ * __curversion_process_chain --
+ *     Return the next version from the in-memory update chain, if any.
+ */
+static int
+__curversion_process_chain(WT_CURSOR *cursor, WT_UPDATE **tombstonep, bool *upd_foundp, bool *donep)
+{
+    WT_CURSOR_BTREE *cbt;
+    WT_CURSOR_VERSION *version_cursor;
+    WT_SESSION_IMPL *session;
+    WT_UPDATE *next_upd, *tombstone, *upd;
+    uint8_t prepare_state;
+    bool version_prepared;
+
+    session = CUR2S(cursor);
+    version_cursor = (WT_CURSOR_VERSION *)cursor;
+    cbt = (WT_CURSOR_BTREE *)version_cursor->file_cursor;
+    tombstone = NULL;
+
+    if (F_ISSET(version_cursor, WT_CURVERSION_UPDATE_EXHAUSTED))
+        return (0);
+
+    upd = version_cursor->next_upd;
+    if (upd == NULL) {
+        version_cursor->next_upd = NULL;
+        F_SET(version_cursor, WT_CURVERSION_UPDATE_EXHAUSTED);
+        return (0);
+    }
+
+    if (version_cursor->start_timestamp != WT_TS_NONE && upd->upd_durable_ts != WT_TS_NONE &&
+      upd->upd_durable_ts <= version_cursor->start_timestamp) {
+        *donep = true;
+        return (0);
+    }
+
+    if (upd->type == WT_UPDATE_TOMBSTONE) {
+        tombstone = upd;
+
+        /*
+         * Record the tombstone's stop information and traverse on to a value-bearing update. If the
+         * tombstone is the last update on the chain, the caller will fall back to the on-disk
+         * value.
+         */
+        WT_ACQUIRE_READ_WITH_BARRIER(prepare_state, upd->prepare_state);
+        version_prepared = !__curversion_is_prepare_rollback_update(upd) &&
+          (prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED);
+        __curversion_record_stop_time_point(version_cursor, upd, version_prepared);
+        upd = __curversion_tombstone_next_upd(session, version_cursor, tombstone);
+    }
+
+    *tombstonep = tombstone;
+
+    if (upd == NULL) {
+        version_cursor->next_upd = NULL;
+        F_SET(version_cursor, WT_CURVERSION_UPDATE_EXHAUSTED);
+        return (0);
+    }
+
+    WT_ACQUIRE_READ_WITH_BARRIER(prepare_state, upd->prepare_state);
+    version_prepared = !__curversion_is_prepare_rollback_update(upd) &&
+      (prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED);
+
+    /*
+     * Copy the update value into the version cursor as we don't know the value format. If the
+     * update is a modify, reconstruct the value.
+     */
+    if (upd->type != WT_UPDATE_MODIFY)
+        __wt_upd_value_assign(cbt->upd_value, upd);
+    else
+        WT_RET(__wt_modify_reconstruct_from_upd_list(
+          session, cbt, upd, cbt->upd_value, WT_OPCTX_TRANSACTION));
+
+    /* Pack the metadata describing this version into the version cursor's value. */
+    WT_RET(__curversion_value_return_from_upd(cursor, version_cursor, upd, version_prepared));
+
+    __curversion_record_stop_time_point(version_cursor, upd, version_prepared);
+
+    *upd_foundp = true;
+
+    next_upd = __curversion_walk_to_next_update(session, version_cursor, upd);
+    version_cursor->next_upd = next_upd;
+    if (next_upd == NULL)
+        F_SET(version_cursor, WT_CURVERSION_UPDATE_EXHAUSTED);
+
+    return (0);
+}
+
+/*
  * __curversion_next_single_key --
  *     Iterate the updates of a single key.
  */
@@ -318,12 +405,12 @@ __curversion_next_single_key(WT_CURSOR *cursor)
     WT_PAGE *page;
     WT_SESSION_IMPL *session;
     WT_TIME_WINDOW *twp;
-    WT_UPDATE *first_globally_visible, *next_upd, *tombstone, *upd;
+    WT_UPDATE *tombstone;
     wt_timestamp_t durable_start_ts, durable_stop_ts, stop_prepare_ts, stop_ts;
     size_t max_memsize;
     uint64_t hs_upd_type, raw, stop_prepared_id, stop_txn;
     uint8_t *p, prepare_state;
-    bool stop_prepared, upd_found, version_prepared;
+    bool done, stop_prepared, upd_found, version_prepared;
 
     session = CUR2S(cursor);
     version_cursor = (WT_CURSOR_VERSION *)cursor;
@@ -332,7 +419,8 @@ __curversion_next_single_key(WT_CURSOR *cursor)
     cbt = (WT_CURSOR_BTREE *)file_cursor;
     twp = NULL;
     upd_found = false;
-    first_globally_visible = tombstone = upd = NULL;
+    done = false;
+    tombstone = NULL;
 
     /* Temporarily clear the raw flag. We need to pack the data according to the format. */
     raw = F_MASK(cursor, WT_CURSTD_RAW);
@@ -346,139 +434,9 @@ __curversion_next_single_key(WT_CURSOR *cursor)
     /* It's unsafe to access the page before checking the cursor's position. */
     page = cbt->ref->page;
 
-    if (!F_ISSET(version_cursor, WT_CURVERSION_UPDATE_EXHAUSTED)) {
-        upd = version_cursor->next_upd;
-
-        if (upd == NULL) {
-            version_cursor->next_upd = NULL;
-            F_SET(version_cursor, WT_CURVERSION_UPDATE_EXHAUSTED);
-        } else {
-            if (version_cursor->start_timestamp != WT_TS_NONE &&
-              upd->upd_durable_ts != WT_TS_NONE &&
-              upd->upd_durable_ts <= version_cursor->start_timestamp)
-                goto done;
-
-            if (upd->type == WT_UPDATE_TOMBSTONE) {
-                tombstone = upd;
-
-                /*
-                 * If the update is a tombstone, we still want to record the stop information but we
-                 * also need traverse to the next update to get the full value. If the tombstone was
-                 * the last update in the update list, retrieve the ondisk value.
-                 */
-                WT_ACQUIRE_READ_WITH_BARRIER(prepare_state, upd->prepare_state);
-                version_prepared = !__curversion_is_prepare_rollback_update(upd) &&
-                  (prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED);
-                version_cursor->upd_stop_txnid = upd->txnid;
-                if (upd->txnid == WT_TXN_ABORTED) {
-                    version_cursor->curversion_stop_rollback_ts = upd->upd_rollback_ts;
-                    version_cursor->curversion_stop_saved_txnid = upd->upd_saved_txnid;
-                } else {
-                    version_cursor->curversion_durable_stop_ts = upd->upd_durable_ts;
-                    version_cursor->curversion_stop_ts = upd->upd_start_ts;
-                }
-                version_cursor->upd_stop_prepare_ts = upd->prepare_ts;
-                version_cursor->upd_stop_prepared_id = upd->prepared_id;
-                version_cursor->upd_stop_prepared = version_prepared;
-
-                upd = __curversion_tombstone_next_upd(session, version_cursor, tombstone);
-            }
-
-            if (upd == NULL) {
-                version_cursor->next_upd = NULL;
-                F_SET(version_cursor, WT_CURVERSION_UPDATE_EXHAUSTED);
-            } else {
-                WT_ACQUIRE_READ_WITH_BARRIER(prepare_state, upd->prepare_state);
-                version_prepared = !__curversion_is_prepare_rollback_update(upd) &&
-                  (prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED);
-
-                /*
-                 * Copy the update value into the version cursor as we don't know the value format.
-                 * If the update is a modify, reconstruct the value.
-                 */
-                if (upd->type != WT_UPDATE_MODIFY)
-                    __wt_upd_value_assign(cbt->upd_value, upd);
-                else
-                    WT_ERR(__wt_modify_reconstruct_from_upd_list(
-                      session, cbt, upd, cbt->upd_value, WT_OPCTX_TRANSACTION));
-
-                /*
-                 * Set the version cursor's value, which also contains all the record metadata for
-                 * that particular version of the update.
-                 */
-                if (upd->txnid == WT_TXN_ABORTED)
-                    WT_ERR(__curversion_set_value_with_format(cursor, WT_CURVERSION_METADATA_FORMAT,
-                      upd->txnid, upd->upd_saved_txnid, upd->upd_rollback_ts, upd->prepare_ts,
-                      upd->prepared_id, version_cursor->upd_stop_txnid,
-                      __curversion_stop_uses_prepare_ts(version_cursor) ?
-                        version_cursor->upd_stop_prepare_ts :
-                        version_cursor->curversion_stop_ts,
-                      version_cursor->curversion_durable_stop_ts,
-                      version_cursor->upd_stop_prepare_ts, version_cursor->upd_stop_prepared_id,
-                      upd->type, version_prepared, upd->flags, WT_CURVERSION_UPDATE_CHAIN));
-                else
-                    WT_ERR(__curversion_set_value_with_format(cursor, WT_CURVERSION_METADATA_FORMAT,
-                      upd->txnid, upd->upd_start_ts, upd->upd_durable_ts, upd->prepare_ts,
-                      upd->prepared_id, version_cursor->upd_stop_txnid,
-                      __curversion_stop_uses_prepare_ts(version_cursor) ?
-                        version_cursor->upd_stop_prepare_ts :
-                        version_cursor->curversion_stop_ts,
-                      version_cursor->curversion_durable_stop_ts,
-                      version_cursor->upd_stop_prepare_ts, version_cursor->upd_stop_prepared_id,
-                      upd->type, version_prepared, upd->flags, WT_CURVERSION_UPDATE_CHAIN));
-
-                version_cursor->upd_stop_txnid = upd->txnid;
-                if (upd->txnid == WT_TXN_ABORTED) {
-                    version_cursor->curversion_stop_rollback_ts = upd->upd_rollback_ts;
-                    version_cursor->curversion_stop_saved_txnid = upd->upd_saved_txnid;
-                } else {
-                    version_cursor->curversion_durable_stop_ts = upd->upd_durable_ts;
-                    version_cursor->curversion_stop_ts = upd->upd_start_ts;
-                }
-                version_cursor->upd_stop_prepare_ts = upd->prepare_ts;
-                version_cursor->upd_stop_prepared_id = upd->prepared_id;
-                version_cursor->upd_stop_prepared = version_prepared;
-
-                upd_found = true;
-
-                /* Walk to the next non-obsolete update. */
-                for (next_upd = upd; next_upd != NULL; next_upd = next_upd->next) {
-                    /* Skip aborted updates unless showing prepared rollbacks. */
-                    if (next_upd->txnid == WT_TXN_ABORTED &&
-                      (!F_ISSET(version_cursor, WT_CURVERSION_SHOW_PREPARED_ROLLBACK) ||
-                        !__curversion_is_prepare_rollback_update(next_upd)))
-                        continue;
-
-                    if (first_globally_visible != NULL) {
-                        next_upd = NULL;
-                        break;
-                    }
-
-                    /* We have traversed all the non-obsolete updates. */
-                    if ((F_ISSET(version_cursor, WT_CURVERSION_TIMESTAMP_ORDER) ||
-                          WT_UPDATE_DATA_VALUE(next_upd)) &&
-                      __wt_txn_upd_visible_all(session, next_upd))
-                        first_globally_visible = next_upd;
-
-                    if (next_upd != upd) {
-                        /*
-                         * If we are here, the previous update is not globally visible. We need
-                         * snapshot isolation and have pinned the global timestamp when we start the
-                         * version cursor. Aborted updates are never globally visible.
-                         */
-                        WT_ASSERT(session,
-                          version_cursor->upd_stop_txnid == WT_TXN_ABORTED ||
-                            !__wt_txn_visible_all(session, version_cursor->upd_stop_txnid,
-                              version_cursor->curversion_durable_stop_ts));
-                        break;
-                    }
-                }
-                version_cursor->next_upd = next_upd;
-                if (next_upd == NULL)
-                    F_SET(version_cursor, WT_CURVERSION_UPDATE_EXHAUSTED);
-            }
-        }
-    }
+    WT_ERR(__curversion_process_chain(cursor, &tombstone, &upd_found, &done));
+    if (done)
+        goto done;
 
     if (!upd_found && !F_ISSET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED)) {
         /*

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -390,6 +390,35 @@ __curversion_process_chain(WT_CURSOR *cursor, WT_UPDATE **tombstonep, bool *upd_
 }
 
 /*
+ * __curversion_disk_skip_no_stop --
+ *     Decide whether to skip an on-disk record that has no stop side, when running in timestamp
+ *     order mode.
+ */
+static bool
+__curversion_disk_skip_no_stop(WT_CURSOR_VERSION *version_cursor, WT_TIME_WINDOW *tw)
+{
+    if (!F_ISSET(version_cursor, WT_CURVERSION_TIMESTAMP_ORDER))
+        return (false);
+
+    /* Prepared values on disk are always skipped. */
+    if (WT_TIME_WINDOW_HAS_START_PREPARE(tw))
+        return (true);
+
+    /*
+     * If the previous emission was a rolled-back prepared update its stop slot holds a rollback
+     * timestamp instead of a real stop timestamp, so the comparison would be meaningless.
+     */
+    if (version_cursor->upd_stop_txnid == WT_TXN_ABORTED)
+        return (false);
+
+    if (__curversion_stop_uses_prepare_ts(version_cursor))
+        return (tw->start_txn > version_cursor->upd_stop_txnid ||
+          tw->start_ts > version_cursor->upd_stop_prepare_ts);
+    return (tw->start_txn > version_cursor->upd_stop_txnid ||
+      tw->start_ts > version_cursor->curversion_stop_ts);
+}
+
+/*
  * __curversion_next_single_key --
  *     Iterate the updates of a single key.
  */

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -461,6 +461,58 @@ __curversion_disk_check_with_stop(WT_SESSION_IMPL *session, WT_CURSOR_VERSION *v
 }
 
 /*
+ * __curversion_disk_finalize_prepared --
+ *     Resolve the prepared-state and visibility decisions for an on-disk record, possibly mutating
+ *     the stop fields when running in visible-only mode.
+ */
+static void
+__curversion_disk_finalize_prepared(WT_CURSOR_VERSION *version_cursor, WT_TIME_WINDOW *tw,
+  WT_UPDATE *tombstone, uint64_t *stop_txnp, wt_timestamp_t *stop_prepare_tsp,
+  uint64_t *stop_prepared_idp, wt_timestamp_t *stop_tsp, wt_timestamp_t *durable_stop_tsp,
+  bool *stop_preparedp, bool *version_preparedp, bool *skipp, bool *donep)
+{
+    uint8_t prepare_state;
+
+    if (tombstone != NULL) {
+        WT_ACQUIRE_READ_WITH_BARRIER(prepare_state, tombstone->prepare_state);
+        *version_preparedp =
+          prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED;
+        return;
+    }
+
+    if (version_cursor->start_timestamp != WT_TS_NONE) {
+        if (WT_TIME_WINDOW_HAS_STOP(tw)) {
+            /* Done if the on-disk stop durable timestamp is at or before the end timestamp. */
+            if (!WT_TIME_WINDOW_HAS_STOP_PREPARE(tw) &&
+              tw->durable_stop_ts <= version_cursor->start_timestamp) {
+                *donep = true;
+                return;
+            }
+        } else if (!WT_TIME_WINDOW_HAS_START_PREPARE(tw) &&
+          tw->durable_start_ts <= version_cursor->start_timestamp) {
+            /* No stop side: done if the start durable timestamp is past the end timestamp. */
+            *donep = true;
+            return;
+        }
+    }
+
+    if (F_ISSET(version_cursor, WT_CURVERSION_VISIBLE_ONLY) && WT_TIME_WINDOW_HAS_PREPARE(tw)) {
+        if (!WT_TIME_WINDOW_HAS_STOP(tw) || *stop_txnp == tw->start_txn) {
+            *skipp = true;
+            return;
+        }
+        *stop_txnp = WT_TXN_MAX;
+        *stop_prepare_tsp = WT_TS_MAX;
+        *stop_prepared_idp = WT_PREPARED_ID_NONE;
+        *stop_tsp = WT_TS_MAX;
+        *durable_stop_tsp = WT_TS_NONE;
+        *stop_preparedp = false;
+        *version_preparedp = false;
+    } else
+        *version_preparedp = WT_TIME_WINDOW_HAS_PREPARE(tw);
+}
+
+/*
  * __curversion_next_single_key --
  *     Iterate the updates of a single key.
  */

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -544,6 +544,123 @@ __curversion_value_return_from_disk_image(WT_CURSOR *cursor, WT_TIME_WINDOW *tw,
 }
 
 /*
+ * __curversion_process_on_disk --
+ *     Return the on-disk value as the next version, if there is one and it should be returned.
+ */
+static int
+__curversion_process_on_disk(
+  WT_CURSOR *cursor, WT_UPDATE *tombstone, WT_PAGE *page, bool *upd_foundp, bool *donep)
+{
+    WT_CURSOR_BTREE *cbt;
+    WT_CURSOR_VERSION *version_cursor;
+    WT_DECL_RET;
+    WT_SESSION_IMPL *session;
+    WT_TIME_WINDOW *tw;
+    wt_timestamp_t durable_stop_ts, stop_prepare_ts, stop_ts;
+    uint64_t stop_prepared_id, stop_txn;
+    bool skip, stop_prepared, version_prepared;
+
+    session = CUR2S(cursor);
+    version_cursor = (WT_CURSOR_VERSION *)cursor;
+    cbt = (WT_CURSOR_BTREE *)version_cursor->file_cursor;
+    tw = &cbt->upd_value->tw;
+    version_prepared = false;
+
+    if (*upd_foundp || F_ISSET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED))
+        return (0);
+
+    /*
+     * Stop once we hit a globally visible record on the update chain; no need to return more
+     * updates. Aborted updates are never globally visible.
+     */
+    if (F_ISSET(version_cursor, WT_CURVERSION_TIMESTAMP_ORDER) &&
+      !version_cursor->upd_stop_prepared && version_cursor->upd_stop_txnid != WT_TXN_ABORTED &&
+      __wt_txn_visible_all(
+        session, version_cursor->upd_stop_txnid, version_cursor->curversion_durable_stop_ts)) {
+        *donep = true;
+        return (0);
+    }
+
+    switch (page->type) {
+    case WT_PAGE_ROW_LEAF:
+        if (cbt->ins != NULL) {
+            F_SET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED);
+            F_SET(version_cursor, WT_CURVERSION_HS_EXHAUSTED);
+            return (WT_NOTFOUND);
+        }
+        break;
+    case WT_PAGE_COL_VAR:
+        /* Empty page doesn't have any on page value. */
+        if (page->entries == 0) {
+            F_SET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED);
+            F_SET(version_cursor, WT_CURVERSION_HS_EXHAUSTED);
+            return (WT_NOTFOUND);
+        }
+        break;
+    default:
+        return (__wt_illegal_value(session, page->type));
+    }
+
+    /*
+     * Get the ondisk value. It is possible to see an overflow-removed value if a concurrent
+     * checkpoint freed the underlying overflow blocks. In that case the value either already came
+     * back via the update chain or will come from the history store, so it is safe to skip.
+     */
+    ret = __wt_value_return_buf(cbt, cbt->ref, &cbt->upd_value->buf, tw);
+    if (ret == WT_RESTART) {
+        F_SET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED);
+        return (0);
+    }
+    WT_RET(ret);
+
+    if (!WT_TIME_WINDOW_HAS_STOP(tw)) {
+        if (__curversion_disk_skip_no_stop(version_cursor, tw)) {
+            F_SET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED);
+            return (0);
+        }
+        durable_stop_ts = version_cursor->curversion_durable_stop_ts;
+        stop_prepare_ts = version_cursor->upd_stop_prepare_ts;
+        stop_prepared_id = version_cursor->upd_stop_prepared_id;
+        stop_ts = version_cursor->curversion_stop_ts;
+        stop_txn = version_cursor->upd_stop_txnid;
+        stop_prepared = __curversion_stop_uses_prepare_ts(version_cursor);
+    } else {
+        skip = false;
+        __curversion_disk_check_with_stop(session, version_cursor, tw, &skip, donep);
+        if (*donep)
+            return (0);
+        if (skip) {
+            F_SET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED);
+            return (0);
+        }
+        durable_stop_ts = tw->durable_stop_ts;
+        stop_prepare_ts = tw->stop_prepare_ts;
+        stop_prepared_id = tw->stop_prepared_id;
+        stop_ts = tw->stop_ts;
+        stop_txn = tw->stop_txn;
+        stop_prepared = WT_TIME_WINDOW_HAS_STOP_PREPARE(tw);
+    }
+
+    skip = false;
+    __curversion_disk_finalize_prepared(version_cursor, tw, tombstone, &stop_txn, &stop_prepare_ts,
+      &stop_prepared_id, &stop_ts, &durable_stop_ts, &stop_prepared, &version_prepared, &skip,
+      donep);
+    if (*donep)
+        return (0);
+    if (skip) {
+        F_SET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED);
+        return (0);
+    }
+
+    WT_RET(__curversion_value_return_from_disk_image(cursor, tw, stop_txn, stop_prepared,
+      stop_prepare_ts, stop_ts, durable_stop_ts, stop_prepared_id, version_prepared));
+
+    *upd_foundp = true;
+    F_SET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED);
+    return (0);
+}
+
+/*
  * __curversion_next_single_key --
  *     Iterate the updates of a single key.
  */
@@ -560,11 +677,11 @@ __curversion_next_single_key(WT_CURSOR *cursor)
     WT_SESSION_IMPL *session;
     WT_TIME_WINDOW *twp;
     WT_UPDATE *tombstone;
-    wt_timestamp_t durable_start_ts, durable_stop_ts, stop_prepare_ts, stop_ts;
+    wt_timestamp_t durable_start_ts, durable_stop_ts;
     size_t max_memsize;
-    uint64_t hs_upd_type, raw, stop_prepared_id, stop_txn;
-    uint8_t *p, prepare_state;
-    bool done, stop_prepared, upd_found, version_prepared;
+    uint64_t hs_upd_type, raw;
+    uint8_t *p;
+    bool done, upd_found;
 
     session = CUR2S(cursor);
     version_cursor = (WT_CURSOR_VERSION *)cursor;
@@ -592,195 +709,10 @@ __curversion_next_single_key(WT_CURSOR *cursor)
     if (done)
         goto done;
 
-    if (!upd_found && !F_ISSET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED)) {
-        /*
-         * We have already seen an update that is globally visible on the update chain. No need to
-         * return more updates. Aborted updates are never globally visible.
-         */
-        if (F_ISSET(version_cursor, WT_CURVERSION_TIMESTAMP_ORDER) &&
-          !version_cursor->upd_stop_prepared && version_cursor->upd_stop_txnid != WT_TXN_ABORTED &&
-          __wt_txn_visible_all(
-            session, version_cursor->upd_stop_txnid, version_cursor->curversion_durable_stop_ts))
-            goto done;
+    WT_ERR(__curversion_process_on_disk(cursor, tombstone, page, &upd_found, &done));
+    if (done)
+        goto done;
 
-        switch (page->type) {
-        case WT_PAGE_ROW_LEAF:
-            if (cbt->ins != NULL) {
-                F_SET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED);
-                F_SET(version_cursor, WT_CURVERSION_HS_EXHAUSTED);
-                WT_ERR(WT_NOTFOUND);
-            }
-            break;
-        case WT_PAGE_COL_VAR:
-            /* Empty page doesn't have any on page value. */
-            if (page->entries == 0) {
-                F_SET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED);
-                F_SET(version_cursor, WT_CURVERSION_HS_EXHAUSTED);
-                WT_ERR(WT_NOTFOUND);
-            }
-            break;
-        default:
-            WT_ERR(__wt_illegal_value(session, page->type));
-        }
-
-        /*
-         * Get the ondisk value. It is possible to see an overflow removed value if checkpoint has
-         * visited this page and freed the underlying overflow blocks. In this case, checkpoint
-         * reconciliation must have also appended the value to the update chain and moved it to the
-         * history store if it is not obsolete. Therefore, we should have either already returned it
-         * when walking the update chain if we are not racing with checkpoint removing the overflow
-         * value concurrently or we shall return it later when we scan the history store if we do
-         * race with checkpoint. If it is already obsolete, there is no need for us to return it as
-         * the version cursor only ensures to return values that are not obsolete. We can safely
-         * ignore the overflow removed value here.
-         */
-        WT_ERR_ERROR_OK(
-          __wt_value_return_buf(cbt, cbt->ref, &cbt->upd_value->buf, &cbt->upd_value->tw),
-          WT_RESTART, true);
-        if (ret == 0) {
-            if (!WT_TIME_WINDOW_HAS_STOP(&cbt->upd_value->tw)) {
-                if (F_ISSET(version_cursor, WT_CURVERSION_TIMESTAMP_ORDER)) {
-                    /* Always skip prepared update on disk. */
-                    if (WT_TIME_WINDOW_HAS_START_PREPARE(&cbt->upd_value->tw))
-                        goto skip_on_page;
-
-                    /*
-                     * Skip the comparison when the previously emitted update was a rolled- back
-                     * prepared update: there is no real stop to compare against, and the fields
-                     * hold rollback metadata rather than a stop timestamp.
-                     */
-                    if (version_cursor->upd_stop_txnid != WT_TXN_ABORTED) {
-                        if (__curversion_stop_uses_prepare_ts(version_cursor)) {
-                            if (cbt->upd_value->tw.start_txn > version_cursor->upd_stop_txnid ||
-                              cbt->upd_value->tw.start_ts > version_cursor->upd_stop_prepare_ts)
-                                goto skip_on_page;
-                        } else {
-                            if (cbt->upd_value->tw.start_txn > version_cursor->upd_stop_txnid ||
-                              cbt->upd_value->tw.start_ts > version_cursor->curversion_stop_ts)
-                                goto skip_on_page;
-                        }
-                    }
-                }
-                durable_stop_ts = version_cursor->curversion_durable_stop_ts;
-                stop_prepare_ts = version_cursor->upd_stop_prepare_ts;
-                stop_prepared_id = version_cursor->upd_stop_prepared_id;
-                stop_ts = version_cursor->curversion_stop_ts;
-                stop_txn = version_cursor->upd_stop_txnid;
-                stop_prepared = __curversion_stop_uses_prepare_ts(version_cursor);
-            } else {
-                if (F_ISSET(version_cursor, WT_CURVERSION_TIMESTAMP_ORDER)) {
-                    if (__wt_txn_tw_start_visible_all(session, &cbt->upd_value->tw))
-                        goto done;
-
-                    if (WT_TIME_WINDOW_HAS_STOP_PREPARE(&cbt->upd_value->tw))
-                        goto skip_on_page;
-
-                    /*
-                     * See the no-stop branch above: skip the comparison when the previous emission
-                     * was a rolled-back prepared update.
-                     */
-                    if (version_cursor->upd_stop_txnid != WT_TXN_ABORTED) {
-                        if (__curversion_stop_uses_prepare_ts(version_cursor)) {
-                            if (cbt->upd_value->tw.stop_txn > version_cursor->upd_stop_txnid ||
-                              cbt->upd_value->tw.stop_ts > version_cursor->upd_stop_prepare_ts)
-                                goto skip_on_page;
-                        } else {
-                            if (cbt->upd_value->tw.stop_txn > version_cursor->upd_stop_txnid ||
-                              cbt->upd_value->tw.stop_ts > version_cursor->curversion_stop_ts)
-                                goto skip_on_page;
-                        }
-                    }
-
-                    /* The update is not visible if start equals stop. */
-                    if (cbt->upd_value->tw.stop_txn == cbt->upd_value->tw.start_txn &&
-                      cbt->upd_value->tw.stop_prepare_ts == cbt->upd_value->tw.start_prepare_ts &&
-                      cbt->upd_value->tw.stop_ts == cbt->upd_value->tw.start_ts &&
-                      cbt->upd_value->tw.durable_stop_ts == cbt->upd_value->tw.durable_start_ts)
-                        goto skip_on_page;
-                }
-                durable_stop_ts = cbt->upd_value->tw.durable_stop_ts;
-                stop_prepare_ts = cbt->upd_value->tw.stop_prepare_ts;
-                stop_prepared_id = cbt->upd_value->tw.stop_prepared_id;
-                stop_ts = cbt->upd_value->tw.stop_ts;
-                stop_txn = cbt->upd_value->tw.stop_txn;
-                stop_prepared = WT_TIME_WINDOW_HAS_STOP_PREPARE(&cbt->upd_value->tw);
-            }
-
-            if (tombstone != NULL) {
-                WT_ACQUIRE_READ_WITH_BARRIER(prepare_state, tombstone->prepare_state);
-                version_prepared =
-                  prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED;
-            } else {
-                if (version_cursor->start_timestamp != WT_TS_NONE) {
-                    if (WT_TIME_WINDOW_HAS_STOP(&cbt->upd_value->tw)) {
-                        /*
-                         * We are done if we have an on-disk stop durable timestamp that is smaller
-                         * than or equal to the end timestamp.
-                         */
-                        if (!WT_TIME_WINDOW_HAS_STOP_PREPARE(&cbt->upd_value->tw) &&
-                          cbt->upd_value->tw.durable_stop_ts <= version_cursor->start_timestamp)
-                            goto done;
-                    } else {
-                        /*
-                         * We are done if we don't have a valid on-disk stop durable timestamp and
-                         * the on disk start durable timestamp is smaller than or equal to the end
-                         * timestamp.
-                         */
-                        if (!WT_TIME_WINDOW_HAS_START_PREPARE(&cbt->upd_value->tw) &&
-                          cbt->upd_value->tw.durable_start_ts <= version_cursor->start_timestamp)
-                            goto done;
-                    }
-                }
-
-                if (F_ISSET(version_cursor, WT_CURVERSION_VISIBLE_ONLY) &&
-                  WT_TIME_WINDOW_HAS_PREPARE(&(cbt->upd_value->tw))) {
-                    if (!WT_TIME_WINDOW_HAS_STOP(&cbt->upd_value->tw))
-                        goto skip_on_page;
-
-                    if (stop_txn == cbt->upd_value->tw.start_txn)
-                        goto skip_on_page;
-
-                    stop_txn = WT_TXN_MAX;
-                    stop_prepare_ts = WT_TS_MAX;
-                    stop_prepared_id = WT_PREPARED_ID_NONE;
-                    stop_ts = WT_TS_MAX;
-                    durable_stop_ts = WT_TS_NONE;
-                    stop_prepared = false;
-                    version_prepared = false;
-                } else
-                    version_prepared = WT_TIME_WINDOW_HAS_PREPARE(&(cbt->upd_value->tw));
-            }
-
-            WT_ERR(__curversion_set_value_with_format(cursor, WT_CURVERSION_METADATA_FORMAT,
-              cbt->upd_value->tw.start_txn,
-              WT_TIME_WINDOW_HAS_START_PREPARE(&(cbt->upd_value->tw)) ?
-                cbt->upd_value->tw.start_prepare_ts :
-                cbt->upd_value->tw.start_ts,
-              WT_TIME_WINDOW_HAS_START_PREPARE(&(cbt->upd_value->tw)) ?
-                cbt->upd_value->tw.start_prepare_ts :
-                cbt->upd_value->tw.durable_start_ts,
-              cbt->upd_value->tw.start_prepare_ts, cbt->upd_value->tw.start_prepared_id, stop_txn,
-              stop_prepared ? stop_prepare_ts : stop_ts, durable_stop_ts, stop_prepare_ts,
-              stop_prepared_id, WT_UPDATE_STANDARD, version_prepared, 0, WT_CURVERSION_DISK_IMAGE));
-
-            version_cursor->upd_stop_txnid = cbt->upd_value->tw.start_txn;
-            version_cursor->curversion_durable_stop_ts =
-              WT_TIME_WINDOW_HAS_START_PREPARE(&(cbt->upd_value->tw)) ?
-              cbt->upd_value->tw.start_prepare_ts :
-              cbt->upd_value->tw.durable_start_ts;
-            version_cursor->curversion_stop_ts =
-              WT_TIME_WINDOW_HAS_START_PREPARE(&(cbt->upd_value->tw)) ?
-              cbt->upd_value->tw.start_prepare_ts :
-              cbt->upd_value->tw.start_ts;
-            version_cursor->upd_stop_prepare_ts = cbt->upd_value->tw.start_prepare_ts;
-            version_cursor->upd_stop_prepared_id = cbt->upd_value->tw.start_prepared_id;
-
-            upd_found = true;
-        } else
-            ret = 0;
-skip_on_page:
-        F_SET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED);
-    }
 
     if (!upd_found && version_cursor->hs_cursor != NULL &&
       !F_ISSET(version_cursor, WT_CURVERSION_HS_EXHAUSTED)) {

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -419,6 +419,48 @@ __curversion_disk_skip_no_stop(WT_CURSOR_VERSION *version_cursor, WT_TIME_WINDOW
 }
 
 /*
+ * __curversion_disk_check_with_stop --
+ *     Apply the timestamp-order filter to an on-disk record that has a stop side.
+ */
+static void
+__curversion_disk_check_with_stop(WT_SESSION_IMPL *session, WT_CURSOR_VERSION *version_cursor,
+  WT_TIME_WINDOW *tw, bool *skipp, bool *donep)
+{
+    if (!F_ISSET(version_cursor, WT_CURVERSION_TIMESTAMP_ORDER))
+        return;
+
+    if (__wt_txn_tw_start_visible_all(session, tw)) {
+        *donep = true;
+        return;
+    }
+
+    if (WT_TIME_WINDOW_HAS_STOP_PREPARE(tw)) {
+        *skipp = true;
+        return;
+    }
+
+    /* See the no-stop branch: skip the comparison after a rolled-back prepared emission. */
+    if (version_cursor->upd_stop_txnid != WT_TXN_ABORTED) {
+        if (__curversion_stop_uses_prepare_ts(version_cursor)) {
+            if (tw->stop_txn > version_cursor->upd_stop_txnid ||
+              tw->stop_ts > version_cursor->upd_stop_prepare_ts) {
+                *skipp = true;
+                return;
+            }
+        } else if (tw->stop_txn > version_cursor->upd_stop_txnid ||
+          tw->stop_ts > version_cursor->curversion_stop_ts) {
+            *skipp = true;
+            return;
+        }
+    }
+
+    /* An update whose start equals stop never became visible. */
+    if (tw->stop_txn == tw->start_txn && tw->stop_prepare_ts == tw->start_prepare_ts &&
+      tw->stop_ts == tw->start_ts && tw->durable_stop_ts == tw->durable_start_ts)
+        *skipp = true;
+}
+
+/*
  * __curversion_next_single_key --
  *     Iterate the updates of a single key.
  */

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -513,6 +513,37 @@ __curversion_disk_finalize_prepared(WT_CURSOR_VERSION *version_cursor, WT_TIME_W
 }
 
 /*
+ * __curversion_value_return_from_disk_image --
+ *     Pack the metadata for the on-disk value and record it as the previously-returned stop state.
+ */
+static int
+__curversion_value_return_from_disk_image(WT_CURSOR *cursor, WT_TIME_WINDOW *tw, uint64_t stop_txn,
+  bool stop_prepared, wt_timestamp_t stop_prepare_ts, wt_timestamp_t stop_ts,
+  wt_timestamp_t durable_stop_ts, uint64_t stop_prepared_id, bool version_prepared)
+{
+    WT_CURSOR_VERSION *version_cursor;
+    wt_timestamp_t durable_start_meta, start_meta;
+    bool has_start_prepare;
+
+    version_cursor = (WT_CURSOR_VERSION *)cursor;
+    has_start_prepare = WT_TIME_WINDOW_HAS_START_PREPARE(tw);
+    start_meta = has_start_prepare ? tw->start_prepare_ts : tw->start_ts;
+    durable_start_meta = has_start_prepare ? tw->start_prepare_ts : tw->durable_start_ts;
+
+    WT_RET(__curversion_set_value_with_format(cursor, WT_CURVERSION_METADATA_FORMAT, tw->start_txn,
+      start_meta, durable_start_meta, tw->start_prepare_ts, tw->start_prepared_id, stop_txn,
+      stop_prepared ? stop_prepare_ts : stop_ts, durable_stop_ts, stop_prepare_ts, stop_prepared_id,
+      WT_UPDATE_STANDARD, version_prepared, 0, WT_CURVERSION_DISK_IMAGE));
+
+    version_cursor->upd_stop_txnid = tw->start_txn;
+    version_cursor->curversion_durable_stop_ts = durable_start_meta;
+    version_cursor->curversion_stop_ts = start_meta;
+    version_cursor->upd_stop_prepare_ts = tw->start_prepare_ts;
+    version_cursor->upd_stop_prepared_id = tw->start_prepared_id;
+    return (0);
+}
+
+/*
  * __curversion_next_single_key --
  *     Iterate the updates of a single key.
  */


### PR DESCRIPTION
Now I have everything I need. Here is the PR body:

---

## WT-17475 — Refactor `__curversion_next_single_key` to reduce cyclomatic complexity

### Background

`__curversion_next_single_key` in `src/cursor/cur_version.c` is the core iteration step of the version cursor: for a given key it sequences through the in-memory update chain, the on-disk image, and the history store. Over time the function accumulated duplicated stop-metadata bookkeeping, back-to-back nearly-identical `__curversion_set_value_with_format` calls (one branch per aborted/live update), and a web of `goto done` / `goto skip_on_page` jumps that made control flow hard to follow. Its cyclomatic complexity reached **107**.

### What changed

The monolith was split into focused, independently testable helpers. The new call graph inside `__curversion_next_single_key` is now three sequential phases:

```c
WT_ERR(__curversion_process_chain(cursor, &tombstone, &upd_found, &done));
if (!done)
    WT_ERR(__curversion_process_on_disk(cursor, tombstone, page, &upd_found, &done));
if (!done)
    WT_ERR(__curversion_process_hs(cursor, page, &key, &hs_value, &upd_found, &done));
```

Each phase owns its guard checks, advances the cursor state, and signals completion via `done`/`upd_found` out-params rather than `goto`. All `goto` labels are gone.

#### Helpers extracted

| Helper | Responsibility |
|--------|----------------|
| `__curversion_record_stop_time_point` | Write an update's txnid/timestamps/prepare info into the version cursor's stop slots. Previously copy-pasted for both tombstone and value-update paths. |
| `__curversion_value_return_from_upd` | Pack in-memory update metadata into the cursor value. Unifies the two near-identical `__curversion_set_value_with_format` calls (aborted vs. live). |
| `__curversion_walk_to_next_update` | Walk the update chain past the just-returned entry to the next non-obsolete update, stopping at the first globally visible one. |
| `__curversion_process_chain` | Full in-memory chain phase: guard, tombstone detection, value assignment, stop recording, advance. |
| `__curversion_disk_skip_no_stop` | Decide whether to skip a no-stop on-disk record in timestamp-order mode. |
| `__curversion_disk_check_with_stop` | Apply timestamp-order filter to an on-disk record that carries a stop time window. |
| `__curversion_disk_finalize_prepared` | Resolve prepared-state visibility for an on-disk record; mutates stop fields in visible-only mode. |
| `__curversion_value_return_from_disk_image` | Pack on-disk time-window metadata and record the start side as the new stop state. |
| `__curversion_process_on_disk` | Full on-disk phase: page-type guard, value read, skip/done decisions, emit. |
| `__curversion_value_return_from_hs` | Pack history-store time-window metadata and record the start side as the new stop state. |
| `__curversion_process_hs` | Full history-store phase: guard, cursor positioning, dedup loop, start-timestamp filter, emit. |

**Complexity after refactor**: all functions ≤ 30 (down from 107).

No algorithmic changes were made; this is a pure structural refactor.

### Evergreen patch

https://spruce.corp.mongodb.com/version/6a015a730fc3ea0007393ce3

All failures are **pre-existing / unrelated** (triage: unrelated).