### PR TITLE
WT-18169 Fix TSAN data race on checkpoint_quit/timestamp_quit flags in format_disagg

### DIFF
--- a/test/format/checkpoint.c
+++ b/test/format/checkpoint.c
@@ -85,7 +85,8 @@ checkpoint(void *arg)
     if (g.disagg_storage_config)
         named_checkpoints = false;
 
-    for (secs = mmrand(&g.extra_rnd, 1, 10); !g.workers_finished && !g.checkpoint_quit;) {
+    for (secs = mmrand(&g.extra_rnd, 1, 10);
+      !g.workers_finished && !__wt_atomic_load_bool_v_relaxed(&g.checkpoint_quit);) {
         if (secs > 0) {
             __wt_sleep(1, 0);
             --secs;

--- a/test/format/format_disagg.c
+++ b/test/format/format_disagg.c
@@ -267,7 +267,7 @@ disagg_async_stepdown(wt_thread_t *checkpoint_tid, wt_thread_t *timestamp_tid)
      * notification could land stable at the wrong boundary.
      */
     if (g.checkpoint_config == CHECKPOINT_ON) {
-        g.checkpoint_quit = true;
+        __wt_atomic_store_bool_v_relaxed(&g.checkpoint_quit, true);
         testutil_check(__wt_thread_join(NULL, checkpoint_tid));
     }
 
@@ -276,7 +276,7 @@ disagg_async_stepdown(wt_thread_t *checkpoint_tid, wt_thread_t *timestamp_tid)
      * after we pin it below.
      */
     if (g.transaction_timestamps_config) {
-        g.timestamp_quit = true;
+        __wt_atomic_store_bool_v_relaxed(&g.timestamp_quit, true);
         testutil_check(__wt_thread_join(NULL, timestamp_tid));
     }
 
@@ -320,8 +320,8 @@ disagg_async_stepdown(wt_thread_t *checkpoint_tid, wt_thread_t *timestamp_tid)
      * so that disagg_switch_roles() can use it for the step-down checkpoint after operations()
      * returns.
      */
-    g.checkpoint_quit = false;
-    g.timestamp_quit = false;
+    __wt_atomic_store_bool_v_relaxed(&g.checkpoint_quit, false);
+    __wt_atomic_store_bool_v_relaxed(&g.timestamp_quit, false);
 
     wt_wrap_close_session(session);
 }

--- a/test/format/format_timestamp.c
+++ b/test/format/format_timestamp.c
@@ -221,7 +221,7 @@ timestamp(void *arg)
      * rollback errors, and we don't have the luxury of giving up on an operation that has rolled
      * back.
      */
-    while (!g.workers_finished && !g.timestamp_quit) {
+    while (!g.workers_finished && !__wt_atomic_load_bool_v_relaxed(&g.timestamp_quit)) {
         if (!GV(RUNS_PREDICTABLE_REPLAY)) {
             /*
              * Under precise checkpoint, eviction can only write pages whose updates are at or below


### PR DESCRIPTION
### Summary

- TSAN flagged a data race between disagg_async_stepdown() writing g.checkpoint_quit (format_disagg.c) and checkpoint() reading it (checkpoint.c). Both g.checkpoint_quit and g.timestamp_quit are volatile bool cross-thread stop signals, but volatile alone doesn't give TSAN a recognized synchronized access, so plain reads/writes are flagged even though the intent is a simple relaxed signal.
- Switch all reads/writes of these two flags to the existing __wt_atomic_load_bool_v_relaxed/__wt_atomic_store_bool_v_relaxed helpers (src/include/tsan_suppress.h), which wrap compiler atomic builtins TSAN recognizes, using relaxed ordering since these flags don't need to synchronize any other shared state.

### Changes

- test/format/checkpoint.c: load g.checkpoint_quit atomically in the checkpoint() loop condition.
- test/format/format_timestamp.c: load g.timestamp_quit atomically in the timestamp() loop condition.
- test/format/format_disagg.c: store g.checkpoint_quit/g.timestamp_quit atomically at all four write sites in disagg_async_stepdown() (signaling quit before joining each thread, and resetting both flags to false afterward).

Test plan

- Build with -DCMAKE_BUILD_TYPE=TSan and run the disaggregated-storage format test to confirm the race no longer reproduces under TSAN.
- Run standard test/format disagg configs to confirm no behavioral change (checkpoint/timestamp threads still stop correctly on stepdown).