### PR TITLE
WT-17592 (disagg.mode=switch) Serialise fast truncate lock in test/format

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1783,6 +1783,42 @@ variables:
           format_args: disagg.mode=switch ops.prepare=0 runs.timer=3
           times: 1
 
+  # Switch mode with fast truncate (the default build option). Exercises the test/format
+  # truncate_lock (test/format/ops.c) by emphasizing truncate ops alongside disagg switching.
+  - &format-stress-test-disagg-switch-fast-truncate
+    depends_on: *s-all-dep
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+      - func: "format test script"
+        vars:
+          # FIXME-WT-17380: Enable prepare for switch mode once failures are resolved.
+          format_test_script_args: -t 180 -c ../../../test/format/CONFIG.disagg -- disagg.mode=switch ops.prepare=0 ops.truncate=1 runs.timer=5:10
+          num_jobs: 1 # FIXME-WT-16134 PALite cannot run multiple jobs. PALI will address this.
+      - func: "format test disagg"
+        vars:
+          # FIXME-WT-17380: Enable prepare for switch mode once failures are resolved.
+          format_args: disagg.mode=switch ops.prepare=0 ops.truncate=1 runs.timer=5:10
+          times: 5
+
+  # FIXME-WT-16113: Consolidate this logic in test/format itself.
+  - &format-stress-test-disagg-switch-fast-truncate-data-validation
+    depends_on: *s-all-dep
+    commands:
+      - func: "get project"
+      - func: "compile wiredtiger"
+      - func: "format test script"
+        vars:
+          # FIXME-WT-17380: Enable prepare for switch mode once failures are resolved.
+          format_test_script_args: -t 180 -c ../../../test/format/CONFIG.disagg -- disagg.mode=switch ops.prepare=0 ops.truncate=1 ops.verify=1 runs.mirror=1 table1.runs.source=table table1.disagg.enabled=0 runs.timer=5:10
+          num_jobs: 1 # FIXME-WT-16134 PALite cannot run multiple jobs. PALI will address this.
+      - func: "format test disagg"
+        vars:
+          # Validate data with a non-layered table.
+          # FIXME-WT-17380: Enable prepare for switch mode once failures are resolved.
+          format_args: disagg.mode=switch ops.prepare=0 ops.truncate=1 ops.verify=1 runs.mirror=1 table1.runs.source=table table1.disagg.enabled=0 runs.timer=5:10
+          times: 5
+
 #######################################
 #               Tasks                 #
 #######################################
@@ -5284,6 +5320,19 @@ tasks:
   - <<: *format-stress-test-disagg-switch-pull-request
     name: format-stress-test-disagg-switch-pull-request-2
     tags: ["pull_request"]
+
+  - <<: *format-stress-test-disagg-switch-fast-truncate
+    name: format-stress-test-disagg-switch-fast-truncate-1
+    tags: ["stress-test-disagg"]
+  - <<: *format-stress-test-disagg-switch-fast-truncate
+    name: format-stress-test-disagg-switch-fast-truncate-2
+    tags: ["stress-test-disagg"]
+  - <<: *format-stress-test-disagg-switch-fast-truncate-data-validation
+    name: format-stress-test-disagg-switch-fast-truncate-validation-1
+    tags: ["stress-test-disagg"]
+  - <<: *format-stress-test-disagg-switch-fast-truncate-data-validation
+    name: format-stress-test-disagg-switch-fast-truncate-validation-2
+    tags: ["stress-test-disagg"]
 
   - name: format-stress-test-disagg-follower-pull-request
     tags: ["pull_request"]

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1786,10 +1786,10 @@ variables:
   # Switch mode with fast truncate (the default build option). Exercises the test/format
   # truncate_lock (test/format/ops.c) by emphasizing truncate ops alongside disagg switching.
   - &format-stress-test-disagg-switch-fast-truncate
-    depends_on: *s-all-dep
+    depends_on:
+      - name: compile
     commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
+      - func: "fetch artifacts"
       - func: "format test script"
         vars:
           # FIXME-WT-17380: Enable prepare for switch mode once failures are resolved.
@@ -1803,10 +1803,10 @@ variables:
 
   # FIXME-WT-16113: Consolidate this logic in test/format itself.
   - &format-stress-test-disagg-switch-fast-truncate-data-validation
-    depends_on: *s-all-dep
+    depends_on:
+      - name: compile
     commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
+      - func: "fetch artifacts"
       - func: "format test script"
         vars:
           # FIXME-WT-17380: Enable prepare for switch mode once failures are resolved.

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1791,12 +1791,12 @@ variables:
       - func: "format test script"
         vars:
           # FIXME-WT-17380: Enable prepare for switch mode once failures are resolved.
-          format_test_script_args: -t 180 -c ../../../test/format/CONFIG.disagg -- disagg.mode=switch ops.prepare=0 ops.truncate=1 runs.timer=5:10 runs.threads=4:16
+          format_test_script_args: -t 180 -c ../../../test/format/CONFIG.disagg -- disagg.mode=switch ops.prepare=0 ops.truncate=1 runs.timer=5:10 runs.threads=4:12
           num_jobs: 1 # FIXME-WT-16134 PALite cannot run multiple jobs. PALI will address this.
       - func: "format test disagg"
         vars:
           # FIXME-WT-17380: Enable prepare for switch mode once failures are resolved.
-          format_args: disagg.mode=switch ops.prepare=0 ops.truncate=1 runs.timer=5:10 runs.threads=4:16
+          format_args: disagg.mode=switch ops.prepare=0 ops.truncate=1 runs.timer=5:10 runs.threads=4:12
           times: 5
 
   # FIXME-WT-16113: Consolidate this logic in test/format itself.
@@ -1808,13 +1808,13 @@ variables:
       - func: "format test script"
         vars:
           # FIXME-WT-17380: Enable prepare for switch mode once failures are resolved.
-          format_test_script_args: -t 180 -c ../../../test/format/CONFIG.disagg -- disagg.mode=switch ops.prepare=0 ops.truncate=1 ops.verify=1 runs.mirror=1 table1.runs.source=table table1.disagg.enabled=0 runs.timer=5:10 runs.threads=4:16
+          format_test_script_args: -t 180 -c ../../../test/format/CONFIG.disagg -- disagg.mode=switch ops.prepare=0 ops.truncate=1 ops.verify=1 runs.mirror=1 table1.runs.source=table table1.disagg.enabled=0 runs.timer=5:10 runs.threads=4:12
           num_jobs: 1 # FIXME-WT-16134 PALite cannot run multiple jobs. PALI will address this.
       - func: "format test disagg"
         vars:
           # Validate data with a non-layered table.
           # FIXME-WT-17380: Enable prepare for switch mode once failures are resolved.
-          format_args: disagg.mode=switch ops.prepare=0 ops.truncate=1 ops.verify=1 runs.mirror=1 table1.runs.source=table table1.disagg.enabled=0 runs.timer=5:10 runs.threads=4:16
+          format_args: disagg.mode=switch ops.prepare=0 ops.truncate=1 ops.verify=1 runs.mirror=1 table1.runs.source=table table1.disagg.enabled=0 runs.timer=5:10 runs.threads=4:12
           times: 5
 
 #######################################

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1710,8 +1710,7 @@ variables:
           times: 1
 
   - &s-all-dep
-    - &s-all-dep-item
-      name: s-all
+    - name: s-all
       variant: ubuntu2004
       patch_optional: true
 
@@ -1789,7 +1788,6 @@ variables:
   - &format-stress-test-disagg-switch-fast-truncate
     depends_on:
       - name: compile
-      - *s-all-dep-item
     commands:
       - func: "fetch artifacts"
       - func: "format test script"
@@ -1807,7 +1805,6 @@ variables:
   - &format-stress-test-disagg-switch-fast-truncate-data-validation
     depends_on:
       - name: compile
-      - *s-all-dep-item
     commands:
       - func: "fetch artifacts"
       - func: "format test script"

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1710,7 +1710,8 @@ variables:
           times: 1
 
   - &s-all-dep
-    - name: s-all
+    - &s-all-dep-item
+      name: s-all
       variant: ubuntu2004
       patch_optional: true
 
@@ -1788,9 +1789,7 @@ variables:
   - &format-stress-test-disagg-switch-fast-truncate
     depends_on:
       - name: compile
-      - name: s-all
-        variant: ubuntu2004
-        patch_optional: true
+      - *s-all-dep-item
     commands:
       - func: "fetch artifacts"
       - func: "format test script"
@@ -1808,9 +1807,7 @@ variables:
   - &format-stress-test-disagg-switch-fast-truncate-data-validation
     depends_on:
       - name: compile
-      - name: s-all
-        variant: ubuntu2004
-        patch_optional: true
+      - *s-all-dep-item
     commands:
       - func: "fetch artifacts"
       - func: "format test script"

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1791,12 +1791,12 @@ variables:
       - func: "format test script"
         vars:
           # FIXME-WT-17380: Enable prepare for switch mode once failures are resolved.
-          format_test_script_args: -t 180 -c ../../../test/format/CONFIG.disagg -- disagg.mode=switch ops.prepare=0 ops.truncate=1 runs.timer=5:10
+          format_test_script_args: -t 180 -c ../../../test/format/CONFIG.disagg -- disagg.mode=switch ops.prepare=0 ops.truncate=1 runs.timer=5:10 runs.threads=4:16
           num_jobs: 1 # FIXME-WT-16134 PALite cannot run multiple jobs. PALI will address this.
       - func: "format test disagg"
         vars:
           # FIXME-WT-17380: Enable prepare for switch mode once failures are resolved.
-          format_args: disagg.mode=switch ops.prepare=0 ops.truncate=1 runs.timer=5:10
+          format_args: disagg.mode=switch ops.prepare=0 ops.truncate=1 runs.timer=5:10 runs.threads=4:16
           times: 5
 
   # FIXME-WT-16113: Consolidate this logic in test/format itself.
@@ -1808,13 +1808,13 @@ variables:
       - func: "format test script"
         vars:
           # FIXME-WT-17380: Enable prepare for switch mode once failures are resolved.
-          format_test_script_args: -t 180 -c ../../../test/format/CONFIG.disagg -- disagg.mode=switch ops.prepare=0 ops.truncate=1 ops.verify=1 runs.mirror=1 table1.runs.source=table table1.disagg.enabled=0 runs.timer=5:10
+          format_test_script_args: -t 180 -c ../../../test/format/CONFIG.disagg -- disagg.mode=switch ops.prepare=0 ops.truncate=1 ops.verify=1 runs.mirror=1 table1.runs.source=table table1.disagg.enabled=0 runs.timer=5:10 runs.threads=4:16
           num_jobs: 1 # FIXME-WT-16134 PALite cannot run multiple jobs. PALI will address this.
       - func: "format test disagg"
         vars:
           # Validate data with a non-layered table.
           # FIXME-WT-17380: Enable prepare for switch mode once failures are resolved.
-          format_args: disagg.mode=switch ops.prepare=0 ops.truncate=1 ops.verify=1 runs.mirror=1 table1.runs.source=table table1.disagg.enabled=0 runs.timer=5:10
+          format_args: disagg.mode=switch ops.prepare=0 ops.truncate=1 ops.verify=1 runs.mirror=1 table1.runs.source=table table1.disagg.enabled=0 runs.timer=5:10 runs.threads=4:16
           times: 5
 
 #######################################

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1783,8 +1783,6 @@ variables:
           format_args: disagg.mode=switch ops.prepare=0 runs.timer=3
           times: 1
 
-  # Switch mode with fast truncate (the default build option). Exercises the test/format
-  # truncate_lock (test/format/ops.c) by emphasizing truncate ops alongside disagg switching.
   - &format-stress-test-disagg-switch-fast-truncate
     depends_on:
       - name: compile
@@ -5320,18 +5318,11 @@ tasks:
   - <<: *format-stress-test-disagg-switch-pull-request
     name: format-stress-test-disagg-switch-pull-request-2
     tags: ["pull_request"]
-
   - <<: *format-stress-test-disagg-switch-fast-truncate
-    name: format-stress-test-disagg-switch-fast-truncate-1
-    tags: ["stress-test-disagg"]
-  - <<: *format-stress-test-disagg-switch-fast-truncate
-    name: format-stress-test-disagg-switch-fast-truncate-2
+    name: format-stress-test-disagg-switch-fast-truncate
     tags: ["stress-test-disagg"]
   - <<: *format-stress-test-disagg-switch-fast-truncate-data-validation
-    name: format-stress-test-disagg-switch-fast-truncate-validation-1
-    tags: ["stress-test-disagg"]
-  - <<: *format-stress-test-disagg-switch-fast-truncate-data-validation
-    name: format-stress-test-disagg-switch-fast-truncate-validation-2
+    name: format-stress-test-disagg-switch-fast-truncate-validation
     tags: ["stress-test-disagg"]
 
   - name: format-stress-test-disagg-follower-pull-request

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1788,6 +1788,9 @@ variables:
   - &format-stress-test-disagg-switch-fast-truncate
     depends_on:
       - name: compile
+      - name: s-all
+        variant: ubuntu2004
+        patch_optional: true
     commands:
       - func: "fetch artifacts"
       - func: "format test script"
@@ -1805,6 +1808,9 @@ variables:
   - &format-stress-test-disagg-switch-fast-truncate-data-validation
     depends_on:
       - name: compile
+      - name: s-all
+        variant: ubuntu2004
+        patch_optional: true
     commands:
       - func: "fetch artifacts"
       - func: "format test script"

--- a/test/evergreen_disagg.yml
+++ b/test/evergreen_disagg.yml
@@ -566,29 +566,6 @@ variables:
           format_args: disagg.mode=switch ops.verify=1 runs.mirror=1 table1.runs.source=table table1.disagg.enabled=0 runs.timer=5:10 ops.prepare=1
           times: 5
 
-  # Switch mode with fast truncate. Fast truncate is the default build option, so this exercises
-  # the format truncate_lock (see test/format/ops.c) by forcing truncates to be selected.
-  - &format-stress-test-disagg-switch-fast-truncate
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "format test disagg"
-        vars:
-          format_args: disagg.mode=switch ops.truncate=1 runs.timer=10:15 ops.prepare=1
-          times: 5
-
-  - &format-stress-test-disagg-switch-fast-truncate-data-validation
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "format test disagg"
-        vars:
-          # Validate data with a non-layered table.
-          format_args: disagg.mode=switch ops.truncate=1 ops.verify=1 runs.mirror=1 table1.runs.source=table table1.disagg.enabled=0 runs.timer=5:10 ops.prepare=1
-          times: 5
-
   - &format-stress-test-disagg-multi
     depends_on:
       - name: compile
@@ -696,24 +673,6 @@ tasks:
     tags: ["stress-test-disagg-fail"]
   - <<: *format-stress-test-disagg-switch-data-validation
     name: format-stress-test-disagg-switch-data-validation-3
-    tags: ["stress-test-disagg-fail"]
-  - <<: *format-stress-test-disagg-switch-fast-truncate
-    name: format-stress-test-disagg-switch-fast-truncate-1
-    tags: ["stress-test-disagg-fail"]
-  - <<: *format-stress-test-disagg-switch-fast-truncate
-    name: format-stress-test-disagg-switch-fast-truncate-2
-    tags: ["stress-test-disagg-fail"]
-  - <<: *format-stress-test-disagg-switch-fast-truncate
-    name: format-stress-test-disagg-switch-fast-truncate-3
-    tags: ["stress-test-disagg-fail"]
-  - <<: *format-stress-test-disagg-switch-fast-truncate-data-validation
-    name: format-stress-test-disagg-switch-fast-truncate-validation-1
-    tags: ["stress-test-disagg-fail"]
-  - <<: *format-stress-test-disagg-switch-fast-truncate-data-validation
-    name: format-stress-test-disagg-switch-fast-truncate-validation-2
-    tags: ["stress-test-disagg-fail"]
-  - <<: *format-stress-test-disagg-switch-fast-truncate-data-validation
-    name: format-stress-test-disagg-switch-fast-truncate-validation-3
     tags: ["stress-test-disagg-fail"]
   - <<: *format-stress-test-disagg-multi
     name: format-stress-test-disagg-multi-1

--- a/test/evergreen_disagg.yml
+++ b/test/evergreen_disagg.yml
@@ -566,6 +566,29 @@ variables:
           format_args: disagg.mode=switch ops.verify=1 runs.mirror=1 table1.runs.source=table table1.disagg.enabled=0 runs.timer=5:10 ops.prepare=1
           times: 5
 
+  # Switch mode with fast truncate. Fast truncate is the default build option, so this exercises
+  # the format truncate_lock (see test/format/ops.c) by forcing truncates to be selected.
+  - &format-stress-test-disagg-switch-fast-truncate
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "format test disagg"
+        vars:
+          format_args: disagg.mode=switch ops.truncate=1 runs.timer=10:15 ops.prepare=1
+          times: 5
+
+  - &format-stress-test-disagg-switch-fast-truncate-data-validation
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "format test disagg"
+        vars:
+          # Validate data with a non-layered table.
+          format_args: disagg.mode=switch ops.truncate=1 ops.verify=1 runs.mirror=1 table1.runs.source=table table1.disagg.enabled=0 runs.timer=5:10 ops.prepare=1
+          times: 5
+
   - &format-stress-test-disagg-multi
     depends_on:
       - name: compile
@@ -673,6 +696,24 @@ tasks:
     tags: ["stress-test-disagg-fail"]
   - <<: *format-stress-test-disagg-switch-data-validation
     name: format-stress-test-disagg-switch-data-validation-3
+    tags: ["stress-test-disagg-fail"]
+  - <<: *format-stress-test-disagg-switch-fast-truncate
+    name: format-stress-test-disagg-switch-fast-truncate-1
+    tags: ["stress-test-disagg-fail"]
+  - <<: *format-stress-test-disagg-switch-fast-truncate
+    name: format-stress-test-disagg-switch-fast-truncate-2
+    tags: ["stress-test-disagg-fail"]
+  - <<: *format-stress-test-disagg-switch-fast-truncate
+    name: format-stress-test-disagg-switch-fast-truncate-3
+    tags: ["stress-test-disagg-fail"]
+  - <<: *format-stress-test-disagg-switch-fast-truncate-data-validation
+    name: format-stress-test-disagg-switch-fast-truncate-validation-1
+    tags: ["stress-test-disagg-fail"]
+  - <<: *format-stress-test-disagg-switch-fast-truncate-data-validation
+    name: format-stress-test-disagg-switch-fast-truncate-validation-2
+    tags: ["stress-test-disagg-fail"]
+  - <<: *format-stress-test-disagg-switch-fast-truncate-data-validation
+    name: format-stress-test-disagg-switch-fast-truncate-validation-3
     tags: ["stress-test-disagg-fail"]
   - <<: *format-stress-test-disagg-multi
     name: format-stress-test-disagg-multi-1

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -263,10 +263,10 @@ typedef struct {
     RWLOCK backup_lock; /* Backup running */
 
     /*
-     * Only acquired in disagg "switch" mode. TRUNCATE takes the write lock; other
-     * writers take the read lock; readers bypass. Both lock types are held from begin_transaction*
-     * through commit/rollback so that TRUNCATE's wrlock-wait drains every in-flight writer's
-     * commit before TRUNCATE's snapshot is taken.
+     * Only acquired in disagg "switch" mode. TRUNCATE takes the write lock; other writers take the
+     * read lock; readers bypass. Both lock types are held from begin_transaction* through
+     * commit/rollback so that TRUNCATE's wrlock-wait drains every in-flight writer's commit before
+     * TRUNCATE's snapshot is taken.
      */
     RWLOCK truncate_lock;
     uint64_t backup_id; /* Block incremental id */

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -263,10 +263,9 @@ typedef struct {
     RWLOCK backup_lock; /* Backup running */
 
     /*
-     * Only acquired in disagg "switch" mode. TRUNCATE takes the write lock; other writers take the
-     * read lock; readers bypass. Both lock types are held from begin_transaction* through
-     * commit/rollback so that TRUNCATE's wrlock-wait drains every in-flight writer's commit before
-     * TRUNCATE's snapshot is taken.
+     * Only acquired in disagg "switch" mode. Truncate takes the write lock; other writers take the
+     * read lock; readers bypass. Both lock types are held from begin_transaction through
+     * commit/rollback so that truncate operations drain every in-flight writer's commit.
      */
     RWLOCK truncate_lock;
     uint64_t backup_id; /* Block incremental id */

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -263,13 +263,10 @@ typedef struct {
     RWLOCK backup_lock; /* Backup running */
 
     /*
-     * Only acquired in disagg "switch" mode (see disagg_is_mode_switch). Truncates run with the
-     * write lock; every other read/write operation runs with the read lock. Truncates are
-     * therefore mutually exclusive with all other ops across all tables. Needed because the
-     * follower-side truncate path doesn't symmetrically conflict-check against concurrent writes
-     * inside its range: a write that allocated its txn id after the truncate transaction did but
-     * committed at an earlier timestamp can leave drain with a txn-id-inverted chain on stable,
-     * tripping __timestamp_no_ts_fix during reconcile.
+     * Only acquired in disagg "switch" mode. TRUNCATE takes the write lock; other
+     * writers take the read lock; readers bypass. Both lock types are held from begin_transaction*
+     * through commit/rollback so that TRUNCATE's wrlock-wait drains every in-flight writer's
+     * commit before TRUNCATE's snapshot is taken.
      */
     RWLOCK truncate_lock;
     uint64_t backup_id; /* Block incremental id */

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -261,6 +261,16 @@ typedef struct {
     bool background_compaction_running; /* Background compaction running */
 
     RWLOCK backup_lock; /* Backup running */
+
+    /*
+     * Truncates run with the write lock; every other read/write operation runs with the read lock.
+     * Truncates are therefore mutually exclusive with all other ops across all tables. Needed for
+     * layered/disagg runs where a follower-side truncate doesn't symmetrically conflict-check
+     * against concurrent writes inside its range: a write that allocated its txn id after the
+     * truncate transaction did but committed at an earlier timestamp can leave drain with a
+     * txn-id-inverted chain on stable, tripping __timestamp_no_ts_fix during reconcile.
+     */
+    RWLOCK truncate_lock;
     uint64_t backup_id; /* Block incremental id */
     bool backup_incr;   /* Incremental backup */
     bool backup_verify; /* Verifying backup */

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -263,12 +263,13 @@ typedef struct {
     RWLOCK backup_lock; /* Backup running */
 
     /*
-     * Truncates run with the write lock; every other read/write operation runs with the read lock.
-     * Truncates are therefore mutually exclusive with all other ops across all tables. Needed for
-     * layered/disagg runs where a follower-side truncate doesn't symmetrically conflict-check
-     * against concurrent writes inside its range: a write that allocated its txn id after the
-     * truncate transaction did but committed at an earlier timestamp can leave drain with a
-     * txn-id-inverted chain on stable, tripping __timestamp_no_ts_fix during reconcile.
+     * Only acquired in disagg "switch" mode (see disagg_is_mode_switch). Truncates run with the
+     * write lock; every other read/write operation runs with the read lock. Truncates are
+     * therefore mutually exclusive with all other ops across all tables. Needed because the
+     * follower-side truncate path doesn't symmetrically conflict-check against concurrent writes
+     * inside its range: a write that allocated its txn id after the truncate transaction did but
+     * committed at an earlier timestamp can leave drain with a txn-id-inverted chain on stable,
+     * tripping __timestamp_no_ts_fix during reconcile.
      */
     RWLOCK truncate_lock;
     uint64_t backup_id; /* Block incremental id */

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -263,11 +263,10 @@ typedef struct {
     RWLOCK backup_lock; /* Backup running */
 
     /*
-     * Only acquired in disagg "switch" mode. Truncate takes the write lock; other writers take the
-     * read lock; readers bypass. Both lock types are held from begin_transaction through
-     * commit/rollback so that truncate operations drain every in-flight writer's commit.
+     * Serializes fast truncate against other writers in disagg switch mode. Truncate takes the
+     * write lock, other writers take the read lock, readers bypass.
      */
-    RWLOCK truncate_lock;
+    RWLOCK fast_truncate_lock;
     uint64_t backup_id; /* Block incremental id */
     bool backup_incr;   /* Incremental backup */
     bool backup_verify; /* Verifying backup */

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -1349,11 +1349,11 @@ rollback_retry:
         }
 
         /*
-         * Switch-mode only, fast-truncate only: TRUNCATE is the writer -- it commits any
-         * in-flight txn, drops its reader lock, takes the writer lock and re-begins under it so
-         * its snapshot drains every concurrent reader's commit. Every other write op is a reader.
-         * Reads bypass. The slow-truncate path doesn't hit the engine gap we're working around,
-         * so leave it on the original code path with no lock activity.
+         * Switch-mode only, fast-truncate only: TRUNCATE is the writer -- it commits any in-flight
+         * txn, drops its reader lock, takes the writer lock and re-begins under it so its snapshot
+         * drains every concurrent reader's commit. Every other write op is a reader. Reads bypass.
+         * The slow-truncate path doesn't hit the engine gap we're working around, so leave it on
+         * the original code path with no lock activity.
          */
         if (disagg_is_mode_switch() && !__wt_process.disagg_slow_truncate_2026) {
             if (op == TRUNCATE) {

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -1015,7 +1015,7 @@ ops(void *arg)
     uint32_t max_rows, ntries, range, rnd;
     u_int i, throttle_delay_max;
     const char *iso_config;
-    bool greater_than, intxn, prepared, mirrored_truncate;
+    bool greater_than, intxn, op_lock_held, prepared, mirrored_truncate;
 
     tinfo = arg;
     mirrored_truncate = false;
@@ -1065,6 +1065,7 @@ ops(void *arg)
 rollback_retry:
         prepared = false;
         mirrored_truncate = false;
+        op_lock_held = false;
         if (tinfo->quit)
             break;
 
@@ -1300,6 +1301,17 @@ rollback_retry:
             modify_build(tinfo);
         }
 
+        /*
+         * Truncates are mutually exclusive with all other read/write ops across all tables -- see
+         * the comment on g.truncate_lock for the rationale. Held for the duration of this op
+         * iteration (including mirrors) and released at skip_operation / the rollback label.
+         */
+        if (op == TRUNCATE)
+            lock_writelock(session, &g.truncate_lock);
+        else
+            lock_readlock(session, &g.truncate_lock);
+        op_lock_held = true;
+
         ret = 0;
         skip1 = skip2 = NULL;
         if (op == MODIFY && table->mirror) {
@@ -1354,6 +1366,15 @@ rollback_retry:
         }
 skip_operation:
         table = tinfo->table = NULL;
+
+        /* Release the per-op truncate lock if still held. */
+        if (op_lock_held) {
+            if (op == TRUNCATE)
+                lock_writeunlock(session, &g.truncate_lock);
+            else
+                lock_readunlock(session, &g.truncate_lock);
+            op_lock_held = false;
+        }
 
         /* Release the truncate operation counter. */
         if (op == TRUNCATE)
@@ -1431,6 +1452,17 @@ skip_operation:
             break;
         case 5: /* 10% */
 rollback:
+            /*
+             * If we jumped here from inside the op execution block (before reaching
+             * skip_operation), the per-op truncate lock is still held -- release it now.
+             */
+            if (op_lock_held) {
+                if (op == TRUNCATE)
+                    lock_writeunlock(session, &g.truncate_lock);
+                else
+                    lock_readunlock(session, &g.truncate_lock);
+                op_lock_held = false;
+            }
             if (GV(RUNS_PREDICTABLE_REPLAY)) {
                 if (tinfo->quit)
                     goto loop_exit;

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -999,46 +999,46 @@ ops_session_open(TINFO *tinfo)
 }
 
 /* Per-thread tracking of which mode of the truncate lock this thread holds, if any. */
-typedef enum { LOCK_HELD_NONE, LOCK_HELD_READ, LOCK_HELD_WRITE } truncate_lock_state_t;
+typedef enum { LOCK_HELD_NONE, LOCK_HELD_READ, LOCK_HELD_WRITE } fast_truncate_lock_state_t;
 
 /*
- * truncate_lock_acquire_read --
- *     Acquire g.truncate_lock for a non-TRUNCATE write under switch mode. No-op otherwise.
+ * fast_truncate_lock_acquire_read --
+ *     Acquire g.fast_truncate_lock for a non-TRUNCATE write under switch mode. No-op otherwise.
  */
 static WT_INLINE void
-truncate_lock_acquire_read(WT_SESSION *session, truncate_lock_state_t *state)
+fast_truncate_lock_acquire_read(WT_SESSION *session, fast_truncate_lock_state_t *state)
 {
     if (disagg_is_mode_switch() && *state == LOCK_HELD_NONE) {
-        lock_readlock(session, &g.truncate_lock);
+        lock_readlock(session, &g.fast_truncate_lock);
         *state = LOCK_HELD_READ;
     }
 }
 
 /*
- * truncate_lock_acquire_write --
- *     Acquire g.truncate_lock exclusively for a TRUNCATE under switch mode. Caller must have
+ * fast_truncate_lock_acquire_write --
+ *     Acquire g.fast_truncate_lock exclusively for a TRUNCATE under switch mode. Caller must have
  *     released any held rdlock first (otherwise this is a self-deadlock).
  */
 static WT_INLINE void
-truncate_lock_acquire_write(WT_SESSION *session, truncate_lock_state_t *state)
+fast_truncate_lock_acquire_write(WT_SESSION *session, fast_truncate_lock_state_t *state)
 {
     if (disagg_is_mode_switch() && *state == LOCK_HELD_NONE) {
-        lock_writelock(session, &g.truncate_lock);
+        lock_writelock(session, &g.fast_truncate_lock);
         *state = LOCK_HELD_WRITE;
     }
 }
 
 /*
- * truncate_lock_release --
- *     Release g.truncate_lock, dispatching by held mode. No-op if not held.
+ * fast_truncate_lock_release --
+ *     Release g.fast_truncate_lock, dispatching by held mode. No-op if not held.
  */
 static WT_INLINE void
-truncate_lock_release(WT_SESSION *session, truncate_lock_state_t *state)
+fast_truncate_lock_release(WT_SESSION *session, fast_truncate_lock_state_t *state)
 {
     if (*state == LOCK_HELD_READ)
-        lock_readunlock(session, &g.truncate_lock);
+        lock_readunlock(session, &g.fast_truncate_lock);
     else if (*state == LOCK_HELD_WRITE)
-        lock_writeunlock(session, &g.truncate_lock);
+        lock_writeunlock(session, &g.fast_truncate_lock);
     *state = LOCK_HELD_NONE;
 }
 
@@ -1060,7 +1060,7 @@ ops(void *arg)
     u_int i, throttle_delay_max;
     const char *iso_config;
     bool greater_than, intxn, prepared, mirrored_truncate;
-    truncate_lock_state_t lock_state;
+    fast_truncate_lock_state_t lock_state;
 
     tinfo = arg;
     mirrored_truncate = false;
@@ -1133,7 +1133,7 @@ rollback_retry:
          */
         if (intxn && GV(RUNS_PREDICTABLE_REPLAY)) {
             commit_transaction(tinfo, false);
-            truncate_lock_release(session, &lock_state);
+            fast_truncate_lock_release(session, &lock_state);
             intxn = false;
         }
 
@@ -1146,7 +1146,7 @@ rollback_retry:
             /* Resolve any running transaction. */
             if (intxn) {
                 commit_transaction(tinfo, false);
-                truncate_lock_release(session, &lock_state);
+                fast_truncate_lock_release(session, &lock_state);
                 intxn = false;
             }
 
@@ -1349,11 +1349,7 @@ rollback_retry:
         }
 
         /*
-         * Switch-mode only, fast-truncate only: TRUNCATE is the writer -- it commits any in-flight
-         * txn, drops its reader lock, takes the writer lock and re-begins under it so its snapshot
-         * drains every concurrent reader's commit. Every other write op is a reader. Reads bypass.
-         * The slow-truncate path doesn't hit the engine gap we're working around, so leave it on
-         * the original code path with no lock activity.
+         * Serialize fast truncate against concurrent writers in disagg switch mode.
          */
         if (disagg_is_mode_switch() && !__wt_process.disagg_slow_truncate_2026) {
             if (op == TRUNCATE) {
@@ -1362,13 +1358,12 @@ rollback_retry:
                     snap_repeat_update(tinfo, true);
                     intxn = false;
                 }
-                truncate_lock_release(session, &lock_state);
-                truncate_lock_acquire_write(session, &lock_state);
-                /* Switch mode implies disagg, which forces transaction.timestamps=on. */
+                fast_truncate_lock_release(session, &lock_state);
+                fast_truncate_lock_acquire_write(session, &lock_state);
                 begin_transaction_ts(tinfo);
                 intxn = true;
             } else if (op != READ)
-                truncate_lock_acquire_read(session, &lock_state);
+                fast_truncate_lock_acquire_read(session, &lock_state);
         }
 
         ret = 0;
@@ -1428,7 +1423,7 @@ skip_operation:
 
         /* Implicit txn: no later commit, release here. Explicit txn keeps the lock until commit. */
         if (!intxn)
-            truncate_lock_release(session, &lock_state);
+            fast_truncate_lock_release(session, &lock_state);
 
         /* Release the truncate operation counter. */
         if (op == TRUNCATE)
@@ -1502,7 +1497,7 @@ skip_operation:
         case 4:           /* 40% */
             __wt_yield(); /* Encourage races */
             commit_transaction(tinfo, prepared);
-            truncate_lock_release(session, &lock_state);
+            fast_truncate_lock_release(session, &lock_state);
             snap_repeat_update(tinfo, true);
             break;
         case 5: /* 10% */
@@ -1513,7 +1508,7 @@ rollback:
                 /* Force a rollback */
                 testutil_assert(intxn);
                 rollback_transaction(tinfo, prepared);
-                truncate_lock_release(session, &lock_state);
+                fast_truncate_lock_release(session, &lock_state);
                 intxn = false;
                 ++ntries;
                 replay_pause_after_rollback(tinfo, ntries);
@@ -1522,7 +1517,7 @@ rollback:
             }
             __wt_yield(); /* Encourage races */
             rollback_transaction(tinfo, prepared);
-            truncate_lock_release(session, &lock_state);
+            fast_truncate_lock_release(session, &lock_state);
             snap_repeat_update(tinfo, false);
             break;
         }
@@ -1539,7 +1534,7 @@ rollback:
 
 loop_exit:
     /* Defensive: release lock on any unexpected exit path. */
-    truncate_lock_release(session, &lock_state);
+    fast_truncate_lock_release(session, &lock_state);
     if (session != NULL)
         testutil_check(session->close(session, NULL));
     tinfo->session = NULL;

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -998,6 +998,50 @@ ops_session_open(TINFO *tinfo)
     tinfo->session = session;
 }
 
+/* Per-thread tracking of which mode of the truncate lock this thread holds, if any. */
+typedef enum { LOCK_HELD_NONE, LOCK_HELD_READ, LOCK_HELD_WRITE } truncate_lock_state_t;
+
+/*
+ * truncate_lock_acquire_read --
+ *     Acquire g.truncate_lock for a non-TRUNCATE write under switch mode. No-op otherwise.
+ */
+static WT_INLINE void
+truncate_lock_acquire_read(WT_SESSION *session, truncate_lock_state_t *state)
+{
+    if (disagg_is_mode_switch() && *state == LOCK_HELD_NONE) {
+        lock_readlock(session, &g.truncate_lock);
+        *state = LOCK_HELD_READ;
+    }
+}
+
+/*
+ * truncate_lock_acquire_write --
+ *     Acquire g.truncate_lock exclusively for a TRUNCATE under switch mode. Caller must have
+ *     released any held rdlock first (otherwise this is a self-deadlock).
+ */
+static WT_INLINE void
+truncate_lock_acquire_write(WT_SESSION *session, truncate_lock_state_t *state)
+{
+    if (disagg_is_mode_switch() && *state == LOCK_HELD_NONE) {
+        lock_writelock(session, &g.truncate_lock);
+        *state = LOCK_HELD_WRITE;
+    }
+}
+
+/*
+ * truncate_lock_release --
+ *     Release g.truncate_lock, dispatching by held mode. No-op if not held.
+ */
+static WT_INLINE void
+truncate_lock_release(WT_SESSION *session, truncate_lock_state_t *state)
+{
+    if (*state == LOCK_HELD_READ)
+        lock_readunlock(session, &g.truncate_lock);
+    else if (*state == LOCK_HELD_WRITE)
+        lock_writeunlock(session, &g.truncate_lock);
+    *state = LOCK_HELD_NONE;
+}
+
 /*
  * ops --
  *     Per-thread operations.
@@ -1015,10 +1059,12 @@ ops(void *arg)
     uint32_t max_rows, ntries, range, rnd;
     u_int i, throttle_delay_max;
     const char *iso_config;
-    bool greater_than, intxn, op_lock_held, prepared, mirrored_truncate;
+    bool greater_than, intxn, prepared, mirrored_truncate;
+    truncate_lock_state_t lock_state;
 
     tinfo = arg;
     mirrored_truncate = false;
+    lock_state = LOCK_HELD_NONE;
 
     /*
      * Characterize the per-thread random number generator. Normally we want independent behavior so
@@ -1065,7 +1111,6 @@ ops(void *arg)
 rollback_retry:
         prepared = false;
         mirrored_truncate = false;
-        op_lock_held = false;
         if (tinfo->quit)
             break;
 
@@ -1088,6 +1133,7 @@ rollback_retry:
          */
         if (intxn && GV(RUNS_PREDICTABLE_REPLAY)) {
             commit_transaction(tinfo, false);
+            truncate_lock_release(session, &lock_state);
             intxn = false;
         }
 
@@ -1100,6 +1146,7 @@ rollback_retry:
             /* Resolve any running transaction. */
             if (intxn) {
                 commit_transaction(tinfo, false);
+                truncate_lock_release(session, &lock_state);
                 intxn = false;
             }
 
@@ -1302,20 +1349,24 @@ rollback_retry:
         }
 
         /*
-         * In disagg "switch" mode the follower-side truncate path doesn't symmetrically
-         * conflict-check against in-flight writes inside its range, so a writer that allocated its
-         * txn id after the truncate transaction's but committed at an earlier timestamp can leave
-         * the drain with a txn-id-inverted chain on stable (trips __timestamp_no_ts_fix during
-         * reconcile). Serialize truncates against everything else for the duration of this op
-         * iteration (released at skip_operation / the rollback label). Only enabled for switch
-         * mode -- other modes don't exhibit the asymmetric-conflict gap.
+         * Switch-mode only: TRUNCATE is the writer -- it commits any in-flight txn, drops its
+         * reader lock, takes the writer lock and re-begins under it so its snapshot drains every
+         * concurrent reader's commit. Every other write op is a reader. Reads bypass.
          */
         if (disagg_is_mode_switch()) {
-            if (op == TRUNCATE)
-                lock_writelock(session, &g.truncate_lock);
-            else
-                lock_readlock(session, &g.truncate_lock);
-            op_lock_held = true;
+            if (op == TRUNCATE) {
+                if (intxn) {
+                    commit_transaction(tinfo, false);
+                    snap_repeat_update(tinfo, true);
+                    intxn = false;
+                }
+                truncate_lock_release(session, &lock_state);
+                truncate_lock_acquire_write(session, &lock_state);
+                /* Switch mode implies disagg, which forces transaction.timestamps=on. */
+                begin_transaction_ts(tinfo);
+                intxn = true;
+            } else if (op != READ)
+                truncate_lock_acquire_read(session, &lock_state);
         }
 
         ret = 0;
@@ -1373,14 +1424,9 @@ rollback_retry:
 skip_operation:
         table = tinfo->table = NULL;
 
-        /* Release the per-op truncate lock if still held. */
-        if (op_lock_held) {
-            if (op == TRUNCATE)
-                lock_writeunlock(session, &g.truncate_lock);
-            else
-                lock_readunlock(session, &g.truncate_lock);
-            op_lock_held = false;
-        }
+        /* Implicit txn: no later commit, release here. Explicit txn keeps the lock until commit. */
+        if (!intxn)
+            truncate_lock_release(session, &lock_state);
 
         /* Release the truncate operation counter. */
         if (op == TRUNCATE)
@@ -1454,27 +1500,18 @@ skip_operation:
         case 4:           /* 40% */
             __wt_yield(); /* Encourage races */
             commit_transaction(tinfo, prepared);
+            truncate_lock_release(session, &lock_state);
             snap_repeat_update(tinfo, true);
             break;
         case 5: /* 10% */
 rollback:
-            /*
-             * If we jumped here from inside the op execution block (before reaching
-             * skip_operation), the per-op truncate lock is still held -- release it now.
-             */
-            if (op_lock_held) {
-                if (op == TRUNCATE)
-                    lock_writeunlock(session, &g.truncate_lock);
-                else
-                    lock_readunlock(session, &g.truncate_lock);
-                op_lock_held = false;
-            }
             if (GV(RUNS_PREDICTABLE_REPLAY)) {
                 if (tinfo->quit)
                     goto loop_exit;
                 /* Force a rollback */
                 testutil_assert(intxn);
                 rollback_transaction(tinfo, prepared);
+                truncate_lock_release(session, &lock_state);
                 intxn = false;
                 ++ntries;
                 replay_pause_after_rollback(tinfo, ntries);
@@ -1483,6 +1520,7 @@ rollback:
             }
             __wt_yield(); /* Encourage races */
             rollback_transaction(tinfo, prepared);
+            truncate_lock_release(session, &lock_state);
             snap_repeat_update(tinfo, false);
             break;
         }
@@ -1498,6 +1536,8 @@ rollback:
     }
 
 loop_exit:
+    /* Defensive: release lock on any unexpected exit path. */
+    truncate_lock_release(session, &lock_state);
     if (session != NULL)
         testutil_check(session->close(session, NULL));
     tinfo->session = NULL;

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -532,6 +532,8 @@ begin_transaction_ts(TINFO *tinfo)
     /* Pick a read timestamp. */
     if (GV(RUNS_PREDICTABLE_REPLAY))
         ts = replay_read_ts(tinfo);
+    else if (disagg_is_mode_switch() && !__wt_process.disagg_slow_truncate_2026)
+        ts = 0;
     else
         /*
          * Transaction timestamp reads are repeatable, but read timestamps must be before any
@@ -1360,9 +1362,7 @@ rollback_retry:
                 }
                 fast_truncate_lock_release(session, &lock_state);
                 fast_truncate_lock_acquire_write(session, &lock_state);
-                tinfo->ignore_prepare = false;
-                wt_wrap_begin_transaction(session, NULL);
-                snap_op_init(tinfo, WT_TS_NONE, false);
+                begin_transaction_ts(tinfo);
                 intxn = true;
             } else if (op != READ)
                 fast_truncate_lock_acquire_read(session, &lock_state);

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -532,17 +532,8 @@ begin_transaction_ts(TINFO *tinfo)
     /* Pick a read timestamp. */
     if (GV(RUNS_PREDICTABLE_REPLAY))
         ts = replay_read_ts(tinfo);
-    else if (disagg_is_mode_switch() && !__wt_process.disagg_slow_truncate_2026)
-        ts = 0;
     else
-        /*
-         * Transaction timestamp reads are repeatable, but read timestamps must be before any
-         * possible commit timestamp. Without a read timestamp, reads are based on the transaction
-         * snapshot, which will include the latest values as of when the snapshot is taken. Test in
-         * both modes: 75% of the time, pick a read timestamp before any commit timestamp still in
-         * use, 25% of the time don't set a timestamp at all.
-         */
-        ts = mmrand(&tinfo->data_rnd, 1, 4) == 1 ? 0 : timestamp_minimum_committed();
+        ts = 0;
     if (ts != 0) {
         /* 10% of times configure ignore_prepare */
         if (GV(OPS_PREPARE) && (mmrand(&tinfo->data_rnd, 1, 10) == 1)) {

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -533,7 +533,14 @@ begin_transaction_ts(TINFO *tinfo)
     if (GV(RUNS_PREDICTABLE_REPLAY))
         ts = replay_read_ts(tinfo);
     else
-        ts = 0;
+        /*
+         * Transaction timestamp reads are repeatable, but read timestamps must be before any
+         * possible commit timestamp. Without a read timestamp, reads are based on the transaction
+         * snapshot, which will include the latest values as of when the snapshot is taken. Test in
+         * both modes: 75% of the time, pick a read timestamp before any commit timestamp still in
+         * use, 25% of the time don't set a timestamp at all.
+         */
+        ts = mmrand(&tinfo->data_rnd, 1, 4) == 1 ? 0 : timestamp_minimum_committed();
     if (ts != 0) {
         /* 10% of times configure ignore_prepare */
         if (GV(OPS_PREPARE) && (mmrand(&tinfo->data_rnd, 1, 10) == 1)) {

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -1302,15 +1302,21 @@ rollback_retry:
         }
 
         /*
-         * Truncates are mutually exclusive with all other read/write ops across all tables -- see
-         * the comment on g.truncate_lock for the rationale. Held for the duration of this op
-         * iteration (including mirrors) and released at skip_operation / the rollback label.
+         * In disagg "switch" mode the follower-side truncate path doesn't symmetrically
+         * conflict-check against in-flight writes inside its range, so a writer that allocated its
+         * txn id after the truncate transaction's but committed at an earlier timestamp can leave
+         * the drain with a txn-id-inverted chain on stable (trips __timestamp_no_ts_fix during
+         * reconcile). Serialize truncates against everything else for the duration of this op
+         * iteration (released at skip_operation / the rollback label). Only enabled for switch
+         * mode -- other modes don't exhibit the asymmetric-conflict gap.
          */
-        if (op == TRUNCATE)
-            lock_writelock(session, &g.truncate_lock);
-        else
-            lock_readlock(session, &g.truncate_lock);
-        op_lock_held = true;
+        if (disagg_is_mode_switch()) {
+            if (op == TRUNCATE)
+                lock_writelock(session, &g.truncate_lock);
+            else
+                lock_readlock(session, &g.truncate_lock);
+            op_lock_held = true;
+        }
 
         ret = 0;
         skip1 = skip2 = NULL;

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -1349,11 +1349,13 @@ rollback_retry:
         }
 
         /*
-         * Switch-mode only: TRUNCATE is the writer -- it commits any in-flight txn, drops its
-         * reader lock, takes the writer lock and re-begins under it so its snapshot drains every
-         * concurrent reader's commit. Every other write op is a reader. Reads bypass.
+         * Switch-mode only, fast-truncate only: TRUNCATE is the writer -- it commits any
+         * in-flight txn, drops its reader lock, takes the writer lock and re-begins under it so
+         * its snapshot drains every concurrent reader's commit. Every other write op is a reader.
+         * Reads bypass. The slow-truncate path doesn't hit the engine gap we're working around,
+         * so leave it on the original code path with no lock activity.
          */
-        if (disagg_is_mode_switch()) {
+        if (disagg_is_mode_switch() && !__wt_process.disagg_slow_truncate_2026) {
             if (op == TRUNCATE) {
                 if (intxn) {
                     commit_transaction(tinfo, false);

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -1360,7 +1360,9 @@ rollback_retry:
                 }
                 fast_truncate_lock_release(session, &lock_state);
                 fast_truncate_lock_acquire_write(session, &lock_state);
-                begin_transaction_ts(tinfo);
+                tinfo->ignore_prepare = false;
+                wt_wrap_begin_transaction(session, NULL);
+                snap_op_init(tinfo, WT_TS_NONE, false);
                 intxn = true;
             } else if (op != READ)
                 fast_truncate_lock_acquire_read(session, &lock_state);

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -533,14 +533,7 @@ begin_transaction_ts(TINFO *tinfo)
     if (GV(RUNS_PREDICTABLE_REPLAY))
         ts = replay_read_ts(tinfo);
     else
-        /*
-         * Transaction timestamp reads are repeatable, but read timestamps must be before any
-         * possible commit timestamp. Without a read timestamp, reads are based on the transaction
-         * snapshot, which will include the latest values as of when the snapshot is taken. Test in
-         * both modes: 75% of the time, pick a read timestamp before any commit timestamp still in
-         * use, 25% of the time don't set a timestamp at all.
-         */
-        ts = mmrand(&tinfo->data_rnd, 1, 4) == 1 ? 0 : timestamp_minimum_committed();
+        ts = 0;
     if (ts != 0) {
         /* 10% of times configure ignore_prepare */
         if (GV(OPS_PREPARE) && (mmrand(&tinfo->data_rnd, 1, 10) == 1)) {

--- a/test/format/t.c
+++ b/test/format/t.c
@@ -134,6 +134,7 @@ locks_init(WT_CONNECTION *conn)
     testutil_check(conn->open_session(conn, NULL, NULL, &session));
     lock_init(session, &g.backup_lock);
     lock_init(session, &g.prepare_commit_lock);
+    lock_init(session, &g.truncate_lock);
     testutil_check(session->close(session, NULL));
 }
 
@@ -149,6 +150,7 @@ locks_destroy(WT_CONNECTION *conn)
     testutil_check(conn->open_session(conn, NULL, NULL, &session));
     lock_destroy(session, &g.backup_lock);
     lock_destroy(session, &g.prepare_commit_lock);
+    lock_destroy(session, &g.truncate_lock);
     testutil_check(session->close(session, NULL));
 }
 

--- a/test/format/t.c
+++ b/test/format/t.c
@@ -134,7 +134,7 @@ locks_init(WT_CONNECTION *conn)
     testutil_check(conn->open_session(conn, NULL, NULL, &session));
     lock_init(session, &g.backup_lock);
     lock_init(session, &g.prepare_commit_lock);
-    lock_init(session, &g.truncate_lock);
+    lock_init(session, &g.fast_truncate_lock);
     testutil_check(session->close(session, NULL));
 }
 
@@ -150,7 +150,7 @@ locks_destroy(WT_CONNECTION *conn)
     testutil_check(conn->open_session(conn, NULL, NULL, &session));
     lock_destroy(session, &g.backup_lock);
     lock_destroy(session, &g.prepare_commit_lock);
-    lock_destroy(session, &g.truncate_lock);
+    lock_destroy(session, &g.fast_truncate_lock);
     testutil_check(session->close(session, NULL));
 }
 


### PR DESCRIPTION
**Summary**

Test-only workaround for a fast-truncate snapshot-skew bug that trips `__timestamp_no_ts_fix` on stable during reconcile under disagg.mode=switch.

**Pre-fix:** ~5% of CONFIG.fail runs fail with assertion failed: 'select_tw->stop_txn >= select_tw->start_txn'. Post-fix: 200/200 runs clean.

**Changes**
Switch-mode-only, fast-truncate-only RWLOCK g.truncate_lock in test/format:

- TRUNCATE: commits any in-flight txn, releases held rdlock, takes wrlock, re-begins the txn under it. Snapshot is captured atomically w.r.t. all concurrent writers.
- Other non-READ writes (INSERT/UPDATE/MODIFY/REMOVE): take rdlock at op-select, hold through commit_transaction/rollback_transaction. Multiple readers run concurrently — non-truncate writes stay parallel.
READ ops: bypass.
- Gated on disagg_is_mode_switch() && !__wt_process.disagg_slow_truncate_2026. Other modes and the slow-truncate build path are unaffected.
- Uses the WT-backed RWLOCK abstraction (lock_readlock / lock_writelock / etc.)
- Special evergreen tasks to be run under fast truncate