### PR TITLE
WT-17898 Use a CAS loop to make disagg block size decrement atomic

### DIFF
--- a/src/block_disagg/block_disagg_size.c
+++ b/src/block_disagg/block_disagg_size.c
@@ -51,7 +51,7 @@ __wti_block_disagg_decrease_size(
     } while (!__wt_atomic_cas_uint64(&block_disagg->size, orig, orig < size ? 0 : orig - size));
 
     if (orig < size)
-        __wt_verbose_error(session, WT_VERB_DISAGGREGATED_STORAGE,
+        __wt_verbose_warning(session, WT_VERB_DISAGGREGATED_STORAGE,
           "disaggregated block size underflow: decrementing %" PRIu64 " from %" PRIu64
           ", clamped to 0",
           size, orig);

--- a/src/block_disagg/block_disagg_size.c
+++ b/src/block_disagg/block_disagg_size.c
@@ -36,13 +36,25 @@ void
 __wti_block_disagg_decrease_size(
   WT_SESSION_IMPL *session, WT_BLOCK_DISAGG *block_disagg, uint64_t size)
 {
-    WT_UNUSED(session);
+    uint64_t orig;
 
-    /* FIXME WT-16864: re-enable this assert once the disagg block size accounting bug is fixed. */
-    if (__wt_atomic_load_uint64(&block_disagg->size) < size)
-        __wt_atomic_store_uint64(&block_disagg->size, 0);
-    else
-        (void)__wt_atomic_sub_uint64(&block_disagg->size, size);
+    /*
+     * Check for underflow and decrement as a single atomic step. The CAS guarantees we subtract
+     * from the same value we validated, closing the race between the check and the subtraction. A
+     * failed CAS means a concurrent update beat us to it; reload and retry.
+     *
+     * FIXME-WT-16864: clamping to zero hides a real accounting bug where we decrement more than was
+     * added. Remove the clamp once that bug is fixed.
+     */
+    do {
+        orig = __wt_atomic_load_uint64(&block_disagg->size);
+    } while (!__wt_atomic_cas_uint64(&block_disagg->size, orig, orig < size ? 0 : orig - size));
+
+    if (orig < size)
+        __wt_verbose_error(session, WT_VERB_DISAGGREGATED_STORAGE,
+          "disaggregated block size underflow: decrementing %" PRIu64 " from %" PRIu64
+          ", clamped to 0",
+          size, orig);
 }
 
 /*


### PR DESCRIPTION
`__wti_block_disagg_decrease_size` was racy, it loaded the size, checked for underflow, then subtracted in a separate atomic op, so another thread could change the size in between and we'd subtract from a value we never validated.

This folds the check and decrement into a single CAS loop, so we only ever subtract from the value we read. The clamp-to-0 stays as a stopgap for the accounting bug in WT-16864, but now logs a verbose message when it fires instead of clamping silently.