### PR TITLE
WT-17715 Fix ingest btree reconciliation assert on non-prunable fallback update

### DIFF
--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -1143,12 +1143,13 @@ __rec_upd_select_inmem(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_CELL_UNPAC
              * appear globally visible before the ingest btree's prune threshold has advanced. Such
              * updates are instead handled by the pruning check above.
              */
-            if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT) && upd->type == WT_UPDATE_TOMBSTONE) {
-                WT_ASSERT(session, upd->upd_durable_ts == WT_TS_NONE);
-                found_last_upd_to_keep = true;
-                break;
-            } else if (!F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT) &&
-              __wt_txn_upd_visible_all(session, upd)) {
+            if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT)) {
+                if (upd->type == WT_UPDATE_TOMBSTONE) {
+                    WT_ASSERT(session, upd->upd_durable_ts == WT_TS_NONE);
+                    found_last_upd_to_keep = true;
+                    break;
+                }
+            } else if (__wt_txn_upd_visible_all(session, upd)) {
                 found_last_upd_to_keep = true;
                 break;
             }

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -1145,7 +1145,8 @@ __rec_upd_select_inmem(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_CELL_UNPAC
              */
             if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT)) {
                 if (upd->type == WT_UPDATE_TOMBSTONE) {
-                    WT_ASSERT(session, __wt_txn_upd_visible_all(session, upd));
+                    /* FIXME-WT-17674: narrow the assertion to check for global visibility. */
+                    WT_ASSERT(session, upd->upd_durable_ts == WT_TS_NONE);
                     found_last_upd_to_keep = true;
                     break;
                 }

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -1136,11 +1136,18 @@ __rec_upd_select_inmem(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_CELL_UNPAC
             upd_select->was_modify = upd->type == WT_UPDATE_MODIFY;
 
             /*
-             * For ingest btrees, skip the global visibility check for non-timestamped tombstones as
-             * they will not be globally visible until they can be pruned.
+             * Tombstones on ingest btrees must be non-timestamped; treat them as the last update to
+             * keep. For other update types on ingest btrees, skip the global visibility check: the
+             * global visibility check can return true even when no checkpoint has been picked up
+             * (e.g. because WT_CONN_CLOSING bypasses the pinned-timestamp cap), making updates
+             * appear globally visible before the ingest btree's prune threshold has advanced. Such
+             * updates are instead handled by the pruning check above.
              */
-            if ((!F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT) || upd->type != WT_UPDATE_TOMBSTONE ||
-                  upd->upd_durable_ts == WT_TS_NONE) &&
+            if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT) && upd->type == WT_UPDATE_TOMBSTONE) {
+                WT_ASSERT(session, upd->upd_durable_ts == WT_TS_NONE);
+                found_last_upd_to_keep = true;
+                break;
+            } else if (!F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT) &&
               __wt_txn_upd_visible_all(session, upd)) {
                 found_last_upd_to_keep = true;
                 break;
@@ -1303,20 +1310,13 @@ __rec_fill_tw_from_upd_select(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_U
             for (; upd->next != NULL; upd = upd->next) {
                 next_txnid = __wt_atomic_load_uint64_v_acquire(&upd->next->txnid);
                 if (next_txnid != WT_TXN_ABORTED) {
-                    if (write_start_prepare)
-                        write_start_prepare = next_txnid == tombstone_txnid;
-                    else
-                        WT_ASSERT(session, !write_prepare || next_txnid != tombstone_txnid);
+                    write_start_prepare = write_prepare && next_txnid == tombstone_txnid;
                     break;
                 }
                 if (!write_prepare)
                     continue;
 
                 if (!F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED))
-                    continue;
-
-                /* We may see aborted reserve updates in between the prepared updates. */
-                if (upd->next->type == WT_UPDATE_RESERVE)
                     continue;
 
                 if (upd->next->prepared_id == WT_PREPARED_ID_NONE) {
@@ -1328,13 +1328,16 @@ __rec_fill_tw_from_upd_select(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_U
                   upd->next->prepare_state == WT_PREPARE_LOCKED ||
                     upd->next->prepare_state == WT_PREPARE_INPROGRESS);
 
+                /* We may see aborted reserve updates in between the prepared updates. */
+                if (upd->next->type == WT_UPDATE_RESERVE)
+                    continue;
+
                 /*
                  * Since we resolve prepared update from the oldest to newest, we may see a
                  * tombstone still in prepared state but a prepared update that is rolled back from
                  * the same transaction here. Handle this case.
                  */
                 if (upd->next->upd_saved_txnid == tombstone_txnid) {
-                    WT_ASSERT(session, write_start_prepare);
                     WT_ASSERT(session, upd->next->prepare_ts == tombstone->prepare_ts);
                     break;
                 } else

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -1145,7 +1145,7 @@ __rec_upd_select_inmem(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_CELL_UNPAC
              */
             if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT)) {
                 if (upd->type == WT_UPDATE_TOMBSTONE) {
-                    WT_ASSERT(session, upd->upd_durable_ts == WT_TS_NONE);
+                    WT_ASSERT(session, __wt_txn_upd_visible_all(session, upd));
                     found_last_upd_to_keep = true;
                     break;
                 }

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -1144,8 +1144,8 @@ __rec_upd_select_inmem(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_CELL_UNPAC
              * updates are instead handled by the pruning check above.
              */
             if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT)) {
-                if (upd->type == WT_UPDATE_TOMBSTONE) {
-                    /* FIXME-WT-17674: narrow the assertion to check for global visibility. */
+                /* FIXME-WT-17674: bypass the global visibility check. */
+                if (upd->type == WT_UPDATE_TOMBSTONE && __wt_txn_upd_visible_all(session, upd)) {
                     WT_ASSERT(session, upd->upd_durable_ts == WT_TS_NONE);
                     found_last_upd_to_keep = true;
                     break;

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -1312,13 +1312,20 @@ __rec_fill_tw_from_upd_select(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_U
             for (; upd->next != NULL; upd = upd->next) {
                 next_txnid = __wt_atomic_load_uint64_v_acquire(&upd->next->txnid);
                 if (next_txnid != WT_TXN_ABORTED) {
-                    write_start_prepare = write_prepare && next_txnid == tombstone_txnid;
+                    if (write_start_prepare)
+                        write_start_prepare = next_txnid == tombstone_txnid;
+                    else
+                        WT_ASSERT(session, !write_prepare || next_txnid != tombstone_txnid);
                     break;
                 }
                 if (!write_prepare)
                     continue;
 
                 if (!F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED))
+                    continue;
+
+                /* We may see aborted reserve updates in between the prepared updates. */
+                if (upd->next->type == WT_UPDATE_RESERVE)
                     continue;
 
                 if (upd->next->prepared_id == WT_PREPARED_ID_NONE) {
@@ -1330,16 +1337,13 @@ __rec_fill_tw_from_upd_select(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_U
                   upd->next->prepare_state == WT_PREPARE_LOCKED ||
                     upd->next->prepare_state == WT_PREPARE_INPROGRESS);
 
-                /* We may see aborted reserve updates in between the prepared updates. */
-                if (upd->next->type == WT_UPDATE_RESERVE)
-                    continue;
-
                 /*
                  * Since we resolve prepared update from the oldest to newest, we may see a
                  * tombstone still in prepared state but a prepared update that is rolled back from
                  * the same transaction here. Handle this case.
                  */
                 if (upd->next->upd_saved_txnid == tombstone_txnid) {
+                    WT_ASSERT(session, write_start_prepare);
                     WT_ASSERT(session, upd->next->prepare_ts == tombstone->prepare_ts);
                     break;
                 } else


### PR DESCRIPTION
## Summary

- During connection close, `WT_CONN_CLOSING` causes `__wt_txn_visible_all` to return `true` unconditionally, bypassing the disaggregated pinned-timestamp cap (`last_checkpoint_timestamp`).
- On an ingest btree with no checkpoint picked up (`rec_prune_timestamp=0`), the old selection loop broke early at the first committed preserved prepared update that appeared globally visible. The fallback block introduced in WT-17684 then walked to the next update — also a committed preserved prepared update from a different transaction — and asserted it was prunable, which it wasn't, causing the crash.
- Fix: on ingest btrees, never use the global visibility check to terminate the update selection loop for non-tombstone updates. The per-btree prune threshold is the correct gate. Tombstones on ingest btrees are always non-timestamped and break unconditionally without a visibility check.