### PR TITLE
WT-18125 Evict stale disaggregated pages as clean

### DIFF
--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -468,13 +468,16 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF_STATE previous_state, u
     }
 
     /*
-     * Pages on an outdated disaggregated read-only btree can never be written to shared storage.
-     * While the previous generation's readers still hold the handle, keep the page resident so a
-     * reader positioned elsewhere on the tree can navigate back to it; the stepdown is only elegant
-     * if reads survive it. Once the last reader releases the handle, discard the page cleanly
-     * rather than routing it to a dirty split that would fail against shared storage.
+     * A page on an outdated disaggregated read-only btree that is not clean-evictable carries
+     * content that can never be written to shared storage nor read back from it. While the previous
+     * generation's readers still hold the handle, keep such a page resident so a reader positioned
+     * elsewhere on the tree can navigate back to it; the stepdown is only elegant if reads survive
+     * it. Once the last reader releases the handle, discard the page cleanly rather than routing it
+     * to a dirty split that would fail against shared storage. A clean-evictable page is exempt
+     * from the gate: its disk image is fully described by the page's address, so it can be re-read
+     * from storage and eviction may discard it normally even with readers present.
      */
-    if (__wt_btree_is_stale_disagg(session)) {
+    if (__wt_btree_is_stale_disagg(session) && !__wt_page_evict_clean(page)) {
         if (__wt_atomic_load_int32_relaxed(&session->dhandle->session_inuse) > 0) {
             ret = __wt_set_return(session, EBUSY);
             goto err;

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -385,13 +385,13 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF_STATE previous_state, u
     WT_PAGE *page;
     uint64_t page_size;
     uint8_t stats_flags;
-    bool evict_clean, closing, ebusy_only, inmem_split, is_dirty, tree_dead;
+    bool evict_clean, closing, ebusy_only, inmem_split, is_dirty, stat_dirty, tree_dead;
 
     conn = S2C(session);
     page = ref->page;
     closing = LF_ISSET(WT_EVICT_CALL_CLOSING);
     stats_flags = 0;
-    evict_clean = ebusy_only = is_dirty = false;
+    evict_clean = ebusy_only = is_dirty = stat_dirty = false;
 
     __wt_verbose_debug3(
       session, WT_VERB_EVICTION, "page %p (%s)", (void *)page, __wt_page_type_string(page->type));
@@ -467,6 +467,9 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF_STATE previous_state, u
         goto done;
     }
 
+    if (__wt_page_is_modified(page))
+        is_dirty = stat_dirty = true;
+
     /*
      * Pages on an outdated disaggregated read-only btree can never be written to shared storage.
      * While the previous generation's readers still hold the handle, keep the page resident so a
@@ -479,11 +482,16 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF_STATE previous_state, u
             ret = __wt_set_return(session, EBUSY);
             goto err;
         }
-        __wt_page_modify_clear(session, page);
-    }
 
-    if (__wt_page_is_modified(page))
-        is_dirty = true;
+        /*
+         * Force the page clean so eviction discards it rather than routing it through a dirty
+         * split. The dirty statistic still reflects the original state captured above, so a page
+         * carrying a leader-era reconciliation result is sized against the dirty statistic even
+         * though it is discarded as clean.
+         */
+        __wt_page_modify_clear(session, page);
+        is_dirty = false;
+    }
 
     /*
      * Track the largest page size seen at eviction, it tells us something about our ability to
@@ -492,7 +500,7 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF_STATE previous_state, u
      */
     page_size = __wt_atomic_load_size_relaxed(&page->memory_footprint);
 
-    if (!is_dirty)
+    if (!stat_dirty)
         /* Clean page */
         __wt_atomic_stats_max_uint64(
           &conn->evict->evict_max_clean_page_size_per_checkpoint, page_size);

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -468,12 +468,19 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF_STATE previous_state, u
     }
 
     /*
-     * Dirty pages on an outdated disaggregated read-only btree can never be written to shared
-     * storage. Clear the dirty flag so eviction discards the page cleanly instead of attempting
-     * reconciliation.
+     * Pages on an outdated disaggregated read-only btree can never be written to shared storage.
+     * While the previous generation's readers still hold the handle, keep the page resident so a
+     * reader positioned elsewhere on the tree can navigate back to it; the stepdown is only elegant
+     * if reads survive it. Once the last reader releases the handle, discard the page cleanly
+     * rather than routing it to a dirty split that would fail against shared storage.
      */
-    if (__wt_btree_is_stale_disagg(session))
+    if (__wt_btree_is_stale_disagg(session)) {
+        if (__wt_atomic_load_int32_relaxed(&session->dhandle->session_inuse) > 0) {
+            ret = __wt_set_return(session, EBUSY);
+            goto err;
+        }
         __wt_page_modify_clear(session, page);
+    }
 
     if (__wt_page_is_modified(page))
         is_dirty = true;
@@ -525,8 +532,14 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF_STATE previous_state, u
     if (!closing && F_ISSET(ref, WT_REF_FLAG_INTERNAL))
         WT_STAT_CONN_DSRC_INCR(session, cache_eviction_internal);
 
-    /* Figure out whether reconciliation was done on the page */
-    if (__wt_page_evict_clean(page)) {
+    /*
+     * Figure out whether reconciliation was done on the page. A stale disaggregated page has had
+     * its dirty flag cleared above, but a non-zero reconciliation result left over from the leader
+     * era keeps the clean check false and would route the page to a dirty split that can never
+     * write back to shared storage. Force clean eviction so the page is discarded instead of
+     * trapped in cache.
+     */
+    if (__wt_page_evict_clean(page) || __wt_btree_is_stale_disagg(session)) {
         evict_clean = true;
         FLD_SET(stats_flags, WT_EVICT_STATS_CLEAN);
     }

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -385,13 +385,13 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF_STATE previous_state, u
     WT_PAGE *page;
     uint64_t page_size;
     uint8_t stats_flags;
-    bool evict_clean, closing, ebusy_only, inmem_split, is_dirty, stat_dirty, tree_dead;
+    bool evict_clean, closing, ebusy_only, inmem_split, is_dirty, tree_dead;
 
     conn = S2C(session);
     page = ref->page;
     closing = LF_ISSET(WT_EVICT_CALL_CLOSING);
     stats_flags = 0;
-    evict_clean = ebusy_only = is_dirty = stat_dirty = false;
+    evict_clean = ebusy_only = is_dirty = false;
 
     __wt_verbose_debug3(
       session, WT_VERB_EVICTION, "page %p (%s)", (void *)page, __wt_page_type_string(page->type));
@@ -467,9 +467,6 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF_STATE previous_state, u
         goto done;
     }
 
-    if (__wt_page_is_modified(page))
-        is_dirty = stat_dirty = true;
-
     /*
      * Pages on an outdated disaggregated read-only btree can never be written to shared storage.
      * While the previous generation's readers still hold the handle, keep the page resident so a
@@ -482,16 +479,11 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF_STATE previous_state, u
             ret = __wt_set_return(session, EBUSY);
             goto err;
         }
-
-        /*
-         * Force the page clean so eviction discards it rather than routing it through a dirty
-         * split. The dirty statistic still reflects the original state captured above, so a page
-         * carrying a leader-era reconciliation result is sized against the dirty statistic even
-         * though it is discarded as clean.
-         */
         __wt_page_modify_clear(session, page);
-        is_dirty = false;
     }
+
+    if (__wt_page_is_modified(page))
+        is_dirty = true;
 
     /*
      * Track the largest page size seen at eviction, it tells us something about our ability to
@@ -500,7 +492,7 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF_STATE previous_state, u
      */
     page_size = __wt_atomic_load_size_relaxed(&page->memory_footprint);
 
-    if (!stat_dirty)
+    if (!is_dirty)
         /* Clean page */
         __wt_atomic_stats_max_uint64(
           &conn->evict->evict_max_clean_page_size_per_checkpoint, page_size);


### PR DESCRIPTION
[WT-18125](https://jira.mongodb.org/browse/WT-18125)

## Problem

Pages on a stale disaggregated read-only btree (`WT_BTREE_DISAGGREGATED | WT_BTREE_READONLY` with an `OUTDATED` dhandle) could get stuck in eviction, driving a cache stall. Clean eviction rejected them as "modified" because they still carried a leader-era reconciliation result (`WT_PM_REC_MULTIBLOCK`), while dirty eviction rejected them as "stale" — the page could satisfy neither direction and looped forever.

## Fix

In `__wt_evict`, once a stale disaggregated tree has no active readers (`session_inuse == 0`), force the page clean with `__wt_page_modify_clear` and let eviction discard it. Such a page can never be written back to shared storage, so routing it through a dirty split is wrong; a clean discard is both correct and terminates the loop. While readers still hold the handle, the page is kept resident (returns `EBUSY`) so a reader positioned elsewhere on the tree can navigate back to it.
