### PR TITLE
WT-18077 Rework __wt_verify checkpoint error handling

### DIFF
--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -437,12 +437,21 @@ __verify_one_checkpoint(
     if (root_addr_size == 0)
         goto done;
 
+    /*
+     * Eviction is still locked out, so the only cleanup a failure owes is the unload: WT_ERR can
+     * bail straight to the err label.
+     */
     WT_ERR(__wti_btree_tree_open(session, root_addr, root_addr_size));
 
     if (WT_VRFY_DUMP(vs))
         WT_ERR(__wt_msg(session, "Root:\n\t> addr: %s",
           __wt_addr_string(session, root_addr, root_addr_size, vs->tmp1)));
 
+    /*
+     * Enable eviction on the tree. From here until it is locked out again below, the err label is no
+     * longer a safe exit: it unloads the checkpoint but does not re-acquire the lock or discard the
+     * tree. Failures must be accumulated into ret so the eviction handshake still runs.
+     */
     __wt_evict_file_exclusive_off(session);
 
     /* Create a fake, unpacked parent cell for the tree based on the checkpoint information. */

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -455,12 +455,6 @@ __verify_one_checkpoint(
 
     /* Verify the tree. */
     WT_WITH_PAGE_INDEX(session, ret = __verify_tree(session, &btree->root, &addr_unpack, vs));
-
-    /*
-     * Bail on a hard verification failure. In read_corrupt mode the tree verification returns
-     * success and stashes the error, so this doesn't fire; the remaining checks run and use WT_TRET
-     * so that error isn't masked before it is applied below.
-     */
     WT_ERR(ret);
 
     /* Account for the root page in the accumulated total block size. */

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -464,7 +464,7 @@ __verify_one_checkpoint(
     WT_ERR(ret);
 
     /* Account for the root page in the accumulated total block size. */
-    WT_TRET(__verify_disagg_accumulate_size(session, vs, ckpt->raw.data, ckpt->raw.size));
+    WT_ERR(__verify_disagg_accumulate_size(session, vs, ckpt->raw.data, ckpt->raw.size));
 
 #ifdef HAVE_DIAGNOSTIC
     /* Validate the size of the btree. */
@@ -476,7 +476,7 @@ __verify_one_checkpoint(
          * Only fail in diagnostic builds for now; enable this branch in production builds once this
          * is resolved.
          */
-        WT_TRET_MSG(session, WT_ERROR,
+        WT_ERR_MSG(session, WT_ERROR,
           "checkpoint size %" PRIu64 " does not match accumulated block size %" PRIu64, ckpt->size,
           vs->total_block_size);
 #endif

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -51,6 +51,7 @@ typedef struct {
 static void __verify_checkpoint_reset(WT_VSTUFF *);
 static int __verify_compare_page_id(const void *, const void *);
 static int __verify_disagg_accumulate_size(WT_SESSION_IMPL *, WT_VSTUFF *, const void *, size_t);
+static int __verify_one_checkpoint(WT_SESSION_IMPL *, WT_VSTUFF *, WT_CKPT *, bool, bool);
 static int __verify_page_content_int(
   WT_SESSION_IMPL *, WT_REF *, WT_CELL_UNPACK_ADDR *, WT_VSTUFF *);
 static int __verify_page_content_leaf(
@@ -400,6 +401,138 @@ __wt_verify_disagg_database_size(WT_SESSION_IMPL *session)
 }
 
 /*
+ * __verify_one_checkpoint --
+ *     Load, verify and unload a single checkpoint. The checkpoint is unloaded on every path once it
+ *     has been loaded, so callers must not add error handling that jumps past the unload.
+ */
+static int
+__verify_one_checkpoint(
+  WT_SESSION_IMPL *session, WT_VSTUFF *vs, WT_CKPT *ckpt, bool skip_hs, bool last_ckpt)
+{
+    WT_BM *bm;
+    WT_BTREE *btree;
+    WT_CELL_UNPACK_ADDR addr_unpack;
+    WT_DECL_RET;
+    size_t root_addr_size;
+    uint8_t root_addr[WT_ADDR_MAX_COOKIE];
+    const char *name;
+
+    btree = S2BT(session);
+    bm = btree->bm;
+    name = session->dhandle->name;
+
+    if (WT_VRFY_DUMP(vs)) {
+        WT_RET(__wt_msg(session, "%s", WT_DIVIDER));
+        WT_RET(__wt_msg(session, "%s, ckpt_name: %s", name, ckpt->name));
+    }
+
+    /*
+     * Load the checkpoint. Once it is loaded every exit path must run through the unload at the err
+     * label.
+     */
+    WT_RET(bm->checkpoint_load(
+      bm, session, ckpt->raw.data, ckpt->raw.size, root_addr, &root_addr_size, true));
+
+    /* Skip trees with no root page. */
+    if (root_addr_size == 0)
+        goto done;
+
+    WT_ERR(__wti_btree_tree_open(session, root_addr, root_addr_size));
+
+    if (WT_VRFY_DUMP(vs))
+        WT_ERR(__wt_msg(session, "Root:\n\t> addr: %s",
+          __wt_addr_string(session, root_addr, root_addr_size, vs->tmp1)));
+
+    __wt_evict_file_exclusive_off(session);
+
+    /* Create a fake, unpacked parent cell for the tree based on the checkpoint information. */
+    memset(&addr_unpack, 0, sizeof(addr_unpack));
+    WT_TIME_AGGREGATE_COPY(&addr_unpack.ta, &ckpt->ta);
+    if (ckpt->ta.prepare)
+        addr_unpack.ta.prepare = 1;
+    addr_unpack.raw = WT_CELL_ADDR_INT;
+
+    /* Only verify HS entries against the last checkpoint. */
+    vs->skip_hs = skip_hs || !last_ckpt;
+    vs->hs_checkpoint_name = ckpt->name;
+
+    /* Verify the tree. */
+    WT_WITH_PAGE_INDEX(session, ret = __verify_tree(session, &btree->root, &addr_unpack, vs));
+
+    /* Account for the root page in the accumulated total block size. */
+    WT_TRET(__verify_disagg_accumulate_size(session, vs, ckpt->raw.data, ckpt->raw.size));
+
+#ifdef HAVE_DIAGNOSTIC
+    /*
+     * Validate the size of the btree. Eviction is enabled between here and the re-acquire below, so
+     * record the mismatch in ret without jumping; the eviction handshake must still run.
+     */
+    if (F_ISSET(btree, WT_BTREE_DISAGGREGATED) && ckpt->size != vs->total_block_size)
+        /*
+         * FIXME-WT-18038: We are seeing mismatches due to nuanced reconciliation issues, where
+         * bytes_total increments happen before the reconciliation panic boundary, leaving us in an
+         * inconsistent state if reconciliation fails after the increment but before completion.
+         * Only fail in diagnostic builds for now; enable this branch in production builds once this
+         * is resolved.
+         */
+        WT_TRET_MSG(session, WT_ERROR,
+          "checkpoint size %" PRIu64 " does not match accumulated block size %" PRIu64, ckpt->size,
+          vs->total_block_size);
+#endif
+
+    /*
+     * The checkpoints are in time-order, so the last one in the list is the most recent. If this is
+     * the most recent checkpoint, verify the history store against it, also verify page discard
+     * function if we're in disagg mode.
+     */
+    if (ret == 0 && last_ckpt) {
+        if (F_ISSET(btree, WT_BTREE_DISAGGREGATED)) {
+            /*
+             * The page discard verification routine depends on get_page_ids being implemented.
+             */
+            WT_BLOCK_DISAGG *block_disagg = (WT_BLOCK_DISAGG *)bm->block;
+            if (block_disagg->plhandle->plh_get_page_ids != NULL && ckpt->raw.data != NULL)
+                WT_TRET(__verify_page_discard(session, bm));
+        }
+
+        if (!skip_hs) {
+            __wt_verbose(session, WT_VERB_VERIFY, "%s: verify against history store", name);
+            WT_TRET_MSG(
+              session, __wt_hs_verify_one(session, btree->id), "history store verification failed");
+        }
+        /*
+         * We cannot error out here. If we got an error verifying the history store, we need to
+         * follow through with reacquiring the exclusive call below. We'll error out after that and
+         * unloading this checkpoint.
+         */
+    }
+
+    /*
+     * If the read_corrupt mode was turned on, we may have continued traversing and verifying the
+     * pages of the tree despite encountering an error. Set the error.
+     */
+    if (vs->verify_err != 0)
+        ret = vs->verify_err;
+
+    /*
+     * We have an exclusive lock on the handle, but we're swapping root pages in-and-out of that
+     * handle, and there's a race with eviction entering the tree and seeing an invalid root page.
+     * Eviction must work on trees being verified (else we'd have to do our own eviction), lock
+     * eviction out whenever we're loading a new root page. This function is called with eviction
+     * locked out, so we released the lock above and re-acquire it here.
+     */
+    WT_TRET(__wt_evict_file_exclusive_on(session));
+    WT_TRET(__wt_evict_file(session, WT_SYNC_DISCARD));
+
+done:
+err:
+    /* Unload the checkpoint. */
+    WT_TRET(bm->checkpoint_unload(bm, session));
+
+    return (ret);
+}
+
+/*
  * __wt_verify --
  *     Verify a file.
  */
@@ -408,12 +541,9 @@ __wt_verify(WT_SESSION_IMPL *session, const char *cfg[])
 {
     WT_BM *bm;
     WT_BTREE *btree;
-    WT_CELL_UNPACK_ADDR addr_unpack;
     WT_CKPT *ckptbase, *ckpt;
     WT_DECL_RET;
     WT_VSTUFF *vs, _vstuff;
-    size_t root_addr_size;
-    uint8_t root_addr[WT_ADDR_MAX_COOKIE];
     const char *name;
     bool bm_start, quit, skip_hs;
 
@@ -496,117 +626,11 @@ __wt_verify(WT_SESSION_IMPL *session, const char *cfg[])
         /* House-keeping between checkpoints. */
         __verify_checkpoint_reset(vs);
 
-        if (WT_VRFY_DUMP(vs)) {
-            WT_ERR(__wt_msg(session, "%s", WT_DIVIDER));
-            WT_ERR(__wt_msg(session, "%s, ckpt_name: %s", name, ckpt->name));
-        }
-
-        /* Load the checkpoint. */
-        WT_ERR(bm->checkpoint_load(
-          bm, session, ckpt->raw.data, ckpt->raw.size, root_addr, &root_addr_size, true));
-
-        /* Skip trees with no root page. */
-        if (root_addr_size != 0) {
-            WT_ERR(__wti_btree_tree_open(session, root_addr, root_addr_size));
-
-            if (WT_VRFY_DUMP(vs))
-                WT_ERR(__wt_msg(session, "Root:\n\t> addr: %s",
-                  __wt_addr_string(session, root_addr, root_addr_size, vs->tmp1)));
-
-            __wt_evict_file_exclusive_off(session);
-
-            /*
-             * Create a fake, unpacked parent cell for the tree based on the checkpoint information.
-             */
-            memset(&addr_unpack, 0, sizeof(addr_unpack));
-            WT_TIME_AGGREGATE_COPY(&addr_unpack.ta, &ckpt->ta);
-            if (ckpt->ta.prepare)
-                addr_unpack.ta.prepare = 1;
-            addr_unpack.raw = WT_CELL_ADDR_INT;
-
-            /* Only verify HS entries against the last checkpoint. */
-            vs->skip_hs = skip_hs || (ckpt + 1)->name != NULL;
-            vs->hs_checkpoint_name = ckpt->name;
-
-            /* Verify the tree. */
-            WT_WITH_PAGE_INDEX(
-              session, ret = __verify_tree(session, &btree->root, &addr_unpack, vs));
-
-            /* Account for the root page in the accumulated total block size. */
-            WT_TRET(__verify_disagg_accumulate_size(session, vs, ckpt->raw.data, ckpt->raw.size));
-
-#ifdef HAVE_DIAGNOSTIC
-            /* Validate the size of the btree. */
-            if (F_ISSET(btree, WT_BTREE_DISAGGREGATED) && ckpt->size != vs->total_block_size)
-                /*
-                 * FIXME-WT-18038: We are seeing mismatches due to nuanced reconciliation issues,
-                 * where bytes_total increments happen before the reconciliation panic boundary,
-                 * leaving us in an inconsistent state if reconciliation fails after the increment
-                 * but before completion. Only fail in diagnostic builds for now; enable this branch
-                 * in production builds once this is resolved.
-                 */
-                WT_ERR_MSG(session, WT_ERROR,
-                  "checkpoint size %" PRIu64 " does not match accumulated block size %" PRIu64,
-                  ckpt->size, vs->total_block_size);
-#endif
-
-            /*
-             * The checkpoints are in time-order, so the last one in the list is the most recent. If
-             * this is the most recent checkpoint, verify the history store against it, also verify
-             * page discard function if we're in disagg mode.
-             */
-            if (ret == 0 && (ckpt + 1)->name == NULL) {
-                if (F_ISSET(btree, WT_BTREE_DISAGGREGATED)) {
-                    /*
-                     * The page discard verification routine depends on get_page_ids being
-                     * implemented.
-                     */
-                    WT_BLOCK_DISAGG *block_disagg = (WT_BLOCK_DISAGG *)bm->block;
-                    if (block_disagg->plhandle->plh_get_page_ids != NULL && ckpt->raw.data != NULL)
-                        WT_TRET(__verify_page_discard(session, bm));
-                }
-
-                if (!skip_hs) {
-                    __wt_verbose(session, WT_VERB_VERIFY, "%s: verify against history store", name);
-                    WT_TRET_MSG(session, __wt_hs_verify_one(session, btree->id),
-                      "history store verification failed");
-                }
-                /*
-                 * We cannot error out here. If we got an error verifying the history store, we need
-                 * to follow through with reacquiring the exclusive call below. We'll error out
-                 * after that and unloading this checkpoint.
-                 */
-            }
-
-            /*
-             * If the read_corrupt mode was turned on, we may have continued traversing and
-             * verifying the pages of the tree despite encountering an error. Set the error.
-             */
-            if (vs->verify_err != 0)
-                ret = vs->verify_err;
-
-            /*
-             * We have an exclusive lock on the handle, but we're swapping root pages in-and-out of
-             * that handle, and there's a race with eviction entering the tree and seeing an invalid
-             * root page. Eviction must work on trees being verified (else we'd have to do our own
-             * eviction), lock eviction out whenever we're loading a new root page. This loop works
-             * because we are called with eviction locked out, so we release the lock at the top of
-             * the loop and re-acquire it here.
-             */
-            WT_TRET(__wt_evict_file_exclusive_on(session));
-            WT_TRET(__wt_evict_file(session, WT_SYNC_DISCARD));
-        }
-
-        /* Unload the checkpoint. */
-        WT_TRET(bm->checkpoint_unload(bm, session));
-
         /*
-         * We've finished one checkpoint's verification (verification, then eviction and checkpoint
-         * unload): if any errors occurred, quit. Done this way because otherwise we'd need at least
-         * two more state variables on error, one to know if we need to discard the tree from the
-         * cache and one to know if we need to unload the checkpoint.
+         * Load, verify and unload the checkpoint. The helper unloads the checkpoint on every path,
+         * so if any errors occurred we can quit directly.
          */
-        WT_ERR(ret);
+        WT_ERR(__verify_one_checkpoint(session, vs, ckpt, skip_hs, (ckpt + 1)->name == NULL));
 
         /* Display the tree shape. */
         if (vs->dump_layout)

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -493,12 +493,12 @@ __verify_one_checkpoint(
              */
             WT_BLOCK_DISAGG *block_disagg = (WT_BLOCK_DISAGG *)bm->block;
             if (block_disagg->plhandle->plh_get_page_ids != NULL && ckpt->raw.data != NULL)
-                WT_TRET(__verify_page_discard(session, bm));
+                WT_ERR(__verify_page_discard(session, bm));
         }
 
         if (!skip_hs) {
             __wt_verbose(session, WT_VERB_VERIFY, "%s: verify against history store", name);
-            WT_TRET_MSG(
+            WT_ERR_MSG(
               session, __wt_hs_verify_one(session, btree->id), "history store verification failed");
         }
     }

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -493,7 +493,7 @@ __verify_one_checkpoint(
 
         if (!skip_hs) {
             __wt_verbose(session, WT_VERB_VERIFY, "%s: verify against history store", name);
-            WT_ERR_MSG(
+            WT_ERR_MSG_CHK(
               session, __wt_hs_verify_one(session, btree->id), "history store verification failed");
         }
     }

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -419,10 +419,6 @@ __verify_one_checkpoint(
         WT_RET(__wt_msg(session, "%s, ckpt_name: %s", name, ckpt->name));
     }
 
-    /*
-     * Load the checkpoint. Once it is loaded every exit path must run through the unload at the err
-     * label.
-     */
     size_t root_addr_size;
     uint8_t root_addr[WT_ADDR_MAX_COOKIE];
     WT_RET(bm->checkpoint_load(
@@ -438,7 +434,10 @@ __verify_one_checkpoint(
         WT_ERR(__wt_msg(session, "Root:\n\t> addr: %s",
           __wt_addr_string(session, root_addr, root_addr_size, vs->tmp1)));
 
-    /* Enable eviction while verifying the tree; the err path re-acquires it under evict_off. */
+    /*
+     * We currently hold an exclusive lock which means eviction cannot work on that tree. Given we
+     * will walk all the pages, we need eviction to be enabled to manage the cache load.
+     */
     __wt_evict_file_exclusive_off(session);
     evict_off = true;
 
@@ -459,8 +458,8 @@ __verify_one_checkpoint(
 
     /*
      * Bail on a hard verification failure. In read_corrupt mode the tree verification returns
-     * success and stashes the error in vs->verify_err, so this doesn't fire; the remaining checks
-     * run and use WT_TRET so that error isn't masked before it is applied below.
+     * success and stashes the error, so this doesn't fire; the remaining checks run and use WT_TRET
+     * so that error isn't masked before it is applied below.
      */
     WT_ERR(ret);
 
@@ -625,10 +624,6 @@ __wt_verify(WT_SESSION_IMPL *session, const char *cfg[])
         /* House-keeping between checkpoints. */
         __verify_checkpoint_reset(vs);
 
-        /*
-         * Load, verify and unload the checkpoint. The helper unloads the checkpoint on every path,
-         * so if any errors occurred we can quit directly.
-         */
         WT_ERR(__verify_one_checkpoint(session, vs, ckpt, skip_hs, (ckpt + 1)->name == NULL));
 
         /* Display the tree shape. */

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -402,8 +402,7 @@ __wt_verify_disagg_database_size(WT_SESSION_IMPL *session)
 
 /*
  * __verify_one_checkpoint --
- *     Load, verify and unload a single checkpoint. The checkpoint is unloaded on every path once it
- *     has been loaded, so callers must not add error handling that jumps past the unload.
+ *     Load, verify and unload a single checkpoint.
  */
 static int
 __verify_one_checkpoint(
@@ -416,10 +415,12 @@ __verify_one_checkpoint(
     size_t root_addr_size;
     uint8_t root_addr[WT_ADDR_MAX_COOKIE];
     const char *name;
+    bool evict_off;
 
     btree = S2BT(session);
     bm = btree->bm;
     name = session->dhandle->name;
+    evict_off = false;
 
     if (WT_VRFY_DUMP(vs)) {
         WT_RET(__wt_msg(session, "%s", WT_DIVIDER));
@@ -437,22 +438,15 @@ __verify_one_checkpoint(
     if (root_addr_size == 0)
         goto done;
 
-    /*
-     * Eviction is still locked out, so the only cleanup a failure owes is the unload: WT_ERR can
-     * bail straight to the err label.
-     */
     WT_ERR(__wti_btree_tree_open(session, root_addr, root_addr_size));
 
     if (WT_VRFY_DUMP(vs))
         WT_ERR(__wt_msg(session, "Root:\n\t> addr: %s",
           __wt_addr_string(session, root_addr, root_addr_size, vs->tmp1)));
 
-    /*
-     * Enable eviction on the tree. From here until it is locked out again below, the err label is no
-     * longer a safe exit: it unloads the checkpoint but does not re-acquire the lock or discard the
-     * tree. Failures must be accumulated into ret so the eviction handshake still runs.
-     */
+    /* Enable eviction while verifying the tree; the err path re-acquires it under evict_off. */
     __wt_evict_file_exclusive_off(session);
+    evict_off = true;
 
     /* Create a fake, unpacked parent cell for the tree based on the checkpoint information. */
     memset(&addr_unpack, 0, sizeof(addr_unpack));
@@ -468,14 +462,18 @@ __verify_one_checkpoint(
     /* Verify the tree. */
     WT_WITH_PAGE_INDEX(session, ret = __verify_tree(session, &btree->root, &addr_unpack, vs));
 
+    /*
+     * Bail on a hard verification failure. In read_corrupt mode the tree verification returns
+     * success and stashes the error in vs->verify_err, so this doesn't fire; the remaining checks
+     * run and use WT_TRET so that error isn't masked before it is applied below.
+     */
+    WT_ERR(ret);
+
     /* Account for the root page in the accumulated total block size. */
     WT_TRET(__verify_disagg_accumulate_size(session, vs, ckpt->raw.data, ckpt->raw.size));
 
 #ifdef HAVE_DIAGNOSTIC
-    /*
-     * Validate the size of the btree. Eviction is enabled between here and the re-acquire below, so
-     * record the mismatch in ret without jumping; the eviction handshake must still run.
-     */
+    /* Validate the size of the btree. */
     if (F_ISSET(btree, WT_BTREE_DISAGGREGATED) && ckpt->size != vs->total_block_size)
         /*
          * FIXME-WT-18038: We are seeing mismatches due to nuanced reconciliation issues, where
@@ -509,11 +507,6 @@ __verify_one_checkpoint(
             WT_TRET_MSG(
               session, __wt_hs_verify_one(session, btree->id), "history store verification failed");
         }
-        /*
-         * We cannot error out here. If we got an error verifying the history store, we need to
-         * follow through with reacquiring the exclusive call below. We'll error out after that and
-         * unloading this checkpoint.
-         */
     }
 
     /*
@@ -523,18 +516,20 @@ __verify_one_checkpoint(
     if (vs->verify_err != 0)
         ret = vs->verify_err;
 
-    /*
-     * We have an exclusive lock on the handle, but we're swapping root pages in-and-out of that
-     * handle, and there's a race with eviction entering the tree and seeing an invalid root page.
-     * Eviction must work on trees being verified (else we'd have to do our own eviction), lock
-     * eviction out whenever we're loading a new root page. This function is called with eviction
-     * locked out, so we released the lock above and re-acquire it here.
-     */
-    WT_TRET(__wt_evict_file_exclusive_on(session));
-    WT_TRET(__wt_evict_file(session, WT_SYNC_DISCARD));
-
 done:
 err:
+    /*
+     * If eviction was enabled to verify the tree, re-acquire the exclusive lock and discard the
+     * tree before unloading the checkpoint. Eviction must work on trees being verified (else we'd
+     * have to do our own eviction), so we release the lock while verifying and lock it out again
+     * here. The discard must run while the lock is held and before the unload, as the tree's pages
+     * reference this checkpoint's block manager.
+     */
+    if (evict_off) {
+        WT_TRET(__wt_evict_file_exclusive_on(session));
+        WT_TRET(__wt_evict_file(session, WT_SYNC_DISCARD));
+    }
+
     /* Unload the checkpoint. */
     WT_TRET(bm->checkpoint_unload(bm, session));
 

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -435,8 +435,9 @@ __verify_one_checkpoint(
           __wt_addr_string(session, root_addr, root_addr_size, vs->tmp1)));
 
     /*
-     * We currently hold an exclusive lock which means eviction cannot work on that tree. Given we
-     * will walk all the pages, we need eviction to be enabled to manage the cache load.
+     * We currently hold an exclusive lock which means eviction cannot work on that tree. Eviction
+     * must work on trees being verified (else we'd have to do our own eviction), so we release the
+     * lock while verifying.
      */
     __wt_evict_file_exclusive_off(session);
     evict_off = true;
@@ -508,10 +509,8 @@ done:
 err:
     /*
      * If eviction was enabled to verify the tree, re-acquire the exclusive lock and discard the
-     * tree before unloading the checkpoint. Eviction must work on trees being verified (else we'd
-     * have to do our own eviction), so we release the lock while verifying and lock it out again
-     * here. The discard must run while the lock is held and before the unload, as the tree's pages
-     * reference this checkpoint's block manager.
+     * tree before unloading the checkpoint.The discard must run while the lock is held and before
+     * the unload, as the tree's pages reference this checkpoint's block manager.
      */
     if (evict_off) {
         WT_TRET(__wt_evict_file_exclusive_on(session));

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -408,19 +408,11 @@ static int
 __verify_one_checkpoint(
   WT_SESSION_IMPL *session, WT_VSTUFF *vs, WT_CKPT *ckpt, bool skip_hs, bool last_ckpt)
 {
-    WT_BM *bm;
-    WT_BTREE *btree;
-    WT_CELL_UNPACK_ADDR addr_unpack;
+    WT_BTREE *btree = S2BT(session);
+    WT_BM *bm = btree->bm;
     WT_DECL_RET;
-    size_t root_addr_size;
-    uint8_t root_addr[WT_ADDR_MAX_COOKIE];
-    const char *name;
-    bool evict_off;
-
-    btree = S2BT(session);
-    bm = btree->bm;
-    name = session->dhandle->name;
-    evict_off = false;
+    const char *name = session->dhandle->name;
+    bool evict_off = false;
 
     if (WT_VRFY_DUMP(vs)) {
         WT_RET(__wt_msg(session, "%s", WT_DIVIDER));
@@ -431,6 +423,8 @@ __verify_one_checkpoint(
      * Load the checkpoint. Once it is loaded every exit path must run through the unload at the err
      * label.
      */
+    size_t root_addr_size;
+    uint8_t root_addr[WT_ADDR_MAX_COOKIE];
     WT_RET(bm->checkpoint_load(
       bm, session, ckpt->raw.data, ckpt->raw.size, root_addr, &root_addr_size, true));
 
@@ -449,6 +443,7 @@ __verify_one_checkpoint(
     evict_off = true;
 
     /* Create a fake, unpacked parent cell for the tree based on the checkpoint information. */
+    WT_CELL_UNPACK_ADDR addr_unpack;
     memset(&addr_unpack, 0, sizeof(addr_unpack));
     WT_TIME_AGGREGATE_COPY(&addr_unpack.ta, &ckpt->ta);
     if (ckpt->ta.prepare)


### PR DESCRIPTION
## Summary
- Extract the per-checkpoint work in `__wt_verify` into a new `__verify_one_checkpoint` helper so the checkpoint is always unloaded via a cleanup label, fixing a leak where `WT_ERR` from `__wti_btree_tree_open` / the root dump message / the diagnostic size check jumped past `checkpoint_unload` (and, in the size-check case, left the `evict_disabled` refcount unbalanced).
- Move the eviction re-acquire + tree discard into the cleanup label under an `evict_off` guard, so every post-load exit path re-acquires the exclusive lock (mandatory refcount balance) and discards the tree before unloading the checkpoint.
- Add `WT_ERR(ret)` after `__verify_tree` to bail immediately on a hard failure; this is a no-op in `read_corrupt` mode (where the error is stashed in `vs->verify_err`), so the remaining checks still run.
- Keep `WT_TRET`/`WT_TRET_MSG` for the accumulate-size, page-discard, history-store, and cleanup calls: everything between `__verify_tree` and the `vs->verify_err` pickup must not jump, or the authoritative corruption error gets masked.

## Testing
- Full `cmake`/`ninja` build passes with `-DHAVE_DIAGNOSTIC=1` (both the diagnostic size-check branch and the non-diagnostic path compile clean under `-Werror -Weverything`).
- No behavior change intended on success paths; the fix is on the error/cleanup paths. Recommend running the verify Python suite and test/format before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)