### PR TITLE
WT-17326 Zero the full page+block header in overflow record writes

### DIFF
--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -3511,6 +3511,8 @@ __wti_rec_cell_build_ovfl(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_KV
         /* Initialize the buffer: disk header and overflow record. */
         dsk = tmp->mem;
         memset(dsk, 0, WT_PAGE_HEADER_SIZE);
+        /* Clear the memory owned by the block manager. */
+        memset(WT_BLOCK_HEADER_REF(dsk), 0, btree->block_header);
         dsk->type = WT_PAGE_OVFL;
         __rec_set_page_write_gen(btree, dsk);
         dsk->u.datalen = (uint32_t)kv->buf.size;


### PR DESCRIPTION
## Summary

`__wti_rec_cell_build_ovfl` called `memset(dsk, 0, WT_PAGE_HEADER_SIZE)`, zeroing only 28 bytes and leaving the block header fields (`disk_size`, `checksum`, `flags`, `unused[3]`) at bytes [28..39] uninitialized. These bytes are then passed through the compression and encryption paths, where MSan detects a use of uninitialized memory.

The regular-page path in `__rec_split_write_header` already zeroes the full header via `memset(WT_BLOCK_HEADER_REF(dsk), 0, btree->block_header)`. This change applies the same coverage to overflow pages by extending the `memset` to `WT_PAGE_HEADER_BYTE_SIZE(btree)` (28 + 12 = 40 bytes).