### PR TITLE
WT-18126 Fix "Resource not accessible" in PR Checklist action

### DIFF
--- a/.github/workflows/pr_checklist.yml
+++ b/.github/workflows/pr_checklist.yml
@@ -1,9 +1,12 @@
 name: PR Checklist
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
+
+permissions:
+  pull-requests: write
 
 jobs:
   add-comment:


### PR DESCRIPTION
The add-comment job used the `pull_request` trigger. For PRs from forks and from GitHub integrations (e.g. Dependabot), GitHub forces the `GITHUB_TOKEN` to read-only, so `github.rest.issues.createComment` failed with HTTP 403.

Add `pull-requests: write` to the workflow permissions (which allows comments to be created), and switch to `pull_request_target` so the job runs from the trusted `pr_checklist.yml` on develop, not whatever version is on the [untrusted] PR's branch.
