### PR TITLE
WT-17422 Add test to validate cache usage accounting for in memory pages

### DIFF
--- a/test/catch2/cross_checkpoint_caching/cross_checkpoint_caching_test_env.cpp
+++ b/test/catch2/cross_checkpoint_caching/cross_checkpoint_caching_test_env.cpp
@@ -51,6 +51,21 @@ cross_checkpoint_caching_test_env::~cross_checkpoint_caching_test_env()
 {
     WT_CONNECTION_IMPL *conn = S2C(_session);
 
+    /*
+     * Tests leave references outstanding, drain them through the real release path so cache byte
+     * accounting unwinds symmetrically rather than relying on destroy to free the entries.
+     */
+    WT_SHARED_DSK_CACHE *shared_dsk_cache = &conn->cache->shared_dsk_cache;
+    if (shared_dsk_cache->hash != nullptr)
+        for (u_int i = 0; i < shared_dsk_cache->hash_size; i++) {
+            WT_SHARED_DSK_ITEM *item;
+            while ((item = TAILQ_FIRST(&shared_dsk_cache->hash[i])) != nullptr) {
+                int32_t refs = item->ref_count;
+                for (int32_t r = 0; r < refs; r++)
+                    __wt_shared_dsk_cache_release(_session, item);
+            }
+        }
+
     __wti_shared_dsk_cache_destroy(_session);
     __wt_atomic_store_uint8_relaxed(&conn->cache->shared_dsk_cache.state, WT_DSK_CACHE_OFF);
 

--- a/test/catch2/cross_checkpoint_caching/unit/test_cross_checkpoint_caching_put.cpp
+++ b/test/catch2/cross_checkpoint_caching/unit/test_cross_checkpoint_caching_put.cpp
@@ -125,3 +125,35 @@ TEST_CASE(
         REQUIRE(env.bucket_size(0) == 1);
     }
 }
+
+TEST_CASE("cross_checkpoint_caching_put: a shared disk image is counted once in cache usage",
+  "[cross_checkpoint_caching],[cross_checkpoint_caching_put]")
+{
+    cross_checkpoint_caching_test_env env(1);
+    WT_CACHE *cache = S2C(env.session())->cache;
+    const uint8_t addr[] = {0x01, 0x02};
+    const size_t image_size = CROSS_CHECKPOINT_CACHING_TEST_DATA_SIZE;
+
+    uint64_t inmem_before = __wt_atomic_load_uint64_relaxed(&cache->bytes_inmem);
+    uint64_t image_before = __wt_atomic_load_uint64_relaxed(&cache->bytes_image_leaf);
+
+    /* Inserting the image accounts its bytes once in the cache totals. */
+    WT_SHARED_DSK_ITEM *item = env.put(addr, sizeof(addr));
+    REQUIRE(item->ref_count == 1);
+    REQUIRE(__wt_atomic_load_uint64_relaxed(&cache->bytes_inmem) == inmem_before + image_size);
+    REQUIRE(__wt_atomic_load_uint64_relaxed(&cache->bytes_image_leaf) == image_before + image_size);
+
+    /* Sharing the image via a put collision bumps the reference count without recounting bytes. */
+    env.put(addr, sizeof(addr));
+    REQUIRE(item->ref_count == 2);
+    REQUIRE(__wt_atomic_load_uint64_relaxed(&cache->bytes_inmem) == inmem_before + image_size);
+    REQUIRE(__wt_atomic_load_uint64_relaxed(&cache->bytes_image_leaf) == image_before + image_size);
+
+    /* Sharing it via get behaves the same way. */
+    WT_SHARED_DSK_ITEM *got = nullptr;
+    __wt_shared_dsk_cache_get(env.session(), addr, sizeof(addr), &got);
+    REQUIRE(got == item);
+    REQUIRE(item->ref_count == 3);
+    REQUIRE(__wt_atomic_load_uint64_relaxed(&cache->bytes_inmem) == inmem_before + image_size);
+    REQUIRE(__wt_atomic_load_uint64_relaxed(&cache->bytes_image_leaf) == image_before + image_size);
+}

--- a/test/catch2/cross_checkpoint_caching/unit/test_cross_checkpoint_caching_release.cpp
+++ b/test/catch2/cross_checkpoint_caching/unit/test_cross_checkpoint_caching_release.cpp
@@ -156,3 +156,34 @@ TEST_CASE(
     __wt_shared_dsk_cache_get(env.session(), addr, sizeof(addr), &got_a);
     REQUIRE(got_a == nullptr);
 }
+
+TEST_CASE(
+  "cross_checkpoint_caching_release: shared image bytes are drained only on the last release",
+  "[cross_checkpoint_caching],[cross_checkpoint_caching_release]")
+{
+    cross_checkpoint_caching_test_env env(1);
+    WT_CACHE *cache = S2C(env.session())->cache;
+    const uint8_t addr[] = {0x01, 0x02};
+    const size_t image_size = CROSS_CHECKPOINT_CACHING_TEST_DATA_SIZE;
+
+    uint64_t inmem_before = __wt_atomic_load_uint64_relaxed(&cache->bytes_inmem);
+    uint64_t image_before = __wt_atomic_load_uint64_relaxed(&cache->bytes_image_leaf);
+
+    /* Two pages share one disk image: counted once, reference count two. */
+    WT_SHARED_DSK_ITEM *item = env.put(addr, sizeof(addr));
+    env.put(addr, sizeof(addr));
+    REQUIRE(item->ref_count == 2);
+    REQUIRE(__wt_atomic_load_uint64_relaxed(&cache->bytes_inmem) == inmem_before + image_size);
+    REQUIRE(__wt_atomic_load_uint64_relaxed(&cache->bytes_image_leaf) == image_before + image_size);
+
+    /* Releasing one of two references keeps the image, so its bytes stay counted. */
+    __wt_shared_dsk_cache_release(env.session(), item);
+    REQUIRE(item->ref_count == 1);
+    REQUIRE(__wt_atomic_load_uint64_relaxed(&cache->bytes_inmem) == inmem_before + image_size);
+    REQUIRE(__wt_atomic_load_uint64_relaxed(&cache->bytes_image_leaf) == image_before + image_size);
+
+    /* The last release removes the image and drains its bytes once, back to the baseline. */
+    __wt_shared_dsk_cache_release(env.session(), item);
+    REQUIRE(__wt_atomic_load_uint64_relaxed(&cache->bytes_inmem) == inmem_before);
+    REQUIRE(__wt_atomic_load_uint64_relaxed(&cache->bytes_image_leaf) == image_before);
+}


### PR DESCRIPTION
This PR adds
1. Shared disk bytes counted once only on its first put.
2. Shared disk bytes drained once only on its last release.
3. Shared disk drain code in destructor to balance the bytes when we finish the test.

And given we've already had the leak check during connection close in __wti_shared_dsk_cache_destroy, and we've already had the overall cache bytes balance check in __wt_cache_destroy. So there's no need to add global balanced cache usage validation tests.