### PR TITLE
WT-17538 Expose key-provider set_key to python tests

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1526,6 +1526,7 @@ proc
 progname
 programmatically
 prout
+providerp
 proxied
 prunable
 ps

--- a/ext/test/key_provider/key_provider.c
+++ b/ext/test/key_provider/key_provider.c
@@ -142,8 +142,9 @@ kp_set_key(KEY_PROVIDER *kp, const WT_CRYPT_KEYS *crypt)
         lsn = DEFAULT_KEY.r.lsn;
     }
 
-    /* Verify that the key data matches the expected key data */
-    assert(memcmp(key_data, DEFAULT_KEY_DATA, sizeof(DEFAULT_KEY_DATA) - 1) == 0);
+    /* Pull mode generates keys with the default prefix. */
+    if (kp->version == 0)
+        assert(memcmp(key_data, DEFAULT_KEY_DATA, sizeof(DEFAULT_KEY_DATA) - 1) == 0);
 
     kp_free_key(kp);
 
@@ -158,37 +159,6 @@ kp_set_key(KEY_PROVIDER *kp, const WT_CRYPT_KEYS *crypt)
     kp->state.key_time = kp_timestamp();
     kp->state.key_state = KEY_STATE_CURRENT;
     return (0);
-}
-
-/*
- * kp_push_active_key --
- *     Push the module's current key into WiredTiger via set_key.
- */
-static int
-kp_push_active_key(WT_KEY_PROVIDER *wtkp, WT_SESSION *session)
-{
-    KEY_PROVIDER *kp = (KEY_PROVIDER *)wtkp;
-    WT_CRYPT_KEYS local_crypt = {{0}, {0}, 0};
-    int ret;
-
-    if (wtkp->set_key == NULL) {
-        LOG_ERROR(kp, session, "%s", "set_key callback not installed in push mode");
-        return (EINVAL);
-    }
-
-    local_crypt.keys.data = kp->state.key_data;
-    local_crypt.keys.size = kp->state.key_size;
-    local_crypt.r.lsn = kp->state.lsn;
-    /*
-     * This runs once per checkpoint, so the counter advances the pushed timestamp by one each time.
-     * FIXME-WT-17539: Temporary until set_key is exposed to Python so tests drive the timestamp.
-     */
-    local_crypt.timestamp = kp->next_push_ts++;
-
-    if ((ret = wtkp->set_key(wtkp, session, &local_crypt)) != 0)
-        LOG_ERROR(kp, session, "Failed to push loaded key: %d", ret);
-
-    return (ret);
 }
 
 /*
@@ -208,14 +178,12 @@ kp_load_key(WT_KEY_PROVIDER *wtkp, WT_SESSION *session, const WT_CRYPT_KEYS *cry
 
     assert(kp->state.key_state == KEY_STATE_CURRENT);
     kp_set_key(kp, crypt);
+    if (kp->version == 1)
+        kp->state.timestamp = crypt->timestamp;
 
     /* Reset expiration if a valid key was loaded. */
     if (crypt->keys.data != NULL)
         KEY_RESET_EXPIRE(kp);
-
-    /* Push mode: initialize the WT-side active key during start up. */
-    if (kp->version == 1)
-        return (kp_push_active_key(wtkp, session));
 
     return (0);
 }
@@ -388,11 +356,20 @@ kp_on_key_update(WT_KEY_PROVIDER *wtkp, WT_SESSION *session, const WT_CRYPT_KEYS
 
         /* Update our internal state */
         assert(crypt->r.lsn != 0);
-        kp->state.lsn = crypt->r.lsn;
 
-        assert(memcmp(kp->state.key_data, crypt->keys.data, kp->state.key_size) == 0);
-        assert(kp->state.key_size == crypt->keys.size);
-        kp->state.key_state = KEY_STATE_CURRENT;
+        if (kp->version == 1) {
+            /* The persisted timestamp and LSN must strictly advance. */
+            assert(crypt->timestamp != 0 && crypt->timestamp > kp->state.timestamp);
+            assert(crypt->r.lsn > kp->state.lsn);
+
+            kp_set_key(kp, crypt);
+            kp->state.timestamp = crypt->timestamp;
+        } else {
+            kp->state.lsn = crypt->r.lsn;
+            assert(memcmp(kp->state.key_data, crypt->keys.data, kp->state.key_size) == 0);
+            assert(kp->state.key_size == crypt->keys.size);
+            kp->state.key_state = KEY_STATE_CURRENT;
+        }
     }
 
     return (0);
@@ -505,7 +482,6 @@ key_provider_extension_init(WT_CONNECTION *conn, WT_CONFIG_ARG *config)
     kp->wtext = wtext;
     kp->verbose = WT_VERBOSE_INFO; /* Default verbosity level */
     kp->key_expires = 43200;       /* Default: 12 hours = 43200 seconds */
-    kp->next_push_ts = 1;          /* set_key rejects timestamp 0. */
 
     int ret = 0;
     WT_KEY_PROVIDER *wtkp = (WT_KEY_PROVIDER *)kp;

--- a/ext/test/key_provider/key_provider.h
+++ b/ext/test/key_provider/key_provider.h
@@ -39,6 +39,7 @@ extern "C" {
  * encryption key management functionality for testing purposes.
  *
  * Configuration parameters:
+ * - version: provider mode, 0 (pull) or 1 (push).
  * - verbose: verbosity level for logging (default: WT_VERBOSE_INFO)
  * - key_expires: key expiration period, in seconds (default: 12 hours = 43200 seconds).
  *     On creation, initial key is set.
@@ -60,6 +61,9 @@ extern "C" {
  * - READ -> CURRENT: on_key_update called, key marked as current
  * irrespective of key expiration:
  * - CURRENT -> CURRENT: key_load called, key loaded from persisted data
+ *
+ * In push mode (version 1) the module hands keys to WiredTiger via set_key and on_key_update simply
+ * adopts the confirmed key; the state machine and key_expires above are not used.
  */
 
 typedef enum { KEY_STATE_CURRENT = 0, KEY_STATE_PENDING, KEY_STATE_READ } KEY_STATE;
@@ -76,12 +80,10 @@ typedef struct {
     int verbose;     /* Verbosity level for logging. See WT_VERBOSE_LEVEL . */
     int key_expires; /* Key expiration time in seconds, or special values as described above */
 
-    /* Monotonic counter used to stamp pushed keys. */
-    uint64_t next_push_ts;
-
     /* Simulated key state */
     struct {
         uint64_t lsn;
+        uint64_t timestamp;
         KEY_STATE key_state;
         uint64_t key_time;
         size_t key_size;

--- a/lang/python/wiredtiger.i
+++ b/lang/python/wiredtiger.i
@@ -96,6 +96,9 @@ from packing import pack, unpack
 %typemap(in, numinputs=0) WT_PAGE_LOG_HANDLE ** (WT_PAGE_LOG_HANDLE *temp = NULL) {
     $1 = &temp;
  }
+%typemap(in, numinputs=0) WT_KEY_PROVIDER ** (WT_KEY_PROVIDER *temp = NULL) {
+    $1 = &temp;
+ }
 %typemap(in, numinputs=0) WT_STORAGE_SOURCE ** (WT_STORAGE_SOURCE *temp = NULL) {
     $1 = &temp;
  }
@@ -318,6 +321,10 @@ from packing import pack, unpack
     $result = SWIG_NewPointerObj(SWIG_as_voidptr(*$1), SWIGTYPE_p___wt_page_log, 0);
 }
 
+%typemap(argout) WT_KEY_PROVIDER ** {
+    $result = SWIG_NewPointerObj(SWIG_as_voidptr(*$1), SWIGTYPE_p___wt_key_provider, 0);
+}
+
 %typemap(argout) WT_PAGE_LOG_HANDLE ** {
     $result = SWIG_NewPointerObj(SWIG_as_voidptr(*$1), SWIGTYPE_p___wt_page_log_handle, 0);
 }
@@ -533,6 +540,8 @@ static int pageLogCompleteCheckpointArgsClearMetadata(
     WT_PAGE_LOG_COMPLETE_CHECKPOINT_ARGS *args);
 static int pageLogCompleteCheckpointArgsSetMetadata(
     WT_PAGE_LOG_COMPLETE_CHECKPOINT_ARGS *args, const WT_ITEM *value);
+static int cryptKeysClearKeys(WT_CRYPT_KEYS *crypt);
+static int cryptKeysSetKeys(WT_CRYPT_KEYS *crypt, const WT_ITEM *value);
 
 #define WT_GETATTR(var, parent, name)					\
     do if ((var = PyObject_GetAttrString(parent, name)) == NULL) {	\
@@ -649,6 +658,7 @@ SELFHELPER(struct __wt_file_handle, file_handle)
 SELFHELPER(struct __wt_file_system, file_system)
 SELFHELPER(struct __wt_page_log, page_log)
 SELFHELPER(struct __wt_page_log_handle, page_log_handle)
+SELFHELPER(struct __wt_key_provider, key_provider)
 SELFHELPER(struct __wt_storage_source, storage_source)
 
  /*
@@ -726,6 +736,8 @@ ANY_OK(__wt_page_log_put_args::__wt_page_log_put_args)
 ANY_OK(__wt_page_log_put_args::~__wt_page_log_put_args)
 ANY_OK(__wt_page_log_get_args::__wt_page_log_get_args)
 ANY_OK(__wt_page_log_get_args::~__wt_page_log_get_args)
+ANY_OK(__wt_crypt_keys::__wt_crypt_keys)
+ANY_OK(__wt_crypt_keys::~__wt_crypt_keys)
 
 COMPARE_OK(__wt_cursor::_compare)
 COMPARE_OK(__wt_cursor::_equals)
@@ -1240,6 +1252,10 @@ SIDESTEP_METHOD(__wt_page_log, terminate,
   (WT_SESSION *session),
   (self, session))
 
+SIDESTEP_METHOD(__wt_key_provider, set_key,
+  (WT_SESSION *session, const WT_CRYPT_KEYS *crypt),
+  (self, session, crypt))
+
 SIDESTEP_METHOD(__wt_page_log_handle, plh_put,
   (WT_SESSION *session, int page_id, int checkpoint_id, WT_PAGE_LOG_PUT_ARGS *put_args, const WT_ITEM *buf),
   (self, session, page_id, checkpoint_id, put_args, buf))
@@ -1434,6 +1450,16 @@ int standalone_build();
 %ignore __wt_item;
 %ignore __wt_lsn;
 
+%ignore __wt_key_provider::load_key;
+%ignore __wt_key_provider::get_key;
+%ignore __wt_key_provider::on_key_update;
+%ignore __wt_key_provider::terminate;
+
+%ignore __wt_crypt_keys::keys;
+
+%ignore __wt_crypt_keys_r;
+%ignore __wt_crypt_keys::r;
+
 %ignore __wt_connection::add_collator;
 %ignore __wt_connection::add_compressor;
 %ignore __wt_connection::add_data_source;
@@ -1462,6 +1488,8 @@ OVERRIDE_METHOD(__wt_session, WT_SESSION, log_printf, (self, msg))
 %rename(Session) __wt_session;
 %rename(Connection) __wt_connection;
 %rename(FileHandle) __wt_file_handle;
+%rename(KeyProvider) __wt_key_provider;
+%rename(CryptKeys) __wt_crypt_keys;
 %rename(PageLog) __wt_page_log;
 %rename(PageLogCompleteCheckpointArgs) __wt_page_log_complete_checkpoint_args;
 %rename(PageLogDiscardArgs) __wt_page_log_discard_args;
@@ -1472,6 +1500,22 @@ OVERRIDE_METHOD(__wt_session, WT_SESSION, log_printf, (self, msg))
 %rename(FileSystem) __wt_file_system;
 
 %include "wiredtiger.h"
+
+%extend __wt_crypt_keys {
+    __wt_crypt_keys() {
+        return (struct __wt_crypt_keys *)calloc(1, sizeof(struct __wt_crypt_keys));
+    }
+    int _set_keys(const WT_ITEM *value) {
+        return (cryptKeysSetKeys($self, value));
+    }
+    int _clear_keys() {
+        return (cryptKeysClearKeys($self));
+    }
+    ~__wt_crypt_keys() {
+        (void)cryptKeysClearKeys($self);
+        free($self);
+    }
+}
 
 %extend __wt_page_log_complete_checkpoint_args {
     __wt_page_log_complete_checkpoint_args() {
@@ -1685,6 +1729,28 @@ err:
         __wt_buf_free(NULL, metadata);
         __wt_free(NULL, metadata);
     }
+    return (ret);
+}
+
+static int
+cryptKeysClearKeys(WT_CRYPT_KEYS *crypt)
+{
+    if (crypt == NULL)
+        return (0);
+    __wt_buf_free(NULL, &crypt->keys);
+    return (0);
+}
+
+static int
+cryptKeysSetKeys(WT_CRYPT_KEYS *crypt, const WT_ITEM *value)
+{
+    WT_DECL_RET;
+
+    WT_ERR(cryptKeysClearKeys(crypt));
+    if (value != NULL && value->size != 0)
+        WT_ERR(__wt_buf_set(NULL, &crypt->keys, value->data, value->size));
+
+err:
     return (ret);
 }
 
@@ -1905,4 +1971,22 @@ PageLogCompleteCheckpointArgs.checkpoint_metadata = property(
 
 del _page_log_complete_checkpoint_args_get_metadata
 del _page_log_complete_checkpoint_args_set_metadata
+
+def _crypt_keys_get_keys(self):
+    return getattr(self, '_keys_python_value', None)
+
+def _crypt_keys_set_keys(self, value):
+    if value is None:
+        self._clear_keys()
+        self._keys_python_value = None
+        return
+    ret = self._set_keys(value)
+    if ret != 0:
+        raise WiredTigerError(wiredtiger_strerror(ret))
+    self._keys_python_value = value
+
+CryptKeys.keys = property(_crypt_keys_get_keys, _crypt_keys_set_keys)
+
+del _crypt_keys_get_keys
+del _crypt_keys_set_keys
 %}

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -2952,6 +2952,22 @@ err:
 }
 
 /*
+ * __conn_get_key_provider --
+ *     WT_CONNECTION->get_key_provider method.
+ */
+static int
+__conn_get_key_provider(WT_CONNECTION *wt_conn, WT_KEY_PROVIDER **key_providerp)
+{
+    WT_CONNECTION_IMPL *conn = (WT_CONNECTION_IMPL *)wt_conn;
+
+    *key_providerp = conn->key_provider;
+    if (*key_providerp == NULL)
+        WT_RET_MSG(conn->default_session, EINVAL, "no key provider configured");
+
+    return (0);
+}
+
+/*
  * __conn_set_file_system --
  *     Configure a custom file system implementation on database open.
  */
@@ -3257,7 +3273,8 @@ wiredtiger_open(const char *home, WT_EVENT_HANDLER *event_handler, const char *c
       __conn_load_extension, __conn_add_data_source, __conn_add_collator, __conn_add_compressor,
       __conn_add_encryptor, __conn_set_file_system, __conn_add_page_log, __conn_add_storage_source,
       __conn_get_page_log, __conn_get_storage_source, __conn_set_context_uint,
-      __conn_dump_error_log, __conn_set_key_provider, __conn_get_extension_api};
+      __conn_dump_error_log, __conn_set_key_provider, __conn_get_key_provider,
+      __conn_get_extension_api};
     static const WT_NAME_FLAG file_types[] = {
       {"data", WT_FILE_TYPE_DATA}, {"log", WT_FILE_TYPE_LOG}, {NULL, 0}};
 

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -3022,6 +3022,16 @@ struct __wt_connection {
      */
     int __F(set_key_provider)(
         WT_CONNECTION *connection, WT_KEY_PROVIDER *km, const char *config);
+
+    /*!
+     * Return the key provider registered with WT_CONNECTION::set_key_provider, or \c EINVAL if
+     * none has been configured.
+     *
+     * @param connection the connection handle
+     * @param key_providerp the returned key provider structure
+     * @errors
+     */
+    int __F(get_key_provider)(WT_CONNECTION *connection, WT_KEY_PROVIDER **key_providerp);
 #endif
 
     /*!
@@ -5754,7 +5764,6 @@ struct __wt_page_log {
     int (*terminate)(WT_PAGE_LOG *page_log, WT_SESSION *session);
 };
 
-#ifndef SWIG
 /*!
  * A structure that represents encrypted keys stored by WiredTiger.
  */
@@ -5857,7 +5866,6 @@ struct __wt_key_provider {
      */
     int (*terminate)(WT_KEY_PROVIDER *key_provider, WT_SESSION *session);
 };
-#endif
 
 /*!
  * Btree disaggregated storage tier types

--- a/test/suite/test_key_provider_disagg03.py
+++ b/test/suite/test_key_provider_disagg03.py
@@ -26,7 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 import re, os, subprocess, json
-import wttest
+import wiredtiger, wttest
 from run import wt_builddir
 from helper_disagg import DisaggConfigMixin, disagg_test_class, gen_disagg_storages, get_shard_id
 from wtdataset import SimpleDataSet
@@ -37,12 +37,15 @@ from wtscenario import make_scenarios
 #    to the turtle key-provider page after a checkpoint.
 @disagg_test_class
 class test_key_provider_disagg03(wttest.WiredTigerTestCase):
-    conn_base_config = ',create,statistics=(all),statistics_log=(wait=1,json=true,on_close=true),'
+    conn_base_config = ',create,statistics=(all),'
     def conn_config(self):
         return self.extensionsConfig() + self.conn_base_config + 'disaggregated=(role="leader")'
 
     disagg_storages = gen_disagg_storages('test_key_provider_disagg03', disagg_only = True)
     scenarios = make_scenarios(disagg_storages)
+
+    # The crypt key data.
+    DEFAULT_KEY_DATA = b'abcdefghijklmnopqrstuvwxyz'
 
     MAIN_KEK_PAGE_ID = 1
     EXPECTED_KEK_VERSION = 1
@@ -81,11 +84,18 @@ class test_key_provider_disagg03(wttest.WiredTigerTestCase):
                 WHERE table_id={self.WT_SPECIAL_PALI_TURTLE_FILE_ID}
                 ORDER BY lsn DESC LIMIT 1;'''
         )
-        m = re.search(".*page_id=(\d+),lsn=(\d+).*version=(\d+)", result['page_data'])
+        m = re.search(r".*page_id=(\d+),lsn=(\d+).*version=(\d+)", result['page_data'])
         self.assertTrue(m)
         page_id, version = int(m.group(1)), int(m.group(3))
         self.assertEqual(page_id, self.MAIN_KEK_PAGE_ID)
         self.assertEqual(version, self.EXPECTED_KEK_VERSION)
+
+    def push_key(self, timestamp):
+        # Push a key with the given timestamp via the exposed set_key API.
+        crypt = wiredtiger.CryptKeys()
+        crypt.keys = self.DEFAULT_KEY_DATA
+        crypt.timestamp = timestamp
+        self.assertEqual(self.conn.get_key_provider().set_key(self.session, crypt), 0)
 
     def test_set_key_persists(self):
         if (self.ds_name != "palite"):
@@ -93,8 +103,10 @@ class test_key_provider_disagg03(wttest.WiredTigerTestCase):
 
         ds = SimpleDataSet(self, self.uri, 10)
         ds.populate()
-        # A pushed key is only persisted once the stable timestamp reaches it. Advance stable so the
-        # checkpoint selects the earliest pushed key.
+
+        # Push a key at timestamp 1, then advance stable to it so the checkpoint selects and
+        # persists the pushed key to the key-provider page.
+        self.push_key(1)
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(1))
         self.session.checkpoint()
 

--- a/test/suite/test_key_provider_disagg04.py
+++ b/test/suite/test_key_provider_disagg04.py
@@ -29,7 +29,7 @@
 # test_key_provider_disagg04.py
 #    Toggle the key_provider API version across restarts and verify the database stays readable.
 
-import wttest
+import wiredtiger, wttest
 from helper_disagg import DisaggConfigMixin, disagg_test_class, gen_disagg_storages
 from wtdataset import SimpleDataSet
 from wtscenario import make_scenarios
@@ -53,10 +53,25 @@ class test_key_provider_disagg04(wttest.WiredTigerTestCase):
     # Restart re-invokes conn_extensions, so flipping this field switches the loaded provider.
     current_version = 0
 
+    DEFAULT_KEY_DATA = b'abcdefghijklmnopqrstuvwxyz'
+
     def conn_extensions(self, extlist):
         config = f'=(early_load=true,config=\"verbose=-1,version={self.current_version}\")'
         extlist.extension('test', "key_provider" + config)
         DisaggConfigMixin.conn_extensions(self, extlist)
+
+    def checkpoint(self):
+        # Push mode: a checkpoint only persists a pushed key once stable reaches its timestamp, so
+        # push at a fresh timestamp then advance stable to it. Pull mode rotates keys through
+        # get_key, so no push is needed there.
+        if self.current_version == 1:
+            self.push_ts += 1
+            crypt = wiredtiger.CryptKeys()
+            crypt.keys = self.DEFAULT_KEY_DATA
+            crypt.timestamp = self.push_ts
+            self.assertEqual(self.conn.get_key_provider().set_key(self.session, crypt), 0)
+            self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(self.push_ts))
+        self.session.checkpoint()
 
     def restart_with_version(self, version):
         self.current_version = version
@@ -65,6 +80,9 @@ class test_key_provider_disagg04(wttest.WiredTigerTestCase):
     def test_key_provider_version_toggle(self):
         if (self.ds_name != "palite"):
             self.skipTest("Must use PALite for disagg key provider testing")
+
+        # Monotonic push timestamp for this test; advances on each push-mode checkpoint.
+        self.push_ts = 0
 
         # The scenario runs start -> other -> start -> other, covering both directions.
         other_version = 1 - self.start_version
@@ -75,9 +93,7 @@ class test_key_provider_disagg04(wttest.WiredTigerTestCase):
 
         ds1 = SimpleDataSet(self, self.uri, self.nentries)
         ds1.populate()
-        # Advance stable so the first checkpoint persists a key.
-        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(1))
-        self.session.checkpoint()
+        self.checkpoint()
         ds1.check()
 
         # Part 2: restart on the other version, verify, add more.
@@ -86,7 +102,7 @@ class test_key_provider_disagg04(wttest.WiredTigerTestCase):
 
         ds2 = SimpleDataSet(self, self.uri, self.nentries * 2)
         ds2.populate(first_row=self.nentries + 1)
-        self.session.checkpoint()
+        self.checkpoint()
         ds2.check()
 
         # Part 3: restart back on the starting version.
@@ -95,7 +111,7 @@ class test_key_provider_disagg04(wttest.WiredTigerTestCase):
 
         ds3 = SimpleDataSet(self, self.uri, self.nentries * 3)
         ds3.populate(first_row=self.nentries * 2 + 1)
-        self.session.checkpoint()
+        self.checkpoint()
         ds3.check()
 
         # Part 4: final flip to the other version, verify all three batches.

--- a/test/suite/test_key_provider_disagg05.py
+++ b/test/suite/test_key_provider_disagg05.py
@@ -26,8 +26,8 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import json, os, struct, subprocess
-import wttest
+import json, os, subprocess
+import wiredtiger, wttest
 from run import wt_builddir
 from helper_disagg import DisaggConfigMixin, disagg_test_class, gen_disagg_storages, get_shard_id
 from wtdataset import SimpleDataSet
@@ -38,7 +38,7 @@ from wtscenario import make_scenarios
 #    verify each checkpoint persists a new key-provider page.
 @disagg_test_class
 class test_key_provider_disagg05(wttest.WiredTigerTestCase):
-    conn_base_config = ',create,statistics=(all),statistics_log=(wait=1,json=true,on_close=true),'
+    conn_base_config = ',create,statistics=(all),'
     def conn_config(self):
         return self.extensionsConfig() + self.conn_base_config + 'disaggregated=(role="leader")'
 
@@ -46,10 +46,15 @@ class test_key_provider_disagg05(wttest.WiredTigerTestCase):
     scenarios = make_scenarios(disagg_storages)
 
     MAIN_KEK_PAGE_ID = 1
+    # Byte offset of the header_size field within WT_CRYPT_HEADER (see crypt_header.h).
+    CRYPT_HEADER_SIZE_OFFSET = 6
     WT_SPECIAL_PALI_KEY_PROVIDER_FILE_ID = 26
     key_provider_table = f'pages_{get_shard_id(WT_SPECIAL_PALI_KEY_PROVIDER_FILE_ID):02d}.db'
 
     uri = "layered:test_key_provider_disagg05"
+
+    # Base bytes for each pushed key; key_for() appends a unique per-push suffix.
+    KEY_PREFIX = b'abcdefghijklmnopqrstuvwxyz'
 
     def conn_extensions(self, extlist):
         config = '=(early_load=true,config=\"verbose=-1,version=1,key_expires=0\")'
@@ -63,60 +68,98 @@ class test_key_provider_disagg05(wttest.WiredTigerTestCase):
             capture_output=True, text=True, check=True)
         return json.loads(result.stdout)
 
-    # The pushed timestamp lives at offset 16 of the WT_CRYPT_HEADER (8 bytes, little-endian).
-    CRYPT_HEADER_TIMESTAMP_OFFSET = 16
-
     def key_provider_pages(self):
-        # Read each persisted page ordered by LSN, with a hex dump of its bytes.
-        return self.sqlite_fetch(
+        # Read each persisted page ordered by LSN, exposing the persisted key as a named field so
+        # callers don't parse the raw hex dump.
+        rows = self.sqlite_fetch(
             f'SELECT lsn, page_id, hex(page_data) AS hex FROM pages '
             f'WHERE table_id={self.WT_SPECIAL_PALI_KEY_PROVIDER_FILE_ID} '
             f'ORDER BY lsn ASC;')
-
-    def header_timestamp(self, hex_page):
-        # The WT_CRYPT_HEADER stores the pushed timestamp as a little-endian uint64 at byte offset 16.
-        data = bytes.fromhex(hex_page)
-        return struct.unpack_from('<Q', data, self.CRYPT_HEADER_TIMESTAMP_OFFSET)[0]
-
-    def validate_key_provider_pages(self, expected_count_min):
-        # Every page references the main KEK page, and both the LSN and the pushed timestamp must
-        # strictly increase across pages.
-        rows = self.key_provider_pages()
-        self.assertGreaterEqual(len(rows), expected_count_min)
-        previous_lsn = -1
-        previous_ts = -1
         for row in rows:
-            self.assertEqual(row['page_id'], self.MAIN_KEK_PAGE_ID)
-            self.assertGreater(row['lsn'], previous_lsn)
-            timestamp = self.header_timestamp(row['hex'])
-            self.assertGreater(timestamp, previous_ts)
-            previous_lsn = row['lsn']
-            previous_ts = timestamp
+            # Each page is the crypt header followed by the key; expose the key under 'key'.
+            data = bytes.fromhex(row['hex'])
+            header_size = data[self.CRYPT_HEADER_SIZE_OFFSET]
+            row['key'] = data[header_size:]
+        return rows
+
+    def validate_latest_key_provider_page(self, timestamp):
+        # Validate the most recently persisted key-provider page: it is on the main KEK page and
+        # holds the key pushed for this checkpoint (which encodes the timestamp).
+        rows = self.key_provider_pages()
+        self.assertGreater(len(rows), 0)
+        latest = rows[-1]
+        self.assertEqual(latest['page_id'], self.MAIN_KEK_PAGE_ID)
+        self.assertEqual(latest['key'], self.key_for(timestamp))
+
+    def key_for(self, timestamp):
+        # A unique key per push: the key prefix followed by the push timestamp.
+        return self.KEY_PREFIX + str(timestamp).encode()
+
+    def push_key(self, timestamp):
+        crypt = wiredtiger.CryptKeys()
+        crypt.keys = self.key_for(timestamp)
+        crypt.timestamp = timestamp
+        self.assertEqual(self.conn.get_key_provider().set_key(self.session, crypt), 0)
 
     def test_multiple_pushes_across_checkpoints(self):
-        # Each checkpoint pushes a fresh key onto the pending list and drains it, persisting one
-        # new key-provider page.
         if self.ds_name != "palite":
             self.skipTest("Must use PALite to verify contents")
 
         ds = SimpleDataSet(self, self.uri, 10)
         ds.populate()
-
-        # The first checkpoint creates the page table; record the baseline page count.
-        stable = 1
-        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(stable))
-        self.session.checkpoint()
-        baseline = len(self.key_provider_pages())
-        self.assertGreaterEqual(baseline, 1)
-
-        # Write and checkpoint a few more times; each checkpoint persists another page.
         cursor = self.session.open_cursor(self.uri)
-        for i in range(4):
-            cursor[ds.key(100 + i)] = ds.value(100 + i)
-            stable += 1
-            self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(stable))
-            self.session.checkpoint()
+
+        # Each checkpoint writes a row (so it does real work) and persists the most recent pending
+        # key whose timestamp is at or below the stable timestamp as a new key-provider page.
+
+        # Queue three keys, then advance stable to 3 so the checkpoint selects the most recent
+        # (timestamp 3) and drains the consumed entries.
+        self.push_key(1)
+        self.push_key(2)
+        self.push_key(3)
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(3))
+        cursor[ds.key(101)] = ds.value(101)
+        self.session.checkpoint()
+        self.validate_latest_key_provider_page(timestamp=3)
+
+        # Push a single key and advance stable to it: the checkpoint persists it (timestamp 4).
+        self.push_key(4)
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(4))
+        cursor[ds.key(102)] = ds.value(102)
+        self.session.checkpoint()
+        self.validate_latest_key_provider_page(timestamp=4)
+
+        # Push another key and advance stable to it: the checkpoint persists it (timestamp 5).
+        self.push_key(5)
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(5))
+        cursor[ds.key(103)] = ds.value(103)
+        self.session.checkpoint()
+        self.validate_latest_key_provider_page(timestamp=5)
+
         cursor.close()
 
-        # The page count must have grown past the baseline.
-        self.validate_key_provider_pages(baseline + 1)
+    def test_select_highest_at_or_below_stable(self):
+        if self.ds_name != "palite":
+            self.skipTest("Must use PALite to verify contents")
+
+        ds = SimpleDataSet(self, self.uri, 10)
+        ds.populate()
+        cursor = self.session.open_cursor(self.uri)
+
+        # Queue three keys but advance stable only to 2: the checkpoint must select the highest
+        # key at or below stable (timestamp 2), leaving the timestamp-3 key pending.
+        self.push_key(1)
+        self.push_key(2)
+        self.push_key(3)
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(2))
+        cursor[ds.key(101)] = ds.value(101)
+        self.session.checkpoint()
+        self.validate_latest_key_provider_page(timestamp=2)
+
+        # Advance stable to 3: the still-pending timestamp-3 key is now selected.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(3))
+        cursor[ds.key(102)] = ds.value(102)
+        self.session.checkpoint()
+        self.validate_latest_key_provider_page(timestamp=3)
+
+        cursor.close()


### PR DESCRIPTION
This exposes the disaggregated key provider's `set_key` callback to Python and removes the temporary push method.

The set_key now belongs to the module that owns the keys and knows the stable timestamp. Now that timestamp-based KEK selection is in place, tests can push keys explicitly at the right timestamps.

Technical Changes
- Add a SWIG binding so tests can call `conn.get_key_provider().set_key(...)`.
- Remove the auto-push from the test key provider extension.
- Rewrite the disagg key-provider tests to push keys explicitly and verify the persisted key page matches the key chosen for each checkpoint timestamp.