### PR TITLE
WT-17920 Detect clang-format location automatically

### DIFF
--- a/dist/s_clang_format
+++ b/dist/s_clang_format
@@ -6,9 +6,17 @@ setup_trap
 cd_top
 check_fast_mode_flag
 
-if ! command -v clang-format &> /dev/null; then
-    echo "error: clang-format not found; please install it and ensure it is on PATH"
-    exit 1
+# Locate the clang-format executable. Prefer one on PATH; otherwise, if clang is
+# available, fall back to the one shipped with the clang toolchain.
+clang_format=`command -v clang-format`
+if [[ -z "$clang_format" ]]; then
+    if command -v clang &> /dev/null; then
+        clang_format=`clang -print-prog-name=clang-format`
+    fi
+    if [[ ! -x "$clang_format" ]]; then
+        echo "error: clang-format not found; please install it and ensure it is on PATH"
+        exit 1
+    fi
 fi
 
 # Parallel execution: if it's the main invocation of the script, collect the file names
@@ -28,7 +36,7 @@ fi
 # We want to be able to detect modifications.
 for f in "$@"; do
     cat "$f" | \
-            clang-format --fallback-style=none | \
+            "$clang_format" --fallback-style=none | \
             python3 dist/s_comment.py > "$t" || exit 1
     if ! cmp -s "$f" "$t"; then
         if [[ -n "$S_RECURSE" ]] ; then

--- a/dist/s_clang_format.list
+++ b/dist/s_clang_format.list
@@ -2,6 +2,7 @@ bench/workgen/workgen.h
 bench/workgen/workgen_int.h
 bench/workgen/workgen_time.h
 bench/workgen/workgen_wrap.cpp
+src/checksum/power8/vec_crc32.c
 src/config/config_def.c
 src/conn/api_strerror.c
 src/include/bitstring_inline.h

--- a/examples/c/ex_encrypt.c
+++ b/examples/c/ex_encrypt.c
@@ -30,14 +30,17 @@
  */
 #include <test_util.h>
 
-#ifdef _WIN32
 /*
- * Explicitly export this function so it is visible when loading extensions.
+ * On Windows, explicitly export this function so it is visible when loading extensions.
  */
-__declspec(dllexport)
+#ifdef _WIN32
+#define EX_EXPORT __declspec(dllexport)
+#else
+#define EX_EXPORT
 #endif
-int
-add_my_encryptors(WT_CONNECTION *connection);
+
+EX_EXPORT
+int add_my_encryptors(WT_CONNECTION *connection);
 
 static const char *home;
 

--- a/examples/c/ex_file_system.c
+++ b/examples/c/ex_file_system.c
@@ -104,14 +104,18 @@ typedef struct demo_file_handle {
 /*
  * Extension initialization function.
  */
-#ifdef _WIN32
+
 /*
- * Explicitly export this function so it is visible when loading extensions.
+ * On Windows, explicitly export this function so it is visible when loading extensions.
  */
-__declspec(dllexport)
+#ifdef _WIN32
+#define EX_EXPORT __declspec(dllexport)
+#else
+#define EX_EXPORT
 #endif
-int
-demo_file_system_create(WT_CONNECTION *, WT_CONFIG_ARG *);
+
+EX_EXPORT
+int demo_file_system_create(WT_CONNECTION *, WT_CONFIG_ARG *);
 
 /*
  * Forward function declarations for file system API implementation

--- a/test/packing/intpack-test3.c
+++ b/test/packing/intpack-test3.c
@@ -71,8 +71,8 @@ test_value(int64_t val)
           "Unpack consumed wrong size for %" PRId64 ", expected %" WT_SIZET_FMT
           ", got %" WT_SIZET_FMT "\n",
           sinput, used_len,
-          cp > p ? used_len + (size_t)(cp - p) : /* More than buf used */
-                   used_len - (size_t)(p - cp));        /* Less than buf used */
+          /* More or less buffer used than expected. */
+          cp > p ? used_len + (size_t)(cp - p) : used_len - (size_t)(p - cp));
         abort();
     }
 

--- a/test/utility/test_util.h
+++ b/test/utility/test_util.h
@@ -449,10 +449,13 @@ typedef struct {
 #define scan_end_check(a) testutil_assert(a)
 
 #ifdef _WIN32
-__declspec(noreturn)
+#define TESTUTIL_NORETURN __declspec(noreturn)
+#else
+#define TESTUTIL_NORETURN
 #endif
-void
-testutil_die(int, const char *, ...) WT_GCC_FUNC_ATTRIBUTE((cold))
+
+TESTUTIL_NORETURN
+void testutil_die(int, const char *, ...) WT_GCC_FUNC_ATTRIBUTE((cold))
   WT_GCC_FUNC_DECL_ATTRIBUTE((noreturn));
 
 /*


### PR DESCRIPTION
- Pick `clang-format` from `PATH` or installed LLVM toolchain
- Smooth style differences between `clang-format` versions (19, 21, 22) so all versions produce consistent formatting.