### PR TITLE
WT-17657 Implement layered cursor debug dump

### DIFF
--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -3068,15 +3068,15 @@ __layered_constituent_dump(
      */
     if (cbt->ref == NULL && key != NULL) {
         constituent->set_key(constituent, key);
-        WT_ERR_NOTFOUND_OK(constituent->search_near(constituent, &exact), false);
+        WT_RET_NOTFOUND_OK(constituent->search_near(constituent, &exact));
     }
 
     if (cbt->ref == NULL)
-        goto done;
+        return (0);
 
     if (ofile != NULL) {
         len = strlen(ofile) + strlen(suffix) + 2;
-        WT_RET(__wt_calloc_def(session, len, &path));
+        WT_ERR(__wt_calloc_def(session, len, &path));
         WT_ERR(__wt_snprintf(path, len, "%s.%s", ofile, suffix));
     }
 
@@ -3084,7 +3084,6 @@ __layered_constituent_dump(
     if (ret == 0)
         *dumped = true;
 
-done:
 err:
     __wt_free(session, path);
     return (ret);

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -3030,36 +3030,114 @@ err:
     return (ret);
 }
 
+#ifdef HAVE_DIAGNOSTIC
+/*
+ * __layered_constituent_dump --
+ *     Position the given constituent btree cursor on the supplied key (if it is not already
+ *     positioned) and dump its page to a file named with the given output path joined to the
+ *     supplied suffix. Layered search routines only leave the constituent that satisfied the lookup
+ *     positioned; the other stays unpositioned. To compare both sides at the same key during
+ *     failure triage we issue a search_near here so the unpositioned constituent gets a page
+ *     reference before the debug dump.
+ */
+static int
+__layered_constituent_dump(
+  WT_CURSOR *constituent, const WT_ITEM *key, const char *ofile, const char *suffix, bool *dumped)
+{
+    WT_CURSOR_BTREE *cbt;
+    WT_DECL_RET;
+    WT_SESSION_IMPL *session;
+    size_t len;
+    int exact;
+    char *path;
+
+    *dumped = false;
+    path = NULL;
+
+    if (constituent == NULL)
+        return (0);
+
+    cbt = (WT_CURSOR_BTREE *)constituent;
+    session = CUR2S(constituent);
+
+    /*
+     * If the constituent isn't currently on a page, do a search_near with the layered cursor's key
+     * so we land on a page that brackets the key in this constituent's btree. search_near may
+     * return WT_NOTFOUND when the key isn't present but still leaves the cursor positioned; either
+     * of {0, WT_NOTFOUND} is acceptable as long as a ref is set afterwards.
+     */
+    if (cbt->ref == NULL && key != NULL) {
+        constituent->set_key(constituent, key);
+        WT_ERR_NOTFOUND_OK(constituent->search_near(constituent, &exact), false);
+    }
+
+    if (cbt->ref == NULL)
+        goto done;
+
+    if (ofile != NULL) {
+        len = strlen(ofile) + strlen(suffix) + 2;
+        WT_RET(__wt_calloc_def(session, len, &path));
+        WT_ERR(__wt_snprintf(path, len, "%s.%s", ofile, suffix));
+    }
+
+    ret = __wt_debug_btree_cursor_page(constituent, path);
+    if (ret == 0)
+        *dumped = true;
+
+done:
+err:
+    __wt_free(session, path);
+    return (ret);
+}
+
 /*
  * __wt_debug_layered_cursor_page --
- *     Dump the in-memory information for a cursor-referenced page.
+ *     Dump the in-memory information for a cursor-referenced page. A layered cursor has two
+ *     underlying btree cursors (ingest + stable); we dump BOTH at the layered cursor's key, issuing
+ *     a search_near on whichever constituent is not currently positioned. This produces one output
+ *     file per constituent (suffixed with the constituent name) so triage can compare the two sides
+ *     for the same key.
  */
 int
 __wt_debug_layered_cursor_page(void *cursor_arg, const char *ofile)
   WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
 {
-    const WT_CURSOR *cursor = (const WT_CURSOR *)cursor_arg;
-    WT_UNUSED(ofile);
+    WT_CURSOR_LAYERED *clayered = (WT_CURSOR_LAYERED *)cursor_arg;
+    bool dumped_ingest, dumped_stable;
 
-    __wt_verbose_debug1(
-      CUR2S(cursor), WT_VERB_DEFAULT, "%s: unsupported cursor type for debug dump", cursor->uri);
+    WT_RET(__layered_constituent_dump(
+      clayered->ingest_cursor, &clayered->iface.key, ofile, "ingest", &dumped_ingest));
+    WT_RET(__layered_constituent_dump(
+      clayered->stable_cursor, &clayered->iface.key, ofile, "stable", &dumped_stable));
+
+    if (!dumped_ingest && !dumped_stable)
+        __wt_verbose_debug1(CUR2S(cursor_arg), WT_VERB_DEFAULT,
+          "%s: layered cursor has no positioned constituent to dump", clayered->iface.uri);
 
     return (0);
 }
 
 /*
  * __wt_debug_layered_cursor_tree_hs --
- *     Dump the in-memory information for a cursor-referenced tree's history store page.
+ *     Dump the in-memory information for a cursor-referenced tree's history store page. Only the
+ *     stable constituent has an associated history store; ingest btrees are in-memory and have no
+ *     history store, so we always dispatch to the stable cursor.
  */
 int
 __wt_debug_layered_cursor_tree_hs(void *cursor_arg, const char *ofile)
   WT_GCC_FUNC_ATTRIBUTE((visibility("default")))
 {
-    const WT_CURSOR *cursor = (const WT_CURSOR *)cursor_arg;
-    WT_UNUSED(ofile);
+    WT_CURSOR_BTREE *cbt;
+    WT_CURSOR_LAYERED *clayered = (WT_CURSOR_LAYERED *)cursor_arg;
 
-    __wt_verbose_debug1(
-      CUR2S(cursor), WT_VERB_DEFAULT, "%s: unsupported cursor type for debug dump", cursor->uri);
+    cbt = (WT_CURSOR_BTREE *)clayered->stable_cursor;
+    if (cbt == NULL || cbt->ref == NULL || cbt->ref->page == NULL) {
+        __wt_verbose_debug1(CUR2S(cursor_arg), WT_VERB_DEFAULT,
+          "%s: stable constituent not positioned, no history store dump available",
+          clayered->iface.uri);
+        return (0);
+    }
 
-    return (0);
+    return (__wt_debug_btree_cursor_tree_hs(clayered->stable_cursor, ofile));
 }
+#endif

--- a/test/format/format_util.c
+++ b/test/format/format_util.c
@@ -258,12 +258,11 @@ cursor_dump_page(WT_CURSOR *cursor, const char *tag)
 
     testutil_snprintf(buf, sizeof(buf), "%s/FAIL.pagedump.%d", g.home, ++next);
 
-    /*
-     * Layered cursors get suffixed files for each constituent (.ingest / .stable). For plain btree
-     * cursors the path is used verbatim.
-     */
-    fprintf(
-      stderr, "%s: dumping to %s (suffixed with constituent for layered cursors)\n", tag, buf);
+    if (WT_PREFIX_MATCH(cursor->uri, "layered:"))
+        fprintf(
+          stderr, "%s: dumping to %s (suffixed with constituent for layered cursors)\n", tag, buf);
+    else
+        fprintf(stderr, "%s: dumping to %s\n", tag, buf);
     trace_msg(CUR2S(cursor), "%s: dumping to %s", tag, buf);
 
     /*

--- a/test/format/format_util.c
+++ b/test/format/format_util.c
@@ -258,7 +258,12 @@ cursor_dump_page(WT_CURSOR *cursor, const char *tag)
 
     testutil_snprintf(buf, sizeof(buf), "%s/FAIL.pagedump.%d", g.home, ++next);
 
-    fprintf(stderr, "%s: dumping to %s\n", tag, buf);
+    /*
+     * Layered cursors get suffixed files for each constituent (.ingest / .stable). For plain btree
+     * cursors the path is used verbatim.
+     */
+    fprintf(
+      stderr, "%s: dumping to %s (suffixed with constituent for layered cursors)\n", tag, buf);
     trace_msg(CUR2S(cursor), "%s: dumping to %s", tag, buf);
 
     /*


### PR DESCRIPTION
## Summary

`__wt_debug_layered_cursor_page` and `__wt_debug_layered_cursor_tree_hs` in `src/cursor/cur_layered.c` were stubs — they logged `"unsupported cursor type for debug dump"` and returned 0 without writing any output. The dispatch in `__wt_debug_cursor_page` ([cur_std.c:1593](src/cursor/cur_std.c)) routes URIs starting with `table:` to these functions, so any caller of the cursor-page debug dump against a layered table (the default in disagg test runs) silently produced no output. This blinded mirror-mismatch triage in `test/format`: `cursor_dump_page` printed `"dumping to /path/FAIL.pagedump.N"` but no file ever appeared.

## Changes

- `src/cursor/cur_layered.c`
  - Implement `__wt_debug_layered_cursor_page`: dump **both** constituents (ingest + stable) at the layered cursor's current key. If a constituent isn't currently positioned (the layered search only positions the constituent that satisfied the lookup), issue a `search_near` on the layered cursor's key so both sides are landed before the dump. Each constituent's page is written to `<ofile>.<constituent>`.
  - Implement `__wt_debug_layered_cursor_tree_hs`: dispatch to the stable cursor only — ingest btrees are in-memory and have no associated history store. If the stable cursor isn't positioned, log a verbose-debug line and return 0.
  - Both functions plus the new helper sit inside the existing `HAVE_DIAGNOSTIC` block (the sole callers in `cur_std.c` are also under `HAVE_DIAGNOSTIC`).

- `test/format/format_util.c`
  - Update `cursor_dump_page`'s message to indicate that layered cursors produce constituent-suffixed files.