### PR TITLE
WT-13690 Enable ZSTD compression in format-stress-ppc-test

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5143,8 +5143,6 @@ tasks:
       - func: "compile wiredtiger"
         vars:
           <<: *configure_flags_with_builtins
-          # FIXME-WT-13690: Enable ZSTD compression once failure has been resolved.
-          HAVE_BUILTIN_EXTENSION_ZSTD: -DHAVE_BUILTIN_EXTENSION_ZSTD=0
       - func: "format test script"
         vars:
           #run for 2 hours ( 2 * 60 = 120 minutes), use default config


### PR DESCRIPTION
Re-enables ZSTD compression in the `format-stress-ppc-test` task by removing the `HAVE_BUILTIN_EXTENSION_ZSTD=0` override and its FIXME-WT-13690 comment.