### PR TITLE
WT-17579 Exclude statistics cursors from cursor-cache lookup

### DIFF
--- a/src/cursor/cur_std.c
+++ b/src/cursor/cur_std.c
@@ -933,6 +933,11 @@ __wti_cursors_can_be_cached(WT_SESSION_IMPL *session, const char *cfg[], bool *c
     if (cval.val)
         goto return_false;
 
+    /* Statistics cursors are never cached, don't search the cache for a match. */
+    WT_RET(__wt_config_gets_def(session, cfg, "statistics", 0, &cval));
+    if (cval.len != 0)
+        goto return_false;
+
     /* Checkpoints are readonly, we won't cache them. */
     WT_RET(__wt_config_gets_def(session, cfg, "checkpoint", 0, &cval));
     if (cval.len != 0 && !WT_CONFIG_MATCHES_DEFAULT(session, WT_SESSION_open_cursor, cval))


### PR DESCRIPTION
Statistics cursors are never cached, but opens with a statistics config searched the cursor cache anyway, walking the full hash bucket and always missing. MongoDB opens statistics cursors at per-transaction rates (session dirty-bytes and table statistics probes), and with large cursor caches the per-open bucket walk caused the many-collection-test worst-per-second latency regression.