### PR TITLE
WT-17820 Prevent splits on stale disaggregated handles

### DIFF
--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -2451,7 +2451,7 @@ __wt_split_multi(WT_SESSION_IMPL *session, WT_REF *ref, int closing)
 
     __wt_verbose(session, WT_VERB_SPLIT, "%p: split-multi", (void *)ref);
 
-    if (!closing && __wt_btree_is_stale_disagg(session))
+    if (__wt_btree_is_stale_disagg(session))
         ret = __wt_set_return(session, EBUSY);
     else
         /*

--- a/src/btree/bt_split.c
+++ b/src/btree/bt_split.c
@@ -2325,6 +2325,9 @@ __wt_split_insert(WT_SESSION_IMPL *session, WT_REF *ref)
 
     __wt_verbose(session, WT_VERB_SPLIT, "%p: split-insert", (void *)ref);
 
+    if (__wt_btree_is_stale_disagg(session))
+        return (__wt_set_return(session, EBUSY));
+
     /*
      * Set the session split generation to ensure underlying code isn't surprised by internal page
      * eviction, then proceed with the insert split.
@@ -2448,11 +2451,14 @@ __wt_split_multi(WT_SESSION_IMPL *session, WT_REF *ref, int closing)
 
     __wt_verbose(session, WT_VERB_SPLIT, "%p: split-multi", (void *)ref);
 
-    /*
-     * Set the session split generation to ensure underlying code isn't surprised by internal page
-     * eviction, then proceed with the split.
-     */
-    WT_WITH_PAGE_INDEX(session, ret = __split_multi_lock(session, ref, closing));
+    if (!closing && __wt_btree_is_stale_disagg(session))
+        ret = __wt_set_return(session, EBUSY);
+    else
+        /*
+         * Set the session split generation to ensure underlying code isn't surprised by internal
+         * page eviction, then proceed with the split.
+         */
+        WT_WITH_PAGE_INDEX(session, ret = __split_multi_lock(session, ref, closing));
 
     if (ret == EBUSY)
         WT_STAT_CONN_DSRC_INCR(session, cache_evict_split_failed_lock);
@@ -2486,6 +2492,9 @@ __wt_split_reverse(WT_SESSION_IMPL *session, WT_REF *ref)
     WT_DECL_RET;
 
     __wt_verbose(session, WT_VERB_SPLIT, "%p: reverse-split", (void *)ref);
+
+    if (__wt_btree_is_stale_disagg(session))
+        return (__wt_set_return(session, EBUSY));
 
     /*
      * Set the session split generation to ensure underlying code isn't surprised by internal page

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -1401,6 +1401,8 @@ err:
 
     if (ret != 0 && reconfig && !was_leader && leader)
         return (__wt_panic(session, ret, "failed to step-up as primary"));
+    if (ret != 0 && reconfig && was_leader && !leader)
+        return (__wt_panic(session, ret, "failed to step-down as primary"));
     return (ret);
 }
 

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -1084,7 +1084,7 @@ err:
  *     Mark all disaggregated btrees readonly and outdated, then step down to follower mode. The
  *     outdated mark makes the next leader open fresh handles instead of reusing these stale ones.
  */
-static void
+static int
 __disagg_mark_btrees_readonly_then_step_down(WT_SESSION_IMPL *session)
 {
     WT_BTREE *btree;
@@ -1109,7 +1109,7 @@ __disagg_mark_btrees_readonly_then_step_down(WT_SESSION_IMPL *session)
             continue;
 
         WT_WITH_BTREE(session, btree, ret = __wt_evict_file_exclusive_on(session));
-        WT_IGNORE_RET(ret);
+        WT_RET(ret);
 
         /* Mark the disaggregated as readonly. */
         F_SET(btree, WT_BTREE_READONLY);
@@ -1129,15 +1129,17 @@ __disagg_mark_btrees_readonly_then_step_down(WT_SESSION_IMPL *session)
     /* Step down to the follower mode. */
     conn->layered_table_manager.leader = false;
     WT_STAT_CONN_SET(session, disagg_role_leader, 0);
+    return (0);
 }
 
 /*
  * __disagg_step_down --
  *     Step down to the follower mode.
  */
-static void
+static int
 __disagg_step_down(WT_SESSION_IMPL *session)
 {
+    WT_DECL_RET;
     WT_SHARED_DSK_CACHE *shared_dsk_cache;
 
     WT_CONNECTION_IMPL *conn = S2C(session);
@@ -1152,7 +1154,9 @@ __disagg_step_down(WT_SESSION_IMPL *session)
      * eviction paths, especially parent split path, from dirtying pages during the step-down
      * window.
      */
-    WT_WITH_HANDLE_LIST_READ_LOCK(session, __disagg_mark_btrees_readonly_then_step_down(session));
+    WT_WITH_HANDLE_LIST_READ_LOCK(
+      session, ret = __disagg_mark_btrees_readonly_then_step_down(session));
+    WT_ERR(ret);
 
     /* Do some cleanup as we are abandoning the current checkpoint. */
     __disagg_shared_metadata_queue_clear(session);
@@ -1172,7 +1176,10 @@ __disagg_step_down(WT_SESSION_IMPL *session)
 
     /* Clear the step-down timestamp after stepping down. */
     __wt_atomic_store_uint64_relaxed(&conn->txn_global.step_down_timestamp, WT_TS_NONE);
+
+err:
     F_CLR_ATOMIC_32(conn, WT_CONN_RECONFIGURING_STEP_DOWN);
+    return (ret);
 }
 
 /*
@@ -1267,8 +1274,9 @@ __wti_disagg_conn_config(WT_SESSION_IMPL *session, const char **cfg, bool reconf
     } else if (was_leader && !leader) {
         /* Leader step-down. */
         time_start = __wt_clock(session);
-        WT_WITH_CHECKPOINT_LOCK(session, __disagg_step_down(session));
+        WT_WITH_CHECKPOINT_LOCK(session, ret = __disagg_step_down(session));
         time_stop = __wt_clock(session);
+        WT_ERR_MSG_CHK(session, ret, "Failed to step down to the follower role");
         WT_STAT_CONN_SET(session, disagg_step_down_time, WT_CLOCKDIFF_MS(time_stop, time_start));
         __wt_verbose_debug1(session, WT_VERB_DISAGGREGATED_STORAGE,
           "Step down completed in %" PRIu64 " milliseconds",

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -454,8 +454,7 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF_STATE previous_state, u
      * storage. Clear the dirty flag so eviction discards the page cleanly instead of attempting
      * reconciliation.
      */
-    if (F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED) &&
-      F_ISSET(S2BT(session), WT_BTREE_READONLY) && F_ISSET(session->dhandle, WT_DHANDLE_OUTDATED))
+    if (__wt_btree_is_stale_disagg(session))
         __wt_page_modify_clear(session, page);
 
     if (__wt_page_is_modified(page))

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -37,6 +37,17 @@ __wt_btree_disable_bulk(WT_SESSION_IMPL *session)
 }
 
 /*
+ * __wt_btree_is_stale_disagg --
+ *     Return whether the current btree belongs to an outdated disaggregated generation.
+ */
+static WT_INLINE bool
+__wt_btree_is_stale_disagg(WT_SESSION_IMPL *session)
+{
+    return (F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED | WT_BTREE_READONLY) &&
+      F_ISSET(session->dhandle, WT_DHANDLE_OUTDATED));
+}
+
+/*
  * __wt_page_is_empty --
  *     Return if the page is empty.
  */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2029,6 +2029,8 @@ static WT_INLINE bool __wt_btree_can_discard(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wt_btree_disagg_checkpointed(WT_SESSION_IMPL *session, WT_BTREE *btree)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+static WT_INLINE bool __wt_btree_is_stale_disagg(WT_SESSION_IMPL *session)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wt_btree_syncing_by_other_sessions(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 static WT_INLINE bool __wt_cache_full(WT_SESSION_IMPL *session)


### PR DESCRIPTION
## Summary

After a disaggregated leader steps down, eviction resumes while the previous generation of cached btree handles remains marked read-only and outdated. A structural split can still run on one of these stale handles and replace a parent index, but the read-only state prevents the parent from being marked dirty. A concurrent clean eviction can then free the parent while the splitter is still using its page lock, causing a use-after-free in the split unlock path.

This change rejects insert, non-closing multi, and reverse splits on handles that are simultaneously disaggregated, read-only, and outdated, before they make any structural changes. It also propagates failures from the step-down eviction exclusivity barrier so the read-only/outdated state is set only after active eviction has drained, closing the check-to-state-change window on which the split gate relies.
