### PR TITLE
WT-17251 Add logging to predictable replay

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1230,7 +1230,6 @@ keyedness
 keyid
 keyids
 keylen
-keyno
 keynum
 keyp
 keystr
@@ -1779,7 +1778,6 @@ tIf
 tV
 tabconfig
 tablename
-tbl
 tc
 tcmalloc
 td

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1230,6 +1230,7 @@ keyedness
 keyid
 keyids
 keylen
+keyno
 keynum
 keyp
 keystr
@@ -1778,6 +1779,7 @@ tIf
 tV
 tabconfig
 tablename
+tbl
 tc
 tcmalloc
 td

--- a/test/evergreen/collect_stat_files.py
+++ b/test/evergreen/collect_stat_files.py
@@ -62,7 +62,7 @@ def main():
 
     destination_dir = args.destination_dir
 
-    regex = re.compile(r'WiredTigerStat.*')
+    regex = re.compile(r'(WiredTigerStat.*|replay_ops_.*\.log)')
     for walk_dir, _, files in os.walk("."):
         if destination_dir in walk_dir:
             # Skip searching for stat files in the destination directory, since that's where we're collecting them and we don't want to copy files that we've already collected.

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -279,6 +279,7 @@ typedef struct {
     wt_timestamp_t replay_cached_committed; /* Our committed timestamp, cached */
     uint32_t replay_calculate_committed;    /* Times before recalculating cached committed */
     wt_timestamp_t replay_start_timestamp;  /* Timestamp at the beginning of a run */
+    FILE *replay_op_log;                    /* Predictable replay per-run operation log */
     wt_timestamp_t stop_timestamp;          /* If non-zero, stop when stable reaches this */
     wt_timestamp_t timestamp_copy;          /* A copy of the timestamp, for safety checks */
 

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -1036,7 +1036,9 @@ ops(void *arg)
 
     tinfo = arg;
     mirrored_truncate = false;
-    rlog_keyno = rlog_lane = rlog_read_ts = rlog_replay_ts = rlog_table_id = rlog_ret = 0;
+    rlog_keyno = rlog_lane = rlog_read_ts = rlog_replay_ts = 0;
+    rlog_table_id = 0;
+    rlog_ret = 0;
     rlog_op_name = NULL;
 
     /*

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -365,7 +365,6 @@ operations(u_int ops_seconds, u_int run_current, u_int run_total)
           replay_log_path, sizeof(replay_log_path), "%s/replay_ops_%u.log", g.home, run_current);
         g.replay_op_log = fopen(replay_log_path, "w");
         testutil_assertfmt(g.replay_op_log != NULL, "failed to open %s", replay_log_path);
-        /* Line-buffer so the log survives the mismatch abort in disagg_sync_multi_node. */
         __wt_stream_set_line_buffer(g.replay_op_log);
     }
 
@@ -1027,7 +1026,7 @@ ops(void *arg)
     iso_level_t iso_level;
     thread_op op;
     uint64_t reset_op, session_op, throttle_delay, truncate_op;
-    uint64_t rlog_keyno, rlog_lane, rlog_read_ts, rlog_replay_ts;
+    uint64_t rlog_key, rlog_lane, rlog_read_ts, rlog_replay_ts;
     uint32_t max_rows, ntries, range, rnd;
     u_int i, rlog_table_id, throttle_delay_max;
     int rlog_ret;
@@ -1036,7 +1035,7 @@ ops(void *arg)
 
     tinfo = arg;
     mirrored_truncate = false;
-    rlog_keyno = rlog_lane = rlog_read_ts = rlog_replay_ts = 0;
+    rlog_key = rlog_lane = rlog_read_ts = rlog_replay_ts = 0;
     rlog_table_id = 0;
     rlog_ret = 0;
     rlog_op_name = NULL;
@@ -1250,7 +1249,7 @@ rollback_retry:
             rlog_lane = tinfo->lane;
             rlog_replay_ts = tinfo->replay_ts;
             rlog_read_ts = tinfo->read_ts;
-            rlog_keyno = tinfo->keyno;
+            rlog_key = tinfo->keyno;
             rlog_table_id = table->id;
             rlog_ret = 0;
             rlog_op_name = op_names[op];
@@ -1466,9 +1465,9 @@ skip_operation:
             snap_repeat_update(tinfo, true);
             if (rlog_op_name != NULL) {
                 fprintf(g.replay_op_log,
-                  "%s lane=%" PRIu64 " commit_ts=%" PRIu64 " read_ts=%" PRIu64 " keyno=%" PRIu64
-                  " tbl=%u ret=%d\n",
-                  rlog_op_name, rlog_lane, rlog_replay_ts, rlog_read_ts, rlog_keyno, rlog_table_id,
+                  "%s lane=%" PRIu64 " commit_ts=%" PRIu64 " read_ts=%" PRIu64 " key=%" PRIu64
+                  " table=%u ret=%d\n",
+                  rlog_op_name, rlog_lane, rlog_replay_ts, rlog_read_ts, rlog_key, rlog_table_id,
                   rlog_ret);
                 rlog_op_name = NULL;
             }

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -1036,9 +1036,7 @@ ops(void *arg)
 
     tinfo = arg;
     mirrored_truncate = false;
-    rlog_keyno = rlog_lane = rlog_read_ts = rlog_ts = 0;
-    rlog_table_id = 0;
-    rlog_ret = 0;
+    rlog_keyno = rlog_lane = rlog_read_ts = rlog_ts = rlog_table_id = rlog_ret = 0;
     rlog_op_name = NULL;
 
     /*
@@ -1239,33 +1237,21 @@ rollback_retry:
         }
         replay_adjust_key(tinfo, max_rows);
 
+        /* Once the operation and key have been finalized, construct a replay log entry. */
         if (GV(RUNS_PREDICTABLE_REPLAY)) {
+            static const char *const op_names[] = {[INSERT] = "INSERT",
+              [MODIFY] = "MODIFY",
+              [READ] = "READ",
+              [REMOVE] = "REMOVE",
+              [TRUNCATE] = "TRUNCATE",
+              [UPDATE] = "UPDATE"};
             rlog_lane = tinfo->lane;
             rlog_ts = tinfo->replay_ts;
             rlog_read_ts = tinfo->read_ts;
             rlog_keyno = tinfo->keyno;
             rlog_table_id = table->id;
             rlog_ret = 0;
-            switch (op) {
-            case REMOVE:
-                rlog_op_name = "REMOVE";
-                break;
-            case INSERT:
-                rlog_op_name = "INSERT";
-                break;
-            case READ:
-                rlog_op_name = "READ";
-                break;
-            case UPDATE:
-                rlog_op_name = "UPDATE";
-                break;
-            case MODIFY:
-                rlog_op_name = "MODIFY";
-                break;
-            case TRUNCATE:
-                rlog_op_name = "TRUNCATE";
-                break;
-            }
+            rlog_op_name = op_names[op];
         }
 
         /*

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -1027,7 +1027,7 @@ ops(void *arg)
     iso_level_t iso_level;
     thread_op op;
     uint64_t reset_op, session_op, throttle_delay, truncate_op;
-    uint64_t rlog_keyno, rlog_lane, rlog_read_ts, rlog_ts;
+    uint64_t rlog_keyno, rlog_lane, rlog_read_ts, rlog_replay_ts;
     uint32_t max_rows, ntries, range, rnd;
     u_int i, rlog_table_id, throttle_delay_max;
     int rlog_ret;
@@ -1036,7 +1036,7 @@ ops(void *arg)
 
     tinfo = arg;
     mirrored_truncate = false;
-    rlog_keyno = rlog_lane = rlog_read_ts = rlog_ts = rlog_table_id = rlog_ret = 0;
+    rlog_keyno = rlog_lane = rlog_read_ts = rlog_replay_ts = rlog_table_id = rlog_ret = 0;
     rlog_op_name = NULL;
 
     /*
@@ -1246,7 +1246,7 @@ rollback_retry:
               [TRUNCATE] = "TRUNCATE",
               [UPDATE] = "UPDATE"};
             rlog_lane = tinfo->lane;
-            rlog_ts = tinfo->replay_ts;
+            rlog_replay_ts = tinfo->replay_ts;
             rlog_read_ts = tinfo->read_ts;
             rlog_keyno = tinfo->keyno;
             rlog_table_id = table->id;
@@ -1464,9 +1464,9 @@ skip_operation:
             snap_repeat_update(tinfo, true);
             if (rlog_op_name != NULL) {
                 fprintf(g.replay_op_log,
-                  "%s lane=%" PRIu64 " ts=%" PRIu64 " read_ts=%" PRIu64 " keyno=%" PRIu64
+                  "%s lane=%" PRIu64 " commit_ts=%" PRIu64 " read_ts=%" PRIu64 " keyno=%" PRIu64
                   " tbl=%u ret=%d\n",
-                  rlog_op_name, rlog_lane, rlog_ts, rlog_read_ts, rlog_keyno, rlog_table_id,
+                  rlog_op_name, rlog_lane, rlog_replay_ts, rlog_read_ts, rlog_keyno, rlog_table_id,
                   rlog_ret);
                 rlog_op_name = NULL;
             }

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -359,6 +359,16 @@ operations(u_int ops_seconds, u_int run_current, u_int run_total)
 
     replay_run_begin(session);
 
+    if (GV(RUNS_PREDICTABLE_REPLAY)) {
+        char replay_log_path[MAX_FORMAT_PATH];
+        testutil_snprintf(
+          replay_log_path, sizeof(replay_log_path), "%s/replay_ops_%u.log", g.home, run_current);
+        g.replay_op_log = fopen(replay_log_path, "w");
+        testutil_assertfmt(g.replay_op_log != NULL, "failed to open %s", replay_log_path);
+        /* Line-buffer so the log survives the mismatch abort in disagg_sync_multi_node. */
+        __wt_stream_set_line_buffer(g.replay_op_log);
+    }
+
     for (i = 0; i < GV(RUNS_THREADS); ++i) {
         tinfo = tinfo_list[i];
         testutil_check(__wt_thread_create(NULL, &tinfo->tid, ops, tinfo));
@@ -503,6 +513,11 @@ operations(u_int ops_seconds, u_int run_current, u_int run_total)
     rollback_to_stable(session);
 
     disagg_sync_multi_node(session);
+
+    if (g.replay_op_log != NULL) {
+        fclose(g.replay_op_log);
+        g.replay_op_log = NULL;
+    }
 
     replay_run_end(session);
 
@@ -1012,13 +1027,19 @@ ops(void *arg)
     iso_level_t iso_level;
     thread_op op;
     uint64_t reset_op, session_op, throttle_delay, truncate_op;
+    uint64_t rlog_keyno, rlog_lane, rlog_read_ts, rlog_ts;
     uint32_t max_rows, ntries, range, rnd;
-    u_int i, throttle_delay_max;
-    const char *iso_config;
+    u_int i, rlog_table_id, throttle_delay_max;
+    int rlog_ret;
+    const char *iso_config, *rlog_op_name;
     bool greater_than, intxn, prepared, mirrored_truncate;
 
     tinfo = arg;
     mirrored_truncate = false;
+    rlog_keyno = rlog_lane = rlog_read_ts = rlog_ts = 0;
+    rlog_table_id = 0;
+    rlog_ret = 0;
+    rlog_op_name = NULL;
 
     /*
      * Characterize the per-thread random number generator. Normally we want independent behavior so
@@ -1070,13 +1091,15 @@ rollback_retry:
 
         ++tinfo->ops;
 
-        if (!tinfo->replay_again)
+        if (!tinfo->replay_again) {
             /*
              * Number of failures so far for the current operation and key. In predictable replay,
              * unless we have a read operation, we cannot give up on any operation and maintain the
              * integrity of the replay.
              */
             ntries = 0;
+            rlog_op_name = NULL;
+        }
 
         /* Number of tries only gets incremented during predictable replay. */
         testutil_assert(ntries == 0 || (!intxn && tinfo->replay_again));
@@ -1216,6 +1239,35 @@ rollback_retry:
         }
         replay_adjust_key(tinfo, max_rows);
 
+        if (GV(RUNS_PREDICTABLE_REPLAY)) {
+            rlog_lane = tinfo->lane;
+            rlog_ts = tinfo->replay_ts;
+            rlog_read_ts = tinfo->read_ts;
+            rlog_keyno = tinfo->keyno;
+            rlog_table_id = table->id;
+            rlog_ret = 0;
+            switch (op) {
+            case REMOVE:
+                rlog_op_name = "REMOVE";
+                break;
+            case INSERT:
+                rlog_op_name = "INSERT";
+                break;
+            case READ:
+                rlog_op_name = "READ";
+                break;
+            case UPDATE:
+                rlog_op_name = "UPDATE";
+                break;
+            case MODIFY:
+                rlog_op_name = "MODIFY";
+                break;
+            case TRUNCATE:
+                rlog_op_name = "TRUNCATE";
+                break;
+            }
+        }
+
         /*
          * If the operation is a truncate, select a range.
          *
@@ -1319,6 +1371,8 @@ rollback_retry:
             testutil_assert(ret == 0 || ret == WT_ROLLBACK);
             if (GV(RUNS_PREDICTABLE_REPLAY) && ret == WT_ROLLBACK)
                 goto rollback;
+            if (GV(RUNS_PREDICTABLE_REPLAY) && op == REMOVE)
+                rlog_ret = tinfo->op_ret;
             skip2 = table;
         }
         if (ret == 0 && table->mirror) {
@@ -1406,6 +1460,16 @@ skip_operation:
             /* ENOTSUP: prepare was skipped (no valid timestamp), treat as unprepared. */
         }
 
+/*
+ * Emit a replay log line to the per-run log file. Defined here so it can be used in the commit case
+ * below.
+ */
+#define rlog_emit(fmt, ...)                             \
+    do {                                                \
+        if (g.replay_op_log != NULL)                    \
+            fprintf(g.replay_op_log, fmt, __VA_ARGS__); \
+    } while (0)
+
         /*
          * If we're in a transaction, commit 40% of the time and rollback 10% of the time (we
          * already continued to add operations to the transaction the remaining half of the time).
@@ -1418,6 +1482,13 @@ skip_operation:
             __wt_yield(); /* Encourage races */
             commit_transaction(tinfo, prepared);
             snap_repeat_update(tinfo, true);
+            if (rlog_op_name != NULL) {
+                rlog_emit("%s lane=%" PRIu64 " ts=%" PRIu64 " read_ts=%" PRIu64 " keyno=%" PRIu64
+                          " tbl=%u ret=%d\n",
+                  rlog_op_name, rlog_lane, rlog_ts, rlog_read_ts, rlog_keyno, rlog_table_id,
+                  rlog_ret);
+                rlog_op_name = NULL;
+            }
             break;
         case 5: /* 10% */
 rollback:
@@ -1438,6 +1509,7 @@ rollback:
             snap_repeat_update(tinfo, false);
             break;
         }
+#undef rlog_emit
 
         /*
          * If this operation was a mirrored truncate, verify the mirrors. This runs after both

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -1375,7 +1375,7 @@ rollback_retry:
             testutil_assert(ret == 0 || ret == WT_ROLLBACK);
             if (GV(RUNS_PREDICTABLE_REPLAY) && ret == WT_ROLLBACK)
                 goto rollback;
-            if (GV(RUNS_PREDICTABLE_REPLAY) && op == REMOVE)
+            if (GV(RUNS_PREDICTABLE_REPLAY))
                 rlog_ret = tinfo->op_ret;
             skip2 = table;
         }

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -1464,16 +1464,6 @@ skip_operation:
             /* ENOTSUP: prepare was skipped (no valid timestamp), treat as unprepared. */
         }
 
-/*
- * Emit a replay log line to the per-run log file. Defined here so it can be used in the commit case
- * below.
- */
-#define rlog_emit(fmt, ...)                             \
-    do {                                                \
-        if (g.replay_op_log != NULL)                    \
-            fprintf(g.replay_op_log, fmt, __VA_ARGS__); \
-    } while (0)
-
         /*
          * If we're in a transaction, commit 40% of the time and rollback 10% of the time (we
          * already continued to add operations to the transaction the remaining half of the time).
@@ -1487,8 +1477,9 @@ skip_operation:
             commit_transaction(tinfo, prepared);
             snap_repeat_update(tinfo, true);
             if (rlog_op_name != NULL) {
-                rlog_emit("%s lane=%" PRIu64 " ts=%" PRIu64 " read_ts=%" PRIu64 " keyno=%" PRIu64
-                          " tbl=%u ret=%d\n",
+                fprintf(g.replay_op_log,
+                  "%s lane=%" PRIu64 " ts=%" PRIu64 " read_ts=%" PRIu64 " keyno=%" PRIu64
+                  " tbl=%u ret=%d\n",
                   rlog_op_name, rlog_lane, rlog_ts, rlog_read_ts, rlog_keyno, rlog_table_id,
                   rlog_ret);
                 rlog_op_name = NULL;
@@ -1513,7 +1504,6 @@ rollback:
             snap_repeat_update(tinfo, false);
             break;
         }
-#undef rlog_emit
 
         /*
          * If this operation was a mirrored truncate, verify the mirrors. This runs after both


### PR DESCRIPTION
Test format predictable replay now writes to a log file that can be analyzed when we see divergences between subsequent runs (or leader vs follower in multi-node). 

Logs are written to `RUNDIR/replay_ops_X.log` and have the following format:
```
INSERT lane=73 commit_ts=14409 read_ts=14408 keyno=4169 tbl=3 ret=0
REMOVE lane=80 commit_ts=14416 read_ts=14408 keyno=80 tbl=2 ret=0
MODIFY lane=75 commit_ts=14411 read_ts=14408 keyno=75 tbl=2 ret=0
MODIFY lane=74 commit_ts=14410 read_ts=14408 keyno=74 tbl=2 ret=0
READ lane=77 commit_ts=14413 read_ts=14408 keyno=91213 tbl=1 ret=0
MODIFY lane=76 commit_ts=14412 read_ts=14408 keyno=87116 tbl=1 ret=0
INSERT lane=87 commit_ts=14423 read_ts=14408 keyno=54359 tbl=3 ret=0
INSERT lane=82 commit_ts=14418 read_ts=14408 keyno=32850 tbl=1 ret=0
UPDATE lane=85 commit_ts=14421 read_ts=14408 keyno=62549 tbl=1 ret=0
```