### PR TITLE
WT-18176 Require the stable disaggregated schema epoch to be set before publishing

### DIFF
--- a/src/schema/schema_publish.c
+++ b/src/schema/schema_publish.c
@@ -41,7 +41,10 @@ __schema_publish_disagg_schema_epoch(
     locked = true;
 
     stable_schema_epoch = __wt_get_stable_disaggregated_schema_epoch(session);
-    if (stable_schema_epoch != WT_SCHEMA_EPOCH_NONE && schema_epoch <= stable_schema_epoch)
+    if (stable_schema_epoch == WT_SCHEMA_EPOCH_NONE)
+        WT_ERR_PANIC(
+          session, EINVAL, "publish requires the stable disaggregated schema epoch to be set");
+    if (schema_epoch <= stable_schema_epoch)
         WT_ERR_MSG(session, EINVAL,
           "Cannot publish with a schema epoch that is older than the stable disaggregated schema "
           "epoch %" PRIu64 " %s",

--- a/test/suite/helpers/helper_disagg.py
+++ b/test/suite/helpers/helper_disagg.py
@@ -840,6 +840,12 @@ class DisaggSchemaEpochMixin:
         session = conn.open_session('')
         return conn, session
 
+    def open_follower_epoch(self, epoch=1):
+        """Open a follower already in epoch world (stable schema epoch set), ready to publish."""
+        conn, session = self.open_follower()
+        self.set_stable_epoch(epoch, conn)
+        return conn, session
+
 class DisaggSizeTestMixin:
     def conn_extensions(self, extlist):
         extlist.skip_if_missing = True

--- a/test/suite/test_layered_schema07.py
+++ b/test/suite/test_layered_schema07.py
@@ -371,6 +371,7 @@ class test_layered_schema07(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
         published; one checkpoint after drop-publish removes the table.
         """
         # Create and publish the table so that it gets included in the checkpoint.
+        self.set_stable_epoch(1)
         self.session.create(self.uri, 'key_format=i,value_format=S')
         self.publish(self.uri, 10)
         self.set_stable_epoch(10)
@@ -428,10 +429,11 @@ class test_layered_schema07(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
         """
         Calling publish with a non-table URI returns EINVAL.
         """
+        self.set_stable_epoch(1)
         self.assertRaisesWithMessage(wiredtiger.WiredTigerError,
             lambda: self.session.publish(
                 f'file:{self.test_name}_err_uri',
-                'disaggregated=(schema_epoch=1)'),
+                'disaggregated=(schema_epoch=10)'),
             '/only supported for table: and layered:/')
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(1) +
                                 ',oldest_timestamp=' + self.timestamp_str(1))
@@ -625,6 +627,7 @@ class test_layered_schema07(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
         """
         Test the publish statistics.
         """
+        self.set_stable_epoch(1)
         self.session.create(self.uri, 'key_format=i,value_format=S')
 
         # No schema_epoch in config: no-op, returns success.

--- a/test/suite/test_layered_schema10.py
+++ b/test/suite/test_layered_schema10.py
@@ -95,7 +95,7 @@ class test_layered_schema10(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
         """A table created and published on a follower is accessible after a role swap."""
         self.setup_leader_with_epoch()
 
-        conn_follow, session_follow = self.open_follower()
+        conn_follow, session_follow = self.open_follower_epoch()
 
         session_follow.create(self.uri, self.table_config)
         self.publish(self.uri, 20, session_follow)
@@ -133,7 +133,7 @@ class test_layered_schema10(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
         """A table created then dropped on a follower must not exist after a role swap."""
         self.setup_leader_with_epoch()
 
-        conn_follow, session_follow = self.open_follower()
+        conn_follow, session_follow = self.open_follower_epoch()
 
         session_follow.create(self.uri, self.table_config)
         self.publish(self.uri, 20, session_follow)
@@ -162,7 +162,7 @@ class test_layered_schema10(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
         """
         self.setup_leader_with_epoch()
 
-        conn_follow, session_follow = self.open_follower()
+        conn_follow, session_follow = self.open_follower_epoch()
 
         session_follow.create(self.uri, self.table_config)
         self.publish(self.uri, 20, session_follow)
@@ -202,7 +202,7 @@ class test_layered_schema10(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
         """Tables published at different epochs are flushed to shared metadata independently."""
         self.setup_leader_with_epoch()
 
-        conn_follow, session_follow = self.open_follower()
+        conn_follow, session_follow = self.open_follower_epoch()
 
         session_follow.create(self.uri, self.table_config)
         session_follow.create(self.uri2, self.table_config)
@@ -247,7 +247,7 @@ class test_layered_schema10(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
         self.set_stable_epoch(15)
         self.leader_checkpoint(2)
 
-        conn_follow, session_follow = self.open_follower()
+        conn_follow, session_follow = self.open_follower_epoch()
 
         # Drop uri on the follower and publish the drop at epoch 25.
         # The REMOVE queue entry captures the current metadata values before deletion.
@@ -366,7 +366,7 @@ class test_layered_schema10(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
         """
         self.setup_leader_with_epoch()
 
-        conn_follow, session_follow = self.open_follower()
+        conn_follow, session_follow = self.open_follower_epoch()
 
         session_follow.create(self.uri, self.table_config)
         self.publish(self.uri, 20, session_follow)

--- a/test/suite/test_layered_schema11.py
+++ b/test/suite/test_layered_schema11.py
@@ -58,13 +58,14 @@ class test_layered_schema11(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
         the shared metadata still contains it and schema epochs are in use.
         """
         # Step 1: Leader creates the table and checkpoints.
+        self.set_stable_epoch(1)
         self.session.create(self.uri, self.table_config)
         self.publish(self.uri, 10)
         self.set_stable_epoch(10)
         self.leader_checkpoint(1)
 
         # Step 2: Follower picks up the checkpoint.
-        conn_follow, session_follow = self.open_follower()
+        conn_follow, session_follow = self.open_follower_epoch()
         self.assertTrue(self.uri_in_local_metadata(conn_follow, self.uri))
 
         # Step 3: Both the follower and the leader drop the table and publish the drop at
@@ -104,6 +105,7 @@ class test_layered_schema11(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
     def test_no_recreate_dropped_table_isolation(self):
         """Dropping one table must not prevent pickup of a second table that still exists."""
         # Step 1: Leader creates both tables and checkpoints at epoch 10.
+        self.set_stable_epoch(1)
         self.session.create(self.uri, self.table_config)
         self.publish(self.uri, 10)
         self.session.create(self.uri2, self.table_config)
@@ -112,7 +114,7 @@ class test_layered_schema11(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
         self.leader_checkpoint(1)
 
         # Step 2: Follower picks up the checkpoint; both tables are in local metadata.
-        conn_follow, session_follow = self.open_follower()
+        conn_follow, session_follow = self.open_follower_epoch()
         self.assertTrue(self.uri_in_local_metadata(conn_follow, self.uri))
         self.assertTrue(self.uri_in_local_metadata(conn_follow, self.uri2))
 
@@ -154,13 +156,14 @@ class test_layered_schema11(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
         REMOVE).
         """
         # Step 1: Leader creates uri and checkpoints at epoch 10.
+        self.set_stable_epoch(1)
         self.session.create(self.uri, self.table_config)
         self.publish(self.uri, 10)
         self.set_stable_epoch(10)
         self.leader_checkpoint(1)
 
         # Step 2: Follower picks up; uri is in local metadata.
-        conn_follow, session_follow = self.open_follower()
+        conn_follow, session_follow = self.open_follower_epoch()
         self.assertTrue(self.uri_in_local_metadata(conn_follow, self.uri))
 
         # Step 3: Both follower and leader drop uri at epoch 25 (REMOVE(25) queued), then
@@ -197,6 +200,7 @@ class test_layered_schema11(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
         Create and publish uri on the leader, checkpoint at epoch 10, and open a follower
         that has picked up the checkpoint.
         """
+        self.set_stable_epoch(1)
         self.session.create(self.uri, self.table_config)
         self.publish(self.uri, 10)
         self.set_stable_epoch(10)
@@ -260,6 +264,7 @@ class test_layered_schema11(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
         self.assertFalse(self.uri_in_local_metadata(conn_follow, self.uri))
 
         # The remove is still unpublished: publishing it with a real epoch succeeds.
+        self.set_stable_epoch(1, conn_follow)
         self.publish(self.uri, 25, session_follow)
 
         session_follow.close()

--- a/test/suite/test_layered_schema17.py
+++ b/test/suite/test_layered_schema17.py
@@ -70,6 +70,7 @@ class test_layered_schema17(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
 
     def setup_leader_with_table(self):
         """Seed the shared storage with a checkpoint at schema epoch 20 containing uri."""
+        self.set_stable_epoch(1)
         self.session.create(self.uri, self.table_config)
         self.publish(self.uri, 20)
         self.set_stable_epoch(20)
@@ -82,6 +83,8 @@ class test_layered_schema17(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
         """
         conn_follow, session_follow = self.open_follower()
         conn_follow.reconfigure('disaggregated=(strict_checkpoint_metadata=true)')
+        # Enter epoch world on the follower so it can publish its own schema operations.
+        self.set_stable_epoch(1, conn_follow)
         return conn_follow, session_follow
 
     def leader_checkpoint_at_epoch(self, epoch, stable_ts):

--- a/test/suite/test_layered_schema18.py
+++ b/test/suite/test_layered_schema18.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# Publishing enters the disaggregated schema-epoch protocol, which is only meaningful once the
+# stable schema epoch is set (epoch world). Publishing with no epoch set is a fatal protocol
+# violation: it panics.
+
+import os
+import wttest
+from helper_disagg import disagg_test_class, gen_disagg_storages, DisaggSchemaEpochMixin
+from suite_subprocess import suite_subprocess
+from wtscenario import make_scenarios
+
+@disagg_test_class
+class test_layered_schema18(wttest.WiredTigerTestCase, suite_subprocess, DisaggSchemaEpochMixin):
+    test_name = __qualname__
+    conn_config = 'disaggregated=(role="leader",lose_all_my_data=true)'
+
+    disagg_storages = gen_disagg_storages(disagg_only=True)
+    scenarios = make_scenarios(disagg_storages)
+
+    def subprocess_publish_without_epoch_panics(self):
+        """Subprocess body: publishing before the stable schema epoch is set panics."""
+        self.session.create('layered:before', 'key_format=i,value_format=S')
+        self.publish('layered:before', 10)  # Expected to panic.
+
+    def test_publish_without_epoch_panics(self):
+        """Publishing with no stable schema epoch set is a fatal protocol violation."""
+        [returncode, home] = self.run_subprocess_function(
+            'SUBPROCESS_publish_without_epoch_panics',
+            f'{self.test_name}.{self.test_name}.subprocess_publish_without_epoch_panics',
+            silent=True)
+        self.assertNotEqual(returncode, 0)
+        self.check_file_contains(os.path.join(home, 'stderr.txt'),
+            'publish requires the stable disaggregated schema epoch to be set')
+
+    def test_publish_with_epoch_succeeds(self):
+        """With the stable epoch set first, create then publish is accepted."""
+        self.set_stable_epoch(5)
+        self.session.create('layered:after', 'key_format=i,value_format=S')
+        self.publish('layered:after', 10)


### PR DESCRIPTION
In disaggregated storage, tables are meant to be created only after the stable schema epoch is set (“epoch world”), so they go through the publish protocol; a table created before any epoch is set stays in the legacy “no-epoch world” and is never held for publication. Nothing stopped a caller from mixing the two — creating a table before setting the epoch and then publishing it, which silently bypassed the protocol. WT_SESSION::publish now panics when the stable disaggregated schema epoch is unset, turning that ordering mistake into an immediate, unrecoverable error; tests that bootstrapped by publishing before setting the epoch are reordered to set it first.