### PR TITLE
WT-17985 Make read_load and write_load metrics always available

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -671,9 +671,9 @@ conn_stats = [
     ##########################################
     # Load Control statistics
     ##########################################
-    LoadControlStat('read_load', 'read load at the system level'),
+    LoadControlStat('read_load', 'read load at the system level', 'no_clear,no_scale'),
     LoadControlStat('read_reject_count', 'number of read operations rejected due to load control'),
-    LoadControlStat('write_load', 'write load at the system level'),
+    LoadControlStat('write_load', 'write load at the system level', 'no_clear,no_scale'),
     LoadControlStat('write_reject_count', 'number of write operations rejected due to load control'),
 
     ##########################################

--- a/src/conn/conn_load_control.c
+++ b/src/conn/conn_load_control.c
@@ -110,6 +110,21 @@ __wt_conn_calc_read_load(WT_SESSION_IMPL *session)
 }
 
 /*
+ * __wti_conn_load_control_stats_update --
+ *     Update the read and write load statistics.
+ */
+void
+__wti_conn_load_control_stats_update(WT_SESSION_IMPL *session)
+{
+    WT_CONNECTION_STATS **stats;
+
+    stats = S2C(session)->stats;
+
+    WT_STATP_CONN_SET(session, stats, read_load, __wt_conn_calc_read_load(session));
+    WT_STATP_CONN_SET(session, stats, write_load, __wt_conn_calc_write_load(session));
+}
+
+/*
  * __wt_conn_calc_write_load --
  *     Calculate and return the write load at the system level. Computed on demand from the
  *     load-shed check and the statistics path rather than in the cache accounting hot path. The

--- a/src/conn/conn_load_control.c
+++ b/src/conn/conn_load_control.c
@@ -95,46 +95,32 @@ __conn_calc_load_pct(uint64_t part, uint64_t whole)
 
 /*
  * __wt_conn_calc_read_load --
- *     Calculate the read load at the system level.
+ *     Calculate and return the read load at the system level. Computed on demand from the load-shed
+ *     check and the statistics path rather than in the cache accounting hot path. The load is
+ *     always calculated; the load control enable flag only governs whether work is shed.
  */
-void
+uint16_t
 __wt_conn_calc_read_load(WT_SESSION_IMPL *session)
 {
     WT_CONNECTION_LOAD_CONTROL *load_control;
-    uint64_t bytes_inuse, bytes_max;
-    uint16_t load;
 
     load_control = &S2C(session)->load_control;
-    if (F_ISSET(load_control, WT_CONN_LOAD_CONTROL)) {
-        bytes_max = load_control->read_load_max;
-        bytes_inuse = __wt_cache_bytes_inuse(S2C(session)->cache);
-
-        load = __conn_calc_load_pct(bytes_inuse, bytes_max);
-        __wt_atomic_store_uint16_relaxed(&load_control->read_load, load);
-        WT_STAT_CONN_SET(session, read_load, load);
-    }
-    return;
+    return (__conn_calc_load_pct(
+      __wt_cache_bytes_inuse(S2C(session)->cache), load_control->read_load_max));
 }
 
 /*
  * __wt_conn_calc_write_load --
- *     Calculate the write load at the system level.
+ *     Calculate and return the write load at the system level. Computed on demand from the
+ *     load-shed check and the statistics path rather than in the cache accounting hot path. The
+ *     load is always calculated; the load control enable flag only governs whether work is shed.
  */
-void
+uint16_t
 __wt_conn_calc_write_load(WT_SESSION_IMPL *session)
 {
     WT_CONNECTION_LOAD_CONTROL *load_control;
-    uint64_t bytes_dirty, bytes_max;
-    uint16_t load;
 
     load_control = &S2C(session)->load_control;
-    if (F_ISSET(load_control, WT_CONN_LOAD_CONTROL)) {
-        bytes_max = load_control->write_load_max;
-        bytes_dirty = __wt_cache_dirty_inuse(S2C(session)->cache);
-
-        load = __conn_calc_load_pct(bytes_dirty, bytes_max);
-        __wt_atomic_store_uint16_relaxed(&load_control->write_load, load);
-        WT_STAT_CONN_SET(session, write_load, load);
-    }
-    return;
+    return (__conn_calc_load_pct(
+      __wt_cache_dirty_inuse(S2C(session)->cache), load_control->write_load_max));
 }

--- a/src/conn/conn_stat.c
+++ b/src/conn/conn_stat.c
@@ -78,8 +78,8 @@ __wt_conn_stat_init(WT_SESSION_IMPL *session)
     __wt_evict_stats_init(session);
     __wt_txn_stats_update(session);
 
-    WT_STATP_CONN_SET(session, stats, read_load, __wt_conn_calc_read_load(session));
-    WT_STATP_CONN_SET(session, stats, write_load, __wt_conn_calc_write_load(session));
+    /* Update the load control statistics after the cache stats are updated. */
+    __wti_conn_load_control_stats_update(session);
     WT_STATP_CONN_SET(
       session, stats, file_open, __wt_atomic_load_uint32_relaxed(&conn->open_file_count));
     WT_STATP_CONN_SET(

--- a/src/conn/conn_stat.c
+++ b/src/conn/conn_stat.c
@@ -78,6 +78,8 @@ __wt_conn_stat_init(WT_SESSION_IMPL *session)
     __wt_evict_stats_init(session);
     __wt_txn_stats_update(session);
 
+    WT_STATP_CONN_SET(session, stats, read_load, __wt_conn_calc_read_load(session));
+    WT_STATP_CONN_SET(session, stats, write_load, __wt_conn_calc_write_load(session));
     WT_STATP_CONN_SET(
       session, stats, file_open, __wt_atomic_load_uint32_relaxed(&conn->open_file_count));
     WT_STATP_CONN_SET(

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -360,7 +360,6 @@ __wt_cache_page_inmem_incr(WT_SESSION_IMPL *session, WT_PAGE *page, size_t size,
     bool is_disagg = __wt_conn_is_disagg(session);
 
     (void)__wt_atomic_add_uint64_relaxed(&cache->bytes_inmem, size);
-    __wt_conn_calc_read_load(session);
     if (is_disagg) {
         if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
             (void)__wt_atomic_add_uint64_relaxed(&cache->bytes_inmem_ingest, size);
@@ -414,7 +413,6 @@ __wt_cache_page_inmem_incr(WT_SESSION_IMPL *session, WT_PAGE *page, size_t size,
                 (void)__wt_atomic_add_uint64_relaxed(&btree->bytes_dirty_leaf, size);
             }
             (void)__wt_atomic_add_uint64_relaxed(&page->modify->bytes_dirty, size);
-            __wt_conn_calc_write_load(session);
         }
     }
 }
@@ -606,7 +604,6 @@ __wt_cache_page_inmem_decr(WT_SESSION_IMPL *session, WT_PAGE *page, size_t size)
     __wt_cache_decr_check_size(session, &page->memory_footprint, size, "WT_PAGE.memory_footprint");
     __wt_cache_decr_check_uint64(session, &btree->bytes_inmem, size, "WT_BTREE.bytes_inmem");
     __wt_cache_decr_check_uint64(session, &cache->bytes_inmem, size, "WT_CACHE.bytes_inmem");
-    __wt_conn_calc_read_load(session);
     if (is_disagg) {
         if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
             __wt_cache_decr_check_uint64(
@@ -619,7 +616,6 @@ __wt_cache_page_inmem_decr(WT_SESSION_IMPL *session, WT_PAGE *page, size_t size)
         __wt_cache_page_byte_updates_decr(session, page, size);
     if (__wt_page_is_modified(page)) {
         __wt_cache_page_byte_dirty_decr(session, page, size);
-        __wt_conn_calc_write_load(session);
     }
     /* Track internal size in cache. */
     if (WT_PAGE_IS_INTERNAL(page)) {

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1971,6 +1971,7 @@ extern void __wti_conn_backup_destroy(WT_SESSION_IMPL *session);
 extern void __wti_conn_capacity_destroy(WT_SESSION_IMPL *session);
 extern void __wti_conn_capacity_init(WT_SESSION_IMPL *session);
 extern void __wti_conn_ext_destroy(WT_SESSION_IMPL *session);
+extern void __wti_conn_load_control_stats_update(WT_SESSION_IMPL *session);
 extern void __wti_conn_prefetch_destroy(WT_SESSION_IMPL *session);
 extern void __wti_conn_tiered_destroy(WT_SESSION_IMPL *session);
 extern void __wti_connection_destroy(WT_CONNECTION_IMPL *conn);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1722,6 +1722,10 @@ extern ssize_t __wt_json_strlen(const char *src, size_t srclen) WT_GCC_FUNC_DECL
   (visibility("default"))) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern u_int __wt_hazard_count(WT_SESSION_IMPL *session, WT_REF *ref)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern uint16_t __wt_conn_calc_read_load(WT_SESSION_IMPL *session)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern uint16_t __wt_conn_calc_write_load(WT_SESSION_IMPL *session)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern uint32_t __wt_checksum_sw(const void *chunk, size_t len)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern uint32_t __wt_checksum_with_seed_sw(uint32_t seed, const void *chunk, size_t len)
@@ -1783,8 +1787,6 @@ extern void __wt_config_init(WT_SESSION_IMPL *session, WT_CONFIG *conf, const ch
 extern void __wt_config_initn(
   WT_SESSION_IMPL *session, WT_CONFIG *conf, const char *str, size_t len);
 extern void __wt_config_subinit(WT_SESSION_IMPL *session, WT_CONFIG *conf, WT_CONFIG_ITEM *item);
-extern void __wt_conn_calc_read_load(WT_SESSION_IMPL *session);
-extern void __wt_conn_calc_write_load(WT_SESSION_IMPL *session);
 extern void __wt_conn_config_discard(WT_SESSION_IMPL *session);
 extern void __wt_conn_foc_discard(WT_SESSION_IMPL *session);
 extern void __wt_conn_stat_init(WT_SESSION_IMPL *session);

--- a/src/include/load_control.h
+++ b/src/include/load_control.h
@@ -10,8 +10,6 @@
 
 struct __wt_connection_load_control {
     uint16_t control_threshold;        /* threshold when the load control starts rejecting work */
-    wt_shared uint16_t read_load;      /* connection read load */
-    wt_shared uint16_t write_load;     /* connection write load */
     wt_shared uint64_t read_load_max;  /* cache max bytes equivalent eviction trigger */
     wt_shared uint64_t write_load_max; /* cache max dirty bytes equivalent to dirty trigger */
 

--- a/src/include/load_control_inline.h
+++ b/src/include/load_control_inline.h
@@ -24,8 +24,7 @@ __wt_conn_load_control_read_loadshed(WT_SESSION_IMPL *session)
 
     /* Shed reads when load control is enabled and the read load is at or above the threshold. */
     if (F_ISSET(load_control, WT_CONN_LOAD_CONTROL) && load_control->control_threshold > 0)
-        return (load_control->control_threshold <=
-          __wt_atomic_load_uint16_relaxed(&load_control->read_load));
+        return (load_control->control_threshold <= __wt_conn_calc_read_load(session));
 
     return (false);
 }
@@ -42,8 +41,7 @@ __wt_conn_load_control_write_loadshed(WT_SESSION_IMPL *session)
 
     /* Shed writes when load control is enabled and the write load is at or above the threshold. */
     if (F_ISSET(load_control, WT_CONN_LOAD_CONTROL) && load_control->control_threshold > 0)
-        return (load_control->control_threshold <=
-          __wt_atomic_load_uint16_relaxed(&load_control->write_load));
+        return (load_control->control_threshold <= __wt_conn_calc_write_load(session));
 
     return (false);
 }

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -3679,8 +3679,8 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     /* not clearing live_restore_state */
     stats->read_reject_count = 0;
     stats->write_reject_count = 0;
-    stats->read_load = 0;
-    stats->write_load = 0;
+    /* not clearing read_load */
+    /* not clearing write_load */
     stats->lock_btree_page_count = 0;
     stats->lock_btree_page_wait_application = 0;
     stats->lock_btree_page_wait_internal = 0;


### PR DESCRIPTION
Remove read_load and write_load from load_control feature flag and make them always available.

load_control feature flag is repurposed only to control the load_shed, not to calculate read_load and write_load metrics.
The read_load and write_load are calculated when the stats cursor is initialized, and removed from the hot path of calculating for every cache bytes change.
