### PR TITLE
WT-17499 Extract optrack fields into WT_CONN_OPTRACK structure

### DIFF
--- a/src/conn/conn_reconfig.c
+++ b/src/conn/conn_reconfig.c
@@ -217,7 +217,7 @@ __wti_conn_optrack_setup(WT_SESSION_IMPL *session, const char *cfg[], bool recon
     /* Once an operation tracking path has been set it can't be changed. */
     if (!reconfig) {
         WT_RET(__wt_config_gets(session, cfg, "operation_tracking.path", &cval));
-        WT_RET(__wt_strndup(session, cval.str, cval.len, &conn->optrack_path));
+        WT_RET(__wt_strndup(session, cval.str, cval.len, &conn->optrack.path));
     }
 
     WT_RET(__wt_config_gets(session, cfg, "operation_tracking.enabled", &cval));
@@ -241,7 +241,7 @@ __wti_conn_optrack_setup(WT_SESSION_IMPL *session, const char *cfg[], bool recon
      * distinguish between log files created by different WiredTiger processes in the same
      * directory. We cache the process id for future use.
      */
-    conn->optrack_pid = __wt_process_id();
+    conn->optrack.pid = __wt_process_id();
 
     /*
      * Open the file in the same directory that will hold a map of translations between function
@@ -249,11 +249,11 @@ __wti_conn_optrack_setup(WT_SESSION_IMPL *session, const char *cfg[], bool recon
      */
     WT_RET(__wt_scr_alloc(session, 0, &buf));
     WT_ERR(__wt_filename_construct(
-      session, conn->optrack_path, "optrack-map", conn->optrack_pid, UINT32_MAX, buf));
+      session, conn->optrack.path, "optrack-map", conn->optrack.pid, UINT32_MAX, buf));
     WT_ERR(__wt_open(session, (const char *)buf->data, WT_FS_OPEN_FILE_TYPE_REGULAR,
-      WT_FS_OPEN_CREATE, &conn->optrack_map_fh));
+      WT_FS_OPEN_CREATE, &conn->optrack.map_fh));
 
-    WT_ERR(__wt_spin_init(session, &conn->optrack_map_spinlock, "optrack map spinlock"));
+    WT_ERR(__wt_spin_init(session, &conn->optrack.map_spinlock, "optrack map spinlock"));
 
     WT_ERR(__wt_malloc(session, WT_OPTRACK_BUFSIZE, &conn->dummy_session.optrack_buf));
 
@@ -279,14 +279,14 @@ __wti_conn_optrack_teardown(WT_SESSION_IMPL *session, bool reconfig)
 
     if (!reconfig)
         /* Looks like we are shutting down */
-        __wt_free(session, conn->optrack_path);
+        __wt_free(session, conn->optrack.path);
 
     if (!F_ISSET_ATOMIC_32(conn, WT_CONN_OPTRACK))
         return (0);
 
-    __wt_spin_destroy(session, &conn->optrack_map_spinlock);
+    __wt_spin_destroy(session, &conn->optrack.map_spinlock);
 
-    WT_TRET(__wt_close(session, &conn->optrack_map_fh));
+    WT_TRET(__wt_close(session, &conn->optrack.map_fh));
     __wt_free(session, conn->dummy_session.optrack_buf);
 
     return (ret);

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -538,6 +538,18 @@ struct __wt_conn_extensions {
 };
 
 /*
+ * WT_CONN_OPTRACK --
+ *	Operation tracking subsystem fields, grouping the spinlock, path,
+ *	map file handle, and cached PID used by the optrack server.
+ */
+struct __wt_conn_optrack {
+    WT_SPINLOCK map_spinlock; /* Translation file spinlock */
+    const char *path;         /* Directory for operation logs */
+    WT_FH *map_fh;            /* Name to id translation file */
+    uintmax_t pid;            /* Cache the process ID */
+};
+
+/*
  * WT_CONN_PREFETCH --
  *	Prefetch subsystem fields, grouping the thread group, queue, lock, and
  *	configuration that drive the prefetch server.
@@ -823,10 +835,7 @@ struct __wt_connection_impl {
 
     uint64_t operation_timeout_us; /* Maximum operation period before rollback */
 
-    const char *optrack_path;         /* Directory for operation logs */
-    WT_FH *optrack_map_fh;            /* Name to id translation file. */
-    WT_SPINLOCK optrack_map_spinlock; /* Translation file spinlock. */
-    uintmax_t optrack_pid;            /* Cache the process ID. */
+    WT_CONN_OPTRACK optrack; /* Operation tracking subsystem */
 
 #ifdef HAVE_CALL_LOG
     /* File stream used for writing to the call log. */

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -175,6 +175,8 @@ struct __wt_conn_evict_config;
 typedef struct __wt_conn_evict_config WT_CONN_EVICT_CONFIG;
 struct __wt_conn_extensions;
 typedef struct __wt_conn_extensions WT_CONN_EXTENSIONS;
+struct __wt_conn_optrack;
+typedef struct __wt_conn_optrack WT_CONN_OPTRACK;
 struct __wt_conn_prefetch;
 typedef struct __wt_conn_prefetch WT_CONN_PREFETCH;
 struct __wt_conn_stat_log;

--- a/src/optrack/optrack.c
+++ b/src/optrack/optrack.c
@@ -25,13 +25,13 @@ __wt_optrack_record_funcid(WT_SESSION_IMPL *session, const char *func, uint16_t 
 
     WT_ERR(__wt_scr_alloc(session, strlen(func) + 32, &tmp));
 
-    __wt_spin_lock(session, &conn->optrack_map_spinlock);
+    __wt_spin_lock(session, &conn->optrack.map_spinlock);
     if (*func_idp == 0) {
         *func_idp = ++optrack_uid;
 
         WT_ERR(__wt_buf_fmt(session, tmp, "%" PRIu16 " %s\n", *func_idp, func));
-        WT_ERR(__wt_filesize(session, conn->optrack_map_fh, &fsize));
-        WT_ERR(__wt_write(session, conn->optrack_map_fh, fsize, tmp->size, tmp->data));
+        WT_ERR(__wt_filesize(session, conn->optrack.map_fh, &fsize));
+        WT_ERR(__wt_write(session, conn->optrack.map_fh, fsize, tmp->size, tmp->data));
     }
 
     if (0) {
@@ -39,7 +39,7 @@ err:
         WT_IGNORE_RET(__wt_panic(session, ret, "operation tracking initialization failure"));
     }
 
-    __wt_spin_unlock_if_owned(session, &conn->optrack_map_spinlock);
+    __wt_spin_unlock_if_owned(session, &conn->optrack.map_spinlock);
     __wt_scr_free(session, &tmp);
 }
 
@@ -64,7 +64,7 @@ __optrack_open_file(WT_SESSION_IMPL *session)
 
     WT_RET(__wt_scr_alloc(session, 0, &buf));
     WT_ERR(__wt_filename_construct(
-      session, conn->optrack_path, "optrack", conn->optrack_pid, session->id, buf));
+      session, conn->optrack.path, "optrack", conn->optrack.pid, session->id, buf));
     WT_ERR(__wt_open(session, (const char *)buf->data, WT_FS_OPEN_FILE_TYPE_REGULAR,
       WT_FS_OPEN_CREATE, &session->optrack_fh));
 


### PR DESCRIPTION
## Summary
- Defines a new `WT_CONN_OPTRACK` structure in `connection.h` containing the four operation-tracking fields: `map_spinlock`, `path`, `map_fh`, and `pid`
- Removes `optrack_map_spinlock`, `optrack_path`, `optrack_map_fh`, and `optrack_pid` from `__wt_connection_impl`; replaces them with a single `WT_CONN_OPTRACK optrack` member
- Adds forward declaration and typedef for `WT_CONN_OPTRACK` in `wt_internal.h` (alphabetically between `WT_CONN_EXTENSIONS` and `WT_CONN_PREFETCH`)
- Updates all access sites in `conn_reconfig.c` and `optrack/optrack.c` to use `conn->optrack.<field>` — field names drop the redundant `optrack_` prefix inside the struct, consistent with the naming convention of other `WT_CONN_*` structs in this epic

## Testing
Pure refactor — no behavioral changes. Covered by the existing test suite. Built cleanly with `ninja wt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)