### PR TITLE
WT-18096 Add mongodb-9.0 to compatibility tests and documentation

### DIFF
--- a/test/compatibility/compatibility_test_for_releases.sh
+++ b/test/compatibility/compatibility_test_for_releases.sh
@@ -73,13 +73,13 @@ is_major_release()
 bflag()
 {
     # Return if the branch's format command takes the -B flag for backward compatibility.
-    test "$1" = "develop" && echo "-B "
+    test "$1" = "develop" && echo "-B"
     test "$1" = "mongodb-9.0" && echo "-B"
     test "$1" = "mongodb-8.3" && echo "-B"
     test "$1" = "mongodb-8.2" && echo "-B"
     test "$1" = "mongodb-8.0" && echo "-B"
-    test "$1" = "mongodb-7.0" && echo "-B "
-    test "$1" = "mongodb-6.0" && echo "-B "
+    test "$1" = "mongodb-7.0" && echo "-B"
+    test "$1" = "mongodb-6.0" && echo "-B"
     return 0
 }
 

--- a/test/compatibility/compatibility_test_for_releases.sh
+++ b/test/compatibility/compatibility_test_for_releases.sh
@@ -74,6 +74,7 @@ bflag()
 {
     # Return if the branch's format command takes the -B flag for backward compatibility.
     test "$1" = "develop" && echo "-B "
+    test "$1" = "mongodb-9.0" && echo "-B"
     test "$1" = "mongodb-8.3" && echo "-B"
     test "$1" = "mongodb-8.2" && echo "-B"
     test "$1" = "mongodb-8.0" && echo "-B"
@@ -743,6 +744,7 @@ upgrade_to_latest=false
 # then the branch name itself will be used for the checkout
 declare -A gittags
 gittags['develop']="develop"
+gittags['mongodb-9.0']="mongodb-9.0"
 gittags['mongodb-8.3']="mongodb-8.3"
 gittags['mongodb-8.0']="mongodb-8.0"
 gittags['mongodb-7.0']="mongodb-7.0"

--- a/test/compatibility/meta/versions.sh
+++ b/test/compatibility/meta/versions.sh
@@ -30,21 +30,21 @@
 
 # Currently this is a temporary setup for python testsuite
 # This will be merged with the following variables in the future
-export SUITE_RELEASE_BRANCHES="develop mongodb-8.3 mongodb-8.2 mongodb-8.0 mongodb-7.0 mongodb-6.0"
+export SUITE_RELEASE_BRANCHES="develop mongodb-9.0 mongodb-8.3 mongodb-8.2 mongodb-8.0 mongodb-7.0 mongodb-6.0"
 
 # This array is used to configure the release branches we'd like to use for testing the importing
 # of files created in previous versions of WiredTiger.
-export IMPORT_RELEASE_BRANCHES="develop mongodb-8.3 mongodb-8.2 mongodb-8.0 mongodb-7.0 mongodb-6.0"
+export IMPORT_RELEASE_BRANCHES="develop mongodb-9.0 mongodb-8.3 mongodb-8.2 mongodb-8.0 mongodb-7.0 mongodb-6.0"
 
-export NEWER_RELEASE_BRANCHES="develop mongodb-8.3 mongodb-8.2 mongodb-8.0 mongodb-7.0 mongodb-6.0"
+export NEWER_RELEASE_BRANCHES="develop mongodb-9.0 mongodb-8.3 mongodb-8.2 mongodb-8.0 mongodb-7.0 mongodb-6.0"
 
 # This array is used to configure the release branches we'd like to run patch version
 # upgrade/downgrade test.
-export PATCH_VERSION_UPGRADE_DOWNGRADE_RELEASE_BRANCHES="mongodb-8.3 mongodb-8.2 mongodb-8.0 mongodb-7.0 mongodb-6.0"
+export PATCH_VERSION_UPGRADE_DOWNGRADE_RELEASE_BRANCHES="mongodb-9.0 mongodb-8.3 mongodb-8.2 mongodb-8.0 mongodb-7.0 mongodb-6.0"
 
 # This array is used to configure the release branches we'd like to run test checkpoint
 # upgrade/downgrade test.
-export TEST_CHECKPOINT_RELEASE_BRANCHES="develop mongodb-8.3 mongodb-8.2 mongodb-8.0 mongodb-7.0 mongodb-6.0"
+export TEST_CHECKPOINT_RELEASE_BRANCHES="develop mongodb-9.0 mongodb-8.3 mongodb-8.2 mongodb-8.0 mongodb-7.0 mongodb-6.0"
 
 # This array is used to configure the release branches we'd like to run upgrade to latest test.
-export UPGRADE_TO_LATEST_UPGRADE_DOWNGRADE_RELEASE_BRANCHES="mongodb-8.3 mongodb-8.2 mongodb-8.0 mongodb-7.0 mongodb-6.0"
+export UPGRADE_TO_LATEST_UPGRADE_DOWNGRADE_RELEASE_BRANCHES="mongodb-9.0 mongodb-8.3 mongodb-8.2 mongodb-8.0 mongodb-7.0 mongodb-6.0"

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -612,27 +612,13 @@ functions:
             echo "Checking out branch $branch ..."
             git checkout $branch
 
-            # Java API is removed in newer branches via WT-6675.
-            if [ $branch == "mongodb-4.2" ]; then
-              pushd build_posix
-              bash reconf
-              ../configure CFLAGS="-DMIGHT_NOT_RUN -Wno-error" --enable-java --enable-python --enable-strict
-              (cd lang/python && make ../../../lang/python/wiredtiger_wrap.c)
-              (cd lang/java && make ../../../lang/java/wiredtiger_wrap.c)
-            elif [ $branch == "mongodb-5.0" ] || [ $branch == "mongodb-4.4" ]; then
-              pushd build_posix
-              bash reconf
-              ../configure CFLAGS="-DMIGHT_NOT_RUN -Wno-error" --enable-python --enable-strict
-              (cd lang/python && make ../../../lang/python/wiredtiger_wrap.c)
-            else
-              . test/evergreen/find_cmake.sh
-              if [ -d cmake_build ]; then rm -r cmake_build; fi
-              mkdir -p cmake_build
-              pushd cmake_build
-              # Adding -DENABLE_PYTHON=1 -DENABLE_STRICT=1 as 6.0 does not default these like develop.
-              $CMAKE -DCMAKE_C_FLAGS="-DMIGHT_NOT_RUN -Wno-error" -DENABLE_PYTHON=1 -DENABLE_STRICT=1 ../.
-              make -C lang/python -j ${num_jobs}
-            fi
+            . test/evergreen/find_cmake.sh
+            if [ -d cmake_build ]; then rm -r cmake_build; fi
+            mkdir -p cmake_build
+            pushd cmake_build
+            # Adding -DENABLE_PYTHON=1 -DENABLE_STRICT=1 as 6.0 does not default these like develop.
+            $CMAKE -DCMAKE_C_FLAGS="-DMIGHT_NOT_RUN -Wno-error" -DENABLE_PYTHON=1 -DENABLE_STRICT=1 ../.
+            make -C lang/python -j ${num_jobs}
             # Pop to root project directory.
             popd
             # Generate WiredTiger documentation.

--- a/test/evergreen_develop.yml
+++ b/test/evergreen_develop.yml
@@ -72,7 +72,7 @@ buildvariants:
   - ubuntu2004-test
   expansions:
     ENABLE_TCMALLOC: 0
-    doc_update_branches: develop,mongodb-8.3,mongodb-8.2,mongodb-8.0,mongodb-7.0,mongodb-6.0,mongodb-5.0,mongodb-4.4,mongodb-4.2
+    doc_update_branches: develop,mongodb-9.0,mongodb-8.3,mongodb-8.2,mongodb-8.0,mongodb-7.0,mongodb-6.0
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo`" | bc)
   tasks:
     - name: doc-update


### PR DESCRIPTION
## Summary
Adds support for the newly created `mongodb-9.0` branch in the compatibility test suite and documentation publishing.

## Changes
- `test/compatibility/meta/versions.sh` — inserted `mongodb-9.0` immediately after `develop` in all six release-branch arrays.
- `test/compatibility/compatibility_test_for_releases.sh` — added `mongodb-9.0` to `bflag()` (`-B`) and the `gittags` map, treating 9.0 like `develop`. `bcopy()` needs no entry (9.0 is newer than 8.0, so it correctly returns false).
- `test/evergreen_develop.yml` — added `mongodb-9.0` to `doc_update_branches`. Also cleaned up a few EOL release branches.

## Testing
`./compatibility_test_for_releases.sh -T` passes with mongodb-9.0 included in the generated pair coverage.