### PR TITLE
WT-18193 Disable disagg tests in the 9.0 Evergreen project

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1606,7 +1606,6 @@ variables:
       - name: make-check-test
       # Use a special version of unit-test for macOS that checks for Python version consistency.
       - name: unit-test-macos
-      - name: unit-test-hook-disagg-leader-macos
       - name: fops
       - name: memory-model-test-mac
         batchtime: 40320 # 28 days
@@ -6923,7 +6922,21 @@ buildvariants:
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo` / 2" | bc)
   tags: ["pull_request"]
   tasks:
-    - name: ".pull_request !.pull_request_compilers !.unit_test_tsan !.unit_test_xsan"
+    - name: >-
+        .pull_request
+        !.pull_request_compilers
+        !.unit_test_tsan
+        !.unit_test_xsan
+        !.unit_test_disagg
+        !format-stress-test-disagg-leader-pull-request-1
+        !format-stress-test-disagg-leader-pull-request-2
+        !format-stress-test-disagg-switch-pull-request-1
+        !format-stress-test-disagg-switch-pull-request-2
+        !format-stress-test-disagg-follower-pull-request
+        !format-stress-test-disagg-leader-tsan
+        !format-stress-test-disagg-switch-tsan
+        !unit-test-hook-disagg-follower
+        !unit-test-hook-disagg-follower-table
     - name: ".lint"
     - name: ".unit_test_long"
       distros: ubuntu2004-large
@@ -6934,7 +6947,6 @@ buildvariants:
     - name: make-check-test
     - name: configure-combinations
     - name: unit-test-zstd
-    - name: unit-test-hook-disagg-leader-key-provider
     - name: unit-test-hook-parallel-checkpoint
     - name: unit-test-hook-tiered
     - name: unit-test-hook-tiered-with-delays
@@ -6948,8 +6960,6 @@ buildvariants:
     - name: long-test
       distros: ubuntu2004-large
     - name: unit-test-extra-long
-      distros: ubuntu2004-large
-    - name: unit-test-hook-disagg-leader-extra-long
       distros: ubuntu2004-large
     - name: static-wt-build-test
     - name: format-smoke-test
@@ -6965,10 +6975,6 @@ buildvariants:
     - name: model-test-long-with-coverage
       batchtime: 1440 # once a day
     - name: model-test-long-random-config
-      batchtime: 1440 # once a day
-    - name: model-test-long-disagg
-      batchtime: 1440 # once a day
-    - name: model-test-long-random-config-disagg
       batchtime: 1440 # once a day
     - name: csuite-long-running
       batchtime: 1440 # once a day
@@ -6997,23 +7003,34 @@ buildvariants:
     additional_san_vars: export ASAN_OPTIONS="$COMMON_SAN_OPTIONS:unmap_shadow_on_exit=1"
   tags: ["pull_request", "sanitizer"]
   tasks:
-    - name: ".pull_request !.pull_request_compilers !.python !.tiered_unittest !csuite-wt12015-backup-corruption-test !.unit_test_tsan !syscall-linux !format-mirror-test"
+    - name: >-
+        .pull_request
+        !.pull_request_compilers
+        !.python
+        !.tiered_unittest
+        !csuite-wt12015-backup-corruption-test
+        !.unit_test_tsan
+        !syscall-linux
+        !format-mirror-test
+        !.unit_test_disagg
+        !format-stress-test-disagg-leader-pull-request-1
+        !format-stress-test-disagg-leader-pull-request-2
+        !format-stress-test-disagg-switch-pull-request-1
+        !format-stress-test-disagg-switch-pull-request-2
+        !format-stress-test-disagg-follower-pull-request
+        !format-stress-test-disagg-leader-tsan
+        !format-stress-test-disagg-switch-tsan
+        !unit-test-hook-disagg-follower
+        !unit-test-hook-disagg-follower-table
     - name: examples-c-test
     - name: format-asan-smoke-test
     - name: model-test-long
       batchtime: 1440 # once a day
     - name: model-test-long-random-config
       batchtime: 1440 # once a day
-    - name: model-test-long-disagg
-      batchtime: 1440 # once a day
-    - name: model-test-long-random-config-disagg
-      batchtime: 1440 # once a day
     - name: live-restore-long
     - name: ".stress-test-asan"
-    - name: ".stress-test-disagg"
-      distros: ubuntu2004-large
     - name: ".unit_test_xsan"
-    - name: ".unit_test_disagg"
     - name: ".unit_test_long"
 
 # FIXME-WT-16067: ASAN could hide warnings when tests are executed by many processes simultaneously.
@@ -7036,25 +7053,12 @@ buildvariants:
     - name: examples-c-test
     - name: unit-test-tsan
       distros: ubuntu2004-large
-    - name: unit-test-hook-disagg-leader-tsan
-      distros: ubuntu2004-large
-    - name: unit-test-hook-disagg-follower-tsan
-      distros: ubuntu2004-large
     # FIXME-WT-16309: Remove TSAN-specific jobs once the common tag works
     - name: unit-test-hook-parallel-checkpoint-tsan
-    - name: format-stress-test-disagg-leader-tsan
-      distros: ubuntu2004-large
-    - name: format-stress-test-disagg-switch-tsan
-      distros: ubuntu2004-large
     - name: format-stress-test-tsan
       distros: ubuntu2004-large
-    # FIXME-WT-16309: Enable the common test format tag for TSAN
-    # - name: ".stress-test-disagg"
-    #   distros: ubuntu2004-large
     - name: generate-tsan-metric
-    - name: generate-tsan-metric-disagg
     - name: generate-tsan-metric-timestamp
-    - name: generate-tsan-metric-disagg-timestamp
     - name: tsan-playground-test
 
 # Very minimal set without any extensions
@@ -7135,9 +7139,6 @@ buildvariants:
     - name: examples-c-production-disable-shared-test
     - name: examples-c-production-disable-static-test
     - name: format-stress-pull-request-test
-    - name: format-stress-test-disagg-leader-pull-request-1
-    - name: format-stress-test-disagg-follower-pull-request
-    - name: format-stress-test-disagg-switch-pull-request-1
     - name: make-check-test
       distros: ubuntu2004-large
     - name: cppsuite-default-all
@@ -7156,8 +7157,6 @@ buildvariants:
     - name: ".stress-test-2"
     - name: ".stress-test-3"
     - name: ".stress-test-4"
-    - name: ".stress-test-disagg"
-      distros: ubuntu2004-large
     - name: format-abort-recovery-stress-test
     - name: format-predictable-test
     - name: schema-abort-predictable-test
@@ -7180,7 +7179,6 @@ buildvariants:
     - name: ".stress-test-2"
     - name: ".stress-test-3"
     - name: ".stress-test-4"
-    - name: ".stress-test-disagg"
     - name: checkpoint-stress-test-tiered
     - name: precise-checkpoint-stress-test-tiered
     - name: format-abort-recovery-stress-test
@@ -7216,8 +7214,6 @@ buildvariants:
     - name: checkpoint-filetypes-test
     - name: unit-test-zstd
     - name: unit-test-extra-long
-      distros: rhel80-large
-    - name: unit-test-hook-disagg-leader-extra-long
       distros: rhel80-large
     - name: spinlock-gcc-test
     - name: spinlock-pthread-adaptive-test
@@ -7349,9 +7345,6 @@ buildvariants:
       distros: ubuntu2004-arm64-large
     - name: format-smoke-test
     - name: format-stress-pull-request-test
-    - name: format-stress-test-disagg-leader-pull-request-1
-    - name: format-stress-test-disagg-follower-pull-request
-    - name: format-stress-test-disagg-switch-pull-request-1
     - name: long-test
       distros: ubuntu2004-arm64-large
     - name: make-check-test
@@ -7362,17 +7355,11 @@ buildvariants:
     - name: model-test-long-random-config
       batchtime: 1440 # once a day
     - name: model-unit-test
-    - name: model-test-long-disagg
-      batchtime: 1440 # once a day
-    - name: model-test-long-random-config-disagg
-      batchtime: 1440 # once a day
     - name: spinlock-gcc-test
     - name: spinlock-pthread-adaptive-test
       distros: ubuntu2004-arm64-large
     - name: unit-test
     - name: unit-test-extra-long
-      distros: ubuntu2004-arm64-large
-    - name: unit-test-hook-disagg-leader-extra-long
       distros: ubuntu2004-arm64-large
     - name: unit-test-zstd
     - name: wtperf-test
@@ -7406,7 +7393,21 @@ buildvariants:
     CMAKE_BUILD_TYPE: -DCMAKE_BUILD_TYPE=RelWithDebInfo
     num_jobs: $(echo "`grep -c ^processor /proc/cpuinfo` * 2" | bc)
   tasks:
-    - name: ".pull_request !.pull_request_compilers !.unit_test_tsan !.unit_test_xsan"
+    - name: >-
+        .pull_request
+        !.pull_request_compilers
+        !.unit_test_tsan
+        !.unit_test_xsan
+        !.unit_test_disagg
+        !format-stress-test-disagg-leader-pull-request-1
+        !format-stress-test-disagg-leader-pull-request-2
+        !format-stress-test-disagg-switch-pull-request-1
+        !format-stress-test-disagg-switch-pull-request-2
+        !format-stress-test-disagg-follower-pull-request
+        !format-stress-test-disagg-leader-tsan
+        !format-stress-test-disagg-switch-tsan
+        !unit-test-hook-disagg-follower
+        !unit-test-hook-disagg-follower-table
     - name: compile
     - name: make-check-test
     - name: unit-test
@@ -7462,8 +7463,6 @@ buildvariants:
     - name: compile
     - name: ".stress-test-1"
     - name: ".stress-test-2"
-    - name: ".stress-test-disagg"
-      distros: ubuntu2004-large
     - name: format-abort-recovery-stress-test
     - name: format-predictable-test
 
@@ -7481,7 +7480,6 @@ buildvariants:
     - name: compile
     - name: ".stress-test-1"
     - name: ".stress-test-2"
-    - name: ".stress-test-disagg"
     - name: format-abort-recovery-stress-test
 
 - name: ubuntu2004-nonstandalone
@@ -7496,12 +7494,24 @@ buildvariants:
     NONSTANDALONE: -DWT_STANDALONE_BUILD=0
     unit_test_variant_args: "--hook nonstandalone"
   tasks:
-    - name: ".pull_request !.pull_request_compilers !.unit_test_tsan !.unit_test_xsan"
+    - name: >-
+        .pull_request
+        !.pull_request_compilers
+        !.unit_test_tsan
+        !.unit_test_xsan
+        !.unit_test_disagg
+        !format-stress-test-disagg-leader-pull-request-1
+        !format-stress-test-disagg-leader-pull-request-2
+        !format-stress-test-disagg-switch-pull-request-1
+        !format-stress-test-disagg-switch-pull-request-2
+        !format-stress-test-disagg-follower-pull-request
+        !format-stress-test-disagg-leader-tsan
+        !format-stress-test-disagg-switch-tsan
+        !unit-test-hook-disagg-follower
+        !unit-test-hook-disagg-follower-table
     - name: compile
     - name: make-check-test
     - name: unit-test-extra-long
-      distros: ubuntu2004-large
-    - name: unit-test-hook-disagg-leader-extra-long
       distros: ubuntu2004-large
     - name: ".data-validation-stress-test"
 
@@ -7520,8 +7530,6 @@ buildvariants:
     - name: ".stress-test-2"
     - name: ".stress-test-3"
     - name: ".stress-test-4"
-    - name: ".stress-test-disagg"
-      distros: ubuntu2004-large
     - name: format-abort-recovery-stress-test
     - name: ".cppsuite-stress-test"
       batchtime: 720 # 12 hours
@@ -7546,8 +7554,6 @@ buildvariants:
       distros: ubuntu2004-test
     - name: format-abort-recovery-stress-test
       distros: ubuntu2004-test
-    - name: ".stress-test-disagg"
-      distros: ubuntu2004-large
     - name: make-check-test
     - name: unit-test
 
@@ -7569,13 +7575,10 @@ buildvariants:
     - name: unit-test
       distros: ubuntu2004-arm64-small
     - name: unit-test-extra-long
-    - name: unit-test-hook-disagg-leader-extra-long
     - name: ".stress-test-1"
     - name: ".stress-test-2"
     - name: ".stress-test-3"
     - name: ".stress-test-4"
-    - name: ".stress-test-disagg"
-    - name: format-stress-disagg-leader-long-running
     - name: format-abort-recovery-stress-test
     - name: ".cppsuite-stress-test"
       batchtime: 720 # 12 hours
@@ -7599,15 +7602,9 @@ buildvariants:
       distros: ubuntu2004-arm64-large
     - name: format-abort-recovery-stress-test
       distros: ubuntu2004-arm64-large
-    - name: ".stress-test-disagg"
-      distros: ubuntu2004-arm64-large
-    - name: format-stress-disagg-leader-long-running
-      distros: ubuntu2004-arm64-large
     - name: make-check-test
     - name: unit-test
     - name: unit-test-extra-long
-      distros: ubuntu2004-arm64-large
-    - name: unit-test-hook-disagg-leader-extra-long
       distros: ubuntu2004-arm64-large
 
 - name: amazon2023-arm64-release-nonstandalone
@@ -7629,15 +7626,9 @@ buildvariants:
       distros: amazon2023.3-arm64-large
     - name: format-abort-recovery-stress-test
       distros: amazon2023.3-arm64-large
-    - name: ".stress-test-disagg"
-      distros: amazon2023.3-arm64-large
-    - name: format-stress-disagg-leader-long-running
-      distros: amazon2023.3-arm64-large
     - name: make-check-test
     - name: unit-test
     - name: unit-test-extra-long
-      distros: amazon2023.3-arm64-large
-    - name: unit-test-hook-disagg-leader-extra-long
       distros: amazon2023.3-arm64-large
 
 - name: amazon2023-arm64-nonstandalone
@@ -7658,13 +7649,10 @@ buildvariants:
     - name: unit-test
       distros: amazon2023.3-arm64-small
     - name: unit-test-extra-long
-    - name: unit-test-hook-disagg-leader-extra-long
     - name: ".stress-test-1"
     - name: ".stress-test-2"
     - name: ".stress-test-3"
     - name: ".stress-test-4"
-    - name: ".stress-test-disagg"
-    - name: format-stress-disagg-leader-long-running
     - name: format-abort-recovery-stress-test
     - name: ".cppsuite-stress-test"
       batchtime: 720 # 12 hours
@@ -7712,9 +7700,6 @@ buildvariants:
       distros: amazon2023.3-arm64-large
     - name: format-smoke-test
     - name: format-stress-pull-request-test
-    - name: format-stress-test-disagg-leader-pull-request-1
-    - name: format-stress-test-disagg-follower-pull-request
-    - name: format-stress-test-disagg-switch-pull-request-1
     - name: long-test
       distros: amazon2023.3-arm64-large
     - name: make-check-test
@@ -7727,17 +7712,11 @@ buildvariants:
     - name: model-test-long-random-config
       batchtime: 1440 # once a day
     - name: model-unit-test
-    - name: model-test-long-disagg
-      batchtime: 1440 # once a day
-    - name: model-test-long-random-config-disagg
-      batchtime: 1440 # once a day
     - name: spinlock-gcc-test
     - name: spinlock-pthread-adaptive-test
       distros: amazon2023.3-arm64-large
     - name: unit-test
     - name: unit-test-extra-long
-      distros: amazon2023.3-arm64-large
-    - name: unit-test-hook-disagg-leader-extra-long
       distros: amazon2023.3-arm64-large
     - name: unit-test-zstd
     - name: wtperf-test
@@ -7761,7 +7740,6 @@ buildvariants:
     - name: ".stress-test-2"
     - name: ".stress-test-3"
     - name: ".stress-test-4"
-    - name: ".stress-test-disagg"
     - name: format-abort-recovery-stress-test
     - name: format-predictable-test
     - name: schema-abort-predictable-test
@@ -7791,23 +7769,34 @@ buildvariants:
     additional_san_vars: export ASAN_OPTIONS="$COMMON_SAN_OPTIONS:unmap_shadow_on_exit=1"
     ctest_extra_args: -E "wt12015_backup_corruption"
   tasks:
-    - name: ".pull_request !.pull_request_compilers !.unit_test_xsan !.python !.tiered_unittest !csuite-wt12015-backup-corruption-test !.unit_test_tsan !syscall-linux"
+    - name: >-
+        .pull_request
+        !.pull_request_compilers
+        !.unit_test_xsan
+        !.python
+        !.tiered_unittest
+        !csuite-wt12015-backup-corruption-test
+        !.unit_test_tsan
+        !syscall-linux
+        !.unit_test_disagg
+        !format-stress-test-disagg-leader-pull-request-1
+        !format-stress-test-disagg-leader-pull-request-2
+        !format-stress-test-disagg-switch-pull-request-1
+        !format-stress-test-disagg-switch-pull-request-2
+        !format-stress-test-disagg-follower-pull-request
+        !format-stress-test-disagg-leader-tsan
+        !format-stress-test-disagg-switch-tsan
+        !unit-test-hook-disagg-follower
+        !unit-test-hook-disagg-follower-table
     - name: examples-c-test
     - name: format-asan-smoke-test
     - name: model-test-long
       batchtime: 1440 # once a day
     - name: model-test-long-random-config
       batchtime: 1440 # once a day
-    - name: model-test-long-disagg
-      batchtime: 1440 # once a day
-    - name: model-test-long-random-config-disagg
-      batchtime: 1440 # once a day
     - name: live-restore-long
     - name: ".stress-test-asan"
-    - name: ".stress-test-disagg"
-      distros: amazon2023.3-arm64-large
     - name: ".unit_test"
-    - name: ".unit_test_disagg"
     - name: ".unit_test_long"
 
 # FIXME-WT-16067: ASAN could hide warnings when tests are executed by many processes simultaneously.
@@ -7827,27 +7816,23 @@ buildvariants:
   tasks:
     - name: compile
     - name: examples-c-test
-    - name: .unit_test_tsan
+    - name: >-
+        .unit_test_tsan
+        !unit-test-hook-disagg-follower-tsan
+        !unit-test-hook-disagg-leader-tsan-bucket00
+        !unit-test-hook-disagg-leader-tsan-bucket01
+        !unit-test-hook-disagg-leader-tsan-bucket02
+        !unit-test-hook-disagg-leader-tsan-bucket03
+        !unit-test-hook-disagg-leader-tsan-bucket04
     # FIXME-WT-16066 Remove unit test tsan once we incorporate TSAN environment variable setting into run.py
     - name: unit-test-tsan
       distros: amazon2023.3-arm64-large
-    - name: unit-test-hook-disagg-leader-tsan
-      distros: amazon2023.3-arm64-large
     # FIXME-WT-16309: Remove TSAN-specific jobs once the common tag works
-    - name: format-stress-test-disagg-leader-tsan
-      distros: amazon2023.3-arm64-large
-    - name: format-stress-test-disagg-switch-tsan
-      distros: amazon2023.3-arm64-large
     - name: unit-test-hook-parallel-checkpoint-tsan
     - name: format-stress-test-tsan
       distros: amazon2023.3-arm64-large
-    # FIXME-WT-16309: Enable the common test format tag for TSAN
-    # - name: ".stress-test-disagg"
-    #   distros: amazon2023.3-arm64-large
     - name: generate-tsan-metric
-    - name: generate-tsan-metric-disagg
     - name: generate-tsan-metric-timestamp
-    - name: generate-tsan-metric-disagg-timestamp
 
 # FIXME-WT-16067: ASAN could hide warnings when tests are executed by many processes simultaneously.
 # Investigate whether a similar thing could happen for MSAN.
@@ -7906,9 +7891,6 @@ buildvariants:
     - name: examples-c-production-disable-shared-test
     - name: examples-c-production-disable-static-test
     - name: format-stress-pull-request-test
-    - name: format-stress-test-disagg-leader-pull-request-1
-    - name: format-stress-test-disagg-follower-pull-request
-    - name: format-stress-test-disagg-switch-pull-request-1
     - name: make-check-test
       distros: amazon2023.3-arm64-large
     - name: cppsuite-default-all
@@ -7928,7 +7910,6 @@ buildvariants:
     - name: ".stress-test-2"
     - name: ".stress-test-3"
     - name: ".stress-test-4"
-    - name: ".stress-test-disagg"
     - name: format-abort-recovery-stress-test
     - name: ".cppsuite-stress-test"
       batchtime: 720 # 12 hours

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -6941,8 +6941,6 @@ buildvariants:
     - name: ".unit_test_long"
       distros: ubuntu2004-large
     - name: compile
-    - name: compile-develop
-    - name: compatibility-test-against-develop
     - name: doc-compile
     - name: make-check-test
     - name: configure-combinations


### PR DESCRIPTION
Disaggregated storage is not used in MongoDB 9.0, an ASC release, so its tests
only produce needless BFGs, Baron workload, and ticket creation. This mirrors
WT-17367 (#14010), which did the same on the 8.3 branch.

Prompted by failures such as
[wiredtiger_mongo_v9.0_ubuntu2004_unit_test_hook_disagg_leader_extra_long](https://spruce.corp.mongodb.com/task/wiredtiger_mongo_v9.0_ubuntu2004_unit_test_hook_disagg_leader_extra_long_08e53ee11f6a28630b40eb6033fa60c2c2f4ce4d_26_07_24_03_33_32/logs?execution=0).

### What changed

`test/evergreen.yml` only. Task definitions are left in place; only buildvariant
task lists and the shared macOS task-list anchor change.

Removed from variants:

- `unit-test-hook-disagg-leader-extra-long` (7 variants), `-key-provider`, `-macos`
- `unit-test-hook-disagg-leader-tsan`, `-follower-tsan`, `format-stress-test-disagg-{leader,switch}-tsan`, `generate-tsan-metric-disagg{,-timestamp}`
- `format-stress-test-disagg-{leader-1,switch-1,follower}-pull-request`
- `model-test-long{,-random-config}-disagg`, `format-stress-disagg-leader-long-running`
- the `.stress-test-disagg` tag selector (13 variants) and `.unit_test_disagg` (2 variants)
- `compatibility-test-against-develop`, plus `compile-develop` which only it depends on

`compatibility-test-against-develop` generates its data files with
`CONFIG.disagg`, so it exists to catch unintentional disagg data format changes.
It passes today, but nothing guarantees that once a format change lands on
develop.

Seven tag selectors were converted from a single-line quoted expression to a
folded `>-` block so the added negation filters stay readable — the five
`.pull_request` selectors plus `amazon2023-arm64-tsan`'s `.unit_test_tsan`. That
accounts for the insertions.

`.data-validation-stress-test` needed no negations here, unlike on 8.3: in 9.0 no
disagg task carries that tag.

### Not included

`precise-checkpoint` tasks are deliberately untouched. The 8.3 change also
stripped those, but whether 9.0 should keep them is a separate decision still
being confirmed with the team.

### Testing

YAML parses, and a tag-expansion sweep over every buildvariant confirms no
disagg task remains scheduled and no variant is left with an empty `tasks:` list.
