### PR TITLE
WT-17935 Hoist split-generation check before WT_BTREE_READONLY shortcut

### DIFF
--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -2302,6 +2302,41 @@ __wt_page_can_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool *inmem_splitp)
         return (false);
     }
 
+    /*
+     * Check we are not evicting an accessible internal page with an active split generation.
+     *
+     * If a split created new internal pages, those newly created internal pages cannot be evicted
+     * until all threads are known to have exited the original parent page's index, because evicting
+     * an internal page discards its WT_REF array, and a thread traversing the original parent page
+     * index might see a freed WT_REF.
+     *
+     * There are two special cases where we know this is safe:
+     *
+     * 1. WT_DHANDLE_DEAD: The handle is dead, so no readers can be looking at an old index.
+     *
+     * 2. WT_DHANDLE_EXCLUSIVE: The session has exclusive access to the dhandle. This means no other
+     *    sessions can access this btree, so there cannot be any concurrent traversals using old
+     * page indexes. This is critical for operations (e.g., ALTER) that need to evict internal pages
+     *    while holding exclusive access.
+     *
+     *    This check is necessary because __wt_gen_active() checks split generation across all
+     *    sessions globally, without distinguishing which btree each session is operating on.
+     * Without the WT_DHANDLE_EXCLUSIVE check, a session traversing btree A could incorrectly block
+     *    eviction of internal pages in btree B during an exclusive operation. The exclusive access
+     *    guarantee ensures that no other sessions can be traversing this specific btree, making it
+     *    safe to skip the split generation check.
+     *
+     * This gate runs before the WT_BTREE_READONLY shortcut because read-only status is a property
+     * of the local btree, while split-generation safety is a global invariant about reader activity
+     * on this page's index across all sessions.
+     */
+    if (F_ISSET(ref, WT_REF_FLAG_INTERNAL) &&
+      !F_ISSET(session->dhandle, WT_DHANDLE_DEAD | WT_DHANDLE_EXCLUSIVE) &&
+      __wt_gen_active(session, WT_GEN_SPLIT, page->pg_intl_split_gen)) {
+        WT_STAT_CONN_DSRC_INCR(session, cache_eviction_blocked_internal_page_split);
+        return (false);
+    }
+
     if (F_ISSET(btree, WT_BTREE_READONLY))
         return (true);
 
@@ -2408,37 +2443,6 @@ __wt_page_can_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool *inmem_splitp)
     if (modified && !WT_SESSION_BTREE_SYNC(session) &&
       __wt_btree_disagg_checkpointed(session, btree)) {
         WT_STAT_CONN_DSRC_INCR(session, cache_eviction_blocked_disagg_next_checkpoint);
-        return (false);
-    }
-
-    /*
-     * Check we are not evicting an accessible internal page with an active split generation.
-     *
-     * If a split created new internal pages, those newly created internal pages cannot be evicted
-     * until all threads are known to have exited the original parent page's index, because evicting
-     * an internal page discards its WT_REF array, and a thread traversing the original parent page
-     * index might see a freed WT_REF.
-     *
-     * There are two special cases where we know this is safe:
-     *
-     * 1. WT_DHANDLE_DEAD: The handle is dead, so no readers can be looking at an old index.
-     *
-     * 2. WT_DHANDLE_EXCLUSIVE: The session has exclusive access to the dhandle. This means no other
-     *    sessions can access this btree, so there cannot be any concurrent traversals using old
-     * page indexes. This is critical for operations (e.g., ALTER) that need to evict internal pages
-     *    while holding exclusive access.
-     *
-     *    This check is necessary because __wt_gen_active() checks split generation across all
-     *    sessions globally, without distinguishing which btree each session is operating on.
-     * Without the WT_DHANDLE_EXCLUSIVE check, a session traversing btree A could incorrectly block
-     *    eviction of internal pages in btree B during an exclusive operation. The exclusive access
-     *    guarantee ensures that no other sessions can be traversing this specific btree, making it
-     *    safe to skip the split generation check.
-     */
-    if (F_ISSET(ref, WT_REF_FLAG_INTERNAL) &&
-      !F_ISSET(session->dhandle, WT_DHANDLE_DEAD | WT_DHANDLE_EXCLUSIVE) &&
-      __wt_gen_active(session, WT_GEN_SPLIT, page->pg_intl_split_gen)) {
-        WT_STAT_CONN_DSRC_INCR(session, cache_eviction_blocked_internal_page_split);
         return (false);
     }
 


### PR DESCRIPTION
## Root cause

`__wt_page_can_evict` had the split-generation safety check for internal pages sitting **after** the `WT_BTREE_READONLY` short-circuit. Under elegant step-down:

1. An internal page has just split and its `pg_intl_split_gen` is still active — other sessions may still be walking the old parent index.
2. Step-down marks the btree `WT_BTREE_READONLY`. The readonly fast-path returns `true` and skips the split-gen gate.
3. Eviction proceeds into `__evict_review` / `__evict_page_dirty_update`, where `WT_ASSERT(!__wt_gen_active(session, WT_GEN_SPLIT, page->pg_intl_split_gen))` fires and aborts.

The readonly fast-path was written under the assumption that a readonly btree has no concurrent activity worth gating on. Step-down breaks that assumption: the btree gets flipped to `WT_BTREE_READONLY` while pre-step-down readers may still be traversing the old parent index of a freshly split internal page.

## Fix

Hoist the split-generation gate to run **before** the `WT_BTREE_READONLY` short-circuit. `WT_BTREE_READONLY` is a local property of one btree; split-generation safety is a global invariant about reader activity across all sessions — the former must not be allowed to short-circuit the latter.

With the gate hoisted, the sequence becomes safe:

1. The split bumps `pg_intl_split_gen`; the gate returns `false`, blocking eviction.
2. Old readers eventually exit the old index → `__wt_gen_active(WT_GEN_SPLIT, ...)` flips to false.
3. `__wt_page_can_evict` returns `true` (gate passes, readonly fast-path then runs as before).
4. The downstream `WT_ASSERT(!__wt_gen_active(...))` is guaranteed to hold.
