### PR TITLE
WT-16596 Remove redundant NULL check (Coverity #185631)

### DIFF
--- a/ext/test/key_provider/key_provider.c
+++ b/ext/test/key_provider/key_provider.c
@@ -519,8 +519,7 @@ key_provider_extension_init(WT_CONNECTION *conn, WT_CONFIG_ARG *config)
     return (0);
 
 err:
-    if (kp != NULL)
-        kp_terminate((WT_KEY_PROVIDER *)kp, NULL);
+    kp_terminate((WT_KEY_PROVIDER *)kp, NULL);
 
     return (ret);
 }


### PR DESCRIPTION
`kp` cannot be NULL at the `err` label. If `calloc` fails, it has already returned early.
