### PR TITLE
WT-17724 format: use config_off_all to disable ops.truncate for all tables with prepare and precise checkpoint

### DIFF
--- a/test/format/format_config.c
+++ b/test/format/format_config.c
@@ -1585,7 +1585,7 @@ config_transaction(void)
     if (GV(PRECISE_CHECKPOINT) && GV(OPS_PREPARE)) {
         if (config_explicit(NULL, "ops.truncate"))
             WARN("%s", "turning off ops.truncate to work with ops.prepare and precise checkpoint");
-        config_off(NULL, "ops.truncate");
+        config_off_all("ops.truncate");
     }
 
     /* Set a default transaction timeout limit if one is not specified. */


### PR DESCRIPTION
## Summary
- `config_off(NULL, "ops.truncate")` only disables the option on the global (NULL/table-0) config; in multi-table format runs, per-table configs were left untouched
- Replaced with `config_off_all("ops.truncate")` so truncate is disabled across all tables when both `OPS_PREPARE` and `PRECISE_CHECKPOINT` are active
- Matches the pattern used elsewhere in the file for table-wide restrictions (e.g. `btree.reverse`, `runs.mirror`)

## Jira
[WT-17724](https://jira.mongodb.org/browse/WT-17724)