### PR TITLE
WT-17719 Bound the poll loops in test_layered_checkpoint08

### DIFF
--- a/test/suite/test_layered_checkpoint08.py
+++ b/test/suite/test_layered_checkpoint08.py
@@ -50,12 +50,15 @@ class test_layered_checkpoint08(wttest.WiredTigerTestCase):
 
     # Wait for a checkpoint to start running
     def wait_for_checkpoint_start(self):
+        deadline = time.time() + 60
         while True:
             stat_cursor = self.session.open_cursor('statistics:')
             state = stat_cursor[wiredtiger.stat.conn.checkpoint_state][2]
             stat_cursor.close()
             if state != 0:
                 break
+            self.assertLess(time.time(), deadline,
+                'checkpoint did not start running within 60 seconds')
             time.sleep(0.1)
 
     # Test dropping an empty table while a checkpoint is running.
@@ -79,7 +82,11 @@ class test_layered_checkpoint08(wttest.WiredTigerTestCase):
 
         session2.close()
 
-        # Wait until the sweep has closed any idle handles
+        # Wait until the sweep has closed any idle handles. With close_scan_interval=1 and
+        # close_idle_time=1, a dead handle is closed within a couple of sweep cycles, so bound the
+        # wait to fail fast with a clear error rather than spin until the task timeout if the sweep
+        # never makes progress.
+        sweep_deadline = time.time() + 60
         while True:
             stat_cursor = self.session.open_cursor('statistics:', None, None)
             sweep_closes_after = stat_cursor[wiredtiger.stat.conn.dh_sweep_dead_close][2]
@@ -87,6 +94,8 @@ class test_layered_checkpoint08(wttest.WiredTigerTestCase):
             if sweep_closes_after - sweep_closes_before > 0:
                 self.pr(f"Dhandles closed by sweep: {sweep_closes_after - sweep_closes_before}")
                 break
+            self.assertLess(time.time(), sweep_deadline,
+                'sweep server did not close the idle table handle within 60 seconds')
             time.sleep(0.5)
 
         # Start a checkpoint in a separate thread


### PR DESCRIPTION
## Summary
- `test_layered_checkpoint08` had two unbounded `while True` poll loops that spun silently until a task-level timeout fired (the 2h Evergreen idle timeout, or the 1800s per-test timeout in the `parallel_checkpoint` hook task) whenever the engine failed to make progress.
- Bounded the sweep-wait loop (`dh_sweep_dead_close`) with a 60s deadline. With `close_scan_interval=1` and `close_idle_time=1` a dead handle is closed within a couple of sweep cycles (~1-2s), so 60s is generous even under ASAN while giving ~120x faster feedback than the 2h timeout.
- Bounded the `wait_for_checkpoint_start()` loop (`checkpoint_state`) with the same 60s deadline; the checkpoint thread is already running and the checkpoint takes >=10s due to `timing_stress_for_test=[checkpoint_slow]`.
- Both loops now fail with a clear assertion message instead of hanging.
- This is the test-robustness follow-up to WT-17700 (the underlying sweep-stall engine bug in the `palite`/disaggregated config is tracked there).

## Testing
- Touched `test/suite/test_layered_checkpoint08.py`. Run with `python3 ../test/suite/run.py test_layered_checkpoint08` on a disagg-enabled build to confirm the happy path still passes; the bounded loops only change behaviour on failure (fail in <=60s instead of hanging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)