### PR TITLE
WT-17699 Fix cache fill ratio statistic stuck in the < 25% bucket

### DIFF
--- a/src/evict/evict_thread.c
+++ b/src/evict/evict_thread.c
@@ -544,7 +544,7 @@ __evict_update_work(WT_SESSION_IMPL *session, bool *eviction_needed)
      * If application threads are blocked by data in cache, track the fill ratio.
      *
      */
-    uint64_t cache_fill_ratio = bytes_inuse / bytes_max;
+    double cache_fill_ratio = (double)bytes_inuse / (double)bytes_max;
     bool evict_is_hard = LF_ISSET(WT_EVICT_CACHE_HARD);
     if (evict_is_hard) {
         if (cache_fill_ratio < 0.25)

--- a/src/evict/evict_thread.c
+++ b/src/evict/evict_thread.c
@@ -541,8 +541,9 @@ __evict_update_work(WT_SESSION_IMPL *session, bool *eviction_needed)
     }
 
     /*
-     * If application threads are blocked by data in cache, track the fill ratio.
-     *
+     * If application threads are blocked by data in cache, track the fill ratio. Compute the ratio
+     * in floating point: integer division of the byte counts truncates to zero below a full cache
+     * and collapses every request into the lowest bucket.
      */
     double cache_fill_ratio = (double)bytes_inuse / (double)bytes_max;
     bool evict_is_hard = LF_ISSET(WT_EVICT_CACHE_HARD);

--- a/test/suite/test_stat12.py
+++ b/test/suite/test_stat12.py
@@ -127,3 +127,47 @@ class test_stat12(wttest.WiredTigerTestCase):
         # can be reached at once, while fill ratio stats are only incremented once if any application thread evicts a page
         self.assertGreaterEqual(eviction_trigger_count, fill_ratio_count, "Fill ratio stats should not exceed eviction trigger stats.")
 
+# Verify the fill ratio is bucketed by its actual value, not collapsed into the lowest
+# bucket. With every trigger placed above 50% of the cache, no hard-eviction request can
+# occur below 50% fill, so only the upper buckets may increment.
+class test_stat12_fill_ratio_bucketing(wttest.WiredTigerTestCase):
+    uri = 'table:test_stat12_bucketing'
+    create_params = 'key_format=i,value_format=S'
+
+    def conn_config(self):
+        return 'cache_size=1MB,statistics=(all),eviction=(threads_max=1),' \
+            'eviction_trigger=95,eviction_target=80,' \
+            'eviction_dirty_trigger=80,eviction_dirty_target=75,' \
+            'eviction_updates_trigger=60,eviction_updates_target=30'
+
+    def test_fill_ratio_buckets(self):
+        self.session.create(self.uri, self.create_params)
+
+        c = self.session.open_cursor(self.uri)
+        for i in range(5000):
+            c[i] = 'x' * 2000
+        c.close()
+        self.session.checkpoint()
+        for i in range(2000):
+            c = self.session.open_cursor(self.uri)
+            c[i] = 'y' * 1000
+            c.close()
+
+        for _ in range(20):
+            stat_cursor = self.session.open_cursor('statistics:', None, None)
+            lt_25 = stat_cursor[wiredtiger.stat.conn.cache_eviction_app_threads_fill_ratio_lt_25][2]
+            r_25_50 = stat_cursor[wiredtiger.stat.conn.cache_eviction_app_threads_fill_ratio_25_50][2]
+            r_50_75 = stat_cursor[wiredtiger.stat.conn.cache_eviction_app_threads_fill_ratio_50_75][2]
+            gt_75 = stat_cursor[wiredtiger.stat.conn.cache_eviction_app_threads_fill_ratio_gt_75][2]
+            stat_cursor.close()
+            if r_50_75 + gt_75 != 0:
+                break
+            time.sleep(1)
+
+        # A hard-eviction request was recorded in an upper bucket: the ratio is computed in
+        # floating point. Integer division would truncate every ratio below 100% to 0 and
+        # dump every request into the lt_25 bucket.
+        self.assertGreater(r_50_75 + gt_75, 0, "Expected fill ratio above 50% to be bucketed.")
+        self.assertEqual(lt_25, 0, "No hard-eviction request can occur below the configured triggers.")
+        self.assertEqual(r_25_50, 0, "No hard-eviction request can occur below the configured triggers.")
+


### PR DESCRIPTION
## Summary
The bucketed "application threads eviction requested with cache fill ratio" statistic computed its ratio with integer division of two unsigned values, which truncates to zero for any cache fill below 100%. Every hard-eviction request therefore landed in the lowest bucket and the other three buckets never populated, leaving the breakdown useless in the common case. Computing the ratio in floating point restores meaningful bucketing.

## Testing
Added a regression test in `test/suite/test_stat12.py` that places all eviction triggers above 50% of the cache, so a correct build records only the upper fill-ratio buckets while integer division would force every request into the lowest bucket. Confirmed the test fails on the unfixed code and passes with the fix; the full Catch2 suite also passes.