### PR TITLE
WT-17922 Move truncate-related fields out of the layered table into a separate structure

### DIFF
--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -212,8 +212,9 @@ __wt_conn_dhandle_alloc(WT_SESSION_IMPL *session, const char *uri, const char *c
     } else if (WT_PREFIX_MATCH(uri, "layered:")) {
         WT_RET(__wt_calloc_one(session, &layered));
         dhandle = (WT_DATA_HANDLE *)layered;
-        TAILQ_INIT(&layered->truncateqh);
-        WT_RET(__wt_rwlock_init(session, &layered->truncate_lock));
+        WT_TRUNCATE_LIST *tl = &layered->truncate_list;
+        TAILQ_INIT(&tl->truncateqh);
+        WT_RET(__wt_rwlock_init(session, &tl->truncate_lock));
         __wt_atomic_store_enum_relaxed(&dhandle->type, WT_DHANDLE_TYPE_LAYERED);
     } else if (WT_PREFIX_MATCH(uri, "table:")) {
         WT_RET(__wt_calloc_one(session, &table));

--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -212,9 +212,9 @@ __wt_conn_dhandle_alloc(WT_SESSION_IMPL *session, const char *uri, const char *c
     } else if (WT_PREFIX_MATCH(uri, "layered:")) {
         WT_RET(__wt_calloc_one(session, &layered));
         dhandle = (WT_DATA_HANDLE *)layered;
-        WT_TRUNCATE_LIST *tl = &layered->truncate_list;
-        TAILQ_INIT(&tl->truncateqh);
-        WT_RET(__wt_rwlock_init(session, &tl->truncate_lock));
+        WT_TRUNCATE_LIST *truncate_list = &layered->truncate_list;
+        TAILQ_INIT(&truncate_list->qh);
+        WT_RET(__wt_rwlock_init(session, &truncate_list->lock));
         __wt_atomic_store_enum_relaxed(&dhandle->type, WT_DHANDLE_TYPE_LAYERED);
     } else if (WT_PREFIX_MATCH(uri, "table:")) {
         WT_RET(__wt_calloc_one(session, &table));

--- a/src/conn/conn_layered_ingest.c
+++ b/src/conn/conn_layered_ingest.c
@@ -709,13 +709,14 @@ __layered_build_sorted_truncates(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *lay
 {
     WT_DECL_RET;
     WT_TRUNCATE *t = NULL, **sorted = NULL;
+    WT_TRUNCATE_LIST *tl = &layered_table->truncate_list;
     size_t i = 0, ntruncates = 0;
 
     *sortedp = NULL;
     *ntruncatesp = 0;
 
-    __wt_readlock(session, &layered_table->truncate_lock);
-    TAILQ_FOREACH (t, &layered_table->truncateqh, q)
+    __wt_readlock(session, &tl->truncate_lock);
+    TAILQ_FOREACH (t, &tl->truncateqh, q)
         if (t->txn_id != WT_TXN_NONE)
             ++ntruncates;
 
@@ -725,7 +726,7 @@ __layered_build_sorted_truncates(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *lay
 
     WT_ERR(__wt_calloc(session, ntruncates, sizeof(WT_TRUNCATE *), &sorted));
     /* Populate the array with committed truncates. */
-    TAILQ_FOREACH (t, &layered_table->truncateqh, q)
+    TAILQ_FOREACH (t, &tl->truncateqh, q)
         if (t->txn_id != WT_TXN_NONE)
             sorted[i++] = t;
 
@@ -735,7 +736,7 @@ __layered_build_sorted_truncates(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *lay
     *ntruncatesp = ntruncates;
 
 err:
-    __wt_readunlock(session, &layered_table->truncate_lock);
+    __wt_readunlock(session, &tl->truncate_lock);
     if (ret != 0)
         __wt_free(session, sorted);
     return (ret);

--- a/src/conn/conn_layered_ingest.c
+++ b/src/conn/conn_layered_ingest.c
@@ -709,14 +709,14 @@ __layered_build_sorted_truncates(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *lay
 {
     WT_DECL_RET;
     WT_TRUNCATE *t = NULL, **sorted = NULL;
-    WT_TRUNCATE_LIST *tl = &layered_table->truncate_list;
+    WT_TRUNCATE_LIST *truncate_list = &layered_table->truncate_list;
     size_t i = 0, ntruncates = 0;
 
     *sortedp = NULL;
     *ntruncatesp = 0;
 
-    __wt_readlock(session, &tl->truncate_lock);
-    TAILQ_FOREACH (t, &tl->truncateqh, q)
+    __wt_readlock(session, &truncate_list->lock);
+    TAILQ_FOREACH (t, &truncate_list->qh, q)
         if (t->txn_id != WT_TXN_NONE)
             ++ntruncates;
 
@@ -726,7 +726,7 @@ __layered_build_sorted_truncates(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *lay
 
     WT_ERR(__wt_calloc(session, ntruncates, sizeof(WT_TRUNCATE *), &sorted));
     /* Populate the array with committed truncates. */
-    TAILQ_FOREACH (t, &tl->truncateqh, q)
+    TAILQ_FOREACH (t, &truncate_list->qh, q)
         if (t->txn_id != WT_TXN_NONE)
             sorted[i++] = t;
 
@@ -736,7 +736,7 @@ __layered_build_sorted_truncates(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *lay
     *ntruncatesp = ntruncates;
 
 err:
-    __wt_readunlock(session, &tl->truncate_lock);
+    __wt_readunlock(session, &truncate_list->lock);
     if (ret != 0)
         __wt_free(session, sorted);
     return (ret);

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -238,12 +238,14 @@ static WT_INLINE void
 __clayered_op_init(
   WTI_CURSOR_LAYERED *clayered, WTI_CLAYERED_OP *op, WTI_CLAYERED_ROLE role, uint32_t flags)
 {
+    WT_LAYERED_TABLE *table = (WT_LAYERED_TABLE *)clayered->dhandle;
+
     op->clayered = clayered;
     op->ingest = (role == WTI_CLAYERED_ROLE_FOLLOWER) ? clayered->ingest_cursor : NULL;
     /* NULL the stable slot when skipped: the persistent cursor may still be open from before. */
     op->stable = LF_ISSET(CLAYERED_ENTER_SKIP_STABLE) ? NULL : clayered->stable_cursor;
-    op->table = (WT_LAYERED_TABLE *)clayered->dhandle;
-    op->collator = op->table->collator;
+    op->truncate_list = &table->truncate_list;
+    op->collator = table->collator;
 }
 
 /*
@@ -848,8 +850,8 @@ __clayered_reposition_truncate_iterate(WTI_CLAYERED_OP *op, WT_CURSOR *stable, b
      * until we find a non-truncated key or reach the end of the range.
      */
     for (;;) {
-        WT_ERR_NOTFOUND_OK(__wt_truncate_delete_visible_check(
-                             session, op->table, &stable->key, &start_key, &stop_key),
+        WT_ERR_NOTFOUND_OK(__wt_truncate_delete_visible_check(session, op->truncate_list,
+                             op->collator, &stable->key, &start_key, &stop_key),
           true);
 
         if (ret == WT_NOTFOUND) {
@@ -955,7 +957,8 @@ __clayered_range_truncate_ingest(
         if (!__wt_clayered_deleted(&cursor->value)) {
             WT_ITEM key;
             WT_RET(__wt_cursor_get_raw_key(cursor, &key));
-            WT_RET(__wt_layered_table_truncate_detect_write_conflict(session, layered, &key));
+            WT_RET(__wt_layered_table_truncate_detect_write_conflict(
+              session, &layered->truncate_list, layered->collator, &key));
             cursor->set_value(cursor, &__wt_tombstone);
             WT_RET(cursor->update(cursor));
         }
@@ -997,8 +1000,8 @@ __clayered_truncate_follower(WT_TRUNCATE_INFO *trunc_info)
 
     WT_LAYERED_TABLE *layered_table = (WT_LAYERED_TABLE *)clayered_start->dhandle;
 
-    WT_RET(__wt_layered_table_truncate_detect_non_ingest_write_conflict(
-      trunc_info->session, layered_table, &start_key, &stop_key));
+    WT_RET(__wt_layered_table_truncate_detect_non_ingest_write_conflict(trunc_info->session,
+      &layered_table->truncate_list, layered_table->collator, &start_key, &stop_key));
 
     /*
      * If either positioning returned WT_NOTFOUND, the ingest table has no keys in the range and
@@ -1781,8 +1784,8 @@ __clayered_lookup(WTI_CLAYERED_OP *op, WT_ITEM *value)
 
         /* Only consult the truncate list when ingest has no entry for this key. */
         if (!found) {
-            WT_ERR_NOTFOUND_OK(
-              __wt_truncate_delete_visible_check(session, op->table, &cursor->key, NULL, NULL),
+            WT_ERR_NOTFOUND_OK(__wt_truncate_delete_visible_check(session, op->truncate_list,
+                                 op->collator, &cursor->key, NULL, NULL),
               true);
             if (ret == 0) {
                 found = true;
@@ -1952,8 +1955,8 @@ __clayered_search_near_int(WTI_CLAYERED_OP *op, int *exactp)
          * exhausts, step backward instead.
          */
         if (ret == 0 &&
-          __wt_truncate_delete_visible_check(session, op->table, &op->stable->key, NULL, NULL) ==
-            0) {
+          __wt_truncate_delete_visible_check(
+            session, op->truncate_list, op->collator, &op->stable->key, NULL, NULL) == 0) {
             WT_ASSERT(session, !F_ISSET(&clayered->iface, WT_CURSTD_KEY_INT));
 
             WT_ERR_NOTFOUND_OK(__clayered_constituent_iter_helper(op, op->stable, true), true);
@@ -2174,7 +2177,8 @@ __clayered_put(
          * FIXME-WT-17425: Investigate whether this function can be called below the cursor layer.
          * Doing so would remove the cursor write operation dependency on the truncate list.
          */
-        WT_RET(__wt_layered_table_truncate_detect_write_conflict(session, op->table, key));
+        WT_RET(__wt_layered_table_truncate_detect_write_conflict(
+          session, op->truncate_list, op->collator, key));
 
         /*
          * Clear the stable cursor position. Don't clear the ingest cursor: we're about to use it
@@ -2353,7 +2357,8 @@ __clayered_remove_from_ingest(WTI_CLAYERED_OP *op, const WT_ITEM *key, bool posi
      * FIXME-WT-17425: Investigate whether this function can be called below the cursor layer. Doing
      * so would remove the write cursor operations dependency on the truncate list.
      */
-    WT_RET(__wt_layered_table_truncate_detect_write_conflict(session, op->table, key));
+    WT_RET(__wt_layered_table_truncate_detect_write_conflict(
+      session, op->truncate_list, op->collator, key));
     c_ingest->set_value(c_ingest, &__wt_tombstone);
     WT_ERR(c_ingest->update(c_ingest));
     clayered->current_cursor = c_ingest;

--- a/src/cursor/cur_layered_private.h
+++ b/src/cursor/cur_layered_private.h
@@ -63,8 +63,8 @@ typedef enum {
  */
 struct __wti_clayered_op {
     WTI_CURSOR_LAYERED *clayered; /* back-pointer; session via CUR2S(clayered) */
-    WT_CURSOR *ingest;            /* resolved slot == clayered->ingest_cursor (may be NULL) */
-    WT_CURSOR *stable;            /* resolved slot == clayered->stable_cursor (may be NULL) */
-    WT_LAYERED_TABLE *table;
+    WT_CURSOR *ingest;               /* resolved slot == clayered->ingest_cursor (may be NULL) */
+    WT_CURSOR *stable;               /* resolved slot == clayered->stable_cursor (may be NULL) */
+    WT_TRUNCATE_LIST *truncate_list; /* the layered table's truncate list */
     WT_COLLATOR *collator;
 };

--- a/src/cursor/cur_layered_private.h
+++ b/src/cursor/cur_layered_private.h
@@ -62,7 +62,7 @@ typedef enum {
  *	State gathered once for a single layered table cursor operation.
  */
 struct __wti_clayered_op {
-    WTI_CURSOR_LAYERED *clayered; /* back-pointer; session via CUR2S(clayered) */
+    WTI_CURSOR_LAYERED *clayered;    /* back-pointer; session via CUR2S(clayered) */
     WT_CURSOR *ingest;               /* resolved slot == clayered->ingest_cursor (may be NULL) */
     WT_CURSOR *stable;               /* resolved slot == clayered->stable_cursor (may be NULL) */
     WT_TRUNCATE_LIST *truncate_list; /* the layered table's truncate list */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -749,10 +749,10 @@ extern int __wt_key_return(WT_CURSOR_BTREE *cbt) WT_GCC_FUNC_DECL_ATTRIBUTE((war
 extern int __wt_layered_table_manager_add_table(WT_SESSION_IMPL *session, uint32_t ingest_id)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_layered_table_truncate_detect_non_ingest_write_conflict(WT_SESSION_IMPL *session,
-  WT_TRUNCATE_LIST *tl, WT_COLLATOR *collator, const WT_ITEM *start_key, const WT_ITEM *stop_key)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_layered_table_truncate_detect_write_conflict(
-  WT_SESSION_IMPL *session, WT_TRUNCATE_LIST *tl, WT_COLLATOR *collator, const WT_ITEM *key)
+  WT_TRUNCATE_LIST *truncate_list, WT_COLLATOR *collator, const WT_ITEM *start_key,
+  const WT_ITEM *stop_key) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_layered_table_truncate_detect_write_conflict(WT_SESSION_IMPL *session,
+  WT_TRUNCATE_LIST *truncate_list, WT_COLLATOR *collator, const WT_ITEM *key)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_layered_truncate(WT_TRUNCATE_INFO *trunc_info)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -1165,9 +1165,9 @@ extern int __wt_tree_walk_count(WT_SESSION_IMPL *session, WT_REF **refp, uint64_
 extern int __wt_tree_walk_custom_skip(WT_SESSION_IMPL *session, WT_REF **refp,
   int (*skip_func)(WT_SESSION_IMPL *, WT_REF *, void *, bool, bool *), void *func_cookie,
   uint32_t flags) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_truncate_delete_visible_check(WT_SESSION_IMPL *session, WT_TRUNCATE_LIST *tl,
-  WT_COLLATOR *collator, WT_ITEM *key, WT_ITEM *start_keyp, WT_ITEM *stop_keyp)
-  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_truncate_delete_visible_check(WT_SESSION_IMPL *session,
+  WT_TRUNCATE_LIST *truncate_list, WT_COLLATOR *collator, WT_ITEM *key, WT_ITEM *start_keyp,
+  WT_ITEM *stop_keyp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_try_readlock(WT_SESSION_IMPL *session, WT_RWLOCK *l)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_try_writelock(WT_SESSION_IMPL *session, WT_RWLOCK *l)

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -749,10 +749,10 @@ extern int __wt_key_return(WT_CURSOR_BTREE *cbt) WT_GCC_FUNC_DECL_ATTRIBUTE((war
 extern int __wt_layered_table_manager_add_table(WT_SESSION_IMPL *session, uint32_t ingest_id)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_layered_table_truncate_detect_non_ingest_write_conflict(WT_SESSION_IMPL *session,
-  WT_LAYERED_TABLE *layered_table, const WT_ITEM *start_key, const WT_ITEM *stop_key)
+  WT_TRUNCATE_LIST *tl, WT_COLLATOR *collator, const WT_ITEM *start_key, const WT_ITEM *stop_key)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_layered_table_truncate_detect_write_conflict(
-  WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered_table, const WT_ITEM *key)
+  WT_SESSION_IMPL *session, WT_TRUNCATE_LIST *tl, WT_COLLATOR *collator, const WT_ITEM *key)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_layered_truncate(WT_TRUNCATE_INFO *trunc_info)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
@@ -1165,8 +1165,8 @@ extern int __wt_tree_walk_count(WT_SESSION_IMPL *session, WT_REF **refp, uint64_
 extern int __wt_tree_walk_custom_skip(WT_SESSION_IMPL *session, WT_REF **refp,
   int (*skip_func)(WT_SESSION_IMPL *, WT_REF *, void *, bool, bool *), void *func_cookie,
   uint32_t flags) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_truncate_delete_visible_check(WT_SESSION_IMPL *session,
-  WT_LAYERED_TABLE *layered_table, WT_ITEM *key, WT_ITEM *start_keyp, WT_ITEM *stop_keyp)
+extern int __wt_truncate_delete_visible_check(WT_SESSION_IMPL *session, WT_TRUNCATE_LIST *tl,
+  WT_COLLATOR *collator, WT_ITEM *key, WT_ITEM *start_keyp, WT_ITEM *stop_keyp)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_try_readlock(WT_SESSION_IMPL *session, WT_RWLOCK *l)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/include/schema.h
+++ b/src/include/schema.h
@@ -89,6 +89,26 @@ struct __wt_truncate {
 };
 
 /*
+ * WT_TRUNCATE_LIST --
+ *	Fast-truncate range list for a layered table: the queue of truncate ranges and the lock
+ *	guarding its membership.
+ */
+struct __wt_truncate_list {
+    /*
+     * Queue head for fast truncate logic.
+     *
+     * FIXME-WT-17330: Evaluate data structure for performance optimization.
+     */
+    TAILQ_HEAD(__truncate_table_list_qh, __wt_truncate) truncateqh;
+
+    /*
+     * Protects truncate list membership (insert/remove/clear). Per-entry visibility is synchronized
+     * lock-free via WT_TRUNCATE.committed.
+     */
+    WT_RWLOCK truncate_lock;
+};
+
+/*
  * WT_LAYERED_TABLE --
  *	Handle for a layered table.
  */
@@ -109,18 +129,7 @@ struct __wt_layered_table {
     const char *key_format, *value_format;
     const char *ingest_uri, *stable_uri;
 
-    /*
-     * Queue head for fast truncate logic.
-     *
-     * FIXME-WT-17330: Evaluate data structure for performance optimization.
-     */
-    TAILQ_HEAD(__truncate_table_list_qh, __wt_truncate) truncateqh;
-
-    /*
-     * Protects truncate list membership (insert/remove/clear). Per-entry visibility is synchronized
-     * lock-free via WT_TRUNCATE.committed.
-     */
-    WT_RWLOCK truncate_lock;
+    WT_TRUNCATE_LIST truncate_list; /* Fast-truncate range list. */
 
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */
 #define WT_LAYERED_TABLE_OPEN 0x1u

--- a/src/include/schema.h
+++ b/src/include/schema.h
@@ -99,13 +99,13 @@ struct __wt_truncate_list {
      *
      * FIXME-WT-17330: Evaluate data structure for performance optimization.
      */
-    TAILQ_HEAD(__truncate_table_list_qh, __wt_truncate) truncateqh;
+    TAILQ_HEAD(__truncate_table_list_qh, __wt_truncate) qh;
 
     /*
      * Protects truncate list membership (insert/remove/clear). Per-entry visibility is synchronized
      * lock-free via WT_TRUNCATE.committed.
      */
-    WT_RWLOCK truncate_lock;
+    WT_RWLOCK lock;
 };
 
 /*

--- a/src/include/schema.h
+++ b/src/include/schema.h
@@ -90,8 +90,7 @@ struct __wt_truncate {
 
 /*
  * WT_TRUNCATE_LIST --
- *	Fast-truncate range list for a layered table: the queue of truncate ranges and the lock
- *	guarding its membership.
+ *	Fast-truncate range list for a layered table.
  */
 struct __wt_truncate_list {
     /*
@@ -101,10 +100,7 @@ struct __wt_truncate_list {
      */
     TAILQ_HEAD(__truncate_table_list_qh, __wt_truncate) qh;
 
-    /*
-     * Protects truncate list membership (insert/remove/clear). Per-entry visibility is synchronized
-     * lock-free via WT_TRUNCATE.committed.
-     */
+    /* Read/write lock. Any modification to the list must be done under a write lock. */
     WT_RWLOCK lock;
 };
 

--- a/src/include/wt_internal.h
+++ b/src/include/wt_internal.h
@@ -453,6 +453,8 @@ struct __wt_truncate;
 typedef struct __wt_truncate WT_TRUNCATE;
 struct __wt_truncate_info;
 typedef struct __wt_truncate_info WT_TRUNCATE_INFO;
+struct __wt_truncate_list;
+typedef struct __wt_truncate_list WT_TRUNCATE_LIST;
 struct __wt_txn;
 typedef struct __wt_txn WT_TXN;
 struct __wt_txn_global;

--- a/src/schema/schema_list.c
+++ b/src/schema/schema_list.c
@@ -259,5 +259,5 @@ __wt_schema_destroy_layered(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered)
 {
     __wt_schema_close_layered(session, layered);
     __wt_layered_table_truncate_clear(session, layered);
-    __wt_rwlock_destroy(session, &layered->truncate_list.truncate_lock);
+    __wt_rwlock_destroy(session, &layered->truncate_list.lock);
 }

--- a/src/schema/schema_list.c
+++ b/src/schema/schema_list.c
@@ -259,5 +259,5 @@ __wt_schema_destroy_layered(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered)
 {
     __wt_schema_close_layered(session, layered);
     __wt_layered_table_truncate_clear(session, layered);
-    __wt_rwlock_destroy(session, &layered->truncate_lock);
+    __wt_rwlock_destroy(session, &layered->truncate_list.truncate_lock);
 }

--- a/src/txn/txn_truncate.c
+++ b/src/txn/txn_truncate.c
@@ -66,14 +66,14 @@ static void
 __truncate_entry_remove(
   WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered_table, WT_TRUNCATE *entry)
 {
-    WT_TRUNCATE_LIST *tl = &layered_table->truncate_list;
+    WT_TRUNCATE_LIST *truncate_list = &layered_table->truncate_list;
 
-    WT_ASSERT(session, !TAILQ_EMPTY(&tl->truncateqh));
+    WT_ASSERT(session, !TAILQ_EMPTY(&truncate_list->qh));
     WT_ASSERT(session, __wt_atomic_load_uint32_relaxed(&layered_table->iface.references) > 0);
 
-    TAILQ_REMOVE(&tl->truncateqh, entry, q);
+    TAILQ_REMOVE(&truncate_list->qh, entry, q);
 
-    if (TAILQ_EMPTY(&tl->truncateqh))
+    if (TAILQ_EMPTY(&truncate_list->qh))
         WT_DHANDLE_RELEASE(&layered_table->iface);
 }
 
@@ -93,7 +93,7 @@ __layered_table_truncate_gc(
     WT_TRUNCATE *entry = NULL;
     WT_TRUNCATE *next = NULL;
 
-    TAILQ_FOREACH_SAFE(entry, &layered_table->truncate_list.truncateqh, q, next)
+    TAILQ_FOREACH_SAFE(entry, &layered_table->truncate_list.qh, q, next)
     {
         const bool is_committed = __wt_atomic_load_bool_acquire(&entry->committed);
 
@@ -155,7 +155,7 @@ __txn_insert_truncate_entry_helper(
 {
     WT_DECL_RET;
     WT_TRUNCATE *entry = *tp;
-    WT_TRUNCATE_LIST *tl = &layered_table->truncate_list;
+    WT_TRUNCATE_LIST *truncate_list = &layered_table->truncate_list;
     wt_timestamp_t prune_timestamp = 0;
 
     WT_RET(__wt_session_get_dhandle(session, layered_table->ingest_uri, NULL, NULL, 0));
@@ -164,17 +164,17 @@ __txn_insert_truncate_entry_helper(
     /* At this point, adding the entry to the truncate list will not fail. */
     __log_truncate_entry(session, layered_table, entry);
 
-    __wt_writelock(session, &tl->truncate_lock);
+    __wt_writelock(session, &truncate_list->lock);
 
     prune_timestamp = __wt_atomic_load_uint64_relaxed(&S2BT(session)->prune_timestamp);
     __layered_table_truncate_gc(session, layered_table, prune_timestamp);
 
-    if (TAILQ_EMPTY(&tl->truncateqh))
+    if (TAILQ_EMPTY(&truncate_list->qh))
         WT_DHANDLE_ACQUIRE(&layered_table->iface);
 
-    TAILQ_INSERT_TAIL(&tl->truncateqh, entry, q);
+    TAILQ_INSERT_TAIL(&truncate_list->qh, entry, q);
 
-    __wt_writeunlock(session, &tl->truncate_lock);
+    __wt_writeunlock(session, &truncate_list->lock);
 
     /* Ownership transferred to the txn op and truncate queue. */
     *tp = NULL;
@@ -249,18 +249,18 @@ __truncate_read_entry_timestamps(
  *     the output parameter when non-NULL.
  */
 static int
-__truncate_search(WT_SESSION_IMPL *session, WT_TRUNCATE_LIST *tl, WT_COLLATOR *collator,
+__truncate_search(WT_SESSION_IMPL *session, WT_TRUNCATE_LIST *truncate_list, WT_COLLATOR *collator,
   const WT_ITEM *key, const WT_TRUNCATE_SEARCH_MODE mode, WT_TRUNCATE **tp, bool *is_foundp)
 {
     WT_ASSERT(session, is_foundp != NULL);
-    WT_ASSERT(session, __wt_rwlock_islocked(session, &tl->truncate_lock));
+    WT_ASSERT(session, __wt_rwlock_islocked(session, &truncate_list->lock));
     *is_foundp = false;
 
     WT_STAT_CONN_INCR(session, layered_truncate_list_search_calls);
 
     WT_TRUNCATE *entry = NULL;
 
-    TAILQ_FOREACH (entry, &tl->truncateqh, q) {
+    TAILQ_FOREACH (entry, &truncate_list->qh, q) {
         WT_STAT_CONN_INCR(session, layered_truncate_list_search_entries_walked);
 
         wt_timestamp_t start_ts, durable_ts;
@@ -294,8 +294,8 @@ __truncate_search(WT_SESSION_IMPL *session, WT_TRUNCATE_LIST *tl, WT_COLLATOR *c
  *     would remove the write cursor operations dependency on the truncate list.
  */
 int
-__wt_layered_table_truncate_detect_write_conflict(
-  WT_SESSION_IMPL *session, WT_TRUNCATE_LIST *tl, WT_COLLATOR *collator, const WT_ITEM *key)
+__wt_layered_table_truncate_detect_write_conflict(WT_SESSION_IMPL *session,
+  WT_TRUNCATE_LIST *truncate_list, WT_COLLATOR *collator, const WT_ITEM *key)
 {
     WT_DECL_RET;
     bool is_found = false;
@@ -304,16 +304,16 @@ __wt_layered_table_truncate_detect_write_conflict(
         return (0);
 
     /* FIXME-WT-17384: Investigate the use of atomics to minimize locking. */
-    __wt_readlock(session, &tl->truncate_lock);
+    __wt_readlock(session, &truncate_list->lock);
 
     /*
      * The truncate entry has already been committed if it is visible to this transaction. We can
      * ignore these entries.
      */
     ret = __truncate_search(
-      session, tl, collator, key, WT_TRUNCATE_SEARCH_NOT_VISIBLE, NULL, &is_found);
+      session, truncate_list, collator, key, WT_TRUNCATE_SEARCH_NOT_VISIBLE, NULL, &is_found);
 
-    __wt_readunlock(session, &tl->truncate_lock);
+    __wt_readunlock(session, &truncate_list->lock);
     WT_RET(ret);
 
     if (is_found) {
@@ -334,17 +334,18 @@ __wt_layered_table_truncate_detect_write_conflict(
  */
 int
 __wt_layered_table_truncate_detect_non_ingest_write_conflict(WT_SESSION_IMPL *session,
-  WT_TRUNCATE_LIST *tl, WT_COLLATOR *collator, const WT_ITEM *start_key, const WT_ITEM *stop_key)
+  WT_TRUNCATE_LIST *truncate_list, WT_COLLATOR *collator, const WT_ITEM *start_key,
+  const WT_ITEM *stop_key)
 {
     WT_DECL_RET;
 
-    __wt_readlock(session, &tl->truncate_lock);
+    __wt_readlock(session, &truncate_list->lock);
 
     WT_STAT_CONN_INCR(session, layered_truncate_list_search_calls);
 
     WT_TRUNCATE *entry = NULL;
     bool is_found = false;
-    TAILQ_FOREACH (entry, &tl->truncateqh, q) {
+    TAILQ_FOREACH (entry, &truncate_list->qh, q) {
         WT_STAT_CONN_INCR(session, layered_truncate_list_search_entries_walked);
 
         wt_timestamp_t start_ts, durable_ts;
@@ -374,7 +375,7 @@ __wt_layered_table_truncate_detect_non_ingest_write_conflict(WT_SESSION_IMPL *se
     }
 
 err:
-    __wt_readunlock(session, &tl->truncate_lock);
+    __wt_readunlock(session, &truncate_list->lock);
     return (ret);
 }
 
@@ -408,7 +409,7 @@ err:
  *     On success, the caller must free start_keyp and stop_keyp.
  */
 int
-__wt_truncate_delete_visible_check(WT_SESSION_IMPL *session, WT_TRUNCATE_LIST *tl,
+__wt_truncate_delete_visible_check(WT_SESSION_IMPL *session, WT_TRUNCATE_LIST *truncate_list,
   WT_COLLATOR *collator, WT_ITEM *key, WT_ITEM *start_keyp, WT_ITEM *stop_keyp)
 {
     /* We either want the full range or no range at all. */
@@ -427,20 +428,20 @@ __wt_truncate_delete_visible_check(WT_SESSION_IMPL *session, WT_TRUNCATE_LIST *t
         return (WT_NOTFOUND);
 
     /* FIXME-WT-17384: Investigate the use of atomics to minimize locking. */
-    __wt_readlock(session, &tl->truncate_lock);
+    __wt_readlock(session, &truncate_list->lock);
 
     /*
      * Ignore all truncate entries that haven't been committed. They won't be visible to this
      * transaction.
      */
-    WT_ERR(
-      __truncate_search(session, tl, collator, key, WT_TRUNCATE_SEARCH_VISIBLE, &tp, &is_found));
+    WT_ERR(__truncate_search(
+      session, truncate_list, collator, key, WT_TRUNCATE_SEARCH_VISIBLE, &tp, &is_found));
 
     if (is_found && start_keyp != NULL)
         WT_ERR(__truncate_entry_copy_keys(session, tp, start_keyp, stop_keyp));
 
 err:
-    __wt_readunlock(session, &tl->truncate_lock);
+    __wt_readunlock(session, &truncate_list->lock);
     WT_RET(ret);
     return (is_found ? 0 : WT_NOTFOUND);
 }
@@ -517,12 +518,12 @@ void
 __wti_layered_table_truncate_rollback_apply(
   WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered_table, WT_TXN_OP *op)
 {
-    WT_TRUNCATE_LIST *tl = &layered_table->truncate_list;
+    WT_TRUNCATE_LIST *truncate_list = &layered_table->truncate_list;
     WT_TRUNCATE *entry = op->u.follower_truncate.t;
 
-    __wt_writelock(session, &tl->truncate_lock);
+    __wt_writelock(session, &truncate_list->lock);
     __truncate_entry_remove(session, layered_table, entry);
-    __wt_writeunlock(session, &tl->truncate_lock);
+    __wt_writeunlock(session, &truncate_list->lock);
 
     op->u.follower_truncate.t = NULL;
     __disagg_truncate_free(session, &entry);
@@ -548,16 +549,16 @@ __wt_layered_table_truncate_clear(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *la
 {
     WT_ASSERT(session, layered_table != NULL);
 
-    WT_TRUNCATE_LIST *tl = &layered_table->truncate_list;
+    WT_TRUNCATE_LIST *truncate_list = &layered_table->truncate_list;
     WT_TRUNCATE *entry = NULL;
 
-    __wt_writelock(session, &tl->truncate_lock);
+    __wt_writelock(session, &truncate_list->lock);
 
-    while ((entry = TAILQ_FIRST(&tl->truncateqh)) != NULL) {
+    while ((entry = TAILQ_FIRST(&truncate_list->qh)) != NULL) {
         __truncate_entry_remove(session, layered_table, entry);
         __disagg_truncate_free(session, &entry);
     }
-    __wt_writeunlock(session, &tl->truncate_lock);
+    __wt_writeunlock(session, &truncate_list->lock);
 }
 
 #ifdef HAVE_UNITTEST

--- a/src/txn/txn_truncate.c
+++ b/src/txn/txn_truncate.c
@@ -66,12 +66,14 @@ static void
 __truncate_entry_remove(
   WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered_table, WT_TRUNCATE *entry)
 {
-    WT_ASSERT(session, !TAILQ_EMPTY(&layered_table->truncateqh));
+    WT_TRUNCATE_LIST *tl = &layered_table->truncate_list;
+
+    WT_ASSERT(session, !TAILQ_EMPTY(&tl->truncateqh));
     WT_ASSERT(session, __wt_atomic_load_uint32_relaxed(&layered_table->iface.references) > 0);
 
-    TAILQ_REMOVE(&layered_table->truncateqh, entry, q);
+    TAILQ_REMOVE(&tl->truncateqh, entry, q);
 
-    if (TAILQ_EMPTY(&layered_table->truncateqh))
+    if (TAILQ_EMPTY(&tl->truncateqh))
         WT_DHANDLE_RELEASE(&layered_table->iface);
 }
 
@@ -91,7 +93,7 @@ __layered_table_truncate_gc(
     WT_TRUNCATE *entry = NULL;
     WT_TRUNCATE *next = NULL;
 
-    TAILQ_FOREACH_SAFE(entry, &layered_table->truncateqh, q, next)
+    TAILQ_FOREACH_SAFE(entry, &layered_table->truncate_list.truncateqh, q, next)
     {
         const bool is_committed = __wt_atomic_load_bool_acquire(&entry->committed);
 
@@ -153,6 +155,7 @@ __txn_insert_truncate_entry_helper(
 {
     WT_DECL_RET;
     WT_TRUNCATE *entry = *tp;
+    WT_TRUNCATE_LIST *tl = &layered_table->truncate_list;
     wt_timestamp_t prune_timestamp = 0;
 
     WT_RET(__wt_session_get_dhandle(session, layered_table->ingest_uri, NULL, NULL, 0));
@@ -161,17 +164,17 @@ __txn_insert_truncate_entry_helper(
     /* At this point, adding the entry to the truncate list will not fail. */
     __log_truncate_entry(session, layered_table, entry);
 
-    __wt_writelock(session, &layered_table->truncate_lock);
+    __wt_writelock(session, &tl->truncate_lock);
 
     prune_timestamp = __wt_atomic_load_uint64_relaxed(&S2BT(session)->prune_timestamp);
     __layered_table_truncate_gc(session, layered_table, prune_timestamp);
 
-    if (TAILQ_EMPTY(&layered_table->truncateqh))
+    if (TAILQ_EMPTY(&tl->truncateqh))
         WT_DHANDLE_ACQUIRE(&layered_table->iface);
 
-    TAILQ_INSERT_TAIL(&layered_table->truncateqh, entry, q);
+    TAILQ_INSERT_TAIL(&tl->truncateqh, entry, q);
 
-    __wt_writeunlock(session, &layered_table->truncate_lock);
+    __wt_writeunlock(session, &tl->truncate_lock);
 
     /* Ownership transferred to the txn op and truncate queue. */
     *tp = NULL;
@@ -246,19 +249,18 @@ __truncate_read_entry_timestamps(
  *     the output parameter when non-NULL.
  */
 static int
-__truncate_search(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered_table, const WT_ITEM *key,
-  const WT_TRUNCATE_SEARCH_MODE mode, WT_TRUNCATE **tp, bool *is_foundp)
+__truncate_search(WT_SESSION_IMPL *session, WT_TRUNCATE_LIST *tl, WT_COLLATOR *collator,
+  const WT_ITEM *key, const WT_TRUNCATE_SEARCH_MODE mode, WT_TRUNCATE **tp, bool *is_foundp)
 {
     WT_ASSERT(session, is_foundp != NULL);
-    WT_ASSERT(session, __wt_rwlock_islocked(session, &layered_table->truncate_lock));
+    WT_ASSERT(session, __wt_rwlock_islocked(session, &tl->truncate_lock));
     *is_foundp = false;
 
     WT_STAT_CONN_INCR(session, layered_truncate_list_search_calls);
 
-    WT_COLLATOR *collator = layered_table->collator;
     WT_TRUNCATE *entry = NULL;
 
-    TAILQ_FOREACH (entry, &layered_table->truncateqh, q) {
+    TAILQ_FOREACH (entry, &tl->truncateqh, q) {
         WT_STAT_CONN_INCR(session, layered_truncate_list_search_entries_walked);
 
         wt_timestamp_t start_ts, durable_ts;
@@ -293,7 +295,7 @@ __truncate_search(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered_table, con
  */
 int
 __wt_layered_table_truncate_detect_write_conflict(
-  WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered_table, const WT_ITEM *key)
+  WT_SESSION_IMPL *session, WT_TRUNCATE_LIST *tl, WT_COLLATOR *collator, const WT_ITEM *key)
 {
     WT_DECL_RET;
     bool is_found = false;
@@ -301,19 +303,17 @@ __wt_layered_table_truncate_detect_write_conflict(
     if (FLD_ISSET(S2C(session)->debug.flags, WT_CONN_DEBUG_DISAGG_SLOW_TRUNCATE_FOLLOWER))
         return (0);
 
-    WT_ASSERT(session, WT_PREFIX_MATCH(layered_table->iface.name, "layered:"));
-
     /* FIXME-WT-17384: Investigate the use of atomics to minimize locking. */
-    __wt_readlock(session, &layered_table->truncate_lock);
+    __wt_readlock(session, &tl->truncate_lock);
 
     /*
      * The truncate entry has already been committed if it is visible to this transaction. We can
      * ignore these entries.
      */
     ret = __truncate_search(
-      session, layered_table, key, WT_TRUNCATE_SEARCH_NOT_VISIBLE, NULL, &is_found);
+      session, tl, collator, key, WT_TRUNCATE_SEARCH_NOT_VISIBLE, NULL, &is_found);
 
-    __wt_readunlock(session, &layered_table->truncate_lock);
+    __wt_readunlock(session, &tl->truncate_lock);
     WT_RET(ret);
 
     if (is_found) {
@@ -334,18 +334,17 @@ __wt_layered_table_truncate_detect_write_conflict(
  */
 int
 __wt_layered_table_truncate_detect_non_ingest_write_conflict(WT_SESSION_IMPL *session,
-  WT_LAYERED_TABLE *layered_table, const WT_ITEM *start_key, const WT_ITEM *stop_key)
+  WT_TRUNCATE_LIST *tl, WT_COLLATOR *collator, const WT_ITEM *start_key, const WT_ITEM *stop_key)
 {
     WT_DECL_RET;
 
-    __wt_readlock(session, &layered_table->truncate_lock);
+    __wt_readlock(session, &tl->truncate_lock);
 
     WT_STAT_CONN_INCR(session, layered_truncate_list_search_calls);
 
-    WT_COLLATOR *collator = layered_table->collator;
     WT_TRUNCATE *entry = NULL;
     bool is_found = false;
-    TAILQ_FOREACH (entry, &layered_table->truncateqh, q) {
+    TAILQ_FOREACH (entry, &tl->truncateqh, q) {
         WT_STAT_CONN_INCR(session, layered_truncate_list_search_entries_walked);
 
         wt_timestamp_t start_ts, durable_ts;
@@ -375,7 +374,7 @@ __wt_layered_table_truncate_detect_non_ingest_write_conflict(WT_SESSION_IMPL *se
     }
 
 err:
-    __wt_readunlock(session, &layered_table->truncate_lock);
+    __wt_readunlock(session, &tl->truncate_lock);
     return (ret);
 }
 
@@ -409,8 +408,8 @@ err:
  *     On success, the caller must free start_keyp and stop_keyp.
  */
 int
-__wt_truncate_delete_visible_check(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered_table,
-  WT_ITEM *key, WT_ITEM *start_keyp, WT_ITEM *stop_keyp)
+__wt_truncate_delete_visible_check(WT_SESSION_IMPL *session, WT_TRUNCATE_LIST *tl,
+  WT_COLLATOR *collator, WT_ITEM *key, WT_ITEM *start_keyp, WT_ITEM *stop_keyp)
 {
     /* We either want the full range or no range at all. */
     WT_ASSERT(session, ((start_keyp != NULL) == (stop_keyp != NULL)));
@@ -427,23 +426,21 @@ __wt_truncate_delete_visible_check(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *l
     if (FLD_ISSET(S2C(session)->debug.flags, WT_CONN_DEBUG_DISAGG_SLOW_TRUNCATE_FOLLOWER))
         return (WT_NOTFOUND);
 
-    WT_ASSERT(session, WT_PREFIX_MATCH(layered_table->iface.name, "layered:"));
-
     /* FIXME-WT-17384: Investigate the use of atomics to minimize locking. */
-    __wt_readlock(session, &layered_table->truncate_lock);
+    __wt_readlock(session, &tl->truncate_lock);
 
     /*
      * Ignore all truncate entries that haven't been committed. They won't be visible to this
      * transaction.
      */
     WT_ERR(
-      __truncate_search(session, layered_table, key, WT_TRUNCATE_SEARCH_VISIBLE, &tp, &is_found));
+      __truncate_search(session, tl, collator, key, WT_TRUNCATE_SEARCH_VISIBLE, &tp, &is_found));
 
     if (is_found && start_keyp != NULL)
         WT_ERR(__truncate_entry_copy_keys(session, tp, start_keyp, stop_keyp));
 
 err:
-    __wt_readunlock(session, &layered_table->truncate_lock);
+    __wt_readunlock(session, &tl->truncate_lock);
     WT_RET(ret);
     return (is_found ? 0 : WT_NOTFOUND);
 }
@@ -520,11 +517,12 @@ void
 __wti_layered_table_truncate_rollback_apply(
   WT_SESSION_IMPL *session, WT_LAYERED_TABLE *layered_table, WT_TXN_OP *op)
 {
+    WT_TRUNCATE_LIST *tl = &layered_table->truncate_list;
     WT_TRUNCATE *entry = op->u.follower_truncate.t;
 
-    __wt_writelock(session, &layered_table->truncate_lock);
+    __wt_writelock(session, &tl->truncate_lock);
     __truncate_entry_remove(session, layered_table, entry);
-    __wt_writeunlock(session, &layered_table->truncate_lock);
+    __wt_writeunlock(session, &tl->truncate_lock);
 
     op->u.follower_truncate.t = NULL;
     __disagg_truncate_free(session, &entry);
@@ -550,15 +548,16 @@ __wt_layered_table_truncate_clear(WT_SESSION_IMPL *session, WT_LAYERED_TABLE *la
 {
     WT_ASSERT(session, layered_table != NULL);
 
+    WT_TRUNCATE_LIST *tl = &layered_table->truncate_list;
     WT_TRUNCATE *entry = NULL;
 
-    __wt_writelock(session, &layered_table->truncate_lock);
+    __wt_writelock(session, &tl->truncate_lock);
 
-    while ((entry = TAILQ_FIRST(&layered_table->truncateqh)) != NULL) {
+    while ((entry = TAILQ_FIRST(&tl->truncateqh)) != NULL) {
         __truncate_entry_remove(session, layered_table, entry);
         __disagg_truncate_free(session, &entry);
     }
-    __wt_writeunlock(session, &layered_table->truncate_lock);
+    __wt_writeunlock(session, &tl->truncate_lock);
 }
 
 #ifdef HAVE_UNITTEST

--- a/test/catch2/truncate/test_layered_truncate_visibility.cpp
+++ b/test/catch2/truncate/test_layered_truncate_visibility.cpp
@@ -42,14 +42,14 @@ public:
         REQUIRE(__wt_calloc(session, 1, sizeof(WT_TXN), &session->txn) == 0);
 
         layered_table.iface.name = "layered:test_layered_truncate_visibility";
-        TAILQ_INIT(&layered_table.truncateqh);
-        REQUIRE(__wt_rwlock_init(session, &layered_table.truncate_lock) == 0);
+        TAILQ_INIT(&layered_table.truncate_list.qh);
+        REQUIRE(__wt_rwlock_init(session, &layered_table.truncate_list.lock) == 0);
     }
 
     ~layered_truncate_visibility_fixture()
     {
         __wt_layered_table_truncate_clear(session, &layered_table);
-        __wt_rwlock_destroy(session, &layered_table.truncate_lock);
+        __wt_rwlock_destroy(session, &layered_table.truncate_list.lock);
         __wt_free(session, session->txn);
         __wt_free(session, txn_shared_list);
     }
@@ -120,7 +120,7 @@ public:
         REQUIRE(__wt_buf_set(session, &entry->start_key, start, strlen(start)) == 0);
         REQUIRE(__wt_buf_set(session, &entry->stop_key, stop, strlen(stop)) == 0);
 
-        TAILQ_INSERT_TAIL(&layered_table.truncateqh, entry, q);
+        TAILQ_INSERT_TAIL(&layered_table.truncate_list.qh, entry, q);
         return entry;
     }
 
@@ -131,8 +131,8 @@ public:
         WT_ITEM item{};
         item.data = key.data();
         item.size = key.size();
-        return (__wt_truncate_delete_visible_check(
-          session, &layered_table, &item, start_keyp, stop_keyp));
+        return (__wt_truncate_delete_visible_check(session, &layered_table.truncate_list,
+          layered_table.collator, &item, start_keyp, stop_keyp));
     }
 };
 
@@ -431,7 +431,7 @@ TEST_CASE_METHOD(layered_truncate_visibility_fixture,
 
     __wti_layered_table_truncate_rollback_apply(session, &layered_table, &op);
     REQUIRE(op.u.follower_truncate.t == nullptr);
-    REQUIRE(TAILQ_FIRST(&layered_table.truncateqh) == surviving);
+    REQUIRE(TAILQ_FIRST(&layered_table.truncate_list.qh) == surviving);
     REQUIRE(TAILQ_NEXT(surviving, q) == nullptr);
 
     const char *key = "0125";

--- a/test/catch2/truncate/test_truncate_visible_check.cpp
+++ b/test/catch2/truncate/test_truncate_visible_check.cpp
@@ -44,8 +44,8 @@ struct TruncVisibleCheckFixture {
         /* Build a minimal WT_LAYERED_TABLE with the required "layered:" name prefix. */
         REQUIRE(__wt_calloc(session, 1, sizeof(WT_LAYERED_TABLE), &layered_table) == 0);
         layered_table->iface.name = "layered:unit_test_table";
-        TAILQ_INIT(&layered_table->truncateqh);
-        REQUIRE(__wt_rwlock_init(session, &layered_table->truncate_lock) == 0);
+        TAILQ_INIT(&layered_table->truncate_list.truncateqh);
+        REQUIRE(__wt_rwlock_init(session, &layered_table->truncate_list.truncate_lock) == 0);
         layered_table->collator = nullptr;
     }
 
@@ -53,12 +53,12 @@ struct TruncVisibleCheckFixture {
     {
         /* Free every truncate entry (key data points to string literals; do not free it). */
         WT_TRUNCATE *t;
-        while ((t = TAILQ_FIRST(&layered_table->truncateqh)) != nullptr) {
-            TAILQ_REMOVE(&layered_table->truncateqh, t, q);
+        while ((t = TAILQ_FIRST(&layered_table->truncate_list.truncateqh)) != nullptr) {
+            TAILQ_REMOVE(&layered_table->truncate_list.truncateqh, t, q);
             __wt_free(session, t);
         }
 
-        __wt_rwlock_destroy(session, &layered_table->truncate_lock);
+        __wt_rwlock_destroy(session, &layered_table->truncate_list.truncate_lock);
         __wt_free(session, layered_table);
 
         __wt_free(session, session->txn);
@@ -86,7 +86,7 @@ struct TruncVisibleCheckFixture {
         t->stop_key.data = stop_key;
         t->stop_key.size = strlen(stop_key);
 
-        TAILQ_INSERT_TAIL(&layered_table->truncateqh, t, q);
+        TAILQ_INSERT_TAIL(&layered_table->truncate_list.truncateqh, t, q);
     }
 
     /* Build a stack-allocated WT_ITEM pointing at a string literal. */
@@ -111,40 +111,40 @@ TEST_CASE_METHOD(TruncVisibleCheckFixture,
     SECTION("empty truncate list")
     {
         WT_ITEM key = make_key("key150");
-        CHECK(__wt_truncate_delete_visible_check(session, layered_table, &key, nullptr, nullptr) ==
-          WT_NOTFOUND);
+        CHECK(__wt_truncate_delete_visible_check(session, &layered_table->truncate_list,
+                layered_table->collator, &key, nullptr, nullptr) == WT_NOTFOUND);
     }
 
     SECTION("key before the truncated range")
     {
         add_truncate_entry("key100", "key200");
         WT_ITEM key = make_key("key050");
-        CHECK(__wt_truncate_delete_visible_check(session, layered_table, &key, nullptr, nullptr) ==
-          WT_NOTFOUND);
+        CHECK(__wt_truncate_delete_visible_check(session, &layered_table->truncate_list,
+                layered_table->collator, &key, nullptr, nullptr) == WT_NOTFOUND);
     }
 
     SECTION("key after the truncated range")
     {
         add_truncate_entry("key100", "key200");
         WT_ITEM key = make_key("key250");
-        CHECK(__wt_truncate_delete_visible_check(session, layered_table, &key, nullptr, nullptr) ==
-          WT_NOTFOUND);
+        CHECK(__wt_truncate_delete_visible_check(session, &layered_table->truncate_list,
+                layered_table->collator, &key, nullptr, nullptr) == WT_NOTFOUND);
     }
 
     SECTION("single-key range: key just before")
     {
         add_truncate_entry("key100", "key100");
         WT_ITEM key = make_key("key099");
-        CHECK(__wt_truncate_delete_visible_check(session, layered_table, &key, nullptr, nullptr) ==
-          WT_NOTFOUND);
+        CHECK(__wt_truncate_delete_visible_check(session, &layered_table->truncate_list,
+                layered_table->collator, &key, nullptr, nullptr) == WT_NOTFOUND);
     }
 
     SECTION("single-key range: key just after")
     {
         add_truncate_entry("key100", "key100");
         WT_ITEM key = make_key("key101");
-        CHECK(__wt_truncate_delete_visible_check(session, layered_table, &key, nullptr, nullptr) ==
-          WT_NOTFOUND);
+        CHECK(__wt_truncate_delete_visible_check(session, &layered_table->truncate_list,
+                layered_table->collator, &key, nullptr, nullptr) == WT_NOTFOUND);
     }
 
     SECTION("key between two non-overlapping ranges")
@@ -152,8 +152,8 @@ TEST_CASE_METHOD(TruncVisibleCheckFixture,
         add_truncate_entry("key100", "key200");
         add_truncate_entry("key400", "key500");
         WT_ITEM key = make_key("key300");
-        CHECK(__wt_truncate_delete_visible_check(session, layered_table, &key, nullptr, nullptr) ==
-          WT_NOTFOUND);
+        CHECK(__wt_truncate_delete_visible_check(session, &layered_table->truncate_list,
+                layered_table->collator, &key, nullptr, nullptr) == WT_NOTFOUND);
     }
 }
 
@@ -164,32 +164,32 @@ TEST_CASE_METHOD(TruncVisibleCheckFixture,
     {
         add_truncate_entry("key100", "key200");
         WT_ITEM key = make_key("key150");
-        CHECK(
-          __wt_truncate_delete_visible_check(session, layered_table, &key, nullptr, nullptr) == 0);
+        CHECK(__wt_truncate_delete_visible_check(session, &layered_table->truncate_list,
+                layered_table->collator, &key, nullptr, nullptr) == 0);
     }
 
     SECTION("key at the start boundary (inclusive)")
     {
         add_truncate_entry("key100", "key200");
         WT_ITEM key = make_key("key100");
-        CHECK(
-          __wt_truncate_delete_visible_check(session, layered_table, &key, nullptr, nullptr) == 0);
+        CHECK(__wt_truncate_delete_visible_check(session, &layered_table->truncate_list,
+                layered_table->collator, &key, nullptr, nullptr) == 0);
     }
 
     SECTION("key at the stop boundary (inclusive)")
     {
         add_truncate_entry("key100", "key200");
         WT_ITEM key = make_key("key200");
-        CHECK(
-          __wt_truncate_delete_visible_check(session, layered_table, &key, nullptr, nullptr) == 0);
+        CHECK(__wt_truncate_delete_visible_check(session, &layered_table->truncate_list,
+                layered_table->collator, &key, nullptr, nullptr) == 0);
     }
 
     SECTION("single-key range, exact match")
     {
         add_truncate_entry("key100", "key100");
         WT_ITEM key = make_key("key100");
-        CHECK(
-          __wt_truncate_delete_visible_check(session, layered_table, &key, nullptr, nullptr) == 0);
+        CHECK(__wt_truncate_delete_visible_check(session, &layered_table->truncate_list,
+                layered_table->collator, &key, nullptr, nullptr) == 0);
     }
 
     SECTION("key matched by the first of two non-overlapping ranges")
@@ -197,8 +197,8 @@ TEST_CASE_METHOD(TruncVisibleCheckFixture,
         add_truncate_entry("key100", "key200");
         add_truncate_entry("key400", "key500");
         WT_ITEM key = make_key("key150");
-        CHECK(
-          __wt_truncate_delete_visible_check(session, layered_table, &key, nullptr, nullptr) == 0);
+        CHECK(__wt_truncate_delete_visible_check(session, &layered_table->truncate_list,
+                layered_table->collator, &key, nullptr, nullptr) == 0);
     }
 
     SECTION("key matched by the second of two non-overlapping ranges")
@@ -206,8 +206,8 @@ TEST_CASE_METHOD(TruncVisibleCheckFixture,
         add_truncate_entry("key100", "key200");
         add_truncate_entry("key400", "key500");
         WT_ITEM key = make_key("key450");
-        CHECK(
-          __wt_truncate_delete_visible_check(session, layered_table, &key, nullptr, nullptr) == 0);
+        CHECK(__wt_truncate_delete_visible_check(session, &layered_table->truncate_list,
+                layered_table->collator, &key, nullptr, nullptr) == 0);
     }
 }
 
@@ -219,8 +219,8 @@ TEST_CASE_METHOD(TruncVisibleCheckFixture,
         add_truncate_entry("key100", "key300");
         add_truncate_entry("key200", "key400");
         WT_ITEM key = make_key("key250");
-        CHECK(
-          __wt_truncate_delete_visible_check(session, layered_table, &key, nullptr, nullptr) == 0);
+        CHECK(__wt_truncate_delete_visible_check(session, &layered_table->truncate_list,
+                layered_table->collator, &key, nullptr, nullptr) == 0);
     }
 
     SECTION("key in the first range only (outside the overlap)")
@@ -228,8 +228,8 @@ TEST_CASE_METHOD(TruncVisibleCheckFixture,
         add_truncate_entry("key100", "key300");
         add_truncate_entry("key200", "key400");
         WT_ITEM key = make_key("key150");
-        CHECK(
-          __wt_truncate_delete_visible_check(session, layered_table, &key, nullptr, nullptr) == 0);
+        CHECK(__wt_truncate_delete_visible_check(session, &layered_table->truncate_list,
+                layered_table->collator, &key, nullptr, nullptr) == 0);
     }
 
     SECTION("key in the second range only (outside the overlap)")
@@ -237,8 +237,8 @@ TEST_CASE_METHOD(TruncVisibleCheckFixture,
         add_truncate_entry("key100", "key300");
         add_truncate_entry("key200", "key400");
         WT_ITEM key = make_key("key350");
-        CHECK(
-          __wt_truncate_delete_visible_check(session, layered_table, &key, nullptr, nullptr) == 0);
+        CHECK(__wt_truncate_delete_visible_check(session, &layered_table->truncate_list,
+                layered_table->collator, &key, nullptr, nullptr) == 0);
     }
 }
 
@@ -255,11 +255,11 @@ TEST_CASE_METHOD(
         add_truncate_entry("key100", "key200");
         WT_ITEM key = make_key("key150");
 
-        CHECK(
-          __wt_truncate_delete_visible_check(session, layered_table, &key, nullptr, nullptr) == 0);
+        CHECK(__wt_truncate_delete_visible_check(session, &layered_table->truncate_list,
+                layered_table->collator, &key, nullptr, nullptr) == 0);
 
-        CHECK(__wt_try_writelock(session, &layered_table->truncate_lock) == 0);
-        __wt_writeunlock(session, &layered_table->truncate_lock);
+        CHECK(__wt_try_writelock(session, &layered_table->truncate_list.truncate_lock) == 0);
+        __wt_writeunlock(session, &layered_table->truncate_list.truncate_lock);
     }
 
     SECTION("read lock is released after a miss")
@@ -267,22 +267,22 @@ TEST_CASE_METHOD(
         add_truncate_entry("key100", "key200");
         WT_ITEM key = make_key("key050");
 
-        CHECK(__wt_truncate_delete_visible_check(session, layered_table, &key, nullptr, nullptr) ==
-          WT_NOTFOUND);
+        CHECK(__wt_truncate_delete_visible_check(session, &layered_table->truncate_list,
+                layered_table->collator, &key, nullptr, nullptr) == WT_NOTFOUND);
 
-        CHECK(__wt_try_writelock(session, &layered_table->truncate_lock) == 0);
-        __wt_writeunlock(session, &layered_table->truncate_lock);
+        CHECK(__wt_try_writelock(session, &layered_table->truncate_list.truncate_lock) == 0);
+        __wt_writeunlock(session, &layered_table->truncate_list.truncate_lock);
     }
 
     SECTION("read lock is released when the truncate list is empty")
     {
         WT_ITEM key = make_key("key150");
 
-        CHECK(__wt_truncate_delete_visible_check(session, layered_table, &key, nullptr, nullptr) ==
-          WT_NOTFOUND);
+        CHECK(__wt_truncate_delete_visible_check(session, &layered_table->truncate_list,
+                layered_table->collator, &key, nullptr, nullptr) == WT_NOTFOUND);
 
-        CHECK(__wt_try_writelock(session, &layered_table->truncate_lock) == 0);
-        __wt_writeunlock(session, &layered_table->truncate_lock);
+        CHECK(__wt_try_writelock(session, &layered_table->truncate_list.truncate_lock) == 0);
+        __wt_writeunlock(session, &layered_table->truncate_list.truncate_lock);
     }
 }
 
@@ -293,8 +293,8 @@ TEST_CASE_METHOD(
     {
         add_truncate_entry("key100", "key200");
         WT_ITEM key = make_key("key150");
-        CHECK(
-          __wt_truncate_delete_visible_check(session, layered_table, &key, nullptr, nullptr) == 0);
+        CHECK(__wt_truncate_delete_visible_check(session, &layered_table->truncate_list,
+                layered_table->collator, &key, nullptr, nullptr) == 0);
     }
 
     SECTION("start and stop keys are copied on a match")

--- a/test/catch2/truncate/test_truncate_visible_check.cpp
+++ b/test/catch2/truncate/test_truncate_visible_check.cpp
@@ -44,8 +44,8 @@ struct TruncVisibleCheckFixture {
         /* Build a minimal WT_LAYERED_TABLE with the required "layered:" name prefix. */
         REQUIRE(__wt_calloc(session, 1, sizeof(WT_LAYERED_TABLE), &layered_table) == 0);
         layered_table->iface.name = "layered:unit_test_table";
-        TAILQ_INIT(&layered_table->truncate_list.truncateqh);
-        REQUIRE(__wt_rwlock_init(session, &layered_table->truncate_list.truncate_lock) == 0);
+        TAILQ_INIT(&layered_table->truncate_list.qh);
+        REQUIRE(__wt_rwlock_init(session, &layered_table->truncate_list.lock) == 0);
         layered_table->collator = nullptr;
     }
 
@@ -53,12 +53,12 @@ struct TruncVisibleCheckFixture {
     {
         /* Free every truncate entry (key data points to string literals; do not free it). */
         WT_TRUNCATE *t;
-        while ((t = TAILQ_FIRST(&layered_table->truncate_list.truncateqh)) != nullptr) {
-            TAILQ_REMOVE(&layered_table->truncate_list.truncateqh, t, q);
+        while ((t = TAILQ_FIRST(&layered_table->truncate_list.qh)) != nullptr) {
+            TAILQ_REMOVE(&layered_table->truncate_list.qh, t, q);
             __wt_free(session, t);
         }
 
-        __wt_rwlock_destroy(session, &layered_table->truncate_list.truncate_lock);
+        __wt_rwlock_destroy(session, &layered_table->truncate_list.lock);
         __wt_free(session, layered_table);
 
         __wt_free(session, session->txn);
@@ -86,7 +86,7 @@ struct TruncVisibleCheckFixture {
         t->stop_key.data = stop_key;
         t->stop_key.size = strlen(stop_key);
 
-        TAILQ_INSERT_TAIL(&layered_table->truncate_list.truncateqh, t, q);
+        TAILQ_INSERT_TAIL(&layered_table->truncate_list.qh, t, q);
     }
 
     /* Build a stack-allocated WT_ITEM pointing at a string literal. */
@@ -258,8 +258,8 @@ TEST_CASE_METHOD(
         CHECK(__wt_truncate_delete_visible_check(session, &layered_table->truncate_list,
                 layered_table->collator, &key, nullptr, nullptr) == 0);
 
-        CHECK(__wt_try_writelock(session, &layered_table->truncate_list.truncate_lock) == 0);
-        __wt_writeunlock(session, &layered_table->truncate_list.truncate_lock);
+        CHECK(__wt_try_writelock(session, &layered_table->truncate_list.lock) == 0);
+        __wt_writeunlock(session, &layered_table->truncate_list.lock);
     }
 
     SECTION("read lock is released after a miss")
@@ -270,8 +270,8 @@ TEST_CASE_METHOD(
         CHECK(__wt_truncate_delete_visible_check(session, &layered_table->truncate_list,
                 layered_table->collator, &key, nullptr, nullptr) == WT_NOTFOUND);
 
-        CHECK(__wt_try_writelock(session, &layered_table->truncate_list.truncate_lock) == 0);
-        __wt_writeunlock(session, &layered_table->truncate_list.truncate_lock);
+        CHECK(__wt_try_writelock(session, &layered_table->truncate_list.lock) == 0);
+        __wt_writeunlock(session, &layered_table->truncate_list.lock);
     }
 
     SECTION("read lock is released when the truncate list is empty")
@@ -281,8 +281,8 @@ TEST_CASE_METHOD(
         CHECK(__wt_truncate_delete_visible_check(session, &layered_table->truncate_list,
                 layered_table->collator, &key, nullptr, nullptr) == WT_NOTFOUND);
 
-        CHECK(__wt_try_writelock(session, &layered_table->truncate_list.truncate_lock) == 0);
-        __wt_writeunlock(session, &layered_table->truncate_list.truncate_lock);
+        CHECK(__wt_try_writelock(session, &layered_table->truncate_list.lock) == 0);
+        __wt_writeunlock(session, &layered_table->truncate_list.lock);
     }
 }
 
@@ -306,8 +306,8 @@ TEST_CASE_METHOD(
         WT_ITEM key = make_key("key150");
         WT_ITEM start_key{};
         WT_ITEM stop_key{};
-        REQUIRE(__wt_truncate_delete_visible_check(
-                  session, layered_table, &key, &start_key, &stop_key) == 0);
+        REQUIRE(__wt_truncate_delete_visible_check(session, &layered_table->truncate_list,
+                  layered_table->collator, &key, &start_key, &stop_key) == 0);
 
         REQUIRE(truncate_list_helpers::as_view(start_key) == expected_start_key);
         REQUIRE(truncate_list_helpers::as_view(stop_key) == expected_stop_key);
@@ -323,8 +323,8 @@ TEST_CASE_METHOD(
         WT_ITEM key = make_key("key150");
         WT_ITEM start_key{};
         WT_ITEM stop_key{};
-        REQUIRE(__wt_truncate_delete_visible_check(
-                  session, layered_table, &key, &start_key, &stop_key) == 0);
+        REQUIRE(__wt_truncate_delete_visible_check(session, &layered_table->truncate_list,
+                  layered_table->collator, &key, &start_key, &stop_key) == 0);
 
         /* Modify the source entry. Changes here should not be reflected in the copied keys */
         auto *const head = truncate_list_helpers::truncate_list_head(*layered_table);
@@ -349,8 +349,8 @@ TEST_CASE_METHOD(
         WT_ITEM key = make_key("key450");
         WT_ITEM start_key{};
         WT_ITEM stop_key{};
-        REQUIRE(__wt_truncate_delete_visible_check(
-                  session, layered_table, &key, &start_key, &stop_key) == 0);
+        REQUIRE(__wt_truncate_delete_visible_check(session, &layered_table->truncate_list,
+                  layered_table->collator, &key, &start_key, &stop_key) == 0);
 
         CHECK(truncate_list_helpers::as_view(start_key) == expected_start_key);
         CHECK(truncate_list_helpers::as_view(stop_key) == expected_stop_key);
@@ -366,8 +366,8 @@ TEST_CASE_METHOD(
         WT_ITEM key = make_key("key050");
         WT_ITEM start_key{};
         WT_ITEM stop_key{};
-        CHECK(__wt_truncate_delete_visible_check(
-                session, layered_table, &key, &start_key, &stop_key) == WT_NOTFOUND);
+        CHECK(__wt_truncate_delete_visible_check(session, &layered_table->truncate_list,
+                layered_table->collator, &key, &start_key, &stop_key) == WT_NOTFOUND);
 
         CHECK(start_key.data == nullptr);
         CHECK(stop_key.data == nullptr);

--- a/test/catch2/truncate/test_truncate_write_conflict.cpp
+++ b/test/catch2/truncate/test_truncate_write_conflict.cpp
@@ -162,7 +162,7 @@ public:
         auto key_item = make_item(key_str);
 
         return __wt_layered_table_truncate_detect_write_conflict(
-          session, layered_table(), &key_item);
+          session, &layered_table()->truncate_list, layered_table()->collator, &key_item);
     }
 
     int
@@ -173,8 +173,8 @@ public:
         auto start_item = make_item(start_str);
         auto stop_item = make_item(stop_str);
 
-        return __wt_layered_table_truncate_detect_non_ingest_write_conflict(
-          session, layered_table(), &start_item, &stop_item);
+        return __wt_layered_table_truncate_detect_non_ingest_write_conflict(session,
+          &layered_table()->truncate_list, layered_table()->collator, &start_item, &stop_item);
     }
 
 private:

--- a/test/catch2/truncate/truncate_list_helpers.cpp
+++ b/test/catch2/truncate/truncate_list_helpers.cpp
@@ -34,7 +34,7 @@ as_view(const WT_ITEM &item)
 WT_TRUNCATE *
 truncate_list_head(WT_LAYERED_TABLE &table)
 {
-    return TAILQ_FIRST(&table.truncateqh);
+    return TAILQ_FIRST(&table.truncate_list.qh);
 }
 
 size_t
@@ -43,7 +43,7 @@ truncate_list_size(const WT_LAYERED_TABLE &table)
     size_t count = 0;
     WT_TRUNCATE *entry = nullptr;
 
-    TAILQ_FOREACH (entry, &table.truncateqh, q) {
+    TAILQ_FOREACH (entry, &table.truncate_list.qh, q) {
         ++count;
     }
 
@@ -53,10 +53,10 @@ truncate_list_size(const WT_LAYERED_TABLE &table)
 bool
 lock_is_released(WT_SESSION_IMPL &session, WT_LAYERED_TABLE &table)
 {
-    if (__wt_try_writelock(&session, &table.truncate_lock) != 0)
+    if (__wt_try_writelock(&session, &table.truncate_list.lock) != 0)
         return false;
 
-    __wt_writeunlock(&session, &table.truncate_lock);
+    __wt_writeunlock(&session, &table.truncate_list.lock);
     return true;
 }
 
@@ -71,8 +71,8 @@ truncate_list_fixture::truncate_list_fixture()
     : _mock(mock_session::build_test_mock_session()), _session(_mock->get_wt_session_impl())
 {
     _table.iface.name = "layered:truncate_list_fixture";
-    TAILQ_INIT(&_table.truncateqh);
-    CHECK(__wt_rwlock_init(_session, &_table.truncate_lock) == 0);
+    TAILQ_INIT(&_table.truncate_list.qh);
+    CHECK(__wt_rwlock_init(_session, &_table.truncate_list.lock) == 0);
     CHECK(truncate_list_size(_table) == 0);
 }
 
@@ -80,17 +80,17 @@ truncate_list_fixture::~truncate_list_fixture()
 {
     WT_TRUNCATE *entry = nullptr;
 
-    const bool had_data = !TAILQ_EMPTY(&_table.truncateqh);
+    const bool had_data = !TAILQ_EMPTY(&_table.truncate_list.qh);
 
-    while ((entry = TAILQ_FIRST(&_table.truncateqh)) != nullptr) {
-        TAILQ_REMOVE(&_table.truncateqh, entry, q);
+    while ((entry = TAILQ_FIRST(&_table.truncate_list.qh)) != nullptr) {
+        TAILQ_REMOVE(&_table.truncate_list.qh, entry, q);
         __wt_free(_session, entry);
     }
 
     if (had_data)
         WT_DHANDLE_RELEASE(&_table.iface);
 
-    __wt_rwlock_destroy(_session, &_table.truncate_lock);
+    __wt_rwlock_destroy(_session, &_table.truncate_list.lock);
 }
 
 WT_TRUNCATE *
@@ -101,7 +101,7 @@ truncate_list_fixture::add_entry(const WT_ITEM &start, const WT_ITEM &stop)
 
     entry->layered_table = &_table;
 
-    if (TAILQ_EMPTY(&_table.truncateqh))
+    if (TAILQ_EMPTY(&_table.truncate_list.qh))
         WT_DHANDLE_ACQUIRE(&_table.iface);
 
     // This is a shallow copy. For the purposes of the tests, we are assuming that the WT_ITEMs are
@@ -111,7 +111,7 @@ truncate_list_fixture::add_entry(const WT_ITEM &start, const WT_ITEM &stop)
 
     const auto initial_size = truncate_list_size(_table);
 
-    TAILQ_INSERT_TAIL(&_table.truncateqh, entry, q);
+    TAILQ_INSERT_TAIL(&_table.truncate_list.qh, entry, q);
 
     const auto expected_size = initial_size + 1;
     CHECK(truncate_list_size(_table) == expected_size);


### PR DESCRIPTION
### Scope
Move the layered table's truncate-related state (truncate queue + lock) out of `WT_LAYERED_TABLE` into a separate `WT_TRUNCATE_LIST` struct. The read/detect path now takes the list (and the collator) instead of the whole table, and the per-operation `WT_CLAYERED_OP` carries `truncate_list` rather than the full table.

### Why
A step toward giving the layered-cursor per-operation context and its internal functions only the state they actually need:
- Don't hand functions more information than they use.
- Lets a self-contained `WT_CLAYERED_OP` be unit-tested without mocking the entire layered table.
