### PR TITLE
[POC] WT-17449 Parallelize the layered ingest drain by key range

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -317,6 +317,7 @@ MSDN
 MSVC
 MSan
 MUTEX
+MVCC
 MacOS
 MapViewOfFile
 Marsaglia's
@@ -939,6 +940,7 @@ dlsym
 dmalloc
 dmb
 dmsg
+drainable
 drealloc
 dropUntilSuccess
 dryrun
@@ -1217,6 +1219,7 @@ keyids
 keylen
 keynum
 keyp
+keysp
 keystr
 keyv
 kp
@@ -1410,6 +1413,7 @@ novalue
 nowait
 np
 npos
+nranges
 nrecords
 nrows
 ns
@@ -1417,6 +1421,7 @@ nsec
 nsecs
 nset
 ntimes
+ntruncates
 nul
 nullptr
 num
@@ -1465,6 +1470,7 @@ packv
 pagesize
 pali
 palite
+parallelized
 param
 params
 parens
@@ -1523,6 +1529,7 @@ probabilistically
 proc
 progname
 programmatically
+proto
 prout
 proxied
 prunable
@@ -1569,6 +1576,7 @@ rebalancing
 recency
 recno
 recnos
+reconciler
 reconfig
 reconfigurations
 reconfigures
@@ -1665,6 +1673,7 @@ sortable
 sp
 spinlock
 spinlocks
+splitsp
 sqlite
 src
 srch
@@ -1770,6 +1779,7 @@ testutil
 th
 there'll
 tid
+tids
 timeslice
 timespec
 timestamper
@@ -1792,6 +1802,7 @@ toml
 toolchain
 toolchains
 totalsec
+touchpoint
 tp
 traceapi
 tracepat
@@ -1838,6 +1849,7 @@ undef
 undeferred
 undefers
 undeleted
+undercounted
 underflowed
 unencoded
 unencrypted
@@ -1868,6 +1880,7 @@ unredacts
 unreferenced
 unsetting
 unsized
+unsynchronized
 unterminated
 untyped
 unvisited

--- a/src/conn/conn_layered_ingest.c
+++ b/src/conn/conn_layered_ingest.c
@@ -21,7 +21,6 @@ static WT_INLINE void
 __layered_assert_stable_btree_state(
   WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *last_upd)
 {
-    WT_UPDATE *upd;
     bool has_value;
 
     if (cbt->compare != 0) {
@@ -29,10 +28,23 @@ __layered_assert_stable_btree_state(
             return;
         /* No on-page value to check; rely solely on visibility. */
         has_value = false;
+    } else if (cbt->ins != NULL) {
+        /*
+         * The key was found via the insert list rather than the on-page binary-search array. This
+         * is legitimate when the stable btree page was reconciled during the leader's last
+         * checkpoint but not yet evicted: in-memory WT_INSERT nodes survive reconciliation until
+         * the page is evicted. Derive has_value by scanning the insert's update chain for any
+         * committed non-tombstone update.
+         */
+        WT_UPDATE *ins_upd;
+        has_value = false;
+        for (ins_upd = cbt->ins->upd; ins_upd != NULL; ins_upd = ins_upd->next)
+            if (ins_upd->txnid != WT_TXN_ABORTED && ins_upd->type != WT_UPDATE_TOMBSTONE) {
+                has_value = true;
+                break;
+            }
     } else {
-        WT_ASSERT_ALWAYS(session, cbt->ins == NULL,
-          "The stable btree should not contain inserts prior to draining");
-
+        WT_UPDATE *upd = NULL;
         if (cbt->ref->page->modify != NULL && cbt->ref->page->modify->mod_row_update != NULL)
             upd = cbt->ref->page->modify->mod_row_update[cbt->slot];
         else
@@ -84,7 +96,7 @@ __layered_assert_stable_btree_state(
  */
 static int
 __layered_move_updates(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_ITEM *key,
-  WT_UPDATE *upds, WT_UPDATE *last_upd, wt_timestamp_t from_ts)
+  WT_UPDATE *upds, WT_UPDATE *last_upd)
 {
     WT_DECL_RET;
 
@@ -94,13 +106,17 @@ __layered_move_updates(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_ITEM *
      */
     __wt_btree_disable_bulk(session);
 
-    /* Search the page. */
+    /*
+     * Re-search and retry on WT_RESTART: concurrent drain workers inserting into the same stable
+     * btree page can cause __wt_insert_serial to return WT_RESTART. The standard WiredTiger pattern
+     * is to re-search before every retry. Reset the cursor first to release the hazard pointer
+     * acquired by the previous __wt_row_search, then search again.
+     */
+retry:
     WT_WITH_PAGE_INDEX(session, ret = __wt_row_search(cbt, key, true, NULL, false, NULL));
     WT_ERR(ret);
 
-    /* We only need to check on the first pass. */
-    if (from_ts == WT_TS_NONE)
-        __layered_assert_stable_btree_state(session, cbt, last_upd);
+    __layered_assert_stable_btree_state(session, cbt, last_upd);
 
     /*
      * If the oldest update being moved is an aborted prepared update and the stable btree has no
@@ -110,15 +126,25 @@ __layered_move_updates(WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_ITEM *
      * prepared update, leaving an orphaned prepared value on the disk image. The tombstone keeps
      * the post-rollback state well-defined (the key never existed).
      */
-    if (cbt->compare != 0 && last_upd->txnid == WT_TXN_ABORTED) {
+    if (cbt->compare != 0 && last_upd->txnid == WT_TXN_ABORTED && last_upd->next == NULL) {
+        /*
+         * Don't reallocate on a WT_RESTART-driven retry: cbt->compare and last_upd->txnid are
+         * stable across retries for the same key, so without the next-NULL guard each retry would
+         * allocate a fresh tombstone and orphan the previous one.
+         */
         WT_ASSERT(session, last_upd->prepared_id != WT_PREPARED_ID_NONE);
         WT_UPDATE *tombstone;
         WT_ERR(__wt_upd_alloc_tombstone(session, &tombstone, NULL));
         last_upd->next = tombstone;
     }
 
-    /* Apply the modification. */
-    WT_ERR(__wt_row_modify(cbt, key, NULL, &upds, WT_UPDATE_INVALID, false, false));
+    ret = __wt_row_modify(cbt, key, NULL, &upds, WT_UPDATE_INVALID, false, false);
+    if (ret == WT_RESTART) {
+        /* Release the hazard pointer before searching again. */
+        WT_ERR(__wt_btcur_reset(cbt));
+        goto retry;
+    }
+    WT_ERR(ret);
 
 err:
     WT_TRET(__wt_btcur_reset(cbt));
@@ -374,6 +400,7 @@ static int
 __layered_fix_prepared_transaction(WT_SESSION_IMPL *session, WT_ITEM *key, WT_BTREE *ingest_btree,
   WT_BTREE *stable_btree, uint64_t txnid, uint64_t prepared_id)
 {
+    WT_DECL_RET;
     WT_FIX_PREPARED_COOKIE cookie;
 
     cookie.key = key;
@@ -382,60 +409,65 @@ __layered_fix_prepared_transaction(WT_SESSION_IMPL *session, WT_ITEM *key, WT_BT
     cookie.txnid = txnid;
     cookie.prepared_id = prepared_id;
 
-    return (
-      __wt_session_array_walk(session, __layered_fix_prepared_transaction_callback, true, &cookie));
+    /*
+     * Serialize across parallel drain workers. Each worker can independently encounter a key
+     * belonging to a still-in-flight prepared transaction and call into here -- the callback then
+     * walks every session in the connection and writes op->btree / op->u.op_upd->txnid for the
+     * matching op. Workers fix different ops (one per key) but they iterate the same txn->mod[]
+     * array, so an unguarded concurrent walk produces an unsynchronized read+write on each
+     * op->btree as workers scan past the other worker's op. The lock is held only across the walk;
+     * rare path, no measurable contention.
+     */
+    __wt_spin_lock(session, &S2C(session)->layered_drain_data.fix_prepared_lock);
+    ret =
+      __wt_session_array_walk(session, __layered_fix_prepared_transaction_callback, true, &cookie);
+    __wt_spin_unlock(session, &S2C(session)->layered_drain_data.fix_prepared_lock);
+    return (ret);
 }
 
+/* Buffer large enough for 255 bytes of key as hex plus NUL. */
+#define WT_LAYERED_KEY_HEX_BUFSIZE 512
+
 /*
- * __layered_apply_truncate_to_stable --
- *     Replay a single follower-recorded truncate against stable. This needs to be done after all
- *     older ingest updates have been drained.
+ * __layered_key_hex --
+ *     Write the full hex encoding of a key bound into buf for logging. A zero-size item (unbounded
+ *     range end) is rendered as "(none)".
  */
-static int
-__layered_apply_truncate_to_stable(WT_SESSION_IMPL *session, WT_TRUNCATE *t)
+static void
+__layered_key_hex(const WT_ITEM *key, char *buf, size_t bufsize)
 {
-    WT_DECL_RET;
+    static const char hex[] = "0123456789abcdef";
+    const uint8_t *data;
+    size_t i, pos;
 
-    WT_ASSERT(session, t->start_key.size > 0 && t->stop_key.size > 0);
-    WT_ASSERT(session, t->start_ts > WT_TS_NONE);
-    WT_ASSERT(session, t->durable_ts >= t->start_ts);
+    if (key->size == 0) {
+        WT_IGNORE_RET(__wt_snprintf(buf, bufsize, "(none)"));
+        return;
+    }
 
-    const char *open_cfg[] = {WT_CONFIG_BASE(session, WT_SESSION_open_cursor), "raw=true", NULL};
-    WT_CURSOR *trunc_start = NULL, *trunc_stop = NULL;
-    WT_ERR(__wt_open_cursor(session, t->layered_table->stable_uri, NULL, open_cfg, &trunc_start));
-    WT_ERR(__wt_open_cursor(session, t->layered_table->stable_uri, NULL, open_cfg, &trunc_stop));
-
-    trunc_start->set_key(trunc_start, &t->start_key);
-    trunc_stop->set_key(trunc_stop, &t->stop_key);
-
-    session->replay_trunc_ctx.txn_id = t->txn_id;
-    session->replay_trunc_ctx.commit_ts = t->start_ts;
-    session->replay_trunc_ctx.durable_ts = t->durable_ts;
-
-    F_SET(session, WT_SESSION_INGEST_REPLAY);
-    ret = __wt_session_range_truncate(session, NULL, trunc_start, trunc_stop);
-    F_CLR(session, WT_SESSION_INGEST_REPLAY);
-
-err:
-    if (trunc_start != NULL)
-        WT_TRET(trunc_start->close(trunc_start));
-    if (trunc_stop != NULL)
-        WT_TRET(trunc_stop->close(trunc_stop));
-    return (ret);
+    data = (const uint8_t *)key->data;
+    for (i = 0, pos = 0; i < key->size && pos + 2 < bufsize; i++) {
+        buf[pos++] = hex[(data[i] >> 4) & 0xf];
+        buf[pos++] = hex[data[i] & 0xf];
+    }
+    buf[pos] = '\0';
 }
 
 /*
  * __layered_copy_ingest_table --
- *     Move ingest updates whose durable timestamp falls in (from_ts, to_ts) to the corresponding
- *     stable table.
+ *     Copy all data from a single ingest table (or a key-range sub-section) to the corresponding
+ *     stable table. key_start and key_stop are optional inclusive-lower / exclusive-upper bounds;
+ *     NULL means unbounded at that end.
  */
 static int
-__layered_copy_ingest_table(
-  WT_SESSION_IMPL *session, const char *ingest_uri, wt_timestamp_t from_ts, wt_timestamp_t to_ts)
+__layered_copy_ingest_table(WT_SESSION_IMPL *session, const char *ingest_uri,
+  const WT_ITEM *key_start, const WT_ITEM *key_stop, wt_timestamp_t from_ts, wt_timestamp_t to_ts,
+  uint64_t *nkeysp)
 {
     WT_BTREE *ingest_btree, *stable_btree;
     WT_CURSOR *ingest_btree_cursor, *ingest_version_cursor, *prepare_cursor, *stable_cursor;
     WT_CURSOR_BTREE *cbt;
+    WT_DECL_ITEM(first_key);
     WT_DECL_ITEM(key);
     WT_DECL_ITEM(stable_uri_buf);
     WT_DECL_ITEM(tmp_key);
@@ -452,12 +484,15 @@ __layered_copy_ingest_table(
     const char *cfg[] = {WT_CONFIG_BASE(session, WT_SESSION_open_cursor), NULL, NULL, NULL};
     const char *open_cfg[] = {
       WT_CONFIG_BASE(session, WT_SESSION_open_cursor), "overwrite", NULL, NULL};
-    bool in_ts_range, is_prepare_rollback, prepare_resolved, preserve_prepared, prepare_txn_fixed;
+    char hex1[WT_LAYERED_KEY_HEX_BUFSIZE], hex2[WT_LAYERED_KEY_HEX_BUFSIZE];
+    bool first_key_set, in_ts_range, is_prepare_rollback, preserve_prepared, prepare_resolved,
+      prepare_txn_fixed, skip_first_next;
 
     ingest_version_cursor = prepare_cursor = stable_cursor = NULL;
     last_upd = prev_upd = upd = upds = NULL;
-    prepare_resolved = prepare_txn_fixed = false;
+    first_key_set = prepare_resolved = prepare_txn_fixed = skip_first_next = false;
     preserve_prepared = F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED);
+    *nkeysp = 0;
 
     WT_RET(__wt_scr_alloc(session, 0, &stable_uri_buf));
     WT_ERR(__layered_derive_stable_uri(session, ingest_uri, stable_uri_buf));
@@ -486,18 +521,51 @@ __layered_copy_ingest_table(
     ingest_btree_cursor = ((WT_CURSOR_VERSION *)ingest_version_cursor)->file_cursor;
     ingest_btree = CUR2BT(ingest_btree_cursor);
 
+    WT_ERR(__wt_scr_alloc(session, 0, &first_key));
     WT_ERR(__wt_scr_alloc(session, 0, &key));
     WT_ERR(__wt_scr_alloc(session, 0, &tmp_key));
     WT_ERR(__wt_scr_alloc(session, 0, &value));
 
+    /*
+     * If a start key is supplied, position the version cursor at the first key at or after
+     * key_start that has a version visible in this slice. A plain exact search is not enough under
+     * timestamp-sliced drain: a split key may have no version in a given slice's timestamp range,
+     * so we search_near and skip forward to the first qualifying key.
+     *
+     * search_near can also return WT_NOTFOUND when the only keys at or after key_start are visible
+     * solely as prepared (uncommitted) updates: its anchor walk skips a key whose only version is
+     * filtered out by the slice's start timestamp, even though a plain next() walk would surface
+     * that prepared version. In that case fall back to an unbounded scan from the start and skip
+     * keys below key_start in the main loop, so a range whose lower keys are prepared-only is still
+     * drained (and its prepared transactions still fixed). A genuinely empty range drains nothing
+     * either way -- the from-start scan simply finds no key in [key_start, key_stop).
+     */
+    if (key_start != NULL) {
+        int start_exact;
+        ingest_version_cursor->set_key(ingest_version_cursor, key_start);
+        WT_ERR_NOTFOUND_OK(
+          ingest_version_cursor->search_near(ingest_version_cursor, &start_exact), true);
+        if (ret == WT_NOTFOUND)
+            WT_ERR(ingest_version_cursor->reset(ingest_version_cursor));
+        else {
+            WT_ERR(ret);
+            /* Positioned strictly below key_start: advance into the range on the first next(). */
+            skip_first_next = start_exact >= 0;
+        }
+    }
+
     for (;;) {
         upd = NULL;
-        WT_ERR_NOTFOUND_OK(ingest_version_cursor->next(ingest_version_cursor), true);
+        if (skip_first_next)
+            skip_first_next = false;
+        else
+            WT_ERR_NOTFOUND_OK(ingest_version_cursor->next(ingest_version_cursor), true);
         if (ret == WT_NOTFOUND) {
             if (key->size > 0 && upds != NULL) {
                 WT_WITH_DHANDLE(session, cbt->dhandle,
-                  ret = __layered_move_updates(session, cbt, key, upds, last_upd, from_ts));
+                  ret = __layered_move_updates(session, cbt, key, upds, last_upd));
                 WT_ERR(ret);
+                ++(*nkeysp);
                 upds = NULL;
             } else
                 ret = 0;
@@ -505,6 +573,43 @@ __layered_copy_ingest_table(
         }
 
         WT_ERR(ingest_version_cursor->get_key(ingest_version_cursor, tmp_key));
+
+        /*
+         * Skip keys strictly below key_start. The cursor is normally already positioned at or after
+         * key_start, so this never fires; it matters only on the from-start fallback taken when
+         * search_near could not anchor on a prepared-only boundary key. No pending updates can have
+         * accumulated yet (the skipped keys precede any in-range key), so there is nothing to
+         * flush.
+         */
+        if (key_start != NULL) {
+            WT_ERR(__wt_compare(session, stable_btree->collator, tmp_key, key_start, &cmp));
+            if (cmp < 0)
+                continue;
+        }
+
+        /*
+         * If a stop key is set for this range, check whether the current key has reached or passed
+         * it. Flush any pending updates accumulated for the previous key, then exit the range
+         * without processing the current key (it belongs to the next range worker).
+         */
+        if (key_stop != NULL) {
+            WT_ERR(__wt_compare(session, stable_btree->collator, tmp_key, key_stop, &cmp));
+            if (cmp >= 0) {
+                __layered_key_hex(tmp_key, hex1, sizeof(hex1));
+                __layered_key_hex(key_stop, hex2, sizeof(hex2));
+                __wt_verbose_level(session, WT_VERB_LAYERED, WT_VERBOSE_DEBUG_1,
+                  "Drain range stop_boundary: table=%s at=%s stop=%s", ingest_uri, hex1, hex2);
+                if (upds != NULL) {
+                    WT_WITH_DHANDLE(session, cbt->dhandle,
+                      ret = __layered_move_updates(session, cbt, key, upds, last_upd));
+                    WT_ERR(ret);
+                    ++(*nkeysp);
+                    upds = NULL;
+                }
+                goto err;
+            }
+        }
+
         WT_ERR(__wt_compare(session, stable_btree->collator, key, tmp_key, &cmp));
         if (cmp != 0) {
             /*
@@ -513,10 +618,16 @@ __layered_copy_ingest_table(
              */
             WT_ASSERT(session, key->size == 0 || cmp <= 0);
 
+            if (!first_key_set) {
+                WT_ERR(__wt_buf_set(session, first_key, tmp_key->data, tmp_key->size));
+                first_key_set = true;
+            }
+
             if (upds != NULL) {
                 WT_WITH_DHANDLE(session, cbt->dhandle,
-                  ret = __layered_move_updates(session, cbt, key, upds, last_upd, from_ts));
+                  ret = __layered_move_updates(session, cbt, key, upds, last_upd));
                 WT_ERR(ret);
+                ++(*nkeysp);
             }
 
             upds = NULL;
@@ -533,8 +644,10 @@ __layered_copy_ingest_table(
 
         is_prepare_rollback = start_txn == WT_TXN_ABORTED;
         /*
-         * Only process updates whose durable timestamp falls in the range. Prepared updates are
-         * included only in the final pass since their commit timestamp is not yet resolved.
+         * Only process updates whose durable timestamp falls in (from_ts, to_ts]. Prepared updates
+         * are included only in the final pass since their commit timestamp is not yet resolved.
+         * This is what lets truncate replays interleave at their timestamp: a key's updates reach
+         * the stable table oldest-first across slices, so each prepend is genuinely the newest.
          */
         in_ts_range = prepare ? (to_ts == WT_TS_MAX) :
                                 (durable_start_ts > from_ts && durable_start_ts <= to_ts);
@@ -557,7 +670,6 @@ __layered_copy_ingest_table(
                     }
                 } else if (!prepare_resolved) {
                     /* Only resolve the updates from the same prepared transaction once. */
-                    WT_ASSERT(session, to_ts == WT_TS_MAX);
                     if (is_prepare_rollback) {
                         /*
                          * The original transaction id is stored in start timestamp and the rollback
@@ -673,6 +785,14 @@ __layered_copy_ingest_table(
     }
 
 err:
+    if (*nkeysp > 0) {
+        __layered_key_hex(first_key, hex1, sizeof(hex1));
+        __layered_key_hex(key, hex2, sizeof(hex2));
+        __wt_verbose_level(session, WT_VERB_LAYERED, WT_VERBOSE_DEBUG_1,
+          "Drain range extent: table=%s keys=%" PRIu64 " first=%s last=%s", ingest_uri, *nkeysp,
+          hex1, hex2);
+    }
+    __wt_scr_free(session, &first_key);
     if (upd != NULL)
         __wt_free(session, upd);
     if (upds != NULL)
@@ -687,6 +807,139 @@ err:
         WT_TRET(prepare_cursor->close(prepare_cursor));
     if (stable_cursor != NULL)
         WT_TRET(stable_cursor->close(stable_cursor));
+    return (ret);
+}
+
+/*
+ * __layered_ingest_table_is_empty --
+ *     Return true if the ingest table has no records.
+ */
+static int
+__layered_ingest_table_is_empty(WT_SESSION_IMPL *session, const char *ingest_uri, bool *emptyp)
+{
+    WT_CURSOR *cursor;
+    WT_DECL_RET;
+
+    *emptyp = false;
+    cursor = NULL;
+
+    if (F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED)) {
+        /*
+         * With preserve_prepared, a rolled-back prepared insert on the ingest btree leaves the key
+         * with an [aborted-prepared-upd -> globally-visible-tombstone] chain. A regular read-
+         * uncommitted cursor walks past the aborted update and sees the tombstone, so it reports
+         * the key as deleted and the ingest btree as empty -- but the corresponding claim-prepared
+         * cell on the stable btree is still unresolved, and only the drain main loop (which
+         * iterates a version cursor with show_prepared_rollback=true) will resolve it. We can't
+         * cheaply distinguish "ingest btree truly empty" from "ingest btree contains only rolled-
+         * back prepares" without running roughly the same scan the drain itself would do, so just
+         * treat the table as non-empty whenever preserve_prepared is enabled. The cost is running
+         * the drain main loop once over a genuinely empty btree -- a single version-cursor next()
+         * returning WT_NOTFOUND.
+         */
+        *emptyp = false;
+    } else {
+        WT_RET(__wt_open_cursor(session, ingest_uri, NULL, NULL, &cursor));
+        /* Set WT_TXN_IGNORE_PREPARE so prepared updates don't cause WT_PREPARE_CONFLICT. */
+        F_SET(session->txn, WT_TXN_IGNORE_PREPARE);
+        WT_WITH_TXN_ISOLATION(session, WT_ISO_READ_UNCOMMITTED, ret = cursor->next(cursor));
+        F_CLR(session->txn, WT_TXN_IGNORE_PREPARE);
+        /*
+         * WT_ROLLBACK here means the cursor hit a modify update that read-uncommitted cannot
+         * reconstruct (WT_MODIFY_READ_UNCOMMITTED). A record exists; the table is not empty.
+         */
+        if (ret == WT_ROLLBACK)
+            *emptyp = false;
+        else if (ret != 0 && ret != WT_NOTFOUND)
+            WT_ERR(ret);
+        else
+            *emptyp = (ret == WT_NOTFOUND);
+    }
+    ret = 0;
+
+err:
+    if (cursor != NULL)
+        WT_TRET(cursor->close(cursor));
+    return (ret);
+}
+
+/*
+ * __layered_apply_truncate_to_stable --
+ *     Replay a single committed follower truncate against the stable btree over its full key range.
+ *     Installs the txn/ts context and issues a range truncate via the INGEST_REPLAY path so that
+ *     tombstones carry the original timestamps.
+ */
+static int
+__layered_apply_truncate_to_stable(WT_SESSION_IMPL *session, WT_TRUNCATE *t)
+{
+    WT_CURSOR *trunc_start, *trunc_stop;
+    WT_DECL_RET;
+    const char *open_cfg[] = {WT_CONFIG_BASE(session, WT_SESSION_open_cursor), "raw=true", NULL};
+
+    WT_ASSERT(session, t->start_key.size > 0 && t->stop_key.size > 0);
+    WT_ASSERT(session, t->start_ts > WT_TS_NONE);
+    WT_ASSERT(session, t->durable_ts >= t->start_ts);
+
+    trunc_start = trunc_stop = NULL;
+    WT_ERR(__wt_open_cursor(session, t->layered_table->stable_uri, NULL, open_cfg, &trunc_start));
+    WT_ERR(__wt_open_cursor(session, t->layered_table->stable_uri, NULL, open_cfg, &trunc_stop));
+
+    trunc_start->set_key(trunc_start, &t->start_key);
+    trunc_stop->set_key(trunc_stop, &t->stop_key);
+
+    session->replay_trunc_ctx.txn_id = t->txn_id;
+    session->replay_trunc_ctx.commit_ts = t->start_ts;
+    session->replay_trunc_ctx.durable_ts = t->durable_ts;
+
+    F_SET(session, WT_SESSION_INGEST_REPLAY);
+    ret = __wt_session_range_truncate(session, NULL, trunc_start, trunc_stop);
+    F_CLR(session, WT_SESSION_INGEST_REPLAY);
+
+err:
+    if (trunc_start != NULL)
+        WT_TRET(trunc_start->close(trunc_start));
+    if (trunc_stop != NULL)
+        WT_TRET(trunc_stop->close(trunc_stop));
+    return (ret);
+}
+
+/*
+ * __layered_apply_and_clear_truncates --
+ *     After all ingest ranges for a table have been drained, apply every committed follower
+ *     truncate from the truncate list to the stable btree (covering keys that only exist in stable
+ *     and were never in the ingest btree), then clear the list. Must be called once per table after
+ *     all parallel drain workers for that table have finished.
+ */
+static int
+__layered_apply_and_clear_truncates(WT_SESSION_IMPL *session, const char *layered_uri)
+{
+    WT_DATA_HANDLE *layered_dhandle;
+    WT_DECL_RET;
+    WT_LAYERED_TABLE *layered_table;
+    WT_TRUNCATE *t;
+
+    layered_dhandle = NULL;
+
+    WT_RET_ERROR_OK(ret = __wt_session_get_dhandle(session, layered_uri, NULL, NULL, 0), ENOENT);
+    if (ret == ENOENT)
+        return (0);
+    layered_dhandle = session->dhandle;
+    layered_table = (WT_LAYERED_TABLE *)layered_dhandle;
+
+    __wt_readlock(session, &layered_table->truncate_lock);
+    TAILQ_FOREACH (t, &layered_table->truncateqh, q) {
+        /* Match the release-store at __wt_txn_truncate_commit. */
+        if (!__wt_atomic_load_bool_acquire(&t->committed))
+            continue;
+        __wt_readunlock(session, &layered_table->truncate_lock);
+        WT_TRET(__layered_apply_truncate_to_stable(session, t));
+        __wt_readlock(session, &layered_table->truncate_lock);
+    }
+    __wt_readunlock(session, &layered_table->truncate_lock);
+
+    __wt_layered_table_truncate_clear(session, layered_table);
+
+    WT_WITH_DHANDLE(session, layered_dhandle, WT_TRET(__wt_session_release_dhandle(session)));
     return (ret);
 }
 
@@ -752,261 +1005,302 @@ err:
 }
 
 /*
- * __layered_drain_ingest_table_and_truncate_list --
- *     Drain ingest to stable in timestamp order, interleaving committed follower truncates.
+ * WT_LAYERED_INTERLEAVE_COPY_ARG --
+ *     Per-range argument for a parallel slice copy in the interleaved drain. Each spawned thread
+ *     copies one key range of one timestamp slice and records its result code.
+ */
+typedef struct {
+    WT_SESSION_IMPL *session; /* Worker's own session; never the calling thread's. */
+    const char *ingest_uri;
+    const WT_ITEM *key_start; /* Inclusive lower bound, NULL = unbounded. */
+    const WT_ITEM *key_stop;  /* Exclusive upper bound, NULL = unbounded. */
+    wt_timestamp_t from_ts;   /* Slice is (from_ts, to_ts]. */
+    wt_timestamp_t to_ts;
+    uint64_t nkeys;
+    int result;
+} WT_LAYERED_INTERLEAVE_COPY_ARG;
+
+/*
+ * __layered_drain_interleave_copy_thread --
+ *     Thread callback for the interleaved drain: copy one key range of one timestamp slice. Errors
+ *     are stored in the argument, not returned, so the spawning thread can aggregate them after the
+ *     join. The slice ordering delivers a key's updates oldest-first, so the single-threaded
+ *     truncate replay between slices is always newest.
+ */
+static WT_THREAD_RET
+__layered_drain_interleave_copy_thread(void *arg)
+{
+    WT_LAYERED_INTERLEAVE_COPY_ARG *a;
+
+    a = (WT_LAYERED_INTERLEAVE_COPY_ARG *)arg;
+    a->result = __layered_copy_ingest_table(
+      a->session, a->ingest_uri, a->key_start, a->key_stop, a->from_ts, a->to_ts, &a->nkeys);
+    return (WT_THREAD_RET_VALUE);
+}
+
+/*
+ * __layered_drain_table_interleaved --
+ *     Drain one ingest table to its stable table for the interleaved-drain proto path. The COPY of
+ *     each timestamp slice is parallelized across K disjoint key ranges; the truncate replays
+ *     between slices run single-threaded. Serializing the truncate-applies is the whole point: the
+ *     concurrent per-worker replay of Structure A conflicted with the ingest fast-truncate clear.
+ *     Here every slice's copies fully finish (their version-cursor snapshots released at the join)
+ *     before the single replay runs, and the fast-truncate clear runs only after every slice with
+ *     no concurrent transaction in flight.
  */
 static int
-__layered_drain_ingest_table_and_truncate_list(WT_SESSION_IMPL *session, const char *ingest_uri)
+__layered_drain_table_interleaved(
+  WT_SESSION_IMPL *session, WT_LAYERED_TABLE_MANAGER_ENTRY *entry, uint64_t *nkeysp)
 {
-    WT_DATA_HANDLE *layered_dhandle = NULL;
+    WT_CONNECTION_IMPL *conn;
+    WT_DATA_HANDLE *layered_dhandle;
     WT_DECL_ITEM(layered_uri_buf);
     WT_DECL_RET;
-    WT_LAYERED_TABLE *layered_table = NULL;
-    WT_TRUNCATE **sorted_truncates = NULL;
-    wt_timestamp_t prev_ts = WT_TS_NONE;
+    WT_ITEM *split_keys;
+    WT_LAYERED_INTERLEAVE_COPY_ARG *args;
+    WT_LAYERED_TABLE *layered_table;
+    WT_SESSION_IMPL **worker_sessions;
+    WT_TRUNCATE **sorted_truncates;
+    wt_thread_t *tids;
+    wt_timestamp_t prev_ts, to_ts;
+    size_t s, ntruncates;
+    uint32_t actual_splits, j, k, nranges;
+    const char *ingest_uri;
+    bool empty;
 
-    WT_RET(__wt_scr_alloc(session, 0, &layered_uri_buf));
-    WT_ERR(__layered_derive_layered_uri(session, ingest_uri, layered_uri_buf));
+    conn = S2C(session);
+    ingest_uri = entry->ingest_uri;
+    layered_dhandle = NULL;
+    layered_table = NULL;
+    split_keys = NULL;
+    sorted_truncates = NULL;
+    args = NULL;
+    tids = NULL;
+    worker_sessions = NULL;
+    ntruncates = 0;
+    actual_splits = 0;
+    nranges = 0;
 
-    WT_ERR_ERROR_OK(
-      __wt_session_get_dhandle(session, layered_uri_buf->data, NULL, NULL, 0), ENOENT, true);
-    if (ret == ENOENT) {
-        __wt_verbose_level(session, WT_VERB_LAYERED, WT_VERBOSE_DEBUG_5,
-          "No layered handle found for ingest table \"%s\", only performing ingest drain",
-          ingest_uri);
-        WT_ERR(__layered_copy_ingest_table(session, ingest_uri, WT_TS_NONE, WT_TS_MAX));
-        ret = 0;
-        goto err;
-    }
+    /* Empty tables: leave their truncates to the post-loop apply-and-clear pass. */
+    WT_RET(__layered_ingest_table_is_empty(session, ingest_uri, &empty));
+    if (empty)
+        return (0);
+
     /*
-     * For each committed truncate, copy ingest updates with upper and lower bounds. The lower bound
-     * is the timestamp of the previous truncate and the upper bound is the timestamp of the current
-     * truncate. After copying ingest updates, apply the range truncate.
+     * Single range per table for now; key-range sampling is added in a follow-up. With no split
+     * keys, actual_splits stays 0 and every slice copies its whole keyspace as one range.
      */
+    nranges = actual_splits + 1;
+
+    WT_ERR(__wt_scr_alloc(session, 0, &layered_uri_buf));
+    WT_ERR(__layered_derive_layered_uri(session, ingest_uri, layered_uri_buf));
+    WT_ERR(__wt_session_get_dhandle(session, layered_uri_buf->data, NULL, NULL, 0));
     layered_dhandle = session->dhandle;
     layered_table = (WT_LAYERED_TABLE *)layered_dhandle;
-    size_t ntruncates;
+
     WT_ERR(
       __layered_build_sorted_truncates(session, layered_table, &sorted_truncates, &ntruncates));
 
-    for (size_t i = 0; i < ntruncates; i++) {
-        WT_TRUNCATE *t = sorted_truncates[i];
-        WT_ERR(__layered_copy_ingest_table(session, ingest_uri, prev_ts, t->start_ts));
-        WT_ERR(__layered_apply_truncate_to_stable(session, t));
-        prev_ts = t->start_ts;
+    WT_ERR(__wt_calloc_def(session, nranges, &args));
+    /*
+     * The calling thread copies range 0 inline; only ranges 1..nranges-1 need their own thread and
+     * session. Allocate the full arrays for index symmetry but populate only the spawned slots.
+     */
+    WT_ERR(__wt_calloc_def(session, nranges, &tids));
+    WT_ERR(__wt_calloc_def(session, nranges, &worker_sessions));
+    for (k = 1; k < nranges; k++)
+        WT_ERR(__wt_open_internal_session(conn, "disagg-drain-interleave", false,
+          WT_SESSION_CAN_WAIT, session->lock_flags, &worker_sessions[k]));
+
+    /*
+     * Walk slices oldest-first. Slice s covers (prev_ts, to_ts]; the tail slice (s == ntruncates)
+     * runs to WT_TS_MAX and is where prepared updates drain. After each non-tail slice's copies
+     * complete, apply that truncate single-threaded.
+     */
+    prev_ts = WT_TS_NONE;
+    for (s = 0; s <= ntruncates; s++) {
+        uint32_t spawned;
+
+        to_ts = (s < ntruncates) ? sorted_truncates[s]->start_ts : WT_TS_MAX;
+
+        for (k = 0; k < nranges; k++) {
+            args[k].session = (k == 0) ? session : worker_sessions[k];
+            args[k].ingest_uri = ingest_uri;
+            args[k].key_start = (k == 0) ? NULL : &split_keys[k - 1];
+            args[k].key_stop = (k == nranges - 1) ? NULL : &split_keys[k];
+            args[k].from_ts = prev_ts;
+            args[k].to_ts = to_ts;
+            args[k].nkeys = 0;
+            args[k].result = 0;
+        }
+
+        /*
+         * Spawn ranges 1..nranges-1; the join below is the barrier for this slice. Threads are
+         * created in order and we stop at the first failure, so the spawned threads are always the
+         * contiguous prefix tids[1..spawned].
+         */
+        spawned = 1;
+        for (k = 1; k < nranges; k++) {
+            ret = __wt_thread_create(
+              session, &tids[k], __layered_drain_interleave_copy_thread, &args[k]);
+            if (ret != 0)
+                break;
+            spawned = k + 1;
+        }
+
+        /* Copy range 0 inline only if no spawn failed; otherwise go straight to the join. */
+        if (ret == 0)
+            args[0].result = __layered_copy_ingest_table(session, ingest_uri, args[0].key_start,
+              args[0].key_stop, prev_ts, to_ts, &args[0].nkeys);
+
+        /* Join every thread we actually created, even on a mid-slice error, to avoid a leak. */
+        for (k = 1; k < spawned; k++)
+            WT_TRET(__wt_thread_join(session, &tids[k]));
+
+        /* First non-zero result wins: thread-create errors, then per-range copy errors. */
+        for (k = 0; ret == 0 && k < nranges; k++)
+            ret = args[k].result;
+        WT_ERR(ret);
+
+        for (k = 0; k < nranges; k++)
+            *nkeysp += args[k].nkeys;
+
+        /* Single-threaded full-range replay between slices, now that all snapshots are released. */
+        if (s < ntruncates)
+            WT_ERR(__layered_apply_truncate_to_stable(session, sorted_truncates[s]));
+        prev_ts = to_ts;
     }
-    WT_ERR(__layered_copy_ingest_table(session, ingest_uri, prev_ts, WT_TS_MAX));
+
+    /*
+     * The workers applied no truncates (we did, single-threaded), so just clear the list. The fast-
+     * truncate clear of the ingest table is safe here: no drain transaction is in flight.
+     */
+    __wt_layered_table_truncate_clear(session, layered_table);
+    WT_WITH_DHANDLE(session, layered_dhandle, WT_TRET(__wt_session_release_dhandle(session)));
+    layered_dhandle = NULL;
+
+    WT_ERR(__layered_clear_ingest_table(session, ingest_uri));
+#ifdef HAVE_DIAGNOSTIC
+    WT_ERR(__layered_assert_ingest_table_empty(session, ingest_uri));
+#endif
+    WT_ERR(__layered_reset_ingest_table_prune_timestamp(session, ingest_uri));
 
 err:
-    if (layered_table != NULL)
-        __wt_layered_table_truncate_clear(session, layered_table);
-
+    if (worker_sessions != NULL) {
+        for (k = 1; k < nranges; k++)
+            if (worker_sessions[k] != NULL)
+                WT_TRET(__wt_session_close_internal(worker_sessions[k]));
+        __wt_free(session, worker_sessions);
+    }
+    __wt_free(session, tids);
+    __wt_free(session, args);
     __wt_free(session, sorted_truncates);
-    /*
-     * Cursor opens and closes can leave session->dhandle pointing at a file dhandle, so scope the
-     * release explicitly back onto the layered dhandle we acquired above.
-     */
     if (layered_dhandle != NULL)
         WT_WITH_DHANDLE(session, layered_dhandle, WT_TRET(__wt_session_release_dhandle(session)));
+    if (split_keys != NULL) {
+        for (j = 0; j < actual_splits; j++)
+            __wt_buf_free(session, &split_keys[j]);
+        __wt_free(session, split_keys);
+    }
     __wt_scr_free(session, &layered_uri_buf);
     return (ret);
 }
 
 /*
- * __layered_drain_worker_run --
- *     Run function for drain workers.
- */
-static int
-__layered_drain_worker_run(WT_SESSION_IMPL *session, WT_THREAD *ctx)
-{
-    WT_DECL_RET;
-    WT_CONNECTION_IMPL *conn = S2C(session);
-    WT_UNUSED(ctx);
-    __wt_spin_lock(session, &conn->layered_drain_data.queue_lock);
-    /* If the queue is empty we are done. */
-    if (TAILQ_EMPTY(&conn->layered_drain_data.work_queue)) {
-        __wt_spin_unlock(session, &conn->layered_drain_data.queue_lock);
-        return (0);
-    }
-
-    WT_LAYERED_DRAIN_ENTRY *work_item = TAILQ_FIRST(&conn->layered_drain_data.work_queue);
-    WT_ASSERT(session, work_item != NULL);
-    TAILQ_REMOVE(&conn->layered_drain_data.work_queue, work_item, q);
-    __wt_spin_unlock(session, &conn->layered_drain_data.queue_lock);
-
-    const char *ingest_uri = work_item->ingest_dhandle->name;
-    WT_ERR_MSG_CHK(session, __layered_drain_ingest_table_and_truncate_list(session, ingest_uri),
-      "Failed to drain ingest and truncate list for \"%s\"", ingest_uri);
-    WT_ERR_MSG_CHK(session, __layered_clear_ingest_table(session, ingest_uri),
-      "Failed to clear ingest table \"%s\"", ingest_uri);
-
-#ifdef HAVE_DIAGNOSTIC
-    WT_ERR(__layered_assert_ingest_table_empty(session, ingest_uri));
-#endif
-
-    WT_ERR_MSG_CHK(session, __layered_reset_ingest_table_prune_timestamp(session, ingest_uri),
-      "Failed to reset ingest table prune timestamp \"%s\"", ingest_uri);
-
-err:
-    /*
-     * Balance the pin acquired when queueing. The work item has already been removed from the
-     * queue, so the cleanup helper won't see it on the error path either.
-     */
-    WT_WITH_DHANDLE(session, work_item->ingest_dhandle, __wt_cursor_dhandle_decr_use(session));
-    __wt_free(session, work_item);
-    return (ret);
-}
-
-/*
- * __layered_drain_worker_check --
- *     Check function for drain workers.
- */
-static bool
-__layered_drain_worker_check(WT_SESSION_IMPL *session)
-{
-    return (__wt_atomic_load_bool_relaxed(&S2C(session)->layered_drain_data.running));
-}
-
-/*
- * __layered_drain_clear_work_queue --
- *     Clear the work queue for ingest table drain.
- */
-static void
-__layered_drain_clear_work_queue(WT_SESSION_IMPL *session)
-{
-    WT_CONNECTION_IMPL *conn = S2C(session);
-    __wt_spin_lock(session, &conn->layered_drain_data.queue_lock);
-    if (!TAILQ_EMPTY(&conn->layered_drain_data.work_queue)) {
-        WT_LAYERED_DRAIN_ENTRY *work_item = NULL, *work_item_tmp = NULL;
-        TAILQ_FOREACH_SAFE(work_item, &conn->layered_drain_data.work_queue, q, work_item_tmp)
-        {
-            TAILQ_REMOVE(&conn->layered_drain_data.work_queue, work_item, q);
-            if (work_item->ingest_dhandle != NULL)
-                WT_WITH_DHANDLE(
-                  session, work_item->ingest_dhandle, __wt_cursor_dhandle_decr_use(session));
-            __wt_free(session, work_item);
-        }
-    }
-    WT_ASSERT_ALWAYS(session, TAILQ_EMPTY(&conn->layered_drain_data.work_queue),
-      "Layered drain work queue failed to drain");
-    __wt_spin_unlock(session, &conn->layered_drain_data.queue_lock);
-    __wt_spin_destroy(session, &conn->layered_drain_data.queue_lock);
-}
-
-/*
- * __layered_queue_ingest_dhandles --
- *     Walk the connection's open dhandle list, queue any open ingest btrees for draining, and pin
- *     each via session_inuse so it survives until the worker processes it. Sourcing the work list
- *     from the dhandle list catches ingest btrees that have been touched (e.g. by prepared
- *     discovery) without their parent `layered:` URI ever being opened.
- */
-static int
-__layered_queue_ingest_dhandles(WT_SESSION_IMPL *session)
-{
-    WT_CONNECTION_IMPL *conn;
-    WT_DATA_HANDLE *dhandle;
-    WT_DECL_RET;
-    WT_LAYERED_DRAIN_ENTRY *work_item;
-
-    conn = S2C(session);
-
-    for (dhandle = NULL;;) {
-        WT_DHANDLE_NEXT(session, dhandle, &conn->dhqh, q);
-        if (dhandle == NULL)
-            break;
-
-        if (!WT_DHANDLE_BTREE(dhandle) || !F_ISSET(dhandle, WT_DHANDLE_OPEN))
-            continue;
-        if (!WT_URI_IS_INGEST(dhandle->name))
-            continue;
-
-        /*
-         * Pin via session_inuse so the dhandle survives sweep across the lock release and worker
-         * processing. The worker decrements after the drain completes.
-         */
-        WT_WITH_DHANDLE(session, dhandle, __wt_cursor_dhandle_incr_use(session));
-
-        if ((ret = __wt_calloc_one(session, &work_item)) != 0) {
-            WT_WITH_DHANDLE(session, dhandle, __wt_cursor_dhandle_decr_use(session));
-            WT_RET(ret);
-        }
-        work_item->ingest_dhandle = dhandle;
-        __wt_spin_lock(session, &conn->layered_drain_data.queue_lock);
-        TAILQ_INSERT_HEAD(&conn->layered_drain_data.work_queue, work_item, q);
-        __wt_spin_unlock(session, &conn->layered_drain_data.queue_lock);
-    }
-    return (0);
-}
-
-/*
  * __wti_layered_drain_ingest_tables --
- *     Moving all the data from the ingest tables to the stable tables
+ *     Move all data from ingest tables to stable tables. Tables are processed sequentially; within
+ *     each non-empty table the per-timestamp-slice copy is parallelized across key ranges while the
+ *     truncate replays between slices run single-threaded (see __layered_drain_table_interleaved).
  */
 int
 __wti_layered_drain_ingest_tables(WT_SESSION_IMPL *session)
 {
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
-
-    bool empty, group_created;
+    WT_LAYERED_TABLE_MANAGER *manager;
+    WT_LAYERED_TABLE_MANAGER_ENTRY **entries;
+    size_t i, table_count;
+    uint64_t nkeys, t_start;
+    int64_t bytes_after, bytes_before;
+    bool lock_initialized;
 
     conn = S2C(session);
-    group_created = false;
-
-    /* Initialize the work queue. */
-    TAILQ_INIT(&conn->layered_drain_data.work_queue);
-    WT_RET(__wt_spin_init(
-      session, &conn->layered_drain_data.queue_lock, "layered drain work queue lock"));
-
-    __wt_atomic_store_bool(&conn->layered_drain_data.running, true);
-
-    bool multithreaded = conn->layered_drain_data.thread_count > 1;
+    manager = &conn->layered_table_manager;
+    entries = NULL;
+    bytes_before = 0;
+    t_start = 0;
+    lock_initialized = false;
 
     /*
-     * Create the thread group. The application thread is also a drain thread so the configured
-     * thread count needs to be greater than 1 for this to be meaningful. We still lock and queue
-     * work for single threaded mode, as such single threaded is only recommended for testing.
+     * Snapshot the table manager's entry array under the lock so we don't race with entries being
+     * added, removed, or the array being reallocated (fixes FIXME-WT-14734). Capture the calloc
+     * return value and check it only after unlocking so we never take the error path with the lock
+     * held.
      */
-    if (multithreaded) {
-        WT_ERR(__wt_thread_group_create(session, &conn->layered_drain_data.threads, "disagg-drain",
-          conn->layered_drain_data.thread_count - 1, conn->layered_drain_data.thread_count - 1,
-          WT_THREAD_CAN_WAIT | WT_THREAD_PANIC_FAIL, __layered_drain_worker_check,
-          __layered_drain_worker_run, NULL));
-        group_created = true;
+    __wt_spin_lock(session, &manager->layered_table_lock);
+    table_count = manager->open_layered_table_count;
+    if (table_count > 0) {
+        ret = __wt_calloc_def(session, table_count, &entries);
+        if (ret == 0)
+            for (i = 0; i < table_count; i++)
+                entries[i] = manager->entries[i];
     }
-
-    /* FIXME-WT-14735: skip empty ingest tables. */
-    WT_WITH_HANDLE_LIST_READ_LOCK(session, ret = __layered_queue_ingest_dhandles(session));
+    __wt_spin_unlock(session, &manager->layered_table_lock);
     WT_ERR(ret);
 
+    bytes_before = WT_STAT_CONN_READ(conn->stats, block_byte_read);
+    __wt_atomic_store_uint64(&conn->layered_drain_data.total_keys_drained, 0);
+    t_start = __wt_clock(session);
+
     /*
-     * We can be lazy here and use the current thread as a worker thread. Then once this loop exits
-     * we can kill our thread group.
+     * The per-slice copies of a table are run on internal worker sessions that call into
+     * __layered_fix_prepared_transaction; serialize those calls with the fix-prepared lock.
      */
-    while (true) {
-        __wt_spin_lock(session, &conn->layered_drain_data.queue_lock);
-        empty = TAILQ_EMPTY(&conn->layered_drain_data.work_queue);
-        __wt_spin_unlock(session, &conn->layered_drain_data.queue_lock);
-        if (empty) {
-            /*
-             * Notify the other threads to exit. Relaxed is okay here as the worker threads will
-             * observe this change eventually.
-             */
-            __wt_atomic_store_bool_relaxed(&conn->layered_drain_data.running, false);
-            break;
-        }
-        WT_ERR(__layered_drain_worker_run(session, NULL));
+    WT_ERR(__wt_spin_init(
+      session, &conn->layered_drain_data.fix_prepared_lock, "layered drain fix-prepared lock"));
+    lock_initialized = true;
+
+    /*
+     * Drain each non-empty table with the timestamp-interleaved algorithm, which clears that
+     * table's truncate list itself. Empty/skipped tables are left for the post-loop apply-and-clear
+     * pass.
+     */
+    for (i = 0; i < table_count; i++) {
+        if (entries[i] == NULL)
+            continue;
+        nkeys = 0;
+        WT_ERR(__layered_drain_table_interleaved(session, entries[i], &nkeys));
+        (void)__wt_atomic_add_uint64(&conn->layered_drain_data.total_keys_drained, nkeys);
     }
 
 err:
-    /* Let any running threads finish up. */
-    if (group_created) {
-        __wt_cond_signal(session, conn->layered_drain_data.threads.wait_cond);
-        __wt_writelock(session, &conn->layered_drain_data.threads.lock);
-        WT_TRET(__wt_thread_group_destroy(session, &conn->layered_drain_data.threads));
+    /*
+     * Apply committed follower truncates to the stable btree and clear the truncate list for every
+     * table whose ingest btree was empty (and therefore skipped above). Keys that only exist in
+     * stable never written to the ingest btree are not covered by ingest tombstones; the explicit
+     * range truncate replay is the only path that stamps them deleted. For drained tables the list
+     * was already cleared, so this is a no-op (apply nothing, clear nothing).
+     */
+    if (entries != NULL) {
+        for (i = 0; i < table_count; i++) {
+            WT_LAYERED_TABLE_MANAGER_ENTRY *e = entries[i];
+            if (e == NULL)
+                continue;
+            WT_TRET(__layered_apply_and_clear_truncates(session, e->layered_uri));
+        }
     }
-    /* Cleanup and release resources. */
-    __layered_drain_clear_work_queue(session);
+
+    bytes_after = WT_STAT_CONN_READ(conn->stats, block_byte_read);
+    if (t_start > 0)
+        __wt_verbose_level(session, WT_VERB_LAYERED, WT_VERBOSE_INFO,
+          "Drain complete: %" WT_SIZET_FMT " table(s) drained_keys=%" PRIu64
+          " block_bytes_read=%" PRId64 " total_ms=%" PRIu64,
+          table_count, __wt_atomic_load_uint64(&conn->layered_drain_data.total_keys_drained),
+          bytes_after - bytes_before, WT_CLOCKDIFF_MS(__wt_clock(session), t_start));
+
+    if (lock_initialized)
+        __wt_spin_destroy(session, &conn->layered_drain_data.fix_prepared_lock);
+    __wt_free(session, entries);
     return (ret);
 }
 

--- a/src/conn/conn_layered_ingest.c
+++ b/src/conn/conn_layered_ingest.c
@@ -864,6 +864,187 @@ err:
 }
 
 /*
+ * __layered_key_cmp --
+ *     Lexicographic comparator for WT_ITEM keys; suitable as a qsort callback.
+ */
+static int
+__layered_key_cmp(const void *a, const void *b)
+{
+    const WT_ITEM *ka, *kb;
+    size_t min_len;
+    int cmp;
+
+    ka = (const WT_ITEM *)a;
+    kb = (const WT_ITEM *)b;
+    min_len = WT_MIN(ka->size, kb->size);
+    if (min_len > 0 && (cmp = memcmp(ka->data, kb->data, min_len)) != 0)
+        return (cmp);
+    return (ka->size < kb->size ? -1 : ka->size > kb->size ? 1 : 0);
+}
+
+/*
+ * __layered_sample_ingest_keys --
+ *     Sample drainable keys from the ingest table and return up to (num_ranges - 1) split keys that
+ *     divide the drainable key space into roughly equal ranges. Uses a version cursor (filtered by
+ *     last_checkpoint_timestamp) so that only keys that will actually be drained contribute to the
+ *     sample preventing split points from landing in the pre-checkpoint key region where no drain
+ *     work will be done. Applies reservoir sampling (Algorithm R) over the sequential drainable-key
+ *     scan so that a single pass produces a uniform random sample of up to num_ranges^2 keys
+ *     without knowing the total count in advance. The caller owns the returned array and must free
+ *     it. Returns actual_splitsp == 0 when the drainable key space is too small to subdivide.
+ *     sampled_keysp receives the total number of unique drainable keys seen, useful as a proxy for
+ *     table size in diagnostic logging.
+ */
+static int
+__layered_sample_ingest_keys(WT_SESSION_IMPL *session, const char *ingest_uri, uint32_t num_ranges,
+  WT_ITEM **split_keysp, uint32_t *actual_splitsp, uint64_t *sampled_keysp)
+{
+    WT_CONNECTION_IMPL *conn;
+    WT_CURSOR *cursor;
+    WT_CURSOR_BTREE *cbt;
+    WT_CURSOR_VERSION *cversion;
+    WT_DECL_ITEM(cur_key);
+    WT_DECL_ITEM(prev_key);
+    WT_DECL_RET;
+    WT_ITEM *samples, *split_keys;
+    wt_timestamp_t last_checkpoint_timestamp;
+    uint64_t key_count;
+    uint32_t i, idx, j, max_splits, n_collected, n_splits, num_samples;
+    char buf[256], buf2[64];
+    const char *cfg[] = {WT_CONFIG_BASE(session, WT_SESSION_open_cursor), NULL, NULL};
+
+    conn = S2C(session);
+    cursor = NULL;
+    samples = NULL;
+    split_keys = NULL;
+    key_count = 0;
+    n_collected = 0;
+    n_splits = 0;
+    *split_keysp = NULL;
+    *actual_splitsp = 0;
+    *sampled_keysp = 0;
+
+    if (num_ranges <= 1)
+        return (0);
+
+    max_splits = num_ranges - 1;
+    num_samples = WT_MIN(num_ranges * num_ranges, 4096);
+
+    /*
+     * Open a version cursor filtered by last_checkpoint_timestamp so that cursor->next() only
+     * returns drainable (post-checkpoint) keys. This guarantees all split points fall on keys that
+     * drain workers will actually encounter, avoiding the pre-checkpoint dead zone.
+     */
+    last_checkpoint_timestamp =
+      __wt_atomic_load_uint64_acquire(&conn->disaggregated_storage.last_checkpoint_timestamp);
+    if (last_checkpoint_timestamp != WT_TS_NONE)
+        WT_ERR(__wt_snprintf(
+          buf2, sizeof(buf2), "start_timestamp=%" PRIx64 "", last_checkpoint_timestamp));
+    else
+        buf2[0] = '\0';
+    /*
+     * Match the drain main loop's version-cursor configuration. timestamp_order=true keeps the
+     * iteration ordered, and show_prepared_rollback=true makes rolled-back prepared updates visible
+     * -- without it, an ingest btree whose keys are dominated by rolled-back prepares would be
+     * undercounted here, causing split points to cluster in the committed region and load to
+     * imbalance across workers.
+     */
+    WT_ERR(__wt_snprintf(buf, sizeof(buf),
+      "debug=(dump_version=(enabled=true,raw_key_value=true,timestamp_order=true,cross_key=true,"
+      "show_prepared_rollback=%s,%s))",
+      F_ISSET(conn, WT_CONN_PRESERVE_PREPARED) ? "true" : "false", buf2));
+    cfg[1] = buf;
+
+    WT_ERR(__wt_scr_alloc(session, 0, &cur_key));
+    WT_ERR(__wt_scr_alloc(session, 0, &prev_key));
+    WT_ERR(__wt_open_cursor(session, ingest_uri, NULL, cfg, &cursor));
+    cversion = (WT_CURSOR_VERSION *)cursor;
+    cbt = (WT_CURSOR_BTREE *)cversion->file_cursor;
+    WT_ERR(__wt_calloc_def(session, num_samples, &samples));
+
+    /*
+     * Reservoir sampling (Algorithm R): stream drainable keys via cursor->next() and maintain a
+     * uniform random sample of num_samples unique keys. We read the raw key from the underlying
+     * btree cursor and compare with prev_key to count each unique key exactly once, regardless of
+     * how many versions it has.
+     */
+    for (;;) {
+        ret = cursor->next(cursor);
+        if (ret == WT_NOTFOUND) {
+            ret = 0;
+            break;
+        }
+        WT_ERR(ret);
+
+        WT_ERR(cbt->iface.get_key(&cbt->iface, cur_key));
+
+        /* Multiple versions of the same key are returned in sequence  count each key once. */
+        if (prev_key->size > 0 && prev_key->size == cur_key->size &&
+          memcmp(prev_key->data, cur_key->data, cur_key->size) == 0)
+            continue;
+
+        WT_ERR(__wt_buf_set(session, prev_key, cur_key->data, cur_key->size));
+        key_count++;
+
+        if (key_count <= num_samples) {
+            /* Fill the reservoir with the first num_samples keys. */
+            WT_ERR(__wt_buf_set(session, &samples[key_count - 1], cur_key->data, cur_key->size));
+        } else {
+            /* Replace a random reservoir slot with probability num_samples / key_count. */
+            j = (uint32_t)(__wt_random(&session->rnd_random) % key_count);
+            if (j < num_samples)
+                WT_ERR(__wt_buf_set(session, &samples[j], cur_key->data, cur_key->size));
+        }
+    }
+
+    n_collected = (uint32_t)WT_MIN(key_count, (uint64_t)num_samples);
+    *sampled_keysp = key_count;
+
+    /* Need at least 2 samples per desired split to produce meaningful boundaries. */
+    n_splits = WT_MIN(max_splits, n_collected / 2);
+    if (n_splits == 0)
+        goto err;
+
+    /* Sort samples lexicographically to approximate the drainable key space distribution. */
+    __wt_qsort(samples, n_collected, sizeof(WT_ITEM), __layered_key_cmp);
+
+    WT_ERR(__wt_calloc_def(session, n_splits, &split_keys));
+
+    /* Pick n_splits evenly spaced entries from the sorted sample array. */
+    for (i = 0; i < n_splits; i++) {
+        idx = (uint32_t)((uint64_t)n_collected * (i + 1) / (n_splits + 1));
+        WT_ERR(__wt_buf_set(session, &split_keys[i], samples[idx].data, samples[idx].size));
+    }
+
+    *split_keysp = split_keys;
+    *actual_splitsp = n_splits;
+    split_keys = NULL;
+
+err:
+    __wt_scr_free(session, &cur_key);
+    __wt_scr_free(session, &prev_key);
+    if (cursor != NULL)
+        WT_TRET(cursor->close(cursor));
+    if (samples != NULL) {
+        /* Only n_collected slots were populated; the tail slots are zeroed. */
+        for (i = 0; i < n_collected; i++)
+            __wt_buf_free(session, &samples[i]);
+        __wt_free(session, samples);
+    }
+    if (split_keys != NULL) {
+        /*
+         * split_keys is allocated with n_splits elements (line 1150), which may be smaller than
+         * max_splits when the drainable key count is sparse. Iterating up to max_splits would walk
+         * past the allocation.
+         */
+        for (i = 0; i < n_splits; i++)
+            __wt_buf_free(session, &split_keys[i]);
+        __wt_free(session, split_keys);
+    }
+    return (ret);
+}
+
+/*
  * __layered_apply_truncate_to_stable --
  *     Replay a single committed follower truncate against the stable btree over its full key range.
  *     Installs the txn/ts context and issues a range truncate via the INGEST_REPLAY path so that
@@ -1064,6 +1245,7 @@ __layered_drain_table_interleaved(
     wt_thread_t *tids;
     wt_timestamp_t prev_ts, to_ts;
     size_t s, ntruncates;
+    uint64_t actual_sampled;
     uint32_t actual_splits, j, k, nranges;
     const char *ingest_uri;
     bool empty;
@@ -1086,10 +1268,9 @@ __layered_drain_table_interleaved(
     if (empty)
         return (0);
 
-    /*
-     * Single range per table for now; key-range sampling is added in a follow-up. With no split
-     * keys, actual_splits stays 0 and every slice copies its whole keyspace as one range.
-     */
+    /* Sample once per table; the same split keys partition every slice. */
+    WT_ERR(__layered_sample_ingest_keys(session, ingest_uri, conn->layered_drain_data.thread_count,
+      &split_keys, &actual_splits, &actual_sampled));
     nranges = actual_splits + 1;
 
     WT_ERR(__wt_scr_alloc(session, 0, &layered_uri_buf));

--- a/src/conn/conn_layered_ingest.c
+++ b/src/conn/conn_layered_ingest.c
@@ -318,8 +318,13 @@ __layered_fix_prepared_transaction_callback(
         /*
          * Mark the original update on the ingest btree as aborted. Otherwise, we may get a
          * WT_ROLLBACK error when we try to truncate the ingest btree.
+         *
+         * Use the synchronized store: a concurrent drain worker's version cursor may be reading
+         * this update's txnid (to skip aborted updates) while we abort it. This matches how WT
+         * aborts an update's txnid elsewhere and pairs with the atomic reads in the visibility
+         * path.
          */
-        op->u.op_upd->txnid = WT_TXN_ABORTED;
+        __wt_tsan_suppress_store_uint64_v(&op->u.op_upd->txnid, WT_TXN_ABORTED);
         /* Point the operation to the stable btree. */
         op->btree = cookie->stable_btree;
 

--- a/src/conn/conn_layered_ingest.c
+++ b/src/conn/conn_layered_ingest.c
@@ -708,35 +708,33 @@ __truncate_cmp_by_start_ts(const void *a, const void *b)
 
 /*
  * __layered_build_sorted_truncates --
- *     Create a sorted array of committed truncates from the table's truncate list.
+ *     Create a timestamp-sorted array of committed truncates from the table's truncate list.
  */
 static int
 __layered_build_sorted_truncates(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered_table,
   WT_TRUNCATE ***sortedp, size_t *ntruncatesp)
 {
     WT_DECL_RET;
-    WT_TRUNCATE *t = NULL, **sorted = NULL;
-    size_t i = 0, ntruncates = 0;
+    WT_TRUNCATE *t, **sorted;
+    size_t i, ntruncates;
 
     *sortedp = NULL;
     *ntruncatesp = 0;
+    sorted = NULL;
+    i = ntruncates = 0;
 
     __wt_readlock(session, &layered_table->truncate_lock);
     TAILQ_FOREACH (t, &layered_table->truncateqh, q)
-        if (t->txn_id != WT_TXN_NONE)
+        if (__wt_atomic_load_bool_acquire(&t->committed))
             ++ntruncates;
-
-    /* Early exit if there are no committed truncates. */
     if (ntruncates == 0)
         goto err;
 
     WT_ERR(__wt_calloc(session, ntruncates, sizeof(WT_TRUNCATE *), &sorted));
-    /* Populate the array with committed truncates. */
     TAILQ_FOREACH (t, &layered_table->truncateqh, q)
-        if (t->txn_id != WT_TXN_NONE)
+        if (__wt_atomic_load_bool_acquire(&t->committed))
             sorted[i++] = t;
 
-    /* Sort the array of committed truncates by start timestamp. */
     __wt_qsort(sorted, ntruncates, sizeof(WT_TRUNCATE *), __truncate_cmp_by_start_ts);
     *sortedp = sorted;
     *ntruncatesp = ntruncates;

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -945,6 +945,7 @@ __clayered_stable_replay_remove_int(WT_CURSOR_BTREE *cbt, const WT_ITEM *value, 
     WT_UNUSED(modify_type);
 
     session = CUR2S(cbt);
+
     WT_RET(__wt_upd_alloc(session, NULL, WT_UPDATE_TOMBSTONE, &upd, NULL));
     upd->txnid = session->replay_trunc_ctx.txn_id;
     upd->upd_start_ts = session->replay_trunc_ctx.commit_ts;

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -1088,6 +1088,275 @@ err:
 }
 
 /*
+ * __curversion_search_near_compare --
+ *     Compare the file cursor's current position against the search key for search-near. Row-store
+ *     compares keys through the collator; column-store compares record numbers.
+ */
+static int
+__curversion_search_near_compare(WT_SESSION_IMPL *session, WT_CURSOR *file_cursor,
+  WT_ITEM *search_key, uint64_t search_recno, int *cmpp)
+{
+    WT_CURSOR_BTREE *cbt = (WT_CURSOR_BTREE *)file_cursor;
+
+    if (CUR2BT(cbt)->type == BTREE_ROW)
+        return (__wt_compare(session, CUR2BT(cbt)->collator, &file_cursor->key, search_key, cmpp));
+
+    *cmpp = cbt->recno < search_recno ? -1 : cbt->recno == search_recno ? 0 : 1;
+    return (0);
+}
+
+/*
+ * __curversion_position_key --
+ *     Establish a clean key-only position on an existing key. The key must exist, so the exact
+ *     search always succeeds. Row-store positions by key bytes, column-store by record number.
+ */
+static int
+__curversion_position_key(
+  WT_SESSION_IMPL *session, WT_CURSOR *file_cursor, WT_ITEM *key, uint64_t recno)
+{
+    WT_CURSOR_BTREE *cbt = (WT_CURSOR_BTREE *)file_cursor;
+
+    WT_RET(file_cursor->reset(file_cursor));
+    if (CUR2BT(cbt)->type == BTREE_ROW)
+        WT_RET(__wt_buf_set(session, &file_cursor->key, key->data, key->size));
+    else
+        file_cursor->recno = recno;
+    F_SET(file_cursor, WT_CURSTD_KEY_EXT | WT_CURSTD_KEY_ONLY);
+    return (__wt_btcur_search(cbt));
+}
+
+/*
+ * __curversion_position_boundary --
+ *     Position the file cursor, in key-only mode, on the boundary key for a search-near phase: when
+ *     at_or_after is true, the smallest key greater than or equal to the search key; otherwise the
+ *     largest key strictly less than it. Returns WT_NOTFOUND when no such key exists. The version
+ *     cursor must observe every key, including ones whose newest committed value is a tombstone, so
+ *     all positioning here runs in key-only mode and steps key by key rather than using the btree
+ *     search-near (which skips records that are not visible to the reader's snapshot, and is not
+ *     safe to run in key-only mode). Stepping off either end of the tree resets the cursor, so the
+ *     best candidate seen so far is tracked separately and the cursor is re-positioned on it before
+ *     returning.
+ */
+static int
+__curversion_position_boundary(WT_SESSION_IMPL *session, WT_CURSOR_VERSION *version_cursor,
+  WT_ITEM *search_key, uint64_t search_recno, WT_ITEM *anchor_key, uint64_t anchor_recno,
+  bool at_or_after)
+{
+    WT_CURSOR *file_cursor;
+    WT_CURSOR_BTREE *cbt;
+    WT_DECL_ITEM(candidate);
+    WT_DECL_RET;
+    uint64_t candidate_recno;
+    int cmp;
+    bool have_candidate;
+
+    file_cursor = version_cursor->file_cursor;
+    cbt = (WT_CURSOR_BTREE *)file_cursor;
+    candidate_recno = 0;
+    have_candidate = false;
+
+    WT_ERR(__wt_scr_alloc(session, 0, &candidate));
+    WT_ERR(__curversion_position_key(session, file_cursor, anchor_key, anchor_recno));
+    WT_ERR(__curversion_search_near_compare(session, file_cursor, search_key, search_recno, &cmp));
+
+    /*
+     * The walk direction is fixed by which side of the search key the anchor falls on. If the
+     * anchor is already on the requested side we step away from the search key tracking the closest
+     * key that still qualifies; if it is on the wrong side we step towards the search key and the
+     * first key that reaches the requested side is the answer.
+     */
+    if (at_or_after ? cmp >= 0 : cmp < 0) {
+        /* On the requested side: keep the closest qualifying key as we step away. */
+        for (;;) {
+            WT_ERR(__wt_buf_set(session, candidate, file_cursor->key.data, file_cursor->key.size));
+            candidate_recno = cbt->recno;
+            have_candidate = true;
+
+            F_SET(file_cursor, WT_CURSTD_KEY_ONLY);
+            if (at_or_after)
+                WT_ERR_NOTFOUND_OK(__wt_btcur_prev(cbt, false), true);
+            else
+                WT_ERR_NOTFOUND_OK(__wt_btcur_next(cbt, false), true);
+            if (ret == WT_NOTFOUND)
+                break;
+
+            WT_ERR(__curversion_search_near_compare(
+              session, file_cursor, search_key, search_recno, &cmp));
+            if (at_or_after ? cmp < 0 : cmp >= 0)
+                break;
+        }
+    } else {
+        /* On the wrong side: step towards the search key until we reach the requested side. */
+        for (;;) {
+            F_SET(file_cursor, WT_CURSTD_KEY_ONLY);
+            if (at_or_after)
+                WT_ERR_NOTFOUND_OK(__wt_btcur_next(cbt, false), true);
+            else
+                WT_ERR_NOTFOUND_OK(__wt_btcur_prev(cbt, false), true);
+            if (ret == WT_NOTFOUND)
+                break;
+
+            WT_ERR(__curversion_search_near_compare(
+              session, file_cursor, search_key, search_recno, &cmp));
+            if (at_or_after ? cmp >= 0 : cmp < 0) {
+                WT_ERR(
+                  __wt_buf_set(session, candidate, file_cursor->key.data, file_cursor->key.size));
+                candidate_recno = cbt->recno;
+                have_candidate = true;
+                break;
+            }
+        }
+    }
+
+    if (!have_candidate) {
+        ret = WT_NOTFOUND;
+        goto err;
+    }
+
+    ret = __curversion_position_key(session, file_cursor, candidate, candidate_recno);
+
+err:
+    __wt_scr_free(session, &candidate);
+    return (ret);
+}
+
+/*
+ * __curversion_search_near --
+ *     WT_CURSOR->search_near method for version cursors. Position on the closest key that has a
+ *     version visible under the cursor's filter, biasing towards keys greater than or equal to the
+ *     search key, and load its newest visible version so the caller can iterate forward.
+ */
+static int
+__curversion_search_near(WT_CURSOR *cursor, int *exactp)
+{
+    WT_CURSOR *file_cursor;
+    WT_CURSOR_BTREE *cbt;
+    WT_CURSOR_VERSION *version_cursor;
+    WT_DECL_ITEM(anchor_key);
+    WT_DECL_ITEM(search_key);
+    WT_DECL_RET;
+    WT_SESSION_IMPL *session;
+    WT_TXN *txn = NULL;
+    uint64_t anchor_recno, search_recno;
+    bool clear_ignore_prepare;
+
+    version_cursor = (WT_CURSOR_VERSION *)cursor;
+    file_cursor = version_cursor->file_cursor;
+    cbt = (WT_CURSOR_BTREE *)file_cursor;
+    clear_ignore_prepare = false;
+
+    CURSOR_API_CALL(cursor, session, ret, search_near, cbt->dhandle);
+    txn = session->txn;
+
+    /* The global visibility must not move while we walk versions, so require snapshot isolation. */
+    if (txn->isolation != WT_ISO_SNAPSHOT)
+        WT_ERR_SUB(session, WT_ROLLBACK, WT_NONE,
+          "version cursor can only be called with snapshot isolation");
+
+    WT_ERR(__cursor_checkkey(file_cursor));
+    if (F_ISSET(file_cursor, WT_CURSTD_KEY_INT))
+        WT_ERR_SUB(
+          session, WT_ROLLBACK, WT_NONE, "version cursor cannot be called when it is positioned");
+
+    /* The forward and backward phases both search from the original key, so save a copy. */
+    WT_ERR(__wt_scr_alloc(session, file_cursor->key.size, &search_key));
+    WT_ERR(__wt_buf_set(session, search_key, file_cursor->key.data, file_cursor->key.size));
+    search_recno = file_cursor->recno;
+
+    /*
+     * Find a real key to anchor the key-only walk on. The btree search-near reads a value, so it
+     * cannot run in key-only mode, but it conveniently handles the empty-tree case and lands on an
+     * existing key regardless of the requested bias. Ignore prepared conflicts while anchoring: the
+     * version cursor surfaces prepared updates through its own walk below, and the anchor only
+     * needs some committed key to seed it; without this, search-near on a prepared key returns
+     * WT_PREPARE_CONFLICT.
+     */
+    F_CLR(file_cursor, WT_CURSTD_KEY_ONLY);
+    if (!F_ISSET(txn, WT_TXN_IGNORE_PREPARE)) {
+        F_SET(txn, WT_TXN_IGNORE_PREPARE);
+        clear_ignore_prepare = true;
+    }
+    WT_ERR_NOTFOUND_OK(__wt_btcur_search_near(cbt, NULL), true);
+    if (clear_ignore_prepare) {
+        F_CLR(txn, WT_TXN_IGNORE_PREPARE);
+        clear_ignore_prepare = false;
+    }
+    if (ret == WT_NOTFOUND)
+        goto notfound;
+    WT_ERR(__wt_scr_alloc(session, file_cursor->key.size, &anchor_key));
+    WT_ERR(__wt_buf_set(session, anchor_key, file_cursor->key.data, file_cursor->key.size));
+    anchor_recno = cbt->recno;
+
+    /*
+     * Forward phase: position on the smallest key at or after the search key, then walk forward
+     * until we find a key with a version visible under the filter.
+     */
+    WT_ERR(__curversion_version_reset(version_cursor));
+    WT_ERR_NOTFOUND_OK(__curversion_position_boundary(session, version_cursor, search_key,
+                         search_recno, anchor_key, anchor_recno, true),
+      true);
+    if (ret == WT_NOTFOUND)
+        goto backward;
+
+    for (;;) {
+        WT_ERR(__curversion_skip_starting_updates(session, version_cursor));
+        WT_ERR_NOTFOUND_OK(__curversion_next_single_key(cursor), true);
+        if (ret == 0)
+            goto found;
+
+        WT_ERR(__curversion_version_reset(version_cursor));
+        F_SET(file_cursor, WT_CURSTD_KEY_ONLY);
+        WT_ERR_NOTFOUND_OK(__wt_btcur_next(cbt, false), true);
+        if (ret == WT_NOTFOUND)
+            break;
+    }
+
+backward:
+    /*
+     * Backward phase: no visible version at or after the search key, so walk backward from the
+     * largest preceding key, returning the first one with a version visible under the filter.
+     */
+    WT_ERR(__curversion_version_reset(version_cursor));
+    WT_ERR_NOTFOUND_OK(__curversion_position_boundary(session, version_cursor, search_key,
+                         search_recno, anchor_key, anchor_recno, false),
+      true);
+    if (ret == WT_NOTFOUND)
+        goto notfound;
+
+    for (;;) {
+        WT_ERR(__curversion_skip_starting_updates(session, version_cursor));
+        WT_ERR_NOTFOUND_OK(__curversion_next_single_key(cursor), true);
+        if (ret == 0)
+            goto found;
+
+        WT_ERR(__curversion_version_reset(version_cursor));
+        F_SET(file_cursor, WT_CURSTD_KEY_ONLY);
+        WT_ERR_NOTFOUND_OK(__wt_btcur_prev(cbt, false), true);
+        if (ret == WT_NOTFOUND)
+            goto notfound;
+    }
+
+found:
+    WT_ERR(
+      __curversion_search_near_compare(session, file_cursor, search_key, search_recno, exactp));
+    ret = 0;
+    if (0) {
+notfound:
+        ret = WT_NOTFOUND;
+    }
+
+err:
+    /* Restore the transaction's ignore-prepare state if an error left it set. */
+    if (clear_ignore_prepare)
+        F_CLR(txn, WT_TXN_IGNORE_PREPARE);
+    __wt_scr_free(session, &search_key);
+    __wt_scr_free(session, &anchor_key);
+    if (ret != 0)
+        WT_TRET(cursor->reset(cursor));
+    API_END_RET(session, ret);
+}
+
+/*
  * __curversion_close --
  *     WT_CURSOR->close method for version cursors.
  */
@@ -1140,7 +1409,7 @@ __wt_curversion_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner
       __wt_cursor_notsup,                              /* prev */
       __curversion_reset,                              /* reset */
       __curversion_search,                             /* search */
-      __wt_cursor_search_near_notsup,                  /* search-near */
+      __curversion_search_near,                        /* search-near */
       __wt_cursor_notsup,                              /* insert */
       __wt_cursor_modify_notsup,                       /* modify */
       __wt_cursor_notsup,                              /* update */

--- a/src/cursor/cur_version.c
+++ b/src/cursor/cur_version.c
@@ -919,7 +919,7 @@ __curversion_skip_starting_updates(WT_SESSION_IMPL *session, WT_CURSOR_VERSION *
 
     for (; upd != NULL; upd = upd->next) {
         /* Skip aborted updates unless showing prepared rollbacks. */
-        if (upd->txnid == WT_TXN_ABORTED) {
+        if (__wt_tsan_suppress_load_uint64_v(&upd->txnid) == WT_TXN_ABORTED) {
             if (F_ISSET(version_cursor, WT_CURVERSION_SHOW_PREPARED_ROLLBACK) &&
               __curversion_is_prepare_rollback_update(upd))
                 break;

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -606,16 +606,6 @@ struct __wt_name_flag {
 };
 
 /*
- * WT_LAYERED_DRAIN_ENTRY --
- *	Queue entry for layered table drain threads. Holds a pinned ingest btree dhandle
- *	(via session_inuse) so the dhandle stays open while the work item is processed.
- */
-struct __wt_layered_drain_entry {
-    WT_DATA_HANDLE *ingest_dhandle;
-    TAILQ_ENTRY(__wt_layered_drain_entry) q;
-};
-
-/*
  * WT_CONN_CAPACITY --
  *	I/O capacity subsystem fields, grouping the WT_THROTTLE throttle
  *	configuration with the session, thread, and condition variable that drive the
@@ -1043,11 +1033,10 @@ struct __wt_connection_impl {
 
     /* Data pertaining to disaggregated storage step up. */
     struct __wt_layered_drain_data {
-        WT_THREAD_GROUP threads;
-        WT_SPINLOCK queue_lock;
-        TAILQ_HEAD(__wt_layered_drain_qh, __wt_layered_drain_entry) work_queue;
-        bool running;
+        WT_SPINLOCK fix_prepared_lock; /* Serializes __layered_fix_prepared_transaction across
+                                          drain workers; see comment at the call site. */
         uint32_t thread_count;
+        uint64_t total_keys_drained; /* Atomic: cumulative keys moved across all ranges/tables. */
     } layered_drain_data;
 
     WT_DISAGGREGATED_STORAGE disaggregated_storage;

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -303,8 +303,6 @@ struct __wt_keyed_encryptor;
 typedef struct __wt_keyed_encryptor WT_KEYED_ENCRYPTOR;
 struct __wt_layered_drain_data;
 typedef struct __wt_layered_drain_data WT_LAYERED_DRAIN_DATA;
-struct __wt_layered_drain_entry;
-typedef struct __wt_layered_drain_entry WT_LAYERED_DRAIN_ENTRY;
 struct __wt_layered_table;
 typedef struct __wt_layered_table WT_LAYERED_TABLE;
 struct __wt_layered_table_manager;

--- a/src/prepared_discover/prepared_discover_walk.c
+++ b/src/prepared_discover/prepared_discover_walk.c
@@ -48,6 +48,67 @@ __prepared_discover_is_follower_stable_walk(WT_SESSION_IMPL *session, const char
 }
 
 /*
+ * __prepared_discover_register_layered --
+ *     Derive the parent layered URI from a stable constituent URI and open it just long enough to
+ *     trigger __schema_open_layered, which registers the layered table with the
+ *     layered_table_manager. Without this, an application that only opens a `prepared_discover:`
+ *     cursor on a follower (no cursor on the layered URI itself) would leave the manager with no
+ *     entry for this table. Step-up drain iterates the manager's entries --
+ *     with no entry, the drain never resolves the claim-prepared cells on the stable side, and a
+ *     post-step-up reader hits WT_PREPARE_CONFLICT.
+ */
+static int
+__prepared_discover_register_layered(WT_SESSION_IMPL *session, const char *stable_uri)
+{
+    static const char file_prefix[] = "file:";
+    static const char stable_suffix[] = ".wt_stable";
+    size_t prefix_len = strlen(file_prefix);
+    const char *suffix_start;
+    WT_CURSOR *cursor;
+    WT_DECL_ITEM(layered_uri_buf);
+    WT_DECL_RET;
+
+    cursor = NULL;
+
+    /*
+     * The follower stable walk is always entered with a checkpoint-suffixed URI of the form
+     * "file:<name>.wt_stable/<checkpoint>" (see __wt_prepared_discover_filter_apply_handles, which
+     * appends the checkpoint name before calling __prepared_discover_walk_one_tree). Locate the
+     * ".wt_stable" boundary -- ignoring everything after it -- and derive "layered:<name>".
+     */
+    if (!WT_PREFIX_MATCH(stable_uri, file_prefix))
+        return (0);
+    suffix_start = strstr(stable_uri, stable_suffix);
+    if (suffix_start == NULL || suffix_start <= stable_uri + prefix_len)
+        return (0);
+
+    WT_RET(__wt_scr_alloc(session, 0, &layered_uri_buf));
+    WT_ERR(__wt_buf_fmt(session, layered_uri_buf, "layered:%.*s",
+      (int)(suffix_start - (stable_uri + prefix_len)), stable_uri + prefix_len));
+
+    /*
+     * Open and immediately close a cursor on the layered URI. The open path runs
+     * __schema_open_layered, which calls __wt_layered_table_manager_add_table; the dhandle stays
+     * cached after the cursor closes so the manager entry persists until shutdown / explicit
+     * removal.
+     */
+    WT_ERR(__wt_open_cursor(session, layered_uri_buf->data, NULL, NULL, &cursor));
+err:
+    if (cursor != NULL)
+        WT_TRET(cursor->close(cursor));
+    __wt_scr_free(session, &layered_uri_buf);
+    /*
+     * ENOENT can happen if the layered table no longer exists in metadata (e.g. dropped between the
+     *     metadata scan that surfaced it and this call). That's benign for prepared discovery --
+     *     there is nothing on the stable side to drain either --
+     *     so swallow it.
+     */
+    if (ret == ENOENT)
+        ret = 0;
+    return (ret);
+}
+
+/*
  * __prepared_discover_open_ingest_cursor --
  *     Derive the ingest URI from the current stable btree handle and open a cursor on it. The
  *     stable btree is preserved as session->dhandle across the open.
@@ -429,8 +490,17 @@ __prepared_discover_walk_one_tree(WT_SESSION_IMPL *session, const char *uri)
     btree = S2BT(session);
     /* There is nothing to do on an empty tree. */
     if (btree->root.page != NULL) {
-        if (__prepared_discover_is_follower_stable_walk(session, uri))
+        if (__prepared_discover_is_follower_stable_walk(session, uri)) {
+            /*
+             * Register the parent layered table with the layered_table_manager before opening the
+             * ingest cursor. Step-up drain iterates manager entries, so a table whose only
+             * follower-side touchpoint was the prepared_discover walk (no application cursor on the
+             * layered URI before step-up) would otherwise be missed by drain.
+             */
+            WT_SAVE_DHANDLE(session, ret = __prepared_discover_register_layered(session, uri));
+            WT_ERR(ret);
             WT_ERR(__prepared_discover_open_ingest_cursor(session, &ingest_cursor));
+        }
 
         flags = WT_READ_NO_EVICT | WT_READ_VISIBLE_ALL | WT_READ_WONT_NEED | WT_READ_SEE_DELETED;
         ref = NULL;

--- a/test/suite/test_layered_stepup11.py
+++ b/test/suite/test_layered_stepup11.py
@@ -1,0 +1,980 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# test_layered_stepup11.py
+#   Tests for the parallel ingest-table drain, which subdivides a table's key space into
+#   ranges that drain concurrently on step-up. Exercises concurrent multi-table
+#   drain, empty-table skip, single-threaded drain, prepared-transaction redirect
+#   (single key, across multiple ranges, and multiple keys in one range), standalone
+#   ingest-tombstone eviction, updates to existing stable keys, the no-subdivision
+#   path, and follower range-truncate replay.
+
+import wiredtiger, wttest
+from helper_disagg import disagg_test_class, gen_disagg_storages, Oplog
+from wtscenario import make_scenarios
+
+@disagg_test_class
+class test_layered_stepup11(wttest.WiredTigerTestCase):
+    conn_base_config = (
+        ',create,statistics=(all),'
+        'precise_checkpoint=true,'
+        'preserve_prepared=true,'
+    )
+
+    disagg_storages = gen_disagg_storages('test_layered_stepup11', disagg_only=True)
+
+    @property
+    def base_config(self):
+        return self.extensionsConfig() + self.conn_base_config
+
+    def conn_config(self):
+        return self.base_config + 'disaggregated=(role="leader")'
+
+    @property
+    def conn_follower_config(self):
+        return self.base_config + 'disaggregated=(role="follower")'
+
+    # The drain subdivides a table only above MIN_RANGE_SIZE=1000 records. multiplier
+    # scales the scenarios' record counts to straddle that threshold: multiplier=1
+    # stays below it (no subdivision), multiplier=10 crosses it so larger tables split.
+
+    sizes = [
+        ('small', dict(multiplier=1)),
+        ('large', dict(multiplier=10)),
+    ]
+
+    resolve = [
+        ('commit',   dict(do_commit=True)),
+        ('rollback', dict(do_commit=False)),
+    ]
+
+    scenarios = make_scenarios(disagg_storages, sizes, resolve)
+
+    def test_drain_multiple_tables(self):
+        """
+        Drain three tables of different sizes concurrently on step-up; verify every
+        table's data survives the follower->leader transition.
+        """
+        uri_a = 'layered:test_layered_stepup11_a'
+        uri_b = 'layered:test_layered_stepup11_b'
+        uri_c = 'layered:test_layered_stepup11_c'
+
+        oplog = Oplog()
+        t_a = oplog.add_uri(uri_a)
+        t_b = oplog.add_uri(uri_b)
+        t_c = oplog.add_uri(uri_c)
+
+        # First batch: leader applies these entries and checkpoints.
+        # With multiplier=10 the third table's second batch will be > MIN_RANGE_SIZE.
+        n_a1 = 50  * self.multiplier
+        n_b1 = 100 * self.multiplier
+        n_c1 = 200 * self.multiplier
+        oplog.insert(t_a, n_a1)
+        oplog.insert(t_b, n_b1)
+        oplog.insert(t_c, n_c1)
+
+        for uri in (uri_a, uri_b, uri_c):
+            self.session.create(uri, 'key_format=S,value_format=S')
+        oplog.apply(self, self.session, 0, n_a1 + n_b1 + n_c1)
+        self.conn.set_timestamp(
+            f'stable_timestamp={self.timestamp_str(oplog.last_timestamp())}')
+        self.session.checkpoint()
+
+        # Second batch: only the follower applies these (they go into the ingest).
+        # With multiplier=10: uri_c gets 3000 ingest entries -> subdivided.
+        n_a2 = 50  * self.multiplier
+        n_b2 = 100 * self.multiplier
+        n_c2 = 300 * self.multiplier
+        oplog.insert(t_a, n_a2)
+        oplog.insert(t_b, n_b2)
+        oplog.insert(t_c, n_c2)
+        total = n_a1 + n_b1 + n_c1 + n_a2 + n_b2 + n_c2
+
+        conn_follow = self.wiredtiger_open('follower', self.conn_follower_config)
+        session_follow = conn_follow.open_session('')
+        for uri in (uri_a, uri_b, uri_c):
+            session_follow.create(uri, 'key_format=S,value_format=S')
+        oplog.apply(self, session_follow, 0, total)
+        oplog.check(self, session_follow, 0, total)
+
+        self.disagg_advance_checkpoint(conn_follow)
+        oplog.check(self, session_follow, 0, total)
+
+        # Step down leader, step up follower (drain runs on all three tables).
+        self.conn.close('debug=(skip_checkpoint=true)')
+        conn_follow.reconfigure('disaggregated=(role="leader")')
+
+        conn_follow.set_timestamp(
+            f'stable_timestamp={self.timestamp_str(oplog.last_timestamp())}')
+        session_follow.checkpoint()
+
+        # Reopen as follower and verify all three tables.
+        conn_follow.close()
+        conn_follow = self.wiredtiger_open('follower', self.conn_follower_config)
+        session_follow = conn_follow.open_session('')
+        oplog.check(self, session_follow, 0, total)
+
+    def test_drain_empty_ingest_tables(self):
+        """Empty ingest table is skipped by the drain; stable data survives step-up."""
+        uri = 'layered:test_layered_stepup11_empty'
+        n = 100
+
+        oplog = Oplog()
+        t = oplog.add_uri(uri)
+        oplog.insert(t, n)
+
+        # Leader: write and checkpoint so records are in stable.
+        self.session.create(uri, 'key_format=S,value_format=S')
+        oplog.apply(self, self.session, 0, n)
+        self.conn.set_timestamp(
+            f'stable_timestamp={self.timestamp_str(oplog.last_timestamp())}')
+        self.session.checkpoint()
+
+        # Follower: create the table and pick up the leader checkpoint, but
+        # write nothing to the follower's ingest.
+        conn_follow = self.wiredtiger_open('follower', self.conn_follower_config)
+        session_follow = conn_follow.open_session('')
+        session_follow.create(uri, 'key_format=S,value_format=S')
+        self.disagg_advance_checkpoint(conn_follow)
+
+        # Step down leader, step up follower.
+        # The ingest table is empty so drain is a no-op.
+        self.conn.close('debug=(skip_checkpoint=true)')
+        conn_follow.reconfigure('disaggregated=(role="leader")')
+
+        conn_follow.set_timestamp(
+            f'stable_timestamp={self.timestamp_str(oplog.last_timestamp())}')
+        session_follow.checkpoint()
+
+        # Reopen as follower; the new-leader checkpoint contains the stable
+        # data and the follower picks it up automatically on open.
+        conn_follow.close()
+        conn_follow = self.wiredtiger_open('follower', self.conn_follower_config)
+        session_follow = conn_follow.open_session('')
+        oplog.check(self, session_follow, 0, n)
+
+    def test_drain_single_thread(self):
+        """
+        drain_threads=1 forces a single-worker full-table drain. The ingest table holds
+        more than MIN_RANGE_SIZE=1000 records, so the default 8 threads would subdivide
+        it; with 1 thread it gets a single full-table work item instead.
+        """
+        uri = 'layered:test_layered_stepup11_single'
+
+        oplog = Oplog()
+        t = oplog.add_uri(uri)
+
+        # First batch on leader -- establishes last_checkpoint_timestamp so that
+        # the follower's ingest entries (second batch) will pass the drain filter.
+        n1 = 50 * self.multiplier
+        oplog.insert(t, n1)
+
+        self.session.create(uri, 'key_format=S,value_format=S')
+        oplog.apply(self, self.session, 0, n1)
+        self.conn.set_timestamp(
+            f'stable_timestamp={self.timestamp_str(oplog.last_timestamp())}')
+        self.session.checkpoint()
+
+        # Second batch goes into the follower's ingest.
+        # With multiplier=10: 2000 ingest records exceed 2*MIN_RANGE_SIZE, so
+        # the default 8 threads would subdivide -- but drain_threads=1 won't.
+        n2 = 200 * self.multiplier
+        oplog.insert(t, n2)
+        total = n1 + n2
+
+        # drain_threads must be set at connection-open time; it is not re-read
+        # during reconfigure (parsed in the init-only section of conn_layered.c).
+        single_thread_config = (
+            self.extensionsConfig() + self.conn_base_config
+            + 'disaggregated=(role="follower",drain_threads=1)'
+        )
+        conn_follow = self.wiredtiger_open('follower', single_thread_config)
+        session_follow = conn_follow.open_session('')
+        session_follow.create(uri, 'key_format=S,value_format=S')
+
+        oplog.apply(self, session_follow, 0, total)
+        oplog.check(self, session_follow, 0, total)
+
+        self.disagg_advance_checkpoint(conn_follow)
+        oplog.check(self, session_follow, 0, total)
+
+        self.conn.close('debug=(skip_checkpoint=true)')
+
+        # Step up -- drain runs with a single worker thread.
+        conn_follow.reconfigure('disaggregated=(role="leader")')
+
+        conn_follow.set_timestamp(
+            f'stable_timestamp={self.timestamp_str(oplog.last_timestamp())}')
+        session_follow.checkpoint()
+
+        conn_follow.close()
+        conn_follow = self.wiredtiger_open('follower', self.conn_follower_config)
+        session_follow = conn_follow.open_session('')
+        oplog.check(self, session_follow, 0, total)
+
+    # Helpers for the prepared-transaction tests. Use integer keys so key ordering
+    # is numeric and range boundaries are predictable.
+
+    def _insert_range(self, session, cursor, start, stop, ts_start):
+        """Insert integer keys [start, stop) each in its own transaction."""
+        ts = ts_start
+        for k in range(start, stop):
+            session.begin_transaction()
+            cursor.set_key(k)
+            cursor.set_value(f'v{k}')
+            cursor.insert()
+            session.commit_transaction(f'commit_timestamp={self.timestamp_str(ts)}')
+            ts += 1
+        return ts  # next available timestamp
+
+    def _verify_range(self, session, cursor, start, stop, ts_read, expect_present=True):
+        """Assert keys [start, stop) are present (or absent) at the given read ts."""
+        session.begin_transaction(f'read_timestamp={self.timestamp_str(ts_read)}')
+        for k in range(start, stop):
+            cursor.set_key(k)
+            ret = cursor.search()
+            if expect_present:
+                self.assertEqual(ret, 0, f'key {k} missing')
+                self.assertEqual(cursor.get_value(), f'v{k}')
+            else:
+                self.assertEqual(ret, wiredtiger.WT_NOTFOUND, f'key {k} unexpectedly found')
+        session.rollback_transaction()
+
+    def _verify_key(self, session, cursor, key, ts_read, expect_value):
+        """Assert a single key equals expect_value (or is absent if None) at ts_read."""
+        session.begin_transaction(f'read_timestamp={self.timestamp_str(ts_read)}')
+        cursor.set_key(key)
+        ret = cursor.search()
+        if expect_value is None:
+            self.assertEqual(ret, wiredtiger.WT_NOTFOUND, f'key {key} unexpectedly found')
+        else:
+            self.assertEqual(ret, 0, f'key {key} missing')
+            self.assertEqual(cursor.get_value(), expect_value)
+        session.rollback_transaction()
+
+    def test_drain_prepared_transaction(self):
+        """
+        Prepared transaction (single key) redirected from ingest to stable during drain.
+
+        Timeline:
+          ts 1..50   : leader writes keys 1..50 to stable (pre-drain baseline).
+          ts 51      : stable_timestamp=50, checkpoint.
+          [reconfigure to follower]
+          ts 52..101 : follower writes keys 101..150 to ingest (committed).
+          ts 200     : prepare_session prepares key 999 (prepare_timestamp=200).
+          stable_timestamp=200.
+          [reconfigure to leader -- drain runs]
+          ts 300     : commit or rollback the prepared transaction.
+          stable_timestamp=300, checkpoint.
+        """
+        uri = 'layered:test_layered_stepup11_prep'
+        self.session.create(uri, 'key_format=i,value_format=S')
+
+        cursor = self.session.open_cursor(uri)
+
+        # Leader writes keys 1..50 at timestamps 1..50.
+        ts = self._insert_range(self.session, cursor, 1, 51, ts_start=1)
+        # ts == 51 now
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(50)}')
+        self.session.checkpoint()
+        cursor.close()
+
+        # Switch to follower role.
+        self.conn.reconfigure('disaggregated=(role="follower")')
+        follower_session = self.conn.open_session('')
+        follower_cursor = follower_session.open_cursor(uri)
+
+        # Follower writes keys 101..150 (committed) into the ingest.
+        ts = self._insert_range(follower_session, follower_cursor, 101, 151, ts_start=ts)
+        follower_cursor.close()
+
+        # Prepare key 999 in a separate session (leaves prepared update in ingest).
+        prepare_session = self.conn.open_session('')
+        prepare_cursor = prepare_session.open_cursor(uri)
+        prepare_session.begin_transaction()
+        prepare_cursor.set_key(999)
+        prepare_cursor.set_value('prepared_value')
+        prepare_cursor.insert()
+        prepare_session.prepare_transaction(
+            f'prepare_timestamp={self.timestamp_str(200)},'
+            f'prepared_id={self.prepared_id_str(1)}')
+        prepare_cursor.close()
+
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(200)}')
+
+        # Step up -- drain runs, __layered_fix_prepared_transaction redirects
+        # the prepared session's op->btree from ingest -> stable.
+        self.conn.reconfigure('disaggregated=(role="leader")')
+
+        # Resolve the prepared transaction after drain.
+        if self.do_commit:
+            prepare_session.commit_transaction(
+                f'commit_timestamp={self.timestamp_str(300)},'
+                f'durable_timestamp={self.timestamp_str(300)}')
+        else:
+            prepare_session.rollback_transaction(
+                f'rollback_timestamp={self.timestamp_str(300)}')
+        prepare_session.close()
+
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(300)}')
+        follower_session.checkpoint()
+
+        # Verify.
+        read_session = self.conn.open_session('')
+        read_cursor = read_session.open_cursor(uri)
+
+        # Keys 1..50: from original stable (always present).
+        self._verify_range(read_session, read_cursor, 1, 51,
+                           ts_read=50, expect_present=True)
+
+        # Keys 101..150: drained from ingest (committed at ts 51..100).
+        self._verify_range(read_session, read_cursor, 101, 151,
+                           ts_read=200, expect_present=True)
+
+        # Key 999: committed value if do_commit, absent if rollback.
+        expected_999 = 'prepared_value' if self.do_commit else None
+        self._verify_key(read_session, read_cursor, 999,
+                         ts_read=300, expect_value=expected_999)
+
+        read_cursor.close()
+        read_session.close()
+
+    def test_drain_prepared_transaction_multi_range(self):
+        """
+        Prepared transaction spanning multiple drain ranges.
+
+        Inserts 10 000 committed keys so the table is subdivided into multiple
+        ranges (MIN_RANGE_SIZE=1000, default 8 threads -> up to 8 ranges).
+        Three prepared keys are placed at the start, middle, and end of the
+        key space to guarantee they fall in different drain ranges.
+        """
+        uri = 'layered:test_layered_stepup11_prep_multi'
+        self.session.create(uri, 'key_format=i,value_format=S')
+
+        # Write one baseline key as leader to establish last_checkpoint_timestamp=1.
+        # All follower writes start at ts=2 so they satisfy durable_start_ts > 1 and drain.
+        baseline_cursor = self.session.open_cursor(uri)
+        self.session.begin_transaction()
+        baseline_cursor.set_key(0)
+        baseline_cursor.set_value('baseline')
+        baseline_cursor.insert()
+        self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(1)}')
+        baseline_cursor.close()
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(1)}')
+        self.session.checkpoint()
+
+        # Switch to follower; all writes go into the ingest.
+        self.conn.reconfigure('disaggregated=(role="follower")')
+        follower_session = self.conn.open_session('')
+        follower_cursor = follower_session.open_cursor(uri)
+
+        # Insert 10 000 committed keys at ts 2..10001.
+        # Use non-overlapping key space around the three prepared keys.
+        committed_keys = list(range(1, 10001))
+        # Reserve keys 500, 5000, 9500 for the prepared transaction.
+        prepared_keys = {500, 5000, 9500}
+        ts = 2  # start above last_checkpoint_timestamp=1 so entries drain
+        for k in committed_keys:
+            if k in prepared_keys:
+                continue
+            follower_session.begin_transaction()
+            follower_cursor.set_key(k)
+            follower_cursor.set_value(f'v{k}')
+            follower_cursor.insert()
+            follower_session.commit_transaction(
+                f'commit_timestamp={self.timestamp_str(ts)}')
+            ts += 1
+        follower_cursor.close()
+
+        # Prepare a transaction that updates the three spread-out keys.
+        prepare_session = self.conn.open_session('')
+        prepare_cursor = prepare_session.open_cursor(uri)
+        prepare_session.begin_transaction()
+        for k in sorted(prepared_keys):
+            prepare_cursor.set_key(k)
+            prepare_cursor.set_value(f'prep_{k}')
+            prepare_cursor.insert()
+        prepare_session.prepare_transaction(
+            f'prepare_timestamp={self.timestamp_str(20000)},'
+            f'prepared_id={self.prepared_id_str(1)}')
+        prepare_cursor.close()
+
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(20000)}')
+
+        # Step up -- drain subdivides the table; each range worker processes
+        # its slice, and __layered_fix_prepared_transaction is called once
+        # per prepared key by whichever range worker owns that key.
+        self.conn.reconfigure('disaggregated=(role="leader")')
+
+        # Resolve prepared transaction after drain.
+        if self.do_commit:
+            prepare_session.commit_transaction(
+                f'commit_timestamp={self.timestamp_str(30000)},'
+                f'durable_timestamp={self.timestamp_str(30000)}')
+        else:
+            prepare_session.rollback_transaction(
+                f'rollback_timestamp={self.timestamp_str(30000)}')
+        prepare_session.close()
+
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(30000)}')
+        follower_session.checkpoint()
+
+        # Verify committed keys are all present.
+        read_session = self.conn.open_session('')
+        read_cursor = read_session.open_cursor(uri)
+
+        read_session.begin_transaction(
+            f'read_timestamp={self.timestamp_str(20000)}')
+        for k in committed_keys:
+            if k in prepared_keys:
+                continue
+            read_cursor.set_key(k)
+            self.assertEqual(read_cursor.search(), 0, f'committed key {k} missing')
+            self.assertEqual(read_cursor.get_value(), f'v{k}')
+        read_session.rollback_transaction()
+
+        # Verify the three prepared keys.
+        for k in sorted(prepared_keys):
+            expected = f'prep_{k}' if self.do_commit else None
+            self._verify_key(read_session, read_cursor, k,
+                             ts_read=30000, expect_value=expected)
+
+        read_cursor.close()
+        read_session.close()
+
+    def test_drain_standalone_ingest_tombstone(self):
+        """
+        Standalone ingest-tombstone eviction during drain.
+
+        A "standalone" tombstone arises when a document was inserted before oplog
+        application began on this node -- so the document's insert lives only in
+        the stable btree -- and is subsequently deleted on the follower.  The
+        ingest btree then holds a tombstone with NO backing on-disk value.
+
+        This exercises the guard added in rec_visibility.c that allows the
+        reconciler to evict such a page without asserting "No on-disk value is
+        found".  It also verifies that after step-up and drain the delete is
+        reflected in the stable table.
+
+        Timeline:
+          ts=10 : leader inserts 'key_to_delete' -> stable btree
+          stable_timestamp=10, checkpoint
+          [reconfigure to follower]
+          ts=20 : follower deletes 'key_to_delete' -> tombstone in ingest only
+          ts=21 : follower inserts 'key_sentinel'  -> ingest (same page)
+          force eviction of the ingest page          -> exercises rec_visibility.c fix
+          [reconfigure to leader -- drain runs]
+          verify 'key_to_delete' absent, 'key_sentinel' present
+        """
+        uri = 'layered:test_layered_stepup11_tombstone'
+        ingest_uri = 'file:test_layered_stepup11_tombstone.wt_ingest'
+
+        # Leader: insert key_to_delete so it lives in the stable btree only.
+        self.session.create(uri, 'key_format=S,value_format=S')
+        cursor = self.session.open_cursor(uri)
+        self.session.begin_transaction()
+        cursor.set_key('key_to_delete')
+        cursor.set_value('original_value')
+        cursor.insert()
+        self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(10)}')
+        cursor.close()
+
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(10)}')
+        self.session.checkpoint()
+
+        # Reconfigure to follower -- subsequent writes go to the ingest btree.
+        self.conn.reconfigure('disaggregated=(role="follower")')
+
+        follower_session = self.conn.open_session('')
+        follower_cursor = follower_session.open_cursor(uri)
+
+        # Delete key_to_delete: tombstone lands in ingest with no backing insert
+        # in the ingest btree (the only insert is in stable from above).
+        follower_session.begin_transaction()
+        follower_cursor.set_key('key_to_delete')
+        follower_cursor.remove()
+        follower_session.commit_transaction(
+            f'commit_timestamp={self.timestamp_str(20)}')
+
+        # Insert a sentinel key so the ingest page has a non-tombstone update
+        # that an eviction cursor can search for to position on the same page.
+        follower_session.begin_transaction()
+        follower_cursor.set_key('key_sentinel')
+        follower_cursor.set_value('sentinel_value')
+        follower_cursor.insert()
+        follower_session.commit_transaction(
+            f'commit_timestamp={self.timestamp_str(21)}')
+        follower_cursor.close()
+
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(21)}')
+
+        # Force eviction of the ingest btree page.  The page holds a tombstone
+        # for key_to_delete whose backing value lives only in the stable btree,
+        # exercising drain of a standalone ingest tombstone (a follower delete of
+        # a stable-only key).
+        evict_session = self.conn.open_session('debug=(release_evict_page)')
+        evict_cursor = evict_session.open_cursor(ingest_uri)
+        evict_cursor.set_key('key_sentinel')
+        evict_cursor.search()  # positions on the page that also holds the tombstone
+        evict_cursor.close()   # triggers eviction of the page
+        evict_session.close()
+
+        # Step up -- drain copies both the tombstone and the sentinel to stable.
+        self.conn.reconfigure('disaggregated=(role="leader")')
+
+        follower_session.checkpoint()
+
+        # Verify: key_to_delete absent (tombstone drained), key_sentinel present.
+        read_session = self.conn.open_session('')
+        read_cursor = read_session.open_cursor(uri)
+
+        read_session.begin_transaction(f'read_timestamp={self.timestamp_str(21)}')
+
+        read_cursor.set_key('key_to_delete')
+        self.assertEqual(read_cursor.search(), wiredtiger.WT_NOTFOUND,
+                         'key_to_delete should be absent after tombstone drain')
+
+        read_cursor.set_key('key_sentinel')
+        self.assertEqual(read_cursor.search(), 0,
+                         'key_sentinel should be present after drain')
+        self.assertEqual(read_cursor.get_value(), 'sentinel_value')
+
+        read_session.rollback_transaction()
+        read_cursor.close()
+        read_session.close()
+
+    def test_drain_update_existing_stable_key(self):
+        """
+        Verify that ingest-btree updates to keys that already exist in the stable
+        btree are correctly drained into stable after follower step-up.  The test
+        also inserts genuinely new keys in the same follower batch to exercise the
+        mixed (update + insert) drain path.
+
+        Timeline:
+          n_stable keys are written as leader -> stable btree, then checkpointed.
+          [reconfigure to follower]
+          First n_update of those keys are overwritten (oplog.update) in ingest.
+          n_fresh brand-new keys are appended (oplog.insert) in ingest.
+          [reconfigure to leader -> drain runs]
+          stable_timestamp advanced, checkpoint taken.
+          [connection closed and reopened as follower]
+          oplog.check verifies every oplog entry (original inserts, updates, fresh
+          inserts) against the new leader checkpoint.
+        """
+        uri = 'layered:test_layered_stepup11_update'
+
+        oplog = Oplog()
+        t = oplog.add_uri(uri)
+
+        n_stable = 50 * self.multiplier
+        n_update = 20 * self.multiplier
+        n_fresh  = 20 * self.multiplier
+
+        # Leader writes n_stable keys and checkpoints them.
+        oplog.insert(t, n_stable)
+
+        self.session.create(uri, 'key_format=S,value_format=S')
+        oplog.apply(self, self.session, 0, n_stable)
+        self.conn.set_timestamp(
+            f'stable_timestamp={self.timestamp_str(oplog.last_timestamp())}')
+        self.session.checkpoint()
+
+        # Reconfigure as follower; the updates and fresh inserts below land in ingest.
+        self.conn.reconfigure('disaggregated=(role="follower")')
+        follower_session = self.conn.open_session('')
+
+        # Overwrite the first n_update stable keys; their updates land in ingest.
+        oplog.update(t, n_update)
+        # Insert n_fresh brand-new keys; these also land in ingest.
+        oplog.insert(t, n_fresh)
+
+        total = n_stable + n_update + n_fresh
+
+        # Apply the follower's batch (the n_update + n_fresh new oplog entries).
+        oplog.apply(self, follower_session, n_stable, n_update + n_fresh)
+
+        # Step up; drain moves the ingest entries into stable.
+        self.conn.reconfigure('disaggregated=(role="leader")')
+
+        self.conn.set_timestamp(
+            f'stable_timestamp={self.timestamp_str(oplog.last_timestamp())}')
+        follower_session.checkpoint()
+
+        # Close everything, reopen as follower, and verify.
+        follower_session.close()
+        self.conn.close('debug=(skip_checkpoint=true)')
+        self.conn = None
+
+        verify_conn = self.wiredtiger_open(self.home, self.conn_follower_config)
+        verify_session = verify_conn.open_session('')
+
+        oplog.check(self, verify_session, 0, total)
+
+        verify_session.close()
+        verify_conn.close()
+
+    def test_drain_multiple_prepared_same_range(self):
+        """
+        Verify that multiple prepared-transaction keys falling in the same
+        drain range are all correctly redirected (stable-btree pointer fixed)
+        by the single range-0 worker.
+
+        Key layout (string keys, lexicographic order):
+          Baseline  (leader, ts=1):        "000" -> "baseline"
+          Committed drainable (follower):  "300"@ts=10, "500"@ts=11,
+                                           "700"@ts=12, "900"@ts=13
+          Prepared  (prepared_id=1):       "100", "150", "200"
+                                           (all < "500", all in range 0)
+
+        With 4 drainable committed keys and drain_threads=8 the planner
+        produces 2 split points ("500", "700").  All three prepared keys
+        are below "500" so they land together in range 0.  Committing or
+        rolling back the prepared transaction is governed by self.do_commit
+        (True/False), which is already parameterised by the class scenarios.
+        """
+        uri = 'layered:test_layered_stepup11_prep_multi_range'
+        self.session.create(uri, 'key_format=S,value_format=S')
+
+        # Leader baseline: insert "000"="baseline" at ts=1 and checkpoint, establishing
+        # last_checkpoint_timestamp=1. All subsequent follower writes use ts > 1 so they
+        # satisfy the drain filter (durable_start_ts > 1).
+        baseline_cursor = self.session.open_cursor(uri)
+        self.session.begin_transaction()
+        baseline_cursor.set_key('000')
+        baseline_cursor.set_value('baseline')
+        baseline_cursor.insert()
+        self.session.commit_transaction(
+            f'commit_timestamp={self.timestamp_str(1)}')
+        baseline_cursor.close()
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(1)}')
+        self.session.checkpoint()
+
+        self.conn.reconfigure('disaggregated=(role="follower")')
+
+        # Follower committed writes: four keys at explicit timestamps (not via oplog) to
+        # deterministically control the sample set and therefore the range split points.
+        follower_session = self.conn.open_session('')
+        follower_cursor = follower_session.open_cursor(uri)
+
+        committed = [
+            ('300', 'v300', 10),
+            ('500', 'v500', 11),
+            ('700', 'v700', 12),
+            ('900', 'v900', 13),
+        ]
+        for key, val, ts in committed:
+            follower_session.begin_transaction()
+            follower_cursor.set_key(key)
+            follower_cursor.set_value(val)
+            follower_cursor.insert()
+            follower_session.commit_transaction(
+                f'commit_timestamp={self.timestamp_str(ts)}')
+        follower_cursor.close()
+
+        # All three prepared keys are inserted in a single transaction before
+        # prepare_transaction is called, so they share prepared_id=1 and all land in
+        # range 0 together during drain.
+        prepare_session = self.conn.open_session('')
+        prepare_cursor = prepare_session.open_cursor(uri)
+        prepare_session.begin_transaction()
+        for key, val in [('100', 'prep100'), ('150', 'prep150'), ('200', 'prep200')]:
+            prepare_cursor.set_key(key)
+            prepare_cursor.set_value(val)
+            prepare_cursor.insert()
+        prepare_session.prepare_transaction(
+            f'prepare_timestamp={self.timestamp_str(200)},'
+            f'prepared_id={self.prepared_id_str(1)}')
+        prepare_cursor.close()
+
+        # Advance stable_timestamp to cover the prepare timestamp.
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(200)}')
+
+        # Step up to leader; drain runs. The range-0 worker owns [unbounded, "500") and
+        # encounters keys "100", "150", "200" in that range, calling
+        # __layered_fix_prepared_transaction for each to redirect the prepared session's
+        # btree pointer from ingest to stable.
+        self.conn.reconfigure('disaggregated=(role="leader")')
+
+        # Resolve the prepared transaction after drain completes.
+        if self.do_commit:
+            prepare_session.commit_transaction(
+                f'commit_timestamp={self.timestamp_str(300)},'
+                f'durable_timestamp={self.timestamp_str(300)}')
+        else:
+            prepare_session.rollback_transaction(
+                f'rollback_timestamp={self.timestamp_str(300)}')
+
+        prepare_session.close()
+
+        # Advance stable_timestamp and checkpoint.
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(300)}')
+        follower_session.checkpoint()
+
+        # Verify.
+        read_session = self.conn.open_session('')
+        read_cursor = read_session.open_cursor(uri)
+
+        # Baseline key must always be present (written as leader, never drained).
+        self._verify_key(read_session, read_cursor, '000',
+                         ts_read=1, expect_value='baseline')
+
+        # Four committed keys must be visible after drain (drained from ingest).
+        for key, val, _ in committed:
+            self._verify_key(read_session, read_cursor, key,
+                             ts_read=200, expect_value=val)
+
+        # Three prepared keys: present with correct values on commit, absent on rollback.
+        for key, val in [('100', 'prep100'), ('150', 'prep150'), ('200', 'prep200')]:
+            expected = val if self.do_commit else None
+            self._verify_key(read_session, read_cursor, key,
+                             ts_read=300, expect_value=expected)
+
+        read_cursor.close()
+        read_session.close()
+
+    def test_drain_tiny_ingest(self):
+        """
+        A single drainable key in the ingest exercises the no-split path
+        through the parallel-drain machinery.  With any drain_threads > 1
+        n_splits = n_collected / 2 = 0 so the table receives one unbounded
+        work item, the same code path as single-thread mode but reached via
+        the sampling gate rather than the thread-count gate.
+
+        Uses the single-connection follower->leader pattern; no
+        disagg_advance_checkpoint is needed.
+        """
+        uri = 'layered:test_layered_stepup11_tiny'
+        n_stable = 10
+
+        oplog = Oplog()
+        t = oplog.add_uri(uri)
+
+        # Leader: write a small stable baseline and checkpoint to set
+        # last_checkpoint_timestamp, so the single ingest key below will
+        # have durable_start_ts > last_checkpoint_timestamp and be drained.
+        oplog.insert(t, n_stable)
+        self.session.create(uri, 'key_format=S,value_format=S')
+        oplog.apply(self, self.session, 0, n_stable)
+        self.conn.set_timestamp(
+            f'stable_timestamp={self.timestamp_str(oplog.last_timestamp())}')
+        self.session.checkpoint()
+
+        # Step down; subsequent write goes to the ingest btree.
+        self.conn.reconfigure('disaggregated=(role="follower")')
+        follower_session = self.conn.open_session('')
+
+        # Insert exactly 1 key (multiplier NOT used  smallness is intentional).
+        oplog.insert(t, 1)
+        oplog.apply(self, follower_session, n_stable, 1)
+
+        # Step up; drain creates one unbounded work item and moves the key.
+        self.conn.reconfigure('disaggregated=(role="leader")')
+
+        total = n_stable + 1
+        self.conn.set_timestamp(
+            f'stable_timestamp={self.timestamp_str(oplog.last_timestamp())}')
+        follower_session.checkpoint()
+        follower_session.close()
+
+        # Verify on the existing leader connection  no reopen needed.
+        verify_session = self.conn.open_session('')
+        oplog.check(self, verify_session, 0, total)
+        verify_session.close()
+
+    def test_drain_range_truncate_stable_only_keys(self):
+        """
+        Verify that a follower range truncate covering keys that exist only in the
+        stable btree (no ingest btree counterpart) is correctly replayed against
+        stable during drain, leaving those keys absent after step-up.
+        """
+        uri = 'layered:test_layered_stepup11_trunc_stable'
+
+        # --- Leader phase: write three keys into stable. ---
+        self.session.create(uri, 'key_format=S,value_format=S')
+        cursor = self.session.open_cursor(uri)
+        for k in ('k1', 'k2', 'k3'):
+            self.session.begin_transaction()
+            cursor.set_key(k)
+            cursor.set_value(f'v_{k}')
+            cursor.insert()
+            self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(10)}')
+        cursor.close()
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(10)}'
+                                f',oldest_timestamp={self.timestamp_str(1)}')
+        self.session.checkpoint()
+
+        # --- Step down to follower. k1..k3 are now stable-only. ---
+        self.conn.reconfigure('disaggregated=(role="follower")')
+
+        follower_session = self.conn.open_session('')
+        follower_cursor = follower_session.open_cursor(uri)
+
+        # Range truncate k1..k3.  Because none of these keys are in the ingest
+        # btree, __clayered_range_truncate only adds a WT_TRUNCATE list entry
+        # and writes no tombstone into the ingest btree.
+        c_start = follower_session.open_cursor(uri)
+        c_stop  = follower_session.open_cursor(uri)
+        c_start.set_key('k1')
+        c_stop.set_key('k3')
+        follower_session.begin_transaction()
+        follower_session.truncate(None, c_start, c_stop, None)
+        follower_session.commit_transaction(f'commit_timestamp={self.timestamp_str(20)}')
+        c_start.close()
+        c_stop.close()
+
+        # Also insert a fresh key k4 (only in ingest) to verify normal drain.
+        follower_session.begin_transaction()
+        follower_cursor.set_key('k4')
+        follower_cursor.set_value('v_k4')
+        follower_cursor.insert()
+        follower_session.commit_transaction(f'commit_timestamp={self.timestamp_str(21)}')
+        follower_cursor.close()
+
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(21)}')
+
+        # --- Step up: drain must replay the WT_TRUNCATE against stable. ---
+        self.conn.reconfigure('disaggregated=(role="leader")')
+        follower_session.checkpoint()
+        follower_session.close()
+
+        # --- Verify. ---
+        read_session = self.conn.open_session('')
+        read_cursor = read_session.open_cursor(uri)
+        read_session.begin_transaction(f'read_timestamp={self.timestamp_str(21)}')
+
+        for k in ('k1', 'k2', 'k3'):
+            read_cursor.set_key(k)
+            self.assertEqual(read_cursor.search(), wiredtiger.WT_NOTFOUND,
+                f'{k} should be absent after truncate drain')
+
+        read_cursor.set_key('k4')
+        self.assertEqual(read_cursor.search(), 0, 'k4 should be present after drain')
+        self.assertEqual(read_cursor.get_value(), 'v_k4')
+
+        read_session.rollback_transaction()
+        read_cursor.close()
+        read_session.close()
+
+
+    def test_drain_range_truncate_ingest_and_stable_keys(self):
+        """
+        Verify that __layered_apply_truncate_to_stable skips keys that were
+        already tombstoned by the ingest drain (keys present in both the ingest
+        and stable btrees), preventing duplicate tombstones.
+
+        Scenario:
+          T=10  (leader)   write k1, k2  checkpoint  both stable-only
+          T=20  (follower) write k2 into ingest (k2 now in both ingest+stable)
+          T=30  (follower) truncate [k1..k2]:
+                             k1 is stable-only  WT_TRUNCATE entry only (no ingest tombstone)
+                             k2 is in ingest    tombstone at T=30 written to ingest +
+                                                 WT_TRUNCATE entry queued
+          step-up:
+            ingest drain copies k2 tombstone@T=30 to stable
+            __layered_apply_truncate_to_stable opens cursors at read_timestamp=T_trunc:
+              k2 appears deleted (ingest tombstone)  skipped (no duplicate tombstone)
+              k1 still visible                       tombstoned correctly
+        """
+        uri = 'layered:test_layered_stepup11_trunc_ingest_stable_keys'
+
+        # --- Leader phase ---
+        self.session.create(uri, 'key_format=S,value_format=S')
+        cursor = self.session.open_cursor(uri)
+        for k, v in (('k1', 'v1_orig'), ('k2', 'v2_orig')):
+            self.session.begin_transaction()
+            cursor.set_key(k)
+            cursor.set_value(v)
+            cursor.insert()
+            self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(10)}')
+        cursor.close()
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(10)}'
+                                f',oldest_timestamp={self.timestamp_str(1)}')
+        self.session.checkpoint()
+
+        # --- Step down ---
+        self.conn.reconfigure('disaggregated=(role="follower")')
+
+        fsession = self.conn.open_session('')
+
+        # T=20: write k2 into ingest  k2 is now in both stable and ingest.
+        fcursor = fsession.open_cursor(uri)
+        fsession.begin_transaction()
+        fcursor.set_key('k2')
+        fcursor.set_value('v2_ingest')
+        fcursor.update()
+        fsession.commit_transaction(f'commit_timestamp={self.timestamp_str(20)}')
+        fcursor.close()
+
+        # T=30: truncate [k1..k2].
+        #   k1 stable-only  WT_TRUNCATE entry only.
+        #   k2 in ingest    tombstone written to ingest at T=30 + WT_TRUNCATE entry.
+        c_start = fsession.open_cursor(uri)
+        c_stop  = fsession.open_cursor(uri)
+        c_start.set_key('k1')
+        c_stop.set_key('k2')
+        fsession.begin_transaction()
+        fsession.truncate(None, c_start, c_stop, None)
+        fsession.commit_transaction(f'commit_timestamp={self.timestamp_str(30)}')
+        c_start.close()
+        c_stop.close()
+
+        self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(30)}')
+
+        # --- Step up and drain ---
+        self.conn.reconfigure('disaggregated=(role="leader")')
+        fsession.checkpoint()
+        fsession.close()
+
+        # --- Verify MVCC chain ---
+        rsession = self.conn.open_session('')
+
+        def read_key(ts, key):
+            rsession.begin_transaction(f'read_timestamp={self.timestamp_str(ts)}')
+            rc = rsession.open_cursor(uri)
+            rc.set_key(key)
+            ret = rc.search()
+            val = rc.get_value() if ret == 0 else None
+            rsession.rollback_transaction()
+            rc.close()
+            return ret, val
+
+        # k1: stable-only; tombstoned by __layered_apply_truncate_to_stable at T=30.
+        self.assertEqual(read_key(29, 'k1'), (0, 'v1_orig'), 'k1 visible before truncate')
+        self.assertEqual(read_key(30, 'k1')[0], wiredtiger.WT_NOTFOUND, 'k1 absent at truncate ts')
+
+        # k2: tombstoned by ingest drain at T=30; __layered_apply_truncate_to_stable
+        # must skip it (no duplicate tombstone).
+        self.assertEqual(read_key(19, 'k2'), (0, 'v2_orig'),   'k2 at T=19: original stable value')
+        self.assertEqual(read_key(25, 'k2'), (0, 'v2_ingest'), 'k2 at T=25: ingest write visible')
+        self.assertEqual(read_key(30, 'k2')[0], wiredtiger.WT_NOTFOUND, 'k2 absent at truncate ts')
+
+        rsession.close()
+
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_version_search_near.py
+++ b/test/suite/test_version_search_near.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# test_version_search_near.py
+#   Test WT_CURSOR::search_near for the version cursor.
+#
+import wttest
+import wiredtiger
+
+# The version cursor value is the metadata format (14 fields) followed by the table value, so the
+# table value lives at index 14 of get_values().
+VALUE_INDEX = 14
+
+class test_version_search_near(wttest.WiredTigerTestCase):
+    uri = 'file:test_version_search_near.wt'
+
+    def create(self):
+        self.session.create(self.uri, 'key_format=S,value_format=S')
+
+    def key(self, i):
+        # Zero-padded so lexicographic order matches numeric order.
+        return 'key%03d' % i
+
+    def open_version_cursor(self, start_timestamp=None):
+        internal_config = ["enabled=true"]
+        if start_timestamp is not None:
+            internal_config.append("start_timestamp=" + self.timestamp_str(start_timestamp))
+        config = "debug=(dump_version=(" + ",".join(internal_config) + "))"
+        return self.session.open_cursor(self.uri, None, config)
+
+    def populate(self, keys, commit_ts=10):
+        """Insert one committed version per key at the given commit timestamp."""
+        cursor = self.session.open_cursor(self.uri, None)
+        for i in keys:
+            self.session.begin_transaction()
+            cursor[self.key(i)] = 'value%03d' % i
+            self.session.commit_transaction("commit_timestamp=" + self.timestamp_str(commit_ts))
+        cursor.close()
+
+    def get_value(self, version_cursor):
+        return version_cursor.get_values()[VALUE_INDEX]
+
+    def test_exact_match(self):
+        """An exact match returns 0 and positions on the searched key."""
+        self.create()
+        self.populate([10, 20, 30])
+
+        self.session.begin_transaction()
+        vc = self.open_version_cursor()
+        vc.set_key(self.key(20))
+        self.assertEqual(vc.search_near(), 0)
+        self.assertEqual(vc.get_key(), self.key(20))
+        self.assertEqual(self.get_value(vc), 'value020')
+        vc.close()
+        self.session.rollback_transaction()
+
+    def test_between_keys(self):
+        """A search key between two existing keys lands on the next greater key, exact > 0."""
+        self.create()
+        self.populate([10, 20, 30])
+
+        self.session.begin_transaction()
+        vc = self.open_version_cursor()
+        vc.set_key(self.key(15))
+        self.assertEqual(vc.search_near(), 1)
+        self.assertEqual(vc.get_key(), self.key(20))
+        self.assertEqual(self.get_value(vc), 'value020')
+        vc.close()
+        self.session.rollback_transaction()
+
+    def test_smaller_than_all(self):
+        """A search key smaller than all keys lands on the smallest key, exact > 0."""
+        self.create()
+        self.populate([10, 20, 30])
+
+        self.session.begin_transaction()
+        vc = self.open_version_cursor()
+        vc.set_key(self.key(5))
+        self.assertEqual(vc.search_near(), 1)
+        self.assertEqual(vc.get_key(), self.key(10))
+        self.assertEqual(self.get_value(vc), 'value010')
+        vc.close()
+        self.session.rollback_transaction()
+
+    def test_larger_than_all(self):
+        """A search key larger than all keys lands on the largest key, exact < 0."""
+        self.create()
+        self.populate([10, 20, 30])
+
+        self.session.begin_transaction()
+        vc = self.open_version_cursor()
+        vc.set_key(self.key(99))
+        self.assertEqual(vc.search_near(), -1)
+        self.assertEqual(vc.get_key(), self.key(30))
+        self.assertEqual(self.get_value(vc), 'value030')
+        vc.close()
+        self.session.rollback_transaction()
+
+    def test_next_after_search_near(self):
+        """After a successful search_near, next() iterates forward over versions and keys."""
+        self.create()
+        # key020 gets two versions; the search_near should land on the newest one.
+        cursor = self.session.open_cursor(self.uri, None)
+        for i in [10, 20, 30]:
+            self.session.begin_transaction()
+            cursor[self.key(i)] = 'value%03d' % i
+            self.session.commit_transaction("commit_timestamp=" + self.timestamp_str(10))
+        self.session.begin_transaction()
+        cursor[self.key(20)] = 'value020b'
+        self.session.commit_transaction("commit_timestamp=" + self.timestamp_str(20))
+        cursor.close()
+
+        self.session.begin_transaction()
+        vc = self.open_version_cursor()
+        vc.set_key(self.key(15))
+        # Lands on key020, newest version first.
+        self.assertEqual(vc.search_near(), 1)
+        self.assertEqual(vc.get_key(), self.key(20))
+        self.assertEqual(self.get_value(vc), 'value020b')
+
+        # next() walks back through the older version of the same key.
+        self.assertEqual(vc.next(), 0)
+        self.assertEqual(vc.get_key(), self.key(20))
+        self.assertEqual(self.get_value(vc), 'value020')
+
+        # No more versions of key020; next() exhausts the single key (cross_key is off).
+        self.assertEqual(vc.next(), wiredtiger.WT_NOTFOUND)
+        vc.close()
+        self.session.rollback_transaction()
+
+    def test_empty_table(self):
+        """An empty table returns WT_NOTFOUND."""
+        self.create()
+
+        self.session.begin_transaction()
+        vc = self.open_version_cursor()
+        vc.set_key(self.key(10))
+        self.assertEqual(vc.search_near(), wiredtiger.WT_NOTFOUND)
+        vc.close()
+        self.session.rollback_transaction()
+
+    def test_all_versions_filtered(self):
+        """
+        A key whose only version is filtered out by start_timestamp is skipped; search_near lands
+        on the next visible key.
+        """
+        self.create()
+        # key010 committed early (durable ts 5), key020 committed later (durable ts 20).
+        cursor = self.session.open_cursor(self.uri, None)
+        self.session.begin_transaction()
+        cursor[self.key(10)] = 'value010'
+        self.session.commit_transaction("commit_timestamp=" + self.timestamp_str(5))
+        self.session.begin_transaction()
+        cursor[self.key(20)] = 'value020'
+        self.session.commit_transaction("commit_timestamp=" + self.timestamp_str(20))
+        cursor.close()
+
+        # With start_timestamp=10, key010's version (durable ts 5) is filtered out.
+        self.session.begin_transaction()
+        vc = self.open_version_cursor(start_timestamp=10)
+        vc.set_key(self.key(10))
+        self.assertEqual(vc.search_near(), 1)
+        self.assertEqual(vc.get_key(), self.key(20))
+        self.assertEqual(self.get_value(vc), 'value020')
+        vc.close()
+        self.session.rollback_transaction()
+
+    def test_all_versions_filtered_backward(self):
+        """
+        When the only visible key is below the search key (everything at/after is filtered),
+        search_near falls back to the largest preceding visible key, exact < 0.
+        """
+        self.create()
+        # key010 committed later (durable ts 20, visible), key020 committed early (durable ts 5).
+        cursor = self.session.open_cursor(self.uri, None)
+        self.session.begin_transaction()
+        cursor[self.key(10)] = 'value010'
+        self.session.commit_transaction("commit_timestamp=" + self.timestamp_str(20))
+        self.session.begin_transaction()
+        cursor[self.key(20)] = 'value020'
+        self.session.commit_transaction("commit_timestamp=" + self.timestamp_str(5))
+        cursor.close()
+
+        # Search for key020 with start_timestamp=10: key020 (durable ts 5) is filtered, the only
+        # visible key (key010) is below the search key.
+        self.session.begin_transaction()
+        vc = self.open_version_cursor(start_timestamp=10)
+        vc.set_key(self.key(20))
+        self.assertEqual(vc.search_near(), -1)
+        self.assertEqual(vc.get_key(), self.key(10))
+        self.assertEqual(self.get_value(vc), 'value010')
+        vc.close()
+        self.session.rollback_transaction()
+
+    def test_deleted_key_with_history(self):
+        """
+        A key whose newest committed version is a tombstone (so it reads as absent) still has older
+        versions, and the version cursor must position on it rather than skipping past to the next
+        live key.
+        """
+        self.create()
+        cursor = self.session.open_cursor(self.uri, None)
+        # key010 gets a value then a tombstone, both committed before the reader's snapshot.
+        self.session.begin_transaction()
+        cursor[self.key(10)] = 'value010'
+        self.session.commit_transaction("commit_timestamp=" + self.timestamp_str(5))
+        self.session.begin_transaction()
+        cursor.set_key(self.key(10))
+        cursor.remove()
+        self.session.commit_transaction("commit_timestamp=" + self.timestamp_str(10))
+        # key020 is a live value.
+        self.session.begin_transaction()
+        cursor[self.key(20)] = 'value020'
+        self.session.commit_transaction("commit_timestamp=" + self.timestamp_str(5))
+        cursor.close()
+
+        # Read after the tombstone so key010 appears deleted to an ordinary cursor.
+        self.session.begin_transaction("read_timestamp=" + self.timestamp_str(20))
+        vc = self.open_version_cursor()
+        vc.set_key(self.key(5))
+        # The smallest key at or after key005 with a visible version is key010 (its older value).
+        self.assertEqual(vc.search_near(), 1)
+        self.assertEqual(vc.get_key(), self.key(10))
+
+        # Walking forward then reaches key020, the live key.
+        vc.reset()
+        vc.set_key(self.key(15))
+        self.assertEqual(vc.search_near(), 1)
+        self.assertEqual(vc.get_key(), self.key(20))
+        self.assertEqual(self.get_value(vc), 'value020')
+        vc.close()
+        self.session.rollback_transaction()
+
+    def test_column_store(self):
+        """
+        Repeat the core cases on a column-store table, where search_near positions by record number
+        rather than by key bytes.
+        """
+        col_uri = 'file:test_version_search_near_col.wt'
+        self.session.create(col_uri, 'key_format=r,value_format=S')
+        cursor = self.session.open_cursor(col_uri, None)
+        for r in [10, 20, 30]:
+            self.session.begin_transaction()
+            cursor[r] = 'value%03d' % r
+            self.session.commit_transaction("commit_timestamp=" + self.timestamp_str(10))
+        cursor.close()
+
+        self.session.begin_transaction()
+        vc = self.session.open_cursor(col_uri, None, "debug=(dump_version=(enabled=true))")
+
+        # Exact match.
+        vc.set_key(20)
+        self.assertEqual(vc.search_near(), 0)
+        self.assertEqual(vc.get_key(), 20)
+
+        # Between two records: lands on the next greater.
+        vc.reset()
+        vc.set_key(15)
+        self.assertEqual(vc.search_near(), 1)
+        self.assertEqual(vc.get_key(), 20)
+
+        # Smaller than all records.
+        vc.reset()
+        vc.set_key(5)
+        self.assertEqual(vc.search_near(), 1)
+        self.assertEqual(vc.get_key(), 10)
+
+        # Larger than all records.
+        vc.reset()
+        vc.set_key(99)
+        self.assertEqual(vc.search_near(), -1)
+        self.assertEqual(vc.get_key(), 30)
+
+        # Iterate forward after landing.
+        vc.reset()
+        vc.set_key(15)
+        self.assertEqual(vc.search_near(), 1)
+        self.assertEqual(vc.get_key(), 20)
+        self.assertEqual(vc.next(), wiredtiger.WT_NOTFOUND)
+        vc.close()
+        self.session.rollback_transaction()
+
+    def test_prepared_key_no_conflict(self):
+        """
+        search_near must not raise WT_PREPARE_CONFLICT when a key at/near the search key has only a
+        prepared (uncommitted) value. The anchor search ignores prepare; the key-only walk then
+        surfaces or skips the key per the reader's visibility.
+        """
+        self.create()
+        self.populate([10, 30])  # committed key010, key030
+
+        # A second session leaves key020 prepared (uncommitted) at prepare_timestamp 5.
+        session2 = self.conn.open_session()
+        cursor2 = session2.open_cursor(self.uri, None)
+        session2.begin_transaction()
+        cursor2[self.key(20)] = 'value020'
+        session2.prepare_transaction("prepare_timestamp=" + self.timestamp_str(5))
+
+        # A plain snapshot reader (NOT ignore_prepare) searches across the prepared key. Without the
+        # anchor's ignore-prepare this raises WT_PREPARE_CONFLICT; with it the call must succeed.
+        self.session.begin_transaction()
+        vc = self.open_version_cursor()
+        vc.set_key(self.key(20))
+        # The call must succeed (no WT_PREPARE_CONFLICT). The version cursor surfaces the prepared
+        # version, so the exact key is found.
+        self.assertEqual(vc.search_near(), 0)
+        self.assertEqual(vc.get_key(), self.key(20))
+        vc.close()
+        self.session.rollback_transaction()
+        session2.rollback_transaction()
+
+if __name__ == '__main__':
+    wttest.run()


### PR DESCRIPTION
The ingest-to-stable drain that runs when a node steps up to leader previously processed each layered table's ingest constituent sequentially. Here we replace it with a parallel slice engine: each table's key space is subdivided into ranges that are copied concurrently, while preserving the timestamp-interleaved ordering that keeps truncate replays correct. Within each committed-truncate timestamp slice the range copies run in parallel; the truncate is then replayed once, single-threaded, between slices.

Range boundaries are chosen by reservoir-sampling the drainable keys through a version cursor filtered by the last-checkpoint timestamp, so split points fall only on keys that will actually drain. Positioning a range copy on that
timestamp-filtered scan uses the version cursor's search_near, added here. Because a worker can abort a prepared op's ingest update concurrently with another worker's version cursor reading that update's txnid, both sides use WT's synchronized store/load idiom, and the prepared-fix walk is serialized with a per-connection lock.

Supporting changes: register a layered table with the table manager during the prepared-discover walk so prepared updates are routed correctly during the drain, and select drainable truncates by the committed flag (acquire load) rather than a non-zero transaction id.

Tested by test_layered_stepup11 (multi-table, single-thread, empty-table, prepared transactions spanning one or many ranges, standalone tombstones, and follower range truncates) and test_version_search_near.
