### PR TITLE
WT-11393 Move connection locks under a separate structure

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -352,6 +352,7 @@ OVFL
 ObWgfvgw
 Og
 Optane
+Optrack
 Outfmt
 PALI
 PALite

--- a/src/block/block_open.c
+++ b/src/block/block_open.c
@@ -188,12 +188,12 @@ __wt_block_open(WT_SESSION_IMPL *session, const char *filename, uint32_t objecti
     /* Block objects can be shared (although there can be only one writer). */
     hash = __wt_hash_city64(filename, strlen(filename));
     bucket = hash & (conn->hash_size - 1);
-    __wt_spin_lock(session, &conn->block_lock);
+    __wt_spin_lock(session, &conn->locks.block_lock);
     TAILQ_FOREACH (block, &conn->blockhash[bucket], hashq)
         if (block->objectid == objectid && strcmp(filename, block->name) == 0) {
             ++block->ref;
             *blockp = block;
-            __wt_spin_unlock(session, &conn->block_lock);
+            __wt_spin_unlock(session, &conn->locks.block_lock);
             return (0);
         }
 
@@ -279,13 +279,13 @@ __wt_block_open(WT_SESSION_IMPL *session, const char *filename, uint32_t objecti
     /* Block is valid, so make it visible in the connection. */
     WT_CONN_BLOCK_INSERT(conn, block, bucket);
 
-    __wt_spin_unlock(session, &conn->block_lock);
+    __wt_spin_unlock(session, &conn->locks.block_lock);
 
     *blockp = block;
     return (0);
 
 err:
-    __wt_spin_unlock(session, &conn->block_lock);
+    __wt_spin_unlock(session, &conn->locks.block_lock);
     WT_TRET(__wt_block_close(session, block));
 
     return (ret);

--- a/src/block_cache/block_cache.c
+++ b/src/block_cache/block_cache.c
@@ -315,14 +315,14 @@ __blkcache_estimate_filesize(WT_SESSION_IMPL *session)
     blkcache->refs_since_filesize_estimated = 0;
 
     size = 0;
-    __wt_spin_lock(session, &conn->block_lock);
+    __wt_spin_lock(session, &conn->locks.block_lock);
     for (bucket = 0; bucket < conn->hash_size; bucket++) {
         TAILQ_FOREACH (block, &conn->blockhash[bucket], hashq) {
             size += (size_t)block->size;
         }
     }
     blkcache->estimated_file_size = size;
-    __wt_spin_unlock(session, &conn->block_lock);
+    __wt_spin_unlock(session, &conn->locks.block_lock);
 
     WT_STAT_CONN_SET(session, block_cache_bypass_filesize, blkcache->estimated_file_size);
 

--- a/src/block_cache/block_mgr.c
+++ b/src/block_cache/block_mgr.c
@@ -23,9 +23,9 @@ __wti_bm_close_block(WT_SESSION_IMPL *session, WT_BLOCK *block)
     __wt_verbose(session, WT_VERB_BLKCACHE, "block close: %s", block->name);
 
     conn = S2C(session);
-    __wt_spin_lock(session, &conn->block_lock);
+    __wt_spin_lock(session, &conn->locks.block_lock);
     if (block->ref > 0 && --block->ref > 0) {
-        __wt_spin_unlock(session, &conn->block_lock);
+        __wt_spin_unlock(session, &conn->locks.block_lock);
         return (0);
     }
 
@@ -33,7 +33,7 @@ __wti_bm_close_block(WT_SESSION_IMPL *session, WT_BLOCK *block)
     hash = __wt_hash_city64(block->name, strlen(block->name));
     bucket = hash & (conn->hash_size - 1);
     WT_CONN_BLOCK_REMOVE(conn, block, bucket);
-    __wt_spin_unlock(session, &conn->block_lock);
+    __wt_spin_unlock(session, &conn->locks.block_lock);
 
     /* You can't close files during a checkpoint. */
     WT_ASSERT(
@@ -676,7 +676,7 @@ __bm_switch_object(WT_BM *bm, WT_SESSION_IMPL *session, uint32_t objectid)
     size_t root_addr_size;
 
     /* The checkpoint lock protects against concurrent switches */
-    WT_ASSERT_SPINLOCK_OWNED(session, &S2C(session)->checkpoint_lock)
+    WT_ASSERT_SPINLOCK_OWNED(session, &S2C(session)->locks.checkpoint_lock)
     WT_ASSERT(session, bm->is_multi_handle);
 
     current = bm->block;

--- a/src/block_cache/block_tier.c
+++ b/src/block_cache/block_tier.c
@@ -54,7 +54,7 @@ __wti_blkcache_tiered_open(
          */
         WT_ASSERT(session,
           !F_ISSET(session->dhandle, WT_DHANDLE_OPEN) ||
-            __wt_spin_owned(session, &S2C(session)->checkpoint_lock));
+            __wt_spin_owned(session, &S2C(session)->locks.checkpoint_lock));
         local_only = true;
         object_uri = tiered->tiers[WT_TIERED_INDEX_LOCAL].name;
         object_name = object_uri;

--- a/src/block_disagg/block_disagg_ckpt.c
+++ b/src/block_disagg/block_disagg_ckpt.c
@@ -145,7 +145,7 @@ __block_disagg_checkpoint_resolve(WT_BM *bm, WT_SESSION_IMPL *session, bool fail
      * related to the given shared table, e.g., the various file, colgroup, table, and layered
      * entries.
      */
-    WT_ASSERT_SPINLOCK_OWNED(session, &conn->schema_lock);
+    WT_ASSERT_SPINLOCK_OWNED(session, &conn->locks.schema_lock);
 
     if (failed)
         return (0);

--- a/src/block_disagg/block_disagg_open.c
+++ b/src/block_disagg/block_disagg_open.c
@@ -87,13 +87,13 @@ __wti_block_disagg_open(WT_SESSION_IMPL *session, const char *filename, const ch
     conn = S2C(session);
     hash = __wt_hash_city64(filename, strlen(filename));
     bucket = hash & (conn->hash_size - 1);
-    __wt_spin_lock(session, &conn->block_lock);
+    __wt_spin_lock(session, &conn->locks.block_lock);
     TAILQ_FOREACH (block, &conn->blockhash[bucket], hashq) {
         /* TODO: Should check to make sure this is the right type of block */
         if (strcmp(filename, block->name) == 0) {
             ++block->ref;
             *blockp = block;
-            __wt_spin_unlock(session, &conn->block_lock);
+            __wt_spin_unlock(session, &conn->locks.block_lock);
             return (0);
         }
     }
@@ -122,13 +122,13 @@ __wti_block_disagg_open(WT_SESSION_IMPL *session, const char *filename, const ch
     WT_ASSERT_ALWAYS(session, block_disagg->plhandle != NULL, "disagg tables need a page log");
 
     *blockp = (WT_BLOCK *)block_disagg;
-    __wt_spin_unlock(session, &conn->block_lock);
+    __wt_spin_unlock(session, &conn->locks.block_lock);
     return (0);
 
 err:
     if (block_disagg != NULL)
         WT_TRET(__block_disagg_destroy(session, block_disagg));
-    __wt_spin_unlock(session, &conn->block_lock);
+    __wt_spin_unlock(session, &conn->locks.block_lock);
     return (ret);
 }
 
@@ -150,13 +150,13 @@ __wti_block_disagg_close(WT_SESSION_IMPL *session, WT_BLOCK_DISAGG *block_disagg
     __wt_verbose(session, WT_VERB_BLOCK, "close: %s (table_id: %" PRIu64 ")",
       block_disagg->name == NULL ? "" : block_disagg->name, block_disagg->tableid);
 
-    __wt_spin_lock(session, &conn->block_lock);
+    __wt_spin_lock(session, &conn->locks.block_lock);
 
     /* Reference count is initialized to 1. */
     if (block_disagg->ref == 0 || --block_disagg->ref == 0)
         ret = __block_disagg_destroy(session, block_disagg);
 
-    __wt_spin_unlock(session, &conn->block_lock);
+    __wt_spin_unlock(session, &conn->locks.block_lock);
 
     return (ret);
 }

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -395,8 +395,8 @@ __wt_verify(WT_SESSION_IMPL *session, const char *cfg[])
     const char *name;
     bool bm_start, quit, skip_hs;
 
-    WT_ASSERT_SPINLOCK_OWNED(session, &S2C(session)->checkpoint_lock);
-    WT_ASSERT_SPINLOCK_OWNED(session, &S2C(session)->schema_lock);
+    WT_ASSERT_SPINLOCK_OWNED(session, &S2C(session)->locks.checkpoint_lock);
+    WT_ASSERT_SPINLOCK_OWNED(session, &S2C(session)->locks.schema_lock);
 
     btree = S2BT(session);
     bm = btree->bm;

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -119,7 +119,7 @@ __checkpoint_flush_tier(WT_SESSION_IMPL *session, bool force)
     cursor = NULL;
     release = false;
 
-    WT_ASSERT_SPINLOCK_OWNED(session, &conn->schema_lock);
+    WT_ASSERT_SPINLOCK_OWNED(session, &conn->locks.schema_lock);
     WT_ASSERT(session, FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_CHECKPOINT));
 
     /*
@@ -980,7 +980,7 @@ __checkpoint_prepare(WT_SESSION_IMPL *session, bool *trackingp, WT_CHECKPOINT_DB
 
     API_CONF(session, WT_SESSION, begin_transaction, "isolation=snapshot", txn_conf);
 
-    WT_ASSERT_SPINLOCK_OWNED(session, &conn->schema_lock);
+    WT_ASSERT_SPINLOCK_OWNED(session, &conn->locks.schema_lock);
 
     if (F_ISSET(conn, WT_CONN_PRECISE_CHECKPOINT)) {
         /* Precise checkpoint doesn't support non-timestamped checkpoint. */
@@ -1574,7 +1574,7 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
     tracking = false;
 
     WT_STAT_CONN_SET(session, checkpoint_state, WTI_CHECKPOINT_STATE_ESTABLISH);
-    WT_ASSERT_SPINLOCK_OWNED(session, &conn->checkpoint_lock);
+    WT_ASSERT_SPINLOCK_OWNED(session, &conn->locks.checkpoint_lock);
 
     WT_RET(__checkpoint_parse_config(session, cfg, &ckpt_cfg));
 
@@ -1954,7 +1954,7 @@ __checkpoint_db_wrapper(WT_SESSION_IMPL *session, const char *cfg[])
     conn = S2C(session);
     txn_global = &conn->txn_global;
 
-    WT_ASSERT_SPINLOCK_OWNED(session, &conn->checkpoint_lock);
+    WT_ASSERT_SPINLOCK_OWNED(session, &conn->locks.checkpoint_lock);
 
     __wt_atomic_store_bool_v_release(&txn_global->checkpoint_running, true);
 

--- a/src/config/config_api.c
+++ b/src/config/config_api.c
@@ -338,7 +338,7 @@ __wt_configure_method(WT_SESSION_IMPL *session, const char *method, const char *
      * configuration information. We're holding the lock for an extended period of time, but
      * configuration changes should be rare and only happen during startup.
      */
-    __wt_spin_lock(session, &conn->api_lock);
+    __wt_spin_lock(session, &conn->locks.api_lock);
 
     /*
      * Allocate new configuration entry and fill it in.
@@ -431,6 +431,6 @@ err:
         __wt_free(session, newcheck_name);
     }
 
-    __wt_spin_unlock(session, &conn->api_lock);
+    __wt_spin_unlock(session, &conn->locks.api_lock);
     return (ret);
 }

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -137,10 +137,10 @@ __conn_add_collator(
     WT_ERR(__wt_strdup(session, name, &ncoll->name));
     ncoll->collator = collator;
 
-    __wt_spin_lock(session, &conn->api_lock);
+    __wt_spin_lock(session, &conn->locks.api_lock);
     TAILQ_INSERT_TAIL(&conn->collqh, ncoll, q);
     ncoll = NULL;
-    __wt_spin_unlock(session, &conn->api_lock);
+    __wt_spin_unlock(session, &conn->locks.api_lock);
 
 err:
     if (ncoll != NULL) {
@@ -238,10 +238,10 @@ __conn_add_compressor(
     WT_ERR(__wt_strdup(session, name, &ncomp->name));
     ncomp->compressor = compressor;
 
-    __wt_spin_lock(session, &conn->api_lock);
+    __wt_spin_lock(session, &conn->locks.api_lock);
     TAILQ_INSERT_TAIL(&conn->compqh, ncomp, q);
     ncomp = NULL;
-    __wt_spin_unlock(session, &conn->api_lock);
+    __wt_spin_unlock(session, &conn->locks.api_lock);
 
 err:
     if (ncomp != NULL) {
@@ -303,10 +303,10 @@ __conn_add_data_source(
     ndsrc->dsrc = dsrc;
 
     /* Link onto the environment's list of data sources. */
-    __wt_spin_lock(session, &conn->api_lock);
+    __wt_spin_lock(session, &conn->locks.api_lock);
     TAILQ_INSERT_TAIL(&conn->dsrcqh, ndsrc, q);
     ndsrc = NULL;
-    __wt_spin_unlock(session, &conn->api_lock);
+    __wt_spin_unlock(session, &conn->locks.api_lock);
 
 err:
     if (ndsrc != NULL) {
@@ -392,7 +392,7 @@ __wt_encryptor_config(WT_SESSION_IMPL *session, WT_CONFIG_ITEM *cval, WT_CONFIG_
     kenc = NULL;
     conn = S2C(session);
 
-    __wt_spin_lock(session, &conn->encryptor_lock);
+    __wt_spin_lock(session, &conn->locks.encryptor_lock);
 
     WT_ERR(__encryptor_confchk(session, cval, &nenc));
     if (nenc == NULL) {
@@ -430,7 +430,7 @@ __wt_encryptor_config(WT_SESSION_IMPL *session, WT_CONFIG_ITEM *cval, WT_CONFIG_
     TAILQ_INSERT_HEAD(&nenc->keyedhashqh[bucket], kenc, hashq);
 
 out:
-    __wt_spin_unlock(session, &conn->encryptor_lock);
+    __wt_spin_unlock(session, &conn->locks.encryptor_lock);
     *kencryptorp = kenc;
     return (0);
 
@@ -439,7 +439,7 @@ err:
         __wt_free(session, kenc->keyid);
         __wt_free(session, kenc);
     }
-    __wt_spin_unlock(session, &conn->encryptor_lock);
+    __wt_spin_unlock(session, &conn->locks.encryptor_lock);
     return (ret);
 }
 
@@ -559,10 +559,10 @@ __conn_add_page_log(
     WT_ERR(__wt_calloc_one(session, &npl));
     WT_ERR(__wt_strdup(session, name, &npl->name));
     npl->page_log = page_log;
-    __wt_spin_lock(session, &conn->api_lock);
+    __wt_spin_lock(session, &conn->locks.api_lock);
     TAILQ_INSERT_TAIL(&conn->pagelogqh, npl, q);
     npl = NULL;
-    __wt_spin_unlock(session, &conn->api_lock);
+    __wt_spin_unlock(session, &conn->locks.api_lock);
 
 err:
     if (npl != NULL) {
@@ -682,10 +682,10 @@ __conn_add_storage_source(
     for (i = 0; i < conn->hash_size; i++)
         TAILQ_INIT(&nstorage->buckethashqh[i]);
 
-    __wt_spin_lock(session, &conn->api_lock);
+    __wt_spin_lock(session, &conn->locks.api_lock);
     TAILQ_INSERT_TAIL(&conn->storagesrcqh, nstorage, q);
     nstorage = NULL;
-    __wt_spin_unlock(session, &conn->api_lock);
+    __wt_spin_unlock(session, &conn->locks.api_lock);
 
 err:
     if (nstorage != NULL) {
@@ -974,9 +974,9 @@ __conn_load_extension_int(
     WT_ERR(load(&S2C(session)->iface, (WT_CONFIG_ARG *)ext_cfg));
 
     /* Link onto the environment's list of open libraries. */
-    __wt_spin_lock(session, &S2C(session)->api_lock);
+    __wt_spin_lock(session, &S2C(session)->locks.api_lock);
     TAILQ_INSERT_TAIL(&S2C(session)->dlhqh, dlh, q);
-    __wt_spin_unlock(session, &S2C(session)->api_lock);
+    __wt_spin_unlock(session, &S2C(session)->locks.api_lock);
     dlh = NULL;
 
 err:

--- a/src/conn/conn_handle.c
+++ b/src/conn/conn_handle.c
@@ -64,7 +64,7 @@ __wti_connection_init(WT_CONNECTION_IMPL *conn)
     /* Read-write locks */
     WT_RET(__wt_rwlock_init(session, &conn->log_mgr.debug_log_retention_lock));
     WT_RWLOCK_INIT_SESSION_TRACKED(session, &conn->locks.dhandle_lock, dhandle);
-    WT_RET(__wt_rwlock_init(session, &conn->hot_backup_lock));
+    WT_RET(__wt_rwlock_init(session, &conn->locks.hot_backup_lock));
     WT_RWLOCK_INIT_TRACKED(session, &conn->locks.table_lock, table);
 
     /* Initialize the generation manager. */
@@ -118,7 +118,7 @@ __wti_connection_destroy(WT_CONNECTION_IMPL *conn)
     __wt_spin_destroy(session, &conn->locks.encryptor_lock);
     __wt_spin_destroy(session, &conn->locks.fh_lock);
     __wt_spin_destroy(session, &conn->locks.flush_tier_lock);
-    __wt_rwlock_destroy(session, &conn->hot_backup_lock);
+    __wt_rwlock_destroy(session, &conn->locks.hot_backup_lock);
     __wt_spin_destroy(session, &conn->locks.metadata_lock);
     __wt_spin_destroy(session, &conn->locks.reconfig_lock);
     __wt_spin_destroy(session, &conn->locks.schema_lock);

--- a/src/conn/conn_handle.c
+++ b/src/conn/conn_handle.c
@@ -45,27 +45,27 @@ __wti_connection_init(WT_CONNECTION_IMPL *conn)
     WT_RET(__wt_stat_connection_init(session, conn));
 
     /* Spinlocks. */
-    WT_RET(__wt_spin_init(session, &conn->api_lock, "api"));
-    WT_SPIN_INIT_TRACKED(session, &conn->checkpoint_lock, checkpoint);
+    WT_RET(__wt_spin_init(session, &conn->locks.api_lock, "api"));
+    WT_SPIN_INIT_TRACKED(session, &conn->locks.checkpoint_lock, checkpoint);
     WT_RET(__wt_spin_init(session, &conn->background_compact.lock, "background compact"));
     WT_RET(__wt_spin_init(
       session, &conn->disaggregated_storage.shared_metadata_queue_lock, "update shared metadata"));
-    WT_RET(__wt_spin_init(session, &conn->encryptor_lock, "encryptor"));
-    WT_RET(__wt_spin_init(session, &conn->fh_lock, "file list"));
-    WT_RET(__wt_spin_init(session, &conn->flush_tier_lock, "flush tier"));
-    WT_SPIN_INIT_TRACKED(session, &conn->metadata_lock, metadata);
-    WT_RET(__wt_spin_init(session, &conn->reconfig_lock, "reconfigure"));
-    WT_SPIN_INIT_SESSION_TRACKED(session, &conn->schema_lock, schema);
-    WT_RET(__wt_spin_init(session, &conn->storage_lock, "tiered storage"));
-    WT_RET(__wt_spin_init(session, &conn->tiered_lock, "tiered work unit list"));
-    WT_RET(__wt_spin_init(session, &conn->turtle_lock, "turtle file"));
-    WT_RET(__wt_spin_init(session, &conn->prefetch_lock, "prefetch"));
+    WT_RET(__wt_spin_init(session, &conn->locks.encryptor_lock, "encryptor"));
+    WT_RET(__wt_spin_init(session, &conn->locks.fh_lock, "file list"));
+    WT_RET(__wt_spin_init(session, &conn->locks.flush_tier_lock, "flush tier"));
+    WT_SPIN_INIT_TRACKED(session, &conn->locks.metadata_lock, metadata);
+    WT_RET(__wt_spin_init(session, &conn->locks.reconfig_lock, "reconfigure"));
+    WT_SPIN_INIT_SESSION_TRACKED(session, &conn->locks.schema_lock, schema);
+    WT_RET(__wt_spin_init(session, &conn->locks.storage_lock, "tiered storage"));
+    WT_RET(__wt_spin_init(session, &conn->locks.tiered_lock, "tiered work unit list"));
+    WT_RET(__wt_spin_init(session, &conn->locks.turtle_lock, "turtle file"));
+    WT_RET(__wt_spin_init(session, &conn->locks.prefetch_lock, "prefetch"));
 
     /* Read-write locks */
     WT_RET(__wt_rwlock_init(session, &conn->log_mgr.debug_log_retention_lock));
-    WT_RWLOCK_INIT_SESSION_TRACKED(session, &conn->dhandle_lock, dhandle);
+    WT_RWLOCK_INIT_SESSION_TRACKED(session, &conn->locks.dhandle_lock, dhandle);
     WT_RET(__wt_rwlock_init(session, &conn->hot_backup_lock));
-    WT_RWLOCK_INIT_TRACKED(session, &conn->table_lock, table);
+    WT_RWLOCK_INIT_TRACKED(session, &conn->locks.table_lock, table);
 
     /* Initialize the generation manager. */
     __wt_gen_init(session);
@@ -74,7 +74,7 @@ __wti_connection_init(WT_CONNECTION_IMPL *conn)
      * Block manager. XXX If there's ever a second block manager, we'll want to make this more
      * opaque, but for now this is simpler.
      */
-    WT_RET(__wt_spin_init(session, &conn->block_lock, "block manager"));
+    WT_RET(__wt_spin_init(session, &conn->locks.block_lock, "block manager"));
     TAILQ_INIT(&conn->blockqh); /* Block manager list */
 
     __wt_checkpoint_timer_stats_clear(session);
@@ -108,25 +108,25 @@ __wti_connection_destroy(WT_CONNECTION_IMPL *conn)
 
     __wt_conn_foc_discard(session); /* free-on-close */
 
-    __wt_spin_destroy(session, &conn->api_lock);
+    __wt_spin_destroy(session, &conn->locks.api_lock);
     __wt_spin_destroy(session, &conn->background_compact.lock);
-    __wt_spin_destroy(session, &conn->block_lock);
-    __wt_spin_destroy(session, &conn->checkpoint_lock);
+    __wt_spin_destroy(session, &conn->locks.block_lock);
+    __wt_spin_destroy(session, &conn->locks.checkpoint_lock);
     __wt_spin_destroy(session, &conn->disaggregated_storage.shared_metadata_queue_lock);
     __wt_rwlock_destroy(session, &conn->log_mgr.debug_log_retention_lock);
-    __wt_rwlock_destroy(session, &conn->dhandle_lock);
-    __wt_spin_destroy(session, &conn->encryptor_lock);
-    __wt_spin_destroy(session, &conn->fh_lock);
-    __wt_spin_destroy(session, &conn->flush_tier_lock);
+    __wt_rwlock_destroy(session, &conn->locks.dhandle_lock);
+    __wt_spin_destroy(session, &conn->locks.encryptor_lock);
+    __wt_spin_destroy(session, &conn->locks.fh_lock);
+    __wt_spin_destroy(session, &conn->locks.flush_tier_lock);
     __wt_rwlock_destroy(session, &conn->hot_backup_lock);
-    __wt_spin_destroy(session, &conn->metadata_lock);
-    __wt_spin_destroy(session, &conn->reconfig_lock);
-    __wt_spin_destroy(session, &conn->schema_lock);
-    __wt_spin_destroy(session, &conn->storage_lock);
-    __wt_rwlock_destroy(session, &conn->table_lock);
-    __wt_spin_destroy(session, &conn->tiered_lock);
-    __wt_spin_destroy(session, &conn->turtle_lock);
-    __wt_spin_destroy(session, &conn->prefetch_lock);
+    __wt_spin_destroy(session, &conn->locks.metadata_lock);
+    __wt_spin_destroy(session, &conn->locks.reconfig_lock);
+    __wt_spin_destroy(session, &conn->locks.schema_lock);
+    __wt_spin_destroy(session, &conn->locks.storage_lock);
+    __wt_rwlock_destroy(session, &conn->locks.table_lock);
+    __wt_spin_destroy(session, &conn->locks.tiered_lock);
+    __wt_spin_destroy(session, &conn->locks.turtle_lock);
+    __wt_spin_destroy(session, &conn->locks.prefetch_lock);
 
     /* Free allocated hash buckets. */
     __wt_free(session, conn->blockhash);

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -82,7 +82,7 @@ __layered_create_missing_stable_tables_helper(WT_SESSION_IMPL *session)
     cursor_check = cursor_scan = NULL;
     stable_uri = NULL;
 
-    WT_ASSERT_SPINLOCK_OWNED(session, &S2C(session)->schema_lock);
+    WT_ASSERT_SPINLOCK_OWNED(session, &S2C(session)->locks.schema_lock);
 
     WT_ERR(__wt_metadata_cursor(session, &cursor_check));
     WT_ERR(__wt_metadata_cursor(session, &cursor_scan));
@@ -297,7 +297,7 @@ __disagg_apply_checkpoint_meta(
     current_value_copy = layered_ingest_uri = cfg_ret = NULL;
     existing_tables = new_tables = new_ingest = 0;
 
-    WT_ASSERT_SPINLOCK_OWNED(session, &S2C(session)->schema_lock);
+    WT_ASSERT_SPINLOCK_OWNED(session, &S2C(session)->locks.schema_lock);
 
     __wt_timer_start(session, &apply_timer);
     __wt_verbose_debug1(session, WT_VERB_DISAGGREGATED_STORAGE,
@@ -464,7 +464,7 @@ __raise_next_file_id(WT_SESSION_IMPL *session, const WT_DISAGG_METADATA *metadat
 {
     WT_CONNECTION_IMPL *conn = S2C(session);
 
-    WT_ASSERT_SPINLOCK_OWNED(session, &conn->schema_lock);
+    WT_ASSERT_SPINLOCK_OWNED(session, &conn->locks.schema_lock);
 
     if (conn->next_file_id < metadata->largest_file_id)
         conn->next_file_id = metadata->largest_file_id;
@@ -540,7 +540,7 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPOINT
     WT_CLEAR(metadata);
     md_cursor = NULL;
 
-    WT_ASSERT_SPINLOCK_OWNED(session, &conn->checkpoint_lock);
+    WT_ASSERT_SPINLOCK_OWNED(session, &conn->locks.checkpoint_lock);
 
     /*
      * Reset the statistics tracked per checkpoint. Technically this isn't a checkpoint but we
@@ -1017,7 +1017,7 @@ __wt_disagg_shared_metadata_queue_drop_size(WT_SESSION_IMPL *session, uint64_t *
     conn = S2C(session);
     *drop_sizep = 0;
 
-    WT_ASSERT_SPINLOCK_OWNED(session, &conn->schema_lock);
+    WT_ASSERT_SPINLOCK_OWNED(session, &conn->locks.schema_lock);
 
     __wt_spin_lock(session, &conn->disaggregated_storage.shared_metadata_queue_lock);
 
@@ -1058,7 +1058,7 @@ __wt_disagg_shared_metadata_queue_process(WT_SESSION_IMPL *session)
      * related to the given shared table, e.g., the various file, colgroup, table, and layered
      * entries.
      */
-    WT_ASSERT_SPINLOCK_OWNED(session, &conn->schema_lock);
+    WT_ASSERT_SPINLOCK_OWNED(session, &conn->locks.schema_lock);
 
     __wt_spin_lock(session, &conn->disaggregated_storage.shared_metadata_queue_lock);
 
@@ -1170,7 +1170,7 @@ __disagg_abandon_checkpoint(WT_SESSION_IMPL *session)
     conn = S2C(session);
     disagg = &conn->disaggregated_storage;
 
-    WT_ASSERT_SPINLOCK_OWNED(session, &conn->checkpoint_lock);
+    WT_ASSERT_SPINLOCK_OWNED(session, &conn->locks.checkpoint_lock);
 
     /* Only the leader can abandon a checkpoint. */
     if (disagg->npage_log == NULL || !conn->layered_table_manager.leader)
@@ -1216,7 +1216,7 @@ __disagg_begin_checkpoint(WT_SESSION_IMPL *session)
     conn = S2C(session);
     disagg = &conn->disaggregated_storage;
 
-    WT_ASSERT_SPINLOCK_OWNED(session, &conn->checkpoint_lock);
+    WT_ASSERT_SPINLOCK_OWNED(session, &conn->locks.checkpoint_lock);
 
     /* Only the leader can begin a global checkpoint. */
     if (disagg->npage_log == NULL || !conn->layered_table_manager.leader)
@@ -1249,7 +1249,7 @@ __disagg_restart_checkpoint(WT_SESSION_IMPL *session)
 {
     WT_DECL_RET;
 
-    WT_ASSERT_SPINLOCK_OWNED(session, &S2C(session)->checkpoint_lock);
+    WT_ASSERT_SPINLOCK_OWNED(session, &S2C(session)->locks.checkpoint_lock);
 
     WT_ERR_MSG_CHK(
       session, __disagg_abandon_checkpoint(session), "Failed to abandon the incomplete checkpoint");
@@ -1283,7 +1283,7 @@ __disagg_step_up(WT_SESSION_IMPL *session)
      * concurrently with a checkpoint, it would do only a part of the work required for the new
      * role, leaving the database in an inconsistent state.
      */
-    WT_ASSERT_SPINLOCK_OWNED(session, &conn->checkpoint_lock);
+    WT_ASSERT_SPINLOCK_OWNED(session, &conn->locks.checkpoint_lock);
 
     __wt_verbose_debug1(
       session, WT_VERB_DISAGGREGATED_STORAGE, "%s", "Stepping up to the leader mode");
@@ -1373,7 +1373,7 @@ __disagg_mark_btrees_readonly_then_step_down(WT_SESSION_IMPL *session)
 static void
 __disagg_step_down(WT_SESSION_IMPL *session)
 {
-    WT_ASSERT_SPINLOCK_OWNED(session, &S2C(session)->checkpoint_lock);
+    WT_ASSERT_SPINLOCK_OWNED(session, &S2C(session)->locks.checkpoint_lock);
 
     __wt_verbose_debug1(
       session, WT_VERB_DISAGGREGATED_STORAGE, "%s", "Stepping down to the follower mode");
@@ -1862,7 +1862,7 @@ __wt_disagg_advance_checkpoint(WT_SESSION_IMPL *session, bool ckpt_success)
     disagg = &conn->disaggregated_storage;
     WT_CLEAR(complete_args);
 
-    WT_ASSERT_SPINLOCK_OWNED(session, &conn->checkpoint_lock);
+    WT_ASSERT_SPINLOCK_OWNED(session, &conn->locks.checkpoint_lock);
 
     /* Only the leader can advance the global checkpoint. */
     if (disagg->npage_log == NULL || !conn->layered_table_manager.leader)

--- a/src/conn/conn_layered_page_log.c
+++ b/src/conn/conn_layered_page_log.c
@@ -27,7 +27,7 @@ __disagg_get_page(WT_SESSION_IMPL *session, WT_PAGE_LOG_HANDLE *page_log, uint64
     if (page_log == NULL)
         return (ENOTSUP);
 
-    WT_ASSERT_SPINLOCK_OWNED(session, &S2C(session)->checkpoint_lock);
+    WT_ASSERT_SPINLOCK_OWNED(session, &S2C(session)->locks.checkpoint_lock);
 
     WT_CLEAR(get_args);
     get_args.lsn = lsn;
@@ -71,7 +71,7 @@ __disagg_put_page(WT_SESSION_IMPL *session, WT_PAGE_LOG_HANDLE *page_log, uint64
     if (page_log == NULL)
         return (ENOTSUP);
 
-    WT_ASSERT_SPINLOCK_OWNED(session, &S2C(session)->checkpoint_lock);
+    WT_ASSERT_SPINLOCK_OWNED(session, &S2C(session)->locks.checkpoint_lock);
 
     WT_CLEAR(put_args);
 
@@ -227,7 +227,7 @@ __wti_disagg_load_crypt_key(WT_SESSION_IMPL *session, WT_DISAGG_METADATA *metada
     WT_CLEAR(crypt);
     WT_CLEAR(key_item);
 
-    WT_ASSERT_SPINLOCK_OWNED(session, &conn->checkpoint_lock);
+    WT_ASSERT_SPINLOCK_OWNED(session, &conn->locks.checkpoint_lock);
 
     /* No key provider configured. */
     if (key_provider == NULL)
@@ -418,7 +418,7 @@ __wt_disagg_put_crypt_helper(WT_SESSION_IMPL *session)
     WT_CLEAR(crypt.keys);
     lsn = 0;
 
-    WT_ASSERT_SPINLOCK_OWNED(session, &conn->checkpoint_lock);
+    WT_ASSERT_SPINLOCK_OWNED(session, &conn->locks.checkpoint_lock);
 
     if (session->ckpt.crash_trigger_point == KEY_PROVIDER_CRASH_BEFORE_KEY_ROTATION)
         __wt_debug_crash(session);
@@ -580,7 +580,7 @@ __wt_disagg_put_checkpoint_meta(WT_SESSION_IMPL *session, const char *checkpoint
     disagg = &conn->disaggregated_storage;
     lsn = 0;
 
-    WT_ASSERT_SPINLOCK_OWNED(session, &conn->checkpoint_lock);
+    WT_ASSERT_SPINLOCK_OWNED(session, &conn->locks.checkpoint_lock);
 
     if (checkpoint_root == NULL) {
         WT_ASSERT(session, checkpoint_root_size == 0);

--- a/src/conn/conn_prefetch.c
+++ b/src/conn/conn_prefetch.c
@@ -44,12 +44,12 @@ __prefetch_thread_run(WT_SESSION_IMPL *session, WT_THREAD *thread)
         /* Encourage races. */
         __wt_timing_stress(session, WT_TIMING_STRESS_PREFETCH_1, NULL);
 
-        __wt_spin_lock(session, &conn->prefetch_lock);
+        __wt_spin_lock(session, &conn->locks.prefetch_lock);
         pe = TAILQ_FIRST(&conn->pfqh);
 
         /* If there is no work for the thread to do - return back to the thread pool */
         if (pe == NULL) {
-            __wt_spin_unlock(session, &conn->prefetch_lock);
+            __wt_spin_unlock(session, &conn->locks.prefetch_lock);
             break;
         }
 
@@ -65,7 +65,7 @@ __prefetch_thread_run(WT_SESSION_IMPL *session, WT_THREAD *thread)
          */
         if (__wt_evict_clean_pressure(session)) {
             F_CLR_ATOMIC_8(pe->ref, WT_REF_FLAG_PREFETCH);
-            __wt_spin_unlock(session, &conn->prefetch_lock);
+            __wt_spin_unlock(session, &conn->locks.prefetch_lock);
             __wt_free(session, pe);
             continue;
         }
@@ -81,7 +81,7 @@ __prefetch_thread_run(WT_SESSION_IMPL *session, WT_THREAD *thread)
 
         WT_PREFETCH_ASSERT(
           session, F_ISSET_ATOMIC_8(pe->ref, WT_REF_FLAG_PREFETCH), prefetch_skipped_no_flag_set);
-        __wt_spin_unlock(session, &conn->prefetch_lock);
+        __wt_spin_unlock(session, &conn->locks.prefetch_lock);
 
         /*
          * It's a weird case, but if verify is utilizing prefetch and encounters a corrupted block,
@@ -181,7 +181,7 @@ __wt_conn_prefetch_queue_push(WT_SESSION_IMPL *session, WT_REF *ref)
     if (__wt_evict_clean_pressure(session))
         return (EBUSY);
 
-    __wt_spin_lock(session, &conn->prefetch_lock);
+    __wt_spin_lock(session, &conn->locks.prefetch_lock);
     /* Don't queue pages for trees that have eviction disabled. */
     if (S2BT(session)->evict_disabled > 0)
         WT_ERR(EBUSY);
@@ -219,7 +219,7 @@ __wt_conn_prefetch_queue_push(WT_SESSION_IMPL *session, WT_REF *ref)
     WT_REF_SET_STATE(ref, WT_REF_DISK);
     TAILQ_INSERT_TAIL(&conn->pfqh, pe, q);
     __wt_tsan_suppress_add_uint64(&conn->prefetch_queue_count, 1);
-    __wt_spin_unlock(session, &conn->prefetch_lock);
+    __wt_spin_unlock(session, &conn->locks.prefetch_lock);
     __wt_cond_signal(session, conn->prefetch_threads.wait_cond);
 
     return (0);
@@ -228,7 +228,7 @@ err:
     /* Unlock the ref. */
     WT_REF_SET_STATE(ref, WT_REF_DISK);
 done:
-    __wt_spin_unlock(session, &conn->prefetch_lock);
+    __wt_spin_unlock(session, &conn->locks.prefetch_lock);
     return (ret);
 }
 
@@ -250,7 +250,7 @@ __wt_conn_prefetch_clear_tree(WT_SESSION_IMPL *session, bool all)
     WT_ASSERT_ALWAYS(session, all || dhandle != NULL,
       "Pre-fetch needs to save a valid dhandle when clearing the queue for a btree");
 
-    __wt_spin_lock(session, &conn->prefetch_lock);
+    __wt_spin_lock(session, &conn->locks.prefetch_lock);
 
     /* Empty the queue of the relevant pages, or all of them if specified. */
     TAILQ_FOREACH_SAFE(pe, &conn->pfqh, q, pe_tmp)
@@ -271,7 +271,7 @@ __wt_conn_prefetch_clear_tree(WT_SESSION_IMPL *session, bool all)
      * important that the flag is checked after locking the prefetch queue lock. If not then threads
      * may not note that the tree is closed for prefetch.
      */
-    __wt_spin_unlock(session, &conn->prefetch_lock);
+    __wt_spin_unlock(session, &conn->locks.prefetch_lock);
 
     /*
      * If we are only clearing refs from a certain tree, wait for any other concurrent pre-fetch

--- a/src/conn/conn_reconfig.c
+++ b/src/conn/conn_reconfig.c
@@ -253,7 +253,7 @@ __wti_conn_optrack_setup(WT_SESSION_IMPL *session, const char *cfg[], bool recon
     WT_ERR(__wt_open(session, (const char *)buf->data, WT_FS_OPEN_FILE_TYPE_REGULAR,
       WT_FS_OPEN_CREATE, &conn->optrack_map_fh));
 
-    WT_ERR(__wt_spin_init(session, &conn->optrack_map_spinlock, "optrack map spinlock"));
+    WT_ERR(__wt_spin_init(session, &conn->locks.optrack_map_spinlock, "optrack map spinlock"));
 
     WT_ERR(__wt_malloc(session, WT_OPTRACK_BUFSIZE, &conn->dummy_session.optrack_buf));
 
@@ -284,7 +284,7 @@ __wti_conn_optrack_teardown(WT_SESSION_IMPL *session, bool reconfig)
     if (!F_ISSET_ATOMIC_32(conn, WT_CONN_OPTRACK))
         return (0);
 
-    __wt_spin_destroy(session, &conn->optrack_map_spinlock);
+    __wt_spin_destroy(session, &conn->locks.optrack_map_spinlock);
 
     WT_TRET(__wt_close(session, &conn->optrack_map_fh));
     __wt_free(session, conn->dummy_session.optrack_buf);
@@ -392,7 +392,7 @@ __wti_conn_reconfig(WT_SESSION_IMPL *session, const char **cfg)
     conn = S2C(session);
 
     /* Serialize reconfiguration. */
-    __wt_spin_lock(session, &conn->reconfig_lock);
+    __wt_spin_lock(session, &conn->locks.reconfig_lock);
 
     /*
      * The configuration argument has been checked for validity, update the previous connection
@@ -504,7 +504,7 @@ done:
     conn->cfg = p;
 
 err:
-    __wt_spin_unlock(session, &conn->reconfig_lock);
+    __wt_spin_unlock(session, &conn->locks.reconfig_lock);
 
     return (ret);
 }

--- a/src/conn/conn_tiered.c
+++ b/src/conn/conn_tiered.c
@@ -113,8 +113,8 @@ __tier_flush_meta(
     WT_RET(__wt_scr_alloc(session, 512, &buf));
     dhandle = &tiered->iface;
 
-    WT_ASSERT_SPINLOCK_OWNED(session, &conn->checkpoint_lock);
-    WT_ASSERT_SPINLOCK_OWNED(session, &conn->schema_lock);
+    WT_ASSERT_SPINLOCK_OWNED(session, &conn->locks.checkpoint_lock);
+    WT_ASSERT_SPINLOCK_OWNED(session, &conn->locks.schema_lock);
     WT_UNUSED(conn); /* Avoid "unused variable" warnings in non-debug builds. */
 
     newconfig = obj_value = NULL;

--- a/src/cursor/cur_backup.c
+++ b/src/cursor/cur_backup.c
@@ -562,8 +562,8 @@ __backup_config(WT_SESSION_IMPL *session, WT_CURSOR_BACKUP *cb, const char *cfg[
     is_dup = othercb != NULL;
 
     if (!is_dup) {
-        WT_ASSERT_SPINLOCK_OWNED(session, &conn->checkpoint_lock);
-        WT_ASSERT_SPINLOCK_OWNED(session, &conn->schema_lock);
+        WT_ASSERT_SPINLOCK_OWNED(session, &conn->locks.checkpoint_lock);
+        WT_ASSERT_SPINLOCK_OWNED(session, &conn->locks.schema_lock);
     }
 
     /*
@@ -765,8 +765,8 @@ __backup_start(
     is_dup = othercb != NULL;
 
     if (!is_dup) {
-        WT_ASSERT_SPINLOCK_OWNED(session, &conn->checkpoint_lock);
-        WT_ASSERT_SPINLOCK_OWNED(session, &conn->schema_lock);
+        WT_ASSERT_SPINLOCK_OWNED(session, &conn->locks.checkpoint_lock);
+        WT_ASSERT_SPINLOCK_OWNED(session, &conn->locks.schema_lock);
     }
 
     cb->next = 0;

--- a/src/evict/evict_lru.c
+++ b/src/evict/evict_lru.c
@@ -39,7 +39,7 @@ __evict_lock_handle_list(WT_SESSION_IMPL *session)
 
     conn = S2C(session);
     evict = conn->evict;
-    dh_lock = &conn->dhandle_lock;
+    dh_lock = &conn->locks.dhandle_lock;
 
     /*
      * Use a custom lock acquisition back off loop so the eviction server notices any interrupt
@@ -511,7 +511,7 @@ __evict_server(WT_SESSION_IMPL *session, bool *did_work)
              */
             ret = __evict_clear_all_walks_and_saved_tree(session);
 
-            __wt_readunlock(session, &conn->dhandle_lock);
+            __wt_readunlock(session, &conn->locks.dhandle_lock);
             WT_RET(ret);
         }
         /* Make sure we'll notice next time we're stuck. */
@@ -1644,7 +1644,7 @@ __evict_walk_choose_dhandle(WT_SESSION_IMPL *session, WT_DATA_HANDLE **dhandle_p
 
     conn = S2C(session);
 
-    WT_ASSERT(session, __wt_rwlock_islocked(session, &conn->dhandle_lock));
+    WT_ASSERT(session, __wt_rwlock_islocked(session, &conn->locks.dhandle_lock));
 
 #undef RANDOM_DH_SELECTION_ENABLED
 
@@ -1929,7 +1929,7 @@ retry:
         btree->evict_walk_skips = 0;
 
         __evict_set_saved_walk_tree(session, dhandle);
-        __wt_readunlock(session, &conn->dhandle_lock);
+        __wt_readunlock(session, &conn->locks.dhandle_lock);
         dhandle_list_locked = false;
 
         /*
@@ -1978,7 +1978,7 @@ retry:
 
 err:
     if (dhandle_list_locked)
-        __wt_readunlock(session, &conn->dhandle_lock);
+        __wt_readunlock(session, &conn->locks.dhandle_lock);
 
     /*
      * If we didn't find any entries on a walk when we weren't interrupted, let our caller know.

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -640,6 +640,30 @@ typedef enum __wt_conn_debug_disagg_address_cookie_upgrade {
 } WT_CONN_DEBUG_DISAGG_ADDRESS_COOKIE_UPGRADE;
 
 /*
+ * WT_CONN_LOCKS --
+ *	All connection-level spinlocks and read-write locks collected in one place.
+ */
+struct __wt_conn_locks {
+    WT_SPINLOCK api_lock;             /* Connection API spinlock */
+    WT_SPINLOCK block_lock;           /* Locked: block manager list */
+    WT_SPINLOCK checkpoint_lock;      /* Checkpoint spinlock */
+    WT_RWLOCK dhandle_lock;           /* Data handle list lock */
+    WT_SPINLOCK encryptor_lock;       /* Encryptor list lock */
+    WT_SPINLOCK fh_lock;              /* File handle queue spinlock */
+    WT_SPINLOCK flush_tier_lock;      /* Flush tier spinlock */
+    WT_SPINLOCK metadata_lock;        /* Metadata update spinlock */
+    WT_SPINLOCK optrack_map_spinlock; /* Optrack name-to-id translation file spinlock */
+    WT_SPINLOCK page_log_lock;        /* Page log list lock */
+    WT_SPINLOCK prefetch_lock;        /* Prefetch spinlock */
+    WT_SPINLOCK reconfig_lock;        /* Single thread reconfigure */
+    WT_SPINLOCK schema_lock;          /* Schema operation spinlock */
+    WT_SPINLOCK storage_lock;         /* Storage source list lock */
+    WT_RWLOCK table_lock;             /* Table list lock */
+    WT_SPINLOCK tiered_lock;          /* Tiered work queue spinlock */
+    WT_SPINLOCK turtle_lock;          /* Turtle file spinlock */
+};
+
+/*
  * WT_CONNECTION_IMPL --
  *	Implementation of WT_CONNECTION
  */
@@ -652,17 +676,7 @@ struct __wt_connection_impl {
 
     const char *cfg; /* Connection configuration */
 
-    WT_SPINLOCK api_lock;        /* Connection API spinlock */
-    WT_SPINLOCK checkpoint_lock; /* Checkpoint spinlock */
-    WT_SPINLOCK fh_lock;         /* File handle queue spinlock */
-    WT_SPINLOCK flush_tier_lock; /* Flush tier spinlock */
-    WT_SPINLOCK metadata_lock;   /* Metadata update spinlock */
-    WT_SPINLOCK reconfig_lock;   /* Single thread reconfigure */
-    WT_SPINLOCK schema_lock;     /* Schema operation spinlock */
-    WT_RWLOCK table_lock;        /* Table list lock */
-    WT_SPINLOCK tiered_lock;     /* Tiered work queue spinlock */
-    WT_SPINLOCK turtle_lock;     /* Turtle file spinlock */
-    WT_RWLOCK dhandle_lock;      /* Data handle list lock */
+    WT_CONN_LOCKS locks; /* All connection-level locks */
 
     /* Connection queue */
     TAILQ_ENTRY(__wt_connection_impl) q;
@@ -698,10 +712,9 @@ struct __wt_connection_impl {
 
     uint64_t operation_timeout_us; /* Maximum operation period before rollback */
 
-    const char *optrack_path;         /* Directory for operation logs */
-    WT_FH *optrack_map_fh;            /* Name to id translation file. */
-    WT_SPINLOCK optrack_map_spinlock; /* Translation file spinlock. */
-    uintmax_t optrack_pid;            /* Cache the process ID. */
+    const char *optrack_path; /* Directory for operation logs */
+    WT_FH *optrack_map_fh;    /* Name to id translation file. */
+    uintmax_t optrack_pid;    /* Cache the process ID. */
 
 #ifdef HAVE_CALL_LOG
     /* File stream used for writing to the call log. */
@@ -731,7 +744,6 @@ struct __wt_connection_impl {
     /* Locked: Tiered system work queue. */
     TAILQ_HEAD(__wt_tiered_qh, __wt_tiered_work_unit) tieredqh;
 
-    WT_SPINLOCK block_lock; /* Locked: block manager list */
     TAILQ_HEAD(__wt_blockhash, __wt_block) * blockhash;
     TAILQ_HEAD(__wt_block_qh, __wt_block) blockqh;
 
@@ -847,7 +859,6 @@ struct __wt_connection_impl {
 #define WT_MAX_PREFETCH_QUEUE 120
 #define WT_PREFETCH_QUEUE_PER_TRIGGER 30
 #define WT_PREFETCH_THREAD_COUNT 8
-    WT_SPINLOCK prefetch_lock;
     WT_THREAD_GROUP prefetch_threads;
     uint64_t prefetch_queue_count;
     /* Queue of refs to pre-fetch from */
@@ -925,15 +936,12 @@ struct __wt_connection_impl {
     TAILQ_HEAD(__wt_dsrc_qh, __wt_named_data_source) dsrcqh;
 
     /* Locked: encryptor list */
-    WT_SPINLOCK encryptor_lock; /* Encryptor list lock */
     TAILQ_HEAD(__wt_encrypt_qh, __wt_named_encryptor) encryptqh;
 
     /* Locked: page log list */
-    WT_SPINLOCK page_log_lock; /* Page log list lock */
     TAILQ_HEAD(__wt_page_log_qh, __wt_named_page_log) pagelogqh;
 
     /* Locked: storage source list */
-    WT_SPINLOCK storage_lock; /* Storage source list lock */
     TAILQ_HEAD(__wt_storage_source_qh, __wt_named_storage_source) storagesrcqh;
 
     void *lang_private; /* Language specific private storage */

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -649,6 +649,7 @@ struct __wt_conn_locks {
     WT_SPINLOCK checkpoint_lock;      /* Checkpoint spinlock */
     WT_RWLOCK dhandle_lock;           /* Data handle list lock */
     WT_SPINLOCK encryptor_lock;       /* Encryptor list lock */
+    WT_RWLOCK hot_backup_lock;        /* Hot backup serialization */
     WT_SPINLOCK fh_lock;              /* File handle queue spinlock */
     WT_SPINLOCK flush_tier_lock;      /* Flush tier spinlock */
     WT_SPINLOCK metadata_lock;        /* Metadata update spinlock */
@@ -791,7 +792,6 @@ struct __wt_connection_impl {
     uint64_t *recovery_ckpt_snapshot;
     uint32_t recovery_ckpt_snapshot_count;
 
-    WT_RWLOCK hot_backup_lock; /* Hot backup serialization */
     wt_shared uint64_t
       hot_backup_start; /* Clock value of most recent checkpoint needed by hot backup */
     wt_timestamp_t hot_backup_timestamp; /* Stable timestamp of checkpoint for the open backup */

--- a/src/include/meta.h
+++ b/src/include/meta.h
@@ -130,10 +130,11 @@
  * WT_WITH_TURTLE_LOCK --
  *	Acquire the turtle file lock, perform an operation, drop the lock.
  */
-#define WT_WITH_TURTLE_LOCK(session, op)                                                      \
-    do {                                                                                      \
-        WT_ASSERT(session, !FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_TURTLE));        \
-        WT_WITH_LOCK_WAIT(session, &S2C(session)->turtle_lock, WT_SESSION_LOCKED_TURTLE, op); \
+#define WT_WITH_TURTLE_LOCK(session, op)                                               \
+    do {                                                                               \
+        WT_ASSERT(session, !FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_TURTLE)); \
+        WT_WITH_LOCK_WAIT(                                                             \
+          session, &S2C(session)->locks.turtle_lock, WT_SESSION_LOCKED_TURTLE, op);    \
     } while (0)
 
 /*

--- a/src/include/schema.h
+++ b/src/include/schema.h
@@ -406,7 +406,7 @@ struct __wt_import_list {
                 op;                                                                            \
             }                                                                                  \
         } else {                                                                               \
-            __wt_readlock(session, &__conn->locks.hot_backup_lock);                                  \
+            __wt_readlock(session, &__conn->locks.hot_backup_lock);                            \
             FLD_SET(session->lock_flags, WT_SESSION_LOCKED_HOTBACKUP_READ);                    \
             if ((__wt_atomic_load_uint64_relaxed(&__conn->hot_backup_start) == 0) == bk_off) { \
                 if ((skipp) != (bool *)NULL)                                                   \
@@ -414,7 +414,7 @@ struct __wt_import_list {
                 op;                                                                            \
             }                                                                                  \
             FLD_CLR(session->lock_flags, WT_SESSION_LOCKED_HOTBACKUP_READ);                    \
-            __wt_readunlock(session, &__conn->locks.hot_backup_lock);                                \
+            __wt_readunlock(session, &__conn->locks.hot_backup_lock);                          \
         }                                                                                      \
     } while (0)
 
@@ -448,11 +448,11 @@ struct __wt_import_list {
         if (FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_HOTBACKUP)) {  \
             op;                                                             \
         } else {                                                            \
-            __wt_readlock(session, &__conn->locks.hot_backup_lock);               \
+            __wt_readlock(session, &__conn->locks.hot_backup_lock);         \
             FLD_SET(session->lock_flags, WT_SESSION_LOCKED_HOTBACKUP_READ); \
             op;                                                             \
             FLD_CLR(session->lock_flags, WT_SESSION_LOCKED_HOTBACKUP_READ); \
-            __wt_readunlock(session, &__conn->locks.hot_backup_lock);             \
+            __wt_readunlock(session, &__conn->locks.hot_backup_lock);       \
         }                                                                   \
     } while (0)
 
@@ -467,10 +467,10 @@ struct __wt_import_list {
             op;                                                                                    \
         } else {                                                                                   \
             WT_ASSERT(session, !FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_HOTBACKUP_READ)); \
-            __wt_writelock(session, &__conn->locks.hot_backup_lock);                                     \
+            __wt_writelock(session, &__conn->locks.hot_backup_lock);                               \
             FLD_SET(session->lock_flags, WT_SESSION_LOCKED_HOTBACKUP_WRITE);                       \
             op;                                                                                    \
             FLD_CLR(session->lock_flags, WT_SESSION_LOCKED_HOTBACKUP_WRITE);                       \
-            __wt_writeunlock(session, &__conn->locks.hot_backup_lock);                                   \
+            __wt_writeunlock(session, &__conn->locks.hot_backup_lock);                             \
         }                                                                                          \
     } while (0)

--- a/src/include/schema.h
+++ b/src/include/schema.h
@@ -406,7 +406,7 @@ struct __wt_import_list {
                 op;                                                                            \
             }                                                                                  \
         } else {                                                                               \
-            __wt_readlock(session, &__conn->hot_backup_lock);                                  \
+            __wt_readlock(session, &__conn->locks.hot_backup_lock);                                  \
             FLD_SET(session->lock_flags, WT_SESSION_LOCKED_HOTBACKUP_READ);                    \
             if ((__wt_atomic_load_uint64_relaxed(&__conn->hot_backup_start) == 0) == bk_off) { \
                 if ((skipp) != (bool *)NULL)                                                   \
@@ -414,7 +414,7 @@ struct __wt_import_list {
                 op;                                                                            \
             }                                                                                  \
             FLD_CLR(session->lock_flags, WT_SESSION_LOCKED_HOTBACKUP_READ);                    \
-            __wt_readunlock(session, &__conn->hot_backup_lock);                                \
+            __wt_readunlock(session, &__conn->locks.hot_backup_lock);                                \
         }                                                                                      \
     } while (0)
 
@@ -448,11 +448,11 @@ struct __wt_import_list {
         if (FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_HOTBACKUP)) {  \
             op;                                                             \
         } else {                                                            \
-            __wt_readlock(session, &__conn->hot_backup_lock);               \
+            __wt_readlock(session, &__conn->locks.hot_backup_lock);               \
             FLD_SET(session->lock_flags, WT_SESSION_LOCKED_HOTBACKUP_READ); \
             op;                                                             \
             FLD_CLR(session->lock_flags, WT_SESSION_LOCKED_HOTBACKUP_READ); \
-            __wt_readunlock(session, &__conn->hot_backup_lock);             \
+            __wt_readunlock(session, &__conn->locks.hot_backup_lock);             \
         }                                                                   \
     } while (0)
 
@@ -467,10 +467,10 @@ struct __wt_import_list {
             op;                                                                                    \
         } else {                                                                                   \
             WT_ASSERT(session, !FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_HOTBACKUP_READ)); \
-            __wt_writelock(session, &__conn->hot_backup_lock);                                     \
+            __wt_writelock(session, &__conn->locks.hot_backup_lock);                                     \
             FLD_SET(session->lock_flags, WT_SESSION_LOCKED_HOTBACKUP_WRITE);                       \
             op;                                                                                    \
             FLD_CLR(session->lock_flags, WT_SESSION_LOCKED_HOTBACKUP_WRITE);                       \
-            __wt_writeunlock(session, &__conn->hot_backup_lock);                                   \
+            __wt_writeunlock(session, &__conn->locks.hot_backup_lock);                                   \
         }                                                                                          \
     } while (0)

--- a/src/include/schema.h
+++ b/src/include/schema.h
@@ -218,21 +218,22 @@ struct __wt_import_list {
  *	Acquire the checkpoint lock, perform an operation, drop the lock.
  */
 #define WT_WITH_CHECKPOINT_LOCK(session, op) \
-    WT_WITH_LOCK_WAIT(session, &S2C(session)->checkpoint_lock, WT_SESSION_LOCKED_CHECKPOINT, op)
-#define WT_WITH_CHECKPOINT_LOCK_NOWAIT(session, ret, op)                                         \
-    do {                                                                                         \
-        int __checkpoint_lock_ret;                                                               \
-        WT_WITH_LOCK_NOWAIT(session, ret, __checkpoint_lock_ret, &S2C(session)->checkpoint_lock, \
-          WT_SESSION_LOCKED_CHECKPOINT, op);                                                     \
-        if (__checkpoint_lock_ret != 0) {                                                        \
-            if (__checkpoint_lock_ret == EBUSY)                                                  \
-                __wt_session_set_last_error(session, EBUSY, WT_CONFLICT_CHECKPOINT_LOCK,         \
-                  "another thread is currently holding the checkpoint lock");                    \
-            else                                                                                 \
-                __wt_session_set_last_error(session, __checkpoint_lock_ret, WT_NONE,             \
-                  "failed to acquire the checkpoint lock");                                      \
-            ret = __checkpoint_lock_ret;                                                         \
-        }                                                                                        \
+    WT_WITH_LOCK_WAIT(                       \
+      session, &S2C(session)->locks.checkpoint_lock, WT_SESSION_LOCKED_CHECKPOINT, op)
+#define WT_WITH_CHECKPOINT_LOCK_NOWAIT(session, ret, op)                                 \
+    do {                                                                                 \
+        int __checkpoint_lock_ret;                                                       \
+        WT_WITH_LOCK_NOWAIT(session, ret, __checkpoint_lock_ret,                         \
+          &S2C(session)->locks.checkpoint_lock, WT_SESSION_LOCKED_CHECKPOINT, op);       \
+        if (__checkpoint_lock_ret != 0) {                                                \
+            if (__checkpoint_lock_ret == EBUSY)                                          \
+                __wt_session_set_last_error(session, EBUSY, WT_CONFLICT_CHECKPOINT_LOCK, \
+                  "another thread is currently holding the checkpoint lock");            \
+            else                                                                         \
+                __wt_session_set_last_error(session, __checkpoint_lock_ret, WT_NONE,     \
+                  "failed to acquire the checkpoint lock");                              \
+            ret = __checkpoint_lock_ret;                                                 \
+        }                                                                                \
     } while (0)
 
 /*
@@ -250,11 +251,11 @@ struct __wt_import_list {
         if (FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_HANDLE_LIST)) {  \
             op;                                                               \
         } else {                                                              \
-            __wt_readlock(session, &S2C(session)->dhandle_lock);              \
+            __wt_readlock(session, &S2C(session)->locks.dhandle_lock);        \
             FLD_SET(session->lock_flags, WT_SESSION_LOCKED_HANDLE_LIST_READ); \
             op;                                                               \
             FLD_CLR(session->lock_flags, WT_SESSION_LOCKED_HANDLE_LIST_READ); \
-            __wt_readunlock(session, &S2C(session)->dhandle_lock);            \
+            __wt_readunlock(session, &S2C(session)->locks.dhandle_lock);      \
         }                                                                     \
     } while (0)
 
@@ -271,11 +272,11 @@ struct __wt_import_list {
         } else {                                                                             \
             WT_ASSERT(                                                                       \
               session, !FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_HANDLE_LIST_READ)); \
-            __wt_writelock(session, &S2C(session)->dhandle_lock);                            \
+            __wt_writelock(session, &S2C(session)->locks.dhandle_lock);                      \
             FLD_SET(session->lock_flags, WT_SESSION_LOCKED_HANDLE_LIST_WRITE);               \
             op;                                                                              \
             FLD_CLR(session->lock_flags, WT_SESSION_LOCKED_HANDLE_LIST_WRITE);               \
-            __wt_writeunlock(session, &S2C(session)->dhandle_lock);                          \
+            __wt_writeunlock(session, &S2C(session)->locks.dhandle_lock);                    \
         }                                                                                    \
     } while (0)
 
@@ -284,7 +285,7 @@ struct __wt_import_list {
  *	Acquire the metadata lock, perform an operation, drop the lock.
  */
 #define WT_WITH_METADATA_LOCK(session, op) \
-    WT_WITH_LOCK_WAIT(session, &S2C(session)->metadata_lock, WT_SESSION_LOCKED_METADATA, op)
+    WT_WITH_LOCK_WAIT(session, &S2C(session)->locks.metadata_lock, WT_SESSION_LOCKED_METADATA, op)
 
 /*
  * WT_WITH_SCHEMA_LOCK, WT_WITH_SCHEMA_LOCK_NOWAIT --
@@ -292,34 +293,35 @@ struct __wt_import_list {
  *	Check that we are not already holding some other lock: the schema lock
  *	must be taken first.
  */
-#define WT_WITH_SCHEMA_LOCK(session, op)                                                      \
-    do {                                                                                      \
-        WT_ASSERT(session,                                                                    \
-          FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_SCHEMA) ||                         \
-            !FLD_ISSET(session->lock_flags,                                                   \
-              WT_SESSION_LOCKED_HANDLE_LIST | WT_SESSION_NO_SCHEMA_LOCK |                     \
-                WT_SESSION_LOCKED_TABLE));                                                    \
-        WT_WITH_LOCK_WAIT(session, &S2C(session)->schema_lock, WT_SESSION_LOCKED_SCHEMA, op); \
+#define WT_WITH_SCHEMA_LOCK(session, op)                                            \
+    do {                                                                            \
+        WT_ASSERT(session,                                                          \
+          FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_SCHEMA) ||               \
+            !FLD_ISSET(session->lock_flags,                                         \
+              WT_SESSION_LOCKED_HANDLE_LIST | WT_SESSION_NO_SCHEMA_LOCK |           \
+                WT_SESSION_LOCKED_TABLE));                                          \
+        WT_WITH_LOCK_WAIT(                                                          \
+          session, &S2C(session)->locks.schema_lock, WT_SESSION_LOCKED_SCHEMA, op); \
     } while (0)
-#define WT_WITH_SCHEMA_LOCK_NOWAIT(session, ret, op)                                         \
-    do {                                                                                     \
-        WT_ASSERT(session,                                                                   \
-          FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_SCHEMA) ||                        \
-            !FLD_ISSET(session->lock_flags,                                                  \
-              WT_SESSION_LOCKED_HANDLE_LIST | WT_SESSION_NO_SCHEMA_LOCK |                    \
-                WT_SESSION_LOCKED_TABLE));                                                   \
-        int __schema_lock_ret;                                                               \
-        WT_WITH_LOCK_NOWAIT(session, ret, __schema_lock_ret, &S2C(session)->schema_lock,     \
-          WT_SESSION_LOCKED_SCHEMA, op);                                                     \
-        if (__schema_lock_ret != 0) {                                                        \
-            if (__schema_lock_ret == EBUSY)                                                  \
-                __wt_session_set_last_error(session, EBUSY, WT_CONFLICT_SCHEMA_LOCK,         \
-                  "another thread is currently holding the schema lock");                    \
-            else                                                                             \
-                __wt_session_set_last_error(                                                 \
-                  session, __schema_lock_ret, WT_NONE, "failed to acquire the schema lock"); \
-            ret = __schema_lock_ret;                                                         \
-        }                                                                                    \
+#define WT_WITH_SCHEMA_LOCK_NOWAIT(session, ret, op)                                           \
+    do {                                                                                       \
+        WT_ASSERT(session,                                                                     \
+          FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_SCHEMA) ||                          \
+            !FLD_ISSET(session->lock_flags,                                                    \
+              WT_SESSION_LOCKED_HANDLE_LIST | WT_SESSION_NO_SCHEMA_LOCK |                      \
+                WT_SESSION_LOCKED_TABLE));                                                     \
+        int __schema_lock_ret;                                                                 \
+        WT_WITH_LOCK_NOWAIT(session, ret, __schema_lock_ret, &S2C(session)->locks.schema_lock, \
+          WT_SESSION_LOCKED_SCHEMA, op);                                                       \
+        if (__schema_lock_ret != 0) {                                                          \
+            if (__schema_lock_ret == EBUSY)                                                    \
+                __wt_session_set_last_error(session, EBUSY, WT_CONFLICT_SCHEMA_LOCK,           \
+                  "another thread is currently holding the schema lock");                      \
+            else                                                                               \
+                __wt_session_set_last_error(                                                   \
+                  session, __schema_lock_ret, WT_NONE, "failed to acquire the schema lock");   \
+            ret = __schema_lock_ret;                                                           \
+        }                                                                                      \
     } while (0)
 
 /*
@@ -339,11 +341,11 @@ struct __wt_import_list {
             op;                                                                                 \
         } else {                                                                                \
             WT_ASSERT(session, !FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_HANDLE_LIST)); \
-            __wt_readlock(session, &S2C(session)->table_lock);                                  \
+            __wt_readlock(session, &S2C(session)->locks.table_lock);                            \
             FLD_SET(session->lock_flags, WT_SESSION_LOCKED_TABLE_READ);                         \
             op;                                                                                 \
             FLD_CLR(session->lock_flags, WT_SESSION_LOCKED_TABLE_READ);                         \
-            __wt_readunlock(session, &S2C(session)->table_lock);                                \
+            __wt_readunlock(session, &S2C(session)->locks.table_lock);                          \
         }                                                                                       \
     } while (0)
 
@@ -355,11 +357,11 @@ struct __wt_import_list {
             WT_ASSERT(session,                                                  \
               !FLD_ISSET(session->lock_flags,                                   \
                 WT_SESSION_LOCKED_TABLE_READ | WT_SESSION_LOCKED_HANDLE_LIST)); \
-            __wt_writelock(session, &S2C(session)->table_lock);                 \
+            __wt_writelock(session, &S2C(session)->locks.table_lock);           \
             FLD_SET(session->lock_flags, WT_SESSION_LOCKED_TABLE_WRITE);        \
             op;                                                                 \
             FLD_CLR(session->lock_flags, WT_SESSION_LOCKED_TABLE_WRITE);        \
-            __wt_writeunlock(session, &S2C(session)->table_lock);               \
+            __wt_writeunlock(session, &S2C(session)->locks.table_lock);         \
         }                                                                       \
     } while (0)
 #define WT_WITH_TABLE_WRITE_LOCK_NOWAIT(session, ret, op)                                          \
@@ -371,12 +373,12 @@ struct __wt_import_list {
         int __table_lock_ret = 0;                                                                  \
         if (FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_TABLE_WRITE)) {                       \
             op;                                                                                    \
-        } else if ((__table_lock_ret = __wt_try_writelock(session, &S2C(session)->table_lock)) ==  \
-          0) {                                                                                     \
+        } else if ((__table_lock_ret =                                                             \
+                       __wt_try_writelock(session, &S2C(session)->locks.table_lock)) == 0) {       \
             FLD_SET(session->lock_flags, WT_SESSION_LOCKED_TABLE_WRITE);                           \
             op;                                                                                    \
             FLD_CLR(session->lock_flags, WT_SESSION_LOCKED_TABLE_WRITE);                           \
-            __wt_writeunlock(session, &S2C(session)->table_lock);                                  \
+            __wt_writeunlock(session, &S2C(session)->locks.table_lock);                            \
         }                                                                                          \
         if (__table_lock_ret != 0) {                                                               \
             WT_ASSERT(session, __table_lock_ret == EBUSY);                                         \

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -171,6 +171,8 @@ struct __wt_config_entry;
 typedef struct __wt_config_entry WT_CONFIG_ENTRY;
 struct __wt_config_parser_impl;
 typedef struct __wt_config_parser_impl WT_CONFIG_PARSER_IMPL;
+struct __wt_conn_locks;
+typedef struct __wt_conn_locks WT_CONN_LOCKS;
 struct __wt_connection_impl;
 typedef struct __wt_connection_impl WT_CONNECTION_IMPL;
 struct __wt_connection_stats;

--- a/src/meta/meta_table.c
+++ b/src/meta/meta_table.c
@@ -49,7 +49,7 @@ __wt_metadata_turtle_rewrite(WT_SESSION_IMPL *session)
 {
     /* Require single-threading. */
     WT_ASSERT(session, FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_TURTLE));
-    WT_ASSERT_SPINLOCK_OWNED(session, &S2C(session)->turtle_lock);
+    WT_ASSERT_SPINLOCK_OWNED(session, &S2C(session)->locks.turtle_lock);
 
     char *existing_config;
     WT_RET(__wt_turtle_read(session, WT_METAFILE_URI, &existing_config));

--- a/src/meta/meta_turtle.c
+++ b/src/meta/meta_turtle.c
@@ -628,7 +628,7 @@ __wt_turtle_read(WT_SESSION_IMPL *session, const char *key, char **valuep)
 
     /* Require single-threading. */
     WT_ASSERT(session, FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_TURTLE));
-    WT_ASSERT_SPINLOCK_OWNED(session, &S2C(session)->turtle_lock);
+    WT_ASSERT_SPINLOCK_OWNED(session, &S2C(session)->locks.turtle_lock);
 
     /*
      * Open the turtle file; there's one case where we won't find the turtle file, yet still
@@ -706,7 +706,7 @@ __wt_turtle_update(WT_SESSION_IMPL *session, const char *key, const char *value)
 
     /* Require single-threading. */
     WT_ASSERT(session, FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_TURTLE));
-    WT_ASSERT_SPINLOCK_OWNED(session, &conn->turtle_lock);
+    WT_ASSERT_SPINLOCK_OWNED(session, &conn->locks.turtle_lock);
 
     /*
      * Create the turtle setup file: we currently re-write it from scratch every time.

--- a/src/optrack/optrack.c
+++ b/src/optrack/optrack.c
@@ -25,7 +25,7 @@ __wt_optrack_record_funcid(WT_SESSION_IMPL *session, const char *func, uint16_t 
 
     WT_ERR(__wt_scr_alloc(session, strlen(func) + 32, &tmp));
 
-    __wt_spin_lock(session, &conn->optrack_map_spinlock);
+    __wt_spin_lock(session, &conn->locks.optrack_map_spinlock);
     if (*func_idp == 0) {
         *func_idp = ++optrack_uid;
 
@@ -39,7 +39,7 @@ err:
         WT_IGNORE_RET(__wt_panic(session, ret, "operation tracking initialization failure"));
     }
 
-    __wt_spin_unlock_if_owned(session, &conn->optrack_map_spinlock);
+    __wt_spin_unlock_if_owned(session, &conn->locks.optrack_map_spinlock);
     __wt_scr_free(session, &tmp);
 }
 

--- a/src/os_common/os_fhandle.c
+++ b/src/os_common/os_fhandle.c
@@ -60,7 +60,7 @@ __wt_handle_is_open(WT_SESSION_IMPL *session, const char *name, bool locked)
     bucket = hash & (conn->hash_size - 1);
 
     if (!locked)
-        __wt_spin_lock(session, &conn->fh_lock);
+        __wt_spin_lock(session, &conn->locks.fh_lock);
 
     TAILQ_FOREACH (fh, &conn->fhhash[bucket], hashq)
         if (strcmp(name, fh->name) == 0) {
@@ -69,7 +69,7 @@ __wt_handle_is_open(WT_SESSION_IMPL *session, const char *name, bool locked)
         }
 
     if (!locked)
-        __wt_spin_unlock(session, &conn->fh_lock);
+        __wt_spin_unlock(session, &conn->locks.fh_lock);
 
     return (found);
 }
@@ -86,9 +86,9 @@ __wt_remove_locked(WT_SESSION_IMPL *session, const char *name, bool *removed)
 
     conn = S2C(session);
     *removed = false;
-    __wt_spin_lock(session, &conn->fh_lock);
+    __wt_spin_lock(session, &conn->locks.fh_lock);
     if (__wt_handle_is_open(session, name, true)) {
-        __wt_spin_unlock(session, &conn->fh_lock);
+        __wt_spin_unlock(session, &conn->locks.fh_lock);
         return (0);
     } else {
         __wt_verbose_debug2(session, WT_VERB_TIERED, "REMOVE_LOCKED: actually remove %s", name);
@@ -97,7 +97,7 @@ __wt_remove_locked(WT_SESSION_IMPL *session, const char *name, bool *removed)
         *removed = true;
     }
 err:
-    __wt_spin_unlock(session, &conn->fh_lock);
+    __wt_spin_unlock(session, &conn->locks.fh_lock);
     return (ret);
 }
 
@@ -121,7 +121,7 @@ __handle_search(WT_SESSION_IMPL *session, const char *name, WT_FH *newfh, WT_FH 
     hash = __wt_hash_city64(name, strlen(name));
     bucket = hash & (conn->hash_size - 1);
 
-    __wt_spin_lock(session, &conn->fh_lock);
+    __wt_spin_lock(session, &conn->locks.fh_lock);
 
     /*
      * If we already have the file open, increment the reference count and return a pointer.
@@ -144,7 +144,7 @@ __handle_search(WT_SESSION_IMPL *session, const char *name, WT_FH *newfh, WT_FH 
         *fhp = newfh;
     }
 
-    __wt_spin_unlock(session, &conn->fh_lock);
+    __wt_spin_unlock(session, &conn->locks.fh_lock);
 
     return (found);
 }
@@ -335,7 +335,7 @@ __handle_close(WT_SESSION_IMPL *session, WT_FH *fh, bool locked)
     (void)__wt_atomic_sub_uint32(&conn->open_file_count, 1);
 
     if (locked)
-        __wt_spin_unlock(session, &conn->fh_lock);
+        __wt_spin_unlock(session, &conn->locks.fh_lock);
 
     /* Discard underlying resources. */
     WT_TRET(fh->handle->close(fh->handle, (WT_SESSION *)session));
@@ -371,10 +371,10 @@ __wt_close(WT_SESSION_IMPL *session, WT_FH **fhp)
      *
      * Assert the reference count is correct, but don't let it wrap.
      */
-    __wt_spin_lock(session, &conn->fh_lock);
+    __wt_spin_lock(session, &conn->locks.fh_lock);
     WT_ASSERT(session, fh->ref > 0);
     if ((fh->ref > 0 && --fh->ref > 0)) {
-        __wt_spin_unlock(session, &conn->fh_lock);
+        __wt_spin_unlock(session, &conn->locks.fh_lock);
         return (0);
     }
 
@@ -395,7 +395,7 @@ __wt_fsync_background_chk(WT_SESSION_IMPL *session)
 
     conn = S2C(session);
     supported = true;
-    __wt_spin_lock(session, &conn->fh_lock);
+    __wt_spin_lock(session, &conn->locks.fh_lock);
     /*
      * Look for the first data file handle and see if the fsync nowait function is supported.
      */
@@ -411,7 +411,7 @@ __wt_fsync_background_chk(WT_SESSION_IMPL *session)
             supported = false;
         break;
     }
-    __wt_spin_unlock(session, &conn->fh_lock);
+    __wt_spin_unlock(session, &conn->locks.fh_lock);
     return (supported);
 }
 
@@ -428,7 +428,7 @@ __fsync_background(WT_SESSION_IMPL *session, WT_FH *fh)
     uint64_t now;
 
     conn = S2C(session);
-    WT_ASSERT_SPINLOCK_OWNED(session, &conn->fh_lock);
+    WT_ASSERT_SPINLOCK_OWNED(session, &conn->locks.fh_lock);
     WT_STAT_CONN_INCR(session, fsync_all_fh_total);
 
     handle = fh->handle;
@@ -441,7 +441,7 @@ __fsync_background(WT_SESSION_IMPL *session, WT_FH *fh)
 
     now = __wt_clock(session);
     if (fh->last_sync == 0 || WT_CLOCKDIFF_SEC(now, fh->last_sync) > 0) {
-        __wt_spin_unlock(session, &conn->fh_lock);
+        __wt_spin_unlock(session, &conn->locks.fh_lock);
 
         /*
          * We set the false flag to indicate a non-blocking background fsync, but there is no
@@ -455,7 +455,7 @@ __fsync_background(WT_SESSION_IMPL *session, WT_FH *fh)
             fh->written = 0;
         }
 
-        __wt_spin_lock(session, &conn->fh_lock);
+        __wt_spin_lock(session, &conn->locks.fh_lock);
     }
     return (ret);
 }
@@ -472,7 +472,7 @@ __wt_fsync_background(WT_SESSION_IMPL *session)
     WT_FH *fh, *fhnext;
 
     conn = S2C(session);
-    __wt_spin_lock(session, &conn->fh_lock);
+    __wt_spin_lock(session, &conn->locks.fh_lock);
     TAILQ_FOREACH_SAFE(fh, &conn->fhqh, q, fhnext)
     {
         /*
@@ -491,7 +491,7 @@ __wt_fsync_background(WT_SESSION_IMPL *session)
          */
         if (--fh->ref == 0) {
             WT_TRET(__handle_close(session, fh, true));
-            __wt_spin_lock(session, &conn->fh_lock);
+            __wt_spin_lock(session, &conn->locks.fh_lock);
         }
 
         /*
@@ -501,7 +501,7 @@ __wt_fsync_background(WT_SESSION_IMPL *session)
         if (fhnext != NULL)
             --fhnext->ref;
     }
-    __wt_spin_unlock(session, &conn->fh_lock);
+    __wt_spin_unlock(session, &conn->locks.fh_lock);
     return (ret);
 }
 

--- a/src/rollback_to_stable/rts_api.c
+++ b/src/rollback_to_stable/rts_api.c
@@ -56,9 +56,9 @@ __rts_check(WT_SESSION_IMPL *session)
      * session open/close to ensure we don't race. This call is a rarely used RTS-only function,
      * acquiring the lock shouldn't be an issue.
      */
-    __wt_spin_lock(session, &conn->api_lock);
+    __wt_spin_lock(session, &conn->locks.api_lock);
     WT_IGNORE_RET(__wt_session_array_walk(session, __rts_check_callback, true, &cookie));
-    __wt_spin_unlock(session, &conn->api_lock);
+    __wt_spin_unlock(session, &conn->locks.api_lock);
 
     /*
      * A new cursor may be positioned or a transaction may start after we return from this call and
@@ -115,8 +115,8 @@ __rollback_to_stable_int(WT_SESSION_IMPL *session, bool no_ckpt)
     dryrun = conn->rts->dryrun;
     threads = conn->rts->threads_num;
 
-    WT_ASSERT_SPINLOCK_OWNED(session, &conn->checkpoint_lock);
-    WT_ASSERT_SPINLOCK_OWNED(session, &conn->schema_lock);
+    WT_ASSERT_SPINLOCK_OWNED(session, &conn->locks.checkpoint_lock);
+    WT_ASSERT_SPINLOCK_OWNED(session, &conn->locks.schema_lock);
 
     /*
      * Rollback to stable should ignore tombstones in the history store since it needs to scan the

--- a/src/schema/schema_alter.c
+++ b/src/schema/schema_alter.c
@@ -394,8 +394,8 @@ __schema_alter(WT_SESSION_IMPL *session, const char *uri, const char *newcfg[])
     const char *cfg[] = {WT_CONFIG_BASE(session, WT_SESSION_alter), newcfg[0], NULL};
     bool exclusive_refreshed;
 
-    WT_ASSERT_SPINLOCK_OWNED(session, &S2C(session)->checkpoint_lock);
-    WT_ASSERT_SPINLOCK_OWNED(session, &S2C(session)->schema_lock);
+    WT_ASSERT_SPINLOCK_OWNED(session, &S2C(session)->locks.checkpoint_lock);
+    WT_ASSERT_SPINLOCK_OWNED(session, &S2C(session)->locks.schema_lock);
 
     /*
      * Determine what configuration says about exclusive access. A non exclusive alter that doesn't
@@ -441,8 +441,8 @@ __wt_schema_alter(WT_SESSION_IMPL *session, const char *uri, const char *newcfg[
     WT_DECL_RET;
     WT_SESSION_IMPL *int_session;
 
-    WT_ASSERT_SPINLOCK_OWNED(session, &S2C(session)->checkpoint_lock);
-    WT_ASSERT_SPINLOCK_OWNED(session, &S2C(session)->schema_lock);
+    WT_ASSERT_SPINLOCK_OWNED(session, &S2C(session)->locks.checkpoint_lock);
+    WT_ASSERT_SPINLOCK_OWNED(session, &S2C(session)->locks.schema_lock);
 
     /* Add a 2 second wait to simulate session alter slowness. */
     tsp.tv_sec = 2;

--- a/src/schema/schema_create.c
+++ b/src/schema/schema_create.c
@@ -1731,7 +1731,7 @@ __wt_schema_create(WT_SESSION_IMPL *session, const char *uri, const char *config
      * We can thus only check whether the lock is acquired, as opposed to, whether the lock is
      * acquired by us.
      */
-    WT_ASSERT(session, __wt_spin_locked(session, &S2C(session)->schema_lock));
+    WT_ASSERT(session, __wt_spin_locked(session, &S2C(session)->locks.schema_lock));
 
     WT_RET(__wti_schema_internal_session(session, &int_session));
     ret = __schema_create(int_session, uri, config);

--- a/src/schema/schema_drop.c
+++ b/src/schema/schema_drop.c
@@ -385,7 +385,7 @@ __drop_tiered(
      * remove the work. So hold the tiered lock for the duration so that the worker thread cannot
      * race and process work for this handle.
      */
-    __wt_spin_lock(session, &conn->tiered_lock);
+    __wt_spin_lock(session, &conn->locks.tiered_lock);
     /*
      * Close all btree handles associated with this table. This must be done after we're done using
      * the tiered structure because that is from the dhandle.
@@ -481,7 +481,7 @@ __drop_tiered(
      */
     __wt_verbose(session, WT_VERB_TIERED, "DROP_TIERED: remove work for %p", (void *)tiered);
     __wt_tiered_remove_work(session, tiered, true);
-    __wt_spin_unlock(session, &conn->tiered_lock);
+    __wt_spin_unlock(session, &conn->locks.tiered_lock);
 
     ret = __wt_metadata_remove(session, uri);
 
@@ -489,7 +489,7 @@ err:
     if (got_dhandle)
         WT_TRET(__wt_session_release_dhandle(session));
     __wt_free(session, name);
-    __wt_spin_unlock_if_owned(session, &conn->tiered_lock);
+    __wt_spin_unlock_if_owned(session, &conn->locks.tiered_lock);
     return (ret);
 }
 
@@ -566,7 +566,7 @@ __wt_schema_drop(
      * We can thus only check whether the lock is acquired, as opposed to, whether the lock is
      * acquired by us.
      */
-    WT_ASSERT(session, __wt_spin_locked(session, &S2C(session)->schema_lock));
+    WT_ASSERT(session, __wt_spin_locked(session, &S2C(session)->locks.schema_lock));
 
     WT_RET(__wti_schema_internal_session(session, &int_session));
     ret = __schema_drop(int_session, uri, cfg, check_visibility);

--- a/src/schema/schema_truncate.c
+++ b/src/schema/schema_truncate.c
@@ -128,8 +128,8 @@ __wt_schema_truncate(WT_SESSION_IMPL *session, const char *uri, const char *cfg[
     WT_DECL_RET;
     const char *tablename;
 
-    WT_ASSERT_SPINLOCK_OWNED(session, &S2C(session)->checkpoint_lock);
-    WT_ASSERT_SPINLOCK_OWNED(session, &S2C(session)->schema_lock);
+    WT_ASSERT_SPINLOCK_OWNED(session, &S2C(session)->locks.checkpoint_lock);
+    WT_ASSERT_SPINLOCK_OWNED(session, &S2C(session)->locks.schema_lock);
 
     tablename = uri;
 

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -409,7 +409,7 @@ __wt_session_close_internal(WT_SESSION_IMPL *session)
     WT_TRET(__wt_session_release_resources(session));
 
     /* The API lock protects opening and closing of sessions. */
-    __wt_spin_lock(session, &conn->api_lock);
+    __wt_spin_lock(session, &conn->locks.api_lock);
 
     /*
      * Free transaction information: inside the lock because we're freeing the WT_TXN structure and
@@ -460,7 +460,7 @@ __wt_session_close_internal(WT_SESSION_IMPL *session)
         if (__wt_atomic_sub_uint32(&conn->session_array.cnt, 1) == 0)
             break;
 
-    __wt_spin_unlock(session, &conn->api_lock);
+    __wt_spin_unlock(session, &conn->locks.api_lock);
 
 #ifdef HAVE_CALL_LOG
     if (!internal_session)
@@ -1419,8 +1419,8 @@ err:
 static int
 __session_salvage_worker(WT_SESSION_IMPL *session, const char *uri, const char *cfg[])
 {
-    WT_ASSERT_SPINLOCK_OWNED(session, &S2C(session)->checkpoint_lock);
-    WT_ASSERT_SPINLOCK_OWNED(session, &S2C(session)->schema_lock);
+    WT_ASSERT_SPINLOCK_OWNED(session, &S2C(session)->locks.checkpoint_lock);
+    WT_ASSERT_SPINLOCK_OWNED(session, &S2C(session)->locks.schema_lock);
 
     WT_RET(__wt_schema_worker(
       session, uri, __wt_salvage, NULL, cfg, WT_DHANDLE_EXCLUSIVE | WT_BTREE_SALVAGE));
@@ -2548,7 +2548,7 @@ __open_session(WT_CONNECTION_IMPL *conn, WT_EVENT_HANDLER *event_handler, const 
     session = conn->default_session;
     session_ret = NULL;
 
-    __wt_spin_lock(session, &conn->api_lock);
+    __wt_spin_lock(session, &conn->locks.api_lock);
 
     /*
      * Make sure we don't try to open a new session after the application closes the connection.
@@ -2707,7 +2707,7 @@ err:
 #endif
     if (ret != 0 && session_ret != NULL && !out_of_sessions)
         __wt_txn_destroy(session_ret);
-    __wt_spin_unlock(session, &conn->api_lock);
+    __wt_spin_unlock(session, &conn->locks.api_lock);
     return (ret);
 }
 

--- a/src/session/session_compact.c
+++ b/src/session/session_compact.c
@@ -163,7 +163,7 @@ __compact_handle_append(WT_SESSION_IMPL *session, const char *cfg[])
 
     WT_UNUSED(cfg);
 
-    WT_ASSERT_SPINLOCK_OWNED(session, &S2C(session)->schema_lock);
+    WT_ASSERT_SPINLOCK_OWNED(session, &S2C(session)->locks.schema_lock);
 
     WT_RET(__wt_session_get_dhandle(session, session->dhandle->name, NULL, NULL, 0));
 

--- a/src/tiered/tiered_config.c
+++ b/src/tiered/tiered_config.c
@@ -50,7 +50,7 @@ __wti_tiered_bucket_config(
     bstorage = new = NULL;
     conn = S2C(session);
 
-    __wt_spin_lock(session, &conn->storage_lock);
+    __wt_spin_lock(session, &conn->locks.storage_lock);
 
     WT_ERR(__wt_schema_open_storage_source(session, &name, &nstorage));
     if (nstorage == NULL) {
@@ -128,7 +128,7 @@ err:
         }
         __wt_free(session, new);
     }
-    __wt_spin_unlock(session, &conn->storage_lock);
+    __wt_spin_unlock(session, &conn->locks.storage_lock);
     __wt_scr_free(session, &buf);
     return (ret);
 }

--- a/src/tiered/tiered_work.c
+++ b/src/tiered/tiered_work.c
@@ -56,7 +56,7 @@ __wt_tiered_remove_work(WT_SESSION_IMPL *session, WT_TIERED *tiered, bool locked
 
     conn = S2C(session);
     if (!locked)
-        __wt_spin_lock(session, &conn->tiered_lock);
+        __wt_spin_lock(session, &conn->locks.tiered_lock);
     TAILQ_FOREACH_SAFE(entry, &conn->tieredqh, q, entry_tmp)
     {
         /* Remove and free any entry for this tiered handle. */
@@ -67,7 +67,7 @@ __wt_tiered_remove_work(WT_SESSION_IMPL *session, WT_TIERED *tiered, bool locked
         }
     }
     if (!locked)
-        __wt_spin_unlock(session, &conn->tiered_lock);
+        __wt_spin_unlock(session, &conn->locks.tiered_lock);
     return;
 }
 
@@ -81,11 +81,11 @@ __tiered_push_work_internal(WT_SESSION_IMPL *session, WT_TIERED_WORK_UNIT *entry
     WT_CONNECTION_IMPL *conn;
 
     conn = S2C(session);
-    __wt_spin_lock(session, &conn->tiered_lock);
+    __wt_spin_lock(session, &conn->locks.tiered_lock);
     TAILQ_INSERT_TAIL(&conn->tieredqh, entry, q);
     WT_ASSERT(session, entry->tiered != NULL);
     WT_STAT_CONN_INCR(session, tiered_work_units_created);
-    __wt_spin_unlock(session, &conn->tiered_lock);
+    __wt_spin_unlock(session, &conn->locks.tiered_lock);
     __tiered_flush_state(session, entry->type, true);
     __wt_cond_signal(session, conn->tiered_cond);
     return;
@@ -152,7 +152,7 @@ __tiered_pop_work(
     conn = S2C(session);
     if (__tiered_queue_peek_empty(conn))
         return;
-    __wt_spin_lock(session, &conn->tiered_lock);
+    __wt_spin_lock(session, &conn->locks.tiered_lock);
 
     TAILQ_FOREACH (entry, &conn->tieredqh, q) {
         if (FLD_ISSET(type, entry->type) && (maxval == 0 || entry->op_val < maxval)) {
@@ -164,7 +164,7 @@ __tiered_pop_work(
             break;
         }
     }
-    __wt_spin_unlock(session, &conn->tiered_lock);
+    __wt_spin_unlock(session, &conn->locks.tiered_lock);
     return;
 }
 
@@ -188,14 +188,14 @@ __wt_tiered_flush_work_wait(WT_SESSION_IMPL *session, uint32_t timeout)
 
     while (!done) {
         found = false;
-        __wt_spin_lock(session, &conn->tiered_lock);
+        __wt_spin_lock(session, &conn->locks.tiered_lock);
         TAILQ_FOREACH (entry, &conn->tieredqh, q)
             if (FLD_ISSET(entry->type, WT_TIERED_WORK_FLUSH)) {
                 found = true;
                 break;
             }
 
-        __wt_spin_unlock(session, &conn->tiered_lock);
+        __wt_spin_unlock(session, &conn->locks.tiered_lock);
         if (found) {
             __wt_cond_signal(session, conn->tiered_cond);
             __wt_sleep(0, 10 * WT_THOUSAND);

--- a/test/catch2/block/unit/test_block_file.cpp
+++ b/test/catch2/block/unit/test_block_file.cpp
@@ -81,8 +81,8 @@ validate_block(std::shared_ptr<mock_session> session, WT_BLOCK *block, config_pa
 
     // Connection block lock should not be locked after the function completes.
     WT_CONNECTION_IMPL *conn = session->get_mock_connection()->get_wt_connection_impl();
-    CHECK(static_cast<bool>(conn->block_lock.initialized) == true);
-    CHECK(conn->block_lock.session_id != session->get_wt_session_impl()->id);
+    CHECK(static_cast<bool>(conn->locks.block_lock.initialized) == true);
+    CHECK(conn->locks.block_lock.session_id != session->get_wt_session_impl()->id);
 }
 
 void
@@ -105,8 +105,8 @@ validate_free_block(std::shared_ptr<mock_session> session, WT_BLOCK *block, conf
     }
 
     // Connection block lock should not be locked after the function completes.
-    REQUIRE(static_cast<bool>(conn->block_lock.initialized) == true);
-    REQUIRE(conn->block_lock.session_id != session->get_wt_session_impl()->id);
+    REQUIRE(static_cast<bool>(conn->locks.block_lock.initialized) == true);
+    REQUIRE(conn->locks.block_lock.session_id != session->get_wt_session_impl()->id);
 }
 
 TEST_CASE("Block manager: __wt_block_open and __wti_bm_close_block", "[block_file]")

--- a/test/catch2/misc_tests/test_page_log_handle.cpp
+++ b/test/catch2/misc_tests/test_page_log_handle.cpp
@@ -72,8 +72,8 @@ TEST_CASE("Test disaggregated configuration logic", "[disagg_config]")
 
     REQUIRE(__wt_spin_init(session, &conn_impl->disaggregated_storage.shared_metadata_queue_lock,
               "update shared metadata") == 0);
-    REQUIRE(__wt_spin_init(session, &conn_impl->api_lock, "api") == 0);
-    REQUIRE(__wt_spin_init(session, &conn_impl->schema_lock, "schema") == 0);
+    REQUIRE(__wt_spin_init(session, &conn_impl->locks.api_lock, "api") == 0);
+    REQUIRE(__wt_spin_init(session, &conn_impl->locks.schema_lock, "schema") == 0);
 
     /* Setup the page log queue. */
     setup_page_log_queue(session);
@@ -126,5 +126,5 @@ TEST_CASE("Test disaggregated configuration logic", "[disagg_config]")
     REQUIRE(__wti_layered_table_manager_destroy(session) == 0);
 
     __wt_spin_destroy(session, &conn_impl->disaggregated_storage.shared_metadata_queue_lock);
-    __wt_spin_destroy(session, &conn_impl->api_lock);
+    __wt_spin_destroy(session, &conn_impl->locks.api_lock);
 }

--- a/test/catch2/wrappers/mock_connection.cpp
+++ b/test/catch2/wrappers/mock_connection.cpp
@@ -21,8 +21,8 @@ mock_connection::~mock_connection()
         __wt_free(nullptr, _connection_impl->blockhash);
     if (_connection_impl->fhhash != nullptr)
         __wt_free(nullptr, _connection_impl->fhhash);
-    if (_connection_impl->block_lock.initialized == 1)
-        __wt_spin_destroy(nullptr, &_connection_impl->block_lock);
+    if (_connection_impl->locks.block_lock.initialized == 1)
+        __wt_spin_destroy(nullptr, &_connection_impl->locks.block_lock);
     /* setup_stats() used nullptr to allocate so use nullptr to free. */
     __wt_stat_connection_discard(nullptr, _connection_impl);
     __wt_free(nullptr, _connection_impl);
@@ -66,8 +66,8 @@ mock_connection::setup_block_manager(WT_SESSION_IMPL *session)
     TAILQ_INIT(&_connection_impl->fhqh);
 
     // Initialize the block manager and file list lock.
-    WT_RET(__wt_spin_init(session, &_connection_impl->fh_lock, "file list"));
-    WT_RET(__wt_spin_init(session, &_connection_impl->block_lock, "block manager"));
+    WT_RET(__wt_spin_init(session, &_connection_impl->locks.fh_lock, "file list"));
+    WT_RET(__wt_spin_init(session, &_connection_impl->locks.block_lock, "block manager"));
 
     // Initialize a file system layer used for testing purposes.
     _connection_impl->home = "";


### PR DESCRIPTION
## Summary
- Introduces `WT_CONN_LOCKS` (`struct __wt_conn_locks`) in `src/include/connection.h` grouping all 17 connection-level synchronization primitives (15 spinlocks + 2 rwlocks) that were previously scattered as individual fields in `__wt_connection_impl`
- Replaces individual lock fields with a single `WT_CONN_LOCKS locks` member in `__wt_connection_impl`; access is now via `conn->locks.<field>`
- Updates all 36 source files across `src/` and `test/` to use the new path (including macro-based access in `schema.h` and `meta.h`)
- This is a pure refactor — no behavioural change, no new locks added or removed

## Testing
This is a pure rename/restructure refactor. Correctness is verified by compilation:
- Incremental `ninja wt` build passes with zero errors or warnings
- All stale references (`conn->api_lock`, `conn->block_lock`, etc.) confirmed absent via grep across `src/`, `test/`, `bench/`, `examples/`, and `tools/`
- Catch2 unit test file `test/catch2/block/unit/test_block_file.cpp` updated to use `conn->locks.block_lock`

🤖 Generated with [Claude Code](https://claude.com/claude-code)