### PR TITLE
WT-17721 Add reusable bounded wait_for_checkpoint_start test helper

### DIFF
--- a/test/suite/helpers/checkpoint_util.py
+++ b/test/suite/helpers/checkpoint_util.py
@@ -31,7 +31,7 @@ import wttest
 from wiredtiger import stat
 
 # checkpoint_util.py
-# Shared base class used by checkpoint tests.
+# Base class providing checkpoint-related helpers.
 class checkpoint_util(wttest.WiredTigerTestCase):
 
     def wait_for_checkpoint_start(self, session=None, timeout=60, poll_interval=0.1):

--- a/test/suite/helpers/checkpoint_util.py
+++ b/test/suite/helpers/checkpoint_util.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import time
+import wttest
+from wiredtiger import stat
+
+# checkpoint_util.py
+# Shared base class used by checkpoint tests.
+class checkpoint_util(wttest.WiredTigerTestCase):
+
+    def wait_for_checkpoint_start(self, session=None, timeout=60, poll_interval=0.1):
+        """
+        Poll until a checkpoint is running (the checkpoint_state connection statistic becomes
+        non-zero). Bounded so the test fails fast with a clear message instead of spinning to a
+        task-level timeout if a checkpoint never starts. poll_interval controls how often the
+        statistic is sampled.
+        """
+        if session == None:
+            session = self.session
+        deadline = time.time() + timeout
+        while True:
+            with wttest.open_cursor(session, 'statistics:') as stat_cursor:
+                state = stat_cursor[stat.conn.checkpoint_state][2]
+            if state != 0:
+                break
+            self.assertLess(time.time(), deadline,
+                'checkpoint did not start running within %d seconds' % timeout)
+            time.sleep(poll_interval)

--- a/test/suite/helpers/wttest.py
+++ b/test/suite/helpers/wttest.py
@@ -471,25 +471,6 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
         self.close_conn()
         self.open_conn(directory, config)
 
-    def wait_for_checkpoint_start(self, session=None, timeout=60, poll_interval=0.1):
-        """
-        Poll until a checkpoint is running (the checkpoint_state connection statistic becomes
-        non-zero). Bounded so the test fails fast with a clear message instead of spinning to a
-        task-level timeout if a checkpoint never starts. poll_interval controls how often the
-        statistic is sampled.
-        """
-        if session == None:
-            session = self.session
-        deadline = time.time() + timeout
-        while True:
-            with open_cursor(session, 'statistics:') as stat_cursor:
-                state = stat_cursor[wiredtiger.stat.conn.checkpoint_state][2]
-            if state != 0:
-                break
-            self.assertLess(time.time(), deadline,
-                'checkpoint did not start running within %d seconds' % timeout)
-            time.sleep(poll_interval)
-
     @contextmanager
     def transaction(self, session=None, begin_config=None, commit_config=None,
                     commit_timestamp=None, read_timestamp=None, rollback=False):

--- a/test/suite/helpers/wttest.py
+++ b/test/suite/helpers/wttest.py
@@ -481,9 +481,8 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
             session = self.session
         deadline = time.time() + timeout
         while True:
-            stat_cursor = session.open_cursor('statistics:')
-            state = stat_cursor[wiredtiger.stat.conn.checkpoint_state][2]
-            stat_cursor.close()
+            with open_cursor(session, 'statistics:') as stat_cursor:
+                state = stat_cursor[wiredtiger.stat.conn.checkpoint_state][2]
             if state != 0:
                 break
             self.assertLess(time.time(), deadline,

--- a/test/suite/helpers/wttest.py
+++ b/test/suite/helpers/wttest.py
@@ -471,11 +471,12 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
         self.close_conn()
         self.open_conn(directory, config)
 
-    def wait_for_checkpoint_start(self, session=None, timeout=60):
+    def wait_for_checkpoint_start(self, session=None, timeout=60, poll_interval=0.1):
         """
         Poll until a checkpoint is running (the checkpoint_state connection statistic becomes
         non-zero). Bounded so the test fails fast with a clear message instead of spinning to a
-        task-level timeout if a checkpoint never starts.
+        task-level timeout if a checkpoint never starts. poll_interval controls how often the
+        statistic is sampled.
         """
         if session == None:
             session = self.session
@@ -487,7 +488,7 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
                 break
             self.assertLess(time.time(), deadline,
                 'checkpoint did not start running within %d seconds' % timeout)
-            time.sleep(0.1)
+            time.sleep(poll_interval)
 
     @contextmanager
     def transaction(self, session=None, begin_config=None, commit_config=None,

--- a/test/suite/helpers/wttest.py
+++ b/test/suite/helpers/wttest.py
@@ -471,6 +471,25 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
         self.close_conn()
         self.open_conn(directory, config)
 
+    def wait_for_checkpoint_start(self, session=None, timeout=60):
+        """
+        Poll until a checkpoint is running (the checkpoint_state connection statistic becomes
+        non-zero). Bounded so the test fails fast with a clear message instead of spinning to a
+        task-level timeout if a checkpoint never starts.
+        """
+        if session == None:
+            session = self.session
+        deadline = time.time() + timeout
+        while True:
+            stat_cursor = session.open_cursor('statistics:')
+            state = stat_cursor[wiredtiger.stat.conn.checkpoint_state][2]
+            stat_cursor.close()
+            if state != 0:
+                break
+            self.assertLess(time.time(), deadline,
+                'checkpoint did not start running within %d seconds' % timeout)
+            time.sleep(0.1)
+
     @contextmanager
     def transaction(self, session=None, begin_config=None, commit_config=None,
                     commit_timestamp=None, read_timestamp=None, rollback=False):

--- a/test/suite/test_layered_checkpoint05.py
+++ b/test/suite/test_layered_checkpoint05.py
@@ -47,16 +47,6 @@ class test_layered_checkpoint05(wttest.WiredTigerTestCase):
     disagg_storages = gen_disagg_storages('test_layered_checkpoint05', disagg_only = True)
     scenarios = make_scenarios(disagg_storages)
 
-    # Wait for a checkpoint to start running
-    def wait_for_checkpoint_start(self):
-        while True:
-            stat_cursor = self.session.open_cursor('statistics:')
-            state = stat_cursor[wiredtiger.stat.conn.checkpoint_state][2]
-            stat_cursor.close()
-            if state != 0:
-                break
-            time.sleep(0.1)
-
     # Test creating an empty table while a checkpoint is running.
     def test_layered_checkpoint05(self):
         # The node started as a follower, so step it up as the leader

--- a/test/suite/test_layered_checkpoint05.py
+++ b/test/suite/test_layered_checkpoint05.py
@@ -27,13 +27,14 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 import threading, time, wiredtiger, wttest
+from checkpoint_util import checkpoint_util
 from helper_disagg import disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 
 # test_layered_checkpoint05.py
 #    Test creating empty tables while a checkpoint is running.
 @disagg_test_class
-class test_layered_checkpoint05(wttest.WiredTigerTestCase):
+class test_layered_checkpoint05(checkpoint_util):
     conn_base_config = 'statistics=(all),' \
                      + 'statistics_log=(wait=1,json=true,on_close=true),' \
                      + 'precise_checkpoint=true,' \

--- a/test/suite/test_layered_checkpoint06.py
+++ b/test/suite/test_layered_checkpoint06.py
@@ -27,6 +27,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 import threading, time, wiredtiger, wttest
+from checkpoint_util import checkpoint_util
 from helper_disagg import disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 
@@ -44,7 +45,7 @@ from wtscenario import make_scenarios
 # change happened after the checkpoint started.
 #
 @disagg_test_class
-class test_layered_checkpoint06(wttest.WiredTigerTestCase):
+class test_layered_checkpoint06(checkpoint_util):
     conn_base_config = 'statistics=(all),' \
                      + 'statistics_log=(wait=1,json=true,on_close=true),' \
                      + 'precise_checkpoint=true,'

--- a/test/suite/test_layered_checkpoint06.py
+++ b/test/suite/test_layered_checkpoint06.py
@@ -57,16 +57,6 @@ class test_layered_checkpoint06(wttest.WiredTigerTestCase):
     disagg_storages = gen_disagg_storages('test_layered_checkpoint06', disagg_only = True)
     scenarios = make_scenarios(disagg_storages)
 
-    # Wait for a checkpoint to start running
-    def wait_for_checkpoint_start(self):
-        while True:
-            stat_cursor = self.session.open_cursor('statistics:')
-            state = stat_cursor[wiredtiger.stat.conn.checkpoint_state][2]
-            stat_cursor.close()
-            if state != 0:
-                break
-            time.sleep(0.1)
-
     # Test stepping up concurrently with a checkpoint.
     def test_layered_checkpoint06(self):
         self.conn.reconfigure('disaggregated=(role="leader")')

--- a/test/suite/test_layered_checkpoint08.py
+++ b/test/suite/test_layered_checkpoint08.py
@@ -27,13 +27,14 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 import threading, time, wiredtiger, wttest
+from checkpoint_util import checkpoint_util
 from helper_disagg import disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 
 # test_layered_checkpoint08.py
 #    Test dropping empty tables while a checkpoint is running.
 @disagg_test_class
-class test_layered_checkpoint08(wttest.WiredTigerTestCase):
+class test_layered_checkpoint08(checkpoint_util):
     conn_base_config = 'statistics=(all),' \
                      + 'statistics_log=(wait=1,json=true,on_close=true),' \
                      + 'precise_checkpoint=true,' \

--- a/test/suite/test_layered_checkpoint08.py
+++ b/test/suite/test_layered_checkpoint08.py
@@ -48,19 +48,6 @@ class test_layered_checkpoint08(wttest.WiredTigerTestCase):
     disagg_storages = gen_disagg_storages('test_layered_checkpoint08', disagg_only = True)
     scenarios = make_scenarios(disagg_storages)
 
-    # Wait for a checkpoint to start running
-    def wait_for_checkpoint_start(self):
-        deadline = time.time() + 60
-        while True:
-            stat_cursor = self.session.open_cursor('statistics:')
-            state = stat_cursor[wiredtiger.stat.conn.checkpoint_state][2]
-            stat_cursor.close()
-            if state != 0:
-                break
-            self.assertLess(time.time(), deadline,
-                'checkpoint did not start running within 60 seconds')
-            time.sleep(0.1)
-
     # Test dropping an empty table while a checkpoint is running.
     def test_layered_checkpoint08(self):
         # The node started as a follower, so step it up as the leader

--- a/test/suite/test_layered_schema08.py
+++ b/test/suite/test_layered_schema08.py
@@ -66,15 +66,6 @@ class test_layered_schema08(wttest.WiredTigerTestCase):
             uris += ['table:' + self.uri_base, 'colgroup:' + self.uri_base]
         return uris
 
-    def wait_for_checkpoint_start(self):
-        while True:
-            stat_cursor = self.session.open_cursor('statistics:')
-            state = stat_cursor[wiredtiger.stat.conn.checkpoint_state][2]
-            stat_cursor.close()
-            if state != 0:
-                break
-            time.sleep(0.1)
-
     def check_shared_metadata(self, expect_contains=None, expect_missing=None):
         cursor = self.session.open_cursor('file:WiredTigerShared.wt_stable', None, None)
         metadata = {}

--- a/test/suite/test_layered_schema08.py
+++ b/test/suite/test_layered_schema08.py
@@ -35,11 +35,12 @@
 #   prepare) remain deferred until the next checkpoint.
 
 import threading, time, wiredtiger, wttest
+from checkpoint_util import checkpoint_util
 from helper_disagg import disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 
 @disagg_test_class
-class test_layered_schema08(wttest.WiredTigerTestCase):
+class test_layered_schema08(checkpoint_util):
     uri_base = 'test_layered_schema08'
     conn_config = 'statistics=(all),disaggregated=(role="leader",lose_all_my_data=true)'
 


### PR DESCRIPTION
## Summary
- `wait_for_checkpoint_start()` was copy-pasted as an unbounded `while True` poll on the `checkpoint_state` statistic across several layered tests, so a checkpoint that never starts would hang the test until a task-level timeout instead of failing fast.
- Added a `checkpoint_util` base class (`test/suite/helpers/checkpoint_util.py`), following the `eviction_util`/`compact_util` convention, with a single reusable `wait_for_checkpoint_start(self, session=None, timeout=60, poll_interval=0.1)` that asserts with a clear message on timeout and opens the stat cursor via the `open_cursor` context manager.
- Migrated `test_layered_checkpoint05`, `test_layered_checkpoint06`, `test_layered_checkpoint08`, and `test_layered_schema08` to inherit from `checkpoint_util` (removed their local copies).
- Follow-up to WT-17719 (per review feedback on #13946). The sibling `wait_for_sweep` helper is tracked in WT-17722; the sweep-wait loop in `test_layered_checkpoint08` is intentionally left as-is for that ticket.

## Testing
- `python3 ../test/suite/run.py -v 2 test_layered_checkpoint05 test_layered_checkpoint06 test_layered_checkpoint08 test_layered_schema08` — all 15 tests pass. The `*_during_checkpoint_*` and `test_layered_checkpoint08` cases exercise the inherited helper's wait path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)