### PR TITLE
WT-17645 Strict memory order for slot_state from releaxed to acquire/release

### DIFF
--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1944,8 +1944,7 @@ __wti_log_release(WT_SESSION_IMPL *session, WTI_LOGSLOT *slot, bool *freep)
         if (freep != NULL)
             *freep = false;
         /*
-         * Guard: slot_state, payload: slot buffer. Release-store pairs with the acquire-load in
-         * __wti_log_wrlsn, ensuring the pwrite above is visible before the slot reaches WRITTEN.
+         * Guard: slot_state. Release-store pairs with the acquire-load in __wti_log_wrlsn.
          */
         __wt_atomic_store_int64_v_release(&slot->slot_state, WTI_LOG_SLOT_WRITTEN);
         /*

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1943,12 +1943,6 @@ __wti_log_release(WT_SESSION_IMPL *session, WTI_LOGSLOT *slot, bool *freep)
       FLD_ISSET(conn->server_flags, WT_CONN_SERVER_LOG)) {
         if (freep != NULL)
             *freep = false;
-        /*
-         * Release-store so that the buffer write (pwrite above) happens-before any thread that
-         * acquire-loads the WRITTEN state. The slot buffer can be reused once it transitions
-         * through WRITTEN -> FREE -> activate, and the chain only carries the pwrite as a prior
-         * write if every step uses release/acquire pairs.
-         */
         __wt_atomic_store_int64_v_release(&slot->slot_state, WTI_LOG_SLOT_WRITTEN);
         /*
          * After this point the worker thread owns the slot. There is nothing more to do but return.

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1943,7 +1943,13 @@ __wti_log_release(WT_SESSION_IMPL *session, WTI_LOGSLOT *slot, bool *freep)
       FLD_ISSET(conn->server_flags, WT_CONN_SERVER_LOG)) {
         if (freep != NULL)
             *freep = false;
-        __wt_atomic_store_int64_v_relaxed(&slot->slot_state, WTI_LOG_SLOT_WRITTEN);
+        /*
+         * Release-store so that the buffer write (pwrite above) happens-before any thread that
+         * acquire-loads the WRITTEN state. The slot buffer can be reused once it transitions
+         * through WRITTEN -> FREE -> activate, and the chain only carries the pwrite as a prior
+         * write if every step uses release/acquire pairs.
+         */
+        __wt_atomic_store_int64_v_release(&slot->slot_state, WTI_LOG_SLOT_WRITTEN);
         /*
          * After this point the worker thread owns the slot. There is nothing more to do but return.
          */

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -1943,6 +1943,10 @@ __wti_log_release(WT_SESSION_IMPL *session, WTI_LOGSLOT *slot, bool *freep)
       FLD_ISSET(conn->server_flags, WT_CONN_SERVER_LOG)) {
         if (freep != NULL)
             *freep = false;
+        /*
+         * Guard: slot_state, payload: slot buffer. Release-store pairs with the acquire-load in
+         * __wti_log_wrlsn, ensuring the pwrite above is visible before the slot reaches WRITTEN.
+         */
         __wt_atomic_store_int64_v_release(&slot->slot_state, WTI_LOG_SLOT_WRITTEN);
         /*
          * After this point the worker thread owns the slot. There is nothing more to do but return.

--- a/src/log/log_mgr.c
+++ b/src/log/log_mgr.c
@@ -770,8 +770,7 @@ restart:
         save_i = i;
         slot = &log->slot_pool[i++];
         /*
-         * Guard: slot_state, payload: slot buffer. Acquire-load pairs with the release-store in
-         * __wti_log_release.
+         * Guard: slot_state. Acquire-load pairs with the release-store in __wti_log_release.
          */
         if (__wt_atomic_load_int64_v_acquire(&slot->slot_state) != WTI_LOG_SLOT_WRITTEN)
             continue;

--- a/src/log/log_mgr.c
+++ b/src/log/log_mgr.c
@@ -769,6 +769,10 @@ restart:
     while (i < WTI_SLOT_POOL) {
         save_i = i;
         slot = &log->slot_pool[i++];
+        /*
+         * Guard: slot_state, payload: slot buffer. Acquire-load pairs with the release-store in
+         * __wti_log_release.
+         */
         if (__wt_atomic_load_int64_v_acquire(&slot->slot_state) != WTI_LOG_SLOT_WRITTEN)
             continue;
         written[written_i].slot_index = save_i;

--- a/src/log/log_mgr.c
+++ b/src/log/log_mgr.c
@@ -769,11 +769,6 @@ restart:
     while (i < WTI_SLOT_POOL) {
         save_i = i;
         slot = &log->slot_pool[i++];
-        /*
-         * Acquire-load to synchronize-with the release-store in __wti_log_release; this carries the
-         * prior pwrite of the slot buffer as happens-before the subsequent slot_free and slot
-         * reuse.
-         */
         if (__wt_atomic_load_int64_v_acquire(&slot->slot_state) != WTI_LOG_SLOT_WRITTEN)
             continue;
         written[written_i].slot_index = save_i;

--- a/src/log/log_mgr.c
+++ b/src/log/log_mgr.c
@@ -769,7 +769,12 @@ restart:
     while (i < WTI_SLOT_POOL) {
         save_i = i;
         slot = &log->slot_pool[i++];
-        if (__wt_atomic_load_int64_v_relaxed(&slot->slot_state) != WTI_LOG_SLOT_WRITTEN)
+        /*
+         * Acquire-load to synchronize-with the release-store in __wti_log_release; this carries the
+         * prior pwrite of the slot buffer as happens-before the subsequent slot_free and slot
+         * reuse.
+         */
+        if (__wt_atomic_load_int64_v_acquire(&slot->slot_state) != WTI_LOG_SLOT_WRITTEN)
             continue;
         written[written_i].slot_index = save_i;
         WT_ASSIGN_LSN(&written[written_i++].lsn, &slot->slot_release_lsn);

--- a/src/log/log_slot.c
+++ b/src/log/log_slot.c
@@ -268,6 +268,10 @@ __log_slot_new(WT_SESSION_IMPL *session)
             if (pool_i >= WTI_SLOT_POOL)
                 pool_i = 0;
             slot = &log->slot_pool[pool_i];
+            /*
+             * Guard: slot_state, payload: slot buffer. Acquire-load pairs with the release-store in
+             * __wti_log_slot_free.
+             */
             if (__wt_atomic_load_int64_v_acquire(&slot->slot_state) == WTI_LOG_SLOT_FREE) {
                 /*
                  * Acquire our starting position in the log file. Assume the full buffer size.
@@ -702,5 +706,9 @@ __wti_log_slot_free(WT_SESSION_IMPL *session, WTI_LOGSLOT *slot)
     WT_UNUSED(session);
     __wt_atomic_store_uint16_relaxed(&slot->flags_atomic, WTI_SLOT_INIT_FLAGS);
     __wt_atomic_store_int32_relaxed(&slot->slot_error, 0);
+    /*
+     * Guard: slot_state, payload: slot buffer. Release-store pairs with the acquire-load in
+     * __log_slot_new, ensuring prior buffer writes are visible before the slot is reused.
+     */
     __wt_atomic_store_int64_v_release(&slot->slot_state, WTI_LOG_SLOT_FREE);
 }

--- a/src/log/log_slot.c
+++ b/src/log/log_slot.c
@@ -269,8 +269,7 @@ __log_slot_new(WT_SESSION_IMPL *session)
                 pool_i = 0;
             slot = &log->slot_pool[pool_i];
             /*
-             * Guard: slot_state, payload: slot buffer. Acquire-load pairs with the release-store in
-             * __wti_log_slot_free.
+             * Guard: slot_state. Acquire-load pairs with the release-store in __wti_log_slot_free.
              */
             if (__wt_atomic_load_int64_v_acquire(&slot->slot_state) == WTI_LOG_SLOT_FREE) {
                 /*
@@ -707,8 +706,7 @@ __wti_log_slot_free(WT_SESSION_IMPL *session, WTI_LOGSLOT *slot)
     __wt_atomic_store_uint16_relaxed(&slot->flags_atomic, WTI_SLOT_INIT_FLAGS);
     __wt_atomic_store_int32_relaxed(&slot->slot_error, 0);
     /*
-     * Guard: slot_state, payload: slot buffer. Release-store pairs with the acquire-load in
-     * __log_slot_new, ensuring prior buffer writes are visible before the slot is reused.
+     * Guard: slot_state. Release-store pairs with the acquire-load in __log_slot_new.
      */
     __wt_atomic_store_int64_v_release(&slot->slot_state, WTI_LOG_SLOT_FREE);
 }

--- a/src/log/log_slot.c
+++ b/src/log/log_slot.c
@@ -268,7 +268,11 @@ __log_slot_new(WT_SESSION_IMPL *session)
             if (pool_i >= WTI_SLOT_POOL)
                 pool_i = 0;
             slot = &log->slot_pool[pool_i];
-            if (__wt_atomic_load_int64_v_relaxed(&slot->slot_state) == WTI_LOG_SLOT_FREE) {
+            /*
+             * Acquire-load pairs with the release-store in __wti_log_slot_free so that picking up a
+             * free slot has happens-before with the pwrite of its buffer in the previous owner.
+             */
+            if (__wt_atomic_load_int64_v_acquire(&slot->slot_state) == WTI_LOG_SLOT_FREE) {
                 /*
                  * Acquire our starting position in the log file. Assume the full buffer size.
                  */
@@ -702,5 +706,11 @@ __wti_log_slot_free(WT_SESSION_IMPL *session, WTI_LOGSLOT *slot)
     WT_UNUSED(session);
     __wt_atomic_store_uint16_relaxed(&slot->flags_atomic, WTI_SLOT_INIT_FLAGS);
     __wt_atomic_store_int32_relaxed(&slot->slot_error, 0);
-    __wt_atomic_store_int64_v_relaxed(&slot->slot_state, WTI_LOG_SLOT_FREE);
+    /*
+     * Release-store the FREE transition: any thread that later acquire-loads slot_state and
+     * observes the slot is FREE (or any value derived from it) must also see all prior writes,
+     * including the pwrite that ran in __wti_log_release before the WRITTEN transition. Without
+     * release/acquire here, slot reuse can race with the previous owner's pwrite under TSAN.
+     */
+    __wt_atomic_store_int64_v_release(&slot->slot_state, WTI_LOG_SLOT_FREE);
 }

--- a/src/log/log_slot.c
+++ b/src/log/log_slot.c
@@ -268,10 +268,6 @@ __log_slot_new(WT_SESSION_IMPL *session)
             if (pool_i >= WTI_SLOT_POOL)
                 pool_i = 0;
             slot = &log->slot_pool[pool_i];
-            /*
-             * Acquire-load pairs with the release-store in __wti_log_slot_free so that picking up a
-             * free slot has happens-before with the pwrite of its buffer in the previous owner.
-             */
             if (__wt_atomic_load_int64_v_acquire(&slot->slot_state) == WTI_LOG_SLOT_FREE) {
                 /*
                  * Acquire our starting position in the log file. Assume the full buffer size.
@@ -706,11 +702,5 @@ __wti_log_slot_free(WT_SESSION_IMPL *session, WTI_LOGSLOT *slot)
     WT_UNUSED(session);
     __wt_atomic_store_uint16_relaxed(&slot->flags_atomic, WTI_SLOT_INIT_FLAGS);
     __wt_atomic_store_int32_relaxed(&slot->slot_error, 0);
-    /*
-     * Release-store the FREE transition: any thread that later acquire-loads slot_state and
-     * observes the slot is FREE (or any value derived from it) must also see all prior writes,
-     * including the pwrite that ran in __wti_log_release before the WRITTEN transition. Without
-     * release/acquire here, slot reuse can race with the previous owner's pwrite under TSAN.
-     */
     __wt_atomic_store_int64_v_release(&slot->slot_state, WTI_LOG_SLOT_FREE);
 }


### PR DESCRIPTION
Apply acquire/release model to log slot state.