### PR TITLE
WT-17497 Extract debug-mode fields into WT_CONN_DEBUG

### DIFF
--- a/src/block_disagg/block_disagg_addr.c
+++ b/src/block_disagg/block_disagg_addr.c
@@ -30,7 +30,7 @@
 static WT_INLINE bool
 __block_disagg_addr_debug_upgrade(WT_SESSION_IMPL *session)
 {
-    return (S2C(session)->debug_disagg_address_cookie_upgrade !=
+    return (S2C(session)->debug.disagg_address_cookie_upgrade !=
       WT_CONN_DEBUG_DISAGG_ADDRESS_COOKIE_UPGRADE_NONE);
 }
 
@@ -45,7 +45,7 @@ __block_disagg_addr_pack_version(WT_SESSION_IMPL *session, uint8_t **pp, size_t 
     uint64_t version_min = WT_BLOCK_DISAGG_ADDR_VERSION_MIN;
 
     /* Apply debug upgrade/downgrade settings (for testing version compatibility handling). */
-    switch (S2C(session)->debug_disagg_address_cookie_upgrade) {
+    switch (S2C(session)->debug.disagg_address_cookie_upgrade) {
     case WT_CONN_DEBUG_DISAGG_ADDRESS_COOKIE_UPGRADE_NONE:
         /* No change to version numbers. */
         break;
@@ -97,7 +97,7 @@ __wti_block_disagg_addr_pack(
     flags = cookie->flags & WT_BLOCK_DISAGG_ADDR_ALL_FLAGS;
 
     /* If testing optional fields, add an extra flag. */
-    if (S2C(session)->debug_disagg_address_cookie_optional_field)
+    if (S2C(session)->debug.disagg_address_cookie_optional_field)
         flags |= WT_BLOCK_DISAGG_ADDR_ALL_FLAGS + 1; /* Set a new flag for testing. */
 
     /* We will store the base LSN as a delta relative to the LSN to save space. */
@@ -121,7 +121,7 @@ __wti_block_disagg_addr_pack(
     /* If testing upgrade/downgrade, pack extra fields. */
     if (__block_disagg_addr_debug_upgrade(session))
         WT_RET(__wt_vpack_uint(pp, 0, cookie->page_id ^ cookie->size));
-    if (S2C(session)->debug_disagg_address_cookie_optional_field)
+    if (S2C(session)->debug.disagg_address_cookie_optional_field)
         WT_RET(__wt_vpack_uint(pp, 0, cookie->page_id ^ cookie->lsn));
 
     return (0);
@@ -153,7 +153,7 @@ __wt_block_disagg_addr_unpack(WT_SESSION_IMPL *session, const uint8_t **buf, siz
      * compatibility handling).
      */
     current_version = WT_BLOCK_DISAGG_ADDR_VERSION;
-    switch (S2C(session)->debug_disagg_address_cookie_upgrade) {
+    switch (S2C(session)->debug.disagg_address_cookie_upgrade) {
     case WT_CONN_DEBUG_DISAGG_ADDRESS_COOKIE_UPGRADE_NONE:
         /* No change to version numbers. */
         break;
@@ -188,7 +188,7 @@ __wt_block_disagg_addr_unpack(WT_SESSION_IMPL *session, const uint8_t **buf, siz
           " does not match expected value %" PRIx64,
           debug_field, page_id ^ size);
     }
-    if (S2C(session)->debug_disagg_address_cookie_optional_field &&
+    if (S2C(session)->debug.disagg_address_cookie_optional_field &&
       FLD_ISSET(flags, WT_BLOCK_DISAGG_ADDR_ALL_FLAGS + 1)) {
         WT_RET(__wt_vunpack_uint(buf, 0, &debug_field));
         WT_ASSERT_ALWAYS(session, debug_field == (page_id ^ lsn),
@@ -228,7 +228,7 @@ __wt_block_disagg_addr_unpack(WT_SESSION_IMPL *session, const uint8_t **buf, siz
     unsupported_flags = flags;
     FLD_CLR(unsupported_flags, WT_BLOCK_DISAGG_ADDR_ALL_FLAGS);
     if (version <= current_version && unsupported_flags == 0 &&
-      !S2C(session)->debug_disagg_address_cookie_optional_field &&
+      !S2C(session)->debug.disagg_address_cookie_optional_field &&
       (size_t)(*buf - begin) != buf_size)
         WT_RET_MSG(session, EINVAL,
           "Disaggregated address cookie size mismatch: expected %" PRIuMAX ", got %" PRIuMAX,

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -356,7 +356,7 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
                 internal_bytes += __wt_atomic_load_size_relaxed(&page->memory_footprint);
                 ++internal_pages;
                 /* Slow down checkpoints. */
-                if (FLD_ISSET(conn->debug_flags, WT_CONN_DEBUG_SLOW_CKPT))
+                if (FLD_ISSET(conn->debug.flags, WT_CONN_DEBUG_SLOW_CKPT))
                     __wt_sleep(0, 10 * WT_THOUSAND);
             } else {
                 leaf_bytes += __wt_atomic_load_size_relaxed(&page->memory_footprint);

--- a/src/btree/row_srch.c
+++ b/src/btree/row_srch.c
@@ -205,7 +205,7 @@ __wt_search_insert(
      * This is an expensive call on a performance-critical path, so we only want to enable it behind
      * the stress_skiplist session flag.
      */
-    if (FLD_ISSET(S2C(session)->debug_flags, WT_CONN_DEBUG_STRESS_SKIPLIST))
+    if (FLD_ISSET(S2C(session)->debug.flags, WT_CONN_DEBUG_STRESS_SKIPLIST))
         WT_RET(__validate_next_stack(session, cbt->next_stack, srch_key));
 
     return (0);

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -2754,12 +2754,12 @@ __wti_disagg_debug_mode_config(WT_SESSION_IMPL *session, const char *cfg[])
     else
         WT_RET_MSG(session, EINVAL, "Invalid value for debug.disagg_address_cookie_upgrade: '%.*s'",
           (int)cval.len, cval.str);
-    conn->debug_disagg_address_cookie_upgrade = address_cookie_upgrade;
+    conn->debug.disagg_address_cookie_upgrade = address_cookie_upgrade;
 
     /* Check whether we are pretending to have an optional field. */
     WT_RET(
       __wt_config_gets(session, cfg, "debug_mode.disagg_address_cookie_optional_field", &cval));
-    conn->debug_disagg_address_cookie_optional_field = cval.val != 0;
+    conn->debug.disagg_address_cookie_optional_field = cval.val != 0;
 
     return (0);
 }

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -2278,17 +2278,17 @@ __debug_mode_log_retention_config(WT_SESSION_IMPL *session, const char *cfg[])
      * value. Once it was on in the past and then turned off, you cannot turn it back on again.
      */
     if (cval.val != 0) {
-        if (conn->debug_ckpt_cnt != 0 && cval.val != conn->debug_ckpt_cnt)
+        if (conn->debug.ckpt_cnt != 0 && cval.val != conn->debug.ckpt_cnt)
             WT_ERR_MSG(session, EINVAL, "Cannot change value for checkpoint retention");
         WT_ERR(
-          __wt_realloc_def(session, &conn->debug_ckpt_alloc, (size_t)cval.val, &conn->debug_ckpt));
+          __wt_realloc_def(session, &conn->debug.ckpt_alloc, (size_t)cval.val, &conn->debug.ckpt));
         FLD_SET(conn->debug.flags, WT_CONN_DEBUG_CKPT_RETAIN);
     } else
         FLD_CLR(conn->debug.flags, WT_CONN_DEBUG_CKPT_RETAIN);
-    conn->debug_ckpt_cnt = (uint32_t)cval.val;
+    conn->debug.ckpt_cnt = (uint32_t)cval.val;
 
     WT_ERR(__wt_config_gets(session, cfg, "debug_mode.log_retention", &cval));
-    conn->debug_log_cnt = (uint32_t)cval.val;
+    conn->debug.log_cnt = (uint32_t)cval.val;
 
 err:
     __wt_writeunlock(session, &conn->log_mgr.debug_log_retention_lock);

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -2282,9 +2282,9 @@ __debug_mode_log_retention_config(WT_SESSION_IMPL *session, const char *cfg[])
             WT_ERR_MSG(session, EINVAL, "Cannot change value for checkpoint retention");
         WT_ERR(
           __wt_realloc_def(session, &conn->debug_ckpt_alloc, (size_t)cval.val, &conn->debug_ckpt));
-        FLD_SET(conn->debug_flags, WT_CONN_DEBUG_CKPT_RETAIN);
+        FLD_SET(conn->debug.flags, WT_CONN_DEBUG_CKPT_RETAIN);
     } else
-        FLD_CLR(conn->debug_flags, WT_CONN_DEBUG_CKPT_RETAIN);
+        FLD_CLR(conn->debug.flags, WT_CONN_DEBUG_CKPT_RETAIN);
     conn->debug_ckpt_cnt = (uint32_t)cval.val;
 
     WT_ERR(__wt_config_gets(session, cfg, "debug_mode.log_retention", &cval));
@@ -2347,108 +2347,108 @@ __wti_debug_mode_config(WT_SESSION_IMPL *session, const char *cfg[])
 
     WT_RET(__wt_config_gets(session, cfg, "debug_mode.configuration", &cval));
     if (cval.val)
-        FLD_SET(conn->debug_flags, WT_CONN_DEBUG_CONFIGURATION);
+        FLD_SET(conn->debug.flags, WT_CONN_DEBUG_CONFIGURATION);
     else
-        FLD_CLR(conn->debug_flags, WT_CONN_DEBUG_CONFIGURATION);
+        FLD_CLR(conn->debug.flags, WT_CONN_DEBUG_CONFIGURATION);
 
     WT_RET(__wt_config_gets(session, cfg, "debug_mode.corruption_abort", &cval));
     if (cval.val)
-        FLD_SET(conn->debug_flags, WT_CONN_DEBUG_CORRUPTION_ABORT);
+        FLD_SET(conn->debug.flags, WT_CONN_DEBUG_CORRUPTION_ABORT);
     else
-        FLD_CLR(conn->debug_flags, WT_CONN_DEBUG_CORRUPTION_ABORT);
+        FLD_CLR(conn->debug.flags, WT_CONN_DEBUG_CORRUPTION_ABORT);
 
     WT_RET(__wt_config_gets(session, cfg, "debug_mode.crash_point.before_insert_colgroup", &cval));
     if (cval.val)
-        FLD_SET(conn->debug_flags, WT_CONN_DEBUG_CRASH_POINT_BEFORE_INSERT_COLGROUP);
+        FLD_SET(conn->debug.flags, WT_CONN_DEBUG_CRASH_POINT_BEFORE_INSERT_COLGROUP);
     else
-        FLD_CLR(conn->debug_flags, WT_CONN_DEBUG_CRASH_POINT_BEFORE_INSERT_COLGROUP);
+        FLD_CLR(conn->debug.flags, WT_CONN_DEBUG_CRASH_POINT_BEFORE_INSERT_COLGROUP);
 
     WT_RET(__wt_config_gets(session, cfg, "debug_mode.crash_point.before_insert_file", &cval));
     if (cval.val)
-        FLD_SET(conn->debug_flags, WT_CONN_DEBUG_CRASH_POINT_BEFORE_INSERT_FILE);
+        FLD_SET(conn->debug.flags, WT_CONN_DEBUG_CRASH_POINT_BEFORE_INSERT_FILE);
     else
-        FLD_CLR(conn->debug_flags, WT_CONN_DEBUG_CRASH_POINT_BEFORE_INSERT_FILE);
+        FLD_CLR(conn->debug.flags, WT_CONN_DEBUG_CRASH_POINT_BEFORE_INSERT_FILE);
 
     WT_RET(__wt_config_gets(session, cfg, "debug_mode.crash_point.after_drop_colgroup", &cval));
     if (cval.val)
-        FLD_SET(conn->debug_flags, WT_CONN_DEBUG_CRASH_POINT_AFTER_DROP_COLGROUP);
+        FLD_SET(conn->debug.flags, WT_CONN_DEBUG_CRASH_POINT_AFTER_DROP_COLGROUP);
     else
-        FLD_CLR(conn->debug_flags, WT_CONN_DEBUG_CRASH_POINT_AFTER_DROP_COLGROUP);
+        FLD_CLR(conn->debug.flags, WT_CONN_DEBUG_CRASH_POINT_AFTER_DROP_COLGROUP);
 
     WT_RET(__wt_config_gets(session, cfg, "debug_mode.crash_point.after_drop_file", &cval));
     if (cval.val)
-        FLD_SET(conn->debug_flags, WT_CONN_DEBUG_CRASH_POINT_AFTER_DROP_FILE);
+        FLD_SET(conn->debug.flags, WT_CONN_DEBUG_CRASH_POINT_AFTER_DROP_FILE);
     else
-        FLD_CLR(conn->debug_flags, WT_CONN_DEBUG_CRASH_POINT_AFTER_DROP_FILE);
+        FLD_CLR(conn->debug.flags, WT_CONN_DEBUG_CRASH_POINT_AFTER_DROP_FILE);
 
     WT_RET(__wt_config_gets(session, cfg, "debug_mode.cursor_copy", &cval));
     if (cval.val)
-        FLD_SET(conn->debug_flags, WT_CONN_DEBUG_CURSOR_COPY);
+        FLD_SET(conn->debug.flags, WT_CONN_DEBUG_CURSOR_COPY);
     else
-        FLD_CLR(conn->debug_flags, WT_CONN_DEBUG_CURSOR_COPY);
+        FLD_CLR(conn->debug.flags, WT_CONN_DEBUG_CURSOR_COPY);
 
     WT_RET(__wt_config_gets(session, cfg, "debug_mode.cursor_reposition", &cval));
     if (cval.val)
-        FLD_SET(conn->debug_flags, WT_CONN_DEBUG_CURSOR_REPOSITION);
+        FLD_SET(conn->debug.flags, WT_CONN_DEBUG_CURSOR_REPOSITION);
     else
-        FLD_CLR(conn->debug_flags, WT_CONN_DEBUG_CURSOR_REPOSITION);
+        FLD_CLR(conn->debug.flags, WT_CONN_DEBUG_CURSOR_REPOSITION);
 
     WT_RET(__wt_config_gets(session, cfg, "debug_mode.eviction", &cval));
     if (cval.val)
-        FLD_SET(conn->debug_flags, WT_CONN_DEBUG_EVICT_AGGRESSIVE_MODE);
+        FLD_SET(conn->debug.flags, WT_CONN_DEBUG_EVICT_AGGRESSIVE_MODE);
     else
-        FLD_CLR(conn->debug_flags, WT_CONN_DEBUG_EVICT_AGGRESSIVE_MODE);
+        FLD_CLR(conn->debug.flags, WT_CONN_DEBUG_EVICT_AGGRESSIVE_MODE);
 
     WT_RET(__wt_config_gets(session, cfg, "debug_mode.realloc_exact", &cval));
     if (cval.val)
-        FLD_SET(conn->debug_flags, WT_CONN_DEBUG_REALLOC_EXACT);
+        FLD_SET(conn->debug.flags, WT_CONN_DEBUG_REALLOC_EXACT);
     else
-        FLD_CLR(conn->debug_flags, WT_CONN_DEBUG_REALLOC_EXACT);
+        FLD_CLR(conn->debug.flags, WT_CONN_DEBUG_REALLOC_EXACT);
 
     WT_RET(__wt_config_gets(session, cfg, "debug_mode.realloc_malloc", &cval));
     if (cval.val)
-        FLD_SET(conn->debug_flags, WT_CONN_DEBUG_REALLOC_MALLOC);
+        FLD_SET(conn->debug.flags, WT_CONN_DEBUG_REALLOC_MALLOC);
     else
-        FLD_CLR(conn->debug_flags, WT_CONN_DEBUG_REALLOC_MALLOC);
+        FLD_CLR(conn->debug.flags, WT_CONN_DEBUG_REALLOC_MALLOC);
 
     WT_RET(__wt_config_gets(session, cfg, "debug_mode.rollback_error", &cval));
     txn_global->debug_rollback = (uint64_t)cval.val;
 
     WT_RET(__wt_config_gets(session, cfg, "debug_mode.slow_checkpoint", &cval));
     if (cval.val)
-        FLD_SET(conn->debug_flags, WT_CONN_DEBUG_SLOW_CKPT);
+        FLD_SET(conn->debug.flags, WT_CONN_DEBUG_SLOW_CKPT);
     else
-        FLD_CLR(conn->debug_flags, WT_CONN_DEBUG_SLOW_CKPT);
+        FLD_CLR(conn->debug.flags, WT_CONN_DEBUG_SLOW_CKPT);
 
     WT_RET(__wt_config_gets(session, cfg, "debug_mode.stress_skiplist", &cval));
     if (cval.val)
-        FLD_SET(conn->debug_flags, WT_CONN_DEBUG_STRESS_SKIPLIST);
+        FLD_SET(conn->debug.flags, WT_CONN_DEBUG_STRESS_SKIPLIST);
     else
-        FLD_CLR(conn->debug_flags, WT_CONN_DEBUG_STRESS_SKIPLIST);
+        FLD_CLR(conn->debug.flags, WT_CONN_DEBUG_STRESS_SKIPLIST);
 
     WT_RET(__wt_config_gets(session, cfg, "debug_mode.table_logging", &cval));
     if (cval.val)
-        FLD_SET(conn->debug_flags, WT_CONN_DEBUG_TABLE_LOGGING);
+        FLD_SET(conn->debug.flags, WT_CONN_DEBUG_TABLE_LOGGING);
     else
-        FLD_CLR(conn->debug_flags, WT_CONN_DEBUG_TABLE_LOGGING);
+        FLD_CLR(conn->debug.flags, WT_CONN_DEBUG_TABLE_LOGGING);
 
     WT_RET(__wt_config_gets(session, cfg, "debug_mode.tiered_flush_error_continue", &cval));
     if (cval.val)
-        FLD_SET(conn->debug_flags, WT_CONN_DEBUG_TIERED_FLUSH_ERROR_CONTINUE);
+        FLD_SET(conn->debug.flags, WT_CONN_DEBUG_TIERED_FLUSH_ERROR_CONTINUE);
     else
-        FLD_CLR(conn->debug_flags, WT_CONN_DEBUG_TIERED_FLUSH_ERROR_CONTINUE);
+        FLD_CLR(conn->debug.flags, WT_CONN_DEBUG_TIERED_FLUSH_ERROR_CONTINUE);
 
     WT_RET(__wt_config_gets(session, cfg, "debug_mode.update_restore_evict", &cval));
     if (cval.val)
-        FLD_SET(conn->debug_flags, WT_CONN_DEBUG_UPDATE_RESTORE_EVICT);
+        FLD_SET(conn->debug.flags, WT_CONN_DEBUG_UPDATE_RESTORE_EVICT);
     else
-        FLD_CLR(conn->debug_flags, WT_CONN_DEBUG_UPDATE_RESTORE_EVICT);
+        FLD_CLR(conn->debug.flags, WT_CONN_DEBUG_UPDATE_RESTORE_EVICT);
 
     WT_RET(__wt_config_gets(session, cfg, "debug_mode.eviction_checkpoint_ts_ordering", &cval));
     if (cval.val)
-        FLD_SET(conn->debug_flags, WT_CONN_DEBUG_EVICTION_CKPT_TS_ORDERING);
+        FLD_SET(conn->debug.flags, WT_CONN_DEBUG_EVICTION_CKPT_TS_ORDERING);
     else
-        FLD_CLR(conn->debug_flags, WT_CONN_DEBUG_EVICTION_CKPT_TS_ORDERING);
+        FLD_CLR(conn->debug.flags, WT_CONN_DEBUG_EVICTION_CKPT_TS_ORDERING);
     return (0);
 }
 

--- a/src/conn/conn_handle.c
+++ b/src/conn/conn_handle.c
@@ -142,7 +142,7 @@ __wti_connection_destroy(WT_CONNECTION_IMPL *conn)
 
     /* Free allocated memory. */
     __wt_free(session, conn->cfg);
-    __wt_free(session, conn->debug_ckpt);
+    __wt_free(session, conn->debug.ckpt);
     __wt_free(session, conn->error_prefix);
     __wt_free(session, conn->home);
     __wt_free(session, WT_CONN_SESSIONS_GET(conn));

--- a/src/conn/conn_tiered.c
+++ b/src/conn/conn_tiered.c
@@ -301,7 +301,7 @@ __tier_do_operation(WT_SESSION_IMPL *session, WT_TIERED *tiered, uint32_t id, co
             /*
              * Continue with the error ignored if we've been told to do that.
              */
-            if (FLD_ISSET(S2C(session)->debug_flags, WT_CONN_DEBUG_TIERED_FLUSH_ERROR_CONTINUE))
+            if (FLD_ISSET(S2C(session)->debug.flags, WT_CONN_DEBUG_TIERED_FLUSH_ERROR_CONTINUE))
                 ret = 0;
             WT_ERR(ret);
         }

--- a/src/cursor/cur_std.c
+++ b/src/cursor/cur_std.c
@@ -395,7 +395,7 @@ __wti_cursor_get_keyv(WT_CURSOR *cursor, uint64_t flags, va_list ap)
         WT_ERR(__wt_cursor_kv_not_set(cursor, true));
 
     /* Force an allocated copy when using cursor copy debug. */
-    if (FLD_ISSET(S2C(session)->debug_flags, WT_CONN_DEBUG_CURSOR_COPY)) {
+    if (FLD_ISSET(S2C(session)->debug.flags, WT_CONN_DEBUG_CURSOR_COPY)) {
         WT_ERR(__wt_buf_grow(session, &cursor->key, cursor->key.size));
         F_SET(cursor, WT_CURSTD_DEBUG_COPY_KEY);
     }
@@ -508,7 +508,7 @@ err:
      * memory in the meantime, free it.
      */
     if (tmp.mem != NULL) {
-        if (buf->mem == NULL && !FLD_ISSET(S2C(session)->debug_flags, WT_CONN_DEBUG_CURSOR_COPY)) {
+        if (buf->mem == NULL && !FLD_ISSET(S2C(session)->debug.flags, WT_CONN_DEBUG_CURSOR_COPY)) {
             buf->mem = tmp.mem;
             buf->memsize = tmp.memsize;
             F_SET(cursor, WT_CURSTD_DEBUG_COPY_KEY);
@@ -552,7 +552,7 @@ __wti_cursor_get_valuev(WT_CURSOR *cursor, va_list ap)
         WT_ERR(__wt_cursor_kv_not_set(cursor, false));
 
     /* Force an allocated copy when using cursor copy debug. */
-    if (FLD_ISSET(S2C(session)->debug_flags, WT_CONN_DEBUG_CURSOR_COPY)) {
+    if (FLD_ISSET(S2C(session)->debug.flags, WT_CONN_DEBUG_CURSOR_COPY)) {
         WT_ERR(__wt_buf_grow(session, &cursor->value, cursor->value.size));
         F_SET(cursor, WT_CURSTD_DEBUG_COPY_VALUE);
     }
@@ -595,7 +595,7 @@ __wt_cursor_get_raw_key_value(WT_CURSOR *cursor, WT_ITEM *key, WT_ITEM *value)
         WT_ERR(__wt_cursor_kv_not_set(cursor, false));
 
     /* Force an allocated copy when using cursor copy debug. */
-    if (FLD_ISSET(S2C(session)->debug_flags, WT_CONN_DEBUG_CURSOR_COPY)) {
+    if (FLD_ISSET(S2C(session)->debug.flags, WT_CONN_DEBUG_CURSOR_COPY)) {
         WT_ERR(__wt_buf_grow(session, &cursor->key, cursor->key.size));
         F_SET(cursor, WT_CURSTD_DEBUG_COPY_KEY);
         WT_ERR(__wt_buf_grow(session, &cursor->value, cursor->value.size));
@@ -693,7 +693,7 @@ err:
      * memory in the meantime, free it.
      */
     if (tmp.mem != NULL) {
-        if (buf->mem == NULL && !FLD_ISSET(S2C(session)->debug_flags, WT_CONN_DEBUG_CURSOR_COPY)) {
+        if (buf->mem == NULL && !FLD_ISSET(S2C(session)->debug.flags, WT_CONN_DEBUG_CURSOR_COPY)) {
             buf->mem = tmp.mem;
             buf->memsize = tmp.memsize;
             F_SET(cursor, WT_CURSTD_DEBUG_COPY_VALUE);

--- a/src/evict/evict_conn.c
+++ b/src/evict/evict_conn.c
@@ -64,9 +64,9 @@ __evict_validate_config(WT_SESSION_IMPL *session, const char *cfg[])
     /* Debug flags are not yet set when this function runs during connection open. Set it now. */
     WT_RET(__wt_config_gets(session, cfg, "debug_mode.configuration", &cval));
     if (cval.val)
-        FLD_SET(conn->debug_flags, WT_CONN_DEBUG_CONFIGURATION);
+        FLD_SET(conn->debug.flags, WT_CONN_DEBUG_CONFIGURATION);
     else
-        FLD_CLR(conn->debug_flags, WT_CONN_DEBUG_CONFIGURATION);
+        FLD_CLR(conn->debug.flags, WT_CONN_DEBUG_CONFIGURATION);
 
     WT_RET(__wt_config_gets(session, cfg, "eviction_target", &cval));
     evict->eviction_target = (double)cval.val;

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -1170,7 +1170,7 @@ __evict_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_flags)
          */
         if (!WT_SESSION_BTREE_SYNC(session)) {
             bool can_scrub = (F_ISSET(evict, WT_EVICT_CACHE_SCRUB) ||
-              (FLD_ISSET(conn->debug_flags, WT_CONN_DEBUG_EVICT_AGGRESSIVE_MODE) &&
+              (FLD_ISSET(conn->debug.flags, WT_CONN_DEBUG_EVICT_AGGRESSIVE_MODE) &&
                 __wt_random(&session->rnd_random) % 3 == 0));
 
             /*

--- a/src/evict/evict_queue.c
+++ b/src/evict/evict_queue.c
@@ -227,7 +227,7 @@ __wti_evict_lru_walk(WT_SESSION_IMPL *session)
      * Style note: __wt_qsort is a macro that can leave a dangling else. Full curly braces are
      * needed here for the compiler.
      */
-    if (FLD_ISSET(conn->debug_flags, WT_CONN_DEBUG_EVICT_AGGRESSIVE_MODE)) {
+    if (FLD_ISSET(conn->debug.flags, WT_CONN_DEBUG_EVICT_AGGRESSIVE_MODE)) {
         __wt_qsort(queue->evict_queue, entries, sizeof(WTI_EVICT_ENTRY), __evict_lru_cmp_debug);
     } else {
         __wt_qsort(queue->evict_queue, entries, sizeof(WTI_EVICT_ENTRY), __evict_lru_cmp);

--- a/src/evict/evict_thread.c
+++ b/src/evict/evict_thread.c
@@ -590,7 +590,7 @@ __evict_update_work(WT_SESSION_IMPL *session, bool *eviction_needed)
     } else
         LF_SET(WT_EVICT_CACHE_NOKEEP);
 
-    if (FLD_ISSET(conn->debug_flags, WT_CONN_DEBUG_UPDATE_RESTORE_EVICT)) {
+    if (FLD_ISSET(conn->debug.flags, WT_CONN_DEBUG_UPDATE_RESTORE_EVICT)) {
         LF_SET(WT_EVICT_CACHE_SCRUB);
         LF_CLR(WT_EVICT_CACHE_NOKEEP);
     }

--- a/src/evict/evict_walk.c
+++ b/src/evict/evict_walk.c
@@ -1173,7 +1173,7 @@ __evict_try_queue_page(WT_SESSION_IMPL *session, WTI_EVICT_QUEUE *queue, WT_REF 
      * being skipped for walks), or we are in eviction debug mode. The goal here is that if trees
      * become completely idle, we eventually push them out of cache completely.
      */
-    if (!FLD_ISSET(conn->debug_flags, WT_CONN_DEBUG_EVICT_AGGRESSIVE_MODE) &&
+    if (!FLD_ISSET(conn->debug.flags, WT_CONN_DEBUG_EVICT_AGGRESSIVE_MODE) &&
       F_ISSET(ref, WT_REF_FLAG_INTERNAL)) {
         if (page == last_parent) {
             WT_STAT_CONN_INCR(session, eviction_server_skip_intl_page_with_active_child);

--- a/src/include/api.h
+++ b/src/include/api.h
@@ -391,12 +391,12 @@
  * eviction of hot pages. These macros facilitate tracking when that is OK.
  */
 #define CURSOR_REPOSITION_ENTER(c, s)                                      \
-    if (FLD_ISSET(S2C(s)->debug_flags, WT_CONN_DEBUG_CURSOR_REPOSITION) && \
+    if (FLD_ISSET(S2C(s)->debug.flags, WT_CONN_DEBUG_CURSOR_REPOSITION) && \
       (s)->api_call_counter == 1)                                          \
     F_SET((c), WT_CURSTD_EVICT_REPOSITION)
 
 #define CURSOR_REPOSITION_END(c, s)                                        \
-    if (FLD_ISSET(S2C(s)->debug_flags, WT_CONN_DEBUG_CURSOR_REPOSITION) && \
+    if (FLD_ISSET(S2C(s)->debug.flags, WT_CONN_DEBUG_CURSOR_REPOSITION) && \
       (s)->api_call_counter == 1)                                          \
     F_CLR((c), WT_CURSTD_EVICT_REPOSITION)
 

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -2487,7 +2487,7 @@ __wt_skip_choose_depth(WT_SESSION_IMPL *session)
     probability = WT_SKIP_PROBABILITY;
 #ifdef HAVE_DIAGNOSTIC
     /* Go from 1/4 chance of having a link to the next element to ~90%. */
-    if (FLD_ISSET(S2C(session)->debug_flags, WT_CONN_DEBUG_STRESS_SKIPLIST))
+    if (FLD_ISSET(S2C(session)->debug.flags, WT_CONN_DEBUG_STRESS_SKIPLIST))
         probability = 0xe6666665; /* ~90% of the value of uint32 max. */
 #endif
 

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -784,6 +784,10 @@ struct __wt_conn_debug {
 #define WT_CONN_DEBUG_UPDATE_RESTORE_EVICT 0x20000u
     /* AUTOMATIC FLAG VALUE GENERATION STOP 32 */
     uint32_t flags;
+
+    /* The debug mode for upgrade/downgrade of the disaggregated storage address cookies. */
+    WT_CONN_DEBUG_DISAGG_ADDRESS_COOKIE_UPGRADE disagg_address_cookie_upgrade;
+    bool disagg_address_cookie_optional_field;
 };
 
 /*
@@ -1077,10 +1081,6 @@ struct __wt_connection_impl {
     /* AUTOMATIC FLAG VALUE GENERATION STOP 64 */
     /* Categories of assertions that can be runtime enabled. */
     uint64_t extra_diagnostics_flags;
-
-    /* The debug mode for upgrade/downgrade of the disaggregated storage address cookies. */
-    WT_CONN_DEBUG_DISAGG_ADDRESS_COOKIE_UPGRADE debug_disagg_address_cookie_upgrade;
-    bool debug_disagg_address_cookie_optional_field;
 
     /* Verbose settings for our various categories. */
     WT_VERBOSE_LEVEL verbose[WT_VERB_NUM_CATEGORIES];

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -753,6 +753,34 @@ typedef enum __wt_conn_debug_disagg_address_cookie_upgrade {
 } WT_CONN_DEBUG_DISAGG_ADDRESS_COOKIE_UPGRADE;
 
 /*
+ * WT_CONN_DEBUG --
+ *     Debug-mode fields extracted from WT_CONNECTION_IMPL.
+ */
+struct __wt_conn_debug {
+/* AUTOMATIC FLAG VALUE GENERATION START 0 */
+#define WT_CONN_DEBUG_CKPT_RETAIN 0x00001u
+#define WT_CONN_DEBUG_CONFIGURATION 0x00002u
+#define WT_CONN_DEBUG_CORRUPTION_ABORT 0x00004u
+#define WT_CONN_DEBUG_CRASH_POINT_AFTER_DROP_COLGROUP 0x00008u
+#define WT_CONN_DEBUG_CRASH_POINT_AFTER_DROP_FILE 0x00010u
+#define WT_CONN_DEBUG_CRASH_POINT_BEFORE_INSERT_COLGROUP 0x00020u
+#define WT_CONN_DEBUG_CRASH_POINT_BEFORE_INSERT_FILE 0x00040u
+#define WT_CONN_DEBUG_CURSOR_COPY 0x00080u
+#define WT_CONN_DEBUG_CURSOR_REPOSITION 0x00100u
+#define WT_CONN_DEBUG_EVICTION_CKPT_TS_ORDERING 0x00200u
+#define WT_CONN_DEBUG_EVICT_AGGRESSIVE_MODE 0x00400u
+#define WT_CONN_DEBUG_REALLOC_EXACT 0x00800u
+#define WT_CONN_DEBUG_REALLOC_MALLOC 0x01000u
+#define WT_CONN_DEBUG_SLOW_CKPT 0x02000u
+#define WT_CONN_DEBUG_STRESS_SKIPLIST 0x04000u
+#define WT_CONN_DEBUG_TABLE_LOGGING 0x08000u
+#define WT_CONN_DEBUG_TIERED_FLUSH_ERROR_CONTINUE 0x10000u
+#define WT_CONN_DEBUG_UPDATE_RESTORE_EVICT 0x20000u
+    /* AUTOMATIC FLAG VALUE GENERATION STOP 32 */
+    uint32_t flags;
+};
+
+/*
  * WT_CONN_EVICT_CONFIG --
  *     Eviction thread group configuration and management fields extracted from WT_CONNECTION_IMPL.
  */
@@ -1026,33 +1054,13 @@ struct __wt_connection_impl {
     bool mmap_all; /* use mmap for all I/O on data files */
     int page_size; /* OS page size for mmap alignment */
 
+    WT_CONN_DEBUG debug; /* Debug-mode configuration */
+
     /* Access to these fields is protected by the debug_log_retention_lock. */
     WT_LSN *debug_ckpt;                /* Debug mode checkpoint LSNs. */
     size_t debug_ckpt_alloc;           /* Checkpoint retention allocated. */
     wt_shared uint32_t debug_ckpt_cnt; /* Checkpoint retention number. */
     wt_shared uint32_t debug_log_cnt;  /* Log file retention count */
-
-/* AUTOMATIC FLAG VALUE GENERATION START 0 */
-#define WT_CONN_DEBUG_CKPT_RETAIN 0x00001u
-#define WT_CONN_DEBUG_CONFIGURATION 0x00002u
-#define WT_CONN_DEBUG_CORRUPTION_ABORT 0x00004u
-#define WT_CONN_DEBUG_CRASH_POINT_AFTER_DROP_COLGROUP 0x00008u
-#define WT_CONN_DEBUG_CRASH_POINT_AFTER_DROP_FILE 0x00010u
-#define WT_CONN_DEBUG_CRASH_POINT_BEFORE_INSERT_COLGROUP 0x00020u
-#define WT_CONN_DEBUG_CRASH_POINT_BEFORE_INSERT_FILE 0x00040u
-#define WT_CONN_DEBUG_CURSOR_COPY 0x00080u
-#define WT_CONN_DEBUG_CURSOR_REPOSITION 0x00100u
-#define WT_CONN_DEBUG_EVICTION_CKPT_TS_ORDERING 0x00200u
-#define WT_CONN_DEBUG_EVICT_AGGRESSIVE_MODE 0x00400u
-#define WT_CONN_DEBUG_REALLOC_EXACT 0x00800u
-#define WT_CONN_DEBUG_REALLOC_MALLOC 0x01000u
-#define WT_CONN_DEBUG_SLOW_CKPT 0x02000u
-#define WT_CONN_DEBUG_STRESS_SKIPLIST 0x04000u
-#define WT_CONN_DEBUG_TABLE_LOGGING 0x08000u
-#define WT_CONN_DEBUG_TIERED_FLUSH_ERROR_CONTINUE 0x10000u
-#define WT_CONN_DEBUG_UPDATE_RESTORE_EVICT 0x20000u
-    /* AUTOMATIC FLAG VALUE GENERATION STOP 32 */
-    uint32_t debug_flags;
 
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */
 #define WT_DIAGNOSTIC_ALL 0x001ull

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -757,6 +757,12 @@ typedef enum __wt_conn_debug_disagg_address_cookie_upgrade {
  *     Debug-mode fields extracted from WT_CONNECTION_IMPL.
  */
 struct __wt_conn_debug {
+    /* Access to these fields is protected by conn->log_mgr.debug_log_retention_lock. */
+    WT_LSN *ckpt;                /* Debug mode checkpoint LSNs. */
+    size_t ckpt_alloc;           /* Checkpoint retention allocated. */
+    wt_shared uint32_t ckpt_cnt; /* Checkpoint retention number. */
+    wt_shared uint32_t log_cnt;  /* Log file retention count */
+
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */
 #define WT_CONN_DEBUG_CKPT_RETAIN 0x00001u
 #define WT_CONN_DEBUG_CONFIGURATION 0x00002u
@@ -1055,12 +1061,6 @@ struct __wt_connection_impl {
     int page_size; /* OS page size for mmap alignment */
 
     WT_CONN_DEBUG debug; /* Debug-mode configuration */
-
-    /* Access to these fields is protected by the debug_log_retention_lock. */
-    WT_LSN *debug_ckpt;                /* Debug mode checkpoint LSNs. */
-    size_t debug_ckpt_alloc;           /* Checkpoint retention allocated. */
-    wt_shared uint32_t debug_ckpt_cnt; /* Checkpoint retention number. */
-    wt_shared uint32_t debug_log_cnt;  /* Log file retention count */
 
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */
 #define WT_DIAGNOSTIC_ALL 0x001ull

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -754,7 +754,7 @@ typedef enum __wt_conn_debug_disagg_address_cookie_upgrade {
 
 /*
  * WT_CONN_DEBUG --
- *     Debug-mode fields extracted from WT_CONNECTION_IMPL.
+ *     Connection debug-mode configuration and state.
  */
 struct __wt_conn_debug {
     /* Access to these fields is protected by conn->log_mgr.debug_log_retention_lock. */

--- a/src/include/cursor_inline.h
+++ b/src/include/cursor_inline.h
@@ -65,7 +65,7 @@ __cursor_copy_release(WT_CURSOR *cursor)
      * we can exit the function quickly.
      */
     if (F_ISSET(cursor, WT_CURSTD_DEBUG_COPY_KEY | WT_CURSTD_DEBUG_COPY_VALUE) &&
-      FLD_ISSET(S2C(CUR2S(cursor))->debug_flags, WT_CONN_DEBUG_CURSOR_COPY)) {
+      FLD_ISSET(S2C(CUR2S(cursor))->debug.flags, WT_CONN_DEBUG_CURSOR_COPY)) {
         if (F_ISSET(cursor, WT_CURSTD_DEBUG_COPY_KEY)) {
             WT_RET(__wt_cursor_copy_release_item(cursor, &cursor->key));
             F_CLR(cursor, WT_CURSTD_DEBUG_COPY_KEY);

--- a/src/include/misc.h
+++ b/src/include/misc.h
@@ -145,7 +145,7 @@
     (((number) * sizeof(**(addr)) <= *(sizep)) ?                                \
         0 :                                                                     \
         __wt_realloc(session, sizep,                                            \
-          (FLD_ISSET(S2C(session)->debug_flags, WT_CONN_DEBUG_REALLOC_EXACT)) ? \
+          (FLD_ISSET(S2C(session)->debug.flags, WT_CONN_DEBUG_REALLOC_EXACT)) ? \
             (number) * sizeof(**(addr)) :                                       \
             WT_MAX(*(sizep)*2, WT_MAX(10, (number)) * sizeof(**(addr))),        \
           addr))

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -54,7 +54,7 @@ __wt_txn_log_op_check(WT_SESSION_IMPL *session)
      * out almost all log records, check it first.
      */
     if (!F_ISSET(S2BT(session), WT_BTREE_LOGGED) &&
-      !FLD_ISSET(conn->debug_flags, WT_CONN_DEBUG_TABLE_LOGGING))
+      !FLD_ISSET(conn->debug.flags, WT_CONN_DEBUG_TABLE_LOGGING))
         return (false);
 
     /*

--- a/src/include/verbose.h
+++ b/src/include/verbose.h
@@ -324,6 +324,6 @@ struct __wt_verbose_multi_category {
  */
 #define WT_CONFIG_DEBUG(session, fmt, ...)                                          \
     do {                                                                            \
-        if (FLD_ISSET(S2C(session)->debug_flags, WT_CONN_DEBUG_CONFIGURATION))      \
+        if (FLD_ISSET(S2C(session)->debug.flags, WT_CONN_DEBUG_CONFIGURATION))      \
             __wt_verbose_warning(session, WT_VERB_CONFIGURATION, fmt, __VA_ARGS__); \
     } while (0)

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -171,6 +171,8 @@ struct __wt_config_parser_impl;
 typedef struct __wt_config_parser_impl WT_CONFIG_PARSER_IMPL;
 struct __wt_conn_capacity;
 typedef struct __wt_conn_capacity WT_CONN_CAPACITY;
+struct __wt_conn_debug;
+typedef struct __wt_conn_debug WT_CONN_DEBUG;
 struct __wt_conn_evict_config;
 typedef struct __wt_conn_evict_config WT_CONN_EVICT_CONFIG;
 struct __wt_conn_extensions;

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -317,10 +317,10 @@ __wt_log_ckpt(WT_SESSION_IMPL *session, WT_LSN *ckpt_lsn)
      * newest LSN into the array.
      */
     __wt_writelock(session, &conn->log_mgr.debug_log_retention_lock);
-    if (conn->debug_ckpt_cnt != 0) {
-        for (i = (int)conn->debug_ckpt_cnt - 1; i > 0; --i)
-            conn->debug_ckpt[i] = conn->debug_ckpt[i - 1];
-        conn->debug_ckpt[0] = *ckpt_lsn;
+    if (conn->debug.ckpt_cnt != 0) {
+        for (i = (int)conn->debug.ckpt_cnt - 1; i > 0; --i)
+            conn->debug.ckpt[i] = conn->debug.ckpt[i - 1];
+        conn->debug.ckpt[0] = *ckpt_lsn;
     }
     __wt_writeunlock(session, &conn->log_mgr.debug_log_retention_lock);
 }

--- a/src/log/log_mgr.c
+++ b/src/log/log_mgr.c
@@ -405,10 +405,10 @@ __compute_min_lognum(WT_SESSION_IMPL *session, WTI_LOG *log, uint32_t backup_fil
 
     /* Adjust the number of log files to retain based on debugging options. */
 
-    if (FLD_ISSET(conn->debug.flags, WT_CONN_DEBUG_CKPT_RETAIN) && conn->debug_ckpt_cnt != 0)
-        min_lognum = WT_MIN(conn->debug_ckpt[conn->debug_ckpt_cnt - 1].l.file, min_lognum);
+    if (FLD_ISSET(conn->debug.flags, WT_CONN_DEBUG_CKPT_RETAIN) && conn->debug.ckpt_cnt != 0)
+        min_lognum = WT_MIN(conn->debug.ckpt[conn->debug.ckpt_cnt - 1].l.file, min_lognum);
 
-    if (conn->debug_log_cnt != 0) {
+    if (conn->debug.log_cnt != 0) {
         /*
          * If we're performing checkpoints, apply the retain value as a minimum, increasing the
          * number the log files we keep. If not performing checkpoints, it's an absolute number of
@@ -418,12 +418,12 @@ __compute_min_lognum(WT_SESSION_IMPL *session, WTI_LOG *log, uint32_t backup_fil
          *
          * Check for N+1, that is, we retain N full log files, and one partial.
          */
-        if ((conn->debug_log_cnt + 1) >= log->fileid)
+        if ((conn->debug.log_cnt + 1) >= log->fileid)
             min_lognum = 0;
         else if (WT_IS_INIT_LSN(&log->ckpt_lsn))
-            min_lognum = log->fileid - (conn->debug_log_cnt + 1);
+            min_lognum = log->fileid - (conn->debug.log_cnt + 1);
         else
-            min_lognum = WT_MIN(log->fileid - (conn->debug_log_cnt + 1), min_lognum);
+            min_lognum = WT_MIN(log->fileid - (conn->debug.log_cnt + 1), min_lognum);
     }
 
     __wt_readunlock(session, &conn->log_mgr.debug_log_retention_lock);
@@ -435,7 +435,7 @@ __compute_min_lognum(WT_SESSION_IMPL *session, WTI_LOG *log, uint32_t backup_fil
           " sync file %" PRIu32 " backup_file %" PRIu32 " debug_log count%" PRIu32
           " old min %" PRIu32,
           (uintmax_t)ts.tv_sec, (uintmax_t)ts.tv_nsec / WT_THOUSAND, min_lognum,
-          log->ckpt_lsn.l.file, log->sync_lsn.l.file, backup_file, conn->debug_log_cnt,
+          log->ckpt_lsn.l.file, log->sync_lsn.l.file, backup_file, conn->debug.log_cnt,
           log->min_fileid));
         log->min_fileid = min_lognum;
     }

--- a/src/log/log_mgr.c
+++ b/src/log/log_mgr.c
@@ -405,7 +405,7 @@ __compute_min_lognum(WT_SESSION_IMPL *session, WTI_LOG *log, uint32_t backup_fil
 
     /* Adjust the number of log files to retain based on debugging options. */
 
-    if (FLD_ISSET(conn->debug_flags, WT_CONN_DEBUG_CKPT_RETAIN) && conn->debug_ckpt_cnt != 0)
+    if (FLD_ISSET(conn->debug.flags, WT_CONN_DEBUG_CKPT_RETAIN) && conn->debug_ckpt_cnt != 0)
         min_lognum = WT_MIN(conn->debug_ckpt[conn->debug_ckpt_cnt - 1].l.file, min_lognum);
 
     if (conn->debug_log_cnt != 0) {

--- a/src/os_common/os_alloc.c
+++ b/src/os_common/os_alloc.c
@@ -146,7 +146,7 @@ __realloc_func(WT_SESSION_IMPL *session, size_t *bytes_allocated_ret, size_t byt
      * memory, scribble over the old memory then free it.
      */
     tmpp = p;
-    if (session != NULL && FLD_ISSET(S2C(session)->debug_flags, WT_CONN_DEBUG_REALLOC_MALLOC) &&
+    if (session != NULL && FLD_ISSET(S2C(session)->debug.flags, WT_CONN_DEBUG_REALLOC_MALLOC) &&
       (bytes_allocated_ret != NULL)) {
         if ((p = malloc(bytes_to_allocate)) == NULL)
             WT_RET_MSG(session, __wt_errno(), "memory allocation of %" WT_SIZET_FMT " bytes failed",

--- a/src/reconcile/rec_hs.c
+++ b/src/reconcile/rec_hs.c
@@ -685,7 +685,7 @@ __wti_rec_hs_insert_updates(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_MULTI
     WT_TIME_WINDOW_INIT(&tw);
     insert_cnt = 0;
     error_on_ts_ordering = F_ISSET(r, WT_REC_CHECKPOINT_RUNNING) ||
-      FLD_ISSET(conn->debug_flags, WT_CONN_DEBUG_EVICTION_CKPT_TS_ORDERING);
+      FLD_ISSET(conn->debug.flags, WT_CONN_DEBUG_EVICTION_CKPT_TS_ORDERING);
     cache_hs_insert_full_update = cache_hs_insert_reverse_modify = cache_hs_write_squash = 0;
     cache_hs_key_processed = cache_hs_update_processed = 0;
 

--- a/src/schema/schema_util.c
+++ b/src/schema/schema_util.c
@@ -219,7 +219,7 @@ __wti_debug_crash_if_flag_set(
 {
     /* FIXME-WT-12021: Replace this function and its call sites with a proper failpoint once the
      * framework is available. */
-    if (FLD_ISSET(S2C(session)->debug_flags, flag)) {
+    if (FLD_ISSET(S2C(session)->debug.flags, flag)) {
         __wt_verbose_warning(session, WT_VERB_DEFAULT, "Simulating a crash %s '%s'", msg, uri);
         /* Wait for the previous metadata change to be persisted. */
         __wt_sleep(2, 0);

--- a/src/support/err.c
+++ b/src/support/err.c
@@ -629,7 +629,7 @@ __wt_panic_func(WT_SESSION_IMPL *session, int error, const char *func, int line,
      */
     if (conn != NULL &&
       (!F_ISSET_ATOMIC_32(conn, WT_CONN_DATA_CORRUPTION) ||
-        FLD_ISSET(conn->debug_flags, WT_CONN_DEBUG_CORRUPTION_ABORT)))
+        FLD_ISSET(conn->debug.flags, WT_CONN_DEBUG_CORRUPTION_ABORT)))
         __wt_abort(session);
 #endif
 

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1918,7 +1918,7 @@ __wt_txn_prepare(WT_SESSION_IMPL *session, const char *cfg[])
      * turned on.
      */
     if (txn->txn_log.logrec != NULL &&
-      !FLD_ISSET(S2C(session)->debug_flags, WT_CONN_DEBUG_TABLE_LOGGING))
+      !FLD_ISSET(S2C(session)->debug.flags, WT_CONN_DEBUG_TABLE_LOGGING))
         WT_RET_MSG(session, EINVAL, "a prepared transaction cannot include a logged table");
 
     /* Set the prepare timestamp. */

--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -223,7 +223,7 @@ __txn_logrec_init(WT_SESSION_IMPL *session)
      * The only way we should ever get in here without a txn id is if we are recording diagnostic
      * information. In that case, allocate an id.
      */
-    if (FLD_ISSET(S2C(session)->debug_flags, WT_CONN_DEBUG_TABLE_LOGGING) &&
+    if (FLD_ISSET(S2C(session)->debug.flags, WT_CONN_DEBUG_TABLE_LOGGING) &&
       txn->time_point.id == WT_TXN_NONE)
         WT_RET(__wt_txn_id_check(session));
     else
@@ -274,7 +274,7 @@ __wt_txn_log_op(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt)
      * skip it.
      */
     if (!F_ISSET(S2BT(session), WT_BTREE_LOGGED) &&
-      FLD_ISSET(conn->debug_flags, WT_CONN_DEBUG_TABLE_LOGGING))
+      FLD_ISSET(conn->debug.flags, WT_CONN_DEBUG_TABLE_LOGGING))
         FLD_SET(fileid, WT_LOGOP_IGNORE);
 
     WT_RET(__txn_logrec_init(session));

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -1129,7 +1129,7 @@ __wt_txn_set_timestamp(WT_SESSION_IMPL *session, const char *cfg[], bool commit)
         WT_RET(__txn_set_rollback_timestamp(session, rollback_ts));
 
     /* Timestamps are only logged in debugging mode. */
-    if (set_ts && FLD_ISSET(conn->debug_flags, WT_CONN_DEBUG_TABLE_LOGGING) &&
+    if (set_ts && FLD_ISSET(conn->debug.flags, WT_CONN_DEBUG_TABLE_LOGGING) &&
       F_ISSET(&conn->log_mgr, WT_LOG_ENABLED) && !F_ISSET(conn, WT_CONN_RECOVERING))
         WT_RET(__wti_txn_ts_log(session));
 
@@ -1194,7 +1194,7 @@ __wt_txn_set_timestamp_uint(WT_SESSION_IMPL *session, WT_TS_TXN_TYPE which, wt_t
     __txn_publish_durable_timestamp(session);
 
     /* Timestamps are only logged in debugging mode. */
-    if (FLD_ISSET(conn->debug_flags, WT_CONN_DEBUG_TABLE_LOGGING) &&
+    if (FLD_ISSET(conn->debug.flags, WT_CONN_DEBUG_TABLE_LOGGING) &&
       F_ISSET(&conn->log_mgr, WT_LOG_ENABLED) && !F_ISSET(conn, WT_CONN_RECOVERING))
         WT_RET(__wti_txn_ts_log(session));
 


### PR DESCRIPTION
## Summary
- Introduces `WT_CONN_DEBUG`, a new sub-struct that groups the debug-mode configuration and state fields extracted from `__wt_connection_impl`
- Moves `debug_flags` (+ all `WT_CONN_DEBUG_*` flag definitions), `debug_ckpt`/`debug_ckpt_alloc`/`debug_ckpt_cnt`/`debug_log_cnt`, and `debug_disagg_address_cookie_upgrade`/`debug_disagg_address_cookie_optional_field` into the new struct
- Access is via `conn->debug.<field>`; `extra_diagnostics_flags`, `verbose`, `json_output`, and `timing_stress_flags` remain on `__wt_connection_impl`
- Updates all call sites across 29 files; a post-move grep confirms zero stale references to the old field paths

## Testing
Pure refactor — no behavioural change. Verified by a clean incremental build (`ninja wt`) with no compiler warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)