### PR TITLE
WT-17588 Build wiredtiger-disagg switch-mode stress tests with slow truncate

### DIFF
--- a/test/evergreen_disagg.yml
+++ b/test/evergreen_disagg.yml
@@ -357,7 +357,8 @@ functions:
           ${ENABLE_CPPSUITE|} \
           ${SPINLOCK_TYPE|} \
           ${ENABLE_COLORIZE_OUTPUT|-DENABLE_COLORIZE_OUTPUT=0} \
-          ${CC_OPTIMIZE_LEVEL|}"
+          ${CC_OPTIMIZE_LEVEL|} \
+          ${WT_DISAGG_SLOW_TRUNCATE_BUILD|}"
 
         # The RHEL PPC platform does not have ZSTD. Strip it out.
         if [ "${build_variant|}" = "rhel8-ppc" ] && [[ "$DEFINED_EVERGREEN_CONFIG_FLAGS" =~ (\-DHAVE_BUILTIN_EXTENSION_ZSTD=1) ]]; then
@@ -548,7 +549,11 @@ variables:
     depends_on:
       - name: compile
     commands:
-      - func: "fetch artifacts"
+      - func: "get project"
+      # FIXME-WT-17564: Remove once proper write conflict detection is implemented on fast truncate.
+      - func: "compile wiredtiger"
+        vars:
+          WT_DISAGG_SLOW_TRUNCATE_BUILD: -DWT_DISAGG_SLOW_TRUNCATE_BUILD=1
       - func: "format test disagg"
         vars:
           format_args: disagg.mode=switch runs.timer=10:15 ops.prepare=1
@@ -559,11 +564,27 @@ variables:
     depends_on:
       - name: compile
     commands:
-      - func: "fetch artifacts"
+      - func: "get project"
+      # FIXME-WT-17564: Remove once proper write conflict detection is implemented on fast truncate.
+      - func: "compile wiredtiger"
+        vars:
+          WT_DISAGG_SLOW_TRUNCATE_BUILD: -DWT_DISAGG_SLOW_TRUNCATE_BUILD=1
       - func: "format test disagg"
         vars:
           # Validate data with a non-layered table.
           format_args: disagg.mode=switch ops.verify=1 runs.mirror=1 table1.runs.source=table table1.disagg.enabled=0 runs.timer=5:10 ops.prepare=1
+          times: 5
+
+  # Variant of format-stress-test-disagg-switch that exercises the default
+  # fast-truncate code path (uses the standard compile artifact).
+  - &format-stress-test-disagg-switch-fast-truncate
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "format test disagg"
+        vars:
+          format_args: disagg.mode=switch runs.timer=10:15 ops.prepare=1
           times: 5
 
   - &format-stress-test-disagg-multi
@@ -673,6 +694,15 @@ tasks:
     tags: ["stress-test-disagg-fail"]
   - <<: *format-stress-test-disagg-switch-data-validation
     name: format-stress-test-disagg-switch-data-validation-3
+    tags: ["stress-test-disagg-fail"]
+  - <<: *format-stress-test-disagg-switch-fast-truncate
+    name: format-stress-test-disagg-switch-fast-truncate-1
+    tags: ["stress-test-disagg-fail", "stress-test-disagg-san-fail"]
+  - <<: *format-stress-test-disagg-switch-fast-truncate
+    name: format-stress-test-disagg-switch-fast-truncate-2
+    tags: ["stress-test-disagg-fail"]
+  - <<: *format-stress-test-disagg-switch-fast-truncate
+    name: format-stress-test-disagg-switch-fast-truncate-3
     tags: ["stress-test-disagg-fail"]
   - <<: *format-stress-test-disagg-multi
     name: format-stress-test-disagg-multi-1

--- a/test/evergreen_disagg.yml
+++ b/test/evergreen_disagg.yml
@@ -584,7 +584,8 @@ variables:
       - func: "fetch artifacts"
       - func: "format test disagg"
         vars:
-          format_args: disagg.mode=switch runs.timer=10:15 ops.prepare=1
+          # FIXME-WT-17380: Enable prepare for switch mode once failures are resolved.
+          format_args: disagg.mode=switch runs.timer=10:15 ops.prepare=0 ops.verify=1 runs.mirror=1
           times: 5
 
   - &format-stress-test-disagg-multi

--- a/test/evergreen_disagg.yml
+++ b/test/evergreen_disagg.yml
@@ -698,12 +698,6 @@ tasks:
   - <<: *format-stress-test-disagg-switch-fast-truncate
     name: format-stress-test-disagg-switch-fast-truncate-1
     tags: ["stress-test-disagg-fail", "stress-test-disagg-san-fail"]
-  - <<: *format-stress-test-disagg-switch-fast-truncate
-    name: format-stress-test-disagg-switch-fast-truncate-2
-    tags: ["stress-test-disagg-fail"]
-  - <<: *format-stress-test-disagg-switch-fast-truncate
-    name: format-stress-test-disagg-switch-fast-truncate-3
-    tags: ["stress-test-disagg-fail"]
   - <<: *format-stress-test-disagg-multi
     name: format-stress-test-disagg-multi-1
     tags: ["stress-test-disagg-fail", "stress-test-disagg-san-fail"]


### PR DESCRIPTION
## Summary
- Thread `WT_DISAGG_SLOW_TRUNCATE_BUILD` through the `wiredtiger-disagg` project's `configure wiredtiger` function so the flag is honored when supplied (mirrors `test/evergreen.yml`).
- Switch `format-stress-test-disagg-switch` and `format-stress-test-disagg-switch-data-validation` to do their own inline `compile wiredtiger` step with `WT_DISAGG_SLOW_TRUNCATE_BUILD=1` instead of fetching the default fast-truncate artifact. This matches the disagg switch-mode setup already in `test/evergreen.yml` and addresses the assertion failures seen on `format-stress-test-disagg-switch-*` (WT-17588).
- Add one `format-stress-test-disagg-switch-fast-truncate-1` task so the default fast-truncate path still has switch-mode coverage in this project.
