### PR TITLE
WT-17917 Replace ingest OVERWRITE FIXME with rationale comment

### DIFF
--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -648,9 +648,11 @@ __clayered_open_ingest(WT_SESSION_IMPL *session, WTI_CURSOR_LAYERED *clayered, W
     /*
      * We always open ingest in overwrite mode to be able to rewrite tombstones with insert().
      *
-     * FIXME-WT-17917: It might be possible that it'll be technically simpler to inherit OVERWRITE
-     * only if it's set for the top cursor and always call update() to put something on top of an
-     * ingest tombstone.
+     * Inheriting the top cursor's OVERWRITE flag instead does not help: duplicate detection needs
+     * both constituents but the ingest cursor sees only one, the ingest write must create-or-replace
+     * (over an absent key or a tombstone) so it needs overwrite regardless, and a delete is a value
+     * rather than a btree tombstone so native non-overwrite semantics give the wrong answer. The
+     * stable-side pre-lookup therefore cannot be removed.
      */
     F_SET(cursor, WT_CURSTD_OVERWRITE | WT_CURSTD_RAW);
 

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -649,10 +649,10 @@ __clayered_open_ingest(WT_SESSION_IMPL *session, WTI_CURSOR_LAYERED *clayered, W
      * We always open ingest in overwrite mode to be able to rewrite tombstones with insert().
      *
      * Inheriting the top cursor's OVERWRITE flag instead does not help: duplicate detection needs
-     * both constituents but the ingest cursor sees only one, the ingest write must create-or-replace
-     * (over an absent key or a tombstone) so it needs overwrite regardless, and a delete is a value
-     * rather than a btree tombstone so native non-overwrite semantics give the wrong answer. The
-     * stable-side pre-lookup therefore cannot be removed.
+     * both constituents but the ingest cursor sees only one, the ingest write must create or
+     * replace (over an absent key or a tombstone) so it needs overwrite regardless, and a delete is
+     * a value rather than a btree tombstone so native non-overwrite semantics give the wrong
+     * answer. The stable-side pre-lookup therefore cannot be removed.
      */
     F_SET(cursor, WT_CURSTD_OVERWRITE | WT_CURSTD_RAW);
 


### PR DESCRIPTION
[WT-17917](https://jira.mongodb.org/browse/WT-17917)

## Background

The ingest constituent cursor is always opened in `WT_CURSTD_OVERWRITE` mode in `__clayered_open_ingest` so `insert()` can rewrite an ingest tombstone. A `FIXME-WT-17917` suggested it might be simpler to instead inherit the top cursor's OVERWRITE flag and use `update()` over a tombstone.

## What changed

Investigation concluded inheriting OVERWRITE does not deliver the payoff (dropping the stable-side pre-lookup):

1. Duplicate detection needs both constituents, but the ingest cursor sees only one — a key can live only in stable.
2. The ingest write must create-or-replace (target may be absent-in-ingest or hold a tombstone), which needs overwrite regardless.
3. A delete is stored as a value, not a btree tombstone, so native non-overwrite semantics give the wrong answer over a tombstone.

So this PR replaces the FIXME with a short comment recording why we always open ingest in overwrite mode. No functional change.