### PR TITLE
WT-17989 Skip application eviction during standalone ingest clear

### DIFF
--- a/src/conn/conn_layered_ingest.c
+++ b/src/conn/conn_layered_ingest.c
@@ -133,6 +133,9 @@ static int
 __layered_clear_ingest_table(WT_SESSION_IMPL *session, const char *uri)
 {
     WT_DECL_RET;
+#ifdef WT_STANDALONE_BUILD
+    uint32_t orig_flags;
+#endif
 
     WT_ASSERT(session, WT_URI_IS_INGEST(uri));
 
@@ -140,9 +143,18 @@ __layered_clear_ingest_table(WT_SESSION_IMPL *session, const char *uri)
      * Clearing the ingest table is final and owned by no transaction. The session flag makes the
      * truncate write globally visible tombstones that are immediately visible to every reader.
      */
+#ifdef WT_STANDALONE_BUILD
+    /* The scan must complete during step-up rather than be rolled back by application eviction. */
+    orig_flags = F_MASK(session, WT_SESSION_IGNORE_CACHE_SIZE);
+    F_SET(session, WT_SESSION_IGNORE_CACHE_SIZE);
+#endif
     F_SET(session, WT_SESSION_NON_TRANSACTIONAL_TRUNCATE);
     ret = session->iface.truncate(&session->iface, uri, NULL, NULL, NULL);
     F_CLR(session, WT_SESSION_NON_TRANSACTIONAL_TRUNCATE);
+#ifdef WT_STANDALONE_BUILD
+    F_CLR(session, WT_SESSION_IGNORE_CACHE_SIZE);
+    F_SET(session, orig_flags);
+#endif
 
     return (ret);
 }

--- a/src/conn/conn_layered_ingest.c
+++ b/src/conn/conn_layered_ingest.c
@@ -144,6 +144,7 @@ __layered_clear_ingest_table(WT_SESSION_IMPL *session, const char *uri)
      * truncate write globally visible tombstones that are immediately visible to every reader.
      */
 #ifdef WT_STANDALONE_BUILD
+    /* FIXME-WT-18058: Replace the whole-table clear with incremental per-page draining. */
     /* The scan must complete during step-up rather than be rolled back by application eviction. */
     orig_flags = F_MASK(session, WT_SESSION_IGNORE_CACHE_SIZE);
     F_SET(session, WT_SESSION_IGNORE_CACHE_SIZE);


### PR DESCRIPTION
## Root cause

During step-up, WiredTiger first drains the ingest table into the stable table and then clears the ingest table with a whole-table non-transactional truncate. The clear operation walks the entire ingest tree while holding a read snapshot.

In the pinned reproduction, individual scan passes took approximately 7.8–8.7 seconds while cache occupancy reached 95–100%. During that time, the drain session's `pinned_id` eventually became the global oldest transaction ID. When the cache became stuck, application-assist eviction identified the drain session as blocking progress and returned `WT_ROLLBACK` with `WT_OLDEST_FOR_EVICTION`. The drain worker treats this error as fatal, so step-up fails.

## Long-term direction

The proposed long-term solution is to replace the whole-table workflow with an incremental per-key/per-page workflow. After a page has been fully drained, its ingest keys would be tombstoned and the completed page would be handed to eviction immediately. This would release snapshots and cache memory incrementally instead of retaining them for the entire table.

That change requires substantial work across version ordering, range truncation, snapshot lifetime, page ownership, and eviction coordination, together with extensive correctness and performance validation.

## Temporary mitigation

As a short-term mitigation, this change temporarily sets `WT_SESSION_IGNORE_CACHE_SIZE` while clearing an ingest table in `WT_STANDALONE_BUILD`. This prevents the clear scan from entering application-assist eviction and being rolled back as the oldest pinned transaction. The original session flag state is preserved and restored after the truncate, including on failure.

Non-standalone builds are unchanged, and this change does not add a `WT_ROLLBACK` retry.