### PR TITLE
WT-18036 Add a WT_ASSERT whenever we are underflowing when decreasing block size

### DIFF
--- a/src/block_disagg/block_disagg_size.c
+++ b/src/block_disagg/block_disagg_size.c
@@ -55,6 +55,7 @@ __wti_block_disagg_decrease_size(
           "disaggregated block size underflow: decrementing %" PRIu64 " from %" PRIu64
           ", clamped to 0",
           size, orig);
+    WT_ASSERT(session, orig >= size);
 }
 
 /*

--- a/src/block_disagg/block_disagg_size.c
+++ b/src/block_disagg/block_disagg_size.c
@@ -51,6 +51,7 @@ __wti_block_disagg_decrease_size(
     } while (!__wt_atomic_cas_uint64(&block_disagg->size, orig, orig < size ? 0 : orig - size));
 
     if (orig < size)
+        /* FIXME-WT-18039: Replace this and the WT_ASSERT below with a WT_ASSERT_ALWAYS. */
         __wt_verbose_warning(session, WT_VERB_DISAGGREGATED_STORAGE,
           "disaggregated block size underflow: decrementing %" PRIu64 " from %" PRIu64
           ", clamped to 0",


### PR DESCRIPTION
We want to get more signal by adding a WT_ASSERT, this will not affect production builds.