### PR TITLE
WT-17672 Rename numbered layered Python tests (Pt 4: Follower/stepup)

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1673,6 +1673,7 @@ stdin
 stdout
 stepback
 stepp
+stepup
 stlr
 stlrb
 stlrh

--- a/test/suite/test_layered_checkpoint15.py
+++ b/test/suite/test_layered_checkpoint15.py
@@ -30,10 +30,10 @@ import os, os.path, shutil, wiredtiger, wttest
 from helper_disagg import disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 
-# test_layered17.py
+# test_layered_checkpoint15.py
 #    Check timestamps.
 @disagg_test_class
-class test_layered17(wttest.WiredTigerTestCase):
+class test_layered_checkpoint15(wttest.WiredTigerTestCase):
     nitems = 500
 
     conn_base_config = 'statistics=(all),' \
@@ -43,9 +43,9 @@ class test_layered17(wttest.WiredTigerTestCase):
 
     create_session_config = 'key_format=S,value_format=S'
 
-    table_name = "test_layered17"
+    table_name = "test_layered_checkpoint15"
 
-    disagg_storages = gen_disagg_storages('test_layered17', disagg_only = True)
+    disagg_storages = gen_disagg_storages('test_layered_checkpoint15', disagg_only = True)
     scenarios = make_scenarios(disagg_storages, [
         ('layered-prefix', dict(prefix='layered:', table_config='')),
         ('layered-type', dict(prefix='table:', table_config='block_manager=disagg,type=layered')),
@@ -53,7 +53,7 @@ class test_layered17(wttest.WiredTigerTestCase):
     ])
 
     # Test timestamps
-    def test_layered17(self):
+    def test_layered_checkpoint15(self):
 
         # Create table
         self.uri = self.prefix + self.table_name

--- a/test/suite/test_layered_config14.py
+++ b/test/suite/test_layered_config14.py
@@ -30,10 +30,10 @@ import wttest
 from helper_disagg import disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 
-# test_layered15.py
+# test_layered_config14.py
 #    Start without local files.
 @disagg_test_class
-class test_layered15(wttest.WiredTigerTestCase):
+class test_layered_config14(wttest.WiredTigerTestCase):
     nitems = 500
 
     conn_config = 'log=(enabled=true),statistics=(all),statistics_log=(wait=1,json=true,on_close=true),' \
@@ -41,16 +41,16 @@ class test_layered15(wttest.WiredTigerTestCase):
 
     create_session_config = 'key_format=S,value_format=S'
 
-    layered_uris = ["table:test_layered15a", "layered:test_layered15b"]
-    file_uris = ["file:test_layered15c"]
-    table_uris = ["table:test_layered15d"]
+    layered_uris = ["table:test_layered_config14a", "layered:test_layered_config14b"]
+    file_uris = ["file:test_layered_config14c"]
+    table_uris = ["table:test_layered_config14d"]
     all_uris = layered_uris + file_uris + table_uris
-    with_ingest_uris = all_uris + ["file:test_layered15a.wt_ingest", "file:test_layered15b.wt_ingest"]
+    with_ingest_uris = all_uris + ["file:test_layered_config14a.wt_ingest", "file:test_layered_config14b.wt_ingest"]
 
     update_uris = [table_uris[0]] + ([layered_uris[0]] if len(layered_uris) > 0 else [])
     same_uris = list(set(all_uris) - set(update_uris))
 
-    disagg_storages = gen_disagg_storages('test_layered15', disagg_only = True)
+    disagg_storages = gen_disagg_storages('test_layered_config14', disagg_only = True)
     scenarios = make_scenarios(disagg_storages)
 
     # Ensure that the metadata cursor has all the expected URIs.
@@ -80,7 +80,7 @@ class test_layered15(wttest.WiredTigerTestCase):
         cursor.close()
 
     # Test starting without local files.
-    def test_layered15(self):
+    def test_layered_config14(self):
         # The node started as a follower, so step it up as the leader
         self.conn.reconfigure('disaggregated=(role="leader")')
 

--- a/test/suite/test_layered_follower01.py
+++ b/test/suite/test_layered_follower01.py
@@ -32,18 +32,18 @@ import wttest
 from helper_disagg import disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 
-# test_layered22.py
+# test_layered_follower01.py
 # Test a secondary can perform reads and writes to the ingest component
 # of a layered table, without the stable component.
 @disagg_test_class
-class test_layered22(wttest.WiredTigerTestCase):
+class test_layered_follower01(wttest.WiredTigerTestCase):
     conn_base_config = 'transaction_sync=(enabled,method=fsync),'
 
-    disagg_storages = gen_disagg_storages('test_layered22', disagg_only = True)
+    disagg_storages = gen_disagg_storages('test_layered_follower01', disagg_only = True)
     scenarios = make_scenarios(disagg_storages)
 
     nitems = 10000
-    uri = 'layered:test_layered22'
+    uri = 'layered:test_layered_follower01'
 
     def conn_config(self):
         return self.conn_base_config + 'disaggregated=(role="follower"),'

--- a/test/suite/test_layered_follower02.py
+++ b/test/suite/test_layered_follower02.py
@@ -31,18 +31,18 @@ from helper_disagg import disagg_test_class, gen_disagg_storages, Oplog
 from wiredtiger import stat
 from helper import WiredTigerCursor, statistic_uri
 
-# test_layered23.py
+# test_layered_follower02.py
 #    Test the basic ability to insert on a follower.
 
 @disagg_test_class
-class test_layered23(wttest.WiredTigerTestCase):
+class test_layered_follower02(wttest.WiredTigerTestCase):
     conn_base_config = ',create,statistics=(all),statistics_log=(wait=1,json=true,on_close=true),'
     def conn_config(self):
         return self.extensionsConfig() + self.conn_base_config + 'disaggregated=(role="leader")'
 
-    scenarios = gen_disagg_storages('test_layered23', disagg_only = True)
+    scenarios = gen_disagg_storages('test_layered_follower02', disagg_only = True)
 
-    uri = "layered:test_layered23"
+    uri = "layered:test_layered_follower02"
 
     # Make sure the stats agree that the leader has done each checkpoint.
     def check_checkpoint(self, expected):

--- a/test/suite/test_layered_follower03.py
+++ b/test/suite/test_layered_follower03.py
@@ -30,10 +30,10 @@ import wiredtiger, wttest
 from helper_disagg import disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 
-# test_layered25.py
+# test_layered_follower03.py
 #    Start without local files and test historical reads.
 @disagg_test_class
-class test_layered25(wttest.WiredTigerTestCase):
+class test_layered_follower03(wttest.WiredTigerTestCase):
     nitems = 500
 
     conn_base_config = 'statistics=(all),' \
@@ -43,9 +43,9 @@ class test_layered25(wttest.WiredTigerTestCase):
 
     create_session_config = 'key_format=S,value_format=S'
 
-    table_name = "test_layered25"
+    table_name = "test_layered_follower03"
 
-    disagg_storages = gen_disagg_storages('test_layered25', disagg_only = True)
+    disagg_storages = gen_disagg_storages('test_layered_follower03', disagg_only = True)
     scenarios = make_scenarios(disagg_storages, [
         ('layered-prefix', dict(prefix='layered:', table_config='')),
         ('layered-type', dict(prefix='table:', table_config='block_manager=disagg,type=layered')),
@@ -53,7 +53,7 @@ class test_layered25(wttest.WiredTigerTestCase):
     ])
 
     # Start without local files and test historical reads.
-    def test_layered25(self):
+    def test_layered_follower03(self):
         # The node started as a follower, so step it up as the leader
         self.conn.reconfigure('disaggregated=(role="leader")')
 

--- a/test/suite/test_layered_follower04.py
+++ b/test/suite/test_layered_follower04.py
@@ -30,11 +30,11 @@ import os, os.path, shutil, wiredtiger, wttest
 from helper_disagg import disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 
-# test_layered26.py
+# test_layered_follower04.py
 #    Make sure a secondary picking up a checkpoint adds in the stable
 #    component of the table.
 @disagg_test_class
-class test_layered26(wttest.WiredTigerTestCase):
+class test_layered_follower04(wttest.WiredTigerTestCase):
     nitems = 5000
 
     conn_base_config = 'precise_checkpoint=true,'
@@ -42,17 +42,17 @@ class test_layered26(wttest.WiredTigerTestCase):
 
     session_create_config = 'key_format=S,value_format=S,'
 
-    disagg_storages = gen_disagg_storages('test_layered26', disagg_only = True)
+    disagg_storages = gen_disagg_storages('test_layered_follower04', disagg_only = True)
     scenarios = make_scenarios(disagg_storages, [
         ('layered-prefix', dict(prefix='layered:', table_config='')),
         ('layered-type', dict(prefix='table:', table_config='block_manager=disagg,type=layered,')),
     ])
 
-    def test_layered26(self):
+    def test_layered_follower04(self):
         # Avoid checkpoint error with precise checkpoint
         self.conn.set_timestamp('stable_timestamp=1')
 
-        self.uri = self.prefix + 'test_layered26'
+        self.uri = self.prefix + 'test_layered_follower04'
 
         # The node started as a follower, so step it up as the leader
         self.conn.reconfigure('disaggregated=(role="leader")')

--- a/test/suite/test_layered_follower05.py
+++ b/test/suite/test_layered_follower05.py
@@ -33,22 +33,22 @@ from metadata_helper import extract_id
 from helper_disagg import disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 
-# test_layered86.py
+# test_layered_follower05.py
 # Make sure that a follower picks up and applies new file IDs.
 @disagg_test_class
-class test_layered86(wttest.WiredTigerTestCase):
+class test_layered_follower05(wttest.WiredTigerTestCase):
     conn_config = 'disaggregated=(role="leader")'
     conn_config_follower = 'disaggregated=(role="follower")'
 
-    uri = "layered:test_layered86"
+    uri = "layered:test_layered_follower05"
 
-    disagg_storages = gen_disagg_storages('test_layered86', disagg_only = True)
+    disagg_storages = gen_disagg_storages('test_layered_follower05', disagg_only = True)
     scenarios = make_scenarios(disagg_storages)
 
     def test_standby_uses_table_id_high_water_mark(self):
         # Make 100 tables, then checkpoint.
         for i in range(0, 100):
-            self.session.create(f"layered:test_layered86_{i}", 'key_format=S,value_format=S')
+            self.session.create(f"layered:test_layered_follower05_{i}", 'key_format=S,value_format=S')
         self.conn.set_timestamp('stable_timestamp=1') # Don't upset precise checkpoint
         self.session.checkpoint()
 
@@ -65,7 +65,7 @@ class test_layered86(wttest.WiredTigerTestCase):
 
         # Drop those tables, checkpoint again.
         for i in range(0, 100):
-            self.session.drop(f"layered:test_layered86_{i}")
+            self.session.drop(f"layered:test_layered_follower05_{i}")
         self.session.checkpoint()
 
         # Make a follower and feed it the latest checkpoint.
@@ -85,7 +85,7 @@ class test_layered86(wttest.WiredTigerTestCase):
 
         # Make a new table on the (new) leader. Checkpoint.
         self.conn_follow.set_timestamp('stable_timestamp=2') # Don't upset precise checkpoint
-        self.session_follow.create(f"layered:test_layered86_101", 'key_format=S,value_format=S')
+        self.session_follow.create(f"layered:test_layered_follower05_101", 'key_format=S,value_format=S')
         self.session_follow.checkpoint()
 
         # Make sure the table ID is higher than what we saw from the old leader

--- a/test/suite/test_layered_follower06.py
+++ b/test/suite/test_layered_follower06.py
@@ -30,21 +30,21 @@ import threading, time, wiredtiger, wttest
 from helper_disagg import disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 
-# test_layered72.py
+# test_layered_follower06.py
 #    Test reading the pinned history store on standby.
 @disagg_test_class
-class test_layered72(wttest.WiredTigerTestCase):
+class test_layered_follower06(wttest.WiredTigerTestCase):
     conn_base_config = 'statistics=(all),' \
                      + 'precise_checkpoint=true,'
     conn_config = conn_base_config + 'disaggregated=(role="leader")'
 
     create_session_config = 'key_format=S,value_format=S'
 
-    uri = "layered:test_layered72"
-    disagg_storages = gen_disagg_storages('test_layered72', disagg_only = True)
+    uri = "layered:test_layered_follower06"
+    disagg_storages = gen_disagg_storages('test_layered_follower06', disagg_only = True)
     scenarios = make_scenarios(disagg_storages)
 
-    def test_layered72(self):
+    def test_layered_follower06(self):
         # Create the follower
         conn_follow = self.wiredtiger_open('follower', self.extensionsConfig() + ',create,' +self.conn_base_config + 'disaggregated=(role="follower")')
         session_follow = conn_follow.open_session('')

--- a/test/suite/test_layered_follower07.py
+++ b/test/suite/test_layered_follower07.py
@@ -32,17 +32,17 @@ from test_cc01 import test_cc_base
 from wiredtiger import stat
 from wtscenario import make_scenarios
 
-# test_cc11.py
+# test_layered_follower07.py
 # Test that checkpoint cleanup is not run on follower.
 @disagg_test_class
-class test_cc11(DisaggConfigMixin, test_cc_base):
-    disagg_storages = gen_disagg_storages('test_cc11', disagg_only = True)
+class test_layered_follower07(DisaggConfigMixin, test_cc_base):
+    disagg_storages = gen_disagg_storages('test_layered_follower07', disagg_only = True)
     scenarios = make_scenarios(disagg_storages)
 
     conn_config = 'cache_size=10MB,page_delta=(delta_pct=100),disaggregated=(role="follower"),checkpoint_cleanup=[wait=1,file_wait_ms=0],'
 
     @wttest.skip_for_hook("tiered", "Cannot run tiered storage in disagg mode")
-    def test_cc11(self):
+    def test_layered_follower07(self):
         # Create a table.
         create_params = 'key_format=i,value_format=S'
         nrows = 10

--- a/test/suite/test_layered_follower08.py
+++ b/test/suite/test_layered_follower08.py
@@ -30,10 +30,10 @@ import os, wiredtiger, wttest
 from helper_disagg import disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 
-# test_layered33.py
+# test_layered_follower08.py
 #    Test delete on the ingest table.
 @disagg_test_class
-class test_layered33(wttest.WiredTigerTestCase):
+class test_layered_follower08(wttest.WiredTigerTestCase):
     conn_base_config = 'statistics=(all),statistics_log=(wait=1,json=true,on_close=true),' \
                      + 'disaggregated=(lose_all_my_data=true),'
     conn_config = conn_base_config + 'disaggregated=(role="follower")'
@@ -43,7 +43,7 @@ class test_layered33(wttest.WiredTigerTestCase):
         ('integer', dict(value_format='I')),
     ]
 
-    disagg_storages = gen_disagg_storages('test_layered33', disagg_only = True)
+    disagg_storages = gen_disagg_storages('test_layered_follower08', disagg_only = True)
     scenarios = make_scenarios(disagg_storages, format_values)
 
     def value(self, v):
@@ -52,7 +52,7 @@ class test_layered33(wttest.WiredTigerTestCase):
         return v
 
     def test_delete(self):
-        uri = "layered:test_layered33"
+        uri = "layered:test_layered_follower08"
         self.session.create(uri, f'key_format=S,value_format={self.value_format}')
 
         cursor = self.session.open_cursor(uri, None, None)

--- a/test/suite/test_layered_follower09.py
+++ b/test/suite/test_layered_follower09.py
@@ -30,18 +30,18 @@ import wttest
 from helper_disagg import disagg_test_class, gen_disagg_storages, Oplog
 from wtscenario import make_scenarios
 
-# test_layered37.py
+# test_layered_follower09.py
 # Test pinning the content in the ingest table
 @disagg_test_class
-class test_layered37(wttest.WiredTigerTestCase):
+class test_layered_follower09(wttest.WiredTigerTestCase):
     conn_base_config = ',create,cache_size=10GB,statistics=(all),statistics_log=(wait=1,json=true,on_close=true),' \
                  + 'disaggregated=(lose_all_my_data=true),'
 
-    disagg_storages = gen_disagg_storages('test_layered37', disagg_only = True)
+    disagg_storages = gen_disagg_storages('test_layered_follower09', disagg_only = True)
 
     scenarios = make_scenarios(disagg_storages)
 
-    uri = 'layered:test_layered37'
+    uri = 'layered:test_layered_follower09'
 
     nitems = 20000
 
@@ -105,7 +105,7 @@ class test_layered37(wttest.WiredTigerTestCase):
         self.disagg_advance_checkpoint(conn_follow)
 
         # Trigger eviction on the ingest table
-        evict_cursor = session_follow.open_cursor("file:test_layered37.wt_ingest", None, "debug=(release_evict)")
+        evict_cursor = session_follow.open_cursor("file:test_layered_follower09.wt_ingest", None, "debug=(release_evict)")
         for i in range(1, self.nitems):
             session_follow.begin_transaction(f'read_timestamp={self.timestamp_str(ts)}')
             evict_cursor.set_key(str(i))

--- a/test/suite/test_layered_follower10.py
+++ b/test/suite/test_layered_follower10.py
@@ -28,22 +28,22 @@
 
 import platform, wttest, wiredtiger
 from helper_disagg import disagg_test_class, gen_disagg_storages
-from test_layered23 import Oplog
+from test_layered_follower02 import Oplog
 from wtscenario import make_scenarios
 
-# test_layered38.py
+# test_layered_follower10.py
 # Test garbage collecting redundant content in the ingest table
 @disagg_test_class
-class test_layered38(wttest.WiredTigerTestCase):
+class test_layered_follower10(wttest.WiredTigerTestCase):
     conn_base_config = ',create,cache_size=10GB,statistics=(all),statistics_log=(wait=1,json=true,on_close=true),' \
                  + 'disaggregated=(lose_all_my_data=true),precise_checkpoint=true,'
 
-    disagg_storages = gen_disagg_storages('test_layered38', disagg_only = True)
+    disagg_storages = gen_disagg_storages('test_layered_follower10', disagg_only = True)
 
     scenarios = make_scenarios(disagg_storages)
 
-    uri = 'layered:test_layered38'
-    ingest_uri = 'file:test_layered38.wt_ingest'
+    uri = 'layered:test_layered_follower10'
+    ingest_uri = 'file:test_layered_follower10.wt_ingest'
 
     nitems = 1000
 
@@ -54,7 +54,7 @@ class test_layered38(wttest.WiredTigerTestCase):
     # This will GC content when possible.
     def evict_ingest(self, session, ts):
         # Trigger eviction on the ingest table
-        evict_cursor = session.open_cursor("file:test_layered38.wt_ingest", None, "debug=(release_evict)")
+        evict_cursor = session.open_cursor("file:test_layered_follower10.wt_ingest", None, "debug=(release_evict)")
         for i in range(1, self.nitems + 1):
             session.begin_transaction(f'read_timestamp={self.timestamp_str(ts)}')
             evict_cursor.set_key(str(i))

--- a/test/suite/test_layered_follower11.py
+++ b/test/suite/test_layered_follower11.py
@@ -33,8 +33,8 @@ from wtscenario import make_scenarios
 # Test we don't remove the user tombstones from the ingest table until they are included in a checkpoint.
 
 @disagg_test_class
-class test_layered49(wttest.WiredTigerTestCase):
-    disagg_storages = gen_disagg_storages('test_layered49', disagg_only = True)
+class test_layered_follower11(wttest.WiredTigerTestCase):
+    disagg_storages = gen_disagg_storages('test_layered_follower11', disagg_only = True)
     scenarios = make_scenarios(disagg_storages)
 
     conn_base_config = 'cache_size=10MB,'
@@ -68,7 +68,7 @@ class test_layered49(wttest.WiredTigerTestCase):
         self.session_follow = self.conn_follow.open_session('')
 
     def test_remove(self):
-        uri = "layered:test_layered49"
+        uri = "layered:test_layered_follower11"
         # Setup
         self.session.create(uri, 'key_format=S,value_format=S')
         self.create_follower()
@@ -109,7 +109,7 @@ class test_layered49(wttest.WiredTigerTestCase):
         self.session_follow.rollback_transaction()
 
     def test_truncate(self):
-        uri = "layered:test_layered49"
+        uri = "layered:test_layered_follower11"
         # Setup
         self.session.create(uri, 'key_format=S,value_format=S')
         self.create_follower()

--- a/test/suite/test_layered_follower12.py
+++ b/test/suite/test_layered_follower12.py
@@ -30,23 +30,23 @@ import os, os.path, shutil, threading, time, wiredtiger, wttest
 from helper_disagg import disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 
-# test_layered61.py
+# test_layered_follower12.py
 # Test the timestamps on the ingest tables are not cleared even they are globally
 # visible.
 @disagg_test_class
-class test_layered61(wttest.WiredTigerTestCase):
+class test_layered_follower12(wttest.WiredTigerTestCase):
     conn_base_config = 'statistics=(all),' \
                      + 'statistics_log=(wait=1,json=true,on_close=true),' \
                      + 'precise_checkpoint=true,'
     conn_config = conn_base_config + 'disaggregated=(role="follower")'
 
     create_session_config = 'key_format=S,value_format=S'
-    uri = "layered:test_layered61"
+    uri = "layered:test_layered_follower12"
 
-    disagg_storages = gen_disagg_storages('test_layered61', disagg_only = True)
+    disagg_storages = gen_disagg_storages('test_layered_follower12', disagg_only = True)
     scenarios = make_scenarios(disagg_storages)
 
-    def test_layered61(self):
+    def test_layered_follower12(self):
         # Create a table with some data
         self.session.create(self.uri, self.create_session_config)
         cursor = self.session.open_cursor(self.uri, None, None)

--- a/test/suite/test_layered_follower13.py
+++ b/test/suite/test_layered_follower13.py
@@ -26,7 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-# test_layered79.py
+# test_layered_follower13.py
 #   Test that when a key is garbage collected during eviction on an ingest
 #   btree, its associated on-disk value is also deleted.
 
@@ -36,16 +36,16 @@ from wtscenario import make_scenarios
 from wiredtiger import stat
 
 @disagg_test_class
-class test_layered79(wttest.WiredTigerTestCase):
+class test_layered_follower13(wttest.WiredTigerTestCase):
     base_config = 'statistics=(all),precise_checkpoint=true,'
     conn_config = base_config + 'disaggregated=(role="leader")'
     conn_config_follower = base_config + 'disaggregated=(role="follower")'
 
-    uri = 'layered:test_layered79'
-    ingest_uri = 'file:test_layered79.wt_ingest'
+    uri = 'layered:test_layered_follower13'
+    ingest_uri = 'file:test_layered_follower13.wt_ingest'
     create_config = 'key_format=i,value_format=S'
 
-    disagg_storages = gen_disagg_storages('test_layered79', disagg_only=True)
+    disagg_storages = gen_disagg_storages('test_layered_follower13', disagg_only=True)
     scenarios = make_scenarios(disagg_storages)
 
     conn_follow = None

--- a/test/suite/test_layered_follower14.py
+++ b/test/suite/test_layered_follower14.py
@@ -26,7 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-# test_layered80.py
+# test_layered_follower14.py
 # Test that the sweep server does not close ingest table dhandles and layered dhandles on a follower
 # or during step-up. Closing the ingest dhandle discards all in-memory data for
 # that table (WT-16974, WT-16703).
@@ -41,7 +41,7 @@ from wiredtiger import stat
 from wtscenario import make_scenarios
 
 @disagg_test_class
-class test_layered80(wttest.WiredTigerTestCase):
+class test_layered_follower14(wttest.WiredTigerTestCase):
     # Use aggressive sweep settings so the server has every opportunity to
     # incorrectly close the ingest dhandle while we are running as follower.
     conn_config = 'statistics=(all),' \
@@ -49,10 +49,10 @@ class test_layered80(wttest.WiredTigerTestCase):
                   'verbose=(sweep:3),' \
                   'disaggregated=(role="follower")'
 
-    uri = 'layered:test_layered80'
+    uri = 'layered:test_layered_follower14'
     nrows = 1000
 
-    disagg_storages = gen_disagg_storages('test_layered80', disagg_only=True)
+    disagg_storages = gen_disagg_storages('test_layered_follower14', disagg_only=True)
     scenarios = make_scenarios(disagg_storages)
 
     def wait_for_sweep(self):
@@ -88,7 +88,7 @@ class test_layered80(wttest.WiredTigerTestCase):
         self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(self.nrows))
 
         # Pin the ingest table dhandle, so it doesn't get swept away on purpose.
-        cursor = self.session.open_cursor("file:test_layered80.wt_ingest")
+        cursor = self.session.open_cursor("file:test_layered_follower14.wt_ingest")
 
         # Wait for the sweep server to run several cycles. If it is not configured
         # to skip layered dhandles, it would mark and close them, causing gaps when

--- a/test/suite/test_layered_stepup01.py
+++ b/test/suite/test_layered_stepup01.py
@@ -29,10 +29,10 @@
 import os, sys, time, wiredtiger, wttest
 from helper_disagg import disagg_test_class
 
-# test_layered07.py
+# test_layered_stepup01.py
 #    Start a second WT that becomes leader and checks that content appears in the first.
 @disagg_test_class
-class test_layered07(wttest.WiredTigerTestCase):
+class test_layered_stepup01(wttest.WiredTigerTestCase):
     nitems = 500
 
     conn_base_config = 'statistics=(all),statistics_log=(wait=1,json=true,on_close=true),' \
@@ -41,10 +41,10 @@ class test_layered07(wttest.WiredTigerTestCase):
 
     create_session_config = 'key_format=S,value_format=S'
 
-    uri = "layered:test_layered07"
+    uri = "layered:test_layered_stepup01"
 
     # Test inserting records into a follower that turned into a leader
-    def test_layered07(self):
+    def test_layered_stepup01(self):
         if sys.platform.startswith('darwin'):
             return
 

--- a/test/suite/test_layered_stepup02.py
+++ b/test/suite/test_layered_stepup02.py
@@ -31,22 +31,22 @@ from helper_disagg import disagg_test_class, gen_disagg_storages
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 
-# test_layered21.py
+# test_layered_stepup02.py
 #    Test the basic ability to insert on a follower.
 @disagg_test_class
-class test_layered21(wttest.WiredTigerTestCase):
+class test_layered_stepup02(wttest.WiredTigerTestCase):
     conn_base_config = 'statistics=(all),statistics_log=(wait=1,json=true,on_close=true),'
     def conn_config(self):
         return self.conn_base_config + f'disaggregated=(role="{self.initial_role}")'
 
-    uri = "layered:test_layered21"
+    uri = "layered:test_layered_stepup02"
     nentries = 1000
 
     role_scenarios = [
         ('leader', dict(initial_role='leader')),
         ('follower', dict(initial_role='follower')),
     ]
-    disagg_storages = gen_disagg_storages('test_layered21', disagg_only = True)
+    disagg_storages = gen_disagg_storages('test_layered_stepup02', disagg_only = True)
     scenarios = make_scenarios(disagg_storages, role_scenarios)
 
     # Test simple inserts to a leader/follower

--- a/test/suite/test_layered_stepup03.py
+++ b/test/suite/test_layered_stepup03.py
@@ -35,12 +35,12 @@ from wtscenario import make_scenarios
 # Test that leader-to-follower role transition doesn't crash when eviction
 # processes pages that were split during a prior checkpoint.
 @disagg_test_class
-class test_layered77(eviction_util, wttest.WiredTigerTestCase):
+class test_layered_stepup03(eviction_util, wttest.WiredTigerTestCase):
     conn_base_config = 'cache_size=10MB,'
 
-    disagg_storages = gen_disagg_storages('test_layered77', disagg_only = True)
+    disagg_storages = gen_disagg_storages('test_layered_stepup03', disagg_only = True)
     scenarios = make_scenarios(disagg_storages)
-    uri='layered:test_layered77'
+    uri='layered:test_layered_stepup03'
 
     def conn_config(self):
         return self.conn_base_config + 'disaggregated=(role="leader"),'

--- a/test/suite/test_layered_stepup04.py
+++ b/test/suite/test_layered_stepup04.py
@@ -26,7 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-# test_layered94.py
+# test_layered_stepup04.py
 #   Verifies that a prepared transaction active on a follower at step-up time can be
 #   committed or rolled back after step-up completes.
 #
@@ -47,8 +47,8 @@ from helper_disagg import disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 
 @disagg_test_class
-class test_layered94(wttest.WiredTigerTestCase):
-    tablename = 'test_layered94'
+class test_layered_stepup04(wttest.WiredTigerTestCase):
+    tablename = 'test_layered_stepup04'
     uri = 'layered:' + tablename
 
     resolve_scenarios = [
@@ -63,7 +63,7 @@ class test_layered94(wttest.WiredTigerTestCase):
         ('single_table', dict(multi_table=False)),
         ('multi_table',  dict(multi_table=True)),
     ]
-    disagg_storages = gen_disagg_storages('test_layered94', disagg_only=True)
+    disagg_storages = gen_disagg_storages('test_layered_stepup04', disagg_only=True)
     scenarios = make_scenarios(
         disagg_storages, resolve_scenarios, checkpoint_scenarios, multi_table_scenarios)
 

--- a/test/suite/test_layered_stepup05.py
+++ b/test/suite/test_layered_stepup05.py
@@ -30,7 +30,7 @@ import wiredtiger, wttest
 from helper_disagg import disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 
-# test_layered99.py
+# test_layered_stepup05.py
 #    Test that cursor operations on a layered cursor after step-up work correctly
 #    when the cursor was reset on the follower before the step-up.
 #
@@ -38,14 +38,14 @@ from wtscenario import make_scenarios
 #      ckpt1 (TS=1): keys "1", "3", "5"
 #      ckpt2 (TS=2): adds "7", "9" and updates "1" to a new value
 @disagg_test_class
-class test_layered99(wttest.WiredTigerTestCase):
-    uri = "layered:test_layered99"
+class test_layered_stepup05(wttest.WiredTigerTestCase):
+    uri = "layered:test_layered_stepup05"
 
     conn_base_config = 'statistics=(all),'
     conn_config = conn_base_config + 'disaggregated=(role="leader")'
     conn_config_follower = conn_base_config + 'disaggregated=(role="follower")'
 
-    disagg_storages = gen_disagg_storages('test_layered99', disagg_only=True)
+    disagg_storages = gen_disagg_storages('test_layered_stepup05', disagg_only=True)
 
     # Timestamps for the two checkpoints.
     ckpt1_ts = 1

--- a/test/suite/test_layered_stepup06.py
+++ b/test/suite/test_layered_stepup06.py
@@ -26,7 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-# test_layered103.py
+# test_layered_stepup06.py
 #   When two prepared sessions share the same prepared_id, a follower
 #   stepping up to leader must resolve all of them.
 #
@@ -42,14 +42,14 @@ from wtscenario import make_scenarios
 
 @wttest.skip_for_hook("tiered", "Layered tables are not supported with tiered storage")
 @disagg_test_class
-class test_layered103(wttest.WiredTigerTestCase):
-    uri = 'layered:test_layered103'
+class test_layered_stepup06(wttest.WiredTigerTestCase):
+    uri = 'layered:test_layered_stepup06'
 
     resolve_scenarios = [
         ('commit',   dict(commit=True)),
         ('rollback', dict(commit=False)),
     ]
-    disagg_storages = gen_disagg_storages('test_layered103', disagg_only=True)
+    disagg_storages = gen_disagg_storages('test_layered_stepup06', disagg_only=True)
     scenarios = make_scenarios(disagg_storages, resolve_scenarios)
 
     conn_base_config = (

--- a/test/suite/test_layered_stepup07.py
+++ b/test/suite/test_layered_stepup07.py
@@ -26,7 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-# test_layered106.py
+# test_layered_stepup07.py
 #   Verify that schema operations on layered tables are illegal during a role transition.
 #   Attempting to take a schema lock fires an assert when step-up or step-down is ongoing,
 #   aborting the process.
@@ -44,13 +44,13 @@ from suite_subprocess import suite_subprocess
 from wtscenario import make_scenarios
 
 @disagg_test_class
-class test_layered106(wttest.WiredTigerTestCase, suite_subprocess):
-    tablename = 'test_layered106'
+class test_layered_stepup07(wttest.WiredTigerTestCase, suite_subprocess):
+    tablename = 'test_layered_stepup07'
     uri = 'layered:' + tablename
     new_uri = 'layered:' + tablename + '_new'
     num_rows = 100
 
-    disagg_storages = gen_disagg_storages('test_layered106', disagg_only=True)
+    disagg_storages = gen_disagg_storages('test_layered_stepup07', disagg_only=True)
     transitions = [
         ('step_up',   dict(start_role='follower', target_role='leader')),
         ('step_down', dict(start_role='leader',   target_role='follower')),
@@ -120,7 +120,7 @@ class test_layered106(wttest.WiredTigerTestCase, suite_subprocess):
     def test_race(self):
         rc, _ = self.run_subprocess_function(
             'SUBPROCESS',
-            'test_layered106.test_layered106.subprocess_race',
+            'test_layered_stepup07.test_layered_stepup07.subprocess_race',
             silent=True)
         self.assertEqual(rc, -signal.SIGABRT,
             f'expected process to abort (rc={-signal.SIGABRT}) but got rc={rc}')

--- a/test/suite/test_layered_stepup08.py
+++ b/test/suite/test_layered_stepup08.py
@@ -30,10 +30,10 @@ import platform, wttest
 from helper_disagg import disagg_test_class, gen_disagg_storages, Oplog
 from wtscenario import make_scenarios
 
-# test_layered27.py
+# test_layered_stepup08.py
 # Test draining the ingest table
 @disagg_test_class
-class test_layered27(wttest.WiredTigerTestCase):
+class test_layered_stepup08(wttest.WiredTigerTestCase):
     conn_base_config = ',create,statistics=(all),statistics_log=(wait=1,json=true,on_close=true),' \
                  + ''
 
@@ -42,11 +42,11 @@ class test_layered27(wttest.WiredTigerTestCase):
         ('large', dict(multiplier=100)),
     ]
 
-    disagg_storages = gen_disagg_storages('test_layered27', disagg_only = True)
+    disagg_storages = gen_disagg_storages('test_layered_stepup08', disagg_only = True)
 
     scenarios = make_scenarios(disagg_storages, sizes)
 
-    uri = 'layered:test_layered27'
+    uri = 'layered:test_layered_stepup08'
 
     @property
     def base_config(self):


### PR DESCRIPTION
Pt 4 of 4 splitting up the test rename effort started in WT-17570.
  Pt 1 (WT-17570): cursor, eviction, fast_truncate — merged
  Pt 2 (WT-17658): delta, checkpoint, prepare — merged
  Pt 3 (WT-17659): schema, config + bucket-fit moves - (Merging)
  **Pt 4 (this): follower, stepup + remaining bucket-fit moves and misnamed layered tests**

24 renames in this slice. Class names, method names, and header comments inside each file are updated to match the new filename.

Folds in misnamed layered tests:
- test_cc11 -> follower07 (checkpoint cleanup not run on follower with page_delta)
- test_layered106 -> stepup07 (schema ops race with step-up/step-down)
