### PR TITLE
WT-18046 Skip test_hs24 under the disagg-leader hook

### DIFF
--- a/test/suite/fail_lists/hook_disagg.fail
+++ b/test/suite/fail_lists/hook_disagg.fail
@@ -19,6 +19,7 @@ test_empty.py
 test_encrypt06.py
 test_env01.py
 test_error_info01.py
+test_hs24.py    # FIXME: WT-18046
 test_log03.py
 test_metadata_cursor01.py
 test_metadata_cursor04.py


### PR DESCRIPTION
## What & why

`test_hs24` intermittently fails on `wiredtiger_open` after `simulate_crash_restart` under the disagg-leader hook, with SQLite `Illegal byte sequence` (`SQLITE_NOTADB`) or `Bad message` (`SQLITE_CORRUPT`) errors — tracked as [WT-17770](https://jira.mongodb.org/browse/WT-17770) (macOS-14-arm64) and [WT-17884](https://jira.mongodb.org/browse/WT-17884) (ubuntu2004-asan).

**Root cause (test infrastructure, not recovery):** `simulate_crash_restart` → `copy_wiredtiger_home` copies the home directory while the connection is still open and recurses into `kv_home`, byte-copying PALite's live SQLite `.db` files. PALite runs SQLite in WAL mode with `synchronous=NORMAL` and mmap, and auto-checkpoints the WAL into the main `.db` in the background. A per-file, unsynchronized copy landing mid-checkpoint captures a torn database image, so reopening the copied store fails. It is timing-dependent, hence rare and host-load-sensitive, and reproduces on both macOS and Linux-asan.

The underlying harness fix is tracked in [WT-18046](https://jira.mongodb.org/browse/WT-18046) (with a standalone reproducer attached: ~283/300 reopen attempts hit corruption). Until that lands, this PR skips the test under the disagg hook.

## Change

Re-add `test_hs24.py` to `test/suite/fail_lists/hook_disagg.fail` with `# FIXME: WT-18046`. This is the same list the test was removed from in WT-16872 (f751e704), which is what re-enabled it and exposed the pre-existing race. The evergreen driver strips the trailing comment (`sed 's/ *#.*//'`), so the effective ignored entry is `test_hs24.py`.

## Reviewer notes

- No production code changes — test-suite fail-list only.
- `test_hs01` (WT-17884) hits the same root cause but is left enabled here per the agreed scope (skip just `test_hs24`).
