### PR TITLE
WT-17905 Escape layered values that collide with the tombstone marker

### DIFF
--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -41,14 +41,50 @@ typedef enum {
     } while (0)
 
 /*
- * __clayered_is_deleted_encoded --
- *     Check if the value starts with the tombstone.
+ * Tombstone value encoding.
+ *
+ * The ingest table holds only recent changes; the full key space lives in the stable table. A read
+ * that does not find a key in the ingest table falls through to the stable table, because the key
+ * may simply have been evicted from the ingest table rather than deleted. A user delete therefore
+ * needs an explicit marker in the ingest table so the read stops and reports the key as gone rather
+ * than falling through: that marker is the reserved value __wt_tombstone, the two bytes {\x14\x14}.
+ * Finding the tombstone means the key was deleted; not finding the key at all means fall through to
+ * the stable table.
+ *
+ * Because the tombstone is itself a value, an application value equal to {\x14\x14} would be read
+ * back as a delete. Such values are escaped before they are stored and un-escaped when read back.
+ * We escape by appending one tombstone byte; decode reverses that by stripping one trailing byte
+ * from a stored value that begins with the tombstone bytes.
+ *
+ * Because decode keys off the two-byte prefix alone, the escape must cover every value that begins
+ * with the tombstone bytes, not only a value equal to the marker. A raw value {\x14\x14\x37} would
+ * otherwise be decoded to {\x14\x14} and corrupt the read, so it too is escaped, to
+ * {\x14\x14\x37\x14}. The stable table has no tombstone marker (deletes there are real removes) and
+ * would not strictly need to escape, but the same encoding is applied to both constituents so a
+ * value decodes identically no matter which constituent served it.
+ *
+ * FIXME-WT-17933: Encoding on the stable table persists the escape byte on disk, which locks it
+ * into the on-disk format. The encoding is only needed for the ingest table; limit it to that
+ * constituent once the ingest tombstone design allows it.
+ *
+ * The size test differs by direction. On encode, a value equal to the tombstone is in the namespace
+ * (it must not masquerade as a delete), so the test is inclusive. Encoding only ever appends, so a
+ * stored escaped value is always strictly longer than the tombstone; decode and stored-value
+ * classification therefore only act on values longer than the tombstone, so their test is
+ * exclusive.
+ */
+
+/*
+ * __clayered_value_in_tombstone_namespace --
+ *     Boundary test shared by the tombstone encode and decode paths.
  */
 static WT_INLINE bool
-__clayered_is_deleted_encoded(const WT_ITEM *value)
+__clayered_value_in_tombstone_namespace(const WT_ITEM *value, bool encode)
 {
-    return (value->size > __wt_tombstone.size &&
-      memcmp(value->data, __wt_tombstone.data, __wt_tombstone.size) == 0);
+    size_t bound = encode ? __wt_tombstone.size : __wt_tombstone.size + 1;
+
+    return (
+      value->size >= bound && memcmp(value->data, __wt_tombstone.data, __wt_tombstone.size) == 0);
 }
 
 /*
@@ -65,7 +101,7 @@ __clayered_deleted_encode(
      * If value requires encoding, get a scratch buffer of the right size and create a copy of the
      * data with the first byte of the tombstone appended.
      */
-    if (__clayered_is_deleted_encoded(value)) {
+    if (__clayered_value_in_tombstone_namespace(value, true)) {
         WT_RET(__wt_scr_alloc(session, value->size + 1, tmpp));
         tmp = *tmpp;
 
@@ -88,7 +124,7 @@ __clayered_deleted_encode(
 static WT_INLINE void
 __clayered_deleted_decode(WT_ITEM *value)
 {
-    if (__clayered_is_deleted_encoded(value))
+    if (__clayered_value_in_tombstone_namespace(value, false))
         --value->size;
 }
 
@@ -2518,6 +2554,8 @@ __clayered_insert(WT_CURSOR *cursor)
 
     WT_ERR(__clayered_modify_check(session, clayered, &cursor->key));
 
+    /* FIXME-WT-17933: on the leader this encodes into the stable table; see the tombstone note
+     * above. */
     WT_ERR(__clayered_deleted_encode(session, &cursor->value, &value, &buf));
     ret = __clayered_put(&op, &cursor->key, &value, WTI_CLAYERED_PUT_INSERT);
     if (ret == WT_DUPLICATE_KEY) {
@@ -2595,6 +2633,8 @@ __clayered_update(WT_CURSOR *cursor)
         WT_ERR(__cursor_needkey(cursor));
     }
 
+    /* FIXME-WT-17933: on the leader this encodes into the stable table; see the tombstone note
+     * above. */
     WT_ERR(__clayered_deleted_encode(session, &cursor->value, &value, &buf));
     WT_ERR(__clayered_put(&op, &cursor->key, &value, WTI_CLAYERED_PUT_UPDATE));
 
@@ -2987,9 +3027,10 @@ __clayered_modify_stable(WTI_CLAYERED_OP *op, WT_MODIFY *entries, int nentries)
      * Similarly, a delete-encoded value alters the original value and also cannot serve as the base
      * value for a modify. In these cases, perform a full update instead.
      */
-    if (ret == 0 && __clayered_is_deleted_encoded(&c_stable->value)) {
+    if (ret == 0 && __clayered_value_in_tombstone_namespace(&c_stable->value, false)) {
         __clayered_deleted_decode(&c_stable->value);
         WT_ERR(__wt_modify_apply_api(c_stable, entries, nentries));
+        /* FIXME-WT-17933: this encodes into the stable table; see the tombstone note above. */
         WT_ERR(__clayered_deleted_encode(session, &c_stable->value, &c_stable->value, &buf));
         __wt_clayered_stable_value_stat(session, c_stable->value.data, c_stable->value.size);
         F_SET(c_stable, WT_CURSTD_VALUE_EXT);
@@ -3053,7 +3094,7 @@ __clayered_modify_ingest(WTI_CLAYERED_OP *op, WT_MODIFY *entries, int nentries)
          * instead.
          */
         if (__wt_clayered_deleted(&c_ingest->value) ||
-          __clayered_is_deleted_encoded(&c_ingest->value)) {
+          __clayered_value_in_tombstone_namespace(&c_ingest->value, false)) {
             __clayered_deleted_decode(&c_ingest->value);
             WT_ERR(__wt_modify_apply_api(c_ingest, entries, nentries));
             WT_ERR(__clayered_deleted_encode(session, &c_ingest->value, &c_ingest->value, &buf));

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -112,10 +112,15 @@ __clayered_deleted_encode(
  *     Decode values that start with the tombstone.
  */
 static WT_INLINE void
-__clayered_deleted_decode(WT_ITEM *value)
+__clayered_deleted_decode(WT_SESSION_IMPL *session, WT_ITEM *value)
 {
-    if (__clayered_value_in_tombstone_namespace(value, false /* decode */))
+    if (__clayered_value_in_tombstone_namespace(value, false /* decode */)) {
+        /* Encoding only ever appends the tombstone byte, so that is the byte being stripped. */
+        WT_ASSERT_ALWAYS(session,
+          ((const uint8_t *)value->data)[value->size - 1] == *(const uint8_t *)__wt_tombstone.data,
+          "layered tombstone decode found a non-tombstone trailing byte");
         --value->size;
+    }
 }
 
 /*
@@ -1424,7 +1429,7 @@ __clayered_iterate(WTI_CURSOR_LAYERED *clayered, uint32_t iter_flag)
     WT_ITEM_SET(iface->key, clayered->current_cursor->key);
     WT_ITEM_SET(iface->value, clayered->current_cursor->value);
     __clayered_stable_read_value_stat(clayered, &iface->value);
-    __clayered_deleted_decode(&iface->value);
+    __clayered_deleted_decode(CUR2S(clayered), &iface->value);
     F_CLR(iface, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
     F_SET(iface, WT_CURSTD_KEY_INT | WT_CURSTD_VALUE_INT);
 
@@ -1898,7 +1903,7 @@ err:
     __clayered_leave(clayered);
     if (ret == 0) {
         __clayered_stable_read_value_stat(clayered, &cursor->value);
-        __clayered_deleted_decode(&cursor->value);
+        __clayered_deleted_decode(session, &cursor->value);
         F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
         F_SET(cursor, WT_CURSTD_KEY_INT | WT_CURSTD_VALUE_INT);
     }
@@ -2177,7 +2182,7 @@ err:
     __clayered_leave(clayered);
     if (ret == 0) {
         __clayered_stable_read_value_stat(clayered, &cursor->value);
-        __clayered_deleted_decode(&cursor->value);
+        __clayered_deleted_decode(session, &cursor->value);
         F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
         F_SET(cursor, WT_CURSTD_KEY_INT | WT_CURSTD_VALUE_INT);
     }
@@ -2982,7 +2987,7 @@ err:
     __clayered_leave(clayered);
     if (ret == 0) {
         __clayered_stable_read_value_stat(clayered, &cursor->value);
-        __clayered_deleted_decode(&cursor->value);
+        __clayered_deleted_decode(session, &cursor->value);
         F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
         F_SET(cursor, WT_CURSTD_KEY_INT | WT_CURSTD_VALUE_INT);
     } else {
@@ -3016,7 +3021,7 @@ __clayered_modify_stable(WTI_CLAYERED_OP *op, WT_MODIFY *entries, int nentries)
      * value for a modify. In these cases, perform a full update instead.
      */
     if (ret == 0 && __clayered_value_in_tombstone_namespace(&c_stable->value, false /* decode */)) {
-        __clayered_deleted_decode(&c_stable->value);
+        __clayered_deleted_decode(session, &c_stable->value);
         WT_ERR(__wt_modify_apply_api(c_stable, entries, nentries));
         /* FIXME-WT-17933: this encodes into the stable table. */
         WT_ERR(__clayered_deleted_encode(session, &c_stable->value, &c_stable->value, &buf));
@@ -3068,7 +3073,7 @@ __clayered_modify_ingest(WTI_CLAYERED_OP *op, WT_MODIFY *entries, int nentries)
          * table.
          */
         c_ingest->set_key(c_ingest, &cursor->key);
-        __clayered_deleted_decode(&value);
+        __clayered_deleted_decode(session, &value);
         WT_ITEM_SET(c_ingest->value, value);
         WT_ERR(__wt_modify_apply_api(c_ingest, entries, nentries));
         WT_ERR(__clayered_deleted_encode(session, &c_ingest->value, &c_ingest->value, &buf));
@@ -3083,7 +3088,7 @@ __clayered_modify_ingest(WTI_CLAYERED_OP *op, WT_MODIFY *entries, int nentries)
          */
         if (__wt_clayered_deleted(&c_ingest->value) ||
           __clayered_value_in_tombstone_namespace(&c_ingest->value, false /* decode */)) {
-            __clayered_deleted_decode(&c_ingest->value);
+            __clayered_deleted_decode(session, &c_ingest->value);
             WT_ERR(__wt_modify_apply_api(c_ingest, entries, nentries));
             WT_ERR(__clayered_deleted_encode(session, &c_ingest->value, &c_ingest->value, &buf));
             F_SET(c_ingest, WT_CURSTD_VALUE_EXT);
@@ -3168,7 +3173,7 @@ __clayered_modify(WT_CURSOR *cursor, WT_MODIFY *entries, int nentries)
      */
     WT_ITEM_SET(cursor->key, current->key);
     WT_ITEM_SET(cursor->value, current->value);
-    __clayered_deleted_decode(&cursor->value);
+    __clayered_deleted_decode(session, &cursor->value);
     WT_ASSERT(session, F_MASK(current, WT_CURSTD_KEY_SET) == WT_CURSTD_KEY_INT);
     F_SET(cursor, WT_CURSTD_KEY_INT);
 

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -43,35 +43,25 @@ typedef enum {
 /*
  * Tombstone value encoding.
  *
- * The ingest table holds only recent changes; the full key space lives in the stable table. A read
- * that does not find a key in the ingest table falls through to the stable table, because the key
- * may simply have been evicted from the ingest table rather than deleted. A user delete therefore
- * needs an explicit marker in the ingest table so the read stops and reports the key as gone rather
- * than falling through: that marker is the reserved value __wt_tombstone, the two bytes {\x14\x14}.
- * Finding the tombstone means the key was deleted; not finding the key at all means fall through to
- * the stable table.
+ * The ingest table holds recent changes; the full key space lives in the stable table, so a read
+ * that misses in the ingest table falls through to the stable table (the key may have been evicted,
+ * not deleted). A user delete therefore needs an explicit marker in the ingest table to stop that
+ * fall-through: the reserved value __wt_tombstone, the two bytes {\x14\x14}.
  *
- * Because the tombstone is itself a value, an application value equal to {\x14\x14} would be read
- * back as a delete. Such values are escaped before they are stored and un-escaped when read back.
- * We escape by appending one tombstone byte; decode reverses that by stripping one trailing byte
- * from a stored value that begins with the tombstone bytes.
+ * An application value equal to {\x14\x14} would then read back as a delete, so it is escaped by
+ * appending one tombstone byte; decode strips one trailing byte from a stored value beginning with
+ * the tombstone bytes. Because decode keys off that prefix alone, every value beginning with the
+ * tombstone must be escaped, not only the marker itself: a raw {\x14\x14\x37} would otherwise
+ * decode to {\x14\x14}, so it is stored as {\x14\x14\x37\x14}.
  *
- * Because decode keys off the two-byte prefix alone, the escape must cover every value that begins
- * with the tombstone bytes, not only a value equal to the marker. A raw value {\x14\x14\x37} would
- * otherwise be decoded to {\x14\x14} and corrupt the read, so it too is escaped, to
- * {\x14\x14\x37\x14}. The stable table has no tombstone marker (deletes there are real removes) and
- * would not strictly need to escape, but the same encoding is applied to both constituents so a
- * value decodes identically no matter which constituent served it.
+ * The size test differs by direction: encode is inclusive (a value equal to the tombstone is in the
+ * namespace), decode and classification are exclusive (encoding only ever appends, so a stored
+ * escaped value is always longer than the tombstone).
  *
- * FIXME-WT-17933: Encoding on the stable table persists the escape byte on disk, which locks it
- * into the on-disk format. The encoding is only needed for the ingest table; limit it to that
- * constituent once the ingest tombstone design allows it.
- *
- * The size test differs by direction. On encode, a value equal to the tombstone is in the namespace
- * (it must not masquerade as a delete), so the test is inclusive. Encoding only ever appends, so a
- * stored escaped value is always strictly longer than the tombstone; decode and stored-value
- * classification therefore only act on values longer than the tombstone, so their test is
- * exclusive.
+ * The stable table has no tombstone marker (deletes there are real removes) and need not escape,
+ * but the same encoding is applied to both constituents so a value decodes identically whichever
+ * served it. FIXME-WT-17933: that persists the escape byte on disk and locks it into the on-disk
+ * format; limit encoding to the ingest table only.
  */
 
 /*
@@ -101,7 +91,7 @@ __clayered_deleted_encode(
      * If value requires encoding, get a scratch buffer of the right size and create a copy of the
      * data with the first byte of the tombstone appended.
      */
-    if (__clayered_value_in_tombstone_namespace(value, true)) {
+    if (__clayered_value_in_tombstone_namespace(value, true /* encode */)) {
         WT_RET(__wt_scr_alloc(session, value->size + 1, tmpp));
         tmp = *tmpp;
 
@@ -124,19 +114,19 @@ __clayered_deleted_encode(
 static WT_INLINE void
 __clayered_deleted_decode(WT_ITEM *value)
 {
-    if (__clayered_value_in_tombstone_namespace(value, false))
+    if (__clayered_value_in_tombstone_namespace(value, false /* decode */))
         --value->size;
 }
 
 /*
  * __wt_clayered_stable_value_stat --
  *     Count and warn about a stable-table value that shares the tombstone's encoded namespace. Such
- *     values begin with the two tombstone bytes and, for historic reasons, are persisted to the
- *     stable table verbatim; they are expected to be extremely rare. Encoding appends a single
- *     tombstone byte (see __clayered_deleted_encode), so the stored form is classified by its
- *     length and trailing byte. The raw bytes may carry application data, so the log records only
- *     the size and a content hash to fingerprint recurring values. This takes raw bytes so both the
- *     layered cursor and the verify page walk can share it.
+ *     values begin with the two tombstone bytes and are escaped like on the ingest table (see
+ *     __clayered_deleted_encode); they are expected to be extremely rare. The stored form is
+ *     classified by its length and trailing byte; a bare two-byte tombstone can only come from
+ *     legacy unescaped data on disk. The raw bytes may carry application data, so the log records
+ *     only the size and a content hash to fingerprint recurring values. This takes raw bytes so
+ *     both the layered cursor and the verify page walk can share it.
  *
  * TODO(WT-17958): Revert WT-17957 when tombstone encoding is removed from the stable table.
  */
@@ -2554,8 +2544,7 @@ __clayered_insert(WT_CURSOR *cursor)
 
     WT_ERR(__clayered_modify_check(session, clayered, &cursor->key));
 
-    /* FIXME-WT-17933: on the leader this encodes into the stable table; see the tombstone note
-     * above. */
+    /* FIXME-WT-17933: on the leader this encodes into the stable table. */
     WT_ERR(__clayered_deleted_encode(session, &cursor->value, &value, &buf));
     ret = __clayered_put(&op, &cursor->key, &value, WTI_CLAYERED_PUT_INSERT);
     if (ret == WT_DUPLICATE_KEY) {
@@ -2633,8 +2622,7 @@ __clayered_update(WT_CURSOR *cursor)
         WT_ERR(__cursor_needkey(cursor));
     }
 
-    /* FIXME-WT-17933: on the leader this encodes into the stable table; see the tombstone note
-     * above. */
+    /* FIXME-WT-17933: on the leader this encodes into the stable table. */
     WT_ERR(__clayered_deleted_encode(session, &cursor->value, &value, &buf));
     WT_ERR(__clayered_put(&op, &cursor->key, &value, WTI_CLAYERED_PUT_UPDATE));
 
@@ -3027,10 +3015,10 @@ __clayered_modify_stable(WTI_CLAYERED_OP *op, WT_MODIFY *entries, int nentries)
      * Similarly, a delete-encoded value alters the original value and also cannot serve as the base
      * value for a modify. In these cases, perform a full update instead.
      */
-    if (ret == 0 && __clayered_value_in_tombstone_namespace(&c_stable->value, false)) {
+    if (ret == 0 && __clayered_value_in_tombstone_namespace(&c_stable->value, false /* decode */)) {
         __clayered_deleted_decode(&c_stable->value);
         WT_ERR(__wt_modify_apply_api(c_stable, entries, nentries));
-        /* FIXME-WT-17933: this encodes into the stable table; see the tombstone note above. */
+        /* FIXME-WT-17933: this encodes into the stable table. */
         WT_ERR(__clayered_deleted_encode(session, &c_stable->value, &c_stable->value, &buf));
         __wt_clayered_stable_value_stat(session, c_stable->value.data, c_stable->value.size);
         F_SET(c_stable, WT_CURSTD_VALUE_EXT);
@@ -3094,7 +3082,7 @@ __clayered_modify_ingest(WTI_CLAYERED_OP *op, WT_MODIFY *entries, int nentries)
          * instead.
          */
         if (__wt_clayered_deleted(&c_ingest->value) ||
-          __clayered_value_in_tombstone_namespace(&c_ingest->value, false)) {
+          __clayered_value_in_tombstone_namespace(&c_ingest->value, false /* decode */)) {
             __clayered_deleted_decode(&c_ingest->value);
             WT_ERR(__wt_modify_apply_api(c_ingest, entries, nentries));
             WT_ERR(__clayered_deleted_encode(session, &c_ingest->value, &c_ingest->value, &buf));

--- a/test/suite/test_layered_tombstone_collision.py
+++ b/test/suite/test_layered_tombstone_collision.py
@@ -27,10 +27,9 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 # test_layered_tombstone_collision.py
-#   Follower writes land in the ingest table, where the two-byte tombstone (0x14 0x14) is also the
-#   delete marker. A user value byte-identical to the tombstone must be escaped on the way in, or it
-#   is read back as WT_NOTFOUND. This test writes such a value on a follower and confirms it round
-#   trips, across the insert, update, and modify paths.
+#   A user value byte-identical to the internal tombstone marker (0x14 0x14) must behave like any
+#   other value across every cursor operation on a follower, never read back as a deletion. Each
+#   value below is exercised by every test case.
 
 import wiredtiger, wttest
 from helper_disagg import disagg_test_class, gen_disagg_storages
@@ -42,61 +41,142 @@ class test_layered_tombstone_collision(wttest.WiredTigerTestCase):
     conn_base_config = ',create,statistics=(all),'
     uri = f'layered:{test_name}'
 
-    # The tombstone itself, a longer value sharing its prefix, and an unrelated value.
-    collide = b'\x14\x14'
-    control = b'\x14\x14\xff'
-    normal = b'hello'
-
+    values = [
+        ('collide', dict(value=b'\x14\x14')),      # exactly the tombstone
+        ('control', dict(value=b'\x14\x14\xff')),  # tombstone prefix + a byte
+        ('other', dict(value=b'\x14\x14\x14')),    # tombstone prefix + a tombstone byte
+    ]
     disagg_storages = gen_disagg_storages(disagg_only=True)
-    scenarios = make_scenarios(disagg_storages)
+    scenarios = make_scenarios(disagg_storages, values)
 
     def conn_config(self):
         return self.extensionsConfig() + self.conn_base_config + 'disaggregated=(role="leader")'
 
-    def open_follower(self):
-        # The framework tracks and closes connections opened through wiredtiger_open.
-        conn = self.wiredtiger_open('follower',
+    def setUp(self):
+        super().setUp()
+        # Reading an escaped value off the stable table logs a warning; that is expected here.
+        self.ignoreStdoutPattern('stable table value in the tombstone namespace')
+        self.session.create(self.uri, 'key_format=S,value_format=u')
+        self.follow_conn = self.wiredtiger_open('follower',
             self.extensionsConfig() + self.conn_base_config + 'disaggregated=(role="follower")')
-        return conn.open_session('')
+        self.follow = self.follow_conn.open_session('')
+        self.follow.create(self.uri, 'key_format=S,value_format=u')
 
-    def check(self, session, key, expected):
-        c = session.open_cursor(self.uri)
+    def put(self, key, value):
+        c = self.follow.open_cursor(self.uri)
+        c[key] = value
+        c.close()
+
+    def cursor(self):
+        return self.follow.open_cursor(self.uri)
+
+    def check(self, key, expected):
+        c = self.cursor()
         c.set_key(key)
-        self.assertEqual(c.search(), 0,
-            f'{key}: value in the tombstone namespace read back as a delete')
+        self.assertEqual(c.search(), 0)
         self.assertEqual(c.get_value(), expected)
         c.close()
 
-    def test_tombstone_collision(self):
-        self.session.create(self.uri, 'key_format=S,value_format=u')
-        session = self.open_follower()
-        session.create(self.uri, 'key_format=S,value_format=u')
+    def test_search(self):
+        self.put('k', self.value)
+        self.check('k', self.value)
 
-        # Insert: the exact-tombstone value must survive alongside its longer sibling.
-        c = session.open_cursor(self.uri)
-        c['collide'] = self.collide
-        c['control'] = self.control
-        c['normal'] = self.normal
-        c.close()
+    def test_next(self):
+        self.put('a', self.value)
+        self.put('b', self.value)
+        c = self.cursor()
+        self.assertEqual(c.next(), 0)
+        self.assertEqual((c.get_key(), c.get_value()), ('a', self.value))
+        self.assertEqual(c.next(), 0)
+        self.assertEqual((c.get_key(), c.get_value()), ('b', self.value))
 
-        self.check(session, 'collide', self.collide)
-        self.check(session, 'control', self.control)
-        self.check(session, 'normal', self.normal)
+    def test_prev(self):
+        self.put('a', self.value)
+        self.put('b', self.value)
+        c = self.cursor()
+        self.assertEqual(c.prev(), 0)
+        self.assertEqual((c.get_key(), c.get_value()), ('b', self.value))
+        self.assertEqual(c.prev(), 0)
+        self.assertEqual((c.get_key(), c.get_value()), ('a', self.value))
 
-        # Update an existing key to the exact-tombstone value.
-        c = session.open_cursor(self.uri)
-        c['normal'] = self.collide
-        c.close()
-        self.check(session, 'normal', self.collide)
+    def test_search_near(self):
+        self.put('k', self.value)
+        c = self.cursor()
+        c.set_key('k')
+        self.assertEqual(c.search_near(), 0)
+        self.assertEqual(c.get_value(), self.value)
 
-        # Modify a value into the exact-tombstone bytes.
-        c = session.open_cursor(self.uri)
-        c['control'] = b'\x14\x14\x14'
-        c.close()
-        c = session.open_cursor(self.uri)
-        c.set_key('control')
+    def test_search_near_nonexact(self):
+        self.put('a', self.value)
+        self.put('c', self.value)
+        c = self.cursor()
+        c.set_key('b')
+        self.assertNotEqual(c.search_near(), 0)
+        self.assertEqual(c.get_value(), self.value)
+
+    def test_update(self):
+        self.put('k', b'plain')
+        self.put('k', self.value)
+        self.check('k', self.value)
+
+    def test_modify_from_value(self):
+        # The value is the modify base; append a byte.
+        self.put('k', self.value)
+        c = self.cursor()
+        c.set_key('k')
         self.assertEqual(c.search(), 0)
-        # Drop the trailing byte, leaving the two tombstone bytes.
-        c.modify([wiredtiger.Modify(b'', 2, 1)])
+        c.modify([wiredtiger.Modify(b'\xaa', len(self.value), 0)])
         c.close()
-        self.check(session, 'control', self.collide)
+        self.check('k', self.value + b'\xaa')
+
+    def test_modify_into_value(self):
+        # Build the value with a modify by dropping a trailing byte.
+        self.put('k', self.value + b'\xaa')
+        c = self.cursor()
+        c.set_key('k')
+        self.assertEqual(c.search(), 0)
+        c.modify([wiredtiger.Modify(b'', len(self.value), 1)])
+        c.close()
+        self.check('k', self.value)
+
+    def test_modify_out_of_namespace(self):
+        # The value is the modify base; replace it with a value outside the namespace.
+        self.put('k', self.value)
+        c = self.cursor()
+        c.set_key('k')
+        self.assertEqual(c.search(), 0)
+        c.modify([wiredtiger.Modify(b'ab', 0, len(self.value))])
+        c.close()
+        self.check('k', b'ab')
+
+    def test_remove(self):
+        self.put('k', self.value)
+        c = self.cursor()
+        c.set_key('k')
+        self.assertEqual(c.remove(), 0)
+        c.close()
+        c = self.cursor()
+        c.set_key('k')
+        self.assertEqual(c.search(), wiredtiger.WT_NOTFOUND)
+
+    def test_reinsert_after_remove(self):
+        # A delete marker followed by an escaped value on the same update chain.
+        self.put('k', self.value)
+        c = self.cursor()
+        c.set_key('k')
+        self.assertEqual(c.remove(), 0)
+        c.close()
+        self.put('k', self.value)
+        self.check('k', self.value)
+
+    def test_leader_write_follower_read(self):
+        # Written on the leader, read on the follower after it picks up the checkpoint.
+        c = self.session.open_cursor(self.uri)
+        self.session.begin_transaction()
+        c['k'] = self.value
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
+        c.close()
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10))
+        self.session.checkpoint()
+        self.disagg_advance_checkpoint(self.follow_conn, self.conn)
+        self.check('k', self.value)

--- a/test/suite/test_layered_tombstone_collision.py
+++ b/test/suite/test_layered_tombstone_collision.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# test_layered_tombstone_collision.py
+#   Follower writes land in the ingest table, where the two-byte tombstone (0x14 0x14) is also the
+#   delete marker. A user value byte-identical to the tombstone must be escaped on the way in, or it
+#   is read back as WT_NOTFOUND. This test writes such a value on a follower and confirms it round
+#   trips, across the insert, update, and modify paths.
+
+import wiredtiger, wttest
+from helper_disagg import disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
+
+@disagg_test_class
+class test_layered_tombstone_collision(wttest.WiredTigerTestCase):
+    test_name = __qualname__
+    conn_base_config = ',create,statistics=(all),'
+    uri = f'layered:{test_name}'
+
+    # The tombstone itself, a longer value sharing its prefix, and an unrelated value.
+    collide = b'\x14\x14'
+    control = b'\x14\x14\xff'
+    normal = b'hello'
+
+    disagg_storages = gen_disagg_storages(disagg_only=True)
+    scenarios = make_scenarios(disagg_storages)
+
+    def conn_config(self):
+        return self.extensionsConfig() + self.conn_base_config + 'disaggregated=(role="leader")'
+
+    def open_follower(self):
+        # The framework tracks and closes connections opened through wiredtiger_open.
+        conn = self.wiredtiger_open('follower',
+            self.extensionsConfig() + self.conn_base_config + 'disaggregated=(role="follower")')
+        return conn.open_session('')
+
+    def check(self, session, key, expected):
+        c = session.open_cursor(self.uri)
+        c.set_key(key)
+        self.assertEqual(c.search(), 0,
+            f'{key}: value in the tombstone namespace read back as a delete')
+        self.assertEqual(c.get_value(), expected)
+        c.close()
+
+    def test_tombstone_collision(self):
+        self.session.create(self.uri, 'key_format=S,value_format=u')
+        session = self.open_follower()
+        session.create(self.uri, 'key_format=S,value_format=u')
+
+        # Insert: the exact-tombstone value must survive alongside its longer sibling.
+        c = session.open_cursor(self.uri)
+        c['collide'] = self.collide
+        c['control'] = self.control
+        c['normal'] = self.normal
+        c.close()
+
+        self.check(session, 'collide', self.collide)
+        self.check(session, 'control', self.control)
+        self.check(session, 'normal', self.normal)
+
+        # Update an existing key to the exact-tombstone value.
+        c = session.open_cursor(self.uri)
+        c['normal'] = self.collide
+        c.close()
+        self.check(session, 'normal', self.collide)
+
+        # Modify a value into the exact-tombstone bytes.
+        c = session.open_cursor(self.uri)
+        c['control'] = b'\x14\x14\x14'
+        c.close()
+        c = session.open_cursor(self.uri)
+        c.set_key('control')
+        self.assertEqual(c.search(), 0)
+        # Drop the trailing byte, leaving the two tombstone bytes.
+        c.modify([wiredtiger.Modify(b'', 2, 1)])
+        c.close()
+        self.check(session, 'control', self.collide)

--- a/test/suite/test_layered_tombstone_collision.py
+++ b/test/suite/test_layered_tombstone_collision.py
@@ -28,8 +28,9 @@
 
 # test_layered_tombstone_collision.py
 #   A user value byte-identical to the internal tombstone marker (0x14 0x14) must behave like any
-#   other value across every cursor operation on a follower, never read back as a deletion. Each
-#   value below is exercised by every test case.
+#   other value across every cursor operation, never read back as a deletion. Each test runs against
+#   every value and in every mode: on the leader, directly on the follower (ingest table), and on
+#   the follower after it picks up the value through a checkpoint.
 
 import wiredtiger, wttest
 from helper_disagg import disagg_test_class, gen_disagg_storages
@@ -46,8 +47,15 @@ class test_layered_tombstone_collision(wttest.WiredTigerTestCase):
         ('control', dict(value=b'\x14\x14\xff')),  # tombstone prefix + a byte
         ('other', dict(value=b'\x14\x14\x14')),    # tombstone prefix + a tombstone byte
     ]
+    # Where the value is written and read. 'checkpoint' writes on the leader and reads on the
+    # follower after a checkpoint pickup; the others write and read on a single node.
+    modes = [
+        ('leader', dict(mode='leader')),
+        ('follower_direct', dict(mode='follower_direct')),
+        ('follower_checkpoint', dict(mode='follower_checkpoint')),
+    ]
     disagg_storages = gen_disagg_storages(disagg_only=True)
-    scenarios = make_scenarios(disagg_storages, values)
+    scenarios = make_scenarios(disagg_storages, values, modes)
 
     def conn_config(self):
         return self.extensionsConfig() + self.conn_base_config + 'disaggregated=(role="leader")'
@@ -62,121 +70,136 @@ class test_layered_tombstone_collision(wttest.WiredTigerTestCase):
         self.follow = self.follow_conn.open_session('')
         self.follow.create(self.uri, 'key_format=S,value_format=u')
 
-    def put(self, key, value):
-        c = self.follow.open_cursor(self.uri)
+        self.commit_ts = 0
+        if self.mode == 'follower_direct':
+            self.wsession = self.rsession = self.follow
+        elif self.mode == 'follower_checkpoint':
+            self.wsession, self.rsession = self.session, self.follow
+        else:
+            self.wsession = self.rsession = self.session
+
+    # Commit the write transaction. Disaggregated storage requires every transaction to be
+    # timestamped; the checkpoint mode also checkpoints at the stable timestamp (see sync).
+    def commit(self):
+        self.commit_ts += 10
+        self.wsession.commit_transaction('commit_timestamp=' + self.timestamp_str(self.commit_ts))
+
+    def write(self, key, value):
+        c = self.wsession.open_cursor(self.uri)
+        self.wsession.begin_transaction()
         c[key] = value
+        self.commit()
         c.close()
 
-    def cursor(self):
-        return self.follow.open_cursor(self.uri)
+    def modify(self, key, mods):
+        c = self.wsession.open_cursor(self.uri)
+        self.wsession.begin_transaction()
+        c.set_key(key)
+        self.assertEqual(c.modify(mods), 0)
+        self.commit()
+        c.close()
+
+    def remove(self, key):
+        c = self.wsession.open_cursor(self.uri)
+        self.wsession.begin_transaction()
+        c.set_key(key)
+        self.assertEqual(c.remove(), 0)
+        self.commit()
+        c.close()
+
+    # Make prior writes visible to the read session. Only the checkpoint mode needs to act.
+    def sync(self):
+        if self.mode == 'follower_checkpoint':
+            self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(self.commit_ts))
+            self.session.checkpoint()
+            self.disagg_advance_checkpoint(self.follow_conn, self.conn)
+
+    def rcursor(self):
+        self.sync()
+        return self.rsession.open_cursor(self.uri)
 
     def check(self, key, expected):
-        c = self.cursor()
+        c = self.rcursor()
         c.set_key(key)
         self.assertEqual(c.search(), 0)
         self.assertEqual(c.get_value(), expected)
         c.close()
 
     def test_search(self):
-        self.put('k', self.value)
+        self.write('k', self.value)
         self.check('k', self.value)
 
     def test_next(self):
-        self.put('a', self.value)
-        self.put('b', self.value)
-        c = self.cursor()
+        self.write('a', self.value)
+        self.write('b', self.value)
+        c = self.rcursor()
         self.assertEqual(c.next(), 0)
         self.assertEqual((c.get_key(), c.get_value()), ('a', self.value))
         self.assertEqual(c.next(), 0)
         self.assertEqual((c.get_key(), c.get_value()), ('b', self.value))
+        c.close()
 
     def test_prev(self):
-        self.put('a', self.value)
-        self.put('b', self.value)
-        c = self.cursor()
+        self.write('a', self.value)
+        self.write('b', self.value)
+        c = self.rcursor()
         self.assertEqual(c.prev(), 0)
         self.assertEqual((c.get_key(), c.get_value()), ('b', self.value))
         self.assertEqual(c.prev(), 0)
         self.assertEqual((c.get_key(), c.get_value()), ('a', self.value))
+        c.close()
 
     def test_search_near(self):
-        self.put('k', self.value)
-        c = self.cursor()
+        self.write('k', self.value)
+        c = self.rcursor()
         c.set_key('k')
         self.assertEqual(c.search_near(), 0)
         self.assertEqual(c.get_value(), self.value)
+        c.close()
 
     def test_search_near_nonexact(self):
-        self.put('a', self.value)
-        self.put('c', self.value)
-        c = self.cursor()
+        self.write('a', self.value)
+        self.write('c', self.value)
+        c = self.rcursor()
         c.set_key('b')
         self.assertNotEqual(c.search_near(), 0)
         self.assertEqual(c.get_value(), self.value)
+        c.close()
 
     def test_update(self):
-        self.put('k', b'plain')
-        self.put('k', self.value)
+        self.write('k', b'plain')
+        self.write('k', self.value)
         self.check('k', self.value)
 
     def test_modify_from_value(self):
         # The value is the modify base; append a byte.
-        self.put('k', self.value)
-        c = self.cursor()
-        c.set_key('k')
-        self.assertEqual(c.search(), 0)
-        c.modify([wiredtiger.Modify(b'\xaa', len(self.value), 0)])
-        c.close()
+        self.write('k', self.value)
+        self.modify('k', [wiredtiger.Modify(b'\xaa', len(self.value), 0)])
         self.check('k', self.value + b'\xaa')
 
     def test_modify_into_value(self):
         # Build the value with a modify by dropping a trailing byte.
-        self.put('k', self.value + b'\xaa')
-        c = self.cursor()
-        c.set_key('k')
-        self.assertEqual(c.search(), 0)
-        c.modify([wiredtiger.Modify(b'', len(self.value), 1)])
-        c.close()
+        self.write('k', self.value + b'\xaa')
+        self.modify('k', [wiredtiger.Modify(b'', len(self.value), 1)])
         self.check('k', self.value)
 
     def test_modify_out_of_namespace(self):
         # The value is the modify base; replace it with a value outside the namespace.
-        self.put('k', self.value)
-        c = self.cursor()
-        c.set_key('k')
-        self.assertEqual(c.search(), 0)
-        c.modify([wiredtiger.Modify(b'ab', 0, len(self.value))])
-        c.close()
+        self.write('k', self.value)
+        self.modify('k', [wiredtiger.Modify(b'ab', 0, len(self.value))])
         self.check('k', b'ab')
 
     def test_remove(self):
-        self.put('k', self.value)
-        c = self.cursor()
-        c.set_key('k')
-        self.assertEqual(c.remove(), 0)
-        c.close()
-        c = self.cursor()
+        self.write('k', self.value)
+        self.remove('k')
+        c = self.rcursor()
         c.set_key('k')
         self.assertEqual(c.search(), wiredtiger.WT_NOTFOUND)
+        c.close()
 
     def test_reinsert_after_remove(self):
         # A delete marker followed by an escaped value on the same update chain.
-        self.put('k', self.value)
-        c = self.cursor()
-        c.set_key('k')
-        self.assertEqual(c.remove(), 0)
-        c.close()
-        self.put('k', self.value)
-        self.check('k', self.value)
-
-    def test_leader_write_follower_read(self):
-        # Written on the leader, read on the follower after it picks up the checkpoint.
-        c = self.session.open_cursor(self.uri)
-        self.session.begin_transaction()
-        c['k'] = self.value
-        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
-        c.close()
-        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10))
-        self.session.checkpoint()
-        self.disagg_advance_checkpoint(self.follow_conn, self.conn)
+        self.write('k', self.value)
+        self.remove('k')
+        self.write('k', self.value)
         self.check('k', self.value)

--- a/test/suite/test_layered_tombstone_legacy.py
+++ b/test/suite/test_layered_tombstone_legacy.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# test_layered_tombstone_legacy.py
+#   Before we reintroduced the escaping logic for the ingest tombstone value, a value equal to the
+#   tombstone (0x14 0x14) could be persisted verbatim in the stable table. Write that raw value
+#   straight into the stable constituent to mimic such on-disk data, and confirm the follower reads
+#   it as a value, not a deletion.
+#
+#   Note that none of the known customers ever pass the exact 0x14 0x14 value to WT, so this is more
+#   of a theoretical scenario.
+
+import wttest
+from helper_disagg import disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
+
+@disagg_test_class
+class test_layered_tombstone_legacy(wttest.WiredTigerTestCase):
+    table = __qualname__
+    conn_base_config = ',create,statistics=(all),'
+    uri = f'layered:{table}'
+    stable_uri = f'file:{table}.wt_stable'
+
+    disagg_storages = gen_disagg_storages(disagg_only=True)
+    scenarios = make_scenarios(disagg_storages)
+
+    def conn_config(self):
+        return self.extensionsConfig() + self.conn_base_config + 'disaggregated=(role="leader")'
+
+    def test_legacy_verbatim_tombstone_value(self):
+        # A raw tombstone value on the stable table logs a warning; that is expected here.
+        self.ignoreStdoutPattern('stable table value in the tombstone namespace')
+        self.session.create(self.uri, 'key_format=S,value_format=u')
+
+        follow_conn = self.wiredtiger_open('follower',
+            self.extensionsConfig() + self.conn_base_config + 'disaggregated=(role="follower")')
+        follow = follow_conn.open_session('')
+        follow.create(self.uri, 'key_format=S,value_format=u')
+
+        # Write the raw tombstone bytes straight into the stable constituent, bypassing the layered
+        # encoding a normal write would apply.
+        c = self.session.open_cursor(self.stable_uri)
+        self.session.begin_transaction()
+        c['k'] = b'\x14\x14'
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
+        c.close()
+
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10))
+        self.session.checkpoint()
+        self.disagg_advance_checkpoint(follow_conn, self.conn)
+
+        # The follower must return the raw value, not treat it as a delete.
+        c = follow.open_cursor(self.uri)
+        c.set_key('k')
+        self.assertEqual(c.search(), 0)
+        self.assertEqual(c.get_value(), b'\x14\x14')
+        c.close()

--- a/test/suite/test_layered_tombstone_value.py
+++ b/test/suite/test_layered_tombstone_value.py
@@ -27,17 +27,16 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 # test_layered_tombstone_value.py
-#   A layered tombstone is two 0x14 bytes. Application values that begin with that sequence share the
-#   encoded namespace and are escaped -- a tombstone byte is appended -- before they are written to
-#   the stable table. This test confirms that such values are counted by category as they cross the
-#   stable read and write paths on a disaggregated leader.
+#   A layered tombstone is two 0x14 bytes. Application values that begin with that sequence share
+#   the encoded namespace and are escaped before being written to the stable table. This
+#   test confirms that such values are counted by category as they cross the stable read and write
+#   paths on a disaggregated leader.
 #
 #   The statistics count the stored (encoded) form. Encoding appends a single tombstone byte to any
-#   value in the namespace, so the public write path can only produce two of the four shapes: three
-#   tombstone bytes (from a value equal to the bare tombstone) and a value ending with the appended
-#   tombstone byte. The other two buckets (the bare two-byte tombstone and a value ending in a
-#   non-tombstone byte) can only arise from legacy unescaped data on disk, so this test cannot
-#   produce them.
+#   value in the namespace, so the public write path can only produce two of the four shapes: 'three
+#   tombstone bytes', and a value that ends with the appended tombstone byte. The other two buckets
+#   (the bare tombstone and a value ending in a non-tombstone byte) can only arise from legacy
+#   unescaped data on disk, so this test cannot produce them.
 
 import wttest
 from wiredtiger import stat
@@ -53,10 +52,10 @@ class test_layered_tombstone_value(wttest.WiredTigerTestCase):
     scenarios = make_scenarios(disagg_storages)
 
     # Application value -> stored (encoded) form -> category it is counted under.
-    normal = b'hello'         # unchanged        -> not in the namespace
-    tomb = b'\x14\x14'        # \x14\x14\x14      -> three tombstone bytes
-    triple = b'\x14\x14\x14'  # \x14\x14\x14\x14  -> suffix (trailing tombstone byte)
-    mixed = b'\x14\x14ab'     # \x14\x14ab\x14    -> suffix (trailing appended byte)
+    normal = b'hello'       # unchanged                  -> not in the namespace
+    tomb = b'\x14\x14'      # \x14\x14\x14                -> three tombstone bytes
+    triple = b'\x14\x14\x14'  # \x14\x14\x14\x14          -> suffix (trailing tombstone byte)
+    mixed = b'\x14\x14ab'   # \x14\x14ab\x14              -> suffix (trailing appended byte)
 
     def conn_config(self):
         return self.extensionsConfig() + \
@@ -86,8 +85,8 @@ class test_layered_tombstone_value(wttest.WiredTigerTestCase):
     def test_stable_value_categories(self):
         items = {1: self.normal, 2: self.tomb, 3: self.triple, 4: self.mixed}
 
-        # Write on the leader: the values are written to the stable table (write path). Each value in
-        # the namespace gains a trailing tombstone byte; the bare tombstone becomes three such bytes.
+        # Write on the leader (write path). Each namespace value gains a trailing tombstone byte;
+        # the bare tombstone becomes three such bytes.
         cursor = self.session.open_cursor(self.uri)
         self.session.begin_transaction()
         for key, value in items.items():
@@ -122,9 +121,8 @@ class test_layered_tombstone_value(wttest.WiredTigerTestCase):
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10))
         self.session.checkpoint()
 
-        # Measure only what verify adds. The stored forms are one three-tombstone-byte encoding (the
-        # escaped bare tombstone) and two suffix-form (trailing 0x14) encodings; the normal value is
-        # not counted.
+        # Measure only what verify adds. The stored forms are one three-tombstone-byte encoding and
+        # two suffix-form (trailing 0x14) encodings; the normal value is not counted.
         before = self.category_counts()
         self.session.verify(self.uri)
         after = self.category_counts()

--- a/test/suite/test_layered_tombstone_value.py
+++ b/test/suite/test_layered_tombstone_value.py
@@ -27,16 +27,17 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 # test_layered_tombstone_value.py
-#   A layered tombstone is two 0x14 bytes. Application values that begin with that sequence share
-#   the encoded namespace and, for historic reasons, are written verbatim to the stable table. This
-#   test confirms that such values are counted by category as they cross the stable read and write
-#   paths on a disaggregated leader.
+#   A layered tombstone is two 0x14 bytes. Application values that begin with that sequence share the
+#   encoded namespace and are escaped -- a tombstone byte is appended -- before they are written to
+#   the stable table. This test confirms that such values are counted by category as they cross the
+#   stable read and write paths on a disaggregated leader.
 #
 #   The statistics count the stored (encoded) form. Encoding appends a single tombstone byte to any
-#   value longer than the tombstone that begins with it, so the public write path can only produce
-#   two of the four shapes: the bare tombstone, and a value that ends with the appended tombstone
-#   byte. The other two buckets ('three tombstone bytes' and a value ending in a non-tombstone byte)
-#   can only arise from legacy unescaped data on disk, so this test cannot produce them.
+#   value in the namespace, so the public write path can only produce two of the four shapes: three
+#   tombstone bytes (from a value equal to the bare tombstone) and a value ending with the appended
+#   tombstone byte. The other two buckets (the bare two-byte tombstone and a value ending in a
+#   non-tombstone byte) can only arise from legacy unescaped data on disk, so this test cannot
+#   produce them.
 
 import wttest
 from wiredtiger import stat
@@ -52,10 +53,10 @@ class test_layered_tombstone_value(wttest.WiredTigerTestCase):
     scenarios = make_scenarios(disagg_storages)
 
     # Application value -> stored (encoded) form -> category it is counted under.
-    normal = b'hello'       # unchanged                  -> not in the namespace
-    tomb = b'\x14\x14'      # \x14\x14        (unchanged) -> tombstone
-    triple = b'\x14\x14\x14'  # \x14\x14\x14\x14          -> suffix (trailing tombstone byte)
-    mixed = b'\x14\x14ab'   # \x14\x14ab\x14              -> suffix (trailing appended byte)
+    normal = b'hello'         # unchanged        -> not in the namespace
+    tomb = b'\x14\x14'        # \x14\x14\x14      -> three tombstone bytes
+    triple = b'\x14\x14\x14'  # \x14\x14\x14\x14  -> suffix (trailing tombstone byte)
+    mixed = b'\x14\x14ab'     # \x14\x14ab\x14    -> suffix (trailing appended byte)
 
     def conn_config(self):
         return self.extensionsConfig() + \
@@ -85,15 +86,15 @@ class test_layered_tombstone_value(wttest.WiredTigerTestCase):
     def test_stable_value_categories(self):
         items = {1: self.normal, 2: self.tomb, 3: self.triple, 4: self.mixed}
 
-        # Write on the leader: the values are written to the stable table (write path). The bare
-        # tombstone is stored verbatim; the two longer values gain a trailing tombstone byte.
+        # Write on the leader: the values are written to the stable table (write path). Each value in
+        # the namespace gains a trailing tombstone byte; the bare tombstone becomes three such bytes.
         cursor = self.session.open_cursor(self.uri)
         self.session.begin_transaction()
         for key, value in items.items():
             cursor[key] = value
         self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
 
-        self.assertEqual(self.category_counts(), (1, 0, 2, 0))
+        self.assertEqual(self.category_counts(), (0, 1, 2, 0))
 
         # Read the values back from the stable table (read path); each category is counted again.
         # The stored value is decoded on the way out, so the application sees the original bytes.
@@ -104,7 +105,7 @@ class test_layered_tombstone_value(wttest.WiredTigerTestCase):
             self.assertEqual(cursor.get_value(), value)
         self.session.rollback_transaction()
 
-        self.assertEqual(self.category_counts(), (2, 0, 4, 0))
+        self.assertEqual(self.category_counts(), (0, 2, 4, 0))
 
     def test_verify_counts_stable_values(self):
         # verify() walks the stable table's pages directly, bypassing the layered cursor, so the
@@ -121,9 +122,10 @@ class test_layered_tombstone_value(wttest.WiredTigerTestCase):
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10))
         self.session.checkpoint()
 
-        # Measure only what verify adds. The stored forms are one bare tombstone and two
-        # suffix-form (trailing 0x14) encodings; the normal value is not counted.
+        # Measure only what verify adds. The stored forms are one three-tombstone-byte encoding (the
+        # escaped bare tombstone) and two suffix-form (trailing 0x14) encodings; the normal value is
+        # not counted.
         before = self.category_counts()
         self.session.verify(self.uri)
         after = self.category_counts()
-        self.assertEqual(tuple(a - b for a, b in zip(after, before)), (1, 0, 2, 0))
+        self.assertEqual(tuple(a - b for a, b in zip(after, before)), (0, 1, 2, 0))


### PR DESCRIPTION
## Problem
On a disaggregated follower, a layered value byte-identical to the ingest tombstone (`{\x14\x14}`) was stored unescaped and read back as `WT_NOTFOUND`, i.e. silent data loss. A prior refactor collapsed the encode and decode boundary checks into one exclusive predicate, dropping the escape of a value exactly equal to the tombstone.

## Fix
Unify the boundary check into a single `__clayered_value_in_tombstone_namespace(value, encode)` helper: inclusive on encode (so a value equal to the tombstone is escaped) and exclusive on decode. A block comment documents the tombstone encoding scheme, and `FIXME-WT-17933` marks the stable-table encode sites that persist unnecessary bytes on disk.

## Tests
- New `test_layered_tombstone_collision.py`: insert/update/modify of a colliding value on a follower round-trips.
- Updated `test_layered_tombstone_value.py` stable-table category expectations.