### PR TITLE
WT-17567 Fix skip-write REPLACE discarding disagg pages ahead of materialization frontier

### DIFF
--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -2361,8 +2361,12 @@ __split_multi(WT_SESSION_IMPL *session, WT_REF *ref, bool closing)
      *
      * Finalize the move, discarding moved update lists from the original page.
      */
-    for (i = 0; i < new_entries; ++i)
+    for (i = 0; i < new_entries; ++i) {
         __split_multi_inmem_final(session, page, &mod->mod_multi[i]);
+        /* A non-closing disaggregated child must be re-instantiated in memory. */
+        WT_ASSERT(session,
+          page->disagg_info == NULL || closing || WT_REF_GET_STATE(ref_new[i]) == WT_REF_MEM);
+    }
 
     /*
      * Page with changes not written in this reconciliation is not marked as clean, do it now, then

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -2354,10 +2354,9 @@ __split_multi(WT_SESSION_IMPL *session, WT_REF *ref, bool closing)
          * backing block must be behind the materialization frontier so it can be read back safely.
          */
         WT_ASSERT(session,
-          page->disagg_info == NULL || closing ||
-          WT_REF_GET_STATE(ref_new[i]) == WT_REF_MEM ||
-          (mod->mod_multi[i].block_meta != NULL &&
-            __wt_materialization_check(session, mod->mod_multi[i].block_meta->disagg_lsn)));
+          page->disagg_info == NULL || closing || WT_REF_GET_STATE(ref_new[i]) == WT_REF_MEM ||
+            (mod->mod_multi[i].block_meta != NULL &&
+              __wt_materialization_check(session, mod->mod_multi[i].block_meta->disagg_lsn)));
     }
 
     /*

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -2351,6 +2351,14 @@ __split_multi(WT_SESSION_IMPL *session, WT_REF *ref, bool closing)
           &parent_incr, i == 0, closing));
 
     /*
+     * Check before publishing: each disaggregated child must be re-instantiated in memory.
+     * Once the new refs are published to other threads the state can change.
+     */
+    for (i = 0; i < new_entries; ++i)
+        WT_ASSERT(session,
+          page->disagg_info == NULL || closing || WT_REF_GET_STATE(ref_new[i]) == WT_REF_MEM);
+
+    /*
      * Split into the parent; if we're closing the file, we hold it exclusively.
      */
     WT_ERR(__split_parent(session, ref, ref_new, new_entries, parent_incr, closing, true));
@@ -2361,12 +2369,8 @@ __split_multi(WT_SESSION_IMPL *session, WT_REF *ref, bool closing)
      *
      * Finalize the move, discarding moved update lists from the original page.
      */
-    for (i = 0; i < new_entries; ++i) {
+    for (i = 0; i < new_entries; ++i)
         __split_multi_inmem_final(session, page, &mod->mod_multi[i]);
-        /* A non-closing disaggregated child must be re-instantiated in memory. */
-        WT_ASSERT(session,
-          page->disagg_info == NULL || closing || WT_REF_GET_STATE(ref_new[i]) == WT_REF_MEM);
-    }
 
     /*
      * Page with changes not written in this reconciliation is not marked as clean, do it now, then

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -2346,13 +2346,9 @@ __split_multi(WT_SESSION_IMPL *session, WT_REF *ref, bool closing)
      * reference structures.
      */
     WT_RET(__wt_calloc_def(session, new_entries, &ref_new));
-    for (i = 0; i < new_entries; ++i) {
+    for (i = 0; i < new_entries; ++i)
         WT_ERR(__wt_multi_to_ref(session, ref, page, &mod->mod_multi[i], new_entries, &ref_new[i],
           &parent_incr, i == 0, closing));
-        /* Each disaggregated child must be re-instantiated in memory before publishing. */
-        WT_ASSERT(session,
-          page->disagg_info == NULL || closing || WT_REF_GET_STATE(ref_new[i]) == WT_REF_MEM);
-    }
 
     /*
      * Split into the parent; if we're closing the file, we hold it exclusively.

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -2346,9 +2346,19 @@ __split_multi(WT_SESSION_IMPL *session, WT_REF *ref, bool closing)
      * reference structures.
      */
     WT_RET(__wt_calloc_def(session, new_entries, &ref_new));
-    for (i = 0; i < new_entries; ++i)
+    for (i = 0; i < new_entries; ++i) {
         WT_ERR(__wt_multi_to_ref(session, ref, page, &mod->mod_multi[i], new_entries, &ref_new[i],
           &parent_incr, i == 0, closing));
+        /*
+         * A disaggregated child without a retained disk image has been pushed to WT_REF_DISK. Its
+         * backing block must be behind the materialization frontier so it can be read back safely.
+         */
+        WT_ASSERT(session,
+          page->disagg_info == NULL || closing ||
+          WT_REF_GET_STATE(ref_new[i]) == WT_REF_MEM ||
+          (mod->mod_multi[i].block_meta != NULL &&
+            __wt_materialization_check(session, mod->mod_multi[i].block_meta->disagg_lsn)));
+    }
 
     /*
      * Split into the parent; if we're closing the file, we hold it exclusively.

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -2346,17 +2346,13 @@ __split_multi(WT_SESSION_IMPL *session, WT_REF *ref, bool closing)
      * reference structures.
      */
     WT_RET(__wt_calloc_def(session, new_entries, &ref_new));
-    for (i = 0; i < new_entries; ++i)
+    for (i = 0; i < new_entries; ++i) {
         WT_ERR(__wt_multi_to_ref(session, ref, page, &mod->mod_multi[i], new_entries, &ref_new[i],
           &parent_incr, i == 0, closing));
-
-    /*
-     * Check before publishing: each disaggregated child must be re-instantiated in memory.
-     * Once the new refs are published to other threads the state can change.
-     */
-    for (i = 0; i < new_entries; ++i)
+        /* Each disaggregated child must be re-instantiated in memory before publishing. */
         WT_ASSERT(session,
           page->disagg_info == NULL || closing || WT_REF_GET_STATE(ref_new[i]) == WT_REF_MEM);
+    }
 
     /*
      * Split into the parent; if we're closing the file, we hold it exclusively.

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -664,7 +664,10 @@ __evict_page_dirty_update(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_
          * to the page and rewrite it in memory.
          */
         if (mod->mod_multi_entries == 1) {
-            WT_ASSERT(session, closing == false);
+            WT_ASSERT(session, !closing);
+            /* A disaggregated page must have a retained image to re-instantiate from. */
+            WT_ASSERT(
+              session, ref->page->disagg_info == NULL || mod->mod_multi[0].disk_image != NULL);
             WT_RET(__wt_split_rewrite(session, ref, &mod->mod_multi[0], true));
         } else
             WT_RET(__wt_split_multi(session, ref, closing));
@@ -691,6 +694,8 @@ __evict_page_dirty_update(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_
             } else
                 WT_ASSERT(
                   session, F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED) && ref->addr != NULL);
+            /* A non-closing disaggregated page must be re-instantiated, not discarded to disk. */
+            WT_ASSERT(session, ref->page->disagg_info == NULL || closing);
             __wt_page_modify_clear(session, ref->page);
             __wt_ref_out(session, ref);
             WT_REF_SET_STATE(ref, WT_REF_DISK);

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -700,7 +700,7 @@ __evict_page_dirty_update(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_
              */
             WT_ASSERT(session,
               ref->page->disagg_info == NULL || closing ||
-              __wt_materialization_check(session, ref->page->disagg_info->rec_lsn_max));
+                __wt_materialization_check(session, ref->page->disagg_info->rec_lsn_max));
             __wt_page_modify_clear(session, ref->page);
             __wt_ref_out(session, ref);
             WT_REF_SET_STATE(ref, WT_REF_DISK);

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -694,8 +694,13 @@ __evict_page_dirty_update(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_
             } else
                 WT_ASSERT(
                   session, F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED) && ref->addr != NULL);
-            /* A non-closing disaggregated page must be re-instantiated, not discarded to disk. */
-            WT_ASSERT(session, ref->page->disagg_info == NULL || closing);
+            /*
+             * A disaggregated page discarded without a disk image must have its backing block
+             * behind the materialization frontier so it can be read back safely.
+             */
+            WT_ASSERT(session,
+              ref->page->disagg_info == NULL || closing ||
+              __wt_materialization_check(session, ref->page->disagg_info->rec_lsn_max));
             __wt_page_modify_clear(session, ref->page);
             __wt_ref_out(session, ref);
             WT_REF_SET_STATE(ref, WT_REF_DISK);

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -3182,7 +3182,8 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
                 if (F_ISSET(r, WT_REC_SCRUB)) {
                     mod->mod_disk_image = r->multi->disk_image;
                     r->multi->disk_image = NULL;
-                }
+                } else
+                    WT_ASSERT(session, F_ISSET(r, WT_REC_CHECKPOINT));
             }
         } else {
             __wt_checkpoint_tree_reconcile_update(session, &r->multi->addr.ta);

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -3172,16 +3172,16 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
                 WT_TIME_AGGREGATE_MERGE_OBSOLETE_VISIBLE(session, &stop_ta, &mod->mod_replace.ta);
             } else {
                 WT_ASSERT(session, F_ISSET(btree, WT_BTREE_DISAGGREGATED) && r->ref->addr != NULL);
+                WT_ASSERT(session, F_ISSET(r->multi, WT_MULTI_SKIP_WRITE));
+                WT_ASSERT(session, F_ISSET(r, WT_REC_SCRUB));
                 /*
                  * Skip-write with no cookie: the previous reconciliation reset rec_result to 0, so
-                 * no prior cookie was copied. If scrub is active, carry the disk image forward so
-                 * the page is re-instantiated in cache rather than discarded ahead of the
-                 * materialization frontier.
+                 * no prior cookie was copied. Carry the disk image forward so the page is
+                 * re-instantiated in cache rather than discarded ahead of the materialization
+                 * frontier.
                  */
-                if (F_ISSET(r, WT_REC_SCRUB)) {
-                    mod->mod_disk_image = r->multi->disk_image;
-                    r->multi->disk_image = NULL;
-                }
+                mod->mod_disk_image = r->multi->disk_image;
+                r->multi->disk_image = NULL;
             }
         } else {
             __wt_checkpoint_tree_reconcile_update(session, &r->multi->addr.ta);

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -3173,15 +3173,16 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
             } else {
                 WT_ASSERT(session, F_ISSET(btree, WT_BTREE_DISAGGREGATED) && r->ref->addr != NULL);
                 WT_ASSERT(session, F_ISSET(r->multi, WT_MULTI_SKIP_WRITE));
-                WT_ASSERT(session, F_ISSET(r, WT_REC_SCRUB));
                 /*
                  * Skip-write with no cookie: the previous reconciliation reset rec_result to 0, so
-                 * no prior cookie was copied. Carry the disk image forward so the page is
-                 * re-instantiated in cache rather than discarded ahead of the materialization
+                 * no prior cookie was copied. Under scrub, carry the disk image forward so the page
+                 * is re-instantiated in cache rather than discarded ahead of the materialization
                  * frontier.
                  */
-                mod->mod_disk_image = r->multi->disk_image;
-                r->multi->disk_image = NULL;
+                if (F_ISSET(r, WT_REC_SCRUB)) {
+                    mod->mod_disk_image = r->multi->disk_image;
+                    r->multi->disk_image = NULL;
+                }
             }
         } else {
             __wt_checkpoint_tree_reconcile_update(session, &r->multi->addr.ta);

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -3170,8 +3170,19 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
                 if (page->disagg_info != NULL)
                     page->disagg_info->block_meta = *r->multi->block_meta;
                 WT_TIME_AGGREGATE_MERGE_OBSOLETE_VISIBLE(session, &stop_ta, &mod->mod_replace.ta);
-            } else
+            } else {
                 WT_ASSERT(session, F_ISSET(btree, WT_BTREE_DISAGGREGATED) && r->ref->addr != NULL);
+                /*
+                 * Skip-write with no cookie: the previous reconciliation reset rec_result to 0, so
+                 * no prior cookie was copied. If scrub is active, carry the disk image forward so
+                 * the page is re-instantiated in cache rather than discarded ahead of the
+                 * materialization frontier.
+                 */
+                if (F_ISSET(r, WT_REC_SCRUB)) {
+                    mod->mod_disk_image = r->multi->disk_image;
+                    r->multi->disk_image = NULL;
+                }
+            }
         } else {
             __wt_checkpoint_tree_reconcile_update(session, &r->multi->addr.ta);
             WT_RET(

--- a/test/suite/test_layered_eviction06.py
+++ b/test/suite/test_layered_eviction06.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wiredtiger, wttest
+from helper_disagg import disagg_test_class, gen_disagg_storages
+from wiredtiger import stat
+from wtscenario import make_scenarios
+
+# test_layered_eviction06.py
+#    A dirty disaggregated leaf that reconciles to a skip-write single-block REPLACE while
+#    ahead of the materialization frontier must be kept in cache, not discarded. Reproduces
+#    the case where an obsolete-time-window cleanup dirties such a page, the skip-write REPLACE
+#    path drops the scrubbed disk image, eviction discards the page, and a subsequent read
+#    faults it back in ahead of the frontier.
+@disagg_test_class
+class test_layered_eviction06(wttest.WiredTigerTestCase):
+    conn_config = 'statistics=(all),disaggregated=(role="leader")'
+
+    create_session_config = 'key_format=i,value_format=S'
+
+    uri = 'layered:test_layered_eviction06'
+
+    disagg_storages = gen_disagg_storages('test_layered_eviction06', disagg_only=True)
+    scenarios = make_scenarios(disagg_storages)
+
+    def get_stat(self, stat):
+        stat_cursor = self.session.open_cursor('statistics:')
+        val = stat_cursor[stat][2]
+        stat_cursor.close()
+        return val
+
+    # Force a read-and-evict of the page holding the given key. The session-level
+    # release_evict_page debug flag is required to let eviction run the obsolete-time-window
+    # review (application threads otherwise skip it).
+    def evict(self, key):
+        evict_session = self.conn.open_session('debug=(release_evict_page=true)')
+        evict_session.begin_transaction('ignore_prepare=true')
+        evict_cursor = evict_session.open_cursor(self.uri, None, None)
+        evict_cursor.set_key(key)
+        self.assertEqual(evict_cursor.search(), 0)
+        evict_cursor.reset()
+        evict_cursor.close()
+        evict_session.rollback_transaction()
+        evict_session.close()
+
+    def advance_frontier(self, page_log):
+        (ret, last_lsn) = page_log.pl_get_last_lsn(self.session)
+        self.assertEqual(ret, 0)
+        page_log.pl_set_last_materialized_lsn(self.session, last_lsn)
+        self.conn.set_context_uint(wiredtiger.WT_CONTEXT_TYPE_LAST_MATERIALIZED_LSN, last_lsn)
+        return last_lsn
+
+    def test_layered_eviction06(self):
+        page_log = self.conn.get_page_log(self.vars.page_log)
+        self.session.create(self.uri, self.create_session_config)
+        cursor = self.session.open_cursor(self.uri)
+
+        # Insert a key with a commit timestamp. There is no delete, so the leaf has no stop time
+        # window - only a start time window that becomes obsolete once oldest advances past it.
+        self.session.begin_transaction()
+        cursor[1] = 'first'
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
+
+        # First checkpoint writes the page to disaggregated storage. Advance the materialization
+        # frontier to this checkpoint so the page is materialized.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10))
+        self.session.checkpoint()
+        lsn1 = self.advance_frontier(page_log)
+        self.pr(f'lsn1 (frontier) = {lsn1}')
+
+        # Insert a second key on the same leaf, dirtying it. Do NOT checkpoint and do NOT advance
+        # the frontier.
+        self.session.begin_transaction()
+        cursor[2] = 'second'
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(20))
+        cursor.close()
+
+        # First eviction: the dirty disaggregated leaf is written ahead of the frontier and, under
+        # forced scrub, retained in cache via a split_rewrite. This is the legal "evict ahead of
+        # the frontier" case. The re-instantiated page is fresh, so its reconciliation result is
+        # reset (rec_result == 0) while its backing image stays ahead of the frontier.
+        self.evict(1)
+
+        # Advance oldest past both start timestamps so the leaf's start time window is obsolete.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(30))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(30))
+
+        # Second eviction: the obsolete-time-window review dirties the fresh page; reconciliation
+        # under forced scrub finds no key-changing updates and takes the skip-write single-block
+        # REPLACE path. Because the previous reconciliation result was reset, no prior block cookie
+        # is copied (the "cookie:0" case), so without the fix no disk image is retained and the
+        # page is discarded from cache while its backing image is still ahead of the frontier.
+        self.evict(1)
+
+        read_ahead_before = self.get_stat(stat.conn.disagg_block_read_ahead_frontier)
+
+        # Read the key back from the stable (disaggregated) constituent directly. A read through
+        # the layered URI is served by the in-memory ingest table and never touches the stable
+        # leaf; reading the stable file forces the disaggregated block read. If the page was
+        # wrongly discarded by the skip-write eviction, this faults it in from storage at an LSN
+        # ahead of the materialization frontier.
+        stable_uri = 'file:' + self.uri.split(':', 1)[1] + '.wt_stable'
+        read_session = self.conn.open_session()
+        read_cursor = read_session.open_cursor(stable_uri)
+        read_cursor.set_key(1)
+        self.assertEqual(read_cursor.search(), 0)
+        self.assertEqual(read_cursor.get_value(), 'first')
+        read_cursor.close()
+        read_session.close()
+
+        # The page should have stayed in cache: no read ahead of the frontier should occur.
+        self.assertEqual(self.get_stat(stat.conn.disagg_block_read_ahead_frontier), read_ahead_before)
+
+        # Checkpoint and advance the frontier past the current LSN so tearDown
+        # verifyLayered can read all pages without tripping the frontier check,
+        # which would otherwise prevent the disaggregated layer from completing
+        # its reads and releasing the dhandle for exclusive verify access.
+        self.session.checkpoint()
+        (ret, current_lsn) = page_log.pl_get_last_lsn(self.session)
+        self.assertEqual(ret, 0)
+        page_log.pl_set_last_materialized_lsn(self.session, current_lsn)
+        self.conn.set_context_uint(wiredtiger.WT_CONTEXT_TYPE_LAST_MATERIALIZED_LSN, current_lsn)


### PR DESCRIPTION
## Summary

- A dirty disaggregated leaf scrub-evicted and retained via split_rewrite resets `mod->rec_result` to 0. A subsequent obsolete-time-window eviction takes the skip-write single-block REPLACE path; `__rec_copy_prev_addr` copies no cookie, and the REPLACE wrap-up only promoted the scrubbed disk image into `mod->mod_disk_image` when `block_cookie != NULL`. In the cookie-0 case the image was silently dropped, causing `__evict_page_dirty_update` to discard the page (`WT_REF_DISK`) with `ref->addr` still pointing at a block whose LSN exceeded the materialization frontier.
- Fix: when `WT_REC_SCRUB` is set and `block_cookie == NULL`, carry `r->multi->disk_image` into `mod->mod_disk_image` in the REPLACE wrap-up so eviction takes the re-instantiation path.
- Add three diagnostic assertions encoding the invariant that non-closing disaggregated pages are always re-instantiated in cache rather than discarded to disk.
- Add `test_layered_eviction06` which reproduces the two-eviction recipe and asserts `disagg_block_read_ahead_frontier` stays at zero with the fix applied.