### PR TITLE
WT-17765 Fix leak in dir_store storage source

### DIFF
--- a/ext/storage_sources/dir_store/dir_store.c
+++ b/ext/storage_sources/dir_store/dir_store.c
@@ -173,6 +173,7 @@ static int dir_store_directory_list_single(
   WT_FILE_SYSTEM *, WT_SESSION *, const char *, const char *, char ***, uint32_t *);
 static int dir_store_directory_list_free(WT_FILE_SYSTEM *, WT_SESSION *, char **, uint32_t);
 static int dir_store_exist(WT_FILE_SYSTEM *, WT_SESSION *, const char *, bool *);
+static void dir_store_fs_free(DIR_STORE_FILE_SYSTEM *);
 static int dir_store_fs_terminate(WT_FILE_SYSTEM *, WT_SESSION *);
 static int dir_store_open(WT_FILE_SYSTEM *, WT_SESSION *, const char *,
   WT_FS_OPEN_FILE_TYPE file_type, uint32_t, WT_FILE_HANDLE **);
@@ -1031,6 +1032,19 @@ err:
 }
 
 /*
+ * dir_store_fs_free --
+ *     Free the memory owned by a file system handle.
+ */
+static void
+dir_store_fs_free(DIR_STORE_FILE_SYSTEM *dir_store_fs)
+{
+    free(dir_store_fs->auth_token);
+    free(dir_store_fs->bucket_dir);
+    free(dir_store_fs->cache_dir);
+    free(dir_store_fs);
+}
+
+/*
  * dir_store_fs_terminate --
  *     Discard any resources on termination of the file system
  */
@@ -1053,10 +1067,7 @@ dir_store_fs_terminate(WT_FILE_SYSTEM *file_system, WT_SESSION *session)
     if ((ret = pthread_rwlock_unlock(&dir_store->file_handle_lock)) != 0)
         ret = dir_store_err(dir_store, session, ret, "fs_terminate: rwlock_unlock");
 
-    free(dir_store_fs->auth_token);
-    free(dir_store_fs->bucket_dir);
-    free(dir_store_fs->cache_dir);
-    free(file_system);
+    dir_store_fs_free(dir_store_fs);
 
     return (ret);
 }
@@ -1355,12 +1366,7 @@ dir_store_terminate(WT_STORAGE_SOURCE *storage, WT_SESSION *session)
     dir_store_file_close_internal(dir_store, session, dir_store_fh);
 
     TAILQ_FOREACH_SAFE(dir_store_fs, &dir_store->fsq, q, safe_fs)
-    {
-        free(dir_store_fs->auth_token);
-        free(dir_store_fs->bucket_dir);
-        free(dir_store_fs->cache_dir);
-        free(dir_store_fs);
-    }
+    dir_store_fs_free(dir_store_fs);
 
     free(dir_store);
     return (ret);

--- a/ext/storage_sources/dir_store/dir_store.c
+++ b/ext/storage_sources/dir_store/dir_store.c
@@ -72,7 +72,7 @@ typedef struct {
     uint32_t rand_w, rand_z;
 
     /*
-     * Locks are used to protect the file handle queue and flush queue.
+     * Locks are used to protect the file handle and file system queues.
      */
     pthread_rwlock_t file_handle_lock;
 
@@ -101,12 +101,13 @@ typedef struct {
     uint64_t read_ops;
     uint64_t write_ops;
 
-    /* Queue of file handles */
+    /* Queues of file handles and file systems. */
     TAILQ_HEAD(dir_store_file_handle_qh, dir_store_file_handle) fileq;
+    TAILQ_HEAD(dir_store_file_system_qh, dir_store_file_system) fsq;
 
 } DIR_STORE;
 
-typedef struct {
+typedef struct dir_store_file_system {
     /* Must come first - this is the interface for the file system we are implementing. */
     WT_FILE_SYSTEM file_system;
     DIR_STORE *dir_store;
@@ -118,6 +119,8 @@ typedef struct {
     char *bucket_dir;     /* Directory that stands in for cloud storage bucket */
     char *cache_dir;      /* Directory for cached objects */
     const char *home_dir; /* Owned by the connection */
+
+    TAILQ_ENTRY(dir_store_file_system) q; /* Queue of file systems */
 } DIR_STORE_FILE_SYSTEM;
 
 typedef struct dir_store_file_handle {
@@ -629,6 +632,19 @@ dir_store_customize_file_system(WT_STORAGE_SOURCE *storage_source, WT_SESSION *s
     fs->file_system.fs_size = dir_store_size;
     fs->file_system.terminate = dir_store_fs_terminate;
 
+    if ((ret = pthread_rwlock_wrlock(&dir_store->file_handle_lock)) != 0) {
+        ret = dir_store_err(dir_store, session, ret, "customize_file_system: rwlock_wrlock");
+        goto err;
+    }
+
+    TAILQ_INSERT_HEAD(&dir_store->fsq, fs, q);
+
+    if ((ret = pthread_rwlock_unlock(&dir_store->file_handle_lock)) != 0) {
+        TAILQ_REMOVE(&dir_store->fsq, fs, q);
+        ret = dir_store_err(dir_store, session, ret, "customize_file_system: rwlock_unlock");
+        goto err;
+    }
+
 err:
     if (ret == 0)
         *file_systemp = &fs->file_system;
@@ -1021,18 +1037,28 @@ err:
 static int
 dir_store_fs_terminate(WT_FILE_SYSTEM *file_system, WT_SESSION *session)
 {
+    DIR_STORE *dir_store;
     DIR_STORE_FILE_SYSTEM *dir_store_fs;
-
-    (void)session; /* unused */
+    int ret;
 
     dir_store_fs = (DIR_STORE_FILE_SYSTEM *)file_system;
-    FS2DS(file_system)->op_count++;
+    dir_store = FS2DS(file_system);
+    dir_store->op_count++;
+
+    if ((ret = pthread_rwlock_wrlock(&dir_store->file_handle_lock)) != 0)
+        return (dir_store_err(dir_store, session, ret, "fs_terminate: rwlock_wrlock"));
+
+    TAILQ_REMOVE(&dir_store->fsq, dir_store_fs, q);
+
+    if ((ret = pthread_rwlock_unlock(&dir_store->file_handle_lock)) != 0)
+        ret = dir_store_err(dir_store, session, ret, "fs_terminate: rwlock_unlock");
+
     free(dir_store_fs->auth_token);
     free(dir_store_fs->bucket_dir);
     free(dir_store_fs->cache_dir);
     free(file_system);
 
-    return (0);
+    return (ret);
 }
 
 /*
@@ -1306,6 +1332,7 @@ static int
 dir_store_terminate(WT_STORAGE_SOURCE *storage, WT_SESSION *session)
 {
     DIR_STORE_FILE_HANDLE *dir_store_fh, *safe_fh;
+    DIR_STORE_FILE_SYSTEM *dir_store_fs, *safe_fs;
     DIR_STORE *dir_store;
     int ret;
 
@@ -1319,13 +1346,21 @@ dir_store_terminate(WT_STORAGE_SOURCE *storage, WT_SESSION *session)
 
     /*
      * We should be single threaded at this point, so it is safe to destroy the lock and access the
-     * file handle list without locking it.
+     * file handle and file system queues without locking.
      */
     if ((ret = pthread_rwlock_destroy(&dir_store->file_handle_lock)) != 0)
         (void)dir_store_err(dir_store, session, ret, "terminate: pthread_rwlock_destroy");
 
     TAILQ_FOREACH_SAFE(dir_store_fh, &dir_store->fileq, q, safe_fh)
     dir_store_file_close_internal(dir_store, session, dir_store_fh);
+
+    TAILQ_FOREACH_SAFE(dir_store_fs, &dir_store->fsq, q, safe_fs)
+    {
+        free(dir_store_fs->auth_token);
+        free(dir_store_fs->bucket_dir);
+        free(dir_store_fs->cache_dir);
+        free(dir_store_fs);
+    }
 
     free(dir_store);
     return (ret);

--- a/test/suite/fail_lists/asan.fail
+++ b/test/suite/fail_lists/asan.fail
@@ -1,6 +1,3 @@
 # This file is used by evergreen.yml when running the python test suite under ASAN.
 # List test files that are not run because they are known failures.
 # They are suppressed because they produce too many warnings that should be solved separately.
-
-# FIXME-WT-17765: memory leaks in dir_store storage source
-test_tiered06.py

--- a/test/suite/test_tiered06.py
+++ b/test/suite/test_tiered06.py
@@ -232,6 +232,7 @@ class test_tiered06(wttest.WiredTigerTestCase, TieredConfigMixin):
                     self.assertEqual(in_block, a_block)
             fh.close(session)
 
+        fs.terminate(session)
         ss.terminate(session)
 
     def create_with_fs(self, fs, fname):


### PR DESCRIPTION
This follows on from WT-16083, which is trying to remove all ASan
suppressions and make the codebase leak-free.

test_tiered06 is currently suppressed in test/suite/fail_lists/asan.fail
due to memory leaks. The test exercises the WiredTiger storage source
API, verifying that it is safe to call ss.terminate() even when some
customised file systems are still open, and that the storage source
should clean up any remaining file systems on its own.

This is currently not the case - file systems are NOT cleaned up.