### PR TITLE
WT-17887 Fix SWIG compilation warnings from WT_CRYPT_KEYS struct

### DIFF
--- a/bench/workgen/workgen.i
+++ b/bench/workgen/workgen.i
@@ -38,6 +38,12 @@
 %include "attribute.i"
 %include "carrays.i"
 
+/*
+ * SWIG doesn't support nested classes when bridging to Python.
+ * Use 'flatnested' feature to generate a non-nested proxy class.
+ */
+%feature("flatnested");
+
 /* We only need to reference WiredTiger types. */
 %import "wiredtiger.h"
 


### PR DESCRIPTION
- Use `%feature("flatnested")` SWIG feature to generate a non-nested proxy class.