### PR TITLE
WT-17686 Fix compatibility test for newer releases

### DIFF
--- a/test/compatibility/compatibility_test_for_releases.sh
+++ b/test/compatibility/compatibility_test_for_releases.sh
@@ -925,7 +925,7 @@ generate_compat_pairs()
             local next_major=$(( major + 1 ))
             local next_major_b="mongodb-${next_major}.0"
             if branch_in_array "$next_major_b" "${branches[@]}"; then
-                add_pair "$branch" "$next_major_b"
+                add_pair "$next_major_b" "$branch"
             elif branch_in_array "develop" "${branches[@]}"; then
                 add_pair "develop" "$branch"
             fi

--- a/test/compatibility/compatibility_test_for_releases.sh
+++ b/test/compatibility/compatibility_test_for_releases.sh
@@ -515,20 +515,6 @@ upgrade_downgrade()
             flags="-1Rq $(bflag $1)"
             ./t $flags -h "$top/$format_dir_branch2/RUNDIR.$am" timer=2
 
-            # $1 (newer binary) doesn't maintain BACKUP.copy, but $2 (older binary) expects it.
-            # Sync BACKUP->BACKUP.copy after $1 runs so $2 finds a consistent BACKUP.copy.
-            # Also remove BACKUP_INFO_FILE: backup tracking state is version-specific metadata
-            # (not a data-format compatibility requirement), so $2 should start a fresh backup
-            # cycle rather than try to resume $1's incremental state.
-            if [ -z "$need_bcopy1" -a "$need_bcopy2" == "1" ] ; then
-                if [ -e "$dir2/BACKUP" ] ; then
-                    echo "Syncing $dir2/BACKUP.copy for older release $2"
-                    rm -rf "$dir2/BACKUP.copy"
-                    cp -rp "$dir2/BACKUP" "$dir2/BACKUP.copy"
-                fi
-                rm -f "$dir2/BACKUP_INFO_FILE"
-            fi
-
             echo "$2 format running on $2 access method $am..."
             cd "$top/$format_dir_branch2"
             flags="-1Rq $(bflag $2)"
@@ -922,7 +908,7 @@ generate_compat_pairs()
             if branch_in_array "$next_major_b" "${branches[@]}"; then
                 add_pair "$branch" "$next_major_b"
             elif branch_in_array "develop" "${branches[@]}"; then
-                add_pair "$branch" "develop"
+                add_pair "develop" "$branch"
             fi
 
         elif is_major_release "$branch"; then
@@ -941,7 +927,7 @@ generate_compat_pairs()
             if branch_in_array "$next_major_b" "${branches[@]}"; then
                 add_pair "$branch" "$next_major_b"
             elif branch_in_array "develop" "${branches[@]}"; then
-                add_pair "$branch" "develop"
+                add_pair "develop" "$branch"
             fi
 
             # All configured minors of the same major X.Y (Y > 0)

--- a/test/compatibility/compatibility_test_for_releases.sh
+++ b/test/compatibility/compatibility_test_for_releases.sh
@@ -906,7 +906,7 @@ generate_compat_pairs()
             local next_major=$(( major + 1 ))
             local next_major_b="mongodb-${next_major}.0"
             if branch_in_array "$next_major_b" "${branches[@]}"; then
-                add_pair "$branch" "$next_major_b"
+                add_pair "$next_major_b" "$branch"
             elif branch_in_array "develop" "${branches[@]}"; then
                 add_pair "develop" "$branch"
             fi

--- a/test/compatibility/compatibility_test_for_releases.sh
+++ b/test/compatibility/compatibility_test_for_releases.sh
@@ -223,36 +223,38 @@ create_configs()
     fi
 
     echo "##################################################" > $file_name
-    echo "runs.type=row" >> $file_name                # WT-7379 - Temporarily disable column store tests
-    echo "block_cache=0" >> $file_name                # Not supported by newer releases, it is forcibly disabled internally.
-    echo "btree.huffman_value=0" >> $file_name        # WT-12456 - Never used, removed from newer releases
-    echo "btree.prefix=0" >> $file_name               # WT-7579 - Prefix testing isn't portable between releases
-    echo "btree.prefix_len=0" >> $file_name           # WT-15548 - Not supported by older releases
-    echo "cache=80" >> $file_name                     # Medium cache so there's eviction
-    echo "checksum=on" >> $file_name                  # WT-7851 Fix illegal checksum configuration
-    echo "checkpoints=1"  >> $file_name               # Force periodic writes
-    echo "compression=snappy"  >> $file_name          # We only build with snappy, force the choice
+    echo "runs.type=row" >> $file_name                          # WT-7379 - Temporarily disable column store tests
+    echo "block_cache=0" >> $file_name                          # Not supported by newer releases, it is forcibly disabled internally.
+    echo "btree.huffman_value=0" >> $file_name                  # WT-12456 - Never used, removed from newer releases
+    echo "btree.prefix=0" >> $file_name                         # WT-7579 - Prefix testing isn't portable between releases
+    echo "btree.prefix_len=0" >> $file_name                     # WT-15548 - Not supported by older releases
+    echo "cache=80" >> $file_name                               # Medium cache so there's eviction
+    echo "checksum=on" >> $file_name                            # WT-7851 Fix illegal checksum configuration
+    echo "checkpoints=1"  >> $file_name                         # Force periodic writes
+    echo "compression=snappy"  >> $file_name                    # We only build with snappy, force the choice
     echo "data_source=table" >> $file_name
-    echo "debug.background_compact=0" >> $file_name   # WT-13276 - Not supported by older releases
-    echo "debug.cursor_reposition=0" >> $file_name    # WT-10594 - Not supported by older releases
-    echo "debug.log_retention=0" >> $file_name        # WT-10434 - Not supported by older releases
-    echo "debug.realloc_malloc=0" >> $file_name       # WT-10111 - Not supported by older releases
-    echo "eviction.evict_use_softptr=0" >> $file_name # WT-14013 - Not supported by older releases
-    echo "in_memory=0" >> $file_name                  # Interested in the on-disk format
-    echo "leak_memory=1" >> $file_name                # Faster runs
-    echo "logging=1" >> $file_name                    # Test log compatibility
-    echo "logging_compression=snappy" >> $file_name   # We only built with snappy, force the choice
-    echo "obsolete_cleanup.method=off" >> $file_name  # WT-14142 - Not supported by older releases
-    echo "obsolete_cleanup.wait=0" >> $file_name      # WT-14142 - Not supported by older releases
-    echo "prefetch=0" >> $file_name                   # WT-12978 - Not supported by older releases
-    echo "prefetch.default=0" >> $file_name           # WT-16671 - Not supported by older releases
+    echo "debug.background_compact=0" >> $file_name             # WT-13276 - Not supported by older releases
+    echo "debug.cursor_reposition=0" >> $file_name              # WT-10594 - Not supported by older releases
+    echo "debug.disagg_slow_truncate_follower=0" >> $file_name  # WT-17686 - Not supported by older releases
+    echo "debug.log_retention=0" >> $file_name                  # WT-10434 - Not supported by older releases
+    echo "debug.realloc_malloc=0" >> $file_name                 # WT-10111 - Not supported by older releases
+    echo "debug.slow_truncate=0" >> $file_name                  # WT-17686 - Not supported by older releases
+    echo "eviction.evict_use_softptr=0" >> $file_name           # WT-14013 - Not supported by older releases
+    echo "in_memory=0" >> $file_name                            # Interested in the on-disk format
+    echo "leak_memory=1" >> $file_name                          # Faster runs
+    echo "logging=1" >> $file_name                              # Test log compatibility
+    echo "logging_compression=snappy" >> $file_name             # We only built with snappy, force the choice
+    echo "obsolete_cleanup.method=off" >> $file_name            # WT-14142 - Not supported by older releases
+    echo "obsolete_cleanup.wait=0" >> $file_name                # WT-14142 - Not supported by older releases
+    echo "prefetch=0" >> $file_name                             # WT-12978 - Not supported by older releases
+    echo "prefetch.default=0" >> $file_name                     # WT-16671 - Not supported by older releases
     echo "rows=1000000" >> $file_name
-    echo "salvage=0" >> $file_name                    # Faster runs
-    echo "statistics_log.sources=off" >> $file_name   # WT-12710 - Prevent statistics from enabling both 'all' and 'sources'
-    echo "stress.checkpoint=0" >> $file_name          # Faster runs
+    echo "salvage=0" >> $file_name                              # Faster runs
+    echo "statistics_log.sources=off" >> $file_name             # WT-12710 - Prevent statistics from enabling both 'all' and 'sources'
+    echo "stress.checkpoint=0" >> $file_name                    # Faster runs
     echo "timer=4" >> $file_name
     echo "verify=1" >> $file_name
-    echo "transaction.timestamps=0" >> $file_name     # WT-8601 - Timestamps do not work with logged tables
+    echo "transaction.timestamps=0" >> $file_name               # WT-8601 - Timestamps do not work with logged tables
     echo "##################################################" >> $file_name
 }
 

--- a/test/compatibility/compatibility_test_for_releases.sh
+++ b/test/compatibility/compatibility_test_for_releases.sh
@@ -515,6 +515,20 @@ upgrade_downgrade()
             flags="-1Rq $(bflag $1)"
             ./t $flags -h "$top/$format_dir_branch2/RUNDIR.$am" timer=2
 
+            # $1 (newer binary) doesn't maintain BACKUP.copy, but $2 (older binary) expects it.
+            # Sync BACKUP->BACKUP.copy after $1 runs so $2 finds a consistent BACKUP.copy.
+            # Also remove BACKUP_INFO_FILE: backup tracking state is version-specific metadata
+            # (not a data-format compatibility requirement), so $2 should start a fresh backup
+            # cycle rather than try to resume $1's incremental state.
+            if [ -z "$need_bcopy1" -a "$need_bcopy2" == "1" ] ; then
+                if [ -e "$dir2/BACKUP" ] ; then
+                    echo "Syncing $dir2/BACKUP.copy for older release $2"
+                    rm -rf "$dir2/BACKUP.copy"
+                    cp -rp "$dir2/BACKUP" "$dir2/BACKUP.copy"
+                fi
+                rm -f "$dir2/BACKUP_INFO_FILE"
+            fi
+
             echo "$2 format running on $2 access method $am..."
             cd "$top/$format_dir_branch2"
             flags="-1Rq $(bflag $2)"


### PR DESCRIPTION
The task `compatibility-test-for-newer-releases` has been failing for two distinct reasons (see [WT-17686](https://jira.mongodb.org/browse/WT-17686?focusedCommentId=8574935&focusedId=8574935&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-8574935)):

- Two new format debug knobs (`debug.slow_truncate` and `debug.disagg_slow_truncate_follower`) were added to develop and are enabled by default. Older releases don't support them. 
    - Fix: `create_configs()` now explicitly sets both to 0 so older binaries never see them enabled.

- `generate_compat_pairs` wrong ordering for develop: `add_pair "mongodb-8.0" "develop"` preserved argument order, emitting `"mongodb-8.0 develop"`. This resulted in the `upgrade_downgrade()` test putting develop in the "older branch" slot. Develop doesn't maintain `BACKUP.copy`, so after develop ran and added files to `BACKUP/`, mongodb-8.0 crashed with `ENOENT` unlinking those files from the missing `BACKUP.copy` (`upgrade_downgrade()` explicitly addresses this inconsistency, but only if `develop` is correctly specified as the "newer" branch). 
    - Fix: Swap the call to `add_pair "develop" "$branch"` so develop is always emitted first and is treated as the "newer" branch.