### PR TITLE
WT-17666 Skip scratch buffer in __rec_append_orig_value for non-overflow value cells

### DIFF
--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -92,6 +92,7 @@ __rec_append_orig_value(WT_SESSION_IMPL *session, WT_PAGE *page, WT_UPDATE *upd,
     WT_CONNECTION_IMPL *conn;
     WT_DECL_ITEM(tmp);
     WT_DECL_RET;
+    WT_ITEM cell_ref, *src;
     WT_UPDATE *append, *oldest_upd, *onpage_upd_or_tombstone, *tombstone;
     size_t size, total_size;
     bool seen_committed, tombstone_globally_visible;
@@ -230,15 +231,26 @@ __rec_append_orig_value(WT_SESSION_IMPL *session, WT_PAGE *page, WT_UPDATE *upd,
 
     /* We need the original on-page value for some reader: get a copy. */
     if (!tombstone_globally_visible) {
-        WT_ERR(__wt_scr_alloc(session, 0, &tmp));
-        WT_ERR(__wt_page_cell_data_ref_kv(session, page, unpack, tmp));
         /*
          * We should never see an overflow removed value because we haven't freed the overflow
          * blocks.
          */
         WT_ASSERT(session,
           unpack->cell == NULL || __wt_cell_type_raw(unpack->cell) != WT_CELL_VALUE_OVFL_RM);
-        WT_ERR(__wt_upd_alloc(session, tmp, WT_UPDATE_STANDARD, &append, &size));
+        /*
+         * A non-overflow value is already fully in memory, so reference it directly rather than
+         * decoding into a scratch buffer; the allocation below copies it out immediately.
+         */
+        if (unpack->type == WT_CELL_VALUE) {
+            cell_ref.data = unpack->data;
+            cell_ref.size = unpack->size;
+            src = &cell_ref;
+        } else {
+            WT_ERR(__wt_scr_alloc(session, 0, &tmp));
+            WT_ERR(__wt_page_cell_data_ref_kv(session, page, unpack, tmp));
+            src = tmp;
+        }
+        WT_ERR(__wt_upd_alloc(session, src, WT_UPDATE_STANDARD, &append, &size));
         total_size += size;
         /*
          * When reconciling during recovery, we need to clear the transaction id as we haven't done


### PR DESCRIPTION
## Summary

In `__rec_append_orig_value` (`src/reconcile/rec_visibility.c`), the on-page value was copied into a session scratch buffer via `__wt_page_cell_data_ref_kv` before being handed to `__wt_upd_alloc`. For non-overflow cells (`unpack->type == WT_CELL_VALUE`), `__cell_data_ref` only sets `store->data`/`store->size` and `__wt_upd_alloc` `memcpy`s the value into the new `WT_UPDATE` immediately, so the scratch buffer is wasted work.

This change references the cell data directly via a stack-local `WT_ITEM` for `WT_CELL_VALUE` cells, keeping the scratch-buffer path for overflow cells where `__wt_ovfl_read` needs a real buffer.

`WT_CELL_VALUE_COPY` cells decode to `unpack->type == WT_CELL_VALUE` after the copy-cell restart in `__wt_cell_unpack_kv`, so they take the fast path correctly. `WT_CELL_VALUE_OVFL` retains its type and uses the scratch path; `WT_CELL_VALUE_OVFL_RM` remains excluded by the existing assert.

## Motivation

Flamegraph from BF-41977 showed `__rec_append_orig_value` self-time at 1.19% DSC vs 0.06% ASC (+1.13pp). The change is small and safe, based on a real hotspot.