### PR TITLE
WT-17793 Increase running frequency for cppsuite-stress-test and workgen-test Evergreen tasks

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -6906,7 +6906,7 @@ buildvariants:
     - name: ".data-validation-stress-test"
     - name: bench-tiered-push-pull
     - name: ".workgen-test"
-      batchtime: 1440 # 24 hours
+      batchtime: 120 # every 2 hours
     - name: model-unit-test
     - name: model-test-long
       batchtime: 1440 # once a day
@@ -7105,7 +7105,7 @@ buildvariants:
     - name: schema-abort-predictable-test
     - name: checkpoint-filetypes-predictable-test
     - name: ".cppsuite-stress-test"
-      batchtime: 720 # twice a day
+      batchtime: 120 # every 2 hours
       distros: ubuntu2004-medium
 
 - name: ubuntu2004-stress-tests-arm64


### PR DESCRIPTION
## Summary

- Reduces `batchtime` for `.cppsuite-stress-test` on `ubuntu2004-stress-tests`: `720` → `120` (every 2 hours)
- Reduces `batchtime` for `.workgen-test` on `ubuntu2004`: `1440` → `120` (every 2 hours)

These changes are needed to meet the 75% task scheduling threshold required for stable commit selection as part of WTBUILD-344.

Current coverage before this change:
- `ubuntu2004-stress-tests` `.cppsuite-stress-test`: 27/37 = 72.97% (below threshold)
- `ubuntu2004` `.workgen-test`: 102/130 = 78.5% (narrow margin)

`model-test-long*` and `csuite-long-running` remain at `batchtime:1440`.

## Test plan

- [ ] Verify Evergreen scheduling picks up the new batchtime values after merge
- [ ] Confirm `ubuntu2004-stress-tests` `.cppsuite-stress-test` coverage rises above 75%