### PR TITLE
WT-17692 Stop emitting empty load_crypt_key on every checkpoint

### DIFF
--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -1581,12 +1581,6 @@ __disagg_begin_checkpoint(WT_SESSION_IMPL *session)
     if (disagg->npage_log == NULL || !conn->layered_table_manager.leader)
         return (0);
 
-    /* On fresh startup, load an empty key to key provider. */
-    if (conn->key_provider != NULL) {
-        WT_DISAGG_METADATA metadata = {0};
-        WT_RET(__wti_disagg_load_crypt_key(session, &metadata));
-    }
-
     __wt_verbose_debug2(session, WT_VERB_DISAGGREGATED_STORAGE,
       "Begin next disaggregated storage checkpoint: num_meta_put=%" PRIu64, disagg->num_meta_put);
 
@@ -1912,9 +1906,17 @@ __wti_disagg_conn_config(WT_SESSION_IMPL *session, const char **cfg, bool reconf
 
                 __wt_buf_free(session, &complete_checkpoint_meta);
                 WT_ERR_MSG_CHK(session, ret, "Failed to pick up checkpoint metadata");
-            } else if (WT_CHECK_AND_RESET(ret, WT_NOTFOUND))
+            } else if (WT_CHECK_AND_RESET(ret, WT_NOTFOUND)) {
                 __wt_verbose_debug2(session, WT_VERB_DISAGGREGATED_STORAGE, "%s",
                   "Did not find any complete checkpoint to pick up at startup");
+                /* On fresh startup, load an empty key to key provider. */
+                if (conn->key_provider != NULL) {
+                    WT_DISAGG_METADATA empty_metadata = {0};
+                    WT_WITH_CHECKPOINT_LOCK(
+                      session, ret = __wti_disagg_load_crypt_key(session, &empty_metadata));
+                    WT_ERR_MSG_CHK(session, ret, "Failed to load empty crypt key at fresh startup");
+                }
+            }
             WT_WITH_CHECKPOINT_LOCK(session, ret = __disagg_begin_checkpoint(session));
             WT_ERR_MSG_CHK(session, ret, "Failed to begin a new checkpoint");
         }

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -1912,6 +1912,8 @@ __wti_disagg_conn_config(WT_SESSION_IMPL *session, const char **cfg, bool reconf
                 /* On fresh startup, load an empty key to key provider. */
                 if (conn->key_provider != NULL) {
                     WT_DISAGG_METADATA empty_metadata = {0};
+                    WT_ASSERT(session,
+                      conn->disaggregated_storage.last_checkpoint_meta_lsn == WT_DISAGG_LSN_NONE);
                     WT_WITH_CHECKPOINT_LOCK(
                       session, ret = __wti_disagg_load_crypt_key(session, &empty_metadata));
                     WT_ERR_MSG_CHK(session, ret, "Failed to load empty crypt key at fresh startup");

--- a/src/docs/arch-disagg-key-provider.dox
+++ b/src/docs/arch-disagg-key-provider.dox
@@ -23,8 +23,11 @@ When WiredTiger persists metadata, it prepends a WT_CRYPT_HEADER. The header con
 The API provides three functions: WT_KEY_PROVIDER::load_key(), WT_KEY_PROVIDER::get_key() and WT_KEY_PROVIDER::on_key_update().
 WiredTiger owns the memory for all metadata buffers.
 
-WiredTiger calls load_key() during startup and checkpoint. It reads the persisted metadata and provides it to the key provider.
-If no metadata exists, it passes an empty WT_CRYPT_KEYS::keys structure..
+WiredTiger calls load_key() at startup and on each checkpoint pickup. It reads the persisted metadata and provides it to the key provider.
+Followers receive load_key() with real metadata every time they pick up a new checkpoint, so they stay in sync with the leader's current key.
+If no metadata exists yet, WiredTiger passes an empty WT_CRYPT_KEYS::keys structure at most once per connection,
+at fresh leader startup, so the provider can choose an initial key before the first get_key().
+Repeating it after a key exists violates the contract — the empty form means no metadata is present.
 
 WiredTiger calls get_key() during a checkpoint to determine whether new metadata should be persisted.
 If WT_CRYPT_KEYS::keys::size is non zero, WiredTiger allocates a buffer and calls get_key() again so the key provider

--- a/test/suite/test_key_provider_disagg03.py
+++ b/test/suite/test_key_provider_disagg03.py
@@ -33,8 +33,11 @@ from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 
 # test_key_provider_disagg03.py
-#    Verify that key rotation across checkpoints is not disabled by the
-#    fresh-startup empty key-load. Regression test for WT-17692.
+#    Regression test for WT-17692. The bootstrap empty key-load was
+#    being emitted on every checkpoint, which kept resetting the key
+#    provider's rotation timer and prevented rotation from ever firing.
+#    This test runs many checkpoints past the provider's expiry
+#    threshold and asserts the persisted key page count grew.
 @disagg_test_class
 class test_key_provider_disagg03(wttest.WiredTigerTestCase):
     conn_base_config = ',create,statistics=(all),statistics_log=(wait=1,json=true,on_close=true),'

--- a/test/suite/test_key_provider_disagg03.py
+++ b/test/suite/test_key_provider_disagg03.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+import re, os, time, subprocess, json
+import wttest
+from run import wt_builddir
+from helper_disagg import DisaggConfigMixin, disagg_test_class, gen_disagg_storages, get_shard_id
+from wtdataset import SimpleDataSet
+from wtscenario import make_scenarios
+
+# test_key_provider_disagg03.py
+#    Verify that key rotation across checkpoints is not disabled by the
+#    fresh-startup empty key-load. Regression test for WT-17692.
+@disagg_test_class
+class test_key_provider_disagg03(wttest.WiredTigerTestCase):
+    conn_base_config = ',create,statistics=(all),statistics_log=(wait=1,json=true,on_close=true),'
+    def conn_config(self):
+        return self.extensionsConfig() + self.conn_base_config + 'disaggregated=(role="leader")'
+
+    disagg_storages = gen_disagg_storages('test_key_provider_disagg03', disagg_only = True)
+    scenarios = make_scenarios(disagg_storages)
+
+    nentries = 50000
+    uri = "layered:test_key_provider_disagg03"
+
+    WT_SPECIAL_PALI_TURTLE_FILE_ID = 2
+    WT_SPECIAL_PALI_KEY_PROVIDER_FILE_ID = 26
+    turtle_table = f'pages_{get_shard_id(WT_SPECIAL_PALI_TURTLE_FILE_ID):02d}.db'
+    key_provider_table = f'pages_{get_shard_id(WT_SPECIAL_PALI_KEY_PROVIDER_FILE_ID):02d}.db'
+
+    # Load the key provider with a one-second expiry so the second checkpoint
+    # in this test will trigger a rotation.
+    def conn_extensions(self, extlist):
+        config = f'=(early_load=true,config=\"verbose=-1,key_expires=1\")'
+        extlist.extension('test', "key_provider" + config)
+        DisaggConfigMixin.conn_extensions(self, extlist)
+
+    def fetch_key_provider_page_count(self, home="."):
+        sqlite_exe = os.path.join(wt_builddir, 'sqlite3')
+        database_home = os.path.join(home, 'kv_home', self.key_provider_table)
+        result = subprocess.run(
+            [sqlite_exe, '-json', database_home,
+             f'SELECT COUNT(*) AS c FROM pages WHERE table_id={self.WT_SPECIAL_PALI_KEY_PROVIDER_FILE_ID};'],
+            capture_output=True, text=True, check=True)
+        return int(json.loads(result.stdout)[0]['c'])
+
+    def test_key_rotation_across_checkpoints(self):
+        if (self.ds_name != "palite"):
+            self.skipTest("Must use PALite to verify contents")
+
+        # Populate the table and take a first checkpoint to persist an
+        # initial key.
+        ds = SimpleDataSet(self, self.uri, self.nentries)
+        ds.populate()
+        ds.check()
+
+        self.session.checkpoint()
+        count_first = self.fetch_key_provider_page_count()
+
+        cursor = self.session.open_cursor(self.uri, None)
+        for cycle in range(40):
+            for i in range(self.nentries):
+                cursor[f'cycle-{cycle:04d}-key-{i:08d}'] = f'value-{i:08d}'
+            self.session.checkpoint()
+        cursor.close()
+
+        count_second = self.fetch_key_provider_page_count()
+
+        self.assertGreater(count_second, count_first,
+            "Key rotation did not occur across checkpoints; "
+            "the empty key-load on every checkpoint is suppressing rotation.")


### PR DESCRIPTION
## Summary

Fixes WT-17692. `__disagg_begin_checkpoint` was emitting an empty `__wti_disagg_load_crypt_key` call on every checkpoint when `key_provider` was configured. The empty form was intended as a one-shot "no persisted key metadata yet" bootstrap signal, but firing it on every checkpoint repeatedly reset the provider's key-rotation clock, permanently disabling key rotation after the initial key was written.

## Changes

- **`src/conn/conn_layered.c`**: removed the per-checkpoint empty `load_crypt_key` from `__disagg_begin_checkpoint`. Moved the one-shot bootstrap into the `WT_NOTFOUND` branch of `__wti_disagg_conn_config` (fresh-leader-startup path). Step-up paths are covered by existing pick-up logic and by the production key provider's own bootstrap mechanism.
- **`src/docs/arch-disagg-key-provider.dox`**: clarified the `load_key()` contract — the empty form is emitted at most once per connection, at fresh leader startup; repeating it after a key exists violates the contract.
- **`test/suite/test_key_provider_disagg03.py`**: new regression test. Configures the test key provider with a short `key_expires`, runs many write+checkpoint cycles, and asserts the persisted key-provider page count grows (rotation occurred).
