### PR TITLE
WT-17862 Account disk image bytes per btree for shared disk pages

### DIFF
--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -1028,6 +1028,22 @@ err:
 }
 
 /*
+ * __inmem_shared_dsk_account --
+ *     Account a shared disk image's bytes in the page footprint and the owning btree's in-memory
+ *     totals.
+ */
+static void
+__inmem_shared_dsk_account(WT_SESSION_IMPL *session, WT_PAGE *page, size_t size)
+{
+    WT_BTREE *btree = S2BT(session);
+
+    (void)__wt_atomic_add_size_relaxed(&page->memory_footprint, size);
+    (void)__wt_atomic_add_uint64_relaxed(&btree->bytes_inmem, size);
+    if (WT_PAGE_IS_INTERNAL(page))
+        (void)__wt_atomic_add_uint64_relaxed(&btree->bytes_internal, size);
+}
+
+/*
  * __wti_page_inmem --
  *     Build in-memory page information.
  */
@@ -1182,9 +1198,9 @@ __wti_page_inmem(WT_SESSION_IMPL *session, WT_REF *ref, const void *image, uint3
     WT_ASSERT(session, shared_dsk_item == NULL || page->disagg_info != NULL);
     if (page->disagg_info != NULL) {
         page->disagg_info->shared_dsk_item = shared_dsk_item;
-        /* memory footprint still includes disk size so per-page eviction logic stays unchanged. */
+        /* Count the disk image in the page footprint and this btree's in-memory total. */
         if (LF_ISSET(WT_PAGE_DISK_SHARED))
-            __wt_cache_page_footprint_incr(session, page, dsk->mem_size);
+            __inmem_shared_dsk_account(session, page, dsk->mem_size);
     }
 
     *pagep = page;

--- a/src/evict/evict_inline.h
+++ b/src/evict/evict_inline.h
@@ -298,13 +298,13 @@ __wt_evict_page_cache_bytes_decr(WT_SESSION_IMPL *session, WT_PAGE *page)
     WT_BTREE *btree;
     WT_CACHE *cache;
     WT_PAGE_MODIFY *modify;
-    uint64_t memory_footprint;
+    uint64_t btree_footprint, memory_footprint;
     bool is_disagg;
 
     btree = S2BT(session);
     cache = S2C(session)->cache;
     modify = page->modify;
-    memory_footprint = __wt_atomic_load_size_relaxed(&page->memory_footprint);
+    btree_footprint = memory_footprint = __wt_atomic_load_size_relaxed(&page->memory_footprint);
     is_disagg = __wt_conn_is_disagg(session);
 
     /*
@@ -320,7 +320,7 @@ __wt_evict_page_cache_bytes_decr(WT_SESSION_IMPL *session, WT_PAGE *page)
 
     /* Update the bytes in-memory to reflect the eviction. */
     __wt_cache_decr_check_uint64(
-      session, &btree->bytes_inmem, memory_footprint, "WT_BTREE.bytes_inmem");
+      session, &btree->bytes_inmem, btree_footprint, "WT_BTREE.bytes_inmem");
     __wt_cache_decr_check_uint64(
       session, &cache->bytes_inmem, memory_footprint, "WT_CACHE.bytes_inmem");
     if (is_disagg) {
@@ -335,7 +335,7 @@ __wt_evict_page_cache_bytes_decr(WT_SESSION_IMPL *session, WT_PAGE *page)
     /* Update the bytes_internal value to reflect the eviction */
     if (WT_PAGE_IS_INTERNAL(page)) {
         __wt_cache_decr_check_uint64(
-          session, &btree->bytes_internal, memory_footprint, "WT_BTREE.bytes_internal");
+          session, &btree->bytes_internal, btree_footprint, "WT_BTREE.bytes_internal");
         __wt_cache_decr_check_uint64(
           session, &cache->bytes_internal, memory_footprint, "WT_CACHE.bytes_internal");
         if (is_disagg) {

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -2950,19 +2950,6 @@ __wt_ref_ascend(WT_SESSION_IMPL *session, WT_REF **refp, WT_PAGE_INDEX **pindexp
 }
 
 /*
- * __wt_cache_page_footprint_incr --
- *     Increment a page's memory footprint without touching cache or btree totals.
- */
-static WT_INLINE void
-__wt_cache_page_footprint_incr(WT_SESSION_IMPL *session, WT_PAGE *page, size_t size)
-{
-    WT_ASSERT(session, size < WT_EXABYTE);
-    if (size == 0)
-        return;
-    (void)__wt_atomic_add_size_relaxed(&page->memory_footprint, size);
-}
-
-/*
  * __wt_cache_shared_dsk_inmem_incr --
  *     Increment the shared disk in memory cache statistics.
  */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2551,8 +2551,6 @@ static WT_INLINE void __wt_cache_page_byte_dirty_decr(
   WT_SESSION_IMPL *session, WT_PAGE *page, size_t size);
 static WT_INLINE void __wt_cache_page_byte_updates_decr(
   WT_SESSION_IMPL *session, WT_PAGE *page, size_t size);
-static WT_INLINE void __wt_cache_page_footprint_incr(
-  WT_SESSION_IMPL *session, WT_PAGE *page, size_t size);
 static WT_INLINE void __wt_cache_page_image_decr(WT_SESSION_IMPL *session, WT_PAGE *page);
 static WT_INLINE void __wt_cache_page_image_incr(WT_SESSION_IMPL *session, WT_PAGE *page);
 static WT_INLINE void __wt_cache_page_inmem_decr(


### PR DESCRIPTION
This PR adds the disk image bytes accounting back as it is used for calculating how many pages we can add to the eviction queue for btree. The WT-17064 removes the accounting however it causes undercount of the bytes used by a btree, causing eviction can't queue enough pages from a btree which degrades the eviction efficiency.
