### PR TITLE
WT-18014 Factor cache miss rate in cache read load calculation

### DIFF
--- a/src/conn/conn_load_control.c
+++ b/src/conn/conn_load_control.c
@@ -110,8 +110,8 @@ __wt_conn_calc_read_load(WT_SESSION_IMPL *session)
 {
     WT_CONNECTION_IMPL *conn;
     WT_CONNECTION_LOAD_CONTROL *load_control;
-    uint64_t cache_read, cache_req, delta_read, delta_req, prev_read, prev_req;
     float cache_miss_pct, read_load;
+    uint64_t cache_read, cache_req, delta_read, delta_req, prev_read, prev_req;
 
     conn = S2C(session);
     load_control = &conn->load_control;

--- a/src/conn/conn_load_control.c
+++ b/src/conn/conn_load_control.c
@@ -141,7 +141,7 @@ __wt_conn_calc_read_load(WT_SESSION_IMPL *session)
             cache_miss_pct = (uint16_t)WT_MIN((delta_read * 100) / delta_req, 100);
     }
 
-    return ((uint16_t)WT_MIN((uint32_t)read_load * (100 + cache_miss_pct) / 100, 1000));
+    return ((uint16_t)WT_MIN((uint32_t)read_load * (uint32_t)(100 + cache_miss_pct) / 100, 1000));
 }
 
 /*

--- a/src/conn/conn_load_control.c
+++ b/src/conn/conn_load_control.c
@@ -96,17 +96,52 @@ __conn_calc_load_pct(uint64_t part, uint64_t whole)
 /*
  * __wt_conn_calc_read_load --
  *     Calculate and return the read load at the system level. Computed on demand from the load-shed
- *     check and the statistics path rather than in the cache accounting hot path. The load is
- *     always calculated; the load control enable flag only governs whether work is shed.
+ *     check and the statistics path rather than in the cache accounting hot path. The cache fill
+ *     ratio is always calculated; it is amplified by (1 + recent read miss rate) only while load
+ *     control is enabled, so that a cache thrashing on disk reads is shed more aggressively (up to
+ *     twice the fill ratio) than one serving mostly hits. The miss rate is sampled from the delta
+ *     of the cumulative cache read and page request counters since the previous review; those
+ *     counters are tracked unconditionally so the sample doesn't go stale while load control is
+ *     disabled. The counters advance concurrently with reads, so the sampled delta is approximate,
+ *     which is acceptable for a load heuristic.
  */
 uint16_t
 __wt_conn_calc_read_load(WT_SESSION_IMPL *session)
 {
+    WT_CONNECTION_IMPL *conn;
     WT_CONNECTION_LOAD_CONTROL *load_control;
+    uint64_t cache_read, cache_req, delta_read, delta_req, prev_read, prev_req;
+    uint16_t read_load, cache_miss_pct;
 
-    load_control = &S2C(session)->load_control;
-    return (__conn_calc_load_pct(
-      __wt_cache_bytes_inuse(S2C(session)->cache), load_control->read_load_max));
+    conn = S2C(session);
+    load_control = &conn->load_control;
+
+    read_load =
+      __conn_calc_load_pct(__wt_cache_bytes_inuse(conn->cache), load_control->read_load_max);
+
+    cache_read = (uint64_t)WT_STAT_CONN_READ(conn->stats, cache_read);
+    cache_req = (uint64_t)WT_STAT_CONN_READ(conn->stats, cache_pages_requested);
+
+    prev_req = __wt_atomic_load_uint64_relaxed(&load_control->prev_cache_pages_requested);
+    delta_req = cache_req - prev_req;
+
+    /*
+     * When statistics are disabled the read counters stay at zero, and with no new page requests
+     * since the last review the miss rate is treated as zero, giving the cache fill ratio alone.
+     */
+    cache_miss_pct = 0;
+    if (delta_req != 0) {
+        prev_read = __wt_atomic_load_uint64_relaxed(&load_control->prev_cache_read);
+        __wt_atomic_store_uint64_relaxed(&load_control->prev_cache_read, cache_read);
+        __wt_atomic_store_uint64_relaxed(&load_control->prev_cache_pages_requested, cache_req);
+        delta_read = cache_read - prev_read;
+
+        /* Factor in the cache miss rate when load control is enabled */
+        if (F_ISSET(load_control, WT_CONN_LOAD_CONTROL))
+            cache_miss_pct = (uint16_t)WT_MIN((delta_read * 100) / delta_req, 100);
+    }
+
+    return ((uint16_t)WT_MIN((uint32_t)read_load * (100 + cache_miss_pct) / 100, 1000));
 }
 
 /*

--- a/src/conn/conn_load_control.c
+++ b/src/conn/conn_load_control.c
@@ -97,13 +97,11 @@ __conn_calc_load_pct(uint64_t part, uint64_t whole)
  * __wt_conn_calc_read_load --
  *     Calculate and return the read load at the system level. Computed on demand from the load-shed
  *     check and the statistics path rather than in the cache accounting hot path. The cache fill
- *     ratio is always calculated; it is amplified by (1 + recent read miss rate) only while load
- *     control is enabled, so that a cache thrashing on disk reads is shed more aggressively (up to
- *     twice the fill ratio) than one serving mostly hits. The miss rate is sampled from the delta
- *     of the cumulative cache read and page request counters since the previous review; those
- *     counters are tracked unconditionally so the sample doesn't go stale while load control is
- *     disabled. The counters advance concurrently with reads, so the sampled delta is approximate,
- *     which is acceptable for a load heuristic.
+ *     ratio is amplified by (1 + recent read miss rate), so that a cache thrashing on disk reads is
+ *     shed more aggressively (up to twice the fill ratio) than one serving mostly hits. The miss
+ *     rate is sampled from the delta of the cumulative cache read and page request counters since
+ *     the previous review. The counters advance concurrently with reads, so the sampled delta is
+ *     approximate, which is acceptable for a load heuristic.
  */
 uint16_t
 __wt_conn_calc_read_load(WT_SESSION_IMPL *session)
@@ -136,9 +134,7 @@ __wt_conn_calc_read_load(WT_SESSION_IMPL *session)
         __wt_atomic_store_uint64_relaxed(&load_control->prev_cache_pages_requested, cache_req);
         delta_read = cache_read - prev_read;
 
-        /* Factor in the cache miss rate when load control is enabled */
-        if (F_ISSET(load_control, WT_CONN_LOAD_CONTROL))
-            cache_miss_pct = WT_MIN((float)delta_read * 100 / (float)delta_req, 100.0F);
+        cache_miss_pct = WT_MIN((float)delta_read * 100 / (float)delta_req, 100.0F);
     }
 
     return ((uint16_t)WT_MIN(read_load * (100 + cache_miss_pct) / 100, 1000.0F));

--- a/src/conn/conn_load_control.c
+++ b/src/conn/conn_load_control.c
@@ -84,13 +84,13 @@ __wti_conn_load_control_config(WT_SESSION_IMPL *session, const char *cfg[], bool
  * __conn_calc_load_pct --
  *     Calculate the percentage of part relative to whole. Returns 0 if whole is zero.
  */
-static WT_INLINE uint16_t
+static WT_INLINE float
 __conn_calc_load_pct(uint64_t part, uint64_t whole)
 {
     if (whole == 0)
-        return (0);
+        return (0.0F);
 
-    return ((uint16_t)WT_MIN((part * 100) / whole, 1000));
+    return (WT_MIN((float)part * 100 / (float)whole, 1000.0F));
 }
 
 /*
@@ -111,7 +111,7 @@ __wt_conn_calc_read_load(WT_SESSION_IMPL *session)
     WT_CONNECTION_IMPL *conn;
     WT_CONNECTION_LOAD_CONTROL *load_control;
     uint64_t cache_read, cache_req, delta_read, delta_req, prev_read, prev_req;
-    uint16_t read_load, cache_miss_pct;
+    float cache_miss_pct, read_load;
 
     conn = S2C(session);
     load_control = &conn->load_control;
@@ -129,7 +129,7 @@ __wt_conn_calc_read_load(WT_SESSION_IMPL *session)
      * When statistics are disabled the read counters stay at zero, and with no new page requests
      * since the last review the miss rate is treated as zero, giving the cache fill ratio alone.
      */
-    cache_miss_pct = 0;
+    cache_miss_pct = 0.0F;
     if (delta_req != 0) {
         prev_read = __wt_atomic_load_uint64_relaxed(&load_control->prev_cache_read);
         __wt_atomic_store_uint64_relaxed(&load_control->prev_cache_read, cache_read);
@@ -138,10 +138,10 @@ __wt_conn_calc_read_load(WT_SESSION_IMPL *session)
 
         /* Factor in the cache miss rate when load control is enabled */
         if (F_ISSET(load_control, WT_CONN_LOAD_CONTROL))
-            cache_miss_pct = (uint16_t)WT_MIN((delta_read * 100) / delta_req, 100);
+            cache_miss_pct = WT_MIN((float)delta_read * 100 / (float)delta_req, 100.0F);
     }
 
-    return ((uint16_t)WT_MIN((uint32_t)read_load * (uint32_t)(100 + cache_miss_pct) / 100, 1000));
+    return ((uint16_t)WT_MIN(read_load * (100 + cache_miss_pct) / 100, 1000.0F));
 }
 
 /*
@@ -169,8 +169,10 @@ uint16_t
 __wt_conn_calc_write_load(WT_SESSION_IMPL *session)
 {
     WT_CONNECTION_LOAD_CONTROL *load_control;
+    float write_load;
 
     load_control = &S2C(session)->load_control;
-    return (__conn_calc_load_pct(
-      __wt_cache_dirty_inuse(S2C(session)->cache), load_control->write_load_max));
+    write_load = __conn_calc_load_pct(
+      __wt_cache_dirty_inuse(S2C(session)->cache), load_control->write_load_max);
+    return ((uint16_t)write_load);
 }

--- a/src/include/load_control.h
+++ b/src/include/load_control.h
@@ -13,6 +13,15 @@ struct __wt_connection_load_control {
     wt_shared uint64_t read_load_max;  /* cache max bytes equivalent eviction trigger */
     wt_shared uint64_t write_load_max; /* cache max dirty bytes equivalent to dirty trigger */
 
+    /*
+     * Read miss rate tracking. The read load is amplified by the fraction of recently requested
+     * pages that had to be read from disk. The miss rate is sampled over the delta of the
+     * cumulative counters since the previous review to reflect current conditions rather than
+     * lifetime history.
+     */
+    wt_shared uint64_t prev_cache_read;            /* cache_read at last miss-rate review */
+    wt_shared uint64_t prev_cache_pages_requested; /* cache_pages_requested at last review */
+
     /* cache eviction controls bit positions */
 #define WT_CONN_LOAD_CONTROL 0x1u
     wt_shared uint32_t flags;


### PR DESCRIPTION
Factor the cache miss rate in cache read load calculation under the load control feature flag.

Cache miss = cache read from disk / Cache pages requested
