### PR TITLE
WT-17578 Fix TSAN data race in __wt_delete_page_rollback for prepared fast-truncate rollback

### DIFF
--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -297,16 +297,19 @@ __wt_delete_page_rollback(WT_SESSION_IMPL *session, WT_TXN_OP *op)
              */
             for (; *updp != NULL; ++updp) {
                 /*
-                 * The ref is locked, no need to pay attention to memory ordering here. Only save
-                 * the txnid for prepared transactions; the saved_txnid field overlaps upd_start_ts
-                 * in the union, so writing it unconditionally would race with concurrent readers
-                 * that read upd_start_ts on the non-prepare path.
+                 * Only save timestamps for prepared transactions; the saved_txnid and rollback_ts
+                 * fields share memory with upd_start_ts and upd_durable_ts in the union, so writing
+                 * them unconditionally would race with concurrent readers. After a split the
+                 * original ref lock does not prevent child refs from being reconciled concurrently,
+                 * so use atomic stores and a release on txnid to establish happens-before with
+                 * reconciliation threads that acquire-load txnid before reading these fields.
                  */
                 if (F_ISSET(&txn->time_point, WT_TXN_TIME_POINT_HAS_TS_ROLLBACK)) {
-                    (*updp)->upd_rollback_ts = txn->time_point.rollback_timestamp;
+                    __wt_atomic_store_uint64_relaxed(
+                      &(*updp)->upd_rollback_ts, txn->time_point.rollback_timestamp);
                     __wt_atomic_store_uint64_relaxed(&(*updp)->upd_saved_txnid, (*updp)->txnid);
                 }
-                __wt_atomic_store_uint64_v_relaxed(&(*updp)->txnid, WT_TXN_ABORTED);
+                __wt_atomic_store_uint64_v_release(&(*updp)->txnid, WT_TXN_ABORTED);
             }
             /* Now discard the updates. */
             __wt_free(session, ref->page->modify->inst_updates);


### PR DESCRIPTION
WT-17381 guarded the `upd_saved_txnid` write under the prepared-rollback
condition and made it atomic, but left the `upd_rollback_ts` write on the
line above as a plain assignment. `bt_delete.c`'s lock loop is a bare CAS
with no hazard-pointer check (unlike eviction, which calls
`__wt_hazard_check` after locking). A cursor reader that already holds a
hazard pointer from before the CAS does not re-check the ref state before
each field access, leaving a window where the plain write to
`upd_rollback_ts` races with the cursor's concurrent read of the same
field (or its union alias `upd_durable_ts`).

The `txnid` abort store used a relaxed ordering, which does not form an
acquire-release pair with the reconciler's acquire load of `txnid` at the
read site, so `upd_rollback_ts` could be invisible even after a reader
observed `WT_TXN_ABORTED`.

Fix both: use `__wt_atomic_store_uint64_relaxed` for `upd_rollback_ts`
(matching `txn.c`'s identical write in the prepared-update abort path) and
promote the `txnid` store from `_v_relaxed` to `_v_release` to establish
happens-before with readers that acquire-load `txnid` before reading the
timestamp fields.