### PR TITLE
WT-15058 Fix layered cursors read committed isolation

### DIFF
--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -1624,11 +1624,7 @@ __wt_btcur_modify(WT_CURSOR_BTREE *cbt, WT_MODIFY *entries, int nentries)
      * time and the failure is unlikely to be detected. Require explicit transactions for modify
      * operations.
      */
-    if (session->txn->isolation != WT_ISO_SNAPSHOT)
-        WT_ERR_MSG(
-          session, ENOTSUP, "not supported in read-committed or read-uncommitted transactions");
-    if (F_ISSET(session->txn, WT_TXN_AUTOCOMMIT))
-        WT_ERR_MSG(session, ENOTSUP, "not supported in implicit transactions");
+    WT_ERR(__cursor_check_modify_txn_mode(session));
 
     if (!F_ISSET(cursor, WT_CURSTD_KEY_INT) || !F_ISSET(cursor, WT_CURSTD_VALUE_INT))
         WT_ERR(__wt_btcur_search(cbt));

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -137,7 +137,7 @@ __clayered_assert_stable_mode(WT_CURSOR_LAYERED *clayered)
 /* __clayered_enter() local flags. */
 #define CLAYERED_ENTER_SKIP_STABLE 0x1u /* Follower writing without reading stable. */
 #define CLAYERED_ENTER_ITERATION 0x2u   /* Cursor is performing iteration. */
-#define CLAYERED_ENTER_RESET 0x4u       /* Reset constituent cursors if needed. */
+#define CLAYERED_ENTER_RC_RESET 0x4u    /* Reset cursor for read-committed isolation. */
 #define CLAYERED_ENTER_ROLE_CHANGE 0x8u /* Leader/follower role changed since last access. */
 
 /*
@@ -180,8 +180,9 @@ __clayered_enter_flags(WT_CLAYERED_OP *op)
 
     flags = 0;
 
-    if (op->mode == WT_CLAYERED_MODE_SEARCH)
-        LF_SET(CLAYERED_ENTER_RESET);
+    if (op->mode == WT_CLAYERED_MODE_SEARCH || op->mode == WT_CLAYERED_MODE_LARGEST_KEY ||
+      op->mode == WT_CLAYERED_MODE_RANDOM)
+        LF_SET(CLAYERED_ENTER_RC_RESET);
     if (op->mode == WT_CLAYERED_MODE_ITERATE || op->mode == WT_CLAYERED_MODE_RANDOM)
         LF_SET(CLAYERED_ENTER_ITERATION);
     /* Follower overwrite writes update the ingest table without accessing the stable table. */
@@ -209,6 +210,65 @@ __clayered_op_init_finish(WT_CLAYERED_OP *op)
 }
 
 /*
+ * __clayered_read_committed_snapshot_reset --
+ *     Reset constituent cursors before a read operation under read-committed isolation.
+ *
+ * Under read-committed, the snapshot is released when the active cursor count drops to zero. File
+ *     cursors achieve this naturally by resetting a cursor where needed (for search, and write on
+ *     the retry path), which drives the count to zero and releases the snapshot before taking a
+ *     fresh one for the new operation.
+ *
+ * Layered cursors hold an extra active-cursor reference that prevents constituent resets from
+ *     driving the count to zero on their own. We therefore reset the constituent cursors here,
+ *     before that extra reference is added, so the count can reach zero and the old snapshot is
+ *     released before the read begins.
+ */
+static WT_INLINE int
+__clayered_read_committed_snapshot_reset(WT_CURSOR_LAYERED *clayered)
+{
+    WT_RET(__wt_cursor_localkey(&clayered->iface));
+    WT_RET(__cursor_localvalue(&clayered->iface));
+    WT_RET(__clayered_reset_cursors(clayered, false));
+    return (0);
+}
+
+/*
+ * __clayered_cursor_enter --
+ *     Every time we enter a layered cursor API, we explicitly increase the number of active cursors
+ *     and then explicitly decrease it at the end to avoid the number of active cursors going to
+ *     zero in the middle of a layered cursor operation in case we close/reset both constituents
+ *     there.
+ *
+ * At the same time, the number of active cursors after exiting a layered cursor API is still
+ *     determined by the active state of its constituent cursors.
+ *
+ * Unlike `__cursor_enter`, this does not trigger the eviction check, which won't be triggered for
+ *     underlying cursors too because of an extra reference. That's fine - eviction at the
+ *     transaction level should be sufficient.
+ */
+static WT_INLINE void
+__clayered_cursor_enter(WT_CURSOR_LAYERED *clayered)
+{
+    if (!F_ISSET(clayered, WT_CLAYERED_ACTIVE)) {
+        ++CUR2S(clayered)->ncursors;
+        F_SET(clayered, WT_CLAYERED_ACTIVE);
+    }
+}
+
+/*
+ * __clayered_cursor_leave --
+ *     Deactivate a layered cursor in the session's cursor count.
+ */
+static WT_INLINE void
+__clayered_cursor_leave(WT_CURSOR_LAYERED *clayered)
+{
+    if (F_ISSET(clayered, WT_CLAYERED_ACTIVE)) {
+        --CUR2S(clayered)->ncursors;
+        F_CLR(clayered, WT_CLAYERED_ACTIVE);
+    }
+}
+
+/*
  * __clayered_enter --
  *     Start an operation on a layered cursor.
  */
@@ -226,17 +286,8 @@ __clayered_enter(WT_CURSOR_LAYERED *clayered, WT_CLAYERED_OP_MODE mode, WT_CLAYE
           "All the cursors should be left unpositioned before changing the role.");
     }
 
-    /*
-     * FIXME-WT-15058: When inside a read committed isolation, the file cursor code expects to
-     * release the snapshot when the count of active cursors is zero. Reset the constituent cursors
-     * to adhere to that behavior. Ideally we should not be changing the active cursors counter
-     * outside of the file cursor code.
-     */
-    if (LF_ISSET(CLAYERED_ENTER_RESET) &&
-      __wt_txn_read_committed_should_release_snapshot(session)) {
-        WT_ASSERT(session, !F_ISSET(&clayered->iface, WT_CURSTD_KEY_INT | WT_CURSTD_VALUE_INT));
-        WT_RET(__clayered_reset_cursors(clayered, false));
-    }
+    if (LF_ISSET(CLAYERED_ENTER_RC_RESET) && __wt_txn_read_committed_snapshot_mode(session))
+        WT_RET(__clayered_read_committed_snapshot_reset(clayered));
 
     /* Manage the ingest cursor: a follower opens it on first use; the leader keeps it closed. */
     WT_RET(__clayered_update_ingest(clayered, flags));
@@ -249,35 +300,9 @@ __clayered_enter(WT_CURSOR_LAYERED *clayered, WT_CLAYERED_OP_MODE mode, WT_CLAYE
 
     __clayered_op_init_finish(op);
 
-    if (!F_ISSET(clayered, WT_CLAYERED_ACTIVE)) {
-        /*
-         * Opening this layered cursor has opened a number of btree cursors, ensure other code
-         * doesn't think this is the first cursor in a session.
-         */
-        ++session->ncursors;
-        WT_RET(__cursor_enter(session));
-        F_SET(clayered, WT_CLAYERED_ACTIVE);
-    }
+    __clayered_cursor_enter(clayered);
 
     return (0);
-}
-
-/*
- * __clayered_leave --
- *     Finish an operation on a layered cursor.
- */
-static void
-__clayered_leave(WT_CURSOR_LAYERED *clayered)
-{
-    WT_SESSION_IMPL *session;
-
-    session = CUR2S(clayered);
-
-    if (F_ISSET(clayered, WT_CLAYERED_ACTIVE)) {
-        --session->ncursors;
-        __cursor_leave(session);
-        F_CLR(clayered, WT_CLAYERED_ACTIVE);
-    }
 }
 
 /*
@@ -1186,9 +1211,12 @@ __clayered_iterate_constituents(WT_CLAYERED_OP *op, uint32_t iter_flag)
         c_ingest = NULL;
 
     /*
-     * FIXME-WT-15058: Both cursors are expected to be initialized, but we currently have an issue
-     * where a cursor open operation can return WT_NOTFOUND for the stable table. Until this is
-     * resolved, it is simpler to handle all the different cases here.
+     * One of the constituents may not be open when cursor operations are performed. For the stable
+     * table, we do not open it on a follower until we pick up a checkpoint. For the ingest table,
+     * we currently always open it, but that is more of an implementation detail than a design
+     * decision.
+     *
+     * Given that, it is safer to handle both cases where only one constituent is open.
      */
     WT_ASSERT(session, c_stable != NULL || c_ingest != NULL);
     if (c_ingest == NULL || c_stable == NULL) {
@@ -1345,7 +1373,7 @@ __clayered_iterate(WT_CURSOR_LAYERED *clayered, uint32_t iter_flag)
 err:
     if (ret != 0)
         F_CLR(iface, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
-    __clayered_leave(clayered);
+    __clayered_cursor_leave(clayered);
     return (ret);
 }
 
@@ -1809,7 +1837,7 @@ __clayered_search(WT_CURSOR *cursor)
     WT_STAT_CLAYERED_READ_CONSTITUENT_INCR(session, clayered, layered_curs_search);
 
 err:
-    __clayered_leave(clayered);
+    __clayered_cursor_leave(clayered);
     if (ret == 0) {
         __clayered_deleted_decode(&cursor->value);
         F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
@@ -2089,7 +2117,7 @@ __clayered_search_near(WT_CURSOR *cursor, int *exactp)
     WT_ITEM_SET(cursor->value, clayered->current_cursor->value);
 
 err:
-    __clayered_leave(clayered);
+    __clayered_cursor_leave(clayered);
     if (ret == 0) {
         __clayered_deleted_decode(&cursor->value);
         F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
@@ -2460,7 +2488,7 @@ __clayered_insert(WT_CURSOR *cursor)
     WT_STAT_CONN_DSRC_INCR(session, layered_curs_insert);
 err:
     __wt_scr_free(session, &buf);
-    __clayered_leave(clayered);
+    __clayered_cursor_leave(clayered);
     CURSOR_UPDATE_API_END(session, ret);
     return (ret);
 }
@@ -2529,7 +2557,7 @@ __clayered_update(WT_CURSOR *cursor)
 
 err:
     __wt_scr_free(session, &buf);
-    __clayered_leave(clayered);
+    __clayered_cursor_leave(clayered);
     CURSOR_UPDATE_API_END(session, ret);
     return (ret);
 }
@@ -2587,7 +2615,7 @@ __clayered_remove(WT_CURSOR *cursor)
     WT_STAT_CONN_DSRC_INCR(session, layered_curs_remove);
 
 err:
-    __clayered_leave(clayered);
+    __clayered_cursor_leave(clayered);
     CURSOR_UPDATE_API_END(session, ret);
     return (ret);
 }
@@ -2636,7 +2664,7 @@ __clayered_reserve(WT_CURSOR *cursor)
     WT_ERR(__clayered_put(&op, &cursor->key, NULL, WT_CLAYERED_PUT_RESERVE));
 
 err:
-    __clayered_leave(clayered);
+    __clayered_cursor_leave(clayered);
     CURSOR_UPDATE_API_END(session, ret);
 
     /*
@@ -2672,7 +2700,7 @@ __clayered_largest_key(WT_CURSOR *cursor)
     F_CLR(clayered, WT_CLAYERED_ITERATE_NEXT | WT_CLAYERED_ITERATE_PREV);
     __cursor_novalue(cursor);
     WT_ERR(__cursor_copy_release(cursor));
-    WT_ERR(__clayered_enter(clayered, WT_CLAYERED_MODE_SCAN, &op));
+    WT_ERR(__clayered_enter(clayered, WT_CLAYERED_MODE_LARGEST_KEY, &op));
 
     c_ingest = op.ingest;
     c_stable = op.stable;
@@ -2721,7 +2749,7 @@ __clayered_largest_key(WT_CURSOR *cursor)
     F_SET(cursor, WT_CURSTD_KEY_EXT);
 
 err:
-    __clayered_leave(clayered);
+    __clayered_cursor_leave(clayered);
     __wt_scr_free(session, &key);
     if (ret != 0)
         WT_TRET(__clayered_reset_cursors(clayered, false));
@@ -2867,7 +2895,7 @@ __clayered_next_random(WT_CURSOR *cursor)
     WT_ITEM_SET(cursor->value, clayered->current_cursor->value);
 
 err:
-    __clayered_leave(clayered);
+    __clayered_cursor_leave(clayered);
     if (ret == 0) {
         __clayered_deleted_decode(&cursor->value);
         F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
@@ -3025,20 +3053,23 @@ __clayered_modify(WT_CURSOR *cursor, WT_MODIFY *entries, int nentries)
 
     CURSOR_API_CHECK_SYSTEM_OVERLOAD(session, ret);
 
+    /* Check for a rational modify vector count. */
+    if (nentries <= 0)
+        WT_ERR_MSG(session, EINVAL, "Illegal modify vector with %d entries", nentries);
+
+    WT_ERR(__cursor_check_modify_txn_mode(session));
+
     /*
      * Modify keeps the cursor positioned. Retain the iteration flags if we are in the middle of a
      * cursor traversal.
      */
     if (!F_ISSET(cursor, WT_CURSTD_KEY_INT))
         F_CLR(clayered, WT_CLAYERED_ITERATE_NEXT | WT_CLAYERED_ITERATE_PREV);
+
     WT_ERR(__cursor_copy_release(cursor));
     WT_ERR(__cursor_needkey(cursor));
     __cursor_novalue(cursor);
     WT_ERR(__clayered_enter(clayered, WT_CLAYERED_MODE_WRITE, &op));
-
-    /* Check for a rational modify vector count. */
-    if (nentries <= 0)
-        WT_ERR_MSG(session, EINVAL, "Illegal modify vector with %d entries", nentries);
 
     WT_ERR(__clayered_modify_int(&op, entries, nentries));
 
@@ -3069,7 +3100,7 @@ __clayered_modify(WT_CURSOR *cursor, WT_MODIFY *entries, int nentries)
     WT_STAT_CONN_DSRC_INCR(session, layered_curs_modify);
 
 err:
-    __clayered_leave(clayered);
+    __clayered_cursor_leave(clayered);
     CURSOR_UPDATE_API_END_STAT(session, ret, cursor_modify);
     return (ret);
 }

--- a/src/cursor/cur_std.c
+++ b/src/cursor/cur_std.c
@@ -1193,16 +1193,7 @@ __cursor_modify(WT_CURSOR *cursor, WT_MODIFY *entries, int nentries)
     if (nentries <= 0)
         WT_ERR_MSG(session, EINVAL, "Illegal modify vector with %d entries", nentries);
 
-    /*
-     * The underlying btree code cannot support WT_CURSOR.modify within a read-committed or
-     * read-uncommitted transaction, or outside of an explicit transaction. Disallow here as well,
-     * for consistency.
-     */
-    if (session->txn->isolation != WT_ISO_SNAPSHOT)
-        WT_ERR_MSG(
-          session, ENOTSUP, "not supported in read-committed or read-uncommitted transactions");
-    if (F_ISSET(session->txn, WT_TXN_AUTOCOMMIT))
-        WT_ERR_MSG(session, ENOTSUP, "not supported in implicit transactions");
+    WT_ERR(__cursor_check_modify_txn_mode(session));
 
     WT_ERR(__cursor_checkkey(cursor));
 

--- a/src/include/cursor.h
+++ b/src/include/cursor.h
@@ -560,7 +560,7 @@ typedef enum {                       /* maps 1:1 onto the API methods */
     WT_CLAYERED_MODE_SEARCH,         /* search, search_near */
     WT_CLAYERED_MODE_ITERATE,        /* next, prev */
     WT_CLAYERED_MODE_RANDOM,         /* next_random */
-    WT_CLAYERED_MODE_SCAN,           /* largest_key */
+    WT_CLAYERED_MODE_LARGEST_KEY,    /* largest_key */
     WT_CLAYERED_MODE_WRITE,          /* remove, reserve, modify; non-overwrite insert/update */
     WT_CLAYERED_MODE_WRITE_OVERWRITE /* overwrite insert/update */
 } WT_CLAYERED_OP_MODE;

--- a/src/include/cursor_inline.h
+++ b/src/include/cursor_inline.h
@@ -135,6 +135,22 @@ __cursor_checkvalue(WT_CURSOR *cursor)
 }
 
 /*
+ * __cursor_check_modify_txn_mode --
+ *     Modify does not support any mode except snapshot isolation with an explicit transaction.
+ */
+static WT_INLINE int
+__cursor_check_modify_txn_mode(WT_SESSION_IMPL *session)
+{
+    if (session->txn->isolation != WT_ISO_SNAPSHOT)
+        WT_RET_MSG(
+          session, ENOTSUP, "not supported in read-committed or read-uncommitted transactions");
+    if (F_ISSET(session->txn, WT_TXN_AUTOCOMMIT))
+        WT_RET_MSG(session, ENOTSUP, "not supported in implicit transactions");
+
+    return (0);
+}
+
+/*
  * __wt_cursor_localkey --
  *     If the key points into the tree, get a local copy.
  */
@@ -275,8 +291,9 @@ __cursor_reset(WT_CURSOR_BTREE *cbt)
      * When the count of active cursors in the session goes to zero, there are no active cursors,
      * and we can release any snapshot we're holding for read committed isolation.
      */
-    if (session->ncursors == 0 && !WT_READING_CHECKPOINT(session))
-        __wt_txn_read_last(session);
+    if (session->ncursors == 0 && !WT_READING_CHECKPOINT(session) &&
+      __wt_txn_read_committed_snapshot_mode(session))
+        __wt_txn_release_snapshot(session);
 
     /* If we're not holding a cursor reference, we're done. */
     if (cbt->ref == NULL)

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2094,7 +2094,7 @@ static WT_INLINE bool __wt_txn_has_newest_and_visible_all(WT_SESSION_IMPL *sessi
   wt_timestamp_t timestamp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wt_txn_log_op_check(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-static WT_INLINE bool __wt_txn_read_committed_should_release_snapshot(WT_SESSION_IMPL *session)
+static WT_INLINE bool __wt_txn_read_committed_snapshot_mode(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wt_txn_snap_min_visible(
   WT_SESSION_IMPL *session, uint64_t id, wt_timestamp_t timestamp, wt_timestamp_t durable_timestamp)
@@ -2645,7 +2645,6 @@ static WT_INLINE void __wt_txn_op_delete_apply_prepare_state(
 static WT_INLINE void __wt_txn_op_set_recno(WT_SESSION_IMPL *session, uint64_t recno);
 static WT_INLINE void __wt_txn_pinned_timestamp(
   WT_SESSION_IMPL *session, wt_timestamp_t *pinned_tsp);
-static WT_INLINE void __wt_txn_read_last(WT_SESSION_IMPL *session);
 static WT_INLINE void __wt_txn_unmodify(WT_SESSION_IMPL *session);
 static WT_INLINE void __wt_upd_value_assign(WT_UPDATE_VALUE *upd_value, WT_UPDATE *upd);
 static WT_INLINE void __wt_upd_value_clear(WT_UPDATE_VALUE *upd_value);

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -2348,39 +2348,18 @@ __wt_txn_modify_check(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE 
 }
 
 /*
- * __wt_txn_read_last --
- *     Called when the last page for a session is released.
+ * __wt_txn_read_committed_snapshot_mode --
+ *     Check if we can release the snap_min ID we put in the global table.
  */
-static WT_INLINE void
-__wt_txn_read_last(WT_SESSION_IMPL *session)
+static WT_INLINE bool
+__wt_txn_read_committed_snapshot_mode(WT_SESSION_IMPL *session)
 {
-    WT_TXN *txn;
-
-    txn = session->txn;
+    WT_TXN *txn = session->txn;
 
     /*
-     * Release the snap_min ID we put in the global table.
-     *
      * If the isolation has been temporarily forced, don't touch the snapshot here: it will be
      * restored by WT_WITH_TXN_ISOLATION.
      */
-    if ((!F_ISSET(txn, WT_TXN_RUNNING) || txn->isolation != WT_ISO_SNAPSHOT) &&
-      txn->forced_iso == 0)
-        __wt_txn_release_snapshot(session);
-}
-
-/*
- * __wt_txn_read_committed_should_release_snapshot --
- *     Called to check whether we want to release our snapshot through calling WT_CURSOR::reset().
- */
-static WT_INLINE bool
-__wt_txn_read_committed_should_release_snapshot(WT_SESSION_IMPL *session)
-{
-    WT_TXN *txn;
-
-    txn = session->txn;
-
-    /* Check if we can release the snap_min ID we put in the global table. */
     return (
       (!F_ISSET(txn, WT_TXN_RUNNING) || txn->isolation != WT_ISO_SNAPSHOT) && txn->forced_iso == 0);
 }

--- a/test/suite/test_cursor_read_committed.py
+++ b/test/suite/test_cursor_read_committed.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# test_cursor_read_committed.py
+#
+# RC snapshot contract: search, search_near, next_random must refresh the
+# snapshot on each call; next, prev must hold it across the scan.
+
+import wiredtiger, wttest
+
+class test_cursor_read_committed(wttest.WiredTigerTestCase):
+
+    uri = 'table:test_cursor_read_committed'
+
+    def conn_config(self):
+        return 'statistics=(all)'
+
+    def setUp(self):
+        super().setUp()
+        self.session.create(self.uri, 'key_format=S,value_format=S')
+        self.writer = self.conn.open_session('')
+        self.reader = self.conn.open_session('')
+
+    def tearDown(self):
+        self.writer.close()
+        self.reader.close()
+        super().tearDown()
+
+    def _write(self, key, value):
+        wc = self.writer.open_cursor(self.uri)
+        wc[key] = value
+        wc.close()
+
+    def _search_refreshes_rc_snapshot(self, op):
+        self._write('ka', 'va')
+        self.reader.begin_transaction('isolation=read-committed')
+        rc = self.reader.open_cursor(self.uri)
+        rc.set_key('ka')
+        self.assertEqual(op(rc), 0)
+        self._write('kb', 'vb')
+        rc.set_key('kb')
+        self.assertEqual(op(rc), 0, "S1 not released")
+        rc.close()
+        self.reader.commit_transaction()
+
+    def test_search_refreshes_rc_snapshot(self):
+        self._search_refreshes_rc_snapshot(lambda rc: rc.search())
+
+    def test_search_near_refreshes_rc_snapshot(self):
+        self._search_refreshes_rc_snapshot(lambda rc: rc.search_near())
+
+    def test_largest_key_refreshes_rc_snapshot(self):
+        # largest_key reads ignoring the snapshot, so its own key cannot witness
+        # the refresh. Instead take a snapshot with search(), commit underneath,
+        # then assert largest_key released it: a following next() is a held read
+        # that reuses the session snapshot, so it must see the post-search value.
+        self._write('ka', 'va')
+        self._write('kc', 'vc')
+        self.reader.begin_transaction('isolation=read-committed')
+        rc = self.reader.open_cursor(self.uri)
+        rc.set_key('ka')
+        self.assertEqual(rc.search(), 0)
+        self._write('ka', 'va2')
+        self.assertEqual(rc.largest_key(), 0)
+        self.assertEqual(rc.get_key(), 'kc')
+        self.assertEqual(rc.next(), 0)
+        self.assertEqual(rc.get_key(), 'ka')
+        self.assertEqual(rc.get_value(), 'va2',
+            "largest_key did not release the snapshot: next() still sees 'va'")
+        rc.close()
+        self.reader.commit_transaction()
+
+    def _scan_holds_snapshot(self, forward):
+        self._write('key_a', 'va')
+        self._write('key_c', 'vc')
+        self.reader.begin_transaction('isolation=read-committed')
+        rc = self.reader.open_cursor(self.uri)
+        step = rc.next if forward else rc.prev
+        first, second = ('key_a', 'key_c') if forward else ('key_c', 'key_a')
+        self.assertEqual(step(), 0)
+        self.assertEqual(rc.get_key(), first)
+        self._write('key_b', 'vb')
+        self.assertEqual(step(), 0)
+        self.assertEqual(rc.get_key(), second, "snapshot released mid-scan: 'key_b' became visible")
+        self.assertEqual(step(), wiredtiger.WT_NOTFOUND)
+        rc.close()
+        self.reader.commit_transaction()
+
+    def test_next_holds_rc_snapshot(self): self._scan_holds_snapshot(True)
+    def test_prev_holds_rc_snapshot(self): self._scan_holds_snapshot(False)
+
+    def test_next_random_refreshes_rc_snapshot(self):
+        # Single key; snapshot refresh detected by value.
+        self._write('k1', 'v1')
+        self.reader.begin_transaction('isolation=read-committed')
+        rc = self.reader.open_cursor(self.uri, None, 'next_random=true')
+        self.assertEqual(rc.next(), 0)
+        self.assertEqual(rc.get_value(), 'v1')
+        self._write('k1', 'v2')
+        self.assertEqual(rc.next(), 0)
+        self.assertEqual(rc.get_value(), 'v2', "S1 not released; still seeing v1")
+        rc.close()
+        self.reader.commit_transaction()


### PR DESCRIPTION
This PR completely aligns layered cursor behaviour with btree cursors for read-committed isolation. Before this PR, we were resetting constituent cursors to release a snapshot only for `search()` and `search_near()`, while btree cursors do this for all APIs except `next()`/`prev()`. It turned out that all the write commands are not allowed to operate in a read-committed mode, so the changes we do for them are only for consistency.

We also removed the unnecessary manual ncursors changes since the same logic is already handled inside `__cursor_enter()` / `__cursor_leave()`.

The resulting logic is now the following: every layered cursor API performs an extra `__cursor_enter()` / `__cursor_leave()` pair to avoid situations where the number of active cursors temporarily drops to 0 in the middle of an operation when both constituents are closed/reset. At the same time, the number of active cursors after exiting a layered cursor API is still determined by the active state of its constituent cursors.

Additionally, we now explicitly fail `modify()` when it is used outside of snapshot isolation with explicit transactions, to make it clear that this API should not participate in this logic.