### PR TITLE
WT-18119 Trust zero checkpoint size in the statistics=(size) fast path

### DIFF
--- a/src/block_disagg/block_disagg_open.c
+++ b/src/block_disagg/block_disagg_open.c
@@ -165,7 +165,7 @@ __wti_block_disagg_close(WT_SESSION_IMPL *session, WT_BLOCK_DISAGG *block_disagg
  * __wt_block_disagg_ckpt_size --
  *     Return the size recorded in the most recent checkpoint for the given URIs metadata entry. For
  *     disaggregated storage there is no underlying file, so the checkpoint size in the metadata is
- *     used as the block_size. A missing metadata entry is not an error; *sizep will be zero.
+ *     used as the block_size. Return WT_NOTFOUND if the metadata entry does not exist.
  */
 int
 __wt_block_disagg_ckpt_size(WT_SESSION_IMPL *session, const char *uri, uint64_t *sizep)
@@ -175,12 +175,13 @@ __wt_block_disagg_ckpt_size(WT_SESSION_IMPL *session, const char *uri, uint64_t 
 
     fileconf = NULL;
     *sizep = 0;
+
     /* Reading checkpoint size requires the file's metadata config string, so look it up first. */
-    ret = __wt_metadata_search(session, uri, &fileconf);
-    if (ret == 0) {
-        ret = __wt_ckpt_last_size(session, fileconf, sizep);
-        __wt_free(session, fileconf);
-    }
+    WT_RET(__wt_metadata_search(session, uri, &fileconf));
+    ret = __wt_ckpt_last_size(session, fileconf, sizep);
+    __wt_free(session, fileconf);
+
+    /* An existing metadata entry without a completed checkpoint has size of zero. */
     WT_RET_NOTFOUND_OK(ret);
     return (0);
 }
@@ -200,7 +201,7 @@ __block_disagg_ckpt_size_dhandle(WT_SESSION_IMPL *session, uint64_t *sizep)
 
     uri = session->dhandle->name;
     WT_ERR(__wt_btree_shared_base_name(session, &uri, NULL, &name_buf));
-    WT_ERR(__wt_block_disagg_ckpt_size(session, uri, sizep));
+    WT_ERR_NOTFOUND_OK(__wt_block_disagg_ckpt_size(session, uri, sizep), false);
 
 err:
     __wt_scr_free(session, &name_buf);

--- a/src/cursor/cur_stat.c
+++ b/src/cursor/cur_stat.c
@@ -441,7 +441,7 @@ retry:
          */
         if (!F_ISSET(cst, WT_STAT_TYPE_TREE_WALK)) {
             uint64_t ckpt_size = 0;
-            WT_ERR(__wt_block_disagg_ckpt_size(session, stable_uri, &ckpt_size));
+            WT_ERR_NOTFOUND_OK(__wt_block_disagg_ckpt_size(session, stable_uri, &ckpt_size), false);
             cst->u.dsrc_stats.block_size += (int64_t)ckpt_size;
             goto done;
         }
@@ -526,21 +526,15 @@ __wt_curstat_size_local(
 /*
  * __wt_curstat_size_disagg --
  *     Fast-path size retrieval for a disaggregated table. There is no local file on disk, so the
- *     size comes from the last checkpoint entry in the metadata. If found, set *existp and return
- *     the size via *sizep. A missing metadata entry is not an error; *existp will be false.
+ *     size comes from the last checkpoint entry in the metadata. Return WT_NOTFOUND if the metadata
+ *     entry does not exist.
  */
 int
-__wt_curstat_size_disagg(WT_SESSION_IMPL *session, const char *uri, bool *existp, int64_t *sizep)
+__wt_curstat_size_disagg(WT_SESSION_IMPL *session, const char *uri, int64_t *sizep)
 {
-    uint64_t ckpt_size;
-
-    *existp = false;
+    uint64_t ckpt_size = 0;
     WT_RET(__wt_block_disagg_ckpt_size(session, uri, &ckpt_size));
-    if (ckpt_size > 0) {
-        *sizep = (int64_t)ckpt_size;
-        *existp = true;
-    }
-
+    *sizep = (int64_t)ckpt_size;
     return (0);
 }
 
@@ -555,13 +549,25 @@ static int
 __curstat_file_size(
   WT_SESSION_IMPL *session, const char *uri, const char *filename, bool *existp, int64_t *sizep)
 {
+    WT_DECL_RET;
+
     /* Try the local file first. */
     WT_RET(__wt_curstat_size_local(session, filename, existp, sizep));
     if (*existp)
         return (0);
 
+    if (!__wt_conn_is_disagg(session) || !WT_SUFFIX_MATCH(uri, ".wt_stable"))
+        return (0);
+
     /* No local file; check the metadata for a disagg checkpoint size. */
-    WT_RET(__wt_curstat_size_disagg(session, uri, existp, sizep));
+    ret = __wt_curstat_size_disagg(session, uri, sizep);
+
+    /* The slow path repeats the metadata lookup, so we should instead return an error. */
+    if (ret == WT_NOTFOUND)
+        return (__wt_set_return(session, ENOENT));
+
+    WT_RET(ret);
+    *existp = true;
     return (0);
 }
 

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -535,8 +535,8 @@ extern int __wt_curstat_init(WT_SESSION_IMPL *session, const char *uri, const ch
   WT_CURSOR_STAT *cst) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_curstat_open(WT_SESSION_IMPL *session, const char *uri, const char *cfg[],
   WT_CURSOR **cursorp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_curstat_size_disagg(WT_SESSION_IMPL *session, const char *uri, bool *existp,
-  int64_t *sizep) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_curstat_size_disagg(WT_SESSION_IMPL *session, const char *uri, int64_t *sizep)
+  WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_curstat_size_local(WT_SESSION_IMPL *session, const char *filename, bool *existp,
   int64_t *sizep) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_curstat_table_init(WT_SESSION_IMPL *session, const char *uri, const char *cfg[],

--- a/src/schema/schema_stat.c
+++ b/src/schema/schema_stat.c
@@ -92,7 +92,9 @@ __curstat_size_only(WT_SESSION_IMPL *session, const char *uri, bool *was_fast, W
     /* Only probe for a stable file on a connection that can create one. */
     if (__wt_conn_is_disagg(session)) {
         WT_ERR(__wt_buf_fmt(session, &namebuf, "file:%s.wt_stable", table_name));
-        WT_ERR(__wt_curstat_size_disagg(session, namebuf.data, was_fast, &size));
+        ret = __wt_curstat_size_disagg(session, namebuf.data, &size);
+        *was_fast = ret == 0;
+        WT_ERR_NOTFOUND_OK(ret, false);
     }
 
     /*

--- a/test/suite/test_disagg_checkpoint_size22.py
+++ b/test/suite/test_disagg_checkpoint_size22.py
@@ -26,10 +26,13 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
+import errno
+import os
 from collections import namedtuple
 from contextlib import closing
 from pathlib import Path
 from helper_disagg import DisaggSizeTestMixin, disagg_test_class
+import wiredtiger
 from wiredtiger import stat
 import wttest
 
@@ -80,7 +83,7 @@ class test_disagg_checkpoint_size22(DisaggSizeTestMixin, wttest.WiredTigerTestCa
             return cursor[key][2]
 
     def block_size(self, uri=None, session=None):
-        """Return the block size reported for a table."""
+        """Return the reported block size."""
         return self.size_stat(stat.dsrc.block_size, uri, session)
 
     def block_manager_consulted(self, uri=None, session=None):
@@ -93,6 +96,14 @@ class test_disagg_checkpoint_size22(DisaggSizeTestMixin, wttest.WiredTigerTestCa
         """Return the number of active dhandles on the connection."""
         with wttest.open_cursor(session or self.session, "statistics:") as cursor:
             return cursor[stat.conn.dh_conn_handle_count][2]
+
+    def follower_config(self):
+        """Return the configuration for a follower connection with statistics enabled."""
+        return (
+            self.extensionsConfig()
+            + ",create,statistics=(fast),"
+            + f'disaggregated=(page_log={self.page_log()},role="follower")'
+        )
 
     def test_layered_table_size_uses_checkpoint_meta(self):
         """A leader reports a layered table's checkpoint size without opening dhandles."""
@@ -111,20 +122,35 @@ class test_disagg_checkpoint_size22(DisaggSizeTestMixin, wttest.WiredTigerTestCa
         expected_size = self.open_layered_table()
 
         # A follower that has picked up the leader's checkpoint but never opened the table.
-        follower_config = (
-            self.extensionsConfig()
-            + ",create,statistics=(fast),"
-            + f'disaggregated=(page_log={self.page_log()},role="follower")'
-        )
-
         with closing(
-            self.wiredtiger_open("follower", follower_config)
+            self.wiredtiger_open("follower", self.follower_config())
         ) as follower_connection:
             self.disagg_advance_checkpoint(follower_connection)
             follower_session = follower_connection.open_session("")
 
             dhandles_before = self.dhandle_count(follower_session)
             self.assertEqual(self.block_size(session=follower_session), expected_size)
+            self.assertFalse(self.block_manager_consulted(session=follower_session))
+            self.assertEqual(self.dhandle_count(follower_session), dhandles_before)
+
+            follower_session.close()
+
+    def test_layered_table_follower_uses_zero_checkpoint_meta(self):
+        """A follower reports a picked-up zero-sized checkpoint without opening dhandles."""
+        self.session.create(self.layered_table.uri, self.layered_table.config)
+        self.session.checkpoint()
+
+        stable_uri = "file:" + self.layered_table.file_name
+        self.assertEqual(self.get_checkpoint_size(stable_uri), 0)
+
+        with closing(
+            self.wiredtiger_open("follower", self.follower_config())
+        ) as follower_connection:
+            self.disagg_advance_checkpoint(follower_connection)
+            follower_session = follower_connection.open_session("")
+
+            dhandles_before = self.dhandle_count(follower_session)
+            self.assertEqual(self.block_size(session=follower_session), 0)
             self.assertFalse(self.block_manager_consulted(session=follower_session))
             self.assertEqual(self.dhandle_count(follower_session), dhandles_before)
 
@@ -141,12 +167,112 @@ class test_disagg_checkpoint_size22(DisaggSizeTestMixin, wttest.WiredTigerTestCa
         )
         self.assertFalse(self.block_manager_consulted(self.local_table.uri))
 
-    def test_layered_table_size_without_checkpoint_uses_slow_path(self):
-        """A layered table with no checkpoint falls back to the slow path."""
+    def test_local_file_size_on_disagg_uses_filesystem(self):
+        """A local file on a disagg connection reports its filesystem size."""
+        self.session.create(self.local_table.uri, self.local_table.config)
+        file_uri = "file:" + self.local_table.file_name
+
+        self.assertEqual(
+            self.block_size(file_uri), Path(self.local_table.file_name).stat().st_size
+        )
+        self.assertFalse(self.block_manager_consulted(file_uri))
+
+    def test_layered_table_before_first_checkpoint_uses_fast_path(self):
+        """A layered table reports zero through the fast path before its first checkpoint."""
         self.open_and_populate(self.layered_table)
 
-        # No checkpoint has occurred, so we expect the slow path to be taken.
-        self.assertTrue(self.block_manager_consulted())
+        self.assertEqual(self.block_size(), 0)
+        self.assertFalse(self.block_manager_consulted())
+
+    def test_layered_table_fake_checkpoint_uses_checkpoint_meta(self):
+        """A fake checkpoint reports zero through the fast path."""
+        self.session.create(self.layered_table.uri, self.layered_table.config)
+        self.session.checkpoint()
+
+        stable_uri = "file:" + self.layered_table.file_name
+        expected_size = self.get_checkpoint_size(stable_uri)
+
+        # Ensure that it was a fake checkpoint.
+        with wttest.open_cursor(self.session, "metadata:") as cursor:
+            metadata = cursor[stable_uri]
+            self.assertEqual(metadata.count("WiredTigerCheckpoint."), 1)
+            self.assertIn('addr=""', metadata)
+
+        self.assertEqual(expected_size, 0)
+        self.assertEqual(self.block_size(), expected_size)
+        self.assertFalse(self.block_manager_consulted())
+
+    def test_layered_table_empty_root_checkpoint_uses_checkpoint_meta(self):
+        """An empty root after a real checkpoint reports zero through the fast path."""
+        self.session.create(self.layered_table.uri, self.layered_table.config)
+        with wttest.open_cursor(self.session, self.layered_table.uri) as cursor:
+            cursor["key"] = "value"
+        self.session.checkpoint()
+
+        stable_uri = "file:" + self.layered_table.file_name
+        self.assertGreater(self.get_checkpoint_size(stable_uri), 0)
+
+        with wttest.open_cursor(self.session, self.layered_table.uri) as cursor:
+            cursor.set_key("key")
+            self.assertEqual(cursor.remove(), 0)
+        self.session.checkpoint()
+
+        self.assertEqual(self.get_checkpoint_size(stable_uri), 0)
+        self.assertEqual(self.block_size(), 0)
+        self.assertFalse(self.block_manager_consulted())
+
+    def test_stable_file_empty_checkpoint_uses_checkpoint_meta(self):
+        """A direct stable-file query reports zero through the fast path for an empty checkpoint."""
+        self.session.create(self.layered_table.uri, self.layered_table.config)
+        self.session.checkpoint()
+
+        stable_uri = "file:" + self.layered_table.file_name
+        self.assertEqual(self.get_checkpoint_size(stable_uri), 0)
+
+        self.assertEqual(self.block_size(stable_uri), 0)
+        self.assertFalse(self.block_manager_consulted(stable_uri))
+
+    def test_stable_file_before_first_checkpoint_uses_fast_path(self):
+        """A direct stable-file query reports zero through the fast path before its first checkpoint."""
+        self.session.create(self.layered_table.uri, self.layered_table.config)
+
+        stable_uri = "file:" + self.layered_table.file_name
+        self.assertEqual(self.block_size(stable_uri), 0)
+        self.assertFalse(self.block_manager_consulted(stable_uri))
+
+    def test_stable_file_size_uses_checkpoint_meta(self):
+        """A direct stable-file query reports a non-zero checkpoint size without opening dhandles."""
+        expected_size = self.open_layered_table()
+        stable_uri = "file:" + self.layered_table.file_name
+
+        # Reopen to drop the cached dhandles.
+        with self.expectedStdoutPattern("Removing local file"):
+            self.reopen_conn()
+
+        dhandles_before = self.dhandle_count()
+        self.assertEqual(self.block_size(stable_uri), expected_size)
+        self.assertFalse(self.block_manager_consulted(stable_uri))
+        self.assertEqual(self.dhandle_count(), dhandles_before)
+
+    def test_missing_local_file_returns_enoent(self):
+        """A missing local file returns ENOENT."""
+        self.assertRaisesException(
+            wiredtiger.WiredTigerError,
+            lambda: self.block_size(f"file:{self.__class__.__name__}_missing.wt"),
+            os.strerror(errno.ENOENT),
+        )
+
+    def test_missing_stable_file_returns_enoent(self):
+        """A missing stable URI returns ENOENT without adding a connection dhandle."""
+        dhandles_before = self.dhandle_count()
+        self.assertRaisesException(
+            wiredtiger.WiredTigerError,
+            lambda: self.block_size(
+                f"file:{self.__class__.__name__}_missing.wt_stable"
+            ),
+            os.strerror(errno.ENOENT),
+        )
+        self.assertEqual(self.dhandle_count(), dhandles_before)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Prior to this change, statistics=(size) always fell back to the slow path when the checkpoint metadata reports a size of zero. For disaggregated storage, the slow path then reread the same metadata while also opening dhandles.

This change aims to reduce these inefficiencies by trusting zero, and returning ENOENT when the checkpoint metadata is not present. The behaviour on the ASC path is preserved.

For more information please refer to WT-18119.