### PR TITLE
WT-17091 Preserve the shared metadata queue across step-down

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -517,6 +517,7 @@ conn_stats = [
     # Checkpoint statistics
     ##########################################
     CheckpointStat('checkpoint_disagg_metadata_apply', 'metadata operations applied during disaggregated checkpoint', 'no_clear,no_scale'),
+    CheckpointStat('checkpoint_disagg_metadata_pair_canceled', 'create and remove metadata operation pairs canceled during disaggregated checkpoint because the remove was not covered', 'no_clear,no_scale'),
     CheckpointStat('checkpoint_disagg_metadata_unstable', 'metadata operations skipped during disaggregated checkpoint because they were not stable', 'no_clear,no_scale'),
     CheckpointStat('checkpoint_fsync_post', 'fsync calls after allocating the transaction ID'),
     CheckpointStat('checkpoint_fsync_post_duration', 'fsync duration after allocating the transaction ID (usecs)', 'no_clear,no_scale'),

--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -517,7 +517,7 @@ conn_stats = [
     # Checkpoint statistics
     ##########################################
     CheckpointStat('checkpoint_disagg_metadata_apply', 'metadata operations applied during disaggregated checkpoint', 'no_clear,no_scale'),
-    CheckpointStat('checkpoint_disagg_metadata_pair_canceled', 'create and remove metadata operation pairs canceled during disaggregated checkpoint because the remove was not covered', 'no_clear,no_scale'),
+    CheckpointStat('checkpoint_disagg_metadata_pair_canceled', 'create and remove metadata operation pairs canceled during disaggregated checkpoint because the remove was never published', 'no_clear,no_scale'),
     CheckpointStat('checkpoint_disagg_metadata_unstable', 'metadata operations skipped during disaggregated checkpoint because they were not stable', 'no_clear,no_scale'),
     CheckpointStat('checkpoint_fsync_post', 'fsync calls after allocating the transaction ID'),
     CheckpointStat('checkpoint_fsync_post_duration', 'fsync duration after allocating the transaction ID (usecs)', 'no_clear,no_scale'),

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -115,13 +115,14 @@ err:
 }
 
 /*
- * __layered_create_has_following_remove --
- *     Return true if there is a REMOVE entry for the same URI after the given CREATE entry in the
- *     shared metadata queue.
+ * __layered_create_following_remove --
+ *     Return the first REMOVE entry for the same URI after the given CREATE entry in the shared
+ *     metadata queue, or NULL if there is none. When cur_schema_epoch is not WT_SCHEMA_EPOCH_NONE,
+ *     return the REMOVE only if it defers past a checkpoint at that schema epoch.
  */
-static bool
-__layered_create_has_following_remove(
-  WT_SESSION_IMPL *session, WT_CONNECTION_IMPL *conn, WT_DISAGG_METADATA_OP *create_entry)
+static WT_DISAGG_METADATA_OP *
+__layered_create_following_remove(WT_SESSION_IMPL *session, WT_CONNECTION_IMPL *conn,
+  WT_DISAGG_METADATA_OP *create_entry, wt_timestamp_t cur_schema_epoch)
 {
     WT_DISAGG_METADATA_OP *tmp;
 
@@ -129,7 +130,7 @@ __layered_create_has_following_remove(
 
     tmp = TAILQ_NEXT(create_entry, q);
     if (tmp == NULL)
-        return (false);
+        return (NULL);
 
     TAILQ_FOREACH_FROM(tmp, &conn->disaggregated_storage.shared_metadata_qh, q)
     {
@@ -140,10 +141,19 @@ __layered_create_has_following_remove(
              * REMOVE at an earlier epoch than the CREATE is a bug in the queue.
              */
             WT_ASSERT(session, tmp->schema_epoch >= create_entry->schema_epoch);
-            return (true);
+            /*
+             * Only the first following REMOVE can pair with the CREATE: a later REMOVE for the same
+             * URI belongs to a re-create, so if this one is covered by the checkpoint, stop the
+             * scan rather than skipping it.
+             */
+            if (cur_schema_epoch != WT_SCHEMA_EPOCH_NONE &&
+              tmp->schema_epoch != WT_SCHEMA_EPOCH_UNPUBLISHED &&
+              tmp->schema_epoch <= cur_schema_epoch)
+                return (NULL);
+            return (tmp);
         }
     }
-    return (false);
+    return (NULL);
 }
 
 /*
@@ -183,7 +193,7 @@ __layered_create_missing_stable_tables_helper(WT_SESSION_IMPL *session)
         WT_ASSERT(session, WT_PREFIX_MATCH(entry->stable_uri, "file:"));
 
         /* Check if the table was dropped. */
-        if (__layered_create_has_following_remove(session, conn, entry)) {
+        if (__layered_create_following_remove(session, conn, entry, WT_SCHEMA_EPOCH_NONE) != NULL) {
             __wt_verbose_debug2(session, WT_VERB_DISAGGREGATED_STORAGE,
               "Skip creating missing stable table \"%s\" with schema epoch %" PRIu64
               " from layered config \"%s\" since it is being dropped",
@@ -692,7 +702,7 @@ __wt_disagg_shared_metadata_queue_process(
     struct __wt_disagg_shared_metadata_qh skipped_creates;
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
-    WT_DISAGG_METADATA_OP *entry, *skipped, *tmp;
+    WT_DISAGG_METADATA_OP *entry, *remove_entry, *skipped, *tmp;
 
     WT_ASSERT(session, drop_sizep != NULL);
     conn = S2C(session);
@@ -728,6 +738,37 @@ __wt_disagg_shared_metadata_queue_process(
             continue;
         }
 
+        /*
+         * A covered CREATE whose first following REMOVE defers past this checkpoint means the table
+         * was dropped locally but the drop is not yet published. Applying the CREATE alone would
+         * advertise a table in shared metadata that no node can serve, so cancel both entries: the
+         * pair nets out because no checkpoint covering only the CREATE has been taken. In legacy
+         * mode nothing defers by epoch, so there is nothing to check.
+         */
+        if (cur_schema_epoch != WT_SCHEMA_EPOCH_NONE &&
+          entry->metadata_op == WT_SHARED_METADATA_CREATE &&
+          (remove_entry =
+              __layered_create_following_remove(session, conn, entry, cur_schema_epoch)) != NULL) {
+            __wt_verbose_error(session, WT_VERB_DISAGGREGATED_STORAGE,
+              "Table \"%s\" was created at epoch %" PRIu64
+              " covered by this checkpoint (schema epoch %" PRIu64
+              "), but its drop at epoch %" PRIu64
+              " was not: canceling both operations so the dropped table is not published to "
+              "shared metadata.",
+              entry->table_name, entry->schema_epoch, cur_schema_epoch, remove_entry->schema_epoch);
+            WT_STAT_CONN_INCR(session, checkpoint_disagg_metadata_pair_canceled);
+
+            /* The canceled REMOVE may be the loop's saved next entry; step past it. */
+            if (remove_entry == tmp)
+                tmp = TAILQ_NEXT(tmp, q);
+            TAILQ_REMOVE(&conn->disaggregated_storage.shared_metadata_qh, remove_entry, q);
+            __disagg_shared_metadata_queue_free(session, &remove_entry);
+
+            TAILQ_REMOVE(&conn->disaggregated_storage.shared_metadata_qh, entry, q);
+            __disagg_shared_metadata_queue_free(session, &entry);
+            continue;
+        }
+
         /* Park CREATE entries with no stable_value; cancel them if a matching REMOVE follows. */
         if (__disagg_handle_create_remove_pairing(session, conn, entry, &skipped_creates))
             continue;
@@ -749,10 +790,11 @@ __wt_disagg_shared_metadata_queue_process(
     }
 
     /*
-     * Any unmatched parked CREATE entry is an API violation: the stable epoch falls between the
-     * CREATE and DROP epochs, so this checkpoint must include the table in shared metadata. But the
-     * table was dropped and its stable constituent was never created, so we have no data to write.
-     * Publish CREATE and DROP at the same epoch to avoid this window.
+     * Any unmatched parked CREATE entry is an API violation: it is covered by this checkpoint, its
+     * stable constituent was never created so there is no data to write, and no REMOVE for the same
+     * URI remains queued to explain it -- a REMOVE deferring past this checkpoint was canceled
+     * together with its CREATE above, and a covered REMOVE cancels the parked CREATE when
+     * processed.
      */
     if (!TAILQ_EMPTY(&skipped_creates)) {
         TAILQ_FOREACH (skipped, &skipped_creates, q)

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -320,6 +320,53 @@ err:
 }
 
 /*
+ * __disagg_cancel_unpublished_creates --
+ *     Cancel the trailing unpublished CREATE entries for the table, returning true if any were
+ *     canceled: the caller is about to enqueue an unpublished REMOVE, so neither side of the pair
+ *     can ever be covered by a checkpoint and the entries net out. (A create through the table:
+ *     prefix enqueues two CREATE entries, hence the loop.) Any other shape must stay queued --
+ *     a published CREATE may be covered by a later checkpoint (the checkpoint-time cancellation in
+ *     __wt_disagg_shared_metadata_queue_process handles a REMOVE deferring past it), and this
+ *     REMOVE may be published later.
+ */
+static bool
+__disagg_cancel_unpublished_creates(WT_SESSION_IMPL *session, const char *table_name)
+{
+    WT_CONNECTION_IMPL *conn;
+    WT_DISAGG_METADATA_OP *entry, *tmp;
+    bool canceled;
+
+    conn = S2C(session);
+    canceled = false;
+
+    /*
+     * The scan and the removals must be one critical section; the schema lock, held by all enqueue
+     * callers, keeps the decision valid until the caller returns.
+     */
+    __wt_spin_lock(session, &conn->disaggregated_storage.shared_metadata_queue_lock);
+    TAILQ_FOREACH_REVERSE_SAFE(entry, &conn->disaggregated_storage.shared_metadata_qh,
+      __wt_disagg_shared_metadata_qh, q, tmp)
+    {
+        if (entry->metadata_op == WT_SHARED_METADATA_UPDATE ||
+          strcmp(entry->table_name, table_name) != 0)
+            continue;
+        if (entry->metadata_op != WT_SHARED_METADATA_CREATE ||
+          entry->schema_epoch != WT_SCHEMA_EPOCH_UNPUBLISHED)
+            break;
+        __wt_verbose_debug1(session, WT_VERB_DISAGGREGATED_STORAGE,
+          "Canceling the unpublished CREATE for table \"%s\" (stable URI \"%s\"): the table was "
+          "created and dropped without being published, so the REMOVE is not enqueued",
+          entry->table_name, entry->stable_uri);
+        TAILQ_REMOVE(&conn->disaggregated_storage.shared_metadata_qh, entry, q);
+        __disagg_shared_metadata_queue_free(session, &entry);
+        canceled = true;
+    }
+    __wt_spin_unlock(session, &conn->disaggregated_storage.shared_metadata_queue_lock);
+
+    return (canceled);
+}
+
+/*
  * __wt_disagg_enqueue_metadata_operation --
  *     Enqueue a metadata operation for a given URI into the shared metadata table to be done at the
  *     next checkpoint.
@@ -344,6 +391,23 @@ __wt_disagg_enqueue_metadata_operation(WT_SESSION_IMPL *session, const char *sta
      * parent session.
      */
     WT_ASSERT(session, FLD_ISSET(session->lock_flags, WT_SESSION_LOCKED_SCHEMA));
+
+    /*
+     * An unpublished REMOVE pairing with an unpublished CREATE cancels it eagerly: the entries
+     * would otherwise linger forever, and on a follower the lingering REMOVE reads as a local drop
+     * newer than every checkpoint, blocking pickup of a table published under the same name. The
+     * cancellation relies on an unpublished CREATE implying the table is absent from shared
+     * metadata, which does not hold in legacy mode (the legacy step-up enqueues unpublished CREATE
+     * entries for tables already in shared metadata, and nothing defers by epoch), so require a
+     * schema epoch: the stable epoch on a leader, or the last picked-up checkpoint's epoch on a
+     * follower. In legacy mode the pair stays queued and nets out at the next checkpoint.
+     */
+    if (metadata_op == WT_SHARED_METADATA_REMOVE && schema_epoch == WT_SCHEMA_EPOCH_UNPUBLISHED &&
+      (__wt_get_stable_disaggregated_schema_epoch(session) != WT_SCHEMA_EPOCH_NONE ||
+        __wt_atomic_load_uint64_acquire(&conn->txn_global.last_ckpt_disaggregated_schema_epoch) !=
+          WT_SCHEMA_EPOCH_NONE) &&
+      __disagg_cancel_unpublished_creates(session, table_name))
+        return (0);
 
     /* Allocate the entry structure. */
     WT_ERR(__wt_calloc_one(session, &entry));

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -10,7 +10,7 @@
 
 static int __disagg_accumulate_drop_size(
   WT_SESSION_IMPL *session, WT_DISAGG_METADATA_OP *entry, uint64_t *drop_size);
-static void __disagg_shared_metadata_queue_clear(WT_SESSION_IMPL *session, bool updates_only);
+static void __disagg_shared_metadata_queue_clear(WT_SESSION_IMPL *session);
 
 /*
  * __layered_create_missing_stable_table --
@@ -62,7 +62,7 @@ __layered_create_missing_stable_tables_legacy(WT_SESSION_IMPL *session)
      * on the follower when the stable constituent did not yet exist) must be cleared before new
      * entries are added below.
      */
-    __disagg_shared_metadata_queue_clear(session, false);
+    __disagg_shared_metadata_queue_clear(session);
 
     WT_ERR(__wt_metadata_cursor(session, &cursor_check));
     WT_ERR(__wt_metadata_cursor(session, &cursor_scan));
@@ -121,10 +121,13 @@ err:
  *     return the REMOVE only if it defers past a checkpoint at that schema epoch.
  */
 static WT_DISAGG_METADATA_OP *
-__layered_create_following_remove(WT_SESSION_IMPL *session, WT_CONNECTION_IMPL *conn,
-  WT_DISAGG_METADATA_OP *create_entry, wt_timestamp_t cur_schema_epoch)
+__layered_create_following_remove(
+  WT_SESSION_IMPL *session, WT_DISAGG_METADATA_OP *create_entry, wt_timestamp_t cur_schema_epoch)
 {
+    WT_CONNECTION_IMPL *conn;
     WT_DISAGG_METADATA_OP *tmp;
+
+    conn = S2C(session);
 
     WT_ASSERT_SPINLOCK_OWNED(session, &conn->disaggregated_storage.shared_metadata_queue_lock);
 
@@ -193,7 +196,7 @@ __layered_create_missing_stable_tables_helper(WT_SESSION_IMPL *session)
         WT_ASSERT(session, WT_PREFIX_MATCH(entry->stable_uri, "file:"));
 
         /* Check if the table was dropped. */
-        if (__layered_create_following_remove(session, conn, entry, WT_SCHEMA_EPOCH_NONE) != NULL) {
+        if (__layered_create_following_remove(session, entry, WT_SCHEMA_EPOCH_NONE) != NULL) {
             __wt_verbose_debug2(session, WT_VERB_DISAGGREGATED_STORAGE,
               "Skip creating missing stable table \"%s\" with schema epoch %" PRIu64
               " from layered config \"%s\" since it is being dropped",
@@ -468,48 +471,63 @@ err:
 
 /*
  * __disagg_shared_metadata_queue_clear --
- *     Clear the shared metadata queue. If updates_only is set, keep CREATE and REMOVE entries: they
- *     are schema intents not yet covered by a checkpoint and remain valid across a role change.
+ *     Clear the update metadata list.
  */
 static void
-__disagg_shared_metadata_queue_clear(WT_SESSION_IMPL *session, bool updates_only)
+__disagg_shared_metadata_queue_clear(WT_SESSION_IMPL *session)
 {
     WT_CONNECTION_IMPL *conn;
     WT_DISAGG_METADATA_OP *entry, *tmp;
-#ifdef HAVE_DIAGNOSTIC
-    wt_timestamp_t stable_schema_epoch;
-#endif
 
     conn = S2C(session);
-#ifdef HAVE_DIAGNOSTIC
-    stable_schema_epoch =
-      __wt_atomic_load_uint64_acquire(&conn->txn_global.last_ckpt_disaggregated_schema_epoch);
-#endif
 
     __wt_spin_lock(session, &conn->disaggregated_storage.shared_metadata_queue_lock);
 
-    TAILQ_FOREACH_SAFE(entry, &conn->disaggregated_storage.shared_metadata_qh, q, tmp)
+    WT_TAILQ_SAFE_REMOVE_BEGIN(entry, &conn->disaggregated_storage.shared_metadata_qh, q, tmp)
     {
-        if (updates_only && entry->metadata_op != WT_SHARED_METADATA_UPDATE) {
-            WT_ASSERT(session,
-              entry->metadata_op == WT_SHARED_METADATA_CREATE ||
-                entry->metadata_op == WT_SHARED_METADATA_REMOVE);
-            /*
-             * A surviving entry is an intent not yet covered by a checkpoint, so its epoch must be
-             * above the last checkpoint's, except in legacy mode where epochs are not in use.
-             */
-            WT_ASSERT(session,
-              stable_schema_epoch == WT_SCHEMA_EPOCH_NONE ||
-                entry->schema_epoch == WT_SCHEMA_EPOCH_UNPUBLISHED ||
-                entry->schema_epoch > stable_schema_epoch);
-            continue;
-        }
         TAILQ_REMOVE(&conn->disaggregated_storage.shared_metadata_qh, entry, q);
         __disagg_shared_metadata_queue_free(session, &entry);
+    }
+    WT_TAILQ_SAFE_REMOVE_END
+
+    __wt_spin_unlock(session, &conn->disaggregated_storage.shared_metadata_queue_lock);
+}
+
+#ifdef HAVE_DIAGNOSTIC
+/*
+ * __disagg_shared_metadata_queue_verify --
+ *     Assert the queue holds only CREATE and REMOVE intents not yet covered by a checkpoint.
+ */
+static void
+__disagg_shared_metadata_queue_verify(WT_SESSION_IMPL *session)
+{
+    WT_CONNECTION_IMPL *conn;
+    WT_DISAGG_METADATA_OP *entry;
+    wt_timestamp_t stable_schema_epoch;
+
+    conn = S2C(session);
+    stable_schema_epoch =
+      __wt_atomic_load_uint64_acquire(&conn->txn_global.last_ckpt_disaggregated_schema_epoch);
+
+    __wt_spin_lock(session, &conn->disaggregated_storage.shared_metadata_queue_lock);
+
+    TAILQ_FOREACH (entry, &conn->disaggregated_storage.shared_metadata_qh, q) {
+        WT_ASSERT(session,
+          entry->metadata_op == WT_SHARED_METADATA_CREATE ||
+            entry->metadata_op == WT_SHARED_METADATA_REMOVE);
+        /*
+         * An entry is an intent not yet covered by a checkpoint, so its epoch must be above the
+         * last checkpoint's, except in legacy mode where epochs are not in use.
+         */
+        WT_ASSERT(session,
+          stable_schema_epoch == WT_SCHEMA_EPOCH_NONE ||
+            entry->schema_epoch == WT_SCHEMA_EPOCH_UNPUBLISHED ||
+            entry->schema_epoch > stable_schema_epoch);
     }
 
     __wt_spin_unlock(session, &conn->disaggregated_storage.shared_metadata_queue_lock);
 }
+#endif
 
 /*
  * __wti_disagg_shared_metadata_queue_prune --
@@ -719,6 +737,66 @@ __disagg_handle_create_remove_pairing(WT_SESSION_IMPL *session, WT_CONNECTION_IM
 }
 
 /*
+ * __disagg_cancel_unpublished_drop_group --
+ *     Cancel a covered CREATE whose first following REMOVE can never be published (its epoch is
+ *     unpublished), returning true if both were canceled (caller should continue). The table was
+ *     dropped locally and no checkpoint will ever cover the drop, so applying the CREATE would
+ *     advertise a table in shared metadata that no node can serve. Cancel the whole group: every
+ *     CREATE for the URI ahead of the REMOVE (a create through the table: prefix enqueues two)
+ *     together with the REMOVE, so no duplicate CREATE survives to republish the dropped table. A
+ *     REMOVE published at a later epoch is the two-phase drop instead: this checkpoint applies the
+ *     CREATE and a later covering checkpoint applies the REMOVE. In legacy mode nothing defers by
+ *     epoch, so there is nothing to check.
+ */
+static bool
+__disagg_cancel_unpublished_drop_group(WT_SESSION_IMPL *session, WT_DISAGG_METADATA_OP *entry,
+  wt_timestamp_t cur_schema_epoch, WT_DISAGG_METADATA_OP **nextp)
+{
+    WT_CONNECTION_IMPL *conn;
+    WT_DISAGG_METADATA_OP *group, *group_next, *remove_entry;
+    bool last;
+
+    conn = S2C(session);
+
+    if (cur_schema_epoch == WT_SCHEMA_EPOCH_NONE || entry->metadata_op != WT_SHARED_METADATA_CREATE)
+        return (false);
+    remove_entry = __layered_create_following_remove(session, entry, cur_schema_epoch);
+    if (remove_entry == NULL || remove_entry->schema_epoch != WT_SCHEMA_EPOCH_UNPUBLISHED)
+        return (false);
+
+    __wt_verbose_error(session, WT_VERB_DISAGGREGATED_STORAGE,
+      "Table \"%s\" was created at epoch %" PRIu64
+      " covered by this checkpoint (schema epoch "
+      "%" PRIu64
+      "), but was dropped without the drop being published: canceling the queued create "
+      "and drop so the dropped table is not published to shared metadata.",
+      entry->table_name, entry->schema_epoch, cur_schema_epoch);
+    WT_STAT_CONN_INCR(session, checkpoint_disagg_metadata_pair_canceled);
+
+    for (group = TAILQ_NEXT(entry, q); group != NULL; group = group_next) {
+        group_next = TAILQ_NEXT(group, q);
+        last = group == remove_entry;
+        if (!last &&
+          (group->metadata_op != WT_SHARED_METADATA_CREATE ||
+            strcmp(group->stable_uri, entry->stable_uri) != 0))
+            continue;
+        /* Both CREATE entries of a table: create were published together. */
+        WT_ASSERT(session, last || group->schema_epoch == entry->schema_epoch);
+        /* A canceled entry may be the caller's saved next entry; step past it. */
+        if (group == *nextp)
+            *nextp = group_next;
+        TAILQ_REMOVE(&conn->disaggregated_storage.shared_metadata_qh, group, q);
+        __disagg_shared_metadata_queue_free(session, &group);
+        if (last)
+            break;
+    }
+
+    TAILQ_REMOVE(&conn->disaggregated_storage.shared_metadata_qh, entry, q);
+    __disagg_shared_metadata_queue_free(session, &entry);
+    return (true);
+}
+
+/*
  * __disagg_accumulate_drop_size --
  *     Accumulate the drop size if the entry represents a table drop operation.
  */
@@ -766,8 +844,7 @@ __wt_disagg_shared_metadata_queue_process(
     struct __wt_disagg_shared_metadata_qh skipped_creates;
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
-    WT_DISAGG_METADATA_OP *entry, *group, *group_next, *remove_entry, *skipped, *tmp;
-    bool last;
+    WT_DISAGG_METADATA_OP *entry, *skipped, *tmp;
 
     WT_ASSERT(session, drop_sizep != NULL);
     conn = S2C(session);
@@ -803,52 +880,9 @@ __wt_disagg_shared_metadata_queue_process(
             continue;
         }
 
-        /*
-         * A covered CREATE whose first following REMOVE can never be published (its epoch is
-         * unpublished) means the table was dropped locally and no checkpoint will ever cover the
-         * drop. Applying the CREATE would advertise a table in shared metadata that no node can
-         * serve, so cancel the whole group: every CREATE for the URI ahead of the REMOVE (a create
-         * through the table: prefix enqueues two) together with the REMOVE, so no duplicate CREATE
-         * survives to republish the dropped table. A REMOVE published at a later epoch is the
-         * two-phase drop instead: this checkpoint applies the CREATE and a later covering
-         * checkpoint applies the REMOVE. In legacy mode nothing defers by epoch, so there is
-         * nothing to check.
-         */
-        if (cur_schema_epoch != WT_SCHEMA_EPOCH_NONE &&
-          entry->metadata_op == WT_SHARED_METADATA_CREATE &&
-          (remove_entry =
-              __layered_create_following_remove(session, conn, entry, cur_schema_epoch)) != NULL &&
-          remove_entry->schema_epoch == WT_SCHEMA_EPOCH_UNPUBLISHED) {
-            __wt_verbose_error(session, WT_VERB_DISAGGREGATED_STORAGE,
-              "Table \"%s\" was created at epoch %" PRIu64
-              " covered by this checkpoint (schema epoch %" PRIu64
-              "), but was dropped without the drop being published: canceling the queued create "
-              "and drop so the dropped table is not published to shared metadata.",
-              entry->table_name, entry->schema_epoch, cur_schema_epoch);
-            WT_STAT_CONN_INCR(session, checkpoint_disagg_metadata_pair_canceled);
-
-            for (group = TAILQ_NEXT(entry, q); group != NULL; group = group_next) {
-                group_next = TAILQ_NEXT(group, q);
-                last = group == remove_entry;
-                if (!last &&
-                  (group->metadata_op != WT_SHARED_METADATA_CREATE ||
-                    strcmp(group->stable_uri, entry->stable_uri) != 0))
-                    continue;
-                /* Both CREATE entries of a table: create were published together. */
-                WT_ASSERT(session, last || group->schema_epoch == entry->schema_epoch);
-                /* A canceled entry may be the loop's saved next entry; step past it. */
-                if (group == tmp)
-                    tmp = group_next;
-                TAILQ_REMOVE(&conn->disaggregated_storage.shared_metadata_qh, group, q);
-                __disagg_shared_metadata_queue_free(session, &group);
-                if (last)
-                    break;
-            }
-
-            TAILQ_REMOVE(&conn->disaggregated_storage.shared_metadata_qh, entry, q);
-            __disagg_shared_metadata_queue_free(session, &entry);
+        /* Cancel a covered CREATE group whose drop can never be published. */
+        if (__disagg_cancel_unpublished_drop_group(session, entry, cur_schema_epoch, &tmp))
             continue;
-        }
 
         /* Park CREATE entries with no stable_value; cancel them if a matching REMOVE follows. */
         if (__disagg_handle_create_remove_pairing(session, conn, entry, &skipped_creates))
@@ -1299,13 +1333,15 @@ __disagg_step_down(WT_SESSION_IMPL *session)
     WT_ERR(ret);
 
     /*
-     * We are abandoning the current leader checkpoint, so drop the UPDATE entries: they are
-     * block-manager bookkeeping for that checkpoint. CREATE and REMOVE entries are intents not yet
-     * covered by any checkpoint and remain valid for the follower era, so they survive with their
-     * schema epochs and stable values intact. No UPDATE can be enqueued concurrently: we hold the
-     * checkpoint lock and UPDATE entries are only enqueued during a checkpoint.
+     * The shared metadata queue survives the role change: its entries are schema intents not yet
+     * covered by any checkpoint and remain valid for the follower era. No UPDATE entry can exist
+     * here: UPDATE entries live only within a running leader checkpoint, which either consumed them
+     * or panicked on failure, followers never enqueue them, and the checkpoint lock we hold keeps a
+     * checkpoint from being in flight.
      */
-    __disagg_shared_metadata_queue_clear(session, true);
+#ifdef HAVE_DIAGNOSTIC
+    __disagg_shared_metadata_queue_verify(session);
+#endif
 
     /*
      * Re-enable the shared disk cache on step-down. Create the table only if this node never had
@@ -1784,7 +1820,7 @@ __wti_disagg_destroy(WT_SESSION_IMPL *session)
     disagg = &conn->disaggregated_storage;
 
     /* Remove the list of URIs for which we still need to update metadata entries. */
-    __disagg_shared_metadata_queue_clear(session, false);
+    __disagg_shared_metadata_queue_clear(session);
 
     /* Close the metadata handles. */
     if (disagg->page_log_meta != NULL) {

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -10,7 +10,7 @@
 
 static int __disagg_accumulate_drop_size(
   WT_SESSION_IMPL *session, WT_DISAGG_METADATA_OP *entry, uint64_t *drop_size);
-static void __disagg_shared_metadata_queue_clear(WT_SESSION_IMPL *session);
+static void __disagg_shared_metadata_queue_clear(WT_SESSION_IMPL *session, bool updates_only);
 
 /*
  * __layered_create_missing_stable_table --
@@ -62,7 +62,7 @@ __layered_create_missing_stable_tables_legacy(WT_SESSION_IMPL *session)
      * on the follower when the stable constituent did not yet exist) must be cleared before new
      * entries are added below.
      */
-    __disagg_shared_metadata_queue_clear(session);
+    __disagg_shared_metadata_queue_clear(session, false);
 
     WT_ERR(__wt_metadata_cursor(session, &cursor_check));
     WT_ERR(__wt_metadata_cursor(session, &cursor_scan));
@@ -394,24 +394,45 @@ err:
 
 /*
  * __disagg_shared_metadata_queue_clear --
- *     Clear the update metadata list.
+ *     Clear the shared metadata queue. If updates_only is set, keep CREATE and REMOVE entries: they
+ *     are schema intents not yet covered by a checkpoint and remain valid across a role change.
  */
 static void
-__disagg_shared_metadata_queue_clear(WT_SESSION_IMPL *session)
+__disagg_shared_metadata_queue_clear(WT_SESSION_IMPL *session, bool updates_only)
 {
     WT_CONNECTION_IMPL *conn;
     WT_DISAGG_METADATA_OP *entry, *tmp;
+#ifdef HAVE_DIAGNOSTIC
+    wt_timestamp_t stable_schema_epoch;
+#endif
 
     conn = S2C(session);
+#ifdef HAVE_DIAGNOSTIC
+    stable_schema_epoch =
+      __wt_atomic_load_uint64_acquire(&conn->txn_global.last_ckpt_disaggregated_schema_epoch);
+#endif
 
     __wt_spin_lock(session, &conn->disaggregated_storage.shared_metadata_queue_lock);
 
-    WT_TAILQ_SAFE_REMOVE_BEGIN(entry, &conn->disaggregated_storage.shared_metadata_qh, q, tmp)
+    TAILQ_FOREACH_SAFE(entry, &conn->disaggregated_storage.shared_metadata_qh, q, tmp)
     {
+        if (updates_only && entry->metadata_op != WT_SHARED_METADATA_UPDATE) {
+            WT_ASSERT(session,
+              entry->metadata_op == WT_SHARED_METADATA_CREATE ||
+                entry->metadata_op == WT_SHARED_METADATA_REMOVE);
+            /*
+             * A surviving entry is an intent not yet covered by a checkpoint, so its epoch must be
+             * above the last checkpoint's, except in legacy mode where epochs are not in use.
+             */
+            WT_ASSERT(session,
+              stable_schema_epoch == WT_SCHEMA_EPOCH_NONE ||
+                entry->schema_epoch == WT_SCHEMA_EPOCH_UNPUBLISHED ||
+                entry->schema_epoch > stable_schema_epoch);
+            continue;
+        }
         TAILQ_REMOVE(&conn->disaggregated_storage.shared_metadata_qh, entry, q);
         __disagg_shared_metadata_queue_free(session, &entry);
     }
-    WT_TAILQ_SAFE_REMOVE_END
 
     __wt_spin_unlock(session, &conn->disaggregated_storage.shared_metadata_queue_lock);
 }
@@ -1154,8 +1175,14 @@ __disagg_step_down(WT_SESSION_IMPL *session)
       session, ret = __disagg_mark_btrees_readonly_then_step_down(session));
     WT_ERR(ret);
 
-    /* Do some cleanup as we are abandoning the current checkpoint. */
-    __disagg_shared_metadata_queue_clear(session);
+    /*
+     * We are abandoning the current leader checkpoint, so drop the UPDATE entries: they are
+     * block-manager bookkeeping for that checkpoint. CREATE and REMOVE entries are intents not yet
+     * covered by any checkpoint and remain valid for the follower era, so they survive with their
+     * schema epochs and stable values intact. No UPDATE can be enqueued concurrently: we hold the
+     * checkpoint lock and UPDATE entries are only enqueued during a checkpoint.
+     */
+    __disagg_shared_metadata_queue_clear(session, true);
 
     /*
      * Re-enable the shared disk cache on step-down. Create the table only if this node never had
@@ -1634,7 +1661,7 @@ __wti_disagg_destroy(WT_SESSION_IMPL *session)
     disagg = &conn->disaggregated_storage;
 
     /* Remove the list of URIs for which we still need to update metadata entries. */
-    __disagg_shared_metadata_queue_clear(session);
+    __disagg_shared_metadata_queue_clear(session, false);
 
     /* Close the metadata handles. */
     if (disagg->page_log_meta != NULL) {

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -326,7 +326,7 @@ err:
  *     can ever be covered by a checkpoint and the entries net out. (A create through the table:
  *     prefix enqueues two CREATE entries, hence the loop.) Any other shape must stay queued --
  *     a published CREATE may be covered by a later checkpoint (the checkpoint-time cancellation in
- *     __wt_disagg_shared_metadata_queue_process handles a REMOVE deferring past it), and this
+ *     __wt_disagg_shared_metadata_queue_process pairs it with an unpublished REMOVE), and this
  *     REMOVE may be published later.
  */
 static bool
@@ -766,7 +766,8 @@ __wt_disagg_shared_metadata_queue_process(
     struct __wt_disagg_shared_metadata_qh skipped_creates;
     WT_CONNECTION_IMPL *conn;
     WT_DECL_RET;
-    WT_DISAGG_METADATA_OP *entry, *remove_entry, *skipped, *tmp;
+    WT_DISAGG_METADATA_OP *entry, *group, *group_next, *remove_entry, *skipped, *tmp;
+    bool last;
 
     WT_ASSERT(session, drop_sizep != NULL);
     conn = S2C(session);
@@ -803,30 +804,46 @@ __wt_disagg_shared_metadata_queue_process(
         }
 
         /*
-         * A covered CREATE whose first following REMOVE defers past this checkpoint means the table
-         * was dropped locally but the drop is not yet published. Applying the CREATE alone would
-         * advertise a table in shared metadata that no node can serve, so cancel both entries: the
-         * pair nets out because no checkpoint covering only the CREATE has been taken. In legacy
-         * mode nothing defers by epoch, so there is nothing to check.
+         * A covered CREATE whose first following REMOVE can never be published (its epoch is
+         * unpublished) means the table was dropped locally and no checkpoint will ever cover the
+         * drop. Applying the CREATE would advertise a table in shared metadata that no node can
+         * serve, so cancel the whole group: every CREATE for the URI ahead of the REMOVE (a create
+         * through the table: prefix enqueues two) together with the REMOVE, so no duplicate CREATE
+         * survives to republish the dropped table. A REMOVE published at a later epoch is the
+         * two-phase drop instead: this checkpoint applies the CREATE and a later covering
+         * checkpoint applies the REMOVE. In legacy mode nothing defers by epoch, so there is
+         * nothing to check.
          */
         if (cur_schema_epoch != WT_SCHEMA_EPOCH_NONE &&
           entry->metadata_op == WT_SHARED_METADATA_CREATE &&
           (remove_entry =
-              __layered_create_following_remove(session, conn, entry, cur_schema_epoch)) != NULL) {
+              __layered_create_following_remove(session, conn, entry, cur_schema_epoch)) != NULL &&
+          remove_entry->schema_epoch == WT_SCHEMA_EPOCH_UNPUBLISHED) {
             __wt_verbose_error(session, WT_VERB_DISAGGREGATED_STORAGE,
               "Table \"%s\" was created at epoch %" PRIu64
               " covered by this checkpoint (schema epoch %" PRIu64
-              "), but its drop at epoch %" PRIu64
-              " was not: canceling both operations so the dropped table is not published to "
-              "shared metadata.",
-              entry->table_name, entry->schema_epoch, cur_schema_epoch, remove_entry->schema_epoch);
+              "), but was dropped without the drop being published: canceling the queued create "
+              "and drop so the dropped table is not published to shared metadata.",
+              entry->table_name, entry->schema_epoch, cur_schema_epoch);
             WT_STAT_CONN_INCR(session, checkpoint_disagg_metadata_pair_canceled);
 
-            /* The canceled REMOVE may be the loop's saved next entry; step past it. */
-            if (remove_entry == tmp)
-                tmp = TAILQ_NEXT(tmp, q);
-            TAILQ_REMOVE(&conn->disaggregated_storage.shared_metadata_qh, remove_entry, q);
-            __disagg_shared_metadata_queue_free(session, &remove_entry);
+            for (group = TAILQ_NEXT(entry, q); group != NULL; group = group_next) {
+                group_next = TAILQ_NEXT(group, q);
+                last = group == remove_entry;
+                if (!last &&
+                  (group->metadata_op != WT_SHARED_METADATA_CREATE ||
+                    strcmp(group->stable_uri, entry->stable_uri) != 0))
+                    continue;
+                /* Both CREATE entries of a table: create were published together. */
+                WT_ASSERT(session, last || group->schema_epoch == entry->schema_epoch);
+                /* A canceled entry may be the loop's saved next entry; step past it. */
+                if (group == tmp)
+                    tmp = group_next;
+                TAILQ_REMOVE(&conn->disaggregated_storage.shared_metadata_qh, group, q);
+                __disagg_shared_metadata_queue_free(session, &group);
+                if (last)
+                    break;
+            }
 
             TAILQ_REMOVE(&conn->disaggregated_storage.shared_metadata_qh, entry, q);
             __disagg_shared_metadata_queue_free(session, &entry);
@@ -855,10 +872,10 @@ __wt_disagg_shared_metadata_queue_process(
 
     /*
      * Any unmatched parked CREATE entry is an API violation: it is covered by this checkpoint, its
-     * stable constituent was never created so there is no data to write, and no REMOVE for the same
-     * URI remains queued to explain it -- a REMOVE deferring past this checkpoint was canceled
-     * together with its CREATE above, and a covered REMOVE cancels the parked CREATE when
-     * processed.
+     * stable constituent was never created so there is no data to write, yet nothing nets it out.
+     * An unpublished REMOVE was canceled together with the URI's CREATE entries above and a covered
+     * REMOVE cancels the parked CREATE when processed, so what remains is a drop published at an
+     * epoch past this checkpoint: the checkpoint must include a table for which no data exists.
      */
     if (!TAILQ_EMPTY(&skipped_creates)) {
         TAILQ_FOREACH (skipped, &skipped_creates, q)

--- a/src/conn/conn_layered_checkpoint_pick_up.c
+++ b/src/conn/conn_layered_checkpoint_pick_up.c
@@ -681,6 +681,19 @@ err:
 }
 
 /*
+ * __disagg_queue_entry_protects --
+ *     Return whether a queued create or remove still protects local state from being reconciled
+ *     away: only when its schema epoch is past the incoming checkpoint's, so the local state is
+ *     newer than the checkpoint rather than a leftover the checkpoint already covers. Without
+ *     schema epochs any entry protects.
+ */
+static bool
+__disagg_queue_entry_protects(wt_timestamp_t latest_epoch, wt_timestamp_t ckpt_schema_epoch)
+{
+    return (ckpt_schema_epoch == WT_SCHEMA_EPOCH_NONE || latest_epoch > ckpt_schema_epoch);
+}
+
+/*
  * __disagg_apply_checkpoint_meta --
  *     Process the metadata entries stored in the shared metadata table for a new checkpoint.
  */
@@ -864,15 +877,16 @@ __disagg_apply_checkpoint_meta(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPO
                  * A btree ID change under the same name means the leader dropped and recreated the
                  * table, possibly across several skipped checkpoints, so the local entries describe
                  * a dead incarnation. Unless the metadata operations queue has a local create or
-                 * drop that has not reached a shared checkpoint yet (the local state is then newer
-                 * than the shared checkpoint), discard the local state and pick the table up as a
-                 * new one.
+                 * drop past this checkpoint's schema epoch (the local state is then newer than the
+                 * shared checkpoint), discard the local state and pick the table up as a new one.
                  */
                 WT_ERR(__disagg_file_id_mismatch(session, sh_cursors[WT_DISAGG_CURSOR_FILE],
                   md_cursors[WT_DISAGG_CURSOR_FILE], &id_mismatch));
                 if (id_mismatch) {
-                    if (__wti_disagg_table_latest_create_remove(session, current, &latest_epoch) !=
-                      WT_SHARED_METADATA_NONE)
+                    latest_op =
+                      __wti_disagg_table_latest_create_remove(session, current, &latest_epoch);
+                    if (latest_op != WT_SHARED_METADATA_NONE &&
+                      __disagg_queue_entry_protects(latest_epoch, ckpt_schema_epoch))
                         continue;
                     WT_ERR(__disagg_drop_local_layered(session, current));
                     WT_ERR(__disagg_pick_up_new_layered(
@@ -898,7 +912,8 @@ __disagg_apply_checkpoint_meta(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPO
             /*
              * The shared metadata has a layered: entry but the local metadata does not. This could
              * be a new layered table that we should pick up, but it could also mean that we have
-             * already dropped the table locally and should not recreate it as a result.
+             * already dropped the table locally, with a local remove past this checkpoint's schema
+             * epoch, and should not recreate it as a result.
              */
             latest_op = __wti_disagg_table_latest_create_remove(session, current, &latest_epoch);
             if (strict &&
@@ -910,7 +925,8 @@ __disagg_apply_checkpoint_meta(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPO
                   "%" PRIu64 "; latest queued operation: %s at schema epoch %" PRIu64,
                   current, ckpt_schema_epoch, __wti_disagg_shared_metadata_op_to_string(latest_op),
                   latest_epoch);
-            if (latest_op == WT_SHARED_METADATA_REMOVE)
+            if (latest_op == WT_SHARED_METADATA_REMOVE &&
+              __disagg_queue_entry_protects(latest_epoch, ckpt_schema_epoch))
                 continue;
 
             /*
@@ -933,7 +949,7 @@ __disagg_apply_checkpoint_meta(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPO
             /*
              * The local metadata has a layered: entry but the shared metadata does not - the leader
              * dropped the table. Discard the local state, unless the metadata operations queue has
-             * a local create that has not reached a shared checkpoint yet.
+             * a local create past this checkpoint's schema epoch.
              */
             latest_op = __wti_disagg_table_latest_create_remove(session, current, &latest_epoch);
             if (strict &&
@@ -945,7 +961,8 @@ __disagg_apply_checkpoint_meta(WT_SESSION_IMPL *session, const WT_DISAGG_CHECKPO
                   "%" PRIu64 "; latest queued operation: %s at schema epoch %" PRIu64,
                   current, ckpt_schema_epoch, __wti_disagg_shared_metadata_op_to_string(latest_op),
                   latest_epoch);
-            if (latest_op == WT_SHARED_METADATA_CREATE)
+            if (latest_op == WT_SHARED_METADATA_CREATE &&
+              __disagg_queue_entry_protects(latest_epoch, ckpt_schema_epoch))
                 continue;
             WT_ERR(__disagg_drop_local_layered(session, current));
         } else {

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -835,6 +835,7 @@ struct __wt_connection_stats {
     int64_t checkpoint_cleanup_success;
     int64_t checkpoint_snapshot_acquired;
     int64_t checkpoint_skipped;
+    int64_t checkpoint_disagg_metadata_pair_canceled;
     int64_t checkpoint_fsync_post;
     int64_t checkpoint_fsync_post_duration;
     int64_t checkpoint_generation;

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -7528,7 +7528,7 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_CHECKPOINT_SKIPPED			1408
 /*!
  * checkpoint: create and remove metadata operation pairs canceled during
- * disaggregated checkpoint because the remove was not covered
+ * disaggregated checkpoint because the remove was never published
  */
 #define	WT_STAT_CONN_CHECKPOINT_DISAGG_METADATA_PAIR_CANCELED	1409
 /*! checkpoint: fsync calls after allocating the transaction ID */

--- a/src/include/wiredtiger.h.in
+++ b/src/include/wiredtiger.h.in
@@ -7526,1641 +7526,1646 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_CHECKPOINT_SNAPSHOT_ACQUIRED	1407
 /*! checkpoint: checkpoints skipped because database was clean */
 #define	WT_STAT_CONN_CHECKPOINT_SKIPPED			1408
+/*!
+ * checkpoint: create and remove metadata operation pairs canceled during
+ * disaggregated checkpoint because the remove was not covered
+ */
+#define	WT_STAT_CONN_CHECKPOINT_DISAGG_METADATA_PAIR_CANCELED	1409
 /*! checkpoint: fsync calls after allocating the transaction ID */
-#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST		1409
+#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST		1410
 /*! checkpoint: fsync duration after allocating the transaction ID (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST_DURATION	1410
+#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST_DURATION	1411
 /*! checkpoint: generation */
-#define	WT_STAT_CONN_CHECKPOINT_GENERATION		1411
+#define	WT_STAT_CONN_CHECKPOINT_GENERATION		1412
 /*! checkpoint: max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_MAX		1412
+#define	WT_STAT_CONN_CHECKPOINT_TIME_MAX		1413
 /*!
  * checkpoint: metadata operations applied during disaggregated
  * checkpoint
  */
-#define	WT_STAT_CONN_CHECKPOINT_DISAGG_METADATA_APPLY	1413
+#define	WT_STAT_CONN_CHECKPOINT_DISAGG_METADATA_APPLY	1414
 /*!
  * checkpoint: metadata operations skipped during disaggregated
  * checkpoint because they were not stable
  */
-#define	WT_STAT_CONN_CHECKPOINT_DISAGG_METADATA_UNSTABLE	1414
+#define	WT_STAT_CONN_CHECKPOINT_DISAGG_METADATA_UNSTABLE	1415
 /*! checkpoint: min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_MIN		1415
+#define	WT_STAT_CONN_CHECKPOINT_TIME_MIN		1416
 /*!
  * checkpoint: most recent duration for checkpoint dropping all handles
  * (usecs)
  */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROP_DURATION	1416
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROP_DURATION	1417
 /*! checkpoint: most recent duration for gathering all handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION		1417
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION		1418
 /*! checkpoint: most recent duration for gathering applied handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLY_DURATION	1418
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLY_DURATION	1419
 /*! checkpoint: most recent duration for gathering skipped handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIP_DURATION	1419
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIP_DURATION	1420
 /*! checkpoint: most recent duration for handles metadata checked (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECK_DURATION	1420
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECK_DURATION	1421
 /*! checkpoint: most recent duration for locking the handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCK_DURATION	1421
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCK_DURATION	1422
 /*! checkpoint: most recent handles applied */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLIED		1422
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLIED		1423
 /*! checkpoint: most recent handles checkpoint dropped */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROPPED		1423
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROPPED		1424
 /*! checkpoint: most recent handles metadata checked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECKED	1424
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECKED	1425
 /*! checkpoint: most recent handles metadata locked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCKED		1425
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCKED		1426
 /*! checkpoint: most recent handles skipped */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIPPED		1426
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIPPED		1427
 /*! checkpoint: most recent handles walked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_WALKED		1427
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_WALKED		1428
 /*! checkpoint: most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_RECENT		1428
+#define	WT_STAT_CONN_CHECKPOINT_TIME_RECENT		1429
 /*! checkpoint: number of bytes reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED_BYTES	1429
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED_BYTES	1430
 /*! checkpoint: number of checkpoints started by api */
-#define	WT_STAT_CONN_CHECKPOINTS_API			1430
+#define	WT_STAT_CONN_CHECKPOINTS_API			1431
 /*! checkpoint: number of checkpoints started by compaction */
-#define	WT_STAT_CONN_CHECKPOINTS_COMPACT		1431
+#define	WT_STAT_CONN_CHECKPOINTS_COMPACT		1432
 /*! checkpoint: number of files synced */
-#define	WT_STAT_CONN_CHECKPOINT_SYNC			1432
+#define	WT_STAT_CONN_CHECKPOINT_SYNC			1433
 /*! checkpoint: number of handles visited after writes complete */
-#define	WT_STAT_CONN_CHECKPOINT_PRESYNC			1433
+#define	WT_STAT_CONN_CHECKPOINT_PRESYNC			1434
 /*! checkpoint: number of history store pages reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_HS_PAGES_RECONCILED	1434
+#define	WT_STAT_CONN_CHECKPOINT_HS_PAGES_RECONCILED	1435
 /*! checkpoint: number of internal pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_INTERNAL	1435
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_INTERNAL	1436
 /*! checkpoint: number of leaf pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_LEAF	1436
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_LEAF	1437
 /*! checkpoint: number of pages reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED	1437
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED	1438
 /*!
  * checkpoint: number of pages reconciled by checkpoint parallel worker
  * threads
  */
-#define	WT_STAT_CONN_CHECKPOINT_PARALLEL_PAGES_RECONCILED	1438
+#define	WT_STAT_CONN_CHECKPOINT_PARALLEL_PAGES_RECONCILED	1439
 /*! checkpoint: prepare currently running */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1439
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1440
 /*! checkpoint: prepare max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1440
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1441
 /*! checkpoint: prepare min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1441
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1442
 /*! checkpoint: prepare most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1442
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1443
 /*! checkpoint: prepare total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1443
+#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1444
 /*! checkpoint: progress state */
-#define	WT_STAT_CONN_CHECKPOINT_STATE			1444
+#define	WT_STAT_CONN_CHECKPOINT_STATE			1445
 /*! checkpoint: scrub dirty target */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1445
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1446
 /*! checkpoint: scrub max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1446
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1447
 /*! checkpoint: scrub min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1447
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1448
 /*! checkpoint: scrub most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1448
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1449
 /*! checkpoint: scrub total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1449
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1450
 /*! checkpoint: stop timing stress active */
-#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1450
+#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1451
 /*!
  * checkpoint: the percentage of checkpoint sync time spent in
  * reconciliation across all threads
  */
-#define	WT_STAT_CONN_CHECKPOINT_SYNC_REC_PCT		1451
+#define	WT_STAT_CONN_CHECKPOINT_SYNC_REC_PCT		1452
 /*! checkpoint: time spent on per-tree checkpoint work (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1452
+#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1453
 /*! checkpoint: total failed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1453
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1454
 /*! checkpoint: total succeed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1454
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1455
 /*! checkpoint: total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1455
+#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1456
 /*!
  * checkpoint: total time (msecs) writing pages to stable storage during
  * checkpoint reconciliation
  */
-#define	WT_STAT_CONN_CHECKPOINT_REC_BLKCACHE_WRITE	1456
+#define	WT_STAT_CONN_CHECKPOINT_REC_BLKCACHE_WRITE	1457
 /*! checkpoint: wait cycles while cache dirty level is decreasing */
-#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1457
+#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1458
 /*! connection: auto adjusting condition resets */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1458
+#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1459
 /*! connection: auto adjusting condition wait calls */
-#define	WT_STAT_CONN_COND_AUTO_WAIT			1459
+#define	WT_STAT_CONN_COND_AUTO_WAIT			1460
 /*!
  * connection: auto adjusting condition wait raced to update timeout and
  * skipped updating
  */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1460
+#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1461
 /*! connection: btrees currently open */
-#define	WT_STAT_CONN_BTREE_OPEN				1461
+#define	WT_STAT_CONN_BTREE_OPEN				1462
 /*! connection: detected system time went backwards */
-#define	WT_STAT_CONN_TIME_TRAVEL			1462
+#define	WT_STAT_CONN_TIME_TRAVEL			1463
 /*! connection: files currently open */
-#define	WT_STAT_CONN_FILE_OPEN				1463
+#define	WT_STAT_CONN_FILE_OPEN				1464
 /*! connection: hash bucket array size for data handles */
-#define	WT_STAT_CONN_BUCKETS_DH				1464
+#define	WT_STAT_CONN_BUCKETS_DH				1465
 /*! connection: hash bucket array size general */
-#define	WT_STAT_CONN_BUCKETS				1465
+#define	WT_STAT_CONN_BUCKETS				1466
 /*! connection: memory allocations */
-#define	WT_STAT_CONN_MEMORY_ALLOCATION			1466
+#define	WT_STAT_CONN_MEMORY_ALLOCATION			1467
 /*! connection: memory frees */
-#define	WT_STAT_CONN_MEMORY_FREE			1467
+#define	WT_STAT_CONN_MEMORY_FREE			1468
 /*! connection: memory re-allocations */
-#define	WT_STAT_CONN_MEMORY_GROW			1468
+#define	WT_STAT_CONN_MEMORY_GROW			1469
 /*! connection: number of sessions without a sweep for 5+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1469
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1470
 /*! connection: number of sessions without a sweep for 60+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1470
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1471
 /*! connection: pthread mutex condition wait calls */
-#define	WT_STAT_CONN_COND_WAIT				1471
+#define	WT_STAT_CONN_COND_WAIT				1472
 /*! connection: pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			1472
+#define	WT_STAT_CONN_RWLOCK_READ			1473
 /*! connection: pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			1473
+#define	WT_STAT_CONN_RWLOCK_WRITE			1474
 /*! connection: total fsync I/Os */
-#define	WT_STAT_CONN_FSYNC_IO				1474
+#define	WT_STAT_CONN_FSYNC_IO				1475
 /*! connection: total read I/Os */
-#define	WT_STAT_CONN_READ_IO				1475
+#define	WT_STAT_CONN_READ_IO				1476
 /*! connection: total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				1476
+#define	WT_STAT_CONN_WRITE_IO				1477
 /*! cursor: Total number of deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1477
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1478
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1478
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1479
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1479
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1480
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1480
+#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1481
 /*!
  * cursor: Total number of in-memory deleted pages skipped during tree
  * walk
  */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1481
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1482
 /*! cursor: Total number of on-disk deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1482
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1483
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1483
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1484
 /*!
  * cursor: Total number of times cursor fails to temporarily release
  * pinned page to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1484
+#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1485
 /*!
  * cursor: Total number of times cursor temporarily releases pinned page
  * to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION			1485
+#define	WT_STAT_CONN_CURSOR_REPOSITION			1486
 /*! cursor: bulk cursor count */
-#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1486
+#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1487
 /*! cursor: cached cursor count */
-#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1487
+#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1488
 /*! cursor: cursor bound calls that return an error */
-#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1488
+#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1489
 /*! cursor: cursor bounds cleared from reset */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1489
+#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1490
 /*! cursor: cursor bounds comparisons performed */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1490
+#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1491
 /*! cursor: cursor bounds next called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1491
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1492
 /*! cursor: cursor bounds next early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1492
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1493
 /*! cursor: cursor bounds prev called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1493
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1494
 /*! cursor: cursor bounds prev early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1494
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1495
 /*! cursor: cursor bounds search early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1495
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1496
 /*! cursor: cursor bounds search near call repositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1496
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1497
 /*! cursor: cursor bulk loaded cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1497
+#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1498
 /*! cursor: cursor cache calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1498
+#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1499
 /*! cursor: cursor close calls that result in cache */
-#define	WT_STAT_CONN_CURSOR_CACHE			1499
+#define	WT_STAT_CONN_CURSOR_CACHE			1500
 /*! cursor: cursor close calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1500
+#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1501
 /*! cursor: cursor compare calls that return an error */
-#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1501
+#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1502
 /*! cursor: cursor create calls */
-#define	WT_STAT_CONN_CURSOR_CREATE			1502
+#define	WT_STAT_CONN_CURSOR_CREATE			1503
 /*! cursor: cursor equals calls that return an error */
-#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1503
+#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1504
 /*! cursor: cursor get key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1504
+#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1505
 /*! cursor: cursor get value calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1505
+#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1506
 /*! cursor: cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT			1506
+#define	WT_STAT_CONN_CURSOR_INSERT			1507
 /*! cursor: cursor insert calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1507
+#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1508
 /*! cursor: cursor insert check calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1508
+#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1509
 /*! cursor: cursor insert key and value bytes */
-#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1509
+#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1510
 /*! cursor: cursor largest key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1510
+#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1511
 /*! cursor: cursor modify calls */
-#define	WT_STAT_CONN_CURSOR_MODIFY			1511
+#define	WT_STAT_CONN_CURSOR_MODIFY			1512
 /*! cursor: cursor modify calls that return an error */
-#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1512
+#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1513
 /*! cursor: cursor modify key and value bytes affected */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1513
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1514
 /*! cursor: cursor modify value bytes modified */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1514
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1515
 /*! cursor: cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT			1515
+#define	WT_STAT_CONN_CURSOR_NEXT			1516
 /*! cursor: cursor next calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1516
+#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1517
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1517
+#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1518
 /*!
  * cursor: cursor next calls that skip greater than 1 and fewer than 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1518
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1519
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1519
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1520
 /*! cursor: cursor next random calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1520
+#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1521
 /*! cursor: cursor operation restarted */
-#define	WT_STAT_CONN_CURSOR_RESTART			1521
+#define	WT_STAT_CONN_CURSOR_RESTART			1522
 /*! cursor: cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV			1522
+#define	WT_STAT_CONN_CURSOR_PREV			1523
 /*! cursor: cursor prev calls that return an error */
-#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1523
+#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1524
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1524
+#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1525
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1525
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1526
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1526
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1527
 /*! cursor: cursor reconfigure calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1527
+#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1528
 /*! cursor: cursor remove calls */
-#define	WT_STAT_CONN_CURSOR_REMOVE			1528
+#define	WT_STAT_CONN_CURSOR_REMOVE			1529
 /*! cursor: cursor remove calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1529
+#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1530
 /*! cursor: cursor remove key bytes removed */
-#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1530
+#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1531
 /*! cursor: cursor reopen calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1531
+#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1532
 /*! cursor: cursor reserve calls */
-#define	WT_STAT_CONN_CURSOR_RESERVE			1532
+#define	WT_STAT_CONN_CURSOR_RESERVE			1533
 /*! cursor: cursor reserve calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1533
+#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1534
 /*! cursor: cursor reset calls */
-#define	WT_STAT_CONN_CURSOR_RESET			1534
+#define	WT_STAT_CONN_CURSOR_RESET			1535
 /*! cursor: cursor reset calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1535
+#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1536
 /*! cursor: cursor search calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH			1536
+#define	WT_STAT_CONN_CURSOR_SEARCH			1537
 /*! cursor: cursor search calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1537
+#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1538
 /*! cursor: cursor search history store calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1538
+#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1539
 /*! cursor: cursor search near calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1539
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1540
 /*! cursor: cursor search near calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1540
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1541
 /*! cursor: cursor sweep buckets */
-#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1541
+#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1542
 /*! cursor: cursor sweep cursors closed */
-#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1542
+#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1543
 /*! cursor: cursor sweep cursors examined */
-#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1543
+#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1544
 /*! cursor: cursor sweeps */
-#define	WT_STAT_CONN_CURSOR_SWEEP			1544
+#define	WT_STAT_CONN_CURSOR_SWEEP			1545
 /*! cursor: cursor truncate calls */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE			1545
+#define	WT_STAT_CONN_CURSOR_TRUNCATE			1546
 /*! cursor: cursor truncates performed on individual keys */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1546
+#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1547
 /*! cursor: cursor update calls */
-#define	WT_STAT_CONN_CURSOR_UPDATE			1547
+#define	WT_STAT_CONN_CURSOR_UPDATE			1548
 /*! cursor: cursor update calls that return an error */
-#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1548
+#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1549
 /*! cursor: cursor update key and value bytes */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1549
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1550
 /*! cursor: cursor update value size change */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1550
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1551
 /*! cursor: cursors reused from cache */
-#define	WT_STAT_CONN_CURSOR_REOPEN			1551
+#define	WT_STAT_CONN_CURSOR_REOPEN			1552
 /*! cursor: open cursor count */
-#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1552
+#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1553
 /*! cursor: open cursor time application (usecs) */
-#define	WT_STAT_CONN_CURSOR_OPEN_TIME_USER_USECS	1553
+#define	WT_STAT_CONN_CURSOR_OPEN_TIME_USER_USECS	1554
 /*! cursor: open cursor time internal (usecs) */
-#define	WT_STAT_CONN_CURSOR_OPEN_TIME_INTERNAL_USECS	1554
+#define	WT_STAT_CONN_CURSOR_OPEN_TIME_INTERNAL_USECS	1555
 /*! data-handle: Layered connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_LAYERED_COUNT	1555
+#define	WT_STAT_CONN_DH_CONN_HANDLE_LAYERED_COUNT	1556
 /*! data-handle: Table connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TABLE_COUNT		1556
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TABLE_COUNT		1557
 /*! data-handle: Tiered connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_COUNT	1557
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_COUNT	1558
 /*! data-handle: Tiered_Tree connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_TREE_COUNT	1558
+#define	WT_STAT_CONN_DH_CONN_HANDLE_TIERED_TREE_COUNT	1559
 /*! data-handle: btree connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_BTREE_COUNT		1559
+#define	WT_STAT_CONN_DH_CONN_HANDLE_BTREE_COUNT		1560
 /*! data-handle: checkpoint connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_CHECKPOINT_COUNT	1560
+#define	WT_STAT_CONN_DH_CONN_HANDLE_CHECKPOINT_COUNT	1561
 /*! data-handle: connection data handle size */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1561
+#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1562
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1562
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1563
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1563
+#define	WT_STAT_CONN_DH_SWEEP_REF			1564
 /*! data-handle: connection sweep dead dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_DEAD_CLOSE		1564
+#define	WT_STAT_CONN_DH_SWEEP_DEAD_CLOSE		1565
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1565
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1566
 /*! data-handle: connection sweep expired dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_EXPIRED_CLOSE		1566
+#define	WT_STAT_CONN_DH_SWEEP_EXPIRED_CLOSE		1567
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1567
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1568
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1568
+#define	WT_STAT_CONN_DH_SWEEPS				1569
 /*!
  * data-handle: connection sweeps skipped due to checkpoint gathering
  * handles
  */
-#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1569
+#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1570
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1570
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1571
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1571
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1572
 /*! disagg: abandon checkpoints failed */
-#define	WT_STAT_CONN_DISAGG_ABANDON_CHECKPOINT_FAILED	1572
+#define	WT_STAT_CONN_DISAGG_ABANDON_CHECKPOINT_FAILED	1573
 /*! disagg: abandon checkpoints succeeded */
-#define	WT_STAT_CONN_DISAGG_ABANDON_CHECKPOINT_SUCCEED	1573
+#define	WT_STAT_CONN_DISAGG_ABANDON_CHECKPOINT_SUCCEED	1574
 /*! disagg: apply checkpoint metadata most recent time (msecs) */
-#define	WT_STAT_CONN_DISAGG_APPLY_CHECKPOINT_META_TIME	1574
+#define	WT_STAT_CONN_DISAGG_APPLY_CHECKPOINT_META_TIME	1575
 /*! disagg: connection reconfiguration */
-#define	WT_STAT_CONN_DISAGG_CONN_RECONFIG		1575
+#define	WT_STAT_CONN_DISAGG_CONN_RECONFIG		1576
 /*! disagg: database size */
-#define	WT_STAT_CONN_DISAGG_DATABASE_SIZE		1576
+#define	WT_STAT_CONN_DISAGG_DATABASE_SIZE		1577
 /*!
  * disagg: existing file metadata entries updated during checkpoint pick-
  * up
  */
-#define	WT_STAT_CONN_DISAGG_PICK_UP_FILE_META_UPDATED	1577
+#define	WT_STAT_CONN_DISAGG_PICK_UP_FILE_META_UPDATED	1578
 /*! disagg: new file metadata entries inserted during checkpoint pick-up */
-#define	WT_STAT_CONN_DISAGG_PICK_UP_FILE_META_INSERTED	1578
+#define	WT_STAT_CONN_DISAGG_PICK_UP_FILE_META_INSERTED	1579
 /*! disagg: pick up checkpoint most recent time (msecs) */
-#define	WT_STAT_CONN_DISAGG_PICK_UP_CHECKPOINT_TIME	1579
+#define	WT_STAT_CONN_DISAGG_PICK_UP_CHECKPOINT_TIME	1580
 /*! disagg: role leader */
-#define	WT_STAT_CONN_DISAGG_ROLE_LEADER			1580
+#define	WT_STAT_CONN_DISAGG_ROLE_LEADER			1581
 /*! disagg: role transition in progress */
-#define	WT_STAT_CONN_DISAGG_ROLE_TRANSITION_IN_PROGRESS	1581
+#define	WT_STAT_CONN_DISAGG_ROLE_TRANSITION_IN_PROGRESS	1582
 /*! disagg: step down most recent time (msecs) */
-#define	WT_STAT_CONN_DISAGG_STEP_DOWN_TIME		1582
+#define	WT_STAT_CONN_DISAGG_STEP_DOWN_TIME		1583
 /*! disagg: step up most recent time (msecs) */
-#define	WT_STAT_CONN_DISAGG_STEP_UP_TIME		1583
+#define	WT_STAT_CONN_DISAGG_STEP_UP_TIME		1584
 /*! layered: Layered table cursor insert operations */
-#define	WT_STAT_CONN_LAYERED_CURS_INSERT		1584
+#define	WT_STAT_CONN_LAYERED_CURS_INSERT		1585
 /*! layered: Layered table cursor modify operations */
-#define	WT_STAT_CONN_LAYERED_CURS_MODIFY		1585
+#define	WT_STAT_CONN_LAYERED_CURS_MODIFY		1586
 /*! layered: Layered table cursor next operations */
-#define	WT_STAT_CONN_LAYERED_CURS_NEXT			1586
+#define	WT_STAT_CONN_LAYERED_CURS_NEXT			1587
 /*! layered: Layered table cursor next operations from the ingest btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_NEXT_INGEST		1587
+#define	WT_STAT_CONN_LAYERED_CURS_NEXT_INGEST		1588
 /*! layered: Layered table cursor next operations from the stable btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_NEXT_STABLE		1588
+#define	WT_STAT_CONN_LAYERED_CURS_NEXT_STABLE		1589
 /*!
  * layered: Layered table cursor opens the stable btree for the first
  * time
  */
-#define	WT_STAT_CONN_LAYERED_CURS_OPEN_STABLE		1589
+#define	WT_STAT_CONN_LAYERED_CURS_OPEN_STABLE		1590
 /*! layered: Layered table cursor prev operations */
-#define	WT_STAT_CONN_LAYERED_CURS_PREV			1590
+#define	WT_STAT_CONN_LAYERED_CURS_PREV			1591
 /*! layered: Layered table cursor prev operations from the ingest btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_PREV_INGEST		1591
+#define	WT_STAT_CONN_LAYERED_CURS_PREV_INGEST		1592
 /*! layered: Layered table cursor prev operations from the stable btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_PREV_STABLE		1592
+#define	WT_STAT_CONN_LAYERED_CURS_PREV_STABLE		1593
 /*! layered: Layered table cursor remove operations */
-#define	WT_STAT_CONN_LAYERED_CURS_REMOVE		1593
+#define	WT_STAT_CONN_LAYERED_CURS_REMOVE		1594
 /*!
  * layered: Layered table cursor reopens the stable btree (role change or
  * checkpoint advance)
  */
-#define	WT_STAT_CONN_LAYERED_CURS_REOPEN_STABLE		1594
+#define	WT_STAT_CONN_LAYERED_CURS_REOPEN_STABLE		1595
 /*! layered: Layered table cursor search near operations */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR		1595
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR		1596
 /*!
  * layered: Layered table cursor search near operations from the ingest
  * btrees
  */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_INGEST	1596
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_INGEST	1597
 /*!
  * layered: Layered table cursor search near operations from the stable
  * btrees
  */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_STABLE	1597
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_NEAR_STABLE	1598
 /*! layered: Layered table cursor search operations */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH		1598
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH		1599
 /*! layered: Layered table cursor search operations from the ingest btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_INGEST		1599
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_INGEST		1600
 /*! layered: Layered table cursor search operations from the stable btrees */
-#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_STABLE		1600
+#define	WT_STAT_CONN_LAYERED_CURS_SEARCH_STABLE		1601
 /*! layered: Layered table cursor update operations */
-#define	WT_STAT_CONN_LAYERED_CURS_UPDATE		1601
+#define	WT_STAT_CONN_LAYERED_CURS_UPDATE		1602
 /*!
  * layered: Layered table stable values beginning with the tombstone byte
  * sequence and ending with a non-tombstone byte
  */
-#define	WT_STAT_CONN_LAYERED_CURS_STABLE_VALUE_TOMBSTONE_PREFIX	1602
+#define	WT_STAT_CONN_LAYERED_CURS_STABLE_VALUE_TOMBSTONE_PREFIX	1603
 /*!
  * layered: Layered table stable values beginning with the tombstone byte
  * sequence and ending with a tombstone byte
  */
-#define	WT_STAT_CONN_LAYERED_CURS_STABLE_VALUE_TOMBSTONE_SUFFIX	1603
+#define	WT_STAT_CONN_LAYERED_CURS_STABLE_VALUE_TOMBSTONE_SUFFIX	1604
 /*!
  * layered: Layered table stable values equal to the tombstone byte
  * sequence
  */
-#define	WT_STAT_CONN_LAYERED_CURS_STABLE_VALUE_TOMBSTONE	1604
+#define	WT_STAT_CONN_LAYERED_CURS_STABLE_VALUE_TOMBSTONE	1605
 /*! layered: Layered table stable values equal to three tombstone bytes */
-#define	WT_STAT_CONN_LAYERED_CURS_STABLE_VALUE_TOMBSTONE_X3	1605
+#define	WT_STAT_CONN_LAYERED_CURS_STABLE_VALUE_TOMBSTONE_X3	1606
 /*!
  * layered: checkpoints performed on this table by the layered table
  * manager
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS	1606
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS	1607
 /*! layered: disagg pick up checkpoints failed */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FAILED	1607
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FAILED	1608
 /*! layered: disagg pick up checkpoints succeeded */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_SUCCEED	1608
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_SUCCEED	1609
 /*!
  * layered: how many log applications the layered table manager applied
  * on this tree
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_APPLIED	1609
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_APPLIED	1610
 /*!
  * layered: how many log applications the layered table manager skipped
  * on this tree
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_SKIPPED	1610
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_LOGOPS_SKIPPED	1611
 /*!
  * layered: how many previously-applied LSNs the layered table manager
  * skipped on this tree
  */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_SKIP_LSN	1611
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_SKIP_LSN	1612
 /*! layered: number of checkpoints picked up by a follower */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FOLLOWER	1612
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_CHECKPOINTS_DISAGG_PICK_UP_FOLLOWER	1613
 /*! layered: the number of tables the layered table manager has open */
-#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_TABLES	1613
+#define	WT_STAT_CONN_LAYERED_TABLE_MANAGER_TABLES	1614
 /*! layered: the number of times the truncate list was searched */
-#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_SEARCH_CALLS	1614
+#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_SEARCH_CALLS	1615
 /*!
  * layered: the number of times truncate list garbage collection ran with
  * a valid prune timestamp
  */
-#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_GC_RUNS	1615
+#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_GC_RUNS	1616
 /*!
  * layered: the number of truncate list entries removed by garbage
  * collection
  */
-#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_GC_ENTRIES_REMOVED	1616
+#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_GC_ENTRIES_REMOVED	1617
 /*! layered: the number of truncate list entries walked during search */
-#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_SEARCH_ENTRIES_WALKED	1617
+#define	WT_STAT_CONN_LAYERED_TRUNCATE_LIST_SEARCH_ENTRIES_WALKED	1618
 /*!
  * live-restore: number of bytes copied from the source to the
  * destination
  */
-#define	WT_STAT_CONN_LIVE_RESTORE_BYTES_COPIED		1618
+#define	WT_STAT_CONN_LIVE_RESTORE_BYTES_COPIED		1619
 /*! live-restore: number of files remaining for migration completion */
-#define	WT_STAT_CONN_LIVE_RESTORE_WORK_REMAINING	1619
+#define	WT_STAT_CONN_LIVE_RESTORE_WORK_REMAINING	1620
 /*! live-restore: number of reads from the source database */
-#define	WT_STAT_CONN_LIVE_RESTORE_SOURCE_READ_COUNT	1620
+#define	WT_STAT_CONN_LIVE_RESTORE_SOURCE_READ_COUNT	1621
 /*! live-restore: source read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT2	1621
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT2	1622
 /*! live-restore: source read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT5	1622
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT5	1623
 /*! live-restore: source read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT10	1623
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT10	1624
 /*! live-restore: source read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT50	1624
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT50	1625
 /*! live-restore: source read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT100	1625
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT100	1626
 /*! live-restore: source read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT250	1626
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT250	1627
 /*! live-restore: source read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT500	1627
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT500	1628
 /*! live-restore: source read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT1000	1628
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_LT1000	1629
 /*! live-restore: source read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_GT1000	1629
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_GT1000	1630
 /*! live-restore: source read latency histogram total (msecs) */
-#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_TOTAL_MSECS	1630
+#define	WT_STAT_CONN_LIVE_RESTORE_HIST_SOURCE_READ_LATENCY_TOTAL_MSECS	1631
 /*! live-restore: state */
-#define	WT_STAT_CONN_LIVE_RESTORE_STATE			1631
+#define	WT_STAT_CONN_LIVE_RESTORE_STATE			1632
 /*! load-control: number of read operations rejected due to load control */
-#define	WT_STAT_CONN_READ_REJECT_COUNT			1632
+#define	WT_STAT_CONN_READ_REJECT_COUNT			1633
 /*! load-control: number of write operations rejected due to load control */
-#define	WT_STAT_CONN_WRITE_REJECT_COUNT			1633
+#define	WT_STAT_CONN_WRITE_REJECT_COUNT			1634
 /*! load-control: read load at the system level */
-#define	WT_STAT_CONN_READ_LOAD				1634
+#define	WT_STAT_CONN_READ_LOAD				1635
 /*! load-control: write load at the system level */
-#define	WT_STAT_CONN_WRITE_LOAD				1635
+#define	WT_STAT_CONN_WRITE_LOAD				1636
 /*! lock: btree page lock acquisitions */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_COUNT		1636
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_COUNT		1637
 /*! lock: btree page lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_APPLICATION	1637
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_APPLICATION	1638
 /*! lock: btree page lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_INTERNAL	1638
+#define	WT_STAT_CONN_LOCK_BTREE_PAGE_WAIT_INTERNAL	1639
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1639
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1640
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1640
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1641
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1641
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1642
 /*! lock: dhandle lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1642
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1643
 /*! lock: dhandle lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1643
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1644
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1644
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1645
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1645
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1646
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1646
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1647
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1647
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1648
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1648
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1649
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1649
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1650
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1650
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1651
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1651
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1652
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1652
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1653
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1653
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1654
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1654
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1655
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1655
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1656
 /*! lock: txn global lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1656
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1657
 /*! lock: txn global lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1657
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1658
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1658
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1659
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1659
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1660
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1660
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1661
 /*! log: force log remove time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1661
+#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1662
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1662
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1663
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1663
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1664
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1664
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1665
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1665
+#define	WT_STAT_CONN_LOG_FLUSH				1666
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1666
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1667
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1667
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1668
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1668
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1669
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1669
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1670
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1670
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1671
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1671
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1672
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1672
+#define	WT_STAT_CONN_LOG_SCANS				1673
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1673
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1674
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1674
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1675
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1675
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1676
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1676
+#define	WT_STAT_CONN_LOG_SYNC				1677
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1677
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1678
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1678
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1679
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1679
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1680
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1680
+#define	WT_STAT_CONN_LOG_WRITES				1681
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1681
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1682
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1682
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1683
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1683
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1684
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1684
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1685
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1685
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1686
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1686
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1687
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1687
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1688
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1688
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1689
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1689
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1690
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1690
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1691
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1691
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1692
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1692
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1693
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1693
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1694
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1694
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1695
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1695
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1696
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1696
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1697
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1697
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1698
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1698
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1699
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1699
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1700
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1700
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1701
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1701
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1702
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1702
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1703
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1703
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1704
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1704
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1705
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1705
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1706
 /*! perf: block manager read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT2	1706
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT2	1707
 /*! perf: block manager read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT5	1707
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT5	1708
 /*! perf: block manager read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT10	1708
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT10	1709
 /*! perf: block manager read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT50	1709
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT50	1710
 /*! perf: block manager read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT100	1710
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT100	1711
 /*! perf: block manager read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT250	1711
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT250	1712
 /*! perf: block manager read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT500	1712
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT500	1713
 /*! perf: block manager read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT1000	1713
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_LT1000	1714
 /*! perf: block manager read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_GT1000	1714
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_GT1000	1715
 /*! perf: block manager read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_TOTAL_MSECS	1715
+#define	WT_STAT_CONN_PERF_HIST_BMREAD_LATENCY_TOTAL_MSECS	1716
 /*! perf: block manager write latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT2	1716
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT2	1717
 /*! perf: block manager write latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT5	1717
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT5	1718
 /*! perf: block manager write latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT10	1718
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT10	1719
 /*! perf: block manager write latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT50	1719
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT50	1720
 /*! perf: block manager write latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT100	1720
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT100	1721
 /*! perf: block manager write latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT250	1721
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT250	1722
 /*! perf: block manager write latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT500	1722
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT500	1723
 /*! perf: block manager write latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT1000	1723
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_LT1000	1724
 /*! perf: block manager write latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_GT1000	1724
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_GT1000	1725
 /*! perf: block manager write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_TOTAL_MSECS	1725
+#define	WT_STAT_CONN_PERF_HIST_BMWRITE_LATENCY_TOTAL_MSECS	1726
 /*! perf: disagg block manager read latency histogram (bucket 1) - 50-99us */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT100	1726
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT100	1727
 /*!
  * perf: disagg block manager read latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT250	1727
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT250	1728
 /*!
  * perf: disagg block manager read latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT500	1728
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT500	1729
 /*!
  * perf: disagg block manager read latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT1000	1729
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT1000	1730
 /*!
  * perf: disagg block manager read latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT2500	1730
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT2500	1731
 /*!
  * perf: disagg block manager read latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT5000	1731
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT5000	1732
 /*!
  * perf: disagg block manager read latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT10000	1732
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_LT10000	1733
 /*!
  * perf: disagg block manager read latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_GT10000	1733
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_GT10000	1734
 /*! perf: disagg block manager read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_TOTAL_USECS	1734
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMREAD_LATENCY_TOTAL_USECS	1735
 /*!
  * perf: disagg block manager write latency histogram (bucket 1) -
  * 50-99us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT100	1735
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT100	1736
 /*!
  * perf: disagg block manager write latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT250	1736
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT250	1737
 /*!
  * perf: disagg block manager write latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT500	1737
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT500	1738
 /*!
  * perf: disagg block manager write latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT1000	1738
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT1000	1739
 /*!
  * perf: disagg block manager write latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT2500	1739
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT2500	1740
 /*!
  * perf: disagg block manager write latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT5000	1740
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT5000	1741
 /*!
  * perf: disagg block manager write latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT10000	1741
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_LT10000	1742
 /*!
  * perf: disagg block manager write latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_GT10000	1742
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_GT10000	1743
 /*! perf: disagg block manager write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_TOTAL_USECS	1743
+#define	WT_STAT_CONN_PERF_HIST_DISAGGBMWRITE_LATENCY_TOTAL_USECS	1744
 /*! perf: file system read latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT2	1744
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT2	1745
 /*! perf: file system read latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT5	1745
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT5	1746
 /*! perf: file system read latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1746
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1747
 /*! perf: file system read latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1747
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1748
 /*! perf: file system read latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1748
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1749
 /*! perf: file system read latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1749
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1750
 /*! perf: file system read latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1750
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1751
 /*! perf: file system read latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1751
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1752
 /*! perf: file system read latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1752
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1753
 /*! perf: file system read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1753
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1754
 /*! perf: file system write latency histogram (bucket 1) - 0-1ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT2	1754
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT2	1755
 /*! perf: file system write latency histogram (bucket 2) - 2-4ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT5	1755
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT5	1756
 /*! perf: file system write latency histogram (bucket 3) - 5-9ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1756
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1757
 /*! perf: file system write latency histogram (bucket 4) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1757
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1758
 /*! perf: file system write latency histogram (bucket 5) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1758
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1759
 /*! perf: file system write latency histogram (bucket 6) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1759
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1760
 /*! perf: file system write latency histogram (bucket 7) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1760
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1761
 /*! perf: file system write latency histogram (bucket 8) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1761
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1762
 /*! perf: file system write latency histogram (bucket 9) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1762
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1763
 /*! perf: file system write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1763
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1764
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 1) -
  * 0-100us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT100	1764
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT100	1765
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT250	1765
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT250	1766
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT500	1766
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT500	1767
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT1000	1767
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT1000	1768
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT2500	1768
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT2500	1769
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT5000	1769
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT5000	1770
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT10000	1770
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_LT10000	1771
 /*!
  * perf: internal page deltas reconstruct latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_GT10000	1771
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_GT10000	1772
 /*! perf: internal page deltas reconstruct latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_TOTAL_USECS	1772
+#define	WT_STAT_CONN_PERF_HIST_INTERNAL_RECONSTRUCT_LATENCY_TOTAL_USECS	1773
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 1) -
  * 0-100us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT100	1773
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT100	1774
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 2) -
  * 100-249us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT250	1774
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT250	1775
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 3) -
  * 250-499us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT500	1775
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT500	1776
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 4) -
  * 500-999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT1000	1776
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT1000	1777
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 5) -
  * 1000-2499us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT2500	1777
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT2500	1778
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 6) -
  * 2500-4999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT5000	1778
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT5000	1779
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 7) -
  * 5000-9999us
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT10000	1779
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_LT10000	1780
 /*!
  * perf: leaf page deltas reconstruct latency histogram (bucket 8) -
  * 10000us+
  */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_GT10000	1780
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_GT10000	1781
 /*! perf: leaf page deltas reconstruct latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_TOTAL_USECS	1781
+#define	WT_STAT_CONN_PERF_HIST_LEAF_RECONSTRUCT_LATENCY_TOTAL_USECS	1782
 /*! perf: operation read latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1782
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1783
 /*! perf: operation read latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1783
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1784
 /*! perf: operation read latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1784
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1785
 /*! perf: operation read latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1785
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1786
 /*! perf: operation read latency histogram (bucket 5) - 1000-2499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT2500	1786
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT2500	1787
 /*! perf: operation read latency histogram (bucket 6) - 2500-4999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT5000	1787
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT5000	1788
 /*! perf: operation read latency histogram (bucket 7) - 5000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1788
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1789
 /*! perf: operation read latency histogram (bucket 8) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1789
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1790
 /*! perf: operation read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1790
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1791
 /*! perf: operation write latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1791
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1792
 /*! perf: operation write latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1792
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1793
 /*! perf: operation write latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1793
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1794
 /*! perf: operation write latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1794
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1795
 /*! perf: operation write latency histogram (bucket 5) - 1000-2499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT2500	1795
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT2500	1796
 /*! perf: operation write latency histogram (bucket 6) - 2500-4999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT5000	1796
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT5000	1797
 /*! perf: operation write latency histogram (bucket 7) - 5000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1797
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1798
 /*! perf: operation write latency histogram (bucket 8) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1798
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1799
 /*! perf: operation write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1799
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1800
 /*! prefetch: could not perform pre-fetch on internal page */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1800
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1801
 /*!
  * prefetch: could not perform pre-fetch on ref without the pre-fetch
  * flag set
  */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1801
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1802
 /*! prefetch: pre-fetch attempted, session has pre-fetching enabled */
-#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1802
+#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1803
 /*! prefetch: pre-fetch not repeating for recently pre-fetched ref */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1803
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1804
 /*! prefetch: pre-fetch not triggered after single disk read */
-#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1804
+#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1805
 /*! prefetch: pre-fetch not triggered as there is no valid dhandle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1805
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1806
 /*! prefetch: pre-fetch not triggered due to disk read count */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1806
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1807
 /*! prefetch: pre-fetch not triggered due to internal session */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1807
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1808
 /*! prefetch: pre-fetch not triggered due to special btree handle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1808
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1809
 /*! prefetch: pre-fetch not triggered, pre-fetch queue is full */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_QUEUE_FULL	1809
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_QUEUE_FULL	1810
 /*! prefetch: pre-fetch page not on disk when reading */
-#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1810
+#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1811
 /*! prefetch: pre-fetch pages queued */
-#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1811
+#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1812
 /*! prefetch: pre-fetch pages read in background */
-#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1812
+#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1813
 /*!
  * prefetch: pre-fetch session check passed, pre-fetch work issued to
  * btree
  */
-#define	WT_STAT_CONN_PREFETCH_ATTEMPTS_SUCCEEDED	1813
+#define	WT_STAT_CONN_PREFETCH_ATTEMPTS_SUCCEEDED	1814
 /*! prefetch: pre-fetch skipped reading in a page due to harmless error */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1814
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1815
 /*!
  * prefetch: pre-fetch skipped traversal of internal page due to active
  * split generation
  */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SPLIT_GEN	1815
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SPLIT_GEN	1816
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1816
+#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1817
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1817
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1818
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1818
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1819
 /*!
  * reconciliation: average length of delta chain on internal page with
  * deltas
  */
-#define	WT_STAT_CONN_REC_AVERAGE_INTERNAL_PAGE_DELTA_CHAIN_LENGTH	1819
+#define	WT_STAT_CONN_REC_AVERAGE_INTERNAL_PAGE_DELTA_CHAIN_LENGTH	1820
 /*! reconciliation: average length of delta chain on leaf page with deltas */
-#define	WT_STAT_CONN_REC_AVERAGE_LEAF_PAGE_DELTA_CHAIN_LENGTH	1820
+#define	WT_STAT_CONN_REC_AVERAGE_LEAF_PAGE_DELTA_CHAIN_LENGTH	1821
 /*!
  * reconciliation: changes since prior reconciliation (bucket 1) between
  * 1 and 5
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE5			1821
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE5			1822
 /*!
  * reconciliation: changes since prior reconciliation (bucket 2) between
  * 6 and 10
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE10			1822
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE10			1823
 /*!
  * reconciliation: changes since prior reconciliation (bucket 3) between
  * 11 and 20
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE20			1823
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE20			1824
 /*!
  * reconciliation: changes since prior reconciliation (bucket 4) between
  * 21 and 50
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE50			1824
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE50			1825
 /*!
  * reconciliation: changes since prior reconciliation (bucket 5) between
  * 51 and 100
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE100		1825
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE100		1826
 /*!
  * reconciliation: changes since prior reconciliation (bucket 6) between
  * 101 and 200
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE200		1826
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE200		1827
 /*!
  * reconciliation: changes since prior reconciliation (bucket 7) between
  * 201 and 500
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_LE500		1827
+#define	WT_STAT_CONN_REC_PAGE_MODS_LE500		1828
 /*!
  * reconciliation: changes since prior reconciliation (bucket 8) greater
  * than 500
  */
-#define	WT_STAT_CONN_REC_PAGE_MODS_GT500		1828
+#define	WT_STAT_CONN_REC_PAGE_MODS_GT500		1829
 /*! reconciliation: cursor next/prev calls during HS wrapup search_near */
-#define	WT_STAT_CONN_REC_HS_WRAPUP_NEXT_PREV_CALLS	1829
+#define	WT_STAT_CONN_REC_HS_WRAPUP_NEXT_PREV_CALLS	1830
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1830
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1831
 /*!
  * reconciliation: free page ID due to failed page replacement
  * reconciliation in disagg
  */
-#define	WT_STAT_CONN_REC_FREE_PAGE_ID_DUE_TO_FAILED_REPLACEMENT_RECONCILIATION	1831
+#define	WT_STAT_CONN_REC_FREE_PAGE_ID_DUE_TO_FAILED_REPLACEMENT_RECONCILIATION	1832
 /*! reconciliation: full internal pages written instead of a page delta */
-#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_INTERNAL	1832
+#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_INTERNAL	1833
 /*! reconciliation: full leaf pages written instead of a page delta */
-#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_LEAF		1833
+#define	WT_STAT_CONN_REC_PAGE_FULL_IMAGE_LEAF		1834
 /*!
  * reconciliation: ingest btree reconciliation keeps the aborted prepare
  * updates
  */
-#define	WT_STAT_CONN_REC_INGEST_KEEP_PREPARE_ROLLBACK	1834
+#define	WT_STAT_CONN_REC_INGEST_KEEP_PREPARE_ROLLBACK	1835
 /*! reconciliation: internal page delta keys deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_DELETED	1835
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_DELETED	1836
 /*! reconciliation: internal page delta keys updated/inserted */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_UPDATED	1836
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL_KEY_UPDATED	1837
 /*! reconciliation: internal page deltas written */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL		1837
+#define	WT_STAT_CONN_REC_PAGE_DELTA_INTERNAL		1838
 /*! reconciliation: internal page multi-block writes */
-#define	WT_STAT_CONN_REC_MULTIBLOCK_INTERNAL		1838
+#define	WT_STAT_CONN_REC_MULTIBLOCK_INTERNAL		1839
 /*! reconciliation: leaf page deltas written */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_LEAF		1839
+#define	WT_STAT_CONN_REC_PAGE_DELTA_LEAF		1840
 /*! reconciliation: leaf page multi-block writes */
-#define	WT_STAT_CONN_REC_MULTIBLOCK_LEAF		1840
+#define	WT_STAT_CONN_REC_MULTIBLOCK_LEAF		1841
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1841
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1842
 /*! reconciliation: max deltas seen on internal page during reconciliation */
-#define	WT_STAT_CONN_REC_MAX_INTERNAL_PAGE_DELTAS	1842
+#define	WT_STAT_CONN_REC_MAX_INTERNAL_PAGE_DELTAS	1843
 /*! reconciliation: max deltas seen on leaf page during reconciliation */
-#define	WT_STAT_CONN_REC_MAX_LEAF_PAGE_DELTAS		1843
+#define	WT_STAT_CONN_REC_MAX_LEAF_PAGE_DELTAS		1844
 /*! reconciliation: maximum milliseconds spent in a reconciliation call */
-#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1844
+#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1845
 /*!
  * reconciliation: maximum milliseconds spent in building a disk image in
  * a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1845
+#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1846
 /*!
  * reconciliation: maximum milliseconds spent in moving updates to the
  * history store in a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1846
+#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1847
 /*!
  * reconciliation: number of keys that are garbage collected from the
  * disk images in the ingest btrees for disaggregated storage
  */
-#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_DISK_IMAGE	1847
+#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_DISK_IMAGE	1848
 /*!
  * reconciliation: number of keys that are garbage collected from the
  * update chains in the ingest btrees for disaggregated storage
  */
-#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_UPDATE_CHAIN	1848
+#define	WT_STAT_CONN_REC_INGEST_GARBAGE_COLLECTION_KEYS_UPDATE_CHAIN	1849
 /*! reconciliation: overflow values written */
-#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1849
+#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1850
 /*! reconciliation: page deltas rejected due to invalid page ID */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_INVALID_PAGE_ID	1850
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_INVALID_PAGE_ID	1851
 /*! reconciliation: page deltas rejected due to max consecutive limit */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MAX_CONSECUTIVE_EXCEEDED	1851
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MAX_CONSECUTIVE_EXCEEDED	1852
 /*! reconciliation: page deltas rejected due to multiblock reconciliation */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MULTIBLOCK	1852
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_MULTIBLOCK	1853
 /*!
  * reconciliation: page deltas rejected due to non-single page in
  * previous reconciliation
  */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_NON_SINGLE_PAGE	1853
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_NON_SINGLE_PAGE	1854
 /*! reconciliation: page deltas rejected due to size threshold */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_SIZE_THRESHOLD	1854
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_SIZE_THRESHOLD	1855
 /*!
  * reconciliation: page deltas rejected due to too many keys removed from
  * the disk image
  */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_DELETE_THRESHOLD	1855
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_DELETE_THRESHOLD	1856
 /*! reconciliation: page deltas rejected due to zero entries */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_ZERO_ENTRIES	1856
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_ZERO_ENTRIES	1857
 /*!
  * reconciliation: page deltas rejected: build function returned false
  * (disabled, in-memory split, or internal page constraints not met)
  */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_BUILD_FAILED	1857
+#define	WT_STAT_CONN_REC_PAGE_DELTA_REJECTED_BUILD_FAILED	1858
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1858
+#define	WT_STAT_CONN_REC_PAGES				1859
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1859
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1860
 /*! reconciliation: page reconciliation calls for pages between 1 and 10MB */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_1MB_TO_10MB		1860
+#define	WT_STAT_CONN_REC_PAGES_SIZE_1MB_TO_10MB		1861
 /*!
  * reconciliation: page reconciliation calls for pages between 10 and
  * 100MB
  */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_10MB_TO_100MB	1861
+#define	WT_STAT_CONN_REC_PAGES_SIZE_10MB_TO_100MB	1862
 /*!
  * reconciliation: page reconciliation calls for pages between 100MB and
  * 1GB
  */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_100MB_TO_1GB	1862
+#define	WT_STAT_CONN_REC_PAGES_SIZE_100MB_TO_1GB	1863
 /*! reconciliation: page reconciliation calls for pages over 1GB */
-#define	WT_STAT_CONN_REC_PAGES_SIZE_1GB_PLUS		1863
+#define	WT_STAT_CONN_REC_PAGES_SIZE_1GB_PLUS		1864
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * prepared transaction metadata
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1864
+#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1865
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * timestamps
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1865
+#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1866
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * transaction ids
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1866
+#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1867
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1867
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1868
 /*! reconciliation: pages eligible for delta generation */
-#define	WT_STAT_CONN_REC_PAGE_DELTA_ELIGIBLE		1868
+#define	WT_STAT_CONN_REC_PAGE_DELTA_ELIGIBLE		1869
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1869
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1870
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1870
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1871
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1871
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1872
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1872
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1873
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1873
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1874
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1874
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1875
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1875
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1876
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1876
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1877
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1877
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1878
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1878
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1879
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1879
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1880
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1880
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1881
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1881
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1882
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1882
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1883
 /*! reconciliation: pages written with at least one internal page delta */
-#define	WT_STAT_CONN_REC_PAGES_WITH_INTERNAL_DELTAS	1883
+#define	WT_STAT_CONN_REC_PAGES_WITH_INTERNAL_DELTAS	1884
 /*! reconciliation: pages written with at least one leaf page delta */
-#define	WT_STAT_CONN_REC_PAGES_WITH_LEAF_DELTAS		1884
+#define	WT_STAT_CONN_REC_PAGES_WITH_LEAF_DELTAS		1885
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1885
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1886
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1886
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1887
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1887
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1888
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1888
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1889
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1889
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1890
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1890
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1891
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1891
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1892
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1892
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1893
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1893
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1894
 /*! reconciliation: writes skipped in disaggregated storage */
-#define	WT_STAT_CONN_REC_SKIP_WRITE			1894
+#define	WT_STAT_CONN_REC_SKIP_WRITE			1895
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1895
+#define	WT_STAT_CONN_SESSION_OPEN			1896
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1896
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1897
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1897
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1898
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1898
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1899
 /*! session: table alter triggering checkpoint calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1899
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1900
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1900
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1901
 /*! session: table compact conflicted with checkpoint */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1901
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1902
 /*! session: table compact dhandle successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1902
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1903
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1903
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1904
 /*! session: table compact failed calls due to cache pressure */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1904
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1905
 /*!
  * session: table compact in-memory page footprint rewritten by
  * compaction
  */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_BYTES_REWRITE_INMEM	1905
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_BYTES_REWRITE_INMEM	1906
 /*! session: table compact passes */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1906
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1907
 /*! session: table compact pulled into eviction */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1907
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1908
 /*! session: table compact running */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1908
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1909
 /*! session: table compact skipped as process would not reduce file size */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1909
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1910
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1910
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1911
 /*! session: table compact timeout */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1911
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1912
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1912
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1913
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1913
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1914
 /*! session: table create with import failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1914
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1915
 /*! session: table create with import repair calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1915
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1916
 /*! session: table create with import successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1916
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1917
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1917
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1918
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1918
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1919
 /*! session: table publish failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_PUBLISH_FAIL		1919
+#define	WT_STAT_CONN_SESSION_TABLE_PUBLISH_FAIL		1920
 /*! session: table publish successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_PUBLISH_SUCCESS	1920
+#define	WT_STAT_CONN_SESSION_TABLE_PUBLISH_SUCCESS	1921
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1921
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1922
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1922
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1923
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1923
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1924
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1924
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1925
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1925
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1926
 /*! session: table verify number of keys checked against the history store */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_HS_KEYS_CHECKED	1926
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_HS_KEYS_CHECKED	1927
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1927
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1928
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1928
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1929
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1929
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1930
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1930
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1931
 /*! thread-yield: application thread operations waiting for cache */
-#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1931
+#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1932
 /*!
  * thread-yield: application thread operations waiting for interruptible
  * cache eviction
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_OPS	1932
+#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_OPS	1933
 /*!
  * thread-yield: application thread operations waiting for mandatory
  * cache eviction
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_OPS	1933
+#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_OPS	1934
 /*! thread-yield: application thread snapshot refreshed for eviction */
-#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1934
+#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1935
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1935
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1936
 /*!
  * thread-yield: application thread time waiting for interruptible cache
  * eviction (usecs)
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_TIME	1936
+#define	WT_STAT_CONN_APPLICATION_CACHE_INTERRUPTIBLE_TIME	1937
 /*!
  * thread-yield: application thread time waiting for mandatory cache
  * eviction (usecs)
  */
-#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_TIME	1937
+#define	WT_STAT_CONN_APPLICATION_CACHE_UNINTERRUPTIBLE_TIME	1938
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1938
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1939
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1939
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1940
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1940
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1941
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1941
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1942
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1942
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1943
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1943
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1944
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1944
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1945
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1945
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1946
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1946
+#define	WT_STAT_CONN_PAGE_SLEEP				1947
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1947
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1948
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1948
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1949
 /*! thread-yield: page split and restart read */
-#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1949
+#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1950
 /*! thread-yield: pages skipped during read due to deleted state */
-#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1950
+#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1951
 /*!
  * tiered-storage: attempts to remove a local object and the object is in
  * use
  */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1951
+#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1952
 /*! tiered-storage: flush_tier failed calls */
-#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1952
+#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1953
 /*! tiered-storage: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1953
+#define	WT_STAT_CONN_FLUSH_TIER				1954
 /*! tiered-storage: flush_tier tables skipped due to no checkpoint */
-#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1954
+#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1955
 /*! tiered-storage: flush_tier tables switched */
-#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1955
+#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1956
 /*! tiered-storage: local objects removed */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1956
+#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1957
 /*! tiered-storage: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1957
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1958
 /*! tiered-storage: tiered operations removed without processing */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1958
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1959
 /*! tiered-storage: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1959
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1960
 /*! tiered-storage: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1960
+#define	WT_STAT_CONN_TIERED_RETENTION			1961
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1961
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1962
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1962
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1963
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1963
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1964
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1964
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1965
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1965
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1966
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1966
+#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1967
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1967
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1968
 /*! transaction: oldest transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1968
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1969
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1969
+#define	WT_STAT_CONN_TXN_PREPARE			1970
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1970
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1971
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1971
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1972
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1972
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1973
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1973
+#define	WT_STAT_CONN_TXN_QUERY_TS			1974
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1974
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1975
 /*! transaction: rollback to stable applied btrees */
-#define	WT_STAT_CONN_TXN_RTS_BTREES_APPLIED		1975
+#define	WT_STAT_CONN_TXN_RTS_BTREES_APPLIED		1976
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1976
+#define	WT_STAT_CONN_TXN_RTS				1977
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1977
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1978
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1978
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1979
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1979
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1980
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1980
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1981
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1981
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1982
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1982
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1983
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1983
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1984
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1984
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1985
 /*!
  * transaction: rollback to stable prepared fast truncations that would
  * have been rolled back in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_PREPARED_FAST_TRUNCATE_DRYRUN	1985
+#define	WT_STAT_CONN_TXN_RTS_PREPARED_FAST_TRUNCATE_DRYRUN	1986
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1986
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1987
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1987
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1988
 /*! transaction: rollback to stable rolled back prepared fast truncations */
-#define	WT_STAT_CONN_TXN_RTS_PREPARED_FAST_TRUNCATE	1988
+#define	WT_STAT_CONN_TXN_RTS_PREPARED_FAST_TRUNCATE	1989
 /*! transaction: rollback to stable skipped btrees */
-#define	WT_STAT_CONN_TXN_RTS_BTREES_SKIPPED		1989
+#define	WT_STAT_CONN_TXN_RTS_BTREES_SKIPPED		1990
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1990
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1991
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1991
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1992
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1992
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1993
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1993
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1994
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1994
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1995
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1995
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1996
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1996
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1997
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1997
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1998
 /*!
  * transaction: rollback to stable updates that would have been aborted
  * in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1998
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1999
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1999
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		2000
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		2000
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		2001
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				2001
+#define	WT_STAT_CONN_TXN_SET_TS				2002
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			2002
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			2003
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		2003
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		2004
 /*! transaction: set timestamp force calls */
-#define	WT_STAT_CONN_TXN_SET_TS_FORCE			2004
+#define	WT_STAT_CONN_TXN_SET_TS_FORCE			2005
 /*!
  * transaction: set timestamp global oldest timestamp set to be more
  * recent than the global stable timestamp
  */
-#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		2005
+#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		2006
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			2006
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			2007
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		2007
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		2008
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			2008
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			2009
 /*! transaction: set timestamp stable disaggregated schema epoch calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_DISAGG_EPOCH	2009
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_DISAGG_EPOCH	2010
 /*! transaction: set timestamp stable disaggregated schema epoch updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_DISAGG_EPOCH_UPD	2010
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_DISAGG_EPOCH_UPD	2011
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		2011
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		2012
 /*! transaction: set timestamp step down updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STEP_DOWN_UPD		2012
+#define	WT_STAT_CONN_TXN_SET_TS_STEP_DOWN_UPD		2013
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				2013
+#define	WT_STAT_CONN_TXN_BEGIN				2014
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		2014
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		2015
 /*! transaction: transaction global checkpoint timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_CHECKPOINT_TIMESTAMP	2015
+#define	WT_STAT_CONN_TXN_GLOBAL_CHECKPOINT_TIMESTAMP	2016
 /*! transaction: transaction global durable timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_DURABLE_TIMESTAMP	2016
+#define	WT_STAT_CONN_TXN_GLOBAL_DURABLE_TIMESTAMP	2017
 /*! transaction: transaction global last running timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_LAST_RUNNING_TIMESTAMP	2017
+#define	WT_STAT_CONN_TXN_GLOBAL_LAST_RUNNING_TIMESTAMP	2018
 /*! transaction: transaction global newest timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_NEWEST_TIMESTAMP	2018
+#define	WT_STAT_CONN_TXN_GLOBAL_NEWEST_TIMESTAMP	2019
 /*! transaction: transaction global oldest timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_OLDEST_TIMESTAMP	2019
+#define	WT_STAT_CONN_TXN_GLOBAL_OLDEST_TIMESTAMP	2020
 /*! transaction: transaction global pinned timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_PINNED_TIMESTAMP	2020
+#define	WT_STAT_CONN_TXN_GLOBAL_PINNED_TIMESTAMP	2021
 /*! transaction: transaction global stable timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_STABLE_TIMESTAMP	2021
+#define	WT_STAT_CONN_TXN_GLOBAL_STABLE_TIMESTAMP	2022
 /*! transaction: transaction global version cursor timestamp */
-#define	WT_STAT_CONN_TXN_GLOBAL_VERSION_CURSOR_TIMESTAMP	2022
+#define	WT_STAT_CONN_TXN_GLOBAL_VERSION_CURSOR_TIMESTAMP	2023
 /*!
  * transaction: transaction number of older readers older than oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_READERS			2023
+#define	WT_STAT_CONN_TXN_PINNED_READERS			2024
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			2024
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			2025
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	2025
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	2026
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_LAG		2026
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_LAG		2027
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT_LAG	2027
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT_LAG	2028
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER_LAG	2028
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER_LAG	2029
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	2029
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	2030
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	2030
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	2031
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	2031
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	2032
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			2032
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			2033
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				2033
+#define	WT_STAT_CONN_TXN_COMMIT				2034
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			2034
+#define	WT_STAT_CONN_TXN_ROLLBACK			2035
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		2035
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		2036
 
 /*!
  * @}

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -2446,6 +2446,8 @@ static const char *const __stats_connection_desc[] = {
   "checkpoint-cleanup: successful calls",
   "checkpoint: checkpoint has acquired a snapshot for its transaction",
   "checkpoint: checkpoints skipped because database was clean",
+  "checkpoint: create and remove metadata operation pairs canceled during disaggregated checkpoint "
+  "because the remove was not covered",
   "checkpoint: fsync calls after allocating the transaction ID",
   "checkpoint: fsync duration after allocating the transaction ID (usecs)",
   "checkpoint: generation",
@@ -3539,6 +3541,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     stats->checkpoint_cleanup_success = 0;
     stats->checkpoint_snapshot_acquired = 0;
     stats->checkpoint_skipped = 0;
+    /* not clearing checkpoint_disagg_metadata_pair_canceled */
     stats->checkpoint_fsync_post = 0;
     /* not clearing checkpoint_fsync_post_duration */
     /* not clearing checkpoint_generation */
@@ -4729,6 +4732,8 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->checkpoint_cleanup_success += WT_STAT_CONN_READ(from, checkpoint_cleanup_success);
     to->checkpoint_snapshot_acquired += WT_STAT_CONN_READ(from, checkpoint_snapshot_acquired);
     to->checkpoint_skipped += WT_STAT_CONN_READ(from, checkpoint_skipped);
+    to->checkpoint_disagg_metadata_pair_canceled +=
+      WT_STAT_CONN_READ(from, checkpoint_disagg_metadata_pair_canceled);
     to->checkpoint_fsync_post += WT_STAT_CONN_READ(from, checkpoint_fsync_post);
     to->checkpoint_fsync_post_duration += WT_STAT_CONN_READ(from, checkpoint_fsync_post_duration);
     to->checkpoint_generation += WT_STAT_CONN_READ(from, checkpoint_generation);

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -2447,7 +2447,7 @@ static const char *const __stats_connection_desc[] = {
   "checkpoint: checkpoint has acquired a snapshot for its transaction",
   "checkpoint: checkpoints skipped because database was clean",
   "checkpoint: create and remove metadata operation pairs canceled during disaggregated checkpoint "
-  "because the remove was not covered",
+  "because the remove was never published",
   "checkpoint: fsync calls after allocating the transaction ID",
   "checkpoint: fsync duration after allocating the transaction ID (usecs)",
   "checkpoint: generation",

--- a/test/suite/test_layered_schema10.py
+++ b/test/suite/test_layered_schema10.py
@@ -34,11 +34,11 @@
 
 import wiredtiger, wttest
 from helper_disagg import disagg_test_class, gen_disagg_storages, DisaggSchemaEpochMixin
-from wiredtiger import stat
+from suite_subprocess import suite_subprocess
 from wtscenario import make_scenarios
 
 @disagg_test_class
-class test_layered_schema10(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
+class test_layered_schema10(wttest.WiredTigerTestCase, suite_subprocess, DisaggSchemaEpochMixin):
     test_name = __qualname__
     conn_base_config = 'statistics=(all),precise_checkpoint=true,'
     conn_config = conn_base_config + 'disaggregated=(role="leader",lose_all_my_data=true)'
@@ -274,13 +274,8 @@ class test_layered_schema10(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
 
         conn_follow.close('debug=(skip_checkpoint=true)')
 
-    def test_create_drop_split_epochs(self):
-        """
-        Publishing CREATE and DROP at different epochs, with a checkpoint whose stable epoch
-        falls in between, is a tolerated contract violation: the checkpoint cancels the queued
-        create/remove pair with an error message and a statistic instead of publishing a
-        dropped table that no node can serve.
-        """
+    def subprocess_create_drop_split_epochs(self):
+        """Subprocess body for the split-epochs panic test; expected to panic/abort."""
         self.setup_leader_with_epoch()
 
         conn_follow, session_follow = self.open_follower()
@@ -303,31 +298,32 @@ class test_layered_schema10(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
         self.assertFalse(self.uri_in_shared_metadata(conn_follow, self.uri))
 
         # Checkpoint at epoch=20: the stable epoch falls between CREATE (epoch=20) and
-        # DROP (epoch=30). Rather than publish a dropped table no node can serve, the
-        # checkpoint cancels the pair and reports it.
+        # DROP (epoch=30), so the table must be visible in shared metadata at this checkpoint.
+        # But the stable constituent was never created, so WiredTiger panics.
         self.set_stable_epoch(20, conn_follow)
         conn_follow.set_timestamp(
             'stable_timestamp=' + self.timestamp_str(2) +
             ',oldest_timestamp=' + self.timestamp_str(1))
         session_ck = conn_follow.open_session('')
-        with self.expectedStderrPattern('canceling both operations'):
-            session_ck.checkpoint()
+        session_ck.checkpoint()  # Expected to panic.
 
-        # The pair nets out: nothing in shared metadata, and the cancellation is counted.
-        self.assertFalse(self.uri_in_shared_metadata(conn_follow, self.uri))
-        stat_cursor = session_ck.open_cursor('statistics:')
-        self.assertEqual(
-            stat_cursor[stat.conn.checkpoint_disagg_metadata_pair_canceled][2], 1)
-        stat_cursor.close()
+    def test_create_drop_split_epochs(self):
+        """
+        Publishing CREATE and DROP at different epochs is an API violation that panics.
 
-        # A later checkpoint covering the epoch of the canceled REMOVE stays clean.
-        self.set_stable_epoch(30, conn_follow)
-        conn_follow.set_timestamp('stable_timestamp=' + self.timestamp_str(3))
-        session_ck.checkpoint()
-        self.assertFalse(self.uri_in_shared_metadata(conn_follow, self.uri))
-        session_ck.close()
-
-        conn_follow.close('debug=(skip_checkpoint=true)')
+        The stable epoch falls between CREATE (epoch=20) and DROP (epoch=30), so this checkpoint
+        must include the table in shared metadata. But the table was dropped and its stable
+        constituent was never created, so we have no data to write. WiredTiger detects this and
+        panics.
+        """
+        # Initialize self.conn so the test fixture can close it cleanly; the real test runs
+        # in a subprocess so that the panic/abort does not kill the test runner.
+        self.setup_leader_with_epoch()
+        subdir = 'SUBPROCESS_create_drop_split_epochs'
+        [returncode, _] = self.run_subprocess_function(subdir,
+            f'{self.test_name}.{self.test_name}.subprocess_create_drop_split_epochs',
+            silent=True)
+        self.assertNotEqual(returncode, 0)
 
     def test_unpublished_create_not_flushed(self):
         """

--- a/test/suite/test_layered_schema10.py
+++ b/test/suite/test_layered_schema10.py
@@ -34,11 +34,11 @@
 
 import wiredtiger, wttest
 from helper_disagg import disagg_test_class, gen_disagg_storages, DisaggSchemaEpochMixin
-from suite_subprocess import suite_subprocess
+from wiredtiger import stat
 from wtscenario import make_scenarios
 
 @disagg_test_class
-class test_layered_schema10(wttest.WiredTigerTestCase, suite_subprocess, DisaggSchemaEpochMixin):
+class test_layered_schema10(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
     test_name = __qualname__
     conn_base_config = 'statistics=(all),precise_checkpoint=true,'
     conn_config = conn_base_config + 'disaggregated=(role="leader",lose_all_my_data=true)'
@@ -274,8 +274,13 @@ class test_layered_schema10(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
 
         conn_follow.close('debug=(skip_checkpoint=true)')
 
-    def subprocess_create_drop_split_epochs(self):
-        """Subprocess body for the split-epochs panic test; expected to panic/abort."""
+    def test_create_drop_split_epochs(self):
+        """
+        Publishing CREATE and DROP at different epochs, with a checkpoint whose stable epoch
+        falls in between, is a tolerated contract violation: the checkpoint cancels the queued
+        create/remove pair with an error message and a statistic instead of publishing a
+        dropped table that no node can serve.
+        """
         self.setup_leader_with_epoch()
 
         conn_follow, session_follow = self.open_follower()
@@ -298,32 +303,31 @@ class test_layered_schema10(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
         self.assertFalse(self.uri_in_shared_metadata(conn_follow, self.uri))
 
         # Checkpoint at epoch=20: the stable epoch falls between CREATE (epoch=20) and
-        # DROP (epoch=30), so the table must be visible in shared metadata at this checkpoint.
-        # But the stable constituent was never created, so WiredTiger panics.
+        # DROP (epoch=30). Rather than publish a dropped table no node can serve, the
+        # checkpoint cancels the pair and reports it.
         self.set_stable_epoch(20, conn_follow)
         conn_follow.set_timestamp(
             'stable_timestamp=' + self.timestamp_str(2) +
             ',oldest_timestamp=' + self.timestamp_str(1))
         session_ck = conn_follow.open_session('')
-        session_ck.checkpoint()  # Expected to panic.
+        with self.expectedStderrPattern('canceling both operations'):
+            session_ck.checkpoint()
 
-    def test_create_drop_split_epochs(self):
-        """
-        Publishing CREATE and DROP at different epochs is an API violation that panics.
+        # The pair nets out: nothing in shared metadata, and the cancellation is counted.
+        self.assertFalse(self.uri_in_shared_metadata(conn_follow, self.uri))
+        stat_cursor = session_ck.open_cursor('statistics:')
+        self.assertEqual(
+            stat_cursor[stat.conn.checkpoint_disagg_metadata_pair_canceled][2], 1)
+        stat_cursor.close()
 
-        The stable epoch falls between CREATE (epoch=20) and DROP (epoch=30), so this checkpoint
-        must include the table in shared metadata. But the table was dropped and its stable
-        constituent was never created, so we have no data to write. WiredTiger detects this and
-        panics.
-        """
-        # Initialize self.conn so the test fixture can close it cleanly; the real test runs
-        # in a subprocess so that the panic/abort does not kill the test runner.
-        self.setup_leader_with_epoch()
-        subdir = 'SUBPROCESS_create_drop_split_epochs'
-        [returncode, _] = self.run_subprocess_function(subdir,
-            f'{self.test_name}.{self.test_name}.subprocess_create_drop_split_epochs',
-            silent=True)
-        self.assertNotEqual(returncode, 0)
+        # A later checkpoint covering the epoch of the canceled REMOVE stays clean.
+        self.set_stable_epoch(30, conn_follow)
+        conn_follow.set_timestamp('stable_timestamp=' + self.timestamp_str(3))
+        session_ck.checkpoint()
+        self.assertFalse(self.uri_in_shared_metadata(conn_follow, self.uri))
+        session_ck.close()
+
+        conn_follow.close('debug=(skip_checkpoint=true)')
 
     def test_unpublished_create_not_flushed(self):
         """

--- a/test/suite/test_layered_schema17.py
+++ b/test/suite/test_layered_schema17.py
@@ -315,10 +315,10 @@ class test_layered_schema17(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
         self.run_panic_subprocess('strict_at_open_panics')
 
     #
-    # Step-down tests: stepping down clears the metadata queue, so a table created
-    # but never published before the step-down becomes an unexplained local-only
-    # difference. The application must drop such tables (or disable strict mode)
-    # before the stepped-down node installs checkpoints.
+    # Step-down tests: stepping down preserves pending CREATE/REMOVE metadata-queue
+    # entries, so a table created but never published before the step-down remains
+    # an explained local-only difference and the stepped-down node can install
+    # checkpoints under strict mode.
     #
 
     def step_down_with_unpublished_table(self):
@@ -335,8 +335,8 @@ class test_layered_schema17(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
         # behind, waiting for a drop.
         self.session.create(self.uri2, self.table_config)
 
-        # Step down; the metadata queue is cleared, so uri2's CREATE no longer
-        # explains its presence in the local metadata.
+        # Step down; uri2's CREATE survives in the metadata queue and keeps
+        # explaining its presence in the local metadata.
         self.conn.reconfigure('disaggregated=(role="follower")')
         conn_follow.reconfigure('disaggregated=(role="leader")')
 
@@ -346,29 +346,32 @@ class test_layered_schema17(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
         session_lead.close()
         return conn_follow
 
-    def subprocess_step_down_pending_create_panics(self):
-        """Subprocess body for the step-down panic test; expected to panic/abort."""
+    def test_strict_step_down_pending_create(self):
+        """
+        A node that steps down with a created-but-unpublished table passes strict
+        validation: the queued CREATE survives the step-down at the unpublished
+        sentinel epoch, which exceeds any checkpoint epoch, so the local-only table
+        is explained and picking up the new leader's checkpoint succeeds.
+        """
         conn_lead = self.step_down_with_unpublished_table()
 
         self.conn.reconfigure('disaggregated=(strict_checkpoint_metadata=true)')
-        self.disagg_advance_checkpoint(self.conn, conn_lead)  # Expected to panic.
+        self.disagg_advance_checkpoint(self.conn, conn_lead)
 
-    def test_strict_step_down_pending_create_panics(self):
-        """
-        A node that steps down with a created-but-unpublished table cannot pass
-        strict validation: the queue was cleared on step-down, so the local-only
-        table is unexplained and picking up the new leader's checkpoint panics.
-        """
-        # Initialize self.conn so the test fixture can close it cleanly; the real test runs
-        # in a subprocess so that the panic/abort does not kill the test runner.
-        self.setup_leader_empty()
-        self.run_panic_subprocess('step_down_pending_create_panics')
+        # The unpublished table survives locally and stays out of shared metadata
+        # until a checkpoint covers its CREATE.
+        self.assertTrue(self.uri_layered_in_local_metadata(self.conn, self.uri2))
+        self.assertFalse(self.uri_in_shared_metadata(self.conn, self.uri2))
+        # The table published before the step-down is still picked up normally.
+        self.assertTrue(self.uri_layered_in_local_metadata(self.conn, self.uri))
+
+        conn_lead.close('debug=(skip_checkpoint=true)')
 
     def test_strict_step_down_drop_then_pickup(self):
         """
-        Completing the pending drop of the unpublished table resolves the step-down
-        inconsistency: once the table is gone from the local metadata, strict
-        validation passes and the stepped-down node can install checkpoints.
+        Completing the pending drop of the unpublished table also passes strict
+        validation: the table is gone from the local metadata and the queue, and
+        the stepped-down node can install checkpoints.
         """
         conn_lead = self.step_down_with_unpublished_table()
 

--- a/test/suite/test_layered_schema18.py
+++ b/test/suite/test_layered_schema18.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# Test dropping a never-published layered table on an ex-leader (the rolled-back
+# create case).
+#
+# A table created while leader but never published leaves a CREATE in the shared
+# metadata queue with the stable constituent's metadata captured, and the local
+# stable constituent exists. Both survive a step-down. Dropping the table as a
+# follower must succeed and remove all local constituents, and the dropped table
+# must stay dead: a later step-up must not recreate the stable constituent and a
+# later leader checkpoint must neither publish the table to shared metadata nor
+# fail.
+
+import wttest
+from helper_disagg import disagg_test_class, gen_disagg_storages, DisaggSchemaEpochMixin
+from wtscenario import make_scenarios
+
+@disagg_test_class
+class test_layered_schema18(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
+    test_name = __qualname__
+    conn_base_config = 'statistics=(all),precise_checkpoint=true,'
+    conn_config = conn_base_config + 'disaggregated=(role="leader",lose_all_my_data=true)'
+    conn_config_follower = conn_base_config + 'disaggregated=(role="follower",lose_all_my_data=true)'
+
+    uri = f'layered:{test_name}'
+    table_config = 'key_format=i,value_format=S'
+
+    disagg_storages = gen_disagg_storages(disagg_only=True)
+    scenarios = make_scenarios(disagg_storages)
+
+    def local_metadata_keys(self, conn):
+        """Return the local metadata keys naming the table or its constituents."""
+        tablename = self.uri[len('layered:'):]
+        session = conn.open_session('')
+        mc = session.open_cursor('metadata:')
+        keys = [k for k, _ in mc if tablename in k]
+        mc.close()
+        session.close()
+        return keys
+
+    def test_drop_never_published_after_step_down(self):
+        """
+        Create a table as leader without publishing it, step down, then drop it
+        (as a drop-pending reaper would for a rolled-back create). The drop must
+        remove all local constituents, and a subsequent fail-back and checkpoint
+        must not resurrect the table.
+        """
+        self.set_stable_epoch(10)
+        self.session.create(self.uri, self.table_config)
+
+        # Committed but unstable data, as a rolled-back create would have.
+        cursor = self.session.open_cursor(self.uri)
+        self.session.begin_transaction()
+        cursor[1] = 'rolled_back'
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(50))
+        cursor.close()
+
+        # A checkpoint below the table's (unpublished) epoch: the CREATE stays
+        # pending and the table is absent from shared metadata.
+        self.leader_checkpoint(1)
+        self.assertTrue(self.uri_in_local_metadata(self.conn, self.uri))
+        self.assertFalse(self.uri_in_shared_metadata(self.conn, self.uri))
+
+        # Step down: the pending CREATE and the local stable constituent survive.
+        self.conn.reconfigure('disaggregated=(role="follower")')
+        self.assertTrue(self.uri_in_local_metadata(self.conn, self.uri))
+
+        # Drop as follower: all local constituents must go away.
+        self.session.drop(self.uri)
+        self.assertEqual(self.local_metadata_keys(self.conn), [])
+        self.assertFalse(self.uri_in_local_metadata(self.conn, self.uri))
+
+        # Fail back: step-up must not recreate the dropped stable constituent.
+        self.conn.reconfigure('disaggregated=(role="leader")')
+        self.assertFalse(self.uri_in_local_metadata(self.conn, self.uri))
+
+        # A later covering checkpoint must succeed and must not publish the
+        # dropped table to shared metadata.
+        self.set_stable_epoch(20)
+        self.leader_checkpoint(60)
+        self.assertFalse(self.uri_in_shared_metadata(self.conn, self.uri))
+
+        # A follower picking up that checkpoint must not see the table.
+        conn_follow, session_follow = self.open_follower()
+        self.assertFalse(self.uri_in_local_metadata(conn_follow, self.uri))
+        self.assertFalse(self.uri_in_shared_metadata(conn_follow, self.uri))
+        session_follow.close()
+        conn_follow.close('debug=(skip_checkpoint=true)')

--- a/test/suite/test_layered_schema18.py
+++ b/test/suite/test_layered_schema18.py
@@ -26,19 +26,21 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-# Test dropping a never-published layered table on an ex-leader (the rolled-back
-# create case).
+# Test dropping a layered table on an ex-leader after a step-down, before any
+# checkpoint covered the table's creation.
 #
-# A table created while leader but never published leaves a CREATE in the shared
-# metadata queue with the stable constituent's metadata captured, and the local
-# stable constituent exists. Both survive a step-down. Dropping the table as a
-# follower must succeed and remove all local constituents, and the dropped table
-# must stay dead: a later step-up must not recreate the stable constituent and a
-# later leader checkpoint must neither publish the table to shared metadata nor
-# fail.
+# A table created while leader leaves a CREATE in the shared metadata queue with
+# the stable constituent's metadata captured, and the local stable constituent
+# exists. Both survive a step-down. Dropping the table as a follower must succeed
+# and remove all local constituents, and the dropped table must stay dead: a later
+# step-up must not recreate the stable constituent and a later leader checkpoint
+# must neither publish the table to shared metadata nor fail. This holds whether
+# the create was never published (the rolled-back create case) or was published at
+# an epoch no checkpoint has covered yet.
 
 import wttest
 from helper_disagg import disagg_test_class, gen_disagg_storages, DisaggSchemaEpochMixin
+from wiredtiger import stat
 from wtscenario import make_scenarios
 
 @disagg_test_class
@@ -107,6 +109,67 @@ class test_layered_schema18(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
         self.assertFalse(self.uri_in_shared_metadata(self.conn, self.uri))
 
         # A follower picking up that checkpoint must not see the table.
+        conn_follow, session_follow = self.open_follower()
+        self.assertFalse(self.uri_in_local_metadata(conn_follow, self.uri))
+        self.assertFalse(self.uri_in_shared_metadata(conn_follow, self.uri))
+        session_follow.close()
+        conn_follow.close('debug=(skip_checkpoint=true)')
+
+    def pair_canceled_count(self):
+        """Return the connection's canceled create/remove pair statistic."""
+        cursor = self.session.open_cursor('statistics:')
+        val = cursor[stat.conn.checkpoint_disagg_metadata_pair_canceled][2]
+        cursor.close()
+        return val
+
+    def test_drop_published_create_after_step_down(self):
+        """
+        Create and publish a table as leader at an epoch above the last checkpoint's,
+        step down, drop it as follower (the drop stays unpublished), fail back, and
+        checkpoint at an epoch covering the create. The checkpoint must cancel the
+        queued create/remove pair rather than publish the dropped table.
+        """
+        self.set_stable_epoch(10)
+        self.session.create(self.uri, self.table_config)
+        self.publish(self.uri, 20)
+
+        # A checkpoint below the publish epoch: the CREATE stays pending and the table
+        # is absent from shared metadata.
+        self.leader_checkpoint(1)
+        self.assertTrue(self.uri_in_local_metadata(self.conn, self.uri))
+        self.assertFalse(self.uri_in_shared_metadata(self.conn, self.uri))
+
+        # Step down and drop: the REMOVE is enqueued but never published.
+        self.conn.reconfigure('disaggregated=(role="follower")')
+        self.session.drop(self.uri)
+        self.assertEqual(self.local_metadata_keys(self.conn), [])
+
+        # Fail back: step-up must not recreate the dropped stable constituent.
+        self.conn.reconfigure('disaggregated=(role="leader")')
+        self.assertFalse(self.uri_in_local_metadata(self.conn, self.uri))
+        self.assertEqual(self.pair_canceled_count(), 0)
+
+        # Checkpoint at an epoch covering the CREATE but not the unpublished REMOVE:
+        # the pair must be canceled instead of resurrecting the table in shared
+        # metadata.
+        self.set_stable_epoch(20)
+        with self.expectedStderrPattern('canceling both operations'):
+            self.leader_checkpoint(60)
+        self.assertFalse(self.uri_in_shared_metadata(self.conn, self.uri))
+        self.assertEqual(self.pair_canceled_count(), 1)
+
+        # The queue is left clean: a later checkpoint and a step-down/step-up cycle
+        # must not revisit the pair.
+        self.set_stable_epoch(30)
+        self.leader_checkpoint(70)
+        self.conn.reconfigure('disaggregated=(role="follower")')
+        self.conn.reconfigure('disaggregated=(role="leader")')
+        self.leader_checkpoint(80)
+        self.assertEqual(self.pair_canceled_count(), 1)
+        self.assertFalse(self.uri_in_local_metadata(self.conn, self.uri))
+        self.assertFalse(self.uri_in_shared_metadata(self.conn, self.uri))
+
+        # A follower picking up the final checkpoint must not see the table.
         conn_follow, session_follow = self.open_follower()
         self.assertFalse(self.uri_in_local_metadata(conn_follow, self.uri))
         self.assertFalse(self.uri_in_shared_metadata(conn_follow, self.uri))

--- a/test/suite/test_layered_schema18.py
+++ b/test/suite/test_layered_schema18.py
@@ -66,6 +66,13 @@ class test_layered_schema18(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
         session.close()
         return keys
 
+    def metadata_unstable_count(self):
+        """Return the connection's deferred (unstable) metadata operation statistic."""
+        cursor = self.session.open_cursor('statistics:')
+        val = cursor[stat.conn.checkpoint_disagg_metadata_unstable][2]
+        cursor.close()
+        return val
+
     def test_drop_never_published_after_step_down(self):
         """
         Create a table as leader without publishing it, step down, then drop it
@@ -103,10 +110,15 @@ class test_layered_schema18(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
         self.assertFalse(self.uri_in_local_metadata(self.conn, self.uri))
 
         # A later covering checkpoint must succeed and must not publish the
-        # dropped table to shared metadata.
+        # dropped table to shared metadata. The drop canceled the queued pair
+        # eagerly, so the checkpoint neither defers the entries nor cancels them
+        # itself.
+        unstable_before = self.metadata_unstable_count()
         self.set_stable_epoch(20)
         self.leader_checkpoint(60)
         self.assertFalse(self.uri_in_shared_metadata(self.conn, self.uri))
+        self.assertEqual(self.metadata_unstable_count(), unstable_before)
+        self.assertEqual(self.pair_canceled_count(), 0)
 
         # A follower picking up that checkpoint must not see the table.
         conn_follow, session_follow = self.open_follower()
@@ -173,5 +185,88 @@ class test_layered_schema18(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
         conn_follow, session_follow = self.open_follower()
         self.assertFalse(self.uri_in_local_metadata(conn_follow, self.uri))
         self.assertFalse(self.uri_in_shared_metadata(conn_follow, self.uri))
+        session_follow.close()
+        conn_follow.close('debug=(skip_checkpoint=true)')
+
+    def test_recreate_never_published(self):
+        """
+        Create a table without publishing it, drop it, and create it again under
+        the same name. The drop must leave no trace of the first incarnation:
+        publishing and checkpointing the new table must succeed and a follower
+        picking up the checkpoint must see only the new incarnation.
+        """
+        self.set_stable_epoch(10)
+        self.session.create(self.uri, self.table_config)
+        self.session.drop(self.uri)
+        self.assertEqual(self.local_metadata_keys(self.conn), [])
+
+        # Re-create under the same name and give it stable content.
+        self.session.create(self.uri, self.table_config)
+        cursor = self.session.open_cursor(self.uri)
+        self.session.begin_transaction()
+        cursor[1] = 'second_incarnation'
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(50))
+        cursor.close()
+
+        # A checkpoint below the new table's (unpublished) epoch defers only
+        # the new CREATE: the first incarnation's create/remove pair was
+        # canceled at drop time and no longer sits in the queue.
+        unstable_before = self.metadata_unstable_count()
+        self.leader_checkpoint(1)
+        self.assertEqual(self.metadata_unstable_count(), unstable_before + 1)
+
+        # Publish and checkpoint the new incarnation; nothing defers and the
+        # checkpoint-time cancellation stays idle.
+        self.publish(self.uri, 20)
+        unstable_before = self.metadata_unstable_count()
+        self.set_stable_epoch(20)
+        self.leader_checkpoint(60)
+        self.assertTrue(self.uri_in_shared_metadata(self.conn, self.uri))
+        self.assertEqual(self.metadata_unstable_count(), unstable_before)
+        self.assertEqual(self.pair_canceled_count(), 0)
+
+        # A follower picking up the checkpoint sees the new incarnation.
+        conn_follow, session_follow = self.open_follower()
+        self.assertTrue(self.uri_in_local_metadata(conn_follow, self.uri))
+        cursor = session_follow.open_cursor(self.uri)
+        self.assertEqual(cursor[1], 'second_incarnation')
+        cursor.close()
+        session_follow.close()
+        conn_follow.close('debug=(skip_checkpoint=true)')
+
+    def test_follower_recreate_never_published(self):
+        """
+        A follower that creates and drops a never-published table must not let
+        the dead pair block picking up a leader-published table under the same
+        name: the queued unpublished REMOVE would otherwise be taken as a local
+        drop newer than every checkpoint.
+        """
+        # Seed the shared storage with a checkpoint carrying a schema epoch.
+        self.set_stable_epoch(10)
+        self.leader_checkpoint(1)
+
+        # The follower creates and drops the table without publishing it.
+        conn_follow, session_follow = self.open_follower()
+        session_follow.create(self.uri, self.table_config)
+        session_follow.drop(self.uri)
+
+        # The leader independently creates, publishes and checkpoints a table
+        # under the same name.
+        self.session.create(self.uri, self.table_config)
+        cursor = self.session.open_cursor(self.uri)
+        self.session.begin_transaction()
+        cursor[1] = 'from_leader'
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(50))
+        cursor.close()
+        self.publish(self.uri, 20)
+        self.set_stable_epoch(20)
+        self.leader_checkpoint(60)
+        self.assertTrue(self.uri_in_shared_metadata(self.conn, self.uri))
+
+        # The follower must pick the table up.
+        self.disagg_advance_checkpoint(conn_follow)
+        cursor = session_follow.open_cursor(self.uri)
+        self.assertEqual(cursor[1], 'from_leader')
+        cursor.close()
         session_follow.close()
         conn_follow.close('debug=(skip_checkpoint=true)')

--- a/test/suite/test_layered_schema18.py
+++ b/test/suite/test_layered_schema18.py
@@ -165,7 +165,7 @@ class test_layered_schema18(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
         # the pair must be canceled instead of resurrecting the table in shared
         # metadata.
         self.set_stable_epoch(20)
-        with self.expectedStderrPattern('canceling both operations'):
+        with self.expectedStderrPattern('canceling the queued create and drop'):
             self.leader_checkpoint(60)
         self.assertFalse(self.uri_in_shared_metadata(self.conn, self.uri))
         self.assertEqual(self.pair_canceled_count(), 1)

--- a/test/suite/test_layered_schema19.py
+++ b/test/suite/test_layered_schema19.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# Test fail-back cycles (step-down followed by step-up) with a pending publish.
+#
+# A table published at a schema epoch above the last checkpoint's stable epoch has a
+# pending CREATE in the shared metadata queue. That intent is role-independent, so it
+# must survive a step-down and still be published by the next covering leader checkpoint
+# after a step-up.
+
+import wttest
+from helper_disagg import disagg_test_class, gen_disagg_storages, DisaggSchemaEpochMixin
+from wtscenario import make_scenarios
+
+@disagg_test_class
+class test_layered_schema19(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
+    test_name = __qualname__
+    conn_base_config = 'statistics=(all),precise_checkpoint=true,'
+    conn_config = conn_base_config + 'disaggregated=(role="leader",lose_all_my_data=true)'
+    conn_config_follower = conn_base_config + 'disaggregated=(role="follower",lose_all_my_data=true)'
+
+    uri = f'layered:{test_name}'
+    table_config = 'key_format=i,value_format=S'
+
+    disagg_storages = gen_disagg_storages(disagg_only=True)
+    scenarios = make_scenarios(disagg_storages)
+
+    def create_with_pending_publish(self, publish_epoch):
+        """
+        Create and publish the table at publish_epoch, then checkpoint at stable epoch 10.
+        The publish epoch is above the checkpoint's, so the CREATE stays pending in the
+        shared metadata queue and the table is absent from shared metadata.
+        """
+        self.set_stable_epoch(10)
+        self.session.create(self.uri, self.table_config)
+        self.publish(self.uri, publish_epoch)
+        self.leader_checkpoint(1)
+
+        self.assertTrue(self.uri_in_local_metadata(self.conn, self.uri))
+        self.assertFalse(self.uri_in_shared_metadata(self.conn, self.uri))
+
+    def test_failback_no_pickup(self):
+        """
+        A pending publish survives a step-down followed by an immediate step-up with no
+        checkpoint pickup in between; the next covering checkpoint publishes the table.
+        """
+        self.create_with_pending_publish(20)
+
+        # Step down: the local stable constituent and the pending CREATE must survive.
+        self.conn.reconfigure('disaggregated=(role="follower")')
+        self.assertTrue(self.uri_in_local_metadata(self.conn, self.uri))
+
+        # Step back up without picking up any checkpoint: creating missing stable tables
+        # no-ops on the existing local constituent.
+        self.conn.reconfigure('disaggregated=(role="leader")')
+        self.assertTrue(self.uri_in_local_metadata(self.conn, self.uri))
+        self.assertFalse(self.uri_in_shared_metadata(self.conn, self.uri))
+
+        # A checkpoint at a covering epoch publishes the table.
+        self.set_stable_epoch(20)
+        self.leader_checkpoint(2)
+        self.assertTrue(self.uri_in_shared_metadata(self.conn, self.uri))
+
+        # A follower picking up that checkpoint sees the table.
+        conn_follow, session_follow = self.open_follower()
+        self.assertTrue(self.uri_in_local_metadata(conn_follow, self.uri))
+        session_follow.close()
+        conn_follow.close('debug=(skip_checkpoint=true)')
+
+    def test_failback_noncovering_pickup(self):
+        """
+        A pending publish survives a step-down and a subsequent pickup of a checkpoint
+        that does not cover its epoch; after a fail-back the next covering checkpoint
+        publishes the table.
+        """
+        self.create_with_pending_publish(30)
+
+        # Open a second node, which picks up the checkpoint at epoch 10 and does not see
+        # the table.
+        conn_follow, session_follow = self.open_follower()
+        session_follow.close()
+        self.assertFalse(self.uri_in_local_metadata(conn_follow, self.uri))
+
+        # Swap roles: this node steps down with the CREATE (epoch 30) still pending.
+        self.conn.reconfigure('disaggregated=(role="follower")')
+        conn_follow.reconfigure('disaggregated=(role="leader")')
+
+        # The new leader checkpoints at epoch 20, which does not cover the pending CREATE.
+        self.set_stable_epoch(20, conn_follow)
+        session_follow = conn_follow.open_session('')
+        self.leader_checkpoint(2, conn_follow, session_follow)
+        session_follow.close()
+
+        # Picking up the non-covering checkpoint keeps the local stable constituent and
+        # the pending CREATE.
+        self.disagg_advance_checkpoint(self.conn, conn_follow)
+        self.assertTrue(self.uri_in_local_metadata(self.conn, self.uri))
+        self.assertFalse(self.uri_in_shared_metadata(self.conn, self.uri))
+
+        # Fail back to this node and checkpoint at a covering epoch: the table is
+        # published to shared metadata.
+        conn_follow.reconfigure('disaggregated=(role="follower")')
+        self.conn.reconfigure('disaggregated=(role="leader")')
+        self.set_stable_epoch(30)
+        self.leader_checkpoint(3)
+        self.assertTrue(self.uri_in_shared_metadata(self.conn, self.uri))
+
+        # The other node picks up the covering checkpoint and sees the table.
+        self.disagg_advance_checkpoint(conn_follow)
+        self.assertTrue(self.uri_in_local_metadata(conn_follow, self.uri))
+        conn_follow.close('debug=(skip_checkpoint=true)')

--- a/test/suite/test_layered_schema19.py
+++ b/test/suite/test_layered_schema19.py
@@ -33,6 +33,7 @@
 # must survive a step-down and still be published by the next covering leader checkpoint
 # after a step-up.
 
+import re
 import wttest
 from helper_disagg import disagg_test_class, gen_disagg_storages, DisaggSchemaEpochMixin
 from wtscenario import make_scenarios
@@ -49,6 +50,24 @@ class test_layered_schema19(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
 
     disagg_storages = gen_disagg_storages(disagg_only=True)
     scenarios = make_scenarios(disagg_storages)
+
+    def local_btree_id(self, conn, uri):
+        """Return the btree ID of uri's stable constituent from conn's local metadata."""
+        session = conn.open_session('')
+        cursor = session.open_cursor('metadata:')
+        value = cursor[self.stable_uri(uri)]
+        cursor.close()
+        session.close()
+        return int(re.search(r'\bid=(\d+)', value).group(1))
+
+    def shared_btree_id(self, conn, uri):
+        """Return the btree ID of uri's stable constituent from the shared metadata table."""
+        session = conn.open_session('')
+        cursor = session.open_cursor('file:WiredTigerShared.wt_stable', None, None)
+        value = cursor[self.stable_uri(uri)]
+        cursor.close()
+        session.close()
+        return int(re.search(r'\bid=(\d+)', value).group(1))
 
     def create_with_pending_publish(self, publish_epoch):
         """
@@ -133,4 +152,58 @@ class test_layered_schema19(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
         # The other node picks up the covering checkpoint and sees the table.
         self.disagg_advance_checkpoint(conn_follow)
         self.assertTrue(self.uri_in_local_metadata(conn_follow, self.uri))
+        conn_follow.close('debug=(skip_checkpoint=true)')
+
+    def test_failback_covering_pickup_new_incarnation(self):
+        """
+        A pending CREATE covered by a picked-up checkpoint no longer protects the local
+        state: when the new leader created its own incarnation of the table (a fresh
+        btree ID), the covering pickup must discard the dead local constituent and bring
+        in the new incarnation in that same pickup, so that an immediate fail-back
+        serves the new leader's data.
+        """
+        self.create_with_pending_publish(20)
+
+        # Open a second node, which picks up the checkpoint at epoch 10 and does not see
+        # the table.
+        conn_follow, session_follow = self.open_follower()
+        session_follow.close()
+        self.assertFalse(self.uri_in_local_metadata(conn_follow, self.uri))
+
+        # Swap roles: this node steps down with the CREATE (epoch 20) still pending.
+        self.conn.reconfigure('disaggregated=(role="follower")')
+        conn_follow.reconfigure('disaggregated=(role="leader")')
+
+        # The new leader creates its own incarnation of the table under the same name
+        # (a fresh btree ID), writes data, and checkpoints at epoch 20, covering the
+        # pending CREATE.
+        session_follow = conn_follow.open_session('')
+        session_follow.create(self.uri, self.table_config)
+        self.publish(self.uri, 20, session_follow)
+        cursor = session_follow.open_cursor(self.uri)
+        session_follow.begin_transaction()
+        for i in range(10):
+            cursor[i] = 'bbb'
+        session_follow.commit_transaction('commit_timestamp=' + self.timestamp_str(5))
+        cursor.close()
+        self.set_stable_epoch(20, conn_follow)
+        self.leader_checkpoint(10, conn_follow, session_follow)
+        session_follow.close()
+        self.assertTrue(self.uri_in_shared_metadata(conn_follow, self.uri))
+
+        # Picking up the covering checkpoint discards this node's dead constituent and
+        # brings in the new incarnation in the same pickup.
+        self.disagg_advance_checkpoint(self.conn, conn_follow)
+        self.assertTrue(self.uri_in_local_metadata(self.conn, self.uri))
+        self.assertEqual(
+            self.local_btree_id(self.conn, self.uri), self.shared_btree_id(self.conn, self.uri))
+
+        # Fail back immediately, with no pickup in between, and read the new
+        # incarnation's data.
+        conn_follow.reconfigure('disaggregated=(role="follower")')
+        self.conn.reconfigure('disaggregated=(role="leader")')
+        cursor = self.session.open_cursor(self.uri)
+        self.assertEqual({k: v for k, v in cursor}, {i: 'bbb' for i in range(10)})
+        cursor.close()
+
         conn_follow.close('debug=(skip_checkpoint=true)')

--- a/test/suite/test_layered_schema20.py
+++ b/test/suite/test_layered_schema20.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# Test the two-phase drop of a layered table on the leader: a table created and
+# dropped at different published epochs, with checkpoints splitting the two.
+#
+# A checkpoint whose stable schema epoch covers the create but not the drop must
+# include the table in shared metadata -- a follower picking up that checkpoint
+# sees the table -- and defer the drop to a later covering checkpoint. Only a
+# drop that was never published may cancel the queued create/remove pair. A
+# create through the table: prefix enqueues two CREATE entries for the table,
+# so the pairing must treat the URI's entries as a group.
+
+import wiredtiger, wttest
+from helper_disagg import disagg_test_class, gen_disagg_storages, DisaggSchemaEpochMixin
+from wiredtiger import stat
+from wtscenario import make_scenarios
+
+@disagg_test_class
+class test_layered_schema20(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
+    test_name = __qualname__
+    conn_base_config = 'statistics=(all),precise_checkpoint=true,'
+    conn_config = conn_base_config + 'disaggregated=(role="leader",lose_all_my_data=true)'
+    conn_config_follower = conn_base_config + 'disaggregated=(role="follower",lose_all_my_data=true)'
+
+    layered_uri = f'layered:{test_name}'
+    table_uri = f'table:{test_name}'
+    table_config = 'key_format=i,value_format=S'
+    table_config_layered = table_config + ',type=layered,block_manager=disagg'
+
+    disagg_storages = gen_disagg_storages(disagg_only=True)
+    scenarios = make_scenarios(disagg_storages)
+
+    def stable_uri(self, uri):
+        """Return the stable component URI, accepting layered: and table: URIs."""
+        return 'file:' + uri.split(':', 1)[1] + '.wt_stable'
+
+    def get_conn_stat(self, stat_key):
+        cursor = self.session.open_cursor('statistics:')
+        val = cursor[stat_key][2]
+        cursor.close()
+        return val
+
+    def pair_canceled_count(self):
+        return self.get_conn_stat(stat.conn.checkpoint_disagg_metadata_pair_canceled)
+
+    def metadata_unstable_count(self):
+        return self.get_conn_stat(stat.conn.checkpoint_disagg_metadata_unstable)
+
+    def check_follower_sees_table(self, uri):
+        """Open a follower on the latest checkpoint and check it sees the table."""
+        conn_follow, session_follow = self.open_follower()
+        self.assertTrue(self.uri_in_shared_metadata(conn_follow, uri))
+        self.assertTrue(self.uri_in_local_metadata(conn_follow, uri))
+        session_follow.close()
+        conn_follow.close('debug=(skip_checkpoint=true)')
+
+    def two_phase_drop(self, uri, config, creates_per_table):
+        """
+        Create a table, publish the create at epoch 20, drop it, publish the
+        drop at epoch 30, and checkpoint in between: the checkpoint must
+        include the table in shared metadata and defer the drop, and the next
+        covering checkpoint must apply it.
+        """
+        self.set_stable_epoch(10)
+        self.session.create(uri, config)
+        self.publish(uri, 20)
+        self.session.drop(uri)
+        self.publish(uri, 30)
+
+        # A checkpoint below the publish epochs defers every queued entry;
+        # the delta pins down how many CREATE entries the create enqueued.
+        unstable_before = self.metadata_unstable_count()
+        self.leader_checkpoint(1)
+        self.assertEqual(self.metadata_unstable_count() - unstable_before,
+                         creates_per_table + 1)
+
+        # A checkpoint covering the create but not the drop must include the
+        # table in shared metadata and defer the REMOVE; nothing is canceled.
+        self.set_stable_epoch(20)
+        self.leader_checkpoint(2)
+        self.assertTrue(self.uri_in_shared_metadata(self.conn, uri))
+        self.assertEqual(self.pair_canceled_count(), 0)
+
+        # A follower picking up that checkpoint sees the table.
+        self.check_follower_sees_table(uri)
+
+        # A checkpoint covering the drop removes the table from shared metadata.
+        self.set_stable_epoch(30)
+        self.leader_checkpoint(3)
+        self.assertFalse(self.uri_in_shared_metadata(self.conn, uri))
+        self.assertEqual(self.pair_canceled_count(), 0)
+
+    def test_two_phase_drop(self):
+        self.two_phase_drop(self.layered_uri, self.table_config, 1)
+
+    def test_two_phase_drop_table_prefix(self):
+        self.two_phase_drop(self.table_uri, self.table_config_layered, 2)
+
+    def test_drop_unpublished_table_prefix(self):
+        """
+        Drop a table: prefix table whose create was published but never covered,
+        without publishing the drop. The checkpoint covering the create must
+        cancel the whole queued group -- both CREATE entries and the REMOVE --
+        so neither entry publishes the dropped table to shared metadata.
+        """
+        self.set_stable_epoch(10)
+        self.session.create(self.table_uri, self.table_config_layered)
+        self.publish(self.table_uri, 20)
+        self.session.drop(self.table_uri)
+
+        # The checkpoint covers the CREATE entries but the REMOVE can never be
+        # published: the pair cancellation must consume the whole group.
+        self.set_stable_epoch(20)
+        with self.expectedStderrPattern('canceling'):
+            self.leader_checkpoint(1)
+        self.assertFalse(self.uri_in_shared_metadata(self.conn, self.table_uri))
+        self.assertEqual(self.pair_canceled_count(), 1)
+
+        # A later checkpoint stays clean: the queue holds nothing for the table.
+        self.set_stable_epoch(30)
+        self.leader_checkpoint(2)
+        self.assertFalse(self.uri_in_shared_metadata(self.conn, self.table_uri))
+        self.assertEqual(self.pair_canceled_count(), 1)


### PR DESCRIPTION
Step-down erased the shared metadata queue, losing pending creates/drops not yet covered by a checkpoint.
The queue's meaning is role-independent, so its entries must survive role transitions.

* Step-down now clears only UPDATE entries; CREATE/REMOVE entries survive with their schema epochs and stable values intact.
* Checkpoint queue processing cancels an eligible CREATE paired with a REMOVE deferring past the checkpoint, instead of publishing a locally-dropped table no node can serve (new stat `checkpoint_disagg_metadata_pair_canceled`).
* Checkpoint pickup discard guards are epoch-aware: a queue entry covered by the incoming checkpoint no longer protects stale local state, which could leave a fast-failback leader serving a dead btree incarnation.
* drop() of a never-published table cancels its queued CREATE entries; the ingering pair made followers skip picking up a same-name table forever.
* Strict step-down validation now passes with a pending create (queue entries explain the local-only table); the panic test became a positive test.