### PR TITLE
WT-18097 Mark log_slot_destroy stdout as expected in test_bug018

### DIFF
--- a/test/suite/test_bug018.py
+++ b/test/suite/test_bug018.py
@@ -105,6 +105,7 @@ class test_bug018(wttest.WiredTigerTestCase, suite_subprocess):
                 pass
 
         # Expect an error and messages, so turn off stderr checking.
+        self.ignoreStdoutPatternIfExists('log_slot_destroy: failed to write slot')
         with self.expectedStderrPattern(''):
             try:
                 self.close_conn()


### PR DESCRIPTION
test_bug018 intentionally yanks a file descriptor out from under WiredTiger to force a write failure during close, but a warning added in WT-17769 now prints on stdout, tripping the harness's stdout check in tearDown. Add this (expected) error message to `ignoreStdoutPatternIfExists()`.