### PR TITLE
WT-17866 Fix missing WT_RET in __recovery_file_scan for incomplete-table cleanup (8.3)

### DIFF
--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -941,7 +941,7 @@ __recovery_file_scan(WT_RECOVERY *r)
       "scanning metadata to remove all incomplete tables");
 
     /* Scan through all table entries in the metadata and clean up incomplete tables. */
-    __recovery_metadata_scan_prefix(r, "table:", NULL, __metadata_clean_incomplete_table);
+    WT_RET(__recovery_metadata_scan_prefix(r, "table:", NULL, __metadata_clean_incomplete_table));
 
     __wt_verbose_level_multi(r->session, WT_VERB_RECOVERY_ALL, WT_VERBOSE_INFO, "%s",
       "scanning metadata to find the largest file ID");

--- a/test/suite/test_recovery02.py
+++ b/test/suite/test_recovery02.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wiredtiger, wttest
+
+class test_recovery02(wttest.WiredTigerTestCase):
+    def test_recovery02(self):
+        # Open the metadata cursor in write mode.
+        cursor = self.session.open_cursor('metadata:', None, 'readonly=0')
+
+        # Insert an incomplete table config (empty config string with no columns key).
+        cursor['table:recovery02'] = ''
+        cursor.close()
+
+        # Close the connection to ensure the metadata checkpoint is written to disk.
+        self.close_conn()
+
+        self.assertRaisesWithMessage(
+            wiredtiger.WiredTigerError, lambda: self.open_conn(), "/Recovery failed/")


### PR DESCRIPTION
During recovery, __recovery_file_scan (txn_recover.c line 976) calls __recovery_metadata_scan_prefix three times to scan the metadata. The two calls for "file:" and "tiered:" prefixes correctly wrap the return value with WT_RET. The call for the "table:" prefix (line 982), which invokes __metadata_clean_incomplete_table, does not. If the cleanup fails for any reason, for example, __wt_schema_drop returning an error or a config parse failure the non-zero return value is silently discarded and recovery proceeds as if nothing went wrong.

For ReProduce;
A csuite test (test_wt17866_txn_recovery_error) reproduces the bug and verifies the fix (I attached the before/after outputs on JIRA).
Without the fix, wiredtiger_open returns 0 despite the cleanup failure and the incomplete metadata entry persists. With the fix, wiredtiger_open correctly returns an error.

Testing:
- ./dist/s_all runned
- environment: GCC 13, Ubuntu 24.04