### PR TITLE
POC: elide table: dhandle for simple layered tables

### DIFF
--- a/src/conn/conn_sweep.c
+++ b/src/conn/conn_sweep.c
@@ -41,6 +41,13 @@ __sweep_file_dhandle_check_and_reset_tod(WT_SESSION_IMPL *session, WT_DATA_HANDL
      */
     table = (WT_TABLE *)dhandle;
     if (table->is_simple && table->cg_complete) {
+        /*
+         * Layered sources are never swept. Pinning the table dhandle to them would retain the table
+         * handle for the life of the connection; allow those table handles to expire instead.
+         */
+        if (WT_PREFIX_MATCH(table->cgroups[0]->source, "layered:"))
+            return (WT_ERROR_LOG_ADD(WT_NOTFOUND));
+
         ret = __wt_conn_dhandle_find(session, table->cgroups[0]->source, NULL);
 
         /*

--- a/src/cursor/cur_table.c
+++ b/src/cursor/cur_table.c
@@ -1004,6 +1004,30 @@ __wt_curtable_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner, 
     tablename = uri;
     WT_PREFIX_SKIP_REQUIRED(session, tablename, "table:");
     columns = strchr(tablename, '(');
+
+    /*
+     * Simple layered tables: open the layered source from metadata without taking a table dhandle.
+     * Layered dhandles are never swept, so holding a table dhandle pinned to them would retain the
+     * table handle for the life of the connection.
+     */
+    if (columns == NULL) {
+        char *layered_source;
+
+        layered_source = NULL;
+        ret = __wt_schema_simple_layered_source(session, uri, &layered_source);
+        if (ret == 0) {
+            ret = __wt_open_cursor(session, layered_source, owner, cfg, cursorp);
+            __wt_free(session, layered_source);
+            if (ret == 0) {
+                cursor = *cursorp;
+                __wt_free(session, cursor->uri);
+                WT_TRET(__wt_strdup(session, uri, &cursor->uri));
+            }
+            return (ret);
+        }
+        WT_RET_NOTFOUND_OK(ret);
+    }
+
     if (columns == NULL)
         WT_RET(__wt_schema_get_table_uri(session, uri, false, 0, &table));
     else {

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -1011,6 +1011,8 @@ extern int __wt_schema_range_truncate(WT_TRUNCATE_INFO *trunc_info)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_schema_release_table(WT_SESSION_IMPL *session, WT_TABLE **tablep)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_schema_simple_layered_source(WT_SESSION_IMPL *session, const char *uri,
+  char **sourcep) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_schema_tiered_shared_colgroup_name(WT_SESSION_IMPL *session, const char *tablename,
   bool active, WT_ITEM *buf) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_schema_truncate(WT_SESSION_IMPL *session, const char *uri, const char *cfg[])

--- a/src/schema/schema_util.c
+++ b/src/schema/schema_util.c
@@ -265,8 +265,7 @@ __wt_schema_simple_layered_source(WT_SESSION_IMPL *session, const char *uri, cha
     WT_ERR(__wt_metadata_search(session, cgname->data, &cgconf));
     WT_ERR(__wt_config_getones(session, cgconf, "source", &cval));
     /* The column-group source must be a layered: URI. */
-    if (cval.len <= strlen("layered:") ||
-      strncmp(cval.str, "layered:", strlen("layered:")) != 0) {
+    if (cval.len <= strlen("layered:") || strncmp(cval.str, "layered:", strlen("layered:")) != 0) {
         ret = WT_NOTFOUND;
         goto err;
     }

--- a/src/schema/schema_util.c
+++ b/src/schema/schema_util.c
@@ -236,11 +236,11 @@ __wt_schema_simple_layered_source(WT_SESSION_IMPL *session, const char *uri, cha
 
     /* Layered tables must say so in their table metadata. */
     ret = __wt_config_getones(session, tableconf, "type", &cval);
-    WT_ERR_NOTFOUND_OK(ret, false);
-    if (ret == WT_NOTFOUND || !WT_CONFIG_LIT_MATCH("layered", cval)) {
+    if (ret == WT_NOTFOUND || (ret == 0 && !WT_CONFIG_LIT_MATCH("layered", cval))) {
         ret = WT_NOTFOUND;
         goto err;
     }
+    WT_ERR(ret);
 
     /* Same simplicity predicate as __wt_is_simple_table: no named columns. */
     WT_ERR(__wt_config_getones(session, tableconf, "columns", &colconf));
@@ -265,7 +265,8 @@ __wt_schema_simple_layered_source(WT_SESSION_IMPL *session, const char *uri, cha
     WT_ERR(__wt_metadata_search(session, cgname->data, &cgconf));
     WT_ERR(__wt_config_getones(session, cgconf, "source", &cval));
     /* The column-group source must be a layered: URI. */
-    if (cval.len <= strlen("layered:") || strncmp(cval.str, "layered:", strlen("layered:")) != 0) {
+    if (cval.len <= strlen("layered:") ||
+      strncmp(cval.str, "layered:", strlen("layered:")) != 0) {
         ret = WT_NOTFOUND;
         goto err;
     }

--- a/src/schema/schema_util.c
+++ b/src/schema/schema_util.c
@@ -210,6 +210,76 @@ __wt_is_simple_table(WT_SESSION_IMPL *session, WT_CONFIG_ITEM *colconf, bool *is
 }
 
 /*
+ * __wt_schema_simple_layered_source --
+ *     Metadata-only probe: if uri is a simple table: with type=layered, copy its underlying layered
+ *     URI. Returns WT_NOTFOUND when the table is missing or not a simple layered table so callers
+ *     can fall back to the normal table-dhandle path.
+ */
+int
+__wt_schema_simple_layered_source(WT_SESSION_IMPL *session, const char *uri, char **sourcep)
+{
+    WT_CONFIG cparser;
+    WT_CONFIG_ITEM ckey, colconf, cval;
+    WT_DECL_ITEM(cgname);
+    WT_DECL_RET;
+    char *cgconf, *tableconf;
+    const char *tablename;
+    bool is_simple;
+
+    *sourcep = NULL;
+    cgconf = tableconf = NULL;
+
+    if (!WT_PREFIX_MATCH(uri, "table:"))
+        return (WT_NOTFOUND);
+
+    WT_RET(__wt_metadata_search(session, uri, &tableconf));
+
+    /* Layered tables must say so in their table metadata. */
+    ret = __wt_config_getones(session, tableconf, "type", &cval);
+    WT_ERR_NOTFOUND_OK(ret, false);
+    if (ret == WT_NOTFOUND || !WT_CONFIG_LIT_MATCH("layered", cval)) {
+        ret = WT_NOTFOUND;
+        goto err;
+    }
+
+    /* Same simplicity predicate as __wt_is_simple_table: no named columns. */
+    WT_ERR(__wt_config_getones(session, tableconf, "columns", &colconf));
+    WT_ERR(__wt_is_simple_table(session, &colconf, &is_simple));
+    if (!is_simple) {
+        ret = WT_NOTFOUND;
+        goto err;
+    }
+
+    /* Named column groups are not simple; refuse those here. */
+    WT_ERR(__wt_config_getones(session, tableconf, "colgroups", &colconf));
+    __wt_config_subinit(session, &cparser, &colconf);
+    if ((ret = __wt_config_next(&cparser, &ckey, &cval)) == 0) {
+        ret = WT_NOTFOUND;
+        goto err;
+    }
+    WT_ERR_NOTFOUND_OK(ret, false);
+
+    tablename = uri + strlen("table:");
+    WT_ERR(__wt_scr_alloc(session, 0, &cgname));
+    WT_ERR(__wt_buf_fmt(session, cgname, "colgroup:%s", tablename));
+    WT_ERR(__wt_metadata_search(session, cgname->data, &cgconf));
+    WT_ERR(__wt_config_getones(session, cgconf, "source", &cval));
+    /* The column-group source must be a layered: URI. */
+    if (cval.len <= strlen("layered:") || strncmp(cval.str, "layered:", strlen("layered:")) != 0) {
+        ret = WT_NOTFOUND;
+        goto err;
+    }
+
+    WT_ERR(__wt_strndup(session, cval.str, cval.len, sourcep));
+
+err:
+    __wt_scr_free(session, &cgname);
+    __wt_free(session, cgconf);
+    __wt_free(session, tableconf);
+    return (ret);
+}
+
+/*
  * __wti_debug_crash_if_flag_set --
  *     Crash during schema operations for debugging purposes.
  */

--- a/test/suite/test_layered_dhandle02.py
+++ b/test/suite/test_layered_dhandle02.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# test_layered_dhandle02.py
+# Simple table: + type=layered cursors must not retain a table: dhandle. The hot
+# path opens layered: from metadata, and sweep must not pin table: to the
+# immortal layered handle.
+
+import time
+import wttest
+from helper_disagg import disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
+from wiredtiger import stat
+
+@disagg_test_class
+class test_layered_dhandle02(wttest.WiredTigerTestCase):
+    uri = 'table:test_layered_dhandle02'
+    create_config = 'key_format=S,value_format=S,block_manager=disagg,type=layered'
+
+    conn_base_config = 'create,statistics=(all),' + \
+        'file_manager=(close_idle_time=1,close_scan_interval=1,close_handle_minimum=0),'
+    conn_config = conn_base_config + 'disaggregated=(role="leader")'
+
+    disagg_storages = gen_disagg_storages(disagg_only=True)
+    scenarios = make_scenarios(disagg_storages)
+
+    def get_stat(self, field):
+        c = self.session.open_cursor('statistics:', None, 'statistics=(fast)')
+        value = c[field][2]
+        c.close()
+        return value
+
+    def wait_for_table_dhandles(self, expect, timeout=20):
+        for _ in range(timeout * 2):
+            # Drop session-cached references that would keep the table handle alive.
+            self.session.reset()
+            if self.get_stat(stat.conn.dh_conn_handle_table_count) == expect:
+                return
+            time.sleep(0.5)
+        self.fail('timed out waiting for dh_conn_handle_table_count == %d (have %d)' % (
+            expect, self.get_stat(stat.conn.dh_conn_handle_table_count)))
+
+    def test_simple_layered_elides_table_dhandle(self):
+        table_before = self.get_stat(stat.conn.dh_conn_handle_table_count)
+        layered_before = self.get_stat(stat.conn.dh_conn_handle_layered_count)
+
+        # Create on a disposable session so its dhandle cache is not retained.
+        s = self.conn.open_session()
+        s.create(self.uri, self.create_config)
+        s.close()
+
+        c = self.session.open_cursor(self.uri)
+        self.assertEqual(c.uri, self.uri)
+        c['a'] = 'b'
+        self.assertEqual(c['a'], 'b')
+        c.close()
+
+        # Hot path should have opened the layered handle without leaving a table handle in use.
+        self.assertEqual(
+            self.get_stat(stat.conn.dh_conn_handle_layered_count), layered_before + 1)
+
+        # Create briefly opens a table handle; sweep must be allowed to reclaim it even while
+        # the layered handle remains open.
+        self.wait_for_table_dhandles(table_before)
+
+        # Cursor still works through table: after the table dhandle is gone.
+        c = self.session.open_cursor(self.uri)
+        self.assertEqual(c['a'], 'b')
+        c['c'] = 'd'
+        c.close()
+        self.wait_for_table_dhandles(table_before)
+        self.assertEqual(
+            self.get_stat(stat.conn.dh_conn_handle_layered_count), layered_before + 1)


### PR DESCRIPTION
Open layered: from metadata on the cursor hot path and stop sweep from
pinning table: to immortal layered handles (4 dhandles -> 3 on the leader).

Summarize the reason behind this change (this might be the problem you're solving, or the context around the request) and the solution you have chosen.
