### PR TITLE
WT-17247 Layered cursor writes on follower should check for potential write conflicts

### DIFF
--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -2100,6 +2100,99 @@ __clayered_put(WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, const WT_I
 }
 
 /*
+ * __clayered_cell_check --
+ *     Detect a write conflict on a positioned constituent cursor.
+ */
+static int
+__clayered_cell_check(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt)
+{
+    WT_TIME_WINDOW tw;
+
+    /* Ignore prepared updates, matching the leader. */
+    if (__wt_read_cell_time_window(cbt, &tw) && WT_TIME_WINDOW_HAS_PREPARE(&tw))
+        return (0);
+
+    /* Ensure the pinned page is valid. */
+    WT_ASSERT(session, cbt->ref != NULL && cbt->ref->page != NULL);
+
+    /* Use the in-memory update chain if present (ingest). */
+    WT_UPDATE *upd = NULL;
+    if (cbt->ins != NULL)
+        upd = cbt->ins->upd;
+    else if (CUR2BT(cbt)->type == BTREE_ROW && cbt->ref->page->modify != NULL &&
+      cbt->ref->page->modify->mod_row_update != NULL) {
+        WT_ASSERT(session, cbt->slot != UINT32_MAX);
+        upd = cbt->ref->page->modify->mod_row_update[cbt->slot];
+    }
+
+    return (__wt_txn_modify_check(session, cbt, upd, NULL, WT_UPDATE_STANDARD));
+}
+
+/*
+ * __clayered_constituent_check --
+ *     Check a constituent for a write conflict on the key.
+ */
+static int
+__clayered_constituent_check(
+  WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, WT_CURSOR *c, const WT_ITEM *key)
+{
+    if (c == NULL)
+        return (0);
+
+    WT_CURSOR_BTREE *cbt = (WT_CURSOR_BTREE *)c;
+    WT_DECL_RET;
+
+    if (clayered->current_cursor == c && F_ISSET(c, WT_CURSTD_KEY_INT)) {
+        /* Positioned on the key: check the held cell and keep the position. */
+        WT_WITH_DHANDLE(session, cbt->dhandle, ret = __clayered_cell_check(session, cbt));
+    } else {
+        WT_WITH_DHANDLE(session, cbt->dhandle, {
+            /* Release any page held from a prior op before searching. */
+            ret = __wt_btcur_reset(cbt);
+            if (ret == 0) {
+                WT_WITH_PAGE_INDEX(
+                  session, ret = __wt_row_search(cbt, (WT_ITEM *)key, false, NULL, false, NULL));
+                if (ret == 0 && cbt->compare == 0)
+                    ret = __clayered_cell_check(session, cbt);
+            }
+            WT_TRET(__wt_btcur_reset(cbt));
+        });
+    }
+
+    return (ret);
+}
+
+/*
+ * __clayered_modify_check --
+ *     Detect a write conflict for a follower write: a committed update invisible to this
+ *     transaction in either constituent.
+ */
+static int
+__clayered_modify_check(WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, const WT_ITEM *key)
+{
+    /* No read timestamp means every update is visible; nothing to probe. */
+    if (!F_ISSET(session->txn, WT_TXN_SHARED_TS_READ))
+        return (0);
+
+    /* The leader's underlying stable cursor runs the check itself. */
+    if (S2C(session)->layered_table_manager.leader)
+        return (0);
+
+    /*
+     * The probe searches and resets the constituent cursors, destroying the walk-consistent
+     * positions an in-progress iteration relies on. Clear the iteration flags so the next
+     * next()/prev() re-seats both constituents.
+     */
+    F_CLR(clayered, WT_CLAYERED_ITERATE_NEXT | WT_CLAYERED_ITERATE_PREV);
+
+    /* Probe the ingest and stable tables. */
+    WT_RET(__clayered_constituent_check(session, clayered, clayered->ingest_cursor, key));
+    WT_RET(__clayered_constituent_check(session, clayered, clayered->stable_cursor, key));
+
+    return (0);
+}
+
+/*
  * __clayered_remove_follower --
  *     Remove an entry from the ingest table.
  */
@@ -2112,6 +2205,8 @@ __clayered_remove_follower(
     WT_ITEM value;
 
     WT_CLEAR(value);
+
+    WT_RET(__clayered_modify_check(session, clayered, key));
 
     if (positioned) {
         if (clayered->current_cursor == c) {
@@ -2247,8 +2342,10 @@ __clayered_insert(WT_CURSOR *cursor)
     WT_ERR(__cursor_needkey(cursor));
     WT_ERR(__cursor_needvalue(cursor));
 
-    if (!S2C(session)->layered_table_manager.leader && F_ISSET(cursor, WT_CURSTD_OVERWRITE))
-        enter_flags |= CLAYERED_ENTER_FOLLOWER_OVERWRITE;
+    /* With a read timestamp the conflict check needs the stable table; don't skip opening it. */
+    if (!S2C(session)->layered_table_manager.leader && F_ISSET(cursor, WT_CURSTD_OVERWRITE) &&
+      !F_ISSET(session->txn, WT_TXN_SHARED_TS_READ))
+        FLD_SET(enter_flags, CLAYERED_ENTER_FOLLOWER_OVERWRITE);
     WT_ERR(__clayered_enter(clayered, enter_flags));
 
     /*
@@ -2257,14 +2354,13 @@ __clayered_insert(WT_CURSOR *cursor)
      */
     if (!S2C(session)->layered_table_manager.leader && !F_ISSET(cursor, WT_CURSTD_OVERWRITE) &&
       (ret = __clayered_lookup(session, clayered, &value)) != WT_NOTFOUND) {
-        if (ret == 0) {
-            WT_ERR(__clayered_copy_duplicate_kv(cursor));
-            WT_ERR(__clayered_reset_cursors(clayered, false));
-            WT_ERR(WT_DUPLICATE_KEY);
-        }
-
-        goto err;
+        WT_ERR(ret);
+        WT_ERR(__clayered_copy_duplicate_kv(cursor));
+        WT_ERR(__clayered_reset_cursors(clayered, false));
+        WT_ERR(WT_DUPLICATE_KEY);
     }
+
+    WT_ERR(__clayered_modify_check(session, clayered, &cursor->key));
 
     WT_ERR(__clayered_deleted_encode(session, &cursor->value, &value, &buf));
     ret = __clayered_put(session, clayered, &cursor->key, &value, WT_CLAYERED_PUT_INSERT);
@@ -2329,9 +2425,13 @@ __clayered_update(WT_CURSOR *cursor)
     WT_ERR(__cursor_needkey(cursor));
     WT_ERR(__cursor_needvalue(cursor));
 
-    if (!S2C(session)->layered_table_manager.leader && F_ISSET(cursor, WT_CURSTD_OVERWRITE))
-        enter_flags |= CLAYERED_ENTER_FOLLOWER_OVERWRITE;
+    /* With a read timestamp the conflict check needs the stable table. */
+    if (!S2C(session)->layered_table_manager.leader && F_ISSET(cursor, WT_CURSTD_OVERWRITE) &&
+      !F_ISSET(session->txn, WT_TXN_SHARED_TS_READ))
+        FLD_SET(enter_flags, CLAYERED_ENTER_FOLLOWER_OVERWRITE);
     WT_ERR(__clayered_enter(clayered, enter_flags));
+
+    WT_ERR(__clayered_modify_check(session, clayered, &cursor->key));
 
     if (!S2C(session)->layered_table_manager.leader && !F_ISSET(cursor, WT_CURSTD_OVERWRITE)) {
         WT_ERR(__clayered_lookup(session, clayered, &value));
@@ -2341,6 +2441,7 @@ __clayered_update(WT_CURSOR *cursor)
          */
         WT_ERR(__cursor_needkey(cursor));
     }
+
     WT_ERR(__clayered_deleted_encode(session, &cursor->value, &value, &buf));
     WT_ERR(__clayered_put(session, clayered, &cursor->key, &value, WT_CLAYERED_PUT_UPDATE));
 
@@ -2452,8 +2553,14 @@ __clayered_reserve(WT_CURSOR *cursor)
 
     WT_ERR(__clayered_enter(clayered, 0));
 
-    /* WT_CURSOR.reserve is update-without-overwrite so we should check whether the key exists. */
-    WT_ERR(__clayered_lookup(session, clayered, &value));
+    WT_ERR(__clayered_modify_check(session, clayered, &cursor->key));
+
+    /*
+     * WT_CURSOR.reserve is update-without-overwrite so we should check whether the key exists. The
+     * leader's stable cursor reserves without overwrite and runs the check itself.
+     */
+    if (!S2C(session)->layered_table_manager.leader)
+        WT_ERR(__clayered_lookup(session, clayered, &value));
 
     WT_ERR(__clayered_put(session, clayered, &cursor->key, NULL, WT_CLAYERED_PUT_RESERVE));
 
@@ -2752,11 +2859,17 @@ __clayered_modify_follower(
 
     WT_CLEAR(value);
 
-    /* Do a search if we're not positioned. */
-    if (!F_ISSET(&clayered->iface, WT_CURSTD_KEY_INT))
-        WT_ERR_NOTFOUND_OK(__clayered_lookup(session, clayered, &value), true);
+    /*
+     * Modify requires a visible base value: search before the conflict check so a missing value
+     * returns WT_NOTFOUND.
+     */
+    if (!F_ISSET(&clayered->iface, WT_CURSTD_KEY_INT) ||
+      !F_ISSET(&clayered->iface, WT_CURSTD_VALUE_INT))
+        WT_ERR(__clayered_lookup(session, clayered, &value));
     else
         WT_ITEM_SET(value, cursor->value);
+
+    WT_ERR(__clayered_modify_check(session, clayered, &cursor->key));
 
     if (clayered->current_cursor != ingest) {
         /*
@@ -2777,7 +2890,7 @@ __clayered_modify_follower(
          * also cannot serve as the base value for a modify. In these cases, perform a full update
          * instead.
          */
-        if (ret == WT_NOTFOUND || __wt_clayered_deleted(&ingest->value) ||
+        if (__wt_clayered_deleted(&ingest->value) ||
           __clayered_is_deleted_encoded(&ingest->value)) {
             __clayered_deleted_decode(&ingest->value);
             WT_ERR(__wt_modify_apply_api(ingest, entries, nentries));

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -121,10 +121,10 @@ __clayered_assert_stable_mode(WT_CURSOR_LAYERED *clayered)
 }
 
 /* __clayered_enter() local flags. */
-#define CLAYERED_ENTER_SKIP_STABLE 0x1u        /* Follower writing without reading stable. */
-#define CLAYERED_ENTER_ITERATION 0x2u          /* Cursor is performing iteration. */
-#define CLAYERED_ENTER_RESET 0x4u              /* Reset constituent cursors if needed. */
-#define CLAYERED_ENTER_ROLE_CHANGE 0x8u        /* Leader/follower role changed since last access. */
+#define CLAYERED_ENTER_SKIP_STABLE 0x1u /* Follower writing without reading stable. */
+#define CLAYERED_ENTER_ITERATION 0x2u   /* Cursor is performing iteration. */
+#define CLAYERED_ENTER_RESET 0x4u       /* Reset constituent cursors if needed. */
+#define CLAYERED_ENTER_ROLE_CHANGE 0x8u /* Leader/follower role changed since last access. */
 
 /*
  * __clayered_enter --

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -121,7 +121,7 @@ __clayered_assert_stable_mode(WT_CURSOR_LAYERED *clayered)
 }
 
 /* __clayered_enter() local flags. */
-#define CLAYERED_ENTER_FOLLOWER_OVERWRITE 0x1u /* Follower writing without reading stable. */
+#define CLAYERED_ENTER_SKIP_STABLE 0x1u        /* Follower writing without reading stable. */
 #define CLAYERED_ENTER_ITERATION 0x2u          /* Cursor is performing iteration. */
 #define CLAYERED_ENTER_RESET 0x4u              /* Reset constituent cursors if needed. */
 #define CLAYERED_ENTER_ROLE_CHANGE 0x8u        /* Leader/follower role changed since last access. */
@@ -144,7 +144,7 @@ __clayered_enter(WT_CURSOR_LAYERED *clayered, uint32_t flags)
     }
 
     /* Follower overwrites update ingest tables without accessing the stable table. */
-    if (!LF_ISSET(CLAYERED_ENTER_FOLLOWER_OVERWRITE))
+    if (!LF_ISSET(CLAYERED_ENTER_SKIP_STABLE))
         F_SET(clayered, WT_CLAYERED_READ_STABLE);
 
     /*
@@ -555,7 +555,7 @@ __clayered_update_stable(WT_CURSOR_LAYERED *clayered, uint32_t flags)
     if (clayered->stable_cursor == NULL) {
         /* Open stable the first time if needed. */
         bool follower_open_stable =
-          (!FLD_ISSET(flags, CLAYERED_ENTER_FOLLOWER_OVERWRITE) && conn_lsn != WT_DISAGG_LSN_NONE);
+          (!FLD_ISSET(flags, CLAYERED_ENTER_SKIP_STABLE) && conn_lsn != WT_DISAGG_LSN_NONE);
         if (conn->layered_table_manager.leader || follower_open_stable) {
             F_CLR(clayered, WT_CLAYERED_ITERATE_NEXT | WT_CLAYERED_ITERATE_PREV);
             WT_RET(__clayered_open_stable(clayered, false));
@@ -2345,7 +2345,7 @@ __clayered_insert(WT_CURSOR *cursor)
     /* With a read timestamp the conflict check needs the stable table; don't skip opening it. */
     if (!S2C(session)->layered_table_manager.leader && F_ISSET(cursor, WT_CURSTD_OVERWRITE) &&
       !F_ISSET(session->txn, WT_TXN_SHARED_TS_READ))
-        FLD_SET(enter_flags, CLAYERED_ENTER_FOLLOWER_OVERWRITE);
+        FLD_SET(enter_flags, CLAYERED_ENTER_SKIP_STABLE);
     WT_ERR(__clayered_enter(clayered, enter_flags));
 
     /*
@@ -2428,7 +2428,7 @@ __clayered_update(WT_CURSOR *cursor)
     /* With a read timestamp the conflict check needs the stable table. */
     if (!S2C(session)->layered_table_manager.leader && F_ISSET(cursor, WT_CURSTD_OVERWRITE) &&
       !F_ISSET(session->txn, WT_TXN_SHARED_TS_READ))
-        FLD_SET(enter_flags, CLAYERED_ENTER_FOLLOWER_OVERWRITE);
+        FLD_SET(enter_flags, CLAYERED_ENTER_SKIP_STABLE);
     WT_ERR(__clayered_enter(clayered, enter_flags));
 
     WT_ERR(__clayered_modify_check(session, clayered, &cursor->key));

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -513,7 +513,6 @@ wt_timestamp_t replay_read_ts(TINFO *);
 void replay_rollback(TINFO *);
 void replay_run_begin(WT_SESSION *);
 void replay_run_end(WT_SESSION *);
-bool replay_stale_read_ts(TINFO *);
 int timestamp_query(const char *, wt_timestamp_t *);
 void timestamp_teardown(WT_SESSION *);
 void trace_config(const char *);

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -1287,18 +1287,8 @@ rollback_retry:
             val_gen(table, &tinfo->data_rnd, tinfo->new_value, tinfo->keyno);
 
         /* If modify, build a modify change vector. */
-        if (op == MODIFY) {
-            /*
-             * FIXME-WT-17311: If we can make modify return WT_ROLLBACK instead of WT_NOTFOUND when
-             * it sees an outdated tombstone, we will no longer need this rollback check. The
-             * WT_ROLLBACK will signal that we need to try again with a higher read timestamp, and
-             * the rollback will be triggered automatically in predictable replay mode.
-             */
-            if (replay_stale_read_ts(tinfo))
-                goto rollback;
-
+        if (op == MODIFY)
             modify_build(tinfo);
-        }
 
         ret = 0;
         skip1 = skip2 = NULL;

--- a/test/format/replay.c
+++ b/test/format/replay.c
@@ -547,24 +547,6 @@ replay_rollback(TINFO *tinfo)
 }
 
 /*
- * replay_stale_read_ts --
- *     Return true if the transaction's read timestamp is below the lane's last commit timestamp,
- *     meaning an operation may produce non-deterministic results. Spins until
- *     replay_maximum_committed catches up before returning, so the subsequent rollback and retry
- *     will acquire a read timestamp that sees a consistent key state.
- */
-bool
-replay_stale_read_ts(TINFO *tinfo)
-{
-    if (!GV(RUNS_PREDICTABLE_REPLAY) || tinfo->read_ts >= g.lanes[tinfo->lane].last_commit_ts)
-        return (false);
-
-    while (replay_maximum_committed() < g.lanes[tinfo->lane].last_commit_ts)
-        __wt_yield();
-    return (true);
-}
-
-/*
  * replay_pause_after_rollback --
  *     Called after a rollback, allowing us to yield or pause.
  */

--- a/test/suite/test_layered_cursor23.py
+++ b/test/suite/test_layered_cursor23.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wiredtiger, wttest
+from helper_disagg import disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
+
+# test_layered_cursor23.py
+#   When a read timestamp is set, a layered cursor must behave exactly like a classic cursor for the
+#   same logical key state. The expected outcome is determined live: each scenario loads a regular
+#   (non-layered) reference table holding the values the role's cursor sees, and the same operations
+#   run against both.
+#
+#   The four scenario flags place a visible (commit_ts < read_ts) and/or an invisible
+#   (read_ts < commit_ts) committed version on the stable and/or ingest constituent. The reference
+#   table is loaded with what the role's layered cursor sees:
+#     leader role  : stable values only (a leader disregards the ingest table);
+#     follower role: the union of stable and ingest (a value present in either constituent).
+#
+#   test_methods drives every write method on a single key and compares the outcomes.
+#   test_traverse brackets the scenario key with two neighbors (one visible only on ingest, one
+#   only on stable) and walks the table with next()/prev(), optionally applying a write to the
+#   current record between steps, comparing the whole sequence to the classic cursor. The neighbors
+#   ensure a mid-walk write on a follower resets the alternate constituent while the other still has
+#   keys to return -- which must not drop them from the scan.
+@disagg_test_class
+class test_layered_cursor23(wttest.WiredTigerTestCase):
+    uri = 'layered:test_layered_cursor23'
+    uri_ref = 'table:test_layered_cursor23_ref'
+    key = 'k'
+    conn_base_config = ',create,statistics=(all),'
+
+    # Visible commit < read < invisible commit <= checkpoint; ingest is newer than stable.
+    OLDEST, VIS, READ, INVIS, CKPT = 1, 100, 150, 200, 250
+    VIS_INGEST, INVIS_INGEST = 110, 210
+
+    roles = [('leader', dict(role='leader')), ('follower', dict(role='follower'))]
+    overwrite_opts = [('ow_true', dict(overwrite=True)), ('ow_false', dict(overwrite=False))]
+    vis_stable_opts = [('vs1', dict(vis_stable=True)), ('vs0', dict(vis_stable=False))]
+    vis_ingest_opts = [('vi1', dict(vis_ingest=True)), ('vi0', dict(vis_ingest=False))]
+    invis_stable_opts = [('xs1', dict(invis_stable=True)), ('xs0', dict(invis_stable=False))]
+    invis_ingest_opts = [('xi1', dict(invis_ingest=True)), ('xi0', dict(invis_ingest=False))]
+
+    disagg_storages = gen_disagg_storages('test_layered_cursor23', disagg_only=True)
+    scenarios = make_scenarios(disagg_storages, roles, overwrite_opts,
+        vis_stable_opts, vis_ingest_opts, invis_stable_opts, invis_ingest_opts)
+
+    def conn_config(self):
+        return self.extensionsConfig() + self.conn_base_config + 'disaggregated=(role="leader")'
+
+    def setUp(self):
+        super().setUp()
+        self.conn_follow = self.wiredtiger_open(
+            'follower',
+            self.extensionsConfig() + self.conn_base_config + 'disaggregated=(role="follower")')
+        self.session_follow = self.conn_follow.open_session('')
+        self.test_session = self.session if self.role == 'leader' else self.session_follow
+
+    # --- shared setup helpers ---
+
+    def commit(self, session, uri, key, value, ts):
+        cursor = session.open_cursor(uri)
+        session.begin_transaction()
+        cursor[key] = value
+        session.commit_transaction('commit_timestamp=' + self.timestamp_str(ts))
+        cursor.close()
+
+    def build(self, session, uri, key, visible, invisible, vis_ts, invis_ts):
+        if visible:
+            self.commit(session, uri, key, 'vis', vis_ts)
+        if invisible:
+            self.commit(session, uri, key, 'invis', invis_ts)
+
+    # The (visible, invisible) state the role's cursor sees for a key in the given constituent state.
+    def ref_state(self, vis_stable, vis_ingest, invis_stable, invis_ingest):
+        if self.role == 'leader':
+            return vis_stable, invis_stable
+        return (vis_stable or vis_ingest), (invis_stable or invis_ingest)
+
+    # Load a key's constituent state into the layered table and the matching value into the reference.
+    def build_key(self, key, vis_stable, vis_ingest, invis_stable, invis_ingest):
+        ref_visible, ref_invisible = self.ref_state(vis_stable, vis_ingest, invis_stable, invis_ingest)
+        self.build(self.session, self.uri_ref, key, ref_visible, ref_invisible, self.VIS, self.INVIS)
+        self.build(self.session, self.uri, key, vis_stable, invis_stable, self.VIS, self.INVIS)
+        self.build(self.session_follow, self.uri, key, vis_ingest, invis_ingest,
+            self.VIS_INGEST, self.INVIS_INGEST)
+
+    def create_tables(self):
+        self.session.create(self.uri, 'key_format=S,value_format=S')
+        self.session_follow.create(self.uri, 'key_format=S,value_format=S')
+        self.session.create(self.uri_ref, 'key_format=S,value_format=S')
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(self.OLDEST))
+        self.conn_follow.set_timestamp('oldest_timestamp=' + self.timestamp_str(self.OLDEST))
+
+    def checkpoint_and_advance(self):
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(self.CKPT))
+        self.session.checkpoint()
+        self.disagg_advance_checkpoint(self.conn_follow)
+
+    # --- test_methods: every write method on a single key ---
+
+    _ops = {
+        'insert': lambda c: c.insert(),
+        'update': lambda c: c.update(),
+        'modify': lambda c: c.modify([wiredtiger.Modify('X', 0, 1)]),
+        'reserve': lambda c: c.reserve(),
+        'remove': lambda c: c.remove(),
+    }
+
+    # Run a write method at the read timestamp on the given table; normalize the result, then roll
+    # back so the prepared state is unchanged for the next method.
+    def run_method(self, session, uri, method):
+        cursor = session.open_cursor(uri, None, f'overwrite={str(self.overwrite).lower()}')
+        session.begin_transaction('read_timestamp=' + self.timestamp_str(self.READ))
+        cursor.set_key(self.key)
+        if method in ('insert', 'update'):
+            cursor.set_value('new')
+        try:
+            ret = self._ops[method](cursor)
+            outcome = 'WT_NOTFOUND' if ret == wiredtiger.WT_NOTFOUND else 'success'
+        except wiredtiger.WiredTigerRollbackError:
+            outcome = 'WT_ROLLBACK'
+        except wiredtiger.WiredTigerError as e:
+            s = str(e)
+            if 'WT_DUPLICATE_KEY' in s:
+                outcome = 'WT_DUPLICATE_KEY'
+            elif 'WT_NOTFOUND' in s:
+                outcome = 'WT_NOTFOUND'
+            else:
+                outcome = f'ERROR({e})'
+        finally:
+            session.rollback_transaction()
+            cursor.close()
+        return outcome
+
+    def test_methods(self):
+        self.create_tables()
+        self.build_key(self.key, self.vis_stable, self.vis_ingest,
+            self.invis_stable, self.invis_ingest)
+        self.checkpoint_and_advance()
+
+        mismatches = []
+        for method in ('insert', 'update', 'modify', 'reserve', 'remove'):
+            expected = self.run_method(self.session, self.uri_ref, method)
+            actual = self.run_method(self.test_session, self.uri, method)
+            if actual != expected:
+                mismatches.append(f'{method}: layered={actual} ref={expected}')
+        self.assertEqual(mismatches, [],
+            f'role={self.role} ow={self.overwrite} '
+            f'vis(s={self.vis_stable},i={self.vis_ingest}) '
+            f'invis(s={self.invis_stable},i={self.invis_ingest}): {"; ".join(mismatches)}')
+
+    # --- test_traverse: walk the table, optionally writing the current record between steps ---
+
+    # Apply a write method to the currently positioned record. Returns a normalized outcome.
+    def apply_positioned(self, cursor, method):
+        if method == 'update':
+            cursor.set_value('new')
+            ret = cursor.update()
+        elif method == 'remove':
+            ret = cursor.remove()
+        else:
+            ret = cursor.modify([wiredtiger.Modify('Y', 0, 1)])
+        return 'WT_NOTFOUND' if ret == wiredtiger.WT_NOTFOUND else 'ok'
+
+    # Walk a table at the read timestamp, recording each step. Optionally apply a write method to the
+    # current record between steps. Roll back at the end so no change persists.
+    def observe(self, session, uri, direction, method):
+        cursor = session.open_cursor(uri, None, 'overwrite=' + str(self.overwrite).lower())
+        session.begin_transaction('read_timestamp=' + self.timestamp_str(self.READ))
+        advance = cursor.next if direction == 'next' else cursor.prev
+        obs = []
+        try:
+            while True:
+                try:
+                    ret = advance()
+                except wiredtiger.WiredTigerRollbackError:
+                    obs.append(('walk', 'WT_ROLLBACK'))
+                    break
+                if ret == wiredtiger.WT_NOTFOUND:
+                    obs.append(('walk', 'end'))
+                    break
+                obs.append(('walk', cursor.get_key(), cursor.get_value()))
+                if method is None:
+                    continue
+                try:
+                    obs.append((method, self.apply_positioned(cursor, method)))
+                except wiredtiger.WiredTigerRollbackError:
+                    # A conflict poisons the transaction; the walk cannot continue.
+                    obs.append((method, 'WT_ROLLBACK'))
+                    break
+                except wiredtiger.WiredTigerError as e:
+                    obs.append((method, f'ERROR({e})'))
+                    break
+        finally:
+            session.rollback_transaction()
+            cursor.close()
+        return obs
+
+    def test_traverse(self):
+        self.create_tables()
+        # Bracket the scenario key with neighbors so the walk spans both constituents: 'a' is
+        # visible only on ingest, 'z' only on stable, and the middle key takes the scenario's state.
+        # On a follower the successful write on the ingest-only neighbor resets the stable cursor
+        # mid-walk; the stable-only neighbor 'z' must still be returned by the rest of the scan.
+        self.build_key('a', False, True, False, False)
+        self.build_key(self.key, self.vis_stable, self.vis_ingest,
+            self.invis_stable, self.invis_ingest)
+        self.build_key('z', True, False, False, False)
+        self.checkpoint_and_advance()
+
+        mismatches = []
+        for direction in ('next', 'prev'):
+            for method in (None, 'modify', 'update', 'remove'):
+                expected = self.observe(self.session, self.uri_ref, direction, method)
+                actual = self.observe(self.test_session, self.uri, direction, method)
+                if actual != expected:
+                    mismatches.append(f'{direction} interleave={method}:\n'
+                        f'    layered={actual}\n    ref    ={expected}')
+        self.assertEqual(mismatches, [],
+            f'role={self.role} ow={self.overwrite} '
+            f'vis(s={self.vis_stable},i={self.vis_ingest}) '
+            f'invis(s={self.invis_stable},i={self.invis_ingest}):\n' + '\n'.join(mismatches))

--- a/test/suite/test_overwrite.py
+++ b/test/suite/test_overwrite.py
@@ -157,3 +157,134 @@ class test_overwrite(wttest.WiredTigerTestCase):
         cursor.set_key(ds.key(201))
         cursor.set_value(ds.value(1008))
         self.assertEqual(cursor.update(), 0)
+
+# test_overwrite_invisible_update
+#    A committed update newer than the transaction's read timestamp is invisible to the reader.
+#    A write that depends on the key's state must then report:
+#      - a write conflict (WT_ROLLBACK)
+#      - except insert without overwrite: it sees the still-visible older value and reports
+#        a duplicate.
+#
+#    Scenario per key: insert@10, update@30 (both committed); a read txn at read_ts=20 sees the @10
+#    value but not the @30 update. The "insert (no prior value)" row instead commits only insert@30,
+#    so at read_ts=20 the key has no visible value and there is no duplicate to detect.
+#
+#    | method                | overwrite=false  | overwrite=true |
+#    +-----------------------+------------------+----------------+
+#    | insert (prior value)  | WT_DUPLICATE_KEY | WT_ROLLBACK    |
+#    | insert (no prior)     | WT_ROLLBACK      | WT_ROLLBACK    |
+#    | update (prior value)  | WT_ROLLBACK      | WT_ROLLBACK    |
+#    | update (no prior)     | WT_ROLLBACK      | WT_ROLLBACK    |
+#    | modify                | WT_ROLLBACK      | WT_ROLLBACK    |
+#    | reserve               | WT_ROLLBACK      | WT_ROLLBACK    |
+#    | remove                | WT_ROLLBACK      | WT_ROLLBACK    |
+#
+class test_overwrite_invisible_update(wttest.WiredTigerTestCase):
+    name = 'overwrite_invis'
+    types = [
+        ('file', dict(uri='file:')),
+        ('table', dict(uri='table:')),
+    ]
+    keyfmt = [
+        ('row', dict(keyfmt='S')),
+        ('row-int', dict(keyfmt='i')),
+        ('var', dict(keyfmt='r')),
+    ]
+    scenarios = make_scenarios(types, keyfmt)
+
+    def make_ds(self):
+        uri = self.uri + self.name
+        ds = SimpleDataSet(self, uri, 0, key_format=self.keyfmt, value_format='S')
+        ds.create()
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
+        return ds, uri
+
+    # Commit a value at ts=10 then a newer value at ts=30; the @30 update is invisible at read_ts=20.
+    def setup_invisible(self, ds, uri, k):
+        cursor = self.session.open_cursor(uri)
+        self.session.begin_transaction()
+        cursor[ds.key(k)] = ds.value(k)
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
+        self.session.begin_transaction()
+        cursor[ds.key(k)] = ds.value(k + 1)
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(30))
+        cursor.close()
+
+    # Commit only an insert at ts=30; at read_ts=20 the key has no visible value at all.
+    def setup_invisible_insert(self, ds, uri, k):
+        cursor = self.session.open_cursor(uri)
+        self.session.begin_transaction()
+        cursor[ds.key(k)] = ds.value(k)
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(30))
+        cursor.close()
+
+    # Run a write method against key k at read_ts=20, then roll back. Returns the method's result;
+    # WT_ROLLBACK / WT_DUPLICATE_KEY surface as exceptions.
+    def attempt(self, ds, uri, k, overwrite, method, setup=None):
+        (setup or self.setup_invisible)(ds, uri, k)
+        cursor = self.session.open_cursor(uri, None, None if overwrite else 'overwrite=false')
+        self.session.begin_transaction('read_timestamp=' + self.timestamp_str(20))
+        cursor.set_key(ds.key(k))
+        if method in ('insert', 'update'):
+            cursor.set_value(ds.value(k + 2))
+        try:
+            if method == 'insert':
+                return cursor.insert()
+            if method == 'update':
+                return cursor.update()
+            if method == 'modify':
+                return cursor.modify([wiredtiger.Modify('X', 0, 1)])
+            if method == 'reserve':
+                return cursor.reserve()
+            if method == 'remove':
+                return cursor.remove()
+        finally:
+            self.session.rollback_transaction()
+            cursor.close()
+
+    def assert_rollback(self, ds, uri, k, overwrite, method, setup=None):
+        self.assertRaises(wiredtiger.WiredTigerRollbackError,
+            lambda: self.attempt(ds, uri, k, overwrite, method, setup))
+
+    def test_invisible_insert(self):
+        ds, uri = self.make_ds()
+        # overwrite=false: the still-visible @10 value makes this a duplicate.
+        self.assertRaisesHavingMessage(
+            wiredtiger.WiredTigerError, lambda: self.attempt(ds, uri, 1, False, 'insert'),
+            '/WT_DUPLICATE_KEY/')
+        # overwrite=true: the blind write conflicts with the invisible committed update.
+        self.assert_rollback(ds, uri, 2, True, 'insert')
+
+    def test_invisible_insert_no_prior(self):
+        ds, uri = self.make_ds()
+        # No visible value: the only committed state is the invisible insert@30, so there is no
+        # duplicate to detect and even overwrite=false reaches the conflict check.
+        self.assert_rollback(ds, uri, 1, False, 'insert', self.setup_invisible_insert)
+        self.assert_rollback(ds, uri, 2, True, 'insert', self.setup_invisible_insert)
+
+    def test_invisible_update(self):
+        ds, uri = self.make_ds()
+        self.assert_rollback(ds, uri, 1, False, 'update')
+        self.assert_rollback(ds, uri, 2, True, 'update')
+
+    def test_invisible_update_no_prior(self):
+        ds, uri = self.make_ds()
+        # No visible value: update's conflict check still fires on the invisible insert@30 (it would
+        # be WT_NOTFOUND only if there were no committed update at all).
+        self.assert_rollback(ds, uri, 1, False, 'update', self.setup_invisible_insert)
+        self.assert_rollback(ds, uri, 2, True, 'update', self.setup_invisible_insert)
+
+    def test_invisible_modify(self):
+        ds, uri = self.make_ds()
+        self.assert_rollback(ds, uri, 1, False, 'modify')
+        self.assert_rollback(ds, uri, 2, True, 'modify')
+
+    def test_invisible_reserve(self):
+        ds, uri = self.make_ds()
+        self.assert_rollback(ds, uri, 1, False, 'reserve')
+        self.assert_rollback(ds, uri, 2, True, 'reserve')
+
+    def test_invisible_remove(self):
+        ds, uri = self.make_ds()
+        self.assert_rollback(ds, uri, 1, False, 'remove')
+        self.assert_rollback(ds, uri, 2, True, 'remove')


### PR DESCRIPTION
Detect write conflicts on follower when read timestamps are used and cursor config is `overwrite=true`.
- Add write conflict check to each cursor method that modifies data: insert, update, modify, reserve, remove.
- Add unit test to ensure that layered cursors detect write conflicts the same way as ASC cursors do.