### PR TITLE
WT-17182 FIX test_update_obsolete_short_chain: keep update chain intact until checkpoint

### DIFF
--- a/test/suite/test_update_obsolete_short_chain.py
+++ b/test/suite/test_update_obsolete_short_chain.py
@@ -67,7 +67,7 @@ class test_update_obsolete_short_chain(wttest.WiredTigerTestCase):
         self.assertEqual(removed_after_second, removed_start)
 
         # Grow the chain to length >= 3. Obsolete updates are then eligible
-        # for cleanup during reconciliation. Keep oldest/stable below value-b's
+        # for cleanup during reconciliation. Keep oldest/stable below value-b
         # timestamp until after the chain is fully built so the in-line serial
         # obsolete check cannot prune value-a before the checkpoint does.
         self.update_with_ts(uri, key, 'value-c', 30)

--- a/test/suite/test_update_obsolete_short_chain.py
+++ b/test/suite/test_update_obsolete_short_chain.py
@@ -63,12 +63,13 @@ class test_update_obsolete_short_chain(wttest.WiredTigerTestCase):
         # After this update, the chain is [new] -> [prior] -> NULL.
         # There is nothing to prune.
         self.update_with_ts(uri, key, 'value-b', 20)
-        self.pin_timestamps(20)
         removed_after_second = self.get_stat(stat.conn.cache_obsolete_updates_removed)
         self.assertEqual(removed_after_second, removed_start)
 
         # Grow the chain to length >= 3. Obsolete updates are then eligible
-        # for cleanup during reconciliation.
+        # for cleanup during reconciliation. Keep oldest/stable below value-b's
+        # timestamp until after the chain is fully built so the in-line serial
+        # obsolete check cannot prune value-a before the checkpoint does.
         self.update_with_ts(uri, key, 'value-c', 30)
         self.pin_timestamps(30)
 


### PR DESCRIPTION
### Summary

This change fixes test_short_chain_no_prune_then_prune in test_update_obsolete_short_chain.py.

The test was intended to verify that checkpoint reconciliation prunes obsolete updates from a 3-entry update chain. Instead, it was collapsing the chain earlier than expected because pin_timestamps(20) was called before the third update was written. That advanced oldest_timestamp too early and allowed the inline obsolete check in __wt_update_serial to prune value-a during the write of value-c, leaving checkpoint with nothing left to prune.

### Fix

Remove the mid-sequence pin_timestamps(20) call between writing value-b and recording removed_after_second.

Advance oldest_timestamp and stable_timestamp only after all three updates are written, just before checkpoint. This keeps the full chain intact through the write sequence so reconciliation can prune value-a during checkpoint and correctly increment cache_obsolete_updates_removed.

### Root cause

The test assumed pin_timestamps(20) was safe to call in the middle of the sequence because the WT-17074 short-chain optimization prevents the inline check from running on a 2-entry chain. However, once the third update is written, the inline check becomes active again, and the already-advanced oldest_timestamp makes value-a obsolete and eligible for immediate pruning.

### Test

With this change:

- the 3-entry chain [c] → [b] → [a] reaches checkpoint intact
- reconciliation prunes the obsolete update as intended
- cache_obsolete_updates_removed is incremented as expected