### PR TITLE
WT-17626 s_clang_format: simplify binary download step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@ cscope.out
 cscope.po.out
 build/
 build_*/
-dist/clang-format
 /docs/
 test-compatibility-run/
 COMPATIBILITY_TEST/

--- a/dist/s_clang_format
+++ b/dist/s_clang_format
@@ -6,38 +6,16 @@ setup_trap
 cd_top
 check_fast_mode_flag
 
+venv="$TOP_DIR/.venv"
+
 download_clang_format() {
     version=$1
-    arch_and_os="$(uname -m)-$(uname)"
-    archive=dist/clang-format.tar.gz
-
-    # Adding more clang-format binaries requires uploading them to boxes.10gen
-    # You can either get the clang-format binary from the llvm releases page
-    # (https://github.com/llvm/llvm-project/releases) or compile clang-format yourself.
-    # Place the binary in dist/ and confirm that s_clang_format runs correctly, then
-    # tar a folder containing just the clang-format binary with the format:
-    # clang-format-llvm-${version}-${arch_and_os}/
-    #     clang-format
-    # into a tarball named clang-format-llvm-${version}-${arch_and_os}.tar.gz
-    # The tarball should extract using the tar command below.
-    # This tarball can then be uploaded via a Jira request to the BUILD team.
-    if [[ "$arch_and_os" =~ ^("aarch64-Linux"|"x86_64-Darwin"|"arm64-Darwin"|"x86_64-Linux")$ ]] ; then
-        curl -s https://s3.amazonaws.com/boxes.10gen.com/build/clang-format-llvm-"$version"-"$arch_and_os".tar.gz -o $archive
-        tar --strip=1 -C dist/ -xf $archive clang-format-llvm-"$version"-"$arch_and_os"/clang-format && rm $archive
-        chmod +x ./dist/clang-format
-
-        if [[ "$arch_and_os" =~ ^("x86_64-Darwin"|"arm64-Darwin")$ ]] ; then
-            # Needed to get around the macOS code signing issue.
-            xattr -c ./dist/clang-format
-        fi
-    else
-         echo "$0: unsupported architecture and OS combination '$arch_and_os' to run clang_format"
-         return 1
-    fi
+    python3 -m venv "$venv"
+    "$venv/bin/pip" install --quiet --disable-pip-version-check "clang-format==$version"
 }
 
 # Override existing Clang-Format versions in the PATH.
-export PATH="${PWD}/dist":$PATH
+export PATH="$venv/bin":$PATH
 
 # Check if Clang-Format is already available with the desired version.
 desired_version="12.0.1"


### PR DESCRIPTION
To ensure consistent code formatting across developer machines,
s_clang_format requires clang-format 12.0.1. If a suitable local binary
is not already available, the script falls back to downloading a
prebuilt binary from MongoDB-managed S3 storage. Those binaries were
published by the BUILD team. They have old dependencies that are
difficult to source on modern systems.

To avoid continuing to maintain our own binary cache, and to make it
easier to provide prebuilt binaries across operating systems and
architectures, use published clang-format wheels from PyPI instead.
These are statically linked so they work more reliably across different
systems.