### PR TITLE
WT-17381 Fix TSAN data race between __wt_delete_page_rollback and cursor readers

### DIFF
--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -296,10 +296,16 @@ __wt_delete_page_rollback(WT_SESSION_IMPL *session, WT_TXN_OP *op)
              * unresolved transactions aren't going anywhere.
              */
             for (; *updp != NULL; ++updp) {
-                /* The ref is locked, no need to pay attention to memory ordering here. */
-                if (F_ISSET(&txn->time_point, WT_TXN_TIME_POINT_HAS_TS_ROLLBACK))
+                /*
+                 * The ref is locked, no need to pay attention to memory ordering here. Only save
+                 * the txnid for prepared transactions; the saved_txnid field overlaps upd_start_ts
+                 * in the union, so writing it unconditionally would race with concurrent readers
+                 * that read upd_start_ts on the non-prepare path.
+                 */
+                if (F_ISSET(&txn->time_point, WT_TXN_TIME_POINT_HAS_TS_ROLLBACK)) {
                     (*updp)->upd_rollback_ts = txn->time_point.rollback_timestamp;
-                __wt_atomic_store_uint64_relaxed(&(*updp)->upd_saved_txnid, (*updp)->txnid);
+                    __wt_atomic_store_uint64_relaxed(&(*updp)->upd_saved_txnid, (*updp)->txnid);
+                }
                 __wt_atomic_store_uint64_v_relaxed(&(*updp)->txnid, WT_TXN_ABORTED);
             }
             /* Now discard the updates. */

--- a/src/include/timestamp_inline.h
+++ b/src/include/timestamp_inline.h
@@ -91,7 +91,9 @@
 /*
  * Set the stop values of a time window from those in an update structure. We can race with prepared
  * rollback. If we read an aborted transaction id in the first attempt, get the transaction id from
- * the saved transaction id.
+ * the saved transaction id. On the non-prepare path we can also race with __wt_delete_page_rollback
+ * writing WT_TXN_ABORTED; use TSAN suppression since the race is benign (both sides are relaxed
+ * atomics and callers handle WT_TXN_ABORTED stop_txn values).
  */
 #define WT_TIME_WINDOW_SET_STOP(tw, upd, write_prepare)                                    \
     do {                                                                                   \
@@ -102,7 +104,7 @@
             if ((tw)->stop_txn == WT_TXN_ABORTED)                                          \
                 (tw)->stop_txn = __wt_atomic_load_uint64_relaxed(&(upd)->upd_saved_txnid); \
         } else {                                                                           \
-            (tw)->stop_txn = __wt_atomic_load_uint64_v_relaxed(&(upd)->txnid);             \
+            (tw)->stop_txn = __wt_tsan_suppress_load_uint64_v(&(upd)->txnid);              \
             (tw)->stop_ts = (upd)->upd_start_ts;                                           \
             (tw)->durable_stop_ts = (upd)->upd_durable_ts;                                 \
         }                                                                                  \


### PR DESCRIPTION
Guard the upd_saved_txnid write in __wt_delete_page_rollback under the WT_TXN_TIME_POINT_HAS_TS_ROLLBACK condition. For non-prepared rollbacks this write served no purpose but silently clobbered upd_start_ts (the same 8 bytes in the union) while a concurrent cursor reader could be reading it as a stop timestamp.

Suppress the remaining TSAN-detected race on the txnid field in WT_TIME_WINDOW_SET_STOP's non-prepare path using
__wt_tsan_suppress_load_uint64_v. The writer stores WT_TXN_ABORTED with a relaxed atomic; the reader likewise uses a relaxed load with no acquire/release pairing — the race is benign and consistent with the existing TSAN suppression pattern elsewhere in the file traversal code.