### PR TITLE
WT-17735 Preserve prepared-rollback fallback on the update chain instead of the on-disk cell

### DIFF
--- a/src/reconcile/rec_col.c
+++ b/src/reconcile/rec_col.c
@@ -454,24 +454,14 @@ record_loop:
                 WT_ERR(__wti_rec_upd_select(session, r, ins, NULL, vpack, &upd_select));
                 upd = upd_select.upd;
                 ins = WT_SKIP_NEXT(ins);
-            } else
-                upd_select.skip_aborted_prepared_value = false;
+            }
 
             update_no_copy = true; /* No data copy */
             repeat_count = 1;      /* Single record */
             deleted = false;
 
-            if (upd == NULL && orig_stale &&
-              (!F_ISSET(conn, WT_CONN_PRESERVE_PREPARED) || !F_ISSET(r, WT_REC_EVICT) ||
-                !upd_select.skip_aborted_prepared_value)) {
-                /*
-                 * The on-disk value is stale and there was no update. Treat it as deleted.
-                 *
-                 * Keep the on-disk cell when the chain still has an unstable aborted prepared
-                 * update that we skipped this round: the cell is its only rollback fallback, and
-                 * dropping it now would strand the prepared update with nothing to fall back to on
-                 * a later reconciliation.
-                 */
+            if (upd == NULL && orig_stale) {
+                /* The on-disk value is stale and there was no update. Treat it as deleted. */
                 deleted = true;
                 ++r->keys_removed_from_disk_image_count;
                 twp = &clear_tw;

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -1174,17 +1174,8 @@ __wti_rec_row_leaf(
                     WT_STAT_CONN_DSRC_INCR(session, rec_ingest_garbage_collection_keys_disk_image);
                 }
             } else if (__wt_txn_tw_stop_visible_all(session, twp)) {
-                /*
-                 * Keep the on-disk cell when the chain still has an unstable aborted prepared
-                 * update that we skipped this round: the cell is its only rollback fallback, and
-                 * dropping it now would strand the prepared update with nothing to fall back to on
-                 * a later reconciliation.
-                 */
-                if (!F_ISSET(conn, WT_CONN_PRESERVE_PREPARED) || !F_ISSET(r, WT_REC_EVICT) ||
-                  !upd_select.skip_aborted_prepared_value) {
-                    upd = &upd_tombstone;
-                    ++r->keys_removed_from_disk_image_count;
-                }
+                upd = &upd_tombstone;
+                ++r->keys_removed_from_disk_image_count;
             }
         }
 

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -799,6 +799,7 @@ __rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_CELL_UNPACK_KV *
           session_txnid != WT_TXN_NONE && txnid == session_txnid) {
             *upd_memsizep += WT_UPDATE_MEMSIZE(upd);
             *has_newer_updatesp = true;
+            WT_ASSERT(session, !upd_select->skip_prepare_rollback);
             continue;
         }
         /*

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -799,7 +799,6 @@ __rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_CELL_UNPACK_KV *
           session_txnid != WT_TXN_NONE && txnid == session_txnid) {
             *upd_memsizep += WT_UPDATE_MEMSIZE(upd);
             *has_newer_updatesp = true;
-            WT_ASSERT(session, !upd_select->skip_aborted_prepared_value);
             continue;
         }
         /*
@@ -832,13 +831,8 @@ __rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_CELL_UNPACK_KV *
 
             *upd_memsizep += WT_UPDATE_MEMSIZE(upd);
             *has_newer_updatesp = true;
-            /*
-             * Same reason as the aborted-prepared skip earlier: this rolled-back prepared value has
-             * no in-chain fallback, so the on-disk cell must not be dropped on this reconciliation.
-             */
             if (upd->txnid == WT_TXN_ABORTED && upd->type != WT_UPDATE_TOMBSTONE)
-                upd_select->skip_aborted_prepared_value = true;
-
+                upd_select->skip_prepare_rollback = true;
             continue;
         }
 
@@ -865,14 +859,8 @@ __rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_CELL_UNPACK_KV *
                     WT_ASSERT(session, !is_hs_page);
                     *upd_memsizep += WT_UPDATE_MEMSIZE(upd);
                     *has_newer_updatesp = true;
-
-                    /*
-                     * Same reason as the aborted-prepared skip earlier: this rolled-back prepared
-                     * value has no in-chain fallback, so the on-disk cell must not be dropped on
-                     * this reconciliation.
-                     */
                     if (upd->txnid == WT_TXN_ABORTED && upd->type != WT_UPDATE_TOMBSTONE)
-                        upd_select->skip_aborted_prepared_value = true;
+                        upd_select->skip_prepare_rollback = true;
                     continue;
                 }
 
@@ -1484,6 +1472,52 @@ __rec_fill_tw_from_upd_select(WT_SESSION_IMPL *session, WT_PAGE *page, WT_CELL_U
 }
 
 /*
+ * __rec_append_orig_value_if_needed --
+ *     Append the on-page value to the update chain if a reader or an unresolved prepared update may
+ *     still need it once this reconciliation replaces or drops the on-page cell.
+ */
+static int
+__rec_append_orig_value_if_needed(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page,
+  WT_UPDATE *first_upd, WT_CELL_UNPACK_KV *vpack, WTI_UPDATE_SELECT *upd_select)
+{
+    /*
+     * There is no on-page value to preserve, or the on-page value is itself a prepared update: a
+     * prepared full update is already on the update chain, and for a prepared tombstone the on-page
+     * value was appended to the update chain when the page was read into memory.
+     */
+    if (!WT_REC_HAS_ON_DISK(vpack) || WT_TIME_WINDOW_HAS_PREPARE(&vpack->tw))
+        return (0);
+
+    /*
+     * If we skipped an unresolved aborted prepared update and selected nothing, the on-page value
+     * is its only rollback fallback: this reconciliation may drop the on-page cell (or a later one
+     * may free its backing overflow blocks), so the fallback must move to the update chain where it
+     * survives the page image being rewritten. Walk the chain from its head and force the append
+     * even though the on-page value's stop may be globally visible.
+     */
+    if (upd_select->upd == NULL) {
+        if (F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED) && upd_select->skip_prepare_rollback)
+            return (__rec_append_orig_value(session, page, first_upd, vpack, true));
+        return (0);
+    }
+
+    /*
+     * Returning an update means the original on-page value might be lost, and that's a problem if
+     * there's a reader that needs it: make a copy of the on-page value. We do that any time there
+     * are saved updates (we may need the original on-page value to terminate the update chain, for
+     * example, in the case of an update that modifies the original value). Additionally, make a
+     * copy of the on-page value if the value is an overflow item and anything other than the
+     * on-page cell is being written, because the value's backing overflow blocks aren't part of the
+     * page and are physically removed when this page is next written.
+     */
+    if (F_ISSET(r, WT_REC_HS) && (upd_select->upd_saved || F_ISSET(vpack, WT_CELL_UNPACK_OVERFLOW)))
+        return (__rec_append_orig_value(
+          session, page, upd_select->upd, vpack, WT_TIME_WINDOW_HAS_PREPARE(&upd_select->tw)));
+
+    return (0);
+}
+
+/*
  * __wti_rec_upd_select --
  *     Return the update in a list that should be written (or NULL if none can be written).
  */
@@ -1667,26 +1701,7 @@ __wti_rec_upd_select(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_INSERT *ins,
           WT_TIME_WINDOW_HAS_PREPARE(&upd_select->tw)),
       "Updated selected that has since been rolled back");
 
-    /*
-     * Returning an update means the original on-page value might be lost, and that's a problem if
-     * there's a reader that needs it, make a copy of the on-page value. We do that any time there
-     * are saved updates (we may need the original on-page value to terminate the update chain, for
-     * example, in the case of an update that modifies the original value). Additionally, make a
-     * copy of the on-page value if the value is an overflow item and anything other than the
-     * on-page cell is being written. This is because the value's backing overflow blocks aren't
-     * part of the page, and they are physically removed by checkpoint writing this page, that is,
-     * the checkpoint doesn't include the overflow blocks so they're removed and future readers of
-     * this page won't be able to find them.
-     *
-     * We never append prepared updates back to the onpage value. If it is a prepared full update,
-     * it is already on the update chain. If it is a prepared tombstone, the onpage value is already
-     * appended to the update chain when the page is read into memory.
-     */
-    if (F_ISSET(r, WT_REC_HS) && upd_select->upd != NULL && WT_REC_HAS_ON_DISK(vpack) &&
-      !WT_TIME_WINDOW_HAS_PREPARE(&(vpack->tw)) &&
-      (upd_select->upd_saved || F_ISSET(vpack, WT_CELL_UNPACK_OVERFLOW)))
-        WT_RET(__rec_append_orig_value(
-          session, page, upd_select->upd, vpack, WT_TIME_WINDOW_HAS_PREPARE(&upd_select->tw)));
+    WT_RET(__rec_append_orig_value_if_needed(session, r, page, first_upd, vpack, upd_select));
 
     __wti_rec_time_window_clear_obsolete(session, upd_select, NULL, r);
 

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -87,7 +87,7 @@ __rec_delete_hs_upd_save(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_INSERT *
  */
 static int
 __rec_append_orig_value(WT_SESSION_IMPL *session, WT_PAGE *page, WT_UPDATE *upd,
-  WT_CELL_UNPACK_KV *unpack, bool write_prepared)
+  WT_CELL_UNPACK_KV *unpack, bool keep_prepare_fallback)
 {
     WT_CONNECTION_IMPL *conn;
     WT_DECL_ITEM(tmp);
@@ -133,16 +133,16 @@ __rec_append_orig_value(WT_SESSION_IMPL *session, WT_PAGE *page, WT_UPDATE *upd,
          * possible for an update on the chain to be globally visible and followed by an (earlier)
          * update that is not yet globally visible.
          *
-         * Skip this shortcut when writing as prepared. The decision to write as prepared was taken
-         * against the pinned stable timestamp captured at reconcile start, which can lag the
-         * current global oldest. By the time we reach here, the chain may have become globally
-         * visible even though we still need to encode this entry as prepared. In that case we must
-         * not return early; the caller relies on the on-page value being available as a rollback
-         * fallback for the prepared update.
+         * Skip this shortcut when the on-page value must be kept as a prepared update's rollback
+         * fallback: visibility can shift between when that need was determined and when we reach
+         * here (the pinned stable timestamp used earlier can lag the current global oldest, or the
+         * prepared update may have been skipped this round entirely), so the chain may look
+         * globally visible even though the fallback is still required. In that case we must not
+         * return early.
          */
         if (WT_UPDATE_DATA_VALUE(upd) &&
           (onpage_upd_or_tombstone != upd || onpage_upd_or_tombstone->type != WT_UPDATE_TOMBSTONE ||
-            !write_prepared) &&
+            !keep_prepare_fallback) &&
           __wt_txn_upd_visible_all(session, upd))
             return (0);
 
@@ -190,7 +190,7 @@ __rec_append_orig_value(WT_SESSION_IMPL *session, WT_PAGE *page, WT_UPDATE *upd,
                  * wrongly leave this key as prepared indefinitely if we rollback the prepared
                  * update.
                  */
-                if (seen_committed || !write_prepared)
+                if (seen_committed || !keep_prepare_fallback)
                     return (0);
             }
 

--- a/src/reconcile/rec_visibility.c
+++ b/src/reconcile/rec_visibility.c
@@ -1495,9 +1495,14 @@ __rec_append_orig_value_if_needed(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT
      * may free its backing overflow blocks), so the fallback must move to the update chain where it
      * survives the page image being rewritten. Walk the chain from its head and force the append
      * even though the on-page value's stop may be globally visible.
+     *
+     * Gate this on WT_REC_HS: prepared updates only reach the disk image on timestamped tables
+     * backed by the history store, so an in-memory database or a non-timestamped table never needs
+     * this fallback.
      */
     if (upd_select->upd == NULL) {
-        if (F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED) && upd_select->skip_prepare_rollback)
+        if (F_ISSET(r, WT_REC_HS) && F_ISSET(S2C(session), WT_CONN_PRESERVE_PREPARED) &&
+          upd_select->skip_prepare_rollback)
             return (__rec_append_orig_value(session, page, first_upd, vpack, true));
         return (0);
     }

--- a/src/reconcile/reconcile_private.h
+++ b/src/reconcile/reconcile_private.h
@@ -439,22 +439,22 @@ struct __wti_update_select {
 
     WT_TIME_WINDOW tw;
 
-    bool upd_saved;                   /* An element on the row's update chain was saved */
-    bool no_ts_tombstone;             /* Tombstone without a timestamp */
-    bool skip_aborted_prepared_value; /* Skip a non-tombstone aborted prepared update on the
-                                          update chain */
-    bool was_modify;                  /* There was a MODIFY on the update chain */
+    bool upd_saved;             /* An element on the row's update chain was saved */
+    bool no_ts_tombstone;       /* Tombstone without a timestamp */
+    bool skip_prepare_rollback; /* Skipped a prepared update rolled back after the stable
+                                   timestamp */
+    bool was_modify;            /* There was a MODIFY on the update chain */
 };
 
-#define WTI_UPDATE_SELECT_INIT(upd_select)                 \
-    do {                                                   \
-        (upd_select)->upd = NULL;                          \
-        (upd_select)->tombstone = NULL;                    \
-        (upd_select)->upd_saved = false;                   \
-        (upd_select)->no_ts_tombstone = false;             \
-        (upd_select)->skip_aborted_prepared_value = false; \
-        (upd_select)->was_modify = false;                  \
-        WT_TIME_WINDOW_INIT(&(upd_select)->tw);            \
+#define WTI_UPDATE_SELECT_INIT(upd_select)           \
+    do {                                             \
+        (upd_select)->upd = NULL;                    \
+        (upd_select)->tombstone = NULL;              \
+        (upd_select)->upd_saved = false;             \
+        (upd_select)->no_ts_tombstone = false;       \
+        (upd_select)->skip_prepare_rollback = false; \
+        (upd_select)->was_modify = false;            \
+        WT_TIME_WINDOW_INIT(&(upd_select)->tw);      \
     } while (0)
 
 #define WT_REC_RESULT_SINGLE_PAGE(session, r)                                    \

--- a/test/suite/test_prepare48.py
+++ b/test/suite/test_prepare48.py
@@ -181,3 +181,89 @@ class test_prepare48(wttest.WiredTigerTestCase):
         self.assert_not_found(2, 55)
 
         cursor.close()
+
+    def test_aborted_prepared_over_removed_overflow(self):
+        # A rolled-back prepared insert sits over a deleted overflow value whose delete is
+        # globally visible, with the rollback timestamp ahead of stable. A checkpoint and a
+        # subsequent eviction of the same page each rewrite the page while the rolled-back
+        # prepared insert is still unresolved. Reads must keep seeing the key as deleted
+        # and the page must remain readable: the overflow value freed by the checkpoint
+        # must not reappear in the image written by the eviction.
+
+        # A small leaf_value_max forces the value to be stored as an overflow item.
+        self.session.create(
+            self.uri,
+            'key_format=i,value_format=S,'
+            'allocation_size=512,leaf_page_max=4KB,leaf_value_max=512,'
+            'memory_page_max=4KB')
+
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(1))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10))
+
+        cursor = self.session.open_cursor(self.uri)
+
+        # key 1 is a permanent companion kept committed throughout, so the leaf never goes
+        # empty and stays in memory. key 2 carries the overflow value under test.
+        self.session.begin_transaction()
+        cursor[1] = 'committed'
+        cursor[2] = 'v_init' + 'A' * 4096
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(20))
+
+        # Push the overflow value to disk, then evict so a later read brings back a clean
+        # page referencing the overflow value.
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(21))
+        self.session.checkpoint()
+        self.force_evict(1, 20)
+
+        # Delete key 2 and checkpoint while oldest is still below the delete, so the new
+        # disk image keeps the overflow value with its delete time rather than removing
+        # it. Evict so a later read brings that image back.
+        self.session.begin_transaction()
+        cursor.set_key(2)
+        cursor.remove()
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(30))
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(31))
+        self.session.checkpoint()
+        self.force_evict(1, 20)
+
+        # Hold a positioned cursor on the page so it cannot be evicted and re-read
+        # underneath us: the checkpoint below must operate on the same in-memory page as
+        # the final eviction. Use an autocommit read so the pin holds no snapshot and does
+        # not hold global visibility back.
+        pin_session = self.conn.open_session()
+        pin_cursor = pin_session.open_cursor(self.uri)
+        pin_cursor.set_key(1)
+        self.assertEqual(pin_cursor.search(), 0)
+
+        # Prepared insert on key 2, rolled back with the rollback timestamp ahead of
+        # stable so the rollback is not yet durable. This also dirties the page so the
+        # next checkpoint rewrites it.
+        self.session.begin_transaction()
+        cursor[2] = 'prepared' + 'B' * 4096
+        self.session.prepare_transaction(
+            'prepare_timestamp=' + self.timestamp_str(40) +
+            ',prepared_id=' + self.prepared_id_str(99))
+        cursor.reset()
+        self.session.rollback_transaction(
+            'rollback_timestamp=' + self.timestamp_str(45))
+
+        # Advance oldest past the delete so the deleted overflow value is obsolete: no
+        # reader at any timestamp can see it any longer.
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(31))
+
+        # Checkpoint with stable still below the prepare timestamp: the checkpoint image
+        # must not include the unstable prepared insert, and the obsolete overflow value
+        # is discarded.
+        self.session.checkpoint()
+
+        # Release the pin and evict the same page. The eviction rewrites the page while
+        # the rolled-back prepared insert is still unresolved; it must not resurrect the
+        # discarded overflow value in the image it writes.
+        pin_cursor.close()
+        pin_session.close()
+        self.force_evict(1, 31)
+
+        # The prepared insert was rolled back: key 2 reads as deleted.
+        self.assert_not_found(2, 45)
+
+        cursor.close()


### PR DESCRIPTION
## Summary

Under `preserve_prepared`, when reconciliation skips an unresolved aborted prepared update (rollback timestamp above stable) and selects nothing else, it fell back to keeping the on-disk cell as the prepared update's rollback anchor. That didn't account for the on-disk cell being a removed-overflow marker (`WT_CELL_VALUE_OVFL_RM`) whose backing block a prior reconciliation had already freed. Copying that marker into a new page image produces a page referencing a freed block, caught by verify/`__err_cell_type` downstream or a `WT_ASSERT` at write time.

- Removes the keep-the-on-disk-cell special case from `rec_row.c`/`rec_col.c`.
- Instead, preserves the fallback by appending the on-page value onto the update chain (`__rec_append_orig_value`) at the two points where it would otherwise be lost: when reconciliation skips the aborted prepared update and selects nothing, and when it writes a selected update as prepared.
- With the fallback moved onto the update chain, checkpoint and eviction now agree on whether to drop the key — no more disagreement about whether the on-disk cell survives.

Adds a regression test, `test_prepare48.py::test_aborted_prepared_over_removed_overflow`, that reproduces the removed-overflow case: aborts on unfixed code, passes with the fix.