### PR TITLE
WT-17651 s_copyright: search explicit source directories instead of excluding build directories

### DIFF
--- a/dist/s_copyright
+++ b/dist/s_copyright
@@ -125,21 +125,19 @@ ENDOFTEXT
 # Parallel execution: if it's the main invocation of the script, collect the file names
 # to process and run them in subprocesses.
 
-# Search for files, skipping some well-known 3rd party directories.
-find [a-z]* -name '*.[ch]' \
+# Search for files in explicit source directories.
+find bench dist docs examples ext lang oss src test tools \
+    -name '*.[ch]' \
     -o -name '*.cpp' \
     -o -name '*.in' \
     -o -name '*.py' \
     -o -name '*.swig' |
     sed	-e '/Makefile.in/d' \
-    -e '/^build\//d' \
-    -e '/^cmake\//d' \
     -e '/checksum\/power8\//d' \
     -e '/checksum\/zseries\//d' \
     -e '/\/3rdparty\//d' \
     -e '/\/node_modules\//d' \
     -e '/^tools\/wt-mcp\/\.venv\//d' \
-    -e '/^venv\//d' \
     -e '/dist\/__/d' \
     -e 's/^\.\///' |
     do_in_parallel || RET=1

--- a/dist/s_copyright
+++ b/dist/s_copyright
@@ -125,8 +125,12 @@ ENDOFTEXT
 # Parallel execution: if it's the main invocation of the script, collect the file names
 # to process and run them in subprocesses.
 
-# Search for files in explicit source directories.
-find bench dist docs examples ext lang oss src test tools \
+# Search for files in explicit source directories, skipping any absent in this tree.
+dirs=()
+for d in bench dist docs examples ext lang oss src test tools; do
+    [ -d "$d" ] && dirs+=("$d")
+done
+find "${dirs[@]}" \
     -name '*.[ch]' \
     -o -name '*.cpp' \
     -o -name '*.in' \


### PR DESCRIPTION
### Summary
Replace the implicit opt-out directory scanning in dist/s_copyright with an explicit opt-in list of source directories.

Previously the script used find [a-z]* to match all lowercase top-level directories and then filtered out build/generated directories (build/, cmake/, venv/) via sed. This meant any new build or third-party directory added at the top level would be silently scanned for copyright headers unless someone remembered to add a corresponding exclusion.

This change flips the model: the find command now targets an explicit list of source directories — bench, dist, docs, examples, ext, lang, oss, src, test, tools — and the redundant sed exclusions for ^build/, ^cmake/, and ^venv/ are removed. Subdirectory-level exclusions (checksum/power8/, checksum/zseries/, 3rdparty/, node_modules/, tools/wt-mcp/.venv/, dist/__) are preserved since they exclude third-party or generated content within the searched trees.

### Files Changed
dist/s_copyright — updated find invocation and trimmed sed filter list

### Testing
Ran dist/s_copyright from the repo root before and after the change and confirmed identical output.
