### PR TITLE
WT-17978 Disable key HS validation for microbenchmark tests

### DIFF
--- a/bench/workgen/runner/microbenchmark_prefetch_off_verify.py
+++ b/bench/workgen/runner/microbenchmark_prefetch_off_verify.py
@@ -48,7 +48,8 @@ prefetch.session = prefetch.conn.open_session("")
 
 def run_workload():
     print("Start verifying...")
-    verify_op = Operation(Operation.OP_VERIFY, prefetch.table, "prefetch=(enabled=false)")
+    verify_op = Operation(Operation.OP_VERIFY, prefetch.table,
+      "session=(prefetch=(enabled=false)),verify=(skip_per_key_hs=true)")
     verify_thread = Thread(verify_op)
     verify_workload = Workload(prefetch.context, verify_thread)
     verify_workload.options.run_time = 300

--- a/bench/workgen/runner/microbenchmark_prefetch_on_verify.py
+++ b/bench/workgen/runner/microbenchmark_prefetch_on_verify.py
@@ -48,7 +48,8 @@ prefetch.session = prefetch.conn.open_session("")
 
 def run_workload():
     print("Start verifying...")
-    verify_op = Operation(Operation.OP_VERIFY, prefetch.table, "prefetch=(enabled=true)")
+    verify_op = Operation(Operation.OP_VERIFY, prefetch.table,
+      "session=(prefetch=(enabled=true)),verify=(skip_per_key_hs=true)")
     verify_thread = Thread(verify_op)
     verify_workload = Workload(prefetch.context, verify_thread)
     verify_workload.options.run_time = 300

--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -2719,19 +2719,26 @@ VerifyOperationInternal::parse_config(const std::string &config)
 
     WT_CONFIG_PARSER *cp = nullptr;
     WT_CONFIG_ITEM k, v;
+    int ret = 0;
 
-    if (wiredtiger_config_parser_open(nullptr, config.c_str(), config.length(), &cp) == 0) {
-        while (cp->next(cp, &k, &v) == 0) {
-            std::string key(k.str, k.len);
-            std::string val(v.str, v.len);
-            if (key == "session") {
-                verify_session_config = val;
-            } else if (key == "verify") {
-                verify_call_config = val;
-            }
-        }
-        cp->close(cp);
+    if ((ret = wiredtiger_config_parser_open(nullptr, config.c_str(), config.length(), &cp)) != 0)
+        THROW_ERRNO(ret, "Error opening config parser for verify op config: \"" << config << "\"");
+
+    while ((ret = cp->next(cp, &k, &v)) == 0) {
+        std::string key(k.str, k.len);
+        std::string val(v.str, v.len);
+        if (key == "session")
+            verify_session_config = val;
+        else if (key == "verify")
+            verify_call_config = val;
+        else
+            THROW("Unknown key \"" << key << "\" in verify op config: \"" << config << "\"");
     }
+    if (ret != WT_NOTFOUND)
+        THROW_ERRNO(ret, "Error parsing verify op config: \"" << config << "\"");
+    ret = cp->close(cp);
+    if (ret != 0)
+        THROW_ERRNO(ret, "Error closing config parser for verify op config");
 }
 
 Track::Track(bool latency_tracking)

--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -2677,7 +2677,8 @@ VerifyOperationInternal::run(ThreadRunner *runner, WT_SESSION *session)
         THROW_ERRNO(ret, "Error opening a session.");
 
     std::string uri = runner->_thread->_op._table._uri;
-    return (verify_session->verify(verify_session, uri.c_str(), nullptr));
+    return (verify_session->verify(verify_session, uri.c_str(),
+      verify_call_config.empty() ? nullptr : verify_call_config.c_str()));
 }
 
 uint64_t
@@ -2707,7 +2708,35 @@ TableOperationInternal::parse_config(const std::string &config)
 void
 VerifyOperationInternal::parse_config(const std::string &config)
 {
-    if (!config.empty())
+    /*
+     * Recognise two structured sub-configs in the op config string:
+     *   session=(...) -> passed to open_session()
+     *   verify=(...)  -> passed to session->verify()
+     * A bare config with neither key is treated as an open_session config.
+     */
+
+    if (config.empty())
+        return;
+
+    WT_CONFIG_PARSER *cp = nullptr;
+    WT_CONFIG_ITEM k, v;
+    bool split = false;
+
+    if (wiredtiger_config_parser_open(nullptr, config.c_str(), config.length(), &cp) == 0) {
+        while (cp->next(cp, &k, &v) == 0) {
+            std::string key(k.str, k.len);
+            std::string val(v.str, v.len);
+            if (key == "session") {
+                verify_session_config = val;
+                split = true;
+            } else if (key == "verify") {
+                verify_call_config = val;
+                split = true;
+            }
+        }
+        cp->close(cp);
+    }
+    if (!split)
         verify_session_config = config;
 }
 

--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -2677,8 +2677,7 @@ VerifyOperationInternal::run(ThreadRunner *runner, WT_SESSION *session)
         THROW_ERRNO(ret, "Error opening a session.");
 
     std::string uri = runner->_thread->_op._table._uri;
-    return (verify_session->verify(verify_session, uri.c_str(),
-      verify_call_config.empty() ? nullptr : verify_call_config.c_str()));
+    return (verify_session->verify(verify_session, uri.c_str(), verify_call_config.c_str()));
 }
 
 uint64_t

--- a/bench/workgen/workgen.cpp
+++ b/bench/workgen/workgen.cpp
@@ -2712,7 +2712,6 @@ VerifyOperationInternal::parse_config(const std::string &config)
      * Recognise two structured sub-configs in the op config string:
      *   session=(...) -> passed to open_session()
      *   verify=(...)  -> passed to session->verify()
-     * A bare config with neither key is treated as an open_session config.
      */
 
     if (config.empty())
@@ -2720,7 +2719,6 @@ VerifyOperationInternal::parse_config(const std::string &config)
 
     WT_CONFIG_PARSER *cp = nullptr;
     WT_CONFIG_ITEM k, v;
-    bool split = false;
 
     if (wiredtiger_config_parser_open(nullptr, config.c_str(), config.length(), &cp) == 0) {
         while (cp->next(cp, &k, &v) == 0) {
@@ -2728,16 +2726,12 @@ VerifyOperationInternal::parse_config(const std::string &config)
             std::string val(v.str, v.len);
             if (key == "session") {
                 verify_session_config = val;
-                split = true;
             } else if (key == "verify") {
                 verify_call_config = val;
-                split = true;
             }
         }
         cp->close(cp);
     }
-    if (!split)
-        verify_session_config = config;
 }
 
 Track::Track(bool latency_tracking)

--- a/bench/workgen/workgen_int.h
+++ b/bench/workgen/workgen_int.h
@@ -317,10 +317,13 @@ struct SleepOperationInternal : OperationInternal {
 
 struct VerifyOperationInternal : OperationInternal {
     std::string verify_session_config;
+    std::string verify_call_config;
 
-    VerifyOperationInternal() : OperationInternal(), verify_session_config() {}
+    VerifyOperationInternal() :
+        OperationInternal(), verify_session_config(), verify_call_config() {}
     VerifyOperationInternal(const VerifyOperationInternal &other) :
-        OperationInternal(other), verify_session_config(other.verify_session_config) {}
+        OperationInternal(other), verify_session_config(other.verify_session_config),
+        verify_call_config(other.verify_call_config) {}
     virtual void parse_config(const std::string &config);
     virtual int run(ThreadRunner *runner, WT_SESSION *session);
 };


### PR DESCRIPTION
Added nested config parsing in `workgen.cpp` for `verify` to allow configuration for `open_session` and `session->verify`.

Use `skip_per_key_hs` config to skip per-key HS validation. for `prefech_on_verify and prefectch_off_verify`.

Fixes regression from re-enabling history store verification. This evergreen [patch](https://spruce.corp.mongodb.com/version/6a58251af6311c0007133eb4/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) for this commit shows the numbers going back to normal. 

prefetch-off-verify, blocks_read:
10,534,221 pre-regression
975,460 post-regression
10,404,649 - this PR

prefetch-on-verify, blocks_read
18,468,356 pre-regression
975,415 post-regression
18,458,793 this PR