### PR TITLE
WT-17141 Fix Coverity 180409 (lock evasion of owning_thread)

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -818,6 +818,7 @@ createsets
 crypto
 cryptobad
 cryptographic
+cst
 cstring
 csuite
 csv

--- a/src/include/gcc.h
+++ b/src/include/gcc.h
@@ -414,6 +414,7 @@ WT_ATOMIC_FUNC(int64, int64_t)
 WT_ATOMIC_FUNC(size, size_t)
 
 WT_ATOMIC_FUNC_STORE_LOAD(bool, bool)
+WT_ATOMIC_FUNC_STORE_LOAD(uintmax, uintmax_t)
 
 /*
  * __wt_atomic_load_double_relaxed --

--- a/src/include/msvc.h
+++ b/src/include/msvc.h
@@ -248,6 +248,7 @@ WT_ATOMIC_FUNC(int64, int64_t, 64, __int64)
 WT_ATOMIC_FUNC(size, size_t, 64, __int64)
 
 WT_ATOMIC_FUNC_STORE_LOAD(bool, bool, 8, char)
+WT_ATOMIC_FUNC_STORE_LOAD(uintmax, uintmax_t, 64, __int64)
 
 /*
  * __wt_atomic_load_double_relaxed --

--- a/src/include/session.h
+++ b/src/include/session.h
@@ -197,7 +197,7 @@ struct __wt_session_impl {
     /* Enforce the contract that a session is only used by a single thread at a time. */
     struct __wt_thread_check {
         WT_SPINLOCK lock;
-        uintmax_t owning_thread;
+        wt_shared uintmax_t owning_thread;
         uint32_t entry_count;
     } thread_check;
 

--- a/src/include/session_inline.h
+++ b/src/include/session_inline.h
@@ -25,11 +25,13 @@ __wt_single_thread_check_start(WT_SESSION_IMPL *s)
     WT_UNUSED(s);
     return;
 #else
-    uintmax_t current_tid;
+    uintmax_t current_tid, owning;
     WT_DECL_RET;
 
     __wt_thread_id(&current_tid);
-    if (!WT_SESSION_IS_DEFAULT(s) && s->thread_check.owning_thread != current_tid) {
+    owning = __wt_atomic_load_uintmax_acquire(&s->thread_check.owning_thread);
+
+    if (!WT_SESSION_IS_DEFAULT(s) && owning != current_tid) {
         ret = __wt_spin_trylock(s, &s->thread_check.lock);
 
         const char *session_name = __wt_atomic_load_ptr_relaxed(&s->name);
@@ -38,11 +40,11 @@ __wt_single_thread_check_start(WT_SESSION_IMPL *s)
           " is accessed concurrently by multiple threads: "
           "current thread %" PRIuMAX ", owning thread %" PRIuMAX
           " (active op: %s, last op: %s, api depth: %u, dhandle: %s)",
-          s->id, current_tid, s->thread_check.owning_thread,
-          session_name != NULL ? session_name : "none", s->lastop != NULL ? s->lastop : "none",
-          s->api_call_counter, s->dhandle != NULL ? s->dhandle->name : "none");
+          s->id, current_tid, owning, session_name != NULL ? session_name : "none",
+          s->lastop != NULL ? s->lastop : "none", s->api_call_counter,
+          s->dhandle != NULL ? s->dhandle->name : "none");
 
-        s->thread_check.owning_thread = current_tid;
+        __wt_atomic_store_uintmax_release(&s->thread_check.owning_thread, current_tid);
     }
     ++s->thread_check.entry_count;
 #endif
@@ -60,7 +62,7 @@ __wt_single_thread_check_stop(WT_SESSION_IMPL *s)
     return;
 #else
     if (--s->thread_check.entry_count == 0 && !WT_SESSION_IS_DEFAULT(s)) {
-        s->thread_check.owning_thread = 0;
+        __wt_atomic_store_uintmax_release(&s->thread_check.owning_thread, 0);
         __wt_spin_unlock(s, &s->thread_check.lock);
     }
 #endif

--- a/src/include/session_inline.h
+++ b/src/include/session_inline.h
@@ -29,6 +29,11 @@ __wt_single_thread_check_start(WT_SESSION_IMPL *s)
     WT_DECL_RET;
 
     __wt_thread_id(&current_tid);
+
+    /*
+     * Use relaxed atomics instead of seq-cst to avoid masking concurrency bugs in diagnostic
+     * builds. Relaxed ordering is safe because the spinlock guarantees mutual exclusion.
+     */
     owning = __wt_atomic_load_uintmax_relaxed(&s->thread_check.owning_thread);
 
     if (!WT_SESSION_IS_DEFAULT(s) && owning != current_tid) {

--- a/src/include/session_inline.h
+++ b/src/include/session_inline.h
@@ -29,7 +29,7 @@ __wt_single_thread_check_start(WT_SESSION_IMPL *s)
     WT_DECL_RET;
 
     __wt_thread_id(&current_tid);
-    owning = __wt_atomic_load_uintmax_acquire(&s->thread_check.owning_thread);
+    owning = __wt_atomic_load_uintmax_relaxed(&s->thread_check.owning_thread);
 
     if (!WT_SESSION_IS_DEFAULT(s) && owning != current_tid) {
         ret = __wt_spin_trylock(s, &s->thread_check.lock);
@@ -44,7 +44,7 @@ __wt_single_thread_check_start(WT_SESSION_IMPL *s)
           s->lastop != NULL ? s->lastop : "none", s->api_call_counter,
           s->dhandle != NULL ? s->dhandle->name : "none");
 
-        __wt_atomic_store_uintmax_release(&s->thread_check.owning_thread, current_tid);
+        __wt_atomic_store_uintmax_relaxed(&s->thread_check.owning_thread, current_tid);
     }
     ++s->thread_check.entry_count;
 #endif
@@ -62,7 +62,7 @@ __wt_single_thread_check_stop(WT_SESSION_IMPL *s)
     return;
 #else
     if (--s->thread_check.entry_count == 0 && !WT_SESSION_IS_DEFAULT(s)) {
-        __wt_atomic_store_uintmax_release(&s->thread_check.owning_thread, 0);
+        __wt_atomic_store_uintmax_relaxed(&s->thread_check.owning_thread, 0);
         __wt_spin_unlock(s, &s->thread_check.lock);
     }
 #endif

--- a/test/catch2/misc_tests/test_acquire_release_macros.cpp
+++ b/test/catch2/misc_tests/test_acquire_release_macros.cpp
@@ -15,6 +15,7 @@ typedef uint64_t uint64;
 typedef uint32_t uint32;
 typedef uint16_t uint16;
 typedef uint8_t uint8;
+typedef uintmax_t uintmax;
 
 #define TEST_ACQUIRE_TYPE(type)                           \
     TEST_CASE("Test acquiring a " #type, "[acqrel]")      \
@@ -56,6 +57,7 @@ typedef uint8_t uint8;
  * This also helps verify the type checking in the acquire read macro, and that the barrier version
  * doesn't produce different results.
  */
+TEST_ACQUIRE_TYPE(uintmax);
 TEST_ACQUIRE_TYPE(uint64);
 TEST_ACQUIRE_TYPE(uint32);
 TEST_ACQUIRE_TYPE(uint16);
@@ -65,6 +67,7 @@ TEST_ACQUIRE_TYPE(uint8);
  * Test each branch of the release macro. Use values that can only fit inside the type being tested
  * to make sure integer truncation doesn't occur.
  */
+TEST_RELEASE_TYPE(uintmax, UINTMAX_MAX);
 TEST_RELEASE_TYPE(uint64, UINT64_MAX);
 TEST_RELEASE_TYPE(uint32, UINT32_MAX);
 TEST_RELEASE_TYPE(uint16, UINT16_MAX);


### PR DESCRIPTION
owning_thread can be modified by another thread, so reading it without a lock requires atomic access. Coverity flagged the plain read as a data race (CID 180409).