### PR TITLE
WT-17840 Fix Clang version inconsistencies across EVG workstations

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -10,6 +10,7 @@
 stepback: true
 pre:
   - func: "cleanup"
+  - func: "pin mongo toolchain"
 post:
   - func: "dump stacktraces"
   - func: "upload stacktraces"
@@ -29,6 +30,28 @@ exec_timeout_secs: 21600 # 6 hrs
 #######################################
 
 functions:
+
+  "pin mongo toolchain":
+    - command: shell.exec
+      type: setup
+      params:
+        shell: bash
+        script: |
+          set -o errexit
+
+          if [ "${REQUIRE_MDB_TOOLCHAIN|}" != "1" ]; then
+              exit 0
+          fi
+
+          MDB_TOOLCHAIN_REV="93d85cc1a00ca1d53fcc7d4ca790f19a4e5dd542"
+          if readlink /opt/mongodbtoolchain/v5/bin/clang 2>/dev/null | grep -q "$MDB_TOOLCHAIN_REV"; then
+              echo "mongodbtoolchain $MDB_TOOLCHAIN_REV already installed, skipping download."
+              exit 0
+          fi
+
+          echo "mongodbtoolchain $MDB_TOOLCHAIN_REV not installed, downloading..."
+          curl -fsSL https://s3.amazonaws.com/mongodbtoolchain.build.10gen.cc/installer.sh \
+              | bash -s -- --revision-id "$MDB_TOOLCHAIN_REV"
 
   "get project" :
     command: git.get_project
@@ -5239,6 +5262,7 @@ buildvariants:
   run_on:
   - ubuntu2004-test
   expansions:
+    REQUIRE_MDB_TOOLCHAIN: "1"
     configure_env_vars: PATH=/opt/mongodbtoolchain/v4/bin:$PATH
     compile_env_vars: PATH=/opt/mongodbtoolchain/v4/bin:$PATH
     test_env_vars:
@@ -5304,6 +5328,7 @@ buildvariants:
   run_on:
   - ubuntu2004-test
   expansions:
+    REQUIRE_MDB_TOOLCHAIN: "1"
     CMAKE_TOOLCHAIN_FILE: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/clang.cmake
     CMAKE_BUILD_TYPE: -DCMAKE_BUILD_TYPE=ASan
     CMAKE_PREFIX_PATH: -DCMAKE_PREFIX_PATH="$(pwd)/TCMALLOC_LIB"
@@ -5333,6 +5358,7 @@ buildvariants:
   run_on:
   - ubuntu2004-test
   expansions:
+    REQUIRE_MDB_TOOLCHAIN: "1"
     configure_env_vars: PATH=/opt/mongodbtoolchain/v4/bin:$PATH
     compile_env_vars: PATH=/opt/mongodbtoolchain/v4/bin:$PATH
     test_env_vars: PATH=/opt/mongodbtoolchain/v4/bin:$PATH
@@ -5352,6 +5378,7 @@ buildvariants:
   run_on:
   - ubuntu2004-test
   expansions:
+    REQUIRE_MDB_TOOLCHAIN: "1"
     CMAKE_TOOLCHAIN_FILE: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_stable_clang.cmake
     CMAKE_BUILD_TYPE: -DCMAKE_BUILD_TYPE=MSan
     smp_command: -j $(grep -c ^processor /proc/cpuinfo)
@@ -5383,6 +5410,7 @@ buildvariants:
   run_on:
   - ubuntu2004-test
   expansions:
+    REQUIRE_MDB_TOOLCHAIN: "1"
     CMAKE_TOOLCHAIN_FILE: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/clang.cmake
     CMAKE_BUILD_TYPE: -DCMAKE_BUILD_TYPE=UBSan
     CC_OPTIMIZE_LEVEL: -DCC_OPTIMIZE_LEVEL=-O1
@@ -5436,6 +5464,7 @@ buildvariants:
   run_on:
   - ubuntu2004-small
   expansions:
+    REQUIRE_MDB_TOOLCHAIN: "1"
     smp_command: -j $(grep -c ^processor /proc/cpuinfo)
     make_command: ninja
     configure_env_vars: PATH=/opt/mongodbtoolchain/v4/bin:$PATH
@@ -5476,6 +5505,7 @@ buildvariants:
   run_on:
   - ubuntu2004-arm64-large
   expansions:
+    REQUIRE_MDB_TOOLCHAIN: "1"
     smp_command: -j $(grep -c ^processor /proc/cpuinfo)
     make_command: ninja
     configure_env_vars: PATH=/opt/mongodbtoolchain/v4/bin:$PATH
@@ -5554,6 +5584,8 @@ buildvariants:
   batchtime: 1440 # 1 day
   run_on:
   - ubuntu2004-test
+  expansions:
+    REQUIRE_MDB_TOOLCHAIN: "1"
   tasks:
     - name: package
 
@@ -5685,6 +5717,7 @@ buildvariants:
   - ubuntu1804-large
   batchtime: 4320 # 3 days
   expansions:
+    REQUIRE_MDB_TOOLCHAIN: "1"
     python_binary: '/opt/mongodbtoolchain/v4/bin/python3'
     smp_command: -j $(grep -c ^processor /proc/cpuinfo)
     configure_env_vars: PATH=/opt/mongodbtoolchain/v4/bin:$PATH
@@ -5789,6 +5822,7 @@ buildvariants:
   - ubuntu2004-arm64-small
   batchtime: 1440 # 24 hours
   expansions:
+    REQUIRE_MDB_TOOLCHAIN: "1"
     configure_env_vars: PATH=/opt/mongodbtoolchain/v4/bin:$PATH
     compile_env_vars: PATH=/opt/mongodbtoolchain/v4/bin:$PATH
     test_env_vars:
@@ -5875,6 +5909,8 @@ buildvariants:
   run_on:
   - ubuntu2004-test
   expansions:
+    REQUIRE_MDB_TOOLCHAIN: "1"
+    ENABLE_TCMALLOC: 0
     posix_configure_flags: -DENABLE_ANTITHESIS=1 -DENABLE_STRICT=0
     CMAKE_TOOLCHAIN_FILE: -DCMAKE_TOOLCHAIN_FILE=../cmake/toolchains/mongodbtoolchain_stable_clang.cmake
     make_command: ninja


### PR DESCRIPTION
This a backport of develop @ 8fe7afe.

The MDB V5 toolchain _should_ have LLVM 19.1.7, but we have encountered workstations with a V5 toolchain where LLVM is 22.1.0.

This breaks assumptions in several of our s_all scripts. Ensure we have the correct LLVM version.