### PR TITLE
WT-17802 Use WT_REF_TRYLOCK in __wt_btcur_skip_page to avoid spinning under contention

### DIFF
--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -2744,9 +2744,12 @@ __wt_btcur_skip_page(
 
     /*
      * We are making these decisions while holding a lock for the page as checkpoint or eviction can
-     * make changes to the data structures (i.e., aggregate timestamps) we are reading.
+     * make changes to the data structures (i.e., aggregate timestamps) we are reading. Skipping is
+     * only an optimization, so try the lock once and read the page rather than spin under
+     * contention.
      */
-    WT_REF_LOCK(session, ref, &previous_state);
+    if (WT_REF_TRYLOCK(session, ref, &previous_state) != 0)
+        return (0);
 
     /*
      * Check the fast-truncate information; there are 3 cases:

--- a/src/include/ref_inline.h
+++ b/src/include/ref_inline.h
@@ -21,7 +21,7 @@ __wt_ref_is_root(WT_REF *ref)
 /*
  * # The ref state API. #
  *
- * 5 macros are defined to manipulate the ref state. This is a highly sensitive field and protected
+ * 6 macros are defined to manipulate the ref state. This is a highly sensitive field and protected
  * via the double underscore keyword. The field should only be accessed via these macros.
  *
  * WT_REF_GET_STATE:
@@ -40,6 +40,11 @@ __wt_ref_is_root(WT_REF *ref)
  * WT_REF_LOCK:
  * Spin until the state WT_REF_LOCKED is swapped into the ref state field. Once the call to this
  * function completes the caller has exclusive access to the ref.
+ *
+ * WT_REF_TRYLOCK:
+ * Try once to swap WT_REF_LOCKED into the ref state field, returning EBUSY without waiting if the
+ * ref is already locked or the state changed under us. Use when locking the ref is only an
+ * optimization and spinning under contention is not worthwhile.
  *
  * WT_REF_UNLOCK:
  * Effectively wraps WT_REF_SET_STATE, however should only be used when returning the ref to the
@@ -149,5 +154,26 @@ __ref_lock(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF_STATE *previous_statep)
 }
 
 #define WT_REF_LOCK(session, ref, previous_statep) __ref_lock((session), (ref), (previous_statep))
+
+/*
+ * __ref_try_lock --
+ *     Try once to lock the ref, returning EBUSY without waiting if it is already locked. On success
+ *     return the previous state to the caller.
+ */
+static WT_INLINE int
+__ref_try_lock(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF_STATE *previous_statep)
+{
+    WT_REF_STATE previous_state;
+
+    previous_state = WT_REF_GET_STATE(ref);
+    if (previous_state == WT_REF_LOCKED ||
+      !WT_REF_CAS_STATE(session, ref, previous_state, WT_REF_LOCKED))
+        return (EBUSY);
+    *(previous_statep) = previous_state;
+    return (0);
+}
+
+#define WT_REF_TRYLOCK(session, ref, previous_statep) \
+    __ref_try_lock((session), (ref), (previous_statep))
 
 #define WT_REF_UNLOCK(ref, state) WT_REF_SET_STATE(ref, state)

--- a/src/include/ref_inline.h
+++ b/src/include/ref_inline.h
@@ -21,7 +21,7 @@ __wt_ref_is_root(WT_REF *ref)
 /*
  * # The ref state API. #
  *
- * 6 macros are defined to manipulate the ref state. This is a highly sensitive field and protected
+ * Macros are defined to manipulate the ref state. This is a highly sensitive field and protected
  * via the double underscore keyword. The field should only be accessed via these macros.
  *
  * WT_REF_GET_STATE:


### PR DESCRIPTION
## Summary

- Replaces `WT_REF_LOCK` (spinning) with `WT_REF_TRYLOCK` (single non-spinning CAS) in `__wt_btcur_skip_page`
- Adds `__ref_try_lock()` and `WT_REF_TRYLOCK` macro to `ref_inline.h`, following the existing `static-inline-wrapped-by-macro` convention
- When the ref is contended, returns 0 immediately (do not skip — read the page normally), which is correct because page-skipping is a pure optimization

## Motivation

`__wt_btcur_skip_page` reads aggregate timestamps to decide whether to skip an entire page. The lock is held purely to protect that read. Spinning under contention is wasteful: if another thread holds the ref lock, we can simply fall through to reading the page — the cursor is no worse off than if skip_page had never been called.

## Performance Validation

Validated via a sys-perf `--alias perf-required` patch (31 HVW tasks, all SUCCEEDED). SPS Performance Comparison across 534 data points showed no regressions; 28 improvements in latency metrics, 0 throughput regressions. See WT-17802 for the full analysis comment.

## Test Plan
- [ ] `--alias perf-required` sys-perf patch: 31/31 SUCCEEDED, no regressions