### PR TITLE
WT-17673 Refactor __wti_rec_col_var to reduce cyclomatic complexity (refactor-bot)

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -989,6 +989,7 @@ exc
 exe
 execfn
 existp
+extendedp
 extern
 extlist
 extlists

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -10,7 +10,6 @@
 #include "reconcile_private.h"
 #include "reconcile_inline.h"
 
-
 /*
  * Per-iteration state built while processing each entry in the variable-length column-store
  * reconciliation loops.
@@ -332,6 +331,7 @@ __rec_col_var_helper(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_SALVAGE_COOK
 
     return (0);
 }
+
 /*
  * __rec_col_var_upd_apply --
  *     Apply a selected update to produce the current-record state. The caller sets cbt->slot to the
@@ -637,6 +637,118 @@ err:
 }
 
 /*
+ * __rec_col_var_append_loop --
+ *     Walk the column-store append list, building per-record state and accumulating RLE runs in
+ *     *st.
+ */
+static int
+__rec_col_var_append_loop(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page,
+  WT_SALVAGE_COOKIE *salvage, struct __wti_col_var_state *st)
+{
+    WT_CURSOR_BTREE *cbt;
+    WT_INSERT *ins;
+    WTI_UPDATE_SELECT upd_select;
+    struct __wti_col_var_cur cur;
+    WT_UPDATE *upd;
+    uint64_t n, skip;
+    bool extended;
+
+    cbt = &r->update_modify_cbt;
+
+    for (ins = WT_SKIP_FIRST(WT_COL_APPEND(page));; ins = WT_SKIP_NEXT(ins)) {
+        if (ins == NULL)
+            /*
+             * Stop when we reach the end of the append list. There might be a gap between that and
+             * the beginning of the next page. (Imagine record 98 is written, then record 100 is
+             * written, then the page splits and record 100 moves to another page. There is no entry
+             * for record 99 and we don't write one out.) In VLCS we (now) tolerate such gaps as
+             * they are, though likely smaller, equivalent to gaps created by fast-truncate.
+             */
+            break;
+        WT_RET(__wti_rec_upd_select(session, r, ins, NULL, NULL, &upd_select));
+        upd = upd_select.upd;
+        n = WT_INSERT_RECNO(ins);
+
+        while (st->src_recno <= n) {
+            WT_CLEAR(cur);
+            cur.update_no_copy = true;
+            cur.repeat_count = 1;
+
+            if (st->src_recno < n) {
+                cur.deleted = true;
+                WT_TIME_WINDOW_INIT(&cur.tw);
+                if (st->last_deleted) {
+                    /* The time window for deleted keys must be empty. */
+                    WT_ASSERT(session, WT_TIME_WINDOW_IS_EMPTY(&st->last_tw));
+                    /*
+                     * The record adjustment is decremented by one so we can naturally fall into the
+                     * RLE accounting below, where we increment rle by one, then continue in the
+                     * outer loop, where we increment src_recno by one.
+                     */
+                    skip = (n - st->src_recno) - 1;
+                    st->rle += skip;
+                    st->src_recno += skip;
+                }
+            } else if (upd == NULL) {
+                /* The updates on the key are all uncommitted so we write a deleted key to disk. */
+                cur.deleted = true;
+                WT_TIME_WINDOW_INIT(&cur.tw);
+            } else {
+                cbt->slot = UINT32_MAX;
+                WT_RET(__rec_col_var_upd_apply(session, r, cbt, &upd_select, st->src_recno, &cur));
+            }
+
+            /*
+             * Handle RLE accounting and comparisons -- see comment above, this code fragment does
+             * the same thing.
+             */
+            WT_RET(__rec_col_var_rle_check(session, r, salvage, st, &cur, &extended));
+            if (extended)
+                goto next;
+
+            /*
+             * Swap the current/last state. We can't simply assign the data values into the last
+             * buffer because they may be a temporary copy built from a chain of modified updates
+             * and creating the next record will overwrite that memory. Check, we'd like to avoid
+             * the copy. If data was taken from an update structure, we can just use the pointers,
+             * they're not moving.
+             */
+            if (!cur.deleted) {
+                if (cur.update_no_copy) {
+                    st->last_value->data = cur.data;
+                    st->last_value->size = cur.size;
+                } else
+                    WT_RET(__wt_buf_set(session, st->last_value, cur.data, cur.size));
+            }
+
+            /* Ready for the next loop, reset the RLE counter. */
+            WT_TIME_WINDOW_COPY(&st->last_tw, &cur.tw);
+            st->last_deleted = cur.deleted;
+            st->last_dictionary = cur.dictionary;
+            st->rle = 1;
+
+            /*
+             * Move to the next record. It's not a simple increment because if it's the maximum
+             * record, incrementing it wraps to 0 and this turns into an infinite loop.
+             */
+next:
+            if (st->src_recno == UINT64_MAX)
+                break;
+            ++st->src_recno;
+        }
+
+        /*
+         * Execute this loop once without an insert item to catch any missing records due to a
+         * split, then quit.
+         */
+        if (ins == NULL)
+            break;
+    }
+
+    return (0);
+}
+
+/*
  * __wti_rec_col_var --
  *     Reconcile a variable-width column-store leaf page.
  */
@@ -646,22 +758,14 @@ __wti_rec_col_var(
 {
     struct __wti_col_var_state st;
     WT_BTREE *btree;
-    WT_CURSOR_BTREE *cbt;
-    WT_INSERT *ins;
     WT_PAGE *page;
     WT_TIME_WINDOW clear_tw;
-    WT_UPDATE *upd;
-    WTI_UPDATE_SELECT upd_select;
-    struct __wti_col_var_cur cur;
-    uint64_t n, skip;
-    bool extended;
 
     btree = S2BT(session);
     page = pageref->page;
     WT_TIME_WINDOW_INIT(&clear_tw);
 
     r->update_modify_cbt.iface.session = (WT_SESSION *)session;
-    cbt = &r->update_modify_cbt;
 
     /* Set the "last" values to cause failure if they're not set before use. */
     WT_CLEAR(st);
@@ -706,97 +810,7 @@ __wti_rec_col_var(
     st.src_recno = r->recno + st.rle;
 
     WT_RET(__rec_col_var_page_loop(session, r, page, salvage, &st));
-
-    /* Walk any append list. */
-    for (ins = WT_SKIP_FIRST(WT_COL_APPEND(page));; ins = WT_SKIP_NEXT(ins)) {
-        if (ins == NULL)
-            /*
-             * Stop when we reach the end of the append list. There might be a gap between that and
-             * the beginning of the next page. (Imagine record 98 is written, then record 100 is
-             * written, then the page splits and record 100 moves to another page. There is no entry
-             * for record 99 and we don't write one out.) In VLCS we (now) tolerate such gaps as
-             * they are, though likely smaller, equivalent to gaps created by fast-truncate.
-             */
-            break;
-        WT_RET(__wti_rec_upd_select(session, r, ins, NULL, NULL, &upd_select));
-        upd = upd_select.upd;
-        n = WT_INSERT_RECNO(ins);
-
-        while (st.src_recno <= n) {
-            WT_CLEAR(cur);
-            cur.update_no_copy = true;
-            cur.repeat_count = 1;
-
-            if (st.src_recno < n) {
-                cur.deleted = true;
-                WT_TIME_WINDOW_INIT(&cur.tw);
-                if (st.last_deleted) {
-                    /* The time window for deleted keys must be empty. */
-                    WT_ASSERT(session, WT_TIME_WINDOW_IS_EMPTY(&st.last_tw));
-                    /*
-                     * The record adjustment is decremented by one so we can naturally fall into the
-                     * RLE accounting below, where we increment rle by one, then continue in the
-                     * outer loop, where we increment src_recno by one.
-                     */
-                    skip = (n - st.src_recno) - 1;
-                    st.rle += skip;
-                    st.src_recno += skip;
-                }
-            } else if (upd == NULL) {
-                /* The updates on the key are all uncommitted so we write a deleted key to disk. */
-                cur.deleted = true;
-                WT_TIME_WINDOW_INIT(&cur.tw);
-            } else {
-                cbt->slot = UINT32_MAX;
-                WT_RET(__rec_col_var_upd_apply(session, r, cbt, &upd_select, st.src_recno, &cur));
-            }
-
-            /*
-             * Handle RLE accounting and comparisons -- see comment above, this code fragment does
-             * the same thing.
-             */
-            WT_RET(__rec_col_var_rle_check(session, r, salvage, &st, &cur, &extended));
-            if (extended)
-                goto next;
-
-            /*
-             * Swap the current/last state. We can't simply assign the data values into the last
-             * buffer because they may be a temporary copy built from a chain of modified updates
-             * and creating the next record will overwrite that memory. Check, we'd like to avoid
-             * the copy. If data was taken from an update structure, we can just use the pointers,
-             * they're not moving.
-             */
-            if (!cur.deleted) {
-                if (cur.update_no_copy) {
-                    st.last_value->data = cur.data;
-                    st.last_value->size = cur.size;
-                } else
-                    WT_RET(__wt_buf_set(session, st.last_value, cur.data, cur.size));
-            }
-
-            /* Ready for the next loop, reset the RLE counter. */
-            WT_TIME_WINDOW_COPY(&st.last_tw, &cur.tw);
-            st.last_deleted = cur.deleted;
-            st.last_dictionary = cur.dictionary;
-            st.rle = 1;
-
-            /*
-             * Move to the next record. It's not a simple increment because if it's the maximum
-             * record, incrementing it wraps to 0 and this turns into an infinite loop.
-             */
-next:
-            if (st.src_recno == UINT64_MAX)
-                break;
-            ++st.src_recno;
-        }
-
-        /*
-         * Execute this loop once without an insert item to catch any missing records due to a
-         * split, then quit.
-         */
-        if (ins == NULL)
-            break;
-    }
+    WT_RET(__rec_col_var_append_loop(session, r, page, salvage, &st));
 
     /* If we were tracking a record, write it. */
     if (st.rle != 0) {

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -410,12 +410,13 @@ __rec_col_var_rle_check(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_SALVAGE_C
 }
 
 /*
- * __wti_rec_col_var --
- *     Reconcile a variable-width column-store leaf page.
+ * __rec_col_var_page_loop --
+ *     Walk the on-page variable-length column-store entries, building per-record state and
+ *     accumulating RLE runs in *st.
  */
-int
-__wti_rec_col_var(
-  WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_REF *pageref, WT_SALVAGE_COOKIE *salvage)
+static int
+__rec_col_var_page_loop(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page,
+  WT_SALVAGE_COOKIE *salvage, struct __wti_col_var_state *st)
 {
     enum { OVFL_IGNORE, OVFL_UNUSED, OVFL_USED } ovfl_state;
     WT_BTREE *btree;
@@ -427,71 +428,22 @@ __wti_rec_col_var(
     WT_DECL_ITEM(orig);
     WT_DECL_RET;
     WT_INSERT *ins;
-    WT_PAGE *page;
-    WT_TIME_WINDOW clear_tw;
-    WT_UPDATE *upd;
     WTI_UPDATE_SELECT upd_select;
     struct __wti_col_var_cur cur;
-    struct __wti_col_var_state st;
-    uint64_t n, nrepeat, skip;
+    WT_UPDATE *upd;
+    uint64_t n, nrepeat;
     uint32_t i;
     bool extended, orig_deleted, orig_stale, ovfl_used;
+
+    orig_stale = false;
 
     btree = S2BT(session);
     conn = S2C(session);
     vpack = &_vpack;
-    page = pageref->page;
-    WT_TIME_WINDOW_INIT(&clear_tw);
-    orig_stale = false;
-
     cbt = &r->update_modify_cbt;
-    cbt->iface.session = (WT_SESSION *)session;
 
-    /* Set the "last" values to cause failure if they're not set. */
-    WT_CLEAR(st);
-    st.last_value = r->last;
-    WT_TIME_WINDOW_INIT(&st.last_tw);
+    WT_RET(__wt_scr_alloc(session, 0, &orig));
 
-    WT_RET(__wti_rec_split_init(session, r, pageref->ref_recno, btree->maxleafpage_precomp));
-
-    WT_ERR(__wt_scr_alloc(session, 0, &orig));
-
-    /*
-     * The salvage code may be calling us to reconcile a page where there were missing records in
-     * the column-store name space. If taking the first record from on the page, it might be a
-     * deleted record, so we have to give the RLE code a chance to figure that out. Else, if not
-     * taking the first record from the page, write a single element representing the missing
-     * records onto a new page. (Don't pass the salvage cookie to our helper function in this case,
-     * we're handling one of the salvage cookie fields on our own, and we don't need the helper
-     * function's assistance.)
-     */
-    if (salvage != NULL && salvage->missing != 0) {
-        if (salvage->skip == 0) {
-            st.rle = salvage->missing;
-            st.last_deleted = true;
-
-            /*
-             * Correct the number of records we're going to "take", pretending the missing records
-             * were on the page.
-             */
-            salvage->take += salvage->missing;
-        } else
-            WT_ERR(__rec_col_var_helper(
-              session, r, NULL, NULL, &clear_tw, salvage->missing, true, false, NULL));
-    }
-
-    /*
-     * We track two data items through this loop: the previous (last) item and the current item: if
-     * the last item is the same as the current item, we increment the RLE count for the last item;
-     * if the last item is different from the current item, we write the last item onto the page,
-     * and replace it with the current item. The r->recno counter tracks records written to the
-     * page, and is incremented by the helper function immediately after writing records to the
-     * page. The record number of our source record, that is, the current item, is maintained in
-     * src_recno.
-     */
-    st.src_recno = r->recno + st.rle;
-
-    /* For each entry in the in-memory page... */
     WT_COL_FOREACH (page, cip, i) {
         ovfl_state = OVFL_IGNORE;
         cell = WT_COL_PTR(page, cip);
@@ -511,9 +463,9 @@ __wti_rec_col_var(
         }
 
 record_loop:
-        for (n = 0; n < nrepeat; n += cur.repeat_count, st.src_recno += cur.repeat_count) {
+        for (n = 0; n < nrepeat; n += cur.repeat_count, st->src_recno += cur.repeat_count) {
             upd = NULL;
-            if (ins != NULL && WT_INSERT_RECNO(ins) == st.src_recno) {
+            if (ins != NULL && WT_INSERT_RECNO(ins) == st->src_recno) {
                 WT_ERR(__wti_rec_upd_select(session, r, ins, NULL, vpack, &upd_select));
                 upd = upd_select.upd;
                 ins = WT_SKIP_NEXT(ins);
@@ -544,7 +496,7 @@ record_loop:
                 if (ins == NULL)
                     cur.repeat_count = nrepeat - n;
                 else
-                    cur.repeat_count = WT_INSERT_RECNO(ins) - st.src_recno;
+                    cur.repeat_count = WT_INSERT_RECNO(ins) - st->src_recno;
 
                 cur.deleted = orig_deleted;
                 if (cur.deleted) {
@@ -584,16 +536,16 @@ record_loop:
                      * An as-yet-unused overflow item: emit the pending run, write this cell
                      * directly once, then skip the normal compare/swap path.
                      */
-                    if (st.rle != 0) {
-                        WT_ERR(__rec_col_var_helper(session, r, salvage, st.last_value,
-                          &st.last_tw, st.rle, st.last_deleted, st.last_dictionary, NULL));
-                        st.rle = 0;
+                    if (st->rle != 0) {
+                        WT_ERR(__rec_col_var_helper(session, r, salvage, st->last_value,
+                          &st->last_tw, st->rle, st->last_deleted, st->last_dictionary, NULL));
+                        st->rle = 0;
                     }
-                    st.last_value->data = vpack->data;
-                    st.last_value->size = vpack->size;
-                    WT_ERR(__rec_col_var_helper(session, r, salvage, st.last_value, &cur.tw,
-                      cur.repeat_count, false, st.last_dictionary, &ovfl_used));
-                    st.wrote_real_values = true;
+                    st->last_value->data = vpack->data;
+                    st->last_value->size = vpack->size;
+                    WT_ERR(__rec_col_var_helper(session, r, salvage, st->last_value, &cur.tw,
+                      cur.repeat_count, false, st->last_dictionary, &ovfl_used));
+                    st->wrote_real_values = true;
                     /*
                      * Salvage may have caused us to skip the overflow item, only update overflow
                      * items we use.
@@ -629,7 +581,7 @@ record_loop:
                 }
             } else {
                 cbt->slot = WT_COL_SLOT(page, cip);
-                WT_ERR(__rec_col_var_upd_apply(session, r, cbt, &upd_select, st.src_recno, &cur));
+                WT_ERR(__rec_col_var_upd_apply(session, r, cbt, &upd_select, st->src_recno, &cur));
                 if (cur.deleted)
                     r->key_removed_from_disk_image = true;
             }
@@ -641,7 +593,7 @@ compare:
              * swap the last and current buffers: do NOT update the starting record number, we've
              * been doing that all along.
              */
-            WT_ERR(__rec_col_var_rle_check(session, r, salvage, &st, &cur, &extended));
+            WT_ERR(__rec_col_var_rle_check(session, r, salvage, st, &cur, &extended));
             if (extended)
                 continue;
 
@@ -660,15 +612,15 @@ compare:
                  * structure, we can just use the pointers, they're not moving.
                  */
                 if (cur.data == vpack->data || cur.update_no_copy) {
-                    st.last_value->data = cur.data;
-                    st.last_value->size = cur.size;
+                    st->last_value->data = cur.data;
+                    st->last_value->size = cur.size;
                 } else
-                    WT_ERR(__wt_buf_set(session, st.last_value, cur.data, cur.size));
+                    WT_ERR(__wt_buf_set(session, st->last_value, cur.data, cur.size));
             }
-            WT_TIME_WINDOW_COPY(&st.last_tw, &cur.tw);
-            st.last_deleted = cur.deleted;
-            st.last_dictionary = cur.dictionary;
-            st.rle = cur.repeat_count;
+            WT_TIME_WINDOW_COPY(&st->last_tw, &cur.tw);
+            st->last_deleted = cur.deleted;
+            st->last_dictionary = cur.dictionary;
+            st->rle = cur.repeat_count;
         }
 
         /*
@@ -678,6 +630,82 @@ compare:
         if (ovfl_state == OVFL_UNUSED && vpack->raw != WT_CELL_VALUE_OVFL_RM)
             WT_ERR(__wt_ovfl_remove(session, page, vpack));
     }
+
+err:
+    __wt_scr_free(session, &orig);
+    return (ret);
+}
+
+/*
+ * __wti_rec_col_var --
+ *     Reconcile a variable-width column-store leaf page.
+ */
+int
+__wti_rec_col_var(
+  WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_REF *pageref, WT_SALVAGE_COOKIE *salvage)
+{
+    struct __wti_col_var_state st;
+    WT_BTREE *btree;
+    WT_CURSOR_BTREE *cbt;
+    WT_INSERT *ins;
+    WT_PAGE *page;
+    WT_TIME_WINDOW clear_tw;
+    WT_UPDATE *upd;
+    WTI_UPDATE_SELECT upd_select;
+    struct __wti_col_var_cur cur;
+    uint64_t n, skip;
+    bool extended;
+
+    btree = S2BT(session);
+    page = pageref->page;
+    WT_TIME_WINDOW_INIT(&clear_tw);
+
+    r->update_modify_cbt.iface.session = (WT_SESSION *)session;
+    cbt = &r->update_modify_cbt;
+
+    /* Set the "last" values to cause failure if they're not set before use. */
+    WT_CLEAR(st);
+    st.last_value = r->last;
+    WT_TIME_WINDOW_INIT(&st.last_tw);
+
+    WT_RET(__wti_rec_split_init(session, r, pageref->ref_recno, btree->maxleafpage_precomp));
+
+    /*
+     * The salvage code may be calling us to reconcile a page where there were missing records in
+     * the column-store name space. If taking the first record from on the page, it might be a
+     * deleted record, so we have to give the RLE code a chance to figure that out. Else, if not
+     * taking the first record from the page, write a single element representing the missing
+     * records onto a new page. (Don't pass the salvage cookie to our helper function in this case,
+     * we're handling one of the salvage cookie fields on our own, and we don't need the helper
+     * function's assistance.)
+     */
+    if (salvage != NULL && salvage->missing != 0) {
+        if (salvage->skip == 0) {
+            st.rle = salvage->missing;
+            st.last_deleted = true;
+
+            /*
+             * Correct the number of records we're going to "take", pretending the missing records
+             * were on the page.
+             */
+            salvage->take += salvage->missing;
+        } else
+            WT_RET(__rec_col_var_helper(
+              session, r, NULL, NULL, &clear_tw, salvage->missing, true, false, NULL));
+    }
+
+    /*
+     * We track two data items through this loop: the previous (last) item and the current item: if
+     * the last item is the same as the current item, we increment the RLE count for the last item;
+     * if the last item is different from the current item, we write the last item onto the page,
+     * and replace it with the current item. The r->recno counter tracks records written to the
+     * page, and is incremented by the helper function immediately after writing records to the
+     * page. The record number of our source record, that is, the current item, is maintained in
+     * src_recno.
+     */
+    st.src_recno = r->recno + st.rle;
+
+    WT_RET(__rec_col_var_page_loop(session, r, page, salvage, &st));
 
     /* Walk any append list. */
     for (ins = WT_SKIP_FIRST(WT_COL_APPEND(page));; ins = WT_SKIP_NEXT(ins)) {
@@ -690,7 +718,7 @@ compare:
              * they are, though likely smaller, equivalent to gaps created by fast-truncate.
              */
             break;
-        WT_ERR(__wti_rec_upd_select(session, r, ins, NULL, NULL, &upd_select));
+        WT_RET(__wti_rec_upd_select(session, r, ins, NULL, NULL, &upd_select));
         upd = upd_select.upd;
         n = WT_INSERT_RECNO(ins);
 
@@ -720,14 +748,14 @@ compare:
                 WT_TIME_WINDOW_INIT(&cur.tw);
             } else {
                 cbt->slot = UINT32_MAX;
-                WT_ERR(__rec_col_var_upd_apply(session, r, cbt, &upd_select, st.src_recno, &cur));
+                WT_RET(__rec_col_var_upd_apply(session, r, cbt, &upd_select, st.src_recno, &cur));
             }
 
             /*
              * Handle RLE accounting and comparisons -- see comment above, this code fragment does
              * the same thing.
              */
-            WT_ERR(__rec_col_var_rle_check(session, r, salvage, &st, &cur, &extended));
+            WT_RET(__rec_col_var_rle_check(session, r, salvage, &st, &cur, &extended));
             if (extended)
                 goto next;
 
@@ -743,7 +771,7 @@ compare:
                     st.last_value->data = cur.data;
                     st.last_value->size = cur.size;
                 } else
-                    WT_ERR(__wt_buf_set(session, st.last_value, cur.data, cur.size));
+                    WT_RET(__wt_buf_set(session, st.last_value, cur.data, cur.size));
             }
 
             /* Ready for the next loop, reset the RLE counter. */
@@ -774,7 +802,7 @@ next:
     if (st.rle != 0) {
         if (!st.last_deleted)
             st.wrote_real_values = true;
-        WT_ERR(__rec_col_var_helper(session, r, salvage, st.last_value, &st.last_tw, st.rle,
+        WT_RET(__rec_col_var_helper(session, r, salvage, st.last_value, &st.last_tw, st.rle,
           st.last_deleted, st.last_dictionary, NULL));
     }
 
@@ -802,9 +830,5 @@ next:
     }
 
     /* Write the remnant page. */
-    WT_ERR(__wti_rec_split_finish(session, r));
-
-err:
-    __wt_scr_free(session, &orig);
-    return (ret);
+    return (__wti_rec_split_finish(session, r));
 }

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -14,7 +14,7 @@
  * Per-iteration state built while processing each entry in the variable-length column-store
  * reconciliation loops.
  */
-struct __wti_col_var_cur {
+typedef struct {
     const void *data;
     uint32_t size;
     WT_TIME_WINDOW tw;
@@ -22,12 +22,13 @@ struct __wti_col_var_cur {
     bool deleted;
     bool dictionary;
     bool update_no_copy;
-};
+} COL_VAR_CUR;
 
 /*
- * State carried across all loop iterations in __wti_rec_col_var for run-length accounting.
+ * State carried across all loop iterations in variable-length column-store reconciliation for
+ * run-length accounting.
  */
-struct __wti_col_var_state {
+typedef struct {
     WT_ITEM *last_value;
     WT_TIME_WINDOW last_tw;
     bool last_deleted;
@@ -35,7 +36,7 @@ struct __wti_col_var_state {
     uint64_t rle;
     uint64_t src_recno;
     bool wrote_real_values;
-};
+} COL_VAR_STATE;
 
 /*
  * __wt_bulk_insert_var --
@@ -339,7 +340,7 @@ __rec_col_var_helper(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_SALVAGE_COOK
  */
 static int
 __rec_col_var_upd_apply(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_CURSOR_BTREE *cbt,
-  WTI_UPDATE_SELECT *upd_select, uint64_t src_recno, struct __wti_col_var_cur *cur)
+  WTI_UPDATE_SELECT *upd_select, uint64_t src_recno, COL_VAR_CUR *cur)
 {
     WT_UPDATE *upd;
 
@@ -377,13 +378,13 @@ __rec_col_var_upd_apply(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_CURSOR_BT
 }
 
 /*
- * __rec_col_var_rle_check --
- *     Compare the current entry against the accumulated run. Extend if they match and set
- *     *extendedp; otherwise emit the pending run (if any) and prepare for a new one.
+ * __rec_col_var_rle_extend --
+ *     Attempt to extend the current run by comparing against the accumulated state. Sets *extendedp
+ *     on a match; otherwise emits the pending run (if any) and prepares for a new one.
  */
 static int
-__rec_col_var_rle_check(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_SALVAGE_COOKIE *salvage,
-  struct __wti_col_var_state *st, struct __wti_col_var_cur *cur, bool *extendedp)
+__rec_col_var_rle_extend(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_SALVAGE_COOKIE *salvage,
+  COL_VAR_STATE *st, COL_VAR_CUR *cur, bool *extendedp)
 {
     *extendedp = false;
 
@@ -416,7 +417,7 @@ __rec_col_var_rle_check(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_SALVAGE_C
  */
 static int
 __rec_col_var_page_loop(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page,
-  WT_SALVAGE_COOKIE *salvage, struct __wti_col_var_state *st)
+  WT_SALVAGE_COOKIE *salvage, COL_VAR_STATE *st)
 {
     enum { OVFL_IGNORE, OVFL_UNUSED, OVFL_USED } ovfl_state;
     WT_BTREE *btree;
@@ -429,7 +430,7 @@ __rec_col_var_page_loop(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *pag
     WT_DECL_RET;
     WT_INSERT *ins;
     WTI_UPDATE_SELECT upd_select;
-    struct __wti_col_var_cur cur;
+    COL_VAR_CUR cur;
     WT_UPDATE *upd;
     uint64_t n, nrepeat;
     uint32_t i;
@@ -593,7 +594,7 @@ compare:
              * swap the last and current buffers: do NOT update the starting record number, we've
              * been doing that all along.
              */
-            WT_ERR(__rec_col_var_rle_check(session, r, salvage, st, &cur, &extended));
+            WT_ERR(__rec_col_var_rle_extend(session, r, salvage, st, &cur, &extended));
             if (extended)
                 continue;
 
@@ -643,12 +644,12 @@ err:
  */
 static int
 __rec_col_var_append_loop(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page,
-  WT_SALVAGE_COOKIE *salvage, struct __wti_col_var_state *st)
+  WT_SALVAGE_COOKIE *salvage, COL_VAR_STATE *st)
 {
     WT_CURSOR_BTREE *cbt;
     WT_INSERT *ins;
     WTI_UPDATE_SELECT upd_select;
-    struct __wti_col_var_cur cur;
+    COL_VAR_CUR cur;
     WT_UPDATE *upd;
     uint64_t n, skip;
     bool extended;
@@ -702,7 +703,7 @@ __rec_col_var_append_loop(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *p
              * Handle RLE accounting and comparisons -- see comment above, this code fragment does
              * the same thing.
              */
-            WT_RET(__rec_col_var_rle_check(session, r, salvage, st, &cur, &extended));
+            WT_RET(__rec_col_var_rle_extend(session, r, salvage, st, &cur, &extended));
             if (extended)
                 goto next;
 
@@ -756,7 +757,7 @@ int
 __wti_rec_col_var(
   WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_REF *pageref, WT_SALVAGE_COOKIE *salvage)
 {
-    struct __wti_col_var_state st;
+    COL_VAR_STATE st;
     WT_BTREE *btree;
     WT_PAGE *page;
     WT_TIME_WINDOW clear_tw;

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -22,7 +22,7 @@ typedef struct {
     bool deleted;
     bool dictionary;
     bool update_no_copy;
-} COL_VAR_CUR;
+} WT_COL_VAR_CUR;
 
 /*
  * State carried across all loop iterations in variable-length column-store reconciliation for
@@ -36,7 +36,7 @@ typedef struct {
     uint64_t rle;
     uint64_t src_recno;
     bool wrote_real_values;
-} COL_VAR_STATE;
+} WT_COL_VAR_STATE;
 
 /*
  * __wt_bulk_insert_var --
@@ -340,7 +340,7 @@ __rec_col_var_helper(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_SALVAGE_COOK
  */
 static int
 __rec_col_var_upd_apply(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_CURSOR_BTREE *cbt,
-  WTI_UPDATE_SELECT *upd_select, uint64_t src_recno, COL_VAR_CUR *cur)
+  WTI_UPDATE_SELECT *upd_select, uint64_t src_recno, WT_COL_VAR_CUR *cur)
 {
     WT_UPDATE *upd;
 
@@ -384,7 +384,7 @@ __rec_col_var_upd_apply(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_CURSOR_BT
  */
 static int
 __rec_col_var_rle_extend(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_SALVAGE_COOKIE *salvage,
-  COL_VAR_STATE *st, COL_VAR_CUR *cur, bool *extendedp)
+  WT_COL_VAR_STATE *st, WT_COL_VAR_CUR *cur, bool *extendedp)
 {
     *extendedp = false;
 
@@ -417,7 +417,7 @@ __rec_col_var_rle_extend(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_SALVAGE_
  */
 static int
 __rec_col_var_page_loop(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page,
-  WT_SALVAGE_COOKIE *salvage, COL_VAR_STATE *st)
+  WT_SALVAGE_COOKIE *salvage, WT_COL_VAR_STATE *st)
 {
     enum { OVFL_IGNORE, OVFL_UNUSED, OVFL_USED } ovfl_state;
     WT_BTREE *btree;
@@ -430,7 +430,7 @@ __rec_col_var_page_loop(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *pag
     WT_DECL_RET;
     WT_INSERT *ins;
     WTI_UPDATE_SELECT upd_select;
-    COL_VAR_CUR cur;
+    WT_COL_VAR_CUR cur;
     WT_UPDATE *upd;
     uint64_t n, nrepeat;
     uint32_t i;
@@ -644,12 +644,12 @@ err:
  */
 static int
 __rec_col_var_append_loop(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page,
-  WT_SALVAGE_COOKIE *salvage, COL_VAR_STATE *st)
+  WT_SALVAGE_COOKIE *salvage, WT_COL_VAR_STATE *st)
 {
     WT_CURSOR_BTREE *cbt;
     WT_INSERT *ins;
     WTI_UPDATE_SELECT upd_select;
-    COL_VAR_CUR cur;
+    WT_COL_VAR_CUR cur;
     WT_UPDATE *upd;
     uint64_t n, skip;
     bool extended;
@@ -757,8 +757,8 @@ int
 __wti_rec_col_var(
   WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_REF *pageref, WT_SALVAGE_COOKIE *salvage)
 {
-    COL_VAR_STATE st;
     WT_BTREE *btree;
+    WT_COL_VAR_STATE st;
     WT_PAGE *page;
     WT_TIME_WINDOW clear_tw;
 

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -10,6 +10,34 @@
 #include "reconcile_private.h"
 #include "reconcile_inline.h"
 
+
+/*
+ * Per-iteration state built while processing each entry in the variable-length column-store
+ * reconciliation loops.
+ */
+struct __wti_col_var_cur {
+    const void *data;
+    uint32_t size;
+    WT_TIME_WINDOW tw;
+    uint64_t repeat_count;
+    bool deleted;
+    bool dictionary;
+    bool update_no_copy;
+};
+
+/*
+ * State carried across all loop iterations in __wti_rec_col_var for run-length accounting.
+ */
+struct __wti_col_var_state {
+    WT_ITEM *last_value;
+    WT_TIME_WINDOW last_tw;
+    bool last_deleted;
+    bool last_dictionary;
+    uint64_t rle;
+    uint64_t src_recno;
+    bool wrote_real_values;
+};
+
 /*
  * __wt_bulk_insert_var --
  *     Variable-length column-store bulk insert.

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -22,7 +22,7 @@ typedef struct {
     bool deleted;
     bool dictionary;
     bool update_no_copy;
-} WT_COL_VAR_CUR;
+} WTI_COL_VAR_CUR;
 
 /*
  * State carried across all loop iterations in variable-length column-store reconciliation for
@@ -36,7 +36,7 @@ typedef struct {
     uint64_t rle;
     uint64_t src_recno;
     bool wrote_real_values;
-} WT_COL_VAR_STATE;
+} WTI_COL_VAR_STATE;
 
 /*
  * __wt_bulk_insert_var --
@@ -340,7 +340,7 @@ __rec_col_var_helper(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_SALVAGE_COOK
  */
 static int
 __rec_col_var_upd_apply(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_CURSOR_BTREE *cbt,
-  WTI_UPDATE_SELECT *upd_select, uint64_t src_recno, WT_COL_VAR_CUR *cur)
+  WTI_UPDATE_SELECT *upd_select, uint64_t src_recno, WTI_COL_VAR_CUR *cur)
 {
     WT_UPDATE *upd;
 
@@ -384,7 +384,7 @@ __rec_col_var_upd_apply(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_CURSOR_BT
  */
 static int
 __rec_col_var_rle_extend(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_SALVAGE_COOKIE *salvage,
-  WT_COL_VAR_STATE *st, WT_COL_VAR_CUR *cur, bool *extendedp)
+  WTI_COL_VAR_STATE *st, WTI_COL_VAR_CUR *cur, bool *extendedp)
 {
     *extendedp = false;
 
@@ -417,7 +417,7 @@ __rec_col_var_rle_extend(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_SALVAGE_
  */
 static int
 __rec_col_var_page_loop(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page,
-  WT_SALVAGE_COOKIE *salvage, WT_COL_VAR_STATE *st)
+  WT_SALVAGE_COOKIE *salvage, WTI_COL_VAR_STATE *st)
 {
     enum { OVFL_IGNORE, OVFL_UNUSED, OVFL_USED } ovfl_state;
     WT_BTREE *btree;
@@ -430,7 +430,7 @@ __rec_col_var_page_loop(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *pag
     WT_DECL_RET;
     WT_INSERT *ins;
     WTI_UPDATE_SELECT upd_select;
-    WT_COL_VAR_CUR cur;
+    WTI_COL_VAR_CUR cur;
     WT_UPDATE *upd;
     uint64_t n, nrepeat;
     uint32_t i;
@@ -644,12 +644,12 @@ err:
  */
 static int
 __rec_col_var_append_loop(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page,
-  WT_SALVAGE_COOKIE *salvage, WT_COL_VAR_STATE *st)
+  WT_SALVAGE_COOKIE *salvage, WTI_COL_VAR_STATE *st)
 {
     WT_CURSOR_BTREE *cbt;
     WT_INSERT *ins;
     WTI_UPDATE_SELECT upd_select;
-    WT_COL_VAR_CUR cur;
+    WTI_COL_VAR_CUR cur;
     WT_UPDATE *upd;
     uint64_t n, skip;
     bool extended;
@@ -758,7 +758,7 @@ __wti_rec_col_var(
   WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_REF *pageref, WT_SALVAGE_COOKIE *salvage)
 {
     WT_BTREE *btree;
-    WT_COL_VAR_STATE st;
+    WTI_COL_VAR_STATE st;
     WT_PAGE *page;
     WT_TIME_WINDOW clear_tw;
 

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -332,6 +332,82 @@ __rec_col_var_helper(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_SALVAGE_COOK
 
     return (0);
 }
+/*
+ * __rec_col_var_upd_apply --
+ *     Apply a selected update to produce the current-record state. The caller sets cbt->slot to the
+ *     appropriate column slot (or UINT32_MAX for append-list entries) before calling.
+ */
+static int
+__rec_col_var_upd_apply(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_CURSOR_BTREE *cbt,
+  WTI_UPDATE_SELECT *upd_select, uint64_t src_recno, struct __wti_col_var_cur *cur)
+{
+    WT_UPDATE *upd;
+
+    upd = upd_select->upd;
+    WT_TIME_WINDOW_COPY(&cur->tw, &upd_select->tw);
+
+    switch (upd->type) {
+    case WT_UPDATE_MODIFY:
+        WT_RET(__wt_modify_reconstruct_from_upd_list(
+          session, cbt, upd, cbt->upd_value, WT_OPCTX_RECONCILATION));
+        __wt_value_return(cbt, cbt->upd_value);
+        cur->data = cbt->iface.value.data;
+        cur->size = (uint32_t)cbt->iface.value.size;
+        cur->update_no_copy = false;
+        cur->dictionary = S2BT(session)->dictionary;
+        break;
+    case WT_UPDATE_STANDARD:
+        cur->data = upd->data;
+        cur->size = upd->size;
+        cur->dictionary = S2BT(session)->dictionary;
+        break;
+    case WT_UPDATE_TOMBSTONE:
+        cur->deleted = true;
+        WT_TIME_WINDOW_INIT(&cur->tw);
+        break;
+    default:
+        WT_RET(__wt_illegal_value(session, upd->type));
+    }
+
+    if (upd_select->no_ts_tombstone && r->hs_clear_on_tombstone)
+        WT_RET(__wti_rec_hs_clear_on_tombstone(
+          session, r, src_recno, NULL, upd->type == WT_UPDATE_TOMBSTONE ? false : true));
+
+    return (0);
+}
+
+/*
+ * __rec_col_var_rle_check --
+ *     Compare the current entry against the accumulated run. Extend if they match and set
+ *     *extendedp; otherwise emit the pending run (if any) and prepare for a new one.
+ */
+static int
+__rec_col_var_rle_check(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_SALVAGE_COOKIE *salvage,
+  struct __wti_col_var_state *st, struct __wti_col_var_cur *cur, bool *extendedp)
+{
+    *extendedp = false;
+
+    if (st->rle != 0) {
+        if (WT_TIME_WINDOWS_EQUAL(&st->last_tw, &cur->tw) &&
+          ((cur->deleted && st->last_deleted) ||
+            (!cur->deleted && !st->last_deleted && st->last_value->size == cur->size &&
+              (cur->size == 0 || memcmp(st->last_value->data, cur->data, cur->size) == 0)))) {
+
+            /* The time window for a pair of deleted keys must be empty. */
+            WT_ASSERT(session,
+              (!cur->deleted && !st->last_deleted) || WT_TIME_WINDOW_IS_EMPTY(&st->last_tw));
+
+            st->rle += cur->repeat_count;
+            *extendedp = true;
+            return (0);
+        }
+        if (!st->last_deleted)
+            st->wrote_real_values = true;
+        WT_RET(__rec_col_var_helper(session, r, salvage, st->last_value, &st->last_tw, st->rle,
+          st->last_deleted, st->last_dictionary, NULL));
+    }
+    return (0);
+}
 
 /*
  * __wti_rec_col_var --
@@ -342,12 +418,6 @@ __wti_rec_col_var(
   WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_REF *pageref, WT_SALVAGE_COOKIE *salvage)
 {
     enum { OVFL_IGNORE, OVFL_UNUSED, OVFL_USED } ovfl_state;
-    struct {
-        WT_ITEM *value; /* Value */
-        WT_TIME_WINDOW tw;
-        bool deleted;    /* If deleted */
-        bool dictionary; /* If dictionary is in use */
-    } last;
     WT_BTREE *btree;
     WT_CELL *cell;
     WT_CELL_UNPACK_KV *vpack, _vpack;
@@ -358,40 +428,33 @@ __wti_rec_col_var(
     WT_DECL_RET;
     WT_INSERT *ins;
     WT_PAGE *page;
-    WT_TIME_WINDOW clear_tw, *twp;
+    WT_TIME_WINDOW clear_tw;
     WT_UPDATE *upd;
     WTI_UPDATE_SELECT upd_select;
-    uint64_t n, nrepeat, repeat_count, rle, skip, src_recno;
-    uint32_t i, size;
-    bool deleted, dictionary, orig_deleted, orig_stale, ovfl_used, update_no_copy,
-      wrote_real_values;
-    const void *data;
+    struct __wti_col_var_cur cur;
+    struct __wti_col_var_state st;
+    uint64_t n, nrepeat, skip;
+    uint32_t i;
+    bool extended, orig_deleted, orig_stale, ovfl_used;
 
     btree = S2BT(session);
     conn = S2C(session);
     vpack = &_vpack;
     page = pageref->page;
     WT_TIME_WINDOW_INIT(&clear_tw);
-    twp = NULL;
-    upd = NULL;
-    size = 0;
     orig_stale = false;
-    wrote_real_values = false;
-    dictionary = false;
-    data = NULL;
 
     cbt = &r->update_modify_cbt;
     cbt->iface.session = (WT_SESSION *)session;
 
     /* Set the "last" values to cause failure if they're not set. */
-    last.value = r->last;
-    WT_TIME_WINDOW_INIT(&last.tw);
-    last.deleted = false;
-    last.dictionary = false;
+    WT_CLEAR(st);
+    st.last_value = r->last;
+    WT_TIME_WINDOW_INIT(&st.last_tw);
 
     WT_RET(__wti_rec_split_init(session, r, pageref->ref_recno, btree->maxleafpage_precomp));
 
-    WT_RET(__wt_scr_alloc(session, 0, &orig));
+    WT_ERR(__wt_scr_alloc(session, 0, &orig));
 
     /*
      * The salvage code may be calling us to reconcile a page where there were missing records in
@@ -402,12 +465,10 @@ __wti_rec_col_var(
      * we're handling one of the salvage cookie fields on our own, and we don't need the helper
      * function's assistance.)
      */
-    rle = 0;
     if (salvage != NULL && salvage->missing != 0) {
         if (salvage->skip == 0) {
-            rle = salvage->missing;
-            last.deleted = true;
-            last.dictionary = false;
+            st.rle = salvage->missing;
+            st.last_deleted = true;
 
             /*
              * Correct the number of records we're going to "take", pretending the missing records
@@ -416,7 +477,7 @@ __wti_rec_col_var(
             salvage->take += salvage->missing;
         } else
             WT_ERR(__rec_col_var_helper(
-              session, r, NULL, NULL, &clear_tw, salvage->missing, true, last.dictionary, NULL));
+              session, r, NULL, NULL, &clear_tw, salvage->missing, true, false, NULL));
     }
 
     /*
@@ -428,7 +489,7 @@ __wti_rec_col_var(
      * page. The record number of our source record, that is, the current item, is maintained in
      * src_recno.
      */
-    src_recno = r->recno + rle;
+    st.src_recno = r->recno + st.rle;
 
     /* For each entry in the in-memory page... */
     WT_COL_FOREACH (page, cip, i) {
@@ -437,107 +498,80 @@ __wti_rec_col_var(
         __wt_cell_unpack_kv(session, page->dsk, cell, vpack);
         nrepeat = __wt_cell_rle(vpack);
         ins = WT_SKIP_FIRST(WT_COL_UPDATE(page, cip));
-        dictionary = false;
 
-        /*
-         * If the original value is "deleted", there's no value to compare, we're done.
-         */
         orig_deleted = vpack->type == WT_CELL_DEL;
         if (orig_deleted)
             goto record_loop;
 
-        /* If the original value is stale, delete it when no updates are found. */
         orig_stale = __wt_txn_tw_stop_visible_all(session, &vpack->tw);
 
-        /*
-         * Overflow items are tricky: we don't know until we're finished processing the set of
-         * values if we need the overflow value or not. If we don't use the overflow item at all, we
-         * have to discard it from the backing file, otherwise we'll leak blocks on the checkpoint.
-         * That's safe because if the backing overflow value is still needed by any running
-         * transaction, we'll cache a copy in the update list.
-         *
-         * Regardless, we avoid copying in overflow records: if there's a WT_INSERT entry that
-         * modifies a reference counted overflow record, we may have to write copies of the overflow
-         * record, and in that case we'll do the comparisons, but we don't read overflow items just
-         * to see if they match records on either side.
-         */
         if (F_ISSET(vpack, WT_CELL_UNPACK_OVERFLOW)) {
             ovfl_state = OVFL_UNUSED;
             goto record_loop;
         }
 
 record_loop:
-        /*
-         * Generate on-page entries: loop repeat records, looking for WT_INSERT entries matching the
-         * record number. The WT_INSERT lists are in sorted order, so only need check the next one.
-         */
-        for (n = 0; n < nrepeat; n += repeat_count, src_recno += repeat_count) {
+        for (n = 0; n < nrepeat; n += cur.repeat_count, st.src_recno += cur.repeat_count) {
             upd = NULL;
-            if (ins != NULL && WT_INSERT_RECNO(ins) == src_recno) {
+            if (ins != NULL && WT_INSERT_RECNO(ins) == st.src_recno) {
                 WT_ERR(__wti_rec_upd_select(session, r, ins, NULL, vpack, &upd_select));
                 upd = upd_select.upd;
                 ins = WT_SKIP_NEXT(ins);
             } else
                 upd_select.skip_aborted_prepared_value = false;
 
-            update_no_copy = true; /* No data copy */
-            repeat_count = 1;      /* Single record */
-            deleted = false;
+            WT_CLEAR(cur);
+            cur.update_no_copy = true;
+            cur.repeat_count = 1;
 
             if (upd == NULL && orig_stale &&
               (!F_ISSET(conn, WT_CONN_PRESERVE_PREPARED) || !F_ISSET(r, WT_REC_EVICT) ||
                 !upd_select.skip_aborted_prepared_value)) {
                 /*
-                 * The on-disk value is stale and there was no update. Treat it as deleted.
-                 *
-                 * Keep the on-disk cell when the chain still has an unstable aborted prepared
-                 * update that we skipped this round: the cell is its only rollback fallback, and
-                 * dropping it now would strand the prepared update with nothing to fall back to on
-                 * a later reconciliation.
+                 * The on-disk value is stale and no update exists. Drop it unless the chain holds
+                 * an unstable aborted prepared update that needs this cell as its rollback target.
                  */
-                deleted = true;
+                cur.deleted = true;
+                WT_TIME_WINDOW_INIT(&cur.tw);
                 r->key_removed_from_disk_image = true;
-                twp = &clear_tw;
             } else if (upd == NULL) {
-                update_no_copy = false; /* Maybe data copy */
+                cur.update_no_copy = false;
 
                 /*
                  * The repeat count is the number of records up to the next WT_INSERT record, or up
                  * to the end of the entry if we have no more WT_INSERT records.
                  */
                 if (ins == NULL)
-                    repeat_count = nrepeat - n;
+                    cur.repeat_count = nrepeat - n;
                 else
-                    repeat_count = WT_INSERT_RECNO(ins) - src_recno;
+                    cur.repeat_count = WT_INSERT_RECNO(ins) - st.src_recno;
 
-                /*
-                 * The key on the old disk image is unchanged. Clear the time window information if
-                 * it's a deleted record, else take the time window from the cell.
-                 */
-                deleted = orig_deleted;
-                if (deleted) {
-                    twp = &clear_tw;
+                cur.deleted = orig_deleted;
+                if (cur.deleted) {
+                    WT_TIME_WINDOW_INIT(&cur.tw);
                     r->key_removed_from_disk_image = true;
                     goto compare;
                 }
-                twp = &vpack->tw;
+
                 /*
                  * If preserve prepared update is enabled, we must select an update to replace the
                  * onpage prepared update. Otherwise, we leak the prepared update.
                  */
                 WT_ASSERT_ALWAYS(session,
-                  !F_ISSET(conn, WT_CONN_PRESERVE_PREPARED) || !WT_TIME_WINDOW_HAS_PREPARE(twp),
+                  !F_ISSET(conn, WT_CONN_PRESERVE_PREPARED) ||
+                    !WT_TIME_WINDOW_HAS_PREPARE(&vpack->tw),
                   "leaked prepared update.");
 
                 /* Clear the on-disk cell time window if it is obsolete. */
                 __wti_rec_time_window_clear_obsolete(session, NULL, vpack, r);
+                WT_TIME_WINDOW_COPY(&cur.tw, &vpack->tw);
 
                 /*
                  * Check if we are dealing with a dictionary cell (a copy of another item on the
                  * page).
                  */
                 if (vpack->raw == WT_CELL_VALUE_COPY)
-                    dictionary = btree->dictionary;
+                    cur.dictionary = btree->dictionary;
 
                 /*
                  * If we are handling overflow items, use the overflow item itself exactly once,
@@ -547,23 +581,19 @@ record_loop:
                 switch (ovfl_state) {
                 case OVFL_UNUSED:
                     /*
-                     * An as-yet-unused overflow item.
-                     *
-                     * We're going to copy the on-page cell, write out any record we're tracking.
+                     * An as-yet-unused overflow item: emit the pending run, write this cell
+                     * directly once, then skip the normal compare/swap path.
                      */
-                    if (rle != 0) {
-                        WT_ERR(__rec_col_var_helper(session, r, salvage, last.value, &last.tw, rle,
-                          last.deleted, last.dictionary, NULL));
-                        rle = 0;
+                    if (st.rle != 0) {
+                        WT_ERR(__rec_col_var_helper(session, r, salvage, st.last_value,
+                          &st.last_tw, st.rle, st.last_deleted, st.last_dictionary, NULL));
+                        st.rle = 0;
                     }
-
-                    last.value->data = vpack->data;
-                    last.value->size = vpack->size;
-                    WT_ERR(__rec_col_var_helper(session, r, salvage, last.value, twp, repeat_count,
-                      false, last.dictionary, &ovfl_used));
-
-                    wrote_real_values = true;
-
+                    st.last_value->data = vpack->data;
+                    st.last_value->size = vpack->size;
+                    WT_ERR(__rec_col_var_helper(session, r, salvage, st.last_value, &cur.tw,
+                      cur.repeat_count, false, st.last_dictionary, &ovfl_used));
+                    st.wrote_real_values = true;
                     /*
                      * Salvage may have caused us to skip the overflow item, only update overflow
                      * items we use.
@@ -575,13 +605,12 @@ record_loop:
                     continue;
                 case OVFL_USED:
                     /*
-                     * Original is an overflow item; we used it for a key and now we need another
-                     * copy; read it into memory.
+                     * Overflow already emitted once; read the value into a scratch buffer so
+                     * subsequent copies work.
                      */
                     WT_ERR(__wt_dsk_cell_data_ref_kv(session, vpack, orig));
-                    data = orig->data;
-                    size = (uint32_t)orig->size;
-
+                    cur.data = orig->data;
+                    cur.size = (uint32_t)orig->size;
                     ovfl_state = OVFL_IGNORE;
                     break;
                 case OVFL_IGNORE:
@@ -590,49 +619,19 @@ record_loop:
                      * Otherwise, use the on-page value.
                      */
                     if (F_ISSET(vpack, WT_CELL_UNPACK_OVERFLOW)) {
-                        data = orig->data;
-                        size = (uint32_t)orig->size;
+                        cur.data = orig->data;
+                        cur.size = (uint32_t)orig->size;
                     } else {
-                        data = vpack->data;
-                        size = vpack->size;
+                        cur.data = vpack->data;
+                        cur.size = vpack->size;
                     }
                     break;
                 }
             } else {
-                twp = &upd_select.tw;
-
-                switch (upd->type) {
-                case WT_UPDATE_MODIFY:
-                    cbt->slot = WT_COL_SLOT(page, cip);
-                    WT_ERR(__wt_modify_reconstruct_from_upd_list(
-                      session, cbt, upd, cbt->upd_value, WT_OPCTX_RECONCILATION));
-                    __wt_value_return(cbt, cbt->upd_value);
-                    data = cbt->iface.value.data;
-                    size = (uint32_t)cbt->iface.value.size;
-                    update_no_copy = false;
-                    dictionary = btree->dictionary;
-                    break;
-                case WT_UPDATE_STANDARD:
-                    data = upd->data;
-                    size = upd->size;
-                    dictionary = btree->dictionary;
-                    break;
-                case WT_UPDATE_TOMBSTONE:
-                    deleted = true;
-                    twp = &clear_tw;
+                cbt->slot = WT_COL_SLOT(page, cip);
+                WT_ERR(__rec_col_var_upd_apply(session, r, cbt, &upd_select, st.src_recno, &cur));
+                if (cur.deleted)
                     r->key_removed_from_disk_image = true;
-                    break;
-                default:
-                    WT_ERR(__wt_illegal_value(session, upd->type));
-                }
-
-                /*
-                 * When a tombstone without a timestamp is written to disk, remove any historical
-                 * versions that are greater in the history store for this key.
-                 */
-                if (upd_select.no_ts_tombstone && r->hs_clear_on_tombstone)
-                    WT_ERR(__wti_rec_hs_clear_on_tombstone(session, r, src_recno, NULL,
-                      upd->type == WT_UPDATE_TOMBSTONE ? false : true));
             }
 
 compare:
@@ -642,31 +641,16 @@ compare:
              * swap the last and current buffers: do NOT update the starting record number, we've
              * been doing that all along.
              */
-            if (rle != 0) {
-                if (WT_TIME_WINDOWS_EQUAL(&last.tw, twp) &&
-                  ((deleted && last.deleted) ||
-                    (!deleted && !last.deleted && last.value->size == size &&
-                      (size == 0 || memcmp(last.value->data, data, size) == 0)))) {
-
-                    /* The time window for deleted keys must be empty. */
-                    WT_ASSERT(
-                      session, (!deleted && !last.deleted) || WT_TIME_WINDOW_IS_EMPTY(&last.tw));
-
-                    rle += repeat_count;
-                    continue;
-                }
-                if (!last.deleted)
-                    wrote_real_values = true;
-                WT_ERR(__rec_col_var_helper(session, r, salvage, last.value, &last.tw, rle,
-                  last.deleted, last.dictionary, NULL));
-            }
+            WT_ERR(__rec_col_var_rle_check(session, r, salvage, &st, &cur, &extended));
+            if (extended)
+                continue;
 
             /*
              * Swap the current/last state.
              *
              * Reset RLE counter and turn on comparisons.
              */
-            if (!deleted) {
+            if (!cur.deleted) {
                 /*
                  * We can't simply assign the data values into the last buffer because they may have
                  * come from a copy built from an encoded/overflow cell and creating the next record
@@ -675,17 +659,16 @@ compare:
                  * unpack structure (which points into the page), or was taken from an update
                  * structure, we can just use the pointers, they're not moving.
                  */
-                if (data == vpack->data || update_no_copy) {
-                    last.value->data = data;
-                    last.value->size = size;
+                if (cur.data == vpack->data || cur.update_no_copy) {
+                    st.last_value->data = cur.data;
+                    st.last_value->size = cur.size;
                 } else
-                    WT_ERR(__wt_buf_set(session, last.value, data, size));
+                    WT_ERR(__wt_buf_set(session, st.last_value, cur.data, cur.size));
             }
-
-            WT_TIME_WINDOW_COPY(&last.tw, twp);
-            last.deleted = deleted;
-            last.dictionary = dictionary;
-            rle = repeat_count;
+            WT_TIME_WINDOW_COPY(&st.last_tw, &cur.tw);
+            st.last_deleted = cur.deleted;
+            st.last_dictionary = cur.dictionary;
+            st.rle = cur.repeat_count;
         }
 
         /*
@@ -707,102 +690,46 @@ compare:
              * they are, though likely smaller, equivalent to gaps created by fast-truncate.
              */
             break;
-        else {
-            WT_ERR(__wti_rec_upd_select(session, r, ins, NULL, NULL, &upd_select));
-            upd = upd_select.upd;
-            n = WT_INSERT_RECNO(ins);
-        }
+        WT_ERR(__wti_rec_upd_select(session, r, ins, NULL, NULL, &upd_select));
+        upd = upd_select.upd;
+        n = WT_INSERT_RECNO(ins);
 
-        while (src_recno <= n) {
-            update_no_copy = true; /* No data copy */
-            deleted = false;
+        while (st.src_recno <= n) {
+            WT_CLEAR(cur);
+            cur.update_no_copy = true;
+            cur.repeat_count = 1;
 
-            /*
-             * The application may have inserted records which left gaps in the name space, and
-             * these gaps can be huge. If we're in a set of deleted records, skip the boring part.
-             */
-            if (src_recno < n) {
-                deleted = true;
-                if (last.deleted) {
+            if (st.src_recno < n) {
+                cur.deleted = true;
+                WT_TIME_WINDOW_INIT(&cur.tw);
+                if (st.last_deleted) {
                     /* The time window for deleted keys must be empty. */
-                    WT_ASSERT(session, WT_TIME_WINDOW_IS_EMPTY(&last.tw));
+                    WT_ASSERT(session, WT_TIME_WINDOW_IS_EMPTY(&st.last_tw));
                     /*
                      * The record adjustment is decremented by one so we can naturally fall into the
                      * RLE accounting below, where we increment rle by one, then continue in the
                      * outer loop, where we increment src_recno by one.
                      */
-                    skip = (n - src_recno) - 1;
-                    rle += skip;
-                    src_recno += skip;
-                } else
-                    /* Set time window for the first deleted key in a deleted range. */
-                    twp = &clear_tw;
+                    skip = (n - st.src_recno) - 1;
+                    st.rle += skip;
+                    st.src_recno += skip;
+                }
             } else if (upd == NULL) {
                 /* The updates on the key are all uncommitted so we write a deleted key to disk. */
-                twp = &clear_tw;
-                deleted = true;
+                cur.deleted = true;
+                WT_TIME_WINDOW_INIT(&cur.tw);
             } else {
-                /* Set time window for the key. */
-                twp = &upd_select.tw;
-
-                switch (upd->type) {
-                case WT_UPDATE_MODIFY:
-                    /*
-                     * Impossible slot, there's no backing on-page item.
-                     */
-                    cbt->slot = UINT32_MAX;
-                    WT_ERR(__wt_modify_reconstruct_from_upd_list(
-                      session, cbt, upd, cbt->upd_value, WT_OPCTX_RECONCILATION));
-                    __wt_value_return(cbt, cbt->upd_value);
-                    data = cbt->iface.value.data;
-                    size = (uint32_t)cbt->iface.value.size;
-                    update_no_copy = false;
-                    dictionary = btree->dictionary;
-                    break;
-                case WT_UPDATE_STANDARD:
-                    data = upd->data;
-                    size = upd->size;
-                    dictionary = btree->dictionary;
-                    break;
-                case WT_UPDATE_TOMBSTONE:
-                    twp = &clear_tw;
-                    deleted = true;
-                    break;
-                default:
-                    WT_ERR(__wt_illegal_value(session, upd->type));
-                }
-
-                /*
-                 * When a tombstone without a timestamp is written to disk, remove any historical
-                 * versions that are greater in the history store for this key.
-                 */
-                if (upd_select.no_ts_tombstone && r->hs_clear_on_tombstone)
-                    WT_ERR(__wti_rec_hs_clear_on_tombstone(session, r, src_recno, NULL,
-                      upd->type == WT_UPDATE_TOMBSTONE ? false : true));
+                cbt->slot = UINT32_MAX;
+                WT_ERR(__rec_col_var_upd_apply(session, r, cbt, &upd_select, st.src_recno, &cur));
             }
 
             /*
              * Handle RLE accounting and comparisons -- see comment above, this code fragment does
              * the same thing.
              */
-            if (rle != 0) {
-                if (WT_TIME_WINDOWS_EQUAL(&last.tw, twp) &&
-                  ((deleted && last.deleted) ||
-                    (!deleted && !last.deleted && last.value->size == size &&
-                      (size == 0 || memcmp(last.value->data, data, size) == 0)))) {
-
-                    /* The time window for deleted keys must be empty. */
-                    WT_ASSERT(
-                      session, (!deleted && !last.deleted) || WT_TIME_WINDOW_IS_EMPTY(&last.tw));
-
-                    ++rle;
-                    goto next;
-                }
-                if (!last.deleted)
-                    wrote_real_values = true;
-                WT_ERR(__rec_col_var_helper(session, r, salvage, last.value, &last.tw, rle,
-                  last.deleted, last.dictionary, NULL));
-            }
+            WT_ERR(__rec_col_var_rle_check(session, r, salvage, &st, &cur, &extended));
+            if (extended)
+                goto next;
 
             /*
              * Swap the current/last state. We can't simply assign the data values into the last
@@ -811,28 +738,28 @@ compare:
              * the copy. If data was taken from an update structure, we can just use the pointers,
              * they're not moving.
              */
-            if (!deleted) {
-                if (update_no_copy) {
-                    last.value->data = data;
-                    last.value->size = size;
+            if (!cur.deleted) {
+                if (cur.update_no_copy) {
+                    st.last_value->data = cur.data;
+                    st.last_value->size = cur.size;
                 } else
-                    WT_ERR(__wt_buf_set(session, last.value, data, size));
+                    WT_ERR(__wt_buf_set(session, st.last_value, cur.data, cur.size));
             }
 
             /* Ready for the next loop, reset the RLE counter. */
-            WT_TIME_WINDOW_COPY(&last.tw, twp);
-            last.deleted = deleted;
-            last.dictionary = dictionary;
-            rle = 1;
+            WT_TIME_WINDOW_COPY(&st.last_tw, &cur.tw);
+            st.last_deleted = cur.deleted;
+            st.last_dictionary = cur.dictionary;
+            st.rle = 1;
 
             /*
              * Move to the next record. It's not a simple increment because if it's the maximum
              * record, incrementing it wraps to 0 and this turns into an infinite loop.
              */
 next:
-            if (src_recno == UINT64_MAX)
+            if (st.src_recno == UINT64_MAX)
                 break;
-            ++src_recno;
+            ++st.src_recno;
         }
 
         /*
@@ -844,11 +771,11 @@ next:
     }
 
     /* If we were tracking a record, write it. */
-    if (rle != 0) {
-        if (!last.deleted)
-            wrote_real_values = true;
-        WT_ERR(__rec_col_var_helper(
-          session, r, salvage, last.value, &last.tw, rle, last.deleted, last.dictionary, NULL));
+    if (st.rle != 0) {
+        if (!st.last_deleted)
+            st.wrote_real_values = true;
+        WT_ERR(__rec_col_var_helper(session, r, salvage, st.last_value, &st.last_tw, st.rle,
+          st.last_deleted, st.last_dictionary, NULL));
     }
 
     /*
@@ -867,7 +794,7 @@ next:
      *       entries at all (not just one with no or only aborted updates) gets marked dirty somehow
      *       and reconciled; this is apparently possible in some circumstances.
      */
-    if (!wrote_real_values && salvage == NULL && r->leave_dirty == false && r->entries > 0) {
+    if (!st.wrote_real_values && salvage == NULL && r->leave_dirty == false && r->entries > 0) {
         WT_ASSERT(session, r->entries == 1);
         r->entries = 0;
         WT_STAT_CONN_DSRC_INCR(session, rec_vlcs_emptied_pages);


### PR DESCRIPTION
## [WT-17673] Refactor `__wti_rec_col_var` to reduce cyclomatic complexity

### What and why

`__wti_rec_col_var` (`src/reconcile/rec_col.c`) reconciles variable-length column-store leaf pages. Before this change it was a single ~300-line function with a cyclomatic complexity of **81** — well above the project threshold — because it contained two structurally similar loops (on-page entries and the append list), each with inline update-application and run-length-encoding (RLE) logic duplicated between them.

### How it was split

Two small structs were introduced to make state explicit and passable across function boundaries:

| Struct | Purpose |
|---|---|
| `__wti_col_var_cur` | Per-iteration snapshot of the current record: `data`, `size`, `tw`, `repeat_count`, `deleted`, `dictionary`, `update_no_copy` |
| `__wti_col_var_state` | Cross-iteration RLE bookkeeping: `last_value`, `last_tw`, `last_deleted`, `last_dictionary`, `rle`, `src_recno`, `wrote_real_values` |

Four helpers were extracted:

| Function | What it does |
|---|---|
| `__rec_col_var_upd_apply` | Applies a selected update (`MODIFY` / `STANDARD` / `TOMBSTONE`) to fill a `__wti_col_var_cur`. Also handles the history-store tombstone clear path. Previously duplicated verbatim inside each loop. |
| `__rec_col_var_rle_check` | Compares the current entry against the accumulated run; extends the run (sets `*extendedp = true`) on a match, or emits the pending run and resets otherwise. Previously duplicated inside each loop. |
| `__rec_col_var_page_loop` | Walks `WT_COL_FOREACH` on-page entries, managing overflow state and calling the two helpers above. |
| `__rec_col_var_append_loop` | Walks `WT_COL_APPEND`, filling namespace gaps with synthetic deletes and calling the same helpers. |

`__wti_rec_col_var` itself is now a thin coordinator: it initialises `__wti_col_var_state`, handles the salvage-missing prefix, delegates to `__rec_col_var_page_loop` then `__rec_col_var_append_loop`, flushes the trailing RLE run, and calls `__wti_rec_split_finish`. Every function in the file is now below complexity 30.

The only behavioural change is cosmetic: the `clear_tw` sentinel (a stack-allocated empty `WT_TIME_WINDOW` passed everywhere a deleted record needed a zeroed window) is gone; deleted paths now call `WT_TIME_WINDOW_INIT(&cur.tw)` directly, which is equivalent.

### Evergreen patch

https://spruce.corp.mongodb.com/version/6a1675ad6645c10007a6434d

All test failures are **unrelated** to this change (pre-existing flakiness, not introduced by the refactor).