### PR TITLE
WT-17642 Add regression test for per-checkpoint handle stats reset

### DIFF
--- a/test/suite/test_config09.py
+++ b/test/suite/test_config09.py
@@ -92,13 +92,26 @@ class test_config09(wttest.WiredTigerTestCase):
         self.assertEqual(val, 1024)
 
         self.update_tables()
-        val = self.get_stat(stat.conn.checkpoint_handle_applied)
+        applied = self.get_stat(stat.conn.checkpoint_handle_applied)
         # We cannot assert it is equal to half because there could be other
         # internal tables in the count. Assert it is less than 75% and at least
         # half.
-        self.assertGreaterEqual(val, self.ntables // 2)
-        self.assertLess(val, self.ntables // 4 * 3)
-        val = self.get_stat(stat.conn.checkpoint_handle_skipped)
-        self.assertNotEqual(val, 0)
+        self.assertGreaterEqual(applied, self.ntables // 2)
+        self.assertLess(applied, self.ntables // 4 * 3)
+        skipped = self.get_stat(stat.conn.checkpoint_handle_skipped)
+        self.assertNotEqual(skipped, 0)
+
+        # The handle stats should be reset at the start of each gather and
+        # then set to the per-checkpoint value. Two back-to-back checkpoints
+        # over the same working set must therefore publish the same value;
+        # if the reset is missing, the second value will be roughly double
+        # the first.
+        locked_1 = self.get_stat(stat.conn.checkpoint_handle_locked)
+        meta_checked_1 = self.get_stat(stat.conn.checkpoint_handle_meta_checked)
+        self.session.checkpoint()
+        locked_2 = self.get_stat(stat.conn.checkpoint_handle_locked)
+        meta_checked_2 = self.get_stat(stat.conn.checkpoint_handle_meta_checked)
+        self.assertEqual(locked_1, locked_2)
+        self.assertEqual(meta_checked_1, meta_checked_2)
 
         self.conn.close()


### PR DESCRIPTION
## Summary

Adds a regression test that verifies `checkpoint_handle_locked` and `checkpoint_handle_meta_checked` publish the per-checkpoint value rather than a cumulative count across the lifetime of the connection.

Two back-to-back checkpoints over the same working set must produce identical values for both stats — if the reset at the start of each gather were ever missing, the second value would be roughly double the first.

## Context

[WT-17642](https://jira.mongodb.org/browse/WT-17642) tracks a customer-visible bug on `mongodb-8.0` where `checkpoint_handle_dropped` / `_locked` / `_meta_checked` (and their `_duration` companions) accumulate forever instead of resetting at the start of each gather. The bug was introduced by [WT-12440](https://jira.mongodb.org/browse/WT-12440), which added new counters but forgot to zero them in `__wt_conn_btree_apply`.

The structural fix in [WT-13990](https://jira.mongodb.org/browse/WT-13990) (`__wt_checkpoint_handle_stats_clear`) already resets all five counters together on `develop` / `mongodb-8.2` / `mongodb-8.3`, so this branch is not buggy today. This PR only adds a regression test so a future refactor that breaks the clear/publish bracketing would be caught.

When we will backport this to 8.0, we will backport the reset logic that is missing there.

## Test plan

- [x] `python3 ../test/suite/run.py test_config09` passes on develop with the patched test.
- [x] Confirmed the same assertions fail on stock `mongodb-8.0` (locked = 100, expected 50) and pass after the minimal 8.0 fix.