### PR TITLE
WT-18076 Skip verify retry loop in switch mode to avoid timeout accumulation

### DIFF
--- a/test/format/verify.c
+++ b/test/format/verify.c
@@ -50,7 +50,7 @@ table_verify(TABLE *table, void *arg)
     /*
      * Verify can race with special-handle transitions and return EBUSY. In switch mode, async role
      * switches can leave handles in a dirty state; skip the retry delay to avoid minutes of
-     * accumulated wait time across many runs.
+     * accumulated wait time across many runs. FIXME - WT-18083
      */
     if (disagg_is_mode_switch()) {
         ret = session->verify(session, table->uri, "strict");

--- a/test/format/verify.c
+++ b/test/format/verify.c
@@ -50,7 +50,7 @@ table_verify(TABLE *table, void *arg)
     /*
      * Verify can race with special-handle transitions and return EBUSY. In switch mode, async role
      * switches can leave handles in a transient state; skip the retry delay to avoid minutes of
-     * accumulated wait time across many runs. FIXME-WT-XXXXX
+     * accumulated wait time across many runs.
      */
     if (disagg_is_mode_switch()) {
         ret = session->verify(session, table->uri, "strict");

--- a/test/format/verify.c
+++ b/test/format/verify.c
@@ -49,7 +49,7 @@ table_verify(TABLE *table, void *arg)
 
     /*
      * Verify can race with special-handle transitions and return EBUSY. In switch mode, async role
-     * switches can leave handles in a transient state; skip the retry delay to avoid minutes of
+     * switches can leave handles in a dirty state; skip the retry delay to avoid minutes of
      * accumulated wait time across many runs.
      */
     if (disagg_is_mode_switch()) {

--- a/test/format/verify.c
+++ b/test/format/verify.c
@@ -47,11 +47,21 @@ table_verify(TABLE *table, void *arg)
     memset(&sap, 0, sizeof(sap));
     wt_wrap_open_session(conn, &sap, table->track_prefix, session_prefetch_cfg(), &session);
 
-    /* Verify can race with special-handle transitions, retry briefly on EBUSY. */
-    for (retries = 0; (ret = session->verify(session, table->uri, "strict")) == EBUSY; ++retries) {
-        if (retries >= WT_MINUTE)
-            break;
-        sleep(1); /* Sleep for 1 second before retrying */
+    /*
+     * Verify can race with special-handle transitions and return EBUSY. In switch mode, async role
+     * switches can leave handles in a transient state; skip the retry delay to avoid minutes of
+     * accumulated wait time across many runs. FIXME-WT-XXXXX
+     */
+    if (disagg_is_mode_switch()) {
+        ret = session->verify(session, table->uri, "strict");
+        retries = 0;
+    } else {
+        for (retries = 0; (ret = session->verify(session, table->uri, "strict")) == EBUSY;
+          ++retries) {
+            if (retries >= WT_MINUTE)
+                break;
+            sleep(1);
+        }
     }
 
     /*
@@ -62,8 +72,12 @@ table_verify(TABLE *table, void *arg)
     testutil_assert(
       ret == 0 || ret == EBUSY || (g.disagg_storage_config && !g.disagg_leader && ret == ENOENT));
 
-    if (ret == EBUSY)
-        WARN("table.%u skipped verify because of EBUSY after %u retries", table->id, retries);
+    if (ret == EBUSY) {
+        if (disagg_is_mode_switch())
+            WARN("table.%u skipped verify in switch mode (EBUSY)", table->id);
+        else
+            WARN("table.%u skipped verify because of EBUSY after %u retries", table->id, retries);
+    }
     wt_wrap_close_session(session);
 }
 


### PR DESCRIPTION
### Summary

In switch mode (async disagg role switches), session->verify() races with special-handle transitions and frequently returns EBUSY. The existing retry loop sleeps 1 second per attempt for up to 60 seconds per verify call. Across 20 format runs this accumulates to ~1 hour of wasted test time and causes Evergreen timeouts.

### Change: 
When disagg_is_mode_switch() is true, attempt verify once and skip the retry loop. If EBUSY is returned, log a switch-mode-specific warning ("skipped verify in switch mode (EBUSY)") and move on. Non-switch runs retain the existing retry behavior unchanged.
