### PR TITLE
WT-17571 Add named test suites with multi-pass hook orchestration

### DIFF
--- a/test/evergreen/code_coverage/code_coverage_config.json
+++ b/test/evergreen/code_coverage/code_coverage_config.json
@@ -248,8 +248,8 @@
     "./wt -?",
     "test/csuite/wt4117_checksum/test_wt4117_checksum",
     "python3 ../test/suite/run.py test_live_restore01",
-    "python3 ../test/suite/run.py test_key_provider_disagg01.py",
-    "python3 ../test/suite/run.py test_key_provider_disagg02.py",
+    "python3 ../test/suite/run.py test_disagg_key_provider01.py",
+    "python3 ../test/suite/run.py test_disagg_key_provider02.py",
     "python3 ../test/suite/run.py --hook disagg --skip-tests-in-file ../test/suite/fail_lists/hook_disagg.fail base"
   ]
 }

--- a/test/suite/README
+++ b/test/suite/README
@@ -11,3 +11,29 @@ is required when new tests is introduced into test/suite. (WT-4441)
 
 Before the above mentioned mechanism is put into place, please double check
 test/evergreen.yml and test run logs to make sure new test are covered.
+
+Named suites (from the CMake build directory):
+  python3 ../test/suite/run.py disagg     # multi-pass: native disagg files +
+                                          # hook passes (leader/follower x
+                                          # layered/table_prefix). Fail-fast.
+  python3 ../test/suite/run.py tiered     # native test_tiered* + --hook tiered pass
+  python3 ../test/suite/run.py classic    # everything that isn't disagg or tiered
+
+A named suite with implied hooks runs as several sequential subprocesses:
+pass 1 is the native test files with no hook; each subsequent pass enables
+one hook entry from the suite (a follower pass may be scoped to a single
+test, matching CI). The runner aborts at the first failing pass. The user's
+-j N is forwarded to each subprocess so internal parallelism is preserved.
+
+To bypass multi-pass and run a single hook config of your choice, pass
+--hook explicitly:
+  python3 ../test/suite/run.py --hook "disagg=(role=follower)" base01
+
+For every enabled hook, if a co-named skip list exists at
+test/suite/fail_lists/hook_<name>.fail it is automatically applied. Any
+--skip-tests-in-file is appended on top.
+
+Named suites are defined by the NAMED_SUITES table in test/suite/run.py.
+Each entry either lists 'prefixes' (test files starting with these prefixes
+belong to the suite) or 'exclude_suites' (the suite is the complement of
+the listed suites' prefixes).

--- a/test/suite/README
+++ b/test/suite/README
@@ -11,13 +11,3 @@ is required when new tests is introduced into test/suite. (WT-4441)
 
 Before the above mentioned mechanism is put into place, please double check
 test/evergreen.yml and test run logs to make sure new test are covered.
-
-Named suites (run from the CMake build directory):
-  python3 ../test/suite/run.py disagg
-  python3 ../test/suite/run.py tiered
-  python3 ../test/suite/run.py classic
-  python3 ../test/suite/run.py -j 8 disagg                          # parallel
-  python3 ../test/suite/run.py -n disagg                            # dry-run
-  python3 ../test/suite/run.py --hook "disagg=(role=follower)" base01
-
-Suites are defined in test/suite/named_suites.py.

--- a/test/suite/README
+++ b/test/suite/README
@@ -12,28 +12,12 @@ is required when new tests is introduced into test/suite. (WT-4441)
 Before the above mentioned mechanism is put into place, please double check
 test/evergreen.yml and test run logs to make sure new test are covered.
 
-Named suites (from the CMake build directory):
-  python3 ../test/suite/run.py disagg     # multi-pass: native disagg files +
-                                          # hook passes (leader/follower x
-                                          # layered/table_prefix). Fail-fast.
-  python3 ../test/suite/run.py tiered     # native test_tiered* + --hook tiered pass
-  python3 ../test/suite/run.py classic    # everything that isn't disagg or tiered
-
-A named suite with implied hooks runs as several sequential subprocesses:
-pass 1 is the native test files with no hook; each subsequent pass enables
-one hook entry from the suite (a follower pass may be scoped to a single
-test, matching CI). The runner aborts at the first failing pass. The user's
--j N is forwarded to each subprocess so internal parallelism is preserved.
-
-To bypass multi-pass and run a single hook config of your choice, pass
---hook explicitly:
+Named suites (run from the CMake build directory):
+  python3 ../test/suite/run.py disagg
+  python3 ../test/suite/run.py tiered
+  python3 ../test/suite/run.py classic
+  python3 ../test/suite/run.py -j 8 disagg                          # parallel
+  python3 ../test/suite/run.py -n disagg                            # dry-run
   python3 ../test/suite/run.py --hook "disagg=(role=follower)" base01
 
-For every enabled hook, if a co-named skip list exists at
-test/suite/fail_lists/hook_<name>.fail it is automatically applied. Any
---skip-tests-in-file is appended on top.
-
-Named suites are defined by the NAMED_SUITES table in test/suite/run.py.
-Each entry either lists 'prefixes' (test files starting with these prefixes
-belong to the suite) or 'exclude_suites' (the suite is the complement of
-the listed suites' prefixes).
+Suites are defined in test/suite/named_suites.py.

--- a/test/suite/fail_lists/asan.fail
+++ b/test/suite/fail_lists/asan.fail
@@ -10,4 +10,4 @@ test_salvage03.py
 test_tiered06.py
 test_txn18.py
 test_txn19.py
-test_verify_disagg.py
+test_disagg_verify.py

--- a/test/suite/named_suites.py
+++ b/test/suite/named_suites.py
@@ -39,8 +39,11 @@
 To add a suite, add an entry to NAMED_SUITES with:
   'prefixes':       tuple of test_*.py prefixes the suite covers, OR
   'exclude_suites': tuple of other suite names this suite is the complement of
-  'hooks':          tuple of additional passes (string spec or
-                    {'hook': spec, 'tests': (testargs,)})
+  'hooks':          extra hook configurations to test. For each entry,
+                    run.py is re-launched with --hook applied. An entry is:
+                      a hook spec string                run over every test
+                      {'hook': spec, 'tests': (...)}    run only over the
+                                                        listed tests
 """
 
 import glob
@@ -56,6 +59,7 @@ NAMED_SUITES = {
         'hooks': (
             'disagg=(role=leader)',
             'disagg=(role=leader,table_prefix=table)',
+            # Follower-role passes are pinned to base01 only, matching CI.
             {'hook': 'disagg=(role=follower)',                    'tests': ('base01',)},
             {'hook': 'disagg=(role=follower,table_prefix=table)', 'tests': ('base01',)},
         ),

--- a/test/suite/named_suites.py
+++ b/test/suite/named_suites.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# [TEST_TAGS]
+# ignored_file
+# [END_TAGS]
+
+"""Named test suites for run.py. Usage:
+
+    python3 ../test/suite/run.py disagg     # multi-pass: see 'disagg' below
+    python3 ../test/suite/run.py tiered
+    python3 ../test/suite/run.py classic
+
+To add a suite, add an entry to NAMED_SUITES with:
+  'prefixes':       tuple of test_*.py prefixes the suite covers, OR
+  'exclude_suites': tuple of other suite names this suite is the complement of
+  'hooks':          tuple of additional passes (string spec or
+                    {'hook': spec, 'tests': (testargs,)})
+"""
+
+import glob
+import os
+import subprocess
+import sys
+
+SUITE_DIR = os.path.dirname(os.path.abspath(__file__))
+
+NAMED_SUITES = {
+    'disagg': {
+        'prefixes': ('test_layered', 'test_disagg'),
+        'hooks': (
+            'disagg=(role=leader)',
+            'disagg=(role=leader,table_prefix=table)',
+            {'hook': 'disagg=(role=follower)',                    'tests': ('base01',)},
+            {'hook': 'disagg=(role=follower,table_prefix=table)', 'tests': ('base01',)},
+        ),
+    },
+    'tiered': {
+        'prefixes': ('test_tiered',),
+        'hooks':    ('tiered',),
+    },
+    'classic': {
+        'exclude_suites': ('disagg', 'tiered'),
+        'hooks':          (),
+    },
+}
+
+
+def _all_test_files():
+    """All test_*.py filenames (basenames) under test/suite."""
+    return [os.path.basename(p)
+            for p in glob.glob(os.path.join(SUITE_DIR, 'test_*.py'))]
+
+
+def test_files_for_suite(name):
+    """Return the list of test_*.py filenames that belong to the named
+    suite, or None if `name` isn't a registered suite."""
+    entry = NAMED_SUITES.get(name)
+    if entry is None:
+        return None
+    all_files = _all_test_files()
+
+    # 'prefixes' suite: keep files whose name starts with any of the
+    # listed prefixes.
+    if 'prefixes' in entry:
+        suite_prefixes = entry['prefixes']
+        return [f for f in all_files if f.startswith(suite_prefixes)]
+
+    # 'exclude_suites' suite: this suite is the complement of one or more
+    # other suites. Collect every prefix from those other suites, then
+    # keep test files that DON'T start with any of them.
+    #
+    # Example: classic's exclude_suites = ('disagg', 'tiered'). We gather
+    # disagg's prefixes ('test_layered', 'test_disagg') and tiered's
+    # ('test_tiered',) into one list, then return every test_*.py that
+    # doesn't start with any of those.
+    excluded_prefixes = []
+    for other_suite_name in entry['exclude_suites']:
+        excluded_prefixes.extend(NAMED_SUITES[other_suite_name]['prefixes'])
+    excluded_prefixes = tuple(excluded_prefixes)
+    return [f for f in all_files if not f.startswith(excluded_prefixes)]
+
+
+def hook_passes_for_suite(name):
+    """Return the list of subprocess passes that the suite's 'hooks' tuple
+    implies. Each pass is a (hook_spec, tests) tuple where:
+        hook_spec  is the --hook argument string for that pass
+        tests      is None (= run all tests via discovery), or a tuple of
+                   testargs to pin the pass to specific tests."""
+    entry = NAMED_SUITES.get(name) or {}
+    passes = []
+    for hook in entry.get('hooks', ()):
+        if isinstance(hook, str):
+            # Plain string: run all tests under this hook.
+            passes.append((hook, None))
+        else:
+            # Dict form: pin this pass to the listed tests.
+            passes.append((hook['hook'], tuple(hook['tests'])))
+    return passes
+
+
+def fail_list_paths_for_hooks(hook_names):
+    """For each enabled hook, look for a sibling skip list at
+    fail_lists/hook_<name>.fail (e.g. 'disagg=(role=leader)' looks for
+    fail_lists/hook_disagg.fail). Return the paths that exist."""
+    existing_paths = []
+    for hook_spec in hook_names:
+        bare_name = hook_spec.split('=', 1)[0]
+        candidate = os.path.join(SUITE_DIR, 'fail_lists',
+                                 f'hook_{bare_name}.fail')
+        if os.path.isfile(candidate):
+            existing_paths.append(candidate)
+    return existing_paths
+
+
+def run_multi_pass_suite(suite_name, forwarded_argv, script_path):
+    """Run the suite as a sequence of run.py subprocess invocations:
+        pass 1   = the suite's native files, no hook
+        pass 2.. = one per entry in the suite's 'hooks' tuple
+    forwarded_argv is the user's other run.py flags (-j, -v, ...) which
+    are passed unchanged to every subprocess. Fail-fast: stops at the
+    first non-zero exit and returns it; returns 0 if every pass succeeds."""
+
+    # Build the list of passes. Each is (label, hook-or-None, tests-or-None):
+    #   label = short string for the progress banner
+    #   hook  = --hook spec to add (None for the native pass)
+    #   tests = list of test args to add (None means let run.py discover)
+    passes = []
+    native_files = test_files_for_suite(suite_name) or []
+    if native_files:
+        passes.append(('native', None, native_files))
+    for hook_spec, pinned_tests in hook_passes_for_suite(suite_name):
+        tests = list(pinned_tests) if pinned_tests else None
+        passes.append((f'hook {hook_spec}', hook_spec, tests))
+
+    # Run each pass as a fresh run.py invocation.
+    base_cmd = [sys.executable, script_path, *forwarded_argv]
+    for i, (label, hook, tests) in enumerate(passes, start=1):
+        cmd = list(base_cmd)
+        if hook is not None:
+            cmd += ['--hook', hook]
+        if tests is not None:
+            cmd += tests
+        test_count = len(tests) if tests else 'discovery'
+        header = f'>>> [{suite_name} pass {i}/{len(passes)}] {label}'
+        print(f'{header} ({test_count} tests)', flush=True)
+        rc = subprocess.call(cmd)
+        if rc != 0:
+            print(f'{header} FAILED exit={rc}', flush=True)
+            return rc
+    return 0
+
+
+def is_multi_pass_invocation(testargs, hook_names):
+    """True iff the run.py invocation should hand off to multi-pass
+    execution rather than running normally. Triggers when the user named a
+    suite that has 'hooks' and did not supply their own --hook."""
+    if hook_names:
+        # User picked a specific hook config; honor it, don't multi-pass.
+        return False
+    return any(a in NAMED_SUITES and NAMED_SUITES[a].get('hooks')
+               for a in testargs)
+
+
+def dispatch_multi_pass(testargs, argv):
+    """Run the multi-pass suite found in testargs. Returns the exit code
+    of the first failing pass, or 0 if all passes succeed. Caller should
+    sys.exit with the returned value.
+
+    Errors out via sys.exit if testargs contains more than one named suite
+    that implies hooks."""
+    multi_pass_suites = [a for a in testargs
+                         if a in NAMED_SUITES
+                         and NAMED_SUITES[a].get('hooks')]
+    if len(multi_pass_suites) > 1:
+        sys.exit('cannot combine multiple named suites that imply hooks: '
+                 + ', '.join(multi_pass_suites))
+    suite = multi_pass_suites[0]
+    # Re-build the child argv by stripping the suite name; everything else
+    # (including -j, -v, --timeout, ...) is forwarded as-is.
+    forwarded = [a for a in argv[1:] if a != suite]
+    return run_multi_pass_suite(suite, forwarded, argv[0])

--- a/test/suite/named_suites.py
+++ b/test/suite/named_suites.py
@@ -59,7 +59,7 @@ NAMED_SUITES = {
         'hooks': (
             'disagg=(role=leader)',
             'disagg=(role=leader,table_prefix=table)',
-            # Follower-role passes are pinned to base01 only, matching CI.
+            # Follower-role passes are pinned to base01 only.
             {'hook': 'disagg=(role=follower)',                    'tests': ('base01',)},
             {'hook': 'disagg=(role=follower,table_prefix=table)', 'tests': ('base01',)},
         ),

--- a/test/suite/named_suites.py
+++ b/test/suite/named_suites.py
@@ -70,12 +70,10 @@ NAMED_SUITES = {
     },
 }
 
-
 def _all_test_files():
     """All test_*.py filenames (basenames) under test/suite."""
     return [os.path.basename(p)
             for p in glob.glob(os.path.join(SUITE_DIR, 'test_*.py'))]
-
 
 def test_files_for_suite(name):
     """Return the list of test_*.py filenames that belong to the named
@@ -94,17 +92,23 @@ def test_files_for_suite(name):
     # 'exclude_suites' suite: this suite is the complement of one or more
     # other suites. Collect every prefix from those other suites, then
     # keep test files that DON'T start with any of them.
-    #
-    # Example: classic's exclude_suites = ('disagg', 'tiered'). We gather
-    # disagg's prefixes ('test_layered', 'test_disagg') and tiered's
-    # ('test_tiered',) into one list, then return every test_*.py that
-    # doesn't start with any of those.
     excluded_prefixes = []
     for other_suite_name in entry['exclude_suites']:
         excluded_prefixes.extend(NAMED_SUITES[other_suite_name]['prefixes'])
     excluded_prefixes = tuple(excluded_prefixes)
     return [f for f in all_files if not f.startswith(excluded_prefixes)]
 
+def fail_list_paths_for_hooks(hook_names):
+    """For each active hook, look for a sibling skip list at
+    fail_lists/hook_<bare_hook_name>.fail. Return the paths that exist."""
+    existing_paths = []
+    for hook_spec in hook_names:
+        bare_name = hook_spec.split('=', 1)[0]
+        candidate = os.path.join(SUITE_DIR, 'fail_lists',
+                                 f'hook_{bare_name}.fail')
+        if os.path.isfile(candidate):
+            existing_paths.append(candidate)
+    return existing_paths
 
 def hook_passes_for_suite(name):
     """Return the list of subprocess passes that the suite's 'hooks' tuple
@@ -122,21 +126,6 @@ def hook_passes_for_suite(name):
             # Dict form: pin this pass to the listed tests.
             passes.append((hook['hook'], tuple(hook['tests'])))
     return passes
-
-
-def fail_list_paths_for_hooks(hook_names):
-    """For each enabled hook, look for a sibling skip list at
-    fail_lists/hook_<name>.fail (e.g. 'disagg=(role=leader)' looks for
-    fail_lists/hook_disagg.fail). Return the paths that exist."""
-    existing_paths = []
-    for hook_spec in hook_names:
-        bare_name = hook_spec.split('=', 1)[0]
-        candidate = os.path.join(SUITE_DIR, 'fail_lists',
-                                 f'hook_{bare_name}.fail')
-        if os.path.isfile(candidate):
-            existing_paths.append(candidate)
-    return existing_paths
-
 
 def run_multi_pass_suite(suite_name, forwarded_argv, script_path):
     """Run the suite as a sequence of run.py subprocess invocations:
@@ -175,7 +164,6 @@ def run_multi_pass_suite(suite_name, forwarded_argv, script_path):
             return rc
     return 0
 
-
 def is_multi_pass_invocation(testargs, hook_names):
     """True iff the run.py invocation should hand off to multi-pass
     execution rather than running normally. Triggers when the user named a
@@ -185,7 +173,6 @@ def is_multi_pass_invocation(testargs, hook_names):
         return False
     return any(a in NAMED_SUITES and NAMED_SUITES[a].get('hooks')
                for a in testargs)
-
 
 def dispatch_multi_pass(testargs, argv):
     """Run the multi-pass suite found in testargs. Returns the exit code

--- a/test/suite/named_suites.py
+++ b/test/suite/named_suites.py
@@ -188,7 +188,7 @@ def dispatch_multi_pass(testargs, argv):
         sys.exit('cannot combine multiple named suites that imply hooks: '
                  + ', '.join(multi_pass_suites))
     suite = multi_pass_suites[0]
-    # Re-build the child argv by stripping the suite name; everything else
-    # (including -j, -v, --timeout, ...) is forwarded as-is.
+    # Re-build the child argv by stripping the suite name; every other
+    # flag the user passed is forwarded as-is.
     forwarded = [a for a in argv[1:] if a != suite]
     return run_multi_pass_suite(suite, forwarded, argv[0])

--- a/test/suite/run.py
+++ b/test/suite/run.py
@@ -139,6 +139,24 @@ reCatname = re.compile(r"test_([^0-9]+)[0-9]*")
 from named_suites import (dispatch_multi_pass, fail_list_paths_for_hooks,
                           is_multi_pass_invocation, test_files_for_suite)
 
+def _read_skip_file(path):
+    """Read a skip-list file and return the test names listed in it
+    (comment lines, trailing comments, and the .py extension stripped)."""
+    with open(path, 'r') as f:
+        lines = f.read().splitlines()
+    lines = [l for l in lines if not l.lstrip().startswith('#')]
+    return [re.split(r'\s+#', l)[0].strip().replace('.py', '') for l in lines]
+
+def collect_skip_tests(hook_names, user_skip_file):
+    """Merged list of test names to skip: auto skip lists for any active
+    hooks plus the user's --skip-tests-in-file."""
+    skip_tests = []
+    for path in fail_list_paths_for_hooks(hook_names):
+        skip_tests.extend(_read_skip_file(path))
+    if user_skip_file:
+        skip_tests.extend(_read_skip_file(user_skip_file))
+    return skip_tests
+
 # Look for a list of the form 0-9,11,15-17.
 def parse_int_list(str):
     # Use a dictionary as the result set to avoid repeated list scans.
@@ -617,10 +635,10 @@ if __name__ == '__main__':
     tests = unittest.TestSuite()
     from testscenarios.scenarios import generate_scenarios
 
-    # A named suite like 'disagg' wants to run with several hook configs
-    # (leader, follower, table_prefix variants). Each needs its own Python
-    # process because a hook can only be installed once per process. Hand
-    # off to the multi-pass orchestrator in that case.
+    # A named suite that implies multiple hook configurations cannot run
+    # in this single process because a hook is installed once per process.
+    # Hand off to the multi-pass orchestrator, which launches one child
+    # per configuration.
     if is_multi_pass_invocation(testargs, hook_names):
         sys.exit(dispatch_multi_pass(testargs, sys.argv))
 
@@ -636,21 +654,7 @@ if __name__ == '__main__':
                                           extralongtest, zstdtest, ignoreStdout, printOutput,
                                           seedw, seedz, hookmgr, ss_random_prefix, timeout)
 
-    def _load_skip_file(path):
-        with open(path, 'r') as f:
-            lines = f.read().splitlines()
-        # Drop comment lines, trailing comments, and the .py extension.
-        lines = [l for l in lines if not l.lstrip().startswith('#')]
-        return [re.split(r'\s+#', l)[0].strip().replace('.py', '') for l in lines]
-
-    skipTests = []
-    # For every enabled hook, auto-skip its co-named fail list if present
-    # (e.g. --hook disagg pairs with fail_lists/hook_disagg.fail). Catches
-    # both direct --hook usage and named-suite-implied hooks.
-    for path in fail_list_paths_for_hooks(hook_names):
-        skipTests.extend(_load_skip_file(path))
-    if skipFileForTests:
-        skipTests.extend(_load_skip_file(skipFileForTests))
+    skipTests = collect_skip_tests(hook_names, skipFileForTests)
 
     # Without any tests listed as arguments, do discovery
     if len(testargs) == 0:
@@ -735,11 +739,8 @@ if __name__ == '__main__':
         # Break it into just our batch.
         tests = unittest.TestSuite(all_tests[batchnum::batchtotal])
     if dryRun:
-        try:
-            for line in tests:
-                print(line)
-        except BrokenPipeError:
-            pass
+        for line in tests:
+            print(line)
     else:
         result = wttest.runsuite(tests, parallel)
         sys.exit(0 if result.wasSuccessful() else 1)

--- a/test/suite/run.py
+++ b/test/suite/run.py
@@ -99,6 +99,8 @@ Variables, via name=value, default listed in brackets:\n\
 Tests:\n\
   may be a file name in test/suite: (e.g. test_base01.py)\n\
   may be a subsuite name (e.g. \'base\' runs test_base*.py)\n\
+  may be a named suite from NAMED_SUITES (e.g. \'disagg\', \'tiered\', \'classic\');\n\
+    a named suite may also imply hooks (e.g. \'disagg\' enables --hook disagg)\n\
 \n\
   When -C or -c are present, there may not be any tests named.\n\
   When -s is present, there must be a test named.\n\
@@ -133,6 +135,9 @@ def show_env(verbose, envvar):
 # capture the category (AKA 'subsuite') part of a test name,
 # e.g. test_util03 -> util
 reCatname = re.compile(r"test_([^0-9]+)[0-9]*")
+
+from named_suites import (dispatch_multi_pass, fail_list_paths_for_hooks,
+                          is_multi_pass_invocation, test_files_for_suite)
 
 # Look for a list of the form 0-9,11,15-17.
 def parse_int_list(str):
@@ -296,6 +301,13 @@ def configApply(suites, configfilename, configwrite):
     return newsuite
 
 def testsFromArg(tests, loader, arg, scenario, skipTests):
+    # Named suites expand to a list of test files (see named_suites.py).
+    named = test_files_for_suite(arg)
+    if named is not None:
+        for name in named:
+            testsFromArg(tests, loader, name, scenario, skipTests)
+        return
+
     # If a group of test is mentioned, do all tests in that group
     # e.g. 'run.py base'
     groupedfiles = glob.glob(suitedir + os.sep + 'test_' + arg + '*.py')
@@ -605,6 +617,13 @@ if __name__ == '__main__':
     tests = unittest.TestSuite()
     from testscenarios.scenarios import generate_scenarios
 
+    # A named suite like 'disagg' wants to run with several hook configs
+    # (leader, follower, table_prefix variants). Each needs its own Python
+    # process because a hook can only be installed once per process. Hand
+    # off to the multi-pass orchestrator in that case.
+    if is_multi_pass_invocation(testargs, hook_names):
+        sys.exit(dispatch_multi_pass(testargs, sys.argv))
+
     import wthooks
     hookmgr = wthooks.WiredTigerHookManager(hook_names)
 
@@ -617,15 +636,21 @@ if __name__ == '__main__':
                                           extralongtest, zstdtest, ignoreStdout, printOutput,
                                           seedw, seedz, hookmgr, ss_random_prefix, timeout)
 
+    def _load_skip_file(path):
+        with open(path, 'r') as f:
+            lines = f.read().splitlines()
+        # Drop comment lines, trailing comments, and the .py extension.
+        lines = [l for l in lines if not l.lstrip().startswith('#')]
+        return [re.split(r'\s+#', l)[0].strip().replace('.py', '') for l in lines]
+
     skipTests = []
+    # For every enabled hook, auto-skip its co-named fail list if present
+    # (e.g. --hook disagg pairs with fail_lists/hook_disagg.fail). Catches
+    # both direct --hook usage and named-suite-implied hooks.
+    for path in fail_list_paths_for_hooks(hook_names):
+        skipTests.extend(_load_skip_file(path))
     if skipFileForTests:
-        with open(skipFileForTests, 'r') as f:
-            # Read the skip file and process it to get a list of tests to skip.
-            skipTests = f.read().splitlines()
-            # Remove comment lines starting with '#'.
-            skipTests = [test for test in skipTests if not test.lstrip().startswith('#')]
-            # Remove trailing comments and file extensions for each line.
-            skipTests = [re.split(r'\s+#', test)[0].strip().replace('.py', '') for test in skipTests]
+        skipTests.extend(_load_skip_file(skipFileForTests))
 
     # Without any tests listed as arguments, do discovery
     if len(testargs) == 0:
@@ -710,8 +735,11 @@ if __name__ == '__main__':
         # Break it into just our batch.
         tests = unittest.TestSuite(all_tests[batchnum::batchtotal])
     if dryRun:
-        for line in tests:
-            print(line)
+        try:
+            for line in tests:
+                print(line)
+        except BrokenPipeError:
+            pass
     else:
         result = wttest.runsuite(tests, parallel)
         sys.exit(0 if result.wasSuccessful() else 1)

--- a/test/suite/run.py
+++ b/test/suite/run.py
@@ -637,7 +637,7 @@ if __name__ == '__main__':
 
     # A named suite that implies multiple hook configurations cannot run
     # in this single process because a hook is installed once per process.
-    # Hand off to the multi-pass orchestrator, which launches one child
+    # Hand off to the multi-pass dispatcher, which launches one child
     # per configuration.
     if is_multi_pass_invocation(testargs, hook_names):
         sys.exit(dispatch_multi_pass(testargs, sys.argv))

--- a/test/suite/test_disagg_key_provider01.py
+++ b/test/suite/test_disagg_key_provider01.py
@@ -33,10 +33,10 @@ from wtdataset import SimpleDataSet
 
 from wtscenario import make_scenarios
 
-# test_key_provider_disagg01.py
+# test_disagg_key_provider01.py
 #    Test basic key provider scenarios.
 @disagg_test_class
-class test_key_provider_disagg01(wttest.WiredTigerTestCase):
+class test_disagg_key_provider01(wttest.WiredTigerTestCase):
     conn_base_config = ',create,statistics=(all),statistics_log=(wait=1,json=true,on_close=true),'
     def conn_config(self):
         return self.extensionsConfig() + self.conn_base_config + 'disaggregated=(role="leader")'
@@ -46,7 +46,7 @@ class test_key_provider_disagg01(wttest.WiredTigerTestCase):
         ('crash', dict(crash=True)),
     ]
 
-    disagg_storages = gen_disagg_storages('test_key_provider_disagg01', disagg_only = True)
+    disagg_storages = gen_disagg_storages('test_disagg_key_provider01', disagg_only = True)
     scenarios = make_scenarios(disagg_storages, crash_value)
 
     nentries = 1000
@@ -61,7 +61,7 @@ class test_key_provider_disagg01(wttest.WiredTigerTestCase):
     turtle_table = f'pages_{get_shard_id(WT_SPECIAL_PALI_TURTLE_FILE_ID):02d}.db'
     key_provider_table = f'pages_{get_shard_id(WT_SPECIAL_PALI_KEY_PROVIDER_FILE_ID):02d}.db'
 
-    uri = "layered:test_key_provider_disagg01"
+    uri = "layered:test_disagg_key_provider01"
 
     # Load the key provider store extension.
     def conn_extensions(self, extlist):
@@ -116,7 +116,7 @@ class test_key_provider_disagg01(wttest.WiredTigerTestCase):
             self.assertEqual(page_id, self.MAIN_KEK_PAGE_ID)
             self.assertEqual(version, self.EXPECTED_KEK_VERSION)
 
-    def test_key_provider_disagg01(self):
+    def test_disagg_key_provider01(self):
         if (self.ds_name != "palite"):
             self.skipTest("Must use PALite to verify contents")
 

--- a/test/suite/test_disagg_key_provider02.py
+++ b/test/suite/test_disagg_key_provider02.py
@@ -33,15 +33,15 @@ from suite_subprocess import suite_subprocess
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
 
-# test_key_provider_disagg02.py
+# test_disagg_key_provider02.py
 #    Ensure that a crash during checkpoint will not corrupt key provider meta information.
 @disagg_test_class
-class test_key_provider_disagg02(wttest.WiredTigerTestCase, suite_subprocess):
+class test_disagg_key_provider02(wttest.WiredTigerTestCase, suite_subprocess):
     conn_base_config = ',create,statistics=(all),statistics_log=(wait=1,json=true,on_close=true),'
     def conn_config(self):
         return self.extensionsConfig() + self.conn_base_config + 'disaggregated=(role="leader")'
 
-    disagg_storages = gen_disagg_storages('test_key_provider_disagg02', disagg_only = True)
+    disagg_storages = gen_disagg_storages('test_disagg_key_provider02', disagg_only = True)
 
     crash_points = [
         ('crash_before_key_rotation', dict(crash_point="before_key_rotation")),
@@ -51,7 +51,7 @@ class test_key_provider_disagg02(wttest.WiredTigerTestCase, suite_subprocess):
 
     scenarios = make_scenarios(disagg_storages, crash_points)
     nentries = 1000
-    uri = "layered:test_key_provider_disagg02"
+    uri = "layered:test_disagg_key_provider02"
 
     WT_SPECIAL_PALI_TURTLE_FILE_ID = 2
     turtle_table = f'pages_{get_shard_id(WT_SPECIAL_PALI_TURTLE_FILE_ID):02d}.db'
@@ -119,7 +119,7 @@ class test_key_provider_disagg02(wttest.WiredTigerTestCase, suite_subprocess):
                 f.write(result_data['page_data'])
         return result_data['page_data']
 
-    def test_key_provider_disagg02(self):
+    def test_disagg_key_provider02(self):
         if (self.ds_name != "palite"):
             self.skipTest("Must use PALite to verify contents")
 
@@ -128,7 +128,7 @@ class test_key_provider_disagg02(wttest.WiredTigerTestCase, suite_subprocess):
         # Ensure that metadata file doesn't update key provider after crash.
         subdir = 'SUBPROCESS'
         [ignore_result, new_home_dir] = self.run_subprocess_function(subdir,
-            'test_key_provider_disagg02.test_key_provider_disagg02.subprocess_func', silent=True)
+            'test_disagg_key_provider02.test_disagg_key_provider02.subprocess_func', silent=True)
 
         self.dir = new_home_dir
         self.validate_persist_meta_file()

--- a/test/suite/test_disagg_leaf_delta01.py
+++ b/test/suite/test_disagg_leaf_delta01.py
@@ -32,12 +32,12 @@ from wtscenario import make_scenarios
 from wiredtiger import stat
 import wiredtiger
 
-# test_leaf_delta_disagg01.py
+# test_disagg_leaf_delta01.py
 # Test we can build leaf delta disk image from base image and deltas correctly, the test covers
 # different scenarios, where the k/v pair on latest delta should overwrite the same k/v pair for
 # earlier delta, the unpacking during merging process for delta and base image should work properly.
 @disagg_test_class
-class test_leaf_delta_disagg01(wttest.WiredTigerTestCase):
+class test_disagg_leaf_delta01(wttest.WiredTigerTestCase):
     prefix_compression = [
         ('enabled', dict(prefix_config='prefix_compression=true', prefix_enabled=True)),
         ('disabled', dict(prefix_config='prefix_compression=false', prefix_enabled=False)),
@@ -47,7 +47,7 @@ class test_leaf_delta_disagg01(wttest.WiredTigerTestCase):
     conn_delta_config = 'disaggregated=(role="leader"),page_delta=(internal_page_delta=true,leaf_page_delta=true),'
     disagg_storages = gen_disagg_storages('test_layered_delta09', disagg_only = True)
 
-    uri='layered:test_leaf_delta_disagg01'
+    uri='layered:test_disagg_leaf_delta01'
     init_key = "abc"
 
     scenarios = make_scenarios(disagg_storages, prefix_compression)

--- a/test/suite/test_disagg_verify.py
+++ b/test/suite/test_disagg_verify.py
@@ -30,16 +30,16 @@ import errno, os, wiredtiger, wttest
 from helper_disagg import disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 
-# test_verify_disagg.py
+# test_disagg_verify.py
 #    SESSION::verify() testing for disagg storage
 
 @disagg_test_class
-class test_verify_disagg(wttest.WiredTigerTestCase):
+class test_disagg_verify(wttest.WiredTigerTestCase):
     hs = [
         ('empty', dict(fill_hs=False)),
         ('populated', dict(fill_hs=True)),
     ]
-    disagg_storages = gen_disagg_storages('test_verify_disagg', disagg_only = True)
+    disagg_storages = gen_disagg_storages('test_disagg_verify', disagg_only = True)
     scenarios = make_scenarios(hs, disagg_storages)
 
     nitems = 10000
@@ -54,7 +54,7 @@ class test_verify_disagg(wttest.WiredTigerTestCase):
     session_follow = None
     conn_follow = None
 
-    uri = 'layered:test_verify_disagg'
+    uri = 'layered:test_disagg_verify'
 
     def leader_put_data(self, value_prefix = '', low = 1, high = nitems):
         cursor = self.session.open_cursor(self.uri, None, None)
@@ -81,7 +81,7 @@ class test_verify_disagg(wttest.WiredTigerTestCase):
         self.session_follow = self.conn_follow.open_session('')
 
 
-    def test_verify_disagg(self):
+    def test_disagg_verify(self):
         if self.fill_hs:
             self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(self.timestamp))
 

--- a/test/suite/test_disagg_verify02.py
+++ b/test/suite/test_disagg_verify02.py
@@ -30,19 +30,19 @@ import re, wiredtiger, wttest
 from helper_disagg import disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 
-# test_verify_disagg02.py
+# test_disagg_verify02.py
 #    Verify that duplicate btree IDs among stable files are detected.
 
 @disagg_test_class
-class test_verify_disagg02(wttest.WiredTigerTestCase):
-    disagg_storages = gen_disagg_storages('test_verify_disagg02', disagg_only=True)
+class test_disagg_verify02(wttest.WiredTigerTestCase):
+    disagg_storages = gen_disagg_storages('test_disagg_verify02', disagg_only=True)
     scenarios = make_scenarios(disagg_storages)
 
     conn_config = 'disaggregated=(role="leader")'
     conn_config_follower = 'disaggregated=(role="follower")'
 
     table_cfg = 'key_format=S,value_format=S,block_manager=disagg'
-    uri = 'layered:test_verify_disagg02'
+    uri = 'layered:test_disagg_verify02'
 
     def test_verify_duplicate_btree_ids(self):
         """
@@ -65,7 +65,7 @@ class test_verify_disagg02(wttest.WiredTigerTestCase):
 
         # Read the stable file's config from the follower's metadata to get its btree ID.
         md_cursor = session_follow.open_cursor('metadata:', None, None)
-        md_cursor.set_key('file:test_verify_disagg02.wt_stable')
+        md_cursor.set_key('file:test_disagg_verify02.wt_stable')
         self.assertEqual(md_cursor.search(), 0)
         victim_config = md_cursor.get_value()
         md_cursor.close()

--- a/test/suite/test_disagg_verify03.py
+++ b/test/suite/test_disagg_verify03.py
@@ -30,18 +30,18 @@ import wttest
 from helper_disagg import disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 
-# test_verify_disagg03.py
+# test_disagg_verify03.py
 #    Opening a disaggregated follower with verify_metadata=true must succeed when
 #    the database contains keys whose deletion was committed at a later timestamp
 #    than an earlier write.
 
 @disagg_test_class
-class test_verify_disagg03(wttest.WiredTigerTestCase):
-    disagg_storages = gen_disagg_storages('test_verify_disagg03', disagg_only=True)
+class test_disagg_verify03(wttest.WiredTigerTestCase):
+    disagg_storages = gen_disagg_storages('test_disagg_verify03', disagg_only=True)
     scenarios = make_scenarios(disagg_storages)
 
     conn_config = 'disaggregated=(role="leader")'
-    uri = 'layered:test_verify_disagg03'
+    uri = 'layered:test_disagg_verify03'
     table_cfg = 'key_format=S,value_format=S,block_manager=disagg'
     nitems = 100
 

--- a/test/suite/test_layered_schema03.py
+++ b/test/suite/test_layered_schema03.py
@@ -44,7 +44,7 @@ class test_layered_schema03(wttest.WiredTigerTestCase):
         ('table-prefix', dict(prefix='table:', table_config=',block_manager=disagg,type=layered')),
     ]
 
-    disagg_storages = gen_disagg_storages('test_key_provider_disagg02', disagg_only = True)
+    disagg_storages = gen_disagg_storages('test_layered_schema03', disagg_only = True)
     scenarios = make_scenarios(table_types, disagg_storages)
     def check_metadata_entry(self):
         meta_cursor = self.session.open_cursor('metadata:')


### PR DESCRIPTION
## Summary
- Introduces `test/suite/named_suites.py` with a `NAMED_SUITES` table so a user can run e.g. `run.py disagg` to exercise the full disagg test surface in one command.
- `disagg` dispatches to five sequential `run.py` subprocesses (native files + leader, leader+table_prefix, follower base01, follower+table_prefix base01) matching the existing CI invocations. Each pass is its own process because a hook can only be installed once per Python process.
- Adds `tiered` (native + hook pass) and `classic` (everything not disagg or tiered, no hook).
- For every active hook, `fail_lists/hook_<name>.fail` is auto-loaded as a skip list — applies to direct `--hook` invocations too, not just named suites.
- Renames lookalike test files so the prefix-based suite definition covers them without extra entries: `test_verify_disagg*` → `test_disagg_verify*`, `test_leaf_delta_disagg01` → `test_disagg_leaf_delta01`, `test_key_provider_disagg*` → `test_disagg_key_provider*`.
- A user-supplied `--hook` bypasses multi-pass and runs as a single pass with their config.
