### PR TITLE
WT-17846 Assert page->dsk is current before victim-cache insertion

### DIFF
--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -131,6 +131,16 @@ __evict_page_victim_cache(WT_SESSION_IMPL *session, WT_REF *ref)
     }
 
     /*
+     * The disk image cached here is only refreshed when the page is instantiated. A page reconciled
+     * in place (for example by a checkpoint) keeps a stale image even as its block metadata
+     * advances to the newly written version, so caching it would pair an old image with newer
+     * metadata. Reconciled pages take the dirty-eviction path rather than this clean one, so the
+     * image is current by the time we get here; assert the invariant that lets us rely on that: the
+     * page was never reconciled, or its last reconciliation result has already been consumed.
+     */
+    WT_ASSERT(session, page->modify == NULL || page->modify->rec_result == 0);
+
+    /*
      * Victim cache: store evicted pages in disagg cache. The format must match what disagg read
      * path expects: WT_PAGE_HEADER + WT_BLOCK_DISAGG_HEADER + data
      */


### PR DESCRIPTION
## Summary
- In `__evict_page_victim_cache` (`src/evict/evict_page.c`), add an assertion guarding the invariant that `page->dsk` is current before it is stored in the disaggregated (PALI) block cache: `WT_ASSERT(session, page->modify == NULL || page->modify->rec_result == 0)`.
- Document *why* a stale image cannot reach the victim cache: `page->dsk` is only refreshed at page instantiation (read-in or split/rewrite). A page reconciled in place (e.g. by checkpoint) keeps a stale image while its `block_meta` advances, so caching it would pair old bytes with new metadata.
- Such pages carry a non-zero `rec_result` and are routed to `__evict_page_dirty_update`, never the clean-eviction victim-cache path — the assertion makes that load-bearing eligibility invariant explicit and guards against future changes that might broaden eligibility.

## Testing
- No behavior change in non-diagnostic builds; the assertion is diagnostic-only.
- Covered by existing eviction / disaggregated-storage suites; the new assertion exercises the clean-eviction path under diagnostic builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)