### PR TITLE
WT-17502 Make YCSB retry on write conflicts

### DIFF
--- a/bench/wtperf/runners/ycsb-100read.wtperf
+++ b/bench/wtperf/runners/ycsb-100read.wtperf
@@ -5,8 +5,6 @@
 # of on-disk data, so the cache should hold around 50% of the total dataset.
 # The total number of user threads is also set to 16 to avoid oversubscription.
 
-# FIXME-WT-17498: Consider bringing wtperf YCSB closer to the MongoDB implementation
-
 conn_config="cache_size=16G,log=(enabled=true)"
 pareto=20
 table_config="type=file"

--- a/bench/wtperf/runners/ycsb-100read.wtperf
+++ b/bench/wtperf/runners/ycsb-100read.wtperf
@@ -5,6 +5,8 @@
 # of on-disk data, so the cache should hold around 50% of the total dataset.
 # The total number of user threads is also set to 16 to avoid oversubscription.
 
+# FIXME-WT-17498: Consider bringing wtperf YCSB closer to the MongoDB implementation
+
 conn_config="cache_size=16G,log=(enabled=true)"
 pareto=20
 table_config="type=file"

--- a/bench/wtperf/runners/ycsb-50read50modify.wtperf
+++ b/bench/wtperf/runners/ycsb-50read50modify.wtperf
@@ -11,6 +11,7 @@ table_config="type=file"
 key_sz=100
 value_sz=1024
 icount=30000000
+retry_writes=true
 run_time=1800
 sess_config="isolation=snapshot"
 threads=((count=8,reads=1),(count=8,modify=1,ops_per_txn=1))

--- a/bench/wtperf/runners/ycsb-50read50modify.wtperf
+++ b/bench/wtperf/runners/ycsb-50read50modify.wtperf
@@ -5,8 +5,6 @@
 # of on-disk data, so the cache should hold around 50% of the total dataset.
 # The total number of user threads is also set to 16 to avoid oversubscription.
 
-# FIXME-WT-17498: Consider bringing wtperf YCSB closer to the MongoDB implementation
-
 conn_config="cache_size=16G,log=(enabled=true)"
 pareto=20
 table_config="type=file"

--- a/bench/wtperf/runners/ycsb-50read50modify.wtperf
+++ b/bench/wtperf/runners/ycsb-50read50modify.wtperf
@@ -5,6 +5,8 @@
 # of on-disk data, so the cache should hold around 50% of the total dataset.
 # The total number of user threads is also set to 16 to avoid oversubscription.
 
+# FIXME-WT-17498: Consider bringing wtperf YCSB closer to the MongoDB implementation
+
 conn_config="cache_size=16G,log=(enabled=true)"
 pareto=20
 table_config="type=file"

--- a/bench/wtperf/runners/ycsb-50read50update.wtperf
+++ b/bench/wtperf/runners/ycsb-50read50update.wtperf
@@ -11,6 +11,7 @@ table_config="type=file"
 key_sz=100
 value_sz=1024
 icount=30000000
+retry_writes=true
 run_time=1800
 threads=((count=8,reads=1),(count=8,updates=1))
 warmup=120

--- a/bench/wtperf/runners/ycsb-50read50update.wtperf
+++ b/bench/wtperf/runners/ycsb-50read50update.wtperf
@@ -5,8 +5,6 @@
 # of on-disk data, so the cache should hold around 50% of the total dataset.
 # The total number of user threads is also set to 16 to avoid oversubscription.
 
-# FIXME-WT-17498: Consider bringing wtperf YCSB closer to the MongoDB implementation
-
 conn_config="cache_size=16G,log=(enabled=true)"
 pareto=20
 table_config="type=file"

--- a/bench/wtperf/runners/ycsb-50read50update.wtperf
+++ b/bench/wtperf/runners/ycsb-50read50update.wtperf
@@ -5,6 +5,8 @@
 # of on-disk data, so the cache should hold around 50% of the total dataset.
 # The total number of user threads is also set to 16 to avoid oversubscription.
 
+# FIXME-WT-17498: Consider bringing wtperf YCSB closer to the MongoDB implementation
+
 conn_config="cache_size=16G,log=(enabled=true)"
 pareto=20
 table_config="type=file"

--- a/bench/wtperf/runners/ycsb-95read5update.wtperf
+++ b/bench/wtperf/runners/ycsb-95read5update.wtperf
@@ -11,6 +11,7 @@ table_config="type=file"
 key_sz=100
 value_sz=1024
 icount=30000000
+retry_writes=true
 run_time=1800
 threads=((count=16,reads=95,updates=5))
 warmup=120

--- a/bench/wtperf/runners/ycsb-95read5update.wtperf
+++ b/bench/wtperf/runners/ycsb-95read5update.wtperf
@@ -5,8 +5,6 @@
 # of on-disk data, so the cache should hold around 50% of the total dataset.
 # The total number of user threads is also set to 16 to avoid oversubscription.
 
-# FIXME-WT-17498: Consider bringing wtperf YCSB closer to the MongoDB implementation
-
 conn_config="cache_size=16G,log=(enabled=true)"
 pareto=20
 table_config="type=file"

--- a/bench/wtperf/runners/ycsb-95read5update.wtperf
+++ b/bench/wtperf/runners/ycsb-95read5update.wtperf
@@ -5,6 +5,8 @@
 # of on-disk data, so the cache should hold around 50% of the total dataset.
 # The total number of user threads is also set to 16 to avoid oversubscription.
 
+# FIXME-WT-17498: Consider bringing wtperf YCSB closer to the MongoDB implementation
+
 conn_config="cache_size=16G,log=(enabled=true)"
 pareto=20
 table_config="type=file"

--- a/bench/wtperf/runners/ycsb-95readlatest5insert.wtperf
+++ b/bench/wtperf/runners/ycsb-95readlatest5insert.wtperf
@@ -10,6 +10,7 @@ table_config="type=file"
 key_sz=100
 value_sz=1024
 icount=30000000
+retry_writes=true
 run_time=1800
 select_latest=true
 threads=((count=16,reads=95,inserts=5))

--- a/bench/wtperf/runners/ycsb-95readlatest5insert.wtperf
+++ b/bench/wtperf/runners/ycsb-95readlatest5insert.wtperf
@@ -5,6 +5,8 @@
 # of on-disk data, so the cache should hold around 50% of the total dataset.
 # The total number of user threads is also set to 16 to avoid oversubscription.
 
+# FIXME-WT-17498: Consider bringing wtperf YCSB closer to the MongoDB implementation
+
 conn_config="cache_size=16G,log=(enabled=true)"
 table_config="type=file"
 key_sz=100

--- a/bench/wtperf/runners/ycsb-95readlatest5insert.wtperf
+++ b/bench/wtperf/runners/ycsb-95readlatest5insert.wtperf
@@ -5,8 +5,6 @@
 # of on-disk data, so the cache should hold around 50% of the total dataset.
 # The total number of user threads is also set to 16 to avoid oversubscription.
 
-# FIXME-WT-17498: Consider bringing wtperf YCSB closer to the MongoDB implementation
-
 conn_config="cache_size=16G,log=(enabled=true)"
 table_config="type=file"
 key_sz=100

--- a/bench/wtperf/runners/ycsb-95scan5insert.wtperf
+++ b/bench/wtperf/runners/ycsb-95scan5insert.wtperf
@@ -11,6 +11,7 @@ table_config="type=file"
 key_sz=100
 value_sz=1024
 icount=30000000
+retry_writes=true
 run_time=1800
 threads=((count=16,reads=95,inserts=5))
 read_range=100

--- a/bench/wtperf/runners/ycsb-95scan5insert.wtperf
+++ b/bench/wtperf/runners/ycsb-95scan5insert.wtperf
@@ -5,8 +5,6 @@
 # of on-disk data, so the cache should hold around 50% of the total dataset.
 # The total number of user threads is also set to 16 to avoid oversubscription.
 
-# FIXME-WT-17498: Consider bringing wtperf YCSB closer to the MongoDB implementation
-
 conn_config="cache_size=16G,log=(enabled=true)"
 pareto=20
 table_config="type=file"

--- a/bench/wtperf/runners/ycsb-95scan5insert.wtperf
+++ b/bench/wtperf/runners/ycsb-95scan5insert.wtperf
@@ -5,6 +5,8 @@
 # of on-disk data, so the cache should hold around 50% of the total dataset.
 # The total number of user threads is also set to 16 to avoid oversubscription.
 
+# FIXME-WT-17498: Consider bringing wtperf YCSB closer to the MongoDB implementation
+
 conn_config="cache_size=16G,log=(enabled=true)"
 pareto=20
 table_config="type=file"

--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -514,6 +514,7 @@ worker(void *arg)
           (trk->ops % opts->sample_rate == 0);
         start = __wt_clock(NULL);
 
+retry:
         cursor->set_key(cursor, key_buf);
         switch (*op) {
         case WORKER_READ:
@@ -690,21 +691,19 @@ worker(void *arg)
                 break;
 
 op_err:
-            if (ret == WT_ROLLBACK && use_txn) {
-                /*
-                 * If we are running with explicit transactions configured and we hit a WT_ROLLBACK,
-                 * then we should rollback the current transaction and attempt to continue. This
-                 * does break the guarantee of insertion order in cases of ordered inserts, as we
-                 * aren't retrying here.
-                 */
-                if ((ret = session->rollback_transaction(session, NULL)) != 0) {
-                    lprintf(wtperf, ret, 0, "Failed rollback_transaction");
-                    goto err;
+            if (ret == WT_ROLLBACK) {
+                if (use_txn) {
+                    if ((ret = session->rollback_transaction(session, NULL)) != 0) {
+                        lprintf(wtperf, ret, 0, "Failed rollback_transaction");
+                        goto err;
+                    }
+                    if ((ret = session->begin_transaction(session, NULL)) != 0) {
+                        lprintf(wtperf, ret, 0, "Worker begin transaction failed");
+                        goto err;
+                    }
                 }
-                if ((ret = session->begin_transaction(session, NULL)) != 0) {
-                    lprintf(wtperf, ret, 0, "Worker begin transaction failed");
-                    goto err;
-                }
+                if (opts->retry_writes)
+                    goto retry;
                 break;
             }
             lprintf(wtperf, ret, 0, "%s failed for: %s, range: %" PRIu64, op_name(op), key_buf,

--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -344,6 +344,7 @@ worker(void *arg)
     uint32_t rand_val, total_table_count;
     uint8_t *op, *op_end;
     int measure_latency, nmodify, ret, truncated;
+    uint32_t retry_count;
     char *index_buf, *index_del_buf, *key_buf, *value, *value_buf;
     char buf[512];
     bool use_txn;
@@ -513,6 +514,7 @@ worker(void *arg)
         measure_latency = opts->sample_interval != 0 && trk != NULL && trk->ops != 0 &&
           (trk->ops % opts->sample_rate == 0);
         start = __wt_clock(NULL);
+        retry_count = 0;
 
 retry:
         cursor->set_key(cursor, key_buf);
@@ -702,8 +704,15 @@ op_err:
                         goto err;
                     }
                 }
-                if (opts->retry_writes)
+                if (opts->retry_writes) {
+                    if (++retry_count > 1000) {
+                        lprintf(wtperf, WT_ERROR, 0,
+                          "Exceeded maximum retry limit of 1000 retries on write conflict, key: %s",
+                          key_buf);
+                        goto err;
+                    }
                     goto retry;
+                }
                 break;
             }
             lprintf(wtperf, ret, 0, "%s failed for: %s, range: %" PRIu64, op_name(op), key_buf,

--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -711,6 +711,13 @@ op_err:
                           key_buf);
                         goto err;
                     }
+                    /*
+                     * Exponential backoff with jitter to break livelock: without a delay, all
+                     * threads retrying the same hot key stay synchronized and keep conflicting with
+                     * each other indefinitely. The backoff grows up to ~1ms.
+                     */
+                    (void)usleep(
+                      (useconds_t)(WT_MIN(1ULL << retry_count, 1000) + __wt_random(&thread->rnd) % 100));
                     goto retry;
                 }
                 break;

--- a/bench/wtperf/wtperf.c
+++ b/bench/wtperf/wtperf.c
@@ -712,12 +712,12 @@ op_err:
                         goto err;
                     }
                     /*
-                     * Exponential backoff with jitter to break livelock: without a delay, all
+                     * Exponential backoff with noise to break live lock: without a delay, all
                      * threads retrying the same hot key stay synchronized and keep conflicting with
                      * each other indefinitely. The backoff grows up to ~1ms.
                      */
-                    (void)usleep(
-                      (useconds_t)(WT_MIN(1ULL << retry_count, 1000) + __wt_random(&thread->rnd) % 100));
+                    (void)usleep((useconds_t)(WT_MIN(1ULL << retry_count, 1000) +
+                      __wt_random(&thread->rnd) % 100));
                     goto retry;
                 }
                 break;

--- a/bench/wtperf/wtperf_opt_inline.h
+++ b/bench/wtperf/wtperf_opt_inline.h
@@ -142,6 +142,8 @@ DEF_OPT_AS_BOOL(
 DEF_OPT_AS_UINT32(random_range, 0,
   "if non zero choose a value from within this range as the key for insert operations")
 DEF_OPT_AS_BOOL(random_value, 0, "generate random content for the value")
+DEF_OPT_AS_BOOL(retry_writes, 0,
+  "retry write operations that fail with WT_ROLLBACK instead of skipping them")
 DEF_OPT_AS_BOOL(range_partition, 0, "partition data by range (vs hash)")
 DEF_OPT_AS_UINT32(read_range, 0,
   "read a sequential range of keys upon each read operation. This value tells us how many keys "

--- a/bench/wtperf/wtperf_opt_inline.h
+++ b/bench/wtperf/wtperf_opt_inline.h
@@ -142,8 +142,8 @@ DEF_OPT_AS_BOOL(
 DEF_OPT_AS_UINT32(random_range, 0,
   "if non zero choose a value from within this range as the key for insert operations")
 DEF_OPT_AS_BOOL(random_value, 0, "generate random content for the value")
-DEF_OPT_AS_BOOL(retry_writes, 0,
-  "retry write operations that fail with WT_ROLLBACK instead of skipping them")
+DEF_OPT_AS_BOOL(
+  retry_writes, 0, "retry write operations that fail with WT_ROLLBACK instead of skipping them")
 DEF_OPT_AS_BOOL(range_partition, 0, "partition data by range (vs hash)")
 DEF_OPT_AS_UINT32(read_range, 0,
   "read a sequential range of keys upon each read operation. This value tells us how many keys "

--- a/src/docs/wtperf.dox
+++ b/src/docs/wtperf.dox
@@ -186,6 +186,8 @@ Scan all data prior to starting the workload phase to warm the cache
 if non zero choose a value from within this range as the key for insert operations
 @par random_value (boolean, default=false)
 generate random content for the value
+@par retry_writes (boolean, default=false)
+retry write operations that fail with WT_ROLLBACK instead of skipping them
 @par range_partition (boolean, default=false)
 partition data by range (vs hash)
 @par read_range (unsigned int, default=0)


### PR DESCRIPTION
It's a part of an initiative of bringing wtperf YCSB closer to MongoDB YCSB ([WT-17498](https://jira.mongodb.org/browse/WT-17498)). 

MongoDB YCSB has retryWrites, while WT always rolls back transactions on conflicts. Currently, we observe around 100k–300k update conflicts during 30-minute workloads with updates, which translates to roughly 55 events happening every second, so this may cause behavioural differences.

The PR makes wtperf YCSB retry operations on write conflicts.
