### PR TITLE
WT-16780 More error logging in __checkpoint_tree (8.0)

### DIFF
--- a/src/include/error.h
+++ b/src/include/error.h
@@ -61,6 +61,12 @@
         } else if (!(keep))     \
             ret = 0;            \
     } while (0)
+#define WT_ERR_MSG_CHK(session, v, ...)            \
+    do {                                           \
+        ret = (v);                                 \
+        if (ret != 0)                              \
+            WT_ERR_MSG(session, ret, __VA_ARGS__); \
+    } while (0)
 #define WT_ERR_ERROR_OK(a, e, keep) WT_ERR_TEST((ret = (a)) != 0 && ret != (e), ret, keep)
 #define WT_ERR_NOTFOUND_OK(a, keep) WT_ERR_ERROR_OK(a, WT_NOTFOUND, keep)
 

--- a/src/txn/txn_ckpt.c
+++ b/src/txn/txn_ckpt.c
@@ -2406,7 +2406,8 @@ __checkpoint_tree(WT_SESSION_IMPL *session, bool is_checkpoint, const char *cfg[
      * this call. Also, marking the btree dirty at this stage will unnecessarily mark the connection
      * as dirty causing checkpoint-skip code to fail.
      */
-    WT_ERR(__wt_page_modify_init(session, btree->root.page));
+    WT_ERR_MSG_CHK(session, __wt_page_modify_init(session, btree->root.page),
+      "checkpoint failed during root page modify init");
     __wt_page_only_modify_set(session, btree->root.page);
 
     /*
@@ -2421,17 +2422,21 @@ __checkpoint_tree(WT_SESSION_IMPL *session, bool is_checkpoint, const char *cfg[
 
     /* Tell logging that a file checkpoint is starting. */
     if (FLD_ISSET(conn->log_flags, WT_CONN_LOG_ENABLED))
-        WT_ERR(__wt_txn_checkpoint_log(session, false, WT_TXN_LOG_CKPT_START, &ckptlsn));
+        WT_ERR_MSG_CHK(session,
+          __wt_txn_checkpoint_log(session, false, WT_TXN_LOG_CKPT_START, &ckptlsn),
+          "checkpoint failed during logging start");
 
     /* Tell the block manager that a file checkpoint is starting. */
-    WT_ERR(bm->checkpoint_start(bm, session));
+    WT_ERR_MSG_CHK(session, bm->checkpoint_start(bm, session),
+      "checkpoint failed to start in the block manager");
     resolve_bm = true;
 
     /* Flush the file from the cache, creating the checkpoint. */
     if (is_checkpoint) {
         if (WT_SESSION_IS_CHECKPOINT(session))
             WT_STAT_CONN_SET(session, checkpoint_state, WT_CHECKPOINT_STATE_SYNC_FILE);
-        WT_ERR(__wt_sync_file(session, WT_SYNC_CHECKPOINT));
+        WT_ERR_MSG_CHK(session, __wt_sync_file(session, WT_SYNC_CHECKPOINT),
+          "checkpoint failed during cache flush and reconciliation");
     } else {
         if (WT_SESSION_IS_CHECKPOINT(session))
             WT_STAT_CONN_SET(session, checkpoint_state, WT_CHECKPOINT_STATE_EVICT_FILE);
@@ -2459,9 +2464,11 @@ fake:
      * and open a checkpoint that isn't yet durable.
      */
     if (WT_IS_METADATA(dhandle) || !F_ISSET(session->txn, WT_TXN_RUNNING))
-        WT_ERR(__wt_checkpoint_sync(session, NULL));
+        WT_ERR_MSG_CHK(
+          session, __wt_checkpoint_sync(session, NULL), "checkpoint failed during file sync");
 
-    WT_ERR(__wt_meta_ckptlist_set(session, dhandle, btree->ckpt, &ckptlsn));
+    WT_ERR_MSG_CHK(session, __wt_meta_ckptlist_set(session, dhandle, btree->ckpt, &ckptlsn),
+      "checkpoint failed during metadata update");
 
     /*
      * If we wrote a checkpoint (rather than faking one), we have to resolve it. Normally, tracking
@@ -2474,19 +2481,30 @@ fake:
         if (WT_SESSION_IS_CHECKPOINT(session))
             WT_STAT_CONN_SET(session, checkpoint_state, WT_CHECKPOINT_STATE_RESOLVE);
         if (WT_META_TRACKING(session) && is_checkpoint)
-            WT_ERR(__wt_meta_track_checkpoint(session));
+            WT_ERR_MSG_CHK(session, __wt_meta_track_checkpoint(session),
+              "checkpoint failed during meta tracking");
         else
-            WT_ERR(bm->checkpoint_resolve(bm, session, false));
+            WT_ERR_MSG_CHK(session, bm->checkpoint_resolve(bm, session, false),
+              "checkpoint failed during block manager resolve");
     }
 
     /* Tell logging that the checkpoint is complete. */
     if (FLD_ISSET(conn->log_flags, WT_CONN_LOG_ENABLED))
-        WT_ERR(__wt_txn_checkpoint_log(session, false, WT_TXN_LOG_CKPT_STOP, NULL));
+        WT_ERR_MSG_CHK(session, __wt_txn_checkpoint_log(session, false, WT_TXN_LOG_CKPT_STOP, NULL),
+          "checkpoint failed during logging completion");
 
 err:
     /* Resolved the checkpoint for the block manager in the error path. */
-    if (resolve_bm)
+    if (resolve_bm) {
+        /*
+         * In case of a failure, log the original error before resolving the checkpoint, as the
+         * resolve may overwrite the current error code with a panic.
+         */
+        if (ret != 0)
+            __wt_verbose_error(session, WT_VERB_CHECKPOINT,
+              "checkpoint failed with error code %d before block manager checkpoint resolve", ret);
         WT_TRET(bm->checkpoint_resolve(bm, session, ret != 0));
+    }
 
     /*
      * If the checkpoint didn't complete successfully, make sure the tree is marked dirty.


### PR DESCRIPTION
Improve error logging in `__checkpoint_tree`.

Backport of [#13487](https://github.com/wiredtiger/wiredtiger/pull/13487) (develop) / [#13649](https://github.com/wiredtiger/wiredtiger/pull/13649) (8.3) to `mongodb-8.0`.

Adapted for 8.0: the `__wt_error_log_*` ring-buffer subsystem, the `WT_ERR_MSG_CHK` macro, the `src/checkpoint/checkpoint_txn.c` reorg, and the renamed log/stat APIs do not exist on 8.0. This change therefore:
- Introduces the self-contained `WT_ERR_MSG_CHK` macro (wraps `WT_ERR_MSG`; no dependency on the error-log subsystem).
- Converts the `__checkpoint_tree` error paths to `WT_ERR_MSG_CHK` with per-step messages, using 8.0's `__wt_txn_checkpoint_log` / `WT_CONN_LOG_ENABLED` / `WT_CHECKPOINT_STATE_*` names (the `__wt_lsn_string` step is not present on 8.0 and is omitted).
- Logs the original error code via `__wt_verbose_error` before the block manager resolve overwrites it with a panic (equivalent to the upstream `#else` / non-`HAVE_ERROR_LOG` branch).