### PR TITLE
WT-17817 Restrict outdated stable dhandle in-use bypass to checkpoint-view handles

### DIFF
--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -294,14 +294,17 @@ __wt_conn_dhandle_find(WT_SESSION_IMPL *session, const char *uri, const char *ch
                 continue;
             if (F_ISSET(dhandle, WT_DHANDLE_OUTDATED)) {
                 /*
-                 * For read-only stable table checkpoints, they are really outdated when they are
-                 * not in use any more. The pinned shared history store checkpoints may be still
-                 * needed by the readers while the stable table checkpoints may still be needed by
-                 * the checkpoint tracking logic.
+                 * An outdated read-only stable handle is only safe to reuse in its checkpoint-view
+                 * form (a "...wt_stable/WiredTigerCheckpoint.N" name): those checkpoint handles
+                 * span eras and sweep keeps them alive for readers and the checkpoint tracking
+                 * logic. A live stable handle must be reopened fresh instead -- draining through an
+                 * outdated one hits resident inserts or unresolved prepared updates left by the
+                 * previous leader era.
                  */
                 if (WT_DHANDLE_BTREE(dhandle) &&
                   F_ISSET((WT_BTREE *)dhandle->handle, WT_BTREE_READONLY)) {
-                    if (__wt_atomic_load_int32_acquire(&dhandle->session_inuse) == 0)
+                    if (__wt_atomic_load_int32_acquire(&dhandle->session_inuse) == 0 ||
+                      !WT_URI_IS_STABLE_CHECKPOINT(dhandle->name))
                         continue;
                 } else
                     continue;

--- a/test/suite/test_layered_eviction07.py
+++ b/test/suite/test_layered_eviction07.py
@@ -75,15 +75,11 @@ class test_layered_eviction07(wttest.WiredTigerTestCase):
 
         # Dirty the same page again, above the last checkpoint timestamp, and do
         # NOT checkpoint. This update belongs to the current leader epoch and is
-        # never flushed to shared storage.
+        # never flushed to shared storage, so it stays dirty and resident.
         #
         # Keep this cursor OPEN across step-down. An open cursor pins its data
-        # handle's in-use count above zero for its whole lifetime. Committing the
-        # transaction resets the cursor (it drops its hazard pointer on the page,
-        # so eviction is not blocked) but does not close it, so the pin survives.
-        # That pin is the whole point: when eviction later opens a handle for this
-        # table, the in-use count keeps it bound to this now read-only handle
-        # instead of being rerouted to a freshly opened one.
+        # handle's in-use count above zero for its whole lifetime, so the handle
+        # is not swept while it is marked read-only.
         cursor = self.session.open_cursor(self.uri, None, None)
         self.session.begin_transaction()
         cursor['a'] = 'c'
@@ -93,10 +89,18 @@ class test_layered_eviction07(wttest.WiredTigerTestCase):
         # and visible to a follower read. The page stays dirty with 'c' resident.
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(20))
 
+        # Open the eviction cursor now, while the handle is still live and
+        # writable. The cursor binds to this data handle and keeps that binding
+        # for its lifetime; a later reconfigure does not re-resolve it by URI. This
+        # is how eviction reaches the dirty resident page on the old handle after
+        # step-down, without relying on handle lookup returning an outdated handle.
+        evict_cursor = self.session.open_cursor(self.uri, None, 'debug=(release_evict)')
+
         # Step down to follower. This marks the btree read-only and the dhandle
         # outdated; it deliberately does not checkpoint, so the dirty page stays
-        # resident. The still-open cursor keeps the in-use count above zero, so
-        # the read-only handle is neither swept nor bypassed by handle lookup.
+        # resident on the handle the eviction cursor is bound to. The still-open
+        # cursors keep the in-use count above zero, so the read-only handle is not
+        # swept.
         self.conn.reconfigure('disaggregated=(role="follower")')
 
         # Step back up to leader. The stale handle keeps its read-only/outdated
@@ -109,19 +113,18 @@ class test_layered_eviction07(wttest.WiredTigerTestCase):
         # read-only btree trips the read-only assertion.
         self.conn.reconfigure('disaggregated=(role="leader")')
 
-        # Force eviction of the now read-only page. Because the leader handle is
-        # still pinned in use, this cursor binds to it (not a freshly opened
-        # handle) and positions on the resident dirty page; reading back 'c'
-        # confirms we are on the dirty handle rather than the checkpointed image.
-        # The reset then drives release_eviction on the dirty read-only page.
+        # Force eviction of the now read-only page. The eviction cursor is still
+        # bound to the stale handle, so positioning it reads the resident dirty
+        # page; reading back 'c' confirms we are on the dirty handle rather than
+        # the checkpointed image. The reset then drives release_eviction on the
+        # dirty read-only page.
         self.session.begin_transaction()
-        evict_cursor = self.session.open_cursor(self.uri, None, 'debug=(release_evict)')
         evict_val = evict_cursor['a']
         evict_cursor.reset()
         evict_cursor.close()
         self.session.rollback_transaction()
 
-        # Drop the pin now that eviction has run.
+        # Drop the write cursor pin now that eviction has run.
         cursor.close()
 
         self.assertEqual(evict_val, 'c')


### PR DESCRIPTION
## Problem
During an elegant step-down, a live stable btree dhandle is marked `WT_BTREE_READONLY` + `WT_DHANDLE_OUTDATED` so the next step-up reopens it fresh. Eviction can pin that dead-era handle (raising `session_inuse`), and on the following step-up drain the `__wt_conn_dhandle_find` in-use bypass returns the same outdated handle instead of opening a fresh one. The ingest drain then lands on dead-era resident inserts / unresolved prepared updates, and `__layered_assert_stable_btree_state` aborts.

## Fix
Restrict the in-use bypass to checkpoint-view stable handles (`WT_URI_IS_STABLE_CHECKPOINT`, i.e. names containing `.wt_stable/`): those checkpoint handles span eras and are kept alive by sweep for readers and the checkpoint tracking logic. A live stable handle now always skips the outdated handle, so the drain opens a fresh current-era one. This aligns the finder's reuse predicate with the one sweep already uses to keep those handles alive during the grace period.
