### PR TITLE
WT-15078 Fix session_get_dhandle returning EBUSY leaves hanging handle

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -969,6 +969,7 @@ durabletime
 dv
 dylib
 eb
+ebusy
 eee
 eg
 ejnprx

--- a/src/schema/schema_drop.c
+++ b/src/schema/schema_drop.c
@@ -133,10 +133,7 @@ __drop_index(
 static int
 __drop_issue_trim(WT_SESSION_IMPL *session, const char *uri)
 {
-    WT_BTREE *btree;
     WT_DECL_RET;
-
-    btree = NULL;
 
     /* Get the layered data handle. */
     ret = __wt_session_get_dhandle(session, uri, NULL, NULL, WT_DHANDLE_EXCLUSIVE);
@@ -144,7 +141,7 @@ __drop_issue_trim(WT_SESSION_IMPL *session, const char *uri)
         WT_RET_SUB(session, ret, WT_CONFLICT_DHANDLE, WT_CONFLICT_DHANDLE_MSG);
     WT_RET(ret);
 
-    btree = S2BT(session);
+    WT_BTREE *btree = S2BT(session);
 
     if (btree->page_log == NULL)
         WT_ERR(ENOTSUP);

--- a/src/schema/schema_drop.c
+++ b/src/schema/schema_drop.c
@@ -140,10 +140,11 @@ __drop_issue_trim(WT_SESSION_IMPL *session, const char *uri)
 
     /* Get the layered data handle. */
     ret = __wt_session_get_dhandle(session, uri, NULL, NULL, WT_DHANDLE_EXCLUSIVE);
-    btree = S2BT(session);
     if (ret == EBUSY)
         WT_RET_SUB(session, ret, WT_CONFLICT_DHANDLE, WT_CONFLICT_DHANDLE_MSG);
     WT_RET(ret);
+
+    btree = S2BT(session);
 
     if (btree->page_log == NULL)
         WT_ERR(ENOTSUP);

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -936,7 +936,10 @@ __wt_session_get_dhandle(WT_SESSION_IMPL *session, const char *uri, const char *
         dhandle = session->dhandle;
 
         /* Try to lock the handle. */
-        WT_RET(__wt_session_lock_dhandle(session, flags, &is_dead));
+        if ((ret = __wt_session_lock_dhandle(session, flags, &is_dead)) != 0) {
+            WT_DHANDLE_CLEAR(session);
+            return (ret);
+        }
         if (is_dead)
             continue;
 

--- a/src/session/session_dhandle.c
+++ b/src/session/session_dhandle.c
@@ -932,14 +932,11 @@ __wt_session_get_dhandle(WT_SESSION_IMPL *session, const char *uri, const char *
     WT_ASSERT(session, !F_ISSET(session, WT_SESSION_NO_DATA_HANDLES));
 
     for (;;) {
-        WT_RET(__session_get_dhandle(session, uri, checkpoint));
+        WT_ERR(__session_get_dhandle(session, uri, checkpoint));
         dhandle = session->dhandle;
 
         /* Try to lock the handle. */
-        if ((ret = __wt_session_lock_dhandle(session, flags, &is_dead)) != 0) {
-            WT_DHANDLE_CLEAR(session);
-            return (ret);
-        }
+        WT_ERR(__wt_session_lock_dhandle(session, flags, &is_dead));
         if (is_dead)
             continue;
 
@@ -1007,7 +1004,7 @@ __wt_session_get_dhandle(WT_SESSION_IMPL *session, const char *uri, const char *
         dhandle->excl_ref = 0;
         F_CLR(dhandle, WT_DHANDLE_EXCLUSIVE);
         WT_WITH_DHANDLE(session, dhandle, __wt_session_dhandle_writeunlock(session));
-        WT_RET(ret);
+        WT_ERR(ret);
     }
 
     WT_ASSERT(session, !F_ISSET(dhandle, WT_DHANDLE_DEAD));
@@ -1017,7 +1014,10 @@ __wt_session_get_dhandle(WT_SESSION_IMPL *session, const char *uri, const char *
       LF_ISSET(WT_DHANDLE_EXCLUSIVE) == F_ISSET(dhandle, WT_DHANDLE_EXCLUSIVE) ||
         dhandle->excl_ref > 1);
 
-    return (0);
+err:
+    if (ret != 0 && session->dhandle != NULL)
+        WT_DHANDLE_CLEAR(session);
+    return (ret);
 }
 
 /*

--- a/test/catch2/CMakeLists.txt
+++ b/test/catch2/CMakeLists.txt
@@ -13,6 +13,7 @@ else()
         misc_tests/test_checkpoint_skip.cpp
         misc_tests/test_config.cpp
         misc_tests/test_crc32.cpp
+        misc_tests/test_dhandle_ebusy.cpp
         misc_tests/test_disagg_block_header_version.cpp
         misc_tests/test_disagg_meta_config.cpp
         misc_tests/test_error.cpp

--- a/test/catch2/misc_tests/test_dhandle_ebusy.cpp
+++ b/test/catch2/misc_tests/test_dhandle_ebusy.cpp
@@ -29,19 +29,23 @@ TEST_CASE("session->dhandle is NULL after EBUSY from get_dhandle", "[dhandle]")
     {
         connection_wrapper conn(home);
 
-        WT_SESSION_IMPL *s1 = conn.create_session();
-        WT_SESSION *pub_s1 = &s1->iface;
-        REQUIRE(pub_s1->create(pub_s1, "file:t.wt", "key_format=i,value_format=i") == 0);
+        WT_SESSION_IMPL *session_impl = conn.create_session();
+        WT_SESSION *session = &session_impl->iface;
+        REQUIRE(session->create(session, "file:t.wt", "key_format=i,value_format=i") == 0);
 
+        /*
+         * Opening a bulk cursor is one way to set the special flag on the dhandle, which prevents
+         * other sessions from locking it.
+         */
         WT_CURSOR *bulk = nullptr;
-        REQUIRE(pub_s1->open_cursor(pub_s1, "file:t.wt", nullptr, "bulk", &bulk) == 0);
+        REQUIRE(session->open_cursor(session, "file:t.wt", nullptr, "bulk", &bulk) == 0);
 
-        WT_SESSION_IMPL *s2 = conn.create_session();
-        REQUIRE(s2->dhandle == nullptr);
+        WT_SESSION_IMPL *session_impl_b = conn.create_session();
+        REQUIRE(session_impl_b->dhandle == nullptr);
 
-        int ret = __wt_session_get_dhandle(s2, "file:t.wt", nullptr, nullptr, 0);
+        int ret = __wt_session_get_dhandle(session_impl_b, "file:t.wt", nullptr, nullptr, 0);
         REQUIRE(ret == EBUSY);
-        CHECK(s2->dhandle == nullptr);
+        CHECK(session_impl_b->dhandle == nullptr);
 
         REQUIRE(bulk->close(bulk) == 0);
     }

--- a/test/catch2/misc_tests/test_dhandle_ebusy.cpp
+++ b/test/catch2/misc_tests/test_dhandle_ebusy.cpp
@@ -11,11 +11,6 @@
  * (bulk/salvage/verify), the session's dhandle ref must be cleared to NULL. Leaving it set exposes
  * callers to a handle they never locked, which can corrupt the dhandle's lock state if they attempt
  * to release it.
- *
- * The public API wraps every call in a push/pop macro, which saves and restores the session's
- * dhandle ref, so the stale pointer never escapes to application code. The bug only affects
- * internal callers that attempt to get dhandles directly, such as the checkpoint and
- * checkpoint-cleanup paths.
  */
 
 #include <catch2/catch.hpp>

--- a/test/catch2/misc_tests/test_dhandle_ebusy.cpp
+++ b/test/catch2/misc_tests/test_dhandle_ebusy.cpp
@@ -7,8 +7,6 @@
  */
 
 /*
- * WT-15078: session_get_dhandle returning EBUSY leaves hanging handle.
- *
  * When __wt_session_lock_dhandle returns EBUSY because the btree has
  * WT_BTREE_SPECIAL_FLAGS (bulk/salvage/verify), session->dhandle must be
  * cleared to NULL.  Leaving it set exposes callers to a handle they never
@@ -30,9 +28,9 @@
 #include "../wrappers/connection_wrapper.h"
 #include "../../utility/test_util.h"
 
-TEST_CASE("WT-15078: session->dhandle is NULL after EBUSY from get_dhandle", "[dhandle][WT-15078]")
+TEST_CASE("session->dhandle is NULL after EBUSY from get_dhandle", "[dhandle]")
 {
-    const std::string home = "WT_TEST.wt15078_dhandle_ebusy";
+    const std::string home = "WT_TEST.dhandle_ebusy";
     testutil_system("rm -rf %s && mkdir -p %s", home.c_str(), home.c_str());
 
     {
@@ -40,36 +38,16 @@ TEST_CASE("WT-15078: session->dhandle is NULL after EBUSY from get_dhandle", "[d
 
         WT_SESSION_IMPL *s1 = conn.create_session();
         WT_SESSION *pub_s1 = &s1->iface;
-
         REQUIRE(pub_s1->create(pub_s1, "file:t.wt", "key_format=i,value_format=i") == 0);
 
-        /*
-         * Open a bulk cursor: this sets WT_BTREE_BULK on the btree and holds
-         * the dhandle exclusively.  While the cursor is open, any other
-         * session calling __wt_session_lock_dhandle on the same file will hit
-         * the WT_BTREE_SPECIAL_FLAGS check and return EBUSY.
-         */
         WT_CURSOR *bulk = nullptr;
         REQUIRE(pub_s1->open_cursor(pub_s1, "file:t.wt", nullptr, "bulk", &bulk) == 0);
 
         WT_SESSION_IMPL *s2 = conn.create_session();
-
         REQUIRE(s2->dhandle == nullptr);
 
-        /*
-         * Call the internal function directly to bypass the API_SESSION_POP
-         * mechanism, which would otherwise restore session->dhandle on return.
-         * This is the path taken by internal subsystems (checkpoint, RTS, …).
-         */
         int ret = __wt_session_get_dhandle(s2, "file:t.wt", nullptr, nullptr, 0);
         REQUIRE(ret == EBUSY);
-
-        /*
-         * This is the invariant WT-15078 requires: session->dhandle must be
-         * NULL after a failed get.  Before the fix it is left pointing at the
-         * bulk-loaded handle, giving callers the illusion that a lock was
-         * acquired.
-         */
         CHECK(s2->dhandle == nullptr);
 
         REQUIRE(bulk->close(bulk) == 0);

--- a/test/catch2/misc_tests/test_dhandle_ebusy.cpp
+++ b/test/catch2/misc_tests/test_dhandle_ebusy.cpp
@@ -7,17 +7,16 @@
  */
 
 /*
- * When __wt_session_lock_dhandle returns EBUSY because the btree has
- * WT_BTREE_SPECIAL_FLAGS (bulk/salvage/verify), session->dhandle must be
+ * When attempting to lock a dhandle returns EBUSY because the btree has
+ * special flags set (bulk/salvage/verify), the session's dhandle ref must be
  * cleared to NULL.  Leaving it set exposes callers to a handle they never
  * locked, which can corrupt the dhandle's lock state if they attempt to
  * release it.
  *
- * The public API wraps every call in API_SESSION_PUSH/POP, which saves and
- * restores session->dhandle, so the stale pointer never escapes to
- * application code.  The bug only affects internal callers that invoke
- * __wt_session_get_dhandle directly, such as the checkpoint and
- * checkpoint-cleanup paths.
+ * The public API wraps every call in a push/pop macro, which saves and
+ * restores the session's dhandle ref, so the stale pointer never escapes to
+ * application code.  The bug only affects internal callers that attempt to
+ * get dhandles directly, such as the checkpoint and checkpoint-cleanup paths.
  */
 
 #include <catch2/catch.hpp>

--- a/test/catch2/misc_tests/test_dhandle_ebusy.cpp
+++ b/test/catch2/misc_tests/test_dhandle_ebusy.cpp
@@ -21,7 +21,7 @@
 #include "../wrappers/connection_wrapper.h"
 #include "../../utility/test_util.h"
 
-TEST_CASE("session->dhandle is NULL after EBUSY from get_dhandle", "[dhandle]")
+TEST_CASE("session->dhandle is NULL after EBUSY from get_dhandle", "[dhandle][dhandle_ebusy]")
 {
     const std::string home = "WT_TEST.dhandle_ebusy";
     testutil_system("rm -rf %s && mkdir -p %s", home.c_str(), home.c_str());

--- a/test/catch2/misc_tests/test_dhandle_ebusy.cpp
+++ b/test/catch2/misc_tests/test_dhandle_ebusy.cpp
@@ -7,16 +7,15 @@
  */
 
 /*
- * When attempting to lock a dhandle returns EBUSY because the btree has
- * special flags set (bulk/salvage/verify), the session's dhandle ref must be
- * cleared to NULL.  Leaving it set exposes callers to a handle they never
- * locked, which can corrupt the dhandle's lock state if they attempt to
- * release it.
+ * When attempting to lock a dhandle returns EBUSY because the btree has special flags set
+ * (bulk/salvage/verify), the session's dhandle ref must be cleared to NULL. Leaving it set exposes
+ * callers to a handle they never locked, which can corrupt the dhandle's lock state if they attempt
+ * to release it.
  *
- * The public API wraps every call in a push/pop macro, which saves and
- * restores the session's dhandle ref, so the stale pointer never escapes to
- * application code.  The bug only affects internal callers that attempt to
- * get dhandles directly, such as the checkpoint and checkpoint-cleanup paths.
+ * The public API wraps every call in a push/pop macro, which saves and restores the session's
+ * dhandle ref, so the stale pointer never escapes to application code. The bug only affects
+ * internal callers that attempt to get dhandles directly, such as the checkpoint and
+ * checkpoint-cleanup paths.
  */
 
 #include <catch2/catch.hpp>

--- a/test/catch2/misc_tests/test_dhandle_ebusy.cpp
+++ b/test/catch2/misc_tests/test_dhandle_ebusy.cpp
@@ -1,0 +1,79 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+/*
+ * WT-15078: session_get_dhandle returning EBUSY leaves hanging handle.
+ *
+ * When __wt_session_lock_dhandle returns EBUSY because the btree has
+ * WT_BTREE_SPECIAL_FLAGS (bulk/salvage/verify), session->dhandle must be
+ * cleared to NULL.  Leaving it set exposes callers to a handle they never
+ * locked, which can corrupt the dhandle's lock state if they attempt to
+ * release it.
+ *
+ * The public API wraps every call in API_SESSION_PUSH/POP, which saves and
+ * restores session->dhandle, so the stale pointer never escapes to
+ * application code.  The bug only affects internal callers that invoke
+ * __wt_session_get_dhandle directly, such as the checkpoint and
+ * checkpoint-cleanup paths.
+ */
+
+#include <catch2/catch.hpp>
+
+#include "wiredtiger.h"
+#include "wt_internal.h"
+#include "../utils.h"
+#include "../wrappers/connection_wrapper.h"
+#include "../../utility/test_util.h"
+
+TEST_CASE("WT-15078: session->dhandle is NULL after EBUSY from get_dhandle", "[dhandle][WT-15078]")
+{
+    const std::string home = "WT_TEST.wt15078_dhandle_ebusy";
+    testutil_system("rm -rf %s && mkdir -p %s", home.c_str(), home.c_str());
+
+    {
+        connection_wrapper conn(home);
+
+        WT_SESSION_IMPL *s1 = conn.create_session();
+        WT_SESSION *pub_s1 = &s1->iface;
+
+        REQUIRE(pub_s1->create(pub_s1, "file:t.wt", "key_format=i,value_format=i") == 0);
+
+        /*
+         * Open a bulk cursor: this sets WT_BTREE_BULK on the btree and holds
+         * the dhandle exclusively.  While the cursor is open, any other
+         * session calling __wt_session_lock_dhandle on the same file will hit
+         * the WT_BTREE_SPECIAL_FLAGS check and return EBUSY.
+         */
+        WT_CURSOR *bulk = nullptr;
+        REQUIRE(pub_s1->open_cursor(pub_s1, "file:t.wt", nullptr, "bulk", &bulk) == 0);
+
+        WT_SESSION_IMPL *s2 = conn.create_session();
+
+        REQUIRE(s2->dhandle == nullptr);
+
+        /*
+         * Call the internal function directly to bypass the API_SESSION_POP
+         * mechanism, which would otherwise restore session->dhandle on return.
+         * This is the path taken by internal subsystems (checkpoint, RTS, …).
+         */
+        int ret = __wt_session_get_dhandle(s2, "file:t.wt", nullptr, nullptr, 0);
+        REQUIRE(ret == EBUSY);
+
+        /*
+         * This is the invariant WT-15078 requires: session->dhandle must be
+         * NULL after a failed get.  Before the fix it is left pointing at the
+         * bulk-loaded handle, giving callers the illusion that a lock was
+         * acquired.
+         */
+        CHECK(s2->dhandle == nullptr);
+
+        REQUIRE(bulk->close(bulk) == 0);
+    }
+
+    utils::wiredtiger_cleanup(home);
+}


### PR DESCRIPTION
I have added a `WT_DHANDLE_CLEAR` call after a failed `__wt_session_lock_dhandle` attempt inside `__wt_session_get_dhandle`, so that the session is not left with a reference to the dhandle.

I also fixed a resulting null-dereference in `__drop_issue_trim`, and added a catch2 test that affirms the correct behavior.