### PR TITLE
WT-17859 Exclude internal and checkpoint sessions from write overload

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -957,9 +957,11 @@ connection_runtime_config = [
             Load control will actively reject the work, based on other settings, to keep the
             system healthy.''',
             type='boolean'),
-        Config('control_threshold', '100', r'''
-            Threshold at which load control will actively start rejecting the work.''',
-            min=10, max=200),
+        Config('control_threshold', '200', r'''
+            Load level, expressed as a percentage of the cache eviction trigger (100 means at
+            the eviction trigger, 200 means twice the trigger), at or above which load control
+            sheds incoming operations. Set to 0 to disable shedding.''',
+            min=0, max=1000),
         ]),
     Config('operation_timeout_ms', '0', r'''
         this option is no longer supported, retained for backward compatibility.''',

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1259,6 +1259,7 @@ lldb
 llll
 llu
 llvm
+loadshed
 loadtext
 loc
 localTime

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -475,8 +475,8 @@ static const char *confchk_json_output_choices[] = {
   __WT_CONFIG_CHOICE_error, __WT_CONFIG_CHOICE_message, NULL};
 
 static const WT_CONFIG_CHECK confchk_wiredtiger_open_load_control_subconfigs[] = {
-  {"control_threshold", "int", NULL, "min=10,max=200", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
-    288, 10, 200, NULL},
+  {"control_threshold", "int", NULL, "min=0,max=1000", NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_INT,
+    288, 0, 1000, NULL},
   {"enable", "boolean", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_BOOLEAN, 287, INT64_MIN,
     INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
@@ -4208,7 +4208,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     ",eviction_obsolete_tw_pages_dirty_max=100,"
     "obsolete_tw_btree_max=100),history_store=(file_max=0),"
     "io_capacity=(chunk_cache=0,total=0),json_output=[],"
-    "load_control=(control_threshold=100,enable=false),"
+    "load_control=(control_threshold=200,enable=false),"
     "log=(archive=true,os_cache_dirty_pct=0,prealloc=true,"
     "prealloc_init_count=1,remove=true,zero_fill=false),"
     "operation_timeout_ms=0,operation_tracking=(enabled=false,"
@@ -4547,7 +4547,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "obsolete_tw_btree_max=100),history_store=(file_max=0),"
     "in_memory=false,io_capacity=(chunk_cache=0,total=0),"
     "json_output=[],live_restore=(enabled=false,path=,read_size=1MB,"
-    "threads_max=8),load_control=(control_threshold=100,enable=false)"
+    "threads_max=8),load_control=(control_threshold=200,enable=false)"
     ",log=(archive=true,compressor=,enabled=false,file_max=100MB,"
     "force_write_wait=0,os_cache_dirty_pct=0,path=\".\",prealloc=true"
     ",prealloc_init_count=1,recover=on,remove=true,zero_fill=false),"
@@ -4620,7 +4620,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "obsolete_tw_btree_max=100),history_store=(file_max=0),"
     "in_memory=false,io_capacity=(chunk_cache=0,total=0),"
     "json_output=[],live_restore=(enabled=false,path=,read_size=1MB,"
-    "threads_max=8),load_control=(control_threshold=100,enable=false)"
+    "threads_max=8),load_control=(control_threshold=200,enable=false)"
     ",log=(archive=true,compressor=,enabled=false,file_max=100MB,"
     "force_write_wait=0,os_cache_dirty_pct=0,path=\".\",prealloc=true"
     ",prealloc_init_count=1,recover=on,remove=true,zero_fill=false),"
@@ -4693,7 +4693,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "obsolete_tw_btree_max=100),history_store=(file_max=0),"
     "io_capacity=(chunk_cache=0,total=0),json_output=[],"
     "live_restore=(enabled=false,path=,read_size=1MB,threads_max=8),"
-    "load_control=(control_threshold=100,enable=false),"
+    "load_control=(control_threshold=200,enable=false),"
     "log=(archive=true,compressor=,enabled=false,file_max=100MB,"
     "force_write_wait=0,os_cache_dirty_pct=0,path=\".\",prealloc=true"
     ",prealloc_init_count=1,recover=on,remove=true,zero_fill=false),"
@@ -4765,7 +4765,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {
     "obsolete_tw_btree_max=100),history_store=(file_max=0),"
     "io_capacity=(chunk_cache=0,total=0),json_output=[],"
     "live_restore=(enabled=false,path=,read_size=1MB,threads_max=8),"
-    "load_control=(control_threshold=100,enable=false),"
+    "load_control=(control_threshold=200,enable=false),"
     "log=(archive=true,compressor=,enabled=false,file_max=100MB,"
     "force_write_wait=0,os_cache_dirty_pct=0,path=\".\",prealloc=true"
     ",prealloc_init_count=1,recover=on,remove=true,zero_fill=false),"

--- a/src/conn/conn_load_control.c
+++ b/src/conn/conn_load_control.c
@@ -67,8 +67,8 @@ __wti_conn_load_control_config(WT_SESSION_IMPL *session, const char *cfg[], bool
     /* load control threshold determines when the load control will be activated */
 
     WT_RET(__wt_config_gets(session, cfg, "load_control.control_threshold", &cval));
-    __wt_atomic_store_uint8_relaxed(
-      &load_control->control_threshold, (((uint8_t)cval.val > 200) ? 200 : (uint8_t)cval.val));
+    __wt_atomic_store_uint16_relaxed(
+      &load_control->control_threshold, (((uint16_t)cval.val > 1000) ? 1000 : (uint16_t)cval.val));
 
     /*
      * Load control thresholds are calculated based on the configuration settings of load control as
@@ -84,13 +84,13 @@ __wti_conn_load_control_config(WT_SESSION_IMPL *session, const char *cfg[], bool
  * __conn_calc_load_pct --
  *     Calculate the percentage of part relative to whole. Returns 0 if whole is zero.
  */
-static WT_INLINE uint8_t
+static WT_INLINE uint16_t
 __conn_calc_load_pct(uint64_t part, uint64_t whole)
 {
     if (whole == 0)
         return (0);
 
-    return (((uint8_t)WT_MIN((part * 100) / whole, 200)));
+    return ((uint16_t)WT_MIN((part * 100) / whole, 1000));
 }
 
 /*
@@ -102,7 +102,7 @@ __wt_conn_calc_read_load(WT_SESSION_IMPL *session)
 {
     WT_CONNECTION_LOAD_CONTROL *load_control;
     uint64_t bytes_inuse, bytes_max;
-    uint8_t load;
+    uint16_t load;
 
     load_control = &S2C(session)->load_control;
     if (F_ISSET(load_control, WT_CONN_LOAD_CONTROL)) {
@@ -110,7 +110,7 @@ __wt_conn_calc_read_load(WT_SESSION_IMPL *session)
         bytes_inuse = __wt_cache_bytes_inuse(S2C(session)->cache);
 
         load = __conn_calc_load_pct(bytes_inuse, bytes_max);
-        __wt_atomic_store_uint8_relaxed(&load_control->read_load, load);
+        __wt_atomic_store_uint16_relaxed(&load_control->read_load, load);
         WT_STAT_CONN_SET(session, read_load, load);
     }
     return;
@@ -125,7 +125,7 @@ __wt_conn_calc_write_load(WT_SESSION_IMPL *session)
 {
     WT_CONNECTION_LOAD_CONTROL *load_control;
     uint64_t bytes_dirty, bytes_max;
-    uint8_t load;
+    uint16_t load;
 
     load_control = &S2C(session)->load_control;
     if (F_ISSET(load_control, WT_CONN_LOAD_CONTROL)) {
@@ -133,7 +133,7 @@ __wt_conn_calc_write_load(WT_SESSION_IMPL *session)
         bytes_dirty = __wt_cache_dirty_inuse(S2C(session)->cache);
 
         load = __conn_calc_load_pct(bytes_dirty, bytes_max);
-        __wt_atomic_store_uint8_relaxed(&load_control->write_load, load);
+        __wt_atomic_store_uint16_relaxed(&load_control->write_load, load);
         WT_STAT_CONN_SET(session, write_load, load);
     }
     return;

--- a/src/include/api.h
+++ b/src/include/api.h
@@ -273,7 +273,7 @@
         if (API_USER_ENTRY(s) &&                                                               \
           (!F_ISSET(                                                                           \
             s, WT_SESSION_INTERNAL | WT_SESSION_CHECKPOINT | WT_SESSION_IGNORE_CACHE_SIZE))) { \
-            if (__wt_conn_load_control_read_overload(s)) {                                     \
+            if (__wt_conn_load_control_read_loadshed(s)) {                                     \
                 WT_STAT_CONN_INCR(s, read_reject_count);                                       \
                 (ret) = WT_ROLLBACK;                                                           \
                 goto err;                                                                      \
@@ -323,7 +323,7 @@
     TXN_API_CALL_NOCONF(s, WT_CURSOR, remove, (dh));                                               \
     if (API_USER_ENTRY(s) &&                                                                       \
       (!F_ISSET(s, WT_SESSION_INTERNAL | WT_SESSION_CHECKPOINT | WT_SESSION_IGNORE_CACHE_SIZE))) { \
-        if (__wt_conn_load_control_write_overload(s)) {                                            \
+        if (__wt_conn_load_control_write_loadshed(s)) {                                            \
             WT_STAT_CONN_INCR(s, write_reject_count);                                              \
             (ret) = WT_ROLLBACK;                                                                   \
             goto err;                                                                              \
@@ -336,7 +336,7 @@
     TXN_API_CALL_NOCONF(s, WT_CURSOR, func_name, ((WT_CURSOR_BTREE *)(cur))->dhandle);             \
     if (API_USER_ENTRY(s) &&                                                                       \
       (!F_ISSET(s, WT_SESSION_INTERNAL | WT_SESSION_CHECKPOINT | WT_SESSION_IGNORE_CACHE_SIZE))) { \
-        if (__wt_conn_load_control_write_overload(s)) {                                            \
+        if (__wt_conn_load_control_write_loadshed(s)) {                                            \
             WT_STAT_CONN_INCR(s, write_reject_count);                                              \
             (ret) = WT_ROLLBACK;                                                                   \
             goto err;                                                                              \
@@ -352,7 +352,7 @@
     TXN_API_CALL_NOCONF(s, WT_CURSOR, func_name, dh);                                              \
     if (API_USER_ENTRY(s) &&                                                                       \
       (!F_ISSET(s, WT_SESSION_INTERNAL | WT_SESSION_CHECKPOINT | WT_SESSION_IGNORE_CACHE_SIZE))) { \
-        if (__wt_conn_load_control_write_overload(s)) {                                            \
+        if (__wt_conn_load_control_write_loadshed(s)) {                                            \
             WT_STAT_CONN_INCR(s, write_reject_count);                                              \
             (ret) = WT_ROLLBACK;                                                                   \
             goto err;                                                                              \

--- a/src/include/api.h
+++ b/src/include/api.h
@@ -318,37 +318,44 @@
     /* !!!! This is a while(1) loop. !!!! */                                                     \
     while (1)
 
-#define CURSOR_REMOVE_API_CALL(cur, s, ret, dh)      \
-    (s) = CUR2S(cur);                                \
-    TXN_API_CALL_NOCONF(s, WT_CURSOR, remove, (dh)); \
-    if (__wt_conn_load_control_write_overload(s)) {  \
-        WT_STAT_CONN_INCR(s, write_reject_count);    \
-        (ret) = WT_ROLLBACK;                         \
-        goto err;                                    \
-    }                                                \
+#define CURSOR_REMOVE_API_CALL(cur, s, ret, dh)                                                    \
+    (s) = CUR2S(cur);                                                                              \
+    TXN_API_CALL_NOCONF(s, WT_CURSOR, remove, (dh));                                               \
+    if (API_USER_ENTRY(s) &&                                                                       \
+      (!F_ISSET(s, WT_SESSION_INTERNAL | WT_SESSION_CHECKPOINT | WT_SESSION_IGNORE_CACHE_SIZE))) { \
+        if (__wt_conn_load_control_write_overload(s)) {                                            \
+            WT_STAT_CONN_INCR(s, write_reject_count);                                              \
+            (ret) = WT_ROLLBACK;                                                                   \
+            goto err;                                                                              \
+        }                                                                                          \
     SESSION_API_PREPARE_CHECK(s, ret, WT_CURSOR, remove)
 
-#define CURSOR_UPDATE_API_CALL_BTREE(cur, s, ret, func_name)                                  \
-    (s) = CUR2S(cur);                                                                         \
-    TXN_API_CALL_NOCONF(s, WT_CURSOR, func_name, ((WT_CURSOR_BTREE *)(cur))->dhandle);        \
-    if (__wt_conn_load_control_write_overload(s)) {                                           \
-        WT_STAT_CONN_INCR(s, write_reject_count);                                             \
-        (ret) = WT_ROLLBACK;                                                                  \
-        goto err;                                                                             \
-    }                                                                                         \
-    SESSION_API_PREPARE_CHECK(s, ret, WT_CURSOR, func_name);                                  \
-    if (F_ISSET(S2C(s), WT_CONN_IN_MEMORY) && !F_ISSET(CUR2BT(cur), WT_BTREE_IGNORE_CACHE) && \
-      __wt_cache_full(s))                                                                     \
-        WT_ERR(WT_CACHE_FULL);
+#define CURSOR_UPDATE_API_CALL_BTREE(cur, s, ret, func_name)                                       \
+    (s) = CUR2S(cur);                                                                              \
+    TXN_API_CALL_NOCONF(s, WT_CURSOR, func_name, ((WT_CURSOR_BTREE *)(cur))->dhandle);             \
+    if (API_USER_ENTRY(s) &&                                                                       \
+      (!F_ISSET(s, WT_SESSION_INTERNAL | WT_SESSION_CHECKPOINT | WT_SESSION_IGNORE_CACHE_SIZE))) { \
+        if (__wt_conn_load_control_write_overload(s)) {                                            \
+            WT_STAT_CONN_INCR(s, write_reject_count);                                              \
+            (ret) = WT_ROLLBACK;                                                                   \
+            goto err;                                                                              \
+        }                                                                                          \
+        SESSION_API_PREPARE_CHECK(s, ret, WT_CURSOR, func_name);                                   \
+        if (F_ISSET(S2C(s), WT_CONN_IN_MEMORY) && !F_ISSET(CUR2BT(cur), WT_BTREE_IGNORE_CACHE) &&  \
+          __wt_cache_full(s))                                                                      \
+            WT_ERR(WT_CACHE_FULL);
 
-#define CURSOR_UPDATE_API_CALL(cur, s, ret, func_name, dh) \
-    (s) = CUR2S(cur);                                      \
-    TXN_API_CALL_NOCONF(s, WT_CURSOR, func_name, dh);      \
-    if (__wt_conn_load_control_write_overload(s)) {        \
-        WT_STAT_CONN_INCR(s, write_reject_count);          \
-        (ret) = WT_ROLLBACK;                               \
-        goto err;                                          \
-    }                                                      \
+#define CURSOR_UPDATE_API_CALL(cur, s, ret, func_name, dh)                                         \
+    (s) = CUR2S(cur);                                                                              \
+    TXN_API_CALL_NOCONF(s, WT_CURSOR, func_name, dh);                                              \
+    if (API_USER_ENTRY(s) &&                                                                       \
+      (!F_ISSET(s, WT_SESSION_INTERNAL | WT_SESSION_CHECKPOINT | WT_SESSION_IGNORE_CACHE_SIZE))) { \
+        if (__wt_conn_load_control_write_overload(s)) {                                            \
+            WT_STAT_CONN_INCR(s, write_reject_count);                                              \
+            (ret) = WT_ROLLBACK;                                                                   \
+            goto err;                                                                              \
+        }                                                                                          \
+    }                                                                                              \
     SESSION_API_PREPARE_CHECK(s, ret, WT_CURSOR, func_name)
 
 #define CURSOR_UPDATE_API_END_RETRY(s, ret, retry) \

--- a/src/include/api.h
+++ b/src/include/api.h
@@ -328,6 +328,7 @@
             (ret) = WT_ROLLBACK;                                                                   \
             goto err;                                                                              \
         }                                                                                          \
+    }                                                                                              \
     SESSION_API_PREPARE_CHECK(s, ret, WT_CURSOR, remove)
 
 #define CURSOR_UPDATE_API_CALL_BTREE(cur, s, ret, func_name)                                       \
@@ -340,10 +341,11 @@
             (ret) = WT_ROLLBACK;                                                                   \
             goto err;                                                                              \
         }                                                                                          \
-        SESSION_API_PREPARE_CHECK(s, ret, WT_CURSOR, func_name);                                   \
-        if (F_ISSET(S2C(s), WT_CONN_IN_MEMORY) && !F_ISSET(CUR2BT(cur), WT_BTREE_IGNORE_CACHE) &&  \
-          __wt_cache_full(s))                                                                      \
-            WT_ERR(WT_CACHE_FULL);
+    }                                                                                              \
+    SESSION_API_PREPARE_CHECK(s, ret, WT_CURSOR, func_name);                                       \
+    if (F_ISSET(S2C(s), WT_CONN_IN_MEMORY) && !F_ISSET(CUR2BT(cur), WT_BTREE_IGNORE_CACHE) &&      \
+      __wt_cache_full(s))                                                                          \
+        WT_ERR(WT_CACHE_FULL);
 
 #define CURSOR_UPDATE_API_CALL(cur, s, ret, func_name, dh)                                         \
     (s) = CUR2S(cur);                                                                              \

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2027,9 +2027,9 @@ static WT_INLINE bool __wt_conf_get_compiled(WT_CONNECTION_IMPL *conn, const cha
   WT_CONF **confp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wt_conf_is_compiled(WT_CONNECTION_IMPL *conn, const char *config)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-static WT_INLINE bool __wt_conn_load_control_read_overload(WT_SESSION_IMPL *session)
+static WT_INLINE bool __wt_conn_load_control_read_loadshed(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-static WT_INLINE bool __wt_conn_load_control_write_overload(WT_SESSION_IMPL *session)
+static WT_INLINE bool __wt_conn_load_control_write_loadshed(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wt_cursor_has_cached_memory(WT_CURSOR *cursor)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/load_control.h
+++ b/src/include/load_control.h
@@ -9,9 +9,9 @@
 #pragma once
 
 struct __wt_connection_load_control {
-    uint8_t control_threshold;         /* threshold when the load control starts rejecting work */
-    wt_shared uint8_t read_load;       /* connection read load */
-    wt_shared uint8_t write_load;      /* connection write load */
+    uint16_t control_threshold;        /* threshold when the load control starts rejecting work */
+    wt_shared uint16_t read_load;      /* connection read load */
+    wt_shared uint16_t write_load;     /* connection write load */
     wt_shared uint64_t read_load_max;  /* cache max bytes equivalent eviction trigger */
     wt_shared uint64_t write_load_max; /* cache max dirty bytes equivalent to dirty trigger */
 

--- a/src/include/load_control_inline.h
+++ b/src/include/load_control_inline.h
@@ -13,35 +13,37 @@ extern "C" {
 #endif
 
 /*
- * __wt_conn_load_control_read_overload --
- *     check if the system is read overloaded.
+ * __wt_conn_load_control_read_loadshed --
+ *     Check whether reads should be shed because the read load has crossed the configured load
+ *     control threshold.
  */
 static WT_INLINE bool
-__wt_conn_load_control_read_overload(WT_SESSION_IMPL *session)
+__wt_conn_load_control_read_loadshed(WT_SESSION_IMPL *session)
 {
     WT_CONNECTION_LOAD_CONTROL *load_control = &S2C(session)->load_control;
 
-    /* If load control is enabled, check if the read load crossed the control threshold. */
-    if (F_ISSET(load_control, WT_CONN_LOAD_CONTROL))
+    /* Shed reads when load control is enabled and the read load is at or above the threshold. */
+    if (F_ISSET(load_control, WT_CONN_LOAD_CONTROL) && load_control->control_threshold > 0)
         return (load_control->control_threshold <=
-          __wt_atomic_load_uint8_relaxed(&load_control->read_load));
+          __wt_atomic_load_uint16_relaxed(&load_control->read_load));
 
     return (false);
 }
 
 /*
- * __wt_conn_load_control_write_overload --
- *     check if the system is write overloaded.
+ * __wt_conn_load_control_write_loadshed --
+ *     Check whether writes should be shed because the write load has crossed the configured load
+ *     control threshold.
  */
 static WT_INLINE bool
-__wt_conn_load_control_write_overload(WT_SESSION_IMPL *session)
+__wt_conn_load_control_write_loadshed(WT_SESSION_IMPL *session)
 {
     WT_CONNECTION_LOAD_CONTROL *load_control = &S2C(session)->load_control;
 
-    /* If load control is enabled, check if the write load crossed the control threshold. */
-    if (F_ISSET(load_control, WT_CONN_LOAD_CONTROL))
+    /* Shed writes when load control is enabled and the write load is at or above the threshold. */
+    if (F_ISSET(load_control, WT_CONN_LOAD_CONTROL) && load_control->control_threshold > 0)
         return (load_control->control_threshold <=
-          __wt_atomic_load_uint8_relaxed(&load_control->write_load));
+          __wt_atomic_load_uint16_relaxed(&load_control->write_load));
 
     return (false);
 }

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -2447,13 +2447,14 @@ struct __wt_connection {
      * chosen from the following options: \c "error"\, \c "message"; default \c [].}
      * @config{load_control = (, enable the load control subsystem., a set of related configuration
      * options defined as follows.}
-     * @config{&nbsp;&nbsp;&nbsp;&nbsp;control_threshold, Threshold at
-     * which load control will actively start rejecting the work., an integer between \c 10 and \c
-     * 200; default \c 100.}
-     * @config{&nbsp;&nbsp;&nbsp;&nbsp;enable, Load control will actively
-     * reject the work\, based on other settings\, to keep the system healthy., a boolean flag;
-     * default \c false.}
-     * @config{ ),,}
+     * @config{&nbsp;&nbsp;&nbsp;&nbsp;control_threshold, Load level\,
+     * expressed as a percentage of the cache eviction trigger (100 means at the eviction trigger\,
+     * 200 means twice the trigger)\, at or above which load control sheds incoming operations.  Set
+     * to 0 to disable shedding., an integer between \c 0 and \c 1000; default \c 200.}
+     * @config{&nbsp;&nbsp;&nbsp;&nbsp;enable, Load control will actively reject the work\, based on
+     * other settings\, to keep the system healthy., a boolean flag; default \c false.}
+     * @config{
+     * ),,}
      * @config{log = (, enable logging.  Enabling logging uses three sessions from the configured
      * session_max., a set of related configuration options defined as follows.}
      * @config{&nbsp;&nbsp;&nbsp;&nbsp;os_cache_dirty_pct, maximum dirty system buffer cache usage\,
@@ -3449,11 +3450,12 @@ struct __wt_connection {
  * @config{ ),,}
  * @config{load_control = (, enable the load control subsystem., a set of related configuration
  * options defined as follows.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;control_threshold, Threshold at
- * which load control will actively start rejecting the work., an integer between \c 10 and \c 200;
- * default \c 100.}
- * @config{&nbsp;&nbsp;&nbsp;&nbsp;enable, Load control will actively reject the
- * work\, based on other settings\, to keep the system healthy., a boolean flag; default \c false.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;control_threshold, Load level\,
+ * expressed as a percentage of the cache eviction trigger (100 means at the eviction trigger\, 200
+ * means twice the trigger)\, at or above which load control sheds incoming operations.  Set to 0 to
+ * disable shedding., an integer between \c 0 and \c 1000; default \c 200.}
+ * @config{&nbsp;&nbsp;&nbsp;&nbsp;enable, Load control will actively reject the work\, based on
+ * other settings\, to keep the system healthy., a boolean flag; default \c false.}
  * @config{ ),,}
  * @config{log = (, enable logging.  Enabling logging uses three sessions from the configured
  * session_max., a set of related configuration options defined as follows.}

--- a/test/suite/test_load01.py
+++ b/test/suite/test_load01.py
@@ -46,6 +46,8 @@ class test_load01(wttest.WiredTigerTestCase):
 
         # Try different load control reconfigurations.
         configs = [
+            "load_control=[enable=false,control_threshold=0]",
+            "load_control=[enable=true,control_threshold=0]",
             "load_control=[enable=false,control_threshold=10]",
             "load_control=[enable=false,control_threshold=25]",
             "load_control=[enable=false,control_threshold=50]",
@@ -62,10 +64,8 @@ class test_load01(wttest.WiredTigerTestCase):
 
         # Try different load control failure reconfigurations.
         failure_configs = [
-            "load_control=[enable=false,control_threshold=0]",
-            "load_control=[enable=true,control_threshold=0]",
             "load_control=[enable=true,control_threshold=-1]",
-            "load_control=[enable=true,control_threshold=210]",
+            "load_control=[enable=true,control_threshold=1110]",
         ]
 
         for cfg in configs:


### PR DESCRIPTION
1. Internal, checkpoint, and IGNORE_CACHE_SIZE sessions are now exempt from write-side load-shed, matching the existing read-side behavior. Prevents the shedding mechanism from interfering with engine-internal work.
2. Configuring control_threshold as 0, will disable load shedding.
3. Widened the control_threshold range to [0..1000], inclusive.
