### PR TITLE
WT-17485 Add load metrics

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -125,6 +125,10 @@ class LiveRestoreStat(Stat):
     prefix = 'live-restore'
     def __init__(self, name, desc, flags=''):
         Stat.__init__(self, name, LiveRestoreStat.prefix, desc, flags)
+class LoadControlStat(Stat):
+    prefix = 'load-control'
+    def __init__(self, name, desc, flags=''):
+        Stat.__init__(self, name, LoadControlStat.prefix, desc, flags)
 class LockStat(Stat):
     prefix = 'lock'
     def __init__(self, name, desc, flags=''):
@@ -647,6 +651,12 @@ conn_stats = [
     LiveRestoreStat('live_restore_source_read_count', 'number of reads from the source database'),
     LiveRestoreStat('live_restore_state', 'state', 'no_clear,no_scale'),
     LiveRestoreStat('live_restore_work_remaining', 'number of files remaining for migration completion', 'no_clear,no_scale'),
+
+    ##########################################
+    # Load Control statistics
+    ##########################################
+    LoadControlStat('read_load', 'read load at the system level'),
+    LoadControlStat('write_load', 'write load at the system level'),
 
     ##########################################
     # Locking statistics

--- a/src/conn/conn_load_control.c
+++ b/src/conn/conn_load_control.c
@@ -79,3 +79,69 @@ __wti_conn_load_control_config(WT_SESSION_IMPL *session, const char *cfg[], bool
 
     return (0);
 }
+
+/*
+ * __conn_calc_load_pct --
+ *     Calculate the percentage of part relative to whole. Returns 0 if whole is zero.
+ */
+static WT_INLINE uint8_t
+__conn_calc_load_pct(uint64_t part, uint64_t whole)
+{
+    uint8_t spill_pct = 0;
+    if (whole == 0)
+        return (0);
+
+    if (part > whole) {
+        part = part - whole;
+        spill_pct = 100;
+    }
+    return (((uint8_t)WT_MIN((part * 100) / whole, 100)) + spill_pct);
+}
+
+/*
+ * __wt_conn_calc_read_load --
+ *     Calculate the read load at the system level.
+ */
+void
+__wt_conn_calc_read_load(WT_SESSION_IMPL *session)
+{
+    WT_CONNECTION_LOAD_CONTROL *load_control;
+    uint64_t bytes_inuse, bytes_max;
+    uint8_t load;
+
+    load_control = &S2C(session)->load_control;
+    /*
+     * Avoid division by zero if the cache size has not yet been set in a shared cache.
+     */
+    bytes_max = load_control->read_load_max;
+    bytes_inuse = __wt_cache_bytes_inuse(S2C(session)->cache);
+
+    load = __conn_calc_load_pct(bytes_inuse, bytes_max);
+    WT_STAT_CONN_SET(session, read_load, load);
+    __wt_atomic_store_uint8_relaxed(&load_control->read_load, load);
+    return;
+}
+
+/*
+ * __wt_conn_calc_write_load --
+ *     Calculate the write load at the system level.
+ */
+void
+__wt_conn_calc_write_load(WT_SESSION_IMPL *session)
+{
+    WT_CONNECTION_LOAD_CONTROL *load_control;
+    uint64_t bytes_dirty, bytes_max;
+    uint8_t load;
+
+    /*
+     * Avoid division by zero if the cache size has not yet been set in a shared cache.
+     */
+    load_control = &S2C(session)->load_control;
+    bytes_max = load_control->write_load_max;
+    bytes_dirty = __wt_cache_dirty_inuse(S2C(session)->cache);
+
+    load = __conn_calc_load_pct(bytes_dirty, bytes_max);
+    WT_STAT_CONN_SET(session, write_load, load);
+    __wt_atomic_store_uint8_relaxed(&load_control->write_load, load);
+    return;
+}

--- a/src/conn/conn_load_control.c
+++ b/src/conn/conn_load_control.c
@@ -90,7 +90,7 @@ __conn_calc_load_pct(uint64_t part, uint64_t whole)
     if (whole == 0)
         return (0);
 
-    return (((uint8_t)WT_MIN((part / whole) * 100, 200)));
+    return (((uint8_t)WT_MIN((part * 100) / whole, 200)));
 }
 
 /*

--- a/src/conn/conn_load_control.c
+++ b/src/conn/conn_load_control.c
@@ -87,15 +87,10 @@ __wti_conn_load_control_config(WT_SESSION_IMPL *session, const char *cfg[], bool
 static WT_INLINE uint8_t
 __conn_calc_load_pct(uint64_t part, uint64_t whole)
 {
-    uint8_t spill_pct = 0;
     if (whole == 0)
         return (0);
 
-    if (part > whole) {
-        part = part - whole;
-        spill_pct = 100;
-    }
-    return (((uint8_t)WT_MIN((part * 100) / whole, 100)) + spill_pct);
+    return (((uint8_t)WT_MIN((part / whole) * 100, 200)));
 }
 
 /*
@@ -117,8 +112,8 @@ __wt_conn_calc_read_load(WT_SESSION_IMPL *session)
     bytes_inuse = __wt_cache_bytes_inuse(S2C(session)->cache);
 
     load = __conn_calc_load_pct(bytes_inuse, bytes_max);
-    WT_STAT_CONN_SET(session, read_load, load);
     __wt_atomic_store_uint8_relaxed(&load_control->read_load, load);
+    WT_STAT_CONN_SET(session, read_load, load);
     return;
 }
 
@@ -141,7 +136,7 @@ __wt_conn_calc_write_load(WT_SESSION_IMPL *session)
     bytes_dirty = __wt_cache_dirty_inuse(S2C(session)->cache);
 
     load = __conn_calc_load_pct(bytes_dirty, bytes_max);
-    WT_STAT_CONN_SET(session, write_load, load);
     __wt_atomic_store_uint8_relaxed(&load_control->write_load, load);
+    WT_STAT_CONN_SET(session, write_load, load);
     return;
 }

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -605,6 +605,7 @@ __wt_cache_page_inmem_decr(WT_SESSION_IMPL *session, WT_PAGE *page, size_t size)
     __wt_cache_decr_check_size(session, &page->memory_footprint, size, "WT_PAGE.memory_footprint");
     __wt_cache_decr_check_uint64(session, &btree->bytes_inmem, size, "WT_BTREE.bytes_inmem");
     __wt_cache_decr_check_uint64(session, &cache->bytes_inmem, size, "WT_CACHE.bytes_inmem");
+    __wt_conn_calc_read_load(session);
     if (is_disagg) {
         if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
             __wt_cache_decr_check_uint64(
@@ -615,8 +616,10 @@ __wt_cache_page_inmem_decr(WT_SESSION_IMPL *session, WT_PAGE *page, size_t size)
     }
     if (page->modify != NULL && !WT_PAGE_IS_INTERNAL(page))
         __wt_cache_page_byte_updates_decr(session, page, size);
-    if (__wt_page_is_modified(page))
+    if (__wt_page_is_modified(page)) {
         __wt_cache_page_byte_dirty_decr(session, page, size);
+        __wt_conn_calc_write_load(session);
+    }
     /* Track internal size in cache. */
     if (WT_PAGE_IS_INTERNAL(page)) {
         __wt_cache_decr_check_uint64(

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -360,6 +360,7 @@ __wt_cache_page_inmem_incr(WT_SESSION_IMPL *session, WT_PAGE *page, size_t size,
     bool is_disagg = __wt_conn_is_disagg(session);
 
     (void)__wt_atomic_add_uint64_relaxed(&cache->bytes_inmem, size);
+    __wt_conn_calc_read_load(session);
     if (is_disagg) {
         if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
             (void)__wt_atomic_add_uint64_relaxed(&cache->bytes_inmem_ingest, size);
@@ -413,6 +414,7 @@ __wt_cache_page_inmem_incr(WT_SESSION_IMPL *session, WT_PAGE *page, size_t size,
                 (void)__wt_atomic_add_uint64_relaxed(&btree->bytes_dirty_leaf, size);
             }
             (void)__wt_atomic_add_uint64_relaxed(&page->modify->bytes_dirty, size);
+            __wt_conn_calc_write_load(session);
         }
     }
 }

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1756,6 +1756,8 @@ extern void __wt_config_init(WT_SESSION_IMPL *session, WT_CONFIG *conf, const ch
 extern void __wt_config_initn(
   WT_SESSION_IMPL *session, WT_CONFIG *conf, const char *str, size_t len);
 extern void __wt_config_subinit(WT_SESSION_IMPL *session, WT_CONFIG *conf, WT_CONFIG_ITEM *item);
+extern void __wt_conn_calc_read_load(WT_SESSION_IMPL *session);
+extern void __wt_conn_calc_write_load(WT_SESSION_IMPL *session);
 extern void __wt_conn_config_discard(WT_SESSION_IMPL *session);
 extern void __wt_conn_foc_discard(WT_SESSION_IMPL *session);
 extern void __wt_conn_stat_init(WT_SESSION_IMPL *session);

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -1034,6 +1034,8 @@ struct __wt_connection_stats {
     int64_t live_restore_hist_source_read_latency_gt1000;
     int64_t live_restore_hist_source_read_latency_total_msecs;
     int64_t live_restore_state;
+    int64_t read_load;
+    int64_t write_load;
     int64_t lock_btree_page_count;
     int64_t lock_btree_page_wait_application;
     int64_t lock_btree_page_wait_internal;

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -7866,1072 +7866,1076 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_TOTAL_MSECS	1606
 /*! live-restore: state */
 #define	WT_STAT_CONN_LIVE_RESTORE_STATE			1607
+/*! load-control: read load at the system level */
+#define	WT_STAT_CONN_READ_LOAD				1608
+/*! load-control: write load at the system level */
+#define	WT_STAT_CONN_WRITE_LOAD				1609
 /*! lock: btree page lock acquisitions */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_COUNT		1608
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_COUNT		1610
 /*! lock: btree page lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_APPLICATION	1609
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_APPLICATION	1611
 /*! lock: btree page lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_INTERNAL	1610
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_INTERNAL	1612
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1611
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1613
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1612
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1614
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1613
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1615
 /*! lock: dhandle lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1614
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1616
 /*! lock: dhandle lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1615
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1617
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1616
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1618
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1617
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1619
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1618
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1620
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1619
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1621
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1620
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1622
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1621
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1623
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1622
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1624
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1623
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1625
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1624
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1626
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1625
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1627
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1626
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1628
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1627
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1629
 /*! lock: txn global lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1628
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1630
 /*! lock: txn global lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1629
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1631
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1630
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1632
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1631
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1633
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1632
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1634
 /*! log: force log remove time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1633
+#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1635
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1634
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1636
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1635
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1637
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1636
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1638
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1637
+#define	WT_STAT_CONN_LOG_FLUSH				1639
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1638
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1640
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1639
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1641
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1640
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1642
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1641
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1643
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1642
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1644
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1643
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1645
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1644
+#define	WT_STAT_CONN_LOG_SCANS				1646
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1645
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1647
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1646
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1648
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1647
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1649
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1648
+#define	WT_STAT_CONN_LOG_SYNC				1650
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1649
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1651
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1650
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1652
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1651
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1653
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1652
+#define	WT_STAT_CONN_LOG_WRITES				1654
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1653
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1655
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1654
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1656
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1655
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1657
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1656
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1658
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1657
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1659
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1658
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1660
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1659
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1661
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1660
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1662
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1661
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1663
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1662
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1664
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1663
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1665
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1664
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1666
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1665
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1667
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1666
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1668
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1667
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1669
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1668
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1670
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1669
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1671
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1670
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1672
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1671
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1673
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1672
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1674
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1673
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1675
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1674
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1676
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1675
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1677
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1676
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1678
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1677
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1679
 /*! perf: block manager read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT2	1678
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT2	1680
 /*! perf: block manager read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT5	1679
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT5	1681
 /*! perf: block manager read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT10	1680
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT10	1682
 /*! perf: block manager read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT50	1681
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT50	1683
 /*! perf: block manager read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT100	1682
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT100	1684
 /*! perf: block manager read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT250	1683
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT250	1685
 /*! perf: block manager read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT500	1684
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT500	1686
 /*! perf: block manager read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT1000	1685
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT1000	1687
 /*! perf: block manager read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_GT1000	1686
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_GT1000	1688
 /*! perf: block manager read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_TOTAL_MSECS	1687
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_TOTAL_MSECS	1689
 /*! perf: block manager write latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT2	1688
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT2	1690
 /*! perf: block manager write latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT5	1689
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT5	1691
 /*! perf: block manager write latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT10	1690
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT10	1692
 /*! perf: block manager write latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT50	1691
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT50	1693
 /*! perf: block manager write latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT100	1692
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT100	1694
 /*! perf: block manager write latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT250	1693
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT250	1695
 /*! perf: block manager write latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT500	1694
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT500	1696
 /*! perf: block manager write latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT1000	1695
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT1000	1697
 /*! perf: block manager write latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_GT1000	1696
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_GT1000	1698
 /*! perf: block manager write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_TOTAL_MSECS	1697
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_TOTAL_MSECS	1699
 /*! perf: disagg block manager read latency histogram (bucket 1) - 50-99us */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT100	1698
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT100	1700
 /*!
  * perf: disagg block manager read latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT250	1699
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT250	1701
 /*!
  * perf: disagg block manager read latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT500	1700
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT500	1702
 /*!
  * perf: disagg block manager read latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT1000	1701
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT1000	1703
 /*!
  * perf: disagg block manager read latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT2500	1702
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT2500	1704
 /*!
  * perf: disagg block manager read latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT5000	1703
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT5000	1705
 /*!
  * perf: disagg block manager read latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT10000	1704
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT10000	1706
 /*!
  * perf: disagg block manager read latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_GT10000	1705
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_GT10000	1707
 /*! perf: disagg block manager read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_TOTAL_USECS	1706
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_TOTAL_USECS	1708
 /*!
  * perf: disagg block manager write latency histogram (bucket 1) -
  * 50-99us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT100	1707
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT100	1709
 /*!
  * perf: disagg block manager write latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT250	1708
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT250	1710
 /*!
  * perf: disagg block manager write latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT500	1709
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT500	1711
 /*!
  * perf: disagg block manager write latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT1000	1710
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT1000	1712
 /*!
  * perf: disagg block manager write latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT2500	1711
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT2500	1713
 /*!
  * perf: disagg block manager write latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT5000	1712
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT5000	1714
 /*!
  * perf: disagg block manager write latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT10000	1713
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT10000	1715
 /*!
  * perf: disagg block manager write latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_GT10000	1714
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_GT10000	1716
 /*! perf: disagg block manager write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_TOTAL_USECS	1715
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_TOTAL_USECS	1717
 /*! perf: file system read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT2	1716
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT2	1718
 /*! perf: file system read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT5	1717
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT5	1719
 /*! perf: file system read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1718
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1720
 /*! perf: file system read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1719
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1721
 /*! perf: file system read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1720
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1722
 /*! perf: file system read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1721
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1723
 /*! perf: file system read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1722
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1724
 /*! perf: file system read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1723
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1725
 /*! perf: file system read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1724
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1726
 /*! perf: file system read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1725
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1727
 /*! perf: file system write latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT2	1726
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT2	1728
 /*! perf: file system write latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT5	1727
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT5	1729
 /*! perf: file system write latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1728
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1730
 /*! perf: file system write latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1729
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1731
 /*! perf: file system write latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1730
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1732
 /*! perf: file system write latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1731
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1733
 /*! perf: file system write latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1732
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1734
 /*! perf: file system write latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1733
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1735
 /*! perf: file system write latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1734
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1736
 /*! perf: file system write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1735
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1737
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 1) -
  * 0-100us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT100	1736
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT100	1738
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT250	1737
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT250	1739
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT500	1738
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT500	1740
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT1000	1739
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT1000	1741
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT2500	1740
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT2500	1742
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT5000	1741
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT5000	1743
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT10000	1742
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT10000	1744
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_GT10000	1743
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_GT10000	1745
 /*! perf: internal page deltas reconstruct latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_TOTAL_USECS	1744
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_TOTAL_USECS	1746
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 1) -
  * 0-100us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT100	1745
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT100	1747
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT250	1746
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT250	1748
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT500	1747
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT500	1749
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT1000	1748
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT1000	1750
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT2500	1749
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT2500	1751
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT5000	1750
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT5000	1752
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT10000	1751
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT10000	1753
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_GT10000	1752
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_GT10000	1754
 /*! perf: leaf page deltas reconstruct latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_TOTAL_USECS	1753
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_TOTAL_USECS	1755
 /*! perf: operation read latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1754
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1756
 /*! perf: operation read latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1755
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1757
 /*! perf: operation read latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1756
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1758
 /*! perf: operation read latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1757
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1759
 /*! perf: operation read latency histogram (bucket 5) - 1000-2499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT2500	1758
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT2500	1760
 /*! perf: operation read latency histogram (bucket 6) - 2500-4999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT5000	1759
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT5000	1761
 /*! perf: operation read latency histogram (bucket 7) - 5000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1760
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1762
 /*! perf: operation read latency histogram (bucket 8) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1761
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1763
 /*! perf: operation read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1762
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1764
 /*! perf: operation write latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1763
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1765
 /*! perf: operation write latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1764
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1766
 /*! perf: operation write latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1765
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1767
 /*! perf: operation write latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1766
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1768
 /*! perf: operation write latency histogram (bucket 5) - 1000-2499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT2500	1767
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT2500	1769
 /*! perf: operation write latency histogram (bucket 6) - 2500-4999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT5000	1768
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT5000	1770
 /*! perf: operation write latency histogram (bucket 7) - 5000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1769
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1771
 /*! perf: operation write latency histogram (bucket 8) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1770
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1772
 /*! perf: operation write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1771
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1773
 /*! prefetch: could not perform pre-fetch on internal page */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1772
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1774
 /*!
  * prefetch: could not perform pre-fetch on ref without the pre-fetch
  * flag set
  */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1773
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1775
 /*! prefetch: pre-fetch attempted, session has pre-fetching enabled */
-#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1774
+#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1776
 /*! prefetch: pre-fetch not repeating for recently pre-fetched ref */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1775
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1777
 /*! prefetch: pre-fetch not triggered after single disk read */
-#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1776
+#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1778
 /*! prefetch: pre-fetch not triggered as there is no valid dhandle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1777
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1779
 /*! prefetch: pre-fetch not triggered due to disk read count */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1778
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1780
 /*! prefetch: pre-fetch not triggered due to internal session */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1779
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1781
 /*! prefetch: pre-fetch not triggered due to special btree handle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1780
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1782
 /*! prefetch: pre-fetch not triggered, pre-fetch queue is full */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_QUEUE_FULL	1781
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_QUEUE_FULL	1783
 /*! prefetch: pre-fetch page not on disk when reading */
-#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1782
+#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1784
 /*! prefetch: pre-fetch pages queued */
-#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1783
+#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1785
 /*! prefetch: pre-fetch pages read in background */
-#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1784
+#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1786
 /*!
  * prefetch: pre-fetch session check passed, pre-fetch work issued to
  * btree
  */
-#define	WT_STAT_CONN_PREFETCH_ATTEMPTS_SUCCEEDED	1785
+#define	WT_STAT_CONN_PREFETCH_ATTEMPTS_SUCCEEDED	1787
 /*! prefetch: pre-fetch skipped reading in a page due to harmless error */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1786
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1788
 /*!
  * prefetch: pre-fetch skipped traversal of internal page due to active
  * split generation
  */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SPLIT_GEN	1787
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SPLIT_GEN	1789
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1788
+#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1790
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1789
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1791
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1790
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1792
 /*!
  * reconciliation: average length of delta chain on internal page with
  * deltas
  */
-#define	WT_STAT_CONN_REC_AVERAGE_INTERNAL_PAGE_DELTA_CHAIN_LENGTH	1791
+#define	WT_STAT_CONN_REC_AVERAGE_INTERNAL_PAGE_DELTA_CHAIN_LENGTH	1793
 /*! reconciliation: average length of delta chain on leaf page with deltas */
-#define	WT_STAT_CONN_REC_AVERAGE_LEAF_PAGE_DELTA_CHAIN_LENGTH	1792
+#define	WT_STAT_CONN_REC_AVERAGE_LEAF_PAGE_DELTA_CHAIN_LENGTH	1794
 /*!
  * reconciliation: changes since prior reconciliation (bucket 1) between
  * 1 and 5
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE5			1793
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE5			1795
 /*!
  * reconciliation: changes since prior reconciliation (bucket 2) between
  * 6 and 10
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE10			1794
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE10			1796
 /*!
  * reconciliation: changes since prior reconciliation (bucket 3) between
  * 11 and 20
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE20			1795
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE20			1797
 /*!
  * reconciliation: changes since prior reconciliation (bucket 4) between
  * 21 and 50
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE50			1796
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE50			1798
 /*!
  * reconciliation: changes since prior reconciliation (bucket 5) between
  * 51 and 100
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE100		1797
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE100		1799
 /*!
  * reconciliation: changes since prior reconciliation (bucket 6) between
  * 101 and 200
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE200		1798
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE200		1800
 /*!
  * reconciliation: changes since prior reconciliation (bucket 7) between
  * 201 and 500
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE500		1799
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE500		1801
 /*!
  * reconciliation: changes since prior reconciliation (bucket 8) greater
  * than 500
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_GT500		1800
+#define	WT_STAT_CONN_REC_PAGE_MODS_GT500		1802
 /*! reconciliation: cursor next/prev calls during HS wrapup search_near */
-#define	WT_STAT_CONN_REC_HS_WRAPUP_NEXT_PREV_CALLS	1801
+#define	WT_STAT_CONN_REC_HS_WRAPUP_NEXT_PREV_CALLS	1803
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1802
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1804
 /*!
  * reconciliation: free page ID due to failed page replacement
  * reconciliation in disagg
  */
-#define	WT_STAT_CONN_REC_FREE_PAGE_ID_DUE_TO_FAILED_REPLACEMENT_RECONCILIATION	1803
+#define	WT_STAT_CONN_REC_FREE_PAGE_ID_DUE_TO_FAILED_REPLACEMENT_RECONCILIATION	1805
 /*! reconciliation: full internal pages written instead of a page delta */
-#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_INTERNAL	1804
+#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_INTERNAL	1806
 /*! reconciliation: full leaf pages written instead of a page delta */
-#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_LEAF		1805
+#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_LEAF		1807
 /*!
  * reconciliation: ingest btree reconciliation keeps the aborted prepare
  * updates
  */
-#define	WT_STAT_CONN_REC_INGEST_KEEP_PREPARE_ROLLBACK	1806
+#define	WT_STAT_CONN_REC_INGEST_KEEP_PREPARE_ROLLBACK	1808
 /*! reconciliation: internal page delta keys deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_DELETED	1807
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_DELETED	1809
 /*! reconciliation: internal page delta keys updated/inserted */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_UPDATED	1808
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_UPDATED	1810
 /*! reconciliation: internal page deltas written */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL		1809
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL		1811
 /*! reconciliation: internal page multi-block writes */
-#define	WT_STAT_CONN_REC_MULTIBLOCK_INTERNAL		1810
+#define	WT_STAT_CONN_REC_MULTIBLOCK_INTERNAL		1812
 /*! reconciliation: leaf page deltas written */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_LEAF		1811
+#define	WT_STAT_CONN_REC_PAGE_DELTA_LEAF		1813
 /*! reconciliation: leaf page multi-block writes */
-#define	WT_STAT_CONN_REC_MULTIBLOCK_LEAF		1812
+#define	WT_STAT_CONN_REC_MULTIBLOCK_LEAF		1814
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1813
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1815
 /*! reconciliation: max deltas seen on internal page during reconciliation */
-#define	WT_STAT_CONN_REC_MAX_INTERNAL_PAGE_DELTAS	1814
+#define	WT_STAT_CONN_REC_MAX_INTERNAL_PAGE_DELTAS	1816
 /*! reconciliation: max deltas seen on leaf page during reconciliation */
-#define	WT_STAT_CONN_REC_MAX_LEAF_PAGE_DELTAS		1815
+#define	WT_STAT_CONN_REC_MAX_LEAF_PAGE_DELTAS		1817
 /*! reconciliation: maximum milliseconds spent in a reconciliation call */
-#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1816
+#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1818
 /*!
  * reconciliation: maximum milliseconds spent in building a disk image in
  * a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1817
+#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1819
 /*!
  * reconciliation: maximum milliseconds spent in moving updates to the
  * history store in a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1818
+#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1820
 /*!
  * reconciliation: number of keys that are garbage collected from the
  * disk images in the ingest btrees for disaggregated storage
  */
-#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_DISK_IMAGE	1819
+#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_DISK_IMAGE	1821
 /*!
  * reconciliation: number of keys that are garbage collected from the
  * update chains in the ingest btrees for disaggregated storage
  */
-#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_UPDATE_CHAIN	1820
+#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_UPDATE_CHAIN	1822
 /*! reconciliation: overflow values written */
-#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1821
+#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1823
 /*! reconciliation: page deltas rejected due to invalid page ID */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_INVALID_PAGE_ID	1822
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_INVALID_PAGE_ID	1824
 /*! reconciliation: page deltas rejected due to max consecutive limit */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MAX_CONSECUTIVE_EXCEEDED	1823
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MAX_CONSECUTIVE_EXCEEDED	1825
 /*! reconciliation: page deltas rejected due to multiblock reconciliation */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MULTIBLOCK	1824
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MULTIBLOCK	1826
 /*!
  * reconciliation: page deltas rejected due to non-single page in
  * previous reconciliation
  */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_NON_SINGLE_PAGE	1825
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_NON_SINGLE_PAGE	1827
 /*! reconciliation: page deltas rejected due to size threshold */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_SIZE_THRESHOLD	1826
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_SIZE_THRESHOLD	1828
 /*! reconciliation: page deltas rejected due to zero entries */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_ZERO_ENTRIES	1827
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_ZERO_ENTRIES	1829
 /*!
  * reconciliation: page deltas rejected: build function returned false
  * (disabled, in-memory split, or internal page constraints not met)
  */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_BUILD_FAILED	1828
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_BUILD_FAILED	1830
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1829
+#define	WT_STAT_CONN_REC_PAGES				1831
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1830
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1832
 /*! reconciliation: page reconciliation calls for pages between 1 and 10MB */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_1MB_TO_10MB		1831
+#define	WT_STAT_CONN_REC_PAGES_SIZE_1MB_TO_10MB		1833
 /*!
  * reconciliation: page reconciliation calls for pages between 10 and
  * 100MB
  */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_10MB_TO_100MB	1832
+#define	WT_STAT_CONN_REC_PAGES_SIZE_10MB_TO_100MB	1834
 /*!
  * reconciliation: page reconciliation calls for pages between 100MB and
  * 1GB
  */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_100MB_TO_1GB	1833
+#define	WT_STAT_CONN_REC_PAGES_SIZE_100MB_TO_1GB	1835
 /*! reconciliation: page reconciliation calls for pages over 1GB */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_1GB_PLUS		1834
+#define	WT_STAT_CONN_REC_PAGES_SIZE_1GB_PLUS		1836
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * prepared transaction metadata
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1835
+#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1837
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * timestamps
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1836
+#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1838
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * transaction ids
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1837
+#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1839
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1838
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1840
 /*! reconciliation: pages eligible for delta generation */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_ELIGIBLE		1839
+#define	WT_STAT_CONN_REC_PAGE_DELTA_ELIGIBLE		1841
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1840
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1842
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1841
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1843
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1842
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1844
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1843
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1845
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1844
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1846
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1845
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1847
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1846
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1848
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1847
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1849
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1848
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1850
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1849
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1851
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1850
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1852
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1851
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1853
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1852
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1854
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1853
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1855
 /*! reconciliation: pages written with at least one internal page delta */
-#define	WT_STAT_CONN_REC_PAGES_WITH_INTERNAL_DELTAS	1854
+#define	WT_STAT_CONN_REC_PAGES_WITH_INTERNAL_DELTAS	1856
 /*! reconciliation: pages written with at least one leaf page delta */
-#define	WT_STAT_CONN_REC_PAGES_WITH_LEAF_DELTAS		1855
+#define	WT_STAT_CONN_REC_PAGES_WITH_LEAF_DELTAS		1857
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1856
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1858
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1857
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1859
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1858
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1860
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1859
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1861
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1860
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1862
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1861
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1863
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1862
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1864
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1863
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1865
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1864
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1866
 /*! reconciliation: writes skipped in disaggregated storage */
-#define	WT_STAT_CONN_REC_SKIP_WRITE			1865
+#define	WT_STAT_CONN_REC_SKIP_WRITE			1867
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1866
+#define	WT_STAT_CONN_SESSION_OPEN			1868
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1867
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1869
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1868
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1870
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1869
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1871
 /*! session: table alter triggering checkpoint calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1870
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1872
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1871
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1873
 /*! session: table compact conflicted with checkpoint */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1872
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1874
 /*! session: table compact dhandle successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1873
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1875
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1874
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1876
 /*! session: table compact failed calls due to cache pressure */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1875
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1877
 /*!
  * session: table compact in-memory page footprint rewritten by
  * compaction
  */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_BYTES_REWRITE_INMEM	1876
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_BYTES_REWRITE_INMEM	1878
 /*! session: table compact passes */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1877
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1879
 /*! session: table compact pulled into eviction */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1878
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1880
 /*! session: table compact running */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1879
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1881
 /*! session: table compact skipped as process would not reduce file size */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1880
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1882
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1881
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1883
 /*! session: table compact timeout */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1882
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1884
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1883
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1885
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1884
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1886
 /*! session: table create with import failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1885
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1887
 /*! session: table create with import repair calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1886
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1888
 /*! session: table create with import successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1887
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1889
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1888
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1890
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1889
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1891
 /*! session: table publish failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_PUBLISH_FAIL		1890
+#define	WT_STAT_CONN_SESSION_TABLE_PUBLISH_FAIL		1892
 /*! session: table publish successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_PUBLISH_SUCCESS	1891
+#define	WT_STAT_CONN_SESSION_TABLE_PUBLISH_SUCCESS	1893
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1892
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1894
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1893
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1895
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1894
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1896
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1895
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1897
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1896
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1898
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1897
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1899
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1898
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1900
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1899
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1901
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1900
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1902
 /*! thread-yield: application thread operations waiting for cache */
-#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1901
+#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1903
 /*!
  * thread-yield: application thread operations waiting for interruptible
  * cache eviction
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_OPS	1902
+#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_OPS	1904
 /*!
  * thread-yield: application thread operations waiting for mandatory
  * cache eviction
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_OPS	1903
+#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_OPS	1905
 /*! thread-yield: application thread snapshot refreshed for eviction */
-#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1904
+#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1906
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1905
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1907
 /*!
  * thread-yield: application thread time waiting for interruptible cache
  * eviction (usecs)
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_TIME	1906
+#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_TIME	1908
 /*!
  * thread-yield: application thread time waiting for mandatory cache
  * eviction (usecs)
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_TIME	1907
+#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_TIME	1909
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1908
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1910
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1909
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1911
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1910
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1912
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1911
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1913
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1912
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1914
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1913
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1915
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1914
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1916
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1915
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1917
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1916
+#define	WT_STAT_CONN_PAGE_SLEEP				1918
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1917
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1919
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1918
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1920
 /*! thread-yield: page split and restart read */
-#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1919
+#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1921
 /*! thread-yield: pages skipped during read due to deleted state */
-#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1920
+#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1922
 /*!
  * tiered-storage: attempts to remove a local object and the object is in
  * use
  */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1921
+#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1923
 /*! tiered-storage: flush_tier failed calls */
-#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1922
+#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1924
 /*! tiered-storage: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1923
+#define	WT_STAT_CONN_FLUSH_TIER				1925
 /*! tiered-storage: flush_tier tables skipped due to no checkpoint */
-#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1924
+#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1926
 /*! tiered-storage: flush_tier tables switched */
-#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1925
+#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1927
 /*! tiered-storage: local objects removed */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1926
+#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1928
 /*! tiered-storage: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1927
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1929
 /*! tiered-storage: tiered operations removed without processing */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1928
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1930
 /*! tiered-storage: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1929
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1931
 /*! tiered-storage: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1930
+#define	WT_STAT_CONN_TIERED_RETENTION			1932
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1931
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1933
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1932
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1934
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1933
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1935
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1934
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1936
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1935
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1937
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1936
+#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1938
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1937
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1939
 /*! transaction: oldest transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1938
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1940
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1939
+#define	WT_STAT_CONN_TXN_PREPARE			1941
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1940
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1942
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1941
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1943
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1942
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1944
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1943
+#define	WT_STAT_CONN_TXN_QUERY_TS			1945
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1944
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1946
 /*! transaction: rollback to stable applied btrees */
-#define	WT_STAT_CONN_TXN_RTS_BTREES_APPLIED		1945
+#define	WT_STAT_CONN_TXN_RTS_BTREES_APPLIED		1947
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1946
+#define	WT_STAT_CONN_TXN_RTS				1948
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1947
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1949
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1948
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1950
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1949
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1951
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1950
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1952
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1951
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1953
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1952
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1954
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1953
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1955
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1954
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1956
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1955
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1957
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1956
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1958
 /*! transaction: rollback to stable skipped btrees */
-#define	WT_STAT_CONN_TXN_RTS_BTREES_SKIPPED		1957
+#define	WT_STAT_CONN_TXN_RTS_BTREES_SKIPPED		1959
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1958
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1960
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1959
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1961
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1960
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1962
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1961
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1963
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1962
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1964
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1963
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1965
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1964
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1966
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1965
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1967
 /*!
  * transaction: rollback to stable updates that would have been aborted
  * in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1966
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1968
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1967
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1969
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1968
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1970
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1969
+#define	WT_STAT_CONN_TXN_SET_TS				1971
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1970
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1972
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1971
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1973
 /*! transaction: set timestamp force calls */
-#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1972
+#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1974
 /*!
  * transaction: set timestamp global oldest timestamp set to be more
  * recent than the global stable timestamp
  */
-#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1973
+#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1975
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1974
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1976
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1975
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1977
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1976
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1978
 /*! transaction: set timestamp stable disaggregated schema epoch calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_DISAGG_EPOCH	1977
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_DISAGG_EPOCH	1979
 /*! transaction: set timestamp stable disaggregated schema epoch updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_DISAGG_EPOCH_UPD	1978
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_DISAGG_EPOCH_UPD	1980
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1979
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1981
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1980
+#define	WT_STAT_CONN_TXN_BEGIN				1982
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1981
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1983
 /*! transaction: transaction global checkpoint timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_CHECKPOINT_TIMESTAMP	1982
+#define	WT_STAT_CONN_TXN_GLOBAL_CHECKPOINT_TIMESTAMP	1984
 /*! transaction: transaction global durable timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_DURABLE_TIMESTAMP	1983
+#define	WT_STAT_CONN_TXN_GLOBAL_DURABLE_TIMESTAMP	1985
 /*! transaction: transaction global last running timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_LAST_RUNNING_TIMESTAMP	1984
+#define	WT_STAT_CONN_TXN_GLOBAL_LAST_RUNNING_TIMESTAMP	1986
 /*! transaction: transaction global newest timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_NEWEST_TIMESTAMP	1985
+#define	WT_STAT_CONN_TXN_GLOBAL_NEWEST_TIMESTAMP	1987
 /*! transaction: transaction global oldest timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_OLDEST_TIMESTAMP	1986
+#define	WT_STAT_CONN_TXN_GLOBAL_OLDEST_TIMESTAMP	1988
 /*! transaction: transaction global pinned timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_PINNED_TIMESTAMP	1987
+#define	WT_STAT_CONN_TXN_GLOBAL_PINNED_TIMESTAMP	1989
 /*! transaction: transaction global stable timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_STABLE_TIMESTAMP	1988
+#define	WT_STAT_CONN_TXN_GLOBAL_STABLE_TIMESTAMP	1990
 /*! transaction: transaction global version cursor timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_VERSION_CURSOR_TIMESTAMP	1989
+#define	WT_STAT_CONN_TXN_GLOBAL_VERSION_CURSOR_TIMESTAMP	1991
 /*!
  * transaction: transaction number of older readers older than oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_READERS			1990
+#define	WT_STAT_CONN_TXN_PINNED_READERS			1992
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1991
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1993
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1992
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1994
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_LAG		1993
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_LAG		1995
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT_LAG	1994
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT_LAG	1996
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER_LAG	1995
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER_LAG	1997
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1996
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1998
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1997
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1999
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1998
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	2000
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1999
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			2001
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				2000
+#define	WT_STAT_CONN_TXN_COMMIT				2002
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			2001
+#define	WT_STAT_CONN_TXN_ROLLBACK			2003
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		2002
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		2004
 
 /*!
  * @}

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -2505,6 +2505,8 @@ static const char *const __stats_connection_desc[] = {
   "live-restore: source read latency histogram (bucket 9) - 1000ms+",
   "live-restore: source read latency histogram total (msecs)",
   "live-restore: state",
+  "load-control: read load at the system level",
+  "load-control: write load at the system level",
   "lock: btree page lock acquisitions",
   "lock: btree page lock application thread wait time (usecs)",
   "lock: btree page lock internal thread wait time (usecs)",
@@ -3559,6 +3561,8 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->live_restore_hist_source_read_latency_gt1000 = 0;
     stats->live_restore_hist_source_read_latency_total_msecs = 0;
     /* not clearing live_restore_state */
+    stats->read_load = 0;
+    stats->write_load = 0;
     stats->lock_btree_page_count = 0;
     stats->lock_btree_page_wait_application = 0;
     stats->lock_btree_page_wait_internal = 0;
@@ -4746,6 +4750,8 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->live_restore_hist_source_read_latency_total_msecs +=
       WT_STAT_CONN_READ(from, live_restore_hist_source_read_latency_total_msecs);
     to->live_restore_state += WT_STAT_CONN_READ(from, live_restore_state);
+    to->read_load += WT_STAT_CONN_READ(from, read_load);
+    to->write_load += WT_STAT_CONN_READ(from, write_load);
     to->lock_btree_page_count += WT_STAT_CONN_READ(from, lock_btree_page_count);
     to->lock_btree_page_wait_application +=
       WT_STAT_CONN_READ(from, lock_btree_page_wait_application);


### PR DESCRIPTION
Add load metrics
Read_load represents 100% equivalent to eviction_trigger, cache fill ratio (default 95%)
Write_load represents 100% equivalent to eviction_dirty_trigger, cache dirty fill ratio (default 20%)

I ran the test format, and gathered the stats to verify.
