### PR TITLE
WT-17254 Make unpositioned follower cursor removes perform blind deletes when overwrite=true

### DIFF
--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -2618,7 +2618,10 @@ __clayered_remove(WT_CURSOR *cursor)
     WT_ERR(__cursor_needkey(cursor));
     __cursor_novalue(cursor);
 
-    WT_ERR(__clayered_enter(clayered, WTI_CLAYERED_MODE_WRITE, &op));
+    WT_ERR(__clayered_enter(clayered,
+      F_ISSET(cursor, WT_CURSTD_OVERWRITE) ? WTI_CLAYERED_MODE_WRITE_OVERWRITE :
+                                             WTI_CLAYERED_MODE_WRITE,
+      &op));
 
     CURSOR_API_CHECK_SYSTEM_OVERLOAD(session, ret);
 

--- a/src/cursor/cur_layered_private.h
+++ b/src/cursor/cur_layered_private.h
@@ -53,8 +53,8 @@ typedef enum {
     WTI_CLAYERED_MODE_ITERATE,        /* next, prev */
     WTI_CLAYERED_MODE_RANDOM,         /* next_random */
     WTI_CLAYERED_MODE_SCAN,           /* largest_key */
-    WTI_CLAYERED_MODE_WRITE,          /* remove, reserve, modify; non-overwrite insert/update */
-    WTI_CLAYERED_MODE_WRITE_OVERWRITE /* overwrite insert/update */
+    WTI_CLAYERED_MODE_WRITE,          /* reserve, modify; non-overwrite insert/update/remove */
+    WTI_CLAYERED_MODE_WRITE_OVERWRITE /* overwrite insert/update/remove */
 } WTI_CLAYERED_OP_MODE;
 
 /*

--- a/test/suite/test_layered_cursor19.py
+++ b/test/suite/test_layered_cursor19.py
@@ -31,8 +31,8 @@ from helper_disagg import DisaggConfigMixin, disagg_test_class, gen_disagg_stora
 from wiredtiger import stat
 from wtscenario import make_scenarios
 
-# On a follower, insert/update on a layered cursor should only open the
-# stable constituent when overwrite=false: with overwrite=true (the
+# On a follower, insert/update/remove on a layered cursor should only open
+# the stable constituent when overwrite=false: with overwrite=true (the
 # default) the write path skips the layered lookup and should open the
 # ingest cursor only.
 @disagg_test_class
@@ -181,6 +181,61 @@ class test_layered_cursor19(wttest.WiredTigerTestCase):
         delta = self.measure_cursor_opens(do_update)
         self.assertGreaterEqual(delta, 2,
             "overwrite=false update on a follower opened {} cursors, "
+            "expected at least 2 (ingest + stable)".format(delta))
+
+        cursor.close()
+
+    # A remove on a follower with overwrite=true (the default) should open
+    # the ingest cursor only, leaving the stable constituent untouched, when
+    # the key being removed lives entirely in the ingest table.
+    def test_follower_remove_overwrite_does_not_open_stable(self):
+        self.seed_leader_and_advance_follower()
+
+        # Prime the ingest table with the key we intend to remove, using a
+        # dedicated cursor that is closed before the measurement.
+        primer = self.session_follow.open_cursor(self.uri)
+        self.session_follow.begin_transaction()
+        primer['k1'] = 'v1'
+        self.session_follow.commit_transaction(
+            'commit_timestamp=' + self.timestamp_str(2))
+        primer.close()
+
+        cursor = self.session_follow.open_cursor(self.uri)
+
+        def do_remove():
+            self.session_follow.begin_transaction()
+            cursor.set_key('k1')
+            self.assertEqual(cursor.remove(), 0)
+            self.session_follow.commit_transaction(
+                'commit_timestamp=' + self.timestamp_str(3))
+
+        delta = self.measure_cursor_opens(do_remove)
+        self.assertEqual(delta, 1,
+            "overwrite=true remove on a follower opened {} cursors, "
+            "expected 1 (ingest only); delta > 1 means the stable cursor "
+            "was opened unnecessarily".format(delta))
+
+        cursor.close()
+
+    # Sanity check mirror for remove: a remove with overwrite=false runs a
+    # layered lookup and must open the stable cursor. The target key here
+    # lives only in stable (ingested via checkpoint from the leader), so the
+    # lookup has to fall through to stable rather than short-circuit.
+    def test_follower_remove_no_overwrite_opens_stable(self):
+        self.seed_leader_and_advance_follower()
+
+        cursor = self.session_follow.open_cursor(self.uri, None, 'overwrite=false')
+
+        def do_remove():
+            self.session_follow.begin_transaction()
+            cursor.set_key('seed')
+            self.assertEqual(cursor.remove(), 0)
+            self.session_follow.commit_transaction(
+                'commit_timestamp=' + self.timestamp_str(2))
+
+        delta = self.measure_cursor_opens(do_remove)
+        self.assertGreaterEqual(delta, 2,
+            "overwrite=false remove on a follower opened {} cursors, "
             "expected at least 2 (ingest + stable)".format(delta))
 
         cursor.close()


### PR DESCRIPTION
## Summary
- Insert and update on a follower's layered cursor already skip the stable lookup when `overwrite=true` and no read timestamp is set (WT-17736): `__clayered_enter` is called with `WTI_CLAYERED_MODE_WRITE_OVERWRITE`, letting the follower avoid opening/consulting the stable cursor.
- `__clayered_remove` never took this path — it always used `WTI_CLAYERED_MODE_WRITE`, forcing a stable consult on every follower remove regardless of `overwrite`.
- Pass `WTI_CLAYERED_MODE_WRITE_OVERWRITE` for remove too when the cursor is configured with `overwrite=true`, matching insert/update. This is the "unpositioned cursor blind delete" case WT-17254 describes: index key deletes are typically unpositioned, and skipping the stable lookup there is what helps secondary/standby performance for those workloads (BF-43334).

## Test plan
- [x] Extended `test_layered_cursor19.py` with two new cases mirroring the existing insert/update coverage: `test_follower_remove_overwrite_does_not_open_stable` and `test_follower_remove_no_overwrite_opens_stable`, asserting on `stat.conn.cursor_open_count` deltas. Verified the new "overwrite" case fails without this change (opens the stable cursor unnecessarily) and passes with it.
- [x] `test_layered_cursor19`, `test_layered_cursor23` (134 scenarios total) pass.
- [x] `dist/s_fast` clean.
- [x] Verified with sys-perf (BF-43334, `tpcc_majority_out_of_cache` on `disagg-m8g-perf-11-node.arm.aws`): 62,404.5 tpmC, in line with the ~62k tpmC manually-validated experiment for this change and a ~56% improvement over the ~40k tpmC baseline. Required WT-17968 and WT-17969 (both filed and up as separate PRs) to get a clean, uncrashed run — those are pre-existing bugs, independent of this change, confirmed via multiple reproductions.