### PR TITLE
WT-17902 Fix 1800s timeout on test_cursor12.test_cursor12.test_modify_many

### DIFF
--- a/test/suite/test_cursor12.py
+++ b/test/suite/test_cursor12.py
@@ -347,7 +347,7 @@ class test_cursor12(wttest.WiredTigerTestCase):
         orig = self.make_value('abcdefghijklmnopqrstuvwxyz')
         c.set_value(orig)
         self.assertEqual(c.update(), 0)
-        for i in range(0, 50000):
+        for i in range(0, 40000):
             new = self.make_value("".join([random.choice(string.digits) \
                 for i in range(5)]))
             orig = orig[:10] + new + orig[15:]


### PR DESCRIPTION
Reduce the number of uncommitted modifies on the same key in `test_modify_many` from 50k to 40k to prevent test timeouts.