### PR TITLE
WT-17537 Read new KEK page format and populate timestamp in WT_CRYPT_HEADER

### DIFF
--- a/src/conn/conn_layered_page_log.c
+++ b/src/conn/conn_layered_page_log.c
@@ -171,56 +171,63 @@ __disagg_get_crypt_key(WT_SESSION_IMPL *session, uint64_t page_id, uint64_t lsn,
  *     Validate the crypt header and payload stored in key_item.
  */
 static int
-__disagg_validate_crypt(WT_SESSION_IMPL *session, WT_ITEM *key_item, WT_CRYPT_HEADER **hdrp)
+__disagg_validate_crypt(WT_SESSION_IMPL *session, WT_ITEM *key_item, WT_CRYPT_HEADER *out)
 {
-    WT_CRYPT_HEADER *header;
+    WT_CRYPT_HEADER local;
     WT_DECL_RET;
-    uint32_t checksum = 0, expected_checksum = 0;
+    uint32_t checksum, expected_checksum;
+    uint8_t hdr_size;
+
+    WT_CLEAR(local);
 
     if (key_item->size < WT_CRYPT_HEADER_MIN_SIZE)
         WT_ERR_MSG(session, EIO,
           "Encryption key data too small: expected at least %d, got %" WT_SIZET_FMT,
           WT_CRYPT_HEADER_MIN_SIZE, key_item->size);
-    __disagg_get_crypt_header(key_item, &header);
 
-    expected_checksum = header->checksum;
+    /* Pull the checksum field out of the buffer, then zero it in place and recompute. */
+    memcpy(&expected_checksum, (uint8_t *)key_item->data + offsetof(WT_CRYPT_HEADER, checksum),
+      sizeof(expected_checksum));
 #ifdef WORDS_BIGENDIAN
     expected_checksum = __wt_bswap32(expected_checksum);
 #endif
-    header->checksum = 0;
+    memset((uint8_t *)key_item->data + offsetof(WT_CRYPT_HEADER, checksum), 0, sizeof(uint32_t));
     checksum = __wt_checksum((uint8_t *)key_item->data, key_item->size);
     if (checksum != expected_checksum)
         WT_ERR_MSG(session, EIO,
           "Encryption key data checksum mismatch: expected %" PRIx32 ", got %" PRIx32,
           expected_checksum, checksum);
 
-    if (header->header_size > key_item->size)
-        WT_ERR_MSG(session, EIO,
-          "Encryption key header_size %" PRIu8 " exceeds buffer size %" WT_SIZET_FMT,
-          header->header_size, key_item->size);
+    /* header_size is a single byte; read it directly from the buffer. */
+    hdr_size = ((uint8_t *)key_item->data)[offsetof(WT_CRYPT_HEADER, header_size)];
 
-    __wt_crypt_header_byteswap(header);
-
-    if (header->header_size < WT_CRYPT_HEADER_MIN_SIZE)
+    if (hdr_size < WT_CRYPT_HEADER_MIN_SIZE)
         WT_ERR_MSG(session, EIO,
           "Encryption key header is too small: expected at least %d, got %" PRIu8,
-          WT_CRYPT_HEADER_MIN_SIZE, header->header_size);
+          WT_CRYPT_HEADER_MIN_SIZE, hdr_size);
+    if (hdr_size > key_item->size)
+        WT_ERR_MSG(session, EIO,
+          "Encryption key header_size %" PRIu8 " exceeds buffer size %" WT_SIZET_FMT, hdr_size,
+          key_item->size);
 
-    if (key_item->size - header->header_size != header->crypt_size)
+    /* Copy a bounded number of bytes into our zero-initialized local. */
+    memcpy(&local, key_item->data, WT_MIN(sizeof(local), (size_t)hdr_size));
+    __wt_crypt_header_byteswap(&local);
+
+    if (key_item->size - local.header_size != local.crypt_size)
         WT_ERR_MSG(session, EIO, "Encryption key data size mismatch: expected %u, got %u",
-          header->crypt_size, (uint32_t)(key_item->size - header->header_size));
+          local.crypt_size, (uint32_t)(key_item->size - local.header_size));
 
-    /* Check for compatibility versions before validating header fields. */
-    if (header->compatible_version > WT_CRYPT_HEADER_VERSION)
+    if (local.compatible_version > WT_CRYPT_HEADER_VERSION)
         WT_ERR_MSG(session, ENOTSUP,
-          "Unsupported encryption key data version %" PRIu8 ", min %" PRIu8, header->version,
-          header->compatible_version);
+          "Unsupported encryption key data version %" PRIu8 ", min %" PRIu8, local.version,
+          local.compatible_version);
 
-    WT_ASSERT_ALWAYS(session, header->signature == WT_CRYPT_HEADER_SIGNATURE,
+    WT_ASSERT_ALWAYS(session, local.signature == WT_CRYPT_HEADER_SIGNATURE,
       "Invalid encryption key data signature: expected 0x%08" PRIx32 ", got 0x%08" PRIx32,
-      WT_CRYPT_HEADER_SIGNATURE, header->signature);
+      WT_CRYPT_HEADER_SIGNATURE, local.signature);
 
-    *hdrp = header;
+    *out = local;
 err:
     return (ret);
 }
@@ -233,7 +240,7 @@ int
 __wti_disagg_load_crypt_key(WT_SESSION_IMPL *session, WT_DISAGG_METADATA *metadata)
 {
     WT_CONNECTION_IMPL *conn;
-    WT_CRYPT_HEADER *crypt_header;
+    WT_CRYPT_HEADER crypt_header;
     WT_CRYPT_KEYS crypt;
     WT_DECL_RET;
     WT_ITEM key_item;
@@ -271,8 +278,8 @@ __wti_disagg_load_crypt_key(WT_SESSION_IMPL *session, WT_DISAGG_METADATA *metada
     WT_ERR(__disagg_validate_crypt(session, &key_item, &crypt_header));
 
     /* Prepare the crypt keys for loading. */
-    crypt.keys.data = (uint8_t *)key_item.data + crypt_header->header_size;
-    crypt.keys.size = crypt_header->crypt_size;
+    crypt.keys.data = (uint8_t *)key_item.data + crypt_header.header_size;
+    crypt.keys.size = crypt_header.crypt_size;
     crypt.r.lsn = lsn;
 
     /* Callback to load the encryption key data into the key provider. */
@@ -976,7 +983,7 @@ __ut_disagg_set_crypt_header(WT_SESSION_IMPL *session, WT_CRYPT_KEYS *crypt)
 }
 
 int
-__ut_disagg_validate_crypt(WT_SESSION_IMPL *session, WT_ITEM *key_item, WT_CRYPT_HEADER **header)
+__ut_disagg_validate_crypt(WT_SESSION_IMPL *session, WT_ITEM *key_item, WT_CRYPT_HEADER *header)
 {
     return (__disagg_validate_crypt(session, key_item, header));
 }

--- a/src/conn/conn_layered_page_log.c
+++ b/src/conn/conn_layered_page_log.c
@@ -193,7 +193,7 @@ __disagg_validate_crypt(WT_SESSION_IMPL *session, WT_ITEM *key_item, WT_CRYPT_HE
         WT_ERR_MSG(session, EIO,
           "Encryption key data checksum mismatch: expected %" PRIx32 ", got %" PRIx32,
           expected_checksum, checksum);
-    __wt_crypt_header_byteswap(header, header->header_size);
+    __wt_crypt_header_byteswap(header, key_item->size);
 
     if (header->header_size < WT_CRYPT_HEADER_MIN_SIZE)
         WT_ERR_MSG(session, EIO,

--- a/src/conn/conn_layered_page_log.c
+++ b/src/conn/conn_layered_page_log.c
@@ -177,10 +177,10 @@ __disagg_validate_crypt(WT_SESSION_IMPL *session, WT_ITEM *key_item, WT_CRYPT_HE
     WT_DECL_RET;
     uint32_t checksum = 0, expected_checksum = 0;
 
-    if (key_item->size < sizeof(WT_CRYPT_HEADER))
+    if (key_item->size < WT_CRYPT_HEADER_MIN_SIZE)
         WT_ERR_MSG(session, EIO,
-          "Encryption key data too small: expected at least %" WT_SIZET_FMT ", got %" WT_SIZET_FMT,
-          sizeof(WT_CRYPT_HEADER), key_item->size);
+          "Encryption key data too small: expected at least %d, got %" WT_SIZET_FMT,
+          WT_CRYPT_HEADER_MIN_SIZE, key_item->size);
     __disagg_get_crypt_header(key_item, &header);
 
     expected_checksum = header->checksum;
@@ -193,12 +193,12 @@ __disagg_validate_crypt(WT_SESSION_IMPL *session, WT_ITEM *key_item, WT_CRYPT_HE
         WT_ERR_MSG(session, EIO,
           "Encryption key data checksum mismatch: expected %" PRIx32 ", got %" PRIx32,
           expected_checksum, checksum);
-    __wt_crypt_header_byteswap(header);
+    __wt_crypt_header_byteswap(header, header->header_size);
 
-    if (header->header_size < sizeof(WT_CRYPT_HEADER))
+    if (header->header_size < WT_CRYPT_HEADER_MIN_SIZE)
         WT_ERR_MSG(session, EIO,
-          "Encryption key header is too small: expected at least %" WT_SIZET_FMT ", got %" PRIu8,
-          sizeof(WT_CRYPT_HEADER), header->header_size);
+          "Encryption key header is too small: expected at least %d, got %" PRIu8,
+          WT_CRYPT_HEADER_MIN_SIZE, header->header_size);
 
     if (key_item->size - header->header_size != header->crypt_size)
         WT_ERR_MSG(session, EIO, "Encryption key data size mismatch: expected %u, got %u",
@@ -398,8 +398,9 @@ __disagg_set_crypt_header(WT_SESSION_IMPL *session, WT_CRYPT_KEYS *crypt)
     crypt_header->header_size = sizeof(WT_CRYPT_HEADER);
     crypt_header->crypt_size = (uint32_t)crypt->keys.size;
     crypt_header->checksum = 0;
+    crypt_header->timestamp = 0;
 
-    __wt_crypt_header_byteswap(crypt_header);
+    __wt_crypt_header_byteswap(crypt_header, sizeof(WT_CRYPT_HEADER));
     crypt->keys.data = crypt->keys.mem;
     crypt->keys.size += sizeof(WT_CRYPT_HEADER);
 

--- a/src/conn/conn_layered_page_log.c
+++ b/src/conn/conn_layered_page_log.c
@@ -977,12 +977,6 @@ __ut_disagg_validate_crypt(WT_SESSION_IMPL *session, WT_ITEM *key_item, WT_CRYPT
     return (__disagg_validate_crypt(session, key_item, header));
 }
 
-void
-__ut_disagg_get_crypt_header(WT_ITEM *key_item, WT_CRYPT_HEADER **header)
-{
-    *header = (WT_CRYPT_HEADER *)key_item->data;
-}
-
 int
 __ut_disagg_parse_version_and_check(
   WT_SESSION_IMPL *session, const WT_ITEM *meta_buf, WT_DISAGG_METADATA *metadata)

--- a/src/conn/conn_layered_page_log.c
+++ b/src/conn/conn_layered_page_log.c
@@ -194,13 +194,12 @@ __disagg_validate_crypt(WT_SESSION_IMPL *session, WT_ITEM *key_item, WT_CRYPT_HE
           "Encryption key data checksum mismatch: expected %" PRIx32 ", got %" PRIx32,
           expected_checksum, checksum);
 
-    /* Reject pages where the header claims to extend past the buffer before we touch any field. */
     if (header->header_size > key_item->size)
         WT_ERR_MSG(session, EIO,
           "Encryption key header_size %" PRIu8 " exceeds buffer size %" WT_SIZET_FMT,
           header->header_size, key_item->size);
 
-    __wt_crypt_header_byteswap(header, header->header_size);
+    __wt_crypt_header_byteswap(header);
 
     if (header->header_size < WT_CRYPT_HEADER_MIN_SIZE)
         WT_ERR_MSG(session, EIO,
@@ -407,7 +406,7 @@ __disagg_set_crypt_header(WT_SESSION_IMPL *session, WT_CRYPT_KEYS *crypt)
     crypt_header->checksum = 0;
     crypt_header->timestamp = 0;
 
-    __wt_crypt_header_byteswap(crypt_header, sizeof(WT_CRYPT_HEADER));
+    __wt_crypt_header_byteswap(crypt_header);
     crypt->keys.data = crypt->keys.mem;
     crypt->keys.size += sizeof(WT_CRYPT_HEADER);
 

--- a/src/conn/conn_layered_page_log.c
+++ b/src/conn/conn_layered_page_log.c
@@ -193,7 +193,7 @@ __disagg_validate_crypt(WT_SESSION_IMPL *session, WT_ITEM *key_item, WT_CRYPT_HE
         WT_ERR_MSG(session, EIO,
           "Encryption key data checksum mismatch: expected %" PRIx32 ", got %" PRIx32,
           expected_checksum, checksum);
-    __wt_crypt_header_byteswap(header, key_item->size);
+    __wt_crypt_header_byteswap(header, header->header_size, key_item->size);
 
     if (header->header_size < WT_CRYPT_HEADER_MIN_SIZE)
         WT_ERR_MSG(session, EIO,
@@ -400,7 +400,7 @@ __disagg_set_crypt_header(WT_SESSION_IMPL *session, WT_CRYPT_KEYS *crypt)
     crypt_header->checksum = 0;
     crypt_header->timestamp = 0;
 
-    __wt_crypt_header_byteswap(crypt_header, sizeof(WT_CRYPT_HEADER));
+    __wt_crypt_header_byteswap(crypt_header, sizeof(WT_CRYPT_HEADER), sizeof(WT_CRYPT_HEADER));
     crypt->keys.data = crypt->keys.mem;
     crypt->keys.size += sizeof(WT_CRYPT_HEADER);
 

--- a/src/conn/conn_layered_page_log.c
+++ b/src/conn/conn_layered_page_log.c
@@ -170,64 +170,67 @@ __disagg_get_crypt_key(WT_SESSION_IMPL *session, uint64_t page_id, uint64_t lsn,
  *     Validate the crypt header and payload stored in key_item.
  */
 static int
-__disagg_validate_crypt(WT_SESSION_IMPL *session, WT_ITEM *key_item, WT_CRYPT_HEADER *out)
+__disagg_validate_crypt(WT_SESSION_IMPL *session, WT_ITEM *key_item, WT_CRYPT_HEADER **hdrp)
 {
-    WT_CRYPT_HEADER local;
+    WT_CRYPT_HEADER *hdr, *raw;
     WT_DECL_RET;
     uint32_t checksum, expected_checksum;
-    uint8_t hdr_size;
 
-    WT_CLEAR(local);
+    *hdrp = NULL;
+    WT_RET(__wt_calloc_one(session, &hdr));
 
     if (key_item->size < WT_CRYPT_HEADER_MIN_SIZE)
         WT_ERR_MSG(session, EIO,
           "Encryption key data too small: expected at least %d, got %" WT_SIZET_FMT,
           WT_CRYPT_HEADER_MIN_SIZE, key_item->size);
 
-    /* Pull the checksum field out of the buffer, then zero it in place and recompute. */
-    memcpy(&expected_checksum, (uint8_t *)key_item->data + offsetof(WT_CRYPT_HEADER, checksum),
-      sizeof(expected_checksum));
+    /*
+     * The first WT_CRYPT_HEADER_MIN_SIZE bytes are guaranteed to be in the buffer, so reading the
+     * checksum and header_size fields via a struct pointer is safe.
+     */
+    raw = (WT_CRYPT_HEADER *)key_item->data;
+
+    expected_checksum = raw->checksum;
 #ifdef WORDS_BIGENDIAN
     expected_checksum = __wt_bswap32(expected_checksum);
 #endif
-    memset((uint8_t *)key_item->data + offsetof(WT_CRYPT_HEADER, checksum), 0, sizeof(uint32_t));
+    raw->checksum = 0;
     checksum = __wt_checksum((uint8_t *)key_item->data, key_item->size);
     if (checksum != expected_checksum)
         WT_ERR_MSG(session, EIO,
           "Encryption key data checksum mismatch: expected %" PRIx32 ", got %" PRIx32,
           expected_checksum, checksum);
 
-    /* header_size is a single byte; read it directly from the buffer. */
-    hdr_size = ((uint8_t *)key_item->data)[offsetof(WT_CRYPT_HEADER, header_size)];
-
-    if (hdr_size < WT_CRYPT_HEADER_MIN_SIZE)
+    if (raw->header_size < WT_CRYPT_HEADER_MIN_SIZE)
         WT_ERR_MSG(session, EIO,
           "Encryption key header is too small: expected at least %d, got %" PRIu8,
-          WT_CRYPT_HEADER_MIN_SIZE, hdr_size);
-    if (hdr_size > key_item->size)
+          WT_CRYPT_HEADER_MIN_SIZE, raw->header_size);
+    if (raw->header_size > key_item->size)
         WT_ERR_MSG(session, EIO,
-          "Encryption key header_size %" PRIu8 " exceeds buffer size %" WT_SIZET_FMT, hdr_size,
-          key_item->size);
+          "Encryption key header_size %" PRIu8 " exceeds buffer size %" WT_SIZET_FMT,
+          raw->header_size, key_item->size);
 
-    /* Copy a bounded number of bytes into our zero-initialized local. */
-    memcpy(&local, key_item->data, WT_MIN(sizeof(local), (size_t)hdr_size));
-    __wt_crypt_header_byteswap(&local);
+    /* Copy a bounded number of bytes into our zero-initialized hdr. */
+    memcpy(hdr, key_item->data, WT_MIN(sizeof(WT_CRYPT_HEADER), (size_t)raw->header_size));
+    __wt_crypt_header_byteswap(hdr);
 
-    if (key_item->size - local.header_size != local.crypt_size)
+    if (key_item->size - hdr->header_size != hdr->crypt_size)
         WT_ERR_MSG(session, EIO, "Encryption key data size mismatch: expected %u, got %u",
-          local.crypt_size, (uint32_t)(key_item->size - local.header_size));
+          hdr->crypt_size, (uint32_t)(key_item->size - hdr->header_size));
 
-    if (local.compatible_version > WT_CRYPT_HEADER_VERSION)
+    if (hdr->compatible_version > WT_CRYPT_HEADER_VERSION)
         WT_ERR_MSG(session, ENOTSUP,
-          "Unsupported encryption key data version %" PRIu8 ", min %" PRIu8, local.version,
-          local.compatible_version);
+          "Unsupported encryption key data version %" PRIu8 ", min %" PRIu8, hdr->version,
+          hdr->compatible_version);
 
-    WT_ASSERT_ALWAYS(session, local.signature == WT_CRYPT_HEADER_SIGNATURE,
+    WT_ASSERT_ALWAYS(session, hdr->signature == WT_CRYPT_HEADER_SIGNATURE,
       "Invalid encryption key data signature: expected 0x%08" PRIx32 ", got 0x%08" PRIx32,
-      WT_CRYPT_HEADER_SIGNATURE, local.signature);
+      WT_CRYPT_HEADER_SIGNATURE, hdr->signature);
 
-    *out = local;
+    *hdrp = hdr;
+    return (0);
 err:
+    __wt_free(session, hdr);
     return (ret);
 }
 
@@ -239,11 +242,13 @@ int
 __wti_disagg_load_crypt_key(WT_SESSION_IMPL *session, WT_DISAGG_METADATA *metadata)
 {
     WT_CONNECTION_IMPL *conn;
-    WT_CRYPT_HEADER crypt_header;
+    WT_CRYPT_HEADER *crypt_header;
     WT_CRYPT_KEYS crypt;
     WT_DECL_RET;
     WT_ITEM key_item;
     WT_KEY_PROVIDER *key_provider;
+
+    crypt_header = NULL;
 
     conn = S2C(session);
     key_provider = conn->key_provider;
@@ -277,8 +282,8 @@ __wti_disagg_load_crypt_key(WT_SESSION_IMPL *session, WT_DISAGG_METADATA *metada
     WT_ERR(__disagg_validate_crypt(session, &key_item, &crypt_header));
 
     /* Prepare the crypt keys for loading. */
-    crypt.keys.data = (uint8_t *)key_item.data + crypt_header.header_size;
-    crypt.keys.size = crypt_header.crypt_size;
+    crypt.keys.data = (uint8_t *)key_item.data + crypt_header->header_size;
+    crypt.keys.size = crypt_header->crypt_size;
     crypt.r.lsn = lsn;
 
     /* Callback to load the encryption key data into the key provider. */
@@ -286,6 +291,7 @@ __wti_disagg_load_crypt_key(WT_SESSION_IMPL *session, WT_DISAGG_METADATA *metada
 
 err:
     __wt_buf_free(session, &key_item);
+    __wt_free(session, crypt_header);
     return (ret);
 }
 
@@ -972,7 +978,7 @@ __ut_disagg_set_crypt_header(WT_SESSION_IMPL *session, WT_CRYPT_KEYS *crypt)
 }
 
 int
-__ut_disagg_validate_crypt(WT_SESSION_IMPL *session, WT_ITEM *key_item, WT_CRYPT_HEADER *header)
+__ut_disagg_validate_crypt(WT_SESSION_IMPL *session, WT_ITEM *key_item, WT_CRYPT_HEADER **header)
 {
     return (__disagg_validate_crypt(session, key_item, header));
 }

--- a/src/conn/conn_layered_page_log.c
+++ b/src/conn/conn_layered_page_log.c
@@ -211,7 +211,7 @@ __disagg_validate_crypt(WT_SESSION_IMPL *session, WT_ITEM *key_item, WT_CRYPT_HE
           header->crypt_size, (uint32_t)(key_item->size - header->header_size));
 
     /* Check for compatibility versions before validating header fields. */
-    if (header->compatible_version > WT_CRYPT_HEADER_COMPATIBLE_VERSION)
+    if (header->compatible_version > WT_CRYPT_HEADER_VERSION)
         WT_ERR_MSG(session, ENOTSUP,
           "Unsupported encryption key data version %" PRIu8 ", min %" PRIu8, header->version,
           header->compatible_version);

--- a/src/conn/conn_layered_page_log.c
+++ b/src/conn/conn_layered_page_log.c
@@ -193,7 +193,14 @@ __disagg_validate_crypt(WT_SESSION_IMPL *session, WT_ITEM *key_item, WT_CRYPT_HE
         WT_ERR_MSG(session, EIO,
           "Encryption key data checksum mismatch: expected %" PRIx32 ", got %" PRIx32,
           expected_checksum, checksum);
-    __wt_crypt_header_byteswap(header, header->header_size, key_item->size);
+
+    /* Reject pages where the header claims to extend past the buffer before we touch any field. */
+    if (header->header_size > key_item->size)
+        WT_ERR_MSG(session, EIO,
+          "Encryption key header_size %" PRIu8 " exceeds buffer size %" WT_SIZET_FMT,
+          header->header_size, key_item->size);
+
+    __wt_crypt_header_byteswap(header, header->header_size);
 
     if (header->header_size < WT_CRYPT_HEADER_MIN_SIZE)
         WT_ERR_MSG(session, EIO,
@@ -400,7 +407,7 @@ __disagg_set_crypt_header(WT_SESSION_IMPL *session, WT_CRYPT_KEYS *crypt)
     crypt_header->checksum = 0;
     crypt_header->timestamp = 0;
 
-    __wt_crypt_header_byteswap(crypt_header, sizeof(WT_CRYPT_HEADER), sizeof(WT_CRYPT_HEADER));
+    __wt_crypt_header_byteswap(crypt_header, sizeof(WT_CRYPT_HEADER));
     crypt->keys.data = crypt->keys.mem;
     crypt->keys.size += sizeof(WT_CRYPT_HEADER);
 

--- a/src/conn/conn_layered_page_log.c
+++ b/src/conn/conn_layered_page_log.c
@@ -10,7 +10,6 @@
 
 /* Function prototypes for disaggregated storage and layered tables. */
 static void __disagg_set_crypt_header(WT_SESSION_IMPL *session, WT_CRYPT_KEYS *crypt);
-static void __disagg_get_crypt_header(WT_ITEM *key_item, WT_CRYPT_HEADER **header);
 
 /*
  * __disagg_get_page --
@@ -288,16 +287,6 @@ __wti_disagg_load_crypt_key(WT_SESSION_IMPL *session, WT_DISAGG_METADATA *metada
 err:
     __wt_buf_free(session, &key_item);
     return (ret);
-}
-
-/*
- * __disagg_get_crypt_header --
- *     Copy and byte-swap the crypt header from the key item. Note: This function is not idempotent.
- */
-static void
-__disagg_get_crypt_header(WT_ITEM *key_item, WT_CRYPT_HEADER **header)
-{
-    *header = (WT_CRYPT_HEADER *)key_item->data;
 }
 
 /*
@@ -991,7 +980,7 @@ __ut_disagg_validate_crypt(WT_SESSION_IMPL *session, WT_ITEM *key_item, WT_CRYPT
 void
 __ut_disagg_get_crypt_header(WT_ITEM *key_item, WT_CRYPT_HEADER **header)
 {
-    __disagg_get_crypt_header(key_item, header);
+    *header = (WT_CRYPT_HEADER *)key_item->data;
 }
 
 int

--- a/src/include/crypt_header.h
+++ b/src/include/crypt_header.h
@@ -42,20 +42,17 @@ struct __wt_crypt_header {
 
 /*
  * __wt_crypt_header_byteswap --
- *     Handle big- and little-endian transformation of a key header. The caller must guarantee
- *     that the underlying buffer holds at least header_size bytes; the timestamp field is
- *     swapped only when the on-disk header_size indicates it is present.
+ *     Handle big- and little-endian transformation of a key header.
  */
 static WT_INLINE void
-__wt_crypt_header_byteswap(WT_CRYPT_HEADER *hdr, size_t header_size)
+__wt_crypt_header_byteswap(WT_CRYPT_HEADER *hdr)
 {
 #ifdef WORDS_BIGENDIAN
     hdr->signature = __wt_bswap32(hdr->signature);
     hdr->crypt_size = __wt_bswap32(hdr->crypt_size);
-    if (header_size >= sizeof(WT_CRYPT_HEADER))
+    if (hdr->header_size >= sizeof(WT_CRYPT_HEADER))
         hdr->timestamp = __wt_bswap64(hdr->timestamp);
 #else
     WT_UNUSED(hdr);
-    WT_UNUSED(header_size);
 #endif
 }

--- a/src/include/crypt_header.h
+++ b/src/include/crypt_header.h
@@ -42,21 +42,20 @@ struct __wt_crypt_header {
 
 /*
  * __wt_crypt_header_byteswap --
- *     Handle big- and little-endian transformation of a key header. The timestamp is swapped only
- *     when the on-disk header advertises that it is present (header_size) AND the underlying buffer
- *     is large enough to hold it (buf_size).
+ *     Handle big- and little-endian transformation of a key header. The caller must guarantee
+ *     that the underlying buffer holds at least header_size bytes; the timestamp field is
+ *     swapped only when the on-disk header_size indicates it is present.
  */
 static WT_INLINE void
-__wt_crypt_header_byteswap(WT_CRYPT_HEADER *hdr, size_t header_size, size_t buf_size)
+__wt_crypt_header_byteswap(WT_CRYPT_HEADER *hdr, size_t header_size)
 {
 #ifdef WORDS_BIGENDIAN
     hdr->signature = __wt_bswap32(hdr->signature);
     hdr->crypt_size = __wt_bswap32(hdr->crypt_size);
-    if (header_size >= sizeof(WT_CRYPT_HEADER) && buf_size >= sizeof(WT_CRYPT_HEADER))
+    if (header_size >= sizeof(WT_CRYPT_HEADER))
         hdr->timestamp = __wt_bswap64(hdr->timestamp);
 #else
     WT_UNUSED(hdr);
     WT_UNUSED(header_size);
-    WT_UNUSED(buf_size);
 #endif
 }

--- a/src/include/crypt_header.h
+++ b/src/include/crypt_header.h
@@ -42,20 +42,21 @@ struct __wt_crypt_header {
 
 /*
  * __wt_crypt_header_byteswap --
- *     Handle big- and little-endian transformation of a key header. The caller passes the number
- *     of bytes safely accessible through hdr (the underlying buffer size); the timestamp field is
- *     only touched when the buffer is large enough to hold it.
+ *     Handle big- and little-endian transformation of a key header. The timestamp is swapped only
+ *     when the on-disk header advertises that it is present (header_size) AND the underlying buffer
+ *     is large enough to hold it (buf_size).
  */
 static WT_INLINE void
-__wt_crypt_header_byteswap(WT_CRYPT_HEADER *hdr, size_t buf_size)
+__wt_crypt_header_byteswap(WT_CRYPT_HEADER *hdr, size_t header_size, size_t buf_size)
 {
 #ifdef WORDS_BIGENDIAN
     hdr->signature = __wt_bswap32(hdr->signature);
     hdr->crypt_size = __wt_bswap32(hdr->crypt_size);
-    if (buf_size >= sizeof(WT_CRYPT_HEADER))
+    if (header_size >= sizeof(WT_CRYPT_HEADER) && buf_size >= sizeof(WT_CRYPT_HEADER))
         hdr->timestamp = __wt_bswap64(hdr->timestamp);
 #else
     WT_UNUSED(hdr);
+    WT_UNUSED(header_size);
     WT_UNUSED(buf_size);
 #endif
 }

--- a/src/include/crypt_header.h
+++ b/src/include/crypt_header.h
@@ -23,7 +23,7 @@ struct __wt_crypt_header {
      * As we create new versions, bump the version number here, and consider what previous versions
      * are compatible with it.
      */
-#define WT_CRYPT_HEADER_VERSION 0x1u
+#define WT_CRYPT_HEADER_VERSION 0x2u
     uint8_t version; /* 04: Header version */
 #define WT_CRYPT_HEADER_COMPATIBLE_VERSION 0x1u
     uint8_t compatible_version; /* 05: Minimum compatibility version */
@@ -31,19 +31,31 @@ struct __wt_crypt_header {
     uint8_t unused[1];          /* 07: Unused padding */
     uint32_t crypt_size;        /* 08-11: Payload size, in bytes */
     uint32_t checksum;          /* 12-15: Payload CRC32 checksum */
+    uint64_t timestamp;         /* 16-23: Key rotation timestamp (0 if unused) */
 };
 
 /*
+ * Minimum number of header bytes every reader must always see. Fields beyond this point are
+ * optional and gated by the on-disk header_size value.
+ */
+#define WT_CRYPT_HEADER_MIN_SIZE 16
+
+/*
  * __wt_crypt_header_byteswap --
- *     Handle big- and little-endian transformation of a key header.
+ *     Handle big- and little-endian transformation of a key header. Only fields covered by
+ *     header_size bytes are swapped; the caller must pass the on-disk header_size value so that
+ *     fields beyond a shorter header are not read.
  */
 static WT_INLINE void
-__wt_crypt_header_byteswap(WT_CRYPT_HEADER *hdr)
+__wt_crypt_header_byteswap(WT_CRYPT_HEADER *hdr, size_t header_size)
 {
 #ifdef WORDS_BIGENDIAN
     hdr->signature = __wt_bswap32(hdr->signature);
     hdr->crypt_size = __wt_bswap32(hdr->crypt_size);
+    if (header_size >= sizeof(WT_CRYPT_HEADER))
+        hdr->timestamp = __wt_bswap64(hdr->timestamp);
 #else
     WT_UNUSED(hdr);
+    WT_UNUSED(header_size);
 #endif
 }

--- a/src/include/crypt_header.h
+++ b/src/include/crypt_header.h
@@ -42,20 +42,20 @@ struct __wt_crypt_header {
 
 /*
  * __wt_crypt_header_byteswap --
- *     Handle big- and little-endian transformation of a key header. Only fields covered by
- *     header_size bytes are swapped; the caller must pass the on-disk header_size value so that
- *     fields beyond a shorter header are not read.
+ *     Handle big- and little-endian transformation of a key header. The caller passes the number
+ *     of bytes safely accessible through hdr (the underlying buffer size); the timestamp field is
+ *     only touched when the buffer is large enough to hold it.
  */
 static WT_INLINE void
-__wt_crypt_header_byteswap(WT_CRYPT_HEADER *hdr, size_t header_size)
+__wt_crypt_header_byteswap(WT_CRYPT_HEADER *hdr, size_t buf_size)
 {
 #ifdef WORDS_BIGENDIAN
     hdr->signature = __wt_bswap32(hdr->signature);
     hdr->crypt_size = __wt_bswap32(hdr->crypt_size);
-    if (header_size >= sizeof(WT_CRYPT_HEADER))
+    if (buf_size >= sizeof(WT_CRYPT_HEADER))
         hdr->timestamp = __wt_bswap64(hdr->timestamp);
 #else
     WT_UNUSED(hdr);
-    WT_UNUSED(header_size);
+    WT_UNUSED(buf_size);
 #endif
 }

--- a/src/include/crypt_header.h
+++ b/src/include/crypt_header.h
@@ -50,8 +50,7 @@ __wt_crypt_header_byteswap(WT_CRYPT_HEADER *hdr)
 #ifdef WORDS_BIGENDIAN
     hdr->signature = __wt_bswap32(hdr->signature);
     hdr->crypt_size = __wt_bswap32(hdr->crypt_size);
-    if (hdr->header_size >= sizeof(WT_CRYPT_HEADER))
-        hdr->timestamp = __wt_bswap64(hdr->timestamp);
+    hdr->timestamp = __wt_bswap64(hdr->timestamp);
 #else
     WT_UNUSED(hdr);
 #endif

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2668,7 +2668,7 @@ extern int __ut_disagg_validate_checkpoint_meta_version(WT_SESSION_IMPL *session
   const char *meta_str, uint32_t *out_version, uint32_t *out_compatible_version)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __ut_disagg_validate_crypt(WT_SESSION_IMPL *session, WT_ITEM *key_item,
-  WT_CRYPT_HEADER **header) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+  WT_CRYPT_HEADER *header) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __ut_layered_derive_layered_uri(WT_SESSION_IMPL *session, const char *ingest_uri,
   WT_ITEM *buf) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __ut_verify_compare_page_id_lists(WT_SESSION_IMPL *session, uint64_t *btree_ids,

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2668,7 +2668,7 @@ extern int __ut_disagg_validate_checkpoint_meta_version(WT_SESSION_IMPL *session
   const char *meta_str, uint32_t *out_version, uint32_t *out_compatible_version)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __ut_disagg_validate_crypt(WT_SESSION_IMPL *session, WT_ITEM *key_item,
-  WT_CRYPT_HEADER *header) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+  WT_CRYPT_HEADER **header) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __ut_layered_derive_layered_uri(WT_SESSION_IMPL *session, const char *ingest_uri,
   WT_ITEM *buf) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __ut_verify_compare_page_id_lists(WT_SESSION_IMPL *session, uint64_t *btree_ids,

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2678,7 +2678,6 @@ extern void __ut_block_off_srch(WT_EXT **head, wt_off_t off, WT_EXT ***stack, bo
 extern void __ut_block_off_srch_pair(
   WT_EXTLIST *el, wt_off_t off, WT_EXT **beforep, WT_EXT **afterp);
 extern void __ut_block_size_srch(WT_SIZE **head, wt_off_t size, WT_SIZE ***stack);
-extern void __ut_disagg_get_crypt_header(WT_ITEM *key_item, WT_CRYPT_HEADER **header);
 extern void __ut_disagg_set_crypt_header(WT_SESSION_IMPL *session, WT_CRYPT_KEYS *crypt);
 extern void __ut_layered_table_truncate_gc(
   WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered_table, const wt_timestamp_t prune_timestamp);

--- a/test/catch2/ext/test_key_provider_header.cpp
+++ b/test/catch2/ext/test_key_provider_header.cpp
@@ -121,7 +121,7 @@ TEST_CASE_METHOD(
     /* Set the header inside the crypt struct. */
     __ut_disagg_set_crypt_header(session_impl, &crypt);
 
-    WT_CRYPT_HEADER read_crypt_header = {};
+    WT_CRYPT_HEADER *read_crypt_header = nullptr;
     SECTION("Test key provider basic unpack")
     {
         /* Fetch the baseline header before performing read. */
@@ -130,7 +130,7 @@ TEST_CASE_METHOD(
         REQUIRE(__ut_disagg_validate_crypt(session_impl, &crypt.keys, &read_crypt_header) == 0);
 
         /* Validate that before and after validation should not change the header. */
-        REQUIRE(memcmp(&write_crypt_header, &read_crypt_header, sizeof(WT_CRYPT_HEADER)) == 0);
+        REQUIRE(memcmp(&write_crypt_header, read_crypt_header, sizeof(WT_CRYPT_HEADER)) == 0);
     }
 
     SECTION("Test key provider header version")
@@ -148,7 +148,7 @@ TEST_CASE_METHOD(
         REQUIRE(__ut_disagg_validate_crypt(session_impl, &crypt.keys, &read_crypt_header) == 0);
 
         /* Validate that before and after validation should not change the header. */
-        REQUIRE(memcmp(&write_crypt_header, &read_crypt_header, sizeof(WT_CRYPT_HEADER)) == 0);
+        REQUIRE(memcmp(&write_crypt_header, read_crypt_header, sizeof(WT_CRYPT_HEADER)) == 0);
     }
 
     SECTION("Test key provider header compatibility issue")
@@ -187,6 +187,7 @@ TEST_CASE_METHOD(
         header->checksum = 123;
         REQUIRE(__ut_disagg_validate_crypt(session_impl, &crypt.keys, &read_crypt_header) == EIO);
     }
+    __wt_free(session_impl, read_crypt_header);
 }
 
 /*
@@ -207,11 +208,12 @@ TEST_CASE_METHOD(
 
     build_crypt_page(&crypt.keys, 1, 1, k_v1_header_size, 0, test_string.size());
 
-    WT_CRYPT_HEADER read_crypt_header = {};
+    WT_CRYPT_HEADER *read_crypt_header = nullptr;
     REQUIRE(__ut_disagg_validate_crypt(session_impl, &crypt.keys, &read_crypt_header) == 0);
-    REQUIRE(read_crypt_header.version == 1);
-    REQUIRE(read_crypt_header.header_size == k_v1_header_size);
-    REQUIRE(read_crypt_header.crypt_size == test_string.size());
+    REQUIRE(read_crypt_header->version == 1);
+    REQUIRE(read_crypt_header->header_size == k_v1_header_size);
+    REQUIRE(read_crypt_header->crypt_size == test_string.size());
+    __wt_free(session_impl, read_crypt_header);
 }
 
 /*
@@ -228,17 +230,18 @@ TEST_CASE_METHOD(
     build_crypt_page(&crypt.keys, WT_CRYPT_HEADER_VERSION + 1, WT_CRYPT_HEADER_COMPATIBLE_VERSION,
       sizeof(WT_CRYPT_HEADER), expected_timestamp, test_string.size());
 
-    WT_CRYPT_HEADER read_crypt_header = {};
+    WT_CRYPT_HEADER *read_crypt_header = nullptr;
     REQUIRE(__ut_disagg_validate_crypt(session_impl, &crypt.keys, &read_crypt_header) == 0);
-    REQUIRE(read_crypt_header.version == WT_CRYPT_HEADER_VERSION + 1);
-    REQUIRE(read_crypt_header.header_size == sizeof(WT_CRYPT_HEADER));
-    REQUIRE(read_crypt_header.crypt_size == test_string.size());
-    REQUIRE(read_crypt_header.timestamp == expected_timestamp);
+    REQUIRE(read_crypt_header->version == WT_CRYPT_HEADER_VERSION + 1);
+    REQUIRE(read_crypt_header->header_size == sizeof(WT_CRYPT_HEADER));
+    REQUIRE(read_crypt_header->crypt_size == test_string.size());
+    REQUIRE(read_crypt_header->timestamp == expected_timestamp);
+    __wt_free(session_impl, read_crypt_header);
 }
 
 /*
- * Forward compatibility: the reader must accept a page whose header_size is larger than the current
- * sizeof(WT_CRYPT_HEADER) -- simulating a future writer that appended additional fields.
+ * Forward compatibility: the reader must accept a page whose header is larger than the current
+ * struct -- simulating a future writer that appended additional fields.
  */
 TEST_CASE_METHOD(
   kp_header_fixture, "Key provider header: reader accepts longer header", "[key_provider_header]")
@@ -256,11 +259,12 @@ TEST_CASE_METHOD(
     build_crypt_page(&crypt.keys, WT_CRYPT_HEADER_VERSION + 1, WT_CRYPT_HEADER_COMPATIBLE_VERSION,
       k_future_header_size, 0, test_string.size());
 
-    WT_CRYPT_HEADER read_crypt_header = {};
+    WT_CRYPT_HEADER *read_crypt_header = nullptr;
     REQUIRE(__ut_disagg_validate_crypt(session_impl, &crypt.keys, &read_crypt_header) == 0);
-    REQUIRE(read_crypt_header.version == WT_CRYPT_HEADER_VERSION + 1);
-    REQUIRE(read_crypt_header.header_size == k_future_header_size);
-    REQUIRE(read_crypt_header.crypt_size == test_string.size());
+    REQUIRE(read_crypt_header->version == WT_CRYPT_HEADER_VERSION + 1);
+    REQUIRE(read_crypt_header->header_size == k_future_header_size);
+    REQUIRE(read_crypt_header->crypt_size == test_string.size());
+    __wt_free(session_impl, read_crypt_header);
 }
 
 /*
@@ -277,7 +281,8 @@ TEST_CASE_METHOD(kp_header_fixture,
     build_crypt_page(&crypt.keys, WT_CRYPT_HEADER_VERSION, WT_CRYPT_HEADER_VERSION,
       sizeof(WT_CRYPT_HEADER), 0, test_string.size());
 
-    WT_CRYPT_HEADER read_crypt_header = {};
+    WT_CRYPT_HEADER *read_crypt_header = nullptr;
     REQUIRE(__ut_disagg_validate_crypt(session_impl, &crypt.keys, &read_crypt_header) == 0);
-    REQUIRE(read_crypt_header.compatible_version == WT_CRYPT_HEADER_VERSION);
+    REQUIRE(read_crypt_header->compatible_version == WT_CRYPT_HEADER_VERSION);
+    __wt_free(session_impl, read_crypt_header);
 }

--- a/test/catch2/ext/test_key_provider_header.cpp
+++ b/test/catch2/ext/test_key_provider_header.cpp
@@ -25,7 +25,7 @@ build_crypt_page(WT_ITEM *key_item, uint8_t version, uint8_t compatible_version,
     local.checksum = 0;
     local.timestamp = timestamp;
 
-    __wt_crypt_header_byteswap(&local, header_size, sizeof(local));
+    __wt_crypt_header_byteswap(&local, header_size);
     memcpy((void *)key_item->data, &local, WT_MIN((size_t)header_size, sizeof(local)));
 
     uint32_t cksum = __wt_checksum(key_item->data, key_item->size);
@@ -77,8 +77,7 @@ struct kp_header_fixture {
 
         /* Prepare the header for validation. */
         memcpy(write_crypt_header, crypt_header, sizeof(WT_CRYPT_HEADER));
-        __wt_crypt_header_byteswap(
-          write_crypt_header, sizeof(WT_CRYPT_HEADER), sizeof(WT_CRYPT_HEADER));
+        __wt_crypt_header_byteswap(write_crypt_header, sizeof(WT_CRYPT_HEADER));
         write_crypt_header->checksum = 0;
     }
 };

--- a/test/catch2/ext/test_key_provider_header.cpp
+++ b/test/catch2/ext/test_key_provider_header.cpp
@@ -24,14 +24,14 @@ build_crypt_page(WT_ITEM *key_item, uint8_t version, uint8_t compatible_version,
     local.timestamp = timestamp;
 
     __wt_crypt_header_byteswap(&local);
-    REQUIRE(WT_MIN((size_t)header_size, sizeof(local)) <= key_item->size);
-    memcpy((void *)key_item->data, &local, WT_MIN((size_t)header_size, sizeof(local)));
+    REQUIRE(WT_MIN((size_t)header_size, sizeof(WT_CRYPT_HEADER)) <= key_item->size);
+    memcpy((void *)key_item->data, &local, WT_MIN((size_t)header_size, sizeof(WT_CRYPT_HEADER)));
 
     uint32_t cksum = __wt_checksum(key_item->data, key_item->size);
 #ifdef WORDS_BIGENDIAN
     cksum = __wt_bswap32(cksum);
 #endif
-    memcpy((uint8_t *)key_item->data + offsetof(WT_CRYPT_HEADER, checksum), &cksum, sizeof(cksum));
+    ((WT_CRYPT_HEADER *)key_item->data)->checksum = cksum;
 }
 
 /* Fixture to initialize the kp header. */
@@ -210,9 +210,13 @@ TEST_CASE_METHOD(
 
     WT_CRYPT_HEADER *read_crypt_header = nullptr;
     REQUIRE(__ut_disagg_validate_crypt(session_impl, &crypt.keys, &read_crypt_header) == 0);
+    REQUIRE(read_crypt_header->signature == WT_CRYPT_HEADER_SIGNATURE);
     REQUIRE(read_crypt_header->version == 1);
+    REQUIRE(read_crypt_header->compatible_version == 1);
     REQUIRE(read_crypt_header->header_size == k_v1_header_size);
     REQUIRE(read_crypt_header->crypt_size == test_string.size());
+    /* No timestamp on a v1 page; the heap-allocated header keeps it as 0. */
+    REQUIRE(read_crypt_header->timestamp == 0);
     __wt_free(session_impl, read_crypt_header);
 }
 
@@ -232,7 +236,9 @@ TEST_CASE_METHOD(
 
     WT_CRYPT_HEADER *read_crypt_header = nullptr;
     REQUIRE(__ut_disagg_validate_crypt(session_impl, &crypt.keys, &read_crypt_header) == 0);
+    REQUIRE(read_crypt_header->signature == WT_CRYPT_HEADER_SIGNATURE);
     REQUIRE(read_crypt_header->version == WT_CRYPT_HEADER_VERSION + 1);
+    REQUIRE(read_crypt_header->compatible_version == WT_CRYPT_HEADER_COMPATIBLE_VERSION);
     REQUIRE(read_crypt_header->header_size == sizeof(WT_CRYPT_HEADER));
     REQUIRE(read_crypt_header->crypt_size == test_string.size());
     REQUIRE(read_crypt_header->timestamp == expected_timestamp);
@@ -261,7 +267,9 @@ TEST_CASE_METHOD(
 
     WT_CRYPT_HEADER *read_crypt_header = nullptr;
     REQUIRE(__ut_disagg_validate_crypt(session_impl, &crypt.keys, &read_crypt_header) == 0);
+    REQUIRE(read_crypt_header->signature == WT_CRYPT_HEADER_SIGNATURE);
     REQUIRE(read_crypt_header->version == WT_CRYPT_HEADER_VERSION + 1);
+    REQUIRE(read_crypt_header->compatible_version == WT_CRYPT_HEADER_COMPATIBLE_VERSION);
     REQUIRE(read_crypt_header->header_size == k_future_header_size);
     REQUIRE(read_crypt_header->crypt_size == test_string.size());
     __wt_free(session_impl, read_crypt_header);
@@ -283,6 +291,10 @@ TEST_CASE_METHOD(kp_header_fixture,
 
     WT_CRYPT_HEADER *read_crypt_header = nullptr;
     REQUIRE(__ut_disagg_validate_crypt(session_impl, &crypt.keys, &read_crypt_header) == 0);
+    REQUIRE(read_crypt_header->signature == WT_CRYPT_HEADER_SIGNATURE);
+    REQUIRE(read_crypt_header->version == WT_CRYPT_HEADER_VERSION);
     REQUIRE(read_crypt_header->compatible_version == WT_CRYPT_HEADER_VERSION);
+    REQUIRE(read_crypt_header->header_size == sizeof(WT_CRYPT_HEADER));
+    REQUIRE(read_crypt_header->crypt_size == test_string.size());
     __wt_free(session_impl, read_crypt_header);
 }

--- a/test/catch2/ext/test_key_provider_header.cpp
+++ b/test/catch2/ext/test_key_provider_header.cpp
@@ -71,11 +71,8 @@ struct kp_header_fixture {
     void
     kp_copy_crypt_key_buffer(WT_CRYPT_HEADER *write_crypt_header)
     {
-        WT_CRYPT_HEADER *crypt_header;
-        __ut_disagg_get_crypt_header(&crypt.keys, &crypt_header);
-
         /* Prepare the header for validation. */
-        memcpy(write_crypt_header, crypt_header, sizeof(WT_CRYPT_HEADER));
+        memcpy(write_crypt_header, crypt.keys.data, sizeof(WT_CRYPT_HEADER));
         __wt_crypt_header_byteswap(write_crypt_header);
         write_crypt_header->checksum = 0;
     }
@@ -102,8 +99,7 @@ TEST_CASE_METHOD(kp_header_fixture, "Key provider set header function", "[key_pr
         __ut_disagg_set_crypt_header(session->get_wt_session_impl(), &crypt);
 
         /* Validate crypt header information. */
-        WT_CRYPT_HEADER *write_crypt_header;
-        __ut_disagg_get_crypt_header(&crypt.keys, &write_crypt_header);
+        WT_CRYPT_HEADER *write_crypt_header = (WT_CRYPT_HEADER *)crypt.keys.data;
         REQUIRE(write_crypt_header->signature == WT_CRYPT_HEADER_SIGNATURE);
         REQUIRE(write_crypt_header->version == WT_CRYPT_HEADER_VERSION);
         REQUIRE(write_crypt_header->compatible_version == WT_CRYPT_HEADER_COMPATIBLE_VERSION);

--- a/test/catch2/ext/test_key_provider_header.cpp
+++ b/test/catch2/ext/test_key_provider_header.cpp
@@ -145,6 +145,7 @@ TEST_CASE_METHOD(
         write_crypt_header.version = WT_CRYPT_HEADER_VERSION + 1;
 
         WT_CRYPT_HEADER *header = (WT_CRYPT_HEADER *)crypt.keys.data;
+        header->compatible_version = WT_CRYPT_HEADER_COMPATIBLE_VERSION;
         header->version = WT_CRYPT_HEADER_VERSION + 1;
         header->checksum = 0;
         header->checksum = __wt_checksum(crypt.keys.data, crypt.keys.size);
@@ -156,8 +157,9 @@ TEST_CASE_METHOD(
 
     SECTION("Test key provider header compatibility issue")
     {
-        build_crypt_page(&crypt.keys, WT_CRYPT_HEADER_VERSION,
-          WT_CRYPT_HEADER_COMPATIBLE_VERSION + 1, sizeof(WT_CRYPT_HEADER), 0, test_string.size());
+        /* Page demands a reader newer than this one (compat_version > our VERSION). */
+        build_crypt_page(&crypt.keys, WT_CRYPT_HEADER_VERSION, WT_CRYPT_HEADER_VERSION + 1,
+          sizeof(WT_CRYPT_HEADER), 0, test_string.size());
         REQUIRE(
           __ut_disagg_validate_crypt(session_impl, &crypt.keys, &read_crypt_header) == ENOTSUP);
     }
@@ -237,4 +239,32 @@ TEST_CASE_METHOD(
     REQUIRE(read_crypt_header->header_size == sizeof(WT_CRYPT_HEADER));
     REQUIRE(read_crypt_header->crypt_size == test_string.size());
     REQUIRE(read_crypt_header->timestamp == expected_timestamp);
+}
+
+/*
+ * Forward compatibility: the reader must accept a page whose header_size is larger than the
+ * current sizeof(WT_CRYPT_HEADER) -- simulating a future writer that appended additional fields.
+ */
+TEST_CASE_METHOD(
+  kp_header_fixture, "Key provider header: reader accepts longer header", "[key_provider_header]")
+{
+    /* A future writer might extend the header beyond the current struct size. */
+    static constexpr uint8_t k_future_header_size = (uint8_t)(sizeof(WT_CRYPT_HEADER) + 8);
+
+    REQUIRE(__wt_buf_initsize(
+              session_impl, &crypt.keys, k_future_header_size + test_string.size()) == 0);
+    memcpy((uint8_t *)crypt.keys.mem + k_future_header_size, test_string.data(),
+      test_string.size());
+    crypt.keys.data = crypt.keys.mem;
+    crypt.keys.size = k_future_header_size + test_string.size();
+
+    build_crypt_page(&crypt.keys, WT_CRYPT_HEADER_VERSION + 1, WT_CRYPT_HEADER_COMPATIBLE_VERSION,
+      k_future_header_size, 0, test_string.size());
+
+    WT_CRYPT_HEADER *read_crypt_header = nullptr;
+    REQUIRE(__ut_disagg_validate_crypt(session_impl, &crypt.keys, &read_crypt_header) == 0);
+    REQUIRE(read_crypt_header != nullptr);
+    REQUIRE(read_crypt_header->version == WT_CRYPT_HEADER_VERSION + 1);
+    REQUIRE(read_crypt_header->header_size == k_future_header_size);
+    REQUIRE(read_crypt_header->crypt_size == test_string.size());
 }

--- a/test/catch2/ext/test_key_provider_header.cpp
+++ b/test/catch2/ext/test_key_provider_header.cpp
@@ -25,15 +25,14 @@ build_crypt_page(WT_ITEM *key_item, uint8_t version, uint8_t compatible_version,
     local.checksum = 0;
     local.timestamp = timestamp;
 
-    __wt_crypt_header_byteswap(&local, sizeof(local));
+    __wt_crypt_header_byteswap(&local, header_size, sizeof(local));
     memcpy((void *)key_item->data, &local, WT_MIN((size_t)header_size, sizeof(local)));
 
     uint32_t cksum = __wt_checksum(key_item->data, key_item->size);
 #ifdef WORDS_BIGENDIAN
     cksum = __wt_bswap32(cksum);
 #endif
-    memcpy(
-      (uint8_t *)key_item->data + offsetof(WT_CRYPT_HEADER, checksum), &cksum, sizeof(cksum));
+    memcpy((uint8_t *)key_item->data + offsetof(WT_CRYPT_HEADER, checksum), &cksum, sizeof(cksum));
 }
 
 /* Fixture to initialize the kp header. */
@@ -64,8 +63,7 @@ struct kp_header_fixture {
     kp_crypt_key_buffer(WT_SESSION_IMPL *session, const std::string &str)
     {
         /* Allocate a buffer and make sure we leave enough space for the header at the start. */
-        REQUIRE(
-          __wt_buf_initsize(session, &crypt.keys, sizeof(WT_CRYPT_HEADER) + str.size()) == 0);
+        REQUIRE(__wt_buf_initsize(session, &crypt.keys, sizeof(WT_CRYPT_HEADER) + str.size()) == 0);
         memcpy(((uint8_t *)(crypt.keys.data) + sizeof(WT_CRYPT_HEADER)), str.data(), str.size());
         crypt.keys.size = str.size();
         crypt.keys.data = (uint8_t *)(crypt.keys.data) + sizeof(WT_CRYPT_HEADER);
@@ -79,10 +77,10 @@ struct kp_header_fixture {
 
         /* Prepare the header for validation. */
         memcpy(write_crypt_header, crypt_header, sizeof(WT_CRYPT_HEADER));
-        __wt_crypt_header_byteswap(write_crypt_header, sizeof(WT_CRYPT_HEADER));
+        __wt_crypt_header_byteswap(
+          write_crypt_header, sizeof(WT_CRYPT_HEADER), sizeof(WT_CRYPT_HEADER));
         write_crypt_header->checksum = 0;
     }
-
 };
 
 TEST_CASE_METHOD(
@@ -161,8 +159,7 @@ TEST_CASE_METHOD(
     SECTION("Test key provider header compatibility issue")
     {
         build_crypt_page(&crypt.keys, WT_CRYPT_HEADER_VERSION,
-          WT_CRYPT_HEADER_COMPATIBLE_VERSION + 1,
-          sizeof(WT_CRYPT_HEADER), 0, test_string.size());
+          WT_CRYPT_HEADER_COMPATIBLE_VERSION + 1, sizeof(WT_CRYPT_HEADER), 0, test_string.size());
         REQUIRE(
           __ut_disagg_validate_crypt(session_impl, &crypt.keys, &read_crypt_header) == ENOTSUP);
     }
@@ -175,16 +172,14 @@ TEST_CASE_METHOD(
 
     SECTION("Test key provider header size smaller than expected")
     {
-        build_crypt_page(&crypt.keys, WT_CRYPT_HEADER_VERSION,
-          WT_CRYPT_HEADER_COMPATIBLE_VERSION,
+        build_crypt_page(&crypt.keys, WT_CRYPT_HEADER_VERSION, WT_CRYPT_HEADER_COMPATIBLE_VERSION,
           10, 0, test_string.size());
         REQUIRE(__ut_disagg_validate_crypt(session_impl, &crypt.keys, &read_crypt_header) == EIO);
     }
 
     SECTION("Test key provider header mismatch size")
     {
-        build_crypt_page(&crypt.keys, WT_CRYPT_HEADER_VERSION,
-          WT_CRYPT_HEADER_COMPATIBLE_VERSION,
+        build_crypt_page(&crypt.keys, WT_CRYPT_HEADER_VERSION, WT_CRYPT_HEADER_COMPATIBLE_VERSION,
           50, 0, test_string.size());
         REQUIRE(__ut_disagg_validate_crypt(session_impl, &crypt.keys, &read_crypt_header) == EIO);
     }
@@ -197,21 +192,18 @@ TEST_CASE_METHOD(
     }
 }
 
-
 /*
- * Backward compatibility: the reader must accept a v1 page (16-byte header, no timestamp field)
- * as written by an older version of WT on disk.
+ * Backward compatibility: the reader must accept a v1 page (16-byte header, no timestamp field) as
+ * written by an older version of WT on disk.
  */
-TEST_CASE_METHOD(kp_header_fixture, "Key provider header: reader accepts v1 page",
-  "[key_provider_header]")
+TEST_CASE_METHOD(
+  kp_header_fixture, "Key provider header: reader accepts v1 page", "[key_provider_header]")
 {
     /* The original on-disk header size, before the timestamp field was appended. */
     static constexpr uint8_t v1_header_size = 16;
 
-    REQUIRE(__wt_buf_initsize(
-              session_impl, &crypt.keys, v1_header_size + test_string.size()) == 0);
-    memcpy(
-      (uint8_t *)crypt.keys.mem + v1_header_size, test_string.data(), test_string.size());
+    REQUIRE(__wt_buf_initsize(session_impl, &crypt.keys, v1_header_size + test_string.size()) == 0);
+    memcpy((uint8_t *)crypt.keys.mem + v1_header_size, test_string.data(), test_string.size());
     crypt.keys.data = crypt.keys.mem;
     crypt.keys.size = v1_header_size + test_string.size();
 
@@ -230,15 +222,14 @@ TEST_CASE_METHOD(kp_header_fixture, "Key provider header: reader accepts v1 page
  * emits, as long as compatible_version stays within what this reader knows. Also verifies the
  * timestamp field reads back unchanged.
  */
-TEST_CASE_METHOD(kp_header_fixture, "Key provider header: reader accepts future version",
-  "[key_provider_header]")
+TEST_CASE_METHOD(
+  kp_header_fixture, "Key provider header: reader accepts future version", "[key_provider_header]")
 {
     crypt.keys.data = crypt.keys.mem;
     crypt.keys.size = sizeof(WT_CRYPT_HEADER) + test_string.size();
 
     const uint64_t expected_timestamp = 10;
-    build_crypt_page(&crypt.keys, WT_CRYPT_HEADER_VERSION + 1,
-      WT_CRYPT_HEADER_COMPATIBLE_VERSION,
+    build_crypt_page(&crypt.keys, WT_CRYPT_HEADER_VERSION + 1, WT_CRYPT_HEADER_COMPATIBLE_VERSION,
       sizeof(WT_CRYPT_HEADER), expected_timestamp, test_string.size());
 
     WT_CRYPT_HEADER *read_crypt_header = nullptr;

--- a/test/catch2/ext/test_key_provider_header.cpp
+++ b/test/catch2/ext/test_key_provider_header.cpp
@@ -269,8 +269,7 @@ TEST_CASE_METHOD(
 
 /*
  * Boundary case for the compatibility check: a page whose compatible_version equals this reader's
- * version. The reader satisfies the page's demand exactly and must accept. This is the case the
- * old check (against COMPATIBLE_VERSION instead of VERSION) wrongly rejected.
+ * version. The reader satisfies the page's demand exactly and must accept.
  */
 TEST_CASE_METHOD(kp_header_fixture,
   "Key provider header: reader accepts compat_version equal to reader version",

--- a/test/catch2/ext/test_key_provider_header.cpp
+++ b/test/catch2/ext/test_key_provider_header.cpp
@@ -10,6 +10,36 @@
 #include <catch2/catch.hpp>
 #include "wrappers/mock_session.h"
 
+/*
+ * Hand-craft a header at the front of key_item. The header is built on the stack and then the
+ * first header_size bytes are copied onto the wire, so buffers smaller than sizeof(WT_CRYPT_HEADER)
+ * are safe.
+ */
+static void
+build_crypt_page(WT_ITEM *key_item, uint8_t version, uint8_t compatible_version,
+  uint8_t header_size, uint64_t timestamp, size_t payload_size)
+{
+    WT_CRYPT_HEADER local;
+    memset(&local, 0, sizeof(local));
+    local.signature = WT_CRYPT_HEADER_SIGNATURE;
+    local.version = version;
+    local.compatible_version = compatible_version;
+    local.header_size = header_size;
+    local.crypt_size = (uint32_t)payload_size;
+    local.checksum = 0;
+    local.timestamp = timestamp;
+
+    __wt_crypt_header_byteswap(&local, sizeof(local));
+    memcpy((void *)key_item->data, &local, WT_MIN((size_t)header_size, sizeof(local)));
+
+    uint32_t cksum = __wt_checksum(key_item->data, key_item->size);
+#ifdef WORDS_BIGENDIAN
+    cksum = __wt_bswap32(cksum);
+#endif
+    memcpy(
+      (uint8_t *)key_item->data + offsetof(WT_CRYPT_HEADER, checksum), &cksum, sizeof(cksum));
+}
+
 /* Fixture to initialize the kp header. */
 struct kp_header_fixture {
     WT_CRYPT_KEYS crypt;
@@ -38,7 +68,8 @@ struct kp_header_fixture {
     kp_crypt_key_buffer(WT_SESSION_IMPL *session, const std::string &str)
     {
         /* Allocate a buffer and make sure we leave enough space for the header at the start. */
-        REQUIRE(__wt_buf_initsize(session, &crypt.keys, sizeof(WT_CRYPT_HEADER) + str.size()) == 0);
+        REQUIRE(
+          __wt_buf_initsize(session, &crypt.keys, sizeof(WT_CRYPT_HEADER) + str.size()) == 0);
         memcpy(((uint8_t *)(crypt.keys.data) + sizeof(WT_CRYPT_HEADER)), str.data(), str.size());
         crypt.keys.size = str.size();
         crypt.keys.data = (uint8_t *)(crypt.keys.data) + sizeof(WT_CRYPT_HEADER);
@@ -52,15 +83,16 @@ struct kp_header_fixture {
 
         /* Prepare the header for validation. */
         memcpy(write_crypt_header, crypt_header, sizeof(WT_CRYPT_HEADER));
-        __wt_crypt_header_byteswap(write_crypt_header);
+        __wt_crypt_header_byteswap(write_crypt_header, sizeof(WT_CRYPT_HEADER));
         write_crypt_header->checksum = 0;
     }
+
 };
 
 TEST_CASE_METHOD(
   kp_header_fixture, "Validate crypt header offsets and size", "[key_provider_header]")
 {
-    REQUIRE(sizeof(WT_CRYPT_HEADER) == 16);
+    REQUIRE(sizeof(WT_CRYPT_HEADER) == 24);
     REQUIRE(offsetof(WT_CRYPT_HEADER, signature) == 0);
     REQUIRE(offsetof(WT_CRYPT_HEADER, version) == 4);
     REQUIRE(offsetof(WT_CRYPT_HEADER, compatible_version) == 5);
@@ -68,6 +100,7 @@ TEST_CASE_METHOD(
     REQUIRE(offsetof(WT_CRYPT_HEADER, unused) == 7);
     REQUIRE(offsetof(WT_CRYPT_HEADER, crypt_size) == 8);
     REQUIRE(offsetof(WT_CRYPT_HEADER, checksum) == 12);
+    REQUIRE(WT_CRYPT_HEADER_MIN_SIZE == 16);
 }
 
 TEST_CASE_METHOD(kp_header_fixture, "Key provider set header function", "[key_provider_header]")
@@ -84,6 +117,7 @@ TEST_CASE_METHOD(kp_header_fixture, "Key provider set header function", "[key_pr
         REQUIRE(write_crypt_header->compatible_version == WT_CRYPT_HEADER_COMPATIBLE_VERSION);
         REQUIRE(write_crypt_header->header_size == sizeof(WT_CRYPT_HEADER));
         REQUIRE(write_crypt_header->crypt_size == test_string.size());
+        REQUIRE(write_crypt_header->timestamp == 0);
         REQUIRE(crypt.keys.size == test_string.size() + sizeof(WT_CRYPT_HEADER));
 
         uint32_t expected_checksum = write_crypt_header->checksum;
@@ -116,11 +150,10 @@ TEST_CASE_METHOD(
         /* Fetch the baseline header before performing read. */
         WT_CRYPT_HEADER write_crypt_header;
         kp_copy_crypt_key_buffer(&write_crypt_header);
-        write_crypt_header.version = 2;
+        write_crypt_header.version = WT_CRYPT_HEADER_VERSION + 1;
 
         WT_CRYPT_HEADER *header = (WT_CRYPT_HEADER *)crypt.keys.data;
-        header->compatible_version = 1;
-        header->version = 2;
+        header->version = WT_CRYPT_HEADER_VERSION + 1;
         header->checksum = 0;
         header->checksum = __wt_checksum(crypt.keys.data, crypt.keys.size);
         REQUIRE(__ut_disagg_validate_crypt(session_impl, &crypt.keys, &read_crypt_header) == 0);
@@ -131,11 +164,9 @@ TEST_CASE_METHOD(
 
     SECTION("Test key provider header compatibility issue")
     {
-        WT_CRYPT_HEADER *header = (WT_CRYPT_HEADER *)crypt.keys.data;
-        header->compatible_version = 2;
-        header->version = 1;
-        header->checksum = 0;
-        header->checksum = __wt_checksum(crypt.keys.data, crypt.keys.size);
+        build_crypt_page(&crypt.keys, WT_CRYPT_HEADER_VERSION,
+          WT_CRYPT_HEADER_COMPATIBLE_VERSION + 1,
+          sizeof(WT_CRYPT_HEADER), 0, test_string.size());
         REQUIRE(
           __ut_disagg_validate_crypt(session_impl, &crypt.keys, &read_crypt_header) == ENOTSUP);
     }
@@ -148,19 +179,17 @@ TEST_CASE_METHOD(
 
     SECTION("Test key provider header size smaller than expected")
     {
-        WT_CRYPT_HEADER *header = (WT_CRYPT_HEADER *)crypt.keys.data;
-        header->header_size = 10;
-        header->checksum = 0;
-        header->checksum = __wt_checksum(crypt.keys.data, crypt.keys.size);
+        build_crypt_page(&crypt.keys, WT_CRYPT_HEADER_VERSION,
+          WT_CRYPT_HEADER_COMPATIBLE_VERSION,
+          10, 0, test_string.size());
         REQUIRE(__ut_disagg_validate_crypt(session_impl, &crypt.keys, &read_crypt_header) == EIO);
     }
 
     SECTION("Test key provider header mismatch size")
     {
-        WT_CRYPT_HEADER *header = (WT_CRYPT_HEADER *)crypt.keys.data;
-        header->header_size = 50;
-        header->checksum = 0;
-        header->checksum = __wt_checksum(crypt.keys.data, crypt.keys.size);
+        build_crypt_page(&crypt.keys, WT_CRYPT_HEADER_VERSION,
+          WT_CRYPT_HEADER_COMPATIBLE_VERSION,
+          50, 0, test_string.size());
         REQUIRE(__ut_disagg_validate_crypt(session_impl, &crypt.keys, &read_crypt_header) == EIO);
     }
 
@@ -170,4 +199,57 @@ TEST_CASE_METHOD(
         header->checksum = 123;
         REQUIRE(__ut_disagg_validate_crypt(session_impl, &crypt.keys, &read_crypt_header) == EIO);
     }
+}
+
+
+/*
+ * Backward compatibility: the reader must accept a v1 page (16-byte header, no timestamp field)
+ * as written by an older version of WT on disk.
+ */
+TEST_CASE_METHOD(kp_header_fixture, "Key provider header: reader accepts v1 page",
+  "[key_provider_header]")
+{
+    /* The original on-disk header size, before the timestamp field was appended. */
+    static constexpr uint8_t v1_header_size = 16;
+
+    REQUIRE(__wt_buf_initsize(
+              session_impl, &crypt.keys, v1_header_size + test_string.size()) == 0);
+    memcpy(
+      (uint8_t *)crypt.keys.mem + v1_header_size, test_string.data(), test_string.size());
+    crypt.keys.data = crypt.keys.mem;
+    crypt.keys.size = v1_header_size + test_string.size();
+
+    build_crypt_page(&crypt.keys, 1, 1, v1_header_size, 0, test_string.size());
+
+    WT_CRYPT_HEADER *read_crypt_header = nullptr;
+    REQUIRE(__ut_disagg_validate_crypt(session_impl, &crypt.keys, &read_crypt_header) == 0);
+    REQUIRE(read_crypt_header != nullptr);
+    REQUIRE(read_crypt_header->version == 1);
+    REQUIRE(read_crypt_header->header_size == v1_header_size);
+    REQUIRE(read_crypt_header->crypt_size == test_string.size());
+}
+
+/*
+ * Forward compatibility: the reader must accept a page whose version is higher than this writer
+ * emits, as long as compatible_version stays within what this reader knows. Also verifies the
+ * timestamp field reads back unchanged.
+ */
+TEST_CASE_METHOD(kp_header_fixture, "Key provider header: reader accepts future version",
+  "[key_provider_header]")
+{
+    crypt.keys.data = crypt.keys.mem;
+    crypt.keys.size = sizeof(WT_CRYPT_HEADER) + test_string.size();
+
+    const uint64_t expected_timestamp = 10;
+    build_crypt_page(&crypt.keys, WT_CRYPT_HEADER_VERSION + 1,
+      WT_CRYPT_HEADER_COMPATIBLE_VERSION,
+      sizeof(WT_CRYPT_HEADER), expected_timestamp, test_string.size());
+
+    WT_CRYPT_HEADER *read_crypt_header = nullptr;
+    REQUIRE(__ut_disagg_validate_crypt(session_impl, &crypt.keys, &read_crypt_header) == 0);
+    REQUIRE(read_crypt_header != nullptr);
+    REQUIRE(read_crypt_header->version == WT_CRYPT_HEADER_VERSION + 1);
+    REQUIRE(read_crypt_header->header_size == sizeof(WT_CRYPT_HEADER));
+    REQUIRE(read_crypt_header->crypt_size == test_string.size());
+    REQUIRE(read_crypt_header->timestamp == expected_timestamp);
 }

--- a/test/catch2/ext/test_key_provider_header.cpp
+++ b/test/catch2/ext/test_key_provider_header.cpp
@@ -24,6 +24,7 @@ build_crypt_page(WT_ITEM *key_item, uint8_t version, uint8_t compatible_version,
     local.timestamp = timestamp;
 
     __wt_crypt_header_byteswap(&local);
+    REQUIRE(WT_MIN((size_t)header_size, sizeof(local)) <= key_item->size);
     memcpy((void *)key_item->data, &local, WT_MIN((size_t)header_size, sizeof(local)));
 
     uint32_t cksum = __wt_checksum(key_item->data, key_item->size);
@@ -176,8 +177,9 @@ TEST_CASE_METHOD(
 
     SECTION("Test key provider header mismatch size")
     {
+        /* header_size larger than the underlying buffer. */
         build_crypt_page(&crypt.keys, WT_CRYPT_HEADER_VERSION, WT_CRYPT_HEADER_COMPATIBLE_VERSION,
-          50, 0, test_string.size());
+          (uint8_t)(sizeof(WT_CRYPT_HEADER) + 10), 0, test_string.size());
         REQUIRE(__ut_disagg_validate_crypt(session_impl, &crypt.keys, &read_crypt_header) == EIO);
     }
 
@@ -197,27 +199,26 @@ TEST_CASE_METHOD(
   kp_header_fixture, "Key provider header: reader accepts v1 page", "[key_provider_header]")
 {
     /* The original on-disk header size, before the timestamp field was appended. */
-    static constexpr uint8_t v1_header_size = 16;
+    static constexpr uint8_t k_v1_header_size = 16;
 
-    REQUIRE(__wt_buf_initsize(session_impl, &crypt.keys, v1_header_size + test_string.size()) == 0);
-    memcpy((uint8_t *)crypt.keys.mem + v1_header_size, test_string.data(), test_string.size());
+    REQUIRE(__wt_buf_initsize(session_impl, &crypt.keys, k_v1_header_size + test_string.size()) == 0);
+    memcpy((uint8_t *)crypt.keys.mem + k_v1_header_size, test_string.data(), test_string.size());
     crypt.keys.data = crypt.keys.mem;
-    crypt.keys.size = v1_header_size + test_string.size();
+    crypt.keys.size = k_v1_header_size + test_string.size();
 
-    build_crypt_page(&crypt.keys, 1, 1, v1_header_size, 0, test_string.size());
+    build_crypt_page(&crypt.keys, 1, 1, k_v1_header_size, 0, test_string.size());
 
     WT_CRYPT_HEADER *read_crypt_header = nullptr;
     REQUIRE(__ut_disagg_validate_crypt(session_impl, &crypt.keys, &read_crypt_header) == 0);
     REQUIRE(read_crypt_header != nullptr);
     REQUIRE(read_crypt_header->version == 1);
-    REQUIRE(read_crypt_header->header_size == v1_header_size);
+    REQUIRE(read_crypt_header->header_size == k_v1_header_size);
     REQUIRE(read_crypt_header->crypt_size == test_string.size());
 }
 
 /*
  * Forward compatibility: the reader must accept a page whose version is higher than this writer
- * emits, as long as compatible_version stays within what this reader knows. Also verifies the
- * timestamp field reads back unchanged.
+ * emits, as long as compatible_version stays within what this reader knows.
  */
 TEST_CASE_METHOD(
   kp_header_fixture, "Key provider header: reader accepts future version", "[key_provider_header]")

--- a/test/catch2/ext/test_key_provider_header.cpp
+++ b/test/catch2/ext/test_key_provider_header.cpp
@@ -25,7 +25,7 @@ build_crypt_page(WT_ITEM *key_item, uint8_t version, uint8_t compatible_version,
     local.checksum = 0;
     local.timestamp = timestamp;
 
-    __wt_crypt_header_byteswap(&local, header_size);
+    __wt_crypt_header_byteswap(&local);
     memcpy((void *)key_item->data, &local, WT_MIN((size_t)header_size, sizeof(local)));
 
     uint32_t cksum = __wt_checksum(key_item->data, key_item->size);
@@ -77,7 +77,7 @@ struct kp_header_fixture {
 
         /* Prepare the header for validation. */
         memcpy(write_crypt_header, crypt_header, sizeof(WT_CRYPT_HEADER));
-        __wt_crypt_header_byteswap(write_crypt_header, sizeof(WT_CRYPT_HEADER));
+        __wt_crypt_header_byteswap(write_crypt_header);
         write_crypt_header->checksum = 0;
     }
 };

--- a/test/catch2/ext/test_key_provider_header.cpp
+++ b/test/catch2/ext/test_key_provider_header.cpp
@@ -266,3 +266,23 @@ TEST_CASE_METHOD(
     REQUIRE(read_crypt_header.header_size == k_future_header_size);
     REQUIRE(read_crypt_header.crypt_size == test_string.size());
 }
+
+/*
+ * Boundary case for the compatibility check: a page whose compatible_version equals this reader's
+ * version. The reader satisfies the page's demand exactly and must accept. This is the case the
+ * old check (against COMPATIBLE_VERSION instead of VERSION) wrongly rejected.
+ */
+TEST_CASE_METHOD(kp_header_fixture,
+  "Key provider header: reader accepts compat_version equal to reader version",
+  "[key_provider_header]")
+{
+    crypt.keys.data = crypt.keys.mem;
+    crypt.keys.size = sizeof(WT_CRYPT_HEADER) + test_string.size();
+
+    build_crypt_page(&crypt.keys, WT_CRYPT_HEADER_VERSION, WT_CRYPT_HEADER_VERSION,
+      sizeof(WT_CRYPT_HEADER), 0, test_string.size());
+
+    WT_CRYPT_HEADER read_crypt_header = {};
+    REQUIRE(__ut_disagg_validate_crypt(session_impl, &crypt.keys, &read_crypt_header) == 0);
+    REQUIRE(read_crypt_header.compatible_version == WT_CRYPT_HEADER_VERSION);
+}

--- a/test/catch2/ext/test_key_provider_header.cpp
+++ b/test/catch2/ext/test_key_provider_header.cpp
@@ -15,14 +15,12 @@ static void
 build_crypt_page(WT_ITEM *key_item, uint8_t version, uint8_t compatible_version,
   uint8_t header_size, uint64_t timestamp, size_t payload_size)
 {
-    WT_CRYPT_HEADER local;
-    memset(&local, 0, sizeof(local));
+    WT_CRYPT_HEADER local = {};
     local.signature = WT_CRYPT_HEADER_SIGNATURE;
     local.version = version;
     local.compatible_version = compatible_version;
     local.header_size = header_size;
     local.crypt_size = (uint32_t)payload_size;
-    local.checksum = 0;
     local.timestamp = timestamp;
 
     __wt_crypt_header_byteswap(&local);

--- a/test/catch2/ext/test_key_provider_header.cpp
+++ b/test/catch2/ext/test_key_provider_header.cpp
@@ -125,7 +125,7 @@ TEST_CASE_METHOD(
     /* Set the header inside the crypt struct. */
     __ut_disagg_set_crypt_header(session_impl, &crypt);
 
-    WT_CRYPT_HEADER *read_crypt_header;
+    WT_CRYPT_HEADER read_crypt_header = {};
     SECTION("Test key provider basic unpack")
     {
         /* Fetch the baseline header before performing read. */
@@ -134,7 +134,7 @@ TEST_CASE_METHOD(
         REQUIRE(__ut_disagg_validate_crypt(session_impl, &crypt.keys, &read_crypt_header) == 0);
 
         /* Validate that before and after validation should not change the header. */
-        REQUIRE(memcmp(&write_crypt_header, read_crypt_header, sizeof(WT_CRYPT_HEADER)) == 0);
+        REQUIRE(memcmp(&write_crypt_header, &read_crypt_header, sizeof(WT_CRYPT_HEADER)) == 0);
     }
 
     SECTION("Test key provider header version")
@@ -152,7 +152,7 @@ TEST_CASE_METHOD(
         REQUIRE(__ut_disagg_validate_crypt(session_impl, &crypt.keys, &read_crypt_header) == 0);
 
         /* Validate that before and after validation should not change the header. */
-        REQUIRE(memcmp(&write_crypt_header, read_crypt_header, sizeof(WT_CRYPT_HEADER)) == 0);
+        REQUIRE(memcmp(&write_crypt_header, &read_crypt_header, sizeof(WT_CRYPT_HEADER)) == 0);
     }
 
     SECTION("Test key provider header compatibility issue")
@@ -203,19 +203,19 @@ TEST_CASE_METHOD(
     /* The original on-disk header size, before the timestamp field was appended. */
     static constexpr uint8_t k_v1_header_size = 16;
 
-    REQUIRE(__wt_buf_initsize(session_impl, &crypt.keys, k_v1_header_size + test_string.size()) == 0);
+    REQUIRE(
+      __wt_buf_initsize(session_impl, &crypt.keys, k_v1_header_size + test_string.size()) == 0);
     memcpy((uint8_t *)crypt.keys.mem + k_v1_header_size, test_string.data(), test_string.size());
     crypt.keys.data = crypt.keys.mem;
     crypt.keys.size = k_v1_header_size + test_string.size();
 
     build_crypt_page(&crypt.keys, 1, 1, k_v1_header_size, 0, test_string.size());
 
-    WT_CRYPT_HEADER *read_crypt_header = nullptr;
+    WT_CRYPT_HEADER read_crypt_header = {};
     REQUIRE(__ut_disagg_validate_crypt(session_impl, &crypt.keys, &read_crypt_header) == 0);
-    REQUIRE(read_crypt_header != nullptr);
-    REQUIRE(read_crypt_header->version == 1);
-    REQUIRE(read_crypt_header->header_size == k_v1_header_size);
-    REQUIRE(read_crypt_header->crypt_size == test_string.size());
+    REQUIRE(read_crypt_header.version == 1);
+    REQUIRE(read_crypt_header.header_size == k_v1_header_size);
+    REQUIRE(read_crypt_header.crypt_size == test_string.size());
 }
 
 /*
@@ -232,18 +232,17 @@ TEST_CASE_METHOD(
     build_crypt_page(&crypt.keys, WT_CRYPT_HEADER_VERSION + 1, WT_CRYPT_HEADER_COMPATIBLE_VERSION,
       sizeof(WT_CRYPT_HEADER), expected_timestamp, test_string.size());
 
-    WT_CRYPT_HEADER *read_crypt_header = nullptr;
+    WT_CRYPT_HEADER read_crypt_header = {};
     REQUIRE(__ut_disagg_validate_crypt(session_impl, &crypt.keys, &read_crypt_header) == 0);
-    REQUIRE(read_crypt_header != nullptr);
-    REQUIRE(read_crypt_header->version == WT_CRYPT_HEADER_VERSION + 1);
-    REQUIRE(read_crypt_header->header_size == sizeof(WT_CRYPT_HEADER));
-    REQUIRE(read_crypt_header->crypt_size == test_string.size());
-    REQUIRE(read_crypt_header->timestamp == expected_timestamp);
+    REQUIRE(read_crypt_header.version == WT_CRYPT_HEADER_VERSION + 1);
+    REQUIRE(read_crypt_header.header_size == sizeof(WT_CRYPT_HEADER));
+    REQUIRE(read_crypt_header.crypt_size == test_string.size());
+    REQUIRE(read_crypt_header.timestamp == expected_timestamp);
 }
 
 /*
- * Forward compatibility: the reader must accept a page whose header_size is larger than the
- * current sizeof(WT_CRYPT_HEADER) -- simulating a future writer that appended additional fields.
+ * Forward compatibility: the reader must accept a page whose header_size is larger than the current
+ * sizeof(WT_CRYPT_HEADER) -- simulating a future writer that appended additional fields.
  */
 TEST_CASE_METHOD(
   kp_header_fixture, "Key provider header: reader accepts longer header", "[key_provider_header]")
@@ -251,20 +250,19 @@ TEST_CASE_METHOD(
     /* A future writer might extend the header beyond the current struct size. */
     static constexpr uint8_t k_future_header_size = (uint8_t)(sizeof(WT_CRYPT_HEADER) + 8);
 
-    REQUIRE(__wt_buf_initsize(
-              session_impl, &crypt.keys, k_future_header_size + test_string.size()) == 0);
-    memcpy((uint8_t *)crypt.keys.mem + k_future_header_size, test_string.data(),
-      test_string.size());
+    REQUIRE(
+      __wt_buf_initsize(session_impl, &crypt.keys, k_future_header_size + test_string.size()) == 0);
+    memcpy(
+      (uint8_t *)crypt.keys.mem + k_future_header_size, test_string.data(), test_string.size());
     crypt.keys.data = crypt.keys.mem;
     crypt.keys.size = k_future_header_size + test_string.size();
 
     build_crypt_page(&crypt.keys, WT_CRYPT_HEADER_VERSION + 1, WT_CRYPT_HEADER_COMPATIBLE_VERSION,
       k_future_header_size, 0, test_string.size());
 
-    WT_CRYPT_HEADER *read_crypt_header = nullptr;
+    WT_CRYPT_HEADER read_crypt_header = {};
     REQUIRE(__ut_disagg_validate_crypt(session_impl, &crypt.keys, &read_crypt_header) == 0);
-    REQUIRE(read_crypt_header != nullptr);
-    REQUIRE(read_crypt_header->version == WT_CRYPT_HEADER_VERSION + 1);
-    REQUIRE(read_crypt_header->header_size == k_future_header_size);
-    REQUIRE(read_crypt_header->crypt_size == test_string.size());
+    REQUIRE(read_crypt_header.version == WT_CRYPT_HEADER_VERSION + 1);
+    REQUIRE(read_crypt_header.header_size == k_future_header_size);
+    REQUIRE(read_crypt_header.crypt_size == test_string.size());
 }

--- a/test/catch2/ext/test_key_provider_header.cpp
+++ b/test/catch2/ext/test_key_provider_header.cpp
@@ -10,11 +10,7 @@
 #include <catch2/catch.hpp>
 #include "wrappers/mock_session.h"
 
-/*
- * Hand-craft a header at the front of key_item. The header is built on the stack and then the
- * first header_size bytes are copied onto the wire, so buffers smaller than sizeof(WT_CRYPT_HEADER)
- * are safe.
- */
+/* Hand-craft a header at the front of key_item. */
 static void
 build_crypt_page(WT_ITEM *key_item, uint8_t version, uint8_t compatible_version,
   uint8_t header_size, uint64_t timestamp, size_t payload_size)


### PR DESCRIPTION
## Summary
Define the v2 on-disk KEK page format and update reader/writer to handle it. Populating `WT_CRYPT_KEYS::timestamp` from the header is deferred to the ticket that introduces the field and a consumer (WT-17536 / WT-17542).

- Append `uint64_t timestamp` to `WT_CRYPT_HEADER` and bump `WT_CRYPT_HEADER_VERSION` to `0x2u`. `compatible_version` stays at `0x1u` so older readers can still parse v2 pages.
- The writer now emits 24-byte headers with `timestamp = 0`; a follow-up ticket (WT-17536 / WT-17542) will populate a meaningful timestamp.

## Test plan
- [x] Catch2 `[key_provider_header]` covers struct layout, writer emission (`timestamp == 0`, `header_size == sizeof(WT_CRYPT_HEADER)`), forward-compat (`version = WT_CRYPT_HEADER_VERSION + 1` with timestamp round-trip), backward-compat (hand-crafted 16-byte header parses), and existing negative paths (bad checksum, header_size mismatches, etc.).
- [x] Catch2 `[key_provider]` (188 assertions) and Python `test_key_provider_disagg01/02` pass.