### PR TITLE
WT-17558 Assign codeowners for agent config files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,9 @@
 # Entire team are code-owners for the time being
 * @wiredtiger/storage-engines @svc-auto-approve-bot
+
+# Agent configurations
+/.claude/ @Sean04 @whoisong
+/.agents/ @Sean04 @whoisong
+/CLAUDE.md @Sean04 @whoisong
+/AGENTS.md @Sean04 @whoisong
+/.mcp.json @Sean04 @whoisong


### PR DESCRIPTION
Assigning @whoisong and @Sean04 to review any changes to the agent files. This is to ensure best practices are followed, and agent files are not inadvertently edited.