### PR TITLE
WT-17417 Fix shared dsk cache init

### DIFF
--- a/src/cache/cache.c
+++ b/src/cache/cache.c
@@ -64,6 +64,7 @@ __wt_cache_config(WT_SESSION_IMPL *session, const char *cfg[], bool reconfig)
 int
 __wt_cache_create(WT_SESSION_IMPL *session, const char *cfg[])
 {
+    WT_CONFIG_ITEM cval;
     u_int hash_size;
 
     WT_ASSERT(session, S2C(session)->cache == NULL);
@@ -77,10 +78,15 @@ __wt_cache_create(WT_SESSION_IMPL *session, const char *cfg[])
      * 0.2% of cache size divided by ~100B per entry (cache_size / 500 / 100), with a minimum of 512
      * buckets.
      *
-     * FIXME: Enable the shared disk cache when it is fully implemented.
+     * We cannot use __wt_conn_is_disagg here because __wti_disagg_conn_config hasn't run yet and
+     * page_log_meta is still NULL. Read the config directly instead.
+     *
+     * FIXME-WT-14721: Once the init ordering in conn_open.c is fixed so that
+     * __wti_disagg_conn_config runs before __wt_cache_create, replace this config lookup with
+     * __wt_conn_is_disagg(session).
      */
-    S2C(session)->cache->shared_dsk_cache.enabled = __wt_conn_is_disagg(session);
-    S2C(session)->cache->shared_dsk_cache.enabled = false;
+    WT_RET(__wt_config_gets(session, cfg, "disaggregated.page_log", &cval));
+    S2C(session)->cache->shared_dsk_cache.enabled = (cval.len != 0);
     if (S2C(session)->cache->shared_dsk_cache.enabled) {
         /* FIXME-WT-17066: We should pick a hash size wisely. */
         hash_size = (u_int)WT_MAX(S2C(session)->cache_size / 500 / 100, 512);


### PR DESCRIPTION
Temporary fix for shared disk cache init ordering: read disaggregated.page_log directly from config in `__wt_cache_create` instead of using `__wt_conn_is_disagg`, which always returned false because `__wti_disagg_conn_config` had not yet run