### PR TITLE
WT-17968 Fix ordering bug that made the checkpoint pick-up pinned-timestamp panic unreachable

### DIFF
--- a/src/conn/conn_layered_checkpoint_pick_up.c
+++ b/src/conn/conn_layered_checkpoint_pick_up.c
@@ -923,23 +923,6 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPOINT
       ckpt_meta->metadata_lsn);
 
     /*
-     * Refresh the pinned timestamp before checking it against the checkpoint's oldest timestamp.
-     * The cached value may lag behind the actual minimum held by active transactions; using a stale
-     * (lower) value here would cause a false panic below.
-     */
-    __wt_txn_update_pinned_timestamp(session, false);
-    uint64_t pinned_timestamp;
-    __wt_txn_pinned_timestamp(session, &pinned_timestamp);
-    if (pinned_timestamp != WT_TS_NONE && metadata.oldest_timestamp > pinned_timestamp) {
-        WT_TRET(__wt_verbose_dump_sessions(session, false));
-        WT_IGNORE_RET(__wt_panic(session, EINVAL,
-          "Disaggregated storage checkpoint oldest_timestamp %s is greater than the current pinned "
-          "timestamp %s",
-          __wt_timestamp_to_string(metadata.oldest_timestamp, ts_string[0]),
-          __wt_timestamp_to_string(pinned_timestamp, ts_string[1])));
-    }
-
-    /*
      * Part 1: Get the metadata of the shared metadata table and insert it into our metadata table.
      */
 
@@ -955,6 +938,24 @@ __disagg_pick_up_checkpoint(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPOINT
       metadata.oldest_timestamp, __wt_timestamp_to_string(metadata.oldest_timestamp, ts_string[1]),
       metadata.schema_epoch, __wt_timestamp_to_string(metadata.schema_epoch, ts_string[2]),
       metadata.largest_file_id, (int)metadata.checkpoint_len, metadata.checkpoint);
+
+    /*
+     * Refresh the pinned timestamp before checking it against the checkpoint's oldest timestamp,
+     * now that the checkpoint's real oldest_timestamp has been parsed above. The cached value may
+     * lag behind the actual minimum held by active transactions; using a stale (lower) value here
+     * would cause a false panic below.
+     */
+    __wt_txn_update_pinned_timestamp(session, false);
+    uint64_t pinned_timestamp;
+    __wt_txn_pinned_timestamp(session, &pinned_timestamp);
+    if (pinned_timestamp != WT_TS_NONE && metadata.oldest_timestamp > pinned_timestamp) {
+        WT_TRET(__wt_verbose_dump_sessions(session, false));
+        WT_IGNORE_RET(__wt_panic(session, EINVAL,
+          "Disaggregated storage checkpoint oldest_timestamp %s is greater than the current pinned "
+          "timestamp %s",
+          __wt_timestamp_to_string(metadata.oldest_timestamp, ts_string[0]),
+          __wt_timestamp_to_string(pinned_timestamp, ts_string[1])));
+    }
 
     /* Load crypt key data with the key provider extension, if any. */
     WT_ERR(__wti_disagg_load_crypt_key(session, &metadata));


### PR DESCRIPTION
## Summary
- `__disagg_pick_up_checkpoint` is supposed to refuse (panic) adopting a checkpoint whose `oldest_timestamp` exceeds the connection's current pinned timestamp, protecting an actively-pinned reader from having its data pruned out from under it.
- The check read `metadata.oldest_timestamp` immediately after `WT_CLEAR(metadata)`, before `__wt_disagg_parse_meta` populated it with the real checkpoint fields — so the comparison was effectively `0 > pinned_timestamp`, which is never true. The safety net was dead code: a checkpoint whose real `oldest_timestamp` exceeds an actively-pinned reader's timestamp could be silently adopted.
- Move the pinned-timestamp refresh and panic check to after `__wt_disagg_parse_meta`, so it reads the real, parsed value. No other logic changes.

## Test plan
- [x] Manually verified: a scripted scenario forcing a checkpoint whose real `oldest_timestamp` exceeds an active reader's pinned read timestamp now correctly panics with "Disaggregated storage checkpoint oldest_timestamp ... is greater than the current pinned timestamp ..."; before the fix it silently succeeded. Not adding this as an automated test since it deliberately crashes the process (`__wt_panic`), which isn't appropriate for the normal test suite.
- [x] `dist/s_fast` clean.