### PR TITLE
WT-17475 Refactor __curversion_next_single_key to reduce cyclomatic complexity (refactor-bot)

### DIFF
--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -231,6 +231,31 @@ __curversion_record_stop_time_point(
 }
 
 /*
+ * __curversion_value_return_from_upd --
+ *     Pack the metadata for an update returned from the in-memory update chain.
+ */
+static int
+__curversion_value_return_from_upd(
+  WT_CURSOR *cursor, WT_CURSOR_VERSION *version_cursor, WT_UPDATE *upd, bool version_prepared)
+{
+    uint64_t durable_meta, start_meta;
+    bool aborted;
+
+    /* Aborted updates encode rollback metadata in the start slots. */
+    aborted = (upd->txnid == WT_TXN_ABORTED);
+    start_meta = aborted ? upd->upd_saved_txnid : (uint64_t)upd->upd_start_ts;
+    durable_meta = aborted ? (uint64_t)upd->upd_rollback_ts : (uint64_t)upd->upd_durable_ts;
+
+    return (__curversion_set_value_with_format(cursor, WT_CURVERSION_METADATA_FORMAT, upd->txnid,
+      start_meta, durable_meta, upd->prepare_ts, upd->prepared_id, version_cursor->upd_stop_txnid,
+      __curversion_stop_uses_prepare_ts(version_cursor) ? version_cursor->upd_stop_prepare_ts :
+                                                          version_cursor->curversion_stop_ts,
+      version_cursor->curversion_durable_stop_ts, version_cursor->upd_stop_prepare_ts,
+      version_cursor->upd_stop_prepared_id, upd->type, version_prepared, upd->flags,
+      WT_CURVERSION_UPDATE_CHAIN));
+}
+
+/*
  * __curversion_next_single_key --
  *     Iterate the updates of a single key.
  */
@@ -324,26 +349,7 @@ __curversion_next_single_key(WT_CURSOR *cursor)
                  * Set the version cursor's value, which also contains all the record metadata for
                  * that particular version of the update.
                  */
-                if (upd->txnid == WT_TXN_ABORTED)
-                    WT_ERR(__curversion_set_value_with_format(cursor, WT_CURVERSION_METADATA_FORMAT,
-                      upd->txnid, upd->upd_saved_txnid, upd->upd_rollback_ts, upd->prepare_ts,
-                      upd->prepared_id, version_cursor->upd_stop_txnid,
-                      __curversion_stop_uses_prepare_ts(version_cursor) ?
-                        version_cursor->upd_stop_prepare_ts :
-                        version_cursor->curversion_stop_ts,
-                      version_cursor->curversion_durable_stop_ts,
-                      version_cursor->upd_stop_prepare_ts, version_cursor->upd_stop_prepared_id,
-                      upd->type, version_prepared, upd->flags, WT_CURVERSION_UPDATE_CHAIN));
-                else
-                    WT_ERR(__curversion_set_value_with_format(cursor, WT_CURVERSION_METADATA_FORMAT,
-                      upd->txnid, upd->upd_start_ts, upd->upd_durable_ts, upd->prepare_ts,
-                      upd->prepared_id, version_cursor->upd_stop_txnid,
-                      __curversion_stop_uses_prepare_ts(version_cursor) ?
-                        version_cursor->upd_stop_prepare_ts :
-                        version_cursor->curversion_stop_ts,
-                      version_cursor->curversion_durable_stop_ts,
-                      version_cursor->upd_stop_prepare_ts, version_cursor->upd_stop_prepared_id,
-                      upd->type, version_prepared, upd->flags, WT_CURVERSION_UPDATE_CHAIN));
+                WT_ERR(__curversion_value_return_from_upd(cursor, version_cursor, upd, version_prepared));
 
                 __curversion_record_stop_time_point(version_cursor, upd, version_prepared);
 

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -210,6 +210,27 @@ __curversion_tombstone_next_upd(
 }
 
 /*
+ * __curversion_record_stop_time_point --
+ *     Save an update's metadata as the previously-returned stop state.
+ */
+static void
+__curversion_record_stop_time_point(
+  WT_CURSOR_VERSION *version_cursor, WT_UPDATE *upd, bool version_prepared)
+{
+    version_cursor->upd_stop_txnid = upd->txnid;
+    if (upd->txnid == WT_TXN_ABORTED) {
+        version_cursor->curversion_stop_rollback_ts = upd->upd_rollback_ts;
+        version_cursor->curversion_stop_saved_txnid = upd->upd_saved_txnid;
+    } else {
+        version_cursor->curversion_durable_stop_ts = upd->upd_durable_ts;
+        version_cursor->curversion_stop_ts = upd->upd_start_ts;
+    }
+    version_cursor->upd_stop_prepare_ts = upd->prepare_ts;
+    version_cursor->upd_stop_prepared_id = upd->prepared_id;
+    version_cursor->upd_stop_prepared = version_prepared;
+}
+
+/*
  * __curversion_next_single_key --
  *     Iterate the updates of a single key.
  */
@@ -276,17 +297,7 @@ __curversion_next_single_key(WT_CURSOR *cursor)
                 WT_ACQUIRE_READ_WITH_BARRIER(prepare_state, upd->prepare_state);
                 version_prepared = !__curversion_is_prepare_rollback_update(upd) &&
                   (prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED);
-                version_cursor->upd_stop_txnid = upd->txnid;
-                if (upd->txnid == WT_TXN_ABORTED) {
-                    version_cursor->curversion_stop_rollback_ts = upd->upd_rollback_ts;
-                    version_cursor->curversion_stop_saved_txnid = upd->upd_saved_txnid;
-                } else {
-                    version_cursor->curversion_durable_stop_ts = upd->upd_durable_ts;
-                    version_cursor->curversion_stop_ts = upd->upd_start_ts;
-                }
-                version_cursor->upd_stop_prepare_ts = upd->prepare_ts;
-                version_cursor->upd_stop_prepared_id = upd->prepared_id;
-                version_cursor->upd_stop_prepared = version_prepared;
+                __curversion_record_stop_time_point(version_cursor, upd, version_prepared);
 
                 upd = __curversion_tombstone_next_upd(session, version_cursor, tombstone);
             }
@@ -334,17 +345,7 @@ __curversion_next_single_key(WT_CURSOR *cursor)
                       version_cursor->upd_stop_prepare_ts, version_cursor->upd_stop_prepared_id,
                       upd->type, version_prepared, upd->flags, WT_CURVERSION_UPDATE_CHAIN));
 
-                version_cursor->upd_stop_txnid = upd->txnid;
-                if (upd->txnid == WT_TXN_ABORTED) {
-                    version_cursor->curversion_stop_rollback_ts = upd->upd_rollback_ts;
-                    version_cursor->curversion_stop_saved_txnid = upd->upd_saved_txnid;
-                } else {
-                    version_cursor->curversion_durable_stop_ts = upd->upd_durable_ts;
-                    version_cursor->curversion_stop_ts = upd->upd_start_ts;
-                }
-                version_cursor->upd_stop_prepare_ts = upd->prepare_ts;
-                version_cursor->upd_stop_prepared_id = upd->prepared_id;
-                version_cursor->upd_stop_prepared = version_prepared;
+                __curversion_record_stop_time_point(version_cursor, upd, version_prepared);
 
                 upd_found = true;
 

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -244,11 +244,14 @@ __curversion_value_return_from_upd(
     wt_timestamp_t stop_ts = __curversion_stop_uses_prepare_ts(version_cursor) ?
       version_cursor->upd_stop_prepare_ts :
       version_cursor->curversion_stop_ts;
+    uint64_t stop_txnid = version_cursor->upd_stop_txnid;
+    wt_timestamp_t stop_durable_ts = version_cursor->curversion_durable_stop_ts;
+    wt_timestamp_t stop_prepare_ts = version_cursor->upd_stop_prepare_ts;
+    uint64_t stop_prepared_id = version_cursor->upd_stop_prepared_id;
 
     return (__curversion_set_value_with_format(cursor, WT_CURVERSION_METADATA_FORMAT, upd->txnid,
-      start_meta, durable_meta, upd->prepare_ts, upd->prepared_id, version_cursor->upd_stop_txnid,
-      stop_ts, version_cursor->curversion_durable_stop_ts, version_cursor->upd_stop_prepare_ts,
-      version_cursor->upd_stop_prepared_id, upd->type, version_prepared, upd->flags,
+      start_meta, durable_meta, upd->prepare_ts, upd->prepared_id, stop_txnid, stop_ts,
+      stop_durable_ts, stop_prepare_ts, stop_prepared_id, upd->type, version_prepared, upd->flags,
       WT_CURVERSION_UPDATE_CHAIN));
 }
 
@@ -453,6 +456,7 @@ typedef struct {
     wt_timestamp_t ts;
     wt_timestamp_t durable_ts;
     bool prepared;
+    bool version_prepared; /* true when the start side of this record is an in-progress prepare */
 } WT_CURVERSION_DISK_STOP_TIME_POINT;
 
 /*
@@ -462,13 +466,12 @@ typedef struct {
  */
 static void
 __curversion_disk_finalize_prepared(WT_CURSOR_VERSION *version_cursor, WT_TIME_WINDOW *tw,
-  WT_UPDATE *tombstone, WT_CURVERSION_DISK_STOP_TIME_POINT *stopp, bool *version_preparedp,
-  bool *skipp, bool *donep)
+  WT_UPDATE *tombstone, WT_CURVERSION_DISK_STOP_TIME_POINT *stopp, bool *skipp, bool *donep)
 {
     if (tombstone != NULL) {
         uint8_t prepare_state;
         WT_ACQUIRE_READ_WITH_BARRIER(prepare_state, tombstone->prepare_state);
-        *version_preparedp =
+        stopp->version_prepared =
           prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED;
     } else {
         if (version_cursor->start_timestamp != WT_TS_NONE) {
@@ -495,10 +498,10 @@ __curversion_disk_finalize_prepared(WT_CURSOR_VERSION *version_cursor, WT_TIME_W
                     stopp->ts = WT_TS_MAX;
                     stopp->durable_ts = WT_TS_NONE;
                     stopp->prepared = false;
-                    *version_preparedp = false;
+                    stopp->version_prepared = false;
                 }
             } else
-                *version_preparedp = WT_TIME_WINDOW_HAS_PREPARE(tw);
+                stopp->version_prepared = WT_TIME_WINDOW_HAS_PREPARE(tw);
         }
     }
 }
@@ -508,8 +511,8 @@ __curversion_disk_finalize_prepared(WT_CURSOR_VERSION *version_cursor, WT_TIME_W
  *     Pack the metadata for the on-disk value and record it as the previously-returned stop state.
  */
 static int
-__curversion_value_return_from_disk_image(WT_CURSOR *cursor, WT_TIME_WINDOW *tw,
-  const WT_CURVERSION_DISK_STOP_TIME_POINT *stopp, bool version_prepared)
+__curversion_value_return_from_disk_image(
+  WT_CURSOR *cursor, WT_TIME_WINDOW *tw, const WT_CURVERSION_DISK_STOP_TIME_POINT *stopp)
 {
     WT_CURSOR_VERSION *version_cursor = (WT_CURSOR_VERSION *)cursor;
     bool has_start_prepare = WT_TIME_WINDOW_HAS_START_PREPARE(tw);
@@ -520,7 +523,8 @@ __curversion_value_return_from_disk_image(WT_CURSOR *cursor, WT_TIME_WINDOW *tw,
     WT_RET(__curversion_set_value_with_format(cursor, WT_CURVERSION_METADATA_FORMAT, tw->start_txn,
       start_meta, durable_start_meta, tw->start_prepare_ts, tw->start_prepared_id, stopp->txn,
       stopp->prepared ? stopp->prepare_ts : stopp->ts, stopp->durable_ts, stopp->prepare_ts,
-      stopp->prepared_id, WT_UPDATE_STANDARD, version_prepared, 0, WT_CURVERSION_DISK_IMAGE));
+      stopp->prepared_id, WT_UPDATE_STANDARD, stopp->version_prepared, 0,
+      WT_CURVERSION_DISK_IMAGE));
 
     version_cursor->upd_stop_txnid = tw->start_txn;
     version_cursor->curversion_durable_stop_ts = durable_start_meta;
@@ -564,7 +568,7 @@ __curversion_process_on_disk(
     WT_CURSOR_VERSION *version_cursor = (WT_CURSOR_VERSION *)cursor;
     WT_CURSOR_BTREE *cbt = (WT_CURSOR_BTREE *)version_cursor->file_cursor;
     WT_TIME_WINDOW *tw = &cbt->upd_value->tw;
-    bool version_prepared = false;
+    stop.version_prepared = false;
 
     if (*upd_foundp || F_ISSET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED))
         return (0);
@@ -638,15 +642,14 @@ __curversion_process_on_disk(
         return (0);
     }
 
-    __curversion_disk_finalize_prepared(
-      version_cursor, tw, tombstone, &stop, &version_prepared, &skip, donep);
+    __curversion_disk_finalize_prepared(version_cursor, tw, tombstone, &stop, &skip, donep);
     if (*donep || skip) {
         if (skip)
             F_SET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED);
         return (0);
     }
 
-    WT_RET(__curversion_value_return_from_disk_image(cursor, tw, &stop, version_prepared));
+    WT_RET(__curversion_value_return_from_disk_image(cursor, tw, &stop));
 
     *upd_foundp = true;
     F_SET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED);

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -186,9 +186,6 @@ static WT_INLINE WT_UPDATE *
 __curversion_tombstone_next_upd(
   WT_SESSION_IMPL *session, WT_CURSOR_VERSION *version_cursor, WT_UPDATE *tombstone)
 {
-    WT_UPDATE *upd;
-    bool show_prepared_rollback;
-
     /*
      * show_prepared_rollback currently targets ingest-table style rollback updates (in-memory
      * trees), where rollback metadata lives on aborted prepared value updates and no globally
@@ -199,8 +196,8 @@ __curversion_tombstone_next_upd(
     if (__wt_txn_upd_visible_all(session, tombstone))
         return (NULL);
 
-    show_prepared_rollback = F_ISSET(version_cursor, WT_CURVERSION_SHOW_PREPARED_ROLLBACK);
-    upd = tombstone->next;
+    bool show_prepared_rollback = F_ISSET(version_cursor, WT_CURVERSION_SHOW_PREPARED_ROLLBACK);
+    WT_UPDATE *upd = tombstone->next;
 
     while (upd != NULL && upd->txnid == WT_TXN_ABORTED &&
       (!show_prepared_rollback || !__curversion_is_prepare_rollback_update(upd)))
@@ -238,13 +235,10 @@ static int
 __curversion_value_return_from_upd(
   WT_CURSOR *cursor, WT_CURSOR_VERSION *version_cursor, WT_UPDATE *upd, bool version_prepared)
 {
-    uint64_t durable_meta, start_meta;
-    bool aborted;
-
     /* Aborted updates encode rollback metadata in the start slots. */
-    aborted = (upd->txnid == WT_TXN_ABORTED);
-    start_meta = aborted ? upd->upd_saved_txnid : (uint64_t)upd->upd_start_ts;
-    durable_meta = aborted ? (uint64_t)upd->upd_rollback_ts : (uint64_t)upd->upd_durable_ts;
+    bool aborted = (upd->txnid == WT_TXN_ABORTED);
+    uint64_t start_meta = aborted ? upd->upd_saved_txnid : (uint64_t)upd->upd_start_ts;
+    uint64_t durable_meta = aborted ? (uint64_t)upd->upd_rollback_ts : (uint64_t)upd->upd_durable_ts;
 
     return (__curversion_set_value_with_format(cursor, WT_CURVERSION_METADATA_FORMAT, upd->txnid,
       start_meta, durable_meta, upd->prepare_ts, upd->prepared_id, version_cursor->upd_stop_txnid,
@@ -264,9 +258,8 @@ static WT_UPDATE *
 __curversion_walk_to_next_update(
   WT_SESSION_IMPL *session, WT_CURSOR_VERSION *version_cursor, WT_UPDATE *upd)
 {
-    WT_UPDATE *first_globally_visible, *next_upd;
-
-    first_globally_visible = NULL;
+    WT_UPDATE *first_globally_visible = NULL;
+    WT_UPDATE *next_upd;
 
     for (next_upd = upd; next_upd != NULL; next_upd = next_upd->next) {
         /* Skip aborted updates unless showing prepared rollbacks. */
@@ -309,22 +302,17 @@ __curversion_walk_to_next_update(
 static int
 __curversion_process_chain(WT_CURSOR *cursor, WT_UPDATE **tombstonep, bool *upd_foundp, bool *donep)
 {
-    WT_CURSOR_BTREE *cbt;
-    WT_CURSOR_VERSION *version_cursor;
-    WT_SESSION_IMPL *session;
-    WT_UPDATE *next_upd, *tombstone, *upd;
+    WT_SESSION_IMPL *session = CUR2S(cursor);
+    WT_CURSOR_VERSION *version_cursor = (WT_CURSOR_VERSION *)cursor;
+    WT_CURSOR_BTREE *cbt = (WT_CURSOR_BTREE *)version_cursor->file_cursor;
+    WT_UPDATE *tombstone = NULL;
     uint8_t prepare_state;
     bool version_prepared;
-
-    session = CUR2S(cursor);
-    version_cursor = (WT_CURSOR_VERSION *)cursor;
-    cbt = (WT_CURSOR_BTREE *)version_cursor->file_cursor;
-    tombstone = NULL;
 
     if (F_ISSET(version_cursor, WT_CURVERSION_UPDATE_EXHAUSTED))
         return (0);
 
-    upd = version_cursor->next_upd;
+    WT_UPDATE *upd = version_cursor->next_upd;
     if (upd == NULL) {
         version_cursor->next_upd = NULL;
         F_SET(version_cursor, WT_CURVERSION_UPDATE_EXHAUSTED);
@@ -381,7 +369,7 @@ __curversion_process_chain(WT_CURSOR *cursor, WT_UPDATE **tombstonep, bool *upd_
 
     *upd_foundp = true;
 
-    next_upd = __curversion_walk_to_next_update(session, version_cursor, upd);
+    WT_UPDATE *next_upd = __curversion_walk_to_next_update(session, version_cursor, upd);
     version_cursor->next_upd = next_upd;
     if (next_upd == NULL)
         F_SET(version_cursor, WT_CURVERSION_UPDATE_EXHAUSTED);
@@ -483,9 +471,8 @@ __curversion_disk_finalize_prepared(WT_CURSOR_VERSION *version_cursor, WT_TIME_W
   WT_UPDATE *tombstone, WT_CURVERSION_DISK_STOP *stopp, bool *version_preparedp, bool *skipp,
   bool *donep)
 {
-    uint8_t prepare_state;
-
     if (tombstone != NULL) {
+        uint8_t prepare_state;
         WT_ACQUIRE_READ_WITH_BARRIER(prepare_state, tombstone->prepare_state);
         *version_preparedp =
           prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED;
@@ -533,14 +520,10 @@ __curversion_value_return_from_disk_image(WT_CURSOR *cursor, WT_TIME_WINDOW *tw,
   bool stop_prepared, wt_timestamp_t stop_prepare_ts, wt_timestamp_t stop_ts,
   wt_timestamp_t durable_stop_ts, uint64_t stop_prepared_id, bool version_prepared)
 {
-    WT_CURSOR_VERSION *version_cursor;
-    wt_timestamp_t durable_start_meta, start_meta;
-    bool has_start_prepare;
-
-    version_cursor = (WT_CURSOR_VERSION *)cursor;
-    has_start_prepare = WT_TIME_WINDOW_HAS_START_PREPARE(tw);
-    start_meta = has_start_prepare ? tw->start_prepare_ts : tw->start_ts;
-    durable_start_meta = has_start_prepare ? tw->start_prepare_ts : tw->durable_start_ts;
+    WT_CURSOR_VERSION *version_cursor = (WT_CURSOR_VERSION *)cursor;
+    bool has_start_prepare = WT_TIME_WINDOW_HAS_START_PREPARE(tw);
+    wt_timestamp_t start_meta = has_start_prepare ? tw->start_prepare_ts : tw->start_ts;
+    wt_timestamp_t durable_start_meta = has_start_prepare ? tw->start_prepare_ts : tw->durable_start_ts;
 
     WT_RET(__curversion_set_value_with_format(cursor, WT_CURVERSION_METADATA_FORMAT, tw->start_txn,
       start_meta, durable_start_meta, tw->start_prepare_ts, tw->start_prepared_id, stop_txn,
@@ -582,19 +565,14 @@ static int
 __curversion_process_on_disk(
   WT_CURSOR *cursor, WT_UPDATE *tombstone, WT_PAGE *page, bool *upd_foundp, bool *donep)
 {
-    WT_CURVERSION_DISK_STOP stop;
-    WT_CURSOR_BTREE *cbt;
-    WT_CURSOR_VERSION *version_cursor;
     WT_DECL_RET;
-    WT_SESSION_IMPL *session;
-    WT_TIME_WINDOW *tw;
-    bool skip, version_prepared;
+    WT_CURVERSION_DISK_STOP stop;
 
-    session = CUR2S(cursor);
-    version_cursor = (WT_CURSOR_VERSION *)cursor;
-    cbt = (WT_CURSOR_BTREE *)version_cursor->file_cursor;
-    tw = &cbt->upd_value->tw;
-    version_prepared = false;
+    WT_SESSION_IMPL *session = CUR2S(cursor);
+    WT_CURSOR_VERSION *version_cursor = (WT_CURSOR_VERSION *)cursor;
+    WT_CURSOR_BTREE *cbt = (WT_CURSOR_BTREE *)version_cursor->file_cursor;
+    WT_TIME_WINDOW *tw = &cbt->upd_value->tw;
+    bool version_prepared = false;
 
     if (*upd_foundp || F_ISSET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED))
         return (0);
@@ -637,6 +615,7 @@ __curversion_process_on_disk(
     }
     WT_RET(ret);
 
+    bool skip = false;
     if (!WT_TIME_WINDOW_HAS_STOP(tw)) {
         if (__curversion_disk_skip_no_stop(version_cursor, tw)) {
             F_SET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED);
@@ -649,7 +628,6 @@ __curversion_process_on_disk(
         stop.txn = version_cursor->upd_stop_txnid;
         stop.prepared = __curversion_stop_uses_prepare_ts(version_cursor);
     } else {
-        skip = false;
         __curversion_disk_check_with_stop(session, version_cursor, tw, &skip, donep);
         if (*donep)
             return (0);
@@ -665,7 +643,6 @@ __curversion_process_on_disk(
         stop.prepared = WT_TIME_WINDOW_HAS_STOP_PREPARE(tw);
     }
 
-    skip = false;
     __curversion_disk_finalize_prepared(
       version_cursor, tw, tombstone, &stop, &version_prepared, &skip, donep);
     if (*donep)
@@ -691,14 +668,10 @@ __curversion_process_on_disk(
 static int
 __curversion_value_return_from_hs(WT_CURSOR *cursor, WT_TIME_WINDOW *twp, uint64_t hs_upd_type)
 {
-    WT_CURSOR_VERSION *version_cursor;
-    wt_timestamp_t durable_start_meta, start_meta;
-    bool has_start_prepare;
-
-    version_cursor = (WT_CURSOR_VERSION *)cursor;
-    has_start_prepare = WT_TIME_WINDOW_HAS_START_PREPARE(twp);
-    start_meta = has_start_prepare ? twp->start_prepare_ts : twp->start_ts;
-    durable_start_meta = has_start_prepare ? twp->start_prepare_ts : twp->durable_start_ts;
+    WT_CURSOR_VERSION *version_cursor = (WT_CURSOR_VERSION *)cursor;
+    bool has_start_prepare = WT_TIME_WINDOW_HAS_START_PREPARE(twp);
+    wt_timestamp_t start_meta = has_start_prepare ? twp->start_prepare_ts : twp->start_ts;
+    wt_timestamp_t durable_start_meta = has_start_prepare ? twp->start_prepare_ts : twp->durable_start_ts;
 
     WT_RET(__curversion_set_value_with_format(cursor, WT_CURVERSION_METADATA_FORMAT, twp->start_txn,
       start_meta, durable_start_meta, twp->start_prepare_ts, twp->start_prepared_id, twp->stop_txn,
@@ -727,22 +700,13 @@ static int
 __curversion_process_hs(WT_CURSOR *cursor, WT_PAGE *page, WT_ITEM **keyp, WT_ITEM **hs_valuep,
   bool *upd_foundp, bool *donep)
 {
-    WT_CURSOR *file_cursor, *hs_cursor;
-    WT_CURSOR_BTREE *cbt;
-    WT_CURSOR_VERSION *version_cursor;
-    WT_SESSION_IMPL *session;
-    WT_TIME_WINDOW *twp;
-    wt_timestamp_t durable_start_ts, durable_stop_ts;
-    size_t max_memsize;
+    WT_SESSION_IMPL *session = CUR2S(cursor);
+    WT_CURSOR_VERSION *version_cursor = (WT_CURSOR_VERSION *)cursor;
+    WT_CURSOR *file_cursor = version_cursor->file_cursor;
+    WT_CURSOR *hs_cursor = version_cursor->hs_cursor;
+    WT_CURSOR_BTREE *cbt = (WT_CURSOR_BTREE *)file_cursor;
+    WT_TIME_WINDOW *twp = NULL;
     uint64_t hs_upd_type;
-    uint8_t *p;
-
-    session = CUR2S(cursor);
-    version_cursor = (WT_CURSOR_VERSION *)cursor;
-    file_cursor = version_cursor->file_cursor;
-    hs_cursor = version_cursor->hs_cursor;
-    cbt = (WT_CURSOR_BTREE *)file_cursor;
-    twp = NULL;
 
     if (*upd_foundp || hs_cursor == NULL || F_ISSET(version_cursor, WT_CURVERSION_HS_EXHAUSTED))
         return (0);
@@ -764,7 +728,7 @@ __curversion_process_hs(WT_CURSOR *cursor, WT_PAGE *page, WT_ITEM **keyp, WT_ITE
             /* Ensure enough room for a column-store key without checking. */
             WT_RET(__wt_scr_alloc(session, WT_INTPACK64_MAXSIZE, keyp));
 
-            p = (*keyp)->mem;
+            uint8_t *p = (*keyp)->mem;
             WT_RET(__wt_vpack_uint(&p, 0, cbt->recno));
             (*keyp)->size = WT_PTRDIFF(p, (*keyp)->data);
             hs_cursor->set_key(hs_cursor, 4, S2BT(session)->id, *keyp, WT_TS_MAX, UINT64_MAX);
@@ -776,6 +740,7 @@ __curversion_process_hs(WT_CURSOR *cursor, WT_PAGE *page, WT_ITEM **keyp, WT_ITE
     WT_RET(__wt_scr_alloc(session, 0, hs_valuep));
 
     for (;;) {
+        wt_timestamp_t durable_start_ts, durable_stop_ts;
         __wt_hs_upd_time_window(hs_cursor, &twp);
         WT_RET(hs_cursor->get_value(
           hs_cursor, &durable_stop_ts, &durable_start_ts, &hs_upd_type, *hs_valuep));
@@ -785,6 +750,7 @@ __curversion_process_hs(WT_CURSOR *cursor, WT_PAGE *page, WT_ITEM **keyp, WT_ITE
          * across iterations, modifies can be applied on top of it.
          */
         if (hs_upd_type == WT_UPDATE_MODIFY) {
+            size_t max_memsize;
             __wt_modify_max_memsize_format((*hs_valuep)->data, file_cursor->value_format,
               cbt->upd_value->buf.size, &max_memsize);
             WT_RET(__wt_buf_set_and_grow(session, &cbt->upd_value->buf, cbt->upd_value->buf.data,

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -661,6 +661,37 @@ __curversion_value_return_from_disk_image(WT_CURSOR *cursor, WT_TIME_WINDOW *tw,
 }
 
 /*
+ * __curversion_value_return_from_hs --
+ *     Pack the metadata for the history-store value and record it as the previously-returned stop
+ *     state.
+ */
+static int
+__curversion_value_return_from_hs(WT_CURSOR *cursor, WT_TIME_WINDOW *twp, uint64_t hs_upd_type)
+{
+    WT_CURSOR_VERSION *version_cursor;
+    wt_timestamp_t durable_start_meta, start_meta;
+    bool has_start_prepare;
+
+    version_cursor = (WT_CURSOR_VERSION *)cursor;
+    has_start_prepare = WT_TIME_WINDOW_HAS_START_PREPARE(twp);
+    start_meta = has_start_prepare ? twp->start_prepare_ts : twp->start_ts;
+    durable_start_meta = has_start_prepare ? twp->start_prepare_ts : twp->durable_start_ts;
+
+    WT_RET(__curversion_set_value_with_format(cursor, WT_CURVERSION_METADATA_FORMAT, twp->start_txn,
+      start_meta, durable_start_meta, twp->start_prepare_ts, twp->start_prepared_id, twp->stop_txn,
+      WT_TIME_WINDOW_HAS_STOP_PREPARE(twp) ? twp->stop_prepare_ts : twp->stop_ts,
+      WT_TIME_WINDOW_HAS_STOP_PREPARE(twp) ? twp->stop_prepare_ts : twp->durable_stop_ts,
+      twp->stop_prepare_ts, twp->stop_prepared_id, hs_upd_type, 0, 0, WT_CURVERSION_HISTORY_STORE));
+
+    version_cursor->upd_stop_txnid = twp->start_txn;
+    version_cursor->curversion_durable_stop_ts = durable_start_meta;
+    version_cursor->curversion_stop_ts = start_meta;
+    version_cursor->upd_stop_prepare_ts = twp->start_prepare_ts;
+    version_cursor->upd_stop_prepared_id = twp->start_prepared_id;
+    return (0);
+}
+
+/*
  * __curversion_next_single_key --
  *     Iterate the updates of a single key.
  */
@@ -803,24 +834,7 @@ __curversion_next_single_key(WT_CURSOR *cursor)
                 goto done;
         }
 
-        WT_ERR(
-          __curversion_set_value_with_format(cursor, WT_CURVERSION_METADATA_FORMAT, twp->start_txn,
-            WT_TIME_WINDOW_HAS_START_PREPARE(twp) ? twp->start_prepare_ts : twp->start_ts,
-            WT_TIME_WINDOW_HAS_START_PREPARE(twp) ? twp->start_prepare_ts : twp->durable_start_ts,
-            twp->start_prepare_ts, twp->start_prepared_id, twp->stop_txn,
-            WT_TIME_WINDOW_HAS_STOP_PREPARE(twp) ? twp->stop_prepare_ts : twp->stop_ts,
-            WT_TIME_WINDOW_HAS_STOP_PREPARE(twp) ? twp->stop_prepare_ts : twp->durable_stop_ts,
-            twp->stop_prepare_ts, twp->stop_prepared_id, hs_upd_type, 0, 0,
-            WT_CURVERSION_HISTORY_STORE));
-
-        version_cursor->upd_stop_txnid = twp->start_txn;
-        version_cursor->curversion_durable_stop_ts =
-          WT_TIME_WINDOW_HAS_START_PREPARE(twp) ? twp->start_prepare_ts : twp->durable_start_ts;
-        version_cursor->curversion_stop_ts =
-          WT_TIME_WINDOW_HAS_START_PREPARE(twp) ? twp->start_prepare_ts : twp->start_ts;
-        version_cursor->upd_stop_prepare_ts = twp->start_prepare_ts;
-        version_cursor->upd_stop_prepared_id = twp->start_prepared_id;
-
+        WT_ERR(__curversion_value_return_from_hs(cursor, twp, hs_upd_type));
         upd_found = true;
     }
 

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -570,8 +570,16 @@ __curversion_process_on_disk(
     WT_TIME_WINDOW *tw = &cbt->upd_value->tw;
     stop.version_prepared = false;
 
+    bool skip = false;
+
     if (*upd_foundp || F_ISSET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED))
         return (0);
+
+    /* No older versions are needed once the previously-returned stop is globally visible. */
+    if (__curversion_stop_globally_visible(session, version_cursor)) {
+        *donep = true;
+        return (0);
+    }
 
     /* Validate the page has an accessible on-disk slot before doing further work. */
     switch (page->type) {
@@ -594,12 +602,6 @@ __curversion_process_on_disk(
         return (__wt_illegal_value(session, page->type));
     }
 
-    /* No older versions are needed once the previously-returned stop is globally visible. */
-    if (__curversion_stop_globally_visible(session, version_cursor)) {
-        *donep = true;
-        return (0);
-    }
-
     /*
      * Get the ondisk value. It is possible to see an overflow-removed value if a concurrent
      * checkpoint freed the underlying overflow blocks. In that case the value either already came
@@ -612,7 +614,6 @@ __curversion_process_on_disk(
     }
     WT_RET(ret);
 
-    bool skip = false;
     if (!WT_TIME_WINDOW_HAS_STOP(tw)) {
         if (__curversion_disk_skip_no_stop(version_cursor, tw)) {
             F_SET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED);
@@ -636,13 +637,12 @@ __curversion_process_on_disk(
         }
     }
 
-    if (*donep || skip) {
-        if (skip)
-            F_SET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED);
-        return (0);
-    }
-
-    __curversion_disk_finalize_prepared(version_cursor, tw, tombstone, &stop, &skip, donep);
+    /*
+     * Only resolve prepare state when nothing has already marked the record done or skipped; then
+     * perform a single combined done/skip check before emitting the value.
+     */
+    if (!*donep && !skip)
+        __curversion_disk_finalize_prepared(version_cursor, tw, tombstone, &stop, &skip, donep);
     if (*donep || skip) {
         if (skip)
             F_SET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED);

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -178,7 +178,7 @@ __curversion_set_value_with_format(WT_CURSOR *cursor, const char *fmt, ...)
 
 /*
  * __curversion_tombstone_next_upd --
- *     After recording stop metadata from a tombstone, advance past it to find the value to emit.
+ *     After recording stop metadata from a tombstone, advance past it to find the value to return.
  *     Handles both the normal case (skip all aborted updates) and show_prepared_rollback mode
  *     (include rolled-back prepared value updates).
  */

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -449,7 +449,7 @@ __curversion_disk_check_with_stop(WT_SESSION_IMPL *session, WT_CURSOR_VERSION *v
 }
 
 /*
- * Stop-side metadata collected for an on-disk record. Bundled so helpers that need to inspect and
+ * Stop time point collected for an on-disk record. Bundled so helpers that need to inspect and
  * potentially mutate all six fields can take a single pointer instead of six separate out-params.
  */
 typedef struct {
@@ -459,7 +459,7 @@ typedef struct {
     wt_timestamp_t ts;
     wt_timestamp_t durable_ts;
     bool prepared;
-} WT_CURVERSION_DISK_STOP;
+} WT_CURVERSION_DISK_STOP_TIME_POINT;
 
 /*
  * __curversion_disk_finalize_prepared --
@@ -468,7 +468,7 @@ typedef struct {
  */
 static void
 __curversion_disk_finalize_prepared(WT_CURSOR_VERSION *version_cursor, WT_TIME_WINDOW *tw,
-  WT_UPDATE *tombstone, WT_CURVERSION_DISK_STOP *stopp, bool *version_preparedp, bool *skipp,
+  WT_UPDATE *tombstone, WT_CURVERSION_DISK_STOP_TIME_POINT *stopp, bool *version_preparedp, bool *skipp,
   bool *donep)
 {
     if (tombstone != NULL) {
@@ -537,7 +537,7 @@ __curversion_value_return_from_disk_image(WT_CURSOR *cursor, WT_TIME_WINDOW *tw,
     version_cursor->upd_stop_prepared_id = tw->start_prepared_id;
     /*
      * upd_stop_prepared is intentionally not updated here. Disk records are stable so their
-     * start side is never an in-progress prepare; any prepared stop inherited from the update
+     * start time point is never an in-progress prepare; any prepared stop inherited from the update
      * chain still gates the globally-visible check for subsequent history-store iterations.
      */
     return (0);
@@ -566,7 +566,7 @@ __curversion_process_on_disk(
   WT_CURSOR *cursor, WT_UPDATE *tombstone, WT_PAGE *page, bool *upd_foundp, bool *donep)
 {
     WT_DECL_RET;
-    WT_CURVERSION_DISK_STOP stop;
+    WT_CURVERSION_DISK_STOP_TIME_POINT stop;
 
     WT_SESSION_IMPL *session = CUR2S(cursor);
     WT_CURSOR_VERSION *version_cursor = (WT_CURSOR_VERSION *)cursor;
@@ -686,8 +686,8 @@ __curversion_value_return_from_hs(WT_CURSOR *cursor, WT_TIME_WINDOW *twp, uint64
     version_cursor->upd_stop_prepared_id = twp->start_prepared_id;
     /*
      * upd_stop_prepared is intentionally not updated here — history-store records are fully
-     * committed so their start side is never an in-progress prepare; any prepared stop inherited
-     * from the update chain still gates the globally-visible check for the next iteration.
+     * committed so their start time point is never an in-progress prepare; any prepared stop
+     * inherited from the update chain still gates the globally-visible check for the next iteration.
      */
     return (0);
 }

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -238,7 +238,8 @@ __curversion_value_return_from_upd(
     /* Aborted updates encode rollback metadata in the start slots. */
     bool aborted = (upd->txnid == WT_TXN_ABORTED);
     uint64_t start_meta = aborted ? upd->upd_saved_txnid : (uint64_t)upd->upd_start_ts;
-    uint64_t durable_meta = aborted ? (uint64_t)upd->upd_rollback_ts : (uint64_t)upd->upd_durable_ts;
+    uint64_t durable_meta =
+      aborted ? (uint64_t)upd->upd_rollback_ts : (uint64_t)upd->upd_durable_ts;
 
     return (__curversion_set_value_with_format(cursor, WT_CURVERSION_METADATA_FORMAT, upd->txnid,
       start_meta, durable_meta, upd->prepare_ts, upd->prepared_id, version_cursor->upd_stop_txnid,
@@ -468,8 +469,8 @@ typedef struct {
  */
 static void
 __curversion_disk_finalize_prepared(WT_CURSOR_VERSION *version_cursor, WT_TIME_WINDOW *tw,
-  WT_UPDATE *tombstone, WT_CURVERSION_DISK_STOP_TIME_POINT *stopp, bool *version_preparedp, bool *skipp,
-  bool *donep)
+  WT_UPDATE *tombstone, WT_CURVERSION_DISK_STOP_TIME_POINT *stopp, bool *version_preparedp,
+  bool *skipp, bool *donep)
 {
     if (tombstone != NULL) {
         uint8_t prepare_state;
@@ -523,7 +524,8 @@ __curversion_value_return_from_disk_image(WT_CURSOR *cursor, WT_TIME_WINDOW *tw,
     WT_CURSOR_VERSION *version_cursor = (WT_CURSOR_VERSION *)cursor;
     bool has_start_prepare = WT_TIME_WINDOW_HAS_START_PREPARE(tw);
     wt_timestamp_t start_meta = has_start_prepare ? tw->start_prepare_ts : tw->start_ts;
-    wt_timestamp_t durable_start_meta = has_start_prepare ? tw->start_prepare_ts : tw->durable_start_ts;
+    wt_timestamp_t durable_start_meta =
+      has_start_prepare ? tw->start_prepare_ts : tw->durable_start_ts;
 
     WT_RET(__curversion_set_value_with_format(cursor, WT_CURVERSION_METADATA_FORMAT, tw->start_txn,
       start_meta, durable_start_meta, tw->start_prepare_ts, tw->start_prepared_id, stop_txn,
@@ -536,9 +538,9 @@ __curversion_value_return_from_disk_image(WT_CURSOR *cursor, WT_TIME_WINDOW *tw,
     version_cursor->upd_stop_prepare_ts = tw->start_prepare_ts;
     version_cursor->upd_stop_prepared_id = tw->start_prepared_id;
     /*
-     * upd_stop_prepared is intentionally not updated here. Disk records are stable so their
-     * start time point is never an in-progress prepare; any prepared stop inherited from the update
-     * chain still gates the globally-visible check for subsequent history-store iterations.
+     * upd_stop_prepared is intentionally not updated here. Disk records are stable so their start
+     * time point is never an in-progress prepare; any prepared stop inherited from the update chain
+     * still gates the globally-visible check for subsequent history-store iterations.
      */
     return (0);
 }
@@ -565,8 +567,8 @@ static int
 __curversion_process_on_disk(
   WT_CURSOR *cursor, WT_UPDATE *tombstone, WT_PAGE *page, bool *upd_foundp, bool *donep)
 {
-    WT_DECL_RET;
     WT_CURVERSION_DISK_STOP_TIME_POINT stop;
+    WT_DECL_RET;
 
     WT_SESSION_IMPL *session = CUR2S(cursor);
     WT_CURSOR_VERSION *version_cursor = (WT_CURSOR_VERSION *)cursor;
@@ -671,7 +673,8 @@ __curversion_value_return_from_hs(WT_CURSOR *cursor, WT_TIME_WINDOW *twp, uint64
     WT_CURSOR_VERSION *version_cursor = (WT_CURSOR_VERSION *)cursor;
     bool has_start_prepare = WT_TIME_WINDOW_HAS_START_PREPARE(twp);
     wt_timestamp_t start_meta = has_start_prepare ? twp->start_prepare_ts : twp->start_ts;
-    wt_timestamp_t durable_start_meta = has_start_prepare ? twp->start_prepare_ts : twp->durable_start_ts;
+    wt_timestamp_t durable_start_meta =
+      has_start_prepare ? twp->start_prepare_ts : twp->durable_start_ts;
 
     WT_RET(__curversion_set_value_with_format(cursor, WT_CURVERSION_METADATA_FORMAT, twp->start_txn,
       start_meta, durable_start_meta, twp->start_prepare_ts, twp->start_prepared_id, twp->stop_txn,
@@ -685,9 +688,9 @@ __curversion_value_return_from_hs(WT_CURSOR *cursor, WT_TIME_WINDOW *twp, uint64
     version_cursor->upd_stop_prepare_ts = twp->start_prepare_ts;
     version_cursor->upd_stop_prepared_id = twp->start_prepared_id;
     /*
-     * upd_stop_prepared is intentionally not updated here — history-store records are fully
-     * committed so their start time point is never an in-progress prepare; any prepared stop
-     * inherited from the update chain still gates the globally-visible check for the next iteration.
+     * upd_stop_prepared is intentionally not updated here history-store records are fully committed
+     * so their start time point is never an in-progress prepare; any prepared stop inherited from
+     * the update chain still gates the globally-visible check for the next iteration.
      */
     return (0);
 }

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -513,6 +513,123 @@ __curversion_disk_finalize_prepared(WT_CURSOR_VERSION *version_cursor, WT_TIME_W
 }
 
 /*
+ * __curversion_process_on_disk --
+ *     Return the on-disk value as the next version, if there is one and it should be returned.
+ */
+static int
+__curversion_process_on_disk(
+  WT_CURSOR *cursor, WT_UPDATE *tombstone, WT_PAGE *page, bool *upd_foundp, bool *donep)
+{
+    WT_CURSOR_BTREE *cbt;
+    WT_CURSOR_VERSION *version_cursor;
+    WT_DECL_RET;
+    WT_SESSION_IMPL *session;
+    WT_TIME_WINDOW *tw;
+    wt_timestamp_t durable_stop_ts, stop_prepare_ts, stop_ts;
+    uint64_t stop_prepared_id, stop_txn;
+    bool skip, stop_prepared, version_prepared;
+
+    session = CUR2S(cursor);
+    version_cursor = (WT_CURSOR_VERSION *)cursor;
+    cbt = (WT_CURSOR_BTREE *)version_cursor->file_cursor;
+    tw = &cbt->upd_value->tw;
+    version_prepared = false;
+
+    if (*upd_foundp || F_ISSET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED))
+        return (0);
+
+    /*
+     * Stop once we hit a globally visible record on the update chain; no need to return more
+     * updates. Aborted updates are never globally visible.
+     */
+    if (F_ISSET(version_cursor, WT_CURVERSION_TIMESTAMP_ORDER) &&
+      !version_cursor->upd_stop_prepared && version_cursor->upd_stop_txnid != WT_TXN_ABORTED &&
+      __wt_txn_visible_all(
+        session, version_cursor->upd_stop_txnid, version_cursor->curversion_durable_stop_ts)) {
+        *donep = true;
+        return (0);
+    }
+
+    switch (page->type) {
+    case WT_PAGE_ROW_LEAF:
+        if (cbt->ins != NULL) {
+            F_SET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED);
+            F_SET(version_cursor, WT_CURVERSION_HS_EXHAUSTED);
+            return (WT_NOTFOUND);
+        }
+        break;
+    case WT_PAGE_COL_VAR:
+        /* Empty page doesn't have any on page value. */
+        if (page->entries == 0) {
+            F_SET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED);
+            F_SET(version_cursor, WT_CURVERSION_HS_EXHAUSTED);
+            return (WT_NOTFOUND);
+        }
+        break;
+    default:
+        return (__wt_illegal_value(session, page->type));
+    }
+
+    /*
+     * Get the ondisk value. It is possible to see an overflow-removed value if a concurrent
+     * checkpoint freed the underlying overflow blocks. In that case the value either already came
+     * back via the update chain or will come from the history store, so it is safe to skip.
+     */
+    ret = __wt_value_return_buf(cbt, cbt->ref, &cbt->upd_value->buf, tw);
+    if (ret == WT_RESTART) {
+        F_SET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED);
+        return (0);
+    }
+    WT_RET(ret);
+
+    if (!WT_TIME_WINDOW_HAS_STOP(tw)) {
+        if (__curversion_disk_skip_no_stop(version_cursor, tw)) {
+            F_SET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED);
+            return (0);
+        }
+        durable_stop_ts = version_cursor->curversion_durable_stop_ts;
+        stop_prepare_ts = version_cursor->upd_stop_prepare_ts;
+        stop_prepared_id = version_cursor->upd_stop_prepared_id;
+        stop_ts = version_cursor->curversion_stop_ts;
+        stop_txn = version_cursor->upd_stop_txnid;
+        stop_prepared = __curversion_stop_uses_prepare_ts(version_cursor);
+    } else {
+        skip = false;
+        __curversion_disk_check_with_stop(session, version_cursor, tw, &skip, donep);
+        if (*donep)
+            return (0);
+        if (skip) {
+            F_SET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED);
+            return (0);
+        }
+        durable_stop_ts = tw->durable_stop_ts;
+        stop_prepare_ts = tw->stop_prepare_ts;
+        stop_prepared_id = tw->stop_prepared_id;
+        stop_ts = tw->stop_ts;
+        stop_txn = tw->stop_txn;
+        stop_prepared = WT_TIME_WINDOW_HAS_STOP_PREPARE(tw);
+    }
+
+    skip = false;
+    __curversion_disk_finalize_prepared(version_cursor, tw, tombstone, &stop_txn, &stop_prepare_ts,
+      &stop_prepared_id, &stop_ts, &durable_stop_ts, &stop_prepared, &version_prepared, &skip,
+      donep);
+    if (*donep)
+        return (0);
+    if (skip) {
+        F_SET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED);
+        return (0);
+    }
+
+    WT_RET(__curversion_value_return_from_disk_image(cursor, tw, stop_txn, stop_prepared,
+      stop_prepare_ts, stop_ts, durable_stop_ts, stop_prepared_id, version_prepared));
+
+    *upd_foundp = true;
+    F_SET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED);
+    return (0);
+}
+
+/*
  * __curversion_value_return_from_disk_image --
  *     Pack the metadata for the on-disk value and record it as the previously-returned stop state.
  */
@@ -560,11 +677,11 @@ __curversion_next_single_key(WT_CURSOR *cursor)
     WT_SESSION_IMPL *session;
     WT_TIME_WINDOW *twp;
     WT_UPDATE *tombstone;
-    wt_timestamp_t durable_start_ts, durable_stop_ts, stop_prepare_ts, stop_ts;
+    wt_timestamp_t durable_start_ts, durable_stop_ts;
     size_t max_memsize;
-    uint64_t hs_upd_type, raw, stop_prepared_id, stop_txn;
-    uint8_t *p, prepare_state;
-    bool done, stop_prepared, upd_found, version_prepared;
+    uint64_t hs_upd_type, raw;
+    uint8_t *p;
+    bool done, upd_found;
 
     session = CUR2S(cursor);
     version_cursor = (WT_CURSOR_VERSION *)cursor;
@@ -589,105 +706,10 @@ __curversion_next_single_key(WT_CURSOR *cursor)
     page = cbt->ref->page;
 
     WT_ERR(__curversion_process_chain(cursor, &tombstone, &upd_found, &done));
-    if (done)
-        goto done;
+    if (!done)
+        WT_ERR(__curversion_process_on_disk(cursor, tombstone, page, &upd_found, &done));
 
-    if (!upd_found && !F_ISSET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED)) {
-        /*
-         * We have already seen an update that is globally visible on the update chain. No need to
-         * return more updates. Aborted updates are never globally visible.
-         */
-        if (F_ISSET(version_cursor, WT_CURVERSION_TIMESTAMP_ORDER) &&
-          !version_cursor->upd_stop_prepared && version_cursor->upd_stop_txnid != WT_TXN_ABORTED &&
-          __wt_txn_visible_all(
-            session, version_cursor->upd_stop_txnid, version_cursor->curversion_durable_stop_ts))
-            goto done;
-
-        switch (page->type) {
-        case WT_PAGE_ROW_LEAF:
-            if (cbt->ins != NULL) {
-                F_SET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED);
-                F_SET(version_cursor, WT_CURVERSION_HS_EXHAUSTED);
-                WT_ERR(WT_NOTFOUND);
-            }
-            break;
-        case WT_PAGE_COL_VAR:
-            /* Empty page doesn't have any on page value. */
-            if (page->entries == 0) {
-                F_SET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED);
-                F_SET(version_cursor, WT_CURVERSION_HS_EXHAUSTED);
-                WT_ERR(WT_NOTFOUND);
-            }
-            break;
-        default:
-            WT_ERR(__wt_illegal_value(session, page->type));
-        }
-
-        /*
-         * Get the ondisk value. It is possible to see an overflow removed value if checkpoint has
-         * visited this page and freed the underlying overflow blocks. In this case, checkpoint
-         * reconciliation must have also appended the value to the update chain and moved it to the
-         * history store if it is not obsolete. Therefore, we should have either already returned it
-         * when walking the update chain if we are not racing with checkpoint removing the overflow
-         * value concurrently or we shall return it later when we scan the history store if we do
-         * race with checkpoint. If it is already obsolete, there is no need for us to return it as
-         * the version cursor only ensures to return values that are not obsolete. We can safely
-         * ignore the overflow removed value here.
-         */
-        WT_ERR_ERROR_OK(
-          __wt_value_return_buf(cbt, cbt->ref, &cbt->upd_value->buf, &cbt->upd_value->tw),
-          WT_RESTART, true);
-        if (ret == 0) {
-            if (!WT_TIME_WINDOW_HAS_STOP(&cbt->upd_value->tw)) {
-                if (__curversion_disk_skip_no_stop(version_cursor, &cbt->upd_value->tw))
-                    goto skip_on_page;
-                durable_stop_ts = version_cursor->curversion_durable_stop_ts;
-                stop_prepare_ts = version_cursor->upd_stop_prepare_ts;
-                stop_prepared_id = version_cursor->upd_stop_prepared_id;
-                stop_ts = version_cursor->curversion_stop_ts;
-                stop_txn = version_cursor->upd_stop_txnid;
-                stop_prepared = __curversion_stop_uses_prepare_ts(version_cursor);
-            } else {
-                {
-                    bool disk_skip = false, disk_done = false;
-                    __curversion_disk_check_with_stop(session, version_cursor,
-                      &cbt->upd_value->tw, &disk_skip, &disk_done);
-                    if (disk_done)
-                        goto done;
-                    if (disk_skip)
-                        goto skip_on_page;
-                }
-                durable_stop_ts = cbt->upd_value->tw.durable_stop_ts;
-                stop_prepare_ts = cbt->upd_value->tw.stop_prepare_ts;
-                stop_prepared_id = cbt->upd_value->tw.stop_prepared_id;
-                stop_ts = cbt->upd_value->tw.stop_ts;
-                stop_txn = cbt->upd_value->tw.stop_txn;
-                stop_prepared = WT_TIME_WINDOW_HAS_STOP_PREPARE(&cbt->upd_value->tw);
-            }
-
-            {
-                bool fp_skip = false, fp_done = false;
-                __curversion_disk_finalize_prepared(version_cursor, &cbt->upd_value->tw,
-                  tombstone, &stop_txn, &stop_prepare_ts, &stop_prepared_id, &stop_ts,
-                  &durable_stop_ts, &stop_prepared, &version_prepared, &fp_skip, &fp_done);
-                if (fp_done)
-                    goto done;
-                if (fp_skip)
-                    goto skip_on_page;
-            }
-
-            WT_ERR(__curversion_value_return_from_disk_image(cursor, &cbt->upd_value->tw,
-              stop_txn, stop_prepared, stop_prepare_ts, stop_ts, durable_stop_ts, stop_prepared_id,
-              version_prepared));
-
-            upd_found = true;
-        } else
-            ret = 0;
-skip_on_page:
-        F_SET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED);
-    }
-
-    if (!upd_found && version_cursor->hs_cursor != NULL &&
+    if (!done && !upd_found && version_cursor->hs_cursor != NULL &&
       !F_ISSET(version_cursor, WT_CURVERSION_HS_EXHAUSTED)) {
         /*
          * We have already seen an update that is globally visible on the update chain. No need to

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -513,6 +513,37 @@ __curversion_disk_finalize_prepared(WT_CURSOR_VERSION *version_cursor, WT_TIME_W
 }
 
 /*
+ * __curversion_value_return_from_disk_image --
+ *     Pack the metadata for the on-disk value and record it as the previously-returned stop state.
+ */
+static int
+__curversion_value_return_from_disk_image(WT_CURSOR *cursor, WT_TIME_WINDOW *tw, uint64_t stop_txn,
+  bool stop_prepared, wt_timestamp_t stop_prepare_ts, wt_timestamp_t stop_ts,
+  wt_timestamp_t durable_stop_ts, uint64_t stop_prepared_id, bool version_prepared)
+{
+    WT_CURSOR_VERSION *version_cursor;
+    wt_timestamp_t durable_start_meta, start_meta;
+    bool has_start_prepare;
+
+    version_cursor = (WT_CURSOR_VERSION *)cursor;
+    has_start_prepare = WT_TIME_WINDOW_HAS_START_PREPARE(tw);
+    start_meta = has_start_prepare ? tw->start_prepare_ts : tw->start_ts;
+    durable_start_meta = has_start_prepare ? tw->start_prepare_ts : tw->durable_start_ts;
+
+    WT_RET(__curversion_set_value_with_format(cursor, WT_CURVERSION_METADATA_FORMAT, tw->start_txn,
+      start_meta, durable_start_meta, tw->start_prepare_ts, tw->start_prepared_id, stop_txn,
+      stop_prepared ? stop_prepare_ts : stop_ts, durable_stop_ts, stop_prepare_ts, stop_prepared_id,
+      WT_UPDATE_STANDARD, version_prepared, 0, WT_CURVERSION_DISK_IMAGE));
+
+    version_cursor->upd_stop_txnid = tw->start_txn;
+    version_cursor->curversion_durable_stop_ts = durable_start_meta;
+    version_cursor->curversion_stop_ts = start_meta;
+    version_cursor->upd_stop_prepare_ts = tw->start_prepare_ts;
+    version_cursor->upd_stop_prepared_id = tw->start_prepared_id;
+    return (0);
+}
+
+/*
  * __curversion_process_on_disk --
  *     Return the on-disk value as the next version, if there is one and it should be returned.
  */
@@ -630,37 +661,6 @@ __curversion_process_on_disk(
 }
 
 /*
- * __curversion_value_return_from_disk_image --
- *     Pack the metadata for the on-disk value and record it as the previously-returned stop state.
- */
-static int
-__curversion_value_return_from_disk_image(WT_CURSOR *cursor, WT_TIME_WINDOW *tw, uint64_t stop_txn,
-  bool stop_prepared, wt_timestamp_t stop_prepare_ts, wt_timestamp_t stop_ts,
-  wt_timestamp_t durable_stop_ts, uint64_t stop_prepared_id, bool version_prepared)
-{
-    WT_CURSOR_VERSION *version_cursor;
-    wt_timestamp_t durable_start_meta, start_meta;
-    bool has_start_prepare;
-
-    version_cursor = (WT_CURSOR_VERSION *)cursor;
-    has_start_prepare = WT_TIME_WINDOW_HAS_START_PREPARE(tw);
-    start_meta = has_start_prepare ? tw->start_prepare_ts : tw->start_ts;
-    durable_start_meta = has_start_prepare ? tw->start_prepare_ts : tw->durable_start_ts;
-
-    WT_RET(__curversion_set_value_with_format(cursor, WT_CURVERSION_METADATA_FORMAT, tw->start_txn,
-      start_meta, durable_start_meta, tw->start_prepare_ts, tw->start_prepared_id, stop_txn,
-      stop_prepared ? stop_prepare_ts : stop_ts, durable_stop_ts, stop_prepare_ts, stop_prepared_id,
-      WT_UPDATE_STANDARD, version_prepared, 0, WT_CURVERSION_DISK_IMAGE));
-
-    version_cursor->upd_stop_txnid = tw->start_txn;
-    version_cursor->curversion_durable_stop_ts = durable_start_meta;
-    version_cursor->curversion_stop_ts = start_meta;
-    version_cursor->upd_stop_prepare_ts = tw->start_prepare_ts;
-    version_cursor->upd_stop_prepared_id = tw->start_prepared_id;
-    return (0);
-}
-
-/*
  * __curversion_value_return_from_hs --
  *     Pack the metadata for the history-store value and record it as the previously-returned stop
  *     state.
@@ -692,27 +692,22 @@ __curversion_value_return_from_hs(WT_CURSOR *cursor, WT_TIME_WINDOW *twp, uint64
 }
 
 /*
- * __curversion_next_single_key --
- *     Iterate the updates of a single key.
+ * __curversion_process_hs --
+ *     Return the next version from the history store, if any.
  */
 static int
-__curversion_next_single_key(WT_CURSOR *cursor)
+__curversion_process_hs(WT_CURSOR *cursor, WT_PAGE *page, WT_ITEM **keyp, WT_ITEM **hs_valuep,
+  bool *upd_foundp, bool *donep)
 {
     WT_CURSOR *file_cursor, *hs_cursor;
     WT_CURSOR_BTREE *cbt;
     WT_CURSOR_VERSION *version_cursor;
-    WT_DECL_ITEM(hs_value);
-    WT_DECL_ITEM(key);
-    WT_DECL_RET;
-    WT_PAGE *page;
     WT_SESSION_IMPL *session;
     WT_TIME_WINDOW *twp;
-    WT_UPDATE *tombstone;
     wt_timestamp_t durable_start_ts, durable_stop_ts;
     size_t max_memsize;
-    uint64_t hs_upd_type, raw;
+    uint64_t hs_upd_type;
     uint8_t *p;
-    bool done, upd_found;
 
     session = CUR2S(cursor);
     version_cursor = (WT_CURSOR_VERSION *)cursor;
@@ -720,9 +715,127 @@ __curversion_next_single_key(WT_CURSOR *cursor)
     hs_cursor = version_cursor->hs_cursor;
     cbt = (WT_CURSOR_BTREE *)file_cursor;
     twp = NULL;
+
+    if (*upd_foundp || hs_cursor == NULL || F_ISSET(version_cursor, WT_CURVERSION_HS_EXHAUSTED))
+        return (0);
+
+    /*
+     * Stop once we hit a globally visible record on the update chain; no need to return more
+     * updates. Aborted updates are never globally visible.
+     */
+    if (F_ISSET(version_cursor, WT_CURVERSION_TIMESTAMP_ORDER) &&
+      !version_cursor->upd_stop_prepared && version_cursor->upd_stop_txnid != WT_TXN_ABORTED &&
+      __wt_txn_visible_all(
+        session, version_cursor->upd_stop_txnid, version_cursor->curversion_durable_stop_ts)) {
+        *donep = true;
+        return (0);
+    }
+
+    /* Ensure we can see all the content in the history store. */
+    F_SET(hs_cursor, WT_CURSTD_HS_READ_COMMITTED);
+
+    if (!F_ISSET(hs_cursor, WT_CURSTD_KEY_INT)) {
+        if (page->type == WT_PAGE_ROW_LEAF)
+            hs_cursor->set_key(
+              hs_cursor, 4, S2BT(session)->id, &file_cursor->key, WT_TS_MAX, UINT64_MAX);
+        else {
+            /* Ensure enough room for a column-store key without checking. */
+            WT_RET(__wt_scr_alloc(session, WT_INTPACK64_MAXSIZE, keyp));
+
+            p = (*keyp)->mem;
+            WT_RET(__wt_vpack_uint(&p, 0, cbt->recno));
+            (*keyp)->size = WT_PTRDIFF(p, (*keyp)->data);
+            hs_cursor->set_key(hs_cursor, 4, S2BT(session)->id, *keyp, WT_TS_MAX, UINT64_MAX);
+        }
+        WT_RET(__wt_curhs_search_near_before(session, hs_cursor));
+    } else
+        WT_RET(hs_cursor->prev(hs_cursor));
+
+    WT_RET(__wt_scr_alloc(session, 0, hs_valuep));
+
+    for (;;) {
+        __wt_hs_upd_time_window(hs_cursor, &twp);
+        WT_RET(hs_cursor->get_value(
+          hs_cursor, &durable_stop_ts, &durable_start_ts, &hs_upd_type, *hs_valuep));
+
+        /*
+         * Reconstruct the history store value if needed. Because the current value is preserved
+         * across iterations, modifies can be applied on top of it.
+         */
+        if (hs_upd_type == WT_UPDATE_MODIFY) {
+            __wt_modify_max_memsize_format((*hs_valuep)->data, file_cursor->value_format,
+              cbt->upd_value->buf.size, &max_memsize);
+            WT_RET(__wt_buf_set_and_grow(session, &cbt->upd_value->buf, cbt->upd_value->buf.data,
+              cbt->upd_value->buf.size, max_memsize));
+            WT_RET(__wt_modify_apply_item(
+              session, file_cursor->value_format, &cbt->upd_value->buf, (*hs_valuep)->data));
+        } else {
+            WT_ASSERT(session, hs_upd_type == WT_UPDATE_STANDARD);
+            cbt->upd_value->buf.data = (*hs_valuep)->data;
+            cbt->upd_value->buf.size = (*hs_valuep)->size;
+        }
+
+        if (!F_ISSET(version_cursor, WT_CURVERSION_TIMESTAMP_ORDER))
+            break;
+
+        /* Skip all non-aborted updates that are duplicate to the previous updates returned. */
+        if (version_cursor->upd_stop_txnid != WT_TXN_ABORTED &&
+          twp->stop_txn <= version_cursor->upd_stop_txnid &&
+          twp->stop_ts <= version_cursor->curversion_stop_ts &&
+          twp->durable_stop_ts <= version_cursor->curversion_durable_stop_ts)
+            break;
+
+        WT_RET(hs_cursor->prev(hs_cursor));
+    }
+
+    if (version_cursor->start_timestamp != WT_TS_NONE) {
+        /* Done if the durable stop timestamp is at or before the end timestamp. */
+        if (twp->stop_ts != WT_TS_MAX && twp->durable_stop_ts <= version_cursor->start_timestamp) {
+            *donep = true;
+            return (0);
+        }
+        /*
+         * FIXME-WT-16136: for the history store it is hard to tell whether a stop durable timestamp
+         * belongs to a tombstone or to the previous full value. For now, always return the value
+         * when its stop durable timestamp is past the end timestamp.
+         */
+        if (twp->stop_ts == WT_TS_MAX && twp->durable_start_ts <= version_cursor->start_timestamp) {
+            *donep = true;
+            return (0);
+        }
+    }
+
+    WT_RET(__curversion_value_return_from_hs(cursor, twp, hs_upd_type));
+    *upd_foundp = true;
+    return (0);
+}
+
+/*
+ * __curversion_next_single_key --
+ *     Iterate the updates of a single key.
+ */
+static int
+__curversion_next_single_key(WT_CURSOR *cursor)
+{
+    WT_CURSOR *file_cursor;
+    WT_CURSOR_BTREE *cbt;
+    WT_CURSOR_VERSION *version_cursor;
+    WT_DECL_ITEM(hs_value);
+    WT_DECL_ITEM(key);
+    WT_DECL_RET;
+    WT_PAGE *page;
+    WT_SESSION_IMPL *session;
+    WT_UPDATE *tombstone;
+    uint64_t raw;
+    bool done, upd_found;
+
+    session = CUR2S(cursor);
+    version_cursor = (WT_CURSOR_VERSION *)cursor;
+    file_cursor = version_cursor->file_cursor;
+    cbt = (WT_CURSOR_BTREE *)file_cursor;
+    tombstone = NULL;
     done = false;
     upd_found = false;
-    tombstone = NULL;
 
     /* Temporarily clear the raw flag. We need to pack the data according to the format. */
     raw = F_MASK(cursor, WT_CURSTD_RAW);
@@ -739,106 +852,9 @@ __curversion_next_single_key(WT_CURSOR *cursor)
     WT_ERR(__curversion_process_chain(cursor, &tombstone, &upd_found, &done));
     if (!done)
         WT_ERR(__curversion_process_on_disk(cursor, tombstone, page, &upd_found, &done));
+    if (!done)
+        WT_ERR(__curversion_process_hs(cursor, page, &key, &hs_value, &upd_found, &done));
 
-    if (!done && !upd_found && version_cursor->hs_cursor != NULL &&
-      !F_ISSET(version_cursor, WT_CURVERSION_HS_EXHAUSTED)) {
-        /*
-         * We have already seen an update that is globally visible on the update chain. No need to
-         * return more updates. Aborted updates are never globally visible.
-         */
-        if (F_ISSET(version_cursor, WT_CURVERSION_TIMESTAMP_ORDER) &&
-          !version_cursor->upd_stop_prepared && version_cursor->upd_stop_txnid != WT_TXN_ABORTED &&
-          __wt_txn_visible_all(
-            session, version_cursor->upd_stop_txnid, version_cursor->curversion_durable_stop_ts))
-            goto done;
-
-        /* Ensure we can see all the content in the history store. */
-        F_SET(hs_cursor, WT_CURSTD_HS_READ_COMMITTED);
-
-        if (!F_ISSET(hs_cursor, WT_CURSTD_KEY_INT)) {
-            if (page->type == WT_PAGE_ROW_LEAF)
-                hs_cursor->set_key(
-                  hs_cursor, 4, S2BT(session)->id, &file_cursor->key, WT_TS_MAX, UINT64_MAX);
-            else {
-                /* Ensure enough room for a column-store key without checking. */
-                WT_ERR(__wt_scr_alloc(session, WT_INTPACK64_MAXSIZE, &key));
-
-                p = key->mem;
-                WT_ERR(__wt_vpack_uint(&p, 0, cbt->recno));
-                key->size = WT_PTRDIFF(p, key->data);
-                hs_cursor->set_key(hs_cursor, 4, S2BT(session)->id, key, WT_TS_MAX, UINT64_MAX);
-            }
-            WT_ERR(__wt_curhs_search_near_before(session, hs_cursor));
-        } else
-            WT_ERR(hs_cursor->prev(hs_cursor));
-
-        WT_ERR(__wt_scr_alloc(session, 0, &hs_value));
-
-        /*
-         * If there are no history store records for the given key or if we have iterated through
-         * all the records already, we have exhausted the history store.
-         */
-        WT_ASSERT(session, ret == 0);
-
-        for (;;) {
-            __wt_hs_upd_time_window(hs_cursor, &twp);
-            WT_ERR(hs_cursor->get_value(
-              hs_cursor, &durable_stop_ts, &durable_start_ts, &hs_upd_type, hs_value));
-
-            /*
-             * Reconstruct the history store value if needed. Since we save the value inside the
-             * version cursor every time we traverse a version, we can simply apply the modify onto
-             * the latest value.
-             */
-            if (hs_upd_type == WT_UPDATE_MODIFY) {
-                __wt_modify_max_memsize_format(hs_value->data, file_cursor->value_format,
-                  cbt->upd_value->buf.size, &max_memsize);
-                WT_ERR(__wt_buf_set_and_grow(session, &cbt->upd_value->buf,
-                  cbt->upd_value->buf.data, cbt->upd_value->buf.size, max_memsize));
-                WT_ERR(__wt_modify_apply_item(
-                  session, file_cursor->value_format, &cbt->upd_value->buf, hs_value->data));
-            } else {
-                WT_ASSERT(session, hs_upd_type == WT_UPDATE_STANDARD);
-                cbt->upd_value->buf.data = hs_value->data;
-                cbt->upd_value->buf.size = hs_value->size;
-            }
-
-            if (!F_ISSET(version_cursor, WT_CURVERSION_TIMESTAMP_ORDER))
-                break;
-
-            /* Skip all non-aborted updates that are duplicate to the previous updates returned. */
-            if (version_cursor->upd_stop_txnid != WT_TXN_ABORTED &&
-              twp->stop_txn <= version_cursor->upd_stop_txnid &&
-              twp->stop_ts <= version_cursor->curversion_stop_ts &&
-              twp->durable_stop_ts <= version_cursor->curversion_durable_stop_ts)
-                break;
-
-            WT_ERR(hs_cursor->prev(hs_cursor));
-        }
-
-        if (version_cursor->start_timestamp != WT_TS_NONE) {
-            /*
-             * We are done if the durable stop timestamp is smaller or equal to the end timestamp.
-             */
-            if (twp->stop_ts != WT_TS_MAX &&
-              twp->durable_stop_ts <= version_cursor->start_timestamp)
-                goto done;
-
-            /*
-             * FIXME-WT-16136: for history store, it is hard to determine if the stop durable
-             * timestamp is from a tombstone or the previous full value. Always return the value for
-             * now if its stop durable timestamp is larger than the end timestamp.
-             */
-            if (twp->stop_ts == WT_TS_MAX &&
-              twp->durable_start_ts <= version_cursor->start_timestamp)
-                goto done;
-        }
-
-        WT_ERR(__curversion_value_return_from_hs(cursor, twp, hs_upd_type));
-        upd_found = true;
-    }
-
-done:
     if (!upd_found)
         ret = WT_NOTFOUND;
     else {

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -513,6 +513,37 @@ __curversion_disk_finalize_prepared(WT_CURSOR_VERSION *version_cursor, WT_TIME_W
 }
 
 /*
+ * __curversion_value_return_from_disk_image --
+ *     Pack the metadata for the on-disk value and record it as the previously-returned stop state.
+ */
+static int
+__curversion_value_return_from_disk_image(WT_CURSOR *cursor, WT_TIME_WINDOW *tw, uint64_t stop_txn,
+  bool stop_prepared, wt_timestamp_t stop_prepare_ts, wt_timestamp_t stop_ts,
+  wt_timestamp_t durable_stop_ts, uint64_t stop_prepared_id, bool version_prepared)
+{
+    WT_CURSOR_VERSION *version_cursor;
+    wt_timestamp_t durable_start_meta, start_meta;
+    bool has_start_prepare;
+
+    version_cursor = (WT_CURSOR_VERSION *)cursor;
+    has_start_prepare = WT_TIME_WINDOW_HAS_START_PREPARE(tw);
+    start_meta = has_start_prepare ? tw->start_prepare_ts : tw->start_ts;
+    durable_start_meta = has_start_prepare ? tw->start_prepare_ts : tw->durable_start_ts;
+
+    WT_RET(__curversion_set_value_with_format(cursor, WT_CURVERSION_METADATA_FORMAT, tw->start_txn,
+      start_meta, durable_start_meta, tw->start_prepare_ts, tw->start_prepared_id, stop_txn,
+      stop_prepared ? stop_prepare_ts : stop_ts, durable_stop_ts, stop_prepare_ts, stop_prepared_id,
+      WT_UPDATE_STANDARD, version_prepared, 0, WT_CURVERSION_DISK_IMAGE));
+
+    version_cursor->upd_stop_txnid = tw->start_txn;
+    version_cursor->curversion_durable_stop_ts = durable_start_meta;
+    version_cursor->curversion_stop_ts = start_meta;
+    version_cursor->upd_stop_prepare_ts = tw->start_prepare_ts;
+    version_cursor->upd_stop_prepared_id = tw->start_prepared_id;
+    return (0);
+}
+
+/*
  * __curversion_next_single_key --
  *     Iterate the updates of a single key.
  */
@@ -645,29 +676,9 @@ __curversion_next_single_key(WT_CURSOR *cursor)
                     goto skip_on_page;
             }
 
-            WT_ERR(__curversion_set_value_with_format(cursor, WT_CURVERSION_METADATA_FORMAT,
-              cbt->upd_value->tw.start_txn,
-              WT_TIME_WINDOW_HAS_START_PREPARE(&(cbt->upd_value->tw)) ?
-                cbt->upd_value->tw.start_prepare_ts :
-                cbt->upd_value->tw.start_ts,
-              WT_TIME_WINDOW_HAS_START_PREPARE(&(cbt->upd_value->tw)) ?
-                cbt->upd_value->tw.start_prepare_ts :
-                cbt->upd_value->tw.durable_start_ts,
-              cbt->upd_value->tw.start_prepare_ts, cbt->upd_value->tw.start_prepared_id, stop_txn,
-              stop_prepared ? stop_prepare_ts : stop_ts, durable_stop_ts, stop_prepare_ts,
-              stop_prepared_id, WT_UPDATE_STANDARD, version_prepared, 0, WT_CURVERSION_DISK_IMAGE));
-
-            version_cursor->upd_stop_txnid = cbt->upd_value->tw.start_txn;
-            version_cursor->curversion_durable_stop_ts =
-              WT_TIME_WINDOW_HAS_START_PREPARE(&(cbt->upd_value->tw)) ?
-              cbt->upd_value->tw.start_prepare_ts :
-              cbt->upd_value->tw.durable_start_ts;
-            version_cursor->curversion_stop_ts =
-              WT_TIME_WINDOW_HAS_START_PREPARE(&(cbt->upd_value->tw)) ?
-              cbt->upd_value->tw.start_prepare_ts :
-              cbt->upd_value->tw.start_ts;
-            version_cursor->upd_stop_prepare_ts = cbt->upd_value->tw.start_prepare_ts;
-            version_cursor->upd_stop_prepared_id = cbt->upd_value->tw.start_prepared_id;
+            WT_ERR(__curversion_value_return_from_disk_image(cursor, &cbt->upd_value->tw,
+              stop_txn, stop_prepared, stop_prepare_ts, stop_ts, durable_stop_ts, stop_prepared_id,
+              version_prepared));
 
             upd_found = true;
         } else

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -241,11 +241,13 @@ __curversion_value_return_from_upd(
     uint64_t durable_meta =
       aborted ? (uint64_t)upd->upd_rollback_ts : (uint64_t)upd->upd_durable_ts;
 
+    wt_timestamp_t stop_ts = __curversion_stop_uses_prepare_ts(version_cursor) ?
+      version_cursor->upd_stop_prepare_ts :
+      version_cursor->curversion_stop_ts;
+
     return (__curversion_set_value_with_format(cursor, WT_CURVERSION_METADATA_FORMAT, upd->txnid,
       start_meta, durable_meta, upd->prepare_ts, upd->prepared_id, version_cursor->upd_stop_txnid,
-      __curversion_stop_uses_prepare_ts(version_cursor) ? version_cursor->upd_stop_prepare_ts :
-                                                          version_cursor->curversion_stop_ts,
-      version_cursor->curversion_durable_stop_ts, version_cursor->upd_stop_prepare_ts,
+      stop_ts, version_cursor->curversion_durable_stop_ts, version_cursor->upd_stop_prepare_ts,
       version_cursor->upd_stop_prepared_id, upd->type, version_prepared, upd->flags,
       WT_CURVERSION_UPDATE_CHAIN));
 }
@@ -423,30 +425,25 @@ __curversion_disk_check_with_stop(WT_SESSION_IMPL *session, WT_CURSOR_VERSION *v
         return;
     }
 
-    if (WT_TIME_WINDOW_HAS_STOP_PREPARE(tw)) {
+    if (WT_TIME_WINDOW_HAS_STOP_PREPARE(tw))
         *skipp = true;
-        return;
-    }
-
-    /* See the no-stop branch: skip the comparison after a rolled-back prepared emission. */
-    if (version_cursor->upd_stop_txnid != WT_TXN_ABORTED) {
-        if (__curversion_stop_uses_prepare_ts(version_cursor)) {
-            if (tw->stop_txn > version_cursor->upd_stop_txnid ||
-              tw->stop_ts > version_cursor->upd_stop_prepare_ts) {
-                *skipp = true;
-                return;
-            }
-        } else if (tw->stop_txn > version_cursor->upd_stop_txnid ||
-          tw->stop_ts > version_cursor->curversion_stop_ts) {
-            *skipp = true;
-            return;
+    else {
+        /* See the no-stop branch: skip the comparison after a rolled-back prepared emission. */
+        if (version_cursor->upd_stop_txnid != WT_TXN_ABORTED) {
+            if (__curversion_stop_uses_prepare_ts(version_cursor))
+                *skipp = (tw->stop_txn > version_cursor->upd_stop_txnid ||
+                  tw->stop_ts > version_cursor->upd_stop_prepare_ts);
+            else
+                *skipp = (tw->stop_txn > version_cursor->upd_stop_txnid ||
+                  tw->stop_ts > version_cursor->curversion_stop_ts);
         }
-    }
 
-    /* An update whose start equals stop never became visible. */
-    if (tw->stop_txn == tw->start_txn && tw->stop_prepare_ts == tw->start_prepare_ts &&
-      tw->stop_ts == tw->start_ts && tw->durable_stop_ts == tw->durable_start_ts)
-        *skipp = true;
+        /* An update whose start equals stop never became visible. */
+        if (!*skipp && tw->stop_txn == tw->start_txn &&
+          tw->stop_prepare_ts == tw->start_prepare_ts && tw->stop_ts == tw->start_ts &&
+          tw->durable_stop_ts == tw->durable_start_ts)
+            *skipp = true;
+    }
 }
 
 /*
@@ -484,32 +481,30 @@ __curversion_disk_finalize_prepared(WT_CURSOR_VERSION *version_cursor, WT_TIME_W
         if (WT_TIME_WINDOW_HAS_STOP(tw)) {
             /* Done if the on-disk stop durable timestamp is at or before the end timestamp. */
             if (!WT_TIME_WINDOW_HAS_STOP_PREPARE(tw) &&
-              tw->durable_stop_ts <= version_cursor->start_timestamp) {
+              tw->durable_stop_ts <= version_cursor->start_timestamp)
                 *donep = true;
-                return;
-            }
         } else if (!WT_TIME_WINDOW_HAS_START_PREPARE(tw) &&
-          tw->durable_start_ts <= version_cursor->start_timestamp) {
+          tw->durable_start_ts <= version_cursor->start_timestamp)
             /* No stop side: done if the start durable timestamp is past the end timestamp. */
             *donep = true;
-            return;
-        }
     }
 
-    if (F_ISSET(version_cursor, WT_CURVERSION_VISIBLE_ONLY) && WT_TIME_WINDOW_HAS_PREPARE(tw)) {
-        if (!WT_TIME_WINDOW_HAS_STOP(tw) || stopp->txn == tw->start_txn) {
-            *skipp = true;
-            return;
-        }
-        stopp->txn = WT_TXN_MAX;
-        stopp->prepare_ts = WT_TS_MAX;
-        stopp->prepared_id = WT_PREPARED_ID_NONE;
-        stopp->ts = WT_TS_MAX;
-        stopp->durable_ts = WT_TS_NONE;
-        stopp->prepared = false;
-        *version_preparedp = false;
-    } else
-        *version_preparedp = WT_TIME_WINDOW_HAS_PREPARE(tw);
+    if (!*donep) {
+        if (F_ISSET(version_cursor, WT_CURVERSION_VISIBLE_ONLY) && WT_TIME_WINDOW_HAS_PREPARE(tw)) {
+            if (!WT_TIME_WINDOW_HAS_STOP(tw) || stopp->txn == tw->start_txn)
+                *skipp = true;
+            else {
+                stopp->txn = WT_TXN_MAX;
+                stopp->prepare_ts = WT_TS_MAX;
+                stopp->prepared_id = WT_PREPARED_ID_NONE;
+                stopp->ts = WT_TS_MAX;
+                stopp->durable_ts = WT_TS_NONE;
+                stopp->prepared = false;
+                *version_preparedp = false;
+            }
+        } else
+            *version_preparedp = WT_TIME_WINDOW_HAS_PREPARE(tw);
+    }
 }
 
 /*
@@ -517,9 +512,8 @@ __curversion_disk_finalize_prepared(WT_CURSOR_VERSION *version_cursor, WT_TIME_W
  *     Pack the metadata for the on-disk value and record it as the previously-returned stop state.
  */
 static int
-__curversion_value_return_from_disk_image(WT_CURSOR *cursor, WT_TIME_WINDOW *tw, uint64_t stop_txn,
-  bool stop_prepared, wt_timestamp_t stop_prepare_ts, wt_timestamp_t stop_ts,
-  wt_timestamp_t durable_stop_ts, uint64_t stop_prepared_id, bool version_prepared)
+__curversion_value_return_from_disk_image(WT_CURSOR *cursor, WT_TIME_WINDOW *tw,
+  const WT_CURVERSION_DISK_STOP_TIME_POINT *stopp, bool version_prepared)
 {
     WT_CURSOR_VERSION *version_cursor = (WT_CURSOR_VERSION *)cursor;
     bool has_start_prepare = WT_TIME_WINDOW_HAS_START_PREPARE(tw);
@@ -528,9 +522,9 @@ __curversion_value_return_from_disk_image(WT_CURSOR *cursor, WT_TIME_WINDOW *tw,
       has_start_prepare ? tw->start_prepare_ts : tw->durable_start_ts;
 
     WT_RET(__curversion_set_value_with_format(cursor, WT_CURVERSION_METADATA_FORMAT, tw->start_txn,
-      start_meta, durable_start_meta, tw->start_prepare_ts, tw->start_prepared_id, stop_txn,
-      stop_prepared ? stop_prepare_ts : stop_ts, durable_stop_ts, stop_prepare_ts, stop_prepared_id,
-      WT_UPDATE_STANDARD, version_prepared, 0, WT_CURVERSION_DISK_IMAGE));
+      start_meta, durable_start_meta, tw->start_prepare_ts, tw->start_prepared_id, stopp->txn,
+      stopp->prepared ? stopp->prepare_ts : stopp->ts, stopp->durable_ts, stopp->prepare_ts,
+      stopp->prepared_id, WT_UPDATE_STANDARD, version_prepared, 0, WT_CURVERSION_DISK_IMAGE));
 
     version_cursor->upd_stop_txnid = tw->start_txn;
     version_cursor->curversion_durable_stop_ts = durable_start_meta;
@@ -579,12 +573,7 @@ __curversion_process_on_disk(
     if (*upd_foundp || F_ISSET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED))
         return (0);
 
-    /* No older versions are needed once the previously-returned stop is globally visible. */
-    if (__curversion_stop_globally_visible(session, version_cursor)) {
-        *donep = true;
-        return (0);
-    }
-
+    /* Validate the page has an accessible on-disk slot before doing further work. */
     switch (page->type) {
     case WT_PAGE_ROW_LEAF:
         if (cbt->ins != NULL) {
@@ -603,6 +592,12 @@ __curversion_process_on_disk(
         break;
     default:
         return (__wt_illegal_value(session, page->type));
+    }
+
+    /* No older versions are needed once the previously-returned stop is globally visible. */
+    if (__curversion_stop_globally_visible(session, version_cursor)) {
+        *donep = true;
+        return (0);
     }
 
     /*
@@ -631,31 +626,31 @@ __curversion_process_on_disk(
         stop.prepared = __curversion_stop_uses_prepare_ts(version_cursor);
     } else {
         __curversion_disk_check_with_stop(session, version_cursor, tw, &skip, donep);
-        if (*donep)
-            return (0);
-        if (skip) {
-            F_SET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED);
-            return (0);
+        if (!skip && !*donep) {
+            stop.durable_ts = tw->durable_stop_ts;
+            stop.prepare_ts = tw->stop_prepare_ts;
+            stop.prepared_id = tw->stop_prepared_id;
+            stop.ts = tw->stop_ts;
+            stop.txn = tw->stop_txn;
+            stop.prepared = WT_TIME_WINDOW_HAS_STOP_PREPARE(tw);
         }
-        stop.durable_ts = tw->durable_stop_ts;
-        stop.prepare_ts = tw->stop_prepare_ts;
-        stop.prepared_id = tw->stop_prepared_id;
-        stop.ts = tw->stop_ts;
-        stop.txn = tw->stop_txn;
-        stop.prepared = WT_TIME_WINDOW_HAS_STOP_PREPARE(tw);
+    }
+
+    if (*donep || skip) {
+        if (skip)
+            F_SET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED);
+        return (0);
     }
 
     __curversion_disk_finalize_prepared(
       version_cursor, tw, tombstone, &stop, &version_prepared, &skip, donep);
-    if (*donep)
-        return (0);
-    if (skip) {
-        F_SET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED);
+    if (*donep || skip) {
+        if (skip)
+            F_SET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED);
         return (0);
     }
 
-    WT_RET(__curversion_value_return_from_disk_image(cursor, tw, stop.txn, stop.prepared,
-      stop.prepare_ts, stop.ts, stop.durable_ts, stop.prepared_id, version_prepared));
+    WT_RET(__curversion_value_return_from_disk_image(cursor, tw, &stop, version_prepared));
 
     *upd_foundp = true;
     F_SET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED);

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -419,6 +419,48 @@ __curversion_disk_skip_no_stop(WT_CURSOR_VERSION *version_cursor, WT_TIME_WINDOW
 }
 
 /*
+ * __curversion_disk_check_with_stop --
+ *     Apply the timestamp-order filter to an on-disk record that has a stop side.
+ */
+static void
+__curversion_disk_check_with_stop(WT_SESSION_IMPL *session, WT_CURSOR_VERSION *version_cursor,
+  WT_TIME_WINDOW *tw, bool *skipp, bool *donep)
+{
+    if (!F_ISSET(version_cursor, WT_CURVERSION_TIMESTAMP_ORDER))
+        return;
+
+    if (__wt_txn_tw_start_visible_all(session, tw)) {
+        *donep = true;
+        return;
+    }
+
+    if (WT_TIME_WINDOW_HAS_STOP_PREPARE(tw)) {
+        *skipp = true;
+        return;
+    }
+
+    /* See the no-stop branch: skip the comparison after a rolled-back prepared emission. */
+    if (version_cursor->upd_stop_txnid != WT_TXN_ABORTED) {
+        if (__curversion_stop_uses_prepare_ts(version_cursor)) {
+            if (tw->stop_txn > version_cursor->upd_stop_txnid ||
+              tw->stop_ts > version_cursor->upd_stop_prepare_ts) {
+                *skipp = true;
+                return;
+            }
+        } else if (tw->stop_txn > version_cursor->upd_stop_txnid ||
+          tw->stop_ts > version_cursor->curversion_stop_ts) {
+            *skipp = true;
+            return;
+        }
+    }
+
+    /* An update whose start equals stop never became visible. */
+    if (tw->stop_txn == tw->start_txn && tw->stop_prepare_ts == tw->start_prepare_ts &&
+      tw->stop_ts == tw->start_ts && tw->durable_stop_ts == tw->durable_start_ts)
+        *skipp = true;
+}
+
+/*
  * __curversion_next_single_key --
  *     Iterate the updates of a single key.
  */
@@ -523,34 +565,13 @@ __curversion_next_single_key(WT_CURSOR *cursor)
                 stop_txn = version_cursor->upd_stop_txnid;
                 stop_prepared = __curversion_stop_uses_prepare_ts(version_cursor);
             } else {
-                if (F_ISSET(version_cursor, WT_CURVERSION_TIMESTAMP_ORDER)) {
-                    if (__wt_txn_tw_start_visible_all(session, &cbt->upd_value->tw))
+                {
+                    bool disk_skip = false, disk_done = false;
+                    __curversion_disk_check_with_stop(session, version_cursor,
+                      &cbt->upd_value->tw, &disk_skip, &disk_done);
+                    if (disk_done)
                         goto done;
-
-                    if (WT_TIME_WINDOW_HAS_STOP_PREPARE(&cbt->upd_value->tw))
-                        goto skip_on_page;
-
-                    /*
-                     * See the no-stop branch above: skip the comparison when the previous emission
-                     * was a rolled-back prepared update.
-                     */
-                    if (version_cursor->upd_stop_txnid != WT_TXN_ABORTED) {
-                        if (__curversion_stop_uses_prepare_ts(version_cursor)) {
-                            if (cbt->upd_value->tw.stop_txn > version_cursor->upd_stop_txnid ||
-                              cbt->upd_value->tw.stop_ts > version_cursor->upd_stop_prepare_ts)
-                                goto skip_on_page;
-                        } else {
-                            if (cbt->upd_value->tw.stop_txn > version_cursor->upd_stop_txnid ||
-                              cbt->upd_value->tw.stop_ts > version_cursor->curversion_stop_ts)
-                                goto skip_on_page;
-                        }
-                    }
-
-                    /* The update is not visible if start equals stop. */
-                    if (cbt->upd_value->tw.stop_txn == cbt->upd_value->tw.start_txn &&
-                      cbt->upd_value->tw.stop_prepare_ts == cbt->upd_value->tw.start_prepare_ts &&
-                      cbt->upd_value->tw.stop_ts == cbt->upd_value->tw.start_ts &&
-                      cbt->upd_value->tw.durable_stop_ts == cbt->upd_value->tw.durable_start_ts)
+                    if (disk_skip)
                         goto skip_on_page;
                 }
                 durable_stop_ts = cbt->upd_value->tw.durable_stop_ts;

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -552,7 +552,26 @@ __curversion_value_return_from_disk_image(WT_CURSOR *cursor, WT_TIME_WINDOW *tw,
     version_cursor->curversion_stop_ts = start_meta;
     version_cursor->upd_stop_prepare_ts = tw->start_prepare_ts;
     version_cursor->upd_stop_prepared_id = tw->start_prepared_id;
+    /*
+     * upd_stop_prepared is intentionally not updated here. Disk records are stable so their
+     * start side is never an in-progress prepare; any prepared stop inherited from the update
+     * chain still gates the globally-visible check for subsequent history-store iterations.
+     */
     return (0);
+}
+
+/*
+ * __curversion_stop_globally_visible --
+ *     True if the previously-returned stop record is globally visible in timestamp-order mode,
+ *     meaning no older versions need to be returned. Aborted stops are never globally visible.
+ */
+static WT_INLINE bool
+__curversion_stop_globally_visible(WT_SESSION_IMPL *session, WT_CURSOR_VERSION *version_cursor)
+{
+    return (F_ISSET(version_cursor, WT_CURVERSION_TIMESTAMP_ORDER) &&
+      !version_cursor->upd_stop_prepared && version_cursor->upd_stop_txnid != WT_TXN_ABORTED &&
+      __wt_txn_visible_all(
+        session, version_cursor->upd_stop_txnid, version_cursor->curversion_durable_stop_ts));
 }
 
 /*
@@ -580,14 +599,8 @@ __curversion_process_on_disk(
     if (*upd_foundp || F_ISSET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED))
         return (0);
 
-    /*
-     * Stop once we hit a globally visible record on the update chain; no need to return more
-     * updates. Aborted updates are never globally visible.
-     */
-    if (F_ISSET(version_cursor, WT_CURVERSION_TIMESTAMP_ORDER) &&
-      !version_cursor->upd_stop_prepared && version_cursor->upd_stop_txnid != WT_TXN_ABORTED &&
-      __wt_txn_visible_all(
-        session, version_cursor->upd_stop_txnid, version_cursor->curversion_durable_stop_ts)) {
+    /* No older versions are needed once the previously-returned stop is globally visible. */
+    if (__curversion_stop_globally_visible(session, version_cursor)) {
         *donep = true;
         return (0);
     }
@@ -698,6 +711,11 @@ __curversion_value_return_from_hs(WT_CURSOR *cursor, WT_TIME_WINDOW *twp, uint64
     version_cursor->curversion_stop_ts = start_meta;
     version_cursor->upd_stop_prepare_ts = twp->start_prepare_ts;
     version_cursor->upd_stop_prepared_id = twp->start_prepared_id;
+    /*
+     * upd_stop_prepared is intentionally not updated here — history-store records are fully
+     * committed so their start side is never an in-progress prepare; any prepared stop inherited
+     * from the update chain still gates the globally-visible check for the next iteration.
+     */
     return (0);
 }
 
@@ -729,14 +747,8 @@ __curversion_process_hs(WT_CURSOR *cursor, WT_PAGE *page, WT_ITEM **keyp, WT_ITE
     if (*upd_foundp || hs_cursor == NULL || F_ISSET(version_cursor, WT_CURVERSION_HS_EXHAUSTED))
         return (0);
 
-    /*
-     * Stop once we hit a globally visible record on the update chain; no need to return more
-     * updates. Aborted updates are never globally visible.
-     */
-    if (F_ISSET(version_cursor, WT_CURVERSION_TIMESTAMP_ORDER) &&
-      !version_cursor->upd_stop_prepared && version_cursor->upd_stop_txnid != WT_TXN_ABORTED &&
-      __wt_txn_visible_all(
-        session, version_cursor->upd_stop_txnid, version_cursor->curversion_durable_stop_ts)) {
+    /* No older versions are needed once the previously-returned stop is globally visible. */
+    if (__curversion_stop_globally_visible(session, version_cursor)) {
         *donep = true;
         return (0);
     }

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -461,6 +461,58 @@ __curversion_disk_check_with_stop(WT_SESSION_IMPL *session, WT_CURSOR_VERSION *v
 }
 
 /*
+ * __curversion_disk_finalize_prepared --
+ *     Resolve the prepared-state and visibility decisions for an on-disk record, possibly mutating
+ *     the stop fields when running in visible-only mode.
+ */
+static void
+__curversion_disk_finalize_prepared(WT_CURSOR_VERSION *version_cursor, WT_TIME_WINDOW *tw,
+  WT_UPDATE *tombstone, uint64_t *stop_txnp, wt_timestamp_t *stop_prepare_tsp,
+  uint64_t *stop_prepared_idp, wt_timestamp_t *stop_tsp, wt_timestamp_t *durable_stop_tsp,
+  bool *stop_preparedp, bool *version_preparedp, bool *skipp, bool *donep)
+{
+    uint8_t prepare_state;
+
+    if (tombstone != NULL) {
+        WT_ACQUIRE_READ_WITH_BARRIER(prepare_state, tombstone->prepare_state);
+        *version_preparedp =
+          prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED;
+        return;
+    }
+
+    if (version_cursor->start_timestamp != WT_TS_NONE) {
+        if (WT_TIME_WINDOW_HAS_STOP(tw)) {
+            /* Done if the on-disk stop durable timestamp is at or before the end timestamp. */
+            if (!WT_TIME_WINDOW_HAS_STOP_PREPARE(tw) &&
+              tw->durable_stop_ts <= version_cursor->start_timestamp) {
+                *donep = true;
+                return;
+            }
+        } else if (!WT_TIME_WINDOW_HAS_START_PREPARE(tw) &&
+          tw->durable_start_ts <= version_cursor->start_timestamp) {
+            /* No stop side: done if the start durable timestamp is past the end timestamp. */
+            *donep = true;
+            return;
+        }
+    }
+
+    if (F_ISSET(version_cursor, WT_CURVERSION_VISIBLE_ONLY) && WT_TIME_WINDOW_HAS_PREPARE(tw)) {
+        if (!WT_TIME_WINDOW_HAS_STOP(tw) || *stop_txnp == tw->start_txn) {
+            *skipp = true;
+            return;
+        }
+        *stop_txnp = WT_TXN_MAX;
+        *stop_prepare_tsp = WT_TS_MAX;
+        *stop_prepared_idp = WT_PREPARED_ID_NONE;
+        *stop_tsp = WT_TS_MAX;
+        *durable_stop_tsp = WT_TS_NONE;
+        *stop_preparedp = false;
+        *version_preparedp = false;
+    } else
+        *version_preparedp = WT_TIME_WINDOW_HAS_PREPARE(tw);
+}
+
+/*
  * __curversion_next_single_key --
  *     Iterate the updates of a single key.
  */
@@ -582,49 +634,15 @@ __curversion_next_single_key(WT_CURSOR *cursor)
                 stop_prepared = WT_TIME_WINDOW_HAS_STOP_PREPARE(&cbt->upd_value->tw);
             }
 
-            if (tombstone != NULL) {
-                WT_ACQUIRE_READ_WITH_BARRIER(prepare_state, tombstone->prepare_state);
-                version_prepared =
-                  prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED;
-            } else {
-                if (version_cursor->start_timestamp != WT_TS_NONE) {
-                    if (WT_TIME_WINDOW_HAS_STOP(&cbt->upd_value->tw)) {
-                        /*
-                         * We are done if we have an on-disk stop durable timestamp that is smaller
-                         * than or equal to the end timestamp.
-                         */
-                        if (!WT_TIME_WINDOW_HAS_STOP_PREPARE(&cbt->upd_value->tw) &&
-                          cbt->upd_value->tw.durable_stop_ts <= version_cursor->start_timestamp)
-                            goto done;
-                    } else {
-                        /*
-                         * We are done if we don't have a valid on-disk stop durable timestamp and
-                         * the on disk start durable timestamp is smaller than or equal to the end
-                         * timestamp.
-                         */
-                        if (!WT_TIME_WINDOW_HAS_START_PREPARE(&cbt->upd_value->tw) &&
-                          cbt->upd_value->tw.durable_start_ts <= version_cursor->start_timestamp)
-                            goto done;
-                    }
-                }
-
-                if (F_ISSET(version_cursor, WT_CURVERSION_VISIBLE_ONLY) &&
-                  WT_TIME_WINDOW_HAS_PREPARE(&(cbt->upd_value->tw))) {
-                    if (!WT_TIME_WINDOW_HAS_STOP(&cbt->upd_value->tw))
-                        goto skip_on_page;
-
-                    if (stop_txn == cbt->upd_value->tw.start_txn)
-                        goto skip_on_page;
-
-                    stop_txn = WT_TXN_MAX;
-                    stop_prepare_ts = WT_TS_MAX;
-                    stop_prepared_id = WT_PREPARED_ID_NONE;
-                    stop_ts = WT_TS_MAX;
-                    durable_stop_ts = WT_TS_NONE;
-                    stop_prepared = false;
-                    version_prepared = false;
-                } else
-                    version_prepared = WT_TIME_WINDOW_HAS_PREPARE(&(cbt->upd_value->tw));
+            {
+                bool fp_skip = false, fp_done = false;
+                __curversion_disk_finalize_prepared(version_cursor, &cbt->upd_value->tw,
+                  tombstone, &stop_txn, &stop_prepare_ts, &stop_prepared_id, &stop_ts,
+                  &durable_stop_ts, &stop_prepared, &version_prepared, &fp_skip, &fp_done);
+                if (fp_done)
+                    goto done;
+                if (fp_skip)
+                    goto skip_on_page;
             }
 
             WT_ERR(__curversion_set_value_with_format(cursor, WT_CURVERSION_METADATA_FORMAT,

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -390,6 +390,35 @@ __curversion_process_chain(WT_CURSOR *cursor, WT_UPDATE **tombstonep, bool *upd_
 }
 
 /*
+ * __curversion_disk_skip_no_stop --
+ *     Decide whether to skip an on-disk record that has no stop side, when running in timestamp
+ *     order mode.
+ */
+static bool
+__curversion_disk_skip_no_stop(WT_CURSOR_VERSION *version_cursor, WT_TIME_WINDOW *tw)
+{
+    if (!F_ISSET(version_cursor, WT_CURVERSION_TIMESTAMP_ORDER))
+        return (false);
+
+    /* Prepared values on disk are always skipped. */
+    if (WT_TIME_WINDOW_HAS_START_PREPARE(tw))
+        return (true);
+
+    /*
+     * If the previous emission was a rolled-back prepared update its stop slot holds a rollback
+     * timestamp instead of a real stop timestamp, so the comparison would be meaningless.
+     */
+    if (version_cursor->upd_stop_txnid == WT_TXN_ABORTED)
+        return (false);
+
+    if (__curversion_stop_uses_prepare_ts(version_cursor))
+        return (tw->start_txn > version_cursor->upd_stop_txnid ||
+          tw->start_ts > version_cursor->upd_stop_prepare_ts);
+    return (tw->start_txn > version_cursor->upd_stop_txnid ||
+      tw->start_ts > version_cursor->curversion_stop_ts);
+}
+
+/*
  * __curversion_next_single_key --
  *     Iterate the updates of a single key.
  */
@@ -485,28 +514,8 @@ __curversion_next_single_key(WT_CURSOR *cursor)
           WT_RESTART, true);
         if (ret == 0) {
             if (!WT_TIME_WINDOW_HAS_STOP(&cbt->upd_value->tw)) {
-                if (F_ISSET(version_cursor, WT_CURVERSION_TIMESTAMP_ORDER)) {
-                    /* Always skip prepared update on disk. */
-                    if (WT_TIME_WINDOW_HAS_START_PREPARE(&cbt->upd_value->tw))
-                        goto skip_on_page;
-
-                    /*
-                     * Skip the comparison when the previously emitted update was a rolled- back
-                     * prepared update: there is no real stop to compare against, and the fields
-                     * hold rollback metadata rather than a stop timestamp.
-                     */
-                    if (version_cursor->upd_stop_txnid != WT_TXN_ABORTED) {
-                        if (__curversion_stop_uses_prepare_ts(version_cursor)) {
-                            if (cbt->upd_value->tw.start_txn > version_cursor->upd_stop_txnid ||
-                              cbt->upd_value->tw.start_ts > version_cursor->upd_stop_prepare_ts)
-                                goto skip_on_page;
-                        } else {
-                            if (cbt->upd_value->tw.start_txn > version_cursor->upd_stop_txnid ||
-                              cbt->upd_value->tw.start_ts > version_cursor->curversion_stop_ts)
-                                goto skip_on_page;
-                        }
-                    }
-                }
+                if (__curversion_disk_skip_no_stop(version_cursor, &cbt->upd_value->tw))
+                    goto skip_on_page;
                 durable_stop_ts = version_cursor->curversion_durable_stop_ts;
                 stop_prepare_ts = version_cursor->upd_stop_prepare_ts;
                 stop_prepared_id = version_cursor->upd_stop_prepared_id;

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -461,15 +461,27 @@ __curversion_disk_check_with_stop(WT_SESSION_IMPL *session, WT_CURSOR_VERSION *v
 }
 
 /*
+ * Stop-side metadata collected for an on-disk record. Bundled so helpers that need to inspect and
+ * potentially mutate all six fields can take a single pointer instead of six separate out-params.
+ */
+typedef struct {
+    uint64_t txn;
+    wt_timestamp_t prepare_ts;
+    uint64_t prepared_id;
+    wt_timestamp_t ts;
+    wt_timestamp_t durable_ts;
+    bool prepared;
+} WT_CURVERSION_DISK_STOP;
+
+/*
  * __curversion_disk_finalize_prepared --
  *     Resolve the prepared-state and visibility decisions for an on-disk record, possibly mutating
  *     the stop fields when running in visible-only mode.
  */
 static void
 __curversion_disk_finalize_prepared(WT_CURSOR_VERSION *version_cursor, WT_TIME_WINDOW *tw,
-  WT_UPDATE *tombstone, uint64_t *stop_txnp, wt_timestamp_t *stop_prepare_tsp,
-  uint64_t *stop_prepared_idp, wt_timestamp_t *stop_tsp, wt_timestamp_t *durable_stop_tsp,
-  bool *stop_preparedp, bool *version_preparedp, bool *skipp, bool *donep)
+  WT_UPDATE *tombstone, WT_CURVERSION_DISK_STOP *stopp, bool *version_preparedp, bool *skipp,
+  bool *donep)
 {
     uint8_t prepare_state;
 
@@ -497,16 +509,16 @@ __curversion_disk_finalize_prepared(WT_CURSOR_VERSION *version_cursor, WT_TIME_W
     }
 
     if (F_ISSET(version_cursor, WT_CURVERSION_VISIBLE_ONLY) && WT_TIME_WINDOW_HAS_PREPARE(tw)) {
-        if (!WT_TIME_WINDOW_HAS_STOP(tw) || *stop_txnp == tw->start_txn) {
+        if (!WT_TIME_WINDOW_HAS_STOP(tw) || stopp->txn == tw->start_txn) {
             *skipp = true;
             return;
         }
-        *stop_txnp = WT_TXN_MAX;
-        *stop_prepare_tsp = WT_TS_MAX;
-        *stop_prepared_idp = WT_PREPARED_ID_NONE;
-        *stop_tsp = WT_TS_MAX;
-        *durable_stop_tsp = WT_TS_NONE;
-        *stop_preparedp = false;
+        stopp->txn = WT_TXN_MAX;
+        stopp->prepare_ts = WT_TS_MAX;
+        stopp->prepared_id = WT_PREPARED_ID_NONE;
+        stopp->ts = WT_TS_MAX;
+        stopp->durable_ts = WT_TS_NONE;
+        stopp->prepared = false;
         *version_preparedp = false;
     } else
         *version_preparedp = WT_TIME_WINDOW_HAS_PREPARE(tw);
@@ -551,14 +563,13 @@ static int
 __curversion_process_on_disk(
   WT_CURSOR *cursor, WT_UPDATE *tombstone, WT_PAGE *page, bool *upd_foundp, bool *donep)
 {
+    WT_CURVERSION_DISK_STOP stop;
     WT_CURSOR_BTREE *cbt;
     WT_CURSOR_VERSION *version_cursor;
     WT_DECL_RET;
     WT_SESSION_IMPL *session;
     WT_TIME_WINDOW *tw;
-    wt_timestamp_t durable_stop_ts, stop_prepare_ts, stop_ts;
-    uint64_t stop_prepared_id, stop_txn;
-    bool skip, stop_prepared, version_prepared;
+    bool skip, version_prepared;
 
     session = CUR2S(cursor);
     version_cursor = (WT_CURSOR_VERSION *)cursor;
@@ -618,12 +629,12 @@ __curversion_process_on_disk(
             F_SET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED);
             return (0);
         }
-        durable_stop_ts = version_cursor->curversion_durable_stop_ts;
-        stop_prepare_ts = version_cursor->upd_stop_prepare_ts;
-        stop_prepared_id = version_cursor->upd_stop_prepared_id;
-        stop_ts = version_cursor->curversion_stop_ts;
-        stop_txn = version_cursor->upd_stop_txnid;
-        stop_prepared = __curversion_stop_uses_prepare_ts(version_cursor);
+        stop.durable_ts = version_cursor->curversion_durable_stop_ts;
+        stop.prepare_ts = version_cursor->upd_stop_prepare_ts;
+        stop.prepared_id = version_cursor->upd_stop_prepared_id;
+        stop.ts = version_cursor->curversion_stop_ts;
+        stop.txn = version_cursor->upd_stop_txnid;
+        stop.prepared = __curversion_stop_uses_prepare_ts(version_cursor);
     } else {
         skip = false;
         __curversion_disk_check_with_stop(session, version_cursor, tw, &skip, donep);
@@ -633,18 +644,17 @@ __curversion_process_on_disk(
             F_SET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED);
             return (0);
         }
-        durable_stop_ts = tw->durable_stop_ts;
-        stop_prepare_ts = tw->stop_prepare_ts;
-        stop_prepared_id = tw->stop_prepared_id;
-        stop_ts = tw->stop_ts;
-        stop_txn = tw->stop_txn;
-        stop_prepared = WT_TIME_WINDOW_HAS_STOP_PREPARE(tw);
+        stop.durable_ts = tw->durable_stop_ts;
+        stop.prepare_ts = tw->stop_prepare_ts;
+        stop.prepared_id = tw->stop_prepared_id;
+        stop.ts = tw->stop_ts;
+        stop.txn = tw->stop_txn;
+        stop.prepared = WT_TIME_WINDOW_HAS_STOP_PREPARE(tw);
     }
 
     skip = false;
-    __curversion_disk_finalize_prepared(version_cursor, tw, tombstone, &stop_txn, &stop_prepare_ts,
-      &stop_prepared_id, &stop_ts, &durable_stop_ts, &stop_prepared, &version_prepared, &skip,
-      donep);
+    __curversion_disk_finalize_prepared(
+      version_cursor, tw, tombstone, &stop, &version_prepared, &skip, donep);
     if (*donep)
         return (0);
     if (skip) {
@@ -652,8 +662,8 @@ __curversion_process_on_disk(
         return (0);
     }
 
-    WT_RET(__curversion_value_return_from_disk_image(cursor, tw, stop_txn, stop_prepared,
-      stop_prepare_ts, stop_ts, durable_stop_ts, stop_prepared_id, version_prepared));
+    WT_RET(__curversion_value_return_from_disk_image(cursor, tw, stop.txn, stop.prepared,
+      stop.prepare_ts, stop.ts, stop.durable_ts, stop.prepared_id, version_prepared));
 
     *upd_foundp = true;
     F_SET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED);

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -402,11 +402,10 @@ __curversion_disk_skip_no_stop(WT_CURSOR_VERSION *version_cursor, WT_TIME_WINDOW
     if (version_cursor->upd_stop_txnid == WT_TXN_ABORTED)
         return (false);
 
-    if (__curversion_stop_uses_prepare_ts(version_cursor))
-        return (tw->start_txn > version_cursor->upd_stop_txnid ||
-          tw->start_ts > version_cursor->upd_stop_prepare_ts);
-    return (tw->start_txn > version_cursor->upd_stop_txnid ||
-      tw->start_ts > version_cursor->curversion_stop_ts);
+    wt_timestamp_t stop_ts = __curversion_stop_uses_prepare_ts(version_cursor) ?
+      version_cursor->upd_stop_prepare_ts :
+      version_cursor->curversion_stop_ts;
+    return (tw->start_txn > version_cursor->upd_stop_txnid || tw->start_ts > stop_ts);
 }
 
 /*
@@ -420,12 +419,9 @@ __curversion_disk_check_with_stop(WT_SESSION_IMPL *session, WT_CURSOR_VERSION *v
     if (!F_ISSET(version_cursor, WT_CURVERSION_TIMESTAMP_ORDER))
         return;
 
-    if (__wt_txn_tw_start_visible_all(session, tw)) {
+    if (__wt_txn_tw_start_visible_all(session, tw))
         *donep = true;
-        return;
-    }
-
-    if (WT_TIME_WINDOW_HAS_STOP_PREPARE(tw))
+    else if (WT_TIME_WINDOW_HAS_STOP_PREPARE(tw))
         *skipp = true;
     else {
         /* See the no-stop branch: skip the comparison after a rolled-back prepared emission. */
@@ -474,36 +470,36 @@ __curversion_disk_finalize_prepared(WT_CURSOR_VERSION *version_cursor, WT_TIME_W
         WT_ACQUIRE_READ_WITH_BARRIER(prepare_state, tombstone->prepare_state);
         *version_preparedp =
           prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED;
-        return;
-    }
-
-    if (version_cursor->start_timestamp != WT_TS_NONE) {
-        if (WT_TIME_WINDOW_HAS_STOP(tw)) {
-            /* Done if the on-disk stop durable timestamp is at or before the end timestamp. */
-            if (!WT_TIME_WINDOW_HAS_STOP_PREPARE(tw) &&
-              tw->durable_stop_ts <= version_cursor->start_timestamp)
+    } else {
+        if (version_cursor->start_timestamp != WT_TS_NONE) {
+            if (WT_TIME_WINDOW_HAS_STOP(tw)) {
+                /* Done if the on-disk stop durable timestamp is at or before the end timestamp. */
+                if (!WT_TIME_WINDOW_HAS_STOP_PREPARE(tw) &&
+                  tw->durable_stop_ts <= version_cursor->start_timestamp)
+                    *donep = true;
+            } else if (!WT_TIME_WINDOW_HAS_START_PREPARE(tw) &&
+              tw->durable_start_ts <= version_cursor->start_timestamp)
+                /* No stop side: done if the start durable timestamp is past the end timestamp. */
                 *donep = true;
-        } else if (!WT_TIME_WINDOW_HAS_START_PREPARE(tw) &&
-          tw->durable_start_ts <= version_cursor->start_timestamp)
-            /* No stop side: done if the start durable timestamp is past the end timestamp. */
-            *donep = true;
-    }
+        }
 
-    if (!*donep) {
-        if (F_ISSET(version_cursor, WT_CURVERSION_VISIBLE_ONLY) && WT_TIME_WINDOW_HAS_PREPARE(tw)) {
-            if (!WT_TIME_WINDOW_HAS_STOP(tw) || stopp->txn == tw->start_txn)
-                *skipp = true;
-            else {
-                stopp->txn = WT_TXN_MAX;
-                stopp->prepare_ts = WT_TS_MAX;
-                stopp->prepared_id = WT_PREPARED_ID_NONE;
-                stopp->ts = WT_TS_MAX;
-                stopp->durable_ts = WT_TS_NONE;
-                stopp->prepared = false;
-                *version_preparedp = false;
-            }
-        } else
-            *version_preparedp = WT_TIME_WINDOW_HAS_PREPARE(tw);
+        if (!*donep) {
+            if (F_ISSET(version_cursor, WT_CURVERSION_VISIBLE_ONLY) &&
+              WT_TIME_WINDOW_HAS_PREPARE(tw)) {
+                if (!WT_TIME_WINDOW_HAS_STOP(tw) || stopp->txn == tw->start_txn)
+                    *skipp = true;
+                else {
+                    stopp->txn = WT_TXN_MAX;
+                    stopp->prepare_ts = WT_TS_MAX;
+                    stopp->prepared_id = WT_PREPARED_ID_NONE;
+                    stopp->ts = WT_TS_MAX;
+                    stopp->durable_ts = WT_TS_NONE;
+                    stopp->prepared = false;
+                    *version_preparedp = false;
+                }
+            } else
+                *version_preparedp = WT_TIME_WINDOW_HAS_PREPARE(tw);
+        }
     }
 }
 

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -303,6 +303,93 @@ __curversion_walk_to_next_update(
 }
 
 /*
+ * __curversion_process_chain --
+ *     Return the next version from the in-memory update chain, if any.
+ */
+static int
+__curversion_process_chain(WT_CURSOR *cursor, WT_UPDATE **tombstonep, bool *upd_foundp, bool *donep)
+{
+    WT_CURSOR_BTREE *cbt;
+    WT_CURSOR_VERSION *version_cursor;
+    WT_SESSION_IMPL *session;
+    WT_UPDATE *next_upd, *tombstone, *upd;
+    uint8_t prepare_state;
+    bool version_prepared;
+
+    session = CUR2S(cursor);
+    version_cursor = (WT_CURSOR_VERSION *)cursor;
+    cbt = (WT_CURSOR_BTREE *)version_cursor->file_cursor;
+    tombstone = NULL;
+
+    if (F_ISSET(version_cursor, WT_CURVERSION_UPDATE_EXHAUSTED))
+        return (0);
+
+    upd = version_cursor->next_upd;
+    if (upd == NULL) {
+        version_cursor->next_upd = NULL;
+        F_SET(version_cursor, WT_CURVERSION_UPDATE_EXHAUSTED);
+        return (0);
+    }
+
+    if (version_cursor->start_timestamp != WT_TS_NONE && upd->upd_durable_ts != WT_TS_NONE &&
+      upd->upd_durable_ts <= version_cursor->start_timestamp) {
+        *donep = true;
+        return (0);
+    }
+
+    if (upd->type == WT_UPDATE_TOMBSTONE) {
+        tombstone = upd;
+
+        /*
+         * Record the tombstone's stop information and traverse on to a value-bearing update. If the
+         * tombstone is the last update on the chain, the caller will fall back to the on-disk
+         * value.
+         */
+        WT_ACQUIRE_READ_WITH_BARRIER(prepare_state, upd->prepare_state);
+        version_prepared = !__curversion_is_prepare_rollback_update(upd) &&
+          (prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED);
+        __curversion_record_stop_time_point(version_cursor, upd, version_prepared);
+        upd = __curversion_tombstone_next_upd(session, version_cursor, tombstone);
+    }
+
+    *tombstonep = tombstone;
+
+    if (upd == NULL) {
+        version_cursor->next_upd = NULL;
+        F_SET(version_cursor, WT_CURVERSION_UPDATE_EXHAUSTED);
+        return (0);
+    }
+
+    WT_ACQUIRE_READ_WITH_BARRIER(prepare_state, upd->prepare_state);
+    version_prepared = !__curversion_is_prepare_rollback_update(upd) &&
+      (prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED);
+
+    /*
+     * Copy the update value into the version cursor as we don't know the value format. If the
+     * update is a modify, reconstruct the value.
+     */
+    if (upd->type != WT_UPDATE_MODIFY)
+        __wt_upd_value_assign(cbt->upd_value, upd);
+    else
+        WT_RET(__wt_modify_reconstruct_from_upd_list(
+          session, cbt, upd, cbt->upd_value, WT_OPCTX_TRANSACTION));
+
+    /* Pack the metadata describing this version into the version cursor's value. */
+    WT_RET(__curversion_value_return_from_upd(cursor, version_cursor, upd, version_prepared));
+
+    __curversion_record_stop_time_point(version_cursor, upd, version_prepared);
+
+    *upd_foundp = true;
+
+    next_upd = __curversion_walk_to_next_update(session, version_cursor, upd);
+    version_cursor->next_upd = next_upd;
+    if (next_upd == NULL)
+        F_SET(version_cursor, WT_CURVERSION_UPDATE_EXHAUSTED);
+
+    return (0);
+}
+
+/*
  * __curversion_next_single_key --
  *     Iterate the updates of a single key.
  */
@@ -318,12 +405,12 @@ __curversion_next_single_key(WT_CURSOR *cursor)
     WT_PAGE *page;
     WT_SESSION_IMPL *session;
     WT_TIME_WINDOW *twp;
-    WT_UPDATE *next_upd, *tombstone, *upd;
+    WT_UPDATE *tombstone;
     wt_timestamp_t durable_start_ts, durable_stop_ts, stop_prepare_ts, stop_ts;
     size_t max_memsize;
     uint64_t hs_upd_type, raw, stop_prepared_id, stop_txn;
     uint8_t *p, prepare_state;
-    bool stop_prepared, upd_found, version_prepared;
+    bool done, stop_prepared, upd_found, version_prepared;
 
     session = CUR2S(cursor);
     version_cursor = (WT_CURSOR_VERSION *)cursor;
@@ -331,8 +418,9 @@ __curversion_next_single_key(WT_CURSOR *cursor)
     hs_cursor = version_cursor->hs_cursor;
     cbt = (WT_CURSOR_BTREE *)file_cursor;
     twp = NULL;
+    done = false;
     upd_found = false;
-    tombstone = upd = NULL;
+    tombstone = NULL;
 
     /* Temporarily clear the raw flag. We need to pack the data according to the format. */
     raw = F_MASK(cursor, WT_CURSTD_RAW);
@@ -346,69 +434,9 @@ __curversion_next_single_key(WT_CURSOR *cursor)
     /* It's unsafe to access the page before checking the cursor's position. */
     page = cbt->ref->page;
 
-    if (!F_ISSET(version_cursor, WT_CURVERSION_UPDATE_EXHAUSTED)) {
-        upd = version_cursor->next_upd;
-
-        if (upd == NULL) {
-            version_cursor->next_upd = NULL;
-            F_SET(version_cursor, WT_CURVERSION_UPDATE_EXHAUSTED);
-        } else {
-            if (version_cursor->start_timestamp != WT_TS_NONE &&
-              upd->upd_durable_ts != WT_TS_NONE &&
-              upd->upd_durable_ts <= version_cursor->start_timestamp)
-                goto done;
-
-            if (upd->type == WT_UPDATE_TOMBSTONE) {
-                tombstone = upd;
-
-                /*
-                 * If the update is a tombstone, we still want to record the stop information but we
-                 * also need traverse to the next update to get the full value. If the tombstone was
-                 * the last update in the update list, retrieve the ondisk value.
-                 */
-                WT_ACQUIRE_READ_WITH_BARRIER(prepare_state, upd->prepare_state);
-                version_prepared = !__curversion_is_prepare_rollback_update(upd) &&
-                  (prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED);
-                __curversion_record_stop_time_point(version_cursor, upd, version_prepared);
-
-                upd = __curversion_tombstone_next_upd(session, version_cursor, tombstone);
-            }
-
-            if (upd == NULL) {
-                version_cursor->next_upd = NULL;
-                F_SET(version_cursor, WT_CURVERSION_UPDATE_EXHAUSTED);
-            } else {
-                WT_ACQUIRE_READ_WITH_BARRIER(prepare_state, upd->prepare_state);
-                version_prepared = !__curversion_is_prepare_rollback_update(upd) &&
-                  (prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED);
-
-                /*
-                 * Copy the update value into the version cursor as we don't know the value format.
-                 * If the update is a modify, reconstruct the value.
-                 */
-                if (upd->type != WT_UPDATE_MODIFY)
-                    __wt_upd_value_assign(cbt->upd_value, upd);
-                else
-                    WT_ERR(__wt_modify_reconstruct_from_upd_list(
-                      session, cbt, upd, cbt->upd_value, WT_OPCTX_TRANSACTION));
-
-                /*
-                 * Set the version cursor's value, which also contains all the record metadata for
-                 * that particular version of the update.
-                 */
-                WT_ERR(__curversion_value_return_from_upd(cursor, version_cursor, upd, version_prepared));
-
-                __curversion_record_stop_time_point(version_cursor, upd, version_prepared);
-
-                upd_found = true;
-
-                next_upd = __curversion_walk_to_next_update(session, version_cursor, upd);
-                version_cursor->next_upd = next_upd;
-                if (next_upd == NULL)
-                    F_SET(version_cursor, WT_CURVERSION_UPDATE_EXHAUSTED);
-            }
-        }
-    }
+    WT_ERR(__curversion_process_chain(cursor, &tombstone, &upd_found, &done));
+    if (done)
+        goto done;
 
     if (!upd_found && !F_ISSET(version_cursor, WT_CURVERSION_ON_DISK_EXHAUSTED)) {
         /*

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -256,6 +256,53 @@ __curversion_value_return_from_upd(
 }
 
 /*
+ * __curversion_walk_to_next_update --
+ *     Locate the next update worth returning after the one just returned. Returns NULL if the chain
+ *     is exhausted or if the just-returned update was globally visible.
+ */
+static WT_UPDATE *
+__curversion_walk_to_next_update(
+  WT_SESSION_IMPL *session, WT_CURSOR_VERSION *version_cursor, WT_UPDATE *upd)
+{
+    WT_UPDATE *first_globally_visible, *next_upd;
+
+    first_globally_visible = NULL;
+
+    for (next_upd = upd; next_upd != NULL; next_upd = next_upd->next) {
+        /* Skip aborted updates unless showing prepared rollbacks. */
+        if (next_upd->txnid == WT_TXN_ABORTED &&
+          (!F_ISSET(version_cursor, WT_CURVERSION_SHOW_PREPARED_ROLLBACK) ||
+            !__curversion_is_prepare_rollback_update(next_upd)))
+            continue;
+
+        if (first_globally_visible != NULL) {
+            next_upd = NULL;
+            break;
+        }
+
+        /* We have traversed all the non-obsolete updates. */
+        if ((F_ISSET(version_cursor, WT_CURVERSION_TIMESTAMP_ORDER) ||
+              WT_UPDATE_DATA_VALUE(next_upd)) &&
+          __wt_txn_upd_visible_all(session, next_upd))
+            first_globally_visible = next_upd;
+
+        if (next_upd != upd) {
+            /*
+             * The previously returned update is not globally visible: snapshot isolation plus the
+             * pinned global timestamp guarantee this. Aborted updates are never globally visible.
+             */
+            WT_ASSERT(session,
+              version_cursor->upd_stop_txnid == WT_TXN_ABORTED ||
+                !__wt_txn_visible_all(session, version_cursor->upd_stop_txnid,
+                  version_cursor->curversion_durable_stop_ts));
+            break;
+        }
+    }
+
+    return (next_upd);
+}
+
+/*
  * __curversion_next_single_key --
  *     Iterate the updates of a single key.
  */
@@ -271,7 +318,7 @@ __curversion_next_single_key(WT_CURSOR *cursor)
     WT_PAGE *page;
     WT_SESSION_IMPL *session;
     WT_TIME_WINDOW *twp;
-    WT_UPDATE *first_globally_visible, *next_upd, *tombstone, *upd;
+    WT_UPDATE *next_upd, *tombstone, *upd;
     wt_timestamp_t durable_start_ts, durable_stop_ts, stop_prepare_ts, stop_ts;
     size_t max_memsize;
     uint64_t hs_upd_type, raw, stop_prepared_id, stop_txn;
@@ -285,7 +332,7 @@ __curversion_next_single_key(WT_CURSOR *cursor)
     cbt = (WT_CURSOR_BTREE *)file_cursor;
     twp = NULL;
     upd_found = false;
-    first_globally_visible = tombstone = upd = NULL;
+    tombstone = upd = NULL;
 
     /* Temporarily clear the raw flag. We need to pack the data according to the format. */
     raw = F_MASK(cursor, WT_CURSTD_RAW);
@@ -355,38 +402,7 @@ __curversion_next_single_key(WT_CURSOR *cursor)
 
                 upd_found = true;
 
-                /* Walk to the next non-obsolete update. */
-                for (next_upd = upd; next_upd != NULL; next_upd = next_upd->next) {
-                    /* Skip aborted updates unless showing prepared rollbacks. */
-                    if (next_upd->txnid == WT_TXN_ABORTED &&
-                      (!F_ISSET(version_cursor, WT_CURVERSION_SHOW_PREPARED_ROLLBACK) ||
-                        !__curversion_is_prepare_rollback_update(next_upd)))
-                        continue;
-
-                    if (first_globally_visible != NULL) {
-                        next_upd = NULL;
-                        break;
-                    }
-
-                    /* We have traversed all the non-obsolete updates. */
-                    if ((F_ISSET(version_cursor, WT_CURVERSION_TIMESTAMP_ORDER) ||
-                          WT_UPDATE_DATA_VALUE(next_upd)) &&
-                      __wt_txn_upd_visible_all(session, next_upd))
-                        first_globally_visible = next_upd;
-
-                    if (next_upd != upd) {
-                        /*
-                         * If we are here, the previous update is not globally visible. We need
-                         * snapshot isolation and have pinned the global timestamp when we start the
-                         * version cursor. Aborted updates are never globally visible.
-                         */
-                        WT_ASSERT(session,
-                          version_cursor->upd_stop_txnid == WT_TXN_ABORTED ||
-                            !__wt_txn_visible_all(session, version_cursor->upd_stop_txnid,
-                              version_cursor->curversion_durable_stop_ts));
-                        break;
-                    }
-                }
+                next_upd = __curversion_walk_to_next_update(session, version_cursor, upd);
                 version_cursor->next_upd = next_upd;
                 if (next_upd == NULL)
                     F_SET(version_cursor, WT_CURVERSION_UPDATE_EXHAUSTED);

--- a/test/format/format_config_def.c
+++ b/test/format/format_config_def.c
@@ -287,8 +287,6 @@ CONFIG configuration_list[] = {{"assert.read_timestamp", "assert read_timestamp"
   {"ops.pct.write", "update operations (percentage)", C_IGNORE | C_TABLE, 0, 0, 100,
     V_TABLE_OPS_PCT_WRITE},
 
-  {"ops.bound_cursor", "configure bound cursor reads", C_BOOL, 5, 0, 0, V_GLOBAL_OPS_BOUND_CURSOR},
-
   {"ops.prepare", "configure transaction prepare", C_BOOL, 5, 0, 0, V_GLOBAL_OPS_PREPARE},
 
   {"ops.reserve", "cursor reserve operations (percentage)", 0, 0, 20, 100, V_GLOBAL_OPS_RESERVE},

--- a/test/format/format_config_def.c
+++ b/test/format/format_config_def.c
@@ -287,6 +287,8 @@ CONFIG configuration_list[] = {{"assert.read_timestamp", "assert read_timestamp"
   {"ops.pct.write", "update operations (percentage)", C_IGNORE | C_TABLE, 0, 0, 100,
     V_TABLE_OPS_PCT_WRITE},
 
+  {"ops.bound_cursor", "configure bound cursor reads", C_BOOL, 5, 0, 0, V_GLOBAL_OPS_BOUND_CURSOR},
+
   {"ops.prepare", "configure transaction prepare", C_BOOL, 5, 0, 0, V_GLOBAL_OPS_PREPARE},
 
   {"ops.reserve", "cursor reserve operations (percentage)", 0, 0, 20, 100, V_GLOBAL_OPS_RESERVE},


### PR DESCRIPTION
## [WT-17475](https://jira.mongodb.org/browse/WT-17475) Refactor `__curversion_next_single_key` to reduce complexity

### What and why

`__curversion_next_single_key` in `src/cursor/cur_version.c` had a cyclomatic complexity of **107**. The function iterated the update chain, the on-disk page image, and the history store inside a single 400-line body threaded together with `goto done` / `goto skip_on_page` jumps, duplicated stop-metadata assignments, and two near-identical `__curversion_set_value_with_format` calls (one for aborted, one for normal updates). The result was hard to review and impossible to test in isolation.

### How it was split

The refactor extracts **ten helper functions**, each well under 30 lines of complexity:

| Helper | Responsibility |
|---|---|
| `__curversion_record_stop_time_point` | Write the just-returned update's txnid/timestamp fields into the `version_cursor` stop slots. Deduplicates four copies of the same block. |
| `__curversion_value_return_from_upd` | Pack the `WT_CURVERSION_METADATA_FORMAT` value for one in-memory update. Unifies the former aborted/normal split into a single call. |
| `__curversion_walk_to_next_update` | Walk the update chain past the just-returned entry to find the next non-obsolete update. |
| `__curversion_process_chain` | Orchestrate the three steps above for the in-memory update chain. Returns early via flag if the chain is exhausted or filtered by `start_timestamp`. |
| `__curversion_disk_skip_no_stop` | Decide whether to skip an on-disk record with no stop side under timestamp-order mode. |
| `__curversion_disk_check_with_stop` | Apply the timestamp-order filter to an on-disk record that has a stop side. |
| `__curversion_disk_finalize_prepared` | Resolve prepare-state and visibility decisions for an on-disk record, including the visible-only mode mutation of stop fields. |
| `__curversion_value_return_from_disk_image` | Pack metadata for the on-disk value and update the stop slots. |
| `__curversion_process_on_disk` | Orchestrate the on-disk phase: page-type guard, overflow-removed handling, filter helpers, and emit. |
| `__curversion_value_return_from_hs` | Pack metadata for a history-store record and update the stop slots. |
| `__curversion_process_hs` | Orchestrate the history-store phase: cursor positioning, modify reconstruction, deduplication loop, and emit. |

`__curversion_next_single_key` itself is now a thin coordinator (~20 lines) that validates position, reads the page, then calls `__curversion_process_chain` → `__curversion_process_on_disk` → `__curversion_process_hs` in sequence, short-circuiting via a `done` flag. All `goto` jumps are eliminated; control flow uses early `return` inside each helper.

### Evergreen patch

[6a015a730fc3ea0007393ce3](https://spruce.corp.mongodb.com/version/6a015a730fc3ea0007393ce3) — all failures triaged as **unrelated**.