### PR TITLE
WT-17616 Update comment guidelines in contributing guide and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,24 @@ Working code samples live in `examples/c/` and `examples/python/`.
 
 Full rules in @CONTRIBUTING.md.
 
+### Comment Prose Style
+
+Mechanics — delimiter style, function-header layout, FIXME tags, wrap width — live in @CONTRIBUTING.md and are enforced by `dist/s_style`, `dist/comment_style.py`, and `dist/s_comment.py`. The guidance here is about what to write in the prose, not how to punctuate it.
+
+- **Be terse.** Aim for one sentence. If you are writing three, you are probably restating the code, explaining things the reader already knows, or narrating the editing session. The codebase prefers no comment to a wordy one — most lines have no comment at all.
+- **Write for a working WiredTiger engineer.** Do not explain concepts a developer in this codebase already understands — hazard pointers, reconciliation, the history store, eviction, dhandles, session and cursor semantics, btree splits, transactions, timestamps.
+- **Reserve block comments for *why*, not *what*.** Good targets:
+  - Concurrency invariants and the reason for an ordering, barrier, or lock.
+  - Counter-intuitive control flow, loop direction, or termination condition.
+  - Performance constraints, on-disk format constraints, or block-manager limits.
+  - References to the algorithm, data structure, or paper being implemented.
+  - Cross-references to other functions whose contract this code depends on.
+- **Do not block-comment routine code:** variable declarations, simple assignments, standard `WT_RET()` / `WT_ERR()` chains, obvious branches.
+- **Describe roles, not identifiers.** Write `the cursor` or `the page being evicted`, not `cbt` or `ref->page`.
+- **Anchor in the codebase, not the editing session.** A comment must read sensibly to someone who only sees the final code. Do not reference the Jira ticket, PR, branch, or author behind the change — that belongs in the commit message. Do not reference closed tickets or merged PRs. Above all, do not reference work that only ever existed in the editing session — earlier iterations, an approach that was reverted, an experiment that never landed. 
+- **Prefer `FIXME-WT-XXXX` over `TODO` and `XXX` in new code.** Legacy `TODO` / `XXX` markers exist but are not the preferred voice; file a ticket and reference it.
+- **No decorative material.** Skip banners, ASCII separators, and section dividers inside functions. Skip `added by` / `modified for X` / `see ticket Y` provenance notes.
+
 ## Test Frameworks
 
 | Framework | Location | Purpose |

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -73,6 +73,32 @@ existing example in the source code and copy it.
     // This is not a
     // valid multi-line comment.
 
+* Every function definition is preceded by a header comment of the form::
+
+    /*
+     * __wt_foo --
+     *     One-sentence description of what the function does.
+     */
+    int
+    __wt_foo(WT_SESSION_IMPL *session, ...)
+
+  The function name appears on its own line, followed by a space and ``--``.
+  The description is indented four spaces past the asterisk (text starts in
+  column 8). Additional paragraphs are separated by a blank `` *`` line.
+* Struct and typedef field comments are trailing single-line comments on
+  the same line as the field, kept to a short noun phrase::
+
+    uint32_t id; /* File ID, for logging */
+    const char *key_format; /* Key format */
+
+  Group-level explanation belongs in a block comment above the struct or
+  above a labelled group of fields, never above an individual field.
+* Flag definitions live between ``/* AUTOMATIC FLAG VALUE GENERATION START N */``
+  and ``/* AUTOMATIC FLAG VALUE GENERATION STOP N */`` markers.
+* A ``FIXME-WT-XXXX`` reference must point at an open Jira ticket. Remove
+  or re-target the comment once the ticket is closed.
+* Do not place any file-level overview comment between the copyright block
+  and the first ``#include``.
 * Lines that need to be wrapped should be split so successive lines
   are longer if possible. This applies to function signatures too
   (exceptions are possible here). If in doubt, Clang-Format will


### PR DESCRIPTION
- The AGENTS.md update targets the writing style of agents.
- The contributing guide update should be useful to both engineers and agents.