### PR TITLE
WT-18118 Remove incorrect EBUSY doc from publish()

### DIFF
--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -1475,7 +1475,7 @@ struct __wt_session {
      * string; default empty.}
      * @config{ ),,}
      * @configend
-     * @ebusy_errors
+     * @errors
      */
     int __F(publish)(WT_SESSION *session,
         const char *name, const char *config);


### PR DESCRIPTION
publish() is documented via @ebusy_errors as potentially returning EBUSY, but it cannot. Replace @ebusy_errors with @errors to match actual behavior.