### PR TITLE
WT-17471 Clear page-index update flag while locked

### DIFF
--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -128,14 +128,6 @@ __wt_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage
 
     if (ret != 0)
         F_SET_ATOMIC_16(ref->page, WT_PAGE_REC_FAIL);
-    else {
-        if (F_ISSET_ATOMIC_16(ref->page, WT_PAGE_COMPACTION_WRITE))
-            WT_STAT_CONN_INCRV(
-              session, session_table_compact_bytes_rewrite_inmem, ref->page->memory_footprint);
-        /* If writing a page in service of compaction, we're done, clear the flag. */
-        F_CLR_ATOMIC_16(
-          ref->page, WT_PAGE_REC_FAIL | WT_PAGE_INMEM_SPLIT | WT_PAGE_COMPACTION_WRITE);
-    }
 
 err:
     if (page_locked)
@@ -396,11 +388,16 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
     /* Wrap up the page reconciliation. Panic on failure. */
     WT_ERR(__rec_write_wrapup(session, r));
     __rec_write_page_status(session, r);
+    if (F_ISSET_ATOMIC_16(page, WT_PAGE_COMPACTION_WRITE))
+        WT_STAT_CONN_INCRV(
+          session, session_table_compact_bytes_rewrite_inmem, page->memory_footprint);
     /*
-     * Retire the page-index update before releasing the lock so a subsequent split cannot have its
-     * newer flag cleared by this reconciliation.
+     * Retire the reconciliation state before releasing the page lock so subsequent operations
+     * cannot have their newer state cleared by this reconciliation.
      */
-    F_CLR_ATOMIC_16(page, WT_PAGE_INTL_PINDEX_UPDATE);
+    F_CLR_ATOMIC_16(page,
+      WT_PAGE_REC_FAIL | WT_PAGE_INMEM_SPLIT | WT_PAGE_INTL_PINDEX_UPDATE |
+        WT_PAGE_COMPACTION_WRITE);
     WT_ERR(__reconcile_post_wrapup(session, r, page, flags, page_lockedp));
 
     /*

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -133,9 +133,8 @@ __wt_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage
             WT_STAT_CONN_INCRV(
               session, session_table_compact_bytes_rewrite_inmem, ref->page->memory_footprint);
         /* If writing a page in service of compaction, we're done, clear the flag. */
-        F_CLR_ATOMIC_16(ref->page,
-          WT_PAGE_REC_FAIL | WT_PAGE_INMEM_SPLIT | WT_PAGE_INTL_PINDEX_UPDATE |
-            WT_PAGE_COMPACTION_WRITE);
+        F_CLR_ATOMIC_16(
+          ref->page, WT_PAGE_REC_FAIL | WT_PAGE_INMEM_SPLIT | WT_PAGE_COMPACTION_WRITE);
     }
 
 err:
@@ -397,6 +396,11 @@ __reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage, u
     /* Wrap up the page reconciliation. Panic on failure. */
     WT_ERR(__rec_write_wrapup(session, r));
     __rec_write_page_status(session, r);
+    /*
+     * Retire the page-index update before releasing the lock so a subsequent split cannot have its
+     * newer flag cleared by this reconciliation.
+     */
+    F_CLR_ATOMIC_16(page, WT_PAGE_INTL_PINDEX_UPDATE);
     WT_ERR(__reconcile_post_wrapup(session, r, page, flags, page_lockedp));
 
     /*


### PR DESCRIPTION
Reconciliation cleared `WT_PAGE_INTL_PINDEX_UPDATE` after `__reconcile_post_wrapup` had released the page lock. A concurrent split could acquire the lock, set a newer page-index update flag, and then have that flag cleared by the older reconciliation.

Move the successful reconciliation clear before `__reconcile_post_wrapup`, while the page lock is still held. Failed reconciliation behavior is unchanged.
