### PR TITLE
WT-17997 Fix TSAN data race on last_ckpt_timestamp between checkpoint and sweep

### DIFF
--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -446,6 +446,11 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
          *
          * Do not mark the tree dirty if there is no change to stable timestamp compared to the last
          * checkpoint.
+         *
+         * The load is relaxed rather than acquire: this runs on the checkpoint thread, which is the
+         * same thread that publishes the timestamp, and the value is only compared to decide
+         * whether to mark the tree dirty. No state published alongside the timestamp is consumed
+         * here.
          */
         if (!btree->modified && !F_ISSET(conn, WT_CONN_RECOVERING) &&
           !F_ISSET_ATOMIC_32(conn, WT_CONN_CLOSING_CHECKPOINT) &&

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -447,10 +447,10 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
          * Do not mark the tree dirty if there is no change to stable timestamp compared to the last
          * checkpoint.
          *
-         * The load is relaxed rather than acquire: this runs on the checkpoint thread, which is the
-         * same thread that publishes the timestamp, and the value is only compared to decide
-         * whether to mark the tree dirty. No state published alongside the timestamp is consumed
-         * here.
+         * The load is relaxed rather than acquire: this runs on the checkpoint thread, under the
+         * checkpoint lock, which is the same thread that publishes the timestamp, and the value is
+         * only compared to decide whether to mark the tree dirty. No state published alongside the
+         * timestamp is consumed here.
          */
         if (!btree->modified && !F_ISSET(conn, WT_CONN_RECOVERING) &&
           !F_ISSET_ATOMIC_32(conn, WT_CONN_CLOSING_CHECKPOINT) &&

--- a/src/btree/bt_sync.c
+++ b/src/btree/bt_sync.c
@@ -450,7 +450,8 @@ __wt_sync_file(WT_SESSION_IMPL *session, WT_CACHE_OP syncop)
         if (!btree->modified && !F_ISSET(conn, WT_CONN_RECOVERING) &&
           !F_ISSET_ATOMIC_32(conn, WT_CONN_CLOSING_CHECKPOINT) &&
           (btree->rec_max_txn >= txn->snapshot_data.snap_min ||
-            (conn->txn_global.checkpoint_timestamp != conn->txn_global.last_ckpt_timestamp &&
+            (conn->txn_global.checkpoint_timestamp !=
+                __wt_atomic_load_uint64_relaxed(&conn->txn_global.last_ckpt_timestamp) &&
               btree->rec_max_timestamp > conn->txn_global.checkpoint_timestamp)))
             __wt_tree_modify_set(session);
         break;

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -134,7 +134,7 @@ __checkpoint_flush_tier(WT_SESSION_IMPL *session, bool force)
     /* Flushing is part of a checkpoint, use the session's checkpoint time. */
     conn->tiered.flush_most_recent = session->ckpt.current_sec;
     /* Storing the last flush timestamp here for the future and for debugging. */
-    conn->tiered.flush_ts = conn->txn_global.last_ckpt_timestamp;
+    conn->tiered.flush_ts = __wt_atomic_load_uint64_relaxed(&conn->txn_global.last_ckpt_timestamp);
     /*
      * It would be more efficient to return here if no tiered storage is enabled in the system. If
      * the user asks for a flush_tier without tiered storage, the loop below is effectively a no-op
@@ -198,7 +198,8 @@ __checkpoint_flush_tier(WT_SESSION_IMPL *session, bool force)
             WT_STAT_CONN_INCR(session, flush_tier_switched);
             __wt_tree_modify_set(session);
             btree->flush_most_recent_secs = session->ckpt.current_sec;
-            btree->flush_most_recent_ts = conn->txn_global.last_ckpt_timestamp;
+            btree->flush_most_recent_ts =
+              __wt_atomic_load_uint64_relaxed(&conn->txn_global.last_ckpt_timestamp);
             WT_ERR(__wt_session_release_dhandle(session));
             release = false;
         }
@@ -1237,6 +1238,7 @@ __checkpoint_can_skip(WT_SESSION_IMPL *session, WT_CHECKPOINT_DB_CONFIG *ckpt_cf
 {
     WT_CONNECTION_IMPL *conn;
     WT_TXN_GLOBAL *txn_global;
+    wt_timestamp_t last_ckpt_ts;
 
     conn = S2C(session);
     txn_global = &conn->txn_global;
@@ -1252,9 +1254,9 @@ __checkpoint_can_skip(WT_SESSION_IMPL *session, WT_CHECKPOINT_DB_CONFIG *ckpt_cf
      * skip checkpoints. Also, don't skip if the stable disaggregated schema epoch changed, as the
      * metadata operation queue may have entries to flush even without new committed data.
      */
-    if (!conn->modified && ckpt_cfg->use_timestamp &&
-      txn_global->last_ckpt_timestamp != WT_TS_NONE &&
-      txn_global->last_ckpt_timestamp == __wt_get_stable_timestamp(session) &&
+    last_ckpt_ts = __wt_atomic_load_uint64_relaxed(&txn_global->last_ckpt_timestamp);
+    if (!conn->modified && ckpt_cfg->use_timestamp && last_ckpt_ts != WT_TS_NONE &&
+      last_ckpt_ts == __wt_get_stable_timestamp(session) &&
       txn_global->last_ckpt_disaggregated_schema_epoch ==
         __wt_get_stable_disaggregated_schema_epoch(session)) {
         ckpt_cfg->can_skip = true;
@@ -1892,14 +1894,14 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
          * than recovery timestamp. This could potentially avoid MongoDB making two calls to
          * determine last stable recovery timestamp.
          *
-         * The store is atomic-relaxed to pair with the relaxed load in sweep.
+         * The store is release to pair with the acquire load in sweep.
          */
         if (ckpt_tmp_ts == WT_TS_NONE)
             ckpt_tmp_ts = conn->txn_global.recovery_timestamp;
-        __wt_atomic_store_uint64_relaxed(&conn->txn_global.last_ckpt_timestamp, ckpt_tmp_ts);
+        __wt_atomic_store_uint64_release(&conn->txn_global.last_ckpt_timestamp, ckpt_tmp_ts);
     } else {
         conn->txn_global.last_ckpt_disaggregated_schema_epoch = WT_TS_NONE;
-        __wt_atomic_store_uint64_relaxed(&conn->txn_global.last_ckpt_timestamp, WT_TS_NONE);
+        __wt_atomic_store_uint64_release(&conn->txn_global.last_ckpt_timestamp, WT_TS_NONE);
     }
 
     /* Disaggregated storage database size accounting. */

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -1884,7 +1884,6 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
      */
     if (ckpt_cfg.use_timestamp) {
         conn->txn_global.last_ckpt_disaggregated_schema_epoch = ckpt_disagg_schema_epoch;
-        conn->txn_global.last_ckpt_timestamp = ckpt_tmp_ts;
         /*
          * MongoDB assumes the checkpoint timestamp will be initialized with WT_TS_NONE. In such
          * cases it queries the recovery timestamp to determine the last stable recovery timestamp.
@@ -1892,12 +1891,15 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
          * timestamp. This should never be a problem, as checkpoint timestamp should never be less
          * than recovery timestamp. This could potentially avoid MongoDB making two calls to
          * determine last stable recovery timestamp.
+         *
+         * The store is atomic-relaxed to pair with the relaxed load in sweep.
          */
-        if (conn->txn_global.last_ckpt_timestamp == WT_TS_NONE)
-            conn->txn_global.last_ckpt_timestamp = conn->txn_global.recovery_timestamp;
+        if (ckpt_tmp_ts == WT_TS_NONE)
+            ckpt_tmp_ts = conn->txn_global.recovery_timestamp;
+        __wt_atomic_store_uint64_relaxed(&conn->txn_global.last_ckpt_timestamp, ckpt_tmp_ts);
     } else {
         conn->txn_global.last_ckpt_disaggregated_schema_epoch = WT_TS_NONE;
-        conn->txn_global.last_ckpt_timestamp = WT_TS_NONE;
+        __wt_atomic_store_uint64_relaxed(&conn->txn_global.last_ckpt_timestamp, WT_TS_NONE);
     }
 
     /* Disaggregated storage database size accounting. */

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -133,7 +133,11 @@ __checkpoint_flush_tier(WT_SESSION_IMPL *session, bool force)
     __wt_atomic_store_bool_relaxed(&conn->tiered.flush_ckpt_complete, false);
     /* Flushing is part of a checkpoint, use the session's checkpoint time. */
     conn->tiered.flush_most_recent = session->ckpt.current_sec;
-    /* Storing the last flush timestamp here for the future and for debugging. */
+    /*
+     * The load is relaxed rather than acquire: this runs on the checkpoint thread, under the
+     * checkpoint lock, which is the same thread that publishes the timestamp. The value is only
+     * copied for future and debugging use.
+     */
     conn->tiered.flush_ts = __wt_atomic_load_uint64_relaxed(&conn->txn_global.last_ckpt_timestamp);
     /*
      * It would be more efficient to return here if no tiered storage is enabled in the system. If

--- a/src/conn/conn_layered_checkpoint_pick_up.c
+++ b/src/conn/conn_layered_checkpoint_pick_up.c
@@ -847,7 +847,9 @@ __disagg_finalize_checkpoint_meta(WT_SESSION_IMPL *session,
     __wt_atomic_store_uint64_release(
       &conn->disaggregated_storage.last_checkpoint_oldest_timestamp, metadata->oldest_timestamp);
     conn->txn_global.last_ckpt_disaggregated_schema_epoch = metadata->schema_epoch;
-    conn->txn_global.last_ckpt_timestamp = metadata->checkpoint_timestamp;
+    /* Atomic-relaxed store to pair with the relaxed load in sweep. */
+    __wt_atomic_store_uint64_relaxed(
+      &conn->txn_global.last_ckpt_timestamp, metadata->checkpoint_timestamp);
 
     /* Set the database size. */
     __wt_disagg_set_database_size(session, ckpt_meta->database_size);

--- a/src/conn/conn_layered_checkpoint_pick_up.c
+++ b/src/conn/conn_layered_checkpoint_pick_up.c
@@ -847,8 +847,8 @@ __disagg_finalize_checkpoint_meta(WT_SESSION_IMPL *session,
     __wt_atomic_store_uint64_release(
       &conn->disaggregated_storage.last_checkpoint_oldest_timestamp, metadata->oldest_timestamp);
     conn->txn_global.last_ckpt_disaggregated_schema_epoch = metadata->schema_epoch;
-    /* Atomic-relaxed store to pair with the relaxed load in sweep. */
-    __wt_atomic_store_uint64_relaxed(
+    /* Release store to pair with the acquire load in sweep. */
+    __wt_atomic_store_uint64_release(
       &conn->txn_global.last_ckpt_timestamp, metadata->checkpoint_timestamp);
 
     /* Set the database size. */

--- a/src/conn/conn_sweep.c
+++ b/src/conn/conn_sweep.c
@@ -169,7 +169,7 @@ __sweep_close_dhandle_locked(WT_SESSION_IMPL *session)
         wt_timestamp_t max_write_ts = __wt_atomic_load_uint64_relaxed(&btree->max_ingest_write_ts);
         if (max_write_ts == WT_TS_NONE ||
           max_write_ts >
-            __wt_atomic_load_uint64_relaxed(&S2C(session)->txn_global.last_ckpt_timestamp))
+            __wt_atomic_load_uint64_acquire(&S2C(session)->txn_global.last_ckpt_timestamp))
             return (0);
     }
 

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -763,7 +763,8 @@ struct __wt_conn_tiered {
 #define WT_CONN_HOTBACKUP_START(conn)                                                          \
     do {                                                                                       \
         WT_ASSERT(session, FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_HOTBACKUP_WRITE)); \
-        (conn)->backup.timestamp = (conn)->txn_global.last_ckpt_timestamp;                     \
+        (conn)->backup.timestamp =                                                             \
+          __wt_atomic_load_uint64_relaxed(&(conn)->txn_global.last_ckpt_timestamp);            \
         __wt_atomic_store_uint64_relaxed(&(conn)->backup.start, (conn)->ckpt.most_recent);     \
         (conn)->backup.list = NULL;                                                            \
     } while (0)

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -764,7 +764,7 @@ struct __wt_conn_tiered {
     do {                                                                                       \
         WT_ASSERT(session, FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_HOTBACKUP_WRITE)); \
         (conn)->backup.timestamp =                                                             \
-          __wt_atomic_load_uint64_relaxed(&(conn)->txn_global.last_ckpt_timestamp);            \
+          __wt_atomic_load_uint64_acquire(&(conn)->txn_global.last_ckpt_timestamp);            \
         __wt_atomic_store_uint64_relaxed(&(conn)->backup.start, (conn)->ckpt.most_recent);     \
         (conn)->backup.list = NULL;                                                            \
     } while (0)

--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -185,6 +185,11 @@ struct __wt_txn_global {
 
     wt_shared wt_timestamp_t durable_timestamp;
     wt_shared wt_timestamp_t last_ckpt_disaggregated_schema_epoch;
+    /*
+     * Release-stored by checkpoint once its durable state is established, acquire-loaded by sweep
+     * so that observing the timestamp guarantees the checkpoint's state is visible before an ingest
+     * table is dropped.
+     */
     wt_shared wt_timestamp_t last_ckpt_timestamp;
     wt_timestamp_t meta_ckpt_timestamp;
     wt_shared wt_timestamp_t oldest_timestamp;

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -205,7 +205,7 @@ __txn_global_query_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t *tsp, cons
         ts = WT_TS_NONE;
         WT_WITH_HOTBACKUP_READ_LOCK_BACKUP(session, ts = conn->backup.timestamp, NULL);
     } else if (WT_CONFIG_LIT_MATCH("last_checkpoint", cval))
-        ts = __wt_atomic_load_uint64_relaxed(&txn_global->last_ckpt_timestamp);
+        ts = __wt_atomic_load_uint64_acquire(&txn_global->last_ckpt_timestamp);
     else if (WT_CONFIG_LIT_MATCH("last_disaggregated_schema_epoch", cval))
         ts = __wt_atomic_load_uint64_acquire(&txn_global->last_ckpt_disaggregated_schema_epoch);
     else if (WT_CONFIG_LIT_MATCH("oldest_timestamp", cval) || WT_CONFIG_LIT_MATCH("oldest", cval))

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -204,11 +204,9 @@ __txn_global_query_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t *tsp, cons
         /* This code will return set a timestamp only if a backup cursor is open. */
         ts = WT_TS_NONE;
         WT_WITH_HOTBACKUP_READ_LOCK_BACKUP(session, ts = conn->backup.timestamp, NULL);
-    } else if (WT_CONFIG_LIT_MATCH("last_checkpoint", cval)) {
-        /* Read-only value forever. Make sure we don't used a cached version. */
-        WT_COMPILER_BARRIER();
-        ts = txn_global->last_ckpt_timestamp;
-    } else if (WT_CONFIG_LIT_MATCH("last_disaggregated_schema_epoch", cval))
+    } else if (WT_CONFIG_LIT_MATCH("last_checkpoint", cval))
+        ts = __wt_atomic_load_uint64_relaxed(&txn_global->last_ckpt_timestamp);
+    else if (WT_CONFIG_LIT_MATCH("last_disaggregated_schema_epoch", cval))
         ts = __wt_atomic_load_uint64_acquire(&txn_global->last_ckpt_disaggregated_schema_epoch);
     else if (WT_CONFIG_LIT_MATCH("oldest_timestamp", cval) || WT_CONFIG_LIT_MATCH("oldest", cval))
         ts = __wt_get_oldest_timestamp(session);


### PR DESCRIPTION
TSAN reports a data race on `txn_global.last_ckpt_timestamp`. The sweep server reads the field concurrently while the checkpoint code writes it with a  plain,  non-atomic store, with no common lock between the two threads:
  - Read: sweep server, in `__sweep_close_dhandle_locked`, to decide whether an ingest table can be closed.
  - Write: checkpoint thread, in `__checkpoint_db_internal` and in the disaggregated checkpoint pick-up path, when publishing the completed checkpoint timestamp.
The checkpoint writers are mutually exclusive (serialized by the checkpoint lock), so the race is strictly read-vs-write: sweep does not take that  lock.