### PR TITLE
WT-17424 Refactor duplicated cache usage accounting into shared macros

### DIFF
--- a/src/evict/evict_inline.h
+++ b/src/evict/evict_inline.h
@@ -321,13 +321,13 @@ __wt_evict_page_cache_bytes_decr(WT_SESSION_IMPL *session, WT_PAGE *page)
     /* Update the bytes in-memory to reflect the eviction. */
     __wt_cache_decr_check_uint64(
       session, &btree->bytes_inmem, btree_footprint, "WT_BTREE.bytes_inmem");
-    WT_CACHE_DISAGG_DECR(session, is_disagg, btree, cache, bytes_inmem, memory_footprint);
+    WT_CACHE_DECR(session, is_disagg, btree, cache, bytes_inmem, memory_footprint);
 
     /* Update the bytes_internal value to reflect the eviction */
     if (WT_PAGE_IS_INTERNAL(page)) {
         __wt_cache_decr_check_uint64(
           session, &btree->bytes_internal, btree_footprint, "WT_BTREE.bytes_internal");
-        WT_CACHE_DISAGG_DECR(session, is_disagg, btree, cache, bytes_internal, memory_footprint);
+        WT_CACHE_DECR(session, is_disagg, btree, cache, bytes_internal, memory_footprint);
     }
 
     /* Update the cache's dirty-byte count. */
@@ -335,13 +335,11 @@ __wt_evict_page_cache_bytes_decr(WT_SESSION_IMPL *session, WT_PAGE *page)
         if (WT_PAGE_IS_INTERNAL(page)) {
             __wt_cache_decr_check_uint64(
               session, &btree->bytes_dirty_intl, modify->bytes_dirty, "WT_BTREE.bytes_dirty_intl");
-            WT_CACHE_DISAGG_DECR(
-              session, is_disagg, btree, cache, bytes_dirty_intl, modify->bytes_dirty);
+            WT_CACHE_DECR(session, is_disagg, btree, cache, bytes_dirty_intl, modify->bytes_dirty);
         } else {
             __wt_cache_decr_check_uint64(
               session, &btree->bytes_dirty_leaf, modify->bytes_dirty, "WT_BTREE.bytes_dirty_leaf");
-            WT_CACHE_DISAGG_DECR(
-              session, is_disagg, btree, cache, bytes_dirty_leaf, modify->bytes_dirty);
+            WT_CACHE_DECR(session, is_disagg, btree, cache, bytes_dirty_leaf, modify->bytes_dirty);
         }
     }
 
@@ -349,8 +347,7 @@ __wt_evict_page_cache_bytes_decr(WT_SESSION_IMPL *session, WT_PAGE *page)
     if (modify != NULL) {
         __wt_cache_decr_check_uint64(
           session, &btree->bytes_updates, modify->bytes_updates, "WT_BTREE.bytes_updates");
-        WT_CACHE_DISAGG_DECR(
-          session, is_disagg, btree, cache, bytes_updates, modify->bytes_updates);
+        WT_CACHE_DECR(session, is_disagg, btree, cache, bytes_updates, modify->bytes_updates);
     }
 
     /* Update bytes and pages evicted. */

--- a/src/evict/evict_inline.h
+++ b/src/evict/evict_inline.h
@@ -321,31 +321,13 @@ __wt_evict_page_cache_bytes_decr(WT_SESSION_IMPL *session, WT_PAGE *page)
     /* Update the bytes in-memory to reflect the eviction. */
     __wt_cache_decr_check_uint64(
       session, &btree->bytes_inmem, btree_footprint, "WT_BTREE.bytes_inmem");
-    __wt_cache_decr_check_uint64(
-      session, &cache->bytes_inmem, memory_footprint, "WT_CACHE.bytes_inmem");
-    if (is_disagg) {
-        if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
-            __wt_cache_decr_check_uint64(
-              session, &cache->bytes_inmem_ingest, memory_footprint, "WT_CACHE.bytes_inmem_ingest");
-        else if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))
-            __wt_cache_decr_check_uint64(
-              session, &cache->bytes_inmem_stable, memory_footprint, "WT_CACHE.bytes_inmem_stable");
-    }
+    WT_CACHE_DISAGG_DECR(session, is_disagg, btree, cache, bytes_inmem, memory_footprint);
 
     /* Update the bytes_internal value to reflect the eviction */
     if (WT_PAGE_IS_INTERNAL(page)) {
         __wt_cache_decr_check_uint64(
           session, &btree->bytes_internal, btree_footprint, "WT_BTREE.bytes_internal");
-        __wt_cache_decr_check_uint64(
-          session, &cache->bytes_internal, memory_footprint, "WT_CACHE.bytes_internal");
-        if (is_disagg) {
-            if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
-                __wt_cache_decr_check_uint64(session, &cache->bytes_internal_ingest,
-                  memory_footprint, "WT_CACHE.bytes_internal_ingest");
-            else if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))
-                __wt_cache_decr_check_uint64(session, &cache->bytes_internal_stable,
-                  memory_footprint, "WT_CACHE.bytes_internal_stable");
-        }
+        WT_CACHE_DISAGG_DECR(session, is_disagg, btree, cache, bytes_internal, memory_footprint);
     }
 
     /* Update the cache's dirty-byte count. */
@@ -353,29 +335,13 @@ __wt_evict_page_cache_bytes_decr(WT_SESSION_IMPL *session, WT_PAGE *page)
         if (WT_PAGE_IS_INTERNAL(page)) {
             __wt_cache_decr_check_uint64(
               session, &btree->bytes_dirty_intl, modify->bytes_dirty, "WT_BTREE.bytes_dirty_intl");
-            __wt_cache_decr_check_uint64(
-              session, &cache->bytes_dirty_intl, modify->bytes_dirty, "WT_CACHE.bytes_dirty_intl");
-            if (is_disagg) {
-                if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
-                    __wt_cache_decr_check_uint64(session, &cache->bytes_dirty_intl_ingest,
-                      modify->bytes_dirty, "WT_CACHE.bytes_dirty_intl_ingest");
-                else if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))
-                    __wt_cache_decr_check_uint64(session, &cache->bytes_dirty_intl_stable,
-                      modify->bytes_dirty, "WT_CACHE.bytes_dirty_intl_stable");
-            }
+            WT_CACHE_DISAGG_DECR(
+              session, is_disagg, btree, cache, bytes_dirty_intl, modify->bytes_dirty);
         } else {
             __wt_cache_decr_check_uint64(
               session, &btree->bytes_dirty_leaf, modify->bytes_dirty, "WT_BTREE.bytes_dirty_leaf");
-            __wt_cache_decr_check_uint64(
-              session, &cache->bytes_dirty_leaf, modify->bytes_dirty, "WT_CACHE.bytes_dirty_leaf");
-            if (is_disagg) {
-                if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
-                    __wt_cache_decr_check_uint64(session, &cache->bytes_dirty_leaf_ingest,
-                      modify->bytes_dirty, "WT_CACHE.bytes_dirty_leaf_ingest");
-                else if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))
-                    __wt_cache_decr_check_uint64(session, &cache->bytes_dirty_leaf_stable,
-                      modify->bytes_dirty, "WT_CACHE.bytes_dirty_leaf_stable");
-            }
+            WT_CACHE_DISAGG_DECR(
+              session, is_disagg, btree, cache, bytes_dirty_leaf, modify->bytes_dirty);
         }
     }
 
@@ -383,16 +349,8 @@ __wt_evict_page_cache_bytes_decr(WT_SESSION_IMPL *session, WT_PAGE *page)
     if (modify != NULL) {
         __wt_cache_decr_check_uint64(
           session, &btree->bytes_updates, modify->bytes_updates, "WT_BTREE.bytes_updates");
-        __wt_cache_decr_check_uint64(
-          session, &cache->bytes_updates, modify->bytes_updates, "WT_CACHE.bytes_updates");
-        if (is_disagg) {
-            if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
-                __wt_cache_decr_check_uint64(session, &cache->bytes_updates_ingest,
-                  modify->bytes_updates, "WT_CACHE.bytes_updates_ingest");
-            else if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))
-                __wt_cache_decr_check_uint64(session, &cache->bytes_updates_stable,
-                  modify->bytes_updates, "WT_CACHE.bytes_updates_stable");
-        }
+        WT_CACHE_DISAGG_DECR(
+          session, is_disagg, btree, cache, bytes_updates, modify->bytes_updates);
     }
 
     /* Update bytes and pages evicted. */

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -370,10 +370,10 @@ __wt_cache_page_inmem_incr(WT_SESSION_IMPL *session, WT_PAGE *page, size_t size,
 
     bool is_disagg = __wt_conn_is_disagg(session);
 
-    WT_CACHE_DISAGG_INCR(is_disagg, btree, cache, bytes_inmem, size);
+    WT_CACHE_INCR(is_disagg, btree, cache, bytes_inmem, size);
     (void)__wt_atomic_add_uint64_relaxed(&btree->bytes_inmem, size);
     if (WT_PAGE_IS_INTERNAL(page)) {
-        WT_CACHE_DISAGG_INCR(is_disagg, btree, cache, bytes_internal, size);
+        WT_CACHE_INCR(is_disagg, btree, cache, bytes_internal, size);
         (void)__wt_atomic_add_uint64_relaxed(&btree->bytes_internal, size);
     }
     (void)__wt_atomic_add_size_relaxed(&page->memory_footprint, size);
@@ -381,16 +381,16 @@ __wt_cache_page_inmem_incr(WT_SESSION_IMPL *session, WT_PAGE *page, size_t size,
     if (__wt_tsan_suppress_load_wt_page_modify_ptr(&page->modify) != NULL) {
         __txn_incr_bytes_dirty(session, size, new_update);
         if (!WT_PAGE_IS_INTERNAL(page)) {
-            WT_CACHE_DISAGG_INCR(is_disagg, btree, cache, bytes_updates, size);
+            WT_CACHE_INCR(is_disagg, btree, cache, bytes_updates, size);
             (void)__wt_atomic_add_uint64_relaxed(&btree->bytes_updates, size);
             (void)__wt_atomic_add_uint64_relaxed(&page->modify->bytes_updates, size);
         }
         if (__wt_page_is_modified(page)) {
             if (WT_PAGE_IS_INTERNAL(page)) {
-                WT_CACHE_DISAGG_INCR(is_disagg, btree, cache, bytes_dirty_intl, size);
+                WT_CACHE_INCR(is_disagg, btree, cache, bytes_dirty_intl, size);
                 (void)__wt_atomic_add_uint64_relaxed(&btree->bytes_dirty_intl, size);
             } else {
-                WT_CACHE_DISAGG_INCR(is_disagg, btree, cache, bytes_dirty_leaf, size);
+                WT_CACHE_INCR(is_disagg, btree, cache, bytes_dirty_leaf, size);
                 (void)__wt_atomic_add_uint64_relaxed(&btree->bytes_dirty_leaf, size);
             }
             (void)__wt_atomic_add_uint64_relaxed(&page->modify->bytes_dirty, size);
@@ -498,11 +498,11 @@ __wt_cache_page_byte_dirty_decr(WT_SESSION_IMPL *session, WT_PAGE *page, size_t 
     if (WT_PAGE_IS_INTERNAL(page)) {
         __wt_cache_decr_check_uint64(
           session, &btree->bytes_dirty_intl, decr, "WT_BTREE.bytes_dirty_intl");
-        WT_CACHE_DISAGG_DECR(session, is_disagg, btree, cache, bytes_dirty_intl, decr);
+        WT_CACHE_DECR(session, is_disagg, btree, cache, bytes_dirty_intl, decr);
     } else {
         __wt_cache_decr_check_uint64(
           session, &btree->bytes_dirty_leaf, decr, "WT_BTREE.bytes_dirty_leaf");
-        WT_CACHE_DISAGG_DECR(session, is_disagg, btree, cache, bytes_dirty_leaf, decr);
+        WT_CACHE_DECR(session, is_disagg, btree, cache, bytes_dirty_leaf, decr);
     }
 }
 
@@ -536,7 +536,7 @@ __wt_cache_page_byte_updates_decr(WT_SESSION_IMPL *session, WT_PAGE *page, size_
         return;
 
     __wt_cache_decr_check_uint64(session, &btree->bytes_updates, decr, "WT_BTREE.bytes_updates");
-    WT_CACHE_DISAGG_DECR(session, __wt_conn_is_disagg(session), btree, cache, bytes_updates, decr);
+    WT_CACHE_DECR(session, __wt_conn_is_disagg(session), btree, cache, bytes_updates, decr);
 }
 
 /*
@@ -558,7 +558,7 @@ __wt_cache_page_inmem_decr(WT_SESSION_IMPL *session, WT_PAGE *page, size_t size)
 
     __wt_cache_decr_check_size(session, &page->memory_footprint, size, "WT_PAGE.memory_footprint");
     __wt_cache_decr_check_uint64(session, &btree->bytes_inmem, size, "WT_BTREE.bytes_inmem");
-    WT_CACHE_DISAGG_DECR(session, is_disagg, btree, cache, bytes_inmem, size);
+    WT_CACHE_DECR(session, is_disagg, btree, cache, bytes_inmem, size);
     if (page->modify != NULL && !WT_PAGE_IS_INTERNAL(page))
         __wt_cache_page_byte_updates_decr(session, page, size);
     if (__wt_page_is_modified(page)) {
@@ -568,7 +568,7 @@ __wt_cache_page_inmem_decr(WT_SESSION_IMPL *session, WT_PAGE *page, size_t size)
     if (WT_PAGE_IS_INTERNAL(page)) {
         __wt_cache_decr_check_uint64(
           session, &btree->bytes_internal, size, "WT_BTREE.bytes_internal");
-        WT_CACHE_DISAGG_DECR(session, is_disagg, btree, cache, bytes_internal, size);
+        WT_CACHE_DECR(session, is_disagg, btree, cache, bytes_internal, size);
     }
 }
 
@@ -2969,9 +2969,9 @@ __wt_cache_shared_dsk_inmem_incr(WT_SESSION_IMPL *session, uint8_t image_type, s
 
     bool is_disagg = __wt_conn_is_disagg(session);
 
-    WT_CACHE_DISAGG_INCR(is_disagg, btree, cache, bytes_inmem, size);
+    WT_CACHE_INCR(is_disagg, btree, cache, bytes_inmem, size);
     if (WT_PAGE_TYPE_IS_INTERNAL(image_type))
-        WT_CACHE_DISAGG_INCR(is_disagg, btree, cache, bytes_internal, size);
+        WT_CACHE_INCR(is_disagg, btree, cache, bytes_internal, size);
 }
 
 /*
@@ -2993,9 +2993,9 @@ __wt_cache_shared_dsk_inmem_decr(WT_SESSION_IMPL *session, uint8_t image_type, s
 
     bool is_disagg = __wt_conn_is_disagg(session);
 
-    WT_CACHE_DISAGG_DECR(session, is_disagg, btree, cache, bytes_inmem, size);
+    WT_CACHE_DECR(session, is_disagg, btree, cache, bytes_inmem, size);
     if (WT_PAGE_TYPE_IS_INTERNAL(image_type))
-        WT_CACHE_DISAGG_DECR(session, is_disagg, btree, cache, bytes_internal, size);
+        WT_CACHE_DECR(session, is_disagg, btree, cache, bytes_internal, size);
 }
 
 /*

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -370,22 +370,10 @@ __wt_cache_page_inmem_incr(WT_SESSION_IMPL *session, WT_PAGE *page, size_t size,
 
     bool is_disagg = __wt_conn_is_disagg(session);
 
-    (void)__wt_atomic_add_uint64_relaxed(&cache->bytes_inmem, size);
-    if (is_disagg) {
-        if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
-            (void)__wt_atomic_add_uint64_relaxed(&cache->bytes_inmem_ingest, size);
-        else if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))
-            (void)__wt_atomic_add_uint64_relaxed(&cache->bytes_inmem_stable, size);
-    }
+    WT_CACHE_DISAGG_INCR(is_disagg, btree, cache, bytes_inmem, size);
     (void)__wt_atomic_add_uint64_relaxed(&btree->bytes_inmem, size);
     if (WT_PAGE_IS_INTERNAL(page)) {
-        (void)__wt_atomic_add_uint64_relaxed(&cache->bytes_internal, size);
-        if (is_disagg) {
-            if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
-                (void)__wt_atomic_add_uint64_relaxed(&cache->bytes_internal_ingest, size);
-            else if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))
-                (void)__wt_atomic_add_uint64_relaxed(&cache->bytes_internal_stable, size);
-        }
+        WT_CACHE_DISAGG_INCR(is_disagg, btree, cache, bytes_internal, size);
         (void)__wt_atomic_add_uint64_relaxed(&btree->bytes_internal, size);
     }
     (void)__wt_atomic_add_size_relaxed(&page->memory_footprint, size);
@@ -393,34 +381,16 @@ __wt_cache_page_inmem_incr(WT_SESSION_IMPL *session, WT_PAGE *page, size_t size,
     if (__wt_tsan_suppress_load_wt_page_modify_ptr(&page->modify) != NULL) {
         __txn_incr_bytes_dirty(session, size, new_update);
         if (!WT_PAGE_IS_INTERNAL(page)) {
-            (void)__wt_atomic_add_uint64_relaxed(&cache->bytes_updates, size);
-            if (is_disagg) {
-                if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
-                    (void)__wt_atomic_add_uint64_relaxed(&cache->bytes_updates_ingest, size);
-                else if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))
-                    (void)__wt_atomic_add_uint64_relaxed(&cache->bytes_updates_stable, size);
-            }
+            WT_CACHE_DISAGG_INCR(is_disagg, btree, cache, bytes_updates, size);
             (void)__wt_atomic_add_uint64_relaxed(&btree->bytes_updates, size);
             (void)__wt_atomic_add_uint64_relaxed(&page->modify->bytes_updates, size);
         }
         if (__wt_page_is_modified(page)) {
             if (WT_PAGE_IS_INTERNAL(page)) {
-                (void)__wt_atomic_add_uint64_relaxed(&cache->bytes_dirty_intl, size);
-                if (is_disagg) {
-                    if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
-                        (void)__wt_atomic_add_uint64_relaxed(&cache->bytes_dirty_intl_ingest, size);
-                    else if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))
-                        (void)__wt_atomic_add_uint64_relaxed(&cache->bytes_dirty_intl_stable, size);
-                }
+                WT_CACHE_DISAGG_INCR(is_disagg, btree, cache, bytes_dirty_intl, size);
                 (void)__wt_atomic_add_uint64_relaxed(&btree->bytes_dirty_intl, size);
             } else {
-                (void)__wt_atomic_add_uint64_relaxed(&cache->bytes_dirty_leaf, size);
-                if (is_disagg) {
-                    if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
-                        (void)__wt_atomic_add_uint64_relaxed(&cache->bytes_dirty_leaf_ingest, size);
-                    else if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))
-                        (void)__wt_atomic_add_uint64_relaxed(&cache->bytes_dirty_leaf_stable, size);
-                }
+                WT_CACHE_DISAGG_INCR(is_disagg, btree, cache, bytes_dirty_leaf, size);
                 (void)__wt_atomic_add_uint64_relaxed(&btree->bytes_dirty_leaf, size);
             }
             (void)__wt_atomic_add_uint64_relaxed(&page->modify->bytes_dirty, size);
@@ -528,29 +498,11 @@ __wt_cache_page_byte_dirty_decr(WT_SESSION_IMPL *session, WT_PAGE *page, size_t 
     if (WT_PAGE_IS_INTERNAL(page)) {
         __wt_cache_decr_check_uint64(
           session, &btree->bytes_dirty_intl, decr, "WT_BTREE.bytes_dirty_intl");
-        __wt_cache_decr_check_uint64(
-          session, &cache->bytes_dirty_intl, decr, "WT_CACHE.bytes_dirty_intl");
-        if (is_disagg) {
-            if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
-                __wt_cache_decr_check_uint64(session, &cache->bytes_dirty_intl_ingest, decr,
-                  "WT_CACHE.bytes_dirty_intl_ingest");
-            else if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))
-                __wt_cache_decr_check_uint64(session, &cache->bytes_dirty_intl_stable, decr,
-                  "WT_CACHE.bytes_dirty_intl_stable");
-        }
+        WT_CACHE_DISAGG_DECR(session, is_disagg, btree, cache, bytes_dirty_intl, decr);
     } else {
         __wt_cache_decr_check_uint64(
           session, &btree->bytes_dirty_leaf, decr, "WT_BTREE.bytes_dirty_leaf");
-        __wt_cache_decr_check_uint64(
-          session, &cache->bytes_dirty_leaf, decr, "WT_CACHE.bytes_dirty_leaf");
-        if (is_disagg) {
-            if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
-                __wt_cache_decr_check_uint64(session, &cache->bytes_dirty_leaf_ingest, decr,
-                  "WT_CACHE.bytes_dirty_leaf_ingest");
-            else if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))
-                __wt_cache_decr_check_uint64(session, &cache->bytes_dirty_leaf_stable, decr,
-                  "WT_CACHE.bytes_dirty_leaf_stable");
-        }
+        WT_CACHE_DISAGG_DECR(session, is_disagg, btree, cache, bytes_dirty_leaf, decr);
     }
 }
 
@@ -584,15 +536,7 @@ __wt_cache_page_byte_updates_decr(WT_SESSION_IMPL *session, WT_PAGE *page, size_
         return;
 
     __wt_cache_decr_check_uint64(session, &btree->bytes_updates, decr, "WT_BTREE.bytes_updates");
-    __wt_cache_decr_check_uint64(session, &cache->bytes_updates, decr, "WT_CACHE.bytes_updates");
-    if (__wt_conn_is_disagg(session)) {
-        if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
-            __wt_cache_decr_check_uint64(
-              session, &cache->bytes_updates_ingest, decr, "WT_CACHE.bytes_updates_ingest");
-        else if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))
-            __wt_cache_decr_check_uint64(
-              session, &cache->bytes_updates_stable, decr, "WT_CACHE.bytes_updates_ingest");
-    }
+    WT_CACHE_DISAGG_DECR(session, __wt_conn_is_disagg(session), btree, cache, bytes_updates, decr);
 }
 
 /*
@@ -614,15 +558,7 @@ __wt_cache_page_inmem_decr(WT_SESSION_IMPL *session, WT_PAGE *page, size_t size)
 
     __wt_cache_decr_check_size(session, &page->memory_footprint, size, "WT_PAGE.memory_footprint");
     __wt_cache_decr_check_uint64(session, &btree->bytes_inmem, size, "WT_BTREE.bytes_inmem");
-    __wt_cache_decr_check_uint64(session, &cache->bytes_inmem, size, "WT_CACHE.bytes_inmem");
-    if (is_disagg) {
-        if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
-            __wt_cache_decr_check_uint64(
-              session, &cache->bytes_inmem_ingest, size, "WT_CACHE.bytes_inmem_ingest");
-        else if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))
-            __wt_cache_decr_check_uint64(
-              session, &cache->bytes_inmem_stable, size, "WT_CACHE.bytes_inmem_stable");
-    }
+    WT_CACHE_DISAGG_DECR(session, is_disagg, btree, cache, bytes_inmem, size);
     if (page->modify != NULL && !WT_PAGE_IS_INTERNAL(page))
         __wt_cache_page_byte_updates_decr(session, page, size);
     if (__wt_page_is_modified(page)) {
@@ -632,16 +568,7 @@ __wt_cache_page_inmem_decr(WT_SESSION_IMPL *session, WT_PAGE *page, size_t size)
     if (WT_PAGE_IS_INTERNAL(page)) {
         __wt_cache_decr_check_uint64(
           session, &btree->bytes_internal, size, "WT_BTREE.bytes_internal");
-        __wt_cache_decr_check_uint64(
-          session, &cache->bytes_internal, size, "WT_CACHE.bytes_internal");
-        if (is_disagg) {
-            if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
-                __wt_cache_decr_check_uint64(
-                  session, &cache->bytes_internal_ingest, size, "WT_CACHE.bytes_internal_ingest");
-            else if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))
-                __wt_cache_decr_check_uint64(
-                  session, &cache->bytes_internal_stable, size, "WT_CACHE.bytes_internal_stable");
-        }
+        WT_CACHE_DISAGG_DECR(session, is_disagg, btree, cache, bytes_internal, size);
     }
 }
 
@@ -3042,22 +2969,9 @@ __wt_cache_shared_dsk_inmem_incr(WT_SESSION_IMPL *session, uint8_t image_type, s
 
     bool is_disagg = __wt_conn_is_disagg(session);
 
-    (void)__wt_atomic_add_uint64_relaxed(&cache->bytes_inmem, size);
-    if (is_disagg) {
-        if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
-            (void)__wt_atomic_add_uint64_relaxed(&cache->bytes_inmem_ingest, size);
-        else if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))
-            (void)__wt_atomic_add_uint64_relaxed(&cache->bytes_inmem_stable, size);
-    }
-    if (WT_PAGE_TYPE_IS_INTERNAL(image_type)) {
-        (void)__wt_atomic_add_uint64_relaxed(&cache->bytes_internal, size);
-        if (is_disagg) {
-            if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
-                (void)__wt_atomic_add_uint64_relaxed(&cache->bytes_internal_ingest, size);
-            else if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))
-                (void)__wt_atomic_add_uint64_relaxed(&cache->bytes_internal_stable, size);
-        }
-    }
+    WT_CACHE_DISAGG_INCR(is_disagg, btree, cache, bytes_inmem, size);
+    if (WT_PAGE_TYPE_IS_INTERNAL(image_type))
+        WT_CACHE_DISAGG_INCR(is_disagg, btree, cache, bytes_internal, size);
 }
 
 /*
@@ -3079,27 +2993,9 @@ __wt_cache_shared_dsk_inmem_decr(WT_SESSION_IMPL *session, uint8_t image_type, s
 
     bool is_disagg = __wt_conn_is_disagg(session);
 
-    __wt_cache_decr_check_uint64(session, &cache->bytes_inmem, size, "WT_CACHE.bytes_inmem");
-    if (is_disagg) {
-        if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
-            __wt_cache_decr_check_uint64(
-              session, &cache->bytes_inmem_ingest, size, "WT_CACHE.bytes_inmem_ingest");
-        else if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))
-            __wt_cache_decr_check_uint64(
-              session, &cache->bytes_inmem_stable, size, "WT_CACHE.bytes_inmem_stable");
-    }
-    if (WT_PAGE_TYPE_IS_INTERNAL(image_type)) {
-        __wt_cache_decr_check_uint64(
-          session, &cache->bytes_internal, size, "WT_CACHE.bytes_internal");
-        if (is_disagg) {
-            if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))
-                __wt_cache_decr_check_uint64(
-                  session, &cache->bytes_internal_ingest, size, "WT_CACHE.bytes_internal_ingest");
-            else if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))
-                __wt_cache_decr_check_uint64(
-                  session, &cache->bytes_internal_stable, size, "WT_CACHE.bytes_internal_stable");
-        }
-    }
+    WT_CACHE_DISAGG_DECR(session, is_disagg, btree, cache, bytes_inmem, size);
+    if (WT_PAGE_TYPE_IS_INTERNAL(image_type))
+        WT_CACHE_DISAGG_DECR(session, is_disagg, btree, cache, bytes_internal, size);
 }
 
 /*

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -199,6 +199,36 @@ struct __wt_cache {
 };
 
 /*
+ * On disaggregated storage each cache byte counter has an ingest and a stable variant that we
+ * mirror based on the btree's role. These macros update the base counter and the right variant in
+ * one place. The field argument is the base member name, and we build the variant names by token
+ * pasting, so all three members need to follow the base/_ingest/_stable naming.
+ */
+#define WT_CACHE_DISAGG_INCR(is_disagg, btree, cache, field, size)                      \
+    do {                                                                                \
+        (void)__wt_atomic_add_uint64_relaxed(&(cache)->field, (size));                  \
+        if (is_disagg) {                                                                \
+            if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))                               \
+                (void)__wt_atomic_add_uint64_relaxed(&(cache)->field##_ingest, (size)); \
+            else if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))                            \
+                (void)__wt_atomic_add_uint64_relaxed(&(cache)->field##_stable, (size)); \
+        }                                                                               \
+    } while (0)
+
+#define WT_CACHE_DISAGG_DECR(session, is_disagg, btree, cache, field, size)                 \
+    do {                                                                                    \
+        __wt_cache_decr_check_uint64(session, &(cache)->field, (size), "WT_CACHE." #field); \
+        if (is_disagg) {                                                                    \
+            if (F_ISSET(btree, WT_BTREE_GARBAGE_COLLECT))                                   \
+                __wt_cache_decr_check_uint64(                                               \
+                  session, &(cache)->field##_ingest, (size), "WT_CACHE." #field "_ingest"); \
+            else if (F_ISSET(btree, WT_BTREE_DISAGGREGATED))                                \
+                __wt_cache_decr_check_uint64(                                               \
+                  session, &(cache)->field##_stable, (size), "WT_CACHE." #field "_stable"); \
+        }                                                                                   \
+    } while (0)
+
+/*
  * WT_CACHE_POOL --
  *	A structure that represents a shared cache.
  */

--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -204,7 +204,7 @@ struct __wt_cache {
  * one place. The field argument is the base member name, and we build the variant names by token
  * pasting, so all three members need to follow the base/_ingest/_stable naming.
  */
-#define WT_CACHE_DISAGG_INCR(is_disagg, btree, cache, field, size)                      \
+#define WT_CACHE_INCR(is_disagg, btree, cache, field, size)                             \
     do {                                                                                \
         (void)__wt_atomic_add_uint64_relaxed(&(cache)->field, (size));                  \
         if (is_disagg) {                                                                \
@@ -215,7 +215,7 @@ struct __wt_cache {
         }                                                                               \
     } while (0)
 
-#define WT_CACHE_DISAGG_DECR(session, is_disagg, btree, cache, field, size)                 \
+#define WT_CACHE_DECR(session, is_disagg, btree, cache, field, size)                        \
     do {                                                                                    \
         __wt_cache_decr_check_uint64(session, &(cache)->field, (size), "WT_CACHE." #field); \
         if (is_disagg) {                                                                    \


### PR DESCRIPTION
Extracts the duplicated disagg-aware cache counter update logic (base counter plus its ingest/stable variant) into two macros in `cache.h`, and delegates the five accounting functions to them. Behavior preserved, with one stale `_ingest` error string on the updates stable path corrected.
