### PR TITLE
WT-17683 Fix incorrect version check in WT_BLOCK_DISAGG_HEADER

### DIFF
--- a/src/block_disagg/block_disagg_read.c
+++ b/src/block_disagg/block_disagg_read.c
@@ -98,14 +98,14 @@ __block_disagg_check_lsn_frontier(WT_SESSION_IMPL *session, uint64_t lsn, uint64
 
 /*
  * __block_disagg_header_version_compatible --
- *     Return whether a reader at the given version can read a header whose oldest-compatible reader
- *     version is compatible_version. A reader can read the header when its own version is at least
- *     the header's compatible version.
+ *     Return whether this build can read a header whose oldest-compatible reader version is
+ *     compatible_version. This build can read the header when its own version is at least the
+ *     header's compatible version.
  */
 static bool
-__block_disagg_header_version_compatible(uint8_t reader_version, uint8_t compatible_version)
+__block_disagg_header_version_compatible(uint8_t compatible_version)
 {
-    return (compatible_version <= reader_version);
+    return (compatible_version <= WT_BLOCK_DISAGG_VERSION);
 }
 
 /*
@@ -218,8 +218,7 @@ __block_disagg_read_multiple(WT_SESSION_IMPL *session, WT_BLOCK_DISAGG *block_di
                       expected_magic);
                     goto corrupt;
                 }
-                if (!__block_disagg_header_version_compatible(
-                      WT_BLOCK_DISAGG_VERSION, swap.compatible_version)) {
+                if (!__block_disagg_header_version_compatible(swap.compatible_version)) {
                     __block_disagg_read_err(session, block_disagg->name, block_disagg->tableid,
                       size, page_id, lsn, is_delta, result,
                       "compatible version error, the block's compatible version %" PRIu8
@@ -395,8 +394,8 @@ __wt_block_disagg_debug_read_page_id(WT_BM *bm, WT_SESSION_IMPL *session, uint64
  *     Unit-test wrapper for __block_disagg_header_version_compatible.
  */
 bool
-__ut_block_disagg_header_version_compatible(uint8_t reader_version, uint8_t compatible_version)
+__ut_block_disagg_header_version_compatible(uint8_t compatible_version)
 {
-    return (__block_disagg_header_version_compatible(reader_version, compatible_version));
+    return (__block_disagg_header_version_compatible(compatible_version));
 }
 #endif

--- a/src/block_disagg/block_disagg_read.c
+++ b/src/block_disagg/block_disagg_read.c
@@ -97,6 +97,18 @@ __block_disagg_check_lsn_frontier(WT_SESSION_IMPL *session, uint64_t lsn, uint64
 }
 
 /*
+ * __block_disagg_header_version_compatible --
+ *     Return whether a reader at the given version can read a header whose oldest-compatible reader
+ *     version is compatible_version. A reader can read the header when its own version is at least
+ *     the header's compatible version.
+ */
+static bool
+__block_disagg_header_version_compatible(uint8_t reader_version, uint8_t compatible_version)
+{
+    return (compatible_version <= reader_version);
+}
+
+/*
  * __block_disagg_read_multiple --
  *     Read a full page along with its deltas, into multiple buffers. The page is referenced by a
  *     page id, checkpoint id pair.
@@ -206,12 +218,13 @@ __block_disagg_read_multiple(WT_SESSION_IMPL *session, WT_BLOCK_DISAGG *block_di
                       expected_magic);
                     goto corrupt;
                 }
-                if (swap.compatible_version > WT_BLOCK_DISAGG_COMPATIBLE_VERSION) {
+                if (!__block_disagg_header_version_compatible(
+                      WT_BLOCK_DISAGG_VERSION, swap.compatible_version)) {
                     __block_disagg_read_err(session, block_disagg->name, block_disagg->tableid,
                       size, page_id, lsn, is_delta, result,
-                      "compatible version error, version %" PRIu8
-                      " is greater than compatible version of %" PRIu8,
-                      swap.compatible_version, WT_BLOCK_DISAGG_COMPATIBLE_VERSION);
+                      "compatible version error, the block's compatible version %" PRIu8
+                      " is greater than the reader version of %" PRIu8,
+                      swap.compatible_version, WT_BLOCK_DISAGG_VERSION);
                     goto corrupt;
                 }
 
@@ -375,3 +388,15 @@ __wt_block_disagg_debug_read_page_id(WT_BM *bm, WT_SESSION_IMPL *session, uint64
 
     return (0);
 }
+
+#ifdef HAVE_UNITTEST
+/*
+ * __ut_block_disagg_header_version_compatible --
+ *     Unit-test wrapper for __block_disagg_header_version_compatible.
+ */
+bool
+__ut_block_disagg_header_version_compatible(uint8_t reader_version, uint8_t compatible_version)
+{
+    return (__block_disagg_header_version_compatible(reader_version, compatible_version));
+}
+#endif

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2657,6 +2657,8 @@ extern WT_EXT *__ut_block_off_srch_last(WT_EXT **head, WT_EXT ***stack)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __ut_block_bitflip_detect(void *data, size_t check_size, uint32_t expected_checksum,
   size_t *bit_position) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern bool __ut_block_disagg_header_version_compatible(uint8_t reader_version,
+  uint8_t compatible_version) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __ut_block_first_srch(WT_SESSION_IMPL *session, WT_EXT **head, wt_off_t size,
   WT_EXT ***stack) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __ut_block_off_match(WT_EXTLIST *el, wt_off_t off, wt_off_t size)

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2657,8 +2657,8 @@ extern WT_EXT *__ut_block_off_srch_last(WT_EXT **head, WT_EXT ***stack)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __ut_block_bitflip_detect(void *data, size_t check_size, uint32_t expected_checksum,
   size_t *bit_position) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern bool __ut_block_disagg_header_version_compatible(uint8_t reader_version,
-  uint8_t compatible_version) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern bool __ut_block_disagg_header_version_compatible(uint8_t compatible_version)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __ut_block_first_srch(WT_SESSION_IMPL *session, WT_EXT **head, wt_off_t size,
   WT_EXT ***stack) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __ut_block_off_match(WT_EXTLIST *el, wt_off_t off, wt_off_t size)

--- a/test/catch2/CMakeLists.txt
+++ b/test/catch2/CMakeLists.txt
@@ -13,6 +13,7 @@ else()
         misc_tests/test_checkpoint_skip.cpp
         misc_tests/test_config.cpp
         misc_tests/test_crc32.cpp
+        misc_tests/test_disagg_block_header_version.cpp
         misc_tests/test_disagg_meta_config.cpp
         misc_tests/test_error.cpp
         misc_tests/test_futex.cpp

--- a/test/catch2/misc_tests/test_disagg_block_header_version.cpp
+++ b/test/catch2/misc_tests/test_disagg_block_header_version.cpp
@@ -1,0 +1,43 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+#include <catch2/catch.hpp>
+#include <cstdint>
+
+#include "wt_internal.h"
+
+/*
+ * A reader can read a disagg block header iff its own version is at least the header's
+ * compatible_version. The read path used to compare against WT_BLOCK_DISAGG_COMPATIBLE_VERSION (the
+ * reader's own oldest-compatible bound) instead of WT_BLOCK_DISAGG_VERSION (the reader's own
+ * version), incorrectly rejecting readable blocks once the writer version diverges from the
+ * compatible version.
+ */
+TEST_CASE("disagg block header version compatibility", "[block_disagg]")
+{
+    /* A reader can read a header that only requires an older or equal version. */
+    REQUIRE(__ut_block_disagg_header_version_compatible(1, 1));
+    REQUIRE(__ut_block_disagg_header_version_compatible(2, 1));
+    REQUIRE(__ut_block_disagg_header_version_compatible(5, 3));
+
+    /*
+     * Reader version 2 reading a block that requires compatible_version 2: the case the buggy check
+     * got wrong, rejecting a block the v2 reader is allowed to read.
+     */
+    REQUIRE(__ut_block_disagg_header_version_compatible(2, 2));
+
+    /* A reader cannot read a header that requires a newer reader than the reader's own version. */
+    REQUIRE_FALSE(__ut_block_disagg_header_version_compatible(1, 2));
+    REQUIRE_FALSE(__ut_block_disagg_header_version_compatible(3, 5));
+
+    /* The current build must be able to read everything it writes. */
+    REQUIRE(__ut_block_disagg_header_version_compatible(
+      WT_BLOCK_DISAGG_VERSION, WT_BLOCK_DISAGG_COMPATIBLE_VERSION));
+    REQUIRE(__ut_block_disagg_header_version_compatible(
+      WT_BLOCK_DISAGG_VERSION, WT_BLOCK_DISAGG_VERSION));
+}

--- a/test/catch2/misc_tests/test_disagg_block_header_version.cpp
+++ b/test/catch2/misc_tests/test_disagg_block_header_version.cpp
@@ -12,32 +12,26 @@
 #include "wt_internal.h"
 
 /*
- * A reader can read a disagg block header iff its own version is at least the header's
- * compatible_version. The read path used to compare against WT_BLOCK_DISAGG_COMPATIBLE_VERSION (the
- * reader's own oldest-compatible bound) instead of WT_BLOCK_DISAGG_VERSION (the reader's own
- * version), incorrectly rejecting readable blocks once the writer version diverges from the
- * compatible version.
+ * This build can read a disagg block header iff its own version is at least the header's
+ * compatible_version. The read path used to compare against WT_BLOCK_DISAGG_COMPATIBLE_VERSION (this
+ * build's own oldest-compatible bound) instead of WT_BLOCK_DISAGG_VERSION (this build's version),
+ * incorrectly rejecting readable blocks once the writer version diverges from the compatible
+ * version. The check is currently equivalent because the two macros are equal; this test fails the
+ * moment WT_BLOCK_DISAGG_VERSION is bumped past WT_BLOCK_DISAGG_COMPATIBLE_VERSION and the wrong
+ * macro is used, which is exactly when the bug can be observed.
  */
 TEST_CASE("disagg block header version compatibility", "[block_disagg]")
 {
-    /* A reader can read a header that only requires an older or equal version. */
-    REQUIRE(__ut_block_disagg_header_version_compatible(1, 1));
-    REQUIRE(__ut_block_disagg_header_version_compatible(2, 1));
-    REQUIRE(__ut_block_disagg_header_version_compatible(5, 3));
+    /* This build can read a header that only requires an older or equal version. */
+    REQUIRE(__ut_block_disagg_header_version_compatible(1));
+    REQUIRE(__ut_block_disagg_header_version_compatible(WT_BLOCK_DISAGG_COMPATIBLE_VERSION));
 
     /*
-     * Reader version 2 reading a block that requires compatible_version 2: the case the buggy check
-     * got wrong, rejecting a block the v2 reader is allowed to read.
+     * This build must read a header whose compatible version equals its own version. This is the
+     * case the buggy check got wrong once the writer version diverges from the compatible version.
      */
-    REQUIRE(__ut_block_disagg_header_version_compatible(2, 2));
+    REQUIRE(__ut_block_disagg_header_version_compatible(WT_BLOCK_DISAGG_VERSION));
 
-    /* A reader cannot read a header that requires a newer reader than the reader's own version. */
-    REQUIRE_FALSE(__ut_block_disagg_header_version_compatible(1, 2));
-    REQUIRE_FALSE(__ut_block_disagg_header_version_compatible(3, 5));
-
-    /* The current build must be able to read everything it writes. */
-    REQUIRE(__ut_block_disagg_header_version_compatible(
-      WT_BLOCK_DISAGG_VERSION, WT_BLOCK_DISAGG_COMPATIBLE_VERSION));
-    REQUIRE(__ut_block_disagg_header_version_compatible(
-      WT_BLOCK_DISAGG_VERSION, WT_BLOCK_DISAGG_VERSION));
+    /* This build cannot read a header that requires a newer reader than its own version. */
+    REQUIRE_FALSE(__ut_block_disagg_header_version_compatible(WT_BLOCK_DISAGG_VERSION + 1));
 }

--- a/test/catch2/misc_tests/test_disagg_block_header_version.cpp
+++ b/test/catch2/misc_tests/test_disagg_block_header_version.cpp
@@ -13,12 +13,12 @@
 
 /*
  * This build can read a disagg block header if its own version is at least the header's
- * compatible_version. The read path used to compare against WT_BLOCK_DISAGG_COMPATIBLE_VERSION (this
- * build's own oldest-compatible bound) instead of WT_BLOCK_DISAGG_VERSION (this build's version),
- * incorrectly rejecting readable blocks once the writer version diverges from the compatible
- * version. The check is currently equivalent because the two macros are equal; this test fails the
- * moment WT_BLOCK_DISAGG_VERSION is bumped past WT_BLOCK_DISAGG_COMPATIBLE_VERSION and the wrong
- * macro is used, which is exactly when the bug can be observed.
+ * compatible_version. The read path used to compare against WT_BLOCK_DISAGG_COMPATIBLE_VERSION
+ * (this build's own oldest-compatible bound) instead of WT_BLOCK_DISAGG_VERSION (this build's
+ * version), incorrectly rejecting readable blocks once the writer version diverges from the
+ * compatible version. The check is currently equivalent because the two macros are equal; this test
+ * fails the moment WT_BLOCK_DISAGG_VERSION is bumped past WT_BLOCK_DISAGG_COMPATIBLE_VERSION and
+ * the wrong macro is used, which is exactly when the bug can be observed.
  */
 TEST_CASE("disagg block header version compatibility", "[block_disagg]")
 {

--- a/test/catch2/misc_tests/test_disagg_block_header_version.cpp
+++ b/test/catch2/misc_tests/test_disagg_block_header_version.cpp
@@ -12,7 +12,7 @@
 #include "wt_internal.h"
 
 /*
- * This build can read a disagg block header iff its own version is at least the header's
+ * This build can read a disagg block header if its own version is at least the header's
  * compatible_version. The read path used to compare against WT_BLOCK_DISAGG_COMPATIBLE_VERSION (this
  * build's own oldest-compatible bound) instead of WT_BLOCK_DISAGG_VERSION (this build's version),
  * incorrectly rejecting readable blocks once the writer version diverges from the compatible


### PR DESCRIPTION
### Problem

The disagg block manager's read path checked the header's `compatible_version`
against `WT_BLOCK_DISAGG_COMPATIBLE_VERSION` (the reader's own oldest-compatible
bound) instead of `WT_BLOCK_DISAGG_VERSION` (the reader's own version).

A reader can read a header iff its own version is at least the header's
`compatible_version`. The bug is latent today because both macros are `0x1`, but
once the writer version is bumped while retaining backward compatibility, a node
would reject blocks it can (and did) write — a false corruption error.

### Fix

- Compare `swap.compatible_version` against `WT_BLOCK_DISAGG_VERSION` and correct
  the error message to refer to the reader version.
- Extract the predicate into `__block_disagg_header_version_compatible()` with a
  `HAVE_UNITTEST` wrapper so the semantics are unit-testable in isolation.

### Testing

New Catch2 test `test_disagg_block_header_version.cpp` exercises a matrix of
reader/compatible versions. Verified it **fails** when the buggy comparison is
reintroduced and **passes** with the fix.
