### PR TITLE
WT-17663 Implement prepared fast truncate write

### DIFF
--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -271,13 +271,14 @@ __wt_delete_page_rollback(WT_SESSION_IMPL *session, WT_TXN_OP *op)
     if (current_state == WT_REF_DELETED) {
         WT_PAGE_DELETED *page_del = ref->page_del;
 
-        if (page_del->prepared_id != WT_PREPARED_ID_NONE) {
+        if (page_del->prepared_id != WT_PREPARED_ID_NONE &&
+          F_ISSET(S2C(session), WT_CONN_PRECISE_CHECKPOINT)) {
             /*
-             * This was a prepared fast-truncate. We cannot discard the page_del because
-             * reconciliation needs to write a prepared proxy cell in the parent page as long as the
-             * prepare timestamp is stable but the rollback timestamp is not. Keep the ref and mark
-             * the structure as aborted so that readers skip the deletion and reconciliation can
-             * apply the correct selection logic.
+             * This was a prepared fast-truncate under a precise checkpoint. We cannot discard the
+             * page_del because reconciliation needs to write a prepared proxy cell in the parent
+             * page as long as the prepare timestamp is stable but the rollback timestamp is not.
+             * Keep the ref in WT_REF_DELETED and mark the structure as aborted so that readers skip
+             * the deletion and reconciliation applies the correct selection logic.
              */
             if (F_ISSET(&txn->time_point, WT_TXN_TIME_POINT_HAS_TS_ROLLBACK))
                 page_del->pg_del_rollback_ts = txn->time_point.rollback_timestamp;
@@ -285,14 +286,12 @@ __wt_delete_page_rollback(WT_SESSION_IMPL *session, WT_TXN_OP *op)
                 page_del->pg_del_rollback_ts = WT_TS_MAX;
             /* Save the original txnid before overwriting it. */
             page_del->pg_del_saved_txnid = page_del->txnid;
-            __wt_atomic_store_uint64_v_relaxed(&page_del->txnid, WT_TXN_ABORTED);
-            /* Keep WT_REF_DELETED; reconciliation will transition to DISK when stable. */
-            current_state = WT_REF_DELETED;
+            __wt_atomic_store_uint64_v_release(&page_del->txnid, WT_TXN_ABORTED);
         } else {
             /*
-             * Non-prepared fast-truncate. Don't set the WT_PAGE_DELETED transaction ID to aborted;
-             * instead, just discard the structure. This avoids having to check for an aborted
-             * delete in other situations.
+             * Non-prepared fast-truncate, or prepared but not under precise checkpoint. Don't set
+             * the WT_PAGE_DELETED transaction ID to aborted; instead, just discard the structure.
+             * This avoids having to check for an aborted delete in other situations.
              */
             current_state = WT_REF_DISK;
             __wt_free(session, ref->page_del);

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -289,9 +289,9 @@ __wt_delete_page_rollback(WT_SESSION_IMPL *session, WT_TXN_OP *op)
                  */
                 page_del->pg_del_rollback_ts = WT_TS_MAX;
             /*
-             * Save the original txnid before overwriting it. Guard against a second call during WAL
-             * replay where txnid is already WT_TXN_ABORTED from the checkpoint cell; overwriting
-             * pg_del_saved_txnid in that case would destroy the original value.
+             * Save the original txnid before overwriting it. Guard against a second call during
+             * write-ahead log replay where txnid is already WT_TXN_ABORTED from the checkpoint
+             * cell; overwriting pg_del_saved_txnid in that case would destroy the original value.
              *
              * After crash-restart, correctness of the stable-rollback check relies on WAL replay to
              * restore rollback timestamps before the next checkpoint runs.

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -273,11 +273,11 @@ __wt_delete_page_rollback(WT_SESSION_IMPL *session, WT_TXN_OP *op)
 
         if (page_del->prepared_id != WT_PREPARED_ID_NONE) {
             /*
-             * This was a prepared fast-truncate. We cannot discard the page_del
-             * because reconciliation needs to write a prepared proxy cell in the parent page as
-             * long as the prepare timestamp is stable but the rollback timestamp is not. Keep the
-             * ref and mark the structure as aborted so that readers skip the
-             * deletion and reconciliation can apply the correct selection logic.
+             * This was a prepared fast-truncate. We cannot discard the page_del because
+             * reconciliation needs to write a prepared proxy cell in the parent page as long as the
+             * prepare timestamp is stable but the rollback timestamp is not. Keep the ref and mark
+             * the structure as aborted so that readers skip the deletion and reconciliation can
+             * apply the correct selection logic.
              */
             if (F_ISSET(&txn->time_point, WT_TXN_TIME_POINT_HAS_TS_ROLLBACK))
                 page_del->pg_del_rollback_ts = txn->time_point.rollback_timestamp;
@@ -290,9 +290,9 @@ __wt_delete_page_rollback(WT_SESSION_IMPL *session, WT_TXN_OP *op)
             current_state = WT_REF_DELETED;
         } else {
             /*
-             * Non-prepared fast-truncate. Don't set the
-             * WT_PAGE_DELETED transaction ID to aborted; instead, just discard the structure. This
-             * avoids having to check for an aborted delete in other situations.
+             * Non-prepared fast-truncate. Don't set the WT_PAGE_DELETED transaction ID to aborted;
+             * instead, just discard the structure. This avoids having to check for an aborted
+             * delete in other situations.
              */
             current_state = WT_REF_DISK;
             __wt_free(session, ref->page_del);

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -269,22 +269,34 @@ __wt_delete_page_rollback(WT_SESSION_IMPL *session, WT_TXN_OP *op)
      * the update list to be null to be conservative.
      */
     if (current_state == WT_REF_DELETED) {
-        /*
-         * When fast truncate succeeds it moves a WT_REF from WT_REF_DISK to WT_REF_DELETED. Thus
-         * the reverse operation is to return the state to WT_REF_DISK.
-         */
-        current_state = WT_REF_DISK;
+        WT_PAGE_DELETED *page_del = ref->page_del;
 
-        /*
-         * TODO: handle prepared rollback here. We can no longer free the page del structure if it
-         * is a prepared transaction.
-         */
-
-        /*
-         * Don't set the WT_PAGE_DELETED transaction ID to aborted; instead, just discard the
-         * structure. This avoids having to check for an aborted delete in other situations.
-         */
-        __wt_free(session, ref->page_del);
+        if (page_del->prepared_id != WT_PREPARED_ID_NONE) {
+            /*
+             * This was a prepared fast-truncate. We cannot discard the page_del
+             * because reconciliation needs to write a prepared proxy cell in the parent page as
+             * long as the prepare timestamp is stable but the rollback timestamp is not. Keep the
+             * ref and mark the structure as aborted so that readers skip the
+             * deletion and reconciliation can apply the correct selection logic.
+             */
+            if (F_ISSET(&txn->time_point, WT_TXN_TIME_POINT_HAS_TS_ROLLBACK))
+                page_del->pg_del_rollback_ts = txn->time_point.rollback_timestamp;
+            else
+                page_del->pg_del_rollback_ts = WT_TS_MAX;
+            /* Save the original txnid before overwriting it. */
+            page_del->pg_del_saved_txnid = page_del->txnid;
+            __wt_atomic_store_uint64_v_relaxed(&page_del->txnid, WT_TXN_ABORTED);
+            /* Keep WT_REF_DELETED; reconciliation will transition to DISK when stable. */
+            current_state = WT_REF_DELETED;
+        } else {
+            /*
+             * Non-prepared fast-truncate. Don't set the
+             * WT_PAGE_DELETED transaction ID to aborted; instead, just discard the structure. This
+             * avoids having to check for an aborted delete in other situations.
+             */
+            current_state = WT_REF_DISK;
+            __wt_free(session, ref->page_del);
+        }
     } else {
         WT_ASSERT(session, ref->page != NULL && ref->page->modify != NULL);
         if ((updp = ref->page->modify->inst_updates) != NULL) {

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -283,9 +283,21 @@ __wt_delete_page_rollback(WT_SESSION_IMPL *session, WT_TXN_OP *op)
             if (F_ISSET(&txn->time_point, WT_TXN_TIME_POINT_HAS_TS_ROLLBACK))
                 page_del->pg_del_rollback_ts = txn->time_point.rollback_timestamp;
             else
+                /*
+                 * No rollback timestamp available; use WT_TS_MAX so that the proxy cell is always
+                 * written (stable_ts < WT_TS_MAX is always true).
+                 */
                 page_del->pg_del_rollback_ts = WT_TS_MAX;
-            /* Save the original txnid before overwriting it. */
-            page_del->pg_del_saved_txnid = page_del->txnid;
+            /*
+             * Save the original txnid before overwriting it. Guard against a second call during WAL
+             * replay where txnid is already WT_TXN_ABORTED from the checkpoint cell; overwriting
+             * pg_del_saved_txnid in that case would destroy the original value.
+             *
+             * After crash-restart, correctness of the stable-rollback check relies on WAL replay to
+             * restore rollback timestamps before the next checkpoint runs.
+             */
+            if (page_del->txnid != WT_TXN_ABORTED)
+                page_del->pg_del_saved_txnid = page_del->txnid;
             __wt_atomic_store_uint64_v_release(&page_del->txnid, WT_TXN_ABORTED);
         } else {
             /*

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -840,7 +840,7 @@ __evict_child_check(WT_SESSION_IMPL *session, WT_REF *parent)
              *     4. Otherwise, check if the operation is globally visible.
              *
              * Even though we specifically can't evict prepared truncations, we don't need to deploy
-             * the special-case logic for prepared transactions in __wt_page_del_visible; prepared
+             * the special-case logic for prepared transactions; prepared
              * transactions aren't committed so they'll fail the first check.
              */
             if (!__wt_page_del_committed_set(child->page_del))

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -2752,7 +2752,7 @@ __wt_btcur_skip_page(
      * Check the fast-truncate information; there are 3 cases:
      *
      * (1) The page is in the WT_REF_DELETED state and page_del is NULL. The page is deleted. This
-     *     case is folded into the next because __wt_page_del_visible handles it.
+     *     case is folded into the next because visibility of truncate function handles it.
      * (2) The page is in the WT_REF_DELETED state and page_del is not NULL. The page is deleted
      *     if the truncate operation is visible. Look at page_del; we could use the info from the
      *     address cell below too, but that's slower.
@@ -2760,7 +2760,7 @@ __wt_btcur_skip_page(
      *     will serve for readonly/unmodified pages, and for modified pages we can't skip the page.
      *     (This case is checked further below.)
      *
-     * In all cases, make use of the option to __wt_page_del_visible to hide prepared transactions,
+     * In all cases, make use of the option to hide prepared transactions,
      * as we shouldn't skip pages where the deletion is prepared but not committed.
      */
     if (previous_state == WT_REF_DELETED && __wt_page_del_visible(session, ref->page_del, true)) {

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -196,17 +196,23 @@ __wt_check_addr_validity(WT_SESSION_IMPL *session, WT_TIME_AGGREGATE *ta, bool e
  *     Pack the validity window for an address.
  */
 static WT_INLINE void
-__cell_pack_addr_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_AGGREGATE *ta)
+__cell_pack_addr_validity(
+  WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_AGGREGATE *ta, bool is_prepared_fast_truncate)
 {
     uint8_t flags, *flagsp;
 
-    /* Globally visible values have no associated validity window. */
-    if (WT_TIME_AGGREGATE_IS_EMPTY(ta)) {
+    /*
+     * A prepared fast-truncate and a prepared time aggregate cannot be on the same page.
+     */
+    WT_ASSERT(session, !(ta->prepare && is_prepared_fast_truncate));
+
+    if (WT_TIME_AGGREGATE_IS_EMPTY(ta) && !is_prepared_fast_truncate) {
         ++*pp;
         return;
     }
 
-    WT_IGNORE_RET(__wt_check_addr_validity(session, ta, false));
+    if (!WT_TIME_AGGREGATE_IS_EMPTY(ta))
+        WT_IGNORE_RET(__wt_check_addr_validity(session, ta, false));
 
     **pp |= WT_CELL_SECOND_DESC;
     ++*pp;
@@ -263,6 +269,8 @@ __cell_pack_addr_validity(WT_SESSION_IMPL *session, uint8_t **pp, WT_TIME_AGGREG
         LF_SET(WT_CELL_TS_DURABLE_STOP);
     }
     if (ta->prepare)
+        LF_SET(WT_CELL_PREPARE);
+    if (is_prepared_fast_truncate)
         LF_SET(WT_CELL_PREPARE);
 
     *flagsp = flags;
@@ -566,10 +574,17 @@ __wt_cell_build_addr(WT_SESSION_IMPL *session, WT_CELL *cell, uint8_t cell_type,
         WT_ASSERT(session, cell_type == WT_CELL_ADDR_DEL || cell_type == WT_CELL_ADDR_LEAF_NO);
         cell_type = WT_CELL_ADDR_DEL;
 
-        /* We should never be in an in-progress prepared state. */
+        /*
+         * In-progress prepared states are only written to disk when preserve_prepared is enabled;
+         * otherwise only committed (INIT) or resolved-but-not-yet-committed (RESOLVED) states are
+         * expected.
+         */
         WT_ASSERT(session,
           page_del->prepare_state == WT_PREPARE_INIT ||
-            page_del->prepare_state == WT_PREPARE_RESOLVED);
+            page_del->prepare_state == WT_PREPARE_RESOLVED ||
+            (F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED) &&
+              (page_del->prepare_state == WT_PREPARE_INPROGRESS ||
+                page_del->prepare_state == WT_PREPARE_LOCKED)));
     }
 
     /* Just pack and return the cell size. */
@@ -584,24 +599,40 @@ static WT_INLINE size_t
 __wt_cell_pack_addr(WT_SESSION_IMPL *session, WT_CELL *cell, u_int cell_type, uint64_t recno,
   WT_PAGE_DELETED *page_del, WT_TIME_AGGREGATE *ta, size_t size)
 {
-    uint8_t *p;
+    uint8_t *p, prepare_state;
+    bool is_prepared_fast_truncate;
+
+    prepare_state = page_del != NULL ?
+      __wt_atomic_load_uint8_v_acquire(&page_del->prepare_state) :
+      WT_PREPARE_INIT;
+    is_prepared_fast_truncate =
+      (prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED);
 
     /* Start building a cell: the descriptor byte starts zero. */
     p = cell->__chunk;
     *p = '\0';
 
-    __cell_pack_addr_validity(session, &p, ta);
+    __cell_pack_addr_validity(session, &p, ta, is_prepared_fast_truncate);
 
     /*
      * If passed fast-delete information, append the fast-delete information after the aggregated
-     * timestamp information.
+     * timestamp information. A prepared fast-truncate stores the prepare timestamp and prepared_id
+     * in place of the committed start/durable timestamps so that recovery can reconstruct the
+     * prepared state.
      */
     if (page_del != NULL) {
         WT_ASSERT(session, cell_type == WT_CELL_ADDR_DEL);
 
         WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->txnid));
-        WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->pg_del_start_ts));
-        WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->pg_del_durable_ts));
+        if (is_prepared_fast_truncate) {
+            WT_ASSERT(session, F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED));
+            WT_ASSERT(session, page_del->prepared_id != WT_PREPARED_ID_NONE);
+            WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->prepare_ts));
+            WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->prepared_id));
+        } else {
+            WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->pg_del_start_ts));
+            WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->pg_del_durable_ts));
+        }
     }
 
     if (recno == WT_RECNO_OOB)

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -572,17 +572,6 @@ __wt_cell_build_addr(WT_SESSION_IMPL *session, WT_CELL *cell, uint8_t cell_type,
         WT_ASSERT(session, cell_type == WT_CELL_ADDR_DEL || cell_type == WT_CELL_ADDR_LEAF_NO);
         cell_type = WT_CELL_ADDR_DEL;
 
-        /*
-         * In-progress prepared states are only written to disk when preserve_prepared is enabled on
-         * a disaggregated btree.
-         */
-        WT_ASSERT(session,
-          page_del->prepare_state == WT_PREPARE_INIT ||
-            page_del->prepare_state == WT_PREPARE_RESOLVED ||
-            (F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED) &&
-              (page_del->prepare_state == WT_PREPARE_INPROGRESS ||
-                page_del->prepare_state == WT_PREPARE_LOCKED)));
-
         /* Use prepared_id to determine whether to write a prepared fast-truncate cell */
         is_prepared_fast_truncate = page_del->prepared_id != WT_PREPARED_ID_NONE &&
           F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED);

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -492,6 +492,7 @@ __wt_cell_pack_internal_key_addr(WT_SESSION_IMPL *session, WT_ITEM *new_image,
     WT_DECL_RET;
     WT_PAGE_DELETED *page_del = NULL;
     WT_TIME_AGGREGATE *ta;
+    bool is_prepared_fast_truncate;
     const void *key_data, *val_data;
     size_t packed_size;
     size_t key_size, val_size;
@@ -525,7 +526,7 @@ __wt_cell_pack_internal_key_addr(WT_SESSION_IMPL *session, WT_ITEM *new_image,
      * prepared cell was unpacked with committed=false and prepared_id set; a committed cell has
      * committed=true and prepared_id may be set but we use the committed encoding.
      */
-    bool is_prepared_fast_truncate =
+    is_prepared_fast_truncate =
       page_del != NULL && !page_del->committed && page_del->prepared_id != WT_PREPARED_ID_NONE;
     __wt_cell_build_addr_kv(
       session, &val_kv, cell_type, page_del, ta, is_prepared_fast_truncate, val_data, val_size);

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -580,7 +580,6 @@ __wt_cell_build_addr(WT_SESSION_IMPL *session, WT_CELL *cell, uint8_t cell_type,
           page_del->prepare_state == WT_PREPARE_INIT ||
             page_del->prepare_state == WT_PREPARE_RESOLVED ||
             (F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED) &&
-              F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED) &&
               (page_del->prepare_state == WT_PREPARE_INPROGRESS ||
                 page_del->prepare_state == WT_PREPARE_LOCKED)));
     }

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -561,6 +561,8 @@ __wt_cell_build_addr(WT_SESSION_IMPL *session, WT_CELL *cell, uint8_t cell_type,
      */
     WT_ASSERT(session, page_del != NULL || cell_type != WT_CELL_ADDR_DEL);
 
+    bool is_prepared_fast_truncate = false;
+
     if (page_del != NULL) {
         /*
          * We only support fast-truncate leaf pages without overflow items, however, we can write a
@@ -580,10 +582,15 @@ __wt_cell_build_addr(WT_SESSION_IMPL *session, WT_CELL *cell, uint8_t cell_type,
             (F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED) &&
               (page_del->prepare_state == WT_PREPARE_INPROGRESS ||
                 page_del->prepare_state == WT_PREPARE_LOCKED)));
+
+        /* Use prepared_id to determine whether to write a prepared fast-truncate cell */
+        is_prepared_fast_truncate = page_del->prepared_id != WT_PREPARED_ID_NONE &&
+          F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED);
     }
 
     /* Just pack and return the cell size. */
-    return (uint16_t)__wt_cell_pack_addr(session, cell, cell_type, recno, page_del, ta, data_size);
+    return (uint16_t)__wt_cell_pack_addr(
+      session, cell, cell_type, recno, page_del, ta, is_prepared_fast_truncate, data_size);
 }
 
 /*
@@ -592,19 +599,9 @@ __wt_cell_build_addr(WT_SESSION_IMPL *session, WT_CELL *cell, uint8_t cell_type,
  */
 static WT_INLINE size_t
 __wt_cell_pack_addr(WT_SESSION_IMPL *session, WT_CELL *cell, u_int cell_type, uint64_t recno,
-  WT_PAGE_DELETED *page_del, WT_TIME_AGGREGATE *ta, size_t size)
+  WT_PAGE_DELETED *page_del, WT_TIME_AGGREGATE *ta, bool is_prepared_fast_truncate, size_t size)
 {
-    uint8_t *p, prepare_state;
-    bool is_prepared_fast_truncate;
-
-    prepare_state = page_del != NULL ? __wt_atomic_load_uint8_v_acquire(&page_del->prepare_state) :
-                                       WT_PREPARE_INIT;
-    /*
-     * A prepared fast-truncate cell is only legal on a disaggregated btree with preserve_prepared.
-     */
-    is_prepared_fast_truncate =
-      (prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED) &&
-      F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED);
+    uint8_t *p;
 
     /* Start building a cell: the descriptor byte starts zero. */
     p = cell->__chunk;

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -575,14 +575,16 @@ __wt_cell_build_addr(WT_SESSION_IMPL *session, WT_CELL *cell, uint8_t cell_type,
         cell_type = WT_CELL_ADDR_DEL;
 
         /*
-         * In-progress prepared states are only written to disk when preserve_prepared is enabled;
-         * otherwise only committed (INIT) or resolved-but-not-yet-committed (RESOLVED) states are
-         * expected.
+         * In-progress prepared states are only written to disk when preserve_prepared is enabled
+         * on a disaggregated btree. Attached storage cannot safely use this format because an older
+         * binary would silently misread the cell. Otherwise only committed (INIT) or
+         * resolved-but-not-yet-committed (RESOLVED) states are expected.
          */
         WT_ASSERT(session,
           page_del->prepare_state == WT_PREPARE_INIT ||
             page_del->prepare_state == WT_PREPARE_RESOLVED ||
             (F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED) &&
+              F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED) &&
               (page_del->prepare_state == WT_PREPARE_INPROGRESS ||
                 page_del->prepare_state == WT_PREPARE_LOCKED)));
     }
@@ -624,7 +626,10 @@ __wt_cell_pack_addr(WT_SESSION_IMPL *session, WT_CELL *cell, u_int cell_type, ui
 
         WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->txnid));
         if (is_prepared_fast_truncate) {
-            WT_ASSERT(session, F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED));
+            /* Only reachable for disaggregated btrees with preserve_prepared; see __wt_cell_build_addr. */
+            WT_ASSERT(session,
+              F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED) &&
+                F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED));
             WT_ASSERT(session, page_del->prepared_id != WT_PREPARED_ID_NONE);
             WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->prepare_ts));
             WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->prepared_id));

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -575,10 +575,8 @@ __wt_cell_build_addr(WT_SESSION_IMPL *session, WT_CELL *cell, uint8_t cell_type,
         cell_type = WT_CELL_ADDR_DEL;
 
         /*
-         * In-progress prepared states are only written to disk when preserve_prepared is enabled
-         * on a disaggregated btree. Attached storage cannot safely use this format because an older
-         * binary would silently misread the cell. Otherwise only committed (INIT) or
-         * resolved-but-not-yet-committed (RESOLVED) states are expected.
+         * In-progress prepared states are only written to disk when preserve_prepared is enabled on
+         * a disaggregated btree.
          */
         WT_ASSERT(session,
           page_del->prepare_state == WT_PREPARE_INIT ||
@@ -608,9 +606,6 @@ __wt_cell_pack_addr(WT_SESSION_IMPL *session, WT_CELL *cell, u_int cell_type, ui
                                        WT_PREPARE_INIT;
     /*
      * A prepared fast-truncate cell is only legal on a disaggregated btree with preserve_prepared.
-     * Folding the flags into this bool prevents __cell_pack_addr_validity from writing
-     * WT_CELL_PREPARE into the second descriptor byte if either condition is unmet  regardless of
-     * whether the caller's assertions (in __wt_cell_build_addr) fire in this build configuration.
      */
     is_prepared_fast_truncate =
       (prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED) &&

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -606,8 +606,16 @@ __wt_cell_pack_addr(WT_SESSION_IMPL *session, WT_CELL *cell, u_int cell_type, ui
 
     prepare_state = page_del != NULL ? __wt_atomic_load_uint8_v_acquire(&page_del->prepare_state) :
                                        WT_PREPARE_INIT;
+    /*
+     * A prepared fast-truncate cell is only legal on a disaggregated btree with preserve_prepared.
+     * Folding the flags into this bool prevents __cell_pack_addr_validity from writing
+     * WT_CELL_PREPARE into the second descriptor byte if either condition is unmet  regardless of
+     * whether the caller's assertions (in __wt_cell_build_addr) fire in this build configuration.
+     */
     is_prepared_fast_truncate =
-      (prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED);
+      (prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED) &&
+      F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED) &&
+      F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED);
 
     /* Start building a cell: the descriptor byte starts zero. */
     p = cell->__chunk;
@@ -626,10 +634,6 @@ __wt_cell_pack_addr(WT_SESSION_IMPL *session, WT_CELL *cell, u_int cell_type, ui
 
         WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->txnid));
         if (is_prepared_fast_truncate) {
-            /* Only reachable for disaggregated btrees with preserve_prepared; see __wt_cell_build_addr. */
-            WT_ASSERT(session,
-              F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED) &&
-                F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED));
             WT_ASSERT(session, page_del->prepared_id != WT_PREPARED_ID_NONE);
             WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->prepare_ts));
             WT_IGNORE_RET(__wt_vpack_uint(&p, 0, page_del->prepared_id));

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -201,9 +201,7 @@ __cell_pack_addr_validity(
 {
     uint8_t flags, *flagsp;
 
-    /*
-     * A prepared fast-truncate and a prepared time aggregate cannot be on the same page.
-     */
+    /* A prepared fast-truncate and a prepared time aggregate cannot be on the same page. */
     WT_ASSERT(session, !(ta->prepare && is_prepared_fast_truncate));
 
     if (WT_TIME_AGGREGATE_IS_EMPTY(ta) && !is_prepared_fast_truncate) {
@@ -606,8 +604,7 @@ __wt_cell_pack_addr(WT_SESSION_IMPL *session, WT_CELL *cell, u_int cell_type, ui
      */
     is_prepared_fast_truncate =
       (prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED) &&
-      F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED) &&
-      F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED);
+      F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED);
 
     /* Start building a cell: the descriptor byte starts zero. */
     p = cell->__chunk;

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -268,9 +268,7 @@ __cell_pack_addr_validity(
         WT_IGNORE_RET(__wt_vpack_uint(pp, 0, ta->newest_stop_durable_ts - ta->newest_stop_ts));
         LF_SET(WT_CELL_TS_DURABLE_STOP);
     }
-    if (ta->prepare)
-        LF_SET(WT_CELL_PREPARE);
-    if (is_prepared_fast_truncate)
+    if (ta->prepare || is_prepared_fast_truncate)
         LF_SET(WT_CELL_PREPARE);
 
     *flagsp = flags;

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -520,8 +520,15 @@ __wt_cell_pack_internal_key_addr(WT_SESSION_IMPL *session, WT_ITEM *new_image,
 
     /* Build packed key/value. */
     __cell_build_int_key_from_kv(&key_kv, key_data, key_size);
-    /* FIXME-WT-17663: pass the correct is_prepared_fast_truncate from the caller. */
-    __wt_cell_build_addr_kv(session, &val_kv, cell_type, page_del, ta, false, val_data, val_size);
+    /*
+     * Re-encode the cell preserving the prepared/committed encoding the original cell had. A
+     * prepared cell was unpacked with committed=false and prepared_id set; a committed cell has
+     * committed=true and prepared_id may be set but we use the committed encoding.
+     */
+    bool is_prepared_fast_truncate =
+      page_del != NULL && !page_del->committed && page_del->prepared_id != WT_PREPARED_ID_NONE;
+    __wt_cell_build_addr_kv(
+      session, &val_kv, cell_type, page_del, ta, is_prepared_fast_truncate, val_data, val_size);
 
     /*
      * Ensure enough space, then recompute write pointer from new_image (not the caller's saved

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -602,9 +602,8 @@ __wt_cell_pack_addr(WT_SESSION_IMPL *session, WT_CELL *cell, u_int cell_type, ui
     uint8_t *p, prepare_state;
     bool is_prepared_fast_truncate;
 
-    prepare_state = page_del != NULL ?
-      __wt_atomic_load_uint8_v_acquire(&page_del->prepare_state) :
-      WT_PREPARE_INIT;
+    prepare_state = page_del != NULL ? __wt_atomic_load_uint8_v_acquire(&page_del->prepare_state) :
+                                       WT_PREPARE_INIT;
     is_prepared_fast_truncate =
       (prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED);
 

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -423,15 +423,16 @@ err:
  */
 static WT_INLINE void
 __wt_cell_build_addr_kv(WT_SESSION_IMPL *session, WT_CELL_KV *val_kv, uint8_t cell_type,
-  WT_PAGE_DELETED *page_del, WT_TIME_AGGREGATE *ta, const void *data, size_t data_size)
+  WT_PAGE_DELETED *page_del, WT_TIME_AGGREGATE *ta, bool is_prepared_fast_truncate,
+  const void *data, size_t data_size)
 {
     WT_ASSERT(session, val_kv != NULL);
 
     val_kv->buf.data = data;
     val_kv->buf.size = data_size;
 
-    val_kv->cell_len = (uint16_t)__wt_cell_build_addr(
-      session, &val_kv->cell, cell_type, WT_RECNO_OOB, page_del, ta, data_size);
+    val_kv->cell_len = (uint16_t)__wt_cell_build_addr(session, &val_kv->cell, cell_type,
+      WT_RECNO_OOB, page_del, ta, is_prepared_fast_truncate, data_size);
 
     val_kv->len = val_kv->cell_len + data_size;
 }
@@ -519,7 +520,8 @@ __wt_cell_pack_internal_key_addr(WT_SESSION_IMPL *session, WT_ITEM *new_image,
 
     /* Build packed key/value. */
     __cell_build_int_key_from_kv(&key_kv, key_data, key_size);
-    __wt_cell_build_addr_kv(session, &val_kv, cell_type, page_del, ta, val_data, val_size);
+    /* FIXME-WT-17663: pass the correct is_prepared_fast_truncate from the caller. */
+    __wt_cell_build_addr_kv(session, &val_kv, cell_type, page_del, ta, false, val_data, val_size);
 
     /*
      * Ensure enough space, then recompute write pointer from new_image (not the caller's saved
@@ -553,15 +555,14 @@ err:
  */
 static WT_INLINE uint16_t
 __wt_cell_build_addr(WT_SESSION_IMPL *session, WT_CELL *cell, uint8_t cell_type, uint64_t recno,
-  WT_PAGE_DELETED *page_del, WT_TIME_AGGREGATE *ta, size_t data_size)
+  WT_PAGE_DELETED *page_del, WT_TIME_AGGREGATE *ta, bool is_prepared_fast_truncate,
+  size_t data_size)
 {
     /*
      * If passed fast-delete information, override the cell type. We should never see fast-truncate
      * cell types without fast-truncate information.
      */
     WT_ASSERT(session, page_del != NULL || cell_type != WT_CELL_ADDR_DEL);
-
-    bool is_prepared_fast_truncate = false;
 
     if (page_del != NULL) {
         /*
@@ -571,10 +572,6 @@ __wt_cell_build_addr(WT_SESSION_IMPL *session, WT_CELL *cell, uint8_t cell_type,
          */
         WT_ASSERT(session, cell_type == WT_CELL_ADDR_DEL || cell_type == WT_CELL_ADDR_LEAF_NO);
         cell_type = WT_CELL_ADDR_DEL;
-
-        /* Use prepared_id to determine whether to write a prepared fast-truncate cell */
-        is_prepared_fast_truncate = page_del->prepared_id != WT_PREPARED_ID_NONE &&
-          F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED);
     }
 
     /* Just pack and return the cell size. */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2435,7 +2435,8 @@ static WT_INLINE u_int __wt_skip_choose_depth(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE uint16_t __wt_cell_build_addr(WT_SESSION_IMPL *session, WT_CELL *cell,
   uint8_t cell_type, uint64_t recno, WT_PAGE_DELETED *page_del, WT_TIME_AGGREGATE *ta,
-  size_t data_size) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+  bool is_prepared_fast_truncate, size_t data_size)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE uint64_t __wt_btree_bytes_evictable(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE uint64_t __wt_btree_bytes_inuse(WT_SESSION_IMPL *session)
@@ -2549,8 +2550,8 @@ static WT_INLINE void __wt_cache_shared_dsk_inmem_decr(
 static WT_INLINE void __wt_cache_shared_dsk_inmem_incr(
   WT_SESSION_IMPL *session, uint8_t image_type, size_t size);
 static WT_INLINE void __wt_cell_build_addr_kv(WT_SESSION_IMPL *session, WT_CELL_KV *val_kv,
-  uint8_t cell_type, WT_PAGE_DELETED *page_del, WT_TIME_AGGREGATE *ta, const void *data,
-  size_t data_size);
+  uint8_t cell_type, WT_PAGE_DELETED *page_del, WT_TIME_AGGREGATE *ta,
+  bool is_prepared_fast_truncate, const void *data, size_t data_size);
 static WT_INLINE void __wt_cell_compress_prefix_key(WT_ITEM *last_key, const void *data,
   size_t size, uint8_t key_pfx_last, u_int prefix_compression_min, uint8_t *pfxp);
 static WT_INLINE void __wt_cell_get_ta(WT_CELL_UNPACK_ADDR *unpack_addr, WT_TIME_AGGREGATE **tap);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2396,8 +2396,8 @@ static WT_INLINE size_t __wt_4b_size_posint1(uint64_t x1)
 static WT_INLINE size_t __wt_4b_size_posint2(uint64_t x1, uint64_t x2)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE size_t __wt_cell_pack_addr(WT_SESSION_IMPL *session, WT_CELL *cell,
-  u_int cell_type, uint64_t recno, WT_PAGE_DELETED *page_del, WT_TIME_AGGREGATE *ta, size_t size)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+  u_int cell_type, uint64_t recno, WT_PAGE_DELETED *page_del, WT_TIME_AGGREGATE *ta,
+  bool is_prepared_fast_truncate, size_t size) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE size_t __wt_cell_pack_copy(WT_SESSION_IMPL *session, WT_CELL *cell,
   WT_TIME_WINDOW *tw, uint64_t rle, uint64_t v) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE size_t __wt_cell_pack_del(WT_SESSION_IMPL *session, WT_CELL *cell,

--- a/src/reconcile/rec_child.c
+++ b/src/reconcile/rec_child.c
@@ -67,21 +67,80 @@ __rec_child_deleted(
             }
 
             if (visible && F_ISSET(conn, WT_CONN_PRECISE_CHECKPOINT) &&
-              page_del->pg_del_durable_ts > r->rec_start_pinned_stable_ts)
+              page_del->pg_del_durable_ts > r->rec_start_pinned_stable_ts) {
+                /*
+                 * The commit is not yet stable. If the prepare is stable, write a prepared proxy
+                 * cell so recovery can reconstruct the prepared state.
+                 */
+                if (page_del->prepared_id != WT_PREPARED_ID_NONE &&
+                  page_del->prepare_ts <= r->rec_start_pinned_stable_ts) {
+                    cmsp->del = *page_del;
+                    cmsp->state = WTI_CHILD_PROXY;
+                    cmsp->is_prepared_fast_truncate = true;
+                    page_del->selected_for_write = true;
+                    return (0);
+                }
                 visible = false;
+            }
 
             visible_all = visible ? __wt_page_del_visible_all(session, page_del, true) : false;
         } else if (F_ISSET(session->txn, WT_TXN_HAS_SNAPSHOT)) {
             visible = __wt_page_del_visible(session, page_del, true);
 
             if (visible && F_ISSET(conn, WT_CONN_PRECISE_CHECKPOINT) &&
-              page_del->pg_del_durable_ts > r->rec_start_pinned_stable_ts)
+              page_del->pg_del_durable_ts > r->rec_start_pinned_stable_ts) {
+                if (page_del->prepared_id != WT_PREPARED_ID_NONE &&
+                  page_del->prepare_ts <= r->rec_start_pinned_stable_ts) {
+                    cmsp->del = *page_del;
+                    cmsp->state = WTI_CHILD_PROXY;
+                    cmsp->is_prepared_fast_truncate = true;
+                    page_del->selected_for_write = true;
+                    return (0);
+                }
                 visible = false;
+            }
 
             visible_all = visible ? __wt_page_del_visible_all(session, page_del, true) : false;
         } else
             visible = visible_all = __wt_page_del_visible_all(session, page_del, true);
     }
+    /*
+     * Handle an aborted prepared fast-truncate. So that reconciliation can write the correct proxy
+     * cell until both the prepare and the rollback are stable.
+     */
+    if (__wt_atomic_load_uint64_v_relaxed(&page_del->txnid) == WT_TXN_ABORTED &&
+      page_del->prepared_id != WT_PREPARED_ID_NONE) {
+        if (F_ISSET(conn, WT_CONN_PRECISE_CHECKPOINT)) {
+            if (page_del->pg_del_rollback_ts <= r->rec_start_pinned_stable_ts) {
+                /*
+                 * The rollback is stable: the deletion effectively never happened. Free disk blocks
+                 * and write the original child block address.
+                 */
+                __wt_overwrite_and_free(session, ref->page_del);
+                cmsp->needs_disk_transition = true;
+                cmsp->state = WTI_CHILD_ORIGINAL;
+                return (0);
+            }
+            if (page_del->prepare_ts <= r->rec_start_pinned_stable_ts) {
+                /*
+                 * The prepare is stable but the rollback is not yet stable. Write a prepared proxy
+                 * cell so that recovery can reconstruct the prepared state.
+                 */
+                cmsp->del = *page_del;
+                cmsp->state = WTI_CHILD_PROXY;
+                cmsp->is_prepared_fast_truncate = true;
+                page_del->selected_for_write = true;
+                return (0);
+            }
+        }
+        /* Neither timestamp threshold met: leave the page dirty. */
+        if (F_ISSET(r, WT_REC_CLEAN_AFTER_REC | WT_REC_EVICT))
+            return (__wt_set_return(session, EBUSY));
+        cmsp->state = WTI_CHILD_ORIGINAL;
+        r->leave_dirty = true;
+        return (0);
+    }
+
     /*
      * If an earlier reconciliation chose to write the fast truncate information to the page, we
      * should select it regardless of visibility unless it is globally visible. This is important as
@@ -90,6 +149,9 @@ __rec_child_deleted(
     if (page_del->selected_for_write && !visible_all) {
         cmsp->del = *page_del;
         cmsp->state = WTI_CHILD_PROXY;
+        /* Preserve the prepared encoding used when the cell was first written. */
+        cmsp->is_prepared_fast_truncate =
+          page_del->prepared_id != WT_PREPARED_ID_NONE && !page_del->committed;
         return (0);
     }
 
@@ -109,6 +171,27 @@ __rec_child_deleted(
         WT_ASSERT(session, !visible_all);
         if (F_ISSET(r, WT_REC_VISIBILITY_ERR))
             WT_RET_PANIC(session, EINVAL, "reconciliation illegally skipped an update");
+
+        /*
+         * In-flight prepared fast-truncate with a stable prepare timestamp: write a prepared proxy
+         * cell so that recovery can reconstruct the prepared state. Prepared fast-truncates are
+         * never evicted so we only reach this path during checkpoint.
+         */
+        if (F_ISSET(conn, WT_CONN_PRECISE_CHECKPOINT) &&
+          page_del->prepared_id != WT_PREPARED_ID_NONE && !page_del->committed) {
+            prepare_state = __wt_atomic_load_uint8_v_acquire(&page_del->prepare_state);
+            if ((prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED) &&
+              page_del->prepare_ts <= r->rec_start_pinned_stable_ts) {
+                WT_ASSERT_ALWAYS(session, !F_ISSET(r, WT_REC_EVICT),
+                  "In progress prepares should never be seen in eviction");
+                cmsp->del = *page_del;
+                cmsp->state = WTI_CHILD_PROXY;
+                cmsp->is_prepared_fast_truncate = true;
+                page_del->selected_for_write = true;
+                return (0);
+            }
+        }
+
         /*
          * In addition to the WT_REC_CLEAN_AFTER_REC case, fail if we're trying to evict an internal
          * page and we can't see the update to it. There's not much point continuing; unlike with a
@@ -202,6 +285,8 @@ __wti_rec_child_modify(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_REF *ref,
 
     /* We may acquire a hazard pointer our caller must release. */
     cmsp->hazard = false;
+    cmsp->is_prepared_fast_truncate = false;
+    cmsp->needs_disk_transition = false;
 
     /* Default to using the original child address. */
     cmsp->state = WTI_CHILD_ORIGINAL;
@@ -242,7 +327,8 @@ __wti_rec_child_modify(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_REF *ref,
                 r->delta.size = 0;
             }
             ret = __rec_child_deleted(session, r, ref, cmsp);
-            WT_REF_SET_STATE(ref, WT_REF_DELETED);
+            /* Transition aborted-stable prepared fast-truncates. */
+            WT_REF_SET_STATE(ref, cmsp->needs_disk_transition ? WT_REF_DISK : WT_REF_DELETED);
             WT_RET(ret);
             goto done;
 

--- a/src/reconcile/rec_child.c
+++ b/src/reconcile/rec_child.c
@@ -96,20 +96,19 @@ __rec_child_deleted(
 
     /*
      * When preserve_prepared is enabled on a disaggregated btree, write an in-progress prepared
-     * fast-truncate as a proxy cell so that recovery can reconstruct the prepared state.
-     * Restricted to disaggregated storage to prevent issues on attached storage on older binary.
+     * fast-truncate as a proxy cell so that recovery can reconstruct the prepared state. Restricted
+     * to disaggregated storage to prevent issues on attached storage on older binary.
      */
     if (!page_del->committed && F_ISSET(conn, WT_CONN_PRESERVE_PREPARED) &&
       F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED)) {
         prepare_state = __wt_atomic_load_uint8_v_acquire(&page_del->prepare_state);
         if (prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED) {
-            WT_ASSERT_ALWAYS(session, !F_ISSET(r, WT_REC_EVICT),
-              "Prepared fast-truncates cannot be evicted when preserve_prepared is enabled");
-            if (F_ISSET(r, WT_REC_CLEAN_AFTER_REC))
+            if (F_ISSET(r, WT_REC_CLEAN_AFTER_REC | WT_REC_EVICT))
                 return (__wt_set_return(session, EBUSY));
             WT_ASSERT(session, page_del->prepared_id != WT_PREPARED_ID_NONE);
             page_del->selected_for_write = true;
             cmsp->del = *page_del;
+            cmsp->del.prepare_state = prepare_state;
             cmsp->state = WTI_CHILD_PROXY;
             r->leave_dirty = true;
             return (0);

--- a/src/reconcile/rec_child.c
+++ b/src/reconcile/rec_child.c
@@ -99,8 +99,7 @@ __rec_child_deleted(
      * fast-truncate as a proxy cell so that recovery can reconstruct the prepared state. Restricted
      * to disaggregated storage to prevent issues on attached storage on older binary.
      */
-    if (!page_del->committed && F_ISSET(conn, WT_CONN_PRESERVE_PREPARED) &&
-      F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED)) {
+    if (!page_del->committed && F_ISSET(conn, WT_CONN_PRESERVE_PREPARED)) {
         prepare_state = __wt_atomic_load_uint8_v_acquire(&page_del->prepare_state);
         if (prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED) {
             if (F_ISSET(r, WT_REC_CLEAN_AFTER_REC | WT_REC_EVICT))

--- a/src/reconcile/rec_child.c
+++ b/src/reconcile/rec_child.c
@@ -37,9 +37,8 @@ __rec_child_deleted(
 
     /*
      * Check visibility. If the truncation is visible to us, we'll also want to know if it's visible
-     * to everyone. Use the special-case logic in visibility of truncate to hide prepared
-     * truncations as we can't write them to disk in the general case. When preserve prepare config
-     * is enabled, in-progress prepared fast-truncates are written as proxy cells.
+     * to everyone. Use the special-case logic in __wt_page_del_visible to hide prepared truncations
+     * as we can't write them to disk.
      *
      * We can't write out uncommitted truncations so we need to check the committed flag on the page
      * delete structure. The committed flag indicates that the truncation has finished being
@@ -92,26 +91,6 @@ __rec_child_deleted(
         cmsp->del = *page_del;
         cmsp->state = WTI_CHILD_PROXY;
         return (0);
-    }
-
-    /*
-     * When preserve prepare config is enabled on a disaggregated btree, write an in-progress
-     * prepared fast-truncate as a proxy cell so that recovery can reconstruct the prepared state.
-     * Restricted to disaggregated storage to prevent issues on attached storage on older binary.
-     */
-    if (!page_del->committed && F_ISSET(conn, WT_CONN_PRESERVE_PREPARED)) {
-        prepare_state = __wt_atomic_load_uint8_v_acquire(&page_del->prepare_state);
-        if (prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED) {
-            if (F_ISSET(r, WT_REC_CLEAN_AFTER_REC | WT_REC_EVICT))
-                return (__wt_set_return(session, EBUSY));
-            WT_ASSERT(session, page_del->prepared_id != WT_PREPARED_ID_NONE);
-            page_del->selected_for_write = true;
-            cmsp->del = *page_del;
-            cmsp->del.prepare_state = prepare_state;
-            cmsp->state = WTI_CHILD_PROXY;
-            r->leave_dirty = true;
-            return (0);
-        }
     }
 
     /*
@@ -186,9 +165,9 @@ __rec_child_deleted(
      * cells to the page. Copy out the current fast-truncate information for that function.
      */
     if (!visible_all) {
-        page_del->selected_for_write = true;
         cmsp->del = *page_del;
         cmsp->state = WTI_CHILD_PROXY;
+        page_del->selected_for_write = true;
         return (0);
     }
 

--- a/src/reconcile/rec_child.c
+++ b/src/reconcile/rec_child.c
@@ -37,9 +37,9 @@ __rec_child_deleted(
 
     /*
      * Check visibility. If the truncation is visible to us, we'll also want to know if it's visible
-     * to everyone. Use the special-case logic in __wt_page_del_visible to hide prepared truncations
-     * as we can't write them to disk in the general case. When preserve_prepared is enabled,
-     * in-progress prepared fast-truncates are written as proxy cells.
+     * to everyone. Use the special-case logic in visibility of truncate to hide prepared
+     * truncations as we can't write them to disk in the general case. When preserve prepare config
+     * is enabled, in-progress prepared fast-truncates are written as proxy cells.
      *
      * We can't write out uncommitted truncations so we need to check the committed flag on the page
      * delete structure. The committed flag indicates that the truncation has finished being
@@ -95,9 +95,9 @@ __rec_child_deleted(
     }
 
     /*
-     * When preserve_prepared is enabled on a disaggregated btree, write an in-progress prepared
-     * fast-truncate as a proxy cell so that recovery can reconstruct the prepared state. Restricted
-     * to disaggregated storage to prevent issues on attached storage on older binary.
+     * When preserve prepare config is enabled on a disaggregated btree, write an in-progress
+     * prepared fast-truncate as a proxy cell so that recovery can reconstruct the prepared state.
+     * Restricted to disaggregated storage to prevent issues on attached storage on older binary.
      */
     if (!page_del->committed && F_ISSET(conn, WT_CONN_PRESERVE_PREPARED)) {
         prepare_state = __wt_atomic_load_uint8_v_acquire(&page_del->prepare_state);

--- a/src/reconcile/rec_child.c
+++ b/src/reconcile/rec_child.c
@@ -10,6 +10,20 @@
 #include "reconcile_private.h"
 #include "reconcile_inline.h"
 /*
+ * __rec_write_prepared_proxy --
+ *     Record that reconciliation should write a prepared proxy cell for a fast-truncated page.
+ */
+static WT_INLINE int
+__rec_write_prepared_proxy(WTI_CHILD_MODIFY_STATE *cmsp, WT_PAGE_DELETED *page_del)
+{
+    cmsp->del = *page_del;
+    cmsp->state = WTI_CHILD_PROXY;
+    cmsp->is_prepared_fast_truncate = true;
+    page_del->selected_for_write = true;
+    return (0);
+}
+
+/*
  * __rec_child_deleted --
  *     Handle pages with leaf pages in the WT_REF_DELETED state.
  */
@@ -53,17 +67,12 @@ __rec_child_deleted(
                 cmsp->state = WTI_CHILD_ORIGINAL;
                 return (0);
             }
-            if (page_del->prepare_ts <= r->rec_start_pinned_stable_ts) {
+            if (page_del->prepare_ts <= r->rec_start_pinned_stable_ts)
                 /*
                  * The prepare is stable but the rollback is not yet stable. Write a prepared proxy
                  * cell so that recovery can reconstruct the prepared state.
                  */
-                cmsp->del = *page_del;
-                cmsp->state = WTI_CHILD_PROXY;
-                cmsp->is_prepared_fast_truncate = true;
-                page_del->selected_for_write = true;
-                return (0);
-            }
+                return (__rec_write_prepared_proxy(cmsp, page_del));
         }
         /*
          * Precise checkpoint is not enabled, or the timestamps do not yet meet the stable
@@ -119,13 +128,8 @@ __rec_child_deleted(
         if (!visible_all && visible && F_ISSET(conn, WT_CONN_PRECISE_CHECKPOINT) &&
           page_del->pg_del_durable_ts > r->rec_start_pinned_stable_ts) {
             if (page_del->prepared_id != WT_PREPARED_ID_NONE &&
-              page_del->prepare_ts <= r->rec_start_pinned_stable_ts) {
-                cmsp->del = *page_del;
-                cmsp->state = WTI_CHILD_PROXY;
-                cmsp->is_prepared_fast_truncate = true;
-                page_del->selected_for_write = true;
-                return (0);
-            }
+              page_del->prepare_ts <= r->rec_start_pinned_stable_ts)
+                return (__rec_write_prepared_proxy(cmsp, page_del));
             visible = false;
         }
 
@@ -176,11 +180,7 @@ __rec_child_deleted(
               page_del->prepare_ts <= r->rec_start_pinned_stable_ts) {
                 WT_ASSERT_ALWAYS(session, !F_ISSET(r, WT_REC_EVICT),
                   "In progress prepares should never be seen in eviction");
-                cmsp->del = *page_del;
-                cmsp->state = WTI_CHILD_PROXY;
-                cmsp->is_prepared_fast_truncate = true;
-                page_del->selected_for_write = true;
-                return (0);
+                return (__rec_write_prepared_proxy(cmsp, page_del));
             }
         }
 

--- a/src/reconcile/rec_child.c
+++ b/src/reconcile/rec_child.c
@@ -36,6 +36,47 @@ __rec_child_deleted(
         return (__wt_ref_block_free(session, ref, true));
 
     /*
+     * Handle an aborted prepared fast-truncate first. Reconciliation writes a prepared proxy cell
+     * until both the prepare and the rollback are stable.
+     */
+    if (__wt_atomic_load_uint64_v_relaxed(&page_del->txnid) == WT_TXN_ABORTED &&
+      page_del->prepared_id != WT_PREPARED_ID_NONE) {
+        if (F_ISSET(conn, WT_CONN_PRECISE_CHECKPOINT)) {
+            if (page_del->pg_del_rollback_ts <= r->rec_start_pinned_stable_ts) {
+                /*
+                 * The rollback is stable: Free the page_del and write the original child block
+                 * address. Signal the caller to transition the ref from WT_REF_DELETED to
+                 * WT_REF_DISK.
+                 */
+                __wt_overwrite_and_free(session, ref->page_del);
+                cmsp->needs_disk_transition = true;
+                cmsp->state = WTI_CHILD_ORIGINAL;
+                return (0);
+            }
+            if (page_del->prepare_ts <= r->rec_start_pinned_stable_ts) {
+                /*
+                 * The prepare is stable but the rollback is not yet stable. Write a prepared proxy
+                 * cell so that recovery can reconstruct the prepared state.
+                 */
+                cmsp->del = *page_del;
+                cmsp->state = WTI_CHILD_PROXY;
+                cmsp->is_prepared_fast_truncate = true;
+                page_del->selected_for_write = true;
+                return (0);
+            }
+        }
+        /*
+         * Precise checkpoint is not enabled, or neither the rollback ts nor the prepare ts is at or
+         * below stable. Leave the page dirty.
+         */
+        if (F_ISSET(r, WT_REC_CLEAN_AFTER_REC | WT_REC_EVICT))
+            return (__wt_set_return(session, EBUSY));
+        cmsp->state = WTI_CHILD_ORIGINAL;
+        r->leave_dirty = true;
+        return (0);
+    }
+
+    /*
      * Check visibility. If the truncation is visible to us, we'll also want to know if it's visible
      * to everyone. Use the special-case logic in __wt_page_del_visible to hide prepared truncations
      * as we can't write them to disk.
@@ -65,80 +106,31 @@ __rec_child_deleted(
                 if (prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED)
                     visible = false;
             }
-
-            if (visible && F_ISSET(conn, WT_CONN_PRECISE_CHECKPOINT) &&
-              page_del->pg_del_durable_ts > r->rec_start_pinned_stable_ts) {
-                /*
-                 * The commit is not yet stable. If the prepare is stable, write a prepared proxy
-                 * cell so recovery can reconstruct the prepared state.
-                 */
-                if (page_del->prepared_id != WT_PREPARED_ID_NONE &&
-                  page_del->prepare_ts <= r->rec_start_pinned_stable_ts) {
-                    cmsp->del = *page_del;
-                    cmsp->state = WTI_CHILD_PROXY;
-                    cmsp->is_prepared_fast_truncate = true;
-                    page_del->selected_for_write = true;
-                    return (0);
-                }
-                visible = false;
-            }
-
-            visible_all = visible ? __wt_page_del_visible_all(session, page_del, true) : false;
         } else if (F_ISSET(session->txn, WT_TXN_HAS_SNAPSHOT)) {
             visible = __wt_page_del_visible(session, page_del, true);
-
-            if (visible && F_ISSET(conn, WT_CONN_PRECISE_CHECKPOINT) &&
-              page_del->pg_del_durable_ts > r->rec_start_pinned_stable_ts) {
-                if (page_del->prepared_id != WT_PREPARED_ID_NONE &&
-                  page_del->prepare_ts <= r->rec_start_pinned_stable_ts) {
-                    cmsp->del = *page_del;
-                    cmsp->state = WTI_CHILD_PROXY;
-                    cmsp->is_prepared_fast_truncate = true;
-                    page_del->selected_for_write = true;
-                    return (0);
-                }
-                visible = false;
-            }
-
-            visible_all = visible ? __wt_page_del_visible_all(session, page_del, true) : false;
         } else
             visible = visible_all = __wt_page_del_visible_all(session, page_del, true);
-    }
-    /*
-     * Handle an aborted prepared fast-truncate. So that reconciliation can write the correct proxy
-     * cell until both the prepare and the rollback are stable.
-     */
-    if (__wt_atomic_load_uint64_v_relaxed(&page_del->txnid) == WT_TXN_ABORTED &&
-      page_del->prepared_id != WT_PREPARED_ID_NONE) {
-        if (F_ISSET(conn, WT_CONN_PRECISE_CHECKPOINT)) {
-            if (page_del->pg_del_rollback_ts <= r->rec_start_pinned_stable_ts) {
-                /*
-                 * The rollback is stable: the deletion effectively never happened. Free disk blocks
-                 * and write the original child block address.
-                 */
-                __wt_overwrite_and_free(session, ref->page_del);
-                cmsp->needs_disk_transition = true;
-                cmsp->state = WTI_CHILD_ORIGINAL;
-                return (0);
-            }
-            if (page_del->prepare_ts <= r->rec_start_pinned_stable_ts) {
-                /*
-                 * The prepare is stable but the rollback is not yet stable. Write a prepared proxy
-                 * cell so that recovery can reconstruct the prepared state.
-                 */
+
+        /*
+         * If the commit is not yet stable but the prepare timestamp is stable, write a prepared
+         * proxy cell so that recovery can reconstruct the prepared state. This check does not apply
+         * to the no-snapshot branch above, which already sets visible all.
+         */
+        if (!visible_all && visible && F_ISSET(conn, WT_CONN_PRECISE_CHECKPOINT) &&
+          page_del->pg_del_durable_ts > r->rec_start_pinned_stable_ts) {
+            if (page_del->prepared_id != WT_PREPARED_ID_NONE &&
+              page_del->prepare_ts <= r->rec_start_pinned_stable_ts) {
                 cmsp->del = *page_del;
                 cmsp->state = WTI_CHILD_PROXY;
                 cmsp->is_prepared_fast_truncate = true;
                 page_del->selected_for_write = true;
                 return (0);
             }
+            visible = false;
         }
-        /* Neither timestamp threshold met: leave the page dirty. */
-        if (F_ISSET(r, WT_REC_CLEAN_AFTER_REC | WT_REC_EVICT))
-            return (__wt_set_return(session, EBUSY));
-        cmsp->state = WTI_CHILD_ORIGINAL;
-        r->leave_dirty = true;
-        return (0);
+
+        if (!visible_all)
+            visible_all = visible ? __wt_page_del_visible_all(session, page_del, true) : false;
     }
 
     /*

--- a/src/reconcile/rec_child.c
+++ b/src/reconcile/rec_child.c
@@ -95,10 +95,16 @@ __rec_child_deleted(
     }
 
     /*
-     * When preserve_prepared is enabled, write an in-progress prepared fast-truncate as a proxy
-     * cell so that recovery can reconstruct the prepared state.
+     * When preserve_prepared is enabled on a disaggregated btree, write an in-progress prepared
+     * fast-truncate as a proxy cell so that recovery can reconstruct the prepared state.
+     *
+     * This is intentionally restricted to disaggregated storage. On attached storage a downgrade to
+     * an older binary that predates the prepared fast-truncate on-disk format (which packs
+     * txnid  prepare_ts  prepared_id rather than txnid  pg_del_start_ts  pg_del_durable_ts)
+     * would silently misread the cell, producing a committed deletion with garbage timestamps.
      */
-    if (!page_del->committed && F_ISSET(conn, WT_CONN_PRESERVE_PREPARED)) {
+    if (!page_del->committed && F_ISSET(conn, WT_CONN_PRESERVE_PREPARED) &&
+      F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED)) {
         prepare_state = __wt_atomic_load_uint8_v_acquire(&page_del->prepare_state);
         if (prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED) {
             WT_ASSERT_ALWAYS(session, !F_ISSET(r, WT_REC_EVICT),

--- a/src/reconcile/rec_child.c
+++ b/src/reconcile/rec_child.c
@@ -97,11 +97,7 @@ __rec_child_deleted(
     /*
      * When preserve_prepared is enabled on a disaggregated btree, write an in-progress prepared
      * fast-truncate as a proxy cell so that recovery can reconstruct the prepared state.
-     *
-     * This is intentionally restricted to disaggregated storage. On attached storage a downgrade to
-     * an older binary that predates the prepared fast-truncate on-disk format (which packs
-     * txnid  prepare_ts  prepared_id rather than txnid  pg_del_start_ts  pg_del_durable_ts)
-     * would silently misread the cell, producing a committed deletion with garbage timestamps.
+     * Restricted to disaggregated storage to prevent issues on attached storage on older binary.
      */
     if (!page_del->committed && F_ISSET(conn, WT_CONN_PRESERVE_PREPARED) &&
       F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED)) {

--- a/src/reconcile/rec_child.c
+++ b/src/reconcile/rec_child.c
@@ -38,7 +38,8 @@ __rec_child_deleted(
     /*
      * Check visibility. If the truncation is visible to us, we'll also want to know if it's visible
      * to everyone. Use the special-case logic in __wt_page_del_visible to hide prepared truncations
-     * as we can't write them to disk.
+     * as we can't write them to disk in the general case. When preserve_prepared is enabled,
+     * in-progress prepared fast-truncates are written as proxy cells.
      *
      * We can't write out uncommitted truncations so we need to check the committed flag on the page
      * delete structure. The committed flag indicates that the truncation has finished being
@@ -91,6 +92,26 @@ __rec_child_deleted(
         cmsp->del = *page_del;
         cmsp->state = WTI_CHILD_PROXY;
         return (0);
+    }
+
+    /*
+     * When preserve_prepared is enabled, write an in-progress prepared fast-truncate as a proxy
+     * cell so that recovery can reconstruct the prepared state.
+     */
+    if (!page_del->committed && F_ISSET(conn, WT_CONN_PRESERVE_PREPARED)) {
+        prepare_state = __wt_atomic_load_uint8_v_acquire(&page_del->prepare_state);
+        if (prepare_state == WT_PREPARE_INPROGRESS || prepare_state == WT_PREPARE_LOCKED) {
+            WT_ASSERT_ALWAYS(session, !F_ISSET(r, WT_REC_EVICT),
+              "Prepared fast-truncates cannot be evicted when preserve_prepared is enabled");
+            if (F_ISSET(r, WT_REC_CLEAN_AFTER_REC))
+                return (__wt_set_return(session, EBUSY));
+            WT_ASSERT(session, page_del->prepared_id != WT_PREPARED_ID_NONE);
+            page_del->selected_for_write = true;
+            cmsp->del = *page_del;
+            cmsp->state = WTI_CHILD_PROXY;
+            r->leave_dirty = true;
+            return (0);
+        }
     }
 
     /*
@@ -165,9 +186,9 @@ __rec_child_deleted(
      * cells to the page. Copy out the current fast-truncate information for that function.
      */
     if (!visible_all) {
+        page_del->selected_for_write = true;
         cmsp->del = *page_del;
         cmsp->state = WTI_CHILD_PROXY;
-        page_del->selected_for_write = true;
         return (0);
     }
 

--- a/src/reconcile/rec_child.c
+++ b/src/reconcile/rec_child.c
@@ -44,9 +44,9 @@ __rec_child_deleted(
         if (F_ISSET(conn, WT_CONN_PRECISE_CHECKPOINT)) {
             if (page_del->pg_del_rollback_ts <= r->rec_start_pinned_stable_ts) {
                 /*
-                 * The rollback is stable: Free the page_del and write the original child block
-                 * address. Signal the caller to transition the ref from WT_REF_DELETED to
-                 * WT_REF_DISK.
+                 * The rollback is stable: Free the page_del, set WTI_CHILD_ORIGINAL so the caller
+                 * writes the original block address with no deletion metadata. Signal the caller to
+                 * transition the ref from WT_REF_DELETED to WT_REF_DISK.
                  */
                 __wt_overwrite_and_free(session, ref->page_del);
                 cmsp->needs_disk_transition = true;
@@ -66,8 +66,8 @@ __rec_child_deleted(
             }
         }
         /*
-         * Precise checkpoint is not enabled, or neither the rollback ts nor the prepare ts is at or
-         * below stable. Leave the page dirty.
+         * Precise checkpoint is not enabled, or the timestamps do not yet meet the stable
+         * threshold. Leave the page dirty.
          */
         if (F_ISSET(r, WT_REC_CLEAN_AFTER_REC | WT_REC_EVICT))
             return (__wt_set_return(session, EBUSY));

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -190,12 +190,14 @@ __wti_rec_col_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_REF *pageref)
         } else {
             __wt_cell_unpack_addr(session, page->dsk, ref->addr, vpack);
             if (cms.state == WTI_CHILD_PROXY ||
-              F_ISSET(vpack, WT_CELL_UNPACK_TIME_WINDOW_CLEARED)) {
+              F_ISSET(vpack, WT_CELL_UNPACK_TIME_WINDOW_CLEARED) ||
+              (cms.needs_disk_transition && vpack->type == WT_CELL_ADDR_DEL)) {
                 /*
-                 * Need to build a proxy (page-deleted) cell or rebuild the cell with updated time
-                 * info.
+                 * Build a proxy (page-deleted) cell, rebuild the cell with updated time info, or
+                 * revert an aborted-stable prepared proxy DEL cell to a plain addr cell.
                  */
-                WT_ASSERT(session, vpack->type != WT_CELL_ADDR_DEL || page_del != NULL);
+                WT_ASSERT(session,
+                  vpack->type != WT_CELL_ADDR_DEL || page_del != NULL || cms.needs_disk_transition);
                 __wti_rec_cell_build_addr(
                   session, r, NULL, vpack, ref->ref_recno, page_del, cms.is_prepared_fast_truncate);
             } else {
@@ -207,7 +209,8 @@ __wti_rec_col_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_REF *pageref)
             }
             WT_TIME_AGGREGATE_COPY(&ta, &vpack->ta);
         }
-        if (page_del != NULL)
+        if (page_del != NULL &&
+          __wt_atomic_load_uint64_v_relaxed(&page_del->txnid) != WT_TXN_ABORTED)
             WT_TIME_AGGREGATE_UPDATE_PAGE_DEL(session, &ft_ta, page_del);
         WTI_CHILD_RELEASE_ERR(session, cms.hazard, ref);
 

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -184,8 +184,8 @@ __wti_rec_col_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_REF *pageref)
         if (addr == NULL && __wt_off_page(page, ref->addr))
             addr = ref->addr;
         if (addr != NULL) {
-            /* FIXME-WT-17663: pass the correct is_prepared_fast_truncate from the caller. */
-            __wti_rec_cell_build_addr(session, r, addr, NULL, ref->ref_recno, page_del, false);
+            __wti_rec_cell_build_addr(
+              session, r, addr, NULL, ref->ref_recno, page_del, cms.is_prepared_fast_truncate);
             WT_TIME_AGGREGATE_COPY(&ta, &addr->ta);
         } else {
             __wt_cell_unpack_addr(session, page->dsk, ref->addr, vpack);
@@ -196,8 +196,8 @@ __wti_rec_col_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_REF *pageref)
                  * info.
                  */
                 WT_ASSERT(session, vpack->type != WT_CELL_ADDR_DEL || page_del != NULL);
-                /* FIXME-WT-17663: pass the correct is_prepared_fast_truncate from the caller. */
-                __wti_rec_cell_build_addr(session, r, NULL, vpack, ref->ref_recno, page_del, false);
+                __wti_rec_cell_build_addr(
+                  session, r, NULL, vpack, ref->ref_recno, page_del, cms.is_prepared_fast_truncate);
             } else {
                 /* Copy the entire existing cell, including any page-delete information. */
                 val->buf.data = ref->addr;

--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -82,7 +82,7 @@ __rec_col_merge(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
 
         /* Build the value cell. */
         addr = &multi->addr;
-        __wti_rec_cell_build_addr(session, r, addr, NULL, r->recno, NULL);
+        __wti_rec_cell_build_addr(session, r, addr, NULL, r->recno, NULL, false);
 
         /* Boundary: split or write the page. */
         if (__wti_rec_need_split(r, val->len))
@@ -184,7 +184,8 @@ __wti_rec_col_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_REF *pageref)
         if (addr == NULL && __wt_off_page(page, ref->addr))
             addr = ref->addr;
         if (addr != NULL) {
-            __wti_rec_cell_build_addr(session, r, addr, NULL, ref->ref_recno, page_del);
+            /* FIXME-WT-17663: pass the correct is_prepared_fast_truncate from the caller. */
+            __wti_rec_cell_build_addr(session, r, addr, NULL, ref->ref_recno, page_del, false);
             WT_TIME_AGGREGATE_COPY(&ta, &addr->ta);
         } else {
             __wt_cell_unpack_addr(session, page->dsk, ref->addr, vpack);
@@ -195,7 +196,8 @@ __wti_rec_col_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_REF *pageref)
                  * info.
                  */
                 WT_ASSERT(session, vpack->type != WT_CELL_ADDR_DEL || page_del != NULL);
-                __wti_rec_cell_build_addr(session, r, NULL, vpack, ref->ref_recno, page_del);
+                /* FIXME-WT-17663: pass the correct is_prepared_fast_truncate from the caller. */
+                __wti_rec_cell_build_addr(session, r, NULL, vpack, ref->ref_recno, page_del, false);
             } else {
                 /* Copy the entire existing cell, including any page-delete information. */
                 val->buf.data = ref->addr;

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -711,15 +711,15 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
         page_del = NULL;
         if (__wt_off_page(page, addr)) {
             page_del = cms.state == WTI_CHILD_PROXY ? &cms.del : NULL;
-            /* FIXME-WT-17663: pass the correct is_prepared_fast_truncate from the caller. */
-            __wti_rec_cell_build_addr(session, r, addr, NULL, WT_RECNO_OOB, page_del, false);
+            __wti_rec_cell_build_addr(
+              session, r, addr, NULL, WT_RECNO_OOB, page_del, cms.is_prepared_fast_truncate);
             source_ta = &addr->ta;
         } else if (cms.state == WTI_CHILD_PROXY) {
             /* Proxy cells require additional information in the address cell. */
             __wt_cell_unpack_addr(session, page->dsk, ref->addr, vpack);
             page_del = &cms.del;
-            /* FIXME-WT-17663: pass the correct is_prepared_fast_truncate from the caller. */
-            __wti_rec_cell_build_addr(session, r, NULL, vpack, WT_RECNO_OOB, page_del, false);
+            __wti_rec_cell_build_addr(
+              session, r, NULL, vpack, WT_RECNO_OOB, page_del, cms.is_prepared_fast_truncate);
             source_ta = &vpack->ta;
         } else {
             retain_onpage = true;
@@ -757,8 +757,8 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
             }
 
             if (F_ISSET(vpack, WT_CELL_UNPACK_TIME_WINDOW_CLEARED))
-                /* FIXME-WT-17663: pass the correct is_prepared_fast_truncate from the caller. */
-                __wti_rec_cell_build_addr(session, r, NULL, vpack, WT_RECNO_OOB, page_del, false);
+                __wti_rec_cell_build_addr(
+                  session, r, NULL, vpack, WT_RECNO_OOB, page_del, cms.is_prepared_fast_truncate);
             else {
                 val->buf.data = ref->addr;
                 val->buf.size = __wt_cell_total_len(vpack);

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -286,8 +286,8 @@ __rec_pack_delta_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_KV 
         static WT_TIME_AGGREGATE local_ta;
         WT_TIME_AGGREGATE_INIT(&local_ta);
 
-        t_kv->cell_len = __wt_cell_pack_addr(
-          session, &t_kv->cell, WT_CELL_ADDR_DEL_VISIBLE_ALL, WT_RECNO_OOB, NULL, &local_ta, 0);
+        t_kv->cell_len = __wt_cell_pack_addr(session, &t_kv->cell, WT_CELL_ADDR_DEL_VISIBLE_ALL,
+          WT_RECNO_OOB, NULL, &local_ta, false, 0);
         t_kv->len = t_kv->cell_len;
         WT_ASSERT(session, t_kv->len == WT_CELL_ADDR_DEL_VISIBLE_ALL_LEN);
         __wti_rec_kv_copy(session, p, t_kv);

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -471,7 +471,7 @@ __rec_row_merge(
         r->cell_zero = false;
 
         addr = &multi->addr;
-        __wti_rec_cell_build_addr(session, r, addr, NULL, WT_RECNO_OOB, NULL);
+        __wti_rec_cell_build_addr(session, r, addr, NULL, WT_RECNO_OOB, NULL, false);
 
         /* Boundary: split or write the page. */
         if (__wti_rec_need_split(r, key->len + val->len))
@@ -711,13 +711,15 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
         page_del = NULL;
         if (__wt_off_page(page, addr)) {
             page_del = cms.state == WTI_CHILD_PROXY ? &cms.del : NULL;
-            __wti_rec_cell_build_addr(session, r, addr, NULL, WT_RECNO_OOB, page_del);
+            /* FIXME-WT-17663: pass the correct is_prepared_fast_truncate from the caller. */
+            __wti_rec_cell_build_addr(session, r, addr, NULL, WT_RECNO_OOB, page_del, false);
             source_ta = &addr->ta;
         } else if (cms.state == WTI_CHILD_PROXY) {
             /* Proxy cells require additional information in the address cell. */
             __wt_cell_unpack_addr(session, page->dsk, ref->addr, vpack);
             page_del = &cms.del;
-            __wti_rec_cell_build_addr(session, r, NULL, vpack, WT_RECNO_OOB, page_del);
+            /* FIXME-WT-17663: pass the correct is_prepared_fast_truncate from the caller. */
+            __wti_rec_cell_build_addr(session, r, NULL, vpack, WT_RECNO_OOB, page_del, false);
             source_ta = &vpack->ta;
         } else {
             retain_onpage = true;
@@ -755,7 +757,8 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
             }
 
             if (F_ISSET(vpack, WT_CELL_UNPACK_TIME_WINDOW_CLEARED))
-                __wti_rec_cell_build_addr(session, r, NULL, vpack, WT_RECNO_OOB, page_del);
+                /* FIXME-WT-17663: pass the correct is_prepared_fast_truncate from the caller. */
+                __wti_rec_cell_build_addr(session, r, NULL, vpack, WT_RECNO_OOB, page_del, false);
             else {
                 val->buf.data = ref->addr;
                 val->buf.size = __wt_cell_total_len(vpack);

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -756,10 +756,12 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
                   ref->page_del->selected_for_write ? "true" : "false");
             }
 
-            if (F_ISSET(vpack, WT_CELL_UNPACK_TIME_WINDOW_CLEARED))
+            if (F_ISSET(vpack, WT_CELL_UNPACK_TIME_WINDOW_CLEARED)) {
+                /* page_del is NULL here; prepared fast truncate must be false. */
+                WT_ASSERT(session, !cms.is_prepared_fast_truncate || page_del != NULL);
                 __wti_rec_cell_build_addr(
                   session, r, NULL, vpack, WT_RECNO_OOB, page_del, cms.is_prepared_fast_truncate);
-            else {
+            } else {
                 val->buf.data = ref->addr;
                 val->buf.size = __wt_cell_total_len(vpack);
                 val->cell_len = 0;

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -739,13 +739,20 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
 
             /* The proxy cells of fast truncate pages must be handled in the above flows. */
             if (ref->page_del == NULL)
-                WT_ASSERT_ALWAYS(session, vpack->type != WT_CELL_ADDR_DEL,
+                /*
+                 * Exception: needs_disk_transition means a previously-written prepared proxy DEL
+                 * cell is being reverted to a plain addr cell (rollback became stable). We rebuild
+                 * the cell from the DEL cell's block address below.
+                 */
+                WT_ASSERT_ALWAYS(session,
+                  vpack->type != WT_CELL_ADDR_DEL || cms.needs_disk_transition,
                   "Proxy cell is selected with original child image, vpack->type=%u, "
                   "ref->page_del=NULL",
                   vpack->type);
             else {
                 char ts_string[2][WT_TS_INT_STRING_SIZE];
-                WT_ASSERT_ALWAYS(session, vpack->type != WT_CELL_ADDR_DEL,
+                WT_ASSERT_ALWAYS(session,
+                  vpack->type != WT_CELL_ADDR_DEL || cms.needs_disk_transition,
                   "Proxy cell is selected with original child image, vpack->type=%u, "
                   "ref->page_del->txnid=%" PRIu64
                   ", pg_del_durable_ts=%s, pg_del_start_ts=%s, committed=%s, selected_for_write=%s",
@@ -756,8 +763,14 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
                   ref->page_del->selected_for_write ? "true" : "false");
             }
 
-            if (F_ISSET(vpack, WT_CELL_UNPACK_TIME_WINDOW_CLEARED)) {
-                /* page_del is NULL here; prepared fast truncate must be false. */
+            if (F_ISSET(vpack, WT_CELL_UNPACK_TIME_WINDOW_CLEARED) ||
+              (cms.needs_disk_transition && vpack->type == WT_CELL_ADDR_DEL)) {
+                /*
+                 * Rebuild the cell. For WT_CELL_UNPACK_TIME_WINDOW_CLEARED: page_del is NULL and
+                 * prepared fast truncate must be false. For needs_disk_transition with a DEL cell:
+                 * page_del is already NULL (freed) and we write a plain addr cell using the block
+                 * address encoded in the DEL cell.
+                 */
                 WT_ASSERT(session, !cms.is_prepared_fast_truncate || page_del != NULL);
                 __wti_rec_cell_build_addr(
                   session, r, NULL, vpack, WT_RECNO_OOB, page_del, cms.is_prepared_fast_truncate);
@@ -780,7 +793,8 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
          * Track the time window. The fast-truncate is a stop time window and has to be considered
          * in the internal page's aggregate information for RTS to find it.
          */
-        if (page_del != NULL)
+        if (page_del != NULL &&
+          __wt_atomic_load_uint64_v_relaxed(&page_del->txnid) != WT_TXN_ABORTED)
             WT_TIME_AGGREGATE_UPDATE_PAGE_DEL(session, &ft_ta, page_del);
 
         F_CLR(ref, WT_REF_FLAG_REC_MULTIPLE);

--- a/src/reconcile/reconcile_inline.h
+++ b/src/reconcile/reconcile_inline.h
@@ -355,7 +355,8 @@ __wti_rec_image_copy(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_KV *kv)
  */
 static WT_INLINE void
 __wti_rec_cell_build_addr(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_ADDR *addr,
-  WT_CELL_UNPACK_ADDR *vpack, uint64_t recno, WT_PAGE_DELETED *page_del)
+  WT_CELL_UNPACK_ADDR *vpack, uint64_t recno, WT_PAGE_DELETED *page_del,
+  bool is_prepared_fast_truncate)
 {
     WTI_REC_KV *val = &r->v;
     WT_TIME_AGGREGATE *ta;
@@ -404,7 +405,7 @@ __wti_rec_cell_build_addr(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_ADDR *a
     val->buf.data = data;
     val->buf.size = data_size;
     val->cell_len = (uint16_t)__wt_cell_build_addr(
-      session, &val->cell, cell_type, recno, page_del, ta, data_size);
+      session, &val->cell, cell_type, recno, page_del, ta, is_prepared_fast_truncate, data_size);
     val->len = val->cell_len + data_size;
 }
 

--- a/src/reconcile/reconcile_private.h
+++ b/src/reconcile/reconcile_private.h
@@ -54,7 +54,8 @@ typedef struct {
 
     bool hazard;                    /* If currently holding a child hazard pointer */
     bool is_prepared_fast_truncate; /* proxy cell should use prepared encoding */
-    bool needs_disk_transition;     /* aborted-stable */
+    /* True when a prepared fast-truncate was aborted and the rollback is stable. */
+    bool needs_disk_transition;
 } WTI_CHILD_MODIFY_STATE;
 
 /*

--- a/src/reconcile/reconcile_private.h
+++ b/src/reconcile/reconcile_private.h
@@ -52,7 +52,9 @@ typedef struct {
 
     WT_PAGE_DELETED del; /* WTI_CHILD_PROXY state fast-truncate information */
 
-    bool hazard; /* If currently holding a child hazard pointer */
+    bool hazard;                    /* If currently holding a child hazard pointer */
+    bool is_prepared_fast_truncate; /* proxy cell should use prepared encoding */
+    bool needs_disk_transition;     /* aborted-stable */
 } WTI_CHILD_MODIFY_STATE;
 
 /*

--- a/src/reconcile/reconcile_private.h
+++ b/src/reconcile/reconcile_private.h
@@ -548,7 +548,8 @@ static WT_INLINE int __wti_rec_get_row_leaf_key(WT_SESSION_IMPL *session, WT_BTR
   WTI_RECONCILE *r, WT_INSERT *ins, WT_ROW *rip, WT_ITEM *key)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE void __wti_rec_cell_build_addr(WT_SESSION_IMPL *session, WTI_RECONCILE *r,
-  WT_ADDR *addr, WT_CELL_UNPACK_ADDR *vpack, uint64_t recno, WT_PAGE_DELETED *page_del);
+  WT_ADDR *addr, WT_CELL_UNPACK_ADDR *vpack, uint64_t recno, WT_PAGE_DELETED *page_del,
+  bool is_prepared_fast_truncate);
 static WT_INLINE void __wti_rec_image_copy(
   WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_KV *kv);
 static WT_INLINE void __wti_rec_kv_copy(WT_SESSION_IMPL *session, uint8_t *p, WTI_REC_KV *kv);

--- a/src/reconcile/reconcile_private.h
+++ b/src/reconcile/reconcile_private.h
@@ -52,7 +52,8 @@ typedef struct {
 
     WT_PAGE_DELETED del; /* WTI_CHILD_PROXY state fast-truncate information */
 
-    bool hazard;                    /* If currently holding a child hazard pointer */
+    bool hazard; /* If currently holding a child hazard pointer */
+
     bool is_prepared_fast_truncate; /* proxy cell should use prepared encoding */
     /* True when a prepared fast-truncate was aborted and the rollback is stable. */
     bool needs_disk_transition;

--- a/test/catch2/misc_tests/test_cell_fast_truncate_unpack.cpp
+++ b/test/catch2/misc_tests/test_cell_fast_truncate_unpack.cpp
@@ -145,7 +145,8 @@ TEST_CASE("Cell Fast Truncate Pack/Unpack: committed deletion round-trips correc
 
     WT_CELL cell;
     memset(&cell, 0, sizeof(cell));
-    WT_IGNORE_RET(__wt_cell_pack_addr(session, &cell, WT_CELL_ADDR_DEL, WT_RECNO_OOB, &page_del, &ta, 0));
+    WT_IGNORE_RET(
+      __wt_cell_pack_addr(session, &cell, WT_CELL_ADDR_DEL, WT_RECNO_OOB, &page_del, &ta, 0));
 
     WT_CELL_UNPACK_ADDR unpack;
     memset(&unpack, 0, sizeof(unpack));
@@ -187,7 +188,8 @@ TEST_CASE("Cell Fast Truncate Pack/Unpack: prepared deletion round-trips correct
 
     WT_CELL cell;
     memset(&cell, 0, sizeof(cell));
-    WT_IGNORE_RET(__wt_cell_pack_addr(session, &cell, WT_CELL_ADDR_DEL, WT_RECNO_OOB, &page_del, &ta, 0));
+    WT_IGNORE_RET(
+      __wt_cell_pack_addr(session, &cell, WT_CELL_ADDR_DEL, WT_RECNO_OOB, &page_del, &ta, 0));
 
     WT_CELL_UNPACK_ADDR unpack;
     memset(&unpack, 0, sizeof(unpack));

--- a/test/catch2/misc_tests/test_cell_fast_truncate_unpack.cpp
+++ b/test/catch2/misc_tests/test_cell_fast_truncate_unpack.cpp
@@ -145,8 +145,8 @@ TEST_CASE("Cell Fast Truncate Pack/Unpack: committed deletion round-trips correc
 
     WT_CELL cell;
     memset(&cell, 0, sizeof(cell));
-    WT_IGNORE_RET(
-      __wt_cell_pack_addr(session, &cell, WT_CELL_ADDR_DEL, WT_RECNO_OOB, &page_del, &ta, 0));
+    WT_IGNORE_RET(__wt_cell_pack_addr(
+      session, &cell, WT_CELL_ADDR_DEL, WT_RECNO_OOB, &page_del, &ta, false, 0));
 
     WT_CELL_UNPACK_ADDR unpack;
     memset(&unpack, 0, sizeof(unpack));
@@ -189,8 +189,8 @@ TEST_CASE("Cell Fast Truncate Pack/Unpack: prepared deletion round-trips correct
 
     WT_CELL cell;
     memset(&cell, 0, sizeof(cell));
-    WT_IGNORE_RET(
-      __wt_cell_pack_addr(session, &cell, WT_CELL_ADDR_DEL, WT_RECNO_OOB, &page_del, &ta, 0));
+    WT_IGNORE_RET(__wt_cell_pack_addr(
+      session, &cell, WT_CELL_ADDR_DEL, WT_RECNO_OOB, &page_del, &ta, true, 0));
 
     WT_CELL_UNPACK_ADDR unpack;
     memset(&unpack, 0, sizeof(unpack));

--- a/test/catch2/misc_tests/test_cell_fast_truncate_unpack.cpp
+++ b/test/catch2/misc_tests/test_cell_fast_truncate_unpack.cpp
@@ -123,6 +123,91 @@ TEST_CASE(
     CHECK(unpack.ta.prepare == 0);
 }
 
+TEST_CASE("Cell Fast Truncate Pack/Unpack: committed deletion round-trips correctly",
+  "[cell][fast_truncate]")
+{
+    auto session_mock = setup_mock_session();
+    WT_SESSION_IMPL *session = session_mock->get_wt_session_impl();
+
+    WT_PAGE_HEADER dsk = make_ft_page_header();
+
+    /* Build a committed page_del and pack it into a cell. */
+    WT_PAGE_DELETED page_del;
+    memset(&page_del, 0, sizeof(page_del));
+    page_del.txnid = 42;
+    page_del.pg_del_start_ts = 100;
+    page_del.pg_del_durable_ts = 110;
+    page_del.prepare_state = WT_PREPARE_INIT;
+    page_del.committed = true;
+
+    WT_TIME_AGGREGATE ta;
+    WT_TIME_AGGREGATE_INIT(&ta);
+
+    WT_CELL cell;
+    memset(&cell, 0, sizeof(cell));
+    WT_IGNORE_RET(__wt_cell_pack_addr(session, &cell, WT_CELL_ADDR_DEL, WT_RECNO_OOB, &page_del, &ta, 0));
+
+    WT_CELL_UNPACK_ADDR unpack;
+    memset(&unpack, 0, sizeof(unpack));
+    __wt_cell_unpack_addr(session, &dsk, &cell, &unpack);
+
+    const WT_PAGE_DELETED &pd = unpack.page_del;
+    CHECK(pd.txnid == 42);
+    CHECK(pd.pg_del_start_ts == 100);
+    CHECK(pd.pg_del_durable_ts == 110);
+    CHECK(pd.prepare_state == WT_PREPARE_INIT);
+    CHECK(pd.committed == true);
+    CHECK(pd.selected_for_write == true);
+    CHECK(unpack.ta.prepare == 0);
+}
+
+TEST_CASE("Cell Fast Truncate Pack/Unpack: prepared deletion round-trips correctly",
+  "[cell][fast_truncate]")
+{
+    auto session_mock = setup_mock_session();
+    WT_SESSION_IMPL *session = session_mock->get_wt_session_impl();
+
+    /* preserve_prepared must be set to allow packing an in-progress prepared state. */
+    F_SET(S2C(session), WT_CONN_PRESERVE_PREPARED);
+
+    WT_PAGE_HEADER dsk = make_ft_page_header();
+
+    /* Build a prepared page_del and pack it into a cell. */
+    WT_PAGE_DELETED page_del;
+    memset(&page_del, 0, sizeof(page_del));
+    page_del.txnid = 99;
+    page_del.prepare_ts = 50;
+    page_del.prepared_id = 7;
+    page_del.pg_del_durable_ts = WT_TS_NONE;
+    page_del.prepare_state = WT_PREPARE_INPROGRESS;
+    page_del.committed = false;
+
+    WT_TIME_AGGREGATE ta;
+    WT_TIME_AGGREGATE_INIT(&ta);
+
+    WT_CELL cell;
+    memset(&cell, 0, sizeof(cell));
+    WT_IGNORE_RET(__wt_cell_pack_addr(session, &cell, WT_CELL_ADDR_DEL, WT_RECNO_OOB, &page_del, &ta, 0));
+
+    WT_CELL_UNPACK_ADDR unpack;
+    memset(&unpack, 0, sizeof(unpack));
+    __wt_cell_unpack_addr(session, &dsk, &cell, &unpack);
+
+    const WT_PAGE_DELETED &pd = unpack.page_del;
+    CHECK(pd.txnid == 99);
+    CHECK(pd.prepare_ts == 50);
+    CHECK(pd.pg_del_start_ts == 50);
+    CHECK(pd.prepared_id == 7);
+    CHECK(pd.pg_del_durable_ts == WT_TS_NONE);
+    CHECK(pd.prepare_state == WT_PREPARE_INPROGRESS);
+    CHECK(pd.committed == false);
+    CHECK(pd.selected_for_write == true);
+    /* A prepared fast-truncate does not propagate prepare to the page-level visibility window. */
+    CHECK(unpack.ta.prepare == 0);
+
+    F_CLR(S2C(session), WT_CONN_PRESERVE_PREPARED);
+}
+
 TEST_CASE("Cell Fast Truncate: prepare flag on non-fast-truncate addr cell marks page as prepared",
   "[cell][fast_truncate]")
 {

--- a/test/catch2/misc_tests/test_cell_fast_truncate_unpack.cpp
+++ b/test/catch2/misc_tests/test_cell_fast_truncate_unpack.cpp
@@ -168,8 +168,9 @@ TEST_CASE("Cell Fast Truncate Pack/Unpack: prepared deletion round-trips correct
     auto session_mock = setup_mock_session();
     WT_SESSION_IMPL *session = session_mock->get_wt_session_impl();
 
-    /* preserve_prepared must be set to allow packing an in-progress prepared state. */
+    /* Both flags are required to pack a prepared fast-truncate cell. */
     F_SET(S2C(session), WT_CONN_PRESERVE_PREPARED);
+    F_SET(S2BT(session), WT_BTREE_DISAGGREGATED);
 
     WT_PAGE_HEADER dsk = make_ft_page_header();
 
@@ -208,6 +209,7 @@ TEST_CASE("Cell Fast Truncate Pack/Unpack: prepared deletion round-trips correct
     CHECK(unpack.ta.prepare == 0);
 
     F_CLR(S2C(session), WT_CONN_PRESERVE_PREPARED);
+    F_CLR(S2BT(session), WT_BTREE_DISAGGREGATED);
 }
 
 TEST_CASE("Cell Fast Truncate: prepare flag on non-fast-truncate addr cell marks page as prepared",

--- a/test/catch2/misc_tests/test_cell_fast_truncate_unpack.cpp
+++ b/test/catch2/misc_tests/test_cell_fast_truncate_unpack.cpp
@@ -189,8 +189,8 @@ TEST_CASE("Cell Fast Truncate Pack/Unpack: prepared deletion round-trips correct
 
     WT_CELL cell;
     memset(&cell, 0, sizeof(cell));
-    WT_IGNORE_RET(__wt_cell_pack_addr(
-      session, &cell, WT_CELL_ADDR_DEL, WT_RECNO_OOB, &page_del, &ta, true, 0));
+    WT_IGNORE_RET(
+      __wt_cell_pack_addr(session, &cell, WT_CELL_ADDR_DEL, WT_RECNO_OOB, &page_del, &ta, true, 0));
 
     WT_CELL_UNPACK_ADDR unpack;
     memset(&unpack, 0, sizeof(unpack));

--- a/test/suite/test_prepare_fast_trunc_proxy.py
+++ b/test/suite/test_prepare_fast_trunc_proxy.py
@@ -35,8 +35,8 @@ from helper import simulate_crash_restart
 # test_prepare_fast_trunc_proxy.py
 #
 # Verify that internal-page reconciliation writes the correct proxy cell encoding
-# (prepared vs. committed vs. absent) for fast-truncated pages based on the three
-# cases introduced in WT-17663:
+# (prepared vs. committed vs. absent) for fast-truncated pages under precise
+# checkpoint.  Four cases are covered:
 #
 #   Case 1 (prepare case):  page_del still in-flight prepared,
 #                           prepare_ts <= stable_ts - write prepared proxy cell
@@ -124,7 +124,7 @@ class test_prepare_fast_trunc_proxy(wttest.WiredTigerTestCase):
     # Case 1: In-flight prepared fast-truncate with prepare_ts (20) <= stable_ts (25)
     #
     # Checkpoint with precise_checkpoint=true should succeed and write prepared
-    # proxy cells (not skip them). After crash-restart the table is openable and
+    # proxy cells (not skip them). After crash-restart the table can be opened and
     # rows outside the truncated range remain visible at ts=10.
     # -------------------------------------------------------------------------
     def test_case1_inflight_prepare(self):

--- a/test/suite/test_prepare_fast_trunc_proxy.py
+++ b/test/suite/test_prepare_fast_trunc_proxy.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wttest
+from wiredtiger import stat
+from wtdataset import SimpleDataSet
+from wtscenario import make_scenarios
+from helper import simulate_crash_restart
+
+# test_prepare_fast_trunc_proxy.py
+#
+# Verify that internal-page reconciliation writes the correct proxy cell encoding
+# (prepared vs. committed vs. absent) for fast-truncated pages based on the three
+# cases introduced in WT-17663:
+#
+#   Case 1 (prepare case):  page_del still in-flight prepared,
+#                           prepare_ts <= stable_ts → write prepared proxy cell
+#   Case 2 (commit case):   page_del committed after prepare,
+#                           durable_ts > stable_ts but prepare_ts <= stable_ts
+#                           → write prepared proxy cell; after RTS data comes back
+#   Case 3 (rollback case, proxy):  page_del prepared then aborted,
+#                           rollback_ts > stable_ts but prepare_ts <= stable_ts
+#                           → write prepared proxy cell; pages accessible after recovery
+#   Case 4 (rollback case, no proxy): page_del prepared then aborted,
+#                           rollback_ts <= stable_ts
+#                           → do NOT write proxy cell; pages accessible after reopen
+class test_prepare_fast_trunc_proxy(wttest.WiredTigerTestCase):
+
+    # precise_checkpoint=true is required for the new selection logic to activate.
+    conn_config = 'statistics=(all),precise_checkpoint=true'
+    session_config = 'isolation=snapshot'
+
+    format_values = [
+        ('column', dict(key_format='r', extraconfig='')),
+        ('integer_row', dict(key_format='i', extraconfig='')),
+    ]
+    scenarios = make_scenarios(format_values)
+
+    nrows = 10000
+
+    def _setup_table(self, uri):
+        """Create, populate with baseline data at ts=10, then reopen so fast-truncate is possible."""
+        ds = SimpleDataSet(
+            self, uri, 0, key_format=self.key_format, value_format='S',
+            config=self.extraconfig)
+        ds.populate()
+
+        value_a = "aaaaa" * 100
+        self.conn.set_timestamp(
+            'oldest_timestamp=' + self.timestamp_str(1) +
+            ',stable_timestamp=' + self.timestamp_str(1))
+
+        cursor = self.session.open_cursor(ds.uri)
+        self.session.begin_transaction()
+        for i in range(1, self.nrows + 1):
+            cursor[ds.key(i)] = value_a
+            if i % 487 == 0:
+                self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
+                self.session.begin_transaction()
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
+        cursor.close()
+
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10))
+
+        # Reopen so pages are on disk and fast-truncate is possible.
+        self.reopen_conn()
+        return ds
+
+    def _fast_truncate(self, session, uri, ds, lo, hi):
+        lo_cursor = session.open_cursor(uri)
+        hi_cursor = session.open_cursor(uri)
+        lo_cursor.set_key(ds.key(lo))
+        hi_cursor.set_key(ds.key(hi))
+        ret = session.truncate(None, lo_cursor, hi_cursor, None)
+        lo_cursor.close()
+        hi_cursor.close()
+        self.assertEqual(ret, 0)
+
+    def _fast_delete_count(self):
+        stat_cursor = self.session.open_cursor('statistics:', None, None)
+        v = stat_cursor[stat.conn.rec_page_delete_fast][2]
+        stat_cursor.close()
+        return v
+
+    def _count_visible_rows(self, uri, ds, lo, hi, read_ts):
+        """Count rows visible in [lo, hi] at read_ts."""
+        cursor = self.session.open_cursor(uri, None, None)
+        self.session.begin_transaction('read_timestamp=' + self.timestamp_str(read_ts))
+        found = 0
+        for i in range(lo, hi + 1):
+            cursor.set_key(ds.key(i))
+            if cursor.search() == 0:
+                found += 1
+        self.session.commit_transaction()
+        cursor.close()
+        return found
+
+    # -------------------------------------------------------------------------
+    # Case 1: In-flight prepared fast-truncate with prepare_ts (20) <= stable_ts (25)
+    #
+    # Checkpoint with precise_checkpoint=true should succeed and write prepared
+    # proxy cells (not skip them). After crash-restart the table is openable and
+    # rows outside the truncated range remain visible at ts=10.
+    # -------------------------------------------------------------------------
+    def test_case1_inflight_prepare(self):
+        uri = 'table:prepare_ft_proxy_case1'
+        ds = self._setup_table(uri)
+
+        session2 = self.conn.open_session()
+
+        # Count fast-deletes before truncation.
+        before_trunc = self._fast_delete_count()
+
+        session2.begin_transaction()
+        lo = self.nrows // 4 + 1
+        hi = 3 * self.nrows // 4
+        self._fast_truncate(session2, uri, ds, lo, hi)
+        # prepare_ts=20 <= stable_ts=25 set below.
+        session2.prepare_transaction('prepare_timestamp=' + self.timestamp_str(20))
+
+        # Verify fast-deletes happened.
+        if not self.runningHook('tiered'):
+            self.assertGreater(self._fast_delete_count(), before_trunc)
+
+        # Advance stable past prepare_ts.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(25))
+
+        # Checkpoint must succeed even with an in-flight prepared fast-truncate
+        # whose prepare_ts is stable.
+        self.session.checkpoint()
+
+        # Crash-restart (recovery).
+        simulate_crash_restart(self, ".", "RESTART")
+
+        # Rows OUTSIDE the truncated range should be visible at ts=10.
+        found_before = self._count_visible_rows(uri, ds, 1, lo - 1, 10)
+        found_after = self._count_visible_rows(uri, ds, hi + 1, self.nrows, 10)
+        self.assertEqual(found_before, lo - 1)
+        self.assertEqual(found_after, self.nrows - hi)
+
+    # -------------------------------------------------------------------------
+    # Case 2: Fast-truncate prepared (ts=20) then committed with durable_ts=35 > stable_ts=25
+    #
+    # The checkpoint at stable_ts=25 must write a PREPARED proxy cell (not a
+    # committed one) because the durable commit is beyond stable. After
+    # crash+restart the stable is still 25 and the data in the truncated range
+    # must still be visible at ts=10 (the deletion is not stable yet).
+    # -------------------------------------------------------------------------
+    def test_case2_commit_durable_beyond_stable(self):
+        uri = 'table:prepare_ft_proxy_case2'
+        ds = self._setup_table(uri)
+
+        session2 = self.conn.open_session()
+
+        before_trunc = self._fast_delete_count()
+
+        session2.begin_transaction()
+        lo = self.nrows // 4 + 1
+        hi = 3 * self.nrows // 4
+        self._fast_truncate(session2, uri, ds, lo, hi)
+        session2.prepare_transaction('prepare_timestamp=' + self.timestamp_str(20))
+        # Commit at 30, durable at 35 – both beyond stable_ts=25.
+        session2.commit_transaction(
+            'commit_timestamp=' + self.timestamp_str(30) +
+            ',durable_timestamp=' + self.timestamp_str(35))
+
+        if not self.runningHook('tiered'):
+            self.assertGreater(self._fast_delete_count(), before_trunc)
+
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(25))
+        self.session.checkpoint()
+
+        # Crash+restart.
+        simulate_crash_restart(self, ".", "RESTART")
+
+        # After recovery the stable_ts is 25 and the durable commit (35) is
+        # beyond stable. The truncated rows should still be visible at ts=10.
+        found = self._count_visible_rows(uri, ds, lo, hi, 10)
+        self.assertEqual(found, hi - lo + 1)
+
+    # -------------------------------------------------------------------------
+    # Case 3: Fast-truncate prepared (ts=20) then rolled back (rollback_ts=30 > stable_ts=25)
+    #
+    # The checkpoint must write a prepared proxy cell (prepare_ts=20 is stable but
+    # rollback_ts=30 is not). After crash+restart the rollback is replayed from the
+    # log and the truncated pages are accessible again at ts=10.
+    # -------------------------------------------------------------------------
+    def test_case3_rollback_beyond_stable(self):
+        uri = 'table:prepare_ft_proxy_case3'
+        ds = self._setup_table(uri)
+
+        session2 = self.conn.open_session()
+
+        before_trunc = self._fast_delete_count()
+
+        session2.begin_transaction()
+        lo = self.nrows // 4 + 1
+        hi = 3 * self.nrows // 4
+        self._fast_truncate(session2, uri, ds, lo, hi)
+        session2.prepare_transaction('prepare_timestamp=' + self.timestamp_str(20))
+
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(25))
+
+        if not self.runningHook('tiered'):
+            self.assertGreater(self._fast_delete_count(), before_trunc)
+
+        # Roll back with rollback_ts=30 > stable_ts=25.
+        session2.rollback_transaction(
+            'rollback_timestamp=' + self.timestamp_str(30))
+
+        # Checkpoint: prepare_ts (20) is stable but rollback_ts (30) is not.
+        # A prepared proxy cell should be written.
+        self.session.checkpoint()
+
+        # Crash+restart. The rollback is in the log and replayed by recovery.
+        simulate_crash_restart(self, ".", "RESTART")
+
+        # After recovery the truncated pages should be accessible (rollback replayed).
+        found = self._count_visible_rows(uri, ds, lo, hi, 10)
+        self.assertEqual(found, hi - lo + 1)
+
+    # -------------------------------------------------------------------------
+    # Case 4: Fast-truncate prepared (ts=20) then rolled back (rollback_ts=30),
+    #         then stable advanced to 35 so rollback_ts (30) <= stable_ts (35).
+    #
+    # Rollback must use rollback_ts > stable_ts at rollback time, so we first
+    # rollback at ts=30 when stable=25, then advance stable to 35. The checkpoint
+    # at stable_ts=35 sees rollback_ts (30) <= stable_ts (35) and must NOT write
+    # a proxy cell.  After reopen the pages are accessible.
+    # -------------------------------------------------------------------------
+    def test_case4_rollback_before_stable(self):
+        uri = 'table:prepare_ft_proxy_case4'
+        ds = self._setup_table(uri)
+
+        session2 = self.conn.open_session()
+
+        before_trunc = self._fast_delete_count()
+
+        session2.begin_transaction()
+        lo = self.nrows // 4 + 1
+        hi = 3 * self.nrows // 4
+        self._fast_truncate(session2, uri, ds, lo, hi)
+        # prepare_ts=20 <= stable_ts=25 (set below before rollback).
+        session2.prepare_transaction('prepare_timestamp=' + self.timestamp_str(20))
+
+        # Set stable to 25; prepare_ts (20) is now stable.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(25))
+
+        if not self.runningHook('tiered'):
+            self.assertGreater(self._fast_delete_count(), before_trunc)
+
+        # Roll back with rollback_ts=30 > stable_ts=25 (required by WiredTiger).
+        session2.rollback_transaction(
+            'rollback_timestamp=' + self.timestamp_str(30))
+
+        # Now advance stable past rollback_ts so rollback_ts (30) <= stable_ts (35).
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(35))
+
+        # Checkpoint at stable_ts=35: rollback_ts (30) <= stable_ts (35),
+        # so no prepared proxy cell should be written.
+        self.session.checkpoint()
+
+        # After reopen the truncated pages must be accessible (deletion was aborted
+        # and that abort is stable).
+        self.reopen_conn()
+
+        found = self._count_visible_rows(uri, ds, lo, hi, 10)
+        self.assertEqual(found, hi - lo + 1)
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_prepare_fast_trunc_proxy.py
+++ b/test/suite/test_prepare_fast_trunc_proxy.py
@@ -39,16 +39,16 @@ from helper import simulate_crash_restart
 # cases introduced in WT-17663:
 #
 #   Case 1 (prepare case):  page_del still in-flight prepared,
-#                           prepare_ts <= stable_ts → write prepared proxy cell
+#                           prepare_ts <= stable_ts - write prepared proxy cell
 #   Case 2 (commit case):   page_del committed after prepare,
 #                           durable_ts > stable_ts but prepare_ts <= stable_ts
-#                           → write prepared proxy cell; after RTS data comes back
+#                           - write prepared proxy cell; after RTS data comes back
 #   Case 3 (rollback case, proxy):  page_del prepared then aborted,
 #                           rollback_ts > stable_ts but prepare_ts <= stable_ts
-#                           → write prepared proxy cell; pages accessible after recovery
+#                           - write prepared proxy cell; pages accessible after recovery
 #   Case 4 (rollback case, no proxy): page_del prepared then aborted,
 #                           rollback_ts <= stable_ts
-#                           → do NOT write proxy cell; pages accessible after reopen
+#                           - do NOT write proxy cell; pages accessible after reopen
 class test_prepare_fast_trunc_proxy(wttest.WiredTigerTestCase):
 
     # precise_checkpoint=true is required for the new selection logic to activate.
@@ -184,7 +184,7 @@ class test_prepare_fast_trunc_proxy(wttest.WiredTigerTestCase):
         hi = 3 * self.nrows // 4
         self._fast_truncate(session2, uri, ds, lo, hi)
         session2.prepare_transaction('prepare_timestamp=' + self.timestamp_str(20))
-        # Commit at 30, durable at 35 – both beyond stable_ts=25.
+        # Commit at 30, durable at 35, both beyond stable_ts=25.
         session2.commit_transaction(
             'commit_timestamp=' + self.timestamp_str(30) +
             ',durable_timestamp=' + self.timestamp_str(35))

--- a/test/suite/test_prepare_fast_trunc_proxy.py
+++ b/test/suite/test_prepare_fast_trunc_proxy.py
@@ -312,7 +312,7 @@ class test_prepare_fast_trunc_proxy(wttest.WiredTigerTestCase):
         self.assertEqual(found, hi - lo + 1)
 
     # -------------------------------------------------------------------------
-    # Case 5: Like Case 4 but a checkpoint is taken WHILE the prepare is in
+    # Case 5: Like Case 4 but a checkpoint is taken while the prepare is in
     #         flight (before rollback), so the first checkpoint writes a
     #         prepared proxy DEL cell.  After rollback and stable advancing past
     #         rollback_ts a second checkpoint must revert that DEL cell to a
@@ -355,8 +355,8 @@ class test_prepare_fast_trunc_proxy(wttest.WiredTigerTestCase):
         # Advance stable past rollback_ts: the rollback is now stable.
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(35))
 
-        # Checkpoint 2: rollback_ts (30) <= stable_ts (35).  The reconciler
-        # must revert the on-page prepared proxy DEL cell to a plain addr cell
+        # Checkpoint 2: rollback_ts (30) <= stable_ts (35).
+        # Must revert the on-page prepared proxy DEL cell to a plain addr cell
         # rather than copying it verbatim or firing an assertion.
         self.session.checkpoint()
 
@@ -370,9 +370,9 @@ class test_prepare_fast_trunc_proxy(wttest.WiredTigerTestCase):
     # Case 6: Fast-truncate prepared (ts=20) then committed with durable_ts=30,
     #         stable advanced to 35 so durable_ts (30) <= stable_ts (35).
     #
-    # The spec's commit path: "if durable_ts <= stable_ts: write as committed
-    # page del".  The checkpoint at stable_ts=35 must write a COMMITTED (not
-    # prepared) proxy cell.  After reopen the truncated rows must NOT be visible
+    # If durable_ts <= stable_ts: write as committed page del.
+    # The checkpoint at stable_ts=35 must write a committed (not prepared)
+    # proxy cell.  After reopen the truncated rows must NOT be visible
     # (the deletion is fully stable).
     # -------------------------------------------------------------------------
     def test_case6_commit_durable_within_stable(self):

--- a/test/suite/test_prepare_fast_trunc_proxy.py
+++ b/test/suite/test_prepare_fast_trunc_proxy.py
@@ -36,7 +36,7 @@ from helper import simulate_crash_restart
 #
 # Verify that internal-page reconciliation writes the correct proxy cell encoding
 # (prepared vs. committed vs. absent) for fast-truncated pages under precise
-# checkpoint.  Four cases are covered:
+# checkpoint.  Six cases are covered:
 #
 #   Case 1 (prepare case):  page_del still in-flight prepared,
 #                           prepare_ts <= stable_ts - write prepared proxy cell
@@ -49,6 +49,10 @@ from helper import simulate_crash_restart
 #   Case 4 (rollback case, no proxy): page_del prepared then aborted,
 #                           rollback_ts <= stable_ts
 #                           - do NOT write proxy cell; pages accessible after reopen
+#   Case 5 (proxy revert):  checkpoint written mid-prepare, then rollback becomes stable
+#                           - second checkpoint must revert prepared proxy cell
+#   Case 6 (commit stable): page_del committed with durable_ts <= stable_ts
+#                           - write committed proxy cell; deletion visible after reopen
 class test_prepare_fast_trunc_proxy(wttest.WiredTigerTestCase):
 
     # precise_checkpoint=true is required for the new selection logic to activate.
@@ -79,6 +83,7 @@ class test_prepare_fast_trunc_proxy(wttest.WiredTigerTestCase):
         self.session.begin_transaction()
         for i in range(1, self.nrows + 1):
             cursor[ds.key(i)] = value_a
+            # Commit in chunks to force multiple leaf pages for fast-truncate.
             if i % 487 == 0:
                 self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
                 self.session.begin_transaction()
@@ -112,12 +117,14 @@ class test_prepare_fast_trunc_proxy(wttest.WiredTigerTestCase):
         cursor = self.session.open_cursor(uri, None, None)
         self.session.begin_transaction('read_timestamp=' + self.timestamp_str(read_ts))
         found = 0
-        for i in range(lo, hi + 1):
-            cursor.set_key(ds.key(i))
-            if cursor.search() == 0:
-                found += 1
-        self.session.commit_transaction()
-        cursor.close()
+        try:
+            for i in range(lo, hi + 1):
+                cursor.set_key(ds.key(i))
+                if cursor.search() == 0:
+                    found += 1
+        finally:
+            self.session.commit_transaction()
+            cursor.close()
         return found
 
     # -------------------------------------------------------------------------
@@ -131,7 +138,7 @@ class test_prepare_fast_trunc_proxy(wttest.WiredTigerTestCase):
         uri = 'table:prepare_ft_proxy_case1'
         ds = self._setup_table(uri)
 
-        session2 = self.conn.open_session()
+        session2 = self.conn.open_session(self.session_config)
 
         # Count fast-deletes before truncation.
         before_trunc = self._fast_delete_count()
@@ -162,6 +169,10 @@ class test_prepare_fast_trunc_proxy(wttest.WiredTigerTestCase):
         found_after = self._count_visible_rows(uri, ds, hi + 1, self.nrows, 10)
         self.assertEqual(found_before, lo - 1)
         self.assertEqual(found_after, self.nrows - hi)
+        # The prepared truncation was never committed, so rows INSIDE the range
+        # must also be visible after recovery rolls it back.
+        found_inside = self._count_visible_rows(uri, ds, lo, hi, 10)
+        self.assertEqual(found_inside, hi - lo + 1)
 
     # -------------------------------------------------------------------------
     # Case 2: Fast-truncate prepared (ts=20) then committed with durable_ts=35 > stable_ts=25
@@ -175,7 +186,7 @@ class test_prepare_fast_trunc_proxy(wttest.WiredTigerTestCase):
         uri = 'table:prepare_ft_proxy_case2'
         ds = self._setup_table(uri)
 
-        session2 = self.conn.open_session()
+        session2 = self.conn.open_session(self.session_config)
 
         before_trunc = self._fast_delete_count()
 
@@ -184,13 +195,15 @@ class test_prepare_fast_trunc_proxy(wttest.WiredTigerTestCase):
         hi = 3 * self.nrows // 4
         self._fast_truncate(session2, uri, ds, lo, hi)
         session2.prepare_transaction('prepare_timestamp=' + self.timestamp_str(20))
-        # Commit at 30, durable at 35, both beyond stable_ts=25.
-        session2.commit_transaction(
-            'commit_timestamp=' + self.timestamp_str(30) +
-            ',durable_timestamp=' + self.timestamp_str(35))
 
         if not self.runningHook('tiered'):
             self.assertGreater(self._fast_delete_count(), before_trunc)
+
+        # Commit at 30, durable at 35. stable_ts is still 10 at commit time;
+        # it is advanced to 25 afterwards to set the checkpoint boundary.
+        session2.commit_transaction(
+            'commit_timestamp=' + self.timestamp_str(30) +
+            ',durable_timestamp=' + self.timestamp_str(35))
 
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(25))
         self.session.checkpoint()
@@ -202,6 +215,11 @@ class test_prepare_fast_trunc_proxy(wttest.WiredTigerTestCase):
         # beyond stable. The truncated rows should still be visible at ts=10.
         found = self._count_visible_rows(uri, ds, lo, hi, 10)
         self.assertEqual(found, hi - lo + 1)
+        # Rows outside the truncated range must also be accessible.
+        found_before = self._count_visible_rows(uri, ds, 1, lo - 1, 10)
+        found_after = self._count_visible_rows(uri, ds, hi + 1, self.nrows, 10)
+        self.assertEqual(found_before, lo - 1)
+        self.assertEqual(found_after, self.nrows - hi)
 
     # -------------------------------------------------------------------------
     # Case 3: Fast-truncate prepared (ts=20) then rolled back (rollback_ts=30 > stable_ts=25)
@@ -214,7 +232,7 @@ class test_prepare_fast_trunc_proxy(wttest.WiredTigerTestCase):
         uri = 'table:prepare_ft_proxy_case3'
         ds = self._setup_table(uri)
 
-        session2 = self.conn.open_session()
+        session2 = self.conn.open_session(self.session_config)
 
         before_trunc = self._fast_delete_count()
 
@@ -237,10 +255,11 @@ class test_prepare_fast_trunc_proxy(wttest.WiredTigerTestCase):
         # A prepared proxy cell should be written.
         self.session.checkpoint()
 
-        # Crash+restart. The rollback is in the log and replayed by recovery.
+        # Crash+restart. Recovery reads the checkpoint's prepared proxy cell
+        # and rolls back the orphaned prepared transaction.
         simulate_crash_restart(self, ".", "RESTART")
 
-        # After recovery the truncated pages should be accessible (rollback replayed).
+        # After recovery the truncated pages should be accessible.
         found = self._count_visible_rows(uri, ds, lo, hi, 10)
         self.assertEqual(found, hi - lo + 1)
 
@@ -257,7 +276,7 @@ class test_prepare_fast_trunc_proxy(wttest.WiredTigerTestCase):
         uri = 'table:prepare_ft_proxy_case4'
         ds = self._setup_table(uri)
 
-        session2 = self.conn.open_session()
+        session2 = self.conn.open_session(self.session_config)
 
         before_trunc = self._fast_delete_count()
 
@@ -291,6 +310,111 @@ class test_prepare_fast_trunc_proxy(wttest.WiredTigerTestCase):
 
         found = self._count_visible_rows(uri, ds, lo, hi, 10)
         self.assertEqual(found, hi - lo + 1)
+
+    # -------------------------------------------------------------------------
+    # Case 5: Like Case 4 but a checkpoint is taken WHILE the prepare is in
+    #         flight (before rollback), so the first checkpoint writes a
+    #         prepared proxy DEL cell.  After rollback and stable advancing past
+    #         rollback_ts a second checkpoint must revert that DEL cell to a
+    #         plain addr cell.
+    #
+    # Sequence:
+    #   prepare at ts=20, stable=25    Checkpoint 1 writes prepared proxy cell
+    #   rollback at ts=30              txnid=ABORTED, page_del preserved
+    #   stable advance to 35           rollback_ts (30) now stable
+    #   Checkpoint 2                   must revert DEL cell to plain addr cell
+    #   reopen                         truncated rows accessible at ts=10
+    # -------------------------------------------------------------------------
+    def test_case5_proxy_written_then_rollback_stable(self):
+        uri = 'table:prepare_ft_proxy_case5'
+        ds = self._setup_table(uri)
+
+        session2 = self.conn.open_session(self.session_config)
+
+        before_trunc = self._fast_delete_count()
+
+        session2.begin_transaction()
+        lo = self.nrows // 4 + 1
+        hi = 3 * self.nrows // 4
+        self._fast_truncate(session2, uri, ds, lo, hi)
+        # prepare_ts=20 will be stable when we set stable=25 below.
+        session2.prepare_transaction('prepare_timestamp=' + self.timestamp_str(20))
+
+        if not self.runningHook('tiered'):
+            self.assertGreater(self._fast_delete_count(), before_trunc)
+
+        # Advance stable past prepare_ts so the first checkpoint writes a
+        # prepared proxy DEL cell (prepare_ts=20 <= stable_ts=25).
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(25))
+        self.session.checkpoint()
+
+        # Roll back with rollback_ts=30 > stable_ts=25 (required by WiredTiger).
+        session2.rollback_transaction(
+            'rollback_timestamp=' + self.timestamp_str(30))
+
+        # Advance stable past rollback_ts: the rollback is now stable.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(35))
+
+        # Checkpoint 2: rollback_ts (30) <= stable_ts (35).  The reconciler
+        # must revert the on-page prepared proxy DEL cell to a plain addr cell
+        # rather than copying it verbatim or firing an assertion.
+        self.session.checkpoint()
+
+        # After reopen the truncated pages must be accessible.
+        self.reopen_conn()
+
+        found = self._count_visible_rows(uri, ds, lo, hi, 10)
+        self.assertEqual(found, hi - lo + 1)
+
+    # -------------------------------------------------------------------------
+    # Case 6: Fast-truncate prepared (ts=20) then committed with durable_ts=30,
+    #         stable advanced to 35 so durable_ts (30) <= stable_ts (35).
+    #
+    # The spec's commit path: "if durable_ts <= stable_ts: write as committed
+    # page del".  The checkpoint at stable_ts=35 must write a COMMITTED (not
+    # prepared) proxy cell.  After reopen the truncated rows must NOT be visible
+    # (the deletion is fully stable).
+    # -------------------------------------------------------------------------
+    def test_case6_commit_durable_within_stable(self):
+        uri = 'table:prepare_ft_proxy_case6'
+        ds = self._setup_table(uri)
+
+        session2 = self.conn.open_session(self.session_config)
+
+        before_trunc = self._fast_delete_count()
+
+        session2.begin_transaction()
+        lo = self.nrows // 4 + 1
+        hi = 3 * self.nrows // 4
+        self._fast_truncate(session2, uri, ds, lo, hi)
+        session2.prepare_transaction('prepare_timestamp=' + self.timestamp_str(20))
+
+        if not self.runningHook('tiered'):
+            self.assertGreater(self._fast_delete_count(), before_trunc)
+
+        # Commit at 25, durable at 30. stable_ts is still 10 at commit time.
+        session2.commit_transaction(
+            'commit_timestamp=' + self.timestamp_str(25) +
+            ',durable_timestamp=' + self.timestamp_str(30))
+
+        # Advance stable past durable_ts: the deletion is now fully stable.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(35))
+        self.session.checkpoint()
+
+        # After reopen, verify the committed deletion is stable.
+        self.reopen_conn()
+
+        # At commit_ts (25) the deletion is visible: rows must be gone.
+        found_deleted = self._count_visible_rows(uri, ds, lo, hi, 25)
+        self.assertEqual(found_deleted, 0)
+        # At ts=10 (before commit_ts) the rows were written and must still be visible.
+        found_historical = self._count_visible_rows(uri, ds, lo, hi, 10)
+        self.assertEqual(found_historical, hi - lo + 1)
+        # Rows outside the truncated range remain accessible at ts=10.
+        found_before = self._count_visible_rows(uri, ds, 1, lo - 1, 10)
+        found_after = self._count_visible_rows(uri, ds, hi + 1, self.nrows, 10)
+        self.assertEqual(found_before, lo - 1)
+        self.assertEqual(found_after, self.nrows - hi)
 
 if __name__ == '__main__':
     wttest.run()


### PR DESCRIPTION
This change implements the on-disk encoding of prepared fast-truncate (WT_PAGE_DELETED) records under precise checkpoint, replacing all FIXME-WT-17663 placeholders, and implementing the full selection policy for prepared, committed, and aborted fast-truncate records relative to rec_pinned_stable_ts.

`bt_delete.c`
In __wt_delete_page_rollback, prepared fast-truncates under precise checkpoint no longer immediately free page_del and transition to WT_REF_DISK. Instead, pg_del_rollback_ts is recorded, the original txnid is saved to pg_del_saved_txnid, and txnid is set to WT_TXN_ABORTED. The page_del structure is preserved so reconciliation can apply the correct proxy-cell selection logic. Non-prepared fast-truncates and prepared fast-truncates outside precise checkpoint continue to free page_del and transition to WT_REF_DISK as before.

`rec_child.c`
The selection policy is implemented in __rec_child_deleted:
Aborted prepared	(rollback_ts <= stable):	Free page_del, set WTI_CHILD_ORIGINAL + needs_disk_transition
Aborted prepared	(prepare_ts <= stable):	Write prepared proxy cell
Aborted prepared	(Neither threshold met):	Leave page dirty
Committed prepared	(durable_ts > stable and prepare_ts <= stable):	Write prepared proxy cell
Committed prepared	(durable_ts <= stable):	Write committed proxy cell
In-flight prepared	(prepare_ts <= stable):	Write prepared proxy cell

`rec_row.c` and `rec_col.c`
All FIXME-WT-17663 placeholders are replaced with cms.is_prepared_fast_truncate. Implement the scenario where needs_disk_transition is set and the on-page cell is WT_CELL_ADDR_DEL (a previously-written prepared proxy DEL cell that must be reverted to a plain addr cell). 

`cell_inline.h`
__wt_cell_pack_internal_key_addr now computes is_prepared_fast_truncate.

`test_prepare_fast_trunc_proxy.py`
Six test cases added covering the cases:
1	- In-flight prepared, prepare_ts ≤ stable:	Checkpoint succeeds; rows outside and inside range visible after crash-restart
2	- Committed, durable_ts > stable but prepare_ts ≤ stable:	Prepared proxy cell written; truncated rows still visible after crash-restart
3	- Rolled back, rollback_ts > stable but prepare_ts ≤ stable:	Prepared proxy cell written; truncated rows accessible after crash-restart
4	- Rolled back, rollback_ts ≤ stable:	No proxy cell written; truncated rows accessible after reopen
5	- Checkpoint written mid-prepare, then rollback becomes stable:	Second checkpoint reverts prepared proxy DEL cell to plain addr cell
6	- Committed, durable_ts ≤ stable:	Committed proxy cell written; deletion visible at commit_ts