### PR TITLE
WT-17274 Write prepared fast-truncate

### DIFF
--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -560,10 +560,16 @@ __wt_cell_build_addr(WT_SESSION_IMPL *session, WT_CELL *cell, uint8_t cell_type,
         WT_ASSERT(session, cell_type == WT_CELL_ADDR_DEL || cell_type == WT_CELL_ADDR_LEAF_NO);
         cell_type = WT_CELL_ADDR_DEL;
 
-        /* We should never be in an in-progress prepared state. */
+        /*
+         * In-progress prepared states are only written to disk when preserve_prepared is enabled,
+         * so that the prepared fast-truncate survives a restart and can be committed or rolled back
+         * during recovery.
+         */
         WT_ASSERT(session,
           page_del->prepare_state == WT_PREPARE_INIT ||
-            page_del->prepare_state == WT_PREPARE_RESOLVED);
+            page_del->prepare_state == WT_PREPARE_RESOLVED ||
+            (page_del->prepare_state == WT_PREPARE_INPROGRESS &&
+              F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED)));
     }
 
     /* Just pack and return the cell size. */
@@ -584,19 +590,36 @@ __wt_cell_pack_addr(WT_SESSION_IMPL *session, WT_CELL *cell, u_int cell_type, ui
     p = cell->__chunk;
     *p = '\0';
 
-    __cell_pack_addr_validity(session, &p, ta);
-
     /*
      * If passed fast-delete information, append the fast-delete information after the aggregated
-     * timestamp information.
+     * timestamp information. For an in-progress prepared fast-truncate (written only when
+     * preserve_prepared is enabled), use a local TA copy with prepare=1 so that
+     * __cell_pack_addr_validity emits WT_CELL_SECOND_DESC and WT_CELL_PREPARE  the signal the
+     * unpack path uses to distinguish prepared from committed fast-truncate payloads. Then encode
+     * prepare_ts and prepared_id rather than the committed-layout timestamps. For committed
+     * fast-truncates (and all other cells), use the caller's TA unchanged.
      */
     if (page_del != NULL) {
         WT_ASSERT(session, cell_type == WT_CELL_ADDR_DEL);
 
-        WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->txnid));
-        WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->pg_del_start_ts));
-        WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->pg_del_durable_ts));
-    }
+        if (page_del->prepare_state == WT_PREPARE_INPROGRESS) {
+            WT_TIME_AGGREGATE local_ta;
+            WT_TIME_AGGREGATE_COPY(&local_ta, ta);
+            local_ta.prepare = 1;
+            __cell_pack_addr_validity(session, &p, &local_ta);
+
+            WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->txnid));
+            WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->prepare_ts));
+            WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->prepared_id));
+        } else {
+            __cell_pack_addr_validity(session, &p, ta);
+
+            WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->txnid));
+            WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->pg_del_start_ts));
+            WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->pg_del_durable_ts));
+        }
+    } else
+        __cell_pack_addr_validity(session, &p, ta);
 
     if (recno == WT_RECNO_OOB)
         cell->__chunk[0] |= (uint8_t)cell_type; /* Type */

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -561,9 +561,7 @@ __wt_cell_build_addr(WT_SESSION_IMPL *session, WT_CELL *cell, uint8_t cell_type,
         cell_type = WT_CELL_ADDR_DEL;
 
         /*
-         * In-progress prepared states are only written to disk when preserve_prepared is enabled,
-         * so that the prepared fast-truncate survives a restart and can be committed or rolled back
-         * during recovery.
+         * In-progress prepared states are only written to disk when preserve_prepared is enabled
          */
         WT_ASSERT(session,
           page_del->prepare_state == WT_PREPARE_INIT ||
@@ -592,12 +590,8 @@ __wt_cell_pack_addr(WT_SESSION_IMPL *session, WT_CELL *cell, u_int cell_type, ui
 
     /*
      * If passed fast-delete information, append the fast-delete information after the aggregated
-     * timestamp information. For an in-progress prepared fast-truncate (written only when
-     * preserve_prepared is enabled), use a local TA copy with prepare=1 so that
-     * __cell_pack_addr_validity emits WT_CELL_SECOND_DESC and WT_CELL_PREPARE  the signal the
-     * unpack path uses to distinguish prepared from committed fast-truncate payloads. Then encode
-     * prepare_ts and prepared_id rather than the committed-layout timestamps. For committed
-     * fast-truncates (and all other cells), use the caller's TA unchanged.
+     * timestamp information. For an in-progress prepared fast-truncate, use a local TA copy with
+     * prepare=1.
      */
     if (page_del != NULL) {
         WT_ASSERT(session, cell_type == WT_CELL_ADDR_DEL);

--- a/src/include/timestamp_inline.h
+++ b/src/include/timestamp_inline.h
@@ -222,14 +222,23 @@
  * page of identical tombstones; this operation is equivalent to applying WT_TIME_AGGREGATE_UPDATE
  * for each tombstone. Note that it does not affect the start times.
  */
-#define WT_TIME_AGGREGATE_UPDATE_PAGE_DEL(session, ta, page_del)                          \
-    do {                                                                                  \
-        WT_ASSERT(session, (ta)->init_merge == 1);                                        \
-        (ta)->newest_stop_durable_ts =                                                    \
-          WT_MAX((page_del)->pg_del_durable_ts, (ta)->newest_stop_durable_ts);            \
-        (ta)->newest_txn = WT_MAX((page_del)->txnid, (ta)->newest_txn);                   \
-        (ta)->newest_stop_ts = WT_MAX((page_del)->pg_del_start_ts, (ta)->newest_stop_ts); \
-        (ta)->newest_stop_txn = WT_MAX((page_del)->txnid, (ta)->newest_stop_txn);         \
+#define WT_TIME_AGGREGATE_UPDATE_PAGE_DEL(session, ta, page_del)                              \
+    do {                                                                                      \
+        WT_ASSERT(session, (ta)->init_merge == 1);                                            \
+        if ((page_del)->prepare_state == WT_PREPARE_INPROGRESS) {                             \
+            (ta)->newest_stop_durable_ts =                                                    \
+              WT_MAX((page_del)->prepare_ts, (ta)->newest_stop_durable_ts);                   \
+            (ta)->newest_txn = WT_MAX((page_del)->txnid, (ta)->newest_txn);                   \
+            (ta)->newest_stop_ts = WT_MAX((page_del)->prepare_ts, (ta)->newest_stop_ts);      \
+            (ta)->newest_stop_txn = WT_MAX((page_del)->txnid, (ta)->newest_stop_txn);         \
+            (ta)->prepare = 1;                                                                \
+        } else {                                                                              \
+            (ta)->newest_stop_durable_ts =                                                    \
+              WT_MAX((page_del)->pg_del_durable_ts, (ta)->newest_stop_durable_ts);            \
+            (ta)->newest_txn = WT_MAX((page_del)->txnid, (ta)->newest_txn);                   \
+            (ta)->newest_stop_ts = WT_MAX((page_del)->pg_del_start_ts, (ta)->newest_stop_ts); \
+            (ta)->newest_stop_txn = WT_MAX((page_del)->txnid, (ta)->newest_stop_txn);         \
+        }                                                                                     \
     } while (0)
 
 /* Merge an aggregated time window into another - choosing the most conservative value from each. */

--- a/src/reconcile/rec_child.c
+++ b/src/reconcile/rec_child.c
@@ -94,6 +94,21 @@ __rec_child_deleted(
     }
 
     /*
+     * When preserve_prepared is enabled, an in-progress prepared fast-truncate must be written to
+     * disk as a proxy cell so the prepared state survives a crash and can be recovered.
+     */
+    prepare_state = __wt_atomic_load_uint8_v_acquire(&page_del->prepare_state);
+    if (!page_del->committed && prepare_state == WT_PREPARE_INPROGRESS &&
+      F_ISSET(conn, WT_CONN_PRESERVE_PREPARED)) {
+        WT_ASSERT_ALWAYS(session, !F_ISSET(r, WT_REC_EVICT),
+          "In-progress prepared fast-truncate should never be seen during eviction");
+        cmsp->del = *page_del;
+        cmsp->state = WTI_CHILD_PROXY;
+        page_del->selected_for_write = true;
+        return (0);
+    }
+
+    /*
      * The truncate may not yet be visible to us. In that case, we proceed as with any change not
      * visible during reconciliation by ignoring the change for the purposes of writing the internal
      * page.


### PR DESCRIPTION
When the preserve_prepared configuration is enabled, fast truncate operations that belong to a prepared transaction must be persisted to disk. Currently, prepared fast truncate state held in WT_PAGE_DELETED is not written out under this configuration, leaving a gap in prepared transaction durability for truncated pages.

WIP