### PR TITLE
WT-17716 Skip ingest cursor open in leader mode for layered cursors

### DIFF
--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -9,6 +9,7 @@
 #include "wt_internal.h"
 
 static int __clayered_copy_bounds(WT_CURSOR_LAYERED *);
+static int __clayered_update_ingest(WT_CURSOR_LAYERED *, uint32_t);
 static int __clayered_update_stable(WT_CURSOR_LAYERED *, uint32_t);
 static int __clayered_lookup(WT_SESSION_IMPL *, WT_CURSOR_LAYERED *, WT_ITEM *);
 static int __clayered_open_ingest(WT_SESSION_IMPL *, WT_CURSOR_LAYERED *, WT_CURSOR **);
@@ -159,25 +160,8 @@ __clayered_enter(WT_CURSOR_LAYERED *clayered, uint32_t flags)
         WT_RET(__clayered_reset_cursors(clayered, false));
     }
 
-    /*
-     * Manage the ingest cursor by role. A follower opens it on first use and never reopens it
-     * during normal operation. The leader keeps it closed: the ingest table is empty for reads and
-     * unused for writes, so an open ingest cursor only adds the per-operation cache/reopen and
-     * dhandle rwlock overhead. A step-up can leave behind an ingest cursor opened while a follower,
-     * so close it on the role change.
-     */
-    if (S2C(session)->layered_table_manager.leader) {
-        if (LF_ISSET(CLAYERED_ENTER_ROLE_CHANGE) && clayered->ingest_cursor != NULL) {
-            WT_CURSOR *ingest = clayered->ingest_cursor;
-            if (clayered->current_cursor == ingest)
-                clayered->current_cursor = NULL;
-            WT_RET(ingest->close(ingest));
-            clayered->ingest_cursor = NULL;
-        }
-    } else if (clayered->ingest_cursor == NULL) {
-        WT_RET(__clayered_open_ingest(session, clayered, &clayered->ingest_cursor));
-        WT_RET(__clayered_copy_bounds(clayered));
-    }
+    /* Manage the ingest cursor: a follower opens it on first use; the leader keeps it closed. */
+    WT_RET(__clayered_update_ingest(clayered, flags));
 
     /* Manage the stable: open it, advance to a newer checkpoint, or reopen on role change. */
     WT_RET(__clayered_update_stable(clayered, flags));
@@ -547,6 +531,35 @@ __clayered_open_ingest(WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, WT
         __clayered_seed_random(session, clayered, cursor);
 
     *cursorp = cursor;
+
+    return (0);
+}
+
+/*
+ * __clayered_update_ingest --
+ *     Manage the ingest cursor lifecycle by node role. A follower opens it on first use and never
+ *     reopens it during normal operation. The leader keeps it closed: the ingest table is empty for
+ *     reads and unused for writes, so an open ingest cursor only adds the per-operation
+ *     cache/reopen and dhandle rwlock overhead. A step-up can leave behind an ingest cursor opened
+ *     while a follower, so close it on the role change.
+ */
+static int
+__clayered_update_ingest(WT_CURSOR_LAYERED *clayered, uint32_t flags)
+{
+    WT_SESSION_IMPL *const session = CUR2S(clayered);
+
+    if (S2C(session)->layered_table_manager.leader) {
+        if (FLD_ISSET(flags, CLAYERED_ENTER_ROLE_CHANGE) && clayered->ingest_cursor != NULL) {
+            WT_CURSOR *ingest = clayered->ingest_cursor;
+            if (clayered->current_cursor == ingest)
+                clayered->current_cursor = NULL;
+            WT_RET(ingest->close(ingest));
+            clayered->ingest_cursor = NULL;
+        }
+    } else if (clayered->ingest_cursor == NULL) {
+        WT_RET(__clayered_open_ingest(session, clayered, &clayered->ingest_cursor));
+        WT_RET(__clayered_copy_bounds(clayered));
+    }
 
     return (0);
 }

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -159,8 +159,22 @@ __clayered_enter(WT_CURSOR_LAYERED *clayered, uint32_t flags)
         WT_RET(__clayered_reset_cursors(clayered, false));
     }
 
-    /* Open the ingest on first use. We never reopen it during normal operation. */
-    if (clayered->ingest_cursor == NULL) {
+    /*
+     * Manage the ingest cursor by role. A follower opens it on first use and never reopens it
+     * during normal operation. The leader keeps it closed: the ingest table is empty for reads and
+     * unused for writes, so an open ingest cursor only adds the per-operation cache/reopen and
+     * dhandle rwlock overhead. A step-up can leave behind an ingest cursor opened while a follower,
+     * so close it on the role change.
+     */
+    if (S2C(session)->layered_table_manager.leader) {
+        if (LF_ISSET(CLAYERED_ENTER_ROLE_CHANGE) && clayered->ingest_cursor != NULL) {
+            WT_CURSOR *ingest = clayered->ingest_cursor;
+            if (clayered->current_cursor == ingest)
+                clayered->current_cursor = NULL;
+            WT_RET(ingest->close(ingest));
+            clayered->ingest_cursor = NULL;
+        }
+    } else if (clayered->ingest_cursor == NULL) {
         WT_RET(__clayered_open_ingest(session, clayered, &clayered->ingest_cursor));
         WT_RET(__clayered_copy_bounds(clayered));
     }
@@ -1965,7 +1979,8 @@ done:
     if (!F_ISSET(clayered, WT_CLAYERED_ITERATE_NEXT | WT_CLAYERED_ITERATE_PREV)) {
         if (clayered->stable_cursor != NULL && clayered->current_cursor == clayered->ingest_cursor)
             WT_ERR(clayered->stable_cursor->reset(clayered->stable_cursor));
-        else if (clayered->current_cursor == clayered->stable_cursor)
+        else if (clayered->ingest_cursor != NULL &&
+          clayered->current_cursor == clayered->stable_cursor)
             WT_ERR(clayered->ingest_cursor->reset(clayered->ingest_cursor));
     }
 
@@ -2501,9 +2516,11 @@ __clayered_largest_key(WT_CURSOR *cursor)
 
     WT_ERR(__wt_scr_alloc(session, 0, &key));
 
-    WT_ERR_NOTFOUND_OK(ingest_cursor->largest_key(ingest_cursor), true);
-    if (ret == 0)
-        ingest_found = true;
+    if (ingest_cursor != NULL) {
+        WT_ERR_NOTFOUND_OK(ingest_cursor->largest_key(ingest_cursor), true);
+        if (ret == 0)
+            ingest_found = true;
+    }
 
     if (stable_cursor != NULL) {
         WT_ERR_NOTFOUND_OK(stable_cursor->largest_key(stable_cursor), true);
@@ -2665,6 +2682,8 @@ __clayered_next_random(WT_CURSOR *cursor)
 
     if (c == NULL || ret == WT_NOTFOUND) {
         c = clayered->ingest_cursor;
+        if (c == NULL)
+            WT_ERR(WT_NOTFOUND);
         WT_ERR(__wti_curfile_next_random(c));
     }
 


### PR DESCRIPTION
## Summary

In leader mode the ingest table is empty for reads and is not used for writes: all reads and writes route to the stable table. Despite this, every layered cursor still opens the ingest cursor on first use and then resets it on each operation, paying the session cursor-cache / reopen bookkeeping and the dhandle rwlock cost. In disaggregated storage (DSC) those bookkeeping steps translate into extra page-service round trips and measurably hurt read latency.

This change skips opening the ingest cursor while the layered cursor is in leader mode, and adds NULL guards on the few code paths that previously assumed an ingest cursor always existed.

## Change

This PR has been rebased onto the WT-17679 layered-cursor enter rework. The previous `__clayered_open_cursors` function was removed by that rework and cursor opening is now inlined into `__clayered_enter`, so the change is now scoped to `src/cursor/cur_layered.c`:

- `__clayered_enter` — open the ingest cursor on first use only when running as a follower. The leader check uses the connection-level flag (`S2C(session)->layered_table_manager.leader`) because the cursor-level `clayered->leader` is refreshed later in the same path and would be stale during the open phase.
- `__clayered_search_near_int` (done-reset path) — guard the `ingest_cursor->reset` call with a NULL check.
- `__clayered_largest_key` — only call `ingest_cursor->largest_key` when the ingest cursor is open.
- `__clayered_next_random` — return `WT_NOTFOUND` if the ingest fallback cursor is not open.

The remaining ingest-vs-leader paths (`__clayered_get_current`, `__clayered_iterate_constituents`, `__clayered_reset_cursors`, `__clayered_copy_constituent_bound`, `__clayered_lookup`, and the ingest search in `__clayered_search_near_int`) were already made leader / NULL aware by the WT-17679 rework, and all write paths (put / remove / modify / truncate) dispatch to follower-only variants under the leader check, so they never touch the ingest cursor in leader mode.