### PR TITLE
WT-18100 Include outdated dhandles in cache verbose dump accounting

### DIFF
--- a/src/evict/evict_verbose.c
+++ b/src/evict/evict_verbose.c
@@ -146,7 +146,7 @@ __verbose_dump_cache_apply(WT_SESSION_IMPL *session, uint64_t *total_bytesp,
 
         /* Skip if the tree is marked discarded by another thread. */
         if (!WT_DHANDLE_BTREE(dhandle) || !F_ISSET(dhandle, WT_DHANDLE_OPEN) ||
-          F_ISSET(dhandle, WT_DHANDLE_DISCARD | WT_DHANDLE_OUTDATED))
+          F_ISSET(dhandle, WT_DHANDLE_DISCARD))
             continue;
 
         WT_WITH_DHANDLE(session, dhandle,


### PR DESCRIPTION
The cache verbose dump (__verbose_dump_cache_apply in src/evict/evict_verbose.c) skips any btree dhandle flagged WT_DHANDLE_OUTDATED in addition to WT_DHANDLE_DISCARD.

An outdated handle (WT_DHANDLE_OUTDATED, 0x400) is still open and can hold cached content, so excluding it from the traversal under-counts the total/dirty/updates byte totals reported by the diagnostic dump. Only genuinely discarded handles (WT_DHANDLE_DISCARD) should be skipped.