### PR TITLE
WT-17514 Perf - Do not fail if a stat field is absent

### DIFF
--- a/bench/perf_run_py/perf_stat.py
+++ b/bench/perf_run_py/perf_stat.py
@@ -58,6 +58,9 @@ class PerfStat:
             self.values.append(converted_value)
 
     def find_stat(self, test_stat_path: str):
+        if not os.path.exists(test_stat_path):
+            return []
+
         matches = []
         for line in open(test_stat_path):
             match = re.search(self.pattern, line)
@@ -104,8 +107,13 @@ class PerfStatMinMax(PerfStat):
 class PerfStatCount(PerfStat):
     def find_stat(self, test_stat_path: str):
         """Return the total number of times a pattern matched"""
+
+        paths = glob.glob(test_stat_path)
+        if not paths:
+            return []
+
+        test_stat_path = paths[0]
         total = 0
-        test_stat_path = glob.glob(test_stat_path)[0]
         for line in open(test_stat_path):
             match = re.search(self.pattern, line)
             if match:

--- a/bench/perf_run_py/perf_stat_collection.py
+++ b/bench/perf_run_py/perf_stat_collection.py
@@ -45,23 +45,13 @@ class PerfStatCollection:
 
     def find_stats(self, test_home: str):
         for stat in self.to_report:
-            matched = []
-            for filename in stat.stat_files:
-                test_stat_path = create_test_stat_path(test_home, filename)
-                try:
-                    values = stat.find_stat(test_stat_path=test_stat_path)
-                except (FileNotFoundError, IndexError):
-                    # Missing some files is fine since the stat should exist in exactly one file.
-                    continue
-                if values:
-                    matched.append(values)
-            if len(matched) > 1:
-                raise RuntimeError(
-                    f"Stat '{stat.short_label}' matched in more than one file: {stat.stat_files}")
-            if len(matched) == 0:
-                raise RuntimeError(
-                    f"Stat '{stat.short_label}' hasn't been found in any of files: {stat.stat_files}")
-            stat.add_values(values=matched[0])
+            values = None
+            for f in stat.stat_files:
+                v = stat.find_stat(create_test_stat_path(test_home, f))
+                if v and values:
+                    raise RuntimeError(f"Stat '{stat.short_label}' matched in more than one file: {stat.stat_files}")
+                values = v
+            stat.add_values(values=values)
 
 
     @staticmethod


### PR DESCRIPTION
Now many-dhandle-stress  is failing with the following error message:

```
Stat 'xxx' hasn't been found in any of files: ['yyy']
```

The culprit commit is https://github.com/wiredtiger/wiredtiger/commit/00fd8270069d98d447855e5e92ccce96272f0a35

We changed the behavior unintentionally there and now perf_run.py reports an error if a stat hasn't been reported in any file which previously was fine. 

This PR changes this behavior back.