### PR TITLE
WT-17769 Fix log slot buffer leaks on corrupted-log open failure

### DIFF
--- a/src/log/log_slot.c
+++ b/src/log/log_slot.c
@@ -506,7 +506,7 @@ __wti_log_slot_destroy(WT_SESSION_IMPL *session)
     WTI_LOG *log;
     WTI_LOGSLOT *slot;
     int64_t rel;
-    int i;
+    int i, write_ret;
 
     conn = S2C(session);
     log = conn->log_mgr.log;
@@ -520,11 +520,18 @@ __wti_log_slot_destroy(WT_SESSION_IMPL *session)
               WTI_LOG_SLOT_RESERVED)) {
             rel =
               WTI_LOG_SLOT_RELEASED_BUFFERED(__wt_atomic_load_int64_v_relaxed(&slot->slot_state));
-            if (rel != 0)
+            if (rel != 0) {
                 /* Writes are not throttled. */
-                WT_TRET(__wt_write(session, slot->slot_fh,
+                write_ret = __wt_write(session, slot->slot_fh,
                   __wt_atomic_load_int64_relaxed(&slot->slot_start_offset), (size_t)rel,
-                  slot->slot_buf.mem));
+                  slot->slot_buf.mem);
+                if (write_ret != 0)
+                    __wt_verbose_warning(session, WT_VERB_LOG,
+                      "log_slot_destroy: failed to write slot %d to %s: %s", i,
+                      slot->slot_fh == NULL ? "(null)" : slot->slot_fh->name,
+                      __wt_strerror(session, write_ret, NULL, 0));
+                WT_TRET(write_ret);
+            }
         }
         __wt_buf_free(session, &log->slot_pool[i].slot_buf);
     }

--- a/src/log/log_slot.c
+++ b/src/log/log_slot.c
@@ -502,6 +502,7 @@ int
 __wti_log_slot_destroy(WT_SESSION_IMPL *session)
 {
     WT_CONNECTION_IMPL *conn;
+    WT_DECL_RET;
     WTI_LOG *log;
     WTI_LOGSLOT *slot;
     int64_t rel;
@@ -521,13 +522,13 @@ __wti_log_slot_destroy(WT_SESSION_IMPL *session)
               WTI_LOG_SLOT_RELEASED_BUFFERED(__wt_atomic_load_int64_v_relaxed(&slot->slot_state));
             if (rel != 0)
                 /* Writes are not throttled. */
-                WT_RET(__wt_write(session, slot->slot_fh,
+                WT_TRET(__wt_write(session, slot->slot_fh,
                   __wt_atomic_load_int64_relaxed(&slot->slot_start_offset), (size_t)rel,
                   slot->slot_buf.mem));
         }
         __wt_buf_free(session, &log->slot_pool[i].slot_buf);
     }
-    return (0);
+    return (ret);
 }
 
 /*

--- a/test/suite/fail_lists/asan.fail
+++ b/test/suite/fail_lists/asan.fail
@@ -4,6 +4,3 @@
 
 # FIXME-WT-17765: memory leaks in dir_store storage source
 test_tiered06.py
-
-# FIXME-WT-17769: log slot buffer leaks on corrupted-log open failure
-test_txn19.py

--- a/test/suite/test_txn19.py
+++ b/test/suite/test_txn19.py
@@ -273,6 +273,8 @@ class test_txn19(wttest.WiredTigerTestCase, suite_subprocess):
         # Then does a restart with recovery, then starts again with salvage,
         # and finally starts again with recovery (adding new records).
 
+        self.ignoreStdoutPattern('log_slot_destroy: failed to write slot')
+
         create_params = 'key_format=i,value_format=S'.format(self.key_format)
         self.session.create(self.uri, create_params)
         self.inserts([x for x in range(0, self.nrecords)])
@@ -512,6 +514,8 @@ class test_txn19_meta(wttest.WiredTigerTestCase, suite_subprocess):
         newdir2 = "RESTART2"
         expect = list(range(1, self.nrecords + 1))
         salvage_config = self.base_config + ',salvage=true'
+
+        self.ignoreStdoutPattern('log_slot_destroy: failed to write slot')
 
         create_params = 'key_format={},value_format=S'.format(self.key_format)
         for suffix in self.suffixes:


### PR DESCRIPTION
When opening a database fails due to a corrupted log file, `__wti_log_slot_destroy` iterates the slot pool to flush buffered data and free each buffer. If the flush of one slot fails, `WT_RET` returns immediately, leaving the remaining slots' buffers unfreed. Switch to `WT_TRET` so all buffers are freed before the error is returned.