### PR TITLE
Pre-size disaggregated block-read scratch buffers in __wt_blkcache_read_multi

### DIFF
--- a/src/block_cache/block_io.c
+++ b/src/block_cache/block_io.c
@@ -534,7 +534,8 @@ __wt_blkcache_read_multi(WT_SESSION_IMPL *session, WT_ITEM **buf, size_t *buf_co
     /* Decrypt. */
     ip_orig = ip;
     if (F_ISSET(dsk, WT_PAGE_ENCRYPTED)) {
-        WT_ERR(__wt_scr_alloc(session, 0, &etmp));
+        /* Pre-size to the leaf page max to avoid realloc on typical pages (WT-17097). */
+        WT_ERR(__wt_scr_alloc(session, btree->maxleafpage, &etmp));
         WT_ERR(__blkcache_read_decrypt(session, ip, etmp, addr, addr_size));
         ip = etmp;
     }
@@ -553,7 +554,7 @@ __wt_blkcache_read_multi(WT_SESSION_IMPL *session, WT_ITEM **buf, size_t *buf_co
      */
     dsk = ip->data;
     if (F_ISSET(dsk, WT_PAGE_COMPRESSED)) {
-        WT_ERR(__wt_scr_alloc(session, 0, &ctmp));
+        WT_ERR(__wt_scr_alloc(session, btree->maxleafpage, &ctmp));
         WT_ERR(__read_decompress(session, dsk, dsk->mem_size, ctmp, addr, addr_size));
         ip = ctmp;
     }
@@ -600,13 +601,13 @@ __wt_blkcache_read_multi(WT_SESSION_IMPL *session, WT_ITEM **buf, size_t *buf_co
             WT_STAT_CONN_INCRV(session, block_byte_read_leaf_disk, ip->size);
 
         if (F_ISSET(blk, WT_BLOCK_DISAGG_ENCRYPTED)) {
-            WT_ERR(__wt_scr_alloc(session, 0, &etmp));
+            WT_ERR(__wt_scr_alloc(session, btree->maxleafpage, &etmp));
             WT_ERR(__blkcache_read_decrypt(session, ip, etmp, addr, addr_size));
             ip = etmp;
         }
         if (F_ISSET(blk, WT_BLOCK_DISAGG_COMPRESSED)) {
             dsk = ip->data;
-            WT_ERR(__wt_scr_alloc(session, 0, &ctmp));
+            WT_ERR(__wt_scr_alloc(session, btree->maxleafpage, &ctmp));
             WT_ERR(__read_decompress(session, ip->data, dsk->mem_size, ctmp, addr, addr_size));
             ip = ctmp;
         }


### PR DESCRIPTION
## Problem

WT-17097 pre-sized the scratch buffer in `__wt_blkcache_read()` from a hardcoded 4KB to `btree->maxleafpage`, avoiding a `realloc` on nearly every compressed/encrypted read (typical `maxleafpage` is 32KB) that contended on tcmalloc's allocator spinlock under concurrency.

That fix only touched `__wt_blkcache_read`. The sibling function `__wt_blkcache_read_multi()`, used for disaggregated-storage reads (base image + deltas fetched from the page server), still allocates its four decrypt/decompress scratch buffers (`etmp`/`ctmp`) with size `0`, hitting the same realloc pattern.

## Fix

Pre-size the `__wt_scr_alloc` calls inside `__wt_blkcache_read_multi` to `btree->maxleafpage`, mirroring the WT-17097 idiom. No other logic changes.

## Validation

Compiles cleanly on current `mongodb-master`, and ran without crash, assertion, or data issue across five disaggregated-storage workloads (out-of-cache read, out-of-cache update, bulk load, TPC-C, LinkBench).

**Throughput: no measurable change.** A same-commit A/B (patched vs. unpatched built from the *identical* revision) showed per-workload deltas within run-to-run noise in both directions (roughly +2% to −5%, none statistically significant at the sampled N). An earlier comparison had suggested large gains, but that turned out to be an artifact of a drifting rolling baseline — the unpatched mainline had itself sped up between the baseline window and the test revision, and a same-commit control removed the confound and the apparent gains disappeared. So on the tested workloads and hardware this is **performance-neutral**.

It is offered primarily as a **mechanism-parity fix**: `__wt_blkcache_read_multi` carries the same undersized-scratch-buffer pattern WT-17097 fixed in its sibling. The `realloc`→allocator-contention path it removes may still matter under conditions not exercised here (encryption-at-rest enabled, higher concurrency, heavier allocator pressure), but that benefit is unconfirmed.

Two points for reviewer consideration:
- The **base-image** decrypt/decompress buffers are leaf-sized, so `maxleafpage` is the right hint there (directly analogous to WT-17097).
- The **per-delta** buffers (inside the loop) are also sized to `maxleafpage`, but deltas are typically smaller than a full leaf page, so sizing them to the leaf max may over-allocate. This is a plausible reason the change trends slightly negative on write/mixed workloads, and is worth deciding on before merge (e.g. size delta buffers to a delta-appropriate hint, or presize only the base-image buffers).

Kept as a **draft** pending direct off-CPU profiling confirmation that the allocator-contention path actually shrinks; without that, there is no demonstrated performance justification to merge.
