### PR TITLE
WT-17758 Do not allow creating tables with empty name

### DIFF
--- a/src/schema/schema_create.c
+++ b/src/schema/schema_create.c
@@ -1554,6 +1554,21 @@ __create_parse_export(
 }
 
 /*
+ * __schema_create_uri_check --
+ *     Validate that a URI passed to session.create() has a non-empty name after the scheme prefix.
+ */
+static int
+__schema_create_uri_check(WT_SESSION_IMPL *session, const char *uri)
+{
+    const char *sep;
+
+    sep = strchr(uri, ':');
+    if (sep != NULL && sep[1] == '\0')
+        WT_RET_MSG(session, EINVAL, "%s: URI requires a non-empty name", uri);
+    return (0);
+}
+
+/*
  * __schema_create_config_check --
  *     Detects any invalid config combinations for schema create.
  */
@@ -1639,6 +1654,7 @@ __schema_create(WT_SESSION_IMPL *session, const char *uri, const char *config)
     import = session->import_list != NULL ||
       (__wt_config_getones(session, config, "import.enabled", &cval) == 0 && cval.val != 0);
 
+    WT_RET(__schema_create_uri_check(session, uri));
     WT_RET(__schema_create_config_check(session, uri, config, import));
 
     /*
@@ -1661,7 +1677,7 @@ __schema_create(WT_SESSION_IMPL *session, const char *uri, const char *config)
 
             /* Get suffix of the URI. */
             import_list.uri_suffix = strchr(uri, ':');
-            WT_ASSERT(session, import_list.uri_suffix != NULL && import_list.uri_suffix[1] != '\0');
+            WT_ASSERT(session, import_list.uri_suffix != NULL);
             ++import_list.uri_suffix;
 
             WT_ERR(__create_parse_export(session, export_file, &import_list));

--- a/test/suite/test_layered_cursor15.py
+++ b/test/suite/test_layered_cursor15.py
@@ -202,7 +202,7 @@ class test_layered_cursor15(wttest.WiredTigerTestCase):
         ts = 100
         uri_sits = []
         for sit in sits:
-            uri = 'table:' + ''.join(sit)
+            uri = 'table:t' + ''.join(sit)
             self.session.create(uri, 'key_format=S,value_format=S,block_manager=disagg,type=layered')
             uri_sits.append((uri, sit))
 

--- a/test/suite/test_schema10.py
+++ b/test/suite/test_schema10.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wiredtiger, wttest
+from wtscenario import make_scenarios
+
+# test_schema10.py
+#    Test that an empty name (e.g. "table:", "file:") is rejected by session.create().
+class test_schema10(wttest.WiredTigerTestCase):
+
+    # URI types dispatched through session.create() that require a non-empty name.
+    uri_types = [
+        ('colgroup', dict(uri='colgroup:')),
+        ('file',     dict(uri='file:')),
+        ('index',    dict(uri='index:')),
+        ('layered',  dict(uri='layered:')),
+        ('table',    dict(uri='table:')),
+    ]
+    scenarios = make_scenarios(uri_types)
+
+    def test_create_empty_name(self):
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.session.create(self.uri, "key_format=S,value_format=S"),
+            "/URI requires a non-empty name/")


### PR DESCRIPTION
Reject any URI with an empty name component before the per-type dispatch, and add test_schema10.py to verify the behavior. Fix test_layered_cursor15.py, which was incidentally creating "table:" from an empty situation sequence.