### PR TITLE
WT-16712 Remove stale page_del assertion in __wti_rec_child_modify

### DIFF
--- a/src/reconcile/rec_child.c
+++ b/src/reconcile/rec_child.c
@@ -219,10 +219,13 @@ __wti_rec_child_modify(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_REF *ref,
     for (;; __wt_yield()) {
         switch (r->tested_ref_state = WT_REF_GET_STATE(ref)) {
         case WT_REF_DISK:
-            /* On disk, not modified by definition. */
+            /*
+             * On disk, not modified by definition. A concurrent fast-truncate can set ref->page_del
+             * immediately after this state is read, so it cannot be asserted NULL here; if that
+             * happens, the truncate simply isn't reflected in this reconciliation and will be
+             * picked up the next time the parent page is reconciled.
+             */
             WT_ASSERT(session, ref->addr != NULL);
-            /* DISK pages do not have fast-truncate info. */
-            WT_ASSERT(session, ref->page_del == NULL);
             goto done;
 
         case WT_REF_DELETED:


### PR DESCRIPTION
## Summary
- `WT_ASSERT(session, ref->page_del == NULL)` in the `WT_REF_DISK` case of `__wti_rec_child_modify` (src/reconcile/rec_child.c) assumed the state read and the subsequent `page_del` read were atomic, but checkpoint reconciliation examines the child ref without locking it.
- A concurrent fast-truncate (`__wti_delete_page`) can CAS the ref `WT_REF_DISK -> WT_REF_LOCKED` and populate `page_del` in the window between the state read and the assertion, tripping it (WT-16712, reproduced on arm64/ppc weak-memory CI variants under ASAN/TSAN stress).
- In this branch `page_del` is only ever compared, never dereferenced or copied, so the race is harmless: reconciliation proceeds with `WTI_CHILD_ORIGINAL` and the truncate is captured on the next reconciliation of the parent page instead. Removed the assertion and left a comment explaining why.

See WT-16712 for the full investigation (a memory-barrier fix on the ref-state read would not have closed this window, since it's a genuine TOCTOU race, not a visibility issue).