### PR TITLE
WT-17561 Reduce stable timestamp update interval under precise checkpoint

### DIFF
--- a/test/format/format_timestamp.c
+++ b/test/format/format_timestamp.c
@@ -204,8 +204,14 @@ timestamp(void *arg)
      */
     while (!g.workers_finished) {
         if (!GV(RUNS_PREDICTABLE_REPLAY)) {
+            /*
+             * Under precise checkpoint, eviction can only write pages whose updates are at or below
+             * the stable timestamp. A long gap between stable timestamp advances lets dirty pages
+             * accumulate above-stable writes faster than eviction can drain them, increasing the
+             * risk of cache pressure. Sleep 0-9ms to keep the interval short.
+             */
             if (GV(PRECISE_CHECKPOINT))
-                random_sleep(&g.extra_rnd, 1);
+                __wt_sleep(0, rng(&g.extra_rnd) % (10 * WT_THOUSAND));
             else
                 random_sleep(&g.extra_rnd, 15);
         } else {


### PR DESCRIPTION
## Summary

- Under `precise_checkpoint`, the timestamp thread slept up to ~900ms between `stable_ts` advances (average ~200ms via `random_sleep(&g.extra_rnd, 1)`).
- This wide window allows dirty pages to accumulate writes above `stable_ts` faster than eviction can drain them, raising the probability of the all-above-stable eviction deadlock (WT-17561).
- Change the sleep to `rng() % 100ms` (average ~50ms, max 99ms), cutting the accumulation window by ~4x.

Note: this is a probabilistic mitigation. If all worker threads block in forced eviction simultaneously, `timestamp_minimum_committed()` returns `WT_TS_NONE` and `stable_ts` cannot advance regardless of call frequency. The root-cause fix requires engine-side changes to the eviction retry gate.