### PR TITLE
WT-17377 Enforce durable timestamp strictly after prepare timestamp

### DIFF
--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -860,6 +860,17 @@ __txn_set_durable_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t durable_ts)
           __wt_timestamp_to_string(last_checkpoint_ts, ts_string[1]));
     }
 
+    /*
+     * With preserve_prepared configured, a prepared but not-yet-durable transaction must have a
+     * durable timestamp strictly after its prepare timestamp, so the two states remain distinct.
+     */
+    if (F_ISSET(conn, WT_CONN_PRESERVE_PREPARED) && durable_ts <= txn->time_point.prepare_timestamp)
+        WT_RET_MSG(session, EINVAL,
+          "durable timestamp %s must be greater than the prepare timestamp %s for this "
+          "transaction",
+          __wt_timestamp_to_string(durable_ts, ts_string[0]),
+          __wt_timestamp_to_string(txn->time_point.prepare_timestamp, ts_string[1]));
+
     WT_RET(__txn_validate_durable_timestamp(session, durable_ts));
     txn->time_point.durable_timestamp = durable_ts;
     F_SET(&txn->time_point, WT_TXN_TIME_POINT_HAS_TS_DURABLE);

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -781,6 +781,18 @@ __txn_validate_durable_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t durabl
           __wt_timestamp_to_string(durable_ts, ts_string[0]),
           __wt_timestamp_to_string(txn->time_point.commit_timestamp, ts_string[1]));
 
+    /*
+     * With preserve_prepared configured, a prepared but not-yet-durable transaction must have a
+     * durable timestamp strictly after its prepare timestamp, so the two states remain distinct.
+     */
+    if (F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED) &&
+      durable_ts <= txn->time_point.prepare_timestamp)
+        WT_RET_MSG(session, EINVAL,
+          "durable timestamp %s must be greater than the prepare timestamp %s for this "
+          "transaction",
+          __wt_timestamp_to_string(durable_ts, ts_string[0]),
+          __wt_timestamp_to_string(txn->time_point.prepare_timestamp, ts_string[1]));
+
     return (0);
 }
 
@@ -859,17 +871,6 @@ __txn_set_durable_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t durable_ts)
           __wt_timestamp_to_string(durable_ts, ts_string[0]),
           __wt_timestamp_to_string(last_checkpoint_ts, ts_string[1]));
     }
-
-    /*
-     * With preserve_prepared configured, a prepared but not-yet-durable transaction must have a
-     * durable timestamp strictly after its prepare timestamp, so the two states remain distinct.
-     */
-    if (F_ISSET(conn, WT_CONN_PRESERVE_PREPARED) && durable_ts <= txn->time_point.prepare_timestamp)
-        WT_RET_MSG(session, EINVAL,
-          "durable timestamp %s must be greater than the prepare timestamp %s for this "
-          "transaction",
-          __wt_timestamp_to_string(durable_ts, ts_string[0]),
-          __wt_timestamp_to_string(txn->time_point.prepare_timestamp, ts_string[1]));
 
     WT_RET(__txn_validate_durable_timestamp(session, durable_ts));
     txn->time_point.durable_timestamp = durable_ts;

--- a/test/suite/test_prepare50.py
+++ b/test/suite/test_prepare50.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# With preserve_prepared configured, a prepared transaction's durable
+# timestamp must be strictly greater than its prepare timestamp.
+
+import wiredtiger, wttest
+
+class test_prepare50(wttest.WiredTigerTestCase):
+
+    test_name = __qualname__
+    conn_config = 'precise_checkpoint=true,preserve_prepared=true'
+    uri = f'table:{test_name}'
+
+    def setUp(self):
+        super().setUp()
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(1))
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
+
+    def test_durable_ts_equal_to_prepare_ts_fails(self):
+        self.session.create(self.uri, 'key_format=i,value_format=S')
+        cursor = self.session.open_cursor(self.uri)
+
+        self.session.begin_transaction()
+        cursor[1] = 'value'
+        self.session.prepare_transaction(
+            'prepare_timestamp=' + self.timestamp_str(10) +
+            ',prepared_id=' + self.prepared_id_str(1))
+        self.session.timestamp_transaction(
+            'commit_timestamp=' + self.timestamp_str(10))
+
+        msg = '/durable timestamp.*must be greater than the prepare timestamp/'
+        self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
+            lambda: self.session.timestamp_transaction(
+                'durable_timestamp=' + self.timestamp_str(10)), msg)
+        self.session.rollback_transaction()
+
+    def test_durable_ts_greater_than_prepare_ts_succeeds(self):
+        self.session.create(self.uri, 'key_format=i,value_format=S')
+        cursor = self.session.open_cursor(self.uri)
+
+        self.session.begin_transaction()
+        cursor[3] = 'value'
+        self.session.prepare_transaction(
+            'prepare_timestamp=' + self.timestamp_str(30) +
+            ',prepared_id=' + self.prepared_id_str(3))
+        self.session.timestamp_transaction(
+            'commit_timestamp=' + self.timestamp_str(30))
+        self.session.timestamp_transaction(
+            'durable_timestamp=' + self.timestamp_str(31))
+        self.session.commit_transaction()
+
+        self.session.begin_transaction('read_timestamp=' + self.timestamp_str(31))
+        self.assertEqual(cursor[3], 'value')
+        self.session.commit_transaction()
+
+if __name__ == '__main__':
+    wttest.run()


### PR DESCRIPTION
## Summary

- With `preserve_prepared` configured, a prepared transaction's `durable_timestamp` must now be strictly greater than its `prepare_timestamp`; setting it equal to (or before) the prepare timestamp returns `WT_EINVAL`.
- Without `preserve_prepared`, behavior is unchanged (existing tests that set `durable_ts == prepare_ts` in that configuration still pass).
- Added `test/suite/test_prepare50.py` covering the rejected-equal and accepted-strictly-greater cases.

https://jira.mongodb.org/browse/WT-17377