### PR TITLE
WT-18021 add diagnostics for page state when page->ref == NULL

### DIFF
--- a/dist/s_funcs.list
+++ b/dist/s_funcs.list
@@ -49,6 +49,7 @@ __wt_session_breakpoint
 __wt_strcat
 __wt_stream_set_no_buffer
 __wt_try_readlock
+__wt_update_list_print
 __wt_verbose_category_string
 populate_thread
 wiredtiger_calc_modify

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1936,6 +1936,7 @@ extern void __wt_txn_snapshot_release_and_restore(WT_SESSION_IMPL *session);
 extern void __wt_txn_stats_update(WT_SESSION_IMPL *session);
 extern void __wt_txn_truncate_end(WT_SESSION_IMPL *session);
 extern void __wt_txn_update_pinned_timestamp(WT_SESSION_IMPL *session, bool force);
+extern void __wt_update_list_print(WT_SESSION_IMPL *session, WT_UPDATE *head);
 extern void __wt_update_obsolete_check(
   WT_SESSION_IMPL *session, WT_CURSOR_BTREE *cbt, WT_UPDATE *upd);
 extern void __wt_update_vector_clear(WT_UPDATE_VECTOR *updates);

--- a/src/support/modify.c
+++ b/src/support/modify.c
@@ -399,6 +399,25 @@ err:
 }
 
 /*
+ * __wt_update_list_print --
+ *     Print the contents of an update chain, one message per update.
+ */
+void
+__wt_update_list_print(WT_SESSION_IMPL *session, WT_UPDATE *head)
+{
+    WT_UPDATE *upd;
+    uint64_t pos;
+
+    for (upd = head, pos = 0; upd != NULL; upd = upd->next, ++pos)
+        WT_IGNORE_RET(__wt_msg(session,
+          "  upd[%" PRIu64 "]=%p type=%d txnid=%" PRIu64 " start_ts=%" PRIu64 " durable_ts=%" PRIu64
+          " prepare_state=%d flags=%#" PRIx16 " size=%" PRIu32,
+          pos, (void *)upd, (int)upd->type, __wt_atomic_load_uint64_v_acquire(&upd->txnid),
+          upd->upd_start_ts, upd->upd_durable_ts,
+          (int)__wt_atomic_load_uint8_v_acquire(&upd->prepare_state), upd->flags, upd->size));
+}
+
+/*
  * __wt_modify_reconstruct_from_upd_list --
  *     Takes an in-memory modify and populates an update value with the reconstructed full value.
  */
@@ -490,19 +509,8 @@ retry:
          * update chain is referencing a page that was never instantiated or has gone away; dump the
          * ref, cursor, and update-chain state to show why no full update was found.
          */
-        if (cbt->ref == NULL || cbt->ref->page == NULL) {
-            WT_UPDATE *dbg_upd;
-            uint64_t dbg_pos;
-
-            for (dbg_upd = modify, dbg_pos = 0; dbg_upd != NULL; dbg_upd = dbg_upd->next, ++dbg_pos)
-                __wt_errx(session,
-                  "  upd[%" PRIu64 "]=%p type=%d txnid=%" PRIu64 " start_ts=%" PRIu64
-                  " durable_ts=%" PRIu64 " prepare_state=%d size=%" PRIu32,
-                  dbg_pos, (void *)dbg_upd, (int)dbg_upd->type,
-                  __wt_atomic_load_uint64_v_acquire(&dbg_upd->txnid), dbg_upd->upd_start_ts,
-                  dbg_upd->upd_durable_ts,
-                  (int)__wt_atomic_load_uint8_v_acquire(&dbg_upd->prepare_state), dbg_upd->size);
-        }
+        if (cbt->ref == NULL || cbt->ref->page == NULL)
+            __wt_update_list_print(session, modify);
 
         WT_ERR_ASSERT(session, WT_DIAGNOSTIC_TXN_VISIBILITY,
           cbt->ref != NULL && cbt->ref->page != NULL, WT_ERROR,

--- a/src/support/modify.c
+++ b/src/support/modify.c
@@ -488,8 +488,22 @@ retry:
         /*
          * We need the on-page value as the base, so the page must be present. If it isn't, an
          * update chain is referencing a page that was never instantiated or has gone away; dump the
-         * ref and cursor state.
+         * ref, cursor, and update-chain state to show why no full update was found.
          */
+        if (cbt->ref == NULL || cbt->ref->page == NULL) {
+            WT_UPDATE *dbg_upd;
+            uint64_t dbg_pos;
+
+            for (dbg_upd = modify, dbg_pos = 0; dbg_upd != NULL; dbg_upd = dbg_upd->next, ++dbg_pos)
+                __wt_errx(session,
+                  "  upd[%" PRIu64 "]=%p type=%d txnid=%" PRIu64 " start_ts=%" PRIu64
+                  " durable_ts=%" PRIu64 " prepare_state=%d size=%" PRIu32,
+                  dbg_pos, (void *)dbg_upd, (int)dbg_upd->type,
+                  __wt_atomic_load_uint64_v_acquire(&dbg_upd->txnid), dbg_upd->upd_start_ts,
+                  dbg_upd->upd_durable_ts,
+                  (int)__wt_atomic_load_uint8_v_acquire(&dbg_upd->prepare_state), dbg_upd->size);
+        }
+
         WT_ERR_ASSERT(session, WT_DIAGNOSTIC_TXN_VISIBILITY,
           cbt->ref != NULL && cbt->ref->page != NULL, WT_ERROR,
           "modify reconstruct with missing base page: dhandle=%s ref=%p state=%d page_del=%p "

--- a/src/support/modify.c
+++ b/src/support/modify.c
@@ -485,6 +485,22 @@ retry:
          */
         WT_ASSERT(session, cbt->slot != UINT32_MAX);
 
+        /*
+         * We need the on-page value as the base, so the page must be present. If it isn't, an
+         * update chain is referencing a page that was never instantiated or has gone away; dump the
+         * ref and cursor state.
+         */
+        WT_ERR_ASSERT(session, WT_DIAGNOSTIC_TXN_VISIBILITY,
+          cbt->ref != NULL && cbt->ref->page != NULL, WT_ERROR,
+          "modify reconstruct with missing base page: dhandle=%s ref=%p state=%d page_del=%p "
+          "slot=%" PRIu32 " ins_head=%p ins=%p modify.type=%d modify.txnid=%" PRIu64
+          " modify.prepare_state=%d",
+          session->dhandle == NULL ? "(null)" : session->dhandle->name, (void *)cbt->ref,
+          cbt->ref == NULL ? -1 : (int)WT_REF_GET_STATE(cbt->ref),
+          cbt->ref == NULL ? NULL : (void *)cbt->ref->page_del, cbt->slot, (void *)cbt->ins_head,
+          (void *)cbt->ins, (int)modify->type, __wt_atomic_load_uint64_v_acquire(&modify->txnid),
+          (int)__wt_atomic_load_uint8_v_acquire(&modify->prepare_state));
+
         WT_ERR_ERROR_OK(
           __wt_value_return_buf(cbt, cbt->ref, &upd_value->buf, &tw), WT_RESTART, true);
 


### PR DESCRIPTION
We have seen an issue where ref->page == NULL when we are trying to read a modify. __wt_modify_reconstruct_from_upd_list() had failed to find a full update in the update chain and falling back to the on-page value via the upd == NULL path, but with the original page is missing. 

The crash came from a resmoke run of jstests/core/query/query_settings/query_settings_size_limits.js on a disaggregated replset, but subsequent runs of the test passes and we have not seen the same issue again. Since we can't reproduce the error, this PR adds some extra diagnostic information to an assert that a page should not be NULL.