### PR TITLE
WT-18127 Clear delta cells' transaction ids using the delta's own write generation

### DIFF
--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -1020,7 +1020,7 @@ __debug_disk_delta(WT_SESSION_IMPL *session, const WT_PAGE_HEADER *base_dsk,
 
         WT_CLEAR(state);
         state.base_dsk = base_dsk;
-        state.dsk = delta_dsk;
+        state.delta_dsk = delta_dsk;
         state.cell = WT_PAGE_HEADER_BYTE(S2BT(session), delta_dsk);
         state.entries = delta_dsk->u.entries;
 

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -1019,6 +1019,7 @@ __debug_disk_delta(WT_SESSION_IMPL *session, const WT_PAGE_HEADER *base_dsk,
         WTI_DELTA_INT_MERGE_STATE state;
 
         WT_CLEAR(state);
+        state.dsk = delta_dsk;
         state.cell = WT_PAGE_HEADER_BYTE(S2BT(session), delta_dsk);
         state.entries = delta_dsk->u.entries;
 

--- a/src/btree/bt_debug.c
+++ b/src/btree/bt_debug.c
@@ -1019,13 +1019,14 @@ __debug_disk_delta(WT_SESSION_IMPL *session, const WT_PAGE_HEADER *base_dsk,
         WTI_DELTA_INT_MERGE_STATE state;
 
         WT_CLEAR(state);
+        state.base_dsk = base_dsk;
         state.dsk = delta_dsk;
         state.cell = WT_PAGE_HEADER_BYTE(S2BT(session), delta_dsk);
         state.entries = delta_dsk->u.entries;
 
         /* Each entry is a key cell plus a value cell, so the count decreases by two. */
         while (state.entries > 0) {
-            WT_CELL_DELTA_INT_UNPACK(session, base_dsk, &state);
+            WT_CELL_DELTA_INT_UNPACK(session, &state);
             WT_ERR(__debug_cell_delta_int(ds, &state.unpack));
             state.unpacked = false;
             state.entries -= 2;

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -529,6 +529,7 @@ __wti_page_merge_deltas_with_base_image_int(WT_SESSION_IMPL *session, WT_ITEM *d
     WT_RET(__wt_calloc_def(session, delta_size, &delta_state));
     for (size_t i = 0; i < delta_size; ++i) {
         WT_PAGE_HEADER *dhdr = (WT_PAGE_HEADER *)deltas[i].data;
+        delta_state[i].dsk = dhdr;
         delta_state[i].cell = WT_PAGE_HEADER_BYTE(btree, dhdr);
         delta_state[i].entries = dhdr->u.entries;
         delta_state[i].unpacked = false;

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -530,7 +530,7 @@ __wti_page_merge_deltas_with_base_image_int(WT_SESSION_IMPL *session, WT_ITEM *d
     for (size_t i = 0; i < delta_size; ++i) {
         WT_PAGE_HEADER *dhdr = (WT_PAGE_HEADER *)deltas[i].data;
         delta_state[i].base_dsk = base_image_header;
-        delta_state[i].dsk = dhdr;
+        delta_state[i].delta_dsk = dhdr;
         delta_state[i].cell = WT_PAGE_HEADER_BYTE(btree, dhdr);
         delta_state[i].entries = dhdr->u.entries;
         delta_state[i].unpacked = false;

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -24,8 +24,8 @@ static int __inmem_row_leaf_entries(WT_SESSION_IMPL *, const WT_PAGE_HEADER *, u
  *     older duplicates are discarded.
  */
 static int
-__page_find_min_delta_int(WT_SESSION_IMPL *session, WTI_DELTA_INT_MERGE_STATE s[], int32_t *min_d,
-  int32_t delta_count, WT_PAGE_HEADER *base_page_header)
+__page_find_min_delta_int(
+  WT_SESSION_IMPL *session, WTI_DELTA_INT_MERGE_STATE s[], int32_t *min_d, int32_t delta_count)
 {
     WT_ITEM cur_key, min_key;
     int32_t j;
@@ -47,7 +47,7 @@ __page_find_min_delta_int(WT_SESSION_IMPL *session, WTI_DELTA_INT_MERGE_STATE s[
          * skip decoding and compare against the already-decoded key.
          */
         if (!s[i].unpacked)
-            WT_CELL_DELTA_INT_UNPACK(session, base_page_header, &s[i]);
+            WT_CELL_DELTA_INT_UNPACK(session, &s[i]);
 
         if (j == -1) {
             j = i;
@@ -529,6 +529,7 @@ __wti_page_merge_deltas_with_base_image_int(WT_SESSION_IMPL *session, WT_ITEM *d
     WT_RET(__wt_calloc_def(session, delta_size, &delta_state));
     for (size_t i = 0; i < delta_size; ++i) {
         WT_PAGE_HEADER *dhdr = (WT_PAGE_HEADER *)deltas[i].data;
+        delta_state[i].base_dsk = base_image_header;
         delta_state[i].dsk = dhdr;
         delta_state[i].cell = WT_PAGE_HEADER_BYTE(btree, dhdr);
         delta_state[i].entries = dhdr->u.entries;
@@ -594,8 +595,7 @@ __wti_page_merge_deltas_with_base_image_int(WT_SESSION_IMPL *session, WT_ITEM *d
     for (;;) {
         /* Find the minimum delta entry only when needed. */
         if (j == -1)
-            WT_ERR(__page_find_min_delta_int(
-              session, delta_state, &j, (int32_t)delta_size, base_image_header));
+            WT_ERR(__page_find_min_delta_int(session, delta_state, &j, (int32_t)delta_size));
 
         /* Check if both base and all deltas are exhausted. */
         if (base_state.entries == 0 && j == -1)

--- a/src/include/cell.h
+++ b/src/include/cell.h
@@ -266,6 +266,7 @@ struct __wt_cell_kv {
  */
 struct __wti_delta_int_merge_state {
     WT_CELL_UNPACK_DELTA_INT unpack; /* Current unpacked key+value entry */
+    const WT_PAGE_HEADER *base_dsk;  /* Base image's disk header (timestamp resolution) */
     const WT_PAGE_HEADER *dsk;       /* This delta's disk header (clearing decisions) */
     uint8_t *cell;                   /* Current position in the delta byte stream */
     uint32_t entries;                /* Remaining cell count (key+value pairs each count as 2) */

--- a/src/include/cell.h
+++ b/src/include/cell.h
@@ -267,7 +267,7 @@ struct __wt_cell_kv {
 struct __wti_delta_int_merge_state {
     WT_CELL_UNPACK_DELTA_INT unpack; /* Current unpacked key+value entry */
     const WT_PAGE_HEADER *base_dsk;  /* Base image's disk header (timestamp resolution) */
-    const WT_PAGE_HEADER *dsk;       /* This delta's disk header (clearing decisions) */
+    const WT_PAGE_HEADER *delta_dsk; /* This delta's disk header (clearing decisions) */
     uint8_t *cell;                   /* Current position in the delta byte stream */
     uint32_t entries;                /* Remaining cell count (key+value pairs each count as 2) */
     bool unpacked;                   /* true when unpack holds a valid, not-yet-consumed entry */

--- a/src/include/cell.h
+++ b/src/include/cell.h
@@ -266,6 +266,7 @@ struct __wt_cell_kv {
  */
 struct __wti_delta_int_merge_state {
     WT_CELL_UNPACK_DELTA_INT unpack; /* Current unpacked key+value entry */
+    const WT_PAGE_HEADER *dsk;       /* This delta's disk header (clearing decisions) */
     uint8_t *cell;                   /* Current position in the delta byte stream */
     uint32_t entries;                /* Remaining cell count (key+value pairs each count as 2) */
     bool unpacked;                   /* true when unpack holds a valid, not-yet-consumed entry */

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -1784,6 +1784,27 @@ __wt_cell_unpack_addr(WT_SESSION_IMPL *session, const WT_PAGE_HEADER *dsk, WT_CE
 }
 
 /*
+ * __wt_cell_unpack_addr_delta --
+ *     Unpack an address cell from an internal page delta. The cell's values are resolved against
+ *     the base image's header, but whether its transaction ids are from an earlier run is a
+ *     property of the delta that carries the cell: make the clearing decision with the delta's own
+ *     write generation, not the base image's.
+ */
+static WT_INLINE void
+__wt_cell_unpack_addr_delta(WT_SESSION_IMPL *session, const WT_PAGE_HEADER *base_dsk,
+  const WT_PAGE_HEADER *delta_dsk, WT_CELL *cell, WT_CELL_UNPACK_ADDR *unpack_addr)
+{
+    WT_DECL_RET;
+
+    ret = __wt_cell_unpack_safe(session, base_dsk, cell, unpack_addr, NULL, NULL);
+    WT_ASSERT(session, ret == 0);
+    WT_UNUSED(ret); /* Avoid "unused variable" warnings in non-debug builds. */
+
+    if (__cell_unpack_window_need_cleanup(session, delta_dsk->write_gen))
+        __cell_addr_window_cleanup(session, base_dsk, unpack_addr);
+}
+
+/*
  * __wt_cell_unpack_kv --
  *     Unpack a value WT_CELL into a structure.
  */
@@ -1820,6 +1841,25 @@ __wt_cell_unpack_kv(WT_SESSION_IMPL *session, const WT_PAGE_HEADER *dsk, WT_CELL
     WT_UNUSED(ret); /* Avoid "unused variable" warnings in non-debug builds. */
 
     __cell_unpack_window_cleanup_kv(session, dsk, unpack_value);
+}
+
+/*
+ * __wt_cell_unpack_kv_delta --
+ *     Unpack a value cell from an internal page delta; see the address variant above for why the
+ *     clearing decision uses the delta's own write generation.
+ */
+static WT_INLINE void
+__wt_cell_unpack_kv_delta(WT_SESSION_IMPL *session, const WT_PAGE_HEADER *base_dsk,
+  const WT_PAGE_HEADER *delta_dsk, WT_CELL *cell, WT_CELL_UNPACK_KV *unpack_value)
+{
+    WT_DECL_RET;
+
+    ret = __wt_cell_unpack_safe(session, base_dsk, cell, NULL, unpack_value, NULL);
+    WT_ASSERT(session, ret == 0);
+    WT_UNUSED(ret); /* Avoid "unused variable" warnings in non-debug builds. */
+
+    if (__cell_unpack_window_need_cleanup(session, delta_dsk->write_gen))
+        __cell_kv_window_cleanup(session, unpack_value);
 }
 
 /*
@@ -1953,15 +1993,20 @@ __wt_page_cell_data_ref_kv(
  * when an entry is consumed or discarded, triggering a fresh decode on the next call.
  *
  * The base page header is passed to the unpack helpers so they can resolve timestamps stored
- * relative to the base page.
+ * relative to the base page. The delta's own header decides whether the cell's transaction ids are
+ * from an earlier run: keying that decision on the base image's write generation would clear the
+ * ids of a current-run delta cell whenever the base image happens to be older, publishing an
+ * address whose aggregate no longer covers the page it references.
  */
-#define WT_CELL_DELTA_INT_UNPACK(session, base_dsk, s)                                      \
-    do {                                                                                    \
-        __wt_cell_unpack_kv(session, base_dsk, (WT_CELL *)(s)->cell, &(s)->unpack.key);     \
-        (s)->cell += (s)->unpack.key.__len;                                                 \
-        __wt_cell_unpack_addr(session, base_dsk, (WT_CELL *)(s)->cell, &(s)->unpack.value); \
-        (s)->cell += (s)->unpack.value.__len;                                               \
-        (s)->unpacked = true;                                                               \
+#define WT_CELL_DELTA_INT_UNPACK(session, base_dsk, s)                            \
+    do {                                                                          \
+        __wt_cell_unpack_kv_delta(                                                \
+          session, base_dsk, (s)->dsk, (WT_CELL *)(s)->cell, &(s)->unpack.key);   \
+        (s)->cell += (s)->unpack.key.__len;                                       \
+        __wt_cell_unpack_addr_delta(                                              \
+          session, base_dsk, (s)->dsk, (WT_CELL *)(s)->cell, &(s)->unpack.value); \
+        (s)->cell += (s)->unpack.value.__len;                                     \
+        (s)->unpacked = true;                                                     \
     } while (0)
 
 /*

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -1998,15 +1998,15 @@ __wt_page_cell_data_ref_kv(
  * ids of a current-run delta cell whenever the base image happens to be older, publishing an
  * address whose aggregate no longer covers the page it references.
  */
-#define WT_CELL_DELTA_INT_UNPACK(session, s)                                           \
-    do {                                                                               \
-        __wt_cell_unpack_kv_delta(                                                     \
-          session, (s)->base_dsk, (s)->dsk, (WT_CELL *)(s)->cell, &(s)->unpack.key);   \
-        (s)->cell += (s)->unpack.key.__len;                                            \
-        __wt_cell_unpack_addr_delta(                                                   \
-          session, (s)->base_dsk, (s)->dsk, (WT_CELL *)(s)->cell, &(s)->unpack.value); \
-        (s)->cell += (s)->unpack.value.__len;                                          \
-        (s)->unpacked = true;                                                          \
+#define WT_CELL_DELTA_INT_UNPACK(session, s)                                                 \
+    do {                                                                                     \
+        __wt_cell_unpack_kv_delta(                                                           \
+          session, (s)->base_dsk, (s)->delta_dsk, (WT_CELL *)(s)->cell, &(s)->unpack.key);   \
+        (s)->cell += (s)->unpack.key.__len;                                                  \
+        __wt_cell_unpack_addr_delta(                                                         \
+          session, (s)->base_dsk, (s)->delta_dsk, (WT_CELL *)(s)->cell, &(s)->unpack.value); \
+        (s)->cell += (s)->unpack.value.__len;                                                \
+        (s)->unpacked = true;                                                                \
     } while (0)
 
 /*

--- a/src/include/cell_inline.h
+++ b/src/include/cell_inline.h
@@ -1998,15 +1998,15 @@ __wt_page_cell_data_ref_kv(
  * ids of a current-run delta cell whenever the base image happens to be older, publishing an
  * address whose aggregate no longer covers the page it references.
  */
-#define WT_CELL_DELTA_INT_UNPACK(session, base_dsk, s)                            \
-    do {                                                                          \
-        __wt_cell_unpack_kv_delta(                                                \
-          session, base_dsk, (s)->dsk, (WT_CELL *)(s)->cell, &(s)->unpack.key);   \
-        (s)->cell += (s)->unpack.key.__len;                                       \
-        __wt_cell_unpack_addr_delta(                                              \
-          session, base_dsk, (s)->dsk, (WT_CELL *)(s)->cell, &(s)->unpack.value); \
-        (s)->cell += (s)->unpack.value.__len;                                     \
-        (s)->unpacked = true;                                                     \
+#define WT_CELL_DELTA_INT_UNPACK(session, s)                                           \
+    do {                                                                               \
+        __wt_cell_unpack_kv_delta(                                                     \
+          session, (s)->base_dsk, (s)->dsk, (WT_CELL *)(s)->cell, &(s)->unpack.key);   \
+        (s)->cell += (s)->unpack.key.__len;                                            \
+        __wt_cell_unpack_addr_delta(                                                   \
+          session, (s)->base_dsk, (s)->dsk, (WT_CELL *)(s)->cell, &(s)->unpack.value); \
+        (s)->cell += (s)->unpack.value.__len;                                          \
+        (s)->unpacked = true;                                                          \
     } while (0)
 
 /*

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2601,10 +2601,16 @@ static WT_INLINE void __wt_cell_type_reset(
   WT_SESSION_IMPL *session, WT_CELL *cell, u_int old_type, u_int new_type);
 static WT_INLINE void __wt_cell_unpack_addr(WT_SESSION_IMPL *session, const WT_PAGE_HEADER *dsk,
   WT_CELL *cell, WT_CELL_UNPACK_ADDR *unpack_addr);
+static WT_INLINE void __wt_cell_unpack_addr_delta(WT_SESSION_IMPL *session,
+  const WT_PAGE_HEADER *base_dsk, const WT_PAGE_HEADER *delta_dsk, WT_CELL *cell,
+  WT_CELL_UNPACK_ADDR *unpack_addr);
 static WT_INLINE void __wt_cell_unpack_delta_leaf_value(WT_SESSION_IMPL *session,
   const WT_PAGE_HEADER *dsk, WT_CELL *value_cell, WT_CELL_UNPACK_DELTA_LEAF_KV *unpack);
 static WT_INLINE void __wt_cell_unpack_kv(WT_SESSION_IMPL *session, const WT_PAGE_HEADER *dsk,
   WT_CELL *cell, WT_CELL_UNPACK_KV *unpack_value);
+static WT_INLINE void __wt_cell_unpack_kv_delta(WT_SESSION_IMPL *session,
+  const WT_PAGE_HEADER *base_dsk, const WT_PAGE_HEADER *delta_dsk, WT_CELL *cell,
+  WT_CELL_UNPACK_KV *unpack_value);
 static WT_INLINE void __wt_cond_wait(
   WT_SESSION_IMPL *session, WT_CONDVAR *cond, uint64_t usecs, bool (*run_func)(WT_SESSION_IMPL *));
 static WT_INLINE void __wt_cursor_bound_reset(WT_CURSOR *cursor);

--- a/test/suite/test_layered_delta16.py
+++ b/test/suite/test_layered_delta16.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import sys, time
+import wttest, wiredtiger
+from helper_disagg import disagg_test_class
+
+# test_layered_delta16.py
+#
+# Verify a tree whose internal pages carry deltas written by a different
+# leader than their base images.
+#
+# The first leader's checkpoint provides the internal pages' base images.
+# After a role switch, the new leader updates a spread of keys while another
+# transaction is running, so the updated pages and the aggregates above them
+# are persisted with their transaction ids. The internal pages above them are
+# written as deltas on the first leader's base images.
+#
+# Rebuilding such a page merges the old base image with the new deltas: the
+# decision to clear a delta cell's transaction ids must be made against the
+# delta that carries the cell, not the base image beneath it. Clearing by the
+# base image's age strips the ids from current cells, and verification then
+# finds pages holding newer transactions than their parents report.
+@disagg_test_class
+class test_layered_delta16(wttest.WiredTigerTestCase):
+    test_name = __qualname__
+    uri = f'layered:{test_name}'
+
+    conn_base_config = 'statistics=(all),disaggregated=(lose_all_my_data=true),' \
+                     + 'page_delta=(delta_pct=100,internal_page_delta=true,leaf_page_delta=true),'
+    conn_config = conn_base_config + 'disaggregated=(role="leader")'
+
+    # Small pages build a tree with several levels above the leaves.
+    create_session_config = 'key_format=S,value_format=S,allocation_size=512,' \
+                          + 'leaf_page_max=512,internal_page_max=512'
+
+    nitems = 5000
+
+    def verify_retry(self, session):
+        # The stable table can be transiently busy; retry on EBUSY but let a
+        # genuine verification failure through.
+        for _ in range(60):
+            try:
+                session.verify(self.uri, None)
+                return
+            except wiredtiger.WiredTigerError as e:
+                if 'resource busy' not in str(e):
+                    raise
+                time.sleep(1)
+
+    def test_verify_internal_deltas_on_old_base(self):
+        if sys.platform.startswith('darwin'):
+            return
+
+        self.ignoreStdoutPattern('Picking up the same checkpoint again')
+
+        self.session.create(self.uri, self.create_session_config)
+
+        self.conn_follow = self.wiredtiger_open('follower',
+            self.extensionsConfig() + ',create,' + self.conn_base_config
+            + 'disaggregated=(role="follower")')
+        session_follow = self.conn_follow.open_session('')
+        session_follow.create(self.uri, self.create_session_config)
+
+        # First leader: populate the whole key space and checkpoint. This
+        # provides the base images for the internal pages.
+        value = 'v' * 20
+        base_ts = 10
+        cursor = self.session.open_cursor(self.uri, None, None)
+        for i in range(1, self.nitems + 1):
+            self.session.begin_transaction()
+            cursor[str(i)] = value
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(base_ts))
+        cursor.close()
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(base_ts))
+        self.session.checkpoint()
+
+        # The second node becomes the leader.
+        self.disagg_switch_follower_and_leader(self.conn_follow, self.conn)
+
+        # Hold a transaction open on the new leader so the update transactions
+        # below are still needed when their pages are written: their ids are
+        # persisted rather than cleared.
+        pin_session = self.conn_follow.open_session('')
+        pin_cursor = pin_session.open_cursor(self.uri, None, None)
+        pin_session.begin_transaction()
+        pin_cursor.set_key('1')
+        pin_cursor.search()
+
+        # Update every key in one narrow range: the leaves and the internal
+        # pages directly above them are rewritten as full images carrying the
+        # new leader's transaction ids, while the internal pages higher up --
+        # with only a few changed children -- are written as deltas on the
+        # first leader's base images.
+        update_ts = base_ts + 10
+        cursor = session_follow.open_cursor(self.uri, None, None)
+        for i in range(2001, 2401):
+            session_follow.begin_transaction()
+            cursor[str(i)] = value + 'x'
+            session_follow.commit_transaction(
+                'commit_timestamp=' + self.timestamp_str(update_ts))
+        cursor.close()
+        self.conn_follow.set_timestamp(
+            'stable_timestamp=' + self.timestamp_str(update_ts))
+        session_follow.checkpoint()
+
+        pin_cursor.close()
+        pin_session.rollback_transaction()
+        pin_session.close()
+
+        # Verify on the new leader: the walk rebuilds the delta-written
+        # internal pages from the old base images and the new deltas, and
+        # checks every page against the aggregate its parent reports for it.
+        self.verify_retry(session_follow)


### PR DESCRIPTION
Rebuilding a full page image from a base image and internal page deltas unpacks the delta cells with the base image's header, so delta timestamps resolve against the base page. The unpack path also made the transaction-id clearing decision from that header's write generation: whether a delta cell's ids belong to an earlier run was decided by the base image's age rather than the delta's own.

When an internal page consists of an older base image plus deltas written by the current run, the merge wrongly cleared the transaction ids from the current-run delta cells while preserving their address cookies. The rebuilt page then held address cells whose aggregates no longer cover the raw transaction ids in the pages they reference, and verification intermittently failed in the format disagg-switch stress tasks with:

```
__time_aggregate_validate_parent: aggregate time window has a newest transaction after its parent's
```

The characteristic signature was a full-image child page under a delta-reconstructed parent whose recorded aggregate has `newest_txn=0`, with parent base LSN < child LSN < parent LSN. The leaf delta path is unaffected because it already unpacks delta cells with the delta's own header, which is why the failure only ever fired at the internal level.

The fix keeps the base image's header for timestamp resolution and makes the clearing decision with the delta's own write generation.

`test_layered_delta16` reproduces deterministically: after a role switch, the new leader updates a dense key range while another transaction is running (so the ids are persisted), leaving the rewritten subtree's full images under internal deltas on the previous leader's base images; verification on the new leader fails without the fix and passes with it.