### PR TITLE
WT-14204 Convert RTS related EBUSY messages into sub-level error code (8.0)

### DIFF
--- a/src/rollback_to_stable/rts_api.c
+++ b/src/rollback_to_stable/rts_api.c
@@ -65,11 +65,14 @@ __rts_check(WT_SESSION_IMPL *session)
      * A new cursor may be positioned or a transaction may start after we return from this call and
      * callers should be aware of this limitation.
      */
-    if (cookie.ret_cursor_active)
-        WT_RET_MSG(session, EBUSY, "rollback_to_stable illegal with active file cursors");
+    if (cookie.ret_cursor_active) {
+        ret = EBUSY;
+        WT_TRET(__wt_verbose_dump_sessions(session, true));
+        WT_RET_MSG(session, ret, "rollback_to_stable illegal with active file cursors");
+    }
     if (cookie.ret_txn_active) {
         ret = EBUSY;
-        WT_TRET(__wt_verbose_dump_txn(session));
+        WT_TRET(__wt_verbose_dump_sessions(session, false));
         WT_RET_MSG(session, ret, "rollback_to_stable illegal with active transactions");
     }
     return (0);


### PR DESCRIPTION
Adding more debugging information for situations where RTS is blocked by active cursors or transactions and returns an EBUSY error. With these changes, RTS will still return the EBUSY error, but it will also log details about all the active cursors and transactions that are causing the blockage.