### PR TITLE
WT-16736 Enable test/format (disagg) multi node in evergreen variants

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5377,17 +5377,8 @@ tasks:
   - <<: *format-stress-test-disagg-multi
     name: format-stress-test-disagg-multi-2
     tags: ["stress-test-disagg"]
-  - <<: *format-stress-test-disagg-multi
-    name: format-stress-test-disagg-multi-3
-    tags: ["stress-test-disagg"]
-  - <<: *format-stress-test-disagg-multi
-    name: format-stress-test-disagg-multi-4
-    tags: ["stress-test-disagg"]
   - <<: *format-stress-test-disagg-multi-pull-request
-    name: format-stress-test-disagg-multi-pull-request-1
-    tags: ["pull_request"]
-  - <<: *format-stress-test-disagg-multi-pull-request
-    name: format-stress-test-disagg-multi-pull-request-2
+    name: format-stress-test-disagg-multi-pull-request
     tags: ["pull_request"]
 
   - name: format-stress-test-disagg-follower-pull-request

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1855,7 +1855,7 @@ variables:
       - func: "format test disagg"
         vars:
           # FIXME-WT-16732: Enable truncate for multi node once predictable replay supports it.
-          format_args: disagg.multi=1 runs.predictable_replay=1 ops.verify=1 disagg.multi_validation=1 runs.rows=5000 runs.ops=20000 ops.truncate=0
+          format_args: disagg.multi=1 runs.predictable_replay=1 ops.verify=1 disagg.multi_validation=1 runs.rows=20000 runs.ops=100000 ops.truncate=0
           times: 10
           reopen: false # FIXME-WT-16481 Reopen currently causes failures in disagg multi mode.
 
@@ -5371,19 +5371,18 @@ tasks:
     name: format-stress-test-disagg-switch-pull-request-stepdown-async-2
     tags: ["pull_request"]
 
-# FIXME-WT-18245: Enable multi-node on release variants after fixing hangs/timeouts.
   - <<: *format-stress-test-disagg-multi
     name: format-stress-test-disagg-multi-1
-    tags: ["stress-test-disagg-multi"]
+    tags: ["stress-test-disagg"]
   - <<: *format-stress-test-disagg-multi
     name: format-stress-test-disagg-multi-2
-    tags: ["stress-test-disagg-multi"]
+    tags: ["stress-test-disagg"]
   - <<: *format-stress-test-disagg-multi
     name: format-stress-test-disagg-multi-3
-    tags: ["stress-test-disagg-multi"]
+    tags: ["stress-test-disagg"]
   - <<: *format-stress-test-disagg-multi
     name: format-stress-test-disagg-multi-4
-    tags: ["stress-test-disagg-multi"]
+    tags: ["stress-test-disagg"]
   - <<: *format-stress-test-disagg-multi-pull-request
     name: format-stress-test-disagg-multi-pull-request-1
     tags: ["pull_request"]
@@ -7131,7 +7130,6 @@ buildvariants:
     - name: live-restore-long
     - name: ".stress-test-asan"
     - name: ".stress-test-disagg"
-    - name: ".stress-test-disagg-multi"
       distros: ubuntu2004-large
     - name: ".unit_test_xsan"
     - name: ".unit_test_disagg"
@@ -7280,7 +7278,6 @@ buildvariants:
     - name: ".stress-test-3"
     - name: ".stress-test-4"
     - name: ".stress-test-disagg"
-    - name: ".stress-test-disagg-multi"
       distros: ubuntu2004-large
     - name: format-abort-recovery-stress-test
     - name: format-predictable-test
@@ -7305,7 +7302,6 @@ buildvariants:
     - name: ".stress-test-3"
     - name: ".stress-test-4"
     - name: ".stress-test-disagg"
-    - name: ".stress-test-disagg-multi"
     - name: checkpoint-stress-test-tiered
     - name: precise-checkpoint-stress-test-tiered
     - name: format-abort-recovery-stress-test
@@ -7646,7 +7642,6 @@ buildvariants:
     - name: ".stress-test-3"
     - name: ".stress-test-4"
     - name: ".stress-test-disagg"
-    - name: ".stress-test-disagg-multi"
       distros: ubuntu2004-large
     - name: format-abort-recovery-stress-test
     - name: ".cppsuite-stress-test"
@@ -7701,7 +7696,6 @@ buildvariants:
     - name: ".stress-test-3"
     - name: ".stress-test-4"
     - name: ".stress-test-disagg"
-    - name: ".stress-test-disagg-multi"
     - name: format-stress-disagg-leader-long-running
     - name: format-abort-recovery-stress-test
     - name: ".cppsuite-stress-test"
@@ -7791,7 +7785,6 @@ buildvariants:
     - name: ".stress-test-3"
     - name: ".stress-test-4"
     - name: ".stress-test-disagg"
-    - name: ".stress-test-disagg-multi"
     - name: format-stress-disagg-leader-long-running
     - name: format-abort-recovery-stress-test
     - name: ".cppsuite-stress-test"
@@ -7890,7 +7883,6 @@ buildvariants:
     - name: ".stress-test-3"
     - name: ".stress-test-4"
     - name: ".stress-test-disagg"
-    - name: ".stress-test-disagg-multi"
     - name: format-abort-recovery-stress-test
     - name: format-predictable-test
     - name: schema-abort-predictable-test
@@ -7934,7 +7926,6 @@ buildvariants:
     - name: live-restore-long
     - name: ".stress-test-asan"
     - name: ".stress-test-disagg"
-    - name: ".stress-test-disagg-multi"
       distros: amazon2023.3-arm64-large
     - name: ".unit_test"
     - name: ".unit_test_disagg"
@@ -8061,7 +8052,6 @@ buildvariants:
     - name: ".stress-test-3"
     - name: ".stress-test-4"
     - name: ".stress-test-disagg"
-    - name: ".stress-test-disagg-multi"
     - name: format-abort-recovery-stress-test
     - name: ".cppsuite-stress-test"
       batchtime: 720 # 12 hours

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1796,7 +1796,7 @@ variables:
         vars:
           # FIXME-WT-18173 Enable modifies in disagg multi mode once the related issues have been resolved.
           # FIXME-WT-16732: Enable truncate for multi node once predictable replay supports it.
-          format_args: disagg.multi=1 runs.predictable_replay=1 ops.verify=1 disagg.multi_validation=1 runs.ops=2000000:4000000 ops.pct.modify=0 ops.truncate=0
+          format_args: disagg.multi=1 runs.predictable_replay=1 ops.verify=1 disagg.multi_validation=1 runs.ops=2000000:4000000 ops.truncate=0
           times: 10
           reopen: false # FIXME-WT-16481 Reopen currently causes failures in disagg multi mode.
 
@@ -1809,7 +1809,7 @@ variables:
         vars:
           # FIXME-WT-18173 Enable modifies in disagg multi mode once the related issues have been resolved.
           # FIXME-WT-16732: Enable truncate for multi node once predictable replay supports it.
-          format_args: disagg.multi=1 runs.predictable_replay=1 ops.verify=1 disagg.multi_validation=1 runs.ops=50000:100000 ops.pct.modify=0 ops.truncate=0
+          format_args: disagg.multi=1 runs.predictable_replay=1 ops.verify=1 disagg.multi_validation=1 runs.rows=10000 runs.ops=30000 ops.truncate=0
           times: 10
           reopen: false # FIXME-WT-16481 Reopen currently causes failures in disagg multi mode.
 

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1810,7 +1810,7 @@ variables:
           # FIXME-WT-18173 Enable modifies in disagg multi mode once the related issues have been resolved.
           # FIXME-WT-16732: Enable truncate for multi node once predictable replay supports it.
           format_args: disagg.multi=1 runs.predictable_replay=1 ops.verify=1 disagg.multi_validation=1 runs.ops=50000:100000 ops.pct.modify=0 ops.truncate=0
-          times: 5
+          times: 10
           reopen: false # FIXME-WT-16481 Reopen currently causes failures in disagg multi mode.
 
   # FIXME-WT-18228 Re-enable random cursor operations in the disaggregated asynchronous step-down format tests

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1787,6 +1787,32 @@ variables:
           format_args: disagg.mode=switch runs.timer=3
           times: 1
 
+  - &format-stress-test-disagg-multi
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "format test disagg"
+        vars:
+          # FIXME-WT-18173 Enable modifies in disagg multi mode once the related issues have been resolved.
+          # FIXME-WT-16732: Enable truncate for multi node once predictable replay supports it.
+          format_args: disagg.multi=1 runs.predictable_replay=1 ops.verify=1 disagg.multi_validation=1 runs.ops=2000000:4000000 ops.pct.modify=0 ops.truncate=0
+          times: 10
+          reopen: false # FIXME-WT-16481 Reopen currently causes failures in disagg multi mode.
+
+  - &format-stress-test-disagg-multi-pull-request
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "format test disagg"
+        vars:
+          # FIXME-WT-18173 Enable modifies in disagg multi mode once the related issues have been resolved.
+          # FIXME-WT-16732: Enable truncate for multi node once predictable replay supports it.
+          format_args: disagg.multi=1 runs.predictable_replay=1 ops.verify=1 disagg.multi_validation=1 runs.ops=500000:1000000 ops.pct.modify=0 ops.truncate=0
+          times: 5
+          reopen: false # FIXME-WT-16481 Reopen currently causes failures in disagg multi mode.
+
   # FIXME-WT-18228 Re-enable random cursor operations in the disaggregated asynchronous step-down format tests
   # Switch-mode variants with asynchronous step-down.
   - &format-stress-test-disagg-switch-stepdown-async

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -5371,18 +5371,19 @@ tasks:
     name: format-stress-test-disagg-switch-pull-request-stepdown-async-2
     tags: ["pull_request"]
 
+# FIXME-WT-18245: Enable multi-node on release variants after fixing hangs/timeouts.
   - <<: *format-stress-test-disagg-multi
     name: format-stress-test-disagg-multi-1
-    tags: ["stress-test-disagg"]
+    tags: ["stress-test-disagg-multi"]
   - <<: *format-stress-test-disagg-multi
     name: format-stress-test-disagg-multi-2
-    tags: ["stress-test-disagg"]
+    tags: ["stress-test-disagg-multi"]
   - <<: *format-stress-test-disagg-multi
     name: format-stress-test-disagg-multi-3
-    tags: ["stress-test-disagg"]
+    tags: ["stress-test-disagg-multi"]
   - <<: *format-stress-test-disagg-multi
     name: format-stress-test-disagg-multi-4
-    tags: ["stress-test-disagg"]
+    tags: ["stress-test-disagg-multi"]
   - <<: *format-stress-test-disagg-multi-pull-request
     name: format-stress-test-disagg-multi-pull-request-1
     tags: ["pull_request"]
@@ -7130,6 +7131,7 @@ buildvariants:
     - name: live-restore-long
     - name: ".stress-test-asan"
     - name: ".stress-test-disagg"
+    - name: ".stress-test-disagg-multi"
       distros: ubuntu2004-large
     - name: ".unit_test_xsan"
     - name: ".unit_test_disagg"
@@ -7278,6 +7280,7 @@ buildvariants:
     - name: ".stress-test-3"
     - name: ".stress-test-4"
     - name: ".stress-test-disagg"
+    - name: ".stress-test-disagg-multi"
       distros: ubuntu2004-large
     - name: format-abort-recovery-stress-test
     - name: format-predictable-test
@@ -7302,6 +7305,7 @@ buildvariants:
     - name: ".stress-test-3"
     - name: ".stress-test-4"
     - name: ".stress-test-disagg"
+    - name: ".stress-test-disagg-multi"
     - name: checkpoint-stress-test-tiered
     - name: precise-checkpoint-stress-test-tiered
     - name: format-abort-recovery-stress-test
@@ -7642,6 +7646,7 @@ buildvariants:
     - name: ".stress-test-3"
     - name: ".stress-test-4"
     - name: ".stress-test-disagg"
+    - name: ".stress-test-disagg-multi"
       distros: ubuntu2004-large
     - name: format-abort-recovery-stress-test
     - name: ".cppsuite-stress-test"
@@ -7696,6 +7701,7 @@ buildvariants:
     - name: ".stress-test-3"
     - name: ".stress-test-4"
     - name: ".stress-test-disagg"
+    - name: ".stress-test-disagg-multi"
     - name: format-stress-disagg-leader-long-running
     - name: format-abort-recovery-stress-test
     - name: ".cppsuite-stress-test"
@@ -7785,6 +7791,7 @@ buildvariants:
     - name: ".stress-test-3"
     - name: ".stress-test-4"
     - name: ".stress-test-disagg"
+    - name: ".stress-test-disagg-multi"
     - name: format-stress-disagg-leader-long-running
     - name: format-abort-recovery-stress-test
     - name: ".cppsuite-stress-test"
@@ -7883,6 +7890,7 @@ buildvariants:
     - name: ".stress-test-3"
     - name: ".stress-test-4"
     - name: ".stress-test-disagg"
+    - name: ".stress-test-disagg-multi"
     - name: format-abort-recovery-stress-test
     - name: format-predictable-test
     - name: schema-abort-predictable-test
@@ -7926,6 +7934,7 @@ buildvariants:
     - name: live-restore-long
     - name: ".stress-test-asan"
     - name: ".stress-test-disagg"
+    - name: ".stress-test-disagg-multi"
       distros: amazon2023.3-arm64-large
     - name: ".unit_test"
     - name: ".unit_test_disagg"
@@ -8052,6 +8061,7 @@ buildvariants:
     - name: ".stress-test-3"
     - name: ".stress-test-4"
     - name: ".stress-test-disagg"
+    - name: ".stress-test-disagg-multi"
     - name: format-abort-recovery-stress-test
     - name: ".cppsuite-stress-test"
       batchtime: 720 # 12 hours

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1809,7 +1809,7 @@ variables:
         vars:
           # FIXME-WT-18173 Enable modifies in disagg multi mode once the related issues have been resolved.
           # FIXME-WT-16732: Enable truncate for multi node once predictable replay supports it.
-          format_args: disagg.multi=1 runs.predictable_replay=1 ops.verify=1 disagg.multi_validation=1 runs.ops=500000:1000000 ops.pct.modify=0 ops.truncate=0
+          format_args: disagg.multi=1 runs.predictable_replay=1 ops.verify=1 disagg.multi_validation=1 runs.ops=50000:100000 ops.pct.modify=0 ops.truncate=0
           times: 5
           reopen: false # FIXME-WT-16481 Reopen currently causes failures in disagg multi mode.
 

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1787,30 +1787,6 @@ variables:
           format_args: disagg.mode=switch runs.timer=3
           times: 1
 
-  - &format-stress-test-disagg-multi
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "format test disagg"
-        vars:
-          # FIXME-WT-16732: Enable truncate for multi node once predictable replay supports it.
-          format_args: disagg.multi=1 runs.predictable_replay=1 ops.verify=1 disagg.multi_validation=1 runs.ops=2000000:4000000 ops.truncate=0
-          times: 10
-          reopen: false # FIXME-WT-16481 Reopen currently causes failures in disagg multi mode.
-
-  - &format-stress-test-disagg-multi-pull-request
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "format test disagg"
-        vars:
-          # FIXME-WT-16732: Enable truncate for multi node once predictable replay supports it.
-          format_args: disagg.multi=1 runs.predictable_replay=1 ops.verify=1 disagg.multi_validation=1 runs.rows=10000 runs.ops=30000 ops.truncate=0
-          times: 10
-          reopen: false # FIXME-WT-16481 Reopen currently causes failures in disagg multi mode.
-
   # FIXME-WT-18228 Re-enable random cursor operations in the disaggregated asynchronous step-down format tests
   # Switch-mode variants with asynchronous step-down.
   - &format-stress-test-disagg-switch-stepdown-async
@@ -1858,6 +1834,30 @@ variables:
         vars:
           format_args: disagg.mode=switch disagg.stepdown_async=1 ops.prepare=0 ops.truncate=0 ops.random_cursor=0 runs.timer=3
           times: 1
+
+  - &format-stress-test-disagg-multi
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "format test disagg"
+        vars:
+          # FIXME-WT-16732: Enable truncate for multi node once predictable replay supports it.
+          format_args: disagg.multi=1 runs.predictable_replay=1 ops.verify=1 disagg.multi_validation=1 runs.ops=2000000:4000000 ops.truncate=0
+          times: 10
+          reopen: false # FIXME-WT-16481 Reopen currently causes failures in disagg multi mode.
+
+  - &format-stress-test-disagg-multi-pull-request
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "format test disagg"
+        vars:
+          # FIXME-WT-16732: Enable truncate for multi node once predictable replay supports it.
+          format_args: disagg.multi=1 runs.predictable_replay=1 ops.verify=1 disagg.multi_validation=1 runs.rows=10000 runs.ops=30000 ops.truncate=0
+          times: 10
+          reopen: false # FIXME-WT-16481 Reopen currently causes failures in disagg multi mode.
 
 #######################################
 #               Tasks                 #
@@ -5369,6 +5369,25 @@ tasks:
     tags: ["pull_request"]
   - <<: *format-stress-test-disagg-switch-pull-request-stepdown-async
     name: format-stress-test-disagg-switch-pull-request-stepdown-async-2
+    tags: ["pull_request"]
+
+  - <<: *format-stress-test-disagg-multi
+    name: format-stress-test-disagg-multi-1
+    tags: ["stress-test-disagg"]
+  - <<: *format-stress-test-disagg-multi
+    name: format-stress-test-disagg-multi-2
+    tags: ["stress-test-disagg"]
+  - <<: *format-stress-test-disagg-multi
+    name: format-stress-test-disagg-multi-3
+    tags: ["stress-test-disagg"]
+  - <<: *format-stress-test-disagg-multi
+    name: format-stress-test-disagg-multi-4
+    tags: ["stress-test-disagg"]
+  - <<: *format-stress-test-disagg-multi-pull-request
+    name: format-stress-test-disagg-multi-pull-request-1
+    tags: ["pull_request"]
+  - <<: *format-stress-test-disagg-multi-pull-request
+    name: format-stress-test-disagg-multi-pull-request-2
     tags: ["pull_request"]
 
   - name: format-stress-test-disagg-follower-pull-request

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1843,7 +1843,7 @@ variables:
       - func: "format test disagg"
         vars:
           # FIXME-WT-16732: Enable truncate for multi node once predictable replay supports it.
-          format_args: disagg.multi=1 runs.predictable_replay=1 ops.verify=1 disagg.multi_validation=1 runs.ops=2000000:4000000 ops.truncate=0
+          format_args: disagg.multi=1 runs.predictable_replay=1 ops.verify=1 disagg.multi_validation=1 runs.ops=1000000:2000000 ops.truncate=0
           times: 10
           reopen: false # FIXME-WT-16481 Reopen currently causes failures in disagg multi mode.
 
@@ -1855,7 +1855,7 @@ variables:
       - func: "format test disagg"
         vars:
           # FIXME-WT-16732: Enable truncate for multi node once predictable replay supports it.
-          format_args: disagg.multi=1 runs.predictable_replay=1 ops.verify=1 disagg.multi_validation=1 runs.rows=10000 runs.ops=30000 ops.truncate=0
+          format_args: disagg.multi=1 runs.predictable_replay=1 ops.verify=1 disagg.multi_validation=1 runs.rows=5000 runs.ops=20000 ops.truncate=0
           times: 10
           reopen: false # FIXME-WT-16481 Reopen currently causes failures in disagg multi mode.
 

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1794,7 +1794,6 @@ variables:
       - func: "fetch artifacts"
       - func: "format test disagg"
         vars:
-          # FIXME-WT-18173 Enable modifies in disagg multi mode once the related issues have been resolved.
           # FIXME-WT-16732: Enable truncate for multi node once predictable replay supports it.
           format_args: disagg.multi=1 runs.predictable_replay=1 ops.verify=1 disagg.multi_validation=1 runs.ops=2000000:4000000 ops.truncate=0
           times: 10
@@ -1807,7 +1806,6 @@ variables:
       - func: "fetch artifacts"
       - func: "format test disagg"
         vars:
-          # FIXME-WT-18173 Enable modifies in disagg multi mode once the related issues have been resolved.
           # FIXME-WT-16732: Enable truncate for multi node once predictable replay supports it.
           format_args: disagg.multi=1 runs.predictable_replay=1 ops.verify=1 disagg.multi_validation=1 runs.rows=10000 runs.ops=30000 ops.truncate=0
           times: 10

--- a/test/evergreen_disagg.yml
+++ b/test/evergreen_disagg.yml
@@ -582,56 +582,6 @@ variables:
           format_args: disagg.mode=switch debug.disagg_slow_truncate_follower=off runs.timer=10:15 ops.prepare=0 ops.verify=1 runs.mirror=1
           times: 5
 
-  - &format-stress-test-disagg-multi
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "format test disagg"
-        vars:
-          # FIXME-WT-17278 Enable removes in disagg multi mode once the related issues have been resolved.
-          format_args: disagg.multi=1 runs.predictable_replay=1 runs.ops=500000:2000000 ops.pct.delete=0
-          times: 5
-          reopen: false # FIXME-WT-16481 Reopen currently causes failures in disagg multi mode.
-
-  - &format-stress-test-disagg-multi-data-validation
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "format test disagg"
-        vars:
-          # Validate data with a non-layered table.
-          # FIXME-WT-17278 Enable removes in disagg multi mode once the related issues have been resolved.
-          format_args: disagg.multi=1 runs.predictable_replay=1 ops.verify=1 disagg.multi_validation=1 disagg.preserve=1 runs.ops=500000:2000000 ops.pct.delete=0
-          times: 5
-          reopen: false # FIXME-WT-16481 Reopen currently causes failures in disagg multi mode.
-
-  # FIXME-WT-17278 We can get rid of this task once the issues related to removes in disagg multi mode have been resolved.
-  - &format-stress-test-disagg-multi-delete-enabled
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "format test disagg"
-        vars:
-          format_args: disagg.multi=1 runs.predictable_replay=1 runs.ops=500000:2000000
-          times: 5
-          reopen: false # FIXME-WT-16481 Reopen currently causes failures in disagg multi mode.
-
-  # FIXME-WT-17278 We can get rid of this task once the issues related to removes in disagg multi mode have been resolved.
-  - &format-stress-test-disagg-multi-delete-enabled-data-validation
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "format test disagg"
-        vars:
-          # Validate data with a non-layered table.
-          format_args: disagg.multi=1 runs.predictable_replay=1 ops.verify=1 disagg.multi_validation=1 disagg.preserve=1 runs.ops=500000:2000000
-          times: 5
-          reopen: false # FIXME-WT-16481 Reopen currently causes failures in disagg multi mode.
-
   - &timestamp-abort-test-disagg
     depends_on:
         - name: compile
@@ -868,30 +818,6 @@ tasks:
   - <<: *format-stress-test-disagg-switch-fast-truncate
     name: format-stress-test-disagg-switch-fast-truncate-1
     tags: ["stress-test-disagg-fail", "stress-test-disagg-san-fail"]
-  - <<: *format-stress-test-disagg-multi
-    name: format-stress-test-disagg-multi-1
-    tags: ["stress-test-disagg-fail", "stress-test-disagg-san-fail"]
-  - <<: *format-stress-test-disagg-multi
-    name: format-stress-test-disagg-multi-2
-    tags: ["stress-test-disagg-fail"]
-  - <<: *format-stress-test-disagg-multi-data-validation
-    name: format-stress-test-disagg-multi-validation-1
-    tags: ["stress-test-disagg-fail"]
-  - <<: *format-stress-test-disagg-multi-data-validation
-    name: format-stress-test-disagg-multi-validation-2
-    tags: ["stress-test-disagg-fail"]
-  - <<: *format-stress-test-disagg-multi-delete-enabled
-    name: format-stress-test-disagg-multi-delete-enabled-1
-    tags: ["stress-test-disagg-fail", "stress-test-disagg-san-fail"]
-  - <<: *format-stress-test-disagg-multi-delete-enabled
-    name: format-stress-test-disagg-multi-delete-enabled-2
-    tags: ["stress-test-disagg-fail"]
-  - <<: *format-stress-test-disagg-multi-delete-enabled-data-validation
-    name: format-stress-test-disagg-multi-delete-enabled-validation-1
-    tags: ["stress-test-disagg-fail"]
-  - <<: *format-stress-test-disagg-multi-delete-enabled-data-validation
-    name: format-stress-test-disagg-multi-delete-enabled-validation-2
-    tags: ["stress-test-disagg-fail"]
 
   - <<: *timestamp-abort-test-disagg
     name: timestamp-abort-test-disagg-1

--- a/test/evergreen_disagg.yml
+++ b/test/evergreen_disagg.yml
@@ -590,7 +590,7 @@ variables:
       - func: "fetch artifacts"
       - func: "format test disagg"
         vars:
-          format_args: disagg.multi=1 runs.predictable_replay=1 runs.ops=500000:2000000
+          format_args: disagg.multi=1 runs.predictable_replay=1 ops.pct.modify=50:90 runs.ops=500000:2000000
           times: 5
           reopen: false # FIXME-WT-16481 Reopen currently causes failures in disagg multi mode.
 
@@ -603,7 +603,7 @@ variables:
       - func: "format test disagg"
         vars:
           # Validate data with a non-layered table.
-          format_args: disagg.multi=1 runs.predictable_replay=1 ops.verify=1 disagg.multi_validation=1 disagg.preserve=1 runs.ops=500000:2000000
+          format_args: disagg.multi=1 runs.predictable_replay=1 ops.pct.modify=50:90 ops.verify=1 disagg.multi_validation=1 disagg.preserve=1 runs.ops=500000:2000000
           times: 5
           reopen: false # FIXME-WT-16481 Reopen currently causes failures in disagg multi mode.
 

--- a/test/evergreen_disagg.yml
+++ b/test/evergreen_disagg.yml
@@ -582,31 +582,6 @@ variables:
           format_args: disagg.mode=switch debug.disagg_slow_truncate_follower=off runs.timer=10:15 ops.prepare=0 ops.verify=1 runs.mirror=1
           times: 5
 
-  # FIXME-WT-18173 We can get rid of this task once the issues related to modifies in disagg multi mode have been resolved.
-  - &format-stress-test-disagg-multi-modify-enabled
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "format test disagg"
-        vars:
-          format_args: disagg.multi=1 runs.predictable_replay=1 ops.pct.modify=50:90 runs.ops=500000:2000000
-          times: 5
-          reopen: false # FIXME-WT-16481 Reopen currently causes failures in disagg multi mode.
-
-  # FIXME-WT-18173 We can get rid of this task once the issues related to modifies in disagg multi mode have been resolved.
-  - &format-stress-test-disagg-multi-modify-enabled-data-validation
-    depends_on:
-      - name: compile
-    commands:
-      - func: "fetch artifacts"
-      - func: "format test disagg"
-        vars:
-          # Validate data with a non-layered table.
-          format_args: disagg.multi=1 runs.predictable_replay=1 ops.pct.modify=50:90 ops.verify=1 disagg.multi_validation=1 disagg.preserve=1 runs.ops=500000:2000000
-          times: 5
-          reopen: false # FIXME-WT-16481 Reopen currently causes failures in disagg multi mode.
-
   - &timestamp-abort-test-disagg
     depends_on:
         - name: compile
@@ -843,19 +818,6 @@ tasks:
   - <<: *format-stress-test-disagg-switch-fast-truncate
     name: format-stress-test-disagg-switch-fast-truncate-1
     tags: ["stress-test-disagg-fail", "stress-test-disagg-san-fail"]
-
-  - <<: *format-stress-test-disagg-multi-modify-enabled
-    name: format-stress-test-disagg-multi-modify-enabled-1
-    tags: ["stress-test-disagg-fail", "stress-test-disagg-san-fail"]
-  - <<: *format-stress-test-disagg-multi-modify-enabled
-    name: format-stress-test-disagg-multi-modify-enabled-2
-    tags: ["stress-test-disagg-fail"]
-  - <<: *format-stress-test-disagg-multi-modify-enabled-data-validation
-    name: format-stress-test-disagg-multi-modify-enabled-validation-1
-    tags: ["stress-test-disagg-fail"]
-  - <<: *format-stress-test-disagg-multi-modify-enabled-data-validation
-    name: format-stress-test-disagg-multi-modify-enabled-validation-2
-    tags: ["stress-test-disagg-fail"]
 
   - <<: *timestamp-abort-test-disagg
     name: timestamp-abort-test-disagg-1

--- a/test/evergreen_disagg.yml
+++ b/test/evergreen_disagg.yml
@@ -582,6 +582,31 @@ variables:
           format_args: disagg.mode=switch debug.disagg_slow_truncate_follower=off runs.timer=10:15 ops.prepare=0 ops.verify=1 runs.mirror=1
           times: 5
 
+  # FIXME-WT-18173 We can get rid of this task once the issues related to modifies in disagg multi mode have been resolved.
+  - &format-stress-test-disagg-multi-modify-enabled
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "format test disagg"
+        vars:
+          format_args: disagg.multi=1 runs.predictable_replay=1 runs.ops=500000:2000000
+          times: 5
+          reopen: false # FIXME-WT-16481 Reopen currently causes failures in disagg multi mode.
+
+  # FIXME-WT-18173 We can get rid of this task once the issues related to modifies in disagg multi mode have been resolved.
+  - &format-stress-test-disagg-multi-modify-enabled-data-validation
+    depends_on:
+      - name: compile
+    commands:
+      - func: "fetch artifacts"
+      - func: "format test disagg"
+        vars:
+          # Validate data with a non-layered table.
+          format_args: disagg.multi=1 runs.predictable_replay=1 ops.verify=1 disagg.multi_validation=1 disagg.preserve=1 runs.ops=500000:2000000
+          times: 5
+          reopen: false # FIXME-WT-16481 Reopen currently causes failures in disagg multi mode.
+
   - &timestamp-abort-test-disagg
     depends_on:
         - name: compile
@@ -818,6 +843,19 @@ tasks:
   - <<: *format-stress-test-disagg-switch-fast-truncate
     name: format-stress-test-disagg-switch-fast-truncate-1
     tags: ["stress-test-disagg-fail", "stress-test-disagg-san-fail"]
+
+  - <<: *format-stress-test-disagg-multi-modify-enabled
+    name: format-stress-test-disagg-multi-modify-enabled-1
+    tags: ["stress-test-disagg-fail", "stress-test-disagg-san-fail"]
+  - <<: *format-stress-test-disagg-multi-modify-enabled
+    name: format-stress-test-disagg-multi-modify-enabled-2
+    tags: ["stress-test-disagg-fail"]
+  - <<: *format-stress-test-disagg-multi-modify-enabled-data-validation
+    name: format-stress-test-disagg-multi-modify-enabled-validation-1
+    tags: ["stress-test-disagg-fail"]
+  - <<: *format-stress-test-disagg-multi-modify-enabled-data-validation
+    name: format-stress-test-disagg-multi-modify-enabled-validation-2
+    tags: ["stress-test-disagg-fail"]
 
   - <<: *timestamp-abort-test-disagg
     name: timestamp-abort-test-disagg-1

--- a/test/format/t.c
+++ b/test/format/t.c
@@ -300,10 +300,10 @@ main(int argc, char *argv[])
         config_single(NULL, *argv, true);
 
     /*
-     * Let the command line -q flag override values configured from other sources. Regardless, don't
-     * go all verbose if we're not talking to a terminal.
+     * Let the command line -q flag override values configured from other sources. Multi-node runs
+     * retain configured verbosity for their separate leader and follower logs.
      */
-    if (quiet_flag || !isatty(1))
+    if ((quiet_flag || !isatty(1)) && !disagg_is_multi_node())
         GV(QUIET) = 1;
 
     /* Configure the random number generators. */

--- a/test/format/verify.c
+++ b/test/format/verify.c
@@ -48,11 +48,10 @@ table_verify(TABLE *table, void *arg)
     wt_wrap_open_session(conn, &sap, table->track_prefix, session_prefetch_cfg(), &session);
 
     /*
-     * Verify can race with special-handle transitions and return EBUSY. In switch mode, async role
-     * switches can leave handles in a dirty state; skip the retry delay to avoid minutes of
-     * accumulated wait time across many runs. FIXME - WT-18083
+     * Verify can race with special-handle transitions and return EBUSY. In switch and multi-node
+     * modes, skip the retry delay to avoid minutes of accumulated wait time across many runs.
      */
-    if (disagg_is_mode_switch()) {
+    if (disagg_is_mode_switch() || disagg_is_multi_node()) {
         ret = session->verify(session, table->uri, "strict");
         retries = 0;
     } else {
@@ -73,8 +72,8 @@ table_verify(TABLE *table, void *arg)
       ret == 0 || ret == EBUSY || (g.disagg_storage_config && !g.disagg_leader && ret == ENOENT));
 
     if (ret == EBUSY) {
-        if (disagg_is_mode_switch())
-            WARN("table.%u skipped verify in switch mode (EBUSY)", table->id);
+        if (disagg_is_mode_switch() || disagg_is_multi_node())
+            WARN("table.%u skipped verify in disagg mode (EBUSY)", table->id);
         else
             WARN("table.%u skipped verify because of EBUSY after %u retries", table->id, retries);
     }


### PR DESCRIPTION
This PR enables disagg multi-node test/format on the mainline Evergreen waterfall.