### PR TITLE
WT-17584 Clean up checkpoint prepare-flag parsing in prepared_discover

### DIFF
--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -775,6 +775,8 @@ extern int __wt_meta_checkpoint_by_name(WT_SESSION_IMPL *session, const char *ur
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_meta_checkpoint_clear(WT_SESSION_IMPL *session, const char *fname)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_meta_checkpoint_has_prepare(WT_SESSION_IMPL *session, const char *config,
+  bool *has_prepp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_meta_checkpoint_last_name(
   WT_SESSION_IMPL *session, const char *fname, const char **namep, int64_t *orderp, uint64_t *timep)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));

--- a/src/meta/meta_ckpt.c
+++ b/src/meta/meta_ckpt.c
@@ -94,6 +94,30 @@ __ckpt_load_blk_mods(WT_SESSION_IMPL *session, const char *config, WT_CKPT *ckpt
 }
 
 /*
+ * __wt_meta_checkpoint_has_prepare --
+ *     Return whether any checkpoint entry in the config string has the prepare flag set.
+ */
+int
+__wt_meta_checkpoint_has_prepare(WT_SESSION_IMPL *session, const char *config, bool *has_prepp)
+{
+    WT_CONFIG ckptconf;
+    WT_CONFIG_ITEM cval, key, value;
+    WT_DECL_RET;
+
+    *has_prepp = false;
+
+    WT_RET(__wt_config_getones(session, config, "checkpoint", &cval));
+    __wt_config_subinit(session, &ckptconf, &cval);
+    for (; __wt_config_next(&ckptconf, &key, &cval) == 0;) {
+        ret = __wt_config_subgets(session, &cval, "prepare", &value);
+        if (ret == 0 && value.val)
+            *has_prepp = true;
+        WT_RET_NOTFOUND_OK(ret);
+    }
+    return (0);
+}
+
+/*
  * __wt_meta_checkpoint --
  *     Return a file's checkpoint information.
  */

--- a/src/prepared_discover/prepared_discover_walk.c
+++ b/src/prepared_discover/prepared_discover_walk.c
@@ -9,33 +9,6 @@
 #include "wt_internal.h"
 
 /*
- * __prepared_discover_btree_has_prepare --
- *     Check the metadata entry for a btree to see whether it included prepared updates.
- */
-static int
-__prepared_discover_btree_has_prepare(WT_SESSION_IMPL *session, const char *config, bool *has_prepp)
-{
-    WT_CONFIG ckptconf;
-    WT_CONFIG_ITEM cval, key, value;
-    WT_DECL_RET;
-
-    *has_prepp = false;
-
-    /* This configuration parsing is copied out of the rollback to stable implementation */
-    WT_RET(__wt_config_getones(session, config, "checkpoint", &cval));
-    __wt_config_subinit(session, &ckptconf, &cval);
-    for (; __wt_config_next(&ckptconf, &key, &cval) == 0;) {
-        ret = __wt_config_subgets(session, &cval, "prepare", &value);
-        if (ret == 0) {
-            if (value.val)
-                *has_prepp = true;
-        }
-        WT_RET_NOTFOUND_OK(ret);
-    }
-    return (0);
-}
-
-/*
  * __prepared_discover_is_follower_stable_walk --
  *     Return true when prepared discovery should read this URI from the stable checkpoint and
  *     replay onto ingest: a disaggregated follower walking a layered stable constituent.
@@ -476,7 +449,7 @@ __wt_prepared_discover_filter_apply_handles(WT_SESSION_IMPL *session)
         if (ret == WT_NOTFOUND)
             config = NULL;
         /* Check to see if there is any prepared content in the handle */
-        WT_ERR(__prepared_discover_btree_has_prepare(session, config, &has_prepare));
+        WT_ERR(__wt_meta_checkpoint_has_prepare(session, config, &has_prepare));
         if (!has_prepare)
             continue;
         if (__prepared_discover_is_follower_stable_walk(session, uri)) {


### PR DESCRIPTION
## Summary

`prepared_discover_walk.c` contained a standalone loop that checked the `prepare` flag in checkpoint config sub-entries, with a comment noting it was copied from the RTS implementation. This PR extracts that logic into `__wt_meta_checkpoint_has_prepare` in `src/meta/meta_ckpt.c` and calls it directly from the prepared_discover call site.

## Why not also refactor the RTS loop?

The RTS loop in `rts_btree_walk.c` parses five additional fields (`newest_start_durable_ts`, `newest_stop_durable_ts`, `newest_txn`, `addr`, `write_gen`) that are specific to rollback-to-stable. Two alternatives were considered and rejected:

- **Full-struct helper** (`__wt_meta_checkpoint_parse_info` returning all six fields): would make RTS call the helper for all fields in a single pass, but packages RTS-specific fields into a general-purpose API and changes the verbose log from per-entry to once-after-parse.
- **Config-iterator helper** (shared setup, callers own their loops): shares only the two-line `__wt_config_getones` + `__wt_config_subinit` boilerplate; the prepare-flag logic would still be independently written in both callers' loop bodies.

The prepare-flag check inside the RTS loop is incidental — embedded alongside five other field reads in a single pass and cannot be delegated to `__wt_meta_checkpoint_has_prepare` without a second pass over the config. The standalone copy in `prepared_discover` is what was actually duplicated, and that is what this PR removes.