### PR TITLE
WT-17939 Add shared disk cache lock contention stat

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -350,6 +350,7 @@ conn_stats = [
     CacheStat('cache_shared_dsk_bytes_duplicate', 'shared disk bytes saved by sharing duplicate disk images', 'no_clear,no_scale,size'),
     CacheStat('cache_shared_dsk_hash_size', 'shared disk hash table size', 'no_clear,no_scale'),
     CacheStat('cache_shared_dsk_hit', 'shared disk hit'),
+    CacheStat('cache_shared_dsk_lock_contention', 'shared disk bucket lock contention count'),
     CacheStat('cache_shared_dsk_miss', 'shared disk miss'),
     CacheStat('cache_tolerance_level', 'cache tolerance configured', 'no_clear,no_scale,size'),
     CacheStat('cache_updates_txn_uncommitted_bytes', 'updates in uncommitted txn - bytes', 'no_clear,no_scale,size'),

--- a/src/cache/shared_dsk.c
+++ b/src/cache/shared_dsk.c
@@ -51,7 +51,10 @@ __wt_shared_dsk_cache_get(WT_SESSION_IMPL *session, const uint8_t *addr, size_t 
     hash = __wt_hash_city64(addr, addr_size);
     bucket = hash % shared_dsk_cache->hash_size;
     lock_idx = bucket % shared_dsk_cache->hash_lock_size;
-    __wt_spin_lock(session, &shared_dsk_cache->hash_locks[lock_idx]);
+    if (__wt_spin_trylock(session, &shared_dsk_cache->hash_locks[lock_idx]) != 0) {
+        WT_STAT_CONN_INCR(session, cache_shared_dsk_lock_contention);
+        __wt_spin_lock(session, &shared_dsk_cache->hash_locks[lock_idx]);
+    }
     TAILQ_FOREACH (shared_dsk_item, &shared_dsk_cache->hash[bucket], hashq) {
         if (shared_dsk_item->addr_size == addr_size && shared_dsk_item->fid == S2BT(session)->id &&
           memcmp(shared_dsk_item->addr, addr, addr_size) == 0) {
@@ -131,7 +134,10 @@ __wt_shared_dsk_cache_put(WT_SESSION_IMPL *session, void *data, size_t data_size
      * Because collisions are unlikely, the allocation and copying remains outside of the bucket
      * lock and collision check.
      */
-    __wt_spin_lock(session, &shared_dsk_cache->hash_locks[lock_idx]);
+    if (__wt_spin_trylock(session, &shared_dsk_cache->hash_locks[lock_idx]) != 0) {
+        WT_STAT_CONN_INCR(session, cache_shared_dsk_lock_contention);
+        __wt_spin_lock(session, &shared_dsk_cache->hash_locks[lock_idx]);
+    }
     TAILQ_FOREACH (shared_dsk_item, &shared_dsk_cache->hash[bucket], hashq) {
 #ifdef HAVE_DIAGNOSTIC
         ++bucket_walk;
@@ -206,14 +212,17 @@ __wt_shared_dsk_cache_release(WT_SESSION_IMPL *session, WT_SHARED_DSK_ITEM *shar
     hash = __wt_hash_city64(shared_dsk_item->addr, shared_dsk_item->addr_size);
     bucket = hash % shared_dsk_cache->hash_size;
     lock_idx = bucket % shared_dsk_cache->hash_lock_size;
-
-    __wt_spin_lock(session, &shared_dsk_cache->hash_locks[lock_idx]);
-    WT_ASSERT(session, shared_dsk_item->ref_count > 0);
     data_size = shared_dsk_item->data_size;
+    dsk_type = ((WT_PAGE_HEADER *)shared_dsk_item->data)->type;
+
+    if (__wt_spin_trylock(session, &shared_dsk_cache->hash_locks[lock_idx]) != 0) {
+        WT_STAT_CONN_INCR(session, cache_shared_dsk_lock_contention);
+        __wt_spin_lock(session, &shared_dsk_cache->hash_locks[lock_idx]);
+    }
+    WT_ASSERT(session, shared_dsk_item->ref_count > 0);
     /* Remove the shared dsk item when ref count is reduced to 0. */
     if (--shared_dsk_item->ref_count == 0) {
         TAILQ_REMOVE(&shared_dsk_cache->hash[bucket], shared_dsk_item, hashq);
-        dsk_type = ((WT_PAGE_HEADER *)shared_dsk_item->data)->type;
         __wt_spin_unlock(session, &shared_dsk_cache->hash_locks[lock_idx]);
 
         /* Symmetrically drain the cache on last release. */

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -771,6 +771,7 @@ struct __wt_connection_stats {
     int64_t cache_scrub_restore;
     int64_t cache_reverse_splits;
     int64_t cache_reverse_splits_skipped_vlcs;
+    int64_t cache_shared_dsk_lock_contention;
     int64_t cache_shared_dsk_bytes_duplicate;
     int64_t cache_shared_dsk_hash_size;
     int64_t cache_shared_dsk_hit;

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -7283,1769 +7283,1771 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
  * restrictions
  */
 #define	WT_STAT_CONN_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	1344
+/*! cache: shared disk bucket lock contention count */
+#define	WT_STAT_CONN_CACHE_SHARED_DSK_LOCK_CONTENTION	1345
 /*! cache: shared disk bytes saved by sharing duplicate disk images */
-#define	WT_STAT_CONN_CACHE_SHARED_DSK_BYTES_DUPLICATE	1345
+#define	WT_STAT_CONN_CACHE_SHARED_DSK_BYTES_DUPLICATE	1346
 /*! cache: shared disk hash table size */
-#define	WT_STAT_CONN_CACHE_SHARED_DSK_HASH_SIZE		1346
+#define	WT_STAT_CONN_CACHE_SHARED_DSK_HASH_SIZE		1347
 /*! cache: shared disk hit */
-#define	WT_STAT_CONN_CACHE_SHARED_DSK_HIT		1347
+#define	WT_STAT_CONN_CACHE_SHARED_DSK_HIT		1348
 /*! cache: shared disk miss */
-#define	WT_STAT_CONN_CACHE_SHARED_DSK_MISS		1348
+#define	WT_STAT_CONN_CACHE_SHARED_DSK_MISS		1349
 /*! cache: shared history store cursor not cached during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_HS_SHARED_CURSOR_NOT_CACHED	1349
+#define	WT_STAT_CONN_CACHE_EVICTION_HS_SHARED_CURSOR_NOT_CACHED	1350
 /*! cache: size of delta updates reconstructed on the base page */
-#define	WT_STAT_CONN_CACHE_READ_DELTA_UPDATES		1350
+#define	WT_STAT_CONN_CACHE_READ_DELTA_UPDATES		1351
 /*! cache: size of tombstones restored when reading a page */
-#define	WT_STAT_CONN_CACHE_READ_RESTORED_TOMBSTONE_BYTES	1351
+#define	WT_STAT_CONN_CACHE_READ_RESTORED_TOMBSTONE_BYTES	1352
 /*! cache: the number of times full update inserted to history store */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1352
+#define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1353
 /*! cache: the number of times reverse modify inserted to history store */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1353
+#define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1354
 /*! cache: time eviction worker threads spend waiting for locks (usecs) */
-#define	WT_STAT_CONN_EVICTION_WORKER_LOCK_WAIT_TIME	1354
+#define	WT_STAT_CONN_EVICTION_WORKER_LOCK_WAIT_TIME	1355
 /*!
  * cache: total milliseconds spent inside reentrant history store
  * evictions in a reconciliation
  */
-#define	WT_STAT_CONN_EVICTION_REENTRY_HS_EVICTION_MILLISECONDS	1355
+#define	WT_STAT_CONN_EVICTION_REENTRY_HS_EVICTION_MILLISECONDS	1356
 /*! cache: tracked bytes belonging to internal pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1356
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1357
 /*!
  * cache: tracked bytes belonging to internal pages in the cache from the
  * ingest btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL_INGEST	1357
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL_INGEST	1358
 /*!
  * cache: tracked bytes belonging to internal pages in the cache from the
  * stable btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL_STABLE	1358
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL_STABLE	1359
 /*! cache: tracked bytes belonging to leaf pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1359
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1360
 /*!
  * cache: tracked bytes belonging to leaf pages in the cache from the
  * ingest btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF_INGEST		1360
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF_INGEST		1361
 /*!
  * cache: tracked bytes belonging to leaf pages in the cache from the
  * stable btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF_STABLE		1361
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF_STABLE		1362
 /*! cache: tracked dirty bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1362
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1363
 /*! cache: tracked dirty bytes in the cache from the ingest btrees */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INGEST		1363
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INGEST		1364
 /*! cache: tracked dirty bytes in the cache from the stable btrees */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_STABLE		1364
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_STABLE		1365
 /*! cache: tracked dirty internal page bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL		1365
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL		1366
 /*!
  * cache: tracked dirty internal page bytes in the cache from the ingest
  * btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL_INGEST	1366
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL_INGEST	1367
 /*!
  * cache: tracked dirty internal page bytes in the cache from the stable
  * btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL_STABLE	1367
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL_STABLE	1368
 /*! cache: tracked dirty leaf page bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF		1368
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF		1369
 /*!
  * cache: tracked dirty leaf page bytes in the cache from the ingest
  * btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF_INGEST	1369
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF_INGEST	1370
 /*!
  * cache: tracked dirty leaf page bytes in the cache from the stable
  * btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF_STABLE	1370
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF_STABLE	1371
 /*! cache: tracked dirty pages in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1371
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1372
 /*! cache: tracked dirty pages in the cache from the ingest btrees */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY_INGEST		1372
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY_INGEST		1373
 /*! cache: tracked dirty pages in the cache from the stable btrees */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY_STABLE		1373
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY_STABLE		1374
 /*! cache: uncommitted truncate blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	1374
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	1375
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1375
+#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1376
 /*! cache: update bytes belonging to the history store table in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_HS_UPDATES		1376
+#define	WT_STAT_CONN_CACHE_BYTES_HS_UPDATES		1377
 /*! cache: updates in uncommitted txn - bytes */
-#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_BYTES	1377
+#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_BYTES	1378
 /*! cache: updates in uncommitted txn - count */
-#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_COUNT	1378
+#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_COUNT	1379
 /*! capacity: background fsync file handles considered */
-#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1379
+#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1380
 /*! capacity: background fsync file handles synced */
-#define	WT_STAT_CONN_FSYNC_ALL_FH			1380
+#define	WT_STAT_CONN_FSYNC_ALL_FH			1381
 /*! capacity: background fsync time (msecs) */
-#define	WT_STAT_CONN_FSYNC_ALL_TIME			1381
+#define	WT_STAT_CONN_FSYNC_ALL_TIME			1382
 /*! capacity: bytes read */
-#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1382
+#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1383
 /*! capacity: bytes written for checkpoint */
-#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1383
+#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1384
 /*! capacity: bytes written for eviction */
-#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1384
+#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1385
 /*! capacity: bytes written for log */
-#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1385
+#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1386
 /*! capacity: bytes written total */
-#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1386
+#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1387
 /*! capacity: threshold to call fsync */
-#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1387
+#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1388
 /*! capacity: time waiting due to total capacity (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1388
+#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1389
 /*! capacity: time waiting during checkpoint (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1389
+#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1390
 /*! capacity: time waiting during eviction (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1390
+#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1391
 /*! capacity: time waiting during logging (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1391
+#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1392
 /*! capacity: time waiting during read (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_READ			1392
+#define	WT_STAT_CONN_CAPACITY_TIME_READ			1393
 /*! checkpoint-cleanup: most recent duration on all eligible files (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_DURATION	1393
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_DURATION	1394
 /*! checkpoint-cleanup: most recent handles processed */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_HANDLE_PROCESSED	1394
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_HANDLE_PROCESSED	1395
 /*! checkpoint-cleanup: most recent in-memory pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_INMEM_PAGES_VISITED	1395
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_INMEM_PAGES_VISITED	1396
 /*! checkpoint-cleanup: pages added for eviction */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_EVICT	1396
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_EVICT	1397
 /*! checkpoint-cleanup: pages dirtied due to obsolete time window */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	1397
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	1398
 /*! checkpoint-cleanup: pages read into cache (reclaim_space) */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	1398
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	1399
 /*! checkpoint-cleanup: pages read into cache due to obsolete time window */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	1399
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	1400
 /*! checkpoint-cleanup: pages removed */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_REMOVED	1400
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_REMOVED	1401
 /*! checkpoint-cleanup: pages skipped during tree walk */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	1401
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	1402
 /*! checkpoint-cleanup: pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_VISITED	1402
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_VISITED	1403
 /*! checkpoint-cleanup: successful calls */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_SUCCESS		1403
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_SUCCESS		1404
 /*! checkpoint: checkpoint has acquired a snapshot for its transaction */
-#define	WT_STAT_CONN_CHECKPOINT_SNAPSHOT_ACQUIRED	1404
+#define	WT_STAT_CONN_CHECKPOINT_SNAPSHOT_ACQUIRED	1405
 /*! checkpoint: checkpoints skipped because database was clean */
-#define	WT_STAT_CONN_CHECKPOINT_SKIPPED			1405
+#define	WT_STAT_CONN_CHECKPOINT_SKIPPED			1406
 /*! checkpoint: fsync calls after allocating the transaction ID */
-#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST		1406
+#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST		1407
 /*! checkpoint: fsync duration after allocating the transaction ID (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST_DURATION	1407
+#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST_DURATION	1408
 /*! checkpoint: generation */
-#define	WT_STAT_CONN_CHECKPOINT_GENERATION		1408
+#define	WT_STAT_CONN_CHECKPOINT_GENERATION		1409
 /*! checkpoint: max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_MAX		1409
+#define	WT_STAT_CONN_CHECKPOINT_TIME_MAX		1410
 /*!
  * checkpoint: metadata operations applied during disaggregated
  * checkpoint
  */
-#define	WT_STAT_CONN_CHECKPOINT_DISAGG_METADATA_APPLY	1410
+#define	WT_STAT_CONN_CHECKPOINT_DISAGG_METADATA_APPLY	1411
 /*!
  * checkpoint: metadata operations skipped during disaggregated
  * checkpoint because they were not stable
  */
-#define	WT_STAT_CONN_CHECKPOINT_DISAGG_METADATA_UNSTABLE	1411
+#define	WT_STAT_CONN_CHECKPOINT_DISAGG_METADATA_UNSTABLE	1412
 /*! checkpoint: min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_MIN		1412
+#define	WT_STAT_CONN_CHECKPOINT_TIME_MIN		1413
 /*!
  * checkpoint: most recent duration for checkpoint dropping all handles
  * (usecs)
  */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROP_DURATION	1413
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROP_DURATION	1414
 /*! checkpoint: most recent duration for gathering all handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION		1414
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION		1415
 /*! checkpoint: most recent duration for gathering applied handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLY_DURATION	1415
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLY_DURATION	1416
 /*! checkpoint: most recent duration for gathering skipped handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIP_DURATION	1416
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIP_DURATION	1417
 /*! checkpoint: most recent duration for handles metadata checked (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECK_DURATION	1417
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECK_DURATION	1418
 /*! checkpoint: most recent duration for locking the handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCK_DURATION	1418
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCK_DURATION	1419
 /*! checkpoint: most recent handles applied */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLIED		1419
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLIED		1420
 /*! checkpoint: most recent handles checkpoint dropped */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROPPED		1420
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROPPED		1421
 /*! checkpoint: most recent handles metadata checked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECKED	1421
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECKED	1422
 /*! checkpoint: most recent handles metadata locked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCKED		1422
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCKED		1423
 /*! checkpoint: most recent handles skipped */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIPPED		1423
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIPPED		1424
 /*! checkpoint: most recent handles walked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_WALKED		1424
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_WALKED		1425
 /*! checkpoint: most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_RECENT		1425
+#define	WT_STAT_CONN_CHECKPOINT_TIME_RECENT		1426
 /*! checkpoint: number of bytes reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED_BYTES	1426
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED_BYTES	1427
 /*! checkpoint: number of checkpoints started by api */
-#define	WT_STAT_CONN_CHECKPOINTS_API			1427
+#define	WT_STAT_CONN_CHECKPOINTS_API			1428
 /*! checkpoint: number of checkpoints started by compaction */
-#define	WT_STAT_CONN_CHECKPOINTS_COMPACT		1428
+#define	WT_STAT_CONN_CHECKPOINTS_COMPACT		1429
 /*! checkpoint: number of files synced */
-#define	WT_STAT_CONN_CHECKPOINT_SYNC			1429
+#define	WT_STAT_CONN_CHECKPOINT_SYNC			1430
 /*! checkpoint: number of handles visited after writes complete */
-#define	WT_STAT_CONN_CHECKPOINT_PRESYNC			1430
+#define	WT_STAT_CONN_CHECKPOINT_PRESYNC			1431
 /*! checkpoint: number of history store pages reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_HS_PAGES_RECONCILED	1431
+#define	WT_STAT_CONN_CHECKPOINT_HS_PAGES_RECONCILED	1432
 /*! checkpoint: number of internal pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_INTERNAL	1432
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_INTERNAL	1433
 /*! checkpoint: number of leaf pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_LEAF	1433
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_LEAF	1434
 /*! checkpoint: number of pages reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED	1434
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED	1435
 /*!
  * checkpoint: number of pages reconciled by checkpoint parallel worker
  * threads
  */
-#define	WT_STAT_CONN_CHECKPOINT_PARALLEL_PAGES_RECONCILED	1435
+#define	WT_STAT_CONN_CHECKPOINT_PARALLEL_PAGES_RECONCILED	1436
 /*! checkpoint: prepare currently running */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1436
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1437
 /*! checkpoint: prepare max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1437
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1438
 /*! checkpoint: prepare min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1438
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1439
 /*! checkpoint: prepare most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1439
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1440
 /*! checkpoint: prepare total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1440
+#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1441
 /*! checkpoint: progress state */
-#define	WT_STAT_CONN_CHECKPOINT_STATE			1441
+#define	WT_STAT_CONN_CHECKPOINT_STATE			1442
 /*! checkpoint: scrub dirty target */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1442
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1443
 /*! checkpoint: scrub max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1443
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1444
 /*! checkpoint: scrub min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1444
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1445
 /*! checkpoint: scrub most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1445
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1446
 /*! checkpoint: scrub total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1446
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1447
 /*! checkpoint: stop timing stress active */
-#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1447
+#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1448
 /*!
  * checkpoint: the percentage of checkpoint sync time spent in
  * reconciliation across all threads
  */
-#define	WT_STAT_CONN_CHECKPOINT_SYNC_REC_PCT		1448
+#define	WT_STAT_CONN_CHECKPOINT_SYNC_REC_PCT		1449
 /*! checkpoint: time spent on per-tree checkpoint work (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1449
+#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1450
 /*! checkpoint: total failed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1450
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1451
 /*! checkpoint: total succeed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1451
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1452
 /*! checkpoint: total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1452
+#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1453
 /*!
  * checkpoint: total time (msecs) writing pages to stable storage during
  * checkpoint reconciliation
  */
-#define	WT_STAT_CONN_CHECKPOINT_REC_BLKCACHE_WRITE	1453
+#define	WT_STAT_CONN_CHECKPOINT_REC_BLKCACHE_WRITE	1454
 /*! checkpoint: wait cycles while cache dirty level is decreasing */
-#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1454
+#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1455
 /*! connection: auto adjusting condition resets */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1455
+#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1456
 /*! connection: auto adjusting condition wait calls */
-#define	WT_STAT_CONN_COND_AUTO_WAIT			1456
+#define	WT_STAT_CONN_COND_AUTO_WAIT			1457
 /*!
  * connection: auto adjusting condition wait raced to update timeout and
  * skipped updating
  */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1457
+#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1458
 /*! connection: btrees currently open */
-#define	WT_STAT_CONN_BTREE_OPEN				1458
+#define	WT_STAT_CONN_BTREE_OPEN				1459
 /*! connection: detected system time went backwards */
-#define	WT_STAT_CONN_TIME_TRAVEL			1459
+#define	WT_STAT_CONN_TIME_TRAVEL			1460
 /*! connection: files currently open */
-#define	WT_STAT_CONN_FILE_OPEN				1460
+#define	WT_STAT_CONN_FILE_OPEN				1461
 /*! connection: hash bucket array size for data handles */
-#define	WT_STAT_CONN_BUCKETS_DH				1461
+#define	WT_STAT_CONN_BUCKETS_DH				1462
 /*! connection: hash bucket array size general */
-#define	WT_STAT_CONN_BUCKETS				1462
+#define	WT_STAT_CONN_BUCKETS				1463
 /*! connection: memory allocations */
-#define	WT_STAT_CONN_MEMORY_ALLOCATION			1463
+#define	WT_STAT_CONN_MEMORY_ALLOCATION			1464
 /*! connection: memory frees */
-#define	WT_STAT_CONN_MEMORY_FREE			1464
+#define	WT_STAT_CONN_MEMORY_FREE			1465
 /*! connection: memory re-allocations */
-#define	WT_STAT_CONN_MEMORY_GROW			1465
+#define	WT_STAT_CONN_MEMORY_GROW			1466
 /*! connection: number of sessions without a sweep for 5+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1466
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1467
 /*! connection: number of sessions without a sweep for 60+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1467
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1468
 /*! connection: pthread mutex condition wait calls */
-#define	WT_STAT_CONN_COND_WAIT				1468
+#define	WT_STAT_CONN_COND_WAIT				1469
 /*! connection: pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			1469
+#define	WT_STAT_CONN_RWLOCK_READ			1470
 /*! connection: pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			1470
+#define	WT_STAT_CONN_RWLOCK_WRITE			1471
 /*! connection: total fsync I/Os */
-#define	WT_STAT_CONN_FSYNC_IO				1471
+#define	WT_STAT_CONN_FSYNC_IO				1472
 /*! connection: total read I/Os */
-#define	WT_STAT_CONN_READ_IO				1472
+#define	WT_STAT_CONN_READ_IO				1473
 /*! connection: total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				1473
+#define	WT_STAT_CONN_WRITE_IO				1474
 /*! cursor: Total number of deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1474
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1475
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1475
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1476
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1476
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1477
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1477
+#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1478
 /*!
  * cursor: Total number of in-memory deleted pages skipped during tree
  * walk
  */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1478
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1479
 /*! cursor: Total number of on-disk deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1479
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1480
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1480
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1481
 /*!
  * cursor: Total number of times cursor fails to temporarily release
  * pinned page to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1481
+#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1482
 /*!
  * cursor: Total number of times cursor temporarily releases pinned page
  * to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION			1482
+#define	WT_STAT_CONN_CURSOR_REPOSITION			1483
 /*! cursor: bulk cursor count */
-#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1483
+#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1484
 /*! cursor: cached cursor count */
-#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1484
+#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1485
 /*! cursor: cursor bound calls that return an error */
-#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1485
+#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1486
 /*! cursor: cursor bounds cleared from reset */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1486
+#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1487
 /*! cursor: cursor bounds comparisons performed */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1487
+#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1488
 /*! cursor: cursor bounds next called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1488
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1489
 /*! cursor: cursor bounds next early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1489
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1490
 /*! cursor: cursor bounds prev called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1490
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1491
 /*! cursor: cursor bounds prev early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1491
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1492
 /*! cursor: cursor bounds search early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1492
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1493
 /*! cursor: cursor bounds search near call repositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1493
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1494
 /*! cursor: cursor bulk loaded cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1494
+#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1495
 /*! cursor: cursor cache calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1495
+#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1496
 /*! cursor: cursor close calls that result in cache */
-#define	WT_STAT_CONN_CURSOR_CACHE			1496
+#define	WT_STAT_CONN_CURSOR_CACHE			1497
 /*! cursor: cursor close calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1497
+#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1498
 /*! cursor: cursor compare calls that return an error */
-#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1498
+#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1499
 /*! cursor: cursor create calls */
-#define	WT_STAT_CONN_CURSOR_CREATE			1499
+#define	WT_STAT_CONN_CURSOR_CREATE			1500
 /*! cursor: cursor equals calls that return an error */
-#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1500
+#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1501
 /*! cursor: cursor get key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1501
+#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1502
 /*! cursor: cursor get value calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1502
+#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1503
 /*! cursor: cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT			1503
+#define	WT_STAT_CONN_CURSOR_INSERT			1504
 /*! cursor: cursor insert calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1504
+#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1505
 /*! cursor: cursor insert check calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1505
+#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1506
 /*! cursor: cursor insert key and value bytes */
-#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1506
+#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1507
 /*! cursor: cursor largest key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1507
+#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1508
 /*! cursor: cursor modify calls */
-#define	WT_STAT_CONN_CURSOR_MODIFY			1508
+#define	WT_STAT_CONN_CURSOR_MODIFY			1509
 /*! cursor: cursor modify calls that return an error */
-#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1509
+#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1510
 /*! cursor: cursor modify key and value bytes affected */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1510
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1511
 /*! cursor: cursor modify value bytes modified */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1511
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1512
 /*! cursor: cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT			1512
+#define	WT_STAT_CONN_CURSOR_NEXT			1513
 /*! cursor: cursor next calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1513
+#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1514
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1514
+#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1515
 /*!
  * cursor: cursor next calls that skip greater than 1 and fewer than 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1515
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1516
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1516
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1517
 /*! cursor: cursor next random calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1517
+#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1518
 /*! cursor: cursor operation restarted */
-#define	WT_STAT_CONN_CURSOR_RESTART			1518
+#define	WT_STAT_CONN_CURSOR_RESTART			1519
 /*! cursor: cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV			1519
+#define	WT_STAT_CONN_CURSOR_PREV			1520
 /*! cursor: cursor prev calls that return an error */
-#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1520
+#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1521
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1521
+#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1522
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1522
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1523
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1523
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1524
 /*! cursor: cursor reconfigure calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1524
+#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1525
 /*! cursor: cursor remove calls */
-#define	WT_STAT_CONN_CURSOR_REMOVE			1525
+#define	WT_STAT_CONN_CURSOR_REMOVE			1526
 /*! cursor: cursor remove calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1526
+#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1527
 /*! cursor: cursor remove key bytes removed */
-#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1527
+#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1528
 /*! cursor: cursor reopen calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1528
+#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1529
 /*! cursor: cursor reserve calls */
-#define	WT_STAT_CONN_CURSOR_RESERVE			1529
+#define	WT_STAT_CONN_CURSOR_RESERVE			1530
 /*! cursor: cursor reserve calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1530
+#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1531
 /*! cursor: cursor reset calls */
-#define	WT_STAT_CONN_CURSOR_RESET			1531
+#define	WT_STAT_CONN_CURSOR_RESET			1532
 /*! cursor: cursor reset calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1532
+#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1533
 /*! cursor: cursor search calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH			1533
+#define	WT_STAT_CONN_CURSOR_SEARCH			1534
 /*! cursor: cursor search calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1534
+#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1535
 /*! cursor: cursor search history store calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1535
+#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1536
 /*! cursor: cursor search near calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1536
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1537
 /*! cursor: cursor search near calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1537
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1538
 /*! cursor: cursor sweep buckets */
-#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1538
+#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1539
 /*! cursor: cursor sweep cursors closed */
-#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1539
+#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1540
 /*! cursor: cursor sweep cursors examined */
-#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1540
+#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1541
 /*! cursor: cursor sweeps */
-#define	WT_STAT_CONN_CURSOR_SWEEP			1541
+#define	WT_STAT_CONN_CURSOR_SWEEP			1542
 /*! cursor: cursor truncate calls */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE			1542
+#define	WT_STAT_CONN_CURSOR_TRUNCATE			1543
 /*! cursor: cursor truncates performed on individual keys */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1543
+#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1544
 /*! cursor: cursor update calls */
-#define	WT_STAT_CONN_CURSOR_UPDATE			1544
+#define	WT_STAT_CONN_CURSOR_UPDATE			1545
 /*! cursor: cursor update calls that return an error */
-#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1545
+#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1546
 /*! cursor: cursor update key and value bytes */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1546
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1547
 /*! cursor: cursor update value size change */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1547
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1548
 /*! cursor: cursors reused from cache */
-#define	WT_STAT_CONN_CURSOR_REOPEN			1548
+#define	WT_STAT_CONN_CURSOR_REOPEN			1549
 /*! cursor: open cursor count */
-#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1549
+#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1550
 /*! cursor: open cursor time application (usecs) */
-#define	WT_STAT_CONN_CURSOR_OPEN_TIME_USER_USECS	1550
+#define	WT_STAT_CONN_CURSOR_OPEN_TIME_USER_USECS	1551
 /*! cursor: open cursor time internal (usecs) */
-#define	WT_STAT_CONN_CURSOR_OPEN_TIME_INTERNAL_USECS	1551
+#define	WT_STAT_CONN_CURSOR_OPEN_TIME_INTERNAL_USECS	1552
 /*! data-handle: Layered connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_LAYERED_COUNT	1552
+#define	WT_STAT_CONN_DH_CONN_HANDLE_LAYERED_COUNT	1553
 /*! data-handle: Table connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TABLE_COUNT		1553
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TABLE_COUNT		1554
 /*! data-handle: Tiered connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_COUNT	1554
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_COUNT	1555
 /*! data-handle: Tiered_Tree connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_TREE_COUNT	1555
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_TREE_COUNT	1556
 /*! data-handle: btree connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_BTREE_COUNT		1556
+#define	WT_STAT_CONN_DH_CONN_HANDLE_BTREE_COUNT		1557
 /*! data-handle: checkpoint connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_CHECKPOINT_COUNT	1557
+#define	WT_STAT_CONN_DH_CONN_HANDLE_CHECKPOINT_COUNT	1558
 /*! data-handle: connection data handle size */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1558
+#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1559
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1559
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1560
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1560
+#define	WT_STAT_CONN_DH_SWEEP_REF			1561
 /*! data-handle: connection sweep dead dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_DEAD_CLOSE		1561
+#define	WT_STAT_CONN_DH_SWEEP_DEAD_CLOSE		1562
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1562
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1563
 /*! data-handle: connection sweep expired dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_EXPIRED_CLOSE		1563
+#define	WT_STAT_CONN_DH_SWEEP_EXPIRED_CLOSE		1564
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1564
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1565
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1565
+#define	WT_STAT_CONN_DH_SWEEPS				1566
 /*!
  * data-handle: connection sweeps skipped due to checkpoint gathering
  * handles
  */
-#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1566
+#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1567
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1567
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1568
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1568
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1569
 /*! disagg: abandon checkpoints failed */
-#define	WT_STAT_CONN_DISAGG_ABANDON_CHECKPOINT_FAILED	1569
+#define	WT_STAT_CONN_DISAGG_ABANDON_CHECKPOINT_FAILED	1570
 /*! disagg: abandon checkpoints succeeded */
-#define	WT_STAT_CONN_DISAGG_ABANDON_CHECKPOINT_SUCCEED	1570
+#define	WT_STAT_CONN_DISAGG_ABANDON_CHECKPOINT_SUCCEED	1571
 /*! disagg: apply checkpoint metadata most recent time (msecs) */
-#define	WT_STAT_CONN_DISAGG_APPLY_CHECKPOINT_META_TIME	1571
+#define	WT_STAT_CONN_DISAGG_APPLY_CHECKPOINT_META_TIME	1572
 /*! disagg: connection reconfiguration */
-#define	WT_STAT_CONN_DISAGG_CONN_RECONFIG		1572
+#define	WT_STAT_CONN_DISAGG_CONN_RECONFIG		1573
 /*! disagg: database size */
-#define	WT_STAT_CONN_DISAGG_DATABASE_SIZE		1573
+#define	WT_STAT_CONN_DISAGG_DATABASE_SIZE		1574
 /*!
  * disagg: existing file metadata entries updated during checkpoint pick-
  * up
  */
-#define	WT_STAT_CONN_DISAGG_PICK_UP_FILE_META_UPDATED	1574
+#define	WT_STAT_CONN_DISAGG_PICK_UP_FILE_META_UPDATED	1575
 /*! disagg: new file metadata entries inserted during checkpoint pick-up */
-#define	WT_STAT_CONN_DISAGG_PICK_UP_FILE_META_INSERTED	1575
+#define	WT_STAT_CONN_DISAGG_PICK_UP_FILE_META_INSERTED	1576
 /*! disagg: pick up checkpoint most recent time (msecs) */
-#define	WT_STAT_CONN_DISAGG_PICK_UP_CHECKPOINT_TIME	1576
+#define	WT_STAT_CONN_DISAGG_PICK_UP_CHECKPOINT_TIME	1577
 /*! disagg: role leader */
-#define	WT_STAT_CONN_DISAGG_ROLE_LEADER			1577
+#define	WT_STAT_CONN_DISAGG_ROLE_LEADER			1578
 /*! disagg: step down most recent time (msecs) */
-#define	WT_STAT_CONN_DISAGG_STEP_DOWN_TIME		1578
+#define	WT_STAT_CONN_DISAGG_STEP_DOWN_TIME		1579
 /*! disagg: step up most recent time (msecs) */
-#define	WT_STAT_CONN_DISAGG_STEP_UP_TIME		1579
+#define	WT_STAT_CONN_DISAGG_STEP_UP_TIME		1580
 /*! layered: Layered table cursor insert operations */
-#define	WT_STAT_CONN_LAYERED_CURS_INSERT		1580
+#define	WT_STAT_CONN_LAYERED_CURS_INSERT		1581
 /*! layered: Layered table cursor modify operations */
-#define	WT_STAT_CONN_LAYERED_CURS_MODIFY		1581
+#define	WT_STAT_CONN_LAYERED_CURS_MODIFY		1582
 /*! layered: Layered table cursor next operations */
-#define	WT_STAT_CONN_LAYERED_CURS_NEXT			1582
+#define	WT_STAT_CONN_LAYERED_CURS_NEXT			1583
 /*! layered: Layered table cursor next operations from the ingest btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_NEXT_INGEST		1583
+#define	WT_STAT_CONN_LAYERED_CURS_NEXT_INGEST		1584
 /*! layered: Layered table cursor next operations from the stable btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_NEXT_STABLE		1584
+#define	WT_STAT_CONN_LAYERED_CURS_NEXT_STABLE		1585
 /*!
  * layered: Layered table cursor opens the stable btree for the first
  * time
  */
-#define	WT_STAT_CONN_LAYERED_CURS_OPEN_STABLE		1585
+#define	WT_STAT_CONN_LAYERED_CURS_OPEN_STABLE		1586
 /*! layered: Layered table cursor prev operations */
-#define	WT_STAT_CONN_LAYERED_CURS_PREV			1586
+#define	WT_STAT_CONN_LAYERED_CURS_PREV			1587
 /*! layered: Layered table cursor prev operations from the ingest btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_PREV_INGEST		1587
+#define	WT_STAT_CONN_LAYERED_CURS_PREV_INGEST		1588
 /*! layered: Layered table cursor prev operations from the stable btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_PREV_STABLE		1588
+#define	WT_STAT_CONN_LAYERED_CURS_PREV_STABLE		1589
 /*! layered: Layered table cursor remove operations */
-#define	WT_STAT_CONN_LAYERED_CURS_REMOVE		1589
+#define	WT_STAT_CONN_LAYERED_CURS_REMOVE		1590
 /*!
  * layered: Layered table cursor reopens the stable btree (role change or
  * checkpoint advance)
  */
-#define	WT_STAT_CONN_LAYERED_CURS_REOPEN_STABLE		1590
+#define	WT_STAT_CONN_LAYERED_CURS_REOPEN_STABLE		1591
 /*! layered: Layered table cursor search near operations */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR		1591
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR		1592
 /*!
  * layered: Layered table cursor search near operations from the ingest
  * btrees
  */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_INGEST	1592
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_INGEST	1593
 /*!
  * layered: Layered table cursor search near operations from the stable
  * btrees
  */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_STABLE	1593
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_STABLE	1594
 /*! layered: Layered table cursor search operations */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH		1594
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH		1595
 /*! layered: Layered table cursor search operations from the ingest btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_INGEST		1595
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_INGEST		1596
 /*! layered: Layered table cursor search operations from the stable btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_STABLE		1596
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_STABLE		1597
 /*! layered: Layered table cursor update operations */
-#define	WT_STAT_CONN_LAYERED_CURS_UPDATE		1597
+#define	WT_STAT_CONN_LAYERED_CURS_UPDATE		1598
 /*!
  * layered: checkpoints performed on this table by the layered table
  * manager
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS	1598
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS	1599
 /*! layered: disagg pick up checkpoints failed */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FAILED	1599
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FAILED	1600
 /*! layered: disagg pick up checkpoints succeeded */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_SUCCEED	1600
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_SUCCEED	1601
 /*!
  * layered: how many log applications the layered table manager applied
  * on this tree
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_APPLIED	1601
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_APPLIED	1602
 /*!
  * layered: how many log applications the layered table manager skipped
  * on this tree
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_SKIPPED	1602
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_SKIPPED	1603
 /*!
  * layered: how many previously-applied LSNs the layered table manager
  * skipped on this tree
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_SKIP_LSN	1603
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_SKIP_LSN	1604
 /*! layered: number of checkpoints picked up by a follower */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FOLLOWER	1604
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FOLLOWER	1605
 /*! layered: the number of tables the layered table manager has open */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_TABLES	1605
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_TABLES	1606
 /*! layered: the number of times the truncate list was searched */
-#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_SEARCH_CALLS	1606
+#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_SEARCH_CALLS	1607
 /*!
  * layered: the number of times truncate list garbage collection ran with
  * a valid prune timestamp
  */
-#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_GC_RUNS	1607
+#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_GC_RUNS	1608
 /*!
  * layered: the number of truncate list entries removed by garbage
  * collection
  */
-#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_GC_ENTRIES_REMOVED	1608
+#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_GC_ENTRIES_REMOVED	1609
 /*! layered: the number of truncate list entries walked during search */
-#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_SEARCH_ENTRIES_WALKED	1609
+#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_SEARCH_ENTRIES_WALKED	1610
 /*!
  * live-restore: number of bytes copied from the source to the
  * destination
  */
-#define	WT_STAT_CONN_LIVE_RESTORE_BYTES_COPIED		1610
+#define	WT_STAT_CONN_LIVE_RESTORE_BYTES_COPIED		1611
 /*! live-restore: number of files remaining for migration completion */
-#define	WT_STAT_CONN_LIVE_RESTORE_WORK_REMAINING	1611
+#define	WT_STAT_CONN_LIVE_RESTORE_WORK_REMAINING	1612
 /*! live-restore: number of reads from the source database */
-#define	WT_STAT_CONN_LIVE_RESTORE_SOURCE_READ_COUNT	1612
+#define	WT_STAT_CONN_LIVE_RESTORE_SOURCE_READ_COUNT	1613
 /*! live-restore: source read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT2	1613
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT2	1614
 /*! live-restore: source read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT5	1614
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT5	1615
 /*! live-restore: source read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT10	1615
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT10	1616
 /*! live-restore: source read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT50	1616
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT50	1617
 /*! live-restore: source read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT100	1617
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT100	1618
 /*! live-restore: source read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT250	1618
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT250	1619
 /*! live-restore: source read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT500	1619
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT500	1620
 /*! live-restore: source read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT1000	1620
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT1000	1621
 /*! live-restore: source read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_GT1000	1621
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_GT1000	1622
 /*! live-restore: source read latency histogram total (msecs) */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_TOTAL_MSECS	1622
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_TOTAL_MSECS	1623
 /*! live-restore: state */
-#define	WT_STAT_CONN_LIVE_RESTORE_STATE			1623
+#define	WT_STAT_CONN_LIVE_RESTORE_STATE			1624
 /*! load-control: number of read operations rejected due to load control */
-#define	WT_STAT_CONN_READ_REJECT_COUNT			1624
+#define	WT_STAT_CONN_READ_REJECT_COUNT			1625
 /*! load-control: number of write operations rejected due to load control */
-#define	WT_STAT_CONN_WRITE_REJECT_COUNT			1625
+#define	WT_STAT_CONN_WRITE_REJECT_COUNT			1626
 /*! load-control: read load at the system level */
-#define	WT_STAT_CONN_READ_LOAD				1626
+#define	WT_STAT_CONN_READ_LOAD				1627
 /*! load-control: write load at the system level */
-#define	WT_STAT_CONN_WRITE_LOAD				1627
+#define	WT_STAT_CONN_WRITE_LOAD				1628
 /*! lock: btree page lock acquisitions */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_COUNT		1628
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_COUNT		1629
 /*! lock: btree page lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_APPLICATION	1629
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_APPLICATION	1630
 /*! lock: btree page lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_INTERNAL	1630
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_INTERNAL	1631
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1631
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1632
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1632
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1633
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1633
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1634
 /*! lock: dhandle lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1634
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1635
 /*! lock: dhandle lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1635
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1636
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1636
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1637
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1637
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1638
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1638
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1639
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1639
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1640
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1640
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1641
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1641
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1642
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1642
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1643
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1643
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1644
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1644
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1645
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1645
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1646
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1646
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1647
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1647
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1648
 /*! lock: txn global lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1648
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1649
 /*! lock: txn global lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1649
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1650
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1650
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1651
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1651
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1652
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1652
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1653
 /*! log: force log remove time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1653
+#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1654
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1654
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1655
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1655
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1656
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1656
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1657
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1657
+#define	WT_STAT_CONN_LOG_FLUSH				1658
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1658
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1659
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1659
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1660
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1660
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1661
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1661
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1662
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1662
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1663
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1663
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1664
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1664
+#define	WT_STAT_CONN_LOG_SCANS				1665
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1665
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1666
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1666
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1667
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1667
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1668
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1668
+#define	WT_STAT_CONN_LOG_SYNC				1669
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1669
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1670
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1670
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1671
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1671
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1672
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1672
+#define	WT_STAT_CONN_LOG_WRITES				1673
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1673
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1674
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1674
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1675
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1675
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1676
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1676
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1677
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1677
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1678
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1678
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1679
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1679
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1680
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1680
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1681
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1681
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1682
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1682
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1683
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1683
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1684
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1684
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1685
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1685
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1686
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1686
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1687
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1687
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1688
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1688
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1689
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1689
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1690
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1690
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1691
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1691
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1692
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1692
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1693
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1693
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1694
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1694
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1695
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1695
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1696
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1696
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1697
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1697
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1698
 /*! perf: block manager read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT2	1698
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT2	1699
 /*! perf: block manager read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT5	1699
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT5	1700
 /*! perf: block manager read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT10	1700
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT10	1701
 /*! perf: block manager read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT50	1701
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT50	1702
 /*! perf: block manager read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT100	1702
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT100	1703
 /*! perf: block manager read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT250	1703
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT250	1704
 /*! perf: block manager read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT500	1704
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT500	1705
 /*! perf: block manager read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT1000	1705
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT1000	1706
 /*! perf: block manager read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_GT1000	1706
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_GT1000	1707
 /*! perf: block manager read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_TOTAL_MSECS	1707
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_TOTAL_MSECS	1708
 /*! perf: block manager write latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT2	1708
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT2	1709
 /*! perf: block manager write latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT5	1709
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT5	1710
 /*! perf: block manager write latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT10	1710
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT10	1711
 /*! perf: block manager write latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT50	1711
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT50	1712
 /*! perf: block manager write latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT100	1712
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT100	1713
 /*! perf: block manager write latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT250	1713
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT250	1714
 /*! perf: block manager write latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT500	1714
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT500	1715
 /*! perf: block manager write latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT1000	1715
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT1000	1716
 /*! perf: block manager write latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_GT1000	1716
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_GT1000	1717
 /*! perf: block manager write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_TOTAL_MSECS	1717
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_TOTAL_MSECS	1718
 /*! perf: disagg block manager read latency histogram (bucket 1) - 50-99us */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT100	1718
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT100	1719
 /*!
  * perf: disagg block manager read latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT250	1719
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT250	1720
 /*!
  * perf: disagg block manager read latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT500	1720
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT500	1721
 /*!
  * perf: disagg block manager read latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT1000	1721
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT1000	1722
 /*!
  * perf: disagg block manager read latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT2500	1722
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT2500	1723
 /*!
  * perf: disagg block manager read latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT5000	1723
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT5000	1724
 /*!
  * perf: disagg block manager read latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT10000	1724
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT10000	1725
 /*!
  * perf: disagg block manager read latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_GT10000	1725
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_GT10000	1726
 /*! perf: disagg block manager read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_TOTAL_USECS	1726
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_TOTAL_USECS	1727
 /*!
  * perf: disagg block manager write latency histogram (bucket 1) -
  * 50-99us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT100	1727
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT100	1728
 /*!
  * perf: disagg block manager write latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT250	1728
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT250	1729
 /*!
  * perf: disagg block manager write latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT500	1729
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT500	1730
 /*!
  * perf: disagg block manager write latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT1000	1730
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT1000	1731
 /*!
  * perf: disagg block manager write latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT2500	1731
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT2500	1732
 /*!
  * perf: disagg block manager write latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT5000	1732
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT5000	1733
 /*!
  * perf: disagg block manager write latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT10000	1733
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT10000	1734
 /*!
  * perf: disagg block manager write latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_GT10000	1734
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_GT10000	1735
 /*! perf: disagg block manager write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_TOTAL_USECS	1735
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_TOTAL_USECS	1736
 /*! perf: file system read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT2	1736
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT2	1737
 /*! perf: file system read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT5	1737
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT5	1738
 /*! perf: file system read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1738
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1739
 /*! perf: file system read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1739
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1740
 /*! perf: file system read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1740
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1741
 /*! perf: file system read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1741
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1742
 /*! perf: file system read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1742
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1743
 /*! perf: file system read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1743
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1744
 /*! perf: file system read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1744
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1745
 /*! perf: file system read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1745
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1746
 /*! perf: file system write latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT2	1746
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT2	1747
 /*! perf: file system write latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT5	1747
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT5	1748
 /*! perf: file system write latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1748
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1749
 /*! perf: file system write latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1749
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1750
 /*! perf: file system write latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1750
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1751
 /*! perf: file system write latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1751
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1752
 /*! perf: file system write latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1752
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1753
 /*! perf: file system write latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1753
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1754
 /*! perf: file system write latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1754
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1755
 /*! perf: file system write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1755
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1756
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 1) -
  * 0-100us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT100	1756
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT100	1757
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT250	1757
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT250	1758
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT500	1758
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT500	1759
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT1000	1759
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT1000	1760
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT2500	1760
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT2500	1761
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT5000	1761
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT5000	1762
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT10000	1762
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT10000	1763
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_GT10000	1763
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_GT10000	1764
 /*! perf: internal page deltas reconstruct latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_TOTAL_USECS	1764
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_TOTAL_USECS	1765
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 1) -
  * 0-100us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT100	1765
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT100	1766
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT250	1766
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT250	1767
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT500	1767
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT500	1768
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT1000	1768
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT1000	1769
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT2500	1769
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT2500	1770
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT5000	1770
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT5000	1771
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT10000	1771
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT10000	1772
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_GT10000	1772
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_GT10000	1773
 /*! perf: leaf page deltas reconstruct latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_TOTAL_USECS	1773
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_TOTAL_USECS	1774
 /*! perf: operation read latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1774
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1775
 /*! perf: operation read latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1775
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1776
 /*! perf: operation read latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1776
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1777
 /*! perf: operation read latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1777
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1778
 /*! perf: operation read latency histogram (bucket 5) - 1000-2499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT2500	1778
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT2500	1779
 /*! perf: operation read latency histogram (bucket 6) - 2500-4999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT5000	1779
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT5000	1780
 /*! perf: operation read latency histogram (bucket 7) - 5000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1780
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1781
 /*! perf: operation read latency histogram (bucket 8) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1781
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1782
 /*! perf: operation read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1782
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1783
 /*! perf: operation write latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1783
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1784
 /*! perf: operation write latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1784
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1785
 /*! perf: operation write latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1785
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1786
 /*! perf: operation write latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1786
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1787
 /*! perf: operation write latency histogram (bucket 5) - 1000-2499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT2500	1787
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT2500	1788
 /*! perf: operation write latency histogram (bucket 6) - 2500-4999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT5000	1788
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT5000	1789
 /*! perf: operation write latency histogram (bucket 7) - 5000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1789
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1790
 /*! perf: operation write latency histogram (bucket 8) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1790
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1791
 /*! perf: operation write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1791
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1792
 /*! prefetch: could not perform pre-fetch on internal page */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1792
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1793
 /*!
  * prefetch: could not perform pre-fetch on ref without the pre-fetch
  * flag set
  */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1793
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1794
 /*! prefetch: pre-fetch attempted, session has pre-fetching enabled */
-#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1794
+#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1795
 /*! prefetch: pre-fetch not repeating for recently pre-fetched ref */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1795
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1796
 /*! prefetch: pre-fetch not triggered after single disk read */
-#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1796
+#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1797
 /*! prefetch: pre-fetch not triggered as there is no valid dhandle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1797
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1798
 /*! prefetch: pre-fetch not triggered due to disk read count */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1798
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1799
 /*! prefetch: pre-fetch not triggered due to internal session */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1799
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1800
 /*! prefetch: pre-fetch not triggered due to special btree handle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1800
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1801
 /*! prefetch: pre-fetch not triggered, pre-fetch queue is full */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_QUEUE_FULL	1801
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_QUEUE_FULL	1802
 /*! prefetch: pre-fetch page not on disk when reading */
-#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1802
+#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1803
 /*! prefetch: pre-fetch pages queued */
-#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1803
+#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1804
 /*! prefetch: pre-fetch pages read in background */
-#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1804
+#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1805
 /*!
  * prefetch: pre-fetch session check passed, pre-fetch work issued to
  * btree
  */
-#define	WT_STAT_CONN_PREFETCH_ATTEMPTS_SUCCEEDED	1805
+#define	WT_STAT_CONN_PREFETCH_ATTEMPTS_SUCCEEDED	1806
 /*! prefetch: pre-fetch skipped reading in a page due to harmless error */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1806
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1807
 /*!
  * prefetch: pre-fetch skipped traversal of internal page due to active
  * split generation
  */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SPLIT_GEN	1807
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SPLIT_GEN	1808
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1808
+#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1809
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1809
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1810
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1810
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1811
 /*!
  * reconciliation: average length of delta chain on internal page with
  * deltas
  */
-#define	WT_STAT_CONN_REC_AVERAGE_INTERNAL_PAGE_DELTA_CHAIN_LENGTH	1811
+#define	WT_STAT_CONN_REC_AVERAGE_INTERNAL_PAGE_DELTA_CHAIN_LENGTH	1812
 /*! reconciliation: average length of delta chain on leaf page with deltas */
-#define	WT_STAT_CONN_REC_AVERAGE_LEAF_PAGE_DELTA_CHAIN_LENGTH	1812
+#define	WT_STAT_CONN_REC_AVERAGE_LEAF_PAGE_DELTA_CHAIN_LENGTH	1813
 /*!
  * reconciliation: changes since prior reconciliation (bucket 1) between
  * 1 and 5
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE5			1813
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE5			1814
 /*!
  * reconciliation: changes since prior reconciliation (bucket 2) between
  * 6 and 10
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE10			1814
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE10			1815
 /*!
  * reconciliation: changes since prior reconciliation (bucket 3) between
  * 11 and 20
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE20			1815
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE20			1816
 /*!
  * reconciliation: changes since prior reconciliation (bucket 4) between
  * 21 and 50
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE50			1816
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE50			1817
 /*!
  * reconciliation: changes since prior reconciliation (bucket 5) between
  * 51 and 100
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE100		1817
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE100		1818
 /*!
  * reconciliation: changes since prior reconciliation (bucket 6) between
  * 101 and 200
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE200		1818
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE200		1819
 /*!
  * reconciliation: changes since prior reconciliation (bucket 7) between
  * 201 and 500
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE500		1819
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE500		1820
 /*!
  * reconciliation: changes since prior reconciliation (bucket 8) greater
  * than 500
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_GT500		1820
+#define	WT_STAT_CONN_REC_PAGE_MODS_GT500		1821
 /*! reconciliation: cursor next/prev calls during HS wrapup search_near */
-#define	WT_STAT_CONN_REC_HS_WRAPUP_NEXT_PREV_CALLS	1821
+#define	WT_STAT_CONN_REC_HS_WRAPUP_NEXT_PREV_CALLS	1822
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1822
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1823
 /*!
  * reconciliation: free page ID due to failed page replacement
  * reconciliation in disagg
  */
-#define	WT_STAT_CONN_REC_FREE_PAGE_ID_DUE_TO_FAILED_REPLACEMENT_RECONCILIATION	1823
+#define	WT_STAT_CONN_REC_FREE_PAGE_ID_DUE_TO_FAILED_REPLACEMENT_RECONCILIATION	1824
 /*! reconciliation: full internal pages written instead of a page delta */
-#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_INTERNAL	1824
+#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_INTERNAL	1825
 /*! reconciliation: full leaf pages written instead of a page delta */
-#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_LEAF		1825
+#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_LEAF		1826
 /*!
  * reconciliation: ingest btree reconciliation keeps the aborted prepare
  * updates
  */
-#define	WT_STAT_CONN_REC_INGEST_KEEP_PREPARE_ROLLBACK	1826
+#define	WT_STAT_CONN_REC_INGEST_KEEP_PREPARE_ROLLBACK	1827
 /*! reconciliation: internal page delta keys deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_DELETED	1827
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_DELETED	1828
 /*! reconciliation: internal page delta keys updated/inserted */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_UPDATED	1828
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_UPDATED	1829
 /*! reconciliation: internal page deltas written */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL		1829
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL		1830
 /*! reconciliation: internal page multi-block writes */
-#define	WT_STAT_CONN_REC_MULTIBLOCK_INTERNAL		1830
+#define	WT_STAT_CONN_REC_MULTIBLOCK_INTERNAL		1831
 /*! reconciliation: leaf page deltas written */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_LEAF		1831
+#define	WT_STAT_CONN_REC_PAGE_DELTA_LEAF		1832
 /*! reconciliation: leaf page multi-block writes */
-#define	WT_STAT_CONN_REC_MULTIBLOCK_LEAF		1832
+#define	WT_STAT_CONN_REC_MULTIBLOCK_LEAF		1833
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1833
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1834
 /*! reconciliation: max deltas seen on internal page during reconciliation */
-#define	WT_STAT_CONN_REC_MAX_INTERNAL_PAGE_DELTAS	1834
+#define	WT_STAT_CONN_REC_MAX_INTERNAL_PAGE_DELTAS	1835
 /*! reconciliation: max deltas seen on leaf page during reconciliation */
-#define	WT_STAT_CONN_REC_MAX_LEAF_PAGE_DELTAS		1835
+#define	WT_STAT_CONN_REC_MAX_LEAF_PAGE_DELTAS		1836
 /*! reconciliation: maximum milliseconds spent in a reconciliation call */
-#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1836
+#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1837
 /*!
  * reconciliation: maximum milliseconds spent in building a disk image in
  * a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1837
+#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1838
 /*!
  * reconciliation: maximum milliseconds spent in moving updates to the
  * history store in a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1838
+#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1839
 /*!
  * reconciliation: number of keys that are garbage collected from the
  * disk images in the ingest btrees for disaggregated storage
  */
-#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_DISK_IMAGE	1839
+#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_DISK_IMAGE	1840
 /*!
  * reconciliation: number of keys that are garbage collected from the
  * update chains in the ingest btrees for disaggregated storage
  */
-#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_UPDATE_CHAIN	1840
+#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_UPDATE_CHAIN	1841
 /*! reconciliation: overflow values written */
-#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1841
+#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1842
 /*! reconciliation: page deltas rejected due to invalid page ID */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_INVALID_PAGE_ID	1842
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_INVALID_PAGE_ID	1843
 /*! reconciliation: page deltas rejected due to max consecutive limit */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MAX_CONSECUTIVE_EXCEEDED	1843
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MAX_CONSECUTIVE_EXCEEDED	1844
 /*! reconciliation: page deltas rejected due to multiblock reconciliation */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MULTIBLOCK	1844
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MULTIBLOCK	1845
 /*!
  * reconciliation: page deltas rejected due to non-single page in
  * previous reconciliation
  */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_NON_SINGLE_PAGE	1845
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_NON_SINGLE_PAGE	1846
 /*! reconciliation: page deltas rejected due to size threshold */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_SIZE_THRESHOLD	1846
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_SIZE_THRESHOLD	1847
 /*!
  * reconciliation: page deltas rejected due to too many keys removed from
  * the disk image
  */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_DELETE_THRESHOLD	1847
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_DELETE_THRESHOLD	1848
 /*! reconciliation: page deltas rejected due to zero entries */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_ZERO_ENTRIES	1848
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_ZERO_ENTRIES	1849
 /*!
  * reconciliation: page deltas rejected: build function returned false
  * (disabled, in-memory split, or internal page constraints not met)
  */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_BUILD_FAILED	1849
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_BUILD_FAILED	1850
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1850
+#define	WT_STAT_CONN_REC_PAGES				1851
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1851
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1852
 /*! reconciliation: page reconciliation calls for pages between 1 and 10MB */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_1MB_TO_10MB		1852
+#define	WT_STAT_CONN_REC_PAGES_SIZE_1MB_TO_10MB		1853
 /*!
  * reconciliation: page reconciliation calls for pages between 10 and
  * 100MB
  */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_10MB_TO_100MB	1853
+#define	WT_STAT_CONN_REC_PAGES_SIZE_10MB_TO_100MB	1854
 /*!
  * reconciliation: page reconciliation calls for pages between 100MB and
  * 1GB
  */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_100MB_TO_1GB	1854
+#define	WT_STAT_CONN_REC_PAGES_SIZE_100MB_TO_1GB	1855
 /*! reconciliation: page reconciliation calls for pages over 1GB */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_1GB_PLUS		1855
+#define	WT_STAT_CONN_REC_PAGES_SIZE_1GB_PLUS		1856
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * prepared transaction metadata
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1856
+#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1857
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * timestamps
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1857
+#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1858
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * transaction ids
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1858
+#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1859
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1859
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1860
 /*! reconciliation: pages eligible for delta generation */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_ELIGIBLE		1860
+#define	WT_STAT_CONN_REC_PAGE_DELTA_ELIGIBLE		1861
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1861
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1862
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1862
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1863
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1863
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1864
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1864
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1865
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1865
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1866
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1866
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1867
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1867
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1868
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1868
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1869
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1869
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1870
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1870
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1871
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1871
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1872
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1872
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1873
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1873
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1874
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1874
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1875
 /*! reconciliation: pages written with at least one internal page delta */
-#define	WT_STAT_CONN_REC_PAGES_WITH_INTERNAL_DELTAS	1875
+#define	WT_STAT_CONN_REC_PAGES_WITH_INTERNAL_DELTAS	1876
 /*! reconciliation: pages written with at least one leaf page delta */
-#define	WT_STAT_CONN_REC_PAGES_WITH_LEAF_DELTAS		1876
+#define	WT_STAT_CONN_REC_PAGES_WITH_LEAF_DELTAS		1877
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1877
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1878
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1878
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1879
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1879
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1880
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1880
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1881
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1881
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1882
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1882
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1883
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1883
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1884
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1884
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1885
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1885
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1886
 /*! reconciliation: writes skipped in disaggregated storage */
-#define	WT_STAT_CONN_REC_SKIP_WRITE			1886
+#define	WT_STAT_CONN_REC_SKIP_WRITE			1887
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1887
+#define	WT_STAT_CONN_SESSION_OPEN			1888
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1888
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1889
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1889
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1890
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1890
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1891
 /*! session: table alter triggering checkpoint calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1891
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1892
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1892
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1893
 /*! session: table compact conflicted with checkpoint */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1893
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1894
 /*! session: table compact dhandle successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1894
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1895
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1895
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1896
 /*! session: table compact failed calls due to cache pressure */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1896
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1897
 /*!
  * session: table compact in-memory page footprint rewritten by
  * compaction
  */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_BYTES_REWRITE_INMEM	1897
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_BYTES_REWRITE_INMEM	1898
 /*! session: table compact passes */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1898
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1899
 /*! session: table compact pulled into eviction */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1899
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1900
 /*! session: table compact running */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1900
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1901
 /*! session: table compact skipped as process would not reduce file size */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1901
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1902
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1902
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1903
 /*! session: table compact timeout */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1903
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1904
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1904
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1905
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1905
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1906
 /*! session: table create with import failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1906
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1907
 /*! session: table create with import repair calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1907
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1908
 /*! session: table create with import successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1908
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1909
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1909
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1910
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1910
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1911
 /*! session: table publish failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_PUBLISH_FAIL		1911
+#define	WT_STAT_CONN_SESSION_TABLE_PUBLISH_FAIL		1912
 /*! session: table publish successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_PUBLISH_SUCCESS	1912
+#define	WT_STAT_CONN_SESSION_TABLE_PUBLISH_SUCCESS	1913
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1913
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1914
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1914
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1915
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1915
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1916
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1916
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1917
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1917
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1918
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1918
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1919
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1919
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1920
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1920
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1921
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1921
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1922
 /*! thread-yield: application thread operations waiting for cache */
-#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1922
+#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1923
 /*!
  * thread-yield: application thread operations waiting for interruptible
  * cache eviction
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_OPS	1923
+#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_OPS	1924
 /*!
  * thread-yield: application thread operations waiting for mandatory
  * cache eviction
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_OPS	1924
+#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_OPS	1925
 /*! thread-yield: application thread snapshot refreshed for eviction */
-#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1925
+#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1926
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1926
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1927
 /*!
  * thread-yield: application thread time waiting for interruptible cache
  * eviction (usecs)
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_TIME	1927
+#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_TIME	1928
 /*!
  * thread-yield: application thread time waiting for mandatory cache
  * eviction (usecs)
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_TIME	1928
+#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_TIME	1929
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1929
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1930
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1930
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1931
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1931
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1932
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1932
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1933
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1933
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1934
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1934
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1935
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1935
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1936
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1936
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1937
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1937
+#define	WT_STAT_CONN_PAGE_SLEEP				1938
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1938
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1939
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1939
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1940
 /*! thread-yield: page split and restart read */
-#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1940
+#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1941
 /*! thread-yield: pages skipped during read due to deleted state */
-#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1941
+#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1942
 /*!
  * tiered-storage: attempts to remove a local object and the object is in
  * use
  */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1942
+#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1943
 /*! tiered-storage: flush_tier failed calls */
-#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1943
+#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1944
 /*! tiered-storage: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1944
+#define	WT_STAT_CONN_FLUSH_TIER				1945
 /*! tiered-storage: flush_tier tables skipped due to no checkpoint */
-#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1945
+#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1946
 /*! tiered-storage: flush_tier tables switched */
-#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1946
+#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1947
 /*! tiered-storage: local objects removed */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1947
+#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1948
 /*! tiered-storage: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1948
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1949
 /*! tiered-storage: tiered operations removed without processing */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1949
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1950
 /*! tiered-storage: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1950
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1951
 /*! tiered-storage: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1951
+#define	WT_STAT_CONN_TIERED_RETENTION			1952
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1952
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1953
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1953
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1954
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1954
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1955
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1955
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1956
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1956
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1957
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1957
+#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1958
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1958
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1959
 /*! transaction: oldest transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1959
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1960
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1960
+#define	WT_STAT_CONN_TXN_PREPARE			1961
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1961
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1962
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1962
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1963
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1963
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1964
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1964
+#define	WT_STAT_CONN_TXN_QUERY_TS			1965
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1965
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1966
 /*! transaction: rollback to stable applied btrees */
-#define	WT_STAT_CONN_TXN_RTS_BTREES_APPLIED		1966
+#define	WT_STAT_CONN_TXN_RTS_BTREES_APPLIED		1967
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1967
+#define	WT_STAT_CONN_TXN_RTS				1968
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1968
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1969
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1969
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1970
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1970
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1971
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1971
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1972
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1972
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1973
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1973
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1974
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1974
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1975
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1975
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1976
 /*!
  * transaction: rollback to stable prepared fast truncations that would
  * have been rolled back in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_PREPARED_FAST_TRUNCATE_DRYRUN	1976
+#define	WT_STAT_CONN_TXN_RTS_PREPARED_FAST_TRUNCATE_DRYRUN	1977
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1977
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1978
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1978
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1979
 /*! transaction: rollback to stable rolled back prepared fast truncations */
-#define	WT_STAT_CONN_TXN_RTS_PREPARED_FAST_TRUNCATE	1979
+#define	WT_STAT_CONN_TXN_RTS_PREPARED_FAST_TRUNCATE	1980
 /*! transaction: rollback to stable skipped btrees */
-#define	WT_STAT_CONN_TXN_RTS_BTREES_SKIPPED		1980
+#define	WT_STAT_CONN_TXN_RTS_BTREES_SKIPPED		1981
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1981
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1982
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1982
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1983
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1983
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1984
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1984
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1985
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1985
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1986
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1986
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1987
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1987
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1988
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1988
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1989
 /*!
  * transaction: rollback to stable updates that would have been aborted
  * in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1989
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1990
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1990
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1991
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1991
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1992
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1992
+#define	WT_STAT_CONN_TXN_SET_TS				1993
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1993
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1994
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1994
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1995
 /*! transaction: set timestamp force calls */
-#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1995
+#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1996
 /*!
  * transaction: set timestamp global oldest timestamp set to be more
  * recent than the global stable timestamp
  */
-#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1996
+#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1997
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1997
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1998
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1998
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1999
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1999
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			2000
 /*! transaction: set timestamp stable disaggregated schema epoch calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_DISAGG_EPOCH	2000
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_DISAGG_EPOCH	2001
 /*! transaction: set timestamp stable disaggregated schema epoch updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_DISAGG_EPOCH_UPD	2001
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_DISAGG_EPOCH_UPD	2002
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		2002
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		2003
 /*! transaction: set timestamp step down updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STEP_DOWN_UPD		2003
+#define	WT_STAT_CONN_TXN_SET_TS_STEP_DOWN_UPD		2004
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				2004
+#define	WT_STAT_CONN_TXN_BEGIN				2005
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		2005
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		2006
 /*! transaction: transaction global checkpoint timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_CHECKPOINT_TIMESTAMP	2006
+#define	WT_STAT_CONN_TXN_GLOBAL_CHECKPOINT_TIMESTAMP	2007
 /*! transaction: transaction global durable timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_DURABLE_TIMESTAMP	2007
+#define	WT_STAT_CONN_TXN_GLOBAL_DURABLE_TIMESTAMP	2008
 /*! transaction: transaction global last running timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_LAST_RUNNING_TIMESTAMP	2008
+#define	WT_STAT_CONN_TXN_GLOBAL_LAST_RUNNING_TIMESTAMP	2009
 /*! transaction: transaction global newest timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_NEWEST_TIMESTAMP	2009
+#define	WT_STAT_CONN_TXN_GLOBAL_NEWEST_TIMESTAMP	2010
 /*! transaction: transaction global oldest timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_OLDEST_TIMESTAMP	2010
+#define	WT_STAT_CONN_TXN_GLOBAL_OLDEST_TIMESTAMP	2011
 /*! transaction: transaction global pinned timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_PINNED_TIMESTAMP	2011
+#define	WT_STAT_CONN_TXN_GLOBAL_PINNED_TIMESTAMP	2012
 /*! transaction: transaction global stable timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_STABLE_TIMESTAMP	2012
+#define	WT_STAT_CONN_TXN_GLOBAL_STABLE_TIMESTAMP	2013
 /*! transaction: transaction global version cursor timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_VERSION_CURSOR_TIMESTAMP	2013
+#define	WT_STAT_CONN_TXN_GLOBAL_VERSION_CURSOR_TIMESTAMP	2014
 /*!
  * transaction: transaction number of older readers older than oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_READERS			2014
+#define	WT_STAT_CONN_TXN_PINNED_READERS			2015
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			2015
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			2016
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	2016
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	2017
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_LAG		2017
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_LAG		2018
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT_LAG	2018
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT_LAG	2019
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER_LAG	2019
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER_LAG	2020
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	2020
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	2021
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	2021
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	2022
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	2022
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	2023
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			2023
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			2024
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				2024
+#define	WT_STAT_CONN_TXN_COMMIT				2025
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			2025
+#define	WT_STAT_CONN_TXN_ROLLBACK			2026
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		2026
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		2027
 
 /*!
  * @}

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -2268,6 +2268,7 @@ static const char *const __stats_connection_desc[] = {
   "cache: reconciled pages scrubbed and added back to the cache clean",
   "cache: reverse splits performed",
   "cache: reverse splits skipped because of VLCS namespace gap restrictions",
+  "cache: shared disk bucket lock contention count",
   "cache: shared disk bytes saved by sharing duplicate disk images",
   "cache: shared disk hash table size",
   "cache: shared disk hit",
@@ -3350,6 +3351,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->cache_scrub_restore = 0;
     stats->cache_reverse_splits = 0;
     stats->cache_reverse_splits_skipped_vlcs = 0;
+    stats->cache_shared_dsk_lock_contention = 0;
     /* not clearing cache_shared_dsk_bytes_duplicate */
     /* not clearing cache_shared_dsk_hash_size */
     stats->cache_shared_dsk_hit = 0;
@@ -4513,6 +4515,8 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->cache_reverse_splits += WT_STAT_CONN_READ(from, cache_reverse_splits);
     to->cache_reverse_splits_skipped_vlcs +=
       WT_STAT_CONN_READ(from, cache_reverse_splits_skipped_vlcs);
+    to->cache_shared_dsk_lock_contention +=
+      WT_STAT_CONN_READ(from, cache_shared_dsk_lock_contention);
     to->cache_shared_dsk_bytes_duplicate +=
       WT_STAT_CONN_READ(from, cache_shared_dsk_bytes_duplicate);
     to->cache_shared_dsk_hash_size += WT_STAT_CONN_READ(from, cache_shared_dsk_hash_size);


### PR DESCRIPTION
The PR is to add a shared disk cache lock contention count stat, so we know how many contention occurred and it can help us tune the shared disk cache hash table further in the future.