### PR TITLE
WT-17864 Avoid database size deduction by failed schema drop

### DIFF
--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -928,19 +928,6 @@ __checkpoint_update_disagg_database_size(WT_SESSION_IMPL *session, uint64_t drop
 }
 
 /*
- * __checkpoint_process_disagg_metadata --
- *     Compute the drop size from the shared metadata queue, then process the queue.
- */
-static int
-__checkpoint_process_disagg_metadata(
-  WT_SESSION_IMPL *session, wt_timestamp_t schema_epoch, uint64_t *drop_sizep)
-{
-    WT_RET(__wt_disagg_shared_metadata_queue_drop_size(session, schema_epoch, drop_sizep));
-    WT_RET(__wt_disagg_shared_metadata_queue_process(session, schema_epoch));
-    return (0);
-}
-
-/*
  * __checkpoint_fail_reset --
  *     Reset fields when a failure occurs.
  */
@@ -1749,8 +1736,8 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
      */
     if (__wt_conn_is_disagg(session) && conn->layered_table_manager.leader) {
         WT_WITH_SCHEMA_LOCK(session,
-          ret =
-            __checkpoint_process_disagg_metadata(session, ckpt_disagg_schema_epoch, &drop_size));
+          ret = __wt_disagg_shared_metadata_queue_process(
+            session, ckpt_disagg_schema_epoch, &drop_size));
         WT_ERR_MSG_CHK(session, ret,
           "Disaggregated storage checkpoint failed while processing shared metadata queue");
     }

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -705,7 +705,7 @@ __wt_disagg_shared_metadata_queue_process(
         WT_ERR(__disagg_shared_metadata_op(session, entry));
 
         /*
-         * A successful schema drop op should contributes to the database size reduction.
+         * A successful schema drop op should contribute to the database size reduction.
          */
         if (entry->metadata_op == WT_SHARED_METADATA_REMOVE && entry->stable_value != NULL) {
             /*
@@ -768,8 +768,7 @@ err:
         TAILQ_REMOVE(&skipped_creates, skipped, q);
         __disagg_shared_metadata_queue_free(session, &skipped);
     }
-    if (stable_config != NULL)
-        __wt_free(session, stable_config);
+    __wt_free(session, stable_config);
     return (ret);
 }
 

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -654,23 +654,24 @@ __disagg_accumulate_drop_size(
 
     stable_config = NULL;
 
-    if (entry->metadata_op == WT_SHARED_METADATA_REMOVE && entry->stable_value != NULL) {
+    if (!(entry->metadata_op == WT_SHARED_METADATA_REMOVE && entry->stable_value != NULL))
+        return (0);
 
-        /* The stable entry is gone only after a real drop; a rolled-back drop leaves it. */
-        WT_ERR_NOTFOUND_OK(__wt_metadata_search(session, entry->stable_uri, &stable_config), true);
+    /* The stable entry is gone only after a real drop; a rolled-back drop leaves it. */
+    WT_ERR_NOTFOUND_OK(__wt_metadata_search(session, entry->stable_uri, &stable_config), true);
 
-        if (WT_CHECK_AND_RESET(ret, WT_NOTFOUND)) {
-            uint64_t size = 0;
-            /* A table dropped before it was ever checkpointed has no checkpoint entry. */
-            WT_ERR_NOTFOUND_OK(__wt_ckpt_last_size(session, entry->stable_value, &size), true);
-            if (!WT_CHECK_AND_RESET(ret, WT_NOTFOUND)) {
-                *drop_sizep += size;
-                __wt_verbose_debug1(session, WT_VERB_DISAGGREGATED_STORAGE,
-                  "Accumulated drop size %" PRIu64 " for table \"%s\" (stable URI \"%s\")", size,
-                  entry->table_name, entry->stable_uri);
-            }
+    if (WT_CHECK_AND_RESET(ret, WT_NOTFOUND)) {
+        uint64_t size = 0;
+        /* A table dropped before it was ever checkpointed has no checkpoint entry. */
+        WT_ERR_NOTFOUND_OK(__wt_ckpt_last_size(session, entry->stable_value, &size), true);
+        if (!WT_CHECK_AND_RESET(ret, WT_NOTFOUND)) {
+            *drop_sizep += size;
+            __wt_verbose_debug2(session, WT_VERB_DISAGGREGATED_STORAGE,
+              "Accumulated drop size %" PRIu64 " for table \"%s\" (stable URI \"%s\")", size,
+              entry->table_name, entry->stable_uri);
         }
     }
+
 err:
     __wt_free(session, stable_config);
     return (ret);
@@ -738,7 +739,7 @@ __wt_disagg_shared_metadata_queue_process(
         WT_STAT_CONN_INCR(session, checkpoint_disagg_metadata_apply);
         WT_ERR(__disagg_shared_metadata_op(session, entry));
 
-        __disagg_accumulate_drop_size(session, entry, drop_sizep);
+        WT_ERR(__disagg_accumulate_drop_size(session, entry, drop_sizep));
 
         TAILQ_REMOVE(&conn->disaggregated_storage.shared_metadata_qh, entry, q);
         __disagg_shared_metadata_queue_free(session, &entry);

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -9,6 +9,8 @@
 #include "wt_internal.h"
 
 static void __disagg_shared_metadata_queue_clear(WT_SESSION_IMPL *session);
+static int __disagg_accumulate_drop_size(
+  WT_SESSION_IMPL *session, WT_DISAGG_METADATA_OP *entry, uint64_t *drop_size);
 
 /*
  * __layered_create_missing_stable_table --
@@ -640,6 +642,42 @@ __disagg_handle_create_remove_pairing(WT_SESSION_IMPL *session, WT_CONNECTION_IM
 }
 
 /*
+ * __disagg_accumulate_drop_size --
+ *     Accumulate the drop size if the entry represents a table drop operation.
+ */
+int
+__disagg_accumulate_drop_size(
+  WT_SESSION_IMPL *session, WT_DISAGG_METADATA_OP *entry, uint64_t *drop_sizep)
+{
+    WT_DECL_RET;
+    char *stable_config;
+
+    WT_ASSERT(session, drop_sizep != NULL);
+    stable_config = NULL;
+
+    if (entry->metadata_op == WT_SHARED_METADATA_REMOVE && entry->stable_value != NULL) {
+
+        /* The stable entry is gone only after a real drop; a rolled-back drop leaves it. */
+        WT_ERR_NOTFOUND_OK(__wt_metadata_search(session, entry->stable_uri, &stable_config), true);
+
+        if (WT_CHECK_AND_RESET(ret, WT_NOTFOUND)) {
+            uint64_t size = 0;
+            /* A table dropped before it was ever checkpointed has no checkpoint entry. */
+            WT_ERR_NOTFOUND_OK(__wt_ckpt_last_size(session, entry->stable_value, &size), true);
+            if (!WT_CHECK_AND_RESET(ret, WT_NOTFOUND)) {
+                *drop_sizep += size;
+                __wt_verbose_debug1(session, WT_VERB_DISAGGREGATED_STORAGE,
+                  "Accumulated drop size %" PRIu64 " for table \"%s\" (stable URI \"%s\")", size,
+                  entry->table_name, entry->stable_uri);
+            }
+        }
+    }
+err:
+    __wt_free(session, stable_config);
+    return (ret);
+}
+
+/*
  * __wt_disagg_shared_metadata_queue_process --
  *     Process the update metadata list, returning the total checkpoint size of the tables actually
  *     dropped so the caller can reduce the database size accordingly.
@@ -653,12 +691,10 @@ __wt_disagg_shared_metadata_queue_process(
     WT_DECL_RET;
     WT_DISAGG_METADATA_OP *entry, *skipped, *tmp;
     uint64_t drop_size;
-    char *stable_config;
 
     conn = S2C(session);
     TAILQ_INIT(&skipped_creates);
     drop_size = 0;
-    stable_config = NULL;
 
     /*
      * This requires schema lock to ensure that we capture a consistent snapshot of metadata entries
@@ -704,27 +740,7 @@ __wt_disagg_shared_metadata_queue_process(
         WT_STAT_CONN_INCR(session, checkpoint_disagg_metadata_apply);
         WT_ERR(__disagg_shared_metadata_op(session, entry));
 
-        /*
-         * A successful schema drop op should contribute to the database size reduction.
-         */
-        if (entry->metadata_op == WT_SHARED_METADATA_REMOVE && entry->stable_value != NULL) {
-            /*
-             * The stable entry is gone only after a real drop; a rolled-back drop leaves it.
-             */
-            WT_ERR_NOTFOUND_OK(
-              __wt_metadata_search(session, entry->stable_uri, &stable_config), true);
-            __wt_free(session, stable_config);
-
-            if (WT_CHECK_AND_RESET(ret, WT_NOTFOUND)) {
-                uint64_t size = 0;
-                /*
-                 * A table dropped before it was ever checkpointed has no checkpoint entry, so
-                 * WT_NOTFOUND from the size lookup is expected and contributes nothing.
-                 */
-                WT_ERR_NOTFOUND_OK(__wt_ckpt_last_size(session, entry->stable_value, &size), false);
-                drop_size += size;
-            }
-        }
+        __disagg_accumulate_drop_size(session, entry, &drop_size);
 
         TAILQ_REMOVE(&conn->disaggregated_storage.shared_metadata_qh, entry, q);
         __disagg_shared_metadata_queue_free(session, &entry);
@@ -755,6 +771,7 @@ err:
      */
     if (drop_sizep != NULL)
         *drop_sizep = drop_size;
+
     if (ret != 0)
         while (!TAILQ_EMPTY(&skipped_creates)) {
             skipped = TAILQ_LAST(&skipped_creates, __wt_disagg_shared_metadata_qh);
@@ -768,7 +785,6 @@ err:
         TAILQ_REMOVE(&skipped_creates, skipped, q);
         __disagg_shared_metadata_queue_free(session, &skipped);
     }
-    __wt_free(session, stable_config);
     return (ret);
 }
 

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -8,9 +8,9 @@
 
 #include "wt_internal.h"
 
-static void __disagg_shared_metadata_queue_clear(WT_SESSION_IMPL *session);
 static int __disagg_accumulate_drop_size(
   WT_SESSION_IMPL *session, WT_DISAGG_METADATA_OP *entry, uint64_t *drop_size);
+static void __disagg_shared_metadata_queue_clear(WT_SESSION_IMPL *session);
 
 /*
  * __layered_create_missing_stable_table --

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -578,50 +578,6 @@ err:
 }
 
 /*
- * __wt_disagg_shared_metadata_queue_drop_size --
- *     Walk the metadata queue and sum the checkpoint sizes of non-deferred drop operations. This is
- *     a read-only operation on the queue.
- */
-int
-__wt_disagg_shared_metadata_queue_drop_size(
-  WT_SESSION_IMPL *session, wt_timestamp_t cur_schema_epoch, uint64_t *drop_sizep)
-{
-    WT_CONNECTION_IMPL *conn;
-    WT_DECL_RET;
-    WT_DISAGG_METADATA_OP *entry;
-
-    conn = S2C(session);
-    *drop_sizep = 0;
-
-    WT_ASSERT_SPINLOCK_OWNED(session, &conn->schema_lock);
-
-    __wt_spin_lock(session, &conn->disaggregated_storage.shared_metadata_queue_lock);
-
-    TAILQ_FOREACH (entry, &conn->disaggregated_storage.shared_metadata_qh, q) {
-        /* Skip entries that are not included in the current schema epoch. */
-        if (entry->deferred)
-            continue;
-        if (cur_schema_epoch != WT_SCHEMA_EPOCH_NONE && entry->schema_epoch > cur_schema_epoch)
-            continue;
-
-        if (entry->metadata_op == WT_SHARED_METADATA_REMOVE && entry->stable_value != NULL) {
-            uint64_t size;
-            /*
-             * A table that was created and dropped without ever being checkpointed won't have a
-             * checkpoint entry in its metadata, so WT_NOTFOUND is expected.
-             */
-            WT_ERR_NOTFOUND_OK(__wt_ckpt_last_size(session, entry->stable_value, &size), false);
-            *drop_sizep += size;
-        }
-    }
-
-err:
-    __wt_spin_unlock(session, &conn->disaggregated_storage.shared_metadata_queue_lock);
-
-    return (ret);
-}
-
-/*
  * __disagg_handle_create_remove_pairing --
  *     Handle CREATE/REMOVE pairing detection during queue processing. If the entry is a CREATE with
  *     no stable value, park it in the skipped list and return true (caller should continue). If the
@@ -685,18 +641,24 @@ __disagg_handle_create_remove_pairing(WT_SESSION_IMPL *session, WT_CONNECTION_IM
 
 /*
  * __wt_disagg_shared_metadata_queue_process --
- *     Process the update metadata list.
+ *     Process the update metadata list, returning the total checkpoint size of the tables actually
+ *     dropped so the caller can reduce the database size accordingly.
  */
 int
-__wt_disagg_shared_metadata_queue_process(WT_SESSION_IMPL *session, wt_timestamp_t cur_schema_epoch)
+__wt_disagg_shared_metadata_queue_process(
+  WT_SESSION_IMPL *session, wt_timestamp_t cur_schema_epoch, uint64_t *drop_sizep)
 {
     struct __wt_disagg_shared_metadata_qh skipped_creates;
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
     WT_DISAGG_METADATA_OP *entry, *skipped, *tmp;
+    uint64_t drop_size;
+    char *stable_config;
 
     conn = S2C(session);
     TAILQ_INIT(&skipped_creates);
+    drop_size = 0;
+    stable_config = NULL;
 
     /*
      * This requires schema lock to ensure that we capture a consistent snapshot of metadata entries
@@ -742,6 +704,28 @@ __wt_disagg_shared_metadata_queue_process(WT_SESSION_IMPL *session, wt_timestamp
         WT_STAT_CONN_INCR(session, checkpoint_disagg_metadata_apply);
         WT_ERR(__disagg_shared_metadata_op(session, entry));
 
+        /*
+         * A successful schema drop op should contributes to the database size reduction.
+         */
+        if (entry->metadata_op == WT_SHARED_METADATA_REMOVE && entry->stable_value != NULL) {
+            /*
+             * The stable entry is gone only after a real drop; a rolled-back drop leaves it.
+             */
+            WT_ERR_NOTFOUND_OK(
+              __wt_metadata_search(session, entry->stable_uri, &stable_config), true);
+            __wt_free(session, stable_config);
+
+            if (WT_CHECK_AND_RESET(ret, WT_NOTFOUND)) {
+                uint64_t size = 0;
+                /*
+                 * A table dropped before it was ever checkpointed has no checkpoint entry, so
+                 * WT_NOTFOUND from the size lookup is expected and contributes nothing.
+                 */
+                WT_ERR_NOTFOUND_OK(__wt_ckpt_last_size(session, entry->stable_value, &size), false);
+                drop_size += size;
+            }
+        }
+
         TAILQ_REMOVE(&conn->disaggregated_storage.shared_metadata_qh, entry, q);
         __disagg_shared_metadata_queue_free(session, &entry);
     }
@@ -769,6 +753,8 @@ err:
      * If we failed, put back the skipped creates, so that we can revisit them if the caller
      * attempts to create a checkpoint again.
      */
+    if (drop_sizep != NULL)
+        *drop_sizep = drop_size;
     if (ret != 0)
         while (!TAILQ_EMPTY(&skipped_creates)) {
             skipped = TAILQ_LAST(&skipped_creates, __wt_disagg_shared_metadata_qh);
@@ -782,6 +768,8 @@ err:
         TAILQ_REMOVE(&skipped_creates, skipped, q);
         __disagg_shared_metadata_queue_free(session, &skipped);
     }
+    if (stable_config != NULL)
+        __wt_free(session, stable_config);
     return (ret);
 }
 

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -652,7 +652,6 @@ __disagg_accumulate_drop_size(
     WT_DECL_RET;
     char *stable_config;
 
-    WT_ASSERT(session, drop_sizep != NULL);
     stable_config = NULL;
 
     if (entry->metadata_op == WT_SHARED_METADATA_REMOVE && entry->stable_value != NULL) {
@@ -690,11 +689,10 @@ __wt_disagg_shared_metadata_queue_process(
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
     WT_DISAGG_METADATA_OP *entry, *skipped, *tmp;
-    uint64_t drop_size;
 
+    WT_ASSERT(session, drop_sizep != NULL);
     conn = S2C(session);
     TAILQ_INIT(&skipped_creates);
-    drop_size = 0;
 
     /*
      * This requires schema lock to ensure that we capture a consistent snapshot of metadata entries
@@ -740,7 +738,7 @@ __wt_disagg_shared_metadata_queue_process(
         WT_STAT_CONN_INCR(session, checkpoint_disagg_metadata_apply);
         WT_ERR(__disagg_shared_metadata_op(session, entry));
 
-        __disagg_accumulate_drop_size(session, entry, &drop_size);
+        __disagg_accumulate_drop_size(session, entry, drop_sizep);
 
         TAILQ_REMOVE(&conn->disaggregated_storage.shared_metadata_qh, entry, q);
         __disagg_shared_metadata_queue_free(session, &entry);
@@ -769,9 +767,6 @@ err:
      * If we failed, put back the skipped creates, so that we can revisit them if the caller
      * attempts to create a checkpoint again.
      */
-    if (drop_sizep != NULL)
-        *drop_sizep = drop_size;
-
     if (ret != 0)
         while (!TAILQ_EMPTY(&skipped_creates)) {
             skipped = TAILQ_LAST(&skipped_creates, __wt_disagg_shared_metadata_qh);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -596,11 +596,9 @@ extern int __wt_disagg_put_checkpoint_meta(WT_SESSION_IMPL *session, const char 
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_disagg_put_crypt_helper(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_disagg_shared_metadata_queue_drop_size(
+extern int __wt_disagg_shared_metadata_queue_process(
   WT_SESSION_IMPL *session, wt_timestamp_t cur_schema_epoch, uint64_t *drop_sizep)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_disagg_shared_metadata_queue_process(WT_SESSION_IMPL *session,
-  wt_timestamp_t cur_schema_epoch) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_disagg_shared_metadata_queue_publish(
   WT_SESSION_IMPL *session, const char *table_name, wt_timestamp_t schema_epoch)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/test/suite/test_disagg_checkpoint_size07.py
+++ b/test/suite/test_disagg_checkpoint_size07.py
@@ -28,6 +28,7 @@
 
 import re, wiredtiger, wttest
 from wiredtiger import stat
+from helper import WiredTigerCursor
 from helper_disagg import DisaggConfigMixin, disagg_test_class
 
 # Tests for database size on schema drop.
@@ -59,17 +60,6 @@ class test_disagg_checkpoint_size07(wttest.WiredTigerTestCase):
         stat_cursor.close()
         return value
 
-    # Read the latest checkpoint size of a stable constituent from its metadata.
-    def stable_checkpoint_size(self, base):
-        meta_cursor = self.session.open_cursor('metadata:')
-        meta_cursor.set_key(f'file:{base}.wt_stable')
-        self.assertEqual(meta_cursor.search(), 0)
-        value = meta_cursor.get_value()
-        meta_cursor.close()
-        sizes = re.findall(r',size=(\d+),', value)
-        self.assertGreater(len(sizes), 0)
-        return int(sizes[-1])
-
     def exists(self, uri):
         meta_cursor = self.session.open_cursor('metadata:')
         meta_cursor.set_key(uri)
@@ -85,15 +75,22 @@ class test_disagg_checkpoint_size07(wttest.WiredTigerTestCase):
 
     def database_size_check(self, context_message=""):
         self.session.checkpoint()
+
+        # Calculate reference value from sum of all the collections
+        accumulated_database_size = 0
+        with WiredTigerCursor(self.session, 'metadata:') as cursor:
+            while cursor.next() == 0:
+                value = cursor.get_value()
+                checkpoints = re.findall(r',checkpoint=([^)]+),', value)
+                if checkpoints:
+                    sizes = re.findall(r',size=(\d+),', checkpoints[0])
+                    if sizes:
+                        accumulated_database_size += int(sizes[-1])
+
         database_size = self.get_database_size()
-        keep_size = self.stable_checkpoint_size(self.keep_base)
-        if self.exists(self.victim_uri):
-            victim_size = self.stable_checkpoint_size(self.victim_base)
-        else:
-            victim_size = 0
-        self.assertGreaterEqual(database_size, keep_size + victim_size,
-            f"database size {database_size} should be at least "
-            f"keep {keep_size} + victim {victim_size} : {context_message}")
+        self.assertGreaterEqual(database_size, accumulated_database_size,
+            f"database size {database_size} should be equal to "
+            f"accumulated {accumulated_database_size} : {context_message}")
 
     def test_failed_drop_does_not_shrink_database_size(self):
         # Filler table for headroom.
@@ -143,3 +140,4 @@ class test_disagg_checkpoint_size07(wttest.WiredTigerTestCase):
             self.conn.reconfigure("verbose=[disaggregated_storage:0]")
 
         self.assertFalse(self.exists(self.victim_uri))
+        self.database_size_check("after successful drop")

--- a/test/suite/test_disagg_checkpoint_size07.py
+++ b/test/suite/test_disagg_checkpoint_size07.py
@@ -35,8 +35,7 @@ from helper_disagg import DisaggConfigMixin, disagg_test_class
 
 @disagg_test_class
 class test_disagg_checkpoint_size07(wttest.WiredTigerTestCase):
-    conn_config = 'statistics=(fast),cache_size=256MB,' \
-        'disaggregated=(role="leader"),disaggregated=(lose_all_my_data=true)'
+    conn_config = 'disaggregated=(role="leader")'
 
     # A filler table that is never dropped, giving the database size enough headroom that the
     # (buggy) repeated subtraction does not underflow before we have observed the pattern.
@@ -89,7 +88,7 @@ class test_disagg_checkpoint_size07(wttest.WiredTigerTestCase):
 
         database_size = self.get_database_size()
         self.assertGreaterEqual(database_size, accumulated_database_size,
-            f"database size {database_size} should be equal to "
+            f"database size {database_size} should be greater orequal to "
             f"accumulated {accumulated_database_size} : {context_message}")
 
     def test_failed_drop_does_not_shrink_database_size(self):
@@ -134,7 +133,7 @@ class test_disagg_checkpoint_size07(wttest.WiredTigerTestCase):
 
         # We should see the drop size for a successful drop
         with self.expectedStdoutPattern('.*Accumulated drop size.*', maxchars=1000000):
-            self.conn.reconfigure("verbose=[disaggregated_storage:1]")
+            self.conn.reconfigure("verbose=[disaggregated_storage:2]")
             self.session.drop(self.victim_uri, None)
             self.session.checkpoint()
             self.conn.reconfigure("verbose=[disaggregated_storage:0]")

--- a/test/suite/test_disagg_checkpoint_size07.py
+++ b/test/suite/test_disagg_checkpoint_size07.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import re, wiredtiger, wttest
+from wiredtiger import stat
+from helper_disagg import DisaggConfigMixin, disagg_test_class
+
+# Tests for database size on schema drop.
+
+@disagg_test_class
+class test_disagg_checkpoint_size07(wttest.WiredTigerTestCase):
+    conn_config = 'statistics=(fast),cache_size=256MB,' \
+        'disaggregated=(role="leader"),disaggregated=(lose_all_my_data=true)'
+
+    # A filler table that is never dropped, giving the database size enough headroom that the
+    # (buggy) repeated subtraction does not underflow before we have observed the pattern.
+    keep_uri = "layered:keep_table"
+    keep_base = "keep_table"
+
+    # The large collection we will repeatedly fail to drop.
+    victim_uri = "layered:victim_table"
+    victim_base = "victim_table"
+
+    value_size = 8000
+    num_failed_ckpts = 4
+
+    def conn_extensions(self, extlist):
+        extlist.skip_if_missing = True
+        DisaggConfigMixin.conn_extensions(self, extlist)
+
+    def get_database_size(self):
+        stat_cursor = self.session.open_cursor('statistics:', None, None)
+        value = stat_cursor[stat.conn.disagg_database_size][2]
+        stat_cursor.close()
+        return value
+
+    # Read the latest checkpoint size of a stable constituent from its metadata.
+    def stable_checkpoint_size(self, base):
+        meta_cursor = self.session.open_cursor('metadata:')
+        meta_cursor.set_key(f'file:{base}.wt_stable')
+        self.assertEqual(meta_cursor.search(), 0)
+        value = meta_cursor.get_value()
+        meta_cursor.close()
+        sizes = re.findall(r',size=(\d+),', value)
+        self.assertGreater(len(sizes), 0)
+        return int(sizes[-1])
+
+    def exists(self, uri):
+        meta_cursor = self.session.open_cursor('metadata:')
+        meta_cursor.set_key(uri)
+        ret = meta_cursor.search()
+        meta_cursor.close()
+        return ret == 0
+
+    def insert(self, uri, nrows, start=0):
+        cursor = self.session.open_cursor(uri)
+        for i in range(start, start + nrows):
+            cursor[str(i)] = str(i) + 'x' * self.value_size
+        cursor.close()
+
+    def test_failed_drop_does_not_shrink_database_size(self):
+        # Filler table for headroom.
+        self.session.create(self.keep_uri, 'key_format=S,value_format=S')
+        self.insert(self.keep_uri, 6000)
+
+        # The large collection that the drop will keep failing on.
+        self.session.create(self.victim_uri, 'key_format=S,value_format=S')
+        self.insert(self.victim_uri, 1000)
+
+        self.session.checkpoint()
+        victim_size = self.stable_checkpoint_size(self.victim_base)
+        self.assertGreater(victim_size, 1000000, "victim collection should be large")
+
+        # Hold the layered data handle busy from another session, but never use the cursor: the
+        # constituent (stable/ingest) cursors stay closed, so only the top-level handle is pinned.
+        # The drop's leader trim and constituent drops then succeed, but the final close fails with
+        # EBUSY -- after the REMOVE has already been enqueued.
+        busy_session = self.conn.open_session()
+        busy_cursor = busy_session.open_cursor(self.victim_uri)
+
+        keep_row = 6000
+        sizes = [self.get_database_size()]
+        for i in range(self.num_failed_ckpts):
+            # A little new data so the checkpoint has a non-zero size delta; the database size
+            # update is gated on that.
+            self.insert(self.keep_uri, 20, start=keep_row)
+            keep_row += 20
+
+            # The caller always retries the drop while the collection still exists.
+            self.assertRaisesException(wiredtiger.WiredTigerError,
+                lambda: self.session.drop(self.victim_uri, None),
+                exceptionString='/resource busy/')
+            self.assertTrue(self.exists(self.victim_uri),
+                "a failed drop must leave the collection in place")
+
+            self.session.checkpoint()
+            sizes.append(self.get_database_size())
+            self.pr(f'failed-drop ckpt {i}: database size {sizes[-2]} -> {sizes[-1]}')
+
+        # None of the failed drops removed anything, so the database size must not shrink by the
+        # collection's size on any of those checkpoints. Before the fix it drops by ~victim_size
+        # on every checkpoint, repeated until the size eventually underflows.
+        for i in range(self.num_failed_ckpts):
+            self.assertGreater(sizes[i + 1], sizes[i] - victim_size // 2,
+                f"ckpt {i}: database size {sizes[i]} -> {sizes[i + 1]} dropped by "
+                f"~{sizes[i] - sizes[i + 1]} for a drop that never succeeded "
+                f"(victim checkpoint size {victim_size})")
+
+        # With the cursor gone the retried drop finally succeeds.
+        busy_cursor.close()
+        busy_session.close()
+        self.assertTrue(self.exists(self.victim_uri))
+        before_real_drop = self.get_database_size()
+        self.session.drop(self.victim_uri, None)
+        self.assertFalse(self.exists(self.victim_uri))
+
+        # A genuine drop should reduce the database size by ~victim_size on the next checkpoint.
+        self.insert(self.keep_uri, 20, start=keep_row)
+        self.session.checkpoint()
+        after_real_drop = self.get_database_size()
+        self.assertLess(after_real_drop, before_real_drop - victim_size // 2,
+            f"a successful drop should reduce the database size: "
+            f"{before_real_drop} -> {after_real_drop}")
+
+

--- a/test/suite/test_disagg_checkpoint_size07.py
+++ b/test/suite/test_disagg_checkpoint_size07.py
@@ -88,7 +88,7 @@ class test_disagg_checkpoint_size07(wttest.WiredTigerTestCase):
 
         database_size = self.get_database_size()
         self.assertGreaterEqual(database_size, accumulated_database_size,
-            f"database size {database_size} should be greater orequal to "
+            f"database size {database_size} should be greater or equal to "
             f"accumulated {accumulated_database_size} : {context_message}")
 
     def test_failed_drop_does_not_shrink_database_size(self):

--- a/test/suite/test_disagg_checkpoint_size07.py
+++ b/test/suite/test_disagg_checkpoint_size07.py
@@ -114,7 +114,7 @@ class test_disagg_checkpoint_size07(wttest.WiredTigerTestCase):
             # The caller always retries the drop while the collection still exists.
             self.assertRaisesException(wiredtiger.WiredTigerError,
                 lambda: self.session.drop(self.victim_uri, None),
-                exceptionString='/resource busy/')
+                exceptionString='Resource busy')
             self.assertTrue(self.exists(self.victim_uri),
                 "a failed drop must leave the collection in place")
 
@@ -145,6 +145,6 @@ class test_disagg_checkpoint_size07(wttest.WiredTigerTestCase):
         after_real_drop = self.get_database_size()
         self.assertLess(after_real_drop, before_real_drop - victim_size // 2,
             f"a successful drop should reduce the database size: "
-            f"{before_real_drop} -> {after_real_drop}")
+            f"{before_real_drop} (before drop) -> {after_real_drop} (after drop)")
 
 

--- a/test/suite/test_disagg_checkpoint_size07.py
+++ b/test/suite/test_disagg_checkpoint_size07.py
@@ -124,7 +124,7 @@ class test_disagg_checkpoint_size07(wttest.WiredTigerTestCase):
 
         # None of the failed drops removed anything, so the database size must not shrink by the
         # collection's size on any of those checkpoints. Before the fix it drops by ~victim_size
-        # on every checkpoint, repeated until the size eventually underflows.
+        # on every checkpoint, repeated until the size eventually overflow.
         for i in range(self.num_failed_ckpts):
             self.assertGreater(sizes[i + 1], sizes[i] - victim_size // 2,
                 f"ckpt {i}: database size {sizes[i]} -> {sizes[i + 1]} dropped by "

--- a/test/suite/test_disagg_checkpoint_size07.py
+++ b/test/suite/test_disagg_checkpoint_size07.py
@@ -112,9 +112,9 @@ class test_disagg_checkpoint_size07(wttest.WiredTigerTestCase):
             keep_row += 20
 
             # The caller always retries the drop while the collection still exists.
-            self.assertRaisesException(wiredtiger.WiredTigerError,
-                lambda: self.session.drop(self.victim_uri, None),
-                exceptionString='Resource busy')
+            self.assertTrue(
+                self.raisesBusy(lambda: self.session.drop(self.victim_uri, None)),
+                "a failed drop must raise EBUSY")
             self.assertTrue(self.exists(self.victim_uri),
                 "a failed drop must leave the collection in place")
 

--- a/test/suite/test_disagg_checkpoint_size07.py
+++ b/test/suite/test_disagg_checkpoint_size07.py
@@ -83,6 +83,18 @@ class test_disagg_checkpoint_size07(wttest.WiredTigerTestCase):
             cursor[str(i)] = str(i) + 'x' * self.value_size
         cursor.close()
 
+    def database_size_check(self, context_message=""):
+        self.session.checkpoint()
+        database_size = self.get_database_size()
+        keep_size = self.stable_checkpoint_size(self.keep_base)
+        if self.exists(self.victim_uri):
+            victim_size = self.stable_checkpoint_size(self.victim_base)
+        else:
+            victim_size = 0
+        self.assertGreaterEqual(database_size, keep_size + victim_size,
+            f"database size {database_size} should be at least "
+            f"keep {keep_size} + victim {victim_size} : {context_message}")
+
     def test_failed_drop_does_not_shrink_database_size(self):
         # Filler table for headroom.
         self.session.create(self.keep_uri, 'key_format=S,value_format=S')
@@ -93,8 +105,6 @@ class test_disagg_checkpoint_size07(wttest.WiredTigerTestCase):
         self.insert(self.victim_uri, 1000)
 
         self.session.checkpoint()
-        victim_size = self.stable_checkpoint_size(self.victim_base)
-        self.assertGreater(victim_size, 1000000, "victim collection should be large")
 
         # Hold the layered data handle busy from another session, but never use the cursor: the
         # constituent (stable/ingest) cursors stay closed, so only the top-level handle is pinned.
@@ -104,7 +114,6 @@ class test_disagg_checkpoint_size07(wttest.WiredTigerTestCase):
         busy_cursor = busy_session.open_cursor(self.victim_uri)
 
         keep_row = 6000
-        sizes = [self.get_database_size()]
         for i in range(self.num_failed_ckpts):
             # A little new data so the checkpoint has a non-zero size delta; the database size
             # update is gated on that.
@@ -117,34 +126,20 @@ class test_disagg_checkpoint_size07(wttest.WiredTigerTestCase):
                 "a failed drop must raise EBUSY")
             self.assertTrue(self.exists(self.victim_uri),
                 "a failed drop must leave the collection in place")
-
             self.session.checkpoint()
-            sizes.append(self.get_database_size())
-            self.pr(f'failed-drop ckpt {i}: database size {sizes[-2]} -> {sizes[-1]}')
 
-        # None of the failed drops removed anything, so the database size must not shrink by the
-        # collection's size on any of those checkpoints. Before the fix it drops by ~victim_size
-        # on every checkpoint, repeated until the size eventually overflow.
-        for i in range(self.num_failed_ckpts):
-            self.assertGreater(sizes[i + 1], sizes[i] - victim_size // 2,
-                f"ckpt {i}: database size {sizes[i]} -> {sizes[i + 1]} dropped by "
-                f"~{sizes[i] - sizes[i + 1]} for a drop that never succeeded "
-                f"(victim checkpoint size {victim_size})")
+        self.database_size_check("after failed drops")
 
         # With the cursor gone the retried drop finally succeeds.
         busy_cursor.close()
         busy_session.close()
         self.assertTrue(self.exists(self.victim_uri))
-        before_real_drop = self.get_database_size()
-        self.session.drop(self.victim_uri, None)
+
+        # We should see the drop size for a successful drop
+        with self.expectedStdoutPattern('.*Accumulated drop size.*', maxchars=1000000):
+            self.conn.reconfigure("verbose=[disaggregated_storage:1]")
+            self.session.drop(self.victim_uri, None)
+            self.session.checkpoint()
+            self.conn.reconfigure("verbose=[disaggregated_storage:0]")
+
         self.assertFalse(self.exists(self.victim_uri))
-
-        # A genuine drop should reduce the database size by ~victim_size on the next checkpoint.
-        self.insert(self.keep_uri, 20, start=keep_row)
-        self.session.checkpoint()
-        after_real_drop = self.get_database_size()
-        self.assertLess(after_real_drop, before_real_drop - victim_size // 2,
-            f"a successful drop should reduce the database size: "
-            f"{before_real_drop} (before drop) -> {after_real_drop} (after drop)")
-
-


### PR DESCRIPTION
Only deduct the size from database in checkpoint on successful schema drop op.