### PR TITLE
WT-17680 (test) Always Bump Snapshot for Eviction Under Precise Checkpoint

### DIFF
--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -1288,20 +1288,7 @@ __evict_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t evict_flags)
          * being processed. Therefore, we use snapshot API that doesn't publish shared IDs to the
          * outside world.
          */
-        if (F_ISSET(conn, WT_CONN_PRECISE_CHECKPOINT) && !F_ISSET(btree, WT_BTREE_IN_MEMORY)) {
-            uint64_t btree_ckpt_gen, ckpt_gen;
-            /*
-             * If precise checkpoint is configured, only evict the updates that visible to the
-             * ongoing checkpoint for trees haven't been visited by the checkpoint.
-             */
-            btree_ckpt_gen = __wt_atomic_load_uint64_acquire(&btree->checkpoint_gen);
-            ckpt_gen = __wt_gen(session, WT_GEN_CHECKPOINT);
-            if (btree_ckpt_gen < ckpt_gen)
-                LF_SET(WT_REC_VISIBLE_NO_SNAPSHOT);
-            else
-                __wt_txn_bump_snapshot(session);
-        } else
-            __wt_txn_bump_snapshot(session);
+        __wt_txn_bump_snapshot(session);
     } else if (use_snapshot_for_app_thread) {
         /*
          * If we couldn't make progress with the application thread's existing snapshot, save the

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -725,24 +725,11 @@ __rec_init(WT_SESSION_IMPL *session, WT_REF *ref, uint32_t flags, WT_SALVAGE_COO
 
     if (LF_ISSET(WT_REC_VISIBLE_NO_SNAPSHOT)) {
         WT_ASSERT(session, LF_ISSET(WT_REC_EVICT));
-        WT_TXN_GLOBAL *txn_global = &conn->txn_global;
-        /*
-         * If precise checkpoint is enabled, set the reconciliation's pinned id to the checkpoint's
-         * pinned id. This forbids eviction to evict anything that is not visible to the current
-         * checkpoint.
-         */
-        if (F_ISSET(conn, WT_CONN_PRECISE_CHECKPOINT)) {
-            r->rec_start_pinned_id =
-              __wt_atomic_load_uint64_v_acquire(&txn_global->checkpoint_txn_shared.pinned_id);
-            if (r->rec_start_pinned_id == WT_TXN_NONE)
-                r->rec_start_pinned_id =
-                  __wt_atomic_load_uint64_v_acquire(&txn_global->last_running);
-        } else
-            r->rec_start_pinned_id = __wt_atomic_load_uint64_v_acquire(&txn_global->last_running);
+        r->rec_start_pinned_id = __wt_atomic_load_uint64_v_acquire(&conn->txn_global.last_running);
 
         if (WT_IS_METADATA(session->dhandle) || WT_IS_DISAGG_META(session->dhandle)) {
             uint64_t ckpt_txn;
-            WT_ACQUIRE_READ_WITH_BARRIER(ckpt_txn, txn_global->checkpoint_txn_shared.id);
+            WT_ACQUIRE_READ_WITH_BARRIER(ckpt_txn, conn->txn_global.checkpoint_txn_shared.id);
             if (ckpt_txn != WT_TXN_NONE && ckpt_txn < r->rec_start_pinned_id)
                 r->rec_start_pinned_id = ckpt_txn;
         }


### PR DESCRIPTION
Summarize the reason behind this change (this might be the problem you're solving, or the context around the request) and the solution you have chosen.
