### PR TITLE
WT-17918 Remove need_stable from the OP structure

### DIFF
--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -182,10 +182,10 @@ __clayered_op_init(
 {
     op->clayered = clayered;
     op->ingest = (role == WTI_CLAYERED_ROLE_FOLLOWER) ? clayered->ingest_cursor : NULL;
-    op->stable = clayered->stable_cursor;
+    /* NULL the stable slot when skipped: the persistent cursor may still be open from before. */
+    op->stable = LF_ISSET(CLAYERED_ENTER_SKIP_STABLE) ? NULL : clayered->stable_cursor;
     op->table = (WT_LAYERED_TABLE *)clayered->dhandle;
     op->collator = op->table->collator;
-    op->need_stable = !LF_ISSET(CLAYERED_ENTER_SKIP_STABLE);
 }
 
 /*
@@ -1732,13 +1732,13 @@ __clayered_lookup(WTI_CLAYERED_OP *op, WT_ITEM *value)
         }
     } else
         /* Be sure we'll make a search attempt further down.  */
-        WT_ASSERT(session, op->need_stable && op->stable != NULL);
+        WT_ASSERT(session, op->stable != NULL);
 
     /*
      * If the key didn't exist in the ingest constituent and the cursor is setup for reading, check
      * the stable constituent.
      */
-    if (!found && op->need_stable && op->stable != NULL)
+    if (!found && op->stable != NULL)
         WT_ERR_NOTFOUND_OK(__clayered_lookup_constituent(op, op->stable, value), true);
 
 err:

--- a/src/cursor/cur_layered_private.h
+++ b/src/cursor/cur_layered_private.h
@@ -67,5 +67,4 @@ struct __wti_clayered_op {
     WT_CURSOR *stable;            /* resolved slot == clayered->stable_cursor (may be NULL) */
     WT_LAYERED_TABLE *table;
     WT_COLLATOR *collator;
-    bool need_stable; /* derived from mode+role; whether the stable cursor must be opened */
 };


### PR DESCRIPTION
`WT_CLAYERED_OP.need_stable` is redundant. It only ever differs from `op->stable` being set, and every consumer already gates stable access on `op->stable != NULL`.

Decide whether to open the stable cursor in `__clayered_enter_flags (CLAYERED_ENTER_SKIP_STABLE)` and leave `op->stable` `NULL` when the operation skips it, then remove the `need_stable` field.