### PR TITLE
WT-17667 Add DisaggCorruptionMixin to inject palite page corruption from Python tests

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -27,6 +27,7 @@ Alakuijala
 Alexandrescu's
 Alloc
 Alves
+AssertionError
 Async
 Athlon
 Auth
@@ -80,6 +81,7 @@ CMake
 CMakeFiles
 CMakeLists
 CMakePresets
+CONCAT
 CONF
 CONFIG
 CPP
@@ -139,6 +141,7 @@ DeleteFileW
 Deterministically
 DisAgg
 Disagg
+DisaggCorruptionMixin
 Disaggregated
 Dk
 DmpeRkvXx
@@ -193,6 +196,7 @@ FTDC
 FULLFSYNC
 FUNCSIG
 Failpoint
+FileNotFoundError
 FindClose
 FindFirstFile
 FindNextFileW
@@ -328,6 +332,7 @@ Munge
 Mutex
 Mutexes
 MySecret
+NN
 NNN
 NOLINT
 NOLINTNEXTLINE
@@ -377,6 +382,7 @@ PSD
 PSE
 PTR
 PYTHONMALLOC
+Palite
 Palites
 Pe
 PlatformSDK

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -196,7 +196,6 @@ FTDC
 FULLFSYNC
 FUNCSIG
 Failpoint
-FileNotFoundError
 FindClose
 FindFirstFile
 FindNextFileW

--- a/test/suite/helpers/helper_disagg.py
+++ b/test/suite/helpers/helper_disagg.py
@@ -28,7 +28,7 @@
 #
 
 import wiredtiger
-import functools, os, shutil, subprocess, wttest
+import functools, json, os, shutil, subprocess, wttest
 from run import wt_builddir
 
 # These routines help run the various page log sources used by disaggregated storage.
@@ -559,156 +559,155 @@ class Oplog(object):
             f' lookup - (table,k) -> list of (ts,value)={self._lookup}'
 
 # DisaggCorruptionMixin provides Python helpers for injecting palite-level page
-# corruption into a running disaggregated-storage test. Each public method closes
-# the WT connection and mutates the relevant per-shard pages_NN.db via the
-# bundled sqlite3 binary; WT is left closed since corruption may prevent it
-# from reopening. Tests can read post-state via direct sqlite3 queries.
+# corruption into a running disaggregated-storage test by directly mutating the
+# per-shard pages_NN.db files.
 #
-# Palite holds an exclusive SQLite lock while WT is open, so writes must happen
-# while the connection is closed. The mutations go through wt_builddir/sqlite3
-# (not system sqlite3) to avoid version skew with the SQLite statically linked
-# into palite.
+# Palite holds an exclusive SQLite lock while WT is open, so writes (and the
+# multi-shard scan that picks a victim row) must happen while the connection
+# is closed. The mutations go through wt_builddir/sqlite3 (not system sqlite3)
+# to avoid version skew with the SQLite statically linked into palite.
 class DisaggCorruptionMixin:
 
     # Mirrors WT_PAGE_LOG_DISCARDED in src/include/page_log.h. The value is
     # static-asserted in ext/page_log/palite/palite.cpp.
     WT_PAGE_LOG_DISCARDED = 0x10000
 
-    def _palite_mutate(self, table_id, sql):
-        """Close WT, run sql via wt_builddir/sqlite3 against the shard DB for
-        table_id. Leaves WT closed - corruption helpers may make WT unable to
-        reopen. Returns a list of non-empty stdout lines."""
+    # ---- Read helpers (WT may be open or closed) ----
+
+    def sqlite_select_json(self, table_id, sql_query):
+        """Read rows from the pages_NN.db for table_id's shard. Palite uses
+        shared SQLite locks for readers, so this is safe whether WT is open
+        or closed. Returns a list of dict rows."""
         shard = get_shard_id(table_id)
         db_path = os.path.join(self.home, 'kv_home', f'pages_{shard:02d}.db')
-        if not os.path.exists(db_path):
-            raise FileNotFoundError(db_path)
         sqlite_exe = os.path.join(wt_builddir, 'sqlite3')
+        result = subprocess.run(
+            [sqlite_exe, '-json', db_path, sql_query],
+            capture_output=True, text=True, check=True)
+        return json.loads(result.stdout) if result.stdout.strip() else []
+
+    def _scan_shards(self, sql, fail_msg):
+        """Iterate per-shard pages_NN.db with WT closed and return the first
+        non-empty JSON row from any shard, or self.fail() with fail_msg.
+        Reopens WT before returning."""
         self.close_conn()
+        try:
+            for shard in range(NUM_SHARDS):
+                db_path = os.path.join(self.home, 'kv_home', f'pages_{shard:02d}.db')
+                if not os.path.exists(db_path):
+                    continue
+                sqlite_exe = os.path.join(wt_builddir, 'sqlite3')
+                result = subprocess.run(
+                    [sqlite_exe, '-json', db_path, sql],
+                    capture_output=True, text=True, check=True)
+                if result.stdout.strip():
+                    return json.loads(result.stdout)[0]
+        finally:
+            self.reopen_conn()
+        self.fail(fail_msg)
+
+    def _pick_any_row(self):
+        """Returns (table_id, page_id, lsn) of any populated row."""
+        row = self._scan_shards(
+            'SELECT table_id, page_id, lsn FROM pages '
+            'ORDER BY table_id DESC, page_id ASC, lsn DESC LIMIT 1;',
+            'no rows found in any pages_NN.db')
+        return int(row['table_id']), int(row['page_id']), int(row['lsn'])
+
+    def _pick_multi_lsn_row(self):
+        """Returns (table_id, page_id) of any row with >= 2 LSNs."""
+        row = self._scan_shards(
+            'SELECT table_id, page_id, COUNT(*) AS n FROM pages '
+            'GROUP BY table_id, page_id HAVING n >= 2 '
+            'ORDER BY table_id DESC LIMIT 1;',
+            'no rows with >= 2 LSNs found in any pages_NN.db')
+        return int(row['table_id']), int(row['page_id'])
+
+    # ---- Write helpers (close WT, leave it closed) ----
+
+    def _palite_mutate(self, table_id, sql):
+        """Run sql via wt_builddir/sqlite3 against the shard DB for table_id.
+        Caller is responsible for closing WT first. Returns a list of
+        non-empty stdout lines."""
+        shard = get_shard_id(table_id)
+        db_path = os.path.join(self.home, 'kv_home', f'pages_{shard:02d}.db')
+        sqlite_exe = os.path.join(wt_builddir, 'sqlite3')
         result = subprocess.run(
             [sqlite_exe, '-bail', db_path],
             input=sql, capture_output=True, text=True, check=True)
         return [line for line in result.stdout.splitlines() if line != '']
 
-    def corrupt_page_image(self, table_id, page_id, lsn=None):
-        """Overwrite the first byte of page_data with 0xff for the row.
-        If lsn is None, target MAX(lsn) for (table_id, page_id).
-        Returns the lsn that was acted on. WT is left closed."""
-        table_id = int(table_id)
-        page_id = int(page_id)
-        if lsn is None:
-            lsn_expr = (f"(SELECT MAX(lsn) FROM pages "
-                        f"WHERE table_id={table_id} AND page_id={page_id})")
-        else:
-            lsn_expr = str(int(lsn))
+    def corrupt_random_page_image(self):
+        """Pick any populated page and overwrite its first byte with 0xff.
+        Returns (table_id, page_id, lsn)."""
+        table_id, page_id, lsn = self._pick_any_row()
+        self.close_conn()
         sql = (
-            f"SELECT {lsn_expr};\n"
             f"UPDATE pages SET page_data = x'ff' || substr(page_data, 2) "
-            f"WHERE table_id={table_id} AND page_id={page_id} AND lsn={lsn_expr};\n"
+            f"WHERE table_id={table_id} AND page_id={page_id} AND lsn={lsn};\n"
             f"SELECT changes();\n"
         )
         rows = self._palite_mutate(table_id, sql)
-        if len(rows) < 2 or rows[0] == '':
-            raise AssertionError(
-                f"no row for table_id={table_id}, page_id={page_id}, lsn={lsn}")
-        resolved_lsn = int(rows[0])
-        affected = int(rows[1])
-        if affected == 0:
-            raise AssertionError(
-                f"mutation affected 0 rows for table_id={table_id}, "
-                f"page_id={page_id}, lsn={lsn}")
-        return resolved_lsn
+        self._require_one_change(rows, table_id, page_id, lsn)
+        return table_id, page_id, lsn
 
-    def delete_page_image(self, table_id, page_id, lsn=None):
-        """DELETE the row from pages. Simulates a missing page.
-        If lsn is None, target MAX(lsn) for (table_id, page_id).
-        Returns the lsn that was acted on. WT is left closed."""
-        table_id = int(table_id)
-        page_id = int(page_id)
-        if lsn is None:
-            lsn_expr = (f"(SELECT MAX(lsn) FROM pages "
-                        f"WHERE table_id={table_id} AND page_id={page_id})")
-        else:
-            lsn_expr = str(int(lsn))
+    def delete_random_page_image(self):
+        """Pick any populated page and DELETE its row.
+        Returns (table_id, page_id, lsn)."""
+        table_id, page_id, lsn = self._pick_any_row()
+        self.close_conn()
         sql = (
-            f"SELECT {lsn_expr};\n"
             f"DELETE FROM pages "
-            f"WHERE table_id={table_id} AND page_id={page_id} AND lsn={lsn_expr};\n"
+            f"WHERE table_id={table_id} AND page_id={page_id} AND lsn={lsn};\n"
             f"SELECT changes();\n"
         )
         rows = self._palite_mutate(table_id, sql)
-        if len(rows) < 2 or rows[0] == '':
-            raise AssertionError(
-                f"no row for table_id={table_id}, page_id={page_id}, lsn={lsn}")
-        resolved_lsn = int(rows[0])
-        affected = int(rows[1])
-        if affected == 0:
-            raise AssertionError(
-                f"mutation affected 0 rows for table_id={table_id}, "
-                f"page_id={page_id}, lsn={lsn}")
-        return resolved_lsn
+        self._require_one_change(rows, table_id, page_id, lsn)
+        return table_id, page_id, lsn
 
-    def set_page_discarded(self, table_id, page_id, lsn=None):
-        """OR WT_PAGE_LOG_DISCARDED (0x10000) into flags.
-        If lsn is None, target MAX(lsn) for (table_id, page_id).
-        Returns the lsn that was acted on. WT is left closed."""
-        table_id = int(table_id)
-        page_id = int(page_id)
-        if lsn is None:
-            lsn_expr = (f"(SELECT MAX(lsn) FROM pages "
-                        f"WHERE table_id={table_id} AND page_id={page_id})")
-        else:
-            lsn_expr = str(int(lsn))
+    def set_random_page_discarded(self):
+        """Pick any populated page and OR WT_PAGE_LOG_DISCARDED into flags.
+        Returns (table_id, page_id, lsn)."""
+        table_id, page_id, lsn = self._pick_any_row()
+        self.close_conn()
         sql = (
-            f"SELECT {lsn_expr};\n"
             f"UPDATE pages SET flags = flags | {self.WT_PAGE_LOG_DISCARDED} "
-            f"WHERE table_id={table_id} AND page_id={page_id} AND lsn={lsn_expr};\n"
+            f"WHERE table_id={table_id} AND page_id={page_id} AND lsn={lsn};\n"
             f"SELECT changes();\n"
         )
         rows = self._palite_mutate(table_id, sql)
-        if len(rows) < 2 or rows[0] == '':
-            raise AssertionError(
-                f"no row for table_id={table_id}, page_id={page_id}, lsn={lsn}")
-        resolved_lsn = int(rows[0])
-        affected = int(rows[1])
-        if affected == 0:
-            raise AssertionError(
-                f"mutation affected 0 rows for table_id={table_id}, "
-                f"page_id={page_id}, lsn={lsn}")
-        return resolved_lsn
+        self._require_one_change(rows, table_id, page_id, lsn)
+        return table_id, page_id, lsn
 
-    def truncate_delta_chain(self, table_id, page_id, keep_lsns):
-        """DELETE every row for (table_id, page_id) whose lsn is not in
-        keep_lsns. keep_lsns is an iterable of ints. Returns the list of
-        LSNs that were deleted (sorted ascending); empty if no rows
-        matched or all existing rows are in keep_lsns. WT is left closed."""
-        table_id = int(table_id)
-        page_id = int(page_id)
-        keep_list = sorted({int(x) for x in keep_lsns})
-        if not keep_list:
-            raise AssertionError("keep_lsns must contain at least one LSN")
-        keep_clause = ", ".join(str(x) for x in keep_list)
+    def truncate_random_delta_chain(self):
+        """Pick a (table_id, page_id) with >= 2 LSNs and DELETE all but the
+        base (lowest) LSN. Returns (table_id, page_id, kept_lsn, deleted_lsns)."""
+        table_id, page_id = self._pick_multi_lsn_row()
+        all_lsns = sorted(int(r['lsn']) for r in self.sqlite_select_json(
+            table_id,
+            f'SELECT lsn FROM pages '
+            f'WHERE table_id={table_id} AND page_id={page_id};'))
+        kept_lsn = all_lsns[0]
+        deleted_lsns = all_lsns[1:]
+        self.close_conn()
         sql = (
-            f"SELECT GROUP_CONCAT(lsn) FROM pages "
-            f"WHERE table_id={table_id} AND page_id={page_id} "
-            f"AND lsn NOT IN ({keep_clause});\n"
             f"DELETE FROM pages "
             f"WHERE table_id={table_id} AND page_id={page_id} "
-            f"AND lsn NOT IN ({keep_clause});\n"
+            f"AND lsn != {kept_lsn};\n"
             f"SELECT changes();\n"
         )
         rows = self._palite_mutate(table_id, sql)
-        # When GROUP_CONCAT matches no rows it returns NULL; sqlite emits an
-        # empty line which _palite_mutate filters out. In that case rows[0] is
-        # changes() and len(rows)==1; otherwise rows[0] is the GROUP_CONCAT
-        # string and rows[1] is changes().
-        if len(rows) == 1:
-            deleted = []
-            affected = int(rows[0])
-        else:
-            deleted = [int(x) for x in rows[0].split(',') if x]
-            affected = int(rows[1])
-        if affected != len(deleted):
+        affected = int(rows[0])
+        if affected != len(deleted_lsns):
             raise AssertionError(
-                f"truncate_delta_chain mismatch: GROUP_CONCAT yielded "
-                f"{len(deleted)} LSNs but changes() reported {affected}")
-        return sorted(deleted)
+                f"truncate mismatch: expected to delete {len(deleted_lsns)} "
+                f"rows, sqlite reported {affected}")
+        return table_id, page_id, kept_lsn, deleted_lsns
+
+    @staticmethod
+    def _require_one_change(rows, table_id, page_id, lsn):
+        affected = int(rows[0])
+        if affected != 1:
+            raise AssertionError(
+                f"expected 1 affected row, got {affected} for "
+                f"table_id={table_id}, page_id={page_id}, lsn={lsn}")

--- a/test/suite/helpers/helper_disagg.py
+++ b/test/suite/helpers/helper_disagg.py
@@ -612,11 +612,16 @@ class DisaggCorruptionMixin:
             self.reopen_conn()
         self.fail(fail_msg)
 
-    def _pick_one_row(self):
+    def _pick_one_row(self, exclude_discarded=False):
         """Pick one row from the palite pages table across all shards.
-        Returns its (table_id, page_id, lsn)  i.e. one page image."""
+        If exclude_discarded is set, rows already marked
+        WT_PAGE_LOG_DISCARDED are skipped, guaranteeing the returned
+        image is still alive. Returns its (table_id, page_id, lsn)
+        i.e. one page image."""
+        where = (f'WHERE flags & {self.WT_PAGE_LOG_DISCARDED} = 0 '
+                 if exclude_discarded else '')
         row = self._scan_shards(
-            'SELECT table_id, page_id, lsn FROM pages '
+            f'SELECT table_id, page_id, lsn FROM pages {where}'
             'ORDER BY table_id DESC, page_id ASC, lsn DESC LIMIT 1;',
             'no rows found in any pages_NN.db')
         return int(row['table_id']), int(row['page_id']), int(row['lsn'])
@@ -678,12 +683,12 @@ class DisaggCorruptionMixin:
         return table_id, page_id, lsn
 
     def set_random_page_discarded(self):
-        """Pick one page image (one (page_id, lsn) row in the palite
-        pages table) and OR WT_PAGE_LOG_DISCARDED into its flags
-        column, marking that single image as a tombstone. Other images
-        in the same delta chain are untouched. Returns the (table_id,
-        page_id, lsn) of the modified image."""
-        table_id, page_id, lsn = self._pick_one_row()
+        """Pick one not-yet-discarded page image (one (page_id, lsn) row
+        in the palite pages table) and OR WT_PAGE_LOG_DISCARDED into its
+        flags column, marking that single image as a tombstone. Other
+        images in the same delta chain are untouched. Returns the
+        (table_id, page_id, lsn) of the modified image."""
+        table_id, page_id, lsn = self._pick_one_row(exclude_discarded=True)
         self.close_conn()
         sql = (
             f"UPDATE pages SET flags = flags | {self.WT_PAGE_LOG_DISCARDED} "

--- a/test/suite/helpers/helper_disagg.py
+++ b/test/suite/helpers/helper_disagg.py
@@ -69,10 +69,11 @@ def disagg_ignore_expected_output(testcase):
 # Several tests access pages data directly by table id.
 # This function computes the shard id for a given table id, which is needed to
 # find the right database file in kv_home directory.
+# See Storage.NUM_SHARDS in ext/page_log/palite/palite.cpp.
+# This must be kept in sync with that value.
+NUM_SHARDS = 17
+
 def get_shard_id(table_id):
-    # See Storage.NUM_SHARDS in ext/page_log/palite/palite.cpp.
-    # This must be kept in sync with that value.
-    NUM_SHARDS = 17
     return int(table_id) % NUM_SHARDS
 
 # A decorator for a disaggregated test class, that ignores verbose warnings about RTS at shutdown.

--- a/test/suite/helpers/helper_disagg.py
+++ b/test/suite/helpers/helper_disagg.py
@@ -560,13 +560,14 @@ class Oplog(object):
 
 # DisaggCorruptionMixin provides Python helpers for injecting palite-level page
 # corruption into a running disaggregated-storage test. Each public method closes
-# the WT connection, mutates the relevant per-shard pages_NN.db via the bundled
-# sqlite3 binary, and reopens the connection.
+# the WT connection and mutates the relevant per-shard pages_NN.db via the
+# bundled sqlite3 binary; WT is left closed since corruption may prevent it
+# from reopening. Tests can read post-state via direct sqlite3 queries.
 #
 # Palite holds an exclusive SQLite lock while WT is open, so writes must happen
 # while the connection is closed. The mutations go through wt_builddir/sqlite3
 # (not system sqlite3) to avoid version skew with the SQLite statically linked
-# into palite. See WT-17667.
+# into palite.
 class DisaggCorruptionMixin:
 
     # Mirrors WT_PAGE_LOG_DISCARDED in src/include/page_log.h. The value is

--- a/test/suite/helpers/helper_disagg.py
+++ b/test/suite/helpers/helper_disagg.py
@@ -597,12 +597,12 @@ class DisaggCorruptionMixin:
         non-empty JSON row from any shard, or self.fail() with fail_msg.
         Reopens WT before returning."""
         self.close_conn()
+        sqlite_exe = os.path.join(wt_builddir, 'sqlite3')
         try:
             for shard in range(NUM_SHARDS):
                 db_path = os.path.join(self.home, 'kv_home', f'pages_{shard:02d}.db')
                 if not os.path.exists(db_path):
                     continue
-                sqlite_exe = os.path.join(wt_builddir, 'sqlite3')
                 result = subprocess.run(
                     [sqlite_exe, '-json', db_path, sql],
                     capture_output=True, text=True, check=True)

--- a/test/suite/helpers/helper_disagg.py
+++ b/test/suite/helpers/helper_disagg.py
@@ -562,6 +562,12 @@ class Oplog(object):
 # corruption into a running disaggregated-storage test by directly mutating the
 # per-shard pages_NN.db files.
 #
+# Palite stores each saved page image as one row in the `pages` table, keyed by
+# (table_id, page_id, lsn). A single logical page (table_id, page_id) can have
+# many rows: a base image plus successive deltas, forming a delta chain. The
+# corruption helpers below operate on one row of that table at a time, i.e.
+# they damage a single page image at a specific LSN unless noted otherwise.
+#
 # Palite holds an exclusive SQLite lock while WT is open, so writes (and the
 # multi-shard scan that picks a victim row) must happen while the connection
 # is closed. The mutations go through wt_builddir/sqlite3 (not system sqlite3)
@@ -572,7 +578,7 @@ class DisaggCorruptionMixin:
     # static-asserted in ext/page_log/palite/palite.cpp.
     WT_PAGE_LOG_DISCARDED = 0x10000
 
-    # ---- Read helpers (WT may be open or closed) ----
+    # ---- Read helpers ----
 
     def sqlite_select_json(self, table_id, sql_query):
         """Read rows from the pages_NN.db for table_id's shard. Palite uses
@@ -607,7 +613,8 @@ class DisaggCorruptionMixin:
         self.fail(fail_msg)
 
     def _pick_any_row(self):
-        """Returns (table_id, page_id, lsn) of any populated row."""
+        """Pick one row from the palite pages table across all shards.
+        Returns its (table_id, page_id, lsn) — i.e. one page image."""
         row = self._scan_shards(
             'SELECT table_id, page_id, lsn FROM pages '
             'ORDER BY table_id DESC, page_id ASC, lsn DESC LIMIT 1;',
@@ -615,7 +622,9 @@ class DisaggCorruptionMixin:
         return int(row['table_id']), int(row['page_id']), int(row['lsn'])
 
     def _pick_multi_lsn_row(self):
-        """Returns (table_id, page_id) of any row with >= 2 LSNs."""
+        """Pick one logical page (table_id, page_id) whose delta chain
+        has >= 2 LSNs in the palite pages table. Returns (table_id,
+        page_id) — the per-LSN rows can then be queried separately."""
         row = self._scan_shards(
             'SELECT table_id, page_id, COUNT(*) AS n FROM pages '
             'GROUP BY table_id, page_id HAVING n >= 2 '
@@ -623,12 +632,11 @@ class DisaggCorruptionMixin:
             'no rows with >= 2 LSNs found in any pages_NN.db')
         return int(row['table_id']), int(row['page_id'])
 
-    # ---- Write helpers (close WT, leave it closed) ----
+    # ---- Write helpers ----
 
     def _palite_mutate(self, table_id, sql):
-        """Run sql via wt_builddir/sqlite3 against the shard DB for table_id.
-        Caller is responsible for closing WT first. Returns a list of
-        non-empty stdout lines."""
+        """Run sql against the pages_NN.db for table_id's shard. Returns the
+        sqlite3 CLI's stdout split into non-empty lines."""
         shard = get_shard_id(table_id)
         db_path = os.path.join(self.home, 'kv_home', f'pages_{shard:02d}.db')
         sqlite_exe = os.path.join(wt_builddir, 'sqlite3')
@@ -638,8 +646,10 @@ class DisaggCorruptionMixin:
         return [line for line in result.stdout.splitlines() if line != '']
 
     def corrupt_random_page_image(self):
-        """Pick any populated page and overwrite its first byte with 0xff.
-        Returns (table_id, page_id, lsn)."""
+        """Pick one page image (one (page_id, lsn) row in the palite
+        pages table) and overwrite the first byte of its stored data
+        with 0xff. Other images in the same delta chain are untouched.
+        Returns the (table_id, page_id, lsn) of the corrupted image."""
         table_id, page_id, lsn = self._pick_any_row()
         self.close_conn()
         sql = (
@@ -652,8 +662,10 @@ class DisaggCorruptionMixin:
         return table_id, page_id, lsn
 
     def delete_random_page_image(self):
-        """Pick any populated page and DELETE its row.
-        Returns (table_id, page_id, lsn)."""
+        """Pick one page image (one (page_id, lsn) row in the palite
+        pages table) and DELETE it. Other images in the same delta
+        chain are untouched. Returns the (table_id, page_id, lsn) of
+        the deleted image."""
         table_id, page_id, lsn = self._pick_any_row()
         self.close_conn()
         sql = (
@@ -666,8 +678,11 @@ class DisaggCorruptionMixin:
         return table_id, page_id, lsn
 
     def set_random_page_discarded(self):
-        """Pick any populated page and OR WT_PAGE_LOG_DISCARDED into flags.
-        Returns (table_id, page_id, lsn)."""
+        """Pick one page image (one (page_id, lsn) row in the palite
+        pages table) and OR WT_PAGE_LOG_DISCARDED into its flags
+        column, marking that single image as a tombstone. Other images
+        in the same delta chain are untouched. Returns the (table_id,
+        page_id, lsn) of the modified image."""
         table_id, page_id, lsn = self._pick_any_row()
         self.close_conn()
         sql = (
@@ -680,8 +695,10 @@ class DisaggCorruptionMixin:
         return table_id, page_id, lsn
 
     def truncate_random_delta_chain(self):
-        """Pick a (table_id, page_id) with >= 2 LSNs and DELETE all but the
-        base (lowest) LSN. Returns (table_id, page_id, kept_lsn, deleted_lsns)."""
+        """Pick a logical page (table_id, page_id) whose delta chain has
+        >= 2 LSNs and DELETE every image except the base (lowest LSN),
+        leaving the base image as the only row for that page. Returns
+        (table_id, page_id, kept_lsn, deleted_lsns)."""
         table_id, page_id = self._pick_multi_lsn_row()
         all_lsns = sorted(int(r['lsn']) for r in self.sqlite_select_json(
             table_id,

--- a/test/suite/helpers/helper_disagg.py
+++ b/test/suite/helpers/helper_disagg.py
@@ -616,3 +616,32 @@ class DisaggCorruptionMixin:
                 f"mutation affected 0 rows for table_id={table_id}, "
                 f"page_id={page_id}, lsn={lsn}")
         return resolved_lsn
+
+    def delete_page_image(self, table_id, page_id, lsn=None):
+        """DELETE the row from pages. Simulates a missing page.
+        If lsn is None, target MAX(lsn) for (table_id, page_id).
+        Returns the lsn that was acted on."""
+        table_id = int(table_id)
+        page_id = int(page_id)
+        if lsn is None:
+            lsn_expr = (f"(SELECT MAX(lsn) FROM pages "
+                        f"WHERE table_id={table_id} AND page_id={page_id})")
+        else:
+            lsn_expr = str(int(lsn))
+        sql = (
+            f"SELECT {lsn_expr};\n"
+            f"DELETE FROM pages "
+            f"WHERE table_id={table_id} AND page_id={page_id} AND lsn={lsn_expr};\n"
+            f"SELECT changes();\n"
+        )
+        rows = self._palite_mutate(table_id, sql)
+        if len(rows) < 2 or rows[0] == '':
+            raise AssertionError(
+                f"no row for table_id={table_id}, page_id={page_id}, lsn={lsn}")
+        resolved_lsn = int(rows[0])
+        affected = int(rows[1])
+        if affected == 0:
+            raise AssertionError(
+                f"mutation affected 0 rows for table_id={table_id}, "
+                f"page_id={page_id}, lsn={lsn}")
+        return resolved_lsn

--- a/test/suite/helpers/helper_disagg.py
+++ b/test/suite/helpers/helper_disagg.py
@@ -575,17 +575,44 @@ class DisaggCorruptionMixin:
 
     def _palite_mutate(self, table_id, sql):
         """Close WT, run sql via wt_builddir/sqlite3 against the shard DB for
-        table_id, reopen WT. Returns a list of non-empty stdout lines."""
+        table_id. Leaves WT closed - corruption helpers may make WT unable to
+        reopen. Returns a list of non-empty stdout lines."""
         shard = get_shard_id(table_id)
         db_path = os.path.join(self.home, 'kv_home', f'pages_{shard:02d}.db')
         if not os.path.exists(db_path):
             raise FileNotFoundError(db_path)
         sqlite_exe = os.path.join(wt_builddir, 'sqlite3')
         self.close_conn()
-        try:
-            result = subprocess.run(
-                [sqlite_exe, '-bail', db_path],
-                input=sql, capture_output=True, text=True, check=True)
-        finally:
-            self.reopen_conn()
+        result = subprocess.run(
+            [sqlite_exe, '-bail', db_path],
+            input=sql, capture_output=True, text=True, check=True)
         return [line for line in result.stdout.splitlines() if line != '']
+
+    def corrupt_page_image(self, table_id, page_id, lsn=None):
+        """Overwrite the first byte of page_data with 0xff for the row.
+        If lsn is None, target MAX(lsn) for (table_id, page_id).
+        Returns the lsn that was acted on."""
+        table_id = int(table_id)
+        page_id = int(page_id)
+        if lsn is None:
+            lsn_expr = (f"(SELECT MAX(lsn) FROM pages "
+                        f"WHERE table_id={table_id} AND page_id={page_id})")
+        else:
+            lsn_expr = str(int(lsn))
+        sql = (
+            f"SELECT {lsn_expr};\n"
+            f"UPDATE pages SET page_data = x'ff' || substr(page_data, 2) "
+            f"WHERE table_id={table_id} AND page_id={page_id} AND lsn={lsn_expr};\n"
+            f"SELECT changes();\n"
+        )
+        rows = self._palite_mutate(table_id, sql)
+        if len(rows) < 2 or rows[0] == '':
+            raise AssertionError(
+                f"no row for table_id={table_id}, page_id={page_id}, lsn={lsn}")
+        resolved_lsn = int(rows[0])
+        affected = int(rows[1])
+        if affected == 0:
+            raise AssertionError(
+                f"mutation affected 0 rows for table_id={table_id}, "
+                f"page_id={page_id}, lsn={lsn}")
+        return resolved_lsn

--- a/test/suite/helpers/helper_disagg.py
+++ b/test/suite/helpers/helper_disagg.py
@@ -28,7 +28,8 @@
 #
 
 import wiredtiger
-import functools, os, shutil, wttest
+import functools, os, shutil, subprocess, wttest
+from run import wt_builddir
 
 # These routines help run the various page log sources used by disaggregated storage.
 # They are required to manage the generation of disaggregated storage specific configurations.
@@ -555,3 +556,35 @@ class Oplog(object):
             f' entries - list of (table,k,v)={self._entries},' + \
             f' uris - list of (uri, entlist)={self._uris},' + \
             f' lookup - (table,k) -> list of (ts,value)={self._lookup}'
+
+# DisaggCorruptionMixin provides Python helpers for injecting palite-level page
+# corruption into a running disaggregated-storage test. Each public method closes
+# the WT connection, mutates the relevant per-shard pages_NN.db via the bundled
+# sqlite3 binary, and reopens the connection.
+#
+# Palite holds an exclusive SQLite lock while WT is open, so writes must happen
+# while the connection is closed. The mutations go through wt_builddir/sqlite3
+# (not system sqlite3) to avoid version skew with the SQLite statically linked
+# into palite. See WT-17667.
+class DisaggCorruptionMixin:
+
+    # Mirrors WT_PAGE_LOG_DISCARDED in src/include/page_log.h. The value is
+    # static-asserted in ext/page_log/palite/palite.cpp.
+    WT_PAGE_LOG_DISCARDED = 0x10000
+
+    def _palite_mutate(self, table_id, sql):
+        """Close WT, run sql via wt_builddir/sqlite3 against the shard DB for
+        table_id, reopen WT. Returns a list of non-empty stdout lines."""
+        shard = get_shard_id(table_id)
+        db_path = os.path.join(self.home, 'kv_home', f'pages_{shard:02d}.db')
+        if not os.path.exists(db_path):
+            raise FileNotFoundError(db_path)
+        sqlite_exe = os.path.join(wt_builddir, 'sqlite3')
+        self.close_conn()
+        try:
+            result = subprocess.run(
+                [sqlite_exe, '-bail', db_path],
+                input=sql, capture_output=True, text=True, check=True)
+        finally:
+            self.reopen_conn()
+        return [line for line in result.stdout.splitlines() if line != '']

--- a/test/suite/helpers/helper_disagg.py
+++ b/test/suite/helpers/helper_disagg.py
@@ -614,7 +614,7 @@ class DisaggCorruptionMixin:
 
     def _pick_any_row(self):
         """Pick one row from the palite pages table across all shards.
-        Returns its (table_id, page_id, lsn) — i.e. one page image."""
+        Returns its (table_id, page_id, lsn)  i.e. one page image."""
         row = self._scan_shards(
             'SELECT table_id, page_id, lsn FROM pages '
             'ORDER BY table_id DESC, page_id ASC, lsn DESC LIMIT 1;',
@@ -624,7 +624,7 @@ class DisaggCorruptionMixin:
     def _pick_multi_lsn_row(self):
         """Pick one logical page (table_id, page_id) whose delta chain
         has >= 2 LSNs in the palite pages table. Returns (table_id,
-        page_id) — the per-LSN rows can then be queried separately."""
+        page_id)  the per-LSN rows can then be queried separately."""
         row = self._scan_shards(
             'SELECT table_id, page_id, COUNT(*) AS n FROM pages '
             'GROUP BY table_id, page_id HAVING n >= 2 '

--- a/test/suite/helpers/helper_disagg.py
+++ b/test/suite/helpers/helper_disagg.py
@@ -612,7 +612,7 @@ class DisaggCorruptionMixin:
             self.reopen_conn()
         self.fail(fail_msg)
 
-    def _pick_any_row(self):
+    def _pick_one_row(self):
         """Pick one row from the palite pages table across all shards.
         Returns its (table_id, page_id, lsn)  i.e. one page image."""
         row = self._scan_shards(
@@ -650,7 +650,7 @@ class DisaggCorruptionMixin:
         pages table) and overwrite the first byte of its stored data
         with 0xff. Other images in the same delta chain are untouched.
         Returns the (table_id, page_id, lsn) of the corrupted image."""
-        table_id, page_id, lsn = self._pick_any_row()
+        table_id, page_id, lsn = self._pick_one_row()
         self.close_conn()
         sql = (
             f"UPDATE pages SET page_data = x'ff' || substr(page_data, 2) "
@@ -666,7 +666,7 @@ class DisaggCorruptionMixin:
         pages table) and DELETE it. Other images in the same delta
         chain are untouched. Returns the (table_id, page_id, lsn) of
         the deleted image."""
-        table_id, page_id, lsn = self._pick_any_row()
+        table_id, page_id, lsn = self._pick_one_row()
         self.close_conn()
         sql = (
             f"DELETE FROM pages "
@@ -683,7 +683,7 @@ class DisaggCorruptionMixin:
         column, marking that single image as a tombstone. Other images
         in the same delta chain are untouched. Returns the (table_id,
         page_id, lsn) of the modified image."""
-        table_id, page_id, lsn = self._pick_any_row()
+        table_id, page_id, lsn = self._pick_one_row()
         self.close_conn()
         sql = (
             f"UPDATE pages SET flags = flags | {self.WT_PAGE_LOG_DISCARDED} "

--- a/test/suite/helpers/helper_disagg.py
+++ b/test/suite/helpers/helper_disagg.py
@@ -674,3 +674,39 @@ class DisaggCorruptionMixin:
                 f"mutation affected 0 rows for table_id={table_id}, "
                 f"page_id={page_id}, lsn={lsn}")
         return resolved_lsn
+
+    def truncate_delta_chain(self, table_id, page_id, keep_lsns):
+        """DELETE every row for (table_id, page_id) whose lsn is not in
+        keep_lsns. keep_lsns is an iterable of ints. Returns the list of
+        LSNs that were deleted (sorted ascending)."""
+        table_id = int(table_id)
+        page_id = int(page_id)
+        keep_list = sorted({int(x) for x in keep_lsns})
+        if not keep_list:
+            raise AssertionError("keep_lsns must contain at least one LSN")
+        keep_clause = ", ".join(str(x) for x in keep_list)
+        sql = (
+            f"SELECT GROUP_CONCAT(lsn) FROM pages "
+            f"WHERE table_id={table_id} AND page_id={page_id} "
+            f"AND lsn NOT IN ({keep_clause});\n"
+            f"DELETE FROM pages "
+            f"WHERE table_id={table_id} AND page_id={page_id} "
+            f"AND lsn NOT IN ({keep_clause});\n"
+            f"SELECT changes();\n"
+        )
+        rows = self._palite_mutate(table_id, sql)
+        # When GROUP_CONCAT matches no rows it returns NULL; sqlite emits an
+        # empty line which _palite_mutate filters out. In that case rows[0] is
+        # changes() and len(rows)==1; otherwise rows[0] is the GROUP_CONCAT
+        # string and rows[1] is changes().
+        if len(rows) == 1:
+            deleted = []
+            affected = int(rows[0])
+        else:
+            deleted = [int(x) for x in rows[0].split(',') if x]
+            affected = int(rows[1])
+        if affected != len(deleted):
+            raise AssertionError(
+                f"truncate_delta_chain mismatch: GROUP_CONCAT yielded "
+                f"{len(deleted)} LSNs but changes() reported {affected}")
+        return sorted(deleted)

--- a/test/suite/helpers/helper_disagg.py
+++ b/test/suite/helpers/helper_disagg.py
@@ -645,3 +645,32 @@ class DisaggCorruptionMixin:
                 f"mutation affected 0 rows for table_id={table_id}, "
                 f"page_id={page_id}, lsn={lsn}")
         return resolved_lsn
+
+    def set_page_discarded(self, table_id, page_id, lsn=None):
+        """OR WT_PAGE_LOG_DISCARDED (0x10000) into flags.
+        If lsn is None, target MAX(lsn) for (table_id, page_id).
+        Returns the lsn that was acted on."""
+        table_id = int(table_id)
+        page_id = int(page_id)
+        if lsn is None:
+            lsn_expr = (f"(SELECT MAX(lsn) FROM pages "
+                        f"WHERE table_id={table_id} AND page_id={page_id})")
+        else:
+            lsn_expr = str(int(lsn))
+        sql = (
+            f"SELECT {lsn_expr};\n"
+            f"UPDATE pages SET flags = flags | {self.WT_PAGE_LOG_DISCARDED} "
+            f"WHERE table_id={table_id} AND page_id={page_id} AND lsn={lsn_expr};\n"
+            f"SELECT changes();\n"
+        )
+        rows = self._palite_mutate(table_id, sql)
+        if len(rows) < 2 or rows[0] == '':
+            raise AssertionError(
+                f"no row for table_id={table_id}, page_id={page_id}, lsn={lsn}")
+        resolved_lsn = int(rows[0])
+        affected = int(rows[1])
+        if affected == 0:
+            raise AssertionError(
+                f"mutation affected 0 rows for table_id={table_id}, "
+                f"page_id={page_id}, lsn={lsn}")
+        return resolved_lsn

--- a/test/suite/helpers/helper_disagg.py
+++ b/test/suite/helpers/helper_disagg.py
@@ -592,7 +592,7 @@ class DisaggCorruptionMixin:
     def corrupt_page_image(self, table_id, page_id, lsn=None):
         """Overwrite the first byte of page_data with 0xff for the row.
         If lsn is None, target MAX(lsn) for (table_id, page_id).
-        Returns the lsn that was acted on."""
+        Returns the lsn that was acted on. WT is left closed."""
         table_id = int(table_id)
         page_id = int(page_id)
         if lsn is None:
@@ -621,7 +621,7 @@ class DisaggCorruptionMixin:
     def delete_page_image(self, table_id, page_id, lsn=None):
         """DELETE the row from pages. Simulates a missing page.
         If lsn is None, target MAX(lsn) for (table_id, page_id).
-        Returns the lsn that was acted on."""
+        Returns the lsn that was acted on. WT is left closed."""
         table_id = int(table_id)
         page_id = int(page_id)
         if lsn is None:
@@ -650,7 +650,7 @@ class DisaggCorruptionMixin:
     def set_page_discarded(self, table_id, page_id, lsn=None):
         """OR WT_PAGE_LOG_DISCARDED (0x10000) into flags.
         If lsn is None, target MAX(lsn) for (table_id, page_id).
-        Returns the lsn that was acted on."""
+        Returns the lsn that was acted on. WT is left closed."""
         table_id = int(table_id)
         page_id = int(page_id)
         if lsn is None:
@@ -679,7 +679,8 @@ class DisaggCorruptionMixin:
     def truncate_delta_chain(self, table_id, page_id, keep_lsns):
         """DELETE every row for (table_id, page_id) whose lsn is not in
         keep_lsns. keep_lsns is an iterable of ints. Returns the list of
-        LSNs that were deleted (sorted ascending)."""
+        LSNs that were deleted (sorted ascending); empty if no rows
+        matched or all existing rows are in keep_lsns. WT is left closed."""
         table_id = int(table_id)
         page_id = int(page_id)
         keep_list = sorted({int(x) for x in keep_lsns})

--- a/test/suite/test_disagg_corruption_mixin.py
+++ b/test/suite/test_disagg_corruption_mixin.py
@@ -224,5 +224,21 @@ class test_disagg_corruption_mixin(wttest.WiredTigerTestCase, DisaggCorruptionMi
             f'WHERE table_id={int(table_id)} AND page_id={int(page_id)} ORDER BY lsn;')]
         self.assertEqual(remaining, keep)
 
+    def test_corrupt_no_match_raises(self):
+        if self.ds_name != 'palite':
+            self.skipTest('palite-only test')
+        self._populate()
+        bogus_page_id = 999_999
+
+        # Pick a (table_id, page_id) we know does not exist. Use a real shard
+        # with a bogus table_id so the pages_NN.db file exists - otherwise we'd
+        # get FileNotFoundError instead of AssertionError. Shift by NUM_SHARDS
+        # rows so the bogus table_id falls in the same shard as a known row.
+        real_table_id, _, _ = self._pick_any_row()
+        bogus_table_id = real_table_id + (NUM_SHARDS * 1000)
+
+        with self.assertRaisesRegex(AssertionError, 'no row'):
+            self.corrupt_page_image(bogus_table_id, bogus_page_id)
+
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_disagg_corruption_mixin.py
+++ b/test/suite/test_disagg_corruption_mixin.py
@@ -26,12 +26,8 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import json, os, subprocess, wttest
-from run import wt_builddir
-from helper_disagg import (
-    DisaggConfigMixin, DisaggCorruptionMixin, disagg_test_class,
-    gen_disagg_storages, get_shard_id, NUM_SHARDS,
-)
+import wttest
+from helper_disagg import DisaggCorruptionMixin, disagg_test_class, gen_disagg_storages
 from wtscenario import make_scenarios
 
 # test_disagg_corruption_mixin.py
@@ -39,9 +35,8 @@ from wtscenario import make_scenarios
 #    disaggregated database.
 @disagg_test_class
 class test_disagg_corruption_mixin(wttest.WiredTigerTestCase, DisaggCorruptionMixin):
-    conn_base_config = ',create,statistics=(all),'
     def conn_config(self):
-        return self.extensionsConfig() + self.conn_base_config + 'disaggregated=(role="leader")'
+        return self.extensionsConfig() + ',create,disaggregated=(role="leader")'
 
     disagg_storages = gen_disagg_storages('test_disagg_corruption_mixin', disagg_only=True)
     scenarios = make_scenarios(disagg_storages)
@@ -49,10 +44,6 @@ class test_disagg_corruption_mixin(wttest.WiredTigerTestCase, DisaggCorruptionMi
     uri = 'layered:test_corruption_mixin'
     nentries = 10
 
-    def conn_extensions(self, extlist):
-        DisaggConfigMixin.conn_extensions(self, extlist)
-
-    # Populate the table and force palite to flush pages by checkpointing.
     def _populate(self):
         self.session.create(self.uri, 'key_format=S,value_format=S')
         c = self.session.open_cursor(self.uri, None, None)
@@ -61,122 +52,45 @@ class test_disagg_corruption_mixin(wttest.WiredTigerTestCase, DisaggCorruptionMi
         c.close()
         self.session.checkpoint()
 
-    # Read rows directly from the per-shard pages DB. Palite uses shared SQLite
-    # locks for readers, so this is safe to call whether the WT connection is
-    # open or closed.
-    def _sqlite_select_json(self, table_id, sql_query):
-        shard = get_shard_id(table_id)
-        db_path = os.path.join(self.home, 'kv_home', f'pages_{shard:02d}.db')
-        sqlite_exe = os.path.join(wt_builddir, 'sqlite3')
-        result = subprocess.run(
-            [sqlite_exe, '-json', db_path, sql_query],
-            capture_output=True, text=True, check=True)
-        return json.loads(result.stdout) if result.stdout.strip() else []
-
-    # Find any populated (table_id, page_id) pair from the pages DB by scanning
-    # all shards. Returns (table_id, page_id, lsn). Requires the WT connection
-    # to be closed. Used by individual test_* methods to pick a victim row.
-    def _pick_any_row(self):
-        self.close_conn()
-        try:
-            for shard in range(NUM_SHARDS):
-                db_path = os.path.join(self.home, 'kv_home', f'pages_{shard:02d}.db')
-                if not os.path.exists(db_path):
-                    continue
-                sqlite_exe = os.path.join(wt_builddir, 'sqlite3')
-                result = subprocess.run(
-                    [sqlite_exe, '-json', db_path,
-                     'SELECT table_id, page_id, lsn FROM pages '
-                     'ORDER BY table_id DESC, page_id ASC, lsn DESC LIMIT 1;'],
-                    capture_output=True, text=True, check=True)
-                if result.stdout.strip():
-                    row = json.loads(result.stdout)[0]
-                    return int(row['table_id']), int(row['page_id']), int(row['lsn'])
-        finally:
-            self.reopen_conn()
-        self.fail("no rows found in any pages_NN.db after populate")
-
-    # Smoke test: populate, find at least one row via sqlite, then confirm we
-    # can also read sqlite while the WT connection is open (per-method helpers
-    # rely on this, but only do reads *after* their reopen_conn; verify here so
-    # a SQLITE_BUSY surface is caught at smoke-test time, not in Task 3).
-    def test_populate_produces_palite_rows(self):
+    def test_corrupt_random_page_image(self):
         if self.ds_name != 'palite':
             self.skipTest('palite-only test')
         self._populate()
-        table_id, page_id, lsn = self._pick_any_row()
-        self.assertGreater(table_id, 0)
-        self.assertGreaterEqual(lsn, 0)
-        # WT connection is reopen after _pick_any_row. Read again now to prove
-        # palite doesn't block readers via its exclusive lock.
-        rows = self._sqlite_select_json(table_id,
-            f'SELECT COUNT(*) AS n FROM pages WHERE table_id={int(table_id)};')
-        self.assertGreater(rows[0]['n'], 0)
-
-    def test_corrupt_page_image(self):
-        if self.ds_name != 'palite':
-            self.skipTest('palite-only test')
-        self._populate()
-        table_id, page_id, lsn = self._pick_any_row()
-
-        # Capture the original first byte of page_data via sqlite hex().
-        before = self._sqlite_select_json(table_id,
+        table_id, page_id, lsn = self.corrupt_random_page_image()
+        after = self.sqlite_select_json(table_id,
             f'SELECT hex(substr(page_data, 1, 1)) AS first FROM pages '
-            f'WHERE table_id={int(table_id)} AND page_id={int(page_id)} AND lsn={int(lsn)};')
-        self.assertEqual(len(before), 1)
-
-        # Mutate. Helper closes WT and leaves it closed; sqlite reads below
-        # work either way.
-        returned_lsn = self.corrupt_page_image(table_id, page_id)
-        self.assertEqual(returned_lsn, lsn)
-
-        # Confirm the first byte is now 0xff.
-        after = self._sqlite_select_json(table_id,
-            f'SELECT hex(substr(page_data, 1, 1)) AS first FROM pages '
-            f'WHERE table_id={int(table_id)} AND page_id={int(page_id)} AND lsn={int(lsn)};')
+            f'WHERE table_id={table_id} AND page_id={page_id} AND lsn={lsn};')
         self.assertEqual(after[0]['first'], 'FF')
 
-    def test_delete_page_image(self):
+    def test_delete_random_page_image(self):
         if self.ds_name != 'palite':
             self.skipTest('palite-only test')
         self._populate()
-        table_id, page_id, lsn = self._pick_any_row()
-
-        returned_lsn = self.delete_page_image(table_id, page_id)
-        self.assertEqual(returned_lsn, lsn)
-
-        # The row should be gone.
-        after = self._sqlite_select_json(table_id,
+        table_id, page_id, lsn = self.delete_random_page_image()
+        after = self.sqlite_select_json(table_id,
             f'SELECT COUNT(*) AS n FROM pages '
-            f'WHERE table_id={int(table_id)} AND page_id={int(page_id)} AND lsn={int(lsn)};')
+            f'WHERE table_id={table_id} AND page_id={page_id} AND lsn={lsn};')
         self.assertEqual(after[0]['n'], 0)
 
-    def test_set_page_discarded(self):
+    def test_set_random_page_discarded(self):
         if self.ds_name != 'palite':
             self.skipTest('palite-only test')
         self._populate()
-        table_id, page_id, lsn = self._pick_any_row()
-
-        # The row should not be discarded yet.
-        before = self._sqlite_select_json(table_id,
-            f'SELECT discarded FROM pages '
-            f'WHERE table_id={int(table_id)} AND page_id={int(page_id)} AND lsn={int(lsn)};')
-        self.assertEqual(before[0]['discarded'], 0)
-
-        returned_lsn = self.set_page_discarded(table_id, page_id)
-        self.assertEqual(returned_lsn, lsn)
-
-        after = self._sqlite_select_json(table_id,
+        table_id, page_id, lsn = self.set_random_page_discarded()
+        mask = DisaggCorruptionMixin.WT_PAGE_LOG_DISCARDED
+        after = self.sqlite_select_json(table_id,
             f'SELECT discarded, flags FROM pages '
-            f'WHERE table_id={int(table_id)} AND page_id={int(page_id)} AND lsn={int(lsn)};')
+            f'WHERE table_id={table_id} AND page_id={page_id} AND lsn={lsn};')
         self.assertEqual(after[0]['discarded'], 1)
-        self.assertTrue(int(after[0]['flags']) & DisaggCorruptionMixin.WT_PAGE_LOG_DISCARDED)
+        self.assertEqual(int(after[0]['flags']) & mask, mask)
 
-    # Force more than one LSN per (table_id, page_id) by repeatedly modifying
-    # and checkpointing. Returns (table_id, page_id) of a row with at least
-    # two LSNs.
-    def _populate_with_multi_lsn(self):
+    def test_truncate_random_delta_chain(self):
+        if self.ds_name != 'palite':
+            self.skipTest('palite-only test')
         self._populate()
+        # Each extra round of (modify + checkpoint) adds another LSN row for
+        # the same (table_id, page_id), giving _pick_multi_lsn_row something
+        # to find.
         for round in range(5):
             c = self.session.open_cursor(self.uri, None, None)
             for i in range(self.nentries):
@@ -184,61 +98,9 @@ class test_disagg_corruption_mixin(wttest.WiredTigerTestCase, DisaggCorruptionMi
             c.close()
             self.session.checkpoint()
 
-        # Find a (table_id, page_id) that has >= 2 LSN rows.
-        self.close_conn()
-        try:
-            for shard in range(NUM_SHARDS):
-                db_path = os.path.join(self.home, 'kv_home', f'pages_{shard:02d}.db')
-                if not os.path.exists(db_path):
-                    continue
-                sqlite_exe = os.path.join(wt_builddir, 'sqlite3')
-                result = subprocess.run(
-                    [sqlite_exe, '-json', db_path,
-                     'SELECT table_id, page_id, COUNT(*) AS n FROM pages '
-                     'GROUP BY table_id, page_id HAVING n >= 2 '
-                     'ORDER BY table_id DESC LIMIT 1;'],
-                    capture_output=True, text=True, check=True)
-                if result.stdout.strip():
-                    row = json.loads(result.stdout)[0]
-                    return int(row['table_id']), int(row['page_id'])
-        finally:
-            self.reopen_conn()
-        self.fail("could not produce a (table_id, page_id) with multiple LSNs")
-
-    def test_truncate_delta_chain(self):
-        if self.ds_name != 'palite':
-            self.skipTest('palite-only test')
-        table_id, page_id = self._populate_with_multi_lsn()
-
-        all_lsns = [int(r['lsn']) for r in self._sqlite_select_json(table_id,
+        table_id, page_id, kept_lsn, deleted_lsns = self.truncate_random_delta_chain()
+        self.assertGreaterEqual(len(deleted_lsns), 1)
+        remaining = [int(r['lsn']) for r in self.sqlite_select_json(table_id,
             f'SELECT lsn FROM pages '
-            f'WHERE table_id={int(table_id)} AND page_id={int(page_id)} ORDER BY lsn;')]
-        self.assertGreaterEqual(len(all_lsns), 2)
-
-        keep = [all_lsns[0]]  # keep only the base
-        deleted = self.truncate_delta_chain(table_id, page_id, keep)
-        self.assertEqual(sorted(deleted), sorted(all_lsns[1:]))
-
-        remaining = [int(r['lsn']) for r in self._sqlite_select_json(table_id,
-            f'SELECT lsn FROM pages '
-            f'WHERE table_id={int(table_id)} AND page_id={int(page_id)} ORDER BY lsn;')]
-        self.assertEqual(remaining, keep)
-
-    def test_corrupt_no_match_raises(self):
-        if self.ds_name != 'palite':
-            self.skipTest('palite-only test')
-        self._populate()
-        bogus_page_id = 999_999
-
-        # Pick a (table_id, page_id) we know does not exist. Use a real shard
-        # with a bogus table_id so the pages_NN.db file exists - otherwise we'd
-        # get FileNotFoundError instead of AssertionError. Shift by NUM_SHARDS
-        # rows so the bogus table_id falls in the same shard as a known row.
-        real_table_id, _, _ = self._pick_any_row()
-        bogus_table_id = real_table_id + (NUM_SHARDS * 1000)
-
-        with self.assertRaisesRegex(AssertionError, 'no row'):
-            self.corrupt_page_image(bogus_table_id, bogus_page_id)
-
-if __name__ == '__main__':
-    wttest.run()
+            f'WHERE table_id={table_id} AND page_id={page_id} ORDER BY lsn;')]
+        self.assertEqual(remaining, [kept_lsn])

--- a/test/suite/test_disagg_corruption_mixin.py
+++ b/test/suite/test_disagg_corruption_mixin.py
@@ -88,13 +88,12 @@ class test_disagg_corruption_mixin(wttest.WiredTigerTestCase, DisaggCorruptionMi
         if self.ds_name != 'palite':
             self.skipTest('palite-only test')
         self._populate()
-        # Each extra round of (modify + checkpoint) adds another LSN row for
-        # the same (table_id, page_id), giving _pick_multi_lsn_row something
-        # to find.
-        for round in range(5):
+
+        # Apply a series of modifications to create page deltas.
+        for iteration in range(5):
             c = self.session.open_cursor(self.uri, None, None)
             for i in range(self.nentries):
-                c[f'k{i:04d}'] = f'v{i:04d}-{round}'
+                c[f'k{i:04d}'] = f'v{i:04d}-{iteration}'
             c.close()
             self.session.checkpoint()
 

--- a/test/suite/test_disagg_corruption_mixin.py
+++ b/test/suite/test_disagg_corruption_mixin.py
@@ -113,5 +113,28 @@ class test_disagg_corruption_mixin(wttest.WiredTigerTestCase, DisaggCorruptionMi
             f'SELECT COUNT(*) AS n FROM pages WHERE table_id={int(table_id)};')
         self.assertGreater(rows[0]['n'], 0)
 
+    def test_corrupt_page_image(self):
+        if self.ds_name != 'palite':
+            self.skipTest('palite-only test')
+        self._populate()
+        table_id, page_id, lsn = self._pick_any_row()
+
+        # Capture the original first byte of page_data via sqlite hex().
+        before = self._sqlite_select_json(table_id,
+            f'SELECT hex(substr(page_data, 1, 1)) AS first FROM pages '
+            f'WHERE table_id={int(table_id)} AND page_id={int(page_id)} AND lsn={int(lsn)};')
+        self.assertEqual(len(before), 1)
+
+        # Mutate. Helper closes WT and leaves it closed; sqlite reads below
+        # work either way.
+        returned_lsn = self.corrupt_page_image(table_id, page_id)
+        self.assertEqual(returned_lsn, lsn)
+
+        # Confirm the first byte is now 0xff.
+        after = self._sqlite_select_json(table_id,
+            f'SELECT hex(substr(page_data, 1, 1)) AS first FROM pages '
+            f'WHERE table_id={int(table_id)} AND page_id={int(page_id)} AND lsn={int(lsn)};')
+        self.assertEqual(after[0]['first'], 'FF')
+
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_disagg_corruption_mixin.py
+++ b/test/suite/test_disagg_corruption_mixin.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import json, os, subprocess, wttest
+from run import wt_builddir
+from helper_disagg import (
+    DisaggConfigMixin, DisaggCorruptionMixin, disagg_test_class,
+    gen_disagg_storages, get_shard_id, NUM_SHARDS,
+)
+from wtscenario import make_scenarios
+
+# test_disagg_corruption_mixin.py
+#    Exercise the DisaggCorruptionMixin helpers against a palite-backed
+#    disaggregated database.
+@disagg_test_class
+class test_disagg_corruption_mixin(wttest.WiredTigerTestCase, DisaggCorruptionMixin):
+    conn_base_config = ',create,statistics=(all),'
+    def conn_config(self):
+        return self.extensionsConfig() + self.conn_base_config + 'disaggregated=(role="leader")'
+
+    disagg_storages = gen_disagg_storages('test_disagg_corruption_mixin', disagg_only=True)
+    scenarios = make_scenarios(disagg_storages)
+
+    uri = 'layered:test_corruption_mixin'
+    nentries = 10
+
+    def conn_extensions(self, extlist):
+        DisaggConfigMixin.conn_extensions(self, extlist)
+
+    # Populate the table and force palite to flush pages by checkpointing.
+    def _populate(self):
+        self.session.create(self.uri, 'key_format=S,value_format=S')
+        c = self.session.open_cursor(self.uri, None, None)
+        for i in range(self.nentries):
+            c[f'k{i:04d}'] = f'v{i:04d}'
+        c.close()
+        self.session.checkpoint()
+
+    # Read rows directly from the per-shard pages DB. Palite uses shared SQLite
+    # locks for readers, so this is safe to call whether the WT connection is
+    # open or closed.
+    def _sqlite_select_json(self, table_id, sql_query):
+        shard = get_shard_id(table_id)
+        db_path = os.path.join(self.home, 'kv_home', f'pages_{shard:02d}.db')
+        sqlite_exe = os.path.join(wt_builddir, 'sqlite3')
+        result = subprocess.run(
+            [sqlite_exe, '-json', db_path, sql_query],
+            capture_output=True, text=True, check=True)
+        return json.loads(result.stdout) if result.stdout.strip() else []
+
+    # Find any populated (table_id, page_id) pair from the pages DB by scanning
+    # all shards. Returns (table_id, page_id, lsn). Requires the WT connection
+    # to be closed. Used by individual test_* methods to pick a victim row.
+    def _pick_any_row(self):
+        self.close_conn()
+        try:
+            for shard in range(NUM_SHARDS):
+                db_path = os.path.join(self.home, 'kv_home', f'pages_{shard:02d}.db')
+                if not os.path.exists(db_path):
+                    continue
+                sqlite_exe = os.path.join(wt_builddir, 'sqlite3')
+                result = subprocess.run(
+                    [sqlite_exe, '-json', db_path,
+                     'SELECT table_id, page_id, lsn FROM pages '
+                     'ORDER BY table_id DESC, page_id ASC, lsn DESC LIMIT 1;'],
+                    capture_output=True, text=True, check=True)
+                if result.stdout.strip():
+                    row = json.loads(result.stdout)[0]
+                    return int(row['table_id']), int(row['page_id']), int(row['lsn'])
+        finally:
+            self.reopen_conn()
+        self.fail("no rows found in any pages_NN.db after populate")
+
+    # Smoke test: populate, find at least one row via sqlite, then confirm we
+    # can also read sqlite while the WT connection is open (per-method helpers
+    # rely on this, but only do reads *after* their reopen_conn; verify here so
+    # a SQLITE_BUSY surface is caught at smoke-test time, not in Task 3).
+    def test_populate_produces_palite_rows(self):
+        if self.ds_name != 'palite':
+            self.skipTest('palite-only test')
+        self._populate()
+        table_id, page_id, lsn = self._pick_any_row()
+        self.assertGreater(table_id, 0)
+        self.assertGreaterEqual(lsn, 0)
+        # WT connection is reopen after _pick_any_row. Read again now to prove
+        # palite doesn't block readers via its exclusive lock.
+        rows = self._sqlite_select_json(table_id,
+            f'SELECT COUNT(*) AS n FROM pages WHERE table_id={int(table_id)};')
+        self.assertGreater(rows[0]['n'], 0)
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_disagg_corruption_mixin.py
+++ b/test/suite/test_disagg_corruption_mixin.py
@@ -172,5 +172,57 @@ class test_disagg_corruption_mixin(wttest.WiredTigerTestCase, DisaggCorruptionMi
         self.assertEqual(after[0]['discarded'], 1)
         self.assertTrue(int(after[0]['flags']) & DisaggCorruptionMixin.WT_PAGE_LOG_DISCARDED)
 
+    # Force more than one LSN per (table_id, page_id) by repeatedly modifying
+    # and checkpointing. Returns (table_id, page_id) of a row with at least
+    # two LSNs.
+    def _populate_with_multi_lsn(self):
+        self._populate()
+        for round in range(5):
+            c = self.session.open_cursor(self.uri, None, None)
+            for i in range(self.nentries):
+                c[f'k{i:04d}'] = f'v{i:04d}-{round}'
+            c.close()
+            self.session.checkpoint()
+
+        # Find a (table_id, page_id) that has >= 2 LSN rows.
+        self.close_conn()
+        try:
+            for shard in range(NUM_SHARDS):
+                db_path = os.path.join(self.home, 'kv_home', f'pages_{shard:02d}.db')
+                if not os.path.exists(db_path):
+                    continue
+                sqlite_exe = os.path.join(wt_builddir, 'sqlite3')
+                result = subprocess.run(
+                    [sqlite_exe, '-json', db_path,
+                     'SELECT table_id, page_id, COUNT(*) AS n FROM pages '
+                     'GROUP BY table_id, page_id HAVING n >= 2 '
+                     'ORDER BY table_id DESC LIMIT 1;'],
+                    capture_output=True, text=True, check=True)
+                if result.stdout.strip():
+                    row = json.loads(result.stdout)[0]
+                    return int(row['table_id']), int(row['page_id'])
+        finally:
+            self.reopen_conn()
+        self.fail("could not produce a (table_id, page_id) with multiple LSNs")
+
+    def test_truncate_delta_chain(self):
+        if self.ds_name != 'palite':
+            self.skipTest('palite-only test')
+        table_id, page_id = self._populate_with_multi_lsn()
+
+        all_lsns = [int(r['lsn']) for r in self._sqlite_select_json(table_id,
+            f'SELECT lsn FROM pages '
+            f'WHERE table_id={int(table_id)} AND page_id={int(page_id)} ORDER BY lsn;')]
+        self.assertGreaterEqual(len(all_lsns), 2)
+
+        keep = [all_lsns[0]]  # keep only the base
+        deleted = self.truncate_delta_chain(table_id, page_id, keep)
+        self.assertEqual(sorted(deleted), sorted(all_lsns[1:]))
+
+        remaining = [int(r['lsn']) for r in self._sqlite_select_json(table_id,
+            f'SELECT lsn FROM pages '
+            f'WHERE table_id={int(table_id)} AND page_id={int(page_id)} ORDER BY lsn;')]
+        self.assertEqual(remaining, keep)
+
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_disagg_corruption_mixin.py
+++ b/test/suite/test_disagg_corruption_mixin.py
@@ -151,5 +151,26 @@ class test_disagg_corruption_mixin(wttest.WiredTigerTestCase, DisaggCorruptionMi
             f'WHERE table_id={int(table_id)} AND page_id={int(page_id)} AND lsn={int(lsn)};')
         self.assertEqual(after[0]['n'], 0)
 
+    def test_set_page_discarded(self):
+        if self.ds_name != 'palite':
+            self.skipTest('palite-only test')
+        self._populate()
+        table_id, page_id, lsn = self._pick_any_row()
+
+        # The row should not be discarded yet.
+        before = self._sqlite_select_json(table_id,
+            f'SELECT discarded FROM pages '
+            f'WHERE table_id={int(table_id)} AND page_id={int(page_id)} AND lsn={int(lsn)};')
+        self.assertEqual(before[0]['discarded'], 0)
+
+        returned_lsn = self.set_page_discarded(table_id, page_id)
+        self.assertEqual(returned_lsn, lsn)
+
+        after = self._sqlite_select_json(table_id,
+            f'SELECT discarded, flags FROM pages '
+            f'WHERE table_id={int(table_id)} AND page_id={int(page_id)} AND lsn={int(lsn)};')
+        self.assertEqual(after[0]['discarded'], 1)
+        self.assertTrue(int(after[0]['flags']) & DisaggCorruptionMixin.WT_PAGE_LOG_DISCARDED)
+
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_disagg_corruption_mixin.py
+++ b/test/suite/test_disagg_corruption_mixin.py
@@ -136,5 +136,20 @@ class test_disagg_corruption_mixin(wttest.WiredTigerTestCase, DisaggCorruptionMi
             f'WHERE table_id={int(table_id)} AND page_id={int(page_id)} AND lsn={int(lsn)};')
         self.assertEqual(after[0]['first'], 'FF')
 
+    def test_delete_page_image(self):
+        if self.ds_name != 'palite':
+            self.skipTest('palite-only test')
+        self._populate()
+        table_id, page_id, lsn = self._pick_any_row()
+
+        returned_lsn = self.delete_page_image(table_id, page_id)
+        self.assertEqual(returned_lsn, lsn)
+
+        # The row should be gone.
+        after = self._sqlite_select_json(table_id,
+            f'SELECT COUNT(*) AS n FROM pages '
+            f'WHERE table_id={int(table_id)} AND page_id={int(page_id)} AND lsn={int(lsn)};')
+        self.assertEqual(after[0]['n'], 0)
+
 if __name__ == '__main__':
     wttest.run()


### PR DESCRIPTION
Adds DisaggCorruptionMixin to helper_disagg.py, giving Python tests a shared way to corrupt a disaggregated database at the palite layer. The mixin auto-picks a victim row by scanning the per-shard pages_NN.db files.

Key helpers:
  - corrupt_random_page_image — flip the first byte of a stored page image
  - delete_random_page_image — drop a single image row
  - set_random_page_discarded — set WT_PAGE_LOG_DISCARDED to tombstone an image
  - truncate_random_delta_chain — delete all but the base image of a delta chain

test_disagg_corruption_mixin.py exercises all four helpers and confirms they raise when no matching row exists.