### PR TITLE
WT-17889 use rdtsc for timestamps

### DIFF
--- a/src/btree/bt_walk.c
+++ b/src/btree/bt_walk.c
@@ -108,13 +108,12 @@ __tree_walk_internal(WT_SESSION_IMPL *session, WT_REF **refp, uint64_t *walkcntp
   int (*skip_func)(WT_SESSION_IMPL *, WT_REF *, void *, bool, bool *), void *func_cookie,
   uint32_t flags)
 {
-    struct timespec start, stop;
     WT_BTREE *btree;
     WT_DECL_RET;
     WT_PAGE_INDEX *pindex;
     WT_REF *couple, *ref, *ref_orig;
     WT_REF_STATE current_state;
-    uint64_t restart_sleep, restart_yield, time_diff_ms;
+    uint64_t restart_sleep, restart_yield, start, stop, time_diff_ms;
     uint32_t slot;
     bool empty_internal, prev, skip;
 
@@ -181,7 +180,7 @@ __tree_walk_internal(WT_SESSION_IMPL *session, WT_REF **refp, uint64_t *walkcntp
      */
     WT_ENTER_PAGE_INDEX(session);
 
-    __wt_epoch(session, &start);
+    start = __wt_clock(session);
     /* If no page is active, begin a walk from the start/end of the tree. */
     if ((ref = ref_orig) == NULL) {
         if (0) {
@@ -386,8 +385,8 @@ descend:
     }
 
 done:
-    __wt_epoch(session, &stop);
-    time_diff_ms = WT_TIMEDIFF_MS(stop, start);
+    stop = __wt_clock(session);
+    time_diff_ms = WT_CLOCKDIFF_MS(stop, start);
     if (time_diff_ms > 10 * WT_THOUSAND)
         __wt_verbose_warning(session, WT_VERB_READ,
           "tree walk took more than 10 seconds (%" PRIu64 "ms)", time_diff_ms);


### PR DESCRIPTION
I noticed __wti_evict_lru_walk spends 1/3 of its cpu time in clock_gettime@@GLIBC_2.17 a small change here to switch to RDTSC shows small but noticeable performance improvement. Is there risk to this change? Feel free to close this if it is a bad idea