### PR TITLE
WT-17787 Add retry logic for table verification on EBUSY errors

### DIFF
--- a/test/format/verify.c
+++ b/test/format/verify.c
@@ -39,13 +39,21 @@ table_verify(TABLE *table, void *arg)
     WT_CONNECTION *conn;
     WT_DECL_RET;
     WT_SESSION *session;
+    u_int retries;
 
     conn = (WT_CONNECTION *)arg;
     testutil_assert(table != NULL);
 
     memset(&sap, 0, sizeof(sap));
     wt_wrap_open_session(conn, &sap, table->track_prefix, session_prefetch_cfg(), &session);
-    ret = session->verify(session, table->uri, "strict");
+
+    /* Verify can race with special-handle transitions, retry briefly on EBUSY. */
+    for (retries = 0; (ret = session->verify(session, table->uri, "strict")) == EBUSY; ++retries) {
+        if (retries >= WT_MINUTE)
+            break;
+        sleep(1); /* Sleep for 1 second before retrying */
+    }
+
     /*
      * On followers, verify returns ENOENT if the stable constituent is missing. Before the first
      * checkpoint is picked up or if the table has not been created locally, this is expected
@@ -55,7 +63,7 @@ table_verify(TABLE *table, void *arg)
       ret == 0 || ret == EBUSY || (g.disagg_storage_config && !g.disagg_leader && ret == ENOENT));
 
     if (ret == EBUSY)
-        WARN("table.%u skipped verify because of EBUSY", table->id);
+        WARN("table.%u skipped verify because of EBUSY after %u retries", table->id, retries);
     wt_wrap_close_session(session);
 }
 


### PR DESCRIPTION
- Retry table verification when `session->verify()` returns `EBUSY`.