### PR TITLE
WT-16083 Fix ASan warnings and remove suppressions

### DIFF
--- a/lang/python/wiredtiger.i
+++ b/lang/python/wiredtiger.i
@@ -182,6 +182,10 @@ from packing import pack, unpack
 	}
 }
 
+%typemap(freearg) (WT_MODIFY *entries, int *nentriesp) {
+	__wt_free(NULL, $1);
+}
+
 %typemap(argout) (WT_MODIFY *entries_string, int *nentriesp) {
 	int i;
 
@@ -196,7 +200,11 @@ from packing import pack, unpack
 		    PyInt_FromLong($1[i].size));
 		PyList_SetItem($result, i, o);
 	}
- }
+}
+
+%typemap(freearg) (WT_MODIFY *entries_string, int *nentriesp) {
+	__wt_free(NULL, $1);
+}
 
 %typemap(in) const WT_ITEM * (WT_ITEM val) {
 	if (unpackBytesOrString($input, &val.data, &val.size) != 0)

--- a/test/evergreen/asan_leaks.supp
+++ b/test/evergreen/asan_leaks.supp
@@ -1,6 +1,7 @@
 # TCMalloc intentionally leaks newed objects. More information can be found in
 # https://github.com/gperftools/gperftools/issues/758.
 leak:InitModule
+
 # ARM64 python leaks memory from an unclear source. This suppresses that one leak.
 leak:PyObject_Malloc
 
@@ -10,9 +11,8 @@ leak:__tiered_open
 # FIXME-WT-16331: test_tiered04
 leak:__tiered_name_str
 
-# FIXME-WT-16083: Resolve the warnings and remove the suppressions.
+# Originates in the Python interpreter and cannot be addressed in WiredTiger code.
 leak:_PyBytes_FromSize
-leak:__cursor_prepared_discover_setup
 
 # FIXME-WT-16668: This leak seems to have occurred as a result of checkpoint size but that project
 # does not directly allocate memory.

--- a/test/evergreen/asan_leaks.supp
+++ b/test/evergreen/asan_leaks.supp
@@ -12,7 +12,6 @@ leak:__tiered_name_str
 
 # FIXME-WT-16083: Resolve the warnings and remove the suppressions.
 leak:_PyBytes_FromSize
-leak:_wrap__wiredtiger_calc_modify
 leak:__cursor_prepared_discover_setup
 
 # FIXME-WT-16668: This leak seems to have occurred as a result of checkpoint size but that project

--- a/test/suite/fail_lists/asan.fail
+++ b/test/suite/fail_lists/asan.fail
@@ -2,12 +2,13 @@
 # List test files that are not run because they are known failures.
 # They are suppressed because they produce too many warnings that should be solved separately.
 
-# FIXME-WT-16083: Resolve the warnings and remove the file.
-
+# FIXME-WT-17767: in-memory page leaks on panicked or failed connection close
 test_corrupt01.py
-test_layered_eviction04.py
 test_salvage03.py
-test_tiered06.py
 test_txn18.py
+
+# FIXME-WT-17765: memory leaks in dir_store storage source
+test_tiered06.py
+
+# FIXME-WT-17769: log slot buffer leaks on corrupted-log open failure
 test_txn19.py
-test_verify_disagg.py


### PR DESCRIPTION
- Fix leak in SWIG layer for wrap_wiredtiger_calc_modify
- asan_leaks.supp : remove __cursor_prepared_discover_setup as it passes without the suppression
- asan.fail: remove tests that pass without suppression. For more complicated leaks, add new FIXMEs