### PR TITLE
WT-16666 Refactor __rec_write_wrapup delta chain size accounting into a helper

### DIFF
--- a/src/block_disagg/block_disagg_size.c
+++ b/src/block_disagg/block_disagg_size.c
@@ -80,16 +80,16 @@ __wt_block_disagg_set_size(WT_SESSION_IMPL *session, uint64_t size)
 }
 
 /*
- * __wt_block_disagg_obsolete_delta_chain --
- *     Notify the block manager that a delta chain has been obsoleted by a full page image. The
- *     cumulative size of the old chain is no longer counted toward the total.
+ * __wt_block_disagg_decrease_ckpt_size --
+ *     Decrease the tree's total checkpoint byte count. The session-level counterpart to
+ *     __wti_block_disagg_decrease_size, resolving the block handle from the session. Callers use
+ *     this when a full page image obsoletes a delta chain whose cumulative size no longer counts.
  */
 void
-__wt_block_disagg_obsolete_delta_chain(WT_SESSION_IMPL *session, uint64_t cumulative_size)
+__wt_block_disagg_decrease_ckpt_size(WT_SESSION_IMPL *session, uint64_t size)
 {
     WT_ASSERT(session, F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED));
-    __wti_block_disagg_decrease_size(
-      session, (WT_BLOCK_DISAGG *)S2BT(session)->bm->block, cumulative_size);
+    __wti_block_disagg_decrease_size(session, (WT_BLOCK_DISAGG *)S2BT(session)->bm->block, size);
 }
 
 /*

--- a/src/block_disagg/block_disagg_size.c
+++ b/src/block_disagg/block_disagg_size.c
@@ -80,13 +80,12 @@ __wt_block_disagg_set_size(WT_SESSION_IMPL *session, uint64_t size)
 }
 
 /*
- * __wt_block_disagg_decrease_ckpt_size --
- *     Decrease the tree's total checkpoint byte count. The session-level counterpart to
- *     __wti_block_disagg_decrease_size, resolving the block handle from the session. Callers use
- *     this when a full page image obsoletes a delta chain whose cumulative size no longer counts.
+ * __wt_block_disagg_decrease_size --
+ *     Decrease the total byte count. Exposed for callers outside the block manager; reconciliation
+ *     uses it when a full page image obsoletes a delta chain.
  */
 void
-__wt_block_disagg_decrease_ckpt_size(WT_SESSION_IMPL *session, uint64_t size)
+__wt_block_disagg_decrease_size(WT_SESSION_IMPL *session, uint64_t size)
 {
     WT_ASSERT(session, F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED));
     __wti_block_disagg_decrease_size(session, (WT_BLOCK_DISAGG *)S2BT(session)->bm->block, size);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1759,10 +1759,9 @@ extern void __wt_block_compact_get_progress_stats(
   WT_SESSION_IMPL *session, WT_BM *bm, uint64_t *pages_reviewedp);
 extern void __wt_block_compact_progress(WT_SESSION_IMPL *session, WT_BLOCK *block);
 extern void __wt_block_disagg_checkpoint_rollback(WT_SESSION_IMPL *session);
+extern void __wt_block_disagg_decrease_ckpt_size(WT_SESSION_IMPL *session, uint64_t size);
 extern void __wt_block_disagg_header_byteswap_copy(
   WT_BLOCK_DISAGG_HEADER *from, WT_BLOCK_DISAGG_HEADER *to);
-extern void __wt_block_disagg_obsolete_delta_chain(
-  WT_SESSION_IMPL *session, uint64_t cumulative_size);
 extern void __wt_block_disagg_set_size(WT_SESSION_IMPL *session, uint64_t size);
 extern void __wt_block_stat(WT_SESSION_IMPL *session, WT_BLOCK *block, WT_DSRC_STATS *stats);
 extern void __wt_bm_set_readonly(WT_SESSION_IMPL *session) WT_GCC_FUNC_DECL_ATTRIBUTE((cold));

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1759,7 +1759,7 @@ extern void __wt_block_compact_get_progress_stats(
   WT_SESSION_IMPL *session, WT_BM *bm, uint64_t *pages_reviewedp);
 extern void __wt_block_compact_progress(WT_SESSION_IMPL *session, WT_BLOCK *block);
 extern void __wt_block_disagg_checkpoint_rollback(WT_SESSION_IMPL *session);
-extern void __wt_block_disagg_decrease_ckpt_size(WT_SESSION_IMPL *session, uint64_t size);
+extern void __wt_block_disagg_decrease_size(WT_SESSION_IMPL *session, uint64_t size);
 extern void __wt_block_disagg_header_byteswap_copy(
   WT_BLOCK_DISAGG_HEADER *from, WT_BLOCK_DISAGG_HEADER *to);
 extern void __wt_block_disagg_set_size(WT_SESSION_IMPL *session, uint64_t size);

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -21,7 +21,7 @@ static int __rec_split_row_promote(WT_SESSION_IMPL *, WTI_RECONCILE *, WT_ITEM *
 static int __rec_split_write(WT_SESSION_IMPL *, WTI_RECONCILE *, WTI_REC_CHUNK *, bool);
 static void __rec_write_page_status(WT_SESSION_IMPL *, WTI_RECONCILE *);
 static int __rec_write_err(WT_SESSION_IMPL *, WTI_RECONCILE *, WT_PAGE *);
-static int __rec_wrapup_obsolete_delta_chain(
+static int __rec_wrapup_decrease_disagg_size(
   WT_SESSION_IMPL *, WTI_RECONCILE *, const uint8_t *, size_t);
 static int __rec_write_wrapup(WT_SESSION_IMPL *, WTI_RECONCILE *);
 static int __reconcile(WT_SESSION_IMPL *, WT_REF *, WT_SALVAGE_COOKIE *, uint32_t, bool *);
@@ -2930,7 +2930,7 @@ __rec_page_modify_ta_safe_free(WT_SESSION_IMPL *session, WT_TIME_AGGREGATE **ta)
 }
 
 /*
- * __rec_wrapup_obsolete_delta_chain --
+ * __rec_wrapup_decrease_disagg_size --
  *     A newly written full page image terminates the on-disk delta chain, so the prior chain's
  *     cumulative size must stop counting toward the tree's byte total. Decrease the size when this
  *     reconciliation wrote a single full image and did not skip the write. Callers gate on their
@@ -2938,7 +2938,7 @@ __rec_page_modify_ta_safe_free(WT_SESSION_IMPL *session, WT_TIME_AGGREGATE **ta)
  *     cookie is supplied it records the size being obsoleted; diagnostic builds check they agree.
  */
 static int
-__rec_wrapup_obsolete_delta_chain(
+__rec_wrapup_decrease_disagg_size(
   WT_SESSION_IMPL *session, WTI_RECONCILE *r, const uint8_t *cookie, size_t cookie_size)
 {
     WT_PAGE *page;
@@ -3060,7 +3060,7 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
         WT_RET(__wt_ref_block_free(session, ref, disagg_page_free_required));
         /* Update the size accounting if we keep the page id and terminate the delta chain. */
         if (disagg_page_is_valid && !disagg_page_free_required)
-            WT_RET(__rec_wrapup_obsolete_delta_chain(session, r, NULL, 0));
+            WT_RET(__rec_wrapup_decrease_disagg_size(session, r, NULL, 0));
         break;
     case WT_PM_REC_EMPTY: /* Page deleted */
         break;
@@ -3106,7 +3106,7 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
                          * terminate the delta chain.
                          */
                         if (disagg_page_is_valid && !disagg_page_free_required)
-                            WT_RET(__rec_wrapup_obsolete_delta_chain(session, r, NULL, 0));
+                            WT_RET(__rec_wrapup_decrease_disagg_size(session, r, NULL, 0));
                     }
                 }
             } else {
@@ -3132,7 +3132,7 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
                      * the one on the multi->block_meta appears to be from the current block.
                      */
                     if (r->multi_next == 1 && r->multi->block_meta != NULL)
-                        WT_RET(__rec_wrapup_obsolete_delta_chain(session, r,
+                        WT_RET(__rec_wrapup_decrease_disagg_size(session, r,
                           mod->mod_replace.block_cookie, mod->mod_replace.block_cookie_size));
                 }
             }

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2963,7 +2963,7 @@ __rec_wrapup_decrease_disagg_size(
     WT_UNUSED(cookie_size);
 #endif
 
-    __wt_block_disagg_obsolete_delta_chain(session, page->disagg_info->block_meta.cumulative_size);
+    __wt_block_disagg_decrease_ckpt_size(session, page->disagg_info->block_meta.cumulative_size);
     return (0);
 }
 
@@ -3389,7 +3389,7 @@ __rec_write_err(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
          */
         if (r->multi->block_meta->delta_count == 0 &&
           page->disagg_info->block_meta.cumulative_size > 0)
-            __wt_block_disagg_obsolete_delta_chain(
+            __wt_block_disagg_decrease_ckpt_size(
               session, page->disagg_info->block_meta.cumulative_size);
         /*
          * The page's on-disk chain has now been removed from the running byte total -- by the

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -21,6 +21,8 @@ static int __rec_split_row_promote(WT_SESSION_IMPL *, WTI_RECONCILE *, WT_ITEM *
 static int __rec_split_write(WT_SESSION_IMPL *, WTI_RECONCILE *, WTI_REC_CHUNK *, bool);
 static void __rec_write_page_status(WT_SESSION_IMPL *, WTI_RECONCILE *);
 static int __rec_write_err(WT_SESSION_IMPL *, WTI_RECONCILE *, WT_PAGE *);
+static int __rec_wrapup_obsolete_delta_chain(
+  WT_SESSION_IMPL *, WTI_RECONCILE *, const uint8_t *, size_t);
 static int __rec_write_wrapup(WT_SESSION_IMPL *, WTI_RECONCILE *);
 static int __reconcile(WT_SESSION_IMPL *, WT_REF *, WT_SALVAGE_COOKIE *, uint32_t, bool *);
 
@@ -2925,6 +2927,44 @@ __rec_page_modify_ta_safe_free(WT_SESSION_IMPL *session, WT_TIME_AGGREGATE **ta)
     if (__wt_stash_add(session, WT_GEN_SPLIT, split_gen, p, sizeof(WT_TIME_AGGREGATE)) != 0)
         WT_IGNORE_RET(__wt_panic(session, ret, "fatal error during page modify ta free"));
     __wt_gen_next(session, WT_GEN_SPLIT, NULL);
+}
+
+/*
+ * __rec_wrapup_obsolete_delta_chain --
+ *     A newly written full page image terminates the on-disk delta chain, so the prior chain's
+ *     cumulative size must stop counting toward the tree's byte total. Decrease the size when this
+ *     reconciliation wrote a single full image and did not skip the write. Callers gate on their
+ *     own page id conditions before establishing there is a chain to obsolete. When a replacement
+ *     cookie is supplied it records the size being obsoleted; diagnostic builds check they agree.
+ */
+static int
+__rec_wrapup_obsolete_delta_chain(
+  WT_SESSION_IMPL *session, WTI_RECONCILE *r, const uint8_t *cookie, size_t cookie_size)
+{
+    WT_PAGE *page;
+
+    page = r->page;
+
+    /* Only a full page image (no deltas) that was actually written terminates the chain. */
+    if (F_ISSET(r->multi, WT_MULTI_SKIP_WRITE) || r->multi->block_meta->delta_count != 0)
+        return (0);
+
+#ifdef HAVE_DIAGNOSTIC
+    if (cookie != NULL) {
+        WT_BLOCK_DISAGG_ADDRESS_COOKIE unpacked;
+        const uint8_t *buf;
+
+        buf = cookie;
+        WT_RET(__wt_block_disagg_addr_unpack(session, &buf, cookie_size, &unpacked));
+        WT_ASSERT(session, unpacked.size == page->disagg_info->block_meta.cumulative_size);
+    }
+#else
+    WT_UNUSED(cookie);
+    WT_UNUSED(cookie_size);
+#endif
+
+    __wt_block_disagg_obsolete_delta_chain(session, page->disagg_info->block_meta.cumulative_size);
+    return (0);
 }
 
 /*

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -3058,14 +3058,9 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
         }
 
         WT_RET(__wt_ref_block_free(session, ref, disagg_page_free_required));
-        /*
-         * Update the tree size accounting if we don't free the page id and we terminate the delta
-         * chain.
-         */
-        if (disagg_page_is_valid && !disagg_page_free_required &&
-          !F_ISSET(r->multi, WT_MULTI_SKIP_WRITE) && r->multi->block_meta->delta_count == 0)
-            __wt_block_disagg_obsolete_delta_chain(
-              session, ref->page->disagg_info->block_meta.cumulative_size);
+        /* Update the size accounting if we keep the page id and terminate the delta chain. */
+        if (disagg_page_is_valid && !disagg_page_free_required)
+            WT_RET(__rec_wrapup_obsolete_delta_chain(session, r, NULL, 0));
         break;
     case WT_PM_REC_EMPTY: /* Page deleted */
         break;
@@ -3110,11 +3105,8 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
                          * Update the tree size accounting if we don't free the page id and we
                          * terminate the delta chain.
                          */
-                        if (disagg_page_is_valid && !disagg_page_free_required &&
-                          !F_ISSET(r->multi, WT_MULTI_SKIP_WRITE) &&
-                          r->multi->block_meta->delta_count == 0)
-                            __wt_block_disagg_obsolete_delta_chain(
-                              session, ref->page->disagg_info->block_meta.cumulative_size);
+                        if (disagg_page_is_valid && !disagg_page_free_required)
+                            WT_RET(__rec_wrapup_obsolete_delta_chain(session, r, NULL, 0));
                     }
                 }
             } else {
@@ -3139,26 +3131,9 @@ __rec_write_wrapup(WT_SESSION_IMPL *session, WTI_RECONCILE *r)
                      * the one held on page->disagg_info appears to be from the previous block, and
                      * the one on the multi->block_meta appears to be from the current block.
                      */
-                    if (r->multi_next == 1 && r->multi->block_meta != NULL &&
-                      r->multi->block_meta->delta_count == 0 &&
-                      !F_ISSET(r->multi, WT_MULTI_SKIP_WRITE)) {
-
-#ifdef HAVE_DIAGNOSTIC
-                        /*
-                         * The previous cookie has the size we want but it should be also the
-                         * previous cumulative size. Sanity check this is the case in diagnostics
-                         * build.
-                         */
-                        WT_BLOCK_DISAGG_ADDRESS_COOKIE cookie;
-                        const uint8_t *buf = mod->mod_replace.block_cookie;
-                        WT_RET(__wt_block_disagg_addr_unpack(
-                          session, &buf, mod->mod_replace.block_cookie_size, &cookie));
-                        WT_ASSERT(
-                          session, cookie.size == page->disagg_info->block_meta.cumulative_size);
-#endif
-                        __wt_block_disagg_obsolete_delta_chain(
-                          session, page->disagg_info->block_meta.cumulative_size);
-                    }
+                    if (r->multi_next == 1 && r->multi->block_meta != NULL)
+                        WT_RET(__rec_wrapup_obsolete_delta_chain(session, r,
+                          mod->mod_replace.block_cookie, mod->mod_replace.block_cookie_size));
                 }
             }
         }

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2963,7 +2963,7 @@ __rec_wrapup_decrease_disagg_size(
     WT_UNUSED(cookie_size);
 #endif
 
-    __wt_block_disagg_decrease_ckpt_size(session, page->disagg_info->block_meta.cumulative_size);
+    __wt_block_disagg_decrease_size(session, page->disagg_info->block_meta.cumulative_size);
     return (0);
 }
 
@@ -3389,8 +3389,7 @@ __rec_write_err(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
          */
         if (r->multi->block_meta->delta_count == 0 &&
           page->disagg_info->block_meta.cumulative_size > 0)
-            __wt_block_disagg_decrease_ckpt_size(
-              session, page->disagg_info->block_meta.cumulative_size);
+            __wt_block_disagg_decrease_size(session, page->disagg_info->block_meta.cumulative_size);
         /*
          * The page's on-disk chain has now been removed from the running byte total -- by the
          * obsolete above for a failed full image, or by the failed block's discard (whose cookie

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2952,10 +2952,8 @@ __rec_wrapup_decrease_disagg_size(
 #ifdef HAVE_DIAGNOSTIC
     if (cookie != NULL) {
         WT_BLOCK_DISAGG_ADDRESS_COOKIE unpacked;
-        const uint8_t *buf;
 
-        buf = cookie;
-        WT_RET(__wt_block_disagg_addr_unpack(session, &buf, cookie_size, &unpacked));
+        WT_RET(__wt_block_disagg_addr_unpack(session, &cookie, cookie_size, &unpacked));
         WT_ASSERT(session, unpacked.size == page->disagg_info->block_meta.cumulative_size);
     }
 #else


### PR DESCRIPTION
Three spots in `__rec_write_wrapup` did the same flag check before calling `__wt_block_disagg_obsolete_delta_chain`. The shared logic has been pulled into a static helper `__rec_wrapup_obsolete_delta_chain`.

The 4th obsolete call (error path) is out of scope as it has different semantics.

`test_disagg_checkpoint_size` and the `layered` checkpoint suite all pass.