### PR TITLE
WT-17835 Avoid scratch buffer churn on every key in the leaf delta write path

### DIFF
--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -315,12 +315,12 @@ __rec_pack_delta_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_KV 
  *     Pack a delta key and a delta value for a leaf page.
  */
 int
-__wti_rec_pack_delta_row_leaf(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_SAVE_UPD *supd)
+__wti_rec_pack_delta_row_leaf(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_SAVE_UPD *supd,
+  WT_ITEM *key, WT_ITEM *custom_value)
 {
     WT_CURSOR_BTREE *cbt;
-    WT_DECL_ITEM(custom_value);
     WT_DECL_RET;
-    WT_ITEM *key, value;
+    WT_ITEM value;
     WT_TIME_WINDOW *twp, tw;
     size_t custom_value_size, new_size;
     uint8_t flags, *p;
@@ -332,7 +332,6 @@ __wti_rec_pack_delta_row_leaf(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_SAV
     WT_CLEAR(value);
 
     /* Get the key data and pack it into a key cell. */
-    WT_ERR(__wt_scr_alloc(session, 0, &key));
     WT_ERR(__wti_rec_get_row_leaf_key(session, S2BT(session), r, supd->ins, supd->rip, key));
     WT_ERR(__rec_cell_build_leaf_key(session, r, key->data, key->size, true, &ovfl_key));
     WT_ASSERT(session, !ovfl_key);
@@ -374,7 +373,7 @@ __wti_rec_pack_delta_row_leaf(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_SAV
     /* Pack the flags and delta value into a custom value. */
     WT_ERR(
       __wt_struct_size(session, &custom_value_size, WT_DELTA_LEAF_VALUE_FORMAT, flags, &value));
-    WT_ERR(__wt_scr_alloc(session, custom_value_size, &custom_value));
+    WT_ERR(__wt_buf_init(session, custom_value, custom_value_size));
     custom_value->size = custom_value_size;
     WT_ERR(__wt_struct_pack(session, (void *)custom_value->data, custom_value_size,
       WT_DELTA_LEAF_VALUE_FORMAT, flags, &value));
@@ -398,8 +397,6 @@ __wti_rec_pack_delta_row_leaf(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_SAV
     __rec_delta_cell_tw_stats(r, twp);
 
 err:
-    __wt_scr_free(session, &key);
-    __wt_scr_free(session, &custom_value);
     return (ret);
 }
 

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2032,6 +2032,9 @@ __wti_rec_build_delta_init(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
 static int
 __rec_build_delta_leaf(WT_SESSION_IMPL *session, WT_PAGE_HEADER *full_image, WTI_RECONCILE *r)
 {
+    WT_DECL_ITEM(custom_value);
+    WT_DECL_ITEM(key);
+    WT_DECL_RET;
     WT_MULTI *multi;
     WT_PAGE_HEADER *header;
     WT_SAVE_UPD *supd;
@@ -2047,7 +2050,10 @@ __rec_build_delta_leaf(WT_SESSION_IMPL *session, WT_PAGE_HEADER *full_image, WTI
     multi = &r->multi[0];
     count = 0;
 
-    WT_RET(__wti_rec_build_delta_init(session, r));
+    WT_ERR(__wti_rec_build_delta_init(session, r));
+
+    WT_ERR(__wt_scr_alloc(session, 0, &key));
+    WT_ERR(__wt_scr_alloc(session, 0, &custom_value));
 
     /* Disable prefix compression until the first key is written. */
     r->key_pfx_compress = false;
@@ -2061,7 +2067,7 @@ __rec_build_delta_leaf(WT_SESSION_IMPL *session, WT_PAGE_HEADER *full_image, WTI
         if (!__rec_selected_key_changed(session, supd))
             continue;
 
-        WT_RET(__wti_rec_pack_delta_row_leaf(session, r, supd));
+        WT_ERR(__wti_rec_pack_delta_row_leaf(session, r, supd, key, custom_value));
         ++count;
     }
 
@@ -2078,7 +2084,10 @@ __rec_build_delta_leaf(WT_SESSION_IMPL *session, WT_PAGE_HEADER *full_image, WTI
       ", total time %" PRIu64 "us",
       full_image->mem_size, r->delta.size, WT_CLOCKDIFF_US(stop, start));
 
-    return (0);
+err:
+    __wt_scr_free(session, &key);
+    __wt_scr_free(session, &custom_value);
+    return (ret);
 }
 
 /*

--- a/src/reconcile/reconcile_private.h
+++ b/src/reconcile/reconcile_private.h
@@ -521,7 +521,8 @@ extern int __wti_rec_hs_delete_updates(WT_SESSION_IMPL *session, WTI_RECONCILE *
 extern int __wti_rec_hs_insert_updates(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_MULTI *multi)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_rec_pack_delta_row_leaf(WT_SESSION_IMPL *session, WTI_RECONCILE *r,
-  WT_SAVE_UPD *supd) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+  WT_SAVE_UPD *supd, WT_ITEM *key, WT_ITEM *custom_value)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wti_rec_row_leaf(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_REF *pageref,


### PR DESCRIPTION
### Summary

- __wti_rec_pack_delta_row_leaf was allocating two scratch buffers (key and custom_value) for every changed key and freeing them before returning, resulting in 2N scratch pool claim/release operations per delta build.
- Move those allocations into __rec_build_delta_leaf so they are claimed once before the loop and released once after it completes.
- Pass both buffers into __wti_rec_pack_delta_row_leaf as parameters. Reset custom_value between iterations with __wt_buf_init, which is just two assignments and one comparison when no reallocation is needed.

### Motivation

The scratch pool scan is O(pool slots). On pages with many concurrent updates — exactly the pages most likely to produce deltas — this added measurable per-key overhead on the reconciliation hot path. The buffers had no semantic reason to have per-key lifetime; both are write-only intermediates that are fully overwritten on each iteration.

### Test Plan

- Using the existing leaf and internal page delta tests.