### PR TITLE
WT-18051 Add compaction to unsupported ops in the disagg hook

### DIFF
--- a/test/suite/fail_lists/hook_disagg.fail
+++ b/test/suite/fail_lists/hook_disagg.fail
@@ -18,7 +18,6 @@ test_durable_ts03.py
 test_empty.py
 test_encrypt06.py
 test_env01.py
-test_error_info01.py
 test_hs24.py    # FIXME: WT-18046
 test_log03.py
 test_metadata_cursor01.py
@@ -40,6 +39,3 @@ test_util13.py
 test_util14.py
 test_util15.py
 test_util17.py
-test_verbose01.py  # FIXME: WT-15372
-test_verbose02.py
-test_verbose04.py

--- a/test/suite/hooks/hook_disagg.py
+++ b/test/suite/hooks/hook_disagg.py
@@ -259,8 +259,8 @@ def session_checkpoint_replace(orig_session_checkpoint, session_self, config):
 
 # Called to replace Session.compact
 def session_compact_replace(orig_session_compact, session_self, uri, config):
-    uri = replace_uri(uri)
-    return orig_session_compact(session_self, uri, config)
+    # Compaction is not supported on disaggregated tables.
+    skip_test('Compaction is not supported in disagg storage')
 
 # Called to replace Session.create
 def session_create_replace(orig_session_create, session_self, uri, config):

--- a/test/suite/test_verbose01.py
+++ b/test/suite/test_verbose01.py
@@ -104,9 +104,6 @@ class test_verbose_base(wttest.WiredTigerTestCase, suite_subprocess):
         if expect_json:
             verbose_config += ",json_output=[message]"
         conn = self.wiredtiger_open(self.home, verbose_config)
-        # If the body raises (e.g. an operation is skipped under a hook), we must still close the
-        # connection and drain the captured verbose output, otherwise it leaks into the stdout check
-        # at teardown.
         try:
             # Yield the connection resource to the execution context, allowing it to perform any
             # necessary operations on the connection (for generating the expected verbose output).

--- a/test/suite/test_verbose01.py
+++ b/test/suite/test_verbose01.py
@@ -104,43 +104,47 @@ class test_verbose_base(wttest.WiredTigerTestCase, suite_subprocess):
         if expect_json:
             verbose_config += ",json_output=[message]"
         conn = self.wiredtiger_open(self.home, verbose_config)
-        # Yield the connection resource to the execution context, allowing it to perform any necessary
-        # operations on the connection (for generating the expected verbose output).
-        yield conn
-        # Read the contents of stdout to extract our verbose messages.
-        output = self.readStdout(self.nlines)
-        # Split the output into their individual messages. We want validate the contents of each message
-        # to ensure we've only generated verbose messages for the expected categories.
-        verbose_messages = output.splitlines()
+        # If the body raises (e.g. an operation is skipped under a hook), we must still close the
+        # connection and drain the captured verbose output, otherwise it leaks into the stdout check
+        # at teardown.
+        try:
+            # Yield the connection resource to the execution context, allowing it to perform any
+            # necessary operations on the connection (for generating the expected verbose output).
+            yield conn
+            # Read the contents of stdout to extract our verbose messages.
+            output = self.readStdout(self.nlines)
+            # Split the output into their individual messages. We want validate the contents of each message
+            # to ensure we've only generated verbose messages for the expected categories.
+            verbose_messages = output.splitlines()
 
-        if expect_output:
-            self.assertGreater(len(verbose_messages), 0)
-        else:
-            self.assertEqual(len(verbose_messages), 0)
+            if expect_output:
+                self.assertGreater(len(verbose_messages), 0)
+            else:
+                self.assertEqual(len(verbose_messages), 0)
 
-        if len(output) >= self.nlines:
-            # If we've read the maximum number of characters, its likely that the last line is truncated ('...'). In this
-            # case, trim the last message as we can't parse it.
-            verbose_messages = verbose_messages[:-1]
+            if len(output) >= self.nlines:
+                # If we've read the maximum number of characters, its likely that the last line is truncated ('...'). In this
+                # case, trim the last message as we can't parse it.
+                verbose_messages = verbose_messages[:-1]
 
-        # Test the contents of each verbose message, ensuring it satisfies the expected pattern.
-        verb_pattern = re.compile('|'.join(patterns))
-        # To avoid truncated messages, slice out the last message string in the
-        for line in verbose_messages:
-            # Check JSON validity
-            if expect_json:
-                try:
-                    json.loads(line)
-                except Exception as e:
-                    self.prout('Unable to parse JSON message: %s' % line)
-                    raise e
+            # Test the contents of each verbose message, ensuring it satisfies the expected pattern.
+            verb_pattern = re.compile('|'.join(patterns))
+            # To avoid truncated messages, slice out the last message string in the
+            for line in verbose_messages:
+                # Check JSON validity
+                if expect_json:
+                    try:
+                        json.loads(line)
+                    except Exception as e:
+                        self.prout('Unable to parse JSON message: %s' % line)
+                        raise e
 
-            self.assertTrue(verb_pattern.search(line) != None, 'Unexpected verbose message: ' + line)
-
-        # Close the connection resource and clean up the contents of the stdout file, flushing out the
-        # verbose output that occurred during the execution of this context.
-        conn.close()
-        self.cleanStdout()
+                self.assertTrue(verb_pattern.search(line) != None, 'Unexpected verbose message: ' + line)
+        finally:
+            # Close the connection resource and clean up the contents of the stdout file, flushing out
+            # the verbose output that occurred during the execution of this context.
+            conn.close()
+            self.cleanStdout()
 
 # Verify basic uses of the verbose configuration API work as intended i.e. passing
 # single & multiple valid and invalid verbose categories. These tests are mainly focused on uses


### PR DESCRIPTION
Compaction is not supported for disagg, but the disagg hook previously allowed python tests to call `session.compact` directly, resulting in `ENOTSUP` errors.

I have updated `session_compact_replace` to automatically skip tests that rely on compaction when running with the disagg hook, which enabled the following tests to be re-enabled:
- `test_error_info01.py`
- `test_verbose01.py`
- `test_verbose02.py`
- `test_verbose04.py`