### PR TITLE
WT-17659 Rename numbered layered Python tests (Pt 3: Schema/config)

### DIFF
--- a/test/suite/test_layered_config01.py
+++ b/test/suite/test_layered_config01.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Public Domain 2014-present MongoDB, Inc.
 # Public Domain 2008-2014 WiredTiger, Inc.
@@ -25,20 +25,38 @@
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
-import wttest
+
+import os, os.path, shutil, wttest
 from helper_disagg import disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
 
-# test_layered29.py
-# Test we can create a large number of layered tables
+# test_layered_config01.py
+#    Test layered table metadata has logging disabled.
 @disagg_test_class
-class test_layered29(wttest.WiredTigerTestCase):
-    conn_base_config = ',create,statistics=(all),statistics_log=(wait=1,json=true,on_close=true),'
-    def conn_config(self):
-        return self.extensionsConfig() + self.conn_base_config + 'disaggregated=(role="leader")'
+class test_layered_config01(wttest.WiredTigerTestCase):
+    conn_config = 'log=(enabled=true),disaggregated=(role="leader"),'
 
-    scenarios = gen_disagg_storages('test_layered29', disagg_only = True)
+    create_session_config = 'key_format=S,value_format=S'
 
-    @wttest.longtest('lots of tables')
-    def test_create_tables(self):
-        for i in range(0, 10000):
-            self.assertEqual(self.session.create("layered:test_table" + str(i), "key_format=S,value_format=S"), 0)
+    layered_uris = ["table:test_layered_config01a", "layered:test_layered_config01b"]
+
+    disagg_storages = gen_disagg_storages('test_layered_config01', disagg_only = True)
+    scenarios = make_scenarios(disagg_storages)
+
+    # Ensure that the metadata cursor has all the expected URIs.
+    def check_metadata_cursor(self):
+        cursor = self.session.open_cursor('metadata:create', None, None)
+        for key in self.layered_uris:
+            cursor.set_key(key)
+            self.assertEqual(cursor.search(), 0)
+            self.assertTrue("log=(enabled=false)" in cursor.get_value())
+
+    def test_layered_config01(self):
+        # Create tables
+        for uri in self.layered_uris:
+            cfg = self.create_session_config
+            if not uri.startswith('layered'):
+                cfg += ',block_manager=disagg,type=layered'
+            self.session.create(uri, cfg)
+
+        self.check_metadata_cursor()

--- a/test/suite/test_layered_config02.py
+++ b/test/suite/test_layered_config02.py
@@ -31,10 +31,10 @@ from helper_disagg import disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 from wiredtiger import stat
 
-# test_layered43.py
+# test_layered_config02.py
 #    Test disaggregated storage with block cache.
 @disagg_test_class
-class test_layered43(wttest.WiredTigerTestCase):
+class test_layered_config02(wttest.WiredTigerTestCase):
     nitems = 500
     key_to_update = 0
     num_updates = 10
@@ -47,9 +47,9 @@ class test_layered43(wttest.WiredTigerTestCase):
 
     create_session_config = 'key_format=S,value_format=S'
 
-    table_name = "test_layered43"
+    table_name = "test_layered_config02"
 
-    disagg_storages = gen_disagg_storages('test_layered43', disagg_only = True)
+    disagg_storages = gen_disagg_storages('test_layered_config02', disagg_only = True)
     scenarios = make_scenarios(disagg_storages, [
         ('layered', dict(prefix='layered:')),
         ('shared', dict(prefix='table:')),
@@ -64,7 +64,7 @@ class test_layered43(wttest.WiredTigerTestCase):
         return val
 
     # Test long delta chains
-    def test_layered43(self):
+    def test_layered_config02(self):
 
         # Create table
         self.uri = self.prefix + self.table_name

--- a/test/suite/test_layered_config03.py
+++ b/test/suite/test_layered_config03.py
@@ -31,11 +31,11 @@ from helper_disagg import disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 from wiredtiger import stat
 
-# test_layered48.py
+# test_layered_config03.py
 #    Ensure overflow keys and values are not being generated in disaggregated storage.
 
 @disagg_test_class
-class test_layered48(wttest.WiredTigerTestCase):
+class test_layered_config03(wttest.WiredTigerTestCase):
     nitems = 500
     key_to_update = 0
     num_updates = 10
@@ -47,9 +47,9 @@ class test_layered48(wttest.WiredTigerTestCase):
 
     create_session_config = 'key_format=S,value_format=S,leaf_key_max=256,leaf_value_max=256'
 
-    table_name = "test_layered48"
+    table_name = "test_layered_config03"
 
-    disagg_storages = gen_disagg_storages('test_layered48', disagg_only = True)
+    disagg_storages = gen_disagg_storages('test_layered_config03', disagg_only = True)
     scenarios = make_scenarios(disagg_storages, [
         ('layered', dict(prefix='layered:')),
         ('shared', dict(prefix='table:')),
@@ -67,7 +67,7 @@ class test_layered48(wttest.WiredTigerTestCase):
         return random_string
 
     # Test overflow keys and values.
-    def test_layered48(self):
+    def test_layered_config03(self):
 
         # Create table
         self.uri = self.prefix + self.table_name

--- a/test/suite/test_layered_config04.py
+++ b/test/suite/test_layered_config04.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Public Domain 2014-present MongoDB, Inc.
 # Public Domain 2008-2014 WiredTiger, Inc.
@@ -27,25 +27,20 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 import wiredtiger, wttest
-from helper_disagg import DisaggConfigMixin, gen_disagg_storages
+from helper_disagg import disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
 
-# test_disagg02.py
-# Note: This test focuses on validating the behavioral differences of
-# WiredTiger API calls when operating in a disaggregated storage environment.
+# Test throw an error if logging is configured for layered table
 
-class test_disagg02(wttest.WiredTigerTestCase, DisaggConfigMixin):
+@disagg_test_class
+class test_layered_config04(wttest.WiredTigerTestCase):
+    disagg_storages = gen_disagg_storages('test_layered_eviction02', disagg_only = True)
+    scenarios = make_scenarios(disagg_storages)
 
-    disagg_storages = gen_disagg_storages('test_disagg02', disagg_only = True)
+    conn_config = 'disaggregated=(role="leader")'
 
-    def conn_extensions(self, extlist):
-        DisaggConfigMixin.conn_extensions(self, extlist)
-
-    @wttest.skip_for_hook("tiered", "Tiered tables do not support compaction")
-    def test_disagg_compact(self):
-        # Test that compact operation fails in disaggregated storage mode.
+    def test_create_logged(self):
+        uri = "layered:test_layered_config04"
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
-            lambda: self.session.compact('table:test_disagg02'),
-            '/Operation not supported/')
-        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
-            lambda: self.session.compact(None, 'background=true'),
-            '/Operation not supported/')
+            lambda: self.session.create(uri, 'key_format=S,value_format=S,log=(enabled=true)'),
+            '/Logging is not supported for layered/')

--- a/test/suite/test_layered_config05.py
+++ b/test/suite/test_layered_config05.py
@@ -30,10 +30,10 @@ import threading, time, wiredtiger, wttest
 from helper_disagg import disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 
-# test_layered68.py
+# test_layered_config05.py
 #    Test that address cookies in disaggregated storage can be upgraded/downgraded safely.
 @disagg_test_class
-class test_layered68(wttest.WiredTigerTestCase):
+class test_layered_config05(wttest.WiredTigerTestCase):
     conn_base_config = 'statistics=(all),' \
                      + 'statistics_log=(wait=1,json=true,on_close=true),' \
                      + 'precise_checkpoint=true,'
@@ -43,7 +43,7 @@ class test_layered68(wttest.WiredTigerTestCase):
 
     num_items = 2000
     num_modify = 100
-    uri = "table:test_layered68"
+    uri = "table:test_layered_config05"
 
     address_cookie_upgrade = [
         ('none', dict(address_cookie_upgrade='none', compatible=True)),
@@ -55,11 +55,11 @@ class test_layered68(wttest.WiredTigerTestCase):
         ('optional_field', dict(optional_field='true')),
     ]
 
-    disagg_storages = gen_disagg_storages('test_layered68', disagg_only = True)
+    disagg_storages = gen_disagg_storages('test_layered_config05', disagg_only = True)
     scenarios = make_scenarios(disagg_storages, address_cookie_upgrade, optional_field)
 
     # Test stepping up concurrently with a checkpoint.
-    def test_layered68(self):
+    def test_layered_config05(self):
         self.conn.reconfigure('disaggregated=(role="leader")')
 
         self.session.create(self.uri, self.create_session_config)

--- a/test/suite/test_layered_config06.py
+++ b/test/suite/test_layered_config06.py
@@ -30,9 +30,9 @@ import os, wttest
 from helper import simulate_crash_restart
 from wtdataset import SimpleDataSet
 
-# test_layered87.py
+# test_layered_config06.py
 #    Make sure RTS does nothing in a disaggregated storage context.
-class test_layered87(wttest.WiredTigerTestCase):
+class test_layered_config06(wttest.WiredTigerTestCase):
     conn_config = 'disaggregated=(page_log=palite),' \
         + 'disaggregated=(role="leader")'
 
@@ -53,8 +53,8 @@ class test_layered87(wttest.WiredTigerTestCase):
         os.symlink('../kv_home', 'follower/kv_home', target_is_directory=True)
 
     @wttest.skip_for_hook("tiered", "Cannot run tiered storage in disagg mode")
-    def test_layered87(self):
-        uri = "table:test_layered87"
+    def test_layered_config06(self):
+        uri = "table:test_layered_config06"
         ds = SimpleDataSet(self, uri, 500, key_format='S', value_format='S')
         ds.populate()
 

--- a/test/suite/test_layered_config07.py
+++ b/test/suite/test_layered_config07.py
@@ -33,14 +33,14 @@ from wtscenario import make_scenarios
 def encode_bytes(str):
     return bytes(str, 'utf-8')
 
-# test_disagg01.py
+# test_layered_config07.py
 # Note that the APIs we are testing are not meant to be used directly
 # by any WiredTiger application, these APIs are used internally.
 # However, it is useful to do tests of this API independently.
 
-class test_disagg01(wttest.WiredTigerTestCase, DisaggConfigMixin):
+class test_layered_config07(wttest.WiredTigerTestCase, DisaggConfigMixin):
 
-    disagg_storages = gen_disagg_storages('test_disagg01', disagg_only = True)
+    disagg_storages = gen_disagg_storages('test_layered_config07', disagg_only = True)
 
     # Make scenarios for different cloud service providers
     scenarios = make_scenarios(disagg_storages)

--- a/test/suite/test_layered_config08.py
+++ b/test/suite/test_layered_config08.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Public Domain 2014-present MongoDB, Inc.
 # Public Domain 2008-2014 WiredTiger, Inc.
@@ -27,20 +27,25 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 import wiredtiger, wttest
-from helper_disagg import disagg_test_class, gen_disagg_storages
-from wtscenario import make_scenarios
+from helper_disagg import DisaggConfigMixin, gen_disagg_storages
 
-# Test throw an error if logging is configured for layered table
+# test_layered_config08.py
+# Note: This test focuses on validating the behavioral differences of
+# WiredTiger API calls when operating in a disaggregated storage environment.
 
-@disagg_test_class
-class test_layered51(wttest.WiredTigerTestCase):
-    disagg_storages = gen_disagg_storages('test_layered50', disagg_only = True)
-    scenarios = make_scenarios(disagg_storages)
+class test_layered_config08(wttest.WiredTigerTestCase, DisaggConfigMixin):
 
-    conn_config = 'disaggregated=(role="leader")'
+    disagg_storages = gen_disagg_storages('test_layered_config08', disagg_only = True)
 
-    def test_create_logged(self):
-        uri = "layered:test_layered51"
+    def conn_extensions(self, extlist):
+        DisaggConfigMixin.conn_extensions(self, extlist)
+
+    @wttest.skip_for_hook("tiered", "Tiered tables do not support compaction")
+    def test_disagg_compact(self):
+        # Test that compact operation fails in disaggregated storage mode.
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
-            lambda: self.session.create(uri, 'key_format=S,value_format=S,log=(enabled=true)'),
-            '/Logging is not supported for layered/')
+            lambda: self.session.compact('table:test_layered_config08'),
+            '/Operation not supported/')
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.session.compact(None, 'background=true'),
+            '/Operation not supported/')

--- a/test/suite/test_layered_config09.py
+++ b/test/suite/test_layered_config09.py
@@ -30,10 +30,10 @@ import wiredtiger, wttest
 from helper_disagg import DisaggConfigMixin, disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 
-# test_disagg03.py
+# test_layered_config09.py
 # Test that creating a tiered table fails when in disaggregated storage mode
 @disagg_test_class
-class test_disagg03(wttest.WiredTigerTestCase, DisaggConfigMixin):
+class test_layered_config09(wttest.WiredTigerTestCase, DisaggConfigMixin):
 
     role_scenarios = [
         ('leader', dict(role='leader')),
@@ -44,7 +44,7 @@ class test_disagg03(wttest.WiredTigerTestCase, DisaggConfigMixin):
         ('tier', dict(prefix='tier:')),
         ('object', dict(prefix='object:')),
     ]
-    disagg_storages = gen_disagg_storages('test_disagg03', disagg_only = True)
+    disagg_storages = gen_disagg_storages('test_layered_config09', disagg_only = True)
     scenarios = make_scenarios(disagg_storages, role_scenarios, prefix_scenarios)
     conn_base_config = 'statistics=(all),verbose=(tiered),'
 
@@ -67,6 +67,6 @@ class test_disagg03(wttest.WiredTigerTestCase, DisaggConfigMixin):
 
         # Hit ENOTSUP with "tier", "tiered", and tiered "object" uri prefix
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
-        lambda: self.session.create(self.prefix + 'test_disagg03',
+        lambda: self.session.create(self.prefix + 'test_layered_config09',
             'key_format=S,value_format=S'),
             '/Operation not supported/')

--- a/test/suite/test_layered_config10.py
+++ b/test/suite/test_layered_config10.py
@@ -30,16 +30,16 @@ import wiredtiger, wttest
 from helper_disagg import DisaggConfigMixin, gen_disagg_storages
 from wiredtiger import stat
 
-# test_disagg04.py
+# test_layered_config10.py
 # Note that the APIs we are testing are not meant to be used directly
 # by any WiredTiger application, these APIs are used internally.
 # However, it is useful to do tests of this API independently.
 
-class test_disagg04(wttest.WiredTigerTestCase, DisaggConfigMixin):
+class test_layered_config10(wttest.WiredTigerTestCase, DisaggConfigMixin):
 
-    disagg_storages = gen_disagg_storages('test_disagg04', disagg_only = True)
+    disagg_storages = gen_disagg_storages('test_layered_config10', disagg_only = True)
 
-    uri = "layered:test_disagg04_%02d"
+    uri = "layered:test_layered_config10_%02d"
     cold_table_config = 'key_format=S,value_format=S,disaggregated=(storage_tier=cold),'
 
     # Load the storage store extension.

--- a/test/suite/test_layered_config11.py
+++ b/test/suite/test_layered_config11.py
@@ -30,11 +30,11 @@ import wttest
 from helper_disagg import DisaggConfigMixin, disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 
-# test_layered08.py
+# test_layered_config11.py
 # Simple read write testing using the page log API
 
 @disagg_test_class
-class test_layered08(wttest.WiredTigerTestCase, DisaggConfigMixin):
+class test_layered_config11(wttest.WiredTigerTestCase, DisaggConfigMixin):
     encrypt = [
         ('none', dict(encryptor='none', encrypt_args='')),
         ('rotn', dict(encryptor='rotn', encrypt_args='keyid=13')),
@@ -46,7 +46,7 @@ class test_layered08(wttest.WiredTigerTestCase, DisaggConfigMixin):
     ]
 
     conn_base_config = 'transaction_sync=(enabled,method=fsync),statistics=(all),statistics_log=(wait=1,json=true,on_close=true),'
-    disagg_storages = gen_disagg_storages('test_layered08', disagg_only = True)
+    disagg_storages = gen_disagg_storages('test_layered_config11', disagg_only = True)
 
     scenarios = make_scenarios(encrypt, compress, disagg_storages)
 
@@ -63,7 +63,7 @@ class test_layered08(wttest.WiredTigerTestCase, DisaggConfigMixin):
         DisaggConfigMixin.conn_extensions(self, extlist)
 
     def test_layered_read_write(self):
-        uri = "layered:test_layered08"
+        uri = "layered:test_layered_config11"
         create_session_config = 'key_format=S,value_format=S,block_compressor={}'.format(self.block_compress)
         self.pr('CREATING')
         self.session.create(uri, create_session_config)

--- a/test/suite/test_layered_config12.py
+++ b/test/suite/test_layered_config12.py
@@ -26,7 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-# test_layered88.py
+# test_layered_config12.py
 # Test that unsupported cursor and table operations return clear errors for layered tables:
 # - Reverse collator (FIXME-WT-14738)
 
@@ -35,12 +35,12 @@ from helper_disagg import disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 
 @disagg_test_class
-class test_layered88(wttest.WiredTigerTestCase):
-    disagg_storages = gen_disagg_storages('test_layered88', disagg_only=True)
+class test_layered_config12(wttest.WiredTigerTestCase):
+    disagg_storages = gen_disagg_storages('test_layered_config12', disagg_only=True)
     scenarios = make_scenarios(disagg_storages)
 
     conn_config = 'disaggregated=(role="leader")'
-    uri = 'layered:test_layered88'
+    uri = 'layered:test_layered_config12'
 
     # Override conn_extensions to load the reverse collator alongside the disagg page log.
     def conn_extensions(self, extlist):

--- a/test/suite/test_layered_config13.py
+++ b/test/suite/test_layered_config13.py
@@ -37,10 +37,10 @@ helper_disagg.disagg_ignore_expected_output = disagg_ignore_expected_output
 
 logdir = "log"
 
-# test_layered46.py
+# test_layered_config13.py
 #    Test deleting local files on restart.
 @disagg_test_class
-class test_layered46(wttest.WiredTigerTestCase):
+class test_layered_config13(wttest.WiredTigerTestCase):
 
     conn_config = (
         "statistics=(all),statistics_log=(wait=1,json=true,on_close=true),"
@@ -48,20 +48,20 @@ class test_layered46(wttest.WiredTigerTestCase):
         + f"log=(enabled=true,path={logdir}),"
     )
 
-    disagg_storages = gen_disagg_storages("test_layered46", disagg_only=True)
+    disagg_storages = gen_disagg_storages("test_layered_config13", disagg_only=True)
 
     # Make scenarios for different cloud service providers.
     scenarios = make_scenarios(disagg_storages)
 
     create_session_config = "key_format=S,value_format=S"
-    uri = "layered:test_layered46"
-    uri_local = "table:test_layered46local"
+    uri = "layered:test_layered_config13"
+    uri_local = "table:test_layered_config13local"
 
     def wiredtiger_open(self, *args, **kwargs):
         os.makedirs(logdir, exist_ok=True)
         return super().wiredtiger_open(*args, **kwargs)
 
-    def test_layered46(self):
+    def test_layered_config13(self):
         self.conn.reconfigure('disaggregated=(role="leader")')
 
         # Create the tables

--- a/test/suite/test_layered_cursor21.py
+++ b/test/suite/test_layered_cursor21.py
@@ -30,7 +30,7 @@ import wttest, wiredtiger
 from helper_disagg import disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 
-# test_cursor_random04.py
+# test_layered_cursor21.py
 #    Regression coverage for WT-15189: next_random on a layered table must
 #    return WT_NOTFOUND rather than spin when every reachable row is a
 #    tombstone. Covers the all-deleted-in-ingest case (stable empty) and the
@@ -38,16 +38,16 @@ from wtscenario import make_scenarios
 
 @disagg_test_class
 @wttest.skip_for_hook("tiered", "Cannot run tiered storage in disagg mode")
-class test_cursor_random04(wttest.WiredTigerTestCase):
+class test_layered_cursor21(wttest.WiredTigerTestCase):
 
     conn_config = 'disaggregated=(role="leader"),'
 
     uris = [
-        ('layered', dict(uri='layered:test_cursor_random04')),
-        ('table', dict(uri='table:test_cursor_random04')),
+        ('layered', dict(uri='layered:test_layered_cursor21')),
+        ('table', dict(uri='table:test_layered_cursor21')),
     ]
 
-    disagg_storages = gen_disagg_storages('test_cursor_random04', disagg_only=True)
+    disagg_storages = gen_disagg_storages('test_layered_cursor21', disagg_only=True)
     scenarios = make_scenarios(disagg_storages, uris)
 
     nitems = 1000

--- a/test/suite/test_layered_eviction05.py
+++ b/test/suite/test_layered_eviction05.py
@@ -35,12 +35,12 @@ from wtscenario import make_scenarios
 
 # Test we don't review obsolete time window for readonly btree in follower.
 @disagg_test_class
-class test_layered55(eviction_util, wttest.WiredTigerTestCase):
+class test_layered_eviction05(eviction_util, wttest.WiredTigerTestCase):
     conn_base_config = 'cache_size=10MB,'
 
-    disagg_storages = gen_disagg_storages('test_layered55', disagg_only = True)
+    disagg_storages = gen_disagg_storages('test_layered_eviction05', disagg_only = True)
     scenarios = make_scenarios(disagg_storages)
-    uri='layered:test_layered55'
+    uri='layered:test_layered_eviction05'
 
     def conn_config(self):
         return self.conn_base_config + 'disaggregated=(role="leader"),'

--- a/test/suite/test_layered_prepare09.py
+++ b/test/suite/test_layered_prepare09.py
@@ -26,7 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-# test_prepare45.py
+# test_layered_prepare09.py
 #   Tests that prepared transactions captured unresolved in a leader checkpoint are correctly
 #   resolved (committed or rolled back) on follower step-up. Covers seven operation types:
 #   - test_prepare_insert: prepared inserts on new keys
@@ -49,15 +49,15 @@ from wtscenario import make_scenarios
 
 @wttest.skip_for_hook("tiered", "Disaggregated layered tests are not supported with tiered storage")
 @disagg_test_class
-class test_prepare45(wttest.WiredTigerTestCase):
-    tablename = 'test_prepare45'
+class test_layered_prepare09(wttest.WiredTigerTestCase):
+    tablename = 'test_layered_prepare09'
     uri = 'layered:' + tablename
 
     resolve_scenarios = [
         ('commit', dict(commit=True)),
         ('rollback', dict(commit=False)),
     ]
-    disagg_storages = gen_disagg_storages('test_prepare45', disagg_only=True)
+    disagg_storages = gen_disagg_storages('test_layered_prepare09', disagg_only=True)
     scenarios = make_scenarios(disagg_storages, resolve_scenarios)
 
     conn_base_config = 'cache_size=10MB,statistics=(all),precise_checkpoint=true,preserve_prepared=true,'

--- a/test/suite/test_layered_schema01.py
+++ b/test/suite/test_layered_schema01.py
@@ -32,12 +32,12 @@ from wtscenario import make_scenarios
 
 StorageSource = wiredtiger.StorageSource  # easy access to constants
 
-# test_layered01.py
+# test_layered_schema01.py
 #    Basic layered tree creation test
 @disagg_test_class
-class test_layered01(wttest.WiredTigerTestCase):
+class test_layered_schema01(wttest.WiredTigerTestCase):
 
-    uri_base = "test_layered01"
+    uri_base = "test_layered_schema01"
     conn_config = 'verbose=[layered],disaggregated=(role="leader"),' \
                 + 'disaggregated=(lose_all_my_data=true)'
 
@@ -57,7 +57,7 @@ class test_layered01(wttest.WiredTigerTestCase):
         self.assertTrue(val_str in val)
 
     # Test calling the create API for a layered table.
-    def test_layered01(self):
+    def test_layered_schema01(self):
         base_create = 'key_format=S,value_format=S'
 
         self.pr("create layered tree")

--- a/test/suite/test_layered_schema02.py
+++ b/test/suite/test_layered_schema02.py
@@ -31,19 +31,19 @@ import wiredtiger
 import wttest
 from helper_disagg import disagg_test_class
 
-# test_layered24.py
+# test_layered_schema02.py
 #    Ensure a secondary that drops a table does not fall back to reading
 #    the stable table.
 @disagg_test_class
-class test_layered24(wttest.WiredTigerTestCase):
-    uri = "layered:test_layered24"
+class test_layered_schema02(wttest.WiredTigerTestCase):
+    uri = "layered:test_layered_schema02"
 
     conn_base_config = ""
     conn_config = conn_base_config + 'disaggregated=(role="leader")'
 
     nitems = 10000
 
-    def test_layered24(self):
+    def test_layered_schema02(self):
         session_config = 'key_format=S,value_format=S'
 
         #

--- a/test/suite/test_layered_schema03.py
+++ b/test/suite/test_layered_schema03.py
@@ -31,11 +31,11 @@ from helper_disagg import disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 from wiredtiger import stat
 
-# test_layered28.py
+# test_layered_schema03.py
 #    Test to ensure that dropping layered tables works and subsequent sweep doesn't crash
 @disagg_test_class
-class test_layered28(wttest.WiredTigerTestCase):
-    uri_base = "test_layered28"
+class test_layered_schema03(wttest.WiredTigerTestCase):
+    uri_base = "test_layered_schema03"
     conn_config = 'statistics=(all),statistics_log=(wait=1,json=true,on_close=true),disaggregated=(role="leader"),' \
                 + 'file_manager=(close_scan_interval=1)'
 

--- a/test/suite/test_layered_schema04.py
+++ b/test/suite/test_layered_schema04.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 #
 # Public Domain 2014-present MongoDB, Inc.
 # Public Domain 2008-2014 WiredTiger, Inc.
@@ -25,38 +25,20 @@
 # OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
-
-import os, os.path, shutil, wttest
+import wttest
 from helper_disagg import disagg_test_class, gen_disagg_storages
-from wtscenario import make_scenarios
 
-# test_layered40.py
-#    Test layered table metadata has logging disabled.
+# test_layered_schema04.py
+# Test we can create a large number of layered tables
 @disagg_test_class
-class test_layered40(wttest.WiredTigerTestCase):
-    conn_config = 'log=(enabled=true),disaggregated=(role="leader"),'
+class test_layered_schema04(wttest.WiredTigerTestCase):
+    conn_base_config = ',create,statistics=(all),statistics_log=(wait=1,json=true,on_close=true),'
+    def conn_config(self):
+        return self.extensionsConfig() + self.conn_base_config + 'disaggregated=(role="leader")'
 
-    create_session_config = 'key_format=S,value_format=S'
+    scenarios = gen_disagg_storages('test_layered_schema04', disagg_only = True)
 
-    layered_uris = ["table:test_layered40a", "layered:test_layered40b"]
-
-    disagg_storages = gen_disagg_storages('test_layered40', disagg_only = True)
-    scenarios = make_scenarios(disagg_storages)
-
-    # Ensure that the metadata cursor has all the expected URIs.
-    def check_metadata_cursor(self):
-        cursor = self.session.open_cursor('metadata:create', None, None)
-        for key in self.layered_uris:
-            cursor.set_key(key)
-            self.assertEqual(cursor.search(), 0)
-            self.assertTrue("log=(enabled=false)" in cursor.get_value())
-
-    def test_layered40(self):
-        # Create tables
-        for uri in self.layered_uris:
-            cfg = self.create_session_config
-            if not uri.startswith('layered'):
-                cfg += ',block_manager=disagg,type=layered'
-            self.session.create(uri, cfg)
-
-        self.check_metadata_cursor()
+    @wttest.longtest('lots of tables')
+    def test_create_tables(self):
+        for i in range(0, 10000):
+            self.assertEqual(self.session.create("layered:test_table" + str(i), "key_format=S,value_format=S"), 0)

--- a/test/suite/test_layered_schema05.py
+++ b/test/suite/test_layered_schema05.py
@@ -30,10 +30,10 @@ import wiredtiger, wttest
 from helper_disagg import disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 
-# test_layered36.py
+# test_layered_schema05.py
 #    Test creating missing stable tables.
 @disagg_test_class
-class test_layered36(wttest.WiredTigerTestCase):
+class test_layered_schema05(wttest.WiredTigerTestCase):
     nitems = 500
 
     conn_base_config = 'statistics=(all),' \
@@ -43,17 +43,17 @@ class test_layered36(wttest.WiredTigerTestCase):
 
     create_session_config = 'key_format=S,value_format=S'
 
-    table_name_empty = "test_layered36a"
-    table_name_filled = "test_layered36b"
+    table_name_empty = "test_layered_schema05a"
+    table_name_filled = "test_layered_schema05b"
 
-    disagg_storages = gen_disagg_storages('test_layered36', disagg_only = True)
+    disagg_storages = gen_disagg_storages('test_layered_schema05', disagg_only = True)
     scenarios = make_scenarios(disagg_storages, [
         ('layered-prefix', dict(prefix='layered:', table_config='')),
         ('layered-type', dict(prefix='table:', table_config='block_manager=disagg,type=layered')),
     ])
 
     # A simple test with a single node.
-    def test_layered36(self):
+    def test_layered_schema05(self):
 
         # Create an empty table.
         uri_empty = self.prefix + self.table_name_empty

--- a/test/suite/test_layered_schema06.py
+++ b/test/suite/test_layered_schema06.py
@@ -41,8 +41,8 @@ TEST_NAMESPACE_BITS = 3
 
 # Test file IDs for tables that should have predefined IDs.
 @disagg_test_class
-class test_layered75(wttest.WiredTigerTestCase):
-    disagg_storages = gen_disagg_storages('test_layered75', disagg_only = True)
+class test_layered_schema06(wttest.WiredTigerTestCase):
+    disagg_storages = gen_disagg_storages('test_layered_schema06', disagg_only = True)
     creation_formats = [
         ('layered-bare',       dict(prefix='layered:', extra_config='')),
         ('layered-disagg',     dict(prefix='layered:', extra_config='block_manager=disagg')),
@@ -165,10 +165,10 @@ class test_layered75(wttest.WiredTigerTestCase):
         return base
 
     def test_populate_table_on_leader(self):
-        self.session.create(f"{self.prefix}test_layered75", self.make_create_config())
+        self.session.create(f"{self.prefix}test_layered_schema06", self.make_create_config())
         # Check the leader
-        expected_files = {"file:test_layered75.wt_stable": TEST_NAMESPACE_SHARED,
-                          "file:test_layered75.wt_ingest": TEST_NAMESPACE_LOCAL}
+        expected_files = {"file:test_layered_schema06.wt_stable": TEST_NAMESPACE_SHARED,
+                          "file:test_layered_schema06.wt_ingest": TEST_NAMESPACE_LOCAL}
         self.check_metadata_ids(self.session, expected_files)
 
         self.create_follower()
@@ -176,10 +176,10 @@ class test_layered75(wttest.WiredTigerTestCase):
         self.check_metadata_ids(self.session_follow)
 
     def test_populate_table_on_leader_pick_up_on_follower(self):
-        expected_files = {"file:test_layered75.wt_stable": TEST_NAMESPACE_SHARED,
-                          "file:test_layered75.wt_ingest": TEST_NAMESPACE_LOCAL}
+        expected_files = {"file:test_layered_schema06.wt_stable": TEST_NAMESPACE_SHARED,
+                          "file:test_layered_schema06.wt_ingest": TEST_NAMESPACE_LOCAL}
 
-        self.session.create(f"{self.prefix}test_layered75", self.make_create_config())
+        self.session.create(f"{self.prefix}test_layered_schema06", self.make_create_config())
         # Check the leader
         self.check_metadata_ids(self.session, expected_files)
 
@@ -193,7 +193,7 @@ class test_layered75(wttest.WiredTigerTestCase):
         expected_files = {}
 
         for i in range(10):
-            table_name = f"test_layered75_{i}"
+            table_name = f"test_layered_schema06_{i}"
             self.session.create(f"{self.prefix}{table_name}", self.make_create_config())
             expected_files[f"file:{table_name}.wt_stable"] = TEST_NAMESPACE_SHARED
             expected_files[f"file:{table_name}.wt_ingest"] = TEST_NAMESPACE_LOCAL
@@ -213,7 +213,7 @@ class test_layered75(wttest.WiredTigerTestCase):
         expected_files = {}
 
         for i in range(10):
-            table_name = f"test_layered75_{i}"
+            table_name = f"test_layered_schema06_{i}"
             self.session.create(f"{self.prefix}{table_name}", self.make_create_config())
             expected_files[f"file:{table_name}.wt_stable"] = TEST_NAMESPACE_SHARED
             expected_files[f"file:{table_name}.wt_ingest"] = TEST_NAMESPACE_LOCAL
@@ -227,7 +227,7 @@ class test_layered75(wttest.WiredTigerTestCase):
         # .wt_stable (shared namespace) and allocate a new .wt_ingest in the
         # local namespace.
         for i in range(10):
-            table_name = f"test_layered75_{i}"
+            table_name = f"test_layered_schema06_{i}"
             self.session.create(f"{self.prefix}{table_name}", self.make_create_config())
 
         # Confirm the follower's ingest table received a local namespace ID.

--- a/test/suite/test_layered_schema07.py
+++ b/test/suite/test_layered_schema07.py
@@ -26,7 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-# test_layered104.py
+# test_layered_schema07.py
 #   Test WT_SESSION::publish for disaggregated storage.
 #
 #   Schema operations (create, drop) on a leader do not get included in the next checkpoint
@@ -41,14 +41,14 @@ from wiredtiger import stat
 
 #   Test WT_SESSION::publish for disaggregated storage.
 @disagg_test_class
-class test_layered104(wttest.WiredTigerTestCase, suite_subprocess):
+class test_layered_schema07(wttest.WiredTigerTestCase, suite_subprocess):
     conn_base_config = 'statistics=(all),precise_checkpoint=true,'
     conn_config = conn_base_config + 'disaggregated=(role="leader",lose_all_my_data=true)'
     conn_config_follower = conn_base_config + 'disaggregated=(role="follower",lose_all_my_data=true)'
 
-    uri = 'layered:test_layered104'
+    uri = 'layered:test_layered_schema07'
 
-    disagg_storages = gen_disagg_storages('test_layered104', disagg_only=True)
+    disagg_storages = gen_disagg_storages('test_layered_schema07', disagg_only=True)
     scenarios = make_scenarios(disagg_storages)
 
     #
@@ -221,7 +221,7 @@ class test_layered104(wttest.WiredTigerTestCase, suite_subprocess):
         """
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.session.publish(
-                'file:test_layered104_err_uri',
+                'file:test_layered_schema07_err_uri',
                 'disaggregated=(schema_epoch=1)'),
             '/only supported for table: and layered:/')
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(1) +
@@ -266,7 +266,7 @@ class test_layered104(wttest.WiredTigerTestCase, suite_subprocess):
         """
         subdir = 'SUBPROCESS'
         [returncode, _] = self.run_subprocess_function(subdir,
-            'test_layered104.test_layered104.subprocess_checkpoint_fails_without_publish',
+            'test_layered_schema07.test_layered_schema07.subprocess_checkpoint_fails_without_publish',
             silent=True)
         self.assertNotEqual(returncode, 0,
             'Expected subprocess to panic on checkpoint of unpublished table')
@@ -321,7 +321,7 @@ class test_layered104(wttest.WiredTigerTestCase, suite_subprocess):
         """
         subdir = 'SUBPROCESS_LATER_EPOCH'
         [returncode, _] = self.run_subprocess_function(subdir,
-            'test_layered104.test_layered104.'
+            'test_layered_schema07.test_layered_schema07.'
             'subprocess_checkpoint_fails_with_publish_at_later_epoch',
             silent=True)
         self.assertNotEqual(returncode, 0,

--- a/test/suite/test_layered_schema08.py
+++ b/test/suite/test_layered_schema08.py
@@ -26,7 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-# test_layered105.py
+# test_layered_schema08.py
 #   Test that shared metadata queue operations are deferred until a checkpoint runs.
 #
 #   Schema operations (create, drop) on a leader enqueue metadata updates with deferred=true.
@@ -39,8 +39,8 @@ from helper_disagg import disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 
 @disagg_test_class
-class test_layered105(wttest.WiredTigerTestCase):
-    uri_base = 'test_layered105'
+class test_layered_schema08(wttest.WiredTigerTestCase):
+    uri_base = 'test_layered_schema08'
     conn_config = 'statistics=(all),disaggregated=(role="leader",lose_all_my_data=true)'
 
     table_types = [
@@ -48,7 +48,7 @@ class test_layered105(wttest.WiredTigerTestCase):
         ('table-prefix', dict(prefix='table:', table_config=',block_manager=disagg,type=layered')),
     ]
 
-    disagg_storages = gen_disagg_storages('test_layered105', disagg_only=True)
+    disagg_storages = gen_disagg_storages('test_layered_schema08', disagg_only=True)
     scenarios = make_scenarios(table_types, disagg_storages)
 
     def uri(self):

--- a/test/suite/test_layered_schema09.py
+++ b/test/suite/test_layered_schema09.py
@@ -26,7 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-# test_timestamp30.py
+# test_layered_schema09.py
 #   Timestamps: Test persisting the stable disaggregated schema epoch in the checkpoint.
 
 import wttest
@@ -35,7 +35,7 @@ from wiredtiger import stat
 
 # Timestamps: Test persisting the stable disaggregated schema epoch in the checkpoint.
 @disagg_test_class
-class test_timestamp30(wttest.WiredTigerTestCase):
+class test_layered_schema09(wttest.WiredTigerTestCase):
 
     conn_config = 'statistics=(all),disaggregated=(role="leader",lose_all_my_data=true)'
 
@@ -55,7 +55,7 @@ class test_timestamp30(wttest.WiredTigerTestCase):
         correctly picked up on restart, and that it can be updated in a checkpoint.
         '''
         # Create a layered table so checkpoints write through disaggregated storage.
-        uri = 'layered:test_timestamp30'
+        uri = 'layered:test_layered_schema09'
         self.session.create(uri, 'key_format=S,value_format=S')
 
         # The first checkpoint, taken before the epoch is set, records 0 in the checkpoint.


### PR DESCRIPTION
Pt 3 of 4 splitting up the test rename effort started in WT-17570.
  - Pt 1 (WT-17570): cursor, eviction, fast_truncate — merged
  - Pt 2 (WT-17658): delta, checkpoint, prepare — merged
  - **Pt 3 (this): schema, config + bucket-fit moves and misnamed layered tests**
  - Pt 4 (new ticket): follower, stepup, ingest

28 renames in this slice. Class names, method names, and header comments inside each file are updated to match the new filename.

Also folds in in misnamed layered tests scattered in other buckets:
- test_cursor_random04 -> cursor21 (next_random on layered table)
- test_cc11 -> checkpoint16 (checkpoint cleanup on follower with page_delta)
- test_timestamp30 -> schema09 (disaggregated schema epoch in checkpoint)
- test_prepare45 -> prepare09 (prepared txns with follower step-up)