### PR TITLE
WT-17962 Fix modify write conflict detection

### DIFF
--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -1599,7 +1599,7 @@ __wt_btcur_modify(WT_CURSOR_BTREE *cbt, WT_MODIFY *entries, int nentries)
     WT_SESSION_IMPL *session;
     size_t max_memsize, new, orig;
     uint64_t sleep_usecs, yield_count;
-    bool overwrite, valid;
+    bool key_out_of_bounds, overwrite, valid;
 
     cursor = &cbt->iface;
     session = CUR2S(cbt);
@@ -1633,13 +1633,17 @@ __wt_btcur_modify(WT_CURSOR_BTREE *cbt, WT_MODIFY *entries, int nentries)
         WT_ERR_MSG(session, ENOTSUP, "not supported in implicit transactions");
 
     if (!F_ISSET(cursor, WT_CURSTD_KEY_INT) || !F_ISSET(cursor, WT_CURSTD_VALUE_INT)) {
+        WT_ERR(__btcur_bounds_contains_key(
+          session, cursor, &cursor->key, cursor->recno, &key_out_of_bounds, NULL));
+        if (key_out_of_bounds)
+            WT_ERR(WT_NOTFOUND);
 retry:
         WT_ERR(__wt_cursor_localkey(cursor));
         WT_ERR(__wt_cursor_func_init(cbt, true));
         WT_ERR(__cursor_search(cbt, NULL, NULL, false));
         if (cbt->compare == 0) {
             WT_ERR(__curfile_update_check(cbt));
-            WT_ERR(__wti_cursor_valid(cbt, &valid, true));
+            WT_ERR(__wti_cursor_valid(cbt, &valid, false));
             if (!valid)
                 WT_ERR(WT_NOTFOUND);
             WT_ERR(__cursor_kv_return(cbt, cbt->upd_value));

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -1246,46 +1246,6 @@ err:
 }
 
 /*
- * __cursor_modify_conflict_check --
- *     For a modify whose base value isn't visible, probe for a write conflict on the key so the
- *     conflict is reported (WT_ROLLBACK) rather than a missing value (WT_NOTFOUND). Handles both
- *     row and column store; the base-read search has reset the cursor, so this re-searches.
- */
-static int
-__cursor_modify_conflict_check(WT_CURSOR_BTREE *cbt)
-{
-    WT_CURSOR *cursor;
-    WT_DECL_RET;
-    WT_SESSION_IMPL *session;
-    uint64_t sleep_usecs, yield_count;
-
-    cursor = &cbt->iface;
-    session = CUR2S(cbt);
-    yield_count = sleep_usecs = 0;
-
-    WT_ERR(__wt_cursor_localkey(cursor));
-    __cursor_novalue(cursor);
-
-retry:
-    WT_ERR(__wt_cursor_func_init(cbt, true));
-    WT_ERR(__cursor_search(cbt, NULL, NULL, true));
-    ret = __curfile_update_check(cbt);
-
-err:
-    if (ret == WT_RESTART) {
-        __cursor_restart(session, &yield_count, &sleep_usecs);
-        goto retry;
-    }
-
-    /* This check doesn't maintain a position across calls, clear resources. */
-    if (ret == 0)
-        F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
-    WT_TRET(__cursor_reset(cbt));
-
-    return (ret);
-}
-
-/*
  * __wt_btcur_remove --
  *     Remove a record from the tree.
  */
@@ -1638,10 +1598,12 @@ __wt_btcur_modify(WT_CURSOR_BTREE *cbt, WT_MODIFY *entries, int nentries)
     WT_DECL_RET;
     WT_SESSION_IMPL *session;
     size_t max_memsize, new, orig;
-    bool overwrite;
+    uint64_t sleep_usecs, yield_count;
+    bool overwrite, valid;
 
     cursor = &cbt->iface;
     session = CUR2S(cbt);
+    yield_count = sleep_usecs = 0;
 
     /* Save the cursor state. */
     __cursor_state_save(cursor, &state);
@@ -1671,18 +1633,18 @@ __wt_btcur_modify(WT_CURSOR_BTREE *cbt, WT_MODIFY *entries, int nentries)
         WT_ERR_MSG(session, ENOTSUP, "not supported in implicit transactions");
 
     if (!F_ISSET(cursor, WT_CURSTD_KEY_INT) || !F_ISSET(cursor, WT_CURSTD_VALUE_INT)) {
-        ret = __wt_btcur_search(cbt);
-        /*
-         * If the base value isn't visible, probe for a write conflict before reporting a missing
-         * value, so the write-conflict check precedes the existence check: an update invisible to
-         * this transaction is reported as WT_ROLLBACK rather than WT_NOTFOUND. The base-read search
-         * resets the cursor on WT_NOTFOUND, so use a self-contained probe.
-         */
-        if (ret == WT_NOTFOUND) {
-            WT_ERR(__cursor_modify_conflict_check(cbt));
-            ret = WT_NOTFOUND;
-        }
-        WT_ERR(ret);
+retry:
+        WT_ERR(__wt_cursor_localkey(cursor));
+        WT_ERR(__wt_cursor_func_init(cbt, true));
+        WT_ERR(__cursor_search(cbt, NULL, NULL, false));
+        if (cbt->compare == 0) {
+            WT_ERR(__curfile_update_check(cbt));
+            WT_ERR(__wti_cursor_valid(cbt, &valid, true));
+            if (!valid)
+                WT_ERR(WT_NOTFOUND);
+            WT_ERR(__cursor_kv_return(cbt, cbt->upd_value));
+        } else
+            WT_ERR(WT_NOTFOUND);
     }
 
     WT_ERR(__wt_modify_pack(cursor, entries, nentries, &modify));
@@ -1723,6 +1685,10 @@ __wt_btcur_modify(WT_CURSOR_BTREE *cbt, WT_MODIFY *entries, int nentries)
      */
     if (ret != 0) {
 err:
+        if (ret == WT_RESTART) {
+            __cursor_restart(session, &yield_count, &sleep_usecs);
+            goto retry;
+        }
         WT_TRET(__cursor_reset(cbt));
         __cursor_state_restore(cursor, &state);
     }

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -1246,6 +1246,46 @@ err:
 }
 
 /*
+ * __cursor_modify_conflict_check --
+ *     For a modify whose base value isn't visible, probe for a write conflict on the key so the
+ *     conflict is reported (WT_ROLLBACK) rather than a missing value (WT_NOTFOUND). Handles both
+ *     row and column store; the base-read search has reset the cursor, so this re-searches.
+ */
+static int
+__cursor_modify_conflict_check(WT_CURSOR_BTREE *cbt)
+{
+    WT_CURSOR *cursor;
+    WT_DECL_RET;
+    WT_SESSION_IMPL *session;
+    uint64_t sleep_usecs, yield_count;
+
+    cursor = &cbt->iface;
+    session = CUR2S(cbt);
+    yield_count = sleep_usecs = 0;
+
+    WT_ERR(__wt_cursor_localkey(cursor));
+    __cursor_novalue(cursor);
+
+retry:
+    WT_ERR(__wt_cursor_func_init(cbt, true));
+    WT_ERR(__cursor_search(cbt, NULL, NULL, true));
+    ret = __curfile_update_check(cbt);
+
+err:
+    if (ret == WT_RESTART) {
+        __cursor_restart(session, &yield_count, &sleep_usecs);
+        goto retry;
+    }
+
+    /* This check doesn't maintain a position across calls, clear resources. */
+    if (ret == 0)
+        F_CLR(cursor, WT_CURSTD_KEY_SET | WT_CURSTD_VALUE_SET);
+    WT_TRET(__cursor_reset(cbt));
+
+    return (ret);
+}
+
+/*
  * __wt_btcur_remove --
  *     Remove a record from the tree.
  */
@@ -1630,8 +1670,20 @@ __wt_btcur_modify(WT_CURSOR_BTREE *cbt, WT_MODIFY *entries, int nentries)
     if (F_ISSET(session->txn, WT_TXN_AUTOCOMMIT))
         WT_ERR_MSG(session, ENOTSUP, "not supported in implicit transactions");
 
-    if (!F_ISSET(cursor, WT_CURSTD_KEY_INT) || !F_ISSET(cursor, WT_CURSTD_VALUE_INT))
-        WT_ERR(__wt_btcur_search(cbt));
+    if (!F_ISSET(cursor, WT_CURSTD_KEY_INT) || !F_ISSET(cursor, WT_CURSTD_VALUE_INT)) {
+        ret = __wt_btcur_search(cbt);
+        /*
+         * If the base value isn't visible, probe for a write conflict before reporting a missing
+         * value, so the write-conflict check precedes the existence check: an update invisible to
+         * this transaction is reported as WT_ROLLBACK rather than WT_NOTFOUND. The base-read search
+         * resets the cursor on WT_NOTFOUND, so use a self-contained probe.
+         */
+        if (ret == WT_NOTFOUND) {
+            WT_ERR(__cursor_modify_conflict_check(cbt));
+            ret = WT_NOTFOUND;
+        }
+        WT_ERR(ret);
+    }
 
     WT_ERR(__wt_modify_pack(cursor, entries, nentries, &modify));
 

--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -1599,7 +1599,7 @@ __wt_btcur_modify(WT_CURSOR_BTREE *cbt, WT_MODIFY *entries, int nentries)
     WT_SESSION_IMPL *session;
     size_t max_memsize, new, orig;
     uint64_t sleep_usecs, yield_count;
-    bool key_out_of_bounds, overwrite, valid;
+    bool key_out_of_bounds, leaf_found, overwrite, valid;
 
     cursor = &cbt->iface;
     session = CUR2S(cbt);
@@ -1637,18 +1637,34 @@ __wt_btcur_modify(WT_CURSOR_BTREE *cbt, WT_MODIFY *entries, int nentries)
           session, cursor, &cursor->key, cursor->recno, &key_out_of_bounds, NULL));
         if (key_out_of_bounds)
             WT_ERR(WT_NOTFOUND);
+
+        /*
+         * If we have a page pinned, search it before descending from the root. This attempt is made
+         * only on the initial pass: the retry path releases the page, so re-checking would examine
+         * a stale reference.
+         */
+        valid = leaf_found = false;
+        if (__cursor_page_pinned(cbt, true)) {
+            __wt_txn_cursor_op(session);
+            WT_ERR(__cursor_search(cbt, cbt->ref, &leaf_found, false));
+            if (leaf_found && cbt->compare == 0) {
+                WT_ERR(__curfile_update_check(cbt));
+                WT_ERR(__wti_cursor_valid(cbt, &valid, false));
+            }
+        }
+        if (!valid) {
 retry:
-        WT_ERR(__wt_cursor_localkey(cursor));
-        WT_ERR(__wt_cursor_func_init(cbt, true));
-        WT_ERR(__cursor_search(cbt, NULL, NULL, false));
-        if (cbt->compare == 0) {
+            WT_ERR(__wt_cursor_localkey(cursor));
+            WT_ERR(__wt_cursor_func_init(cbt, true));
+            WT_ERR(__cursor_search(cbt, NULL, NULL, false));
+            if (cbt->compare != 0)
+                WT_ERR(WT_NOTFOUND);
             WT_ERR(__curfile_update_check(cbt));
             WT_ERR(__wti_cursor_valid(cbt, &valid, false));
             if (!valid)
                 WT_ERR(WT_NOTFOUND);
-            WT_ERR(__cursor_kv_return(cbt, cbt->upd_value));
-        } else
-            WT_ERR(WT_NOTFOUND);
+        }
+        WT_ERR(__cursor_kv_return(cbt, cbt->upd_value));
     }
 
     WT_ERR(__wt_modify_pack(cursor, entries, nentries, &modify));

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -3221,28 +3221,16 @@ __clayered_modify_ingest(WTI_CLAYERED_OP *op, WT_MODIFY *entries, int nentries)
     WT_DECL_RET;
     WT_DECL_ITEM(buf);
     WT_ITEM value;
-    int modify_check_ret;
 
     WT_CLEAR(value);
 
-    /*
-     * FIXME-WT-17962: In ASC, the cursor modify logic differs from insert() and update(): it first
-     * checks whether the entry exists and only then checks for invisible updates, so a missing base
-     * value returns WT_NOTFOUND ahead of any WT_ROLLBACK. For now, layered cursors should follow
-     * the same behavior. However, we still need to call lookup after the modify check, since the
-     * modify check may unposition the internal cursors.
-     */
-    modify_check_ret = __clayered_modify_check(session, clayered, &cursor->key);
-    if (modify_check_ret != 0 && modify_check_ret != WT_ROLLBACK)
-        WT_ERR(modify_check_ret);
+    WT_ERR(__clayered_modify_check(session, clayered, &cursor->key));
 
     if (!F_ISSET(&clayered->iface, WT_CURSTD_KEY_INT) ||
       !F_ISSET(&clayered->iface, WT_CURSTD_VALUE_INT))
         WT_ERR(__clayered_lookup(op, &value));
     else
         WT_ITEM_SET(value, cursor->value);
-
-    WT_ERR(modify_check_ret);
 
     if (clayered->current_cursor != c_ingest) {
         /*

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -514,7 +514,6 @@ wt_timestamp_t replay_read_ts(TINFO *);
 void replay_rollback(TINFO *);
 void replay_run_begin(WT_SESSION *);
 void replay_run_end(WT_SESSION *);
-bool replay_stale_read_ts(TINFO *);
 int timestamp_query(const char *, wt_timestamp_t *);
 void timestamp_teardown(WT_SESSION *);
 void trace_config(const char *);

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -1326,12 +1326,8 @@ rollback_retry:
             val_gen(table, &tinfo->data_rnd, tinfo->new_value, tinfo->keyno);
 
         /* If modify, build a modify change vector. */
-        if (op == MODIFY) {
-            if (replay_stale_read_ts(tinfo))
-                goto rollback;
-
+        if (op == MODIFY)
             modify_build(tinfo);
-        }
 
         ret = 0;
         skip1 = skip2 = NULL;

--- a/test/format/replay.c
+++ b/test/format/replay.c
@@ -547,24 +547,6 @@ replay_rollback(TINFO *tinfo)
 }
 
 /*
- * replay_stale_read_ts --
- *     Return true if the transaction's read timestamp is below the lane's last commit timestamp,
- *     meaning an operation may produce non-deterministic results. Spins until
- *     replay_maximum_committed catches up before returning, so the subsequent rollback and retry
- *     will acquire a read timestamp that sees a consistent key state.
- */
-bool
-replay_stale_read_ts(TINFO *tinfo)
-{
-    if (!GV(RUNS_PREDICTABLE_REPLAY) || tinfo->read_ts >= g.lanes[tinfo->lane].last_commit_ts)
-        return (false);
-
-    while (replay_maximum_committed() < g.lanes[tinfo->lane].last_commit_ts)
-        __wt_yield();
-    return (true);
-}
-
-/*
  * replay_pause_after_rollback --
  *     Called after a rollback, allowing us to yield or pause.
  */

--- a/test/suite/test_cursor12.py
+++ b/test/suite/test_cursor12.py
@@ -417,7 +417,7 @@ class test_cursor12(wttest.WiredTigerTestCase):
         mods.append(mod)
         mods = self.fix_mods(mods)
         xc.set_key(ds.key(30))
-        self.assertEqual(xc.modify(mods), wiredtiger.WT_NOTFOUND)
+        self.assertRaises(wiredtiger.WiredTigerRollbackError, lambda: xc.modify(mods))
         xs.rollback_transaction()
 
         # Rollback our transaction.


### PR DESCRIPTION
Unpositioned modify (in ASC and DSC) now detects write conflicts against committed-but-invisible updates by performing a write-conflict check (`__curfile_update_check/__clayered_modify_check`) before the existence check (`__wti_cursor_valid/__clayered_lookup`).

This shouldn't be a problem for mongo, as mongo always searches (leaving the cursor positioned) before calling modify, so the unpositioned path is never taken. However, test/format predictable replay currently always uses `positioned=false` for modify, which is where we detected this problem originally.

I also removed test/format's `replay_stale_read_ts` workaround, as this PR should resolve the underlying data corruption.