### PR TITLE
WT-18162 Skip materializing globally visible deleted keys when rebuilding a disaggregated leaf page

### DIFF
--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -255,7 +255,9 @@ __page_free_delta_leaf_merge_state(
 
 /*
  * __time_window_clear_obsolete --
- *     Where possible modify time window values to avoid writing obsolete values to the cell.
+ *     Clear a globally visible start from a value's time window to avoid writing obsolete values to
+ *     the cell. A globally visible stop is not handled here: the caller drops the whole cell in
+ *     that case, so it is never packed.
  */
 static WT_INLINE void
 __time_window_clear_obsolete(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw)
@@ -264,28 +266,12 @@ __time_window_clear_obsolete(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw)
     if (WT_TIME_WINDOW_IS_EMPTY(tw))
         return;
 
-    /*
-     * Check if the start of the time window is globally visible, and if so remove unnecessary
-     * values.
-     */
     if (__wt_txn_tw_start_visible_all(session, tw)) {
         /* The durable timestamp should never be less than the start timestamp. */
         WT_ASSERT(session, tw->start_ts <= tw->durable_start_ts);
 
         tw->start_ts = tw->durable_start_ts = WT_TS_NONE;
         tw->start_txn = WT_TXN_NONE;
-    }
-
-    /*
-     * Check if the stop of the time window is globally visible, and if so remove unnecessary
-     * values.
-     */
-    if (__wt_txn_tw_stop_visible_all(session, tw)) {
-        /* The durable timestamp should never be less than the stop timestamp. */
-        WT_ASSERT(session, tw->stop_ts <= tw->durable_stop_ts);
-
-        tw->stop_ts = tw->durable_stop_ts = WT_TS_NONE;
-        tw->stop_txn = WT_TXN_NONE;
     }
 }
 
@@ -370,21 +356,29 @@ __wti_page_merge_deltas_with_base_image_leaf(WT_SESSION_IMPL *session, WT_ITEM *
             WT_ERR(__wt_compare(
               session, btree->collator, base_state.current_key, delta_state[j].current_key, &cmp));
 
-        /* Build disk image */
+        /*
+         * Build the disk image. A key whose stop is globally visible is a globally visible delete
+         * that no reader can see, so skip it entirely rather than materializing an obsolete cell.
+         * Dropping it only lowers the page's aggregate, so it stays covered by the parent, and it
+         * removes the obsolete stop that would otherwise have to be normalized.
+         */
         if (cmp < 0) {
-            __time_window_clear_obsolete(session, &base_state.unpack_value->tw);
-            /* Pack row-leaf base key/value. */
-            WT_ERR(__wt_cell_pack_leaf_kv(session, base_state.empty_value_cell,
-              base_state.current_key->data, base_state.current_key->size,
-              base_state.unpack_value->data, base_state.unpack_value->size,
-              &base_state.unpack_value->tw, new_image, &disk_s));
+            if (!__wt_txn_tw_stop_visible_all(session, &base_state.unpack_value->tw)) {
+                __time_window_clear_obsolete(session, &base_state.unpack_value->tw);
+                /* Pack row-leaf base key/value. */
+                WT_ERR(__wt_cell_pack_leaf_kv(session, base_state.empty_value_cell,
+                  base_state.current_key->data, base_state.current_key->size,
+                  base_state.unpack_value->data, base_state.unpack_value->size,
+                  &base_state.unpack_value->tw, new_image, &disk_s));
 
 #ifdef HAVE_DIAGNOSTIC
-            WT_TIME_AGGREGATE_UPDATE(session, ta, &base_state.unpack_value->tw);
+                WT_TIME_AGGREGATE_UPDATE(session, ta, &base_state.unpack_value->tw);
 #endif
+            }
         } else {
-            /* Pack row-leaf delta entry. */
-            if (!F_ISSET(delta_state[j].unpack, WT_DELTA_LEAF_IS_DELETE)) {
+            /* Pack row-leaf delta entry, dropping globally visible deletes. */
+            if (!F_ISSET(delta_state[j].unpack, WT_DELTA_LEAF_IS_DELETE) &&
+              !__wt_txn_tw_stop_visible_all(session, &delta_state[j].unpack->delta_value.tw)) {
                 __time_window_clear_obsolete(session, &delta_state[j].unpack->delta_value.tw);
                 WT_ERR(__wt_cell_pack_leaf_kv(session,
                   delta_state[j].unpack->delta_value_data.size == 0 &&
@@ -437,10 +431,16 @@ __wti_page_merge_deltas_with_base_image_leaf(WT_SESSION_IMPL *session, WT_ITEM *
     dsk->type = WT_PAGE_ROW_LEAF;
     dsk->flags = 0;
 
-    if (disk_s.all_empty_value)
-        F_SET(dsk, WT_PAGE_EMPTY_V_ALL);
-    if (!disk_s.any_empty_value)
-        F_SET(dsk, WT_PAGE_EMPTY_V_NONE);
+    /*
+     * The all-empty and no-empty value flags are mutually exclusive; with no entries both would be
+     * set vacuously (an invalid combination), so only set them when the page has values.
+     */
+    if (disk_s.entries != 0) {
+        if (disk_s.all_empty_value)
+            F_SET(dsk, WT_PAGE_EMPTY_V_ALL);
+        if (!disk_s.any_empty_value)
+            F_SET(dsk, WT_PAGE_EMPTY_V_NONE);
+    }
 
     /* Compute final on-disk image size using pointer difference. */
     new_image->size = WT_PTRDIFF(disk_s.cell_ptr, new_image->mem);

--- a/test/suite/test_layered_delta17.py
+++ b/test/suite/test_layered_delta17.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wttest, wiredtiger
+from wiredtiger import stat
+from helper_disagg import disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
+
+# test_layered_delta17.py
+#
+# Reconstructing a leaf page from its base image and deltas drops every key whose
+# stop is globally visible. When all of a page's keys are dropped, the merge
+# produces a leaf image with no entries: check the reader tolerates that empty
+# reconstructed page.
+@disagg_test_class
+class test_layered_delta17(wttest.WiredTigerTestCase):
+    test_name = __qualname__
+    uri = f"layered:{test_name}"
+
+    conn_base_config = 'statistics=(all),transaction_sync=(enabled,method=fsync),' \
+                     + 'page_delta=(delta_pct=100,leaf_page_delta=true),precise_checkpoint=true,'
+    disagg_storages = gen_disagg_storages(disagg_only=True)
+    scenarios = make_scenarios(disagg_storages)
+
+    nitems = 10
+
+    def conn_config(self):
+        return self.conn_base_config + 'disaggregated=(role="leader")'
+
+    def session_create_config(self):
+        return 'key_format=S,value_format=S'
+
+    def evict(self, key):
+        # Force the page holding key out of cache so the next access rebuilds it
+        # from its base image and deltas.
+        s = self.conn.open_session("debug=(release_evict_page)")
+        c = s.open_cursor(self.uri, None, None)
+        s.begin_transaction()
+        c.set_key(key)
+        c.search_near()
+        c.close()
+        s.rollback_transaction()
+        s.close()
+
+    def test_empty_reconstructed_page(self):
+        self.session.create(self.uri, self.session_create_config())
+        value = "a" * 20
+
+        # Populate the leaf, delete every key, and checkpoint with the oldest
+        # timestamp still behind the delete. The tombstones are not yet globally
+        # visible, so they are retained and written into the leaf's base image
+        # (rather than the page being collapsed away).
+        cursor = self.session.open_cursor(self.uri, None, None)
+        for i in range(self.nitems):
+            self.session.begin_transaction()
+            cursor[str(i)] = value
+            self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(5)}')
+        for i in range(self.nitems):
+            self.session.begin_transaction()
+            cursor.set_key(str(i))
+            cursor.remove()
+            self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(10)}')
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10))
+        self.session.checkpoint()
+        self.evict(str(0))
+
+        # Add and then remove a throwaway key, checkpointing each change so the
+        # page carries leaf deltas on top of the tombstone-bearing base image:
+        # reconstructing it now has to run the base+delta merge. The throwaway
+        # key nets out to nothing, and the oldest timestamp is still behind every
+        # delete so nothing is dropped at write time.
+        self.session.begin_transaction()
+        cursor['zzz'] = value
+        self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(12)}')
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(12))
+        self.session.checkpoint()
+        self.assertGreaterEqual(self.get_stat(stat.dsrc.rec_page_delta_leaf, self.uri), 1)
+        self.session.begin_transaction()
+        cursor.set_key('zzz')
+        cursor.remove()
+        self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(14)}')
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(14))
+        self.session.checkpoint()
+        self.evict(str(0))
+
+        # Make every delete globally visible, then read the page back. The read
+        # rebuilds it from the base image and deltas; every key's stop is now
+        # globally visible, so the merge drops them all and produces an empty leaf.
+        self.conn.set_timestamp(f'oldest_timestamp={self.timestamp_str(20)},'
+                                f'stable_timestamp={self.timestamp_str(20)}')
+
+        cursor.close()
+        cursor = self.session.open_cursor(self.uri, None, None)
+
+        # Forward and backward scans see nothing.
+        self.assertEqual(cursor.next(), wiredtiger.WT_NOTFOUND)
+        self.assertEqual(cursor.prev(), wiredtiger.WT_NOTFOUND)
+
+        # A point search for any prior key returns not-found rather than crashing.
+        for i in range(self.nitems):
+            cursor.set_key(str(i))
+            self.assertEqual(cursor.search(), wiredtiger.WT_NOTFOUND)
+        cursor.close()
+
+        # The empty reconstructed page verifies and checkpoints cleanly.
+        self.session.verify(self.uri, None)
+        self.session.checkpoint()


### PR DESCRIPTION
## Summary

When rebuilding a disaggregated leaf page from its base image + deltas, skip emitting any key whose stop is globally visible, instead of materializing an obsolete cell. This removes wasted work and eliminates the race that caused the WT-18087 panic. Fixes WT-18087; implements WT-18162 (supersedes the reorder-only approach in WT-17885).

## Problem

`__wti_page_merge_deltas_with_base_image_leaf` reconstructs a page by packing each surviving base/delta value into a new image. Before packing, `__time_window_clear_obsolete` normalized obsolete windows, including clearing a globally visible stop (WT-17577). That clearing was a two-step check — clear the start if globally visible, then clear the stop if globally visible — and the two `__wt_txn_visible_all` checks each sample the global visibility state (`oldest_id`, pinned timestamp) independently. A thread preempted between them can observe the state advance:

- start check: start not yet globally visible -> start kept
- (preemption; `oldest_id` / pinned advance)
- stop check: stop now globally visible -> stop zeroed

The result is a live start above a zeroed stop (`start_ts > stop_ts = 0`), which `__wt_time_value_validate` rejects when the cell is packed, panicking on diagnostic builds. WT-18087 captured a core where a valid on-disk `start(ts=3,txn=24648)/stop(ts=4,txn=34647)` had become `start(3,24648)/stop(0,0)` in memory.

## Fix

A key whose stop is globally visible is a globally visible delete that no reader can see, and reconciliation already omits such pairs when it writes a page. So in the merge loop, when `__wt_txn_tw_stop_visible_all()` holds, skip emitting the key/value entirely (base branch and kept-delta branch). Structural bookkeeping is unaffected: entries, the `WT_PAGE_EMPTY_V_*` flags, and prefix compression against `disk_s.last_key` are all updated inside the pack call, so a skipped pack contributes nothing and the next key prefix-compresses against the last emitted key.

Dropping a cell only lowers the page's aggregate, so `child <= parent` still holds (this also directly removes the obsolete stop that WT-17577 normalized). `__time_window_clear_obsolete` is reduced to clearing a globally visible start for the values that are kept (its original WT-16523 purpose); the stop is never normalized because such cells are no longer emitted.

## Empty reconstructed page

When every key on a page is dropped, the merge produces a leaf image with no entries. In that case `all_empty_value` is vacuously true and `any_empty_value` is false, so the old code set both `WT_PAGE_EMPTY_V_ALL` and `WT_PAGE_EMPTY_V_NONE` — a mutually exclusive pair that fails `__wt_verify_dsk_image` (`invalid flags combination: 0x6`) on the next read. Only set these flags when the page has entries.

## Testing

- `test_layered_delta17` drives a page to an empty reconstructed image (base image of retained tombstones + a delta, with the deletes made globally visible before the read) and checks that forward/backward scans, point searches, `verify`, and `checkpoint` all handle the empty page. It aborts without the flag fix and passes with it.
- Full `layered_delta` suite (146 tests) passes.

## Notes

- This is the shared history store, so dropping here is effectively early HS pruning on the read path; it is safe because a globally visible delete is invisible to every reader, and reconciliation would drop it on the next write regardless.