### PR TITLE
WT-17682 Fix s_fast to use git merge-base and skip unchanged scripts

### DIFF
--- a/dist/common_functions.py
+++ b/dist/common_functions.py
@@ -41,18 +41,12 @@ import inspect, os, subprocess, sys
 
 
 def last_commit_from_dev():
-    # Find the commit from develop at which point the current branch diverged.
-    # rev-list will show all commits that are present on our current branch but not on develop, and
-    # the oldest of these is our first commit post-divergence. If this commit exists then
-    # we can take its parent. If no such commits exist then we're currently on a commit in the
-    # develop branch and can use HEAD instead
-
-    earliest_commit = subprocess.run( "git rev-list HEAD...develop | tail -n 1",
-        shell=True, capture_output=True, text=True).stdout
-
-    commit_on_dev = f"{earliest_commit}~" if earliest_commit else "HEAD"
-
-    return subprocess.run(f"git rev-parse {commit_on_dev}",
+    # Find the most recent common ancestor between the current branch and origin/develop.
+    # Using git merge-base correctly handles branches that have merged develop multiple
+    # times: it returns the latest develop commit reachable from HEAD, so that
+    # filter_if_fast only sees files changed by the author's own commits rather than
+    # every file touched by develop since the branch was first created.
+    return subprocess.run("git merge-base origin/develop HEAD",
         shell=True, capture_output=True, text=True).stdout.strip()
 
 

--- a/dist/s_copyright
+++ b/dist/s_copyright
@@ -3,6 +3,7 @@
 . `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh
 setup_trap
 cd_top
+check_fast_mode_flag
 
 # Check the copyrights.
 

--- a/dist/s_evergreen
+++ b/dist/s_evergreen
@@ -7,7 +7,7 @@ check_fast_mode_flag
 
 # In fast mode, skip if no evergreen yml files were modified in our commits.
 if is_fast_mode; then
-    search=`git diff --name-only "$(last_commit_from_dev)" | grep -E 'evergreen.*\.yml$'`
+    search=`git diff --name-only "$(last_commit_from_dev)" | grep -E 'evergreen.*\.yml$' || true`
     if test -z "$search"; then
         exit 0
     fi

--- a/dist/s_evergreen
+++ b/dist/s_evergreen
@@ -3,6 +3,15 @@
 . `dirname -- ${BASH_SOURCE[0]}`/common_functions.sh
 setup_trap
 cd_top
+check_fast_mode_flag
+
+# In fast mode, skip if no evergreen yml files were modified in our commits.
+if is_fast_mode; then
+    search=`git diff --name-only "$(last_commit_from_dev)" | grep -E 'evergreen.*\.yml$'`
+    if test -z "$search"; then
+        exit 0
+    fi
+fi
 
 error=0
 


### PR DESCRIPTION
- Fix `last_commit_from_dev()` in `dist/common_functions.py` to use `git merge-base origin/develop HEAD` instead of the broken `rev-list` walk, so `filter_if_fast` correctly scopes to only the author's changed files even on branches that have merged develop multiple times
- Add fast-mode support to `dist/s_evergreen` so it exits early when no `evergreen*.yml` files were modified, eliminating spurious Evergreen credential prompts on every `s_fast` run
- Add `check_fast_mode_flag` to `dist/s_copyright` so the sequential ~17s full-tree scan is skipped in fast mode when no relevant files changed
