### PR TITLE
WT-17907 Use stop transaction range to skip more deleted pages during tree walk

### DIFF
--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -2796,13 +2796,17 @@ __wt_btcur_skip_page(
             walk_skip_stats->total_del_pages_skipped++;
         }
     } else if (clean_page && __wt_get_page_modify_ta(session, ref->page, &ta) && !ta->prepare &&
-      __wt_txn_snap_min_visible(
-        session, ta->newest_stop_txn, ta->newest_stop_ts, ta->newest_stop_durable_ts)) {
+      __wt_txn_snap_range_visible(session, ta->oldest_stop_txn, ta->newest_stop_txn,
+        ta->newest_stop_ts, ta->newest_stop_durable_ts)) {
         /*
          * If the reader can see all of the deleted content, they can skip a deleted clean page.
          * Before determining whether the deleted page is visible, copy the stop time aggregate
          * information pointer because as part of the checkpoint operation, this pointer can be
          * released in parallel.
+         *
+         * The in-memory page-modify aggregate carries both ends of the stop-transaction range, so
+         * use the range visibility check; it skips more pages than the snap_min bound used on the
+         * disk-address path, which only has the newest stop transaction.
          */
         *skipp = true;
         walk_skip_stats->total_inmem_del_pages_skipped++;

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2096,6 +2096,12 @@ static WT_INLINE bool __wt_txn_read_committed_should_release_snapshot(WT_SESSION
 static WT_INLINE bool __wt_txn_snap_min_visible(
   WT_SESSION_IMPL *session, uint64_t id, wt_timestamp_t timestamp, wt_timestamp_t durable_timestamp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static WT_INLINE bool __wt_txn_snap_range_visible(WT_SESSION_IMPL *session, uint64_t oldest_id,
+  uint64_t newest_id, wt_timestamp_t timestamp, wt_timestamp_t durable_timestamp)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static WT_INLINE bool __wt_txn_snapshot_intersects_range(
+  uint64_t *snapshot, uint32_t snapshot_count, uint64_t lo, uint64_t hi)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wt_txn_timestamp_visible(WT_SESSION_IMPL *session, wt_timestamp_t timestamp,
   wt_timestamp_t durable_timestamp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wt_txn_timestamp_visible_all(WT_SESSION_IMPL *session,

--- a/src/include/timestamp.h
+++ b/src/include/timestamp.h
@@ -62,6 +62,15 @@ struct __wt_time_aggregate {
     wt_timestamp_t newest_stop_ts;  /* default value: WT_TS_MAX */
     uint64_t newest_stop_txn;       /* default value: WT_TXN_MAX */
 
+    /*
+     * Smallest stop transaction on the page, excluding records with no stop and records whose stop
+     * is already cleared as globally visible. In-memory only: it is never packed into a cell, so a
+     * disk-loaded aggregate leaves it at the default. Only the in-memory page-modify skip path
+     * (__wt_get_page_modify_ta) consults it, to test whether a reader's concurrent snapshot
+     * intersects the page's stop-txn range rather than falling back to the snap_min bound.
+     */
+    uint64_t oldest_stop_txn; /* default value: WT_TXN_MAX */
+
     uint8_t prepare;
 
     uint8_t init_merge; /* Initialized for aggregation and merge */

--- a/src/include/timestamp_inline.h
+++ b/src/include/timestamp_inline.h
@@ -144,6 +144,7 @@
         (ta)->newest_txn = WT_TXN_NONE;             \
         (ta)->newest_stop_ts = WT_TS_MAX;           \
         (ta)->newest_stop_txn = WT_TXN_MAX;         \
+        (ta)->oldest_stop_txn = WT_TXN_MAX;         \
         (ta)->prepare = 0;                          \
         (ta)->init_merge = 0;                       \
     } while (0)
@@ -164,6 +165,7 @@
         (ta)->newest_txn = WT_TXN_NONE;             \
         (ta)->newest_stop_ts = WT_TS_NONE;          \
         (ta)->newest_stop_txn = WT_TXN_NONE;        \
+        (ta)->oldest_stop_txn = WT_TXN_MAX;         \
         (ta)->prepare = 0;                          \
         (ta)->init_merge = 1;                       \
     } while (0)
@@ -184,37 +186,45 @@
 #define WT_TIME_AGGREGATE_COPY(dest, source) (*(dest) = *(source))
 
 /* Update the aggregated window to reflect for a new time window. */
-#define WT_TIME_AGGREGATE_UPDATE(session, ta, tw)                                          \
-    do {                                                                                   \
-        WT_ASSERT(session, (ta)->init_merge == 1);                                         \
-        if ((tw)->start_prepare_ts == WT_TS_NONE) {                                        \
-            (ta)->oldest_start_ts = WT_MIN((tw)->start_ts, (ta)->oldest_start_ts);         \
-            (ta)->newest_start_durable_ts =                                                \
-              WT_MAX((tw)->durable_start_ts, (ta)->newest_start_durable_ts);               \
-        } else {                                                                           \
-            (ta)->oldest_start_ts = WT_MIN((tw)->start_prepare_ts, (ta)->oldest_start_ts); \
-            (ta)->newest_start_durable_ts =                                                \
-              WT_MAX((tw)->start_prepare_ts, (ta)->newest_start_durable_ts);               \
-        }                                                                                  \
-        (ta)->newest_txn = WT_MAX((tw)->start_txn, (ta)->newest_txn);                      \
-        /*                                                                                 \
-         * Aggregation of newest transaction is calculated from both start and             \
-         * stop transactions. Consider only valid stop transactions.                       \
-         */                                                                                \
-        if ((tw)->stop_txn != WT_TXN_MAX)                                                  \
-            (ta)->newest_txn = WT_MAX((tw)->stop_txn, (ta)->newest_txn);                   \
-        if ((tw)->stop_prepare_ts == WT_TS_NONE) {                                         \
-            (ta)->newest_stop_ts = WT_MAX((tw)->stop_ts, (ta)->newest_stop_ts);            \
-            (ta)->newest_stop_durable_ts =                                                 \
-              WT_MAX((tw)->durable_stop_ts, (ta)->newest_stop_durable_ts);                 \
-        } else {                                                                           \
-            (ta)->newest_stop_ts = WT_MAX((tw)->stop_prepare_ts, (ta)->newest_stop_ts);    \
-            (ta)->newest_stop_durable_ts =                                                 \
-              WT_MAX((tw)->stop_prepare_ts, (ta)->newest_stop_durable_ts);                 \
-        }                                                                                  \
-        (ta)->newest_stop_txn = WT_MAX((tw)->stop_txn, (ta)->newest_stop_txn);             \
-        if (WT_TIME_WINDOW_HAS_PREPARE(tw))                                                \
-            (ta)->prepare = 1;                                                             \
+#define WT_TIME_AGGREGATE_UPDATE(session, ta, tw)                                           \
+    do {                                                                                    \
+        WT_ASSERT(session, (ta)->init_merge == 1);                                          \
+        if ((tw)->start_prepare_ts == WT_TS_NONE) {                                         \
+            (ta)->oldest_start_ts = WT_MIN((tw)->start_ts, (ta)->oldest_start_ts);          \
+            (ta)->newest_start_durable_ts =                                                 \
+              WT_MAX((tw)->durable_start_ts, (ta)->newest_start_durable_ts);                \
+        } else {                                                                            \
+            (ta)->oldest_start_ts = WT_MIN((tw)->start_prepare_ts, (ta)->oldest_start_ts);  \
+            (ta)->newest_start_durable_ts =                                                 \
+              WT_MAX((tw)->start_prepare_ts, (ta)->newest_start_durable_ts);                \
+        }                                                                                   \
+        (ta)->newest_txn = WT_MAX((tw)->start_txn, (ta)->newest_txn);                       \
+        /*                                                                                  \
+         * Aggregation of newest transaction is calculated from both start and              \
+         * stop transactions. Consider only valid stop transactions.                        \
+         */                                                                                 \
+        if ((tw)->stop_txn != WT_TXN_MAX)                                                   \
+            (ta)->newest_txn = WT_MAX((tw)->stop_txn, (ta)->newest_txn);                    \
+        if ((tw)->stop_prepare_ts == WT_TS_NONE) {                                          \
+            (ta)->newest_stop_ts = WT_MAX((tw)->stop_ts, (ta)->newest_stop_ts);             \
+            (ta)->newest_stop_durable_ts =                                                  \
+              WT_MAX((tw)->durable_stop_ts, (ta)->newest_stop_durable_ts);                  \
+        } else {                                                                            \
+            (ta)->newest_stop_ts = WT_MAX((tw)->stop_prepare_ts, (ta)->newest_stop_ts);     \
+            (ta)->newest_stop_durable_ts =                                                  \
+              WT_MAX((tw)->stop_prepare_ts, (ta)->newest_stop_durable_ts);                  \
+        }                                                                                   \
+        (ta)->newest_stop_txn = WT_MAX((tw)->stop_txn, (ta)->newest_stop_txn);              \
+        /*                                                                                  \
+         * Track the smallest stop transaction so readers can test their concurrent         \
+         * snapshot against the page's stop range. Ignore records with no stop (WT_TXN_MAX) \
+         * and stops already cleared as globally visible (WT_TXN_NONE); neither constrains  \
+         * any reader.                                                                      \
+         */                                                                                 \
+        if ((tw)->stop_txn != WT_TXN_MAX && (tw)->stop_txn != WT_TXN_NONE)                  \
+            (ta)->oldest_stop_txn = WT_MIN((tw)->stop_txn, (ta)->oldest_stop_txn);          \
+        if (WT_TIME_WINDOW_HAS_PREPARE(tw))                                                 \
+            (ta)->prepare = 1;                                                              \
     } while (0)
 
 /*
@@ -230,6 +240,8 @@
         (ta)->newest_txn = WT_MAX((page_del)->txnid, (ta)->newest_txn);                   \
         (ta)->newest_stop_ts = WT_MAX((page_del)->pg_del_start_ts, (ta)->newest_stop_ts); \
         (ta)->newest_stop_txn = WT_MAX((page_del)->txnid, (ta)->newest_stop_txn);         \
+        if ((page_del)->txnid != WT_TXN_NONE)                                             \
+            (ta)->oldest_stop_txn = WT_MIN((page_del)->txnid, (ta)->oldest_stop_txn);     \
     } while (0)
 
 /* Merge an aggregated time window into another - choosing the most conservative value from each. */
@@ -244,6 +256,7 @@
         (dest)->newest_txn = WT_MAX((dest)->newest_txn, (source)->newest_txn);                \
         (dest)->newest_stop_ts = WT_MAX((dest)->newest_stop_ts, (source)->newest_stop_ts);    \
         (dest)->newest_stop_txn = WT_MAX((dest)->newest_stop_txn, (source)->newest_stop_txn); \
+        (dest)->oldest_stop_txn = WT_MIN((dest)->oldest_stop_txn, (source)->oldest_stop_txn); \
         /*                                                                                    \
          * Aggregation of newest transaction is calculated from both start and stop           \
          * transactions. Consider only valid stop transactions.                               \
@@ -284,6 +297,7 @@
         (out_ta)->newest_txn = WT_MAX((out_ta)->newest_txn, (in_ta)->newest_txn);                \
         (out_ta)->newest_stop_ts = WT_MAX((out_ta)->newest_stop_ts, (in_ta)->newest_stop_ts);    \
         (out_ta)->newest_stop_txn = WT_MAX((out_ta)->newest_stop_txn, (in_ta)->newest_stop_txn); \
+        (out_ta)->oldest_stop_txn = WT_MIN((out_ta)->oldest_stop_txn, (in_ta)->oldest_stop_txn); \
     } while (0)
 
 /* Check if the stop time aggregate is set. */

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1355,6 +1355,66 @@ __wt_txn_snap_min_visible(
 }
 
 /*
+ * __wt_txn_snapshot_intersects_range --
+ *     Return whether any id in the sorted snapshot array falls within the inclusive range [lo, hi].
+ *     The array holds the concurrent (uncommitted-at-snapshot) transaction ids in ascending order.
+ */
+static WT_INLINE bool
+__wt_txn_snapshot_intersects_range(
+  uint64_t *snapshot, uint32_t snapshot_count, uint64_t lo, uint64_t hi)
+{
+    uint32_t base, indx, limit;
+
+    /* Find the lowest index whose id is not less than lo, then test it against the upper bound. */
+    for (base = 0, limit = snapshot_count; limit != 0; limit >>= 1) {
+        indx = base + (limit >> 1);
+        if (snapshot[indx] < lo) {
+            base = indx + 1;
+            --limit;
+        }
+    }
+    return (base < snapshot_count && snapshot[base] <= hi);
+}
+
+/*
+ * __wt_txn_snap_range_visible --
+ *     Can the current transaction's snapshot see an entire range of stop transactions? Used to
+ *     decide whether a fully-deleted page can be skipped during a tree walk. Unlike
+ *     __wt_txn_snap_min_visible, which only proves visibility when the whole range sits below the
+ *     smallest concurrent transaction, this also skips when the range straddles the concurrent
+ *     window but no concurrent transaction's id falls inside it. As with the snap_min variant, this
+ *     assesses broader visibility from an aggregated time window; it does not reflect whether a
+ *     specific update is visible.
+ */
+static WT_INLINE bool
+__wt_txn_snap_range_visible(WT_SESSION_IMPL *session, uint64_t oldest_id, uint64_t newest_id,
+  wt_timestamp_t timestamp, wt_timestamp_t durable_timestamp)
+{
+    WT_TXN *txn;
+
+    txn = session->txn;
+    WT_ASSERT(session, F_ISSET(txn, WT_TXN_HAS_SNAPSHOT));
+
+    /* A stop from a transaction not committed at snapshot time (or still in flight) blocks skip. */
+    if (newest_id >= txn->snapshot_data.snap_max)
+        return (false);
+
+    /*
+     * If the whole stop range sits below the smallest concurrent transaction, every stop committed
+     * before the snapshot and is visible. Otherwise the range overlaps the concurrent window: only
+     * proceed when no concurrent transaction's id falls within the range, which proves every stop
+     * on the page committed before the snapshot.
+     */
+    if (newest_id >= txn->snapshot_data.snap_min && txn->snapshot_data.snapshot_count != 0 &&
+      __wt_txn_snapshot_intersects_range(
+        txn->snapshot_data.snapshot, txn->snapshot_data.snapshot_count, oldest_id, newest_id))
+        return (false);
+
+    /* Timestamp check. */
+    return (__wt_txn_timestamp_visible(session, timestamp, durable_timestamp));
+}
+
+/*
  * __wt_txn_visible --
  *     Can the current transaction see the given ID/timestamp?
  */

--- a/test/suite/test_checkpoint32.py
+++ b/test/suite/test_checkpoint32.py
@@ -113,5 +113,129 @@ class test_checkpoint32(wttest.WiredTigerTestCase):
         session2.close()
         cursor.close()
 
+    # As above, but hold the reader's snapshot minimum below the delete transactions with an
+    # unrelated long-running transaction. The page's stop transactions then fall in a committed gap
+    # between concurrent transactions: the snap_min bound alone cannot skip the page, but the
+    # stop-transaction range check proves every stop committed before the snapshot and can.
+    def test_checkpoint_committed_gap(self):
+        # Avoid checkpoint error with precise checkpoint
+        if self.ckpt_config == 'precise_checkpoint=true':
+            self.conn.set_timestamp('stable_timestamp=1')
+
+        uri = 'table:checkpoint32_gap'
+        nrows = 1000
+
+        # Create a table.
+        ds = SimpleDataSet(
+            self, uri, 0, key_format=self.key_format, value_format=self.value_format,
+            config=self.extraconfig)
+        ds.populate()
+
+        value_a = "aaaaa" * 100
+
+        # Write some initial data.
+        cursor = self.session.open_cursor(ds.uri, None, None)
+        for i in range(1, nrows + 1):
+            self.session.begin_transaction()
+            cursor[ds.key(i)] = value_a
+            self.session.commit_transaction()
+
+        # Start a long-running transaction that writes to an unrelated table. The write allocates a
+        # transaction id below the deletes that follow; leaving it open both pins the oldest id (so
+        # the tombstones are retained at reconciliation) and holds later readers' snapshot minimum
+        # below the delete transactions.
+        gap_uri = 'table:checkpoint32_gap_other'
+        self.session.create(gap_uri, 'key_format=S,value_format=S')
+        session_gap = self.conn.open_session()
+        session_gap.begin_transaction()
+        gap_cursor = session_gap.open_cursor(gap_uri)
+        gap_cursor['gapkey'] = 'gapval'
+
+        # Now remove all data. These commits use transaction ids above the open gap transaction.
+        for i in range(1, nrows + 1):
+            self.session.begin_transaction()
+            cursor.set_key(ds.key(i))
+            self.assertEqual(cursor.remove(), 0)
+            self.session.commit_transaction()
+
+        # Checkpoint.
+        self.session.checkpoint()
+
+        # Get the existing in-memory delete page skip statistic value.
+        prev_cur_inmem_del_page_skip = self.get_stat(stat.conn.cursor_tree_walk_inmem_del_page_skip)
+
+        # Read the removed data while the gap transaction is still open, so the reader's snapshot
+        # minimum sits below the (committed and visible) delete transactions.
+        self.check(ds, 0, value_a)
+
+        # Get the new in-memory delete page skip statistic value.
+        cur_inmem_del_page_skip = self.get_stat(stat.conn.cursor_tree_walk_inmem_del_page_skip)
+
+        self.assertGreater(cur_inmem_del_page_skip, prev_cur_inmem_del_page_skip)
+
+        # Tidy up.
+        gap_cursor.close()
+        session_gap.rollback_transaction()
+        session_gap.close()
+        cursor.close()
+
+    # Skip fully-deleted pages during the tree walk while they are on disk (the WT_REF_DISK path
+    # that reads the stop time aggregate from the parent's address cell), as opposed to the
+    # in-memory page-modify path exercised above.
+    def test_checkpoint_ondisk_skip(self):
+        # Avoid checkpoint error with precise checkpoint
+        if self.ckpt_config == 'precise_checkpoint=true':
+            self.conn.set_timestamp('stable_timestamp=1')
+
+        uri = 'table:checkpoint32_ondisk'
+        nrows = 1000
+
+        # Create a table.
+        ds = SimpleDataSet(
+            self, uri, 0, key_format=self.key_format, value_format=self.value_format,
+            config=self.extraconfig)
+        ds.populate()
+
+        value_a = "aaaaa" * 100
+
+        # Write some initial data.
+        cursor = self.session.open_cursor(ds.uri, None, None)
+        for i in range(1, nrows + 1):
+            self.session.begin_transaction()
+            cursor[ds.key(i)] = value_a
+            self.session.commit_transaction()
+
+        # Hold a reader open so the tombstones are not globally visible at checkpoint time; this
+        # forces the deleted pages to be written to disk with their stop time aggregate rather than
+        # discarded from the tree.
+        session2 = self.conn.open_session()
+        session2.begin_transaction()
+
+        # Now remove all data.
+        for i in range(1, nrows + 1):
+            self.session.begin_transaction()
+            cursor.set_key(ds.key(i))
+            self.assertEqual(cursor.remove(), 0)
+            self.session.commit_transaction()
+
+        # Checkpoint, then drop the cache so the deleted leaf pages are read back from disk. After
+        # the reopen the holding reader is gone, so the deletes are visible to a fresh reader.
+        self.session.checkpoint()
+        session2.rollback_transaction()
+        session2.close()
+        cursor.close()
+        self.reopen_conn()
+
+        # Get the existing on-disk delete page skip statistic value.
+        prev_cur_del_page_skip = self.get_stat(stat.conn.cursor_tree_walk_del_page_skip)
+
+        # Now read the removed data; the deleted pages are skipped from their on-disk address cells.
+        self.check(ds, 0, value_a)
+
+        # Get the new on-disk delete page skip statistic value.
+        cur_del_page_skip = self.get_stat(stat.conn.cursor_tree_walk_del_page_skip)
+
+        self.assertGreater(cur_del_page_skip, prev_cur_del_page_skip)
+
 if __name__ == '__main__':
     wttest.run()


### PR DESCRIPTION
During a tree walk, a fully-deleted page can only be skipped when its entire stop-transaction range sits below the reader's snapshot minimum, because the page aggregate carries just the newest (maximum) stop transaction. This is conservative: pages whose deletes committed in a gap between concurrent transactions are read even though every delete is visible to the reader.

This tracks the smallest stop transaction in the in-memory page-modify time aggregate and uses a range visibility check on the in-memory skip path, allowing a page to be skipped when no concurrent transaction falls within the page's stop-transaction range. The new field is in-memory only and is never packed into a cell, so there is no on-disk format change. The on-disk address-cell skip path is unchanged.