### PR TITLE
WT-17587 Skip test_truncate24 column-store variant under disagg hook

### DIFF
--- a/test/suite/test_truncate24.py
+++ b/test/suite/test_truncate24.py
@@ -49,6 +49,8 @@ class test_truncate24(wttest.WiredTigerTestCase):
 
     @wttest.skip_for_hook("tiered", "test depends on regular checkpoints running")
     def test_truncate24(self):
+        if self.runningHook('disagg') and self.key_format == 'r':
+            self.skipTest("disagg does not support column-store")
         uri = 'table:truncate24'
         ds = SimpleDataSet(self, uri, 0, key_format=self.key_format, value_format=self.value_format)
         ds.populate()


### PR DESCRIPTION
Skip the column-store (`var`) scenario of `test_truncate24` when running under the `disagg` hook. Disaggregated storage does not support column-store, so running this variant under the hook is invalid and can
produce spurious failures / slow tree walks.