### PR TITLE
WT-17767 Fix memory leak on panicked or failed connection close

### DIFF
--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -454,8 +454,13 @@ __wt_conn_dhandle_close(WT_SESSION_IMPL *session, bool final, bool mark_dead, bo
         bm = btree->bm;
         if (bm != NULL)
             is_mapped = bm->is_mapped(bm, session);
-        if (!discard && mark_dead && (bm == NULL || !is_mapped))
-            marked_dead = true;
+        if (!discard && mark_dead && (bm == NULL || !is_mapped)) {
+            /* On the final close, discard pages now because no later sweep will run. */
+            if (final)
+                discard = true;
+            else
+                marked_dead = true;
+        }
 
         /*
          * Flush dirty data from any durable trees we couldn't mark dead. That involves writing a

--- a/test/suite/fail_lists/asan.fail
+++ b/test/suite/fail_lists/asan.fail
@@ -2,11 +2,6 @@
 # List test files that are not run because they are known failures.
 # They are suppressed because they produce too many warnings that should be solved separately.
 
-# FIXME-WT-17767: in-memory page leaks on panicked or failed connection close
-test_corrupt01.py
-test_salvage03.py
-test_txn18.py
-
 # FIXME-WT-17765: memory leaks in dir_store storage source
 test_tiered06.py
 


### PR DESCRIPTION
test_corrupt01, test_salvage03, and test_txn18 are suppressed in test/suite/fail_lists/asan.fail because they trigger LeakSanitizer errors under the ASan build. All three tests exercise failure paths where a connection open or close is expected to fail.

The leak is the same in all three cases: when a connection enters a panic state or fails mid-recovery, __wt_conn_dhandle_close marks open handles as dead and defers eviction of their in-memory pages to the sweep server. The sweep server, however, is already stopped by the time the final handle discard loop runs. The deferred eviction never happens, and the pages remain allocated until process exit.