### PR TITLE
WT-18131 Reset full checkpoint state on logging failure

### DIFF
--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -570,6 +570,15 @@ err:
     WT_CONN_CLOSE_ABORT(session, ret);
 #endif
     __wt_logrec_free(session, &logrec);
+
+    if (full && ret != 0) {
+        /* Clear full checkpoint state on failure. */
+        WT_INIT_LSN(ckpt_lsn);
+        txn->ckpt_nsnapshot = 0;
+        __wt_scr_free(session, &txn->ckpt_snapshot);
+        txn->full_ckpt = false;
+    }
+
     return (ret);
 }
 

--- a/src/txn/txn_log.c
+++ b/src/txn/txn_log.c
@@ -429,6 +429,22 @@ __wti_txn_ts_log(WT_SESSION_IMPL *session)
 }
 
 /*
+ * __checkpoint_log_cleanup --
+ *     Reset checkpoint logging state and free any allocated resources.
+ */
+static void
+__checkpoint_log_cleanup(WT_SESSION_IMPL *session)
+{
+    WT_TXN *txn;
+
+    txn = session->txn;
+    WT_INIT_LSN(&txn->ckpt_lsn);
+    txn->ckpt_nsnapshot = 0;
+    __wt_scr_free(session, &txn->ckpt_snapshot);
+    txn->full_ckpt = false;
+}
+
+/*
  * __wt_checkpoint_log --
  *     Write a log record for a checkpoint operation.
  */
@@ -556,10 +572,7 @@ __wt_checkpoint_log(WT_SESSION_IMPL *session, bool full, uint32_t flags, WT_LSN 
         /* FALLTHROUGH */
     case WT_TXN_LOG_CKPT_CLEANUP:
         /* Cleanup any allocated resources */
-        WT_INIT_LSN(ckpt_lsn);
-        txn->ckpt_nsnapshot = 0;
-        __wt_scr_free(session, &txn->ckpt_snapshot);
-        txn->full_ckpt = false;
+        __checkpoint_log_cleanup(session);
         break;
     default:
         WT_ERR(__wt_illegal_value(session, flags));
@@ -569,16 +582,9 @@ err:
 #ifdef HAVE_DIAGNOSTIC
     WT_CONN_CLOSE_ABORT(session, ret);
 #endif
+    if (ret != 0)
+        __checkpoint_log_cleanup(session);
     __wt_logrec_free(session, &logrec);
-
-    if (full && ret != 0) {
-        /* Clear full checkpoint state on failure. */
-        WT_INIT_LSN(ckpt_lsn);
-        txn->ckpt_nsnapshot = 0;
-        __wt_scr_free(session, &txn->ckpt_snapshot);
-        txn->full_ckpt = false;
-    }
-
     return (ret);
 }
 

--- a/test/catch2/CMakeLists.txt
+++ b/test/catch2/CMakeLists.txt
@@ -10,6 +10,7 @@ else()
         misc_tests/test_acquire_release_macros.cpp
         misc_tests/test_cell_fast_truncate_unpack.cpp
         misc_tests/test_cell_prepared_time_window.cpp
+        misc_tests/test_checkpoint_log_cleanup.cpp
         misc_tests/test_checkpoint_skip.cpp
         misc_tests/test_config.cpp
         misc_tests/test_crc32.cpp

--- a/test/catch2/misc_tests/test_checkpoint_log_cleanup.cpp
+++ b/test/catch2/misc_tests/test_checkpoint_log_cleanup.cpp
@@ -1,0 +1,99 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+#include <catch2/catch.hpp>
+
+#include <filesystem>
+
+#include "wiredtiger.h"
+#include "../utils.h"
+#include "../wrappers/connection_wrapper.h"
+#include "wt_internal.h"
+
+static constexpr const char *k_db1 = "test_db_ckpt_log_stop_1";
+static constexpr const char *k_db2 = "test_db_ckpt_log_stop_2";
+
+/* Cleanup checkpoint log state on destruction. */
+struct ckpt_log_state_guard {
+    WT_SESSION_IMPL *session;
+
+    ~ckpt_log_state_guard()
+    {
+        WT_TXN *txn = session->txn;
+        if (txn->full_ckpt || txn->ckpt_snapshot != nullptr)
+            WT_IGNORE_RET(__wt_checkpoint_log(session, true, WT_TXN_LOG_CKPT_CLEANUP, nullptr));
+    }
+};
+
+/* Drive the checkpoint log state machine through PREPARE and START. */
+static void
+run_prepare_and_start(WT_SESSION_IMPL *session)
+{
+    WT_TXN *txn = session->txn;
+
+    int ret = __wt_checkpoint_log(session, true, WT_TXN_LOG_CKPT_PREPARE, nullptr);
+    REQUIRE(ret == 0);
+    REQUIRE(txn->full_ckpt);
+
+    ret = __wt_checkpoint_log(session, true, WT_TXN_LOG_CKPT_START, nullptr);
+    REQUIRE(ret == 0);
+    REQUIRE(txn->ckpt_snapshot != nullptr);
+}
+
+/* Force memory allocation inside STOP to fail by inflating the snapshot size. */
+static int
+inject_stop_failure(WT_SESSION_IMPL *session)
+{
+    session->txn->ckpt_snapshot->size = SIZE_MAX >> 2;
+    return __wt_checkpoint_log(session, true, WT_TXN_LOG_CKPT_STOP, nullptr);
+}
+
+TEST_CASE("Checkpoint log STOP failure must reset full_ckpt and free ckpt_snapshot",
+  "[checkpoint][txn_log]")
+{
+    std::filesystem::remove_all(k_db1);
+    connection_wrapper conn(k_db1, "create,log=(enabled=true)");
+    WT_SESSION_IMPL *session = conn.create_session();
+    WT_TXN *txn = session->txn;
+    REQUIRE(txn != nullptr);
+
+    REQUIRE_FALSE(txn->full_ckpt);
+    REQUIRE(txn->ckpt_snapshot == nullptr);
+
+    run_prepare_and_start(session);
+    REQUIRE(txn->full_ckpt);
+    REQUIRE(txn->ckpt_snapshot != nullptr);
+
+    ckpt_log_state_guard guard{session};
+
+    int stop_ret = inject_stop_failure(session);
+    REQUIRE(stop_ret != 0);
+
+    REQUIRE_FALSE(txn->full_ckpt);
+    REQUIRE(txn->ckpt_snapshot == nullptr);
+}
+
+TEST_CASE("After checkpoint STOP failure, full_ckpt must not suppress subsequent file-sync logging",
+  "[checkpoint][txn_log]")
+{
+    std::filesystem::remove_all(k_db2);
+    connection_wrapper conn(k_db2, "create,log=(enabled=true)");
+    WT_SESSION_IMPL *session = conn.create_session();
+    WT_TXN *txn = session->txn;
+    REQUIRE(txn != nullptr);
+
+    run_prepare_and_start(session);
+    REQUIRE(txn->full_ckpt);
+
+    ckpt_log_state_guard guard{session};
+
+    int stop_ret = inject_stop_failure(session);
+    REQUIRE(stop_ret != 0);
+
+    REQUIRE_FALSE(txn->full_ckpt);
+}


### PR DESCRIPTION
In src/txn/txn_log.c _wt_checkpoint_log (line 436), if a failure occurs during checkpoint logging stages (such as WT_TXN_LOG_CKPT_START or WT_TXN_LOG_CKPT_STOP), control jumps to the err: label (line 568). This jump bypasses the WT_TXN_LOG_CKPT_CLEANUP block, leaving txn->full_ckpt stuck as true and leaking the allocated txn->ckpt_snapshot scratch buffer. Consequently, subsequent non-full checkpoint or file-sync logging calls will silently short-circuit and return 0, compromising durability guarantees. Additionally, the leaked scratch buffer remains marked as in-use, causing a memory leak.

For Reproduce;
A catch2 unit test (test_checkpoint_log_cleanup.cpp) reproduces the bug and verifies the fix (I attached the before/after outputs on JIRA).
Without the fix, txn->full_ckpt remains true after a checkpoint logging failure, causing subsequent non-full checkpoint and file-sync logging calls to silently short-circuit and return 0, while the ckpt_snapshot scratch buffer leaks.
With the fix, full_ckpt is correctly reset and the scratch buffer is released on error.

Testing:
- ./dist/s_all runned
- environment: GCC 13, Ubuntu 24.04
