### PR TITLE
WT-17870 Fix hash mismatch b/w leader & follower

### DIFF
--- a/test/format/format.h
+++ b/test/format/format.h
@@ -513,6 +513,7 @@ wt_timestamp_t replay_read_ts(TINFO *);
 void replay_rollback(TINFO *);
 void replay_run_begin(WT_SESSION *);
 void replay_run_end(WT_SESSION *);
+bool replay_stale_read_ts(TINFO *);
 int timestamp_query(const char *, wt_timestamp_t *);
 void timestamp_teardown(WT_SESSION *);
 void trace_config(const char *);

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -1287,8 +1287,12 @@ rollback_retry:
             val_gen(table, &tinfo->data_rnd, tinfo->new_value, tinfo->keyno);
 
         /* If modify, build a modify change vector. */
-        if (op == MODIFY)
+        if (op == MODIFY) {
+            if (replay_stale_read_ts(tinfo))
+                goto rollback;
+
             modify_build(tinfo);
+        }
 
         ret = 0;
         skip1 = skip2 = NULL;

--- a/test/format/replay.c
+++ b/test/format/replay.c
@@ -547,6 +547,24 @@ replay_rollback(TINFO *tinfo)
 }
 
 /*
+ * replay_stale_read_ts --
+ *     Return true if the transaction's read timestamp is below the lane's last commit timestamp,
+ *     meaning an operation may produce non-deterministic results. Spins until
+ *     replay_maximum_committed catches up before returning, so the subsequent rollback and retry
+ *     will acquire a read timestamp that sees a consistent key state.
+ */
+bool
+replay_stale_read_ts(TINFO *tinfo)
+{
+    if (!GV(RUNS_PREDICTABLE_REPLAY) || tinfo->read_ts >= g.lanes[tinfo->lane].last_commit_ts)
+        return (false);
+
+    while (replay_maximum_committed() < g.lanes[tinfo->lane].last_commit_ts)
+        __wt_yield();
+    return (true);
+}
+
+/*
  * replay_pause_after_rollback --
  *     Called after a rollback, allowing us to yield or pause.
  */


### PR DESCRIPTION
Restoring the workaround added in [WT-17117](https://jira.mongodb.org/browse/WT-17117) to allow modify ops in predictable replay, since [WT-17247](https://jira.mongodb.org/browse/WT-17247) removed it but did not completely solve the underlying issue.