### PR TITLE
WT-17595 Fix data races around session name

### DIFF
--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1448,7 +1448,7 @@ __conn_open_session(WT_CONNECTION *wt_conn, WT_EVENT_HANDLER *event_handler, con
 
     session_ret = NULL;
     WT_ERR(__wt_open_session(conn, event_handler, config, true, &session_ret));
-    session_ret->name = "connection-open-session";
+    __wt_atomic_store_ptr_relaxed(&session_ret->name, "connection-open-session");
     *wt_sessionp = &session_ret->iface;
 
 err:

--- a/src/include/session_inline.h
+++ b/src/include/session_inline.h
@@ -32,14 +32,15 @@ __wt_single_thread_check_start(WT_SESSION_IMPL *s)
     if (!WT_SESSION_IS_DEFAULT(s) && s->thread_check.owning_thread != current_tid) {
         ret = __wt_spin_trylock(s, &s->thread_check.lock);
 
+        const char *session_name = __wt_atomic_load_ptr_relaxed(&s->name);
         WT_ASSERT_ALWAYS(s, ret == 0,
           "Session %" PRIu32
           " is accessed concurrently by multiple threads: "
           "current thread %" PRIuMAX ", owning thread %" PRIuMAX
           " (active op: %s, last op: %s, api depth: %u, dhandle: %s)",
-          s->id, current_tid, s->thread_check.owning_thread, s->name != NULL ? s->name : "none",
-          s->lastop != NULL ? s->lastop : "none", s->api_call_counter,
-          s->dhandle != NULL ? s->dhandle->name : "none");
+          s->id, current_tid, s->thread_check.owning_thread,
+          session_name != NULL ? session_name : "none", s->lastop != NULL ? s->lastop : "none",
+          s->api_call_counter, s->dhandle != NULL ? s->dhandle->name : "none");
 
         s->thread_check.owning_thread = current_tid;
     }

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -2631,7 +2631,7 @@ __open_session(WT_CONNECTION_IMPL *conn, WT_EVENT_HANDLER *event_handler, const 
         session_ret->iface = F_ISSET(conn, WT_CONN_READONLY) ? stds_readonly : stds;
     session_ret->iface.connection = &conn->iface;
 
-    session_ret->name = NULL;
+    __wt_atomic_store_ptr_relaxed(&session_ret->name, NULL);
     session_ret->id = i;
 
 #ifdef HAVE_UNITTEST_ASSERTS

--- a/src/session/session_helper.c
+++ b/src/session/session_helper.c
@@ -78,13 +78,15 @@ __wt_session_dump(WT_SESSION_IMPL *session, WT_SESSION_IMPL *dump_session, bool 
     WT_CURSOR *cursor;
     WT_DECL_ITEM(buf);
     WT_DECL_RET;
+    const char *session_name;
 
     WT_ERR(__wt_scr_alloc(session, 0, &buf));
 
     WT_ERR(__wt_msg(
       session, "Session: ID: %" PRIu32 " @: 0x%p", dump_session->id, (void *)dump_session));
-    WT_ERR(
-      __wt_msg(session, "  Name: %s", dump_session->name == NULL ? "EMPTY" : dump_session->name));
+
+    session_name = __wt_atomic_load_ptr_relaxed(&dump_session->name);
+    WT_ERR(__wt_msg(session, "  Name: %s", session_name == NULL ? "EMPTY" : session_name));
     WT_ERR(__wt_msg(session, "  Last operation: %s",
       dump_session->lastop == NULL ? "NONE" : dump_session->lastop));
     WT_ERR(__wt_msg(session, "  Current dhandle: %s",

--- a/src/support/hazard.c
+++ b/src/support/hazard.c
@@ -415,6 +415,8 @@ __wt_hazard_check_assert(WT_SESSION_IMPL *session, void *ref, bool waitfor)
             break;
         __wt_sleep(0, 10 * WT_THOUSAND);
     }
+
+    const char *session_name = __wt_atomic_load_ptr_relaxed(&s->name);
 #ifdef HAVE_DIAGNOSTIC
     /*
      * In diagnostic mode we also track the file and line where the hazard pointer is set. If this
@@ -422,10 +424,11 @@ __wt_hazard_check_assert(WT_SESSION_IMPL *session, void *ref, bool waitfor)
      */
     __wt_errx(session,
       "hazard pointer reference to discarded object: (%p: session %p name %s: %s, line %d)",
-      (void *)hp->ref, (void *)s, s->name == NULL ? "UNKNOWN" : s->name, hp->func, hp->line);
+      (void *)hp->ref, (void *)s, session_name == NULL ? "UNKNOWN" : session_name, hp->func,
+      hp->line);
 #else
     __wt_errx(session, "hazard pointer reference to discarded object: (%p: session %p name %s)",
-      (void *)hp->ref, (void *)s, s->name == NULL ? "UNKNOWN" : s->name);
+      (void *)hp->ref, (void *)s, session_name == NULL ? "UNKNOWN" : session_name);
 #endif
     return (false);
 }

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -2765,13 +2765,15 @@ __wt_verbose_dump_txn_one(
 
     buf_len = 512;
     WT_RET(__wt_scr_alloc(session, buf_len, &buf));
+
+    const char *session_name = __wt_atomic_load_ptr_relaxed(&txn_session->name);
     WT_ERR(__wt_snprintf((char *)buf->data, buf_len,
       "session ID: %" PRIu32 ", txn ID: %" PRIu64 ", pinned ID: %" PRIu64
       ", metadata pinned ID: %" PRIu64 ", name: %s",
       txn_session->id, __wt_atomic_load_uint64_v_relaxed(&txn_shared->id),
       __wt_atomic_load_uint64_v_relaxed(&txn_shared->pinned_id),
       __wt_atomic_load_uint64_v_relaxed(&txn_shared->metadata_pinned),
-      txn_session->name == NULL ? "EMPTY" : txn_session->name));
+      session_name == NULL ? "EMPTY" : session_name));
 
     if (error_code != 0)
         WT_ERR_MSG(session, error_code, "%s, %s", (char *)buf->data,


### PR DESCRIPTION
This looks to be a similar class of data race captured in WT-17249.