### PR TITLE
WT-17642 Reset checkpoint handle stats per-checkpoint; add regression test (8.0)

### DIFF
--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -718,6 +718,8 @@ __wt_conn_btree_apply(WT_SESSION_IMPL *session, const char *uri,
             time_start = __wt_clock(session);
             conn->ckpt_apply = conn->ckpt_skip = 0;
             conn->ckpt_apply_time = conn->ckpt_skip_time = 0;
+            conn->ckpt_drop = conn->ckpt_lock = conn->ckpt_meta_check = 0;
+            conn->ckpt_drop_time = conn->ckpt_lock_time = conn->ckpt_meta_check_time = 0;
             F_SET(conn, WT_CONN_CKPT_GATHER);
         }
         for (dhandle = NULL;;) {

--- a/test/suite/test_config09.py
+++ b/test/suite/test_config09.py
@@ -92,13 +92,26 @@ class test_config09(wttest.WiredTigerTestCase):
         self.assertEqual(val, 1024)
 
         self.update_tables()
-        val = self.get_stat(stat.conn.checkpoint_handle_applied)
+        applied = self.get_stat(stat.conn.checkpoint_handle_applied)
         # We cannot assert it is equal to half because there could be other
         # internal tables in the count. Assert it is less than 75% and at least
         # half.
-        self.assertGreaterEqual(val, self.ntables // 2)
-        self.assertLess(val, self.ntables // 4 * 3)
-        val = self.get_stat(stat.conn.checkpoint_handle_skipped)
-        self.assertNotEqual(val, 0)
+        self.assertGreaterEqual(applied, self.ntables // 2)
+        self.assertLess(applied, self.ntables // 4 * 3)
+        skipped = self.get_stat(stat.conn.checkpoint_handle_skipped)
+        self.assertNotEqual(skipped, 0)
+
+        # The handle stats should be reset at the start of each gather and
+        # then set to the per-checkpoint value. Two back-to-back checkpoints
+        # over the same working set must therefore publish the same value;
+        # if the reset is missing, the second value will be roughly double
+        # the first.
+        locked_1 = self.get_stat(stat.conn.checkpoint_handle_locked)
+        meta_checked_1 = self.get_stat(stat.conn.checkpoint_handle_meta_checked)
+        self.session.checkpoint()
+        locked_2 = self.get_stat(stat.conn.checkpoint_handle_locked)
+        meta_checked_2 = self.get_stat(stat.conn.checkpoint_handle_meta_checked)
+        self.assertEqual(locked_1, locked_2)
+        self.assertEqual(meta_checked_1, meta_checked_2)
 
         self.conn.close()


### PR DESCRIPTION
## Summary

Backport of WT-17642 to `mongodb-8.0`. This branch is the only one still affected by the bug — `mongodb-8.2+` already carry the fix via WT-13990.

**Commit 1 — regression test** (cherry-picked from #13881): extends `test_config09` to assert that `checkpoint_handle_locked` and `checkpoint_handle_meta_checked` publish the per-checkpoint value rather than a cumulative count. Two back-to-back checkpoints over the same working set must produce identical values; without the fix the second value is ~1.5× the first.

**Commit 2 — fix**: adds the two missing zero-assignments in `__wt_conn_btree_apply` (`src/conn/conn_dhandle.c`) to reset `ckpt_drop`, `ckpt_lock`, `ckpt_meta_check` and their `_time` companions at the start of each gather, mirroring the existing `ckpt_apply`/`ckpt_skip` reset that WT-12440 forgot to extend.

## Context

[WT-17642](https://jira.mongodb.org/browse/WT-17642) — WT-12440 (Feb 2024) added the new counters but forgot to zero them; WT-13990 (Jan 2025) fixed this on `mongodb-8.2+` as a side-effect of a larger refactor. `mongodb-8.0` never got the reset.

## Test plan

- [x] `test_config09` **fails** on stock `mongodb-8.0` (`locked_1=100, locked_2=150`)
- [x] `test_config09` **passes** with the fix applied (`locked_1=100, locked_2=100`)