### PR TITLE
WT-17411 Fix UAF: hold child hazard pointer through internal-page value image copy

### DIFF
--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -207,14 +207,17 @@ __wti_rec_col_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_REF *pageref)
         }
         if (page_del != NULL)
             WT_TIME_AGGREGATE_UPDATE_PAGE_DEL(session, &ft_ta, page_del);
-        WTI_CHILD_RELEASE_ERR(session, cms.hazard, ref);
 
         /* Boundary: split or write the page. */
         if (__wti_rec_need_split(r, val->len))
             WT_ERR(__wti_rec_split_crossing_bnd(session, r, val->len));
 
-        /* Copy the value (which is in val, val == r->v) onto the page. */
+        /*
+         * Copy the value onto the page. val->buf.data may point directly into ref's WT_ADDR
+         * block_cookie; hold the hazard pointer until after the copy.
+         */
         __wti_rec_image_copy(session, r, val);
+        WTI_CHILD_RELEASE_ERR(session, cms.hazard, ref);
         if (page_del != NULL)
             WTI_REC_CHUNK_TA_MERGE(session, r->cur_ptr, &ft_ta);
         WTI_REC_CHUNK_TA_MERGE(session, r->cur_ptr, &ta);

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -779,7 +779,6 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
             WT_TIME_AGGREGATE_UPDATE_PAGE_DEL(session, &ft_ta, page_del);
 
         F_CLR(ref, WT_REF_FLAG_REC_MULTIPLE);
-        WTI_CHILD_RELEASE_ERR(session, cms.hazard, ref);
 
         /* Build key cell. Truncate any 0th key, internal pages don't need 0th keys. */
         __wt_ref_key(page, ref, &p, &size);
@@ -791,9 +790,13 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
         if (__wti_rec_need_split(r, key->len + val->len))
             WT_ERR(__wti_rec_split_crossing_bnd(session, r, key->len + val->len));
 
-        /* Copy the key and value onto the page. */
+        /*
+         * Copy the key and value onto the page. val->buf.data may point directly into ref's WT_ADDR
+         * block_cookie; hold the hazard pointer until after both copies.
+         */
         __wti_rec_image_copy(session, r, key);
         __wti_rec_image_copy(session, r, val);
+        WTI_CHILD_RELEASE_ERR(session, cms.hazard, ref);
         if (page_del != NULL)
             WTI_REC_CHUNK_TA_MERGE(session, r->cur_ptr, &ft_ta);
         WTI_REC_CHUNK_TA_MERGE(session, r->cur_ptr, &ta);


### PR DESCRIPTION
In `__wti_rec_row_int` and `__wti_rec_col_int`, `WTI_CHILD_RELEASE_ERR` was called
before `__wti_rec_image_copy(val)`. When the reconciled child has an off-page `WT_ADDR`,
`val->buf.data` points directly into the child's `WT_ADDR::block_cookie`. Releasing the
hazard pointer at that point allows a concurrent `__wt_split_rewrite` to call
`__wt_ref_addr_free`, freeing the `WT_ADDR` and its `block_cookie` before the image copy
reads it — a latent Use-After-Free / ASAN hit under concurrent split workloads.

Move `WTI_CHILD_RELEASE_ERR` to after both `__wti_rec_image_copy` calls so the hazard
pointer is held for the full lifetime of `val->buf.data`.

The early-exit `continue` paths (IGNORE, EMPTY, MULTIBLOCK cases) are unaffected —
they release before `continue` with no `val->buf.data` alias in play.