### PR TITLE
WT-16096 Lag the oldest ts behind stable under precise checkpoint so format's snap re-reads don't age out

### DIFF
--- a/test/format/follower.c
+++ b/test/format/follower.c
@@ -149,6 +149,7 @@ follower_read_latest_checkpoint(void)
 
     conn = g.wts_conn;
     disagg_page_log = (char *)GVS(DISAGG_PAGE_LOG);
+    memset(&sap, 0, sizeof(sap));
     memset(&args, 0, sizeof(args));
 
     /* Only follower can pickup checkpoints. */

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -523,6 +523,7 @@ void snap_init(TINFO *);
 void snap_op_init(TINFO *, wt_timestamp_t, bool);
 void snap_repeat_stable(WT_SESSION *, TINFO **, size_t);
 void snap_repeat_single(TINFO *);
+wt_timestamp_t snap_repeat_ts_span(void);
 int snap_repeat_txn(TINFO *);
 void snap_repeat_update(TINFO *, bool);
 void snap_teardown(TINFO *);

--- a/test/format/format_timestamp.c
+++ b/test/format/format_timestamp.c
@@ -130,7 +130,7 @@ timestamp_once(WT_SESSION *session, bool allow_lag, bool final)
     static const char *oldest_timestamp_str = "oldest_timestamp=";
     static const char *stable_timestamp_str = "stable_timestamp=";
     WT_CONNECTION *conn;
-    wt_timestamp_t oldest_timestamp, stable_timestamp, stop_timestamp;
+    wt_timestamp_t lag, oldest_timestamp, stable_timestamp, stop_timestamp;
     char buf[WT_TS_HEX_STRING_SIZE * 2 + 64];
 
     /* Ensure timestamps are used. */
@@ -168,6 +168,17 @@ timestamp_once(WT_SESSION *session, bool allow_lag, bool final)
          */
         if (allow_lag)
             oldest_timestamp -= (oldest_timestamp - g.oldest_timestamp) / 2;
+
+        /*
+         * Under precise checkpoint this thread ticks every few milliseconds and the halving above
+         * converges to a near-zero gap between oldest and stable, so snap_repeat's historical reads
+         * age out almost immediately and repeatable-read verification is silently lost. Trail
+         * oldest behind stable far enough that recorded operations stay readable, never moving
+         * oldest backwards: populate and role-switch callers pin oldest to stable.
+         */
+        lag = snap_repeat_ts_span();
+        if (allow_lag && GV(PRECISE_CHECKPOINT) && stable_timestamp > lag)
+            oldest_timestamp = WT_MAX(stable_timestamp - lag, g.oldest_timestamp);
     }
 
     testutil_snprintf(buf, sizeof(buf), "%s%" PRIx64 ",%s%" PRIx64, oldest_timestamp_str,

--- a/test/format/snap.c
+++ b/test/format/snap.c
@@ -31,6 +31,18 @@
 #define SNAP_LIST_SIZE 512
 
 /*
+ * snap_repeat_ts_span --
+ *     Return the span of global timestamps a thread's snap list covers: one timestamp is allocated
+ *     per operation across all threads, and each thread keeps its last SNAP_LIST_SIZE operations.
+ *     Timestamps within this distance of stable must stay readable for snap_repeat.
+ */
+wt_timestamp_t
+snap_repeat_ts_span(void)
+{
+    return ((wt_timestamp_t)SNAP_LIST_SIZE * GV(RUNS_THREADS));
+}
+
+/*
  * snap_init --
  *     Initialize the repeatable operation tracking.
  */


### PR DESCRIPTION
**Root cause found**
The messages come from test/format's own verification, not a WT bug:
- Each worker remembers its last 512 operations and their commit timestamps, and later re-reads them at those old timestamps to verify repeatability (snap_repeat).
- A re-read only works while the old timestamp is at or above oldest. WT correctly refuses anything older with EINVAL, and that refusal is what prints this NOTICE.
- Normally the timestamp thread ticks every ~15 seconds, so oldest trails stable by seconds and re-reads succeed.
- Under precise_checkpoint=1 the tick drops to 0-9 ms (stable must keep moving for eviction). The lag-halving logic converges to zero at that cadence, measured average oldest-to-stable gap: 0.125 timestamps.
- So every recorded timestamp is already too old within milliseconds: nearly 100% of re-reads fail, producing ~100k NOTICE lines per 10-minute run, and repeatable-read verification is silently disabled.

**Fix (test/format only):**

- Keep oldest trailing stable by the span the snap lists cover: 512 ops per thread x thread count (~13k timestamps at 26 threads), via a new snap_repeat_ts_span() helper.
- Applies only under precise checkpoint, never moves oldest backwards.
- Bounded rolling window, roughly half a second of history at observed throughput, far less than the ~15 seconds stock format has always pinned.