### PR TITLE
WT-17731 Eliminate 7-byte alignment padding in __wt_page_modify caused by bool instantiated

### DIFF
--- a/src/include/btmem.h
+++ b/src/include/btmem.h
@@ -503,7 +503,6 @@ struct __wt_page_modify {
      * that deleted the page is resolved. These transitions are independent; that is, the first
      * reconciliation can happen either before or after the delete transaction resolves.
      */
-    bool instantiated;        /* True if this is a newly instantiated page. */
     WT_UPDATE **inst_updates; /* Update list for instantiated page with unresolved truncate. */
 
 #define WT_PAGE_LOCK(s, p) __wt_spin_lock_track((s), &(p)->modify->page_lock)
@@ -526,6 +525,9 @@ struct __wt_page_modify {
 #define WT_PAGE_CLEAN 0
 #define WT_PAGE_DIRTY_FIRST 1
     wt_shared uint32_t page_state;
+
+    /* Kept with the trailing byte fields to avoid alignment padding before inst_updates. */
+    bool instantiated; /* True if this is a newly instantiated page. */
 
 #define WT_PM_REC_EMPTY 1      /* Reconciliation: no replacement */
 #define WT_PM_REC_MULTIBLOCK 2 /* Reconciliation: multiple blocks */


### PR DESCRIPTION
Moving `bool instantiated` from before `inst_updates` (where it forced 7 bytes of compiler alignment padding before the pointer) to sit alongside `rec_result`, `restore_state`, and `flags` at the end of `__wt_page_modify`. All four fields are 1 byte wide, so they pack together without padding. Saves 7 bytes per `WT_PAGE_MODIFY` allocation with no semantic change.