### PR TITLE
WT-17638 Fix NULL-home SIGSEGV in __wt_ref_addr_copy during parent split

### DIFF
--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -1843,12 +1843,18 @@ __wt_ref_addr_copy(WT_SESSION_IMPL *session, WT_REF *ref, WT_ADDR_COPY *copy)
      * home, we also observe the corresponding off-page addr. The dangerous combination is reading a
      * new home with an old addr, as the on-page cell would be misinterpreted as an off-page
      * address.
+     *
+     * home can be transiently NULL on a leaf during a deepening parent split: a new ref is
+     * zero-initialized with home=NULL and addr is swapped off-page before home is written. Treat
+     * that window as "no address" so callers do not pass NULL to __wt_off_page.
      */
-    page = (WT_PAGE *)__wt_atomic_load_ptr_relaxed(&ref->home);
+    page = (WT_PAGE *)__wt_atomic_load_ptr_acquire(&ref->home);
 
     addr = (WT_ADDR *)__wt_atomic_load_ptr_acquire(&ref->addr);
     /* If NULL, there is no information. */
     if (addr == NULL)
+        return (false);
+    if (page == NULL)
         return (false);
 
     /* If off-page, the pointer references a WT_ADDR structure. */

--- a/src/include/ref_inline.h
+++ b/src/include/ref_inline.h
@@ -15,7 +15,7 @@
 static WT_INLINE bool
 __wt_ref_is_root(WT_REF *ref)
 {
-    return (__wt_tsan_suppress_load_wt_page_ptr_v(&ref->home) == NULL);
+    return ((WT_PAGE *)__wt_atomic_load_ptr_acquire(&ref->home) == NULL);
 }
 
 /*

--- a/test/catch2/CMakeLists.txt
+++ b/test/catch2/CMakeLists.txt
@@ -23,6 +23,7 @@ else()
         misc_tests/test_prepare_mod_sort.cpp
         misc_tests/test_rec_upd_select.cpp
         misc_tests/test_reconciliation_tracking.cpp
+        misc_tests/test_ref_addr_copy_null_home.cpp
         misc_tests/test_layered_incomplete_table.cpp
         misc_tests/test_layered_ingest_uri.cpp
         misc_tests/test_semaphore.cpp

--- a/test/catch2/misc_tests/test_ref_addr_copy_null_home.cpp
+++ b/test/catch2/misc_tests/test_ref_addr_copy_null_home.cpp
@@ -1,0 +1,130 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+/*
+ * WT-17638: verify that __wt_ref_addr_copy returns false safely when ref->home is
+ * transiently NULL during a deepening parent split, and that __wt_ref_is_root uses a
+ * proper acquire load rather than a TSAN-suppressed relaxed one.
+ *
+ * Race reproduced:
+ *   During a deepening parent split a new WT_REF is zero-initialized (home=NULL) and
+ *   its addr field is CAS'd off-page before home is written to point at the new parent.
+ *   An eviction thread reading ref->home with a relaxed atomic load observed NULL and
+ *   passed it to __wt_off_page, which dereferences page->dsk unconditionally,
+ *   causing a SIGSEGV.
+ *
+ *   __wt_ref_is_root also relaxed-loads ref->home: on a leaf with a transiently-NULL
+ *   home it returned true, causing __reconcile to call __rec_root_write on a leaf page
+ *   and fire an ASSERT_ALWAYS.
+ *
+ * Fix:
+ *   1. __wt_ref_addr_copy: relax -> acquire load of home + NULL guard before __wt_off_page.
+ *   2. __wt_ref_is_root: replace TSAN-suppressed relaxed load with acquire load.
+ *
+ * How this test demonstrates the problem:
+ *   The first test case calls __wt_ref_addr_copy with home=NULL and a non-NULL addr
+ *   (simulating the exact split window).  On unfixed code this segfaults inside
+ *   __wt_off_page.  On fixed code it returns false safely.
+ *
+ *   The second test case verifies that __wt_ref_is_root correctly returns true for
+ *   the root ref (permanent NULL home) and false for a non-root ref.
+ */
+
+#include <catch2/catch.hpp>
+
+#include "wiredtiger.h"
+#include "wt_internal.h"
+#include "../utils.h"
+#include "../wrappers/connection_wrapper.h"
+
+/*
+ * [btree][split][wt-17638]: __wt_ref_addr_copy returns false for NULL home
+ *
+ * Constructs the exact WT_REF state visible during the race window: home is NULL
+ * (not yet written by the split) while addr already points to an off-page WT_ADDR
+ * (already CAS'd in __split_ref_move).
+ *
+ * Before the fix: __wt_ref_addr_copy calls __wt_off_page(NULL, addr), dereferencing
+ * a NULL pointer -> SIGSEGV.
+ * After the fix: the NULL guard returns false before __wt_off_page is reached.
+ */
+TEST_CASE("WT-17638: ref_addr_copy returns false when home is NULL", "[btree][split][wt-17638]")
+{
+    connection_wrapper conn(DB_HOME);
+    WT_SESSION_IMPL *session = conn.create_session();
+
+    /*
+     * __wt_ref_addr_copy requires the caller to hold the split generation so
+     * the page-index memory it might access cannot be freed concurrently.
+     */
+    WT_ENTER_GENERATION(session, WT_GEN_SPLIT);
+
+    /*
+     * Build the synthetic WT_REF that mirrors the split window:
+     *   - home = NULL   (not yet written by the split code)
+     *   - addr = &addr_obj (already CAS'd to an off-page WT_ADDR)
+     *
+     * We use a stack-allocated WT_ADDR so the pointer is non-NULL and its
+     * block_cookie_size is 0, meaning the copy path would call memcpy(..., 0)
+     * which is safe.  We never reach the copy path on the fixed code anyway.
+     */
+    WT_ADDR addr_obj;
+    memset(&addr_obj, 0, sizeof(addr_obj));
+    addr_obj.type = WT_ADDR_LEAF_NO;
+
+    WT_REF ref;
+    memset(&ref, 0, sizeof(ref));
+    /* Leave ref.home = NULL to reproduce the split window. */
+    ref.addr = &addr_obj; /* addr is non-NULL: CAS has already run */
+    F_SET(&ref, WT_REF_FLAG_LEAF);
+
+    WT_ADDR_COPY copy;
+    memset(&copy, 0, sizeof(copy));
+
+    /*
+     * Before the fix this segfaults in __wt_off_page(NULL, &addr_obj).
+     * After the fix the NULL guard returns false before reaching __wt_off_page.
+     */
+    REQUIRE(__wt_ref_addr_copy(session, &ref, &copy) == false);
+
+    WT_LEAVE_GENERATION(session, WT_GEN_SPLIT);
+}
+
+/*
+ * [btree][split][wt-17638]: __wt_ref_is_root uses acquire load
+ *
+ * Before the fix __wt_ref_is_root used a TSAN-suppressed relaxed load of home.
+ * Under TSAN the non-atomic write child_ref->home=child (in __split_ref_prepare)
+ * raced with the relaxed read, which could manifest as NULL, causing __wt_ref_is_root
+ * to return true for a leaf and trigger an ASSERT_ALWAYS in __rec_root_write.
+ *
+ * After the fix it uses an acquire load (__wt_atomic_load_ptr_acquire), which no
+ * longer requires a TSAN suppression and provides correct acquire semantics.
+ *
+ * This test verifies the semantics are preserved: a ref with home=NULL is the root,
+ * a ref with a non-NULL home is not.
+ */
+TEST_CASE("WT-17638: ref_is_root returns correct value with acquire load", "[btree][split][wt-17638]")
+{
+    WT_REF ref;
+    memset(&ref, 0, sizeof(ref));
+
+    SECTION("NULL home is the root ref")
+    {
+        /* ref.home = NULL: this is how the root ref is permanently identified. */
+        REQUIRE(__wt_ref_is_root(&ref) == true);
+    }
+
+    SECTION("non-NULL home is not the root ref")
+    {
+        WT_PAGE dummy_page;
+        memset(&dummy_page, 0, sizeof(dummy_page));
+        ref.home = &dummy_page;
+        REQUIRE(__wt_ref_is_root(&ref) == false);
+    }
+}

--- a/test/suite/test_wt17638.py
+++ b/test/suite/test_wt17638.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# test_wt17638.py
+#   Stress test for the race between a deepening parent split and concurrent eviction.
+#
+#   During a deepening parent split (__split_deepen / __split_ref_prepare) a new WT_REF
+#   is zero-initialized (home=NULL) and its addr field is atomically swapped off-page
+#   before home is written.  An eviction thread reading ref->home with a relaxed atomic
+#   load observed NULL and passed it to __wt_off_page, which dereferences page->dsk
+#   unconditionally, causing a SIGSEGV (or an ASSERT_ALWAYS in __rec_root_write under
+#   TSAN when __wt_ref_is_root returned true for a leaf).
+#
+#   The fix upgrades both reads to acquire loads and adds a NULL guard before
+#   __wt_off_page in __wt_ref_addr_copy.
+#
+#   This test creates conditions that widen the race window:
+#     - Small pages (4 KB leaf/internal) to force frequent splits.
+#     - Small cache (10 MB) to keep eviction pressure high.
+#     - Timing stress on split_1 and split_5 to pause the split thread just after
+#       __split_ref_prepare runs (addr CAS done, home write imminent).
+#     - Concurrent eviction threads scanning refs while the split pauses.
+#
+#   On unfixed code with TSAN or on weakly-ordered hardware this reproduces the crash.
+#   On fixed code the test passes cleanly.
+
+import threading
+import wttest
+
+class test_wt17638(wttest.WiredTigerTestCase):
+    uri = 'table:test_wt17638'
+
+    # Small cache + split timing stress to maximize races between eviction and splits.
+    conn_config = (
+        'cache_size=10MB,'
+        'timing_stress_for_test=[split_1,split_5],'
+        'eviction=(threads_min=2,threads_max=4)'
+    )
+
+    # Tiny pages so splits happen frequently.
+    table_config = (
+        'key_format=i,value_format=S,'
+        'allocation_size=4KB,'
+        'leaf_page_max=4KB,'
+        'internal_page_max=4KB,'
+        'split_pct=75'
+    )
+
+    NUM_WRITER_THREADS = 4
+    ROWS_PER_THREAD = 2000
+    VALUE = 'x' * 128  # 128-byte value to fill pages quickly
+
+    def _writer(self, thread_id, errors):
+        """Insert rows in a dedicated session to drive splits."""
+        session = self.conn.open_session()
+        cursor = session.open_cursor(self.uri)
+        base = thread_id * self.ROWS_PER_THREAD
+        try:
+            for i in range(self.ROWS_PER_THREAD):
+                cursor[base + i] = self.VALUE
+        except Exception as e:
+            errors.append(str(e))
+        finally:
+            cursor.close()
+            session.close()
+
+    def _evict_scanner(self, stop_event, errors):
+        """Repeatedly scan the table with release_evict to trigger __wt_ref_addr_copy."""
+        session = self.conn.open_session()
+        evict_cursor = session.open_cursor(self.uri, None, 'debug=(release_evict)')
+        try:
+            while not stop_event.is_set():
+                session.begin_transaction('read_timestamp=' + self.timestamp_str(1))
+                try:
+                    evict_cursor.reset()
+                    while evict_cursor.next() == 0:
+                        evict_cursor.reset()
+                        break  # one page per pass keeps throughput high
+                except Exception:
+                    pass
+                finally:
+                    session.rollback_transaction()
+        except Exception as e:
+            errors.append(str(e))
+        finally:
+            try:
+                evict_cursor.close()
+            except Exception:
+                pass
+            session.close()
+
+    def test_wt17638_split_eviction_race(self):
+        """Drive concurrent splits and eviction to expose the NULL-home race."""
+        self.session.create(self.uri, self.table_config)
+
+        # Pin oldest timestamp so the evict scanner can open a read txn.
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
+
+        errors = []
+        stop_event = threading.Event()
+
+        # Start eviction scanner threads before writers so eviction is already
+        # running when the first splits fire.
+        evict_threads = []
+        for _ in range(2):
+            t = threading.Thread(target=self._evict_scanner, args=(stop_event, errors))
+            t.start()
+            evict_threads.append(t)
+
+        # Run writer threads concurrently so splits happen across all key ranges.
+        writer_threads = []
+        for tid in range(self.NUM_WRITER_THREADS):
+            t = threading.Thread(target=self._writer, args=(tid, errors))
+            t.start()
+            writer_threads.append(t)
+
+        for t in writer_threads:
+            t.join()
+
+        # Let eviction threads drain any in-flight scans.
+        stop_event.set()
+        for t in evict_threads:
+            t.join()
+
+        self.assertEqual(errors, [],
+            'Unexpected errors during split/eviction stress: ' + '; '.join(errors))
+
+        # Verify all rows are readable after the stress run.
+        cursor = self.session.open_cursor(self.uri)
+        count = sum(1 for _ in cursor)
+        cursor.close()
+        self.assertEqual(count, self.NUM_WRITER_THREADS * self.ROWS_PER_THREAD)


### PR DESCRIPTION
## Summary

During a deepening parent split (`__split_deepen` / `__split_ref_prepare`), a
new `WT_REF` is zero-initialized with `home=NULL`, and its `addr` field is
atomically swapped off-page *before* `home` is written to point at the new
parent page. Two callers reading `ref->home` with a relaxed atomic load could
observe `NULL` in that window:

- **`__wt_ref_addr_copy`**: passed `NULL` directly to `__wt_off_page`, which
  dereferences `page->dsk` unconditionally → **SIGSEGV** on non-TSAN builds.
- **`__wt_ref_is_root`**: returned `true` for a non-root leaf, causing
  `__reconcile` to call `__rec_root_write` on a leaf page →
  **`ASSERT_ALWAYS`** under TSAN.

## Fix

Upgrade both reads from a relaxed (or TSAN-suppressed relaxed) load to an
acquire load, pairing with the sequentially-consistent CAS on `ref->addr`
during the split. Additionally, add a `NULL` guard in `__wt_ref_addr_copy`
before passing `home` to `__wt_off_page`, treating a transiently-NULL home as
"no address available".

## Tests

A Catch2 unit test constructs the exact race-window `WT_REF` state
(`home=NULL`, `addr` pointing to a valid off-page `WT_ADDR`) and verifies
`__wt_ref_addr_copy` returns `false` safely. On unfixed code the test
reproduces the SIGSEGV deterministically. A Python stress test drives
concurrent splits and eviction threads with `timing_stress_for_test=[split_1,split_5]`
and small pages to widen the race window on TSAN or weakly-ordered hardware.