### PR TITLE
WT-17760 Fix verifier row-index desync against the history store

### DIFF
--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -35,6 +35,10 @@ typedef struct {
     bool dump_pages;
     bool read_corrupt;
 
+    /* Whether to read from the history store, and if so, which checkpoint. */
+    bool skip_hs;
+    const char *hs_checkpoint_name;
+
     /* Page layout information. */
     uint64_t depth, depth_internal[100], depth_leaf[100], tree_stack[100], keys_count_stack[100],
       key_sz_stack[100], val_sz_stack[100], total_sz_stack[100];
@@ -501,6 +505,10 @@ __wt_verify(WT_SESSION_IMPL *session, const char *cfg[])
             if (ckpt->ta.prepare)
                 addr_unpack.ta.prepare = 1;
             addr_unpack.raw = WT_CELL_ADDR_INT;
+
+            /* Only verify history store entries against the last checkpoint. */
+            vs->skip_hs = skip_hs || (ckpt + 1)->name != NULL;
+            vs->hs_checkpoint_name = ckpt->name;
 
             /* Verify the tree. */
             WT_WITH_PAGE_INDEX(
@@ -1351,27 +1359,30 @@ static int
 __verify_key_hs(
   WT_SESSION_IMPL *session, WT_ITEM *tmp1, wt_timestamp_t newer_start_ts, WT_VSTUFF *vs)
 {
-/* FIXME-WT-10779 - Enable the history store validation. */
-#ifdef WT_VERIFY_VALIDATE_HISTORY_STORE
     WT_BTREE *btree;
     WT_CURSOR *hs_cursor;
     WT_DECL_RET;
-    wt_timestamp_t older_start_ts, older_stop_ts;
+    WT_TIME_WINDOW *tw;
+    wt_timestamp_t older_start_ts;
     uint64_t hs_counter;
     uint32_t hs_btree_id;
+    int cmp;
     char ts_string[2][WT_TS_INT_STRING_SIZE];
 
     btree = S2BT(session);
     hs_btree_id = btree->id;
-    WT_RET(__wt_curhs_open(session, hs_btree_id, NULL, NULL, &hs_cursor));
-    F_SET(hs_cursor, WT_CURSTD_HS_READ_COMMITTED);
 
     /*
-     * Set the data store timestamp and transactions to initiate timestamp range verification. Since
-     * transaction-ids are wiped out on start, we could possibly have a start txn-id of WT_TXN_NONE,
-     * in which case we initialize our newest with the max txn-id.
+     * Read the history store at the same checkpoint as the data store being verified, so the two
+     * views are consistent. The checkpoint name is communicated to the cursor open through the
+     * session.
      */
-    older_stop_ts = WT_TS_NONE;
+    WT_ASSERT(session, session->hs_checkpoint == NULL);
+    session->hs_checkpoint = vs->hs_checkpoint_name;
+    ret = __wt_curhs_open(session, hs_btree_id, NULL, NULL, &hs_cursor);
+    session->hs_checkpoint = NULL;
+    WT_RET(ret);
+    F_SET(hs_cursor, WT_CURSTD_HS_READ_COMMITTED);
 
     /*
      * Open a history store cursor positioned at the end of the data store key (the newest record)
@@ -1382,20 +1393,29 @@ __verify_key_hs(
 
     for (; ret == 0; ret = hs_cursor->prev(hs_cursor)) {
         WT_ERR(hs_cursor->get_key(hs_cursor, &hs_btree_id, vs->tmp2, &older_start_ts, &hs_counter));
+
+        /* Stop when we have iterated past the current btree or key. */
+        if (hs_btree_id != btree->id)
+            break;
+        WT_ERR(__wt_compare(session, NULL, vs->tmp2, tmp1, &cmp));
+        if (cmp != 0)
+            break;
+
+        __wt_hs_upd_time_window(hs_cursor, &tw);
+
         /* Verify the newer record's start is later than the older record's stop. */
-        if (newer_start_ts < older_stop_ts) {
+        if (newer_start_ts != WT_TS_NONE && newer_start_ts < tw->stop_ts) {
             WT_ERR_MSG(session, WT_ERROR,
-              "key %s has a overlap of timestamp ranges between history store stop timestamp %s "
+              "key %s has an overlap of timestamp ranges between history store stop timestamp %s "
               "being newer than a more recent timestamp range having start timestamp %s",
               __wt_buf_set_printable_format(
                 session, tmp1->data, tmp1->size, btree->key_format, false, vs->tmp2),
-              __wt_timestamp_to_string(older_stop_ts, ts_string[0]),
+              __wt_timestamp_to_string(tw->stop_ts, ts_string[0]),
               __wt_timestamp_to_string(newer_start_ts, ts_string[1]));
         }
 
         if (vs->stable_timestamp != WT_TS_NONE)
-            WT_ERR(
-              __verify_ts_stable_cmp(session, tmp1, NULL, 0, older_start_ts, older_stop_ts, vs));
+            WT_ERR(__verify_ts_stable_cmp(session, tmp1, NULL, 0, older_start_ts, tw->stop_ts, vs));
 
         /*
          * Since we are iterating from newer to older, the current older record becomes the newer
@@ -1406,13 +1426,6 @@ __verify_key_hs(
 err:
     WT_TRET(hs_cursor->close(hs_cursor));
     return (ret == WT_NOTFOUND ? 0 : ret);
-#else
-    WT_UNUSED(session);
-    WT_UNUSED(tmp1);
-    WT_UNUSED(newer_start_ts);
-    WT_UNUSED(vs);
-    return (0);
-#endif
 }
 
 /*
@@ -1560,18 +1573,29 @@ __verify_page_content_leaf(
 
         /* Verify key-associated history-store entries. */
         if (page->type == WT_PAGE_ROW_LEAF) {
-            if (unpack.type != WT_CELL_VALUE && unpack.type != WT_CELL_VALUE_COPY &&
-              unpack.type != WT_CELL_VALUE_OVFL && unpack.type != WT_CELL_VALUE_SHORT)
+            /*
+             * Drive history store verification from key cells, not value cells. A globally visible
+             * zero-length value has no on-page value cell, so advancing the row index per value
+             * cell would pair a key with a later row's time window. Read each row's time window
+             * directly so the key and its window stay in step, including rows whose value cell was
+             * omitted.
+             */
+            if (unpack.type != WT_CELL_KEY && unpack.type != WT_CELL_KEY_OVFL)
                 continue;
 
-            WT_RET(__wt_row_leaf_key(session, page, rip++, vs->tmp1, false));
-            WT_RET(__verify_key_hs(session, vs->tmp1, tw->start_ts, vs));
+            WT_RET(__wt_row_leaf_key(session, page, rip, vs->tmp1, false));
+            __wti_read_row_time_window(session, page, rip, tw);
+            ++rip;
+            if (!vs->skip_hs)
+                WT_RET(__verify_key_hs(session, vs->tmp1, tw->start_ts, vs));
         } else if (page->type == WT_PAGE_COL_VAR) {
             rle = __wt_cell_rle(&unpack);
             p = vs->tmp1->mem;
             WT_RET(__wt_vpack_uint(&p, 0, recno));
             vs->tmp1->size = WT_PTRDIFF(p, vs->tmp1->mem);
-            WT_RET(__verify_key_hs(session, vs->tmp1, tw->start_ts, vs));
+
+            if (!vs->skip_hs)
+                WT_RET(__verify_key_hs(session, vs->tmp1, tw->start_ts, vs));
 
             recno += rle;
             vs->records_so_far += rle;

--- a/test/suite/test_verify3.py
+++ b/test/suite/test_verify3.py
@@ -29,7 +29,7 @@
 import wttest
 
 # test_verify3.py
-#    Regression test for a verifier row-index desynchronization against the history store.
+#    Regression test for a verifier row-index misalignment against the history store.
 #
 #    When a row's value is zero-length and globally visible, reconciliation omits its on-page
 #    value cell. History store verification used to advance the row index once per value cell,

--- a/test/suite/test_verify3.py
+++ b/test/suite/test_verify3.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wttest
+
+# test_verify3.py
+#    Regression test for a verifier row-index desynchronization against the history store.
+#
+#    When a row's value is zero-length and globally visible, reconciliation omits its on-page
+#    value cell. History store verification used to advance the row index once per value cell,
+#    so an omitted value cell made every following key pair with a later row's data store time
+#    window. That produced a spurious "overlap of timestamp ranges" error and left the last row
+#    unverified. Driving the row index from key cells keeps each key paired with its own window.
+class test_verify3(wttest.WiredTigerTestCase):
+    uri = 'table:test_verify3'
+
+    def commit_at(self, ts):
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(ts))
+
+    def test_verify_omitted_value_cell(self):
+        self.session.create(self.uri, 'key_format=S,value_format=u')
+        self.conn.set_timestamp('oldest_timestamp=1,stable_timestamp=1')
+
+        c = self.session.open_cursor(self.uri)
+
+        # k0: an empty, globally visible value, so its on-page value cell is omitted.
+        self.session.begin_transaction()
+        c['k0'] = b''
+        self.commit_at(2)
+
+        # k1: an older version is destined for the history store with stop timestamp 30.
+        self.session.begin_transaction()
+        c['k1'] = b'a'
+        self.commit_at(10)
+        self.session.begin_transaction()
+        c['k1'] = b'A'
+        self.commit_at(30)
+
+        # k2: a single version with a start timestamp between k1's two versions.
+        self.session.begin_transaction()
+        c['k2'] = b'b'
+        self.commit_at(20)
+        c.close()
+
+        # Move oldest past k0 so its value cell is omitted, but below k1's history store stop so
+        # that record survives, then make everything stable and checkpoint.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(50))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(5))
+        self.session.checkpoint()
+
+        # Every row is now paired with its own time window, so verification succeeds.
+        self.assertEqual(self.session.verify(self.uri, None), 0)


### PR DESCRIPTION
## What

Fix a row-index desynchronization in the verifier's row-store leaf
history-store check, and enable history store verification (the validation
was previously compiled out).

This builds on the WT-10779 enablement work: the dormant validation loop
already existed in `develop` but was guarded out, so the latent bug never
fired. Turning the validation on exposed it.

## Why it was wrong

When a row's value is zero-length and globally visible, reconciliation
omits its on-page value cell. The leaf history-store check advanced the
logical row index once per **value** cell. An omitted value cell therefore
shifted the pairing: every following key was matched against a **later**
row's time window. This produced a spurious "overlap of timestamp ranges"
error and left the final row unverified.

## Fix

- Drive the row index from **key** cells, not value cells, so the physical
  cell stream and the logical row axis stay in step regardless of omitted
  value cells.
- Read each row's time window directly via the row-return path so the key
  and its window are always consistent.
- Open the history store at the same checkpoint as the data store being
  verified, so the two views are consistent.

## Test

`test/suite/test_verify3.py` engineers an omitted (empty, globally visible)
value cell ahead of rows that carry history-store records, and asserts
`verify()` succeeds. It fails without the key-driven change and passes with
it.
