### PR TITLE
WT-17614 Add a reference Dockerfile for local WT development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,10 +3,10 @@ FROM ubuntu:26.04
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     aspell aspell-en ca-certificates ccache clang-22 clang-format-22 \
-    clang-tidy-22 clangd-22 cmake curl diffutils doxygen ed file findutils g++ \
-    gcc gdb git gzip liblz4-dev libsnappy-dev libsodium-dev libzstd-dev lld-22 \
-    lldb-22 llvm-22 make ninja-build perl python-is-python3 python3 \
-    python3-dev python3-pip python3-venv swig tar universal-ctags zlib1g-dev \
+    clang-tidy-22 clangd-22 cmake curl doxygen ed file g++ gcc gdb git \
+    liblz4-dev libsnappy-dev libsodium-dev libzstd-dev lld-22 lldb-22 llvm-22 \
+    make ninja-build python-is-python3 python3 python3-dev python3-pip \
+    python3-venv swig universal-ctags zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
 
 ENV PATH="/usr/lib/llvm-22/bin:$PATH"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,10 +6,10 @@ RUN apt-get update && \
     aspell-en=2020.12.07-0-1.1build1 \
     ca-certificates=20260223 \
     ccache=4.12.3-1 \
-    clang=1:21.1.6-71 \
-    clang-format=1:21.1.6-71 \
-    clang-tidy=1:21.1.6-71 \
-    clangd=1:21.1.6-71 \
+    clang-22=1:22.1.2-1ubuntu1 \
+    clang-format-22=1:22.1.2-1ubuntu1 \
+    clang-tidy-22=1:22.1.2-1ubuntu1 \
+    clangd-22=1:22.1.2-1ubuntu1 \
     cmake=4.2.3-2ubuntu2 \
     curl=8.18.0-1ubuntu2.1 \
     diffutils=1:3.12-1 \
@@ -26,9 +26,9 @@ RUN apt-get update && \
     libsnappy-dev=1.2.2-2 \
     libsodium-dev=1.0.18-2 \
     libzstd-dev=1.5.7+dfsg-3 \
-    lld=1:21.1.6-71 \
-    lldb=1:21.1.6-71 \
-    llvm=1:21.1.6-71 \
+    lld-22=1:22.1.2-1ubuntu1 \
+    lldb-22=1:22.1.2-1ubuntu1 \
+    llvm-22=1:22.1.2-1ubuntu1 \
     make=4.4.1-3 \
     ninja-build=1.13.2-1 \
     perl=5.40.1-7build1 \
@@ -42,6 +42,8 @@ RUN apt-get update && \
     universal-ctags=6.2.1-1 \
     zlib1g-dev=1:1.3.dfsg+really1.3.1-1ubuntu3 \
     && rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/usr/lib/llvm-22/bin:$PATH"
 
 RUN useradd -m -s /bin/bash wiredtiger
 USER wiredtiger

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,14 +2,12 @@ FROM ubuntu:26.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    aspell aspell-en ca-certificates ccache clang-22 clang-format-22 \
-    clang-tidy-22 clangd-22 cmake curl doxygen ed file g++ gcc gdb git \
-    liblz4-dev libsnappy-dev libsodium-dev libzstd-dev lld-22 lldb-22 llvm-22 \
-    make ninja-build python-is-python3 python3 python3-dev python3-pip \
-    python3-venv swig universal-ctags zlib1g-dev \
+    aspell aspell-en ca-certificates ccache clang clang-format clang-tidy \
+    clangd cmake curl doxygen ed file g++ gcc gdb git liblz4-dev libsnappy-dev \
+    libsodium-dev libzstd-dev lld lldb llvm make ninja-build python-is-python3 \
+    python3 python3-dev python3-pip python3-venv swig universal-ctags \
+    zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
-
-ENV PATH="/usr/lib/llvm-22/bin:$PATH"
 
 RUN useradd -m -s /bin/bash wiredtiger
 USER wiredtiger

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -43,18 +43,6 @@ RUN apt-get update && \
     zlib1g-dev=1:1.3.dfsg+really1.3.1-1ubuntu3 \
     && rm -rf /var/lib/apt/lists/*
 
-# libtinfo5 is required by dist/s_clang_format. It is not available on Ubuntu
-# 26.04, so install the Ubuntu 22.04 version.
-RUN ARCH=$(dpkg --print-architecture) && \
-    if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "i386" ]; then \
-      BASE_URL="http://security.ubuntu.com/ubuntu/pool/universe/n/ncurses"; \
-    else \
-      BASE_URL="http://ports.ubuntu.com/ubuntu-ports/pool/universe/n/ncurses"; \
-    fi && \
-    curl -fsSL "${BASE_URL}/libtinfo5_6.3-2ubuntu0.1_${ARCH}.deb" -o libtinfo5.deb && \
-    dpkg -i libtinfo5.deb && \
-    rm libtinfo5.deb
-
 RUN useradd -m -s /bin/bash wiredtiger
 USER wiredtiger
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,45 +2,11 @@ FROM ubuntu:26.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    aspell=0.60.8.2-3 \
-    aspell-en=2020.12.07-0-1.1build1 \
-    ca-certificates=20260223 \
-    ccache=4.12.3-1 \
-    clang-22=1:22.1.2-1ubuntu1 \
-    clang-format-22=1:22.1.2-1ubuntu1 \
-    clang-tidy-22=1:22.1.2-1ubuntu1 \
-    clangd-22=1:22.1.2-1ubuntu1 \
-    cmake=4.2.3-2ubuntu2 \
-    curl=8.18.0-1ubuntu2.1 \
-    diffutils=1:3.12-1 \
-    doxygen=1.15.0+ds1-1ubuntu3 \
-    ed=1.22.4-1 \
-    file=1:5.46-5build2 \
-    findutils=4.10.0-3build2 \
-    g++=4:15.2.0-5ubuntu1 \
-    gcc=4:15.2.0-5ubuntu1 \
-    gdb=17.1-2ubuntu1 \
-    git=1:2.53.0-1ubuntu1 \
-    gzip=1.14-1~exp2ubuntu1 \
-    liblz4-dev=1.10.0-8 \
-    libsnappy-dev=1.2.2-2 \
-    libsodium-dev=1.0.18-2 \
-    libzstd-dev=1.5.7+dfsg-3 \
-    lld-22=1:22.1.2-1ubuntu1 \
-    lldb-22=1:22.1.2-1ubuntu1 \
-    llvm-22=1:22.1.2-1ubuntu1 \
-    make=4.4.1-3 \
-    ninja-build=1.13.2-1 \
-    perl=5.40.1-7build1 \
-    python3=3.14.3-0ubuntu2 \
-    python3-dev=3.14.3-0ubuntu2 \
-    python-is-python3=3.13.3-1+build1 \
-    python3-pip=25.1.1+dfsg-1ubuntu2 \
-    python3-venv=3.14.3-0ubuntu2 \
-    swig=4.4.0-1 \
-    tar=1.35+dfsg-4 \
-    universal-ctags=6.2.1-1 \
-    zlib1g-dev=1:1.3.dfsg+really1.3.1-1ubuntu3 \
+    aspell aspell-en ca-certificates ccache clang-22 clang-format-22 \
+    clang-tidy-22 clangd-22 cmake curl diffutils doxygen ed file findutils g++ \
+    gcc gdb git gzip liblz4-dev libsnappy-dev libsodium-dev libzstd-dev lld-22 \
+    lldb-22 llvm-22 make ninja-build perl python-is-python3 python3 \
+    python3-dev python3-pip python3-venv swig tar universal-ctags zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
 
 ENV PATH="/usr/lib/llvm-22/bin:$PATH"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -18,9 +18,6 @@ RUN python -m venv /home/wiredtiger/venv
 ENV PATH="/home/wiredtiger/venv/bin:$PATH"
 
 RUN pip install --no-cache-dir \
-    find_libpython==0.4.0 \
-    gcovr==5.0 \
-    psutil==5.9.4 \
-    ruff==0.4.5
+    find_libpython==0.4.0 gcovr==5.0 psutil==5.9.4 ruff==0.4.5
 
 WORKDIR /workdir

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,70 @@
+FROM ubuntu:26.04
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    aspell=0.60.8.2-3 \
+    aspell-en=2020.12.07-0-1.1build1 \
+    ca-certificates=20260223 \
+    ccache=4.12.3-1 \
+    clang=1:21.1.6-71 \
+    clang-format=1:21.1.6-71 \
+    clang-tidy=1:21.1.6-71 \
+    clangd=1:21.1.6-71 \
+    cmake=4.2.3-2ubuntu2 \
+    curl=8.18.0-1ubuntu2.1 \
+    diffutils=1:3.12-1 \
+    doxygen=1.15.0+ds1-1ubuntu3 \
+    ed=1.22.4-1 \
+    file=1:5.46-5build2 \
+    findutils=4.10.0-3build2 \
+    g++=4:15.2.0-5ubuntu1 \
+    gcc=4:15.2.0-5ubuntu1 \
+    gdb=17.1-2ubuntu1 \
+    git=1:2.53.0-1ubuntu1 \
+    gzip=1.14-1~exp2ubuntu1 \
+    liblz4-dev=1.10.0-8 \
+    libsnappy-dev=1.2.2-2 \
+    libsodium-dev=1.0.18-2 \
+    libzstd-dev=1.5.7+dfsg-3 \
+    lld=1:21.1.6-71 \
+    lldb=1:21.1.6-71 \
+    llvm=1:21.1.6-71 \
+    make=4.4.1-3 \
+    ninja-build=1.13.2-1 \
+    perl=5.40.1-7build1 \
+    python3=3.14.3-0ubuntu2 \
+    python3-dev=3.14.3-0ubuntu2 \
+    python-is-python3=3.13.3-1+build1 \
+    python3-pip=25.1.1+dfsg-1ubuntu2 \
+    python3-venv=3.14.3-0ubuntu2 \
+    swig=4.4.0-1 \
+    tar=1.35+dfsg-4 \
+    universal-ctags=6.2.1-1 \
+    zlib1g-dev=1:1.3.dfsg+really1.3.1-1ubuntu3 \
+    && rm -rf /var/lib/apt/lists/*
+
+# libtinfo5 is required by dist/s_clang_format. It is not available on Ubuntu
+# 26.04, so install the Ubuntu 22.04 version.
+RUN ARCH=$(dpkg --print-architecture) && \
+    if [ "$ARCH" = "amd64" ] || [ "$ARCH" = "i386" ]; then \
+      BASE_URL="http://security.ubuntu.com/ubuntu/pool/universe/n/ncurses"; \
+    else \
+      BASE_URL="http://ports.ubuntu.com/ubuntu-ports/pool/universe/n/ncurses"; \
+    fi && \
+    curl -fsSL "${BASE_URL}/libtinfo5_6.3-2ubuntu0.1_${ARCH}.deb" -o libtinfo5.deb && \
+    dpkg -i libtinfo5.deb && \
+    rm libtinfo5.deb
+
+RUN useradd -m -s /bin/bash wiredtiger
+USER wiredtiger
+
+RUN python -m venv /home/wiredtiger/venv
+ENV PATH="/home/wiredtiger/venv/bin:$PATH"
+
+RUN pip install --no-cache-dir \
+    find_libpython==0.4.0 \
+    gcovr==5.0 \
+    psutil==5.9.4 \
+    ruff==0.4.5
+
+WORKDIR /workdir

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+{
+  "name": "WiredTiger",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "llvm-vs-code-extensions.vscode-clangd",
+        "ms-python.python",
+        "ms-vscode.cmake-tools",
+        "ms-vscode.cpptools",
+        "redhat.vscode-yaml"
+      ],
+      "settings": {
+        "C_Cpp.intelliSenseEngine": "disabled",
+        "clangd.path": "clangd"
+      }
+    }
+  }
+}

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -58,6 +58,20 @@ choco install swig
 choco install python --pre
 ```
 
+##### Docker
+
+Alternatively, the repository ships a Dockerfile in `.devcontainer/Dockerfile`
+with all required and optional build dependencies pre-installed. Build the image
+and mount the repository:
+
+```bash
+docker build -t wiredtiger-dev .devcontainer
+docker run -it -v "$PWD":/workdir wiredtiger-dev
+```
+
+The `.devcontainer/devcontainer.json` also makes this image usable as a
+[Dev Container](https://containers.dev/) in supporting editors (e.g. VS Code).
+
 ### Building the WiredTiger Library
 
 Building the WiredTiger library is relatively straightforward. Navigate to the top level of the WiredTiger repository and run the following commands:


### PR DESCRIPTION
Our docs state that building WiredTiger only requires CMake and a semi-recent C11 compiler. In reality, a complete development setup also requires Python, Git, SWIG, the LLVM toolchain, and a few other things.

This PR adds an optional .devcontainer configuration to the repo to serve as a reference for a minimal development environment. This will provide a reproducible and isolated setup without cluttering host system packages.

While this does not replace the official Evergreen workstations, it gives people the option of a batteries-included, no-thinking-required local development environment. It also helps validate that WiredTiger can be built with basic open-source tools, which is useful for the open-source community who lack access to our internal workstation images.

The MongoDB repo already does something similar here for reference: https://github.com/mongodb/mongo/blob/master/.devcontainer/Dockerfile