### PR TITLE
WT-17493 Extract tiered storage thread fields into WT_CONN_TIERED

### DIFF
--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -79,7 +79,7 @@ __checkpoint_flush_tier_wait(WT_SESSION_IMPL *session, const char **cfg)
      * yield or wait based on how much of the workload has been performed. Flushing operations could
      * take a long time so yielding may not be effective.
      */
-    while (!WT_FLUSH_STATE_DONE(conn->flush_state)) {
+    while (!WT_FLUSH_STATE_DONE(conn->tiered.flush_state)) {
         if (start != 0) {
             __wt_seconds(session, &now);
             if (now - start > timeout)
@@ -88,8 +88,8 @@ __checkpoint_flush_tier_wait(WT_SESSION_IMPL *session, const char **cfg)
         if (++yield_count < WT_THOUSAND)
             __wt_yield();
         else {
-            __wt_cond_signal(session, conn->tiered_cond);
-            __wt_cond_wait(session, conn->flush_cond, 200, NULL);
+            __wt_cond_signal(session, conn->tiered.cond);
+            __wt_cond_wait(session, conn->tiered.flush_cond, 200, NULL);
         }
     }
     return (0);
@@ -129,12 +129,12 @@ __checkpoint_flush_tier(WT_SESSION_IMPL *session, bool force)
      * - Do the work to create said objects.
      * - Move the objects.
      */
-    __wt_atomic_store_uint32_v_relaxed(&conn->flush_state, 0);
-    __wt_atomic_store_bool_relaxed(&conn->flush_ckpt_complete, false);
+    __wt_atomic_store_uint32_v_relaxed(&conn->tiered.flush_state, 0);
+    __wt_atomic_store_bool_relaxed(&conn->tiered.flush_ckpt_complete, false);
     /* Flushing is part of a checkpoint, use the session's checkpoint time. */
-    conn->flush_most_recent = session->ckpt.current_sec;
+    conn->tiered.flush_most_recent = session->ckpt.current_sec;
     /* Storing the last flush timestamp here for the future and for debugging. */
-    conn->flush_ts = conn->txn_global.last_ckpt_timestamp;
+    conn->tiered.flush_ts = conn->txn_global.last_ckpt_timestamp;
     /*
      * It would be more efficient to return here if no tiered storage is enabled in the system. If
      * the user asks for a flush_tier without tiered storage, the loop below is effectively a no-op
@@ -1329,7 +1329,7 @@ __checkpoint_establish_time(WT_SESSION_IMPL *session)
      */
 
     __wt_seconds(session, &ckpt_sec);
-    ckpt_sec = WT_MAX(ckpt_sec, conn->flush_most_recent);
+    ckpt_sec = WT_MAX(ckpt_sec, conn->tiered.flush_most_recent);
 
     for (;;) {
         WT_ACQUIRE_READ_WITH_BARRIER(most_recent, conn->ckpt.most_recent);
@@ -1973,9 +1973,9 @@ __checkpoint_db_wrapper(WT_SESSION_IMPL *session, const char *cfg[])
      * Signal the tiered storage thread because it waits for the checkpoint to complete to process
      * flush units. Indicate that the checkpoint has completed.
      */
-    if (conn->tiered_cond != NULL) {
-        __wt_atomic_store_bool_relaxed(&conn->flush_ckpt_complete, true);
-        __wt_cond_signal(session, conn->tiered_cond);
+    if (conn->tiered.cond != NULL) {
+        __wt_atomic_store_bool_relaxed(&conn->tiered.flush_ckpt_complete, true);
+        __wt_cond_signal(session, conn->tiered.cond);
     }
 
     return (ret);

--- a/src/conn/conn_handle.c
+++ b/src/conn/conn_handle.c
@@ -20,12 +20,14 @@ __wti_connection_init(WT_CONNECTION_IMPL *conn)
 
     session = conn->default_session;
 
-    TAILQ_INIT(&conn->dhqh);            /* Data handle list */
-    TAILQ_INIT(&conn->dlhqh);           /* Library list */
-    TAILQ_INIT(&conn->dsrcqh);          /* Data source list */
-    TAILQ_INIT(&conn->fhqh);            /* File list */
-    TAILQ_INIT(&conn->tiered.tieredqh); /* Tiered work unit list */
+    TAILQ_INIT(&conn->dhqh);  /* Data handle list */
+    TAILQ_INIT(&conn->dlhqh); /* Library list */
+    TAILQ_INIT(&conn->dsrcqh); /* Data source list */
+    TAILQ_INIT(&conn->fhqh);  /* File list */
     WT_RET(__wti_conn_prefetch_init(session));
+
+    /* Tiered storage. */
+    WT_RET(__wti_conn_tiered_init(session));
 
     /* Extension interface lists. */
     WT_RET(__wti_conn_ext_init(session));
@@ -49,11 +51,9 @@ __wti_connection_init(WT_CONNECTION_IMPL *conn)
     WT_RET(__wt_spin_init(
       session, &conn->disaggregated_storage.shared_metadata_queue_lock, "update shared metadata"));
     WT_RET(__wt_spin_init(session, &conn->fh_lock, "file list"));
-    WT_RET(__wt_spin_init(session, &conn->tiered.flush_tier_lock, "flush tier"));
     WT_SPIN_INIT_TRACKED(session, &conn->metadata_lock, metadata);
     WT_RET(__wt_spin_init(session, &conn->reconfig_lock, "reconfigure"));
     WT_SPIN_INIT_SESSION_TRACKED(session, &conn->schema_lock, schema);
-    WT_RET(__wt_spin_init(session, &conn->tiered.tiered_lock, "tiered work unit list"));
     WT_RET(__wt_spin_init(session, &conn->turtle_lock, "turtle file"));
 
     /* Read-write locks */
@@ -111,15 +111,16 @@ __wti_connection_destroy(WT_CONNECTION_IMPL *conn)
     __wt_rwlock_destroy(session, &conn->log_mgr.debug_log_retention_lock);
     __wt_rwlock_destroy(session, &conn->dhandle_lock);
     __wt_spin_destroy(session, &conn->fh_lock);
-    __wt_spin_destroy(session, &conn->tiered.flush_tier_lock);
     __wt_rwlock_destroy(session, &conn->hot_backup_lock);
     __wt_spin_destroy(session, &conn->metadata_lock);
     __wt_spin_destroy(session, &conn->reconfig_lock);
     __wt_spin_destroy(session, &conn->schema_lock);
     __wt_rwlock_destroy(session, &conn->table_lock);
-    __wt_spin_destroy(session, &conn->tiered.tiered_lock);
     __wt_spin_destroy(session, &conn->turtle_lock);
     __wti_conn_prefetch_destroy(session);
+
+    /* Tiered storage. */
+    __wti_conn_tiered_destroy(session);
 
     /* Extension interface lists. */
     __wti_conn_ext_destroy(session);

--- a/src/conn/conn_handle.c
+++ b/src/conn/conn_handle.c
@@ -20,10 +20,10 @@ __wti_connection_init(WT_CONNECTION_IMPL *conn)
 
     session = conn->default_session;
 
-    TAILQ_INIT(&conn->dhqh);  /* Data handle list */
-    TAILQ_INIT(&conn->dlhqh); /* Library list */
+    TAILQ_INIT(&conn->dhqh);   /* Data handle list */
+    TAILQ_INIT(&conn->dlhqh);  /* Library list */
     TAILQ_INIT(&conn->dsrcqh); /* Data source list */
-    TAILQ_INIT(&conn->fhqh);  /* File list */
+    TAILQ_INIT(&conn->fhqh);   /* File list */
     WT_RET(__wti_conn_prefetch_init(session));
 
     /* Tiered storage. */

--- a/src/conn/conn_handle.c
+++ b/src/conn/conn_handle.c
@@ -20,11 +20,11 @@ __wti_connection_init(WT_CONNECTION_IMPL *conn)
 
     session = conn->default_session;
 
-    TAILQ_INIT(&conn->dhqh);     /* Data handle list */
-    TAILQ_INIT(&conn->dlhqh);    /* Library list */
-    TAILQ_INIT(&conn->dsrcqh);   /* Data source list */
-    TAILQ_INIT(&conn->fhqh);     /* File list */
-    TAILQ_INIT(&conn->tieredqh); /* Tiered work unit list */
+    TAILQ_INIT(&conn->dhqh);            /* Data handle list */
+    TAILQ_INIT(&conn->dlhqh);           /* Library list */
+    TAILQ_INIT(&conn->dsrcqh);          /* Data source list */
+    TAILQ_INIT(&conn->fhqh);            /* File list */
+    TAILQ_INIT(&conn->tiered.tieredqh); /* Tiered work unit list */
     WT_RET(__wti_conn_prefetch_init(session));
 
     /* Extension interface lists. */
@@ -49,11 +49,11 @@ __wti_connection_init(WT_CONNECTION_IMPL *conn)
     WT_RET(__wt_spin_init(
       session, &conn->disaggregated_storage.shared_metadata_queue_lock, "update shared metadata"));
     WT_RET(__wt_spin_init(session, &conn->fh_lock, "file list"));
-    WT_RET(__wt_spin_init(session, &conn->flush_tier_lock, "flush tier"));
+    WT_RET(__wt_spin_init(session, &conn->tiered.flush_tier_lock, "flush tier"));
     WT_SPIN_INIT_TRACKED(session, &conn->metadata_lock, metadata);
     WT_RET(__wt_spin_init(session, &conn->reconfig_lock, "reconfigure"));
     WT_SPIN_INIT_SESSION_TRACKED(session, &conn->schema_lock, schema);
-    WT_RET(__wt_spin_init(session, &conn->tiered_lock, "tiered work unit list"));
+    WT_RET(__wt_spin_init(session, &conn->tiered.tiered_lock, "tiered work unit list"));
     WT_RET(__wt_spin_init(session, &conn->turtle_lock, "turtle file"));
 
     /* Read-write locks */
@@ -111,13 +111,13 @@ __wti_connection_destroy(WT_CONNECTION_IMPL *conn)
     __wt_rwlock_destroy(session, &conn->log_mgr.debug_log_retention_lock);
     __wt_rwlock_destroy(session, &conn->dhandle_lock);
     __wt_spin_destroy(session, &conn->fh_lock);
-    __wt_spin_destroy(session, &conn->flush_tier_lock);
+    __wt_spin_destroy(session, &conn->tiered.flush_tier_lock);
     __wt_rwlock_destroy(session, &conn->hot_backup_lock);
     __wt_spin_destroy(session, &conn->metadata_lock);
     __wt_spin_destroy(session, &conn->reconfig_lock);
     __wt_spin_destroy(session, &conn->schema_lock);
     __wt_rwlock_destroy(session, &conn->table_lock);
-    __wt_spin_destroy(session, &conn->tiered_lock);
+    __wt_spin_destroy(session, &conn->tiered.tiered_lock);
     __wt_spin_destroy(session, &conn->turtle_lock);
     __wti_conn_prefetch_destroy(session);
 

--- a/src/conn/conn_tiered.c
+++ b/src/conn/conn_tiered.c
@@ -20,6 +20,36 @@
 #endif
 
 /*
+ * __wti_conn_tiered_init --
+ *     Initialize the WT_CONN_TIERED structure.
+ */
+int
+__wti_conn_tiered_init(WT_SESSION_IMPL *session)
+{
+    WT_CONNECTION_IMPL *conn;
+
+    conn = S2C(session);
+    TAILQ_INIT(&conn->tiered.tieredqh); /* Tiered work unit list */
+    WT_RET(__wt_spin_init(session, &conn->tiered.tiered_lock, "tiered work unit list"));
+    WT_RET(__wt_spin_init(session, &conn->tiered.flush_tier_lock, "flush tier"));
+    return (0);
+}
+
+/*
+ * __wti_conn_tiered_destroy --
+ *     Destroy the WT_CONN_TIERED structure.
+ */
+void
+__wti_conn_tiered_destroy(WT_SESSION_IMPL *session)
+{
+    WT_CONNECTION_IMPL *conn;
+
+    conn = S2C(session);
+    __wt_spin_destroy(session, &conn->tiered.tiered_lock);
+    __wt_spin_destroy(session, &conn->tiered.flush_tier_lock);
+}
+
+/*
  * __tiered_server_run_chk --
  *     Check to decide if the tiered storage server should continue running.
  */

--- a/src/conn/conn_tiered.c
+++ b/src/conn/conn_tiered.c
@@ -360,7 +360,7 @@ __tier_storage_copy(WT_SESSION_IMPL *session)
 
     conn = S2C(session);
     /* There is nothing to do until the checkpoint after the flush completes. */
-    if (!__wt_atomic_load_bool_relaxed(&conn->flush_ckpt_complete))
+    if (!__wt_atomic_load_bool_relaxed(&conn->tiered.flush_ckpt_complete))
         return (0);
     entry = NULL;
     for (;;) {
@@ -436,13 +436,13 @@ __tiered_server(void *arg)
     WT_CLEAR(tmp);
 
     /* Condition timeout is in microseconds. */
-    cond_time = conn->tiered_interval * WT_MILLION;
+    cond_time = conn->tiered.interval * WT_MILLION;
     time_start = __wt_clock(session);
     signalled = false;
     for (;;) {
         /* Wait until the next event. */
         __wt_cond_wait_signal(
-          session, conn->tiered_cond, cond_time, __tiered_server_run_chk, &signalled);
+          session, conn->tiered.cond, cond_time, __tiered_server_run_chk, &signalled);
 
         /* Check if we're quitting or being reconfigured. */
         if (!__tiered_server_run_chk(session))
@@ -456,7 +456,7 @@ __tiered_server(void *arg)
          *  - Perform any shared storage processing after flushing.
          *  - Remove any cached objects that are aged out.
          */
-        if (timediff >= conn->tiered_interval || signalled) {
+        if (timediff >= conn->tiered.interval || signalled) {
             msg = "tier_storage_copy";
             WT_ERR(__tier_storage_copy(session));
             msg = "tier_storage_finish";
@@ -496,12 +496,12 @@ __wti_tiered_storage_create(WT_SESSION_IMPL *session, bool disagg)
     }
 
     /* Start the internal thread. */
-    WT_ERR(__wt_cond_alloc(session, "flush tier", &conn->flush_cond));
-    WT_ERR(__wt_cond_alloc(session, "storage server", &conn->tiered_cond));
+    WT_ERR(__wt_cond_alloc(session, "flush tier", &conn->tiered.flush_cond));
+    WT_ERR(__wt_cond_alloc(session, "storage server", &conn->tiered.cond));
     FLD_SET(conn->server_flags, WT_CONN_SERVER_TIERED);
 
-    WT_ERR(__wt_open_internal_session(conn, "tiered-server", true, 0, 0, &conn->tiered_session));
-    session = conn->tiered_session;
+    WT_ERR(__wt_open_internal_session(conn, "tiered-server", true, 0, 0, &conn->tiered.session));
+    session = conn->tiered.session;
 
     /*
      * Check for objects that are not flushed on the first flush_tier call. We cannot do that work
@@ -510,8 +510,8 @@ __wti_tiered_storage_create(WT_SESSION_IMPL *session, bool disagg)
      */
     F_SET_ATOMIC_32(conn, WT_CONN_TIERED_FIRST_FLUSH);
     /* Start the thread. */
-    WT_ERR(__wt_thread_create(session, &conn->tiered_tid, __tiered_server, session));
-    conn->tiered_tid_set = true;
+    WT_ERR(__wt_thread_create(session, &conn->tiered.tid, __tiered_server, session));
+    conn->tiered.tid_set = true;
 
     if (0) {
 err:
@@ -538,32 +538,32 @@ __wti_tiered_storage_destroy(WT_SESSION_IMPL *session, bool final_flush)
      * Stop the internal server thread. If there is unfinished work, we will recover it on startup
      * just as if there had been a system failure.
      */
-    if (conn->flush_cond != NULL)
-        __wt_cond_signal(session, conn->flush_cond);
-    if (final_flush && conn->tiered_cond != NULL) {
-        __wt_cond_signal(session, conn->tiered_cond);
+    if (conn->tiered.flush_cond != NULL)
+        __wt_cond_signal(session, conn->tiered.flush_cond);
+    if (final_flush && conn->tiered.cond != NULL) {
+        __wt_cond_signal(session, conn->tiered.cond);
         __wt_tiered_flush_work_wait(session, 30);
     }
     FLD_CLR(conn->server_flags, WT_CONN_SERVER_TIERED);
-    if (conn->tiered_tid_set) {
-        WT_ASSERT(session, conn->tiered_cond != NULL);
-        __wt_cond_signal(session, conn->tiered_cond);
-        WT_TRET(__wt_thread_join(session, &conn->tiered_tid));
-        conn->tiered_tid_set = false;
-        while ((entry = TAILQ_FIRST(&conn->tieredqh)) != NULL) {
-            TAILQ_REMOVE(&conn->tieredqh, entry, q);
+    if (conn->tiered.tid_set) {
+        WT_ASSERT(session, conn->tiered.cond != NULL);
+        __wt_cond_signal(session, conn->tiered.cond);
+        WT_TRET(__wt_thread_join(session, &conn->tiered.tid));
+        conn->tiered.tid_set = false;
+        while ((entry = TAILQ_FIRST(&conn->tiered.tieredqh)) != NULL) {
+            TAILQ_REMOVE(&conn->tiered.tieredqh, entry, q);
             __wt_tiered_work_free(session, entry);
         }
     }
-    if (conn->tiered_session != NULL) {
-        WT_TRET(__wt_session_close_internal(conn->tiered_session));
-        conn->tiered_session = NULL;
+    if (conn->tiered.session != NULL) {
+        WT_TRET(__wt_session_close_internal(conn->tiered.session));
+        conn->tiered.session = NULL;
     }
 
     /* Destroy all condition variables after threads have stopped. */
-    __wt_cond_destroy(session, &conn->tiered_cond);
+    __wt_cond_destroy(session, &conn->tiered.cond);
     /* The flush condition variable must be last because any internal thread could be using it. */
-    __wt_cond_destroy(session, &conn->flush_cond);
+    __wt_cond_destroy(session, &conn->tiered.flush_cond);
 
     return (ret);
 }

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -608,6 +608,30 @@ struct __wt_conn_sweep {
 };
 
 /*
+ * WT_CONN_TIERED --
+ *	Fields for the tiered storage server thread and its associated queue and locks.
+ */
+struct __wt_conn_tiered {
+    /* Locked: tiered system work queue */
+    TAILQ_HEAD(__wt_tiered_qh, __wt_tiered_work_unit) tieredqh;
+
+    WT_SPINLOCK tiered_lock;     /* Tiered work queue spinlock */
+    WT_SPINLOCK flush_tier_lock; /* Flush tier spinlock */
+
+    WT_SESSION_IMPL *session;           /* Tiered thread session */
+    wt_thread_t tid;                    /* Tiered thread */
+    bool tid_set;                       /* Tiered thread set */
+    WT_CONDVAR *flush_cond;             /* Flush wait mutex */
+    WT_CONDVAR *cond;                   /* Tiered wait mutex */
+    uint64_t interval;                  /* Tiered work interval */
+    bool server_running;                /* Internal tiered server operating */
+    wt_shared bool flush_ckpt_complete; /* Checkpoint after flush completed */
+    uint64_t flush_most_recent;         /* Clock value of last flush_tier */
+    uint32_t flush_state;               /* State of last flush tier */
+    wt_timestamp_t flush_ts;            /* Timestamp of most recent flush_tier */
+};
+
+/*
  * WT_CONN_CHECK_PANIC --
  *	Check if we've panicked and return the appropriate error.
  */
@@ -744,12 +768,10 @@ struct __wt_connection_impl {
     WT_SPINLOCK api_lock;        /* Connection API spinlock */
     WT_SPINLOCK checkpoint_lock; /* Checkpoint spinlock */
     WT_SPINLOCK fh_lock;         /* File handle queue spinlock */
-    WT_SPINLOCK flush_tier_lock; /* Flush tier spinlock */
     WT_SPINLOCK metadata_lock;   /* Metadata update spinlock */
     WT_SPINLOCK reconfig_lock;   /* Single thread reconfigure */
     WT_SPINLOCK schema_lock;     /* Schema operation spinlock */
     WT_RWLOCK table_lock;        /* Table list lock */
-    WT_SPINLOCK tiered_lock;     /* Tiered work queue spinlock */
     WT_SPINLOCK turtle_lock;     /* Turtle file spinlock */
     WT_RWLOCK dhandle_lock;      /* Data handle list lock */
 
@@ -819,8 +841,6 @@ struct __wt_connection_impl {
     /* Locked: file list */
     TAILQ_HEAD(__wt_fhhash, __wt_fh) * fhhash;
     TAILQ_HEAD(__wt_fh_qh, __wt_fh) fhqh;
-    /* Locked: Tiered system work queue. */
-    TAILQ_HEAD(__wt_tiered_qh, __wt_tiered_work_unit) tieredqh;
 
     WT_SPINLOCK block_lock; /* Locked: block manager list */
     TAILQ_HEAD(__wt_blockhash, __wt_block) * blockhash;
@@ -951,17 +971,7 @@ struct __wt_connection_impl {
 
     WT_CONN_STAT_LOG stat_log; /* Statistics logging subsystem */
 
-    WT_SESSION_IMPL *tiered_session;    /* Tiered thread session */
-    wt_thread_t tiered_tid;             /* Tiered thread */
-    bool tiered_tid_set;                /* Tiered thread set */
-    WT_CONDVAR *flush_cond;             /* Flush wait mutex */
-    WT_CONDVAR *tiered_cond;            /* Tiered wait mutex */
-    uint64_t tiered_interval;           /* Tiered work interval */
-    bool tiered_server_running;         /* Internal tiered server operating */
-    wt_shared bool flush_ckpt_complete; /* Checkpoint after flush completed */
-    uint64_t flush_most_recent;         /* Clock value of last flush_tier */
-    uint32_t flush_state;               /* State of last flush tier */
-    wt_timestamp_t flush_ts;            /* Timestamp of most recent flush_tier */
+    WT_CONN_TIERED tiered; /* Tiered storage server thread fields */
 
     WT_LOG_MANAGER log_mgr;
 

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1445,6 +1445,8 @@ extern int __wti_conn_remove_storage_source(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_conn_statistics_config(WT_SESSION_IMPL *session, const char *cfg[])
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wti_conn_tiered_init(WT_SESSION_IMPL *session)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_connection_close(WT_CONNECTION_IMPL *conn)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_connection_init(WT_CONNECTION_IMPL *conn)
@@ -1921,6 +1923,7 @@ extern void __wti_ckpt_verbose(WT_SESSION_IMPL *session, WT_BLOCK *block, const 
   const char *ckpt_name, const uint8_t *ckpt_string, size_t ckpt_size);
 extern void __wti_conn_ext_destroy(WT_SESSION_IMPL *session);
 extern void __wti_conn_prefetch_destroy(WT_SESSION_IMPL *session);
+extern void __wti_conn_tiered_destroy(WT_SESSION_IMPL *session);
 extern void __wti_connection_destroy(WT_CONNECTION_IMPL *conn);
 extern void __wti_cursor_reopen(WT_CURSOR *cursor, WT_DATA_HANDLE *dhandle);
 extern void __wti_cursor_set_key_notsup(WT_CURSOR *cursor, ...);

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -181,6 +181,8 @@ struct __wt_conn_stat_log;
 typedef struct __wt_conn_stat_log WT_CONN_STAT_LOG;
 struct __wt_conn_sweep;
 typedef struct __wt_conn_sweep WT_CONN_SWEEP;
+struct __wt_conn_tiered;
+typedef struct __wt_conn_tiered WT_CONN_TIERED;
 struct __wt_connection_impl;
 typedef struct __wt_connection_impl WT_CONNECTION_IMPL;
 struct __wt_connection_stats;

--- a/src/schema/schema_drop.c
+++ b/src/schema/schema_drop.c
@@ -385,7 +385,7 @@ __drop_tiered(
      * remove the work. So hold the tiered lock for the duration so that the worker thread cannot
      * race and process work for this handle.
      */
-    __wt_spin_lock(session, &conn->tiered_lock);
+    __wt_spin_lock(session, &conn->tiered.tiered_lock);
     /*
      * Close all btree handles associated with this table. This must be done after we're done using
      * the tiered structure because that is from the dhandle.
@@ -481,7 +481,7 @@ __drop_tiered(
      */
     __wt_verbose(session, WT_VERB_TIERED, "DROP_TIERED: remove work for %p", (void *)tiered);
     __wt_tiered_remove_work(session, tiered, true);
-    __wt_spin_unlock(session, &conn->tiered_lock);
+    __wt_spin_unlock(session, &conn->tiered.tiered_lock);
 
     ret = __wt_metadata_remove(session, uri);
 
@@ -489,7 +489,7 @@ err:
     if (got_dhandle)
         WT_TRET(__wt_session_release_dhandle(session));
     __wt_free(session, name);
-    __wt_spin_unlock_if_owned(session, &conn->tiered_lock);
+    __wt_spin_unlock_if_owned(session, &conn->tiered.tiered_lock);
     return (ret);
 }
 

--- a/src/tiered/tiered_config.c
+++ b/src/tiered/tiered_config.c
@@ -167,7 +167,7 @@ __wt_tiered_conn_config(WT_SESSION_IMPL *session, const char **cfg, bool reconfi
 
     /* Set up the rest of the tiered storage configuration. c*/
     WT_ERR(__wt_config_gets(session, cfg, "tiered_storage.interval", &cval));
-    conn->tiered_interval = (uint64_t)cval.val;
+    conn->tiered.interval = (uint64_t)cval.val;
 
     WT_ASSERT(session, WT_CONN_TIERED_STORAGE_ENABLED(conn));
     WT_STAT_CONN_SET(session, tiered_retention, conn->bstorage->retain_secs);

--- a/src/tiered/tiered_work.c
+++ b/src/tiered/tiered_work.c
@@ -21,9 +21,9 @@ __tiered_flush_state(WT_SESSION_IMPL *session, uint32_t type, bool incr)
         return;
     conn = S2C(session);
     if (incr)
-        (void)__wt_atomic_add_uint32_v(&conn->flush_state, 1);
+        (void)__wt_atomic_add_uint32_v(&conn->tiered.flush_state, 1);
     else
-        (void)__wt_atomic_sub_uint32_v(&conn->flush_state, 1);
+        (void)__wt_atomic_sub_uint32_v(&conn->tiered.flush_state, 1);
 }
 
 /*
@@ -39,8 +39,8 @@ __wt_tiered_work_free(WT_SESSION_IMPL *session, WT_TIERED_WORK_UNIT *entry)
     WT_DHANDLE_RELEASE((WT_DATA_HANDLE *)&entry->tiered->iface);
     __tiered_flush_state(session, entry->type, false);
     /* If all work is done signal any waiting thread waiting for sync. */
-    if (WT_FLUSH_STATE_DONE(conn->flush_state))
-        __wt_cond_signal(session, conn->flush_cond);
+    if (WT_FLUSH_STATE_DONE(conn->tiered.flush_state))
+        __wt_cond_signal(session, conn->tiered.flush_cond);
     __wt_free(session, entry);
 }
 
@@ -56,18 +56,18 @@ __wt_tiered_remove_work(WT_SESSION_IMPL *session, WT_TIERED *tiered, bool locked
 
     conn = S2C(session);
     if (!locked)
-        __wt_spin_lock(session, &conn->tiered_lock);
-    TAILQ_FOREACH_SAFE(entry, &conn->tieredqh, q, entry_tmp)
+        __wt_spin_lock(session, &conn->tiered.tiered_lock);
+    TAILQ_FOREACH_SAFE(entry, &conn->tiered.tieredqh, q, entry_tmp)
     {
         /* Remove and free any entry for this tiered handle. */
         if (entry->tiered == tiered) {
-            TAILQ_REMOVE(&conn->tieredqh, entry, q);
+            TAILQ_REMOVE(&conn->tiered.tieredqh, entry, q);
             WT_STAT_CONN_INCR(session, tiered_work_units_removed);
             __wt_tiered_work_free(session, entry);
         }
     }
     if (!locked)
-        __wt_spin_unlock(session, &conn->tiered_lock);
+        __wt_spin_unlock(session, &conn->tiered.tiered_lock);
     return;
 }
 
@@ -81,13 +81,13 @@ __tiered_push_work_internal(WT_SESSION_IMPL *session, WT_TIERED_WORK_UNIT *entry
     WT_CONNECTION_IMPL *conn;
 
     conn = S2C(session);
-    __wt_spin_lock(session, &conn->tiered_lock);
-    TAILQ_INSERT_TAIL(&conn->tieredqh, entry, q);
+    __wt_spin_lock(session, &conn->tiered.tiered_lock);
+    TAILQ_INSERT_TAIL(&conn->tiered.tieredqh, entry, q);
     WT_ASSERT(session, entry->tiered != NULL);
     WT_STAT_CONN_INCR(session, tiered_work_units_created);
-    __wt_spin_unlock(session, &conn->tiered_lock);
+    __wt_spin_unlock(session, &conn->tiered.tiered_lock);
     __tiered_flush_state(session, entry->type, true);
-    __wt_cond_signal(session, conn->tiered_cond);
+    __wt_cond_signal(session, conn->tiered.cond);
     return;
 }
 
@@ -131,7 +131,7 @@ __tiered_push_new_work(WT_SESSION_IMPL *session, WT_TIERED_WORK_UNIT *entry)
 static inline bool
 __tiered_queue_peek_empty(WT_CONNECTION_IMPL *conn)
 {
-    return (TAILQ_EMPTY(&conn->tieredqh));
+    return (TAILQ_EMPTY(&conn->tiered.tieredqh));
 }
 
 /*
@@ -152,11 +152,11 @@ __tiered_pop_work(
     conn = S2C(session);
     if (__tiered_queue_peek_empty(conn))
         return;
-    __wt_spin_lock(session, &conn->tiered_lock);
+    __wt_spin_lock(session, &conn->tiered.tiered_lock);
 
-    TAILQ_FOREACH (entry, &conn->tieredqh, q) {
+    TAILQ_FOREACH (entry, &conn->tiered.tieredqh, q) {
         if (FLD_ISSET(type, entry->type) && (maxval == 0 || entry->op_val < maxval)) {
-            TAILQ_REMOVE(&conn->tieredqh, entry, q);
+            TAILQ_REMOVE(&conn->tiered.tieredqh, entry, q);
             WT_STAT_CONN_INCR(session, tiered_work_units_dequeued);
             WT_ASSERT(session, entry->tiered != NULL);
             WT_ASSERT(session, entry->tiered->bstorage != NULL);
@@ -164,7 +164,7 @@ __tiered_pop_work(
             break;
         }
     }
-    __wt_spin_unlock(session, &conn->tiered_lock);
+    __wt_spin_unlock(session, &conn->tiered.tiered_lock);
     return;
 }
 
@@ -188,16 +188,16 @@ __wt_tiered_flush_work_wait(WT_SESSION_IMPL *session, uint32_t timeout)
 
     while (!done) {
         found = false;
-        __wt_spin_lock(session, &conn->tiered_lock);
-        TAILQ_FOREACH (entry, &conn->tieredqh, q)
+        __wt_spin_lock(session, &conn->tiered.tiered_lock);
+        TAILQ_FOREACH (entry, &conn->tiered.tieredqh, q)
             if (FLD_ISSET(entry->type, WT_TIERED_WORK_FLUSH)) {
                 found = true;
                 break;
             }
 
-        __wt_spin_unlock(session, &conn->tiered_lock);
+        __wt_spin_unlock(session, &conn->tiered.tiered_lock);
         if (found) {
-            __wt_cond_signal(session, conn->tiered_cond);
+            __wt_cond_signal(session, conn->tiered.cond);
             __wt_sleep(0, 10 * WT_THOUSAND);
             __wt_epoch(session, &now);
         }


### PR DESCRIPTION
## Summary
- Introduces `WT_CONN_TIERED` (`struct __wt_conn_tiered`), a new sub-struct in `__wt_connection_impl` that owns all tiered-storage thread management state
- Moves 13 fields out of the flat connection struct: the tiered work queue (`tieredqh`), thread handle (`session`, `tid`, `tid_set`), condvars (`cond`, `flush_cond`), timing (`interval`), liveness flag (`server_running`), and flush state (`flush_ckpt_complete`, `flush_most_recent`, `flush_state`, `flush_ts`)
- Both spinlocks that guard tiered operations (`tiered_lock`, `flush_tier_lock`) travel into the sub-struct, following the purpose-based grouping convention established in SPM-3483
- Access paths updated from `conn->tiered_*` / `conn->flush_*` to `conn->tiered.<field>` across 8 files; grep confirms no stale references remain
- Follows the same struct placement and naming conventions as WT-17491 (WT_CONN_EXTENSIONS) and WT-17492 (WT_CONN_STAT_LOG)

## Testing
Pure refactor — no behaviour change. Verified by:
- Clean `ninja wt` build with no warnings
- Grep across `src/` and `test/` confirms no stale references to old field paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)