### PR TITLE
WT-17274 Write prepared fast truncate

### DIFF
--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -840,7 +840,7 @@ __evict_child_check(WT_SESSION_IMPL *session, WT_REF *parent)
              *     4. Otherwise, check if the operation is globally visible.
              *
              * Even though we specifically can't evict prepared truncations, we don't need to deploy
-             * the special-case logic for prepared transactions in __wt_page_del_visible; prepared
+             * the special-case logic for prepared transactions; prepared
              * transactions aren't committed so they'll fail the first check.
              */
             if (!__wt_page_del_committed_set(child->page_del))

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -2752,7 +2752,7 @@ __wt_btcur_skip_page(
      * Check the fast-truncate information; there are 3 cases:
      *
      * (1) The page is in the WT_REF_DELETED state and page_del is NULL. The page is deleted. This
-     *     case is folded into the next because __wt_page_del_visible handles it.
+     *     case is folded into the next because visibility of truncate function handles it.
      * (2) The page is in the WT_REF_DELETED state and page_del is not NULL. The page is deleted
      *     if the truncate operation is visible. Look at page_del; we could use the info from the
      *     address cell below too, but that's slower.
@@ -2760,7 +2760,7 @@ __wt_btcur_skip_page(
      *     will serve for readonly/unmodified pages, and for modified pages we can't skip the page.
      *     (This case is checked further below.)
      *
-     * In all cases, make use of the option to __wt_page_del_visible to hide prepared transactions,
+     * In all cases, make use of the option to hide prepared transactions,
      * as we shouldn't skip pages where the deletion is prepared but not committed.
      */
     if (previous_state == WT_REF_DELETED && __wt_page_del_visible(session, ref->page_del, true)) {

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -196,17 +196,23 @@ __wt_check_addr_validity(WT_SESSION_IMPL *session, WT_TIME_AGGREGATE *ta, bool e
  *     Pack the validity window for an address.
  */
 static WT_INLINE void
-__cell_pack_addr_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_AGGREGATE *ta)
+__cell_pack_addr_validity(
+  WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_AGGREGATE *ta, bool is_prepared_fast_truncate)
 {
     uint8_t flags, *flagsp;
 
-    /* Globally visible values have no associated validity window. */
-    if (WT_TIME_AGGREGATE_IS_EMPTY(ta)) {
+    /*
+     * A prepared fast-truncate and a prepared time aggregate cannot be on the same page.
+     */
+    WT_ASSERT(session, !(ta->prepare && is_prepared_fast_truncate));
+
+    if (WT_TIME_AGGREGATE_IS_EMPTY(ta) && !is_prepared_fast_truncate) {
         ++*pp;
         return;
     }
 
-    WT_IGNORE_RET(__wt_check_addr_validity(session, ta, false));
+    if (!WT_TIME_AGGREGATE_IS_EMPTY(ta))
+        WT_IGNORE_RET(__wt_check_addr_validity(session, ta, false));
 
     **pp |= WT_CELL_SECOND_DESC;
     ++*pp;
@@ -263,6 +269,8 @@ __cell_pack_addr_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_AGGREG
         LF_SET(WT_CELL_TS_DURABLE_STOP);
     }
     if (ta->prepare)
+        LF_SET(WT_CELL_PREPARE);
+    if (is_prepared_fast_truncate)
         LF_SET(WT_CELL_PREPARE);
 
     *flagsp = flags;
@@ -566,10 +574,17 @@ __wt_cell_build_addr(WT_SESSION_IMPL *session, WT_CELL *cell, uint8_t cell_type,
         WT_ASSERT(session, cell_type == WT_CELL_ADDR_DEL || cell_type == WT_CELL_ADDR_LEAF_NO);
         cell_type = WT_CELL_ADDR_DEL;
 
-        /* We should never be in an in-progress prepared state. */
+        /*
+         * In-progress prepared states are only written to disk when preserve_prepared is enabled;
+         * otherwise only committed (INIT) or resolved-but-not-yet-committed (RESOLVED) states are
+         * expected.
+         */
         WT_ASSERT(session,
           page_del->prepare_state == WT_PREPARE_INIT ||
-            page_del->prepare_state == WT_PREPARE_RESOLVED);
+            page_del->prepare_state == WT_PREPARE_RESOLVED ||
+            (F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED) &&
+              (page_del->prepare_state == WT_PREPARE_INPROGRESS ||
+                page_del->prepare_state == WT_PREPARE_LOCKED)));
     }
 
     /* Just pack and return the cell size. */
@@ -584,24 +599,40 @@ static WT_INLINE size_t
 __wt_cell_pack_addr(WT_SESSION_IMPL *session, WT_CELL *cell, u_int cell_type, uint64_t recno,
   WT_PAGE_DELETED *page_del, WT_TIME_AGGREGATE *ta, size_t size)
 {
-    uint8_t *p;
+    uint8_t *p, prepare_state;
+    bool is_prepared_fast_truncate;
+
+    prepare_state = page_del != NULL ?
+      __wt_atomic_load_uint8_v_acquire(&page_del->prepare_state) :
+      WT_PREPARE_INIT;
+    is_prepared_fast_truncate =
+      (prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED);
 
     /* Start building a cell: the descriptor byte starts zero. */
     p = cell->__chunk;
     *p = '\0';
 
-    __cell_pack_addr_validity(session, &p, ta);
+    __cell_pack_addr_validity(session, &p, ta, is_prepared_fast_truncate);
 
     /*
      * If passed fast-delete information, append the fast-delete information after the aggregated
-     * timestamp information.
+     * timestamp information. A prepared fast-truncate stores the prepare timestamp and prepared_id
+     * in place of the committed start/durable timestamps so that recovery can reconstruct the
+     * prepared state.
      */
     if (page_del != NULL) {
         WT_ASSERT(session, cell_type == WT_CELL_ADDR_DEL);
 
         WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->txnid));
-        WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->pg_del_start_ts));
-        WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->pg_del_durable_ts));
+        if (is_prepared_fast_truncate) {
+            WT_ASSERT(session, F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED));
+            WT_ASSERT(session, page_del->prepared_id != WT_PREPARED_ID_NONE);
+            WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->prepare_ts));
+            WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->prepared_id));
+        } else {
+            WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->pg_del_start_ts));
+            WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->pg_del_durable_ts));
+        }
     }
 
     if (recno == WT_RECNO_OOB)

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -572,17 +572,6 @@ __wt_cell_build_addr(WT_SESSION_IMPL *session, WT_CELL *cell, uint8_t cell_type,
         WT_ASSERT(session, cell_type == WT_CELL_ADDR_DEL || cell_type == WT_CELL_ADDR_LEAF_NO);
         cell_type = WT_CELL_ADDR_DEL;
 
-        /*
-         * In-progress prepared states are only written to disk when preserve_prepared is enabled on
-         * a disaggregated btree.
-         */
-        WT_ASSERT(session,
-          page_del->prepare_state == WT_PREPARE_INIT ||
-            page_del->prepare_state == WT_PREPARE_RESOLVED ||
-            (F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED) &&
-              (page_del->prepare_state == WT_PREPARE_INPROGRESS ||
-                page_del->prepare_state == WT_PREPARE_LOCKED)));
-
         /* Use prepared_id to determine whether to write a prepared fast-truncate cell */
         is_prepared_fast_truncate = page_del->prepared_id != WT_PREPARED_ID_NONE &&
           F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED);

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -580,7 +580,6 @@ __wt_cell_build_addr(WT_SESSION_IMPL *session, WT_CELL *cell, uint8_t cell_type,
           page_del->prepare_state == WT_PREPARE_INIT ||
             page_del->prepare_state == WT_PREPARE_RESOLVED ||
             (F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED) &&
-              F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED) &&
               (page_del->prepare_state == WT_PREPARE_INPROGRESS ||
                 page_del->prepare_state == WT_PREPARE_LOCKED)));
     }

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -561,6 +561,8 @@ __wt_cell_build_addr(WT_SESSION_IMPL *session, WT_CELL *cell, uint8_t cell_type,
      */
     WT_ASSERT(session, page_del != NULL || cell_type != WT_CELL_ADDR_DEL);
 
+    bool is_prepared_fast_truncate = false;
+
     if (page_del != NULL) {
         /*
          * We only support fast-truncate leaf pages without overflow items, however, we can write a
@@ -580,10 +582,15 @@ __wt_cell_build_addr(WT_SESSION_IMPL *session, WT_CELL *cell, uint8_t cell_type,
             (F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED) &&
               (page_del->prepare_state == WT_PREPARE_INPROGRESS ||
                 page_del->prepare_state == WT_PREPARE_LOCKED)));
+
+        /* Use prepared_id to determine whether to write a prepared fast-truncate cell */
+        is_prepared_fast_truncate = page_del->prepared_id != WT_PREPARED_ID_NONE &&
+          F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED);
     }
 
     /* Just pack and return the cell size. */
-    return (uint16_t)__wt_cell_pack_addr(session, cell, cell_type, recno, page_del, ta, data_size);
+    return (uint16_t)__wt_cell_pack_addr(
+      session, cell, cell_type, recno, page_del, ta, is_prepared_fast_truncate, data_size);
 }
 
 /*
@@ -592,19 +599,9 @@ __wt_cell_build_addr(WT_SESSION_IMPL *session, WT_CELL *cell, uint8_t cell_type,
  */
 static WT_INLINE size_t
 __wt_cell_pack_addr(WT_SESSION_IMPL *session, WT_CELL *cell, u_int cell_type, uint64_t recno,
-  WT_PAGE_DELETED *page_del, WT_TIME_AGGREGATE *ta, size_t size)
+  WT_PAGE_DELETED *page_del, WT_TIME_AGGREGATE *ta, bool is_prepared_fast_truncate, size_t size)
 {
-    uint8_t *p, prepare_state;
-    bool is_prepared_fast_truncate;
-
-    prepare_state = page_del != NULL ? __wt_atomic_load_uint8_v_acquire(&page_del->prepare_state) :
-                                       WT_PREPARE_INIT;
-    /*
-     * A prepared fast-truncate cell is only legal on a disaggregated btree with preserve_prepared.
-     */
-    is_prepared_fast_truncate =
-      (prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED) &&
-      F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED);
+    uint8_t *p;
 
     /* Start building a cell: the descriptor byte starts zero. */
     p = cell->__chunk;

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -575,14 +575,16 @@ __wt_cell_build_addr(WT_SESSION_IMPL *session, WT_CELL *cell, uint8_t cell_type,
         cell_type = WT_CELL_ADDR_DEL;
 
         /*
-         * In-progress prepared states are only written to disk when preserve_prepared is enabled;
-         * otherwise only committed (INIT) or resolved-but-not-yet-committed (RESOLVED) states are
-         * expected.
+         * In-progress prepared states are only written to disk when preserve_prepared is enabled
+         * on a disaggregated btree. Attached storage cannot safely use this format because an older
+         * binary would silently misread the cell. Otherwise only committed (INIT) or
+         * resolved-but-not-yet-committed (RESOLVED) states are expected.
          */
         WT_ASSERT(session,
           page_del->prepare_state == WT_PREPARE_INIT ||
             page_del->prepare_state == WT_PREPARE_RESOLVED ||
             (F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED) &&
+              F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED) &&
               (page_del->prepare_state == WT_PREPARE_INPROGRESS ||
                 page_del->prepare_state == WT_PREPARE_LOCKED)));
     }
@@ -624,7 +626,10 @@ __wt_cell_pack_addr(WT_SESSION_IMPL *session, WT_CELL *cell, u_int cell_type, ui
 
         WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->txnid));
         if (is_prepared_fast_truncate) {
-            WT_ASSERT(session, F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED));
+            /* Only reachable for disaggregated btrees with preserve_prepared; see __wt_cell_build_addr. */
+            WT_ASSERT(session,
+              F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED) &&
+                F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED));
             WT_ASSERT(session, page_del->prepared_id != WT_PREPARED_ID_NONE);
             WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->prepare_ts));
             WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->prepared_id));

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -575,10 +575,8 @@ __wt_cell_build_addr(WT_SESSION_IMPL *session, WT_CELL *cell, uint8_t cell_type,
         cell_type = WT_CELL_ADDR_DEL;
 
         /*
-         * In-progress prepared states are only written to disk when preserve_prepared is enabled
-         * on a disaggregated btree. Attached storage cannot safely use this format because an older
-         * binary would silently misread the cell. Otherwise only committed (INIT) or
-         * resolved-but-not-yet-committed (RESOLVED) states are expected.
+         * In-progress prepared states are only written to disk when preserve_prepared is enabled on
+         * a disaggregated btree.
          */
         WT_ASSERT(session,
           page_del->prepare_state == WT_PREPARE_INIT ||
@@ -608,9 +606,6 @@ __wt_cell_pack_addr(WT_SESSION_IMPL *session, WT_CELL *cell, u_int cell_type, ui
                                        WT_PREPARE_INIT;
     /*
      * A prepared fast-truncate cell is only legal on a disaggregated btree with preserve_prepared.
-     * Folding the flags into this bool prevents __cell_pack_addr_validity from writing
-     * WT_CELL_PREPARE into the second descriptor byte if either condition is unmet  regardless of
-     * whether the caller's assertions (in __wt_cell_build_addr) fire in this build configuration.
      */
     is_prepared_fast_truncate =
       (prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED) &&

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -606,8 +606,16 @@ __wt_cell_pack_addr(WT_SESSION_IMPL *session, WT_CELL *cell, u_int cell_type, ui
 
     prepare_state = page_del != NULL ? __wt_atomic_load_uint8_v_acquire(&page_del->prepare_state) :
                                        WT_PREPARE_INIT;
+    /*
+     * A prepared fast-truncate cell is only legal on a disaggregated btree with preserve_prepared.
+     * Folding the flags into this bool prevents __cell_pack_addr_validity from writing
+     * WT_CELL_PREPARE into the second descriptor byte if either condition is unmet  regardless of
+     * whether the caller's assertions (in __wt_cell_build_addr) fire in this build configuration.
+     */
     is_prepared_fast_truncate =
-      (prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED);
+      (prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED) &&
+      F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED) &&
+      F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED);
 
     /* Start building a cell: the descriptor byte starts zero. */
     p = cell->__chunk;
@@ -626,10 +634,6 @@ __wt_cell_pack_addr(WT_SESSION_IMPL *session, WT_CELL *cell, u_int cell_type, ui
 
         WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->txnid));
         if (is_prepared_fast_truncate) {
-            /* Only reachable for disaggregated btrees with preserve_prepared; see __wt_cell_build_addr. */
-            WT_ASSERT(session,
-              F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED) &&
-                F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED));
             WT_ASSERT(session, page_del->prepared_id != WT_PREPARED_ID_NONE);
             WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->prepare_ts));
             WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->prepared_id));

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -201,9 +201,7 @@ __cell_pack_addr_validity(
 {
     uint8_t flags, *flagsp;
 
-    /*
-     * A prepared fast-truncate and a prepared time aggregate cannot be on the same page.
-     */
+    /* A prepared fast-truncate and a prepared time aggregate cannot be on the same page. */
     WT_ASSERT(session, !(ta->prepare && is_prepared_fast_truncate));
 
     if (WT_TIME_AGGREGATE_IS_EMPTY(ta) && !is_prepared_fast_truncate) {
@@ -606,8 +604,7 @@ __wt_cell_pack_addr(WT_SESSION_IMPL *session, WT_CELL *cell, u_int cell_type, ui
      */
     is_prepared_fast_truncate =
       (prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED) &&
-      F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED) &&
-      F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED);
+      F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED);
 
     /* Start building a cell: the descriptor byte starts zero. */
     p = cell->__chunk;

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -268,9 +268,7 @@ __cell_pack_addr_validity(
         WT_IGNORE_RET(__wt_vpack_uint(pp, 0, ta->newest_stop_durable_ts - ta->newest_stop_ts));
         LF_SET(WT_CELL_TS_DURABLE_STOP);
     }
-    if (ta->prepare)
-        LF_SET(WT_CELL_PREPARE);
-    if (is_prepared_fast_truncate)
+    if (ta->prepare || is_prepared_fast_truncate)
         LF_SET(WT_CELL_PREPARE);
 
     *flagsp = flags;

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -602,9 +602,8 @@ __wt_cell_pack_addr(WT_SESSION_IMPL *session, WT_CELL *cell, u_int cell_type, ui
     uint8_t *p, prepare_state;
     bool is_prepared_fast_truncate;
 
-    prepare_state = page_del != NULL ?
-      __wt_atomic_load_uint8_v_acquire(&page_del->prepare_state) :
-      WT_PREPARE_INIT;
+    prepare_state = page_del != NULL ? __wt_atomic_load_uint8_v_acquire(&page_del->prepare_state) :
+                                       WT_PREPARE_INIT;
     is_prepared_fast_truncate =
       (prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED);
 

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -423,15 +423,16 @@ err:
  */
 static WT_INLINE void
 __wt_cell_build_addr_kv(WT_SESSION_IMPL *session, WT_CELL_KV *val_kv, uint8_t cell_type,
-  WT_PAGE_DELETED *page_del, WT_TIME_AGGREGATE *ta, const void *data, size_t data_size)
+  WT_PAGE_DELETED *page_del, WT_TIME_AGGREGATE *ta, bool is_prepared_fast_truncate,
+  const void *data, size_t data_size)
 {
     WT_ASSERT(session, val_kv != NULL);
 
     val_kv->buf.data = data;
     val_kv->buf.size = data_size;
 
-    val_kv->cell_len = (uint16_t)__wt_cell_build_addr(
-      session, &val_kv->cell, cell_type, WT_RECNO_OOB, page_del, ta, data_size);
+    val_kv->cell_len = (uint16_t)__wt_cell_build_addr(session, &val_kv->cell, cell_type,
+      WT_RECNO_OOB, page_del, ta, is_prepared_fast_truncate, data_size);
 
     val_kv->len = val_kv->cell_len + data_size;
 }
@@ -519,7 +520,8 @@ __wt_cell_pack_internal_key_addr(WT_SESSION_IMPL *session, WT_ITEM *new_image,
 
     /* Build packed key/value. */
     __cell_build_int_key_from_kv(&key_kv, key_data, key_size);
-    __wt_cell_build_addr_kv(session, &val_kv, cell_type, page_del, ta, val_data, val_size);
+    /* FIXME-WT-17663: pass the correct is_prepared_fast_truncate from the caller. */
+    __wt_cell_build_addr_kv(session, &val_kv, cell_type, page_del, ta, false, val_data, val_size);
 
     /*
      * Ensure enough space, then recompute write pointer from new_image (not the caller's saved
@@ -553,15 +555,14 @@ err:
  */
 static WT_INLINE uint16_t
 __wt_cell_build_addr(WT_SESSION_IMPL *session, WT_CELL *cell, uint8_t cell_type, uint64_t recno,
-  WT_PAGE_DELETED *page_del, WT_TIME_AGGREGATE *ta, size_t data_size)
+  WT_PAGE_DELETED *page_del, WT_TIME_AGGREGATE *ta, bool is_prepared_fast_truncate,
+  size_t data_size)
 {
     /*
      * If passed fast-delete information, override the cell type. We should never see fast-truncate
      * cell types without fast-truncate information.
      */
     WT_ASSERT(session, page_del != NULL || cell_type != WT_CELL_ADDR_DEL);
-
-    bool is_prepared_fast_truncate = false;
 
     if (page_del != NULL) {
         /*
@@ -571,10 +572,6 @@ __wt_cell_build_addr(WT_SESSION_IMPL *session, WT_CELL *cell, uint8_t cell_type,
          */
         WT_ASSERT(session, cell_type == WT_CELL_ADDR_DEL || cell_type == WT_CELL_ADDR_LEAF_NO);
         cell_type = WT_CELL_ADDR_DEL;
-
-        /* Use prepared_id to determine whether to write a prepared fast-truncate cell */
-        is_prepared_fast_truncate = page_del->prepared_id != WT_PREPARED_ID_NONE &&
-          F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED);
     }
 
     /* Just pack and return the cell size. */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2435,7 +2435,8 @@ static WT_INLINE u_int __wt_skip_choose_depth(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE uint16_t __wt_cell_build_addr(WT_SESSION_IMPL *session, WT_CELL *cell,
   uint8_t cell_type, uint64_t recno, WT_PAGE_DELETED *page_del, WT_TIME_AGGREGATE *ta,
-  size_t data_size) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+  bool is_prepared_fast_truncate, size_t data_size)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE uint64_t __wt_btree_bytes_evictable(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE uint64_t __wt_btree_bytes_inuse(WT_SESSION_IMPL *session)
@@ -2549,8 +2550,8 @@ static WT_INLINE void __wt_cache_shared_dsk_inmem_decr(
 static WT_INLINE void __wt_cache_shared_dsk_inmem_incr(
   WT_SESSION_IMPL *session, uint8_t image_type, size_t size);
 static WT_INLINE void __wt_cell_build_addr_kv(WT_SESSION_IMPL *session, WT_CELL_KV *val_kv,
-  uint8_t cell_type, WT_PAGE_DELETED *page_del, WT_TIME_AGGREGATE *ta, const void *data,
-  size_t data_size);
+  uint8_t cell_type, WT_PAGE_DELETED *page_del, WT_TIME_AGGREGATE *ta,
+  bool is_prepared_fast_truncate, const void *data, size_t data_size);
 static WT_INLINE void __wt_cell_compress_prefix_key(WT_ITEM *last_key, const void *data,
   size_t size, uint8_t key_pfx_last, u_int prefix_compression_min, uint8_t *pfxp);
 static WT_INLINE void __wt_cell_get_ta(WT_CELL_UNPACK_ADDR *unpack_addr, WT_TIME_AGGREGATE **tap);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2396,8 +2396,8 @@ static WT_INLINE size_t __wt_4b_size_posint1(uint64_t x1)
 static WT_INLINE size_t __wt_4b_size_posint2(uint64_t x1, uint64_t x2)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE size_t __wt_cell_pack_addr(WT_SESSION_IMPL *session, WT_CELL *cell,
-  u_int cell_type, uint64_t recno, WT_PAGE_DELETED *page_del, WT_TIME_AGGREGATE *ta, size_t size)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+  u_int cell_type, uint64_t recno, WT_PAGE_DELETED *page_del, WT_TIME_AGGREGATE *ta,
+  bool is_prepared_fast_truncate, size_t size) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE size_t __wt_cell_pack_copy(WT_SESSION_IMPL *session, WT_CELL *cell,
   WT_TIME_WINDOW *tw, uint64_t rle, uint64_t v) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE size_t __wt_cell_pack_del(WT_SESSION_IMPL *session, WT_CELL *cell,

--- a/src/reconcile/rec_child.c
+++ b/src/reconcile/rec_child.c
@@ -96,20 +96,19 @@ __rec_child_deleted(
 
     /*
      * When preserve_prepared is enabled on a disaggregated btree, write an in-progress prepared
-     * fast-truncate as a proxy cell so that recovery can reconstruct the prepared state.
-     * Restricted to disaggregated storage to prevent issues on attached storage on older binary.
+     * fast-truncate as a proxy cell so that recovery can reconstruct the prepared state. Restricted
+     * to disaggregated storage to prevent issues on attached storage on older binary.
      */
     if (!page_del->committed && F_ISSET(conn, WT_CONN_PRESERVE_PREPARED) &&
       F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED)) {
         prepare_state = __wt_atomic_load_uint8_v_acquire(&page_del->prepare_state);
         if (prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED) {
-            WT_ASSERT_ALWAYS(session, !F_ISSET(r, WT_REC_EVICT),
-              "Prepared fast-truncates cannot be evicted when preserve_prepared is enabled");
-            if (F_ISSET(r, WT_REC_CLEAN_AFTER_REC))
+            if (F_ISSET(r, WT_REC_CLEAN_AFTER_REC | WT_REC_EVICT))
                 return (__wt_set_return(session, EBUSY));
             WT_ASSERT(session, page_del->prepared_id != WT_PREPARED_ID_NONE);
             page_del->selected_for_write = true;
             cmsp->del = *page_del;
+            cmsp->del.prepare_state = prepare_state;
             cmsp->state = WTI_CHILD_PROXY;
             r->leave_dirty = true;
             return (0);

--- a/src/reconcile/rec_child.c
+++ b/src/reconcile/rec_child.c
@@ -99,8 +99,7 @@ __rec_child_deleted(
      * fast-truncate as a proxy cell so that recovery can reconstruct the prepared state. Restricted
      * to disaggregated storage to prevent issues on attached storage on older binary.
      */
-    if (!page_del->committed && F_ISSET(conn, WT_CONN_PRESERVE_PREPARED) &&
-      F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED)) {
+    if (!page_del->committed && F_ISSET(conn, WT_CONN_PRESERVE_PREPARED)) {
         prepare_state = __wt_atomic_load_uint8_v_acquire(&page_del->prepare_state);
         if (prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED) {
             if (F_ISSET(r, WT_REC_CLEAN_AFTER_REC | WT_REC_EVICT))

--- a/src/reconcile/rec_child.c
+++ b/src/reconcile/rec_child.c
@@ -37,9 +37,8 @@ __rec_child_deleted(
 
     /*
      * Check visibility. If the truncation is visible to us, we'll also want to know if it's visible
-     * to everyone. Use the special-case logic in visibility of truncate to hide prepared
-     * truncations as we can't write them to disk in the general case. When preserve prepare config
-     * is enabled, in-progress prepared fast-truncates are written as proxy cells.
+     * to everyone. Use the special-case logic in __wt_page_del_visible to hide prepared truncations
+     * as we can't write them to disk.
      *
      * We can't write out uncommitted truncations so we need to check the committed flag on the page
      * delete structure. The committed flag indicates that the truncation has finished being
@@ -92,26 +91,6 @@ __rec_child_deleted(
         cmsp->del = *page_del;
         cmsp->state = WTI_CHILD_PROXY;
         return (0);
-    }
-
-    /*
-     * When preserve prepare config is enabled on a disaggregated btree, write an in-progress
-     * prepared fast-truncate as a proxy cell so that recovery can reconstruct the prepared state.
-     * Restricted to disaggregated storage to prevent issues on attached storage on older binary.
-     */
-    if (!page_del->committed && F_ISSET(conn, WT_CONN_PRESERVE_PREPARED)) {
-        prepare_state = __wt_atomic_load_uint8_v_acquire(&page_del->prepare_state);
-        if (prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED) {
-            if (F_ISSET(r, WT_REC_CLEAN_AFTER_REC | WT_REC_EVICT))
-                return (__wt_set_return(session, EBUSY));
-            WT_ASSERT(session, page_del->prepared_id != WT_PREPARED_ID_NONE);
-            page_del->selected_for_write = true;
-            cmsp->del = *page_del;
-            cmsp->del.prepare_state = prepare_state;
-            cmsp->state = WTI_CHILD_PROXY;
-            r->leave_dirty = true;
-            return (0);
-        }
     }
 
     /*
@@ -186,9 +165,9 @@ __rec_child_deleted(
      * cells to the page. Copy out the current fast-truncate information for that function.
      */
     if (!visible_all) {
-        page_del->selected_for_write = true;
         cmsp->del = *page_del;
         cmsp->state = WTI_CHILD_PROXY;
+        page_del->selected_for_write = true;
         return (0);
     }
 

--- a/src/reconcile/rec_child.c
+++ b/src/reconcile/rec_child.c
@@ -37,9 +37,9 @@ __rec_child_deleted(
 
     /*
      * Check visibility. If the truncation is visible to us, we'll also want to know if it's visible
-     * to everyone. Use the special-case logic in __wt_page_del_visible to hide prepared truncations
-     * as we can't write them to disk in the general case. When preserve_prepared is enabled,
-     * in-progress prepared fast-truncates are written as proxy cells.
+     * to everyone. Use the special-case logic in visibility of truncate to hide prepared
+     * truncations as we can't write them to disk in the general case. When preserve prepare config
+     * is enabled, in-progress prepared fast-truncates are written as proxy cells.
      *
      * We can't write out uncommitted truncations so we need to check the committed flag on the page
      * delete structure. The committed flag indicates that the truncation has finished being
@@ -95,9 +95,9 @@ __rec_child_deleted(
     }
 
     /*
-     * When preserve_prepared is enabled on a disaggregated btree, write an in-progress prepared
-     * fast-truncate as a proxy cell so that recovery can reconstruct the prepared state. Restricted
-     * to disaggregated storage to prevent issues on attached storage on older binary.
+     * When preserve prepare config is enabled on a disaggregated btree, write an in-progress
+     * prepared fast-truncate as a proxy cell so that recovery can reconstruct the prepared state.
+     * Restricted to disaggregated storage to prevent issues on attached storage on older binary.
      */
     if (!page_del->committed && F_ISSET(conn, WT_CONN_PRESERVE_PREPARED)) {
         prepare_state = __wt_atomic_load_uint8_v_acquire(&page_del->prepare_state);

--- a/src/reconcile/rec_child.c
+++ b/src/reconcile/rec_child.c
@@ -95,10 +95,16 @@ __rec_child_deleted(
     }
 
     /*
-     * When preserve_prepared is enabled, write an in-progress prepared fast-truncate as a proxy
-     * cell so that recovery can reconstruct the prepared state.
+     * When preserve_prepared is enabled on a disaggregated btree, write an in-progress prepared
+     * fast-truncate as a proxy cell so that recovery can reconstruct the prepared state.
+     *
+     * This is intentionally restricted to disaggregated storage. On attached storage a downgrade to
+     * an older binary that predates the prepared fast-truncate on-disk format (which packs
+     * txnid  prepare_ts  prepared_id rather than txnid  pg_del_start_ts  pg_del_durable_ts)
+     * would silently misread the cell, producing a committed deletion with garbage timestamps.
      */
-    if (!page_del->committed && F_ISSET(conn, WT_CONN_PRESERVE_PREPARED)) {
+    if (!page_del->committed && F_ISSET(conn, WT_CONN_PRESERVE_PREPARED) &&
+      F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED)) {
         prepare_state = __wt_atomic_load_uint8_v_acquire(&page_del->prepare_state);
         if (prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED) {
             WT_ASSERT_ALWAYS(session, !F_ISSET(r, WT_REC_EVICT),

--- a/src/reconcile/rec_child.c
+++ b/src/reconcile/rec_child.c
@@ -97,11 +97,7 @@ __rec_child_deleted(
     /*
      * When preserve_prepared is enabled on a disaggregated btree, write an in-progress prepared
      * fast-truncate as a proxy cell so that recovery can reconstruct the prepared state.
-     *
-     * This is intentionally restricted to disaggregated storage. On attached storage a downgrade to
-     * an older binary that predates the prepared fast-truncate on-disk format (which packs
-     * txnid  prepare_ts  prepared_id rather than txnid  pg_del_start_ts  pg_del_durable_ts)
-     * would silently misread the cell, producing a committed deletion with garbage timestamps.
+     * Restricted to disaggregated storage to prevent issues on attached storage on older binary.
      */
     if (!page_del->committed && F_ISSET(conn, WT_CONN_PRESERVE_PREPARED) &&
       F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED)) {

--- a/src/reconcile/rec_child.c
+++ b/src/reconcile/rec_child.c
@@ -38,7 +38,8 @@ __rec_child_deleted(
     /*
      * Check visibility. If the truncation is visible to us, we'll also want to know if it's visible
      * to everyone. Use the special-case logic in __wt_page_del_visible to hide prepared truncations
-     * as we can't write them to disk.
+     * as we can't write them to disk in the general case. When preserve_prepared is enabled,
+     * in-progress prepared fast-truncates are written as proxy cells.
      *
      * We can't write out uncommitted truncations so we need to check the committed flag on the page
      * delete structure. The committed flag indicates that the truncation has finished being
@@ -91,6 +92,26 @@ __rec_child_deleted(
         cmsp->del = *page_del;
         cmsp->state = WTI_CHILD_PROXY;
         return (0);
+    }
+
+    /*
+     * When preserve_prepared is enabled, write an in-progress prepared fast-truncate as a proxy
+     * cell so that recovery can reconstruct the prepared state.
+     */
+    if (!page_del->committed && F_ISSET(conn, WT_CONN_PRESERVE_PREPARED)) {
+        prepare_state = __wt_atomic_load_uint8_v_acquire(&page_del->prepare_state);
+        if (prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED) {
+            WT_ASSERT_ALWAYS(session, !F_ISSET(r, WT_REC_EVICT),
+              "Prepared fast-truncates cannot be evicted when preserve_prepared is enabled");
+            if (F_ISSET(r, WT_REC_CLEAN_AFTER_REC))
+                return (__wt_set_return(session, EBUSY));
+            WT_ASSERT(session, page_del->prepared_id != WT_PREPARED_ID_NONE);
+            page_del->selected_for_write = true;
+            cmsp->del = *page_del;
+            cmsp->state = WTI_CHILD_PROXY;
+            r->leave_dirty = true;
+            return (0);
+        }
     }
 
     /*
@@ -165,9 +186,9 @@ __rec_child_deleted(
      * cells to the page. Copy out the current fast-truncate information for that function.
      */
     if (!visible_all) {
+        page_del->selected_for_write = true;
         cmsp->del = *page_del;
         cmsp->state = WTI_CHILD_PROXY;
-        page_del->selected_for_write = true;
         return (0);
     }
 

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -82,7 +82,7 @@ __rec_col_merge(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
 
         /* Build the value cell. */
         addr = &multi->addr;
-        __wti_rec_cell_build_addr(session, r, addr, NULL, r->recno, NULL);
+        __wti_rec_cell_build_addr(session, r, addr, NULL, r->recno, NULL, false);
 
         /* Boundary: split or write the page. */
         if (__wti_rec_need_split(r, val->len))
@@ -184,7 +184,8 @@ __wti_rec_col_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_REF *pageref)
         if (addr == NULL && __wt_off_page(page, ref->addr))
             addr = ref->addr;
         if (addr != NULL) {
-            __wti_rec_cell_build_addr(session, r, addr, NULL, ref->ref_recno, page_del);
+            /* FIXME-WT-17663: pass the correct is_prepared_fast_truncate from the caller. */
+            __wti_rec_cell_build_addr(session, r, addr, NULL, ref->ref_recno, page_del, false);
             WT_TIME_AGGREGATE_COPY(&ta, &addr->ta);
         } else {
             __wt_cell_unpack_addr(session, page->dsk, ref->addr, vpack);
@@ -195,7 +196,8 @@ __wti_rec_col_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_REF *pageref)
                  * info.
                  */
                 WT_ASSERT(session, vpack->type != WT_CELL_ADDR_DEL || page_del != NULL);
-                __wti_rec_cell_build_addr(session, r, NULL, vpack, ref->ref_recno, page_del);
+                /* FIXME-WT-17663: pass the correct is_prepared_fast_truncate from the caller. */
+                __wti_rec_cell_build_addr(session, r, NULL, vpack, ref->ref_recno, page_del, false);
             } else {
                 /* Copy the entire existing cell, including any page-delete information. */
                 val->buf.data = ref->addr;

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -286,8 +286,8 @@ __rec_pack_delta_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_KV 
         static WT_TIME_AGGREGATE local_ta;
         WT_TIME_AGGREGATE_INIT(&local_ta);
 
-        t_kv->cell_len = __wt_cell_pack_addr(
-          session, &t_kv->cell, WT_CELL_ADDR_DEL_VISIBLE_ALL, WT_RECNO_OOB, NULL, &local_ta, 0);
+        t_kv->cell_len = __wt_cell_pack_addr(session, &t_kv->cell, WT_CELL_ADDR_DEL_VISIBLE_ALL,
+          WT_RECNO_OOB, NULL, &local_ta, false, 0);
         t_kv->len = t_kv->cell_len;
         WT_ASSERT(session, t_kv->len == WT_CELL_ADDR_DEL_VISIBLE_ALL_LEN);
         __wti_rec_kv_copy(session, p, t_kv);

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -471,7 +471,7 @@ __rec_row_merge(
         r->cell_zero = false;
 
         addr = &multi->addr;
-        __wti_rec_cell_build_addr(session, r, addr, NULL, WT_RECNO_OOB, NULL);
+        __wti_rec_cell_build_addr(session, r, addr, NULL, WT_RECNO_OOB, NULL, false);
 
         /* Boundary: split or write the page. */
         if (__wti_rec_need_split(r, key->len + val->len))
@@ -711,13 +711,15 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
         page_del = NULL;
         if (__wt_off_page(page, addr)) {
             page_del = cms.state == WTI_CHILD_PROXY ? &cms.del : NULL;
-            __wti_rec_cell_build_addr(session, r, addr, NULL, WT_RECNO_OOB, page_del);
+            /* FIXME-WT-17663: pass the correct is_prepared_fast_truncate from the caller. */
+            __wti_rec_cell_build_addr(session, r, addr, NULL, WT_RECNO_OOB, page_del, false);
             source_ta = &addr->ta;
         } else if (cms.state == WTI_CHILD_PROXY) {
             /* Proxy cells require additional information in the address cell. */
             __wt_cell_unpack_addr(session, page->dsk, ref->addr, vpack);
             page_del = &cms.del;
-            __wti_rec_cell_build_addr(session, r, NULL, vpack, WT_RECNO_OOB, page_del);
+            /* FIXME-WT-17663: pass the correct is_prepared_fast_truncate from the caller. */
+            __wti_rec_cell_build_addr(session, r, NULL, vpack, WT_RECNO_OOB, page_del, false);
             source_ta = &vpack->ta;
         } else {
             retain_onpage = true;
@@ -755,7 +757,8 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
             }
 
             if (F_ISSET(vpack, WT_CELL_UNPACK_TIME_WINDOW_CLEARED))
-                __wti_rec_cell_build_addr(session, r, NULL, vpack, WT_RECNO_OOB, page_del);
+                /* FIXME-WT-17663: pass the correct is_prepared_fast_truncate from the caller. */
+                __wti_rec_cell_build_addr(session, r, NULL, vpack, WT_RECNO_OOB, page_del, false);
             else {
                 val->buf.data = ref->addr;
                 val->buf.size = __wt_cell_total_len(vpack);

--- a/src/reconcile/reconcile_inline.h
+++ b/src/reconcile/reconcile_inline.h
@@ -355,7 +355,8 @@ __wti_rec_image_copy(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_KV *kv)
  */
 static WT_INLINE void
 __wti_rec_cell_build_addr(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_ADDR *addr,
-  WT_CELL_UNPACK_ADDR *vpack, uint64_t recno, WT_PAGE_DELETED *page_del)
+  WT_CELL_UNPACK_ADDR *vpack, uint64_t recno, WT_PAGE_DELETED *page_del,
+  bool is_prepared_fast_truncate)
 {
     WTI_REC_KV *val = &r->v;
     WT_TIME_AGGREGATE *ta;
@@ -404,7 +405,7 @@ __wti_rec_cell_build_addr(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_ADDR *a
     val->buf.data = data;
     val->buf.size = data_size;
     val->cell_len = (uint16_t)__wt_cell_build_addr(
-      session, &val->cell, cell_type, recno, page_del, ta, data_size);
+      session, &val->cell, cell_type, recno, page_del, ta, is_prepared_fast_truncate, data_size);
     val->len = val->cell_len + data_size;
 }
 

--- a/src/reconcile/reconcile_private.h
+++ b/src/reconcile/reconcile_private.h
@@ -548,7 +548,8 @@ static WT_INLINE int __wti_rec_get_row_leaf_key(WT_SESSION_IMPL *session, WT_BTR
   WTI_RECONCILE *r, WT_INSERT *ins, WT_ROW *rip, WT_ITEM *key)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE void __wti_rec_cell_build_addr(WT_SESSION_IMPL *session, WTI_RECONCILE *r,
-  WT_ADDR *addr, WT_CELL_UNPACK_ADDR *vpack, uint64_t recno, WT_PAGE_DELETED *page_del);
+  WT_ADDR *addr, WT_CELL_UNPACK_ADDR *vpack, uint64_t recno, WT_PAGE_DELETED *page_del,
+  bool is_prepared_fast_truncate);
 static WT_INLINE void __wti_rec_image_copy(
   WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_KV *kv);
 static WT_INLINE void __wti_rec_kv_copy(WT_SESSION_IMPL *session, uint8_t *p, WTI_REC_KV *kv);

--- a/test/catch2/misc_tests/test_cell_fast_truncate_unpack.cpp
+++ b/test/catch2/misc_tests/test_cell_fast_truncate_unpack.cpp
@@ -145,7 +145,8 @@ TEST_CASE("Cell Fast Truncate Pack/Unpack: committed deletion round-trips correc
 
     WT_CELL cell;
     memset(&cell, 0, sizeof(cell));
-    WT_IGNORE_RET(__wt_cell_pack_addr(session, &cell, WT_CELL_ADDR_DEL, WT_RECNO_OOB, &page_del, &ta, 0));
+    WT_IGNORE_RET(
+      __wt_cell_pack_addr(session, &cell, WT_CELL_ADDR_DEL, WT_RECNO_OOB, &page_del, &ta, 0));
 
     WT_CELL_UNPACK_ADDR unpack;
     memset(&unpack, 0, sizeof(unpack));
@@ -187,7 +188,8 @@ TEST_CASE("Cell Fast Truncate Pack/Unpack: prepared deletion round-trips correct
 
     WT_CELL cell;
     memset(&cell, 0, sizeof(cell));
-    WT_IGNORE_RET(__wt_cell_pack_addr(session, &cell, WT_CELL_ADDR_DEL, WT_RECNO_OOB, &page_del, &ta, 0));
+    WT_IGNORE_RET(
+      __wt_cell_pack_addr(session, &cell, WT_CELL_ADDR_DEL, WT_RECNO_OOB, &page_del, &ta, 0));
 
     WT_CELL_UNPACK_ADDR unpack;
     memset(&unpack, 0, sizeof(unpack));

--- a/test/catch2/misc_tests/test_cell_fast_truncate_unpack.cpp
+++ b/test/catch2/misc_tests/test_cell_fast_truncate_unpack.cpp
@@ -145,8 +145,8 @@ TEST_CASE("Cell Fast Truncate Pack/Unpack: committed deletion round-trips correc
 
     WT_CELL cell;
     memset(&cell, 0, sizeof(cell));
-    WT_IGNORE_RET(
-      __wt_cell_pack_addr(session, &cell, WT_CELL_ADDR_DEL, WT_RECNO_OOB, &page_del, &ta, 0));
+    WT_IGNORE_RET(__wt_cell_pack_addr(
+      session, &cell, WT_CELL_ADDR_DEL, WT_RECNO_OOB, &page_del, &ta, false, 0));
 
     WT_CELL_UNPACK_ADDR unpack;
     memset(&unpack, 0, sizeof(unpack));
@@ -189,8 +189,8 @@ TEST_CASE("Cell Fast Truncate Pack/Unpack: prepared deletion round-trips correct
 
     WT_CELL cell;
     memset(&cell, 0, sizeof(cell));
-    WT_IGNORE_RET(
-      __wt_cell_pack_addr(session, &cell, WT_CELL_ADDR_DEL, WT_RECNO_OOB, &page_del, &ta, 0));
+    WT_IGNORE_RET(__wt_cell_pack_addr(
+      session, &cell, WT_CELL_ADDR_DEL, WT_RECNO_OOB, &page_del, &ta, true, 0));
 
     WT_CELL_UNPACK_ADDR unpack;
     memset(&unpack, 0, sizeof(unpack));

--- a/test/catch2/misc_tests/test_cell_fast_truncate_unpack.cpp
+++ b/test/catch2/misc_tests/test_cell_fast_truncate_unpack.cpp
@@ -123,6 +123,91 @@ TEST_CASE(
     CHECK(unpack.ta.prepare == 0);
 }
 
+TEST_CASE("Cell Fast Truncate Pack/Unpack: committed deletion round-trips correctly",
+  "[cell][fast_truncate]")
+{
+    auto session_mock = setup_mock_session();
+    WT_SESSION_IMPL *session = session_mock->get_wt_session_impl();
+
+    WT_PAGE_HEADER dsk = make_ft_page_header();
+
+    /* Build a committed page_del and pack it into a cell. */
+    WT_PAGE_DELETED page_del;
+    memset(&page_del, 0, sizeof(page_del));
+    page_del.txnid = 42;
+    page_del.pg_del_start_ts = 100;
+    page_del.pg_del_durable_ts = 110;
+    page_del.prepare_state = WT_PREPARE_INIT;
+    page_del.committed = true;
+
+    WT_TIME_AGGREGATE ta;
+    WT_TIME_AGGREGATE_INIT(&ta);
+
+    WT_CELL cell;
+    memset(&cell, 0, sizeof(cell));
+    WT_IGNORE_RET(__wt_cell_pack_addr(session, &cell, WT_CELL_ADDR_DEL, WT_RECNO_OOB, &page_del, &ta, 0));
+
+    WT_CELL_UNPACK_ADDR unpack;
+    memset(&unpack, 0, sizeof(unpack));
+    __wt_cell_unpack_addr(session, &dsk, &cell, &unpack);
+
+    const WT_PAGE_DELETED &pd = unpack.page_del;
+    CHECK(pd.txnid == 42);
+    CHECK(pd.pg_del_start_ts == 100);
+    CHECK(pd.pg_del_durable_ts == 110);
+    CHECK(pd.prepare_state == WT_PREPARE_INIT);
+    CHECK(pd.committed == true);
+    CHECK(pd.selected_for_write == true);
+    CHECK(unpack.ta.prepare == 0);
+}
+
+TEST_CASE("Cell Fast Truncate Pack/Unpack: prepared deletion round-trips correctly",
+  "[cell][fast_truncate]")
+{
+    auto session_mock = setup_mock_session();
+    WT_SESSION_IMPL *session = session_mock->get_wt_session_impl();
+
+    /* preserve_prepared must be set to allow packing an in-progress prepared state. */
+    F_SET(S2C(session), WT_CONN_PRESERVE_PREPARED);
+
+    WT_PAGE_HEADER dsk = make_ft_page_header();
+
+    /* Build a prepared page_del and pack it into a cell. */
+    WT_PAGE_DELETED page_del;
+    memset(&page_del, 0, sizeof(page_del));
+    page_del.txnid = 99;
+    page_del.prepare_ts = 50;
+    page_del.prepared_id = 7;
+    page_del.pg_del_durable_ts = WT_TS_NONE;
+    page_del.prepare_state = WT_PREPARE_INPROGRESS;
+    page_del.committed = false;
+
+    WT_TIME_AGGREGATE ta;
+    WT_TIME_AGGREGATE_INIT(&ta);
+
+    WT_CELL cell;
+    memset(&cell, 0, sizeof(cell));
+    WT_IGNORE_RET(__wt_cell_pack_addr(session, &cell, WT_CELL_ADDR_DEL, WT_RECNO_OOB, &page_del, &ta, 0));
+
+    WT_CELL_UNPACK_ADDR unpack;
+    memset(&unpack, 0, sizeof(unpack));
+    __wt_cell_unpack_addr(session, &dsk, &cell, &unpack);
+
+    const WT_PAGE_DELETED &pd = unpack.page_del;
+    CHECK(pd.txnid == 99);
+    CHECK(pd.prepare_ts == 50);
+    CHECK(pd.pg_del_start_ts == 50);
+    CHECK(pd.prepared_id == 7);
+    CHECK(pd.pg_del_durable_ts == WT_TS_NONE);
+    CHECK(pd.prepare_state == WT_PREPARE_INPROGRESS);
+    CHECK(pd.committed == false);
+    CHECK(pd.selected_for_write == true);
+    /* A prepared fast-truncate does not propagate prepare to the page-level visibility window. */
+    CHECK(unpack.ta.prepare == 0);
+
+    F_CLR(S2C(session), WT_CONN_PRESERVE_PREPARED);
+}
+
 TEST_CASE("Cell Fast Truncate: prepare flag on non-fast-truncate addr cell marks page as prepared",
   "[cell][fast_truncate]")
 {

--- a/test/catch2/misc_tests/test_cell_fast_truncate_unpack.cpp
+++ b/test/catch2/misc_tests/test_cell_fast_truncate_unpack.cpp
@@ -168,8 +168,9 @@ TEST_CASE("Cell Fast Truncate Pack/Unpack: prepared deletion round-trips correct
     auto session_mock = setup_mock_session();
     WT_SESSION_IMPL *session = session_mock->get_wt_session_impl();
 
-    /* preserve_prepared must be set to allow packing an in-progress prepared state. */
+    /* Both flags are required to pack a prepared fast-truncate cell. */
     F_SET(S2C(session), WT_CONN_PRESERVE_PREPARED);
+    F_SET(S2BT(session), WT_BTREE_DISAGGREGATED);
 
     WT_PAGE_HEADER dsk = make_ft_page_header();
 
@@ -208,6 +209,7 @@ TEST_CASE("Cell Fast Truncate Pack/Unpack: prepared deletion round-trips correct
     CHECK(unpack.ta.prepare == 0);
 
     F_CLR(S2C(session), WT_CONN_PRESERVE_PREPARED);
+    F_CLR(S2BT(session), WT_BTREE_DISAGGREGATED);
 }
 
 TEST_CASE("Cell Fast Truncate: prepare flag on non-fast-truncate addr cell marks page as prepared",

--- a/test/catch2/misc_tests/test_cell_fast_truncate_unpack.cpp
+++ b/test/catch2/misc_tests/test_cell_fast_truncate_unpack.cpp
@@ -189,8 +189,8 @@ TEST_CASE("Cell Fast Truncate Pack/Unpack: prepared deletion round-trips correct
 
     WT_CELL cell;
     memset(&cell, 0, sizeof(cell));
-    WT_IGNORE_RET(__wt_cell_pack_addr(
-      session, &cell, WT_CELL_ADDR_DEL, WT_RECNO_OOB, &page_del, &ta, true, 0));
+    WT_IGNORE_RET(
+      __wt_cell_pack_addr(session, &cell, WT_CELL_ADDR_DEL, WT_RECNO_OOB, &page_del, &ta, true, 0));
 
     WT_CELL_UNPACK_ADDR unpack;
     memset(&unpack, 0, sizeof(unpack));


### PR DESCRIPTION
This change implements the write side of the prepared fast truncate on-disk format. 

rec_child.c — __rec_child_deleted: A new block is inserted after the existing visibility check. For an in-progress prepared fast-truncate, when WT_CONN_PRESERVE_PREPARED is set, the page_del is copied into cmsp->del, the child state is set to WTI_CHILD_PROXY so the address cell is written, and r->leave_dirty = true ensures a subsequent checkpoint rewrites the cell once the transaction resolves.

cell_inline.h — __wt_cell_pack_addr: When is_prepared_fast_truncate is true, the page_del block is packed in prepared format (prepare_ts → prepared_id). __wt_cell_build_addr: updated to allow WT_PREPARE_INPROGRESS and WT_PREPARE_LOCKED when WT_CONN_PRESERVE_PREPARED is set. 

Limited to disagg only because downgrading in attached storage could cause data corruption issues.