### PR TITLE
WT-17742 Update stale FIXME reference in test/format/format_config.c

### DIFF
--- a/test/format/format_config.c
+++ b/test/format/format_config.c
@@ -1581,7 +1581,7 @@ config_transaction(void)
         config_off(NULL, "precise_checkpoint");
         config_off(NULL, "preserve_prepared");
     }
-    /* FIXME-WT-15565 Write prepared truncate operation to disk. */
+    /* FIXME-WT-17277 Write prepared truncate operation to disk. */
     if (GV(PRECISE_CHECKPOINT) && GV(OPS_PREPARE)) {
         if (config_explicit(NULL, "ops.truncate"))
             WARN("%s", "turning off ops.truncate to work with ops.prepare and precise checkpoint");


### PR DESCRIPTION
## Summary
- Updates the FIXME comment in `test/format/format_config.c` to reference WT-17277 instead of the stale WT-15565
- No logic changes — comment-only fix

## Test plan
- [x] No functional change; CI should pass cleanly