### PR TITLE
WT-17264 Improve base config error handling

### DIFF
--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1750,6 +1750,26 @@ __conn_chunk_cache_check(WT_SESSION_IMPL *session, const char *config, const cha
 }
 
 /*
+ * __conn_rename_bad_base_config --
+ *     Move an invalid base configuration file aside so a later open can start from defaults.
+ */
+static int
+__conn_rename_bad_base_config(WT_SESSION_IMPL *session, bool *renamedp)
+{
+    *renamedp = false;
+
+    /* A readonly connection must not modify the database, so leave the file in place. */
+    if (F_ISSET(S2C(session), WT_CONN_READONLY))
+        return (0);
+
+    WT_RET(__wt_fs_rename(session, WT_BASECONFIG, WT_BASECONFIG_BAD, true));
+    *renamedp = true;
+    __wt_errx(session, "the bad base configuration file has been renamed from '%s' to '%s'",
+      WT_BASECONFIG, WT_BASECONFIG_BAD);
+    return (0);
+}
+
+/*
  * __conn_config_file --
  *     Read WiredTiger config files from the home directory.
  */
@@ -1882,13 +1902,19 @@ __conn_config_file(
 err:
     WT_TRET(__wt_close(session, &fh));
 
-    /**
-     * Encountering an invalid configuration string from the base configuration file suggests
-     * that there is corruption present in the file.
+    /*
+     * An EINVAL from the base configuration file means we could not process it. This could be
+     * genuine parse-level corruption, or a file the filesystem could not read. Rename it if
+     * possible and tell the user how to recover. An earlier error message should have provided
+     * specifics by this point.
      */
     if (!is_user && ret == EINVAL) {
-        F_SET_ATOMIC_32(S2C(session), WT_CONN_DATA_CORRUPTION);
-        return (WT_ERROR);
+        bool renamed = false;
+        WT_TRET(__conn_rename_bad_base_config(session, &renamed));
+        WT_RET_MSG(session, WT_ERROR,
+          "the base configuration file '%s' is invalid. Either correct the file, or reopen with "
+          "config_base=false",
+          renamed ? WT_BASECONFIG_BAD : WT_BASECONFIG);
     }
 
     return (ret);

--- a/src/conn/conn_api.c
+++ b/src/conn/conn_api.c
@@ -1903,10 +1903,9 @@ err:
     WT_TRET(__wt_close(session, &fh));
 
     /*
-     * An EINVAL from the base configuration file means we could not process it. This could be
-     * genuine parse-level corruption, or a file the filesystem could not read. Rename it if
-     * possible and tell the user how to recover. An earlier error message should have provided
-     * specifics by this point.
+     * An EINVAL from the base configuration file means there is corruption and we could not process
+     * it. Rename it if possible and tell the user how to recover. An earlier error message should
+     * have provided specifics by this point.
      */
     if (!is_user && ret == EINVAL) {
         bool renamed = false;

--- a/src/include/meta.h
+++ b/src/include/meta.h
@@ -12,6 +12,7 @@
 #define WT_SINGLETHREAD "WiredTiger.lock" /* Locking file */
 
 #define WT_BASECONFIG "WiredTiger.basecfg"         /* Base configuration */
+#define WT_BASECONFIG_BAD "WiredTiger.basecfg.bad" /* Base config, renamed if corrupted */
 #define WT_BASECONFIG_SET "WiredTiger.basecfg.set" /* Base config temp */
 
 #define WT_USERCONFIG "WiredTiger.config" /* User configuration */

--- a/test/suite/test_baseconfig.py
+++ b/test/suite/test_baseconfig.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Public Domain 2014-present MongoDB, Inc.
 # Public Domain 2008-2014 WiredTiger, Inc.
@@ -27,27 +27,255 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 import os
-import wiredtiger, wttest
+import re
+from pathlib import Path
+from wiredtiger import WiredTigerError
+import wttest
 
-# test_baseconfig
-#       test base configuration file being ignored.
+
 class test_baseconfig(wttest.WiredTigerTestCase):
-    def test_baseconfig(self):
-        # Open up another database and modify the baseconfig
-        os.mkdir("A")
-        conn = self.wiredtiger_open("A", 'create')
-        # Mark the new directory as corrupted
-        self.databaseCorrupted("A")
-        self.assertTrue(os.path.exists("A/WiredTiger.basecfg"))
-        with open("A/WiredTiger.basecfg", "a") as basecfg_file:
-            basecfg_file.write("foo!")
-        conn.close()
+    """
+    This file tests how the base config file is handled in different corruption scenarios.
+    We expect the file to be renamed where possible, and an error message given in all cases.
+    """
 
-        # Open a database, we should assert here as the basecfg is invalid
+    def setUp(self):
+        super().setUp()
+        self.db_path = Path("test_baseconfig")
+        self.db_path.mkdir()
+        self.wiredtiger_open(str(self.db_path), "create").close()
+        self.base_config_path = self.db_path / "WiredTiger.basecfg"
+        self.bad_base_config_path = self.db_path / "WiredTiger.basecfg.bad"
+        self.assertTrue(self.base_config_path.exists())
+        self.assertFalse(self.bad_base_config_path.exists())
+
+    def open_and_close_database(self, config=""):
+        """Open the database and close it again."""
+        self.wiredtiger_open(str(self.db_path), config).close()
+
+    # The notification emitted when a corrupt base config is renamed out of the way.
+    renamed_notification = (
+        r"the bad base configuration file has been renamed from "
+        r"'WiredTiger\.basecfg' to 'WiredTiger\.basecfg\.bad'"
+    )
+
+    def invalid_pattern(self, filename):
+        """The error raised for an invalid base config."""
+        return (
+            r"the base configuration file '"
+            + re.escape(filename)
+            + r"' is invalid\. Either correct the file, or reopen with config_base=false"
+        )
+
+    def test_new_value_without_separator_is_renamed(self):
+        """A raw tokenizer failure ("new value without a separator") causes a rename."""
+        # Overwrite the first bytes of the file with garbage.
+        with open(self.base_config_path, "r+", encoding="utf-8") as base_config:
+            base_config.write("Bad!" * 4)
+
         self.assertRaisesWithMessage(
-            wiredtiger.WiredTigerError,
-            lambda: self.wiredtiger_open("A", ''),
-            '/unknown configuration key/')
+            WiredTigerError,
+            lambda: self.wiredtiger_open(str(self.db_path), ""),
+            "/New value starts without a separator/",
+        )
+        self.assertFalse(self.base_config_path.exists())
+        self.assertTrue(self.bad_base_config_path.exists())
 
-        conn = self.wiredtiger_open("A", "create,config_base=false")
-        conn.close()
+    def test_unknown_config_key_is_renamed(self):
+        """An unrecognized key causes a rename."""
+        # Seek to the end of the file and append garbage, producing a bare, unrecognized key.
+        with open(self.base_config_path, "r+", encoding="utf-8") as base_config:
+            base_config.seek(0, os.SEEK_END)
+            base_config.write("Bad!" * 4)
+
+        self.assertRaisesWithMessage(
+            WiredTigerError,
+            lambda: self.wiredtiger_open(str(self.db_path), ""),
+            "/unknown configuration key/",
+        )
+        self.assertFalse(self.base_config_path.exists())
+        self.assertTrue(self.bad_base_config_path.exists())
+
+    def test_reopen_after_rename_succeeds(self):
+        """A reopen after the rename succeeds from default settings."""
+        # Seek to the end of the file and append garbage.
+        with open(self.base_config_path, "r+", encoding="utf-8") as base_config:
+            base_config.seek(0, os.SEEK_END)
+            base_config.write("Bad!" * 4)
+
+        self.assertRaisesWithMessage(
+            WiredTigerError, lambda: self.wiredtiger_open(str(self.db_path), ""), "/.*/"
+        )
+        self.open_and_close_database()
+
+    def test_config_base_false_skips_corrupt_file(self):
+        """The advised recovery, config_base=false, opens without touching the corrupt file."""
+        # Seek to the end of the file and append garbage.
+        with open(self.base_config_path, "r+", encoding="utf-8") as base_config:
+            base_config.seek(0, os.SEEK_END)
+            base_config.write("Bad!" * 4)
+
+        self.open_and_close_database("config_base=false")
+        # The file is skipped, not parsed, so it is neither renamed nor removed.
+        self.assertTrue(self.base_config_path.exists())
+        self.assertFalse(self.bad_base_config_path.exists())
+
+    def test_rename_is_reported(self):
+        """When the file is renamed the user is notified"""
+        # Seek to the end of the file and append garbage.
+        with open(self.base_config_path, "r+", encoding="utf-8") as base_config:
+            base_config.seek(0, os.SEEK_END)
+            base_config.write("Bad!" * 4)
+
+        # The rename is reported and the error names the renamed (.bad) file.
+        with self.expectedStderrPattern(
+            self.invalid_pattern("WiredTiger.basecfg.bad"),
+            ignore_pat=wttest.WT_ERROR_LOG_PATTERN,
+        ):
+            self.assertRaises(
+                WiredTigerError, lambda: self.wiredtiger_open(str(self.db_path), "")
+            )
+            self.assertIsNotNone(
+                re.search(self.renamed_notification, self.readStderr())
+            )
+
+    def test_read_only_does_not_rename(self):
+        """A read-only connection does not rename the file."""
+        # Seek to the end of the file and append garbage.
+        with open(self.base_config_path, "r+", encoding="utf-8") as base_config:
+            base_config.seek(0, os.SEEK_END)
+            base_config.write("Bad!" * 4)
+
+        # Without a rename the error names the original file and no rename is reported.
+        with self.expectedStderrPattern(
+            self.invalid_pattern("WiredTiger.basecfg"),
+            ignore_pat=wttest.WT_ERROR_LOG_PATTERN,
+        ):
+            self.assertRaises(
+                WiredTigerError,
+                lambda: self.wiredtiger_open(str(self.db_path), "readonly"),
+            )
+            self.assertIsNone(re.search(self.renamed_notification, self.readStderr()))
+
+        self.assertTrue(self.base_config_path.exists())
+        self.assertFalse(self.bad_base_config_path.exists())
+
+    def test_unbalanced_bracket_is_renamed(self):
+        """A raw syntax error causes a rename."""
+        with open(self.base_config_path, "a", encoding="utf-8") as base_config:
+            base_config.write("\nfoo=(bar\n")
+
+        self.assertRaisesWithMessage(
+            WiredTigerError,
+            lambda: self.wiredtiger_open(str(self.db_path), ""),
+            "/Unbalanced brackets/",
+        )
+        self.assertFalse(self.base_config_path.exists())
+        self.assertTrue(self.bad_base_config_path.exists())
+
+    def test_removal_is_tolerated(self):
+        """A missing base config is treated the same as one that was never configured."""
+        self.base_config_path.unlink()
+        self.open_and_close_database()
+        self.assertFalse(self.bad_base_config_path.exists())
+
+    def test_truncate_middle_is_tolerated(self):
+        """Truncating partway through the file does not fail the open."""
+        size = self.base_config_path.stat().st_size
+        with open(self.base_config_path, "r+", encoding="utf-8") as base_config:
+            base_config.truncate(size // 2)
+
+        self.open_and_close_database()
+        self.assertFalse(self.bad_base_config_path.exists())
+
+    def test_zero_at_start_is_tolerated(self):
+        """Null bytes overwriting the start of the file, with real content surviving after
+        them, does not fail the open."""
+        # Overwrite only the first half of the file with null bytes, leaving the second half
+        # intact.
+        size = self.base_config_path.stat().st_size
+        with open(self.base_config_path, "r+", encoding="utf-8") as base_config:
+            base_config.write("\0" * (size // 2))
+
+        self.open_and_close_database()
+        self.assertFalse(self.bad_base_config_path.exists())
+
+    def test_zero_truncated_is_tolerated(self):
+        """A file replaced entirely with null bytes does not fail the open."""
+        with open(self.base_config_path, "r+", encoding="utf-8") as base_config:
+            base_config.truncate(0)
+            base_config.write("\0" * 4096)
+
+        self.open_and_close_database()
+        self.assertFalse(self.bad_base_config_path.exists())
+
+    def test_zero_at_end_is_tolerated(self):
+        """Null bytes appended to the end of the file do not fail the open."""
+        with open(self.base_config_path, "r+", encoding="utf-8") as base_config:
+            base_config.seek(0, os.SEEK_END)
+            base_config.write("\0" * 4096)
+
+        self.open_and_close_database()
+        self.assertFalse(self.bad_base_config_path.exists())
+
+    def test_garbage_middle_is_tolerated(self):
+        """Garbage in the middle of the file does not fail the open."""
+        size = self.base_config_path.stat().st_size
+        with open(self.base_config_path, "r+", encoding="utf-8") as base_config:
+            base_config.seek(size // 2)
+            base_config.write("Bad!" * 1024)
+
+        self.open_and_close_database()
+        self.assertFalse(self.bad_base_config_path.exists())
+
+    def test_empty_basecfg_is_tolerated(self):
+        """An empty base config is treated the same as a missing one."""
+        with open(self.base_config_path, "r+", encoding="utf-8") as base_config:
+            base_config.truncate(0)
+
+        self.open_and_close_database()
+        self.assertFalse(self.bad_base_config_path.exists())
+
+    def test_unsupported_setting_is_not_renamed(self):
+        """Unsupported settings do not trigger a rename."""
+        with open(self.base_config_path, "a", encoding="utf-8") as base_config:
+            base_config.write("\nchunk_cache=(enabled=true)\n")
+
+        self.assertRaisesWithMessage(
+            WiredTigerError,
+            lambda: self.wiredtiger_open(str(self.db_path), ""),
+            "/chunk cache has been deprecated/",
+        )
+        self.assertTrue(self.base_config_path.exists())
+        self.assertFalse(self.bad_base_config_path.exists())
+
+    def test_incompatible_version_is_not_renamed(self):
+        """A base config from a newer release does not trigger a rename."""
+        with open(self.base_config_path, "a", encoding="utf-8") as base_config:
+            base_config.write("\nversion=(major=99,minor=0)\n")
+
+        self.assertRaisesWithMessage(
+            WiredTigerError,
+            lambda: self.wiredtiger_open(str(self.db_path), ""),
+            "/incompatible release/",
+        )
+        self.assertTrue(self.base_config_path.exists())
+        self.assertFalse(self.bad_base_config_path.exists())
+
+    def test_oversized_basecfg_is_not_renamed(self):
+        """An oversized base config does not trigger a rename."""
+        # Append enough content to push the file past the 100KB limit.
+        with open(self.base_config_path, "a", encoding="utf-8") as base_config:
+            base_config.write("#" + "x" * (101 * 1024) + "\n")
+
+        self.assertRaisesWithMessage(
+            WiredTigerError,
+            lambda: self.wiredtiger_open(str(self.db_path), ""),
+            "/Configuration file too big/",
+        )
+        self.assertTrue(self.base_config_path.exists())
+        self.assertFalse(self.bad_base_config_path.exists())
+
+
+if __name__ == "__main__":
+    wttest.run()

--- a/test/suite/test_txn19.py
+++ b/test/suite/test_txn19.py
@@ -376,10 +376,11 @@ class test_txn19_meta(wttest.WiredTigerTestCase, suite_subprocess):
         ('garbage-end', dict(kind='garbage-end', f=lambda fname:
             corrupt(fname, False, -1, 'Bad!' * 1024))),
     ]
-    # File to be corrupted
+    # File to be corrupted. WiredTiger.basecfg is deliberately excluded as it is not metadata that
+    # salvage ever operates on. Its own corruption/recovery behavior is covered directly by
+    # test_baseconfig.py.
     filename_scenarios = [
         ('WiredTiger', dict(filename='WiredTiger')),
-        ('WiredTiger.basecfg', dict(filename='WiredTiger.basecfg')),
         ('WiredTiger.turtle', dict(filename='WiredTiger.turtle')),
         ('WiredTiger.wt', dict(filename='WiredTiger.wt')),
         ('WiredTigerHS.wt', dict(filename='WiredTigerHS.wt')),
@@ -393,25 +394,19 @@ class test_txn19_meta(wttest.WiredTigerTestCase, suite_subprocess):
     # In many cases, wiredtiger_open without any salvage options will
     # just work.  We list those cases here.
     openable = [
-        "removal:WiredTiger.basecfg",
         "removal:WiredTiger.turtle",
         "truncate:WiredTiger",
-        "truncate:WiredTiger.basecfg",
         "truncate-middle:WiredTiger",
-        "truncate-middle:WiredTiger.basecfg",
         "truncate-middle:WiredTiger.turtle",
         "truncate-middle:WiredTiger.wt",
         "truncate-middle:WiredTigerHS.wt",
         "zero:WiredTiger",
-        "zero:WiredTiger.basecfg",
         "zero-end:WiredTiger",
-        "zero-end:WiredTiger.basecfg",
         "zero-end:WiredTiger.turtle",
         "zero-end:WiredTiger.wt",
         "zero-end:WiredTigerHS.wt",
         "garbage-begin:WiredTiger",
         "garbage-middle:WiredTiger",
-        "garbage-middle:WiredTiger.basecfg",
         "garbage-middle:WiredTiger.turtle",
         "garbage-middle:WiredTiger.wt",
         "garbage-middle:WiredTigerHS.wt",
@@ -430,10 +425,8 @@ class test_txn19_meta(wttest.WiredTigerTestCase, suite_subprocess):
         "truncate:WiredTigerHS.wt",
         "zero:WiredTiger.wt",
         "zero:WiredTigerHS.wt",
-        "garbage-begin:WiredTiger.basecfg",
         "garbage-begin:WiredTiger.wt",
         "garbage-begin:WiredTigerHS.wt",
-        "garbage-end:WiredTiger.basecfg",
     ]
 
     scenarios = make_scenarios(key_format_values, corruption_scenarios, filename_scenarios)
@@ -485,9 +478,6 @@ class test_txn19_meta(wttest.WiredTigerTestCase, suite_subprocess):
                     errmsg = '/hs_exists/'
                 elif self.kind == 'truncate':
                     errmsg = '/file size=0, alloc size=4096/'
-            if self.filename == 'WiredTiger.basecfg':
-                if self.kind == 'garbage-begin' or self.kind == 'garbage-end':
-                    errmsg = '/Bad!Bad!Bad!/'
             if self.filename == 'WiredTiger.wt':
                 if self.kind == 'truncate':
                     errmsg = '/is smaller than allocation size; file size=0, alloc size=4096/'


### PR DESCRIPTION
Currently we signal to salvage if we detect corruption in the base config file. Salvaging may not be the correct mechanism as it will not repair the file. This would not help the end user, and it can also be problematic for WT development (especially with version changes as seen in WT-17248) as this can cause constant errors.

This PR proposes that we should instead rename the base config if we detect corruption. This would allow the user to manually fix it, but also move the file out of the way to stop constant errors. I think the OS level errors are still relevant here because we retry those operation multiple times.

The related ticket is: WT-17264.

I have also moved some of the testing out of test_txn19.py, as salvaging is not relevant to the base config. I think it makes more sense to test this functionality in the base config tests.