### PR TITLE
WT-18004 Rename set_timestamp config option from step_down_ts to step_down_timestamp

### DIFF
--- a/dist/api_data.py
+++ b/dist/api_data.py
@@ -2331,7 +2331,7 @@ methods = {
         checkpoints will not include commits that are newer than the specified timestamp in tables
         configured with \c "log=(enabled=false)". Values must be monotonically increasing. The value
         must not be older than the current oldest timestamp. See @ref timestamp_global_api'''),
-    Config('step_down_ts', '', r'''
+    Config('step_down_timestamp', '', r'''
         the cutover timestamp for a planned step-down of disaggregated storage: committed writes
         after this timestamp are directed to the ingest constituent and writes at or before it to
         the stable constituent. Only valid on a leader'''),

--- a/src/config/config_def.c
+++ b/src/config/config_def.c
@@ -934,7 +934,7 @@ static const WT_CONFIG_CHECK confchk_WT_CONNECTION_set_timestamp[] = {
     WT_CONFIG_COMPILED_TYPE_STRING, 325, INT64_MIN, INT64_MAX, NULL},
   {"stable_timestamp", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 169,
     INT64_MIN, INT64_MAX, NULL},
-  {"step_down_ts", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 326,
+  {"step_down_timestamp", "string", NULL, NULL, NULL, 0, NULL, WT_CONFIG_COMPILED_TYPE_STRING, 326,
     INT64_MIN, INT64_MAX, NULL},
   {NULL, NULL, NULL, NULL, NULL, 0, NULL, 0, 0, 0, 0, NULL}};
 
@@ -4244,7 +4244,7 @@ static const WT_CONFIG_ENTRY config_entries[] = {
   {"WT_CONNECTION.set_timestamp",
     "durable_timestamp=,force=false,oldest_timestamp=,"
     "stable_disaggregated_schema_epoch=,stable_timestamp=,"
-    "step_down_ts=",
+    "step_down_timestamp=",
     confchk_WT_CONNECTION_set_timestamp, 6, confchk_WT_CONNECTION_set_timestamp_jump, 15,
     WT_CONF_SIZING_NONE, false},
   {"WT_CURSOR.bound", "action=set,bound=,inclusive=true", confchk_WT_CURSOR_bound, 3,

--- a/src/include/conf_keys.h
+++ b/src/include/conf_keys.h
@@ -350,7 +350,7 @@
 #define WT_CONF_ID_start_generation 119ULL
 #define WT_CONF_ID_start_timestamp 135ULL
 #define WT_CONF_ID_statistics 155ULL
-#define WT_CONF_ID_step_down_ts 326ULL
+#define WT_CONF_ID_step_down_timestamp 326ULL
 #define WT_CONF_ID_storage_path 337ULL
 #define WT_CONF_ID_storage_tier 22ULL
 #define WT_CONF_ID_stress_skiplist 246ULL
@@ -808,7 +808,7 @@ static const struct {
     uint64_t stable_disaggregated_schema_epoch;
     uint64_t stable_timestamp;
     uint64_t statistics;
-    uint64_t step_down_ts;
+    uint64_t step_down_timestamp;
     uint64_t strict;
     uint64_t sync;
     uint64_t target;
@@ -1239,7 +1239,7 @@ static const struct {
   WT_CONF_ID_stable_disaggregated_schema_epoch,
   WT_CONF_ID_stable_timestamp,
   WT_CONF_ID_statistics,
-  WT_CONF_ID_step_down_ts,
+  WT_CONF_ID_step_down_timestamp,
   WT_CONF_ID_strict,
   WT_CONF_ID_sync,
   WT_CONF_ID_target,

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -2755,9 +2755,10 @@ struct __wt_connection {
      * specified timestamp in tables configured with \c "log=(enabled=false)". Values must be
      * monotonically increasing.  The value must not be older than the current oldest timestamp.
      * See @ref timestamp_global_api., a string; default empty.}
-     * @config{step_down_ts, the cutover timestamp for a planned step-down of disaggregated storage:
-     * committed writes after this timestamp are directed to the ingest constituent and writes at or
-     * before it to the stable constituent.  Only valid on a leader., a string; default empty.}
+     * @config{step_down_timestamp, the cutover timestamp for a planned step-down of disaggregated
+     * storage: committed writes after this timestamp are directed to the ingest constituent and
+     * writes at or before it to the stable constituent.  Only valid on a leader., a string; default
+     * empty.}
      * @configend
      * @errors
      */

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -376,7 +376,7 @@ __wt_txn_global_set_timestamp(WT_SESSION_IMPL *session, const char *cfg[])
     if (has_stable_disagg_epoch)
         WT_STAT_CONN_INCR(session, txn_set_ts_stable_disagg_epoch);
 
-    WT_RET(__wt_config_gets_def(session, cfg, "step_down_ts", 0, &step_down_cval));
+    WT_RET(__wt_config_gets_def(session, cfg, "step_down_timestamp", 0, &step_down_cval));
     has_step_down = step_down_cval.len != 0;
 
     /* If no timestamp was supplied, there's nothing to do. */


### PR DESCRIPTION
### Summary

This change renames the WT_CONNECTION::set_timestamp option from step_down_ts to step_down_timestamp for planned step-down in disaggregated storage.

### Why

The existing name is inconsistent with other set_timestamp options, which use the *_timestamp form. Renaming it improves API consistency and aligns the public option with the existing internal step_down_timestamp naming.

### What changed

- Renamed the public set_timestamp config option from step_down_ts to step_down_timestamp
- Updated parsing, documentation, and tests to use the new name
