### PR TITLE
WT-18013 Fix use-after-free from reentrant cursor-cache sweep on layered close

### DIFF
--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -3071,21 +3071,16 @@ __clayered_close(WT_CURSOR *cursor)
 err:
     if (ret == 0) {
         /*
-         * If releasing the cursor fails in any way, it will be left in a state that allows it to be
-         * normally closed.
+         * Close constituent cursors before caching the layered cursor. A cursor-cache sweep
+         * triggered during constituent close could otherwise find the layered cursor already in the
+         * cache with constituent pointers still set, and double-close them.
          */
+        WT_TRET(__clayered_close_cursors(clayered));
+
         bool released = false;
-        ret = __wti_cursor_cache_release(session, cursor, &released);
-
-        if (released) {
-            /*
-             * If the cursor has been cached, try to cache the constituent cursors by evoking a
-             * cursor close.
-             */
-            WT_TRET(__clayered_close_cursors(clayered));
-
+        WT_TRET(__wti_cursor_cache_release(session, cursor, &released));
+        if (released)
             goto done;
-        }
     }
     /* For cached cursors, free any extra buffers retained now. */
     __wt_cursor_free_cached_memory(cursor);

--- a/test/csuite/schema_disagg_abort/workload.c
+++ b/test/csuite/schema_disagg_abort/workload.c
@@ -61,12 +61,7 @@ schema_worker_open(THREAD_DATA *td, SCHEMA_WORKER_CTX *ctx)
 
     ctx->rnd = &td->rnd;
     ctx->state = td->state;
-    /*
-     * FIXME-WT-18013: Disable cursor caching. A cached cursor keeps referencing its table's data
-     * handle after the table is dropped, so recreating the same URI or a cache sweep dereferences
-     * the freed handle and crashes.
-     */
-    testutil_check(td->conn->open_session(td->conn, NULL, "cache_cursors=false", &ctx->session));
+    testutil_check(td->conn->open_session(td->conn, NULL, NULL, &ctx->session));
     testutil_snprintf(ctx->tableconf, sizeof(ctx->tableconf),
       "key_format=S,value_format=S,type=layered,block_manager=disagg");
 }


### PR DESCRIPTION
Closing a layered cursor can crash with a use-after-free. When a layered cursor is closed, it is placed in the cursor cache before its stable and ingest constituent cursors are closed. Closing a constituent can trigger a cursor-cache sweep, which finds the just-cached layered cursor, still referencing those constituents, and closes it, freeing them. The original close path then uses the freed memory and crashes.

This reproduces on a disaggregated leader under sustained create/drop/publish activity with cursor caching on.

**Fix:** Close the constituent cursors before caching the layered cursor, so the layered cursor only enters the cache once its constituent references are cleared and a reentrant sweep cannot free them.
