### PR TITLE
WT-17615 Skip redundant B-tree search in RTS row modify helper

### DIFF
--- a/src/rollback_to_stable/rts_btree.c
+++ b/src/rollback_to_stable/rts_btree.c
@@ -268,7 +268,8 @@ err:
 
 /*
  * __rts_btree_row_modify --
- *     Add the provided update to the head of the update list.
+ *     Add the provided update to the head of the update list. The caller supplies the row slot via
+ *     rip; the cursor is positioned directly without a page search.
  */
 static WT_INLINE int
 __rts_btree_row_modify(
@@ -285,8 +286,9 @@ __rts_btree_row_modify(
 
     /*
      * The caller already holds the slot, so position the cursor directly instead of searching the
-     * page for the key. With compare == 0 and ins == NULL, __wt_row_modify targets
-     * mod_row_update[slot] and never reaches the insert path that needs the key.
+     * page for the key. cbt.ins is NULL because __wt_btcur_init zeroes the struct; with compare ==
+     * 0 and ins == NULL, __wt_row_modify targets mod_row_update[slot] directly and never reaches
+     * the insert path that needs the key argument.
      */
     cbt.ref = ref;
     cbt.slot = WT_ROW_SLOT(ref->page, rip);

--- a/src/rollback_to_stable/rts_btree.c
+++ b/src/rollback_to_stable/rts_btree.c
@@ -271,7 +271,8 @@ err:
  *     Add the provided update to the head of the update list.
  */
 static WT_INLINE int
-__rts_btree_row_modify(WT_SESSION_IMPL *session, WT_REF *ref, WT_UPDATE **updp, WT_ITEM *key)
+__rts_btree_row_modify(
+  WT_SESSION_IMPL *session, WT_REF *ref, WT_ROW *rip, WT_UPDATE **updp, WT_ITEM *key)
 {
     WT_CURSOR_BTREE cbt;
     WT_DECL_RET;
@@ -282,8 +283,14 @@ __rts_btree_row_modify(WT_SESSION_IMPL *session, WT_REF *ref, WT_UPDATE **updp, 
     __wt_btcur_init(session, &cbt);
     __wt_btcur_open(&cbt);
 
-    /* Search the page. */
-    WT_ERR(__wt_row_search(&cbt, key, true, ref, true, NULL));
+    /*
+     * The caller already holds the slot, so position the cursor directly instead of searching the
+     * page for the key. With compare == 0 and ins == NULL, __wt_row_modify targets
+     * mod_row_update[slot] and never reaches the insert path that needs the key.
+     */
+    cbt.ref = ref;
+    cbt.slot = WT_ROW_SLOT(ref->page, rip);
+    cbt.compare = 0;
 
     /* Apply the modification. */
     if (!dryrun)
@@ -626,7 +633,7 @@ __rts_btree_ondisk_fixup_key(WT_SESSION_IMPL *session, WT_REF *ref, WT_ROW *rip,
     }
 
     if (rip != NULL)
-        WT_ERR(__rts_btree_row_modify(session, ref, &upd, key));
+        WT_ERR(__rts_btree_row_modify(session, ref, rip, &upd, key));
     else
         WT_ERR(__rts_btree_col_modify(session, ref, &upd, recno));
 
@@ -833,7 +840,7 @@ __rts_btree_abort_ondisk_kv(WT_SESSION_IMPL *session, WT_REF *ref, WT_ROW *rip, 
       __wt_key_string(session, key->data, key->size, S2BT(session)->key_format, key_string));
 
     if (rip != NULL)
-        WT_ERR(__rts_btree_row_modify(session, ref, &upd, key));
+        WT_ERR(__rts_btree_row_modify(session, ref, rip, &upd, key));
     else
         WT_ERR(__rts_btree_col_modify(session, ref, &upd, recno));
 


### PR DESCRIPTION
## Summary

Rollback-to-stable iterates over every key on every dirty page during startup recovery and prepared-transaction rollback. For each key it aborts, the row-store modify helper opened a cursor and performed a full B-tree search to re-find a key the caller had already positioned on.

This change threads the already-known row slot into the helper so the cursor is positioned directly. With `compare == 0` and no insert entry, the update lands on the existing slot without any tree traversal or key comparison, removing a search per key on the critical recovery path. This mirrors the existing technique in `__wti_page_inmem_updates` (`bt_page.c`).

## Testing

The full `rollback_to_stable` Python suite, `durable_rollback_to_stable`, `rollback01`, and the `wt8246_compact_rts_data_correctness` csuite test pass, covering row store, prepared transactions, history-store restore, and recovery.