### PR TITLE
WT-17598 Fix double-counting of cache size in __wti_page_inmem_updates (8.3)

### DIFF
--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -1080,14 +1080,13 @@ __wti_page_inmem_updates(WT_SESSION_IMPL *session, WT_REF *ref)
     WT_PAGE *page;
     WT_ROW *rip;
     WT_UPDATE *upd;
-    size_t size, total_size;
+    size_t size;
     uint64_t recno, rle;
     uint32_t i;
 
     btree = S2BT(session);
     page = ref->page;
     upd = NULL;
-    total_size = 0;
 
     /*
      * This variable is only used in assertions so in non-diagnostic builds it throws an unused
@@ -1125,7 +1124,6 @@ __wti_page_inmem_updates(WT_SESSION_IMPL *session, WT_REF *ref)
                 /* Create an update to resolve the prepare. */
                 WT_ERR(
                   __page_inmem_update_col(session, ref, &cbt, recno, value, &unpack, &upd, &size));
-                total_size += size;
                 upd = NULL;
             }
         }
@@ -1150,7 +1148,6 @@ __wti_page_inmem_updates(WT_SESSION_IMPL *session, WT_REF *ref)
               "Should never read an overflow removed value for a prepared update");
 
             WT_ERR(__page_inmem_update(session, value, &unpack, &upd, &size));
-            total_size += size;
 
             /* Search the page and apply the modification. */
             WT_ERR(__wt_row_search(&cbt, key, true, ref, true, NULL));
@@ -1164,7 +1161,6 @@ __wti_page_inmem_updates(WT_SESSION_IMPL *session, WT_REF *ref)
      * updates to avoid reconciling the page every time.
      */
     __wt_page_modify_clear(session, page);
-    __wt_cache_page_inmem_incr(session, page, total_size, false);
 
     if (0) {
 err:


### PR DESCRIPTION
Backport of the cache double-count fix from WT-17598 to the 8.3 branch.

Since WT-6458, `__wti_page_inmem_updates` accumulated `total_size` across
all restored updates and issued a batch `__wt_cache_page_inmem_incr` at the
end — but the serial functions (`__wt_update_serial`, `__wt_insert_serial`,
`__wt_col_append_serial`) it calls had already incremented the same bytes.
This caused `bytes_inmem` and `page->memory_footprint` to be counted twice
for every prepared update and disagg tombstone restored during page-in,
making cache pressure appear 2× higher than actual and triggering
unnecessary eviction.

The fix removes the redundant `total_size` accumulation and the batch
`__wt_cache_page_inmem_incr` call; the serial functions already account
for each update's size correctly.

The broader batching optimisation from WT-17598 (session flag to suppress
per-update serial increments) is not included — that was subsequently
reverted in WT-17600. Only the double-count removal is backported.