### PR TITLE
WT-17533 Fix inaccurate lock description for backup.start in arch-cursor.dox

### DIFF
--- a/src/docs/arch-cursor.dox
+++ b/src/docs/arch-cursor.dox
@@ -180,8 +180,8 @@ First, we'll look at full backups.
 A backup cursor for a full backup returns the set of files that need to be copied to achieve the
 backup.  The backup cursor, when opened, ensures that it is the only backup cursor running
 in the system and returns an error if not.  This is managed using the
-\c WT_CONNECTION_IMPL->backup.start variable, which can only be accessed when the
-connection schema lock is held.  A non-zero value means a hot backup is in progress.
+\c WT_CONNECTION_IMPL->backup.start variable, which is guarded by the hot backup
+read-write lock \c backup.lock.  A non-zero value means a hot backup is in progress.
 Closing the backup cursor sets it back to zero.
 
 Having an open backup influences actions


### PR DESCRIPTION
## Summary
- `src/docs/arch-cursor.dox` claimed `WT_CONNECTION_IMPL->backup.start` could only be accessed when the connection schema lock is held.
- The field is actually guarded by the hot backup read-write lock `backup.lock` (see `WT_WITH_HOTBACKUP_WRITE_LOCK` in `src/cursor/cur_backup.c` and the `backup.lock` read/write locking in `src/include/schema.h`).
- Updated the sentence to reference `backup.lock` instead.

## Testing
Documentation-only change; no functional code touched. Verified by inspecting current call sites of `conn->backup.start` and the locking around them.