### PR TITLE
WT-14798 Stop writing checkpointStart records to phylog

### DIFF
--- a/ext/page_log/palite/palite.cpp
+++ b/ext/page_log/palite/palite.cpp
@@ -2390,13 +2390,6 @@ public:
         return 0;
     }
 
-    int
-    begin_checkpoint(uint64_t checkpoint_id)
-    {
-        LOG_DEBUG("checkpoint_id={}", checkpoint_id);
-        return 0;
-    }
-
     /*
      * Abandon (delete) all page log entries and checkpoint records with an LSN greater than the
      * given LSN.
@@ -2538,12 +2531,6 @@ palite_abandon_checkpoint(WT_PAGE_LOG *page_log, WT_SESSION *sess)
 }
 
 static int
-palite_begin_checkpoint(WT_PAGE_LOG *page_log, WT_SESSION *sess, uint64_t checkpoint_id)
-{
-    return safe_call<Palite>(sess, page_log, &Palite::begin_checkpoint, checkpoint_id);
-}
-
-static int
 palite_complete_checkpoint(
   WT_PAGE_LOG *page_log, WT_SESSION *sess, WT_PAGE_LOG_COMPLETE_CHECKPOINT_ARGS *args)
 {
@@ -2598,7 +2585,6 @@ Palite::initialize_interface()
 {
     pl_add_reference = palite_add_reference;
     pl_abandon_checkpoint = palite_abandon_checkpoint;
-    pl_begin_checkpoint = palite_begin_checkpoint;
     pl_complete_checkpoint = palite_complete_checkpoint;
     pl_get_complete_checkpoint_ext = palite_get_complete_checkpoint_ext;
     pl_get_last_lsn = palite_get_last_lsn;

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -1205,7 +1205,9 @@ __disagg_abandon_checkpoint(WT_SESSION_IMPL *session)
 
 /*
  * __disagg_begin_checkpoint --
- *     Begin the next checkpoint.
+ *     Prepare WiredTiger's internal state for the next checkpoint. This snapshots the metadata-put
+ *     counter used to detect whether checkpoint metadata was written, and loads the encryption key
+ *     into the key provider if one is configured.
  */
 static int
 __disagg_begin_checkpoint(WT_SESSION_IMPL *session)
@@ -1227,9 +1229,6 @@ __disagg_begin_checkpoint(WT_SESSION_IMPL *session)
         WT_DISAGG_METADATA metadata = {0};
         WT_RET(__wti_disagg_load_crypt_key(session, &metadata));
     }
-
-    WT_RET(disagg->npage_log->page_log->pl_begin_checkpoint(
-      disagg->npage_log->page_log, &session->iface, 0));
 
     __wt_verbose_debug2(session, WT_VERB_DISAGGREGATED_STORAGE,
       "Begin next disaggregated storage checkpoint: num_meta_put=%" PRIu64, disagg->num_meta_put);

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -1205,9 +1205,7 @@ __disagg_abandon_checkpoint(WT_SESSION_IMPL *session)
 
 /*
  * __disagg_begin_checkpoint --
- *     Prepare WiredTiger's internal state for the next checkpoint. This snapshots the metadata-put
- *     counter used to detect whether checkpoint metadata was written, and loads the encryption key
- *     into the key provider if one is configured.
+ *     Begin the next checkpoint.
  */
 static int
 __disagg_begin_checkpoint(WT_SESSION_IMPL *session)

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -5606,6 +5606,10 @@ struct __wt_page_log {
      * can put or get using the checkpoint id.  The checkpoint id must be greater than
      * any previous checkpoint id used with this call.
      *
+     * Deprecated: WiredTiger no longer calls this function. It is retained for binary
+     * interface compatibility only and may be removed in a future release. Implementations
+     * may set this field to NULL.
+     *
      * @errors
      *
      * @param page_log the WT_PAGE_LOG

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -5606,10 +5606,6 @@ struct __wt_page_log {
      * can put or get using the checkpoint id.  The checkpoint id must be greater than
      * any previous checkpoint id used with this call.
      *
-     * Deprecated: WiredTiger no longer calls this function. It is retained for binary
-     * interface compatibility only and may be removed in a future release. Implementations
-     * may set this field to NULL.
-     *
      * @errors
      *
      * @param page_log the WT_PAGE_LOG
@@ -5617,6 +5613,7 @@ struct __wt_page_log {
      * @param checkpoint_id the checkpoint id to use. Must be greater than any other
      *        checkpoint_id used with this call.
      */
+    /* FIXME-WT-17548 Disable block cache until it is stable. */
     int (*pl_begin_checkpoint)(WT_PAGE_LOG *page_log, WT_SESSION *session, uint64_t checkpoint_id);
 
     /*!

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -5613,7 +5613,7 @@ struct __wt_page_log {
      * @param checkpoint_id the checkpoint id to use. Must be greater than any other
      *        checkpoint_id used with this call.
      */
-    /* FIXME-WT-17548 Disable block cache until it is stable. */
+    /* FIXME-WT-17548 will be removed. */
     int (*pl_begin_checkpoint)(WT_PAGE_LOG *page_log, WT_SESSION *session, uint64_t checkpoint_id);
 
     /*!

--- a/test/suite/test_disagg01.py
+++ b/test/suite/test_disagg01.py
@@ -55,7 +55,6 @@ class test_disagg01(wttest.WiredTigerTestCase, DisaggConfigMixin):
         session = self.session
         page_log = self.conn.get_page_log('palite')
 
-        page_log.pl_begin_checkpoint(session, 1)
         ckpt_complete_args = wiredtiger.PageLogCompleteCheckpointArgs()
         ckpt_complete_args.checkpoint_id = 1
         ckpt_complete_args.checkpoint_timestamp = 0
@@ -64,7 +63,6 @@ class test_disagg01(wttest.WiredTigerTestCase, DisaggConfigMixin):
         ckpt_complete_args.checkpoint_oldest_timestamp = 0
         page_log.pl_complete_checkpoint(session, ckpt_complete_args)
 
-        page_log.pl_begin_checkpoint(session, 2)
         handle = page_log.pl_open_handle(session, 1)
 
         page20_full = encode_bytes('Hello20')


### PR DESCRIPTION
WiredTiger was calling pl_begin_checkpoint (the checkpointStart record) on the PALI page log at every checkpoint begin. PALI confirmed this is a no-op on their end and safe to remove.

- Remove the pl_begin_checkpoint call from __disagg_begin_checkpoint(). The function still handles key-provider loading and snapshots the num_meta_put counter for checkpoint metadata tracking.
- Remove Palite::begin_checkpoint() and its C wrapper from palite.cpp.
- Mark pl_begin_checkpoint as deprecated in wiredtiger.h.in; keep the struct field for ABI compatibility with MongoDB vendoring. The field will be removed in a follow-up ticket.
- Remove pl_begin_checkpoint test calls from test_disagg01.py since PALite no longer assigns the function pointer.

Summarize the reason behind this change (this might be the problem you're solving, or the context around the request) and the solution you have chosen.
