### PR TITLE
WT-18162 Skip materializing globally visible deleted keys when rebuilding a disaggregated leaf page

### DIFF
--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -686,8 +686,12 @@ __wti_delete_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
     /* Fast-truncate only happens to leaf pages. */
     WT_ASSERT(session, page->type == WT_PAGE_ROW_LEAF || page->type == WT_PAGE_COL_VAR);
 
-    /* Empty pages should get skipped before reaching this point. */
-    WT_ASSERT(session, page->entries > 0);
+    /*
+     * A leaf page can be empty only when it was rebuilt from a base image and deltas: that merge
+     * drops every key whose stop is globally visible, which can leave no entries. Instantiating
+     * such a page is a no-op (there are no rows to tombstone). Any other empty page is unexpected.
+     */
+    WT_ASSERT(session, page->entries > 0 || WT_DELTA_LEAF_ENABLED(session));
 
     WT_STAT_CONN_DSRC_INCR(session, cache_read_deleted);
 

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -255,7 +255,10 @@ __page_free_delta_leaf_merge_state(
 
 /*
  * __time_window_clear_obsolete --
- *     Where possible modify time window values to avoid writing obsolete values to the cell.
+ *     Clear a globally visible start from a value's time window to avoid writing obsolete values to
+ *     the cell. A globally visible stop is not handled here: the caller drops the whole cell in
+ *     that case, so it is never packed, and never clearing a stop means we cannot leave a live
+ *     start above a zeroed stop.
  */
 static WT_INLINE void
 __time_window_clear_obsolete(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw)
@@ -264,28 +267,12 @@ __time_window_clear_obsolete(WT_SESSION_IMPL *session, WT_TIME_WINDOW *tw)
     if (WT_TIME_WINDOW_IS_EMPTY(tw))
         return;
 
-    /*
-     * Check if the start of the time window is globally visible, and if so remove unnecessary
-     * values.
-     */
     if (__wt_txn_tw_start_visible_all(session, tw)) {
         /* The durable timestamp should never be less than the start timestamp. */
         WT_ASSERT(session, tw->start_ts <= tw->durable_start_ts);
 
         tw->start_ts = tw->durable_start_ts = WT_TS_NONE;
         tw->start_txn = WT_TXN_NONE;
-    }
-
-    /*
-     * Check if the stop of the time window is globally visible, and if so remove unnecessary
-     * values.
-     */
-    if (__wt_txn_tw_stop_visible_all(session, tw)) {
-        /* The durable timestamp should never be less than the stop timestamp. */
-        WT_ASSERT(session, tw->stop_ts <= tw->durable_stop_ts);
-
-        tw->stop_ts = tw->durable_stop_ts = WT_TS_NONE;
-        tw->stop_txn = WT_TXN_NONE;
     }
 }
 
@@ -370,21 +357,31 @@ __wti_page_merge_deltas_with_base_image_leaf(WT_SESSION_IMPL *session, WT_ITEM *
             WT_ERR(__wt_compare(
               session, btree->collator, base_state.current_key, delta_state[j].current_key, &cmp));
 
-        /* Build disk image */
+        /*
+         * Build the disk image. A key whose stop is globally visible is a globally visible delete
+         * that no reader can see, so skip materializing it. Only a real value cell carries a stop:
+         * an empty-value cell has no value cell and, by construction, an empty time window (a live
+         * zero-length value), so it is never a delete and its unpack_value time window is not its
+         * own -- never test it for a stop.
+         */
         if (cmp < 0) {
-            __time_window_clear_obsolete(session, &base_state.unpack_value->tw);
-            /* Pack row-leaf base key/value. */
-            WT_ERR(__wt_cell_pack_leaf_kv(session, base_state.empty_value_cell,
-              base_state.current_key->data, base_state.current_key->size,
-              base_state.unpack_value->data, base_state.unpack_value->size,
-              &base_state.unpack_value->tw, new_image, &disk_s));
+            if (base_state.empty_value_cell ||
+              !__wt_txn_tw_stop_visible_all(session, &base_state.unpack_value->tw)) {
+                __time_window_clear_obsolete(session, &base_state.unpack_value->tw);
+                /* Pack row-leaf base key/value. */
+                WT_ERR(__wt_cell_pack_leaf_kv(session, base_state.empty_value_cell,
+                  base_state.current_key->data, base_state.current_key->size,
+                  base_state.unpack_value->data, base_state.unpack_value->size,
+                  &base_state.unpack_value->tw, new_image, &disk_s));
 
 #ifdef HAVE_DIAGNOSTIC
-            WT_TIME_AGGREGATE_UPDATE(session, ta, &base_state.unpack_value->tw);
+                WT_TIME_AGGREGATE_UPDATE(session, ta, &base_state.unpack_value->tw);
 #endif
+            }
         } else {
-            /* Pack row-leaf delta entry. */
-            if (!F_ISSET(delta_state[j].unpack, WT_DELTA_LEAF_IS_DELETE)) {
+            /* Pack row-leaf delta entry, dropping globally visible deletes. */
+            if (!F_ISSET(delta_state[j].unpack, WT_DELTA_LEAF_IS_DELETE) &&
+              !__wt_txn_tw_stop_visible_all(session, &delta_state[j].unpack->delta_value.tw)) {
                 __time_window_clear_obsolete(session, &delta_state[j].unpack->delta_value.tw);
                 WT_ERR(__wt_cell_pack_leaf_kv(session,
                   delta_state[j].unpack->delta_value_data.size == 0 &&
@@ -437,10 +434,16 @@ __wti_page_merge_deltas_with_base_image_leaf(WT_SESSION_IMPL *session, WT_ITEM *
     dsk->type = WT_PAGE_ROW_LEAF;
     dsk->flags = 0;
 
-    if (disk_s.all_empty_value)
-        F_SET(dsk, WT_PAGE_EMPTY_V_ALL);
-    if (!disk_s.any_empty_value)
-        F_SET(dsk, WT_PAGE_EMPTY_V_NONE);
+    /*
+     * The all-empty and no-empty value flags are mutually exclusive; with no entries both would be
+     * set vacuously (an invalid combination), so only set them when the page has values.
+     */
+    if (disk_s.entries != 0) {
+        if (disk_s.all_empty_value)
+            F_SET(dsk, WT_PAGE_EMPTY_V_ALL);
+        if (!disk_s.any_empty_value)
+            F_SET(dsk, WT_PAGE_EMPTY_V_NONE);
+    }
 
     /* Compute final on-disk image size using pointer difference. */
     new_image->size = WT_PTRDIFF(disk_s.cell_ptr, new_image->mem);

--- a/test/catch2/CMakeLists.txt
+++ b/test/catch2/CMakeLists.txt
@@ -21,6 +21,7 @@ else()
         misc_tests/test_futex.cpp
         misc_tests/test_intpack.cpp
         misc_tests/test_mock_session.cpp
+        misc_tests/test_page_delta_merge_empty_value.cpp
         misc_tests/test_page_log_handle.cpp
         misc_tests/test_pow.cpp
         misc_tests/test_prepare_mod_sort.cpp

--- a/test/catch2/misc_tests/test_page_delta_merge_empty_value.cpp
+++ b/test/catch2/misc_tests/test_page_delta_merge_empty_value.cpp
@@ -1,0 +1,174 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+/*
+ * Unit test for __wti_page_merge_deltas_with_base_image_leaf: rebuilding a leaf page from its base
+ * image and deltas must not drop a live key stored as an empty-value cell.
+ *
+ * An empty-value cell (a key with no value cell -- a zero-length value with an empty time window)
+ * has no stop of its own; for the last entry on a page the unpacked value still holds the previous
+ * entry's time window. The logic that skips globally visible deletes must not consult that stale
+ * window for an empty-value cell, or it drops the live key.
+ */
+#include <catch2/catch.hpp>
+#include <cstring>
+#include "../wrappers/mock_session.h"
+
+extern "C" {
+#include "wt_internal.h"
+}
+
+namespace {
+
+static void
+init_disk_state(WT_SESSION_IMPL *session, WT_ITEM *img, WTI_DISK_LEAF_MERGE_STATE *s)
+{
+    WT_BTREE *btree = S2BT(session);
+    memset(s, 0, sizeof(*s));
+    /*
+     * __wt_cell_pack_leaf_kv appends at img->mem + img->size, so reserve the page header up front
+     * (matching how the real merge seeds new_image->size before packing cells).
+     */
+    img->size = WT_PAGE_HEADER_BYTE_SIZE(btree);
+    s->cell_ptr = (uint8_t *)WT_PAGE_HEADER_BYTE(btree, img->mem);
+    s->all_empty_value = true;
+    s->any_empty_value = false;
+    s->entries = 0;
+    s->key_pfx_last = 0;
+    s->key_pfx_compress = false; /* No prefix compression: keys are stored in full. */
+    REQUIRE(__wt_scr_alloc(session, 0, &s->last_key) == 0);
+}
+
+static void
+finalize_leaf_image(WT_ITEM *img, WTI_DISK_LEAF_MERGE_STATE *s)
+{
+    WT_PAGE_HEADER *dsk = (WT_PAGE_HEADER *)img->mem;
+    memset(dsk, 0, WT_PAGE_HEADER_SIZE);
+    dsk->u.entries = s->entries;
+    dsk->type = WT_PAGE_ROW_LEAF;
+    dsk->version = WT_PAGE_VERSION_TS;
+    dsk->write_gen = 1000; /* High: keep read-side transaction-id cleanup out of the picture. */
+    img->size = WT_PTRDIFF(s->cell_ptr, img->mem);
+    dsk->mem_size = WT_STORE_SIZE(img->size);
+}
+
+static bool
+image_has_key(WT_ITEM *img, const char *key, size_t key_size)
+{
+    const uint8_t *p = (const uint8_t *)img->mem;
+    if (key_size == 0 || img->size < key_size)
+        return false;
+    for (size_t i = 0; i + key_size <= img->size; i++)
+        if (memcmp(p + i, key, key_size) == 0)
+            return true;
+    return false;
+}
+
+struct merge_empty_value_fixture {
+    std::shared_ptr<mock_session> mock;
+    WT_SESSION_IMPL *session;
+
+    merge_empty_value_fixture() : mock(mock_session::build_test_mock_session())
+    {
+        mock->setup_block_manager_file_operations();
+        session = mock->get_wt_session_impl();
+        session->id = 0;
+
+        WT_TXN_SHARED *txn_shared_list;
+        REQUIRE(__wt_calloc(session, 1, sizeof(WT_TXN_SHARED), &txn_shared_list) == 0);
+        S2C(session)->txn_global.txn_shared_list = txn_shared_list;
+        REQUIRE(__wt_calloc(session, 1, sizeof(WT_TXN), &session->txn) == 0);
+
+        WT_TXN_GLOBAL *txn_global = &S2C(session)->txn_global;
+        txn_global->oldest_id = 100;
+        txn_global->pinned_timestamp = 100;
+        txn_global->oldest_timestamp = 100;
+        txn_global->has_pinned_timestamp = true;
+        txn_global->checkpoint_txn_shared.pinned_id = WT_TXN_NONE;
+
+        WT_BTREE *btree = S2BT(session);
+        btree->collator = nullptr;
+        btree->prefix_compression = false;
+        btree->block_header = 0;
+        btree->base_write_gen = 1;
+    }
+
+    ~merge_empty_value_fixture()
+    {
+        __wt_free(session, session->txn);
+        __wt_free(session, S2C(session)->txn_global.txn_shared_list);
+    }
+};
+
+} // namespace
+
+TEST_CASE_METHOD(merge_empty_value_fixture,
+  "merge deltas keeps an empty-value last key with a globally visible neighbor",
+  "[page_delta_merge]")
+{
+    WT_ITEM base, delta, new_image;
+    WT_CLEAR(base);
+    WT_CLEAR(delta);
+    WT_CLEAR(new_image);
+    REQUIRE(__wt_buf_init(session, &base, 4096) == 0);
+    REQUIRE(__wt_buf_init(session, &delta, 4096) == 0);
+    REQUIRE(__wt_buf_init(session, &new_image, 8192) == 0);
+
+    /*
+     * Base image: "aaa" is a value cell with a globally visible stop (a delete that should be
+     * dropped); "zzz" is an empty-value cell (zero-length value, empty window) and the last entry.
+     */
+    WTI_DISK_LEAF_MERGE_STATE bs;
+    init_disk_state(session, &base, &bs);
+    WT_TIME_WINDOW tw_stop;
+    WT_TIME_WINDOW_INIT(&tw_stop);
+    tw_stop.stop_ts = tw_stop.durable_stop_ts = 5; /* 5 <= pinned 100: globally visible */
+    tw_stop.stop_txn = WT_TXN_NONE;
+    REQUIRE(
+      __wt_cell_pack_leaf_kv(session, false, "aaa", 3, "value1", 6, &tw_stop, &base, &bs) == 0);
+    WT_TIME_WINDOW tw_empty;
+    WT_TIME_WINDOW_INIT(&tw_empty);
+    REQUIRE(
+      __wt_cell_pack_leaf_kv(session, true, "zzz", 3, nullptr, 0, &tw_empty, &base, &bs) == 0);
+    finalize_leaf_image(&base, &bs);
+    REQUIRE(((WT_PAGE_HEADER *)base.mem)->u.entries == 3); /* aaa key+value, zzz key */
+    __wt_scr_free(session, &bs.last_key);
+
+    /*
+     * An empty delta (header only, no entries) is enough to invoke the merge; it then walks the
+     * base image, where "zzz" is the last entry, exercising the empty-value/last-entry path.
+     */
+    WTI_DISK_LEAF_MERGE_STATE ds;
+    init_disk_state(session, &delta, &ds);
+    finalize_leaf_image(&delta, &ds);
+    __wt_scr_free(session, &ds.last_key);
+
+    int ret;
+#ifdef HAVE_DIAGNOSTIC
+    WT_TIME_AGGREGATE ta;
+    ret = __wti_page_merge_deltas_with_base_image_leaf(
+      session, &delta, 1, &new_image, (WT_PAGE_HEADER *)base.mem, &ta);
+#else
+    ret = __wti_page_merge_deltas_with_base_image_leaf(
+      session, &delta, 1, &new_image, (WT_PAGE_HEADER *)base.mem);
+#endif
+    REQUIRE(ret == 0);
+
+    /*
+     * Exactly one entry must survive: "aaa" (globally visible stop) is dropped, and the empty-value
+     * last key "zzz" is kept. Because "aaa" is gone and one entry remains, that entry is "zzz". The
+     * buggy version consulted the empty-value cell's stale time window (the adjacent "aaa" stop) and
+     * dropped it too, leaving zero entries.
+     */
+    REQUIRE(((WT_PAGE_HEADER *)new_image.mem)->u.entries == 1);
+    REQUIRE(!image_has_key(&new_image, "aaa", 3)); /* the dropped key is gone */
+
+    __wt_buf_free(session, &base);
+    __wt_buf_free(session, &delta);
+    __wt_buf_free(session, &new_image);
+}

--- a/test/catch2/misc_tests/test_page_delta_merge_empty_value.cpp
+++ b/test/catch2/misc_tests/test_page_delta_merge_empty_value.cpp
@@ -162,8 +162,8 @@ TEST_CASE_METHOD(merge_empty_value_fixture,
     /*
      * Exactly one entry must survive: "aaa" (globally visible stop) is dropped, and the empty-value
      * last key "zzz" is kept. Because "aaa" is gone and one entry remains, that entry is "zzz". The
-     * buggy version consulted the empty-value cell's stale time window (the adjacent "aaa" stop) and
-     * dropped it too, leaving zero entries.
+     * buggy version consulted the empty-value cell's stale time window (the adjacent "aaa" stop)
+     * and dropped it too, leaving zero entries.
      */
     REQUIRE(((WT_PAGE_HEADER *)new_image.mem)->u.entries == 1);
     REQUIRE(!image_has_key(&new_image, "aaa", 3)); /* the dropped key is gone */

--- a/test/catch2/misc_tests/test_page_delta_merge_empty_value.cpp
+++ b/test/catch2/misc_tests/test_page_delta_merge_empty_value.cpp
@@ -94,7 +94,7 @@ struct merge_empty_value_fixture {
         WT_BTREE *btree = S2BT(session);
         btree->collator = nullptr;
         btree->prefix_compression = false;
-        btree->block_header = 0;
+        btree->block_header = WT_BLOCK_HEADER_SIZE;
         btree->base_write_gen = 1;
     }
 
@@ -166,7 +166,8 @@ TEST_CASE_METHOD(merge_empty_value_fixture,
      * and dropped it too, leaving zero entries.
      */
     REQUIRE(((WT_PAGE_HEADER *)new_image.mem)->u.entries == 1);
-    REQUIRE(!image_has_key(&new_image, "aaa", 3)); /* the dropped key is gone */
+    REQUIRE(image_has_key(&new_image, "zzz", 3));  /* live empty-value last key survived */
+    REQUIRE(!image_has_key(&new_image, "aaa", 3)); /* globally visible stop was dropped */
 
     __wt_buf_free(session, &base);
     __wt_buf_free(session, &delta);

--- a/test/suite/test_layered_delta17.py
+++ b/test/suite/test_layered_delta17.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wttest, wiredtiger
+from wiredtiger import stat
+from helper_disagg import disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
+
+# test_layered_delta17.py
+#
+# Rebuilding a disaggregated leaf page from its base image and deltas drops every
+# key whose stop is globally visible. When all of a page's keys are dropped the
+# merge produces a leaf image with no entries; check the reader, verify, and
+# checkpoint all tolerate that empty reconstructed page (rather than tripping the
+# mutually-exclusive empty-value page flags during verification).
+@disagg_test_class
+class test_layered_delta17(wttest.WiredTigerTestCase):
+    uri = "table:test_layered_delta17"
+    conn_base_config = ('statistics=(all),transaction_sync=(enabled,method=fsync),'
+                        'page_delta=(delta_pct=100,leaf_page_delta=true),precise_checkpoint=true,')
+    disagg_storages = gen_disagg_storages(disagg_only=True)
+    scenarios = make_scenarios(disagg_storages)
+
+    nitems = 10
+
+    def conn_config(self):
+        return self.conn_base_config + 'disaggregated=(role="leader")'
+
+    def rstat(self, key):
+        with wttest.open_cursor(self.session, "statistics:" + self.uri) as c:
+            return c[key][2]
+
+    def evict(self, key):
+        # Force the page holding key out of cache so the next access rebuilds it
+        # from its base image and deltas.
+        s = self.conn.open_session("debug=(release_evict_page)")
+        c = s.open_cursor(self.uri, None, None)
+        s.begin_transaction()
+        c.set_key(key)
+        c.search_near()
+        c.close()
+        s.rollback_transaction()
+        s.close()
+
+    def test_empty_reconstructed_page(self):
+        self.session.create(self.uri, "key_format=S,value_format=S,block_manager=disagg")
+        value = "a" * 20
+
+        # Populate the leaf, delete every key, and checkpoint with the oldest
+        # timestamp still behind the delete. The tombstones are retained and
+        # written into the leaf's base image.
+        cursor = self.session.open_cursor(self.uri, None, None)
+        for i in range(self.nitems):
+            self.session.begin_transaction()
+            cursor[str(i)] = value
+            self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(5)}')
+        for i in range(self.nitems):
+            self.session.begin_transaction()
+            cursor.set_key(str(i))
+            cursor.remove()
+            self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(10)}')
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10))
+        self.session.checkpoint()
+        self.evict(str(0))
+
+        # Add and then remove a throwaway key, checkpointing each change so the
+        # page carries leaf deltas on top of the tombstone-bearing base image:
+        # reconstructing it now has to run the base+delta merge. The throwaway key
+        # nets out to nothing, and the oldest timestamp is still behind every
+        # delete so nothing is dropped at write time.
+        self.session.begin_transaction()
+        cursor['zzz'] = value
+        self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(12)}')
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(12))
+        self.session.checkpoint()
+        self.assertGreaterEqual(self.rstat(stat.dsrc.rec_page_delta_leaf), 1)
+        self.session.begin_transaction()
+        cursor.set_key('zzz')
+        cursor.remove()
+        self.session.commit_transaction(f'commit_timestamp={self.timestamp_str(14)}')
+        self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(14))
+        self.session.checkpoint()
+        self.evict(str(0))
+
+        # Make every delete globally visible, then read the page back. The read
+        # rebuilds it from the base image and deltas; every key is dropped and the
+        # merge yields an empty leaf.
+        self.conn.set_timestamp('oldest_timestamp=' + self.timestamp_str(20) +
+                                ',stable_timestamp=' + self.timestamp_str(20))
+
+        cursor.close()
+        cursor = self.session.open_cursor(self.uri, None, None)
+
+        # Forward and backward scans see nothing.
+        self.assertEqual(cursor.next(), wiredtiger.WT_NOTFOUND)
+        self.assertEqual(cursor.prev(), wiredtiger.WT_NOTFOUND)
+
+        # A point search for any prior key returns not-found rather than crashing.
+        for i in range(self.nitems):
+            cursor.set_key(str(i))
+            self.assertEqual(cursor.search(), wiredtiger.WT_NOTFOUND)
+        cursor.close()
+
+        # The empty reconstructed page verifies and checkpoints cleanly.
+        self.session.verify(self.uri, None)
+        self.session.checkpoint()


### PR DESCRIPTION
## Summary

When rebuilding a disaggregated leaf page from its base image + deltas, skip emitting any key whose stop is globally visible, instead of materializing an obsolete cell. This removes wasted work and eliminates the race that caused the WT-18087 panic. Fixes WT-18087; implements WT-18162 (re-land of the reverted #14286).

## Problem

`__wti_page_merge_deltas_with_base_image_leaf` reconstructs a page by packing each surviving base/delta value into a new image. Before packing, `__time_window_clear_obsolete` normalized obsolete windows, including clearing a globally visible stop (WT-17577). That clearing was a two-step check — clear the start if globally visible, then the stop if globally visible — and the two `__wt_txn_visible_all` checks each sample the global visibility state (`oldest_id`, pinned timestamp) independently. A thread preempted between them can observe the state advance: the start is judged not-yet-visible (kept), then the stop is judged visible (zeroed), producing `start_ts > stop_ts = 0`, which `__wt_time_value_validate` rejects when the cell is packed, panicking on diagnostic builds. WT-18087 captured a core where a valid on-disk `start(ts=3,txn=24648)/stop(ts=4,txn=34647)` had become `start(3,24648)/stop(0,0)` in memory.

## Fix

A key whose stop is globally visible is a globally visible delete that no reader can see, and reconciliation already omits such pairs when it writes a page. So in the merge loop, when `__wt_txn_tw_stop_visible_all()` holds, skip emitting the key/value entirely (base and kept-delta paths). Dropping a cell only lowers the page's aggregate, so `child <= parent` still holds, and it removes the obsolete stop that WT-17577 normalized. `__time_window_clear_obsolete` is reduced to clearing a globally visible start for the values that are kept.

### Empty-value cells

Only a real value cell carries a stop. An empty-value cell (a key with no value cell — a zero-length value with an empty time window) is never a delete, and for the last entry on a page its unpacked value still holds the previous entry's window. The skip decision is therefore guarded with the empty-value flag so it never tests that stale/foreign window and drops a live key. An earlier version of this change omitted that guard and dropped live empty-value keys, which showed up as a mirror data mismatch in `format-stress-test-disagg-switch` (a live key present in the base mirror but missing from the disaggregated mirror).

### Empty reconstructed page

When every key on a page is dropped the merge yields a leaf image with no entries:
- Only set the mutually-exclusive `WT_PAGE_EMPTY_V_ALL`/`WT_PAGE_EMPTY_V_NONE` flags when the page has entries, so an empty reconstructed page does not fail verification with an invalid flags combination (`__wt_verify_dsk_image`: "invalid flags combination: 0x6").
- Allow an empty leaf in `__wti_delete_page_instantiate` when leaf page deltas are enabled (instantiating it is a no-op), rather than asserting every leaf has entries.

## Testing

- **`test_page_delta_merge_empty_value.cpp`** (Catch2): builds a base image with a value cell whose stop is globally visible followed by an empty-value last cell, plus a delta, then calls the merge directly and asserts the empty-value last key is not dropped (the rebuilt image has one entry). Fails without the empty-value guard (zero entries), passes with it.
- **`test_layered_delta17.py`**: drives a page to an empty reconstructed image and checks that scans, point searches, `verify`, and `checkpoint` all handle it. Aborts without the empty-page flag fix, passes with it.
- Full `layered_delta` Python suite passes.

## Notes

- This is the shared history store, so dropping here is effectively early HS pruning on the read path; it is safe because a globally visible delete is invisible to every reader, and reconciliation would drop it on the next write regardless.
