### PR TITLE
WT-16348 Possible integer overflow in test_disagg_failover_perf.cpp

### DIFF
--- a/test/cppsuite/tests/test_disagg_failover_perf.cpp
+++ b/test/cppsuite/tests/test_disagg_failover_perf.cpp
@@ -580,7 +580,8 @@ main(int argc, char *argv[])
 
     /* Optionally scan created tables to warm the WT cache. */
     if (opt.warm_cache_pct > 0)
-        cache_warming(opt.collection_count * opt.key_count * opt.warm_cache_pct / 100);
+        cache_warming(
+          static_cast<int64_t>(opt.collection_count) * opt.key_count * opt.warm_cache_pct / 100);
 
     crud_operations();
 


### PR DESCRIPTION
Cast `opt.collection_count` to `int64_t` before the multiplication chain in the `warm_cache_pct > 0` branch of `test_disagg_failover_perf.cpp` main, so the product widens in 64-bit instead of overflowing 32-bit `int`. Fixes Coverity CID 184231 (`OVERFLOW_BEFORE_WIDEN`).