### PR TITLE
WT-17496 Extract prefetch queue and thread fields into WT_CONN_PREFETCH

### DIFF
--- a/src/btree/bt_prefetch.c
+++ b/src/btree/bt_prefetch.c
@@ -60,7 +60,7 @@ __wti_btree_prefetch(WT_SESSION_IMPL *session, WT_REF *ref)
     /* Load and decompress a set of pages into the block cache. */
     WT_INTL_FOREACH_BEGIN (session, ref->home, next_ref) {
         /* Don't let the pre-fetch queue get overwhelmed. */
-        if (__wt_tsan_suppress_load_uint64(&conn->prefetch_queue_count) > WT_MAX_PREFETCH_QUEUE ||
+        if (__wt_tsan_suppress_load_uint64(&conn->prefetch.queue_count) > WT_MAX_PREFETCH_QUEUE ||
           block_preload > WT_PREFETCH_QUEUE_PER_TRIGGER)
             break;
 

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -3498,19 +3498,19 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler, const char *c
     conn->mmap_all = cval.val != 0;
 
     WT_ERR(__wt_config_gets(session, cfg, "prefetch.available", &cval));
-    conn->prefetch_available = cval.val != 0;
+    conn->prefetch.available = cval.val != 0;
     WT_ERR(__wt_config_gets(session, cfg, "prefetch.default", &cval));
-    conn->prefetch_auto_on = cval.val != 0;
+    conn->prefetch.auto_on = cval.val != 0;
 
-    if (F_ISSET(conn, WT_CONN_IN_MEMORY) && (conn->prefetch_available || conn->prefetch_auto_on)) {
+    if (F_ISSET(conn, WT_CONN_IN_MEMORY) && (conn->prefetch.available || conn->prefetch.auto_on)) {
         __wt_verbose(session, WT_VERB_PREFETCH, "%s",
           "prefetch configuration is incompatible with in-memory configuration");
         WT_CONFIG_DEBUG(session, "%s", "setting prefetch.available and prefetch.default to false");
-        conn->prefetch_auto_on = false;
-        conn->prefetch_available = false;
+        conn->prefetch.auto_on = false;
+        conn->prefetch.available = false;
     }
 
-    if (conn->prefetch_auto_on && !conn->prefetch_available)
+    if (conn->prefetch.auto_on && !conn->prefetch.available)
         WT_ERR_MSG(session, EINVAL,
           "pre-fetching cannot be enabled if pre-fetching is configured as unavailable");
 

--- a/src/conn/conn_handle.c
+++ b/src/conn/conn_handle.c
@@ -25,7 +25,7 @@ __wti_connection_init(WT_CONNECTION_IMPL *conn)
     TAILQ_INIT(&conn->dsrcqh);        /* Data source list */
     TAILQ_INIT(&conn->fhqh);          /* File list */
     TAILQ_INIT(&conn->tieredqh);      /* Tiered work unit list */
-    TAILQ_INIT(&conn->prefetch.pfqh); /* Pre-fetch reference list */
+    WT_RET(__wti_conn_prefetch_init(session));
 
     /* Extension interface lists. */
     WT_RET(__wti_conn_ext_init(session));
@@ -55,7 +55,6 @@ __wti_connection_init(WT_CONNECTION_IMPL *conn)
     WT_SPIN_INIT_SESSION_TRACKED(session, &conn->schema_lock, schema);
     WT_RET(__wt_spin_init(session, &conn->tiered_lock, "tiered work unit list"));
     WT_RET(__wt_spin_init(session, &conn->turtle_lock, "turtle file"));
-    WT_RET(__wt_spin_init(session, &conn->prefetch.lock, "prefetch"));
 
     /* Read-write locks */
     WT_RET(__wt_rwlock_init(session, &conn->log_mgr.debug_log_retention_lock));
@@ -120,7 +119,7 @@ __wti_connection_destroy(WT_CONNECTION_IMPL *conn)
     __wt_rwlock_destroy(session, &conn->table_lock);
     __wt_spin_destroy(session, &conn->tiered_lock);
     __wt_spin_destroy(session, &conn->turtle_lock);
-    __wt_spin_destroy(session, &conn->prefetch.lock);
+    __wti_conn_prefetch_destroy(session);
 
     /* Extension interface lists. */
     __wti_conn_ext_destroy(session);

--- a/src/conn/conn_handle.c
+++ b/src/conn/conn_handle.c
@@ -20,12 +20,12 @@ __wti_connection_init(WT_CONNECTION_IMPL *conn)
 
     session = conn->default_session;
 
-    TAILQ_INIT(&conn->dhqh);     /* Data handle list */
-    TAILQ_INIT(&conn->dlhqh);    /* Library list */
-    TAILQ_INIT(&conn->dsrcqh);   /* Data source list */
-    TAILQ_INIT(&conn->fhqh);     /* File list */
-    TAILQ_INIT(&conn->tieredqh); /* Tiered work unit list */
-    TAILQ_INIT(&conn->prefetch.pfqh);     /* Pre-fetch reference list */
+    TAILQ_INIT(&conn->dhqh);          /* Data handle list */
+    TAILQ_INIT(&conn->dlhqh);         /* Library list */
+    TAILQ_INIT(&conn->dsrcqh);        /* Data source list */
+    TAILQ_INIT(&conn->fhqh);          /* File list */
+    TAILQ_INIT(&conn->tieredqh);      /* Tiered work unit list */
+    TAILQ_INIT(&conn->prefetch.pfqh); /* Pre-fetch reference list */
 
     /* Extension interface lists. */
     WT_RET(__wti_conn_ext_init(session));

--- a/src/conn/conn_handle.c
+++ b/src/conn/conn_handle.c
@@ -25,7 +25,7 @@ __wti_connection_init(WT_CONNECTION_IMPL *conn)
     TAILQ_INIT(&conn->dsrcqh);   /* Data source list */
     TAILQ_INIT(&conn->fhqh);     /* File list */
     TAILQ_INIT(&conn->tieredqh); /* Tiered work unit list */
-    TAILQ_INIT(&conn->pfqh);     /* Pre-fetch reference list */
+    TAILQ_INIT(&conn->prefetch.pfqh);     /* Pre-fetch reference list */
 
     /* Extension interface lists. */
     WT_RET(__wti_conn_ext_init(session));
@@ -55,7 +55,7 @@ __wti_connection_init(WT_CONNECTION_IMPL *conn)
     WT_SPIN_INIT_SESSION_TRACKED(session, &conn->schema_lock, schema);
     WT_RET(__wt_spin_init(session, &conn->tiered_lock, "tiered work unit list"));
     WT_RET(__wt_spin_init(session, &conn->turtle_lock, "turtle file"));
-    WT_RET(__wt_spin_init(session, &conn->prefetch_lock, "prefetch"));
+    WT_RET(__wt_spin_init(session, &conn->prefetch.lock, "prefetch"));
 
     /* Read-write locks */
     WT_RET(__wt_rwlock_init(session, &conn->log_mgr.debug_log_retention_lock));
@@ -120,7 +120,7 @@ __wti_connection_destroy(WT_CONNECTION_IMPL *conn)
     __wt_rwlock_destroy(session, &conn->table_lock);
     __wt_spin_destroy(session, &conn->tiered_lock);
     __wt_spin_destroy(session, &conn->turtle_lock);
-    __wt_spin_destroy(session, &conn->prefetch_lock);
+    __wt_spin_destroy(session, &conn->prefetch.lock);
 
     /* Extension interface lists. */
     __wti_conn_ext_destroy(session);

--- a/src/conn/conn_handle.c
+++ b/src/conn/conn_handle.c
@@ -20,11 +20,11 @@ __wti_connection_init(WT_CONNECTION_IMPL *conn)
 
     session = conn->default_session;
 
-    TAILQ_INIT(&conn->dhqh);          /* Data handle list */
-    TAILQ_INIT(&conn->dlhqh);         /* Library list */
-    TAILQ_INIT(&conn->dsrcqh);        /* Data source list */
-    TAILQ_INIT(&conn->fhqh);          /* File list */
-    TAILQ_INIT(&conn->tieredqh);      /* Tiered work unit list */
+    TAILQ_INIT(&conn->dhqh);     /* Data handle list */
+    TAILQ_INIT(&conn->dlhqh);    /* Library list */
+    TAILQ_INIT(&conn->dsrcqh);   /* Data source list */
+    TAILQ_INIT(&conn->fhqh);     /* File list */
+    TAILQ_INIT(&conn->tieredqh); /* Tiered work unit list */
     WT_RET(__wti_conn_prefetch_init(session));
 
     /* Extension interface lists. */

--- a/src/conn/conn_prefetch.c
+++ b/src/conn/conn_prefetch.c
@@ -38,23 +38,23 @@ __prefetch_thread_run(WT_SESSION_IMPL *session, WT_THREAD *thread)
     F_SET(session, WT_SESSION_PREFETCH_THREAD);
 
     if (FLD_ISSET(conn->server_flags, WT_CONN_SERVER_PREFETCH))
-        __wt_cond_wait(session, conn->prefetch_threads.wait_cond, WT_THOUSAND * WT_THOUSAND, NULL);
+        __wt_cond_wait(session, conn->prefetch.threads.wait_cond, WT_THOUSAND * WT_THOUSAND, NULL);
 
-    while (!TAILQ_EMPTY(&conn->pfqh)) {
+    while (!TAILQ_EMPTY(&conn->prefetch.pfqh)) {
         /* Encourage races. */
         __wt_timing_stress(session, WT_TIMING_STRESS_PREFETCH_1, NULL);
 
-        __wt_spin_lock(session, &conn->prefetch_lock);
-        pe = TAILQ_FIRST(&conn->pfqh);
+        __wt_spin_lock(session, &conn->prefetch.lock);
+        pe = TAILQ_FIRST(&conn->prefetch.pfqh);
 
         /* If there is no work for the thread to do - return back to the thread pool */
         if (pe == NULL) {
-            __wt_spin_unlock(session, &conn->prefetch_lock);
+            __wt_spin_unlock(session, &conn->prefetch.lock);
             break;
         }
 
-        TAILQ_REMOVE(&conn->pfqh, pe, q);
-        __wt_tsan_suppress_sub_uint64(&conn->prefetch_queue_count, 1);
+        TAILQ_REMOVE(&conn->prefetch.pfqh, pe, q);
+        __wt_tsan_suppress_sub_uint64(&conn->prefetch.queue_count, 1);
 
         /*
          * If the cache is getting close to its eviction clean trigger, don't attempt to pre-fetch
@@ -65,7 +65,7 @@ __prefetch_thread_run(WT_SESSION_IMPL *session, WT_THREAD *thread)
          */
         if (__wt_evict_clean_pressure(session)) {
             F_CLR_ATOMIC_8(pe->ref, WT_REF_FLAG_PREFETCH);
-            __wt_spin_unlock(session, &conn->prefetch_lock);
+            __wt_spin_unlock(session, &conn->prefetch.lock);
             __wt_free(session, pe);
             continue;
         }
@@ -81,7 +81,7 @@ __prefetch_thread_run(WT_SESSION_IMPL *session, WT_THREAD *thread)
 
         WT_PREFETCH_ASSERT(
           session, F_ISSET_ATOMIC_8(pe->ref, WT_REF_FLAG_PREFETCH), prefetch_skipped_no_flag_set);
-        __wt_spin_unlock(session, &conn->prefetch_lock);
+        __wt_spin_unlock(session, &conn->prefetch.lock);
 
         /*
          * It's a weird case, but if verify is utilizing prefetch and encounters a corrupted block,
@@ -137,19 +137,19 @@ __wti_prefetch_create(WT_SESSION_IMPL *session, const char *cfg[])
      * as well, in preparation for the functionality being runtime configurable.
      */
     WT_RET(__wt_config_gets(session, cfg, "prefetch.available", &cval));
-    conn->prefetch_available = cval.val != 0;
+    conn->prefetch.available = cval.val != 0;
 
     /*
      * Pre-fetch functionality isn't runtime configurable, so don't bother starting utility threads
      * if it isn't available.
      */
-    if (!conn->prefetch_available)
+    if (!conn->prefetch.available)
         return (0);
 
     FLD_SET(conn->server_flags, WT_CONN_SERVER_PREFETCH);
 
     session_flags = WT_THREAD_CAN_WAIT | WT_THREAD_PANIC_FAIL;
-    WT_ERR(__wt_thread_group_create(session, &conn->prefetch_threads, "prefetch-server",
+    WT_ERR(__wt_thread_group_create(session, &conn->prefetch.threads, "prefetch-server",
       WT_PREFETCH_THREAD_COUNT, WT_PREFETCH_THREAD_COUNT, session_flags, __prefetch_thread_chk,
       __prefetch_thread_run, NULL));
     return (0);
@@ -181,7 +181,7 @@ __wt_conn_prefetch_queue_push(WT_SESSION_IMPL *session, WT_REF *ref)
     if (__wt_evict_clean_pressure(session))
         return (EBUSY);
 
-    __wt_spin_lock(session, &conn->prefetch_lock);
+    __wt_spin_lock(session, &conn->prefetch.lock);
     /* Don't queue pages for trees that have eviction disabled. */
     if (S2BT(session)->evict_disabled > 0)
         WT_ERR(EBUSY);
@@ -217,10 +217,10 @@ __wt_conn_prefetch_queue_push(WT_SESSION_IMPL *session, WT_REF *ref)
     F_SET_ATOMIC_8(ref, WT_REF_FLAG_PREFETCH);
     /* Unlock the ref. */
     WT_REF_SET_STATE(ref, WT_REF_DISK);
-    TAILQ_INSERT_TAIL(&conn->pfqh, pe, q);
-    __wt_tsan_suppress_add_uint64(&conn->prefetch_queue_count, 1);
-    __wt_spin_unlock(session, &conn->prefetch_lock);
-    __wt_cond_signal(session, conn->prefetch_threads.wait_cond);
+    TAILQ_INSERT_TAIL(&conn->prefetch.pfqh, pe, q);
+    __wt_tsan_suppress_add_uint64(&conn->prefetch.queue_count, 1);
+    __wt_spin_unlock(session, &conn->prefetch.lock);
+    __wt_cond_signal(session, conn->prefetch.threads.wait_cond);
 
     return (0);
 
@@ -228,7 +228,7 @@ err:
     /* Unlock the ref. */
     WT_REF_SET_STATE(ref, WT_REF_DISK);
 done:
-    __wt_spin_unlock(session, &conn->prefetch_lock);
+    __wt_spin_unlock(session, &conn->prefetch.lock);
     return (ret);
 }
 
@@ -250,20 +250,20 @@ __wt_conn_prefetch_clear_tree(WT_SESSION_IMPL *session, bool all)
     WT_ASSERT_ALWAYS(session, all || dhandle != NULL,
       "Pre-fetch needs to save a valid dhandle when clearing the queue for a btree");
 
-    __wt_spin_lock(session, &conn->prefetch_lock);
+    __wt_spin_lock(session, &conn->prefetch.lock);
 
     /* Empty the queue of the relevant pages, or all of them if specified. */
-    TAILQ_FOREACH_SAFE(pe, &conn->pfqh, q, pe_tmp)
+    TAILQ_FOREACH_SAFE(pe, &conn->prefetch.pfqh, q, pe_tmp)
     {
         if (all || pe->dhandle == dhandle) {
-            TAILQ_REMOVE(&conn->pfqh, pe, q);
+            TAILQ_REMOVE(&conn->prefetch.pfqh, pe, q);
             F_CLR_ATOMIC_8(pe->ref, WT_REF_FLAG_PREFETCH);
             __wt_free(session, pe);
-            __wt_tsan_suppress_sub_uint64(&conn->prefetch_queue_count, 1);
+            __wt_tsan_suppress_sub_uint64(&conn->prefetch.queue_count, 1);
         }
     }
     if (all)
-        WT_ASSERT(session, conn->prefetch_queue_count == 0);
+        WT_ASSERT(session, conn->prefetch.queue_count == 0);
 
     /*
      * Give up the lock, consumers of the queue shouldn't see pages relevant to them. Additionally
@@ -271,7 +271,7 @@ __wt_conn_prefetch_clear_tree(WT_SESSION_IMPL *session, bool all)
      * important that the flag is checked after locking the prefetch queue lock. If not then threads
      * may not note that the tree is closed for prefetch.
      */
-    __wt_spin_unlock(session, &conn->prefetch_lock);
+    __wt_spin_unlock(session, &conn->prefetch.lock);
 
     /*
      * If we are only clearing refs from a certain tree, wait for any other concurrent pre-fetch
@@ -306,11 +306,11 @@ __wti_prefetch_destroy(WT_SESSION_IMPL *session)
     WT_TRET(__wt_conn_prefetch_clear_tree(session, true));
 
     /* Let any running threads finish up. */
-    __wt_cond_signal(session, conn->prefetch_threads.wait_cond);
+    __wt_cond_signal(session, conn->prefetch.threads.wait_cond);
 
-    __wt_writelock(session, &conn->prefetch_threads.lock);
+    __wt_writelock(session, &conn->prefetch.threads.lock);
 
-    WT_RET(__wt_thread_group_destroy(session, &conn->prefetch_threads));
+    WT_RET(__wt_thread_group_destroy(session, &conn->prefetch.threads));
 
     return (ret);
 }

--- a/src/conn/conn_prefetch.c
+++ b/src/conn/conn_prefetch.c
@@ -9,6 +9,34 @@
 #include "wt_internal.h"
 
 /*
+ * __wti_conn_prefetch_init --
+ *     Initialize the WT_CONN_PREFETCH structure.
+ */
+int
+__wti_conn_prefetch_init(WT_SESSION_IMPL *session)
+{
+    WT_CONNECTION_IMPL *conn;
+
+    conn = S2C(session);
+    TAILQ_INIT(&conn->prefetch.pfqh); /* Pre-fetch reference list */
+    WT_RET(__wt_spin_init(session, &conn->prefetch.lock, "prefetch"));
+    return (0);
+}
+
+/*
+ * __wti_conn_prefetch_destroy --
+ *     Destroy the WT_CONN_PREFETCH structure.
+ */
+void
+__wti_conn_prefetch_destroy(WT_SESSION_IMPL *session)
+{
+    WT_CONNECTION_IMPL *conn;
+
+    conn = S2C(session);
+    __wt_spin_destroy(session, &conn->prefetch.lock);
+}
+
+/*
  * __prefetch_thread_chk --
  *     Check to decide if the pre-fetch thread should continue running.
  */

--- a/src/docs/arch-prefetch.dox
+++ b/src/docs/arch-prefetch.dox
@@ -100,7 +100,7 @@ has processed the leaf page.
 
 Pre-fetch is a highly concurrent module and we rely on a few mechanisms to ensure
 that it runs smoothly with the rest of the system.
-- A connection level lock \c prefetch_lock is used for the pre-fetch queue, and is
+- A connection level lock \c prefetch.lock is used for the pre-fetch queue, and is
 needed when adding and removing \c WT_PREFETCH_QUEUE_ENTRY items from it.
 - Whenever we modify a \c ref structure, e.g. when adding it to the pre-fetch queue
 and setting the corresponding \c WT_REF_FLAG_PREFETCH flag, it must be in the

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -543,13 +543,13 @@ struct __wt_conn_extensions {
  *	configuration that drive the prefetch server.
  */
 struct __wt_conn_prefetch {
-    WT_SPINLOCK lock;       /* Prefetch queue lock */
+    WT_SPINLOCK lock;        /* Prefetch queue lock */
     WT_THREAD_GROUP threads; /* Prefetch thread group */
-    uint64_t queue_count;   /* Prefetch queue entry count */
+    uint64_t queue_count;    /* Prefetch queue entry count */
     /* Locked: queue of refs to pre-fetch */
     TAILQ_HEAD(__wt_pf_qh, __wt_prefetch_queue_entry) pfqh;
-    bool auto_on;     /* Prefetch auto-enabled */
-    bool available;   /* Prefetch available */
+    bool auto_on;   /* Prefetch auto-enabled */
+    bool available; /* Prefetch available */
 };
 
 /*

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -538,6 +538,21 @@ struct __wt_conn_extensions {
 };
 
 /*
+ * WT_CONN_PREFETCH --
+ *	Prefetch subsystem fields, grouping the thread group, queue, lock, and
+ *	configuration that drive the prefetch server.
+ */
+struct __wt_conn_prefetch {
+    WT_SPINLOCK lock;       /* Prefetch queue lock */
+    WT_THREAD_GROUP threads; /* Prefetch thread group */
+    uint64_t queue_count;   /* Prefetch queue entry count */
+    /* Locked: queue of refs to pre-fetch */
+    TAILQ_HEAD(__wt_pf_qh, __wt_prefetch_queue_entry) pfqh;
+    bool auto_on;     /* Prefetch auto-enabled */
+    bool available;   /* Prefetch available */
+};
+
+/*
  * WT_NAME_FLAG --
  *	Simple structure for name and flag configuration searches
  */
@@ -894,13 +909,7 @@ struct __wt_connection_impl {
 #define WT_MAX_PREFETCH_QUEUE 120
 #define WT_PREFETCH_QUEUE_PER_TRIGGER 30
 #define WT_PREFETCH_THREAD_COUNT 8
-    WT_SPINLOCK prefetch_lock;
-    WT_THREAD_GROUP prefetch_threads;
-    uint64_t prefetch_queue_count;
-    /* Queue of refs to pre-fetch from */
-    TAILQ_HEAD(__wt_pf_qh, __wt_prefetch_queue_entry) pfqh; /* Locked: prefetch_lock */
-    bool prefetch_auto_on;
-    bool prefetch_available;
+    WT_CONN_PREFETCH prefetch; /* Prefetch thread group and configuration */
 
     /* Data pertaining to disaggregated storage step up. */
     struct __wt_layered_drain_data {

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1425,6 +1425,8 @@ extern int __wti_conn_page_history_config(WT_SESSION_IMPL *session, const char *
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_conn_page_history_destroy(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wti_conn_prefetch_init(WT_SESSION_IMPL *session)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_conn_reconfig(WT_SESSION_IMPL *session, const char **cfg)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_conn_remove_collator(WT_SESSION_IMPL *session)
@@ -1918,6 +1920,7 @@ extern void __wti_btcur_iterate_setup(WT_CURSOR_BTREE *cbt);
 extern void __wti_ckpt_verbose(WT_SESSION_IMPL *session, WT_BLOCK *block, const char *tag,
   const char *ckpt_name, const uint8_t *ckpt_string, size_t ckpt_size);
 extern void __wti_conn_ext_destroy(WT_SESSION_IMPL *session);
+extern void __wti_conn_prefetch_destroy(WT_SESSION_IMPL *session);
 extern void __wti_connection_destroy(WT_CONNECTION_IMPL *conn);
 extern void __wti_cursor_reopen(WT_CURSOR *cursor, WT_DATA_HANDLE *dhandle);
 extern void __wti_cursor_set_key_notsup(WT_CURSOR *cursor, ...);

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -173,6 +173,8 @@ struct __wt_config_parser_impl;
 typedef struct __wt_config_parser_impl WT_CONFIG_PARSER_IMPL;
 struct __wt_conn_extensions;
 typedef struct __wt_conn_extensions WT_CONN_EXTENSIONS;
+struct __wt_conn_prefetch;
+typedef struct __wt_conn_prefetch WT_CONN_PREFETCH;
 struct __wt_conn_stat_log;
 typedef struct __wt_conn_stat_log WT_CONN_STAT_LOG;
 struct __wt_connection_impl;

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -487,7 +487,7 @@ __session_config_prefetch(WT_SESSION_IMPL *session, WT_CONF *conf)
      */
     if (__wt_conf_getones(session, conf, Prefetch.enabled, &cval) == 0) {
         if (cval.val) {
-            if (!S2C(session)->prefetch_available) {
+            if (!S2C(session)->prefetch.available) {
                 F_CLR(session, WT_SESSION_PREFETCH_ENABLED);
                 WT_RET_MSG(session, EINVAL,
                   "pre-fetching cannot be enabled for the session if pre-fetching is configured as "
@@ -2673,7 +2673,7 @@ __open_session(WT_CONNECTION_IMPL *conn, WT_EVENT_HANDLER *event_handler, const 
     if (F_ISSET(conn, WT_CONN_CACHE_CURSORS))
         F_SET(session_ret, WT_SESSION_CACHE_CURSORS);
 
-    if (conn->prefetch_auto_on)
+    if (conn->prefetch.auto_on)
         F_SET(session_ret, WT_SESSION_PREFETCH_ENABLED);
     else
         F_CLR(session_ret, WT_SESSION_PREFETCH_ENABLED);

--- a/src/session/session_prefetch.c
+++ b/src/session/session_prefetch.c
@@ -28,7 +28,7 @@ __wt_session_prefetch_check(WT_SESSION_IMPL *session, WT_REF *ref)
       __wt_atomic_load_enum_relaxed(&session->dhandle->type) == WT_DHANDLE_TYPE_TIERED_TREE)
         return (false);
 
-    if (__wt_tsan_suppress_load_uint64(&S2C(session)->prefetch_queue_count) >
+    if (__wt_tsan_suppress_load_uint64(&S2C(session)->prefetch.queue_count) >
       WT_MAX_PREFETCH_QUEUE) {
         WT_STAT_CONN_INCR(session, prefetch_skipped_queue_full);
         return (false);


### PR DESCRIPTION
## Summary
- Define `WT_CONN_PREFETCH` sub-struct in `connection.h` grouping the prefetch subsystem's spinlock (`lock`), thread group (`threads`), queue (`pfqh`), queue count (`queue_count`), and configuration flags (`auto_on`, `available`)
- Replace 6 flat fields on `__wt_connection_impl` with a single `WT_CONN_PREFETCH prefetch` member; the three `#define` constants (`WT_MAX_PREFETCH_QUEUE` etc.) remain adjacent as they are not struct fields
- Update all access sites from `conn->prefetch_<field>` / `conn->pfqh` to `conn->prefetch.<field>` across `conn_prefetch.c`, `conn_api.c`, `conn_handle.c`, `bt_prefetch.c`, `session_api.c`, and `session_prefetch.c`
- Add forward declaration and typedef for `WT_CONN_PREFETCH` in `wt_internal.h` alphabetically between `WT_CONN_EXTENSIONS` and `WT_CONN_STAT_LOG`
- Follows the same pattern established by WT-17491 (`WT_CONN_EXTENSIONS`), WT-17492 (`WT_CONN_STAT_LOG`), WT-17493 (`WT_CONN_TIERED`), WT-17494 (`WT_CONN_EVICT_CONFIG`), and WT-17495 (`WT_CONN_SWEEP`) for modularizing `__wt_connection_impl`

## Testing
Pure refactor — no behavioural change. Verified with an incremental `ninja wt` build (clean, zero warnings). No test files were modified; all existing test coverage applies unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)