### PR TITLE
WT-16813 Add garbage collection of the truncate list

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1199,6 +1199,7 @@ keyid
 keyids
 keylen
 keynum
+keyp
 keystr
 keyv
 kp

--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -631,6 +631,8 @@ conn_stats = [
     ##########################################
     LayeredStat('layered_table_manager_checkpoints_disagg_pick_up_follower', 'number of checkpoints picked up by a follower'),
     LayeredStat('layered_table_manager_tables', 'the number of tables the layered table manager has open'),
+    LayeredStat('layered_truncate_list_gc_entries_removed', 'the number of truncate list entries removed by garbage collection'),
+    LayeredStat('layered_truncate_list_gc_runs', 'the number of times truncate list garbage collection ran with a valid prune timestamp'),
     LayeredStat('layered_truncate_list_search_calls', 'the number of times the truncate list was searched'),
     LayeredStat('layered_truncate_list_search_entries_walked', 'the number of truncate list entries walked during search'),
 

--- a/src/conn/conn_layered_ingest.c
+++ b/src/conn/conn_layered_ingest.c
@@ -975,7 +975,7 @@ err:
 
 /*
  * __layered_update_ingest_table_prune_timestamp --
- *     Update the prune timestamp of the specified ingest table.
+ *     Update the prune timestamp and clean up the truncate list of the specified ingest table.
  *
  * We want to see what is the oldest checkpoint on the provided table that is in use by any open
  *     cursor. Even if there are no open cursors on it, the most recent checkpoint on the table is
@@ -990,30 +990,19 @@ err:
  *     calls.
  */
 static int
-__layered_update_ingest_table_prune_timestamp(WT_SESSION_IMPL *session, const char *layered_uri,
-  wt_timestamp_t checkpoint_timestamp, WT_ITEM *uri_at_checkpoint_buf)
+__layered_update_ingest_table_prune_timestamp(WT_SESSION_IMPL *session,
+  WT_LAYERED_TABLE *layered_table, wt_timestamp_t checkpoint_timestamp,
+  WT_ITEM *uri_at_checkpoint_buf, wt_timestamp_t *prune_tsp)
 {
     WT_BTREE *btree;
     WT_DECL_RET;
-    WT_LAYERED_TABLE *layered_table;
     wt_timestamp_t btree_prune_timestamp, prune_timestamp;
     int64_t ckpt_inuse, last_ckpt;
     int32_t layered_dhandle_inuse, stable_dhandle_inuse;
 
-    layered_table = NULL;
+    WT_ASSERT(session, prune_tsp != NULL);
     prune_timestamp = WT_TS_NONE;
-
-    /*
-     * Get the layered table from the provided URI. We don't hold any global locks so that's
-     * possible that it was already removed.
-     */
-    WT_ERR_NOTFOUND_OK(__wt_session_get_dhandle(session, layered_uri, NULL, NULL, 0), true);
-    if (ret == WT_NOTFOUND) {
-        __wt_verbose_level(session, WT_VERB_LAYERED, WT_VERBOSE_DEBUG_5,
-          "GC %s: Layered table was not found.", layered_uri);
-        return (0);
-    }
-    layered_table = (WT_LAYERED_TABLE *)session->dhandle;
+    *prune_tsp = WT_TS_NONE;
 
     /*
      * Get the last existing checkpoint. If we've never seen a checkpoint, then there's nothing in
@@ -1117,15 +1106,46 @@ __layered_update_ingest_table_prune_timestamp(WT_SESSION_IMPL *session, const ch
      * obsolete value. Therefore, no synchronization is required.
      */
     __wt_atomic_store_uint64_relaxed(&btree->prune_timestamp, prune_timestamp);
+    *prune_tsp = prune_timestamp;
     layered_table->last_ckpt_inuse = ckpt_inuse;
 
     WT_ERR(__wt_session_release_dhandle(session));
 
 err:
-    WT_ASSERT(session, layered_table != NULL);
     session->dhandle = (WT_DATA_HANDLE *)layered_table;
-    WT_TRET(__wt_session_release_dhandle(session));
+    return (ret);
+}
 
+/*
+ * __layered_single_ingest_table_gc_prune --
+ *     Update the prune timestamps and garbage collect the truncate list for a given ingest table.
+ */
+static int
+__layered_single_ingest_table_gc_prune(WT_SESSION_IMPL *session, const char *layered_uri,
+  wt_timestamp_t checkpoint_timestamp, WT_ITEM *uri_at_checkpoint_buf)
+{
+    WT_DECL_RET;
+    WT_LAYERED_TABLE *layered_table = NULL;
+
+    ret = __wt_session_get_dhandle(session, layered_uri, NULL, NULL, 0);
+
+    if (ret == WT_NOTFOUND) {
+        __wt_verbose_level(session, WT_VERB_LAYERED, WT_VERBOSE_DEBUG_5,
+          "GC %s: Layered table was not found.", layered_uri);
+        return (0);
+    }
+
+    WT_RET(ret);
+    layered_table = (WT_LAYERED_TABLE *)session->dhandle;
+    wt_timestamp_t prune_timestamp = WT_TS_NONE;
+
+    WT_ERR(__layered_update_ingest_table_prune_timestamp(
+      session, layered_table, checkpoint_timestamp, uri_at_checkpoint_buf, &prune_timestamp));
+
+    __wt_layered_table_truncate_gc(session, layered_table, prune_timestamp);
+
+err:
+    WT_TRET(__wt_session_release_dhandle(session));
     return (ret);
 }
 
@@ -1171,7 +1191,7 @@ __wti_layered_iterate_ingest_tables_for_gc_pruning(
         /* Check the buffer-copy result here to avoid returning with the mutex held. */
         WT_ERR(ret);
 
-        WT_ERR(__layered_update_ingest_table_prune_timestamp(
+        WT_ERR(__layered_single_ingest_table_gc_prune(
           session, layered_table_uri_buf->data, checkpoint_timestamp, uri_at_checkpoint_buf));
 
         __wt_spin_lock(session, &manager->layered_table_lock);

--- a/src/conn/conn_layered_ingest.c
+++ b/src/conn/conn_layered_ingest.c
@@ -975,7 +975,7 @@ err:
 
 /*
  * __layered_update_ingest_table_prune_timestamp --
- *     Update the prune timestamp and clean up the truncate list of the specified ingest table.
+ *     Update the prune timestamp of the specified ingest table.
  *
  * We want to see what is the oldest checkpoint on the provided table that is in use by any open
  *     cursor. Even if there are no open cursors on it, the most recent checkpoint on the table is
@@ -990,19 +990,30 @@ err:
  *     calls.
  */
 static int
-__layered_update_ingest_table_prune_timestamp(WT_SESSION_IMPL *session,
-  WT_LAYERED_TABLE *layered_table, wt_timestamp_t checkpoint_timestamp,
-  WT_ITEM *uri_at_checkpoint_buf, wt_timestamp_t *prune_tsp)
+__layered_update_ingest_table_prune_timestamp(WT_SESSION_IMPL *session, const char *layered_uri,
+  wt_timestamp_t checkpoint_timestamp, WT_ITEM *uri_at_checkpoint_buf)
 {
     WT_BTREE *btree;
     WT_DECL_RET;
+    WT_LAYERED_TABLE *layered_table;
     wt_timestamp_t btree_prune_timestamp, prune_timestamp;
     int64_t ckpt_inuse, last_ckpt;
     int32_t layered_dhandle_inuse, stable_dhandle_inuse;
 
-    WT_ASSERT(session, prune_tsp != NULL);
+    layered_table = NULL;
     prune_timestamp = WT_TS_NONE;
-    *prune_tsp = WT_TS_NONE;
+
+    /*
+     * Get the layered table from the provided URI. We don't hold any global locks so that's
+     * possible that it was already removed.
+     */
+    WT_ERR_NOTFOUND_OK(__wt_session_get_dhandle(session, layered_uri, NULL, NULL, 0), true);
+    if (ret == WT_NOTFOUND) {
+        __wt_verbose_level(session, WT_VERB_LAYERED, WT_VERBOSE_DEBUG_5,
+          "GC %s: Layered table was not found.", layered_uri);
+        return (0);
+    }
+    layered_table = (WT_LAYERED_TABLE *)session->dhandle;
 
     /*
      * Get the last existing checkpoint. If we've never seen a checkpoint, then there's nothing in
@@ -1106,46 +1117,15 @@ __layered_update_ingest_table_prune_timestamp(WT_SESSION_IMPL *session,
      * obsolete value. Therefore, no synchronization is required.
      */
     __wt_atomic_store_uint64_relaxed(&btree->prune_timestamp, prune_timestamp);
-    *prune_tsp = prune_timestamp;
     layered_table->last_ckpt_inuse = ckpt_inuse;
 
     WT_ERR(__wt_session_release_dhandle(session));
 
 err:
+    WT_ASSERT(session, layered_table != NULL);
     session->dhandle = (WT_DATA_HANDLE *)layered_table;
-    return (ret);
-}
-
-/*
- * __layered_single_ingest_table_gc_prune --
- *     Update the prune timestamps and garbage collect the truncate list for a given ingest table.
- */
-static int
-__layered_single_ingest_table_gc_prune(WT_SESSION_IMPL *session, const char *layered_uri,
-  wt_timestamp_t checkpoint_timestamp, WT_ITEM *uri_at_checkpoint_buf)
-{
-    WT_DECL_RET;
-    WT_LAYERED_TABLE *layered_table = NULL;
-
-    ret = __wt_session_get_dhandle(session, layered_uri, NULL, NULL, 0);
-
-    if (ret == WT_NOTFOUND) {
-        __wt_verbose_level(session, WT_VERB_LAYERED, WT_VERBOSE_DEBUG_5,
-          "GC %s: Layered table was not found.", layered_uri);
-        return (0);
-    }
-
-    WT_RET(ret);
-    layered_table = (WT_LAYERED_TABLE *)session->dhandle;
-    wt_timestamp_t prune_timestamp = WT_TS_NONE;
-
-    WT_ERR(__layered_update_ingest_table_prune_timestamp(
-      session, layered_table, checkpoint_timestamp, uri_at_checkpoint_buf, &prune_timestamp));
-
-    __wt_layered_table_truncate_gc(session, layered_table, prune_timestamp);
-
-err:
     WT_TRET(__wt_session_release_dhandle(session));
+
     return (ret);
 }
 
@@ -1191,7 +1171,7 @@ __wti_layered_iterate_ingest_tables_for_gc_pruning(
         /* Check the buffer-copy result here to avoid returning with the mutex held. */
         WT_ERR(ret);
 
-        WT_ERR(__layered_single_ingest_table_gc_prune(
+        WT_ERR(__layered_update_ingest_table_prune_timestamp(
           session, layered_table_uri_buf->data, checkpoint_timestamp, uri_at_checkpoint_buf));
 
         __wt_spin_lock(session, &manager->layered_table_lock);

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -1697,7 +1697,7 @@ __clayered_lookup(WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, WT_ITEM
         /* Only consult the truncate list when ingest has no entry for this key. */
         if (!found) {
             WT_ERR_NOTFOUND_OK(__wt_truncate_delete_visible_check(session,
-                                 (WT_LAYERED_TABLE *)clayered->dhandle, &cursor->key, NULL),
+                                 (WT_LAYERED_TABLE *)clayered->dhandle, &cursor->key, NULL, NULL),
               true);
             if (ret == 0) {
                 found = true;
@@ -1876,7 +1876,7 @@ __clayered_search_near_int(WT_SESSION_IMPL *session, WT_CURSOR *cursor, int *exa
          */
         if (ret == 0 &&
           __wt_truncate_delete_visible_check(session, (WT_LAYERED_TABLE *)clayered->dhandle,
-            &clayered->stable_cursor->key, NULL) == 0) {
+            &clayered->stable_cursor->key, NULL, NULL) == 0) {
             WT_ASSERT(session, !F_ISSET(&clayered->iface, WT_CURSTD_KEY_INT));
 
             WT_ERR_NOTFOUND_OK(

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -747,7 +747,10 @@ __clayered_reposition_truncate_iterate(WT_CURSOR_LAYERED *clayered, WT_CURSOR *s
     WT_DECL_RET;
     int cmp;
     WT_SESSION_IMPL *session = CUR2S(clayered);
-    WT_TRUNCATE *t;
+
+    WT_ITEM start_key, stop_key;
+    WT_CLEAR(start_key);
+    WT_CLEAR(stop_key);
 
     if (__wt_process.disagg_slow_truncate_2026)
         return (0);
@@ -758,14 +761,18 @@ __clayered_reposition_truncate_iterate(WT_CURSOR_LAYERED *clayered, WT_CURSOR *s
      * until we find a non-truncated key or reach the end of the range.
      */
     for (;;) {
-        ret = __wt_truncate_delete_visible_check(
-          session, (WT_LAYERED_TABLE *)clayered->dhandle, &stable->key, &t);
-        if (ret == WT_NOTFOUND)
-            break;
-        WT_RET(ret);
+        WT_ERR_NOTFOUND_OK(
+          __wt_truncate_delete_visible_check(
+            session, (WT_LAYERED_TABLE *)clayered->dhandle, &stable->key, &start_key, &stop_key),
+          true);
 
-        stable->set_key(stable, forward ? &t->stop_key : &t->start_key);
-        WT_RET(stable->search_near(stable, &cmp));
+        if (ret == WT_NOTFOUND) {
+            ret = 0;
+            break;
+        }
+
+        stable->set_key(stable, forward ? &stop_key : &start_key);
+        WT_ERR(stable->search_near(stable, &cmp));
 
         /*
          * Advance until the stable cursor is strictly past the truncated boundary. The boundary
@@ -777,13 +784,17 @@ __clayered_reposition_truncate_iterate(WT_CURSOR_LAYERED *clayered, WT_CURSOR *s
              * The cursor next()/prev() could return back WT_NOTFOUND, meaning we have reached the
              * end of the table.
              */
-            WT_RET(forward ? stable->next(stable) : stable->prev(stable));
+            WT_ERR(forward ? stable->next(stable) : stable->prev(stable));
 
-            WT_RET(__wt_compare(
-              session, collator, &stable->key, forward ? &t->stop_key : &t->start_key, &cmp));
+            WT_ERR(__wt_compare(
+              session, collator, &stable->key, forward ? &stop_key : &start_key, &cmp));
         }
     }
-    return (0);
+
+err:
+    __wt_buf_free(session, &start_key);
+    __wt_buf_free(session, &stop_key);
+    return (ret);
 }
 
 /*

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2674,6 +2674,8 @@ extern void __ut_block_off_srch_pair(
 extern void __ut_block_size_srch(WT_SIZE **head, wt_off_t size, WT_SIZE ***stack);
 extern void __ut_disagg_get_crypt_header(WT_ITEM *key_item, WT_CRYPT_HEADER **header);
 extern void __ut_disagg_set_crypt_header(WT_SESSION_IMPL *session, WT_CRYPT_KEYS *crypt);
+extern void __ut_layered_table_truncate_gc(
+  WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered_table, const wt_timestamp_t prune_timestamp);
 
 #endif
 

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1820,8 +1820,6 @@ extern void __wt_json_close(WT_SESSION_IMPL *session, WT_CURSOR *cursor);
 extern void __wt_layered_table_manager_remove_table(WT_SESSION_IMPL *session, uint32_t ingest_id);
 extern void __wt_layered_table_truncate_clear(
   WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered_table);
-extern void __wt_layered_table_truncate_gc(WT_SESSION_IMPL *const session,
-  WT_LAYERED_TABLE *const layered_table, const wt_timestamp_t prune_ts);
 extern void __wt_log_data_dump(
   WT_SESSION_IMPL *session, const void *data, size_t size, const char *fmt, ...)
   WT_GCC_FUNC_DECL_ATTRIBUTE((cold)) WT_GCC_FUNC_DECL_ATTRIBUTE((format(printf, 4, 5)));

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1820,6 +1820,8 @@ extern void __wt_json_close(WT_SESSION_IMPL *session, WT_CURSOR *cursor);
 extern void __wt_layered_table_manager_remove_table(WT_SESSION_IMPL *session, uint32_t ingest_id);
 extern void __wt_layered_table_truncate_clear(
   WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered_table);
+extern void __wt_layered_table_truncate_gc(WT_SESSION_IMPL *const session,
+  WT_LAYERED_TABLE *const layered_table, const wt_timestamp_t prune_ts);
 extern void __wt_log_data_dump(
   WT_SESSION_IMPL *session, const void *data, size_t size, const char *fmt, ...)
   WT_GCC_FUNC_DECL_ATTRIBUTE((cold)) WT_GCC_FUNC_DECL_ATTRIBUTE((format(printf, 4, 5)));

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1147,8 +1147,8 @@ extern int __wt_tree_walk_count(WT_SESSION_IMPL *session, WT_REF **refp, uint64_
 extern int __wt_tree_walk_custom_skip(WT_SESSION_IMPL *session, WT_REF **refp,
   int (*skip_func)(WT_SESSION_IMPL *, WT_REF *, void *, bool, bool *), void *func_cookie,
   uint32_t flags) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_truncate_delete_visible_check(
-  WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered_table, WT_ITEM *key, WT_TRUNCATE **tp)
+extern int __wt_truncate_delete_visible_check(WT_SESSION_IMPL *session,
+  WT_LAYERED_TABLE *layered_table, WT_ITEM *key, WT_ITEM *start_keyp, WT_ITEM *stop_keyp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_try_readlock(WT_SESSION_IMPL *session, WT_RWLOCK *l)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -1019,6 +1019,8 @@ struct __wt_connection_stats {
     int64_t layered_table_manager_checkpoints_disagg_pick_up_follower;
     int64_t layered_table_manager_tables;
     int64_t layered_truncate_list_search_calls;
+    int64_t layered_truncate_list_gc_runs;
+    int64_t layered_truncate_list_gc_entries_removed;
     int64_t layered_truncate_list_search_entries_walked;
     int64_t live_restore_bytes_copied;
     int64_t live_restore_work_remaining;

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -7834,1111 +7834,1121 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_TABLES	1591
 /*! layered: the number of times the truncate list was searched */
 #define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_SEARCH_CALLS	1592
+/*!
+ * layered: the number of times truncate list garbage collection ran with
+ * a valid prune timestamp
+ */
+#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_GC_RUNS	1593
+/*!
+ * layered: the number of truncate list entries removed by garbage
+ * collection
+ */
+#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_GC_ENTRIES_REMOVED	1594
 /*! layered: the number of truncate list entries walked during search */
-#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_SEARCH_ENTRIES_WALKED	1593
+#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_SEARCH_ENTRIES_WALKED	1595
 /*!
  * live-restore: number of bytes copied from the source to the
  * destination
  */
-#define	WT_STAT_CONN_LIVE_RESTORE_BYTES_COPIED		1594
+#define	WT_STAT_CONN_LIVE_RESTORE_BYTES_COPIED		1596
 /*! live-restore: number of files remaining for migration completion */
-#define	WT_STAT_CONN_LIVE_RESTORE_WORK_REMAINING	1595
+#define	WT_STAT_CONN_LIVE_RESTORE_WORK_REMAINING	1597
 /*! live-restore: number of reads from the source database */
-#define	WT_STAT_CONN_LIVE_RESTORE_SOURCE_READ_COUNT	1596
+#define	WT_STAT_CONN_LIVE_RESTORE_SOURCE_READ_COUNT	1598
 /*! live-restore: source read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT2	1597
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT2	1599
 /*! live-restore: source read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT5	1598
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT5	1600
 /*! live-restore: source read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT10	1599
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT10	1601
 /*! live-restore: source read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT50	1600
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT50	1602
 /*! live-restore: source read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT100	1601
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT100	1603
 /*! live-restore: source read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT250	1602
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT250	1604
 /*! live-restore: source read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT500	1603
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT500	1605
 /*! live-restore: source read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT1000	1604
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT1000	1606
 /*! live-restore: source read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_GT1000	1605
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_GT1000	1607
 /*! live-restore: source read latency histogram total (msecs) */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_TOTAL_MSECS	1606
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_TOTAL_MSECS	1608
 /*! live-restore: state */
-#define	WT_STAT_CONN_LIVE_RESTORE_STATE			1607
+#define	WT_STAT_CONN_LIVE_RESTORE_STATE			1609
 /*! load-control: number of write operations rejected due to load control */
-#define	WT_STAT_CONN_WRITE_REJECT_COUNT			1608
+#define	WT_STAT_CONN_WRITE_REJECT_COUNT			1610
 /*! load-control: read load at the system level */
-#define	WT_STAT_CONN_READ_LOAD				1609
+#define	WT_STAT_CONN_READ_LOAD				1611
 /*! load-control: write load at the system level */
-#define	WT_STAT_CONN_WRITE_LOAD				1610
+#define	WT_STAT_CONN_WRITE_LOAD				1612
 /*! lock: btree page lock acquisitions */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_COUNT		1611
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_COUNT		1613
 /*! lock: btree page lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_APPLICATION	1612
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_APPLICATION	1614
 /*! lock: btree page lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_INTERNAL	1613
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_INTERNAL	1615
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1614
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1616
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1615
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1617
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1616
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1618
 /*! lock: dhandle lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1617
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1619
 /*! lock: dhandle lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1618
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1620
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1619
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1621
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1620
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1622
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1621
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1623
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1622
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1624
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1623
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1625
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1624
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1626
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1625
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1627
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1626
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1628
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1627
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1629
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1628
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1630
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1629
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1631
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1630
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1632
 /*! lock: txn global lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1631
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1633
 /*! lock: txn global lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1632
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1634
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1633
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1635
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1634
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1636
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1635
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1637
 /*! log: force log remove time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1636
+#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1638
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1637
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1639
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1638
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1640
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1639
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1641
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1640
+#define	WT_STAT_CONN_LOG_FLUSH				1642
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1641
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1643
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1642
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1644
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1643
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1645
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1644
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1646
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1645
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1647
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1646
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1648
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1647
+#define	WT_STAT_CONN_LOG_SCANS				1649
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1648
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1650
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1649
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1651
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1650
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1652
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1651
+#define	WT_STAT_CONN_LOG_SYNC				1653
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1652
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1654
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1653
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1655
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1654
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1656
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1655
+#define	WT_STAT_CONN_LOG_WRITES				1657
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1656
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1658
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1657
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1659
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1658
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1660
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1659
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1661
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1660
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1662
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1661
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1663
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1662
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1664
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1663
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1665
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1664
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1666
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1665
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1667
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1666
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1668
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1667
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1669
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1668
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1670
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1669
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1671
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1670
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1672
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1671
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1673
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1672
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1674
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1673
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1675
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1674
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1676
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1675
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1677
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1676
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1678
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1677
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1679
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1678
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1680
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1679
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1681
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1680
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1682
 /*! perf: block manager read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT2	1681
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT2	1683
 /*! perf: block manager read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT5	1682
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT5	1684
 /*! perf: block manager read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT10	1683
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT10	1685
 /*! perf: block manager read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT50	1684
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT50	1686
 /*! perf: block manager read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT100	1685
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT100	1687
 /*! perf: block manager read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT250	1686
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT250	1688
 /*! perf: block manager read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT500	1687
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT500	1689
 /*! perf: block manager read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT1000	1688
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT1000	1690
 /*! perf: block manager read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_GT1000	1689
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_GT1000	1691
 /*! perf: block manager read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_TOTAL_MSECS	1690
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_TOTAL_MSECS	1692
 /*! perf: block manager write latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT2	1691
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT2	1693
 /*! perf: block manager write latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT5	1692
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT5	1694
 /*! perf: block manager write latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT10	1693
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT10	1695
 /*! perf: block manager write latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT50	1694
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT50	1696
 /*! perf: block manager write latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT100	1695
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT100	1697
 /*! perf: block manager write latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT250	1696
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT250	1698
 /*! perf: block manager write latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT500	1697
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT500	1699
 /*! perf: block manager write latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT1000	1698
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT1000	1700
 /*! perf: block manager write latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_GT1000	1699
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_GT1000	1701
 /*! perf: block manager write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_TOTAL_MSECS	1700
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_TOTAL_MSECS	1702
 /*! perf: disagg block manager read latency histogram (bucket 1) - 50-99us */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT100	1701
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT100	1703
 /*!
  * perf: disagg block manager read latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT250	1702
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT250	1704
 /*!
  * perf: disagg block manager read latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT500	1703
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT500	1705
 /*!
  * perf: disagg block manager read latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT1000	1704
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT1000	1706
 /*!
  * perf: disagg block manager read latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT2500	1705
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT2500	1707
 /*!
  * perf: disagg block manager read latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT5000	1706
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT5000	1708
 /*!
  * perf: disagg block manager read latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT10000	1707
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT10000	1709
 /*!
  * perf: disagg block manager read latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_GT10000	1708
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_GT10000	1710
 /*! perf: disagg block manager read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_TOTAL_USECS	1709
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_TOTAL_USECS	1711
 /*!
  * perf: disagg block manager write latency histogram (bucket 1) -
  * 50-99us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT100	1710
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT100	1712
 /*!
  * perf: disagg block manager write latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT250	1711
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT250	1713
 /*!
  * perf: disagg block manager write latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT500	1712
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT500	1714
 /*!
  * perf: disagg block manager write latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT1000	1713
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT1000	1715
 /*!
  * perf: disagg block manager write latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT2500	1714
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT2500	1716
 /*!
  * perf: disagg block manager write latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT5000	1715
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT5000	1717
 /*!
  * perf: disagg block manager write latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT10000	1716
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT10000	1718
 /*!
  * perf: disagg block manager write latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_GT10000	1717
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_GT10000	1719
 /*! perf: disagg block manager write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_TOTAL_USECS	1718
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_TOTAL_USECS	1720
 /*! perf: file system read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT2	1719
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT2	1721
 /*! perf: file system read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT5	1720
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT5	1722
 /*! perf: file system read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1721
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1723
 /*! perf: file system read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1722
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1724
 /*! perf: file system read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1723
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1725
 /*! perf: file system read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1724
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1726
 /*! perf: file system read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1725
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1727
 /*! perf: file system read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1726
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1728
 /*! perf: file system read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1727
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1729
 /*! perf: file system read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1728
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1730
 /*! perf: file system write latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT2	1729
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT2	1731
 /*! perf: file system write latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT5	1730
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT5	1732
 /*! perf: file system write latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1731
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1733
 /*! perf: file system write latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1732
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1734
 /*! perf: file system write latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1733
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1735
 /*! perf: file system write latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1734
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1736
 /*! perf: file system write latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1735
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1737
 /*! perf: file system write latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1736
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1738
 /*! perf: file system write latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1737
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1739
 /*! perf: file system write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1738
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1740
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 1) -
  * 0-100us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT100	1739
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT100	1741
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT250	1740
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT250	1742
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT500	1741
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT500	1743
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT1000	1742
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT1000	1744
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT2500	1743
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT2500	1745
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT5000	1744
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT5000	1746
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT10000	1745
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT10000	1747
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_GT10000	1746
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_GT10000	1748
 /*! perf: internal page deltas reconstruct latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_TOTAL_USECS	1747
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_TOTAL_USECS	1749
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 1) -
  * 0-100us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT100	1748
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT100	1750
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT250	1749
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT250	1751
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT500	1750
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT500	1752
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT1000	1751
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT1000	1753
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT2500	1752
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT2500	1754
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT5000	1753
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT5000	1755
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT10000	1754
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT10000	1756
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_GT10000	1755
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_GT10000	1757
 /*! perf: leaf page deltas reconstruct latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_TOTAL_USECS	1756
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_TOTAL_USECS	1758
 /*! perf: operation read latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1757
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1759
 /*! perf: operation read latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1758
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1760
 /*! perf: operation read latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1759
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1761
 /*! perf: operation read latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1760
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1762
 /*! perf: operation read latency histogram (bucket 5) - 1000-2499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT2500	1761
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT2500	1763
 /*! perf: operation read latency histogram (bucket 6) - 2500-4999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT5000	1762
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT5000	1764
 /*! perf: operation read latency histogram (bucket 7) - 5000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1763
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1765
 /*! perf: operation read latency histogram (bucket 8) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1764
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1766
 /*! perf: operation read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1765
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1767
 /*! perf: operation write latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1766
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1768
 /*! perf: operation write latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1767
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1769
 /*! perf: operation write latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1768
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1770
 /*! perf: operation write latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1769
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1771
 /*! perf: operation write latency histogram (bucket 5) - 1000-2499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT2500	1770
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT2500	1772
 /*! perf: operation write latency histogram (bucket 6) - 2500-4999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT5000	1771
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT5000	1773
 /*! perf: operation write latency histogram (bucket 7) - 5000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1772
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1774
 /*! perf: operation write latency histogram (bucket 8) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1773
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1775
 /*! perf: operation write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1774
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1776
 /*! prefetch: could not perform pre-fetch on internal page */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1775
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1777
 /*!
  * prefetch: could not perform pre-fetch on ref without the pre-fetch
  * flag set
  */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1776
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1778
 /*! prefetch: pre-fetch attempted, session has pre-fetching enabled */
-#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1777
+#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1779
 /*! prefetch: pre-fetch not repeating for recently pre-fetched ref */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1778
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1780
 /*! prefetch: pre-fetch not triggered after single disk read */
-#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1779
+#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1781
 /*! prefetch: pre-fetch not triggered as there is no valid dhandle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1780
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1782
 /*! prefetch: pre-fetch not triggered due to disk read count */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1781
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1783
 /*! prefetch: pre-fetch not triggered due to internal session */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1782
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1784
 /*! prefetch: pre-fetch not triggered due to special btree handle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1783
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1785
 /*! prefetch: pre-fetch not triggered, pre-fetch queue is full */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_QUEUE_FULL	1784
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_QUEUE_FULL	1786
 /*! prefetch: pre-fetch page not on disk when reading */
-#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1785
+#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1787
 /*! prefetch: pre-fetch pages queued */
-#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1786
+#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1788
 /*! prefetch: pre-fetch pages read in background */
-#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1787
+#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1789
 /*!
  * prefetch: pre-fetch session check passed, pre-fetch work issued to
  * btree
  */
-#define	WT_STAT_CONN_PREFETCH_ATTEMPTS_SUCCEEDED	1788
+#define	WT_STAT_CONN_PREFETCH_ATTEMPTS_SUCCEEDED	1790
 /*! prefetch: pre-fetch skipped reading in a page due to harmless error */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1789
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1791
 /*!
  * prefetch: pre-fetch skipped traversal of internal page due to active
  * split generation
  */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SPLIT_GEN	1790
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SPLIT_GEN	1792
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1791
+#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1793
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1792
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1794
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1793
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1795
 /*!
  * reconciliation: average length of delta chain on internal page with
  * deltas
  */
-#define	WT_STAT_CONN_REC_AVERAGE_INTERNAL_PAGE_DELTA_CHAIN_LENGTH	1794
+#define	WT_STAT_CONN_REC_AVERAGE_INTERNAL_PAGE_DELTA_CHAIN_LENGTH	1796
 /*! reconciliation: average length of delta chain on leaf page with deltas */
-#define	WT_STAT_CONN_REC_AVERAGE_LEAF_PAGE_DELTA_CHAIN_LENGTH	1795
+#define	WT_STAT_CONN_REC_AVERAGE_LEAF_PAGE_DELTA_CHAIN_LENGTH	1797
 /*!
  * reconciliation: changes since prior reconciliation (bucket 1) between
  * 1 and 5
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE5			1796
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE5			1798
 /*!
  * reconciliation: changes since prior reconciliation (bucket 2) between
  * 6 and 10
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE10			1797
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE10			1799
 /*!
  * reconciliation: changes since prior reconciliation (bucket 3) between
  * 11 and 20
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE20			1798
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE20			1800
 /*!
  * reconciliation: changes since prior reconciliation (bucket 4) between
  * 21 and 50
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE50			1799
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE50			1801
 /*!
  * reconciliation: changes since prior reconciliation (bucket 5) between
  * 51 and 100
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE100		1800
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE100		1802
 /*!
  * reconciliation: changes since prior reconciliation (bucket 6) between
  * 101 and 200
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE200		1801
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE200		1803
 /*!
  * reconciliation: changes since prior reconciliation (bucket 7) between
  * 201 and 500
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE500		1802
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE500		1804
 /*!
  * reconciliation: changes since prior reconciliation (bucket 8) greater
  * than 500
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_GT500		1803
+#define	WT_STAT_CONN_REC_PAGE_MODS_GT500		1805
 /*! reconciliation: cursor next/prev calls during HS wrapup search_near */
-#define	WT_STAT_CONN_REC_HS_WRAPUP_NEXT_PREV_CALLS	1804
+#define	WT_STAT_CONN_REC_HS_WRAPUP_NEXT_PREV_CALLS	1806
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1805
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1807
 /*!
  * reconciliation: free page ID due to failed page replacement
  * reconciliation in disagg
  */
-#define	WT_STAT_CONN_REC_FREE_PAGE_ID_DUE_TO_FAILED_REPLACEMENT_RECONCILIATION	1806
+#define	WT_STAT_CONN_REC_FREE_PAGE_ID_DUE_TO_FAILED_REPLACEMENT_RECONCILIATION	1808
 /*! reconciliation: full internal pages written instead of a page delta */
-#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_INTERNAL	1807
+#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_INTERNAL	1809
 /*! reconciliation: full leaf pages written instead of a page delta */
-#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_LEAF		1808
+#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_LEAF		1810
 /*!
  * reconciliation: ingest btree reconciliation keeps the aborted prepare
  * updates
  */
-#define	WT_STAT_CONN_REC_INGEST_KEEP_PREPARE_ROLLBACK	1809
+#define	WT_STAT_CONN_REC_INGEST_KEEP_PREPARE_ROLLBACK	1811
 /*! reconciliation: internal page delta keys deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_DELETED	1810
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_DELETED	1812
 /*! reconciliation: internal page delta keys updated/inserted */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_UPDATED	1811
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_UPDATED	1813
 /*! reconciliation: internal page deltas written */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL		1812
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL		1814
 /*! reconciliation: internal page multi-block writes */
-#define	WT_STAT_CONN_REC_MULTIBLOCK_INTERNAL		1813
+#define	WT_STAT_CONN_REC_MULTIBLOCK_INTERNAL		1815
 /*! reconciliation: leaf page deltas written */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_LEAF		1814
+#define	WT_STAT_CONN_REC_PAGE_DELTA_LEAF		1816
 /*! reconciliation: leaf page multi-block writes */
-#define	WT_STAT_CONN_REC_MULTIBLOCK_LEAF		1815
+#define	WT_STAT_CONN_REC_MULTIBLOCK_LEAF		1817
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1816
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1818
 /*! reconciliation: max deltas seen on internal page during reconciliation */
-#define	WT_STAT_CONN_REC_MAX_INTERNAL_PAGE_DELTAS	1817
+#define	WT_STAT_CONN_REC_MAX_INTERNAL_PAGE_DELTAS	1819
 /*! reconciliation: max deltas seen on leaf page during reconciliation */
-#define	WT_STAT_CONN_REC_MAX_LEAF_PAGE_DELTAS		1818
+#define	WT_STAT_CONN_REC_MAX_LEAF_PAGE_DELTAS		1820
 /*! reconciliation: maximum milliseconds spent in a reconciliation call */
-#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1819
+#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1821
 /*!
  * reconciliation: maximum milliseconds spent in building a disk image in
  * a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1820
+#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1822
 /*!
  * reconciliation: maximum milliseconds spent in moving updates to the
  * history store in a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1821
+#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1823
 /*!
  * reconciliation: number of keys that are garbage collected from the
  * disk images in the ingest btrees for disaggregated storage
  */
-#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_DISK_IMAGE	1822
+#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_DISK_IMAGE	1824
 /*!
  * reconciliation: number of keys that are garbage collected from the
  * update chains in the ingest btrees for disaggregated storage
  */
-#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_UPDATE_CHAIN	1823
+#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_UPDATE_CHAIN	1825
 /*! reconciliation: overflow values written */
-#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1824
+#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1826
 /*! reconciliation: page deltas rejected due to invalid page ID */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_INVALID_PAGE_ID	1825
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_INVALID_PAGE_ID	1827
 /*! reconciliation: page deltas rejected due to max consecutive limit */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MAX_CONSECUTIVE_EXCEEDED	1826
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MAX_CONSECUTIVE_EXCEEDED	1828
 /*! reconciliation: page deltas rejected due to multiblock reconciliation */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MULTIBLOCK	1827
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MULTIBLOCK	1829
 /*!
  * reconciliation: page deltas rejected due to non-single page in
  * previous reconciliation
  */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_NON_SINGLE_PAGE	1828
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_NON_SINGLE_PAGE	1830
 /*! reconciliation: page deltas rejected due to size threshold */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_SIZE_THRESHOLD	1829
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_SIZE_THRESHOLD	1831
 /*! reconciliation: page deltas rejected due to zero entries */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_ZERO_ENTRIES	1830
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_ZERO_ENTRIES	1832
 /*!
  * reconciliation: page deltas rejected: build function returned false
  * (disabled, in-memory split, or internal page constraints not met)
  */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_BUILD_FAILED	1831
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_BUILD_FAILED	1833
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1832
+#define	WT_STAT_CONN_REC_PAGES				1834
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1833
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1835
 /*! reconciliation: page reconciliation calls for pages between 1 and 10MB */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_1MB_TO_10MB		1834
+#define	WT_STAT_CONN_REC_PAGES_SIZE_1MB_TO_10MB		1836
 /*!
  * reconciliation: page reconciliation calls for pages between 10 and
  * 100MB
  */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_10MB_TO_100MB	1835
+#define	WT_STAT_CONN_REC_PAGES_SIZE_10MB_TO_100MB	1837
 /*!
  * reconciliation: page reconciliation calls for pages between 100MB and
  * 1GB
  */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_100MB_TO_1GB	1836
+#define	WT_STAT_CONN_REC_PAGES_SIZE_100MB_TO_1GB	1838
 /*! reconciliation: page reconciliation calls for pages over 1GB */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_1GB_PLUS		1837
+#define	WT_STAT_CONN_REC_PAGES_SIZE_1GB_PLUS		1839
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * prepared transaction metadata
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1838
+#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1840
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * timestamps
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1839
+#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1841
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * transaction ids
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1840
+#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1842
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1841
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1843
 /*! reconciliation: pages eligible for delta generation */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_ELIGIBLE		1842
+#define	WT_STAT_CONN_REC_PAGE_DELTA_ELIGIBLE		1844
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1843
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1845
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1844
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1846
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1845
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1847
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1846
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1848
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1847
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1849
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1848
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1850
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1849
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1851
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1850
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1852
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1851
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1853
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1852
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1854
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1853
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1855
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1854
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1856
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1855
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1857
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1856
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1858
 /*! reconciliation: pages written with at least one internal page delta */
-#define	WT_STAT_CONN_REC_PAGES_WITH_INTERNAL_DELTAS	1857
+#define	WT_STAT_CONN_REC_PAGES_WITH_INTERNAL_DELTAS	1859
 /*! reconciliation: pages written with at least one leaf page delta */
-#define	WT_STAT_CONN_REC_PAGES_WITH_LEAF_DELTAS		1858
+#define	WT_STAT_CONN_REC_PAGES_WITH_LEAF_DELTAS		1860
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1859
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1861
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1860
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1862
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1861
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1863
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1862
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1864
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1863
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1865
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1864
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1866
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1865
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1867
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1866
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1868
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1867
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1869
 /*! reconciliation: writes skipped in disaggregated storage */
-#define	WT_STAT_CONN_REC_SKIP_WRITE			1868
+#define	WT_STAT_CONN_REC_SKIP_WRITE			1870
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1869
+#define	WT_STAT_CONN_SESSION_OPEN			1871
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1870
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1872
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1871
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1873
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1872
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1874
 /*! session: table alter triggering checkpoint calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1873
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1875
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1874
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1876
 /*! session: table compact conflicted with checkpoint */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1875
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1877
 /*! session: table compact dhandle successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1876
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1878
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1877
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1879
 /*! session: table compact failed calls due to cache pressure */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1878
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1880
 /*!
  * session: table compact in-memory page footprint rewritten by
  * compaction
  */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_BYTES_REWRITE_INMEM	1879
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_BYTES_REWRITE_INMEM	1881
 /*! session: table compact passes */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1880
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1882
 /*! session: table compact pulled into eviction */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1881
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1883
 /*! session: table compact running */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1882
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1884
 /*! session: table compact skipped as process would not reduce file size */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1883
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1885
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1884
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1886
 /*! session: table compact timeout */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1885
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1887
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1886
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1888
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1887
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1889
 /*! session: table create with import failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1888
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1890
 /*! session: table create with import repair calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1889
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1891
 /*! session: table create with import successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1890
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1892
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1891
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1893
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1892
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1894
 /*! session: table publish failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_PUBLISH_FAIL		1893
+#define	WT_STAT_CONN_SESSION_TABLE_PUBLISH_FAIL		1895
 /*! session: table publish successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_PUBLISH_SUCCESS	1894
+#define	WT_STAT_CONN_SESSION_TABLE_PUBLISH_SUCCESS	1896
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1895
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1897
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1896
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1898
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1897
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1899
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1898
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1900
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1899
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1901
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1900
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1902
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1901
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1903
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1902
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1904
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1903
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1905
 /*! thread-yield: application thread operations waiting for cache */
-#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1904
+#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1906
 /*!
  * thread-yield: application thread operations waiting for interruptible
  * cache eviction
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_OPS	1905
+#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_OPS	1907
 /*!
  * thread-yield: application thread operations waiting for mandatory
  * cache eviction
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_OPS	1906
+#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_OPS	1908
 /*! thread-yield: application thread snapshot refreshed for eviction */
-#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1907
+#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1909
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1908
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1910
 /*!
  * thread-yield: application thread time waiting for interruptible cache
  * eviction (usecs)
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_TIME	1909
+#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_TIME	1911
 /*!
  * thread-yield: application thread time waiting for mandatory cache
  * eviction (usecs)
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_TIME	1910
+#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_TIME	1912
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1911
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1913
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1912
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1914
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1913
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1915
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1914
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1916
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1915
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1917
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1916
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1918
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1917
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1919
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1918
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1920
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1919
+#define	WT_STAT_CONN_PAGE_SLEEP				1921
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1920
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1922
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1921
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1923
 /*! thread-yield: page split and restart read */
-#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1922
+#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1924
 /*! thread-yield: pages skipped during read due to deleted state */
-#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1923
+#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1925
 /*!
  * tiered-storage: attempts to remove a local object and the object is in
  * use
  */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1924
+#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1926
 /*! tiered-storage: flush_tier failed calls */
-#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1925
+#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1927
 /*! tiered-storage: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1926
+#define	WT_STAT_CONN_FLUSH_TIER				1928
 /*! tiered-storage: flush_tier tables skipped due to no checkpoint */
-#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1927
+#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1929
 /*! tiered-storage: flush_tier tables switched */
-#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1928
+#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1930
 /*! tiered-storage: local objects removed */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1929
+#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1931
 /*! tiered-storage: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1930
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1932
 /*! tiered-storage: tiered operations removed without processing */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1931
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1933
 /*! tiered-storage: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1932
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1934
 /*! tiered-storage: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1933
+#define	WT_STAT_CONN_TIERED_RETENTION			1935
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1934
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1936
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1935
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1937
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1936
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1938
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1937
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1939
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1938
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1940
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1939
+#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1941
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1940
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1942
 /*! transaction: oldest transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1941
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1943
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1942
+#define	WT_STAT_CONN_TXN_PREPARE			1944
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1943
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1945
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1944
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1946
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1945
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1947
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1946
+#define	WT_STAT_CONN_TXN_QUERY_TS			1948
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1947
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1949
 /*! transaction: rollback to stable applied btrees */
-#define	WT_STAT_CONN_TXN_RTS_BTREES_APPLIED		1948
+#define	WT_STAT_CONN_TXN_RTS_BTREES_APPLIED		1950
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1949
+#define	WT_STAT_CONN_TXN_RTS				1951
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1950
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1952
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1951
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1953
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1952
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1954
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1953
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1955
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1954
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1956
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1955
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1957
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1956
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1958
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1957
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1959
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1958
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1960
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1959
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1961
 /*! transaction: rollback to stable skipped btrees */
-#define	WT_STAT_CONN_TXN_RTS_BTREES_SKIPPED		1960
+#define	WT_STAT_CONN_TXN_RTS_BTREES_SKIPPED		1962
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1961
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1963
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1962
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1964
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1963
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1965
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1964
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1966
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1965
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1967
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1966
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1968
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1967
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1969
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1968
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1970
 /*!
  * transaction: rollback to stable updates that would have been aborted
  * in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1969
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1971
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1970
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1972
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1971
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1973
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1972
+#define	WT_STAT_CONN_TXN_SET_TS				1974
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1973
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1975
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1974
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1976
 /*! transaction: set timestamp force calls */
-#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1975
+#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1977
 /*!
  * transaction: set timestamp global oldest timestamp set to be more
  * recent than the global stable timestamp
  */
-#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1976
+#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1978
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1977
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1979
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1978
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1980
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1979
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1981
 /*! transaction: set timestamp stable disaggregated schema epoch calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_DISAGG_EPOCH	1980
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_DISAGG_EPOCH	1982
 /*! transaction: set timestamp stable disaggregated schema epoch updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_DISAGG_EPOCH_UPD	1981
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_DISAGG_EPOCH_UPD	1983
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1982
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1984
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1983
+#define	WT_STAT_CONN_TXN_BEGIN				1985
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1984
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1986
 /*! transaction: transaction global checkpoint timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_CHECKPOINT_TIMESTAMP	1985
+#define	WT_STAT_CONN_TXN_GLOBAL_CHECKPOINT_TIMESTAMP	1987
 /*! transaction: transaction global durable timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_DURABLE_TIMESTAMP	1986
+#define	WT_STAT_CONN_TXN_GLOBAL_DURABLE_TIMESTAMP	1988
 /*! transaction: transaction global last running timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_LAST_RUNNING_TIMESTAMP	1987
+#define	WT_STAT_CONN_TXN_GLOBAL_LAST_RUNNING_TIMESTAMP	1989
 /*! transaction: transaction global newest timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_NEWEST_TIMESTAMP	1988
+#define	WT_STAT_CONN_TXN_GLOBAL_NEWEST_TIMESTAMP	1990
 /*! transaction: transaction global oldest timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_OLDEST_TIMESTAMP	1989
+#define	WT_STAT_CONN_TXN_GLOBAL_OLDEST_TIMESTAMP	1991
 /*! transaction: transaction global pinned timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_PINNED_TIMESTAMP	1990
+#define	WT_STAT_CONN_TXN_GLOBAL_PINNED_TIMESTAMP	1992
 /*! transaction: transaction global stable timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_STABLE_TIMESTAMP	1991
+#define	WT_STAT_CONN_TXN_GLOBAL_STABLE_TIMESTAMP	1993
 /*! transaction: transaction global version cursor timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_VERSION_CURSOR_TIMESTAMP	1992
+#define	WT_STAT_CONN_TXN_GLOBAL_VERSION_CURSOR_TIMESTAMP	1994
 /*!
  * transaction: transaction number of older readers older than oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_READERS			1993
+#define	WT_STAT_CONN_TXN_PINNED_READERS			1995
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1994
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1996
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1995
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1997
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_LAG		1996
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_LAG		1998
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT_LAG	1997
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT_LAG	1999
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER_LAG	1998
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER_LAG	2000
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1999
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	2001
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	2000
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	2002
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	2001
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	2003
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			2002
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			2004
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				2003
+#define	WT_STAT_CONN_TXN_COMMIT				2005
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			2004
+#define	WT_STAT_CONN_TXN_ROLLBACK			2006
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		2005
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		2007
 
 /*!
  * @}

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -2490,6 +2490,8 @@ static const char *const __stats_connection_desc[] = {
   "layered: number of checkpoints picked up by a follower",
   "layered: the number of tables the layered table manager has open",
   "layered: the number of times the truncate list was searched",
+  "layered: the number of times truncate list garbage collection ran with a valid prune timestamp",
+  "layered: the number of truncate list entries removed by garbage collection",
   "layered: the number of truncate list entries walked during search",
   "live-restore: number of bytes copied from the source to the destination",
   "live-restore: number of files remaining for migration completion",
@@ -3547,6 +3549,8 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->layered_table_manager_checkpoints_disagg_pick_up_follower = 0;
     stats->layered_table_manager_tables = 0;
     stats->layered_truncate_list_search_calls = 0;
+    stats->layered_truncate_list_gc_runs = 0;
+    stats->layered_truncate_list_gc_entries_removed = 0;
     stats->layered_truncate_list_search_entries_walked = 0;
     stats->live_restore_bytes_copied = 0;
     /* not clearing live_restore_work_remaining */
@@ -4726,6 +4730,9 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->layered_table_manager_tables += WT_STAT_CONN_READ(from, layered_table_manager_tables);
     to->layered_truncate_list_search_calls +=
       WT_STAT_CONN_READ(from, layered_truncate_list_search_calls);
+    to->layered_truncate_list_gc_runs += WT_STAT_CONN_READ(from, layered_truncate_list_gc_runs);
+    to->layered_truncate_list_gc_entries_removed +=
+      WT_STAT_CONN_READ(from, layered_truncate_list_gc_entries_removed);
     to->layered_truncate_list_search_entries_walked +=
       WT_STAT_CONN_READ(from, layered_truncate_list_search_entries_walked);
     to->live_restore_bytes_copied += WT_STAT_CONN_READ(from, live_restore_bytes_copied);

--- a/src/txn/txn_truncate.c
+++ b/src/txn/txn_truncate.c
@@ -479,3 +479,53 @@ __wt_layered_table_truncate_clear(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *la
     }
     __wt_writeunlock(session, &layered_table->truncate_lock);
 }
+
+/*
+ * __truncate_entry_eligible_for_gc --
+ *     Determine if an entry is redundant and should be removed from the list.
+ */
+static bool
+__truncate_entry_eligible_for_gc(const WT_TRUNCATE *const entry, const wt_timestamp_t prune_ts)
+{
+    if (prune_ts == WT_TS_NONE)
+        return (false);
+
+    if (entry->durable_ts == WT_TS_NONE)
+        return (false);
+
+    return (entry->durable_ts <= prune_ts);
+}
+
+/*
+ * __wt_layered_table_truncate_gc --
+ *     Reap truncate-list entries whose effect is now durable in the picked-up checkpoint.
+ */
+void
+__wt_layered_table_truncate_gc(WT_SESSION_IMPL *const session,
+  WT_LAYERED_TABLE *const layered_table, const wt_timestamp_t prune_ts)
+{
+    if (!__wt_process.disagg_fast_truncate_2026)
+        return;
+
+    WT_ASSERT(session, layered_table != NULL);
+    WT_ASSERT(session, WT_PREFIX_MATCH(layered_table->iface.name, "layered:"));
+
+    if (prune_ts == WT_TS_NONE)
+        return;
+
+    WT_TRUNCATE *entry = NULL;
+    WT_TRUNCATE *next = NULL;
+
+    __wt_writelock(session, &layered_table->truncate_lock);
+
+    TAILQ_FOREACH_SAFE(entry, &layered_table->truncateqh, q, next)
+    {
+        if (!__truncate_entry_eligible_for_gc(entry, prune_ts))
+            continue;
+
+        TAILQ_REMOVE(&layered_table->truncateqh, entry, q);
+        __disagg_truncate_free(session, &entry);
+    }
+
+    __wt_writeunlock(session, &layered_table->truncate_lock);
+}

--- a/src/txn/txn_truncate.c
+++ b/src/txn/txn_truncate.c
@@ -143,6 +143,7 @@ __txn_insert_truncate_entry_helper(
 {
     WT_DECL_RET;
     WT_TRUNCATE *entry = *tp;
+    wt_timestamp_t prune_timestamp = 0;
 
     WT_RET(__wt_session_get_dhandle(session, layered_table->ingest_uri, NULL, NULL, 0));
     WT_ERR(__wt_txn_truncate(session, entry));
@@ -152,9 +153,7 @@ __txn_insert_truncate_entry_helper(
 
     __wt_writelock(session, &layered_table->truncate_lock);
 
-    const wt_timestamp_t prune_timestamp =
-      __wt_atomic_load_uint64_relaxed(&S2BT(session)->prune_timestamp);
-
+    prune_timestamp = __wt_atomic_load_uint64_relaxed(&S2BT(session)->prune_timestamp);
     __layered_table_truncate_gc(session, layered_table, prune_timestamp);
 
     if (TAILQ_EMPTY(&layered_table->truncateqh))

--- a/src/txn/txn_truncate.c
+++ b/src/txn/txn_truncate.c
@@ -75,31 +75,13 @@ __truncate_entry_remove(
 }
 
 /*
- * __truncate_entry_eligible_for_gc --
- *     Determine if an entry is redundant and should be removed from the list.
- */
-static bool
-__truncate_entry_eligible_for_gc(const WT_TRUNCATE *const entry, const wt_timestamp_t prune_ts)
-{
-    if (prune_ts == WT_TS_NONE)
-        return (false);
-
-    if (entry->durable_ts == WT_TS_NONE)
-        return (false);
-
-    return (entry->durable_ts <= prune_ts);
-}
-
-/*
  * __layered_table_truncate_gc --
  *     Reap truncate-list entries whose effect is now durable in the picked-up checkpoint.
  */
 static void
-__layered_table_truncate_gc(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered_table)
+__layered_table_truncate_gc(
+  WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered_table, const wt_timestamp_t prune_timestamp)
 {
-    const wt_timestamp_t prune_timestamp =
-      __wt_atomic_load_uint64_relaxed(&S2BT(session)->prune_timestamp);
-
     if (prune_timestamp == WT_TS_NONE)
         return;
 
@@ -108,7 +90,10 @@ __layered_table_truncate_gc(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered_
 
     TAILQ_FOREACH_SAFE(entry, &layered_table->truncateqh, q, next)
     {
-        if (!__truncate_entry_eligible_for_gc(entry, prune_timestamp))
+        const bool is_eligible =
+          entry->durable_ts != WT_TS_NONE && entry->durable_ts <= prune_timestamp;
+
+        if (!is_eligible)
             continue;
 
         __truncate_entry_remove(session, layered_table, entry);
@@ -167,7 +152,10 @@ __txn_insert_truncate_entry_helper(
 
     __wt_writelock(session, &layered_table->truncate_lock);
 
-    __layered_table_truncate_gc(session, layered_table);
+    const wt_timestamp_t prune_timestamp =
+      __wt_atomic_load_uint64_relaxed(&S2BT(session)->prune_timestamp);
+
+    __layered_table_truncate_gc(session, layered_table, prune_timestamp);
 
     if (TAILQ_EMPTY(&layered_table->truncateqh))
         WT_DHANDLE_ACQUIRE(&layered_table->iface);
@@ -524,3 +512,12 @@ __wt_layered_table_truncate_clear(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *la
     }
     __wt_writeunlock(session, &layered_table->truncate_lock);
 }
+
+#ifdef HAVE_UNITTEST
+void
+__ut_layered_table_truncate_gc(
+  WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered_table, const wt_timestamp_t prune_timestamp)
+{
+    __layered_table_truncate_gc(session, layered_table, prune_timestamp);
+}
+#endif

--- a/src/txn/txn_truncate.c
+++ b/src/txn/txn_truncate.c
@@ -92,8 +92,10 @@ __layered_table_truncate_gc(
     {
         const bool is_committed = __wt_atomic_load_bool_acquire(&entry->committed);
 
-        /* Committed entries with durable_ts == WT_TS_NONE are never pruned here. Without a
-         * timestamp, we cannot determine whether the follower has picked up these changes yet. */
+        /*
+         * Committed entries with durable_ts == WT_TS_NONE are never pruned here. Without a
+         * timestamp, we cannot determine whether the follower has picked up these changes yet.
+         */
         const bool is_time =
           entry->durable_ts != WT_TS_NONE && entry->durable_ts <= prune_timestamp;
 

--- a/src/txn/txn_truncate.c
+++ b/src/txn/txn_truncate.c
@@ -368,14 +368,40 @@ err:
 }
 
 /*
+ * __truncate_entry_copy_keys --
+ *     Copy the start and stop keys from a truncate entry into caller-owned buffers.
+ */
+static int
+__truncate_entry_copy_keys(
+  WT_SESSION_IMPL *session, const WT_TRUNCATE *const entry, WT_ITEM *start_keyp, WT_ITEM *stop_keyp)
+{
+    WT_ASSERT(session, start_keyp != NULL && stop_keyp != NULL);
+
+    WT_DECL_RET;
+    WT_ERR(__wt_buf_set(session, start_keyp, entry->start_key.data, entry->start_key.size));
+    WT_ERR(__wt_buf_set(session, stop_keyp, entry->stop_key.data, entry->stop_key.size));
+
+    if (0) {
+err:
+        __wt_buf_free(session, start_keyp);
+        __wt_buf_free(session, stop_keyp);
+    }
+
+    return (ret);
+}
+
+/*
  * __wt_truncate_delete_visible_check --
- *     Search if the given key has been deleted in the layered table truncate list.
+ *     Search if the given key has been deleted in the layered table truncate list. start_keyp and
+ *     stop_keyp are optional out parameters that represent the truncate range that deleted the key.
+ *     Freeing of start_keyp and stop_keyp must be managed by the caller.
  */
 int
-__wt_truncate_delete_visible_check(
-  WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered_table, WT_ITEM *key, WT_TRUNCATE **tp)
+__wt_truncate_delete_visible_check(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered_table,
+  WT_ITEM *key, WT_ITEM *start_keyp, WT_ITEM *stop_keyp)
 {
     WT_DECL_RET;
+    WT_TRUNCATE *tp = NULL;
     bool is_found = false;
 
     if (__wt_process.disagg_slow_truncate_2026)
@@ -394,11 +420,16 @@ __wt_truncate_delete_visible_check(
      * Ignore all truncate entries that haven't been committed. They won't be visible to this
      * transaction.
      */
-    ret = __truncate_search(session, layered_table, key, WT_TRUNCATE_SEARCH_VISIBLE, tp, &is_found);
+    WT_ERR(
+      __truncate_search(session, layered_table, key, WT_TRUNCATE_SEARCH_VISIBLE, &tp, &is_found));
 
+    const bool keys_wanted = (start_keyp != NULL && stop_keyp != NULL);
+
+    if (is_found && keys_wanted)
+        WT_ERR(__truncate_entry_copy_keys(session, tp, start_keyp, stop_keyp));
+
+err:
     __wt_readunlock(session, &layered_table->truncate_lock);
-    WT_RET(ret);
-
     return (is_found ? 0 : WT_NOTFOUND);
 }
 

--- a/src/txn/txn_truncate.c
+++ b/src/txn/txn_truncate.c
@@ -58,6 +58,65 @@ __key_within_truncate_range(WT_SESSION_IMPL *session, WT_COLLATOR *collator,
 }
 
 /*
+ * __truncate_entry_remove --
+ *     Remove an entry from the truncate queue. Must be called under the truncate write lock.
+ */
+static void
+__truncate_entry_remove(
+  WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered_table, WT_TRUNCATE *entry)
+{
+    WT_ASSERT(session, !TAILQ_EMPTY(&layered_table->truncateqh));
+    WT_ASSERT(session, __wt_atomic_load_uint32_relaxed(&layered_table->iface.references) > 0);
+
+    TAILQ_REMOVE(&layered_table->truncateqh, entry, q);
+
+    if (TAILQ_EMPTY(&layered_table->truncateqh))
+        WT_DHANDLE_RELEASE(&layered_table->iface);
+}
+
+/*
+ * __truncate_entry_eligible_for_gc --
+ *     Determine if an entry is redundant and should be removed from the list.
+ */
+static bool
+__truncate_entry_eligible_for_gc(const WT_TRUNCATE *const entry, const wt_timestamp_t prune_ts)
+{
+    if (prune_ts == WT_TS_NONE)
+        return (false);
+
+    if (entry->durable_ts == WT_TS_NONE)
+        return (false);
+
+    return (entry->durable_ts <= prune_ts);
+}
+
+/*
+ * __layered_table_truncate_gc --
+ *     Reap truncate-list entries whose effect is now durable in the picked-up checkpoint.
+ */
+static void
+__layered_table_truncate_gc(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered_table)
+{
+    const wt_timestamp_t prune_timestamp =
+      __wt_atomic_load_uint64_relaxed(&S2BT(session)->prune_timestamp);
+
+    if (prune_timestamp == WT_TS_NONE)
+        return;
+
+    WT_TRUNCATE *entry = NULL;
+    WT_TRUNCATE *next = NULL;
+
+    TAILQ_FOREACH_SAFE(entry, &layered_table->truncateqh, q, next)
+    {
+        if (!__truncate_entry_eligible_for_gc(entry, prune_timestamp))
+            continue;
+
+        __truncate_entry_remove(session, layered_table, entry);
+        __disagg_truncate_free(session, &entry);
+    }
+}
+
+/*
  * __log_truncate_entry --
  *     Create a log message for the truncate entry that will be added to the truncate list.
  */
@@ -90,7 +149,8 @@ err:
 
 /*
  * __txn_insert_truncate_entry_helper --
- *     Register a truncate entry to the latest transaction and store it in the truncate list.
+ *     Register a truncate entry to the latest transaction and store it in the truncate list. This
+ *     function will also opportunistically prune the truncate list so it does not grow infinitely.
  */
 static int
 __txn_insert_truncate_entry_helper(
@@ -106,6 +166,8 @@ __txn_insert_truncate_entry_helper(
     __log_truncate_entry(session, layered_table, entry);
 
     __wt_writelock(session, &layered_table->truncate_lock);
+
+    __layered_table_truncate_gc(session, layered_table);
 
     if (TAILQ_EMPTY(&layered_table->truncateqh))
         WT_DHANDLE_ACQUIRE(&layered_table->iface);
@@ -415,23 +477,6 @@ __wti_mark_committed_truncate_table(WT_SESSION_IMPL *session, WT_TXN_OP *op)
 }
 
 /*
- * __truncate_entry_remove --
- *     Remove an entry from the truncate queue. Must be called under the truncate write lock.
- */
-static void
-__truncate_entry_remove(
-  WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered_table, WT_TRUNCATE *entry)
-{
-    WT_ASSERT(session, !TAILQ_EMPTY(&layered_table->truncateqh));
-    WT_ASSERT(session, __wt_atomic_load_uint32_relaxed(&layered_table->iface.references) > 0);
-
-    TAILQ_REMOVE(&layered_table->truncateqh, entry, q);
-
-    if (TAILQ_EMPTY(&layered_table->truncateqh))
-        WT_DHANDLE_RELEASE(&layered_table->iface);
-}
-
-/*
  * __wti_layered_table_truncate_rollback_apply --
  *     Remove a truncate entry from a layered table as part of rollback processing.
  */
@@ -477,55 +522,5 @@ __wt_layered_table_truncate_clear(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *la
         __truncate_entry_remove(session, layered_table, entry);
         __disagg_truncate_free(session, &entry);
     }
-    __wt_writeunlock(session, &layered_table->truncate_lock);
-}
-
-/*
- * __truncate_entry_eligible_for_gc --
- *     Determine if an entry is redundant and should be removed from the list.
- */
-static bool
-__truncate_entry_eligible_for_gc(const WT_TRUNCATE *const entry, const wt_timestamp_t prune_ts)
-{
-    if (prune_ts == WT_TS_NONE)
-        return (false);
-
-    if (entry->durable_ts == WT_TS_NONE)
-        return (false);
-
-    return (entry->durable_ts <= prune_ts);
-}
-
-/*
- * __wt_layered_table_truncate_gc --
- *     Reap truncate-list entries whose effect is now durable in the picked-up checkpoint.
- */
-void
-__wt_layered_table_truncate_gc(WT_SESSION_IMPL *const session,
-  WT_LAYERED_TABLE *const layered_table, const wt_timestamp_t prune_ts)
-{
-    if (!__wt_process.disagg_fast_truncate_2026)
-        return;
-
-    WT_ASSERT(session, layered_table != NULL);
-    WT_ASSERT(session, WT_PREFIX_MATCH(layered_table->iface.name, "layered:"));
-
-    if (prune_ts == WT_TS_NONE)
-        return;
-
-    WT_TRUNCATE *entry = NULL;
-    WT_TRUNCATE *next = NULL;
-
-    __wt_writelock(session, &layered_table->truncate_lock);
-
-    TAILQ_FOREACH_SAFE(entry, &layered_table->truncateqh, q, next)
-    {
-        if (!__truncate_entry_eligible_for_gc(entry, prune_ts))
-            continue;
-
-        TAILQ_REMOVE(&layered_table->truncateqh, entry, q);
-        __disagg_truncate_free(session, &entry);
-    }
-
     __wt_writeunlock(session, &layered_table->truncate_lock);
 }

--- a/src/txn/txn_truncate.c
+++ b/src/txn/txn_truncate.c
@@ -90,10 +90,14 @@ __layered_table_truncate_gc(
 
     TAILQ_FOREACH_SAFE(entry, &layered_table->truncateqh, q, next)
     {
-        const bool is_eligible =
+        const bool is_committed = __wt_atomic_load_bool_acquire(&entry->committed);
+
+        /* Committed entries with durable_ts == WT_TS_NONE are never pruned here. Without a
+         * timestamp, we cannot determine whether the follower has picked up these changes yet. */
+        const bool is_time =
           entry->durable_ts != WT_TS_NONE && entry->durable_ts <= prune_timestamp;
 
-        if (!is_eligible)
+        if (!is_committed || !is_time)
             continue;
 
         __truncate_entry_remove(session, layered_table, entry);
@@ -393,15 +397,14 @@ err:
  * __wt_truncate_delete_visible_check --
  *     Search if the given key has been deleted in the layered table truncate list. start_keyp and
  *     stop_keyp are optional out parameters that represent the truncate range that deleted the key.
- *     Freeing of start_keyp and stop_keyp must be managed by the caller.
+ *     On success, the caller must free start_keyp and stop_keyp.
  */
 int
 __wt_truncate_delete_visible_check(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered_table,
   WT_ITEM *key, WT_ITEM *start_keyp, WT_ITEM *stop_keyp)
 {
     /* We either want the full range or no range at all. */
-    const bool keys_wanted = (start_keyp != NULL && stop_keyp != NULL);
-    WT_ASSERT(session, (start_keyp == NULL && stop_keyp == NULL) || keys_wanted);
+    WT_ASSERT(session, ((start_keyp != NULL) == (stop_keyp != NULL)));
 
     WT_DECL_RET;
     WT_TRUNCATE *tp = NULL;
@@ -426,18 +429,13 @@ __wt_truncate_delete_visible_check(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *l
     WT_ERR(
       __truncate_search(session, layered_table, key, WT_TRUNCATE_SEARCH_VISIBLE, &tp, &is_found));
 
-    if (is_found && keys_wanted)
+    if (is_found && start_keyp != NULL)
         WT_ERR(__truncate_entry_copy_keys(session, tp, start_keyp, stop_keyp));
 
 err:
     __wt_readunlock(session, &layered_table->truncate_lock);
-
     WT_RET(ret);
-
-    if (!is_found)
-        return (WT_NOTFOUND);
-
-    return (0);
+    return (is_found ? 0 : WT_NOTFOUND);
 }
 
 /*

--- a/src/txn/txn_truncate.c
+++ b/src/txn/txn_truncate.c
@@ -400,6 +400,10 @@ int
 __wt_truncate_delete_visible_check(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered_table,
   WT_ITEM *key, WT_ITEM *start_keyp, WT_ITEM *stop_keyp)
 {
+    /* We either want the full range or no range at all. */
+    const bool keys_wanted = (start_keyp != NULL && stop_keyp != NULL);
+    WT_ASSERT(session, (start_keyp == NULL && stop_keyp == NULL) || keys_wanted);
+
     WT_DECL_RET;
     WT_TRUNCATE *tp = NULL;
     bool is_found = false;
@@ -423,14 +427,18 @@ __wt_truncate_delete_visible_check(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *l
     WT_ERR(
       __truncate_search(session, layered_table, key, WT_TRUNCATE_SEARCH_VISIBLE, &tp, &is_found));
 
-    const bool keys_wanted = (start_keyp != NULL && stop_keyp != NULL);
-
     if (is_found && keys_wanted)
         WT_ERR(__truncate_entry_copy_keys(session, tp, start_keyp, stop_keyp));
 
 err:
     __wt_readunlock(session, &layered_table->truncate_lock);
-    return (is_found ? 0 : WT_NOTFOUND);
+
+    WT_RET(ret);
+
+    if (!is_found)
+        return (WT_NOTFOUND);
+
+    return (0);
 }
 
 /*

--- a/src/txn/txn_truncate.c
+++ b/src/txn/txn_truncate.c
@@ -85,6 +85,8 @@ __layered_table_truncate_gc(
     if (prune_timestamp == WT_TS_NONE)
         return;
 
+    WT_STAT_CONN_INCR(session, layered_truncate_list_gc_runs);
+
     WT_TRUNCATE *entry = NULL;
     WT_TRUNCATE *next = NULL;
 
@@ -104,6 +106,7 @@ __layered_table_truncate_gc(
 
         __truncate_entry_remove(session, layered_table, entry);
         __disagg_truncate_free(session, &entry);
+        WT_STAT_CONN_INCR(session, layered_truncate_list_gc_entries_removed);
     }
 }
 

--- a/test/catch2/CMakeLists.txt
+++ b/test/catch2/CMakeLists.txt
@@ -62,6 +62,7 @@ else()
         truncate/test_truncate_visible_check.cpp
         truncate/test_layered_truncate_visibility.cpp
         truncate/test_layered_table_truncate_clear.cpp
+        truncate/test_layered_table_truncate_gc.cpp
         truncate/test_layered_table_truncate_rollback.cpp
     )
 endif()

--- a/test/catch2/truncate/test_insert_truncate_entry.cpp
+++ b/test/catch2/truncate/test_insert_truncate_entry.cpp
@@ -116,6 +116,23 @@ insert_n_entries(follower_connection &connection, const size_t count)
     return 0;
 }
 
+int
+insert_gc_eligible_entry(follower_connection &connection)
+{
+    WT_RET(insert_one_entry(connection));
+
+    const wt_timestamp_t prune_ts = 10u;
+    connection.session().txn->time_point.durable_timestamp = prune_ts - 1u;
+    connection.session().txn->time_point.commit_timestamp = prune_ts - 1u;
+
+    auto *op = last_txn_op(connection.session());
+    __wti_mark_committed_truncate_table_apply(
+      &connection.session(), &connection.layered_table(), op);
+
+    connection.set_prune_timestamp(prune_ts);
+    return 0;
+}
+
 } // namespace
 
 SCENARIO("adding an entry successfully returns 0", "[truncate_list][insert]")
@@ -444,21 +461,17 @@ SCENARIO("adding an entry releases the truncate lock", "[truncate_list][insert]"
 // This test only verifies that insert wires up the GC call.
 SCENARIO("inserting an entry triggers garbage collection", "[truncate_list][insert]")
 {
-    GIVEN("a truncate list with one eligible entry eligible for garbage collection")
+    GIVEN("a truncate list with one entry eligible for garbage collection")
     {
         follower_connection connection;
-        CHECK(insert_one_entry(connection) == 0);
-
-        const wt_timestamp_t prune_ts = 10u;
-        truncate_list_head(connection.layered_table())->durable_ts = prune_ts - 1u;
-        connection.set_prune_timestamp(prune_ts);
+        CHECK(insert_gc_eligible_entry(connection) == 0);
 
         const auto expected_size = truncate_list_size(connection.layered_table());
 
         WHEN("a new entry is inserted")
         {
-            auto expected_start_key = make_item("key001");
-            auto expected_stop_key = make_item("key004");
+            auto expected_start_key = make_item("should_survive001");
+            auto expected_stop_key = make_item("should_survive002");
             CHECK(__wt_insert_truncate_entry(&connection.session(), &connection.layered_table(),
                     &expected_start_key, &expected_stop_key) == 0);
 

--- a/test/catch2/truncate/test_insert_truncate_entry.cpp
+++ b/test/catch2/truncate/test_insert_truncate_entry.cpp
@@ -74,6 +74,16 @@ public:
         return __wt_atomic_load_uint32_relaxed(&layered_table().iface.references);
     }
 
+    void
+    set_prune_timestamp(const wt_timestamp_t prune_ts)
+    {
+        REQUIRE(__wt_session_get_dhandle(
+                  _session_impl, layered_table().ingest_uri, nullptr, nullptr, 0) == 0);
+
+        __wt_atomic_store_uint64_relaxed(&S2BT(_session_impl)->prune_timestamp, prune_ts);
+        REQUIRE(__wt_session_release_dhandle(_session_impl) == 0);
+    }
+
 private:
     static constexpr auto home = "WT_TEST.truncate_list";
 
@@ -425,6 +435,31 @@ SCENARIO("adding an entry releases the truncate lock", "[truncate_list][insert]"
             THEN("the truncate lock is not held")
             {
                 REQUIRE(lock_is_released(connection.session(), connection.layered_table()));
+            }
+        }
+    }
+}
+
+// GC correctness is covered exhaustively in test_layered_table_truncate_gc.cpp.
+// This test only verifies that insert wires up the GC call.
+SCENARIO("inserting an entry triggers garbage collection", "[truncate_list][insert]")
+{
+    GIVEN("a truncate list with one eligible entry eligible for garbage collection")
+    {
+        follower_connection connection;
+        CHECK(insert_one_entry(connection) == 0);
+
+        const wt_timestamp_t prune_ts = 10u;
+        truncate_list_head(connection.layered_table())->durable_ts = prune_ts - 1u;
+        connection.set_prune_timestamp(prune_ts);
+
+        WHEN("a new entry is inserted")
+        {
+            CHECK(insert_one_entry(connection) == 0);
+
+            THEN("the eligible entry is garbage collected")
+            {
+                REQUIRE(truncate_list_size(connection.layered_table()) == 1u);
             }
         }
     }

--- a/test/catch2/truncate/test_insert_truncate_entry.cpp
+++ b/test/catch2/truncate/test_insert_truncate_entry.cpp
@@ -453,13 +453,27 @@ SCENARIO("inserting an entry triggers garbage collection", "[truncate_list][inse
         truncate_list_head(connection.layered_table())->durable_ts = prune_ts - 1u;
         connection.set_prune_timestamp(prune_ts);
 
+        const auto expected_size = truncate_list_size(connection.layered_table());
+
         WHEN("a new entry is inserted")
         {
-            CHECK(insert_one_entry(connection) == 0);
+            auto expected_start_key = make_item("key001");
+            auto expected_stop_key = make_item("key004");
+            CHECK(__wt_insert_truncate_entry(&connection.session(), &connection.layered_table(),
+                    &expected_start_key, &expected_stop_key) == 0);
 
             THEN("the eligible entry is garbage collected")
             {
-                REQUIRE(truncate_list_size(connection.layered_table()) == 1u);
+                REQUIRE(truncate_list_size(connection.layered_table()) == expected_size);
+            }
+
+            THEN("the surviving entry is the newly inserted one")
+            {
+                const auto *const head = truncate_list_head(connection.layered_table());
+                REQUIRE(head != nullptr);
+
+                REQUIRE(as_view(head->start_key) == as_view(expected_start_key));
+                REQUIRE(as_view(head->stop_key) == as_view(expected_stop_key));
             }
         }
     }

--- a/test/catch2/truncate/test_layered_table_truncate_clear.cpp
+++ b/test/catch2/truncate/test_layered_table_truncate_clear.cpp
@@ -22,7 +22,6 @@ SCENARIO("clearing empties the truncate list", "[truncate_list][clear]")
         truncate_list_fixture fixture;
         fixture.add_entry(make_item("a"), make_item("z"));
         fixture.add_entry(make_item("b"), make_item("y"));
-        CHECK(truncate_list_size(fixture.layered_table()) == 2);
 
         WHEN("the truncate list is cleared")
         {
@@ -43,7 +42,6 @@ SCENARIO("clearing the truncate list releases the dhandle reference", "[truncate
         truncate_list_fixture fixture;
         fixture.add_entry(make_item("a"), make_item("z"));
         fixture.add_entry(make_item("b"), make_item("y"));
-        CHECK(truncate_list_size(fixture.layered_table()) == 2);
 
         const auto reference_count = fixture.reference_count();
 
@@ -65,7 +63,6 @@ SCENARIO("clearing an empty truncate list is a no-op", "[truncate_list][clear]")
     {
         truncate_list_fixture fixture;
         const auto reference_count = fixture.reference_count();
-        CHECK(truncate_list_size(fixture.layered_table()) == 0);
 
         WHEN("the truncate list is cleared")
         {
@@ -87,7 +84,6 @@ SCENARIO("clearing the truncate list releases the truncate lock", "[truncate_lis
         truncate_list_fixture fixture;
         fixture.add_entry(make_item("a"), make_item("z"));
         fixture.add_entry(make_item("b"), make_item("y"));
-        CHECK(truncate_list_size(fixture.layered_table()) == 2);
 
         WHEN("the truncate list is cleared")
         {

--- a/test/catch2/truncate/test_layered_table_truncate_gc.cpp
+++ b/test/catch2/truncate/test_layered_table_truncate_gc.cpp
@@ -1,0 +1,273 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+#include <catch2/catch.hpp>
+
+#include "wt_internal.h"
+#include "truncate_list_helpers.hpp"
+
+using namespace truncate_list_helpers;
+
+namespace {
+
+void
+insert_durable_entry(truncate_list_fixture &fixture, const wt_timestamp_t durable_ts)
+{
+    REQUIRE(durable_ts != WT_TS_NONE);
+    auto *entry = fixture.add_entry(make_item("a"), make_item("z"));
+    entry->durable_ts = durable_ts;
+}
+
+} // namespace
+
+SCENARIO("garbage collection with a zeroed prune timestamp is a no-op", "[truncate_list][gc]")
+{
+    GIVEN("a truncate list with one durable entry")
+    {
+        truncate_list_fixture fixture;
+
+        const wt_timestamp_t durable_ts = 10u;
+        insert_durable_entry(fixture, durable_ts);
+
+        const auto initial_size = truncate_list_size(fixture.layered_table());
+        const auto initial_ref_count = fixture.reference_count();
+
+        WHEN("garbage collection runs with WT_TS_NONE as the prune timestamp")
+        {
+            __ut_layered_table_truncate_gc(
+              &fixture.session(), &fixture.layered_table(), WT_TS_NONE);
+
+            THEN("the truncate list remains unchanged")
+            {
+                REQUIRE(truncate_list_size(fixture.layered_table()) == initial_size);
+                REQUIRE(fixture.reference_count() == initial_ref_count);
+            }
+        }
+    }
+}
+
+SCENARIO("garbage collection does not remove an entry with a zeroed durable timestamp",
+  "[truncate_list][gc]")
+{
+    GIVEN("a truncate list with one entry whose durable timestamp is WT_TS_NONE")
+    {
+        truncate_list_fixture fixture;
+        fixture.add_entry(make_item("a"), make_item("z"));
+
+        const auto initial_size = truncate_list_size(fixture.layered_table());
+        const auto initial_ref_count = fixture.reference_count();
+
+        WHEN("garbage collection runs with a valid prune timestamp")
+        {
+            const wt_timestamp_t prune_ts = 10u;
+            __ut_layered_table_truncate_gc(&fixture.session(), &fixture.layered_table(), prune_ts);
+
+            THEN("the truncate list remains unchanged")
+            {
+                REQUIRE(truncate_list_size(fixture.layered_table()) == initial_size);
+                REQUIRE(fixture.reference_count() == initial_ref_count);
+            }
+        }
+    }
+}
+
+SCENARIO(
+  "garbage collection does not remove an entry above the prune timestamp", "[truncate_list][gc]")
+{
+    GIVEN("a truncate list with one entry whose durable timestamp is above the prune timestamp")
+    {
+        truncate_list_fixture fixture;
+
+        const wt_timestamp_t durable_ts = 10u;
+        insert_durable_entry(fixture, durable_ts);
+
+        const auto initial_size = truncate_list_size(fixture.layered_table());
+        const auto initial_ref_count = fixture.reference_count();
+
+        WHEN("garbage collection runs with a lower prune timestamp")
+        {
+            const auto prune_ts = durable_ts - 1u;
+            __ut_layered_table_truncate_gc(&fixture.session(), &fixture.layered_table(), prune_ts);
+
+            THEN("the truncate list remains unchanged")
+            {
+                REQUIRE(truncate_list_size(fixture.layered_table()) == initial_size);
+                REQUIRE(fixture.reference_count() == initial_ref_count);
+            }
+        }
+    }
+}
+
+SCENARIO("garbage collection removes an entry at the prune timestamp", "[truncate_list][gc]")
+{
+    GIVEN("a truncate list with one entry whose durable timestamp equals the prune timestamp")
+    {
+        truncate_list_fixture fixture;
+
+        const wt_timestamp_t durable_ts = 10u;
+        insert_durable_entry(fixture, durable_ts);
+
+        const auto initial_ref_count = fixture.reference_count();
+
+        WHEN("garbage collection runs with a matching prune timestamp")
+        {
+            __ut_layered_table_truncate_gc(
+              &fixture.session(), &fixture.layered_table(), durable_ts);
+
+            THEN("the entry is removed")
+            {
+                REQUIRE(truncate_list_size(fixture.layered_table()) == 0u);
+            }
+
+            THEN("the dhandle reference is released")
+            {
+                const auto expected_ref_count = initial_ref_count - 1u;
+                REQUIRE(fixture.reference_count() == expected_ref_count);
+            }
+        }
+    }
+}
+
+SCENARIO("garbage collection removes an entry below the prune timestamp", "[truncate_list][gc]")
+{
+    GIVEN("a truncate list with one entry whose durable timestamp is below the prune timestamp")
+    {
+        truncate_list_fixture fixture;
+
+        const wt_timestamp_t durable_ts = 10u;
+        insert_durable_entry(fixture, durable_ts);
+
+        const auto initial_ref_count = fixture.reference_count();
+
+        WHEN("garbage collection runs with a higher prune timestamp")
+        {
+            const auto prune_ts = durable_ts + 1u;
+            __ut_layered_table_truncate_gc(&fixture.session(), &fixture.layered_table(), prune_ts);
+
+            THEN("the truncate list is empty")
+            {
+                REQUIRE(truncate_list_size(fixture.layered_table()) == 0u);
+            }
+
+            THEN("the dhandle reference is released")
+            {
+                const auto expected_ref_count = initial_ref_count - 1u;
+                REQUIRE(fixture.reference_count() == expected_ref_count);
+            }
+        }
+    }
+}
+
+SCENARIO("garbage collection removes eligible entries from a multi-entry list",
+  "[truncate_list][gc]")
+{
+    GIVEN("a truncate list with one eligible entry and one ineligible entry")
+    {
+        truncate_list_fixture fixture;
+
+        const wt_timestamp_t prune_ts = 10u;
+        const auto expected_durable_ts = prune_ts + 1u;
+        insert_durable_entry(fixture, prune_ts - 1u);
+        insert_durable_entry(fixture, expected_durable_ts);
+
+        const auto initial_size = truncate_list_size(fixture.layered_table());
+        const auto initial_ref_count = fixture.reference_count();
+
+        WHEN("garbage collection runs")
+        {
+            __ut_layered_table_truncate_gc(&fixture.session(), &fixture.layered_table(), prune_ts);
+
+            THEN("the eligible entry is removed")
+            {
+                const auto expected_size = initial_size - 1u;
+                REQUIRE(truncate_list_size(fixture.layered_table()) == expected_size);
+
+                const auto *head = truncate_list_head(fixture.layered_table());
+                REQUIRE(head->durable_ts == expected_durable_ts);
+            }
+
+            THEN("the dhandle reference is not released")
+            {
+                REQUIRE(fixture.reference_count() == initial_ref_count);
+            }
+        }
+    }
+
+    GIVEN("a truncate list with two eligible entries")
+    {
+        truncate_list_fixture fixture;
+
+        const wt_timestamp_t prune_ts = 10u;
+        insert_durable_entry(fixture, prune_ts - 1u);
+        insert_durable_entry(fixture, prune_ts);
+
+        const auto initial_ref_count = fixture.reference_count();
+
+        WHEN("garbage collection runs")
+        {
+            __ut_layered_table_truncate_gc(&fixture.session(), &fixture.layered_table(), prune_ts);
+
+            THEN("all entries are removed")
+            {
+                REQUIRE(truncate_list_size(fixture.layered_table()) == 0u);
+            }
+
+            THEN("the dhandle reference is released")
+            {
+                const auto expected_ref_count = initial_ref_count - 1u;
+                REQUIRE(fixture.reference_count() == expected_ref_count);
+            }
+        }
+    }
+
+    GIVEN("a truncate list with two ineligible entries")
+    {
+        truncate_list_fixture fixture;
+
+        const wt_timestamp_t prune_ts = 10u;
+        insert_durable_entry(fixture, prune_ts + 1u);
+        insert_durable_entry(fixture, prune_ts + 2u);
+
+        const auto initial_size = truncate_list_size(fixture.layered_table());
+        const auto initial_ref_count = fixture.reference_count();
+
+        WHEN("garbage collection runs")
+        {
+            __ut_layered_table_truncate_gc(&fixture.session(), &fixture.layered_table(), prune_ts);
+
+            THEN("the truncate list remains unchanged")
+            {
+                REQUIRE(truncate_list_size(fixture.layered_table()) == initial_size);
+                REQUIRE(fixture.reference_count() == initial_ref_count);
+            }
+        }
+    }
+}
+
+SCENARIO("garbage collection with an empty truncate list is a no-op", "[truncate_list][gc]")
+{
+    GIVEN("an empty truncate list")
+    {
+        truncate_list_fixture fixture;
+
+        const auto initial_size = truncate_list_size(fixture.layered_table());
+        const auto initial_ref_count = fixture.reference_count();
+
+        WHEN("garbage collection runs with a valid prune timestamp")
+        {
+            const wt_timestamp_t prune_ts = 10u;
+            __ut_layered_table_truncate_gc(&fixture.session(), &fixture.layered_table(), prune_ts);
+
+            THEN("the truncate list remains unchanged")
+            {
+                REQUIRE(truncate_list_size(fixture.layered_table()) == initial_size);
+                REQUIRE(fixture.reference_count() == initial_ref_count);
+            }
+        }
+    }
+}

--- a/test/catch2/truncate/test_layered_table_truncate_gc.cpp
+++ b/test/catch2/truncate/test_layered_table_truncate_gc.cpp
@@ -163,8 +163,8 @@ SCENARIO("garbage collection removes an entry below the prune timestamp", "[trun
     }
 }
 
-SCENARIO("garbage collection removes eligible entries from a multi-entry list",
-  "[truncate_list][gc]")
+SCENARIO(
+  "garbage collection removes eligible entries from a multi-entry list", "[truncate_list][gc]")
 {
     GIVEN("a truncate list with one eligible entry and one ineligible entry")
     {
@@ -232,6 +232,60 @@ SCENARIO("garbage collection removes eligible entries from a multi-entry list",
         const wt_timestamp_t prune_ts = 10u;
         insert_durable_entry(fixture, prune_ts + 1u);
         insert_durable_entry(fixture, prune_ts + 2u);
+
+        const auto initial_size = truncate_list_size(fixture.layered_table());
+        const auto initial_ref_count = fixture.reference_count();
+
+        WHEN("garbage collection runs")
+        {
+            __ut_layered_table_truncate_gc(&fixture.session(), &fixture.layered_table(), prune_ts);
+
+            THEN("the truncate list remains unchanged")
+            {
+                REQUIRE(truncate_list_size(fixture.layered_table()) == initial_size);
+                REQUIRE(fixture.reference_count() == initial_ref_count);
+            }
+        }
+    }
+
+    GIVEN("a truncate list with one uncommitted entry and one eligible entry")
+    {
+        truncate_list_fixture fixture;
+
+        const wt_timestamp_t prune_ts = 10u;
+        fixture.add_entry(make_item("a"), make_item("z"));
+        insert_durable_entry(fixture, prune_ts - 1u);
+
+        const auto initial_size = truncate_list_size(fixture.layered_table());
+        const auto initial_ref_count = fixture.reference_count();
+
+        WHEN("garbage collection runs")
+        {
+            __ut_layered_table_truncate_gc(&fixture.session(), &fixture.layered_table(), prune_ts);
+
+            THEN("the eligible entry is removed and the uncommitted entry survives")
+            {
+                const auto expected_size = initial_size - 1u;
+                REQUIRE(truncate_list_size(fixture.layered_table()) == expected_size);
+
+                const auto *head = truncate_list_head(fixture.layered_table());
+                REQUIRE(head->durable_ts == WT_TS_NONE);
+            }
+
+            THEN("the dhandle reference is not released")
+            {
+                REQUIRE(fixture.reference_count() == initial_ref_count);
+            }
+        }
+    }
+
+    GIVEN("a truncate list with one uncommitted entry and one ineligible entry")
+    {
+        truncate_list_fixture fixture;
+
+        const wt_timestamp_t prune_ts = 10u;
+        fixture.add_entry(make_item("a"), make_item("z"));
+        insert_durable_entry(fixture, prune_ts + 1u);
 
         const auto initial_size = truncate_list_size(fixture.layered_table());
         const auto initial_ref_count = fixture.reference_count();

--- a/test/catch2/truncate/test_layered_table_truncate_gc.cpp
+++ b/test/catch2/truncate/test_layered_table_truncate_gc.cpp
@@ -18,9 +18,8 @@ namespace {
 void
 insert_durable_entry(truncate_list_fixture &fixture, const wt_timestamp_t durable_ts)
 {
-    REQUIRE(durable_ts != WT_TS_NONE);
     auto *entry = fixture.add_entry(make_item("a"), make_item("z"));
-    entry->durable_ts = durable_ts;
+    fixture.commit_entry(entry, durable_ts);
 }
 
 } // namespace
@@ -35,7 +34,7 @@ SCENARIO("garbage collection with a zeroed prune timestamp is a no-op", "[trunca
         insert_durable_entry(fixture, durable_ts);
 
         const auto initial_size = truncate_list_size(fixture.layered_table());
-        const auto initial_ref_count = fixture.reference_count();
+        const auto initial_reference_count = fixture.reference_count();
 
         WHEN("garbage collection runs with WT_TS_NONE as the prune timestamp")
         {
@@ -45,7 +44,31 @@ SCENARIO("garbage collection with a zeroed prune timestamp is a no-op", "[trunca
             THEN("the truncate list remains unchanged")
             {
                 REQUIRE(truncate_list_size(fixture.layered_table()) == initial_size);
-                REQUIRE(fixture.reference_count() == initial_ref_count);
+                REQUIRE(fixture.reference_count() == initial_reference_count);
+            }
+        }
+    }
+}
+
+SCENARIO("garbage collection does not remove an uncommitted entry", "[truncate_list][gc]")
+{
+    GIVEN("a truncate list with one uncommitted entry")
+    {
+        truncate_list_fixture fixture;
+        fixture.add_entry(make_item("a"), make_item("z"));
+
+        const auto initial_size = truncate_list_size(fixture.layered_table());
+        const auto initial_reference_count = fixture.reference_count();
+
+        WHEN("garbage collection runs with a valid prune timestamp")
+        {
+            const wt_timestamp_t prune_ts = 10u;
+            __ut_layered_table_truncate_gc(&fixture.session(), &fixture.layered_table(), prune_ts);
+
+            THEN("the truncate list remains unchanged")
+            {
+                REQUIRE(truncate_list_size(fixture.layered_table()) == initial_size);
+                REQUIRE(fixture.reference_count() == initial_reference_count);
             }
         }
     }
@@ -57,10 +80,10 @@ SCENARIO("garbage collection does not remove an entry with a zeroed durable time
     GIVEN("a truncate list with one entry whose durable timestamp is WT_TS_NONE")
     {
         truncate_list_fixture fixture;
-        fixture.add_entry(make_item("a"), make_item("z"));
+        insert_durable_entry(fixture, WT_TS_NONE);
 
         const auto initial_size = truncate_list_size(fixture.layered_table());
-        const auto initial_ref_count = fixture.reference_count();
+        const auto initial_reference_count = fixture.reference_count();
 
         WHEN("garbage collection runs with a valid prune timestamp")
         {
@@ -70,7 +93,7 @@ SCENARIO("garbage collection does not remove an entry with a zeroed durable time
             THEN("the truncate list remains unchanged")
             {
                 REQUIRE(truncate_list_size(fixture.layered_table()) == initial_size);
-                REQUIRE(fixture.reference_count() == initial_ref_count);
+                REQUIRE(fixture.reference_count() == initial_reference_count);
             }
         }
     }
@@ -87,7 +110,7 @@ SCENARIO(
         insert_durable_entry(fixture, durable_ts);
 
         const auto initial_size = truncate_list_size(fixture.layered_table());
-        const auto initial_ref_count = fixture.reference_count();
+        const auto initial_reference_count = fixture.reference_count();
 
         WHEN("garbage collection runs with a lower prune timestamp")
         {
@@ -97,7 +120,7 @@ SCENARIO(
             THEN("the truncate list remains unchanged")
             {
                 REQUIRE(truncate_list_size(fixture.layered_table()) == initial_size);
-                REQUIRE(fixture.reference_count() == initial_ref_count);
+                REQUIRE(fixture.reference_count() == initial_reference_count);
             }
         }
     }
@@ -112,8 +135,6 @@ SCENARIO("garbage collection removes an entry at the prune timestamp", "[truncat
         const wt_timestamp_t durable_ts = 10u;
         insert_durable_entry(fixture, durable_ts);
 
-        const auto initial_ref_count = fixture.reference_count();
-
         WHEN("garbage collection runs with a matching prune timestamp")
         {
             __ut_layered_table_truncate_gc(
@@ -122,12 +143,6 @@ SCENARIO("garbage collection removes an entry at the prune timestamp", "[truncat
             THEN("the entry is removed")
             {
                 REQUIRE(truncate_list_size(fixture.layered_table()) == 0u);
-            }
-
-            THEN("the dhandle reference is released")
-            {
-                const auto expected_ref_count = initial_ref_count - 1u;
-                REQUIRE(fixture.reference_count() == expected_ref_count);
             }
         }
     }
@@ -142,43 +157,37 @@ SCENARIO("garbage collection removes an entry below the prune timestamp", "[trun
         const wt_timestamp_t durable_ts = 10u;
         insert_durable_entry(fixture, durable_ts);
 
-        const auto initial_ref_count = fixture.reference_count();
-
         WHEN("garbage collection runs with a higher prune timestamp")
         {
             const auto prune_ts = durable_ts + 1u;
             __ut_layered_table_truncate_gc(&fixture.session(), &fixture.layered_table(), prune_ts);
 
-            THEN("the truncate list is empty")
+            THEN("the entry is removed")
             {
                 REQUIRE(truncate_list_size(fixture.layered_table()) == 0u);
-            }
-
-            THEN("the dhandle reference is released")
-            {
-                const auto expected_ref_count = initial_ref_count - 1u;
-                REQUIRE(fixture.reference_count() == expected_ref_count);
             }
         }
     }
 }
 
 SCENARIO(
-  "garbage collection removes eligible entries from a multi-entry list", "[truncate_list][gc]")
+  "garbage collection on a multi-entry list only removes eligible entries", "[truncate_list][gc]")
 {
     GIVEN("a truncate list with one eligible entry and one ineligible entry")
     {
         truncate_list_fixture fixture;
 
         const wt_timestamp_t prune_ts = 10u;
-        const auto expected_durable_ts = prune_ts + 1u;
-        insert_durable_entry(fixture, prune_ts - 1u);
-        insert_durable_entry(fixture, expected_durable_ts);
+
+        const auto eligible_durable_ts = prune_ts - 1u;
+        insert_durable_entry(fixture, eligible_durable_ts);
+
+        const auto surviving_durable_ts = prune_ts + 1u;
+        insert_durable_entry(fixture, surviving_durable_ts);
 
         const auto initial_size = truncate_list_size(fixture.layered_table());
-        const auto initial_ref_count = fixture.reference_count();
 
-        WHEN("garbage collection runs")
+        WHEN("garbage collection runs with a valid prune timestamp")
         {
             __ut_layered_table_truncate_gc(&fixture.session(), &fixture.layered_table(), prune_ts);
 
@@ -188,12 +197,7 @@ SCENARIO(
                 REQUIRE(truncate_list_size(fixture.layered_table()) == expected_size);
 
                 const auto *head = truncate_list_head(fixture.layered_table());
-                REQUIRE(head->durable_ts == expected_durable_ts);
-            }
-
-            THEN("the dhandle reference is not released")
-            {
-                REQUIRE(fixture.reference_count() == initial_ref_count);
+                REQUIRE(head->durable_ts == surviving_durable_ts);
             }
         }
     }
@@ -206,21 +210,13 @@ SCENARIO(
         insert_durable_entry(fixture, prune_ts - 1u);
         insert_durable_entry(fixture, prune_ts);
 
-        const auto initial_ref_count = fixture.reference_count();
-
-        WHEN("garbage collection runs")
+        WHEN("garbage collection runs with a valid prune timestamp")
         {
             __ut_layered_table_truncate_gc(&fixture.session(), &fixture.layered_table(), prune_ts);
 
             THEN("all entries are removed")
             {
                 REQUIRE(truncate_list_size(fixture.layered_table()) == 0u);
-            }
-
-            THEN("the dhandle reference is released")
-            {
-                const auto expected_ref_count = initial_ref_count - 1u;
-                REQUIRE(fixture.reference_count() == expected_ref_count);
             }
         }
     }
@@ -234,16 +230,16 @@ SCENARIO(
         insert_durable_entry(fixture, prune_ts + 2u);
 
         const auto initial_size = truncate_list_size(fixture.layered_table());
-        const auto initial_ref_count = fixture.reference_count();
+        const auto initial_reference_count = fixture.reference_count();
 
-        WHEN("garbage collection runs")
+        WHEN("garbage collection runs with a valid prune timestamp")
         {
             __ut_layered_table_truncate_gc(&fixture.session(), &fixture.layered_table(), prune_ts);
 
             THEN("the truncate list remains unchanged")
             {
                 REQUIRE(truncate_list_size(fixture.layered_table()) == initial_size);
-                REQUIRE(fixture.reference_count() == initial_ref_count);
+                REQUIRE(fixture.reference_count() == initial_reference_count);
             }
         }
     }
@@ -254,27 +250,22 @@ SCENARIO(
 
         const wt_timestamp_t prune_ts = 10u;
         fixture.add_entry(make_item("a"), make_item("z"));
+
         insert_durable_entry(fixture, prune_ts - 1u);
 
         const auto initial_size = truncate_list_size(fixture.layered_table());
-        const auto initial_ref_count = fixture.reference_count();
 
-        WHEN("garbage collection runs")
+        WHEN("garbage collection runs with a valid prune timestamp")
         {
             __ut_layered_table_truncate_gc(&fixture.session(), &fixture.layered_table(), prune_ts);
 
-            THEN("the eligible entry is removed and the uncommitted entry survives")
+            THEN("the eligible entry is removed")
             {
                 const auto expected_size = initial_size - 1u;
                 REQUIRE(truncate_list_size(fixture.layered_table()) == expected_size);
 
                 const auto *head = truncate_list_head(fixture.layered_table());
                 REQUIRE(head->durable_ts == WT_TS_NONE);
-            }
-
-            THEN("the dhandle reference is not released")
-            {
-                REQUIRE(fixture.reference_count() == initial_ref_count);
             }
         }
     }
@@ -283,21 +274,22 @@ SCENARIO(
     {
         truncate_list_fixture fixture;
 
-        const wt_timestamp_t prune_ts = 10u;
         fixture.add_entry(make_item("a"), make_item("z"));
+
+        const wt_timestamp_t prune_ts = 10u;
         insert_durable_entry(fixture, prune_ts + 1u);
 
         const auto initial_size = truncate_list_size(fixture.layered_table());
-        const auto initial_ref_count = fixture.reference_count();
+        const auto initial_reference_count = fixture.reference_count();
 
-        WHEN("garbage collection runs")
+        WHEN("garbage collection runs with a valid prune timestamp")
         {
             __ut_layered_table_truncate_gc(&fixture.session(), &fixture.layered_table(), prune_ts);
 
             THEN("the truncate list remains unchanged")
             {
                 REQUIRE(truncate_list_size(fixture.layered_table()) == initial_size);
-                REQUIRE(fixture.reference_count() == initial_ref_count);
+                REQUIRE(fixture.reference_count() == initial_reference_count);
             }
         }
     }
@@ -310,7 +302,7 @@ SCENARIO("garbage collection with an empty truncate list is a no-op", "[truncate
         truncate_list_fixture fixture;
 
         const auto initial_size = truncate_list_size(fixture.layered_table());
-        const auto initial_ref_count = fixture.reference_count();
+        const auto initial_reference_count = fixture.reference_count();
 
         WHEN("garbage collection runs with a valid prune timestamp")
         {
@@ -320,7 +312,53 @@ SCENARIO("garbage collection with an empty truncate list is a no-op", "[truncate
             THEN("the truncate list remains unchanged")
             {
                 REQUIRE(truncate_list_size(fixture.layered_table()) == initial_size);
-                REQUIRE(fixture.reference_count() == initial_ref_count);
+                REQUIRE(fixture.reference_count() == initial_reference_count);
+            }
+        }
+    }
+}
+
+SCENARIO("garbage collection does not release the dhandle reference when the list is not cleared",
+  "[truncate_list][gc]")
+{
+    GIVEN("a truncate list with one eligible entry and one ineligible entry")
+    {
+        truncate_list_fixture fixture;
+        const wt_timestamp_t prune_ts = 10u;
+        insert_durable_entry(fixture, prune_ts - 1u);
+        insert_durable_entry(fixture, prune_ts + 1u);
+
+        const auto initial_reference_count = fixture.reference_count();
+
+        WHEN("garbage collection runs with a valid prune timestamp")
+        {
+            __ut_layered_table_truncate_gc(&fixture.session(), &fixture.layered_table(), prune_ts);
+
+            THEN("the dhandle reference count is unchanged")
+            {
+                REQUIRE(fixture.reference_count() == initial_reference_count);
+            }
+        }
+    }
+}
+
+SCENARIO(
+  "garbage collection that empties the list releases the dhandle reference", "[truncate_list][gc]")
+{
+    GIVEN("a truncate list with one eligible entry")
+    {
+        truncate_list_fixture fixture;
+        const wt_timestamp_t prune_ts = 10u;
+        insert_durable_entry(fixture, prune_ts - 1u);
+        const auto initial_reference_count = fixture.reference_count();
+
+        WHEN("garbage collection runs with a valid prune timestamp")
+        {
+            __ut_layered_table_truncate_gc(&fixture.session(), &fixture.layered_table(), prune_ts);
+
+            THEN("the dhandle reference count is decremented by exactly one")
+            {
+                REQUIRE(fixture.reference_count() == initial_reference_count - 1u);
             }
         }
     }

--- a/test/catch2/truncate/test_layered_table_truncate_rollback.cpp
+++ b/test/catch2/truncate/test_layered_table_truncate_rollback.cpp
@@ -42,7 +42,6 @@ SCENARIO(
     {
         truncate_list_fixture fixture;
         fixture.add_entry(make_item("a"), make_item("z"));
-        CHECK(truncate_list_size(fixture.layered_table()) == 1);
 
         WHEN("the truncate is rolled back")
         {
@@ -62,7 +61,6 @@ SCENARIO("rolling back a truncate entry clears the op pointer", "[truncate_list]
     {
         truncate_list_fixture fixture;
         fixture.add_entry(make_item("a"), make_item("z"));
-        CHECK(truncate_list_size(fixture.layered_table()) == 1);
 
         WHEN("the truncate is rolled back")
         {
@@ -84,7 +82,6 @@ SCENARIO(
     {
         truncate_list_fixture fixture;
         fixture.add_entry(make_item("a"), make_item("z"));
-        CHECK(truncate_list_size(fixture.layered_table()) == 1);
 
         const auto reference_count = fixture.reference_count();
 
@@ -106,7 +103,6 @@ SCENARIO("rolling back a truncate entry releases the truncate lock", "[truncate_
     {
         truncate_list_fixture fixture;
         fixture.add_entry(make_item("a"), make_item("z"));
-        CHECK(truncate_list_size(fixture.layered_table()) == 1);
 
         WHEN("the truncate is rolled back")
         {
@@ -131,8 +127,6 @@ SCENARIO("rolling back affects only the targeted entry in a multi-entry truncate
         auto *last_entry = fixture.add_entry(make_item("e"), make_item("f"));
 
         const auto size = truncate_list_size(fixture.layered_table());
-        CHECK(size == 3);
-
         const auto reference_count = fixture.reference_count();
 
         auto first_op = make_op(first_entry);

--- a/test/catch2/truncate/test_layered_truncate_visibility.cpp
+++ b/test/catch2/truncate/test_layered_truncate_visibility.cpp
@@ -351,8 +351,7 @@ TEST_CASE_METHOD(layered_truncate_visibility_fixture,
     const wt_timestamp_t overlapping_durable_ts = 40;
 
     /* Truncate at txn 10: already committed, over 0150-0300. */
-    WT_TRUNCATE *overlapping = add_truncate(
-      overlapping_txn_id, overlapping_start_ts, overlapping_durable_ts, "0150", "0300");
+    add_truncate(overlapping_txn_id, overlapping_start_ts, overlapping_durable_ts, "0150", "0300");
 
     txn_id = 60;
     wt_timestamp_t read_timestamp = 30;

--- a/test/catch2/truncate/test_layered_truncate_visibility.cpp
+++ b/test/catch2/truncate/test_layered_truncate_visibility.cpp
@@ -12,6 +12,7 @@
 
 #include "wt_internal.h"
 #include "wrappers/mock_session.h"
+#include "truncate_list_helpers.hpp"
 
 /*
  * test_layered_truncate_visibility.cpp
@@ -124,12 +125,14 @@ public:
     }
 
     int
-    truncate_visible(std::string_view key, WT_TRUNCATE **matched = nullptr)
+    truncate_visible(
+      std::string_view key, WT_ITEM *start_keyp = nullptr, WT_ITEM *stop_keyp = nullptr)
     {
         WT_ITEM item{};
         item.data = key.data();
         item.size = key.size();
-        return (__wt_truncate_delete_visible_check(session, &layered_table, &item, matched));
+        return (__wt_truncate_delete_visible_check(
+          session, &layered_table, &item, start_keyp, stop_keyp));
     }
 };
 
@@ -141,20 +144,23 @@ TEST_CASE_METHOD(
     const uint64_t txn_id = 50;
     const wt_timestamp_t start_ts = WT_TS_NONE;
     const wt_timestamp_t durable_ts = WT_TS_NONE;
+
     const char *start = "0100";
     const char *stop = "0700";
 
     add_truncate(txn_id, start_ts, durable_ts, start, stop);
 
-    WT_TRUNCATE *matched = nullptr;
+    WT_ITEM start_key{};
+    WT_ITEM stop_key{};
     const char *key = "0150";
     set_reader(txn_id, WT_TS_NONE);
-    REQUIRE(truncate_visible(key, &matched) == 0);
-    REQUIRE(matched != nullptr);
 
-    const std::string_view matched_start{
-      static_cast<const char *>(matched->start_key.data), matched->start_key.size};
-    REQUIRE(matched_start == start);
+    REQUIRE(truncate_visible(key, &start_key, &stop_key) == 0);
+    REQUIRE(truncate_list_helpers::as_view(start_key) == start);
+    REQUIRE(truncate_list_helpers::as_view(stop_key) == stop);
+
+    __wt_buf_free(session, &start_key);
+    __wt_buf_free(session, &stop_key);
 }
 
 TEST_CASE_METHOD(layered_truncate_visibility_fixture,
@@ -317,9 +323,15 @@ TEST_CASE_METHOD(layered_truncate_visibility_fixture, "truncate commit stamps th
 
     /* With snap_min=300, txn 250 is visible and its published truncate matches the key. */
     set_reader(txn_id, read_timestamp, WT_ISO_SNAPSHOT, 300, 400);
-    WT_TRUNCATE *matched = nullptr;
-    REQUIRE(truncate_visible(key, &matched) == 0);
-    REQUIRE(matched == committed);
+    WT_ITEM matched_start{};
+    WT_ITEM matched_stop{};
+    REQUIRE(truncate_visible(key, &matched_start, &matched_stop) == 0);
+
+    REQUIRE(truncate_list_helpers::as_view(matched_start) == start);
+    REQUIRE(truncate_list_helpers::as_view(matched_stop) == stop);
+
+    __wt_buf_free(session, &matched_start);
+    __wt_buf_free(session, &matched_stop);
 }
 
 TEST_CASE_METHOD(layered_truncate_visibility_fixture,
@@ -373,9 +385,12 @@ TEST_CASE_METHOD(layered_truncate_visibility_fixture,
     set_reader(txn_id, read_timestamp);
     REQUIRE(truncate_visible(target_only_key) == WT_NOTFOUND);
 
-    WT_TRUNCATE *matched = nullptr;
-    REQUIRE(truncate_visible(overlap_key, &matched) == 0);
-    REQUIRE(matched == overlapping);
+    WT_ITEM matched_start{};
+    WT_ITEM matched_stop{};
+    REQUIRE(truncate_visible(overlap_key, &matched_start, &matched_stop) == 0);
+
+    REQUIRE(truncate_list_helpers::as_view(matched_start) == "0150");
+    REQUIRE(truncate_list_helpers::as_view(matched_stop) == "0300");
     REQUIRE(truncate_visible(overlap_only_key) == 0);
 
     txn_id = 300;
@@ -384,9 +399,14 @@ TEST_CASE_METHOD(layered_truncate_visibility_fixture,
     set_reader(txn_id, read_timestamp, WT_ISO_SNAPSHOT, 300, 400);
     REQUIRE(truncate_visible(target_only_key) == 0);
 
-    matched = nullptr;
-    REQUIRE(truncate_visible(overlap_key, &matched) == 0);
-    REQUIRE(matched == committed);
+    REQUIRE(truncate_visible(overlap_key, &matched_start, &matched_stop) == 0);
+
+    REQUIRE(truncate_list_helpers::as_view(matched_start) == "0100");
+    REQUIRE(truncate_list_helpers::as_view(matched_stop) == "0200");
+
+    __wt_buf_free(session, &matched_start);
+    __wt_buf_free(session, &matched_stop);
+
     REQUIRE(truncate_visible(overlap_only_key) == 0);
 }
 
@@ -419,10 +439,16 @@ TEST_CASE_METHOD(layered_truncate_visibility_fixture,
     set_reader(50, WT_TS_NONE);
     REQUIRE(truncate_visible(key) == WT_NOTFOUND);
 
-    WT_TRUNCATE *matched = nullptr;
+    WT_ITEM matched_start{};
+    WT_ITEM matched_stop{};
     key = "0175";
-    REQUIRE(truncate_visible(key, &matched) == 0);
-    REQUIRE(matched == surviving);
+    REQUIRE(truncate_visible(key, &matched_start, &matched_stop) == 0);
+
+    REQUIRE(truncate_list_helpers::as_view(matched_start) == start);
+    REQUIRE(truncate_list_helpers::as_view(matched_stop) == stop);
+
+    __wt_buf_free(session, &matched_start);
+    __wt_buf_free(session, &matched_stop);
 
     key = "0350";
     REQUIRE(truncate_visible(key) == 0);

--- a/test/catch2/truncate/test_truncate_visible_check.cpp
+++ b/test/catch2/truncate/test_truncate_visible_check.cpp
@@ -14,7 +14,7 @@
  *   - keys inside, outside, and at the boundaries of a single range
  *   - single-key ranges (start == stop)
  *   - multiple non-overlapping and overlapping ranges
- *   - the optional output pointer is filled on a match
+ *   - start and stop key buffers are copied on a match
  *   - the feature flag early-return path
  *   - lock discipline: read lock is always released
  */
@@ -23,6 +23,7 @@
 #include "wrappers/mock_session.h"
 
 #include "wt_internal.h"
+#include "truncate_list_helpers.hpp"
 
 /*
  * Fixture: a minimal session and a hand-constructed WT_LAYERED_TABLE with an empty truncate list.
@@ -110,40 +111,40 @@ TEST_CASE_METHOD(TruncVisibleCheckFixture,
     SECTION("empty truncate list")
     {
         WT_ITEM key = make_key("key150");
-        CHECK(
-          __wt_truncate_delete_visible_check(session, layered_table, &key, nullptr) == WT_NOTFOUND);
+        CHECK(__wt_truncate_delete_visible_check(session, layered_table, &key, nullptr, nullptr) ==
+          WT_NOTFOUND);
     }
 
     SECTION("key before the truncated range")
     {
         add_truncate_entry("key100", "key200");
         WT_ITEM key = make_key("key050");
-        CHECK(
-          __wt_truncate_delete_visible_check(session, layered_table, &key, nullptr) == WT_NOTFOUND);
+        CHECK(__wt_truncate_delete_visible_check(session, layered_table, &key, nullptr, nullptr) ==
+          WT_NOTFOUND);
     }
 
     SECTION("key after the truncated range")
     {
         add_truncate_entry("key100", "key200");
         WT_ITEM key = make_key("key250");
-        CHECK(
-          __wt_truncate_delete_visible_check(session, layered_table, &key, nullptr) == WT_NOTFOUND);
+        CHECK(__wt_truncate_delete_visible_check(session, layered_table, &key, nullptr, nullptr) ==
+          WT_NOTFOUND);
     }
 
     SECTION("single-key range: key just before")
     {
         add_truncate_entry("key100", "key100");
         WT_ITEM key = make_key("key099");
-        CHECK(
-          __wt_truncate_delete_visible_check(session, layered_table, &key, nullptr) == WT_NOTFOUND);
+        CHECK(__wt_truncate_delete_visible_check(session, layered_table, &key, nullptr, nullptr) ==
+          WT_NOTFOUND);
     }
 
     SECTION("single-key range: key just after")
     {
         add_truncate_entry("key100", "key100");
         WT_ITEM key = make_key("key101");
-        CHECK(
-          __wt_truncate_delete_visible_check(session, layered_table, &key, nullptr) == WT_NOTFOUND);
+        CHECK(__wt_truncate_delete_visible_check(session, layered_table, &key, nullptr, nullptr) ==
+          WT_NOTFOUND);
     }
 
     SECTION("key between two non-overlapping ranges")
@@ -151,8 +152,8 @@ TEST_CASE_METHOD(TruncVisibleCheckFixture,
         add_truncate_entry("key100", "key200");
         add_truncate_entry("key400", "key500");
         WT_ITEM key = make_key("key300");
-        CHECK(
-          __wt_truncate_delete_visible_check(session, layered_table, &key, nullptr) == WT_NOTFOUND);
+        CHECK(__wt_truncate_delete_visible_check(session, layered_table, &key, nullptr, nullptr) ==
+          WT_NOTFOUND);
     }
 }
 
@@ -163,28 +164,32 @@ TEST_CASE_METHOD(TruncVisibleCheckFixture,
     {
         add_truncate_entry("key100", "key200");
         WT_ITEM key = make_key("key150");
-        CHECK(__wt_truncate_delete_visible_check(session, layered_table, &key, nullptr) == 0);
+        CHECK(
+          __wt_truncate_delete_visible_check(session, layered_table, &key, nullptr, nullptr) == 0);
     }
 
     SECTION("key at the start boundary (inclusive)")
     {
         add_truncate_entry("key100", "key200");
         WT_ITEM key = make_key("key100");
-        CHECK(__wt_truncate_delete_visible_check(session, layered_table, &key, nullptr) == 0);
+        CHECK(
+          __wt_truncate_delete_visible_check(session, layered_table, &key, nullptr, nullptr) == 0);
     }
 
     SECTION("key at the stop boundary (inclusive)")
     {
         add_truncate_entry("key100", "key200");
         WT_ITEM key = make_key("key200");
-        CHECK(__wt_truncate_delete_visible_check(session, layered_table, &key, nullptr) == 0);
+        CHECK(
+          __wt_truncate_delete_visible_check(session, layered_table, &key, nullptr, nullptr) == 0);
     }
 
     SECTION("single-key range, exact match")
     {
         add_truncate_entry("key100", "key100");
         WT_ITEM key = make_key("key100");
-        CHECK(__wt_truncate_delete_visible_check(session, layered_table, &key, nullptr) == 0);
+        CHECK(
+          __wt_truncate_delete_visible_check(session, layered_table, &key, nullptr, nullptr) == 0);
     }
 
     SECTION("key matched by the first of two non-overlapping ranges")
@@ -192,7 +197,8 @@ TEST_CASE_METHOD(TruncVisibleCheckFixture,
         add_truncate_entry("key100", "key200");
         add_truncate_entry("key400", "key500");
         WT_ITEM key = make_key("key150");
-        CHECK(__wt_truncate_delete_visible_check(session, layered_table, &key, nullptr) == 0);
+        CHECK(
+          __wt_truncate_delete_visible_check(session, layered_table, &key, nullptr, nullptr) == 0);
     }
 
     SECTION("key matched by the second of two non-overlapping ranges")
@@ -200,7 +206,8 @@ TEST_CASE_METHOD(TruncVisibleCheckFixture,
         add_truncate_entry("key100", "key200");
         add_truncate_entry("key400", "key500");
         WT_ITEM key = make_key("key450");
-        CHECK(__wt_truncate_delete_visible_check(session, layered_table, &key, nullptr) == 0);
+        CHECK(
+          __wt_truncate_delete_visible_check(session, layered_table, &key, nullptr, nullptr) == 0);
     }
 }
 
@@ -212,7 +219,8 @@ TEST_CASE_METHOD(TruncVisibleCheckFixture,
         add_truncate_entry("key100", "key300");
         add_truncate_entry("key200", "key400");
         WT_ITEM key = make_key("key250");
-        CHECK(__wt_truncate_delete_visible_check(session, layered_table, &key, nullptr) == 0);
+        CHECK(
+          __wt_truncate_delete_visible_check(session, layered_table, &key, nullptr, nullptr) == 0);
     }
 
     SECTION("key in the first range only (outside the overlap)")
@@ -220,7 +228,8 @@ TEST_CASE_METHOD(TruncVisibleCheckFixture,
         add_truncate_entry("key100", "key300");
         add_truncate_entry("key200", "key400");
         WT_ITEM key = make_key("key150");
-        CHECK(__wt_truncate_delete_visible_check(session, layered_table, &key, nullptr) == 0);
+        CHECK(
+          __wt_truncate_delete_visible_check(session, layered_table, &key, nullptr, nullptr) == 0);
     }
 
     SECTION("key in the second range only (outside the overlap)")
@@ -228,7 +237,8 @@ TEST_CASE_METHOD(TruncVisibleCheckFixture,
         add_truncate_entry("key100", "key300");
         add_truncate_entry("key200", "key400");
         WT_ITEM key = make_key("key350");
-        CHECK(__wt_truncate_delete_visible_check(session, layered_table, &key, nullptr) == 0);
+        CHECK(
+          __wt_truncate_delete_visible_check(session, layered_table, &key, nullptr, nullptr) == 0);
     }
 }
 
@@ -245,7 +255,8 @@ TEST_CASE_METHOD(
         add_truncate_entry("key100", "key200");
         WT_ITEM key = make_key("key150");
 
-        CHECK(__wt_truncate_delete_visible_check(session, layered_table, &key, nullptr) == 0);
+        CHECK(
+          __wt_truncate_delete_visible_check(session, layered_table, &key, nullptr, nullptr) == 0);
 
         CHECK(__wt_try_writelock(session, &layered_table->truncate_lock) == 0);
         __wt_writeunlock(session, &layered_table->truncate_lock);
@@ -256,8 +267,8 @@ TEST_CASE_METHOD(
         add_truncate_entry("key100", "key200");
         WT_ITEM key = make_key("key050");
 
-        CHECK(
-          __wt_truncate_delete_visible_check(session, layered_table, &key, nullptr) == WT_NOTFOUND);
+        CHECK(__wt_truncate_delete_visible_check(session, layered_table, &key, nullptr, nullptr) ==
+          WT_NOTFOUND);
 
         CHECK(__wt_try_writelock(session, &layered_table->truncate_lock) == 0);
         __wt_writeunlock(session, &layered_table->truncate_lock);
@@ -267,8 +278,8 @@ TEST_CASE_METHOD(
     {
         WT_ITEM key = make_key("key150");
 
-        CHECK(
-          __wt_truncate_delete_visible_check(session, layered_table, &key, nullptr) == WT_NOTFOUND);
+        CHECK(__wt_truncate_delete_visible_check(session, layered_table, &key, nullptr, nullptr) ==
+          WT_NOTFOUND);
 
         CHECK(__wt_try_writelock(session, &layered_table->truncate_lock) == 0);
         __wt_writeunlock(session, &layered_table->truncate_lock);
@@ -276,33 +287,90 @@ TEST_CASE_METHOD(
 }
 
 TEST_CASE_METHOD(
-  TruncVisibleCheckFixture, "truncate_delete_visible_check: output parameter tp", "[truncate]")
+  TruncVisibleCheckFixture, "truncate_delete_visible_check: output parameters", "[truncate]")
 {
-    SECTION("When tp is null ensure function does not crash on a match")
+    SECTION("returns 0 when keys are not requested on a match")
     {
         add_truncate_entry("key100", "key200");
         WT_ITEM key = make_key("key150");
-        CHECK(__wt_truncate_delete_visible_check(session, layered_table, &key, nullptr) == 0);
+        CHECK(
+          __wt_truncate_delete_visible_check(session, layered_table, &key, nullptr, nullptr) == 0);
     }
 
-    SECTION("tp is set to the matching entry when key is deleted")
+    SECTION("start and stop keys are copied on a match")
     {
-        add_truncate_entry("key100", "key200");
+        const auto expected_start_key = "key100";
+        const auto expected_stop_key = "key200";
+        add_truncate_entry(expected_start_key, expected_stop_key);
+
         WT_ITEM key = make_key("key150");
-        WT_TRUNCATE *tp = nullptr;
-        REQUIRE(__wt_truncate_delete_visible_check(session, layered_table, &key, &tp) == 0);
-        REQUIRE(tp != nullptr);
-        CHECK(strncmp((const char *)tp->start_key.data, "key100", tp->start_key.size) == 0);
-        CHECK(strncmp((const char *)tp->stop_key.data, "key200", tp->stop_key.size) == 0);
+        WT_ITEM start_key{};
+        WT_ITEM stop_key{};
+        REQUIRE(__wt_truncate_delete_visible_check(
+                  session, layered_table, &key, &start_key, &stop_key) == 0);
+
+        REQUIRE(truncate_list_helpers::as_view(start_key) == expected_start_key);
+        REQUIRE(truncate_list_helpers::as_view(stop_key) == expected_stop_key);
+
+        __wt_buf_free(session, &start_key);
+        __wt_buf_free(session, &stop_key);
     }
 
-    SECTION("tp is null, when there is a miss")
+    SECTION("copied keys are independent of the source entry")
     {
         add_truncate_entry("key100", "key200");
+
+        WT_ITEM key = make_key("key150");
+        WT_ITEM start_key{};
+        WT_ITEM stop_key{};
+        REQUIRE(__wt_truncate_delete_visible_check(
+                  session, layered_table, &key, &start_key, &stop_key) == 0);
+
+        /* Modify the source entry. Changes here should not be reflected in the copied keys */
+        auto *const head = truncate_list_helpers::truncate_list_head(*layered_table);
+        head->start_key.data = "key101";
+
+        /* Keys were deep-copied under the lock; they must still be valid. */
+        CHECK(truncate_list_helpers::as_view(start_key) == "key100");
+        CHECK(truncate_list_helpers::as_view(stop_key) == "key200");
+
+        __wt_buf_free(session, &start_key);
+        __wt_buf_free(session, &stop_key);
+    }
+
+    SECTION("keys returned are from the correctly matched range")
+    {
+        add_truncate_entry("key100", "key200");
+
+        const auto expected_start_key = "key400";
+        const auto expected_stop_key = "key500";
+        add_truncate_entry(expected_start_key, expected_stop_key);
+
+        WT_ITEM key = make_key("key450");
+        WT_ITEM start_key{};
+        WT_ITEM stop_key{};
+        REQUIRE(__wt_truncate_delete_visible_check(
+                  session, layered_table, &key, &start_key, &stop_key) == 0);
+
+        CHECK(truncate_list_helpers::as_view(start_key) == expected_start_key);
+        CHECK(truncate_list_helpers::as_view(stop_key) == expected_stop_key);
+
+        __wt_buf_free(session, &start_key);
+        __wt_buf_free(session, &stop_key);
+    }
+
+    SECTION("key buffers are untouched on a miss")
+    {
+        add_truncate_entry("key100", "key200");
+
         WT_ITEM key = make_key("key050");
-        WT_TRUNCATE *tp = nullptr;
-        CHECK(__wt_truncate_delete_visible_check(session, layered_table, &key, &tp) == WT_NOTFOUND);
-        CHECK(tp == nullptr);
+        WT_ITEM start_key{};
+        WT_ITEM stop_key{};
+        CHECK(__wt_truncate_delete_visible_check(
+                session, layered_table, &key, &start_key, &stop_key) == WT_NOTFOUND);
+
+        CHECK(start_key.data == nullptr);
+        CHECK(stop_key.data == nullptr);
     }
 }
 
@@ -318,8 +386,8 @@ TEST_CASE_METHOD(
         add_truncate_entry("key100", "key200");
         __wt_process.disagg_slow_truncate_2026 = true;
         WT_ITEM key = make_key("key150");
-        CHECK(
-          __wt_truncate_delete_visible_check(session, layered_table, &key, nullptr) == WT_NOTFOUND);
+        CHECK(__wt_truncate_delete_visible_check(session, layered_table, &key, nullptr, nullptr) ==
+          WT_NOTFOUND);
         __wt_process.disagg_slow_truncate_2026 = false;
     }
 }

--- a/test/catch2/truncate/truncate_list_helpers.cpp
+++ b/test/catch2/truncate/truncate_list_helpers.cpp
@@ -118,4 +118,22 @@ truncate_list_fixture::add_entry(const WT_ITEM &start, const WT_ITEM &stop)
     return entry;
 }
 
+void
+truncate_list_fixture::commit_entry(WT_TRUNCATE *entry, const wt_timestamp_t durable_ts)
+{
+    WT_TXN txn{};
+    txn.time_point.id = entry->txn_id;
+    txn.time_point.commit_timestamp = durable_ts;
+    txn.time_point.durable_timestamp = durable_ts;
+
+    _session->txn = &txn;
+
+    WT_TXN_OP op{};
+    op.type = WT_TXN_OP_FOLLOWER_TRUNCATE;
+    op.u.follower_truncate.t = entry;
+
+    __wti_mark_committed_truncate_table_apply(_session, &_table, &op);
+    _session->txn = nullptr;
+}
+
 } // namespace truncate_list_helpers

--- a/test/catch2/truncate/truncate_list_helpers.cpp
+++ b/test/catch2/truncate/truncate_list_helpers.cpp
@@ -121,12 +121,14 @@ truncate_list_fixture::add_entry(const WT_ITEM &start, const WT_ITEM &stop)
 void
 truncate_list_fixture::commit_entry(WT_TRUNCATE *entry, const wt_timestamp_t durable_ts)
 {
-    WT_TXN txn{};
-    txn.time_point.id = entry->txn_id;
-    txn.time_point.commit_timestamp = durable_ts;
-    txn.time_point.durable_timestamp = durable_ts;
+    /* WT_TXN has a flexible array member; MSVC forbids stack-allocating such types. */
+    auto *const txn = static_cast<WT_TXN *>(std::calloc(1, sizeof(WT_TXN)));
 
-    _session->txn = &txn;
+    txn->time_point.id = entry->txn_id;
+    txn->time_point.commit_timestamp = durable_ts;
+    txn->time_point.durable_timestamp = durable_ts;
+
+    _session->txn = txn;
 
     WT_TXN_OP op{};
     op.type = WT_TXN_OP_FOLLOWER_TRUNCATE;
@@ -134,6 +136,8 @@ truncate_list_fixture::commit_entry(WT_TRUNCATE *entry, const wt_timestamp_t dur
 
     __wti_mark_committed_truncate_table_apply(_session, &_table, &op);
     _session->txn = nullptr;
+
+    std::free(txn);
 }
 
 } // namespace truncate_list_helpers

--- a/test/catch2/truncate/truncate_list_helpers.cpp
+++ b/test/catch2/truncate/truncate_list_helpers.cpp
@@ -72,7 +72,8 @@ truncate_list_fixture::truncate_list_fixture()
 {
     _table.iface.name = "layered:truncate_list_fixture";
     TAILQ_INIT(&_table.truncateqh);
-    REQUIRE(__wt_rwlock_init(_session, &_table.truncate_lock) == 0);
+    CHECK(__wt_rwlock_init(_session, &_table.truncate_lock) == 0);
+    CHECK(truncate_list_size(_table) == 0);
 }
 
 truncate_list_fixture::~truncate_list_fixture()
@@ -108,7 +109,12 @@ truncate_list_fixture::add_entry(const WT_ITEM &start, const WT_ITEM &stop)
     entry->start_key = start;
     entry->stop_key = stop;
 
+    const auto initial_size = truncate_list_size(_table);
+
     TAILQ_INSERT_TAIL(&_table.truncateqh, entry, q);
+
+    const auto expected_size = initial_size + 1;
+    CHECK(truncate_list_size(_table) == expected_size);
     return entry;
 }
 

--- a/test/catch2/truncate/truncate_list_helpers.hpp
+++ b/test/catch2/truncate/truncate_list_helpers.hpp
@@ -61,6 +61,7 @@ public:
     }
 
     WT_TRUNCATE *add_entry(const WT_ITEM &start, const WT_ITEM &stop);
+    void commit_entry(WT_TRUNCATE *entry, wt_timestamp_t durable_ts);
 
 private:
     std::shared_ptr<mock_session> _mock;


### PR DESCRIPTION
There are a few changes here:
- Add garbage collection of the truncate list that is triggered on every **insert**. This is governed by the checkpoint / prune timestamp.
- Copy out the start and stop key when searching. This is to prevent a dangling pointer situation when GC triggers.
- Add GC and key copying unit tests
- All other changes are related to compilation.

Patch build:
https://spruce.corp.mongodb.com/version/6a0e4b396d8e8e00072c5863