### PR TITLE
WT-17349 Support wt util reading individual pages without checkpoint pickup

### DIFF
--- a/src/block_disagg/block_disagg_read.c
+++ b/src/block_disagg/block_disagg_read.c
@@ -419,8 +419,8 @@ __wt_block_disagg_debug_read_page_id_raw(WT_SESSION_IMPL *session, uint64_t tabl
       npage_log->page_log, &session->iface, table_id, &plhandle));
 
     tmp_count = (uint32_t)*results_count;
-    ret = plhandle->plh_get(
-      plhandle, &session->iface, page_id, 0, get_args, results_array, &tmp_count);
+    ret =
+      plhandle->plh_get(plhandle, &session->iface, page_id, 0, get_args, results_array, &tmp_count);
     if (ret == 0) {
         WT_ASSERT(session, tmp_count <= WT_DELTA_LIMIT + 1);
         *results_count = tmp_count;

--- a/src/block_disagg/block_disagg_read.c
+++ b/src/block_disagg/block_disagg_read.c
@@ -388,6 +388,50 @@ __wt_block_disagg_debug_read_page_id(WT_BM *bm, WT_SESSION_IMPL *session, uint64
     return (0);
 }
 
+/*
+ * __wt_block_disagg_debug_read_page_id_raw --
+ *     Debug-only entry: fetch a page chain by (table_id, page_id, lsn) directly off the connection
+ *     page log, without a btree or block manager. Used to inspect pages when the checkpoint cannot
+ *     be picked up. The caller owns validation, decode, and printing. Not for production paths.
+ */
+int
+__wt_block_disagg_debug_read_page_id_raw(WT_SESSION_IMPL *session, uint64_t table_id,
+  uint64_t page_id, uint64_t lsn, WT_PAGE_LOG_GET_ARGS *get_args, WT_ITEM *results_array,
+  u_int *results_count)
+{
+    WT_CONNECTION_IMPL *conn;
+    WT_DECL_RET;
+    WT_NAMED_PAGE_LOG *npage_log;
+    WT_PAGE_LOG_HANDLE *plhandle;
+    uint32_t tmp_count;
+
+    conn = S2C(session);
+    npage_log = conn->disaggregated_storage.npage_log;
+    plhandle = NULL;
+
+    if (npage_log == NULL)
+        WT_RET_MSG(session, ENOTSUP, "wt page is only supported in disaggregated storage mode");
+
+    WT_CLEAR(*get_args);
+    get_args->lsn = lsn;
+
+    WT_RET(npage_log->page_log->pl_open_handle(
+      npage_log->page_log, &session->iface, table_id, &plhandle));
+
+    tmp_count = (uint32_t)*results_count;
+    ret = plhandle->plh_get(
+      plhandle, &session->iface, page_id, 0, get_args, results_array, &tmp_count);
+    if (ret == 0) {
+        WT_ASSERT(session, tmp_count <= WT_DELTA_LIMIT + 1);
+        *results_count = tmp_count;
+        if (tmp_count == 0)
+            ret = WT_NOTFOUND;
+    }
+
+    WT_TRET(plhandle->plh_close(plhandle, &session->iface));
+    return (ret);
+}
+
 #ifdef HAVE_UNITTEST
 /*
  * __ut_block_disagg_header_version_compatible --

--- a/src/block_disagg/block_disagg_read.c
+++ b/src/block_disagg/block_disagg_read.c
@@ -419,8 +419,8 @@ __wt_block_disagg_debug_read_page_id_raw(WT_SESSION_IMPL *session, uint64_t tabl
       npage_log->page_log, &session->iface, table_id, &plhandle));
 
     tmp_count = (uint32_t)*results_count;
-    WT_ERR(
-      plhandle->plh_get(plhandle, &session->iface, page_id, 0, get_args, results_array, &tmp_count));
+    WT_ERR(plhandle->plh_get(
+      plhandle, &session->iface, page_id, 0, get_args, results_array, &tmp_count));
     WT_ASSERT(session, tmp_count <= WT_DELTA_LIMIT + 1);
     *results_count = tmp_count;
     if (tmp_count == 0)

--- a/src/block_disagg/block_disagg_read.c
+++ b/src/block_disagg/block_disagg_read.c
@@ -392,7 +392,7 @@ __wt_block_disagg_debug_read_page_id(WT_BM *bm, WT_SESSION_IMPL *session, uint64
  * __wt_block_disagg_debug_read_page_id_raw --
  *     Debug-only entry: fetch a page chain by (table_id, page_id, lsn) directly off the connection
  *     page log, without a btree or block manager. Used to inspect pages when the checkpoint cannot
- *     be picked up. The caller owns validation, decode, and printing. Not for production paths.
+ *     be picked up. Not for production paths.
  */
 int
 __wt_block_disagg_debug_read_page_id_raw(WT_SESSION_IMPL *session, uint64_t table_id,
@@ -419,15 +419,14 @@ __wt_block_disagg_debug_read_page_id_raw(WT_SESSION_IMPL *session, uint64_t tabl
       npage_log->page_log, &session->iface, table_id, &plhandle));
 
     tmp_count = (uint32_t)*results_count;
-    ret =
-      plhandle->plh_get(plhandle, &session->iface, page_id, 0, get_args, results_array, &tmp_count);
-    if (ret == 0) {
-        WT_ASSERT(session, tmp_count <= WT_DELTA_LIMIT + 1);
-        *results_count = tmp_count;
-        if (tmp_count == 0)
-            ret = WT_NOTFOUND;
-    }
+    WT_ERR(
+      plhandle->plh_get(plhandle, &session->iface, page_id, 0, get_args, results_array, &tmp_count));
+    WT_ASSERT(session, tmp_count <= WT_DELTA_LIMIT + 1);
+    *results_count = tmp_count;
+    if (tmp_count == 0)
+        ret = WT_NOTFOUND;
 
+err:
     WT_TRET(plhandle->plh_close(plhandle, &session->iface));
     return (ret);
 }

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -584,8 +584,12 @@ int
 __wt_debug_disagg_page_id_raw(
   WT_SESSION_IMPL *session, uint64_t table_id, uint64_t page_id, uint64_t lsn)
 {
+    WT_BTREE fake_btree;
     WT_COMPRESSOR *compressor;
     WT_CONNECTION_IMPL *conn;
+    WT_DATA_HANDLE fake_dhandle;
+    WT_DATA_HANDLE *saved_dhandle;
+    bool fake_dhandle_installed;
     WT_DECL_RET;
     WT_ITEM results[WT_DELTA_LIMIT + 1];
     WT_NAMED_COMPRESSOR *ncomp;
@@ -593,6 +597,7 @@ __wt_debug_disagg_page_id_raw(
     u_int count, i, ncompressors;
 
     conn = S2C(session);
+    fake_dhandle_installed = false;
     memset(results, 0, sizeof(results));
     count = WT_ELEMENTS(results);
 
@@ -608,11 +613,31 @@ __wt_debug_disagg_page_id_raw(
     WT_ERR(__wt_block_disagg_debug_read_page_id_raw(
       session, table_id, page_id, lsn, &get_args, results, &count));
 
+    /*
+     * The page dump machinery requires a session with a valid dhandle and btree. Synthesize minimal
+     * versions on the stack so cell iteration and display work without opening the table — the
+     * only critical field is block_header, which governs where page cells start. Set the SPECIAL
+     * namespace on the fake btree id to suppress history store cursor setup.
+     */
+    memset(&fake_btree, 0, sizeof(fake_btree));
+    fake_btree.block_header = WT_BLOCK_DISAGG_HEADER_SIZE;
+    fake_btree.key_format = "u";
+    fake_btree.value_format = "u";
+    fake_btree.id = WT_BTREE_ID_NAMESPACED(0, WT_BTREE_ID_NAMESPACE_SPECIAL);
+
+    memset(&fake_dhandle, 0, sizeof(fake_dhandle));
+    fake_dhandle.handle = &fake_btree;
+
+    saved_dhandle = session->dhandle;
+    session->dhandle = &fake_dhandle;
+    fake_dhandle_installed = true;
     WT_ERR(__wt_msg(session, "table_id: %" PRIu64, table_id));
     WT_TRET(__debug_disagg_dump_results(
       session, results, count, &get_args, page_id, lsn, compressor, NULL));
 
 err:
+    if (fake_dhandle_installed)
+        session->dhandle = saved_dhandle;
     for (i = 0; i < WT_ELEMENTS(results); i++)
         __wt_buf_free(session, &results[i]);
     return (ret);

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -538,8 +538,8 @@ err:
 
 /*
  * __wt_debug_disagg_page_id --
- *     Fetch and dump a disaggregated page chain by (page_id, lsn) for the current dhandle, bypassing
- *     the address-cookie path.
+ *     Fetch and dump a disaggregated page chain by (page_id, lsn) for the current dhandle,
+ *     bypassing the address-cookie path.
  */
 int
 __wt_debug_disagg_page_id(
@@ -589,12 +589,12 @@ __wt_debug_disagg_page_id_raw(
     WT_CONNECTION_IMPL *conn;
     WT_DATA_HANDLE fake_dhandle;
     WT_DATA_HANDLE *saved_dhandle;
-    bool fake_dhandle_installed;
     WT_DECL_RET;
     WT_ITEM results[WT_DELTA_LIMIT + 1];
     WT_NAMED_COMPRESSOR *ncomp;
     WT_PAGE_LOG_GET_ARGS get_args;
     u_int count, i, ncompressors;
+    bool fake_dhandle_installed;
 
     conn = S2C(session);
     fake_dhandle_installed = false;
@@ -615,8 +615,8 @@ __wt_debug_disagg_page_id_raw(
 
     /*
      * The page dump machinery requires a session with a valid dhandle and btree. Synthesize minimal
-     * versions on the stack so cell iteration and display work without opening the table — the
-     * only critical field is block_header, which governs where page cells start. Set the SPECIAL
+     * versions on the stack so cell iteration and display work without opening the table. The only
+     * critical field is block_header, which governs where page cells start. Set the SPECIAL
      * namespace on the fake btree id to suppress history store cursor setup.
      */
     memset(&fake_btree, 0, sizeof(fake_btree));
@@ -931,7 +931,7 @@ __debug_cell_kv(
     if (page == NULL && S2BT(session)->bm == NULL &&
       (unpack->raw == WT_CELL_KEY_OVFL || unpack->raw == WT_CELL_VALUE_OVFL ||
         unpack->raw == WT_CELL_VALUE_OVFL_RM))
-        return (ds->f(ds, "\t%s%soverflow item not resolved (no block manager)\n",
+        return (ds->f(ds, "\t%s%s(overflow item not resolved: no block manager)\n",
           tag == NULL ? "" : tag, tag == NULL ? "" : ": "));
 
     WT_RET(page == NULL ? __wt_dsk_cell_data_ref_kv(session, unpack, ds->t1) :

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -625,6 +625,11 @@ __wt_debug_disagg_page_id_raw(
     fake_btree.key_format = "u";
     fake_btree.value_format = "u";
     fake_btree.id = WT_BTREE_ID_NAMESPACED(0, WT_BTREE_ID_NAMESPACE_SPECIAL);
+    /*
+     * base_write_gen is left 0: cell time-window cleanup compares it against the page's write
+     * generation, which is always non-zero on a real disagg page, so the comparison never triggers
+     * cleanup.
+     */
 
     memset(&fake_dhandle, 0, sizeof(fake_dhandle));
     fake_dhandle.handle = &fake_btree;

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -928,17 +928,6 @@ __debug_cell_kv(
     if (unpack->raw == WT_CELL_DEL)
         return (0);
 
-    /*
-     * Overflow cells store their data through the block manager. The raw page-dump path (wt page
-     * -t) has no open btree and thus no block manager, so note the overflow and skip resolving it
-     * rather than dereferencing a NULL block manager.
-     */
-    if (page == NULL && S2BT(session)->bm == NULL &&
-      (unpack->raw == WT_CELL_KEY_OVFL || unpack->raw == WT_CELL_VALUE_OVFL ||
-        unpack->raw == WT_CELL_VALUE_OVFL_RM))
-        return (ds->f(ds, "\t%s%s(overflow item not resolved: no block manager)\n",
-          tag == NULL ? "" : tag, tag == NULL ? "" : ": "));
-
     WT_RET(page == NULL ? __wt_dsk_cell_data_ref_kv(session, unpack, ds->t1) :
                           __wt_page_cell_data_ref_kv(session, page, unpack, ds->t1));
 

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -418,47 +418,32 @@ __wti_debug_offset_blind(WT_SESSION_IMPL *session, wt_off_t offset, const char *
 }
 
 /*
- * __wt_debug_disagg_page_id --
- *     Fetch and dump a disaggregated page chain by (page_id, lsn), bypassing the address-cookie
- *     path; deltas are raw-dumped because structured delta decoding is not yet supported.
+ * __debug_disagg_dump_results --
+ *     Validate and dump a disaggregated page chain returned by the page log. The base image is
+ *     decoded and printed; deltas are raw-dumped because structured delta decoding is not yet
+ *     supported. A compressed base image with no available compressor, or an encrypted image, is
+ *     raw-dumped rather than treated as fatal. Does not free the result buffers.
  */
-int
-__wt_debug_disagg_page_id(
-  WT_SESSION_IMPL *session, uint64_t page_id, uint64_t lsn, const char *ofile)
+static int
+__debug_disagg_dump_results(WT_SESSION_IMPL *session, WT_ITEM *results, u_int count,
+  WT_PAGE_LOG_GET_ARGS *get_args, uint64_t page_id, uint64_t lsn, WT_COMPRESSOR *compressor,
+  const char *ofile)
 {
     WT_BLOCK_DISAGG_HEADER *blk, swap;
-    WT_BTREE *btree;
-    WT_COMPRESSOR *compressor;
     WT_DECL_ITEM(decompressed);
     WT_DECL_RET;
-    WT_ITEM results[WT_DELTA_LIMIT + 1];
     WT_PAGE_HEADER *dsk;
     const WT_PAGE_HEADER *display;
-    WT_PAGE_LOG_GET_ARGS get_args;
     size_t result_len;
     uint32_t size;
     uint8_t expected_magic;
-    u_int count, i;
+    u_int i;
 
-    WT_ASSERT(session, S2BT_SAFE(session) != NULL);
-    btree = S2BT(session);
-
-    if (!F_ISSET(btree, WT_BTREE_DISAGGREGATED))
-        WT_RET_MSG(session, ENOTSUP, "wt page is only supported in disaggregated storage mode");
-
-    compressor = btree->compressor;
-    memset(results, 0, sizeof(results));
-    count = WT_ELEMENTS(results);
-
-    WT_ERR(__wt_block_disagg_debug_read_page_id(
-      btree->bm, session, page_id, lsn, &get_args, results, &count));
-
-    WT_ERR(__wt_msg(session, "uri: %s", session->dhandle->name));
     WT_ERR(__wt_msg(session,
       "disagg_meta: page_id=%" PRIu64 " lsn=%" PRIu64 " base_lsn=%" PRIu64 " backlink_lsn=%" PRIu64
       " base_ckpt=%" PRIu64 " backlink_ckpt=%" PRIu64 " delta_count=%" PRIu64,
-      page_id, lsn, get_args.base_lsn, get_args.backlink_lsn, get_args.base_checkpoint_id,
-      get_args.backlink_checkpoint_id, get_args.delta_count));
+      page_id, lsn, get_args->base_lsn, get_args->backlink_lsn, get_args->base_checkpoint_id,
+      get_args->backlink_checkpoint_id, get_args->delta_count));
     WT_ERR(__wt_msg(session, "results: count=%u", count));
 
     if (count > 1)
@@ -500,17 +485,22 @@ __wt_debug_disagg_page_id(
             dsk = (WT_PAGE_HEADER *)results[i].data;
             display = dsk;
 
-            if (F_ISSET(dsk, WT_PAGE_ENCRYPTED))
-                WT_ERR_MSG(session, ENOTSUP,
-                  "page %" PRIu64 " is encrypted; wt page does not yet support decryption",
-                  page_id);
+            if (F_ISSET(dsk, WT_PAGE_ENCRYPTED)) {
+                __wt_log_data_dump(session, results[i].data, results[i].size,
+                  "encrypted base page (decryption unsupported): page_id %" PRIu64 ", lsn %" PRIu64,
+                  page_id, lsn);
+                continue;
+            }
 
             if (F_ISSET(dsk, WT_PAGE_COMPRESSED)) {
-                if (compressor == NULL || compressor->decompress == NULL)
-                    WT_ERR_MSG(session, ENOTSUP,
-                      "page %" PRIu64
-                      " is compressed but no decompressor is configured on the dhandle",
-                      page_id);
+                /* Without a btree the table's compressor may be unknown; raw-dump if so. */
+                if (compressor == NULL || compressor->decompress == NULL) {
+                    __wt_log_data_dump(session, results[i].data, results[i].size,
+                      "compressed base page (no compressor available): page_id %" PRIu64
+                      ", lsn %" PRIu64,
+                      page_id, lsn);
+                    continue;
+                }
 
                 WT_ERR(__wt_scr_alloc(session, dsk->mem_size, &decompressed));
                 decompressed->size = dsk->mem_size;
@@ -543,6 +533,86 @@ __wt_debug_disagg_page_id(
 
 err:
     __wt_scr_free(session, &decompressed);
+    return (ret);
+}
+
+/*
+ * __wt_debug_disagg_page_id --
+ *     Fetch and dump a disaggregated page chain by (page_id, lsn) for the current dhandle, bypassing
+ *     the address-cookie path.
+ */
+int
+__wt_debug_disagg_page_id(
+  WT_SESSION_IMPL *session, uint64_t page_id, uint64_t lsn, const char *ofile)
+{
+    WT_BTREE *btree;
+    WT_DECL_RET;
+    WT_ITEM results[WT_DELTA_LIMIT + 1];
+    WT_PAGE_LOG_GET_ARGS get_args;
+    u_int count, i;
+
+    WT_ASSERT(session, S2BT_SAFE(session) != NULL);
+    btree = S2BT(session);
+
+    if (!F_ISSET(btree, WT_BTREE_DISAGGREGATED))
+        WT_RET_MSG(session, ENOTSUP, "wt page is only supported in disaggregated storage mode");
+
+    memset(results, 0, sizeof(results));
+    count = WT_ELEMENTS(results);
+
+    WT_ERR(__wt_block_disagg_debug_read_page_id(
+      btree->bm, session, page_id, lsn, &get_args, results, &count));
+
+    WT_ERR(__wt_msg(session, "uri: %s", session->dhandle->name));
+    WT_TRET(__debug_disagg_dump_results(
+      session, results, count, &get_args, page_id, lsn, btree->compressor, ofile));
+
+err:
+    for (i = 0; i < WT_ELEMENTS(results); i++)
+        __wt_buf_free(session, &results[i]);
+    return (ret);
+}
+
+/*
+ * __wt_debug_disagg_page_id_raw --
+ *     Fetch and dump a disaggregated page chain by (table_id, page_id, lsn) directly off the
+ *     connection page log, without opening the table. Used when the checkpoint is unreadable. With
+ *     no btree the table's compressor is unknown, so the sole registered compressor is used if
+ *     unambiguous, otherwise a compressed image is raw-dumped.
+ */
+int
+__wt_debug_disagg_page_id_raw(
+  WT_SESSION_IMPL *session, uint64_t table_id, uint64_t page_id, uint64_t lsn)
+{
+    WT_COMPRESSOR *compressor;
+    WT_CONNECTION_IMPL *conn;
+    WT_DECL_RET;
+    WT_ITEM results[WT_DELTA_LIMIT + 1];
+    WT_NAMED_COMPRESSOR *ncomp;
+    WT_PAGE_LOG_GET_ARGS get_args;
+    u_int count, i, ncompressors;
+
+    conn = S2C(session);
+    memset(results, 0, sizeof(results));
+    count = WT_ELEMENTS(results);
+
+    compressor = NULL;
+    ncompressors = 0;
+    TAILQ_FOREACH (ncomp, &conn->ext.compqh, q) {
+        compressor = ncomp->compressor;
+        ++ncompressors;
+    }
+    if (ncompressors != 1)
+        compressor = NULL;
+
+    WT_ERR(__wt_block_disagg_debug_read_page_id_raw(
+      session, table_id, page_id, lsn, &get_args, results, &count));
+
+    WT_ERR(__wt_msg(session, "table_id: %" PRIu64, table_id));
+    WT_TRET(__debug_disagg_dump_results(
+      session, results, count, &get_args, page_id, lsn, compressor, NULL));
+
+err:
     for (i = 0; i < WT_ELEMENTS(results); i++)
         __wt_buf_free(session, &results[i]);
     return (ret);

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -550,7 +550,7 @@ err:
 
 /*
  * __wt_debug_disagg_page_id_raw --
- *     Fetch a pages by (table_id, page_id, lsn) directly off the connection page log, without
+ *     Fetch a page by (table_id, page_id, lsn) directly off the connection page log, without
  *     opening the table, and dump each result as raw bytes. Used when the checkpoint is unreadable
  *     so the table cannot be opened; without a btree the on-disk formats are unknown, so no attempt
  *     is made to decode page contents.

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -621,6 +621,7 @@ __wt_debug_disagg_page_id_raw(
      */
     memset(&fake_btree, 0, sizeof(fake_btree));
     fake_btree.block_header = WT_BLOCK_DISAGG_HEADER_SIZE;
+    /* "u" (raw bytes) because the table's real formats are unknown without a btree. */
     fake_btree.key_format = "u";
     fake_btree.value_format = "u";
     fake_btree.id = WT_BTREE_ID_NAMESPACED(0, WT_BTREE_ID_NAMESPACE_SPECIAL);
@@ -921,6 +922,17 @@ __debug_cell_kv(
     /* Early exit for column store deleted cells. There's nothing further to print. */
     if (unpack->raw == WT_CELL_DEL)
         return (0);
+
+    /*
+     * Overflow cells store their data through the block manager. The raw page-dump path (wt page
+     * -t) has no open btree and thus no block manager, so note the overflow and skip resolving it
+     * rather than dereferencing a NULL block manager.
+     */
+    if (page == NULL && S2BT(session)->bm == NULL &&
+      (unpack->raw == WT_CELL_KEY_OVFL || unpack->raw == WT_CELL_VALUE_OVFL ||
+        unpack->raw == WT_CELL_VALUE_OVFL_RM))
+        return (ds->f(ds, "\t%s%soverflow item not resolved (no block manager)\n",
+          tag == NULL ? "" : tag, tag == NULL ? "" : ": "));
 
     WT_RET(page == NULL ? __wt_dsk_cell_data_ref_kv(session, unpack, ds->t1) :
                           __wt_page_cell_data_ref_kv(session, page, unpack, ds->t1));

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -418,32 +418,47 @@ __wti_debug_offset_blind(WT_SESSION_IMPL *session, wt_off_t offset, const char *
 }
 
 /*
- * __debug_disagg_dump_results --
- *     Validate and dump a disaggregated page chain returned by the page log. The base image is
- *     decoded and printed; deltas are raw-dumped because structured delta decoding is not yet
- *     supported. A compressed base image with no available compressor, or an encrypted image, is
- *     raw-dumped rather than treated as fatal. Does not free the result buffers.
+ * __wt_debug_disagg_page_id --
+ *     Fetch and dump a disaggregated page chain by (page_id, lsn), bypassing the address-cookie
+ *     path; deltas are raw-dumped because structured delta decoding is not yet supported.
  */
-static int
-__debug_disagg_dump_results(WT_SESSION_IMPL *session, WT_ITEM *results, u_int count,
-  WT_PAGE_LOG_GET_ARGS *get_args, uint64_t page_id, uint64_t lsn, WT_COMPRESSOR *compressor,
-  const char *ofile)
+int
+__wt_debug_disagg_page_id(
+  WT_SESSION_IMPL *session, uint64_t page_id, uint64_t lsn, const char *ofile)
 {
     WT_BLOCK_DISAGG_HEADER *blk, swap;
+    WT_BTREE *btree;
+    WT_COMPRESSOR *compressor;
     WT_DECL_ITEM(decompressed);
     WT_DECL_RET;
+    WT_ITEM results[WT_DELTA_LIMIT + 1];
     WT_PAGE_HEADER *dsk;
     const WT_PAGE_HEADER *display;
+    WT_PAGE_LOG_GET_ARGS get_args;
     size_t result_len;
     uint32_t size;
     uint8_t expected_magic;
-    u_int i;
+    u_int count, i;
 
+    WT_ASSERT(session, S2BT_SAFE(session) != NULL);
+    btree = S2BT(session);
+
+    if (!F_ISSET(btree, WT_BTREE_DISAGGREGATED))
+        WT_RET_MSG(session, ENOTSUP, "wt page is only supported in disaggregated storage mode");
+
+    compressor = btree->compressor;
+    memset(results, 0, sizeof(results));
+    count = WT_ELEMENTS(results);
+
+    WT_ERR(__wt_block_disagg_debug_read_page_id(
+      btree->bm, session, page_id, lsn, &get_args, results, &count));
+
+    WT_ERR(__wt_msg(session, "uri: %s", session->dhandle->name));
     WT_ERR(__wt_msg(session,
       "disagg_meta: page_id=%" PRIu64 " lsn=%" PRIu64 " base_lsn=%" PRIu64 " backlink_lsn=%" PRIu64
       " base_ckpt=%" PRIu64 " backlink_ckpt=%" PRIu64 " delta_count=%" PRIu64,
-      page_id, lsn, get_args->base_lsn, get_args->backlink_lsn, get_args->base_checkpoint_id,
-      get_args->backlink_checkpoint_id, get_args->delta_count));
+      page_id, lsn, get_args.base_lsn, get_args.backlink_lsn, get_args.base_checkpoint_id,
+      get_args.backlink_checkpoint_id, get_args.delta_count));
     WT_ERR(__wt_msg(session, "results: count=%u", count));
 
     if (count > 1)
@@ -485,22 +500,17 @@ __debug_disagg_dump_results(WT_SESSION_IMPL *session, WT_ITEM *results, u_int co
             dsk = (WT_PAGE_HEADER *)results[i].data;
             display = dsk;
 
-            if (F_ISSET(dsk, WT_PAGE_ENCRYPTED)) {
-                __wt_log_data_dump(session, results[i].data, results[i].size,
-                  "encrypted base page (decryption unsupported): page_id %" PRIu64 ", lsn %" PRIu64,
-                  page_id, lsn);
-                continue;
-            }
+            if (F_ISSET(dsk, WT_PAGE_ENCRYPTED))
+                WT_ERR_MSG(session, ENOTSUP,
+                  "page %" PRIu64 " is encrypted; wt page does not yet support decryption",
+                  page_id);
 
             if (F_ISSET(dsk, WT_PAGE_COMPRESSED)) {
-                /* Without a btree the table's compressor may be unknown; raw-dump if so. */
-                if (compressor == NULL || compressor->decompress == NULL) {
-                    __wt_log_data_dump(session, results[i].data, results[i].size,
-                      "compressed base page (no compressor available): page_id %" PRIu64
-                      ", lsn %" PRIu64,
-                      page_id, lsn);
-                    continue;
-                }
+                if (compressor == NULL || compressor->decompress == NULL)
+                    WT_ERR_MSG(session, ENOTSUP,
+                      "page %" PRIu64
+                      " is compressed but no decompressor is configured on the dhandle",
+                      page_id);
 
                 WT_ERR(__wt_scr_alloc(session, dsk->mem_size, &decompressed));
                 decompressed->size = dsk->mem_size;
@@ -533,41 +543,6 @@ __debug_disagg_dump_results(WT_SESSION_IMPL *session, WT_ITEM *results, u_int co
 
 err:
     __wt_scr_free(session, &decompressed);
-    return (ret);
-}
-
-/*
- * __wt_debug_disagg_page_id --
- *     Fetch and dump a disaggregated page chain by (page_id, lsn) for the current dhandle,
- *     bypassing the address-cookie path.
- */
-int
-__wt_debug_disagg_page_id(
-  WT_SESSION_IMPL *session, uint64_t page_id, uint64_t lsn, const char *ofile)
-{
-    WT_BTREE *btree;
-    WT_DECL_RET;
-    WT_ITEM results[WT_DELTA_LIMIT + 1];
-    WT_PAGE_LOG_GET_ARGS get_args;
-    u_int count, i;
-
-    WT_ASSERT(session, S2BT_SAFE(session) != NULL);
-    btree = S2BT(session);
-
-    if (!F_ISSET(btree, WT_BTREE_DISAGGREGATED))
-        WT_RET_MSG(session, ENOTSUP, "wt page is only supported in disaggregated storage mode");
-
-    memset(results, 0, sizeof(results));
-    count = WT_ELEMENTS(results);
-
-    WT_ERR(__wt_block_disagg_debug_read_page_id(
-      btree->bm, session, page_id, lsn, &get_args, results, &count));
-
-    WT_ERR(__wt_msg(session, "uri: %s", session->dhandle->name));
-    WT_TRET(__debug_disagg_dump_results(
-      session, results, count, &get_args, page_id, lsn, btree->compressor, ofile));
-
-err:
     for (i = 0; i < WT_ELEMENTS(results); i++)
         __wt_buf_free(session, &results[i]);
     return (ret);
@@ -575,75 +550,39 @@ err:
 
 /*
  * __wt_debug_disagg_page_id_raw --
- *     Fetch and dump a disaggregated page chain by (table_id, page_id, lsn) directly off the
- *     connection page log, without opening the table. Used when the checkpoint is unreadable. With
- *     no btree the table's compressor is unknown, so the sole registered compressor is used if
- *     unambiguous, otherwise a compressed image is raw-dumped.
+ *     Fetch a disaggregated page chain by (table_id, page_id, lsn) directly off the connection page
+ *     log, without opening the table, and dump each result as raw bytes. Used when the checkpoint
+ *     is unreadable so the table cannot be opened; without a btree the on-disk formats are unknown,
+ *     so no attempt is made to decode page contents.
  */
 int
 __wt_debug_disagg_page_id_raw(
   WT_SESSION_IMPL *session, uint64_t table_id, uint64_t page_id, uint64_t lsn)
 {
-    WT_BTREE fake_btree;
-    WT_COMPRESSOR *compressor;
-    WT_CONNECTION_IMPL *conn;
-    WT_DATA_HANDLE fake_dhandle;
-    WT_DATA_HANDLE *saved_dhandle;
     WT_DECL_RET;
     WT_ITEM results[WT_DELTA_LIMIT + 1];
-    WT_NAMED_COMPRESSOR *ncomp;
     WT_PAGE_LOG_GET_ARGS get_args;
-    u_int count, i, ncompressors;
-    bool fake_dhandle_installed;
+    u_int count, i;
 
-    conn = S2C(session);
-    fake_dhandle_installed = false;
     memset(results, 0, sizeof(results));
     count = WT_ELEMENTS(results);
-
-    compressor = NULL;
-    ncompressors = 0;
-    TAILQ_FOREACH (ncomp, &conn->ext.compqh, q) {
-        compressor = ncomp->compressor;
-        ++ncompressors;
-    }
-    if (ncompressors != 1)
-        compressor = NULL;
 
     WT_ERR(__wt_block_disagg_debug_read_page_id_raw(
       session, table_id, page_id, lsn, &get_args, results, &count));
 
-    /*
-     * The page dump machinery requires a session with a valid dhandle and btree. Synthesize minimal
-     * versions on the stack so cell iteration and display work without opening the table. The only
-     * critical field is block_header, which governs where page cells start. Set the SPECIAL
-     * namespace on the fake btree id to suppress history store cursor setup.
-     */
-    memset(&fake_btree, 0, sizeof(fake_btree));
-    fake_btree.block_header = WT_BLOCK_DISAGG_HEADER_SIZE;
-    /* "u" (raw bytes) because the table's real formats are unknown without a btree. */
-    fake_btree.key_format = "u";
-    fake_btree.value_format = "u";
-    fake_btree.id = WT_BTREE_ID_NAMESPACED(0, WT_BTREE_ID_NAMESPACE_SPECIAL);
-    /*
-     * base_write_gen is left 0: cell time-window cleanup compares it against the page's write
-     * generation, which is always non-zero on a real disagg page, so the comparison never triggers
-     * cleanup.
-     */
-
-    memset(&fake_dhandle, 0, sizeof(fake_dhandle));
-    fake_dhandle.handle = &fake_btree;
-
-    saved_dhandle = session->dhandle;
-    session->dhandle = &fake_dhandle;
-    fake_dhandle_installed = true;
     WT_ERR(__wt_msg(session, "table_id: %" PRIu64, table_id));
-    WT_TRET(__debug_disagg_dump_results(
-      session, results, count, &get_args, page_id, lsn, compressor, NULL));
+    WT_ERR(__wt_msg(session,
+      "disagg_meta: page_id=%" PRIu64 " lsn=%" PRIu64 " base_lsn=%" PRIu64 " backlink_lsn=%" PRIu64
+      " base_ckpt=%" PRIu64 " backlink_ckpt=%" PRIu64 " delta_count=%" PRIu64,
+      page_id, lsn, get_args.base_lsn, get_args.backlink_lsn, get_args.base_checkpoint_id,
+      get_args.backlink_checkpoint_id, get_args.delta_count));
+    WT_ERR(__wt_msg(session, "results: count=%u", count));
+
+    for (i = 0; i < count; i++)
+        __wt_log_data_dump(session, results[i].data, results[i].size,
+          "result %u of %u: page_id %" PRIu64 ", lsn %" PRIu64, i, count, page_id, lsn);
 
 err:
-    if (fake_dhandle_installed)
-        session->dhandle = saved_dhandle;
     for (i = 0; i < WT_ELEMENTS(results); i++)
         __wt_buf_free(session, &results[i]);
     return (ret);

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -550,10 +550,10 @@ err:
 
 /*
  * __wt_debug_disagg_page_id_raw --
- *     Fetch a disaggregated page chain by (table_id, page_id, lsn) directly off the connection page
- *     log, without opening the table, and dump each result as raw bytes. Used when the checkpoint
- *     is unreadable so the table cannot be opened; without a btree the on-disk formats are unknown,
- *     so no attempt is made to decode page contents.
+ *     Fetch a pages by (table_id, page_id, lsn) directly off the connection page log, without
+ *     opening the table, and dump each result as raw bytes. Used when the checkpoint is unreadable
+ *     so the table cannot be opened; without a btree the on-disk formats are unknown, so no attempt
+ *     is made to decode page contents.
  */
 int
 __wt_debug_disagg_page_id_raw(
@@ -579,8 +579,12 @@ __wt_debug_disagg_page_id_raw(
     WT_ERR(__wt_msg(session, "results: count=%u", count));
 
     for (i = 0; i < count; i++)
-        __wt_log_data_dump(session, results[i].data, results[i].size,
-          "result %u of %u: page_id %" PRIu64 ", lsn %" PRIu64, i, count, page_id, lsn);
+        if (i == 0)
+            __wt_log_data_dump(session, results[i].data, results[i].size,
+              "base of %u delta(s): page_id %" PRIu64 ", lsn %" PRIu64, count - 1, page_id, lsn);
+        else
+            __wt_log_data_dump(session, results[i].data, results[i].size,
+              "delta %u of %u: page_id %" PRIu64 ", lsn %" PRIu64, i, count - 1, page_id, lsn);
 
 err:
     for (i = 0; i < WT_ELEMENTS(results); i++)

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -560,6 +560,8 @@ extern int __wt_debug_cursor_tree_hs(void *cursor_arg, const char *ofile)
     WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_debug_disagg_page_id(WT_SESSION_IMPL *session, uint64_t page_id, uint64_t lsn,
   const char *ofile) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_debug_disagg_page_id_raw(WT_SESSION_IMPL *session, uint64_t table_id,
+  uint64_t page_id, uint64_t lsn) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_debug_layered_cursor_page(void *cursor_arg, const char *ofile)
   WT_GCC_FUNC_DECL_ATTRIBUTE((visibility("default")))
     WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -188,6 +188,9 @@ extern int __wt_block_disagg_ckpt_size(WT_SESSION_IMPL *session, const char *uri
 extern int __wt_block_disagg_debug_read_page_id(WT_BM *bm, WT_SESSION_IMPL *session,
   uint64_t page_id, uint64_t lsn, WT_PAGE_LOG_GET_ARGS *get_args, WT_ITEM *results_array,
   u_int *results_count) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_block_disagg_debug_read_page_id_raw(WT_SESSION_IMPL *session, uint64_t table_id,
+  uint64_t page_id, uint64_t lsn, WT_PAGE_LOG_GET_ARGS *get_args, WT_ITEM *results_array,
+  u_int *results_count) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_block_disagg_manager_create(WT_SESSION_IMPL *session, WT_BUCKET_STORAGE *bstorage,
   const char *filename) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_block_disagg_manager_open(WT_SESSION_IMPL *session, const char *uri,

--- a/src/utilities/util_main.c
+++ b/src/utilities/util_main.c
@@ -116,8 +116,7 @@ util_disagg_pick_up_latest_checkpoint(WT_CONNECTION *conn, WT_SESSION *session)
      */
     if ((ret = conn->reconfigure(conn, reconfig)) != 0) {
         fprintf(stderr,
-          "%s: failed to pick up the latest disaggregated checkpoint (%s); proceeding with empty "
-          "metadata\n",
+          "%s: failed to pick up the latest checkpoint (%s); proceeding with empty metadata\n",
           progname, wiredtiger_strerror(ret));
         ret = 0;
     }

--- a/src/utilities/util_main.c
+++ b/src/utilities/util_main.c
@@ -109,7 +109,18 @@ util_disagg_pick_up_latest_checkpoint(WT_CONNECTION *conn, WT_SESSION *session)
     }
     WT_ERR(__wt_snprintf(reconfig, reconfig_len, "disaggregated=(checkpoint_meta=\"%.*s\")",
       (int)args.checkpoint_metadata.size, (const char *)args.checkpoint_metadata.data));
-    WT_ERR(conn->reconfigure(conn, reconfig));
+    /*
+     * A failed pickup is non-fatal in the utility: the checkpoint may be corrupt or unreadable, but
+     * individual pages can still be read directly off the page log (wt page -t). Warn and proceed
+     * with empty metadata.
+     */
+    if ((ret = conn->reconfigure(conn, reconfig)) != 0) {
+        fprintf(stderr,
+          "%s: failed to pick up the latest disaggregated checkpoint (%s); proceeding with empty "
+          "metadata\n",
+          progname, wiredtiger_strerror(ret));
+        ret = 0;
+    }
 
 err:
 done:

--- a/src/utilities/util_page.c
+++ b/src/utilities/util_page.c
@@ -18,8 +18,8 @@ usage(void)
     static const char *options[] = {"-p page_id",
       "required: numeric page id (decimal or 0x-prefixed hex)", "-l lsn",
       "required: numeric LSN (decimal or 0x-prefixed hex)", "-t table_id",
-      "numeric table id to read directly off the page log without opening the table (use when the "
-      "checkpoint is unreadable)",
+      "numeric table id to read directly off the page server without opening the table (use when "
+      "the checkpoint is unreadable)",
       "-?", "show this message", NULL, NULL};
 
     util_usage("page -p page_id -l lsn [-t table_id] [uri]", "options:", options);

--- a/src/utilities/util_page.c
+++ b/src/utilities/util_page.c
@@ -89,20 +89,21 @@ util_page(WT_SESSION *session, int argc, char *argv[])
      * table id instead reads directly off the connection page log without opening the table, which
      * works even when the checkpoint cannot be picked up.
      */
-    if (!have_table_id) {
+#ifdef HAVE_DIAGNOSTIC
+    if (have_table_id) {
+        ret = __wt_debug_disagg_page_id_raw(session_impl, table_id, page_id, lsn);
+    } else {
         if (argc != 1)
             return (usage());
         if ((uri = util_uri(session, *argv, "file")) == NULL)
             return (1);
-        WT_ERR(__wt_session_get_dhandle(session_impl, uri, NULL, NULL, 0));
+        if ((ret = __wt_session_get_dhandle(session_impl, uri, NULL, NULL, 0)) == 0) {
+            ret = __wt_debug_disagg_page_id(session_impl, page_id, lsn, NULL);
+            WT_TRET(__wt_session_release_dhandle(session_impl));
+        }
     }
-
-#ifdef HAVE_DIAGNOSTIC
-    if (have_table_id)
-        ret = __wt_debug_disagg_page_id_raw(session_impl, table_id, page_id, lsn);
-    else
-        ret = __wt_debug_disagg_page_id(session_impl, page_id, lsn, NULL);
 #else
+    WT_UNUSED(have_table_id);
     fprintf(stderr,
       "%s: page: this subcommand requires a diagnostic build "
       "(rebuild WiredTiger with -DHAVE_DIAGNOSTIC=1)\n",
@@ -110,10 +111,6 @@ util_page(WT_SESSION *session, int argc, char *argv[])
     ret = ENOTSUP;
 #endif
 
-    if (!have_table_id)
-        WT_TRET(__wt_session_release_dhandle(session_impl));
-
-err:
     util_free(uri);
     if (ret != 0)
         (void)util_err(session, ret, "page");

--- a/src/utilities/util_page.c
+++ b/src/utilities/util_page.c
@@ -85,9 +85,9 @@ util_page(WT_SESSION *session, int argc, char *argv[])
     }
 
     /*
-     * Without an explicit table id, resolve the URI to a dhandle and read through it. An explicit
-     * table id instead reads directly off the connection page log without opening the table, which
-     * works even when the checkpoint cannot be picked up.
+     * An explicit table id reads directly off the connection page log without opening the table,
+     * which works even when the checkpoint cannot be picked up. Otherwise resolve the URI to a
+     * dhandle and read through it.
      */
 #ifdef HAVE_DIAGNOSTIC
     if (have_table_id) {

--- a/src/utilities/util_page.c
+++ b/src/utilities/util_page.c
@@ -85,9 +85,9 @@ util_page(WT_SESSION *session, int argc, char *argv[])
     }
 
     /*
-     * With an explicit table id, read directly off the connection page log without opening the
-     * table; this works even when the checkpoint cannot be picked up. Otherwise resolve the URI to a
-     * dhandle and read through it.
+     * Without an explicit table id, resolve the URI to a dhandle and read through it. An explicit
+     * table id instead reads directly off the connection page log without opening the table, which
+     * works even when the checkpoint cannot be picked up.
      */
     if (!have_table_id) {
         if (argc != 1)

--- a/src/utilities/util_page.c
+++ b/src/utilities/util_page.c
@@ -104,6 +104,7 @@ util_page(WT_SESSION *session, int argc, char *argv[])
     }
 #else
     WT_UNUSED(have_table_id);
+    WT_UNUSED(session_impl);
     fprintf(stderr,
       "%s: page: this subcommand requires a diagnostic build "
       "(rebuild WiredTiger with -DHAVE_DIAGNOSTIC=1)\n",

--- a/src/utilities/util_page.c
+++ b/src/utilities/util_page.c
@@ -98,8 +98,10 @@ util_page(WT_SESSION *session, int argc, char *argv[])
     }
 
 #ifdef HAVE_DIAGNOSTIC
-    ret = have_table_id ? __wt_debug_disagg_page_id_raw(session_impl, table_id, page_id, lsn) :
-                          __wt_debug_disagg_page_id(session_impl, page_id, lsn, NULL);
+    if (have_table_id)
+        ret = __wt_debug_disagg_page_id_raw(session_impl, table_id, page_id, lsn);
+    else
+        ret = __wt_debug_disagg_page_id(session_impl, page_id, lsn, NULL);
 #else
     fprintf(stderr,
       "%s: page: this subcommand requires a diagnostic build "

--- a/src/utilities/util_page.c
+++ b/src/utilities/util_page.c
@@ -17,9 +17,12 @@ usage(void)
 {
     static const char *options[] = {"-p page_id",
       "required: numeric page id (decimal or 0x-prefixed hex)", "-l lsn",
-      "required: numeric LSN (decimal or 0x-prefixed hex)", "-?", "show this message", NULL, NULL};
+      "required: numeric LSN (decimal or 0x-prefixed hex)", "-t table_id",
+      "numeric table id to read directly off the page log without opening the table (use when the "
+      "checkpoint is unreadable)",
+      "-?", "show this message", NULL, NULL};
 
-    util_usage("page -p page_id -l lsn uri", "options:", options);
+    util_usage("page -p page_id -l lsn [-t table_id] [uri]", "options:", options);
     return (1);
 }
 
@@ -32,19 +35,21 @@ util_page(WT_SESSION *session, int argc, char *argv[])
 {
     WT_DECL_RET;
     WT_SESSION_IMPL *session_impl;
-    uint64_t lsn, page_id;
+    uint64_t lsn, page_id, table_id;
     int ch;
     char *uri;
-    bool have_lsn, have_page_id;
+    bool have_lsn, have_page_id, have_table_id;
 
     session_impl = (WT_SESSION_IMPL *)session;
     have_lsn = false;
     have_page_id = false;
+    have_table_id = false;
     lsn = 0;
     page_id = 0;
+    table_id = 0;
     uri = NULL;
 
-    while ((ch = __wt_getopt(progname, argc, argv, "l:p:?")) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv, "l:p:t:?")) != EOF)
         switch (ch) {
         case 'l':
             if (util_str2num(session, __wt_optarg, true, &lsn) != 0)
@@ -55,6 +60,11 @@ util_page(WT_SESSION *session, int argc, char *argv[])
             if (util_str2num(session, __wt_optarg, true, &page_id) != 0)
                 return (usage());
             have_page_id = true;
+            break;
+        case 't':
+            if (util_str2num(session, __wt_optarg, true, &table_id) != 0)
+                return (usage());
+            have_table_id = true;
             break;
         case '?':
             usage();
@@ -73,6 +83,26 @@ util_page(WT_SESSION *session, int argc, char *argv[])
         fprintf(stderr, "%s: page: -l lsn is required\n", progname);
         return (usage());
     }
+
+    /*
+     * With an explicit table id, read directly off the connection page log without opening the
+     * table. This works even when the checkpoint cannot be picked up.
+     */
+    if (have_table_id) {
+#ifdef HAVE_DIAGNOSTIC
+        ret = __wt_debug_disagg_page_id_raw(session_impl, table_id, page_id, lsn);
+#else
+        fprintf(stderr,
+          "%s: page: this subcommand requires a diagnostic build "
+          "(rebuild WiredTiger with -DHAVE_DIAGNOSTIC=1)\n",
+          progname);
+        ret = ENOTSUP;
+#endif
+        if (ret != 0)
+            (void)util_err(session, ret, "page");
+        return (ret == 0 ? 0 : 1);
+    }
+
     if (argc != 1)
         return (usage());
     if ((uri = util_uri(session, *argv, "file")) == NULL)

--- a/src/utilities/util_page.c
+++ b/src/utilities/util_page.c
@@ -86,31 +86,20 @@ util_page(WT_SESSION *session, int argc, char *argv[])
 
     /*
      * With an explicit table id, read directly off the connection page log without opening the
-     * table. This works even when the checkpoint cannot be picked up.
+     * table; this works even when the checkpoint cannot be picked up. Otherwise resolve the URI to a
+     * dhandle and read through it.
      */
-    if (have_table_id) {
-#ifdef HAVE_DIAGNOSTIC
-        ret = __wt_debug_disagg_page_id_raw(session_impl, table_id, page_id, lsn);
-#else
-        fprintf(stderr,
-          "%s: page: this subcommand requires a diagnostic build "
-          "(rebuild WiredTiger with -DHAVE_DIAGNOSTIC=1)\n",
-          progname);
-        ret = ENOTSUP;
-#endif
-        if (ret != 0)
-            (void)util_err(session, ret, "page");
-        return (ret == 0 ? 0 : 1);
+    if (!have_table_id) {
+        if (argc != 1)
+            return (usage());
+        if ((uri = util_uri(session, *argv, "file")) == NULL)
+            return (1);
+        WT_ERR(__wt_session_get_dhandle(session_impl, uri, NULL, NULL, 0));
     }
 
-    if (argc != 1)
-        return (usage());
-    if ((uri = util_uri(session, *argv, "file")) == NULL)
-        return (1);
-
-    WT_ERR(__wt_session_get_dhandle(session_impl, uri, NULL, NULL, 0));
 #ifdef HAVE_DIAGNOSTIC
-    ret = __wt_debug_disagg_page_id(session_impl, page_id, lsn, NULL);
+    ret = have_table_id ? __wt_debug_disagg_page_id_raw(session_impl, table_id, page_id, lsn) :
+                          __wt_debug_disagg_page_id(session_impl, page_id, lsn, NULL);
 #else
     fprintf(stderr,
       "%s: page: this subcommand requires a diagnostic build "
@@ -118,7 +107,9 @@ util_page(WT_SESSION *session, int argc, char *argv[])
       progname);
     ret = ENOTSUP;
 #endif
-    WT_TRET(__wt_session_release_dhandle(session_impl));
+
+    if (!have_table_id)
+        WT_TRET(__wt_session_release_dhandle(session_impl));
 
 err:
     util_free(uri);

--- a/test/suite/helpers/helper_disagg.py
+++ b/test/suite/helpers/helper_disagg.py
@@ -650,19 +650,16 @@ class DisaggCorruptionMixin:
             input=sql, capture_output=True, text=True, check=True)
         return [line for line in result.stdout.splitlines() if line != '']
 
-    # Table id 2 / page id 1 are WT_SPECIAL_PALI_TURTLE_FILE_ID and
-    # WT_DISAGG_METADATA_MAIN_PAGE_ID: the shared metadata page the follower
-    # reads during checkpoint pickup. Corrupting its newest image makes pickup
-    # fail while leaving every data-table page intact.
-    METADATA_TABLE_ID = 2
-    METADATA_PAGE_ID = 1
-
     def corrupt_checkpoint_metadata_page(self):
         """Overwrite the first byte of the newest shared-metadata page image
         with 0xff so follower checkpoint pickup fails. Returns the
         (table_id, page_id, lsn) of the corrupted image."""
-        table_id = self.METADATA_TABLE_ID
-        page_id = self.METADATA_PAGE_ID
+        # Table id 2 / page id 1 are WT_SPECIAL_PALI_TURTLE_FILE_ID and
+        # WT_DISAGG_METADATA_MAIN_PAGE_ID: the shared metadata page the follower
+        # reads during checkpoint pickup. Corrupting its newest image makes pickup
+        # fail while leaving every data-table page intact.
+        table_id = 2
+        page_id = 1
         # Close before querying so WiredTiger flushes its final checkpoint
         # to palite; the newest lsn we find is then the one pickup will use.
         self.close_conn()

--- a/test/suite/helpers/helper_disagg.py
+++ b/test/suite/helpers/helper_disagg.py
@@ -650,6 +650,37 @@ class DisaggCorruptionMixin:
             input=sql, capture_output=True, text=True, check=True)
         return [line for line in result.stdout.splitlines() if line != '']
 
+    # Table id 2 / page id 1 are WT_SPECIAL_PALI_TURTLE_FILE_ID and
+    # WT_DISAGG_METADATA_MAIN_PAGE_ID: the shared metadata page the follower
+    # reads during checkpoint pickup. Corrupting its newest image makes pickup
+    # fail while leaving every data-table page intact.
+    METADATA_TABLE_ID = 2
+    METADATA_PAGE_ID = 1
+
+    def corrupt_checkpoint_metadata_page(self):
+        """Overwrite the first byte of the newest shared-metadata page image
+        with 0xff so follower checkpoint pickup fails. Returns the
+        (table_id, page_id, lsn) of the corrupted image."""
+        table_id = self.METADATA_TABLE_ID
+        page_id = self.METADATA_PAGE_ID
+        # Close before querying so WiredTiger flushes its final checkpoint
+        # to palite; the newest lsn we find is then the one pickup will use.
+        self.close_conn()
+        rows = self.sqlite_select_json(table_id,
+            f'SELECT lsn FROM pages WHERE table_id={table_id} '
+            f'AND page_id={page_id} ORDER BY lsn DESC LIMIT 1;')
+        self.assertTrue(rows,
+            f'no metadata page rows for table_id={table_id}, page_id={page_id}')
+        lsn = int(rows[0]['lsn'])
+        sql = (
+            f"UPDATE pages SET page_data = x'ff' || substr(page_data, 2) "
+            f"WHERE table_id={table_id} AND page_id={page_id} AND lsn={lsn};\n"
+            f"SELECT changes();\n"
+        )
+        rows = self._palite_mutate(table_id, sql)
+        self._require_one_change(rows, table_id, page_id, lsn)
+        return table_id, page_id, lsn
+
     def corrupt_random_page_image(self):
         """Pick one page image (one (page_id, lsn) row in the palite
         pages table) and overwrite the first byte of its stored data

--- a/test/suite/test_disagg_util03.py
+++ b/test/suite/test_disagg_util03.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wiredtiger, wttest
+from helper_disagg import DisaggConfigMixin, DisaggCorruptionMixin
+from suite_subprocess import suite_subprocess
+
+# Reading individual pages in follower mode without a checkpoint pickup
+# (WT-17349). The tool must start when the checkpoint is corrupt, and
+# `wt page -t` must read intact data pages directly off the page log.
+@wttest.skip_for_hook("tiered", "wt page does not run under tiered hook")
+class test_disagg_util03(wttest.WiredTigerTestCase, suite_subprocess,
+                         DisaggConfigMixin, DisaggCorruptionMixin):
+    uri = "layered:util03"
+    stable_uri = "file:util03.wt_stable"
+    nrows = 1000
+    conn_config = 'disaggregated=(role="leader")'
+
+    def conn_extensions(self, extlist):
+        extlist.skip_if_missing = True
+        DisaggConfigMixin.conn_extensions(self, extlist)
+
+    def _follower_config(self):
+        return self.extensionsConfig() + ',disaggregated=(role="follower")'
+
+    def _run_wt(self, *args, failure=False):
+        cmd = ['-C', self._follower_config()] + list(args)
+        # reopensession=False: the Python connection stays closed after wt exits;
+        # the test does not need it again, and the corrupt checkpoint would make
+        # open_conn() fail anyway.
+        self.runWt(cmd, outfilename='wt.out', errfilename='wt.err',
+                   failure=failure, reopensession=False)
+        with open('wt.out') as f:
+            out = f.read()
+        with open('wt.err') as f:
+            err = f.read()
+        return out, err
+
+    def _populate(self):
+        self.session.create(self.uri, "key_format=S,value_format=S")
+        c = self.session.open_cursor(self.uri)
+        for i in range(self.nrows):
+            c[f"k{i:08}"] = f"v{i:08}"
+        c.close()
+        self.session.checkpoint()
+
+    def test_tool_starts_with_corrupt_checkpoint(self):
+        if self.ds_name != 'palite':
+            self.skipTest('palite-only test')
+        self._populate()
+        self.corrupt_checkpoint_metadata_page()
+        # `wt list` needs no page data; with empty metadata it lists nothing
+        # and must exit zero, with a warning rather than an abort.
+        _, err = self._run_wt('list')
+        self.assertIn('proceeding with empty metadata', err)
+
+if __name__ == '__main__':
+    wttest.run()

--- a/test/suite/test_disagg_util03.py
+++ b/test/suite/test_disagg_util03.py
@@ -126,7 +126,3 @@ class test_disagg_util03(wttest.WiredTigerTestCase, suite_subprocess,
             'page', '-t', str(table_id), '-p', '99999999', '-l', '1',
             failure=True)
         self.assertIn("WT_NOTFOUND", err)
-
-
-if __name__ == '__main__':
-    wttest.run()

--- a/test/suite/test_disagg_util03.py
+++ b/test/suite/test_disagg_util03.py
@@ -26,8 +26,11 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
+import json, os, re, subprocess
 import wiredtiger, wttest
-from helper_disagg import DisaggConfigMixin, DisaggCorruptionMixin
+from helper_disagg import DisaggConfigMixin, DisaggCorruptionMixin, get_shard_id
+from metadata_helper import get_table_id
+from run import wt_builddir
 from suite_subprocess import suite_subprocess
 
 # Reading individual pages in follower mode without a checkpoint pickup
@@ -78,6 +81,46 @@ class test_disagg_util03(wttest.WiredTigerTestCase, suite_subprocess,
         # and must exit zero, with a warning rather than an abort.
         _, err = self._run_wt('list')
         self.assertIn('proceeding with empty metadata', err)
+
+    def _find_base_image_page(self):
+        # Newest base-image row (no backlink) for the data table.
+        table_id = get_table_id(self.session, self.stable_uri)
+        shard = get_shard_id(table_id)
+        db = os.path.join(self.home, 'kv_home', f'pages_{shard:02d}.db')
+        sql = (f"SELECT page_id, lsn FROM pages WHERE table_id={table_id} "
+               f"AND base_lsn=0 AND backlink_lsn=0 ORDER BY lsn DESC LIMIT 1;")
+        sqlite_exe = os.path.join(wt_builddir, 'sqlite3')
+        out = subprocess.run([sqlite_exe, '-json', db, sql],
+                             capture_output=True, text=True, check=True).stdout
+        rows = json.loads(out) if out.strip() else []
+        self.assertTrue(rows, f"no base-image row for table_id={table_id}")
+        return table_id, int(rows[0]['page_id']), int(rows[0]['lsn'])
+
+    def test_raw_read_after_corrupt_checkpoint(self):
+        if self.ds_name != 'palite':
+            self.skipTest('palite-only test')
+        if not wiredtiger.diagnostic_build():
+            self.skipTest('wt page requires a diagnostic build')
+        self._populate()
+        table_id, page_id, lsn = self._find_base_image_page()
+        self.corrupt_checkpoint_metadata_page()
+        out, err = self._run_wt(
+            'page', '-t', str(table_id), '-p', str(page_id), '-l', str(lsn))
+        self.assertIn('proceeding with empty metadata', err)
+        self.assertIn(f"table_id: {table_id}", out)
+        self.assertIn("- row-store ", out)
+
+    def test_raw_read_unknown_page(self):
+        if self.ds_name != 'palite':
+            self.skipTest('palite-only test')
+        if not wiredtiger.diagnostic_build():
+            self.skipTest('wt page requires a diagnostic build')
+        self._populate()
+        table_id = get_table_id(self.session, self.stable_uri)
+        _, err = self._run_wt(
+            'page', '-t', str(table_id), '-p', '99999999', '-l', '1',
+            failure=True)
+        self.assertIn("WT_NOTFOUND", err)
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_disagg_util03.py
+++ b/test/suite/test_disagg_util03.py
@@ -33,8 +33,8 @@ from metadata_helper import get_table_id
 from run import wt_builddir
 from suite_subprocess import suite_subprocess
 
-# Reading individual pages in follower mode without a checkpoint pickup
-# (WT-17349). The tool must start when the checkpoint is corrupt, and
+# Reading individual pages in follower mode without a checkpoint pickup.
+# The tool must start when the checkpoint is corrupt, and
 # `wt page -t` must read intact data pages directly off the page log.
 @wttest.skip_for_hook("tiered", "wt page does not run under tiered hook")
 class test_disagg_util03(wttest.WiredTigerTestCase, suite_subprocess,

--- a/test/suite/test_disagg_util03.py
+++ b/test/suite/test_disagg_util03.py
@@ -53,9 +53,8 @@ class test_disagg_util03(wttest.WiredTigerTestCase, suite_subprocess,
 
     def _run_wt(self, *args, failure=False):
         cmd = ['-C', self._follower_config()] + list(args)
-        # reopensession=False: the Python connection stays closed after wt exits;
-        # the test does not need it again, and the corrupt checkpoint would make
-        # open_conn() fail anyway.
+        # Do not reopen the session after wt exits; the test does not need it
+        # again and the corrupt checkpoint would make open_conn() fail anyway.
         self.runWt(cmd, outfilename='wt.out', errfilename='wt.err',
                    failure=failure, reopensession=False)
         with open('wt.out') as f:

--- a/test/suite/test_disagg_util03.py
+++ b/test/suite/test_disagg_util03.py
@@ -26,7 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import json, os, re, subprocess
+import json, os, subprocess
 import wiredtiger, wttest
 from helper_disagg import DisaggConfigMixin, DisaggCorruptionMixin, get_shard_id
 from metadata_helper import get_table_id
@@ -121,6 +121,7 @@ class test_disagg_util03(wttest.WiredTigerTestCase, suite_subprocess,
             'page', '-t', str(table_id), '-p', '99999999', '-l', '1',
             failure=True)
         self.assertIn("WT_NOTFOUND", err)
+
 
 if __name__ == '__main__':
     wttest.run()

--- a/test/suite/test_disagg_util03.py
+++ b/test/suite/test_disagg_util03.py
@@ -82,12 +82,14 @@ class test_disagg_util03(wttest.WiredTigerTestCase, suite_subprocess,
         self.assertIn('proceeding with empty metadata', err)
 
     def _find_base_image_page(self):
-        # Newest base-image row (no backlink) for the data table.
+        # Largest base-image row (no backlink) for the data table: the leaf
+        # data page rather than the small internal root.
         table_id = get_table_id(self.session, self.stable_uri)
         shard = get_shard_id(table_id)
         db = os.path.join(self.home, 'kv_home', f'pages_{shard:02d}.db')
         sql = (f"SELECT page_id, lsn FROM pages WHERE table_id={table_id} "
-               f"AND base_lsn=0 AND backlink_lsn=0 ORDER BY lsn DESC LIMIT 1;")
+               f"AND base_lsn=0 AND backlink_lsn=0 "
+               f"ORDER BY length(page_data) DESC LIMIT 1;")
         sqlite_exe = os.path.join(wt_builddir, 'sqlite3')
         out = subprocess.run([sqlite_exe, '-json', db, sql],
                              capture_output=True, text=True, check=True).stdout
@@ -106,11 +108,12 @@ class test_disagg_util03(wttest.WiredTigerTestCase, suite_subprocess,
         out, err = self._run_wt(
             'page', '-t', str(table_id), '-p', str(page_id), '-l', str(lsn))
         self.assertIn('proceeding with empty metadata', err)
-        # The page-log metadata is printed to stdout; the page image itself is
-        # dumped as raw bytes to stderr (no decode without the table's formats).
+        # The page-log metadata is printed to stdout; the page image itself
+        # is dumped as raw bytes to stderr.
         self.assertIn(f"table_id: {table_id}", out)
         self.assertIn("results: count=1", out)
-        self.assertIn(f"result 0 of 1: page_id {page_id}", err)
+        self.assertIn(f"base of 0 delta(s): page_id {page_id}", err)
+        self.assertIn("(chunk 2 of ", err)
 
     def test_raw_read_unknown_page(self):
         if self.ds_name != 'palite':

--- a/test/suite/test_disagg_util03.py
+++ b/test/suite/test_disagg_util03.py
@@ -106,8 +106,11 @@ class test_disagg_util03(wttest.WiredTigerTestCase, suite_subprocess,
         out, err = self._run_wt(
             'page', '-t', str(table_id), '-p', str(page_id), '-l', str(lsn))
         self.assertIn('proceeding with empty metadata', err)
+        # The page-log metadata is printed to stdout; the page image itself is
+        # dumped as raw bytes to stderr (no decode without the table's formats).
         self.assertIn(f"table_id: {table_id}", out)
-        self.assertIn("- row-store ", out)
+        self.assertIn("results: count=1", out)
+        self.assertIn(f"result 0 of 1: page_id {page_id}", err)
 
     def test_raw_read_unknown_page(self):
         if self.ds_name != 'palite':


### PR DESCRIPTION
## Motivation

In disaggregated mode, `wt` uses the latest checkpoint to open tables before any subcommand runs. If that checkpoint is corrupt or unreadable, the tool currently aborts before any useful work can be done. This makes it impossible to inspect individual pages with `wt page` when the first thing to diagnose is a bad checkpoint.

## What changed

- **`util_main.c`** — `util_disagg_pick_up_latest_checkpoint` now treats a failed `conn->reconfigure` call as a non-fatal warning. It prints a message to stderr and continues with empty metadata, so other `wt` subcommands can still run against the page log directly.

- **`util_page.c`** — Added a `-t table_id` flag to `wt page`. When `-t` is given, the URI argument is not required; the page is read directly off the connection page log via the new raw-read path rather than through a dhandle. This path works even when the checkpoint cannot be picked up.

- **`src/btree/bt_debug.c`** — Added `__wt_debug_disagg_page_id_raw`, which fetches a page chain by `(table_id, page_id, lsn)` directly off the connection page log and dumps each result as raw bytes.

- **`src/block_disagg/block_disagg_read.c`** — Added `__wt_block_disagg_debug_read_page_id_raw`, the low-level entry point that opens a page-log handle and fetches a page by table id. The existing `__wt_block_disagg_debug_read_page_id` continues to be used by the URI path.

I also tried including page key/value cell decoding; however, this proved pretty cumbersome and required a few assumptions since there is no btree available in this new path. Instead, I went for just printing the bytes and using the decode tool to manually decode the page. 

## Testing

Added `test/suite/test_disagg_util03.py`:

- `test_tool_starts_with_corrupt_checkpoint` — corrupts the shared metadata page (table_id=2, page_id=1) so checkpoint pickup fails, then verifies `wt list` exits cleanly and emits the "proceeding with empty metadata" warning.
- `test_raw_read_after_corrupt_checkpoint` — after the same corruption, verifies `wt page -t <table_id> -p <page_id> -l <lsn>` prints the page-log metadata to stdout and dumps raw page bytes to stderr.
- `test_raw_read_unknown_page` — verifies `wt page -t` returns `WT_NOTFOUND` for a nonexistent page.

