### PR TITLE
WT-17777 Do not clobber source files if formatting is unavailable

### DIFF
--- a/dist/common_functions.sh
+++ b/dist/common_functions.sh
@@ -93,6 +93,22 @@ check_fast_mode_flag() {
   fi
 }
 
+# Locate the clang-format executable. Prefer one on PATH; otherwise, if clang is
+# available, fall back to the one shipped with the clang toolchain. Exits with an
+# error if no usable binary is found. Sets the `clang_format` variable on success.
+check_clang_format() {
+  clang_format=`command -v clang-format`
+  if [[ -z "$clang_format" ]]; then
+    if command -v clang &> /dev/null; then
+      clang_format=`clang -print-prog-name=clang-format`
+    fi
+    if [[ ! -x "$clang_format" ]]; then
+      echo "error: clang-format not found; please install it and ensure it is on PATH" >&2
+      exit 1
+    fi
+  fi
+}
+
 # Get the earliest common commit from the dev branch.
 last_commit_from_dev() { python3 "$DIST_DIR"/common_functions.py last_commit_from_dev; }
 

--- a/dist/s_all
+++ b/dist/s_all
@@ -42,6 +42,9 @@ type python3 > /dev/null 2>&1 || {
     exit 1
 }
 
+# We require clang-format which may not be installed.
+check_clang_format
+
 echo 'dist/s_all run started...'
 
 export WT_FAST=""

--- a/dist/s_clang_format
+++ b/dist/s_clang_format
@@ -6,18 +6,7 @@ setup_trap
 cd_top
 check_fast_mode_flag
 
-# Locate the clang-format executable. Prefer one on PATH; otherwise, if clang is
-# available, fall back to the one shipped with the clang toolchain.
-clang_format=`command -v clang-format`
-if [[ -z "$clang_format" ]]; then
-    if command -v clang &> /dev/null; then
-        clang_format=`clang -print-prog-name=clang-format`
-    fi
-    if [[ ! -x "$clang_format" ]]; then
-        echo "error: clang-format not found; please install it and ensure it is on PATH"
-        exit 1
-    fi
-fi
+check_clang_format
 
 # Parallel execution: if it's the main invocation of the script, collect the file names
 # to process and run them in subprocesses.


### PR DESCRIPTION
Add a preflight check for clang-format before running s_all. Before, the script would leave files in an unformatted state and also leave behind temporary files.