### PR TITLE
WT-17527 Fix statistics counting

### DIFF
--- a/bench/perf_run_py/perf_stat.py
+++ b/bench/perf_run_py/perf_stat.py
@@ -130,6 +130,8 @@ class PerfStatLatency(PerfStat):
         self.ops = ops
 
     def find_stat(self, test_stat_path: str):
+        if not os.path.exists(test_stat_path):
+            return []
         values = []
         for line in open(test_stat_path):
             as_dict = json.loads(line)
@@ -189,6 +191,8 @@ class PerfStatMonitorAvg(PerfStat):
         self.field = field
 
     def find_stat(self, test_stat_path: str):
+        if not os.path.exists(test_stat_path):
+            return []
         values = []
         for line in open(test_stat_path):
             as_dict = json.loads(line)

--- a/bench/perf_run_py/perf_stat_collection.py
+++ b/bench/perf_run_py/perf_stat_collection.py
@@ -45,12 +45,12 @@ class PerfStatCollection:
 
     def find_stats(self, test_home: str):
         for stat in self.to_report:
-            values = None
+            values = []
             for f in stat.stat_files:
                 v = stat.find_stat(create_test_stat_path(test_home, f))
                 if v and values:
                     raise RuntimeError(f"Stat '{stat.short_label}' matched in more than one file: {stat.stat_files}")
-                values = v
+                values = v or values
             stat.add_values(values=values)
 
 


### PR DESCRIPTION
When we merged [WT-17514](https://jira.mongodb.org/browse/WT-17514) (that was another hotfix) we introduced a new issue. 

The root cause is in perf_stat_collection.py values = v is unconditional, so the last iteration of the loop always overwrites values, even with an empty list.

Here's the exact scenario for read_ops and update_ops, which both have stat_files=['test.stat', 'workload.stat']:

- Iteration 1 (test.stat): stat is found  v = [1234.0], values = None ( condition is False  values = [1234.0] 
- Iteration 2 (workload.stat): file absent find_stat returns []  if v and values is False (because v is falsy) values = [] overwrites the good values with an empty list

Then sum([]) / len([]) gives ZeroDivisionError.

This PR fixes this + adds a non existent files guard in a couple of potentially dangerous places
