### PR TITLE
WT-17402 Update arch-tiered-storage.dox after cloud storage removal

### DIFF
--- a/src/docs/arch-tiered-storage.dox
+++ b/src/docs/arch-tiered-storage.dox
@@ -22,7 +22,7 @@ cloud objects that makes these btrees different.
 
 Tiered storage is configured and enabled on the connection
 via ::wiredtiger_open configuration options
-(e.g. <code>tiered_storage=(name="s3_store",bucket="...")</code> ).
+(e.g. <code>tiered_storage=(name="dir_store",bucket="...")</code> ).
 Once enabled on the connection, the configuration applies to all tables created.
 The configuration can be overridden on individual tables with
 configuration options for WT_SESSION::create .
@@ -271,8 +271,7 @@ The connection has a pointer to a \c WT_BUCKET_STORAGE, and each
 Among the fields of a \c WT_BUCKET_STORAGE is a pointer to a \c
 WT_STORAGE_SOURCE. The storage source can be thought of as a driver,
 or an abstraction of a cloud provider with operations. WiredTiger has
-several instances of \c WT_STORAGE_SOURCE, these include the drivers
-for the AWS, GCP, and Azure clouds, as well as \c dir_store,
+instances of \c WT_STORAGE_SOURCE, including \c dir_store,
 used for testing and development.
 A storage source can be asked to create a custom file system
 (returning a \c WT_FILE_SYSTEM) from a


### PR DESCRIPTION
## Summary

- Replace `s3_store` example with `dir_store` in the tiered storage configuration example
- Remove mention of AWS, GCP, and Azure cloud drivers from the `WT_STORAGE_SOURCE` description

The `arch-storage-extension.dox` page (which described the removed cloud storage extensions) and its references in `arch-index.dox` and `docs_data.py` were already cleaned up as part of [WT-17401 (#13795)](https://github.com/wiredtiger/wiredtiger/pull/13795). This commit handles the remaining stale references in `arch-tiered-storage.dox`.

## Test plan

- [ ] Documentation-only change — no functional code modified
- [ ] Grep confirms no remaining `s3_store`, `azure_store`, or `gcp_store` references in `src/docs/`, `bench/`, `test/suite/`, or `dist/`