### PR TITLE
WT-17892 Fix memory leak in __curhs_remove_int and __curhs_update when __wt_hs_modify fails

### DIFF
--- a/src/cursor/cur_hs.c
+++ b/src/cursor/cur_hs.c
@@ -1149,6 +1149,9 @@ __curhs_remove_int(WT_CURSOR_BTREE *cbt, const WT_ITEM *value, u_int modify_type
         WT_WITH_PAGE_INDEX(session, ret = __curhs_search(cbt, false));
         WT_ERR(ret);
     }
+    WT_ERR(ret);
+    /* We no longer own the update memory, the page does; don't free it under any circumstances. */
+    hs_tombstone = NULL;
 
     if (0) {
 err:
@@ -1270,6 +1273,9 @@ __curhs_update(WT_CURSOR *cursor)
         WT_WITH_PAGE_INDEX(session, ret = __curhs_search(cbt, false));
         WT_ERR(ret);
     }
+    WT_ERR(ret);
+    /* We no longer own the update memory, the page does; don't free it under any circumstances. */
+    hs_tombstone = hs_upd = NULL;
 
     __curhs_set_key_ptr(cursor, file_cursor);
     __curhs_set_value_ptr(cursor, file_cursor);


### PR DESCRIPTION
## Summary
- `__curhs_remove_int` and `__curhs_update` both retry `__wt_hs_modify` in a `while` loop on `WT_RESTART`, but had no `WT_ERR(ret)` after the loop exits
- If `__wt_hs_modify` returned any non-`WT_RESTART` error, execution fell through without triggering `err:`, leaking `hs_tombstone` (and `hs_upd` in `__curhs_update`)
- Fix adds `WT_ERR(ret)` after each loop, matching the pattern already used by the `do-while` insert path (~line 1090)
- The `hs_tombstone = hs_upd = NULL` assignment after success is defensive (no fallible code follows in either function), but makes the ownership transfer to the page explicit and consistent with the existing idiom in the file
