### PR TITLE
WT-17157 Improve __WT_TRET_WINS macro with error levels

### DIFF
--- a/dist/s_define.list
+++ b/dist/s_define.list
@@ -143,6 +143,8 @@ pg_del_saved_txnid
 __WIREDTIGER_EXT_H_
 __WIREDTIGER_H_
 __WT_INTERNAL_H
+__WT_RET_DOMINANT
+__WT_RET_SOFT
 __WT_TRET_WINS
 __wt_atomic_and_generic_relaxed
 __wt_atomic_load_enum_acquire

--- a/dist/s_define.list
+++ b/dist/s_define.list
@@ -143,8 +143,8 @@ pg_del_saved_txnid
 __WIREDTIGER_EXT_H_
 __WIREDTIGER_H_
 __WT_INTERNAL_H
-__WT_RET_DOMINANT
-__WT_RET_SOFT
+__WT_TRET_DOMINANT
+__WT_TRET_SOFT
 __WT_TRET_WINS
 __wt_atomic_and_generic_relaxed
 __wt_atomic_load_enum_acquire

--- a/src/include/error.h
+++ b/src/include/error.h
@@ -181,12 +181,23 @@
         WT_RET_TEST(__ret == (e), e); \
     } while (0)
 /*
+ * __WT_RET_DOMINANT --
+ *     True when an error code can override another because it is stronger.
+ */
+#define __WT_RET_DOMINANT(__ret) ((__ret) == WT_PANIC)
+
+/*
+ * __WT_RET_SOFT --
+ *     True when an error code is weak enough that another can override it.
+ */
+#define __WT_RET_SOFT(__ret) \
+    ((__ret) == 0 || (__ret) == WT_DUPLICATE_KEY || (__ret) == WT_NOTFOUND || (__ret) == WT_RESTART)
+
+/*
  * __WT_TRET_WINS --
  *     True when __ret should override the current value of ret. Requires ret to be in scope.
  */
-#define __WT_TRET_WINS(__ret)                                                          \
-    (__ret == WT_PANIC || ret == 0 || ret == WT_DUPLICATE_KEY || ret == WT_NOTFOUND || \
-      ret == WT_RESTART)
+#define __WT_TRET_WINS(__ret) (__WT_RET_DOMINANT(__ret) || __WT_RET_SOFT(ret))
 
 #ifdef INLINE_FUNCTIONS_INSTEAD_OF_MACROS
 /* Set "ret" if not already set. */

--- a/src/include/error.h
+++ b/src/include/error.h
@@ -181,23 +181,23 @@
         WT_RET_TEST(__ret == (e), e); \
     } while (0)
 /*
- * __WT_RET_DOMINANT --
+ * __WT_TRET_DOMINANT --
  *     True when an error code can override another because it is stronger.
  */
-#define __WT_RET_DOMINANT(__ret) ((__ret) == WT_PANIC)
+#define __WT_TRET_DOMINANT(__ret) ((__ret) == WT_PANIC)
 
 /*
- * __WT_RET_SOFT --
+ * __WT_TRET_SOFT --
  *     True when an error code is weak enough that another can override it.
  */
-#define __WT_RET_SOFT(__ret) \
+#define __WT_TRET_SOFT(__ret) \
     ((__ret) == 0 || (__ret) == WT_DUPLICATE_KEY || (__ret) == WT_NOTFOUND || (__ret) == WT_RESTART)
 
 /*
  * __WT_TRET_WINS --
  *     True when __ret should override the current value of ret. Requires ret to be in scope.
  */
-#define __WT_TRET_WINS(__ret) (__WT_RET_DOMINANT(__ret) || __WT_RET_SOFT(ret))
+#define __WT_TRET_WINS(__ret) (__WT_TRET_DOMINANT(__ret) || __WT_TRET_SOFT(ret))
 
 #ifdef INLINE_FUNCTIONS_INSTEAD_OF_MACROS
 /* Set "ret" if not already set. */


### PR DESCRIPTION
As per: WT-17157, here is proposal to further improve error handling by introducing distinct levels of error codes, such as 'dominant' and 'soft', to clarify precedence and simplify logic.