### PR TITLE
WT-18075 test format: correct the drain check and stable timestamp bookkeeping in async step-down

### DIFF
--- a/test/format/format_disagg.c
+++ b/test/format/format_disagg.c
@@ -225,18 +225,17 @@ disagg_is_mode_switch(void)
 
 /*
  * stepdown_workers_drained --
- *     Return true when WT's all_durable timestamp has reached step_down_ts, meaning every
- *     transaction at or below step_down_ts has completed (committed or rolled back). Using
- *     all_durable is stronger than checking per-thread commit_ts: it guarantees no gaps remain in
- *     the commit history at or below the step-down boundary.
+ *     Return true once every worker's most recent commit is past step_down_ts, proving no worker
+ *     can commit at or below the boundary again. Only commits the workers have completed count:
+ *     querying WT's all_durable would miss a timestamp a worker has allocated but not yet given to
+ *     timestamp_transaction, letting the drain finish early and that commit land behind stable.
+ *     Timer-based runs are required (enforced at configuration): a worker that exhausts its
+ *     operation count stops committing and would stall the drain.
  */
 static bool
 stepdown_workers_drained(wt_timestamp_t step_down_ts)
 {
-    wt_timestamp_t all_durable;
-
-    testutil_check(timestamp_query("get=all_durable", &all_durable));
-    return (all_durable >= step_down_ts);
+    return (timestamp_minimum_committed() >= step_down_ts);
 }
 
 /*

--- a/test/format/format_disagg.c
+++ b/test/format/format_disagg.c
@@ -382,6 +382,7 @@ disagg_switch_roles(void)
             lock_writelock(session, &g.prepare_commit_lock);
             testutil_check(g.wts_conn->set_timestamp(g.wts_conn, config));
             lock_writeunlock(session, &g.prepare_commit_lock);
+            g.stable_timestamp = g.stepdown_ts;
 
             /*
              * Step-down checkpoint: stable is pinned at step_down_ts, so the checkpoint captures


### PR DESCRIPTION
### Summary

Two fixes to the async step-down path in test/format.

**1. Step-down drain polled all_durable, which can miss unpublished commit timestamps**

all_durable only sees timestamps registered with WT via timestamp_transaction(). A
worker allocates its commit timestamp from g.timestamp first and registers it with WT
afterwards, so it can hold a timestamp at or below step_down_ts that WT doesn't yet know
about — letting the drain finish early and that commit land behind stable.

The drain now waits on timestamp_minimum_committed() >= step_down_ts, counting only
commits the workers have actually completed — the same signal timestamp_once() uses to
advance stable. This requires timer-based runs (a worker that exhausts runs.ops stops
committing and would stall the drain), so configuration now dies on an explicit
runs.ops with disagg.stepdown_async and forces runs.ops=0 otherwise.

**2. Pinning stable at step-down did not update g.stable_timestamp**

Every set_timestamp(stable_timestamp=...) must also update g.stable_timestamp, format's
cached view of stable (as timestamp_once() does). The async step-down path pinned stable
directly without doing so, leaving the cache stale for the whole follower phase.
Readers include snap_op_init() (snap-list rotation for RTS verification),
snap_repeat_rollback(), checksum_database(), and testutil_disagg_preserve().

### Changes

- stepdown_workers_drained() uses timestamp_minimum_committed() instead of all_durable
- config_disagg_storage() enforces timer-based runs for disagg.stepdown_async
- disagg_switch_roles() sets g.stable_timestamp = g.stepdown_ts after pinning stable