### PR TITLE
WT-17544 Skip build directory in s_copyright

### DIFF
--- a/dist/s_copyright
+++ b/dist/s_copyright
@@ -132,6 +132,7 @@ find [a-z]* -name '*.[ch]' \
     -o -name '*.py' \
     -o -name '*.swig' |
     sed	-e '/Makefile.in/d' \
+    -e '/^build\//d' \
     -e '/^cmake\//d' \
     -e '/checksum\/power8\//d' \
     -e '/checksum\/zseries\//d' \


### PR DESCRIPTION
This ticket is to exclude build directory in s_copyright.