### PR TITLE
WT-17899 Prevent the reopening of the stable cursor during a prepare conflict stall

### DIFF
--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -409,6 +409,17 @@ __clayered_open_stable(
 }
 
 /*
+ * __clayered_ingest_prepare_stalled --
+ *     Determine if the ingest cursor is on a prepare conflict.
+ */
+static WT_INLINE bool
+__clayered_ingest_prepare_stalled(const WT_CURSOR *current, const WT_CURSOR *ingest)
+{
+    return (ingest != NULL && current == ingest && !F_ISSET(ingest, WT_CURSTD_KEY_INT) &&
+      ((const WT_CURSOR_BTREE *)ingest)->ref != NULL);
+}
+
+/*
  * __clayered_can_advance_stable --
  *     Return true if the stable cursor can be advanced to a newer checkpoint at this time.
  */
@@ -426,6 +437,13 @@ __clayered_can_advance_stable(WTI_CURSOR_LAYERED *clayered, uint64_t conn_lsn, b
 
     /* No need to advance if there is no newer checkpoint. */
     if (clayered->stable_checkpoint_meta_lsn == conn_lsn)
+        return (false);
+
+    /*
+     * Do not advance while ingest is stalled on a prepare conflict with no key. Stable could lose
+     * its position with no ingest key to recover it, skipping visible keys.
+     */
+    if (__clayered_ingest_prepare_stalled(clayered->current_cursor, clayered->ingest_cursor))
         return (false);
 
     /*
@@ -562,9 +580,15 @@ __clayered_update_state(WTI_CURSOR_LAYERED *clayered, WTI_CLAYERED_ROLE role)
      * If the transaction context has changed since the last call (different read timestamp or a new
      * snapshot), the parked alternate cursor's cached position may be stale. Clear the iteration
      * flags to force a re-search under the new context.
+     *
+     * FIXME-WT-17960: a context change while ingest is stalled on a prepare conflict leaves stable
+     * parked under the old context with no anchor to re-search it from.
      */
-    if (clayered->snapshot_gen != snapshot_gen || clayered->read_timestamp != read_timestamp)
+    if (clayered->snapshot_gen != snapshot_gen || clayered->read_timestamp != read_timestamp) {
+        WT_ASSERT(session,
+          !__clayered_ingest_prepare_stalled(clayered->current_cursor, clayered->ingest_cursor));
         F_CLR(clayered, WTI_CLAYERED_ITERATE_NEXT | WTI_CLAYERED_ITERATE_PREV);
+    }
 
     clayered->snapshot_gen = snapshot_gen;
     clayered->read_timestamp = read_timestamp;

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -416,7 +416,7 @@ static WT_INLINE bool
 __clayered_ingest_prepare_stalled(const WT_CURSOR *current, const WT_CURSOR *ingest)
 {
     return (ingest != NULL && current == ingest && !F_ISSET(ingest, WT_CURSTD_KEY_INT) &&
-      ((const WT_CURSOR_BTREE *)ingest)->ref != NULL);
+      ((WT_CURSOR_BTREE *)ingest)->ref != NULL);
 }
 
 /*

--- a/test/suite/test_layered_prepare10.py
+++ b/test/suite/test_layered_prepare10.py
@@ -36,10 +36,10 @@ from wiredtiger import WiredTigerError
 @disagg_test_class
 class test_layered_prepare10(wttest.WiredTigerTestCase):
     """
-    A reader stalls mid-walk on a prepared update, leaving the ingest cursor with no key but still
-    positioned. While it is stalled, the parked stable key is deleted by a newer checkpoint that
-    the follower picks up. Once the conflict resolves, the walk must still return every other
-    visible key.
+    A reader stalls mid-walk on a prepare transaction, leaving the ingest cursor with no key but
+    still positioned. While it is stalled, the key that the stable cursor is on is deleted by a
+    newer checkpoint that the follower picks up. Once the conflict resolves, the walk must still
+    return every other visible key.
     """
 
     uri = f"layered:{__qualname__}"
@@ -48,34 +48,22 @@ class test_layered_prepare10(wttest.WiredTigerTestCase):
 
     disagg_storages = gen_disagg_storages(disagg_only=True)
 
-    # Stable keys serve all scenarios.
     STABLE_KEYS = (4, 6, 8)
+    INGEST_KEYS = (1, 5, 7, 11)
+
+    # The prepared key needs to be before the stable range (LHS for forward and RHS for backward).
+    # This is to demonstrate the worst case, as no stable keys will have been given to the user yet.
     scenarios = make_scenarios(
         disagg_storages,
         [
-            # Merged walk 1, [3 prepared], 4, 5, 6, 8. Returns 1, then stalls on the prepare,
-            # with the stable block (4, 6, 8) still ahead, so a dropped stable key is observable.
-            (
-                "forward",
-                dict(
-                    forward=True,
-                    ingest=(1, 5),
-                    prepared=3,
-                    all_keys=[1, 4, 5, 6, 8],
-                ),
-            ),
-            # Mirror is 11, [9 prepared], 8, 7, 6, 4. Only ingest and prepared flip per direction.
-            (
-                "backward",
-                dict(
-                    forward=False,
-                    ingest=(7, 11),
-                    prepared=9,
-                    all_keys=[11, 8, 7, 6, 4],
-                ),
-            ),
+            ("forward", dict(forward=True, prepared_key=3)),
+            ("backward", dict(forward=False, prepared_key=9)),
         ],
     )
+
+    @property
+    def walk_order(self):
+        return sorted((*self.INGEST_KEYS, *self.STABLE_KEYS), reverse=not self.forward)
 
     def setUp(self):
         super().setUp()
@@ -91,6 +79,9 @@ class test_layered_prepare10(wttest.WiredTigerTestCase):
             self._commit(self.session, key, "stable", stable_ts)
         self._leader_checkpoint(stable_ts)
 
+    def _follower_session(self):
+        return closing(self.follower.open_session())
+
     def _setup_follower(self):
         self.follower = self.wiredtiger_open(
             "follower",
@@ -98,8 +89,8 @@ class test_layered_prepare10(wttest.WiredTigerTestCase):
             f'disaggregated=(role="follower")',
         )
         self.disagg_advance_checkpoint(self.follower)
-        with closing(self.follower.open_session()) as session:
-            for key in self.ingest:
+        with self._follower_session() as session:
+            for key in self.INGEST_KEYS:
                 self._commit(session, key, "ingest", 22)
 
     def _commit(self, session, key, value, ts):
@@ -117,75 +108,75 @@ class test_layered_prepare10(wttest.WiredTigerTestCase):
             cursor.set_key(key)
             self.assertEqual(cursor.remove(), 0)
 
-    def _leader_checkpoint(self, stable):
-        self.conn.set_timestamp(f"stable_timestamp={self.timestamp_str(stable)}")
+    def _leader_checkpoint(self, ts):
+        self.conn.set_timestamp(f"stable_timestamp={self.timestamp_str(ts)}")
         self.session.checkpoint()
 
-    def _prepared_session(self):
-        session = self.follower.open_session()
+    def _start_prepare_txn(self, session):
         session.begin_transaction()
         with wttest.open_cursor(session, self.uri) as cursor:
-            cursor[self.prepared] = "prepared"
+            cursor[self.prepared_key] = "prepared"
         session.prepare_transaction(
             f"prepare_timestamp={self.timestamp_str(25)},"
             f"prepared_id={self.prepared_id_str(1)}"
         )
-        return session
+
+    def _rollback_prepare_txn(self, session):
+        session.rollback_transaction(f"rollback_timestamp={self.timestamp_str(35)}")
 
     @contextmanager
-    def _prepare_stalled_reader(self, seen_keys, ts):
-        """Walk a reader onto the prepared key so the ingest cursor stalls with no key."""
-        with (
-            closing(self._prepared_session()) as prep_session,
-            closing(self.follower.open_session()) as reader,
-            self.transaction(
-                session=reader,
-                read_timestamp=ts,
-                rollback=True,
-            ),
-            closing(reader.open_cursor(self.uri)) as read_cursor,
-        ):
-            step = read_cursor.next if self.forward else read_cursor.prev
+    def _during_prepare_txn_stall(self, read_ts, seen_keys):
+        """
+        Stall a reader on the prepared key for the relevant test. On exit, rollback the prepare txn
+        and record the rest of the cursor walk into seen_keys.
+        """
 
-            # Surface the first key, then stall advancing onto the prepared update.
+        with (
+            self._follower_session() as prepared_session,
+            self._follower_session() as read_session,
+            wttest.open_cursor(read_session, self.uri) as read_cursor,
+        ):
+            self._start_prepare_txn(prepared_session)
+            read_session.begin_transaction(
+                f"read_timestamp={self.timestamp_str(read_ts)}"
+            )
+
+            # Stall the reader on the prepare conflict.
+            step = read_cursor.next if self.forward else read_cursor.prev
             self.assertEqual(step(), 0)
             seen_keys.append(read_cursor.get_key())
             self.assertRaisesException(
-                WiredTigerError,
-                step,
-                "/conflict with a prepared update/",
+                WiredTigerError, step, "/conflict with a prepared update/"
             )
 
-            try:
-                yield
-            finally:
-                prep_session.rollback_transaction(
-                    f"rollback_timestamp={self.timestamp_str(35)}"
-                )
+            yield
+
+            self._rollback_prepare_txn(prepared_session)
             while step() == 0:
                 seen_keys.append(read_cursor.get_key())
+            read_session.rollback_transaction()
 
     def test_reopen_notfound_while_ingest_stalled(self):
-        """The parked stable key is deleted in a newer checkpoint."""
-        # The stable cursor parks on the first stable key the walk reaches in this direction.
-        parked_key = self.STABLE_KEYS[0] if self.forward else self.STABLE_KEYS[-1]
+        """The key that the stable cursor is on is deleted in a newer checkpoint."""
+
+        # The first key (depending on direction) is what the stable cursor will be positioned on.
+        parked_stable_key = self.STABLE_KEYS[0] if self.forward else self.STABLE_KEYS[-1]
+        delete_ts = 28
 
         # Simulate the oplog delete landing in the follower's ingest before the read (a tombstone),
         # so the key stays masked regardless of the stable checkpoint.
-        delete_ts = 28
-        with closing(self.follower.open_session()) as session:
-            self._remove(session, parked_key, delete_ts)
+        with self._follower_session() as session:
+            self._remove(session, parked_stable_key, delete_ts)
 
-        seen_keys = []
         read_ts = 30
-        with self._prepare_stalled_reader(seen_keys, read_ts):
-            # The same delete lands in a newer checkpoint the follower then picks up mid-stall.
-            self._remove(self.session, parked_key, delete_ts)
+        seen_keys = []
+        with self._during_prepare_txn_stall(read_ts, seen_keys):
+            self._remove(self.session, parked_stable_key, delete_ts)
             self._leader_checkpoint(read_ts)
             self.disagg_advance_checkpoint(self.follower)
 
         # The deleted key should not be visible.
-        expected = [k for k in self.all_keys if k != parked_key]
+        expected = [k for k in self.walk_order if k != parked_stable_key]
         self.assertEqual(seen_keys, expected, "the walk lost a visible key")
 
 

--- a/test/suite/test_layered_prepare10.py
+++ b/test/suite/test_layered_prepare10.py
@@ -51,8 +51,9 @@ class test_layered_prepare10(wttest.WiredTigerTestCase):
     STABLE_KEYS = (4, 6, 8)
     INGEST_KEYS = (1, 5, 7, 11)
 
-    # The prepared key needs to be before the stable range (LHS for forward and RHS for backward).
-    # This is to demonstrate the worst case, as no stable keys will have been given to the user yet.
+    # The prepared key sits just before the stable range (either below it for forward or above it
+    # for backward). This is to demonstrate the worst case where no stable keys have been returned
+    # to the user yet.
     scenarios = make_scenarios(
         disagg_storages,
         [

--- a/test/suite/test_layered_prepare10.py
+++ b/test/suite/test_layered_prepare10.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+from contextlib import closing, contextmanager
+from helper_disagg import disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
+import wttest
+from wiredtiger import WiredTigerError
+
+
+@disagg_test_class
+class test_layered_prepare10(wttest.WiredTigerTestCase):
+    """
+    A reader stalls mid-walk on a prepared update, leaving the ingest cursor with no key but still
+    positioned. While it is stalled, the parked stable key is deleted by a newer checkpoint that
+    the follower picks up. Once the conflict resolves, the walk must still return every other
+    visible key.
+    """
+
+    uri = f"layered:{__qualname__}"
+    BASE_CONFIG = "statistics=(all),precise_checkpoint=true,preserve_prepared=true"
+    conn_config = BASE_CONFIG + ',disaggregated=(role="leader")'
+
+    disagg_storages = gen_disagg_storages(disagg_only=True)
+
+    # Stable keys serve all scenarios.
+    STABLE_KEYS = (4, 6, 8)
+    scenarios = make_scenarios(
+        disagg_storages,
+        [
+            # Merged walk 1, [3 prepared], 4, 5, 6, 8. Returns 1, then stalls on the prepare,
+            # with the stable block (4, 6, 8) still ahead, so a dropped stable key is observable.
+            (
+                "forward",
+                dict(
+                    forward=True,
+                    ingest=(1, 5),
+                    prepared=3,
+                    all_keys=[1, 4, 5, 6, 8],
+                ),
+            ),
+            # Mirror is 11, [9 prepared], 8, 7, 6, 4. Only ingest and prepared flip per direction.
+            (
+                "backward",
+                dict(
+                    forward=False,
+                    ingest=(7, 11),
+                    prepared=9,
+                    all_keys=[11, 8, 7, 6, 4],
+                ),
+            ),
+        ],
+    )
+
+    def setUp(self):
+        super().setUp()
+        self._setup_leader()
+        self._setup_follower()
+
+    def _setup_leader(self):
+        oldest = self.timestamp_str(10)
+        self.conn.set_timestamp(f"oldest_timestamp={oldest},stable_timestamp={oldest}")
+        self.session.create(self.uri, "key_format=i,value_format=S")
+        stable_ts = 20
+        for key in self.STABLE_KEYS:
+            self._commit(self.session, key, "stable", stable_ts)
+        self._leader_checkpoint(stable_ts)
+
+    def _setup_follower(self):
+        self.follower = self.wiredtiger_open(
+            "follower",
+            f"{self.extensionsConfig()},create,{self.BASE_CONFIG},"
+            f'disaggregated=(role="follower")',
+        )
+        self.disagg_advance_checkpoint(self.follower)
+        with closing(self.follower.open_session()) as session:
+            for key in self.ingest:
+                self._commit(session, key, "ingest", 22)
+
+    def _commit(self, session, key, value, ts):
+        with (
+            wttest.open_cursor(session, self.uri) as cursor,
+            self.transaction(session=session, commit_timestamp=ts),
+        ):
+            cursor[key] = value
+
+    def _remove(self, session, key, ts):
+        with (
+            wttest.open_cursor(session, self.uri) as cursor,
+            self.transaction(session=session, commit_timestamp=ts),
+        ):
+            cursor.set_key(key)
+            self.assertEqual(cursor.remove(), 0)
+
+    def _leader_checkpoint(self, stable):
+        self.conn.set_timestamp(f"stable_timestamp={self.timestamp_str(stable)}")
+        self.session.checkpoint()
+
+    def _prepared_session(self):
+        session = self.follower.open_session()
+        session.begin_transaction()
+        with wttest.open_cursor(session, self.uri) as cursor:
+            cursor[self.prepared] = "prepared"
+        session.prepare_transaction(
+            f"prepare_timestamp={self.timestamp_str(25)},"
+            f"prepared_id={self.prepared_id_str(1)}"
+        )
+        return session
+
+    @contextmanager
+    def _prepare_stalled_reader(self, seen_keys, ts):
+        """Walk a reader onto the prepared key so the ingest cursor stalls with no key."""
+        with (
+            closing(self._prepared_session()) as prep_session,
+            closing(self.follower.open_session()) as reader,
+            self.transaction(
+                session=reader,
+                read_timestamp=ts,
+                rollback=True,
+            ),
+            closing(reader.open_cursor(self.uri)) as read_cursor,
+        ):
+            step = read_cursor.next if self.forward else read_cursor.prev
+
+            # Surface the first key, then stall advancing onto the prepared update.
+            self.assertEqual(step(), 0)
+            seen_keys.append(read_cursor.get_key())
+            self.assertRaisesException(
+                WiredTigerError,
+                step,
+                "/conflict with a prepared update/",
+            )
+
+            try:
+                yield
+            finally:
+                prep_session.rollback_transaction(
+                    f"rollback_timestamp={self.timestamp_str(35)}"
+                )
+            while step() == 0:
+                seen_keys.append(read_cursor.get_key())
+
+    def test_reopen_notfound_while_ingest_stalled(self):
+        """The parked stable key is deleted in a newer checkpoint."""
+        # The stable cursor parks on the first stable key the walk reaches in this direction.
+        parked_key = self.STABLE_KEYS[0] if self.forward else self.STABLE_KEYS[-1]
+
+        # Simulate the oplog delete landing in the follower's ingest before the read (a tombstone),
+        # so the key stays masked regardless of the stable checkpoint.
+        delete_ts = 28
+        with closing(self.follower.open_session()) as session:
+            self._remove(session, parked_key, delete_ts)
+
+        seen_keys = []
+        read_ts = 30
+        with self._prepare_stalled_reader(seen_keys, read_ts):
+            # The same delete lands in a newer checkpoint the follower then picks up mid-stall.
+            self._remove(self.session, parked_key, delete_ts)
+            self._leader_checkpoint(read_ts)
+            self.disagg_advance_checkpoint(self.follower)
+
+        # The deleted key should not be visible.
+        expected = [k for k in self.all_keys if k != parked_key]
+        self.assertEqual(seen_keys, expected, "the walk lost a visible key")
+
+
+if __name__ == "__main__":
+    wttest.run()


### PR DESCRIPTION
If a reader is stalled on a prepared update, a few things can change underneath it resulting in the clearing of iteration flags:

- The key the stable cursor is parked on can be deleted when a new checkpoint is picked up
- The reader's snapshot can be refreshed
- The read timestamp can change

In all three cases we currently hit an assertion where we expect the iteration flags to still be set whenever the ingest cursor is keyless. That is true when the stall begins, but the three changes above clear the iteration flags while the stall is still in progress.

In this particular BF, the problem is the first one (checkpoint). There is no resetting of the snapshot, and the read timestamp is fixed. The immediate solution is to prevent the reopening of the stable cursor during this situation. For now I have put an assertion for the snapshot/timestamp case.

Refer to the following tickets for more information:
- https://jira.mongodb.org/browse/BF-43990
- https://jira.mongodb.org/browse/WT-17899