### PR TITLE
WT-17971 Add Python tests for schema transaction interaction and table lifecycle

### DIFF
--- a/test/suite/helpers/helper_disagg.py
+++ b/test/suite/helpers/helper_disagg.py
@@ -808,43 +808,27 @@ class DisaggSchemaEpochMixin:
         tablename = uri[len('layered:'):]
         return 'file:' + tablename + '.wt_stable'
 
-    def uri_in_shared_metadata(self, conn, stable_uri):
-        """Return True if stable_uri is present in the shared metadata table."""
+    def uri_in_shared_metadata(self, conn, uri):
+        """Return True if uri's stable constituent is present in the shared metadata table."""
         session = conn.open_session('')
         cursor = session.open_cursor('file:WiredTigerShared.wt_stable', None, None)
-        cursor.set_key(stable_uri)
+        cursor.set_key(self.stable_uri(uri))
         found = cursor.search() == 0
         cursor.close()
         session.close()
         return found
 
     def uri_in_local_metadata(self, conn, uri):
-        """Return True if uri is present in the local metadata (cursor open succeeds)."""
+        """Return True if uri's stable constituent is present in conn's local metadata."""
         session = conn.open_session('')
         exists = True
         try:
-            c = session.open_cursor(uri)
+            c = session.open_cursor(self.stable_uri(uri))
             c.close()
         except wiredtiger.WiredTigerError:
             exists = False
         session.close()
         return exists
-
-    def assertInLocal(self, conn, uri):
-        """Assert that uri's stable constituent is present in conn's local metadata."""
-        self.assertTrue(self.uri_in_local_metadata(conn, self.stable_uri(uri)))
-
-    def assertNotInLocal(self, conn, uri):
-        """Assert that uri's stable constituent is absent from conn's local metadata."""
-        self.assertFalse(self.uri_in_local_metadata(conn, self.stable_uri(uri)))
-
-    def assertInShared(self, conn, uri):
-        """Assert that uri's stable constituent is present in the shared metadata table."""
-        self.assertTrue(self.uri_in_shared_metadata(conn, self.stable_uri(uri)))
-
-    def assertNotInShared(self, conn, uri):
-        """Assert that uri's stable constituent is absent from the shared metadata table."""
-        self.assertFalse(self.uri_in_shared_metadata(conn, self.stable_uri(uri)))
 
     def open_follower(self):
         """Open a follower, pick up the latest leader checkpoint, and open a session on it."""

--- a/test/suite/helpers/helper_disagg.py
+++ b/test/suite/helpers/helper_disagg.py
@@ -776,6 +776,86 @@ class DisaggCorruptionMixin:
                 f"expected 1 affected row, got {affected} for "
                 f"table_id={table_id}, page_id={page_id}, lsn={lsn}")
 
+# Shared helpers for tests that exercise WT_SESSION::publish and schema epochs on
+# layered tables. Tests using this mixin must define conn_config_follower.
+class DisaggSchemaEpochMixin:
+    def set_stable_epoch(self, epoch, conn=None):
+        """Set stable_disaggregated_schema_epoch on the given (or main) connection."""
+        if conn is None:
+            conn = self.conn
+        conn.set_timestamp(
+            'stable_disaggregated_schema_epoch=' + self.timestamp_str(epoch))
+
+    def leader_checkpoint(self, stable_ts, conn=None, session=None):
+        """Set the oldest and stable timestamps, then take a timestamped checkpoint."""
+        if conn is None:
+            conn = self.conn
+        if session is None:
+            session = self.session
+        conn.set_timestamp(
+            'stable_timestamp=' + self.timestamp_str(stable_ts) +
+            ',oldest_timestamp=' + self.timestamp_str(1))
+        session.checkpoint()
+
+    def publish(self, uri, epoch, session=None):
+        """Publish a schema change for uri at the given epoch."""
+        if session is None:
+            session = self.session
+        session.publish(uri, 'disaggregated=(schema_epoch=' + self.timestamp_str(epoch) + ')')
+
+    def stable_uri(self, uri):
+        """Return the stable component URI for a given layered table URI."""
+        tablename = uri[len('layered:'):]
+        return 'file:' + tablename + '.wt_stable'
+
+    def uri_in_shared_metadata(self, conn, stable_uri):
+        """Return True if stable_uri is present in the shared metadata table."""
+        session = conn.open_session('')
+        cursor = session.open_cursor('file:WiredTigerShared.wt_stable', None, None)
+        cursor.set_key(stable_uri)
+        found = cursor.search() == 0
+        cursor.close()
+        session.close()
+        return found
+
+    def uri_in_local_metadata(self, conn, uri):
+        """Return True if uri is present in the local metadata (cursor open succeeds)."""
+        session = conn.open_session('')
+        exists = True
+        try:
+            c = session.open_cursor(uri)
+            c.close()
+        except wiredtiger.WiredTigerError:
+            exists = False
+        session.close()
+        return exists
+
+    def assertInLocal(self, conn, uri):
+        """Assert that uri's stable constituent is present in conn's local metadata."""
+        self.assertTrue(self.uri_in_local_metadata(conn, self.stable_uri(uri)))
+
+    def assertNotInLocal(self, conn, uri):
+        """Assert that uri's stable constituent is absent from conn's local metadata."""
+        self.assertFalse(self.uri_in_local_metadata(conn, self.stable_uri(uri)))
+
+    def assertInShared(self, conn, uri):
+        """Assert that uri's stable constituent is present in the shared metadata table."""
+        self.assertTrue(self.uri_in_shared_metadata(conn, self.stable_uri(uri)))
+
+    def assertNotInShared(self, conn, uri):
+        """Assert that uri's stable constituent is absent from the shared metadata table."""
+        self.assertFalse(self.uri_in_shared_metadata(conn, self.stable_uri(uri)))
+
+    def open_follower(self):
+        """Open a follower, pick up the latest leader checkpoint, and open a session on it."""
+        conn = self.wiredtiger_open(
+            'follower',
+            self.extensionsConfig() + ',create,' + self.conn_config_follower)
+        self.ignoreStdoutPattern('WT_VERB_RTS|(wiredtiger_open:.*WT_VERB_METADATA)')
+        self.disagg_advance_checkpoint(conn)
+        session = conn.open_session('')
+        return conn, session
+
 class DisaggSizeTestMixin:
     def conn_extensions(self, extlist):
         extlist.skip_if_missing = True

--- a/test/suite/test_layered_schema07.py
+++ b/test/suite/test_layered_schema07.py
@@ -33,14 +33,14 @@
 
 import os, time
 import wiredtiger, wttest
-from helper_disagg import disagg_test_class, gen_disagg_storages
+from helper_disagg import disagg_test_class, gen_disagg_storages, DisaggSchemaEpochMixin
 from suite_subprocess import suite_subprocess
 from wtscenario import make_scenarios
 from wiredtiger import stat
 
 # Test WT_SESSION::publish for disaggregated storage.
 @disagg_test_class
-class test_layered_schema07(wttest.WiredTigerTestCase, suite_subprocess):
+class test_layered_schema07(wttest.WiredTigerTestCase, suite_subprocess, DisaggSchemaEpochMixin):
     test_name = __qualname__
     conn_base_config = 'statistics=(all),precise_checkpoint=true,'
     conn_config = conn_base_config + 'disaggregated=(role="leader",lose_all_my_data=true)'
@@ -54,22 +54,6 @@ class test_layered_schema07(wttest.WiredTigerTestCase, suite_subprocess):
     #
     # Helper methods
     #
-
-    def set_stable_epoch(self, epoch):
-        """
-        Set stable_disaggregated_schema_epoch.
-        """
-        self.conn.set_timestamp(
-            'stable_disaggregated_schema_epoch=' + self.timestamp_str(epoch))
-
-    def leader_checkpoint(self, stable_ts):
-        """
-        Set the oldest and stable timestamps, and then take a timestamped checkpoint.
-        """
-        self.conn.set_timestamp(
-            'stable_timestamp=' + self.timestamp_str(stable_ts) +
-            ',oldest_timestamp=' + self.timestamp_str(1))
-        self.session.checkpoint()
 
     def open_follower(self):
         """
@@ -98,15 +82,6 @@ class test_layered_schema07(wttest.WiredTigerTestCase, suite_subprocess):
         session_follower.close()
         conn_follower.close()
         return exists
-
-    def publish(self, uri, epoch, session=None):
-        """
-        Publish a schema change with the given epoch. If session is None, use the main test session.
-        """
-        if session is None:
-            session = self.session
-        session.publish(uri, 'disaggregated=(schema_epoch=' + self.timestamp_str(epoch) + ')')
-
 
     #
     # Functional tests

--- a/test/suite/test_layered_schema10.py
+++ b/test/suite/test_layered_schema10.py
@@ -33,12 +33,12 @@
 # was a follower.
 
 import wiredtiger, wttest
-from helper_disagg import disagg_test_class, gen_disagg_storages
+from helper_disagg import disagg_test_class, gen_disagg_storages, DisaggSchemaEpochMixin
 from suite_subprocess import suite_subprocess
 from wtscenario import make_scenarios
 
 @disagg_test_class
-class test_layered_schema10(wttest.WiredTigerTestCase, suite_subprocess):
+class test_layered_schema10(wttest.WiredTigerTestCase, suite_subprocess, DisaggSchemaEpochMixin):
     test_name = __qualname__
     conn_base_config = 'statistics=(all),precise_checkpoint=true,'
     conn_config = conn_base_config + 'disaggregated=(role="leader",lose_all_my_data=true)'
@@ -55,72 +55,6 @@ class test_layered_schema10(wttest.WiredTigerTestCase, suite_subprocess):
     #
     # Helper methods
     #
-
-    def set_stable_epoch(self, epoch, conn=None):
-        if conn is None:
-            conn = self.conn
-        conn.set_timestamp(
-            'stable_disaggregated_schema_epoch=' + self.timestamp_str(epoch))
-
-    def leader_checkpoint(self, stable_ts, conn=None, session=None):
-        if conn is None:
-            conn = self.conn
-        if session is None:
-            session = self.session
-        conn.set_timestamp(
-            'stable_timestamp=' + self.timestamp_str(stable_ts) +
-            ',oldest_timestamp=' + self.timestamp_str(1))
-        session.checkpoint()
-
-    def publish(self, uri, epoch, session=None):
-        if session is None:
-            session = self.session
-        session.publish(uri, 'disaggregated=(schema_epoch=' + self.timestamp_str(epoch) + ')')
-
-    def stable_uri(self, uri):
-        """Return the stable component URI for a given layered table URI."""
-        tablename = uri[len('layered:'):]
-        return 'file:' + tablename + '.wt_stable'
-
-    def uri_in_shared_metadata(self, conn, stable_uri):
-        """
-        Return True if stable_uri is present in the shared metadata table.
-        """
-        session = conn.open_session('')
-        cursor = session.open_cursor('file:WiredTigerShared.wt_stable', None, None)
-        cursor.set_key(stable_uri)
-        found = cursor.search() == 0
-        cursor.close()
-        session.close()
-        return found
-
-    def uri_in_local_metadata(self, conn, uri):
-        """Return True if uri is present in the local metadata (cursor open succeeds)."""
-        session = conn.open_session('')
-        exists = True
-        try:
-            c = session.open_cursor(uri)
-            c.close()
-        except wiredtiger.WiredTigerError:
-            exists = False
-        session.close()
-        return exists
-
-    def assertInLocal(self, conn, uri):
-        """Assert that uri's stable constituent is present in conn's local metadata."""
-        self.assertTrue(self.uri_in_local_metadata(conn, self.stable_uri(uri)))
-
-    def assertNotInLocal(self, conn, uri):
-        """Assert that uri's stable constituent is absent from conn's local metadata."""
-        self.assertFalse(self.uri_in_local_metadata(conn, self.stable_uri(uri)))
-
-    def assertInShared(self, conn, uri):
-        """Assert that uri's stable constituent is present in the shared metadata table."""
-        self.assertTrue(self.uri_in_shared_metadata(conn, self.stable_uri(uri)))
-
-    def assertNotInShared(self, conn, uri):
-        """Assert that uri's stable constituent is absent from the shared metadata table."""
-        self.assertFalse(self.uri_in_shared_metadata(conn, self.stable_uri(uri)))
 
     def setup_leader_with_epoch(self):
         """
@@ -141,16 +75,6 @@ class test_layered_schema10(wttest.WiredTigerTestCase, suite_subprocess):
         """
         self.conn.reconfigure('disaggregated=(role="follower")')
         conn_follower.reconfigure('disaggregated=(role="leader")')
-
-    def open_follower(self):
-        """Open a follower, pick up the latest leader checkpoint, and open a session on it."""
-        conn = self.wiredtiger_open(
-            'follower',
-            self.extensionsConfig() + ',create,' + self.conn_config_follower)
-        self.ignoreStdoutPattern('WT_VERB_RTS|(wiredtiger_open:.*WT_VERB_METADATA)')
-        self.disagg_advance_checkpoint(conn)
-        session = conn.open_session('')
-        return conn, session
 
     def checkpoint_and_advance(self, epoch, stable_ts, conn_leader):
         """

--- a/test/suite/test_layered_schema10.py
+++ b/test/suite/test_layered_schema10.py
@@ -104,20 +104,20 @@ class test_layered_schema10(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
         # Pre-swap state:
         # Shared metadata: empty (no schema operations on the initial leader).
         # Follower: uri layered table present; metadata queue holds CREATE uri at epoch 20.
-        self.assertNotInLocal(conn_follow, self.uri)
+        self.assertFalse(self.uri_in_local_metadata(conn_follow, self.uri))
         self.swap_roles(conn_follow)
 
         # After step-up: uri stable constituent created locally; shared metadata unchanged.
-        self.assertNotInShared(conn_follow, self.uri)
-        self.assertInLocal(conn_follow, self.uri)
+        self.assertFalse(self.uri_in_shared_metadata(conn_follow, self.uri))
+        self.assertTrue(self.uri_in_local_metadata(conn_follow, self.uri))
 
         self.checkpoint_and_advance(15, 2, conn_follow)
         # After checkpoint at epoch=15: CREATE (epoch=20) deferred; uri absent from self.conn.
-        self.assertNotInLocal(self.conn, self.uri)
+        self.assertFalse(self.uri_in_local_metadata(self.conn, self.uri))
 
         self.checkpoint_and_advance(20, 3, conn_follow)
         # After checkpoint at epoch=20: CREATE flushed; uri's stable constituent visible to self.conn.
-        self.assertInLocal(self.conn, self.uri)
+        self.assertTrue(self.uri_in_local_metadata(self.conn, self.uri))
 
         session_follow = conn_follow.open_session('')
         c = session_follow.open_cursor(self.uri)
@@ -146,12 +146,12 @@ class test_layered_schema10(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
         # Follower: uri was created then immediately dropped; the layered table no longer
         #   exists; no stable constituent was ever created (skipped on create, moot on drop);
         #   queue holds CREATE uri (epoch 20) then REMOVE uri (epoch 30).
-        self.assertNotInLocal(conn_follow, self.uri)
+        self.assertFalse(self.uri_in_local_metadata(conn_follow, self.uri))
         self.swap_roles(conn_follow)
 
         # After step-up: net create+drop leaves no trace in either metadata store.
-        self.assertNotInShared(conn_follow, self.uri)
-        self.assertNotInLocal(conn_follow, self.uri)
+        self.assertFalse(self.uri_in_shared_metadata(conn_follow, self.uri))
+        self.assertFalse(self.uri_in_local_metadata(conn_follow, self.uri))
 
         conn_follow.close('debug=(skip_checkpoint=true)')
 
@@ -179,22 +179,22 @@ class test_layered_schema10(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
         #   operations on the initial leader; uri created on the follower, never checkpointed).
         # Follower: uri layered table present with committed data; metadata queue holds
         #   CREATE uri at epoch 20.
-        self.assertNotInShared(self.conn, self.uri)
-        self.assertNotInLocal(conn_follow, self.uri)
+        self.assertFalse(self.uri_in_shared_metadata(self.conn, self.uri))
+        self.assertFalse(self.uri_in_local_metadata(conn_follow, self.uri))
         self.swap_roles(conn_follow)
 
         # After step-up: uri stable constituent created locally; shared metadata unchanged.
         # self.conn has not yet picked up any new checkpoint.
-        self.assertNotInShared(conn_follow, self.uri)
-        self.assertInLocal(conn_follow, self.uri)
-        self.assertNotInShared(self.conn, self.uri)
-        self.assertNotInLocal(self.conn, self.uri)
+        self.assertFalse(self.uri_in_shared_metadata(conn_follow, self.uri))
+        self.assertTrue(self.uri_in_local_metadata(conn_follow, self.uri))
+        self.assertFalse(self.uri_in_shared_metadata(self.conn, self.uri))
+        self.assertFalse(self.uri_in_local_metadata(self.conn, self.uri))
 
         self.checkpoint_and_advance(20, 100, conn_follow)
         # After checkpoint at epoch=20: CREATE flushed; conn_follow (leader) sees the update
         # in shared metadata; self.conn (follower) sees it via local metadata after pickup.
-        self.assertInShared(conn_follow, self.uri)
-        self.assertInLocal(self.conn, self.uri)
+        self.assertTrue(self.uri_in_shared_metadata(conn_follow, self.uri))
+        self.assertTrue(self.uri_in_local_metadata(self.conn, self.uri))
 
         conn_follow.close('debug=(skip_checkpoint=true)')
 
@@ -214,23 +214,23 @@ class test_layered_schema10(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
         # Shared metadata: empty (no schema operations on the initial leader).
         # Follower: uri and uri2 layered tables present; queue holds CREATE uri (epoch 20)
         #   and CREATE uri2 (epoch 30).
-        self.assertNotInLocal(conn_follow, self.uri)
-        self.assertNotInLocal(conn_follow, self.uri2)
+        self.assertFalse(self.uri_in_local_metadata(conn_follow, self.uri))
+        self.assertFalse(self.uri_in_local_metadata(conn_follow, self.uri2))
         self.swap_roles(conn_follow)
 
         # After step-up: both stable constituents created locally.
-        self.assertInLocal(conn_follow, self.uri)
-        self.assertInLocal(conn_follow, self.uri2)
+        self.assertTrue(self.uri_in_local_metadata(conn_follow, self.uri))
+        self.assertTrue(self.uri_in_local_metadata(conn_follow, self.uri2))
 
         self.checkpoint_and_advance(20, 2, conn_follow)
         # After checkpoint at epoch=20: CREATE uri flushed; CREATE uri2 (epoch=30) deferred.
-        self.assertInLocal(self.conn, self.uri)
-        self.assertNotInLocal(self.conn, self.uri2)
+        self.assertTrue(self.uri_in_local_metadata(self.conn, self.uri))
+        self.assertFalse(self.uri_in_local_metadata(self.conn, self.uri2))
 
         self.checkpoint_and_advance(30, 3, conn_follow)
         # After checkpoint at epoch=30: CREATE uri2 flushed; both tables visible to self.conn.
-        self.assertInLocal(self.conn, self.uri)
-        self.assertInLocal(self.conn, self.uri2)
+        self.assertTrue(self.uri_in_local_metadata(self.conn, self.uri))
+        self.assertTrue(self.uri_in_local_metadata(self.conn, self.uri2))
 
         conn_follow.close('debug=(skip_checkpoint=true)')
 
@@ -258,19 +258,19 @@ class test_layered_schema10(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
         # Pre-swap state:
         # Shared metadata: uri (epoch 15), from the leader checkpoint; the follower picked it up.
         # Follower: uri was dropped; queue holds REMOVE uri at epoch 25.
-        self.assertInShared(conn_follow, self.uri)
+        self.assertTrue(self.uri_in_shared_metadata(conn_follow, self.uri))
         self.swap_roles(conn_follow)
 
         # After step-up: REMOVE queued; shared metadata still reflects the last checkpoint.
-        self.assertInShared(conn_follow, self.uri)
+        self.assertTrue(self.uri_in_shared_metadata(conn_follow, self.uri))
 
         self.checkpoint_and_advance(20, 3, conn_follow)
         # After checkpoint at epoch=20: REMOVE (epoch=25) deferred; uri still in shared metadata.
-        self.assertInShared(conn_follow, self.uri)
+        self.assertTrue(self.uri_in_shared_metadata(conn_follow, self.uri))
 
         self.checkpoint_and_advance(25, 4, conn_follow)
         # After checkpoint at epoch=25: REMOVE flushed; uri gone from shared metadata.
-        self.assertNotInShared(conn_follow, self.uri)
+        self.assertFalse(self.uri_in_shared_metadata(conn_follow, self.uri))
 
         conn_follow.close('debug=(skip_checkpoint=true)')
 
@@ -294,8 +294,8 @@ class test_layered_schema10(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
 
         # After step-up: CREATE followed by REMOVE causes step-up to skip stable constituent
         # creation, leaving no local trace.
-        self.assertNotInLocal(conn_follow, self.uri)
-        self.assertNotInShared(conn_follow, self.uri)
+        self.assertFalse(self.uri_in_local_metadata(conn_follow, self.uri))
+        self.assertFalse(self.uri_in_shared_metadata(conn_follow, self.uri))
 
         # Checkpoint at epoch=20: the stable epoch falls between CREATE (epoch=20) and
         # DROP (epoch=30), so the table must be visible in shared metadata at this checkpoint.
@@ -342,21 +342,21 @@ class test_layered_schema10(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
         # Shared metadata: empty (no schema operations on the initial leader).
         # Follower: uri layered table present; metadata queue holds CREATE uri with the
         #   unpublished sentinel epoch, which is deferred past any finite stable schema epoch.
-        self.assertNotInLocal(conn_follow, self.uri)
+        self.assertFalse(self.uri_in_local_metadata(conn_follow, self.uri))
         self.swap_roles(conn_follow)
 
         # After step-up: stable constituent created locally; shared metadata unchanged
         # (and will never contain uri because the sentinel epoch can never be reached).
-        self.assertInLocal(conn_follow, self.uri)
-        self.assertNotInShared(conn_follow, self.uri)
+        self.assertTrue(self.uri_in_local_metadata(conn_follow, self.uri))
+        self.assertFalse(self.uri_in_shared_metadata(conn_follow, self.uri))
 
         self.checkpoint_and_advance(20, 2, conn_follow)
         # After checkpoint at epoch=20: unpublished CREATE deferred; uri absent from self.conn.
-        self.assertNotInLocal(self.conn, self.uri)
+        self.assertFalse(self.uri_in_local_metadata(self.conn, self.uri))
 
         self.checkpoint_and_advance(100, 3, conn_follow)
         # After checkpoint at epoch=100: still deferred; uri absent from self.conn.
-        self.assertNotInLocal(self.conn, self.uri)
+        self.assertFalse(self.uri_in_local_metadata(self.conn, self.uri))
 
         conn_follow.close('debug=(skip_checkpoint=true)')
 
@@ -386,7 +386,7 @@ class test_layered_schema10(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
         session_follow.checkpoint()
         self.disagg_advance_checkpoint(self.conn, conn_follow)
         # After checkpoint at epoch=15: CREATE (epoch=20) deferred; uri absent from self.conn.
-        self.assertNotInLocal(self.conn, self.uri)
+        self.assertFalse(self.uri_in_local_metadata(self.conn, self.uri))
 
         # Advance ONLY the stable schema epoch to 20; stable_timestamp stays at 2.
         # The checkpoint must NOT be skipped because the schema epoch changed, even though no
@@ -395,7 +395,7 @@ class test_layered_schema10(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
         session_follow.checkpoint()
         self.disagg_advance_checkpoint(self.conn, conn_follow)
         # After checkpoint at epoch=20: CREATE flushed; uri visible to self.conn.
-        self.assertInLocal(self.conn, self.uri)
+        self.assertTrue(self.uri_in_local_metadata(self.conn, self.uri))
 
         session_follow.close()
         conn_follow.close('debug=(skip_checkpoint=true)')

--- a/test/suite/test_layered_schema11.py
+++ b/test/suite/test_layered_schema11.py
@@ -31,11 +31,11 @@
 # shared metadata from an older checkpoint.
 
 import wiredtiger, wttest
-from helper_disagg import disagg_test_class, gen_disagg_storages
+from helper_disagg import disagg_test_class, gen_disagg_storages, DisaggSchemaEpochMixin
 from wtscenario import make_scenarios
 
 @disagg_test_class
-class test_layered_schema11(wttest.WiredTigerTestCase):
+class test_layered_schema11(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
     test_name = __qualname__
     conn_base_config = 'statistics=(all),precise_checkpoint=true,'
     conn_config = conn_base_config + 'disaggregated=(role="leader",lose_all_my_data=true)'
@@ -47,84 +47,6 @@ class test_layered_schema11(wttest.WiredTigerTestCase):
 
     disagg_storages = gen_disagg_storages(disagg_only=True)
     scenarios = make_scenarios(disagg_storages)
-
-    #
-    # Helper methods
-    #
-
-    def set_stable_epoch(self, epoch, conn=None):
-        if conn is None:
-            conn = self.conn
-        conn.set_timestamp(
-            'stable_disaggregated_schema_epoch=' + self.timestamp_str(epoch))
-
-    def leader_checkpoint(self, stable_ts, conn=None, session=None):
-        if conn is None:
-            conn = self.conn
-        if session is None:
-            session = self.session
-        conn.set_timestamp(
-            'stable_timestamp=' + self.timestamp_str(stable_ts) +
-            ',oldest_timestamp=' + self.timestamp_str(1))
-        session.checkpoint()
-
-    def publish(self, uri, epoch, session=None):
-        if session is None:
-            session = self.session
-        session.publish(uri, 'disaggregated=(schema_epoch=' + self.timestamp_str(epoch) + ')')
-
-    def stable_uri(self, uri):
-        """Return the stable component URI for a given layered table URI."""
-        tablename = uri[len('layered:'):]
-        return 'file:' + tablename + '.wt_stable'
-
-    def uri_in_shared_metadata(self, conn, stable_uri):
-        """Return True if stable_uri is present in the shared metadata table."""
-        session = conn.open_session('')
-        cursor = session.open_cursor('file:WiredTigerShared.wt_stable', None, None)
-        cursor.set_key(stable_uri)
-        found = cursor.search() == 0
-        cursor.close()
-        session.close()
-        return found
-
-    def assertNotInShared(self, conn, uri):
-        """Assert that uri's stable constituent is absent from the shared metadata table."""
-        self.assertFalse(self.uri_in_shared_metadata(conn, self.stable_uri(uri)))
-
-    def assertInShared(self, conn, uri):
-        """Assert that uri's stable constituent is present in the shared metadata table."""
-        self.assertTrue(self.uri_in_shared_metadata(conn, self.stable_uri(uri)))
-
-    def uri_in_local_metadata(self, conn, uri):
-        """Return True if uri is present in the local metadata (cursor open succeeds)."""
-        session = conn.open_session('')
-        exists = True
-        try:
-            c = session.open_cursor(uri)
-            c.close()
-        except wiredtiger.WiredTigerError:
-            exists = False
-        session.close()
-        return exists
-
-    def assertInLocal(self, conn, uri):
-        """Assert that uri's stable constituent is present in conn's local metadata."""
-        self.assertTrue(self.uri_in_local_metadata(conn, self.stable_uri(uri)))
-
-    def assertNotInLocal(self, conn, uri):
-        """Assert that uri's stable constituent is absent from conn's local metadata."""
-        self.assertFalse(self.uri_in_local_metadata(conn, self.stable_uri(uri)))
-
-    def open_follower(self):
-        """Open a follower, pick up the latest leader checkpoint, and open a session on it."""
-        conn = self.wiredtiger_open(
-            'follower',
-            self.extensionsConfig() + ',create,' + self.conn_config_follower)
-        self.ignoreStdoutPattern('WT_VERB_RTS|(wiredtiger_open:.*WT_VERB_METADATA)')
-        self.disagg_advance_checkpoint(conn)
-        session = conn.open_session('')
-        return conn, session
 
     #
     # Functional tests

--- a/test/suite/test_layered_schema11.py
+++ b/test/suite/test_layered_schema11.py
@@ -65,7 +65,7 @@ class test_layered_schema11(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
 
         # Step 2: Follower picks up the checkpoint.
         conn_follow, session_follow = self.open_follower()
-        self.assertInLocal(conn_follow, self.uri)
+        self.assertTrue(self.uri_in_local_metadata(conn_follow, self.uri))
 
         # Step 3: Both the follower and the leader drop the table and publish the drop at
         # epoch 25. The follower's REMOVE(25) enters its local queue. The leader's REMOVE(25)
@@ -73,7 +73,7 @@ class test_layered_schema11(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
         # shared metadata for now.
         session_follow.drop(self.uri)
         self.publish(self.uri, 25, session_follow)
-        self.assertNotInLocal(conn_follow, self.uri)
+        self.assertFalse(self.uri_in_local_metadata(conn_follow, self.uri))
         self.session.drop(self.uri)
         self.publish(self.uri, 25)
 
@@ -85,7 +85,7 @@ class test_layered_schema11(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
         # Step 5: Follower picks up the new checkpoint. The table is in shared metadata but
         # absent locally; the REMOVE in the queue prevents recreation.
         self.disagg_advance_checkpoint(conn_follow)
-        self.assertNotInLocal(conn_follow, self.uri)
+        self.assertFalse(self.uri_in_local_metadata(conn_follow, self.uri))
 
         # Step 6: Leader advances past the drop epoch (epoch 25) and checkpoints. The REMOVE(25)
         # is now eligible to be flushed; the table must be removed from shared metadata.
@@ -95,8 +95,8 @@ class test_layered_schema11(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
         # Step 7: Follower picks up the post-drop checkpoint. The table must be absent from
         # both shared and local metadata.
         self.disagg_advance_checkpoint(conn_follow)
-        self.assertNotInShared(conn_follow, self.uri)
-        self.assertNotInLocal(conn_follow, self.uri)
+        self.assertFalse(self.uri_in_shared_metadata(conn_follow, self.uri))
+        self.assertFalse(self.uri_in_local_metadata(conn_follow, self.uri))
 
         session_follow.close()
         conn_follow.close('debug=(skip_checkpoint=true)')
@@ -113,14 +113,14 @@ class test_layered_schema11(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
 
         # Step 2: Follower picks up the checkpoint; both tables are in local metadata.
         conn_follow, session_follow = self.open_follower()
-        self.assertInLocal(conn_follow, self.uri)
-        self.assertInLocal(conn_follow, self.uri2)
+        self.assertTrue(self.uri_in_local_metadata(conn_follow, self.uri))
+        self.assertTrue(self.uri_in_local_metadata(conn_follow, self.uri2))
 
         # Step 3: Both follower and leader drop uri at epoch 25; uri2 is kept.
         session_follow.drop(self.uri)
         self.publish(self.uri, 25, session_follow)
-        self.assertNotInLocal(conn_follow, self.uri)
-        self.assertInLocal(conn_follow, self.uri2)
+        self.assertFalse(self.uri_in_local_metadata(conn_follow, self.uri))
+        self.assertTrue(self.uri_in_local_metadata(conn_follow, self.uri2))
         self.session.drop(self.uri)
         self.publish(self.uri, 25)
 
@@ -131,8 +131,8 @@ class test_layered_schema11(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
 
         # Step 5: Follower picks up; uri must not be recreated, uri2 must still be present.
         self.disagg_advance_checkpoint(conn_follow)
-        self.assertNotInLocal(conn_follow, self.uri)
-        self.assertInLocal(conn_follow, self.uri2)
+        self.assertFalse(self.uri_in_local_metadata(conn_follow, self.uri))
+        self.assertTrue(self.uri_in_local_metadata(conn_follow, self.uri2))
 
         # Step 6: Leader advances to epoch 25 and checkpoints; uri is removed from shared metadata.
         self.set_stable_epoch(25)
@@ -140,9 +140,9 @@ class test_layered_schema11(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
 
         # Step 7: Follower picks up; uri absent from both shared and local; uri2 intact.
         self.disagg_advance_checkpoint(conn_follow)
-        self.assertNotInShared(conn_follow, self.uri)
-        self.assertNotInLocal(conn_follow, self.uri)
-        self.assertInLocal(conn_follow, self.uri2)
+        self.assertFalse(self.uri_in_shared_metadata(conn_follow, self.uri))
+        self.assertFalse(self.uri_in_local_metadata(conn_follow, self.uri))
+        self.assertTrue(self.uri_in_local_metadata(conn_follow, self.uri2))
 
         session_follow.close()
         conn_follow.close('debug=(skip_checkpoint=true)')
@@ -161,7 +161,7 @@ class test_layered_schema11(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
 
         # Step 2: Follower picks up; uri is in local metadata.
         conn_follow, session_follow = self.open_follower()
-        self.assertInLocal(conn_follow, self.uri)
+        self.assertTrue(self.uri_in_local_metadata(conn_follow, self.uri))
 
         # Step 3: Both follower and leader drop uri at epoch 25 (REMOVE(25) queued), then
         # re-create it at epoch 40 (CREATE(40) queued). The latest queue entry for uri is now
@@ -183,7 +183,7 @@ class test_layered_schema11(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
         # Step 5: Follower picks up. Because the latest queue entry is CREATE(40) (not REMOVE),
         # the REMOVE check does not block pickup; uri must be present in local metadata.
         self.disagg_advance_checkpoint(conn_follow)
-        self.assertInLocal(conn_follow, self.uri)
+        self.assertTrue(self.uri_in_local_metadata(conn_follow, self.uri))
 
         session_follow.close()
         conn_follow.close('debug=(skip_checkpoint=true)')

--- a/test/suite/test_layered_schema12.py
+++ b/test/suite/test_layered_schema12.py
@@ -37,11 +37,11 @@
 # dropped before either operation is published must leave no durable trace.
 
 import wiredtiger, wttest
-from helper_disagg import disagg_test_class, gen_disagg_storages
+from helper_disagg import disagg_test_class, gen_disagg_storages, DisaggSchemaEpochMixin
 from wtscenario import make_scenarios
 
 @disagg_test_class
-class test_layered_schema12(wttest.WiredTigerTestCase):
+class test_layered_schema12(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
     test_name = __qualname__
     conn_base_config = 'statistics=(all),precise_checkpoint=true,'
     conn_config = conn_base_config + 'disaggregated=(role="leader",lose_all_my_data=true)'
@@ -58,19 +58,6 @@ class test_layered_schema12(wttest.WiredTigerTestCase):
     # Helper methods
     #
 
-    def set_stable_epoch(self, epoch):
-        self.conn.set_timestamp(
-            'stable_disaggregated_schema_epoch=' + self.timestamp_str(epoch))
-
-    def leader_checkpoint(self, stable_ts):
-        self.conn.set_timestamp(
-            'stable_timestamp=' + self.timestamp_str(stable_ts) +
-            ',oldest_timestamp=' + self.timestamp_str(1))
-        self.session.checkpoint()
-
-    def publish(self, uri, epoch):
-        self.session.publish(uri, 'disaggregated=(schema_epoch=' + self.timestamp_str(epoch) + ')')
-
     def write(self, uri, key, value, commit_ts):
         cursor = self.session.open_cursor(uri)
         self.session.begin_transaction()
@@ -78,54 +65,21 @@ class test_layered_schema12(wttest.WiredTigerTestCase):
         self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
         cursor.close()
 
-    def stable_uri(self, uri):
-        """Return the stable component URI for a given layered table URI."""
-        tablename = uri[len('layered:'):]
-        return 'file:' + tablename + '.wt_stable'
-
-    def uri_in_shared_metadata(self, conn, uri):
-        """Return True if uri's stable constituent is present in the shared metadata table."""
-        session = conn.open_session('')
-        cursor = session.open_cursor('file:WiredTigerShared.wt_stable', None, None)
-        cursor.set_key(self.stable_uri(uri))
-        found = cursor.search() == 0
-        cursor.close()
-        session.close()
-        return found
-
-    def uri_in_local_metadata(self, conn, uri):
-        """Return True if uri is present in the local metadata (cursor open succeeds)."""
-        session = conn.open_session('')
-        exists = True
-        try:
-            c = session.open_cursor(uri)
-            c.close()
-        except wiredtiger.WiredTigerError:
-            exists = False
-        session.close()
-        return exists
-
-    def open_follower(self):
-        """Open a follower and pick up the latest leader checkpoint."""
-        conn = self.wiredtiger_open(
-            'follower',
-            self.extensionsConfig() + ',create,' + self.conn_config_follower)
-        self.ignoreStdoutPattern('WT_VERB_RTS|(wiredtiger_open:.*WT_VERB_METADATA)')
-        self.disagg_advance_checkpoint(conn)
-        return conn
-
     def assertOnFollower(self, present):
         """
         Pick up the latest checkpoint on a fresh follower and assert which of the
-        expected tables are present. present maps uri -> bool.
+        expected tables are present in both the local and shared metadata.
+        present maps uri -> bool.
         """
-        conn = self.open_follower()
+        conn, _ = self.open_follower()
         try:
             for uri, expected in present.items():
-                self.assertEqual(self.uri_in_local_metadata(conn, uri), expected,
-                    f'follower local metadata: {uri} expected present={expected}')
-                self.assertEqual(self.uri_in_shared_metadata(conn, uri), expected,
-                    f'follower shared metadata: {uri} expected present={expected}')
+                if expected:
+                    self.assertInLocal(conn, uri)
+                    self.assertInShared(conn, uri)
+                else:
+                    self.assertNotInLocal(conn, uri)
+                    self.assertNotInShared(conn, uri)
         finally:
             conn.close('debug=(skip_checkpoint=true)')
 
@@ -135,10 +89,9 @@ class test_layered_schema12(wttest.WiredTigerTestCase):
 
     def test_unrelated_writes_succeed_with_unpublished_table(self):
         """
-        An unpublished table models a schema change from an in-progress transaction
-        (e.g. a multi-document transaction that has created a collection but not yet
-        committed). Unrelated writes to other published tables must continue to
-        succeed while that schema change remains pending.
+        A table that is created but not yet published has a pending schema change.
+        Writes to other, published tables must continue to succeed while that schema
+        change remains pending, and the pending table must not become durable.
         """
         self.set_stable_epoch(10)
 
@@ -157,6 +110,10 @@ class test_layered_schema12(wttest.WiredTigerTestCase):
         # A checkpoint covering the unrelated writes must also succeed with the
         # schema change still pending.
         self.leader_checkpoint(40)
+
+        # The published table is durable in both local and shared metadata; the
+        # unpublished table appears in neither.
+        self.assertOnFollower({self.uri: True, self.uri2: False})
 
     def test_checkpoint_succeeds_with_unpublished_table(self):
         """
@@ -281,6 +238,6 @@ class test_layered_schema12(wttest.WiredTigerTestCase):
             ',oldest_timestamp=' + self.timestamp_str(1))
 
         # The durable table survives; the transient table is not resurrected.
-        self.assertTrue(self.uri_in_local_metadata(self.conn, self.uri))
-        self.assertFalse(self.uri_in_local_metadata(self.conn, self.uri2))
-        self.assertFalse(self.uri_in_shared_metadata(self.conn, self.uri2))
+        self.assertInLocal(self.conn, self.uri)
+        self.assertNotInLocal(self.conn, self.uri2)
+        self.assertNotInShared(self.conn, self.uri2)

--- a/test/suite/test_layered_schema12.py
+++ b/test/suite/test_layered_schema12.py
@@ -75,11 +75,11 @@ class test_layered_schema12(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
         try:
             for uri, expected in present.items():
                 if expected:
-                    self.assertInLocal(conn, uri)
-                    self.assertInShared(conn, uri)
+                    self.assertTrue(self.uri_in_local_metadata(conn, uri))
+                    self.assertTrue(self.uri_in_shared_metadata(conn, uri))
                 else:
-                    self.assertNotInLocal(conn, uri)
-                    self.assertNotInShared(conn, uri)
+                    self.assertFalse(self.uri_in_local_metadata(conn, uri))
+                    self.assertFalse(self.uri_in_shared_metadata(conn, uri))
         finally:
             conn.close('debug=(skip_checkpoint=true)')
 
@@ -135,6 +135,10 @@ class test_layered_schema12(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
 
         # The checkpoint must succeed even though uri2 remains unpublished.
         self.leader_checkpoint(50)
+
+        # The published table is durable; the unpublished table is in neither the
+        # shared nor the local metadata.
+        self.assertOnFollower({self.uri: True, self.uri2: False})
 
     def test_unpublished_table_not_in_durable_metadata(self):
         """
@@ -238,6 +242,6 @@ class test_layered_schema12(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
             ',oldest_timestamp=' + self.timestamp_str(1))
 
         # The durable table survives; the transient table is not resurrected.
-        self.assertInLocal(self.conn, self.uri)
-        self.assertNotInLocal(self.conn, self.uri2)
-        self.assertNotInShared(self.conn, self.uri2)
+        self.assertTrue(self.uri_in_local_metadata(self.conn, self.uri))
+        self.assertFalse(self.uri_in_local_metadata(self.conn, self.uri2))
+        self.assertFalse(self.uri_in_shared_metadata(self.conn, self.uri2))

--- a/test/suite/test_layered_schema12.py
+++ b/test/suite/test_layered_schema12.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# Test the interaction between unpublished schema changes and concurrent
+# transactions, and the lifecycle of tables created and dropped without ever
+# reaching a checkpoint.
+#
+# An unpublished table (created but not yet published with a schema epoch)
+# behaves like a newly created table that has not been included in any
+# checkpoint: it must never appear in the shared metadata, and it must not
+# obstruct unrelated writes or checkpoints. A table that is created and then
+# dropped before either operation is published must leave no durable trace.
+
+import wiredtiger, wttest
+from helper_disagg import disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
+
+@disagg_test_class
+class test_layered_schema12(wttest.WiredTigerTestCase):
+    test_name = __qualname__
+    conn_base_config = 'statistics=(all),precise_checkpoint=true,'
+    conn_config = conn_base_config + 'disaggregated=(role="leader",lose_all_my_data=true)'
+    conn_config_follower = conn_base_config + 'disaggregated=(role="follower",lose_all_my_data=true)'
+
+    uri = f'layered:{test_name}'
+    uri2 = f'layered:{test_name}_b'
+    table_config = 'key_format=i,value_format=S'
+
+    disagg_storages = gen_disagg_storages(disagg_only=True)
+    scenarios = make_scenarios(disagg_storages)
+
+    #
+    # Helper methods
+    #
+
+    def set_stable_epoch(self, epoch):
+        self.conn.set_timestamp(
+            'stable_disaggregated_schema_epoch=' + self.timestamp_str(epoch))
+
+    def leader_checkpoint(self, stable_ts):
+        self.conn.set_timestamp(
+            'stable_timestamp=' + self.timestamp_str(stable_ts) +
+            ',oldest_timestamp=' + self.timestamp_str(1))
+        self.session.checkpoint()
+
+    def publish(self, uri, epoch):
+        self.session.publish(uri, 'disaggregated=(schema_epoch=' + self.timestamp_str(epoch) + ')')
+
+    def write(self, uri, key, value, commit_ts):
+        cursor = self.session.open_cursor(uri)
+        self.session.begin_transaction()
+        cursor[key] = value
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
+        cursor.close()
+
+    def stable_uri(self, uri):
+        """Return the stable component URI for a given layered table URI."""
+        tablename = uri[len('layered:'):]
+        return 'file:' + tablename + '.wt_stable'
+
+    def uri_in_shared_metadata(self, conn, uri):
+        """Return True if uri's stable constituent is present in the shared metadata table."""
+        session = conn.open_session('')
+        cursor = session.open_cursor('file:WiredTigerShared.wt_stable', None, None)
+        cursor.set_key(self.stable_uri(uri))
+        found = cursor.search() == 0
+        cursor.close()
+        session.close()
+        return found
+
+    def uri_in_local_metadata(self, conn, uri):
+        """Return True if uri is present in the local metadata (cursor open succeeds)."""
+        session = conn.open_session('')
+        exists = True
+        try:
+            c = session.open_cursor(uri)
+            c.close()
+        except wiredtiger.WiredTigerError:
+            exists = False
+        session.close()
+        return exists
+
+    def open_follower(self):
+        """Open a follower and pick up the latest leader checkpoint."""
+        conn = self.wiredtiger_open(
+            'follower',
+            self.extensionsConfig() + ',create,' + self.conn_config_follower)
+        self.ignoreStdoutPattern('WT_VERB_RTS|(wiredtiger_open:.*WT_VERB_METADATA)')
+        self.disagg_advance_checkpoint(conn)
+        return conn
+
+    def assertOnFollower(self, present):
+        """
+        Pick up the latest checkpoint on a fresh follower and assert which of the
+        expected tables are present. present maps uri -> bool.
+        """
+        conn = self.open_follower()
+        try:
+            for uri, expected in present.items():
+                self.assertEqual(self.uri_in_local_metadata(conn, uri), expected,
+                    f'follower local metadata: {uri} expected present={expected}')
+                self.assertEqual(self.uri_in_shared_metadata(conn, uri), expected,
+                    f'follower shared metadata: {uri} expected present={expected}')
+        finally:
+            conn.close('debug=(skip_checkpoint=true)')
+
+    #
+    # Transaction interaction tests
+    #
+
+    def test_unrelated_writes_succeed_with_unpublished_table(self):
+        """
+        An unpublished table models a schema change from an in-progress transaction
+        (e.g. a multi-document transaction that has created a collection but not yet
+        committed). Unrelated writes to other published tables must continue to
+        succeed while that schema change remains pending.
+        """
+        self.set_stable_epoch(10)
+
+        # A published table that unrelated writes target.
+        self.session.create(self.uri, self.table_config)
+        self.publish(self.uri, 20)
+
+        # A table created but never published: its schema change is still pending.
+        self.session.create(self.uri2, self.table_config)
+
+        # Unrelated writes to the published table must succeed while uri2 is unpublished.
+        self.set_stable_epoch(20)
+        for i in range(10):
+            self.write(self.uri, i, 'value', 30 + i)
+
+        # A checkpoint covering the unrelated writes must also succeed with the
+        # schema change still pending.
+        self.leader_checkpoint(40)
+
+    def test_checkpoint_succeeds_with_unpublished_table(self):
+        """
+        A checkpoint taken while a table is unpublished must succeed, provided the
+        unpublished table has no writes at or below the stable timestamp. The
+        published table's stable writes are checkpointed as normal.
+        """
+        self.set_stable_epoch(10)
+
+        self.session.create(self.uri, self.table_config)
+        self.publish(self.uri, 20)
+        self.set_stable_epoch(20)
+
+        # Create an unpublished table alongside the published one.
+        self.session.create(self.uri2, self.table_config)
+
+        # Stable writes to the published table, none to the unpublished table.
+        self.write(self.uri, 1, 'value', 50)
+
+        # The checkpoint must succeed even though uri2 remains unpublished.
+        self.leader_checkpoint(50)
+
+    def test_unpublished_table_not_in_durable_metadata(self):
+        """
+        A table left unpublished when a checkpoint is taken must not leak into the
+        durable (shared) metadata. Followers picking up the checkpoint must not see
+        the unpublished table, while the published table is visible.
+        """
+        self.set_stable_epoch(10)
+
+        self.session.create(self.uri, self.table_config)
+        self.publish(self.uri, 20)
+
+        # uri2 is created but deliberately never published.
+        self.session.create(self.uri2, self.table_config)
+
+        self.set_stable_epoch(20)
+        self.leader_checkpoint(1)
+
+        # The published table is durable; the unpublished table is not.
+        self.assertOnFollower({self.uri: True, self.uri2: False})
+
+    #
+    # Table lifecycle tests
+    #
+
+    def test_create_drop_unpublished_not_durable(self):
+        """
+        Create and drop a table without ever publishing either operation and without
+        an intervening checkpoint. The transient table must leave no durable trace:
+        it appears in neither the shared nor the local metadata of a follower after a
+        subsequent checkpoint.
+        """
+        self.set_stable_epoch(10)
+
+        # An unrelated published table to give the checkpoint something to persist.
+        self.session.create(self.uri, self.table_config)
+        self.publish(self.uri, 20)
+        self.set_stable_epoch(20)
+
+        # Create then drop uri2, both unpublished and before any checkpoint.
+        self.session.create(self.uri2, self.table_config)
+        self.session.drop(self.uri2)
+
+        self.leader_checkpoint(1)
+
+        # uri2 never becomes durable; uri does.
+        self.assertOnFollower({self.uri: True, self.uri2: False})
+
+    def test_create_publish_drop_publish_reaped_before_checkpoint(self):
+        """
+        Create, publish, drop, and publish the drop of a table, all before any
+        checkpoint incorporates the create. When the stable epoch finally advances
+        past both operations and a checkpoint is taken, the create and the drop
+        cancel out: the table must never appear in a checkpoint.
+        """
+        self.set_stable_epoch(10)
+
+        # An unrelated table that must remain durable throughout.
+        self.session.create(self.uri, self.table_config)
+        self.publish(self.uri, 20)
+
+        # Full create/publish/drop/publish lifecycle for uri2 while the stable epoch
+        # is still behind, so neither operation is applied to a checkpoint yet.
+        self.session.create(self.uri2, self.table_config)
+        self.publish(self.uri2, 20)
+        self.session.drop(self.uri2)
+        self.publish(self.uri2, 30)
+
+        # Advance past both epochs and checkpoint: the CREATE and REMOVE for uri2 are
+        # both eligible and cancel out.
+        self.set_stable_epoch(30)
+        self.leader_checkpoint(1)
+
+        self.assertOnFollower({self.uri: True, self.uri2: False})
+
+    def test_create_drop_unpublished_not_resurrected_on_restart(self):
+        """
+        A table created and dropped without publishing, and without a checkpoint that
+        includes it, must not be resurrected when the node restarts from the shared
+        checkpoint.
+        """
+        self.set_stable_epoch(10)
+
+        # Establish a durable table and checkpoint so there is something to restart from.
+        self.session.create(self.uri, self.table_config)
+        self.publish(self.uri, 20)
+        self.set_stable_epoch(20)
+        self.write(self.uri, 1, 'value', 50)
+        self.leader_checkpoint(50)
+
+        # Create and drop uri2 without publishing or checkpointing it.
+        self.session.create(self.uri2, self.table_config)
+        self.session.drop(self.uri2)
+
+        # Restart, discarding local files and picking up the shared checkpoint.
+        self.restart_without_local_files(step_up=True)
+
+        # Re-establish the stable timestamp so the shutdown checkpoint can proceed.
+        self.conn.set_timestamp(
+            'stable_timestamp=' + self.timestamp_str(50) +
+            ',oldest_timestamp=' + self.timestamp_str(1))
+
+        # The durable table survives; the transient table is not resurrected.
+        self.assertTrue(self.uri_in_local_metadata(self.conn, self.uri))
+        self.assertFalse(self.uri_in_local_metadata(self.conn, self.uri2))
+        self.assertFalse(self.uri_in_shared_metadata(self.conn, self.uri2))


### PR DESCRIPTION
Add test_layered_schema12.py covering for disaggregated storage:
- unrelated writes and checkpoints succeeding while a schema change is pending (unpublished table) and pending metadata not leaking into durable/shared metadata
- create/drop/reap table lifecycles without a checkpoint verifying the transient sequence is neither durable nor resurrected on restart