### PR TITLE
WT-17926 Fix WT_NOTFOUND propagation in __metadata_clean_incomplete_table for read-only connections

### DIFF
--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -946,6 +946,7 @@ __metadata_clean_incomplete_table(WT_RECOVERY *r, const char *uri, const char *c
         __wt_verbose_level_multi(r->session, WT_VERB_RECOVERY_ALL, WT_VERBOSE_WARNING,
           "cannot remove incomplete table '%s' (%s, %s) in readonly mode", uri, colgroup_msg,
           file_msg);
+        ret = 0;
         goto done;
     }
 

--- a/test/suite/test_recovery03.py
+++ b/test/suite/test_recovery03.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wiredtiger
+import wttest
+
+@wttest.skip_for_hook("tiered", "test depends on metadata recovery")
+@wttest.skip_for_hook("disagg", "log tables is not supported on disagg")
+class test_recovery03(wttest.WiredTigerTestCase):
+    def test_recovery03(self):
+        self.session.create('table:test_ok', 'key_format=i,value_format=i')
+
+        # Inject an incomplete table entry.
+        cursor = self.session.open_cursor('metadata:', None, 'readonly=0')
+        cursor['table:recovery03'] = 'columns=()'
+        cursor.close()
+
+        # Close the connection to flush metadata to disk.
+        self.close_conn()
+
+        # Reopen in read-only mode.
+        with self.expectedStdoutPattern(
+                r'cannot remove incomplete table .* in readonly mode'):
+            self.conn = self.wiredtiger_open(self.home, 'readonly=true')
+            self.session = self.setUpSessionOpen(self.conn)


### PR DESCRIPTION
When a WiredTiger database is opened in read-only mode and the metadata contains an incomplete table entry (e.g., from an interrupted session.create that wrote the table key but not the colgroup or file entries), startup fails with WT_NOTFOUND. In __metadata_clean_incomplete_table (src/txn/txn_recover.c line 885) , after checking for missing colgroup or file metadata via WT_ERR_NOTFOUND_OK(..., true), ret retains WT_NOTFOUND; the read-only branch logs a warning and executes goto done, but done shares the same cleanup block as err and returns ret directly, propagating WT_NOTFOUND up through __recovery_file_scan to the caller, aborting the open, despite the code's clear intent to tolerate incomplete tables in read-only mode and succeed.

For Reproduce:
Added a python suite test (test/suite/test_recovery03.py) reproduces the bug and verifies the fix. Without the fix, wiredtiger_open returns WT_NOTFOUND and startup fails entirely despite the code's intent to warn and continue. With the fix, wiredtiger_open returns 0, logs a warning, and the read-only connection opens successfully. (I added before/after outputs on JIRA)

Testing:
- ./dist/s_all runned
- environment: GCC 13, Ubuntu 24.04