### PR TITLE
WT-18175 Use mongo's uv_sync.sh instead of the removed poetry_sync.sh

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -298,7 +298,7 @@ functions:
         ${PREPARE_PATH}
         virtualenv -p python3.13 venv
         source venv/bin/activate
-        buildscripts/poetry_sync.sh
+        buildscripts/uv_sync.sh
 
         # Without this variable the bazel execution might be stalled for many hours.
         # This is because evergreen is using a go Cmd.Wait and waiting for some file descriptors


### PR DESCRIPTION
The "compile mongodb" function runs `buildscripts/poetry_sync.sh` in the cloned mongo repo, but [SERVER-126500](https://jira.mongodb.org/browse/SERVER-126500) deleted that script from master when it moved from Poetry to uv, so the task exits 127 before bazel runs.

Fix: call `buildscripts/uv_sync.sh`, mongo's replacement, which needs no other changes because the function already activates a virtualenv immediately before it.

Both `ubuntu2004-perf-tests` and `amazon2023-perf-tests-arm64` schedule `many-collection-test` via the shared `perf-tasks-template` anchor, so both are currently red on develop.

Verified green:
- [amazon2023-perf-tests-arm64](https://spruce.corp.mongodb.com/version/6a6582786a47940007c6f36a)
- [ubuntu2004-perf-tests](https://spruce.corp.mongodb.com/version/6a6589ec980046000798b444)