### PR TITLE
WT-17574 Align Switch Mode with the Evergreen Timeout Window

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1759,7 +1759,7 @@ variables:
       - func: "compile wiredtiger"
       - func: "format test script"
         vars:
-          format_test_script_args: -t 180 -c ../../../test/format/CONFIG.disagg -- disagg.mode=switch runs.timer=5:10
+          format_test_script_args: -t 120 -c ../../../test/format/CONFIG.disagg -- disagg.mode=switch runs.timer=5:10
           num_jobs: 1 # FIXME-WT-16134 PALite cannot run multiple jobs. PALI will address this.
       - func: "format test disagg"
         vars:
@@ -1774,7 +1774,7 @@ variables:
       - func: "compile wiredtiger"
       - func: "format test script"
         vars:
-          format_test_script_args: -t 180 -c ../../../test/format/CONFIG.disagg -- disagg.mode=switch ops.verify=1 runs.mirror=1 table1.runs.source=table table1.disagg.enabled=0 runs.timer=5:10
+          format_test_script_args: -t 120 -c ../../../test/format/CONFIG.disagg -- disagg.mode=switch ops.verify=1 runs.mirror=1 table1.runs.source=table table1.disagg.enabled=0 runs.timer=5:10
           num_jobs: 1 # FIXME-WT-16134 PALite cannot run multiple jobs. PALI will address this.
       - func: "format test disagg"
         vars:


### PR DESCRIPTION
In the worst-case scenario, it's very easy for Switch Mode to exceed the 6-hour limit. It already runs 3 hours of fixed testing, followed by five runs, each of which can take 20–30 minutes, adding up to ~3 hours or more.  test/format (switch) timing isn't perfectly accurate, which can result in unexpected timeouts.

Reducing the runtime by about an hour is a better approach. We already have extensive switch Mode coverage across nearly 50 tasks per commit, so increasing the timeout doesn't seem justified.
