### PR TITLE
WT-17743 Assert that removed-overflow cells never appear in the reconcile image

### DIFF
--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -1189,6 +1189,12 @@ __wti_rec_row_leaf(
         if (upd == NULL) {
             /* Clear the on-disk cell time window if it is obsolete. */
             __wti_rec_time_window_clear_obsolete(session, NULL, vpack, r);
+            /*
+             * A removed-overflow cell must never be written to disk: the backing block is already
+             * gone so copying its in-memory marker verbatim produces a corrupt page image.
+             */
+            WT_ASSERT(session,
+              !F_ISSET(vpack, WT_CELL_UNPACK_OVERFLOW) || vpack->raw != WT_CELL_VALUE_OVFL_RM);
 
             /*
              * When the page was read into memory, there may not have been a value item.

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -1191,10 +1191,10 @@ __wti_rec_row_leaf(
             __wti_rec_time_window_clear_obsolete(session, NULL, vpack, r);
             /*
              * A removed-overflow cell must never be written to disk: the backing block is already
-             * gone so copying its in-memory marker verbatim produces a corrupt page image.
+             * gone so copying its in-memory marker produces a corrupt page image.
              */
             WT_ASSERT(session,
-              !F_ISSET(vpack, WT_CELL_UNPACK_OVERFLOW) || vpack->raw != WT_CELL_VALUE_OVFL_RM);
+              vpack->cell == NULL || __wt_cell_type_raw(vpack->cell) != WT_CELL_VALUE_OVFL_RM);
 
             /*
              * When the page was read into memory, there may not have been a value item.


### PR DESCRIPTION
## Summary

Add a diagnostic assertion in \`__wti_rec_row_leaf\` that fires when an
overflow cell marked as removed (\`WT_CELL_VALUE_OVFL_RM\`, 0xB0) would be
copied to the reconcile image via the \`upd == NULL\` copy path.