### PR TITLE
WT-17900 Fix slow statistics collection after checkpoint in statistic=(fast) mode

### DIFF
--- a/src/cursor/cur_stat.c
+++ b/src/cursor/cur_stat.c
@@ -436,12 +436,9 @@ retry:
     /* Now do the stable table. */
     if (!S2C(session)->layered_table_manager.leader) {
         /*
-         * On a follower, opening the stable checkpoint dhandle reads its root from the disagg page
-         * service and can block for seconds, recurring every checkpoint as the stable name
-         * advances. When no tree walk is requested, take block_size from the checkpoint metadata
-         * instead; the other non-walk stable stats are ~0 on a follower because its pages are not
-         * resident in the local cache. A tree walk (statistics=(all)) still opens the checkpoint to
-         * read it.
+         * When no tree walk is requested, take block_size from the checkpoint metadata instead; the
+         * other non-walk stable stats are ~0 on a follower because its pages are not resident in
+         * the local cache.
          */
         if (!F_ISSET(cst, WT_STAT_TYPE_TREE_WALK)) {
             ckpt_size = 0;

--- a/src/cursor/cur_stat.c
+++ b/src/cursor/cur_stat.c
@@ -415,7 +415,6 @@ __curstat_layered_init(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR_STAT
     WT_DECL_ITEM(stable_uri_buf);
     WT_DECL_RET;
     WT_LAYERED_TABLE *layered = NULL;
-    uint64_t ckpt_size;
     const char *checkpoint_name = NULL;
     const char *stable_uri = NULL;
 
@@ -436,16 +435,11 @@ retry:
     /* Now do the stable table. */
     if (!S2C(session)->layered_table_manager.leader) {
         /*
-         * When no tree walk is requested, take block_size from the checkpoint metadata instead; the
-         * other non-walk stable stats are ~0 on a follower because its pages are not resident in
-         * the local cache.
+         * Non-walk stable stats are ~0 on a follower because its pages are not resident in the
+         * local cache. Skip opening the stable table.
          */
-        if (!F_ISSET(cst, WT_STAT_TYPE_TREE_WALK)) {
-            ckpt_size = 0;
-            WT_ERR(__wt_block_disagg_ckpt_size(session, stable_uri, &ckpt_size));
-            cst->u.dsrc_stats.block_size += (int64_t)ckpt_size;
+        if (!F_ISSET(cst, WT_STAT_TYPE_TREE_WALK))
             goto done;
-        }
 
         /* Look up the most recent data store checkpoint. This fetches the exact name to use. */
         WT_ERR_NOTFOUND_OK(

--- a/src/cursor/cur_stat.c
+++ b/src/cursor/cur_stat.c
@@ -412,10 +412,9 @@ static int
 __curstat_layered_init(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR_STAT *cst)
 {
     WT_DATA_HANDLE *dhandle;
-    WT_DECL_ITEM(stable_uri_buf);
     WT_DECL_RET;
     WT_LAYERED_TABLE *layered = NULL;
-    const char *checkpoint_name = NULL;
+    uint64_t ckpt_size;
     const char *stable_uri = NULL;
 
     WT_RET(__wt_session_get_dhandle(session, uri, NULL, NULL, 0));
@@ -434,24 +433,10 @@ retry:
     stable_uri = layered->stable_uri;
     /* Now do the stable table. */
     if (!S2C(session)->layered_table_manager.leader) {
-        /* Look up the most recent data store checkpoint. This fetches the exact name to use. */
-        WT_ERR_NOTFOUND_OK(
-          __wt_meta_checkpoint_last_name(session, stable_uri, &checkpoint_name, NULL, NULL), true);
-
-        /* We only need to check the stable table if we have picked up a checkpoint. */
-        if (ret == WT_NOTFOUND) {
-            ret = 0;
-            goto done;
-        }
-
-        WT_ERR(__wt_scr_alloc(session, 0, &stable_uri_buf));
-        /*
-         * Use a URI with a "/<checkpoint name> suffix. This is interpreted as reading from the
-         * stable checkpoint, but without it being a traditional checkpoint cursor.
-         */
-        WT_ERR(
-          __wt_buf_fmt(session, stable_uri_buf, "%s/%s", layered->stable_uri, checkpoint_name));
-        stable_uri = stable_uri_buf->data;
+        ckpt_size = 0;
+        WT_ERR(__wt_block_disagg_ckpt_size(session, stable_uri, &ckpt_size));
+        cst->u.dsrc_stats.block_size += (int64_t)ckpt_size;
+        goto done;
     }
 
     ret = __wt_session_get_dhandle(session, stable_uri, NULL, NULL, 0);
@@ -467,8 +452,6 @@ done:
     __wt_curstat_dsrc_final(cst);
 
 err:
-    __wt_free(session, checkpoint_name);
-    __wt_scr_free(session, &stable_uri_buf);
     /* The constituent table dhandles have been released. Release the layered dhandle. */
     if (session->dhandle == NULL)
         session->dhandle = dhandle;

--- a/src/cursor/cur_stat.c
+++ b/src/cursor/cur_stat.c
@@ -412,9 +412,11 @@ static int
 __curstat_layered_init(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR_STAT *cst)
 {
     WT_DATA_HANDLE *dhandle;
+    WT_DECL_ITEM(stable_uri_buf);
     WT_DECL_RET;
     WT_LAYERED_TABLE *layered = NULL;
     uint64_t ckpt_size;
+    const char *checkpoint_name = NULL;
     const char *stable_uri = NULL;
 
     WT_RET(__wt_session_get_dhandle(session, uri, NULL, NULL, 0));
@@ -433,10 +435,39 @@ retry:
     stable_uri = layered->stable_uri;
     /* Now do the stable table. */
     if (!S2C(session)->layered_table_manager.leader) {
-        ckpt_size = 0;
-        WT_ERR(__wt_block_disagg_ckpt_size(session, stable_uri, &ckpt_size));
-        cst->u.dsrc_stats.block_size += (int64_t)ckpt_size;
-        goto done;
+        /*
+         * On a follower, opening the stable checkpoint dhandle reads its root from the disagg page
+         * service and can block for seconds, recurring every checkpoint as the stable name
+         * advances. When no tree walk is requested, take block_size from the checkpoint metadata
+         * instead; the other non-walk stable stats are ~0 on a follower because its pages are not
+         * resident in the local cache. A tree walk (statistics=(all)) still opens the checkpoint to
+         * read it.
+         */
+        if (!F_ISSET(cst, WT_STAT_TYPE_TREE_WALK)) {
+            ckpt_size = 0;
+            WT_ERR(__wt_block_disagg_ckpt_size(session, stable_uri, &ckpt_size));
+            cst->u.dsrc_stats.block_size += (int64_t)ckpt_size;
+            goto done;
+        }
+
+        /* Look up the most recent data store checkpoint. This fetches the exact name to use. */
+        WT_ERR_NOTFOUND_OK(
+          __wt_meta_checkpoint_last_name(session, stable_uri, &checkpoint_name, NULL, NULL), true);
+
+        /* We only need to check the stable table if we have picked up a checkpoint. */
+        if (ret == WT_NOTFOUND) {
+            ret = 0;
+            goto done;
+        }
+
+        WT_ERR(__wt_scr_alloc(session, 0, &stable_uri_buf));
+        /*
+         * Use a URI with a "/<checkpoint name> suffix. This is interpreted as reading from the
+         * stable checkpoint, but without it being a traditional checkpoint cursor.
+         */
+        WT_ERR(
+          __wt_buf_fmt(session, stable_uri_buf, "%s/%s", layered->stable_uri, checkpoint_name));
+        stable_uri = stable_uri_buf->data;
     }
 
     ret = __wt_session_get_dhandle(session, stable_uri, NULL, NULL, 0);
@@ -452,6 +483,8 @@ done:
     __wt_curstat_dsrc_final(cst);
 
 err:
+    __wt_free(session, checkpoint_name);
+    __wt_scr_free(session, &stable_uri_buf);
     /* The constituent table dhandles have been released. Release the layered dhandle. */
     if (session->dhandle == NULL)
         session->dhandle = dhandle;


### PR DESCRIPTION
This PR is to skip opening the stable URI when initializing a non-btree-walk (e.g. fast) layered statistics cursor. This prevents unnecessary stalling while waiting for the page service to respond, which caused gaps in FTDC.

I have verified that we don't lose any meaningful information by skipping the stable btree, since on a follower node the stable component doesn't contribute anything meaningful to any of the stats tracked in `__wt_btree_stat_init`.