### PR TITLE
WT-17488 Fix out-of-bounds read in __checkpoint_mark_skip on empty list (8.3)

### DIFF
--- a/src/checkpoint/checkpoint.h
+++ b/src/checkpoint/checkpoint.h
@@ -206,6 +206,8 @@ extern void __wt_ckptlist_free(WT_SESSION_IMPL *session, WT_CKPT **ckptbasep);
 extern void __wt_ckptlist_saved_free(WT_SESSION_IMPL *session);
 
 #ifdef HAVE_UNITTEST
+extern bool __ut_checkpoint_skip_ckptlist(WT_CKPT *ckptbase)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 
 #endif
 

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -2507,6 +2507,48 @@ skip:
 }
 
 /*
+ * __checkpoint_skip_ckptlist --
+ *     Return true if the checkpoint list indicates the checkpoint can be skipped: the last two
+ *     entries share the same name (or both use the internal name prefix) and fewer than two
+ *     checkpoints are being deleted. Requires at least two entries; returns false for shorter lists
+ *     so callers need not guard against out-of-bounds reads. If countp is non-NULL it is set to the
+ *     number of entries in the list regardless of the return value.
+ */
+static bool
+__checkpoint_skip_ckptlist(WT_CKPT *ckptbase, u_int *countp)
+{
+    WT_CKPT *ckpt;
+    int deleted;
+    const char *name;
+
+    deleted = 0;
+    WT_CKPT_FOREACH (ckptbase, ckpt) {
+        if (F_ISSET(ckpt, WT_CKPT_DELETE))
+            ++deleted;
+    }
+
+    if (countp != NULL)
+        *countp = (u_int)(ckpt - ckptbase);
+
+    /* Need at least two entries to compare names; guard before accessing entries. */
+    if (ckpt <= ckptbase + 1 || deleted >= 2)
+        return (false);
+
+    /* List has at least two real entries: accesses are safe. */
+    name = (ckpt - 1)->name;
+    return (strcmp(name, (ckpt - 2)->name) == 0 ||
+      (WT_PREFIX_MATCH(name, WT_CHECKPOINT) && WT_PREFIX_MATCH((ckpt - 2)->name, WT_CHECKPOINT)));
+}
+
+#ifdef HAVE_UNITTEST
+bool
+__ut_checkpoint_skip_ckptlist(WT_CKPT *ckptbase)
+{
+    return (__checkpoint_skip_ckptlist(ckptbase, NULL));
+}
+#endif
+
+/*
  * __checkpoint_mark_skip --
  *     Figure out whether the checkpoint can be skipped for a tree.
  */
@@ -2538,25 +2580,9 @@ __checkpoint_mark_skip(WT_SESSION_IMPL *session, WT_CKPT *ckptbase, bool force)
      */
     F_CLR(btree, WT_BTREE_SKIP_CKPT);
     if (!btree->modified && !force && !bm->can_truncate(bm, session)) {
-        WT_CKPT *ckpt = NULL;
-        int deleted = 0;
+        u_int count = 0;
 
-        WT_CKPT_FOREACH (ckptbase, ckpt) {
-            if (F_ISSET(ckpt, WT_CKPT_DELETE))
-                ++deleted;
-        }
-
-        /*
-         * Complicated test: if the tree is clean and last two checkpoints have the same name
-         * (correcting for internal checkpoint names with their generational suffix numbers), we can
-         * skip the checkpoint, there's nothing to do. The exception is if we're deleting two or
-         * more checkpoints: then we may save space.
-         */
-        const char *name = (ckpt - 1)->name;
-        if (ckpt > ckptbase + 1 && deleted < 2 &&
-          (strcmp(name, (ckpt - 2)->name) == 0 ||
-            (WT_PREFIX_MATCH(name, WT_CHECKPOINT) &&
-              WT_PREFIX_MATCH((ckpt - 2)->name, WT_CHECKPOINT)))) {
+        if (__checkpoint_skip_ckptlist(ckptbase, &count)) {
             F_SET(btree, WT_BTREE_SKIP_CKPT);
             /*
              * If there are potentially extra checkpoints to delete, we set the timer to recheck
@@ -2565,7 +2591,7 @@ __checkpoint_mark_skip(WT_SESSION_IMPL *session, WT_CKPT *ckptbase, bool force)
              * to forever. If the table gets dirtied or a checkpoint is forced that will clear the
              * timer.
              */
-            if (ckpt - ckptbase > 2) {
+            if (count > 2) {
                 uint64_t timer = 0;
                 __wt_seconds(session, &timer);
                 timer += WT_MINUTE * WT_BTREE_CLEAN_MINUTES;

--- a/test/catch2/CMakeLists.txt
+++ b/test/catch2/CMakeLists.txt
@@ -8,6 +8,7 @@ else()
         misc_tests/test_binary_search_string.cpp
         misc_tests/test_bitmap.cpp
         misc_tests/test_cell_prepared_time_window.cpp
+        misc_tests/test_checkpoint_skip.cpp
         misc_tests/test_config.cpp
         misc_tests/test_crc32.cpp
         misc_tests/test_disagg_meta_config.cpp

--- a/test/catch2/misc_tests/test_checkpoint_skip.cpp
+++ b/test/catch2/misc_tests/test_checkpoint_skip.cpp
@@ -1,0 +1,118 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+#include <catch2/catch.hpp>
+#include "wt_internal.h"
+
+#include <cstring>
+
+/* Initialize a WT_CKPT entry. Pass NULL as name for the sentinel. */
+static void
+make_ckpt(WT_CKPT *ckpt, const char *name, uint32_t flags)
+{
+    memset(ckpt, 0, sizeof(*ckpt));
+    ckpt->name = (name != NULL) ? const_cast<char *>(name) : NULL;
+    ckpt->flags = flags;
+}
+
+/* Empty list: only the NULL sentinel, no real entries. */
+TEST_CASE("__checkpoint_skip_ckptlist: empty list returns false", "[checkpoint_mark_skip]")
+{
+    WT_CKPT list[1];
+    make_ckpt(&list[0], NULL, 0);
+    REQUIRE(__ut_checkpoint_skip_ckptlist(list) == false);
+}
+
+/* Single entry: cannot compare two names. */
+TEST_CASE("__checkpoint_skip_ckptlist: single entry returns false", "[checkpoint_mark_skip]")
+{
+    WT_CKPT list[2];
+    make_ckpt(&list[0], "WiredTigerCheckpoint.1", 0);
+    make_ckpt(&list[1], NULL, 0);
+    REQUIRE(__ut_checkpoint_skip_ckptlist(list) == false);
+}
+
+/* Two entries with the same name: checkpoint can be skipped. */
+TEST_CASE(
+  "__checkpoint_skip_ckptlist: two entries same name returns true", "[checkpoint_mark_skip]")
+{
+    WT_CKPT list[3];
+    make_ckpt(&list[0], "my_checkpoint", 0);
+    make_ckpt(&list[1], "my_checkpoint", 0);
+    make_ckpt(&list[2], NULL, 0);
+    REQUIRE(__ut_checkpoint_skip_ckptlist(list) == true);
+}
+
+/* Two entries with different names: checkpoint must not be skipped. */
+TEST_CASE(
+  "__checkpoint_skip_ckptlist: two entries different names returns false", "[checkpoint_mark_skip]")
+{
+    WT_CKPT list[3];
+    make_ckpt(&list[0], "checkpoint_A", 0);
+    make_ckpt(&list[1], "checkpoint_B", 0);
+    make_ckpt(&list[2], NULL, 0);
+    REQUIRE(__ut_checkpoint_skip_ckptlist(list) == false);
+}
+
+/* Two internal-prefix entries (e.g. WiredTigerCheckpoint.N): treated as equivalent. */
+TEST_CASE(
+  "__checkpoint_skip_ckptlist: two internal-prefix entries returns true", "[checkpoint_mark_skip]")
+{
+    WT_CKPT list[3];
+    make_ckpt(&list[0], WT_CHECKPOINT ".1", 0);
+    make_ckpt(&list[1], WT_CHECKPOINT ".2", 0);
+    make_ckpt(&list[2], NULL, 0);
+    REQUIRE(__ut_checkpoint_skip_ckptlist(list) == true);
+}
+
+/* Two or more deletions: may reclaim space, do not skip. */
+TEST_CASE("__checkpoint_skip_ckptlist: two deletions returns false", "[checkpoint_mark_skip]")
+{
+    WT_CKPT list[4];
+    make_ckpt(&list[0], "my_checkpoint", WT_CKPT_DELETE);
+    make_ckpt(&list[1], "my_checkpoint", WT_CKPT_DELETE);
+    make_ckpt(&list[2], "my_checkpoint", 0);
+    make_ckpt(&list[3], NULL, 0);
+    REQUIRE(__ut_checkpoint_skip_ckptlist(list) == false);
+}
+
+/* Three entries where the last two share an internal prefix: skip. */
+TEST_CASE(
+  "__checkpoint_skip_ckptlist: three entries last two match returns true", "[checkpoint_mark_skip]")
+{
+    WT_CKPT list[4];
+    make_ckpt(&list[0], WT_CHECKPOINT ".1", 0);
+    make_ckpt(&list[1], WT_CHECKPOINT ".2", 0);
+    make_ckpt(&list[2], WT_CHECKPOINT ".3", 0);
+    make_ckpt(&list[3], NULL, 0);
+    REQUIRE(__ut_checkpoint_skip_ckptlist(list) == true);
+}
+
+/* Three entries where the last two differ: do not skip. */
+TEST_CASE("__checkpoint_skip_ckptlist: three entries last two differ returns false",
+  "[checkpoint_mark_skip]")
+{
+    WT_CKPT list[4];
+    make_ckpt(&list[0], "snap_A", 0);
+    make_ckpt(&list[1], "snap_B", 0);
+    make_ckpt(&list[2], "snap_C", 0);
+    make_ckpt(&list[3], NULL, 0);
+    REQUIRE(__ut_checkpoint_skip_ckptlist(list) == false);
+}
+
+/* One deletion with matching last-two names: single deletion still allows skip. */
+TEST_CASE("__checkpoint_skip_ckptlist: one deletion same last-two names returns true",
+  "[checkpoint_mark_skip]")
+{
+    WT_CKPT list[4];
+    make_ckpt(&list[0], "my_checkpoint", WT_CKPT_DELETE);
+    make_ckpt(&list[1], "my_checkpoint", 0);
+    make_ckpt(&list[2], "my_checkpoint", 0);
+    make_ckpt(&list[3], NULL, 0);
+    REQUIRE(__ut_checkpoint_skip_ckptlist(list) == true);
+}


### PR DESCRIPTION
**Problem**:
In __checkpoint_mark_skip, the code unconditionally reads (ckpt - 1)->name immediately after WT_CKPT_FOREACH completes, before the guard ckpt > ckptbase + 1 that would make the access safe. If the checkpoint list is empty (only the NULL sentinel), ckpt == ckptbase after the loop and (ckpt - 1) is an out-of-bounds read undefined behavior caught by ASan in a minimal repro.

In the current production call path, __checkpoint_lock_dirty_tree always appends a new entry before calling __checkpoint_mark_skip, so the list is never empty at runtime. The bug is therefore latent the code is fragile and becomes immediately exploitable if that call-site guarantee is ever relaxed by a refactor.

Testing:
- Minimal C repro compiled with ASan (GCC 13, Ubuntu 24.04)
- ASan build (CMAKE_BUILD_TYPE=ASan, clang-18)