### PR TITLE
WT-17643 Stop dist/s_mentions from grepping its own tmp file

### DIFF
--- a/dist/s_mentions
+++ b/dist/s_mentions
@@ -26,26 +26,12 @@ fi
 # Get what could be the ticket id.
 ticket_id=$(echo "$branch_name" | cut -d "-" -f-2)
 
-# Exclude s_all's per-step output files. They live in dist/ and contain grep matches for the
-# ticket id, so without this exclude the recursive grep reads its own stdout and grows the tmp
-# file unboundedly (feedback loop).
-search_function="grep -Iinr --exclude-dir=.git --exclude=__s_all_tmp_*"
-
-# Find the name of the build folders WiredTiger has been compiled in.
-# Users can name this folder anything, but it needs to be in the rootdir and to contain CMakeFiles
-build_files=$(find ../ -maxdepth 2 -name CMakeFiles)
-for build_dir in $build_files; do
-    build_folder=$(basename $(dirname $build_dir))
-    search_function="$search_function --exclude-dir=$build_folder"
-done
-
-search_function="$search_function $ticket_id ../ 2>&1"
-
-# Check for comments related to the ticket.
-if eval "$search_function >/dev/null" ; then
-    echo "There are comments mentioning $ticket_id in the code, please check if they need to be \
-resolved:"
-    eval "$search_function"
+# Check for comments related to the ticket. git grep searches only tracked files, so build
+# directories and temporary files are excluded automatically. Note: newly created files that are
+# not yet added to git will be missed, but they can be checked once they are tracked.
+if git -C .. grep -Iin "$ticket_id" > /dev/null 2>&1; then
+    echo "There are comments mentioning $ticket_id in the code, please check if they need to be resolved:"
+    git -C .. grep -Iin "$ticket_id"
 fi
 
 exit 0

--- a/dist/s_mentions
+++ b/dist/s_mentions
@@ -26,7 +26,10 @@ fi
 # Get what could be the ticket id.
 ticket_id=$(echo "$branch_name" | cut -d "-" -f-2)
 
-search_function="grep -Iinr --exclude-dir=.git"
+# Exclude s_all's per-step output files. They live in dist/ and contain grep matches for the
+# ticket id, so without this exclude the recursive grep reads its own stdout and grows the tmp
+# file unboundedly (feedback loop).
+search_function="grep -Iinr --exclude-dir=.git --exclude=__s_all_tmp_*"
 
 # Find the name of the build folders WiredTiger has been compiled in.
 # Users can name this folder anything, but it needs to be in the rootdir and to contain CMakeFiles


### PR DESCRIPTION
## Summary

- `dist/s_fast` / `dist/s_all` hang on any `wt-NNNN` branch because `s_mentions` recursively greps from `dist/`'s parent for the branch's ticket id. The walk reads its own in-flight stdout file (`dist/__s_all_tmp_-s_mentions-<pid>`), every match line contains the ticket id, so grep keeps re-matching its own output and the tmp file grows unboundedly (saw 60 GB before kill).
- Add `--exclude=__s_all_tmp_*` so the recursive grep cannot read `s_all`'s per-step output files.

## Test plan

- [x] Run `dist/s_fast` from a worktree on a `wt-NNNN` branch and confirm it completes in normal time with no oversized files left in `dist/`.
- [x] Confirm s_mentions still surfaces real matches (the worktree's `.git` pointer line was reported as expected).