### PR TITLE
WT-17594 Track fast-truncated pages that haven't been reconciled during verify

### DIFF
--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1800,7 +1800,7 @@ __verify_page_discard(WT_SESSION_IMPL *session, WT_BM *bm)
     checkpoint_lsn = __wt_atomic_load_uint64_acquire(
       &S2C(session)->disaggregated_storage.last_checkpoint_meta_lsn);
     if (checkpoint_lsn == WT_DISAGG_LSN_NONE)
-        /* FIXME WT-18186: should probably be page log LSN max. */
+        /* FIXME-WT-18186: should probably be page log LSN max. */
         checkpoint_lsn = INT_MAX;
 
     /*

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1707,67 +1707,116 @@ __verify_compare_page_id_lists(WT_SESSION_IMPL *session, uint64_t *btree_ids, si
 }
 
 /*
+ * WT_VERIFY_PAGE_ID_LIST --
+ *     A list of page IDs found walking the btree.
+ */
+typedef struct {
+    uint64_t *ids;
+    size_t count;
+    size_t capacity_in_bytes;
+} WT_VERIFY_PAGE_ID_LIST;
+
+/*
+ * __verify_page_id_append --
+ *     Append a page ID to the given list, growing the list if necessary.
+ */
+static int
+__verify_page_id_append(WT_SESSION_IMPL *session, WT_VERIFY_PAGE_ID_LIST *list, uint64_t page_id)
+{
+    if (list->count == (list->capacity_in_bytes / sizeof(*list->ids)))
+        WT_RET(
+          __wt_realloc_def(session, &list->capacity_in_bytes, list->count * 2 + 10, &list->ids));
+
+    list->ids[list->count++] = page_id;
+    return (0);
+}
+
+/*
+ * __verify_page_discard_skip --
+ *     Tree walk callback. Skip fast-truncated pages, but record their page IDs.
+ */
+static int
+__verify_page_discard_skip(
+  WT_SESSION_IMPL *session, WT_REF *ref, void *context, bool visible_all, bool *skipp)
+{
+    WT_UNUSED(visible_all);
+
+    *skipp = false;
+    if (WT_REF_GET_STATE(ref) != WT_REF_DELETED)
+        return (0);
+    *skipp = true;
+
+    WT_ADDR_COPY addr;
+    if (!__wt_ref_addr_copy(session, ref, &addr))
+        /* Block already freed, no need to record it. */
+        return (0);
+
+    const uint8_t *p = addr.addr;
+    WT_BLOCK_DISAGG_ADDRESS_COOKIE cookie;
+    WT_RET(__wt_block_disagg_addr_unpack(session, &p, addr.size, &cookie));
+
+    WT_VERIFY_PAGE_ID_LIST *list = context;
+    return (__verify_page_id_append(session, list, cookie.page_id));
+}
+
+/*
  * __verify_page_discard --
  *     Verify all live pages in disagg mode, ensuring that no pages were incorrectly discarded.
  */
 static int
 __verify_page_discard(WT_SESSION_IMPL *session, WT_BM *bm)
 {
-    WT_REF *ref = NULL;
-    uint64_t num_pages_found_in_btree = 0;
-    size_t capacity_in_bytes = 0;
-    uint64_t *page_ids = NULL;
-    int ret = 0;
+    WT_DECL_ITEM(item);
+    WT_DECL_RET;
+    WT_REF *ref;
+    WT_VERIFY_PAGE_ID_LIST list;
+    size_t num_pages_found_in_pali;
+    uint64_t checkpoint_lsn;
+
+    ref = NULL;
+    WT_CLEAR(list);
 
     /*
      * Walk the btree to retrieve the page IDs for all pages in the btree at the loaded checkpoint
-     * time.
+     * time. Fast-truncated pages are collected by the skip function: their blocks are not discarded
+     * until their parent is reconciled, so PALI still holds them.
      */
-    while ((ret = (__wt_tree_walk(session, &ref, WT_READ_VISIBLE_ALL | WT_READ_WONT_NEED))) == 0 &&
+    while ((ret = (__wt_tree_walk_custom_skip(session, &ref, __verify_page_discard_skip, &list,
+              WT_READ_SEE_DELETED | WT_READ_VISIBLE_ALL | WT_READ_WONT_NEED))) == 0 &&
       ref != NULL) {
         WT_PAGE *page = ref->page;
 
-        /*
-         * Use dynamically allocated array to track page IDs as we don't know the number of pages
-         *  here. Check if the array size needs to grow.
-         */
-        if (num_pages_found_in_btree == (capacity_in_bytes / sizeof(*page_ids))) {
-            uint64_t new_capacity_count = num_pages_found_in_btree * 2 + 10;
-            WT_RET(__wt_realloc_def(session, &capacity_in_bytes, new_capacity_count, &page_ids));
-        }
-
         if (page != NULL) {
             WT_ASSERT(session, page->disagg_info != NULL);
-            page_ids[num_pages_found_in_btree++] = page->disagg_info->block_meta.page_id;
+            /* Pages created in memory and never reconciled have no backing block. */
+            if (page->disagg_info->block_meta.page_id != WT_BLOCK_INVALID_PAGE_ID)
+                WT_ERR(
+                  __verify_page_id_append(session, &list, page->disagg_info->block_meta.page_id));
         }
     }
 
-    WT_RET_NOTFOUND_OK(ret);
+    WT_ERR_NOTFOUND_OK(ret, false);
+
+    checkpoint_lsn = __wt_atomic_load_uint64_acquire(
+      &S2C(session)->disaggregated_storage.last_checkpoint_meta_lsn);
+    if (checkpoint_lsn == WT_DISAGG_LSN_NONE)
+        checkpoint_lsn = WT_PAGE_LOG_LSN_MAX;
 
     /*
-     * Track the number of pages found in the PALI walk. This value is tracked separately because
-     * WT_ITEM->size must match the allocated memory, while the actual number of pages found may be
-     * smaller than that allocation.
+     * Get page IDs from PALI. The number of pages is tracked separately because WT_ITEM->size must
+     * match the allocated memory, while the actual number of pages found may be smaller than that
+     * allocation.
      */
-    size_t num_pages_found_in_pali = 0;
-    uint64_t checkpoint_lsn;
-    checkpoint_lsn =
-      S2C(session)->disaggregated_storage.last_checkpoint_meta_lsn == WT_DISAGG_LSN_NONE ?
-      INT_MAX :
-      S2C(session)->disaggregated_storage.last_checkpoint_meta_lsn;
-
-    WT_DECL_ITEM(item);
-    WT_RET(__wt_scr_alloc(session, num_pages_found_in_pali, &item));
-
+    num_pages_found_in_pali = 0;
+    WT_ERR(__wt_scr_alloc(session, 0, &item));
     WT_ASSERT(session, bm->get_page_ids != NULL);
-    /* Get page IDs from PALI. */
     WT_ERR(bm->get_page_ids(bm, session, item, &num_pages_found_in_pali, checkpoint_lsn));
 
-    if ((uint64_t)num_pages_found_in_pali != num_pages_found_in_btree) {
+    if ((uint64_t)num_pages_found_in_pali != list.count) {
         __wt_verbose_error(session, WT_VERB_VERIFY,
           "Mismatch in the number of page IDs found from PALI and btree walk: PALI %" PRIu64
           " Btree walk %" PRIu64,
-          (uint64_t)num_pages_found_in_pali, num_pages_found_in_btree);
+          (uint64_t)num_pages_found_in_pali, list.count);
         WT_TRET(EINVAL);
     }
 
@@ -1775,16 +1824,15 @@ __verify_page_discard(WT_SESSION_IMPL *session, WT_BM *bm)
      * Sort the btree walk array by page ID in ascending order to match the order used in the PALI
      * walk.
      */
-    __wt_qsort(page_ids, num_pages_found_in_btree, sizeof(uint64_t), __verify_compare_page_id);
+    __wt_qsort(list.ids, list.count, sizeof(uint64_t), __verify_compare_page_id);
 
     WT_ERR_MSG_CHK(session,
-      __verify_compare_page_id_lists(session, page_ids, (size_t)num_pages_found_in_btree,
+      __verify_compare_page_id_lists(session, list.ids, (size_t)list.count,
         (const uint64_t *)item->data, num_pages_found_in_pali),
       "Page discard verification found mismatches");
 
 err:
-
-    __wt_free(session, page_ids);
+    __wt_free(session, list.ids);
     __wt_scr_free(session, &item);
 
     return (ret);

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1827,7 +1827,7 @@ __verify_page_discard(WT_SESSION_IMPL *session, WT_BM *bm)
     __wt_qsort(list.ids, list.count, sizeof(uint64_t), __verify_compare_page_id);
 
     WT_ERR_MSG_CHK(session,
-      __verify_compare_page_id_lists(session, list.ids, (size_t)list.count,
+      __verify_compare_page_id_lists(session, list.ids, list.count,
         (const uint64_t *)item->data, num_pages_found_in_pali),
       "Page discard verification found mismatches");
 

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1800,7 +1800,8 @@ __verify_page_discard(WT_SESSION_IMPL *session, WT_BM *bm)
     checkpoint_lsn = __wt_atomic_load_uint64_acquire(
       &S2C(session)->disaggregated_storage.last_checkpoint_meta_lsn);
     if (checkpoint_lsn == WT_DISAGG_LSN_NONE)
-        checkpoint_lsn = WT_PAGE_LOG_LSN_MAX;
+        /* FIXME WT-18186: should probably be page log LSN max. */
+        checkpoint_lsn = INT_MAX;
 
     /*
      * Get page IDs from PALI. The number of pages is tracked separately because WT_ITEM->size must

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1827,8 +1827,8 @@ __verify_page_discard(WT_SESSION_IMPL *session, WT_BM *bm)
     __wt_qsort(list.ids, list.count, sizeof(uint64_t), __verify_compare_page_id);
 
     WT_ERR_MSG_CHK(session,
-      __verify_compare_page_id_lists(session, list.ids, list.count,
-        (const uint64_t *)item->data, num_pages_found_in_pali),
+      __verify_compare_page_id_lists(
+        session, list.ids, list.count, (const uint64_t *)item->data, num_pages_found_in_pali),
       "Page discard verification found mismatches");
 
 err:

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1815,7 +1815,7 @@ __verify_page_discard(WT_SESSION_IMPL *session, WT_BM *bm)
     if ((uint64_t)num_pages_found_in_pali != list.count) {
         __wt_verbose_error(session, WT_VERB_VERIFY,
           "Mismatch in the number of page IDs found from PALI and btree walk: PALI %" PRIu64
-          " Btree walk %" PRIu64,
+          " Btree walk %" WT_SIZET_FMT,
           (uint64_t)num_pages_found_in_pali, list.count);
         WT_TRET(EINVAL);
     }

--- a/test/suite/test_disagg_fast_truncate02.py
+++ b/test/suite/test_disagg_fast_truncate02.py
@@ -133,8 +133,8 @@ class test_disagg_fast_truncate02(wttest.WiredTigerTestCase):
         self.session.checkpoint()
 
         # Once the truncate is globally visible, tree walks skip the deleted refs, but their blocks
-        # remain allocated until the parent is reconciled. Verify's page-discard check must still
-        # count these pages.
+        # remain allocated until the parent is reconciled. The page-discard check in verify must
+        # still count these pages.
         ts = self.timestamp_str(self.visible_ts)
         self.conn.set_timestamp(f"oldest_timestamp={ts},stable_timestamp={ts}")
 

--- a/test/suite/test_disagg_fast_truncate02.py
+++ b/test/suite/test_disagg_fast_truncate02.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wttest
+from helper_disagg import disagg_test_class, gen_disagg_storages
+from wiredtiger import stat
+from wtscenario import make_scenarios
+
+
+@disagg_test_class
+class test_disagg_fast_truncate02(wttest.WiredTigerTestCase):
+    """
+    Check that verify accounts for fast-truncated pages that haven't been discarded yet.
+
+    If checkpoint runs before a fast-truncate is globally visible, the parent page keeps proxy cells
+    for the truncated leaf pages, and they're not discarded until the parent is reconciled.
+
+    Once the truncate becomes globally visible, tree walks skip the deleted refs, so verify's page
+    discard check must collect the page IDs from the refs' addresses or it reports pages missing
+    from the btree that PALI correctly considers live.
+
+    Verifying the tree contents instantiates deleted pages, which hides the problem. So we use a
+    small cache and aggressive eviction, and hopefully the instantiated pages revert to deleted refs
+    before the page-discard check walks them.
+
+    """
+
+    uri = "table:test_disagg_fast_truncate02"
+    nrows = 20000
+    value = "a" * 100
+    trunc_start = 1000
+    trunc_stop = 19000
+
+    truncate_ts = 20
+    visible_ts = 30
+
+    disagg_storages = gen_disagg_storages(disagg_only=True)
+    scenarios = make_scenarios(disagg_storages)
+
+    conn_config = 'cache_size=2MB,statistics=(all),debug_mode=(eviction=true),disaggregated=(role="leader"),'
+
+    def evict_keys(self, keys):
+        """Evict the pages holding the given keys."""
+        with (
+            wttest.open_cursor(
+                self.session, self.uri, config="debug=(release_evict)"
+            ) as evict_cursor,
+            self.transaction(rollback=True),
+        ):
+            for key in keys:
+                evict_cursor.set_key(key)
+                evict_cursor.search()
+                evict_cursor.reset()
+
+    def populate(self):
+        """Create the table, load it, checkpoint, and evict all leaf pages to disk."""
+        self.conn.set_timestamp("oldest_timestamp=" + self.timestamp_str(1))
+
+        # Small pages spread data over many leaf pages, so the truncate fully covers some.
+        self.session.create(
+            self.uri,
+            "key_format=i,value_format=S,block_manager=disagg,log=(enabled=false),"
+            "allocation_size=512,leaf_page_max=512,internal_page_max=512",
+        )
+        with (
+            wttest.open_cursor(self.session, self.uri) as cursor,
+            self.transaction(commit_timestamp=10),
+        ):
+            for key in range(1, self.nrows + 1):
+                cursor[key] = self.value
+
+        self.conn.set_timestamp("stable_timestamp=" + self.timestamp_str(10))
+        self.session.checkpoint()
+
+        # On-disk leaf pages are eligible for fast truncate.
+        self.evict_keys(range(1, self.nrows + 1))
+
+    def fast_truncate(self, trunc_start, trunc_stop, truncate_ts):
+        """Fast-truncate the configured key range at truncate_ts."""
+        with (
+            wttest.open_cursor(self.session, self.uri) as start_cursor,
+            wttest.open_cursor(self.session, self.uri) as stop_cursor,
+            self.transaction(commit_timestamp=truncate_ts),
+        ):
+            start_cursor.set_key(trunc_start)
+            stop_cursor.set_key(trunc_stop)
+            self.session.truncate(None, start_cursor, stop_cursor, None)
+
+    def test_verify_undiscarded_fast_truncated_pages(self):
+        self.populate()
+
+        fast_delete_before = self.get_stat(stat.dsrc.rec_page_delete_fast, self.uri)
+
+        # With oldest pinned at 1 the truncate is committed but not globally visible, so the
+        # checkpoint writes proxy cells for the truncated leaf pages and their blocks aren't
+        # discarded yet in PALI.
+        self.fast_truncate(self.trunc_start, self.trunc_stop, self.truncate_ts)
+        self.assertStatGreaterSoon(
+            stat.dsrc.rec_page_delete_fast,
+            fast_delete_before,
+            self.uri,
+            msg="fast truncate did not trigger",
+        )
+
+        self.conn.set_timestamp(
+            "stable_timestamp=" + self.timestamp_str(self.truncate_ts)
+        )
+        self.session.checkpoint()
+
+        # Once the truncate is globally visible, tree walks skip the deleted refs, but their blocks
+        # remain allocated until the parent is reconciled. Verify's page-discard check must still
+        # count these pages.
+        ts = self.timestamp_str(self.visible_ts)
+        self.conn.set_timestamp(f"oldest_timestamp={ts},stable_timestamp={ts}")
+
+        self.verifyUntilSuccess(self.session, self.uri, config=None)

--- a/test/suite/test_disagg_fast_truncate02.py
+++ b/test/suite/test_disagg_fast_truncate02.py
@@ -62,7 +62,7 @@ class test_disagg_fast_truncate02(wttest.WiredTigerTestCase):
     disagg_storages = gen_disagg_storages(disagg_only=True)
     scenarios = make_scenarios(disagg_storages)
 
-    conn_config = 'cache_size=2MB,statistics=(all),debug_mode=(eviction=true),disaggregated=(role="leader"),'
+    conn_config = 'cache_size=50MB,statistics=(all),debug_mode=(eviction=true),disaggregated=(role="leader"),'
 
     def evict_keys(self, keys):
         """Evict the pages holding the given keys."""
@@ -87,6 +87,7 @@ class test_disagg_fast_truncate02(wttest.WiredTigerTestCase):
             "key_format=i,value_format=S,block_manager=disagg,log=(enabled=false),"
             "allocation_size=512,leaf_page_max=512,internal_page_max=512",
         )
+
         with (
             wttest.open_cursor(self.session, self.uri) as cursor,
             self.transaction(commit_timestamp=10),
@@ -138,4 +139,5 @@ class test_disagg_fast_truncate02(wttest.WiredTigerTestCase):
         ts = self.timestamp_str(self.visible_ts)
         self.conn.set_timestamp(f"oldest_timestamp={ts},stable_timestamp={ts}")
 
+        self.conn.reconfigure('cache_size=2MB,debug_mode=(eviction=true)')
         self.verifyUntilSuccess(self.session, self.uri)

--- a/test/suite/test_disagg_fast_truncate02.py
+++ b/test/suite/test_disagg_fast_truncate02.py
@@ -138,4 +138,4 @@ class test_disagg_fast_truncate02(wttest.WiredTigerTestCase):
         ts = self.timestamp_str(self.visible_ts)
         self.conn.set_timestamp(f"oldest_timestamp={ts},stable_timestamp={ts}")
 
-        self.verifyUntilSuccess(self.session, self.uri, config=None)
+        self.verifyUntilSuccess(self.session, self.uri)


### PR DESCRIPTION
The overall idea here is that when we fast-truncate a page, we don't actually delete any refs until we reconcile the parent page. That means we don't issue a page discard to PALI, but the tree walk knows enough to skip the cells we marked as deleted. So we add these pages to the big list of pages we're going to compare with what we get from PALI.