### PR TITLE
WT-17849 Skip evergreen validate when not logged in

### DIFF
--- a/dist/s_evergreen_validate
+++ b/dist/s_evergreen_validate
@@ -24,6 +24,12 @@ if [ $(command -v evergreen) ] && [ -f ~/.evergreen.yml ]; then
             exit 0
         fi
     fi
+
+    if ! timeout 5 evergreen client get-oauth-token > /dev/null 2>&1; then
+        echo "$0 skipping evergreen validation due to no login. Run 'evergreen login' to fix."
+        exit 0
+    fi
+
     echo "Validating evergreen.yml " > dist/$t
     evergreen validate -p wiredtiger test/evergreen.yml >> dist/$t 2>&1
     exit1=$?


### PR DESCRIPTION
The idea here is to see if we can get the current Oauth token, which in my testing fails when not logged in. The check is performed before the main `evergreen validate` run, because all output from that command is redirected so the user won't see it.