### PR TITLE
WT-17733 Close connection in test/suite if validation during tearDown fails

### DIFF
--- a/test/suite/helpers/wttest.py
+++ b/test/suite/helpers/wttest.py
@@ -622,6 +622,7 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
         dumped_error_log = False
         teardown_failed = False
         teardown_msg = None
+        verify_failed = False
         if not dueToRetry:
             for action in self.teardown_actions:
                 try:
@@ -644,8 +645,9 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
             try:
                 self.verifyLayered()
             except Exception:
-                self.prexception(sys.exc_info())
                 passed = False
+                dumped_error_log = True
+                verify_failed = True
 
         try:
             self.platform_api.tearDown(self)
@@ -720,6 +722,8 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
             print("[pid:{}]: {}: {:.2f} seconds".format(os.getpid(), str(self), elapsed))
         if teardown_failed:
             self.fail(f'Teardown of {self} failed with message: {teardown_msg}')
+        if verify_failed:
+            self.fail(f'Verification failed')
         if close_failed:
             self.fail(f'Closing the connection failed')
         if (not passed or teardown_failed) and (not self.skipped):

--- a/test/suite/helpers/wttest.py
+++ b/test/suite/helpers/wttest.py
@@ -641,7 +641,11 @@ class WiredTigerTestCase(abstract_test_case.AbstractWiredTigerTestCase):
         passed = not (self.failed() or teardown_failed)
 
         if passed and self.__module__.startswith("test_layered"):
-            self.verifyLayered()
+            try:
+                self.verifyLayered()
+            except Exception:
+                self.prexception(sys.exc_info())
+                passed = False
 
         try:
             self.platform_api.tearDown(self)


### PR DESCRIPTION
Correctly handle any failures generated by self.verifyLayered() to ensure that we report the error correctly and that we clean up the test properly.