### PR TITLE
WT-17542 Select the checkpoint KEK by timestamp and write a v2 page

### DIFF
--- a/src/conn/conn_layered_page_log.c
+++ b/src/conn/conn_layered_page_log.c
@@ -10,6 +10,7 @@
 
 /* Function prototypes for disaggregated storage and layered tables. */
 static void __disagg_set_crypt_header(WT_SESSION_IMPL *session, WT_CRYPT_KEYS *crypt);
+static void __disagg_prune_pending_crypt_keys(WT_SESSION_IMPL *session, wt_timestamp_t bound);
 
 /*
  * __disagg_get_page --
@@ -289,6 +290,9 @@ __wti_disagg_load_crypt_key(WT_SESSION_IMPL *session, WT_DISAGG_METADATA *metada
     /* Callback to load the encryption key data into the key provider. */
     WT_ERR(key_provider->load_key(key_provider, (WT_SESSION *)session, &crypt));
 
+    /* Prune the in-memory list on every checkpoint pickup. */
+    __disagg_prune_pending_crypt_keys(session, crypt_header->timestamp);
+
 err:
     __wt_buf_free(session, &key_item);
     __wt_free(session, crypt_header);
@@ -459,6 +463,53 @@ __wti_disagg_pending_crypt_key_clear(WT_SESSION_IMPL *session)
 }
 
 /*
+ * __disagg_select_pending_crypt_key --
+ *     Return the queued key with the highest timestamp less than or equal to the checkpoint
+ *     timestamp, or NULL if none qualifies. Caller must hold the pending key lock.
+ */
+static WT_DISAGG_PENDING_CRYPT_KEY *
+__disagg_select_pending_crypt_key(WT_SESSION_IMPL *session, wt_timestamp_t checkpoint_timestamp)
+{
+    WT_CONNECTION_IMPL *conn;
+    WT_DISAGG_PENDING_CRYPT_KEY *chosen, *entry;
+
+    conn = S2C(session);
+    chosen = NULL;
+
+    TAILQ_FOREACH (entry, &conn->disaggregated_storage.pending_crypt_key_qh, q) {
+        if (entry->timestamp > checkpoint_timestamp)
+            break;
+        chosen = entry;
+    }
+    return (chosen);
+}
+
+/*
+ * __disagg_prune_pending_crypt_keys --
+ *     Free queued keys with a timestamp less than or equal to the given bound, retaining newer
+ *     entries.
+ */
+static void
+__disagg_prune_pending_crypt_keys(WT_SESSION_IMPL *session, wt_timestamp_t bound)
+{
+    WT_CONNECTION_IMPL *conn;
+    WT_DISAGG_PENDING_CRYPT_KEY *entry, *tmp;
+
+    conn = S2C(session);
+
+    __wt_spin_lock(session, &conn->disaggregated_storage.pending_crypt_key_lock);
+    WT_TAILQ_SAFE_REMOVE_BEGIN(entry, &conn->disaggregated_storage.pending_crypt_key_qh, q, tmp)
+    {
+        if (entry->timestamp > bound)
+            break;
+        TAILQ_REMOVE(&conn->disaggregated_storage.pending_crypt_key_qh, entry, q);
+        __disagg_pending_crypt_key_free(session, &entry);
+    }
+    WT_TAILQ_SAFE_REMOVE_END
+    __wt_spin_unlock(session, &conn->disaggregated_storage.pending_crypt_key_lock);
+}
+
+/*
  * __wti_disagg_set_crypt_key --
  *     Queue an encryption key to be persisted at the next checkpoint that covers its timestamp.
  *     Timestamps must be monotonically increasing and greater than the global stable timestamp.
@@ -528,6 +579,7 @@ __wt_disagg_put_crypt_helper(WT_SESSION_IMPL *session)
     WT_DECL_RET;
     WT_DISAGG_PENDING_CRYPT_KEY *chosen_key;
     WT_KEY_PROVIDER *key_provider;
+    wt_timestamp_t ckpt_timestamp;
     uint64_t lsn;
     bool push_mode;
 
@@ -535,6 +587,7 @@ __wt_disagg_put_crypt_helper(WT_SESSION_IMPL *session)
     key_provider = conn->key_provider;
     WT_CLEAR(crypt);
     lsn = 0;
+    ckpt_timestamp = WT_TS_NONE;
     push_mode = F_ISSET(conn, WT_CONN_KEY_PROVIDER_PUSH);
 
     WT_ASSERT_SPINLOCK_OWNED(session, &conn->checkpoint_lock);
@@ -543,10 +596,11 @@ __wt_disagg_put_crypt_helper(WT_SESSION_IMPL *session)
         __wt_debug_crash(session);
 
     if (push_mode) {
-        /* Push mode: pick the most recently pushed key under the lock. */
+        /* Push mode: select the key with the highest timestamp less than or equal to the
+         * checkpoint timestamp. */
+        ckpt_timestamp = conn->disaggregated_storage.cur_checkpoint_timestamp;
         __wt_spin_lock(session, &conn->disaggregated_storage.pending_crypt_key_lock);
-        chosen_key = TAILQ_LAST(
-          &conn->disaggregated_storage.pending_crypt_key_qh, __wt_disagg_pending_crypt_key_qh);
+        chosen_key = __disagg_select_pending_crypt_key(session, ckpt_timestamp);
         __wt_spin_unlock(session, &conn->disaggregated_storage.pending_crypt_key_lock);
         if (chosen_key == NULL)
             goto done;
@@ -597,9 +651,12 @@ __wt_disagg_put_crypt_helper(WT_SESSION_IMPL *session)
     }
     WT_IGNORE_RET(key_provider->on_key_update(key_provider, (WT_SESSION *)session, &crypt));
 
-    /* On success, drain all items in queue. */
+    /*
+     * On success, drain all keys with a timestamp less than or equal to the checkpoint timestamp;
+     * newer keys are retained for a later checkpoint.
+     */
     if (push_mode && ret == 0)
-        __wti_disagg_pending_crypt_key_clear(session);
+        __disagg_prune_pending_crypt_keys(session, ckpt_timestamp);
 
     if (session->ckpt.crash_trigger_point == KEY_PROVIDER_CRASH_AFTER_KEY_ROTATION)
         __wt_debug_crash(session);
@@ -699,6 +756,44 @@ err:
 }
 
 /*
+ * __disagg_append_crypt_meta --
+ *     Append key provider metadata referencing the KEK page to the checkpoint metadata.
+ */
+static int
+__disagg_append_crypt_meta(WT_SESSION_IMPL *session, WT_ITEM *metadata_buf)
+{
+    WT_CONNECTION_IMPL *conn;
+
+    conn = S2C(session);
+
+    if (conn->key_provider == NULL)
+        return (0);
+
+    /*
+     * A brand-new database in push mode can reach a checkpoint before persisting a key, leaving no
+     * key-provider page to reference; skip the metadata in that case.
+     */
+    if (F_ISSET(conn, WT_CONN_KEY_PROVIDER_PUSH) &&
+      conn->disaggregated_storage.last_key_provider_page_lsn[WT_DISAGG_KEY_PROVIDER_MAIN_PAGE_ID] ==
+        0)
+        return (0);
+
+    /*
+     * Every other case has a persisted page to reference: pull mode writes one at each checkpoint,
+     * and push mode only reaches here once a key has been persisted.
+     */
+    WT_ASSERT(session,
+      conn->disaggregated_storage.last_key_provider_page_lsn[WT_DISAGG_KEY_PROVIDER_MAIN_PAGE_ID] !=
+        0);
+
+    return (__wt_buf_catfmt(session, metadata_buf,
+      ",\n"
+      "key_provider=(page.1=(page_id=%d,lsn=%" PRIu64 "),version=1)",
+      WT_DISAGG_KEY_PROVIDER_MAIN_PAGE_ID,
+      conn->disaggregated_storage.last_key_provider_page_lsn[WT_DISAGG_KEY_PROVIDER_MAIN_PAGE_ID]));
+}
+
+/*
  * __wt_disagg_put_checkpoint_meta --
  *     Write checkpoint information to the metadata page log and do the relevant bookkeeping.
  */
@@ -753,22 +848,7 @@ __wt_disagg_put_checkpoint_meta(WT_SESSION_IMPL *session, const char *checkpoint
         checkpoint_root_copy, checkpoint_timestamp, oldest_timestamp, schema_epoch, max_table_id));
 
     /* Append key provider metadata, if available. */
-    if (conn->key_provider != NULL) {
-        /*
-         * The key provider LSN field should always be initialized. The LSN is provided either
-         * during startup, or when we detect a new encryption key.
-         */
-        WT_ASSERT(session,
-          conn->disaggregated_storage
-              .last_key_provider_page_lsn[WT_DISAGG_KEY_PROVIDER_MAIN_PAGE_ID] != 0);
-
-        WT_ERR(__wt_buf_catfmt(session, metadata_buf,
-          ",\n"
-          "key_provider=(page.1=(page_id=%d,lsn=%" PRIu64 "),version=1)",
-          WT_DISAGG_KEY_PROVIDER_MAIN_PAGE_ID,
-          conn->disaggregated_storage
-            .last_key_provider_page_lsn[WT_DISAGG_KEY_PROVIDER_MAIN_PAGE_ID]));
-    }
+    WT_ERR(__disagg_append_crypt_meta(session, metadata_buf));
 
     /* Compute the checksum for the metadata page. */
     checksum = __wt_checksum(metadata_buf->data, metadata_buf->size);
@@ -1103,5 +1183,17 @@ __ut_disagg_parse_version_and_check(
   WT_SESSION_IMPL *session, const WT_ITEM *meta_buf, WT_DISAGG_METADATA *metadata)
 {
     return (__disagg_parse_version_and_check(session, meta_buf, metadata));
+}
+
+WT_DISAGG_PENDING_CRYPT_KEY *
+__ut_disagg_select_pending_crypt_key(WT_SESSION_IMPL *session, wt_timestamp_t checkpoint_timestamp)
+{
+    return (__disagg_select_pending_crypt_key(session, checkpoint_timestamp));
+}
+
+void
+__ut_disagg_prune_pending_crypt_keys(WT_SESSION_IMPL *session, wt_timestamp_t bound)
+{
+    __disagg_prune_pending_crypt_keys(session, bound);
 }
 #endif

--- a/src/conn/conn_layered_page_log.c
+++ b/src/conn/conn_layered_page_log.c
@@ -779,17 +779,9 @@ __disagg_append_crypt_meta(WT_SESSION_IMPL *session, WT_ITEM *metadata_buf)
         return (0);
 
     /*
-     * A brand-new database in push mode can reach a checkpoint before persisting a key, leaving no
-     * key-provider page to reference; skip the metadata in that case.
-     */
-    if (F_ISSET(conn, WT_CONN_KEY_PROVIDER_PUSH) &&
-      conn->disaggregated_storage.last_key_provider_page_lsn[WT_DISAGG_KEY_PROVIDER_MAIN_PAGE_ID] ==
-        0)
-        return (0);
-
-    /*
-     * Every other case has a persisted page to reference: pull mode writes one at each checkpoint,
-     * and push mode only reaches here once a key has been persisted.
+     * A configured key provider always has a persisted KEK page by checkpoint time. Everything the
+     * checkpoint writes, including the metadata table, is encrypted, so a key must already exist;
+     * reaching here without one should be impossible.
      */
     WT_ASSERT(session,
       conn->disaggregated_storage.last_key_provider_page_lsn[WT_DISAGG_KEY_PROVIDER_MAIN_PAGE_ID] !=

--- a/src/conn/conn_layered_page_log.c
+++ b/src/conn/conn_layered_page_log.c
@@ -472,11 +472,20 @@ __disagg_select_pending_crypt_key(WT_SESSION_IMPL *session, wt_timestamp_t check
 {
     WT_CONNECTION_IMPL *conn;
     WT_DISAGG_PENDING_CRYPT_KEY *chosen, *entry;
+    wt_timestamp_t prev_timestamp;
 
     conn = S2C(session);
     chosen = NULL;
+    prev_timestamp = WT_TS_NONE;
 
+    /*
+     * set_key enqueues in strictly ascending timestamp order, so the first entry past the
+     * checkpoint timestamp ends the search. Assert the ordering as we go rather than trusting the
+     * API.
+     */
     TAILQ_FOREACH (entry, &conn->disaggregated_storage.pending_crypt_key_qh, q) {
+        WT_ASSERT(session, entry->timestamp > prev_timestamp);
+        prev_timestamp = entry->timestamp;
         if (entry->timestamp > checkpoint_timestamp)
             break;
         chosen = entry;

--- a/src/conn/conn_layered_page_log.c
+++ b/src/conn/conn_layered_page_log.c
@@ -478,11 +478,7 @@ __disagg_select_pending_crypt_key(WT_SESSION_IMPL *session, wt_timestamp_t check
     chosen = NULL;
     prev_timestamp = WT_TS_NONE;
 
-    /*
-     * The queue is sorted in ascending timestamp order, so bail out on the first entry past the
-     * checkpoint timestamp. Assert the ordering as we scan rather than trusting the API to enforce
-     * it.
-     */
+    /* The queue is sorted in ascending timestamp order; assert the ordering while scanning. */
     TAILQ_FOREACH (entry, &conn->disaggregated_storage.pending_crypt_key_qh, q) {
         WT_ASSERT(session, entry->timestamp > prev_timestamp);
         prev_timestamp = entry->timestamp;

--- a/src/conn/conn_layered_page_log.c
+++ b/src/conn/conn_layered_page_log.c
@@ -472,16 +472,19 @@ __disagg_select_pending_crypt_key(WT_SESSION_IMPL *session, wt_timestamp_t check
 {
     WT_CONNECTION_IMPL *conn;
     WT_DISAGG_PENDING_CRYPT_KEY *chosen, *entry;
-    wt_timestamp_t prev_timestamp;
+#ifdef HAVE_DIAGNOSTIC
+    wt_timestamp_t prev_timestamp = WT_TS_NONE;
+#endif
 
     conn = S2C(session);
     chosen = NULL;
-    prev_timestamp = WT_TS_NONE;
 
     /* The queue is sorted in ascending timestamp order; assert the ordering while scanning. */
     TAILQ_FOREACH (entry, &conn->disaggregated_storage.pending_crypt_key_qh, q) {
+#ifdef HAVE_DIAGNOSTIC
         WT_ASSERT(session, entry->timestamp > prev_timestamp);
         prev_timestamp = entry->timestamp;
+#endif
         if (entry->timestamp > checkpoint_timestamp)
             break;
         chosen = entry;

--- a/src/conn/conn_layered_page_log.c
+++ b/src/conn/conn_layered_page_log.c
@@ -479,9 +479,9 @@ __disagg_select_pending_crypt_key(WT_SESSION_IMPL *session, wt_timestamp_t check
     prev_timestamp = WT_TS_NONE;
 
     /*
-     * set_key enqueues in strictly ascending timestamp order, so the first entry past the
-     * checkpoint timestamp ends the search. Assert the ordering as we go rather than trusting the
-     * API.
+     * The queue is sorted in ascending timestamp order, so bail out on the first entry past the
+     * checkpoint timestamp. Assert the ordering as we scan rather than trusting the API to enforce
+     * it.
      */
     TAILQ_FOREACH (entry, &conn->disaggregated_storage.pending_crypt_key_qh, q) {
         WT_ASSERT(session, entry->timestamp > prev_timestamp);

--- a/src/conn/conn_layered_page_log.c
+++ b/src/conn/conn_layered_page_log.c
@@ -786,11 +786,13 @@ __disagg_append_crypt_meta(WT_SESSION_IMPL *session, WT_ITEM *metadata_buf)
       conn->disaggregated_storage.last_key_provider_page_lsn[WT_DISAGG_KEY_PROVIDER_MAIN_PAGE_ID] !=
         0);
 
-    return (__wt_buf_catfmt(session, metadata_buf,
+    WT_RET(__wt_buf_catfmt(session, metadata_buf,
       ",\n"
       "key_provider=(page.1=(page_id=%d,lsn=%" PRIu64 "),version=1)",
       WT_DISAGG_KEY_PROVIDER_MAIN_PAGE_ID,
       conn->disaggregated_storage.last_key_provider_page_lsn[WT_DISAGG_KEY_PROVIDER_MAIN_PAGE_ID]));
+
+    return (0);
 }
 
 /*

--- a/src/conn/conn_layered_page_log.c
+++ b/src/conn/conn_layered_page_log.c
@@ -470,17 +470,13 @@ __wti_disagg_pending_crypt_key_clear(WT_SESSION_IMPL *session)
 static WT_DISAGG_PENDING_CRYPT_KEY *
 __disagg_select_pending_crypt_key(WT_SESSION_IMPL *session, wt_timestamp_t checkpoint_timestamp)
 {
-    WT_CONNECTION_IMPL *conn;
-    WT_DISAGG_PENDING_CRYPT_KEY *chosen, *entry;
+    WT_DISAGG_PENDING_CRYPT_KEY *chosen = NULL, *entry;
 #ifdef HAVE_DIAGNOSTIC
     wt_timestamp_t prev_timestamp = WT_TS_NONE;
 #endif
 
-    conn = S2C(session);
-    chosen = NULL;
-
     /* The queue is sorted in ascending timestamp order; assert the ordering while scanning. */
-    TAILQ_FOREACH (entry, &conn->disaggregated_storage.pending_crypt_key_qh, q) {
+    TAILQ_FOREACH (entry, &S2C(session)->disaggregated_storage.pending_crypt_key_qh, q) {
 #ifdef HAVE_DIAGNOSTIC
         WT_ASSERT(session, entry->timestamp > prev_timestamp);
         prev_timestamp = entry->timestamp;

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2654,6 +2654,8 @@ static inline bool __wt_get_page_modify_ta(WT_SESSION_IMPL *session, WT_PAGE *pa
   WT_TIME_AGGREGATE **ta) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 
 #ifdef HAVE_UNITTEST
+extern WT_DISAGG_PENDING_CRYPT_KEY *__ut_disagg_select_pending_crypt_key(WT_SESSION_IMPL *session,
+  wt_timestamp_t checkpoint_timestamp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern WT_EXT *__ut_block_off_srch_last(WT_EXT **head, WT_EXT ***stack)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern bool __ut_block_bitflip_detect(void *data, size_t check_size, uint32_t expected_checksum,
@@ -2710,6 +2712,7 @@ extern void __ut_block_off_srch(WT_EXT **head, wt_off_t off, WT_EXT ***stack, bo
 extern void __ut_block_off_srch_pair(
   WT_EXTLIST *el, wt_off_t off, WT_EXT **beforep, WT_EXT **afterp);
 extern void __ut_block_size_srch(WT_SIZE **head, wt_off_t size, WT_SIZE ***stack);
+extern void __ut_disagg_prune_pending_crypt_keys(WT_SESSION_IMPL *session, wt_timestamp_t bound);
 extern void __ut_disagg_set_crypt_header(WT_SESSION_IMPL *session, WT_CRYPT_KEYS *crypt);
 extern void __ut_layered_table_truncate_gc(
   WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered_table, const wt_timestamp_t prune_timestamp);

--- a/test/catch2/ext/test_key_provider.cpp
+++ b/test/catch2/ext/test_key_provider.cpp
@@ -537,26 +537,28 @@ TEST_CASE_METHOD(
     validate_pending_queue(conn_impl, {});
 
     /* Distinct key bytes per entry so the surviving entries' keys can be validated. */
-    const std::string keys[4] = {
-      "prune-key-ten", "prune-key-twenty", "prune-key-thirty", "prune-key-forty"};
-    const uint64_t timestamps[4] = {10, 20, 30, 40};
-    for (int i = 0; i < 4; i++)
+    const std::string keys[5] = {"prune-key-ten", "prune-key-twenty", "prune-key-thirty",
+      "prune-key-forty", "prune-key-fifty"};
+    const uint64_t timestamps[5] = {10, 20, 30, 40, 50};
+    for (int i = 0; i < 5; i++)
         REQUIRE(push_key(&stub, keys[i], timestamps[i]) == 0);
-    validate_pending_queue(conn_impl, {{10, keys[0]}, {20, keys[1]}, {30, keys[2]}, {40, keys[3]}});
+    validate_pending_queue(
+      conn_impl, {{10, keys[0]}, {20, keys[1]}, {30, keys[2]}, {40, keys[3]}, {50, keys[4]}});
 
     /* A bound below every entry frees nothing. */
     __ut_disagg_prune_pending_crypt_keys(session_impl, 5);
-    validate_pending_queue(conn_impl, {{10, keys[0]}, {20, keys[1]}, {30, keys[2]}, {40, keys[3]}});
+    validate_pending_queue(
+      conn_impl, {{10, keys[0]}, {20, keys[1]}, {30, keys[2]}, {40, keys[3]}, {50, keys[4]}});
+
+    /* A bound exactly at an entry frees that entry too. */
+    __ut_disagg_prune_pending_crypt_keys(session_impl, 10);
+    validate_pending_queue(conn_impl, {{20, keys[1]}, {30, keys[2]}, {40, keys[3]}, {50, keys[4]}});
 
     /* A bound between entries frees the covered keys and retains the newer ones. */
     __ut_disagg_prune_pending_crypt_keys(session_impl, 25);
-    validate_pending_queue(conn_impl, {{30, keys[2]}, {40, keys[3]}});
+    validate_pending_queue(conn_impl, {{30, keys[2]}, {40, keys[3]}, {50, keys[4]}});
 
-    /* A bound exactly at an entry frees that entry too. */
-    __ut_disagg_prune_pending_crypt_keys(session_impl, 30);
-    validate_pending_queue(conn_impl, {{40, keys[3]}});
-
-    /* A bound at or above every remaining entry drains the queue. */
+    /* A bound at or above every remaining entry drains the three that are left. */
     __ut_disagg_prune_pending_crypt_keys(session_impl, 1000);
     validate_pending_queue(conn_impl, {});
 

--- a/test/catch2/ext/test_key_provider.cpp
+++ b/test/catch2/ext/test_key_provider.cpp
@@ -537,27 +537,22 @@ TEST_CASE_METHOD(
     validate_pending_queue(conn_impl, {});
 
     /* Distinct key bytes per entry so the surviving entries' keys can be validated. */
-    const std::string keys[6] = {"prune-key-ten", "prune-key-twenty", "prune-key-thirty",
-      "prune-key-forty", "prune-key-fifty", "prune-key-sixty"};
-    const uint64_t timestamps[6] = {10, 20, 30, 40, 50, 60};
-    for (int i = 0; i < 6; i++)
+    const std::string keys[5] = {"prune-key-ten", "prune-key-twenty", "prune-key-thirty",
+      "prune-key-forty", "prune-key-fifty"};
+    const uint64_t timestamps[5] = {10, 20, 30, 40, 50};
+    for (int i = 0; i < 5; i++)
         REQUIRE(push_key(&stub, keys[i], timestamps[i]) == 0);
-    validate_pending_queue(conn_impl,
-      {{10, keys[0]}, {20, keys[1]}, {30, keys[2]}, {40, keys[3]}, {50, keys[4]}, {60, keys[5]}});
+    validate_pending_queue(
+      conn_impl, {{10, keys[0]}, {20, keys[1]}, {30, keys[2]}, {40, keys[3]}, {50, keys[4]}});
 
     /* A bound below every entry frees nothing. */
     __ut_disagg_prune_pending_crypt_keys(session_impl, 5);
-    validate_pending_queue(conn_impl,
-      {{10, keys[0]}, {20, keys[1]}, {30, keys[2]}, {40, keys[3]}, {50, keys[4]}, {60, keys[5]}});
-
-    /* A bound exactly at an entry frees that entry too. */
-    __ut_disagg_prune_pending_crypt_keys(session_impl, 10);
     validate_pending_queue(
-      conn_impl, {{20, keys[1]}, {30, keys[2]}, {40, keys[3]}, {50, keys[4]}, {60, keys[5]}});
+      conn_impl, {{10, keys[0]}, {20, keys[1]}, {30, keys[2]}, {40, keys[3]}, {50, keys[4]}});
 
-    /* A bound between entries frees the two covered keys and retains the newer ones. */
-    __ut_disagg_prune_pending_crypt_keys(session_impl, 35);
-    validate_pending_queue(conn_impl, {{40, keys[3]}, {50, keys[4]}, {60, keys[5]}});
+    /* A bound exactly at an entry frees that entry and everything older. */
+    __ut_disagg_prune_pending_crypt_keys(session_impl, 20);
+    validate_pending_queue(conn_impl, {{30, keys[2]}, {40, keys[3]}, {50, keys[4]}});
 
     /* A bound at or above every remaining entry drains the three that are left. */
     __ut_disagg_prune_pending_crypt_keys(session_impl, 1000);

--- a/test/catch2/ext/test_key_provider.cpp
+++ b/test/catch2/ext/test_key_provider.cpp
@@ -556,7 +556,7 @@ TEST_CASE_METHOD(
     F_CLR(conn_impl, WT_CONN_KEY_PROVIDER_PUSH);
 }
 
-TEST_CASE_METHOD(kp_fixture, "checkpoint selection and prune edge cases", "[key_provider]")
+TEST_CASE_METHOD(kp_fixture, "checkpoint selection edge cases", "[key_provider]")
 {
     WT_CONNECTION *wt_conn = conn.get_wt_connection();
     WT_CONNECTION_IMPL *conn_impl = conn.get_wt_connection_impl();
@@ -564,10 +564,8 @@ TEST_CASE_METHOD(kp_fixture, "checkpoint selection and prune edge cases", "[key_
     WT_KEY_PROVIDER stub = {};
     REQUIRE(wt_conn->set_key_provider(wt_conn, &stub, "version=1") == 0);
 
-    /* An empty queue selects nothing, and pruning it is a no-op. */
+    /* An empty queue selects nothing. */
     REQUIRE(__ut_disagg_select_pending_crypt_key(session_impl, 100) == nullptr);
-    __ut_disagg_prune_pending_crypt_keys(session_impl, 100);
-    validate_pending_queue(conn_impl, {});
 
     /* A single entry is selected only once the checkpoint timestamp reaches it. */
     const std::string edge_key = "edge-test-key";
@@ -575,7 +573,26 @@ TEST_CASE_METHOD(kp_fixture, "checkpoint selection and prune edge cases", "[key_
     REQUIRE(__ut_disagg_select_pending_crypt_key(session_impl, 49) == nullptr);
     validate_chosen_key(__ut_disagg_select_pending_crypt_key(session_impl, 50), 50, edge_key);
 
+    __wti_disagg_pending_crypt_key_clear(session_impl);
+    conn_impl->key_provider = nullptr;
+    F_CLR(conn_impl, WT_CONN_KEY_PROVIDER_PUSH);
+}
+
+TEST_CASE_METHOD(kp_fixture, "checkpoint prune edge cases", "[key_provider]")
+{
+    WT_CONNECTION *wt_conn = conn.get_wt_connection();
+    WT_CONNECTION_IMPL *conn_impl = conn.get_wt_connection_impl();
+    WT_SESSION_IMPL *session_impl = (WT_SESSION_IMPL *)session;
+    WT_KEY_PROVIDER stub = {};
+    REQUIRE(wt_conn->set_key_provider(wt_conn, &stub, "version=1") == 0);
+
+    /* Pruning an empty queue is a no-op. */
+    __ut_disagg_prune_pending_crypt_keys(session_impl, 100);
+    validate_pending_queue(conn_impl, {});
+
     /* A bound below the entry retains it; a bound exactly at the entry frees it. */
+    const std::string edge_key = "edge-test-key";
+    REQUIRE(push_key(&stub, edge_key, 50) == 0);
     __ut_disagg_prune_pending_crypt_keys(session_impl, 49);
     validate_pending_queue(conn_impl, {{50, edge_key}});
     __ut_disagg_prune_pending_crypt_keys(session_impl, 50);

--- a/test/catch2/ext/test_key_provider.cpp
+++ b/test/catch2/ext/test_key_provider.cpp
@@ -523,8 +523,7 @@ TEST_CASE_METHOD(
     F_CLR(conn_impl, WT_CONN_KEY_PROVIDER_PUSH);
 }
 
-TEST_CASE_METHOD(
-  kp_fixture, "checkpoint prune frees covered keys and retains newer ones", "[key_provider]")
+TEST_CASE_METHOD(kp_fixture, "checkpoint prune below the bound frees nothing", "[key_provider]")
 {
     WT_CONNECTION *wt_conn = conn.get_wt_connection();
     WT_CONNECTION_IMPL *conn_impl = conn.get_wt_connection_impl();
@@ -536,29 +535,80 @@ TEST_CASE_METHOD(
     __ut_disagg_prune_pending_crypt_keys(session_impl, 100);
     validate_pending_queue(conn_impl, {});
 
-    /* Distinct key bytes per entry so the surviving entries' keys can be validated. */
-    const std::string keys[5] = {"prune-key-ten", "prune-key-twenty", "prune-key-thirty",
-      "prune-key-forty", "prune-key-fifty"};
-    const uint64_t timestamps[5] = {10, 20, 30, 40, 50};
-    for (int i = 0; i < 5; i++)
+    const std::string keys[3] = {"prune-key-ten", "prune-key-twenty", "prune-key-thirty"};
+    const uint64_t timestamps[3] = {10, 20, 30};
+    for (int i = 0; i < 3; i++)
         REQUIRE(push_key(&stub, keys[i], timestamps[i]) == 0);
-    validate_pending_queue(
-      conn_impl, {{10, keys[0]}, {20, keys[1]}, {30, keys[2]}, {40, keys[3]}, {50, keys[4]}});
 
     /* A bound below every entry frees nothing. */
     __ut_disagg_prune_pending_crypt_keys(session_impl, 5);
-    validate_pending_queue(
-      conn_impl, {{10, keys[0]}, {20, keys[1]}, {30, keys[2]}, {40, keys[3]}, {50, keys[4]}});
+    validate_pending_queue(conn_impl, {{10, keys[0]}, {20, keys[1]}, {30, keys[2]}});
+
+    __wti_disagg_pending_crypt_key_clear(session_impl);
+    conn_impl->key_provider = nullptr;
+    F_CLR(conn_impl, WT_CONN_KEY_PROVIDER_PUSH);
+}
+
+TEST_CASE_METHOD(
+  kp_fixture, "checkpoint prune at an exact boundary frees that key and older", "[key_provider]")
+{
+    WT_CONNECTION *wt_conn = conn.get_wt_connection();
+    WT_CONNECTION_IMPL *conn_impl = conn.get_wt_connection_impl();
+    WT_SESSION_IMPL *session_impl = (WT_SESSION_IMPL *)session;
+    WT_KEY_PROVIDER stub = {};
+    REQUIRE(wt_conn->set_key_provider(wt_conn, &stub, "version=1") == 0);
+
+    const std::string keys[3] = {"prune-key-ten", "prune-key-twenty", "prune-key-thirty"};
+    const uint64_t timestamps[3] = {10, 20, 30};
+    for (int i = 0; i < 3; i++)
+        REQUIRE(push_key(&stub, keys[i], timestamps[i]) == 0);
 
     /* A bound exactly at an entry frees that entry and everything older. */
     __ut_disagg_prune_pending_crypt_keys(session_impl, 20);
-    validate_pending_queue(conn_impl, {{30, keys[2]}, {40, keys[3]}, {50, keys[4]}});
+    validate_pending_queue(conn_impl, {{30, keys[2]}});
+
+    __wti_disagg_pending_crypt_key_clear(session_impl);
+    conn_impl->key_provider = nullptr;
+    F_CLR(conn_impl, WT_CONN_KEY_PROVIDER_PUSH);
+}
+
+TEST_CASE_METHOD(
+  kp_fixture, "checkpoint prune between entries frees the covered keys", "[key_provider]")
+{
+    WT_CONNECTION *wt_conn = conn.get_wt_connection();
+    WT_CONNECTION_IMPL *conn_impl = conn.get_wt_connection_impl();
+    WT_SESSION_IMPL *session_impl = (WT_SESSION_IMPL *)session;
+    WT_KEY_PROVIDER stub = {};
+    REQUIRE(wt_conn->set_key_provider(wt_conn, &stub, "version=1") == 0);
+
+    const std::string keys[3] = {"prune-key-ten", "prune-key-twenty", "prune-key-thirty"};
+    const uint64_t timestamps[3] = {10, 20, 30};
+    for (int i = 0; i < 3; i++)
+        REQUIRE(push_key(&stub, keys[i], timestamps[i]) == 0);
 
     /* A bound between entries frees the two covered keys and retains the newer one. */
-    __ut_disagg_prune_pending_crypt_keys(session_impl, 45);
-    validate_pending_queue(conn_impl, {{50, keys[4]}});
+    __ut_disagg_prune_pending_crypt_keys(session_impl, 25);
+    validate_pending_queue(conn_impl, {{30, keys[2]}});
 
-    /* A bound at or above the last entry drains the queue. */
+    __wti_disagg_pending_crypt_key_clear(session_impl);
+    conn_impl->key_provider = nullptr;
+    F_CLR(conn_impl, WT_CONN_KEY_PROVIDER_PUSH);
+}
+
+TEST_CASE_METHOD(kp_fixture, "checkpoint prune above all drains the queue", "[key_provider]")
+{
+    WT_CONNECTION *wt_conn = conn.get_wt_connection();
+    WT_CONNECTION_IMPL *conn_impl = conn.get_wt_connection_impl();
+    WT_SESSION_IMPL *session_impl = (WT_SESSION_IMPL *)session;
+    WT_KEY_PROVIDER stub = {};
+    REQUIRE(wt_conn->set_key_provider(wt_conn, &stub, "version=1") == 0);
+
+    const std::string keys[3] = {"prune-key-ten", "prune-key-twenty", "prune-key-thirty"};
+    const uint64_t timestamps[3] = {10, 20, 30};
+    for (int i = 0; i < 3; i++)
+        REQUIRE(push_key(&stub, keys[i], timestamps[i]) == 0);
+
+    /* A bound at or above every entry drains the whole queue at once. */
     __ut_disagg_prune_pending_crypt_keys(session_impl, 1000);
     validate_pending_queue(conn_impl, {});
 

--- a/test/catch2/ext/test_key_provider.cpp
+++ b/test/catch2/ext/test_key_provider.cpp
@@ -523,7 +523,7 @@ TEST_CASE_METHOD(
     F_CLR(conn_impl, WT_CONN_KEY_PROVIDER_PUSH);
 }
 
-TEST_CASE_METHOD(kp_fixture, "checkpoint prune below the bound frees nothing", "[key_provider]")
+TEST_CASE_METHOD(kp_fixture, "checkpoint prune scenarios", "[key_provider]")
 {
     WT_CONNECTION *wt_conn = conn.get_wt_connection();
     WT_CONNECTION_IMPL *conn_impl = conn.get_wt_connection_impl();
@@ -540,78 +540,28 @@ TEST_CASE_METHOD(kp_fixture, "checkpoint prune below the bound frees nothing", "
     for (int i = 0; i < 3; i++)
         REQUIRE(push_key(&stub, keys[i], timestamps[i]) == 0);
 
-    /* A bound below every entry frees nothing. */
-    __ut_disagg_prune_pending_crypt_keys(session_impl, 5);
-    validate_pending_queue(conn_impl, {{10, keys[0]}, {20, keys[1]}, {30, keys[2]}});
+    SECTION("a bound below every entry frees nothing")
+    {
+        __ut_disagg_prune_pending_crypt_keys(session_impl, 5);
+        validate_pending_queue(conn_impl, {{10, keys[0]}, {20, keys[1]}, {30, keys[2]}});
+    }
+    SECTION("a bound exactly at an entry frees that entry and everything older")
+    {
+        __ut_disagg_prune_pending_crypt_keys(session_impl, 20);
+        validate_pending_queue(conn_impl, {{30, keys[2]}});
+    }
+    SECTION("a bound between entries frees the covered keys and retains the newer one")
+    {
+        __ut_disagg_prune_pending_crypt_keys(session_impl, 25);
+        validate_pending_queue(conn_impl, {{30, keys[2]}});
+    }
+    SECTION("a bound at or above every entry drains the whole queue")
+    {
+        __ut_disagg_prune_pending_crypt_keys(session_impl, 1000);
+        validate_pending_queue(conn_impl, {});
+    }
 
     __wti_disagg_pending_crypt_key_clear(session_impl);
-    conn_impl->key_provider = nullptr;
-    F_CLR(conn_impl, WT_CONN_KEY_PROVIDER_PUSH);
-}
-
-TEST_CASE_METHOD(
-  kp_fixture, "checkpoint prune at an exact boundary frees that key and older", "[key_provider]")
-{
-    WT_CONNECTION *wt_conn = conn.get_wt_connection();
-    WT_CONNECTION_IMPL *conn_impl = conn.get_wt_connection_impl();
-    WT_SESSION_IMPL *session_impl = (WT_SESSION_IMPL *)session;
-    WT_KEY_PROVIDER stub = {};
-    REQUIRE(wt_conn->set_key_provider(wt_conn, &stub, "version=1") == 0);
-
-    const std::string keys[3] = {"prune-key-ten", "prune-key-twenty", "prune-key-thirty"};
-    const uint64_t timestamps[3] = {10, 20, 30};
-    for (int i = 0; i < 3; i++)
-        REQUIRE(push_key(&stub, keys[i], timestamps[i]) == 0);
-
-    /* A bound exactly at an entry frees that entry and everything older. */
-    __ut_disagg_prune_pending_crypt_keys(session_impl, 20);
-    validate_pending_queue(conn_impl, {{30, keys[2]}});
-
-    __wti_disagg_pending_crypt_key_clear(session_impl);
-    conn_impl->key_provider = nullptr;
-    F_CLR(conn_impl, WT_CONN_KEY_PROVIDER_PUSH);
-}
-
-TEST_CASE_METHOD(
-  kp_fixture, "checkpoint prune between entries frees the covered keys", "[key_provider]")
-{
-    WT_CONNECTION *wt_conn = conn.get_wt_connection();
-    WT_CONNECTION_IMPL *conn_impl = conn.get_wt_connection_impl();
-    WT_SESSION_IMPL *session_impl = (WT_SESSION_IMPL *)session;
-    WT_KEY_PROVIDER stub = {};
-    REQUIRE(wt_conn->set_key_provider(wt_conn, &stub, "version=1") == 0);
-
-    const std::string keys[3] = {"prune-key-ten", "prune-key-twenty", "prune-key-thirty"};
-    const uint64_t timestamps[3] = {10, 20, 30};
-    for (int i = 0; i < 3; i++)
-        REQUIRE(push_key(&stub, keys[i], timestamps[i]) == 0);
-
-    /* A bound between entries frees the two covered keys and retains the newer one. */
-    __ut_disagg_prune_pending_crypt_keys(session_impl, 25);
-    validate_pending_queue(conn_impl, {{30, keys[2]}});
-
-    __wti_disagg_pending_crypt_key_clear(session_impl);
-    conn_impl->key_provider = nullptr;
-    F_CLR(conn_impl, WT_CONN_KEY_PROVIDER_PUSH);
-}
-
-TEST_CASE_METHOD(kp_fixture, "checkpoint prune above all drains the queue", "[key_provider]")
-{
-    WT_CONNECTION *wt_conn = conn.get_wt_connection();
-    WT_CONNECTION_IMPL *conn_impl = conn.get_wt_connection_impl();
-    WT_SESSION_IMPL *session_impl = (WT_SESSION_IMPL *)session;
-    WT_KEY_PROVIDER stub = {};
-    REQUIRE(wt_conn->set_key_provider(wt_conn, &stub, "version=1") == 0);
-
-    const std::string keys[3] = {"prune-key-ten", "prune-key-twenty", "prune-key-thirty"};
-    const uint64_t timestamps[3] = {10, 20, 30};
-    for (int i = 0; i < 3; i++)
-        REQUIRE(push_key(&stub, keys[i], timestamps[i]) == 0);
-
-    /* A bound at or above every entry drains the whole queue at once. */
-    __ut_disagg_prune_pending_crypt_keys(session_impl, 1000);
-    validate_pending_queue(conn_impl, {});
-
     conn_impl->key_provider = nullptr;
     F_CLR(conn_impl, WT_CONN_KEY_PROVIDER_PUSH);
 }

--- a/test/catch2/ext/test_key_provider.cpp
+++ b/test/catch2/ext/test_key_provider.cpp
@@ -502,21 +502,25 @@ TEST_CASE_METHOD(
     for (int i = 0; i < 4; i++)
         REQUIRE(push_key(&stub, keys[i], timestamps[i]) == 0);
 
-    /* The checkpoint timestamp straddles the queue; pick the highest entry not exceeding it. */
-    WT_DISAGG_PENDING_CRYPT_KEY *chosen = __ut_disagg_select_pending_crypt_key(session_impl, 25);
-    validate_chosen_key(chosen, 20, keys[1]);
+    SECTION("a timestamp that straddles the queue picks the highest entry not exceeding it")
+    {
+        validate_chosen_key(__ut_disagg_select_pending_crypt_key(session_impl, 25), 20, keys[1]);
+    }
 
-    /* An exact match on a queued timestamp is selected. */
-    chosen = __ut_disagg_select_pending_crypt_key(session_impl, 30);
-    validate_chosen_key(chosen, 30, keys[2]);
+    SECTION("an exact match on a queued timestamp is selected")
+    {
+        validate_chosen_key(__ut_disagg_select_pending_crypt_key(session_impl, 30), 30, keys[2]);
+    }
 
-    /* A checkpoint timestamp beyond the queue selects the newest entry. */
-    chosen = __ut_disagg_select_pending_crypt_key(session_impl, 100);
-    validate_chosen_key(chosen, 40, keys[3]);
+    SECTION("a timestamp beyond the queue selects the newest entry")
+    {
+        validate_chosen_key(__ut_disagg_select_pending_crypt_key(session_impl, 100), 40, keys[3]);
+    }
 
-    /* No entry qualifies when the checkpoint timestamp precedes the whole queue. */
-    chosen = __ut_disagg_select_pending_crypt_key(session_impl, 5);
-    REQUIRE(chosen == nullptr);
+    SECTION("a timestamp before the whole queue selects nothing")
+    {
+        REQUIRE(__ut_disagg_select_pending_crypt_key(session_impl, 5) == nullptr);
+    }
 
     __wti_disagg_pending_crypt_key_clear(session_impl);
     conn_impl->key_provider = nullptr;
@@ -545,16 +549,19 @@ TEST_CASE_METHOD(kp_fixture, "checkpoint prune scenarios", "[key_provider]")
         __ut_disagg_prune_pending_crypt_keys(session_impl, 5);
         validate_pending_queue(conn_impl, {{10, keys[0]}, {20, keys[1]}, {30, keys[2]}});
     }
+
     SECTION("a bound exactly at an entry frees that entry and everything older")
     {
         __ut_disagg_prune_pending_crypt_keys(session_impl, 20);
         validate_pending_queue(conn_impl, {{30, keys[2]}});
     }
+
     SECTION("a bound between entries frees the covered keys and retains the newer one")
     {
         __ut_disagg_prune_pending_crypt_keys(session_impl, 25);
         validate_pending_queue(conn_impl, {{30, keys[2]}});
     }
+
     SECTION("a bound at or above every entry drains the whole queue")
     {
         __ut_disagg_prune_pending_crypt_keys(session_impl, 1000);

--- a/test/catch2/ext/test_key_provider.cpp
+++ b/test/catch2/ext/test_key_provider.cpp
@@ -554,7 +554,11 @@ TEST_CASE_METHOD(
     __ut_disagg_prune_pending_crypt_keys(session_impl, 20);
     validate_pending_queue(conn_impl, {{30, keys[2]}, {40, keys[3]}, {50, keys[4]}});
 
-    /* A bound at or above every remaining entry drains the three that are left. */
+    /* A bound between entries frees the two covered keys and retains the newer one. */
+    __ut_disagg_prune_pending_crypt_keys(session_impl, 45);
+    validate_pending_queue(conn_impl, {{50, keys[4]}});
+
+    /* A bound at or above the last entry drains the queue. */
     __ut_disagg_prune_pending_crypt_keys(session_impl, 1000);
     validate_pending_queue(conn_impl, {});
 

--- a/test/catch2/ext/test_key_provider.cpp
+++ b/test/catch2/ext/test_key_provider.cpp
@@ -537,26 +537,27 @@ TEST_CASE_METHOD(
     validate_pending_queue(conn_impl, {});
 
     /* Distinct key bytes per entry so the surviving entries' keys can be validated. */
-    const std::string keys[5] = {"prune-key-ten", "prune-key-twenty", "prune-key-thirty",
-      "prune-key-forty", "prune-key-fifty"};
-    const uint64_t timestamps[5] = {10, 20, 30, 40, 50};
-    for (int i = 0; i < 5; i++)
+    const std::string keys[6] = {"prune-key-ten", "prune-key-twenty", "prune-key-thirty",
+      "prune-key-forty", "prune-key-fifty", "prune-key-sixty"};
+    const uint64_t timestamps[6] = {10, 20, 30, 40, 50, 60};
+    for (int i = 0; i < 6; i++)
         REQUIRE(push_key(&stub, keys[i], timestamps[i]) == 0);
-    validate_pending_queue(
-      conn_impl, {{10, keys[0]}, {20, keys[1]}, {30, keys[2]}, {40, keys[3]}, {50, keys[4]}});
+    validate_pending_queue(conn_impl,
+      {{10, keys[0]}, {20, keys[1]}, {30, keys[2]}, {40, keys[3]}, {50, keys[4]}, {60, keys[5]}});
 
     /* A bound below every entry frees nothing. */
     __ut_disagg_prune_pending_crypt_keys(session_impl, 5);
-    validate_pending_queue(
-      conn_impl, {{10, keys[0]}, {20, keys[1]}, {30, keys[2]}, {40, keys[3]}, {50, keys[4]}});
+    validate_pending_queue(conn_impl,
+      {{10, keys[0]}, {20, keys[1]}, {30, keys[2]}, {40, keys[3]}, {50, keys[4]}, {60, keys[5]}});
 
     /* A bound exactly at an entry frees that entry too. */
     __ut_disagg_prune_pending_crypt_keys(session_impl, 10);
-    validate_pending_queue(conn_impl, {{20, keys[1]}, {30, keys[2]}, {40, keys[3]}, {50, keys[4]}});
+    validate_pending_queue(
+      conn_impl, {{20, keys[1]}, {30, keys[2]}, {40, keys[3]}, {50, keys[4]}, {60, keys[5]}});
 
-    /* A bound between entries frees the covered keys and retains the newer ones. */
-    __ut_disagg_prune_pending_crypt_keys(session_impl, 25);
-    validate_pending_queue(conn_impl, {{30, keys[2]}, {40, keys[3]}, {50, keys[4]}});
+    /* A bound between entries frees the two covered keys and retains the newer ones. */
+    __ut_disagg_prune_pending_crypt_keys(session_impl, 35);
+    validate_pending_queue(conn_impl, {{40, keys[3]}, {50, keys[4]}, {60, keys[5]}});
 
     /* A bound at or above every remaining entry drains the three that are left. */
     __ut_disagg_prune_pending_crypt_keys(session_impl, 1000);

--- a/test/catch2/ext/test_key_provider.cpp
+++ b/test/catch2/ext/test_key_provider.cpp
@@ -532,6 +532,10 @@ TEST_CASE_METHOD(
     WT_KEY_PROVIDER stub = {};
     REQUIRE(wt_conn->set_key_provider(wt_conn, &stub, "version=1") == 0);
 
+    /* Pruning an empty queue is a no-op. */
+    __ut_disagg_prune_pending_crypt_keys(session_impl, 100);
+    validate_pending_queue(conn_impl, {});
+
     /* Distinct key bytes per entry so the surviving entries' keys can be validated. */
     const std::string keys[4] = {
       "prune-key-ten", "prune-key-twenty", "prune-key-thirty", "prune-key-forty"};
@@ -540,15 +544,19 @@ TEST_CASE_METHOD(
         REQUIRE(push_key(&stub, keys[i], timestamps[i]) == 0);
     validate_pending_queue(conn_impl, {{10, keys[0]}, {20, keys[1]}, {30, keys[2]}, {40, keys[3]}});
 
-    /* Pruning at the checkpoint timestamp frees the chosen key and everything older. */
+    /* A bound below every entry frees nothing. */
+    __ut_disagg_prune_pending_crypt_keys(session_impl, 5);
+    validate_pending_queue(conn_impl, {{10, keys[0]}, {20, keys[1]}, {30, keys[2]}, {40, keys[3]}});
+
+    /* A bound between entries frees the covered keys and retains the newer ones. */
     __ut_disagg_prune_pending_crypt_keys(session_impl, 25);
     validate_pending_queue(conn_impl, {{30, keys[2]}, {40, keys[3]}});
 
-    /* A bound below all remaining entries frees nothing. */
-    __ut_disagg_prune_pending_crypt_keys(session_impl, 5);
-    validate_pending_queue(conn_impl, {{30, keys[2]}, {40, keys[3]}});
+    /* A bound exactly at an entry frees that entry too. */
+    __ut_disagg_prune_pending_crypt_keys(session_impl, 30);
+    validate_pending_queue(conn_impl, {{40, keys[3]}});
 
-    /* A bound at or above every entry drains the queue. */
+    /* A bound at or above every remaining entry drains the queue. */
     __ut_disagg_prune_pending_crypt_keys(session_impl, 1000);
     validate_pending_queue(conn_impl, {});
 
@@ -574,30 +582,6 @@ TEST_CASE_METHOD(kp_fixture, "checkpoint selection edge cases", "[key_provider]"
     validate_chosen_key(__ut_disagg_select_pending_crypt_key(session_impl, 50), 50, edge_key);
 
     __wti_disagg_pending_crypt_key_clear(session_impl);
-    conn_impl->key_provider = nullptr;
-    F_CLR(conn_impl, WT_CONN_KEY_PROVIDER_PUSH);
-}
-
-TEST_CASE_METHOD(kp_fixture, "checkpoint prune edge cases", "[key_provider]")
-{
-    WT_CONNECTION *wt_conn = conn.get_wt_connection();
-    WT_CONNECTION_IMPL *conn_impl = conn.get_wt_connection_impl();
-    WT_SESSION_IMPL *session_impl = (WT_SESSION_IMPL *)session;
-    WT_KEY_PROVIDER stub = {};
-    REQUIRE(wt_conn->set_key_provider(wt_conn, &stub, "version=1") == 0);
-
-    /* Pruning an empty queue is a no-op. */
-    __ut_disagg_prune_pending_crypt_keys(session_impl, 100);
-    validate_pending_queue(conn_impl, {});
-
-    /* A bound below the entry retains it; a bound exactly at the entry frees it. */
-    const std::string edge_key = "edge-test-key";
-    REQUIRE(push_key(&stub, edge_key, 50) == 0);
-    __ut_disagg_prune_pending_crypt_keys(session_impl, 49);
-    validate_pending_queue(conn_impl, {{50, edge_key}});
-    __ut_disagg_prune_pending_crypt_keys(session_impl, 50);
-    validate_pending_queue(conn_impl, {});
-
     conn_impl->key_provider = nullptr;
     F_CLR(conn_impl, WT_CONN_KEY_PROVIDER_PUSH);
 }

--- a/test/catch2/ext/test_key_provider.cpp
+++ b/test/catch2/ext/test_key_provider.cpp
@@ -9,6 +9,8 @@
 #include <functional>
 #include <iostream>
 #include <memory>
+#include <utility>
+#include <vector>
 
 #include <catch2/catch.hpp>
 
@@ -138,7 +140,49 @@ struct kp_fixture {
 
         return (crypt);
     }
+
+    int
+    push_key(WT_KEY_PROVIDER *provider, const std::string &key_bytes, uint64_t timestamp)
+    {
+        WT_CRYPT_KEYS crypt = {};
+        crypt.keys.data = key_bytes.data();
+        crypt.keys.size = key_bytes.size();
+        crypt.timestamp = timestamp;
+        return (provider->set_key(provider, session, &crypt));
+    }
 };
+
+/*
+ * validate_chosen_key --
+ *     Assert the entry a checkpoint selected carries the expected timestamp and key bytes.
+ */
+static void
+validate_chosen_key(
+  WT_DISAGG_PENDING_CRYPT_KEY *entry, uint64_t timestamp, const std::string &key_bytes)
+{
+    REQUIRE(entry != nullptr);
+    REQUIRE(entry->timestamp == timestamp);
+    REQUIRE(entry->keys.size == key_bytes.size());
+    REQUIRE(memcmp(entry->keys.data, key_bytes.data(), key_bytes.size()) == 0);
+}
+
+/*
+ * validate_pending_queue --
+ *     Assert the pending queue holds exactly the expected (timestamp, key bytes) entries in order.
+ *     Used to confirm a checkpoint pruned the queue correctly.
+ */
+static void
+validate_pending_queue(
+  WT_CONNECTION_IMPL *conn_impl, const std::vector<std::pair<uint64_t, std::string>> &expected)
+{
+    WT_DISAGG_PENDING_CRYPT_KEY *entry =
+      TAILQ_FIRST(&conn_impl->disaggregated_storage.pending_crypt_key_qh);
+    for (const auto &expect : expected) {
+        validate_chosen_key(entry, expect.first, expect.second);
+        entry = TAILQ_NEXT(entry, q);
+    }
+    REQUIRE(entry == nullptr); /* No unexpected trailing entries. */
+}
 
 TEST_CASE_METHOD(kp_fixture, "Config", "[key_provider]")
 {
@@ -348,21 +392,6 @@ TEST_CASE_METHOD(kp_fixture, "set_key_provider version selects push mode", "[key
     F_CLR(conn_impl, WT_CONN_KEY_PROVIDER_PUSH);
 }
 
-/*
- * push_key --
- *     Build a WT_CRYPT_KEYS and invoke the provider's set_key, returning its error code so the
- *     caller can assert both success and failure paths.
- */
-static int
-push_key(WT_KEY_PROVIDER *kp, WT_SESSION *session, const std::string &key_bytes, uint64_t timestamp)
-{
-    WT_CRYPT_KEYS crypt = {};
-    crypt.keys.data = key_bytes.data();
-    crypt.keys.size = key_bytes.size();
-    crypt.timestamp = timestamp;
-    return kp->set_key(kp, session, &crypt);
-}
-
 TEST_CASE_METHOD(kp_fixture, "set_key stores the pushed key as the active key", "[key_provider]")
 {
     WT_CONNECTION *wt_conn = conn.get_wt_connection();
@@ -373,15 +402,8 @@ TEST_CASE_METHOD(kp_fixture, "set_key stores the pushed key as the active key", 
     REQUIRE(TAILQ_EMPTY(&conn_impl->disaggregated_storage.pending_crypt_key_qh));
 
     const std::string key_bytes = "push-mode-test-key-0123456789";
-    REQUIRE(push_key(&stub, session, key_bytes, 1) == 0);
-
-    WT_DISAGG_PENDING_CRYPT_KEY *entry =
-      TAILQ_FIRST(&conn_impl->disaggregated_storage.pending_crypt_key_qh);
-    REQUIRE(entry != nullptr);
-    REQUIRE(entry->timestamp == 1);
-    REQUIRE(entry->keys.size == key_bytes.size());
-    REQUIRE(memcmp(entry->keys.data, key_bytes.data(), key_bytes.size()) == 0);
-    REQUIRE(TAILQ_NEXT(entry, q) == nullptr);
+    REQUIRE(push_key(&stub, key_bytes, 1) == 0);
+    validate_pending_queue(conn_impl, {{1, key_bytes}});
 
     conn_impl->key_provider = nullptr;
     F_CLR(conn_impl, WT_CONN_KEY_PROVIDER_PUSH);
@@ -397,17 +419,9 @@ TEST_CASE_METHOD(kp_fixture, "set_key accumulates monotonic entries", "[key_prov
     const std::string keys[3] = {"key-one-0123456789", "key-two-9876543210", "key-three-55555"};
     const uint64_t timestamps[3] = {10, 20, 30};
     for (int i = 0; i < 3; i++)
-        REQUIRE(push_key(&stub, session, keys[i], timestamps[i]) == 0);
+        REQUIRE(push_key(&stub, keys[i], timestamps[i]) == 0);
 
-    int n = 0;
-    WT_DISAGG_PENDING_CRYPT_KEY *entry;
-    TAILQ_FOREACH (entry, &conn_impl->disaggregated_storage.pending_crypt_key_qh, q) {
-        REQUIRE(entry->timestamp == timestamps[n]);
-        REQUIRE(entry->keys.size == keys[n].size());
-        REQUIRE(memcmp(entry->keys.data, keys[n].data(), keys[n].size()) == 0);
-        n++;
-    }
-    REQUIRE(n == 3);
+    validate_pending_queue(conn_impl, {{10, keys[0]}, {20, keys[1]}, {30, keys[2]}});
 
     conn_impl->key_provider = nullptr;
     F_CLR(conn_impl, WT_CONN_KEY_PROVIDER_PUSH);
@@ -421,10 +435,10 @@ TEST_CASE_METHOD(kp_fixture, "set_key rejects non-monotonic timestamp", "[key_pr
     REQUIRE(wt_conn->set_key_provider(wt_conn, &stub, "version=1") == 0);
 
     const std::string key_bytes = "push-mode-key-monotonic";
-    REQUIRE(push_key(&stub, session, key_bytes, 10) == 0);
-    REQUIRE(push_key(&stub, session, key_bytes, 10) == EINVAL); /* Equal rejected. */
-    REQUIRE(push_key(&stub, session, key_bytes, 5) == EINVAL);  /* Smaller rejected. */
-    REQUIRE(push_key(&stub, session, key_bytes, 11) == 0);      /* Larger accepted. */
+    REQUIRE(push_key(&stub, key_bytes, 10) == 0);
+    REQUIRE(push_key(&stub, key_bytes, 10) == EINVAL); /* Equal rejected. */
+    REQUIRE(push_key(&stub, key_bytes, 5) == EINVAL);  /* Smaller rejected. */
+    REQUIRE(push_key(&stub, key_bytes, 11) == 0);      /* Larger accepted. */
 
     /* Only the two successful pushes are queued. */
     int n = 0;
@@ -447,9 +461,9 @@ TEST_CASE_METHOD(kp_fixture, "set_key rejects timestamp <= stable", "[key_provid
     REQUIRE(wt_conn->set_timestamp(wt_conn, "stable_timestamp=14") == 0); /* 0x14 == 20. */
 
     const std::string key_bytes = "push-mode-stable-check";
-    REQUIRE(push_key(&stub, session, key_bytes, 20) == EINVAL); /* Equal to stable. */
-    REQUIRE(push_key(&stub, session, key_bytes, 10) == EINVAL); /* Below stable. */
-    REQUIRE(push_key(&stub, session, key_bytes, 30) == 0);      /* Strictly above stable. */
+    REQUIRE(push_key(&stub, key_bytes, 20) == EINVAL); /* Equal to stable. */
+    REQUIRE(push_key(&stub, key_bytes, 10) == EINVAL); /* Below stable. */
+    REQUIRE(push_key(&stub, key_bytes, 30) == 0);      /* Strictly above stable. */
 
     conn_impl->key_provider = nullptr;
     F_CLR(conn_impl, WT_CONN_KEY_PROVIDER_PUSH);
@@ -467,6 +481,127 @@ TEST_CASE_METHOD(kp_fixture, "set_key rejects empty input", "[key_provider]")
     crypt.keys.size = 0;
     crypt.timestamp = 1;
     REQUIRE(stub.set_key(&stub, session, &crypt) == EINVAL);
+
+    conn_impl->key_provider = nullptr;
+    F_CLR(conn_impl, WT_CONN_KEY_PROVIDER_PUSH);
+}
+
+TEST_CASE_METHOD(
+  kp_fixture, "checkpoint selection picks highest timestamp at or below ckpt ts", "[key_provider]")
+{
+    WT_CONNECTION *wt_conn = conn.get_wt_connection();
+    WT_CONNECTION_IMPL *conn_impl = conn.get_wt_connection_impl();
+    WT_SESSION_IMPL *session_impl = (WT_SESSION_IMPL *)session;
+    WT_KEY_PROVIDER stub = {};
+    REQUIRE(wt_conn->set_key_provider(wt_conn, &stub, "version=1") == 0);
+
+    /* Each pushed key has distinct bytes so the chosen entry's key can be validated. */
+    const std::string keys[4] = {
+      "selection-key-ten", "selection-key-twenty", "selection-key-thirty", "selection-key-forty"};
+    const uint64_t timestamps[4] = {10, 20, 30, 40};
+    for (int i = 0; i < 4; i++)
+        REQUIRE(push_key(&stub, keys[i], timestamps[i]) == 0);
+
+    /* The checkpoint timestamp straddles the queue; pick the highest entry not exceeding it. */
+    WT_DISAGG_PENDING_CRYPT_KEY *chosen = __ut_disagg_select_pending_crypt_key(session_impl, 25);
+    validate_chosen_key(chosen, 20, keys[1]);
+
+    /* An exact match on a queued timestamp is selected. */
+    chosen = __ut_disagg_select_pending_crypt_key(session_impl, 30);
+    validate_chosen_key(chosen, 30, keys[2]);
+
+    /* A checkpoint timestamp beyond the queue selects the newest entry. */
+    chosen = __ut_disagg_select_pending_crypt_key(session_impl, 100);
+    validate_chosen_key(chosen, 40, keys[3]);
+
+    /* No entry qualifies when the checkpoint timestamp precedes the whole queue. */
+    chosen = __ut_disagg_select_pending_crypt_key(session_impl, 5);
+    REQUIRE(chosen == nullptr);
+
+    __wti_disagg_pending_crypt_key_clear(session_impl);
+    conn_impl->key_provider = nullptr;
+    F_CLR(conn_impl, WT_CONN_KEY_PROVIDER_PUSH);
+}
+
+TEST_CASE_METHOD(
+  kp_fixture, "checkpoint prune frees covered keys and retains newer ones", "[key_provider]")
+{
+    WT_CONNECTION *wt_conn = conn.get_wt_connection();
+    WT_CONNECTION_IMPL *conn_impl = conn.get_wt_connection_impl();
+    WT_SESSION_IMPL *session_impl = (WT_SESSION_IMPL *)session;
+    WT_KEY_PROVIDER stub = {};
+    REQUIRE(wt_conn->set_key_provider(wt_conn, &stub, "version=1") == 0);
+
+    /* Distinct key bytes per entry so the surviving entries' keys can be validated. */
+    const std::string keys[4] = {
+      "prune-key-ten", "prune-key-twenty", "prune-key-thirty", "prune-key-forty"};
+    const uint64_t timestamps[4] = {10, 20, 30, 40};
+    for (int i = 0; i < 4; i++)
+        REQUIRE(push_key(&stub, keys[i], timestamps[i]) == 0);
+    validate_pending_queue(conn_impl, {{10, keys[0]}, {20, keys[1]}, {30, keys[2]}, {40, keys[3]}});
+
+    /* Pruning at the checkpoint timestamp frees the chosen key and everything older. */
+    __ut_disagg_prune_pending_crypt_keys(session_impl, 25);
+    validate_pending_queue(conn_impl, {{30, keys[2]}, {40, keys[3]}});
+
+    /* A bound below all remaining entries frees nothing. */
+    __ut_disagg_prune_pending_crypt_keys(session_impl, 5);
+    validate_pending_queue(conn_impl, {{30, keys[2]}, {40, keys[3]}});
+
+    /* A bound at or above every entry drains the queue. */
+    __ut_disagg_prune_pending_crypt_keys(session_impl, 1000);
+    validate_pending_queue(conn_impl, {});
+
+    conn_impl->key_provider = nullptr;
+    F_CLR(conn_impl, WT_CONN_KEY_PROVIDER_PUSH);
+}
+
+TEST_CASE_METHOD(kp_fixture, "checkpoint selection and prune edge cases", "[key_provider]")
+{
+    WT_CONNECTION *wt_conn = conn.get_wt_connection();
+    WT_CONNECTION_IMPL *conn_impl = conn.get_wt_connection_impl();
+    WT_SESSION_IMPL *session_impl = (WT_SESSION_IMPL *)session;
+    WT_KEY_PROVIDER stub = {};
+    REQUIRE(wt_conn->set_key_provider(wt_conn, &stub, "version=1") == 0);
+
+    /* An empty queue selects nothing, and pruning it is a no-op. */
+    REQUIRE(__ut_disagg_select_pending_crypt_key(session_impl, 100) == nullptr);
+    __ut_disagg_prune_pending_crypt_keys(session_impl, 100);
+    validate_pending_queue(conn_impl, {});
+
+    /* A single entry is selected only once the checkpoint timestamp reaches it. */
+    const std::string edge_key = "edge-test-key";
+    REQUIRE(push_key(&stub, edge_key, 50) == 0);
+    REQUIRE(__ut_disagg_select_pending_crypt_key(session_impl, 49) == nullptr);
+    validate_chosen_key(__ut_disagg_select_pending_crypt_key(session_impl, 50), 50, edge_key);
+
+    /* A bound below the entry retains it; a bound exactly at the entry frees it. */
+    __ut_disagg_prune_pending_crypt_keys(session_impl, 49);
+    validate_pending_queue(conn_impl, {{50, edge_key}});
+    __ut_disagg_prune_pending_crypt_keys(session_impl, 50);
+    validate_pending_queue(conn_impl, {});
+
+    conn_impl->key_provider = nullptr;
+    F_CLR(conn_impl, WT_CONN_KEY_PROVIDER_PUSH);
+}
+
+TEST_CASE_METHOD(kp_fixture, "pending key clear drains the whole queue", "[key_provider]")
+{
+    WT_CONNECTION *wt_conn = conn.get_wt_connection();
+    WT_CONNECTION_IMPL *conn_impl = conn.get_wt_connection_impl();
+    WT_SESSION_IMPL *session_impl = (WT_SESSION_IMPL *)session;
+    WT_KEY_PROVIDER stub = {};
+    REQUIRE(wt_conn->set_key_provider(wt_conn, &stub, "version=1") == 0);
+
+    const std::string keys[3] = {"clear-key-ten", "clear-key-twenty", "clear-key-thirty"};
+    const uint64_t timestamps[3] = {10, 20, 30};
+    for (int i = 0; i < 3; i++)
+        REQUIRE(push_key(&stub, keys[i], timestamps[i]) == 0);
+    validate_pending_queue(conn_impl, {{10, keys[0]}, {20, keys[1]}, {30, keys[2]}});
+
+    /* Clearing drains every queued key regardless of timestamp. */
+    __wti_disagg_pending_crypt_key_clear(session_impl);
+    validate_pending_queue(conn_impl, {});
 
     conn_impl->key_provider = nullptr;
     F_CLR(conn_impl, WT_CONN_KEY_PROVIDER_PUSH);

--- a/test/suite/test_key_provider_disagg03.py
+++ b/test/suite/test_key_provider_disagg03.py
@@ -93,6 +93,9 @@ class test_key_provider_disagg03(wttest.WiredTigerTestCase):
 
         ds = SimpleDataSet(self, self.uri, 10)
         ds.populate()
+        # A pushed key is only persisted once the stable timestamp reaches it. Advance stable so the
+        # checkpoint selects the earliest pushed key.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(1))
         self.session.checkpoint()
 
         self.assertGreaterEqual(self.key_provider_page_count(), 1)

--- a/test/suite/test_key_provider_disagg04.py
+++ b/test/suite/test_key_provider_disagg04.py
@@ -75,8 +75,7 @@ class test_key_provider_disagg04(wttest.WiredTigerTestCase):
 
         ds1 = SimpleDataSet(self, self.uri, self.nentries)
         ds1.populate()
-        # In push mode the first checkpoint must persist a key, so advance stable to cover the
-        # pushed key. Later parts already have a persisted page to reference after a restart.
+        # Advance stable so the first checkpoint persists a key.
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(1))
         self.session.checkpoint()
         ds1.check()

--- a/test/suite/test_key_provider_disagg04.py
+++ b/test/suite/test_key_provider_disagg04.py
@@ -75,6 +75,9 @@ class test_key_provider_disagg04(wttest.WiredTigerTestCase):
 
         ds1 = SimpleDataSet(self, self.uri, self.nentries)
         ds1.populate()
+        # In push mode the first checkpoint must persist a key, so advance stable to cover the
+        # pushed key. Later parts already have a persisted page to reference after a restart.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(1))
         self.session.checkpoint()
         ds1.check()
 

--- a/test/suite/test_key_provider_disagg05.py
+++ b/test/suite/test_key_provider_disagg05.py
@@ -94,9 +94,8 @@ class test_key_provider_disagg05(wttest.WiredTigerTestCase):
             previous_ts = timestamp
 
     def test_multiple_pushes_across_checkpoints(self):
-        # A checkpoint persists the pushed key whose timestamp the stable timestamp has reached.
-        # The test key provider stamps each pushed key with a per-checkpoint counter, so advancing
-        # stable by one before each checkpoint lets a new key become durable every time.
+        # Each checkpoint pushes a fresh key onto the pending list and drains it, persisting one
+        # new key-provider page.
         if self.ds_name != "palite":
             self.skipTest("Must use PALite to verify contents")
 

--- a/test/suite/test_key_provider_disagg05.py
+++ b/test/suite/test_key_provider_disagg05.py
@@ -94,8 +94,9 @@ class test_key_provider_disagg05(wttest.WiredTigerTestCase):
             previous_ts = timestamp
 
     def test_multiple_pushes_across_checkpoints(self):
-        # Each checkpoint pushes a fresh key onto the pending list and drains it, persisting one
-        # new key-provider page.
+        # A checkpoint persists the pushed key whose timestamp the stable timestamp has reached.
+        # The test key provider stamps each pushed key with a per-checkpoint counter, so advancing
+        # stable by one before each checkpoint lets a new key become durable every time.
         if self.ds_name != "palite":
             self.skipTest("Must use PALite to verify contents")
 
@@ -103,14 +104,19 @@ class test_key_provider_disagg05(wttest.WiredTigerTestCase):
         ds.populate()
 
         # The first checkpoint creates the page table; record the baseline page count.
+        stable = 1
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(stable))
         self.session.checkpoint()
         baseline = len(self.key_provider_pages())
         self.assertGreaterEqual(baseline, 1)
 
-        # Write and checkpoint a few more times; each checkpoint persists another page.
+        # Write and checkpoint a few more times; each checkpoint persists another page with a
+        # strictly higher timestamp and LSN.
         cursor = self.session.open_cursor(self.uri)
         for i in range(4):
             cursor[ds.key(100 + i)] = ds.value(100 + i)
+            stable += 1
+            self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(stable))
             self.session.checkpoint()
         cursor.close()
 

--- a/test/suite/test_key_provider_disagg05.py
+++ b/test/suite/test_key_provider_disagg05.py
@@ -109,8 +109,7 @@ class test_key_provider_disagg05(wttest.WiredTigerTestCase):
         baseline = len(self.key_provider_pages())
         self.assertGreaterEqual(baseline, 1)
 
-        # Write and checkpoint a few more times; each checkpoint persists another page with a
-        # strictly higher timestamp and LSN.
+        # Write and checkpoint a few more times; each checkpoint persists another page.
         cursor = self.session.open_cursor(self.uri)
         for i in range(4):
             cursor[ds.key(100 + i)] = ds.value(100 + i)


### PR DESCRIPTION
The changes in this PR builds on the KEK push model. This is the final change where we read the existing pending list and pick the correct CRYPT key that the highest timestamp at or equal to the checkpoint timestamp and writes it as a v2 KEK page.

Keys newer than the checkpoint are kept for a later checkpoint. Older keys are pruned, when writing a checkpoint (on primary) and when a follower picks up a new checkpoint. 

Catch2 unit tests cover the selection and pruning. Extensive testing coverage will be written once infrastructure is place following [WT-17538](https://jira.mongodb.org/browse/WT-17538).