### PR TITLE
WT-17380 Enable prepare for test/format disagg switch mode on mainline

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1727,12 +1727,12 @@ variables:
       - func: "format test script"
         vars:
           # FIXME-WT-17380: Enable prepare for switch mode once failures are resolved.
-          format_test_script_args: -t 180 -c ../../../test/format/CONFIG.disagg -- disagg.mode=switch ops.prepare=0 runs.timer=5:10
+          format_test_script_args: -t 180 -c ../../../test/format/CONFIG.disagg -- disagg.mode=switch runs.timer=5:10
           num_jobs: 1 # FIXME-WT-16134 PALite cannot run multiple jobs. PALI will address this.
       - func: "format test disagg"
         vars:
           # FIXME-WT-17380: Enable prepare for switch mode once failures are resolved.
-          format_args: disagg.mode=switch ops.prepare=0 runs.timer=5:10
+          format_args: disagg.mode=switch runs.timer=5:10
           times: 5
 
   # FIXME-WT-16113: Consolidate this logic in test/format itself.
@@ -1744,13 +1744,13 @@ variables:
       - func: "format test script"
         vars:
           # FIXME-WT-17380: Enable prepare for switch mode once failures are resolved.
-          format_test_script_args: -t 180 -c ../../../test/format/CONFIG.disagg -- disagg.mode=switch ops.prepare=0 ops.verify=1 runs.mirror=1 table1.runs.source=table table1.disagg.enabled=0 runs.timer=5:10
+          format_test_script_args: -t 180 -c ../../../test/format/CONFIG.disagg -- disagg.mode=switch ops.verify=1 runs.mirror=1 table1.runs.source=table table1.disagg.enabled=0 runs.timer=5:10
           num_jobs: 1 # FIXME-WT-16134 PALite cannot run multiple jobs. PALI will address this.
       - func: "format test disagg"
         vars:
           # Validate data with a non-layered table.
           # FIXME-WT-17380: Enable prepare for switch mode once failures are resolved.
-          format_args: disagg.mode=switch ops.prepare=0 ops.verify=1 runs.mirror=1 table1.runs.source=table table1.disagg.enabled=0 runs.timer=5:10
+          format_args: disagg.mode=switch ops.verify=1 runs.mirror=1 table1.runs.source=table table1.disagg.enabled=0 runs.timer=5:10
           times: 5
 
   - &format-stress-test-disagg-switch-pull-request
@@ -1762,11 +1762,11 @@ variables:
         vars:
           # run for 10 minutes.
           # FIXME-WT-17380: Enable prepare for switch mode once failures are resolved.
-          format_test_script_args: -c ../../../test/format/CONFIG.disagg -t 10 -- disagg.mode=switch ops.prepare=0 runs.rows=10000 runs.ops=50000
+          format_test_script_args: -c ../../../test/format/CONFIG.disagg -t 10 -- disagg.mode=switch runs.rows=10000 runs.ops=50000
       - func: "format test disagg"
         vars:
           # FIXME-WT-17380: Enable prepare for switch mode once failures are resolved.
-          format_args: disagg.mode=switch ops.prepare=0 runs.timer=3
+          format_args: disagg.mode=switch runs.timer=3
           times: 1
 
 #######################################
@@ -5308,12 +5308,12 @@ tasks:
           # Limit the number of operations to avoid an internal TSAN issue; run more operations with detect_deadlocks=0.
           # FIXME-WT-16313: Consider how to avoid the internal TSAN issue.
           # FIXME-WT-17380: Enable prepare for switch mode once failures are resolved.
-          format_args: disagg.mode=switch ops.prepare=0 runs.rows=1000:3000 runs.tables=1:3 runs.ops=3000
+          format_args: disagg.mode=switch runs.rows=1000:3000 runs.tables=1:3 runs.ops=3000
           times: 2
       - func: "format test disagg"
         vars:
           # FIXME-WT-17380: Enable prepare for switch mode once failures are resolved.
-          format_args: disagg.mode=switch ops.prepare=0 runs.rows=100000:300000 runs.tables=1:3 runs.ops=300000
+          format_args: disagg.mode=switch runs.rows=100000:300000 runs.tables=1:3 runs.ops=300000
           additional_san_vars: export TSAN_OPTIONS="$TSAN_OPTIONS:detect_deadlocks=0"
           times: 2
 

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1726,12 +1726,10 @@ variables:
       - func: "compile wiredtiger"
       - func: "format test script"
         vars:
-          # FIXME-WT-17380: Enable prepare for switch mode once failures are resolved.
           format_test_script_args: -t 180 -c ../../../test/format/CONFIG.disagg -- disagg.mode=switch runs.timer=5:10
           num_jobs: 1 # FIXME-WT-16134 PALite cannot run multiple jobs. PALI will address this.
       - func: "format test disagg"
         vars:
-          # FIXME-WT-17380: Enable prepare for switch mode once failures are resolved.
           format_args: disagg.mode=switch runs.timer=5:10
           times: 5
 
@@ -1743,13 +1741,11 @@ variables:
       - func: "compile wiredtiger"
       - func: "format test script"
         vars:
-          # FIXME-WT-17380: Enable prepare for switch mode once failures are resolved.
           format_test_script_args: -t 180 -c ../../../test/format/CONFIG.disagg -- disagg.mode=switch ops.verify=1 runs.mirror=1 table1.runs.source=table table1.disagg.enabled=0 runs.timer=5:10
           num_jobs: 1 # FIXME-WT-16134 PALite cannot run multiple jobs. PALI will address this.
       - func: "format test disagg"
         vars:
           # Validate data with a non-layered table.
-          # FIXME-WT-17380: Enable prepare for switch mode once failures are resolved.
           format_args: disagg.mode=switch ops.verify=1 runs.mirror=1 table1.runs.source=table table1.disagg.enabled=0 runs.timer=5:10
           times: 5
 
@@ -1761,11 +1757,9 @@ variables:
       - func: "format test script"
         vars:
           # run for 10 minutes.
-          # FIXME-WT-17380: Enable prepare for switch mode once failures are resolved.
           format_test_script_args: -c ../../../test/format/CONFIG.disagg -t 10 -- disagg.mode=switch runs.rows=10000 runs.ops=50000
       - func: "format test disagg"
         vars:
-          # FIXME-WT-17380: Enable prepare for switch mode once failures are resolved.
           format_args: disagg.mode=switch runs.timer=3
           times: 1
 
@@ -5307,12 +5301,10 @@ tasks:
         vars:
           # Limit the number of operations to avoid an internal TSAN issue; run more operations with detect_deadlocks=0.
           # FIXME-WT-16313: Consider how to avoid the internal TSAN issue.
-          # FIXME-WT-17380: Enable prepare for switch mode once failures are resolved.
           format_args: disagg.mode=switch runs.rows=1000:3000 runs.tables=1:3 runs.ops=3000
           times: 2
       - func: "format test disagg"
         vars:
-          # FIXME-WT-17380: Enable prepare for switch mode once failures are resolved.
           format_args: disagg.mode=switch runs.rows=100000:300000 runs.tables=1:3 runs.ops=300000
           additional_san_vars: export TSAN_OPTIONS="$TSAN_OPTIONS:detect_deadlocks=0"
           times: 2

--- a/test/evergreen_disagg.yml
+++ b/test/evergreen_disagg.yml
@@ -540,30 +540,6 @@ functions:
 #######################################
 
 variables:
-  - &format-stress-test-disagg-switch
-    depends_on:
-      - name: compile
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
-      - func: "format test disagg"
-        vars:
-          format_args: disagg.mode=switch runs.timer=10:15 ops.prepare=1
-          times: 5
-
-  # FIXME-WT-16113: Consolidate this logic in test/format itself.
-  - &format-stress-test-disagg-switch-data-validation
-    depends_on:
-      - name: compile
-    commands:
-      - func: "get project"
-      - func: "compile wiredtiger"
-      - func: "format test disagg"
-        vars:
-          # Validate data with a non-layered table.
-          format_args: disagg.mode=switch ops.verify=1 runs.mirror=1 table1.runs.source=table table1.disagg.enabled=0 runs.timer=5:10 ops.prepare=1
-          times: 5
-
   # Variant of format-stress-test-disagg-switch that exercises the default
   # fast-truncate code path.
   - &format-stress-test-disagg-switch-fast-truncate
@@ -666,25 +642,6 @@ tasks:
       - func: "upload artifact"
       - func: "cleanup"
 
-  # FIXME-WT-17380: Enable disagg switch mode (prepared-enabled) on all platforms once failures have been resolved.
-  - <<: *format-stress-test-disagg-switch
-    name: format-stress-test-disagg-switch-1
-    tags: ["stress-test-disagg-fail", "stress-test-disagg-san-fail"]
-  - <<: *format-stress-test-disagg-switch
-    name: format-stress-test-disagg-switch-2
-    tags: ["stress-test-disagg-fail"]
-  - <<: *format-stress-test-disagg-switch
-    name: format-stress-test-disagg-switch-3
-    tags: ["stress-test-disagg-fail"]
-  - <<: *format-stress-test-disagg-switch-data-validation
-    name: format-stress-test-disagg-switch-data-validation-1
-    tags: ["stress-test-disagg-fail"]
-  - <<: *format-stress-test-disagg-switch-data-validation
-    name: format-stress-test-disagg-switch-data-validation-2
-    tags: ["stress-test-disagg-fail"]
-  - <<: *format-stress-test-disagg-switch-data-validation
-    name: format-stress-test-disagg-switch-data-validation-3
-    tags: ["stress-test-disagg-fail"]
   - <<: *format-stress-test-disagg-switch-fast-truncate
     name: format-stress-test-disagg-switch-fast-truncate-1
     tags: ["stress-test-disagg-fail", "stress-test-disagg-san-fail"]


### PR DESCRIPTION
All the prerequisite issues related to the switch have been resolved. We can now enable it on the mainline. Please refer to the patch linked in the ticket for details.
