### PR TITLE
WT-17495 Extract handle sweep thread fields into WT_CONN_SWEEP

### DIFF
--- a/src/conn/conn_sweep.c
+++ b/src/conn/conn_sweep.c
@@ -191,7 +191,7 @@ __sweep_expire(WT_SESSION_IMPL *session, uint64_t now)
 
     TAILQ_FOREACH (dhandle, &conn->dhqh, q) {
         bool sweep_non_outdated_handle =
-          __wt_atomic_load_uint32_relaxed(&conn->open_btree_count) >= conn->sweep_handles_min;
+          __wt_atomic_load_uint32_relaxed(&conn->open_btree_count) >= conn->sweep.handles_min;
         /*
          * Ignore open files once the btree file count is below the minimum number of handles.
          */
@@ -210,7 +210,7 @@ __sweep_expire(WT_SESSION_IMPL *session, uint64_t now)
         } else if (WT_IS_METADATA(dhandle) || !F_ISSET(dhandle, WT_DHANDLE_OPEN) ||
           __wt_atomic_load_int32_relaxed(&dhandle->session_inuse) != 0 ||
           __wt_tsan_suppress_load_uint64(&dhandle->timeofdeath) == 0 ||
-          now - dhandle->timeofdeath <= conn->sweep_idle_time)
+          now - dhandle->timeofdeath <= conn->sweep.idle_time)
             continue;
 
         /*
@@ -455,10 +455,10 @@ __sweep_server(void *arg)
     for (;;) {
         /* Wait until the next event. */
         if (FLD_ISSET(conn->timing_stress_flags, WT_TIMING_STRESS_AGGRESSIVE_SWEEP))
-            sweep_interval = conn->sweep_interval / 10;
+            sweep_interval = conn->sweep.interval / 10;
         else
-            sweep_interval = conn->sweep_interval;
-        __wt_cond_wait_signal(session, conn->sweep_cond, sweep_interval * WT_MILLION,
+            sweep_interval = conn->sweep.interval;
+        __wt_cond_wait_signal(session, conn->sweep.cond, sweep_interval * WT_MILLION,
           __sweep_server_run_chk, &cv_signalled);
 
         /* Check if we're quitting or being reconfigured. */
@@ -486,15 +486,15 @@ __sweep_server(void *arg)
          * Mark handles with a time of death, and report whether any handles are marked dead. If
          * sweep_idle_time is 0, handles never become idle.
          */
-        if (conn->sweep_idle_time != 0)
+        if (conn->sweep.idle_time != 0)
             __sweep_mark(session, now);
 
         /*
          * Close handles if we have reached the configured limit or in disaggregated storage. If
          * sweep_idle_time is 0, handles never become idle.
          */
-        if (conn->sweep_idle_time != 0 &&
-          (__wt_atomic_load_uint32_relaxed(&conn->open_btree_count) >= conn->sweep_handles_min ||
+        if (conn->sweep.idle_time != 0 &&
+          (__wt_atomic_load_uint32_relaxed(&conn->open_btree_count) >= conn->sweep.handles_min ||
             __wt_conn_is_disagg(session)))
             WT_ERR(__sweep_expire(session, now));
 
@@ -538,18 +538,18 @@ __wti_sweep_config(WT_SESSION_IMPL *session, const char *cfg[])
      * A non-zero idle time is incompatible with in-memory, and the default is non-zero; set the
      * in-memory configuration idle time to zero.
      */
-    conn->sweep_idle_time = 0;
+    conn->sweep.idle_time = 0;
     WT_RET(__wt_config_gets(session, cfg, "in_memory", &cval));
     if (cval.val == 0) {
         WT_RET(__wt_config_gets(session, cfg, "file_manager.close_idle_time", &cval));
-        conn->sweep_idle_time = (uint64_t)cval.val;
+        conn->sweep.idle_time = (uint64_t)cval.val;
     }
 
     WT_RET(__wt_config_gets(session, cfg, "file_manager.close_scan_interval", &cval));
-    conn->sweep_interval = (uint64_t)cval.val;
+    conn->sweep.interval = (uint64_t)cval.val;
 
     WT_RET(__wt_config_gets(session, cfg, "file_manager.close_handle_minimum", &cval));
-    conn->sweep_handles_min = (uint64_t)cval.val;
+    conn->sweep.handles_min = (uint64_t)cval.val;
 
     return (0);
 }
@@ -575,13 +575,13 @@ __wti_sweep_create(WT_SESSION_IMPL *session)
      */
     session_flags = WT_SESSION_CAN_WAIT | WT_SESSION_IGNORE_CACHE_SIZE;
     WT_RET(__wt_open_internal_session(
-      conn, "sweep-server", true, session_flags, 0, &conn->sweep_session));
-    session = conn->sweep_session;
+      conn, "sweep-server", true, session_flags, 0, &conn->sweep.session));
+    session = conn->sweep.session;
 
-    WT_RET(__wt_cond_alloc(session, "handle sweep server", &conn->sweep_cond));
+    WT_RET(__wt_cond_alloc(session, "handle sweep server", &conn->sweep.cond));
 
-    WT_RET(__wt_thread_create(session, &conn->sweep_tid, __sweep_server, session));
-    conn->sweep_tid_set = 1;
+    WT_RET(__wt_thread_create(session, &conn->sweep.tid, __sweep_server, session));
+    conn->sweep.tid_set = 1;
 
     return (0);
 }
@@ -599,17 +599,17 @@ __wti_sweep_destroy(WT_SESSION_IMPL *session)
     conn = S2C(session);
 
     FLD_CLR(conn->server_flags, WT_CONN_SERVER_SWEEP);
-    if (conn->sweep_tid_set) {
-        __wt_cond_signal(session, conn->sweep_cond);
-        WT_TRET(__wt_thread_join(session, &conn->sweep_tid));
-        conn->sweep_tid_set = 0;
+    if (conn->sweep.tid_set) {
+        __wt_cond_signal(session, conn->sweep.cond);
+        WT_TRET(__wt_thread_join(session, &conn->sweep.tid));
+        conn->sweep.tid_set = 0;
     }
-    __wt_cond_destroy(session, &conn->sweep_cond);
+    __wt_cond_destroy(session, &conn->sweep.cond);
 
-    if (conn->sweep_session != NULL) {
-        WT_TRET(__wt_session_close_internal(conn->sweep_session));
+    if (conn->sweep.session != NULL) {
+        WT_TRET(__wt_session_close_internal(conn->sweep.session));
 
-        conn->sweep_session = NULL;
+        conn->sweep.session = NULL;
     }
 
     return (ret);

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -578,6 +578,21 @@ struct __wt_conn_stat_log {
 };
 
 /*
+ * WT_CONN_SWEEP --
+ *	Handle sweep subsystem fields, grouping the session, thread, and
+ *	configuration that drive the handle sweep server.
+ */
+struct __wt_conn_sweep {
+    WT_SESSION_IMPL *session; /* Handle sweep session */
+    wt_thread_t tid;          /* Handle sweep thread */
+    int tid_set;              /* Handle sweep thread set */
+    WT_CONDVAR *cond;         /* Handle sweep wait mutex */
+    uint64_t idle_time;       /* Handle sweep idle time */
+    uint64_t interval;        /* Handle sweep interval */
+    uint64_t handles_min;     /* Handle sweep minimum open */
+};
+
+/*
  * WT_CONN_CHECK_PANIC --
  *	Check if we've panicked and return the appropriate error.
  */
@@ -942,13 +957,7 @@ struct __wt_connection_impl {
      */
     bool modified;
 
-    WT_SESSION_IMPL *sweep_session; /* Handle sweep session */
-    wt_thread_t sweep_tid;          /* Handle sweep thread */
-    int sweep_tid_set;              /* Handle sweep thread set */
-    WT_CONDVAR *sweep_cond;         /* Handle sweep wait mutex */
-    uint64_t sweep_idle_time;       /* Handle sweep idle time */
-    uint64_t sweep_interval;        /* Handle sweep interval */
-    uint64_t sweep_handles_min;     /* Handle sweep minimum open */
+    WT_CONN_SWEEP sweep; /* Handle sweep thread and configuration */
 
     WT_CONN_EXTENSIONS ext; /* Extension interface lists */
 

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -175,6 +175,8 @@ struct __wt_conn_extensions;
 typedef struct __wt_conn_extensions WT_CONN_EXTENSIONS;
 struct __wt_conn_stat_log;
 typedef struct __wt_conn_stat_log WT_CONN_STAT_LOG;
+struct __wt_conn_sweep;
+typedef struct __wt_conn_sweep WT_CONN_SWEEP;
 struct __wt_connection_impl;
 typedef struct __wt_connection_impl WT_CONNECTION_IMPL;
 struct __wt_connection_stats;

--- a/src/meta/meta_track.c
+++ b/src/meta/meta_track.c
@@ -336,8 +336,8 @@ err:
      * Wake up the sweep thread: particularly for the in-memory storage engine, we want to reclaim
      * space immediately.
      */
-    if (did_drop && S2C(session)->sweep_cond != NULL)
-        __wt_cond_signal(session, S2C(session)->sweep_cond);
+    if (did_drop && S2C(session)->sweep.cond != NULL)
+        __wt_cond_signal(session, S2C(session)->sweep.cond);
 
     if (ret != 0)
         WT_RET_PANIC(session, ret, "failed to apply or unroll all tracked operations");

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -827,7 +827,7 @@ __wt_session_dhandle_sweep(WT_SESSION_IMPL *session)
      * Periodically sweep for dead handles; if we've swept recently, don't do it again.
      */
     __wt_seconds(session, &now);
-    if (now - __wt_atomic_load_uint64_relaxed(&session->last_sweep) < conn->sweep_interval)
+    if (now - __wt_atomic_load_uint64_relaxed(&session->last_sweep) < conn->sweep.interval)
         return;
     __wt_atomic_store_uint64_relaxed(&session->last_sweep, now);
 
@@ -845,7 +845,7 @@ __wt_session_dhandle_sweep(WT_SESSION_IMPL *session)
         if (dhandle != session->dhandle &&
           __wt_atomic_load_int32_relaxed(&dhandle->session_inuse) == 0 &&
           (WT_DHANDLE_INACTIVE(dhandle) || F_ISSET(dhandle, WT_DHANDLE_OUTDATED) ||
-            (dhandle->timeofdeath != 0 && now - dhandle->timeofdeath > conn->sweep_idle_time)) &&
+            (dhandle->timeofdeath != 0 && now - dhandle->timeofdeath > conn->sweep.idle_time)) &&
           (!WT_DHANDLE_BTREE(dhandle) ||
             FLD_ISSET(dhandle->advisory_flags, WT_DHANDLE_ADVISORY_EVICTED))) {
             WT_STAT_CONN_INCR(session, dh_session_handles);


### PR DESCRIPTION
## Summary
- Define `WT_CONN_SWEEP` sub-struct in `connection.h` grouping the handle sweep server's session, thread (`tid`/`tid_set`), condition variable (`cond`), and configuration (`idle_time`, `interval`, `handles_min`)
- Replace 7 flat fields on `__wt_connection_impl` with a single `WT_CONN_SWEEP sweep` member
- Update all access sites from `conn->sweep_<field>` to `conn->sweep.<field>` across `conn_sweep.c`, `meta_track.c`, and `session_dhandle.c`
- Add forward declaration and typedef for `WT_CONN_SWEEP` in `wt_internal.h` in alphabetical order among `WT_CONN_*` entries
- Follows the same pattern established by WT-17491 (`WT_CONN_EXTENSIONS`), WT-17492 (`WT_CONN_STAT_LOG`), WT-17493 (`WT_CONN_TIERED`), and WT-17494 (`WT_CONN_EVICT_CONFIG`) for modularizing `__wt_connection_impl`

## Testing
Pure refactor — no behavioural change. Verified with an incremental `ninja wt` build (clean, zero warnings). No test files were modified; all existing test coverage applies unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)