### PR TITLE
WT-18002 Roll back truncate that pins too much dirty cache

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -1610,8 +1610,9 @@ session_stats = [
     SessionStat('lock_dhandle_wait', 'dhandle lock wait time (usecs)'),
     SessionStat('lock_schema_wait', 'schema lock wait time (usecs)'),
     SessionStat('read_time', 'page read from disk to cache time (usecs)'),
-    SessionStat('txn_bytes_dirty', 'dirty bytes in this txn', 'no_clear,no_scale,size'),
+    SessionStat('txn_bytes_dirty', 'dirty bytes in this txn, from both updates and fast-truncate', 'no_clear,no_scale,size'),
     SessionStat('txn_truncate_bytes_dirty', 'dirty bytes pinned by fast-truncate in this txn', 'no_clear,no_scale,size'),
     SessionStat('txn_updates', 'number of updates in this txn', 'no_clear,no_scale,size'),
+    SessionStat('txn_updates_bytes_dirty', 'dirty bytes from updates in this txn', 'no_clear,no_scale,size'),
     SessionStat('write_time', 'page write from cache to disk time (usecs)'),
 ]

--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -1033,6 +1033,7 @@ conn_stats = [
     TxnStat('txn_stepdown_epoch_set', 'step-down disaggregated schema epoch is currently set', 'no_clear,no_scale'),
     TxnStat('txn_stepdown_ts_set', 'step-down timestamp is currently set', 'no_clear,no_scale'),
     TxnStat('txn_timestamp_oldest_active_read', 'transaction read timestamp of the oldest active reader', 'no_clear,no_scale'),
+    TxnStat('txn_truncate_dirty_cache_rollback', 'truncate operations rolled back because they pinned too much dirty cache'),
     TxnStat('txn_walk_sessions', 'transaction walk of concurrent sessions'),
 
     ##########################################

--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -359,6 +359,7 @@ conn_stats = [
     CacheStat('cache_shared_dsk_lock_contention', 'shared disk bucket lock contention count'),
     CacheStat('cache_shared_dsk_miss', 'shared disk miss'),
     CacheStat('cache_tolerance_level', 'cache tolerance configured', 'no_clear,no_scale,size'),
+    CacheStat('cache_truncate_txn_uncommitted_bytes', 'pages dirtied by fast-truncate in uncommitted txn - bytes', 'no_clear,no_scale,size'),
     CacheStat('cache_updates_txn_uncommitted_bytes', 'updates in uncommitted txn - bytes', 'no_clear,no_scale,size'),
     CacheStat('cache_updates_txn_uncommitted_count', 'updates in uncommitted txn - count', 'no_clear,no_scale,size'),
     CacheStat('cache_write_app_count', 'application threads page write from cache to disk count'),
@@ -1610,6 +1611,7 @@ session_stats = [
     SessionStat('lock_schema_wait', 'schema lock wait time (usecs)'),
     SessionStat('read_time', 'page read from disk to cache time (usecs)'),
     SessionStat('txn_bytes_dirty', 'dirty bytes in this txn', 'no_clear,no_scale,size'),
+    SessionStat('txn_truncate_bytes_dirty', 'dirty bytes pinned by fast-truncate in this txn', 'no_clear,no_scale,size'),
     SessionStat('txn_updates', 'number of updates in this txn', 'no_clear,no_scale,size'),
     SessionStat('write_time', 'page write from cache to disk time (usecs)'),
 ]

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -91,6 +91,7 @@ __wti_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
     WT_DECL_RET;
     WT_PAGE *parent;
     WT_REF_STATE previous_state;
+    size_t footprint;
     WT_BTREE *btree = S2BT(session);
     bool parent_was_clean;
 
@@ -217,10 +218,23 @@ __wti_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
      * A newly dirtied parent internal page stays pinned until the truncate is stable. Account for
      * it and let the transaction's cache-pressure check roll the truncate back if it has pinned too
      * much; the delete just performed unwinds normally on rollback.
+     *
+     * Skipped for the history store, whose truncation is non-transactional: there would be no
+     * transaction to bound, and none to resolve and give back the bytes counted below.
      */
-    if (parent_was_clean) {
-        session->txn->truncate_dirty_bytes +=
-          __wt_atomic_load_size_relaxed(&parent->memory_footprint);
+    if (parent_was_clean && !WT_IS_HS(session->dhandle)) {
+        footprint = __wt_atomic_load_size_relaxed(&parent->memory_footprint);
+        session->txn->truncate_dirty_bytes += footprint;
+
+        /*
+         * These pages are dirty content the transaction has not resolved, so they belong in its
+         * dirty-byte tracking. Increment the session and connection counters together: the drain
+         * unwinds the connection counter by the session counter's value, so the two must record the
+         * same bytes. The update counts are left alone, since no update was created.
+         */
+        WT_STAT_CONN_INCRV_ATOMIC(session, cache_updates_txn_uncommitted_bytes, (int64_t)footprint);
+        WT_STAT_SESSION_INCRV(session, txn_bytes_dirty, (int64_t)footprint);
+
         /*
          * The delete is complete and registered as a transaction operation, so transaction rollback
          * frees page_del and restores the ref: return directly rather than through the error path

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -227,13 +227,12 @@ __wti_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
         session->txn->truncate_dirty_bytes += footprint;
 
         /*
-         * These pages are dirty content the transaction has not resolved, so they belong in its
-         * dirty-byte tracking. Increment the session and connection counters together: the drain
-         * unwinds the connection counter by the session counter's value, so the two must record the
-         * same bytes. The update counts are left alone, since no update was created.
+         * These pages are dirty content the transaction has not resolved, tracked separately from
+         * update content: a truncate creates no updates.
          */
-        WT_STAT_CONN_INCRV_ATOMIC(session, cache_updates_txn_uncommitted_bytes, (int64_t)footprint);
-        WT_STAT_SESSION_INCRV(session, txn_bytes_dirty, (int64_t)footprint);
+        WT_STAT_CONN_INCRV_ATOMIC(
+          session, cache_truncate_txn_uncommitted_bytes, (int64_t)footprint);
+        WT_STAT_SESSION_INCRV(session, txn_truncate_bytes_dirty, (int64_t)footprint);
 
         /*
          * The delete is complete and registered as a transaction operation, so transaction rollback

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -81,29 +81,6 @@
  */
 
 /*
- * The fraction of the cache-wide dirty budget one truncate may pin before it is rolled back;
- * leaving no headroom risks stalling the cache. The fraction is a heuristic.
- */
-#define WT_TRUNCATE_DIRTY_BUDGET_PCT 75
-
-/*
- * __delete_truncate_dirty_exceeded --
- *     Return whether the running transaction's fast-truncate has pinned enough dirty internal-page
- *     content to approach the cache's dirty eviction threshold.
- */
-static bool
-__delete_truncate_dirty_exceeded(WT_SESSION_IMPL *session)
-{
-    WT_CONNECTION_IMPL *conn = S2C(session);
-    double dirty_trigger = __wt_atomic_load_double_relaxed(&conn->evict->eviction_dirty_trigger);
-    uint64_t bytes_max = __wt_tsan_suppress_load_uint64_v(&conn->cache_size) + 1;
-    uint64_t threshold =
-      (uint64_t)(dirty_trigger * (double)bytes_max) / 100 * WT_TRUNCATE_DIRTY_BUDGET_PCT / 100;
-
-    return (session->txn->truncate_dirty_bytes >= threshold);
-}
-
-/*
  * __wti_delete_page --
  *     If deleting a range, try to delete the page without instantiating it.
  */
@@ -239,23 +216,22 @@ __wti_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
     WT_REF_SET_STATE(ref, WT_REF_DELETED);
 
     /*
-     * Newly dirtied parent internal pages stay pinned until the truncate is stable; if one truncate
-     * pins too much, roll it back rather than let the cache stall. The delete unwinds normally.
+     * A newly dirtied parent internal page stays pinned until the truncate is stable. Account for
+     * it and let the transaction's cache-pressure check roll the truncate back if it has pinned too
+     * much; the delete just performed unwinds normally on rollback.
      */
     if (parent_was_clean) {
         session->txn->truncate_dirty_bytes +=
           __wt_atomic_load_size_relaxed(&parent->memory_footprint);
-        if (__delete_truncate_dirty_exceeded(session)) {
-            WT_STAT_CONN_INCR(session, txn_truncate_dirty_cache_rollback);
-            __wt_verbose_warning(session, WT_VERB_TRANSACTION,
-              "truncate rolled back: pinned %" PRIu64
-              " bytes of dirty internal pages, exceeding the cache dirty threshold",
-              session->txn->truncate_dirty_bytes);
-            return (WT_ROLLBACK);
-        }
+        /*
+         * A cache-pressure rollback here must not run the error path below: the delete is already a
+         * committed transaction operation that unwinds on rollback, and its page_del is owned by
+         * the transaction. Return the result directly.
+         */
+        ret = __wt_txn_is_blocking(session);
     }
 
-    return (0);
+    return (ret);
 
 err:
     __wt_free(session, ref->page_del);

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -222,9 +222,9 @@ __wti_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
         session->txn->truncate_dirty_bytes +=
           __wt_atomic_load_size_relaxed(&parent->memory_footprint);
         /*
-         * A cache-pressure rollback here must not run the error path below: the delete is already a
-         * committed transaction operation that unwinds on rollback, and its page_del is owned by
-         * the transaction. Return the result directly.
+         * The delete is complete and registered as a transaction operation, so transaction rollback
+         * frees page_del and restores the ref: return directly rather than through the error path
+         * below.
          */
         ret = __wt_txn_is_blocking(session);
     }

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -81,11 +81,8 @@
  */
 
 /*
- * Cap a single truncate at a fraction of the cache-wide dirty eviction budget. A truncate that
- * alone approaches the whole budget leaves no room for the rest of the workload and risks stalling
- * the cache with content that cannot be evicted until the truncate is stable. The fraction is a
- * heuristic: high enough to allow large legitimate truncates, low enough to keep headroom for
- * concurrent activity.
+ * The fraction of the cache-wide dirty budget one truncate may pin before it is rolled back;
+ * leaving no headroom risks stalling the cache. The fraction is a heuristic.
  */
 #define WT_TRUNCATE_DIRTY_BUDGET_PCT 75
 
@@ -97,14 +94,10 @@
 static bool
 __delete_truncate_dirty_exceeded(WT_SESSION_IMPL *session)
 {
-    WT_CONNECTION_IMPL *conn;
-    double dirty_trigger;
-    uint64_t bytes_max, threshold;
-
-    conn = S2C(session);
-    dirty_trigger = __wt_atomic_load_double_relaxed(&conn->evict->eviction_dirty_trigger);
-    bytes_max = __wt_tsan_suppress_load_uint64_v(&conn->cache_size) + 1;
-    threshold =
+    WT_CONNECTION_IMPL *conn = S2C(session);
+    double dirty_trigger = __wt_atomic_load_double_relaxed(&conn->evict->eviction_dirty_trigger);
+    uint64_t bytes_max = __wt_tsan_suppress_load_uint64_v(&conn->cache_size) + 1;
+    uint64_t threshold =
       (uint64_t)(dirty_trigger * (double)bytes_max) / 100 * WT_TRUNCATE_DIRTY_BUDGET_PCT / 100;
 
     return (session->txn->truncate_dirty_bytes >= threshold);
@@ -119,11 +112,8 @@ __wti_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
 {
     WT_ADDR_COPY addr;
     WT_DECL_RET;
-    WT_PAGE *parent;
-    WT_PAGE_MODIFY *parent_mod;
     WT_REF_STATE previous_state;
     WT_BTREE *btree = S2BT(session);
-    bool parent_was_clean;
 
     *skipp = false;
 
@@ -210,14 +200,17 @@ __wti_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
 
     /*
      * This action dirties the parent page: mark it dirty now, there's no future reconciliation of
-     * the child leaf page that will dirty it as we write the tree. Note whether the parent was
-     * already dirty: if we're the first to dirty it, this truncate has pulled a fresh internal page
-     * into dirty cache and we attribute its footprint to the transaction below.
+     * the child leaf page that will dirty it as we write the tree.
      */
-    parent = ref->home;
-    parent_mod = __wt_tsan_suppress_load_wt_page_modify_ptr(&parent->modify);
-    parent_was_clean = parent_mod == NULL ||
-      __wt_atomic_load_uint32_relaxed(&parent_mod->page_state) == WT_PAGE_CLEAN;
+    WT_PAGE *parent = ref->home;
+
+    /* If we are the first to dirty the parent, this truncate pulled it into dirty cache. */
+    WT_PAGE_MODIFY *parent_mod = __wt_tsan_suppress_load_wt_page_modify_ptr(&parent->modify);
+    bool parent_was_clean = true;
+    if (parent_mod != NULL &&
+      __wt_atomic_load_uint32_relaxed(&parent_mod->page_state) != WT_PAGE_CLEAN)
+        parent_was_clean = false;
+
     WT_ERR(__wt_page_parent_modify_set(session, ref, false));
 
     /*
@@ -246,11 +239,8 @@ __wti_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
     WT_REF_SET_STATE(ref, WT_REF_DELETED);
 
     /*
-     * Track the dirty cache this fast-truncate has pinned in the transaction. Each freshly dirtied
-     * parent internal page must stay in cache until the truncate is stable. If a single truncate
-     * pins enough dirty internal-page content to approach the cache's dirty eviction threshold, the
-     * system can stall indefinitely with no way to make progress. Force the transaction to roll
-     * back instead: the delete just performed is a transactional operation that unwinds normally.
+     * Newly dirtied parent internal pages stay pinned until the truncate is stable; if one truncate
+     * pins too much, roll it back rather than let the cache stall. The delete unwinds normally.
      */
     if (parent_was_clean) {
         session->txn->truncate_dirty_bytes +=

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -90,7 +90,6 @@ __wti_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
     WT_ADDR_COPY addr;
     WT_DECL_RET;
     WT_PAGE *parent;
-    WT_PAGE_MODIFY *parent_mod;
     WT_REF_STATE previous_state;
     WT_BTREE *btree = S2BT(session);
     bool parent_was_clean;
@@ -185,11 +184,7 @@ __wti_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
     parent = ref->home;
 
     /* If we are the first to dirty the parent, this truncate pulled it into dirty cache. */
-    parent_mod = __wt_tsan_suppress_load_wt_page_modify_ptr(&parent->modify);
-    parent_was_clean = true;
-    if (parent_mod != NULL &&
-      __wt_atomic_load_uint32_relaxed(&parent_mod->page_state) != WT_PAGE_CLEAN)
-        parent_was_clean = false;
+    parent_was_clean = !__wt_page_is_modified(parent);
 
     WT_ERR(__wt_page_parent_modify_set(session, ref, false));
 

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -81,6 +81,36 @@
  */
 
 /*
+ * Cap a single truncate at a fraction of the cache-wide dirty eviction budget. A truncate that
+ * alone approaches the whole budget leaves no room for the rest of the workload and risks stalling
+ * the cache with content that cannot be evicted until the truncate is stable. The fraction is a
+ * heuristic: high enough to allow large legitimate truncates, low enough to keep headroom for
+ * concurrent activity.
+ */
+#define WT_TRUNCATE_DIRTY_BUDGET_PCT 75
+
+/*
+ * __delete_truncate_dirty_exceeded --
+ *     Return whether the running transaction's fast-truncate has pinned enough dirty internal-page
+ *     content to approach the cache's dirty eviction threshold.
+ */
+static bool
+__delete_truncate_dirty_exceeded(WT_SESSION_IMPL *session)
+{
+    WT_CONNECTION_IMPL *conn;
+    double dirty_trigger;
+    uint64_t bytes_max, threshold;
+
+    conn = S2C(session);
+    dirty_trigger = __wt_atomic_load_double_relaxed(&conn->evict->eviction_dirty_trigger);
+    bytes_max = __wt_tsan_suppress_load_uint64_v(&conn->cache_size) + 1;
+    threshold =
+      (uint64_t)(dirty_trigger * (double)bytes_max) / 100 * WT_TRUNCATE_DIRTY_BUDGET_PCT / 100;
+
+    return (session->txn->truncate_dirty_bytes >= threshold);
+}
+
+/*
  * __wti_delete_page --
  *     If deleting a range, try to delete the page without instantiating it.
  */
@@ -89,8 +119,11 @@ __wti_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
 {
     WT_ADDR_COPY addr;
     WT_DECL_RET;
+    WT_PAGE *parent;
+    WT_PAGE_MODIFY *parent_mod;
     WT_REF_STATE previous_state;
     WT_BTREE *btree = S2BT(session);
+    bool parent_was_clean;
 
     *skipp = false;
 
@@ -177,8 +210,14 @@ __wti_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
 
     /*
      * This action dirties the parent page: mark it dirty now, there's no future reconciliation of
-     * the child leaf page that will dirty it as we write the tree.
+     * the child leaf page that will dirty it as we write the tree. Note whether the parent was
+     * already dirty: if we're the first to dirty it, this truncate has pulled a fresh internal page
+     * into dirty cache and we attribute its footprint to the transaction below.
      */
+    parent = ref->home;
+    parent_mod = __wt_tsan_suppress_load_wt_page_modify_ptr(&parent->modify);
+    parent_was_clean = parent_mod == NULL ||
+      __wt_atomic_load_uint32_relaxed(&parent_mod->page_state) == WT_PAGE_CLEAN;
     WT_ERR(__wt_page_parent_modify_set(session, ref, false));
 
     /*
@@ -205,6 +244,27 @@ __wti_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
 
     /* Set the page to its new state. */
     WT_REF_SET_STATE(ref, WT_REF_DELETED);
+
+    /*
+     * Track the dirty cache this fast-truncate has pinned in the transaction. Each freshly dirtied
+     * parent internal page must stay in cache until the truncate is stable. If a single truncate
+     * pins enough dirty internal-page content to approach the cache's dirty eviction threshold, the
+     * system can stall indefinitely with no way to make progress. Force the transaction to roll
+     * back instead: the delete just performed is a transactional operation that unwinds normally.
+     */
+    if (parent_was_clean) {
+        session->txn->truncate_dirty_bytes +=
+          __wt_atomic_load_size_relaxed(&parent->memory_footprint);
+        if (__delete_truncate_dirty_exceeded(session)) {
+            WT_STAT_CONN_INCR(session, txn_truncate_dirty_cache_rollback);
+            __wt_verbose_warning(session, WT_VERB_TRANSACTION,
+              "truncate rolled back: pinned %" PRIu64
+              " bytes of dirty internal pages, exceeding the cache dirty threshold",
+              session->txn->truncate_dirty_bytes);
+            return (WT_ROLLBACK);
+        }
+    }
+
     return (0);
 
 err:

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -227,6 +227,9 @@ __wti_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
          * below.
          */
         ret = __wt_txn_is_blocking(session);
+        if (ret == WT_ROLLBACK)
+            __wt_verbose_warning(session, WT_VERB_TRANSACTION, "%s",
+              "rolling back a truncate that is pinning too much dirty cache");
     }
 
     return (ret);

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -233,6 +233,7 @@ __wti_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
         WT_STAT_CONN_INCRV_ATOMIC(
           session, cache_truncate_txn_uncommitted_bytes, (int64_t)footprint);
         WT_STAT_SESSION_INCRV(session, txn_truncate_bytes_dirty, (int64_t)footprint);
+        WT_STAT_SESSION_INCRV(session, txn_bytes_dirty, (int64_t)footprint);
 
         /*
          * The delete is complete and registered as a transaction operation, so transaction rollback

--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -89,8 +89,11 @@ __wti_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
 {
     WT_ADDR_COPY addr;
     WT_DECL_RET;
+    WT_PAGE *parent;
+    WT_PAGE_MODIFY *parent_mod;
     WT_REF_STATE previous_state;
     WT_BTREE *btree = S2BT(session);
+    bool parent_was_clean;
 
     *skipp = false;
 
@@ -179,11 +182,11 @@ __wti_delete_page(WT_SESSION_IMPL *session, WT_REF *ref, bool *skipp)
      * This action dirties the parent page: mark it dirty now, there's no future reconciliation of
      * the child leaf page that will dirty it as we write the tree.
      */
-    WT_PAGE *parent = ref->home;
+    parent = ref->home;
 
     /* If we are the first to dirty the parent, this truncate pulled it into dirty cache. */
-    WT_PAGE_MODIFY *parent_mod = __wt_tsan_suppress_load_wt_page_modify_ptr(&parent->modify);
-    bool parent_was_clean = true;
+    parent_mod = __wt_tsan_suppress_load_wt_page_modify_ptr(&parent->modify);
+    parent_was_clean = true;
     if (parent_mod != NULL &&
       __wt_atomic_load_uint32_relaxed(&parent_mod->page_state) != WT_PAGE_CLEAN)
         parent_was_clean = false;

--- a/src/cursor/cur_stat.c
+++ b/src/cursor/cur_stat.c
@@ -734,13 +734,6 @@ __curstat_session_init(WT_SESSION_IMPL *session, WT_CURSOR_STAT *cst)
      * Copy stats from the session to the cursor. Optionally clear the session's statistics.
      */
     memcpy(&cst->u.session_stats, &session->stats, sizeof(WT_SESSION_STATS));
-
-    /*
-     * Report the transaction's whole dirty footprint. Update and fast-truncate content is tracked
-     * apart so that each unwinds its own connection counter, but callers want the total.
-     */
-    cst->u.session_stats.txn_bytes_dirty += cst->u.session_stats.txn_truncate_bytes_dirty;
-
     if (F_ISSET(cst, WT_STAT_CLEAR))
         __wt_stat_session_clear_single(&session->stats);
 

--- a/src/cursor/cur_stat.c
+++ b/src/cursor/cur_stat.c
@@ -734,6 +734,13 @@ __curstat_session_init(WT_SESSION_IMPL *session, WT_CURSOR_STAT *cst)
      * Copy stats from the session to the cursor. Optionally clear the session's statistics.
      */
     memcpy(&cst->u.session_stats, &session->stats, sizeof(WT_SESSION_STATS));
+
+    /*
+     * Report the transaction's whole dirty footprint. Update and fast-truncate content is tracked
+     * apart so that each unwinds its own connection counter, but callers want the total.
+     */
+    cst->u.session_stats.txn_bytes_dirty += cst->u.session_stats.txn_truncate_bytes_dirty;
+
     if (F_ISSET(cst, WT_STAT_CLEAR))
         __wt_stat_session_clear_single(&session->stats);
 

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -741,6 +741,7 @@ struct __wt_connection_stats {
     int64_t cache_pages_inuse;
     int64_t cache_pages_inuse_ingest;
     int64_t cache_pages_inuse_stable;
+    int64_t cache_truncate_txn_uncommitted_bytes;
     int64_t cache_eviction_dirty_obsolete_tw;
     int64_t cache_eviction_ahead_of_last_materialized_lsn;
     int64_t eviction_pages_in_parallel_with_checkpoint;
@@ -1952,6 +1953,7 @@ struct __wt_session_stats {
     int64_t bytes_write;
     int64_t lock_dhandle_wait;
     int64_t txn_bytes_dirty;
+    int64_t txn_truncate_bytes_dirty;
     int64_t txn_updates;
     int64_t read_time;
     int64_t write_time;

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -1490,6 +1490,7 @@ struct __wt_connection_stats {
     int64_t txn_commit;
     int64_t txn_rollback;
     int64_t txn_rollback_too_large_for_cache;
+    int64_t txn_truncate_dirty_cache_rollback;
     int64_t txn_update_conflict;
     int64_t txn_rollback_stepdown;
 };

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -1952,6 +1952,7 @@ struct __wt_session_stats {
     int64_t bytes_read;
     int64_t bytes_write;
     int64_t lock_dhandle_wait;
+    int64_t txn_updates_bytes_dirty;
     int64_t txn_bytes_dirty;
     int64_t txn_truncate_bytes_dirty;
     int64_t txn_updates;

--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -482,12 +482,7 @@ struct __wt_txn {
      */
     uint64_t bytes_dirty;
 
-    /*
-     * Dirty cache pinned by this transaction's fast-truncate. Fast-truncate leaves leaf pages on
-     * disk but pulls in and dirties their parent internal pages, which cannot be reconciled until
-     * the truncate is stable. Tracked so a single truncate that would pin enough dirty content to
-     * stall the cache can be rolled back rather than wedging the system.
-     */
+    /* Dirty internal-page cache pinned by this transaction's fast-truncate, used to bound it. */
     uint64_t truncate_dirty_bytes;
 
     /* Checkpoint status. */

--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -482,6 +482,14 @@ struct __wt_txn {
      */
     uint64_t bytes_dirty;
 
+    /*
+     * Dirty cache pinned by this transaction's fast-truncate. Fast-truncate leaves leaf pages on
+     * disk but pulls in and dirties their parent internal pages, which cannot be reconciled until
+     * the truncate is stable. Tracked so a single truncate that would pin enough dirty content to
+     * stall the cache can be rolled back rather than wedging the system.
+     */
+    uint64_t truncate_dirty_bytes;
+
     /* Checkpoint status. */
     WT_LSN ckpt_lsn;
     uint32_t ckpt_nsnapshot;

--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -478,11 +478,11 @@ struct __wt_txn {
 #endif
 
     /*
-     * Cache bytes this transaction has dirtied and not yet resolved. Eviction cannot reclaim these
-     * bytes, so it is maintained unconditionally rather than tracked only through the equivalent
-     * session statistic.
+     * Cache bytes this transaction's updates have dirtied and not yet resolved. Eviction cannot
+     * reclaim these bytes, so it is maintained unconditionally rather than tracked only through the
+     * equivalent session statistic.
      */
-    uint64_t bytes_dirty;
+    uint64_t update_dirty_bytes;
 
     /* Dirty internal-page cache pinned by this transaction's fast-truncate, used to bound it. */
     uint64_t truncate_dirty_bytes;

--- a/src/include/txn.h
+++ b/src/include/txn.h
@@ -37,6 +37,8 @@
     "Write transaction straddled the step-down timestamp setting boundary"
 #define WT_TXN_ROLLBACK_REASON_TOO_LARGE_FOR_CACHE \
     "Transaction dirty content alone exceeds the eviction updates or dirty trigger"
+#define WT_TXN_ROLLBACK_REASON_TRUNCATE_DIRTY \
+    "Truncate pinned too much dirty cache in the transaction"
 
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */
 #define WT_TXN_LOG_CKPT_CLEANUP 0x01u

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1901,7 +1901,7 @@ __txn_incr_bytes_dirty(WT_SESSION_IMPL *session, size_t size, bool new_update)
     if (__wt_session_gen(session, WT_GEN_EVICT) != 0)
         return;
 
-    session->txn->bytes_dirty += size;
+    session->txn->update_dirty_bytes += size;
 
     WT_STAT_CONN_INCRV_ATOMIC(session, cache_updates_txn_uncommitted_bytes, (int64_t)size);
     WT_STAT_CONN_INCRV_ATOMIC(session, cache_updates_txn_uncommitted_count, 1);
@@ -1918,7 +1918,7 @@ __txn_clear_bytes_dirty(WT_SESSION_IMPL *session)
 {
     int64_t val;
 
-    session->txn->bytes_dirty = 0;
+    session->txn->update_dirty_bytes = 0;
 
     val = WT_STAT_SESSION_READ(&(session)->stats, txn_bytes_dirty);
     if (val != 0) {

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1919,6 +1919,7 @@ __txn_clear_bytes_dirty(WT_SESSION_IMPL *session)
     int64_t val;
 
     session->txn->update_dirty_bytes = 0;
+    session->txn->truncate_dirty_bytes = 0;
 
     val = WT_STAT_SESSION_READ(&(session)->stats, txn_bytes_dirty);
     if (val != 0) {

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1927,6 +1927,12 @@ __txn_clear_bytes_dirty(WT_SESSION_IMPL *session)
         WT_STAT_SESSION_SET(session, txn_bytes_dirty, 0);
     }
 
+    val = WT_STAT_SESSION_READ(&(session)->stats, txn_truncate_bytes_dirty);
+    if (val != 0) {
+        WT_STAT_CONN_DECRV_ATOMIC(session, cache_truncate_txn_uncommitted_bytes, val);
+        WT_STAT_SESSION_SET(session, txn_truncate_bytes_dirty, 0);
+    }
+
     val = WT_STAT_SESSION_READ(&(session)->stats, txn_updates);
     if (val != 0) {
         WT_STAT_CONN_DECRV_ATOMIC(session, cache_updates_txn_uncommitted_count, val);

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1905,6 +1905,7 @@ __txn_incr_bytes_dirty(WT_SESSION_IMPL *session, size_t size, bool new_update)
 
     WT_STAT_CONN_INCRV_ATOMIC(session, cache_updates_txn_uncommitted_bytes, (int64_t)size);
     WT_STAT_CONN_INCRV_ATOMIC(session, cache_updates_txn_uncommitted_count, 1);
+    WT_STAT_SESSION_INCRV(session, txn_updates_bytes_dirty, (int64_t)size);
     WT_STAT_SESSION_INCRV(session, txn_bytes_dirty, (int64_t)size);
     WT_STAT_SESSION_INCRV(session, txn_updates, 1);
 }
@@ -1921,10 +1922,12 @@ __txn_clear_bytes_dirty(WT_SESSION_IMPL *session)
     session->txn->update_dirty_bytes = 0;
     session->txn->truncate_dirty_bytes = 0;
 
-    val = WT_STAT_SESSION_READ(&(session)->stats, txn_bytes_dirty);
+    WT_STAT_SESSION_SET(session, txn_bytes_dirty, 0);
+
+    val = WT_STAT_SESSION_READ(&(session)->stats, txn_updates_bytes_dirty);
     if (val != 0) {
         WT_STAT_CONN_DECRV_ATOMIC(session, cache_updates_txn_uncommitted_bytes, val);
-        WT_STAT_SESSION_SET(session, txn_bytes_dirty, 0);
+        WT_STAT_SESSION_SET(session, txn_updates_bytes_dirty, 0);
     }
 
     val = WT_STAT_SESSION_READ(&(session)->stats, txn_truncate_bytes_dirty);

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -9320,14 +9320,19 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
  * transaction: transactions rolled back because their own dirty content
  * exceeds the eviction updates or dirty trigger
  */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TOO_LARGE_FOR_CACHE	2063
+#define	WT_STAT_CONN_TXN_ROLLBACK_TOO_LARGE_FOR_CACHE	2061
+/*!
+ * transaction: truncate operations rolled back because they pinned too
+ * much dirty cache
+ */
+#define	WT_STAT_CONN_TXN_TRUNCATE_DIRTY_CACHE_ROLLBACK	2062
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		2064
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		2063
 /*!
  * transaction: write transactions rolled back for straddling the step-
  * down timestamp setting boundary
  */
-#define	WT_STAT_CONN_TXN_ROLLBACK_STEPDOWN		2065
+#define	WT_STAT_CONN_TXN_ROLLBACK_STEPDOWN		2064
 
 /*!
  * @}

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -8124,1210 +8124,1217 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
  * transaction snapshot
  */
 #define	WT_STAT_CONN_LAYERED_CURS_OPEN_STABLE_REFUSED	1625
+/*!
+ * layered: Layered table cursor stable open rolled back after racing a
+ * step-down
+ */
+#define	WT_STAT_CONN_LAYERED_CURS_OPEN_STABLE_STEPDOWN_RACE	1626
 /*! layered: Layered table cursor update operations */
-#define	WT_STAT_CONN_LAYERED_CURS_UPDATE		1626
+#define	WT_STAT_CONN_LAYERED_CURS_UPDATE		1627
+/*! layered: Layered table live stable open refused on a follower */
+#define	WT_STAT_CONN_LAYERED_STABLE_LIVE_OPEN_REFUSED	1628
 /*!
  * layered: Layered table stable values beginning with the tombstone byte
  * sequence and ending with a non-tombstone byte
  */
-#define	WT_STAT_CONN_LAYERED_CURS_STABLE_VALUE_TOMBSTONE_PREFIX	1627
+#define	WT_STAT_CONN_LAYERED_CURS_STABLE_VALUE_TOMBSTONE_PREFIX	1629
 /*!
  * layered: Layered table stable values beginning with the tombstone byte
  * sequence and ending with a tombstone byte
  */
-#define	WT_STAT_CONN_LAYERED_CURS_STABLE_VALUE_TOMBSTONE_SUFFIX	1628
+#define	WT_STAT_CONN_LAYERED_CURS_STABLE_VALUE_TOMBSTONE_SUFFIX	1630
 /*!
  * layered: Layered table stable values equal to the tombstone byte
  * sequence
  */
-#define	WT_STAT_CONN_LAYERED_CURS_STABLE_VALUE_TOMBSTONE	1629
+#define	WT_STAT_CONN_LAYERED_CURS_STABLE_VALUE_TOMBSTONE	1631
 /*! layered: Layered table stable values equal to three tombstone bytes */
-#define	WT_STAT_CONN_LAYERED_CURS_STABLE_VALUE_TOMBSTONE_X3	1630
+#define	WT_STAT_CONN_LAYERED_CURS_STABLE_VALUE_TOMBSTONE_X3	1632
 /*!
  * layered: checkpoints performed on this table by the layered table
  * manager
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS	1631
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS	1633
 /*! layered: disagg pick up checkpoints failed */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FAILED	1632
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FAILED	1634
 /*! layered: disagg pick up checkpoints succeeded */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_SUCCEED	1633
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_SUCCEED	1635
 /*!
  * layered: how many log applications the layered table manager applied
  * on this tree
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_APPLIED	1634
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_APPLIED	1636
 /*!
  * layered: how many log applications the layered table manager skipped
  * on this tree
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_SKIPPED	1635
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_SKIPPED	1637
 /*!
  * layered: how many previously-applied LSNs the layered table manager
  * skipped on this tree
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_SKIP_LSN	1636
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_SKIP_LSN	1638
 /*! layered: number of checkpoints picked up by a follower */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FOLLOWER	1637
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FOLLOWER	1639
 /*! layered: the number of tables the layered table manager has open */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_TABLES	1638
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_TABLES	1640
 /*! layered: the number of times the truncate list was searched */
-#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_SEARCH_CALLS	1639
+#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_SEARCH_CALLS	1641
 /*!
  * layered: the number of times truncate list garbage collection ran with
  * a valid prune timestamp
  */
-#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_GC_RUNS	1640
+#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_GC_RUNS	1642
 /*!
  * layered: the number of truncate list entries removed by garbage
  * collection
  */
-#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_GC_ENTRIES_REMOVED	1641
+#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_GC_ENTRIES_REMOVED	1643
 /*! layered: the number of truncate list entries walked during search */
-#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_SEARCH_ENTRIES_WALKED	1642
+#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_SEARCH_ENTRIES_WALKED	1644
 /*!
  * live-restore: number of bytes copied from the source to the
  * destination
  */
-#define	WT_STAT_CONN_LIVE_RESTORE_BYTES_COPIED		1643
+#define	WT_STAT_CONN_LIVE_RESTORE_BYTES_COPIED		1645
 /*! live-restore: number of files remaining for migration completion */
-#define	WT_STAT_CONN_LIVE_RESTORE_WORK_REMAINING	1644
+#define	WT_STAT_CONN_LIVE_RESTORE_WORK_REMAINING	1646
 /*! live-restore: number of reads from the source database */
-#define	WT_STAT_CONN_LIVE_RESTORE_SOURCE_READ_COUNT	1645
+#define	WT_STAT_CONN_LIVE_RESTORE_SOURCE_READ_COUNT	1647
 /*! live-restore: source read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT2	1646
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT2	1648
 /*! live-restore: source read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT5	1647
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT5	1649
 /*! live-restore: source read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT10	1648
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT10	1650
 /*! live-restore: source read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT50	1649
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT50	1651
 /*! live-restore: source read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT100	1650
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT100	1652
 /*! live-restore: source read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT250	1651
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT250	1653
 /*! live-restore: source read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT500	1652
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT500	1654
 /*! live-restore: source read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT1000	1653
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT1000	1655
 /*! live-restore: source read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_GT1000	1654
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_GT1000	1656
 /*! live-restore: source read latency histogram total (msecs) */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_TOTAL_MSECS	1655
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_TOTAL_MSECS	1657
 /*! live-restore: state */
-#define	WT_STAT_CONN_LIVE_RESTORE_STATE			1656
+#define	WT_STAT_CONN_LIVE_RESTORE_STATE			1658
 /*! load-control: number of read operations rejected due to load control */
-#define	WT_STAT_CONN_READ_REJECT_COUNT			1657
+#define	WT_STAT_CONN_READ_REJECT_COUNT			1659
 /*! load-control: number of write operations rejected due to load control */
-#define	WT_STAT_CONN_WRITE_REJECT_COUNT			1658
+#define	WT_STAT_CONN_WRITE_REJECT_COUNT			1660
 /*! load-control: read load at the system level */
-#define	WT_STAT_CONN_READ_LOAD				1659
+#define	WT_STAT_CONN_READ_LOAD				1661
 /*! load-control: write load at the system level */
-#define	WT_STAT_CONN_WRITE_LOAD				1660
+#define	WT_STAT_CONN_WRITE_LOAD				1662
 /*! lock: btree page lock acquisitions */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_COUNT		1661
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_COUNT		1663
 /*! lock: btree page lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_APPLICATION	1662
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_APPLICATION	1664
 /*! lock: btree page lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_INTERNAL	1663
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_INTERNAL	1665
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1664
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1666
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1665
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1667
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1666
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1668
 /*! lock: dhandle lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1667
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1669
 /*! lock: dhandle lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1668
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1670
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1669
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1671
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1670
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1672
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1671
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1673
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1672
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1674
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1673
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1675
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1674
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1676
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1675
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1677
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1676
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1678
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1677
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1679
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1678
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1680
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1679
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1681
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1680
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1682
 /*! lock: txn global lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1681
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1683
 /*! lock: txn global lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1682
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1684
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1683
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1685
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1684
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1686
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1685
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1687
 /*! log: force log remove time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1686
+#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1688
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1687
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1689
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1688
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1690
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1689
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1691
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1690
+#define	WT_STAT_CONN_LOG_FLUSH				1692
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1691
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1693
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1692
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1694
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1693
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1695
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1694
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1696
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1695
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1697
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1696
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1698
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1697
+#define	WT_STAT_CONN_LOG_SCANS				1699
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1698
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1700
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1699
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1701
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1700
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1702
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1701
+#define	WT_STAT_CONN_LOG_SYNC				1703
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1702
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1704
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1703
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1705
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1704
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1706
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1705
+#define	WT_STAT_CONN_LOG_WRITES				1707
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1706
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1708
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1707
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1709
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1708
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1710
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1709
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1711
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1710
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1712
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1711
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1713
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1712
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1714
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1713
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1715
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1714
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1716
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1715
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1717
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1716
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1718
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1717
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1719
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1718
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1720
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1719
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1721
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1720
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1722
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1721
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1723
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1722
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1724
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1723
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1725
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1724
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1726
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1725
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1727
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1726
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1728
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1727
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1729
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1728
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1730
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1729
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1731
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1730
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1732
 /*! perf: block manager read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT2	1731
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT2	1733
 /*! perf: block manager read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT5	1732
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT5	1734
 /*! perf: block manager read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT10	1733
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT10	1735
 /*! perf: block manager read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT50	1734
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT50	1736
 /*! perf: block manager read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT100	1735
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT100	1737
 /*! perf: block manager read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT250	1736
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT250	1738
 /*! perf: block manager read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT500	1737
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT500	1739
 /*! perf: block manager read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT1000	1738
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT1000	1740
 /*! perf: block manager read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_GT1000	1739
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_GT1000	1741
 /*! perf: block manager read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_TOTAL_MSECS	1740
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_TOTAL_MSECS	1742
 /*! perf: block manager write latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT2	1741
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT2	1743
 /*! perf: block manager write latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT5	1742
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT5	1744
 /*! perf: block manager write latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT10	1743
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT10	1745
 /*! perf: block manager write latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT50	1744
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT50	1746
 /*! perf: block manager write latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT100	1745
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT100	1747
 /*! perf: block manager write latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT250	1746
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT250	1748
 /*! perf: block manager write latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT500	1747
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT500	1749
 /*! perf: block manager write latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT1000	1748
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT1000	1750
 /*! perf: block manager write latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_GT1000	1749
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_GT1000	1751
 /*! perf: block manager write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_TOTAL_MSECS	1750
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_TOTAL_MSECS	1752
 /*! perf: disagg block manager read latency histogram (bucket 1) - 50-99us */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT100	1751
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT100	1753
 /*!
  * perf: disagg block manager read latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT250	1752
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT250	1754
 /*!
  * perf: disagg block manager read latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT500	1753
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT500	1755
 /*!
  * perf: disagg block manager read latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT1000	1754
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT1000	1756
 /*!
  * perf: disagg block manager read latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT2500	1755
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT2500	1757
 /*!
  * perf: disagg block manager read latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT5000	1756
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT5000	1758
 /*!
  * perf: disagg block manager read latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT10000	1757
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT10000	1759
 /*!
  * perf: disagg block manager read latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_GT10000	1758
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_GT10000	1760
 /*! perf: disagg block manager read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_TOTAL_USECS	1759
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_TOTAL_USECS	1761
 /*!
  * perf: disagg block manager write latency histogram (bucket 1) -
  * 50-99us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT100	1760
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT100	1762
 /*!
  * perf: disagg block manager write latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT250	1761
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT250	1763
 /*!
  * perf: disagg block manager write latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT500	1762
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT500	1764
 /*!
  * perf: disagg block manager write latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT1000	1763
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT1000	1765
 /*!
  * perf: disagg block manager write latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT2500	1764
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT2500	1766
 /*!
  * perf: disagg block manager write latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT5000	1765
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT5000	1767
 /*!
  * perf: disagg block manager write latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT10000	1766
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT10000	1768
 /*!
  * perf: disagg block manager write latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_GT10000	1767
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_GT10000	1769
 /*! perf: disagg block manager write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_TOTAL_USECS	1768
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_TOTAL_USECS	1770
 /*! perf: file system read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT2	1769
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT2	1771
 /*! perf: file system read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT5	1770
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT5	1772
 /*! perf: file system read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1771
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1773
 /*! perf: file system read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1772
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1774
 /*! perf: file system read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1773
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1775
 /*! perf: file system read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1774
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1776
 /*! perf: file system read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1775
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1777
 /*! perf: file system read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1776
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1778
 /*! perf: file system read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1777
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1779
 /*! perf: file system read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1778
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1780
 /*! perf: file system write latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT2	1779
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT2	1781
 /*! perf: file system write latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT5	1780
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT5	1782
 /*! perf: file system write latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1781
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1783
 /*! perf: file system write latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1782
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1784
 /*! perf: file system write latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1783
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1785
 /*! perf: file system write latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1784
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1786
 /*! perf: file system write latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1785
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1787
 /*! perf: file system write latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1786
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1788
 /*! perf: file system write latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1787
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1789
 /*! perf: file system write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1788
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1790
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 1) -
  * 0-100us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT100	1789
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT100	1791
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT250	1790
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT250	1792
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT500	1791
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT500	1793
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT1000	1792
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT1000	1794
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT2500	1793
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT2500	1795
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT5000	1794
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT5000	1796
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT10000	1795
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT10000	1797
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_GT10000	1796
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_GT10000	1798
 /*! perf: internal page deltas reconstruct latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_TOTAL_USECS	1797
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_TOTAL_USECS	1799
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 1) -
  * 0-100us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT100	1798
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT100	1800
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT250	1799
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT250	1801
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT500	1800
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT500	1802
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT1000	1801
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT1000	1803
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT2500	1802
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT2500	1804
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT5000	1803
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT5000	1805
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT10000	1804
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT10000	1806
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_GT10000	1805
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_GT10000	1807
 /*! perf: leaf page deltas reconstruct latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_TOTAL_USECS	1806
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_TOTAL_USECS	1808
 /*! perf: operation read latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1807
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1809
 /*! perf: operation read latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1808
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1810
 /*! perf: operation read latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1809
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1811
 /*! perf: operation read latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1810
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1812
 /*! perf: operation read latency histogram (bucket 5) - 1000-2499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT2500	1811
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT2500	1813
 /*! perf: operation read latency histogram (bucket 6) - 2500-4999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT5000	1812
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT5000	1814
 /*! perf: operation read latency histogram (bucket 7) - 5000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1813
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1815
 /*! perf: operation read latency histogram (bucket 8) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1814
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1816
 /*! perf: operation read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1815
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1817
 /*! perf: operation write latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1816
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1818
 /*! perf: operation write latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1817
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1819
 /*! perf: operation write latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1818
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1820
 /*! perf: operation write latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1819
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1821
 /*! perf: operation write latency histogram (bucket 5) - 1000-2499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT2500	1820
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT2500	1822
 /*! perf: operation write latency histogram (bucket 6) - 2500-4999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT5000	1821
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT5000	1823
 /*! perf: operation write latency histogram (bucket 7) - 5000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1822
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1824
 /*! perf: operation write latency histogram (bucket 8) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1823
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1825
 /*! perf: operation write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1824
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1826
 /*! prefetch: could not perform pre-fetch on internal page */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1825
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1827
 /*!
  * prefetch: could not perform pre-fetch on ref without the pre-fetch
  * flag set
  */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1826
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1828
 /*! prefetch: pre-fetch attempted, session has pre-fetching enabled */
-#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1827
+#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1829
 /*! prefetch: pre-fetch not repeating for recently pre-fetched ref */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1828
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1830
 /*! prefetch: pre-fetch not triggered after single disk read */
-#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1829
+#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1831
 /*! prefetch: pre-fetch not triggered as there is no valid dhandle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1830
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1832
 /*! prefetch: pre-fetch not triggered due to disk read count */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1831
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1833
 /*! prefetch: pre-fetch not triggered due to internal session */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1832
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1834
 /*! prefetch: pre-fetch not triggered due to special btree handle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1833
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1835
 /*! prefetch: pre-fetch not triggered, pre-fetch queue is full */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_QUEUE_FULL	1834
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_QUEUE_FULL	1836
 /*! prefetch: pre-fetch page not on disk when reading */
-#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1835
+#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1837
 /*! prefetch: pre-fetch pages queued */
-#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1836
+#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1838
 /*! prefetch: pre-fetch pages read in background */
-#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1837
+#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1839
 /*!
  * prefetch: pre-fetch session check passed, pre-fetch work issued to
  * btree
  */
-#define	WT_STAT_CONN_PREFETCH_ATTEMPTS_SUCCEEDED	1838
+#define	WT_STAT_CONN_PREFETCH_ATTEMPTS_SUCCEEDED	1840
 /*! prefetch: pre-fetch skipped reading in a page due to harmless error */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1839
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1841
 /*!
  * prefetch: pre-fetch skipped traversal of internal page due to active
  * split generation
  */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SPLIT_GEN	1840
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SPLIT_GEN	1842
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1841
+#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1843
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1842
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1844
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1843
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1845
 /*!
  * reconciliation: average length of delta chain on internal page with
  * deltas
  */
-#define	WT_STAT_CONN_REC_AVERAGE_INTERNAL_PAGE_DELTA_CHAIN_LENGTH	1844
+#define	WT_STAT_CONN_REC_AVERAGE_INTERNAL_PAGE_DELTA_CHAIN_LENGTH	1846
 /*! reconciliation: average length of delta chain on leaf page with deltas */
-#define	WT_STAT_CONN_REC_AVERAGE_LEAF_PAGE_DELTA_CHAIN_LENGTH	1845
+#define	WT_STAT_CONN_REC_AVERAGE_LEAF_PAGE_DELTA_CHAIN_LENGTH	1847
 /*!
  * reconciliation: changes since prior reconciliation (bucket 1) between
  * 1 and 5
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE5			1846
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE5			1848
 /*!
  * reconciliation: changes since prior reconciliation (bucket 2) between
  * 6 and 10
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE10			1847
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE10			1849
 /*!
  * reconciliation: changes since prior reconciliation (bucket 3) between
  * 11 and 20
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE20			1848
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE20			1850
 /*!
  * reconciliation: changes since prior reconciliation (bucket 4) between
  * 21 and 50
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE50			1849
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE50			1851
 /*!
  * reconciliation: changes since prior reconciliation (bucket 5) between
  * 51 and 100
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE100		1850
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE100		1852
 /*!
  * reconciliation: changes since prior reconciliation (bucket 6) between
  * 101 and 200
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE200		1851
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE200		1853
 /*!
  * reconciliation: changes since prior reconciliation (bucket 7) between
  * 201 and 500
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE500		1852
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE500		1854
 /*!
  * reconciliation: changes since prior reconciliation (bucket 8) greater
  * than 500
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_GT500		1853
+#define	WT_STAT_CONN_REC_PAGE_MODS_GT500		1855
 /*! reconciliation: cursor next/prev calls during HS wrapup search_near */
-#define	WT_STAT_CONN_REC_HS_WRAPUP_NEXT_PREV_CALLS	1854
+#define	WT_STAT_CONN_REC_HS_WRAPUP_NEXT_PREV_CALLS	1856
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1855
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1857
 /*!
  * reconciliation: free page ID due to failed page replacement
  * reconciliation in disagg
  */
-#define	WT_STAT_CONN_REC_FREE_PAGE_ID_DUE_TO_FAILED_REPLACEMENT_RECONCILIATION	1856
+#define	WT_STAT_CONN_REC_FREE_PAGE_ID_DUE_TO_FAILED_REPLACEMENT_RECONCILIATION	1858
 /*! reconciliation: full internal pages written instead of a page delta */
-#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_INTERNAL	1857
+#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_INTERNAL	1859
 /*! reconciliation: full leaf pages written instead of a page delta */
-#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_LEAF		1858
+#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_LEAF		1860
 /*!
  * reconciliation: ingest btree reconciliation keeps the aborted prepare
  * updates
  */
-#define	WT_STAT_CONN_REC_INGEST_KEEP_PREPARE_ROLLBACK	1859
+#define	WT_STAT_CONN_REC_INGEST_KEEP_PREPARE_ROLLBACK	1861
 /*! reconciliation: internal page delta keys deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_DELETED	1860
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_DELETED	1862
 /*! reconciliation: internal page delta keys updated/inserted */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_UPDATED	1861
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_UPDATED	1863
 /*! reconciliation: internal page deltas written */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL		1862
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL		1864
 /*! reconciliation: internal page multi-block writes */
-#define	WT_STAT_CONN_REC_MULTIBLOCK_INTERNAL		1863
+#define	WT_STAT_CONN_REC_MULTIBLOCK_INTERNAL		1865
 /*! reconciliation: leaf page deltas written */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_LEAF		1864
+#define	WT_STAT_CONN_REC_PAGE_DELTA_LEAF		1866
 /*! reconciliation: leaf page multi-block writes */
-#define	WT_STAT_CONN_REC_MULTIBLOCK_LEAF		1865
+#define	WT_STAT_CONN_REC_MULTIBLOCK_LEAF		1867
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1866
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1868
 /*! reconciliation: max deltas seen on internal page during reconciliation */
-#define	WT_STAT_CONN_REC_MAX_INTERNAL_PAGE_DELTAS	1867
+#define	WT_STAT_CONN_REC_MAX_INTERNAL_PAGE_DELTAS	1869
 /*! reconciliation: max deltas seen on leaf page during reconciliation */
-#define	WT_STAT_CONN_REC_MAX_LEAF_PAGE_DELTAS		1868
+#define	WT_STAT_CONN_REC_MAX_LEAF_PAGE_DELTAS		1870
 /*! reconciliation: maximum milliseconds spent in a reconciliation call */
-#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1869
+#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1871
 /*!
  * reconciliation: maximum milliseconds spent in building a disk image in
  * a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1870
+#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1872
 /*!
  * reconciliation: maximum milliseconds spent in moving updates to the
  * history store in a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1871
+#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1873
 /*!
  * reconciliation: number of keys that are garbage collected from the
  * disk images in the ingest btrees for disaggregated storage
  */
-#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_DISK_IMAGE	1872
+#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_DISK_IMAGE	1874
 /*!
  * reconciliation: number of keys that are garbage collected from the
  * update chains in the ingest btrees for disaggregated storage
  */
-#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_UPDATE_CHAIN	1873
+#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_UPDATE_CHAIN	1875
 /*! reconciliation: overflow values written */
-#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1874
+#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1876
 /*! reconciliation: page deltas rejected due to invalid page ID */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_INVALID_PAGE_ID	1875
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_INVALID_PAGE_ID	1877
 /*! reconciliation: page deltas rejected due to max consecutive limit */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MAX_CONSECUTIVE_EXCEEDED	1876
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MAX_CONSECUTIVE_EXCEEDED	1878
 /*! reconciliation: page deltas rejected due to multiblock reconciliation */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MULTIBLOCK	1877
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MULTIBLOCK	1879
 /*!
  * reconciliation: page deltas rejected due to non-single page in
  * previous reconciliation
  */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_NON_SINGLE_PAGE	1878
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_NON_SINGLE_PAGE	1880
 /*! reconciliation: page deltas rejected due to size threshold */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_SIZE_THRESHOLD	1879
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_SIZE_THRESHOLD	1881
 /*!
  * reconciliation: page deltas rejected due to too many keys removed from
  * the disk image
  */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_DELETE_THRESHOLD	1880
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_DELETE_THRESHOLD	1882
 /*! reconciliation: page deltas rejected due to zero entries */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_ZERO_ENTRIES	1881
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_ZERO_ENTRIES	1883
 /*!
  * reconciliation: page deltas rejected: build function returned false
  * (disabled, in-memory split, or internal page constraints not met)
  */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_BUILD_FAILED	1882
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_BUILD_FAILED	1884
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1883
+#define	WT_STAT_CONN_REC_PAGES				1885
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1884
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1886
 /*! reconciliation: page reconciliation calls for pages between 1 and 10MB */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_1MB_TO_10MB		1885
+#define	WT_STAT_CONN_REC_PAGES_SIZE_1MB_TO_10MB		1887
 /*!
  * reconciliation: page reconciliation calls for pages between 10 and
  * 100MB
  */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_10MB_TO_100MB	1886
+#define	WT_STAT_CONN_REC_PAGES_SIZE_10MB_TO_100MB	1888
 /*!
  * reconciliation: page reconciliation calls for pages between 100MB and
  * 1GB
  */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_100MB_TO_1GB	1887
+#define	WT_STAT_CONN_REC_PAGES_SIZE_100MB_TO_1GB	1889
 /*! reconciliation: page reconciliation calls for pages over 1GB */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_1GB_PLUS		1888
+#define	WT_STAT_CONN_REC_PAGES_SIZE_1GB_PLUS		1890
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * prepared transaction metadata
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1889
+#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1891
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * timestamps
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1890
+#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1892
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * transaction ids
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1891
+#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1893
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1892
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1894
 /*! reconciliation: pages eligible for delta generation */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_ELIGIBLE		1893
+#define	WT_STAT_CONN_REC_PAGE_DELTA_ELIGIBLE		1895
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1894
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1896
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1895
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1897
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1896
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1898
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1897
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1899
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1898
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1900
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1899
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1901
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1900
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1902
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1901
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1903
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1902
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1904
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1903
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1905
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1904
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1906
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1905
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1907
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1906
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1908
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1907
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1909
 /*! reconciliation: pages written with at least one internal page delta */
-#define	WT_STAT_CONN_REC_PAGES_WITH_INTERNAL_DELTAS	1908
+#define	WT_STAT_CONN_REC_PAGES_WITH_INTERNAL_DELTAS	1910
 /*! reconciliation: pages written with at least one leaf page delta */
-#define	WT_STAT_CONN_REC_PAGES_WITH_LEAF_DELTAS		1909
+#define	WT_STAT_CONN_REC_PAGES_WITH_LEAF_DELTAS		1911
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1910
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1912
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1911
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1913
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1912
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1914
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1913
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1915
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1914
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1916
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1915
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1917
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1916
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1918
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1917
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1919
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1918
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1920
 /*! reconciliation: writes skipped in disaggregated storage */
-#define	WT_STAT_CONN_REC_SKIP_WRITE			1919
+#define	WT_STAT_CONN_REC_SKIP_WRITE			1921
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1920
+#define	WT_STAT_CONN_SESSION_OPEN			1922
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1921
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1923
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1922
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1924
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1923
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1925
 /*! session: table alter triggering checkpoint calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1924
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1926
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1925
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1927
 /*! session: table compact conflicted with checkpoint */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1926
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1928
 /*! session: table compact dhandle successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1927
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1929
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1928
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1930
 /*! session: table compact failed calls due to cache pressure */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1929
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1931
 /*!
  * session: table compact in-memory page footprint rewritten by
  * compaction
  */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_BYTES_REWRITE_INMEM	1930
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_BYTES_REWRITE_INMEM	1932
 /*! session: table compact passes */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1931
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1933
 /*! session: table compact pulled into eviction */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1932
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1934
 /*! session: table compact running */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1933
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1935
 /*! session: table compact skipped as process would not reduce file size */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1934
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1936
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1935
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1937
 /*! session: table compact timeout */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1936
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1938
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1937
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1939
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1938
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1940
 /*! session: table create with import failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1939
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1941
 /*! session: table create with import repair calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1940
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1942
 /*! session: table create with import successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1941
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1943
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1942
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1944
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1943
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1945
 /*! session: table publish failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_PUBLISH_FAIL		1944
+#define	WT_STAT_CONN_SESSION_TABLE_PUBLISH_FAIL		1946
 /*! session: table publish successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_PUBLISH_SUCCESS	1945
+#define	WT_STAT_CONN_SESSION_TABLE_PUBLISH_SUCCESS	1947
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1946
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1948
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1947
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1949
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1948
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1950
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1949
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1951
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1950
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1952
 /*! session: table verify number of keys checked against the history store */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_HS_KEYS_CHECKED	1951
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_HS_KEYS_CHECKED	1953
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1952
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1954
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1953
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1955
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1954
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1956
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1955
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1957
 /*!
  * thread-yield: application thread eviction used the published
  * checkpoint snapshot for visibility
  */
-#define	WT_STAT_CONN_APPLICATION_EVICT_CHECKPOINT_SNAPSHOT	1956
+#define	WT_STAT_CONN_APPLICATION_EVICT_CHECKPOINT_SNAPSHOT	1958
 /*! thread-yield: application thread operations waiting for cache */
-#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1957
+#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1959
 /*!
  * thread-yield: application thread operations waiting for interruptible
  * cache eviction
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_OPS	1958
+#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_OPS	1960
 /*!
  * thread-yield: application thread operations waiting for mandatory
  * cache eviction
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_OPS	1959
+#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_OPS	1961
 /*! thread-yield: application thread snapshot refreshed for eviction */
-#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1960
+#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1962
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1961
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1963
 /*!
  * thread-yield: application thread time waiting for interruptible cache
  * eviction (usecs)
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_TIME	1962
+#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_TIME	1964
 /*!
  * thread-yield: application thread time waiting for mandatory cache
  * eviction (usecs)
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_TIME	1963
+#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_TIME	1965
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1964
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1966
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1965
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1967
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1966
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1968
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1967
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1969
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1968
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1970
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1969
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1971
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1970
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1972
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1971
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1973
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1972
+#define	WT_STAT_CONN_PAGE_SLEEP				1974
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1973
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1975
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1974
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1976
 /*! thread-yield: page split and restart read */
-#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1975
+#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1977
 /*! thread-yield: pages skipped during read due to deleted state */
-#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1976
+#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1978
 /*!
  * tiered-storage: attempts to remove a local object and the object is in
  * use
  */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1977
+#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1979
 /*! tiered-storage: flush_tier failed calls */
-#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1978
+#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1980
 /*! tiered-storage: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1979
+#define	WT_STAT_CONN_FLUSH_TIER				1981
 /*! tiered-storage: flush_tier tables skipped due to no checkpoint */
-#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1980
+#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1982
 /*! tiered-storage: flush_tier tables switched */
-#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1981
+#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1983
 /*! tiered-storage: local objects removed */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1982
+#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1984
 /*! tiered-storage: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1983
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1985
 /*! tiered-storage: tiered operations removed without processing */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1984
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1986
 /*! tiered-storage: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1985
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1987
 /*! tiered-storage: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1986
+#define	WT_STAT_CONN_TIERED_RETENTION			1988
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1987
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1989
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1988
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1990
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1989
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1991
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1990
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1992
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1991
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1993
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1992
+#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1994
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1993
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1995
 /*! transaction: oldest transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1994
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1996
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1995
+#define	WT_STAT_CONN_TXN_PREPARE			1997
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1996
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1998
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1997
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1999
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1998
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		2000
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1999
+#define	WT_STAT_CONN_TXN_QUERY_TS			2001
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	2000
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	2002
 /*! transaction: rollback to stable applied btrees */
-#define	WT_STAT_CONN_TXN_RTS_BTREES_APPLIED		2001
+#define	WT_STAT_CONN_TXN_RTS_BTREES_APPLIED		2003
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				2002
+#define	WT_STAT_CONN_TXN_RTS				2004
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	2003
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	2005
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2004
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2006
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		2005
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		2007
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		2006
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		2008
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		2007
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		2009
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	2008
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	2010
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	2009
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	2011
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		2010
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		2012
 /*!
  * transaction: rollback to stable prepared fast truncations that would
  * have been rolled back in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_PREPARED_FAST_TRUNCATE_DRYRUN	2011
+#define	WT_STAT_CONN_TXN_RTS_PREPARED_FAST_TRUNCATE_DRYRUN	2013
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	2012
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	2014
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		2013
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		2015
 /*! transaction: rollback to stable rolled back prepared fast truncations */
-#define	WT_STAT_CONN_TXN_RTS_PREPARED_FAST_TRUNCATE	2014
+#define	WT_STAT_CONN_TXN_RTS_PREPARED_FAST_TRUNCATE	2016
 /*! transaction: rollback to stable skipped btrees */
-#define	WT_STAT_CONN_TXN_RTS_BTREES_SKIPPED		2015
+#define	WT_STAT_CONN_TXN_RTS_BTREES_SKIPPED		2017
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		2016
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		2018
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		2017
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		2019
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		2018
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		2020
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	2019
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	2021
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	2020
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	2022
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		2021
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		2023
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	2022
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	2024
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			2023
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			2025
 /*!
  * transaction: rollback to stable updates that would have been aborted
  * in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		2024
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		2026
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		2025
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		2027
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		2026
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		2028
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				2027
+#define	WT_STAT_CONN_TXN_SET_TS				2029
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			2028
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			2030
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		2029
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		2031
 /*! transaction: set timestamp force calls */
-#define	WT_STAT_CONN_TXN_SET_TS_FORCE			2030
+#define	WT_STAT_CONN_TXN_SET_TS_FORCE			2032
 /*!
  * transaction: set timestamp global oldest timestamp set to be more
  * recent than the global stable timestamp
  */
-#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		2031
+#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		2033
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			2032
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			2034
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		2033
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		2035
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			2034
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			2036
 /*! transaction: set timestamp stable disaggregated schema epoch calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_DISAGG_EPOCH	2035
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_DISAGG_EPOCH	2037
 /*! transaction: set timestamp stable disaggregated schema epoch updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_DISAGG_EPOCH_UPD	2036
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_DISAGG_EPOCH_UPD	2038
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		2037
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		2039
 /*! transaction: step-down disaggregated schema epoch is currently set */
-#define	WT_STAT_CONN_TXN_STEPDOWN_EPOCH_SET		2038
+#define	WT_STAT_CONN_TXN_STEPDOWN_EPOCH_SET		2040
 /*! transaction: step-down timestamp is currently set */
-#define	WT_STAT_CONN_TXN_STEPDOWN_TS_SET		2039
+#define	WT_STAT_CONN_TXN_STEPDOWN_TS_SET		2041
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				2040
+#define	WT_STAT_CONN_TXN_BEGIN				2042
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		2041
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		2043
 /*! transaction: transaction global checkpoint timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_CHECKPOINT_TIMESTAMP	2042
+#define	WT_STAT_CONN_TXN_GLOBAL_CHECKPOINT_TIMESTAMP	2044
 /*! transaction: transaction global durable timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_DURABLE_TIMESTAMP	2043
+#define	WT_STAT_CONN_TXN_GLOBAL_DURABLE_TIMESTAMP	2045
 /*! transaction: transaction global last running timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_LAST_RUNNING_TIMESTAMP	2044
+#define	WT_STAT_CONN_TXN_GLOBAL_LAST_RUNNING_TIMESTAMP	2046
 /*! transaction: transaction global newest timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_NEWEST_TIMESTAMP	2045
+#define	WT_STAT_CONN_TXN_GLOBAL_NEWEST_TIMESTAMP	2047
 /*! transaction: transaction global oldest timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_OLDEST_TIMESTAMP	2046
+#define	WT_STAT_CONN_TXN_GLOBAL_OLDEST_TIMESTAMP	2048
 /*! transaction: transaction global pinned timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_PINNED_TIMESTAMP	2047
+#define	WT_STAT_CONN_TXN_GLOBAL_PINNED_TIMESTAMP	2049
 /*! transaction: transaction global stable timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_STABLE_TIMESTAMP	2048
+#define	WT_STAT_CONN_TXN_GLOBAL_STABLE_TIMESTAMP	2050
 /*! transaction: transaction global version cursor timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_VERSION_CURSOR_TIMESTAMP	2049
+#define	WT_STAT_CONN_TXN_GLOBAL_VERSION_CURSOR_TIMESTAMP	2051
 /*!
  * transaction: transaction number of older readers older than oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_READERS			2050
+#define	WT_STAT_CONN_TXN_PINNED_READERS			2052
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			2051
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			2053
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	2052
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	2054
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_LAG		2053
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_LAG		2055
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT_LAG	2054
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT_LAG	2056
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER_LAG	2055
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER_LAG	2057
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	2056
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	2058
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	2057
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	2059
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	2058
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	2060
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			2059
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			2061
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				2060
+#define	WT_STAT_CONN_TXN_COMMIT				2062
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			2061
+#define	WT_STAT_CONN_TXN_ROLLBACK			2063
 /*!
  * transaction: transactions rolled back because their own dirty content
  * exceeds the eviction updates or dirty trigger
  */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TOO_LARGE_FOR_CACHE	2062
+#define	WT_STAT_CONN_TXN_ROLLBACK_TOO_LARGE_FOR_CACHE	2064
 /*!
  * transaction: truncate operations rolled back because they pinned too
  * much dirty cache
  */
-#define	WT_STAT_CONN_TXN_TRUNCATE_DIRTY_CACHE_ROLLBACK	2063
+#define	WT_STAT_CONN_TXN_TRUNCATE_DIRTY_CACHE_ROLLBACK	2065
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		2064
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		2066
 /*!
  * transaction: write transactions rolled back for straddling the step-
  * down timestamp setting boundary
  */
-#define	WT_STAT_CONN_TXN_ROLLBACK_STEPDOWN		2065
+#define	WT_STAT_CONN_TXN_ROLLBACK_STEPDOWN		2067
 
 /*!
  * @}

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -10698,24 +10698,26 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_SESSION_BYTES_WRITE			4001
 /*! session: dhandle lock wait time (usecs) */
 #define	WT_STAT_SESSION_LOCK_DHANDLE_WAIT		4002
-/*! session: dirty bytes in this txn */
-#define	WT_STAT_SESSION_TXN_BYTES_DIRTY			4003
+/*! session: dirty bytes from updates in this txn */
+#define	WT_STAT_SESSION_TXN_UPDATES_BYTES_DIRTY		4003
+/*! session: dirty bytes in this txn, from both updates and fast-truncate */
+#define	WT_STAT_SESSION_TXN_BYTES_DIRTY			4004
 /*! session: dirty bytes pinned by fast-truncate in this txn */
-#define	WT_STAT_SESSION_TXN_TRUNCATE_BYTES_DIRTY	4004
+#define	WT_STAT_SESSION_TXN_TRUNCATE_BYTES_DIRTY	4005
 /*! session: number of updates in this txn */
-#define	WT_STAT_SESSION_TXN_UPDATES			4005
+#define	WT_STAT_SESSION_TXN_UPDATES			4006
 /*! session: page read from disk to cache time (usecs) */
-#define	WT_STAT_SESSION_READ_TIME			4006
+#define	WT_STAT_SESSION_READ_TIME			4007
 /*! session: page write from cache to disk time (usecs) */
-#define	WT_STAT_SESSION_WRITE_TIME			4007
+#define	WT_STAT_SESSION_WRITE_TIME			4008
 /*! session: schema lock wait time (usecs) */
-#define	WT_STAT_SESSION_LOCK_SCHEMA_WAIT		4008
+#define	WT_STAT_SESSION_LOCK_SCHEMA_WAIT		4009
 /*! session: time waiting for cache (usecs) */
-#define	WT_STAT_SESSION_CACHE_TIME			4009
+#define	WT_STAT_SESSION_CACHE_TIME			4010
 /*! session: time waiting for cache interruptible eviction (usecs) */
-#define	WT_STAT_SESSION_CACHE_TIME_INTERRUPTIBLE	4010
+#define	WT_STAT_SESSION_CACHE_TIME_INTERRUPTIBLE	4011
 /*! session: time waiting for mandatory cache eviction (usecs) */
-#define	WT_STAT_SESSION_CACHE_TIME_MANDATORY		4011
+#define	WT_STAT_SESSION_CACHE_TIME_MANDATORY		4012
 /*! @} */
 /*
  * Statistics section: END

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -7337,2002 +7337,1997 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_CACHE_PAGES_INUSE_INGEST		1313
 /*! cache: pages currently held in the cache from the stable btrees */
 #define	WT_STAT_CONN_CACHE_PAGES_INUSE_STABLE		1314
+/*! cache: pages dirtied by fast-truncate in uncommitted txn - bytes */
+#define	WT_STAT_CONN_CACHE_TRUNCATE_TXN_UNCOMMITTED_BYTES	1315
 /*! cache: pages dirtied due to obsolete time window by eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY_OBSOLETE_TW	1315
+#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY_OBSOLETE_TW	1316
 /*! cache: pages evicted ahead of the page materialization frontier */
-#define	WT_STAT_CONN_CACHE_EVICTION_AHEAD_OF_LAST_MATERIALIZED_LSN	1316
+#define	WT_STAT_CONN_CACHE_EVICTION_AHEAD_OF_LAST_MATERIALIZED_LSN	1317
 /*! cache: pages evicted in parallel with checkpoint */
-#define	WT_STAT_CONN_EVICTION_PAGES_IN_PARALLEL_WITH_CHECKPOINT	1317
+#define	WT_STAT_CONN_EVICTION_PAGES_IN_PARALLEL_WITH_CHECKPOINT	1318
 /*! cache: pages queued for eviction */
-#define	WT_STAT_CONN_EVICTION_PAGES_ORDINARY_QUEUED	1318
+#define	WT_STAT_CONN_EVICTION_PAGES_ORDINARY_QUEUED	1319
 /*! cache: pages queued for eviction post lru sorting */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_POST_LRU	1319
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_POST_LRU	1320
 /*! cache: pages queued for urgent eviction */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT	1320
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT	1321
 /*! cache: pages queued for urgent eviction during walk */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_OLDEST	1321
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_OLDEST	1322
 /*!
  * cache: pages queued for urgent eviction from history store due to high
  * dirty content
  */
-#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT_HS_DIRTY	1322
+#define	WT_STAT_CONN_EVICTION_PAGES_QUEUED_URGENT_HS_DIRTY	1323
 /*! cache: pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ				1323
+#define	WT_STAT_CONN_CACHE_READ				1324
 /*! cache: pages read into cache after truncate */
-#define	WT_STAT_CONN_CACHE_READ_DELETED			1324
+#define	WT_STAT_CONN_CACHE_READ_DELETED			1325
 /*! cache: pages read into cache after truncate in prepare state */
-#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1325
+#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1326
 /*! cache: pages read into cache by checkpoint */
-#define	WT_STAT_CONN_CACHE_READ_CHECKPOINT		1326
+#define	WT_STAT_CONN_CACHE_READ_CHECKPOINT		1327
 /*!
  * cache: pages removed from the ordinary queue to be queued for urgent
  * eviction
  */
-#define	WT_STAT_CONN_EVICTION_CLEAR_ORDINARY		1327
+#define	WT_STAT_CONN_EVICTION_CLEAR_ORDINARY		1328
 /*! cache: pages requested from the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1328
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1329
 /*! cache: pages requested from the cache due to pre-fetch */
-#define	WT_STAT_CONN_CACHE_PAGES_PREFETCH		1329
+#define	WT_STAT_CONN_CACHE_PAGES_PREFETCH		1330
 /*! cache: pages requested from the cache internal */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_INTERNAL	1330
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_INTERNAL	1331
 /*! cache: pages requested from the cache leaf */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_LEAF		1331
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_LEAF		1332
 /*! cache: pages requested from the history store */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_HS		1332
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_HS		1333
 /*! cache: pages seen by eviction walk */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1333
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1334
 /*! cache: pages seen by eviction walk that are already queued */
-#define	WT_STAT_CONN_EVICTION_PAGES_ALREADY_QUEUED	1334
+#define	WT_STAT_CONN_EVICTION_PAGES_ALREADY_QUEUED	1335
 /*! cache: pages selected for eviction unable to be evicted */
-#define	WT_STAT_CONN_EVICTION_FAIL			1335
+#define	WT_STAT_CONN_EVICTION_FAIL			1336
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * active children on an internal page
  */
-#define	WT_STAT_CONN_EVICTION_FAIL_ACTIVE_CHILDREN_ON_AN_INTERNAL_PAGE	1336
+#define	WT_STAT_CONN_EVICTION_FAIL_ACTIVE_CHILDREN_ON_AN_INTERNAL_PAGE	1337
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * failure in reconciliation
  */
-#define	WT_STAT_CONN_EVICTION_FAIL_IN_RECONCILIATION	1337
+#define	WT_STAT_CONN_EVICTION_FAIL_IN_RECONCILIATION	1338
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * race between checkpoint and updates without timestamps
  */
-#define	WT_STAT_CONN_EVICTION_FAIL_CHECKPOINT_NO_TS	1338
+#define	WT_STAT_CONN_EVICTION_FAIL_CHECKPOINT_NO_TS	1339
 /*!
  * cache: pages selected for eviction unable to be evicted belonging to
  * ingest btrees
  */
-#define	WT_STAT_CONN_EVICTION_FAIL_INGEST		1339
+#define	WT_STAT_CONN_EVICTION_FAIL_INGEST		1340
 /*! cache: pages walked for eviction */
-#define	WT_STAT_CONN_EVICTION_WALK			1340
+#define	WT_STAT_CONN_EVICTION_WALK			1341
 /*!
  * cache: pages with a clean re-instantiation image retained by
  * checkpoint scrub
  */
-#define	WT_STAT_CONN_CACHE_SCRUB_IMAGE_PAGES		1341
+#define	WT_STAT_CONN_CACHE_SCRUB_IMAGE_PAGES		1342
 /*!
  * cache: pages with an unresolved multiblock split flagged by checkpoint
  * to be evicted soon
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_MULTIBLOCK_CHECKPOINT_FLAGGED	1342
+#define	WT_STAT_CONN_CACHE_EVICTION_MULTIBLOCK_CHECKPOINT_FLAGGED	1343
 /*!
  * cache: pages with an unresolved multiblock split re-reconciled by
  * checkpoint
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_MULTIBLOCK_SPLIT_RE_RECONCILED	1343
+#define	WT_STAT_CONN_CACHE_EVICTION_MULTIBLOCK_SPLIT_RE_RECONCILED	1344
 /*! cache: pages written from cache */
-#define	WT_STAT_CONN_CACHE_WRITE			1344
+#define	WT_STAT_CONN_CACHE_WRITE			1345
 /*!
  * cache: pages written requiring in-memory restoration due to checkpoint
  * scrub
  */
-#define	WT_STAT_CONN_CACHE_WRITE_RESTORE_SCRUB_CHECKPOINT	1345
+#define	WT_STAT_CONN_CACHE_WRITE_RESTORE_SCRUB_CHECKPOINT	1346
 /*!
  * cache: pages written requiring in-memory restoration due to invisible
  * updates
  */
-#define	WT_STAT_CONN_CACHE_WRITE_RESTORE_INVISIBLE	1346
+#define	WT_STAT_CONN_CACHE_WRITE_RESTORE_INVISIBLE	1347
 /*!
  * cache: pages written requiring in-memory restoration due to scrub
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_WRITE_RESTORE_SCRUB		1347
+#define	WT_STAT_CONN_CACHE_WRITE_RESTORE_SCRUB		1348
 /*! cache: percentage overhead */
-#define	WT_STAT_CONN_CACHE_OVERHEAD			1348
+#define	WT_STAT_CONN_CACHE_OVERHEAD			1349
 /*!
  * cache: precise checkpoint caused an eviction to be skipped because any
  * dirty content needs to remain in cache
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_PRECISE_CHECKPOINT	1349
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_PRECISE_CHECKPOINT	1350
 /*!
  * cache: realizing in-memory split after reconciliation failed due to
  * internal lock busy
  */
-#define	WT_STAT_CONN_CACHE_EVICT_SPLIT_FAILED_LOCK	1350
+#define	WT_STAT_CONN_CACHE_EVICT_SPLIT_FAILED_LOCK	1351
 /*! cache: recent modification of a page blocked its eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	1351
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	1352
 /*! cache: reconciled pages scrubbed and added back to the cache clean */
-#define	WT_STAT_CONN_CACHE_SCRUB_RESTORE		1352
+#define	WT_STAT_CONN_CACHE_SCRUB_RESTORE		1353
 /*! cache: reverse splits performed */
-#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS		1353
+#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS		1354
 /*!
  * cache: reverse splits skipped because of VLCS namespace gap
  * restrictions
  */
-#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	1354
+#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	1355
 /*! cache: shared disk bucket lock contention count */
-#define	WT_STAT_CONN_CACHE_SHARED_DSK_LOCK_CONTENTION	1355
+#define	WT_STAT_CONN_CACHE_SHARED_DSK_LOCK_CONTENTION	1356
 /*! cache: shared disk bytes saved by sharing duplicate disk images */
-#define	WT_STAT_CONN_CACHE_SHARED_DSK_BYTES_DUPLICATE	1356
+#define	WT_STAT_CONN_CACHE_SHARED_DSK_BYTES_DUPLICATE	1357
 /*! cache: shared disk hash table size */
-#define	WT_STAT_CONN_CACHE_SHARED_DSK_HASH_SIZE		1357
+#define	WT_STAT_CONN_CACHE_SHARED_DSK_HASH_SIZE		1358
 /*! cache: shared disk hit */
-#define	WT_STAT_CONN_CACHE_SHARED_DSK_HIT		1358
+#define	WT_STAT_CONN_CACHE_SHARED_DSK_HIT		1359
 /*! cache: shared disk miss */
-#define	WT_STAT_CONN_CACHE_SHARED_DSK_MISS		1359
+#define	WT_STAT_CONN_CACHE_SHARED_DSK_MISS		1360
 /*! cache: shared history store cursor not cached during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_HS_SHARED_CURSOR_NOT_CACHED	1360
+#define	WT_STAT_CONN_CACHE_EVICTION_HS_SHARED_CURSOR_NOT_CACHED	1361
 /*! cache: size of delta updates reconstructed on the base page */
-#define	WT_STAT_CONN_CACHE_READ_DELTA_UPDATES		1361
+#define	WT_STAT_CONN_CACHE_READ_DELTA_UPDATES		1362
 /*! cache: size of tombstones restored when reading a page */
-#define	WT_STAT_CONN_CACHE_READ_RESTORED_TOMBSTONE_BYTES	1362
+#define	WT_STAT_CONN_CACHE_READ_RESTORED_TOMBSTONE_BYTES	1363
 /*! cache: the number of times full update inserted to history store */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1363
+#define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1364
 /*! cache: the number of times reverse modify inserted to history store */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1364
+#define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1365
 /*! cache: time eviction worker threads spend waiting for locks (usecs) */
-#define	WT_STAT_CONN_EVICTION_WORKER_LOCK_WAIT_TIME	1365
+#define	WT_STAT_CONN_EVICTION_WORKER_LOCK_WAIT_TIME	1366
 /*!
  * cache: total milliseconds spent inside reentrant history store
  * evictions in a reconciliation
  */
-#define	WT_STAT_CONN_EVICTION_REENTRY_HS_EVICTION_MILLISECONDS	1366
+#define	WT_STAT_CONN_EVICTION_REENTRY_HS_EVICTION_MILLISECONDS	1367
 /*! cache: tracked bytes belonging to internal pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1367
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1368
 /*!
  * cache: tracked bytes belonging to internal pages in the cache from the
  * ingest btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL_INGEST	1368
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL_INGEST	1369
 /*!
  * cache: tracked bytes belonging to internal pages in the cache from the
  * stable btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL_STABLE	1369
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL_STABLE	1370
 /*! cache: tracked bytes belonging to leaf pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1370
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1371
 /*!
  * cache: tracked bytes belonging to leaf pages in the cache from the
  * ingest btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF_INGEST		1371
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF_INGEST		1372
 /*!
  * cache: tracked bytes belonging to leaf pages in the cache from the
  * stable btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF_STABLE		1372
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF_STABLE		1373
 /*! cache: tracked dirty bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1373
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1374
 /*! cache: tracked dirty bytes in the cache from the ingest btrees */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INGEST		1374
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INGEST		1375
 /*! cache: tracked dirty bytes in the cache from the stable btrees */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_STABLE		1375
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_STABLE		1376
 /*! cache: tracked dirty internal page bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL		1376
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL		1377
 /*!
  * cache: tracked dirty internal page bytes in the cache from the ingest
  * btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL_INGEST	1377
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL_INGEST	1378
 /*!
  * cache: tracked dirty internal page bytes in the cache from the stable
  * btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL_STABLE	1378
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL_STABLE	1379
 /*! cache: tracked dirty leaf page bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF		1379
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF		1380
 /*!
  * cache: tracked dirty leaf page bytes in the cache from the ingest
  * btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF_INGEST	1380
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF_INGEST	1381
 /*!
  * cache: tracked dirty leaf page bytes in the cache from the stable
  * btrees
  */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF_STABLE	1381
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF_STABLE	1382
 /*! cache: tracked dirty pages in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1382
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1383
 /*! cache: tracked dirty pages in the cache from the ingest btrees */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY_INGEST		1383
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY_INGEST		1384
 /*! cache: tracked dirty pages in the cache from the stable btrees */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY_STABLE		1384
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY_STABLE		1385
 /*! cache: uncommitted truncate blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	1385
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	1386
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1386
+#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1387
 /*! cache: update bytes belonging to the history store table in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_HS_UPDATES		1387
+#define	WT_STAT_CONN_CACHE_BYTES_HS_UPDATES		1388
 /*! cache: updates in uncommitted txn - bytes */
-#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_BYTES	1388
+#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_BYTES	1389
 /*! cache: updates in uncommitted txn - count */
-#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_COUNT	1389
+#define	WT_STAT_CONN_CACHE_UPDATES_TXN_UNCOMMITTED_COUNT	1390
 /*! capacity: background fsync file handles considered */
-#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1390
+#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1391
 /*! capacity: background fsync file handles synced */
-#define	WT_STAT_CONN_FSYNC_ALL_FH			1391
+#define	WT_STAT_CONN_FSYNC_ALL_FH			1392
 /*! capacity: background fsync time (msecs) */
-#define	WT_STAT_CONN_FSYNC_ALL_TIME			1392
+#define	WT_STAT_CONN_FSYNC_ALL_TIME			1393
 /*! capacity: bytes read */
-#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1393
+#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1394
 /*! capacity: bytes written for checkpoint */
-#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1394
+#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1395
 /*! capacity: bytes written for eviction */
-#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1395
+#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1396
 /*! capacity: bytes written for log */
-#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1396
+#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1397
 /*! capacity: bytes written total */
-#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1397
+#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1398
 /*! capacity: threshold to call fsync */
-#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1398
+#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1399
 /*! capacity: time waiting due to total capacity (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1399
+#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1400
 /*! capacity: time waiting during checkpoint (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1400
+#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1401
 /*! capacity: time waiting during eviction (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1401
+#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1402
 /*! capacity: time waiting during logging (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1402
+#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1403
 /*! capacity: time waiting during read (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_READ			1403
+#define	WT_STAT_CONN_CAPACITY_TIME_READ			1404
 /*! checkpoint-cleanup: most recent duration on all eligible files (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_DURATION	1404
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_DURATION	1405
 /*! checkpoint-cleanup: most recent handles processed */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_HANDLE_PROCESSED	1405
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_HANDLE_PROCESSED	1406
 /*! checkpoint-cleanup: most recent in-memory pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_INMEM_PAGES_VISITED	1406
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_INMEM_PAGES_VISITED	1407
 /*! checkpoint-cleanup: pages added for eviction */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_EVICT	1407
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_EVICT	1408
 /*! checkpoint-cleanup: pages dirtied due to obsolete time window */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	1408
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	1409
 /*! checkpoint-cleanup: pages read into cache (reclaim_space) */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	1409
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	1410
 /*! checkpoint-cleanup: pages read into cache due to obsolete time window */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	1410
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	1411
 /*! checkpoint-cleanup: pages removed */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_REMOVED	1411
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_REMOVED	1412
 /*! checkpoint-cleanup: pages skipped during tree walk */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	1412
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	1413
 /*! checkpoint-cleanup: pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_VISITED	1413
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_VISITED	1414
 /*! checkpoint-cleanup: successful calls */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_SUCCESS		1414
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_SUCCESS		1415
 /*! checkpoint: checkpoint has acquired a snapshot for its transaction */
-#define	WT_STAT_CONN_CHECKPOINT_SNAPSHOT_ACQUIRED	1415
+#define	WT_STAT_CONN_CHECKPOINT_SNAPSHOT_ACQUIRED	1416
 /*! checkpoint: checkpoints skipped because database was clean */
-#define	WT_STAT_CONN_CHECKPOINT_SKIPPED			1416
+#define	WT_STAT_CONN_CHECKPOINT_SKIPPED			1417
 /*! checkpoint: fsync calls after allocating the transaction ID */
-#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST		1417
+#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST		1418
 /*! checkpoint: fsync duration after allocating the transaction ID (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST_DURATION	1418
+#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST_DURATION	1419
 /*! checkpoint: generation */
-#define	WT_STAT_CONN_CHECKPOINT_GENERATION		1419
+#define	WT_STAT_CONN_CHECKPOINT_GENERATION		1420
 /*! checkpoint: max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_MAX		1420
+#define	WT_STAT_CONN_CHECKPOINT_TIME_MAX		1421
 /*!
  * checkpoint: metadata operations applied during disaggregated
  * checkpoint
  */
-#define	WT_STAT_CONN_CHECKPOINT_DISAGG_METADATA_APPLY	1421
+#define	WT_STAT_CONN_CHECKPOINT_DISAGG_METADATA_APPLY	1422
 /*!
  * checkpoint: metadata operations skipped during disaggregated
  * checkpoint because they were not stable
  */
-#define	WT_STAT_CONN_CHECKPOINT_DISAGG_METADATA_UNSTABLE	1422
+#define	WT_STAT_CONN_CHECKPOINT_DISAGG_METADATA_UNSTABLE	1423
 /*! checkpoint: min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_MIN		1423
+#define	WT_STAT_CONN_CHECKPOINT_TIME_MIN		1424
 /*!
  * checkpoint: most recent duration for checkpoint dropping all handles
  * (usecs)
  */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROP_DURATION	1424
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROP_DURATION	1425
 /*! checkpoint: most recent duration for gathering all handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION		1425
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION		1426
 /*! checkpoint: most recent duration for gathering applied handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLY_DURATION	1426
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLY_DURATION	1427
 /*! checkpoint: most recent duration for gathering skipped handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIP_DURATION	1427
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIP_DURATION	1428
 /*! checkpoint: most recent duration for handles metadata checked (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECK_DURATION	1428
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECK_DURATION	1429
 /*! checkpoint: most recent duration for locking the handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCK_DURATION	1429
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCK_DURATION	1430
 /*! checkpoint: most recent handles applied */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLIED		1430
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLIED		1431
 /*! checkpoint: most recent handles checkpoint dropped */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROPPED		1431
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROPPED		1432
 /*! checkpoint: most recent handles metadata checked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECKED	1432
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECKED	1433
 /*! checkpoint: most recent handles metadata locked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCKED		1433
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCKED		1434
 /*! checkpoint: most recent handles skipped */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIPPED		1434
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIPPED		1435
 /*! checkpoint: most recent handles walked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_WALKED		1435
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_WALKED		1436
 /*! checkpoint: most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_RECENT		1436
+#define	WT_STAT_CONN_CHECKPOINT_TIME_RECENT		1437
 /*! checkpoint: number of bytes reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED_BYTES	1437
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED_BYTES	1438
 /*! checkpoint: number of checkpoints started by api */
-#define	WT_STAT_CONN_CHECKPOINTS_API			1438
+#define	WT_STAT_CONN_CHECKPOINTS_API			1439
 /*! checkpoint: number of checkpoints started by compaction */
-#define	WT_STAT_CONN_CHECKPOINTS_COMPACT		1439
+#define	WT_STAT_CONN_CHECKPOINTS_COMPACT		1440
 /*! checkpoint: number of files synced */
-#define	WT_STAT_CONN_CHECKPOINT_SYNC			1440
+#define	WT_STAT_CONN_CHECKPOINT_SYNC			1441
 /*! checkpoint: number of handles visited after writes complete */
-#define	WT_STAT_CONN_CHECKPOINT_PRESYNC			1441
+#define	WT_STAT_CONN_CHECKPOINT_PRESYNC			1442
 /*! checkpoint: number of history store pages reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_HS_PAGES_RECONCILED	1442
+#define	WT_STAT_CONN_CHECKPOINT_HS_PAGES_RECONCILED	1443
 /*! checkpoint: number of internal pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_INTERNAL	1443
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_INTERNAL	1444
 /*! checkpoint: number of leaf pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_LEAF	1444
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_LEAF	1445
 /*! checkpoint: number of pages reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED	1445
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED	1446
 /*!
  * checkpoint: number of pages reconciled by checkpoint parallel worker
  * threads
  */
-#define	WT_STAT_CONN_CHECKPOINT_PARALLEL_PAGES_RECONCILED	1446
+#define	WT_STAT_CONN_CHECKPOINT_PARALLEL_PAGES_RECONCILED	1447
 /*!
  * checkpoint: number of pages whose reconciliation was skipped because
  * eviction already reconciled them under the checkpoint snapshot
  */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILIATION_SKIPPED_EVICT_SNAPSHOT	1447
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILIATION_SKIPPED_EVICT_SNAPSHOT	1448
 /*! checkpoint: prepare currently running */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1448
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1449
 /*! checkpoint: prepare max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1449
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1450
 /*! checkpoint: prepare min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1450
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1451
 /*! checkpoint: prepare most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1451
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1452
 /*! checkpoint: prepare total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1452
+#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1453
 /*! checkpoint: progress state */
-#define	WT_STAT_CONN_CHECKPOINT_STATE			1453
+#define	WT_STAT_CONN_CHECKPOINT_STATE			1454
 /*! checkpoint: scrub dirty target */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1454
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1455
 /*! checkpoint: scrub max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1455
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1456
 /*! checkpoint: scrub min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1456
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1457
 /*! checkpoint: scrub most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1457
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1458
 /*! checkpoint: scrub total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1458
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1459
 /*! checkpoint: stop timing stress active */
-#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1459
+#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1460
 /*!
  * checkpoint: the percentage of checkpoint sync time spent in
  * reconciliation across all threads
  */
-#define	WT_STAT_CONN_CHECKPOINT_SYNC_REC_PCT		1460
+#define	WT_STAT_CONN_CHECKPOINT_SYNC_REC_PCT		1461
 /*! checkpoint: time spent on per-tree checkpoint work (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1461
+#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1462
 /*! checkpoint: total failed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1462
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1463
 /*! checkpoint: total succeed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1463
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1464
 /*! checkpoint: total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1464
+#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1465
 /*!
  * checkpoint: total time (msecs) writing pages to stable storage during
  * checkpoint reconciliation
  */
-#define	WT_STAT_CONN_CHECKPOINT_REC_BLKCACHE_WRITE	1465
+#define	WT_STAT_CONN_CHECKPOINT_REC_BLKCACHE_WRITE	1466
 /*! checkpoint: wait cycles while cache dirty level is decreasing */
-#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1466
+#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1467
 /*! connection: auto adjusting condition resets */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1467
+#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1468
 /*! connection: auto adjusting condition wait calls */
-#define	WT_STAT_CONN_COND_AUTO_WAIT			1468
+#define	WT_STAT_CONN_COND_AUTO_WAIT			1469
 /*!
  * connection: auto adjusting condition wait raced to update timeout and
  * skipped updating
  */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1469
+#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1470
 /*! connection: btrees currently open */
-#define	WT_STAT_CONN_BTREE_OPEN				1470
+#define	WT_STAT_CONN_BTREE_OPEN				1471
 /*! connection: detected system time went backwards */
-#define	WT_STAT_CONN_TIME_TRAVEL			1471
+#define	WT_STAT_CONN_TIME_TRAVEL			1472
 /*! connection: files currently open */
-#define	WT_STAT_CONN_FILE_OPEN				1472
+#define	WT_STAT_CONN_FILE_OPEN				1473
 /*! connection: hash bucket array size for data handles */
-#define	WT_STAT_CONN_BUCKETS_DH				1473
+#define	WT_STAT_CONN_BUCKETS_DH				1474
 /*! connection: hash bucket array size general */
-#define	WT_STAT_CONN_BUCKETS				1474
+#define	WT_STAT_CONN_BUCKETS				1475
 /*! connection: memory allocations */
-#define	WT_STAT_CONN_MEMORY_ALLOCATION			1475
+#define	WT_STAT_CONN_MEMORY_ALLOCATION			1476
 /*! connection: memory frees */
-#define	WT_STAT_CONN_MEMORY_FREE			1476
+#define	WT_STAT_CONN_MEMORY_FREE			1477
 /*! connection: memory re-allocations */
-#define	WT_STAT_CONN_MEMORY_GROW			1477
+#define	WT_STAT_CONN_MEMORY_GROW			1478
 /*! connection: number of sessions without a sweep for 5+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1478
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1479
 /*! connection: number of sessions without a sweep for 60+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1479
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1480
 /*! connection: pthread mutex condition wait calls */
-#define	WT_STAT_CONN_COND_WAIT				1480
+#define	WT_STAT_CONN_COND_WAIT				1481
 /*! connection: pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			1481
+#define	WT_STAT_CONN_RWLOCK_READ			1482
 /*! connection: pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			1482
+#define	WT_STAT_CONN_RWLOCK_WRITE			1483
 /*! connection: total fsync I/Os */
-#define	WT_STAT_CONN_FSYNC_IO				1483
+#define	WT_STAT_CONN_FSYNC_IO				1484
 /*! connection: total read I/Os */
-#define	WT_STAT_CONN_READ_IO				1484
+#define	WT_STAT_CONN_READ_IO				1485
 /*! connection: total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				1485
+#define	WT_STAT_CONN_WRITE_IO				1486
 /*! cursor: Total number of deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1486
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1487
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1487
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1488
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1488
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1489
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1489
+#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1490
 /*!
  * cursor: Total number of in-memory deleted pages skipped during tree
  * walk
  */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1490
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1491
 /*! cursor: Total number of on-disk deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1491
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1492
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1492
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1493
 /*!
  * cursor: Total number of times a tree walk waited for the page lock
  * during the page skip check
  */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_SKIP_LOCK_CONTENDED	1493
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_SKIP_LOCK_CONTENDED	1494
 /*!
  * cursor: Total number of times cursor fails to temporarily release
  * pinned page to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1494
+#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1495
 /*!
  * cursor: Total number of times cursor temporarily releases pinned page
  * to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION			1495
+#define	WT_STAT_CONN_CURSOR_REPOSITION			1496
 /*! cursor: bulk cursor count */
-#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1496
+#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1497
 /*! cursor: cached cursor count */
-#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1497
+#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1498
 /*! cursor: cursor bound calls that return an error */
-#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1498
+#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1499
 /*! cursor: cursor bounds cleared from reset */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1499
+#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1500
 /*! cursor: cursor bounds comparisons performed */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1500
+#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1501
 /*! cursor: cursor bounds next called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1501
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1502
 /*! cursor: cursor bounds next early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1502
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1503
 /*! cursor: cursor bounds prev called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1503
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1504
 /*! cursor: cursor bounds prev early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1504
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1505
 /*! cursor: cursor bounds search early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1505
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1506
 /*! cursor: cursor bounds search near call repositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1506
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1507
 /*! cursor: cursor bulk loaded cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1507
+#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1508
 /*! cursor: cursor cache calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1508
+#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1509
 /*! cursor: cursor close calls that result in cache */
-#define	WT_STAT_CONN_CURSOR_CACHE			1509
+#define	WT_STAT_CONN_CURSOR_CACHE			1510
 /*! cursor: cursor close calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1510
+#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1511
 /*! cursor: cursor compare calls that return an error */
-#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1511
+#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1512
 /*! cursor: cursor create calls */
-#define	WT_STAT_CONN_CURSOR_CREATE			1512
+#define	WT_STAT_CONN_CURSOR_CREATE			1513
 /*! cursor: cursor equals calls that return an error */
-#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1513
+#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1514
 /*! cursor: cursor get key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1514
+#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1515
 /*! cursor: cursor get value calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1515
+#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1516
 /*! cursor: cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT			1516
+#define	WT_STAT_CONN_CURSOR_INSERT			1517
 /*! cursor: cursor insert calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1517
+#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1518
 /*! cursor: cursor insert check calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1518
+#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1519
 /*! cursor: cursor insert key and value bytes */
-#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1519
+#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1520
 /*! cursor: cursor largest key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1520
+#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1521
 /*! cursor: cursor modify calls */
-#define	WT_STAT_CONN_CURSOR_MODIFY			1521
+#define	WT_STAT_CONN_CURSOR_MODIFY			1522
 /*! cursor: cursor modify calls that return an error */
-#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1522
+#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1523
 /*! cursor: cursor modify key and value bytes affected */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1523
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1524
 /*! cursor: cursor modify value bytes modified */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1524
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1525
 /*! cursor: cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT			1525
+#define	WT_STAT_CONN_CURSOR_NEXT			1526
 /*! cursor: cursor next calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1526
+#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1527
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1527
+#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1528
 /*!
  * cursor: cursor next calls that skip greater than 1 and fewer than 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1528
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1529
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1529
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1530
 /*! cursor: cursor next random calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1530
+#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1531
 /*! cursor: cursor operation restarted */
-#define	WT_STAT_CONN_CURSOR_RESTART			1531
+#define	WT_STAT_CONN_CURSOR_RESTART			1532
 /*! cursor: cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV			1532
+#define	WT_STAT_CONN_CURSOR_PREV			1533
 /*! cursor: cursor prev calls that return an error */
-#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1533
+#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1534
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1534
+#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1535
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1535
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1536
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1536
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1537
 /*! cursor: cursor reconfigure calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1537
+#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1538
 /*! cursor: cursor remove calls */
-#define	WT_STAT_CONN_CURSOR_REMOVE			1538
+#define	WT_STAT_CONN_CURSOR_REMOVE			1539
 /*! cursor: cursor remove calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1539
+#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1540
 /*! cursor: cursor remove key bytes removed */
-#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1540
+#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1541
 /*! cursor: cursor reopen calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1541
+#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1542
 /*! cursor: cursor reserve calls */
-#define	WT_STAT_CONN_CURSOR_RESERVE			1542
+#define	WT_STAT_CONN_CURSOR_RESERVE			1543
 /*! cursor: cursor reserve calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1543
+#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1544
 /*! cursor: cursor reset calls */
-#define	WT_STAT_CONN_CURSOR_RESET			1544
+#define	WT_STAT_CONN_CURSOR_RESET			1545
 /*! cursor: cursor reset calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1545
+#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1546
 /*! cursor: cursor search calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH			1546
+#define	WT_STAT_CONN_CURSOR_SEARCH			1547
 /*! cursor: cursor search calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1547
+#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1548
 /*! cursor: cursor search history store calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1548
+#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1549
 /*! cursor: cursor search near calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1549
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1550
 /*! cursor: cursor search near calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1550
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1551
 /*! cursor: cursor sweep buckets */
-#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1551
+#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1552
 /*! cursor: cursor sweep cursors closed */
-#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1552
+#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1553
 /*! cursor: cursor sweep cursors examined */
-#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1553
+#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1554
 /*! cursor: cursor sweeps */
-#define	WT_STAT_CONN_CURSOR_SWEEP			1554
+#define	WT_STAT_CONN_CURSOR_SWEEP			1555
 /*! cursor: cursor truncate calls */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE			1555
+#define	WT_STAT_CONN_CURSOR_TRUNCATE			1556
 /*! cursor: cursor truncates performed on individual keys */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1556
+#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1557
 /*! cursor: cursor update calls */
-#define	WT_STAT_CONN_CURSOR_UPDATE			1557
+#define	WT_STAT_CONN_CURSOR_UPDATE			1558
 /*! cursor: cursor update calls that return an error */
-#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1558
+#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1559
 /*! cursor: cursor update key and value bytes */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1559
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1560
 /*! cursor: cursor update value size change */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1560
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1561
 /*! cursor: cursors reused from cache */
-#define	WT_STAT_CONN_CURSOR_REOPEN			1561
+#define	WT_STAT_CONN_CURSOR_REOPEN			1562
 /*! cursor: open cursor count */
-#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1562
+#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1563
 /*! cursor: open cursor time application (usecs) */
-#define	WT_STAT_CONN_CURSOR_OPEN_TIME_USER_USECS	1563
+#define	WT_STAT_CONN_CURSOR_OPEN_TIME_USER_USECS	1564
 /*! cursor: open cursor time internal (usecs) */
-#define	WT_STAT_CONN_CURSOR_OPEN_TIME_INTERNAL_USECS	1564
+#define	WT_STAT_CONN_CURSOR_OPEN_TIME_INTERNAL_USECS	1565
 /*! data-handle: Layered connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_LAYERED_COUNT	1565
+#define	WT_STAT_CONN_DH_CONN_HANDLE_LAYERED_COUNT	1566
 /*! data-handle: Table connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TABLE_COUNT		1566
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TABLE_COUNT		1567
 /*! data-handle: Tiered connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_COUNT	1567
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_COUNT	1568
 /*! data-handle: Tiered_Tree connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_TREE_COUNT	1568
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_TREE_COUNT	1569
 /*! data-handle: btree connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_BTREE_COUNT		1569
+#define	WT_STAT_CONN_DH_CONN_HANDLE_BTREE_COUNT		1570
 /*! data-handle: checkpoint connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_CHECKPOINT_COUNT	1570
+#define	WT_STAT_CONN_DH_CONN_HANDLE_CHECKPOINT_COUNT	1571
 /*! data-handle: connection data handle size */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1571
+#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1572
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1572
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1573
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1573
+#define	WT_STAT_CONN_DH_SWEEP_REF			1574
 /*! data-handle: connection sweep dead dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_DEAD_CLOSE		1574
+#define	WT_STAT_CONN_DH_SWEEP_DEAD_CLOSE		1575
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1575
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1576
 /*! data-handle: connection sweep expired dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_EXPIRED_CLOSE		1576
+#define	WT_STAT_CONN_DH_SWEEP_EXPIRED_CLOSE		1577
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1577
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1578
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1578
+#define	WT_STAT_CONN_DH_SWEEPS				1579
 /*!
  * data-handle: connection sweeps skipped due to checkpoint gathering
  * handles
  */
-#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1579
+#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1580
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1580
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1581
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1581
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1582
 /*! disagg: abandon checkpoints failed */
-#define	WT_STAT_CONN_DISAGG_ABANDON_CHECKPOINT_FAILED	1582
+#define	WT_STAT_CONN_DISAGG_ABANDON_CHECKPOINT_FAILED	1583
 /*! disagg: abandon checkpoints succeeded */
-#define	WT_STAT_CONN_DISAGG_ABANDON_CHECKPOINT_SUCCEED	1583
+#define	WT_STAT_CONN_DISAGG_ABANDON_CHECKPOINT_SUCCEED	1584
 /*! disagg: apply checkpoint metadata most recent time (msecs) */
-#define	WT_STAT_CONN_DISAGG_APPLY_CHECKPOINT_META_TIME	1584
+#define	WT_STAT_CONN_DISAGG_APPLY_CHECKPOINT_META_TIME	1585
 /*!
  * disagg: checkpoint metadata compatible version of the most recently
  * picked up checkpoint: 0 none
  */
-#define	WT_STAT_CONN_DISAGG_CHECKPOINT_STORAGE_COMPATIBLE_VERSION	1585
+#define	WT_STAT_CONN_DISAGG_CHECKPOINT_STORAGE_COMPATIBLE_VERSION	1586
 /*! disagg: checkpoint metadata compatible version this binary supports */
-#define	WT_STAT_CONN_DISAGG_CHECKPOINT_BINARY_COMPATIBLE_VERSION	1586
+#define	WT_STAT_CONN_DISAGG_CHECKPOINT_BINARY_COMPATIBLE_VERSION	1587
 /*!
  * disagg: checkpoint metadata version of the most recently picked up
  * checkpoint: 0 none
  */
-#define	WT_STAT_CONN_DISAGG_CHECKPOINT_STORAGE_VERSION	1587
+#define	WT_STAT_CONN_DISAGG_CHECKPOINT_STORAGE_VERSION	1588
 /*! disagg: checkpoint metadata version this binary writes */
-#define	WT_STAT_CONN_DISAGG_CHECKPOINT_BINARY_VERSION	1588
+#define	WT_STAT_CONN_DISAGG_CHECKPOINT_BINARY_VERSION	1589
 /*! disagg: checkpoint pick-ups deferred for active transaction snapshots */
-#define	WT_STAT_CONN_DISAGG_CHECKPOINT_DEFER		1589
+#define	WT_STAT_CONN_DISAGG_CHECKPOINT_DEFER		1590
 /*! disagg: connection reconfiguration */
-#define	WT_STAT_CONN_DISAGG_CONN_RECONFIG		1590
+#define	WT_STAT_CONN_DISAGG_CONN_RECONFIG		1591
 /*! disagg: database size */
-#define	WT_STAT_CONN_DISAGG_DATABASE_SIZE		1591
+#define	WT_STAT_CONN_DISAGG_DATABASE_SIZE		1592
 /*!
  * disagg: existing file metadata entries updated during checkpoint pick-
  * up
  */
-#define	WT_STAT_CONN_DISAGG_PICK_UP_FILE_META_UPDATED	1592
+#define	WT_STAT_CONN_DISAGG_PICK_UP_FILE_META_UPDATED	1593
 /*! disagg: ingest-to-stable tombstone escape bytes stripped */
-#define	WT_STAT_CONN_DISAGG_INGEST_STABLE_TOMBSTONE_STRIPPED	1593
+#define	WT_STAT_CONN_DISAGG_INGEST_STABLE_TOMBSTONE_STRIPPED	1594
 /*! disagg: most recently adopted checkpoint metadata LSN */
-#define	WT_STAT_CONN_DISAGG_CHECKPOINT_META_LSN		1594
+#define	WT_STAT_CONN_DISAGG_CHECKPOINT_META_LSN		1595
 /*! disagg: most recently delivered checkpoint metadata LSN */
-#define	WT_STAT_CONN_DISAGG_CHECKPOINT_DELIVERED_LSN	1595
+#define	WT_STAT_CONN_DISAGG_CHECKPOINT_DELIVERED_LSN	1596
 /*! disagg: new file metadata entries inserted during checkpoint pick-up */
-#define	WT_STAT_CONN_DISAGG_PICK_UP_FILE_META_INSERTED	1596
+#define	WT_STAT_CONN_DISAGG_PICK_UP_FILE_META_INSERTED	1597
 /*! disagg: pick up checkpoint most recent time (msecs) */
-#define	WT_STAT_CONN_DISAGG_PICK_UP_CHECKPOINT_TIME	1597
+#define	WT_STAT_CONN_DISAGG_PICK_UP_CHECKPOINT_TIME	1598
 /*! disagg: pick up checkpoint time at startup (msecs) */
-#define	WT_STAT_CONN_DISAGG_PICK_UP_CHECKPOINT_TIME_STARTUP	1598
+#define	WT_STAT_CONN_DISAGG_PICK_UP_CHECKPOINT_TIME_STARTUP	1599
 /*! disagg: role leader */
-#define	WT_STAT_CONN_DISAGG_ROLE_LEADER			1599
+#define	WT_STAT_CONN_DISAGG_ROLE_LEADER			1600
 /*!
  * disagg: snapshots rebuilt after racing a checkpoint pick-up or role
  * change
  */
-#define	WT_STAT_CONN_DISAGG_SNAPSHOT_REBUILD		1600
+#define	WT_STAT_CONN_DISAGG_SNAPSHOT_REBUILD		1601
 /*!
  * disagg: stable tombstone encoding mode: 0 not yet determined, 1 legacy
  * escaped, 2 unescaped
  */
-#define	WT_STAT_CONN_DISAGG_STABLE_TOMBSTONE_ENCODING	1601
+#define	WT_STAT_CONN_DISAGG_STABLE_TOMBSTONE_ENCODING	1602
 /*! disagg: step down in progress */
-#define	WT_STAT_CONN_DISAGG_STEP_DOWN_IN_PROGRESS	1602
+#define	WT_STAT_CONN_DISAGG_STEP_DOWN_IN_PROGRESS	1603
 /*! disagg: step down most recent time (msecs) */
-#define	WT_STAT_CONN_DISAGG_STEP_DOWN_TIME		1603
+#define	WT_STAT_CONN_DISAGG_STEP_DOWN_TIME		1604
 /*! disagg: step up in progress */
-#define	WT_STAT_CONN_DISAGG_STEP_UP_IN_PROGRESS		1604
+#define	WT_STAT_CONN_DISAGG_STEP_UP_IN_PROGRESS		1605
 /*! disagg: step up most recent time (msecs) */
-#define	WT_STAT_CONN_DISAGG_STEP_UP_TIME		1605
+#define	WT_STAT_CONN_DISAGG_STEP_UP_TIME		1606
 /*!
  * disagg: tables created without a stable constituent while the step-
  * down timestamp is set
  */
-#define	WT_STAT_CONN_DISAGG_STEP_DOWN_WINDOW_CREATES	1606
+#define	WT_STAT_CONN_DISAGG_STEP_DOWN_WINDOW_CREATES	1607
 /*! layered: Layered table cursor insert operations */
-#define	WT_STAT_CONN_LAYERED_CURS_INSERT		1607
+#define	WT_STAT_CONN_LAYERED_CURS_INSERT		1608
 /*! layered: Layered table cursor modify operations */
-#define	WT_STAT_CONN_LAYERED_CURS_MODIFY		1608
+#define	WT_STAT_CONN_LAYERED_CURS_MODIFY		1609
 /*! layered: Layered table cursor next operations */
-#define	WT_STAT_CONN_LAYERED_CURS_NEXT			1609
+#define	WT_STAT_CONN_LAYERED_CURS_NEXT			1610
 /*! layered: Layered table cursor next operations from the ingest btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_NEXT_INGEST		1610
+#define	WT_STAT_CONN_LAYERED_CURS_NEXT_INGEST		1611
 /*! layered: Layered table cursor next operations from the stable btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_NEXT_STABLE		1611
+#define	WT_STAT_CONN_LAYERED_CURS_NEXT_STABLE		1612
 /*!
  * layered: Layered table cursor opens the stable btree for the first
  * time
  */
-#define	WT_STAT_CONN_LAYERED_CURS_OPEN_STABLE		1612
+#define	WT_STAT_CONN_LAYERED_CURS_OPEN_STABLE		1613
 /*! layered: Layered table cursor prev operations */
-#define	WT_STAT_CONN_LAYERED_CURS_PREV			1613
+#define	WT_STAT_CONN_LAYERED_CURS_PREV			1614
 /*! layered: Layered table cursor prev operations from the ingest btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_PREV_INGEST		1614
+#define	WT_STAT_CONN_LAYERED_CURS_PREV_INGEST		1615
 /*! layered: Layered table cursor prev operations from the stable btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_PREV_STABLE		1615
+#define	WT_STAT_CONN_LAYERED_CURS_PREV_STABLE		1616
 /*! layered: Layered table cursor remove operations */
-#define	WT_STAT_CONN_LAYERED_CURS_REMOVE		1616
+#define	WT_STAT_CONN_LAYERED_CURS_REMOVE		1617
 /*!
  * layered: Layered table cursor reopens the stable btree (role change or
  * checkpoint advance)
  */
-#define	WT_STAT_CONN_LAYERED_CURS_REOPEN_STABLE		1617
+#define	WT_STAT_CONN_LAYERED_CURS_REOPEN_STABLE		1618
 /*! layered: Layered table cursor search near operations */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR		1618
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR		1619
 /*!
  * layered: Layered table cursor search near operations from the ingest
  * btrees
  */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_INGEST	1619
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_INGEST	1620
 /*!
  * layered: Layered table cursor search near operations from the stable
  * btrees
  */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_STABLE	1620
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_STABLE	1621
 /*! layered: Layered table cursor search operations */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH		1621
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH		1622
 /*! layered: Layered table cursor search operations from the ingest btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_INGEST		1622
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_INGEST		1623
 /*! layered: Layered table cursor search operations from the stable btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_STABLE		1623
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_STABLE		1624
 /*!
  * layered: Layered table cursor stable open refused to preserve a
  * transaction snapshot
  */
-#define	WT_STAT_CONN_LAYERED_CURS_OPEN_STABLE_REFUSED	1624
-/*!
- * layered: Layered table cursor stable open rolled back after racing a
- * step-down
- */
-#define	WT_STAT_CONN_LAYERED_CURS_OPEN_STABLE_STEPDOWN_RACE	1625
+#define	WT_STAT_CONN_LAYERED_CURS_OPEN_STABLE_REFUSED	1625
 /*! layered: Layered table cursor update operations */
 #define	WT_STAT_CONN_LAYERED_CURS_UPDATE		1626
-/*! layered: Layered table live stable open refused on a follower */
-#define	WT_STAT_CONN_LAYERED_STABLE_LIVE_OPEN_REFUSED	1627
 /*!
  * layered: Layered table stable values beginning with the tombstone byte
  * sequence and ending with a non-tombstone byte
  */
-#define	WT_STAT_CONN_LAYERED_CURS_STABLE_VALUE_TOMBSTONE_PREFIX	1628
+#define	WT_STAT_CONN_LAYERED_CURS_STABLE_VALUE_TOMBSTONE_PREFIX	1627
 /*!
  * layered: Layered table stable values beginning with the tombstone byte
  * sequence and ending with a tombstone byte
  */
-#define	WT_STAT_CONN_LAYERED_CURS_STABLE_VALUE_TOMBSTONE_SUFFIX	1629
+#define	WT_STAT_CONN_LAYERED_CURS_STABLE_VALUE_TOMBSTONE_SUFFIX	1628
 /*!
  * layered: Layered table stable values equal to the tombstone byte
  * sequence
  */
-#define	WT_STAT_CONN_LAYERED_CURS_STABLE_VALUE_TOMBSTONE	1630
+#define	WT_STAT_CONN_LAYERED_CURS_STABLE_VALUE_TOMBSTONE	1629
 /*! layered: Layered table stable values equal to three tombstone bytes */
-#define	WT_STAT_CONN_LAYERED_CURS_STABLE_VALUE_TOMBSTONE_X3	1631
+#define	WT_STAT_CONN_LAYERED_CURS_STABLE_VALUE_TOMBSTONE_X3	1630
 /*!
  * layered: checkpoints performed on this table by the layered table
  * manager
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS	1632
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS	1631
 /*! layered: disagg pick up checkpoints failed */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FAILED	1633
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FAILED	1632
 /*! layered: disagg pick up checkpoints succeeded */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_SUCCEED	1634
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_SUCCEED	1633
 /*!
  * layered: how many log applications the layered table manager applied
  * on this tree
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_APPLIED	1635
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_APPLIED	1634
 /*!
  * layered: how many log applications the layered table manager skipped
  * on this tree
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_SKIPPED	1636
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_SKIPPED	1635
 /*!
  * layered: how many previously-applied LSNs the layered table manager
  * skipped on this tree
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_SKIP_LSN	1637
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_SKIP_LSN	1636
 /*! layered: number of checkpoints picked up by a follower */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FOLLOWER	1638
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FOLLOWER	1637
 /*! layered: the number of tables the layered table manager has open */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_TABLES	1639
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_TABLES	1638
 /*! layered: the number of times the truncate list was searched */
-#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_SEARCH_CALLS	1640
+#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_SEARCH_CALLS	1639
 /*!
  * layered: the number of times truncate list garbage collection ran with
  * a valid prune timestamp
  */
-#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_GC_RUNS	1641
+#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_GC_RUNS	1640
 /*!
  * layered: the number of truncate list entries removed by garbage
  * collection
  */
-#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_GC_ENTRIES_REMOVED	1642
+#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_GC_ENTRIES_REMOVED	1641
 /*! layered: the number of truncate list entries walked during search */
-#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_SEARCH_ENTRIES_WALKED	1643
+#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_SEARCH_ENTRIES_WALKED	1642
 /*!
  * live-restore: number of bytes copied from the source to the
  * destination
  */
-#define	WT_STAT_CONN_LIVE_RESTORE_BYTES_COPIED		1644
+#define	WT_STAT_CONN_LIVE_RESTORE_BYTES_COPIED		1643
 /*! live-restore: number of files remaining for migration completion */
-#define	WT_STAT_CONN_LIVE_RESTORE_WORK_REMAINING	1645
+#define	WT_STAT_CONN_LIVE_RESTORE_WORK_REMAINING	1644
 /*! live-restore: number of reads from the source database */
-#define	WT_STAT_CONN_LIVE_RESTORE_SOURCE_READ_COUNT	1646
+#define	WT_STAT_CONN_LIVE_RESTORE_SOURCE_READ_COUNT	1645
 /*! live-restore: source read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT2	1647
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT2	1646
 /*! live-restore: source read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT5	1648
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT5	1647
 /*! live-restore: source read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT10	1649
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT10	1648
 /*! live-restore: source read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT50	1650
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT50	1649
 /*! live-restore: source read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT100	1651
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT100	1650
 /*! live-restore: source read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT250	1652
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT250	1651
 /*! live-restore: source read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT500	1653
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT500	1652
 /*! live-restore: source read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT1000	1654
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT1000	1653
 /*! live-restore: source read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_GT1000	1655
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_GT1000	1654
 /*! live-restore: source read latency histogram total (msecs) */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_TOTAL_MSECS	1656
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_TOTAL_MSECS	1655
 /*! live-restore: state */
-#define	WT_STAT_CONN_LIVE_RESTORE_STATE			1657
+#define	WT_STAT_CONN_LIVE_RESTORE_STATE			1656
 /*! load-control: number of read operations rejected due to load control */
-#define	WT_STAT_CONN_READ_REJECT_COUNT			1658
+#define	WT_STAT_CONN_READ_REJECT_COUNT			1657
 /*! load-control: number of write operations rejected due to load control */
-#define	WT_STAT_CONN_WRITE_REJECT_COUNT			1659
+#define	WT_STAT_CONN_WRITE_REJECT_COUNT			1658
 /*! load-control: read load at the system level */
-#define	WT_STAT_CONN_READ_LOAD				1660
+#define	WT_STAT_CONN_READ_LOAD				1659
 /*! load-control: write load at the system level */
-#define	WT_STAT_CONN_WRITE_LOAD				1661
+#define	WT_STAT_CONN_WRITE_LOAD				1660
 /*! lock: btree page lock acquisitions */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_COUNT		1662
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_COUNT		1661
 /*! lock: btree page lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_APPLICATION	1663
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_APPLICATION	1662
 /*! lock: btree page lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_INTERNAL	1664
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_INTERNAL	1663
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1665
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1664
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1666
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1665
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1667
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1666
 /*! lock: dhandle lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1668
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1667
 /*! lock: dhandle lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1669
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1668
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1670
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1669
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1671
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1670
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1672
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1671
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1673
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1672
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1674
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1673
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1675
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1674
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1676
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1675
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1677
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1676
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1678
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1677
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1679
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1678
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1680
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1679
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1681
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1680
 /*! lock: txn global lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1682
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1681
 /*! lock: txn global lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1683
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1682
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1684
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1683
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1685
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1684
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1686
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1685
 /*! log: force log remove time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1687
+#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1686
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1688
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1687
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1689
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1688
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1690
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1689
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1691
+#define	WT_STAT_CONN_LOG_FLUSH				1690
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1692
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1691
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1693
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1692
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1694
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1693
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1695
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1694
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1696
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1695
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1697
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1696
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1698
+#define	WT_STAT_CONN_LOG_SCANS				1697
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1699
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1698
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1700
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1699
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1701
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1700
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1702
+#define	WT_STAT_CONN_LOG_SYNC				1701
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1703
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1702
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1704
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1703
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1705
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1704
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1706
+#define	WT_STAT_CONN_LOG_WRITES				1705
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1707
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1706
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1708
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1707
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1709
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1708
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1710
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1709
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1711
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1710
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1712
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1711
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1713
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1712
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1714
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1713
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1715
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1714
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1716
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1715
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1717
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1716
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1718
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1717
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1719
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1718
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1720
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1719
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1721
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1720
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1722
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1721
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1723
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1722
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1724
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1723
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1725
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1724
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1726
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1725
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1727
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1726
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1728
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1727
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1729
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1728
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1730
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1729
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1731
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1730
 /*! perf: block manager read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT2	1732
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT2	1731
 /*! perf: block manager read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT5	1733
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT5	1732
 /*! perf: block manager read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT10	1734
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT10	1733
 /*! perf: block manager read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT50	1735
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT50	1734
 /*! perf: block manager read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT100	1736
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT100	1735
 /*! perf: block manager read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT250	1737
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT250	1736
 /*! perf: block manager read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT500	1738
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT500	1737
 /*! perf: block manager read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT1000	1739
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT1000	1738
 /*! perf: block manager read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_GT1000	1740
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_GT1000	1739
 /*! perf: block manager read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_TOTAL_MSECS	1741
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_TOTAL_MSECS	1740
 /*! perf: block manager write latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT2	1742
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT2	1741
 /*! perf: block manager write latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT5	1743
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT5	1742
 /*! perf: block manager write latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT10	1744
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT10	1743
 /*! perf: block manager write latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT50	1745
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT50	1744
 /*! perf: block manager write latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT100	1746
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT100	1745
 /*! perf: block manager write latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT250	1747
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT250	1746
 /*! perf: block manager write latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT500	1748
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT500	1747
 /*! perf: block manager write latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT1000	1749
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT1000	1748
 /*! perf: block manager write latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_GT1000	1750
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_GT1000	1749
 /*! perf: block manager write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_TOTAL_MSECS	1751
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_TOTAL_MSECS	1750
 /*! perf: disagg block manager read latency histogram (bucket 1) - 50-99us */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT100	1752
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT100	1751
 /*!
  * perf: disagg block manager read latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT250	1753
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT250	1752
 /*!
  * perf: disagg block manager read latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT500	1754
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT500	1753
 /*!
  * perf: disagg block manager read latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT1000	1755
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT1000	1754
 /*!
  * perf: disagg block manager read latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT2500	1756
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT2500	1755
 /*!
  * perf: disagg block manager read latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT5000	1757
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT5000	1756
 /*!
  * perf: disagg block manager read latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT10000	1758
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT10000	1757
 /*!
  * perf: disagg block manager read latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_GT10000	1759
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_GT10000	1758
 /*! perf: disagg block manager read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_TOTAL_USECS	1760
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_TOTAL_USECS	1759
 /*!
  * perf: disagg block manager write latency histogram (bucket 1) -
  * 50-99us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT100	1761
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT100	1760
 /*!
  * perf: disagg block manager write latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT250	1762
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT250	1761
 /*!
  * perf: disagg block manager write latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT500	1763
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT500	1762
 /*!
  * perf: disagg block manager write latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT1000	1764
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT1000	1763
 /*!
  * perf: disagg block manager write latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT2500	1765
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT2500	1764
 /*!
  * perf: disagg block manager write latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT5000	1766
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT5000	1765
 /*!
  * perf: disagg block manager write latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT10000	1767
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT10000	1766
 /*!
  * perf: disagg block manager write latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_GT10000	1768
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_GT10000	1767
 /*! perf: disagg block manager write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_TOTAL_USECS	1769
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_TOTAL_USECS	1768
 /*! perf: file system read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT2	1770
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT2	1769
 /*! perf: file system read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT5	1771
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT5	1770
 /*! perf: file system read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1772
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1771
 /*! perf: file system read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1773
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1772
 /*! perf: file system read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1774
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1773
 /*! perf: file system read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1775
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1774
 /*! perf: file system read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1776
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1775
 /*! perf: file system read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1777
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1776
 /*! perf: file system read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1778
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1777
 /*! perf: file system read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1779
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1778
 /*! perf: file system write latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT2	1780
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT2	1779
 /*! perf: file system write latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT5	1781
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT5	1780
 /*! perf: file system write latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1782
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1781
 /*! perf: file system write latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1783
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1782
 /*! perf: file system write latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1784
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1783
 /*! perf: file system write latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1785
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1784
 /*! perf: file system write latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1786
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1785
 /*! perf: file system write latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1787
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1786
 /*! perf: file system write latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1788
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1787
 /*! perf: file system write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1789
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1788
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 1) -
  * 0-100us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT100	1790
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT100	1789
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT250	1791
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT250	1790
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT500	1792
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT500	1791
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT1000	1793
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT1000	1792
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT2500	1794
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT2500	1793
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT5000	1795
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT5000	1794
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT10000	1796
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT10000	1795
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_GT10000	1797
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_GT10000	1796
 /*! perf: internal page deltas reconstruct latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_TOTAL_USECS	1798
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_TOTAL_USECS	1797
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 1) -
  * 0-100us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT100	1799
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT100	1798
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT250	1800
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT250	1799
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT500	1801
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT500	1800
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT1000	1802
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT1000	1801
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT2500	1803
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT2500	1802
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT5000	1804
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT5000	1803
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT10000	1805
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT10000	1804
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_GT10000	1806
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_GT10000	1805
 /*! perf: leaf page deltas reconstruct latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_TOTAL_USECS	1807
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_TOTAL_USECS	1806
 /*! perf: operation read latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1808
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1807
 /*! perf: operation read latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1809
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1808
 /*! perf: operation read latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1810
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1809
 /*! perf: operation read latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1811
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1810
 /*! perf: operation read latency histogram (bucket 5) - 1000-2499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT2500	1812
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT2500	1811
 /*! perf: operation read latency histogram (bucket 6) - 2500-4999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT5000	1813
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT5000	1812
 /*! perf: operation read latency histogram (bucket 7) - 5000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1814
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1813
 /*! perf: operation read latency histogram (bucket 8) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1815
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1814
 /*! perf: operation read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1816
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1815
 /*! perf: operation write latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1817
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1816
 /*! perf: operation write latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1818
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1817
 /*! perf: operation write latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1819
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1818
 /*! perf: operation write latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1820
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1819
 /*! perf: operation write latency histogram (bucket 5) - 1000-2499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT2500	1821
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT2500	1820
 /*! perf: operation write latency histogram (bucket 6) - 2500-4999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT5000	1822
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT5000	1821
 /*! perf: operation write latency histogram (bucket 7) - 5000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1823
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1822
 /*! perf: operation write latency histogram (bucket 8) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1824
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1823
 /*! perf: operation write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1825
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1824
 /*! prefetch: could not perform pre-fetch on internal page */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1826
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1825
 /*!
  * prefetch: could not perform pre-fetch on ref without the pre-fetch
  * flag set
  */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1827
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1826
 /*! prefetch: pre-fetch attempted, session has pre-fetching enabled */
-#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1828
+#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1827
 /*! prefetch: pre-fetch not repeating for recently pre-fetched ref */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1829
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1828
 /*! prefetch: pre-fetch not triggered after single disk read */
-#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1830
+#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1829
 /*! prefetch: pre-fetch not triggered as there is no valid dhandle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1831
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1830
 /*! prefetch: pre-fetch not triggered due to disk read count */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1832
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1831
 /*! prefetch: pre-fetch not triggered due to internal session */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1833
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1832
 /*! prefetch: pre-fetch not triggered due to special btree handle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1834
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1833
 /*! prefetch: pre-fetch not triggered, pre-fetch queue is full */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_QUEUE_FULL	1835
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_QUEUE_FULL	1834
 /*! prefetch: pre-fetch page not on disk when reading */
-#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1836
+#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1835
 /*! prefetch: pre-fetch pages queued */
-#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1837
+#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1836
 /*! prefetch: pre-fetch pages read in background */
-#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1838
+#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1837
 /*!
  * prefetch: pre-fetch session check passed, pre-fetch work issued to
  * btree
  */
-#define	WT_STAT_CONN_PREFETCH_ATTEMPTS_SUCCEEDED	1839
+#define	WT_STAT_CONN_PREFETCH_ATTEMPTS_SUCCEEDED	1838
 /*! prefetch: pre-fetch skipped reading in a page due to harmless error */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1840
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1839
 /*!
  * prefetch: pre-fetch skipped traversal of internal page due to active
  * split generation
  */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SPLIT_GEN	1841
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SPLIT_GEN	1840
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1842
+#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1841
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1843
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1842
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1844
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1843
 /*!
  * reconciliation: average length of delta chain on internal page with
  * deltas
  */
-#define	WT_STAT_CONN_REC_AVERAGE_INTERNAL_PAGE_DELTA_CHAIN_LENGTH	1845
+#define	WT_STAT_CONN_REC_AVERAGE_INTERNAL_PAGE_DELTA_CHAIN_LENGTH	1844
 /*! reconciliation: average length of delta chain on leaf page with deltas */
-#define	WT_STAT_CONN_REC_AVERAGE_LEAF_PAGE_DELTA_CHAIN_LENGTH	1846
+#define	WT_STAT_CONN_REC_AVERAGE_LEAF_PAGE_DELTA_CHAIN_LENGTH	1845
 /*!
  * reconciliation: changes since prior reconciliation (bucket 1) between
  * 1 and 5
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE5			1847
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE5			1846
 /*!
  * reconciliation: changes since prior reconciliation (bucket 2) between
  * 6 and 10
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE10			1848
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE10			1847
 /*!
  * reconciliation: changes since prior reconciliation (bucket 3) between
  * 11 and 20
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE20			1849
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE20			1848
 /*!
  * reconciliation: changes since prior reconciliation (bucket 4) between
  * 21 and 50
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE50			1850
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE50			1849
 /*!
  * reconciliation: changes since prior reconciliation (bucket 5) between
  * 51 and 100
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE100		1851
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE100		1850
 /*!
  * reconciliation: changes since prior reconciliation (bucket 6) between
  * 101 and 200
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE200		1852
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE200		1851
 /*!
  * reconciliation: changes since prior reconciliation (bucket 7) between
  * 201 and 500
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE500		1853
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE500		1852
 /*!
  * reconciliation: changes since prior reconciliation (bucket 8) greater
  * than 500
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_GT500		1854
+#define	WT_STAT_CONN_REC_PAGE_MODS_GT500		1853
 /*! reconciliation: cursor next/prev calls during HS wrapup search_near */
-#define	WT_STAT_CONN_REC_HS_WRAPUP_NEXT_PREV_CALLS	1855
+#define	WT_STAT_CONN_REC_HS_WRAPUP_NEXT_PREV_CALLS	1854
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1856
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1855
 /*!
  * reconciliation: free page ID due to failed page replacement
  * reconciliation in disagg
  */
-#define	WT_STAT_CONN_REC_FREE_PAGE_ID_DUE_TO_FAILED_REPLACEMENT_RECONCILIATION	1857
+#define	WT_STAT_CONN_REC_FREE_PAGE_ID_DUE_TO_FAILED_REPLACEMENT_RECONCILIATION	1856
 /*! reconciliation: full internal pages written instead of a page delta */
-#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_INTERNAL	1858
+#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_INTERNAL	1857
 /*! reconciliation: full leaf pages written instead of a page delta */
-#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_LEAF		1859
+#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_LEAF		1858
 /*!
  * reconciliation: ingest btree reconciliation keeps the aborted prepare
  * updates
  */
-#define	WT_STAT_CONN_REC_INGEST_KEEP_PREPARE_ROLLBACK	1860
+#define	WT_STAT_CONN_REC_INGEST_KEEP_PREPARE_ROLLBACK	1859
 /*! reconciliation: internal page delta keys deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_DELETED	1861
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_DELETED	1860
 /*! reconciliation: internal page delta keys updated/inserted */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_UPDATED	1862
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_UPDATED	1861
 /*! reconciliation: internal page deltas written */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL		1863
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL		1862
 /*! reconciliation: internal page multi-block writes */
-#define	WT_STAT_CONN_REC_MULTIBLOCK_INTERNAL		1864
+#define	WT_STAT_CONN_REC_MULTIBLOCK_INTERNAL		1863
 /*! reconciliation: leaf page deltas written */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_LEAF		1865
+#define	WT_STAT_CONN_REC_PAGE_DELTA_LEAF		1864
 /*! reconciliation: leaf page multi-block writes */
-#define	WT_STAT_CONN_REC_MULTIBLOCK_LEAF		1866
+#define	WT_STAT_CONN_REC_MULTIBLOCK_LEAF		1865
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1867
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1866
 /*! reconciliation: max deltas seen on internal page during reconciliation */
-#define	WT_STAT_CONN_REC_MAX_INTERNAL_PAGE_DELTAS	1868
+#define	WT_STAT_CONN_REC_MAX_INTERNAL_PAGE_DELTAS	1867
 /*! reconciliation: max deltas seen on leaf page during reconciliation */
-#define	WT_STAT_CONN_REC_MAX_LEAF_PAGE_DELTAS		1869
+#define	WT_STAT_CONN_REC_MAX_LEAF_PAGE_DELTAS		1868
 /*! reconciliation: maximum milliseconds spent in a reconciliation call */
-#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1870
+#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1869
 /*!
  * reconciliation: maximum milliseconds spent in building a disk image in
  * a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1871
+#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1870
 /*!
  * reconciliation: maximum milliseconds spent in moving updates to the
  * history store in a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1872
+#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1871
 /*!
  * reconciliation: number of keys that are garbage collected from the
  * disk images in the ingest btrees for disaggregated storage
  */
-#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_DISK_IMAGE	1873
+#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_DISK_IMAGE	1872
 /*!
  * reconciliation: number of keys that are garbage collected from the
  * update chains in the ingest btrees for disaggregated storage
  */
-#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_UPDATE_CHAIN	1874
+#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_UPDATE_CHAIN	1873
 /*! reconciliation: overflow values written */
-#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1875
+#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1874
 /*! reconciliation: page deltas rejected due to invalid page ID */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_INVALID_PAGE_ID	1876
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_INVALID_PAGE_ID	1875
 /*! reconciliation: page deltas rejected due to max consecutive limit */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MAX_CONSECUTIVE_EXCEEDED	1877
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MAX_CONSECUTIVE_EXCEEDED	1876
 /*! reconciliation: page deltas rejected due to multiblock reconciliation */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MULTIBLOCK	1878
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MULTIBLOCK	1877
 /*!
  * reconciliation: page deltas rejected due to non-single page in
  * previous reconciliation
  */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_NON_SINGLE_PAGE	1879
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_NON_SINGLE_PAGE	1878
 /*! reconciliation: page deltas rejected due to size threshold */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_SIZE_THRESHOLD	1880
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_SIZE_THRESHOLD	1879
 /*!
  * reconciliation: page deltas rejected due to too many keys removed from
  * the disk image
  */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_DELETE_THRESHOLD	1881
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_DELETE_THRESHOLD	1880
 /*! reconciliation: page deltas rejected due to zero entries */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_ZERO_ENTRIES	1882
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_ZERO_ENTRIES	1881
 /*!
  * reconciliation: page deltas rejected: build function returned false
  * (disabled, in-memory split, or internal page constraints not met)
  */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_BUILD_FAILED	1883
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_BUILD_FAILED	1882
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1884
+#define	WT_STAT_CONN_REC_PAGES				1883
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1885
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1884
 /*! reconciliation: page reconciliation calls for pages between 1 and 10MB */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_1MB_TO_10MB		1886
+#define	WT_STAT_CONN_REC_PAGES_SIZE_1MB_TO_10MB		1885
 /*!
  * reconciliation: page reconciliation calls for pages between 10 and
  * 100MB
  */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_10MB_TO_100MB	1887
+#define	WT_STAT_CONN_REC_PAGES_SIZE_10MB_TO_100MB	1886
 /*!
  * reconciliation: page reconciliation calls for pages between 100MB and
  * 1GB
  */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_100MB_TO_1GB	1888
+#define	WT_STAT_CONN_REC_PAGES_SIZE_100MB_TO_1GB	1887
 /*! reconciliation: page reconciliation calls for pages over 1GB */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_1GB_PLUS		1889
+#define	WT_STAT_CONN_REC_PAGES_SIZE_1GB_PLUS		1888
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * prepared transaction metadata
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1890
+#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1889
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * timestamps
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1891
+#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1890
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * transaction ids
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1892
+#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1891
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1893
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1892
 /*! reconciliation: pages eligible for delta generation */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_ELIGIBLE		1894
+#define	WT_STAT_CONN_REC_PAGE_DELTA_ELIGIBLE		1893
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1895
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1894
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1896
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1895
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1897
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1896
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1898
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1897
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1899
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1898
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1900
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1899
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1901
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1900
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1902
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1901
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1903
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1902
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1904
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1903
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1905
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1904
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1906
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1905
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1907
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1906
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1908
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1907
 /*! reconciliation: pages written with at least one internal page delta */
-#define	WT_STAT_CONN_REC_PAGES_WITH_INTERNAL_DELTAS	1909
+#define	WT_STAT_CONN_REC_PAGES_WITH_INTERNAL_DELTAS	1908
 /*! reconciliation: pages written with at least one leaf page delta */
-#define	WT_STAT_CONN_REC_PAGES_WITH_LEAF_DELTAS		1910
+#define	WT_STAT_CONN_REC_PAGES_WITH_LEAF_DELTAS		1909
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1911
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1910
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1912
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1911
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1913
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1912
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1914
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1913
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1915
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1914
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1916
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1915
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1917
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1916
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1918
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1917
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1919
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1918
 /*! reconciliation: writes skipped in disaggregated storage */
-#define	WT_STAT_CONN_REC_SKIP_WRITE			1920
+#define	WT_STAT_CONN_REC_SKIP_WRITE			1919
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1921
+#define	WT_STAT_CONN_SESSION_OPEN			1920
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1922
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1921
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1923
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1922
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1924
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1923
 /*! session: table alter triggering checkpoint calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1925
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1924
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1926
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1925
 /*! session: table compact conflicted with checkpoint */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1927
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1926
 /*! session: table compact dhandle successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1928
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1927
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1929
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1928
 /*! session: table compact failed calls due to cache pressure */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1930
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1929
 /*!
  * session: table compact in-memory page footprint rewritten by
  * compaction
  */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_BYTES_REWRITE_INMEM	1931
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_BYTES_REWRITE_INMEM	1930
 /*! session: table compact passes */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1932
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1931
 /*! session: table compact pulled into eviction */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1933
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1932
 /*! session: table compact running */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1934
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1933
 /*! session: table compact skipped as process would not reduce file size */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1935
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1934
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1936
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1935
 /*! session: table compact timeout */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1937
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1936
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1938
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1937
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1939
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1938
 /*! session: table create with import failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1940
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1939
 /*! session: table create with import repair calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1941
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1940
 /*! session: table create with import successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1942
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1941
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1943
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1942
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1944
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1943
 /*! session: table publish failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_PUBLISH_FAIL		1945
+#define	WT_STAT_CONN_SESSION_TABLE_PUBLISH_FAIL		1944
 /*! session: table publish successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_PUBLISH_SUCCESS	1946
+#define	WT_STAT_CONN_SESSION_TABLE_PUBLISH_SUCCESS	1945
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1947
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1946
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1948
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1947
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1949
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1948
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1950
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1949
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1951
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1950
 /*! session: table verify number of keys checked against the history store */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_HS_KEYS_CHECKED	1952
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_HS_KEYS_CHECKED	1951
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1953
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1952
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1954
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1953
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1955
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1954
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1956
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1955
 /*!
  * thread-yield: application thread eviction used the published
  * checkpoint snapshot for visibility
  */
-#define	WT_STAT_CONN_APPLICATION_EVICT_CHECKPOINT_SNAPSHOT	1957
+#define	WT_STAT_CONN_APPLICATION_EVICT_CHECKPOINT_SNAPSHOT	1956
 /*! thread-yield: application thread operations waiting for cache */
-#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1958
+#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1957
 /*!
  * thread-yield: application thread operations waiting for interruptible
  * cache eviction
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_OPS	1959
+#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_OPS	1958
 /*!
  * thread-yield: application thread operations waiting for mandatory
  * cache eviction
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_OPS	1960
+#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_OPS	1959
 /*! thread-yield: application thread snapshot refreshed for eviction */
-#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1961
+#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1960
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1962
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1961
 /*!
  * thread-yield: application thread time waiting for interruptible cache
  * eviction (usecs)
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_TIME	1963
+#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_TIME	1962
 /*!
  * thread-yield: application thread time waiting for mandatory cache
  * eviction (usecs)
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_TIME	1964
+#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_TIME	1963
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1965
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1964
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1966
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1965
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1967
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1966
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1968
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1967
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1969
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1968
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1970
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1969
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1971
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1970
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1972
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1971
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1973
+#define	WT_STAT_CONN_PAGE_SLEEP				1972
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1974
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1973
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1975
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1974
 /*! thread-yield: page split and restart read */
-#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1976
+#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1975
 /*! thread-yield: pages skipped during read due to deleted state */
-#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1977
+#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1976
 /*!
  * tiered-storage: attempts to remove a local object and the object is in
  * use
  */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1978
+#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1977
 /*! tiered-storage: flush_tier failed calls */
-#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1979
+#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1978
 /*! tiered-storage: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1980
+#define	WT_STAT_CONN_FLUSH_TIER				1979
 /*! tiered-storage: flush_tier tables skipped due to no checkpoint */
-#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1981
+#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1980
 /*! tiered-storage: flush_tier tables switched */
-#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1982
+#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1981
 /*! tiered-storage: local objects removed */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1983
+#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1982
 /*! tiered-storage: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1984
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1983
 /*! tiered-storage: tiered operations removed without processing */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1985
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1984
 /*! tiered-storage: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1986
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1985
 /*! tiered-storage: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1987
+#define	WT_STAT_CONN_TIERED_RETENTION			1986
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1988
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1987
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1989
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1988
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1990
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1989
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1991
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1990
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1992
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1991
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1993
+#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1992
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1994
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1993
 /*! transaction: oldest transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1995
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1994
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1996
+#define	WT_STAT_CONN_TXN_PREPARE			1995
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1997
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1996
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1998
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1997
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1999
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1998
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			2000
+#define	WT_STAT_CONN_TXN_QUERY_TS			1999
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	2001
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	2000
 /*! transaction: rollback to stable applied btrees */
-#define	WT_STAT_CONN_TXN_RTS_BTREES_APPLIED		2002
+#define	WT_STAT_CONN_TXN_RTS_BTREES_APPLIED		2001
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				2003
+#define	WT_STAT_CONN_TXN_RTS				2002
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	2004
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	2003
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2005
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	2004
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		2006
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		2005
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		2007
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		2006
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		2008
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		2007
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	2009
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	2008
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	2010
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	2009
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		2011
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		2010
 /*!
  * transaction: rollback to stable prepared fast truncations that would
  * have been rolled back in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_PREPARED_FAST_TRUNCATE_DRYRUN	2012
+#define	WT_STAT_CONN_TXN_RTS_PREPARED_FAST_TRUNCATE_DRYRUN	2011
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	2013
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	2012
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		2014
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		2013
 /*! transaction: rollback to stable rolled back prepared fast truncations */
-#define	WT_STAT_CONN_TXN_RTS_PREPARED_FAST_TRUNCATE	2015
+#define	WT_STAT_CONN_TXN_RTS_PREPARED_FAST_TRUNCATE	2014
 /*! transaction: rollback to stable skipped btrees */
-#define	WT_STAT_CONN_TXN_RTS_BTREES_SKIPPED		2016
+#define	WT_STAT_CONN_TXN_RTS_BTREES_SKIPPED		2015
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		2017
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		2016
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		2018
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		2017
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		2019
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		2018
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	2020
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	2019
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	2021
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	2020
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		2022
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		2021
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	2023
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	2022
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			2024
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			2023
 /*!
  * transaction: rollback to stable updates that would have been aborted
  * in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		2025
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		2024
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		2026
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		2025
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		2027
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		2026
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				2028
+#define	WT_STAT_CONN_TXN_SET_TS				2027
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			2029
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			2028
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		2030
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		2029
 /*! transaction: set timestamp force calls */
-#define	WT_STAT_CONN_TXN_SET_TS_FORCE			2031
+#define	WT_STAT_CONN_TXN_SET_TS_FORCE			2030
 /*!
  * transaction: set timestamp global oldest timestamp set to be more
  * recent than the global stable timestamp
  */
-#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		2032
+#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		2031
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			2033
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			2032
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		2034
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		2033
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			2035
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			2034
 /*! transaction: set timestamp stable disaggregated schema epoch calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_DISAGG_EPOCH	2036
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_DISAGG_EPOCH	2035
 /*! transaction: set timestamp stable disaggregated schema epoch updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_DISAGG_EPOCH_UPD	2037
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_DISAGG_EPOCH_UPD	2036
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		2038
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		2037
 /*! transaction: step-down disaggregated schema epoch is currently set */
-#define	WT_STAT_CONN_TXN_STEPDOWN_EPOCH_SET		2039
+#define	WT_STAT_CONN_TXN_STEPDOWN_EPOCH_SET		2038
 /*! transaction: step-down timestamp is currently set */
-#define	WT_STAT_CONN_TXN_STEPDOWN_TS_SET		2040
+#define	WT_STAT_CONN_TXN_STEPDOWN_TS_SET		2039
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				2041
+#define	WT_STAT_CONN_TXN_BEGIN				2040
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		2042
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		2041
 /*! transaction: transaction global checkpoint timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_CHECKPOINT_TIMESTAMP	2043
+#define	WT_STAT_CONN_TXN_GLOBAL_CHECKPOINT_TIMESTAMP	2042
 /*! transaction: transaction global durable timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_DURABLE_TIMESTAMP	2044
+#define	WT_STAT_CONN_TXN_GLOBAL_DURABLE_TIMESTAMP	2043
 /*! transaction: transaction global last running timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_LAST_RUNNING_TIMESTAMP	2045
+#define	WT_STAT_CONN_TXN_GLOBAL_LAST_RUNNING_TIMESTAMP	2044
 /*! transaction: transaction global newest timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_NEWEST_TIMESTAMP	2046
+#define	WT_STAT_CONN_TXN_GLOBAL_NEWEST_TIMESTAMP	2045
 /*! transaction: transaction global oldest timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_OLDEST_TIMESTAMP	2047
+#define	WT_STAT_CONN_TXN_GLOBAL_OLDEST_TIMESTAMP	2046
 /*! transaction: transaction global pinned timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_PINNED_TIMESTAMP	2048
+#define	WT_STAT_CONN_TXN_GLOBAL_PINNED_TIMESTAMP	2047
 /*! transaction: transaction global stable timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_STABLE_TIMESTAMP	2049
+#define	WT_STAT_CONN_TXN_GLOBAL_STABLE_TIMESTAMP	2048
 /*! transaction: transaction global version cursor timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_VERSION_CURSOR_TIMESTAMP	2050
+#define	WT_STAT_CONN_TXN_GLOBAL_VERSION_CURSOR_TIMESTAMP	2049
 /*!
  * transaction: transaction number of older readers older than oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_READERS			2051
+#define	WT_STAT_CONN_TXN_PINNED_READERS			2050
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			2052
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			2051
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	2053
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	2052
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_LAG		2054
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_LAG		2053
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT_LAG	2055
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT_LAG	2054
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER_LAG	2056
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER_LAG	2055
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	2057
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	2056
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	2058
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	2057
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	2059
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	2058
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			2060
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			2059
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				2061
+#define	WT_STAT_CONN_TXN_COMMIT				2060
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			2062
+#define	WT_STAT_CONN_TXN_ROLLBACK			2061
 /*!
  * transaction: transactions rolled back because their own dirty content
  * exceeds the eviction updates or dirty trigger
  */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TOO_LARGE_FOR_CACHE	2061
+#define	WT_STAT_CONN_TXN_ROLLBACK_TOO_LARGE_FOR_CACHE	2062
 /*!
  * transaction: truncate operations rolled back because they pinned too
  * much dirty cache
  */
-#define	WT_STAT_CONN_TXN_TRUNCATE_DIRTY_CACHE_ROLLBACK	2062
+#define	WT_STAT_CONN_TXN_TRUNCATE_DIRTY_CACHE_ROLLBACK	2063
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		2063
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		2064
 /*!
  * transaction: write transactions rolled back for straddling the step-
  * down timestamp setting boundary
  */
-#define	WT_STAT_CONN_TXN_ROLLBACK_STEPDOWN		2064
+#define	WT_STAT_CONN_TXN_ROLLBACK_STEPDOWN		2065
 
 /*!
  * @}
@@ -10698,20 +10693,22 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_SESSION_LOCK_DHANDLE_WAIT		4002
 /*! session: dirty bytes in this txn */
 #define	WT_STAT_SESSION_TXN_BYTES_DIRTY			4003
+/*! session: dirty bytes pinned by fast-truncate in this txn */
+#define	WT_STAT_SESSION_TXN_TRUNCATE_BYTES_DIRTY	4004
 /*! session: number of updates in this txn */
-#define	WT_STAT_SESSION_TXN_UPDATES			4004
+#define	WT_STAT_SESSION_TXN_UPDATES			4005
 /*! session: page read from disk to cache time (usecs) */
-#define	WT_STAT_SESSION_READ_TIME			4005
+#define	WT_STAT_SESSION_READ_TIME			4006
 /*! session: page write from cache to disk time (usecs) */
-#define	WT_STAT_SESSION_WRITE_TIME			4006
+#define	WT_STAT_SESSION_WRITE_TIME			4007
 /*! session: schema lock wait time (usecs) */
-#define	WT_STAT_SESSION_LOCK_SCHEMA_WAIT		4007
+#define	WT_STAT_SESSION_LOCK_SCHEMA_WAIT		4008
 /*! session: time waiting for cache (usecs) */
-#define	WT_STAT_SESSION_CACHE_TIME			4008
+#define	WT_STAT_SESSION_CACHE_TIME			4009
 /*! session: time waiting for cache interruptible eviction (usecs) */
-#define	WT_STAT_SESSION_CACHE_TIME_INTERRUPTIBLE	4009
+#define	WT_STAT_SESSION_CACHE_TIME_INTERRUPTIBLE	4010
 /*! session: time waiting for mandatory cache eviction (usecs) */
-#define	WT_STAT_SESSION_CACHE_TIME_MANDATORY		4010
+#define	WT_STAT_SESSION_CACHE_TIME_MANDATORY		4011
 /*! @} */
 /*
  * Statistics section: END

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -5662,7 +5662,8 @@ static const char *const __stats_session_desc[] = {
   "session: bytes read into cache",
   "session: bytes written from cache",
   "session: dhandle lock wait time (usecs)",
-  "session: dirty bytes in this txn",
+  "session: dirty bytes from updates in this txn",
+  "session: dirty bytes in this txn, from both updates and fast-truncate",
   "session: dirty bytes pinned by fast-truncate in this txn",
   "session: number of updates in this txn",
   "session: page read from disk to cache time (usecs)",
@@ -5693,6 +5694,7 @@ __wt_stat_session_clear_single(WT_SESSION_STATS *stats)
     stats->bytes_read = 0;
     stats->bytes_write = 0;
     stats->lock_dhandle_wait = 0;
+    /* not clearing txn_updates_bytes_dirty */
     /* not clearing txn_bytes_dirty */
     /* not clearing txn_truncate_bytes_dirty */
     /* not clearing txn_updates */

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -3152,6 +3152,7 @@ static const char *const __stats_connection_desc[] = {
   "transaction: transactions rolled back",
   "transaction: transactions rolled back because their own dirty content exceeds the eviction "
   "updates or dirty trigger",
+  "transaction: truncate operations rolled back because they pinned too much dirty cache",
   "transaction: update conflicts",
   "transaction: write transactions rolled back for straddling the step-down timestamp setting "
   "boundary",
@@ -4259,6 +4260,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->txn_commit = 0;
     stats->txn_rollback = 0;
     stats->txn_rollback_too_large_for_cache = 0;
+    stats->txn_truncate_dirty_cache_rollback = 0;
     stats->txn_update_conflict = 0;
     stats->txn_rollback_stepdown = 0;
 }
@@ -5646,6 +5648,8 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->txn_rollback += WT_STAT_CONN_READ(from, txn_rollback);
     to->txn_rollback_too_large_for_cache +=
       WT_STAT_CONN_READ(from, txn_rollback_too_large_for_cache);
+    to->txn_truncate_dirty_cache_rollback +=
+      WT_STAT_CONN_READ(from, txn_truncate_dirty_cache_rollback);
     to->txn_update_conflict += WT_STAT_CONN_READ(from, txn_update_conflict);
     to->txn_rollback_stepdown += WT_STAT_CONN_READ(from, txn_rollback_stepdown);
 }

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -2380,6 +2380,7 @@ static const char *const __stats_connection_desc[] = {
   "cache: pages currently held in the cache",
   "cache: pages currently held in the cache from the ingest btrees",
   "cache: pages currently held in the cache from the stable btrees",
+  "cache: pages dirtied by fast-truncate in uncommitted txn - bytes",
   "cache: pages dirtied due to obsolete time window by eviction",
   "cache: pages evicted ahead of the page materialization frontier",
   "cache: pages evicted in parallel with checkpoint",
@@ -3511,6 +3512,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     /* not clearing cache_pages_inuse */
     /* not clearing cache_pages_inuse_ingest */
     /* not clearing cache_pages_inuse_stable */
+    /* not clearing cache_truncate_txn_uncommitted_bytes */
     stats->cache_eviction_dirty_obsolete_tw = 0;
     stats->cache_eviction_ahead_of_last_materialized_lsn = 0;
     stats->eviction_pages_in_parallel_with_checkpoint = 0;
@@ -4708,6 +4710,8 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->cache_pages_inuse += WT_STAT_CONN_READ(from, cache_pages_inuse);
     to->cache_pages_inuse_ingest += WT_STAT_CONN_READ(from, cache_pages_inuse_ingest);
     to->cache_pages_inuse_stable += WT_STAT_CONN_READ(from, cache_pages_inuse_stable);
+    to->cache_truncate_txn_uncommitted_bytes +=
+      WT_STAT_CONN_READ(from, cache_truncate_txn_uncommitted_bytes);
     to->cache_eviction_dirty_obsolete_tw +=
       WT_STAT_CONN_READ(from, cache_eviction_dirty_obsolete_tw);
     to->cache_eviction_ahead_of_last_materialized_lsn +=
@@ -5659,6 +5663,7 @@ static const char *const __stats_session_desc[] = {
   "session: bytes written from cache",
   "session: dhandle lock wait time (usecs)",
   "session: dirty bytes in this txn",
+  "session: dirty bytes pinned by fast-truncate in this txn",
   "session: number of updates in this txn",
   "session: page read from disk to cache time (usecs)",
   "session: page write from cache to disk time (usecs)",
@@ -5689,6 +5694,7 @@ __wt_stat_session_clear_single(WT_SESSION_STATS *stats)
     stats->bytes_write = 0;
     stats->lock_dhandle_wait = 0;
     /* not clearing txn_bytes_dirty */
+    /* not clearing txn_truncate_bytes_dirty */
     /* not clearing txn_updates */
     stats->read_time = 0;
     stats->write_time = 0;

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -2991,10 +2991,11 @@ __wt_txn_is_blocking(WT_SESSION_IMPL *session)
                 WT_STAT_CONN_INCR(session, txn_truncate_dirty_cache_rollback);
                 WT_RET_SUB(session, WT_ROLLBACK, WT_TXN_TOO_LARGE_FOR_CACHE,
                   WT_TXN_ROLLBACK_REASON_TRUNCATE_DIRTY);
+            } else {
+                WT_STAT_CONN_INCR(session, txn_rollback_too_large_for_cache);
+                WT_RET_SUB(session, WT_ROLLBACK, WT_TXN_TOO_LARGE_FOR_CACHE,
+                  WT_TXN_ROLLBACK_REASON_TOO_LARGE_FOR_CACHE);
             }
-            WT_STAT_CONN_INCR(session, txn_rollback_too_large_for_cache);
-            WT_RET_SUB(session, WT_ROLLBACK, WT_TXN_TOO_LARGE_FOR_CACHE,
-              WT_TXN_ROLLBACK_REASON_TOO_LARGE_FOR_CACHE);
         }
     }
     return (0);

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -2898,9 +2898,33 @@ __wt_txn_global_shutdown(WT_SESSION_IMPL *session, const char **cfg)
 }
 
 /*
+ * The fraction of the cache-wide dirty budget one transaction's fast-truncate may pin before it is
+ * rolled back; leaving no headroom risks stalling the cache. The fraction is a heuristic.
+ */
+#define WT_TRUNCATE_DIRTY_BUDGET_PCT 75
+
+/*
+ * __txn_truncate_dirty_exceeded --
+ *     Return whether the running transaction's fast-truncate has pinned more than its share of the
+ *     cache's dirty eviction budget.
+ */
+static bool
+__txn_truncate_dirty_exceeded(WT_SESSION_IMPL *session)
+{
+    WT_CONNECTION_IMPL *conn = S2C(session);
+    double dirty_trigger = __wt_atomic_load_double_relaxed(&conn->evict->eviction_dirty_trigger);
+    uint64_t bytes_max = __wt_tsan_suppress_load_uint64_v(&conn->cache_size) + 1;
+    uint64_t threshold =
+      (uint64_t)(dirty_trigger * (double)bytes_max) / 100 * WT_TRUNCATE_DIRTY_BUDGET_PCT / 100;
+
+    return (session->txn->truncate_dirty_bytes >= threshold);
+}
+
+/*
  * __wt_txn_is_blocking --
- *     Return an error if this transaction is likely blocking eviction from making progress, called
- *     by eviction to determine if a worker thread should be released.
+ *     Return an error if this transaction is likely blocking eviction from making progress. Called
+ *     by eviction to determine if a worker thread should be released, and by fast-truncate to bound
+ *     its own cache footprint.
  */
 int
 __wt_txn_is_blocking(WT_SESSION_IMPL *session)
@@ -2943,6 +2967,16 @@ __wt_txn_is_blocking(WT_SESSION_IMPL *session)
     if (txn->mod_count == 0 && !__wt_op_timer_fired(session) && !F_ISSET(txn, WT_TXN_RUNNING))
         return (0);
 #endif
+
+    /*
+     * A fast-truncate that has pinned too much dirty cache must roll back on its own, independent
+     * of transaction age: the internal pages it dirties cannot be evicted until the truncate is
+     * stable and can stall the cache by themselves.
+     */
+    if (__txn_truncate_dirty_exceeded(session)) {
+        WT_STAT_CONN_INCR(session, txn_truncate_dirty_cache_rollback);
+        WT_RET_SUB(session, WT_ROLLBACK, WT_CACHE_OVERFLOW, WT_TXN_ROLLBACK_REASON_TRUNCATE_DIRTY);
+    }
 
     /*
      * Once eviction is stuck, check if either the transaction's ID or its pinned ID is equal to the

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1009,6 +1009,9 @@ __txn_release(WT_SESSION_IMPL *session)
 
     /* Clear operation timer. */
     txn->operation_timeout_us = 0;
+
+    /* Clear the fast-truncate dirty cache tracking. */
+    txn->truncate_dirty_bytes = 0;
 }
 
 /*

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -168,8 +168,6 @@ __wt_txn_release_snapshot(WT_SESSION_IMPL *session)
 
     /* Leave the generation after releasing the snapshot. */
     __wt_session_gen_leave(session, WT_GEN_HAS_SNAPSHOT);
-
-    __txn_clear_bytes_dirty(session);
 }
 
 /*
@@ -1009,6 +1007,9 @@ __txn_release(WT_SESSION_IMPL *session)
 
     /* Clear operation timer. */
     txn->operation_timeout_us = 0;
+
+    /* Reset the dirty footprint tracking */
+    __txn_clear_bytes_dirty(session);
 }
 
 /*

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -2911,13 +2911,19 @@ __wt_txn_global_shutdown(WT_SESSION_IMPL *session, const char **cfg)
 static bool
 __txn_truncate_dirty_exceeded(WT_SESSION_IMPL *session)
 {
+    uint64_t truncate_dirty_bytes = session->txn->truncate_dirty_bytes;
+
+    /* A transaction that has not fast-truncated anything can never exceed the budget. */
+    if (truncate_dirty_bytes == 0)
+        return (false);
+
     WT_CONNECTION_IMPL *conn = S2C(session);
     double dirty_trigger = __wt_atomic_load_double_relaxed(&conn->evict->eviction_dirty_trigger);
     uint64_t bytes_max = __wt_tsan_suppress_load_uint64_v(&conn->cache_size) + 1;
     uint64_t threshold =
       (uint64_t)(dirty_trigger * (double)bytes_max) / 100 * WT_TRUNCATE_DIRTY_BUDGET_PCT / 100;
 
-    return (session->txn->truncate_dirty_bytes >= threshold);
+    return (truncate_dirty_bytes >= threshold);
 }
 
 /*

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -2898,35 +2898,6 @@ __wt_txn_global_shutdown(WT_SESSION_IMPL *session, const char **cfg)
 }
 
 /*
- * The fraction of the cache-wide dirty budget one transaction's fast-truncate may pin before it is
- * rolled back; leaving no headroom risks stalling the cache. The fraction is a heuristic.
- */
-#define WT_TRUNCATE_DIRTY_BUDGET_PCT 75
-
-/*
- * __txn_truncate_dirty_exceeded --
- *     Return whether the running transaction's fast-truncate has pinned more than its share of the
- *     cache's dirty eviction budget.
- */
-static bool
-__txn_truncate_dirty_exceeded(WT_SESSION_IMPL *session)
-{
-    uint64_t truncate_dirty_bytes = session->txn->truncate_dirty_bytes;
-
-    /* A transaction that has not fast-truncated anything can never exceed the budget. */
-    if (truncate_dirty_bytes == 0)
-        return (false);
-
-    WT_CONNECTION_IMPL *conn = S2C(session);
-    double dirty_trigger = __wt_atomic_load_double_relaxed(&conn->evict->eviction_dirty_trigger);
-    uint64_t bytes_max = __wt_tsan_suppress_load_uint64_v(&conn->cache_size) + 1;
-    uint64_t threshold =
-      (uint64_t)(dirty_trigger * (double)bytes_max) / 100 * WT_TRUNCATE_DIRTY_BUDGET_PCT / 100;
-
-    return (truncate_dirty_bytes >= threshold);
-}
-
-/*
  * __wt_txn_is_blocking --
  *     Return an error if this transaction is likely blocking eviction from making progress. Called
  *     by eviction to determine if a worker thread should be released, and by fast-truncate to bound
@@ -2940,7 +2911,7 @@ __wt_txn_is_blocking(WT_SESSION_IMPL *session)
     WT_TXN *txn;
     WT_TXN_SHARED *txn_shared;
     double trigger;
-    uint64_t global_oldest;
+    uint64_t bytes_dirty, global_oldest;
     bool is_txn_id_global_oldest;
 
     conn = S2C(session);
@@ -2975,16 +2946,6 @@ __wt_txn_is_blocking(WT_SESSION_IMPL *session)
 #endif
 
     /*
-     * A fast-truncate that has pinned too much dirty cache must roll back on its own, independent
-     * of transaction age: the internal pages it dirties cannot be evicted until the truncate is
-     * stable and can stall the cache by themselves.
-     */
-    if (__txn_truncate_dirty_exceeded(session)) {
-        WT_STAT_CONN_INCR(session, txn_truncate_dirty_cache_rollback);
-        WT_RET_SUB(session, WT_ROLLBACK, WT_CACHE_OVERFLOW, WT_TXN_ROLLBACK_REASON_TRUNCATE_DIRTY);
-    }
-
-    /*
      * Once eviction is stuck, check if either the transaction's ID or its pinned ID is equal to the
      * oldest transaction ID: it is likely to be the reason the cache is stuck full.
      */
@@ -3004,7 +2965,9 @@ __wt_txn_is_blocking(WT_SESSION_IMPL *session)
      * A transaction whose own unresolved dirty content already exceeds the updates trigger (or the
      * dirty trigger, whichever is lower, since the two are not guaranteed to be ordered) can never
      * bring the cache back under that trigger by staying alive, so roll it back now while that is
-     * still legal.
+     * still legal. The dirty internal pages a fast-truncate pins count towards that footprint:
+     * eviction cannot reclaim them either, since they cannot be reconciled until the truncate is
+     * stable.
      *
      * Requires an actual modification: instantiating a fast-truncated column-store page while
      * reading it charges dirty bytes to whichever transaction happens to touch the page
@@ -3018,8 +2981,18 @@ __wt_txn_is_blocking(WT_SESSION_IMPL *session)
          * dirtied anything at all. Configuration never leaves either trigger at zero, so treat it
          * as a value we raced with rather than a threshold to enforce.
          */
-        if (trigger > DBL_EPSILON &&
-          txn->bytes_dirty > (uint64_t)(trigger * conn->cache_size) / 100) {
+        bytes_dirty = txn->bytes_dirty + txn->truncate_dirty_bytes;
+        if (trigger > DBL_EPSILON && bytes_dirty > (uint64_t)(trigger * conn->cache_size) / 100) {
+            /*
+             * Attribute the rollback to whichever half of the footprint dominates: a truncate that
+             * pinned mostly internal pages is a different diagnosis from a transaction that wrote
+             * too many updates.
+             */
+            if (txn->truncate_dirty_bytes > txn->bytes_dirty) {
+                WT_STAT_CONN_INCR(session, txn_truncate_dirty_cache_rollback);
+                WT_RET_SUB(
+                  session, WT_ROLLBACK, WT_CACHE_OVERFLOW, WT_TXN_ROLLBACK_REASON_TRUNCATE_DIRTY);
+            }
             WT_STAT_CONN_INCR(session, txn_rollback_too_large_for_cache);
             WT_RET_SUB(session, WT_ROLLBACK, WT_TXN_TOO_LARGE_FOR_CACHE,
               WT_TXN_ROLLBACK_REASON_TOO_LARGE_FOR_CACHE);

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -2981,13 +2981,13 @@ __wt_txn_is_blocking(WT_SESSION_IMPL *session)
          * dirtied anything at all. Configuration never leaves either trigger at zero, so treat it
          * as a value we raced with rather than a threshold to enforce.
          */
-        total_dirty = txn->bytes_dirty + txn->truncate_dirty_bytes;
+        total_dirty = txn->update_dirty_bytes + txn->truncate_dirty_bytes;
         if (trigger > DBL_EPSILON && total_dirty > (uint64_t)(trigger * conn->cache_size) / 100) {
             /*
              * The statistic and the reason distinguish a truncate that pinned mostly internal pages
              * from a transaction that wrote too many updates.
              */
-            if (txn->truncate_dirty_bytes > txn->bytes_dirty) {
+            if (txn->truncate_dirty_bytes > txn->update_dirty_bytes) {
                 WT_STAT_CONN_INCR(session, txn_truncate_dirty_cache_rollback);
                 WT_RET_SUB(session, WT_ROLLBACK, WT_TXN_TOO_LARGE_FOR_CACHE,
                   WT_TXN_ROLLBACK_REASON_TRUNCATE_DIRTY);

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -2911,7 +2911,7 @@ __wt_txn_is_blocking(WT_SESSION_IMPL *session)
     WT_TXN *txn;
     WT_TXN_SHARED *txn_shared;
     double trigger;
-    uint64_t bytes_dirty, global_oldest;
+    uint64_t global_oldest, total_dirty;
     bool is_txn_id_global_oldest;
 
     conn = S2C(session);
@@ -2981,17 +2981,16 @@ __wt_txn_is_blocking(WT_SESSION_IMPL *session)
          * dirtied anything at all. Configuration never leaves either trigger at zero, so treat it
          * as a value we raced with rather than a threshold to enforce.
          */
-        bytes_dirty = txn->bytes_dirty + txn->truncate_dirty_bytes;
-        if (trigger > DBL_EPSILON && bytes_dirty > (uint64_t)(trigger * conn->cache_size) / 100) {
+        total_dirty = txn->bytes_dirty + txn->truncate_dirty_bytes;
+        if (trigger > DBL_EPSILON && total_dirty > (uint64_t)(trigger * conn->cache_size) / 100) {
             /*
-             * Attribute the rollback to whichever half of the footprint dominates: a truncate that
-             * pinned mostly internal pages is a different diagnosis from a transaction that wrote
-             * too many updates.
+             * The statistic and the reason distinguish a truncate that pinned mostly internal pages
+             * from a transaction that wrote too many updates.
              */
             if (txn->truncate_dirty_bytes > txn->bytes_dirty) {
                 WT_STAT_CONN_INCR(session, txn_truncate_dirty_cache_rollback);
-                WT_RET_SUB(
-                  session, WT_ROLLBACK, WT_CACHE_OVERFLOW, WT_TXN_ROLLBACK_REASON_TRUNCATE_DIRTY);
+                WT_RET_SUB(session, WT_ROLLBACK, WT_TXN_TOO_LARGE_FOR_CACHE,
+                  WT_TXN_ROLLBACK_REASON_TRUNCATE_DIRTY);
             }
             WT_STAT_CONN_INCR(session, txn_rollback_too_large_for_cache);
             WT_RET_SUB(session, WT_ROLLBACK, WT_TXN_TOO_LARGE_FOR_CACHE,

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -1009,9 +1009,6 @@ __txn_release(WT_SESSION_IMPL *session)
 
     /* Clear operation timer. */
     txn->operation_timeout_us = 0;
-
-    /* Clear the fast-truncate dirty cache tracking. */
-    txn->truncate_dirty_bytes = 0;
 }
 
 /*

--- a/test/catch2/sub_level_error/unit/test_sub_level_error_rollback.cpp
+++ b/test/catch2/sub_level_error/unit/test_sub_level_error_rollback.cpp
@@ -164,10 +164,6 @@ TEST_CASE("Test functions for error handling in rollback workflows",
 
     SECTION("Test WT_OLDEST_FOR_EVICTION in __wt_txn_is_blocking - transaction ID")
     {
-        // The oldest-transaction rollback only applies when eviction is stuck, so mark it stuck.
-        conn_impl->evict->evict_aggressive_score = WT_EVICT_SCORE_MAX;
-        F_SET(conn_impl->evict, WT_EVICT_CACHE_HARD);
-
         // Set the transaction to have 1 modification.
         session_impl->txn->mod_count = 1;
 
@@ -197,6 +193,63 @@ TEST_CASE("Test functions for error handling in rollback workflows",
 
         // Reset updates to the initial value.
         session_impl->txn->mod_count = 0;
+    }
+
+    SECTION("Test WT_TXN_TOO_LARGE_FOR_CACHE in __wt_txn_is_blocking - dirty content footprint")
+    {
+        WT_TXN *txn = session_impl->txn;
+
+        // Pick a threshold of 100 bytes: the lower of the two triggers is 10% of the cache size.
+        conn_impl->cache_size = 1000;
+        conn_impl->evict->eviction_dirty_trigger = 20;
+        conn_impl->evict->eviction_updates_trigger = 10;
+
+        // The check requires a modification, otherwise a reader could be rolled back.
+        txn->mod_count = 1;
+
+        // A footprint at or below the threshold is not grounds for rollback.
+        txn->bytes_dirty = 60;
+        txn->truncate_dirty_bytes = 40;
+        CHECK(__wt_txn_is_blocking(session_impl) == 0);
+        check_error_info(err_info, 0, WT_NONE, WT_ERROR_INFO_SUCCESS);
+
+        // Neither half exceeds the threshold alone, but together they do. The updates half is the
+        // larger one, so the rollback is reported as a transaction that wrote too much.
+        txn->bytes_dirty = 60;
+        txn->truncate_dirty_bytes = 41;
+        CHECK(__wt_txn_is_blocking(session_impl) == WT_ROLLBACK);
+        check_error_info(err_info, WT_ROLLBACK, WT_TXN_TOO_LARGE_FOR_CACHE,
+          "Transaction dirty content alone exceeds the eviction updates or dirty trigger");
+
+        __wt_session_reset_last_error(session_impl);
+
+        // Same condition and sub-error code, but now the truncate half dominates, so the rollback
+        // is attributed to the truncate instead.
+        txn->bytes_dirty = 41;
+        txn->truncate_dirty_bytes = 60;
+        CHECK(__wt_txn_is_blocking(session_impl) == WT_ROLLBACK);
+        check_error_info(err_info, WT_ROLLBACK, WT_TXN_TOO_LARGE_FOR_CACHE,
+          "Truncate pinned too much dirty cache in the transaction");
+
+        __wt_session_reset_last_error(session_impl);
+
+        // A truncate footprint on its own is enough to trip the bound.
+        txn->bytes_dirty = 0;
+        txn->truncate_dirty_bytes = 101;
+        CHECK(__wt_txn_is_blocking(session_impl) == WT_ROLLBACK);
+        check_error_info(err_info, WT_ROLLBACK, WT_TXN_TOO_LARGE_FOR_CACHE,
+          "Truncate pinned too much dirty cache in the transaction");
+
+        __wt_session_reset_last_error(session_impl);
+
+        // A zero trigger is treated as a value we raced with, not a threshold to enforce.
+        conn_impl->evict->eviction_updates_trigger = 0;
+        CHECK(__wt_txn_is_blocking(session_impl) == 0);
+        check_error_info(err_info, 0, WT_NONE, WT_ERROR_INFO_SUCCESS);
+
+        // Reset to the initial values.
+        txn->bytes_dirty = txn->truncate_dirty_bytes = 0;
+        txn->mod_count = 0;
     }
 
     SECTION(

--- a/test/catch2/sub_level_error/unit/test_sub_level_error_rollback.cpp
+++ b/test/catch2/sub_level_error/unit/test_sub_level_error_rollback.cpp
@@ -208,14 +208,14 @@ TEST_CASE("Test functions for error handling in rollback workflows",
         txn->mod_count = 1;
 
         // A footprint at or below the threshold is not grounds for rollback.
-        txn->bytes_dirty = 60;
+        txn->update_dirty_bytes = 60;
         txn->truncate_dirty_bytes = 40;
         CHECK(__wt_txn_is_blocking(session_impl) == 0);
         check_error_info(err_info, 0, WT_NONE, WT_ERROR_INFO_SUCCESS);
 
         // Neither half exceeds the threshold alone, but together they do. The updates half is the
         // larger one, so the rollback is reported as a transaction that wrote too much.
-        txn->bytes_dirty = 60;
+        txn->update_dirty_bytes = 60;
         txn->truncate_dirty_bytes = 41;
         CHECK(__wt_txn_is_blocking(session_impl) == WT_ROLLBACK);
         check_error_info(err_info, WT_ROLLBACK, WT_TXN_TOO_LARGE_FOR_CACHE,
@@ -225,7 +225,7 @@ TEST_CASE("Test functions for error handling in rollback workflows",
 
         // Same condition and sub-error code, but now the truncate half dominates, so the rollback
         // is attributed to the truncate instead.
-        txn->bytes_dirty = 41;
+        txn->update_dirty_bytes = 41;
         txn->truncate_dirty_bytes = 60;
         CHECK(__wt_txn_is_blocking(session_impl) == WT_ROLLBACK);
         check_error_info(err_info, WT_ROLLBACK, WT_TXN_TOO_LARGE_FOR_CACHE,
@@ -234,7 +234,7 @@ TEST_CASE("Test functions for error handling in rollback workflows",
         __wt_session_reset_last_error(session_impl);
 
         // A truncate footprint on its own is enough to trip the bound.
-        txn->bytes_dirty = 0;
+        txn->update_dirty_bytes = 0;
         txn->truncate_dirty_bytes = 101;
         CHECK(__wt_txn_is_blocking(session_impl) == WT_ROLLBACK);
         check_error_info(err_info, WT_ROLLBACK, WT_TXN_TOO_LARGE_FOR_CACHE,
@@ -248,7 +248,7 @@ TEST_CASE("Test functions for error handling in rollback workflows",
         check_error_info(err_info, 0, WT_NONE, WT_ERROR_INFO_SUCCESS);
 
         // Reset to the initial values.
-        txn->bytes_dirty = txn->truncate_dirty_bytes = 0;
+        txn->update_dirty_bytes = txn->truncate_dirty_bytes = 0;
         txn->mod_count = 0;
     }
 

--- a/test/catch2/sub_level_error/unit/test_sub_level_error_rollback.cpp
+++ b/test/catch2/sub_level_error/unit/test_sub_level_error_rollback.cpp
@@ -164,6 +164,10 @@ TEST_CASE("Test functions for error handling in rollback workflows",
 
     SECTION("Test WT_OLDEST_FOR_EVICTION in __wt_txn_is_blocking - transaction ID")
     {
+        // The oldest-transaction rollback only applies when eviction is stuck, so mark it stuck.
+        conn_impl->evict->evict_aggressive_score = WT_EVICT_SCORE_MAX;
+        F_SET(conn_impl->evict, WT_EVICT_CACHE_HARD);
+
         // Set the transaction to have 1 modification.
         session_impl->txn->mod_count = 1;
 

--- a/test/suite/test_truncate31.py
+++ b/test/suite/test_truncate31.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wttest
+from wiredtiger import stat, WiredTigerError, wiredtiger_strerror, WT_ROLLBACK, WT_NOTFOUND
+from wtdataset import SimpleDataSet
+from wtscenario import make_scenarios
+
+# test_truncate31.py
+#    A fast-truncate over a very large range pulls in and dirties the parent
+#    internal pages of every fast-deleted leaf. Those internal pages cannot be
+#    reconciled until the truncate becomes stable, so if the truncate is not
+#    globally visible they pin dirty cache indefinitely. A single truncate that
+#    would pin enough dirty content to approach the cache's dirty eviction
+#    threshold is rolled back (WT_ROLLBACK) rather than being allowed to wedge
+#    the system. This mimics the oplog-truncation stall from HELP-96307.
+# The fast-truncate dirty-cache accounting relies on on-disk leaf pages, local
+# eviction_dirty_trigger semantics, and reopen_conn, none of which behave the
+# same under the tiered or disaggregated storage hooks.
+@wttest.skip_for_hook("tiered", "fast-truncate dirty-cache accounting is not meaningful under tiered storage")
+@wttest.skip_for_hook("disagg", "fast-truncate dirty-cache accounting is not meaningful under disaggregated storage")
+class test_truncate31(wttest.WiredTigerTestCase):
+    # A small cache with a low dirty trigger so the accumulated dirty internal
+    # pages from a large truncate cross the per-transaction threshold quickly.
+    conn_config = 'cache_size=20MB,statistics=(all),' \
+        'eviction_dirty_target=1,eviction_dirty_trigger=2'
+
+    # Small page sizes so a modestly sized table spans many leaf pages and hence
+    # many parent internal pages, which is what a fast-truncate pins in cache.
+    table_config = 'allocation_size=512B,leaf_page_max=2KB,internal_page_max=2KB'
+
+    format_values = [
+        ('column', dict(key_format='r', value_format='S')),
+        ('integer_row', dict(key_format='i', value_format='S')),
+    ]
+    scenarios = make_scenarios(format_values)
+
+    def large_truncate(self, uri, lo, hi):
+        # Truncate [lo, hi) using a bounded transaction. Returns WT_ROLLBACK if
+        # the operation was aborted, 0 on success.
+        self.session.begin_transaction()
+        start = self.session.open_cursor(uri, None)
+        start.set_key(lo)
+        end = self.session.open_cursor(uri, None)
+        end.set_key(hi)
+        try:
+            self.session.truncate(None, start, end, None)
+        except WiredTigerError as e:
+            start.close()
+            end.close()
+            self.session.rollback_transaction()
+            if wiredtiger_strerror(WT_ROLLBACK) in str(e):
+                return WT_ROLLBACK
+            raise
+        start.close()
+        end.close()
+        self.session.commit_transaction()
+        return 0
+
+    def populate_on_disk(self, uri, nrows):
+        # Populate a table and push its leaf pages to disk so a later truncate
+        # can fast-delete them. Returns the dataset handle.
+        ds = SimpleDataSet(self, uri, 0, key_format=self.key_format,
+            value_format=self.value_format, config=self.table_config)
+        ds.populate()
+        cursor = self.session.open_cursor(uri)
+        for i in range(1, nrows + 1):
+            self.session.begin_transaction()
+            cursor[ds.key(i)] = str(i) + "abcde" * 8
+            self.session.commit_transaction()
+        cursor.close()
+        return ds
+
+    def combined_truncate(self, write_uri, write_ds, write_keys,
+            trunc_uri, trunc_ds, lo, hi):
+        # In a single transaction, apply a set of writes to one table and then
+        # truncate a range of another. Returns WT_ROLLBACK if the truncate
+        # aborted (leaving the transaction in its error state for the caller to
+        # inspect and roll back), or 0 after committing on success.
+        self.session.begin_transaction()
+        wcursor = self.session.open_cursor(write_uri)
+        for i in write_keys:
+            wcursor[write_ds.key(i)] = "combined" + str(i)
+        wcursor.close()
+
+        start = self.session.open_cursor(trunc_uri, None)
+        start.set_key(trunc_ds.key(lo))
+        end = self.session.open_cursor(trunc_uri, None)
+        end.set_key(trunc_ds.key(hi))
+        try:
+            self.session.truncate(None, start, end, None)
+        except WiredTigerError as e:
+            start.close()
+            end.close()
+            if wiredtiger_strerror(WT_ROLLBACK) in str(e):
+                return WT_ROLLBACK
+            raise
+        start.close()
+        end.close()
+        self.session.commit_transaction()
+        return 0
+
+    def test_truncate_combined_abort(self):
+        # A transaction that mixes ordinary writes with a large truncate: when
+        # the truncate trips the dirty-cache limit the entire transaction must
+        # abort, discarding the ordinary writes too. A later, smaller
+        # transaction must be unaffected (the per-txn counter does not leak).
+        trunc_uri = 'table:oplog_combined'
+        side_uri = 'table:side_combined'
+        nrows = 300000
+        side_nrows = 2000
+
+        trunc_ds = self.populate_on_disk(trunc_uri, nrows)
+        side_ds = self.populate_on_disk(side_uri, side_nrows)
+
+        self.session.checkpoint()
+        self.reopen_conn()
+
+        # Keys we add to the side table inside the doomed transaction. They live
+        # above the populated range so they are guaranteed absent beforehand.
+        combined_keys = list(range(side_nrows + 1, side_nrows + 51))
+
+        # Model the stall: a concurrent long-running transaction keeps the
+        # truncate from becoming globally visible.
+        session2 = self.conn.open_session()
+        session2.begin_transaction()
+
+        with self.expectedStdoutPattern('truncate rolled back'):
+            ret = self.combined_truncate(side_uri, side_ds, combined_keys,
+                trunc_uri, trunc_ds, 1, nrows)
+        self.assertEqual(ret, WT_ROLLBACK)
+
+        # The transaction is now in its error state: committing it fails, and
+        # the failed commit rolls the transaction back so the session is reusable.
+        with self.expectedStderrPattern('transaction requires rollback'):
+            self.assertRaisesException(WiredTigerError,
+                lambda: self.session.commit_transaction())
+
+        # The ordinary writes in the aborted transaction must not have persisted.
+        vcursor = self.session.open_cursor(side_uri)
+        for i in combined_keys:
+            vcursor.set_key(side_ds.key(i))
+            self.assertEqual(vcursor.search(), WT_NOTFOUND)
+        vcursor.close()
+
+        stat_cursor = self.session.open_cursor('statistics:', None, None)
+        truncate_rollbacks = \
+            stat_cursor[stat.conn.txn_truncate_dirty_cache_rollback][2]
+        stat_cursor.close()
+        self.assertEqual(truncate_rollbacks, 1)
+
+        # Independence: a subsequent small transaction that combines a modest
+        # truncate with a write must commit cleanly and not trip the limit. The
+        # per-transaction counter from the aborted transaction must not leak.
+        small_keys = list(range(side_nrows + 51, side_nrows + 61))
+        ret = self.combined_truncate(side_uri, side_ds, small_keys,
+            side_uri, side_ds, 1, 100)
+        self.assertEqual(ret, 0)
+
+        # Its effects must persist, and the rollback stat must be unchanged.
+        vcursor = self.session.open_cursor(side_uri)
+        for i in small_keys:
+            vcursor.set_key(side_ds.key(i))
+            self.assertEqual(vcursor.search(), 0)
+        vcursor.close()
+
+        stat_cursor = self.session.open_cursor('statistics:', None, None)
+        truncate_rollbacks = \
+            stat_cursor[stat.conn.txn_truncate_dirty_cache_rollback][2]
+        stat_cursor.close()
+        self.assertEqual(truncate_rollbacks, 1)
+
+        session2.rollback_transaction()
+        session2.close()
+
+    def test_truncate_abort(self):
+        uri = 'table:oplog'
+        nrows = 300000
+
+        ds = SimpleDataSet(self, uri, 0, key_format=self.key_format,
+            value_format=self.value_format, config=self.table_config)
+        ds.populate()
+
+        # Distinct values (so VLCS doesn't condense the table via RLE) written in
+        # their own transactions so pages become clean and evictable as we go.
+        cursor = self.session.open_cursor(uri)
+        for i in range(1, nrows + 1):
+            self.session.begin_transaction()
+            cursor[ds.key(i)] = str(i) + "abcde" * 8
+            self.session.commit_transaction()
+        cursor.close()
+
+        # Checkpoint and reopen so the leaf pages live on disk, making them
+        # eligible for fast-truncate (which deletes them without reading them).
+        self.session.checkpoint()
+        self.reopen_conn()
+
+        # A concurrent long-running transaction models the real stall: the
+        # truncate is not globally visible, so its freshly dirtied parent pages
+        # cannot be reconciled or evicted and stay pinned in cache. The abort
+        # itself is driven purely by the accumulated dirty-byte total, not by
+        # visibility, so it fires during the truncate walk regardless.
+        session2 = self.conn.open_session()
+        session2.begin_transaction()
+
+        # Truncate the entire range in a single transaction. The dirty internal
+        # pages pinned by the truncate should cross the threshold and force the
+        # transaction to roll back, emitting a warning as it does so.
+        with self.expectedStdoutPattern('truncate rolled back'):
+            ret = self.large_truncate(uri, ds.key(1), ds.key(nrows))
+        self.assertEqual(ret, WT_ROLLBACK)
+
+        # We should have fast-deleted at least one page on the way to the stall,
+        # and the rollback should be reflected in the tracking statistic.
+        stat_cursor = self.session.open_cursor('statistics:', None, None)
+        fastdelete_pages = stat_cursor[stat.conn.rec_page_delete_fast][2]
+        truncate_rollbacks = \
+            stat_cursor[stat.conn.txn_truncate_dirty_cache_rollback][2]
+        stat_cursor.close()
+        self.assertGreater(fastdelete_pages, 0)
+        self.assertEqual(truncate_rollbacks, 1)
+
+        session2.rollback_transaction()
+        session2.close()
+
+    def test_truncate_small_ok(self):
+        # A control case: a small truncate stays well under the threshold and
+        # commits normally.
+        uri = 'table:oplog_small'
+        nrows = 2000
+
+        ds = SimpleDataSet(self, uri, 0, key_format=self.key_format,
+            value_format=self.value_format, config=self.table_config)
+        ds.populate()
+
+        cursor = self.session.open_cursor(uri)
+        for i in range(1, nrows + 1):
+            self.session.begin_transaction()
+            cursor[ds.key(i)] = str(i) + "abcde" * 8
+            self.session.commit_transaction()
+        cursor.close()
+
+        self.session.checkpoint()
+        self.reopen_conn()
+
+        ret = self.large_truncate(uri, ds.key(1), ds.key(nrows))
+        self.assertEqual(ret, 0)
+
+        # A truncate that stays under the threshold must not be rolled back.
+        stat_cursor = self.session.open_cursor('statistics:', None, None)
+        truncate_rollbacks = \
+            stat_cursor[stat.conn.txn_truncate_dirty_cache_rollback][2]
+        stat_cursor.close()
+        self.assertEqual(truncate_rollbacks, 0)

--- a/test/suite/test_truncate31.py
+++ b/test/suite/test_truncate31.py
@@ -150,8 +150,10 @@ class test_truncate31(wttest.WiredTigerTestCase):
         session2 = self.conn.open_session()
         session2.begin_transaction()
 
-        ret = self.combined_truncate(side_uri, side_ds, combined_keys,
-            trunc_uri, trunc_ds, 1, nrows)
+        # The rollback also emits a warning naming the truncate as the cause.
+        with self.expectedStdoutPattern('rolling back a truncate that is pinning too much dirty cache'):
+            ret = self.combined_truncate(side_uri, side_ds, combined_keys,
+                trunc_uri, trunc_ds, 1, nrows)
         self.assertEqual(ret, WT_ROLLBACK)
 
         # The transaction is now in its error state: committing it fails, and
@@ -230,7 +232,9 @@ class test_truncate31(wttest.WiredTigerTestCase):
         # Truncate the entire range in a single transaction. The dirty internal
         # pages pinned by the truncate should cross the threshold and force the
         # transaction to roll back.
-        ret = self.large_truncate(uri, ds.key(1), ds.key(nrows))
+        # The rollback also emits a warning naming the truncate as the cause.
+        with self.expectedStdoutPattern('rolling back a truncate that is pinning too much dirty cache'):
+            ret = self.large_truncate(uri, ds.key(1), ds.key(nrows))
         self.assertEqual(ret, WT_ROLLBACK)
 
         # We should have fast-deleted at least one page on the way to the stall,

--- a/test/suite/test_truncate31.py
+++ b/test/suite/test_truncate31.py
@@ -150,9 +150,8 @@ class test_truncate31(wttest.WiredTigerTestCase):
         session2 = self.conn.open_session()
         session2.begin_transaction()
 
-        with self.expectedStdoutPattern('truncate rolled back'):
-            ret = self.combined_truncate(side_uri, side_ds, combined_keys,
-                trunc_uri, trunc_ds, 1, nrows)
+        ret = self.combined_truncate(side_uri, side_ds, combined_keys,
+            trunc_uri, trunc_ds, 1, nrows)
         self.assertEqual(ret, WT_ROLLBACK)
 
         # The transaction is now in its error state: committing it fails, and
@@ -230,9 +229,8 @@ class test_truncate31(wttest.WiredTigerTestCase):
 
         # Truncate the entire range in a single transaction. The dirty internal
         # pages pinned by the truncate should cross the threshold and force the
-        # transaction to roll back, emitting a warning as it does so.
-        with self.expectedStdoutPattern('truncate rolled back'):
-            ret = self.large_truncate(uri, ds.key(1), ds.key(nrows))
+        # transaction to roll back.
+        ret = self.large_truncate(uri, ds.key(1), ds.key(nrows))
         self.assertEqual(ret, WT_ROLLBACK)
 
         # We should have fast-deleted at least one page on the way to the stall,


### PR DESCRIPTION
An optimized (fast) truncate deletes leaf pages without reading them, but must pull in and dirty each parent internal page, which cannot be reconciled until the truncate is stable. A single huge truncate can pin enough dirty internal-page content to stall the cache indefinitely.

Track the dirty internal-page footprint a fast-truncate pins in the running transaction. When it reaches 75% of the cache-wide dirty eviction budget, return WT_ROLLBACK to force the transaction to abort rather than wedge the system. Expose the event via a new connection statistic (txn_truncate_dirty_cache_rollback) and a verbose warning.