### PR TITLE
WT-17869 Fix unsigned underflow in pinned timestamp lag statistics

### DIFF
--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -2381,15 +2381,15 @@ __wt_txn_stats_update(WT_SESSION_IMPL *session)
     WT_CONNECTION_STATS **stats;
     WT_TXN_GLOBAL *txn_global;
     wt_timestamp_t checkpoint_timestamp, checkpoint_pinned_ts_lag;
-    wt_timestamp_t durable_timestamp;
+    wt_timestamp_t durable_timestamp, durable_oldest_lag;
     wt_timestamp_t oldest_active_read_timestamp, oldest_reader_lag;
-    wt_timestamp_t oldest_timestamp;
+    wt_timestamp_t oldest_timestamp, pinned_ts_lag;
     wt_timestamp_t pinned_timestamp;
     uint64_t checkpoint_pinned;
 
     conn = S2C(session);
     checkpoint_pinned = WT_TXN_NONE;
-    checkpoint_pinned_ts_lag = oldest_reader_lag = WT_TS_NONE;
+    checkpoint_pinned_ts_lag = durable_oldest_lag = oldest_reader_lag = pinned_ts_lag = WT_TS_NONE;
     checkpoint_timestamp = WT_TS_NONE;
     txn_global = &conn->txn_global;
     stats = conn->stats;
@@ -2412,8 +2412,9 @@ __wt_txn_stats_update(WT_SESSION_IMPL *session)
         pinned_timestamp = checkpoint_timestamp;
 
     /* Represents the lag of the pinned timestamp with respect to the oldest timestamp.*/
-    WT_STATP_CONN_SET(
-      session, stats, txn_pinned_timestamp_lag, oldest_timestamp - pinned_timestamp);
+    if (oldest_timestamp > pinned_timestamp)
+        pinned_ts_lag = oldest_timestamp - pinned_timestamp;
+    WT_STATP_CONN_SET(session, stats, txn_pinned_timestamp_lag, pinned_ts_lag);
 
     /* Represents the lag of the checkpoint timestamp with respect to the oldest timestamp.*/
     if (checkpoint_timestamp != WT_TS_NONE && checkpoint_timestamp < oldest_timestamp)
@@ -2422,8 +2423,10 @@ __wt_txn_stats_update(WT_SESSION_IMPL *session)
     WT_STATP_CONN_SET(
       session, stats, txn_pinned_timestamp_checkpoint_lag, checkpoint_pinned_ts_lag);
 
-    WT_STATP_CONN_SET(
-      session, stats, txn_pinned_timestamp_oldest, durable_timestamp - oldest_timestamp);
+    /* Represents how far the durable timestamp leads the oldest timestamp. */
+    if (durable_timestamp > oldest_timestamp)
+        durable_oldest_lag = durable_timestamp - oldest_timestamp;
+    WT_STATP_CONN_SET(session, stats, txn_pinned_timestamp_oldest, durable_oldest_lag);
 
     __wti_txn_get_pinned_timestamp(session, &oldest_active_read_timestamp, 0);
     if (oldest_active_read_timestamp != WT_TS_NONE &&

--- a/test/catch2/CMakeLists.txt
+++ b/test/catch2/CMakeLists.txt
@@ -31,6 +31,7 @@ else()
         misc_tests/test_session_config.cpp
         misc_tests/test_string_match.cpp
         misc_tests/test_tailq.cpp
+        misc_tests/test_txn_pinned_timestamp_stat.cpp
         misc_tests/test_verify_compare_page_id_lists.cpp
         block/api/test_block_api_misc.cpp
         block/api/test_block_api_write.cpp

--- a/test/catch2/misc_tests/test_txn_pinned_timestamp_stat.cpp
+++ b/test/catch2/misc_tests/test_txn_pinned_timestamp_stat.cpp
@@ -1,0 +1,57 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+#include <catch2/catch.hpp>
+#include "wt_internal.h"
+
+#include "../utils.h"
+#include "../wrappers/connection_wrapper.h"
+#include "../../utility/test_util.h"
+
+/*
+ * The pinned-timestamp lag statistics are computed as unsigned timestamp subtractions. When the
+ * durable timestamp trails the oldest timestamp the subtraction must not underflow. The public stat
+ * cursor clamps negative aggregates to zero, so the underflow is only observable in the raw
+ * per-bucket value written by the statistics update.
+ */
+TEST_CASE("txn stats: pinned timestamp statistics do not underflow", "[txn][statistics]")
+{
+    const std::string home = "WT_TEST.txn_pinned_timestamp_stat";
+    testutil_system("rm -rf %s && mkdir -p %s", home.c_str(), home.c_str());
+
+    connection_wrapper conn(home, "create,statistics=(all)");
+    WT_CONNECTION_IMPL *conn_impl = conn.get_wt_connection_impl();
+    WT_CONNECTION *wt_conn = conn.get_wt_connection();
+    WT_SESSION_IMPL *session = conn.create_session();
+
+    /* The update writes to bucket zero after clearing every bucket. */
+    int64_t *stat = &conn_impl->stats[0]->txn_pinned_timestamp_oldest;
+
+    SECTION("durable timestamp unset, oldest advanced")
+    {
+        REQUIRE(wt_conn->set_timestamp(wt_conn, "oldest_timestamp=64,stable_timestamp=64") == 0);
+        __wt_txn_stats_update(session);
+        CHECK(*stat == 0);
+    }
+
+    SECTION("durable timestamp explicitly behind oldest")
+    {
+        REQUIRE(wt_conn->set_timestamp(wt_conn, "oldest_timestamp=64,stable_timestamp=64") == 0);
+        REQUIRE(wt_conn->set_timestamp(wt_conn, "durable_timestamp=20") == 0);
+        __wt_txn_stats_update(session);
+        CHECK(*stat == 0);
+    }
+
+    SECTION("durable timestamp ahead of oldest reflects the real lag")
+    {
+        REQUIRE(wt_conn->set_timestamp(wt_conn, "oldest_timestamp=64,stable_timestamp=64") == 0);
+        REQUIRE(wt_conn->set_timestamp(wt_conn, "durable_timestamp=100") == 0);
+        __wt_txn_stats_update(session);
+        CHECK(*stat == 0x100 - 0x64);
+    }
+}

--- a/test/catch2/misc_tests/test_txn_pinned_timestamp_stat.cpp
+++ b/test/catch2/misc_tests/test_txn_pinned_timestamp_stat.cpp
@@ -11,7 +11,6 @@
 
 #include "../utils.h"
 #include "../wrappers/connection_wrapper.h"
-#include "../../utility/test_util.h"
 
 /*
  * The pinned-timestamp lag statistics are computed as unsigned timestamp subtractions. When the
@@ -22,8 +21,8 @@
 TEST_CASE("txn stats: pinned timestamp statistics do not underflow", "[txn][statistics]")
 {
     const std::string home = "WT_TEST.txn_pinned_timestamp_stat";
-    testutil_system("rm -rf %s && mkdir -p %s", home.c_str(), home.c_str());
 
+    /* The connection wrapper creates the home directory and cleans it up on destruction. */
     connection_wrapper conn(home, "create,statistics=(all)");
     WT_CONNECTION_IMPL *conn_impl = conn.get_wt_connection_impl();
     WT_CONNECTION *wt_conn = conn.get_wt_connection();

--- a/test/suite/test_timestamp30.py
+++ b/test/suite/test_timestamp30.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# test_timestamp30.py
+#   Timestamps: the pinned-timestamp lag statistics must never report a
+#   negative value when a timestamp trails the oldest timestamp.
+
+import wttest
+from wiredtiger import stat
+
+class test_timestamp30(wttest.WiredTigerTestCase):
+    conn_config = 'statistics=(all)'
+
+    def get_stat(self, which):
+        stat_cursor = self.session.open_cursor('statistics:', None, None)
+        val = stat_cursor[which][2]
+        stat_cursor.close()
+        return val
+
+    # The durable timestamp is not required to lead the oldest timestamp: an
+    # application may advance oldest without ever setting durable, and may even
+    # move durable backwards. When durable trails oldest the "pinned by the
+    # oldest timestamp" statistic must report 0 rather than an underflowed
+    # (negative) value.
+    def test_pinned_timestamp_oldest_no_underflow(self):
+        # Advance oldest and stable while leaving the durable timestamp unset.
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(100) +
+            ',stable_timestamp=' + self.timestamp_str(100))
+        self.assertGreaterEqual(
+            self.get_stat(stat.conn.txn_pinned_timestamp_oldest), 0)
+        self.assertGreaterEqual(
+            self.get_stat(stat.conn.txn_pinned_timestamp_lag), 0)
+
+        # Explicitly move the durable timestamp behind oldest.
+        self.conn.set_timestamp('durable_timestamp=' + self.timestamp_str(50))
+        self.assertGreaterEqual(
+            self.get_stat(stat.conn.txn_pinned_timestamp_oldest), 0)
+
+        # Once durable leads oldest the statistic reflects the real lag.
+        self.conn.set_timestamp('durable_timestamp=' + self.timestamp_str(300))
+        self.assertEqual(
+            self.get_stat(stat.conn.txn_pinned_timestamp_oldest), 300 - 100)


### PR DESCRIPTION
## Root cause

`__wt_txn_stats_update` computed the `txn_pinned_timestamp_oldest` and `txn_pinned_timestamp_lag` statistics as unconditional unsigned (`uint64_t`) timestamp subtractions:

- `txn_pinned_timestamp_oldest = durable_timestamp - oldest_timestamp`
- `txn_pinned_timestamp_lag = oldest_timestamp - pinned_timestamp`

Neither subtraction has an ordering guarantee. Unlike `oldest`/`stable`, the durable timestamp is not required to lead the oldest timestamp — it defaults to `WT_TS_NONE` until set, and the application may deliberately move it backwards. The pinned timestamp can likewise exceed the oldest timestamp (e.g. when clamped up to a higher checkpoint timestamp). When the minuend is smaller, the subtraction underflows and wraps to a huge value.

The public stat cursor clamps negative aggregates to zero, so the wrapped value is usually masked on read, but the underflow itself is a bug.

## Fix

Guard both subtractions, mirroring the pattern already used by the adjacent `txn_pinned_timestamp_checkpoint_lag` and `txn_pinned_timestamp_reader_lag` statistics.

## Tests

- **Catch2** (`test_txn_pinned_timestamp_stat.cpp`): inspects the raw per-bucket statistic before aggregation clamps negatives to zero — this is the level at which the underflow is observable. Fails without the fix (`-100`, `-68`), passes with it.
- **Python** (`test_timestamp30.py`): behavioral coverage through the stat cursor.