### PR TITLE
WT-17888 Fix -Wnontrivial-memcall compile error in reconciliation tracking test

### DIFF
--- a/test/catch2/misc_tests/test_reconciliation_tracking.cpp
+++ b/test/catch2/misc_tests/test_reconciliation_tracking.cpp
@@ -37,13 +37,13 @@ block_free_fail(
 static void
 setup_failing_bm(WT_SESSION_IMPL *session, WT_DATA_HANDLE *dhandle, WT_BTREE *btree, WT_BM *bm)
 {
-    memset(bm, 0, sizeof(*bm));
+    memset((void *)bm, 0, sizeof(*bm));
     bm->free = block_free_fail;
 
-    memset(btree, 0, sizeof(*btree));
+    memset((void *)btree, 0, sizeof(*btree));
     btree->bm = bm;
 
-    memset(dhandle, 0, sizeof(*dhandle));
+    memset((void *)dhandle, 0, sizeof(*dhandle));
     dhandle->handle = btree;
 
     session->dhandle = dhandle;


### PR DESCRIPTION
## Summary
- New Apple Clang (AppleClang 21, shipping with recent Xcode/CLT) introduced `-Wnontrivial-memcall`, which rejects `memset` calls on pointers to non-trivially copyable C++ types.
- WiredTiger builds with `-Werror`, so this turns a warning into a compile error on macOS clean builds.
- Fix: add `(void *)` cast to the first argument of the three `memset` calls in `setup_failing_bm()` in `test/catch2/misc_tests/test_reconciliation_tracking.cpp` (lines 40, 43, 46).

