### PR TITLE
WT-17572 Make s-all dependency optional in Evergreen patch builds

### DIFF
--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -599,7 +599,7 @@ __wti_page_merge_deltas_with_base_image_leaf(WT_SESSION_IMPL *session, WT_ITEM *
     WT_ERR(__page_init_dsk_leaf_merge_state(session, btree, new_image, &disk_s));
     new_image->size = WT_PTRDIFF(disk_s.p_ptr, new_image->mem);
 
-    /* We never prefix compress
+    /* We never prefix compress aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
      the first key. */
     disk_s.key_pfx_compress = false;
     for (;;) {

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -599,8 +599,7 @@ __wti_page_merge_deltas_with_base_image_leaf(WT_SESSION_IMPL *session, WT_ITEM *
     WT_ERR(__page_init_dsk_leaf_merge_state(session, btree, new_image, &disk_s));
     new_image->size = WT_PTRDIFF(disk_s.p_ptr, new_image->mem);
 
-    /* We never prefix compress aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-     the first key. */
+    /* We never prefix compress the first key. */
     disk_s.key_pfx_compress = false;
     for (;;) {
         /* Only find next delta when needed. */

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -599,7 +599,8 @@ __wti_page_merge_deltas_with_base_image_leaf(WT_SESSION_IMPL *session, WT_ITEM *
     WT_ERR(__page_init_dsk_leaf_merge_state(session, btree, new_image, &disk_s));
     new_image->size = WT_PTRDIFF(disk_s.p_ptr, new_image->mem);
 
-    /* We never prefix compress the first key. */
+    /* We never prefix compress
+     the first key. */
     disk_s.key_pfx_compress = false;
     for (;;) {
         /* Only find next delta when needed. */

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1770,6 +1770,7 @@ tasks:
     depends_on: &s-all-dep
       - name: s-all
         variant: ubuntu2004
+        patch_optional: true
     commands:
       - func: "get project"
       - func: "compile wiredtiger"


### PR DESCRIPTION
### Summary
The s-all task runs lint and formatting validation (dist/s_all) on the ubuntu2004 variant. It is a prerequisite for ~40 tasks (compile, test suites, etc.) via the reusable s-all-dep YAML anchor in test/evergreen.yml.

Currently, every task that uses *s-all-dep has a hard dependency on s-all. In patch builds, where developers typically schedule only a subset of tasks, s-all is often not included. This causes all dependent tasks to fail with a dependency error rather than running, even when the developer has no intent to validate formatting.

### Problem

Patch builds are blocked unnecessarily when s-all is not scheduled. Developers cannot run individual compile or test tasks in a patch without also scheduling the full lint/format check.

### Change

Add patch_optional: true to the s-all-dep anchor:


```
depends_on: &s-all-dep
  - name: s-all
    variant: ubuntu2004
    status: "*"
    patch_optional: true
```
This single-line change propagates to all ~40 tasks that alias *s-all-dep.
