### PR TITLE
WT-18140 Suppress expected log-salvage output in test_truncate30

### DIFF
--- a/test/suite/test_truncate30.py
+++ b/test/suite/test_truncate30.py
@@ -105,6 +105,11 @@ class test_truncate30(wttest.WiredTigerTestCase):
         # into level-2 internal page splits that create dsk==NULL pages
         # inheriting page_del children from the replayed truncation.
         # Without the fix: SIGSEGV. With the fix: recovery completes cleanly.
+        #
+        # The WAL is copied while it may be mid-write, so recovery can find a torn
+        # final record and salvage/truncate the log. Those NOTICE messages are an
+        # expected outcome of the crash simulation, not a failure.
+        self.ignoreStdoutPattern('log record at position|corrupted at position|salvage: log file')
         simulate_crash_restart(self, '.', 'CRASH')
 
         # ---- Phase 4: verify integrity ----


### PR DESCRIPTION
## WT-18140

`test_truncate30.test_truncate_recovery_null_dsk` fails intermittently because it produces unexpected WAL-related logs

### Root cause

The test writes operations to the WAL only (no checkpoint) and then calls `simulate_crash_restart`, which copies the database files **while the connection is still open** and runs recovery on the copy. Because the WAL is copied mid-flight, the final log record is sometimes captured partially written. Recovery's log-verification path (`__log_record_verify` / `__log_scan`) then sees a zero-length record header, emits the three `[WT_VERB_LOG][NOTICE]` messages above, and salvages/truncates the log — which is **correct, expected recovery behaviour** (the same NOTICE is deliberately asserted in `test_log06.py`).

The test never told the harness those messages were expected, so whenever the copy happens to land mid-record, the `tearDown` output check fails. Purely a test-timing flake, no product bug.

### Fix

Suppress the expected salvage/truncation NOTICE lines with `ignoreStdoutPattern`, the same way other recovery/salvage tests do (e.g. `test_cc10.py`, `test_corrupt01.py`).
