### PR TITLE
WT-17426 reconcile: keep truncated keys after rollback to stable

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1821,6 +1821,7 @@ trk
 trk's
 trun
 trunc
+truncate's
 truncations
 trylock
 tryrdlock

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2160,10 +2160,19 @@ static void
 __rec_set_updates_durable(WT_SESSION_IMPL *session, WT_MULTI *multi)
 {
     WT_SAVE_UPD *supd;
+    wt_timestamp_t pinned_stable_ts;
     uint32_t i;
 
     if (!F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED))
         return;
+
+    /*
+     * A committed stop ahead of the stable timestamp can be rolled back by a later rollback to
+     * stable, which resurrects the on-page value below it. Capture stable so we don't leave such a
+     * value durable: otherwise the next reconciliation would skip rewriting the leaf and keep the
+     * now-stale stop (this mirrors the prepared-tombstone handling below).
+     */
+    pinned_stable_ts = __wt_txn_pinned_stable_timestamp(session);
 
     /*
      * FIXME-WT-14882: we should rethink where we should call this. Is this safe to call this right
@@ -2198,7 +2207,15 @@ __rec_set_updates_durable(WT_SESSION_IMPL *session, WT_MULTI *multi)
                      */
                 } else {
                     F_SET(supd->onpage_tombstone, WT_UPDATE_DURABLE);
-                    F_SET(supd->onpage_upd, WT_UPDATE_DURABLE);
+                    /*
+                     * If the stop is not yet stable, leave the value non-durable so that a rollback
+                     * to stable aborting the stop forces the next reconciliation to rewrite the
+                     * leaf instead of retaining the stale stop.
+                     */
+                    if (supd->tw.durable_stop_ts > pinned_stable_ts)
+                        F_CLR(supd->onpage_upd, WT_UPDATE_DURABLE);
+                    else
+                        F_SET(supd->onpage_upd, WT_UPDATE_DURABLE);
                 }
             } else {
                 if (WT_TIME_WINDOW_HAS_START_PREPARE(&supd->tw))

--- a/test/suite/test_layered_truncate_rts01.py
+++ b/test/suite/test_layered_truncate_rts01.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wttest
+from helper_disagg import disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
+
+# test_layered_truncate_rts01.py
+#   Rolling back a committed-but-unstable truncate on a disaggregated leader
+#   must restore every truncated key.
+#
+#   A checkpoint persists a truncate whose durable timestamp is ahead of stable,
+#   as per-key stop tombstones, into the stable constituent. Correctness then
+#   relies on rollback_to_stable() undoing it.
+@disagg_test_class
+class test_layered_truncate_rts01(wttest.WiredTigerTestCase):
+
+    # These constants are tuned to the on-disk leaf layout and to cache/eviction
+    # timing -- the test is sensitive to both, so don't change them casually:
+    #   - leaf_page_max=32KB with the 78-byte value gives ~56 leaves at
+    #     nrows=10000, the first holding keys 1..165 and the last 9719..10000.
+    #   - The truncate starts at key 5, so keys 1..4 survive: the first leaf is
+    #     partially truncated (instantiated into per-key tombstones, not
+    #     fast-deleted).
+    #   - The instantiate keys (5,165,5000,9719,10000) land on the first, a
+    #     middle, and the last truncated leaf (165 = last key of the first leaf,
+    #     9719 = first key of the last). Instantiating only these few leaves
+    #     reproduces the bug; reading the whole range, or using a shorter value,
+    #     shifts cache pressure and makes it pass.
+    #   - cache_size=10MB forces the base data out to the stable constituent.
+    #   - Timestamps: the truncate's durable time (5 prepare / 3 no_prepare) is
+    #     ahead of stable (4 / 2), so it is committed but unstable and RTS undoes it.
+    conn_config = 'cache_size=10MB,statistics=(all),disaggregated=(role="leader"),'
+    uri = 'layered:test_layered_truncate_rts01'
+    create_cfg = 'key_format=i,value_format=S,leaf_page_max=32KB'
+
+    value = "abcdefghijklmnopqrstuvwxyz" * 3
+    instantiate_keys = [5, 165, 5000, 9719, 10000]
+
+    prepare_values = [
+        ('prepare', dict(prepare=True)),
+        ('noprepare', dict(prepare=False)),
+    ]
+
+    disagg_storages = gen_disagg_storages(disagg_only=True)
+    scenarios = make_scenarios(disagg_storages, prepare_values)
+
+    nrows = 10000
+
+    def test_truncate_rts(self):
+        self.session.create(self.uri, self.create_cfg)
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
+
+        # Insert the base data and flush it into the stable constituent.
+        c = self.session.open_cursor(self.uri)
+        for i in range(1, self.nrows + 1):
+            self.session.begin_transaction()
+            c[i] = self.value
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(2))
+        c.close()
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(2))
+        self.session.checkpoint()
+
+        # Truncate keys 5..end as a committed-but-unstable delete (durable >
+        # stable); RTS must undo it.
+        self.session.begin_transaction()
+        start = self.session.open_cursor(self.uri)
+        start.set_key(5)
+        self.session.truncate(None, start, None, None)
+        start.close()
+        if self.prepare:
+            self.session.prepare_transaction('prepare_timestamp=' + self.timestamp_str(3))
+            self.session.timestamp_transaction('commit_timestamp=' + self.timestamp_str(3))
+            self.session.timestamp_transaction('durable_timestamp=' + self.timestamp_str(5))
+            self.session.commit_transaction()
+        else:
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(3))
+
+        # Instantiate a few truncated leaves into per-key tombstones -- the chain
+        # the checkpoint persists with the unstable stop.
+        inst = self.session.open_cursor(self.uri)
+        for k in self.instantiate_keys:
+            inst.set_key(k)
+            inst.search()
+            inst.reset()
+        inst.close()
+
+        # Advance stable below the truncate's durable timestamp (prepare only).
+        if self.prepare:
+            self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(4) +
+                                    ',stable_timestamp=' + self.timestamp_str(4))
+
+        # Checkpoint: persist the unstable stop and mark the values durable.
+        self.session.checkpoint()
+
+        # RTS aborts the in-memory tombstones, leaving the durable values.
+        self.conn.rollback_to_stable()
+
+        # Force every stable leaf to reconcile and evict.
+        ev = self.session.open_cursor(self.uri, None, 'debug=(release_evict)')
+        while ev.next() == 0:
+            pass
+        ev.close()
+
+        # A fresh read re-instantiates each leaf; every truncated key must be back.
+        missing = []
+        vc = self.session.open_cursor(self.uri)
+        for i in range(1, self.nrows + 1):
+            vc.set_key(i)
+            if vc.search() != 0:
+                missing.append(i)
+                if len(missing) >= 5:
+                    break
+            vc.reset()
+        vc.close()
+        self.assertEqual(missing, [],
+                         f'keys NOT FOUND after RTS: {missing}')


### PR DESCRIPTION
* On a leader, a checkpoint can persist a committed truncate whose stop is newer than the stable timestamp, and reconciliation also marked the on-page value durable. After rollback to stable aborts the tombstone, the value is selected with no tombstone and, being durable, looks unchanged from the previous reconciliation; the skip-write path then keeps the old image (value plus stop) and the key reads back `WT_NOTFOUND`.
* Mark the value durable only when its stop is at or below the stable timestamp; otherwise clear the durable flag so a rollback that aborts the stop forces the next reconciliation to rewrite the page, mirroring the prepared-tombstone handling.
* Add `test_layered_truncate_rts01`.