### PR TITLE
WT-17739 Add libclang-rt to Dockerfile for sanitizer builds

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,10 +3,10 @@ FROM ubuntu:26.04
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     aspell aspell-en ca-certificates ccache clang clang-format clang-tidy \
-    clangd cmake curl doxygen ed file g++ gcc gdb git liblz4-dev libsnappy-dev \
-    libsodium-dev libzstd-dev lld lldb llvm make ninja-build python-is-python3 \
-    python3 python3-dev python3-pip python3-venv swig universal-ctags \
-    zlib1g-dev \
+    clangd cmake curl doxygen ed file g++ gcc gdb git libclang-rt-21-dev \
+    liblz4-dev libsnappy-dev libsodium-dev libzstd-dev lld lldb llvm make \
+    ninja-build python-is-python3 python3 python3-dev python3-pip python3-venv \
+    swig universal-ctags zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
 
 RUN useradd -m -s /bin/bash wiredtiger


### PR DESCRIPTION
ASan builds require libclang_rt.asan.so, which does not come in the base Clang package. You need the libclang-rt-dev package.