### PR TITLE
WT-16969 Fix doc-update GitHub authentication

### DIFF
--- a/test/evergreen/doc_update.py
+++ b/test/evergreen/doc_update.py
@@ -41,6 +41,7 @@ import sys
 
 from contextlib import contextmanager
 
+from github.Auth import AppAuth
 from github.GithubIntegration import GithubIntegration
 
 
@@ -67,7 +68,8 @@ if (not app_id) or (not private_key):
         "Please ensure GITHUB_APP_ID and GITHUB_APP_PRIVATE_KEY environment variables are set."
     )
 try:
-    app = GithubIntegration(int(app_id), private_key)
+    auth = AppAuth(app_id, private_key)
+    app = GithubIntegration(auth=auth)
 except Exception as e:
     sys.exit(e)
 


### PR DESCRIPTION
The doc-update task was failing because doc_update.py used a deprecated PyGithub API that accepted an integer app ID. Switch to the modern AppAuth-based API, which takes the app ID as a string.