### PR TITLE
WT-17755 Layered cursor - drive operations by ingest presence, not node role

### DIFF
--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -2359,7 +2359,7 @@ __clayered_copy_duplicate_kv(WT_CLAYERED_OP *op)
  * __clayered_needs_pre_lookup --
  *     Return whether a write must look up the key before modifying the ingest table.
  */
-static bool
+static WT_INLINE bool
 __clayered_needs_pre_lookup(WT_CLAYERED_OP *op)
 {
     /*
@@ -2829,10 +2829,8 @@ __clayered_next_random(WT_CURSOR *cursor)
 
     if (c == NULL || ret == WT_NOTFOUND) {
         c = op.ingest;
-        /* No ingest cursor to fall back to: there is no random row available. */
         if (c == NULL)
             WT_ERR(WT_NOTFOUND);
-
         WT_ERR(__wti_curfile_next_random(c));
     }
 

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -202,7 +202,7 @@ __clayered_op_init_finish(WT_CLAYERED_OP *op)
 {
     WT_CURSOR_LAYERED *clayered = op->clayered;
 
-    op->ingest = clayered->ingest_cursor;
+    op->ingest = (op->role == WT_CLAYERED_ROLE_FOLLOWER) ? clayered->ingest_cursor : NULL;
     op->stable = clayered->stable_cursor;
     op->table = (WT_LAYERED_TABLE *)clayered->dhandle;
     op->collator = op->table->collator;
@@ -607,6 +607,14 @@ __clayered_open_ingest(WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, WT
     layered = (WT_LAYERED_TABLE *)clayered->dhandle;
 
     WT_RET(__wt_open_cursor(session, layered->ingest_uri, c, ckpt_cfg, &cursor));
+
+    /*
+     * We always open ingest in overwrite mode to be able to rewrite tombstones with insert().
+     *
+     * FIXME-WT-XXXX: It might be possible that it'll be technically simpler to inherit OVERWRITE
+     * only if it's set for the top cursor and always call update() to put something on top of an
+     * ingest tombstone.
+     */
     F_SET(cursor, WT_CURSTD_OVERWRITE | WT_CURSTD_RAW);
 
     if (F_ISSET(c, WT_CURSTD_DEBUG_RESET_EVICT))
@@ -723,14 +731,6 @@ __clayered_get_current(WT_CLAYERED_OP *op, bool smallest)
      */
     if (op->ingest != NULL && F_ISSET(op->ingest, WT_CURSTD_KEY_INT))
         ingest_positioned = true;
-
-    /*
-     * FIXME-WT-16810: In leader mode, skip searching ingest as it should be empty. This will need
-     * revisiting when asynchronous step-up is supported, because ingest may legitimately contain
-     * data for some time after promotion.
-     */
-    if (op->role == WT_CLAYERED_ROLE_LEADER)
-        ingest_positioned = false;
 
     if (op->stable != NULL && F_ISSET(op->stable, WT_CURSTD_KEY_INT))
         stable_positioned = true;
@@ -1173,17 +1173,10 @@ __clayered_iterate_constituents(WT_CLAYERED_OP *op, uint32_t iter_flag)
 
     current_moved = false;
     forward = (iter_flag == WT_CLAYERED_ITERATE_NEXT);
-    /* Local copy: leader mode clears the ingest cursor to NULL below. */
+
+    /* The ingest cursor is NULL when it's fine to access stable table only (e.g. on leader). */
     WT_CURSOR *c_ingest = op->ingest;
     WT_CURSOR *c_stable = op->stable;
-
-    /*
-     * FIXME-WT-16810: In leader mode, skip iterating through ingest as it should be empty. This
-     * will need revisiting when asynchronous step-up is supported, because ingest may legitimately
-     * contain data for some time after promotion.
-     */
-    if (op->role == WT_CLAYERED_ROLE_LEADER)
-        c_ingest = NULL;
 
     /*
      * FIXME-WT-15058: Both cursors are expected to be initialized, but we currently have an issue
@@ -1740,7 +1733,7 @@ __clayered_lookup(WT_CLAYERED_OP *op, WT_ITEM *value)
     cursor = &clayered->iface;
     found = false;
 
-    if (op->role == WT_CLAYERED_ROLE_FOLLOWER) {
+    if (op->ingest != NULL) {
         WT_ERR_NOTFOUND_OK(__clayered_lookup_constituent(op, op->ingest, value), true);
         if (ret == 0) {
             found = true;
@@ -1899,12 +1892,8 @@ __clayered_search_near_int(WT_CLAYERED_OP *op, int *exactp)
      * * Otherwise a larger key is preferred if one exists.
      * * Otherwise a smaller key should be returned.
      * If both constituents have a larger key available, return the one closes to the search term.
-     *
-     * FIXME-WT-16810: In leader mode, skip searching ingest as it should be empty.
-     * This will need revisiting when asynchronous step-up is supported, because ingest may
-     * legitimately contain data for some time after promotion.
      */
-    if (op->role == WT_CLAYERED_ROLE_FOLLOWER) {
+    if (op->ingest != NULL) {
         op->ingest->set_key(op->ingest, &cursor->key);
         WT_ERR_NOTFOUND_OK(op->ingest->search_near(op->ingest, &ingest_cmp), true);
         if (ret == 0) {
@@ -2044,6 +2033,7 @@ done:
      * constituent cursor that is not the current cursor to prevent unnecessarily pinning the page
      * in memory.
      */
+    WT_ASSERT(session, clayered->current_cursor == op->ingest || clayered->current_cursor == op->stable);
     if (!F_ISSET(clayered, WT_CLAYERED_ITERATE_NEXT | WT_CLAYERED_ITERATE_PREV)) {
         if (op->stable != NULL && clayered->current_cursor == op->ingest)
             WT_ERR(op->stable->reset(op->stable));
@@ -2113,12 +2103,11 @@ __clayered_reserve_constituent(WT_CLAYERED_OP *op, WT_CURSOR *constituent)
     CURSOR_API_CHECK_SYSTEM_OVERLOAD(session, ret);
 
     /*
-     * Pass overwrite=true for followers: a follower's ingest table may not contain the key yet (it
-     * lives only in the stable table), so we need overwrite mode to allow the reserve to succeed
-     * without the key being present in the update tree.
+     * Pass overwrite=true for ingest table, it may not contain the key yet (it lives only in the
+     * stable table), so we need overwrite mode to allow the reserve to succeed without the key
+     * being present in the update tree.
      */
-    WT_ERR(
-      __wt_btcur_reserve((WT_CURSOR_BTREE *)constituent, op->role == WT_CLAYERED_ROLE_FOLLOWER));
+    WT_ERR(__wt_btcur_reserve((WT_CURSOR_BTREE *)constituent, constituent == op->ingest));
 
 err:
     CURSOR_UPDATE_API_END_STAT(session, ret, cursor_reserve);
@@ -2136,9 +2125,10 @@ __clayered_put(
 {
     WT_CURSOR_LAYERED *clayered = op->clayered;
     WT_SESSION_IMPL *session = CUR2S(clayered);
-    bool leader = op->role == WT_CLAYERED_ROLE_LEADER;
+    WT_CURSOR *c = op->ingest != NULL ? op->ingest : op->stable;
+    WT_ASSERT(session, c != NULL);
 
-    if (!leader) {
+    if (c == op->ingest) {
         /*
          * FIXME-WT-17425: Investigate whether this function can be called below the cursor layer.
          * Doing so would remove the cursor write operation dependency on the truncate list.
@@ -2153,7 +2143,6 @@ __clayered_put(
             WT_RET(__clayered_reset_cursors(clayered, true));
     }
 
-    WT_CURSOR *c = leader ? op->stable : op->ingest;
     c->set_key(c, key);
     /* Reserve does not require a value. */
     if (put_op != WT_CLAYERED_PUT_RESERVE)
@@ -2272,11 +2261,11 @@ __clayered_modify_check(WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, c
 }
 
 /*
- * __clayered_remove_follower --
+ * __clayered_remove_from_ingest --
  *     Remove an entry from the ingest table.
  */
 static WT_INLINE int
-__clayered_remove_follower(WT_CLAYERED_OP *op, const WT_ITEM *key, bool positioned)
+__clayered_remove_from_ingest(WT_CLAYERED_OP *op, const WT_ITEM *key, bool positioned)
 {
     WT_CURSOR_LAYERED *clayered = op->clayered;
     WT_SESSION_IMPL *session = CUR2S(clayered);
@@ -2331,11 +2320,11 @@ err:
 }
 
 /*
- * __clayered_remove_leader --
+ * __clayered_remove_from_stable --
  *     Remove an entry from the stable table.
  */
 static WT_INLINE int
-__clayered_remove_leader(WT_CLAYERED_OP *op, const WT_ITEM *key, bool positioned)
+__clayered_remove_from_stable(WT_CLAYERED_OP *op, const WT_ITEM *key, bool positioned)
 {
     WT_CURSOR_LAYERED *clayered = op->clayered;
     WT_SESSION_IMPL *session = CUR2S(clayered);
@@ -2360,8 +2349,8 @@ __clayered_remove_leader(WT_CLAYERED_OP *op, const WT_ITEM *key, bool positioned
 static WT_INLINE int
 __clayered_remove_int(WT_CLAYERED_OP *op, const WT_ITEM *key, bool positioned)
 {
-    return (op->role == WT_CLAYERED_ROLE_LEADER ? __clayered_remove_leader(op, key, positioned) :
-                                                  __clayered_remove_follower(op, key, positioned));
+    return (op->ingest == NULL ? __clayered_remove_from_stable(op, key, positioned) :
+                                 __clayered_remove_from_ingest(op, key, positioned));
 }
 
 /*
@@ -2387,6 +2376,22 @@ __clayered_copy_duplicate_kv(WT_CLAYERED_OP *op)
     WT_RET(__clayered_reset_cursors(clayered, false));
 
     return (0);
+}
+
+/*
+ * __clayered_needs_pre_lookup --
+ *     Return whether a write must look up the key before modifying the ingest table.
+ */
+static bool
+__clayered_needs_pre_lookup(WT_CLAYERED_OP *op)
+{
+    /*
+     * The ingest cursor is always in overwrite mode so insert() can write over an ingest tombstone,
+     * which means non-overwrite duplicate detection has to happen here instead. This lookup also
+     * covers the cases that need both constituents consulted, currently a subset of having an
+     * ingest cursor.
+     */
+    return (op->ingest != NULL && !F_ISSET(&op->clayered->iface, WT_CURSTD_OVERWRITE));
 }
 
 /*
@@ -2422,14 +2427,17 @@ __clayered_insert(WT_CURSOR *cursor)
 
     /*
      * It isn't necessary to copy the key out after the lookup in this case because any non-failed
-     * lookup results in an error, and a failed lookup leaves the original key intact.
+     * lookup results in an error, and a failed lookup leaves the original key intact. A successful
+     * lookup is a duplicate; WT_NOTFOUND is the happy path that falls through to the insert; any
+     * other error is returned.
      */
-    if (op.role == WT_CLAYERED_ROLE_FOLLOWER && !F_ISSET(cursor, WT_CURSTD_OVERWRITE) &&
-      (ret = __clayered_lookup(&op, &value)) != WT_NOTFOUND) {
-        WT_ERR(ret);
-        WT_ERR(__clayered_copy_duplicate_kv(&op));
-        WT_ERR(__clayered_reset_cursors(clayered, false));
-        WT_ERR(WT_DUPLICATE_KEY);
+    if (__clayered_needs_pre_lookup(&op) && (ret = __clayered_lookup(&op, &value)) != WT_NOTFOUND) {
+        if (ret == 0) {
+            WT_ERR(__clayered_copy_duplicate_kv(&op));
+            WT_ERR(__clayered_reset_cursors(clayered, false));
+            WT_ERR(WT_DUPLICATE_KEY);
+        }
+        goto err;
     }
 
     WT_ERR(__clayered_modify_check(session, clayered, &cursor->key));
@@ -2502,7 +2510,7 @@ __clayered_update(WT_CURSOR *cursor)
 
     WT_ERR(__clayered_modify_check(session, clayered, &cursor->key));
 
-    if (op.role == WT_CLAYERED_ROLE_FOLLOWER && !F_ISSET(cursor, WT_CURSTD_OVERWRITE)) {
+    if (__clayered_needs_pre_lookup(&op)) {
         WT_ERR(__clayered_lookup(&op, &value));
         /*
          * Copy the key out, since the insert resets non-primary chunk cursors which our lookup may
@@ -2844,8 +2852,10 @@ __clayered_next_random(WT_CURSOR *cursor)
 
     if (c == NULL || ret == WT_NOTFOUND) {
         c = op.ingest;
+        /* No ingest cursor to fall back to: there is no random row available. */
         if (c == NULL)
             WT_ERR(WT_NOTFOUND);
+
         WT_ERR(__wti_curfile_next_random(c));
     }
 
@@ -2881,11 +2891,11 @@ err:
 }
 
 /*
- * __clayered_modify_leader --
- *     Apply a set of modifications on a leader node.
+ * __clayered_modify_stable --
+ *     Apply a set of modifications to the stable table.
  */
 static int
-__clayered_modify_leader(WT_CLAYERED_OP *op, WT_MODIFY *entries, int nentries)
+__clayered_modify_stable(WT_CLAYERED_OP *op, WT_MODIFY *entries, int nentries)
 {
     WT_CURSOR_LAYERED *clayered = op->clayered;
     WT_SESSION_IMPL *session = CUR2S(clayered);
@@ -2919,11 +2929,11 @@ err:
 }
 
 /*
- * __clayered_modify_follower --
- *     Apply a set of modifications on a leader node.
+ * __clayered_modify_ingest --
+ *     Apply a set of modifications to the ingest table.
  */
 static int
-__clayered_modify_follower(WT_CLAYERED_OP *op, WT_MODIFY *entries, int nentries)
+__clayered_modify_ingest(WT_CLAYERED_OP *op, WT_MODIFY *entries, int nentries)
 {
     WT_CURSOR_LAYERED *clayered = op->clayered;
     WT_SESSION_IMPL *session = CUR2S(clayered);
@@ -2994,15 +3004,15 @@ err:
 
 /*
  * __clayered_modify_int --
- *     Dispatch a modify call based on leader/follower status.
+ *     Dispatch a modify call based on whether an ingest cursor is present.
  */
 static int
 __clayered_modify_int(WT_CLAYERED_OP *op, WT_MODIFY *entries, int nentries)
 {
-    if (op->role == WT_CLAYERED_ROLE_LEADER)
-        WT_RET(__clayered_modify_leader(op, entries, nentries));
+    if (op->ingest == NULL)
+        WT_RET(__clayered_modify_stable(op, entries, nentries));
     else
-        WT_RET(__clayered_modify_follower(op, entries, nentries));
+        WT_RET(__clayered_modify_ingest(op, entries, nentries));
 
     return (0);
 }

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -587,7 +587,7 @@ __clayered_open_ingest(WT_SESSION_IMPL *session, WT_CURSOR_LAYERED *clayered, WT
     /*
      * We always open ingest in overwrite mode to be able to rewrite tombstones with insert().
      *
-     * FIXME-WT-XXXX: It might be possible that it'll be technically simpler to inherit OVERWRITE
+     * FIXME-WT-17917: It might be possible that it'll be technically simpler to inherit OVERWRITE
      * only if it's set for the top cursor and always call update() to put something on top of an
      * ingest tombstone.
      */

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -15,7 +15,7 @@ static int __clayered_lookup(WT_CLAYERED_OP *, WT_ITEM *);
 static int __clayered_open_ingest(WT_SESSION_IMPL *, WT_CURSOR_LAYERED *, WT_CURSOR **);
 static int __clayered_reset_cursors(WT_CURSOR_LAYERED *, bool);
 static int __clayered_search_near(WT_CURSOR *, int *);
-static void __clayered_update_state(WT_CURSOR_LAYERED *);
+static void __clayered_update_state(WT_CURSOR_LAYERED *, WT_CLAYERED_ROLE);
 
 /* Operations passed to __clayered_put. */
 typedef enum {
@@ -141,71 +141,49 @@ __clayered_assert_stable_mode(WT_CURSOR_LAYERED *clayered)
 #define CLAYERED_ENTER_ROLE_CHANGE 0x8u /* Leader/follower role changed since last access. */
 
 /*
- * __clayered_op_init_begin --
- *     Populate the per-operation state that is known before the constituents are synchronized.
+ * __clayered_enter_flags --
+ *     Derive the enter-time control flags from the operation mode and resolved role.
  */
-static WT_INLINE void
-__clayered_op_init_begin(WT_CURSOR_LAYERED *clayered, WT_CLAYERED_OP_MODE mode, WT_CLAYERED_OP *op)
+static WT_INLINE uint32_t
+__clayered_enter_flags(WT_CURSOR_LAYERED *clayered, WT_CLAYERED_OP_MODE mode, WT_CLAYERED_ROLE role)
 {
     WT_SESSION_IMPL *session = CUR2S(clayered);
-    WT_CONNECTION_IMPL *conn = S2C(session);
+    uint32_t flags = 0;
 
-    op->clayered = clayered;
-    op->mode = mode;
-
-    /*
-     * Resolve the role for this operation. The live role is read once here; the role detector
-     * settles clayered->last_role to the same value.
-     */
-    op->role =
-      conn->layered_table_manager.leader ? WT_CLAYERED_ROLE_LEADER : WT_CLAYERED_ROLE_FOLLOWER;
+    if (mode == WT_CLAYERED_MODE_SEARCH)
+        LF_SET(CLAYERED_ENTER_RESET);
+    if (mode == WT_CLAYERED_MODE_ITERATE || mode == WT_CLAYERED_MODE_RANDOM)
+        LF_SET(CLAYERED_ENTER_ITERATION);
 
     /*
      * Reads (search, search_near, iterate, random, scan) and non-overwrite writes always need the
      * stable cursor; an overwrite write needs it on the leader, or on a follower with a read
      * timestamp where the write-conflict check must consult the stable table.
      */
-    op->need_stable = (mode != WT_CLAYERED_MODE_WRITE_OVERWRITE) ||
-      (op->role == WT_CLAYERED_ROLE_LEADER) || F_ISSET(session->txn, WT_TXN_SHARED_TS_READ);
-}
-
-/*
- * __clayered_enter_flags --
- *     Derive the enter-time control flags from the operation mode and resolved role.
- */
-static WT_INLINE uint32_t
-__clayered_enter_flags(WT_CLAYERED_OP *op)
-{
-    uint32_t flags;
-
-    flags = 0;
-
-    if (op->mode == WT_CLAYERED_MODE_SEARCH)
-        LF_SET(CLAYERED_ENTER_RESET);
-    if (op->mode == WT_CLAYERED_MODE_ITERATE || op->mode == WT_CLAYERED_MODE_RANDOM)
-        LF_SET(CLAYERED_ENTER_ITERATION);
-    /* Follower overwrite writes update the ingest table without accessing the stable table. */
-    if (!op->need_stable)
+    if ((mode == WT_CLAYERED_MODE_WRITE_OVERWRITE) && (role == WT_CLAYERED_ROLE_FOLLOWER) &&
+      !F_ISSET(session->txn, WT_TXN_SHARED_TS_READ))
         LF_SET(CLAYERED_ENTER_SKIP_STABLE);
-    if (op->role != op->clayered->last_role)
+
+    if (role != clayered->last_role)
         LF_SET(CLAYERED_ENTER_ROLE_CHANGE);
 
     return (flags);
 }
 
 /*
- * __clayered_op_init_finish --
- *     Capture the resolved constituents into the op once the cursors are synchronized.
+ * __clayered_op_init --
+ *     Populate the per-operation state.
  */
 static WT_INLINE void
-__clayered_op_init_finish(WT_CLAYERED_OP *op)
+__clayered_op_init(
+  WT_CURSOR_LAYERED *clayered, WT_CLAYERED_OP *op, WT_CLAYERED_ROLE role, uint32_t flags)
 {
-    WT_CURSOR_LAYERED *clayered = op->clayered;
-
-    op->ingest = (op->role == WT_CLAYERED_ROLE_FOLLOWER) ? clayered->ingest_cursor : NULL;
+    op->clayered = clayered;
+    op->ingest = (role == WT_CLAYERED_ROLE_FOLLOWER) ? clayered->ingest_cursor : NULL;
     op->stable = clayered->stable_cursor;
     op->table = (WT_LAYERED_TABLE *)clayered->dhandle;
     op->collator = op->table->collator;
+    op->need_stable = !LF_ISSET(CLAYERED_ENTER_SKIP_STABLE);
 }
 
 /*
@@ -216,10 +194,10 @@ static WT_INLINE int
 __clayered_enter(WT_CURSOR_LAYERED *clayered, WT_CLAYERED_OP_MODE mode, WT_CLAYERED_OP *op)
 {
     WT_SESSION_IMPL *const session = CUR2S(clayered);
-    uint32_t flags;
-
-    __clayered_op_init_begin(clayered, mode, op);
-    flags = __clayered_enter_flags(op);
+    WT_CONNECTION_IMPL *conn = S2C(session);
+    WT_CLAYERED_ROLE role =
+      conn->layered_table_manager.leader ? WT_CLAYERED_ROLE_LEADER : WT_CLAYERED_ROLE_FOLLOWER;
+    uint32_t flags = __clayered_enter_flags(clayered, mode, role);
 
     if (FLD_ISSET(flags, CLAYERED_ENTER_ROLE_CHANGE)) {
         WT_ASSERT_ALWAYS(session, !F_ISSET(&clayered->iface, WT_CURSTD_KEY_INT),
@@ -242,12 +220,12 @@ __clayered_enter(WT_CURSOR_LAYERED *clayered, WT_CLAYERED_OP_MODE mode, WT_CLAYE
     WT_RET(__clayered_update_ingest(clayered, flags));
 
     /* Manage the stable: open it, advance to a newer checkpoint, or reopen on role change. */
-    WT_RET(__clayered_update_stable(clayered, flags, op->role));
+    WT_RET(__clayered_update_stable(clayered, flags, role));
 
-    __clayered_update_state(clayered);
+    __clayered_update_state(clayered, role);
     __clayered_assert_stable_mode(clayered);
 
-    __clayered_op_init_finish(op);
+    __clayered_op_init(clayered, op, role, flags);
 
     if (!F_ISSET(clayered, WT_CLAYERED_ACTIVE)) {
         /*
@@ -569,10 +547,9 @@ err:
  *     Validate and update cursor state and refresh the transaction context.
  */
 static void
-__clayered_update_state(WT_CURSOR_LAYERED *clayered)
+__clayered_update_state(WT_CURSOR_LAYERED *clayered, WT_CLAYERED_ROLE role)
 {
     WT_SESSION_IMPL *const session = CUR2S(clayered);
-    const WT_CONNECTION_IMPL *const conn = S2C(session);
     const WT_TXN_SHARED *const txn_shared = WT_SESSION_TXN_SHARED(session);
 
     const uint64_t snapshot_gen = __wt_session_gen(session, WT_GEN_HAS_SNAPSHOT);
@@ -588,8 +565,7 @@ __clayered_update_state(WT_CURSOR_LAYERED *clayered)
 
     clayered->snapshot_gen = snapshot_gen;
     clayered->read_timestamp = read_timestamp;
-    clayered->last_role =
-      conn->layered_table_manager.leader ? WT_CLAYERED_ROLE_LEADER : WT_CLAYERED_ROLE_FOLLOWER;
+    clayered->last_role = role;
 }
 
 /*
@@ -2446,7 +2422,7 @@ __clayered_insert(WT_CURSOR *cursor)
     WT_ERR(__clayered_deleted_encode(session, &cursor->value, &value, &buf));
     ret = __clayered_put(&op, &cursor->key, &value, WT_CLAYERED_PUT_INSERT);
     if (ret == WT_DUPLICATE_KEY) {
-        WT_ASSERT(session, op.role == WT_CLAYERED_ROLE_LEADER);
+        WT_ASSERT(session, op.ingest == NULL);
         /*
          * The btree cursor already holds a local copy of the existing value from duplicate
          * detection. Copy it directly without a second search.
@@ -2636,10 +2612,10 @@ __clayered_reserve(WT_CURSOR *cursor)
     WT_ERR(__clayered_modify_check(session, clayered, &cursor->key));
 
     /*
-     * WT_CURSOR.reserve is update-without-overwrite so we should check whether the key exists. The
-     * leader's stable cursor reserves without overwrite and runs the check itself.
+     * WT_CURSOR.reserve is update-without-overwrite so we should check whether the key exists. With
+     * no ingest cursor the stable cursor reserves without overwrite and runs the check itself.
      */
-    if (op.role == WT_CLAYERED_ROLE_FOLLOWER)
+    if (op.ingest != NULL)
         WT_ERR(__clayered_lookup(&op, &value));
 
     WT_ERR(__clayered_put(&op, &cursor->key, NULL, WT_CLAYERED_PUT_RESERVE));

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -2033,7 +2033,8 @@ done:
      * constituent cursor that is not the current cursor to prevent unnecessarily pinning the page
      * in memory.
      */
-    WT_ASSERT(session, clayered->current_cursor == op->ingest || clayered->current_cursor == op->stable);
+    WT_ASSERT(
+      session, clayered->current_cursor == op->ingest || clayered->current_cursor == op->stable);
     if (!F_ISSET(clayered, WT_CLAYERED_ITERATE_NEXT | WT_CLAYERED_ITERATE_PREV)) {
         if (op->stable != NULL && clayered->current_cursor == op->ingest)
             WT_ERR(op->stable->reset(op->stable));
@@ -2427,17 +2428,17 @@ __clayered_insert(WT_CURSOR *cursor)
 
     /*
      * It isn't necessary to copy the key out after the lookup in this case because any non-failed
-     * lookup results in an error, and a failed lookup leaves the original key intact. A successful
-     * lookup is a duplicate; WT_NOTFOUND is the happy path that falls through to the insert; any
-     * other error is returned.
+     * lookup results in an error, and a failed lookup leaves the original key intact.
      */
-    if (__clayered_needs_pre_lookup(&op) && (ret = __clayered_lookup(&op, &value)) != WT_NOTFOUND) {
+    if (__clayered_needs_pre_lookup(&op)) {
+        WT_ERR_NOTFOUND_OK(__clayered_lookup(&op, &value), true);
         if (ret == 0) {
             WT_ERR(__clayered_copy_duplicate_kv(&op));
             WT_ERR(__clayered_reset_cursors(clayered, false));
             WT_ERR(WT_DUPLICATE_KEY);
+        } else if (ret != WT_NOTFOUND) { /* Not found is a happy path. */
+            goto err;
         }
-        goto err;
     }
 
     WT_ERR(__clayered_modify_check(session, clayered, &cursor->key));

--- a/src/include/cursor.h
+++ b/src/include/cursor.h
@@ -571,10 +571,8 @@ typedef enum {                       /* maps 1:1 onto the API methods */
  */
 struct __wt_clayered_op {
     WT_CURSOR_LAYERED *clayered; /* back-pointer; session via CUR2S(clayered) */
-    WT_CLAYERED_OP_MODE mode;
-    WT_CLAYERED_ROLE role;
-    WT_CURSOR *ingest; /* resolved slot == clayered->ingest_cursor (may be NULL) */
-    WT_CURSOR *stable; /* resolved slot == clayered->stable_cursor (may be NULL) */
+    WT_CURSOR *ingest;           /* resolved slot == clayered->ingest_cursor (may be NULL) */
+    WT_CURSOR *stable;           /* resolved slot == clayered->stable_cursor (may be NULL) */
     WT_LAYERED_TABLE *table;
     WT_COLLATOR *collator;
     bool need_stable; /* derived from mode+role; whether the stable cursor must be opened */

--- a/test/catch2/cursors/unit/test_layered_op.cpp
+++ b/test/catch2/cursors/unit/test_layered_op.cpp
@@ -201,10 +201,6 @@ TEST_CASE(
     {
         position_at(ingest, "i");
         position_at(stable, "s");
-        /*
-         * A leader-mode op has no ingest constituent: __clayered_op_finalize leaves op->ingest NULL
-         * on the leader, and __clayered_get_current keys off op->ingest, not op->role.
-         */
         op.role = WT_CLAYERED_ROLE_LEADER;
         op.ingest = nullptr;
         REQUIRE(__clayered_get_current(&op, true) == 0);

--- a/test/catch2/cursors/unit/test_layered_op.cpp
+++ b/test/catch2/cursors/unit/test_layered_op.cpp
@@ -172,7 +172,6 @@ TEST_CASE(
     make_op(op, clayered, session_impl);
     op.ingest = ingest;
     op.stable = stable;
-    op.role = WT_CLAYERED_ROLE_FOLLOWER; /* follower so ingest is considered */
 
     SECTION("smallest picks the lower key (ingest 'i' < stable 's')")
     {
@@ -197,11 +196,10 @@ TEST_CASE(
         REQUIRE(clayered.current_cursor == stable);
     }
 
-    SECTION("leader role ignores the ingest cursor")
+    SECTION("no ingest cursor -> stable only")
     {
         position_at(ingest, "i");
         position_at(stable, "s");
-        op.role = WT_CLAYERED_ROLE_LEADER;
         op.ingest = nullptr;
         REQUIRE(__clayered_get_current(&op, true) == 0);
         /* With no ingest cursor, stable is the only candidate even though 'i' < 's'. */

--- a/test/catch2/cursors/unit/test_layered_op.cpp
+++ b/test/catch2/cursors/unit/test_layered_op.cpp
@@ -201,9 +201,14 @@ TEST_CASE(
     {
         position_at(ingest, "i");
         position_at(stable, "s");
+        /*
+         * A leader-mode op has no ingest constituent: __clayered_op_finalize leaves op->ingest NULL
+         * on the leader, and __clayered_get_current keys off op->ingest, not op->role.
+         */
         op.role = WT_CLAYERED_ROLE_LEADER;
+        op.ingest = nullptr;
         REQUIRE(__clayered_get_current(&op, true) == 0);
-        /* Ingest is skipped in leader mode, so stable wins even though 'i' < 's'. */
+        /* With no ingest cursor, stable is the only candidate even though 'i' < 's'. */
         REQUIRE(clayered.current_cursor == stable);
     }
 


### PR DESCRIPTION
Whether a layered-cursor operation works on the ingest table or the stable table is fully determined by which constituent cursor the operation resolved, not by the node's leader/follower role: a leader has only a stable cursor, a follower has both. Keying the read and write paths on the resolved ingest cursor (op->ingest) rather than the role lets one code path serve both roles and keeps role-specific naming and comments out of the per-operation logic.

Write paths are named and dispatched by their destination table -- ingest versus stable -- and the leader path is hardened where it has no ingest cursor to fall back on. Role is kept only where it is genuinely resolved, when opening and synchronizing the constituents, not in the API-method logic.

That's the required prework for the step-down project. It also allows us to remove the `role` and `mode` fields from the op structure.
