### PR TITLE
WT-18107 Fix follower stable timestamp regression in disagg key seed

### DIFF
--- a/test/format/format.h
+++ b/test/format/format.h
@@ -476,7 +476,7 @@ WT_THREAD_RET checkpoint(void *);
 WT_THREAD_RET compact(void *);
 WT_THREAD_RET follower(void *);
 WT_THREAD_RET disagg_key_rotation(void *);
-void disagg_key_push_initial(WT_CONNECTION *);
+void disagg_key_push_initial(WT_CONNECTION *, bool);
 void disagg_key_history_clear(void);
 void disagg_key_validate_after_checkpoint(WT_SESSION *);
 int follower_fetch_full_metadata(WT_SESSION *, WT_PAGE_LOG *, const WT_ITEM *, WT_ITEM *);

--- a/test/format/key_rotation.c
+++ b/test/format/key_rotation.c
@@ -92,7 +92,7 @@ disagg_key_push(
  *     for the leader and before step-up for the follower.
  */
 void
-disagg_key_push_initial(WT_CONNECTION *conn)
+disagg_key_push_initial(WT_CONNECTION *conn, bool advance_stable)
 {
     if (GV(DISAGG_KEY_PROVIDER) != DISAGG_KEY_PROVIDER_PUSH)
         return;
@@ -105,11 +105,16 @@ disagg_key_push_initial(WT_CONNECTION *conn)
     wt_timestamp_t push_ts;
     testutil_check(disagg_key_push(session, kp, g.stable_timestamp, &push_ts));
 
-    /* Advance stable to the pushed key so the checkpoint drains it. */
-    char ts_buf[WT_TS_HEX_STRING_SIZE + 24];
-    testutil_snprintf(ts_buf, sizeof(ts_buf), "stable_timestamp=%" PRIx64, (uint64_t)push_ts);
-    testutil_check(conn->set_timestamp(conn, ts_buf));
-    g.stable_timestamp = push_ts;
+    /*
+     * The leader seeds before its create-time close checkpoint, which must drain the key now, so it
+     * advances stable.
+     */
+    if (advance_stable) {
+        char ts_buf[WT_TS_HEX_STRING_SIZE + 24];
+        testutil_snprintf(ts_buf, sizeof(ts_buf), "stable_timestamp=%" PRIx64, (uint64_t)push_ts);
+        testutil_check(conn->set_timestamp(conn, ts_buf));
+        g.stable_timestamp = push_ts;
+    }
 
     testutil_check(session->close(session, NULL));
 }

--- a/test/format/t.c
+++ b/test/format/t.c
@@ -363,7 +363,7 @@ main(int argc, char *argv[])
         wts_open(g.home, &g.wts_conn, true);
         /* Follower: seed an initial key before the first step-up checkpoint. */
         if (!g.disagg_leader)
-            disagg_key_push_initial(g.wts_conn);
+            disagg_key_push_initial(g.wts_conn, false);
         timestamp_init();
     }
     wts_prepare_discover(g.wts_conn);

--- a/test/format/wts.c
+++ b/test/format/wts.c
@@ -592,7 +592,7 @@ create_database(const char *home, WT_CONNECTION **connp)
 
     /* Leader: seed an initial key before the create-time close checkpoint. */
     if (g.disagg_leader)
-        disagg_key_push_initial(conn);
+        disagg_key_push_initial(conn, true);
 
     *connp = conn;
 }


### PR DESCRIPTION
The follower seeds its initial key on the live connection, where the raw set_timestamp(stable) call moved the connection's stable ahead of format's recovered timestamp bookkeeping. The next `timestamp_once` during bulk load then computed a lower stable and hit EINVAL setting it backwards.

Only the leader needs the stable bump (its create-time close checkpoint must drain the key immediately). The follower has no such checkpoint, so let the bulk load advance stable instead. Gate the bump behind an advance_stable flag