### PR TITLE
WT-17974 Add multi-node schema abort test infrastructure

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -451,6 +451,7 @@ SDK
 SIGABRT
 SIGBUS
 SIGKILL
+SIGPIPE
 SIGSEGV
 SIMD
 SLS
@@ -504,6 +505,7 @@ TSan
 TTY
 TW
 TXN
+TerminateProcess
 TestSuiteConnection
 Testcases
 ThreadList
@@ -872,6 +874,7 @@ cutlim
 cutover
 cv
 cval
+cwait
 cx
 cxa
 cygwin
@@ -1034,6 +1037,7 @@ fclose
 fcntl
 fd
 fdatasync
+fds
 feffff
 fextend
 ffc
@@ -1479,6 +1483,7 @@ oplog
 optrack
 optwt
 optype
+orchestrator
 ord
 ori
 origcnt
@@ -1598,6 +1603,7 @@ readtime
 readunlock
 realloc
 reallocations
+realpath
 rebalancing
 recency
 recno
@@ -1698,6 +1704,7 @@ softptr
 somename
 sortable
 sp
+spawnv
 spinlock
 spinlocks
 sqlite
@@ -1761,6 +1768,7 @@ subinit
 sublicense
 sublist
 suboptimal
+subproc
 subprocess
 subprocesses
 substring
@@ -1907,6 +1915,7 @@ unredacts
 unreferenced
 unsetting
 unsized
+unspawned
 unsynchronised
 unterminated
 untyped

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1975,6 +1975,7 @@ vdata
 vec
 vectorized
 verifier
+verifier's
 verifyLayered
 vers
 vfprintf

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -167,6 +167,7 @@ ENOSPC
 ENOTSUP
 ENUM
 EOF
+EPIPE
 EQ
 ERANGE
 ETIME
@@ -367,6 +368,7 @@ Og
 Optane
 Outfmt
 PALI
+PALITE
 PALite
 PDEATHSIG
 PFX
@@ -407,6 +409,7 @@ Py
 QQQS
 QSQ
 Qsort
+Quiesce
 RCPC
 RCpc
 RDNOLOCK
@@ -451,6 +454,8 @@ SDK
 SIGABRT
 SIGBUS
 SIGKILL
+SIGKILLed
+SIGKILLs
 SIGPIPE
 SIGSEGV
 SIMD
@@ -646,6 +651,7 @@ ajn
 al
 alloc
 allocator
+allocator's
 allocators
 allocfile
 allocsize
@@ -679,6 +685,7 @@ bInheritHandle
 backends
 backlink
 backoff
+backpressures
 badsize
 bal
 basecfg
@@ -808,6 +815,7 @@ collatorp
 collist
 columngroup
 commandline
+commit's
 committime
 compactUntilSuccess
 comparator
@@ -916,6 +924,8 @@ deflateEnd
 deflateInit
 del
 deletable
+demuxes
+demuxing
 dequeued
 der
 deref
@@ -958,6 +968,7 @@ dmb
 dmsg
 drealloc
 dropUntilSuccess
+droppable
 dryrun
 ds
 dsb
@@ -1016,6 +1027,7 @@ ev
 evd
 eventv
 evictable
+evq
 ewma
 exactp
 exc
@@ -1026,6 +1038,7 @@ extern
 extlist
 extlists
 extraconfig
+fN
 fadvise
 fahrenheit
 failover
@@ -1252,6 +1265,7 @@ kp
 kv
 kvraw
 kvs
+lN
 lang
 las
 latin
@@ -1394,6 +1408,7 @@ namespace
 namespaced
 namespaces
 nbits
+nclose
 nclr
 nd
 needkey
@@ -1553,6 +1568,7 @@ presync
 prev
 prevlsn
 printf
+println
 printlog
 priv
 probabilistically
@@ -1835,6 +1851,7 @@ tombstoned
 toml
 toolchain
 toolchains
+topologies
 totalsec
 tp
 traceapi
@@ -1892,6 +1909,7 @@ unesc
 unescape
 unescaped
 unflatten
+ungated
 unhandled
 unicode
 uninstantiated
@@ -1920,6 +1938,8 @@ unsynchronised
 unterminated
 untyped
 unvisited
+unwedge
+up's
 upd
 uri
 uri's
@@ -1967,6 +1987,7 @@ vpmsumd
 vprintf
 vsize
 vsnprintf
+vtable
 vthread
 vunpack
 vxr

--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -926,6 +926,7 @@ del
 deletable
 demuxes
 demuxing
+dequeue
 dequeued
 der
 deref

--- a/dist/s_void
+++ b/dist/s_void
@@ -183,6 +183,7 @@ func_ok()
         -e '/int lz4_terminate$/d' \
         -e '/int main$/d' \
         -e '/int message_handler$/d' \
+        -e '/int node_run$/d' \
         -e '/int nop_decompress$/d' \
         -e '/int nop_decrypt$/d' \
         -e '/int nop_error$/d' \

--- a/src/block_disagg/block_disagg_read.c
+++ b/src/block_disagg/block_disagg_read.c
@@ -68,17 +68,20 @@ err:
     }
     va_end(args);
 
+    /*
+     * Build the message once: the two sinks differ only in where the text goes. Truncation is
+     * harmless here and a failure return has nowhere useful to go, so the result is ignored.
+     */
+    char msg[1024];
+    WT_IGNORE_RET(__wt_snprintf(msg, sizeof(msg),
+      "%s: read error for %" PRIu32 "B block at page %" PRIu64 ", lsn %" PRIu64
+      ", table_id %" PRIu64 ", %s, %s",
+      name, size, page_id, lsn, table_id, page_desc, context_msg));
+
     if (F_ISSET(session, WT_SESSION_QUIET_CORRUPT_FILE))
-        __wt_verbose_debug1(session, WT_VERB_READ,
-          "%s: read error for %" PRIu32 "B block at page %" PRIu64 ", lsn %" PRIu64
-          ", table_id %" PRIu64 ", %s, %s",
-          name, size, page_id, lsn, table_id, page_desc, context_msg);
+        __wt_verbose_debug1(session, WT_VERB_READ, "%s", msg);
     else
-        __wt_errx(session,
-          "%s: read error for %" PRIu32
-          "B block at "
-          "page %" PRIu64 ", lsn %" PRIu64 ", table_id %" PRIu64 ", %s, %s",
-          name, size, page_id, lsn, table_id, page_desc, context_msg);
+        __wt_errx(session, "%s", msg);
 }
 
 /*

--- a/src/block_disagg/block_disagg_read.c
+++ b/src/block_disagg/block_disagg_read.c
@@ -38,7 +38,8 @@ err:
 
 /*
  * __block_disagg_read_err --
- *     Print a block disagg read error context in a standard way.
+ *     Print a block disagg read error context in a standard way. When the caller expects and
+ *     tolerates corruption, report at read-verbose level instead of dropping the context entirely.
  */
 static void
 __block_disagg_read_err(WT_SESSION_IMPL *session, const char *name, uint64_t table_id,
@@ -67,11 +68,17 @@ err:
     }
     va_end(args);
 
-    __wt_errx(session,
-      "%s: read error for %" PRIu32
-      "B block at "
-      "page %" PRIu64 ", lsn %" PRIu64 ", table_id %" PRIu64 ", %s, %s",
-      name, size, page_id, lsn, table_id, page_desc, context_msg);
+    if (F_ISSET(session, WT_SESSION_QUIET_CORRUPT_FILE))
+        __wt_verbose_debug1(session, WT_VERB_READ,
+          "%s: read error for %" PRIu32 "B block at page %" PRIu64 ", lsn %" PRIu64
+          ", table_id %" PRIu64 ", %s, %s",
+          name, size, page_id, lsn, table_id, page_desc, context_msg);
+    else
+        __wt_errx(session,
+          "%s: read error for %" PRIu32
+          "B block at "
+          "page %" PRIu64 ", lsn %" PRIu64 ", table_id %" PRIu64 ", %s, %s",
+          name, size, page_id, lsn, table_id, page_desc, context_msg);
 }
 
 /*
@@ -266,12 +273,11 @@ __block_disagg_read_multiple(WT_SESSION_IMPL *session, WT_BLOCK_DISAGG *block_di
                 continue;
             }
 
-            if (!F_ISSET(session, WT_SESSION_QUIET_CORRUPT_FILE))
-                __block_disagg_read_err(session, block_disagg->name, block_disagg->tableid, size,
-                  page_id, lsn, is_delta, result,
-                  "calculated checksum of %" PRIx32 " doesn't match expected checksum of %" PRIx32,
-                  swap.checksum, checksum);
-        } else if (!F_ISSET(session, WT_SESSION_QUIET_CORRUPT_FILE))
+            __block_disagg_read_err(session, block_disagg->name, block_disagg->tableid, size,
+              page_id, lsn, is_delta, result,
+              "calculated checksum of %" PRIx32 " doesn't match expected checksum of %" PRIx32,
+              swap.checksum, checksum);
+        } else
             __block_disagg_read_err(session, block_disagg->name, block_disagg->tableid, size,
               page_id, lsn, is_delta, result,
               "header checksum of %" PRIx32 " doesn't match expected checksum of %" PRIx32,

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -953,7 +953,8 @@ __wti_btree_tree_open(WT_SESSION_IMPL *session, const uint8_t *addr, size_t addr
         F_SET_ATOMIC_32(S2C(session), WT_CONN_DATA_CORRUPTION);
     F_CLR(session, WT_SESSION_QUIET_CORRUPT_FILE);
     if (ret != 0)
-        __wt_err(session, ret, "unable to read root page from %s", session->dhandle->name);
+        __wt_err(session, ret, "unable to read root page from %s (address %s)",
+          session->dhandle->name, (const char *)tmp->data);
     /*
      * Failure to open metadata means that the database is unavailable. Try to provide a helpful
      * failure message.

--- a/test/csuite/CMakeLists.txt
+++ b/test/csuite/CMakeLists.txt
@@ -95,15 +95,19 @@ define_c_test(
 if(ENABLE_PALITE AND WT_POSIX)
     create_test_executable(test_schema_disagg_abort
         SOURCES
+            schema_disagg_abort/event_pipe.c
             schema_disagg_abort/follower.c
+            schema_disagg_abort/generator.c
             schema_disagg_abort/leader.c
             schema_disagg_abort/main.c
             schema_disagg_abort/node.c
             schema_disagg_abort/parent.c
+            schema_disagg_abort/reader.c
             schema_disagg_abort/schema_disagg_abort.h
             schema_disagg_abort/subproc.c
             schema_disagg_abort/subproc.h
             schema_disagg_abort/verify.c
+            schema_disagg_abort/worker.c
         ADDITIONAL_FILES ${CMAKE_CURRENT_SOURCE_DIR}/schema_disagg_abort/smoke.sh
         BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/schema_disagg_abort
     )

--- a/test/csuite/CMakeLists.txt
+++ b/test/csuite/CMakeLists.txt
@@ -96,8 +96,11 @@ if(ENABLE_PALITE AND WT_POSIX)
     create_test_executable(test_schema_disagg_abort
         SOURCES
             schema_disagg_abort/main.c
-            schema_disagg_abort/workload.c
+            schema_disagg_abort/parent.c
+            schema_disagg_abort/leader.c
+            schema_disagg_abort/follower.c
             schema_disagg_abort/verify.c
+            schema_disagg_abort/subproc.c
         ADDITIONAL_FILES ${CMAKE_CURRENT_SOURCE_DIR}/schema_disagg_abort/smoke.sh
         BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/schema_disagg_abort
     )

--- a/test/csuite/CMakeLists.txt
+++ b/test/csuite/CMakeLists.txt
@@ -95,12 +95,15 @@ define_c_test(
 if(ENABLE_PALITE AND WT_POSIX)
     create_test_executable(test_schema_disagg_abort
         SOURCES
-            schema_disagg_abort/main.c
-            schema_disagg_abort/parent.c
-            schema_disagg_abort/leader.c
             schema_disagg_abort/follower.c
-            schema_disagg_abort/verify.c
+            schema_disagg_abort/leader.c
+            schema_disagg_abort/main.c
+            schema_disagg_abort/node.c
+            schema_disagg_abort/parent.c
+            schema_disagg_abort/schema_disagg_abort.h
             schema_disagg_abort/subproc.c
+            schema_disagg_abort/subproc.h
+            schema_disagg_abort/verify.c
         ADDITIONAL_FILES ${CMAKE_CURRENT_SOURCE_DIR}/schema_disagg_abort/smoke.sh
         BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/schema_disagg_abort
     )

--- a/test/csuite/schema_disagg_abort/README.md
+++ b/test/csuite/schema_disagg_abort/README.md
@@ -14,7 +14,7 @@ The binary runs in one of two roles, dispatched in `main.c`:
   topology, then drives a one-second-tick timeline of switches, kills, and a graceful stop
   (see [Running](#running)); a child dying at any other point fails the test. It opens
   WiredTiger only afterwards, to recover and verify.
-- **node** — a database node that leads or follows (`node.c`; role specifics in
+- **node** — a database node running as leader or follower (`node.c`; role specifics in
   `leader.c`/`follower.c` behind the `NODE_ROLE` vtable). Spawned by re-executing the binary
   with internal options (`-r node -i <id> -A l|f`, pipe fds via `-R`/`-W`), so nothing is
   inherited by forking. `subproc.[ch]` is the posix_spawn layer.
@@ -26,8 +26,8 @@ One run under the test home (`-h WT_TEST.foo`):
 ```
 WT_TEST.foo/
 ├── records/                      the verifier's ground truth
-│   ├── node<N>-schema-<T>        ops node N ORIGINATED while leading, per worker thread T
-│   └── node<N>-relay-<T>         peer ops node N APPLIED while following, per thread T
+│   ├── node<N>-leader-<T>        ops node N ORIGINATED itself, per worker thread T
+│   └── node<N>-follower-<T>      peer ops node N APPLIED as follower, per thread T
 ├── PALITE/                       shared page log — the "disaggregated storage"
 ├── WT_NODE0/                     node 0's local WiredTiger home
 ├── WT_NODE1/                     node 1's local WT home (only with -r lf)
@@ -47,9 +47,11 @@ WT_TEST.foo.SAVE/                 copy of the home, taken just before verificati
   reopen does not wipe it. Verification does: it opens with
   `disaggregated=(lose_all_my_data=true)`, deleting the local files and rebuilding the home
   from the page log — hence the `.SAVE` copy, taken first and replaced on every rerun.
-- **`records/`** — `CREATE <epoch> <uri>`, `DROP <epoch> <uri>`,
-  `INSERT <commit_ts> <kmin> <kmax> <uri>` (`record_event_line` defines the format). Opened
-  lazily, appended across terms, line-buffered so completed lines survive SIGKILL.
+- **`records/`** — named for the origin of what they log: `leader` files for the operations the
+  node produced itself, `follower` files for the peer's events it applied. Line formats:
+  `CREATE <epoch> <uri>`, `DROP <epoch> <uri>`, `INSERT <commit_ts> <kmin> <kmax> <uri>`
+  (`record_event_line` defines them). Opened lazily, appended across terms, line-buffered so
+  completed lines survive SIGKILL.
 - **Sentinels** (home root): `leader_ready` = first checkpoint (the parent starts the clock);
   `follower_ready` = first pickup; `switch_request` = switch command, **consumed (unlinked)**
   by the acting node so each request fires once; `switch_done.<k>` = k-th switch finished;
@@ -58,17 +60,23 @@ WT_TEST.foo.SAVE/                 copy of the home, taken just before verificati
 ## Event pipeline
 
 One pipeline, identical in both roles: a *source* writes `SCHEMA_EVENT`s to a pipe, the
-reader demuxes them by `thread_id` into per-worker queues, and the workers execute them.
+reader demuxes them by `thread_id` into per-worker queues, and the workers execute them. What
+differs is where the source is.
 
-- **Leading**: the source is the node's own **generator** thread, writing the term's full
-  stream — workload ops, `EVENT_CKPT` at random 0–3 s intervals, `EVENT_SWITCH` to end the
-  term — into a process-local **self-pipe**; workers relay every applied event to the peer.
-- **Following**: the source is the peer's relay (one pipe per direction; a node writes while
-  leading, reads while following). Nothing is relayed onward.
+- **A phase that generates** — a leader always, and a follower with no peer to receive from —
+  runs the node's own **generator** thread, writing the term's full stream (workload ops,
+  `EVENT_CKPT` at random 0–3 s intervals, `EVENT_SWITCH` to end the term) into a process-local
+  **self-pipe**. A leader's workers also relay every applied event to the peer.
+- **A phase that consumes** — a follower with a live peer — has no generator at all: its
+  source is the peer's relay (one pipe per direction, each named for the node that reads it).
+  Nothing is relayed onward.
+
+A peerless follower therefore creates and publishes tables of its own, and never checkpoints
+until it steps up: the way a fresh node bootstraps its own tables before taking leadership.
 
 Each workload event carries an `event_ts` from the node-wide monotonic allocator
 (`current_ts`): CREATE/DROP the epoch they publish at, INSERT its commit timestamp (also the
-row value); `EVENT_SWITCH` carries the term's high-water mark, `EVENT_CKPT` nothing. One
+row value); `EVENT_SWITCH` carries the term's final counter, `EVENT_CKPT` nothing. One
 counter for both axes makes causality an ordering property — a commit always draws a higher
 value than its table's create — so one frontier serves both the stable timestamp and the
 stable schema epoch. Backpressure is end-to-end: a full ring blocks the reader, a full pipe
@@ -77,16 +85,16 @@ blocks the producer.
 ## Threads (per phase)
 
 Every workload thread is per-phase: `workload_start` creates them, `workload_stop` joins them
-in dependency order — generator, reader, then `stop_phase` quiesces the workers, which drain
-their queues. The main thread runs the `node_run` loop: `workload_start` →
-`node_trigger_wait` (1 s poll on `handover_received`/`stop_run`) → `workload_stop` →
-transition or exit.
+in dependency order — the generator first if the phase had one, then the reader, then
+`stop_phase` quiesces the workers, which drain their queues. The main thread runs the
+`node_run` loop: `workload_start` → `node_trigger_wait` (1 s poll on
+`handover_received`/`stop_run`) → `workload_stop` → transition or exit.
 
 | Thread | Count | Does |
 |---|---|---|
-| generator | 1 | **leading** (`generator_lead`): `generator_round` feeds every worker one op — pick a slot with that worker's rnd, flip the slot model, allocate `event_ts`, emit CREATE/DROP, and give one create in `INSERT_ODDS` an INSERT at a fresh commit ts; drops of uncovered *dirty* slots are skipped and an empty round sleeps 1 ms. `EVENT_CKPT` every random 0–3 s; `switch_request` polled ~1/s. **following** (`generator_follow`): the same ~1/s sentinel watch, acting only when lone |
-| reader | 1 iff leading or peered | `select` (1 s) on the source pipe → demux ops into per-worker rings; `CKPT` → `leader_checkpoint` (leading; skipped while stable=0, MAX_STARTUP watchdog) or drain barrier → `follower_pick_up_checkpoint` (following); `SWITCH` → drain → assert counter == the sender's high-water mark → hand over; EOF (peer pipe only) → lone follower |
-| worker ×N | `-T`, ≤ 12 | pop own ring → execute the op (bounded EBUSY retry) → `apply_event`: schema ops record then publish, inserts commit then record → relay when leading → mark completed |
+| generator | 1 iff the phase generates | - `generator_round` feeds every worker one op — pick a slot with that worker's rnd, flip the slot model, allocate `event_ts`, emit CREATE/DROP, and give one create in `INSERT_ODDS` an INSERT at a fresh commit ts; drops of uncovered *dirty* slots are skipped and an empty round sleeps 1 ms</br>- `EVENT_CKPT` every random 0–3 s</br>- `switch_request` polled ~1/s → `EVENT_SWITCH` ends the stream and the phase</br>- holds its lead over the workers to one switch period's work (`GEN_APPLY_RATE_FLOOR`), so a hand-over has little to drain |
+| reader | 1 | - `select` (1 s) on the source pipe → demux ops into per-worker rings</br>- `CKPT` → **leader**: `leader_checkpoint` (skipped while stable=0, MAX_STARTUP watchdog); **follower**: drain barrier → `follower_pick_up_checkpoint`</br>- `SWITCH` → drain → assert counter == the sender's final counter → hand over</br>- EOF (peer pipe only) → peer dead: carry on as a lone follower |
+| worker ×N | `-T`, ≤ 12 | pop own ring → execute the op (bounded EBUSY retry) → `apply_event`: schema ops record then publish, inserts commit then record → relay to the peer (leader only) → mark completed |
 | timestamp | 1 | every 100 ms: frontier = min of workers' `completed_ts`; set oldest/stable/stable-schema-epoch to it (never backwards) |
 
 Coordination is lock-free by design: `stop_phase` quiesces every loop, per-worker SPSC rings plus `busy` flags connect
@@ -96,61 +104,64 @@ reader to workers, and `completed_ts[]` feeds the frontier.
 
 Both roles run the same state machine (`node_run`); only `leave()`/`enter()` differ. The
 hand-over value is the node's own quiesced counter: after `workload_stop`, `current_ts` holds
-everything the term allocated or adopted.
+everything the term allocated or adopted. `EVENT_SWITCH` is the stream's last event, so a
+hand-over cannot complete until everything already in flight is applied — which is why the
+generator's lead is bounded rather than left to the pipe's own capacity.
 
 ```
-        ┌──────────────────────── LEADING ─────────────────────────────┐
+        ┌──────────────────────── LEADER ──────────────────────────────┐
         │ generator: ops + CKPT events ▶ self-pipe                     │
         │            switch_request → EVENT_SWITCH(counter), exit      │
         │ reader   : CKPT   → leader_checkpoint ▶ PALITE → relay       │
         │                     (skip while stable=0; 1st: leader_ready) │
-        │            SWITCH → drain → assert counter == high-water     │
+        │            SWITCH → drain → assert counter == sender's final │
         │                     → handover                               │
-        │ workers  : execute → record(schema) + publish/commit         │
+        │ workers  : execute → record(leader) + publish/commit         │
         │            → relay ▶ peer pipe                               │
         └──────────────────────────────────────────────────────────────┘
   stop_run ──▶ quiesce → close(NULL: closing checkpoint) → exit(0)
   handover ──▶ quiesce → LEAVE: stable := counter → final checkpoint
                → CLOSE conn → send CKPT + SWITCH(counter) [peer alive]
-               ENTER follower: reopen conn ──▶ FOLLOWING
+               ENTER follower: reopen conn ──▶ FOLLOWER
   EPIPE on relay ──▶ peer_alive = false (lone leader keeps producing)
 
-        ┌──────────────────────── FOLLOWING ───────────────────────────┐
-        │ generator: idle sentinel watch; when lone:                   │
-        │            switch_request → handover, exit                   │
+        ┌──────────────────────── FOLLOWER ────────────────────────────┐
+        │ generator: none when peered; the peer's relay is the source  │
+        │            when lone: ops + CKPT events ▶ self-pipe          │
+        │            switch_request → EVENT_SWITCH(counter), exit      │
         │ reader   : CKPT   → drain → pickup ◀ PALITE                  │
         │                     (1st: follower_ready)                    │
         │            SWITCH → drain → assert → handover                │
-        │            EOF    → peer dead: continue as lone follower     │
-        │ workers  : execute the SAME ops → record(relay)              │
-        │            + publish/commit at the stream's event_ts         │
-        └──────────────────────────────────────────────────────────-───┘
+        │            EOF    → peer dead: carry on, now generating      │
+        │ workers  : execute → record + publish/commit at the stream's │
+        │            event_ts (a follower never relays)                │
+        └──────────────────────────────────────────────────────────────┘
   stop_run ──▶ quiesce → close(skip_checkpoint) → exit(0)
   handover ──▶ quiesce → LEAVE: nothing
                ENTER leader: [lone: adopt latest checkpoint first]
                → reconfigure(role=leader) → seed + restore frontier
-               from the own counter ──▶ LEADING
+               from the own counter ──▶ LEADER
 ```
 
 ### Role differences
 
 | Aspect | Leader | Follower |
 |---|---|---|
-| Event source | own generator → self-pipe | peer's relay → in-pipe; none when lone (idles) |
+| Event source | own generator → self-pipe | peer's relay → in-pipe; its own generator when lone |
 | Counter | generator *allocates* `event_ts` values | *adopts* them from events (`counter_advance`) |
 | `EVENT_CKPT` | reader produces the checkpoint, then relays the event (no barrier: it races the workload) | reader barriers, then picks the checkpoint up |
 | Relay | workers relay applied events; reader relays `EVENT_CKPT` | — |
 | `leave()` | heavy: advance stable to the term's counter, final checkpoint, **close the connection**, hand over | empty |
 | `enter()` | reconfigure + seed counter + restore frontier (+ adopt-latest when lone) | reopen the connection |
 | Graceful close | `close(NULL)` — closing checkpoint | `close(skip_checkpoint)` |
-| Readiness / records | `leader_ready`; `node*-schema-*` | `follower_ready`; `node*-relay-*` |
+| Readiness / records | `leader_ready`; `node*-leader-*` | `follower_ready`; `node*-follower-*` |
 | Peer-death signal | EPIPE while relaying | pipe EOF |
 
 Both roles react to peer death the same way: keep the role, become "lone"
-(`peer_alive = false`). Lone-ness changes four things — a follower phase starts no reader
-thread, the generator becomes the switch-sentinel actor, a lone step-up adopts the page log's
-latest checkpoint before reconfiguring, and the transition reports `switch_done.<k>` itself
-(a lone step-down has no peer to hand over to).
+(`peer_alive = false`). Lone-ness changes three things — the next follower phase generates its
+own workload instead of consuming a peer's, a lone step-up adopts the page log's latest
+checkpoint before reconfiguring, and the transition reports `switch_done.<k>` itself (a lone
+step-down has no peer to hand over to).
 
 ## Invariants
 
@@ -175,8 +186,8 @@ latest checkpoint before reconfiguring, and the transition reports `switch_done.
    restores the same frontier so an early checkpoint of the new term cannot regress the
    shared epoch.
 4. **Hand-over integrity**: `EVENT_SWITCH` is the last event of a term's stream; the receiver
-   drains everything before acting and asserts its counter equals the event's high-water mark
-   — every allocated value rides an event that precedes the switch. The old leader closes its
+   drains everything before acting and asserts its counter equals the event's final counter —
+   every allocated value rides an event that precedes the switch. The old leader closes its
    connection *before* the switch is sent (one writer per page log).
 5. **Uniform EBUSY policy**: workers retry the same operation with a MAX_STARTUP bound; the
    stream is fixed at generation time and the slot model flips when the generator emits, so
@@ -185,7 +196,7 @@ latest checkpoint before reconfiguring, and the transition reports `switch_done.
 ## Verification
 
 After the run the parent copies the home to `.SAVE`, recovery-opens every node home that
-exists, and checks it against the union of the nodes' `schema` records (`verify.c`):
+exists, and checks it against the union of the nodes' `leader` records (`verify.c`):
 
 - `last_disaggregated_schema_epoch` is the durability cutoff: records above it never reached
   a checkpoint and carry no expectations.
@@ -193,9 +204,9 @@ exists, and checks it against the union of the nodes' `schema` records (`verify.
 - Data: for durable creates the recorded key range must be present, each row valued by its
   commit timestamp (a mismatch means another generation's data); inserts above the last
   checkpoint timestamp are skipped.
-- `verify_relay_prefix`: what a node recorded while following must be an exact line-prefix of
-  what its peer recorded while leading, per thread; a partial trailing line is accepted (the
-  recorder was killed mid-write).
+- `verify_relay_prefix`: what a node recorded as follower must be an exact line-prefix of what
+  its peer recorded as leader, per thread; a partial trailing line is accepted (the recorder
+  was killed mid-write).
 
 ## Running
 
@@ -204,9 +215,11 @@ test_schema_disagg_abort [-b build-dir] [-h dir] [-k [l|f]N] [-p] [-r l|f|lf] [-
                          [-T threads] [-t time] [-u pool] [-v]
 ```
 
-- `-r` topology: `l` lone leader, `f` lone follower (idles; verification finds an empty run),
-  `lf` both; default is a random single node.
-- `-s N` switches roles every N seconds; `-k lN`/`-k fN` SIGKILL the *current* holder of the
-  role at N seconds (plain `-k N` for a single node); `-t` stops gracefully.
+- `-r` topology: `l` lone leader, `f` lone follower (generates its own workload and never
+  checkpoints, so nothing is durable until it steps up), `lf` both; default is a random single
+  node.
+- `-s N` switches roles every N seconds, each landing within one more period (the hand-over
+  drains what is in flight); `-k lN`/`-k fN` SIGKILL the *current* holder of the role at N
+  seconds (plain `-k N` for a single node); `-t` stops gracefully.
 - `-p` preserves the home; `-v` verifies an existing home only (requires `-T`, `-u`).
 - Every run prints a `CONFIG:` line (including the random seeds) that reproduces it.

--- a/test/csuite/schema_disagg_abort/README.md
+++ b/test/csuite/schema_disagg_abort/README.md
@@ -1,0 +1,212 @@
+# schema_disagg_abort
+
+Stress test for disaggregated (layered) schema operations under crashes and role switches.
+One or two nodes share a page log; tables are created, populated, and dropped continuously
+while checkpoints move data into shared storage; the parent kills nodes and swaps
+leader/follower roles mid-run; a final recovery pass verifies what survived against
+per-operation record files.
+
+## Processes
+
+The binary runs in one of two roles, dispatched in `main.c`:
+
+- **parent** — orchestrator and verifier (`parent.c`). Spawns the nodes per the `-r`
+  topology, then drives a one-second-tick timeline of switches, kills, and a graceful stop
+  (see [Running](#running)); a child dying at any other point fails the test. It opens
+  WiredTiger only afterwards, to recover and verify.
+- **node** — a database node that leads or follows (`node.c`; role specifics in
+  `leader.c`/`follower.c` behind the `NODE_ROLE` vtable). Spawned by re-executing the binary
+  with internal options (`-r node -i <id> -A l|f`, pipe fds via `-R`/`-W`), so nothing is
+  inherited by forking. `subproc.[ch]` is the posix_spawn layer.
+
+## Directory layout
+
+One run under the test home (`-h WT_TEST.foo`):
+
+```
+WT_TEST.foo/
+├── records/                      the verifier's ground truth
+│   ├── node<N>-schema-<T>        ops node N ORIGINATED while leading, per worker thread T
+│   └── node<N>-relay-<T>         peer ops node N APPLIED while following, per thread T
+├── PALITE/                       shared page log — the "disaggregated storage"
+├── WT_NODE0/                     node 0's local WiredTiger home
+├── WT_NODE1/                     node 1's local WT home (only with -r lf)
+├── leader_ready                  ┐
+├── follower_ready                │ sentinel files: the parent⇄node
+├── switch_request                │ coordination protocol
+├── switch_done.<k>               │
+└── stop_run                      ┘
+WT_TEST.foo.SAVE/                 copy of the home, taken just before verification
+```
+
+- **`PALITE/`** — shared by both nodes, and the only durable state that matters. Leader
+  checkpoints write pages and checkpoint metadata into it; followers adopt from it via
+  `pl_get_complete_checkpoint` → `reconfigure(checkpoint_meta)`. Single-writer is enforced by
+  protocol ordering: step-down closes the connection before the peer steps up.
+- **`WT_NODE<i>/`** — a node's local database, kept across its role switches; a follower
+  reopen does not wipe it. Verification does: it opens with
+  `disaggregated=(lose_all_my_data=true)`, deleting the local files and rebuilding the home
+  from the page log — hence the `.SAVE` copy, taken first and replaced on every rerun.
+- **`records/`** — `CREATE <epoch> <uri>`, `DROP <epoch> <uri>`,
+  `INSERT <commit_ts> <kmin> <kmax> <uri>` (`record_event_line` defines the format). Opened
+  lazily, appended across terms, line-buffered so completed lines survive SIGKILL.
+- **Sentinels** (home root): `leader_ready` = first checkpoint (the parent starts the clock);
+  `follower_ready` = first pickup; `switch_request` = switch command, **consumed (unlinked)**
+  by the acting node so each request fires once; `switch_done.<k>` = k-th switch finished;
+  `stop_run` = graceful stop, not consumed.
+
+## Event pipeline
+
+One pipeline, identical in both roles: a *source* writes `SCHEMA_EVENT`s to a pipe, the
+reader demuxes them by `thread_id` into per-worker queues, and the workers execute them.
+
+- **Leading**: the source is the node's own **generator** thread, writing the term's full
+  stream — workload ops, `EVENT_CKPT` at random 0–3 s intervals, `EVENT_SWITCH` to end the
+  term — into a process-local **self-pipe**; workers relay every applied event to the peer.
+- **Following**: the source is the peer's relay (one pipe per direction; a node writes while
+  leading, reads while following). Nothing is relayed onward.
+
+Each workload event carries an `event_ts` from the node-wide monotonic allocator
+(`current_ts`): CREATE/DROP the epoch they publish at, INSERT its commit timestamp (also the
+row value); `EVENT_SWITCH` carries the term's high-water mark, `EVENT_CKPT` nothing. One
+counter for both axes makes causality an ordering property — a commit always draws a higher
+value than its table's create — so one frontier serves both the stable timestamp and the
+stable schema epoch. Backpressure is end-to-end: a full ring blocks the reader, a full pipe
+blocks the producer.
+
+## Threads (per phase)
+
+Every workload thread is per-phase: `workload_start` creates them, `workload_stop` joins them
+in dependency order — generator, reader, then `stop_phase` quiesces the workers, which drain
+their queues. The main thread runs the `node_run` loop: `workload_start` →
+`node_trigger_wait` (1 s poll on `handover_received`/`stop_run`) → `workload_stop` →
+transition or exit.
+
+| Thread | Count | Does |
+|---|---|---|
+| generator | 1 | **leading** (`generator_lead`): `generator_round` feeds every worker one op — pick a slot with that worker's rnd, flip the slot model, allocate `event_ts`, emit CREATE/DROP, and give one create in `INSERT_ODDS` an INSERT at a fresh commit ts; drops of uncovered *dirty* slots are skipped and an empty round sleeps 1 ms. `EVENT_CKPT` every random 0–3 s; `switch_request` polled ~1/s. **following** (`generator_follow`): the same ~1/s sentinel watch, acting only when lone |
+| reader | 1 iff leading or peered | `select` (1 s) on the source pipe → demux ops into per-worker rings; `CKPT` → `leader_checkpoint` (leading; skipped while stable=0, MAX_STARTUP watchdog) or drain barrier → `follower_pick_up_checkpoint` (following); `SWITCH` → drain → assert counter == the sender's high-water mark → hand over; EOF (peer pipe only) → lone follower |
+| worker ×N | `-T`, ≤ 12 | pop own ring → execute the op (bounded EBUSY retry) → `apply_event`: schema ops record then publish, inserts commit then record → relay when leading → mark completed |
+| timestamp | 1 | every 100 ms: frontier = min of workers' `completed_ts`; set oldest/stable/stable-schema-epoch to it (never backwards) |
+
+Coordination is lock-free by design: `stop_phase` quiesces every loop, per-worker SPSC rings plus `busy` flags connect
+reader to workers, and `completed_ts[]` feeds the frontier.
+
+## Control loop and transitions
+
+Both roles run the same state machine (`node_run`); only `leave()`/`enter()` differ. The
+hand-over value is the node's own quiesced counter: after `workload_stop`, `current_ts` holds
+everything the term allocated or adopted.
+
+```
+        ┌──────────────────────── LEADING ─────────────────────────────┐
+        │ generator: ops + CKPT events ▶ self-pipe                     │
+        │            switch_request → EVENT_SWITCH(counter), exit      │
+        │ reader   : CKPT   → leader_checkpoint ▶ PALITE → relay       │
+        │                     (skip while stable=0; 1st: leader_ready) │
+        │            SWITCH → drain → assert counter == high-water     │
+        │                     → handover                               │
+        │ workers  : execute → record(schema) + publish/commit         │
+        │            → relay ▶ peer pipe                               │
+        └──────────────────────────────────────────────────────────────┘
+  stop_run ──▶ quiesce → close(NULL: closing checkpoint) → exit(0)
+  handover ──▶ quiesce → LEAVE: stable := counter → final checkpoint
+               → CLOSE conn → send CKPT + SWITCH(counter) [peer alive]
+               ENTER follower: reopen conn ──▶ FOLLOWING
+  EPIPE on relay ──▶ peer_alive = false (lone leader keeps producing)
+
+        ┌──────────────────────── FOLLOWING ───────────────────────────┐
+        │ generator: idle sentinel watch; when lone:                   │
+        │            switch_request → handover, exit                   │
+        │ reader   : CKPT   → drain → pickup ◀ PALITE                  │
+        │                     (1st: follower_ready)                    │
+        │            SWITCH → drain → assert → handover                │
+        │            EOF    → peer dead: continue as lone follower     │
+        │ workers  : execute the SAME ops → record(relay)              │
+        │            + publish/commit at the stream's event_ts         │
+        └──────────────────────────────────────────────────────────-───┘
+  stop_run ──▶ quiesce → close(skip_checkpoint) → exit(0)
+  handover ──▶ quiesce → LEAVE: nothing
+               ENTER leader: [lone: adopt latest checkpoint first]
+               → reconfigure(role=leader) → seed + restore frontier
+               from the own counter ──▶ LEADING
+```
+
+### Role differences
+
+| Aspect | Leader | Follower |
+|---|---|---|
+| Event source | own generator → self-pipe | peer's relay → in-pipe; none when lone (idles) |
+| Counter | generator *allocates* `event_ts` values | *adopts* them from events (`counter_advance`) |
+| `EVENT_CKPT` | reader produces the checkpoint, then relays the event (no barrier: it races the workload) | reader barriers, then picks the checkpoint up |
+| Relay | workers relay applied events; reader relays `EVENT_CKPT` | — |
+| `leave()` | heavy: advance stable to the term's counter, final checkpoint, **close the connection**, hand over | empty |
+| `enter()` | reconfigure + seed counter + restore frontier (+ adopt-latest when lone) | reopen the connection |
+| Graceful close | `close(NULL)` — closing checkpoint | `close(skip_checkpoint)` |
+| Readiness / records | `leader_ready`; `node*-schema-*` | `follower_ready`; `node*-relay-*` |
+| Peer-death signal | EPIPE while relaying | pipe EOF |
+
+Both roles react to peer death the same way: keep the role, become "lone"
+(`peer_alive = false`). Lone-ness changes four things — a follower phase starts no reader
+thread, the generator becomes the switch-sentinel actor, a lone step-up adopts the page log's
+latest checkpoint before reconfiguring, and the transition reports `switch_done.<k>` itself
+(a lone step-down has no peer to hand over to).
+
+## Invariants
+
+1. **`apply_event` ordering**: schema ops record before publishing, so the record reaches the
+   file before a checkpoint can make the epoch durable (a record without a durable epoch is
+   ignored by the verifier; the reverse would be a hole); inserts commit, then record. Both
+   relay *before* the completion store, so the stable frontier — and any checkpoint — only
+   covers already-relayed events: the peer holds every event at or below a checkpoint's
+   frontier by the time it sees that checkpoint's pipe event.
+2. **Drop coverage gating**: a *dirty* table — one written since its create — cannot be
+   dropped until a completed checkpoint persists its data, and a fixed stream cannot skip, so
+   an uncovered drop would wedge its worker and, through the full ring, the reader and the
+   checkpoints that would unwedge it. A DROP is therefore emitted for a slot holding data only
+   once its insert commit is at or below `ckpt_covered_ts`, the connection's
+   `last_disaggregated_schema_epoch` as republished by the timestamp thread; the pick is
+   skipped otherwise. Clean tables are never gated, which is why only one create in
+   `INSERT_ODDS` takes data: the schema churn then runs at worker speed and a couple of gated
+   slots per checkpoint interval keep exercising the waiting path.
+3. **Frontier hand-off**: at step-down the term is quiesced and drained, so `leader_leave`
+   advances oldest/stable/stable-epoch to the term's counter before its final checkpoint
+   (publishes above that epoch would die with the closed connection), and `leader_enter`
+   restores the same frontier so an early checkpoint of the new term cannot regress the
+   shared epoch.
+4. **Hand-over integrity**: `EVENT_SWITCH` is the last event of a term's stream; the receiver
+   drains everything before acting and asserts its counter equals the event's high-water mark
+   — every allocated value rides an event that precedes the switch. The old leader closes its
+   connection *before* the switch is sent (one writer per page log).
+5. **Uniform EBUSY policy**: workers retry the same operation with a MAX_STARTUP bound; the
+   stream is fixed at generation time and the slot model flips when the generator emits, so
+   the executed state converges to the model.
+
+## Verification
+
+After the run the parent copies the home to `.SAVE`, recovery-opens every node home that
+exists, and checks it against the union of the nodes' `schema` records (`verify.c`):
+
+- `last_disaggregated_schema_epoch` is the durability cutoff: records above it never reached
+  a checkpoint and carry no expectations.
+- Presence: a slot whose last durable operation was CREATE must exist; DROP must be absent.
+- Data: for durable creates the recorded key range must be present, each row valued by its
+  commit timestamp (a mismatch means another generation's data); inserts above the last
+  checkpoint timestamp are skipped.
+- `verify_relay_prefix`: what a node recorded while following must be an exact line-prefix of
+  what its peer recorded while leading, per thread; a partial trailing line is accepted (the
+  recorder was killed mid-write).
+
+## Running
+
+```
+test_schema_disagg_abort [-b build-dir] [-h dir] [-k [l|f]N] [-p] [-r l|f|lf] [-s N]
+                         [-T threads] [-t time] [-u pool] [-v]
+```
+
+- `-r` topology: `l` lone leader, `f` lone follower (idles; verification finds an empty run),
+  `lf` both; default is a random single node.
+- `-s N` switches roles every N seconds; `-k lN`/`-k fN` SIGKILL the *current* holder of the
+  role at N seconds (plain `-k N` for a single node); `-t` stops gracefully.
+- `-p` preserves the home; `-v` verifies an existing home only (requires `-T`, `-u`).
+- Every run prints a `CONFIG:` line (including the random seeds) that reproduces it.

--- a/test/csuite/schema_disagg_abort/event_pipe.c
+++ b/test/csuite/schema_disagg_abort/event_pipe.c
@@ -1,0 +1,104 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+/*
+ * The event framing every pipe shares. A write() of sizeof(SCHEMA_EVENT) is atomic, so writers need
+ * no locking; only a dead writer's truncated tail has to be reassembled on read.
+ *
+ * Two write disciplines: the self-pipe must not lose an event, so a failed write fails the test;
+ * the peer's pipe dies with the peer, so a failed write there is reported to the caller.
+ */
+
+#include "schema_disagg_abort.h"
+
+#include <sys/select.h>
+
+/*
+ * node_event_send --
+ *     Relay one event to the peer over the node's out-pipe. Returns false without failing when
+ *     there is no peer (no pipe, or the peer is gone), leaving the caller to decide whether
+ *     delivery is optional (the workload relay) or mandatory (the hand-over).
+ */
+bool
+node_event_send(TEST_CONFIG *cfg, const SCHEMA_EVENT *ev)
+{
+    if (cfg->pipe_write_fd < 0)
+        return (false);
+
+    const ssize_t nw = write(cfg->pipe_write_fd, ev, sizeof(*ev));
+    if (nw < 0) {
+        if (errno != EPIPE && errno != EBADF)
+            testutil_die(errno, "write event pipe");
+        close(cfg->pipe_write_fd);
+        cfg->pipe_write_fd = -1;
+        cfg->peer_alive = false;
+        return (false);
+    }
+    testutil_assert(nw == (ssize_t)sizeof(*ev));
+    return (true);
+}
+
+/*
+ * pipe_event_write --
+ *     Write one event to a pipe whose writer lives in this process - the node's self-pipe. Blocks
+ *     while the pipe is full: the consumption rate downstream backpressures the writer.
+ */
+void
+pipe_event_write(int fd, const SCHEMA_EVENT *ev)
+{
+    ssize_t nw;
+    while ((nw = write(fd, ev, sizeof(*ev))) < 0)
+        if (errno != EINTR)
+            testutil_die(errno, "write event pipe");
+    testutil_assert(nw == (ssize_t)sizeof(*ev));
+}
+
+/*
+ * pipe_wait_readable --
+ *     Wait up to a second for a pipe to become readable, so the reader can notice a stop request
+ *     even when the source is silent.
+ */
+bool
+pipe_wait_readable(int fd)
+{
+    fd_set rfds;
+    FD_ZERO(&rfds);
+    FD_SET(fd, &rfds);
+
+    struct timeval tv = {1, 0};
+    const int ret = select(fd + 1, &rfds, NULL, NULL, &tv);
+    if (ret < 0) {
+        if (errno == EINTR)
+            return (false);
+        testutil_die(errno, "reader select pipe");
+    }
+    return (ret > 0);
+}
+
+/*
+ * pipe_event_read --
+ *     Read one complete event from a pipe. Returns false on EOF (the writer died). The writer's
+ *     death can truncate the final write, so reassemble the event from partial reads.
+ */
+bool
+pipe_event_read(int fd, SCHEMA_EVENT *ev)
+{
+    size_t have = 0;
+    while (have < sizeof(*ev)) {
+        const ssize_t nr = read(fd, (uint8_t *)ev + have, sizeof(*ev) - have);
+        if (nr < 0) {
+            if (errno == EINTR)
+                continue;
+            testutil_die(errno, "reader read pipe");
+        }
+        if (nr == 0)
+            return (false);
+        have += (size_t)nr;
+    }
+    return (true);
+}

--- a/test/csuite/schema_disagg_abort/follower.c
+++ b/test/csuite/schema_disagg_abort/follower.c
@@ -1,77 +1,18 @@
 /*-
- * Public Domain 2014-present MongoDB, Inc.
- * Public Domain 2008-2014 WiredTiger, Inc.
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
  *
- * This is free and unencumbered software released into the public domain.
- *
- * Anyone is free to copy, modify, publish, use, compile, sell, or
- * distribute this software, either in source code form or as a compiled
- * binary, for any purpose, commercial or non-commercial, and by any
- * means.
- *
- * In jurisdictions that recognize copyright laws, the author or authors
- * of this software dedicate any and all copyright interest in the
- * software to the public domain. We make this dedication for the benefit
- * of the public at large and to the detriment of our heirs and
- * successors. We intend this dedication to be an overt act of
- * relinquishment in perpetuity of all present and future rights to this
- * software under copyright law.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
- * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
- * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * See the file LICENSE for redistribution information.
  */
 
 /*
- * Follower role: opens its own home as a disaggregated follower and processes schema events from
- * the pipe. Checkpoint events trigger a page log checkpoint pickup. On pipe EOF (the leader died)
- * in kill-leader mode the follower steps up, then exits cleanly.
+ * Follower role: picking up the leader's checkpoints from the page log, and the role transitions.
+ * Everything a running follower executes goes through the same reader and worker loops as a leader,
+ * in node.c.
  */
 
 #include "schema_disagg_abort.h"
-
-/*
- * follower_record_event --
- *     Append a schema or insert event to the per-thread follower record file, creating it on first
- *     use. The formats match the leader's record files so the verifier can parse both.
- */
-static void
-follower_record_event(FILE *record_fps[MAX_TH], const SCHEMA_EVENT *ev)
-{
-    testutil_assert(ev->thread_id < MAX_TH);
-
-    FILE *fp = record_fps[ev->thread_id];
-
-    if (fp == NULL) {
-        char fname[128];
-        testutil_snprintf(fname, sizeof(fname), FOLLOWER_RECORDS_FILE, ev->thread_id);
-        (void)unlink(fname);
-        testutil_assert_errno((fp = fopen(fname, "w")) != NULL);
-        record_fps[ev->thread_id] = fp;
-        /* Flush per line so the records survive a SIGKILL. */
-        __wt_stream_set_line_buffer(fp);
-    }
-
-    switch (ev->type) {
-    case EVENT_INSERT:
-        if (fprintf(fp, "INSERT %" PRIu64 " %" PRIu64 " %" PRIu32 " %" PRIu32 " %s\n", ev->epoch,
-              ev->commit_ts, ev->key_min, ev->key_max, ev->uri) < 0)
-            testutil_die(EIO, "fprintf follower insert record");
-        break;
-    case EVENT_CREATE:
-    case EVENT_DROP:
-        if (fprintf(fp, "%s %" PRIu64 " %s\n", ev->type == EVENT_CREATE ? "CREATE" : "DROP",
-              ev->epoch, ev->uri) < 0)
-            testutil_die(EIO, "fprintf follower schema record");
-        break;
-    case EVENT_CKPT:
-        testutil_assertfmt(false, "Unexpected event type: %d", ev->type);
-    }
-}
 
 /*
  * follower_pick_up_checkpoint --
@@ -79,8 +20,7 @@ follower_record_event(FILE *record_fps[MAX_TH], const SCHEMA_EVENT *ev)
  *     connection. Writes the ready sentinel after the first successful pickup.
  */
 static void
-follower_pick_up_checkpoint(
-  WT_CONNECTION *conn, WT_SESSION *session, WT_PAGE_LOG *page_log, bool *picked_up)
+follower_pick_up_checkpoint(WT_SESSION *session, WT_PAGE_LOG *page_log, bool *picked_up)
 {
     WT_PAGE_LOG_GET_COMPLETE_CHECKPOINT_ARGS ckpt_args = {0};
 
@@ -89,6 +29,7 @@ follower_pick_up_checkpoint(
         return;
     testutil_check(ret);
 
+    WT_CONNECTION *conn = session->connection;
     char meta_config[4096];
     testutil_snprintf(meta_config, sizeof(meta_config), "disaggregated=(checkpoint_meta=\"%.*s\")",
       (int)ckpt_args.checkpoint_metadata.size, (const char *)ckpt_args.checkpoint_metadata.data);
@@ -102,95 +43,15 @@ follower_pick_up_checkpoint(
 }
 
 /*
- * follower_step_up --
- *     Step up to the leader role after the leader dies: reconfigure, set a valid stable timestamp,
- *     take a checkpoint, and signal the parent via the stepped-up sentinel.
- */
-static void
-follower_step_up(WT_CONNECTION *conn, WT_SESSION *session)
-{
-    printf("Follower: stepping up to leader\n");
-    fflush(stdout);
-
-    testutil_check(conn->reconfigure(conn, "disaggregated=(role=leader)"));
-
-    char ts_buf[64];
-    uint64_t step_ts = 1;
-    if (conn->query_timestamp(conn, ts_buf, "get=last_checkpoint") == 0)
-        (void)sscanf(ts_buf, "%" SCNx64, &step_ts);
-    if (step_ts == 0)
-        step_ts = 1;
-
-    char ts_cfg[128];
-    testutil_snprintf(ts_cfg, sizeof(ts_cfg),
-      "stable_timestamp=%" PRIx64 ",oldest_timestamp=%" PRIx64, step_ts, step_ts);
-    testutil_check(conn->set_timestamp(conn, ts_cfg));
-
-    /* Carry the schema epoch forward so the step-up checkpoint does not publish epoch zero. */
-    uint64_t step_epoch = 0;
-    memset(ts_buf, 0, sizeof(ts_buf));
-    if (conn->query_timestamp(conn, ts_buf, "get=last_disaggregated_schema_epoch") == 0)
-        (void)sscanf(ts_buf, "%" SCNx64, &step_epoch);
-    if (step_epoch != 0) {
-        testutil_snprintf(
-          ts_cfg, sizeof(ts_cfg), "stable_disaggregated_schema_epoch=%" PRIx64, step_epoch);
-        testutil_check(conn->set_timestamp(conn, ts_cfg));
-    }
-
-    testutil_check(session->checkpoint(session, "use_timestamp=true"));
-    testutil_sentinel(NULL, FOLLOWER_STEPPED_UP_FILE);
-
-    printf("Follower: stepped up, checkpoint complete\n");
-    fflush(stdout);
-}
-
-/*
- * pipe_read_event --
- *     Read one complete event from the pipe. Returns false on EOF (the leader died). The leader's
- *     death can truncate the final write, so reassemble the event from partial reads.
- */
-static bool
-pipe_read_event(int fd, SCHEMA_EVENT *ev)
-{
-    size_t have = 0;
-    while (have < sizeof(*ev)) {
-        const ssize_t nr = read(fd, (uint8_t *)ev + have, sizeof(*ev) - have);
-        if (nr < 0) {
-            if (errno == EINTR)
-                continue;
-            testutil_die(errno, "follower read pipe");
-        }
-        if (nr == 0)
-            return (false);
-        have += (size_t)nr;
-    }
-    return (true);
-}
-
-/*
- * follower_main --
- *     Follower role entry point; never returns.
+ * follower_adopt_latest --
+ *     Adopt the latest complete checkpoint from the page log, if there is one: the last act of
+ *     following before a lone step-up. A node without a live peer has no reader picking checkpoints
+ *     up, and must not lead over a stale or empty view of the database.
  */
 void
-follower_main(TEST_CONFIG *cfg)
+follower_adopt_latest(WORKLOAD_STATE *state)
 {
-    /* The follower only reads from the event pipe. */
-    testutil_assert(cfg->pipe_read_fd >= 0 && cfg->pipe_write_fd >= 0);
-    close(cfg->pipe_write_fd);
-    cfg->pipe_write_fd = -1;
-
-    if (chdir(cfg->home) != 0)
-        testutil_die(errno, "Follower chdir: %s", cfg->home);
-
-    cfg->opts->disagg.is_enabled = true;
-    cfg->opts->disagg.mode = "follower";
-    cfg->opts->disagg.page_log = "palite";
-    cfg->opts->disagg.page_log_home = cfg->page_log_home;
-    cfg->opts->disagg.drain_threads = 1;
-
-    WT_CONNECTION *conn;
-    testutil_wiredtiger_open(
-      cfg->opts, FOLLOWER_HOME_DIR, ENV_CONFIG_DEF, NULL, &conn, false, false);
+    WT_CONNECTION *conn = state->conn;
 
     WT_SESSION *session;
     testutil_check(conn->open_session(conn, NULL, NULL, &session));
@@ -198,33 +59,60 @@ follower_main(TEST_CONFIG *cfg)
     WT_PAGE_LOG *page_log;
     testutil_check(conn->get_page_log(conn, "palite", &page_log));
 
-    FILE *record_fps[MAX_TH] = {0};
-    bool picked_up = false;
+    bool picked_up = true; /* No ready sentinel: this is not the initial pickup. */
+    follower_pick_up_checkpoint(session, page_log, &picked_up);
 
-    SCHEMA_EVENT ev;
-    while (pipe_read_event(cfg->pipe_read_fd, &ev))
-        switch (ev.type) {
-        case EVENT_CREATE:
-        case EVENT_DROP:
-        case EVENT_INSERT:
-            follower_record_event(record_fps, &ev);
-            break;
-        case EVENT_CKPT:
-            follower_pick_up_checkpoint(conn, session, page_log, &picked_up);
-            break;
-        }
-
-    for (uint32_t i = 0; i < MAX_TH; i++)
-        if (record_fps[i] != NULL)
-            (void)fclose(record_fps[i]);
-    memset(record_fps, 0, sizeof(record_fps));
     testutil_check(page_log->terminate(page_log, NULL));
-
-    /* Step up only when the test intended the leader to die first. */
-    if (cfg->kill_mode == KILL_LEADER)
-        follower_step_up(conn, session);
-
     testutil_check(session->close(session, NULL));
-    testutil_check(conn->close(conn, "debug=(skip_checkpoint=true)"));
-    exit(EXIT_SUCCESS);
+
+    println("Node %" PRIu32 ": adopted the latest checkpoint before step-up", state->cfg->node_id);
 }
+
+/*
+ * follower_leave --
+ *     Step out of following: nothing to do. The reader was already joined when the phase stopped,
+ *     and the connection stays open for the step-up's reconfigure.
+ */
+static void
+follower_leave(WORKLOAD_STATE *state, uint64_t counter_hwm)
+{
+    WT_UNUSED(state);
+    WT_UNUSED(counter_hwm);
+}
+
+/*
+ * follower_enter --
+ *     Step down: the connection was closed to release the page log's writer slot, so reopen it in
+ *     the follower role and put it back in the epoch world.
+ */
+static void
+follower_enter(WORKLOAD_STATE *state, uint64_t counter_hwm)
+{
+    node_open(state->cfg, node_role_follower.name, &state->conn);
+
+    /*
+     * The reopened connection starts outside the epoch world, and this node keeps publishing the
+     * operations it applies for the new leader, so restore the frontier at the term's high-water
+     * mark. Everything the new leader relays was allocated above it.
+     */
+    set_frontier(state->conn, counter_hwm);
+}
+
+/*
+ * follower_checkpoint --
+ *     Adopt the leader's checkpoint. The drain barrier comes first, so everything at or below the
+ *     checkpoint's stable frontier is applied locally before its metadata is adopted; later
+ *     publishes and commits then stay above the adopted stable values.
+ */
+static void
+follower_checkpoint(
+  WORKLOAD_STATE *state, WT_SESSION *session, CKPT_CTX *ckpt, const SCHEMA_EVENT *ev)
+{
+    WT_UNUSED(ev); /* A follower adopts what the page log holds; the event is only the trigger. */
+
+    workload_drain_barrier(state);
+    follower_pick_up_checkpoint(session, ckpt->page_log, &ckpt->picked_up);
+}
+
+const NODE_ROLE node_role_follower = {"follower", "debug=(skip_checkpoint=true)", false,
+  follower_leave, follower_enter, follower_checkpoint};

--- a/test/csuite/schema_disagg_abort/follower.c
+++ b/test/csuite/schema_disagg_abort/follower.c
@@ -1,0 +1,230 @@
+/*-
+ * Public Domain 2014-present MongoDB, Inc.
+ * Public Domain 2008-2014 WiredTiger, Inc.
+ *
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*
+ * Follower role: opens its own home as a disaggregated follower and processes schema events from
+ * the pipe. Checkpoint events trigger a page log checkpoint pickup. On pipe EOF (the leader died)
+ * in kill-leader mode the follower steps up, then exits cleanly.
+ */
+
+#include "schema_disagg_abort.h"
+
+/*
+ * follower_record_event --
+ *     Append a schema or insert event to the per-thread follower record file, creating it on first
+ *     use. The formats match the leader's record files so the verifier can parse both.
+ */
+static void
+follower_record_event(FILE *record_fps[MAX_TH], const SCHEMA_EVENT *ev)
+{
+    testutil_assert(ev->thread_id < MAX_TH);
+
+    FILE *fp = record_fps[ev->thread_id];
+
+    if (fp == NULL) {
+        char fname[128];
+        testutil_snprintf(fname, sizeof(fname), FOLLOWER_RECORDS_FILE, ev->thread_id);
+        (void)unlink(fname);
+        testutil_assert_errno((fp = fopen(fname, "w")) != NULL);
+        record_fps[ev->thread_id] = fp;
+        /* Flush per line so the records survive a SIGKILL. */
+        __wt_stream_set_line_buffer(fp);
+    }
+
+    switch (ev->type) {
+    case EVENT_INSERT:
+        if (fprintf(fp, "INSERT %" PRIu64 " %" PRIu64 " %" PRIu32 " %" PRIu32 " %s\n", ev->epoch,
+              ev->commit_ts, ev->key_min, ev->key_max, ev->uri) < 0)
+            testutil_die(EIO, "fprintf follower insert record");
+        break;
+    case EVENT_CREATE:
+    case EVENT_DROP:
+        if (fprintf(fp, "%s %" PRIu64 " %s\n", ev->type == EVENT_CREATE ? "CREATE" : "DROP",
+              ev->epoch, ev->uri) < 0)
+            testutil_die(EIO, "fprintf follower schema record");
+        break;
+    case EVENT_CKPT:
+        testutil_assertfmt(false, "Unexpected event type: %d", ev->type);
+    }
+}
+
+/*
+ * follower_pick_up_checkpoint --
+ *     Fetch the latest complete checkpoint from the page log and apply it to the follower
+ *     connection. Writes the ready sentinel after the first successful pickup.
+ */
+static void
+follower_pick_up_checkpoint(
+  WT_CONNECTION *conn, WT_SESSION *session, WT_PAGE_LOG *page_log, bool *picked_up)
+{
+    WT_PAGE_LOG_GET_COMPLETE_CHECKPOINT_ARGS ckpt_args = {0};
+
+    const int ret = page_log->pl_get_complete_checkpoint(page_log, session, &ckpt_args);
+    if (ret == WT_NOTFOUND)
+        return;
+    testutil_check(ret);
+
+    char meta_config[4096];
+    testutil_snprintf(meta_config, sizeof(meta_config), "disaggregated=(checkpoint_meta=\"%.*s\")",
+      (int)ckpt_args.checkpoint_metadata.size, (const char *)ckpt_args.checkpoint_metadata.data);
+    testutil_check(conn->reconfigure(conn, meta_config));
+    free(ckpt_args.checkpoint_metadata.mem);
+
+    if (!*picked_up) {
+        testutil_sentinel(NULL, FOLLOWER_READY_FILE);
+        *picked_up = true;
+    }
+}
+
+/*
+ * follower_step_up --
+ *     Step up to the leader role after the leader dies: reconfigure, set a valid stable timestamp,
+ *     take a checkpoint, and signal the parent via the stepped-up sentinel.
+ */
+static void
+follower_step_up(WT_CONNECTION *conn, WT_SESSION *session)
+{
+    printf("Follower: stepping up to leader\n");
+    fflush(stdout);
+
+    testutil_check(conn->reconfigure(conn, "disaggregated=(role=leader)"));
+
+    char ts_buf[64];
+    uint64_t step_ts = 1;
+    if (conn->query_timestamp(conn, ts_buf, "get=last_checkpoint") == 0)
+        (void)sscanf(ts_buf, "%" SCNx64, &step_ts);
+    if (step_ts == 0)
+        step_ts = 1;
+
+    char ts_cfg[128];
+    testutil_snprintf(ts_cfg, sizeof(ts_cfg),
+      "stable_timestamp=%" PRIx64 ",oldest_timestamp=%" PRIx64, step_ts, step_ts);
+    testutil_check(conn->set_timestamp(conn, ts_cfg));
+
+    /* Carry the schema epoch forward so the step-up checkpoint does not publish epoch zero. */
+    uint64_t step_epoch = 0;
+    memset(ts_buf, 0, sizeof(ts_buf));
+    if (conn->query_timestamp(conn, ts_buf, "get=last_disaggregated_schema_epoch") == 0)
+        (void)sscanf(ts_buf, "%" SCNx64, &step_epoch);
+    if (step_epoch != 0) {
+        testutil_snprintf(
+          ts_cfg, sizeof(ts_cfg), "stable_disaggregated_schema_epoch=%" PRIx64, step_epoch);
+        testutil_check(conn->set_timestamp(conn, ts_cfg));
+    }
+
+    testutil_check(session->checkpoint(session, "use_timestamp=true"));
+    testutil_sentinel(NULL, FOLLOWER_STEPPED_UP_FILE);
+
+    printf("Follower: stepped up, checkpoint complete\n");
+    fflush(stdout);
+}
+
+/*
+ * pipe_read_event --
+ *     Read one complete event from the pipe. Returns false on EOF (the leader died). The leader's
+ *     death can truncate the final write, so reassemble the event from partial reads.
+ */
+static bool
+pipe_read_event(int fd, SCHEMA_EVENT *ev)
+{
+    size_t have = 0;
+    while (have < sizeof(*ev)) {
+        const ssize_t nr = read(fd, (uint8_t *)ev + have, sizeof(*ev) - have);
+        if (nr < 0) {
+            if (errno == EINTR)
+                continue;
+            testutil_die(errno, "follower read pipe");
+        }
+        if (nr == 0)
+            return (false);
+        have += (size_t)nr;
+    }
+    return (true);
+}
+
+/*
+ * follower_main --
+ *     Follower role entry point; never returns.
+ */
+void
+follower_main(TEST_CONFIG *cfg)
+{
+    /* The follower only reads from the event pipe. */
+    testutil_assert(cfg->pipe_read_fd >= 0 && cfg->pipe_write_fd >= 0);
+    close(cfg->pipe_write_fd);
+    cfg->pipe_write_fd = -1;
+
+    if (chdir(cfg->home) != 0)
+        testutil_die(errno, "Follower chdir: %s", cfg->home);
+
+    cfg->opts->disagg.is_enabled = true;
+    cfg->opts->disagg.mode = "follower";
+    cfg->opts->disagg.page_log = "palite";
+    cfg->opts->disagg.page_log_home = cfg->page_log_home;
+    cfg->opts->disagg.drain_threads = 1;
+
+    WT_CONNECTION *conn;
+    testutil_wiredtiger_open(
+      cfg->opts, FOLLOWER_HOME_DIR, ENV_CONFIG_DEF, NULL, &conn, false, false);
+
+    WT_SESSION *session;
+    testutil_check(conn->open_session(conn, NULL, NULL, &session));
+
+    WT_PAGE_LOG *page_log;
+    testutil_check(conn->get_page_log(conn, "palite", &page_log));
+
+    FILE *record_fps[MAX_TH] = {0};
+    bool picked_up = false;
+
+    SCHEMA_EVENT ev;
+    while (pipe_read_event(cfg->pipe_read_fd, &ev))
+        switch (ev.type) {
+        case EVENT_CREATE:
+        case EVENT_DROP:
+        case EVENT_INSERT:
+            follower_record_event(record_fps, &ev);
+            break;
+        case EVENT_CKPT:
+            follower_pick_up_checkpoint(conn, session, page_log, &picked_up);
+            break;
+        }
+
+    for (uint32_t i = 0; i < MAX_TH; i++)
+        if (record_fps[i] != NULL)
+            (void)fclose(record_fps[i]);
+    memset(record_fps, 0, sizeof(record_fps));
+    testutil_check(page_log->terminate(page_log, NULL));
+
+    /* Step up only when the test intended the leader to die first. */
+    if (cfg->kill_mode == KILL_LEADER)
+        follower_step_up(conn, session);
+
+    testutil_check(session->close(session, NULL));
+    testutil_check(conn->close(conn, "debug=(skip_checkpoint=true)"));
+    exit(EXIT_SUCCESS);
+}

--- a/test/csuite/schema_disagg_abort/follower.c
+++ b/test/csuite/schema_disagg_abort/follower.c
@@ -74,10 +74,10 @@ follower_adopt_latest(WORKLOAD_STATE *state)
  *     and the connection stays open for the step-up's reconfigure.
  */
 static void
-follower_leave(WORKLOAD_STATE *state, uint64_t counter_hwm)
+follower_leave(WORKLOAD_STATE *state, uint64_t final_counter)
 {
     WT_UNUSED(state);
-    WT_UNUSED(counter_hwm);
+    WT_UNUSED(final_counter);
 }
 
 /*
@@ -86,16 +86,16 @@ follower_leave(WORKLOAD_STATE *state, uint64_t counter_hwm)
  *     the follower role and put it back in the epoch world.
  */
 static void
-follower_enter(WORKLOAD_STATE *state, uint64_t counter_hwm)
+follower_enter(WORKLOAD_STATE *state, uint64_t final_counter)
 {
     node_open(state->cfg, node_role_follower.name, &state->conn);
 
     /*
      * The reopened connection starts outside the epoch world, and this node keeps publishing the
-     * operations it applies for the new leader, so restore the frontier at the term's high-water
-     * mark. Everything the new leader relays was allocated above it.
+     * operations it applies for the new leader, so restore the frontier at the term's final counter
+     * value. Everything the new leader relays was allocated above it.
      */
-    set_frontier(state->conn, counter_hwm);
+    set_frontier(state->conn, final_counter);
 }
 
 /*

--- a/test/csuite/schema_disagg_abort/generator.c
+++ b/test/csuite/schema_disagg_abort/generator.c
@@ -1,0 +1,239 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+/*
+ * The generator stage: the node's command stream - workload, checkpoint events, and the switch
+ * event that ends a term - written into the self-pipe. Started only for a phase that produces its
+ * own stream: a leader always does, and so does a follower with no peer.
+ *
+ * All switch triggering lives here, never in the control loop: the generator consumes the parent's
+ * switch request and turns it into the stream's final event.
+ */
+
+#include "schema_disagg_abort.h"
+
+/*
+ * generator_running --
+ *     The generator's loop condition: true until the engine directs it to exit.
+ */
+static bool
+generator_running(WORKLOAD_STATE *state)
+{
+    return (!__wt_atomic_load_bool_acquire(&state->generator_stop) && workload_running(state));
+}
+
+/*
+ * generator_emit --
+ *     Write one event to the node's self-pipe, blocking while it is full: the workers' consumption
+ *     rate backpressures the generator through the pipe and the queues.
+ */
+static void
+generator_emit(WORKLOAD_STATE *state, const SCHEMA_EVENT *ev)
+{
+    pipe_event_write(state->cfg->self_pipe_write_fd, ev);
+    ++state->emitted;
+}
+
+/*
+ * generator_op --
+ *     Generate one schema operation for the given worker thread: pick a slot, flip it between
+ *     create and drop, allocate the epoch, and give one create in INSERT_ODDS an insert at a fresh
+ *     commit timestamp, which comes from the same allocator as the epoch and so is above the
+ *     table's create epoch by construction. Reports whether an event was emitted.
+ *
+ * Only a slot holding data is gated: a dirty table cannot be dropped until a completed checkpoint
+ *     covers its insert (the drop would wedge in EBUSY), so that pick is simply skipped, the
+ *     generation-time analogue of trying another slot. Clean tables churn ungated. The slot model
+ *     flips at generation time; the worker's bounded EBUSY retry guarantees the executed state
+ *     converges to it.
+ */
+static bool
+generator_op(WORKLOAD_STATE *state, uint32_t t)
+{
+    WT_RAND_STATE *rnd = &state->gen_rnd[t];
+
+    const uint32_t slot = __wt_random(rnd) % state->cfg->pool_size;
+    const bool is_create = !state->table_exists[t][slot];
+    /* A clean table (commit timestamp 0) is droppable at once; a dirty one waits for coverage. */
+    if (!is_create && state->table_commit_ts[t][slot] != 0 &&
+      state->table_commit_ts[t][slot] > __wt_atomic_load_uint64_acquire(&state->ckpt_covered_ts))
+        return (false);
+    state->table_exists[t][slot] = is_create;
+
+    SCHEMA_EVENT ev = {0};
+    ev.type = is_create ? EVENT_CREATE : EVENT_DROP;
+    ev.thread_id = t;
+    ev.event_ts = __wt_atomic_add_uint64(&state->current_ts, 1);
+    testutil_snprintf(ev.uri, sizeof(ev.uri), SCHEMA_TABLE_FMT, state->cfg->node_id, t, slot);
+    generator_emit(state, &ev);
+
+    if (is_create) {
+        /* Most creates leave the table clean, so the churn is not gated on checkpoints. */
+        state->table_commit_ts[t][slot] = 0;
+        if (__wt_random(rnd) % INSERT_ODDS == 0) {
+            ev.type = EVENT_INSERT;
+            ev.event_ts = __wt_atomic_add_uint64(&state->current_ts, 1);
+            ev.key_min = DATA_KEY_MIN;
+            ev.key_max = DATA_KEY_MAX;
+            state->table_commit_ts[t][slot] = ev.event_ts;
+            generator_emit(state, &ev);
+        }
+    }
+    return (true);
+}
+
+/*
+ * generator_round --
+ *     Feed every worker thread one generated operation, round-robin. Reports whether anything was
+ *     emitted: nothing is while the lead over the workers is spent, or when every pick was an
+ *     uncovered drop, and the caller waits instead of spinning on the slot model.
+ */
+static bool
+generator_round(WORKLOAD_STATE *state, uint64_t lead_max)
+{
+    if (state->emitted - __wt_atomic_load_uint64_acquire(&state->applied) > lead_max)
+        return (false);
+
+    bool emitted = false;
+
+    for (uint32_t t = 0; t < state->nth_workers && generator_running(state); t++)
+        if (generator_op(state, t))
+            emitted = true;
+    return (emitted);
+}
+
+/*
+ * A leading generator's pacing state: the checkpoint cadence, the sentinel poll throttle, and the
+ * lead it may build over its workers.
+ */
+typedef struct {
+    WT_RAND_STATE *rnd; /* the generator's own rnd stream, used for the checkpoint intervals */
+    struct timespec last_ckpt;
+    struct timespec last_poll;
+    uint64_t ckpt_wait; /* seconds until the next checkpoint event is due */
+    uint64_t lead_max;  /* events that may be in flight; UINT64_MAX when nothing bounds it */
+} GENERATOR_PACING;
+
+/*
+ * generator_pacing_init --
+ *     Initialize the pacing state at the start of a leading phase.
+ */
+static void
+generator_pacing_init(GENERATOR_PACING *pacing, const TEST_CONFIG *cfg, WT_RAND_STATE *rnd)
+{
+    pacing->rnd = rnd;
+    __wt_epoch(NULL, &pacing->last_ckpt);
+    pacing->last_poll = pacing->last_ckpt;
+    pacing->ckpt_wait = __wt_random(rnd) % MAX_CKPT_INVL;
+    /* Bound the lead so a hand-over drains inside one switch period; no switches, no bound. */
+    pacing->lead_max = cfg->switch_interval == 0 ?
+      UINT64_MAX :
+      WT_MAX(cfg->switch_interval * GEN_APPLY_RATE_FLOOR, GEN_LEAD_MIN);
+}
+
+/*
+ * generator_ckpt_due --
+ *     Pace the stream's checkpoint events: true when the current random interval has elapsed,
+ *     starting the next one.
+ */
+static bool
+generator_ckpt_due(GENERATOR_PACING *pacing)
+{
+    struct timespec now;
+    __wt_epoch(NULL, &now);
+    if ((uint64_t)WT_TIMEDIFF_SEC(now, pacing->last_ckpt) < pacing->ckpt_wait)
+        return (false);
+    pacing->last_ckpt = now;
+    pacing->ckpt_wait = __wt_random(pacing->rnd) % MAX_CKPT_INVL;
+    return (true);
+}
+
+/*
+ * generator_switch_requested --
+ *     Watch for the parent's switch request, polling the sentinel at most once a second (the
+ *     cadence the control loop's own waits use).
+ */
+static bool
+generator_switch_requested(GENERATOR_PACING *pacing)
+{
+    struct timespec now;
+    __wt_epoch(NULL, &now);
+    if (WT_TIMEDIFF_SEC(now, pacing->last_poll) < 1)
+        return (false);
+    pacing->last_poll = now;
+    return (node_switch_request_consume());
+}
+
+/*
+ * thread_generator_run --
+ *     The generator thread: feeds workload rounds into the self-pipe, a checkpoint event whenever
+ *     one is due, and, once the parent requests a switch, the hand-over event that ends the stream
+ *     and the phase.
+ */
+static WT_THREAD_RET
+thread_generator_run(void *arg)
+{
+    WORKLOAD_STATE *state = arg;
+
+    /* The pacing stream is the one past the workers' streams. */
+    GENERATOR_PACING pacing;
+    generator_pacing_init(&pacing, state->cfg, &state->gen_rnd[state->nth_workers]);
+
+    while (generator_running(state)) {
+        if (!generator_round(state, pacing.lead_max))
+            __wt_sleep(0, WT_THOUSAND);
+
+        if (generator_ckpt_due(&pacing)) {
+            SCHEMA_EVENT ev = {0};
+            ev.type = EVENT_CKPT;
+            generator_emit(state, &ev);
+        }
+
+        if (generator_switch_requested(&pacing)) {
+            /* The stream's last event, carrying the counter the next leader continues from. */
+            SCHEMA_EVENT ev = {0};
+            ev.type = EVENT_SWITCH;
+            ev.event_ts = __wt_atomic_load_uint64_acquire(&state->current_ts);
+            generator_emit(state, &ev);
+            break;
+        }
+    }
+    return (WT_THREAD_RET_VALUE);
+}
+
+/* The generator thread's handle; its state lives in the workload state. */
+static wt_thread_t generator_thr;
+static bool generator_started = false;
+
+/*
+ * node_generator_start --
+ *     Start the generator thread for a phase that produces its own stream. Started last of the
+ *     phase's threads, once the machinery consuming the stream is up.
+ */
+void
+node_generator_start(WORKLOAD_STATE *state)
+{
+    testutil_assert(!generator_started);
+    testutil_check(__wt_thread_create(NULL, &generator_thr, thread_generator_run, state));
+    generator_started = true;
+}
+
+/*
+ * node_generator_stop --
+ *     Stop and join the generator thread, if one is running. First of the phase's threads to go,
+ *     while the reader still drains the self-pipe it may be blocked on.
+ */
+void
+node_generator_stop(WORKLOAD_STATE *state)
+{
+    if (!generator_started)
+        return;
+    __wt_atomic_store_bool_release(&state->generator_stop, true);
+    testutil_check(__wt_thread_join(NULL, &generator_thr));
+    generator_started = false;
+}

--- a/test/csuite/schema_disagg_abort/generator.c
+++ b/test/csuite/schema_disagg_abort/generator.c
@@ -24,7 +24,7 @@
 static bool
 generator_running(WORKLOAD_STATE *state)
 {
-    return (!__wt_atomic_load_bool_acquire(&state->generator_stop) && workload_running(state));
+    return (!__wt_atomic_load_bool(&state->generator_stop) && workload_running(state));
 }
 
 /*
@@ -61,7 +61,7 @@ generator_op(WORKLOAD_STATE *state, uint32_t t)
     const bool is_create = !state->table_exists[t][slot];
     /* A clean table (commit timestamp 0) is droppable at once; a dirty one waits for coverage. */
     if (!is_create && state->table_commit_ts[t][slot] != 0 &&
-      state->table_commit_ts[t][slot] > __wt_atomic_load_uint64_acquire(&state->ckpt_covered_ts))
+      state->table_commit_ts[t][slot] > __wt_atomic_load_uint64(&state->ckpt_covered_ts))
         return (false);
     state->table_exists[t][slot] = is_create;
 
@@ -96,7 +96,7 @@ generator_op(WORKLOAD_STATE *state, uint32_t t)
 static bool
 generator_round(WORKLOAD_STATE *state, uint64_t lead_max)
 {
-    if (state->emitted - __wt_atomic_load_uint64_acquire(&state->applied) > lead_max)
+    if (state->emitted - __wt_atomic_load_uint64(&state->applied) > lead_max)
         return (false);
 
     bool emitted = false;
@@ -198,7 +198,7 @@ thread_generator_run(void *arg)
             /* The stream's last event, carrying the counter the next leader continues from. */
             SCHEMA_EVENT ev = {0};
             ev.type = EVENT_SWITCH;
-            ev.event_ts = __wt_atomic_load_uint64_acquire(&state->current_ts);
+            ev.event_ts = __wt_atomic_load_uint64(&state->current_ts);
             generator_emit(state, &ev);
             break;
         }
@@ -233,7 +233,7 @@ node_generator_stop(WORKLOAD_STATE *state)
 {
     if (!generator_started)
         return;
-    __wt_atomic_store_bool_release(&state->generator_stop, true);
+    __wt_atomic_store_bool(&state->generator_stop, true);
     testutil_check(__wt_thread_join(NULL, &generator_thr));
     generator_started = false;
 }

--- a/test/csuite/schema_disagg_abort/leader.c
+++ b/test/csuite/schema_disagg_abort/leader.c
@@ -26,7 +26,55 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
+/*
+ * Leader role: opens the database as a disaggregated leader and runs schema worker threads, a
+ * checkpoint thread, and a timestamp thread until the parent kills the process. In multi-node mode
+ * every schema operation and checkpoint is relayed to the follower over the event pipe.
+ */
+
 #include "schema_disagg_abort.h"
+
+#include <signal.h>
+
+/* Forward declaration: WORKLOAD_STATE holds a pointer into the THREAD_DATA array. */
+typedef struct __thread_data THREAD_DATA;
+
+/*
+ * Global state shared by all workload threads. The threads coordinate without locks (WT-18084: a
+ * rwlock here starved the checkpoint thread under stress).
+ */
+typedef struct {
+    bool stable_set; /* set once the stable timestamp is first advanced; atomic access */
+    bool stop_phase; /* set to quiesce all worker threads between phases; atomic access */
+    /* Leader phases checkpoint; a follower phase only advances the epoch. Fixed per phase. */
+    bool ckpt_enabled;
+    /*
+     * Monotonic allocators. Every publish and commit must draw a value above the global stable
+     * epoch and timestamp, so these only ever increase.
+     */
+    uint64_t next_epoch;
+    uint64_t next_commit_ts;
+    THREAD_DATA *workers; /* schema worker thread data array (length nth_workers) */
+    uint32_t nth_workers;
+} WORKLOAD_STATE;
+
+/* Per-thread argument. */
+struct __thread_data {
+    TEST_CONFIG *cfg;
+    WT_CONNECTION *conn;
+    WORKLOAD_STATE *state;
+    uint32_t info;
+    WT_RAND_STATE rnd;
+    /*
+     * The timestamp thread takes the minimum of each field across all workers to set the global
+     * stable epoch and stable timestamp. stable_ready_ts trails the thread's commits until each
+     * insert's table epoch is stable.
+     */
+    uint64_t published_epoch;
+    uint64_t stable_ready_ts;
+    /* Seeded from the caller and copied back so a role switch carries table state across phases. */
+    bool table_exists[MAX_POOL_SIZE];
+};
 
 /* Per-thread schema worker state. */
 typedef struct {
@@ -40,22 +88,42 @@ typedef struct {
 } SCHEMA_WORKER_CTX;
 
 /*
+ * pipe_write_event --
+ *     Relay one event to the follower. Single write() calls of sizeof(SCHEMA_EVENT) are atomic, so
+ *     concurrent threads need no extra locking. Stops relaying silently once the follower is gone.
+ */
+static void
+pipe_write_event(TEST_CONFIG *cfg, const SCHEMA_EVENT *ev)
+{
+    if (cfg->pipe_write_fd < 0)
+        return;
+
+    const ssize_t nw = write(cfg->pipe_write_fd, ev, sizeof(*ev));
+    if (nw < 0) {
+        if (errno == EPIPE || errno == EBADF) {
+            close(cfg->pipe_write_fd);
+            cfg->pipe_write_fd = -1;
+        } else
+            testutil_die(errno, "write schema pipe");
+    } else
+        testutil_assert(nw == (ssize_t)sizeof(*ev));
+}
+
+/*
  * schema_worker_open --
  *     Open the session, record file, and URI table for a schema worker thread.
  */
 static void
 schema_worker_open(THREAD_DATA *td, SCHEMA_WORKER_CTX *ctx)
 {
-    uint32_t i;
-    char fname[128];
-
     /* Append so a later phase preserves the earlier phase's records for the post-crash verifier. */
+    char fname[128];
     testutil_snprintf(fname, sizeof(fname), SCHEMA_RECORDS_FILE, td->info);
     testutil_assert_errno((ctx->schema_fp = fopen(fname, "a")) != NULL);
     /* Flush the record file per line so entries survive the SIGKILL crash. */
     __wt_stream_set_line_buffer(ctx->schema_fp);
 
-    for (i = 0; i < td->cfg->pool_size; i++)
+    for (uint32_t i = 0; i < td->cfg->pool_size; i++)
         testutil_snprintf(ctx->uris[i], sizeof(ctx->uris[i]), SCHEMA_TABLE_FMT, td->info, i);
 
     /* Resume from the carried-over table state so a role switch continues where phase 1 left off.
@@ -77,21 +145,16 @@ schema_worker_open(THREAD_DATA *td, SCHEMA_WORKER_CTX *ctx)
 static int
 schema_op_execute(SCHEMA_WORKER_CTX *ctx, uint64_t slot)
 {
-    WT_DECL_RET;
+    const bool is_create = !ctx->table_exists[slot];
 
-    if (!ctx->table_exists[slot]) {
-        ret = ctx->session->create(ctx->session, ctx->uris[slot], ctx->tableconf);
-        if (ret == EBUSY)
-            return (ret);
-        testutil_check(ret);
-        ctx->table_exists[slot] = true;
-    } else {
-        ret = ctx->session->drop(ctx->session, ctx->uris[slot], "force=false,lock_wait=false");
-        if (ret == EBUSY)
-            return (ret);
-        testutil_check(ret);
-        ctx->table_exists[slot] = false;
-    }
+    const int ret = is_create ?
+      ctx->session->create(ctx->session, ctx->uris[slot], ctx->tableconf) :
+      ctx->session->drop(ctx->session, ctx->uris[slot], "force=false,lock_wait=false");
+    if (ret == EBUSY)
+        return (ret);
+    testutil_check(ret);
+    ctx->table_exists[slot] = is_create;
+
     return (0);
 }
 
@@ -104,7 +167,6 @@ static int
 schema_op_publish(SCHEMA_WORKER_CTX *ctx, uint64_t slot, uint64_t epoch)
 {
     char pub_cfg[64];
-
     testutil_snprintf(pub_cfg, sizeof(pub_cfg), "disaggregated=(schema_epoch=%" PRIx64 ")", epoch);
     return (ctx->session->publish(ctx->session, ctx->uris[slot], pub_cfg));
 }
@@ -117,41 +179,38 @@ schema_op_publish(SCHEMA_WORKER_CTX *ctx, uint64_t slot, uint64_t epoch)
 static void
 schema_op_insert_data(SCHEMA_WORKER_CTX *ctx, uint64_t slot, uint64_t epoch, uint64_t commit_ts)
 {
-    WT_CURSOR *cursor;
-    uint32_t r;
-    char commit_cfg[64], key_buf[16], val_buf[32];
-
+    char val_buf[32];
     testutil_snprintf(val_buf, sizeof(val_buf), "%" PRIu64, epoch);
     testutil_check(ctx->session->begin_transaction(ctx->session, NULL));
+
+    WT_CURSOR *cursor;
     testutil_check(ctx->session->open_cursor(ctx->session, ctx->uris[slot], NULL, NULL, &cursor));
-    for (r = DATA_KEY_MIN; r <= DATA_KEY_MAX; r++) {
+    for (uint32_t r = DATA_KEY_MIN; r <= DATA_KEY_MAX; r++) {
+        char key_buf[16];
         testutil_snprintf(key_buf, sizeof(key_buf), "%" PRIu32, r);
         cursor->set_key(cursor, key_buf);
         cursor->set_value(cursor, val_buf);
         testutil_check(cursor->insert(cursor));
     }
     testutil_check(cursor->close(cursor));
+
+    char commit_cfg[64];
     testutil_snprintf(commit_cfg, sizeof(commit_cfg), "commit_timestamp=%" PRIx64, commit_ts);
     testutil_check(ctx->session->commit_transaction(ctx->session, commit_cfg));
 }
 
 /*
  * workers_min --
- *     Return the minimum of the selected per-thread field across all schema worker threads, read
- *     with acquire ordering to pair with each worker's release store. Returns 0 if any worker has
- *     not yet set the field.
+ *     Return the minimum of the selected per-thread field across all schema worker threads. Returns
+ *     0 if any worker has not yet set the field.
  */
 static uint64_t
 workers_min(WORKLOAD_STATE *state, bool want_epoch)
 {
-    THREAD_DATA *w;
-    uint64_t min_val, val;
-    uint32_t i;
-
-    min_val = UINT64_MAX;
-    for (i = 0; i < state->nth_workers; i++) {
-        w = &state->workers[i];
-        val =
+    uint64_t min_val = UINT64_MAX;
+    for (uint32_t i = 0; i < state->nth_workers; i++) {
+        THREAD_DATA *w = &state->workers[i];
+        const uint64_t val =
           __wt_atomic_load_uint64_acquire(want_epoch ? &w->published_epoch : &w->stable_ready_ts);
         if (val == 0)
             return (0);
@@ -170,6 +229,7 @@ typedef struct {
     uint64_t epoch;
     uint64_t commit_ts;
 } PUBLISH_WAIT_QUEUE_ENTRY;
+
 typedef struct {
     PUBLISH_WAIT_QUEUE_ENTRY entries[PUBLISH_WAIT_QUEUE_MAX];
     uint64_t head; /* next entry to release */
@@ -184,11 +244,9 @@ typedef struct {
 static void
 publish_wait_queue_push(PUBLISH_WAIT_QUEUE *q, uint64_t epoch, uint64_t commit_ts)
 {
-    PUBLISH_WAIT_QUEUE_ENTRY *e;
-
     if (q->tail - q->head == PUBLISH_WAIT_QUEUE_MAX)
         q->head++;
-    e = &q->entries[q->tail++ % PUBLISH_WAIT_QUEUE_MAX];
+    PUBLISH_WAIT_QUEUE_ENTRY *e = &q->entries[q->tail++ % PUBLISH_WAIT_QUEUE_MAX];
     e->epoch = epoch;
     e->commit_ts = commit_ts;
 }
@@ -201,12 +259,9 @@ publish_wait_queue_push(PUBLISH_WAIT_QUEUE *q, uint64_t epoch, uint64_t commit_t
 static uint64_t
 publish_wait_queue_release(PUBLISH_WAIT_QUEUE *q, uint64_t stable_epoch)
 {
-    PUBLISH_WAIT_QUEUE_ENTRY *e;
-    uint64_t released;
-
-    released = 0;
+    uint64_t released = 0;
     while (q->head != q->tail) {
-        e = &q->entries[q->head % PUBLISH_WAIT_QUEUE_MAX];
+        const PUBLISH_WAIT_QUEUE_ENTRY *e = &q->entries[q->head % PUBLISH_WAIT_QUEUE_MAX];
         if (e->epoch > stable_epoch)
             break;
         released = e->commit_ts;
@@ -219,24 +274,24 @@ publish_wait_queue_release(PUBLISH_WAIT_QUEUE *q, uint64_t stable_epoch)
  * thread_schema_run --
  *     Creates and drops disaggregated tables from a per-thread pool. Each successful operation is
  *     assigned a monotonically increasing schema epoch and durably recorded so the verifier can
- *     reconstruct the expected post-recovery state. Inserted data is committed immediately but held
- *     back from stability until its table is published, so data never goes stable before its table.
+ *     reconstruct the expected post-recovery state.
  */
 static WT_THREAD_RET
 thread_schema_run(void *arg)
 {
-    PUBLISH_WAIT_QUEUE queue;
-    SCHEMA_WORKER_CTX ctx;
-    THREAD_DATA *td;
-    bool is_create;
-    uint64_t commit_ts, epoch, released, slot;
+    THREAD_DATA *td = arg;
 
-    td = (THREAD_DATA *)arg;
+    SCHEMA_WORKER_CTX ctx;
     schema_worker_open(td, &ctx);
 
+    SCHEMA_EVENT ev = {0};
+    ev.thread_id = td->info;
+
+    PUBLISH_WAIT_QUEUE queue;
     WT_CLEAR(queue);
+
     for (;;) {
-        if (td->state->stop_phase) {
+        if (__wt_atomic_load_bool_acquire(&td->state->stop_phase)) {
             /* Carry the final table state back so the next phase resumes from it. */
             memcpy(td->table_exists, ctx.table_exists, sizeof(td->table_exists));
             testutil_check(fclose(ctx.schema_fp));
@@ -248,17 +303,18 @@ thread_schema_run(void *arg)
          * Release queued inserts whose table epoch every thread has now published. Until then their
          * data stays unstable, exercising unpublished tables that hold unstable data.
          */
-        released = publish_wait_queue_release(&queue, workers_min(td->state, true));
+        const uint64_t released = publish_wait_queue_release(&queue, workers_min(td->state, true));
         if (released != 0)
             __wt_atomic_store_uint64_release(&td->stable_ready_ts, released);
 
-        slot = __wt_random(&td->rnd) % td->cfg->pool_size;
+        const uint64_t slot = __wt_random(&td->rnd) % td->cfg->pool_size;
         if (schema_op_execute(&ctx, slot) == EBUSY) {
             __wt_yield();
             continue;
         }
-        is_create = ctx.table_exists[slot];
-        epoch = __wt_atomic_add_uint64(&ctx.state->next_epoch, 1);
+        const bool is_create = ctx.table_exists[slot];
+        const uint64_t epoch = __wt_atomic_add_uint64(&ctx.state->next_epoch, 1);
+
         /*
          * Write the record before publishing so it reaches the file before a checkpoint can make
          * the epoch durable. A crash after the record but before the epoch is durable is safe: the
@@ -268,14 +324,37 @@ thread_schema_run(void *arg)
               ctx.uris[slot]) < 0)
             testutil_die(EIO, "fprintf schema record");
         testutil_check(schema_op_publish(&ctx, slot, epoch));
-        /* Release so the timestamp thread's paired acquire load sees the completed publish. */
+
+        /*
+         * Relay the operation BEFORE the published_epoch release store below. The store is what
+         * lets the stable epoch advance past this operation, which is what lets a checkpoint cover
+         * it, which is what lets the checkpoint thread send that checkpoint's pipe event. Relaying
+         * first therefore guarantees the follower has every event at or below a checkpoint's stable
+         * epoch by the time it sees that checkpoint's event.
+         */
+        ev.type = is_create ? EVENT_CREATE : EVENT_DROP;
+        ev.epoch = epoch;
+        testutil_snprintf(ev.uri, sizeof(ev.uri), "%s", ctx.uris[slot]);
+        pipe_write_event(td->cfg, &ev);
+
         __wt_atomic_store_uint64_release(&td->published_epoch, epoch);
+
         if (is_create) {
-            commit_ts = __wt_atomic_add_uint64(&ctx.state->next_commit_ts, 1);
+            const uint64_t commit_ts = __wt_atomic_add_uint64(&ctx.state->next_commit_ts, 1);
             schema_op_insert_data(&ctx, slot, epoch, commit_ts);
             if (fprintf(ctx.schema_fp, "INSERT %" PRIu64 " %" PRIu64 " %d %d %s\n", epoch,
                   commit_ts, DATA_KEY_MIN, DATA_KEY_MAX, ctx.uris[slot]) < 0)
                 testutil_die(EIO, "fprintf insert record");
+            /*
+             * Relay before the queue push for the same reason as above: the push is what later lets
+             * this thread's stable_ready_ts (and so the stable timestamp, and so a checkpoint
+             * containing this data) advance past the commit.
+             */
+            ev.type = EVENT_INSERT;
+            ev.commit_ts = commit_ts;
+            ev.key_min = DATA_KEY_MIN;
+            ev.key_max = DATA_KEY_MAX;
+            pipe_write_event(td->cfg, &ev);
             publish_wait_queue_push(&queue, epoch, commit_ts);
         }
     }
@@ -290,33 +369,31 @@ thread_schema_run(void *arg)
 static WT_THREAD_RET
 thread_ts_run(void *arg)
 {
-    THREAD_DATA *td;
-    uint64_t stable_epoch, stable_ts;
-    char tscfg[128];
+    THREAD_DATA *td = arg;
 
-    td = (THREAD_DATA *)arg;
     for (;;) {
-        if (td->state->stop_phase)
+        if (__wt_atomic_load_bool_acquire(&td->state->stop_phase))
             return (WT_THREAD_RET_VALUE);
+
         /*
          * Read the stable timestamp minimum before the epoch minimum, so the epoch covers every
          * commit included in the timestamp. Order matters: the reverse could make data stable on an
          * unpublished table.
          */
-        stable_ts = workers_min(td->state, false);
-        stable_epoch = workers_min(td->state, true);
+        const uint64_t stable_ts = workers_min(td->state, false);
+        const uint64_t stable_epoch = workers_min(td->state, true);
         if (stable_epoch == 0 || stable_ts == 0) {
             __wt_sleep(0, 100 * WT_THOUSAND);
             continue;
         }
 
+        char tscfg[128];
         testutil_snprintf(tscfg, sizeof(tscfg),
           "oldest_timestamp=%" PRIx64 ",stable_timestamp=%" PRIx64
           ",stable_disaggregated_schema_epoch=%" PRIx64,
           stable_ts, stable_ts, stable_epoch);
         testutil_check(td->conn->set_timestamp(td->conn, tscfg));
-        if (!td->state->stable_set)
-            td->state->stable_set = true;
+        __wt_atomic_store_bool_release(&td->state->stable_set, true);
         __wt_sleep(0, 100 * WT_THOUSAND);
     }
     /* NOTREACHED */
@@ -325,40 +402,40 @@ thread_ts_run(void *arg)
 /*
  * thread_ckpt_run --
  *     Checkpoints periodically in a leader phase, then writes the ready sentinel after the first
- *     checkpoint that includes a schema operation. A follower phase runs no checkpoint.
+ *     checkpoint. A follower phase runs no checkpoint.
  */
 static WT_THREAD_RET
 thread_ckpt_run(void *arg)
 {
-    struct timespec now, start;
-    THREAD_DATA *td;
+    THREAD_DATA *td = arg;
+
     WT_SESSION *session;
-    uint64_t diff_sec, sleep_time;
-    int i;
-    bool created_ready;
-
-    td = (THREAD_DATA *)arg;
     testutil_check(td->conn->open_session(td->conn, NULL, NULL, &session));
-    created_ready = false;
 
+    SCHEMA_EVENT ev = {0};
+    ev.type = EVENT_CKPT;
+
+    struct timespec start;
     __wt_epoch(NULL, &start);
-    for (i = 1;; ++i) {
-        if (td->state->stop_phase) {
+
+    bool created_ready = false;
+    for (int i = 1;; ++i) {
+        if (__wt_atomic_load_bool_acquire(&td->state->stop_phase)) {
             testutil_check(session->close(session, NULL));
             return (WT_THREAD_RET_VALUE);
         }
-        if (!td->state->stable_set) {
+        if (!__wt_atomic_load_bool_acquire(&td->state->stable_set)) {
+            struct timespec now;
             __wt_epoch(NULL, &now);
-            diff_sec = WT_TIMEDIFF_SEC(now, start);
-            if (diff_sec > MAX_STARTUP)
+            if (WT_TIMEDIFF_SEC(now, start) > MAX_STARTUP)
                 testutil_die(ETIMEDOUT, "stable timestamp not set after %d seconds", MAX_STARTUP);
             __wt_sleep(0, WT_THOUSAND);
             continue;
         }
 
-        sleep_time = __wt_random(&td->rnd) % MAX_CKPT_INVL;
+        const uint64_t sleep_time = __wt_random(&td->rnd) % MAX_CKPT_INVL;
         __wt_sleep(sleep_time, 0);
-        if (td->state->stop_phase) {
+        if (__wt_atomic_load_bool_acquire(&td->state->stop_phase)) {
             testutil_check(session->close(session, NULL));
             return (WT_THREAD_RET_VALUE);
         }
@@ -367,58 +444,65 @@ thread_ckpt_run(void *arg)
         if (!td->state->ckpt_enabled)
             continue;
 
+        /* The timestamp thread owns the stable epoch and timestamps; just checkpoint. */
         testutil_check(session->checkpoint(session, "use_timestamp=true"));
+
+        /* Tell the follower a new checkpoint is available in the page log. */
+        pipe_write_event(td->cfg, &ev);
 
         printf("Checkpoint %d complete\n", i);
         fflush(stdout);
 
         /* stable_set implies every worker published, so this checkpoint has a schema operation. */
         if (!created_ready) {
-            testutil_sentinel(NULL, READY_FILE);
+            testutil_sentinel(NULL, LEADER_READY_FILE);
             created_ready = true;
         }
     }
     /* NOTREACHED */
 }
 
+/* Thread handles have process lifetime; phases join and restart them but never free them. */
+static wt_thread_t workload_thr[MAX_TH + 2];
+static THREAD_DATA workload_td[MAX_TH + 2];
+
 /*
  * workload_threads_start --
- *     Allocate and start all worker threads: N schema threads plus one checkpoint thread and one
+ *     Start all worker threads for one phase: N schema threads plus one checkpoint thread and one
  *     timestamp thread. Each schema thread is seeded with the carried-over table state.
  */
 static void
-workload_threads_start(TEST_CONFIG *cfg, WT_CONNECTION *conn, WORKLOAD_STATE *state,
-  bool (*table_exists)[MAX_POOL_SIZE], wt_thread_t **thr_out, THREAD_DATA **td_out)
+workload_threads_start(
+  TEST_CONFIG *cfg, WT_CONNECTION *conn, WORKLOAD_STATE *state, bool (*table_exists)[MAX_POOL_SIZE])
 {
-    THREAD_DATA *td;
-    wt_thread_t *thr;
-    uint32_t i;
+    testutil_assert(cfg->nth <= MAX_TH);
 
-    thr = dcalloc(cfg->nth + 2, sizeof(*thr));
-    td = dcalloc(cfg->nth + 2, sizeof(THREAD_DATA));
-
-    state->workers = td;
+    /* Expose the worker array so the timestamp thread can compute the stable minima. */
+    state->workers = workload_td;
     state->nth_workers = cfg->nth;
 
-    for (i = 0; i < cfg->nth + 2; i++) {
-        td[i].cfg = cfg;
-        td[i].conn = conn;
-        td[i].state = state;
-        td[i].info = i;
+    for (uint32_t i = 0; i < cfg->nth + 2; i++) {
+        THREAD_DATA *td = &workload_td[i];
+        td->cfg = cfg;
+        td->conn = conn;
+        td->state = state;
+        td->info = i;
         testutil_random_from_random(
-          &td[i].rnd, i < cfg->nth ? &cfg->opts->data_rnd : &cfg->opts->extra_rnd);
+          &td->rnd, i < cfg->nth ? &cfg->opts->data_rnd : &cfg->opts->extra_rnd);
+        /* The stable minima must wait for this phase's workers, not trust the previous phase's. */
+        td->published_epoch = 0;
+        td->stable_ready_ts = 0;
     }
 
-    testutil_check(__wt_thread_create(NULL, &thr[cfg->nth], thread_ckpt_run, &td[cfg->nth]));
-    testutil_check(__wt_thread_create(NULL, &thr[cfg->nth + 1], thread_ts_run, &td[cfg->nth + 1]));
-    for (i = 0; i < cfg->nth; ++i) {
-        /* Seed each schema thread with the carried-over table-exists row. */
-        memcpy(td[i].table_exists, table_exists[i], sizeof(td[i].table_exists));
-        testutil_check(__wt_thread_create(NULL, &thr[i], thread_schema_run, &td[i]));
+    testutil_check(
+      __wt_thread_create(NULL, &workload_thr[cfg->nth], thread_ckpt_run, &workload_td[cfg->nth]));
+    testutil_check(__wt_thread_create(
+      NULL, &workload_thr[cfg->nth + 1], thread_ts_run, &workload_td[cfg->nth + 1]));
+    for (uint32_t i = 0; i < cfg->nth; ++i) {
+        memcpy(workload_td[i].table_exists, table_exists[i], sizeof(workload_td[i].table_exists));
+        testutil_check(
+          __wt_thread_create(NULL, &workload_thr[i], thread_schema_run, &workload_td[i]));
     }
-
-    *thr_out = thr;
-    *td_out = td;
 }
 
 /*
@@ -426,87 +510,77 @@ workload_threads_start(TEST_CONFIG *cfg, WT_CONNECTION *conn, WORKLOAD_STATE *st
  *     Join all worker threads.
  */
 static void
-workload_threads_join(TEST_CONFIG *cfg, wt_thread_t *thr)
+workload_threads_join(const TEST_CONFIG *cfg)
 {
-    uint32_t i;
-
-    for (i = 0; i < cfg->nth + 2; ++i)
-        testutil_check(__wt_thread_join(NULL, &thr[i]));
+    for (uint32_t i = 0; i < cfg->nth + 2; ++i)
+        testutil_check(__wt_thread_join(NULL, &workload_thr[i]));
 }
 
 /*
  * workload_run_phase --
- *     Start the worker threads for one phase and run them for the given duration. A duration of
- *     zero runs until the parent sends SIGKILL. A leader phase checkpoints; a follower phase only
- *     advances the schema epoch. The threads are quiesced and joined before returning, carrying the
- *     table state back for the next phase.
+ *     Run the worker threads for one phase. A duration of zero runs until the parent sends SIGKILL.
+ *     A leader phase checkpoints; a follower phase only advances the schema epoch. Bounded phases
+ *     are quiesced and joined before returning, carrying the table state back for the next phase.
  */
 static void
 workload_run_phase(TEST_CONFIG *cfg, WT_CONNECTION *conn, WORKLOAD_STATE *state,
   bool (*table_exists)[MAX_POOL_SIZE], bool leader_phase, uint32_t seconds)
 {
-    THREAD_DATA *td;
-    wt_thread_t *thr;
-    uint32_t i;
-
-    state->stop_phase = false;
+    __wt_atomic_store_bool_release(&state->stop_phase, false);
     state->ckpt_enabled = leader_phase;
-    workload_threads_start(cfg, conn, state, table_exists, &thr, &td);
+    workload_threads_start(cfg, conn, state, table_exists);
     fflush(stdout);
 
     if (seconds == 0)
-        workload_threads_join(cfg, thr); /* Blocks until SIGKILL from parent. */
+        workload_threads_join(cfg); /* Blocks until SIGKILL from parent. */
     else {
-        /* A leader phase writes READY_FILE from its checkpoint thread. Wait for it before timing.
-         */
+        /* A leader phase writes the ready sentinel from its checkpoint thread; time after it. */
         if (leader_phase)
-            while (access(READY_FILE, F_OK) != 0)
+            while (!testutil_exists(NULL, LEADER_READY_FILE))
                 __wt_sleep(1, 0);
         __wt_sleep(seconds, 0);
-        state->stop_phase = true;
-        workload_threads_join(cfg, thr);
+        __wt_atomic_store_bool_release(&state->stop_phase, true);
+        workload_threads_join(cfg);
     }
 
     /* Copy the threads' final table state back so the next phase resumes from it. */
-    for (i = 0; i < cfg->nth; i++)
-        memcpy(table_exists[i], td[i].table_exists, sizeof(td[i].table_exists));
-
-    free(thr);
-    free(td);
+    for (uint32_t i = 0; i < cfg->nth; i++)
+        memcpy(table_exists[i], workload_td[i].table_exists, sizeof(workload_td[i].table_exists));
 }
 
 /*
- * run_workload --
- *     Child process: opens the database and runs schema worker threads, a checkpoint thread, and a
- *     timestamp thread until the parent sends SIGKILL. In switch mode the child randomly starts as
- *     leader or follower, runs a first schema phase, switches roles, then resumes the schema
- *     workload under the new role until the crash.
+ * leader_main --
+ *     Leader role entry point; never returns. In switch mode the node randomly starts as leader or
+ *     follower, runs a first schema phase, switches roles, then resumes the workload under the new
+ *     role until the crash.
  */
 void
-run_workload(TEST_CONFIG *cfg)
+leader_main(TEST_CONFIG *cfg)
 {
-    WORKLOAD_STATE state;
-    WT_CONNECTION *conn;
-    FILE *switch_fp;
-    bool start_as_leader;
-    bool table_exists[MAX_TH][MAX_POOL_SIZE];
-    uint32_t i, phase1_time;
-    char fname[128];
+    /* The leader only writes to the event pipe. */
+    if (cfg->pipe_read_fd >= 0) {
+        close(cfg->pipe_read_fd);
+        cfg->pipe_read_fd = -1;
+    }
+    /* A dead follower must not kill the leader, ignore SIGPIPE. */
+    if (cfg->pipe_write_fd >= 0)
+        (void)signal(SIGPIPE, SIG_IGN);
 
     if (chdir(cfg->home) != 0)
-        testutil_die(errno, "Child chdir: %s", cfg->home);
+        testutil_die(errno, "Leader chdir: %s", cfg->home);
 
     /* Discard any record files left by a previous run before the workers start. */
-    for (i = 0; i < cfg->nth; i++) {
+    for (uint32_t i = 0; i < cfg->nth; i++) {
+        char fname[128];
         testutil_snprintf(fname, sizeof(fname), SCHEMA_RECORDS_FILE, i);
         (void)unlink(fname);
     }
+    /* Remove the ready sentinel once here so a later phase's checkpoint thread cannot recreate a
+     * stale one. */
+    (void)unlink(LEADER_READY_FILE);
 
-    /* Remove the ready sentinel once here so a later phase's checkpoint thread cannot delete it. */
-    (void)unlink(READY_FILE);
-
-    WT_CLEAR(state);
-    memset(table_exists, 0, sizeof(table_exists));
+    WORKLOAD_STATE state = {0};
+    static bool table_exists[MAX_TH][MAX_POOL_SIZE];
 
     cfg->opts->disagg.is_enabled = true;
     cfg->opts->disagg.page_log = "palite";
@@ -514,21 +588,20 @@ run_workload(TEST_CONFIG *cfg)
     cfg->opts->disagg.drain_threads = 1;
 
     /* The starting role is leader unless switch mode randomly picks follower. */
-    start_as_leader = !cfg->switch_mode || (__wt_random(&cfg->opts->data_rnd) & 1) != 0;
+    const bool start_as_leader = !cfg->switch_mode || (__wt_random(&cfg->opts->data_rnd) & 1) != 0;
     cfg->opts->disagg.mode = start_as_leader ? "leader" : "follower";
+
+    WT_CONNECTION *conn;
     testutil_wiredtiger_open(cfg->opts, WT_HOME_DIR, ENV_CONFIG_DEF, NULL, &conn, false, false);
 
     if (!cfg->switch_mode) {
         /* Run the leader workload until the parent sends SIGKILL. */
         workload_run_phase(cfg, conn, &state, table_exists, true, 0);
-        _exit(EXIT_SUCCESS);
+        _exit(EXIT_SUCCESS); /* NOTREACHED */
     }
 
-    printf("Switch mode: starting as %s\n", start_as_leader ? "leader" : "follower");
-    fflush(stdout);
-
     /* Phase 1: run the schema workload for a bounded interval under the starting role. */
-    phase1_time = MIN_TIME + __wt_random(&cfg->opts->extra_rnd) % MIN_TIME;
+    const uint32_t phase1_time = MIN_TIME + __wt_random(&cfg->opts->extra_rnd) % MIN_TIME;
     printf("Switch mode: %s phase 1 for %" PRIu32 " seconds\n",
       start_as_leader ? "leader" : "follower", phase1_time);
     fflush(stdout);
@@ -550,17 +623,10 @@ run_workload(TEST_CONFIG *cfg)
     }
     fflush(stdout);
 
-    /*
-     * Record the role switch so the parent knows phase 1 has finished and can start its crash timer
-     * only once phase 2 is under way. The verifier skips this marker because it carries no URI.
-     */
-    testutil_snprintf(fname, sizeof(fname), SCHEMA_RECORDS_FILE, (uint32_t)0);
-    testutil_assert_errno((switch_fp = fopen(fname, "a")) != NULL);
-    if (fprintf(switch_fp, "SWITCH %" PRIu64 "\n", state.next_epoch) < 0)
-        testutil_die(EIO, "fprintf switch record");
-    testutil_check(fclose(switch_fp));
+    /* Open the crash window: the parent starts its timer only once phase 2 is under way. */
+    testutil_sentinel(NULL, SWITCH_DONE_FILE);
 
     /* Phase 2: resume the schema workload under the new role until the parent sends SIGKILL. */
     workload_run_phase(cfg, conn, &state, table_exists, !start_as_leader, 0);
-    _exit(EXIT_SUCCESS);
+    exit(EXIT_SUCCESS); /* NOTREACHED */
 }

--- a/test/csuite/schema_disagg_abort/leader.c
+++ b/test/csuite/schema_disagg_abort/leader.c
@@ -65,11 +65,11 @@ leader_checkpoint(
  *     Step down: take a final checkpoint so the term's tail is durable, close the connection before
  *     the peer steps up (the page log allows one writer), then hand the term over - a checkpoint
  *     event first, so the peer picks up the final checkpoint through the normal path, then the
- *     switch event carrying the counter high-water mark it must continue from. Without a live peer
- *     there is nothing to send: this node continues both sides of the swap itself.
+ *     switch event carrying the term's final counter value, which it must continue from. Without a
+ *     live peer there is nothing to send: this node continues both sides of the swap itself.
  */
 static void
-leader_leave(WORKLOAD_STATE *state, uint64_t counter_hwm)
+leader_leave(WORKLOAD_STATE *state, uint64_t final_counter)
 {
     WT_CONNECTION *conn = state->conn;
     WT_SESSION *session;
@@ -81,8 +81,8 @@ leader_leave(WORKLOAD_STATE *state, uint64_t counter_hwm)
      * thread's periodic advance can miss the drain's last burst, and publishes above the final
      * checkpoint's stable epoch would be lost with the closed connection.
      */
-    if (counter_hwm != 0)
-        set_frontier(conn, counter_hwm);
+    if (final_counter != 0)
+        set_frontier(conn, final_counter);
     testutil_check(session->checkpoint(session, "use_timestamp=true"));
     testutil_check(session->close(session, NULL));
     testutil_check(conn->close(conn, "debug=(skip_checkpoint=true)"));
@@ -92,7 +92,7 @@ leader_leave(WORKLOAD_STATE *state, uint64_t counter_hwm)
     ev.type = EVENT_CKPT;
     if (node_event_send(state->cfg, &ev)) {
         ev.type = EVENT_SWITCH;
-        ev.event_ts = counter_hwm;
+        ev.event_ts = final_counter;
         testutil_assert(node_event_send(state->cfg, &ev));
     }
 }
@@ -103,7 +103,7 @@ leader_leave(WORKLOAD_STATE *state, uint64_t counter_hwm)
  *     step-up is the transition that completes a swap.
  */
 static void
-leader_enter(WORKLOAD_STATE *state, uint64_t counter_hwm)
+leader_enter(WORKLOAD_STATE *state, uint64_t final_counter)
 {
     /*
      * A lone step-up first adopts the latest checkpoint from the page log; with a live peer the
@@ -113,15 +113,15 @@ leader_enter(WORKLOAD_STATE *state, uint64_t counter_hwm)
         follower_adopt_latest(state);
 
     testutil_check(state->conn->reconfigure(state->conn, "disaggregated=(role=leader)"));
-    workload_seed_counter(state, counter_hwm);
+    workload_seed_counter(state, final_counter);
 
     /*
      * Restore the stable frontier on the new leader's connection: a follower's reopened connection
      * starts with none, and a checkpoint taken before this term advances it (a short term's closing
      * checkpoint, say) must not regress the shared metadata's epoch.
      */
-    if (counter_hwm != 0)
-        set_frontier(state->conn, counter_hwm);
+    if (final_counter != 0)
+        set_frontier(state->conn, final_counter);
 }
 
 const NODE_ROLE node_role_leader = {

--- a/test/csuite/schema_disagg_abort/leader.c
+++ b/test/csuite/schema_disagg_abort/leader.c
@@ -1,632 +1,128 @@
 /*-
- * Public Domain 2014-present MongoDB, Inc.
- * Public Domain 2008-2014 WiredTiger, Inc.
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
  *
- * This is free and unencumbered software released into the public domain.
- *
- * Anyone is free to copy, modify, publish, use, compile, sell, or
- * distribute this software, either in source code form or as a compiled
- * binary, for any purpose, commercial or non-commercial, and by any
- * means.
- *
- * In jurisdictions that recognize copyright laws, the author or authors
- * of this software dedicate any and all copyright interest in the
- * software to the public domain. We make this dedication for the benefit
- * of the public at large and to the detriment of our heirs and
- * successors. We intend this dedication to be an overt act of
- * relinquishment in perpetuity of all present and future rights to this
- * software under copyright law.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
- * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
- * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * See the file LICENSE for redistribution information.
  */
 
 /*
- * Leader role: opens the database as a disaggregated leader and runs schema worker threads, a
- * checkpoint thread, and a timestamp thread until the parent kills the process. In multi-node mode
- * every schema operation and checkpoint is relayed to the follower over the event pipe.
+ * Leader role: the two ends of a leadership term. Stepping down makes the term's tail durable,
+ * releases the page log's single writer slot by closing the connection, and hands the term over to
+ * the peer; stepping up is a reconfigure that continues the previous term's counter.
+ *
+ * Everything a running leader does (generating, executing, and relaying events, checkpointing) is
+ * the generic engine in node.c with role->leads set.
  */
 
 #include "schema_disagg_abort.h"
 
-#include <signal.h>
-
-/* Forward declaration: WORKLOAD_STATE holds a pointer into the THREAD_DATA array. */
-typedef struct __thread_data THREAD_DATA;
-
 /*
- * Global state shared by all workload threads. The threads coordinate without locks (WT-18084: a
- * rwlock here starved the checkpoint thread under stress).
- */
-typedef struct {
-    bool stable_set; /* set once the stable timestamp is first advanced; atomic access */
-    bool stop_phase; /* set to quiesce all worker threads between phases; atomic access */
-    /* Leader phases checkpoint; a follower phase only advances the epoch. Fixed per phase. */
-    bool ckpt_enabled;
-    /*
-     * Monotonic allocators. Every publish and commit must draw a value above the global stable
-     * epoch and timestamp, so these only ever increase.
-     */
-    uint64_t next_epoch;
-    uint64_t next_commit_ts;
-    THREAD_DATA *workers; /* schema worker thread data array (length nth_workers) */
-    uint32_t nth_workers;
-} WORKLOAD_STATE;
-
-/* Per-thread argument. */
-struct __thread_data {
-    TEST_CONFIG *cfg;
-    WT_CONNECTION *conn;
-    WORKLOAD_STATE *state;
-    uint32_t info;
-    WT_RAND_STATE rnd;
-    /*
-     * The timestamp thread takes the minimum of each field across all workers to set the global
-     * stable epoch and stable timestamp. stable_ready_ts trails the thread's commits until each
-     * insert's table epoch is stable.
-     */
-    uint64_t published_epoch;
-    uint64_t stable_ready_ts;
-    /* Seeded from the caller and copied back so a role switch carries table state across phases. */
-    bool table_exists[MAX_POOL_SIZE];
-};
-
-/* Per-thread schema worker state. */
-typedef struct {
-    WT_SESSION *session;
-    WORKLOAD_STATE *state;
-    WT_RAND_STATE *rnd;
-    FILE *schema_fp;
-    char tableconf[128];
-    char uris[MAX_POOL_SIZE][64];
-    bool table_exists[MAX_POOL_SIZE];
-} SCHEMA_WORKER_CTX;
-
-/*
- * pipe_write_event --
- *     Relay one event to the follower. Single write() calls of sizeof(SCHEMA_EVENT) are atomic, so
- *     concurrent threads need no extra locking. Stops relaying silently once the follower is gone.
+ * leader_checkpoint --
+ *     Produce one checkpoint in response to a checkpoint event, then relay the event so the peer
+ *     picks the checkpoint up. The first produced checkpoint reports leader readiness.
+ *
+ * Nothing is checkpointed while no stable timestamp exists yet: such a checkpoint would cover
+ *     nothing, and the pipe delivers another event shortly. That is only legitimate early in the
+ *     phase, so the wait is bounded. There is no drain barrier either: the checkpoint must keep
+ *     racing the in-flight workload, and use_timestamp bounds it to the stable frontier, which only
+ *     covers applied, and therefore already relayed, events.
  */
 static void
-pipe_write_event(TEST_CONFIG *cfg, const SCHEMA_EVENT *ev)
+leader_checkpoint(
+  WORKLOAD_STATE *state, WT_SESSION *session, CKPT_CTX *ckpt, const SCHEMA_EVENT *ev)
 {
-    if (cfg->pipe_write_fd < 0)
+    /* The stable value this checkpoint is bound to cover; it can only advance mid-checkpoint. */
+    const uint64_t covered = query_ts(state->conn, "stable_timestamp");
+    if (covered == 0) {
+        struct timespec now;
+        __wt_epoch(NULL, &now);
+        if (WT_TIMEDIFF_SEC(now, ckpt->phase_start) > MAX_STARTUP)
+            testutil_die(ETIMEDOUT, "stable timestamp not set after %d seconds", MAX_STARTUP);
         return;
+    }
 
-    const ssize_t nw = write(cfg->pipe_write_fd, ev, sizeof(*ev));
-    if (nw < 0) {
-        if (errno == EPIPE || errno == EBADF) {
-            close(cfg->pipe_write_fd);
-            cfg->pipe_write_fd = -1;
-        } else
-            testutil_die(errno, "write schema pipe");
-    } else
-        testutil_assert(nw == (ssize_t)sizeof(*ev));
-}
+    /* The timestamp thread owns the stable epoch and timestamps; just checkpoint. */
+    testutil_check(session->checkpoint(session, "use_timestamp=true"));
 
-/*
- * schema_worker_open --
- *     Open the session, record file, and URI table for a schema worker thread.
- */
-static void
-schema_worker_open(THREAD_DATA *td, SCHEMA_WORKER_CTX *ctx)
-{
-    /* Append so a later phase preserves the earlier phase's records for the post-crash verifier. */
-    char fname[128];
-    testutil_snprintf(fname, sizeof(fname), SCHEMA_RECORDS_FILE, td->info);
-    testutil_assert_errno((ctx->schema_fp = fopen(fname, "a")) != NULL);
-    /* Flush the record file per line so entries survive the SIGKILL crash. */
-    __wt_stream_set_line_buffer(ctx->schema_fp);
-
-    for (uint32_t i = 0; i < td->cfg->pool_size; i++)
-        testutil_snprintf(ctx->uris[i], sizeof(ctx->uris[i]), SCHEMA_TABLE_FMT, td->info, i);
-
-    /* Resume from the carried-over table state so a role switch continues where phase 1 left off.
+    /*
+     * The generator's drop gate is not published here: the timestamp thread republishes it from the
+     * connection's durable schema epoch, which this checkpoint has just advanced.
      */
-    memcpy(ctx->table_exists, td->table_exists, sizeof(ctx->table_exists));
 
-    ctx->rnd = &td->rnd;
-    ctx->state = td->state;
-    testutil_check(td->conn->open_session(td->conn, NULL, NULL, &ctx->session));
-    testutil_snprintf(ctx->tableconf, sizeof(ctx->tableconf),
-      "key_format=S,value_format=S,type=layered,block_manager=disagg");
+    /* Tell the peer a new checkpoint is available in the page log. */
+    (void)node_event_send(state->cfg, ev);
+
+    println("Node %" PRIu32 ": checkpoint %d complete", state->cfg->node_id, ++ckpt->produced);
+
+    /* A stable frontier implies every worker published, so this checkpoint has a schema op. */
+    if (ckpt->produced == 1)
+        testutil_sentinel(NULL, LEADER_READY_FILE);
 }
 
 /*
- * schema_op_execute --
- *     Execute the next schema operation on the given slot and update the caller's table-exists
- *     state.
- */
-static int
-schema_op_execute(SCHEMA_WORKER_CTX *ctx, uint64_t slot)
-{
-    const bool is_create = !ctx->table_exists[slot];
-
-    const int ret = is_create ?
-      ctx->session->create(ctx->session, ctx->uris[slot], ctx->tableconf) :
-      ctx->session->drop(ctx->session, ctx->uris[slot], "force=false,lock_wait=false");
-    if (ret == EBUSY)
-        return (ret);
-    testutil_check(ret);
-    ctx->table_exists[slot] = is_create;
-
-    return (0);
-}
-
-/*
- * schema_op_publish --
- *     Publish the schema operation at the given epoch so it is visible to followers. Must be called
- *     for both CREATE and DROP.
- */
-static int
-schema_op_publish(SCHEMA_WORKER_CTX *ctx, uint64_t slot, uint64_t epoch)
-{
-    char pub_cfg[64];
-    testutil_snprintf(pub_cfg, sizeof(pub_cfg), "disaggregated=(schema_epoch=%" PRIx64 ")", epoch);
-    return (ctx->session->publish(ctx->session, ctx->uris[slot], pub_cfg));
-}
-
-/*
- * schema_op_insert_data --
- *     Populate a newly created table with rows keyed DATA_KEY_MIN..DATA_KEY_MAX, each valued with
- *     the epoch, at the given commit timestamp.
+ * leader_leave --
+ *     Step down: take a final checkpoint so the term's tail is durable, close the connection before
+ *     the peer steps up (the page log allows one writer), then hand the term over - a checkpoint
+ *     event first, so the peer picks up the final checkpoint through the normal path, then the
+ *     switch event carrying the counter high-water mark it must continue from. Without a live peer
+ *     there is nothing to send: this node continues both sides of the swap itself.
  */
 static void
-schema_op_insert_data(SCHEMA_WORKER_CTX *ctx, uint64_t slot, uint64_t epoch, uint64_t commit_ts)
+leader_leave(WORKLOAD_STATE *state, uint64_t counter_hwm)
 {
-    char val_buf[32];
-    testutil_snprintf(val_buf, sizeof(val_buf), "%" PRIu64, epoch);
-    testutil_check(ctx->session->begin_transaction(ctx->session, NULL));
-
-    WT_CURSOR *cursor;
-    testutil_check(ctx->session->open_cursor(ctx->session, ctx->uris[slot], NULL, NULL, &cursor));
-    for (uint32_t r = DATA_KEY_MIN; r <= DATA_KEY_MAX; r++) {
-        char key_buf[16];
-        testutil_snprintf(key_buf, sizeof(key_buf), "%" PRIu32, r);
-        cursor->set_key(cursor, key_buf);
-        cursor->set_value(cursor, val_buf);
-        testutil_check(cursor->insert(cursor));
-    }
-    testutil_check(cursor->close(cursor));
-
-    char commit_cfg[64];
-    testutil_snprintf(commit_cfg, sizeof(commit_cfg), "commit_timestamp=%" PRIx64, commit_ts);
-    testutil_check(ctx->session->commit_transaction(ctx->session, commit_cfg));
-}
-
-/*
- * workers_min --
- *     Return the minimum of the selected per-thread field across all schema worker threads. Returns
- *     0 if any worker has not yet set the field.
- */
-static uint64_t
-workers_min(WORKLOAD_STATE *state, bool want_epoch)
-{
-    uint64_t min_val = UINT64_MAX;
-    for (uint32_t i = 0; i < state->nth_workers; i++) {
-        THREAD_DATA *w = &state->workers[i];
-        const uint64_t val =
-          __wt_atomic_load_uint64_acquire(want_epoch ? &w->published_epoch : &w->stable_ready_ts);
-        if (val == 0)
-            return (0);
-        if (val < min_val)
-            min_val = val;
-    }
-    return (min_val);
-}
-
-/*
- * Inserts committed on not-yet-stable tables, queued until their table's epoch is stable. Entries
- * arrive already ordered because epochs and commit timestamps come from monotonic counters.
- */
-#define PUBLISH_WAIT_QUEUE_MAX 256
-typedef struct {
-    uint64_t epoch;
-    uint64_t commit_ts;
-} PUBLISH_WAIT_QUEUE_ENTRY;
-
-typedef struct {
-    PUBLISH_WAIT_QUEUE_ENTRY entries[PUBLISH_WAIT_QUEUE_MAX];
-    uint64_t head; /* next entry to release */
-    uint64_t tail; /* next slot to fill */
-} PUBLISH_WAIT_QUEUE;
-
-/*
- * publish_wait_queue_push --
- *     Queue a committed insert awaiting its table's epoch to become stable. Drop the oldest entry
- *     if the queue is full: a later release covers it, since epochs and timestamps only climb.
- */
-static void
-publish_wait_queue_push(PUBLISH_WAIT_QUEUE *q, uint64_t epoch, uint64_t commit_ts)
-{
-    if (q->tail - q->head == PUBLISH_WAIT_QUEUE_MAX)
-        q->head++;
-    PUBLISH_WAIT_QUEUE_ENTRY *e = &q->entries[q->tail++ % PUBLISH_WAIT_QUEUE_MAX];
-    e->epoch = epoch;
-    e->commit_ts = commit_ts;
-}
-
-/*
- * publish_wait_queue_release --
- *     Pop every queued insert whose table epoch has reached the stable frontier and return the
- *     newest released commit timestamp, or 0 if none were released.
- */
-static uint64_t
-publish_wait_queue_release(PUBLISH_WAIT_QUEUE *q, uint64_t stable_epoch)
-{
-    uint64_t released = 0;
-    while (q->head != q->tail) {
-        const PUBLISH_WAIT_QUEUE_ENTRY *e = &q->entries[q->head % PUBLISH_WAIT_QUEUE_MAX];
-        if (e->epoch > stable_epoch)
-            break;
-        released = e->commit_ts;
-        q->head++;
-    }
-    return (released);
-}
-
-/*
- * thread_schema_run --
- *     Creates and drops disaggregated tables from a per-thread pool. Each successful operation is
- *     assigned a monotonically increasing schema epoch and durably recorded so the verifier can
- *     reconstruct the expected post-recovery state.
- */
-static WT_THREAD_RET
-thread_schema_run(void *arg)
-{
-    THREAD_DATA *td = arg;
-
-    SCHEMA_WORKER_CTX ctx;
-    schema_worker_open(td, &ctx);
-
-    SCHEMA_EVENT ev = {0};
-    ev.thread_id = td->info;
-
-    PUBLISH_WAIT_QUEUE queue;
-    WT_CLEAR(queue);
-
-    for (;;) {
-        if (__wt_atomic_load_bool_acquire(&td->state->stop_phase)) {
-            /* Carry the final table state back so the next phase resumes from it. */
-            memcpy(td->table_exists, ctx.table_exists, sizeof(td->table_exists));
-            testutil_check(fclose(ctx.schema_fp));
-            testutil_check(ctx.session->close(ctx.session, NULL));
-            return (WT_THREAD_RET_VALUE);
-        }
-
-        /*
-         * Release queued inserts whose table epoch every thread has now published. Until then their
-         * data stays unstable, exercising unpublished tables that hold unstable data.
-         */
-        const uint64_t released = publish_wait_queue_release(&queue, workers_min(td->state, true));
-        if (released != 0)
-            __wt_atomic_store_uint64_release(&td->stable_ready_ts, released);
-
-        const uint64_t slot = __wt_random(&td->rnd) % td->cfg->pool_size;
-        if (schema_op_execute(&ctx, slot) == EBUSY) {
-            __wt_yield();
-            continue;
-        }
-        const bool is_create = ctx.table_exists[slot];
-        const uint64_t epoch = __wt_atomic_add_uint64(&ctx.state->next_epoch, 1);
-
-        /*
-         * Write the record before publishing so it reaches the file before a checkpoint can make
-         * the epoch durable. A crash after the record but before the epoch is durable is safe: the
-         * verifier ignores records whose epoch is above the recovered durable epoch.
-         */
-        if (fprintf(ctx.schema_fp, "%s %" PRIu64 " %s\n", is_create ? "CREATE" : "DROP", epoch,
-              ctx.uris[slot]) < 0)
-            testutil_die(EIO, "fprintf schema record");
-        testutil_check(schema_op_publish(&ctx, slot, epoch));
-
-        /*
-         * Relay the operation BEFORE the published_epoch release store below. The store is what
-         * lets the stable epoch advance past this operation, which is what lets a checkpoint cover
-         * it, which is what lets the checkpoint thread send that checkpoint's pipe event. Relaying
-         * first therefore guarantees the follower has every event at or below a checkpoint's stable
-         * epoch by the time it sees that checkpoint's event.
-         */
-        ev.type = is_create ? EVENT_CREATE : EVENT_DROP;
-        ev.epoch = epoch;
-        testutil_snprintf(ev.uri, sizeof(ev.uri), "%s", ctx.uris[slot]);
-        pipe_write_event(td->cfg, &ev);
-
-        __wt_atomic_store_uint64_release(&td->published_epoch, epoch);
-
-        if (is_create) {
-            const uint64_t commit_ts = __wt_atomic_add_uint64(&ctx.state->next_commit_ts, 1);
-            schema_op_insert_data(&ctx, slot, epoch, commit_ts);
-            if (fprintf(ctx.schema_fp, "INSERT %" PRIu64 " %" PRIu64 " %d %d %s\n", epoch,
-                  commit_ts, DATA_KEY_MIN, DATA_KEY_MAX, ctx.uris[slot]) < 0)
-                testutil_die(EIO, "fprintf insert record");
-            /*
-             * Relay before the queue push for the same reason as above: the push is what later lets
-             * this thread's stable_ready_ts (and so the stable timestamp, and so a checkpoint
-             * containing this data) advance past the commit.
-             */
-            ev.type = EVENT_INSERT;
-            ev.commit_ts = commit_ts;
-            ev.key_min = DATA_KEY_MIN;
-            ev.key_max = DATA_KEY_MAX;
-            pipe_write_event(td->cfg, &ev);
-            publish_wait_queue_push(&queue, epoch, commit_ts);
-        }
-    }
-    /* NOTREACHED */
-}
-
-/*
- * thread_ts_run --
- *     Advances the oldest and stable timestamps and the stable schema epoch, keeping stable data on
- *     published tables only. Runs in both roles so a follower phase also advances the epoch.
- */
-static WT_THREAD_RET
-thread_ts_run(void *arg)
-{
-    THREAD_DATA *td = arg;
-
-    for (;;) {
-        if (__wt_atomic_load_bool_acquire(&td->state->stop_phase))
-            return (WT_THREAD_RET_VALUE);
-
-        /*
-         * Read the stable timestamp minimum before the epoch minimum, so the epoch covers every
-         * commit included in the timestamp. Order matters: the reverse could make data stable on an
-         * unpublished table.
-         */
-        const uint64_t stable_ts = workers_min(td->state, false);
-        const uint64_t stable_epoch = workers_min(td->state, true);
-        if (stable_epoch == 0 || stable_ts == 0) {
-            __wt_sleep(0, 100 * WT_THOUSAND);
-            continue;
-        }
-
-        char tscfg[128];
-        testutil_snprintf(tscfg, sizeof(tscfg),
-          "oldest_timestamp=%" PRIx64 ",stable_timestamp=%" PRIx64
-          ",stable_disaggregated_schema_epoch=%" PRIx64,
-          stable_ts, stable_ts, stable_epoch);
-        testutil_check(td->conn->set_timestamp(td->conn, tscfg));
-        __wt_atomic_store_bool_release(&td->state->stable_set, true);
-        __wt_sleep(0, 100 * WT_THOUSAND);
-    }
-    /* NOTREACHED */
-}
-
-/*
- * thread_ckpt_run --
- *     Checkpoints periodically in a leader phase, then writes the ready sentinel after the first
- *     checkpoint. A follower phase runs no checkpoint.
- */
-static WT_THREAD_RET
-thread_ckpt_run(void *arg)
-{
-    THREAD_DATA *td = arg;
-
+    WT_CONNECTION *conn = state->conn;
     WT_SESSION *session;
-    testutil_check(td->conn->open_session(td->conn, NULL, NULL, &session));
+    testutil_check(conn->open_session(conn, NULL, NULL, &session));
+
+    /*
+     * The term is quiesced and fully drained: everything it allocated is committed and published.
+     * Advance the stable frontier over all of it before the final checkpoint - the timestamp
+     * thread's periodic advance can miss the drain's last burst, and publishes above the final
+     * checkpoint's stable epoch would be lost with the closed connection.
+     */
+    if (counter_hwm != 0)
+        set_frontier(conn, counter_hwm);
+    testutil_check(session->checkpoint(session, "use_timestamp=true"));
+    testutil_check(session->close(session, NULL));
+    testutil_check(conn->close(conn, "debug=(skip_checkpoint=true)"));
+    state->conn = NULL;
 
     SCHEMA_EVENT ev = {0};
     ev.type = EVENT_CKPT;
-
-    struct timespec start;
-    __wt_epoch(NULL, &start);
-
-    bool created_ready = false;
-    for (int i = 1;; ++i) {
-        if (__wt_atomic_load_bool_acquire(&td->state->stop_phase)) {
-            testutil_check(session->close(session, NULL));
-            return (WT_THREAD_RET_VALUE);
-        }
-        if (!__wt_atomic_load_bool_acquire(&td->state->stable_set)) {
-            struct timespec now;
-            __wt_epoch(NULL, &now);
-            if (WT_TIMEDIFF_SEC(now, start) > MAX_STARTUP)
-                testutil_die(ETIMEDOUT, "stable timestamp not set after %d seconds", MAX_STARTUP);
-            __wt_sleep(0, WT_THOUSAND);
-            continue;
-        }
-
-        const uint64_t sleep_time = __wt_random(&td->rnd) % MAX_CKPT_INVL;
-        __wt_sleep(sleep_time, 0);
-        if (__wt_atomic_load_bool_acquire(&td->state->stop_phase)) {
-            testutil_check(session->close(session, NULL));
-            return (WT_THREAD_RET_VALUE);
-        }
-
-        /* A follower phase advances the schema epoch only through the timestamp thread. */
-        if (!td->state->ckpt_enabled)
-            continue;
-
-        /* The timestamp thread owns the stable epoch and timestamps; just checkpoint. */
-        testutil_check(session->checkpoint(session, "use_timestamp=true"));
-
-        /* Tell the follower a new checkpoint is available in the page log. */
-        pipe_write_event(td->cfg, &ev);
-
-        printf("Checkpoint %d complete\n", i);
-        fflush(stdout);
-
-        /* stable_set implies every worker published, so this checkpoint has a schema operation. */
-        if (!created_ready) {
-            testutil_sentinel(NULL, LEADER_READY_FILE);
-            created_ready = true;
-        }
+    if (node_event_send(state->cfg, &ev)) {
+        ev.type = EVENT_SWITCH;
+        ev.event_ts = counter_hwm;
+        testutil_assert(node_event_send(state->cfg, &ev));
     }
-    /* NOTREACHED */
 }
 
-/* Thread handles have process lifetime; phases join and restart them but never free them. */
-static wt_thread_t workload_thr[MAX_TH + 2];
-static THREAD_DATA workload_td[MAX_TH + 2];
-
 /*
- * workload_threads_start --
- *     Start all worker threads for one phase: N schema threads plus one checkpoint thread and one
- *     timestamp thread. Each schema thread is seeded with the carried-over table state.
+ * leader_enter --
+ *     Step up: reconfigure into the leader role and continue the previous leader's counter. The
+ *     step-up is the transition that completes a swap.
  */
 static void
-workload_threads_start(
-  TEST_CONFIG *cfg, WT_CONNECTION *conn, WORKLOAD_STATE *state, bool (*table_exists)[MAX_POOL_SIZE])
+leader_enter(WORKLOAD_STATE *state, uint64_t counter_hwm)
 {
-    testutil_assert(cfg->nth <= MAX_TH);
+    /*
+     * A lone step-up first adopts the latest checkpoint from the page log; with a live peer the
+     * reader already picked up the hand-over checkpoint through the normal path.
+     */
+    if (!state->cfg->peer_alive)
+        follower_adopt_latest(state);
 
-    /* Expose the worker array so the timestamp thread can compute the stable minima. */
-    state->workers = workload_td;
-    state->nth_workers = cfg->nth;
-
-    for (uint32_t i = 0; i < cfg->nth + 2; i++) {
-        THREAD_DATA *td = &workload_td[i];
-        td->cfg = cfg;
-        td->conn = conn;
-        td->state = state;
-        td->info = i;
-        testutil_random_from_random(
-          &td->rnd, i < cfg->nth ? &cfg->opts->data_rnd : &cfg->opts->extra_rnd);
-        /* The stable minima must wait for this phase's workers, not trust the previous phase's. */
-        td->published_epoch = 0;
-        td->stable_ready_ts = 0;
-    }
-
-    testutil_check(
-      __wt_thread_create(NULL, &workload_thr[cfg->nth], thread_ckpt_run, &workload_td[cfg->nth]));
-    testutil_check(__wt_thread_create(
-      NULL, &workload_thr[cfg->nth + 1], thread_ts_run, &workload_td[cfg->nth + 1]));
-    for (uint32_t i = 0; i < cfg->nth; ++i) {
-        memcpy(workload_td[i].table_exists, table_exists[i], sizeof(workload_td[i].table_exists));
-        testutil_check(
-          __wt_thread_create(NULL, &workload_thr[i], thread_schema_run, &workload_td[i]));
-    }
-}
-
-/*
- * workload_threads_join --
- *     Join all worker threads.
- */
-static void
-workload_threads_join(const TEST_CONFIG *cfg)
-{
-    for (uint32_t i = 0; i < cfg->nth + 2; ++i)
-        testutil_check(__wt_thread_join(NULL, &workload_thr[i]));
-}
-
-/*
- * workload_run_phase --
- *     Run the worker threads for one phase. A duration of zero runs until the parent sends SIGKILL.
- *     A leader phase checkpoints; a follower phase only advances the schema epoch. Bounded phases
- *     are quiesced and joined before returning, carrying the table state back for the next phase.
- */
-static void
-workload_run_phase(TEST_CONFIG *cfg, WT_CONNECTION *conn, WORKLOAD_STATE *state,
-  bool (*table_exists)[MAX_POOL_SIZE], bool leader_phase, uint32_t seconds)
-{
-    __wt_atomic_store_bool_release(&state->stop_phase, false);
-    state->ckpt_enabled = leader_phase;
-    workload_threads_start(cfg, conn, state, table_exists);
-    fflush(stdout);
-
-    if (seconds == 0)
-        workload_threads_join(cfg); /* Blocks until SIGKILL from parent. */
-    else {
-        /* A leader phase writes the ready sentinel from its checkpoint thread; time after it. */
-        if (leader_phase)
-            while (!testutil_exists(NULL, LEADER_READY_FILE))
-                __wt_sleep(1, 0);
-        __wt_sleep(seconds, 0);
-        __wt_atomic_store_bool_release(&state->stop_phase, true);
-        workload_threads_join(cfg);
-    }
-
-    /* Copy the threads' final table state back so the next phase resumes from it. */
-    for (uint32_t i = 0; i < cfg->nth; i++)
-        memcpy(table_exists[i], workload_td[i].table_exists, sizeof(workload_td[i].table_exists));
-}
-
-/*
- * leader_main --
- *     Leader role entry point; never returns. In switch mode the node randomly starts as leader or
- *     follower, runs a first schema phase, switches roles, then resumes the workload under the new
- *     role until the crash.
- */
-void
-leader_main(TEST_CONFIG *cfg)
-{
-    /* The leader only writes to the event pipe. */
-    if (cfg->pipe_read_fd >= 0) {
-        close(cfg->pipe_read_fd);
-        cfg->pipe_read_fd = -1;
-    }
-    /* A dead follower must not kill the leader, ignore SIGPIPE. */
-    if (cfg->pipe_write_fd >= 0)
-        (void)signal(SIGPIPE, SIG_IGN);
-
-    if (chdir(cfg->home) != 0)
-        testutil_die(errno, "Leader chdir: %s", cfg->home);
-
-    /* Discard any record files left by a previous run before the workers start. */
-    for (uint32_t i = 0; i < cfg->nth; i++) {
-        char fname[128];
-        testutil_snprintf(fname, sizeof(fname), SCHEMA_RECORDS_FILE, i);
-        (void)unlink(fname);
-    }
-    /* Remove the ready sentinel once here so a later phase's checkpoint thread cannot recreate a
-     * stale one. */
-    (void)unlink(LEADER_READY_FILE);
-
-    WORKLOAD_STATE state = {0};
-    static bool table_exists[MAX_TH][MAX_POOL_SIZE];
-
-    cfg->opts->disagg.is_enabled = true;
-    cfg->opts->disagg.page_log = "palite";
-    cfg->opts->disagg.page_log_home = cfg->page_log_home;
-    cfg->opts->disagg.drain_threads = 1;
-
-    /* The starting role is leader unless switch mode randomly picks follower. */
-    const bool start_as_leader = !cfg->switch_mode || (__wt_random(&cfg->opts->data_rnd) & 1) != 0;
-    cfg->opts->disagg.mode = start_as_leader ? "leader" : "follower";
-
-    WT_CONNECTION *conn;
-    testutil_wiredtiger_open(cfg->opts, WT_HOME_DIR, ENV_CONFIG_DEF, NULL, &conn, false, false);
-
-    if (!cfg->switch_mode) {
-        /* Run the leader workload until the parent sends SIGKILL. */
-        workload_run_phase(cfg, conn, &state, table_exists, true, 0);
-        _exit(EXIT_SUCCESS); /* NOTREACHED */
-    }
-
-    /* Phase 1: run the schema workload for a bounded interval under the starting role. */
-    const uint32_t phase1_time = MIN_TIME + __wt_random(&cfg->opts->extra_rnd) % MIN_TIME;
-    printf("Switch mode: %s phase 1 for %" PRIu32 " seconds\n",
-      start_as_leader ? "leader" : "follower", phase1_time);
-    fflush(stdout);
-    workload_run_phase(cfg, conn, &state, table_exists, start_as_leader, phase1_time);
+    testutil_check(state->conn->reconfigure(state->conn, "disaggregated=(role=leader)"));
+    workload_seed_counter(state, counter_hwm);
 
     /*
-     * Switch roles. Step up with a reconfigure; step down by closing and reopening because graceful
-     * step-down is not yet supported.
+     * Restore the stable frontier on the new leader's connection: a follower's reopened connection
+     * starts with none, and a checkpoint taken before this term advances it (a short term's closing
+     * checkpoint, say) must not regress the shared metadata's epoch.
      */
-    if (start_as_leader) {
-        testutil_check(conn->close(conn, NULL));
-        cfg->opts->disagg.mode = "follower";
-        testutil_wiredtiger_open(cfg->opts, WT_HOME_DIR, ENV_CONFIG_DEF, NULL, &conn, false, false);
-        printf("Switch mode: stepped down to follower\n");
-    } else {
-        testutil_check(conn->reconfigure(conn, "disaggregated=(role=leader)"));
-        cfg->opts->disagg.mode = "leader";
-        printf("Switch mode: stepped up to leader\n");
-    }
-    fflush(stdout);
-
-    /* Open the crash window: the parent starts its timer only once phase 2 is under way. */
-    testutil_sentinel(NULL, SWITCH_DONE_FILE);
-
-    /* Phase 2: resume the schema workload under the new role until the parent sends SIGKILL. */
-    workload_run_phase(cfg, conn, &state, table_exists, !start_as_leader, 0);
-    exit(EXIT_SUCCESS); /* NOTREACHED */
+    if (counter_hwm != 0)
+        set_frontier(state->conn, counter_hwm);
 }
+
+const NODE_ROLE node_role_leader = {
+  "leader", NULL, true, leader_leave, leader_enter, leader_checkpoint};

--- a/test/csuite/schema_disagg_abort/main.c
+++ b/test/csuite/schema_disagg_abort/main.c
@@ -26,37 +26,36 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
+/*
+ * Entry point: parse the command line, then dispatch to the parent, leader, or follower role. See
+ * schema_disagg_abort.h for the overall test structure.
+ */
+
 #include "schema_disagg_abort.h"
 
-/*
- * Disaggregated schema epoch crash recovery test.
- *
- * Worker threads create, drop, and publish layered tables on a leader while it checkpoints. The
- * test crashes the leader mid-run and confirms that, after recovery, the tables match the schema
- * operations that were made durable before the crash.
- */
+#include "subproc.h"
 
 extern int __wt_optind;
 extern char *__wt_optarg;
 
-static TEST_OPTS _opts;
-
-static void sig_handler(int) WT_GCC_FUNC_DECL_ATTRIBUTE((noreturn));
 static void usage(void) WT_GCC_FUNC_DECL_ATTRIBUTE((noreturn));
 
 /*
  * usage --
- *     Print the command-line usage and exit.
+ *     Print the command-line usage and exit. The -r/-R/-W options are internal: the parent uses
+ *     them to spawn its child roles.
  */
 static void
 usage(void)
 {
     fprintf(stderr,
-      "usage: %s [-b build-dir] [-h dir] [-m] [-p] [-s pool] [-T threads] [-t time] [-v]\n",
+      "usage: %s [-b build-dir] [-h dir] [-k l|f|b] [-m] [-p] [-s pool] [-T threads] [-t time] "
+      "[-v]\n",
       progname);
     fprintf(stderr, "%s",
       "\t-b build directory (required for PALite extension)\n"
       "\t-h home directory\n"
+      "\t-k multi-node kill target: l=leader f=follower b=both (default: single-node)\n"
       "\t-m switch mode (randomly start as leader or follower, then switch roles mid-run)\n"
       "\t-p preserve directory contents\n"
       "\t-s URI pool size per thread\n"
@@ -67,250 +66,244 @@ usage(void)
 }
 
 /*
- * sig_handler --
- *     Reap the leader child and fail the test if it exits before the parent kills it.
+ * parse_kill_mode --
+ *     Translate the -k option value.
  */
-static void
-sig_handler(int sig)
+static KILL_MODE
+parse_kill_mode(const char *arg)
 {
-    pid_t pid;
-
-    WT_UNUSED(sig);
-    pid = wait(NULL);
-    testutil_die(EINVAL, "Child process %" PRIu64 " abnormally exited", (uint64_t)pid);
+    if (strcmp(arg, "l") == 0)
+        return (KILL_LEADER);
+    if (strcmp(arg, "f") == 0)
+        return (KILL_FOLLOWER);
+    if (strcmp(arg, "b") == 0)
+        return (KILL_BOTH);
+    usage();
+    /* NOTREACHED */
 }
 
 /*
- * create_test_dirs --
- *     Create the directory structure needed for a fresh test run.
+ * parse_role --
+ *     Translate the internal -r option value.
  */
-static void
-create_test_dirs(TEST_CONFIG *cfg)
+static TEST_ROLE
+parse_role(const char *arg)
 {
-    char buf[PATH_MAX];
-
-    testutil_recreate_dir(cfg->home);
-    testutil_snprintf(buf, sizeof(buf), "%s/%s", cfg->home, RECORDS_DIR);
-    testutil_mkdir(buf);
-    testutil_snprintf(buf, sizeof(buf), "%s/%s", cfg->home, WT_HOME_DIR);
-    testutil_mkdir(buf);
+    if (strcmp(arg, "leader") == 0)
+        return (ROLE_LEADER);
+    if (strcmp(arg, "follower") == 0)
+        return (ROLE_FOLLOWER);
+    usage();
+    /* NOTREACHED */
 }
 
 /*
- * switch_recorded --
- *     Return whether the child has written the switch marker to thread 0's record file.
+ * parse_uint_in_range --
+ *     Parse a numeric option value, enforcing an inclusive range.
  */
-static bool
-switch_recorded(const char *home)
+static uint32_t
+parse_uint_in_range(const char *arg, uint32_t min, uint32_t max, const char *what)
 {
-    FILE *fp;
-    char line[512], path[512];
-    bool found;
-
-    testutil_snprintf(path, sizeof(path), "%s/" SCHEMA_RECORDS_FILE, home, (uint32_t)0);
-    if ((fp = fopen(path, "r")) == NULL)
-        return (false);
-    found = false;
-    while (fgets(line, sizeof(line), fp) != NULL)
-        if (strncmp(line, "SWITCH", strlen("SWITCH")) == 0) {
-            found = true;
-            break;
-        }
-    (void)fclose(fp);
-    return (found);
-}
-
-/*
- * fork_and_kill_child --
- *     Fork the child, wait until the crash window has opened, sleep the timeout, then SIGKILL it to
- *     simulate a crash.
- */
-static void
-fork_and_kill_child(TEST_CONFIG *cfg, uint32_t timeout)
-{
-    struct sigaction sa;
-    pid_t child_pid;
-    int status;
-
-    memset(&sa, 0, sizeof(sa));
-    sa.sa_handler = sig_handler;
-    testutil_assert_errno(sigaction(SIGCHLD, &sa, NULL) == 0);
-
-    testutil_assert_errno((child_pid = fork()) >= 0);
-    if (child_pid == 0) {
-        run_workload(cfg);
-        /* NOTREACHED */
+    const uint32_t value = (uint32_t)atoi(arg);
+    if (value < min || value > max) {
+        fprintf(stderr, "%s must be between %" PRIu32 " and %" PRIu32 "\n", what, min, max);
+        usage();
     }
-
-    /*
-     * Wait until the crash window has opened before starting the timer. In switch mode the crash
-     * must land in phase 2, so wait for the switch marker, which appears regardless of the starting
-     * role. Otherwise wait for the first leader checkpoint.
-     */
-    if (cfg->switch_mode) {
-        while (!switch_recorded(cfg->home))
-            testutil_sleep_wait(1, child_pid);
-    } else
-        while (!testutil_exists(cfg->home, READY_FILE))
-            testutil_sleep_wait(1, child_pid);
-
-    sleep(timeout);
-
-    sa.sa_handler = SIG_DFL;
-    testutil_assert_errno(sigaction(SIGCHLD, &sa, NULL) == 0);
-
-    testutil_assert_errno(kill(child_pid, SIGKILL) == 0);
-    testutil_assert_errno(waitpid(child_pid, &status, 0) != -1);
+    return (value);
 }
 
 /*
- * open_leader_for_recovery --
- *     Configure disaggregated leader options and open the database to trigger recovery.
+ * parse_args --
+ *     Parse the command line into the configuration and derive the path fields. Reports whether the
+ *     thread count and timeout were left to be randomized.
  */
 static void
-open_leader_for_recovery(TEST_CONFIG *cfg, WT_CONNECTION **connp)
+parse_args(TEST_CONFIG *cfg, int argc, char *argv[], bool *rand_thp, bool *rand_timep)
 {
-    cfg->opts->disagg.is_enabled = true;
-    cfg->opts->disagg.mode = "leader";
-    cfg->opts->disagg.page_log = "palite";
-    cfg->opts->disagg.page_log_home = cfg->page_log_home;
-    cfg->opts->disagg.drain_threads = 1;
+    bool pool_size_set = false;
 
-    testutil_wiredtiger_open(cfg->opts, WT_HOME_DIR, "create,disaggregated=(lose_all_my_data=true)",
-      NULL, connp, true, false);
-}
+    *rand_thp = *rand_timep = true;
 
-/*
- * main --
- *     Parse arguments, run the workload, then verify schema and data state after recovery.
- */
-int
-main(int argc, char *argv[])
-{
-    TEST_CONFIG cfg;
-    WT_CONNECTION *conn;
-    uint32_t rand_value, timeout;
+    testutil_parse_begin_opt(argc, argv, "b:h:k:mpP:r:R:s:T:t:vW:", cfg->opts);
+
     int ch;
-    char cwd_start[PATH_MAX];
-    bool pool_size_set, rand_th, rand_time, verify_only;
-
-    (void)testutil_set_progname(argv);
-
-    memset(&cfg, 0, sizeof(cfg));
-    cfg.opts = &_opts;
-    memset(cfg.opts, 0, sizeof(*cfg.opts));
-
-    cfg.nth = MIN_TH;
-    cfg.pool_size = MAX_POOL_SIZE / 8; /* Default: 8 slots per thread. */
-    pool_size_set = false;
-    rand_th = rand_time = true;
-    timeout = MIN_TIME;
-    verify_only = false;
-
-    testutil_parse_begin_opt(argc, argv, "b:h:mpP:s:T:t:v", cfg.opts);
-
-    while ((ch = __wt_getopt(progname, argc, argv, "b:h:mpP:s:T:t:v")) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv, "b:h:k:mpP:r:R:s:T:t:vW:")) != EOF)
         switch (ch) {
+        case 'k':
+            cfg->kill_mode = parse_kill_mode(__wt_optarg);
+            break;
         case 'm':
-            cfg.switch_mode = true;
+            cfg->switch_mode = true;
+            break;
+        case 'r':
+            cfg->role = parse_role(__wt_optarg);
+            break;
+        case 'R':
+            cfg->pipe_read_fd = atoi(__wt_optarg);
             break;
         case 's':
             pool_size_set = true;
-            cfg.pool_size = (uint32_t)atoi(__wt_optarg);
-            if (cfg.pool_size < MIN_POOL_SIZE || cfg.pool_size > MAX_POOL_SIZE) {
-                fprintf(
-                  stderr, "Pool size must be between %d and %d\n", MIN_POOL_SIZE, MAX_POOL_SIZE);
-                usage();
-            }
+            cfg->pool_size =
+              parse_uint_in_range(__wt_optarg, MIN_POOL_SIZE, MAX_POOL_SIZE, "Pool size");
             break;
         case 'T':
-            rand_th = false;
-            cfg.nth = (uint32_t)atoi(__wt_optarg);
-            if (cfg.nth < MIN_TH || cfg.nth > MAX_TH) {
-                fprintf(stderr, "Thread count must be between %d and %d\n", MIN_TH, MAX_TH);
-                usage();
-            }
+            *rand_thp = false;
+            cfg->nth = parse_uint_in_range(__wt_optarg, 1, MAX_TH, "Thread count");
             break;
         case 't':
-            rand_time = false;
-            timeout = (uint32_t)atoi(__wt_optarg);
+            *rand_timep = false;
+            cfg->timeout = (uint32_t)atoi(__wt_optarg);
             break;
         case 'v':
-            verify_only = true;
+            cfg->verify_only = true;
+            break;
+        case 'W':
+            cfg->pipe_write_fd = atoi(__wt_optarg);
             break;
         default:
-            if (testutil_parse_single_opt(cfg.opts, ch) != 0)
+            if (testutil_parse_single_opt(cfg->opts, ch) != 0)
                 usage();
         }
-    argc -= __wt_optind;
-    if (argc != 0)
+    if (argc - __wt_optind != 0)
         usage();
-    if (verify_only && rand_th) {
+    if (cfg->switch_mode && cfg->kill_mode != KILL_NONE) {
+        /* The pipe relay semantics across a role switch are not defined yet. */
+        fprintf(stderr, "Switch mode (-m) cannot be combined with multi-node (-k)\n");
+        exit(EXIT_FAILURE);
+    }
+    if (cfg->verify_only && *rand_thp) {
         fprintf(stderr, "Verify requires -T\n");
         exit(EXIT_FAILURE);
     }
-    if (verify_only && !pool_size_set) {
+    if (cfg->verify_only && !pool_size_set) {
         fprintf(stderr, "Verify requires -s\n");
         exit(EXIT_FAILURE);
     }
 
-    cfg.opts->disagg.is_enabled = true;
-    testutil_parse_end_opt(cfg.opts);
-    testutil_work_dir_from_path(cfg.home, sizeof(cfg.home), cfg.opts->home);
-    testutil_assert_errno(getcwd(cwd_start, sizeof(cwd_start)) != NULL);
+    cfg->opts->disagg.is_enabled = true;
+    testutil_parse_end_opt(cfg->opts);
+    testutil_work_dir_from_path(cfg->home, sizeof(cfg->home), cfg->opts->home);
 
-    if (!verify_only) {
-        create_test_dirs(&cfg);
+    char cwd[PATH_MAX];
+    testutil_assert_errno(getcwd(cwd, sizeof(cwd)) != NULL);
+    testutil_snprintf(
+      cfg->page_log_home, sizeof(cfg->page_log_home), "%s/%s/%s", cwd, cfg->home, WT_HOME_DIR);
+}
 
-        if (rand_time) {
-            timeout = __wt_random(&cfg.opts->extra_rnd) % MAX_TIME;
-            if (timeout < MIN_TIME)
-                timeout = MIN_TIME;
-        }
-
-        rand_value = __wt_random(&cfg.opts->data_rnd);
-        if (rand_th) {
-            cfg.nth = rand_value % MAX_TH;
-            if (cfg.nth < MIN_TH)
-                cfg.nth = MIN_TH;
-        }
-
-        printf("Parent: Create %" PRIu32 " schema threads; pool %" PRIu32 " slots; sleep %" PRIu32
-               " seconds\n",
-          cfg.nth, cfg.pool_size, timeout);
-        printf("CONFIG: %s -s %" PRIu32 " -T %" PRIu32 " -t %" PRIu32 "%s " TESTUTIL_SEED_FORMAT
-               "\n",
-          progname, cfg.pool_size, cfg.nth, timeout, cfg.switch_mode ? " -m" : "",
-          cfg.opts->data_seed, cfg.opts->extra_seed);
-
-        testutil_snprintf(cfg.page_log_home, sizeof(cfg.page_log_home), "%s/%s/%s", cwd_start,
-          cfg.home, WT_HOME_DIR);
-
-        fork_and_kill_child(&cfg, timeout);
+/*
+ * randomize_run_parameters --
+ *     Choose random values for the parameters not fixed on the command line. The data random stream
+ *     is consumed unconditionally to keep it in sync between runs with and without -T.
+ */
+static void
+randomize_run_parameters(TEST_CONFIG *cfg, bool rand_th, bool rand_time)
+{
+    if (rand_time) {
+        cfg->timeout = __wt_random(&cfg->opts->extra_rnd) % MAX_TIME;
+        if (cfg->timeout < MIN_TIME)
+            cfg->timeout = MIN_TIME;
     }
 
-    if (chdir(cfg.home) != 0)
-        testutil_die(errno, "parent chdir: %s", cfg.home);
+    const uint32_t rand_value = __wt_random(&cfg->opts->data_rnd);
+    if (rand_th) {
+        cfg->nth = rand_value % MAX_TH;
+        if (cfg->nth < MIN_TH)
+            cfg->nth = MIN_TH;
+    }
+}
 
-    if (!verify_only)
-        testutil_copy_data();
+/*
+ * kill_mode_desc --
+ *     Return a human-readable name for a kill mode.
+ */
+static const char *
+kill_mode_desc(KILL_MODE mode)
+{
+    switch (mode) {
+    case KILL_NONE:
+        return ("none (single-node)");
+    case KILL_LEADER:
+        return ("leader");
+    case KILL_FOLLOWER:
+        return ("follower");
+    case KILL_BOTH:
+        return ("both");
+    }
+    return (NULL); /* NOTREACHED */
+}
 
-    if (cfg.page_log_home[0] == '\0')
-        testutil_snprintf(cfg.page_log_home, sizeof(cfg.page_log_home), "%s/%s/%s", cwd_start,
-          cfg.home, WT_HOME_DIR);
+/*
+ * kill_mode_arg --
+ *     Return the command-line fragment reproducing a kill mode.
+ */
+static const char *
+kill_mode_arg(KILL_MODE mode)
+{
+    switch (mode) {
+    case KILL_NONE:
+        return ("");
+    case KILL_LEADER:
+        return (" -k l");
+    case KILL_FOLLOWER:
+        return (" -k f");
+    case KILL_BOTH:
+        return (" -k b");
+    }
+    return (NULL); /* NOTREACHED */
+}
 
-    printf("Open leader database, run recovery and verify content\n");
+/*
+ * print_run_banner --
+ *     Report the effective run parameters, including the CONFIG line that reproduces the run.
+ */
+static void
+print_run_banner(const TEST_CONFIG *cfg)
+{
+    printf("Parent: Create %" PRIu32 " schema threads; pool %" PRIu32
+           " slots; kill %s; switch %s; sleep "
+           "%" PRIu32 " seconds\n",
+      cfg->nth, cfg->pool_size, kill_mode_desc(cfg->kill_mode), cfg->switch_mode ? "yes" : "no",
+      cfg->timeout);
+    printf("CONFIG: %s%s%s -s %" PRIu32 " -T %" PRIu32 " -t %" PRIu32 " " TESTUTIL_SEED_FORMAT "\n",
+      progname, kill_mode_arg(cfg->kill_mode), cfg->switch_mode ? " -m" : "", cfg->pool_size,
+      cfg->nth, cfg->timeout, cfg->opts->data_seed, cfg->opts->extra_seed);
+}
 
-    open_leader_for_recovery(&cfg, &conn);
-    verify_schema_state(conn, &cfg);
-    testutil_check(conn->close(conn, "debug=(skip_checkpoint=true)"));
+/*
+ * main --
+ *     Parse arguments and run the requested role.
+ */
+int
+main(int argc, char *argv[])
+{
+    static TEST_OPTS s_opts;
 
-    if (chdir(cwd_start) != 0)
-        testutil_die(errno, "root chdir: %s", cfg.home);
+    (void)testutil_set_progname(argv);
 
-    if (!cfg.opts->preserve)
-        testutil_remove(cfg.home);
+    TEST_CONFIG cfg = {0};
+    cfg.opts = &s_opts;
+    cfg.nth = MIN_TH;
+    cfg.pool_size = MAX_POOL_SIZE / 8; /* Default: 8 slots per thread. */
+    cfg.timeout = MIN_TIME;
+    cfg.pipe_read_fd = cfg.pipe_write_fd = -1;
 
-    testutil_cleanup(cfg.opts);
+    bool rand_th, rand_time;
+    parse_args(&cfg, argc, argv, &rand_th, &rand_time);
+
+    /* The child roles get their full configuration from the command line; just run them. */
+    if (cfg.role == ROLE_LEADER)
+        leader_main(&cfg); /* NOTREACHED */
+    if (cfg.role == ROLE_FOLLOWER)
+        follower_main(&cfg); /* NOTREACHED */
+
+    if (!cfg.verify_only) {
+        randomize_run_parameters(&cfg, rand_th, rand_time);
+        print_run_banner(&cfg);
+    }
+
+    char self_path[PATH_MAX];
+    subproc_self_path(argv[0], self_path, sizeof(self_path));
+
+    parent_main(&cfg, self_path);
     return (EXIT_SUCCESS);
 }

--- a/test/csuite/schema_disagg_abort/main.c
+++ b/test/csuite/schema_disagg_abort/main.c
@@ -1,33 +1,13 @@
 /*-
- * Public Domain 2014-present MongoDB, Inc.
- * Public Domain 2008-2014 WiredTiger, Inc.
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
  *
- * This is free and unencumbered software released into the public domain.
- *
- * Anyone is free to copy, modify, publish, use, compile, sell, or
- * distribute this software, either in source code form or as a compiled
- * binary, for any purpose, commercial or non-commercial, and by any
- * means.
- *
- * In jurisdictions that recognize copyright laws, the author or authors
- * of this software dedicate any and all copyright interest in the
- * software to the public domain. We make this dedication for the benefit
- * of the public at large and to the detriment of our heirs and
- * successors. We intend this dedication to be an overt act of
- * relinquishment in perpetuity of all present and future rights to this
- * software under copyright law.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
- * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
- * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * See the file LICENSE for redistribution information.
  */
 
 /*
- * Entry point: parse the command line, then dispatch to the parent, leader, or follower role. See
+ * Entry point: parse the command line, then dispatch to the parent or node role. See
  * schema_disagg_abort.h for the overall test structure.
  */
 
@@ -41,60 +21,81 @@ extern char *__wt_optarg;
 static void usage(void) WT_GCC_FUNC_DECL_ATTRIBUTE((noreturn));
 
 /*
+ * println --
+ *     Print one progress line, immediately flushed so it survives a SIGKILL and interleaves
+ *     usefully with the other processes' output.
+ */
+void
+println(const char *fmt, ...)
+{
+    va_list ap;
+
+    va_start(ap, fmt);
+    vprintf(fmt, ap);
+    va_end(ap);
+    putchar('\n');
+    fflush(stdout);
+}
+
+/*
+ * query_ts --
+ *     Return one of the connection's timestamps as an integer. A timestamp that was never set reads
+ *     as zero; an unknown name is a coding error and fails the test.
+ */
+uint64_t
+query_ts(WT_CONNECTION *conn, const char *name)
+{
+    char config[64], hex_ts[64];
+    testutil_snprintf(config, sizeof(config), "get=%s", name);
+    testutil_check(conn->query_timestamp(conn, hex_ts, config));
+
+    uint64_t ts = 0;
+    (void)sscanf(hex_ts, "%" SCNx64, &ts);
+    return (ts);
+}
+
+/*
+ * set_frontier --
+ *     Move the connection's frontier - the oldest and stable timestamps and the stable schema epoch
+ *     - to one allocator value. The three always advance together: a single counter feeds both the
+ *     timestamp and the epoch axis, so everything at or below the value is committed and published.
+ */
+void
+set_frontier(WT_CONNECTION *conn, uint64_t ts)
+{
+    char config[128];
+    testutil_snprintf(config, sizeof(config),
+      "oldest_timestamp=%" PRIx64 ",stable_timestamp=%" PRIx64
+      ",stable_disaggregated_schema_epoch=%" PRIx64,
+      ts, ts, ts);
+    testutil_check(conn->set_timestamp(conn, config));
+}
+
+/*
  * usage --
- *     Print the command-line usage and exit. The -r/-R/-W options are internal: the parent uses
- *     them to spawn its child roles.
+ *     Print the command-line usage and exit. The -A/-i/-R/-W options and the "-r node" value are
+ *     internal: the parent uses them to spawn its nodes.
  */
 static void
 usage(void)
 {
     fprintf(stderr,
-      "usage: %s [-b build-dir] [-h dir] [-k l|f|b] [-m] [-p] [-s pool] [-T threads] [-t time] "
-      "[-v]\n",
+      "usage: %s [-b build-dir] [-h dir] [-k [l|f]N] [-p] [-r l|f|lf] [-s N] [-T threads] "
+      "[-t time] [-u pool] [-v]\n",
       progname);
     fprintf(stderr, "%s",
       "\t-b build directory (required for PALite extension)\n"
       "\t-h home directory\n"
-      "\t-k multi-node kill target: l=leader f=follower b=both (default: single-node)\n"
-      "\t-m switch mode (randomly start as leader or follower, then switch roles mid-run)\n"
+      "\t-k kill after N seconds: lN the current leader, fN the current follower (two nodes),\n"
+      "\t   plain N the lone node (single node); may be given more than once\n"
       "\t-p preserve directory contents\n"
-      "\t-s URI pool size per thread\n"
+      "\t-r roles to run: l leader, f follower, lf both; default: a random single node\n"
+      "\t-s switch roles every N seconds\n"
       "\t-T number of schema threads\n"
-      "\t-t timeout in seconds\n"
+      "\t-t total run time in seconds; the nodes stop gracefully unless killed\n"
+      "\t-u URI pool size per thread\n"
       "\t-v verify only\n");
     exit(EXIT_FAILURE);
-}
-
-/*
- * parse_kill_mode --
- *     Translate the -k option value.
- */
-static KILL_MODE
-parse_kill_mode(const char *arg)
-{
-    if (strcmp(arg, "l") == 0)
-        return (KILL_LEADER);
-    if (strcmp(arg, "f") == 0)
-        return (KILL_FOLLOWER);
-    if (strcmp(arg, "b") == 0)
-        return (KILL_BOTH);
-    usage();
-    /* NOTREACHED */
-}
-
-/*
- * parse_role --
- *     Translate the internal -r option value.
- */
-static TEST_ROLE
-parse_role(const char *arg)
-{
-    if (strcmp(arg, "leader") == 0)
-        return (ROLE_LEADER);
-    if (strcmp(arg, "follower") == 0)
-        return (ROLE_FOLLOWER);
-    usage();
-    /* NOTREACHED */
 }
 
 /*
@@ -113,9 +114,60 @@ parse_uint_in_range(const char *arg, uint32_t min, uint32_t max, const char *wha
 }
 
 /*
+ * parse_roles --
+ *     Translate the -r option value: the public topology letters, or the internal "node" value the
+ *     parent spawns children with.
+ */
+static void
+parse_roles(TEST_CONFIG *cfg, const char *arg)
+{
+    if (strcmp(arg, "node") == 0) {
+        cfg->role = ROLE_NODE;
+        return;
+    }
+    for (const char *p = arg; *p != '\0'; p++)
+        if (*p == 'l')
+            cfg->with_leader = true;
+        else if (*p == 'f')
+            cfg->with_follower = true;
+        else
+            usage();
+    if (!cfg->with_leader && !cfg->with_follower)
+        usage();
+}
+
+/* Command-line prefixes of the kill targets, indexed by KILL_TARGET. */
+static const char *const kill_prefix[KILL_TARGETS] = {"", "l", "f"};
+
+/*
+ * parse_kill_spec --
+ *     Translate one -k option value: "lN" kills the current leader at N seconds, "fN" the current
+ *     follower, a plain "N" the lone node.
+ */
+static void
+parse_kill_spec(TEST_CONFIG *cfg, const char *arg)
+{
+    KILL_TARGET target = KILL_LONE;
+    const char *num = arg;
+
+    if (arg[0] == 'l') {
+        target = KILL_LEADER;
+        ++num;
+    } else if (arg[0] == 'f') {
+        target = KILL_FOLLOWER;
+        ++num;
+    }
+
+    const uint32_t value = (uint32_t)atoi(num);
+    if (value == 0 || cfg->kill_time[target] != 0)
+        usage();
+    cfg->kill_time[target] = value;
+}
+
+/*
  * parse_args --
  *     Parse the command line into the configuration and derive the path fields. Reports whether the
- *     thread count and timeout were left to be randomized.
+ *     thread count and total time were left to be randomized.
  */
 static void
 parse_args(TEST_CONFIG *cfg, int argc, char *argv[], bool *rand_thp, bool *rand_timep)
@@ -124,35 +176,46 @@ parse_args(TEST_CONFIG *cfg, int argc, char *argv[], bool *rand_thp, bool *rand_
 
     *rand_thp = *rand_timep = true;
 
-    testutil_parse_begin_opt(argc, argv, "b:h:k:mpP:r:R:s:T:t:vW:", cfg->opts);
+    testutil_parse_begin_opt(argc, argv, "A:b:h:i:k:pP:r:R:s:t:T:u:vW:", cfg->opts);
 
     int ch;
-    while ((ch = __wt_getopt(progname, argc, argv, "b:h:k:mpP:r:R:s:T:t:vW:")) != EOF)
+    while ((ch = __wt_getopt(progname, argc, argv, "A:b:h:i:k:pP:r:R:s:t:T:u:vW:")) != EOF)
         switch (ch) {
-        case 'k':
-            cfg->kill_mode = parse_kill_mode(__wt_optarg);
+        case 'A':
+            if (strcmp(__wt_optarg, "l") == 0)
+                cfg->start_leader = true;
+            else if (strcmp(__wt_optarg, "f") == 0)
+                cfg->start_leader = false;
+            else
+                usage();
             break;
-        case 'm':
-            cfg->switch_mode = true;
+        case 'i':
+            cfg->node_id = parse_uint_in_range(__wt_optarg, 0, MAX_NODES - 1, "Node id");
+            break;
+        case 'k':
+            parse_kill_spec(cfg, __wt_optarg);
             break;
         case 'r':
-            cfg->role = parse_role(__wt_optarg);
+            parse_roles(cfg, __wt_optarg);
             break;
         case 'R':
             cfg->pipe_read_fd = atoi(__wt_optarg);
             break;
         case 's':
-            pool_size_set = true;
-            cfg->pool_size =
-              parse_uint_in_range(__wt_optarg, MIN_POOL_SIZE, MAX_POOL_SIZE, "Pool size");
+            cfg->switch_interval = parse_uint_in_range(__wt_optarg, 1, UINT32_MAX, "Interval");
+            break;
+        case 't':
+            *rand_timep = false;
+            cfg->total_time = (uint32_t)atoi(__wt_optarg);
             break;
         case 'T':
             *rand_thp = false;
             cfg->nth = parse_uint_in_range(__wt_optarg, 1, MAX_TH, "Thread count");
             break;
-        case 't':
-            *rand_timep = false;
-            cfg->timeout = (uint32_t)atoi(__wt_optarg);
+        case 'u':
+            pool_size_set = true;
+            cfg->pool_size =
+              parse_uint_in_range(__wt_optarg, MIN_POOL_SIZE, MAX_POOL_SIZE, "Pool size");
             break;
         case 'v':
             cfg->verify_only = true;
@@ -166,17 +229,12 @@ parse_args(TEST_CONFIG *cfg, int argc, char *argv[], bool *rand_thp, bool *rand_
         }
     if (argc - __wt_optind != 0)
         usage();
-    if (cfg->switch_mode && cfg->kill_mode != KILL_NONE) {
-        /* The pipe relay semantics across a role switch are not defined yet. */
-        fprintf(stderr, "Switch mode (-m) cannot be combined with multi-node (-k)\n");
-        exit(EXIT_FAILURE);
-    }
     if (cfg->verify_only && *rand_thp) {
         fprintf(stderr, "Verify requires -T\n");
         exit(EXIT_FAILURE);
     }
     if (cfg->verify_only && !pool_size_set) {
-        fprintf(stderr, "Verify requires -s\n");
+        fprintf(stderr, "Verify requires -u\n");
         exit(EXIT_FAILURE);
     }
 
@@ -187,7 +245,7 @@ parse_args(TEST_CONFIG *cfg, int argc, char *argv[], bool *rand_thp, bool *rand_
     char cwd[PATH_MAX];
     testutil_assert_errno(getcwd(cwd, sizeof(cwd)) != NULL);
     testutil_snprintf(
-      cfg->page_log_home, sizeof(cfg->page_log_home), "%s/%s/%s", cwd, cfg->home, WT_HOME_DIR);
+      cfg->page_log_home, sizeof(cfg->page_log_home), "%s/%s/%s", cwd, cfg->home, PAGE_LOG_DIR);
 }
 
 /*
@@ -199,9 +257,9 @@ static void
 randomize_run_parameters(TEST_CONFIG *cfg, bool rand_th, bool rand_time)
 {
     if (rand_time) {
-        cfg->timeout = __wt_random(&cfg->opts->extra_rnd) % MAX_TIME;
-        if (cfg->timeout < MIN_TIME)
-            cfg->timeout = MIN_TIME;
+        cfg->total_time = __wt_random(&cfg->opts->extra_rnd) % MAX_TIME;
+        if (cfg->total_time < MIN_TIME)
+            cfg->total_time = MIN_TIME;
     }
 
     const uint32_t rand_value = __wt_random(&cfg->opts->data_rnd);
@@ -210,46 +268,45 @@ randomize_run_parameters(TEST_CONFIG *cfg, bool rand_th, bool rand_time)
         if (cfg->nth < MIN_TH)
             cfg->nth = MIN_TH;
     }
+
+    /* No -r: run a random single node. */
+    if (!cfg->with_leader && !cfg->with_follower) {
+        if ((__wt_random(&cfg->opts->data_rnd) & 1) != 0)
+            cfg->with_leader = true;
+        else
+            cfg->with_follower = true;
+    }
 }
 
 /*
- * kill_mode_desc --
- *     Return a human-readable name for a kill mode.
+ * validate_run_parameters --
+ *     Reject option combinations that make no sense for the resolved topology.
  */
-static const char *
-kill_mode_desc(KILL_MODE mode)
+static void
+validate_run_parameters(const TEST_CONFIG *cfg)
 {
-    switch (mode) {
-    case KILL_NONE:
-        return ("none (single-node)");
-    case KILL_LEADER:
-        return ("leader");
-    case KILL_FOLLOWER:
-        return ("follower");
-    case KILL_BOTH:
-        return ("both");
+    const bool multi_node = cfg->with_leader && cfg->with_follower;
+
+    if (cfg->kill_time[KILL_LONE] != 0 && multi_node) {
+        fprintf(stderr, "-k N targets the lone node; use -k lN / -k fN with -r lf\n");
+        usage();
     }
-    return (NULL); /* NOTREACHED */
+    if ((cfg->kill_time[KILL_LEADER] != 0 || cfg->kill_time[KILL_FOLLOWER] != 0) && !multi_node) {
+        fprintf(stderr, "-k lN / -k fN target roles; use plain -k N with a single node\n");
+        usage();
+    }
 }
 
 /*
- * kill_mode_arg --
- *     Return the command-line fragment reproducing a kill mode.
+ * roles_arg --
+ *     Return the -r fragment reproducing the resolved topology.
  */
 static const char *
-kill_mode_arg(KILL_MODE mode)
+roles_arg(const TEST_CONFIG *cfg)
 {
-    switch (mode) {
-    case KILL_NONE:
-        return ("");
-    case KILL_LEADER:
-        return (" -k l");
-    case KILL_FOLLOWER:
-        return (" -k f");
-    case KILL_BOTH:
-        return (" -k b");
-    }
-    return (NULL); /* NOTREACHED */
+    if (cfg->with_leader && cfg->with_follower)
+        return ("lf");
+    return (cfg->with_leader ? "l" : "f");
 }
 
 /*
@@ -259,14 +316,25 @@ kill_mode_arg(KILL_MODE mode)
 static void
 print_run_banner(const TEST_CONFIG *cfg)
 {
-    printf("Parent: Create %" PRIu32 " schema threads; pool %" PRIu32
-           " slots; kill %s; switch %s; sleep "
-           "%" PRIu32 " seconds\n",
-      cfg->nth, cfg->pool_size, kill_mode_desc(cfg->kill_mode), cfg->switch_mode ? "yes" : "no",
-      cfg->timeout);
-    printf("CONFIG: %s%s%s -s %" PRIu32 " -T %" PRIu32 " -t %" PRIu32 " " TESTUTIL_SEED_FORMAT "\n",
-      progname, kill_mode_arg(cfg->kill_mode), cfg->switch_mode ? " -m" : "", cfg->pool_size,
-      cfg->nth, cfg->timeout, cfg->opts->data_seed, cfg->opts->extra_seed);
+    println("Parent: roles %s; %" PRIu32 " schema threads; pool %" PRIu32
+            " slots; switch every %" PRIu32 "s; kill leader@%" PRIu32 " follower@%" PRIu32
+            " lone@%" PRIu32 "; stop at %" PRIu32 "s",
+      roles_arg(cfg), cfg->nth, cfg->pool_size, cfg->switch_interval, cfg->kill_time[KILL_LEADER],
+      cfg->kill_time[KILL_FOLLOWER], cfg->kill_time[KILL_LONE], cfg->total_time);
+
+    char switch_arg[32] = "", kill_args[64] = "";
+    if (cfg->switch_interval != 0)
+        testutil_snprintf(switch_arg, sizeof(switch_arg), " -s %" PRIu32, cfg->switch_interval);
+    size_t len = 0;
+    for (int k = 0; k < KILL_TARGETS; k++)
+        if (cfg->kill_time[k] != 0)
+            testutil_snprintf_len_incr(kill_args, sizeof(kill_args), &len, " -k %s%" PRIu32,
+              kill_prefix[k], cfg->kill_time[k]);
+
+    println("CONFIG: %s -r %s%s%s -u %" PRIu32 " -T %" PRIu32 " -t %" PRIu32
+            " " TESTUTIL_SEED_FORMAT,
+      progname, roles_arg(cfg), switch_arg, kill_args, cfg->pool_size, cfg->nth, cfg->total_time,
+      cfg->opts->data_seed, cfg->opts->extra_seed);
 }
 
 /*
@@ -283,21 +351,25 @@ main(int argc, char *argv[])
     TEST_CONFIG cfg = {0};
     cfg.opts = &s_opts;
     cfg.nth = MIN_TH;
-    cfg.pool_size = MAX_POOL_SIZE / 8; /* Default: 8 slots per thread. */
-    cfg.timeout = MIN_TIME;
+    /*
+     * Default: 32 slots per thread. A wide pool keeps the generator's picks off the few slots gated
+     * behind a checkpoint, so it rarely comes up empty and has to wait.
+     */
+    cfg.pool_size = MAX_POOL_SIZE / 2;
+    cfg.total_time = MIN_TIME;
     cfg.pipe_read_fd = cfg.pipe_write_fd = -1;
+    cfg.self_pipe_read_fd = cfg.self_pipe_write_fd = -1;
 
     bool rand_th, rand_time;
     parse_args(&cfg, argc, argv, &rand_th, &rand_time);
 
-    /* The child roles get their full configuration from the command line; just run them. */
-    if (cfg.role == ROLE_LEADER)
-        leader_main(&cfg); /* NOTREACHED */
-    if (cfg.role == ROLE_FOLLOWER)
-        follower_main(&cfg); /* NOTREACHED */
+    /* The node role gets its full configuration from the command line; just run it. */
+    if (cfg.role == ROLE_NODE)
+        return (node_main(&cfg));
 
     if (!cfg.verify_only) {
         randomize_run_parameters(&cfg, rand_th, rand_time);
+        validate_run_parameters(&cfg);
         print_run_banner(&cfg);
     }
 

--- a/test/csuite/schema_disagg_abort/node.c
+++ b/test/csuite/schema_disagg_abort/node.c
@@ -57,7 +57,7 @@ workload_counter_advance(WORKLOAD_STATE *state, uint64_t v)
 {
     uint64_t cur;
     do {
-        cur = __wt_atomic_load_uint64_acquire(&state->current_ts);
+        cur = __wt_atomic_load_uint64(&state->current_ts);
     } while (cur < v && !__wt_atomic_cas_uint64(&state->current_ts, cur, v));
 }
 
@@ -68,7 +68,7 @@ workload_counter_advance(WORKLOAD_STATE *state, uint64_t v)
 bool
 workload_running(WORKLOAD_STATE *state)
 {
-    return (!__wt_atomic_load_bool_acquire(&state->stop_phase));
+    return (!__wt_atomic_load_bool(&state->stop_phase));
 }
 
 /*
@@ -138,7 +138,7 @@ static NODE_TRIGGER
 node_trigger_wait(WORKLOAD_STATE *state)
 {
     while (!node_stop_requested()) {
-        if (__wt_atomic_load_bool_acquire(&state->handover_received))
+        if (__wt_atomic_load_bool(&state->handover_received))
             return (TRIGGER_SWITCH);
 
         const bool abandoned_follower = !state->generates && !state->cfg->peer_alive;
@@ -182,10 +182,10 @@ static bool
 evq_push(EVENT_QUEUE *q, const SCHEMA_EVENT *ev)
 {
     const uint64_t tail = q->tail; /* single producer */
-    if (tail - __wt_atomic_load_uint64_acquire(&q->head) >= EVQ_SIZE)
+    if (tail - __wt_atomic_load_uint64(&q->head) >= EVQ_SIZE)
         return (false);
     q->ev[tail % EVQ_SIZE] = *ev;
-    __wt_atomic_store_uint64_release(&q->tail, tail + 1);
+    __wt_atomic_store_uint64(&q->tail, tail + 1);
     return (true);
 }
 
@@ -197,10 +197,10 @@ static bool
 evq_pop(EVENT_QUEUE *q, SCHEMA_EVENT *ev)
 {
     const uint64_t head = q->head; /* single consumer */
-    if (head == __wt_atomic_load_uint64_acquire(&q->tail))
+    if (head == __wt_atomic_load_uint64(&q->tail))
         return (false);
     *ev = q->ev[head % EVQ_SIZE];
-    __wt_atomic_store_uint64_release(&q->head, head + 1);
+    __wt_atomic_store_uint64(&q->head, head + 1);
     return (true);
 }
 
@@ -211,7 +211,7 @@ evq_pop(EVENT_QUEUE *q, SCHEMA_EVENT *ev)
 static bool
 evq_empty(EVENT_QUEUE *q)
 {
-    return (__wt_atomic_load_uint64_acquire(&q->head) == __wt_atomic_load_uint64_acquire(&q->tail));
+    return (__wt_atomic_load_uint64(&q->head) == __wt_atomic_load_uint64(&q->tail));
 }
 
 /*
@@ -261,8 +261,8 @@ void
 workload_drain_barrier(WORKLOAD_STATE *state)
 {
     for (uint32_t t = 0; t < state->nth_workers; t++)
-        while ((!evq_empty(&state->workers[t].evq) ||
-                 __wt_atomic_load_bool_acquire(&state->workers[t].busy)) &&
+        while (
+          (!evq_empty(&state->workers[t].evq) || __wt_atomic_load_bool(&state->workers[t].busy)) &&
           workload_running(state))
             __wt_sleep(0, WT_THOUSAND);
 }
@@ -278,7 +278,7 @@ workers_min(WORKLOAD_STATE *state)
 {
     uint64_t min_val = UINT64_MAX;
     for (uint32_t i = 0; i < state->nth_workers; i++) {
-        const uint64_t val = __wt_atomic_load_uint64_acquire(&state->workers[i].completed_ts);
+        const uint64_t val = __wt_atomic_load_uint64(&state->workers[i].completed_ts);
         if (val == 0)
             return (0);
         if (val < min_val)
@@ -318,7 +318,7 @@ thread_ts_run(void *arg)
         }
 
         const uint64_t durable_epoch = query_ts(state->conn, "last_disaggregated_schema_epoch");
-        __wt_atomic_store_uint64_release(&state->ckpt_covered_ts, durable_epoch);
+        __wt_atomic_store_uint64(&state->ckpt_covered_ts, durable_epoch);
 
         __wt_sleep(0, 100 * WT_THOUSAND);
     }
@@ -395,7 +395,7 @@ workload_stop(WORKLOAD_STATE *state)
     node_generator_stop(state);
     node_reader_stop(state);
 
-    __wt_atomic_store_bool_release(&state->stop_phase, true);
+    __wt_atomic_store_bool(&state->stop_phase, true);
     node_workers_join(state);
     testutil_check(__wt_thread_join(NULL, &ts_thr));
 }

--- a/test/csuite/schema_disagg_abort/node.c
+++ b/test/csuite/schema_disagg_abort/node.c
@@ -7,36 +7,19 @@
  */
 
 /*
- * The generic node: everything a database node does regardless of role. This file owns the phase
- * loop, the WiredTiger connection, the event pipes, and the workload engine.
+ * The generic node: the phase loop, the WiredTiger connection, the workload engine's state and
+ * per-phase lifecycle, the worker event queues, and the timestamp thread.
  *
- * One pipeline serves both roles: a generator thread produces the node's command stream into a
- * self-pipe (a leader always does, and so does a follower with no peer to receive from), a reader
- * thread demuxes the source pipe - the self-pipe, or a live peer's - to N worker threads that apply
- * the events, and a timestamp thread advances the frontier. The threads coordinate without locks.
- *
- * The role specifics live in leader.c and follower.c behind the NODE_ROLE operations.
+ * One pipeline serves both roles, coordinating without locks: a generator produces the node's
+ * command stream into a self-pipe, a reader demuxes the source pipe - the self-pipe, or a live
+ * peer's - to N workers that apply the events, and a timestamp thread advances the frontier. Each
+ * stage lives in its own file behind a start/stop pair; the role specifics live in leader.c and
+ * follower.c behind the NODE_ROLE operations.
  */
 
 #include "schema_disagg_abort.h"
 
 #include <signal.h>
-#include <sys/select.h>
-
-/* The table configuration every schema table is created with, on either role. */
-#define SCHEMA_TABLE_CONFIG "key_format=S,value_format=S,type=layered,block_manager=disagg"
-
-/* Thread argument: the shared workload state plus this thread's identity. */
-typedef struct {
-    WORKLOAD_STATE *state;
-    uint32_t thread_index;
-} THREAD_ARG;
-
-/* Per-thread worker state for one phase. */
-typedef struct {
-    WT_SESSION *session;
-    FILE *record_fp; /* records for what this node originated, or for what it applied */
-} WORKER_CTX;
 
 /*
  * workload_state_create --
@@ -65,12 +48,12 @@ workload_seed_counter(WORKLOAD_STATE *state, uint64_t ts)
 }
 
 /*
- * counter_advance --
+ * workload_counter_advance --
  *     Advance the monotonic allocator to at least the given applied value, so a follower's counter
  *     tracks everything it applied.
  */
-static void
-counter_advance(WORKLOAD_STATE *state, uint64_t v)
+void
+workload_counter_advance(WORKLOAD_STATE *state, uint64_t v)
 {
     uint64_t cur;
     do {
@@ -82,7 +65,7 @@ counter_advance(WORKLOAD_STATE *state, uint64_t v)
  * workload_running --
  *     The condition every phase loop runs on: true until the phase is directed to quiesce.
  */
-static bool
+bool
 workload_running(WORKLOAD_STATE *state)
 {
     return (!__wt_atomic_load_bool_acquire(&state->stop_phase));
@@ -117,32 +100,6 @@ node_open(TEST_CONFIG *cfg, const char *disagg_mode, WT_CONNECTION **connp)
 }
 
 /*
- * node_event_send --
- *     Relay one event to the peer over the node's out-pipe. Single write() calls of
- *     sizeof(SCHEMA_EVENT) are atomic, so concurrent threads need no extra locking. Returns false
- *     without failing when there is no peer (no pipe, or the peer is gone), leaving the caller to
- *     decide whether delivery is optional (the workload relay) or mandatory (the hand-over).
- */
-bool
-node_event_send(TEST_CONFIG *cfg, const SCHEMA_EVENT *ev)
-{
-    if (cfg->pipe_write_fd < 0)
-        return (false);
-
-    const ssize_t nw = write(cfg->pipe_write_fd, ev, sizeof(*ev));
-    if (nw < 0) {
-        if (errno != EPIPE && errno != EBADF)
-            testutil_die(errno, "write event pipe");
-        close(cfg->pipe_write_fd);
-        cfg->pipe_write_fd = -1;
-        cfg->peer_alive = false;
-        return (false);
-    }
-    testutil_assert(nw == (ssize_t)sizeof(*ev));
-    return (true);
-}
-
-/*
  * node_stop_requested --
  *     Check for the parent's graceful-stop sentinel. Not consumed: every node must see it.
  */
@@ -157,7 +114,7 @@ node_stop_requested(void)
  *     Check for the parent's switch-request sentinel and consume it, so one request triggers
  *     exactly one switch. Only the acting node (the leader, or a lone node) may call this.
  */
-static bool
+bool
 node_switch_request_consume(void)
 {
     if (!testutil_exists(NULL, SWITCH_REQUEST_FILE))
@@ -268,9 +225,29 @@ workload_enqueue(WORKLOAD_STATE *state, const SCHEMA_EVENT *ev)
 {
     testutil_assert(ev->thread_id < state->nth_workers);
 
-    EVENT_QUEUE *q = &state->threads[ev->thread_id].evq;
+    EVENT_QUEUE *q = &state->workers[ev->thread_id].evq;
     while (!evq_push(q, ev) && workload_running(state))
         __wt_sleep(0, WT_THOUSAND);
+}
+
+/*
+ * workload_dequeue --
+ *     Take the next event queued for one worker; false when nothing is queued for it.
+ */
+bool
+workload_dequeue(WORKLOAD_STATE *state, uint32_t thread_index, SCHEMA_EVENT *ev)
+{
+    return (evq_pop(&state->workers[thread_index].evq, ev));
+}
+
+/*
+ * workload_queue_empty --
+ *     Report whether one worker's queue is empty.
+ */
+bool
+workload_queue_empty(WORKLOAD_STATE *state, uint32_t thread_index)
+{
+    return (evq_empty(&state->workers[thread_index].evq));
 }
 
 /*
@@ -284,243 +261,10 @@ void
 workload_drain_barrier(WORKLOAD_STATE *state)
 {
     for (uint32_t t = 0; t < state->nth_workers; t++)
-        while ((!evq_empty(&state->threads[t].evq) ||
-                 __wt_atomic_load_bool_acquire(&state->threads[t].busy)) &&
+        while ((!evq_empty(&state->workers[t].evq) ||
+                 __wt_atomic_load_bool_acquire(&state->workers[t].busy)) &&
           workload_running(state))
             __wt_sleep(0, WT_THOUSAND);
-}
-
-/*
- * record_event_line --
- *     Append one event to a record file; the one place that defines the record format for both the
- *     schema and the relay files.
- */
-static void
-record_event_line(FILE *fp, const SCHEMA_EVENT *ev)
-{
-    int ret = 0;
-
-    switch (ev->type) {
-    case EVENT_CREATE:
-    case EVENT_DROP:
-        ret = fprintf(fp, "%s %" PRIu64 " %s\n", ev->type == EVENT_CREATE ? "CREATE" : "DROP",
-          ev->event_ts, ev->uri);
-        break;
-    case EVENT_INSERT:
-        ret = fprintf(fp, "INSERT %" PRIu64 " %" PRIu32 " %" PRIu32 " %s\n", ev->event_ts,
-          ev->key_min, ev->key_max, ev->uri);
-        break;
-    case EVENT_CKPT:
-    case EVENT_SWITCH:
-        testutil_assertfmt(false, "Unexpected record event type: %d", ev->type);
-    }
-    if (ret < 0)
-        testutil_die(EIO, "fprintf event record");
-}
-
-/*
- * worker_record_open --
- *     Open a worker's record file, named for the origin of what it logs: the operations this node
- *     produced itself go to its leader records, the peer's relayed events to its follower records.
- *     Append so a later phase preserves the earlier records for the post-crash verifier.
- */
-static FILE *
-worker_record_open(const WORKLOAD_STATE *state, uint32_t thread_index)
-{
-    char fname[128];
-    testutil_snprintf(fname, sizeof(fname),
-      state->generates ? LEADER_RECORDS_FILE : FOLLOWER_RECORDS_FILE, state->cfg->node_id,
-      thread_index);
-
-    FILE *fp;
-    testutil_assert_errno((fp = fopen(fname, "a")) != NULL);
-    /* Flush the record file per line so entries survive a SIGKILL crash. */
-    __wt_stream_set_line_buffer(fp);
-    return (fp);
-}
-
-/*
- * schema_op_execute --
- *     Execute one schema operation: the single call site for creating and dropping the test's
- *     tables, on either role. EBUSY is retried (the stream cannot be reordered, and when the source
- *     is the peer the operation already succeeded there), with a bound so a wedged operation fails
- *     the test instead of hanging it.
- */
-static void
-schema_op_execute(WT_SESSION *session, const SCHEMA_EVENT *ev)
-{
-    const bool is_create = ev->type == EVENT_CREATE;
-    testutil_assert(ev->type == EVENT_CREATE || ev->type == EVENT_DROP);
-
-    struct timespec start;
-    __wt_epoch(NULL, &start);
-
-    int ret;
-    for (;;) {
-        ret = is_create ? session->create(session, ev->uri, SCHEMA_TABLE_CONFIG) :
-                          session->drop(session, ev->uri, "force=false,lock_wait=false");
-        if (ret != EBUSY)
-            break;
-
-        struct timespec now;
-        __wt_epoch(NULL, &now);
-        if (WT_TIMEDIFF_SEC(now, start) > MAX_STARTUP)
-            testutil_die(ETIMEDOUT, "%s %s: EBUSY for %d seconds", is_create ? "CREATE" : "DROP",
-              ev->uri, MAX_STARTUP);
-        __wt_yield();
-    }
-    testutil_assertfmt(ret == 0, "%s %s (ts %" PRIu64 "): %s", is_create ? "CREATE" : "DROP",
-      ev->uri, ev->event_ts, wiredtiger_strerror(ret));
-}
-
-/*
- * schema_op_publish --
- *     Publish the schema operation at the given epoch so it becomes visible in shared metadata at
- *     the next checkpoint. Runs on both roles: a follower's applied operations queue up and drain
- *     when it eventually leads.
- */
-static void
-schema_op_publish(WT_SESSION *session, const char *uri, uint64_t epoch)
-{
-    char pub_cfg[64];
-    testutil_snprintf(pub_cfg, sizeof(pub_cfg), "disaggregated=(schema_epoch=%" PRIx64 ")", epoch);
-    testutil_check(session->publish(session, uri, pub_cfg));
-}
-
-/*
- * schema_op_insert_data --
- *     Populate a table with rows keyed key_min..key_max at the given commit timestamp; each row is
- *     valued with the commit timestamp, so the verifier can tell which generation of a reused table
- *     name wrote the data.
- */
-static void
-schema_op_insert_data(
-  WT_SESSION *session, const char *uri, uint64_t commit_ts, uint32_t key_min, uint32_t key_max)
-{
-    char val_buf[32];
-    testutil_snprintf(val_buf, sizeof(val_buf), "%" PRIu64, commit_ts);
-    testutil_check(session->begin_transaction(session, NULL));
-
-    WT_CURSOR *cursor;
-    testutil_check(session->open_cursor(session, uri, NULL, NULL, &cursor));
-    for (uint32_t r = key_min; r <= key_max; r++) {
-        char key_buf[16];
-        testutil_snprintf(key_buf, sizeof(key_buf), "%" PRIu32, r);
-        cursor->set_key(cursor, key_buf);
-        cursor->set_value(cursor, val_buf);
-        testutil_check(cursor->insert(cursor));
-    }
-    testutil_check(cursor->close(cursor));
-
-    char commit_cfg[64];
-    testutil_snprintf(commit_cfg, sizeof(commit_cfg), "commit_timestamp=%" PRIx64, commit_ts);
-    testutil_check(session->commit_transaction(session, commit_cfg));
-}
-
-/*
- * worker_complete --
- *     Mark one allocator value fully completed by a worker: track it in the counter (a no-op for
- *     freshly allocated values) and publish it as the thread's completed frontier mark.
- */
-static void
-worker_complete(WORKLOAD_STATE *state, uint32_t thread_index, uint64_t value)
-{
-    counter_advance(state, value);
-    (void)__wt_atomic_add_uint64(&state->applied, 1);
-    __wt_atomic_store_uint64_release(&state->threads[thread_index].completed_ts, value);
-}
-
-/*
- * apply_event --
- *     Apply one event on this node, identically for both roles and exactly as the source stream
- *     fixed it - same operation, same epoch, same commit timestamp: execute the schema operation or
- *     the insert, record the event, publish a schema operation, relay it to the peer when leading,
- *     and mark it completed.
- *
- * The ordering is load-bearing. A schema operation is recorded before it is published, so the
- *     record reaches the file before a checkpoint can make the epoch durable (a record without a
- *     durable epoch is ignored by the verifier, the reverse would be a hole). The relay precedes
- *     the completion store, which is what lets the stable frontier advance past this operation,
- *     what lets a checkpoint cover it, and what lets the checkpoint thread send that checkpoint's
- *     pipe event: the peer holds every event at or below a checkpoint's stable frontier by the time
- *     it sees that checkpoint's event.
- */
-static void
-apply_event(WORKLOAD_STATE *state, WORKER_CTX *ctx, uint32_t thread_index, const SCHEMA_EVENT *ev)
-{
-    const bool relay = state->leads;
-
-    if (ctx->record_fp == NULL)
-        ctx->record_fp = worker_record_open(state, thread_index);
-
-    switch (ev->type) {
-    case EVENT_INSERT:
-        schema_op_insert_data(ctx->session, ev->uri, ev->event_ts, ev->key_min, ev->key_max);
-        record_event_line(ctx->record_fp, ev);
-        if (relay)
-            (void)node_event_send(state->cfg, ev);
-        worker_complete(state, thread_index, ev->event_ts);
-        break;
-    case EVENT_CREATE:
-    case EVENT_DROP:
-        schema_op_execute(ctx->session, ev);
-        record_event_line(ctx->record_fp, ev);
-        schema_op_publish(ctx->session, ev->uri, ev->event_ts);
-        if (relay)
-            (void)node_event_send(state->cfg, ev);
-        worker_complete(state, thread_index, ev->event_ts);
-        break;
-    case EVENT_CKPT:
-    case EVENT_SWITCH:
-        testutil_assertfmt(false, "Unexpected apply event type: %d", ev->type);
-    }
-}
-
-/*
- * worker_apply_loop --
- *     A worker's phase, identical in both roles: execute whatever the reader queued while the phase
- *     runs, then drain the queue so a graceful stop loses nothing.
- */
-static void
-worker_apply_loop(WORKLOAD_STATE *state, WORKER_CTX *ctx, uint32_t thread_index)
-{
-    EVENT_QUEUE *q = &state->threads[thread_index].evq;
-    bool *busyp = &state->threads[thread_index].busy;
-
-    while (workload_running(state) || !evq_empty(q)) {
-        /* Publish busy before checking the queue so the drain barrier never races an apply. */
-        __wt_atomic_store_bool_release(busyp, true);
-        SCHEMA_EVENT ev;
-        const bool popped = evq_pop(q, &ev);
-        if (popped)
-            apply_event(state, ctx, thread_index, &ev);
-        __wt_atomic_store_bool_release(busyp, false);
-        if (!popped)
-            __wt_sleep(0, WT_THOUSAND);
-    }
-}
-
-/*
- * thread_worker_run --
- *     One worker thread: set up the per-phase context, run the processing loop, tear the context
- *     down.
- */
-static WT_THREAD_RET
-thread_worker_run(void *arg)
-{
-    const THREAD_ARG *ta = arg;
-    WORKLOAD_STATE *state = ta->state;
-
-    WORKER_CTX ctx;
-    WT_CLEAR(ctx);
-    testutil_check(state->conn->open_session(state->conn, NULL, NULL, &ctx.session));
-
-    worker_apply_loop(state, &ctx, ta->thread_index);
-
-    if (ctx.record_fp != NULL)
-        testutil_check(fclose(ctx.record_fp));
-    testutil_check(ctx.session->close(ctx.session, NULL));
-    return (WT_THREAD_RET_VALUE);
 }
 
 /*
@@ -534,7 +278,7 @@ workers_min(WORKLOAD_STATE *state)
 {
     uint64_t min_val = UINT64_MAX;
     for (uint32_t i = 0; i < state->nth_workers; i++) {
-        const uint64_t val = __wt_atomic_load_uint64_acquire(&state->threads[i].completed_ts);
+        const uint64_t val = __wt_atomic_load_uint64_acquire(&state->workers[i].completed_ts);
         if (val == 0)
             return (0);
         if (val < min_val)
@@ -558,8 +302,7 @@ workers_min(WORKLOAD_STATE *state)
 static WT_THREAD_RET
 thread_ts_run(void *arg)
 {
-    const THREAD_ARG *ta = arg;
-    WORKLOAD_STATE *state = ta->state;
+    WORKLOAD_STATE *state = arg;
 
     while (workload_running(state)) {
         /*
@@ -582,362 +325,8 @@ thread_ts_run(void *arg)
     return (WT_THREAD_RET_VALUE);
 }
 
-/*
- * generator_running --
- *     The generator's loop condition: true until the engine directs it to exit.
- */
-static bool
-generator_running(WORKLOAD_STATE *state)
-{
-    return (!__wt_atomic_load_bool_acquire(&state->generator_stop) && workload_running(state));
-}
-
-/*
- * generator_emit --
- *     Write one event to the node's self-pipe, blocking while it is full: the workers' consumption
- *     rate backpressures the generator through the pipe and the queues.
- */
-static void
-generator_emit(WORKLOAD_STATE *state, const SCHEMA_EVENT *ev)
-{
-    ssize_t nw;
-    while ((nw = write(state->cfg->self_pipe_write_fd, ev, sizeof(*ev))) < 0)
-        if (errno != EINTR)
-            testutil_die(errno, "write self pipe");
-    testutil_assert(nw == (ssize_t)sizeof(*ev));
-    ++state->emitted;
-}
-
-/*
- * generator_op --
- *     Generate one schema operation for the given worker thread: pick a slot, flip it between
- *     create and drop, allocate the epoch, and give one create in INSERT_ODDS an insert at a fresh
- *     commit timestamp, which comes from the same allocator as the epoch and so is above the
- *     table's create epoch by construction. Reports whether an event was emitted.
- *
- * Only a slot holding data is gated: a dirty table cannot be dropped until a completed checkpoint
- *     covers its insert (the drop would wedge in EBUSY), so that pick is simply skipped, the
- *     generation-time analogue of trying another slot. Clean tables churn ungated. The slot model
- *     flips at generation time; the worker's bounded EBUSY retry guarantees the executed state
- *     converges to it.
- */
-static bool
-generator_op(WORKLOAD_STATE *state, uint32_t t)
-{
-    WT_RAND_STATE *rnd = &state->threads[t].rnd;
-
-    const uint32_t slot = __wt_random(rnd) % state->cfg->pool_size;
-    const bool is_create = !state->table_exists[t][slot];
-    /* A clean table (commit timestamp 0) is droppable at once; a dirty one waits for coverage. */
-    if (!is_create && state->table_commit_ts[t][slot] != 0 &&
-      state->table_commit_ts[t][slot] > __wt_atomic_load_uint64_acquire(&state->ckpt_covered_ts))
-        return (false);
-    state->table_exists[t][slot] = is_create;
-
-    SCHEMA_EVENT ev = {0};
-    ev.type = is_create ? EVENT_CREATE : EVENT_DROP;
-    ev.thread_id = t;
-    ev.event_ts = __wt_atomic_add_uint64(&state->current_ts, 1);
-    testutil_snprintf(ev.uri, sizeof(ev.uri), SCHEMA_TABLE_FMT, state->cfg->node_id, t, slot);
-    generator_emit(state, &ev);
-
-    if (is_create) {
-        /* Most creates leave the table clean, so the churn is not gated on checkpoints. */
-        state->table_commit_ts[t][slot] = 0;
-        if (__wt_random(rnd) % INSERT_ODDS == 0) {
-            ev.type = EVENT_INSERT;
-            ev.event_ts = __wt_atomic_add_uint64(&state->current_ts, 1);
-            ev.key_min = DATA_KEY_MIN;
-            ev.key_max = DATA_KEY_MAX;
-            state->table_commit_ts[t][slot] = ev.event_ts;
-            generator_emit(state, &ev);
-        }
-    }
-    return (true);
-}
-
-/*
- * generator_round --
- *     Feed every worker thread one generated operation, round-robin. Reports whether anything was
- *     emitted: nothing is while the lead over the workers is spent, or when every pick was an
- *     uncovered drop, and the caller waits instead of spinning on the slot model.
- */
-static bool
-generator_round(WORKLOAD_STATE *state, uint64_t lead_max)
-{
-    if (state->emitted - __wt_atomic_load_uint64_acquire(&state->applied) > lead_max)
-        return (false);
-
-    bool emitted = false;
-
-    for (uint32_t t = 0; t < state->nth_workers && generator_running(state); t++)
-        if (generator_op(state, t))
-            emitted = true;
-    return (emitted);
-}
-
-/*
- * A leading generator's pacing state: the checkpoint cadence, the sentinel poll throttle, and the
- * lead it may build over its workers.
- */
-typedef struct {
-    WT_RAND_STATE *rnd; /* the generator's own rnd stream, used for the checkpoint intervals */
-    struct timespec last_ckpt;
-    struct timespec last_poll;
-    uint64_t ckpt_wait; /* seconds until the next checkpoint event is due */
-    uint64_t lead_max;  /* events that may be in flight; UINT64_MAX when nothing bounds it */
-} GENERATOR_PACING;
-
-/*
- * generator_pacing_init --
- *     Initialize the pacing state at the start of a leading phase.
- */
-static void
-generator_pacing_init(GENERATOR_PACING *pacing, const TEST_CONFIG *cfg, WT_RAND_STATE *rnd)
-{
-    pacing->rnd = rnd;
-    __wt_epoch(NULL, &pacing->last_ckpt);
-    pacing->last_poll = pacing->last_ckpt;
-    pacing->ckpt_wait = __wt_random(rnd) % MAX_CKPT_INVL;
-    /* Bound the lead so a hand-over drains inside one switch period; no switches, no bound. */
-    pacing->lead_max = cfg->switch_interval == 0 ?
-      UINT64_MAX :
-      WT_MAX(cfg->switch_interval * GEN_APPLY_RATE_FLOOR, GEN_LEAD_MIN);
-}
-
-/*
- * generator_ckpt_due --
- *     Pace the stream's checkpoint events: true when the current random interval has elapsed,
- *     starting the next one.
- */
-static bool
-generator_ckpt_due(GENERATOR_PACING *pacing)
-{
-    struct timespec now;
-    __wt_epoch(NULL, &now);
-    if ((uint64_t)WT_TIMEDIFF_SEC(now, pacing->last_ckpt) < pacing->ckpt_wait)
-        return (false);
-    pacing->last_ckpt = now;
-    pacing->ckpt_wait = __wt_random(pacing->rnd) % MAX_CKPT_INVL;
-    return (true);
-}
-
-/*
- * generator_switch_requested --
- *     Watch for the parent's switch request, polling the sentinel at most once a second (the
- *     cadence the control loop's own waits use).
- */
-static bool
-generator_switch_requested(GENERATOR_PACING *pacing)
-{
-    struct timespec now;
-    __wt_epoch(NULL, &now);
-    if (WT_TIMEDIFF_SEC(now, pacing->last_poll) < 1)
-        return (false);
-    pacing->last_poll = now;
-    return (node_switch_request_consume());
-}
-
-/*
- * thread_generator_run --
- *     The node's command source, started only for a phase that produces its own stream: a leader
- *     always does, and so does a follower with no peer to receive from. Feeds workload rounds into
- *     the self-pipe, a checkpoint event whenever one is due, and, once the parent requests a
- *     switch, the hand-over event that ends the stream and the phase. All switch triggering lives
- *     here, never in the control loop.
- */
-static WT_THREAD_RET
-thread_generator_run(void *arg)
-{
-    const THREAD_ARG *ta = arg;
-    WORKLOAD_STATE *state = ta->state;
-
-    GENERATOR_PACING pacing;
-    generator_pacing_init(&pacing, state->cfg, &state->threads[ta->thread_index].rnd);
-
-    while (generator_running(state)) {
-        if (!generator_round(state, pacing.lead_max))
-            __wt_sleep(0, WT_THOUSAND);
-
-        if (generator_ckpt_due(&pacing)) {
-            SCHEMA_EVENT ev = {0};
-            ev.type = EVENT_CKPT;
-            generator_emit(state, &ev);
-        }
-
-        if (generator_switch_requested(&pacing)) {
-            /* The stream's last event, carrying the counter the next leader continues from. */
-            SCHEMA_EVENT ev = {0};
-            ev.type = EVENT_SWITCH;
-            ev.event_ts = __wt_atomic_load_uint64_acquire(&state->current_ts);
-            generator_emit(state, &ev);
-            break;
-        }
-    }
-    return (WT_THREAD_RET_VALUE);
-}
-
-/* The reader thread's handle; its context and results live in the workload state. */
-static wt_thread_t reader_thr;
-static bool reader_started = false;
-
-/*
- * pipe_wait_readable --
- *     Wait up to a second for the pipe to become readable, so the reader can notice a stop request
- *     even when the source is silent.
- */
-static bool
-pipe_wait_readable(int fd)
-{
-    fd_set rfds;
-    FD_ZERO(&rfds);
-    FD_SET(fd, &rfds);
-
-    struct timeval tv = {1, 0};
-    const int ret = select(fd + 1, &rfds, NULL, NULL, &tv);
-    if (ret < 0) {
-        if (errno == EINTR)
-            return (false);
-        testutil_die(errno, "reader select pipe");
-    }
-    return (ret > 0);
-}
-
-/*
- * pipe_read_event --
- *     Read one complete event from the pipe. Returns false on EOF (the writer died). The writer's
- *     death can truncate the final write, so reassemble the event from partial reads.
- */
-static bool
-pipe_read_event(int fd, SCHEMA_EVENT *ev)
-{
-    size_t have = 0;
-    while (have < sizeof(*ev)) {
-        const ssize_t nr = read(fd, (uint8_t *)ev + have, sizeof(*ev) - have);
-        if (nr < 0) {
-            if (errno == EINTR)
-                continue;
-            testutil_die(errno, "reader read pipe");
-        }
-        if (nr == 0)
-            return (false);
-        have += (size_t)nr;
-    }
-    return (true);
-}
-
-/*
- * node_current_role --
- *     Return the role this phase runs. The engine tracks the role as a single bool, so the role
- *     instance is derived from it rather than stored: one source of truth, no invariant to keep.
- */
-static const NODE_ROLE *
-node_current_role(const WORKLOAD_STATE *state)
-{
-    return (state->leads ? &node_role_leader : &node_role_follower);
-}
-
-/*
- * thread_reader_run --
- *     Drain the node's event source: the self-pipe when this phase generates, the peer's pipe
- *     otherwise. Schema and data events are queued for the worker threads; a checkpoint event is
- *     produced (leading) or picked up after a drain barrier (following); the hand-over event ends
- *     the phase. Pipe EOF can only happen on a peer-fed pipe: it marks the peer dead and turns this
- *     node into a lone follower.
- */
-static WT_THREAD_RET
-thread_reader_run(void *arg)
-{
-    WORKLOAD_STATE *state = arg;
-    TEST_CONFIG *cfg = state->cfg;
-    const int src_fd = state->generates ? cfg->self_pipe_read_fd : cfg->pipe_read_fd;
-
-    WT_SESSION *session;
-    testutil_check(state->conn->open_session(state->conn, NULL, NULL, &session));
-
-    /* The role's checkpoint bookkeeping for this phase; only a follower picks checkpoints up. */
-    CKPT_CTX ckpt = {0};
-    __wt_epoch(NULL, &ckpt.phase_start);
-    if (!state->leads)
-        testutil_check(state->conn->get_page_log(state->conn, "palite", &ckpt.page_log));
-
-    SCHEMA_EVENT ev;
-    bool running = true;
-    while (running && !__wt_atomic_load_bool_acquire(&state->reader_stop)) {
-        if (!pipe_wait_readable(src_fd))
-            continue;
-        if (!pipe_read_event(src_fd, &ev)) {
-            /* EOF: the peer died. Keep the role; the node continues as a lone follower. */
-            testutil_assert(!state->leads); /* The self-pipe's writer lives in this process. */
-            cfg->peer_alive = false;
-            println("Node %" PRIu32 ": peer died; continuing as a lone follower", cfg->node_id);
-            running = false;
-            continue;
-        }
-
-        switch (ev.type) {
-        case EVENT_CREATE:
-        case EVENT_DROP:
-        case EVENT_INSERT:
-            workload_enqueue(state, &ev);
-            break;
-        case EVENT_CKPT:
-            node_current_role(state)->checkpoint(state, session, &ckpt, &ev);
-            break;
-        case EVENT_SWITCH:
-            /* The final event of the term's stream: this node must step up. */
-            workload_drain_barrier(state);
-            /*
-             * Relay-integrity check: the drained counter must equal the sender's final counter.
-             * Every counter value the term allocated rides an event that precedes the switch in the
-             * stream, so after the drain nothing may be missing.
-             */
-            testutil_assertfmt(__wt_atomic_load_uint64_acquire(&state->current_ts) == ev.event_ts,
-              "hand-over: drained counter %" PRIu64 " != sender's final counter %" PRIu64,
-              __wt_atomic_load_uint64_acquire(&state->current_ts), ev.event_ts);
-            __wt_atomic_store_bool_release(&state->handover_received, true);
-            running = false;
-            break;
-        }
-    }
-
-    if (ckpt.page_log != NULL)
-        testutil_check(ckpt.page_log->terminate(ckpt.page_log, NULL));
-    testutil_check(session->close(session, NULL));
-    return (WT_THREAD_RET_VALUE);
-}
-
-/*
- * node_reader_start --
- *     Start the reader thread for a phase with an event source: any leader phase (the self-pipe),
- *     or a follower phase with a live peer. The per-phase hand-over and stop fields were reset by
- *     workload_start.
- */
-static void
-node_reader_start(WORKLOAD_STATE *state)
-{
-    testutil_assert(!reader_started);
-    testutil_check(__wt_thread_create(NULL, &reader_thr, thread_reader_run, state));
-    reader_started = true;
-}
-
-/*
- * node_reader_stop --
- *     Stop and join the reader thread, if one is running.
- */
-static void
-node_reader_stop(WORKLOAD_STATE *state)
-{
-    if (!reader_started)
-        return;
-    __wt_atomic_store_bool_release(&state->reader_stop, true);
-    testutil_check(__wt_thread_join(NULL, &reader_thr));
-    reader_started = false;
-}
-
-/* Thread handles have process lifetime; phases join and restart them but never free them. */
-static wt_thread_t workload_thr[MAX_TH + 2];
-static THREAD_ARG workload_arg[MAX_TH + 2];
+/* The timestamp thread's handle; phases join and restart it but never free it. */
+static wt_thread_t ts_thr;
 
 /*
  * workload_start --
@@ -964,35 +353,32 @@ workload_start(WORKLOAD_STATE *state, bool as_leader)
     state->ckpt_covered_ts = 0;
     state->emitted = state->applied = 0;
 
-    for (uint32_t i = 0; i < cfg->nth + 2; i++) {
-        workload_arg[i].state = state;
-        workload_arg[i].thread_index = i;
-        testutil_random_from_random(
-          &state->threads[i].rnd, i < cfg->nth ? &cfg->opts->data_rnd : &cfg->opts->extra_rnd);
+    for (uint32_t i = 0; i < cfg->nth; i++) {
         /*
          * The stable frontier must wait for this phase's workers, not trust the previous phase's.
          */
-        state->threads[i].completed_ts = 0;
-        state->threads[i].busy = false;
-        state->threads[i].evq.head = state->threads[i].evq.tail = 0;
+        state->workers[i].completed_ts = 0;
+        state->workers[i].busy = false;
+        state->workers[i].evq.head = state->workers[i].evq.tail = 0;
     }
 
-    /* Start timestamp thread. */
-    testutil_check(__wt_thread_create(
-      NULL, &workload_thr[cfg->nth + 1], thread_ts_run, &workload_arg[cfg->nth + 1]));
+    /*
+     * Reseed the generator's streams: the worker streams first, then its own pacing stream. Every
+     * phase draws, whether it generates or not, so the streams stay in step across role switches.
+     */
+    for (uint32_t i = 0; i <= cfg->nth; i++)
+        testutil_random_from_random(
+          &state->gen_rnd[i], i < cfg->nth ? &cfg->opts->data_rnd : &cfg->opts->extra_rnd);
 
-    /* Start worker threads. */
-    for (uint32_t i = 0; i < cfg->nth; i++)
-        testutil_check(
-          __wt_thread_create(NULL, &workload_thr[i], thread_worker_run, &workload_arg[i]));
+    testutil_check(__wt_thread_create(NULL, &ts_thr, thread_ts_run, state));
+    node_workers_start(state);
 
     /* Every phase has a source: this node's own generator, or a live peer's relay. */
     node_reader_start(state);
 
     /* Start the generator last, once the machinery consuming its stream is up. */
     if (state->generates)
-        testutil_check(__wt_thread_create(
-          NULL, &workload_thr[cfg->nth], thread_generator_run, &workload_arg[cfg->nth]));
+        node_generator_start(state);
     fflush(stdout);
 }
 
@@ -1006,17 +392,12 @@ workload_start(WORKLOAD_STATE *state, bool as_leader)
 void
 workload_stop(WORKLOAD_STATE *state)
 {
-    if (state->generates) {
-        __wt_atomic_store_bool_release(&state->generator_stop, true);
-        testutil_check(__wt_thread_join(NULL, &workload_thr[state->nth_workers]));
-    }
-
+    node_generator_stop(state);
     node_reader_stop(state);
 
     __wt_atomic_store_bool_release(&state->stop_phase, true);
-    for (uint32_t i = 0; i < state->nth_workers + 2; ++i)
-        if (i != state->nth_workers)
-            testutil_check(__wt_thread_join(NULL, &workload_thr[i]));
+    node_workers_join(state);
+    testutil_check(__wt_thread_join(NULL, &ts_thr));
 }
 
 /*

--- a/test/csuite/schema_disagg_abort/node.c
+++ b/test/csuite/schema_disagg_abort/node.c
@@ -10,10 +10,10 @@
  * The generic node: everything a database node does regardless of role. This file owns the phase
  * loop, the WiredTiger connection, the event pipes, and the workload engine.
  *
- * One pipeline serves both roles: a generator thread produces the node's command stream (the full
- * workload into the self-pipe when leading, only the lone node's switch trigger when following), a
- * reader thread demuxes the source pipe to N worker threads that apply the events, and a timestamp
- * thread advances the frontier. The threads coordinate without locks.
+ * One pipeline serves both roles: a generator thread produces the node's command stream into a
+ * self-pipe (a leader always does, and so does a follower with no peer to receive from), a reader
+ * thread demuxes the source pipe - the self-pipe, or a live peer's - to N worker threads that apply
+ * the events, and a timestamp thread advances the frontier. The threads coordinate without locks.
  *
  * The role specifics live in leader.c and follower.c behind the NODE_ROLE operations.
  */
@@ -35,7 +35,7 @@ typedef struct {
 /* Per-thread worker state for one phase. */
 typedef struct {
     WT_SESSION *session;
-    FILE *record_fp; /* schema records (leading) or relay records (following); opens lazily */
+    FILE *record_fp; /* records for what this node originated, or for what it applied */
 } WORKER_CTX;
 
 /*
@@ -54,8 +54,8 @@ workload_state_create(TEST_CONFIG *cfg)
 
 /*
  * workload_seed_counter --
- *     Seed the monotonic allocator from the previous leader's high-water mark, so a node stepping
- *     up continues the global epoch/timestamp sequence.
+ *     Seed the monotonic allocator from the previous leader's final counter, so a node stepping up
+ *     continues the global epoch/timestamp sequence.
  */
 void
 workload_seed_counter(WORKLOAD_STATE *state, uint64_t ts)
@@ -172,9 +172,10 @@ typedef enum { TRIGGER_STOP, TRIGGER_SWITCH } NODE_TRIGGER;
 /*
  * node_trigger_wait --
  *     The payload wait of a phase, identical in both roles: sleep until something ends the phase.
- *     The stop sentinel ends any phase; the hand-over report ends it with a switch. All switch
- *     triggering lives in the generator, so the trigger arrives here uniformly, whether it came
- *     from the node's own stream, the peer's hand-over, or a lone follower's sentinel poll.
+ *     The stop sentinel ends any phase; a hand-over report ends it with a switch.
+ *
+ * Whoever owns the phase's stream consumes the switch request. A phase left with no stream - a
+ *     follower whose peer died has neither generator nor reader - consumes it here instead.
  */
 static NODE_TRIGGER
 node_trigger_wait(WORKLOAD_STATE *state)
@@ -182,6 +183,11 @@ node_trigger_wait(WORKLOAD_STATE *state)
     while (!node_stop_requested()) {
         if (__wt_atomic_load_bool_acquire(&state->handover_received))
             return (TRIGGER_SWITCH);
+
+        const bool abandoned_follower = !state->generates && !state->cfg->peer_alive;
+        if (abandoned_follower && node_switch_request_consume())
+            return (TRIGGER_SWITCH);
+
         /*
          * Nothing will ever end this phase once the parent is gone: it owns both sentinels. A lone
          * follower would otherwise idle for as long as the machine is up.
@@ -314,19 +320,17 @@ record_event_line(FILE *fp, const SCHEMA_EVENT *ev)
 
 /*
  * worker_record_open --
- *     Open a worker's record file: schema records when leading, relay records when following.
+ *     Open a worker's record file, named for the origin of what it logs: the operations this node
+ *     produced itself go to its leader records, the peer's relayed events to its follower records.
  *     Append so a later phase preserves the earlier records for the post-crash verifier.
  */
 static FILE *
 worker_record_open(const WORKLOAD_STATE *state, uint32_t thread_index)
 {
     char fname[128];
-    if (state->leads)
-        testutil_snprintf(
-          fname, sizeof(fname), SCHEMA_RECORDS_FILE, state->cfg->node_id, thread_index);
-    else
-        testutil_snprintf(
-          fname, sizeof(fname), RELAY_RECORDS_FILE, state->cfg->node_id, thread_index);
+    testutil_snprintf(fname, sizeof(fname),
+      state->generates ? LEADER_RECORDS_FILE : FOLLOWER_RECORDS_FILE, state->cfg->node_id,
+      thread_index);
 
     FILE *fp;
     testutil_assert_errno((fp = fopen(fname, "a")) != NULL);
@@ -422,6 +426,7 @@ static void
 worker_complete(WORKLOAD_STATE *state, uint32_t thread_index, uint64_t value)
 {
     counter_advance(state, value);
+    (void)__wt_atomic_add_uint64(&state->applied, 1);
     __wt_atomic_store_uint64_release(&state->threads[thread_index].completed_ts, value);
 }
 
@@ -600,6 +605,7 @@ generator_emit(WORKLOAD_STATE *state, const SCHEMA_EVENT *ev)
         if (errno != EINTR)
             testutil_die(errno, "write self pipe");
     testutil_assert(nw == (ssize_t)sizeof(*ev));
+    ++state->emitted;
 }
 
 /*
@@ -653,12 +659,15 @@ generator_op(WORKLOAD_STATE *state, uint32_t t)
 /*
  * generator_round --
  *     Feed every worker thread one generated operation, round-robin. Reports whether anything was
- *     emitted: an empty round means every pick was an uncovered drop, and the caller should wait
- *     out the next checkpoint instead of spinning on the slot model.
+ *     emitted: nothing is while the lead over the workers is spent, or when every pick was an
+ *     uncovered drop, and the caller waits instead of spinning on the slot model.
  */
 static bool
-generator_round(WORKLOAD_STATE *state)
+generator_round(WORKLOAD_STATE *state, uint64_t lead_max)
 {
+    if (state->emitted - __wt_atomic_load_uint64_acquire(&state->applied) > lead_max)
+        return (false);
+
     bool emitted = false;
 
     for (uint32_t t = 0; t < state->nth_workers && generator_running(state); t++)
@@ -667,12 +676,16 @@ generator_round(WORKLOAD_STATE *state)
     return (emitted);
 }
 
-/* A leading generator's pacing state: the checkpoint cadence and the sentinel poll throttle. */
+/*
+ * A leading generator's pacing state: the checkpoint cadence, the sentinel poll throttle, and the
+ * lead it may build over its workers.
+ */
 typedef struct {
     WT_RAND_STATE *rnd; /* the generator's own rnd stream, used for the checkpoint intervals */
     struct timespec last_ckpt;
     struct timespec last_poll;
     uint64_t ckpt_wait; /* seconds until the next checkpoint event is due */
+    uint64_t lead_max;  /* events that may be in flight; UINT64_MAX when nothing bounds it */
 } GENERATOR_PACING;
 
 /*
@@ -680,12 +693,16 @@ typedef struct {
  *     Initialize the pacing state at the start of a leading phase.
  */
 static void
-generator_pacing_init(GENERATOR_PACING *pacing, WT_RAND_STATE *rnd)
+generator_pacing_init(GENERATOR_PACING *pacing, const TEST_CONFIG *cfg, WT_RAND_STATE *rnd)
 {
     pacing->rnd = rnd;
     __wt_epoch(NULL, &pacing->last_ckpt);
     pacing->last_poll = pacing->last_ckpt;
     pacing->ckpt_wait = __wt_random(rnd) % MAX_CKPT_INVL;
+    /* Bound the lead so a hand-over drains inside one switch period; no switches, no bound. */
+    pacing->lead_max = cfg->switch_interval == 0 ?
+      UINT64_MAX :
+      WT_MAX(cfg->switch_interval * GEN_APPLY_RATE_FLOOR, GEN_LEAD_MIN);
 }
 
 /*
@@ -722,19 +739,24 @@ generator_switch_requested(GENERATOR_PACING *pacing)
 }
 
 /*
- * generator_lead --
- *     A leading generator's phase: produce the term's event stream into the self-pipe - workload
- *     rounds, a checkpoint event whenever one is due, and, once the parent requests a switch, the
- *     hand-over event that ends the stream and the phase.
+ * thread_generator_run --
+ *     The node's command source, started only for a phase that produces its own stream: a leader
+ *     always does, and so does a follower with no peer to receive from. Feeds workload rounds into
+ *     the self-pipe, a checkpoint event whenever one is due, and, once the parent requests a
+ *     switch, the hand-over event that ends the stream and the phase. All switch triggering lives
+ *     here, never in the control loop.
  */
-static void
-generator_lead(WORKLOAD_STATE *state, WT_RAND_STATE *rnd)
+static WT_THREAD_RET
+thread_generator_run(void *arg)
 {
+    const THREAD_ARG *ta = arg;
+    WORKLOAD_STATE *state = ta->state;
+
     GENERATOR_PACING pacing;
-    generator_pacing_init(&pacing, rnd);
+    generator_pacing_init(&pacing, state->cfg, &state->threads[ta->thread_index].rnd);
 
     while (generator_running(state)) {
-        if (!generator_round(state))
+        if (!generator_round(state, pacing.lead_max))
             __wt_sleep(0, WT_THOUSAND);
 
         if (generator_ckpt_due(&pacing)) {
@@ -749,46 +771,9 @@ generator_lead(WORKLOAD_STATE *state, WT_RAND_STATE *rnd)
             ev.type = EVENT_SWITCH;
             ev.event_ts = __wt_atomic_load_uint64_acquire(&state->current_ts);
             generator_emit(state, &ev);
-            return;
+            break;
         }
     }
-}
-
-/*
- * generator_follow --
- *     A following generator's phase: watch for the parent's switch request on a lone node's behalf
- *     and report the hand-over directly, since a lone follower has no reader or in-flight stream to
- *     order against. A peered follower must not act: its hand-over arrives through the peer's
- *     stream.
- */
-static void
-generator_follow(WORKLOAD_STATE *state)
-{
-    while (generator_running(state)) {
-        if (!state->cfg->peer_alive && node_switch_request_consume()) {
-            __wt_atomic_store_bool_release(&state->handover_received, true);
-            return;
-        }
-        __wt_sleep(1, 0);
-    }
-}
-
-/*
- * thread_generator_run --
- *     The node's command source, one per phase in either role: the whole event stream when leading,
- *     only the lone node's switch trigger when following. Either way, all switch triggering lives
- *     in the generated stream or here, never in the control loop.
- */
-static WT_THREAD_RET
-thread_generator_run(void *arg)
-{
-    const THREAD_ARG *ta = arg;
-    WORKLOAD_STATE *state = ta->state;
-
-    if (state->leads)
-        generator_lead(state, &state->threads[ta->thread_index].rnd);
-    else
-        generator_follow(state);
     return (WT_THREAD_RET_VALUE);
 }
 
@@ -854,18 +839,18 @@ node_current_role(const WORKLOAD_STATE *state)
 
 /*
  * thread_reader_run --
- *     Drain the node's event source: the self-pipe when leading, the peer's pipe when following.
- *     Schema and data events are queued for the worker threads; a checkpoint event is produced
- *     (leading) or picked up after a drain barrier (following); the hand-over event ends the phase.
- *     Pipe EOF can only happen on a peer-fed pipe: it marks the peer dead and turns this node into
- *     a lone follower.
+ *     Drain the node's event source: the self-pipe when this phase generates, the peer's pipe
+ *     otherwise. Schema and data events are queued for the worker threads; a checkpoint event is
+ *     produced (leading) or picked up after a drain barrier (following); the hand-over event ends
+ *     the phase. Pipe EOF can only happen on a peer-fed pipe: it marks the peer dead and turns this
+ *     node into a lone follower.
  */
 static WT_THREAD_RET
 thread_reader_run(void *arg)
 {
     WORKLOAD_STATE *state = arg;
     TEST_CONFIG *cfg = state->cfg;
-    const int src_fd = state->leads ? cfg->self_pipe_read_fd : cfg->pipe_read_fd;
+    const int src_fd = state->generates ? cfg->self_pipe_read_fd : cfg->pipe_read_fd;
 
     WT_SESSION *session;
     testutil_check(state->conn->open_session(state->conn, NULL, NULL, &session));
@@ -903,12 +888,12 @@ thread_reader_run(void *arg)
             /* The final event of the term's stream: this node must step up. */
             workload_drain_barrier(state);
             /*
-             * Relay-integrity check: the drained counter must equal the sender's high-water mark.
+             * Relay-integrity check: the drained counter must equal the sender's final counter.
              * Every counter value the term allocated rides an event that precedes the switch in the
              * stream, so after the drain nothing may be missing.
              */
             testutil_assertfmt(__wt_atomic_load_uint64_acquire(&state->current_ts) == ev.event_ts,
-              "hand-over: drained counter %" PRIu64 " != sender high-water %" PRIu64,
+              "hand-over: drained counter %" PRIu64 " != sender's final counter %" PRIu64,
               __wt_atomic_load_uint64_acquire(&state->current_ts), ev.event_ts);
             __wt_atomic_store_bool_release(&state->handover_received, true);
             running = false;
@@ -969,12 +954,15 @@ workload_start(WORKLOAD_STATE *state, bool as_leader)
 
     state->nth_workers = cfg->nth;
     state->leads = as_leader;
+    /* A leader feeds itself; so does a follower with no peer. Snapshot it: peer_alive can flip. */
+    state->generates = as_leader || !cfg->peer_alive;
     state->stop_phase = false;
     state->reader_stop = false;
     state->generator_stop = false;
     state->handover_received = false;
     /* Start gated: the timestamp thread republishes the connection's durable epoch immediately. */
     state->ckpt_covered_ts = 0;
+    state->emitted = state->applied = 0;
 
     for (uint32_t i = 0; i < cfg->nth + 2; i++) {
         workload_arg[i].state = state;
@@ -998,28 +986,30 @@ workload_start(WORKLOAD_STATE *state, bool as_leader)
         testutil_check(
           __wt_thread_create(NULL, &workload_thr[i], thread_worker_run, &workload_arg[i]));
 
-    /* The queue source's producer: the reader drains the self-pipe or a live peer's pipe. */
-    if (as_leader || cfg->peer_alive)
-        node_reader_start(state);
+    /* Every phase has a source: this node's own generator, or a live peer's relay. */
+    node_reader_start(state);
 
     /* Start the generator last, once the machinery consuming its stream is up. */
-    testutil_check(__wt_thread_create(
-      NULL, &workload_thr[cfg->nth], thread_generator_run, &workload_arg[cfg->nth]));
+    if (state->generates)
+        testutil_check(__wt_thread_create(
+          NULL, &workload_thr[cfg->nth], thread_generator_run, &workload_arg[cfg->nth]));
     fflush(stdout);
 }
 
 /*
  * workload_stop --
- *     Quiesce and join all of the phase's threads, in dependency order. The generator goes first,
- *     while the reader still drains the self-pipe the generator may be blocked on; the reader next,
- *     while the workers are still consuming; then the workers drain what the reader delivered
- *     before exiting.
+ *     Quiesce and join all of the phase's threads, in dependency order. The generator goes first if
+ *     the phase had one, while the reader still drains the self-pipe it may be blocked on; the
+ *     reader next, while the workers are still consuming; then the workers drain what the reader
+ *     delivered before exiting.
  */
 void
 workload_stop(WORKLOAD_STATE *state)
 {
-    __wt_atomic_store_bool_release(&state->generator_stop, true);
-    testutil_check(__wt_thread_join(NULL, &workload_thr[state->nth_workers]));
+    if (state->generates) {
+        __wt_atomic_store_bool_release(&state->generator_stop, true);
+        testutil_check(__wt_thread_join(NULL, &workload_thr[state->nth_workers]));
+    }
 
     node_reader_stop(state);
 
@@ -1058,15 +1048,15 @@ node_run(TEST_CONFIG *cfg, WORKLOAD_STATE *state, const NODE_ROLE *role)
 
         if (trigger == TRIGGER_SWITCH) {
             /*
-             * The ending term's counter high-water mark. The workload is quiesced and drained, so
-             * the node's own counter holds every value the term allocated or adopted - on a peered
-             * hand-over the reader asserted it equals the sender's high-water mark.
+             * The counter the ending term finished on. The workload is quiesced and drained, so the
+             * node's own counter holds every value the term allocated or adopted - on a peered
+             * hand-over the reader asserted it equals the sender's final counter.
              */
-            const uint64_t counter_hwm = state->current_ts;
+            const uint64_t final_counter = state->current_ts;
 
-            role->leave(state, counter_hwm);
+            role->leave(state, final_counter);
             role = node_switch_role(role);
-            role->enter(state, counter_hwm);
+            role->enter(state, final_counter);
             println("Node %" PRIu32 ": now %s", cfg->node_id, role->name);
             /* The swap-completing transition: entering leadership, or a lone node's only one. */
             node_transition_done(cfg, state, role->leads || !cfg->peer_alive);

--- a/test/csuite/schema_disagg_abort/node.c
+++ b/test/csuite/schema_disagg_abort/node.c
@@ -1,0 +1,1120 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+/*
+ * The generic node: everything a database node does regardless of role. This file owns the phase
+ * loop, the WiredTiger connection, the event pipes, and the workload engine.
+ *
+ * One pipeline serves both roles: a generator thread produces the node's command stream (the full
+ * workload into the self-pipe when leading, only the lone node's switch trigger when following), a
+ * reader thread demuxes the source pipe to N worker threads that apply the events, and a timestamp
+ * thread advances the frontier. The threads coordinate without locks.
+ *
+ * The role specifics live in leader.c and follower.c behind the NODE_ROLE operations.
+ */
+
+#include "schema_disagg_abort.h"
+
+#include <signal.h>
+#include <sys/select.h>
+
+/* The table configuration every schema table is created with, on either role. */
+#define SCHEMA_TABLE_CONFIG "key_format=S,value_format=S,type=layered,block_manager=disagg"
+
+/* Thread argument: the shared workload state plus this thread's identity. */
+typedef struct {
+    WORKLOAD_STATE *state;
+    uint32_t thread_index;
+} THREAD_ARG;
+
+/* Per-thread worker state for one phase. */
+typedef struct {
+    WT_SESSION *session;
+    FILE *record_fp; /* schema records (leading) or relay records (following); opens lazily */
+} WORKER_CTX;
+
+/*
+ * workload_state_create --
+ *     Return the node's workload state, zeroed and bound to the configuration. The state has
+ *     process lifetime; the control loop and the role transitions keep its connection current.
+ */
+WORKLOAD_STATE *
+workload_state_create(TEST_CONFIG *cfg)
+{
+    static WORKLOAD_STATE state;
+    WT_CLEAR(state);
+    state.cfg = cfg;
+    return (&state);
+}
+
+/*
+ * workload_seed_counter --
+ *     Seed the monotonic allocator from the previous leader's high-water mark, so a node stepping
+ *     up continues the global epoch/timestamp sequence.
+ */
+void
+workload_seed_counter(WORKLOAD_STATE *state, uint64_t ts)
+{
+    testutil_assert(state->current_ts <= ts);
+    state->current_ts = ts;
+}
+
+/*
+ * counter_advance --
+ *     Advance the monotonic allocator to at least the given applied value, so a follower's counter
+ *     tracks everything it applied.
+ */
+static void
+counter_advance(WORKLOAD_STATE *state, uint64_t v)
+{
+    uint64_t cur;
+    do {
+        cur = __wt_atomic_load_uint64_acquire(&state->current_ts);
+    } while (cur < v && !__wt_atomic_cas_uint64(&state->current_ts, cur, v));
+}
+
+/*
+ * workload_running --
+ *     The condition every phase loop runs on: true until the phase is directed to quiesce.
+ */
+static bool
+workload_running(WORKLOAD_STATE *state)
+{
+    return (!__wt_atomic_load_bool_acquire(&state->stop_phase));
+}
+
+/*
+ * disagg_opts_init --
+ *     Point the test options at the shared PALite page log: the single source of truth for the
+ *     disaggregated configuration, used by the nodes and by the parent's recovery opens.
+ */
+void
+disagg_opts_init(const TEST_CONFIG *cfg)
+{
+    cfg->opts->disagg.is_enabled = true;
+    cfg->opts->disagg.page_log = "palite";
+    cfg->opts->disagg.page_log_home = cfg->page_log_home;
+    cfg->opts->disagg.drain_threads = 1;
+}
+
+/*
+ * node_open --
+ *     Open this node's WiredTiger connection in the given disaggregated mode.
+ */
+void
+node_open(TEST_CONFIG *cfg, const char *disagg_mode, WT_CONNECTION **connp)
+{
+    char node_home[32];
+    testutil_snprintf(node_home, sizeof(node_home), NODE_HOME_FMT, cfg->node_id);
+
+    cfg->opts->disagg.mode = disagg_mode;
+    testutil_wiredtiger_open(cfg->opts, node_home, ENV_CONFIG_DEF, NULL, connp, false, false);
+}
+
+/*
+ * node_event_send --
+ *     Relay one event to the peer over the node's out-pipe. Single write() calls of
+ *     sizeof(SCHEMA_EVENT) are atomic, so concurrent threads need no extra locking. Returns false
+ *     without failing when there is no peer (no pipe, or the peer is gone), leaving the caller to
+ *     decide whether delivery is optional (the workload relay) or mandatory (the hand-over).
+ */
+bool
+node_event_send(TEST_CONFIG *cfg, const SCHEMA_EVENT *ev)
+{
+    if (cfg->pipe_write_fd < 0)
+        return (false);
+
+    const ssize_t nw = write(cfg->pipe_write_fd, ev, sizeof(*ev));
+    if (nw < 0) {
+        if (errno != EPIPE && errno != EBADF)
+            testutil_die(errno, "write event pipe");
+        close(cfg->pipe_write_fd);
+        cfg->pipe_write_fd = -1;
+        cfg->peer_alive = false;
+        return (false);
+    }
+    testutil_assert(nw == (ssize_t)sizeof(*ev));
+    return (true);
+}
+
+/*
+ * node_stop_requested --
+ *     Check for the parent's graceful-stop sentinel. Not consumed: every node must see it.
+ */
+static bool
+node_stop_requested(void)
+{
+    return (testutil_exists(NULL, STOP_FILE));
+}
+
+/*
+ * node_switch_request_consume --
+ *     Check for the parent's switch-request sentinel and consume it, so one request triggers
+ *     exactly one switch. Only the acting node (the leader, or a lone node) may call this.
+ */
+static bool
+node_switch_request_consume(void)
+{
+    if (!testutil_exists(NULL, SWITCH_REQUEST_FILE))
+        return (false);
+    testutil_assert_errno(remove(SWITCH_REQUEST_FILE) == 0);
+    return (true);
+}
+
+/* What ends a phase of either role. */
+typedef enum { TRIGGER_STOP, TRIGGER_SWITCH } NODE_TRIGGER;
+
+/*
+ * node_trigger_wait --
+ *     The payload wait of a phase, identical in both roles: sleep until something ends the phase.
+ *     The stop sentinel ends any phase; the hand-over report ends it with a switch. All switch
+ *     triggering lives in the generator, so the trigger arrives here uniformly, whether it came
+ *     from the node's own stream, the peer's hand-over, or a lone follower's sentinel poll.
+ */
+static NODE_TRIGGER
+node_trigger_wait(WORKLOAD_STATE *state)
+{
+    while (!node_stop_requested()) {
+        if (__wt_atomic_load_bool_acquire(&state->handover_received))
+            return (TRIGGER_SWITCH);
+        /*
+         * Nothing will ever end this phase once the parent is gone: it owns both sentinels. A lone
+         * follower would otherwise idle for as long as the machine is up.
+         */
+        if (getppid() == 1)
+            testutil_die(ECHILD, "Node %" PRIu32 ": parent exited", state->cfg->node_id);
+        __wt_sleep(1, 0);
+    }
+    return (TRIGGER_STOP);
+}
+
+/*
+ * node_transition_done --
+ *     Account for a completed role transition; the transition that completes the swap reports it to
+ *     the parent through the numbered sentinel.
+ */
+static void
+node_transition_done(const TEST_CONFIG *cfg, WORKLOAD_STATE *state, bool completes_swap)
+{
+    ++state->switch_gen;
+    if (!completes_swap)
+        return;
+
+    char name[64];
+    testutil_snprintf(name, sizeof(name), SWITCH_DONE_FMT, state->switch_gen);
+    testutil_sentinel(NULL, name);
+    println("Node %" PRIu32 ": switch %" PRIu32 " complete", cfg->node_id, state->switch_gen);
+}
+
+/*
+ * evq_push --
+ *     Try to append one event to a worker's ring; false when full.
+ */
+static bool
+evq_push(EVENT_QUEUE *q, const SCHEMA_EVENT *ev)
+{
+    const uint64_t tail = q->tail; /* single producer */
+    if (tail - __wt_atomic_load_uint64_acquire(&q->head) >= EVQ_SIZE)
+        return (false);
+    q->ev[tail % EVQ_SIZE] = *ev;
+    __wt_atomic_store_uint64_release(&q->tail, tail + 1);
+    return (true);
+}
+
+/*
+ * evq_pop --
+ *     Try to take one event off a worker's ring; false when empty.
+ */
+static bool
+evq_pop(EVENT_QUEUE *q, SCHEMA_EVENT *ev)
+{
+    const uint64_t head = q->head; /* single consumer */
+    if (head == __wt_atomic_load_uint64_acquire(&q->tail))
+        return (false);
+    *ev = q->ev[head % EVQ_SIZE];
+    __wt_atomic_store_uint64_release(&q->head, head + 1);
+    return (true);
+}
+
+/*
+ * evq_empty --
+ *     Report whether a worker's ring is empty.
+ */
+static bool
+evq_empty(EVENT_QUEUE *q)
+{
+    return (__wt_atomic_load_uint64_acquire(&q->head) == __wt_atomic_load_uint64_acquire(&q->tail));
+}
+
+/*
+ * workload_enqueue --
+ *     Queue one received schema event for its worker thread, blocking while the ring is full: the
+ *     stalled reader stops draining the pipe, which backpressures the leader. Gives up when the
+ *     phase is stopping.
+ */
+void
+workload_enqueue(WORKLOAD_STATE *state, const SCHEMA_EVENT *ev)
+{
+    testutil_assert(ev->thread_id < state->nth_workers);
+
+    EVENT_QUEUE *q = &state->threads[ev->thread_id].evq;
+    while (!evq_push(q, ev) && workload_running(state))
+        __wt_sleep(0, WT_THOUSAND);
+}
+
+/*
+ * workload_drain_barrier --
+ *     Wait until every worker has applied everything queued so far. The follower's reader runs this
+ *     before a checkpoint pickup and before a hand-over: everything at or below the checkpoint's
+ *     stable frontier must be applied locally before its metadata is adopted, so later publishes
+ *     and commits stay above the adopted stable values.
+ */
+void
+workload_drain_barrier(WORKLOAD_STATE *state)
+{
+    for (uint32_t t = 0; t < state->nth_workers; t++)
+        while ((!evq_empty(&state->threads[t].evq) ||
+                 __wt_atomic_load_bool_acquire(&state->threads[t].busy)) &&
+          workload_running(state))
+            __wt_sleep(0, WT_THOUSAND);
+}
+
+/*
+ * record_event_line --
+ *     Append one event to a record file; the one place that defines the record format for both the
+ *     schema and the relay files.
+ */
+static void
+record_event_line(FILE *fp, const SCHEMA_EVENT *ev)
+{
+    int ret = 0;
+
+    switch (ev->type) {
+    case EVENT_CREATE:
+    case EVENT_DROP:
+        ret = fprintf(fp, "%s %" PRIu64 " %s\n", ev->type == EVENT_CREATE ? "CREATE" : "DROP",
+          ev->event_ts, ev->uri);
+        break;
+    case EVENT_INSERT:
+        ret = fprintf(fp, "INSERT %" PRIu64 " %" PRIu32 " %" PRIu32 " %s\n", ev->event_ts,
+          ev->key_min, ev->key_max, ev->uri);
+        break;
+    case EVENT_CKPT:
+    case EVENT_SWITCH:
+        testutil_assertfmt(false, "Unexpected record event type: %d", ev->type);
+    }
+    if (ret < 0)
+        testutil_die(EIO, "fprintf event record");
+}
+
+/*
+ * worker_record_open --
+ *     Open a worker's record file: schema records when leading, relay records when following.
+ *     Append so a later phase preserves the earlier records for the post-crash verifier.
+ */
+static FILE *
+worker_record_open(const WORKLOAD_STATE *state, uint32_t thread_index)
+{
+    char fname[128];
+    if (state->leads)
+        testutil_snprintf(
+          fname, sizeof(fname), SCHEMA_RECORDS_FILE, state->cfg->node_id, thread_index);
+    else
+        testutil_snprintf(
+          fname, sizeof(fname), RELAY_RECORDS_FILE, state->cfg->node_id, thread_index);
+
+    FILE *fp;
+    testutil_assert_errno((fp = fopen(fname, "a")) != NULL);
+    /* Flush the record file per line so entries survive a SIGKILL crash. */
+    __wt_stream_set_line_buffer(fp);
+    return (fp);
+}
+
+/*
+ * schema_op_execute --
+ *     Execute one schema operation: the single call site for creating and dropping the test's
+ *     tables, on either role. EBUSY is retried (the stream cannot be reordered, and when the source
+ *     is the peer the operation already succeeded there), with a bound so a wedged operation fails
+ *     the test instead of hanging it.
+ */
+static void
+schema_op_execute(WT_SESSION *session, const SCHEMA_EVENT *ev)
+{
+    const bool is_create = ev->type == EVENT_CREATE;
+    testutil_assert(ev->type == EVENT_CREATE || ev->type == EVENT_DROP);
+
+    struct timespec start;
+    __wt_epoch(NULL, &start);
+
+    int ret;
+    for (;;) {
+        ret = is_create ? session->create(session, ev->uri, SCHEMA_TABLE_CONFIG) :
+                          session->drop(session, ev->uri, "force=false,lock_wait=false");
+        if (ret != EBUSY)
+            break;
+
+        struct timespec now;
+        __wt_epoch(NULL, &now);
+        if (WT_TIMEDIFF_SEC(now, start) > MAX_STARTUP)
+            testutil_die(ETIMEDOUT, "%s %s: EBUSY for %d seconds", is_create ? "CREATE" : "DROP",
+              ev->uri, MAX_STARTUP);
+        __wt_yield();
+    }
+    testutil_assertfmt(ret == 0, "%s %s (ts %" PRIu64 "): %s", is_create ? "CREATE" : "DROP",
+      ev->uri, ev->event_ts, wiredtiger_strerror(ret));
+}
+
+/*
+ * schema_op_publish --
+ *     Publish the schema operation at the given epoch so it becomes visible in shared metadata at
+ *     the next checkpoint. Runs on both roles: a follower's applied operations queue up and drain
+ *     when it eventually leads.
+ */
+static void
+schema_op_publish(WT_SESSION *session, const char *uri, uint64_t epoch)
+{
+    char pub_cfg[64];
+    testutil_snprintf(pub_cfg, sizeof(pub_cfg), "disaggregated=(schema_epoch=%" PRIx64 ")", epoch);
+    testutil_check(session->publish(session, uri, pub_cfg));
+}
+
+/*
+ * schema_op_insert_data --
+ *     Populate a table with rows keyed key_min..key_max at the given commit timestamp; each row is
+ *     valued with the commit timestamp, so the verifier can tell which generation of a reused table
+ *     name wrote the data.
+ */
+static void
+schema_op_insert_data(
+  WT_SESSION *session, const char *uri, uint64_t commit_ts, uint32_t key_min, uint32_t key_max)
+{
+    char val_buf[32];
+    testutil_snprintf(val_buf, sizeof(val_buf), "%" PRIu64, commit_ts);
+    testutil_check(session->begin_transaction(session, NULL));
+
+    WT_CURSOR *cursor;
+    testutil_check(session->open_cursor(session, uri, NULL, NULL, &cursor));
+    for (uint32_t r = key_min; r <= key_max; r++) {
+        char key_buf[16];
+        testutil_snprintf(key_buf, sizeof(key_buf), "%" PRIu32, r);
+        cursor->set_key(cursor, key_buf);
+        cursor->set_value(cursor, val_buf);
+        testutil_check(cursor->insert(cursor));
+    }
+    testutil_check(cursor->close(cursor));
+
+    char commit_cfg[64];
+    testutil_snprintf(commit_cfg, sizeof(commit_cfg), "commit_timestamp=%" PRIx64, commit_ts);
+    testutil_check(session->commit_transaction(session, commit_cfg));
+}
+
+/*
+ * worker_complete --
+ *     Mark one allocator value fully completed by a worker: track it in the counter (a no-op for
+ *     freshly allocated values) and publish it as the thread's completed frontier mark.
+ */
+static void
+worker_complete(WORKLOAD_STATE *state, uint32_t thread_index, uint64_t value)
+{
+    counter_advance(state, value);
+    __wt_atomic_store_uint64_release(&state->threads[thread_index].completed_ts, value);
+}
+
+/*
+ * apply_event --
+ *     Apply one event on this node, identically for both roles and exactly as the source stream
+ *     fixed it - same operation, same epoch, same commit timestamp: execute the schema operation or
+ *     the insert, record the event, publish a schema operation, relay it to the peer when leading,
+ *     and mark it completed.
+ *
+ * The ordering is load-bearing. A schema operation is recorded before it is published, so the
+ *     record reaches the file before a checkpoint can make the epoch durable (a record without a
+ *     durable epoch is ignored by the verifier, the reverse would be a hole). The relay precedes
+ *     the completion store, which is what lets the stable frontier advance past this operation,
+ *     what lets a checkpoint cover it, and what lets the checkpoint thread send that checkpoint's
+ *     pipe event: the peer holds every event at or below a checkpoint's stable frontier by the time
+ *     it sees that checkpoint's event.
+ */
+static void
+apply_event(WORKLOAD_STATE *state, WORKER_CTX *ctx, uint32_t thread_index, const SCHEMA_EVENT *ev)
+{
+    const bool relay = state->leads;
+
+    if (ctx->record_fp == NULL)
+        ctx->record_fp = worker_record_open(state, thread_index);
+
+    switch (ev->type) {
+    case EVENT_INSERT:
+        schema_op_insert_data(ctx->session, ev->uri, ev->event_ts, ev->key_min, ev->key_max);
+        record_event_line(ctx->record_fp, ev);
+        if (relay)
+            (void)node_event_send(state->cfg, ev);
+        worker_complete(state, thread_index, ev->event_ts);
+        break;
+    case EVENT_CREATE:
+    case EVENT_DROP:
+        schema_op_execute(ctx->session, ev);
+        record_event_line(ctx->record_fp, ev);
+        schema_op_publish(ctx->session, ev->uri, ev->event_ts);
+        if (relay)
+            (void)node_event_send(state->cfg, ev);
+        worker_complete(state, thread_index, ev->event_ts);
+        break;
+    case EVENT_CKPT:
+    case EVENT_SWITCH:
+        testutil_assertfmt(false, "Unexpected apply event type: %d", ev->type);
+    }
+}
+
+/*
+ * worker_apply_loop --
+ *     A worker's phase, identical in both roles: execute whatever the reader queued while the phase
+ *     runs, then drain the queue so a graceful stop loses nothing.
+ */
+static void
+worker_apply_loop(WORKLOAD_STATE *state, WORKER_CTX *ctx, uint32_t thread_index)
+{
+    EVENT_QUEUE *q = &state->threads[thread_index].evq;
+    bool *busyp = &state->threads[thread_index].busy;
+
+    while (workload_running(state) || !evq_empty(q)) {
+        /* Publish busy before checking the queue so the drain barrier never races an apply. */
+        __wt_atomic_store_bool_release(busyp, true);
+        SCHEMA_EVENT ev;
+        const bool popped = evq_pop(q, &ev);
+        if (popped)
+            apply_event(state, ctx, thread_index, &ev);
+        __wt_atomic_store_bool_release(busyp, false);
+        if (!popped)
+            __wt_sleep(0, WT_THOUSAND);
+    }
+}
+
+/*
+ * thread_worker_run --
+ *     One worker thread: set up the per-phase context, run the processing loop, tear the context
+ *     down.
+ */
+static WT_THREAD_RET
+thread_worker_run(void *arg)
+{
+    const THREAD_ARG *ta = arg;
+    WORKLOAD_STATE *state = ta->state;
+
+    WORKER_CTX ctx;
+    WT_CLEAR(ctx);
+    testutil_check(state->conn->open_session(state->conn, NULL, NULL, &ctx.session));
+
+    worker_apply_loop(state, &ctx, ta->thread_index);
+
+    if (ctx.record_fp != NULL)
+        testutil_check(fclose(ctx.record_fp));
+    testutil_check(ctx.session->close(ctx.session, NULL));
+    return (WT_THREAD_RET_VALUE);
+}
+
+/*
+ * workers_min --
+ *     Return the minimum completed value across all worker threads: the frontier with no unfinished
+ *     publish or commit at or below it. Returns 0 if any worker has not yet completed an operation
+ *     this phase.
+ */
+static uint64_t
+workers_min(WORKLOAD_STATE *state)
+{
+    uint64_t min_val = UINT64_MAX;
+    for (uint32_t i = 0; i < state->nth_workers; i++) {
+        const uint64_t val = __wt_atomic_load_uint64_acquire(&state->threads[i].completed_ts);
+        if (val == 0)
+            return (0);
+        if (val < min_val)
+            min_val = val;
+    }
+    return (min_val);
+}
+
+/*
+ * thread_ts_run --
+ *     Advances the oldest and stable timestamps and the stable schema epoch to the workers'
+ *     completed frontier, keeping stable data on published tables only. Runs in both roles; on a
+ *     follower, checkpoint pickups may adopt stable values ahead of the local frontier, so the
+ *     thread never moves the stable timestamp backwards.
+ *
+ * It also republishes the connection's durable schema epoch, the gate the generator drops dirty
+ *     tables behind. Taking it from the connection rather than from the checkpoint call site keeps
+ *     one owner for the value and keeps it right across role transitions: a follower's pickups
+ *     advance it too.
+ */
+static WT_THREAD_RET
+thread_ts_run(void *arg)
+{
+    const THREAD_ARG *ta = arg;
+    WORKLOAD_STATE *state = ta->state;
+
+    while (workload_running(state)) {
+        /*
+         * The single frontier serves both axes: everything at or below it is published and
+         * committed, and any commit below it lands in a table created (and published) at a lower
+         * value still.
+         */
+        const uint64_t frontier = workers_min(state);
+        if (frontier != 0) {
+            const uint64_t cur_stable = query_ts(state->conn, "stable_timestamp");
+            if (frontier >= cur_stable)
+                set_frontier(state->conn, frontier);
+        }
+
+        const uint64_t durable_epoch = query_ts(state->conn, "last_disaggregated_schema_epoch");
+        __wt_atomic_store_uint64_release(&state->ckpt_covered_ts, durable_epoch);
+
+        __wt_sleep(0, 100 * WT_THOUSAND);
+    }
+    return (WT_THREAD_RET_VALUE);
+}
+
+/*
+ * generator_running --
+ *     The generator's loop condition: true until the engine directs it to exit.
+ */
+static bool
+generator_running(WORKLOAD_STATE *state)
+{
+    return (!__wt_atomic_load_bool_acquire(&state->generator_stop) && workload_running(state));
+}
+
+/*
+ * generator_emit --
+ *     Write one event to the node's self-pipe, blocking while it is full: the workers' consumption
+ *     rate backpressures the generator through the pipe and the queues.
+ */
+static void
+generator_emit(WORKLOAD_STATE *state, const SCHEMA_EVENT *ev)
+{
+    ssize_t nw;
+    while ((nw = write(state->cfg->self_pipe_write_fd, ev, sizeof(*ev))) < 0)
+        if (errno != EINTR)
+            testutil_die(errno, "write self pipe");
+    testutil_assert(nw == (ssize_t)sizeof(*ev));
+}
+
+/*
+ * generator_op --
+ *     Generate one schema operation for the given worker thread: pick a slot, flip it between
+ *     create and drop, allocate the epoch, and give one create in INSERT_ODDS an insert at a fresh
+ *     commit timestamp, which comes from the same allocator as the epoch and so is above the
+ *     table's create epoch by construction. Reports whether an event was emitted.
+ *
+ * Only a slot holding data is gated: a dirty table cannot be dropped until a completed checkpoint
+ *     covers its insert (the drop would wedge in EBUSY), so that pick is simply skipped, the
+ *     generation-time analogue of trying another slot. Clean tables churn ungated. The slot model
+ *     flips at generation time; the worker's bounded EBUSY retry guarantees the executed state
+ *     converges to it.
+ */
+static bool
+generator_op(WORKLOAD_STATE *state, uint32_t t)
+{
+    WT_RAND_STATE *rnd = &state->threads[t].rnd;
+
+    const uint32_t slot = __wt_random(rnd) % state->cfg->pool_size;
+    const bool is_create = !state->table_exists[t][slot];
+    /* A clean table (commit timestamp 0) is droppable at once; a dirty one waits for coverage. */
+    if (!is_create && state->table_commit_ts[t][slot] != 0 &&
+      state->table_commit_ts[t][slot] > __wt_atomic_load_uint64_acquire(&state->ckpt_covered_ts))
+        return (false);
+    state->table_exists[t][slot] = is_create;
+
+    SCHEMA_EVENT ev = {0};
+    ev.type = is_create ? EVENT_CREATE : EVENT_DROP;
+    ev.thread_id = t;
+    ev.event_ts = __wt_atomic_add_uint64(&state->current_ts, 1);
+    testutil_snprintf(ev.uri, sizeof(ev.uri), SCHEMA_TABLE_FMT, state->cfg->node_id, t, slot);
+    generator_emit(state, &ev);
+
+    if (is_create) {
+        /* Most creates leave the table clean, so the churn is not gated on checkpoints. */
+        state->table_commit_ts[t][slot] = 0;
+        if (__wt_random(rnd) % INSERT_ODDS == 0) {
+            ev.type = EVENT_INSERT;
+            ev.event_ts = __wt_atomic_add_uint64(&state->current_ts, 1);
+            ev.key_min = DATA_KEY_MIN;
+            ev.key_max = DATA_KEY_MAX;
+            state->table_commit_ts[t][slot] = ev.event_ts;
+            generator_emit(state, &ev);
+        }
+    }
+    return (true);
+}
+
+/*
+ * generator_round --
+ *     Feed every worker thread one generated operation, round-robin. Reports whether anything was
+ *     emitted: an empty round means every pick was an uncovered drop, and the caller should wait
+ *     out the next checkpoint instead of spinning on the slot model.
+ */
+static bool
+generator_round(WORKLOAD_STATE *state)
+{
+    bool emitted = false;
+
+    for (uint32_t t = 0; t < state->nth_workers && generator_running(state); t++)
+        if (generator_op(state, t))
+            emitted = true;
+    return (emitted);
+}
+
+/* A leading generator's pacing state: the checkpoint cadence and the sentinel poll throttle. */
+typedef struct {
+    WT_RAND_STATE *rnd; /* the generator's own rnd stream, used for the checkpoint intervals */
+    struct timespec last_ckpt;
+    struct timespec last_poll;
+    uint64_t ckpt_wait; /* seconds until the next checkpoint event is due */
+} GENERATOR_PACING;
+
+/*
+ * generator_pacing_init --
+ *     Initialize the pacing state at the start of a leading phase.
+ */
+static void
+generator_pacing_init(GENERATOR_PACING *pacing, WT_RAND_STATE *rnd)
+{
+    pacing->rnd = rnd;
+    __wt_epoch(NULL, &pacing->last_ckpt);
+    pacing->last_poll = pacing->last_ckpt;
+    pacing->ckpt_wait = __wt_random(rnd) % MAX_CKPT_INVL;
+}
+
+/*
+ * generator_ckpt_due --
+ *     Pace the stream's checkpoint events: true when the current random interval has elapsed,
+ *     starting the next one.
+ */
+static bool
+generator_ckpt_due(GENERATOR_PACING *pacing)
+{
+    struct timespec now;
+    __wt_epoch(NULL, &now);
+    if ((uint64_t)WT_TIMEDIFF_SEC(now, pacing->last_ckpt) < pacing->ckpt_wait)
+        return (false);
+    pacing->last_ckpt = now;
+    pacing->ckpt_wait = __wt_random(pacing->rnd) % MAX_CKPT_INVL;
+    return (true);
+}
+
+/*
+ * generator_switch_requested --
+ *     Watch for the parent's switch request, polling the sentinel at most once a second (the
+ *     cadence the control loop's own waits use).
+ */
+static bool
+generator_switch_requested(GENERATOR_PACING *pacing)
+{
+    struct timespec now;
+    __wt_epoch(NULL, &now);
+    if (WT_TIMEDIFF_SEC(now, pacing->last_poll) < 1)
+        return (false);
+    pacing->last_poll = now;
+    return (node_switch_request_consume());
+}
+
+/*
+ * generator_lead --
+ *     A leading generator's phase: produce the term's event stream into the self-pipe - workload
+ *     rounds, a checkpoint event whenever one is due, and, once the parent requests a switch, the
+ *     hand-over event that ends the stream and the phase.
+ */
+static void
+generator_lead(WORKLOAD_STATE *state, WT_RAND_STATE *rnd)
+{
+    GENERATOR_PACING pacing;
+    generator_pacing_init(&pacing, rnd);
+
+    while (generator_running(state)) {
+        if (!generator_round(state))
+            __wt_sleep(0, WT_THOUSAND);
+
+        if (generator_ckpt_due(&pacing)) {
+            SCHEMA_EVENT ev = {0};
+            ev.type = EVENT_CKPT;
+            generator_emit(state, &ev);
+        }
+
+        if (generator_switch_requested(&pacing)) {
+            /* The stream's last event, carrying the counter the next leader continues from. */
+            SCHEMA_EVENT ev = {0};
+            ev.type = EVENT_SWITCH;
+            ev.event_ts = __wt_atomic_load_uint64_acquire(&state->current_ts);
+            generator_emit(state, &ev);
+            return;
+        }
+    }
+}
+
+/*
+ * generator_follow --
+ *     A following generator's phase: watch for the parent's switch request on a lone node's behalf
+ *     and report the hand-over directly, since a lone follower has no reader or in-flight stream to
+ *     order against. A peered follower must not act: its hand-over arrives through the peer's
+ *     stream.
+ */
+static void
+generator_follow(WORKLOAD_STATE *state)
+{
+    while (generator_running(state)) {
+        if (!state->cfg->peer_alive && node_switch_request_consume()) {
+            __wt_atomic_store_bool_release(&state->handover_received, true);
+            return;
+        }
+        __wt_sleep(1, 0);
+    }
+}
+
+/*
+ * thread_generator_run --
+ *     The node's command source, one per phase in either role: the whole event stream when leading,
+ *     only the lone node's switch trigger when following. Either way, all switch triggering lives
+ *     in the generated stream or here, never in the control loop.
+ */
+static WT_THREAD_RET
+thread_generator_run(void *arg)
+{
+    const THREAD_ARG *ta = arg;
+    WORKLOAD_STATE *state = ta->state;
+
+    if (state->leads)
+        generator_lead(state, &state->threads[ta->thread_index].rnd);
+    else
+        generator_follow(state);
+    return (WT_THREAD_RET_VALUE);
+}
+
+/* The reader thread's handle; its context and results live in the workload state. */
+static wt_thread_t reader_thr;
+static bool reader_started = false;
+
+/*
+ * pipe_wait_readable --
+ *     Wait up to a second for the pipe to become readable, so the reader can notice a stop request
+ *     even when the source is silent.
+ */
+static bool
+pipe_wait_readable(int fd)
+{
+    fd_set rfds;
+    FD_ZERO(&rfds);
+    FD_SET(fd, &rfds);
+
+    struct timeval tv = {1, 0};
+    const int ret = select(fd + 1, &rfds, NULL, NULL, &tv);
+    if (ret < 0) {
+        if (errno == EINTR)
+            return (false);
+        testutil_die(errno, "reader select pipe");
+    }
+    return (ret > 0);
+}
+
+/*
+ * pipe_read_event --
+ *     Read one complete event from the pipe. Returns false on EOF (the writer died). The writer's
+ *     death can truncate the final write, so reassemble the event from partial reads.
+ */
+static bool
+pipe_read_event(int fd, SCHEMA_EVENT *ev)
+{
+    size_t have = 0;
+    while (have < sizeof(*ev)) {
+        const ssize_t nr = read(fd, (uint8_t *)ev + have, sizeof(*ev) - have);
+        if (nr < 0) {
+            if (errno == EINTR)
+                continue;
+            testutil_die(errno, "reader read pipe");
+        }
+        if (nr == 0)
+            return (false);
+        have += (size_t)nr;
+    }
+    return (true);
+}
+
+/*
+ * node_current_role --
+ *     Return the role this phase runs. The engine tracks the role as a single bool, so the role
+ *     instance is derived from it rather than stored: one source of truth, no invariant to keep.
+ */
+static const NODE_ROLE *
+node_current_role(const WORKLOAD_STATE *state)
+{
+    return (state->leads ? &node_role_leader : &node_role_follower);
+}
+
+/*
+ * thread_reader_run --
+ *     Drain the node's event source: the self-pipe when leading, the peer's pipe when following.
+ *     Schema and data events are queued for the worker threads; a checkpoint event is produced
+ *     (leading) or picked up after a drain barrier (following); the hand-over event ends the phase.
+ *     Pipe EOF can only happen on a peer-fed pipe: it marks the peer dead and turns this node into
+ *     a lone follower.
+ */
+static WT_THREAD_RET
+thread_reader_run(void *arg)
+{
+    WORKLOAD_STATE *state = arg;
+    TEST_CONFIG *cfg = state->cfg;
+    const int src_fd = state->leads ? cfg->self_pipe_read_fd : cfg->pipe_read_fd;
+
+    WT_SESSION *session;
+    testutil_check(state->conn->open_session(state->conn, NULL, NULL, &session));
+
+    /* The role's checkpoint bookkeeping for this phase; only a follower picks checkpoints up. */
+    CKPT_CTX ckpt = {0};
+    __wt_epoch(NULL, &ckpt.phase_start);
+    if (!state->leads)
+        testutil_check(state->conn->get_page_log(state->conn, "palite", &ckpt.page_log));
+
+    SCHEMA_EVENT ev;
+    bool running = true;
+    while (running && !__wt_atomic_load_bool_acquire(&state->reader_stop)) {
+        if (!pipe_wait_readable(src_fd))
+            continue;
+        if (!pipe_read_event(src_fd, &ev)) {
+            /* EOF: the peer died. Keep the role; the node continues as a lone follower. */
+            testutil_assert(!state->leads); /* The self-pipe's writer lives in this process. */
+            cfg->peer_alive = false;
+            println("Node %" PRIu32 ": peer died; continuing as a lone follower", cfg->node_id);
+            running = false;
+            continue;
+        }
+
+        switch (ev.type) {
+        case EVENT_CREATE:
+        case EVENT_DROP:
+        case EVENT_INSERT:
+            workload_enqueue(state, &ev);
+            break;
+        case EVENT_CKPT:
+            node_current_role(state)->checkpoint(state, session, &ckpt, &ev);
+            break;
+        case EVENT_SWITCH:
+            /* The final event of the term's stream: this node must step up. */
+            workload_drain_barrier(state);
+            /*
+             * Relay-integrity check: the drained counter must equal the sender's high-water mark.
+             * Every counter value the term allocated rides an event that precedes the switch in the
+             * stream, so after the drain nothing may be missing.
+             */
+            testutil_assertfmt(__wt_atomic_load_uint64_acquire(&state->current_ts) == ev.event_ts,
+              "hand-over: drained counter %" PRIu64 " != sender high-water %" PRIu64,
+              __wt_atomic_load_uint64_acquire(&state->current_ts), ev.event_ts);
+            __wt_atomic_store_bool_release(&state->handover_received, true);
+            running = false;
+            break;
+        }
+    }
+
+    if (ckpt.page_log != NULL)
+        testutil_check(ckpt.page_log->terminate(ckpt.page_log, NULL));
+    testutil_check(session->close(session, NULL));
+    return (WT_THREAD_RET_VALUE);
+}
+
+/*
+ * node_reader_start --
+ *     Start the reader thread for a phase with an event source: any leader phase (the self-pipe),
+ *     or a follower phase with a live peer. The per-phase hand-over and stop fields were reset by
+ *     workload_start.
+ */
+static void
+node_reader_start(WORKLOAD_STATE *state)
+{
+    testutil_assert(!reader_started);
+    testutil_check(__wt_thread_create(NULL, &reader_thr, thread_reader_run, state));
+    reader_started = true;
+}
+
+/*
+ * node_reader_stop --
+ *     Stop and join the reader thread, if one is running.
+ */
+static void
+node_reader_stop(WORKLOAD_STATE *state)
+{
+    if (!reader_started)
+        return;
+    __wt_atomic_store_bool_release(&state->reader_stop, true);
+    testutil_check(__wt_thread_join(NULL, &reader_thr));
+    reader_started = false;
+}
+
+/* Thread handles have process lifetime; phases join and restart them but never free them. */
+static wt_thread_t workload_thr[MAX_TH + 2];
+static THREAD_ARG workload_arg[MAX_TH + 2];
+
+/*
+ * workload_start --
+ *     Start one phase's threads, the same set in either role: N event-processing workers, the
+ *     timestamp thread, the reader (when the phase has an event source), and the generator. Only
+ *     the event source differs by role: a leader phase consumes its own generated stream, a
+ *     follower phase consumes the peer's.
+ */
+void
+workload_start(WORKLOAD_STATE *state, bool as_leader)
+{
+    TEST_CONFIG *cfg = state->cfg;
+    testutil_assert(cfg->nth <= MAX_TH);
+
+    state->nth_workers = cfg->nth;
+    state->leads = as_leader;
+    state->stop_phase = false;
+    state->reader_stop = false;
+    state->generator_stop = false;
+    state->handover_received = false;
+    /* Start gated: the timestamp thread republishes the connection's durable epoch immediately. */
+    state->ckpt_covered_ts = 0;
+
+    for (uint32_t i = 0; i < cfg->nth + 2; i++) {
+        workload_arg[i].state = state;
+        workload_arg[i].thread_index = i;
+        testutil_random_from_random(
+          &state->threads[i].rnd, i < cfg->nth ? &cfg->opts->data_rnd : &cfg->opts->extra_rnd);
+        /*
+         * The stable frontier must wait for this phase's workers, not trust the previous phase's.
+         */
+        state->threads[i].completed_ts = 0;
+        state->threads[i].busy = false;
+        state->threads[i].evq.head = state->threads[i].evq.tail = 0;
+    }
+
+    /* Start timestamp thread. */
+    testutil_check(__wt_thread_create(
+      NULL, &workload_thr[cfg->nth + 1], thread_ts_run, &workload_arg[cfg->nth + 1]));
+
+    /* Start worker threads. */
+    for (uint32_t i = 0; i < cfg->nth; i++)
+        testutil_check(
+          __wt_thread_create(NULL, &workload_thr[i], thread_worker_run, &workload_arg[i]));
+
+    /* The queue source's producer: the reader drains the self-pipe or a live peer's pipe. */
+    if (as_leader || cfg->peer_alive)
+        node_reader_start(state);
+
+    /* Start the generator last, once the machinery consuming its stream is up. */
+    testutil_check(__wt_thread_create(
+      NULL, &workload_thr[cfg->nth], thread_generator_run, &workload_arg[cfg->nth]));
+    fflush(stdout);
+}
+
+/*
+ * workload_stop --
+ *     Quiesce and join all of the phase's threads, in dependency order. The generator goes first,
+ *     while the reader still drains the self-pipe the generator may be blocked on; the reader next,
+ *     while the workers are still consuming; then the workers drain what the reader delivered
+ *     before exiting.
+ */
+void
+workload_stop(WORKLOAD_STATE *state)
+{
+    __wt_atomic_store_bool_release(&state->generator_stop, true);
+    testutil_check(__wt_thread_join(NULL, &workload_thr[state->nth_workers]));
+
+    node_reader_stop(state);
+
+    __wt_atomic_store_bool_release(&state->stop_phase, true);
+    for (uint32_t i = 0; i < state->nth_workers + 2; ++i)
+        if (i != state->nth_workers)
+            testutil_check(__wt_thread_join(NULL, &workload_thr[i]));
+}
+
+/*
+ * node_switch_role --
+ *     Return the opposite role instance: follower if the current role is leader, and vice versa.
+ */
+static const NODE_ROLE *
+node_switch_role(const NODE_ROLE *role)
+{
+    return (role->leads ? &node_role_follower : &node_role_leader);
+}
+
+/*
+ * node_run --
+ *     The node's control loop, one state machine for both roles. Each iteration runs one phase:
+ *     start the workload in the current role, wait for the trigger that ends the phase, quiesce,
+ *     then switch roles through the role's leave/enter operations. Returns the process exit status
+ *     once the parent directs a graceful stop; a SIGKILL can end the process at any point instead.
+ */
+static int
+node_run(TEST_CONFIG *cfg, WORKLOAD_STATE *state, const NODE_ROLE *role)
+{
+    NODE_TRIGGER trigger;
+
+    do {
+        workload_start(state, role->leads);
+        trigger = node_trigger_wait(state);
+        workload_stop(state);
+
+        if (trigger == TRIGGER_SWITCH) {
+            /*
+             * The ending term's counter high-water mark. The workload is quiesced and drained, so
+             * the node's own counter holds every value the term allocated or adopted - on a peered
+             * hand-over the reader asserted it equals the sender's high-water mark.
+             */
+            const uint64_t counter_hwm = state->current_ts;
+
+            role->leave(state, counter_hwm);
+            role = node_switch_role(role);
+            role->enter(state, counter_hwm);
+            println("Node %" PRIu32 ": now %s", cfg->node_id, role->name);
+            /* The swap-completing transition: entering leadership, or a lone node's only one. */
+            node_transition_done(cfg, state, role->leads || !cfg->peer_alive);
+        }
+    } while (trigger != TRIGGER_STOP);
+
+    /* The parent directed a graceful stop; the last phase is already quiesced. */
+    testutil_check(state->conn->close(state->conn, role->close_config));
+    println("Node %" PRIu32 ": stopped gracefully as %s", cfg->node_id, role->name);
+    return (EXIT_SUCCESS);
+}
+
+/*
+ * node_main --
+ *     Node role entry point: set the node up in its parent-assigned starting role, hand control to
+ *     the state machine, and report its exit status.
+ */
+int
+node_main(TEST_CONFIG *cfg)
+{
+    /* A dead peer must not kill this node with a pipe signal. */
+    if (cfg->pipe_write_fd >= 0)
+        (void)signal(SIGPIPE, SIG_IGN);
+
+    /* The node's own event source; both ends live for the process, across every role switch. */
+    int self_pipe[2];
+    testutil_assert_errno(pipe(self_pipe) == 0);
+    cfg->self_pipe_read_fd = self_pipe[0];
+    cfg->self_pipe_write_fd = self_pipe[1];
+
+    if (chdir(cfg->home) != 0)
+        testutil_die(errno, "Node %" PRIu32 " chdir: %s", cfg->node_id, cfg->home);
+
+    disagg_opts_init(cfg);
+    cfg->peer_alive = cfg->pipe_read_fd >= 0;
+
+    WORKLOAD_STATE *state = workload_state_create(cfg);
+
+    const NODE_ROLE *role = cfg->start_leader ? &node_role_leader : &node_role_follower;
+    node_open(cfg, role->name, &state->conn);
+    /*
+     * Enter the epoch world before the workload can publish anything, on either role: a follower
+     * publishes the operations it applies too. The allocator starts at the same value, so the first
+     * event's epoch is above the stable one.
+     */
+    workload_seed_counter(state, SCHEMA_EPOCH_BOOTSTRAP);
+    set_frontier(state->conn, SCHEMA_EPOCH_BOOTSTRAP);
+    println("Node %" PRIu32 ": starting as %s", cfg->node_id, role->name);
+
+    return (node_run(cfg, state, role));
+}

--- a/test/csuite/schema_disagg_abort/parent.c
+++ b/test/csuite/schema_disagg_abort/parent.c
@@ -79,16 +79,18 @@ spawn_node(const TEST_CONFIG *cfg, const char *self_path, uint32_t node_id, bool
     static const char *const node_names[SUBPROC_SLOTS] = {"node0", "node1"};
     testutil_assert(node_id < SUBPROC_SLOTS);
 
-    char id_arg[16], nth_arg[16], pool_arg[16], rfd_arg[16], wfd_arg[16], seed_arg[80];
+    char id_arg[16], nth_arg[16], pool_arg[16], rfd_arg[16], switch_arg[16], wfd_arg[16],
+      seed_arg[80];
     testutil_snprintf(id_arg, sizeof(id_arg), "%" PRIu32, node_id);
     testutil_snprintf(nth_arg, sizeof(nth_arg), "%" PRIu32, cfg->nth);
     testutil_snprintf(pool_arg, sizeof(pool_arg), "%" PRIu32, cfg->pool_size);
     testutil_snprintf(rfd_arg, sizeof(rfd_arg), "%d", read_fd);
+    testutil_snprintf(switch_arg, sizeof(switch_arg), "%" PRIu32, cfg->switch_interval);
     testutil_snprintf(wfd_arg, sizeof(wfd_arg), "%d", write_fd);
     testutil_snprintf(seed_arg, sizeof(seed_arg), TESTUTIL_SEED_FORMAT, cfg->opts->data_seed,
       cfg->opts->extra_seed);
 
-    const char *argv[24];
+    const char *argv[28];
     size_t n = 0;
     argv[n++] = self_path;
     argv[n++] = "-r";
@@ -107,6 +109,11 @@ spawn_node(const TEST_CONFIG *cfg, const char *self_path, uint32_t node_id, bool
     argv[n++] = nth_arg;
     argv[n++] = "-u";
     argv[n++] = pool_arg;
+    /* The node bounds how far its generator runs ahead so a hand-over drains inside a period. */
+    if (cfg->switch_interval != 0) {
+        argv[n++] = "-s";
+        argv[n++] = switch_arg;
+    }
     if (read_fd >= 0) {
         argv[n++] = "-R";
         argv[n++] = rfd_arg;
@@ -260,23 +267,28 @@ run_children(TEST_CONFIG *cfg, const char *self_path)
     if (nnodes == 1)
         spawn_node(cfg, self_path, 0, cfg->with_leader, -1, -1, NULL, 0, &children[0]);
     else {
-        /* One pipe per direction; a node writes while leading and reads while following. */
-        int p01[2], p10[2];
-        subproc_pipe(p01);
-        subproc_pipe(p10);
+        /*
+         * One pipe per direction, each named for the node that reads it: a node writes to its
+         * peer's pipe while leading and reads its own while following.
+         */
+        int to_node0[2], to_node1[2];
+        subproc_pipe(to_node0);
+        subproc_pipe(to_node1);
 
-        const int close0[] = {p01[0], p10[1]}; /* node0 keeps p01 write, p10 read */
-        spawn_node(
-          cfg, self_path, 0, true, p10[0], p01[1], close0, WT_ELEMENTS(close0), &children[0]);
-        const int close1[] = {p01[1], p10[0]}; /* node1 keeps p01 read, p10 write */
-        spawn_node(
-          cfg, self_path, 1, false, p01[0], p10[1], close1, WT_ELEMENTS(close1), &children[1]);
+        /* node0 keeps the to_node1 write and the to_node0 read. */
+        const int close0[] = {to_node1[0], to_node0[1]};
+        spawn_node(cfg, self_path, 0, true, to_node0[0], to_node1[1], close0, WT_ELEMENTS(close0),
+          &children[0]);
+        /* node1 keeps the to_node0 write and the to_node1 read. */
+        const int close1[] = {to_node1[1], to_node0[0]};
+        spawn_node(cfg, self_path, 1, false, to_node1[0], to_node0[1], close1, WT_ELEMENTS(close1),
+          &children[1]);
 
         /* The children own the pipes now; each pipe's ends live only in its two users. */
-        close(p01[0]);
-        close(p01[1]);
-        close(p10[0]);
-        close(p10[1]);
+        close(to_node0[0]);
+        close(to_node0[1]);
+        close(to_node1[0]);
+        close(to_node1[1]);
     }
 
     /*

--- a/test/csuite/schema_disagg_abort/parent.c
+++ b/test/csuite/schema_disagg_abort/parent.c
@@ -1,36 +1,20 @@
 /*-
- * Public Domain 2014-present MongoDB, Inc.
- * Public Domain 2008-2014 WiredTiger, Inc.
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
  *
- * This is free and unencumbered software released into the public domain.
- *
- * Anyone is free to copy, modify, publish, use, compile, sell, or
- * distribute this software, either in source code form or as a compiled
- * binary, for any purpose, commercial or non-commercial, and by any
- * means.
- *
- * In jurisdictions that recognize copyright laws, the author or authors
- * of this software dedicate any and all copyright interest in the
- * software to the public domain. We make this dedication for the benefit
- * of the public at large and to the detriment of our heirs and
- * successors. We intend this dedication to be an overt act of
- * relinquishment in perpetuity of all present and future rights to this
- * software under copyright law.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
- * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
- * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * See the file LICENSE for redistribution information.
  */
 
 /*
- * Parent role: orchestrator and verifier. Spawns the leader (and, in multi-node mode, the
- * follower), monitors their health during the timed run, kills them per the configured mode with
- * strict exit-status checks, then reopens the surviving state and verifies it against the record
- * files. The parent never opens WiredTiger while children are running.
+ * Parent role: orchestrator and verifier. Spawns one or two symmetric nodes per the -r topology,
+ * then drives a one-second-tick timeline: a role switch every -s seconds (directed through the
+ * switch-request sentinel and confirmed through the numbered switch-done sentinel), SIGKILLs at the
+ * -k times (targeting whichever node currently holds the role), and a graceful stop at the -t
+ * timeout. Children dying at any other point fail the test.
+ *
+ * Afterwards the parent reopens the surviving state and verifies it against the record files. It
+ * never opens WiredTiger while children are running.
  */
 
 #include "schema_disagg_abort.h"
@@ -42,59 +26,65 @@
 static void die_on_child_status(const SUBPROC *proc, SUBPROC_STATUS status, int code)
   WT_GCC_FUNC_DECL_ATTRIBUTE((noreturn));
 
+/* The spawned children, so that a failing parent can take them down with it. */
+static SUBPROC *live_children = NULL;
+
+/*
+ * kill_children --
+ *     Kill whatever is still running when the test fails. Without this a failure leaves the
+ *     surviving node behind: nothing else ever reaps it, and it runs on for as long as the machine
+ *     is up, competing with later runs.
+ */
+static void
+kill_children(void)
+{
+    if (live_children == NULL)
+        return;
+
+    for (size_t i = 0; i < SUBPROC_SLOTS; ++i)
+        if (live_children[i].who != NULL && !live_children[i].reaped)
+            (void)kill(live_children[i].pid, SIGKILL);
+}
+
 /*
  * create_test_dirs --
  *     Create the directory structure needed for a fresh test run.
  */
 static void
-create_test_dirs(const TEST_CONFIG *cfg)
+create_test_dirs(const TEST_CONFIG *cfg, uint32_t nnodes)
 {
     char buf[PATH_MAX];
 
     testutil_recreate_dir(cfg->home);
     testutil_snprintf(buf, sizeof(buf), "%s/%s", cfg->home, RECORDS_DIR);
     testutil_mkdir(buf);
-    testutil_snprintf(buf, sizeof(buf), "%s/%s", cfg->home, WT_HOME_DIR);
+    testutil_snprintf(buf, sizeof(buf), "%s/%s", cfg->home, PAGE_LOG_DIR);
     testutil_mkdir(buf);
-    if (cfg->kill_mode != KILL_NONE) {
-        testutil_snprintf(buf, sizeof(buf), "%s/%s", cfg->home, FOLLOWER_HOME_DIR);
+    for (uint32_t id = 0; id < nnodes; id++) {
+        testutil_snprintf(buf, sizeof(buf), "%s/" NODE_HOME_FMT, cfg->home, id);
         testutil_mkdir(buf);
     }
 }
 
 /*
- * kill_mode_option --
- *     Return the -k option value for a kill mode.
- */
-static const char *
-kill_mode_option(KILL_MODE mode)
-{
-    switch (mode) {
-    case KILL_LEADER:
-        return ("l");
-    case KILL_FOLLOWER:
-        return ("f");
-    case KILL_BOTH:
-        return ("b");
-    case KILL_NONE:
-        break;
-    }
-    return (NULL);
-}
-
-/*
- * spawn_role --
- *     Spawn this binary again in a child role, passing the full configuration on the command line.
- *     The role name doubles as the child's diagnostic name.
+ * spawn_node --
+ *     Spawn this binary again as a node, passing the full configuration on the command line. The
+ *     node inherits only its own two pipe ends; the peer's ends are closed in the child so pipe EOF
+ *     still signals the peer's death.
  */
 static void
-spawn_role(const TEST_CONFIG *cfg, const char *self_path, const char *role, SUBPROC *proc)
+spawn_node(const TEST_CONFIG *cfg, const char *self_path, uint32_t node_id, bool leader,
+  int read_fd, int write_fd, const int *close_fds, size_t nclose, SUBPROC *proc)
 {
-    char nth_arg[16], pool_arg[16], rfd_arg[16], wfd_arg[16], seed_arg[80];
+    static const char *const node_names[SUBPROC_SLOTS] = {"node0", "node1"};
+    testutil_assert(node_id < SUBPROC_SLOTS);
+
+    char id_arg[16], nth_arg[16], pool_arg[16], rfd_arg[16], wfd_arg[16], seed_arg[80];
+    testutil_snprintf(id_arg, sizeof(id_arg), "%" PRIu32, node_id);
     testutil_snprintf(nth_arg, sizeof(nth_arg), "%" PRIu32, cfg->nth);
     testutil_snprintf(pool_arg, sizeof(pool_arg), "%" PRIu32, cfg->pool_size);
-    testutil_snprintf(rfd_arg, sizeof(rfd_arg), "%d", cfg->pipe_read_fd);
-    testutil_snprintf(wfd_arg, sizeof(wfd_arg), "%d", cfg->pipe_write_fd);
+    testutil_snprintf(rfd_arg, sizeof(rfd_arg), "%d", read_fd);
+    testutil_snprintf(wfd_arg, sizeof(wfd_arg), "%d", write_fd);
     testutil_snprintf(seed_arg, sizeof(seed_arg), TESTUTIL_SEED_FORMAT, cfg->opts->data_seed,
       cfg->opts->extra_seed);
 
@@ -102,7 +92,11 @@ spawn_role(const TEST_CONFIG *cfg, const char *self_path, const char *role, SUBP
     size_t n = 0;
     argv[n++] = self_path;
     argv[n++] = "-r";
-    argv[n++] = role;
+    argv[n++] = "node";
+    argv[n++] = "-i";
+    argv[n++] = id_arg;
+    argv[n++] = "-A";
+    argv[n++] = leader ? "l" : "f";
     argv[n++] = "-h";
     argv[n++] = cfg->opts->home;
     if (cfg->opts->build_dir != NULL) {
@@ -111,13 +105,9 @@ spawn_role(const TEST_CONFIG *cfg, const char *self_path, const char *role, SUBP
     }
     argv[n++] = "-T";
     argv[n++] = nth_arg;
-    argv[n++] = "-s";
+    argv[n++] = "-u";
     argv[n++] = pool_arg;
-    if (cfg->switch_mode)
-        argv[n++] = "-m";
-    if (cfg->kill_mode != KILL_NONE) {
-        argv[n++] = "-k";
-        argv[n++] = kill_mode_option(cfg->kill_mode);
+    if (read_fd >= 0) {
         argv[n++] = "-R";
         argv[n++] = rfd_arg;
         argv[n++] = "-W";
@@ -126,7 +116,7 @@ spawn_role(const TEST_CONFIG *cfg, const char *self_path, const char *role, SUBP
     argv[n++] = seed_arg;
     argv[n] = NULL;
 
-    subproc_spawn(proc, role, self_path, (char *const *)argv);
+    subproc_spawn(proc, node_names[node_id], self_path, (char *const *)argv, close_fds, nclose);
 }
 
 /*
@@ -141,80 +131,64 @@ die_on_child_status(const SUBPROC *proc, SUBPROC_STATUS status, int code)
 }
 
 /*
+ * child_alive --
+ *     Report whether a slot holds a spawned, still-running child.
+ */
+static bool
+child_alive(SUBPROC *proc)
+{
+    if (proc->who == NULL || proc->reaped)
+        return (false);
+
+    int code;
+    const SUBPROC_STATUS status = subproc_poll(proc, &code);
+    if (status != SUBPROC_RUNNING)
+        die_on_child_status(proc, status, code); /* Dying on its own fails the test. */
+    return (true);
+}
+
+/*
+ * children_poll --
+ *     Health-check every spawned child, failing the test if one died on its own; reports how many
+ *     are still running.
+ */
+static uint32_t
+children_poll(SUBPROC children[SUBPROC_SLOTS])
+{
+    uint32_t alive = 0;
+    for (size_t i = 0; i < SUBPROC_SLOTS; ++i)
+        if (child_alive(&children[i]))
+            ++alive;
+    return (alive);
+}
+
+/*
  * wait_for_sentinel --
- *     Wait up to the given number of seconds for a child to create a sentinel file, failing if the
- *     child dies or times out first.
+ *     Wait up to the given number of seconds for the children to create a sentinel file, failing if
+ *     a child dies or the wait times out first.
  */
 static void
-wait_for_sentinel(const TEST_CONFIG *cfg, SUBPROC *proc, const char *sentinel, uint32_t max_wait)
+wait_for_sentinel(
+  const TEST_CONFIG *cfg, SUBPROC children[SUBPROC_SLOTS], const char *sentinel, uint32_t max_wait)
 {
     for (uint32_t waited = 0; !testutil_exists(cfg->home, sentinel); ++waited) {
-        int code;
-        const SUBPROC_STATUS status = subproc_poll(proc, &code);
-        if (status != SUBPROC_RUNNING)
-            die_on_child_status(proc, status, code);
+        if (children_poll(children) == 0)
+            testutil_die(EINVAL, "no live children while waiting for %s", sentinel);
         if (waited >= max_wait)
-            testutil_die(ETIMEDOUT, "%s did not create %s within %" PRIu32 " seconds", proc->who,
-              sentinel, max_wait);
+            testutil_die(
+              ETIMEDOUT, "%s was not created within %" PRIu32 " seconds", sentinel, max_wait);
         sleep(1);
     }
 }
 
 /*
- * timed_run --
- *     Let the workload run for the configured timeout, failing fast if a child dies early. Slots
- *     that were never spawned (NULL who) are skipped.
+ * reap_child --
+ *     Wait for a child to terminate and assert it ended the expected way: SIGKILLed on our signal,
+ *     or a clean exit after the stop sentinel. A child that outlives the wait is killed and the
+ *     test failed.
  */
 static void
-timed_run(SUBPROC children[SUBPROC_SLOTS], uint32_t timeout)
-{
-    for (uint32_t elapsed = 0; elapsed < timeout; ++elapsed) {
-        for (size_t i = 0; i < SUBPROC_SLOTS; ++i) {
-            SUBPROC *const proc = &children[i];
-
-            if (proc->who == NULL)
-                continue;
-
-            int code;
-            const SUBPROC_STATUS status = subproc_poll(proc, &code);
-            if (status != SUBPROC_RUNNING)
-                die_on_child_status(proc, status, code);
-        }
-        sleep(1);
-    }
-}
-
-/*
- * reap_killed --
- *     Reap a killed child and assert it died from our signal, not on its own.
- */
-static void
-reap_killed(SUBPROC *proc)
-{
-    int code;
-    const SUBPROC_STATUS status = subproc_wait(proc, &code);
-    if (status != SUBPROC_KILLED || code != SIGKILL)
-        die_on_child_status(proc, status, code);
-}
-
-/*
- * kill_and_reap --
- *     Kill a child abruptly and assert it died from our signal.
- */
-static void
-kill_and_reap(SUBPROC *proc)
-{
-    subproc_kill(proc);
-    reap_killed(proc);
-}
-
-/*
- * reap_stepped_up_follower --
- *     Wait for the follower to step up and exit on its own, then assert it exited cleanly and left
- *     the stepped-up sentinel.
- */
-static void
-reap_stepped_up_follower(const TEST_CONFIG *cfg, SUBPROC *proc)
+reap_child(SUBPROC *proc, SUBPROC_STATUS want_status, int want_code)
 {
     int code;
     SUBPROC_STATUS status;
@@ -223,100 +197,156 @@ reap_stepped_up_follower(const TEST_CONFIG *cfg, SUBPROC *proc)
         if (waited >= MAX_STARTUP) {
             subproc_kill(proc);
             (void)subproc_wait(proc, &code);
-            testutil_die(ETIMEDOUT, "%s did not step up within %d seconds", proc->who, MAX_STARTUP);
+            testutil_die(
+              ETIMEDOUT, "%s did not terminate within %d seconds", proc->who, MAX_STARTUP);
         }
         sleep(1);
     }
 
-    if (status != SUBPROC_EXITED || code != EXIT_SUCCESS)
+    if (status != want_status || code != want_code)
         die_on_child_status(proc, status, code);
-    testutil_assert(testutil_exists(cfg->home, FOLLOWER_STEPPED_UP_FILE));
 }
 
 /*
- * run_and_kill_children --
- *     Run the crash scenario: spawn the children, let them work, then kill per the configured mode.
+ * direct_switch --
+ *     Direct one role switch and wait for its completion: the current leader steps down and hands
+ *     over to a live peer, or a lone survivor flips its role by itself. Updates the parent's view
+ *     of who holds which role. Skipped when no child is left to act.
  */
 static void
-run_and_kill_children(TEST_CONFIG *cfg, const char *self_path)
+direct_switch(const TEST_CONFIG *cfg, SUBPROC children[SUBPROC_SLOTS], int *cur_leaderp,
+  int *cur_followerp, uint32_t *genp)
 {
-    const bool multi_node = cfg->kill_mode != KILL_NONE;
+    const int leader = *cur_leaderp, follower = *cur_followerp;
+    const bool leader_alive = leader >= 0 && child_alive(&children[leader]);
+    const bool follower_alive = follower >= 0 && child_alive(&children[follower]);
 
-    SUBPROC children[SUBPROC_SLOTS];
-    WT_CLEAR(children);
-    SUBPROC *const leader = &children[SUBPROC_LEADER];
-    SUBPROC *const follower = &children[SUBPROC_FOLLOWER];
-
-    if (multi_node) {
-        int fds[2];
-        subproc_pipe(fds);
-        cfg->pipe_read_fd = fds[0];
-        cfg->pipe_write_fd = fds[1];
+    if (!leader_alive && !follower_alive) {
+        println("Parent: skipping switch, no live children");
+        return;
     }
 
-    spawn_role(cfg, self_path, "leader", leader);
+    const uint32_t gen = ++*genp;
+    println("Parent: directing switch %" PRIu32, gen);
+    testutil_sentinel(cfg->home, SWITCH_REQUEST_FILE);
 
-    if (multi_node) {
-        spawn_role(cfg, self_path, "follower", follower);
+    char done_name[64];
+    testutil_snprintf(done_name, sizeof(done_name), SWITCH_DONE_FMT, gen);
+    wait_for_sentinel(cfg, children, done_name, 4 * MAX_STARTUP);
 
-        /* The children own the pipe now; the follower must see EOF once the leader dies. */
-        close(cfg->pipe_read_fd);
-        close(cfg->pipe_write_fd);
-        cfg->pipe_read_fd = cfg->pipe_write_fd = -1;
+    /* Live nodes swapped roles; a dead slot leaves its new role vacant. */
+    *cur_leaderp = follower_alive ? follower : -1;
+    *cur_followerp = leader_alive ? leader : -1;
+}
+
+/*
+ * run_children --
+ *     Run the scenario: spawn the node(s) per the topology, then drive the timeline of switches,
+ *     kills, and the final graceful stop.
+ */
+static void
+run_children(TEST_CONFIG *cfg, const char *self_path)
+{
+    const uint32_t nnodes = (cfg->with_leader ? 1u : 0u) + (cfg->with_follower ? 1u : 0u);
+    static SUBPROC children[SUBPROC_SLOTS];
+    WT_CLEAR(children);
+
+    /* Any failure from here on kills the children before it aborts the process. */
+    live_children = children;
+    custom_die = kill_children;
+
+    create_test_dirs(cfg, nnodes);
+
+    if (nnodes == 1)
+        spawn_node(cfg, self_path, 0, cfg->with_leader, -1, -1, NULL, 0, &children[0]);
+    else {
+        /* One pipe per direction; a node writes while leading and reads while following. */
+        int p01[2], p10[2];
+        subproc_pipe(p01);
+        subproc_pipe(p10);
+
+        const int close0[] = {p01[0], p10[1]}; /* node0 keeps p01 write, p10 read */
+        spawn_node(
+          cfg, self_path, 0, true, p10[0], p01[1], close0, WT_ELEMENTS(close0), &children[0]);
+        const int close1[] = {p01[1], p10[0]}; /* node1 keeps p01 read, p10 write */
+        spawn_node(
+          cfg, self_path, 1, false, p01[0], p10[1], close1, WT_ELEMENTS(close1), &children[1]);
+
+        /* The children own the pipes now; each pipe's ends live only in its two users. */
+        close(p01[0]);
+        close(p01[1]);
+        close(p10[0]);
+        close(p10[1]);
     }
 
     /*
-     * Wait until the crash window has opened before starting the timer. In switch mode the crash
-     * must land in phase 2, so wait for the switch sentinel. Otherwise wait for the leader's ready
-     * sentinel, which follows its first checkpoint. Both can run long under heavy schema churn
-     * (many workers, large URI pools): give them a much wider window than the follower, whose first
-     * pickup follows promptly once a checkpoint exists.
+     * Start the clock only once the workload is productive: a leader's first checkpoint can run
+     * long under heavy schema churn, so give it a much wider window than the follower, whose first
+     * pickup follows promptly once a checkpoint exists. A lone follower has nothing to wait for.
      */
-    wait_for_sentinel(
-      cfg, leader, cfg->switch_mode ? SWITCH_DONE_FILE : LEADER_READY_FILE, 4 * MAX_STARTUP);
-    if (multi_node)
-        wait_for_sentinel(cfg, follower, FOLLOWER_READY_FILE, MAX_STARTUP);
+    if (cfg->with_leader)
+        wait_for_sentinel(cfg, children, LEADER_READY_FILE, 4 * MAX_STARTUP);
+    if (nnodes == 2)
+        wait_for_sentinel(cfg, children, FOLLOWER_READY_FILE, MAX_STARTUP);
 
-    timed_run(children, cfg->timeout);
+    int cur_leader = cfg->with_leader ? 0 : -1;
+    int cur_follower = nnodes == 2 ? 1 : (cfg->with_follower ? 0 : -1);
+    uint32_t switch_gen = 0;
+    uint32_t next_switch = cfg->switch_interval;
 
-    printf("Kill: %s\n", multi_node ? kill_mode_option(cfg->kill_mode) : "leader (single-node)");
-    fflush(stdout);
+    for (uint32_t elapsed = 1; elapsed <= cfg->total_time; ++elapsed) {
+        (void)children_poll(children); /* Dying on its own fails the test. */
+        sleep(1);
 
-    switch (cfg->kill_mode) {
-    case KILL_NONE:
-        kill_and_reap(leader);
-        break;
-    case KILL_LEADER:
-        /* The pipe EOF makes the follower step up, checkpoint, and exit on its own. */
-        kill_and_reap(leader);
-        reap_stepped_up_follower(cfg, follower);
-        break;
-    case KILL_FOLLOWER:
-        kill_and_reap(follower);
-        kill_and_reap(leader);
-        break;
-    case KILL_BOTH:
-        /* Kill both before reaping either, so the deaths overlap as much as possible. */
-        subproc_kill(follower);
-        subproc_kill(leader);
-        reap_killed(follower);
-        reap_killed(leader);
-        break;
+        /* Kills first: overlapping a kill with a same-tick switch is the interesting order. */
+        SUBPROC *targets[KILL_TARGETS];
+        size_t ntargets = 0;
+        for (int k = 0; k < KILL_TARGETS; ++k) {
+            if (cfg->kill_time[k] != elapsed)
+                continue;
+            /* The lone node lives in slot 0; role targets follow the parent's tracking. */
+            const int slot = k == KILL_LONE ? 0 : (k == KILL_LEADER ? cur_leader : cur_follower);
+            if (slot < 0 || !child_alive(&children[slot]))
+                continue;
+            targets[ntargets++] = &children[slot];
+            if (cur_leader == slot)
+                cur_leader = -1;
+            if (cur_follower == slot)
+                cur_follower = -1;
+        }
+        /* Kill before reaping so simultaneous deaths overlap as much as possible. */
+        for (size_t i = 0; i < ntargets; ++i) {
+            println("Parent: killing %s at %" PRIu32 "s", targets[i]->who, elapsed);
+            subproc_kill(targets[i]);
+        }
+        for (size_t i = 0; i < ntargets; ++i)
+            reap_child(targets[i], SUBPROC_KILLED, SIGKILL);
+
+        if (cfg->switch_interval != 0 && elapsed == next_switch) {
+            next_switch += cfg->switch_interval;
+            direct_switch(cfg, children, &cur_leader, &cur_follower, &switch_gen);
+        }
     }
+
+    println("Parent: directing graceful stop");
+    testutil_sentinel(cfg->home, STOP_FILE);
+    for (size_t i = 0; i < SUBPROC_SLOTS; ++i)
+        if (children[i].who != NULL && !children[i].reaped)
+            reap_child(&children[i], SUBPROC_EXITED, EXIT_SUCCESS);
 }
 
 /*
  * open_for_recovery --
- *     Open the given home as a disaggregated leader to trigger recovery.
+ *     Open the given node home as a disaggregated leader to trigger recovery.
  */
 static void
-open_for_recovery(const TEST_CONFIG *cfg, const char *home_dir, WT_CONNECTION **connp)
+open_for_recovery(const TEST_CONFIG *cfg, uint32_t node_id, WT_CONNECTION **connp)
 {
-    cfg->opts->disagg.is_enabled = true;
+    char home_dir[32];
+    testutil_snprintf(home_dir, sizeof(home_dir), NODE_HOME_FMT, node_id);
+
+    disagg_opts_init(cfg);
     cfg->opts->disagg.mode = "leader";
-    cfg->opts->disagg.page_log = "palite";
-    cfg->opts->disagg.page_log_home = cfg->page_log_home;
-    cfg->opts->disagg.drain_threads = 1;
 
     testutil_wiredtiger_open(cfg->opts, home_dir, "create,disaggregated=(lose_all_my_data=true)",
       NULL, connp, true, false);
@@ -324,38 +354,33 @@ open_for_recovery(const TEST_CONFIG *cfg, const char *home_dir, WT_CONNECTION **
 
 /*
  * verify_homes --
- *     Reopen and verify the surviving state: the leader home always, the follower home in
- *     multi-node mode.
+ *     Reopen and verify the surviving state of every node home that exists against the union of the
+ *     nodes' records, then check the relay's integrity.
  */
 static void
 verify_homes(const TEST_CONFIG *cfg)
 {
-    printf("Open leader database, run recovery and verify content\n");
+    for (uint32_t id = 0; id < MAX_NODES; id++) {
+        char home_dir[32];
+        testutil_snprintf(home_dir, sizeof(home_dir), NODE_HOME_FMT, id);
+        if (!testutil_exists(NULL, home_dir))
+            continue;
 
-    WT_CONNECTION *conn;
-    open_for_recovery(cfg, WT_HOME_DIR, &conn);
-    verify_schema_state(conn, cfg, SCHEMA_RECORDS_BASE);
-    testutil_check(conn->close(conn, "debug=(skip_checkpoint=true)"));
+        println("Parent: Open node%" PRIu32 " database, run recovery and verify content", id);
 
-    if (cfg->kill_mode != KILL_NONE) {
-        /*
-         * In kill-leader mode the follower's own records are complete up to its stepped-up
-         * checkpoint. In the other modes the reopened follower converges to the leader's last
-         * complete checkpoint, so the leader's records are the sound reference.
-         */
-        printf("Open follower database, run recovery and verify content\n");
-
-        open_for_recovery(cfg, FOLLOWER_HOME_DIR, &conn);
-        verify_schema_state(
-          conn, cfg, cfg->kill_mode == KILL_LEADER ? FOLLOWER_RECORDS_BASE : SCHEMA_RECORDS_BASE);
+        WT_CONNECTION *conn;
+        open_for_recovery(cfg, id, &conn);
+        verify_schema_state(conn, cfg);
         testutil_check(conn->close(conn, "debug=(skip_checkpoint=true)"));
     }
+
+    verify_relay_prefix(cfg);
 }
 
 /*
  * parent_main --
- *     Parent role entry point: run the crash scenario, then verify the outcome. Any failure aborts
- *     the process, so returning at all means success.
+ *     Parent role entry point: run the scenario, then verify the outcome. Any failure aborts the
+ *     process, so returning at all means success.
  */
 void
 parent_main(TEST_CONFIG *cfg, const char *self_path)
@@ -363,10 +388,8 @@ parent_main(TEST_CONFIG *cfg, const char *self_path)
     char cwd_start[PATH_MAX];
     testutil_assert_errno(getcwd(cwd_start, sizeof(cwd_start)) != NULL);
 
-    if (!cfg->verify_only) {
-        create_test_dirs(cfg);
-        run_and_kill_children(cfg, self_path);
-    }
+    if (!cfg->verify_only)
+        run_children(cfg, self_path);
 
     if (chdir(cfg->home) != 0)
         testutil_die(errno, "parent chdir: %s", cfg->home);
@@ -376,7 +399,7 @@ parent_main(TEST_CONFIG *cfg, const char *self_path)
 
     if (cfg->page_log_home[0] == '\0')
         testutil_snprintf(cfg->page_log_home, sizeof(cfg->page_log_home), "%s/%s/%s", cwd_start,
-          cfg->home, WT_HOME_DIR);
+          cfg->home, PAGE_LOG_DIR);
 
     verify_homes(cfg);
 

--- a/test/csuite/schema_disagg_abort/parent.c
+++ b/test/csuite/schema_disagg_abort/parent.c
@@ -1,0 +1,390 @@
+/*-
+ * Public Domain 2014-present MongoDB, Inc.
+ * Public Domain 2008-2014 WiredTiger, Inc.
+ *
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*
+ * Parent role: orchestrator and verifier. Spawns the leader (and, in multi-node mode, the
+ * follower), monitors their health during the timed run, kills them per the configured mode with
+ * strict exit-status checks, then reopens the surviving state and verifies it against the record
+ * files. The parent never opens WiredTiger while children are running.
+ */
+
+#include "schema_disagg_abort.h"
+
+#include <signal.h>
+
+#include "subproc.h"
+
+static void die_on_child_status(const SUBPROC *proc, SUBPROC_STATUS status, int code)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((noreturn));
+
+/*
+ * create_test_dirs --
+ *     Create the directory structure needed for a fresh test run.
+ */
+static void
+create_test_dirs(const TEST_CONFIG *cfg)
+{
+    char buf[PATH_MAX];
+
+    testutil_recreate_dir(cfg->home);
+    testutil_snprintf(buf, sizeof(buf), "%s/%s", cfg->home, RECORDS_DIR);
+    testutil_mkdir(buf);
+    testutil_snprintf(buf, sizeof(buf), "%s/%s", cfg->home, WT_HOME_DIR);
+    testutil_mkdir(buf);
+    if (cfg->kill_mode != KILL_NONE) {
+        testutil_snprintf(buf, sizeof(buf), "%s/%s", cfg->home, FOLLOWER_HOME_DIR);
+        testutil_mkdir(buf);
+    }
+}
+
+/*
+ * kill_mode_option --
+ *     Return the -k option value for a kill mode.
+ */
+static const char *
+kill_mode_option(KILL_MODE mode)
+{
+    switch (mode) {
+    case KILL_LEADER:
+        return ("l");
+    case KILL_FOLLOWER:
+        return ("f");
+    case KILL_BOTH:
+        return ("b");
+    case KILL_NONE:
+        break;
+    }
+    return (NULL);
+}
+
+/*
+ * spawn_role --
+ *     Spawn this binary again in a child role, passing the full configuration on the command line.
+ *     The role name doubles as the child's diagnostic name.
+ */
+static void
+spawn_role(const TEST_CONFIG *cfg, const char *self_path, const char *role, SUBPROC *proc)
+{
+    char nth_arg[16], pool_arg[16], rfd_arg[16], wfd_arg[16], seed_arg[80];
+    testutil_snprintf(nth_arg, sizeof(nth_arg), "%" PRIu32, cfg->nth);
+    testutil_snprintf(pool_arg, sizeof(pool_arg), "%" PRIu32, cfg->pool_size);
+    testutil_snprintf(rfd_arg, sizeof(rfd_arg), "%d", cfg->pipe_read_fd);
+    testutil_snprintf(wfd_arg, sizeof(wfd_arg), "%d", cfg->pipe_write_fd);
+    testutil_snprintf(seed_arg, sizeof(seed_arg), TESTUTIL_SEED_FORMAT, cfg->opts->data_seed,
+      cfg->opts->extra_seed);
+
+    const char *argv[24];
+    size_t n = 0;
+    argv[n++] = self_path;
+    argv[n++] = "-r";
+    argv[n++] = role;
+    argv[n++] = "-h";
+    argv[n++] = cfg->opts->home;
+    if (cfg->opts->build_dir != NULL) {
+        argv[n++] = "-b";
+        argv[n++] = cfg->opts->build_dir;
+    }
+    argv[n++] = "-T";
+    argv[n++] = nth_arg;
+    argv[n++] = "-s";
+    argv[n++] = pool_arg;
+    if (cfg->switch_mode)
+        argv[n++] = "-m";
+    if (cfg->kill_mode != KILL_NONE) {
+        argv[n++] = "-k";
+        argv[n++] = kill_mode_option(cfg->kill_mode);
+        argv[n++] = "-R";
+        argv[n++] = rfd_arg;
+        argv[n++] = "-W";
+        argv[n++] = wfd_arg;
+    }
+    argv[n++] = seed_arg;
+    argv[n] = NULL;
+
+    subproc_spawn(proc, role, self_path, (char *const *)argv);
+}
+
+/*
+ * die_on_child_status --
+ *     Fail the test, reporting how a child terminated.
+ */
+static void
+die_on_child_status(const SUBPROC *proc, SUBPROC_STATUS status, int code)
+{
+    testutil_die(EINVAL, "%s terminated unexpectedly: %s %d", proc->who,
+      status == SUBPROC_EXITED ? "exit code" : "signal", code);
+}
+
+/*
+ * wait_for_sentinel --
+ *     Wait up to the given number of seconds for a child to create a sentinel file, failing if the
+ *     child dies or times out first.
+ */
+static void
+wait_for_sentinel(const TEST_CONFIG *cfg, SUBPROC *proc, const char *sentinel, uint32_t max_wait)
+{
+    for (uint32_t waited = 0; !testutil_exists(cfg->home, sentinel); ++waited) {
+        int code;
+        const SUBPROC_STATUS status = subproc_poll(proc, &code);
+        if (status != SUBPROC_RUNNING)
+            die_on_child_status(proc, status, code);
+        if (waited >= max_wait)
+            testutil_die(ETIMEDOUT, "%s did not create %s within %" PRIu32 " seconds", proc->who,
+              sentinel, max_wait);
+        sleep(1);
+    }
+}
+
+/*
+ * timed_run --
+ *     Let the workload run for the configured timeout, failing fast if a child dies early. Slots
+ *     that were never spawned (NULL who) are skipped.
+ */
+static void
+timed_run(SUBPROC children[SUBPROC_SLOTS], uint32_t timeout)
+{
+    for (uint32_t elapsed = 0; elapsed < timeout; ++elapsed) {
+        for (size_t i = 0; i < SUBPROC_SLOTS; ++i) {
+            SUBPROC *const proc = &children[i];
+
+            if (proc->who == NULL)
+                continue;
+
+            int code;
+            const SUBPROC_STATUS status = subproc_poll(proc, &code);
+            if (status != SUBPROC_RUNNING)
+                die_on_child_status(proc, status, code);
+        }
+        sleep(1);
+    }
+}
+
+/*
+ * reap_killed --
+ *     Reap a killed child and assert it died from our signal, not on its own.
+ */
+static void
+reap_killed(SUBPROC *proc)
+{
+    int code;
+    const SUBPROC_STATUS status = subproc_wait(proc, &code);
+    if (status != SUBPROC_KILLED || code != SIGKILL)
+        die_on_child_status(proc, status, code);
+}
+
+/*
+ * kill_and_reap --
+ *     Kill a child abruptly and assert it died from our signal.
+ */
+static void
+kill_and_reap(SUBPROC *proc)
+{
+    subproc_kill(proc);
+    reap_killed(proc);
+}
+
+/*
+ * reap_stepped_up_follower --
+ *     Wait for the follower to step up and exit on its own, then assert it exited cleanly and left
+ *     the stepped-up sentinel.
+ */
+static void
+reap_stepped_up_follower(const TEST_CONFIG *cfg, SUBPROC *proc)
+{
+    int code;
+    SUBPROC_STATUS status;
+
+    for (uint32_t waited = 0; (status = subproc_poll(proc, &code)) == SUBPROC_RUNNING; ++waited) {
+        if (waited >= MAX_STARTUP) {
+            subproc_kill(proc);
+            (void)subproc_wait(proc, &code);
+            testutil_die(ETIMEDOUT, "%s did not step up within %d seconds", proc->who, MAX_STARTUP);
+        }
+        sleep(1);
+    }
+
+    if (status != SUBPROC_EXITED || code != EXIT_SUCCESS)
+        die_on_child_status(proc, status, code);
+    testutil_assert(testutil_exists(cfg->home, FOLLOWER_STEPPED_UP_FILE));
+}
+
+/*
+ * run_and_kill_children --
+ *     Run the crash scenario: spawn the children, let them work, then kill per the configured mode.
+ */
+static void
+run_and_kill_children(TEST_CONFIG *cfg, const char *self_path)
+{
+    const bool multi_node = cfg->kill_mode != KILL_NONE;
+
+    SUBPROC children[SUBPROC_SLOTS];
+    WT_CLEAR(children);
+    SUBPROC *const leader = &children[SUBPROC_LEADER];
+    SUBPROC *const follower = &children[SUBPROC_FOLLOWER];
+
+    if (multi_node) {
+        int fds[2];
+        subproc_pipe(fds);
+        cfg->pipe_read_fd = fds[0];
+        cfg->pipe_write_fd = fds[1];
+    }
+
+    spawn_role(cfg, self_path, "leader", leader);
+
+    if (multi_node) {
+        spawn_role(cfg, self_path, "follower", follower);
+
+        /* The children own the pipe now; the follower must see EOF once the leader dies. */
+        close(cfg->pipe_read_fd);
+        close(cfg->pipe_write_fd);
+        cfg->pipe_read_fd = cfg->pipe_write_fd = -1;
+    }
+
+    /*
+     * Wait until the crash window has opened before starting the timer. In switch mode the crash
+     * must land in phase 2, so wait for the switch sentinel. Otherwise wait for the leader's ready
+     * sentinel, which follows its first checkpoint. Both can run long under heavy schema churn
+     * (many workers, large URI pools): give them a much wider window than the follower, whose first
+     * pickup follows promptly once a checkpoint exists.
+     */
+    wait_for_sentinel(
+      cfg, leader, cfg->switch_mode ? SWITCH_DONE_FILE : LEADER_READY_FILE, 4 * MAX_STARTUP);
+    if (multi_node)
+        wait_for_sentinel(cfg, follower, FOLLOWER_READY_FILE, MAX_STARTUP);
+
+    timed_run(children, cfg->timeout);
+
+    printf("Kill: %s\n", multi_node ? kill_mode_option(cfg->kill_mode) : "leader (single-node)");
+    fflush(stdout);
+
+    switch (cfg->kill_mode) {
+    case KILL_NONE:
+        kill_and_reap(leader);
+        break;
+    case KILL_LEADER:
+        /* The pipe EOF makes the follower step up, checkpoint, and exit on its own. */
+        kill_and_reap(leader);
+        reap_stepped_up_follower(cfg, follower);
+        break;
+    case KILL_FOLLOWER:
+        kill_and_reap(follower);
+        kill_and_reap(leader);
+        break;
+    case KILL_BOTH:
+        /* Kill both before reaping either, so the deaths overlap as much as possible. */
+        subproc_kill(follower);
+        subproc_kill(leader);
+        reap_killed(follower);
+        reap_killed(leader);
+        break;
+    }
+}
+
+/*
+ * open_for_recovery --
+ *     Open the given home as a disaggregated leader to trigger recovery.
+ */
+static void
+open_for_recovery(const TEST_CONFIG *cfg, const char *home_dir, WT_CONNECTION **connp)
+{
+    cfg->opts->disagg.is_enabled = true;
+    cfg->opts->disagg.mode = "leader";
+    cfg->opts->disagg.page_log = "palite";
+    cfg->opts->disagg.page_log_home = cfg->page_log_home;
+    cfg->opts->disagg.drain_threads = 1;
+
+    testutil_wiredtiger_open(cfg->opts, home_dir, "create,disaggregated=(lose_all_my_data=true)",
+      NULL, connp, true, false);
+}
+
+/*
+ * verify_homes --
+ *     Reopen and verify the surviving state: the leader home always, the follower home in
+ *     multi-node mode.
+ */
+static void
+verify_homes(const TEST_CONFIG *cfg)
+{
+    printf("Open leader database, run recovery and verify content\n");
+
+    WT_CONNECTION *conn;
+    open_for_recovery(cfg, WT_HOME_DIR, &conn);
+    verify_schema_state(conn, cfg, SCHEMA_RECORDS_BASE);
+    testutil_check(conn->close(conn, "debug=(skip_checkpoint=true)"));
+
+    if (cfg->kill_mode != KILL_NONE) {
+        /*
+         * In kill-leader mode the follower's own records are complete up to its stepped-up
+         * checkpoint. In the other modes the reopened follower converges to the leader's last
+         * complete checkpoint, so the leader's records are the sound reference.
+         */
+        printf("Open follower database, run recovery and verify content\n");
+
+        open_for_recovery(cfg, FOLLOWER_HOME_DIR, &conn);
+        verify_schema_state(
+          conn, cfg, cfg->kill_mode == KILL_LEADER ? FOLLOWER_RECORDS_BASE : SCHEMA_RECORDS_BASE);
+        testutil_check(conn->close(conn, "debug=(skip_checkpoint=true)"));
+    }
+}
+
+/*
+ * parent_main --
+ *     Parent role entry point: run the crash scenario, then verify the outcome. Any failure aborts
+ *     the process, so returning at all means success.
+ */
+void
+parent_main(TEST_CONFIG *cfg, const char *self_path)
+{
+    char cwd_start[PATH_MAX];
+    testutil_assert_errno(getcwd(cwd_start, sizeof(cwd_start)) != NULL);
+
+    if (!cfg->verify_only) {
+        create_test_dirs(cfg);
+        run_and_kill_children(cfg, self_path);
+    }
+
+    if (chdir(cfg->home) != 0)
+        testutil_die(errno, "parent chdir: %s", cfg->home);
+
+    if (!cfg->verify_only)
+        testutil_copy_data();
+
+    if (cfg->page_log_home[0] == '\0')
+        testutil_snprintf(cfg->page_log_home, sizeof(cfg->page_log_home), "%s/%s/%s", cwd_start,
+          cfg->home, WT_HOME_DIR);
+
+    verify_homes(cfg);
+
+    if (chdir(cwd_start) != 0)
+        testutil_die(errno, "root chdir: %s", cfg->home);
+
+    if (!cfg->opts->preserve)
+        testutil_remove(cfg->home);
+
+    testutil_cleanup(cfg->opts);
+}

--- a/test/csuite/schema_disagg_abort/reader.c
+++ b/test/csuite/schema_disagg_abort/reader.c
@@ -52,7 +52,7 @@ thread_reader_run(void *arg)
 
     SCHEMA_EVENT ev;
     bool running = true;
-    while (running && !__wt_atomic_load_bool_acquire(&state->reader_stop)) {
+    while (running && !__wt_atomic_load_bool(&state->reader_stop)) {
         if (!pipe_wait_readable(src_fd))
             continue;
         if (!pipe_event_read(src_fd, &ev)) {
@@ -81,10 +81,10 @@ thread_reader_run(void *arg)
              * Every counter value the term allocated rides an event that precedes the switch in the
              * stream, so after the drain nothing may be missing.
              */
-            testutil_assertfmt(__wt_atomic_load_uint64_acquire(&state->current_ts) == ev.event_ts,
+            testutil_assertfmt(__wt_atomic_load_uint64(&state->current_ts) == ev.event_ts,
               "hand-over: drained counter %" PRIu64 " != sender's final counter %" PRIu64,
-              __wt_atomic_load_uint64_acquire(&state->current_ts), ev.event_ts);
-            __wt_atomic_store_bool_release(&state->handover_received, true);
+              __wt_atomic_load_uint64(&state->current_ts), ev.event_ts);
+            __wt_atomic_store_bool(&state->handover_received, true);
             running = false;
             break;
         }
@@ -123,7 +123,7 @@ node_reader_stop(WORKLOAD_STATE *state)
 {
     if (!reader_started)
         return;
-    __wt_atomic_store_bool_release(&state->reader_stop, true);
+    __wt_atomic_store_bool(&state->reader_stop, true);
     testutil_check(__wt_thread_join(NULL, &reader_thr));
     reader_started = false;
 }

--- a/test/csuite/schema_disagg_abort/reader.c
+++ b/test/csuite/schema_disagg_abort/reader.c
@@ -1,0 +1,129 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+/*
+ * The reader stage: the single consumer of the node's event source - the self-pipe when this phase
+ * generates, a live peer's otherwise. Queues events for the workers, dispatches checkpoint events
+ * to the role, and ends the phase on the hand-over. Its checkpoint bookkeeping lives on this
+ * thread's stack, so the engine holds no per-role state.
+ */
+
+#include "schema_disagg_abort.h"
+
+/*
+ * node_current_role --
+ *     Return the role this phase runs. The engine tracks the role as a single bool, so the role
+ *     instance is derived from it rather than stored: one source of truth, no invariant to keep.
+ */
+static const NODE_ROLE *
+node_current_role(const WORKLOAD_STATE *state)
+{
+    return (state->leads ? &node_role_leader : &node_role_follower);
+}
+
+/*
+ * thread_reader_run --
+ *     Drain the node's event source: the self-pipe when this phase generates, the peer's pipe
+ *     otherwise. Schema and data events are queued for the worker threads; a checkpoint event is
+ *     produced (leading) or picked up after a drain barrier (following); the hand-over event ends
+ *     the phase. Pipe EOF can only happen on a peer-fed pipe: it marks the peer dead and turns this
+ *     node into a lone follower.
+ */
+static WT_THREAD_RET
+thread_reader_run(void *arg)
+{
+    WORKLOAD_STATE *state = arg;
+    TEST_CONFIG *cfg = state->cfg;
+    const int src_fd = state->generates ? cfg->self_pipe_read_fd : cfg->pipe_read_fd;
+
+    WT_SESSION *session;
+    testutil_check(state->conn->open_session(state->conn, NULL, NULL, &session));
+
+    /* The role's checkpoint bookkeeping for this phase; only a follower picks checkpoints up. */
+    CKPT_CTX ckpt = {0};
+    __wt_epoch(NULL, &ckpt.phase_start);
+    if (!state->leads)
+        testutil_check(state->conn->get_page_log(state->conn, "palite", &ckpt.page_log));
+
+    SCHEMA_EVENT ev;
+    bool running = true;
+    while (running && !__wt_atomic_load_bool_acquire(&state->reader_stop)) {
+        if (!pipe_wait_readable(src_fd))
+            continue;
+        if (!pipe_event_read(src_fd, &ev)) {
+            /* EOF: the peer died. Keep the role; the node continues as a lone follower. */
+            testutil_assert(!state->leads); /* The self-pipe's writer lives in this process. */
+            cfg->peer_alive = false;
+            println("Node %" PRIu32 ": peer died; continuing as a lone follower", cfg->node_id);
+            running = false;
+            continue;
+        }
+
+        switch (ev.type) {
+        case EVENT_CREATE:
+        case EVENT_DROP:
+        case EVENT_INSERT:
+            workload_enqueue(state, &ev);
+            break;
+        case EVENT_CKPT:
+            node_current_role(state)->checkpoint(state, session, &ckpt, &ev);
+            break;
+        case EVENT_SWITCH:
+            /* The final event of the term's stream: this node must step up. */
+            workload_drain_barrier(state);
+            /*
+             * Relay-integrity check: the drained counter must equal the sender's final counter.
+             * Every counter value the term allocated rides an event that precedes the switch in the
+             * stream, so after the drain nothing may be missing.
+             */
+            testutil_assertfmt(__wt_atomic_load_uint64_acquire(&state->current_ts) == ev.event_ts,
+              "hand-over: drained counter %" PRIu64 " != sender's final counter %" PRIu64,
+              __wt_atomic_load_uint64_acquire(&state->current_ts), ev.event_ts);
+            __wt_atomic_store_bool_release(&state->handover_received, true);
+            running = false;
+            break;
+        }
+    }
+
+    if (ckpt.page_log != NULL)
+        testutil_check(ckpt.page_log->terminate(ckpt.page_log, NULL));
+    testutil_check(session->close(session, NULL));
+    return (WT_THREAD_RET_VALUE);
+}
+
+/* The reader thread's handle; its context and results live in the workload state. */
+static wt_thread_t reader_thr;
+static bool reader_started = false;
+
+/*
+ * node_reader_start --
+ *     Start the reader thread for a phase with an event source: any leader phase (the self-pipe),
+ *     or a follower phase with a live peer. The per-phase hand-over and stop fields were reset by
+ *     workload_start.
+ */
+void
+node_reader_start(WORKLOAD_STATE *state)
+{
+    testutil_assert(!reader_started);
+    testutil_check(__wt_thread_create(NULL, &reader_thr, thread_reader_run, state));
+    reader_started = true;
+}
+
+/*
+ * node_reader_stop --
+ *     Stop and join the reader thread, if one is running.
+ */
+void
+node_reader_stop(WORKLOAD_STATE *state)
+{
+    if (!reader_started)
+        return;
+    __wt_atomic_store_bool_release(&state->reader_stop, true);
+    testutil_check(__wt_thread_join(NULL, &reader_thr));
+    reader_started = false;
+}

--- a/test/csuite/schema_disagg_abort/schema_disagg_abort.h
+++ b/test/csuite/schema_disagg_abort/schema_disagg_abort.h
@@ -1,47 +1,39 @@
 /*-
- * Public Domain 2014-present MongoDB, Inc.
- * Public Domain 2008-2014 WiredTiger, Inc.
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
  *
- * This is free and unencumbered software released into the public domain.
- *
- * Anyone is free to copy, modify, publish, use, compile, sell, or
- * distribute this software, either in source code form or as a compiled
- * binary, for any purpose, commercial or non-commercial, and by any
- * means.
- *
- * In jurisdictions that recognize copyright laws, the author or authors
- * of this software dedicate any and all copyright interest in the
- * software to the public domain. We make this dedication for the benefit
- * of the public at large and to the detriment of our heirs and
- * successors. We intend this dedication to be an overt act of
- * relinquishment in perpetuity of all present and future rights to this
- * software under copyright law.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
- * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
- * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * See the file LICENSE for redistribution information.
  */
 
 /*
  * Disaggregated schema epoch crash recovery test.
  *
- * The test binary runs in one of three roles, each in its own process:
+ * The test binary runs in one of two roles, each in its own process:
  *
- *   parent   - orchestrator and verifier. Spawns the children, kills them per the configured mode,
- *              then reopens the surviving state and verifies it against the record files.
- *   leader   - runs schema worker threads that create, drop, publish, and populate layered tables
- *              while checkpointing, until killed.
- *   follower - tracks the leader through schema events and checkpoint pickups; steps up when the
- *              leader dies in kill-leader mode.
+ *   parent - orchestrator and verifier. Spawns one or two symmetric nodes per the -r topology,
+ *            then drives a timeline: role switches every -s seconds, SIGKILLs at the -k times,
+ *            and a graceful stop at the -t timeout. Afterwards it reopens the surviving state
+ *            and verifies it against the record files.
+ *   node   - a database node that leads or follows, described below.
  *
- * The children are started by re-spawning this binary with an internal role option, so no state is
- * inherited by forking: everything a child needs travels through the command line. The leader
- * relays events to the follower over a pipe whose descriptor numbers are likewise passed on the
- * command line.
+ * Events are the single currency, and both node roles run the identical pipeline: a source writes
+ * events to a pipe, the reader demuxes them to per-thread queues, and the workers execute them. A
+ * leader's source is its own generator thread writing the full stream (the workload, checkpoint
+ * events, and the switch event that ends a term) to a self-pipe; a follower's source is the peer's
+ * relay. The remaining role differences: on a checkpoint event a leader produces the checkpoint
+ * (and relays the event), a follower picks it up; and a leader relays every applied event to the
+ * peer. A follower with no event source (no peer, or the peer died) simply idles in role.
+ *
+ * Nodes switch roles on the switch event: the leader's generator emits it when the parent drops the
+ * switch-request sentinel, and the hand-over relays it to the peer; a lone follower's generator
+ * consumes the sentinel and reports the hand-over directly. Nodes stop gracefully when the parent
+ * drops the stop sentinel.
+ *
+ * The children are started by re-spawning this binary with internal options, so no state is
+ * inherited by forking: everything a node needs travels through the command line. The two nodes
+ * are connected by a pair of pipes, one per direction; a node writes to its out-pipe while
+ * leading and reads from its in-pipe while following.
  */
 
 #pragma once
@@ -50,6 +42,19 @@
 
 /* Tunables. */
 #define MAX_CKPT_INVL 4
+/*
+ * One create in INSERT_ODDS takes data. Only a dirty table's drop has to wait for the checkpoint
+ * that persists its data, so keeping inserts rare lets the schema churn run at full speed and
+ * leaves a handful of gated slots per checkpoint interval to exercise the waiting path.
+ */
+#define INSERT_ODDS 64
+/*
+ * The value a node enters the "epoch world" at. Publishing panics while the stable schema epoch is
+ * unset, so every connection sets the frontier before anything publishes, and the allocator starts
+ * from the same value: publish also requires the epoch to be above the stable one.
+ */
+#define SCHEMA_EPOCH_BOOTSTRAP 1
+#define MAX_NODES 2
 #define MAX_POOL_SIZE 64
 #define MAX_STARTUP 60
 #define MAX_TH 12
@@ -58,45 +63,68 @@
 #define MIN_TH 2
 #define MIN_TIME 10
 
-/* URI / file name patterns. */
+/* Directory layout under the test home. */
+#define NODE_HOME_FMT "WT_NODE%" PRIu32
+#define PAGE_LOG_DIR "PALITE"
+
+/* URI / file name patterns; tables and record files are namespaced by owning node. */
 #define DATA_KEY_MIN 0
 #define DATA_KEY_MAX 9
-#define LEADER_READY_FILE "leader_ready"
-#define SWITCH_DONE_FILE "switch_done" /* switch mode: the role transition has completed */
-#define SCHEMA_TABLE_FMT "table:schema_%u_%u"
+#define SCHEMA_TABLE_FMT "table:schema_%" PRIu32 "_%" PRIu32 "_%" PRIu32 /* node, thread, slot */
 
 /*
- * Per-thread record files: "<records dir>/<base>-<thread>". The single-format/base-name split keeps
- * every snprintf format a literal so the compiler can check it.
+ * Per-node, per-thread record files: "<records dir>/node<node>-<kind>-<thread>". A node's "schema"
+ * files log the operations it originated while leading; its "relay" files log the peer's events it
+ * applied while following.
  */
-#define RECORDS_FILE_FMT RECORDS_DIR DIR_DELIM_STR "%s-%" PRIu32
-#define SCHEMA_RECORDS_BASE "schema"
-#define SCHEMA_RECORDS_FILE RECORDS_DIR DIR_DELIM_STR SCHEMA_RECORDS_BASE "-%" PRIu32
+#define SCHEMA_RECORDS_FILE RECORDS_DIR DIR_DELIM_STR "node%" PRIu32 "-schema-%" PRIu32
+#define RELAY_RECORDS_FILE RECORDS_DIR DIR_DELIM_STR "node%" PRIu32 "-relay-%" PRIu32
 
-/* Multi-node mode: follower home, sentinels and record files. */
-#define FOLLOWER_HOME_DIR "WT_FOLLOWER"
-#define FOLLOWER_READY_FILE "follower_ready"
-#define FOLLOWER_STEPPED_UP_FILE "follower_stepped_up"
-#define FOLLOWER_RECORDS_BASE "follower"
-#define FOLLOWER_RECORDS_FILE RECORDS_DIR DIR_DELIM_STR FOLLOWER_RECORDS_BASE "-%" PRIu32
+/*
+ * Sentinels the nodes and the parent coordinate through. The switch request is consumed by the
+ * acting node (the leader, or a lone node), so each request fires exactly one switch.
+ */
+#define LEADER_READY_FILE "leader_ready"       /* initial leader completed a checkpoint */
+#define FOLLOWER_READY_FILE "follower_ready"   /* initial follower completed a pickup */
+#define SWITCH_REQUEST_FILE "switch_request"   /* parent directs a role switch */
+#define SWITCH_DONE_FMT "switch_done.%" PRIu32 /* the n-th switch completed */
+#define STOP_FILE "stop_run"                   /* parent directs a graceful stop */
 
 /* Connection config. */
 #define ENV_CONFIG_DEF "create,statistics=(all),statistics_log=(json,on_close,wait=1)"
 
 /* Which process this instance of the binary is. */
-typedef enum { ROLE_PARENT = 0, ROLE_LEADER, ROLE_FOLLOWER } TEST_ROLE;
+typedef enum { ROLE_PARENT = 0, ROLE_NODE } TEST_ROLE;
 
-/* Which child processes the parent kills in multi-node mode. */
-typedef enum { KILL_NONE = 0, KILL_LEADER, KILL_FOLLOWER, KILL_BOTH } KILL_MODE;
+/* Timed SIGKILL targets; leader/follower refer to the CURRENT role at kill time. */
+typedef enum { KILL_LONE = 0, KILL_LEADER, KILL_FOLLOWER } KILL_TARGET;
+#define KILL_TARGETS 3
 
-/* Schema event relayed from the leader to the follower over the pipe. */
-typedef enum { EVENT_CREATE, EVENT_DROP, EVENT_INSERT, EVENT_CKPT } EVENT_TYPE;
+/*
+ * Events, the single currency both roles run on. A leader's generator produces CREATE/DROP/INSERT
+ * events; the leader executes them and relays them to its peer, which executes them identically.
+ * EVENT_CKPT makes the leader produce a checkpoint (and relay the event) and the follower pick it
+ * up.
+ *
+ * EVENT_SWITCH is the final event of a leadership term's stream: it directs the receiving node to
+ * step up, and carries the term's counter high-water mark as a relay-integrity check, which the
+ * receiver's own counter must equal once it has drained the stream. Schema epochs and commit
+ * timestamps come from that one shared counter, so a commit's value always exceeds its table's
+ * create epoch.
+ */
+typedef enum { EVENT_CREATE, EVENT_DROP, EVENT_INSERT, EVENT_CKPT, EVENT_SWITCH } EVENT_TYPE;
 
 typedef struct {
     EVENT_TYPE type;
     uint32_t thread_id;
-    uint64_t epoch;
-    uint64_t commit_ts;
+    /*
+     * The event's value from the single monotonic allocator: the value whose completion the event
+     * represents. CREATE/DROP carry the schema epoch the operation publishes at; INSERT carries the
+     * commit timestamp (and the inserted rows are valued with it); EVENT_SWITCH carries the ending
+     * term's counter high-water mark, which the receiver's drained counter must match. Unused by
+     * EVENT_CKPT.
+     */
+    uint64_t event_ts;
     uint32_t key_min;
     uint32_t key_max;
     char uri[64];
@@ -106,26 +134,152 @@ typedef struct {
 typedef struct {
     TEST_OPTS *opts;
     TEST_ROLE role;
+    bool with_leader;   /* parent: the -r topology */
+    bool with_follower; /* parent: the -r topology */
+    uint32_t node_id;   /* this node's id (namespace, homes, records); parent: unused */
+    bool start_leader;  /* this node's parent-assigned starting role */
+    bool peer_alive;    /* this node has a live peer; cleared on pipe EOF/EPIPE */
     char home[PATH_MAX];
     char page_log_home[PATH_MAX];
     uint32_t nth;
     uint32_t pool_size;
-    uint32_t timeout;
-    KILL_MODE kill_mode; /* KILL_NONE runs the single-node scenario */
-    bool switch_mode;    /* single-node: random starting role, then a role switch mid-run */
+    uint32_t total_time;              /* -t: graceful stop after this many seconds */
+    uint32_t switch_interval;         /* -s: switch roles every N seconds; 0: never */
+    uint32_t kill_time[KILL_TARGETS]; /* -k [l|f]N: SIGKILL the target at N; 0: never */
     bool verify_only;
-    int pipe_read_fd;  /* -1 when single-node */
-    int pipe_write_fd; /* -1 when single-node */
+    int pipe_read_fd;       /* this node's in-pipe (peer's events); -1 when lone */
+    int pipe_write_fd;      /* this node's out-pipe (events to the peer); -1 when lone */
+    int self_pipe_read_fd;  /* this node's own event source; the generator writes it when */
+    int self_pipe_write_fd; /* leading, the reader drains it; process lifetime, never closed */
 } TEST_CONFIG;
+
+/*
+ * Per-worker single-producer/single-consumer event ring: the reader thread produces, the worker
+ * consumes. A full ring blocks the reader, which stops draining the source pipe and so
+ * backpressures the producer - the peer leader, or the node's own generator.
+ */
+#define EVQ_SIZE 256
+typedef struct {
+    SCHEMA_EVENT ev[EVQ_SIZE];
+    uint64_t head; /* consumer position; atomic access */
+    uint64_t tail; /* producer position; atomic access */
+} EVENT_QUEUE;
+
+/*
+ * Workload-engine state, one per node process, owned by node.c.
+ */
+typedef struct __workload_state {
+    TEST_CONFIG *cfg;    /* bound at creation */
+    WT_CONNECTION *conn; /* owned here; the control loop and the role transitions keep it
+                            current: a step-down closes it, a follower reopen replaces it */
+    /*
+     * This phase leads: the generator produces the workload, checkpoint events are produced rather
+     * than picked up, and every applied event is relayed to the peer. Fixed per phase.
+     */
+    bool leads;
+    bool stop_phase;        /* set to quiesce all worker threads between phases; atomic access */
+    bool reader_stop;       /* the engine directs the reader to exit; atomic access */
+    bool generator_stop;    /* the engine directs the generator to exit; atomic access */
+    bool handover_received; /* the term was handed over this phase; atomic access */
+    /*
+     * The highest schema epoch a completed checkpoint made durable, republished by the timestamp
+     * thread from the connection's last_disaggregated_schema_epoch. A dirty table's drop stays
+     * EBUSY until a checkpoint persists its data, and the event stream cannot be reordered, so an
+     * uncovered drop would wedge its worker (and, through the full queue, the reader and the
+     * checkpoints that would unwedge it). The generator therefore emits a DROP for a slot holding
+     * data only once its insert is at or below this value. Atomic access.
+     */
+    uint64_t ckpt_covered_ts;
+    uint32_t switch_gen; /* how many role transitions this node has completed */
+    /*
+     * Single monotonic allocator for schema epochs AND commit timestamps. One counter makes
+     * causality an ordering property: a commit into a table always draws a higher value than the
+     * table's create, so one stable frontier is consistent on both axes by construction. A follower
+     * advances it to every value it applies, and a node stepping up mid-test seeds it from the
+     * previous leader's high-water mark.
+     */
+    uint64_t current_ts;
+    uint32_t nth_workers;
+    /* Per-thread state: workers first, then the generator and timestamp threads. */
+    struct {
+        WT_RAND_STATE rnd; /* a worker's rnd drives its generated stream; owned by the generator */
+        EVENT_QUEUE evq;   /* this worker's inbound events */
+        bool busy;         /* the worker is mid-apply; atomic access */
+        /*
+         * The highest allocator value the thread has fully completed (published or committed). The
+         * thread's single in-flight operation always holds a higher value, so the minimum across
+         * all workers is a frontier with nothing unfinished at or below it; the timestamp thread
+         * sets the stable timestamp and stable schema epoch to that minimum.
+         */
+        uint64_t completed_ts;
+    } threads[MAX_TH + 2];
+    /*
+     * The generator's per-thread slot model, carried across phases so each leader phase resumes its
+     * own namespace where the last ended: whether the slot's table exists, and the commit timestamp
+     * of its insert, which a checkpoint must cover before the slot may be dropped. Zero means the
+     * table is clean (no insert), and a clean table can be dropped at any time.
+     */
+    bool table_exists[MAX_TH][MAX_POOL_SIZE];
+    uint64_t table_commit_ts[MAX_TH][MAX_POOL_SIZE];
+} WORKLOAD_STATE;
+
+/*
+ * The reader thread's checkpoint bookkeeping for one phase. Thread-local: it lives on the reader's
+ * stack and is handed to the role's checkpoint operation, so the engine holds no per-role state.
+ * Each field belongs to one role only.
+ */
+typedef struct {
+    WT_PAGE_LOG *page_log;       /* following: the page log checkpoints are picked up from */
+    bool picked_up;              /* following: the first pickup reported readiness */
+    struct timespec phase_start; /* leading: when the phase began, bounding the startup skip */
+    int produced;                /* leading: checkpoints produced so far */
+} CKPT_CTX;
+
+/*
+ * A node role, in the C flavor of a vtable: the node's single control loop (the state machine in
+ * node.c) runs the phases, and the role differences that are behavior rather than a choice of data
+ * dispatch through these operations. leave() steps out of the role once a switch is triggered and
+ * enter() completes the transition into it, both carrying the ending term's counter high-water
+ * mark; checkpoint() handles one checkpoint event, producing it or picking it up.
+ */
+typedef struct __node_role NODE_ROLE;
+struct __node_role {
+    const char *name;         /* also the disaggregated connection mode string */
+    const char *close_config; /* connection close configuration for a graceful stop */
+    bool leads;               /* this role generates events and checkpoints */
+    void (*leave)(WORKLOAD_STATE *state, uint64_t counter_hwm);
+    void (*enter)(WORKLOAD_STATE *state, uint64_t counter_hwm);
+    void (*checkpoint)(
+      WORKLOAD_STATE *state, WT_SESSION *session, CKPT_CTX *ckpt, const SCHEMA_EVENT *ev);
+};
+
+/* main.c */
+void println(const char *fmt, ...) WT_GCC_FUNC_DECL_ATTRIBUTE((format(printf, 1, 2)));
+uint64_t query_ts(WT_CONNECTION *conn, const char *name);
+void set_frontier(WT_CONNECTION *conn, uint64_t ts);
+
+/* leader.c: the leader specifics - checkpoint production and the role transitions. */
+extern const NODE_ROLE node_role_leader;
+
+/* follower.c: the follower specifics - checkpoint pickup and the role transitions. */
+extern const NODE_ROLE node_role_follower;
+void follower_adopt_latest(WORKLOAD_STATE *state);
 
 /* parent.c */
 void parent_main(TEST_CONFIG *cfg, const char *self_path);
 
-/* leader.c */
-void leader_main(TEST_CONFIG *cfg) WT_GCC_FUNC_DECL_ATTRIBUTE((noreturn));
-
-/* follower.c */
-void follower_main(TEST_CONFIG *cfg) WT_GCC_FUNC_DECL_ATTRIBUTE((noreturn));
+/* node.c: the generic node - control loop, connection, event pipe, and the workload engine. */
+int node_main(TEST_CONFIG *cfg);
+void node_open(TEST_CONFIG *cfg, const char *disagg_mode, WT_CONNECTION **connp);
+bool node_event_send(TEST_CONFIG *cfg, const SCHEMA_EVENT *ev);
+void disagg_opts_init(const TEST_CONFIG *cfg);
+WORKLOAD_STATE *workload_state_create(TEST_CONFIG *cfg);
+void workload_start(WORKLOAD_STATE *state, bool as_leader);
+void workload_stop(WORKLOAD_STATE *state);
+void workload_enqueue(WORKLOAD_STATE *state, const SCHEMA_EVENT *ev);
+void workload_drain_barrier(WORKLOAD_STATE *state);
+void workload_seed_counter(WORKLOAD_STATE *state, uint64_t ts);
 
 /* verify.c */
-void verify_schema_state(WT_CONNECTION *conn, const TEST_CONFIG *cfg, const char *records_base);
+void verify_schema_state(WT_CONNECTION *conn, const TEST_CONFIG *cfg);
+void verify_relay_prefix(const TEST_CONFIG *cfg);

--- a/test/csuite/schema_disagg_abort/schema_disagg_abort.h
+++ b/test/csuite/schema_disagg_abort/schema_disagg_abort.h
@@ -42,17 +42,9 @@
 
 /* Tunables. */
 #define MAX_CKPT_INVL 4
-/*
- * One create in INSERT_ODDS takes data. Only a dirty table's drop has to wait for the checkpoint
- * that persists its data, so keeping inserts rare lets the schema churn run at full speed and
- * leaves a handful of gated slots per checkpoint interval to exercise the waiting path.
- */
 #define INSERT_ODDS 64
-/*
- * The value a node enters the "epoch world" at. Publishing panics while the stable schema epoch is
- * unset, so every connection sets the frontier before anything publishes, and the allocator starts
- * from the same value: publish also requires the epoch to be above the stable one.
- */
+#define GEN_APPLY_RATE_FLOOR 30 /* generator: applied values/second, the multi-node worst case */
+#define GEN_LEAD_MIN 64         /* generator: lead floor, so the workers stay fed */
 #define SCHEMA_EPOCH_BOOTSTRAP 1
 #define MAX_NODES 2
 #define MAX_POOL_SIZE 64
@@ -73,12 +65,12 @@
 #define SCHEMA_TABLE_FMT "table:schema_%" PRIu32 "_%" PRIu32 "_%" PRIu32 /* node, thread, slot */
 
 /*
- * Per-node, per-thread record files: "<records dir>/node<node>-<kind>-<thread>". A node's "schema"
- * files log the operations it originated while leading; its "relay" files log the peer's events it
- * applied while following.
+ * Per-node, per-thread record files: "<records dir>/node<node>-<role>-<thread>", named for the role
+ * the node held when it wrote them. Its "leader" files log the operations it originated; its
+ * "follower" files log the peer's events it applied.
  */
-#define SCHEMA_RECORDS_FILE RECORDS_DIR DIR_DELIM_STR "node%" PRIu32 "-schema-%" PRIu32
-#define RELAY_RECORDS_FILE RECORDS_DIR DIR_DELIM_STR "node%" PRIu32 "-relay-%" PRIu32
+#define LEADER_RECORDS_FILE RECORDS_DIR DIR_DELIM_STR "node%" PRIu32 "-leader-%" PRIu32
+#define FOLLOWER_RECORDS_FILE RECORDS_DIR DIR_DELIM_STR "node%" PRIu32 "-follower-%" PRIu32
 
 /*
  * Sentinels the nodes and the parent coordinate through. The switch request is consumed by the
@@ -107,7 +99,7 @@ typedef enum { KILL_LONE = 0, KILL_LEADER, KILL_FOLLOWER } KILL_TARGET;
  * up.
  *
  * EVENT_SWITCH is the final event of a leadership term's stream: it directs the receiving node to
- * step up, and carries the term's counter high-water mark as a relay-integrity check, which the
+ * step up, and carries the term's final counter value as a relay-integrity check, which the
  * receiver's own counter must equal once it has drained the stream. Schema epochs and commit
  * timestamps come from that one shared counter, so a commit's value always exceeds its table's
  * create epoch.
@@ -121,7 +113,7 @@ typedef struct {
      * The event's value from the single monotonic allocator: the value whose completion the event
      * represents. CREATE/DROP carry the schema epoch the operation publishes at; INSERT carries the
      * commit timestamp (and the inserted rows are valued with it); EVENT_SWITCH carries the ending
-     * term's counter high-water mark, which the receiver's drained counter must match. Unused by
+     * term's final counter value, which the receiver's drained counter must match. Unused by
      * EVENT_CKPT.
      */
     uint64_t event_ts;
@@ -177,6 +169,7 @@ typedef struct __workload_state {
      * than picked up, and every applied event is relayed to the peer. Fixed per phase.
      */
     bool leads;
+    bool generates;         /* this phase generates events into the self-pipe; fixed per phase */
     bool stop_phase;        /* set to quiesce all worker threads between phases; atomic access */
     bool reader_stop;       /* the engine directs the reader to exit; atomic access */
     bool generator_stop;    /* the engine directs the generator to exit; atomic access */
@@ -196,9 +189,15 @@ typedef struct __workload_state {
      * causality an ordering property: a commit into a table always draws a higher value than the
      * table's create, so one stable frontier is consistent on both axes by construction. A follower
      * advances it to every value it applies, and a node stepping up mid-test seeds it from the
-     * previous leader's high-water mark.
+     * previous leader's final counter.
      */
     uint64_t current_ts;
+    /*
+     * In flight is emitted minus applied. Counted rather than derived from the completed frontier:
+     * a worker whose picks are all gated never reports one.
+     */
+    uint64_t emitted; /* generator only */
+    uint64_t applied; /* atomic access: every worker adds to it */
     uint32_t nth_workers;
     /* Per-thread state: workers first, then the generator and timestamp threads. */
     struct {
@@ -239,16 +238,16 @@ typedef struct {
  * A node role, in the C flavor of a vtable: the node's single control loop (the state machine in
  * node.c) runs the phases, and the role differences that are behavior rather than a choice of data
  * dispatch through these operations. leave() steps out of the role once a switch is triggered and
- * enter() completes the transition into it, both carrying the ending term's counter high-water
- * mark; checkpoint() handles one checkpoint event, producing it or picking it up.
+ * enter() completes the transition into it, both carrying the ending term's final counter mark;
+ * checkpoint() handles one checkpoint event, producing it or picking it up.
  */
 typedef struct __node_role NODE_ROLE;
 struct __node_role {
     const char *name;         /* also the disaggregated connection mode string */
     const char *close_config; /* connection close configuration for a graceful stop */
     bool leads;               /* this role generates events and checkpoints */
-    void (*leave)(WORKLOAD_STATE *state, uint64_t counter_hwm);
-    void (*enter)(WORKLOAD_STATE *state, uint64_t counter_hwm);
+    void (*leave)(WORKLOAD_STATE *state, uint64_t final_counter);
+    void (*enter)(WORKLOAD_STATE *state, uint64_t final_counter);
     void (*checkpoint)(
       WORKLOAD_STATE *state, WT_SESSION *session, CKPT_CTX *ckpt, const SCHEMA_EVENT *ev);
 };

--- a/test/csuite/schema_disagg_abort/schema_disagg_abort.h
+++ b/test/csuite/schema_disagg_abort/schema_disagg_abort.h
@@ -199,11 +199,10 @@ typedef struct __workload_state {
     uint64_t emitted; /* generator only */
     uint64_t applied; /* atomic access: every worker adds to it */
     uint32_t nth_workers;
-    /* Per-thread state: workers first, then the generator and timestamp threads. */
+    /* Per-worker state, owned by worker.c; the queue is filled by the reader. */
     struct {
-        WT_RAND_STATE rnd; /* a worker's rnd drives its generated stream; owned by the generator */
-        EVENT_QUEUE evq;   /* this worker's inbound events */
-        bool busy;         /* the worker is mid-apply; atomic access */
+        EVENT_QUEUE evq; /* this worker's inbound events */
+        bool busy;       /* the worker is mid-apply; atomic access */
         /*
          * The highest allocator value the thread has fully completed (published or committed). The
          * thread's single in-flight operation always holds a higher value, so the minimum across
@@ -211,7 +210,13 @@ typedef struct __workload_state {
          * sets the stable timestamp and stable schema epoch to that minimum.
          */
         uint64_t completed_ts;
-    } threads[MAX_TH + 2];
+    } workers[MAX_TH];
+    /*
+     * The generator's random streams, owned by generator.c: one per worker, driving the stream of
+     * operations generated for that worker, plus its own pacing stream one past them. Reseeded by
+     * workload_start on every phase, generating or not, so they stay in step across role switches.
+     */
+    WT_RAND_STATE gen_rnd[MAX_TH + 1];
     /*
      * The generator's per-thread slot model, carried across phases so each leader phase resumes its
      * own namespace where the last ended: whether the slot's table exists, and the commit timestamp
@@ -267,17 +272,42 @@ void follower_adopt_latest(WORKLOAD_STATE *state);
 /* parent.c */
 void parent_main(TEST_CONFIG *cfg, const char *self_path);
 
-/* node.c: the generic node - control loop, connection, event pipe, and the workload engine. */
+/*
+ * node.c: the generic node - the control loop and role state machine, the connection, the workload
+ * engine's state and per-phase lifecycle, the worker event queues, and the timestamp thread.
+ */
 int node_main(TEST_CONFIG *cfg);
 void node_open(TEST_CONFIG *cfg, const char *disagg_mode, WT_CONNECTION **connp);
-bool node_event_send(TEST_CONFIG *cfg, const SCHEMA_EVENT *ev);
 void disagg_opts_init(const TEST_CONFIG *cfg);
+bool node_switch_request_consume(void);
 WORKLOAD_STATE *workload_state_create(TEST_CONFIG *cfg);
 void workload_start(WORKLOAD_STATE *state, bool as_leader);
 void workload_stop(WORKLOAD_STATE *state);
+bool workload_running(WORKLOAD_STATE *state);
 void workload_enqueue(WORKLOAD_STATE *state, const SCHEMA_EVENT *ev);
+bool workload_dequeue(WORKLOAD_STATE *state, uint32_t thread_index, SCHEMA_EVENT *ev);
+bool workload_queue_empty(WORKLOAD_STATE *state, uint32_t thread_index);
 void workload_drain_barrier(WORKLOAD_STATE *state);
 void workload_seed_counter(WORKLOAD_STATE *state, uint64_t ts);
+void workload_counter_advance(WORKLOAD_STATE *state, uint64_t v);
+
+/* event_pipe.c: the event framing every pipe shares. */
+bool node_event_send(TEST_CONFIG *cfg, const SCHEMA_EVENT *ev);
+void pipe_event_write(int fd, const SCHEMA_EVENT *ev);
+bool pipe_event_read(int fd, SCHEMA_EVENT *ev);
+bool pipe_wait_readable(int fd);
+
+/* generator.c: the generator stage - the node's command stream, and all switch triggering. */
+void node_generator_start(WORKLOAD_STATE *state);
+void node_generator_stop(WORKLOAD_STATE *state);
+
+/* reader.c: the reader stage - demuxing the source pipe to the workers. */
+void node_reader_start(WORKLOAD_STATE *state);
+void node_reader_stop(WORKLOAD_STATE *state);
+
+/* worker.c: the worker stage - executing events and recording them. */
+void node_workers_start(WORKLOAD_STATE *state);
+void node_workers_join(WORKLOAD_STATE *state);
 
 /* verify.c */
 void verify_schema_state(WT_CONNECTION *conn, const TEST_CONFIG *cfg);

--- a/test/csuite/schema_disagg_abort/schema_disagg_abort.h
+++ b/test/csuite/schema_disagg_abort/schema_disagg_abort.h
@@ -26,12 +26,27 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
+/*
+ * Disaggregated schema epoch crash recovery test.
+ *
+ * The test binary runs in one of three roles, each in its own process:
+ *
+ *   parent   - orchestrator and verifier. Spawns the children, kills them per the configured mode,
+ *              then reopens the surviving state and verifies it against the record files.
+ *   leader   - runs schema worker threads that create, drop, publish, and populate layered tables
+ *              while checkpointing, until killed.
+ *   follower - tracks the leader through schema events and checkpoint pickups; steps up when the
+ *              leader dies in kill-leader mode.
+ *
+ * The children are started by re-spawning this binary with an internal role option, so no state is
+ * inherited by forking: everything a child needs travels through the command line. The leader
+ * relays events to the follower over a pipe whose descriptor numbers are likewise passed on the
+ * command line.
+ */
+
 #pragma once
 
 #include "test_util.h"
-
-#include <sys/wait.h>
-#include <signal.h>
 
 /* Tunables. */
 #define MAX_CKPT_INVL 4
@@ -46,62 +61,71 @@
 /* URI / file name patterns. */
 #define DATA_KEY_MIN 0
 #define DATA_KEY_MAX 9
-#define READY_FILE "child_ready"
+#define LEADER_READY_FILE "leader_ready"
+#define SWITCH_DONE_FILE "switch_done" /* switch mode: the role transition has completed */
 #define SCHEMA_TABLE_FMT "table:schema_%u_%u"
-#define SCHEMA_RECORDS_FILE RECORDS_DIR DIR_DELIM_STR "schema-%" PRIu32
+
+/*
+ * Per-thread record files: "<records dir>/<base>-<thread>". The single-format/base-name split keeps
+ * every snprintf format a literal so the compiler can check it.
+ */
+#define RECORDS_FILE_FMT RECORDS_DIR DIR_DELIM_STR "%s-%" PRIu32
+#define SCHEMA_RECORDS_BASE "schema"
+#define SCHEMA_RECORDS_FILE RECORDS_DIR DIR_DELIM_STR SCHEMA_RECORDS_BASE "-%" PRIu32
+
+/* Multi-node mode: follower home, sentinels and record files. */
+#define FOLLOWER_HOME_DIR "WT_FOLLOWER"
+#define FOLLOWER_READY_FILE "follower_ready"
+#define FOLLOWER_STEPPED_UP_FILE "follower_stepped_up"
+#define FOLLOWER_RECORDS_BASE "follower"
+#define FOLLOWER_RECORDS_FILE RECORDS_DIR DIR_DELIM_STR FOLLOWER_RECORDS_BASE "-%" PRIu32
 
 /* Connection config. */
 #define ENV_CONFIG_DEF "create,statistics=(all),statistics_log=(json,on_close,wait=1)"
 
-/* Test-wide configuration passed from parent to child and to the verifier. */
+/* Which process this instance of the binary is. */
+typedef enum { ROLE_PARENT = 0, ROLE_LEADER, ROLE_FOLLOWER } TEST_ROLE;
+
+/* Which child processes the parent kills in multi-node mode. */
+typedef enum { KILL_NONE = 0, KILL_LEADER, KILL_FOLLOWER, KILL_BOTH } KILL_MODE;
+
+/* Schema event relayed from the leader to the follower over the pipe. */
+typedef enum { EVENT_CREATE, EVENT_DROP, EVENT_INSERT, EVENT_CKPT } EVENT_TYPE;
+
+typedef struct {
+    EVENT_TYPE type;
+    uint32_t thread_id;
+    uint64_t epoch;
+    uint64_t commit_ts;
+    uint32_t key_min;
+    uint32_t key_max;
+    char uri[64];
+} SCHEMA_EVENT;
+
+/* Test-wide configuration, built from the command line by every role independently. */
 typedef struct {
     TEST_OPTS *opts;
-    char home[1024];
+    TEST_ROLE role;
+    char home[PATH_MAX];
     char page_log_home[PATH_MAX];
     uint32_t nth;
     uint32_t pool_size;
-    bool switch_mode; /* enable role-switch phase */
+    uint32_t timeout;
+    KILL_MODE kill_mode; /* KILL_NONE runs the single-node scenario */
+    bool switch_mode;    /* single-node: random starting role, then a role switch mid-run */
+    bool verify_only;
+    int pipe_read_fd;  /* -1 when single-node */
+    int pipe_write_fd; /* -1 when single-node */
 } TEST_CONFIG;
 
-/* Forward declaration: WORKLOAD_STATE holds a pointer into the THREAD_DATA array. */
-typedef struct __thread_data THREAD_DATA;
+/* parent.c */
+void parent_main(TEST_CONFIG *cfg, const char *self_path);
 
-/* Global state shared by all workload threads. */
-typedef struct {
-    volatile bool stable_set; /* set once the stable timestamp is first advanced */
-    volatile bool stop_phase; /* set to quiesce all worker threads cleanly between phases */
-    volatile bool
-      ckpt_enabled; /* leader phase checkpoints; follower phase only advances the epoch */
-    /*
-     * Monotonic allocators. Every publish and commit must draw a value above the global stable
-     * epoch and timestamp, so these only ever increase.
-     */
-    uint64_t next_epoch;
-    uint64_t next_commit_ts;
-    THREAD_DATA *workers; /* schema worker thread data array (length nth_workers) */
-    uint32_t nth_workers;
-} WORKLOAD_STATE;
+/* leader.c */
+void leader_main(TEST_CONFIG *cfg) WT_GCC_FUNC_DECL_ATTRIBUTE((noreturn));
 
-/* Per-thread argument. */
-struct __thread_data {
-    TEST_CONFIG *cfg;
-    WT_CONNECTION *conn;
-    WORKLOAD_STATE *state;
-    uint32_t info;
-    WT_RAND_STATE rnd;
-    /*
-     * The timestamp thread takes the minimum of each field across all threads to set the global
-     * stable epoch and stable timestamp. stable_ready_ts trails the thread's commits until each
-     * insert's table epoch is stable.
-     */
-    uint64_t published_epoch;
-    uint64_t stable_ready_ts;
-    /* Seeded from the caller and copied back so a role switch carries table state across phases. */
-    bool table_exists[MAX_POOL_SIZE];
-};
-
-/* workload.c */
-void run_workload(TEST_CONFIG *) WT_GCC_FUNC_DECL_ATTRIBUTE((noreturn));
+/* follower.c */
+void follower_main(TEST_CONFIG *cfg) WT_GCC_FUNC_DECL_ATTRIBUTE((noreturn));
 
 /* verify.c */
-void verify_schema_state(WT_CONNECTION *conn, TEST_CONFIG *cfg);
+void verify_schema_state(WT_CONNECTION *conn, const TEST_CONFIG *cfg, const char *records_base);

--- a/test/csuite/schema_disagg_abort/smoke.sh
+++ b/test/csuite/schema_disagg_abort/smoke.sh
@@ -4,27 +4,61 @@ set -e
 
 # Smoke-test schema-disagg-abort as part of running "make check".
 
+# The build directory holds the PALite extension the test loads. The cmake build can pass it in
+# with -b; otherwise it is derived from where the binary sits in the build tree.
+build_dir=
+while getopts ":b:" opt; do
+    case $opt in
+        b) build_dir=$OPTARG ;;
+    esac
+done
+shift $(( OPTIND - 1 ))
+
 if [ -n "$1" ]
 then
+    # If the test binary is passed in manually.
     test_bin=$1
 else
+    # If $binary_dir isn't set, default to using the build directory this script resides under.
+    # Our CMake build syncs a copy of this script next to the binary, so running that copy works;
+    # the copy in the source tree has no binary beside it and needs the path passed in.
     binary_dir=${binary_dir:-`dirname $0`}
     test_bin=$binary_dir/test_schema_disagg_abort
 fi
 
-# Resolve the build directory (two levels up from the test binary).
-build_dir=$(cd "$(dirname "$test_bin")/../../../" && pwd)
+if [ ! -x "$test_bin" ]
+then
+    echo "$0: no test binary at \"$test_bin\"." >&2
+    echo "Run the copy of this script that cmake put in the build directory, or name the binary:" >&2
+    echo "    sh $0 <build>/test/csuite/schema_disagg_abort/test_schema_disagg_abort" >&2
+    exit 1
+fi
 
-$TEST_WRAPPER "$test_bin" -b "$build_dir" -t 10 -T 2 -h WT_TEST.schema_disagg_abort.t2
-$TEST_WRAPPER "$test_bin" -b "$build_dir" -t 10 -T 4 -h WT_TEST.schema_disagg_abort.t4
-$TEST_WRAPPER "$test_bin" -b "$build_dir" -t 10 -T 2 -s 4 -h WT_TEST.schema_disagg_abort.s4
-$TEST_WRAPPER "$test_bin" -b "$build_dir" -t 10 -T 2 -s 16 -h WT_TEST.schema_disagg_abort.s16
+# Three levels up from the binary in the build tree.
+[ -n "$build_dir" ] || build_dir=$(cd "$(dirname "$test_bin")/../../.." && pwd)
 
-# Multi-node: a follower tracks the leader via checkpoint pickup, then one or both nodes die.
-$TEST_WRAPPER "$test_bin" -b "$build_dir" -t 10 -T 2 -k l -h WT_TEST.schema_disagg_abort.kl
-$TEST_WRAPPER "$test_bin" -b "$build_dir" -t 10 -T 2 -k f -h WT_TEST.schema_disagg_abort.kf
-$TEST_WRAPPER "$test_bin" -b "$build_dir" -t 10 -T 2 -k b -h WT_TEST.schema_disagg_abort.kb
+# Single-node graceful runs.
+$TEST_WRAPPER "$test_bin" -b "$build_dir" -r l -t 10 -T 2 -h WT_TEST.schema_disagg_abort.l
+$TEST_WRAPPER "$test_bin" -b "$build_dir" -r l -t 10 -T 4 -h WT_TEST.schema_disagg_abort.l4
+$TEST_WRAPPER "$test_bin" -b "$build_dir" -r l -t 10 -T 2 -u 4 -h WT_TEST.schema_disagg_abort.u4
 
-# Switch mode: the crash always lands in phase 2, shallow or deep depending on the timeout.
-$TEST_WRAPPER "$test_bin" -b "$build_dir" -t 5  -T 2 -m -h WT_TEST.schema_disagg_abort.switch_short
-$TEST_WRAPPER "$test_bin" -b "$build_dir" -t 25 -T 2 -m -h WT_TEST.schema_disagg_abort.switch_long
+# A lone follower has no event source and stays idle; verification finds an empty run.
+$TEST_WRAPPER "$test_bin" -b "$build_dir" -r f -t 10 -T 2 -h WT_TEST.schema_disagg_abort.f
+
+# Single-node role switches every 5 seconds, ending gracefully.
+$TEST_WRAPPER "$test_bin" -b "$build_dir" -r l -s 5 -t 20 -T 2 -h WT_TEST.schema_disagg_abort.ls
+
+# Single-node crash: kill the lone node mid-run.
+$TEST_WRAPPER "$test_bin" -b "$build_dir" -r l -k 8 -t 10 -T 2 -h WT_TEST.schema_disagg_abort.lk
+
+# Two nodes: the follower applies the leader's events and picks up checkpoints.
+$TEST_WRAPPER "$test_bin" -b "$build_dir" -r lf -t 10 -T 2 -h WT_TEST.schema_disagg_abort.lf
+$TEST_WRAPPER "$test_bin" -b "$build_dir" -r lf -k l8 -t 12 -T 2 -h WT_TEST.schema_disagg_abort.kl
+$TEST_WRAPPER "$test_bin" -b "$build_dir" -r lf -k f8 -t 12 -T 2 -h WT_TEST.schema_disagg_abort.kf
+$TEST_WRAPPER "$test_bin" -b "$build_dir" -r lf -k l8 -k f8 -t 12 -T 2 -h WT_TEST.schema_disagg_abort.kb
+
+# Two nodes with role swaps; after a kill the lone survivor still switches by sentinel. A step-up
+# still trips the stale-metadata paths, so these two are EXPECTED to fail until
+# FIXME-WT-18068 / FIXME-WT-17746 land, and pass afterwards.
+$TEST_WRAPPER "$test_bin" -b "$build_dir" -r lf -s 5 -t 20 -T 2 -h WT_TEST.schema_disagg_abort.lfs
+$TEST_WRAPPER "$test_bin" -b "$build_dir" -r lf -s 6 -k l9 -t 20 -T 2 -h WT_TEST.schema_disagg_abort.lfsk

--- a/test/csuite/schema_disagg_abort/smoke.sh
+++ b/test/csuite/schema_disagg_abort/smoke.sh
@@ -20,6 +20,11 @@ $TEST_WRAPPER "$test_bin" -b "$build_dir" -t 10 -T 4 -h WT_TEST.schema_disagg_ab
 $TEST_WRAPPER "$test_bin" -b "$build_dir" -t 10 -T 2 -s 4 -h WT_TEST.schema_disagg_abort.s4
 $TEST_WRAPPER "$test_bin" -b "$build_dir" -t 10 -T 2 -s 16 -h WT_TEST.schema_disagg_abort.s16
 
-# Switch-mode: the crash always lands in phase 2, shallow or deep depending on the timeout.
+# Multi-node: a follower tracks the leader via checkpoint pickup, then one or both nodes die.
+$TEST_WRAPPER "$test_bin" -b "$build_dir" -t 10 -T 2 -k l -h WT_TEST.schema_disagg_abort.kl
+$TEST_WRAPPER "$test_bin" -b "$build_dir" -t 10 -T 2 -k f -h WT_TEST.schema_disagg_abort.kf
+$TEST_WRAPPER "$test_bin" -b "$build_dir" -t 10 -T 2 -k b -h WT_TEST.schema_disagg_abort.kb
+
+# Switch mode: the crash always lands in phase 2, shallow or deep depending on the timeout.
 $TEST_WRAPPER "$test_bin" -b "$build_dir" -t 5  -T 2 -m -h WT_TEST.schema_disagg_abort.switch_short
 $TEST_WRAPPER "$test_bin" -b "$build_dir" -t 25 -T 2 -m -h WT_TEST.schema_disagg_abort.switch_long

--- a/test/csuite/schema_disagg_abort/smoke.sh
+++ b/test/csuite/schema_disagg_abort/smoke.sh
@@ -42,8 +42,11 @@ $TEST_WRAPPER "$test_bin" -b "$build_dir" -r l -t 10 -T 2 -h WT_TEST.schema_disa
 $TEST_WRAPPER "$test_bin" -b "$build_dir" -r l -t 10 -T 4 -h WT_TEST.schema_disagg_abort.l4
 $TEST_WRAPPER "$test_bin" -b "$build_dir" -r l -t 10 -T 2 -u 4 -h WT_TEST.schema_disagg_abort.u4
 
-# A lone follower has no event source and stays idle; verification finds an empty run.
+# A lone follower generates its own workload and never checkpoints, so nothing becomes durable; the
+# second run then steps up over the operations it accumulated, the way a fresh node bootstraps its
+# own tables before taking leadership.
 $TEST_WRAPPER "$test_bin" -b "$build_dir" -r f -t 10 -T 2 -h WT_TEST.schema_disagg_abort.f
+$TEST_WRAPPER "$test_bin" -b "$build_dir" -r f -s 6 -t 18 -T 2 -h WT_TEST.schema_disagg_abort.fs
 
 # Single-node role switches every 5 seconds, ending gracefully.
 $TEST_WRAPPER "$test_bin" -b "$build_dir" -r l -s 5 -t 20 -T 2 -h WT_TEST.schema_disagg_abort.ls
@@ -57,8 +60,6 @@ $TEST_WRAPPER "$test_bin" -b "$build_dir" -r lf -k l8 -t 12 -T 2 -h WT_TEST.sche
 $TEST_WRAPPER "$test_bin" -b "$build_dir" -r lf -k f8 -t 12 -T 2 -h WT_TEST.schema_disagg_abort.kf
 $TEST_WRAPPER "$test_bin" -b "$build_dir" -r lf -k l8 -k f8 -t 12 -T 2 -h WT_TEST.schema_disagg_abort.kb
 
-# Two nodes with role swaps; after a kill the lone survivor still switches by sentinel. A step-up
-# still trips the stale-metadata paths, so these two are EXPECTED to fail until
-# FIXME-WT-18068 / FIXME-WT-17746 land, and pass afterwards.
+# Two nodes with role swaps; after a kill the lone survivor still switches by sentinel.
 $TEST_WRAPPER "$test_bin" -b "$build_dir" -r lf -s 5 -t 20 -T 2 -h WT_TEST.schema_disagg_abort.lfs
 $TEST_WRAPPER "$test_bin" -b "$build_dir" -r lf -s 6 -k l9 -t 20 -T 2 -h WT_TEST.schema_disagg_abort.lfsk

--- a/test/csuite/schema_disagg_abort/subproc.c
+++ b/test/csuite/schema_disagg_abort/subproc.c
@@ -1,29 +1,9 @@
 /*-
- * Public Domain 2014-present MongoDB, Inc.
- * Public Domain 2008-2014 WiredTiger, Inc.
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
  *
- * This is free and unencumbered software released into the public domain.
- *
- * Anyone is free to copy, modify, publish, use, compile, sell, or
- * distribute this software, either in source code form or as a compiled
- * binary, for any purpose, commercial or non-commercial, and by any
- * means.
- *
- * In jurisdictions that recognize copyright laws, the author or authors
- * of this software dedicate any and all copyright interest in the
- * software to the public domain. We make this dedication for the benefit
- * of the public at large and to the detriment of our heirs and
- * successors. We intend this dedication to be an overt act of
- * relinquishment in perpetuity of all present and future rights to this
- * software under copyright law.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
- * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
- * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * See the file LICENSE for redistribution information.
  */
 
 #include "test_util.h"
@@ -66,15 +46,22 @@ subproc_self_path(const char *argv0, char *buf, size_t buf_size)
 
 /*
  * subproc_spawn --
- *     Start a child process running the given binary.
+ *     Start a child process running the given binary, closing the given descriptors in the child.
  */
 void
-subproc_spawn(SUBPROC *proc, const char *who, const char *path, char *const argv[])
+subproc_spawn(SUBPROC *proc, const char *who, const char *path, char *const argv[],
+  const int *close_fds, size_t nclose)
 {
     memset(proc, 0, sizeof(*proc));
     proc->who = who;
 
-    const int ret = posix_spawn(&proc->pid, path, NULL, NULL, argv, environ);
+    posix_spawn_file_actions_t actions;
+    testutil_assert(posix_spawn_file_actions_init(&actions) == 0);
+    for (size_t i = 0; i < nclose; i++)
+        testutil_assert(posix_spawn_file_actions_addclose(&actions, close_fds[i]) == 0);
+
+    const int ret = posix_spawn(&proc->pid, path, &actions, NULL, argv, environ);
+    testutil_assert(posix_spawn_file_actions_destroy(&actions) == 0);
     if (ret != 0)
         testutil_die(ret, "posix_spawn %s: %s", who, path);
 }
@@ -108,15 +95,15 @@ subproc_decode(int status, int *codep)
 }
 
 /*
- * subproc_poll --
- *     Non-blocking status probe.
+ * subproc_reap --
+ *     Collect a child's termination status, optionally blocking until it terminates.
  */
-SUBPROC_STATUS
-subproc_poll(SUBPROC *proc, int *codep)
+static SUBPROC_STATUS
+subproc_reap(SUBPROC *proc, int *codep, bool block)
 {
     if (!proc->reaped) {
         int status;
-        const pid_t got = waitpid(proc->pid, &status, WNOHANG);
+        const pid_t got = waitpid(proc->pid, &status, block ? 0 : WNOHANG);
         testutil_assert_errno(got != -1);
         if (got == 0)
             return (SUBPROC_RUNNING);
@@ -127,17 +114,21 @@ subproc_poll(SUBPROC *proc, int *codep)
 }
 
 /*
+ * subproc_poll --
+ *     Non-blocking status probe.
+ */
+SUBPROC_STATUS
+subproc_poll(SUBPROC *proc, int *codep)
+{
+    return (subproc_reap(proc, codep, false));
+}
+
+/*
  * subproc_wait --
  *     Blocking wait for termination.
  */
 SUBPROC_STATUS
 subproc_wait(SUBPROC *proc, int *codep)
 {
-    if (!proc->reaped) {
-        int status;
-        testutil_assert_errno(waitpid(proc->pid, &status, 0) != -1);
-        proc->reaped = true;
-        proc->status = status;
-    }
-    return (subproc_decode(proc->status, codep));
+    return (subproc_reap(proc, codep, true));
 }

--- a/test/csuite/schema_disagg_abort/subproc.c
+++ b/test/csuite/schema_disagg_abort/subproc.c
@@ -1,0 +1,143 @@
+/*-
+ * Public Domain 2014-present MongoDB, Inc.
+ * Public Domain 2008-2014 WiredTiger, Inc.
+ *
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include "test_util.h"
+
+#include "subproc.h"
+
+#include <signal.h>
+#include <spawn.h>
+#include <sys/wait.h>
+
+#if !defined(__GLIBC__)
+/* POSIX specifies the symbol but not a header declaration; GLIBC declares it in <unistd.h>. */
+extern char **environ;
+#endif
+
+/*
+ * subproc_pipe --
+ *     Create the leader-to-follower event pipe.
+ */
+void
+subproc_pipe(int fds[2])
+{
+    testutil_assert_errno(pipe(fds) == 0);
+}
+
+/*
+ * subproc_self_path --
+ *     Resolve the running binary's path for re-spawning.
+ */
+void
+subproc_self_path(const char *argv0, char *buf, size_t buf_size)
+{
+    char resolved[PATH_MAX];
+
+    /* argv0 works as-is when realpath fails (e.g., the binary was found via PATH). */
+    const char *path = realpath(argv0, resolved) != NULL ? resolved : argv0;
+    testutil_assert(strlen(path) < buf_size);
+    strcpy(buf, path);
+}
+
+/*
+ * subproc_spawn --
+ *     Start a child process running the given binary.
+ */
+void
+subproc_spawn(SUBPROC *proc, const char *who, const char *path, char *const argv[])
+{
+    memset(proc, 0, sizeof(*proc));
+    proc->who = who;
+
+    const int ret = posix_spawn(&proc->pid, path, NULL, NULL, argv, environ);
+    if (ret != 0)
+        testutil_die(ret, "posix_spawn %s: %s", who, path);
+}
+
+/*
+ * subproc_kill --
+ *     Terminate a child abruptly, with no chance for cleanup.
+ */
+void
+subproc_kill(SUBPROC *proc)
+{
+    testutil_assertfmt(!proc->reaped, "%s: killing an already reaped child", proc->who);
+    if (kill(proc->pid, SIGKILL) != 0)
+        testutil_die(errno, "kill %s", proc->who);
+}
+
+/*
+ * subproc_decode --
+ *     Translate a raw wait status into the portable status/code pair.
+ */
+static SUBPROC_STATUS
+subproc_decode(int status, int *codep)
+{
+    if (WIFEXITED(status)) {
+        *codep = WEXITSTATUS(status);
+        return (SUBPROC_EXITED);
+    }
+    testutil_assert(WIFSIGNALED(status));
+    *codep = WTERMSIG(status);
+    return (SUBPROC_KILLED);
+}
+
+/*
+ * subproc_poll --
+ *     Non-blocking status probe.
+ */
+SUBPROC_STATUS
+subproc_poll(SUBPROC *proc, int *codep)
+{
+    if (!proc->reaped) {
+        int status;
+        const pid_t got = waitpid(proc->pid, &status, WNOHANG);
+        testutil_assert_errno(got != -1);
+        if (got == 0)
+            return (SUBPROC_RUNNING);
+        proc->reaped = true;
+        proc->status = status;
+    }
+    return (subproc_decode(proc->status, codep));
+}
+
+/*
+ * subproc_wait --
+ *     Blocking wait for termination.
+ */
+SUBPROC_STATUS
+subproc_wait(SUBPROC *proc, int *codep)
+{
+    if (!proc->reaped) {
+        int status;
+        testutil_assert_errno(waitpid(proc->pid, &status, 0) != -1);
+        proc->reaped = true;
+        proc->status = status;
+    }
+    return (subproc_decode(proc->status, codep));
+}

--- a/test/csuite/schema_disagg_abort/subproc.h
+++ b/test/csuite/schema_disagg_abort/subproc.h
@@ -1,0 +1,74 @@
+/*-
+ * Public Domain 2014-present MongoDB, Inc.
+ * Public Domain 2008-2014 WiredTiger, Inc.
+ *
+ * This is free and unencumbered software released into the public domain.
+ *
+ * Anyone is free to copy, modify, publish, use, compile, sell, or
+ * distribute this software, either in source code form or as a compiled
+ * binary, for any purpose, commercial or non-commercial, and by any
+ * means.
+ *
+ * In jurisdictions that recognize copyright laws, the author or authors
+ * of this software dedicate any and all copyright interest in the
+ * software to the public domain. We make this dedication for the benefit
+ * of the public at large and to the detriment of our heirs and
+ * successors. We intend this dedication to be an overt act of
+ * relinquishment in perpetuity of all present and future rights to this
+ * software under copyright law.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/*
+ * Minimal child-process layer built on spawn-style creation, chosen so a Windows port only has to
+ * substitute the CRT near-equivalents (_spawnv, _pipe, _cwait/TerminateProcess) inside subproc.c
+ * without touching the callers.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <sys/types.h>
+
+typedef struct {
+    const char *who; /* Child's role name for diagnostics; NULL marks an unspawned slot. */
+    pid_t pid;
+    bool reaped;
+    int status; /* Raw wait status, valid once reaped. */
+} SUBPROC;
+
+/* Fixed slots for the children a test run can have. */
+#define SUBPROC_LEADER 0
+#define SUBPROC_FOLLOWER 1
+#define SUBPROC_SLOTS 2
+
+typedef enum {
+    SUBPROC_RUNNING,
+    SUBPROC_EXITED, /* Normal exit; code is the exit status. */
+    SUBPROC_KILLED  /* Abnormal termination; code is the signal number. */
+} SUBPROC_STATUS;
+
+/* Create the leader-to-follower event pipe; fds[0] is the read end. */
+void subproc_pipe(int fds[2]);
+
+/* Resolve the running binary's path for re-spawning; argv0 is used as a fallback. */
+void subproc_self_path(const char *argv0, char *buf, size_t buf_size);
+
+/* Start a child process running the given binary; the child inherits open descriptors. */
+void subproc_spawn(SUBPROC *proc, const char *who, const char *path, char *const argv[]);
+
+/* Terminate a child abruptly, with no chance for cleanup. */
+void subproc_kill(SUBPROC *proc);
+
+/* Non-blocking status probe. */
+SUBPROC_STATUS subproc_poll(SUBPROC *proc, int *codep);
+
+/* Blocking wait for termination. */
+SUBPROC_STATUS subproc_wait(SUBPROC *proc, int *codep);

--- a/test/csuite/schema_disagg_abort/subproc.h
+++ b/test/csuite/schema_disagg_abort/subproc.h
@@ -1,29 +1,9 @@
 /*-
- * Public Domain 2014-present MongoDB, Inc.
- * Public Domain 2008-2014 WiredTiger, Inc.
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
  *
- * This is free and unencumbered software released into the public domain.
- *
- * Anyone is free to copy, modify, publish, use, compile, sell, or
- * distribute this software, either in source code form or as a compiled
- * binary, for any purpose, commercial or non-commercial, and by any
- * means.
- *
- * In jurisdictions that recognize copyright laws, the author or authors
- * of this software dedicate any and all copyright interest in the
- * software to the public domain. We make this dedication for the benefit
- * of the public at large and to the detriment of our heirs and
- * successors. We intend this dedication to be an overt act of
- * relinquishment in perpetuity of all present and future rights to this
- * software under copyright law.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
- * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
- * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * See the file LICENSE for redistribution information.
  */
 
 /*
@@ -44,9 +24,7 @@ typedef struct {
     int status; /* Raw wait status, valid once reaped. */
 } SUBPROC;
 
-/* Fixed slots for the children a test run can have. */
-#define SUBPROC_LEADER 0
-#define SUBPROC_FOLLOWER 1
+/* Fixed slots for the children a test run can have, indexed by node id. */
 #define SUBPROC_SLOTS 2
 
 typedef enum {
@@ -61,8 +39,12 @@ void subproc_pipe(int fds[2]);
 /* Resolve the running binary's path for re-spawning; argv0 is used as a fallback. */
 void subproc_self_path(const char *argv0, char *buf, size_t buf_size);
 
-/* Start a child process running the given binary; the child inherits open descriptors. */
-void subproc_spawn(SUBPROC *proc, const char *who, const char *path, char *const argv[]);
+/*
+ * Start a child process running the given binary. The child inherits open descriptors except those
+ * in close_fds (length nclose), which are closed in the child before it starts.
+ */
+void subproc_spawn(SUBPROC *proc, const char *who, const char *path, char *const argv[],
+  const int *close_fds, size_t nclose);
 
 /* Terminate a child abruptly, with no chance for cleanup. */
 void subproc_kill(SUBPROC *proc);

--- a/test/csuite/schema_disagg_abort/verify.c
+++ b/test/csuite/schema_disagg_abort/verify.c
@@ -26,10 +26,17 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
+/*
+ * Verification: run by the parent after recovery. Replays the record files against the recovered
+ * database state.
+ */
+
 #include "schema_disagg_abort.h"
 
-/* No durable insert was recorded for the slot's last create. */
-#define DATA_COMMIT_TS_NONE UINT64_MAX
+/*
+ * No durable insert was recorded for the slot's last create.
+ */
+#define DATA_COMMIT_TS_NONE WT_TS_NONE
 
 /* The last durable create or drop recorded for one URI slot, and its inserted data if any. */
 typedef struct {
@@ -59,27 +66,23 @@ parse_schema_records(const char *fname, uint32_t t, uint64_t durable_epoch,
   SLOT_STATE states[MAX_POOL_SIZE], uint32_t pool_size)
 {
     FILE *fp;
-    uint64_t commit_ts, entry_epoch;
-    uint32_t key_max, key_min, s, t2;
-    char line[256], op[16], rec_uri[128];
+    testutil_assert_errno((fp = fopen(fname, "r")) != NULL);
 
-    for (s = 0; s < pool_size; s++) {
-        states[s].epoch = 0;
-        states[s].commit_ts = DATA_COMMIT_TS_NONE;
-        states[s].key_min = states[s].key_max = 0;
-        states[s].is_create = false;
-        states[s].valid = false;
-        states[s].churned_past_durable = false;
-    }
-
-    if ((fp = fopen(fname, "r")) == NULL)
-        return;
-
+    /* Zero state is fully valid: invalid slot, no durable insert (DATA_COMMIT_TS_NONE). */
+    memset(states, 0, sizeof(SLOT_STATE) * pool_size);
+    char line[256];
     while (fgets(line, sizeof(line), fp) != NULL) {
+        char op[16];
         if (sscanf(line, "%15s", op) != 1)
             continue;
 
+        uint64_t entry_epoch;
+        uint32_t s, t2;
+        char rec_uri[128];
+
         if (strcmp(op, "INSERT") == 0) {
+            uint64_t commit_ts;
+            uint32_t key_max, key_min;
             if (sscanf(line, "%*s %" SCNu64 " %" SCNu64 " %" SCNu32 " %" SCNu32 " %127s",
                   &entry_epoch, &commit_ts, &key_min, &key_max, rec_uri) != 5)
                 continue;
@@ -124,28 +127,26 @@ static uint32_t
 check_schema_presence(
   WT_SESSION *session, uint32_t t, const SLOT_STATE states[MAX_POOL_SIZE], uint32_t pool_size)
 {
-    WT_CURSOR *md_cursor;
-    WT_DECL_RET;
-    uint32_t s, skipped;
-    char uri[64];
-
-    skipped = 0;
+    uint32_t skipped = 0;
 
     /* Validate presence against the metadata entry rather than instantiating each table. */
+    WT_CURSOR *md_cursor;
     testutil_check(session->open_cursor(session, "metadata:", NULL, NULL, &md_cursor));
 
-    for (s = 0; s < pool_size; s++) {
+    for (uint32_t s = 0; s < pool_size; s++) {
         if (!states[s].valid)
             continue;
+
         /* FIXME-WT-18099: A create above the recovered epoch resurrects a dropped table. */
         if (!states[s].is_create && states[s].churned_past_durable) {
             ++skipped;
             continue;
         }
 
+        char uri[64];
         testutil_snprintf(uri, sizeof(uri), SCHEMA_TABLE_FMT, t, s);
         md_cursor->set_key(md_cursor, uri);
-        ret = md_cursor->search(md_cursor);
+        const int ret = md_cursor->search(md_cursor);
         testutil_assert(ret == 0 || ret == WT_NOTFOUND);
 
         if (states[s].is_create)
@@ -165,43 +166,46 @@ check_schema_presence(
  *     For each slot whose last checkpointed operation was a CREATE and whose data commit timestamp
  *     is at or below the last checkpoint timestamp, confirm the recorded key range is present.
  *     Slots with no durable insert record, or whose data commit timestamp exceeds last_ckpt_ts, are
- *     skipped.
+ *     skipped. Returns the number of slots skipped for FIXME-WT-18099.
  */
 static uint32_t
 check_data_rows(WT_SESSION *session, uint32_t t, const SLOT_STATE states[MAX_POOL_SIZE],
   uint32_t pool_size, uint64_t last_ckpt_ts)
 {
-    WT_CURSOR *cursor;
-    WT_DECL_RET;
-    uint32_t r, s, skipped;
-    char expected_val[32], key_buf[16], uri[64];
-    const char *actual_val;
+    uint32_t skipped = 0;
 
-    skipped = 0;
-    for (s = 0; s < pool_size; s++) {
+    for (uint32_t s = 0; s < pool_size; s++) {
         if (!states[s].valid || !states[s].is_create)
             continue;
-        /* FIXME-WT-18099: The URI was churned above the recovered epoch, so its data is unreliable.
-         */
-        if (states[s].churned_past_durable) {
-            ++skipped;
-            continue;
-        }
         if (states[s].commit_ts == DATA_COMMIT_TS_NONE)
             continue;
         if (last_ckpt_ts > 0 && states[s].commit_ts > last_ckpt_ts)
             continue;
 
+        /* FIXME-WT-18099: The URI was churned above the recovered epoch, so its data is
+         * unreliable. */
+        if (states[s].churned_past_durable) {
+            ++skipped;
+            continue;
+        }
+
+        char uri[64];
         testutil_snprintf(uri, sizeof(uri), SCHEMA_TABLE_FMT, t, s);
+
+        WT_CURSOR *cursor;
         testutil_check(session->open_cursor(session, uri, NULL, NULL, &cursor));
 
+        char expected_val[32];
         testutil_snprintf(expected_val, sizeof(expected_val), "%" PRIu64, states[s].epoch);
-        for (r = states[s].key_min; r <= states[s].key_max; r++) {
+        for (uint32_t r = states[s].key_min; r <= states[s].key_max; r++) {
+            char key_buf[16];
             testutil_snprintf(key_buf, sizeof(key_buf), "%" PRIu32, r);
             cursor->set_key(cursor, key_buf);
-            ret = cursor->search(cursor);
+            const int ret = cursor->search(cursor);
             testutil_assertfmt(ret == 0, "%s key %s: %s (epoch %" PRIu64 ")", uri, key_buf,
               ret == WT_NOTFOUND ? "missing" : wiredtiger_strerror(ret), states[s].epoch);
+
+            const char *actual_val;
             testutil_check(cursor->get_value(cursor, &actual_val));
             testutil_assertfmt(strcmp(actual_val, expected_val) == 0, "%s key %s: got %s want %s",
               uri, key_buf, actual_val, expected_val);
@@ -215,37 +219,44 @@ check_data_rows(WT_SESSION *session, uint32_t t, const SLOT_STATE states[MAX_POO
  * verify_schema_state --
  *     Verify schema and data state after recovery.
  *
- * Reads the per-thread schema record files and takes last_disaggregated_schema_epoch as the highest
- *     durable schema epoch. Asserts that every table whose last durable operation was a create
- *     exists and holds the right rows, and every one last dropped is gone. Aborts on the first
- *     mismatch.
+ * Reads the per-thread record files with the given base name (schema or follower) and takes
+ *     last_disaggregated_schema_epoch as the highest durable schema epoch. Asserts that every table
+ *     whose last durable operation was a create exists and holds the right rows, and every one last
+ *     dropped is gone. Aborts on the first mismatch.
  */
 void
-verify_schema_state(WT_CONNECTION *conn, TEST_CONFIG *cfg)
+verify_schema_state(WT_CONNECTION *conn, const TEST_CONFIG *cfg, const char *records_base)
 {
-    SLOT_STATE states[MAX_POOL_SIZE];
-    WT_SESSION *session;
-    uint64_t durable_epoch, last_ckpt_ts;
-    char fname[128], ts_buf[64];
-    uint32_t presence_skipped, data_skipped, t;
-
-    presence_skipped = data_skipped = 0;
-    durable_epoch = 0;
+    char ts_buf[64];
+    uint64_t durable_epoch = 0;
     testutil_check(conn->query_timestamp(conn, ts_buf, "get=last_disaggregated_schema_epoch"));
     (void)sscanf(ts_buf, "%" SCNx64, &durable_epoch);
     printf("Schema verify: last_disaggregated_schema_epoch = %" PRIu64 "\n", durable_epoch);
     if (durable_epoch == 0)
         testutil_die(EINVAL, "last_disaggregated_schema_epoch is 0 after recovery");
 
-    last_ckpt_ts = 0;
+    uint64_t last_ckpt_ts = 0;
     (void)conn->query_timestamp(conn, ts_buf, "get=last_checkpoint");
     (void)sscanf(ts_buf, "%" SCNx64, &last_ckpt_ts);
     printf("Schema verify: last_checkpoint_timestamp = %" PRIu64 "\n", last_ckpt_ts);
 
+    WT_SESSION *session;
     testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
-    for (t = 0; t < cfg->nth; t++) {
-        testutil_snprintf(fname, sizeof(fname), SCHEMA_RECORDS_FILE, t);
+    uint32_t data_skipped = 0, presence_skipped = 0;
+    for (uint32_t t = 0; t < cfg->nth; t++) {
+        char fname[128];
+        testutil_snprintf(fname, sizeof(fname), RECORDS_FILE_FMT, records_base, t);
+
+        /*
+         * A missing record file means there are no expectations to verify for this thread. That is
+         * benign: the follower creates its files lazily on the first relayed event, so a thread
+         * whose events never reached the follower leaves none.
+         */
+        if (!testutil_exists(NULL, fname))
+            continue;
+
+        SLOT_STATE states[MAX_POOL_SIZE];
         parse_schema_records(fname, t, durable_epoch, states, cfg->pool_size);
         presence_skipped += check_schema_presence(session, t, states, cfg->pool_size);
         data_skipped += check_data_rows(session, t, states, cfg->pool_size, last_ckpt_ts);

--- a/test/csuite/schema_disagg_abort/verify.c
+++ b/test/csuite/schema_disagg_abort/verify.c
@@ -26,12 +26,6 @@ typedef struct {
     uint32_t key_max;
     bool is_create;
     bool valid;
-    /*
-     * FIXME-WT-18099: A create or drop above the recovered epoch churns the reused URI. After
-     * recovery the slot no longer matches its durable state, so a dropped table can reappear or a
-     * durable create can read back empty. Skip verifying it.
-     */
-    bool churned_past_durable;
     char uri[64]; /* filled when valid, so the checks need not rebuild it */
 } SLOT_STATE;
 
@@ -107,10 +101,8 @@ parse_schema_records(const char *fname, uint32_t node, uint32_t t, uint64_t dura
             continue;
         if (!parse_record_uri(rec_uri, node, t, pool_size, &s))
             continue;
-        if (entry_epoch > durable_epoch) {
-            states[s].churned_past_durable = true;
+        if (entry_epoch > durable_epoch)
             continue;
-        }
         if (entry_epoch > states[s].epoch) {
             states[s].epoch = entry_epoch;
             states[s].commit_ts = DATA_COMMIT_TS_NONE;
@@ -125,15 +117,12 @@ parse_schema_records(const char *fname, uint32_t node, uint32_t t, uint64_t dura
 /*
  * check_schema_presence --
  *     For each slot with a durable record, assert that a table whose last operation was a create
- *     still exists and one whose last operation was a drop is absent. Returns the number of slots
- *     skipped for FIXME-WT-18099.
+ *     still exists and one whose last operation was a drop is absent.
  */
-static uint32_t
+static void
 check_schema_presence(
   WT_SESSION *session, const SLOT_STATE states[MAX_POOL_SIZE], uint32_t pool_size)
 {
-    uint32_t skipped = 0;
-
     /* Validate presence against the metadata entry rather than instantiating each table. */
     WT_CURSOR *md_cursor;
     testutil_check(session->open_cursor(session, "metadata:", NULL, NULL, &md_cursor));
@@ -141,12 +130,6 @@ check_schema_presence(
     for (uint32_t s = 0; s < pool_size; s++) {
         if (!states[s].valid)
             continue;
-
-        /* FIXME-WT-18099: A create above the recovered epoch resurrects a dropped table. */
-        if (!states[s].is_create && states[s].churned_past_durable) {
-            ++skipped;
-            continue;
-        }
 
         md_cursor->set_key(md_cursor, states[s].uri);
         const int ret = md_cursor->search(md_cursor);
@@ -161,7 +144,6 @@ check_schema_presence(
     }
 
     testutil_check(md_cursor->close(md_cursor));
-    return (skipped);
 }
 
 /*
@@ -169,14 +151,12 @@ check_schema_presence(
  *     For each slot whose last checkpointed operation was a CREATE and whose data commit timestamp
  *     is at or below the last checkpoint timestamp, confirm the recorded key range is present.
  *     Slots with no durable insert record, or whose data commit timestamp exceeds last_ckpt_ts, are
- *     skipped. Returns the number of slots skipped for FIXME-WT-18099.
+ *     skipped.
  */
-static uint32_t
+static void
 check_data_rows(WT_SESSION *session, const SLOT_STATE states[MAX_POOL_SIZE], uint32_t pool_size,
   uint64_t last_ckpt_ts)
 {
-    uint32_t skipped = 0;
-
     for (uint32_t s = 0; s < pool_size; s++) {
         if (!states[s].valid || !states[s].is_create)
             continue;
@@ -184,13 +164,6 @@ check_data_rows(WT_SESSION *session, const SLOT_STATE states[MAX_POOL_SIZE], uin
             continue;
         if (last_ckpt_ts > 0 && states[s].commit_ts > last_ckpt_ts)
             continue;
-
-        /* FIXME-WT-18099: The URI was churned above the recovered epoch, so its data is
-         * unreliable. */
-        if (states[s].churned_past_durable) {
-            ++skipped;
-            continue;
-        }
 
         WT_CURSOR *cursor;
         testutil_check(session->open_cursor(session, states[s].uri, NULL, NULL, &cursor));
@@ -214,7 +187,6 @@ check_data_rows(WT_SESSION *session, const SLOT_STATE states[MAX_POOL_SIZE], uin
         }
         testutil_check(cursor->close(cursor));
     }
-    return (skipped);
 }
 
 /*
@@ -244,7 +216,6 @@ verify_schema_state(WT_CONNECTION *conn, const TEST_CONFIG *cfg)
     WT_SESSION *session;
     testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
-    uint32_t data_skipped = 0, presence_skipped = 0;
     for (uint32_t n = 0; n < MAX_NODES; n++)
         for (uint32_t t = 0; t < cfg->nth; t++) {
             char fname[128];
@@ -260,14 +231,9 @@ verify_schema_state(WT_CONNECTION *conn, const TEST_CONFIG *cfg)
 
             SLOT_STATE states[MAX_POOL_SIZE];
             parse_schema_records(fname, n, t, durable_epoch, states, cfg->pool_size);
-            presence_skipped += check_schema_presence(session, states, cfg->pool_size);
-            data_skipped += check_data_rows(session, states, cfg->pool_size, last_ckpt_ts);
+            check_schema_presence(session, states, cfg->pool_size);
+            check_data_rows(session, states, cfg->pool_size, last_ckpt_ts);
         }
-
-    /* Surface how much coverage the pick-up gap costs this run. */
-    println("Schema verify: skipped %" PRIu32 " presence and %" PRIu32
-            " data checks for churned-above-epoch slots (FIXME-WT-18099)",
-      presence_skipped, data_skipped);
 
     testutil_check(session->close(session, NULL));
 }

--- a/test/csuite/schema_disagg_abort/verify.c
+++ b/test/csuite/schema_disagg_abort/verify.c
@@ -1,29 +1,9 @@
 /*-
- * Public Domain 2014-present MongoDB, Inc.
- * Public Domain 2008-2014 WiredTiger, Inc.
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
  *
- * This is free and unencumbered software released into the public domain.
- *
- * Anyone is free to copy, modify, publish, use, compile, sell, or
- * distribute this software, either in source code form or as a compiled
- * binary, for any purpose, commercial or non-commercial, and by any
- * means.
- *
- * In jurisdictions that recognize copyright laws, the author or authors
- * of this software dedicate any and all copyright interest in the
- * software to the public domain. We make this dedication for the benefit
- * of the public at large and to the detriment of our heirs and
- * successors. We intend this dedication to be an overt act of
- * relinquishment in perpetuity of all present and future rights to this
- * software under copyright law.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
- * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
- * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
+ * See the file LICENSE for redistribution information.
  */
 
 /*
@@ -52,7 +32,26 @@ typedef struct {
      * durable create can read back empty. Skip verifying it.
      */
     bool churned_past_durable;
+    char uri[64]; /* filled when valid, so the checks need not rebuild it */
 } SLOT_STATE;
+
+/*
+ * parse_record_uri --
+ *     Parse and filter one record's URI: true when it belongs to the given node and thread and its
+ *     slot is inside the pool, reporting the slot.
+ */
+static bool
+parse_record_uri(
+  const char *rec_uri, uint32_t node, uint32_t t, uint32_t pool_size, uint32_t *slotp)
+{
+    uint32_t n2, s, t2;
+
+    if (sscanf(rec_uri, SCHEMA_TABLE_FMT, &n2, &t2, &s) != 3 || n2 != node || t2 != t ||
+      s >= pool_size)
+        return (false);
+    *slotp = s;
+    return (true);
+}
 
 /*
  * parse_schema_records --
@@ -62,7 +61,7 @@ typedef struct {
  *     threads.
  */
 static void
-parse_schema_records(const char *fname, uint32_t t, uint64_t durable_epoch,
+parse_schema_records(const char *fname, uint32_t node, uint32_t t, uint64_t durable_epoch,
   SLOT_STATE states[MAX_POOL_SIZE], uint32_t pool_size)
 {
     FILE *fp;
@@ -77,21 +76,26 @@ parse_schema_records(const char *fname, uint32_t t, uint64_t durable_epoch,
             continue;
 
         uint64_t entry_epoch;
-        uint32_t s, t2;
+        uint32_t s;
         char rec_uri[128];
 
         if (strcmp(op, "INSERT") == 0) {
             uint64_t commit_ts;
             uint32_t key_max, key_min;
-            if (sscanf(line, "%*s %" SCNu64 " %" SCNu64 " %" SCNu32 " %" SCNu32 " %127s",
-                  &entry_epoch, &commit_ts, &key_min, &key_max, rec_uri) != 5)
+            if (sscanf(line, "%*s %" SCNu64 " %" SCNu32 " %" SCNu32 " %127s", &commit_ts, &key_min,
+                  &key_max, rec_uri) != 4)
                 continue;
-            if (entry_epoch > durable_epoch)
+            if (commit_ts > durable_epoch)
                 continue;
-            if (sscanf(rec_uri, SCHEMA_TABLE_FMT, &t2, &s) != 2 || t2 != t || s >= pool_size)
+            if (!parse_record_uri(rec_uri, node, t, pool_size, &s))
                 continue;
-            /* The insert belongs to the slot's current create. */
-            if (states[s].valid && states[s].is_create && states[s].epoch == entry_epoch) {
+            /*
+             * The insert belongs to the slot's current create: the per-thread records are in apply
+             * order and an insert immediately follows its create. A cut-off create cannot capture a
+             * stray insert - a commit's value always exceeds its table's create epoch, so the
+             * durability cutoff above already dropped the insert too.
+             */
+            if (states[s].valid && states[s].is_create) {
                 states[s].commit_ts = commit_ts;
                 states[s].key_min = key_min;
                 states[s].key_max = key_max;
@@ -101,7 +105,7 @@ parse_schema_records(const char *fname, uint32_t t, uint64_t durable_epoch,
 
         if (sscanf(line, "%*s %" SCNu64 " %127s", &entry_epoch, rec_uri) != 2)
             continue;
-        if (sscanf(rec_uri, SCHEMA_TABLE_FMT, &t2, &s) != 2 || t2 != t || s >= pool_size)
+        if (!parse_record_uri(rec_uri, node, t, pool_size, &s))
             continue;
         if (entry_epoch > durable_epoch) {
             states[s].churned_past_durable = true;
@@ -112,6 +116,7 @@ parse_schema_records(const char *fname, uint32_t t, uint64_t durable_epoch,
             states[s].commit_ts = DATA_COMMIT_TS_NONE;
             states[s].is_create = (strcmp(op, "CREATE") == 0);
             states[s].valid = true;
+            testutil_snprintf(states[s].uri, sizeof(states[s].uri), "%s", rec_uri);
         }
     }
     (void)fclose(fp);
@@ -125,7 +130,7 @@ parse_schema_records(const char *fname, uint32_t t, uint64_t durable_epoch,
  */
 static uint32_t
 check_schema_presence(
-  WT_SESSION *session, uint32_t t, const SLOT_STATE states[MAX_POOL_SIZE], uint32_t pool_size)
+  WT_SESSION *session, const SLOT_STATE states[MAX_POOL_SIZE], uint32_t pool_size)
 {
     uint32_t skipped = 0;
 
@@ -143,18 +148,16 @@ check_schema_presence(
             continue;
         }
 
-        char uri[64];
-        testutil_snprintf(uri, sizeof(uri), SCHEMA_TABLE_FMT, t, s);
-        md_cursor->set_key(md_cursor, uri);
+        md_cursor->set_key(md_cursor, states[s].uri);
         const int ret = md_cursor->search(md_cursor);
         testutil_assert(ret == 0 || ret == WT_NOTFOUND);
 
         if (states[s].is_create)
             testutil_assertfmt(ret == 0, "%s missing after recovery (CREATE at epoch %" PRIu64 ")",
-              uri, states[s].epoch);
+              states[s].uri, states[s].epoch);
         else
             testutil_assertfmt(
-              ret == WT_NOTFOUND, "%s present after recovery (last op was DROP)", uri);
+              ret == WT_NOTFOUND, "%s present after recovery (last op was DROP)", states[s].uri);
     }
 
     testutil_check(md_cursor->close(md_cursor));
@@ -169,8 +172,8 @@ check_schema_presence(
  *     skipped. Returns the number of slots skipped for FIXME-WT-18099.
  */
 static uint32_t
-check_data_rows(WT_SESSION *session, uint32_t t, const SLOT_STATE states[MAX_POOL_SIZE],
-  uint32_t pool_size, uint64_t last_ckpt_ts)
+check_data_rows(WT_SESSION *session, const SLOT_STATE states[MAX_POOL_SIZE], uint32_t pool_size,
+  uint64_t last_ckpt_ts)
 {
     uint32_t skipped = 0;
 
@@ -189,26 +192,25 @@ check_data_rows(WT_SESSION *session, uint32_t t, const SLOT_STATE states[MAX_POO
             continue;
         }
 
-        char uri[64];
-        testutil_snprintf(uri, sizeof(uri), SCHEMA_TABLE_FMT, t, s);
-
         WT_CURSOR *cursor;
-        testutil_check(session->open_cursor(session, uri, NULL, NULL, &cursor));
+        testutil_check(session->open_cursor(session, states[s].uri, NULL, NULL, &cursor));
 
+        /* Rows are valued with their commit timestamp; a mismatch means another generation's
+         * data. */
         char expected_val[32];
-        testutil_snprintf(expected_val, sizeof(expected_val), "%" PRIu64, states[s].epoch);
+        testutil_snprintf(expected_val, sizeof(expected_val), "%" PRIu64, states[s].commit_ts);
         for (uint32_t r = states[s].key_min; r <= states[s].key_max; r++) {
             char key_buf[16];
             testutil_snprintf(key_buf, sizeof(key_buf), "%" PRIu32, r);
             cursor->set_key(cursor, key_buf);
             const int ret = cursor->search(cursor);
-            testutil_assertfmt(ret == 0, "%s key %s: %s (epoch %" PRIu64 ")", uri, key_buf,
-              ret == WT_NOTFOUND ? "missing" : wiredtiger_strerror(ret), states[s].epoch);
+            testutil_assertfmt(ret == 0, "%s key %s: %s (epoch %" PRIu64 ")", states[s].uri,
+              key_buf, ret == WT_NOTFOUND ? "missing" : wiredtiger_strerror(ret), states[s].epoch);
 
             const char *actual_val;
             testutil_check(cursor->get_value(cursor, &actual_val));
             testutil_assertfmt(strcmp(actual_val, expected_val) == 0, "%s key %s: got %s want %s",
-              uri, key_buf, actual_val, expected_val);
+              states[s].uri, key_buf, actual_val, expected_val);
         }
         testutil_check(cursor->close(cursor));
     }
@@ -219,53 +221,123 @@ check_data_rows(WT_SESSION *session, uint32_t t, const SLOT_STATE states[MAX_POO
  * verify_schema_state --
  *     Verify schema and data state after recovery.
  *
- * Reads the per-thread record files with the given base name (schema or follower) and takes
+ * Reads every node's per-thread schema record files (each node logs only its own operations while
+ *     leading; the shared page log makes all of them visible to any recovered node) and takes
  *     last_disaggregated_schema_epoch as the highest durable schema epoch. Asserts that every table
  *     whose last durable operation was a create exists and holds the right rows, and every one last
  *     dropped is gone. Aborts on the first mismatch.
  */
 void
-verify_schema_state(WT_CONNECTION *conn, const TEST_CONFIG *cfg, const char *records_base)
+verify_schema_state(WT_CONNECTION *conn, const TEST_CONFIG *cfg)
 {
-    char ts_buf[64];
-    uint64_t durable_epoch = 0;
-    testutil_check(conn->query_timestamp(conn, ts_buf, "get=last_disaggregated_schema_epoch"));
-    (void)sscanf(ts_buf, "%" SCNx64, &durable_epoch);
-    printf("Schema verify: last_disaggregated_schema_epoch = %" PRIu64 "\n", durable_epoch);
-    if (durable_epoch == 0)
-        testutil_die(EINVAL, "last_disaggregated_schema_epoch is 0 after recovery");
+    /* A run may legitimately do nothing: a lone follower has no event source. */
+    bool have_records = false;
+    for (uint32_t n = 0; n < MAX_NODES && !have_records; n++)
+        for (uint32_t t = 0; t < cfg->nth && !have_records; t++) {
+            char fname[128];
+            testutil_snprintf(fname, sizeof(fname), SCHEMA_RECORDS_FILE, n, t);
+            have_records = testutil_exists(NULL, fname);
+        }
 
-    uint64_t last_ckpt_ts = 0;
-    (void)conn->query_timestamp(conn, ts_buf, "get=last_checkpoint");
-    (void)sscanf(ts_buf, "%" SCNx64, &last_ckpt_ts);
-    printf("Schema verify: last_checkpoint_timestamp = %" PRIu64 "\n", last_ckpt_ts);
+    const uint64_t durable_epoch = query_ts(conn, "last_disaggregated_schema_epoch");
+    println("Schema verify: last_disaggregated_schema_epoch = %" PRIu64, durable_epoch);
+    if (durable_epoch == 0) {
+        if (!have_records) {
+            println("Schema verify: empty run, no records to check");
+            return;
+        }
+        testutil_die(EINVAL, "last_disaggregated_schema_epoch is 0 after recovery");
+    }
+
+    const uint64_t last_ckpt_ts = query_ts(conn, "last_checkpoint");
+    println("Schema verify: last_checkpoint_timestamp = %" PRIu64, last_ckpt_ts);
 
     WT_SESSION *session;
     testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
     uint32_t data_skipped = 0, presence_skipped = 0;
-    for (uint32_t t = 0; t < cfg->nth; t++) {
-        char fname[128];
-        testutil_snprintf(fname, sizeof(fname), RECORDS_FILE_FMT, records_base, t);
+    for (uint32_t n = 0; n < MAX_NODES; n++)
+        for (uint32_t t = 0; t < cfg->nth; t++) {
+            char fname[128];
+            testutil_snprintf(fname, sizeof(fname), SCHEMA_RECORDS_FILE, n, t);
 
-        /*
-         * A missing record file means there are no expectations to verify for this thread. That is
-         * benign: the follower creates its files lazily on the first relayed event, so a thread
-         * whose events never reached the follower leaves none.
-         */
-        if (!testutil_exists(NULL, fname))
-            continue;
+            /*
+             * A missing record file means there are no expectations to verify for this thread:
+             * record files are created lazily, so a thread that never got to operate (or a node
+             * that never led) leaves none.
+             */
+            if (!testutil_exists(NULL, fname))
+                continue;
 
-        SLOT_STATE states[MAX_POOL_SIZE];
-        parse_schema_records(fname, t, durable_epoch, states, cfg->pool_size);
-        presence_skipped += check_schema_presence(session, t, states, cfg->pool_size);
-        data_skipped += check_data_rows(session, t, states, cfg->pool_size, last_ckpt_ts);
-    }
+            SLOT_STATE states[MAX_POOL_SIZE];
+            parse_schema_records(fname, n, t, durable_epoch, states, cfg->pool_size);
+            presence_skipped += check_schema_presence(session, states, cfg->pool_size);
+            data_skipped += check_data_rows(session, states, cfg->pool_size, last_ckpt_ts);
+        }
 
-    /* Surface how much coverage the WT-18099 pick-up gap costs this run. */
-    printf("Schema verify: skipped %" PRIu32 " presence and %" PRIu32
-           " data checks for churned-above-epoch slots (FIXME-WT-18099)\n",
+    /* Surface how much coverage the pick-up gap costs this run. */
+    println("Schema verify: skipped %" PRIu32 " presence and %" PRIu32
+            " data checks for churned-above-epoch slots (FIXME-WT-18099)",
       presence_skipped, data_skipped);
 
     testutil_check(session->close(session, NULL));
+}
+
+/*
+ * verify_relay_prefix --
+ *     Check the integrity of the event relay: everything a node recorded while following must be an
+ *     exact prefix of what its peer recorded while leading, per thread.
+ *
+ * The leader writes its own record before relaying the event, and the pipe preserves order, so any
+ *     divergence or reordering is a relay bug. A SIGKILL can truncate the recorder's final line, so
+ *     a partial trailing line is accepted if it is a prefix of the peer's line.
+ */
+void
+verify_relay_prefix(const TEST_CONFIG *cfg)
+{
+    uint32_t checked = 0;
+    for (uint32_t n = 0; n < MAX_NODES; n++)
+        for (uint32_t t = 0; t < cfg->nth; t++) {
+            char relay_fname[128], schema_fname[128];
+            testutil_snprintf(relay_fname, sizeof(relay_fname), RELAY_RECORDS_FILE, n, t);
+            testutil_snprintf(schema_fname, sizeof(schema_fname), SCHEMA_RECORDS_FILE, 1 - n, t);
+
+            /* No relay file means no events were relayed for this thread; nothing to check. */
+            if (!testutil_exists(NULL, relay_fname))
+                continue;
+            testutil_assertfmt(testutil_exists(NULL, schema_fname),
+              "%s exists but the peer's %s does not", relay_fname, schema_fname);
+
+            FILE *ffp, *sfp;
+            testutil_assert_errno((ffp = fopen(relay_fname, "r")) != NULL);
+            testutil_assert_errno((sfp = fopen(schema_fname, "r")) != NULL);
+
+            char fline[256], sline[256];
+            uint32_t lineno = 0;
+            while (fgets(fline, sizeof(fline), ffp) != NULL) {
+                ++lineno;
+                testutil_assertfmt(fgets(sline, sizeof(sline), sfp) != NULL,
+                  "%s line %" PRIu32 " has no counterpart in %s", relay_fname, lineno,
+                  schema_fname);
+
+                const size_t flen = strlen(fline);
+                if (flen > 0 && fline[flen - 1] == '\n')
+                    testutil_assertfmt(strcmp(fline, sline) == 0,
+                      "%s diverges from %s at line %" PRIu32 ": \"%s\" vs \"%s\"", relay_fname,
+                      schema_fname, lineno, fline, sline);
+                else
+                    /* Partial trailing line: the recorder was killed mid-write. */
+                    testutil_assertfmt(strncmp(sline, fline, flen) == 0,
+                      "%s truncated line %" PRIu32 " is not a prefix of %s: \"%s\" vs \"%s\"",
+                      relay_fname, lineno, schema_fname, fline, sline);
+            }
+
+            (void)fclose(ffp);
+            (void)fclose(sfp);
+            ++checked;
+        }
+
+    println("Relay verify: %" PRIu32
+            " relay record files are prefixes of the peer's schema records",
+      checked);
 }

--- a/test/csuite/schema_disagg_abort/verify.c
+++ b/test/csuite/schema_disagg_abort/verify.c
@@ -221,8 +221,8 @@ check_data_rows(WT_SESSION *session, const SLOT_STATE states[MAX_POOL_SIZE], uin
  * verify_schema_state --
  *     Verify schema and data state after recovery.
  *
- * Reads every node's per-thread schema record files (each node logs only its own operations while
- *     leading; the shared page log makes all of them visible to any recovered node) and takes
+ * Reads every node's per-thread leader record files (each node logs only its own operations while
+ *     it leads; the shared page log makes all of them visible to any recovered node) and takes
  *     last_disaggregated_schema_epoch as the highest durable schema epoch. Asserts that every table
  *     whose last durable operation was a create exists and holds the right rows, and every one last
  *     dropped is gone. Aborts on the first mismatch.
@@ -230,23 +230,12 @@ check_data_rows(WT_SESSION *session, const SLOT_STATE states[MAX_POOL_SIZE], uin
 void
 verify_schema_state(WT_CONNECTION *conn, const TEST_CONFIG *cfg)
 {
-    /* A run may legitimately do nothing: a lone follower has no event source. */
-    bool have_records = false;
-    for (uint32_t n = 0; n < MAX_NODES && !have_records; n++)
-        for (uint32_t t = 0; t < cfg->nth && !have_records; t++) {
-            char fname[128];
-            testutil_snprintf(fname, sizeof(fname), SCHEMA_RECORDS_FILE, n, t);
-            have_records = testutil_exists(NULL, fname);
-        }
-
     const uint64_t durable_epoch = query_ts(conn, "last_disaggregated_schema_epoch");
     println("Schema verify: last_disaggregated_schema_epoch = %" PRIu64, durable_epoch);
+    /* Nothing durable means no record is below the cutoff, so there is nothing to check. */
     if (durable_epoch == 0) {
-        if (!have_records) {
-            println("Schema verify: empty run, no records to check");
-            return;
-        }
-        testutil_die(EINVAL, "last_disaggregated_schema_epoch is 0 after recovery");
+        println("Schema verify: nothing durable, no expectations to check");
+        return;
     }
 
     const uint64_t last_ckpt_ts = query_ts(conn, "last_checkpoint");
@@ -259,7 +248,7 @@ verify_schema_state(WT_CONNECTION *conn, const TEST_CONFIG *cfg)
     for (uint32_t n = 0; n < MAX_NODES; n++)
         for (uint32_t t = 0; t < cfg->nth; t++) {
             char fname[128];
-            testutil_snprintf(fname, sizeof(fname), SCHEMA_RECORDS_FILE, n, t);
+            testutil_snprintf(fname, sizeof(fname), LEADER_RECORDS_FILE, n, t);
 
             /*
              * A missing record file means there are no expectations to verify for this thread:
@@ -298,38 +287,38 @@ verify_relay_prefix(const TEST_CONFIG *cfg)
     uint32_t checked = 0;
     for (uint32_t n = 0; n < MAX_NODES; n++)
         for (uint32_t t = 0; t < cfg->nth; t++) {
-            char relay_fname[128], schema_fname[128];
-            testutil_snprintf(relay_fname, sizeof(relay_fname), RELAY_RECORDS_FILE, n, t);
-            testutil_snprintf(schema_fname, sizeof(schema_fname), SCHEMA_RECORDS_FILE, 1 - n, t);
+            char follower_fname[128], leader_fname[128];
+            testutil_snprintf(follower_fname, sizeof(follower_fname), FOLLOWER_RECORDS_FILE, n, t);
+            testutil_snprintf(leader_fname, sizeof(leader_fname), LEADER_RECORDS_FILE, 1 - n, t);
 
             /* No relay file means no events were relayed for this thread; nothing to check. */
-            if (!testutil_exists(NULL, relay_fname))
+            if (!testutil_exists(NULL, follower_fname))
                 continue;
-            testutil_assertfmt(testutil_exists(NULL, schema_fname),
-              "%s exists but the peer's %s does not", relay_fname, schema_fname);
+            testutil_assertfmt(testutil_exists(NULL, leader_fname),
+              "%s exists but the peer's %s does not", follower_fname, leader_fname);
 
             FILE *ffp, *sfp;
-            testutil_assert_errno((ffp = fopen(relay_fname, "r")) != NULL);
-            testutil_assert_errno((sfp = fopen(schema_fname, "r")) != NULL);
+            testutil_assert_errno((ffp = fopen(follower_fname, "r")) != NULL);
+            testutil_assert_errno((sfp = fopen(leader_fname, "r")) != NULL);
 
             char fline[256], sline[256];
             uint32_t lineno = 0;
             while (fgets(fline, sizeof(fline), ffp) != NULL) {
                 ++lineno;
                 testutil_assertfmt(fgets(sline, sizeof(sline), sfp) != NULL,
-                  "%s line %" PRIu32 " has no counterpart in %s", relay_fname, lineno,
-                  schema_fname);
+                  "%s line %" PRIu32 " has no counterpart in %s", follower_fname, lineno,
+                  leader_fname);
 
                 const size_t flen = strlen(fline);
                 if (flen > 0 && fline[flen - 1] == '\n')
                     testutil_assertfmt(strcmp(fline, sline) == 0,
-                      "%s diverges from %s at line %" PRIu32 ": \"%s\" vs \"%s\"", relay_fname,
-                      schema_fname, lineno, fline, sline);
+                      "%s diverges from %s at line %" PRIu32 ": \"%s\" vs \"%s\"", follower_fname,
+                      leader_fname, lineno, fline, sline);
                 else
                     /* Partial trailing line: the recorder was killed mid-write. */
                     testutil_assertfmt(strncmp(sline, fline, flen) == 0,
                       "%s truncated line %" PRIu32 " is not a prefix of %s: \"%s\" vs \"%s\"",
-                      relay_fname, lineno, schema_fname, fline, sline);
+                      follower_fname, lineno, leader_fname, fline, sline);
             }
 
             (void)fclose(ffp);
@@ -338,6 +327,6 @@ verify_relay_prefix(const TEST_CONFIG *cfg)
         }
 
     println("Relay verify: %" PRIu32
-            " relay record files are prefixes of the peer's schema records",
+            " follower record files are prefixes of the peer's leader records",
       checked);
 }

--- a/test/csuite/schema_disagg_abort/worker.c
+++ b/test/csuite/schema_disagg_abort/worker.c
@@ -1,0 +1,292 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+/*
+ * The worker stage: N threads applying what the reader queued, exactly as the source stream fixed
+ * each event, so both roles execute an identical history. Writes the verifier's record files, and
+ * reports each completed operation as the thread's frontier mark.
+ */
+
+#include "schema_disagg_abort.h"
+
+/* The table configuration every schema table is created with, on either role. */
+#define SCHEMA_TABLE_CONFIG "key_format=S,value_format=S,type=layered,block_manager=disagg"
+
+/* Thread argument: the shared workload state plus this worker's identity. */
+typedef struct {
+    WORKLOAD_STATE *state;
+    uint32_t thread_index;
+} THREAD_ARG;
+
+/* Per-thread worker state for one phase. */
+typedef struct {
+    WT_SESSION *session;
+    FILE *record_fp; /* records for what this node originated, or for what it applied */
+} WORKER_CTX;
+
+/*
+ * record_event_line --
+ *     Append one event to a record file; the one place that defines the record format for both the
+ *     schema and the relay files.
+ */
+static void
+record_event_line(FILE *fp, const SCHEMA_EVENT *ev)
+{
+    int ret = 0;
+
+    switch (ev->type) {
+    case EVENT_CREATE:
+    case EVENT_DROP:
+        ret = fprintf(fp, "%s %" PRIu64 " %s\n", ev->type == EVENT_CREATE ? "CREATE" : "DROP",
+          ev->event_ts, ev->uri);
+        break;
+    case EVENT_INSERT:
+        ret = fprintf(fp, "INSERT %" PRIu64 " %" PRIu32 " %" PRIu32 " %s\n", ev->event_ts,
+          ev->key_min, ev->key_max, ev->uri);
+        break;
+    case EVENT_CKPT:
+    case EVENT_SWITCH:
+        testutil_assertfmt(false, "Unexpected record event type: %d", ev->type);
+    }
+    if (ret < 0)
+        testutil_die(EIO, "fprintf event record");
+}
+
+/*
+ * worker_record_open --
+ *     Open a worker's record file, named for the origin of what it logs: the operations this node
+ *     produced itself go to its leader records, the peer's relayed events to its follower records.
+ *     Append so a later phase preserves the earlier records for the post-crash verifier.
+ */
+static FILE *
+worker_record_open(const WORKLOAD_STATE *state, uint32_t thread_index)
+{
+    char fname[128];
+    testutil_snprintf(fname, sizeof(fname),
+      state->generates ? LEADER_RECORDS_FILE : FOLLOWER_RECORDS_FILE, state->cfg->node_id,
+      thread_index);
+
+    FILE *fp;
+    testutil_assert_errno((fp = fopen(fname, "a")) != NULL);
+    /* Flush the record file per line so entries survive a SIGKILL crash. */
+    __wt_stream_set_line_buffer(fp);
+    return (fp);
+}
+
+/*
+ * schema_op_execute --
+ *     Execute one schema operation: the single call site for creating and dropping the test's
+ *     tables, on either role. EBUSY is retried (the stream cannot be reordered, and when the source
+ *     is the peer the operation already succeeded there), with a bound so a wedged operation fails
+ *     the test instead of hanging it.
+ */
+static void
+schema_op_execute(WT_SESSION *session, const SCHEMA_EVENT *ev)
+{
+    const bool is_create = ev->type == EVENT_CREATE;
+    testutil_assert(ev->type == EVENT_CREATE || ev->type == EVENT_DROP);
+
+    struct timespec start;
+    __wt_epoch(NULL, &start);
+
+    int ret;
+    for (;;) {
+        ret = is_create ? session->create(session, ev->uri, SCHEMA_TABLE_CONFIG) :
+                          session->drop(session, ev->uri, "force=false,lock_wait=false");
+        if (ret != EBUSY)
+            break;
+
+        struct timespec now;
+        __wt_epoch(NULL, &now);
+        if (WT_TIMEDIFF_SEC(now, start) > MAX_STARTUP)
+            testutil_die(ETIMEDOUT, "%s %s: EBUSY for %d seconds", is_create ? "CREATE" : "DROP",
+              ev->uri, MAX_STARTUP);
+        __wt_yield();
+    }
+    testutil_assertfmt(ret == 0, "%s %s (ts %" PRIu64 "): %s", is_create ? "CREATE" : "DROP",
+      ev->uri, ev->event_ts, wiredtiger_strerror(ret));
+}
+
+/*
+ * schema_op_publish --
+ *     Publish the schema operation at the given epoch so it becomes visible in shared metadata at
+ *     the next checkpoint. Runs on both roles: a follower's applied operations queue up and drain
+ *     when it eventually leads.
+ */
+static void
+schema_op_publish(WT_SESSION *session, const char *uri, uint64_t epoch)
+{
+    char pub_cfg[64];
+    testutil_snprintf(pub_cfg, sizeof(pub_cfg), "disaggregated=(schema_epoch=%" PRIx64 ")", epoch);
+    testutil_check(session->publish(session, uri, pub_cfg));
+}
+
+/*
+ * schema_op_insert_data --
+ *     Populate a table with rows keyed key_min..key_max at the given commit timestamp; each row is
+ *     valued with the commit timestamp, so the verifier can tell which generation of a reused table
+ *     name wrote the data.
+ */
+static void
+schema_op_insert_data(
+  WT_SESSION *session, const char *uri, uint64_t commit_ts, uint32_t key_min, uint32_t key_max)
+{
+    char val_buf[32];
+    testutil_snprintf(val_buf, sizeof(val_buf), "%" PRIu64, commit_ts);
+    testutil_check(session->begin_transaction(session, NULL));
+
+    WT_CURSOR *cursor;
+    testutil_check(session->open_cursor(session, uri, NULL, NULL, &cursor));
+    for (uint32_t r = key_min; r <= key_max; r++) {
+        char key_buf[16];
+        testutil_snprintf(key_buf, sizeof(key_buf), "%" PRIu32, r);
+        cursor->set_key(cursor, key_buf);
+        cursor->set_value(cursor, val_buf);
+        testutil_check(cursor->insert(cursor));
+    }
+    testutil_check(cursor->close(cursor));
+
+    char commit_cfg[64];
+    testutil_snprintf(commit_cfg, sizeof(commit_cfg), "commit_timestamp=%" PRIx64, commit_ts);
+    testutil_check(session->commit_transaction(session, commit_cfg));
+}
+
+/*
+ * worker_complete --
+ *     Mark one allocator value fully completed by a worker: track it in the counter (a no-op for
+ *     freshly allocated values) and publish it as the thread's completed frontier mark.
+ */
+static void
+worker_complete(WORKLOAD_STATE *state, uint32_t thread_index, uint64_t value)
+{
+    workload_counter_advance(state, value);
+    (void)__wt_atomic_add_uint64(&state->applied, 1);
+    __wt_atomic_store_uint64_release(&state->workers[thread_index].completed_ts, value);
+}
+
+/*
+ * apply_event --
+ *     Apply one event on this node, identically for both roles and exactly as the source stream
+ *     fixed it - same operation, same epoch, same commit timestamp: execute the schema operation or
+ *     the insert, record the event, publish a schema operation, relay it to the peer when leading,
+ *     and mark it completed.
+ *
+ * The ordering is load-bearing. A schema operation is recorded before it is published, so the
+ *     record reaches the file before a checkpoint can make the epoch durable (a record without a
+ *     durable epoch is ignored by the verifier, the reverse would be a hole). The relay precedes
+ *     the completion store, which is what lets the stable frontier advance past this operation,
+ *     what lets a checkpoint cover it, and what lets the checkpoint thread send that checkpoint's
+ *     pipe event: the peer holds every event at or below a checkpoint's stable frontier by the time
+ *     it sees that checkpoint's event.
+ */
+static void
+apply_event(WORKLOAD_STATE *state, WORKER_CTX *ctx, uint32_t thread_index, const SCHEMA_EVENT *ev)
+{
+    const bool relay = state->leads;
+
+    if (ctx->record_fp == NULL)
+        ctx->record_fp = worker_record_open(state, thread_index);
+
+    switch (ev->type) {
+    case EVENT_INSERT:
+        schema_op_insert_data(ctx->session, ev->uri, ev->event_ts, ev->key_min, ev->key_max);
+        record_event_line(ctx->record_fp, ev);
+        if (relay)
+            (void)node_event_send(state->cfg, ev);
+        worker_complete(state, thread_index, ev->event_ts);
+        break;
+    case EVENT_CREATE:
+    case EVENT_DROP:
+        schema_op_execute(ctx->session, ev);
+        record_event_line(ctx->record_fp, ev);
+        schema_op_publish(ctx->session, ev->uri, ev->event_ts);
+        if (relay)
+            (void)node_event_send(state->cfg, ev);
+        worker_complete(state, thread_index, ev->event_ts);
+        break;
+    case EVENT_CKPT:
+    case EVENT_SWITCH:
+        testutil_assertfmt(false, "Unexpected apply event type: %d", ev->type);
+    }
+}
+
+/*
+ * worker_apply_loop --
+ *     A worker's phase, identical in both roles: execute whatever the reader queued while the phase
+ *     runs, then drain the queue so a graceful stop loses nothing.
+ */
+static void
+worker_apply_loop(WORKLOAD_STATE *state, WORKER_CTX *ctx, uint32_t thread_index)
+{
+    bool *busyp = &state->workers[thread_index].busy;
+
+    while (workload_running(state) || !workload_queue_empty(state, thread_index)) {
+        /* Publish busy before checking the queue so the drain barrier never races an apply. */
+        __wt_atomic_store_bool_release(busyp, true);
+        SCHEMA_EVENT ev;
+        const bool popped = workload_dequeue(state, thread_index, &ev);
+        if (popped)
+            apply_event(state, ctx, thread_index, &ev);
+        __wt_atomic_store_bool_release(busyp, false);
+        if (!popped)
+            __wt_sleep(0, WT_THOUSAND);
+    }
+}
+
+/*
+ * thread_worker_run --
+ *     One worker thread: set up the per-phase context, run the processing loop, tear the context
+ *     down.
+ */
+static WT_THREAD_RET
+thread_worker_run(void *arg)
+{
+    const THREAD_ARG *ta = arg;
+    WORKLOAD_STATE *state = ta->state;
+
+    WORKER_CTX ctx;
+    WT_CLEAR(ctx);
+    testutil_check(state->conn->open_session(state->conn, NULL, NULL, &ctx.session));
+
+    worker_apply_loop(state, &ctx, ta->thread_index);
+
+    if (ctx.record_fp != NULL)
+        testutil_check(fclose(ctx.record_fp));
+    testutil_check(ctx.session->close(ctx.session, NULL));
+    return (WT_THREAD_RET_VALUE);
+}
+
+/* Thread handles have process lifetime; phases join and restart them but never free them. */
+static wt_thread_t worker_thr[MAX_TH];
+static THREAD_ARG worker_arg[MAX_TH];
+
+/*
+ * node_workers_start --
+ *     Start this phase's worker threads.
+ */
+void
+node_workers_start(WORKLOAD_STATE *state)
+{
+    for (uint32_t i = 0; i < state->nth_workers; i++) {
+        worker_arg[i].state = state;
+        worker_arg[i].thread_index = i;
+        testutil_check(__wt_thread_create(NULL, &worker_thr[i], thread_worker_run, &worker_arg[i]));
+    }
+}
+
+/*
+ * node_workers_join --
+ *     Join the worker threads. The engine has already directed the phase to quiesce, which the
+ *     workers answer by draining whatever the reader delivered before exiting.
+ */
+void
+node_workers_join(WORKLOAD_STATE *state)
+{
+    for (uint32_t i = 0; i < state->nth_workers; i++)
+        testutil_check(__wt_thread_join(NULL, &worker_thr[i]));
+}

--- a/test/csuite/schema_disagg_abort/worker.c
+++ b/test/csuite/schema_disagg_abort/worker.c
@@ -166,7 +166,7 @@ worker_complete(WORKLOAD_STATE *state, uint32_t thread_index, uint64_t value)
 {
     workload_counter_advance(state, value);
     (void)__wt_atomic_add_uint64(&state->applied, 1);
-    __wt_atomic_store_uint64_release(&state->workers[thread_index].completed_ts, value);
+    __wt_atomic_store_uint64(&state->workers[thread_index].completed_ts, value);
 }
 
 /*
@@ -227,12 +227,12 @@ worker_apply_loop(WORKLOAD_STATE *state, WORKER_CTX *ctx, uint32_t thread_index)
 
     while (workload_running(state) || !workload_queue_empty(state, thread_index)) {
         /* Publish busy before checking the queue so the drain barrier never races an apply. */
-        __wt_atomic_store_bool_release(busyp, true);
+        __wt_atomic_store_bool(busyp, true);
         SCHEMA_EVENT ev;
         const bool popped = workload_dequeue(state, thread_index, &ev);
         if (popped)
             apply_event(state, ctx, thread_index, &ev);
-        __wt_atomic_store_bool_release(busyp, false);
+        __wt_atomic_store_bool(busyp, false);
         if (!popped)
             __wt_sleep(0, WT_THOUSAND);
     }

--- a/test/evergreen_disagg.yml
+++ b/test/evergreen_disagg.yml
@@ -658,8 +658,9 @@ variables:
             build_dir=$(cd ../../../ && pwd)
             for i in $(seq ${times|10}); do
               echo "Iteration $i/${times|10}"
-              # Max out pool size (-s) and schema threads (-T) for maximum schema churn.
-              ./test_schema_disagg_abort -b "$build_dir" -s 64 -T 12 -t 300
+              # One node leading throughout. Max out the schema threads (-T) and the per-thread
+              # URI pool (-u) for maximum schema churn.
+              ./test_schema_disagg_abort -b "$build_dir" -r l -T 12 -u 64 -t 300
             done
 
   - &schema-disagg-abort-switch-test-disagg
@@ -679,8 +680,120 @@ variables:
             build_dir=$(cd ../../../ && pwd)
             for i in $(seq ${times|10}); do
               echo "Iteration $i/${times|10}"
-              # Switch mode (-m) exercises a random role switch mid-workload before the crash.
-              ./test_schema_disagg_abort -b "$build_dir" -s 64 -T 12 -t 300 -m
+              # One node stepping down and back up every 30 seconds (-s).
+              ./test_schema_disagg_abort -b "$build_dir" -r l -s 30 -T 12 -u 64 -t 300
+            done
+
+  - &schema-disagg-abort-crash-test-disagg
+    depends_on:
+        - name: compile
+    exec_timeout_secs: 7200
+    commands:
+      - func: "fetch artifacts"
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger/cmake_build/test/csuite/schema_disagg_abort"
+          shell: bash
+          script: |
+            set -o errexit
+            set -o verbose
+            ${PREPARE_TEST_ENV}
+            build_dir=$(cd ../../../ && pwd)
+            for i in $(seq ${times|10}); do
+              echo "Iteration $i/${times|10}"
+              # SIGKILL the lone node at 150s (-k), then recover and verify at the timeout.
+              ./test_schema_disagg_abort -b "$build_dir" -r l -k 150 -T 12 -u 64 -t 300
+            done
+
+  - &schema-disagg-abort-multi-test-disagg
+    depends_on:
+        - name: compile
+    exec_timeout_secs: 7200
+    commands:
+      - func: "fetch artifacts"
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger/cmake_build/test/csuite/schema_disagg_abort"
+          shell: bash
+          script: |
+            set -o errexit
+            set -o verbose
+            ${PREPARE_TEST_ENV}
+            build_dir=$(cd ../../../ && pwd)
+            for i in $(seq ${times|10}); do
+              echo "Iteration $i/${times|10}"
+              # Leader and follower (-r lf): the follower applies the relayed stream and picks up
+              # the leader's checkpoints.
+              ./test_schema_disagg_abort -b "$build_dir" -r lf -T 12 -u 64 -t 300
+            done
+
+  - &schema-disagg-abort-multi-crash-test-disagg
+    depends_on:
+        - name: compile
+    exec_timeout_secs: 7200
+    commands:
+      - func: "fetch artifacts"
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger/cmake_build/test/csuite/schema_disagg_abort"
+          shell: bash
+          script: |
+            set -o errexit
+            set -o verbose
+            ${PREPARE_TEST_ENV}
+            build_dir=$(cd ../../../ && pwd)
+            for i in $(seq ${times|10}); do
+              echo "Iteration $i/${times|10}"
+              # Kill the leader at 100s and the follower at 200s; each survivor carries on alone.
+              ./test_schema_disagg_abort -b "$build_dir" -r lf -k l100 -k f200 -T 12 -u 64 -t 300
+            done
+
+  # Two-node role switches. A step-up over a table the peer created, dropped and recreated still
+  # trips the stale-metadata paths, so this task is EXPECTED to fail until FIXME-WT-18068 and
+  # FIXME-WT-17746 land, and to pass afterwards.
+  - &schema-disagg-abort-multi-switch-test-disagg
+    depends_on:
+        - name: compile
+    exec_timeout_secs: 7200
+    commands:
+      - func: "fetch artifacts"
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger/cmake_build/test/csuite/schema_disagg_abort"
+          shell: bash
+          script: |
+            set -o errexit
+            set -o verbose
+            ${PREPARE_TEST_ENV}
+            build_dir=$(cd ../../../ && pwd)
+            for i in $(seq ${times|10}); do
+              echo "Iteration $i/${times|10}"
+              # The two nodes swap roles every 30 seconds.
+              ./test_schema_disagg_abort -b "$build_dir" -r lf -s 30 -T 12 -u 64 -t 300
+            done
+
+  # Same step-up exposure as above, with a kill on top: also EXPECTED to fail until
+  # FIXME-WT-18068 and FIXME-WT-17746 land.
+  - &schema-disagg-abort-multi-switch-crash-test-disagg
+    depends_on:
+        - name: compile
+    exec_timeout_secs: 7200
+    commands:
+      - func: "fetch artifacts"
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger/cmake_build/test/csuite/schema_disagg_abort"
+          shell: bash
+          script: |
+            set -o errexit
+            set -o verbose
+            ${PREPARE_TEST_ENV}
+            build_dir=$(cd ../../../ && pwd)
+            for i in $(seq ${times|10}); do
+              echo "Iteration $i/${times|10}"
+              # Swap roles every 30s and kill whoever leads at 150s; the survivor keeps switching
+              # by sentinel.
+              ./test_schema_disagg_abort -b "$build_dir" -r lf -s 30 -k l150 -T 12 -u 64 -t 300
             done
 
   - &schema-disagg-abort-smoke-test-disagg
@@ -697,7 +810,9 @@ variables:
             set -o errexit
             set -o verbose
             ${PREPARE_TEST_ENV}
-            # Lightweight smoke coverage: leader plus short switch-mode runs.
+            # The full mode matrix in short runs: single node, lone follower, role switches,
+            # kills, and both two-node topologies. The two-node switch modes at the end are
+            # EXPECTED to fail until FIXME-WT-18068 and FIXME-WT-17746 land.
             bash ./smoke.sh
 
   # Configure flags for builtins.
@@ -771,6 +886,26 @@ tasks:
 
   - <<: *schema-disagg-abort-switch-test-disagg
     name: schema-disagg-abort-switch-test-disagg-1
+    tags: ["stress-test-disagg-fail", "stress-test-disagg-san-fail"]
+
+  - <<: *schema-disagg-abort-crash-test-disagg
+    name: schema-disagg-abort-crash-test-disagg-1
+    tags: ["stress-test-disagg-fail", "stress-test-disagg-san-fail"]
+
+  - <<: *schema-disagg-abort-multi-test-disagg
+    name: schema-disagg-abort-multi-test-disagg-1
+    tags: ["stress-test-disagg-fail", "stress-test-disagg-san-fail"]
+
+  - <<: *schema-disagg-abort-multi-crash-test-disagg
+    name: schema-disagg-abort-multi-crash-test-disagg-1
+    tags: ["stress-test-disagg-fail", "stress-test-disagg-san-fail"]
+
+  - <<: *schema-disagg-abort-multi-switch-test-disagg
+    name: schema-disagg-abort-multi-switch-test-disagg-1
+    tags: ["stress-test-disagg-fail", "stress-test-disagg-san-fail"]
+
+  - <<: *schema-disagg-abort-multi-switch-crash-test-disagg
+    name: schema-disagg-abort-multi-switch-crash-test-disagg-1
     tags: ["stress-test-disagg-fail", "stress-test-disagg-san-fail"]
 
   - <<: *schema-disagg-abort-smoke-test-disagg

--- a/test/evergreen_disagg.yml
+++ b/test/evergreen_disagg.yml
@@ -748,9 +748,7 @@ variables:
               ./test_schema_disagg_abort -b "$build_dir" -r lf -k l100 -k f200 -T 12 -u 64 -t 300
             done
 
-  # Two-node role switches. A step-up over a table the peer created, dropped and recreated still
-  # trips the stale-metadata paths, so this task is EXPECTED to fail until FIXME-WT-18068 and
-  # FIXME-WT-17746 land, and to pass afterwards.
+  # Two-node role switches. A step-up over a table the peer created.
   - &schema-disagg-abort-multi-switch-test-disagg
     depends_on:
         - name: compile
@@ -772,8 +770,7 @@ variables:
               ./test_schema_disagg_abort -b "$build_dir" -r lf -s 30 -T 12 -u 64 -t 300
             done
 
-  # Same step-up exposure as above, with a kill on top: also EXPECTED to fail until
-  # FIXME-WT-18068 and FIXME-WT-17746 land.
+  # Same step-up exposure as above, with a kill on top.
   - &schema-disagg-abort-multi-switch-crash-test-disagg
     depends_on:
         - name: compile
@@ -794,6 +791,29 @@ variables:
               # Swap roles every 30s and kill whoever leads at 150s; the survivor keeps switching
               # by sentinel.
               ./test_schema_disagg_abort -b "$build_dir" -r lf -s 30 -k l150 -T 12 -u 64 -t 300
+            done
+
+  - &schema-disagg-abort-follower-stepup-test-disagg
+    depends_on:
+        - name: compile
+    exec_timeout_secs: 7200
+    commands:
+      - func: "fetch artifacts"
+      - command: shell.exec
+        params:
+          working_dir: "wiredtiger/cmake_build/test/csuite/schema_disagg_abort"
+          shell: bash
+          script: |
+            set -o errexit
+            set -o verbose
+            ${PREPARE_TEST_ENV}
+            build_dir=$(cd ../../../ && pwd)
+            for i in $(seq ${times|10}); do
+              echo "Iteration $i/${times|10}"
+              # A lone follower generates its own workload and never checkpoints, then steps up over
+              # the operations it accumulated: the way a fresh node bootstraps its own tables before
+              # taking leadership.
+              ./test_schema_disagg_abort -b "$build_dir" -r f -s 30 -T 12 -u 64 -t 300
             done
 
   - &schema-disagg-abort-smoke-test-disagg
@@ -906,6 +926,10 @@ tasks:
 
   - <<: *schema-disagg-abort-multi-switch-crash-test-disagg
     name: schema-disagg-abort-multi-switch-crash-test-disagg-1
+    tags: ["stress-test-disagg-fail", "stress-test-disagg-san-fail"]
+
+  - <<: *schema-disagg-abort-follower-stepup-test-disagg
+    name: schema-disagg-abort-follower-stepup-test-disagg-1
     tags: ["stress-test-disagg-fail", "stress-test-disagg-san-fail"]
 
   - <<: *schema-disagg-abort-smoke-test-disagg


### PR DESCRIPTION
- schema_disagg_abort has been expanded to include leader/follower multi-node scenarios
