### PR TITLE
WT-15887 Stop test_prepare_hs03 from corrupting checkpoint extent-list blocks

### DIFF
--- a/test/suite/helpers/metadata_helper.py
+++ b/test/suite/helpers/metadata_helper.py
@@ -26,7 +26,7 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import re
+import os, re, sys
 from helper import WiredTigerCursor
 
 def extract_id(metadata_value):
@@ -46,3 +46,51 @@ def get_table_id(session, uri):
         if c.search() != 0:
             raise KeyError(f"URI not found in metadata: {uri}")
         return extract_id(c.get_value())
+
+# Byte offset of each address triple (offset, size, checksum) within a decoded checkpoint cookie.
+_CKPT_COOKIE_TRIPLE = {'root': 0, 'alloc': 3, 'avail': 6, 'discard': 9}
+
+def checkpoint_extent_list_blocks(session, uri, kinds=('alloc', 'avail', 'discard'), allocsize=4096):
+    """
+    Decode every checkpoint's address cookie in uri's metadata and return the on-disk
+    (offset, size) of its extent-list blocks for the requested kinds ('alloc', 'avail', 'discard').
+
+    A regular (non-tiered, non-disagg) checkpoint cookie is version 1 followed by 14 packed integers:
+    the root, alloc, avail and discard address triples, then the file and checkpoint sizes. Only
+    blocks with a non-zero size, i.e. those written to their own on-disk block, are returned.
+
+    Corruption tests use this to target or avoid these blocks: a checkpoint that drops another reads
+    its alloc and discard extent lists, and a failed read there is fatal.
+    """
+    # unpack_int lives with the wt tooling, which is not on the suite path by default.
+    tools_dir = os.path.join(os.path.dirname(__file__), '..', '..', '..', 'tools')
+    if tools_dir not in sys.path:
+        sys.path.append(tools_dir)
+    from py_common.binary_data import unpack_int
+
+    with WiredTigerCursor(session, 'metadata:') as c:
+        c.set_key(uri)
+        if c.search() != 0:
+            raise KeyError(f"URI not found in metadata: {uri}")
+        config = c.get_value()
+
+    blocks = []
+    for cookie in re.findall(r'addr="([0-9a-fA-F]+)"', config):
+        addr = bytes(bytearray.fromhex(cookie))
+        if addr[0] != 1:
+            continue
+        addr = addr[1:]
+        values = []
+        while True:
+            try:
+                v, addr = unpack_int(addr)
+                values.append(v)
+            except Exception:
+                break
+        if len(values) != 14:
+            continue
+        for kind in kinds:
+            off, size, _ = values[_CKPT_COOKIE_TRIPLE[kind]:_CKPT_COOKIE_TRIPLE[kind] + 3]
+            if size != 0:
+                blocks.append(((off + 1) * allocsize, size * allocsize))
+    return blocks

--- a/test/suite/test_corrupt02.py
+++ b/test/suite/test_corrupt02.py
@@ -26,8 +26,8 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-import os, re, sys
 import wiredtiger, wttest
+from metadata_helper import checkpoint_extent_list_blocks
 
 # When a checkpoint drops a previous checkpoint, it reads that checkpoint's extent lists. If the
 # extent-list block is corrupt, the read fails its checksum and drives the diagnostic extent-list
@@ -45,43 +45,6 @@ class test_corrupt02(wttest.WiredTigerTestCase):
     test_name = __qualname__
     uri = f'table:{test_name}'
     tablename = f'{test_name}.wt'
-    allocsize = 4096
-
-    def alloc_extlist_blocks(self):
-        # Decode every checkpoint's address cookie from the metadata and return the (offset, size) of
-        # each alloc extent-list block that lives in its own on-disk block.
-        tools_dir = os.path.join(os.path.dirname(__file__), '..', '..', 'tools')
-        if tools_dir not in sys.path:
-            sys.path.append(tools_dir)
-        from py_common.binary_data import unpack_int
-
-        cursor = self.session.open_cursor('metadata:', None, None)
-        cursor.set_key('file:' + self.tablename)
-        self.assertEqual(cursor.search(), 0)
-        config = cursor.get_value()
-        cursor.close()
-
-        blocks = []
-        for cookie in re.findall(r'addr="([0-9a-fA-F]+)"', config):
-            addr = bytes(bytearray.fromhex(cookie))
-            # A regular checkpoint cookie is version 1 followed by 14 packed ints: the root, alloc,
-            # avail and discard triples then the file and checkpoint sizes.
-            if addr[0] != 1:
-                continue
-            addr = addr[1:]
-            values = []
-            while True:
-                try:
-                    v, addr = unpack_int(addr)
-                    values.append(v)
-                except Exception:
-                    break
-            if len(values) != 14:
-                continue
-            off, size, _ = values[3:6]
-            if size != 0:
-                blocks.append(((off + 1) * self.allocsize, size * self.allocsize))
-        return blocks
 
     def write_rows(self, start, count):
         cursor = self.session.open_cursor(self.uri)
@@ -98,7 +61,7 @@ class test_corrupt02(wttest.WiredTigerTestCase):
 
         # Corrupt every alloc extent-list block the checkpoint cookies point at, leaving the rest of
         # the file intact.
-        blocks = self.alloc_extlist_blocks()
+        blocks = checkpoint_extent_list_blocks(self.session, 'file:' + self.tablename, kinds=('alloc',))
         self.assertGreater(len(blocks), 0,
             "expected at least one on-disk alloc extent-list block to corrupt")
         with open(self.tablename, 'r+b') as f:

--- a/test/suite/test_prepare_hs03.py
+++ b/test/suite/test_prepare_hs03.py
@@ -34,7 +34,7 @@
 from helper import copy_wiredtiger_home
 import wttest
 from wtdataset import SimpleDataSet
-import os
+import os, re, sys
 from wtscenario import make_scenarios
 from wiredtiger import stat
 
@@ -68,16 +68,76 @@ class test_prepare_hs03(wttest.WiredTigerTestCase):
 
     scenarios = make_scenarios(corrupt_values, format_values)
 
+    # Default allocation size, and therefore the size of a checkpoint's extent-list blocks.
+    allocsize = 4096
+
+    def extlist_blocks(self):
+        # Decode every checkpoint's address cookie from the metadata and return the (offset, size) of
+        # its alloc/avail/discard extent-list blocks. Corrupting one of these makes the following
+        # checkpoint's block read fatal (WT_PANIC) rather than something salvage can recover, so the
+        # corruption below must leave them intact.
+        tools_dir = os.path.join(os.path.dirname(__file__), '..', '..', 'tools')
+        if tools_dir not in sys.path:
+            sys.path.append(tools_dir)
+        from py_common.binary_data import unpack_int
+
+        cursor = self.session.open_cursor('metadata:', None, None)
+        cursor.set_key('file:' + self.test_name + '.wt')
+        self.assertEqual(cursor.search(), 0)
+        config = cursor.get_value()
+        cursor.close()
+
+        blocks = []
+        for cookie in re.findall(r'addr="([0-9a-fA-F]+)"', config):
+            addr = bytes(bytearray.fromhex(cookie))
+            # A regular checkpoint cookie is version 1 followed by 14 packed ints: the root, alloc,
+            # avail and discard triples then the file and checkpoint sizes.
+            if addr[0] != 1:
+                continue
+            addr = addr[1:]
+            values = []
+            while True:
+                try:
+                    v, addr = unpack_int(addr)
+                    values.append(v)
+                except Exception:
+                    break
+            if len(values) != 14:
+                continue
+            for off, size, _ in (values[3:6], values[6:9], values[9:12]):
+                if size != 0:
+                    blocks.append(((off + 1) * self.allocsize, size * self.allocsize))
+        return blocks
+
     def corrupt_table(self, data_to_corrupt_with):
         tablename=f"{self.test_name}.wt"
         self.assertEqual(os.path.exists(tablename), True)
 
-        # This code will overwrite part of the table with 'bad' data, corrupting the table in the process.
-        # The impact of this overwriting can depend on the number of bytes overwritten, depending on what the
+        # Overwrite part of the table with 'bad' data, corrupting the table in the process. The impact
+        # of this overwriting can depend on the number of bytes overwritten, depending on what the
         # rest of the test does and expects.
-        with open(tablename, 'r+') as tablepointer:
-            tablepointer.seek(1024)
-            tablepointer.write(data_to_corrupt_with)
+        #
+        # Leave the checkpoint's extent-list blocks intact. Salvage cannot recover a corrupt extent
+        # list, and a later checkpoint that drops this one reads its extent lists: a failed read
+        # there is fatal (a WT_PANIC under the default corruption_abort), so corrupting one aborts
+        # the test whenever the file layout happens to place an extent-list block in the range below.
+        protect = sorted(self.extlist_blocks())
+        start = 1024
+        data = bytes(data_to_corrupt_with, 'latin-1')
+        end = start + len(data)
+        with open(tablename, 'r+b') as tablepointer:
+            pos = start
+            for b_off, b_size in protect:
+                b_end = b_off + b_size
+                if b_end <= pos or b_off >= end:
+                    continue
+                if b_off > pos:
+                    tablepointer.seek(pos)
+                    tablepointer.write(data[pos - start:b_off - start])
+                pos = max(pos, b_end)
+            if pos < end:
+                tablepointer.seek(pos)
+                tablepointer.write(data[pos - start:])
 
     def corrupt_salvage_verify(self):
         # An exclusive handle operation can fail if there is dirty data in the cache, closing the

--- a/test/suite/test_prepare_hs03.py
+++ b/test/suite/test_prepare_hs03.py
@@ -32,9 +32,10 @@
 # [END_TAGS]
 
 from helper import copy_wiredtiger_home
+from metadata_helper import checkpoint_extent_list_blocks
 import wttest
 from wtdataset import SimpleDataSet
-import os, re, sys
+import os
 from wtscenario import make_scenarios
 from wiredtiger import stat
 
@@ -68,47 +69,6 @@ class test_prepare_hs03(wttest.WiredTigerTestCase):
 
     scenarios = make_scenarios(corrupt_values, format_values)
 
-    # Default allocation size, and therefore the size of a checkpoint's extent-list blocks.
-    allocsize = 4096
-
-    def extlist_blocks(self):
-        # Decode every checkpoint's address cookie from the metadata and return the (offset, size) of
-        # its alloc/avail/discard extent-list blocks. Corrupting one of these makes the following
-        # checkpoint's block read fatal (WT_PANIC) rather than something salvage can recover, so the
-        # corruption below must leave them intact.
-        tools_dir = os.path.join(os.path.dirname(__file__), '..', '..', 'tools')
-        if tools_dir not in sys.path:
-            sys.path.append(tools_dir)
-        from py_common.binary_data import unpack_int
-
-        cursor = self.session.open_cursor('metadata:', None, None)
-        cursor.set_key('file:' + self.test_name + '.wt')
-        self.assertEqual(cursor.search(), 0)
-        config = cursor.get_value()
-        cursor.close()
-
-        blocks = []
-        for cookie in re.findall(r'addr="([0-9a-fA-F]+)"', config):
-            addr = bytes(bytearray.fromhex(cookie))
-            # A regular checkpoint cookie is version 1 followed by 14 packed ints: the root, alloc,
-            # avail and discard triples then the file and checkpoint sizes.
-            if addr[0] != 1:
-                continue
-            addr = addr[1:]
-            values = []
-            while True:
-                try:
-                    v, addr = unpack_int(addr)
-                    values.append(v)
-                except Exception:
-                    break
-            if len(values) != 14:
-                continue
-            for off, size, _ in (values[3:6], values[6:9], values[9:12]):
-                if size != 0:
-                    blocks.append(((off + 1) * self.allocsize, size * self.allocsize))
-        return blocks
-
     def corrupt_table(self, data_to_corrupt_with):
         tablename=f"{self.test_name}.wt"
         self.assertEqual(os.path.exists(tablename), True)
@@ -121,7 +81,7 @@ class test_prepare_hs03(wttest.WiredTigerTestCase):
         # list, and a later checkpoint that drops this one reads its extent lists: a failed read
         # there is fatal (a WT_PANIC under the default corruption_abort), so corrupting one aborts
         # the test whenever the file layout happens to place an extent-list block in the range below.
-        protect = sorted(self.extlist_blocks())
+        protect = sorted(checkpoint_extent_list_blocks(self.session, 'file:' + self.test_name + '.wt'))
         start = 1024
         data = bytes(data_to_corrupt_with, 'latin-1')
         end = start + len(data)

--- a/test/suite/test_prepare_hs03.py
+++ b/test/suite/test_prepare_hs03.py
@@ -73,10 +73,6 @@ class test_prepare_hs03(wttest.WiredTigerTestCase):
         tablename=f"{self.test_name}.wt"
         self.assertEqual(os.path.exists(tablename), True)
 
-        # Overwrite part of the table with 'bad' data, corrupting the table in the process. The impact
-        # of this overwriting can depend on the number of bytes overwritten, depending on what the
-        # rest of the test does and expects.
-        #
         # Leave the checkpoint's extent-list blocks intact. Salvage cannot recover a corrupt extent
         # list, and a later checkpoint that drops this one reads its extent lists: a failed read
         # there is fatal (a WT_PANIC under the default corruption_abort), so corrupting one aborts

--- a/test/suite/test_prepare_hs03.py
+++ b/test/suite/test_prepare_hs03.py
@@ -81,19 +81,19 @@ class test_prepare_hs03(wttest.WiredTigerTestCase):
         start = 1024
         data = bytes(data_to_corrupt_with, 'latin-1')
         end = start + len(data)
-        with open(tablename, 'r+b') as tablepointer:
+        with open(tablename, 'r+b') as f:
             pos = start
             for b_off, b_size in protect:
                 b_end = b_off + b_size
                 if b_end <= pos or b_off >= end:
                     continue
                 if b_off > pos:
-                    tablepointer.seek(pos)
-                    tablepointer.write(data[pos - start:b_off - start])
+                    f.seek(pos)
+                    f.write(data[pos - start:b_off - start])
                 pos = max(pos, b_end)
             if pos < end:
-                tablepointer.seek(pos)
-                tablepointer.write(data[pos - start:])
+                f.seek(pos)
+                f.write(data[pos - start:])
 
     def corrupt_salvage_verify(self):
         # An exclusive handle operation can fail if there is dirty data in the cache, closing the


### PR DESCRIPTION
`test_prepare_hs03` corrupts the table at a fixed file offset (1024) with a large blob and expects salvage/verify to recover. The failure this addresses is intermittent: whether the blob lands on a checkpoint's extent-list block depends on the run-to-run file layout.

**Problem**

When the corruption happens to cover an extent-list block, a later checkpoint that drops that checkpoint reads its extent lists (`__ckpt_read_deletion_extlists` -> `__ckpt_extlist_read`). A failed read there is fatal — a `WT_PANIC` under the default `corruption_abort=true` — which salvage cannot recover from. So the test aborted intermittently, depending purely on layout. (The spurious `__assert_ckpt_matches` abort that this used to surface as was the diagnostic-path use-after-free fixed separately in WT-18048.)

**Solution**

Decode the checkpoint address cookies from the metadata and leave the alloc/avail/discard extent-list blocks intact, while still corrupting the surrounding data. The corruption stays recoverable by salvage, and the test no longer creates the fatal case, so it passes deterministically.

The cookie decode reuses `tools/py_common/binary_data.py` (the same helper the merged `test_corrupt02.py` uses).

**Testing**

`test_prepare_hs03` now passes across all four scenarios and repeated runs with no aborts (previously intermittent). Tiered/disagg hooks still skip (unchanged), and the file is ruff-clean.
