### PR TITLE
WT-17711 Fix RESERVE update skipped before prepared_id check in prepare rollback path

### DIFF
--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -1290,7 +1290,8 @@ __rec_fill_tw_from_upd_select(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_U
                 next_txnid = __wt_atomic_load_uint64_v_acquire(&upd->next->txnid);
                 if (next_txnid != WT_TXN_ABORTED) {
                     write_start_prepare &= next_txnid == tombstone_txnid;
-                    WT_ASSERT(session, write_start_prepare || next_txnid != tombstone_txnid);
+                    WT_ASSERT(session,
+                      !write_prepare || write_start_prepare || next_txnid != tombstone_txnid);
                     break;
                 }
                 if (!write_prepare)

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -1289,9 +1289,10 @@ __rec_fill_tw_from_upd_select(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_U
             for (; upd->next != NULL; upd = upd->next) {
                 next_txnid = __wt_atomic_load_uint64_v_acquire(&upd->next->txnid);
                 if (next_txnid != WT_TXN_ABORTED) {
-                    write_start_prepare &= next_txnid == tombstone_txnid;
-                    WT_ASSERT(session,
-                      !write_prepare || write_start_prepare || next_txnid != tombstone_txnid);
+                    if (write_start_prepare)
+                        write_start_prepare = next_txnid == tombstone_txnid;
+                    else
+                        WT_ASSERT(session, !write_prepare || next_txnid != tombstone_txnid);
                     break;
                 }
                 if (!write_prepare)

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -1289,13 +1289,18 @@ __rec_fill_tw_from_upd_select(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_U
             for (; upd->next != NULL; upd = upd->next) {
                 next_txnid = __wt_atomic_load_uint64_v_acquire(&upd->next->txnid);
                 if (next_txnid != WT_TXN_ABORTED) {
-                    write_start_prepare = write_prepare && next_txnid == tombstone_txnid;
+                    write_start_prepare &= next_txnid == tombstone_txnid;
+                    WT_ASSERT(session, write_start_prepare || next_txnid != tombstone_txnid);
                     break;
                 }
                 if (!write_prepare)
                     continue;
 
                 if (!F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED))
+                    continue;
+
+                /* We may see aborted reserve updates in between the prepared updates. */
+                if (upd->next->type == WT_UPDATE_RESERVE)
                     continue;
 
                 if (upd->next->prepared_id == WT_PREPARED_ID_NONE) {
@@ -1307,16 +1312,13 @@ __rec_fill_tw_from_upd_select(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_U
                   upd->next->prepare_state == WT_PREPARE_LOCKED ||
                     upd->next->prepare_state == WT_PREPARE_INPROGRESS);
 
-                /* We may see aborted reserve updates in between the prepared updates. */
-                if (upd->next->type == WT_UPDATE_RESERVE)
-                    continue;
-
                 /*
                  * Since we resolve prepared update from the oldest to newest, we may see a
                  * tombstone still in prepared state but a prepared update that is rolled back from
                  * the same transaction here. Handle this case.
                  */
                 if (upd->next->upd_saved_txnid == tombstone_txnid) {
+                    WT_ASSERT(session, write_start_prepare);
                     WT_ASSERT(session, upd->next->prepare_ts == tombstone->prepare_ts);
                     break;
                 } else

--- a/test/suite/test_prepare49.py
+++ b/test/suite/test_prepare49.py
@@ -32,25 +32,24 @@
 
 import wttest
 
-
 class test_prepare49(wttest.WiredTigerTestCase):
 
     conn_config = 'precise_checkpoint=true,preserve_prepared=true'
     uri = 'table:test_prepare49'
 
     def _force_evict(self, key, read_ts):
-        sess = self.conn.open_session()
+        session = self.conn.open_session()
         try:
-            cur = sess.open_cursor(self.uri, None, 'debug=(release_evict)')
-            sess.begin_transaction(
+            cursor = session.open_cursor(self.uri, None, 'debug=(release_evict)')
+            session.begin_transaction(
                 'ignore_prepare=true,read_timestamp=' + self.timestamp_str(read_ts))
-            cur.set_key(key)
-            self.assertEqual(cur.search(), 0)
-            cur.reset()
-            cur.close()
-            sess.rollback_transaction()
+            cursor.set_key(key)
+            self.assertEqual(cursor.search(), 0)
+            cursor.reset()
+            cursor.close()
+            session.rollback_transaction()
         finally:
-            sess.close()
+            session.close()
 
     def test_evict_after_rollback_with_reserve_between_prepared_ops(self):
         self.session.create(self.uri, 'key_format=i,value_format=S')
@@ -68,15 +67,15 @@ class test_prepare49(wttest.WiredTigerTestCase):
         # Prepare a transaction that updates, reserves, then deletes the same
         # key.  The reservation is between the update and the delete, placing
         # all three operations under the same prepared transaction.
-        sess_a = self.conn.open_session()
-        cur_a = sess_a.open_cursor(self.uri)
-        sess_a.begin_transaction()
-        cur_a[1] = 'updated'
-        cur_a.set_key(1)
-        cur_a.reserve()
-        cur_a.set_key(1)
-        cur_a.remove()
-        sess_a.prepare_transaction(
+        session_a = self.conn.open_session()
+        cursor_a = session_a.open_cursor(self.uri)
+        session_a.begin_transaction()
+        cursor_a[1] = 'updated'
+        cursor_a.set_key(1)
+        cursor_a.reserve()
+        cursor_a.set_key(1)
+        cursor_a.remove()
+        session_a.prepare_transaction(
             'prepare_timestamp=' + self.timestamp_str(10) +
             ',prepared_id=' + self.prepared_id_str(1))
 
@@ -85,10 +84,10 @@ class test_prepare49(wttest.WiredTigerTestCase):
         # is still ahead of stable so the rolled-back prepared cell is retained
         # on disk for recovery purposes.
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(15))
-        sess_a.rollback_transaction(
+        session_a.rollback_transaction(
             'rollback_timestamp=' + self.timestamp_str(20))
-        cur_a.close()
-        sess_a.close()
+        cursor_a.close()
+        session_a.close()
 
         # Eviction must complete without crashing.  Reading at the base
         # timestamp to make the key visible for the eviction trigger.

--- a/test/suite/test_prepare49.py
+++ b/test/suite/test_prepare49.py
@@ -62,20 +62,17 @@ class test_prepare49(wttest.WiredTigerTestCase):
         cursor[1] = 'base'
         self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(5))
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(5))
-        cursor.close()
 
         # Prepare a transaction that updates, reserves, then deletes the same
         # key.  The reservation is between the update and the delete, placing
         # all three operations under the same prepared transaction.
-        session_a = self.conn.open_session()
-        cursor_a = session_a.open_cursor(self.uri)
-        session_a.begin_transaction()
-        cursor_a[1] = 'updated'
-        cursor_a.set_key(1)
-        cursor_a.reserve()
-        cursor_a.set_key(1)
-        cursor_a.remove()
-        session_a.prepare_transaction(
+        self.session.begin_transaction()
+        cursor[1] = 'updated'
+        cursor.set_key(1)
+        cursor.reserve()
+        cursor.set_key(1)
+        cursor.remove()
+        self.session.prepare_transaction(
             'prepare_timestamp=' + self.timestamp_str(10) +
             ',prepared_id=' + self.prepared_id_str(1))
 
@@ -84,10 +81,9 @@ class test_prepare49(wttest.WiredTigerTestCase):
         # is still ahead of stable so the rolled-back prepared cell is retained
         # on disk for recovery purposes.
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(15))
-        session_a.rollback_transaction(
+        self.session.rollback_transaction(
             'rollback_timestamp=' + self.timestamp_str(20))
-        cursor_a.close()
-        session_a.close()
+        cursor.close()
 
         # Eviction must complete without crashing.  Reading at the base
         # timestamp to make the key visible for the eviction trigger.

--- a/test/suite/test_prepare49.py
+++ b/test/suite/test_prepare49.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# test_prepare49.py
+#   Evicting a page after rolling back a prepared transaction that reserved
+#   and then deleted a key must succeed when preserve_prepared is configured.
+
+import wttest
+
+
+class test_prepare49(wttest.WiredTigerTestCase):
+
+    conn_config = 'precise_checkpoint=true,preserve_prepared=true'
+    uri = 'table:test_prepare49'
+
+    def _force_evict(self, key, read_ts):
+        sess = self.conn.open_session()
+        try:
+            cur = sess.open_cursor(self.uri, None, 'debug=(release_evict)')
+            sess.begin_transaction(
+                'ignore_prepare=true,read_timestamp=' + self.timestamp_str(read_ts))
+            cur.set_key(key)
+            self.assertEqual(cur.search(), 0)
+            cur.reset()
+            cur.close()
+            sess.rollback_transaction()
+        finally:
+            sess.close()
+
+    def test_evict_after_rollback_with_reserve_between_prepared_ops(self):
+        self.session.create(self.uri, 'key_format=i,value_format=S')
+
+        # Commit a stable base value for the key.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(4) +
+                                ',oldest_timestamp=' + self.timestamp_str(4))
+        cursor = self.session.open_cursor(self.uri)
+        self.session.begin_transaction()
+        cursor[1] = 'base'
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(5))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(5))
+        cursor.close()
+
+        # Prepare a transaction that updates, reserves, then deletes the same
+        # key.  The reservation is between the update and the delete, placing
+        # all three operations under the same prepared transaction.
+        sess_a = self.conn.open_session()
+        cur_a = sess_a.open_cursor(self.uri)
+        sess_a.begin_transaction()
+        cur_a[1] = 'updated'
+        cur_a.set_key(1)
+        cur_a.reserve()
+        cur_a.set_key(1)
+        cur_a.remove()
+        sess_a.prepare_transaction(
+            'prepare_timestamp=' + self.timestamp_str(10) +
+            ',prepared_id=' + self.prepared_id_str(1))
+
+        # Advance stable past the prepare timestamp so eviction considers the
+        # prepared cell stable, then roll back with a rollback timestamp that
+        # is still ahead of stable so the rolled-back prepared cell is retained
+        # on disk for recovery purposes.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(15))
+        sess_a.rollback_transaction(
+            'rollback_timestamp=' + self.timestamp_str(20))
+        cur_a.close()
+        sess_a.close()
+
+        # Eviction must complete without crashing.  Reading at the base
+        # timestamp to make the key visible for the eviction trigger.
+        self._force_evict(1, 5)


### PR DESCRIPTION
## Summary

- When a prepared transaction performs update → reserve → remove on the same key, the RESERVE update is abandoned at prepare time but remains on the update chain between the prepared tombstone and the prepared standard update.
- During eviction with `preserve_prepared` enabled, the loop that walks the update chain checked `prepared_id==0` before `type==RESERVE`, so the RESERVE incorrectly set `write_start_prepare=false`. The loop then found the matching prepared standard update from the same transaction and broke out, but `write_start_prepare` was still false, firing the Case-3 assertion.
- Fix moves the RESERVE type check before the `prepared_id==0` check so the RESERVE is skipped without modifying `write_start_prepare`. Two assertions are added to strengthen the invariant at each break point in the loop.