### PR TITLE
WT-18105 Omit prefetch config in test/format when prefetch off

### DIFF
--- a/test/format/wts.c
+++ b/test/format/wts.c
@@ -403,8 +403,9 @@ configure_tiered_storage(const char *home, char **p, size_t max, char *ext_cfg, 
 static void
 configure_prefetch(char **p, size_t max)
 {
-    CONFIG_APPEND(*p, ",prefetch=(available=%s,default=%s)", GV(PREFETCH) ? "true" : "false",
-      GV(PREFETCH_DEFAULT) ? "true" : "false");
+    if (GV(PREFETCH))
+        CONFIG_APPEND(
+          *p, ",prefetch=(available=true,default=%s)", GV(PREFETCH_DEFAULT) ? "true" : "false");
 }
 
 /*


### PR DESCRIPTION
test/format was unconditionally appending `prefetch=(available=...,default=...)` to the connection config. In `compatibility-test-dirty-restart`, older WT builds (e.g. release 10.0.0) do not know the `prefetch` configuration key and reject `wiredtiger_open` with `unknown configuration key: 'prefetch'`, resulting in the observed segfaults. Only append the prefetch config when `PREFETCH` is enabled so older builds are unaffected.
