### PR TITLE
WT-17850 Add statistics for disaggregated victim cache put cost

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -235,6 +235,7 @@ conn_stats = [
     ##########################################
     # Block cache statistics
     ##########################################
+    BlockCacheStat('block_cache_app_thread_put_time', 'time application threads spent adding pages to the disaggregated victim cache (usecs)'),
     BlockCacheStat('block_cache_app_thread_puts', 'pages added to the disaggregated victim cache by application threads'),
     BlockCacheStat('block_cache_blocks', 'total blocks'),
     BlockCacheStat('block_cache_blocks_evicted', 'evicted blocks'),
@@ -255,12 +256,12 @@ conn_stats = [
     BlockCacheStat('block_cache_bytes_update', 'cached bytes updated'),
     BlockCacheStat('block_cache_cold_not_cached', 'cold collection pages not added to the disaggregated victim cache during eviction'),
     BlockCacheStat('block_cache_eviction_passes', 'number of eviction passes'),
-    BlockCacheStat('block_cache_eviction_thread_puts', 'pages added to the disaggregated victim cache by eviction threads'),
     BlockCacheStat('block_cache_hits', 'number of hits'),
     BlockCacheStat('block_cache_lookups', 'lookups'),
     BlockCacheStat('block_cache_misses', 'number of misses'),
     BlockCacheStat('block_cache_not_evicted_overhead', 'number of blocks not evicted due to overhead'),
     BlockCacheStat('block_cache_put_time', 'time spent adding pages to the disaggregated victim cache (usecs)'),
+    BlockCacheStat('block_cache_puts', 'pages added to the disaggregated victim cache'),
 
     ##########################################
     # Block manager statistics

--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -235,7 +235,6 @@ conn_stats = [
     ##########################################
     # Block cache statistics
     ##########################################
-    BlockCacheStat('block_cache_app_thread_put_time', 'application thread time spent adding pages to the disaggregated victim cache (usecs)', 'no_clear'),
     BlockCacheStat('block_cache_app_thread_puts', 'pages added to the disaggregated victim cache by application threads'),
     BlockCacheStat('block_cache_blocks', 'total blocks'),
     BlockCacheStat('block_cache_blocks_evicted', 'evicted blocks'),
@@ -261,6 +260,7 @@ conn_stats = [
     BlockCacheStat('block_cache_lookups', 'lookups'),
     BlockCacheStat('block_cache_misses', 'number of misses'),
     BlockCacheStat('block_cache_not_evicted_overhead', 'number of blocks not evicted due to overhead'),
+    BlockCacheStat('block_cache_put_time', 'time spent adding pages to the disaggregated victim cache (usecs)'),
 
     ##########################################
     # Block manager statistics

--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -235,6 +235,8 @@ conn_stats = [
     ##########################################
     # Block cache statistics
     ##########################################
+    BlockCacheStat('block_cache_app_thread_put_time', 'application thread time spent adding pages to the disaggregated victim cache (usecs)', 'no_clear'),
+    BlockCacheStat('block_cache_app_thread_puts', 'pages added to the disaggregated victim cache by application threads'),
     BlockCacheStat('block_cache_blocks', 'total blocks'),
     BlockCacheStat('block_cache_blocks_evicted', 'evicted blocks'),
     BlockCacheStat('block_cache_blocks_insert_read', 'total blocks inserted on read path'),
@@ -254,6 +256,7 @@ conn_stats = [
     BlockCacheStat('block_cache_bytes_update', 'cached bytes updated'),
     BlockCacheStat('block_cache_cold_not_cached', 'cold collection pages not added to the disaggregated victim cache during eviction'),
     BlockCacheStat('block_cache_eviction_passes', 'number of eviction passes'),
+    BlockCacheStat('block_cache_eviction_thread_puts', 'pages added to the disaggregated victim cache by eviction threads'),
     BlockCacheStat('block_cache_hits', 'number of hits'),
     BlockCacheStat('block_cache_lookups', 'lookups'),
     BlockCacheStat('block_cache_misses', 'number of misses'),

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -226,11 +226,6 @@ __evict_page_victim_cache(WT_SESSION_IMPL *session, WT_REF *ref)
       .lsn = page->disagg_info->block_meta.disagg_lsn,
     };
 
-    bool is_app_thread = !F_ISSET(session, WT_SESSION_INTERNAL);
-    WT_STAT_CONN_INCR(session, block_cache_puts);
-    if (is_app_thread)
-        WT_STAT_CONN_INCR(session, block_cache_app_thread_puts);
-
     WT_IGNORE_RET(plh->plh_cache_put(
       plh, &session->iface, page->disagg_info->block_meta.page_id, 0, &args, cache_buf));
 
@@ -241,9 +236,12 @@ __evict_page_victim_cache(WT_SESSION_IMPL *session, WT_REF *ref)
         __wt_page_header_byteswap(dsk);
 
     uint64_t elapsed = WT_CLOCKDIFF_US(__wt_clock(session), time_start);
+    WT_STAT_CONN_INCR(session, block_cache_puts);
     WT_STAT_CONN_INCRV(session, block_cache_put_time, elapsed);
-    if (is_app_thread)
+    if (!F_ISSET(session, WT_SESSION_INTERNAL)) {
+        WT_STAT_CONN_INCR(session, block_cache_app_thread_puts);
         WT_STAT_CONN_INCRV(session, block_cache_app_thread_put_time, elapsed);
+    }
 }
 
 /*

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -135,7 +135,6 @@ __evict_page_victim_cache(WT_SESSION_IMPL *session, WT_REF *ref)
      * puts are also counted by thread role: application threads pay this on a user operation's
      * critical path under cache pressure, eviction threads pay it in the background.
      */
-    bool app_thread = !F_ISSET(session, WT_SESSION_INTERNAL);
     uint64_t time_start = __wt_clock(session);
 
     /*
@@ -226,7 +225,7 @@ __evict_page_victim_cache(WT_SESSION_IMPL *session, WT_REF *ref)
       .lsn = page->disagg_info->block_meta.disagg_lsn,
     };
 
-    if (app_thread)
+    if (!F_ISSET(session, WT_SESSION_INTERNAL))
         WT_STAT_CONN_INCR(session, block_cache_app_thread_puts);
     else
         WT_STAT_CONN_INCR(session, block_cache_eviction_thread_puts);

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -131,13 +131,12 @@ __evict_page_victim_cache(WT_SESSION_IMPL *session, WT_REF *ref)
     }
 
     /*
-     * Time the victim-cache work done by application threads: this compression, checksum and put
-     * sit on a user operation's critical path, reached only because the cache is already under
-     * pressure. Eviction threads do the same work in the background, so only the application-thread
-     * cost is worth measuring.
+     * Time the victim-cache work - compression, checksum and put - to track its average cost. The
+     * puts are also counted by thread role: application threads pay this on a user operation's
+     * critical path under cache pressure, eviction threads pay it in the background.
      */
     bool app_thread = !F_ISSET(session, WT_SESSION_INTERNAL);
-    uint64_t time_start = app_thread ? __wt_clock(session) : 0;
+    uint64_t time_start = __wt_clock(session);
 
     /*
      * Victim cache: store evicted pages in disagg cache. The format must match what disagg read
@@ -241,9 +240,8 @@ __evict_page_victim_cache(WT_SESSION_IMPL *session, WT_REF *ref)
         /* Swap page header back to native order. */
         __wt_page_header_byteswap(dsk);
 
-    if (time_start != 0)
-        WT_STAT_CONN_INCRV(session, block_cache_app_thread_put_time,
-          WT_CLOCKDIFF_US(__wt_clock(session), time_start));
+    WT_STAT_CONN_INCRV(
+      session, block_cache_put_time, WT_CLOCKDIFF_US(__wt_clock(session), time_start));
 }
 
 /*

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -131,6 +131,15 @@ __evict_page_victim_cache(WT_SESSION_IMPL *session, WT_REF *ref)
     }
 
     /*
+     * Time the victim-cache work done by application threads: this compression, checksum and put
+     * sit on a user operation's critical path, reached only because the cache is already under
+     * pressure. Eviction threads do the same work in the background, so only the application-thread
+     * cost is worth measuring.
+     */
+    bool app_thread = !F_ISSET(session, WT_SESSION_INTERNAL);
+    uint64_t time_start = app_thread ? __wt_clock(session) : 0;
+
+    /*
      * Victim cache: store evicted pages in disagg cache. The format must match what disagg read
      * path expects: WT_PAGE_HEADER + WT_BLOCK_DISAGG_HEADER + data
      */
@@ -218,6 +227,11 @@ __evict_page_victim_cache(WT_SESSION_IMPL *session, WT_REF *ref)
       .lsn = page->disagg_info->block_meta.disagg_lsn,
     };
 
+    if (app_thread)
+        WT_STAT_CONN_INCR(session, block_cache_app_thread_puts);
+    else
+        WT_STAT_CONN_INCR(session, block_cache_eviction_thread_puts);
+
     WT_IGNORE_RET(plh->plh_cache_put(
       plh, &session->iface, page->disagg_info->block_meta.page_id, 0, &args, cache_buf));
 
@@ -226,6 +240,10 @@ __evict_page_victim_cache(WT_SESSION_IMPL *session, WT_REF *ref)
     else
         /* Swap page header back to native order. */
         __wt_page_header_byteswap(dsk);
+
+    if (time_start != 0)
+        WT_STAT_CONN_INCRV(session, block_cache_app_thread_put_time,
+          WT_CLOCKDIFF_US(__wt_clock(session), time_start));
 }
 
 /*

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -131,9 +131,10 @@ __evict_page_victim_cache(WT_SESSION_IMPL *session, WT_REF *ref)
     }
 
     /*
-     * Time the victim-cache work - compression, checksum and put - to track its average cost. The
-     * puts are also counted by thread role: application threads pay this on a user operation's
-     * critical path under cache pressure, eviction threads pay it in the background.
+     * Time the victim-cache work - compression, checksum and put - and count the pages cached.
+     * Track totals across all threads and, separately, the share borne by application threads,
+     * which pay it on a user operation's critical path under cache pressure rather than in the
+     * background.
      */
     uint64_t time_start = __wt_clock(session);
 
@@ -225,10 +226,10 @@ __evict_page_victim_cache(WT_SESSION_IMPL *session, WT_REF *ref)
       .lsn = page->disagg_info->block_meta.disagg_lsn,
     };
 
-    if (!F_ISSET(session, WT_SESSION_INTERNAL))
+    bool is_app_thread = !F_ISSET(session, WT_SESSION_INTERNAL);
+    WT_STAT_CONN_INCR(session, block_cache_puts);
+    if (is_app_thread)
         WT_STAT_CONN_INCR(session, block_cache_app_thread_puts);
-    else
-        WT_STAT_CONN_INCR(session, block_cache_eviction_thread_puts);
 
     WT_IGNORE_RET(plh->plh_cache_put(
       plh, &session->iface, page->disagg_info->block_meta.page_id, 0, &args, cache_buf));
@@ -239,8 +240,10 @@ __evict_page_victim_cache(WT_SESSION_IMPL *session, WT_REF *ref)
         /* Swap page header back to native order. */
         __wt_page_header_byteswap(dsk);
 
-    WT_STAT_CONN_INCRV(
-      session, block_cache_put_time, WT_CLOCKDIFF_US(__wt_clock(session), time_start));
+    uint64_t elapsed = WT_CLOCKDIFF_US(__wt_clock(session), time_start);
+    WT_STAT_CONN_INCRV(session, block_cache_put_time, elapsed);
+    if (is_app_thread)
+        WT_STAT_CONN_INCRV(session, block_cache_app_thread_put_time, elapsed);
 }
 
 /*

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -453,6 +453,7 @@ struct __wt_connection_stats {
     int64_t backup_blocks;
     int64_t backup_blocks_compressed;
     int64_t backup_blocks_uncompressed;
+    int64_t block_cache_app_thread_put_time;
     int64_t block_cache_blocks_update;
     int64_t block_cache_bytes_update;
     int64_t block_cache_cold_not_cached;
@@ -468,6 +469,8 @@ struct __wt_connection_stats {
     int64_t block_cache_hits;
     int64_t block_cache_misses;
     int64_t block_cache_bypass_chkpt;
+    int64_t block_cache_app_thread_puts;
+    int64_t block_cache_eviction_thread_puts;
     int64_t block_cache_blocks_removed;
     int64_t block_cache_blocks_removed_blocked;
     int64_t block_cache_blocks;

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -468,9 +468,10 @@ struct __wt_connection_stats {
     int64_t block_cache_hits;
     int64_t block_cache_misses;
     int64_t block_cache_bypass_chkpt;
+    int64_t block_cache_puts;
     int64_t block_cache_app_thread_puts;
-    int64_t block_cache_eviction_thread_puts;
     int64_t block_cache_blocks_removed;
+    int64_t block_cache_app_thread_put_time;
     int64_t block_cache_blocks_removed_blocked;
     int64_t block_cache_put_time;
     int64_t block_cache_blocks;

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -453,7 +453,6 @@ struct __wt_connection_stats {
     int64_t backup_blocks;
     int64_t backup_blocks_compressed;
     int64_t backup_blocks_uncompressed;
-    int64_t block_cache_app_thread_put_time;
     int64_t block_cache_blocks_update;
     int64_t block_cache_bytes_update;
     int64_t block_cache_cold_not_cached;
@@ -473,6 +472,7 @@ struct __wt_connection_stats {
     int64_t block_cache_eviction_thread_puts;
     int64_t block_cache_blocks_removed;
     int64_t block_cache_blocks_removed_blocked;
+    int64_t block_cache_put_time;
     int64_t block_cache_blocks;
     int64_t block_cache_blocks_insert_read;
     int64_t block_cache_blocks_insert_write;

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -6316,61 +6316,61 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_BACKUP_BLOCKS_COMPRESSED		1025
 /*! backup: total modified incremental blocks without compressed data */
 #define	WT_STAT_CONN_BACKUP_BLOCKS_UNCOMPRESSED		1026
-/*!
- * block-cache: application thread time spent adding pages to the
- * disaggregated victim cache (usecs)
- */
-#define	WT_STAT_CONN_BLOCK_CACHE_APP_THREAD_PUT_TIME	1027
 /*! block-cache: cached blocks updated */
-#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_UPDATE		1028
+#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_UPDATE		1027
 /*! block-cache: cached bytes updated */
-#define	WT_STAT_CONN_BLOCK_CACHE_BYTES_UPDATE		1029
+#define	WT_STAT_CONN_BLOCK_CACHE_BYTES_UPDATE		1028
 /*!
  * block-cache: cold collection pages not added to the disaggregated
  * victim cache during eviction
  */
-#define	WT_STAT_CONN_BLOCK_CACHE_COLD_NOT_CACHED	1030
+#define	WT_STAT_CONN_BLOCK_CACHE_COLD_NOT_CACHED	1029
 /*! block-cache: evicted blocks */
-#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_EVICTED		1031
+#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_EVICTED		1030
 /*! block-cache: file size causing bypass */
-#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_FILESIZE	1032
+#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_FILESIZE	1031
 /*! block-cache: lookups */
-#define	WT_STAT_CONN_BLOCK_CACHE_LOOKUPS		1033
+#define	WT_STAT_CONN_BLOCK_CACHE_LOOKUPS		1032
 /*! block-cache: number of blocks not evicted due to overhead */
-#define	WT_STAT_CONN_BLOCK_CACHE_NOT_EVICTED_OVERHEAD	1034
+#define	WT_STAT_CONN_BLOCK_CACHE_NOT_EVICTED_OVERHEAD	1033
 /*!
  * block-cache: number of bypasses because no-write-allocate setting was
  * on
  */
-#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_WRITEALLOC	1035
+#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_WRITEALLOC	1034
 /*! block-cache: number of bypasses due to overhead on put */
-#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_OVERHEAD_PUT	1036
+#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_OVERHEAD_PUT	1035
 /*! block-cache: number of bypasses on get */
-#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_GET		1037
+#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_GET		1036
 /*! block-cache: number of bypasses on put because file is too small */
-#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_PUT		1038
+#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_PUT		1037
 /*! block-cache: number of eviction passes */
-#define	WT_STAT_CONN_BLOCK_CACHE_EVICTION_PASSES	1039
+#define	WT_STAT_CONN_BLOCK_CACHE_EVICTION_PASSES	1038
 /*! block-cache: number of hits */
-#define	WT_STAT_CONN_BLOCK_CACHE_HITS			1040
+#define	WT_STAT_CONN_BLOCK_CACHE_HITS			1039
 /*! block-cache: number of misses */
-#define	WT_STAT_CONN_BLOCK_CACHE_MISSES			1041
+#define	WT_STAT_CONN_BLOCK_CACHE_MISSES			1040
 /*! block-cache: number of put bypasses on checkpoint I/O */
-#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_CHKPT		1042
+#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_CHKPT		1041
 /*!
  * block-cache: pages added to the disaggregated victim cache by
  * application threads
  */
-#define	WT_STAT_CONN_BLOCK_CACHE_APP_THREAD_PUTS	1043
+#define	WT_STAT_CONN_BLOCK_CACHE_APP_THREAD_PUTS	1042
 /*!
  * block-cache: pages added to the disaggregated victim cache by eviction
  * threads
  */
-#define	WT_STAT_CONN_BLOCK_CACHE_EVICTION_THREAD_PUTS	1044
+#define	WT_STAT_CONN_BLOCK_CACHE_EVICTION_THREAD_PUTS	1043
 /*! block-cache: removed blocks */
-#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_REMOVED		1045
+#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_REMOVED		1044
 /*! block-cache: time sleeping to remove block (usecs) */
-#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_REMOVED_BLOCKED	1046
+#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_REMOVED_BLOCKED	1045
+/*!
+ * block-cache: time spent adding pages to the disaggregated victim cache
+ * (usecs)
+ */
+#define	WT_STAT_CONN_BLOCK_CACHE_PUT_TIME		1046
 /*! block-cache: total blocks */
 #define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS			1047
 /*! block-cache: total blocks inserted on read path */

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -6316,2699 +6316,2714 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_BACKUP_BLOCKS_COMPRESSED		1025
 /*! backup: total modified incremental blocks without compressed data */
 #define	WT_STAT_CONN_BACKUP_BLOCKS_UNCOMPRESSED		1026
+/*!
+ * block-cache: application thread time spent adding pages to the
+ * disaggregated victim cache (usecs)
+ */
+#define	WT_STAT_CONN_BLOCK_CACHE_APP_THREAD_PUT_TIME	1027
 /*! block-cache: cached blocks updated */
-#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_UPDATE		1027
+#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_UPDATE		1028
 /*! block-cache: cached bytes updated */
-#define	WT_STAT_CONN_BLOCK_CACHE_BYTES_UPDATE		1028
+#define	WT_STAT_CONN_BLOCK_CACHE_BYTES_UPDATE		1029
 /*!
  * block-cache: cold collection pages not added to the disaggregated
  * victim cache during eviction
  */
-#define	WT_STAT_CONN_BLOCK_CACHE_COLD_NOT_CACHED	1029
+#define	WT_STAT_CONN_BLOCK_CACHE_COLD_NOT_CACHED	1030
 /*! block-cache: evicted blocks */
-#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_EVICTED		1030
+#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_EVICTED		1031
 /*! block-cache: file size causing bypass */
-#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_FILESIZE	1031
+#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_FILESIZE	1032
 /*! block-cache: lookups */
-#define	WT_STAT_CONN_BLOCK_CACHE_LOOKUPS		1032
+#define	WT_STAT_CONN_BLOCK_CACHE_LOOKUPS		1033
 /*! block-cache: number of blocks not evicted due to overhead */
-#define	WT_STAT_CONN_BLOCK_CACHE_NOT_EVICTED_OVERHEAD	1033
+#define	WT_STAT_CONN_BLOCK_CACHE_NOT_EVICTED_OVERHEAD	1034
 /*!
  * block-cache: number of bypasses because no-write-allocate setting was
  * on
  */
-#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_WRITEALLOC	1034
+#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_WRITEALLOC	1035
 /*! block-cache: number of bypasses due to overhead on put */
-#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_OVERHEAD_PUT	1035
+#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_OVERHEAD_PUT	1036
 /*! block-cache: number of bypasses on get */
-#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_GET		1036
+#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_GET		1037
 /*! block-cache: number of bypasses on put because file is too small */
-#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_PUT		1037
+#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_PUT		1038
 /*! block-cache: number of eviction passes */
-#define	WT_STAT_CONN_BLOCK_CACHE_EVICTION_PASSES	1038
+#define	WT_STAT_CONN_BLOCK_CACHE_EVICTION_PASSES	1039
 /*! block-cache: number of hits */
-#define	WT_STAT_CONN_BLOCK_CACHE_HITS			1039
+#define	WT_STAT_CONN_BLOCK_CACHE_HITS			1040
 /*! block-cache: number of misses */
-#define	WT_STAT_CONN_BLOCK_CACHE_MISSES			1040
+#define	WT_STAT_CONN_BLOCK_CACHE_MISSES			1041
 /*! block-cache: number of put bypasses on checkpoint I/O */
-#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_CHKPT		1041
+#define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_CHKPT		1042
+/*!
+ * block-cache: pages added to the disaggregated victim cache by
+ * application threads
+ */
+#define	WT_STAT_CONN_BLOCK_CACHE_APP_THREAD_PUTS	1043
+/*!
+ * block-cache: pages added to the disaggregated victim cache by eviction
+ * threads
+ */
+#define	WT_STAT_CONN_BLOCK_CACHE_EVICTION_THREAD_PUTS	1044
 /*! block-cache: removed blocks */
-#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_REMOVED		1042
+#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_REMOVED		1045
 /*! block-cache: time sleeping to remove block (usecs) */
-#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_REMOVED_BLOCKED	1043
+#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_REMOVED_BLOCKED	1046
 /*! block-cache: total blocks */
-#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS			1044
+#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS			1047
 /*! block-cache: total blocks inserted on read path */
-#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_INSERT_READ	1045
+#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_INSERT_READ	1048
 /*! block-cache: total blocks inserted on write path */
-#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_INSERT_WRITE	1046
+#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_INSERT_WRITE	1049
 /*! block-cache: total bytes */
-#define	WT_STAT_CONN_BLOCK_CACHE_BYTES			1047
+#define	WT_STAT_CONN_BLOCK_CACHE_BYTES			1050
 /*! block-cache: total bytes inserted on read path */
-#define	WT_STAT_CONN_BLOCK_CACHE_BYTES_INSERT_READ	1048
+#define	WT_STAT_CONN_BLOCK_CACHE_BYTES_INSERT_READ	1051
 /*! block-cache: total bytes inserted on write path */
-#define	WT_STAT_CONN_BLOCK_CACHE_BYTES_INSERT_WRITE	1049
+#define	WT_STAT_CONN_BLOCK_CACHE_BYTES_INSERT_WRITE	1052
 /*! block-disagg: Bytes read from the shared history store in SLS */
-#define	WT_STAT_CONN_DISAGG_BLOCK_HS_BYTE_READ		1050
+#define	WT_STAT_CONN_DISAGG_BLOCK_HS_BYTE_READ		1053
 /*! block-disagg: Bytes written to the shared history store in SLS */
-#define	WT_STAT_CONN_DISAGG_BLOCK_HS_BYTE_WRITE		1051
+#define	WT_STAT_CONN_DISAGG_BLOCK_HS_BYTE_WRITE		1054
 /*! block-disagg: Disaggregated block manager get */
-#define	WT_STAT_CONN_DISAGG_BLOCK_GET			1052
+#define	WT_STAT_CONN_DISAGG_BLOCK_GET			1055
 /*! block-disagg: Disaggregated block manager get cold page */
-#define	WT_STAT_CONN_DISAGG_BLOCK_GET_COLD		1053
+#define	WT_STAT_CONN_DISAGG_BLOCK_GET_COLD		1056
 /*!
  * block-disagg: Disaggregated block manager get from the shared history
  * store in SLS
  */
-#define	WT_STAT_CONN_DISAGG_BLOCK_HS_GET		1054
+#define	WT_STAT_CONN_DISAGG_BLOCK_HS_GET		1057
 /*! block-disagg: Disaggregated block manager page discard calls */
-#define	WT_STAT_CONN_DISAGG_BLOCK_PAGE_DISCARD		1055
+#define	WT_STAT_CONN_DISAGG_BLOCK_PAGE_DISCARD		1058
 /*! block-disagg: Disaggregated block manager put */
-#define	WT_STAT_CONN_DISAGG_BLOCK_PUT			1056
+#define	WT_STAT_CONN_DISAGG_BLOCK_PUT			1059
 /*! block-disagg: Disaggregated block manager put cold page */
-#define	WT_STAT_CONN_DISAGG_BLOCK_PUT_COLD		1057
+#define	WT_STAT_CONN_DISAGG_BLOCK_PUT_COLD		1060
 /*!
  * block-disagg: Disaggregated block manager put to the shared history
  * store in SLS
  */
-#define	WT_STAT_CONN_DISAGG_BLOCK_HS_PUT		1058
+#define	WT_STAT_CONN_DISAGG_BLOCK_HS_PUT		1061
 /*!
  * block-disagg: Disaggregated block manager read ahead of
  * materialization frontier
  */
-#define	WT_STAT_CONN_DISAGG_BLOCK_READ_AHEAD_FRONTIER	1059
+#define	WT_STAT_CONN_DISAGG_BLOCK_READ_AHEAD_FRONTIER	1062
 /*! block-manager: blocks pre-loaded */
-#define	WT_STAT_CONN_BLOCK_PRELOAD			1060
+#define	WT_STAT_CONN_BLOCK_PRELOAD			1063
 /*! block-manager: blocks read */
-#define	WT_STAT_CONN_BLOCK_READ				1061
+#define	WT_STAT_CONN_BLOCK_READ				1064
 /*! block-manager: blocks written */
-#define	WT_STAT_CONN_BLOCK_WRITE			1062
+#define	WT_STAT_CONN_BLOCK_WRITE			1065
 /*! block-manager: bytes read */
-#define	WT_STAT_CONN_BLOCK_BYTE_READ			1063
+#define	WT_STAT_CONN_BLOCK_BYTE_READ			1066
 /*! block-manager: bytes read for internal pages */
-#define	WT_STAT_CONN_BLOCK_BYTE_READ_INTL		1064
+#define	WT_STAT_CONN_BLOCK_BYTE_READ_INTL		1067
 /*!
  * block-manager: bytes read for internal pages before decompression and
  * decryption
  */
-#define	WT_STAT_CONN_BLOCK_BYTE_READ_INTL_DISK		1065
+#define	WT_STAT_CONN_BLOCK_BYTE_READ_INTL_DISK		1068
 /*! block-manager: bytes read for leaf pages */
-#define	WT_STAT_CONN_BLOCK_BYTE_READ_LEAF		1066
+#define	WT_STAT_CONN_BLOCK_BYTE_READ_LEAF		1069
 /*!
  * block-manager: bytes read for leaf pages before decompression and
  * decryption
  */
-#define	WT_STAT_CONN_BLOCK_BYTE_READ_LEAF_DISK		1067
+#define	WT_STAT_CONN_BLOCK_BYTE_READ_LEAF_DISK		1070
 /*! block-manager: bytes read via memory map API */
-#define	WT_STAT_CONN_BLOCK_BYTE_READ_MMAP		1068
+#define	WT_STAT_CONN_BLOCK_BYTE_READ_MMAP		1071
 /*! block-manager: bytes read via system call API */
-#define	WT_STAT_CONN_BLOCK_BYTE_READ_SYSCALL		1069
+#define	WT_STAT_CONN_BLOCK_BYTE_READ_SYSCALL		1072
 /*!
  * block-manager: bytes saved from being written when using internal page
  * deltas
  */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_SAVED_DELTA_INTL	1070
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_SAVED_DELTA_INTL	1073
 /*!
  * block-manager: bytes saved from being written when using leaf page
  * deltas
  */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_SAVED_DELTA_LEAF	1071
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_SAVED_DELTA_LEAF	1074
 /*! block-manager: bytes written */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE			1072
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE			1075
 /*! block-manager: bytes written by compaction */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_COMPACT		1073
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_COMPACT		1076
 /*! block-manager: bytes written for checkpoint */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_CHECKPOINT	1074
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_CHECKPOINT	1077
 /*!
  * block-manager: bytes written for internal pages after compression and
  * encryption
  */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_INTL_DISK		1075
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_INTL_DISK		1078
 /*!
  * block-manager: bytes written for internal pages before compression and
  * encryption
  */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_INTL		1076
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_INTL		1079
 /*!
  * block-manager: bytes written for leaf pages after compression and
  * encryption
  */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_LEAF_DISK		1077
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_LEAF_DISK		1080
 /*!
  * block-manager: bytes written for leaf pages before compression and
  * encryption
  */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_LEAF		1078
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_LEAF		1081
 /*! block-manager: bytes written via memory map API */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_MMAP		1079
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_MMAP		1082
 /*! block-manager: bytes written via system call API */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_SYSCALL		1080
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_SYSCALL		1083
 /*! block-manager: mapped blocks read */
-#define	WT_STAT_CONN_BLOCK_MAP_READ			1081
+#define	WT_STAT_CONN_BLOCK_MAP_READ			1084
 /*! block-manager: mapped bytes read */
-#define	WT_STAT_CONN_BLOCK_BYTE_MAP_READ		1082
+#define	WT_STAT_CONN_BLOCK_BYTE_MAP_READ		1085
 /*!
  * block-manager: number of internal page deltas written that were
  * between 0-20 percent the size of the full image
  */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_INTL_DELTA_LT20	1083
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_INTL_DELTA_LT20	1086
 /*!
  * block-manager: number of internal page deltas written that were
  * between 20-40 percent the size of the full image
  */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_INTL_DELTA_LT40	1084
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_INTL_DELTA_LT40	1087
 /*!
  * block-manager: number of internal page deltas written that were
  * between 40-60 percent the size of the full image
  */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_INTL_DELTA_LT60	1085
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_INTL_DELTA_LT60	1088
 /*!
  * block-manager: number of internal page deltas written that were
  * between 60-80 percent the size of the full image
  */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_INTL_DELTA_LT80	1086
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_INTL_DELTA_LT80	1089
 /*!
  * block-manager: number of internal page deltas written that were
  * between 80-100 percent the size of the full image
  */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_INTL_DELTA_LT100	1087
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_INTL_DELTA_LT100	1090
 /*!
  * block-manager: number of internal page deltas written that were
  * greater than the size of the full image
  */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_INTL_DELTA_GT100	1088
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_INTL_DELTA_GT100	1091
 /*!
  * block-manager: number of leaf page deltas written that were between
  * 0-20 percent the size of the full image
  */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_LEAF_DELTA_LT20	1089
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_LEAF_DELTA_LT20	1092
 /*!
  * block-manager: number of leaf page deltas written that were between
  * 20-40 percent the size of the full image
  */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_LEAF_DELTA_LT40	1090
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_LEAF_DELTA_LT40	1093
 /*!
  * block-manager: number of leaf page deltas written that were between
  * 40-60 percent the size of the full image
  */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_LEAF_DELTA_LT60	1091
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_LEAF_DELTA_LT60	1094
 /*!
  * block-manager: number of leaf page deltas written that were between
  * 60-80 percent the size of the full image
  */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_LEAF_DELTA_LT80	1092
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_LEAF_DELTA_LT80	1095
 /*!
  * block-manager: number of leaf page deltas written that were between
  * 80-100 percent the size of the full image
  */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_LEAF_DELTA_LT100	1093
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_LEAF_DELTA_LT100	1096
 /*!
  * block-manager: number of leaf page deltas written that were greater
  * than the size of the full image
  */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_LEAF_DELTA_GT100	1094
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_LEAF_DELTA_GT100	1097
 /*!
  * block-manager: number of times the file was remapped because it
  * changed size via fallocate or truncate
  */
-#define	WT_STAT_CONN_BLOCK_REMAP_FILE_RESIZE		1095
+#define	WT_STAT_CONN_BLOCK_REMAP_FILE_RESIZE		1098
 /*! block-manager: number of times the region was remapped via write */
-#define	WT_STAT_CONN_BLOCK_REMAP_FILE_WRITE		1096
+#define	WT_STAT_CONN_BLOCK_REMAP_FILE_WRITE		1099
 /*!
  * block-manager: time spent(usecs) on the most recent linear walk of
  * extents during first-fit allocation
  */
-#define	WT_STAT_CONN_BLOCK_FIRST_SRCH_WALK_TIME		1097
+#define	WT_STAT_CONN_BLOCK_FIRST_SRCH_WALK_TIME		1100
 /*! cache: application requested eviction interrupt */
-#define	WT_STAT_CONN_EVICTION_INTERUPTED_BY_APP		1098
+#define	WT_STAT_CONN_EVICTION_INTERUPTED_BY_APP		1101
 /*! cache: application thread time evicting (usecs) */
-#define	WT_STAT_CONN_EVICTION_APP_TIME			1099
+#define	WT_STAT_CONN_EVICTION_APP_TIME			1102
 /*!
  * cache: application threads eviction requested with cache fill ratio <
  * 25%
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_APP_THREADS_FILL_RATIO_LT_25	1100
+#define	WT_STAT_CONN_CACHE_EVICTION_APP_THREADS_FILL_RATIO_LT_25	1103
 /*!
  * cache: application threads eviction requested with cache fill ratio >=
  * 25% and < 50%
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_APP_THREADS_FILL_RATIO_25_50	1101
+#define	WT_STAT_CONN_CACHE_EVICTION_APP_THREADS_FILL_RATIO_25_50	1104
 /*!
  * cache: application threads eviction requested with cache fill ratio >=
  * 50% and < 75%
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_APP_THREADS_FILL_RATIO_50_75	1102
+#define	WT_STAT_CONN_CACHE_EVICTION_APP_THREADS_FILL_RATIO_50_75	1105
 /*!
  * cache: application threads eviction requested with cache fill ratio >=
  * 75%
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_APP_THREADS_FILL_RATIO_GT_75	1103
+#define	WT_STAT_CONN_CACHE_EVICTION_APP_THREADS_FILL_RATIO_GT_75	1106
 /*!
  * cache: application threads eviction skip page with updates or dirty
  * page
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_APP_THREADS_SKIP_UPDATES_DIRTY_PAGE	1104
+#define	WT_STAT_CONN_CACHE_EVICTION_APP_THREADS_SKIP_UPDATES_DIRTY_PAGE	1107
 /*! cache: application threads page read from disk to cache count */
-#define	WT_STAT_CONN_CACHE_READ_APP_COUNT		1105
+#define	WT_STAT_CONN_CACHE_READ_APP_COUNT		1108
 /*! cache: application threads page read from disk to cache time (usecs) */
-#define	WT_STAT_CONN_CACHE_READ_APP_TIME		1106
+#define	WT_STAT_CONN_CACHE_READ_APP_TIME		1109
 /*! cache: application threads page write from cache to disk count */
-#define	WT_STAT_CONN_CACHE_WRITE_APP_COUNT		1107
+#define	WT_STAT_CONN_CACHE_WRITE_APP_COUNT		1110
 /*! cache: application threads page write from cache to disk time (usecs) */
-#define	WT_STAT_CONN_CACHE_WRITE_APP_TIME		1108
+#define	WT_STAT_CONN_CACHE_WRITE_APP_TIME		1111
 /*! cache: bytes allocated for updates */
-#define	WT_STAT_CONN_CACHE_BYTES_UPDATES		1109
+#define	WT_STAT_CONN_CACHE_BYTES_UPDATES		1112
 /*! cache: bytes allocated for updates from the ingest btrees */
-#define	WT_STAT_CONN_CACHE_BYTES_UPDATES_INGEST		1110
+#define	WT_STAT_CONN_CACHE_BYTES_UPDATES_INGEST		1113
 /*! cache: bytes allocated for updates from the stable btrees */
-#define	WT_STAT_CONN_CACHE_BYTES_UPDATES_STABLE		1111
+#define	WT_STAT_CONN_CACHE_BYTES_UPDATES_STABLE		1114
 /*! cache: bytes belonging to page images in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_IMAGE			1112
+#define	WT_STAT_CONN_CACHE_BYTES_IMAGE			1115
 /*!
  * cache: bytes belonging to page images in the cache from the ingest
  * btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_IMAGE_INGEST		1113
+#define	WT_STAT_CONN_CACHE_BYTES_IMAGE_INGEST		1116
 /*!
  * cache: bytes belonging to page images in the cache from the stable
  * btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_IMAGE_STABLE		1114
+#define	WT_STAT_CONN_CACHE_BYTES_IMAGE_STABLE		1117
 /*! cache: bytes belonging to the history store table in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_HS			1115
+#define	WT_STAT_CONN_CACHE_BYTES_HS			1118
 /*! cache: bytes currently in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_INUSE			1116
+#define	WT_STAT_CONN_CACHE_BYTES_INUSE			1119
 /*! cache: bytes dirty in the cache cumulative */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_TOTAL		1117
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_TOTAL		1120
 /*! cache: bytes not belonging to page images in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_OTHER			1118
+#define	WT_STAT_CONN_CACHE_BYTES_OTHER			1121
 /*! cache: bytes read into cache */
-#define	WT_STAT_CONN_CACHE_BYTES_READ			1119
+#define	WT_STAT_CONN_CACHE_BYTES_READ			1122
 /*! cache: bytes written from cache */
-#define	WT_STAT_CONN_CACHE_BYTES_WRITE			1120
+#define	WT_STAT_CONN_CACHE_BYTES_WRITE			1123
 /*! cache: cache tolerance configured */
-#define	WT_STAT_CONN_CACHE_TOLERANCE_LEVEL		1121
+#define	WT_STAT_CONN_CACHE_TOLERANCE_LEVEL		1124
 /*! cache: checkpoint blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_CHECKPOINT	1122
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_CHECKPOINT	1125
 /*!
  * cache: checkpoint of history store file blocked non-history store page
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_CHECKPOINT_HS	1123
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_CHECKPOINT_HS	1126
 /*! cache: dirty bytes belonging to the history store table in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_HS_DIRTY		1124
+#define	WT_STAT_CONN_CACHE_BYTES_HS_DIRTY		1127
 /*! cache: dirty internal page cannot be evicted in disaggregated storage */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_DISAGG_DIRTY_INTERNAL_PAGE	1125
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_DISAGG_DIRTY_INTERNAL_PAGE	1128
 /*! cache: evict page attempts by eviction server */
-#define	WT_STAT_CONN_EVICTION_SERVER_EVICT_ATTEMPT	1126
+#define	WT_STAT_CONN_EVICTION_SERVER_EVICT_ATTEMPT	1129
 /*! cache: evict page attempts by eviction worker threads */
-#define	WT_STAT_CONN_EVICTION_WORKER_EVICT_ATTEMPT	1127
+#define	WT_STAT_CONN_EVICTION_WORKER_EVICT_ATTEMPT	1130
 /*! cache: evict page failures by eviction server */
-#define	WT_STAT_CONN_EVICTION_SERVER_EVICT_FAIL		1128
+#define	WT_STAT_CONN_EVICTION_SERVER_EVICT_FAIL		1131
 /*! cache: evict page failures by eviction worker threads */
-#define	WT_STAT_CONN_EVICTION_WORKER_EVICT_FAIL		1129
+#define	WT_STAT_CONN_EVICTION_WORKER_EVICT_FAIL		1132
 /*! cache: eviction calls to get a page found queue empty */
-#define	WT_STAT_CONN_EVICTION_GET_REF_EMPTY		1130
+#define	WT_STAT_CONN_EVICTION_GET_REF_EMPTY		1133
 /*! cache: eviction calls to get a page found queue empty after locking */
-#define	WT_STAT_CONN_EVICTION_GET_REF_EMPTY2		1131
+#define	WT_STAT_CONN_EVICTION_GET_REF_EMPTY2		1134
 /*! cache: eviction currently operating in aggressive mode */
-#define	WT_STAT_CONN_EVICTION_AGGRESSIVE_SET		1132
+#define	WT_STAT_CONN_EVICTION_AGGRESSIVE_SET		1135
 /*! cache: eviction empty score */
-#define	WT_STAT_CONN_EVICTION_EMPTY_SCORE		1133
+#define	WT_STAT_CONN_EVICTION_EMPTY_SCORE		1136
 /*!
  * cache: eviction gave up due to detecting a disk value without a
  * timestamp behind the last update on the chain
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_1	1134
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_1	1137
 /*!
  * cache: eviction gave up due to detecting a tombstone without a
  * timestamp ahead of the selected on disk update
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_2	1135
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_2	1138
 /*!
  * cache: eviction gave up due to detecting a tombstone without a
  * timestamp ahead of the selected on disk update after validating the
  * update chain
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_3	1136
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_3	1139
 /*!
  * cache: eviction gave up due to detecting update chain entries without
  * timestamps after the selected on disk update
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_4	1137
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_4	1140
 /*!
  * cache: eviction gave up due to needing to remove a record from the
  * history store but checkpoint is running
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_REMOVE_HS_RACE_WITH_CHECKPOINT	1138
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_REMOVE_HS_RACE_WITH_CHECKPOINT	1141
 /*! cache: eviction gave up due to no progress being made */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_PROGRESS	1139
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_PROGRESS	1142
 /*! cache: eviction passes of a file */
-#define	WT_STAT_CONN_EVICTION_WALK_PASSES		1140
+#define	WT_STAT_CONN_EVICTION_WALK_PASSES		1143
 /*! cache: eviction server candidate queue empty when topping up */
-#define	WT_STAT_CONN_EVICTION_QUEUE_EMPTY		1141
+#define	WT_STAT_CONN_EVICTION_QUEUE_EMPTY		1144
 /*! cache: eviction server candidate queue not empty when topping up */
-#define	WT_STAT_CONN_EVICTION_QUEUE_NOT_EMPTY		1142
+#define	WT_STAT_CONN_EVICTION_QUEUE_NOT_EMPTY		1145
 /*! cache: eviction server completed walks of all dhandles */
-#define	WT_STAT_CONN_EVICTION_DHANDLE_COMPLETE_WALK	1143
+#define	WT_STAT_CONN_EVICTION_DHANDLE_COMPLETE_WALK	1146
 /*!
  * cache: eviction server push pages to queue failed because of racing
  * with setting flag
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_PUSH_PAGES_FAILED_WHEN_FLAGING	1144
+#define	WT_STAT_CONN_EVICTION_SERVER_PUSH_PAGES_FAILED_WHEN_FLAGING	1147
 /*!
  * cache: eviction server skipped the internal pages if eviction is not
  * in aggressive mode
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_INTL_PAGE_NON_AGGRESSIVE	1145
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_INTL_PAGE_NON_AGGRESSIVE	1148
 /*! cache: eviction server skipped the pages already in the urgent queue */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_ALREADY_IN_URGENT_QUEUE	1146
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_ALREADY_IN_URGENT_QUEUE	1149
 /*! cache: eviction server skipped the pages when prefetching */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_PREFETCHED	1147
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_PREFETCHED	1150
 /*! cache: eviction server skipped the root pages */
-#define	WT_STAT_CONN_EVICTION_ROOT_PAGES_SKIPPED	1148
+#define	WT_STAT_CONN_EVICTION_ROOT_PAGES_SKIPPED	1151
 /*!
  * cache: eviction server skips clean history store pages with updates
  * when a precise checkpoint is in progress
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_HISTORY_STORE_PAGES_WITH_UPDATES_DURING_CHECKPOINT	1149
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_HISTORY_STORE_PAGES_WITH_UPDATES_DURING_CHECKPOINT	1152
 /*! cache: eviction server skips dirty pages during a running checkpoint */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_DIRTY_PAGES_DURING_CHECKPOINT	1150
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_DIRTY_PAGES_DURING_CHECKPOINT	1153
 /*!
  * cache: eviction server skips disaggregated trees already visited by
  * the ongoing checkpoint
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_DISAGG_TREES_CHECKPOINTED	1151
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_DISAGG_TREES_CHECKPOINTED	1154
 /*! cache: eviction server skips ingest btrees in disagg */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_INGEST_TREES	1152
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_INGEST_TREES	1155
 /*! cache: eviction server skips internal pages as it has an active child */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_INTL_PAGE_WITH_ACTIVE_CHILD	1153
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_INTL_PAGE_WITH_ACTIVE_CHILD	1156
 /*! cache: eviction server skips metadata pages with history */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_METATDATA_WITH_HISTORY	1154
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_METATDATA_WITH_HISTORY	1157
 /*!
  * cache: eviction server skips pages that are written with transactions
  * greater than the checkpoint timestamp
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_CHECKPOINT_TIMESTAMP	1155
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_CHECKPOINT_TIMESTAMP	1158
 /*!
  * cache: eviction server skips pages that are written with transactions
  * greater than the last running
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_LAST_RUNNING	1156
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_LAST_RUNNING	1159
 /*!
  * cache: eviction server skips pages that are written with transactions
  * greater than the prune timestamp
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_PRUNE_TIMESTAMP	1157
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_PRUNE_TIMESTAMP	1160
 /*!
  * cache: eviction server skips pages that have been reconciled
  * previously at the same prune timestamp
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_PRUNE_TIMESTAMP_NOT_MOVE	1158
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_PRUNE_TIMESTAMP_NOT_MOVE	1161
 /*!
  * cache: eviction server skips pages that previously failed eviction and
  * likely will again
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_RETRY	1159
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_RETRY	1162
 /*! cache: eviction server skips pages that we do not want to evict */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_UNWANTED_PAGES	1160
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_UNWANTED_PAGES	1163
 /*! cache: eviction server skips stable btrees in disagg */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_STABLE_TREES	1161
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_STABLE_TREES	1164
 /*! cache: eviction server skips tree that we do not want to evict */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_UNWANTED_TREE	1162
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_UNWANTED_TREE	1165
 /*!
  * cache: eviction server skips trees because there are too many active
  * walks
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_TOO_MANY_ACTIVE_WALKS	1163
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_TOO_MANY_ACTIVE_WALKS	1166
 /*! cache: eviction server skips trees that are being checkpointed */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_CHECKPOINTING_TREES	1164
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_CHECKPOINTING_TREES	1167
 /*!
  * cache: eviction server skips trees that are configured to stick in
  * cache
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_STICK_IN_CACHE	1165
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_STICK_IN_CACHE	1168
 /*!
  * cache: eviction server skips trees that are read-only if it is not
  * looking for clean pages
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_READ_ONLY	1166
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_READ_ONLY	1169
 /*! cache: eviction server skips trees that disable eviction */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_EVICTION_DISABLED	1167
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_EVICTION_DISABLED	1170
 /*! cache: eviction server skips trees that were not useful before */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_NOT_USEFUL_BEFORE	1168
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_NOT_USEFUL_BEFORE	1171
 /*!
  * cache: eviction server slept, because we did not make progress with
  * eviction
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SLEPT		1169
+#define	WT_STAT_CONN_EVICTION_SERVER_SLEPT		1172
 /*! cache: eviction server unable to reach eviction goal */
-#define	WT_STAT_CONN_EVICTION_SLOW			1170
+#define	WT_STAT_CONN_EVICTION_SLOW			1173
 /*! cache: eviction server waiting for a leaf page */
-#define	WT_STAT_CONN_EVICTION_WALK_LEAF_NOTFOUND	1171
+#define	WT_STAT_CONN_EVICTION_WALK_LEAF_NOTFOUND	1174
 /*! cache: eviction state */
-#define	WT_STAT_CONN_EVICTION_STATE			1172
+#define	WT_STAT_CONN_EVICTION_STATE			1175
 /*!
  * cache: eviction threshold cache full target multiplied by 100 for
  * precision
  */
-#define	WT_STAT_CONN_EVICTION_THRESHOLD_CACHE_FULL_TARGET	1173
+#define	WT_STAT_CONN_EVICTION_THRESHOLD_CACHE_FULL_TARGET	1176
 /*!
  * cache: eviction threshold cache full trigger multiplied by 100 for
  * precision
  */
-#define	WT_STAT_CONN_EVICTION_THRESHOLD_CACHE_FULL_TRIGGER	1174
+#define	WT_STAT_CONN_EVICTION_THRESHOLD_CACHE_FULL_TRIGGER	1177
 /*! cache: eviction threshold dirty target multiplied by 100 for precision */
-#define	WT_STAT_CONN_EVICTION_THRESHOLD_DIRTY_TARGET	1175
+#define	WT_STAT_CONN_EVICTION_THRESHOLD_DIRTY_TARGET	1178
 /*!
  * cache: eviction threshold dirty trigger multiplied by 100 for
  * precision
  */
-#define	WT_STAT_CONN_EVICTION_THRESHOLD_DIRTY_TRIGGER	1176
+#define	WT_STAT_CONN_EVICTION_THRESHOLD_DIRTY_TRIGGER	1179
 /*!
  * cache: eviction threshold updates target multiplied by 100 for
  * precision
  */
-#define	WT_STAT_CONN_EVICTION_THRESHOLD_UPDATES_TARGET	1177
+#define	WT_STAT_CONN_EVICTION_THRESHOLD_UPDATES_TARGET	1180
 /*!
  * cache: eviction threshold updates trigger multiplied by 100 for
  * precision
  */
-#define	WT_STAT_CONN_EVICTION_THRESHOLD_UPDATES_TRIGGER	1178
+#define	WT_STAT_CONN_EVICTION_THRESHOLD_UPDATES_TRIGGER	1181
 /*!
  * cache: eviction walk most recent sleeps for checkpoint handle
  * gathering
  */
-#define	WT_STAT_CONN_EVICTION_WALK_SLEEPS		1179
+#define	WT_STAT_CONN_EVICTION_WALK_SLEEPS		1182
 /*! cache: eviction walk pages queued that had updates */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_UPDATES	1180
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_UPDATES	1183
 /*! cache: eviction walk pages queued that were clean */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_CLEAN	1181
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_CLEAN	1184
 /*! cache: eviction walk pages queued that were dirty */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_DIRTY	1182
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_DIRTY	1185
 /*! cache: eviction walk pages seen that had updates */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN_UPDATES	1183
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN_UPDATES	1186
 /*! cache: eviction walk pages seen that were clean */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN_CLEAN	1184
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN_CLEAN	1187
 /*! cache: eviction walk pages seen that were dirty */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN_DIRTY	1185
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN_DIRTY	1188
 /*! cache: eviction walk restored - had to walk this many pages */
-#define	WT_STAT_CONN_NPOS_EVICT_WALK_MAX		1186
+#define	WT_STAT_CONN_NPOS_EVICT_WALK_MAX		1189
 /*! cache: eviction walk restored position */
-#define	WT_STAT_CONN_EVICTION_RESTORED_POS		1187
+#define	WT_STAT_CONN_EVICTION_RESTORED_POS		1190
 /*! cache: eviction walk restored position differs from the saved one */
-#define	WT_STAT_CONN_EVICTION_RESTORED_POS_DIFFER	1188
+#define	WT_STAT_CONN_EVICTION_RESTORED_POS_DIFFER	1191
 /*! cache: eviction walk target pages histogram - 0-9 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT10	1189
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT10	1192
 /*! cache: eviction walk target pages histogram - 10-31 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT32	1190
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT32	1193
 /*! cache: eviction walk target pages histogram - 128 and higher */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_GE128	1191
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_GE128	1194
 /*! cache: eviction walk target pages histogram - 32-63 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT64	1192
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT64	1195
 /*! cache: eviction walk target pages histogram - 64-128 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT128	1193
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT128	1196
 /*!
  * cache: eviction walk target pages reduced due to history store cache
  * pressure
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_REDUCED	1194
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_REDUCED	1197
 /*! cache: eviction walk target strategy clean pages */
-#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_CLEAN	1195
+#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_CLEAN	1198
 /*! cache: eviction walk target strategy dirty pages */
-#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_DIRTY	1196
+#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_DIRTY	1199
 /*! cache: eviction walk target strategy pages with updates */
-#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_UPDATES	1197
+#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_UPDATES	1200
 /*! cache: eviction walks abandoned */
-#define	WT_STAT_CONN_EVICTION_WALKS_ABANDONED		1198
+#define	WT_STAT_CONN_EVICTION_WALKS_ABANDONED		1201
 /*! cache: eviction walks gave up because they restarted their walk twice */
-#define	WT_STAT_CONN_EVICTION_WALKS_STOPPED		1199
+#define	WT_STAT_CONN_EVICTION_WALKS_STOPPED		1202
 /*!
  * cache: eviction walks gave up because they saw too many pages and
  * found no candidates
  */
-#define	WT_STAT_CONN_EVICTION_WALKS_GAVE_UP_NO_TARGETS	1200
+#define	WT_STAT_CONN_EVICTION_WALKS_GAVE_UP_NO_TARGETS	1203
 /*!
  * cache: eviction walks gave up because they saw too many pages and
  * found too few candidates
  */
-#define	WT_STAT_CONN_EVICTION_WALKS_GAVE_UP_RATIO	1201
+#define	WT_STAT_CONN_EVICTION_WALKS_GAVE_UP_RATIO	1204
 /*!
  * cache: eviction walks random search fails to locate a page, results in
  * a null position
  */
-#define	WT_STAT_CONN_EVICTION_WALK_RANDOM_RETURNS_NULL_POSITION	1202
+#define	WT_STAT_CONN_EVICTION_WALK_RANDOM_RETURNS_NULL_POSITION	1205
 /*! cache: eviction walks reached end of tree */
-#define	WT_STAT_CONN_EVICTION_WALKS_ENDED		1203
+#define	WT_STAT_CONN_EVICTION_WALKS_ENDED		1206
 /*! cache: eviction walks restarted */
-#define	WT_STAT_CONN_EVICTION_WALK_RESTART		1204
+#define	WT_STAT_CONN_EVICTION_WALK_RESTART		1207
 /*! cache: eviction walks started from root of tree */
-#define	WT_STAT_CONN_EVICTION_WALK_FROM_ROOT		1205
+#define	WT_STAT_CONN_EVICTION_WALK_FROM_ROOT		1208
 /*! cache: eviction walks started from saved location in tree */
-#define	WT_STAT_CONN_EVICTION_WALK_SAVED_POS		1206
+#define	WT_STAT_CONN_EVICTION_WALK_SAVED_POS		1209
 /*! cache: eviction worker thread active */
-#define	WT_STAT_CONN_EVICTION_ACTIVE_WORKERS		1207
+#define	WT_STAT_CONN_EVICTION_ACTIVE_WORKERS		1210
 /*! cache: eviction worker thread stable number */
-#define	WT_STAT_CONN_EVICTION_STABLE_STATE_WORKERS	1208
+#define	WT_STAT_CONN_EVICTION_STABLE_STATE_WORKERS	1211
 /*! cache: files with active eviction walks */
-#define	WT_STAT_CONN_EVICTION_WALKS_ACTIVE		1209
+#define	WT_STAT_CONN_EVICTION_WALKS_ACTIVE		1212
 /*! cache: files with new eviction walks started */
-#define	WT_STAT_CONN_EVICTION_WALKS_STARTED		1210
+#define	WT_STAT_CONN_EVICTION_WALKS_STARTED		1213
 /*!
  * cache: forced eviction - do not retry count to evict pages selected to
  * evict during reconciliation
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_NO_RETRY		1211
+#define	WT_STAT_CONN_EVICTION_FORCE_NO_RETRY		1214
 /*!
  * cache: forced eviction - history store pages failed to evict while
  * session has history store cursor open
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_HS_FAIL		1212
+#define	WT_STAT_CONN_EVICTION_FORCE_HS_FAIL		1215
 /*!
  * cache: forced eviction - history store pages selected while session
  * has history store cursor open
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_HS			1213
+#define	WT_STAT_CONN_EVICTION_FORCE_HS			1216
 /*!
  * cache: forced eviction - history store pages successfully evicted
  * while session has history store cursor open
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_HS_SUCCESS		1214
+#define	WT_STAT_CONN_EVICTION_FORCE_HS_SUCCESS		1217
 /*!
  * cache: forced eviction - pages evicted belonging to ingest btrees
  * count
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_INGEST_SUCCESS	1215
+#define	WT_STAT_CONN_EVICTION_FORCE_INGEST_SUCCESS	1218
 /*! cache: forced eviction - pages evicted that were clean count */
-#define	WT_STAT_CONN_EVICTION_FORCE_CLEAN		1216
+#define	WT_STAT_CONN_EVICTION_FORCE_CLEAN		1219
 /*! cache: forced eviction - pages evicted that were dirty count */
-#define	WT_STAT_CONN_EVICTION_FORCE_DIRTY		1217
+#define	WT_STAT_CONN_EVICTION_FORCE_DIRTY		1220
 /*!
  * cache: forced eviction - pages selected because of a large number of
  * updates to a single item
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_LONG_UPDATE_LIST	1218
+#define	WT_STAT_CONN_EVICTION_FORCE_LONG_UPDATE_LIST	1221
 /*!
  * cache: forced eviction - pages selected because of too many deleted
  * items count
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_DELETE		1219
+#define	WT_STAT_CONN_EVICTION_FORCE_DELETE		1222
 /*!
  * cache: forced eviction - pages selected belonging to ingest btrees
  * unable to be evicted count
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_INGEST_FAIL		1220
+#define	WT_STAT_CONN_EVICTION_FORCE_INGEST_FAIL		1223
 /*! cache: forced eviction - pages selected count */
-#define	WT_STAT_CONN_EVICTION_FORCE			1221
+#define	WT_STAT_CONN_EVICTION_FORCE			1224
 /*! cache: forced eviction - pages selected unable to be evicted count */
-#define	WT_STAT_CONN_EVICTION_FORCE_FAIL		1222
+#define	WT_STAT_CONN_EVICTION_FORCE_FAIL		1225
 /*!
  * cache: garbage collection from the ingest btree page is skipped
  * because the prune timestamp has not moved
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_PRUNE_TIMESTAMP	1223
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_PRUNE_TIMESTAMP	1226
 /*! cache: hazard pointer blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_HAZARD	1224
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_HAZARD	1227
 /*! cache: hazard pointer check calls */
-#define	WT_STAT_CONN_CACHE_HAZARD_CHECKS		1225
+#define	WT_STAT_CONN_CACHE_HAZARD_CHECKS		1228
 /*! cache: hazard pointer check entries walked */
-#define	WT_STAT_CONN_CACHE_HAZARD_WALKS			1226
+#define	WT_STAT_CONN_CACHE_HAZARD_WALKS			1229
 /*! cache: hazard pointer maximum array length */
-#define	WT_STAT_CONN_CACHE_HAZARD_MAX			1227
+#define	WT_STAT_CONN_CACHE_HAZARD_MAX			1230
 /*! cache: history store cursor not cached during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_HS_CURSOR_NOT_CACHED	1228
+#define	WT_STAT_CONN_CACHE_EVICTION_HS_CURSOR_NOT_CACHED	1231
 /*! cache: history store table insert calls */
-#define	WT_STAT_CONN_CACHE_HS_INSERT			1229
+#define	WT_STAT_CONN_CACHE_HS_INSERT			1232
 /*! cache: history store table insert calls that returned restart */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_RESTART		1230
+#define	WT_STAT_CONN_CACHE_HS_INSERT_RESTART		1233
 /*! cache: history store table key to be processed */
-#define	WT_STAT_CONN_CACHE_HS_KEY_PROCESSED		1231
+#define	WT_STAT_CONN_CACHE_HS_KEY_PROCESSED		1234
 /*! cache: history store table max on-disk size */
-#define	WT_STAT_CONN_CACHE_HS_ONDISK_MAX		1232
+#define	WT_STAT_CONN_CACHE_HS_ONDISK_MAX		1235
 /*! cache: history store table on-disk size */
-#define	WT_STAT_CONN_CACHE_HS_ONDISK			1233
+#define	WT_STAT_CONN_CACHE_HS_ONDISK			1236
 /*! cache: history store table reads */
-#define	WT_STAT_CONN_CACHE_HS_READ			1234
+#define	WT_STAT_CONN_CACHE_HS_READ			1237
 /*! cache: history store table reads missed */
-#define	WT_STAT_CONN_CACHE_HS_READ_MISS			1235
+#define	WT_STAT_CONN_CACHE_HS_READ_MISS			1238
 /*! cache: history store table reads requiring squashed modifies */
-#define	WT_STAT_CONN_CACHE_HS_READ_SQUASH		1236
+#define	WT_STAT_CONN_CACHE_HS_READ_SQUASH		1239
 /*!
  * cache: history store table resolved updates without timestamps that
  * lose their durable timestamp
  */
-#define	WT_STAT_CONN_CACHE_HS_ORDER_LOSE_DURABLE_TIMESTAMP	1237
+#define	WT_STAT_CONN_CACHE_HS_ORDER_LOSE_DURABLE_TIMESTAMP	1240
 /*!
  * cache: history store table truncation by rollback to stable to remove
  * an unstable update
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE	1238
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE	1241
 /*!
  * cache: history store table truncation by rollback to stable to remove
  * an update
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS		1239
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS		1242
 /*!
  * cache: history store table truncation to remove all the keys of a
  * btree
  */
-#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE		1240
+#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE		1243
 /*! cache: history store table truncation to remove an update */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE		1241
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE		1244
 /*!
  * cache: history store table truncation to remove range of updates due
  * to an update without a timestamp on data page
  */
-#define	WT_STAT_CONN_CACHE_HS_ORDER_REMOVE		1242
+#define	WT_STAT_CONN_CACHE_HS_ORDER_REMOVE		1245
 /*!
  * cache: history store table truncation to remove range of updates due
  * to key being removed from the data page during reconciliation
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_ONPAGE_REMOVAL	1243
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_ONPAGE_REMOVAL	1246
 /*!
  * cache: history store table truncations that would have happened in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE_DRYRUN	1244
+#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE_DRYRUN	1247
 /*!
  * cache: history store table truncations to remove an unstable update
  * that would have happened in non-dryrun mode
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE_DRYRUN	1245
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE_DRYRUN	1248
 /*!
  * cache: history store table truncations to remove an update that would
  * have happened in non-dryrun mode
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_DRYRUN	1246
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_DRYRUN	1249
 /*! cache: history store table update to be processed */
-#define	WT_STAT_CONN_CACHE_HS_UPDATE_PROCESSED		1247
+#define	WT_STAT_CONN_CACHE_HS_UPDATE_PROCESSED		1250
 /*!
  * cache: history store table updates without timestamps fixed up by
  * reinserting with the fixed timestamp
  */
-#define	WT_STAT_CONN_CACHE_HS_ORDER_REINSERT		1248
+#define	WT_STAT_CONN_CACHE_HS_ORDER_REINSERT		1251
 /*! cache: history store table writes requiring squashed modifies */
-#define	WT_STAT_CONN_CACHE_HS_WRITE_SQUASH		1249
+#define	WT_STAT_CONN_CACHE_HS_WRITE_SQUASH		1252
 /*! cache: in-memory page passed criteria to be split */
-#define	WT_STAT_CONN_CACHE_INMEM_SPLITTABLE		1250
+#define	WT_STAT_CONN_CACHE_INMEM_SPLITTABLE		1253
 /*! cache: in-memory page splits */
-#define	WT_STAT_CONN_CACHE_INMEM_SPLIT			1251
+#define	WT_STAT_CONN_CACHE_INMEM_SPLIT			1254
 /*! cache: in-memory page splits performed on ingest btree pages */
-#define	WT_STAT_CONN_CACHE_INMEM_SPLIT_INGEST		1252
+#define	WT_STAT_CONN_CACHE_INMEM_SPLIT_INGEST		1255
 /*! cache: ingest pages evicted */
-#define	WT_STAT_CONN_EVICTION_INGEST_SUCCESS		1253
+#define	WT_STAT_CONN_EVICTION_INGEST_SUCCESS		1256
 /*! cache: internal page split blocked its eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_INTERNAL_PAGE_SPLIT	1254
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_INTERNAL_PAGE_SPLIT	1257
 /*! cache: internal pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL		1255
+#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL		1258
 /*! cache: internal pages queued for eviction */
-#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_QUEUED	1256
+#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_QUEUED	1259
 /*! cache: internal pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ_INTERNAL		1257
+#define	WT_STAT_CONN_CACHE_READ_INTERNAL		1260
 /*! cache: internal pages seen by eviction walk */
-#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_SEEN	1258
+#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_SEEN	1261
 /*! cache: internal pages seen by eviction walk that are already queued */
-#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_ALREADY_QUEUED	1259
+#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_ALREADY_QUEUED	1262
 /*! cache: internal pages split during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_INTERNAL	1260
+#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_INTERNAL	1263
 /*! cache: leaf pages currently held in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_INUSE_LEAF		1261
+#define	WT_STAT_CONN_CACHE_PAGES_INUSE_LEAF		1264
 /*! cache: leaf pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ_LEAF			1262
+#define	WT_STAT_CONN_CACHE_READ_LEAF			1265
 /*! cache: leaf pages split during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_LEAF		1263
+#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_LEAF		1266
 /*!
  * cache: locate a random in-mem ref by examining all entries on the root
  * page
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_RANDOM_SAMPLE_INMEM_ROOT	1264
+#define	WT_STAT_CONN_CACHE_EVICTION_RANDOM_SAMPLE_INMEM_ROOT	1267
 /*! cache: maximum bytes configured */
-#define	WT_STAT_CONN_CACHE_BYTES_MAX			1265
+#define	WT_STAT_CONN_CACHE_BYTES_MAX			1268
 /*! cache: maximum clean page size seen at eviction per checkpoint */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_CLEAN_PAGE_SIZE_PER_CHECKPOINT	1266
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_CLEAN_PAGE_SIZE_PER_CHECKPOINT	1269
 /*! cache: maximum dirty page size seen at eviction per checkpoint */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_DIRTY_PAGE_SIZE_PER_CHECKPOINT	1267
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_DIRTY_PAGE_SIZE_PER_CHECKPOINT	1270
 /*!
  * cache: maximum gap between unvisited page and connection evict pass
  * generation seen at eviction
  */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_UNVISITED_GEN_GAP	1268
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_UNVISITED_GEN_GAP	1271
 /*!
  * cache: maximum gap between unvisited page and connection evict pass
  * generation seen at eviction per checkpoint
  */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_UNVISITED_GEN_GAP_PER_CHECKPOINT	1269
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_UNVISITED_GEN_GAP_PER_CHECKPOINT	1272
 /*!
  * cache: maximum gap between visited page and connection evict pass
  * generation seen at eviction
  */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_VISITED_GEN_GAP	1270
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_VISITED_GEN_GAP	1273
 /*!
  * cache: maximum gap between visited page and connection evict pass
  * generation seen at eviction per checkpoint
  */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_VISITED_GEN_GAP_PER_CHECKPOINT	1271
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_VISITED_GEN_GAP_PER_CHECKPOINT	1274
 /*! cache: maximum milliseconds spent at a single eviction */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_MILLISECONDS	1272
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_MILLISECONDS	1275
 /*! cache: maximum milliseconds spent at a single eviction per checkpoint */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_MILLISECONDS_PER_CHECKPOINT	1273
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_MILLISECONDS_PER_CHECKPOINT	1276
 /*!
  * cache: maximum number of times a page tried to be added to eviction
  * queue but fail
  */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_ATTEMPTS_TO_QUEUE_PAGE	1274
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_ATTEMPTS_TO_QUEUE_PAGE	1277
 /*! cache: maximum number of times a page tried to be evicted */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_ATTEMPTS_TO_EVICT_PAGE	1275
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_ATTEMPTS_TO_EVICT_PAGE	1278
 /*! cache: maximum updates page size seen at eviction per checkpoint */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_UPDATES_PAGE_SIZE_PER_CHECKPOINT	1276
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_UPDATES_PAGE_SIZE_PER_CHECKPOINT	1279
 /*! cache: modified page evict attempts by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_DIRTY_ATTEMPT		1277
+#define	WT_STAT_CONN_EVICTION_APP_DIRTY_ATTEMPT		1280
 /*! cache: modified page evict failures by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_DIRTY_FAIL		1278
+#define	WT_STAT_CONN_EVICTION_APP_DIRTY_FAIL		1281
 /*! cache: modified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1279
+#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1282
 /*! cache: multi-block reconciliation blocked whilst checkpoint is running */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_MULTI_BLOCK_RECONCILIATION_DURING_CHECKPOINT	1280
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_MULTI_BLOCK_RECONCILIATION_DURING_CHECKPOINT	1283
 /*! cache: npos read - had to walk this many pages */
-#define	WT_STAT_CONN_NPOS_READ_WALK_MAX			1281
+#define	WT_STAT_CONN_NPOS_READ_WALK_MAX			1284
 /*! cache: number of internal pages read that had deltas attached */
-#define	WT_STAT_CONN_CACHE_READ_INTERNAL_DELTA		1282
+#define	WT_STAT_CONN_CACHE_READ_INTERNAL_DELTA		1285
 /*! cache: number of leaf pages read that had deltas attached */
-#define	WT_STAT_CONN_CACHE_READ_LEAF_DELTA		1283
+#define	WT_STAT_CONN_CACHE_READ_LEAF_DELTA		1286
 /*! cache: number of times dirty trigger was reached */
-#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_DIRTY_REACHED	1284
+#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_DIRTY_REACHED	1287
 /*! cache: number of times eviction trigger was reached */
-#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_REACHED	1285
+#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_REACHED	1288
 /*! cache: number of times updates trigger was reached */
-#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_UPDATES_REACHED	1286
+#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_UPDATES_REACHED	1289
 /*! cache: number of times when cas update the btree max_lsn failed */
-#define	WT_STAT_CONN_CACHE_CAS_BTREE_MAX_LSN_RACE	1287
+#define	WT_STAT_CONN_CACHE_CAS_BTREE_MAX_LSN_RACE	1290
 /*! cache: obsolete updates removed */
-#define	WT_STAT_CONN_CACHE_OBSOLETE_UPDATES_REMOVED	1288
+#define	WT_STAT_CONN_CACHE_OBSOLETE_UPDATES_REMOVED	1291
 /*! cache: operations timed out waiting for space in cache */
-#define	WT_STAT_CONN_EVICTION_TIMED_OUT_OPS		1289
+#define	WT_STAT_CONN_EVICTION_TIMED_OUT_OPS		1292
 /*!
  * cache: overflow keys on a multiblock row-store page blocked its
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_OVERFLOW_KEYS	1290
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_OVERFLOW_KEYS	1293
 /*! cache: overflow pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ_OVERFLOW		1291
+#define	WT_STAT_CONN_CACHE_READ_OVERFLOW		1294
 /*! cache: page evict attempts by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_ATTEMPT		1292
+#define	WT_STAT_CONN_EVICTION_APP_ATTEMPT		1295
 /*! cache: page evict failures by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_FAIL			1293
+#define	WT_STAT_CONN_EVICTION_APP_FAIL			1296
 /*! cache: page eviction blocked due to materialization frontier */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_MATERIALIZATION	1294
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_MATERIALIZATION	1297
 /*!
  * cache: page eviction blocked in disaggregated storage as it can only
  * be written by the next checkpoint
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_DISAGG_NEXT_CHECKPOINT	1295
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_DISAGG_NEXT_CHECKPOINT	1298
 /*! cache: page split during eviction deepened the tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1296
+#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1299
 /*! cache: page written requiring history store records */
-#define	WT_STAT_CONN_CACHE_WRITE_HS			1297
+#define	WT_STAT_CONN_CACHE_WRITE_HS			1300
 /*! cache: pages already in queue when topping up */
-#define	WT_STAT_CONN_EVICTION_PAGES_REMAINING_IN_QUEUE	1298
+#define	WT_STAT_CONN_EVICTION_PAGES_REMAINING_IN_QUEUE	1301
 /*! cache: pages considered for eviction that were brought in by pre-fetch */
-#define	WT_STAT_CONN_EVICTION_CONSIDER_PREFETCH		1299
+#define	WT_STAT_CONN_EVICTION_CONSIDER_PREFETCH		1302
 /*! cache: pages currently held in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_INUSE			1300
+#define	WT_STAT_CONN_CACHE_PAGES_INUSE			1303
 /*! cache: pages currently held in the cache from the ingest btrees */
-#define	WT_STAT_CONN_CACHE_PAGES_INUSE_INGEST		1301
+#define	WT_STAT_CONN_CACHE_PAGES_INUSE_INGEST		1304
 /*! cache: pages currently held in the cache from the stable btrees */
-#define	WT_STAT_CONN_CACHE_PAGES_INUSE_STABLE		1302
+#define	WT_STAT_CONN_CACHE_PAGES_INUSE_STABLE		1305
 /*! cache: pages dirtied due to obsolete time window by eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY_OBSOLETE_TW	1303
+#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY_OBSOLETE_TW	1306
 /*! cache: pages evicted ahead of the page materialization frontier */
-#define	WT_STAT_CONN_CACHE_EVICTION_AHEAD_OF_LAST_MATERIALIZED_LSN	1304
+#define	WT_STAT_CONN_CACHE_EVICTION_AHEAD_OF_LAST_MATERIALIZED_LSN	1307
 /*! cache: pages evicted in parallel with checkpoint */
-#define	WT_STAT_CONN_EVICTION_PAGES_IN_PARALLEL_WITH_CHECKPOINT	1305
+#define	WT_STAT_CONN_EVICTION_PAGES_IN_PARALLEL_WITH_CHECKPOINT	1308
 /*! cache: pages queued for eviction */
-#define	WT_STAT_CONN_EVICTION_PAGES_ORDINARY_QUEUED	1306
+#define	WT_STAT_CONN_EVICTION_PAGES_ORDINARY_QUEUED	1309
 /*! cache: pages queued for eviction post lru sorting */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_POST_LRU	1307
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_POST_LRU	1310
 /*! cache: pages queued for urgent eviction */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT	1308
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT	1311
 /*! cache: pages queued for urgent eviction during walk */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_OLDEST	1309
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_OLDEST	1312
 /*!
  * cache: pages queued for urgent eviction from history store due to high
  * dirty content
  */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT_HS_DIRTY	1310
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT_HS_DIRTY	1313
 /*! cache: pages read into cache after truncate */
-#define	WT_STAT_CONN_CACHE_READ_DELETED			1311
+#define	WT_STAT_CONN_CACHE_READ_DELETED			1314
 /*! cache: pages read into cache after truncate in prepare state */
-#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1312
+#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1315
 /*! cache: pages read into cache by checkpoint */
-#define	WT_STAT_CONN_CACHE_READ_CHECKPOINT		1313
+#define	WT_STAT_CONN_CACHE_READ_CHECKPOINT		1316
 /*!
  * cache: pages removed from the ordinary queue to be queued for urgent
  * eviction
  */
-#define	WT_STAT_CONN_EVICTION_CLEAR_ORDINARY		1314
+#define	WT_STAT_CONN_EVICTION_CLEAR_ORDINARY		1317
 /*! cache: pages requested from the cache due to pre-fetch */
-#define	WT_STAT_CONN_CACHE_PAGES_PREFETCH		1315
+#define	WT_STAT_CONN_CACHE_PAGES_PREFETCH		1318
 /*! cache: pages requested from the cache internal */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_INTERNAL	1316
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_INTERNAL	1319
 /*! cache: pages requested from the cache leaf */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_LEAF		1317
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_LEAF		1320
 /*! cache: pages requested from the history store */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_HS		1318
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_HS		1321
 /*! cache: pages seen by eviction walk */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1319
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1322
 /*! cache: pages seen by eviction walk that are already queued */
-#define	WT_STAT_CONN_EVICTION_PAGES_ALREADY_QUEUED	1320
+#define	WT_STAT_CONN_EVICTION_PAGES_ALREADY_QUEUED	1323
 /*! cache: pages selected for eviction unable to be evicted */
-#define	WT_STAT_CONN_EVICTION_FAIL			1321
+#define	WT_STAT_CONN_EVICTION_FAIL			1324
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * active children on an internal page
  */
-#define	WT_STAT_CONN_EVICTION_FAIL_ACTIVE_CHILDREN_ON_AN_INTERNAL_PAGE	1322
+#define	WT_STAT_CONN_EVICTION_FAIL_ACTIVE_CHILDREN_ON_AN_INTERNAL_PAGE	1325
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * failure in reconciliation
  */
-#define	WT_STAT_CONN_EVICTION_FAIL_IN_RECONCILIATION	1323
+#define	WT_STAT_CONN_EVICTION_FAIL_IN_RECONCILIATION	1326
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * race between checkpoint and updates without timestamps
  */
-#define	WT_STAT_CONN_EVICTION_FAIL_CHECKPOINT_NO_TS	1324
+#define	WT_STAT_CONN_EVICTION_FAIL_CHECKPOINT_NO_TS	1327
 /*!
  * cache: pages selected for eviction unable to be evicted belonging to
  * ingest btrees
  */
-#define	WT_STAT_CONN_EVICTION_FAIL_INGEST		1325
+#define	WT_STAT_CONN_EVICTION_FAIL_INGEST		1328
 /*! cache: pages walked for eviction */
-#define	WT_STAT_CONN_EVICTION_WALK			1326
+#define	WT_STAT_CONN_EVICTION_WALK			1329
 /*!
  * cache: pages with an unresolved multiblock split flagged by checkpoint
  * to be evicted soon
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_MULTIBLOCK_CHECKPOINT_FLAGGED	1327
+#define	WT_STAT_CONN_CACHE_EVICTION_MULTIBLOCK_CHECKPOINT_FLAGGED	1330
 /*!
  * cache: pages with an unresolved multiblock split re-reconciled by
  * checkpoint
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_MULTIBLOCK_SPLIT_RE_RECONCILED	1328
+#define	WT_STAT_CONN_CACHE_EVICTION_MULTIBLOCK_SPLIT_RE_RECONCILED	1331
 /*! cache: pages written from cache */
-#define	WT_STAT_CONN_CACHE_WRITE			1329
+#define	WT_STAT_CONN_CACHE_WRITE			1332
 /*!
  * cache: pages written requiring in-memory restoration due to invisible
  * updates
  */
-#define	WT_STAT_CONN_CACHE_WRITE_RESTORE_INVISIBLE	1330
+#define	WT_STAT_CONN_CACHE_WRITE_RESTORE_INVISIBLE	1333
 /*!
  * cache: pages written requiring in-memory restoration due to scrub
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_WRITE_RESTORE_SCRUB		1331
+#define	WT_STAT_CONN_CACHE_WRITE_RESTORE_SCRUB		1334
 /*! cache: percentage overhead */
-#define	WT_STAT_CONN_CACHE_OVERHEAD			1332
+#define	WT_STAT_CONN_CACHE_OVERHEAD			1335
 /*!
  * cache: precise checkpoint caused an eviction to be skipped because any
  * dirty content needs to remain in cache
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_PRECISE_CHECKPOINT	1333
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_PRECISE_CHECKPOINT	1336
 /*!
  * cache: realizing in-memory split after reconciliation failed due to
  * internal lock busy
  */
-#define	WT_STAT_CONN_CACHE_EVICT_SPLIT_FAILED_LOCK	1334
+#define	WT_STAT_CONN_CACHE_EVICT_SPLIT_FAILED_LOCK	1337
 /*! cache: recent modification of a page blocked its eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	1335
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	1338
 /*! cache: reconciled pages scrubbed and added back to the cache clean */
-#define	WT_STAT_CONN_CACHE_SCRUB_RESTORE		1336
+#define	WT_STAT_CONN_CACHE_SCRUB_RESTORE		1339
 /*! cache: reverse splits performed */
-#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS		1337
+#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS		1340
 /*!
  * cache: reverse splits skipped because of VLCS namespace gap
  * restrictions
  */
-#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	1338
+#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	1341
 /*! cache: shared disk hash table size */
-#define	WT_STAT_CONN_CACHE_SHARED_DSK_HASH_SIZE		1339
+#define	WT_STAT_CONN_CACHE_SHARED_DSK_HASH_SIZE		1342
 /*! cache: shared disk hit */
-#define	WT_STAT_CONN_CACHE_SHARED_DSK_HIT		1340
+#define	WT_STAT_CONN_CACHE_SHARED_DSK_HIT		1343
 /*! cache: shared disk miss */
-#define	WT_STAT_CONN_CACHE_SHARED_DSK_MISS		1341
+#define	WT_STAT_CONN_CACHE_SHARED_DSK_MISS		1344
 /*! cache: shared history store cursor not cached during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_HS_SHARED_CURSOR_NOT_CACHED	1342
+#define	WT_STAT_CONN_CACHE_EVICTION_HS_SHARED_CURSOR_NOT_CACHED	1345
 /*! cache: size of delta updates reconstructed on the base page */
-#define	WT_STAT_CONN_CACHE_READ_DELTA_UPDATES		1343
+#define	WT_STAT_CONN_CACHE_READ_DELTA_UPDATES		1346
 /*! cache: size of tombstones restored when reading a page */
-#define	WT_STAT_CONN_CACHE_READ_RESTORED_TOMBSTONE_BYTES	1344
+#define	WT_STAT_CONN_CACHE_READ_RESTORED_TOMBSTONE_BYTES	1347
 /*! cache: the number of times full update inserted to history store */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1345
+#define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1348
 /*! cache: the number of times reverse modify inserted to history store */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1346
+#define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1349
 /*! cache: time eviction worker threads spend waiting for locks (usecs) */
-#define	WT_STAT_CONN_EVICTION_WORKER_LOCK_WAIT_TIME	1347
+#define	WT_STAT_CONN_EVICTION_WORKER_LOCK_WAIT_TIME	1350
 /*!
  * cache: total milliseconds spent inside reentrant history store
  * evictions in a reconciliation
  */
-#define	WT_STAT_CONN_EVICTION_REENTRY_HS_EVICTION_MILLISECONDS	1348
+#define	WT_STAT_CONN_EVICTION_REENTRY_HS_EVICTION_MILLISECONDS	1351
 /*! cache: tracked bytes belonging to internal pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1349
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1352
 /*!
  * cache: tracked bytes belonging to internal pages in the cache from the
  * ingest btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL_INGEST	1350
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL_INGEST	1353
 /*!
  * cache: tracked bytes belonging to internal pages in the cache from the
  * stable btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL_STABLE	1351
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL_STABLE	1354
 /*! cache: tracked bytes belonging to leaf pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1352
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1355
 /*!
  * cache: tracked bytes belonging to leaf pages in the cache from the
  * ingest btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF_INGEST		1353
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF_INGEST		1356
 /*!
  * cache: tracked bytes belonging to leaf pages in the cache from the
  * stable btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF_STABLE		1354
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF_STABLE		1357
 /*! cache: tracked dirty bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1355
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1358
 /*! cache: tracked dirty bytes in the cache from the ingest btrees */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INGEST		1356
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INGEST		1359
 /*! cache: tracked dirty bytes in the cache from the stable btrees */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_STABLE		1357
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_STABLE		1360
 /*! cache: tracked dirty internal page bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL		1358
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL		1361
 /*!
  * cache: tracked dirty internal page bytes in the cache from the ingest
  * btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL_INGEST	1359
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL_INGEST	1362
 /*!
  * cache: tracked dirty internal page bytes in the cache from the stable
  * btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL_STABLE	1360
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL_STABLE	1363
 /*! cache: tracked dirty leaf page bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF		1361
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF		1364
 /*!
  * cache: tracked dirty leaf page bytes in the cache from the ingest
  * btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF_INGEST	1362
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF_INGEST	1365
 /*!
  * cache: tracked dirty leaf page bytes in the cache from the stable
  * btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF_STABLE	1363
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF_STABLE	1366
 /*! cache: tracked dirty pages in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1364
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1367
 /*! cache: tracked dirty pages in the cache from the ingest btrees */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY_INGEST		1365
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY_INGEST		1368
 /*! cache: tracked dirty pages in the cache from the stable btrees */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY_STABLE		1366
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY_STABLE		1369
 /*! cache: uncommitted truncate blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	1367
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	1370
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1368
+#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1371
 /*! cache: update bytes belonging to the history store table in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_HS_UPDATES		1369
+#define	WT_STAT_CONN_CACHE_BYTES_HS_UPDATES		1372
 /*! cache: updates in uncommitted txn - bytes */
-#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_BYTES	1370
+#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_BYTES	1373
 /*! cache: updates in uncommitted txn - count */
-#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_COUNT	1371
+#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_COUNT	1374
 /*! capacity: background fsync file handles considered */
-#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1372
+#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1375
 /*! capacity: background fsync file handles synced */
-#define	WT_STAT_CONN_FSYNC_ALL_FH			1373
+#define	WT_STAT_CONN_FSYNC_ALL_FH			1376
 /*! capacity: background fsync time (msecs) */
-#define	WT_STAT_CONN_FSYNC_ALL_TIME			1374
+#define	WT_STAT_CONN_FSYNC_ALL_TIME			1377
 /*! capacity: bytes read */
-#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1375
+#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1378
 /*! capacity: bytes written for checkpoint */
-#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1376
+#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1379
 /*! capacity: bytes written for eviction */
-#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1377
+#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1380
 /*! capacity: bytes written for log */
-#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1378
+#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1381
 /*! capacity: bytes written total */
-#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1379
+#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1382
 /*! capacity: threshold to call fsync */
-#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1380
+#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1383
 /*! capacity: time waiting due to total capacity (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1381
+#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1384
 /*! capacity: time waiting during checkpoint (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1382
+#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1385
 /*! capacity: time waiting during eviction (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1383
+#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1386
 /*! capacity: time waiting during logging (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1384
+#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1387
 /*! capacity: time waiting during read (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_READ			1385
+#define	WT_STAT_CONN_CAPACITY_TIME_READ			1388
 /*! checkpoint-cleanup: most recent duration on all eligible files (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_DURATION	1386
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_DURATION	1389
 /*! checkpoint-cleanup: most recent handles processed */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_HANDLE_PROCESSED	1387
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_HANDLE_PROCESSED	1390
 /*! checkpoint-cleanup: most recent in-memory pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_INMEM_PAGES_VISITED	1388
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_INMEM_PAGES_VISITED	1391
 /*! checkpoint-cleanup: pages added for eviction */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_EVICT	1389
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_EVICT	1392
 /*! checkpoint-cleanup: pages dirtied due to obsolete time window */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	1390
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	1393
 /*! checkpoint-cleanup: pages read into cache (reclaim_space) */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	1391
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	1394
 /*! checkpoint-cleanup: pages read into cache due to obsolete time window */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	1392
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	1395
 /*! checkpoint-cleanup: pages removed */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_REMOVED	1393
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_REMOVED	1396
 /*! checkpoint-cleanup: pages skipped during tree walk */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	1394
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	1397
 /*! checkpoint-cleanup: pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_VISITED	1395
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_VISITED	1398
 /*! checkpoint-cleanup: successful calls */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_SUCCESS		1396
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_SUCCESS		1399
 /*! checkpoint: checkpoint has acquired a snapshot for its transaction */
-#define	WT_STAT_CONN_CHECKPOINT_SNAPSHOT_ACQUIRED	1397
+#define	WT_STAT_CONN_CHECKPOINT_SNAPSHOT_ACQUIRED	1400
 /*! checkpoint: checkpoints skipped because database was clean */
-#define	WT_STAT_CONN_CHECKPOINT_SKIPPED			1398
+#define	WT_STAT_CONN_CHECKPOINT_SKIPPED			1401
 /*! checkpoint: fsync calls after allocating the transaction ID */
-#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST		1399
+#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST		1402
 /*! checkpoint: fsync duration after allocating the transaction ID (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST_DURATION	1400
+#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST_DURATION	1403
 /*! checkpoint: generation */
-#define	WT_STAT_CONN_CHECKPOINT_GENERATION		1401
+#define	WT_STAT_CONN_CHECKPOINT_GENERATION		1404
 /*! checkpoint: max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_MAX		1402
+#define	WT_STAT_CONN_CHECKPOINT_TIME_MAX		1405
 /*!
  * checkpoint: metadata operations applied during disaggregated
  * checkpoint
  */
-#define	WT_STAT_CONN_CHECKPOINT_DISAGG_METADATA_APPLY	1403
+#define	WT_STAT_CONN_CHECKPOINT_DISAGG_METADATA_APPLY	1406
 /*!
  * checkpoint: metadata operations skipped during disaggregated
  * checkpoint because they were not stable
  */
-#define	WT_STAT_CONN_CHECKPOINT_DISAGG_METADATA_UNSTABLE	1404
+#define	WT_STAT_CONN_CHECKPOINT_DISAGG_METADATA_UNSTABLE	1407
 /*! checkpoint: min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_MIN		1405
+#define	WT_STAT_CONN_CHECKPOINT_TIME_MIN		1408
 /*!
  * checkpoint: most recent duration for checkpoint dropping all handles
  * (usecs)
  */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROP_DURATION	1406
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROP_DURATION	1409
 /*! checkpoint: most recent duration for gathering all handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION		1407
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION		1410
 /*! checkpoint: most recent duration for gathering applied handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLY_DURATION	1408
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLY_DURATION	1411
 /*! checkpoint: most recent duration for gathering skipped handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIP_DURATION	1409
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIP_DURATION	1412
 /*! checkpoint: most recent duration for handles metadata checked (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECK_DURATION	1410
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECK_DURATION	1413
 /*! checkpoint: most recent duration for locking the handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCK_DURATION	1411
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCK_DURATION	1414
 /*! checkpoint: most recent handles applied */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLIED		1412
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLIED		1415
 /*! checkpoint: most recent handles checkpoint dropped */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROPPED		1413
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROPPED		1416
 /*! checkpoint: most recent handles metadata checked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECKED	1414
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECKED	1417
 /*! checkpoint: most recent handles metadata locked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCKED		1415
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCKED		1418
 /*! checkpoint: most recent handles skipped */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIPPED		1416
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIPPED		1419
 /*! checkpoint: most recent handles walked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_WALKED		1417
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_WALKED		1420
 /*! checkpoint: most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_RECENT		1418
+#define	WT_STAT_CONN_CHECKPOINT_TIME_RECENT		1421
 /*! checkpoint: number of bytes reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED_BYTES	1419
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED_BYTES	1422
 /*! checkpoint: number of checkpoints started by api */
-#define	WT_STAT_CONN_CHECKPOINTS_API			1420
+#define	WT_STAT_CONN_CHECKPOINTS_API			1423
 /*! checkpoint: number of checkpoints started by compaction */
-#define	WT_STAT_CONN_CHECKPOINTS_COMPACT		1421
+#define	WT_STAT_CONN_CHECKPOINTS_COMPACT		1424
 /*! checkpoint: number of files synced */
-#define	WT_STAT_CONN_CHECKPOINT_SYNC			1422
+#define	WT_STAT_CONN_CHECKPOINT_SYNC			1425
 /*! checkpoint: number of handles visited after writes complete */
-#define	WT_STAT_CONN_CHECKPOINT_PRESYNC			1423
+#define	WT_STAT_CONN_CHECKPOINT_PRESYNC			1426
 /*! checkpoint: number of history store pages reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_HS_PAGES_RECONCILED	1424
+#define	WT_STAT_CONN_CHECKPOINT_HS_PAGES_RECONCILED	1427
 /*! checkpoint: number of internal pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_INTERNAL	1425
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_INTERNAL	1428
 /*! checkpoint: number of leaf pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_LEAF	1426
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_LEAF	1429
 /*! checkpoint: number of pages reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED	1427
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED	1430
 /*!
  * checkpoint: number of pages reconciled by checkpoint parallel worker
  * threads
  */
-#define	WT_STAT_CONN_CHECKPOINT_PARALLEL_PAGES_RECONCILED	1428
+#define	WT_STAT_CONN_CHECKPOINT_PARALLEL_PAGES_RECONCILED	1431
 /*! checkpoint: prepare currently running */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1429
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1432
 /*! checkpoint: prepare max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1430
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1433
 /*! checkpoint: prepare min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1431
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1434
 /*! checkpoint: prepare most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1432
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1435
 /*! checkpoint: prepare total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1433
+#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1436
 /*! checkpoint: progress state */
-#define	WT_STAT_CONN_CHECKPOINT_STATE			1434
+#define	WT_STAT_CONN_CHECKPOINT_STATE			1437
 /*! checkpoint: scrub dirty target */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1435
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1438
 /*! checkpoint: scrub max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1436
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1439
 /*! checkpoint: scrub min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1437
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1440
 /*! checkpoint: scrub most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1438
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1441
 /*! checkpoint: scrub total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1439
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1442
 /*! checkpoint: stop timing stress active */
-#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1440
+#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1443
 /*!
  * checkpoint: the percentage of checkpoint sync time spent in
  * reconciliation across all threads
  */
-#define	WT_STAT_CONN_CHECKPOINT_SYNC_REC_PCT		1441
+#define	WT_STAT_CONN_CHECKPOINT_SYNC_REC_PCT		1444
 /*! checkpoint: time spent on per-tree checkpoint work (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1442
+#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1445
 /*! checkpoint: total failed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1443
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1446
 /*! checkpoint: total succeed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1444
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1447
 /*! checkpoint: total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1445
+#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1448
 /*!
  * checkpoint: total time (msecs) writing pages to stable storage during
  * checkpoint reconciliation
  */
-#define	WT_STAT_CONN_CHECKPOINT_REC_BLKCACHE_WRITE	1446
+#define	WT_STAT_CONN_CHECKPOINT_REC_BLKCACHE_WRITE	1449
 /*! checkpoint: wait cycles while cache dirty level is decreasing */
-#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1447
+#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1450
 /*! connection: auto adjusting condition resets */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1448
+#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1451
 /*! connection: auto adjusting condition wait calls */
-#define	WT_STAT_CONN_COND_AUTO_WAIT			1449
+#define	WT_STAT_CONN_COND_AUTO_WAIT			1452
 /*!
  * connection: auto adjusting condition wait raced to update timeout and
  * skipped updating
  */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1450
+#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1453
 /*! connection: btrees currently open */
-#define	WT_STAT_CONN_BTREE_OPEN				1451
+#define	WT_STAT_CONN_BTREE_OPEN				1454
 /*! connection: detected system time went backwards */
-#define	WT_STAT_CONN_TIME_TRAVEL			1452
+#define	WT_STAT_CONN_TIME_TRAVEL			1455
 /*! connection: files currently open */
-#define	WT_STAT_CONN_FILE_OPEN				1453
+#define	WT_STAT_CONN_FILE_OPEN				1456
 /*! connection: hash bucket array size for data handles */
-#define	WT_STAT_CONN_BUCKETS_DH				1454
+#define	WT_STAT_CONN_BUCKETS_DH				1457
 /*! connection: hash bucket array size general */
-#define	WT_STAT_CONN_BUCKETS				1455
+#define	WT_STAT_CONN_BUCKETS				1458
 /*! connection: memory allocations */
-#define	WT_STAT_CONN_MEMORY_ALLOCATION			1456
+#define	WT_STAT_CONN_MEMORY_ALLOCATION			1459
 /*! connection: memory frees */
-#define	WT_STAT_CONN_MEMORY_FREE			1457
+#define	WT_STAT_CONN_MEMORY_FREE			1460
 /*! connection: memory re-allocations */
-#define	WT_STAT_CONN_MEMORY_GROW			1458
+#define	WT_STAT_CONN_MEMORY_GROW			1461
 /*! connection: number of sessions without a sweep for 5+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1459
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1462
 /*! connection: number of sessions without a sweep for 60+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1460
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1463
 /*! connection: pthread mutex condition wait calls */
-#define	WT_STAT_CONN_COND_WAIT				1461
+#define	WT_STAT_CONN_COND_WAIT				1464
 /*! connection: pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			1462
+#define	WT_STAT_CONN_RWLOCK_READ			1465
 /*! connection: pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			1463
+#define	WT_STAT_CONN_RWLOCK_WRITE			1466
 /*! connection: total fsync I/Os */
-#define	WT_STAT_CONN_FSYNC_IO				1464
+#define	WT_STAT_CONN_FSYNC_IO				1467
 /*! connection: total read I/Os */
-#define	WT_STAT_CONN_READ_IO				1465
+#define	WT_STAT_CONN_READ_IO				1468
 /*! connection: total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				1466
+#define	WT_STAT_CONN_WRITE_IO				1469
 /*! cursor: Total number of deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1467
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1470
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1468
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1471
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1469
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1472
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1470
+#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1473
 /*!
  * cursor: Total number of in-memory deleted pages skipped during tree
  * walk
  */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1471
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1474
 /*! cursor: Total number of on-disk deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1472
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1475
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1473
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1476
 /*!
  * cursor: Total number of times cursor fails to temporarily release
  * pinned page to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1474
+#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1477
 /*!
  * cursor: Total number of times cursor temporarily releases pinned page
  * to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION			1475
+#define	WT_STAT_CONN_CURSOR_REPOSITION			1478
 /*! cursor: bulk cursor count */
-#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1476
+#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1479
 /*! cursor: cached cursor count */
-#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1477
+#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1480
 /*! cursor: cursor bound calls that return an error */
-#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1478
+#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1481
 /*! cursor: cursor bounds cleared from reset */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1479
+#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1482
 /*! cursor: cursor bounds comparisons performed */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1480
+#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1483
 /*! cursor: cursor bounds next called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1481
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1484
 /*! cursor: cursor bounds next early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1482
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1485
 /*! cursor: cursor bounds prev called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1483
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1486
 /*! cursor: cursor bounds prev early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1484
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1487
 /*! cursor: cursor bounds search early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1485
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1488
 /*! cursor: cursor bounds search near call repositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1486
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1489
 /*! cursor: cursor bulk loaded cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1487
+#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1490
 /*! cursor: cursor cache calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1488
+#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1491
 /*! cursor: cursor close calls that result in cache */
-#define	WT_STAT_CONN_CURSOR_CACHE			1489
+#define	WT_STAT_CONN_CURSOR_CACHE			1492
 /*! cursor: cursor close calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1490
+#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1493
 /*! cursor: cursor compare calls that return an error */
-#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1491
+#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1494
 /*! cursor: cursor create calls */
-#define	WT_STAT_CONN_CURSOR_CREATE			1492
+#define	WT_STAT_CONN_CURSOR_CREATE			1495
 /*! cursor: cursor equals calls that return an error */
-#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1493
+#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1496
 /*! cursor: cursor get key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1494
+#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1497
 /*! cursor: cursor get value calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1495
+#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1498
 /*! cursor: cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT			1496
+#define	WT_STAT_CONN_CURSOR_INSERT			1499
 /*! cursor: cursor insert calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1497
+#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1500
 /*! cursor: cursor insert check calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1498
+#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1501
 /*! cursor: cursor insert key and value bytes */
-#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1499
+#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1502
 /*! cursor: cursor largest key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1500
+#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1503
 /*! cursor: cursor modify calls */
-#define	WT_STAT_CONN_CURSOR_MODIFY			1501
+#define	WT_STAT_CONN_CURSOR_MODIFY			1504
 /*! cursor: cursor modify calls that return an error */
-#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1502
+#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1505
 /*! cursor: cursor modify key and value bytes affected */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1503
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1506
 /*! cursor: cursor modify value bytes modified */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1504
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1507
 /*! cursor: cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT			1505
+#define	WT_STAT_CONN_CURSOR_NEXT			1508
 /*! cursor: cursor next calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1506
+#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1509
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1507
+#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1510
 /*!
  * cursor: cursor next calls that skip greater than 1 and fewer than 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1508
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1511
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1509
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1512
 /*! cursor: cursor next random calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1510
+#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1513
 /*! cursor: cursor operation restarted */
-#define	WT_STAT_CONN_CURSOR_RESTART			1511
+#define	WT_STAT_CONN_CURSOR_RESTART			1514
 /*! cursor: cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV			1512
+#define	WT_STAT_CONN_CURSOR_PREV			1515
 /*! cursor: cursor prev calls that return an error */
-#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1513
+#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1516
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1514
+#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1517
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1515
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1518
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1516
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1519
 /*! cursor: cursor reconfigure calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1517
+#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1520
 /*! cursor: cursor remove calls */
-#define	WT_STAT_CONN_CURSOR_REMOVE			1518
+#define	WT_STAT_CONN_CURSOR_REMOVE			1521
 /*! cursor: cursor remove calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1519
+#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1522
 /*! cursor: cursor remove key bytes removed */
-#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1520
+#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1523
 /*! cursor: cursor reopen calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1521
+#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1524
 /*! cursor: cursor reserve calls */
-#define	WT_STAT_CONN_CURSOR_RESERVE			1522
+#define	WT_STAT_CONN_CURSOR_RESERVE			1525
 /*! cursor: cursor reserve calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1523
+#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1526
 /*! cursor: cursor reset calls */
-#define	WT_STAT_CONN_CURSOR_RESET			1524
+#define	WT_STAT_CONN_CURSOR_RESET			1527
 /*! cursor: cursor reset calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1525
+#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1528
 /*! cursor: cursor search calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH			1526
+#define	WT_STAT_CONN_CURSOR_SEARCH			1529
 /*! cursor: cursor search calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1527
+#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1530
 /*! cursor: cursor search history store calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1528
+#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1531
 /*! cursor: cursor search near calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1529
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1532
 /*! cursor: cursor search near calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1530
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1533
 /*! cursor: cursor sweep buckets */
-#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1531
+#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1534
 /*! cursor: cursor sweep cursors closed */
-#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1532
+#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1535
 /*! cursor: cursor sweep cursors examined */
-#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1533
+#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1536
 /*! cursor: cursor sweeps */
-#define	WT_STAT_CONN_CURSOR_SWEEP			1534
+#define	WT_STAT_CONN_CURSOR_SWEEP			1537
 /*! cursor: cursor truncate calls */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE			1535
+#define	WT_STAT_CONN_CURSOR_TRUNCATE			1538
 /*! cursor: cursor truncates performed on individual keys */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1536
+#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1539
 /*! cursor: cursor update calls */
-#define	WT_STAT_CONN_CURSOR_UPDATE			1537
+#define	WT_STAT_CONN_CURSOR_UPDATE			1540
 /*! cursor: cursor update calls that return an error */
-#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1538
+#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1541
 /*! cursor: cursor update key and value bytes */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1539
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1542
 /*! cursor: cursor update value size change */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1540
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1543
 /*! cursor: cursors reused from cache */
-#define	WT_STAT_CONN_CURSOR_REOPEN			1541
+#define	WT_STAT_CONN_CURSOR_REOPEN			1544
 /*! cursor: open cursor count */
-#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1542
+#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1545
 /*! cursor: open cursor time application (usecs) */
-#define	WT_STAT_CONN_CURSOR_OPEN_TIME_USER_USECS	1543
+#define	WT_STAT_CONN_CURSOR_OPEN_TIME_USER_USECS	1546
 /*! cursor: open cursor time internal (usecs) */
-#define	WT_STAT_CONN_CURSOR_OPEN_TIME_INTERNAL_USECS	1544
+#define	WT_STAT_CONN_CURSOR_OPEN_TIME_INTERNAL_USECS	1547
 /*! data-handle: Layered connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_LAYERED_COUNT	1545
+#define	WT_STAT_CONN_DH_CONN_HANDLE_LAYERED_COUNT	1548
 /*! data-handle: Table connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TABLE_COUNT		1546
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TABLE_COUNT		1549
 /*! data-handle: Tiered connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_COUNT	1547
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_COUNT	1550
 /*! data-handle: Tiered_Tree connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_TREE_COUNT	1548
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_TREE_COUNT	1551
 /*! data-handle: btree connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_BTREE_COUNT		1549
+#define	WT_STAT_CONN_DH_CONN_HANDLE_BTREE_COUNT		1552
 /*! data-handle: checkpoint connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_CHECKPOINT_COUNT	1550
+#define	WT_STAT_CONN_DH_CONN_HANDLE_CHECKPOINT_COUNT	1553
 /*! data-handle: connection data handle size */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1551
+#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1554
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1552
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1555
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1553
+#define	WT_STAT_CONN_DH_SWEEP_REF			1556
 /*! data-handle: connection sweep dead dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_DEAD_CLOSE		1554
+#define	WT_STAT_CONN_DH_SWEEP_DEAD_CLOSE		1557
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1555
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1558
 /*! data-handle: connection sweep expired dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_EXPIRED_CLOSE		1556
+#define	WT_STAT_CONN_DH_SWEEP_EXPIRED_CLOSE		1559
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1557
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1560
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1558
+#define	WT_STAT_CONN_DH_SWEEPS				1561
 /*!
  * data-handle: connection sweeps skipped due to checkpoint gathering
  * handles
  */
-#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1559
+#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1562
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1560
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1563
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1561
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1564
 /*! disagg: abandon checkpoints failed */
-#define	WT_STAT_CONN_DISAGG_ABANDON_CHECKPOINT_FAILED	1562
+#define	WT_STAT_CONN_DISAGG_ABANDON_CHECKPOINT_FAILED	1565
 /*! disagg: abandon checkpoints succeeded */
-#define	WT_STAT_CONN_DISAGG_ABANDON_CHECKPOINT_SUCCEED	1563
+#define	WT_STAT_CONN_DISAGG_ABANDON_CHECKPOINT_SUCCEED	1566
 /*! disagg: apply checkpoint metadata most recent time (msecs) */
-#define	WT_STAT_CONN_DISAGG_APPLY_CHECKPOINT_META_TIME	1564
+#define	WT_STAT_CONN_DISAGG_APPLY_CHECKPOINT_META_TIME	1567
 /*! disagg: connection reconfiguration */
-#define	WT_STAT_CONN_DISAGG_CONN_RECONFIG		1565
+#define	WT_STAT_CONN_DISAGG_CONN_RECONFIG		1568
 /*! disagg: database size */
-#define	WT_STAT_CONN_DISAGG_DATABASE_SIZE		1566
+#define	WT_STAT_CONN_DISAGG_DATABASE_SIZE		1569
 /*!
  * disagg: existing file metadata entries updated during checkpoint pick-
  * up
  */
-#define	WT_STAT_CONN_DISAGG_PICK_UP_FILE_META_UPDATED	1567
+#define	WT_STAT_CONN_DISAGG_PICK_UP_FILE_META_UPDATED	1570
 /*! disagg: new file metadata entries inserted during checkpoint pick-up */
-#define	WT_STAT_CONN_DISAGG_PICK_UP_FILE_META_INSERTED	1568
+#define	WT_STAT_CONN_DISAGG_PICK_UP_FILE_META_INSERTED	1571
 /*! disagg: pick up checkpoint most recent time (msecs) */
-#define	WT_STAT_CONN_DISAGG_PICK_UP_CHECKPOINT_TIME	1569
+#define	WT_STAT_CONN_DISAGG_PICK_UP_CHECKPOINT_TIME	1572
 /*! disagg: role leader */
-#define	WT_STAT_CONN_DISAGG_ROLE_LEADER			1570
+#define	WT_STAT_CONN_DISAGG_ROLE_LEADER			1573
 /*! disagg: step down most recent time (msecs) */
-#define	WT_STAT_CONN_DISAGG_STEP_DOWN_TIME		1571
+#define	WT_STAT_CONN_DISAGG_STEP_DOWN_TIME		1574
 /*! disagg: step up most recent time (msecs) */
-#define	WT_STAT_CONN_DISAGG_STEP_UP_TIME		1572
+#define	WT_STAT_CONN_DISAGG_STEP_UP_TIME		1575
 /*! layered: Layered table cursor insert operations */
-#define	WT_STAT_CONN_LAYERED_CURS_INSERT		1573
+#define	WT_STAT_CONN_LAYERED_CURS_INSERT		1576
 /*! layered: Layered table cursor modify operations */
-#define	WT_STAT_CONN_LAYERED_CURS_MODIFY		1574
+#define	WT_STAT_CONN_LAYERED_CURS_MODIFY		1577
 /*! layered: Layered table cursor next operations */
-#define	WT_STAT_CONN_LAYERED_CURS_NEXT			1575
+#define	WT_STAT_CONN_LAYERED_CURS_NEXT			1578
 /*! layered: Layered table cursor next operations from the ingest btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_NEXT_INGEST		1576
+#define	WT_STAT_CONN_LAYERED_CURS_NEXT_INGEST		1579
 /*! layered: Layered table cursor next operations from the stable btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_NEXT_STABLE		1577
+#define	WT_STAT_CONN_LAYERED_CURS_NEXT_STABLE		1580
 /*!
  * layered: Layered table cursor opens the stable btree for the first
  * time
  */
-#define	WT_STAT_CONN_LAYERED_CURS_OPEN_STABLE		1578
+#define	WT_STAT_CONN_LAYERED_CURS_OPEN_STABLE		1581
 /*! layered: Layered table cursor prev operations */
-#define	WT_STAT_CONN_LAYERED_CURS_PREV			1579
+#define	WT_STAT_CONN_LAYERED_CURS_PREV			1582
 /*! layered: Layered table cursor prev operations from the ingest btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_PREV_INGEST		1580
+#define	WT_STAT_CONN_LAYERED_CURS_PREV_INGEST		1583
 /*! layered: Layered table cursor prev operations from the stable btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_PREV_STABLE		1581
+#define	WT_STAT_CONN_LAYERED_CURS_PREV_STABLE		1584
 /*! layered: Layered table cursor remove operations */
-#define	WT_STAT_CONN_LAYERED_CURS_REMOVE		1582
+#define	WT_STAT_CONN_LAYERED_CURS_REMOVE		1585
 /*!
  * layered: Layered table cursor reopens the stable btree (role change or
  * checkpoint advance)
  */
-#define	WT_STAT_CONN_LAYERED_CURS_REOPEN_STABLE		1583
+#define	WT_STAT_CONN_LAYERED_CURS_REOPEN_STABLE		1586
 /*! layered: Layered table cursor search near operations */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR		1584
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR		1587
 /*!
  * layered: Layered table cursor search near operations from the ingest
  * btrees
  */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_INGEST	1585
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_INGEST	1588
 /*!
  * layered: Layered table cursor search near operations from the stable
  * btrees
  */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_STABLE	1586
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_STABLE	1589
 /*! layered: Layered table cursor search operations */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH		1587
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH		1590
 /*! layered: Layered table cursor search operations from the ingest btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_INGEST		1588
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_INGEST		1591
 /*! layered: Layered table cursor search operations from the stable btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_STABLE		1589
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_STABLE		1592
 /*! layered: Layered table cursor update operations */
-#define	WT_STAT_CONN_LAYERED_CURS_UPDATE		1590
+#define	WT_STAT_CONN_LAYERED_CURS_UPDATE		1593
 /*!
  * layered: checkpoints performed on this table by the layered table
  * manager
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS	1591
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS	1594
 /*! layered: disagg pick up checkpoints failed */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FAILED	1592
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FAILED	1595
 /*! layered: disagg pick up checkpoints succeeded */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_SUCCEED	1593
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_SUCCEED	1596
 /*!
  * layered: how many log applications the layered table manager applied
  * on this tree
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_APPLIED	1594
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_APPLIED	1597
 /*!
  * layered: how many log applications the layered table manager skipped
  * on this tree
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_SKIPPED	1595
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_SKIPPED	1598
 /*!
  * layered: how many previously-applied LSNs the layered table manager
  * skipped on this tree
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_SKIP_LSN	1596
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_SKIP_LSN	1599
 /*! layered: number of checkpoints picked up by a follower */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FOLLOWER	1597
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FOLLOWER	1600
 /*! layered: the number of tables the layered table manager has open */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_TABLES	1598
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_TABLES	1601
 /*! layered: the number of times the truncate list was searched */
-#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_SEARCH_CALLS	1599
+#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_SEARCH_CALLS	1602
 /*!
  * layered: the number of times truncate list garbage collection ran with
  * a valid prune timestamp
  */
-#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_GC_RUNS	1600
+#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_GC_RUNS	1603
 /*!
  * layered: the number of truncate list entries removed by garbage
  * collection
  */
-#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_GC_ENTRIES_REMOVED	1601
+#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_GC_ENTRIES_REMOVED	1604
 /*! layered: the number of truncate list entries walked during search */
-#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_SEARCH_ENTRIES_WALKED	1602
+#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_SEARCH_ENTRIES_WALKED	1605
 /*!
  * live-restore: number of bytes copied from the source to the
  * destination
  */
-#define	WT_STAT_CONN_LIVE_RESTORE_BYTES_COPIED		1603
+#define	WT_STAT_CONN_LIVE_RESTORE_BYTES_COPIED		1606
 /*! live-restore: number of files remaining for migration completion */
-#define	WT_STAT_CONN_LIVE_RESTORE_WORK_REMAINING	1604
+#define	WT_STAT_CONN_LIVE_RESTORE_WORK_REMAINING	1607
 /*! live-restore: number of reads from the source database */
-#define	WT_STAT_CONN_LIVE_RESTORE_SOURCE_READ_COUNT	1605
+#define	WT_STAT_CONN_LIVE_RESTORE_SOURCE_READ_COUNT	1608
 /*! live-restore: source read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT2	1606
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT2	1609
 /*! live-restore: source read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT5	1607
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT5	1610
 /*! live-restore: source read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT10	1608
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT10	1611
 /*! live-restore: source read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT50	1609
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT50	1612
 /*! live-restore: source read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT100	1610
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT100	1613
 /*! live-restore: source read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT250	1611
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT250	1614
 /*! live-restore: source read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT500	1612
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT500	1615
 /*! live-restore: source read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT1000	1613
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT1000	1616
 /*! live-restore: source read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_GT1000	1614
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_GT1000	1617
 /*! live-restore: source read latency histogram total (msecs) */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_TOTAL_MSECS	1615
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_TOTAL_MSECS	1618
 /*! live-restore: state */
-#define	WT_STAT_CONN_LIVE_RESTORE_STATE			1616
+#define	WT_STAT_CONN_LIVE_RESTORE_STATE			1619
 /*! load-control: number of read operations rejected due to load control */
-#define	WT_STAT_CONN_READ_REJECT_COUNT			1617
+#define	WT_STAT_CONN_READ_REJECT_COUNT			1620
 /*! load-control: number of write operations rejected due to load control */
-#define	WT_STAT_CONN_WRITE_REJECT_COUNT			1618
+#define	WT_STAT_CONN_WRITE_REJECT_COUNT			1621
 /*! load-control: read load at the system level */
-#define	WT_STAT_CONN_READ_LOAD				1619
+#define	WT_STAT_CONN_READ_LOAD				1622
 /*! load-control: write load at the system level */
-#define	WT_STAT_CONN_WRITE_LOAD				1620
+#define	WT_STAT_CONN_WRITE_LOAD				1623
 /*! lock: btree page lock acquisitions */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_COUNT		1621
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_COUNT		1624
 /*! lock: btree page lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_APPLICATION	1622
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_APPLICATION	1625
 /*! lock: btree page lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_INTERNAL	1623
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_INTERNAL	1626
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1624
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1627
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1625
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1628
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1626
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1629
 /*! lock: dhandle lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1627
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1630
 /*! lock: dhandle lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1628
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1631
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1629
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1632
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1630
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1633
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1631
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1634
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1632
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1635
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1633
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1636
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1634
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1637
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1635
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1638
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1636
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1639
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1637
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1640
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1638
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1641
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1639
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1642
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1640
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1643
 /*! lock: txn global lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1641
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1644
 /*! lock: txn global lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1642
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1645
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1643
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1646
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1644
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1647
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1645
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1648
 /*! log: force log remove time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1646
+#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1649
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1647
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1650
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1648
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1651
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1649
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1652
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1650
+#define	WT_STAT_CONN_LOG_FLUSH				1653
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1651
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1654
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1652
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1655
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1653
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1656
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1654
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1657
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1655
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1658
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1656
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1659
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1657
+#define	WT_STAT_CONN_LOG_SCANS				1660
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1658
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1661
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1659
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1662
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1660
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1663
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1661
+#define	WT_STAT_CONN_LOG_SYNC				1664
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1662
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1665
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1663
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1666
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1664
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1667
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1665
+#define	WT_STAT_CONN_LOG_WRITES				1668
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1666
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1669
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1667
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1670
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1668
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1671
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1669
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1672
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1670
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1673
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1671
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1674
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1672
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1675
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1673
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1676
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1674
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1677
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1675
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1678
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1676
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1679
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1677
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1680
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1678
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1681
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1679
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1682
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1680
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1683
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1681
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1684
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1682
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1685
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1683
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1686
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1684
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1687
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1685
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1688
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1686
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1689
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1687
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1690
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1688
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1691
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1689
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1692
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1690
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1693
 /*! perf: block manager read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT2	1691
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT2	1694
 /*! perf: block manager read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT5	1692
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT5	1695
 /*! perf: block manager read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT10	1693
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT10	1696
 /*! perf: block manager read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT50	1694
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT50	1697
 /*! perf: block manager read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT100	1695
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT100	1698
 /*! perf: block manager read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT250	1696
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT250	1699
 /*! perf: block manager read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT500	1697
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT500	1700
 /*! perf: block manager read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT1000	1698
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT1000	1701
 /*! perf: block manager read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_GT1000	1699
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_GT1000	1702
 /*! perf: block manager read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_TOTAL_MSECS	1700
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_TOTAL_MSECS	1703
 /*! perf: block manager write latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT2	1701
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT2	1704
 /*! perf: block manager write latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT5	1702
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT5	1705
 /*! perf: block manager write latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT10	1703
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT10	1706
 /*! perf: block manager write latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT50	1704
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT50	1707
 /*! perf: block manager write latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT100	1705
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT100	1708
 /*! perf: block manager write latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT250	1706
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT250	1709
 /*! perf: block manager write latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT500	1707
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT500	1710
 /*! perf: block manager write latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT1000	1708
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT1000	1711
 /*! perf: block manager write latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_GT1000	1709
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_GT1000	1712
 /*! perf: block manager write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_TOTAL_MSECS	1710
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_TOTAL_MSECS	1713
 /*! perf: disagg block manager read latency histogram (bucket 1) - 50-99us */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT100	1711
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT100	1714
 /*!
  * perf: disagg block manager read latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT250	1712
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT250	1715
 /*!
  * perf: disagg block manager read latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT500	1713
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT500	1716
 /*!
  * perf: disagg block manager read latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT1000	1714
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT1000	1717
 /*!
  * perf: disagg block manager read latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT2500	1715
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT2500	1718
 /*!
  * perf: disagg block manager read latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT5000	1716
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT5000	1719
 /*!
  * perf: disagg block manager read latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT10000	1717
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT10000	1720
 /*!
  * perf: disagg block manager read latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_GT10000	1718
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_GT10000	1721
 /*! perf: disagg block manager read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_TOTAL_USECS	1719
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_TOTAL_USECS	1722
 /*!
  * perf: disagg block manager write latency histogram (bucket 1) -
  * 50-99us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT100	1720
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT100	1723
 /*!
  * perf: disagg block manager write latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT250	1721
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT250	1724
 /*!
  * perf: disagg block manager write latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT500	1722
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT500	1725
 /*!
  * perf: disagg block manager write latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT1000	1723
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT1000	1726
 /*!
  * perf: disagg block manager write latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT2500	1724
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT2500	1727
 /*!
  * perf: disagg block manager write latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT5000	1725
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT5000	1728
 /*!
  * perf: disagg block manager write latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT10000	1726
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT10000	1729
 /*!
  * perf: disagg block manager write latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_GT10000	1727
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_GT10000	1730
 /*! perf: disagg block manager write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_TOTAL_USECS	1728
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_TOTAL_USECS	1731
 /*! perf: file system read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT2	1729
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT2	1732
 /*! perf: file system read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT5	1730
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT5	1733
 /*! perf: file system read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1731
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1734
 /*! perf: file system read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1732
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1735
 /*! perf: file system read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1733
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1736
 /*! perf: file system read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1734
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1737
 /*! perf: file system read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1735
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1738
 /*! perf: file system read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1736
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1739
 /*! perf: file system read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1737
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1740
 /*! perf: file system read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1738
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1741
 /*! perf: file system write latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT2	1739
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT2	1742
 /*! perf: file system write latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT5	1740
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT5	1743
 /*! perf: file system write latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1741
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1744
 /*! perf: file system write latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1742
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1745
 /*! perf: file system write latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1743
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1746
 /*! perf: file system write latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1744
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1747
 /*! perf: file system write latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1745
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1748
 /*! perf: file system write latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1746
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1749
 /*! perf: file system write latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1747
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1750
 /*! perf: file system write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1748
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1751
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 1) -
  * 0-100us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT100	1749
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT100	1752
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT250	1750
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT250	1753
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT500	1751
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT500	1754
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT1000	1752
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT1000	1755
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT2500	1753
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT2500	1756
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT5000	1754
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT5000	1757
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT10000	1755
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT10000	1758
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_GT10000	1756
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_GT10000	1759
 /*! perf: internal page deltas reconstruct latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_TOTAL_USECS	1757
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_TOTAL_USECS	1760
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 1) -
  * 0-100us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT100	1758
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT100	1761
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT250	1759
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT250	1762
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT500	1760
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT500	1763
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT1000	1761
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT1000	1764
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT2500	1762
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT2500	1765
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT5000	1763
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT5000	1766
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT10000	1764
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT10000	1767
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_GT10000	1765
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_GT10000	1768
 /*! perf: leaf page deltas reconstruct latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_TOTAL_USECS	1766
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_TOTAL_USECS	1769
 /*! perf: operation read latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1767
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1770
 /*! perf: operation read latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1768
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1771
 /*! perf: operation read latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1769
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1772
 /*! perf: operation read latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1770
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1773
 /*! perf: operation read latency histogram (bucket 5) - 1000-2499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT2500	1771
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT2500	1774
 /*! perf: operation read latency histogram (bucket 6) - 2500-4999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT5000	1772
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT5000	1775
 /*! perf: operation read latency histogram (bucket 7) - 5000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1773
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1776
 /*! perf: operation read latency histogram (bucket 8) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1774
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1777
 /*! perf: operation read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1775
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1778
 /*! perf: operation write latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1776
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1779
 /*! perf: operation write latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1777
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1780
 /*! perf: operation write latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1778
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1781
 /*! perf: operation write latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1779
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1782
 /*! perf: operation write latency histogram (bucket 5) - 1000-2499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT2500	1780
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT2500	1783
 /*! perf: operation write latency histogram (bucket 6) - 2500-4999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT5000	1781
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT5000	1784
 /*! perf: operation write latency histogram (bucket 7) - 5000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1782
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1785
 /*! perf: operation write latency histogram (bucket 8) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1783
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1786
 /*! perf: operation write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1784
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1787
 /*! prefetch: could not perform pre-fetch on internal page */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1785
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1788
 /*!
  * prefetch: could not perform pre-fetch on ref without the pre-fetch
  * flag set
  */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1786
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1789
 /*! prefetch: pre-fetch attempted, session has pre-fetching enabled */
-#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1787
+#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1790
 /*! prefetch: pre-fetch not repeating for recently pre-fetched ref */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1788
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1791
 /*! prefetch: pre-fetch not triggered after single disk read */
-#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1789
+#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1792
 /*! prefetch: pre-fetch not triggered as there is no valid dhandle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1790
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1793
 /*! prefetch: pre-fetch not triggered due to disk read count */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1791
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1794
 /*! prefetch: pre-fetch not triggered due to internal session */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1792
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1795
 /*! prefetch: pre-fetch not triggered due to special btree handle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1793
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1796
 /*! prefetch: pre-fetch not triggered, pre-fetch queue is full */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_QUEUE_FULL	1794
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_QUEUE_FULL	1797
 /*! prefetch: pre-fetch page not on disk when reading */
-#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1795
+#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1798
 /*! prefetch: pre-fetch pages queued */
-#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1796
+#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1799
 /*! prefetch: pre-fetch pages read in background */
-#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1797
+#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1800
 /*!
  * prefetch: pre-fetch session check passed, pre-fetch work issued to
  * btree
  */
-#define	WT_STAT_CONN_PREFETCH_ATTEMPTS_SUCCEEDED	1798
+#define	WT_STAT_CONN_PREFETCH_ATTEMPTS_SUCCEEDED	1801
 /*! prefetch: pre-fetch skipped reading in a page due to harmless error */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1799
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1802
 /*!
  * prefetch: pre-fetch skipped traversal of internal page due to active
  * split generation
  */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SPLIT_GEN	1800
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SPLIT_GEN	1803
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1801
+#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1804
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1802
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1805
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1803
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1806
 /*!
  * reconciliation: average length of delta chain on internal page with
  * deltas
  */
-#define	WT_STAT_CONN_REC_AVERAGE_INTERNAL_PAGE_DELTA_CHAIN_LENGTH	1804
+#define	WT_STAT_CONN_REC_AVERAGE_INTERNAL_PAGE_DELTA_CHAIN_LENGTH	1807
 /*! reconciliation: average length of delta chain on leaf page with deltas */
-#define	WT_STAT_CONN_REC_AVERAGE_LEAF_PAGE_DELTA_CHAIN_LENGTH	1805
+#define	WT_STAT_CONN_REC_AVERAGE_LEAF_PAGE_DELTA_CHAIN_LENGTH	1808
 /*!
  * reconciliation: changes since prior reconciliation (bucket 1) between
  * 1 and 5
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE5			1806
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE5			1809
 /*!
  * reconciliation: changes since prior reconciliation (bucket 2) between
  * 6 and 10
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE10			1807
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE10			1810
 /*!
  * reconciliation: changes since prior reconciliation (bucket 3) between
  * 11 and 20
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE20			1808
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE20			1811
 /*!
  * reconciliation: changes since prior reconciliation (bucket 4) between
  * 21 and 50
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE50			1809
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE50			1812
 /*!
  * reconciliation: changes since prior reconciliation (bucket 5) between
  * 51 and 100
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE100		1810
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE100		1813
 /*!
  * reconciliation: changes since prior reconciliation (bucket 6) between
  * 101 and 200
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE200		1811
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE200		1814
 /*!
  * reconciliation: changes since prior reconciliation (bucket 7) between
  * 201 and 500
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE500		1812
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE500		1815
 /*!
  * reconciliation: changes since prior reconciliation (bucket 8) greater
  * than 500
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_GT500		1813
+#define	WT_STAT_CONN_REC_PAGE_MODS_GT500		1816
 /*! reconciliation: cursor next/prev calls during HS wrapup search_near */
-#define	WT_STAT_CONN_REC_HS_WRAPUP_NEXT_PREV_CALLS	1814
+#define	WT_STAT_CONN_REC_HS_WRAPUP_NEXT_PREV_CALLS	1817
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1815
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1818
 /*!
  * reconciliation: free page ID due to failed page replacement
  * reconciliation in disagg
  */
-#define	WT_STAT_CONN_REC_FREE_PAGE_ID_DUE_TO_FAILED_REPLACEMENT_RECONCILIATION	1816
+#define	WT_STAT_CONN_REC_FREE_PAGE_ID_DUE_TO_FAILED_REPLACEMENT_RECONCILIATION	1819
 /*! reconciliation: full internal pages written instead of a page delta */
-#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_INTERNAL	1817
+#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_INTERNAL	1820
 /*! reconciliation: full leaf pages written instead of a page delta */
-#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_LEAF		1818
+#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_LEAF		1821
 /*!
  * reconciliation: ingest btree reconciliation keeps the aborted prepare
  * updates
  */
-#define	WT_STAT_CONN_REC_INGEST_KEEP_PREPARE_ROLLBACK	1819
+#define	WT_STAT_CONN_REC_INGEST_KEEP_PREPARE_ROLLBACK	1822
 /*! reconciliation: internal page delta keys deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_DELETED	1820
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_DELETED	1823
 /*! reconciliation: internal page delta keys updated/inserted */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_UPDATED	1821
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_UPDATED	1824
 /*! reconciliation: internal page deltas written */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL		1822
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL		1825
 /*! reconciliation: internal page multi-block writes */
-#define	WT_STAT_CONN_REC_MULTIBLOCK_INTERNAL		1823
+#define	WT_STAT_CONN_REC_MULTIBLOCK_INTERNAL		1826
 /*! reconciliation: leaf page deltas written */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_LEAF		1824
+#define	WT_STAT_CONN_REC_PAGE_DELTA_LEAF		1827
 /*! reconciliation: leaf page multi-block writes */
-#define	WT_STAT_CONN_REC_MULTIBLOCK_LEAF		1825
+#define	WT_STAT_CONN_REC_MULTIBLOCK_LEAF		1828
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1826
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1829
 /*! reconciliation: max deltas seen on internal page during reconciliation */
-#define	WT_STAT_CONN_REC_MAX_INTERNAL_PAGE_DELTAS	1827
+#define	WT_STAT_CONN_REC_MAX_INTERNAL_PAGE_DELTAS	1830
 /*! reconciliation: max deltas seen on leaf page during reconciliation */
-#define	WT_STAT_CONN_REC_MAX_LEAF_PAGE_DELTAS		1828
+#define	WT_STAT_CONN_REC_MAX_LEAF_PAGE_DELTAS		1831
 /*! reconciliation: maximum milliseconds spent in a reconciliation call */
-#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1829
+#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1832
 /*!
  * reconciliation: maximum milliseconds spent in building a disk image in
  * a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1830
+#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1833
 /*!
  * reconciliation: maximum milliseconds spent in moving updates to the
  * history store in a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1831
+#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1834
 /*!
  * reconciliation: number of keys that are garbage collected from the
  * disk images in the ingest btrees for disaggregated storage
  */
-#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_DISK_IMAGE	1832
+#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_DISK_IMAGE	1835
 /*!
  * reconciliation: number of keys that are garbage collected from the
  * update chains in the ingest btrees for disaggregated storage
  */
-#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_UPDATE_CHAIN	1833
+#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_UPDATE_CHAIN	1836
 /*! reconciliation: overflow values written */
-#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1834
+#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1837
 /*! reconciliation: page deltas rejected due to invalid page ID */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_INVALID_PAGE_ID	1835
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_INVALID_PAGE_ID	1838
 /*! reconciliation: page deltas rejected due to max consecutive limit */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MAX_CONSECUTIVE_EXCEEDED	1836
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MAX_CONSECUTIVE_EXCEEDED	1839
 /*! reconciliation: page deltas rejected due to multiblock reconciliation */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MULTIBLOCK	1837
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MULTIBLOCK	1840
 /*!
  * reconciliation: page deltas rejected due to non-single page in
  * previous reconciliation
  */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_NON_SINGLE_PAGE	1838
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_NON_SINGLE_PAGE	1841
 /*! reconciliation: page deltas rejected due to size threshold */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_SIZE_THRESHOLD	1839
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_SIZE_THRESHOLD	1842
 /*!
  * reconciliation: page deltas rejected due to too many keys removed from
  * the disk image
  */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_DELETE_THRESHOLD	1840
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_DELETE_THRESHOLD	1843
 /*! reconciliation: page deltas rejected due to zero entries */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_ZERO_ENTRIES	1841
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_ZERO_ENTRIES	1844
 /*!
  * reconciliation: page deltas rejected: build function returned false
  * (disabled, in-memory split, or internal page constraints not met)
  */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_BUILD_FAILED	1842
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_BUILD_FAILED	1845
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1843
+#define	WT_STAT_CONN_REC_PAGES				1846
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1844
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1847
 /*! reconciliation: page reconciliation calls for pages between 1 and 10MB */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_1MB_TO_10MB		1845
+#define	WT_STAT_CONN_REC_PAGES_SIZE_1MB_TO_10MB		1848
 /*!
  * reconciliation: page reconciliation calls for pages between 10 and
  * 100MB
  */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_10MB_TO_100MB	1846
+#define	WT_STAT_CONN_REC_PAGES_SIZE_10MB_TO_100MB	1849
 /*!
  * reconciliation: page reconciliation calls for pages between 100MB and
  * 1GB
  */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_100MB_TO_1GB	1847
+#define	WT_STAT_CONN_REC_PAGES_SIZE_100MB_TO_1GB	1850
 /*! reconciliation: page reconciliation calls for pages over 1GB */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_1GB_PLUS		1848
+#define	WT_STAT_CONN_REC_PAGES_SIZE_1GB_PLUS		1851
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * prepared transaction metadata
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1849
+#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1852
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * timestamps
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1850
+#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1853
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * transaction ids
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1851
+#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1854
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1852
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1855
 /*! reconciliation: pages eligible for delta generation */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_ELIGIBLE		1853
+#define	WT_STAT_CONN_REC_PAGE_DELTA_ELIGIBLE		1856
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1854
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1857
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1855
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1858
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1856
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1859
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1857
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1860
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1858
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1861
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1859
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1862
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1860
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1863
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1861
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1864
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1862
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1865
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1863
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1866
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1864
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1867
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1865
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1868
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1866
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1869
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1867
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1870
 /*! reconciliation: pages written with at least one internal page delta */
-#define	WT_STAT_CONN_REC_PAGES_WITH_INTERNAL_DELTAS	1868
+#define	WT_STAT_CONN_REC_PAGES_WITH_INTERNAL_DELTAS	1871
 /*! reconciliation: pages written with at least one leaf page delta */
-#define	WT_STAT_CONN_REC_PAGES_WITH_LEAF_DELTAS		1869
+#define	WT_STAT_CONN_REC_PAGES_WITH_LEAF_DELTAS		1872
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1870
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1873
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1871
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1874
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1872
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1875
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1873
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1876
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1874
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1877
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1875
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1878
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1876
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1879
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1877
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1880
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1878
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1881
 /*! reconciliation: writes skipped in disaggregated storage */
-#define	WT_STAT_CONN_REC_SKIP_WRITE			1879
+#define	WT_STAT_CONN_REC_SKIP_WRITE			1882
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1880
+#define	WT_STAT_CONN_SESSION_OPEN			1883
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1881
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1884
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1882
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1885
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1883
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1886
 /*! session: table alter triggering checkpoint calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1884
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1887
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1885
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1888
 /*! session: table compact conflicted with checkpoint */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1886
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1889
 /*! session: table compact dhandle successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1887
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1890
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1888
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1891
 /*! session: table compact failed calls due to cache pressure */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1889
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1892
 /*!
  * session: table compact in-memory page footprint rewritten by
  * compaction
  */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_BYTES_REWRITE_INMEM	1890
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_BYTES_REWRITE_INMEM	1893
 /*! session: table compact passes */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1891
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1894
 /*! session: table compact pulled into eviction */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1892
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1895
 /*! session: table compact running */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1893
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1896
 /*! session: table compact skipped as process would not reduce file size */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1894
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1897
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1895
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1898
 /*! session: table compact timeout */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1896
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1899
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1897
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1900
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1898
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1901
 /*! session: table create with import failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1899
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1902
 /*! session: table create with import repair calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1900
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1903
 /*! session: table create with import successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1901
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1904
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1902
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1905
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1903
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1906
 /*! session: table publish failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_PUBLISH_FAIL		1904
+#define	WT_STAT_CONN_SESSION_TABLE_PUBLISH_FAIL		1907
 /*! session: table publish successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_PUBLISH_SUCCESS	1905
+#define	WT_STAT_CONN_SESSION_TABLE_PUBLISH_SUCCESS	1908
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1906
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1909
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1907
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1910
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1908
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1911
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1909
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1912
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1910
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1913
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1911
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1914
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1912
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1915
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1913
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1916
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1914
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1917
 /*! thread-yield: application thread operations waiting for cache */
-#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1915
+#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1918
 /*!
  * thread-yield: application thread operations waiting for interruptible
  * cache eviction
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_OPS	1916
+#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_OPS	1919
 /*!
  * thread-yield: application thread operations waiting for mandatory
  * cache eviction
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_OPS	1917
+#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_OPS	1920
 /*! thread-yield: application thread snapshot refreshed for eviction */
-#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1918
+#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1921
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1919
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1922
 /*!
  * thread-yield: application thread time waiting for interruptible cache
  * eviction (usecs)
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_TIME	1920
+#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_TIME	1923
 /*!
  * thread-yield: application thread time waiting for mandatory cache
  * eviction (usecs)
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_TIME	1921
+#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_TIME	1924
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1922
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1925
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1923
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1926
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1924
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1927
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1925
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1928
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1926
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1929
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1927
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1930
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1928
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1931
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1929
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1932
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1930
+#define	WT_STAT_CONN_PAGE_SLEEP				1933
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1931
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1934
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1932
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1935
 /*! thread-yield: page split and restart read */
-#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1933
+#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1936
 /*! thread-yield: pages skipped during read due to deleted state */
-#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1934
+#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1937
 /*!
  * tiered-storage: attempts to remove a local object and the object is in
  * use
  */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1935
+#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1938
 /*! tiered-storage: flush_tier failed calls */
-#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1936
+#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1939
 /*! tiered-storage: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1937
+#define	WT_STAT_CONN_FLUSH_TIER				1940
 /*! tiered-storage: flush_tier tables skipped due to no checkpoint */
-#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1938
+#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1941
 /*! tiered-storage: flush_tier tables switched */
-#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1939
+#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1942
 /*! tiered-storage: local objects removed */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1940
+#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1943
 /*! tiered-storage: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1941
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1944
 /*! tiered-storage: tiered operations removed without processing */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1942
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1945
 /*! tiered-storage: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1943
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1946
 /*! tiered-storage: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1944
+#define	WT_STAT_CONN_TIERED_RETENTION			1947
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1945
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1948
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1946
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1949
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1947
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1950
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1948
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1951
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1949
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1952
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1950
+#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1953
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1951
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1954
 /*! transaction: oldest transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1952
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1955
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1953
+#define	WT_STAT_CONN_TXN_PREPARE			1956
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1954
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1957
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1955
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1958
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1956
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1959
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1957
+#define	WT_STAT_CONN_TXN_QUERY_TS			1960
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1958
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1961
 /*! transaction: rollback to stable applied btrees */
-#define	WT_STAT_CONN_TXN_RTS_BTREES_APPLIED		1959
+#define	WT_STAT_CONN_TXN_RTS_BTREES_APPLIED		1962
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1960
+#define	WT_STAT_CONN_TXN_RTS				1963
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1961
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1964
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1962
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1965
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1963
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1966
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1964
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1967
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1965
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1968
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1966
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1969
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1967
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1970
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1968
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1971
 /*!
  * transaction: rollback to stable prepared fast truncations that would
  * have been rolled back in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_PREPARED_FAST_TRUNCATE_DRYRUN	1969
+#define	WT_STAT_CONN_TXN_RTS_PREPARED_FAST_TRUNCATE_DRYRUN	1972
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1970
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1973
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1971
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1974
 /*! transaction: rollback to stable rolled back prepared fast truncations */
-#define	WT_STAT_CONN_TXN_RTS_PREPARED_FAST_TRUNCATE	1972
+#define	WT_STAT_CONN_TXN_RTS_PREPARED_FAST_TRUNCATE	1975
 /*! transaction: rollback to stable skipped btrees */
-#define	WT_STAT_CONN_TXN_RTS_BTREES_SKIPPED		1973
+#define	WT_STAT_CONN_TXN_RTS_BTREES_SKIPPED		1976
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1974
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1977
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1975
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1978
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1976
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1979
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1977
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1980
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1978
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1981
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1979
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1982
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1980
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1983
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1981
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1984
 /*!
  * transaction: rollback to stable updates that would have been aborted
  * in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1982
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1985
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1983
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1986
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1984
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1987
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1985
+#define	WT_STAT_CONN_TXN_SET_TS				1988
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1986
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1989
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1987
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1990
 /*! transaction: set timestamp force calls */
-#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1988
+#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1991
 /*!
  * transaction: set timestamp global oldest timestamp set to be more
  * recent than the global stable timestamp
  */
-#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1989
+#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1992
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1990
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1993
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1991
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1994
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1992
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1995
 /*! transaction: set timestamp stable disaggregated schema epoch calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_DISAGG_EPOCH	1993
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_DISAGG_EPOCH	1996
 /*! transaction: set timestamp stable disaggregated schema epoch updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_DISAGG_EPOCH_UPD	1994
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_DISAGG_EPOCH_UPD	1997
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1995
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1998
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1996
+#define	WT_STAT_CONN_TXN_BEGIN				1999
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1997
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		2000
 /*! transaction: transaction global checkpoint timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_CHECKPOINT_TIMESTAMP	1998
+#define	WT_STAT_CONN_TXN_GLOBAL_CHECKPOINT_TIMESTAMP	2001
 /*! transaction: transaction global durable timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_DURABLE_TIMESTAMP	1999
+#define	WT_STAT_CONN_TXN_GLOBAL_DURABLE_TIMESTAMP	2002
 /*! transaction: transaction global last running timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_LAST_RUNNING_TIMESTAMP	2000
+#define	WT_STAT_CONN_TXN_GLOBAL_LAST_RUNNING_TIMESTAMP	2003
 /*! transaction: transaction global newest timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_NEWEST_TIMESTAMP	2001
+#define	WT_STAT_CONN_TXN_GLOBAL_NEWEST_TIMESTAMP	2004
 /*! transaction: transaction global oldest timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_OLDEST_TIMESTAMP	2002
+#define	WT_STAT_CONN_TXN_GLOBAL_OLDEST_TIMESTAMP	2005
 /*! transaction: transaction global pinned timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_PINNED_TIMESTAMP	2003
+#define	WT_STAT_CONN_TXN_GLOBAL_PINNED_TIMESTAMP	2006
 /*! transaction: transaction global stable timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_STABLE_TIMESTAMP	2004
+#define	WT_STAT_CONN_TXN_GLOBAL_STABLE_TIMESTAMP	2007
 /*! transaction: transaction global version cursor timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_VERSION_CURSOR_TIMESTAMP	2005
+#define	WT_STAT_CONN_TXN_GLOBAL_VERSION_CURSOR_TIMESTAMP	2008
 /*!
  * transaction: transaction number of older readers older than oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_READERS			2006
+#define	WT_STAT_CONN_TXN_PINNED_READERS			2009
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			2007
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			2010
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	2008
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	2011
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_LAG		2009
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_LAG		2012
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT_LAG	2010
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT_LAG	2013
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER_LAG	2011
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER_LAG	2014
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	2012
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	2015
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	2013
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	2016
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	2014
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	2017
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			2015
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			2018
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				2016
+#define	WT_STAT_CONN_TXN_COMMIT				2019
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			2017
+#define	WT_STAT_CONN_TXN_ROLLBACK			2020
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		2018
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		2021
 
 /*!
  * @}

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -6352,2678 +6352,2680 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_BLOCK_CACHE_MISSES			1040
 /*! block-cache: number of put bypasses on checkpoint I/O */
 #define	WT_STAT_CONN_BLOCK_CACHE_BYPASS_CHKPT		1041
+/*! block-cache: pages added to the disaggregated victim cache */
+#define	WT_STAT_CONN_BLOCK_CACHE_PUTS			1042
 /*!
  * block-cache: pages added to the disaggregated victim cache by
  * application threads
  */
-#define	WT_STAT_CONN_BLOCK_CACHE_APP_THREAD_PUTS	1042
-/*!
- * block-cache: pages added to the disaggregated victim cache by eviction
- * threads
- */
-#define	WT_STAT_CONN_BLOCK_CACHE_EVICTION_THREAD_PUTS	1043
+#define	WT_STAT_CONN_BLOCK_CACHE_APP_THREAD_PUTS	1043
 /*! block-cache: removed blocks */
 #define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_REMOVED		1044
+/*!
+ * block-cache: time application threads spent adding pages to the
+ * disaggregated victim cache (usecs)
+ */
+#define	WT_STAT_CONN_BLOCK_CACHE_APP_THREAD_PUT_TIME	1045
 /*! block-cache: time sleeping to remove block (usecs) */
-#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_REMOVED_BLOCKED	1045
+#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_REMOVED_BLOCKED	1046
 /*!
  * block-cache: time spent adding pages to the disaggregated victim cache
  * (usecs)
  */
-#define	WT_STAT_CONN_BLOCK_CACHE_PUT_TIME		1046
+#define	WT_STAT_CONN_BLOCK_CACHE_PUT_TIME		1047
 /*! block-cache: total blocks */
-#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS			1047
+#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS			1048
 /*! block-cache: total blocks inserted on read path */
-#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_INSERT_READ	1048
+#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_INSERT_READ	1049
 /*! block-cache: total blocks inserted on write path */
-#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_INSERT_WRITE	1049
+#define	WT_STAT_CONN_BLOCK_CACHE_BLOCKS_INSERT_WRITE	1050
 /*! block-cache: total bytes */
-#define	WT_STAT_CONN_BLOCK_CACHE_BYTES			1050
+#define	WT_STAT_CONN_BLOCK_CACHE_BYTES			1051
 /*! block-cache: total bytes inserted on read path */
-#define	WT_STAT_CONN_BLOCK_CACHE_BYTES_INSERT_READ	1051
+#define	WT_STAT_CONN_BLOCK_CACHE_BYTES_INSERT_READ	1052
 /*! block-cache: total bytes inserted on write path */
-#define	WT_STAT_CONN_BLOCK_CACHE_BYTES_INSERT_WRITE	1052
+#define	WT_STAT_CONN_BLOCK_CACHE_BYTES_INSERT_WRITE	1053
 /*! block-disagg: Bytes read from the shared history store in SLS */
-#define	WT_STAT_CONN_DISAGG_BLOCK_HS_BYTE_READ		1053
+#define	WT_STAT_CONN_DISAGG_BLOCK_HS_BYTE_READ		1054
 /*! block-disagg: Bytes written to the shared history store in SLS */
-#define	WT_STAT_CONN_DISAGG_BLOCK_HS_BYTE_WRITE		1054
+#define	WT_STAT_CONN_DISAGG_BLOCK_HS_BYTE_WRITE		1055
 /*! block-disagg: Disaggregated block manager get */
-#define	WT_STAT_CONN_DISAGG_BLOCK_GET			1055
+#define	WT_STAT_CONN_DISAGG_BLOCK_GET			1056
 /*! block-disagg: Disaggregated block manager get cold page */
-#define	WT_STAT_CONN_DISAGG_BLOCK_GET_COLD		1056
+#define	WT_STAT_CONN_DISAGG_BLOCK_GET_COLD		1057
 /*!
  * block-disagg: Disaggregated block manager get from the shared history
  * store in SLS
  */
-#define	WT_STAT_CONN_DISAGG_BLOCK_HS_GET		1057
+#define	WT_STAT_CONN_DISAGG_BLOCK_HS_GET		1058
 /*! block-disagg: Disaggregated block manager page discard calls */
-#define	WT_STAT_CONN_DISAGG_BLOCK_PAGE_DISCARD		1058
+#define	WT_STAT_CONN_DISAGG_BLOCK_PAGE_DISCARD		1059
 /*! block-disagg: Disaggregated block manager put */
-#define	WT_STAT_CONN_DISAGG_BLOCK_PUT			1059
+#define	WT_STAT_CONN_DISAGG_BLOCK_PUT			1060
 /*! block-disagg: Disaggregated block manager put cold page */
-#define	WT_STAT_CONN_DISAGG_BLOCK_PUT_COLD		1060
+#define	WT_STAT_CONN_DISAGG_BLOCK_PUT_COLD		1061
 /*!
  * block-disagg: Disaggregated block manager put to the shared history
  * store in SLS
  */
-#define	WT_STAT_CONN_DISAGG_BLOCK_HS_PUT		1061
+#define	WT_STAT_CONN_DISAGG_BLOCK_HS_PUT		1062
 /*!
  * block-disagg: Disaggregated block manager read ahead of
  * materialization frontier
  */
-#define	WT_STAT_CONN_DISAGG_BLOCK_READ_AHEAD_FRONTIER	1062
+#define	WT_STAT_CONN_DISAGG_BLOCK_READ_AHEAD_FRONTIER	1063
 /*! block-manager: blocks pre-loaded */
-#define	WT_STAT_CONN_BLOCK_PRELOAD			1063
+#define	WT_STAT_CONN_BLOCK_PRELOAD			1064
 /*! block-manager: blocks read */
-#define	WT_STAT_CONN_BLOCK_READ				1064
+#define	WT_STAT_CONN_BLOCK_READ				1065
 /*! block-manager: blocks written */
-#define	WT_STAT_CONN_BLOCK_WRITE			1065
+#define	WT_STAT_CONN_BLOCK_WRITE			1066
 /*! block-manager: bytes read */
-#define	WT_STAT_CONN_BLOCK_BYTE_READ			1066
+#define	WT_STAT_CONN_BLOCK_BYTE_READ			1067
 /*! block-manager: bytes read for internal pages */
-#define	WT_STAT_CONN_BLOCK_BYTE_READ_INTL		1067
+#define	WT_STAT_CONN_BLOCK_BYTE_READ_INTL		1068
 /*!
  * block-manager: bytes read for internal pages before decompression and
  * decryption
  */
-#define	WT_STAT_CONN_BLOCK_BYTE_READ_INTL_DISK		1068
+#define	WT_STAT_CONN_BLOCK_BYTE_READ_INTL_DISK		1069
 /*! block-manager: bytes read for leaf pages */
-#define	WT_STAT_CONN_BLOCK_BYTE_READ_LEAF		1069
+#define	WT_STAT_CONN_BLOCK_BYTE_READ_LEAF		1070
 /*!
  * block-manager: bytes read for leaf pages before decompression and
  * decryption
  */
-#define	WT_STAT_CONN_BLOCK_BYTE_READ_LEAF_DISK		1070
+#define	WT_STAT_CONN_BLOCK_BYTE_READ_LEAF_DISK		1071
 /*! block-manager: bytes read via memory map API */
-#define	WT_STAT_CONN_BLOCK_BYTE_READ_MMAP		1071
+#define	WT_STAT_CONN_BLOCK_BYTE_READ_MMAP		1072
 /*! block-manager: bytes read via system call API */
-#define	WT_STAT_CONN_BLOCK_BYTE_READ_SYSCALL		1072
+#define	WT_STAT_CONN_BLOCK_BYTE_READ_SYSCALL		1073
 /*!
  * block-manager: bytes saved from being written when using internal page
  * deltas
  */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_SAVED_DELTA_INTL	1073
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_SAVED_DELTA_INTL	1074
 /*!
  * block-manager: bytes saved from being written when using leaf page
  * deltas
  */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_SAVED_DELTA_LEAF	1074
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_SAVED_DELTA_LEAF	1075
 /*! block-manager: bytes written */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE			1075
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE			1076
 /*! block-manager: bytes written by compaction */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_COMPACT		1076
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_COMPACT		1077
 /*! block-manager: bytes written for checkpoint */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_CHECKPOINT	1077
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_CHECKPOINT	1078
 /*!
  * block-manager: bytes written for internal pages after compression and
  * encryption
  */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_INTL_DISK		1078
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_INTL_DISK		1079
 /*!
  * block-manager: bytes written for internal pages before compression and
  * encryption
  */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_INTL		1079
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_INTL		1080
 /*!
  * block-manager: bytes written for leaf pages after compression and
  * encryption
  */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_LEAF_DISK		1080
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_LEAF_DISK		1081
 /*!
  * block-manager: bytes written for leaf pages before compression and
  * encryption
  */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_LEAF		1081
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_LEAF		1082
 /*! block-manager: bytes written via memory map API */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_MMAP		1082
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_MMAP		1083
 /*! block-manager: bytes written via system call API */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_SYSCALL		1083
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_SYSCALL		1084
 /*! block-manager: mapped blocks read */
-#define	WT_STAT_CONN_BLOCK_MAP_READ			1084
+#define	WT_STAT_CONN_BLOCK_MAP_READ			1085
 /*! block-manager: mapped bytes read */
-#define	WT_STAT_CONN_BLOCK_BYTE_MAP_READ		1085
+#define	WT_STAT_CONN_BLOCK_BYTE_MAP_READ		1086
 /*!
  * block-manager: number of internal page deltas written that were
  * between 0-20 percent the size of the full image
  */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_INTL_DELTA_LT20	1086
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_INTL_DELTA_LT20	1087
 /*!
  * block-manager: number of internal page deltas written that were
  * between 20-40 percent the size of the full image
  */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_INTL_DELTA_LT40	1087
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_INTL_DELTA_LT40	1088
 /*!
  * block-manager: number of internal page deltas written that were
  * between 40-60 percent the size of the full image
  */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_INTL_DELTA_LT60	1088
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_INTL_DELTA_LT60	1089
 /*!
  * block-manager: number of internal page deltas written that were
  * between 60-80 percent the size of the full image
  */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_INTL_DELTA_LT80	1089
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_INTL_DELTA_LT80	1090
 /*!
  * block-manager: number of internal page deltas written that were
  * between 80-100 percent the size of the full image
  */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_INTL_DELTA_LT100	1090
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_INTL_DELTA_LT100	1091
 /*!
  * block-manager: number of internal page deltas written that were
  * greater than the size of the full image
  */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_INTL_DELTA_GT100	1091
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_INTL_DELTA_GT100	1092
 /*!
  * block-manager: number of leaf page deltas written that were between
  * 0-20 percent the size of the full image
  */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_LEAF_DELTA_LT20	1092
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_LEAF_DELTA_LT20	1093
 /*!
  * block-manager: number of leaf page deltas written that were between
  * 20-40 percent the size of the full image
  */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_LEAF_DELTA_LT40	1093
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_LEAF_DELTA_LT40	1094
 /*!
  * block-manager: number of leaf page deltas written that were between
  * 40-60 percent the size of the full image
  */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_LEAF_DELTA_LT60	1094
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_LEAF_DELTA_LT60	1095
 /*!
  * block-manager: number of leaf page deltas written that were between
  * 60-80 percent the size of the full image
  */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_LEAF_DELTA_LT80	1095
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_LEAF_DELTA_LT80	1096
 /*!
  * block-manager: number of leaf page deltas written that were between
  * 80-100 percent the size of the full image
  */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_LEAF_DELTA_LT100	1096
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_LEAF_DELTA_LT100	1097
 /*!
  * block-manager: number of leaf page deltas written that were greater
  * than the size of the full image
  */
-#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_LEAF_DELTA_GT100	1097
+#define	WT_STAT_CONN_BLOCK_BYTE_WRITE_LEAF_DELTA_GT100	1098
 /*!
  * block-manager: number of times the file was remapped because it
  * changed size via fallocate or truncate
  */
-#define	WT_STAT_CONN_BLOCK_REMAP_FILE_RESIZE		1098
+#define	WT_STAT_CONN_BLOCK_REMAP_FILE_RESIZE		1099
 /*! block-manager: number of times the region was remapped via write */
-#define	WT_STAT_CONN_BLOCK_REMAP_FILE_WRITE		1099
+#define	WT_STAT_CONN_BLOCK_REMAP_FILE_WRITE		1100
 /*!
  * block-manager: time spent(usecs) on the most recent linear walk of
  * extents during first-fit allocation
  */
-#define	WT_STAT_CONN_BLOCK_FIRST_SRCH_WALK_TIME		1100
+#define	WT_STAT_CONN_BLOCK_FIRST_SRCH_WALK_TIME		1101
 /*! cache: application requested eviction interrupt */
-#define	WT_STAT_CONN_EVICTION_INTERUPTED_BY_APP		1101
+#define	WT_STAT_CONN_EVICTION_INTERUPTED_BY_APP		1102
 /*! cache: application thread time evicting (usecs) */
-#define	WT_STAT_CONN_EVICTION_APP_TIME			1102
+#define	WT_STAT_CONN_EVICTION_APP_TIME			1103
 /*!
  * cache: application threads eviction requested with cache fill ratio <
  * 25%
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_APP_THREADS_FILL_RATIO_LT_25	1103
+#define	WT_STAT_CONN_CACHE_EVICTION_APP_THREADS_FILL_RATIO_LT_25	1104
 /*!
  * cache: application threads eviction requested with cache fill ratio >=
  * 25% and < 50%
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_APP_THREADS_FILL_RATIO_25_50	1104
+#define	WT_STAT_CONN_CACHE_EVICTION_APP_THREADS_FILL_RATIO_25_50	1105
 /*!
  * cache: application threads eviction requested with cache fill ratio >=
  * 50% and < 75%
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_APP_THREADS_FILL_RATIO_50_75	1105
+#define	WT_STAT_CONN_CACHE_EVICTION_APP_THREADS_FILL_RATIO_50_75	1106
 /*!
  * cache: application threads eviction requested with cache fill ratio >=
  * 75%
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_APP_THREADS_FILL_RATIO_GT_75	1106
+#define	WT_STAT_CONN_CACHE_EVICTION_APP_THREADS_FILL_RATIO_GT_75	1107
 /*!
  * cache: application threads eviction skip page with updates or dirty
  * page
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_APP_THREADS_SKIP_UPDATES_DIRTY_PAGE	1107
+#define	WT_STAT_CONN_CACHE_EVICTION_APP_THREADS_SKIP_UPDATES_DIRTY_PAGE	1108
 /*! cache: application threads page read from disk to cache count */
-#define	WT_STAT_CONN_CACHE_READ_APP_COUNT		1108
+#define	WT_STAT_CONN_CACHE_READ_APP_COUNT		1109
 /*! cache: application threads page read from disk to cache time (usecs) */
-#define	WT_STAT_CONN_CACHE_READ_APP_TIME		1109
+#define	WT_STAT_CONN_CACHE_READ_APP_TIME		1110
 /*! cache: application threads page write from cache to disk count */
-#define	WT_STAT_CONN_CACHE_WRITE_APP_COUNT		1110
+#define	WT_STAT_CONN_CACHE_WRITE_APP_COUNT		1111
 /*! cache: application threads page write from cache to disk time (usecs) */
-#define	WT_STAT_CONN_CACHE_WRITE_APP_TIME		1111
+#define	WT_STAT_CONN_CACHE_WRITE_APP_TIME		1112
 /*! cache: bytes allocated for updates */
-#define	WT_STAT_CONN_CACHE_BYTES_UPDATES		1112
+#define	WT_STAT_CONN_CACHE_BYTES_UPDATES		1113
 /*! cache: bytes allocated for updates from the ingest btrees */
-#define	WT_STAT_CONN_CACHE_BYTES_UPDATES_INGEST		1113
+#define	WT_STAT_CONN_CACHE_BYTES_UPDATES_INGEST		1114
 /*! cache: bytes allocated for updates from the stable btrees */
-#define	WT_STAT_CONN_CACHE_BYTES_UPDATES_STABLE		1114
+#define	WT_STAT_CONN_CACHE_BYTES_UPDATES_STABLE		1115
 /*! cache: bytes belonging to page images in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_IMAGE			1115
+#define	WT_STAT_CONN_CACHE_BYTES_IMAGE			1116
 /*!
  * cache: bytes belonging to page images in the cache from the ingest
  * btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_IMAGE_INGEST		1116
+#define	WT_STAT_CONN_CACHE_BYTES_IMAGE_INGEST		1117
 /*!
  * cache: bytes belonging to page images in the cache from the stable
  * btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_IMAGE_STABLE		1117
+#define	WT_STAT_CONN_CACHE_BYTES_IMAGE_STABLE		1118
 /*! cache: bytes belonging to the history store table in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_HS			1118
+#define	WT_STAT_CONN_CACHE_BYTES_HS			1119
 /*! cache: bytes currently in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_INUSE			1119
+#define	WT_STAT_CONN_CACHE_BYTES_INUSE			1120
 /*! cache: bytes dirty in the cache cumulative */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_TOTAL		1120
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_TOTAL		1121
 /*! cache: bytes not belonging to page images in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_OTHER			1121
+#define	WT_STAT_CONN_CACHE_BYTES_OTHER			1122
 /*! cache: bytes read into cache */
-#define	WT_STAT_CONN_CACHE_BYTES_READ			1122
+#define	WT_STAT_CONN_CACHE_BYTES_READ			1123
 /*! cache: bytes written from cache */
-#define	WT_STAT_CONN_CACHE_BYTES_WRITE			1123
+#define	WT_STAT_CONN_CACHE_BYTES_WRITE			1124
 /*! cache: cache tolerance configured */
-#define	WT_STAT_CONN_CACHE_TOLERANCE_LEVEL		1124
+#define	WT_STAT_CONN_CACHE_TOLERANCE_LEVEL		1125
 /*! cache: checkpoint blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_CHECKPOINT	1125
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_CHECKPOINT	1126
 /*!
  * cache: checkpoint of history store file blocked non-history store page
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_CHECKPOINT_HS	1126
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_CHECKPOINT_HS	1127
 /*! cache: dirty bytes belonging to the history store table in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_HS_DIRTY		1127
+#define	WT_STAT_CONN_CACHE_BYTES_HS_DIRTY		1128
 /*! cache: dirty internal page cannot be evicted in disaggregated storage */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_DISAGG_DIRTY_INTERNAL_PAGE	1128
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_DISAGG_DIRTY_INTERNAL_PAGE	1129
 /*! cache: evict page attempts by eviction server */
-#define	WT_STAT_CONN_EVICTION_SERVER_EVICT_ATTEMPT	1129
+#define	WT_STAT_CONN_EVICTION_SERVER_EVICT_ATTEMPT	1130
 /*! cache: evict page attempts by eviction worker threads */
-#define	WT_STAT_CONN_EVICTION_WORKER_EVICT_ATTEMPT	1130
+#define	WT_STAT_CONN_EVICTION_WORKER_EVICT_ATTEMPT	1131
 /*! cache: evict page failures by eviction server */
-#define	WT_STAT_CONN_EVICTION_SERVER_EVICT_FAIL		1131
+#define	WT_STAT_CONN_EVICTION_SERVER_EVICT_FAIL		1132
 /*! cache: evict page failures by eviction worker threads */
-#define	WT_STAT_CONN_EVICTION_WORKER_EVICT_FAIL		1132
+#define	WT_STAT_CONN_EVICTION_WORKER_EVICT_FAIL		1133
 /*! cache: eviction calls to get a page found queue empty */
-#define	WT_STAT_CONN_EVICTION_GET_REF_EMPTY		1133
+#define	WT_STAT_CONN_EVICTION_GET_REF_EMPTY		1134
 /*! cache: eviction calls to get a page found queue empty after locking */
-#define	WT_STAT_CONN_EVICTION_GET_REF_EMPTY2		1134
+#define	WT_STAT_CONN_EVICTION_GET_REF_EMPTY2		1135
 /*! cache: eviction currently operating in aggressive mode */
-#define	WT_STAT_CONN_EVICTION_AGGRESSIVE_SET		1135
+#define	WT_STAT_CONN_EVICTION_AGGRESSIVE_SET		1136
 /*! cache: eviction empty score */
-#define	WT_STAT_CONN_EVICTION_EMPTY_SCORE		1136
+#define	WT_STAT_CONN_EVICTION_EMPTY_SCORE		1137
 /*!
  * cache: eviction gave up due to detecting a disk value without a
  * timestamp behind the last update on the chain
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_1	1137
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_1	1138
 /*!
  * cache: eviction gave up due to detecting a tombstone without a
  * timestamp ahead of the selected on disk update
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_2	1138
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_2	1139
 /*!
  * cache: eviction gave up due to detecting a tombstone without a
  * timestamp ahead of the selected on disk update after validating the
  * update chain
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_3	1139
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_3	1140
 /*!
  * cache: eviction gave up due to detecting update chain entries without
  * timestamps after the selected on disk update
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_4	1140
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_4	1141
 /*!
  * cache: eviction gave up due to needing to remove a record from the
  * history store but checkpoint is running
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_REMOVE_HS_RACE_WITH_CHECKPOINT	1141
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_REMOVE_HS_RACE_WITH_CHECKPOINT	1142
 /*! cache: eviction gave up due to no progress being made */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_PROGRESS	1142
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_PROGRESS	1143
 /*! cache: eviction passes of a file */
-#define	WT_STAT_CONN_EVICTION_WALK_PASSES		1143
+#define	WT_STAT_CONN_EVICTION_WALK_PASSES		1144
 /*! cache: eviction server candidate queue empty when topping up */
-#define	WT_STAT_CONN_EVICTION_QUEUE_EMPTY		1144
+#define	WT_STAT_CONN_EVICTION_QUEUE_EMPTY		1145
 /*! cache: eviction server candidate queue not empty when topping up */
-#define	WT_STAT_CONN_EVICTION_QUEUE_NOT_EMPTY		1145
+#define	WT_STAT_CONN_EVICTION_QUEUE_NOT_EMPTY		1146
 /*! cache: eviction server completed walks of all dhandles */
-#define	WT_STAT_CONN_EVICTION_DHANDLE_COMPLETE_WALK	1146
+#define	WT_STAT_CONN_EVICTION_DHANDLE_COMPLETE_WALK	1147
 /*!
  * cache: eviction server push pages to queue failed because of racing
  * with setting flag
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_PUSH_PAGES_FAILED_WHEN_FLAGING	1147
+#define	WT_STAT_CONN_EVICTION_SERVER_PUSH_PAGES_FAILED_WHEN_FLAGING	1148
 /*!
  * cache: eviction server skipped the internal pages if eviction is not
  * in aggressive mode
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_INTL_PAGE_NON_AGGRESSIVE	1148
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_INTL_PAGE_NON_AGGRESSIVE	1149
 /*! cache: eviction server skipped the pages already in the urgent queue */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_ALREADY_IN_URGENT_QUEUE	1149
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_ALREADY_IN_URGENT_QUEUE	1150
 /*! cache: eviction server skipped the pages when prefetching */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_PREFETCHED	1150
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_PREFETCHED	1151
 /*! cache: eviction server skipped the root pages */
-#define	WT_STAT_CONN_EVICTION_ROOT_PAGES_SKIPPED	1151
+#define	WT_STAT_CONN_EVICTION_ROOT_PAGES_SKIPPED	1152
 /*!
  * cache: eviction server skips clean history store pages with updates
  * when a precise checkpoint is in progress
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_HISTORY_STORE_PAGES_WITH_UPDATES_DURING_CHECKPOINT	1152
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_HISTORY_STORE_PAGES_WITH_UPDATES_DURING_CHECKPOINT	1153
 /*! cache: eviction server skips dirty pages during a running checkpoint */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_DIRTY_PAGES_DURING_CHECKPOINT	1153
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_DIRTY_PAGES_DURING_CHECKPOINT	1154
 /*!
  * cache: eviction server skips disaggregated trees already visited by
  * the ongoing checkpoint
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_DISAGG_TREES_CHECKPOINTED	1154
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_DISAGG_TREES_CHECKPOINTED	1155
 /*! cache: eviction server skips ingest btrees in disagg */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_INGEST_TREES	1155
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_INGEST_TREES	1156
 /*! cache: eviction server skips internal pages as it has an active child */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_INTL_PAGE_WITH_ACTIVE_CHILD	1156
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_INTL_PAGE_WITH_ACTIVE_CHILD	1157
 /*! cache: eviction server skips metadata pages with history */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_METATDATA_WITH_HISTORY	1157
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_METATDATA_WITH_HISTORY	1158
 /*!
  * cache: eviction server skips pages that are written with transactions
  * greater than the checkpoint timestamp
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_CHECKPOINT_TIMESTAMP	1158
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_CHECKPOINT_TIMESTAMP	1159
 /*!
  * cache: eviction server skips pages that are written with transactions
  * greater than the last running
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_LAST_RUNNING	1159
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_LAST_RUNNING	1160
 /*!
  * cache: eviction server skips pages that are written with transactions
  * greater than the prune timestamp
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_PRUNE_TIMESTAMP	1160
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_PRUNE_TIMESTAMP	1161
 /*!
  * cache: eviction server skips pages that have been reconciled
  * previously at the same prune timestamp
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_PRUNE_TIMESTAMP_NOT_MOVE	1161
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_PRUNE_TIMESTAMP_NOT_MOVE	1162
 /*!
  * cache: eviction server skips pages that previously failed eviction and
  * likely will again
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_RETRY	1162
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_PAGES_RETRY	1163
 /*! cache: eviction server skips pages that we do not want to evict */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_UNWANTED_PAGES	1163
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_UNWANTED_PAGES	1164
 /*! cache: eviction server skips stable btrees in disagg */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_STABLE_TREES	1164
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_STABLE_TREES	1165
 /*! cache: eviction server skips tree that we do not want to evict */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_UNWANTED_TREE	1165
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_UNWANTED_TREE	1166
 /*!
  * cache: eviction server skips trees because there are too many active
  * walks
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_TOO_MANY_ACTIVE_WALKS	1166
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_TOO_MANY_ACTIVE_WALKS	1167
 /*! cache: eviction server skips trees that are being checkpointed */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_CHECKPOINTING_TREES	1167
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_CHECKPOINTING_TREES	1168
 /*!
  * cache: eviction server skips trees that are configured to stick in
  * cache
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_STICK_IN_CACHE	1168
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_STICK_IN_CACHE	1169
 /*!
  * cache: eviction server skips trees that are read-only if it is not
  * looking for clean pages
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_READ_ONLY	1169
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_READ_ONLY	1170
 /*! cache: eviction server skips trees that disable eviction */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_EVICTION_DISABLED	1170
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_EVICTION_DISABLED	1171
 /*! cache: eviction server skips trees that were not useful before */
-#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_NOT_USEFUL_BEFORE	1171
+#define	WT_STAT_CONN_EVICTION_SERVER_SKIP_TREES_NOT_USEFUL_BEFORE	1172
 /*!
  * cache: eviction server slept, because we did not make progress with
  * eviction
  */
-#define	WT_STAT_CONN_EVICTION_SERVER_SLEPT		1172
+#define	WT_STAT_CONN_EVICTION_SERVER_SLEPT		1173
 /*! cache: eviction server unable to reach eviction goal */
-#define	WT_STAT_CONN_EVICTION_SLOW			1173
+#define	WT_STAT_CONN_EVICTION_SLOW			1174
 /*! cache: eviction server waiting for a leaf page */
-#define	WT_STAT_CONN_EVICTION_WALK_LEAF_NOTFOUND	1174
+#define	WT_STAT_CONN_EVICTION_WALK_LEAF_NOTFOUND	1175
 /*! cache: eviction state */
-#define	WT_STAT_CONN_EVICTION_STATE			1175
+#define	WT_STAT_CONN_EVICTION_STATE			1176
 /*!
  * cache: eviction threshold cache full target multiplied by 100 for
  * precision
  */
-#define	WT_STAT_CONN_EVICTION_THRESHOLD_CACHE_FULL_TARGET	1176
+#define	WT_STAT_CONN_EVICTION_THRESHOLD_CACHE_FULL_TARGET	1177
 /*!
  * cache: eviction threshold cache full trigger multiplied by 100 for
  * precision
  */
-#define	WT_STAT_CONN_EVICTION_THRESHOLD_CACHE_FULL_TRIGGER	1177
+#define	WT_STAT_CONN_EVICTION_THRESHOLD_CACHE_FULL_TRIGGER	1178
 /*! cache: eviction threshold dirty target multiplied by 100 for precision */
-#define	WT_STAT_CONN_EVICTION_THRESHOLD_DIRTY_TARGET	1178
+#define	WT_STAT_CONN_EVICTION_THRESHOLD_DIRTY_TARGET	1179
 /*!
  * cache: eviction threshold dirty trigger multiplied by 100 for
  * precision
  */
-#define	WT_STAT_CONN_EVICTION_THRESHOLD_DIRTY_TRIGGER	1179
+#define	WT_STAT_CONN_EVICTION_THRESHOLD_DIRTY_TRIGGER	1180
 /*!
  * cache: eviction threshold updates target multiplied by 100 for
  * precision
  */
-#define	WT_STAT_CONN_EVICTION_THRESHOLD_UPDATES_TARGET	1180
+#define	WT_STAT_CONN_EVICTION_THRESHOLD_UPDATES_TARGET	1181
 /*!
  * cache: eviction threshold updates trigger multiplied by 100 for
  * precision
  */
-#define	WT_STAT_CONN_EVICTION_THRESHOLD_UPDATES_TRIGGER	1181
+#define	WT_STAT_CONN_EVICTION_THRESHOLD_UPDATES_TRIGGER	1182
 /*!
  * cache: eviction walk most recent sleeps for checkpoint handle
  * gathering
  */
-#define	WT_STAT_CONN_EVICTION_WALK_SLEEPS		1182
+#define	WT_STAT_CONN_EVICTION_WALK_SLEEPS		1183
 /*! cache: eviction walk pages queued that had updates */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_UPDATES	1183
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_UPDATES	1184
 /*! cache: eviction walk pages queued that were clean */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_CLEAN	1184
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_CLEAN	1185
 /*! cache: eviction walk pages queued that were dirty */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_DIRTY	1185
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_DIRTY	1186
 /*! cache: eviction walk pages seen that had updates */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN_UPDATES	1186
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN_UPDATES	1187
 /*! cache: eviction walk pages seen that were clean */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN_CLEAN	1187
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN_CLEAN	1188
 /*! cache: eviction walk pages seen that were dirty */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN_DIRTY	1188
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN_DIRTY	1189
 /*! cache: eviction walk restored - had to walk this many pages */
-#define	WT_STAT_CONN_NPOS_EVICT_WALK_MAX		1189
+#define	WT_STAT_CONN_NPOS_EVICT_WALK_MAX		1190
 /*! cache: eviction walk restored position */
-#define	WT_STAT_CONN_EVICTION_RESTORED_POS		1190
+#define	WT_STAT_CONN_EVICTION_RESTORED_POS		1191
 /*! cache: eviction walk restored position differs from the saved one */
-#define	WT_STAT_CONN_EVICTION_RESTORED_POS_DIFFER	1191
+#define	WT_STAT_CONN_EVICTION_RESTORED_POS_DIFFER	1192
 /*! cache: eviction walk target pages histogram - 0-9 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT10	1192
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT10	1193
 /*! cache: eviction walk target pages histogram - 10-31 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT32	1193
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT32	1194
 /*! cache: eviction walk target pages histogram - 128 and higher */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_GE128	1194
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_GE128	1195
 /*! cache: eviction walk target pages histogram - 32-63 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT64	1195
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT64	1196
 /*! cache: eviction walk target pages histogram - 64-128 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT128	1196
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT128	1197
 /*!
  * cache: eviction walk target pages reduced due to history store cache
  * pressure
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_REDUCED	1197
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_REDUCED	1198
 /*! cache: eviction walk target strategy clean pages */
-#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_CLEAN	1198
+#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_CLEAN	1199
 /*! cache: eviction walk target strategy dirty pages */
-#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_DIRTY	1199
+#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_DIRTY	1200
 /*! cache: eviction walk target strategy pages with updates */
-#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_UPDATES	1200
+#define	WT_STAT_CONN_EVICTION_TARGET_STRATEGY_UPDATES	1201
 /*! cache: eviction walks abandoned */
-#define	WT_STAT_CONN_EVICTION_WALKS_ABANDONED		1201
+#define	WT_STAT_CONN_EVICTION_WALKS_ABANDONED		1202
 /*! cache: eviction walks gave up because they restarted their walk twice */
-#define	WT_STAT_CONN_EVICTION_WALKS_STOPPED		1202
+#define	WT_STAT_CONN_EVICTION_WALKS_STOPPED		1203
 /*!
  * cache: eviction walks gave up because they saw too many pages and
  * found no candidates
  */
-#define	WT_STAT_CONN_EVICTION_WALKS_GAVE_UP_NO_TARGETS	1203
+#define	WT_STAT_CONN_EVICTION_WALKS_GAVE_UP_NO_TARGETS	1204
 /*!
  * cache: eviction walks gave up because they saw too many pages and
  * found too few candidates
  */
-#define	WT_STAT_CONN_EVICTION_WALKS_GAVE_UP_RATIO	1204
+#define	WT_STAT_CONN_EVICTION_WALKS_GAVE_UP_RATIO	1205
 /*!
  * cache: eviction walks random search fails to locate a page, results in
  * a null position
  */
-#define	WT_STAT_CONN_EVICTION_WALK_RANDOM_RETURNS_NULL_POSITION	1205
+#define	WT_STAT_CONN_EVICTION_WALK_RANDOM_RETURNS_NULL_POSITION	1206
 /*! cache: eviction walks reached end of tree */
-#define	WT_STAT_CONN_EVICTION_WALKS_ENDED		1206
+#define	WT_STAT_CONN_EVICTION_WALKS_ENDED		1207
 /*! cache: eviction walks restarted */
-#define	WT_STAT_CONN_EVICTION_WALK_RESTART		1207
+#define	WT_STAT_CONN_EVICTION_WALK_RESTART		1208
 /*! cache: eviction walks started from root of tree */
-#define	WT_STAT_CONN_EVICTION_WALK_FROM_ROOT		1208
+#define	WT_STAT_CONN_EVICTION_WALK_FROM_ROOT		1209
 /*! cache: eviction walks started from saved location in tree */
-#define	WT_STAT_CONN_EVICTION_WALK_SAVED_POS		1209
+#define	WT_STAT_CONN_EVICTION_WALK_SAVED_POS		1210
 /*! cache: eviction worker thread active */
-#define	WT_STAT_CONN_EVICTION_ACTIVE_WORKERS		1210
+#define	WT_STAT_CONN_EVICTION_ACTIVE_WORKERS		1211
 /*! cache: eviction worker thread stable number */
-#define	WT_STAT_CONN_EVICTION_STABLE_STATE_WORKERS	1211
+#define	WT_STAT_CONN_EVICTION_STABLE_STATE_WORKERS	1212
 /*! cache: files with active eviction walks */
-#define	WT_STAT_CONN_EVICTION_WALKS_ACTIVE		1212
+#define	WT_STAT_CONN_EVICTION_WALKS_ACTIVE		1213
 /*! cache: files with new eviction walks started */
-#define	WT_STAT_CONN_EVICTION_WALKS_STARTED		1213
+#define	WT_STAT_CONN_EVICTION_WALKS_STARTED		1214
 /*!
  * cache: forced eviction - do not retry count to evict pages selected to
  * evict during reconciliation
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_NO_RETRY		1214
+#define	WT_STAT_CONN_EVICTION_FORCE_NO_RETRY		1215
 /*!
  * cache: forced eviction - history store pages failed to evict while
  * session has history store cursor open
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_HS_FAIL		1215
+#define	WT_STAT_CONN_EVICTION_FORCE_HS_FAIL		1216
 /*!
  * cache: forced eviction - history store pages selected while session
  * has history store cursor open
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_HS			1216
+#define	WT_STAT_CONN_EVICTION_FORCE_HS			1217
 /*!
  * cache: forced eviction - history store pages successfully evicted
  * while session has history store cursor open
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_HS_SUCCESS		1217
+#define	WT_STAT_CONN_EVICTION_FORCE_HS_SUCCESS		1218
 /*!
  * cache: forced eviction - pages evicted belonging to ingest btrees
  * count
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_INGEST_SUCCESS	1218
+#define	WT_STAT_CONN_EVICTION_FORCE_INGEST_SUCCESS	1219
 /*! cache: forced eviction - pages evicted that were clean count */
-#define	WT_STAT_CONN_EVICTION_FORCE_CLEAN		1219
+#define	WT_STAT_CONN_EVICTION_FORCE_CLEAN		1220
 /*! cache: forced eviction - pages evicted that were dirty count */
-#define	WT_STAT_CONN_EVICTION_FORCE_DIRTY		1220
+#define	WT_STAT_CONN_EVICTION_FORCE_DIRTY		1221
 /*!
  * cache: forced eviction - pages selected because of a large number of
  * updates to a single item
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_LONG_UPDATE_LIST	1221
+#define	WT_STAT_CONN_EVICTION_FORCE_LONG_UPDATE_LIST	1222
 /*!
  * cache: forced eviction - pages selected because of too many deleted
  * items count
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_DELETE		1222
+#define	WT_STAT_CONN_EVICTION_FORCE_DELETE		1223
 /*!
  * cache: forced eviction - pages selected belonging to ingest btrees
  * unable to be evicted count
  */
-#define	WT_STAT_CONN_EVICTION_FORCE_INGEST_FAIL		1223
+#define	WT_STAT_CONN_EVICTION_FORCE_INGEST_FAIL		1224
 /*! cache: forced eviction - pages selected count */
-#define	WT_STAT_CONN_EVICTION_FORCE			1224
+#define	WT_STAT_CONN_EVICTION_FORCE			1225
 /*! cache: forced eviction - pages selected unable to be evicted count */
-#define	WT_STAT_CONN_EVICTION_FORCE_FAIL		1225
+#define	WT_STAT_CONN_EVICTION_FORCE_FAIL		1226
 /*!
  * cache: garbage collection from the ingest btree page is skipped
  * because the prune timestamp has not moved
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_PRUNE_TIMESTAMP	1226
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_PRUNE_TIMESTAMP	1227
 /*! cache: hazard pointer blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_HAZARD	1227
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_HAZARD	1228
 /*! cache: hazard pointer check calls */
-#define	WT_STAT_CONN_CACHE_HAZARD_CHECKS		1228
+#define	WT_STAT_CONN_CACHE_HAZARD_CHECKS		1229
 /*! cache: hazard pointer check entries walked */
-#define	WT_STAT_CONN_CACHE_HAZARD_WALKS			1229
+#define	WT_STAT_CONN_CACHE_HAZARD_WALKS			1230
 /*! cache: hazard pointer maximum array length */
-#define	WT_STAT_CONN_CACHE_HAZARD_MAX			1230
+#define	WT_STAT_CONN_CACHE_HAZARD_MAX			1231
 /*! cache: history store cursor not cached during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_HS_CURSOR_NOT_CACHED	1231
+#define	WT_STAT_CONN_CACHE_EVICTION_HS_CURSOR_NOT_CACHED	1232
 /*! cache: history store table insert calls */
-#define	WT_STAT_CONN_CACHE_HS_INSERT			1232
+#define	WT_STAT_CONN_CACHE_HS_INSERT			1233
 /*! cache: history store table insert calls that returned restart */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_RESTART		1233
+#define	WT_STAT_CONN_CACHE_HS_INSERT_RESTART		1234
 /*! cache: history store table key to be processed */
-#define	WT_STAT_CONN_CACHE_HS_KEY_PROCESSED		1234
+#define	WT_STAT_CONN_CACHE_HS_KEY_PROCESSED		1235
 /*! cache: history store table max on-disk size */
-#define	WT_STAT_CONN_CACHE_HS_ONDISK_MAX		1235
+#define	WT_STAT_CONN_CACHE_HS_ONDISK_MAX		1236
 /*! cache: history store table on-disk size */
-#define	WT_STAT_CONN_CACHE_HS_ONDISK			1236
+#define	WT_STAT_CONN_CACHE_HS_ONDISK			1237
 /*! cache: history store table reads */
-#define	WT_STAT_CONN_CACHE_HS_READ			1237
+#define	WT_STAT_CONN_CACHE_HS_READ			1238
 /*! cache: history store table reads missed */
-#define	WT_STAT_CONN_CACHE_HS_READ_MISS			1238
+#define	WT_STAT_CONN_CACHE_HS_READ_MISS			1239
 /*! cache: history store table reads requiring squashed modifies */
-#define	WT_STAT_CONN_CACHE_HS_READ_SQUASH		1239
+#define	WT_STAT_CONN_CACHE_HS_READ_SQUASH		1240
 /*!
  * cache: history store table resolved updates without timestamps that
  * lose their durable timestamp
  */
-#define	WT_STAT_CONN_CACHE_HS_ORDER_LOSE_DURABLE_TIMESTAMP	1240
+#define	WT_STAT_CONN_CACHE_HS_ORDER_LOSE_DURABLE_TIMESTAMP	1241
 /*!
  * cache: history store table truncation by rollback to stable to remove
  * an unstable update
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE	1241
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE	1242
 /*!
  * cache: history store table truncation by rollback to stable to remove
  * an update
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS		1242
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS		1243
 /*!
  * cache: history store table truncation to remove all the keys of a
  * btree
  */
-#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE		1243
+#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE		1244
 /*! cache: history store table truncation to remove an update */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE		1244
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE		1245
 /*!
  * cache: history store table truncation to remove range of updates due
  * to an update without a timestamp on data page
  */
-#define	WT_STAT_CONN_CACHE_HS_ORDER_REMOVE		1245
+#define	WT_STAT_CONN_CACHE_HS_ORDER_REMOVE		1246
 /*!
  * cache: history store table truncation to remove range of updates due
  * to key being removed from the data page during reconciliation
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_ONPAGE_REMOVAL	1246
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_ONPAGE_REMOVAL	1247
 /*!
  * cache: history store table truncations that would have happened in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE_DRYRUN	1247
+#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE_DRYRUN	1248
 /*!
  * cache: history store table truncations to remove an unstable update
  * that would have happened in non-dryrun mode
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE_DRYRUN	1248
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE_DRYRUN	1249
 /*!
  * cache: history store table truncations to remove an update that would
  * have happened in non-dryrun mode
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_DRYRUN	1249
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_DRYRUN	1250
 /*! cache: history store table update to be processed */
-#define	WT_STAT_CONN_CACHE_HS_UPDATE_PROCESSED		1250
+#define	WT_STAT_CONN_CACHE_HS_UPDATE_PROCESSED		1251
 /*!
  * cache: history store table updates without timestamps fixed up by
  * reinserting with the fixed timestamp
  */
-#define	WT_STAT_CONN_CACHE_HS_ORDER_REINSERT		1251
+#define	WT_STAT_CONN_CACHE_HS_ORDER_REINSERT		1252
 /*! cache: history store table writes requiring squashed modifies */
-#define	WT_STAT_CONN_CACHE_HS_WRITE_SQUASH		1252
+#define	WT_STAT_CONN_CACHE_HS_WRITE_SQUASH		1253
 /*! cache: in-memory page passed criteria to be split */
-#define	WT_STAT_CONN_CACHE_INMEM_SPLITTABLE		1253
+#define	WT_STAT_CONN_CACHE_INMEM_SPLITTABLE		1254
 /*! cache: in-memory page splits */
-#define	WT_STAT_CONN_CACHE_INMEM_SPLIT			1254
+#define	WT_STAT_CONN_CACHE_INMEM_SPLIT			1255
 /*! cache: in-memory page splits performed on ingest btree pages */
-#define	WT_STAT_CONN_CACHE_INMEM_SPLIT_INGEST		1255
+#define	WT_STAT_CONN_CACHE_INMEM_SPLIT_INGEST		1256
 /*! cache: ingest pages evicted */
-#define	WT_STAT_CONN_EVICTION_INGEST_SUCCESS		1256
+#define	WT_STAT_CONN_EVICTION_INGEST_SUCCESS		1257
 /*! cache: internal page split blocked its eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_INTERNAL_PAGE_SPLIT	1257
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_INTERNAL_PAGE_SPLIT	1258
 /*! cache: internal pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL		1258
+#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL		1259
 /*! cache: internal pages queued for eviction */
-#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_QUEUED	1259
+#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_QUEUED	1260
 /*! cache: internal pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ_INTERNAL		1260
+#define	WT_STAT_CONN_CACHE_READ_INTERNAL		1261
 /*! cache: internal pages seen by eviction walk */
-#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_SEEN	1261
+#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_SEEN	1262
 /*! cache: internal pages seen by eviction walk that are already queued */
-#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_ALREADY_QUEUED	1262
+#define	WT_STAT_CONN_EVICTION_INTERNAL_PAGES_ALREADY_QUEUED	1263
 /*! cache: internal pages split during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_INTERNAL	1263
+#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_INTERNAL	1264
 /*! cache: leaf pages currently held in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_INUSE_LEAF		1264
+#define	WT_STAT_CONN_CACHE_PAGES_INUSE_LEAF		1265
 /*! cache: leaf pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ_LEAF			1265
+#define	WT_STAT_CONN_CACHE_READ_LEAF			1266
 /*! cache: leaf pages split during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_LEAF		1266
+#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_LEAF		1267
 /*!
  * cache: locate a random in-mem ref by examining all entries on the root
  * page
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_RANDOM_SAMPLE_INMEM_ROOT	1267
+#define	WT_STAT_CONN_CACHE_EVICTION_RANDOM_SAMPLE_INMEM_ROOT	1268
 /*! cache: maximum bytes configured */
-#define	WT_STAT_CONN_CACHE_BYTES_MAX			1268
+#define	WT_STAT_CONN_CACHE_BYTES_MAX			1269
 /*! cache: maximum clean page size seen at eviction per checkpoint */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_CLEAN_PAGE_SIZE_PER_CHECKPOINT	1269
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_CLEAN_PAGE_SIZE_PER_CHECKPOINT	1270
 /*! cache: maximum dirty page size seen at eviction per checkpoint */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_DIRTY_PAGE_SIZE_PER_CHECKPOINT	1270
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_DIRTY_PAGE_SIZE_PER_CHECKPOINT	1271
 /*!
  * cache: maximum gap between unvisited page and connection evict pass
  * generation seen at eviction
  */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_UNVISITED_GEN_GAP	1271
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_UNVISITED_GEN_GAP	1272
 /*!
  * cache: maximum gap between unvisited page and connection evict pass
  * generation seen at eviction per checkpoint
  */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_UNVISITED_GEN_GAP_PER_CHECKPOINT	1272
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_UNVISITED_GEN_GAP_PER_CHECKPOINT	1273
 /*!
  * cache: maximum gap between visited page and connection evict pass
  * generation seen at eviction
  */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_VISITED_GEN_GAP	1273
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_VISITED_GEN_GAP	1274
 /*!
  * cache: maximum gap between visited page and connection evict pass
  * generation seen at eviction per checkpoint
  */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_VISITED_GEN_GAP_PER_CHECKPOINT	1274
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_VISITED_GEN_GAP_PER_CHECKPOINT	1275
 /*! cache: maximum milliseconds spent at a single eviction */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_MILLISECONDS	1275
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_MILLISECONDS	1276
 /*! cache: maximum milliseconds spent at a single eviction per checkpoint */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_MILLISECONDS_PER_CHECKPOINT	1276
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_MILLISECONDS_PER_CHECKPOINT	1277
 /*!
  * cache: maximum number of times a page tried to be added to eviction
  * queue but fail
  */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_ATTEMPTS_TO_QUEUE_PAGE	1277
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_ATTEMPTS_TO_QUEUE_PAGE	1278
 /*! cache: maximum number of times a page tried to be evicted */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_ATTEMPTS_TO_EVICT_PAGE	1278
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_ATTEMPTS_TO_EVICT_PAGE	1279
 /*! cache: maximum updates page size seen at eviction per checkpoint */
-#define	WT_STAT_CONN_EVICTION_MAXIMUM_UPDATES_PAGE_SIZE_PER_CHECKPOINT	1279
+#define	WT_STAT_CONN_EVICTION_MAXIMUM_UPDATES_PAGE_SIZE_PER_CHECKPOINT	1280
 /*! cache: modified page evict attempts by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_DIRTY_ATTEMPT		1280
+#define	WT_STAT_CONN_EVICTION_APP_DIRTY_ATTEMPT		1281
 /*! cache: modified page evict failures by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_DIRTY_FAIL		1281
+#define	WT_STAT_CONN_EVICTION_APP_DIRTY_FAIL		1282
 /*! cache: modified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1282
+#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1283
 /*! cache: multi-block reconciliation blocked whilst checkpoint is running */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_MULTI_BLOCK_RECONCILIATION_DURING_CHECKPOINT	1283
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_MULTI_BLOCK_RECONCILIATION_DURING_CHECKPOINT	1284
 /*! cache: npos read - had to walk this many pages */
-#define	WT_STAT_CONN_NPOS_READ_WALK_MAX			1284
+#define	WT_STAT_CONN_NPOS_READ_WALK_MAX			1285
 /*! cache: number of internal pages read that had deltas attached */
-#define	WT_STAT_CONN_CACHE_READ_INTERNAL_DELTA		1285
+#define	WT_STAT_CONN_CACHE_READ_INTERNAL_DELTA		1286
 /*! cache: number of leaf pages read that had deltas attached */
-#define	WT_STAT_CONN_CACHE_READ_LEAF_DELTA		1286
+#define	WT_STAT_CONN_CACHE_READ_LEAF_DELTA		1287
 /*! cache: number of times dirty trigger was reached */
-#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_DIRTY_REACHED	1287
+#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_DIRTY_REACHED	1288
 /*! cache: number of times eviction trigger was reached */
-#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_REACHED	1288
+#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_REACHED	1289
 /*! cache: number of times updates trigger was reached */
-#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_UPDATES_REACHED	1289
+#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_UPDATES_REACHED	1290
 /*! cache: number of times when cas update the btree max_lsn failed */
-#define	WT_STAT_CONN_CACHE_CAS_BTREE_MAX_LSN_RACE	1290
+#define	WT_STAT_CONN_CACHE_CAS_BTREE_MAX_LSN_RACE	1291
 /*! cache: obsolete updates removed */
-#define	WT_STAT_CONN_CACHE_OBSOLETE_UPDATES_REMOVED	1291
+#define	WT_STAT_CONN_CACHE_OBSOLETE_UPDATES_REMOVED	1292
 /*! cache: operations timed out waiting for space in cache */
-#define	WT_STAT_CONN_EVICTION_TIMED_OUT_OPS		1292
+#define	WT_STAT_CONN_EVICTION_TIMED_OUT_OPS		1293
 /*!
  * cache: overflow keys on a multiblock row-store page blocked its
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_OVERFLOW_KEYS	1293
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_OVERFLOW_KEYS	1294
 /*! cache: overflow pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ_OVERFLOW		1294
+#define	WT_STAT_CONN_CACHE_READ_OVERFLOW		1295
 /*! cache: page evict attempts by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_ATTEMPT		1295
+#define	WT_STAT_CONN_EVICTION_APP_ATTEMPT		1296
 /*! cache: page evict failures by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_FAIL			1296
+#define	WT_STAT_CONN_EVICTION_APP_FAIL			1297
 /*! cache: page eviction blocked due to materialization frontier */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_MATERIALIZATION	1297
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_MATERIALIZATION	1298
 /*!
  * cache: page eviction blocked in disaggregated storage as it can only
  * be written by the next checkpoint
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_DISAGG_NEXT_CHECKPOINT	1298
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_DISAGG_NEXT_CHECKPOINT	1299
 /*! cache: page split during eviction deepened the tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1299
+#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1300
 /*! cache: page written requiring history store records */
-#define	WT_STAT_CONN_CACHE_WRITE_HS			1300
+#define	WT_STAT_CONN_CACHE_WRITE_HS			1301
 /*! cache: pages already in queue when topping up */
-#define	WT_STAT_CONN_EVICTION_PAGES_REMAINING_IN_QUEUE	1301
+#define	WT_STAT_CONN_EVICTION_PAGES_REMAINING_IN_QUEUE	1302
 /*! cache: pages considered for eviction that were brought in by pre-fetch */
-#define	WT_STAT_CONN_EVICTION_CONSIDER_PREFETCH		1302
+#define	WT_STAT_CONN_EVICTION_CONSIDER_PREFETCH		1303
 /*! cache: pages currently held in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_INUSE			1303
+#define	WT_STAT_CONN_CACHE_PAGES_INUSE			1304
 /*! cache: pages currently held in the cache from the ingest btrees */
-#define	WT_STAT_CONN_CACHE_PAGES_INUSE_INGEST		1304
+#define	WT_STAT_CONN_CACHE_PAGES_INUSE_INGEST		1305
 /*! cache: pages currently held in the cache from the stable btrees */
-#define	WT_STAT_CONN_CACHE_PAGES_INUSE_STABLE		1305
+#define	WT_STAT_CONN_CACHE_PAGES_INUSE_STABLE		1306
 /*! cache: pages dirtied due to obsolete time window by eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY_OBSOLETE_TW	1306
+#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY_OBSOLETE_TW	1307
 /*! cache: pages evicted ahead of the page materialization frontier */
-#define	WT_STAT_CONN_CACHE_EVICTION_AHEAD_OF_LAST_MATERIALIZED_LSN	1307
+#define	WT_STAT_CONN_CACHE_EVICTION_AHEAD_OF_LAST_MATERIALIZED_LSN	1308
 /*! cache: pages evicted in parallel with checkpoint */
-#define	WT_STAT_CONN_EVICTION_PAGES_IN_PARALLEL_WITH_CHECKPOINT	1308
+#define	WT_STAT_CONN_EVICTION_PAGES_IN_PARALLEL_WITH_CHECKPOINT	1309
 /*! cache: pages queued for eviction */
-#define	WT_STAT_CONN_EVICTION_PAGES_ORDINARY_QUEUED	1309
+#define	WT_STAT_CONN_EVICTION_PAGES_ORDINARY_QUEUED	1310
 /*! cache: pages queued for eviction post lru sorting */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_POST_LRU	1310
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_POST_LRU	1311
 /*! cache: pages queued for urgent eviction */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT	1311
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT	1312
 /*! cache: pages queued for urgent eviction during walk */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_OLDEST	1312
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_OLDEST	1313
 /*!
  * cache: pages queued for urgent eviction from history store due to high
  * dirty content
  */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT_HS_DIRTY	1313
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT_HS_DIRTY	1314
 /*! cache: pages read into cache after truncate */
-#define	WT_STAT_CONN_CACHE_READ_DELETED			1314
+#define	WT_STAT_CONN_CACHE_READ_DELETED			1315
 /*! cache: pages read into cache after truncate in prepare state */
-#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1315
+#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1316
 /*! cache: pages read into cache by checkpoint */
-#define	WT_STAT_CONN_CACHE_READ_CHECKPOINT		1316
+#define	WT_STAT_CONN_CACHE_READ_CHECKPOINT		1317
 /*!
  * cache: pages removed from the ordinary queue to be queued for urgent
  * eviction
  */
-#define	WT_STAT_CONN_EVICTION_CLEAR_ORDINARY		1317
+#define	WT_STAT_CONN_EVICTION_CLEAR_ORDINARY		1318
 /*! cache: pages requested from the cache due to pre-fetch */
-#define	WT_STAT_CONN_CACHE_PAGES_PREFETCH		1318
+#define	WT_STAT_CONN_CACHE_PAGES_PREFETCH		1319
 /*! cache: pages requested from the cache internal */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_INTERNAL	1319
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_INTERNAL	1320
 /*! cache: pages requested from the cache leaf */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_LEAF		1320
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_LEAF		1321
 /*! cache: pages requested from the history store */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_HS		1321
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_HS		1322
 /*! cache: pages seen by eviction walk */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1322
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1323
 /*! cache: pages seen by eviction walk that are already queued */
-#define	WT_STAT_CONN_EVICTION_PAGES_ALREADY_QUEUED	1323
+#define	WT_STAT_CONN_EVICTION_PAGES_ALREADY_QUEUED	1324
 /*! cache: pages selected for eviction unable to be evicted */
-#define	WT_STAT_CONN_EVICTION_FAIL			1324
+#define	WT_STAT_CONN_EVICTION_FAIL			1325
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * active children on an internal page
  */
-#define	WT_STAT_CONN_EVICTION_FAIL_ACTIVE_CHILDREN_ON_AN_INTERNAL_PAGE	1325
+#define	WT_STAT_CONN_EVICTION_FAIL_ACTIVE_CHILDREN_ON_AN_INTERNAL_PAGE	1326
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * failure in reconciliation
  */
-#define	WT_STAT_CONN_EVICTION_FAIL_IN_RECONCILIATION	1326
+#define	WT_STAT_CONN_EVICTION_FAIL_IN_RECONCILIATION	1327
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * race between checkpoint and updates without timestamps
  */
-#define	WT_STAT_CONN_EVICTION_FAIL_CHECKPOINT_NO_TS	1327
+#define	WT_STAT_CONN_EVICTION_FAIL_CHECKPOINT_NO_TS	1328
 /*!
  * cache: pages selected for eviction unable to be evicted belonging to
  * ingest btrees
  */
-#define	WT_STAT_CONN_EVICTION_FAIL_INGEST		1328
+#define	WT_STAT_CONN_EVICTION_FAIL_INGEST		1329
 /*! cache: pages walked for eviction */
-#define	WT_STAT_CONN_EVICTION_WALK			1329
+#define	WT_STAT_CONN_EVICTION_WALK			1330
 /*!
  * cache: pages with an unresolved multiblock split flagged by checkpoint
  * to be evicted soon
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_MULTIBLOCK_CHECKPOINT_FLAGGED	1330
+#define	WT_STAT_CONN_CACHE_EVICTION_MULTIBLOCK_CHECKPOINT_FLAGGED	1331
 /*!
  * cache: pages with an unresolved multiblock split re-reconciled by
  * checkpoint
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_MULTIBLOCK_SPLIT_RE_RECONCILED	1331
+#define	WT_STAT_CONN_CACHE_EVICTION_MULTIBLOCK_SPLIT_RE_RECONCILED	1332
 /*! cache: pages written from cache */
-#define	WT_STAT_CONN_CACHE_WRITE			1332
+#define	WT_STAT_CONN_CACHE_WRITE			1333
 /*!
  * cache: pages written requiring in-memory restoration due to invisible
  * updates
  */
-#define	WT_STAT_CONN_CACHE_WRITE_RESTORE_INVISIBLE	1333
+#define	WT_STAT_CONN_CACHE_WRITE_RESTORE_INVISIBLE	1334
 /*!
  * cache: pages written requiring in-memory restoration due to scrub
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_WRITE_RESTORE_SCRUB		1334
+#define	WT_STAT_CONN_CACHE_WRITE_RESTORE_SCRUB		1335
 /*! cache: percentage overhead */
-#define	WT_STAT_CONN_CACHE_OVERHEAD			1335
+#define	WT_STAT_CONN_CACHE_OVERHEAD			1336
 /*!
  * cache: precise checkpoint caused an eviction to be skipped because any
  * dirty content needs to remain in cache
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_PRECISE_CHECKPOINT	1336
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_PRECISE_CHECKPOINT	1337
 /*!
  * cache: realizing in-memory split after reconciliation failed due to
  * internal lock busy
  */
-#define	WT_STAT_CONN_CACHE_EVICT_SPLIT_FAILED_LOCK	1337
+#define	WT_STAT_CONN_CACHE_EVICT_SPLIT_FAILED_LOCK	1338
 /*! cache: recent modification of a page blocked its eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	1338
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	1339
 /*! cache: reconciled pages scrubbed and added back to the cache clean */
-#define	WT_STAT_CONN_CACHE_SCRUB_RESTORE		1339
+#define	WT_STAT_CONN_CACHE_SCRUB_RESTORE		1340
 /*! cache: reverse splits performed */
-#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS		1340
+#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS		1341
 /*!
  * cache: reverse splits skipped because of VLCS namespace gap
  * restrictions
  */
-#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	1341
+#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	1342
 /*! cache: shared disk hash table size */
-#define	WT_STAT_CONN_CACHE_SHARED_DSK_HASH_SIZE		1342
+#define	WT_STAT_CONN_CACHE_SHARED_DSK_HASH_SIZE		1343
 /*! cache: shared disk hit */
-#define	WT_STAT_CONN_CACHE_SHARED_DSK_HIT		1343
+#define	WT_STAT_CONN_CACHE_SHARED_DSK_HIT		1344
 /*! cache: shared disk miss */
-#define	WT_STAT_CONN_CACHE_SHARED_DSK_MISS		1344
+#define	WT_STAT_CONN_CACHE_SHARED_DSK_MISS		1345
 /*! cache: shared history store cursor not cached during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_HS_SHARED_CURSOR_NOT_CACHED	1345
+#define	WT_STAT_CONN_CACHE_EVICTION_HS_SHARED_CURSOR_NOT_CACHED	1346
 /*! cache: size of delta updates reconstructed on the base page */
-#define	WT_STAT_CONN_CACHE_READ_DELTA_UPDATES		1346
+#define	WT_STAT_CONN_CACHE_READ_DELTA_UPDATES		1347
 /*! cache: size of tombstones restored when reading a page */
-#define	WT_STAT_CONN_CACHE_READ_RESTORED_TOMBSTONE_BYTES	1347
+#define	WT_STAT_CONN_CACHE_READ_RESTORED_TOMBSTONE_BYTES	1348
 /*! cache: the number of times full update inserted to history store */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1348
+#define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1349
 /*! cache: the number of times reverse modify inserted to history store */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1349
+#define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1350
 /*! cache: time eviction worker threads spend waiting for locks (usecs) */
-#define	WT_STAT_CONN_EVICTION_WORKER_LOCK_WAIT_TIME	1350
+#define	WT_STAT_CONN_EVICTION_WORKER_LOCK_WAIT_TIME	1351
 /*!
  * cache: total milliseconds spent inside reentrant history store
  * evictions in a reconciliation
  */
-#define	WT_STAT_CONN_EVICTION_REENTRY_HS_EVICTION_MILLISECONDS	1351
+#define	WT_STAT_CONN_EVICTION_REENTRY_HS_EVICTION_MILLISECONDS	1352
 /*! cache: tracked bytes belonging to internal pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1352
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1353
 /*!
  * cache: tracked bytes belonging to internal pages in the cache from the
  * ingest btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL_INGEST	1353
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL_INGEST	1354
 /*!
  * cache: tracked bytes belonging to internal pages in the cache from the
  * stable btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL_STABLE	1354
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL_STABLE	1355
 /*! cache: tracked bytes belonging to leaf pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1355
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1356
 /*!
  * cache: tracked bytes belonging to leaf pages in the cache from the
  * ingest btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF_INGEST		1356
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF_INGEST		1357
 /*!
  * cache: tracked bytes belonging to leaf pages in the cache from the
  * stable btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF_STABLE		1357
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF_STABLE		1358
 /*! cache: tracked dirty bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1358
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1359
 /*! cache: tracked dirty bytes in the cache from the ingest btrees */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INGEST		1359
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INGEST		1360
 /*! cache: tracked dirty bytes in the cache from the stable btrees */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_STABLE		1360
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_STABLE		1361
 /*! cache: tracked dirty internal page bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL		1361
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL		1362
 /*!
  * cache: tracked dirty internal page bytes in the cache from the ingest
  * btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL_INGEST	1362
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL_INGEST	1363
 /*!
  * cache: tracked dirty internal page bytes in the cache from the stable
  * btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL_STABLE	1363
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL_STABLE	1364
 /*! cache: tracked dirty leaf page bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF		1364
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF		1365
 /*!
  * cache: tracked dirty leaf page bytes in the cache from the ingest
  * btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF_INGEST	1365
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF_INGEST	1366
 /*!
  * cache: tracked dirty leaf page bytes in the cache from the stable
  * btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF_STABLE	1366
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF_STABLE	1367
 /*! cache: tracked dirty pages in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1367
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1368
 /*! cache: tracked dirty pages in the cache from the ingest btrees */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY_INGEST		1368
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY_INGEST		1369
 /*! cache: tracked dirty pages in the cache from the stable btrees */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY_STABLE		1369
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY_STABLE		1370
 /*! cache: uncommitted truncate blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	1370
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	1371
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1371
+#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1372
 /*! cache: update bytes belonging to the history store table in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_HS_UPDATES		1372
+#define	WT_STAT_CONN_CACHE_BYTES_HS_UPDATES		1373
 /*! cache: updates in uncommitted txn - bytes */
-#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_BYTES	1373
+#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_BYTES	1374
 /*! cache: updates in uncommitted txn - count */
-#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_COUNT	1374
+#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_COUNT	1375
 /*! capacity: background fsync file handles considered */
-#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1375
+#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1376
 /*! capacity: background fsync file handles synced */
-#define	WT_STAT_CONN_FSYNC_ALL_FH			1376
+#define	WT_STAT_CONN_FSYNC_ALL_FH			1377
 /*! capacity: background fsync time (msecs) */
-#define	WT_STAT_CONN_FSYNC_ALL_TIME			1377
+#define	WT_STAT_CONN_FSYNC_ALL_TIME			1378
 /*! capacity: bytes read */
-#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1378
+#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1379
 /*! capacity: bytes written for checkpoint */
-#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1379
+#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1380
 /*! capacity: bytes written for eviction */
-#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1380
+#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1381
 /*! capacity: bytes written for log */
-#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1381
+#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1382
 /*! capacity: bytes written total */
-#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1382
+#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1383
 /*! capacity: threshold to call fsync */
-#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1383
+#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1384
 /*! capacity: time waiting due to total capacity (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1384
+#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1385
 /*! capacity: time waiting during checkpoint (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1385
+#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1386
 /*! capacity: time waiting during eviction (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1386
+#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1387
 /*! capacity: time waiting during logging (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1387
+#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1388
 /*! capacity: time waiting during read (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_READ			1388
+#define	WT_STAT_CONN_CAPACITY_TIME_READ			1389
 /*! checkpoint-cleanup: most recent duration on all eligible files (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_DURATION	1389
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_DURATION	1390
 /*! checkpoint-cleanup: most recent handles processed */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_HANDLE_PROCESSED	1390
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_HANDLE_PROCESSED	1391
 /*! checkpoint-cleanup: most recent in-memory pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_INMEM_PAGES_VISITED	1391
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_INMEM_PAGES_VISITED	1392
 /*! checkpoint-cleanup: pages added for eviction */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_EVICT	1392
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_EVICT	1393
 /*! checkpoint-cleanup: pages dirtied due to obsolete time window */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	1393
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	1394
 /*! checkpoint-cleanup: pages read into cache (reclaim_space) */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	1394
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	1395
 /*! checkpoint-cleanup: pages read into cache due to obsolete time window */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	1395
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	1396
 /*! checkpoint-cleanup: pages removed */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_REMOVED	1396
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_REMOVED	1397
 /*! checkpoint-cleanup: pages skipped during tree walk */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	1397
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	1398
 /*! checkpoint-cleanup: pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_VISITED	1398
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_VISITED	1399
 /*! checkpoint-cleanup: successful calls */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_SUCCESS		1399
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_SUCCESS		1400
 /*! checkpoint: checkpoint has acquired a snapshot for its transaction */
-#define	WT_STAT_CONN_CHECKPOINT_SNAPSHOT_ACQUIRED	1400
+#define	WT_STAT_CONN_CHECKPOINT_SNAPSHOT_ACQUIRED	1401
 /*! checkpoint: checkpoints skipped because database was clean */
-#define	WT_STAT_CONN_CHECKPOINT_SKIPPED			1401
+#define	WT_STAT_CONN_CHECKPOINT_SKIPPED			1402
 /*! checkpoint: fsync calls after allocating the transaction ID */
-#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST		1402
+#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST		1403
 /*! checkpoint: fsync duration after allocating the transaction ID (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST_DURATION	1403
+#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST_DURATION	1404
 /*! checkpoint: generation */
-#define	WT_STAT_CONN_CHECKPOINT_GENERATION		1404
+#define	WT_STAT_CONN_CHECKPOINT_GENERATION		1405
 /*! checkpoint: max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_MAX		1405
+#define	WT_STAT_CONN_CHECKPOINT_TIME_MAX		1406
 /*!
  * checkpoint: metadata operations applied during disaggregated
  * checkpoint
  */
-#define	WT_STAT_CONN_CHECKPOINT_DISAGG_METADATA_APPLY	1406
+#define	WT_STAT_CONN_CHECKPOINT_DISAGG_METADATA_APPLY	1407
 /*!
  * checkpoint: metadata operations skipped during disaggregated
  * checkpoint because they were not stable
  */
-#define	WT_STAT_CONN_CHECKPOINT_DISAGG_METADATA_UNSTABLE	1407
+#define	WT_STAT_CONN_CHECKPOINT_DISAGG_METADATA_UNSTABLE	1408
 /*! checkpoint: min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_MIN		1408
+#define	WT_STAT_CONN_CHECKPOINT_TIME_MIN		1409
 /*!
  * checkpoint: most recent duration for checkpoint dropping all handles
  * (usecs)
  */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROP_DURATION	1409
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROP_DURATION	1410
 /*! checkpoint: most recent duration for gathering all handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION		1410
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION		1411
 /*! checkpoint: most recent duration for gathering applied handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLY_DURATION	1411
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLY_DURATION	1412
 /*! checkpoint: most recent duration for gathering skipped handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIP_DURATION	1412
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIP_DURATION	1413
 /*! checkpoint: most recent duration for handles metadata checked (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECK_DURATION	1413
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECK_DURATION	1414
 /*! checkpoint: most recent duration for locking the handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCK_DURATION	1414
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCK_DURATION	1415
 /*! checkpoint: most recent handles applied */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLIED		1415
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLIED		1416
 /*! checkpoint: most recent handles checkpoint dropped */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROPPED		1416
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROPPED		1417
 /*! checkpoint: most recent handles metadata checked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECKED	1417
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECKED	1418
 /*! checkpoint: most recent handles metadata locked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCKED		1418
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCKED		1419
 /*! checkpoint: most recent handles skipped */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIPPED		1419
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIPPED		1420
 /*! checkpoint: most recent handles walked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_WALKED		1420
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_WALKED		1421
 /*! checkpoint: most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_RECENT		1421
+#define	WT_STAT_CONN_CHECKPOINT_TIME_RECENT		1422
 /*! checkpoint: number of bytes reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED_BYTES	1422
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED_BYTES	1423
 /*! checkpoint: number of checkpoints started by api */
-#define	WT_STAT_CONN_CHECKPOINTS_API			1423
+#define	WT_STAT_CONN_CHECKPOINTS_API			1424
 /*! checkpoint: number of checkpoints started by compaction */
-#define	WT_STAT_CONN_CHECKPOINTS_COMPACT		1424
+#define	WT_STAT_CONN_CHECKPOINTS_COMPACT		1425
 /*! checkpoint: number of files synced */
-#define	WT_STAT_CONN_CHECKPOINT_SYNC			1425
+#define	WT_STAT_CONN_CHECKPOINT_SYNC			1426
 /*! checkpoint: number of handles visited after writes complete */
-#define	WT_STAT_CONN_CHECKPOINT_PRESYNC			1426
+#define	WT_STAT_CONN_CHECKPOINT_PRESYNC			1427
 /*! checkpoint: number of history store pages reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_HS_PAGES_RECONCILED	1427
+#define	WT_STAT_CONN_CHECKPOINT_HS_PAGES_RECONCILED	1428
 /*! checkpoint: number of internal pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_INTERNAL	1428
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_INTERNAL	1429
 /*! checkpoint: number of leaf pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_LEAF	1429
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_LEAF	1430
 /*! checkpoint: number of pages reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED	1430
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED	1431
 /*!
  * checkpoint: number of pages reconciled by checkpoint parallel worker
  * threads
  */
-#define	WT_STAT_CONN_CHECKPOINT_PARALLEL_PAGES_RECONCILED	1431
+#define	WT_STAT_CONN_CHECKPOINT_PARALLEL_PAGES_RECONCILED	1432
 /*! checkpoint: prepare currently running */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1432
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1433
 /*! checkpoint: prepare max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1433
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1434
 /*! checkpoint: prepare min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1434
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1435
 /*! checkpoint: prepare most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1435
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1436
 /*! checkpoint: prepare total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1436
+#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1437
 /*! checkpoint: progress state */
-#define	WT_STAT_CONN_CHECKPOINT_STATE			1437
+#define	WT_STAT_CONN_CHECKPOINT_STATE			1438
 /*! checkpoint: scrub dirty target */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1438
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1439
 /*! checkpoint: scrub max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1439
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1440
 /*! checkpoint: scrub min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1440
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1441
 /*! checkpoint: scrub most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1441
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1442
 /*! checkpoint: scrub total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1442
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1443
 /*! checkpoint: stop timing stress active */
-#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1443
+#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1444
 /*!
  * checkpoint: the percentage of checkpoint sync time spent in
  * reconciliation across all threads
  */
-#define	WT_STAT_CONN_CHECKPOINT_SYNC_REC_PCT		1444
+#define	WT_STAT_CONN_CHECKPOINT_SYNC_REC_PCT		1445
 /*! checkpoint: time spent on per-tree checkpoint work (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1445
+#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1446
 /*! checkpoint: total failed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1446
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1447
 /*! checkpoint: total succeed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1447
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1448
 /*! checkpoint: total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1448
+#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1449
 /*!
  * checkpoint: total time (msecs) writing pages to stable storage during
  * checkpoint reconciliation
  */
-#define	WT_STAT_CONN_CHECKPOINT_REC_BLKCACHE_WRITE	1449
+#define	WT_STAT_CONN_CHECKPOINT_REC_BLKCACHE_WRITE	1450
 /*! checkpoint: wait cycles while cache dirty level is decreasing */
-#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1450
+#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1451
 /*! connection: auto adjusting condition resets */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1451
+#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1452
 /*! connection: auto adjusting condition wait calls */
-#define	WT_STAT_CONN_COND_AUTO_WAIT			1452
+#define	WT_STAT_CONN_COND_AUTO_WAIT			1453
 /*!
  * connection: auto adjusting condition wait raced to update timeout and
  * skipped updating
  */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1453
+#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1454
 /*! connection: btrees currently open */
-#define	WT_STAT_CONN_BTREE_OPEN				1454
+#define	WT_STAT_CONN_BTREE_OPEN				1455
 /*! connection: detected system time went backwards */
-#define	WT_STAT_CONN_TIME_TRAVEL			1455
+#define	WT_STAT_CONN_TIME_TRAVEL			1456
 /*! connection: files currently open */
-#define	WT_STAT_CONN_FILE_OPEN				1456
+#define	WT_STAT_CONN_FILE_OPEN				1457
 /*! connection: hash bucket array size for data handles */
-#define	WT_STAT_CONN_BUCKETS_DH				1457
+#define	WT_STAT_CONN_BUCKETS_DH				1458
 /*! connection: hash bucket array size general */
-#define	WT_STAT_CONN_BUCKETS				1458
+#define	WT_STAT_CONN_BUCKETS				1459
 /*! connection: memory allocations */
-#define	WT_STAT_CONN_MEMORY_ALLOCATION			1459
+#define	WT_STAT_CONN_MEMORY_ALLOCATION			1460
 /*! connection: memory frees */
-#define	WT_STAT_CONN_MEMORY_FREE			1460
+#define	WT_STAT_CONN_MEMORY_FREE			1461
 /*! connection: memory re-allocations */
-#define	WT_STAT_CONN_MEMORY_GROW			1461
+#define	WT_STAT_CONN_MEMORY_GROW			1462
 /*! connection: number of sessions without a sweep for 5+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1462
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1463
 /*! connection: number of sessions without a sweep for 60+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1463
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1464
 /*! connection: pthread mutex condition wait calls */
-#define	WT_STAT_CONN_COND_WAIT				1464
+#define	WT_STAT_CONN_COND_WAIT				1465
 /*! connection: pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			1465
+#define	WT_STAT_CONN_RWLOCK_READ			1466
 /*! connection: pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			1466
+#define	WT_STAT_CONN_RWLOCK_WRITE			1467
 /*! connection: total fsync I/Os */
-#define	WT_STAT_CONN_FSYNC_IO				1467
+#define	WT_STAT_CONN_FSYNC_IO				1468
 /*! connection: total read I/Os */
-#define	WT_STAT_CONN_READ_IO				1468
+#define	WT_STAT_CONN_READ_IO				1469
 /*! connection: total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				1469
+#define	WT_STAT_CONN_WRITE_IO				1470
 /*! cursor: Total number of deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1470
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1471
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1471
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1472
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1472
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1473
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1473
+#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1474
 /*!
  * cursor: Total number of in-memory deleted pages skipped during tree
  * walk
  */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1474
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1475
 /*! cursor: Total number of on-disk deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1475
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1476
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1476
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1477
 /*!
  * cursor: Total number of times cursor fails to temporarily release
  * pinned page to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1477
+#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1478
 /*!
  * cursor: Total number of times cursor temporarily releases pinned page
  * to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION			1478
+#define	WT_STAT_CONN_CURSOR_REPOSITION			1479
 /*! cursor: bulk cursor count */
-#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1479
+#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1480
 /*! cursor: cached cursor count */
-#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1480
+#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1481
 /*! cursor: cursor bound calls that return an error */
-#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1481
+#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1482
 /*! cursor: cursor bounds cleared from reset */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1482
+#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1483
 /*! cursor: cursor bounds comparisons performed */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1483
+#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1484
 /*! cursor: cursor bounds next called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1484
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1485
 /*! cursor: cursor bounds next early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1485
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1486
 /*! cursor: cursor bounds prev called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1486
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1487
 /*! cursor: cursor bounds prev early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1487
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1488
 /*! cursor: cursor bounds search early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1488
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1489
 /*! cursor: cursor bounds search near call repositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1489
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1490
 /*! cursor: cursor bulk loaded cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1490
+#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1491
 /*! cursor: cursor cache calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1491
+#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1492
 /*! cursor: cursor close calls that result in cache */
-#define	WT_STAT_CONN_CURSOR_CACHE			1492
+#define	WT_STAT_CONN_CURSOR_CACHE			1493
 /*! cursor: cursor close calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1493
+#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1494
 /*! cursor: cursor compare calls that return an error */
-#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1494
+#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1495
 /*! cursor: cursor create calls */
-#define	WT_STAT_CONN_CURSOR_CREATE			1495
+#define	WT_STAT_CONN_CURSOR_CREATE			1496
 /*! cursor: cursor equals calls that return an error */
-#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1496
+#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1497
 /*! cursor: cursor get key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1497
+#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1498
 /*! cursor: cursor get value calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1498
+#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1499
 /*! cursor: cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT			1499
+#define	WT_STAT_CONN_CURSOR_INSERT			1500
 /*! cursor: cursor insert calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1500
+#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1501
 /*! cursor: cursor insert check calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1501
+#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1502
 /*! cursor: cursor insert key and value bytes */
-#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1502
+#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1503
 /*! cursor: cursor largest key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1503
+#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1504
 /*! cursor: cursor modify calls */
-#define	WT_STAT_CONN_CURSOR_MODIFY			1504
+#define	WT_STAT_CONN_CURSOR_MODIFY			1505
 /*! cursor: cursor modify calls that return an error */
-#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1505
+#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1506
 /*! cursor: cursor modify key and value bytes affected */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1506
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1507
 /*! cursor: cursor modify value bytes modified */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1507
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1508
 /*! cursor: cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT			1508
+#define	WT_STAT_CONN_CURSOR_NEXT			1509
 /*! cursor: cursor next calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1509
+#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1510
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1510
+#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1511
 /*!
  * cursor: cursor next calls that skip greater than 1 and fewer than 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1511
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1512
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1512
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1513
 /*! cursor: cursor next random calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1513
+#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1514
 /*! cursor: cursor operation restarted */
-#define	WT_STAT_CONN_CURSOR_RESTART			1514
+#define	WT_STAT_CONN_CURSOR_RESTART			1515
 /*! cursor: cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV			1515
+#define	WT_STAT_CONN_CURSOR_PREV			1516
 /*! cursor: cursor prev calls that return an error */
-#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1516
+#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1517
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1517
+#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1518
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1518
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1519
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1519
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1520
 /*! cursor: cursor reconfigure calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1520
+#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1521
 /*! cursor: cursor remove calls */
-#define	WT_STAT_CONN_CURSOR_REMOVE			1521
+#define	WT_STAT_CONN_CURSOR_REMOVE			1522
 /*! cursor: cursor remove calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1522
+#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1523
 /*! cursor: cursor remove key bytes removed */
-#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1523
+#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1524
 /*! cursor: cursor reopen calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1524
+#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1525
 /*! cursor: cursor reserve calls */
-#define	WT_STAT_CONN_CURSOR_RESERVE			1525
+#define	WT_STAT_CONN_CURSOR_RESERVE			1526
 /*! cursor: cursor reserve calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1526
+#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1527
 /*! cursor: cursor reset calls */
-#define	WT_STAT_CONN_CURSOR_RESET			1527
+#define	WT_STAT_CONN_CURSOR_RESET			1528
 /*! cursor: cursor reset calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1528
+#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1529
 /*! cursor: cursor search calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH			1529
+#define	WT_STAT_CONN_CURSOR_SEARCH			1530
 /*! cursor: cursor search calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1530
+#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1531
 /*! cursor: cursor search history store calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1531
+#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1532
 /*! cursor: cursor search near calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1532
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1533
 /*! cursor: cursor search near calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1533
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1534
 /*! cursor: cursor sweep buckets */
-#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1534
+#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1535
 /*! cursor: cursor sweep cursors closed */
-#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1535
+#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1536
 /*! cursor: cursor sweep cursors examined */
-#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1536
+#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1537
 /*! cursor: cursor sweeps */
-#define	WT_STAT_CONN_CURSOR_SWEEP			1537
+#define	WT_STAT_CONN_CURSOR_SWEEP			1538
 /*! cursor: cursor truncate calls */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE			1538
+#define	WT_STAT_CONN_CURSOR_TRUNCATE			1539
 /*! cursor: cursor truncates performed on individual keys */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1539
+#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1540
 /*! cursor: cursor update calls */
-#define	WT_STAT_CONN_CURSOR_UPDATE			1540
+#define	WT_STAT_CONN_CURSOR_UPDATE			1541
 /*! cursor: cursor update calls that return an error */
-#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1541
+#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1542
 /*! cursor: cursor update key and value bytes */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1542
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1543
 /*! cursor: cursor update value size change */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1543
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1544
 /*! cursor: cursors reused from cache */
-#define	WT_STAT_CONN_CURSOR_REOPEN			1544
+#define	WT_STAT_CONN_CURSOR_REOPEN			1545
 /*! cursor: open cursor count */
-#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1545
+#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1546
 /*! cursor: open cursor time application (usecs) */
-#define	WT_STAT_CONN_CURSOR_OPEN_TIME_USER_USECS	1546
+#define	WT_STAT_CONN_CURSOR_OPEN_TIME_USER_USECS	1547
 /*! cursor: open cursor time internal (usecs) */
-#define	WT_STAT_CONN_CURSOR_OPEN_TIME_INTERNAL_USECS	1547
+#define	WT_STAT_CONN_CURSOR_OPEN_TIME_INTERNAL_USECS	1548
 /*! data-handle: Layered connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_LAYERED_COUNT	1548
+#define	WT_STAT_CONN_DH_CONN_HANDLE_LAYERED_COUNT	1549
 /*! data-handle: Table connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TABLE_COUNT		1549
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TABLE_COUNT		1550
 /*! data-handle: Tiered connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_COUNT	1550
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_COUNT	1551
 /*! data-handle: Tiered_Tree connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_TREE_COUNT	1551
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_TREE_COUNT	1552
 /*! data-handle: btree connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_BTREE_COUNT		1552
+#define	WT_STAT_CONN_DH_CONN_HANDLE_BTREE_COUNT		1553
 /*! data-handle: checkpoint connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_CHECKPOINT_COUNT	1553
+#define	WT_STAT_CONN_DH_CONN_HANDLE_CHECKPOINT_COUNT	1554
 /*! data-handle: connection data handle size */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1554
+#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1555
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1555
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1556
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1556
+#define	WT_STAT_CONN_DH_SWEEP_REF			1557
 /*! data-handle: connection sweep dead dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_DEAD_CLOSE		1557
+#define	WT_STAT_CONN_DH_SWEEP_DEAD_CLOSE		1558
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1558
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1559
 /*! data-handle: connection sweep expired dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_EXPIRED_CLOSE		1559
+#define	WT_STAT_CONN_DH_SWEEP_EXPIRED_CLOSE		1560
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1560
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1561
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1561
+#define	WT_STAT_CONN_DH_SWEEPS				1562
 /*!
  * data-handle: connection sweeps skipped due to checkpoint gathering
  * handles
  */
-#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1562
+#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1563
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1563
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1564
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1564
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1565
 /*! disagg: abandon checkpoints failed */
-#define	WT_STAT_CONN_DISAGG_ABANDON_CHECKPOINT_FAILED	1565
+#define	WT_STAT_CONN_DISAGG_ABANDON_CHECKPOINT_FAILED	1566
 /*! disagg: abandon checkpoints succeeded */
-#define	WT_STAT_CONN_DISAGG_ABANDON_CHECKPOINT_SUCCEED	1566
+#define	WT_STAT_CONN_DISAGG_ABANDON_CHECKPOINT_SUCCEED	1567
 /*! disagg: apply checkpoint metadata most recent time (msecs) */
-#define	WT_STAT_CONN_DISAGG_APPLY_CHECKPOINT_META_TIME	1567
+#define	WT_STAT_CONN_DISAGG_APPLY_CHECKPOINT_META_TIME	1568
 /*! disagg: connection reconfiguration */
-#define	WT_STAT_CONN_DISAGG_CONN_RECONFIG		1568
+#define	WT_STAT_CONN_DISAGG_CONN_RECONFIG		1569
 /*! disagg: database size */
-#define	WT_STAT_CONN_DISAGG_DATABASE_SIZE		1569
+#define	WT_STAT_CONN_DISAGG_DATABASE_SIZE		1570
 /*!
  * disagg: existing file metadata entries updated during checkpoint pick-
  * up
  */
-#define	WT_STAT_CONN_DISAGG_PICK_UP_FILE_META_UPDATED	1570
+#define	WT_STAT_CONN_DISAGG_PICK_UP_FILE_META_UPDATED	1571
 /*! disagg: new file metadata entries inserted during checkpoint pick-up */
-#define	WT_STAT_CONN_DISAGG_PICK_UP_FILE_META_INSERTED	1571
+#define	WT_STAT_CONN_DISAGG_PICK_UP_FILE_META_INSERTED	1572
 /*! disagg: pick up checkpoint most recent time (msecs) */
-#define	WT_STAT_CONN_DISAGG_PICK_UP_CHECKPOINT_TIME	1572
+#define	WT_STAT_CONN_DISAGG_PICK_UP_CHECKPOINT_TIME	1573
 /*! disagg: role leader */
-#define	WT_STAT_CONN_DISAGG_ROLE_LEADER			1573
+#define	WT_STAT_CONN_DISAGG_ROLE_LEADER			1574
 /*! disagg: step down most recent time (msecs) */
-#define	WT_STAT_CONN_DISAGG_STEP_DOWN_TIME		1574
+#define	WT_STAT_CONN_DISAGG_STEP_DOWN_TIME		1575
 /*! disagg: step up most recent time (msecs) */
-#define	WT_STAT_CONN_DISAGG_STEP_UP_TIME		1575
+#define	WT_STAT_CONN_DISAGG_STEP_UP_TIME		1576
 /*! layered: Layered table cursor insert operations */
-#define	WT_STAT_CONN_LAYERED_CURS_INSERT		1576
+#define	WT_STAT_CONN_LAYERED_CURS_INSERT		1577
 /*! layered: Layered table cursor modify operations */
-#define	WT_STAT_CONN_LAYERED_CURS_MODIFY		1577
+#define	WT_STAT_CONN_LAYERED_CURS_MODIFY		1578
 /*! layered: Layered table cursor next operations */
-#define	WT_STAT_CONN_LAYERED_CURS_NEXT			1578
+#define	WT_STAT_CONN_LAYERED_CURS_NEXT			1579
 /*! layered: Layered table cursor next operations from the ingest btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_NEXT_INGEST		1579
+#define	WT_STAT_CONN_LAYERED_CURS_NEXT_INGEST		1580
 /*! layered: Layered table cursor next operations from the stable btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_NEXT_STABLE		1580
+#define	WT_STAT_CONN_LAYERED_CURS_NEXT_STABLE		1581
 /*!
  * layered: Layered table cursor opens the stable btree for the first
  * time
  */
-#define	WT_STAT_CONN_LAYERED_CURS_OPEN_STABLE		1581
+#define	WT_STAT_CONN_LAYERED_CURS_OPEN_STABLE		1582
 /*! layered: Layered table cursor prev operations */
-#define	WT_STAT_CONN_LAYERED_CURS_PREV			1582
+#define	WT_STAT_CONN_LAYERED_CURS_PREV			1583
 /*! layered: Layered table cursor prev operations from the ingest btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_PREV_INGEST		1583
+#define	WT_STAT_CONN_LAYERED_CURS_PREV_INGEST		1584
 /*! layered: Layered table cursor prev operations from the stable btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_PREV_STABLE		1584
+#define	WT_STAT_CONN_LAYERED_CURS_PREV_STABLE		1585
 /*! layered: Layered table cursor remove operations */
-#define	WT_STAT_CONN_LAYERED_CURS_REMOVE		1585
+#define	WT_STAT_CONN_LAYERED_CURS_REMOVE		1586
 /*!
  * layered: Layered table cursor reopens the stable btree (role change or
  * checkpoint advance)
  */
-#define	WT_STAT_CONN_LAYERED_CURS_REOPEN_STABLE		1586
+#define	WT_STAT_CONN_LAYERED_CURS_REOPEN_STABLE		1587
 /*! layered: Layered table cursor search near operations */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR		1587
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR		1588
 /*!
  * layered: Layered table cursor search near operations from the ingest
  * btrees
  */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_INGEST	1588
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_INGEST	1589
 /*!
  * layered: Layered table cursor search near operations from the stable
  * btrees
  */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_STABLE	1589
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_STABLE	1590
 /*! layered: Layered table cursor search operations */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH		1590
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH		1591
 /*! layered: Layered table cursor search operations from the ingest btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_INGEST		1591
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_INGEST		1592
 /*! layered: Layered table cursor search operations from the stable btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_STABLE		1592
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_STABLE		1593
 /*! layered: Layered table cursor update operations */
-#define	WT_STAT_CONN_LAYERED_CURS_UPDATE		1593
+#define	WT_STAT_CONN_LAYERED_CURS_UPDATE		1594
 /*!
  * layered: checkpoints performed on this table by the layered table
  * manager
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS	1594
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS	1595
 /*! layered: disagg pick up checkpoints failed */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FAILED	1595
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FAILED	1596
 /*! layered: disagg pick up checkpoints succeeded */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_SUCCEED	1596
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_SUCCEED	1597
 /*!
  * layered: how many log applications the layered table manager applied
  * on this tree
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_APPLIED	1597
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_APPLIED	1598
 /*!
  * layered: how many log applications the layered table manager skipped
  * on this tree
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_SKIPPED	1598
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_SKIPPED	1599
 /*!
  * layered: how many previously-applied LSNs the layered table manager
  * skipped on this tree
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_SKIP_LSN	1599
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_SKIP_LSN	1600
 /*! layered: number of checkpoints picked up by a follower */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FOLLOWER	1600
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FOLLOWER	1601
 /*! layered: the number of tables the layered table manager has open */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_TABLES	1601
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_TABLES	1602
 /*! layered: the number of times the truncate list was searched */
-#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_SEARCH_CALLS	1602
+#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_SEARCH_CALLS	1603
 /*!
  * layered: the number of times truncate list garbage collection ran with
  * a valid prune timestamp
  */
-#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_GC_RUNS	1603
+#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_GC_RUNS	1604
 /*!
  * layered: the number of truncate list entries removed by garbage
  * collection
  */
-#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_GC_ENTRIES_REMOVED	1604
+#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_GC_ENTRIES_REMOVED	1605
 /*! layered: the number of truncate list entries walked during search */
-#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_SEARCH_ENTRIES_WALKED	1605
+#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_SEARCH_ENTRIES_WALKED	1606
 /*!
  * live-restore: number of bytes copied from the source to the
  * destination
  */
-#define	WT_STAT_CONN_LIVE_RESTORE_BYTES_COPIED		1606
+#define	WT_STAT_CONN_LIVE_RESTORE_BYTES_COPIED		1607
 /*! live-restore: number of files remaining for migration completion */
-#define	WT_STAT_CONN_LIVE_RESTORE_WORK_REMAINING	1607
+#define	WT_STAT_CONN_LIVE_RESTORE_WORK_REMAINING	1608
 /*! live-restore: number of reads from the source database */
-#define	WT_STAT_CONN_LIVE_RESTORE_SOURCE_READ_COUNT	1608
+#define	WT_STAT_CONN_LIVE_RESTORE_SOURCE_READ_COUNT	1609
 /*! live-restore: source read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT2	1609
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT2	1610
 /*! live-restore: source read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT5	1610
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT5	1611
 /*! live-restore: source read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT10	1611
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT10	1612
 /*! live-restore: source read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT50	1612
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT50	1613
 /*! live-restore: source read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT100	1613
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT100	1614
 /*! live-restore: source read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT250	1614
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT250	1615
 /*! live-restore: source read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT500	1615
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT500	1616
 /*! live-restore: source read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT1000	1616
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT1000	1617
 /*! live-restore: source read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_GT1000	1617
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_GT1000	1618
 /*! live-restore: source read latency histogram total (msecs) */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_TOTAL_MSECS	1618
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_TOTAL_MSECS	1619
 /*! live-restore: state */
-#define	WT_STAT_CONN_LIVE_RESTORE_STATE			1619
+#define	WT_STAT_CONN_LIVE_RESTORE_STATE			1620
 /*! load-control: number of read operations rejected due to load control */
-#define	WT_STAT_CONN_READ_REJECT_COUNT			1620
+#define	WT_STAT_CONN_READ_REJECT_COUNT			1621
 /*! load-control: number of write operations rejected due to load control */
-#define	WT_STAT_CONN_WRITE_REJECT_COUNT			1621
+#define	WT_STAT_CONN_WRITE_REJECT_COUNT			1622
 /*! load-control: read load at the system level */
-#define	WT_STAT_CONN_READ_LOAD				1622
+#define	WT_STAT_CONN_READ_LOAD				1623
 /*! load-control: write load at the system level */
-#define	WT_STAT_CONN_WRITE_LOAD				1623
+#define	WT_STAT_CONN_WRITE_LOAD				1624
 /*! lock: btree page lock acquisitions */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_COUNT		1624
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_COUNT		1625
 /*! lock: btree page lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_APPLICATION	1625
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_APPLICATION	1626
 /*! lock: btree page lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_INTERNAL	1626
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_INTERNAL	1627
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1627
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1628
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1628
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1629
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1629
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1630
 /*! lock: dhandle lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1630
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1631
 /*! lock: dhandle lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1631
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1632
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1632
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1633
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1633
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1634
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1634
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1635
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1635
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1636
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1636
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1637
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1637
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1638
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1638
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1639
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1639
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1640
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1640
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1641
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1641
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1642
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1642
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1643
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1643
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1644
 /*! lock: txn global lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1644
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1645
 /*! lock: txn global lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1645
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1646
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1646
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1647
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1647
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1648
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1648
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1649
 /*! log: force log remove time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1649
+#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1650
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1650
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1651
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1651
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1652
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1652
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1653
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1653
+#define	WT_STAT_CONN_LOG_FLUSH				1654
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1654
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1655
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1655
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1656
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1656
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1657
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1657
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1658
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1658
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1659
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1659
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1660
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1660
+#define	WT_STAT_CONN_LOG_SCANS				1661
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1661
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1662
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1662
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1663
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1663
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1664
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1664
+#define	WT_STAT_CONN_LOG_SYNC				1665
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1665
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1666
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1666
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1667
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1667
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1668
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1668
+#define	WT_STAT_CONN_LOG_WRITES				1669
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1669
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1670
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1670
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1671
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1671
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1672
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1672
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1673
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1673
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1674
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1674
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1675
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1675
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1676
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1676
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1677
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1677
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1678
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1678
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1679
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1679
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1680
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1680
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1681
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1681
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1682
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1682
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1683
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1683
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1684
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1684
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1685
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1685
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1686
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1686
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1687
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1687
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1688
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1688
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1689
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1689
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1690
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1690
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1691
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1691
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1692
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1692
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1693
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1693
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1694
 /*! perf: block manager read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT2	1694
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT2	1695
 /*! perf: block manager read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT5	1695
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT5	1696
 /*! perf: block manager read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT10	1696
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT10	1697
 /*! perf: block manager read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT50	1697
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT50	1698
 /*! perf: block manager read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT100	1698
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT100	1699
 /*! perf: block manager read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT250	1699
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT250	1700
 /*! perf: block manager read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT500	1700
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT500	1701
 /*! perf: block manager read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT1000	1701
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT1000	1702
 /*! perf: block manager read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_GT1000	1702
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_GT1000	1703
 /*! perf: block manager read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_TOTAL_MSECS	1703
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_TOTAL_MSECS	1704
 /*! perf: block manager write latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT2	1704
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT2	1705
 /*! perf: block manager write latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT5	1705
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT5	1706
 /*! perf: block manager write latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT10	1706
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT10	1707
 /*! perf: block manager write latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT50	1707
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT50	1708
 /*! perf: block manager write latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT100	1708
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT100	1709
 /*! perf: block manager write latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT250	1709
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT250	1710
 /*! perf: block manager write latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT500	1710
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT500	1711
 /*! perf: block manager write latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT1000	1711
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT1000	1712
 /*! perf: block manager write latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_GT1000	1712
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_GT1000	1713
 /*! perf: block manager write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_TOTAL_MSECS	1713
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_TOTAL_MSECS	1714
 /*! perf: disagg block manager read latency histogram (bucket 1) - 50-99us */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT100	1714
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT100	1715
 /*!
  * perf: disagg block manager read latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT250	1715
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT250	1716
 /*!
  * perf: disagg block manager read latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT500	1716
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT500	1717
 /*!
  * perf: disagg block manager read latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT1000	1717
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT1000	1718
 /*!
  * perf: disagg block manager read latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT2500	1718
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT2500	1719
 /*!
  * perf: disagg block manager read latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT5000	1719
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT5000	1720
 /*!
  * perf: disagg block manager read latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT10000	1720
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT10000	1721
 /*!
  * perf: disagg block manager read latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_GT10000	1721
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_GT10000	1722
 /*! perf: disagg block manager read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_TOTAL_USECS	1722
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_TOTAL_USECS	1723
 /*!
  * perf: disagg block manager write latency histogram (bucket 1) -
  * 50-99us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT100	1723
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT100	1724
 /*!
  * perf: disagg block manager write latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT250	1724
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT250	1725
 /*!
  * perf: disagg block manager write latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT500	1725
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT500	1726
 /*!
  * perf: disagg block manager write latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT1000	1726
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT1000	1727
 /*!
  * perf: disagg block manager write latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT2500	1727
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT2500	1728
 /*!
  * perf: disagg block manager write latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT5000	1728
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT5000	1729
 /*!
  * perf: disagg block manager write latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT10000	1729
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT10000	1730
 /*!
  * perf: disagg block manager write latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_GT10000	1730
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_GT10000	1731
 /*! perf: disagg block manager write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_TOTAL_USECS	1731
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_TOTAL_USECS	1732
 /*! perf: file system read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT2	1732
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT2	1733
 /*! perf: file system read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT5	1733
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT5	1734
 /*! perf: file system read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1734
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1735
 /*! perf: file system read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1735
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1736
 /*! perf: file system read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1736
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1737
 /*! perf: file system read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1737
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1738
 /*! perf: file system read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1738
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1739
 /*! perf: file system read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1739
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1740
 /*! perf: file system read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1740
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1741
 /*! perf: file system read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1741
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1742
 /*! perf: file system write latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT2	1742
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT2	1743
 /*! perf: file system write latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT5	1743
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT5	1744
 /*! perf: file system write latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1744
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1745
 /*! perf: file system write latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1745
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1746
 /*! perf: file system write latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1746
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1747
 /*! perf: file system write latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1747
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1748
 /*! perf: file system write latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1748
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1749
 /*! perf: file system write latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1749
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1750
 /*! perf: file system write latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1750
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1751
 /*! perf: file system write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1751
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1752
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 1) -
  * 0-100us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT100	1752
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT100	1753
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT250	1753
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT250	1754
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT500	1754
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT500	1755
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT1000	1755
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT1000	1756
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT2500	1756
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT2500	1757
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT5000	1757
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT5000	1758
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT10000	1758
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT10000	1759
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_GT10000	1759
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_GT10000	1760
 /*! perf: internal page deltas reconstruct latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_TOTAL_USECS	1760
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_TOTAL_USECS	1761
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 1) -
  * 0-100us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT100	1761
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT100	1762
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT250	1762
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT250	1763
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT500	1763
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT500	1764
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT1000	1764
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT1000	1765
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT2500	1765
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT2500	1766
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT5000	1766
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT5000	1767
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT10000	1767
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT10000	1768
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_GT10000	1768
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_GT10000	1769
 /*! perf: leaf page deltas reconstruct latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_TOTAL_USECS	1769
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_TOTAL_USECS	1770
 /*! perf: operation read latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1770
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1771
 /*! perf: operation read latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1771
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1772
 /*! perf: operation read latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1772
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1773
 /*! perf: operation read latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1773
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1774
 /*! perf: operation read latency histogram (bucket 5) - 1000-2499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT2500	1774
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT2500	1775
 /*! perf: operation read latency histogram (bucket 6) - 2500-4999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT5000	1775
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT5000	1776
 /*! perf: operation read latency histogram (bucket 7) - 5000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1776
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1777
 /*! perf: operation read latency histogram (bucket 8) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1777
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1778
 /*! perf: operation read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1778
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1779
 /*! perf: operation write latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1779
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1780
 /*! perf: operation write latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1780
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1781
 /*! perf: operation write latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1781
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1782
 /*! perf: operation write latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1782
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1783
 /*! perf: operation write latency histogram (bucket 5) - 1000-2499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT2500	1783
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT2500	1784
 /*! perf: operation write latency histogram (bucket 6) - 2500-4999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT5000	1784
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT5000	1785
 /*! perf: operation write latency histogram (bucket 7) - 5000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1785
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1786
 /*! perf: operation write latency histogram (bucket 8) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1786
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1787
 /*! perf: operation write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1787
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1788
 /*! prefetch: could not perform pre-fetch on internal page */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1788
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1789
 /*!
  * prefetch: could not perform pre-fetch on ref without the pre-fetch
  * flag set
  */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1789
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1790
 /*! prefetch: pre-fetch attempted, session has pre-fetching enabled */
-#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1790
+#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1791
 /*! prefetch: pre-fetch not repeating for recently pre-fetched ref */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1791
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1792
 /*! prefetch: pre-fetch not triggered after single disk read */
-#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1792
+#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1793
 /*! prefetch: pre-fetch not triggered as there is no valid dhandle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1793
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1794
 /*! prefetch: pre-fetch not triggered due to disk read count */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1794
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1795
 /*! prefetch: pre-fetch not triggered due to internal session */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1795
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1796
 /*! prefetch: pre-fetch not triggered due to special btree handle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1796
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1797
 /*! prefetch: pre-fetch not triggered, pre-fetch queue is full */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_QUEUE_FULL	1797
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_QUEUE_FULL	1798
 /*! prefetch: pre-fetch page not on disk when reading */
-#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1798
+#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1799
 /*! prefetch: pre-fetch pages queued */
-#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1799
+#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1800
 /*! prefetch: pre-fetch pages read in background */
-#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1800
+#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1801
 /*!
  * prefetch: pre-fetch session check passed, pre-fetch work issued to
  * btree
  */
-#define	WT_STAT_CONN_PREFETCH_ATTEMPTS_SUCCEEDED	1801
+#define	WT_STAT_CONN_PREFETCH_ATTEMPTS_SUCCEEDED	1802
 /*! prefetch: pre-fetch skipped reading in a page due to harmless error */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1802
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1803
 /*!
  * prefetch: pre-fetch skipped traversal of internal page due to active
  * split generation
  */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SPLIT_GEN	1803
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SPLIT_GEN	1804
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1804
+#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1805
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1805
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1806
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1806
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1807
 /*!
  * reconciliation: average length of delta chain on internal page with
  * deltas
  */
-#define	WT_STAT_CONN_REC_AVERAGE_INTERNAL_PAGE_DELTA_CHAIN_LENGTH	1807
+#define	WT_STAT_CONN_REC_AVERAGE_INTERNAL_PAGE_DELTA_CHAIN_LENGTH	1808
 /*! reconciliation: average length of delta chain on leaf page with deltas */
-#define	WT_STAT_CONN_REC_AVERAGE_LEAF_PAGE_DELTA_CHAIN_LENGTH	1808
+#define	WT_STAT_CONN_REC_AVERAGE_LEAF_PAGE_DELTA_CHAIN_LENGTH	1809
 /*!
  * reconciliation: changes since prior reconciliation (bucket 1) between
  * 1 and 5
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE5			1809
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE5			1810
 /*!
  * reconciliation: changes since prior reconciliation (bucket 2) between
  * 6 and 10
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE10			1810
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE10			1811
 /*!
  * reconciliation: changes since prior reconciliation (bucket 3) between
  * 11 and 20
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE20			1811
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE20			1812
 /*!
  * reconciliation: changes since prior reconciliation (bucket 4) between
  * 21 and 50
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE50			1812
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE50			1813
 /*!
  * reconciliation: changes since prior reconciliation (bucket 5) between
  * 51 and 100
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE100		1813
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE100		1814
 /*!
  * reconciliation: changes since prior reconciliation (bucket 6) between
  * 101 and 200
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE200		1814
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE200		1815
 /*!
  * reconciliation: changes since prior reconciliation (bucket 7) between
  * 201 and 500
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE500		1815
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE500		1816
 /*!
  * reconciliation: changes since prior reconciliation (bucket 8) greater
  * than 500
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_GT500		1816
+#define	WT_STAT_CONN_REC_PAGE_MODS_GT500		1817
 /*! reconciliation: cursor next/prev calls during HS wrapup search_near */
-#define	WT_STAT_CONN_REC_HS_WRAPUP_NEXT_PREV_CALLS	1817
+#define	WT_STAT_CONN_REC_HS_WRAPUP_NEXT_PREV_CALLS	1818
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1818
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1819
 /*!
  * reconciliation: free page ID due to failed page replacement
  * reconciliation in disagg
  */
-#define	WT_STAT_CONN_REC_FREE_PAGE_ID_DUE_TO_FAILED_REPLACEMENT_RECONCILIATION	1819
+#define	WT_STAT_CONN_REC_FREE_PAGE_ID_DUE_TO_FAILED_REPLACEMENT_RECONCILIATION	1820
 /*! reconciliation: full internal pages written instead of a page delta */
-#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_INTERNAL	1820
+#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_INTERNAL	1821
 /*! reconciliation: full leaf pages written instead of a page delta */
-#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_LEAF		1821
+#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_LEAF		1822
 /*!
  * reconciliation: ingest btree reconciliation keeps the aborted prepare
  * updates
  */
-#define	WT_STAT_CONN_REC_INGEST_KEEP_PREPARE_ROLLBACK	1822
+#define	WT_STAT_CONN_REC_INGEST_KEEP_PREPARE_ROLLBACK	1823
 /*! reconciliation: internal page delta keys deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_DELETED	1823
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_DELETED	1824
 /*! reconciliation: internal page delta keys updated/inserted */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_UPDATED	1824
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_UPDATED	1825
 /*! reconciliation: internal page deltas written */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL		1825
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL		1826
 /*! reconciliation: internal page multi-block writes */
-#define	WT_STAT_CONN_REC_MULTIBLOCK_INTERNAL		1826
+#define	WT_STAT_CONN_REC_MULTIBLOCK_INTERNAL		1827
 /*! reconciliation: leaf page deltas written */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_LEAF		1827
+#define	WT_STAT_CONN_REC_PAGE_DELTA_LEAF		1828
 /*! reconciliation: leaf page multi-block writes */
-#define	WT_STAT_CONN_REC_MULTIBLOCK_LEAF		1828
+#define	WT_STAT_CONN_REC_MULTIBLOCK_LEAF		1829
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1829
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1830
 /*! reconciliation: max deltas seen on internal page during reconciliation */
-#define	WT_STAT_CONN_REC_MAX_INTERNAL_PAGE_DELTAS	1830
+#define	WT_STAT_CONN_REC_MAX_INTERNAL_PAGE_DELTAS	1831
 /*! reconciliation: max deltas seen on leaf page during reconciliation */
-#define	WT_STAT_CONN_REC_MAX_LEAF_PAGE_DELTAS		1831
+#define	WT_STAT_CONN_REC_MAX_LEAF_PAGE_DELTAS		1832
 /*! reconciliation: maximum milliseconds spent in a reconciliation call */
-#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1832
+#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1833
 /*!
  * reconciliation: maximum milliseconds spent in building a disk image in
  * a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1833
+#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1834
 /*!
  * reconciliation: maximum milliseconds spent in moving updates to the
  * history store in a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1834
+#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1835
 /*!
  * reconciliation: number of keys that are garbage collected from the
  * disk images in the ingest btrees for disaggregated storage
  */
-#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_DISK_IMAGE	1835
+#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_DISK_IMAGE	1836
 /*!
  * reconciliation: number of keys that are garbage collected from the
  * update chains in the ingest btrees for disaggregated storage
  */
-#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_UPDATE_CHAIN	1836
+#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_UPDATE_CHAIN	1837
 /*! reconciliation: overflow values written */
-#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1837
+#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1838
 /*! reconciliation: page deltas rejected due to invalid page ID */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_INVALID_PAGE_ID	1838
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_INVALID_PAGE_ID	1839
 /*! reconciliation: page deltas rejected due to max consecutive limit */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MAX_CONSECUTIVE_EXCEEDED	1839
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MAX_CONSECUTIVE_EXCEEDED	1840
 /*! reconciliation: page deltas rejected due to multiblock reconciliation */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MULTIBLOCK	1840
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MULTIBLOCK	1841
 /*!
  * reconciliation: page deltas rejected due to non-single page in
  * previous reconciliation
  */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_NON_SINGLE_PAGE	1841
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_NON_SINGLE_PAGE	1842
 /*! reconciliation: page deltas rejected due to size threshold */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_SIZE_THRESHOLD	1842
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_SIZE_THRESHOLD	1843
 /*!
  * reconciliation: page deltas rejected due to too many keys removed from
  * the disk image
  */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_DELETE_THRESHOLD	1843
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_DELETE_THRESHOLD	1844
 /*! reconciliation: page deltas rejected due to zero entries */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_ZERO_ENTRIES	1844
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_ZERO_ENTRIES	1845
 /*!
  * reconciliation: page deltas rejected: build function returned false
  * (disabled, in-memory split, or internal page constraints not met)
  */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_BUILD_FAILED	1845
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_BUILD_FAILED	1846
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1846
+#define	WT_STAT_CONN_REC_PAGES				1847
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1847
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1848
 /*! reconciliation: page reconciliation calls for pages between 1 and 10MB */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_1MB_TO_10MB		1848
+#define	WT_STAT_CONN_REC_PAGES_SIZE_1MB_TO_10MB		1849
 /*!
  * reconciliation: page reconciliation calls for pages between 10 and
  * 100MB
  */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_10MB_TO_100MB	1849
+#define	WT_STAT_CONN_REC_PAGES_SIZE_10MB_TO_100MB	1850
 /*!
  * reconciliation: page reconciliation calls for pages between 100MB and
  * 1GB
  */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_100MB_TO_1GB	1850
+#define	WT_STAT_CONN_REC_PAGES_SIZE_100MB_TO_1GB	1851
 /*! reconciliation: page reconciliation calls for pages over 1GB */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_1GB_PLUS		1851
+#define	WT_STAT_CONN_REC_PAGES_SIZE_1GB_PLUS		1852
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * prepared transaction metadata
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1852
+#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1853
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * timestamps
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1853
+#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1854
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * transaction ids
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1854
+#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1855
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1855
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1856
 /*! reconciliation: pages eligible for delta generation */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_ELIGIBLE		1856
+#define	WT_STAT_CONN_REC_PAGE_DELTA_ELIGIBLE		1857
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1857
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1858
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1858
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1859
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1859
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1860
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1860
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1861
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1861
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1862
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1862
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1863
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1863
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1864
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1864
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1865
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1865
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1866
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1866
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1867
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1867
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1868
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1868
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1869
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1869
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1870
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1870
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1871
 /*! reconciliation: pages written with at least one internal page delta */
-#define	WT_STAT_CONN_REC_PAGES_WITH_INTERNAL_DELTAS	1871
+#define	WT_STAT_CONN_REC_PAGES_WITH_INTERNAL_DELTAS	1872
 /*! reconciliation: pages written with at least one leaf page delta */
-#define	WT_STAT_CONN_REC_PAGES_WITH_LEAF_DELTAS		1872
+#define	WT_STAT_CONN_REC_PAGES_WITH_LEAF_DELTAS		1873
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1873
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1874
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1874
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1875
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1875
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1876
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1876
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1877
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1877
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1878
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1878
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1879
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1879
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1880
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1880
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1881
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1881
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1882
 /*! reconciliation: writes skipped in disaggregated storage */
-#define	WT_STAT_CONN_REC_SKIP_WRITE			1882
+#define	WT_STAT_CONN_REC_SKIP_WRITE			1883
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1883
+#define	WT_STAT_CONN_SESSION_OPEN			1884
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1884
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1885
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1885
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1886
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1886
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1887
 /*! session: table alter triggering checkpoint calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1887
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1888
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1888
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1889
 /*! session: table compact conflicted with checkpoint */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1889
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1890
 /*! session: table compact dhandle successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1890
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1891
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1891
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1892
 /*! session: table compact failed calls due to cache pressure */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1892
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1893
 /*!
  * session: table compact in-memory page footprint rewritten by
  * compaction
  */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_BYTES_REWRITE_INMEM	1893
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_BYTES_REWRITE_INMEM	1894
 /*! session: table compact passes */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1894
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1895
 /*! session: table compact pulled into eviction */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1895
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1896
 /*! session: table compact running */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1896
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1897
 /*! session: table compact skipped as process would not reduce file size */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1897
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1898
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1898
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1899
 /*! session: table compact timeout */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1899
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1900
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1900
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1901
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1901
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1902
 /*! session: table create with import failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1902
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1903
 /*! session: table create with import repair calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1903
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1904
 /*! session: table create with import successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1904
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1905
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1905
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1906
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1906
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1907
 /*! session: table publish failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_PUBLISH_FAIL		1907
+#define	WT_STAT_CONN_SESSION_TABLE_PUBLISH_FAIL		1908
 /*! session: table publish successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_PUBLISH_SUCCESS	1908
+#define	WT_STAT_CONN_SESSION_TABLE_PUBLISH_SUCCESS	1909
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1909
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1910
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1910
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1911
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1911
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1912
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1912
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1913
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1913
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1914
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1914
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1915
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1915
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1916
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1916
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1917
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1917
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1918
 /*! thread-yield: application thread operations waiting for cache */
-#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1918
+#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1919
 /*!
  * thread-yield: application thread operations waiting for interruptible
  * cache eviction
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_OPS	1919
+#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_OPS	1920
 /*!
  * thread-yield: application thread operations waiting for mandatory
  * cache eviction
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_OPS	1920
+#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_OPS	1921
 /*! thread-yield: application thread snapshot refreshed for eviction */
-#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1921
+#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1922
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1922
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1923
 /*!
  * thread-yield: application thread time waiting for interruptible cache
  * eviction (usecs)
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_TIME	1923
+#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_TIME	1924
 /*!
  * thread-yield: application thread time waiting for mandatory cache
  * eviction (usecs)
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_TIME	1924
+#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_TIME	1925
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1925
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1926
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1926
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1927
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1927
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1928
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1928
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1929
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1929
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1930
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1930
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1931
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1931
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1932
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1932
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1933
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1933
+#define	WT_STAT_CONN_PAGE_SLEEP				1934
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1934
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1935
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1935
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1936
 /*! thread-yield: page split and restart read */
-#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1936
+#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1937
 /*! thread-yield: pages skipped during read due to deleted state */
-#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1937
+#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1938
 /*!
  * tiered-storage: attempts to remove a local object and the object is in
  * use
  */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1938
+#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1939
 /*! tiered-storage: flush_tier failed calls */
-#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1939
+#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1940
 /*! tiered-storage: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1940
+#define	WT_STAT_CONN_FLUSH_TIER				1941
 /*! tiered-storage: flush_tier tables skipped due to no checkpoint */
-#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1941
+#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1942
 /*! tiered-storage: flush_tier tables switched */
-#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1942
+#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1943
 /*! tiered-storage: local objects removed */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1943
+#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1944
 /*! tiered-storage: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1944
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1945
 /*! tiered-storage: tiered operations removed without processing */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1945
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1946
 /*! tiered-storage: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1946
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1947
 /*! tiered-storage: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1947
+#define	WT_STAT_CONN_TIERED_RETENTION			1948
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1948
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1949
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1949
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1950
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1950
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1951
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1951
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1952
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1952
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1953
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1953
+#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1954
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1954
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1955
 /*! transaction: oldest transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1955
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1956
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1956
+#define	WT_STAT_CONN_TXN_PREPARE			1957
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1957
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1958
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1958
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1959
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1959
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1960
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1960
+#define	WT_STAT_CONN_TXN_QUERY_TS			1961
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1961
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1962
 /*! transaction: rollback to stable applied btrees */
-#define	WT_STAT_CONN_TXN_RTS_BTREES_APPLIED		1962
+#define	WT_STAT_CONN_TXN_RTS_BTREES_APPLIED		1963
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1963
+#define	WT_STAT_CONN_TXN_RTS				1964
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1964
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1965
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1965
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1966
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1966
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1967
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1967
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1968
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1968
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1969
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1969
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1970
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1970
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1971
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1971
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1972
 /*!
  * transaction: rollback to stable prepared fast truncations that would
  * have been rolled back in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_PREPARED_FAST_TRUNCATE_DRYRUN	1972
+#define	WT_STAT_CONN_TXN_RTS_PREPARED_FAST_TRUNCATE_DRYRUN	1973
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1973
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1974
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1974
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1975
 /*! transaction: rollback to stable rolled back prepared fast truncations */
-#define	WT_STAT_CONN_TXN_RTS_PREPARED_FAST_TRUNCATE	1975
+#define	WT_STAT_CONN_TXN_RTS_PREPARED_FAST_TRUNCATE	1976
 /*! transaction: rollback to stable skipped btrees */
-#define	WT_STAT_CONN_TXN_RTS_BTREES_SKIPPED		1976
+#define	WT_STAT_CONN_TXN_RTS_BTREES_SKIPPED		1977
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1977
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1978
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1978
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1979
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1979
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1980
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1980
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1981
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1981
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1982
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1982
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1983
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1983
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1984
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1984
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1985
 /*!
  * transaction: rollback to stable updates that would have been aborted
  * in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1985
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1986
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1986
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1987
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1987
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1988
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1988
+#define	WT_STAT_CONN_TXN_SET_TS				1989
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1989
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1990
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1990
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1991
 /*! transaction: set timestamp force calls */
-#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1991
+#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1992
 /*!
  * transaction: set timestamp global oldest timestamp set to be more
  * recent than the global stable timestamp
  */
-#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1992
+#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1993
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1993
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1994
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1994
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1995
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1995
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1996
 /*! transaction: set timestamp stable disaggregated schema epoch calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_DISAGG_EPOCH	1996
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_DISAGG_EPOCH	1997
 /*! transaction: set timestamp stable disaggregated schema epoch updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_DISAGG_EPOCH_UPD	1997
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_DISAGG_EPOCH_UPD	1998
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1998
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1999
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1999
+#define	WT_STAT_CONN_TXN_BEGIN				2000
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		2000
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		2001
 /*! transaction: transaction global checkpoint timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_CHECKPOINT_TIMESTAMP	2001
+#define	WT_STAT_CONN_TXN_GLOBAL_CHECKPOINT_TIMESTAMP	2002
 /*! transaction: transaction global durable timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_DURABLE_TIMESTAMP	2002
+#define	WT_STAT_CONN_TXN_GLOBAL_DURABLE_TIMESTAMP	2003
 /*! transaction: transaction global last running timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_LAST_RUNNING_TIMESTAMP	2003
+#define	WT_STAT_CONN_TXN_GLOBAL_LAST_RUNNING_TIMESTAMP	2004
 /*! transaction: transaction global newest timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_NEWEST_TIMESTAMP	2004
+#define	WT_STAT_CONN_TXN_GLOBAL_NEWEST_TIMESTAMP	2005
 /*! transaction: transaction global oldest timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_OLDEST_TIMESTAMP	2005
+#define	WT_STAT_CONN_TXN_GLOBAL_OLDEST_TIMESTAMP	2006
 /*! transaction: transaction global pinned timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_PINNED_TIMESTAMP	2006
+#define	WT_STAT_CONN_TXN_GLOBAL_PINNED_TIMESTAMP	2007
 /*! transaction: transaction global stable timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_STABLE_TIMESTAMP	2007
+#define	WT_STAT_CONN_TXN_GLOBAL_STABLE_TIMESTAMP	2008
 /*! transaction: transaction global version cursor timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_VERSION_CURSOR_TIMESTAMP	2008
+#define	WT_STAT_CONN_TXN_GLOBAL_VERSION_CURSOR_TIMESTAMP	2009
 /*!
  * transaction: transaction number of older readers older than oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_READERS			2009
+#define	WT_STAT_CONN_TXN_PINNED_READERS			2010
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			2010
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			2011
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	2011
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	2012
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_LAG		2012
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_LAG		2013
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT_LAG	2013
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT_LAG	2014
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER_LAG	2014
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER_LAG	2015
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	2015
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	2016
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	2016
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	2017
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	2017
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	2018
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			2018
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			2019
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				2019
+#define	WT_STAT_CONN_TXN_COMMIT				2020
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			2020
+#define	WT_STAT_CONN_TXN_ROLLBACK			2021
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		2021
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		2022
 
 /*!
  * @}

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -1895,6 +1895,8 @@ static const char *const __stats_connection_desc[] = {
   "backup: total modified incremental blocks",
   "backup: total modified incremental blocks with compressed data",
   "backup: total modified incremental blocks without compressed data",
+  "block-cache: application thread time spent adding pages to the disaggregated victim cache "
+  "(usecs)",
   "block-cache: cached blocks updated",
   "block-cache: cached bytes updated",
   "block-cache: cold collection pages not added to the disaggregated victim cache during eviction",
@@ -1910,6 +1912,8 @@ static const char *const __stats_connection_desc[] = {
   "block-cache: number of hits",
   "block-cache: number of misses",
   "block-cache: number of put bypasses on checkpoint I/O",
+  "block-cache: pages added to the disaggregated victim cache by application threads",
+  "block-cache: pages added to the disaggregated victim cache by eviction threads",
   "block-cache: removed blocks",
   "block-cache: time sleeping to remove block (usecs)",
   "block-cache: total blocks",
@@ -3010,6 +3014,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->backup_blocks = 0;
     stats->backup_blocks_compressed = 0;
     stats->backup_blocks_uncompressed = 0;
+    /* not clearing block_cache_app_thread_put_time */
     stats->block_cache_blocks_update = 0;
     stats->block_cache_bytes_update = 0;
     stats->block_cache_cold_not_cached = 0;
@@ -3025,6 +3030,8 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->block_cache_hits = 0;
     stats->block_cache_misses = 0;
     stats->block_cache_bypass_chkpt = 0;
+    stats->block_cache_app_thread_puts = 0;
+    stats->block_cache_eviction_thread_puts = 0;
     stats->block_cache_blocks_removed = 0;
     stats->block_cache_blocks_removed_blocked = 0;
     stats->block_cache_blocks = 0;
@@ -4054,6 +4061,7 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->backup_blocks += WT_STAT_CONN_READ(from, backup_blocks);
     to->backup_blocks_compressed += WT_STAT_CONN_READ(from, backup_blocks_compressed);
     to->backup_blocks_uncompressed += WT_STAT_CONN_READ(from, backup_blocks_uncompressed);
+    to->block_cache_app_thread_put_time += WT_STAT_CONN_READ(from, block_cache_app_thread_put_time);
     to->block_cache_blocks_update += WT_STAT_CONN_READ(from, block_cache_blocks_update);
     to->block_cache_bytes_update += WT_STAT_CONN_READ(from, block_cache_bytes_update);
     to->block_cache_cold_not_cached += WT_STAT_CONN_READ(from, block_cache_cold_not_cached);
@@ -4070,6 +4078,9 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->block_cache_hits += WT_STAT_CONN_READ(from, block_cache_hits);
     to->block_cache_misses += WT_STAT_CONN_READ(from, block_cache_misses);
     to->block_cache_bypass_chkpt += WT_STAT_CONN_READ(from, block_cache_bypass_chkpt);
+    to->block_cache_app_thread_puts += WT_STAT_CONN_READ(from, block_cache_app_thread_puts);
+    to->block_cache_eviction_thread_puts +=
+      WT_STAT_CONN_READ(from, block_cache_eviction_thread_puts);
     to->block_cache_blocks_removed += WT_STAT_CONN_READ(from, block_cache_blocks_removed);
     to->block_cache_blocks_removed_blocked +=
       WT_STAT_CONN_READ(from, block_cache_blocks_removed_blocked);

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -1895,8 +1895,6 @@ static const char *const __stats_connection_desc[] = {
   "backup: total modified incremental blocks",
   "backup: total modified incremental blocks with compressed data",
   "backup: total modified incremental blocks without compressed data",
-  "block-cache: application thread time spent adding pages to the disaggregated victim cache "
-  "(usecs)",
   "block-cache: cached blocks updated",
   "block-cache: cached bytes updated",
   "block-cache: cold collection pages not added to the disaggregated victim cache during eviction",
@@ -1916,6 +1914,7 @@ static const char *const __stats_connection_desc[] = {
   "block-cache: pages added to the disaggregated victim cache by eviction threads",
   "block-cache: removed blocks",
   "block-cache: time sleeping to remove block (usecs)",
+  "block-cache: time spent adding pages to the disaggregated victim cache (usecs)",
   "block-cache: total blocks",
   "block-cache: total blocks inserted on read path",
   "block-cache: total blocks inserted on write path",
@@ -3014,7 +3013,6 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->backup_blocks = 0;
     stats->backup_blocks_compressed = 0;
     stats->backup_blocks_uncompressed = 0;
-    /* not clearing block_cache_app_thread_put_time */
     stats->block_cache_blocks_update = 0;
     stats->block_cache_bytes_update = 0;
     stats->block_cache_cold_not_cached = 0;
@@ -3034,6 +3032,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->block_cache_eviction_thread_puts = 0;
     stats->block_cache_blocks_removed = 0;
     stats->block_cache_blocks_removed_blocked = 0;
+    stats->block_cache_put_time = 0;
     stats->block_cache_blocks = 0;
     stats->block_cache_blocks_insert_read = 0;
     stats->block_cache_blocks_insert_write = 0;
@@ -4061,7 +4060,6 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->backup_blocks += WT_STAT_CONN_READ(from, backup_blocks);
     to->backup_blocks_compressed += WT_STAT_CONN_READ(from, backup_blocks_compressed);
     to->backup_blocks_uncompressed += WT_STAT_CONN_READ(from, backup_blocks_uncompressed);
-    to->block_cache_app_thread_put_time += WT_STAT_CONN_READ(from, block_cache_app_thread_put_time);
     to->block_cache_blocks_update += WT_STAT_CONN_READ(from, block_cache_blocks_update);
     to->block_cache_bytes_update += WT_STAT_CONN_READ(from, block_cache_bytes_update);
     to->block_cache_cold_not_cached += WT_STAT_CONN_READ(from, block_cache_cold_not_cached);
@@ -4084,6 +4082,7 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->block_cache_blocks_removed += WT_STAT_CONN_READ(from, block_cache_blocks_removed);
     to->block_cache_blocks_removed_blocked +=
       WT_STAT_CONN_READ(from, block_cache_blocks_removed_blocked);
+    to->block_cache_put_time += WT_STAT_CONN_READ(from, block_cache_put_time);
     to->block_cache_blocks += WT_STAT_CONN_READ(from, block_cache_blocks);
     to->block_cache_blocks_insert_read += WT_STAT_CONN_READ(from, block_cache_blocks_insert_read);
     to->block_cache_blocks_insert_write += WT_STAT_CONN_READ(from, block_cache_blocks_insert_write);

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -1910,9 +1910,11 @@ static const char *const __stats_connection_desc[] = {
   "block-cache: number of hits",
   "block-cache: number of misses",
   "block-cache: number of put bypasses on checkpoint I/O",
+  "block-cache: pages added to the disaggregated victim cache",
   "block-cache: pages added to the disaggregated victim cache by application threads",
-  "block-cache: pages added to the disaggregated victim cache by eviction threads",
   "block-cache: removed blocks",
+  "block-cache: time application threads spent adding pages to the disaggregated victim cache "
+  "(usecs)",
   "block-cache: time sleeping to remove block (usecs)",
   "block-cache: time spent adding pages to the disaggregated victim cache (usecs)",
   "block-cache: total blocks",
@@ -3028,9 +3030,10 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->block_cache_hits = 0;
     stats->block_cache_misses = 0;
     stats->block_cache_bypass_chkpt = 0;
+    stats->block_cache_puts = 0;
     stats->block_cache_app_thread_puts = 0;
-    stats->block_cache_eviction_thread_puts = 0;
     stats->block_cache_blocks_removed = 0;
+    stats->block_cache_app_thread_put_time = 0;
     stats->block_cache_blocks_removed_blocked = 0;
     stats->block_cache_put_time = 0;
     stats->block_cache_blocks = 0;
@@ -4076,10 +4079,10 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->block_cache_hits += WT_STAT_CONN_READ(from, block_cache_hits);
     to->block_cache_misses += WT_STAT_CONN_READ(from, block_cache_misses);
     to->block_cache_bypass_chkpt += WT_STAT_CONN_READ(from, block_cache_bypass_chkpt);
+    to->block_cache_puts += WT_STAT_CONN_READ(from, block_cache_puts);
     to->block_cache_app_thread_puts += WT_STAT_CONN_READ(from, block_cache_app_thread_puts);
-    to->block_cache_eviction_thread_puts +=
-      WT_STAT_CONN_READ(from, block_cache_eviction_thread_puts);
     to->block_cache_blocks_removed += WT_STAT_CONN_READ(from, block_cache_blocks_removed);
+    to->block_cache_app_thread_put_time += WT_STAT_CONN_READ(from, block_cache_app_thread_put_time);
     to->block_cache_blocks_removed_blocked +=
       WT_STAT_CONN_READ(from, block_cache_blocks_removed_blocked);
     to->block_cache_put_time += WT_STAT_CONN_READ(from, block_cache_put_time);


### PR DESCRIPTION
## Summary
Application threads can be pulled into eviction under cache pressure and, on disaggregated btrees, end up running `__evict_page_victim_cache` — compressing, checksumming and putting a clean leaf page into the victim cache on the user operation's critical path. This adds statistics to measure that contribution so we can decide whether application threads should keep doing it.

New connection-level statistics, collected as a self-contained set (time **and** count, for application threads **and** for all threads):
- `block-cache: pages added to the disaggregated victim cache` (`block_cache_puts`)
- `block-cache: time spent adding pages to the disaggregated victim cache (usecs)` (`block_cache_put_time`)
- `block-cache: pages added to the disaggregated victim cache by application threads` (`block_cache_app_thread_puts`)
- `block-cache: time application threads spent adding pages to the disaggregated victim cache (usecs)` (`block_cache_app_thread_put_time`)

From these, the average per-put cost (overall and application-thread) is derivable, as is the eviction-thread share (all − application), so no separate eviction-thread stat is needed.

Instrumentation in `__evict_page_victim_cache`:
- The full put path (compress + checksum + `plh_cache_put`) is timed; the elapsed time is added to the all-thread total and, for application threads, to the application-thread total.
- Application threads are identified with `WT_SESSION_INTERNAL` (the same predicate eviction uses to attribute application-thread work).

A worst-case (maximum) put-latency statistic is intentionally **not** included here — it needs a running-max field and a decision on per-collection-period vs lifetime semantics, tracked separately in [WT-17854](https://jira.mongodb.org/browse/WT-17854).

## Testing
- Regenerated statistics code via `dist/stat.py` (clang-format 19.1.7); `dist/s_fast` passes (stat ordering and validation).
- Incremental build (`ninja wt`) compiles clean, no warnings.
- No functional test files touched — these are measurement-only statistics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)