### PR TITLE
WT-12734 Atomically read WT_LSN fields in log server functions

### DIFF
--- a/src/log/log.c
+++ b/src/log/log.c
@@ -364,7 +364,7 @@ __wt_log_force_sync(WT_SESSION_IMPL *session, WT_LSN *min_lsn)
      * current one and advance the LSN. Signal the worker thread because we know the LSN has moved
      * into a later log file and there should be a log file ready to close.
      */
-    while (log->sync_lsn.l.file < min_lsn->l.file) {
+    while (__wt_lsn_file(&log->sync_lsn) < __wt_lsn_file(min_lsn)) {
         __wt_cond_signal(session, S2C(session)->log_mgr.file.cond);
         __wt_cond_wait(session, log->log_sync_cond, 10 * WT_THOUSAND, NULL);
     }

--- a/src/log/log_mgr.c
+++ b/src/log/log_mgr.c
@@ -398,8 +398,9 @@ __compute_min_lognum(WT_SESSION_IMPL *session, WTI_LOG *log, uint32_t backup_fil
      * backup or the checkpoint LSN. Otherwise we want the minimum of the last log file written to
      * disk and the checkpoint LSN.
      */
-    min_lognum = backup_file == 0 ? WT_MIN(log->ckpt_lsn.l.file, log->sync_lsn.l.file) :
-                                    WT_MIN(log->ckpt_lsn.l.file, backup_file);
+    min_lognum = backup_file == 0 ?
+      WT_MIN(__wt_lsn_file(&log->ckpt_lsn), __wt_lsn_file(&log->sync_lsn)) :
+      WT_MIN(__wt_lsn_file(&log->ckpt_lsn), backup_file);
 
     __wt_readlock(session, &conn->log_mgr.debug_log_retention_lock);
 
@@ -435,8 +436,8 @@ __compute_min_lognum(WT_SESSION_IMPL *session, WTI_LOG *log, uint32_t backup_fil
           " sync file %" PRIu32 " backup_file %" PRIu32 " debug_log count%" PRIu32
           " old min %" PRIu32,
           (uintmax_t)ts.tv_sec, (uintmax_t)ts.tv_nsec / WT_THOUSAND, min_lognum,
-          log->ckpt_lsn.l.file, log->sync_lsn.l.file, backup_file, conn->debug.log_cnt,
-          log->min_fileid));
+          __wt_lsn_file(&log->ckpt_lsn), __wt_lsn_file(&log->sync_lsn), backup_file,
+          conn->debug.log_cnt, log->min_fileid));
         log->min_fileid = min_lognum;
     }
 
@@ -897,7 +898,7 @@ __log_wrlsn_server(void *arg)
             __wti_log_wrlsn(session, &yield);
         else
             WT_STAT_CONN_INCR(session, log_write_lsn_skip);
-        prev = log->alloc_lsn;
+        WT_ASSIGN_LSN(&prev, &log->alloc_lsn);
         did_work = (yield == 0);
 
         /*

--- a/test/evergreen/tsan_warnings.supp
+++ b/test/evergreen/tsan_warnings.supp
@@ -11,11 +11,6 @@ race:src/support/stat.c
 # around usages of these functions.
 race:__wt_tsan_suppress_*
 
-# FIXME-WT-12734 this function copies an 8 byte struct which needs further investigation.
-race:__log_wrlsn_server
-race:__wt_log_force_sync
-race:__compute_min_lognum
-
 # FIXME-WT-12611 CONNECTION_API_CALL contains a data race that touches the session array, but the number of macro
 # calls makes diagnosing this very hard. For now suppress the surrounding function and handle this in a separate ticket.
 race:__conn_open_session

--- a/test/evergreen/tsan_warnings.supp
+++ b/test/evergreen/tsan_warnings.supp
@@ -11,6 +11,10 @@ race:src/support/stat.c
 # around usages of these functions.
 race:__wt_tsan_suppress_*
 
+# FIXME-WT-16301 __log_newfile mutates log manager state (log->fileid, alloc_lsn) without synchronizing
+# with concurrent readers such as __compute_min_lognum and __log_fsync_file.
+race:__log_newfile
+
 # FIXME-WT-12611 CONNECTION_API_CALL contains a data race that touches the session array, but the number of macro
 # calls makes diagnosing this very hard. For now suppress the surrounding function and handle this in a separate ticket.
 race:__conn_open_session


### PR DESCRIPTION
## Problem

`__log_wrlsn_server`, `__wt_log_force_sync` and `__compute_min_lognum` read the log manager's `WT_LSN` fields (`alloc_lsn`, `sync_lsn`, `ckpt_lsn`) with plain struct/field accesses, while the log worker threads write those same fields atomically via `WT_ASSIGN_LSN` (the 64-bit `file_offset`). TSan flagged these as data races, and they were being hidden behind broad, function-level suppressions.

## Solution

Route the racy reads through the existing atomic accessors:
- `__log_wrlsn_server`: replace the raw `prev = log->alloc_lsn;` struct copy with `WT_ASSIGN_LSN(&prev, &log->alloc_lsn)`.
- `__wt_log_force_sync` and `__compute_min_lognum`: read `.l.file` via `__wt_lsn_file()` (a relaxed atomic load) instead of direct field access.

The three `FIXME-WT-12734` suppressions (`__log_wrlsn_server`, `__wt_log_force_sync`, `__compute_min_lognum`) are removed.

## Reviewer notes

- Removing the broad `__compute_min_lognum` suppression exposed a **distinct, pre-existing** race: `__log_newfile` mutates `log->fileid` (and `alloc_lsn`) without synchronizing with concurrent readers. That is unrelated to the `WT_LSN` copy fixed here and is tracked separately by WT-16301, so it is handled with a narrow `race:__log_newfile` suppression rather than fixed in this PR. This is deliberately tighter than the old reader-side suppression — future genuine races in `__compute_min_lognum` unrelated to log-file creation will still be caught.
- Commits are split for review: (1) the source fix, (2) suppression removal, (3) the WT-16301 suppression.
