### PR TITLE
WT-16778 Use proper atomic ops for has_durable_timestamp and durable_timestamp

### DIFF
--- a/src/rollback_to_stable/rts_api.c
+++ b/src/rollback_to_stable/rts_api.c
@@ -174,8 +174,8 @@ __rollback_to_stable_int(WT_SESSION_IMPL *session, bool no_ckpt)
 
     /* Rollback the global durable timestamp to the stable timestamp. */
     if (!dryrun) {
-        /* FIXME-WT-16778: use atomic write for the has durable timestamp flag. */
-        txn_global->has_durable_timestamp = stable_timestamp != WT_TS_NONE;
+        __wt_atomic_store_bool_relaxed(
+          &txn_global->has_durable_timestamp, stable_timestamp != WT_TS_NONE);
         __wt_atomic_store_uint64_relaxed(&txn_global->durable_timestamp, stable_timestamp);
     }
     __rts_assert_timestamps_unchanged(session, pinned_timestamp, stable_timestamp);

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -6,6 +6,7 @@
  * See the file LICENSE for redistribution information.
  */
 
+#include "gcc.h"
 #include "wt_internal.h"
 
 /*
@@ -1831,8 +1832,8 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
      */
     if (update_durable_ts)
         while (candidate_durable_timestamp > prev_durable_timestamp) {
-            if (__wt_atomic_cas_uint64(&txn_global->durable_timestamp, prev_durable_timestamp,
-                  candidate_durable_timestamp)) {
+            if (__wt_atomic_cas_uint64_relaxed(&txn_global->durable_timestamp,
+                  prev_durable_timestamp, candidate_durable_timestamp)) {
                 __wt_atomic_store_bool_release(&txn_global->has_durable_timestamp, true);
                 break;
             }

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -6,7 +6,6 @@
  * See the file LICENSE for redistribution information.
  */
 
-#include "gcc.h"
 #include "wt_internal.h"
 
 /*

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1836,7 +1836,8 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
                 __wt_atomic_store_bool_release(&txn_global->has_durable_timestamp, true);
                 break;
             }
-            prev_durable_timestamp = __wt_atomic_load_uint64_relaxed(&txn_global->durable_timestamp);
+            prev_durable_timestamp =
+              __wt_atomic_load_uint64_relaxed(&txn_global->durable_timestamp);
         }
 
     /*
@@ -2896,7 +2897,8 @@ __wt_verbose_dump_txn(WT_SESSION_IMPL *session)
       session, "oldest ID: %" PRIu64, __wt_atomic_load_uint64_v_relaxed(&txn_global->oldest_id)));
 
     WT_RET(__wt_msg(session, "durable timestamp: %s",
-      __wt_timestamp_to_string(__wt_atomic_load_uint64_relaxed(&txn_global->durable_timestamp), ts_string)));
+      __wt_timestamp_to_string(
+        __wt_atomic_load_uint64_relaxed(&txn_global->durable_timestamp), ts_string)));
     WT_RET(__wt_msg(session, "oldest timestamp: %s",
       __wt_timestamp_to_string(txn_global->oldest_timestamp, ts_string)));
     WT_RET(__wt_msg(session, "pinned timestamp: %s",
@@ -2908,8 +2910,7 @@ __wt_verbose_dump_txn(WT_SESSION_IMPL *session)
       __wt_timestamp_to_string(
         __wt_atomic_load_uint64_relaxed(&txn_global->stable_disaggregated_schema_epoch),
         ts_string)));
-    WT_RET(__wt_msg(
-      session, "has_durable_timestamp: %s",
+    WT_RET(__wt_msg(session, "has_durable_timestamp: %s",
       __wt_atomic_load_bool_relaxed(&txn_global->has_durable_timestamp) ? "yes" : "no"));
     WT_RET(__wt_msg(session, "has_oldest_timestamp: %s",
       __wt_atomic_load_bool_relaxed(&txn_global->has_oldest_timestamp) ? "yes" : "no"));

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1821,7 +1821,7 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
     update_durable_ts = false;
     prev_durable_timestamp = WT_TS_NONE;
     if (candidate_durable_timestamp != WT_TS_NONE) {
-        prev_durable_timestamp = __wt_tsan_suppress_load_uint64(&txn_global->durable_timestamp);
+        prev_durable_timestamp = __wt_atomic_load_uint64_relaxed(&txn_global->durable_timestamp);
         update_durable_ts = candidate_durable_timestamp > prev_durable_timestamp;
     }
 
@@ -1833,10 +1833,10 @@ __wt_txn_commit(WT_SESSION_IMPL *session, const char *cfg[])
         while (candidate_durable_timestamp > prev_durable_timestamp) {
             if (__wt_atomic_cas_uint64(&txn_global->durable_timestamp, prev_durable_timestamp,
                   candidate_durable_timestamp)) {
-                __wt_tsan_suppress_store_bool(&txn_global->has_durable_timestamp, true);
+                __wt_atomic_store_bool_release(&txn_global->has_durable_timestamp, true);
                 break;
             }
-            prev_durable_timestamp = __wt_tsan_suppress_load_uint64(&txn_global->durable_timestamp);
+            prev_durable_timestamp = __wt_atomic_load_uint64_relaxed(&txn_global->durable_timestamp);
         }
 
     /*
@@ -2896,7 +2896,7 @@ __wt_verbose_dump_txn(WT_SESSION_IMPL *session)
       session, "oldest ID: %" PRIu64, __wt_atomic_load_uint64_v_relaxed(&txn_global->oldest_id)));
 
     WT_RET(__wt_msg(session, "durable timestamp: %s",
-      __wt_timestamp_to_string(txn_global->durable_timestamp, ts_string)));
+      __wt_timestamp_to_string(__wt_atomic_load_uint64_relaxed(&txn_global->durable_timestamp), ts_string)));
     WT_RET(__wt_msg(session, "oldest timestamp: %s",
       __wt_timestamp_to_string(txn_global->oldest_timestamp, ts_string)));
     WT_RET(__wt_msg(session, "pinned timestamp: %s",
@@ -2909,7 +2909,8 @@ __wt_verbose_dump_txn(WT_SESSION_IMPL *session)
         __wt_atomic_load_uint64_relaxed(&txn_global->stable_disaggregated_schema_epoch),
         ts_string)));
     WT_RET(__wt_msg(
-      session, "has_durable_timestamp: %s", txn_global->has_durable_timestamp ? "yes" : "no"));
+      session, "has_durable_timestamp: %s",
+      __wt_atomic_load_bool_relaxed(&txn_global->has_durable_timestamp) ? "yes" : "no"));
     WT_RET(__wt_msg(session, "has_oldest_timestamp: %s",
       __wt_atomic_load_bool_relaxed(&txn_global->has_oldest_timestamp) ? "yes" : "no"));
     WT_RET(__wt_msg(

--- a/src/txn/txn_recover.c
+++ b/src/txn/txn_recover.c
@@ -1389,8 +1389,8 @@ done:
     } else {
         /* Although rollback to stable is not needed, we still need to set the durable timestamp. */
         WT_TXN_GLOBAL *txn_global = &conn->txn_global;
-        txn_global->has_durable_timestamp =
-          __wt_atomic_load_bool_relaxed(&txn_global->has_stable_timestamp);
+        __wt_atomic_store_bool_relaxed(&txn_global->has_durable_timestamp,
+          __wt_atomic_load_bool_relaxed(&txn_global->has_stable_timestamp));
         __wt_atomic_store_uint64_relaxed(
           &txn_global->durable_timestamp, __wt_get_stable_timestamp(session));
 

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -138,13 +138,13 @@ __txn_get_durable_timestamp(WT_TXN_SHARED *txn_shared, wt_timestamp_t *durable_t
 }
 
 /*
- * __txn_global_query_timestamp --
- *     Query a timestamp on the global transaction.
+ * __txn_get_all_durable_timestamp --
+ *     Compute the all_durable timestamp: the highest durable timestamp such that all transactions
+ *     with a lower durable timestamp have committed.
  */
 static int
-__txn_global_query_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t *tsp, const char *cfg[])
+__txn_get_all_durable_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t *tsp)
 {
-    WT_CONFIG_ITEM cval;
     WT_CONNECTION_IMPL *conn;
     WT_TXN_GLOBAL *txn_global;
     WT_TXN_SHARED *s;
@@ -154,34 +154,52 @@ __txn_global_query_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t *tsp, cons
     conn = S2C(session);
     txn_global = &conn->txn_global;
 
+    if (!__wt_atomic_load_bool_acquire(&txn_global->has_durable_timestamp)) {
+        *tsp = WT_TS_NONE;
+        return (0);
+    }
+
+    __wt_readlock(session, &txn_global->rwlock);
+
+    ts = __wt_atomic_load_uint64_relaxed(&txn_global->durable_timestamp);
+
+    /* Walk the array of concurrent transactions. */
+    WT_ACQUIRE_READ_WITH_BARRIER(session_cnt, conn->session_array.cnt);
+    for (i = 0, s = txn_global->txn_shared_list; i < session_cnt; i++, s++) {
+        __txn_get_durable_timestamp(s, &tmpts);
+        if (tmpts != WT_TS_NONE && (ts == WT_TS_NONE || --tmpts < ts))
+            ts = tmpts;
+    }
+
+    __wt_readunlock(session, &txn_global->rwlock);
+
+    WT_STAT_CONN_INCR(session, txn_walk_sessions);
+    WT_STAT_CONN_INCRV(session, txn_sessions_walked, i);
+
+    *tsp = ts;
+    return (0);
+}
+
+/*
+ * __txn_global_query_timestamp --
+ *     Query a timestamp on the global transaction.
+ */
+static int
+__txn_global_query_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t *tsp, const char *cfg[])
+{
+    WT_CONFIG_ITEM cval;
+    WT_CONNECTION_IMPL *conn;
+    WT_TXN_GLOBAL *txn_global;
+    wt_timestamp_t ts;
+
+    conn = S2C(session);
+    txn_global = &conn->txn_global;
+
     WT_STAT_CONN_INCR(session, txn_query_ts);
     WT_RET(__wt_config_gets(session, cfg, "get", &cval));
     if (WT_CONFIG_LIT_MATCH("all_durable", cval)) {
-        /*
-         * If there is no durable timestamp set, there is nothing to return. No need to walk the
-         * concurrent transactions.
-         */
-        if (!txn_global->has_durable_timestamp) {
-            *tsp = WT_TS_NONE;
-            return (0);
-        }
-
-        __wt_readlock(session, &txn_global->rwlock);
-
-        ts = txn_global->durable_timestamp;
-
-        /* Walk the array of concurrent transactions. */
-        WT_ACQUIRE_READ_WITH_BARRIER(session_cnt, conn->session_array.cnt);
-        for (i = 0, s = txn_global->txn_shared_list; i < session_cnt; i++, s++) {
-            __txn_get_durable_timestamp(s, &tmpts);
-            if (tmpts != WT_TS_NONE && (ts == WT_TS_NONE || --tmpts < ts))
-                ts = tmpts;
-        }
-
-        __wt_readunlock(session, &txn_global->rwlock);
-
-        WT_STAT_CONN_INCR(session, txn_walk_sessions);
-        WT_STAT_CONN_INCRV(session, txn_sessions_walked, i);
+        WT_RET(__txn_get_all_durable_timestamp(session, tsp));
+        return (0);
     } else if (WT_CONFIG_LIT_MATCH("backup_checkpoint", cval)) {
         /* This code will return set a timestamp only if a backup cursor is open. */
         ts = WT_TS_NONE;
@@ -475,8 +493,8 @@ set:
      * largest durable_timestamp so it moves forward whenever transactions are assigned timestamps).
      */
     if (has_durable) {
-        __wt_tsan_suppress_store_uint64(&txn_global->durable_timestamp, durable_ts);
-        txn_global->has_durable_timestamp = true;
+        __wt_atomic_store_uint64_relaxed(&txn_global->durable_timestamp, durable_ts);
+        __wt_atomic_store_bool_release(&txn_global->has_durable_timestamp, true);
         WT_STAT_CONN_INCR(session, txn_set_ts_durable_upd);
         __wt_verbose_timestamp(session, durable_ts, "Updated global durable timestamp");
     }


### PR DESCRIPTION
## Summary

- Replace `__wt_tsan_suppress_load_uint64` / `__wt_tsan_suppress_store_bool` calls and bare C reads/writes of `txn_global->has_durable_timestamp` and `txn_global->durable_timestamp` with the appropriate `__wt_atomic_*` primitives.
- The store to `has_durable_timestamp` after a successful CAS on `durable_timestamp` uses a **release** store; the fast-path check in `__txn_get_all_durable_timestamp` (and previously `__txn_global_query_timestamp`) uses an **acquire** load, so those two operations form a proper release/acquire pair without requiring the rwlock.
- Extract the all_durable timestamp walk into a dedicated `__txn_get_all_durable_timestamp` function to improve readability.