### PR TITLE
WT-18171 Use atomic OR to set WT_PAGE_EVICT_LRU_URGENT in urgent eviction

### DIFF
--- a/src/evict/evict_dispatch.c
+++ b/src/evict/evict_dispatch.c
@@ -517,7 +517,7 @@ __wt_evict_page_urgent(WT_SESSION_IMPL *session, WT_REF *ref)
       __wti_evict_push_candidate(session, urgent_queue, evict_entry, ref)) {
         ++urgent_queue->evict_candidates;
         queued = true;
-        FLD_SET(page->flags_atomic, WT_PAGE_EVICT_LRU_URGENT);
+        F_SET_ATOMIC_16(page, WT_PAGE_EVICT_LRU_URGENT);
     }
     __wt_spin_unlock(session, &urgent_queue->evict_lock);
 

--- a/src/evict/evict_walk.c
+++ b/src/evict/evict_walk.c
@@ -592,7 +592,7 @@ __wti_evict_push_candidate(
      * Threads can race to queue a page (e.g., an ordinary LRU walk can race with a page being
      * queued for urgent eviction).
      */
-    orig_flags = new_flags = ref->page->flags_atomic;
+    orig_flags = new_flags = __wt_atomic_load_uint16_relaxed(&ref->page->flags_atomic);
     FLD_SET(new_flags, WT_PAGE_EVICT_LRU);
     if (orig_flags == new_flags ||
       !__wt_atomic_cas_uint16(&ref->page->flags_atomic, orig_flags, new_flags)) {


### PR DESCRIPTION
## Summary

The urgent-eviction path set its flag with a plain read-modify-write instead of an atomic
set, so it could clobber a bit that a concurrent internal-page split had just set in the
same shared word — which the split then asserts on, firing the assertion. The fix makes
urgent eviction set its bit atomically, like every other writer of this word.
