### PR TITLE
WT-17628 Allow s_docs to work with newer Doxygen versions

### DIFF
--- a/dist/s_docs
+++ b/dist/s_docs
@@ -194,17 +194,28 @@ setup_doxygen()
         exit 0
     }
 
-    # Do not build the documentation if doxygen version is not compatible.
+    # Select Doxyfile based on doxygen major.minor version.
     v=$(doxygen --version)
-    case "$v" in
-        1.8.17) doxyfile="Doxyfile";;
-        1.9.1) doxyfile="Doxyfile.9";;
-        1.9.3) doxyfile="Doxyfile.9";;
-        1.11.*) doxyfile="Doxyfile.11";;
-        *)
-            echo "$0 skipped: unsupported version of doxygen: $v, not 1.8.17, 1.9.1, 1.9.3 or 1.11.*"
-            exit 0
-    esac
+    major=$(cut -d. -f1 <<< "$v")
+    minor=$(cut -d. -f2 <<< "$v")
+
+    # Doxygen < 1.8:
+    if [ "$major" -lt 1 ] || { [ "$major" -eq 1 ] && [ "$minor" -lt 8 ]; }; then
+        echo "$0 failed: doxygen $v is too old, need 1.8 or later"
+        exit 1
+
+    # Doxygen 1.8:
+    elif [ "$major" -eq 1 ] && [ "$minor" -eq 8 ]; then
+        doxyfile="Doxyfile"
+
+    # Doxygen 1.9 - 1.10:
+    elif [ "$major" -eq 1 ] && [ "$minor" -lt 11 ]; then
+        doxyfile="Doxyfile.9"
+
+    # Doxygen >= 1.11:
+    else
+        doxyfile="Doxyfile.11"
+    fi
 }
 
 build()

--- a/src/docs/arch-fast-truncate.dox
+++ b/src/docs/arch-fast-truncate.dox
@@ -703,7 +703,7 @@ Get an empty page instead and mark it instantiated.}
 Return \c WT_NOTFOUND instead of reading the page if we are skipping deleted pages.}
 
 @row{bt_split.c, Hook, in \c __split_parent_discard_ref,
-Discard the \c page_del field of the }\c WT_REF.
+Discard the \c page_del field of the \c WT_REF.}
 @row{bt_split.c, Hook, in \c __split_parent,
 For VLCS trees\, avoid discarding the leftmost child even if it's deleted.}
 


### PR DESCRIPTION
dist/s_docs selects a Doxyfile based on an exact-match case statement
against the installed Doxygen version string:

1.8.17 -> Doxyfile
1.9.1 -> Doxyfile.9
1.9.3 -> Doxyfile.9
1.11.* -> Doxyfile.11

This has two problems. First, any version not in the list - including
1.8.16, 1.9.2, 1.9.4, 1.9.5, or anything in the 1.10.x range - silently
exits 0 and skips doc generation with no indication of what to do.

Also, Doxygen 1.11.* is ancient. A Homebrew install of Doxygen today
gives you 1.17.

Update s_docs to be future-proof.