### PR TITLE
WT-17066 Tune shared disk hash table bucket and lock count

### DIFF
--- a/src/cache/cache.c
+++ b/src/cache/cache.c
@@ -77,16 +77,14 @@ __wt_cache_create(WT_SESSION_IMPL *session, const char *cfg[])
     WT_RET(__wt_cache_config(session, cfg, false));
 
     /*
-     * Initialize the shared disk hash table only on disagg standby nodes.
+     * Initialize the shared disk hash table only on disagg nodes.
+     *
      * FIXME-WT-14721: Replace this config lookup with the standard disaggregated check once the
      * disaggregated configuration is available here.
      */
-    S2C(session)->cache->shared_dsk_cache.enabled = false;
     WT_RET(__wt_config_gets(session, cfg, "disaggregated.page_log", &cval));
-    if (cval.len != 0) {
-        WT_RET(__wt_disagg_config_get_role(session, cfg, &leader));
-        S2C(session)->cache->shared_dsk_cache.enabled = !leader;
-    }
+    S2C(session)->cache->shared_dsk_cache.enabled = (cval.len != 0);
+    S2C(session)->cache->shared_dsk_cache.enabled = false;
     if (S2C(session)->cache->shared_dsk_cache.enabled) {
         /*
          * Best-effort sizing: budget 0.2% of the cache and assume one item per bucket, so dividing

--- a/src/cache/cache.c
+++ b/src/cache/cache.c
@@ -68,6 +68,7 @@ __wt_cache_create(WT_SESSION_IMPL *session, const char *cfg[])
 {
     WT_CONFIG_ITEM cval;
     u_int hash_size;
+    bool leader;
 
     WT_ASSERT(session, S2C(session)->cache == NULL);
     WT_RET(__wt_calloc_one(session, &S2C(session)->cache));
@@ -76,18 +77,24 @@ __wt_cache_create(WT_SESSION_IMPL *session, const char *cfg[])
     WT_RET(__wt_cache_config(session, cfg, false));
 
     /*
-     * Initialize the shared disk hash table only on disaggregated nodes. Size the hash table at
-     * 0.2% of cache size divided by ~100B per entry (cache size / 500 / 100), with a minimum of 512
-     * buckets.
+     * Initialize the shared disk hash table only on disagg standby nodes.
      * FIXME-WT-14721: Replace this config lookup with the standard disaggregated check once the
      * disaggregated configuration is available here.
      */
-    WT_RET(__wt_config_gets(session, cfg, "disaggregated.page_log", &cval));
-    S2C(session)->cache->shared_dsk_cache.enabled = (cval.len != 0);
     S2C(session)->cache->shared_dsk_cache.enabled = false;
+    WT_RET(__wt_config_gets(session, cfg, "disaggregated.page_log", &cval));
+    if (cval.len != 0) {
+        WT_RET(__wt_disagg_config_get_role(session, cfg, &leader));
+        S2C(session)->cache->shared_dsk_cache.enabled = !leader;
+    }
     if (S2C(session)->cache->shared_dsk_cache.enabled) {
-        /* FIXME-WT-17066: We should pick a hash size wisely. */
-        hash_size = (u_int)WT_MAX(S2C(session)->cache_size / 500 / 100, 512);
+        /*
+         * Best-effort sizing: budget 0.2% of the cache and assume one item per bucket, so dividing
+         * that budget by the per-bucket cost gives the count, with a floor of a thousand buckets.
+         */
+        hash_size = (u_int)WT_MAX(S2C(session)->cache_size / 500 /
+            (sizeof(WT_SHARED_DSK_ITEM) + sizeof(*S2C(session)->cache->shared_dsk_cache.hash)),
+          WT_THOUSAND);
         WT_RET(__wti_shared_dsk_cache_init(session, hash_size));
         WT_STAT_CONN_SET(session, cache_shared_dsk_hash_size, hash_size);
     }

--- a/src/cache/cache.c
+++ b/src/cache/cache.c
@@ -68,7 +68,6 @@ __wt_cache_create(WT_SESSION_IMPL *session, const char *cfg[])
 {
     WT_CONFIG_ITEM cval;
     u_int hash_size;
-    bool leader;
 
     WT_ASSERT(session, S2C(session)->cache == NULL);
     WT_RET(__wt_calloc_one(session, &S2C(session)->cache));

--- a/src/cache/shared_dsk.c
+++ b/src/cache/shared_dsk.c
@@ -242,7 +242,7 @@ __wti_shared_dsk_cache_init(WT_SESSION_IMPL *session, u_int hash_size)
 
     shared_dsk_cache = &S2C(session)->cache->shared_dsk_cache;
     shared_dsk_cache->hash_size = hash_size;
-    shared_dsk_cache->hash_lock_size = WT_MIN(hash_size, WT_THOUSAND);
+    shared_dsk_cache->hash_lock_size = WT_MIN(hash_size, WT_THOUSAND * 2);
 #ifdef HAVE_DIAGNOSTIC
     shared_dsk_cache->max_bucket_walk = 0;
     shared_dsk_cache->max_ref_count = 0;

--- a/src/cache/shared_dsk.c
+++ b/src/cache/shared_dsk.c
@@ -242,8 +242,7 @@ __wti_shared_dsk_cache_init(WT_SESSION_IMPL *session, u_int hash_size)
 
     shared_dsk_cache = &S2C(session)->cache->shared_dsk_cache;
     shared_dsk_cache->hash_size = hash_size;
-    /* FIXME-WT-17066: We should pick a WT_SHARED_DSK_CACHE_MAX_LOCKS wisely. */
-    shared_dsk_cache->hash_lock_size = WT_MIN(hash_size, WT_SHARED_DSK_CACHE_MAX_LOCKS);
+    shared_dsk_cache->hash_lock_size = WT_MIN(hash_size, WT_THOUSAND);
 #ifdef HAVE_DIAGNOSTIC
     shared_dsk_cache->max_bucket_walk = 0;
     shared_dsk_cache->max_ref_count = 0;

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -57,9 +57,6 @@ struct __wt_shared_dsk_item {
     uint8_t addr[];
 };
 
-/* Maximum number of shared disk cache hash locks. */
-#define WT_SHARED_DSK_CACHE_MAX_LOCKS 8192
-
 struct __wt_shared_dsk_cache {
     bool enabled;
 


### PR DESCRIPTION
This PR is to tune the shared disk hash table bucket and lock count based on the perf patches I ran. Please view the summary posted in the ticket comment for why picking 0.2 cache size as bucket count and 2000 as max bucket locks.