### PR TITLE
WT-18020 Fix memory leak when retrying in __curstat_layered_init

### DIFF
--- a/src/cursor/cur_stat.c
+++ b/src/cursor/cur_stat.c
@@ -455,8 +455,15 @@ retry:
     }
 
     ret = __wt_session_get_dhandle(session, stable_uri, NULL, NULL, 0);
-    if (ret == EBUSY)
+    if (ret == EBUSY) {
+        /*
+         * The retry re-fetches the checkpoint name and reallocates the scratch buffer, so release
+         * both before looping.
+         */
+        __wt_free(session, checkpoint_name);
+        __wt_scr_free(session, &stable_uri_buf);
         goto retry;
+    }
 
     WT_ERR(ret);
 


### PR DESCRIPTION
There is a memory leak here because we allocate memory on retry. If we get to this point, we have already allocated memory, so we should free it before moving on.

[WT-18020](https://jira.mongodb.org/browse/WT-18020)
[BF-44471](https://jira.mongodb.org/browse/BF-44471)