### PR TITLE
WT-17371 Fix occasional timeouts of recovery-stress-test

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1644,7 +1644,7 @@ variables:
           CC_OPTIMIZE_LEVEL: -DCC_OPTIMIZE_LEVEL=-O0
       - func: "recovery stress test script"
         vars:
-          times: 25
+          times: 20
 
   - &workgen-test
     tags: ["workgen-test"]


### PR DESCRIPTION
The recovery stress tests take longer to complete due to a side-effect of [WT-17279](https://jira.mongodb.org/browse/WT-17279), which is that eviction now contends with checkpoint during reconfigure. The recovery stress test script runs `test_timestamp_abort` which calls reconfigure every ~2 seconds, so this change slowed the task down by a noticeable amount and caused it to sometimes hit the configured 7 hour timeout.

I've confirmed with @bvpvamsikrishna that this is a test-only fix. Rather than increase the timeout threshold, I have chosen to reduce the number of iterations from 25 to 20, this should eliminate the timeouts we are seeing in CI.