### PR TITLE
WT-16124 Add PR FIXME closure check

### DIFF
--- a/.github/workflows/fixme_closure_check.yml
+++ b/.github/workflows/fixme_closure_check.yml
@@ -1,0 +1,50 @@
+name: FIXME Closure Check
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+jobs:
+  check-fixmes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Check for stale FIXME references
+        shell: bash
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          title="$PR_TITLE"
+
+          if [[ "$title" == Revert\ \"* ]]; then
+            echo "Skipping FIXME closure check for revert PR."
+            exit 0
+          fi
+
+          ticket="$(grep -Eo 'WT-[0-9]+' <<< "$title" | head -n 1 || true)"
+
+          if [[ -z "$ticket" ]]; then
+            echo "No WT ticket found in PR title."
+            exit 0
+          fi
+
+          matches="$(git grep -n -E "FIXME-${ticket}([^0-9]|$)" HEAD || true)"
+
+          if [[ -z "$matches" ]]; then
+            echo "No stale FIXME references found for ${ticket}."
+            exit 0
+          fi
+
+          echo "::error::PR closes ${ticket} but FIXME references to it remain. Remove them or retarget them to a follow-up ticket."
+          echo "$matches"
+          exit 1

--- a/.github/workflows/fixme_closure_check.yml
+++ b/.github/workflows/fixme_closure_check.yml
@@ -38,7 +38,7 @@ jobs:
             exit 0
           fi
 
-          matches="$(git grep -n -E "FIXME-${ticket}([^0-9]|$)" HEAD || true)"
+          matches="$(git grep -n -P "FIX-?ME[-:\s]+.*?${ticket}(?![0-9])" HEAD || true)"
 
           if [[ -z "$matches" ]]; then
             echo "No stale FIXME references found for ${ticket}."


### PR DESCRIPTION
See WT-16989 for context. This implements the first half of the proposal: ensuring that when a ticket is closed through a PR, any associated FIXMEs are removed at the same time.

The check:

- Extracts the WT ticket number from the PR title (WT-XXXX My PR description here).
- Fails if the PR branch source code contains FIXME-WT-XXXX for that ticket.
- Ignores other ticket numbers - you're only responsible for the ticket your PR is closing.

Revert PRs are skipped, because by reverting, you are reopening the ticket, so FIXMEs cannot be stale.

This is a PR check rather than a dist script because it relies on PR metadata to determine which ticket is being closed. GitHub Actions has that context. A dist script running against the source tree alone does not. You cannot rely on the branch name or the commit message, because the format of these is not actually enforced.