### PR TITLE
WT-18119 Trust zero checkpoint size in the statistics=(size) fast path

### DIFF
--- a/src/cursor/cur_stat.c
+++ b/src/cursor/cur_stat.c
@@ -533,10 +533,23 @@ __curstat_size_local(
 }
 
 /*
+ * __curstat_size_shared --
+ *     Fast-path size retrieval from shared-file metadata. Metadata with no checkpoint entry has a
+ *     size of zero.
+ */
+static int
+__curstat_size_shared(WT_SESSION_IMPL *session, const char *file_config, int64_t *sizep)
+{
+    uint64_t checkpoint_size = 0;
+    WT_RET_NOTFOUND_OK(__wt_ckpt_last_size(session, file_config, &checkpoint_size));
+    *sizep = (int64_t)checkpoint_size;
+    return (0);
+}
+
+/*
  * __curstat_file_size --
  *     Fast-path size retrieval for a file URI. On a disaggregated connection, use file metadata to
- *     select the size source. Returns WT_NOTFOUND on metadata failure (does not exist or could not
- *     be parsed).
+ *     select the size source. A missing metadata entry returns WT_NOTFOUND.
  */
 static int
 __curstat_file_size(WT_SESSION_IMPL *session, const char *file_uri, bool *was_fastp, int64_t *sizep)
@@ -558,13 +571,9 @@ __curstat_file_size(WT_SESSION_IMPL *session, const char *file_uri, bool *was_fa
 
     /* Use the block manager to classify if the file is disagg or not. */
     WT_ERR(__wt_btree_shared(session, file_uri, config, &shared));
-
     if (shared) {
-        /* A shared file without a checkpoint entry has a size of zero. */
-        uint64_t checkpoint_size = 0;
-        WT_ERR_NOTFOUND_OK(__wt_ckpt_last_size(session, file_config, &checkpoint_size), false);
+        WT_ERR(__curstat_size_shared(session, file_config, sizep));
         *was_fastp = true;
-        *sizep = (int64_t)checkpoint_size;
     } else
         WT_ERR(__curstat_size_local(session, filename, was_fastp, sizep));
 
@@ -575,8 +584,8 @@ err:
 
 /*
  * __curstat_table_size --
- *     Fast-path size retrieval for a simple table URI. Returns WT_NOTFOUND on metadata failure
- *     (does not exist or could not be parsed).
+ *     Fast-path size retrieval for a simple table URI. A missing table metadata entry returns
+ *     WT_NOTFOUND.
  */
 static int
 __curstat_table_size(
@@ -591,6 +600,7 @@ __curstat_table_size(
     WT_CONFIG_ITEM column_config = {0};
     WT_ITEM uri_buffer = {0};
     bool simple = false;
+    char *stable_config = NULL;
     char *table_config = NULL;
 
     /* Only tables that are "simple" (no named columns) can use the fast path. */
@@ -600,10 +610,15 @@ __curstat_table_size(
     if (!simple)
         goto err;
 
-    /* Only probe for a stable file on a connection that can create one. */
+    /* A stable file is always shared, so read its metadata directly. */
     if (__wt_conn_is_disagg(session)) {
         WT_ERR(__wt_buf_fmt(session, &uri_buffer, "file:%s.wt_stable", table_name));
-        WT_ERR_NOTFOUND_OK(__curstat_file_size(session, uri_buffer.data, was_fastp, sizep), false);
+        ret = __wt_metadata_search(session, uri_buffer.data, &stable_config);
+        if (ret == 0) {
+            WT_ERR(__curstat_size_shared(session, stable_config, sizep));
+            *was_fastp = true;
+        }
+        WT_ERR_NOTFOUND_OK(ret, false);
     }
 
     /* At this point, disagg or not, fall back to the local non-layered file. */
@@ -613,6 +628,7 @@ __curstat_table_size(
     }
 
 err:
+    __wt_free(session, stable_config);
     __wt_free(session, table_config);
     __wt_buf_free(session, &uri_buffer);
     return (ret);

--- a/src/cursor/cur_stat.c
+++ b/src/cursor/cur_stat.c
@@ -540,6 +540,8 @@ __curstat_size_local(
 static int
 __curstat_size_shared(WT_SESSION_IMPL *session, const char *file_config, int64_t *sizep)
 {
+    WT_ASSERT(session, file_config != NULL);
+
     uint64_t checkpoint_size = 0;
     WT_RET_NOTFOUND_OK(__wt_ckpt_last_size(session, file_config, &checkpoint_size));
     *sizep = (int64_t)checkpoint_size;
@@ -958,3 +960,32 @@ err:
 
     return (ret);
 }
+
+#ifdef HAVE_UNITTEST
+int
+__ut_curstat_size_local(
+  WT_SESSION_IMPL *session, const char *filename, bool *was_fastp, int64_t *sizep)
+{
+    return (__curstat_size_local(session, filename, was_fastp, sizep));
+}
+
+int
+__ut_curstat_size_shared(WT_SESSION_IMPL *session, const char *file_config, int64_t *sizep)
+{
+    return (__curstat_size_shared(session, file_config, sizep));
+}
+
+int
+__ut_curstat_file_size(
+  WT_SESSION_IMPL *session, const char *file_uri, bool *was_fastp, int64_t *sizep)
+{
+    return (__curstat_file_size(session, file_uri, was_fastp, sizep));
+}
+
+int
+__ut_curstat_table_size(
+  WT_SESSION_IMPL *session, const char *table_uri, bool *was_fastp, int64_t *sizep)
+{
+    return (__curstat_table_size(session, table_uri, was_fastp, sizep));
+}
+#endif

--- a/src/cursor/cur_stat.c
+++ b/src/cursor/cur_stat.c
@@ -505,116 +505,143 @@ err:
 
 /*
  * __curstat_size_local --
- *     Fast-path size retrieval for a local file. Returns WT_NOTFOUND if the file does not exist.
+ *     Fast-path size retrieval for a local file. *was_fast is true if the lookup is successful, or
+ *     false if the file is missing.
  */
 static int
-__curstat_size_local(WT_SESSION_IMPL *session, const char *filename, int64_t *sizep)
+__curstat_size_local(
+  WT_SESSION_IMPL *session, const char *filename, bool *was_fastp, int64_t *sizep)
 {
+    *was_fastp = false;
+
     bool file_exists = false;
     WT_RET(__wt_fs_exist(session, filename, &file_exists));
     if (!file_exists)
-        return (WT_NOTFOUND);
+        return (0);
 
     wt_off_t size = 0;
-    WT_RET(__wt_block_manager_named_size(session, filename, &size));
+    const int ret = __wt_block_manager_named_size(session, filename, &size);
+
+    /* Treat a concurrent file removal the same as the file not originally existing. */
+    if (ret == ENOENT)
+        return (0);
+    WT_RET(ret);
+
+    *was_fastp = true;
     *sizep = (int64_t)size;
     return (0);
 }
 
 /*
- * __curstat_size_disagg --
- *     Fast-path size retrieval for a disaggregated file URI. Returns ENOENT if its metadata entry
- *     does not exist. An existing metadata entry with no checkpoints has a size of zero.
+ * __curstat_file_size --
+ *     Fast-path size retrieval for a file URI. On a disaggregated connection, use file metadata to
+ *     select the size source. Returns WT_NOTFOUND on metadata failure (does not exist or could not
+ *     be parsed).
  */
 static int
-__curstat_size_disagg(WT_SESSION_IMPL *session, const char *file_uri, int64_t *sizep)
+__curstat_file_size(WT_SESSION_IMPL *session, const char *file_uri, bool *was_fastp, int64_t *sizep)
 {
+    const char *filename = file_uri;
+    WT_PREFIX_SKIP_REQUIRED(session, filename, "file:");
+
+    *was_fastp = false;
+
+    if (!__wt_conn_is_disagg(session))
+        return (__curstat_size_local(session, filename, was_fastp, sizep));
+
     char *file_config = NULL;
-    int ret = __wt_metadata_search(session, file_uri, &file_config);
+    WT_RET(__wt_metadata_search(session, file_uri, &file_config));
 
-    /*
-     * Map a missing metadata entry to ENOENT. Returning WT_NOTFOUND would send the caller to the
-     * dhandle slow path, which disaggregated lookups must never take.
-     */
-    if (ret == WT_NOTFOUND)
-        return (__wt_set_return(session, ENOENT));
-    WT_RET(ret);
+    WT_DECL_RET;
+    const char *config[] = {WT_CONFIG_BASE(session, file_meta), file_config, NULL};
+    bool shared = false;
 
-    uint64_t checkpoint_size = 0;
-    ret = __wt_ckpt_last_size(session, file_config, &checkpoint_size);
+    /* Use the block manager to classify if the file is disagg or not. */
+    WT_ERR(__wt_btree_shared(session, file_uri, config, &shared));
+
+    if (shared) {
+        /* A shared file without a checkpoint entry has a size of zero. */
+        uint64_t checkpoint_size = 0;
+        WT_ERR_NOTFOUND_OK(__wt_ckpt_last_size(session, file_config, &checkpoint_size), false);
+        *was_fastp = true;
+        *sizep = (int64_t)checkpoint_size;
+    } else
+        WT_ERR(__curstat_size_local(session, filename, was_fastp, sizep));
+
+err:
     __wt_free(session, file_config);
-
-    /* No checkpoint entries is considered a zero size case. */
-    WT_RET_NOTFOUND_OK(ret);
-    *sizep = (int64_t)checkpoint_size;
-    return (0);
+    return (ret);
 }
 
 /*
  * __curstat_table_size --
- *     Fast-path size retrieval for a simple table URI.
+ *     Fast-path size retrieval for a simple table URI. Returns WT_NOTFOUND on metadata failure
+ *     (does not exist or could not be parsed).
  */
 static int
-__curstat_table_size(WT_SESSION_IMPL *session, const char *table_uri, int64_t *sizep)
+__curstat_table_size(
+  WT_SESSION_IMPL *session, const char *table_uri, bool *was_fastp, int64_t *sizep)
 {
     const char *table_name = table_uri;
     WT_PREFIX_SKIP_REQUIRED(session, table_name, "table:");
 
+    *was_fastp = false;
+
     WT_DECL_RET;
     WT_CONFIG_ITEM column_config = {0};
-    WT_ITEM name_buffer = {0};
+    WT_ITEM uri_buffer = {0};
     bool simple = false;
     char *table_config = NULL;
 
-    /* The fast path only works for tables without named columns. */
+    /* Only tables that are "simple" (no named columns) can use the fast path. */
     WT_RET(__wt_metadata_search(session, table_uri, &table_config));
     WT_ERR(__wt_config_getones(session, table_config, "columns", &column_config));
     WT_ERR(__wt_is_simple_table(session, &column_config, &simple));
-    if (!simple) {
-        ret = WT_NOTFOUND;
+    if (!simple)
         goto err;
-    }
 
+    /* Only probe for a stable file on a connection that can create one. */
     if (__wt_conn_is_disagg(session)) {
-        WT_ERR(__wt_buf_fmt(session, &name_buffer, "file:%s.wt_stable", table_name));
-        ret = __curstat_size_disagg(session, name_buffer.data, sizep);
-
-        /* A missing stable metadata entry falls back to the local file. */
-        if (ret != ENOENT)
-            goto err;
+        WT_ERR(__wt_buf_fmt(session, &uri_buffer, "file:%s.wt_stable", table_name));
+        WT_ERR_NOTFOUND_OK(__curstat_file_size(session, uri_buffer.data, was_fastp, sizep), false);
     }
 
-    WT_ERR(__wt_buf_fmt(session, &name_buffer, "%s.wt", table_name));
-    ret = __curstat_size_local(session, name_buffer.data, sizep);
+    /* At this point, disagg or not, fall back to the local non-layered file. */
+    if (!*was_fastp) {
+        WT_ERR(__wt_buf_fmt(session, &uri_buffer, "file:%s.wt", table_name));
+        WT_ERR_NOTFOUND_OK(__curstat_file_size(session, uri_buffer.data, was_fastp, sizep), false);
+    }
 
 err:
     __wt_free(session, table_config);
-    __wt_buf_free(session, &name_buffer);
+    __wt_buf_free(session, &uri_buffer);
     return (ret);
 }
 
 /*
  * __curstat_size --
- *     Fast-path size retrieval for a file or simple table URI.
+ *     Fast-path size retrieval for a file or table URI.
  */
 static int
-__curstat_size(WT_SESSION_IMPL *session, const char *uri, int64_t *sizep)
+__curstat_size(WT_SESSION_IMPL *session, const char *uri, bool *was_fastp, int64_t *sizep)
 {
     WT_ASSERT(session, uri != NULL);
+    WT_ASSERT(session, was_fastp != NULL);
     WT_ASSERT(session, sizep != NULL);
 
+    *was_fastp = false;
     *sizep = 0;
 
     if (WT_PREFIX_MATCH(uri, "table:"))
-        return (__curstat_table_size(session, uri, sizep));
+        return (__curstat_table_size(session, uri, was_fastp, sizep));
 
-    const char *filename = uri;
-    WT_PREFIX_SKIP_REQUIRED(session, filename, "file:");
+    WT_ASSERT(session, WT_PREFIX_MATCH(uri, "file:"));
 
-    if (__wt_conn_is_disagg(session) && WT_SUFFIX_MATCH(uri, ".wt_stable"))
-        return (__curstat_size_disagg(session, uri, sizep));
+    /* Checkpoint-view URIs require the slow path. */
+    if (WT_URI_IS_STABLE_CHECKPOINT(uri))
+        return (0);
 
-    return (__curstat_size_local(session, filename, sizep));
+    return (__curstat_file_size(session, uri, was_fastp, sizep));
 }
 
 /*
@@ -705,10 +732,6 @@ __curstat_session_init(WT_SESSION_IMPL *session, WT_CURSOR_STAT *cst)
 int
 __wt_curstat_init(WT_SESSION_IMPL *session, const char *uri, const char *cfg[], WT_CURSOR_STAT *cst)
 {
-    WT_DECL_RET;
-    int64_t size = 0;
-    const char *dsrc_uri = NULL;
-
     if (strcmp(uri, "statistics:") == 0) {
         __curstat_conn_init(session, cst);
         return (0);
@@ -716,22 +739,21 @@ __wt_curstat_init(WT_SESSION_IMPL *session, const char *uri, const char *cfg[], 
 
     /* Data source statistics are only available after recovery completes. */
     WT_ASSERT(session, F_ISSET(S2C(session), WT_CONN_RECOVERY_COMPLETE));
-    dsrc_uri = uri + strlen("statistics:");
+    const char *dsrc_uri = uri + strlen("statistics:");
 
-    /*
-     * Resolve size-only statistics from local files or metadata before falling back to dhandle
-     * statistics or schema operations.
-     */
+    /* Resolve file or simple-table sizes without opening dhandles or performing schema ops. */
     if (F_ISSET(cst, WT_STAT_TYPE_SIZE) &&
       (WT_PREFIX_MATCH(dsrc_uri, "file:") || WT_PREFIX_MATCH(dsrc_uri, "table:"))) {
-        ret = __curstat_size(session, dsrc_uri, &size);
-        if (ret == 0) {
+        bool was_fast = false;
+        int64_t size = 0;
+        WT_RET(__curstat_size(session, dsrc_uri, &was_fast, &size));
+
+        if (was_fast) {
             __wt_stat_dsrc_init_single(&cst->u.dsrc_stats);
             cst->u.dsrc_stats.block_size = size;
             __wt_curstat_dsrc_final(cst);
             return (0);
         }
-        WT_RET_NOTFOUND_OK(ret);
     }
 
     if (strcmp(dsrc_uri, "session") == 0) {

--- a/src/cursor/cur_stat.c
+++ b/src/cursor/cur_stat.c
@@ -523,9 +523,9 @@ __curstat_size_local(
     const int ret = __wt_block_manager_named_size(session, filename, &size);
 
     /* Treat a concurrent file removal the same as the file not originally existing. */
+    WT_RET_ERROR_OK(ret, ENOENT);
     if (ret == ENOENT)
         return (0);
-    WT_RET(ret);
 
     *was_fastp = true;
     *sizep = (int64_t)size;
@@ -559,18 +559,18 @@ __curstat_file_size(WT_SESSION_IMPL *session, const char *file_uri, bool *was_fa
 
     *was_fastp = false;
 
-    if (!__wt_conn_is_disagg(session))
-        return (__curstat_size_local(session, filename, was_fastp, sizep));
-
-    char *file_config = NULL;
-    WT_RET(__wt_metadata_search(session, file_uri, &file_config));
-
     WT_DECL_RET;
-    const char *config[] = {WT_CONFIG_BASE(session, file_meta), file_config, NULL};
+    char *file_config = NULL;
     bool shared = false;
 
-    /* Use the block manager to classify if the file is disagg or not. */
-    WT_ERR(__wt_btree_shared(session, file_uri, config, &shared));
+    if (__wt_conn_is_disagg(session)) {
+        WT_ERR(__wt_metadata_search(session, file_uri, &file_config));
+        const char *config[] = {WT_CONFIG_BASE(session, file_meta), file_config, NULL};
+
+        /* Use the block manager to classify if the file is disagg or not. */
+        WT_ERR(__wt_btree_shared(session, file_uri, config, &shared));
+    }
+
     if (shared) {
         WT_ERR(__curstat_size_shared(session, file_config, sizep));
         *was_fastp = true;

--- a/src/cursor/cur_stat.c
+++ b/src/cursor/cur_stat.c
@@ -504,65 +504,117 @@ err:
 }
 
 /*
- * __wt_curstat_size_local --
- *     Fast-path size retrieval for a local file. If the file exists, set *existp and return the
- *     size via *sizep. A non-existent file is not an error; *existp will be false.
- */
-int
-__wt_curstat_size_local(
-  WT_SESSION_IMPL *session, const char *filename, bool *existp, int64_t *sizep)
-{
-    wt_off_t size;
-
-    WT_RET(__wt_fs_exist(session, filename, existp));
-    if (*existp) {
-        WT_RET(__wt_block_manager_named_size(session, filename, &size));
-        *sizep = (int64_t)size;
-    }
-
-    return (0);
-}
-
-/*
- * __wt_curstat_size_disagg --
- *     Fast-path size retrieval for a disaggregated table. There is no local file on disk, so the
- *     size comes from the last checkpoint entry in the metadata. If found, set *existp and return
- *     the size via *sizep. A missing metadata entry is not an error; *existp will be false.
- */
-int
-__wt_curstat_size_disagg(WT_SESSION_IMPL *session, const char *uri, bool *existp, int64_t *sizep)
-{
-    uint64_t ckpt_size;
-
-    *existp = false;
-    WT_RET(__wt_block_disagg_ckpt_size(session, uri, &ckpt_size));
-    if (ckpt_size > 0) {
-        *sizep = (int64_t)ckpt_size;
-        *existp = true;
-    }
-
-    return (0);
-}
-
-/*
- * __curstat_file_size --
- *     Fast-path size retrieval for a file: URI. Try to determine the size without opening the
- *     dhandle: first check for a local file on disk, then fall back to reading the checkpoint size
- *     from the metadata (for disaggregated storage). If neither succeeds, *existp is false and the
- *     caller should fall through to the slow path.
+ * __curstat_size_local --
+ *     Fast-path size retrieval for a local file. Returns WT_NOTFOUND if the file does not exist.
  */
 static int
-__curstat_file_size(
-  WT_SESSION_IMPL *session, const char *uri, const char *filename, bool *existp, int64_t *sizep)
+__curstat_size_local(WT_SESSION_IMPL *session, const char *filename, int64_t *sizep)
 {
-    /* Try the local file first. */
-    WT_RET(__wt_curstat_size_local(session, filename, existp, sizep));
-    if (*existp)
-        return (0);
+    bool file_exists = false;
+    WT_RET(__wt_fs_exist(session, filename, &file_exists));
+    if (!file_exists)
+        return (WT_NOTFOUND);
 
-    /* No local file; check the metadata for a disagg checkpoint size. */
-    WT_RET(__wt_curstat_size_disagg(session, uri, existp, sizep));
+    wt_off_t size = 0;
+    WT_RET(__wt_block_manager_named_size(session, filename, &size));
+    *sizep = (int64_t)size;
     return (0);
+}
+
+/*
+ * __curstat_size_disagg --
+ *     Fast-path size retrieval for a disaggregated file URI. Returns ENOENT if its metadata entry
+ *     does not exist. An existing metadata entry with no checkpoints has a size of zero.
+ */
+static int
+__curstat_size_disagg(WT_SESSION_IMPL *session, const char *file_uri, int64_t *sizep)
+{
+    char *file_config = NULL;
+    int ret = __wt_metadata_search(session, file_uri, &file_config);
+
+    /*
+     * Map a missing metadata entry to ENOENT. Returning WT_NOTFOUND would send the caller to the
+     * dhandle slow path, which disaggregated lookups must never take.
+     */
+    if (ret == WT_NOTFOUND)
+        return (__wt_set_return(session, ENOENT));
+    WT_RET(ret);
+
+    uint64_t checkpoint_size = 0;
+    ret = __wt_ckpt_last_size(session, file_config, &checkpoint_size);
+    __wt_free(session, file_config);
+
+    /* No checkpoint entries is considered a zero size case. */
+    WT_RET_NOTFOUND_OK(ret);
+    *sizep = (int64_t)checkpoint_size;
+    return (0);
+}
+
+/*
+ * __curstat_table_size --
+ *     Fast-path size retrieval for a simple table URI.
+ */
+static int
+__curstat_table_size(WT_SESSION_IMPL *session, const char *table_uri, int64_t *sizep)
+{
+    const char *table_name = table_uri;
+    WT_PREFIX_SKIP_REQUIRED(session, table_name, "table:");
+
+    WT_DECL_RET;
+    WT_CONFIG_ITEM column_config = {0};
+    WT_ITEM name_buffer = {0};
+    bool simple = false;
+    char *table_config = NULL;
+
+    /* The fast path only works for tables without named columns. */
+    WT_RET(__wt_metadata_search(session, table_uri, &table_config));
+    WT_ERR(__wt_config_getones(session, table_config, "columns", &column_config));
+    WT_ERR(__wt_is_simple_table(session, &column_config, &simple));
+    if (!simple) {
+        ret = WT_NOTFOUND;
+        goto err;
+    }
+
+    if (__wt_conn_is_disagg(session)) {
+        WT_ERR(__wt_buf_fmt(session, &name_buffer, "file:%s.wt_stable", table_name));
+        ret = __curstat_size_disagg(session, name_buffer.data, sizep);
+
+        /* A missing stable metadata entry falls back to the local file. */
+        if (ret != ENOENT)
+            goto err;
+    }
+
+    WT_ERR(__wt_buf_fmt(session, &name_buffer, "%s.wt", table_name));
+    ret = __curstat_size_local(session, name_buffer.data, sizep);
+
+err:
+    __wt_free(session, table_config);
+    __wt_buf_free(session, &name_buffer);
+    return (ret);
+}
+
+/*
+ * __curstat_size --
+ *     Fast-path size retrieval for a file or simple table URI.
+ */
+static int
+__curstat_size(WT_SESSION_IMPL *session, const char *uri, int64_t *sizep)
+{
+    WT_ASSERT(session, uri != NULL);
+    WT_ASSERT(session, sizep != NULL);
+
+    *sizep = 0;
+
+    if (WT_PREFIX_MATCH(uri, "table:"))
+        return (__curstat_table_size(session, uri, sizep));
+
+    const char *filename = uri;
+    WT_PREFIX_SKIP_REQUIRED(session, filename, "file:");
+
+    if (__wt_conn_is_disagg(session) && WT_SUFFIX_MATCH(uri, ".wt_stable"))
+        return (__curstat_size_disagg(session, uri, sizep));
+
+    return (__curstat_size_local(session, filename, sizep));
 }
 
 /*
@@ -575,32 +627,6 @@ __curstat_file_init(
 {
     WT_DATA_HANDLE *dhandle;
     WT_DECL_RET;
-    int64_t size;
-    const char *filename;
-    bool exist;
-
-    /*
-     * If we are only getting the size of the file, try to avoid opening the dhandle. This only
-     * applies to file: types. Tiered tables need to use the dhandle. If the fast path fails to
-     * determine a size, fall through to the slow path below.
-     */
-    if (F_ISSET(cst, WT_STAT_TYPE_SIZE) && WT_PREFIX_MATCH(uri, "file:")) {
-        filename = uri;
-        WT_PREFIX_SKIP(filename, "file:");
-
-        size = 0;
-        WT_RET(__curstat_file_size(session, uri, filename, &exist, &size));
-        if (exist) {
-            __wt_stat_dsrc_init_single(&cst->u.dsrc_stats);
-            cst->u.dsrc_stats.block_size = size;
-            __wt_curstat_dsrc_final(cst);
-            return (0);
-        }
-        /*
-         * Neither the local file nor the disagg metadata entry was found; fall through to the slow
-         * path which opens the dhandle.
-         */
-    }
 
     WT_RET(__wt_session_get_btree_ckpt(session, uri, cfg, 0, NULL, NULL));
     dhandle = session->dhandle;
@@ -679,7 +705,9 @@ __curstat_session_init(WT_SESSION_IMPL *session, WT_CURSOR_STAT *cst)
 int
 __wt_curstat_init(WT_SESSION_IMPL *session, const char *uri, const char *cfg[], WT_CURSOR_STAT *cst)
 {
-    const char *dsrc_uri;
+    WT_DECL_RET;
+    int64_t size = 0;
+    const char *dsrc_uri = NULL;
 
     if (strcmp(uri, "statistics:") == 0) {
         __curstat_conn_init(session, cst);
@@ -689,6 +717,22 @@ __wt_curstat_init(WT_SESSION_IMPL *session, const char *uri, const char *cfg[], 
     /* Data source statistics are only available after recovery completes. */
     WT_ASSERT(session, F_ISSET(S2C(session), WT_CONN_RECOVERY_COMPLETE));
     dsrc_uri = uri + strlen("statistics:");
+
+    /*
+     * Resolve size-only statistics from local files or metadata before falling back to dhandle
+     * statistics or schema operations.
+     */
+    if (F_ISSET(cst, WT_STAT_TYPE_SIZE) &&
+      (WT_PREFIX_MATCH(dsrc_uri, "file:") || WT_PREFIX_MATCH(dsrc_uri, "table:"))) {
+        ret = __curstat_size(session, dsrc_uri, &size);
+        if (ret == 0) {
+            __wt_stat_dsrc_init_single(&cst->u.dsrc_stats);
+            cst->u.dsrc_stats.block_size = size;
+            __wt_curstat_dsrc_final(cst);
+            return (0);
+        }
+        WT_RET_NOTFOUND_OK(ret);
+    }
 
     if (strcmp(dsrc_uri, "session") == 0) {
         __curstat_session_init(session, cst);

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -541,10 +541,6 @@ extern int __wt_curstat_init(WT_SESSION_IMPL *session, const char *uri, const ch
   WT_CURSOR_STAT *cst) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_curstat_open(WT_SESSION_IMPL *session, const char *uri, const char *cfg[],
   WT_CURSOR **cursorp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_curstat_size_disagg(WT_SESSION_IMPL *session, const char *uri, bool *existp,
-  int64_t *sizep) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
-extern int __wt_curstat_size_local(WT_SESSION_IMPL *session, const char *filename, bool *existp,
-  int64_t *sizep) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_curstat_table_init(WT_SESSION_IMPL *session, const char *uri, const char *cfg[],
   WT_CURSOR_STAT *cst) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_curtable_open(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR *owner,

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -2756,6 +2756,14 @@ extern int __ut_block_size_prealloc(WT_SESSION_IMPL *session, u_int max)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __ut_ckpt_mod_blkmod_entry(WT_SESSION_IMPL *session, WT_CKPT_BLOCK_MODS *blk_mod,
   wt_off_t offset, wt_off_t len) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __ut_curstat_file_size(WT_SESSION_IMPL *session, const char *file_uri, bool *was_fastp,
+  int64_t *sizep) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __ut_curstat_size_local(WT_SESSION_IMPL *session, const char *filename, bool *was_fastp,
+  int64_t *sizep) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __ut_curstat_size_shared(WT_SESSION_IMPL *session, const char *file_config,
+  int64_t *sizep) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __ut_curstat_table_size(WT_SESSION_IMPL *session, const char *table_uri, bool *was_fastp,
+  int64_t *sizep) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __ut_disagg_parse_version_and_check(WT_SESSION_IMPL *session, const WT_ITEM *meta_buf,
   WT_DISAGG_METADATA *metadata) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __ut_disagg_replace_checkpoint(

--- a/src/schema/schema_stat.c
+++ b/src/schema/schema_stat.c
@@ -55,68 +55,6 @@ err:
 }
 
 /*
- * __curstat_size_only --
- *     For very simple tables we can avoid getting table handles if configured to only retrieve the
- *     size. It's worthwhile because workloads that create and drop a lot of tables can put a lot of
- *     pressure on the table list lock.
- */
-static int
-__curstat_size_only(WT_SESSION_IMPL *session, const char *uri, bool *was_fast, WT_CURSOR_STAT *cst)
-{
-    WT_CONFIG cparser;
-    WT_CONFIG_ITEM ckey, colconf, cval;
-    WT_DECL_RET;
-    WT_ITEM namebuf;
-    int64_t size;
-    char *tableconf;
-    const char *table_name;
-
-    WT_CLEAR(namebuf);
-    size = 0;
-    table_name = uri + strlen("table:");
-    *was_fast = false;
-
-    /* Retrieve the metadata for this table. */
-    WT_RET(__wt_metadata_search(session, uri, &tableconf));
-
-    /*
-     * The fast path only works if the table consists of a single file and does not have any
-     * indexes. The absence of named columns is how we determine that neither of those conditions
-     * can be satisfied.
-     */
-    WT_ERR(__wt_config_getones(session, tableconf, "columns", &colconf));
-    __wt_config_subinit(session, &cparser, &colconf);
-    if ((ret = __wt_config_next(&cparser, &ckey, &cval)) == 0)
-        goto err;
-
-    /* Only probe for a stable file on a connection that can create one. */
-    if (__wt_conn_is_disagg(session)) {
-        WT_ERR(__wt_buf_fmt(session, &namebuf, "file:%s.wt_stable", table_name));
-        WT_ERR(__wt_curstat_size_disagg(session, namebuf.data, was_fast, &size));
-    }
-
-    /*
-     * At this point, disagg or not, fall back to the local non-layered file.
-     */
-    if (!*was_fast) {
-        WT_ERR(__wt_buf_fmt(session, &namebuf, "%s.wt", table_name));
-        WT_ERR(__wt_curstat_size_local(session, namebuf.data, was_fast, &size));
-    }
-
-    if (*was_fast) {
-        __wt_stat_dsrc_init_single(&cst->u.dsrc_stats);
-        cst->u.dsrc_stats.block_size = size;
-        __wt_curstat_dsrc_final(cst);
-    }
-
-err:
-    __wt_free(session, tableconf);
-    __wt_buf_free(session, &namebuf);
-
-    return (ret);
-}
-
-/*
  * __wt_curstat_table_init --
  *     Initialize the statistics for a table.
  */
@@ -131,17 +69,6 @@ __wt_curstat_table_init(
     WT_TABLE *table;
     u_int i;
     const char *name;
-    bool was_fast;
-
-    /*
-     * If only gathering table size statistics, try a fast path that avoids the schema and table
-     * list locks.
-     */
-    if (F_ISSET(cst, WT_STAT_TYPE_SIZE)) {
-        WT_RET(__curstat_size_only(session, uri, &was_fast, cst));
-        if (was_fast)
-            return (0);
-    }
 
     name = uri + strlen("table:");
     WT_RET(__wt_schema_get_table(session, name, strlen(name), false, 0, &table));

--- a/test/catch2/CMakeLists.txt
+++ b/test/catch2/CMakeLists.txt
@@ -59,6 +59,7 @@ else()
         cursors/api/test_bulk_cursor.cpp
         cursors/unit/test_bounds_restore.cpp
         cursors/unit/test_cursor_get_raw_key_value.cpp
+        cursors/unit/test_curstat_size.cpp
         cursors/unit/test_layered_op.cpp
         ext/test_key_provider.cpp
         ext/test_key_provider_header.cpp

--- a/test/catch2/CMakeLists.txt
+++ b/test/catch2/CMakeLists.txt
@@ -120,6 +120,7 @@ set(unittest_sources
     wrappers/connection_wrapper.cpp
     wrappers/item_wrapper.cpp
     wrappers/mock_connection.cpp
+    wrappers/mock_metadata_cursor.cpp
     wrappers/mock_session.cpp
     truncate/truncate_list_helpers.cpp
     ${unittests}

--- a/test/catch2/cursors/unit/test_curstat_size.cpp
+++ b/test/catch2/cursors/unit/test_curstat_size.cpp
@@ -8,14 +8,8 @@
 
 #include <catch2/catch.hpp>
 
-#include <cstdarg>
-#include <optional>
-#include <string>
-#include <string_view>
-#include <unordered_map>
-#include <variant>
-
 #include "wt_internal.h"
+#include "../../wrappers/mock_metadata_cursor.h"
 #include "../../wrappers/mock_session.h"
 
 namespace {
@@ -24,100 +18,6 @@ constexpr auto filename = "test.wt";
 constexpr auto file_uri = "file:test.wt";
 constexpr auto table_uri = "table:test";
 constexpr auto stable_uri = "file:test.wt_stable";
-
-class mock_metadata_cursor {
-    using metadata_result = std::variant<std::string, int>;
-
-public:
-    mock_metadata_cursor()
-    {
-        _cursor.lang_private = this;
-        _cursor.set_key = set_key;
-        _cursor.search = search;
-        _cursor.get_value = get_value;
-        _cursor.reset = reset;
-    }
-
-    [[nodiscard]] WT_CURSOR &
-    cursor()
-    {
-        return _cursor;
-    }
-
-    void
-    insert_metadata(std::string_view uri, std::string_view value)
-    {
-        _metadata.insert_or_assign(std::string(uri), std::string(value));
-    }
-
-    void
-    insert_metadata_error(std::string_view uri, int error)
-    {
-        _metadata.insert_or_assign(std::string(uri), error);
-    }
-
-private:
-    static mock_metadata_cursor &
-    to_mock_cursor(WT_CURSOR *cursor)
-    {
-        return *static_cast<mock_metadata_cursor *>(cursor->lang_private);
-    }
-
-    static void
-    set_key(WT_CURSOR *cursor, ...)
-    {
-        va_list ap;
-        va_start(ap, cursor);
-        to_mock_cursor(cursor)._search_key = va_arg(ap, const char *);
-        va_end(ap);
-    }
-
-    static int
-    search(WT_CURSOR *cursor)
-    {
-        auto &mock = to_mock_cursor(cursor);
-        mock._search_result.reset();
-
-        const auto it = mock._metadata.find(mock._search_key);
-        if (it == mock._metadata.end())
-            return WT_NOTFOUND;
-
-        const auto *value = std::get_if<std::string>(&it->second);
-        if (value == nullptr)
-            return std::get<int>(it->second);
-
-        mock._search_result = *value;
-        return 0;
-    }
-
-    static int
-    get_value(WT_CURSOR *cursor, ...)
-    {
-        const auto &mock = to_mock_cursor(cursor);
-        if (!mock._search_result.has_value())
-            return EINVAL;
-
-        va_list ap;
-        va_start(ap, cursor);
-        *va_arg(ap, const char **) = mock._search_result->c_str();
-        va_end(ap);
-        return 0;
-    }
-
-    static int
-    reset(WT_CURSOR *cursor)
-    {
-        auto &mock = to_mock_cursor(cursor);
-        mock._search_key = {};
-        mock._search_result.reset();
-        return 0;
-    }
-
-    WT_CURSOR _cursor{};
-    std::unordered_map<std::string, metadata_result> _metadata;
-    std::string _search_key;
-    std::optional<std::string> _search_result;
-};
 
 int
 fs_exist_default(WT_FILE_SYSTEM *, WT_SESSION *, const char *, bool *existp)

--- a/test/catch2/cursors/unit/test_curstat_size.cpp
+++ b/test/catch2/cursors/unit/test_curstat_size.cpp
@@ -188,18 +188,6 @@ TEST_CASE_METHOD(curstat_size_fixture, "local size", "[curstat_size]")
 
 TEST_CASE_METHOD(curstat_size_fixture, "shared size", "[curstat_size]")
 {
-    SECTION("propagates a checkpoint error")
-    {
-        constexpr auto expected_error = WT_ERROR;
-        constexpr auto config =
-          "checkpoint=(WiredTigerCheckpoint.1=(addr=\"\",order=,time=1,size=0,write_gen=1))";
-
-        int64_t size = 0;
-        const auto result = __ut_curstat_size_shared(session(), config, &size);
-
-        REQUIRE(result == expected_error);
-    }
-
     SECTION("reports zero when there is no checkpoint entry")
     {
         constexpr auto config = "checkpoint=()";
@@ -266,22 +254,6 @@ TEST_CASE_METHOD(curstat_size_fixture, "file size", "[curstat_size][curstat_file
         const auto result = __ut_curstat_file_size(session(), file_uri, &was_fast, &size);
 
         REQUIRE(result == expected_error);
-    }
-
-    SECTION("propagates an error from shared sizing")
-    {
-        enable_disaggregated_storage();
-
-        constexpr auto file_config =
-          "block_manager=disagg,"
-          "checkpoint=(WiredTigerCheckpoint.1=(addr=\"\",order=))";
-        metadata_cursor().insert_metadata(file_uri, file_config);
-
-        bool was_fast = false;
-        int64_t size = 0;
-        const auto result = __ut_curstat_file_size(session(), file_uri, &was_fast, &size);
-
-        REQUIRE(result == WT_ERROR);
     }
 
     SECTION("retrieves the shared checkpoint size")
@@ -442,22 +414,6 @@ TEST_CASE_METHOD(curstat_size_fixture, "table size", "[curstat_size][curstat_tab
         const auto result = __ut_curstat_table_size(session(), table_uri, &was_fast, &size);
 
         REQUIRE(result == expected_error);
-    }
-
-    SECTION("propagates an error from shared sizing")
-    {
-        enable_disaggregated_storage();
-
-        metadata_cursor().insert_metadata(table_uri, "columns=()");
-
-        constexpr auto stable_config = "checkpoint=(WiredTigerCheckpoint.1=(addr=\"\",order=))";
-        metadata_cursor().insert_metadata(stable_uri, stable_config);
-
-        bool was_fast = false;
-        int64_t size = 0;
-        const auto result = __ut_curstat_table_size(session(), table_uri, &was_fast, &size);
-
-        REQUIRE(result == WT_ERROR);
     }
 
     SECTION("retrieves the shared checkpoint size")

--- a/test/catch2/cursors/unit/test_curstat_size.cpp
+++ b/test/catch2/cursors/unit/test_curstat_size.cpp
@@ -9,6 +9,7 @@
 #include <catch2/catch.hpp>
 
 #include <cstdarg>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -25,9 +26,9 @@ constexpr auto table_uri = "table:test";
 constexpr auto stable_uri = "file:test.wt_stable";
 
 class mock_metadata_cursor {
-public:
-    using response = std::variant<std::string, int>;
+    using metadata_result = std::variant<std::string, int>;
 
+public:
     mock_metadata_cursor()
     {
         _cursor.lang_private = this;
@@ -46,18 +47,18 @@ public:
     void
     insert_metadata(std::string_view uri, std::string_view value)
     {
-        _responses.insert_or_assign(std::string(uri), response{std::string(value)});
+        _metadata.insert_or_assign(std::string(uri), std::string(value));
     }
 
     void
     insert_metadata_error(std::string_view uri, int error)
     {
-        _responses.insert_or_assign(std::string(uri), response{error});
+        _metadata.insert_or_assign(std::string(uri), error);
     }
 
 private:
     static mock_metadata_cursor &
-    self(WT_CURSOR *cursor)
+    to_mock_cursor(WT_CURSOR *cursor)
     {
         return *static_cast<mock_metadata_cursor *>(cursor->lang_private);
     }
@@ -67,59 +68,55 @@ private:
     {
         va_list ap;
         va_start(ap, cursor);
-        self(cursor)._key = va_arg(ap, const char *);
+        to_mock_cursor(cursor)._search_key = va_arg(ap, const char *);
         va_end(ap);
-    }
-
-    [[nodiscard]] const response *
-    find_response() const
-    {
-        const auto it = _responses.find(_key);
-        if (it == _responses.end())
-            return nullptr;
-
-        return &it->second;
     }
 
     static int
     search(WT_CURSOR *cursor)
     {
-        const auto *response = self(cursor).find_response();
-        if (response == nullptr)
+        auto &mock = to_mock_cursor(cursor);
+        mock._search_result.reset();
+
+        const auto it = mock._metadata.find(mock._search_key);
+        if (it == mock._metadata.end())
             return WT_NOTFOUND;
 
-        const auto *error = std::get_if<int>(response);
-        return error == nullptr ? 0 : *error;
+        const auto *value = std::get_if<std::string>(&it->second);
+        if (value == nullptr)
+            return std::get<int>(it->second);
+
+        mock._search_result = *value;
+        return 0;
     }
 
     static int
     get_value(WT_CURSOR *cursor, ...)
     {
-        const auto *response = self(cursor).find_response();
-        if (response == nullptr)
-            return WT_NOTFOUND;
-
-        const auto *value = std::get_if<std::string>(response);
-        if (value == nullptr)
-            return WT_NOTFOUND;
+        const auto &mock = to_mock_cursor(cursor);
+        if (!mock._search_result.has_value())
+            return EINVAL;
 
         va_list ap;
         va_start(ap, cursor);
-        *va_arg(ap, const char **) = value->c_str();
+        *va_arg(ap, const char **) = mock._search_result->c_str();
         va_end(ap);
         return 0;
     }
 
     static int
-    reset(WT_CURSOR *)
+    reset(WT_CURSOR *cursor)
     {
+        auto &mock = to_mock_cursor(cursor);
+        mock._search_key = {};
+        mock._search_result.reset();
         return 0;
     }
 
     WT_CURSOR _cursor{};
-
-    std::unordered_map<std::string, response> _responses;
-    std::string _key;
+    std::unordered_map<std::string, metadata_result> _metadata;
+    std::string _search_key;
+    std::optional<std::string> _search_result;
 };
 
 int
@@ -147,9 +144,8 @@ public:
         REQUIRE(connection->setup_block_manager(session_impl) == 0);
 
         // Metadata searches need both session and shared transaction state.
-        REQUIRE(__wt_calloc_one(session_impl, &_txn) == 0);
+        REQUIRE(__wt_calloc_one(session_impl, &session_impl->txn) == 0);
         conn->txn_global.txn_shared_list = &_txn_shared;
-        session_impl->txn = _txn;
 
         conn->file_system->fs_exist = fs_exist_default;
         conn->file_system->fs_size = fs_size_default;
@@ -165,9 +161,9 @@ public:
 
         // Detach test state before the mock session is destroyed.
         session_impl->meta_cursor = nullptr;
-        session_impl->txn = nullptr;
         conn->txn_global.txn_shared_list = nullptr;
-        __wt_free(session_impl, _txn);
+        __wt_free(session_impl, session_impl->txn);
+        session_impl->txn = nullptr;
 
         // Reset optional disaggregated configuration.
         conn->disaggregated_storage.page_log_meta = nullptr;
@@ -207,277 +203,157 @@ public:
 private:
     std::shared_ptr<mock_session> _mock;
     mock_metadata_cursor _metadata_cursor;
-    WT_TXN *_txn = nullptr;
     WT_TXN_SHARED _txn_shared{};
     WT_PAGE_LOG_HANDLE _page_log_handle{};
 };
 
 } // namespace
 
-SCENARIO_METHOD(curstat_size_fixture, "local size propagates a file system error", "[curstat_size]")
+TEST_CASE_METHOD(curstat_size_fixture, "local size", "[curstat_size]")
 {
-    GIVEN("a file system that returns an existence-check error")
+    SECTION("propagates a file system error")
     {
         constexpr auto expected_error = EIO;
         file_system().fs_exist = [](WT_FILE_SYSTEM *, WT_SESSION *, const char *, bool *) {
-            return expected_error;
+            return EIO;
         };
 
-        WHEN("the local size is requested")
-        {
-            bool was_fast = true;
-            int64_t size = 0;
-            const auto result = __ut_curstat_size_local(session(), filename, &was_fast, &size);
+        bool was_fast = true;
+        int64_t size = 0;
+        const auto result = __ut_curstat_size_local(session(), filename, &was_fast, &size);
 
-            THEN("it returns the file system error")
-            {
-                REQUIRE(result == expected_error);
-            }
-        }
+        REQUIRE(result == expected_error);
     }
-}
 
-SCENARIO_METHOD(curstat_size_fixture, "local size reports a missing file", "[curstat_size]")
-{
-    GIVEN("a file system that reports the file does not exist")
+    SECTION("reports a missing file")
     {
         file_system().fs_exist = [](WT_FILE_SYSTEM *, WT_SESSION *, const char *, bool *existp) {
             *existp = false;
             return 0;
         };
 
-        WHEN("the local size is requested")
-        {
-            bool was_fast = true;
-            int64_t size = 0;
-            const auto result = __ut_curstat_size_local(session(), filename, &was_fast, &size);
+        bool was_fast = true;
+        int64_t size = 0;
+        const auto result = __ut_curstat_size_local(session(), filename, &was_fast, &size);
 
-            THEN("it returns zero")
-            {
-                REQUIRE(result == 0);
-            }
-
-            AND_THEN("it indicates that the fast path did not resolve the size")
-            {
-                REQUIRE_FALSE(was_fast);
-            }
-        }
+        REQUIRE(result == 0);
+        REQUIRE_FALSE(was_fast);
     }
-}
 
-SCENARIO_METHOD(curstat_size_fixture, "local size propagates a size error", "[curstat_size]")
-{
-    GIVEN("a file system that returns a size-check error")
+    SECTION("propagates a size error")
     {
         constexpr auto expected_error = EIO;
         file_system().fs_size = [](WT_FILE_SYSTEM *, WT_SESSION *, const char *, wt_off_t *) {
-            return expected_error;
+            return EIO;
         };
 
-        WHEN("the local size is requested")
-        {
-            bool was_fast = true;
-            int64_t size = 0;
-            const auto result = __ut_curstat_size_local(session(), filename, &was_fast, &size);
+        bool was_fast = true;
+        int64_t size = 0;
+        const auto result = __ut_curstat_size_local(session(), filename, &was_fast, &size);
 
-            THEN("it returns the size error")
-            {
-                REQUIRE(result == expected_error);
-            }
-        }
+        REQUIRE(result == expected_error);
     }
-}
 
-SCENARIO_METHOD(
-  curstat_size_fixture, "local size treats a concurrent removal as missing", "[curstat_size]")
-{
-    GIVEN("a file system whose size check returns ENOENT")
+    SECTION("treats a concurrent removal as missing")
     {
-        constexpr auto expected_error = ENOENT;
         file_system().fs_size = [](WT_FILE_SYSTEM *, WT_SESSION *, const char *, wt_off_t *) {
-            return expected_error;
+            return ENOENT;
         };
 
-        WHEN("the local size is requested")
-        {
-            bool was_fast = true;
-            int64_t size = 0;
-            const auto result = __ut_curstat_size_local(session(), filename, &was_fast, &size);
+        bool was_fast = true;
+        int64_t size = 0;
+        const auto result = __ut_curstat_size_local(session(), filename, &was_fast, &size);
 
-            THEN("it returns zero")
-            {
-                REQUIRE(result == 0);
-            }
-
-            AND_THEN("it indicates that the fast path did not resolve the size")
-            {
-                REQUIRE_FALSE(was_fast);
-            }
-        }
+        REQUIRE(result == 0);
+        REQUIRE_FALSE(was_fast);
     }
-}
 
-SCENARIO_METHOD(curstat_size_fixture, "local size reports a valid size", "[curstat_size]")
-{
-    GIVEN("a file system that reports an existing file with a valid size")
+    SECTION("reports a valid size")
     {
         constexpr wt_off_t expected_size = 5678;
         file_system().fs_size = [](WT_FILE_SYSTEM *, WT_SESSION *, const char *, wt_off_t *sizep) {
-            *sizep = expected_size;
+            *sizep = 5678;
             return 0;
         };
 
-        WHEN("the local size is requested")
-        {
-            bool was_fast = false;
-            int64_t size = 0;
-            const auto result = __ut_curstat_size_local(session(), filename, &was_fast, &size);
+        bool was_fast = false;
+        int64_t size = 0;
+        const auto result = __ut_curstat_size_local(session(), filename, &was_fast, &size);
 
-            THEN("it returns zero")
-            {
-                REQUIRE(result == 0);
-            }
-
-            AND_THEN("it indicates that the fast path resolved the size")
-            {
-                REQUIRE(was_fast);
-            }
-
-            AND_THEN("it reports the file size")
-            {
-                REQUIRE(size == expected_size);
-            }
-        }
+        REQUIRE(result == 0);
+        REQUIRE(was_fast);
+        REQUIRE(size == expected_size);
     }
 }
 
-SCENARIO_METHOD(curstat_size_fixture, "shared size propagates a checkpoint error", "[curstat_size]")
+TEST_CASE_METHOD(curstat_size_fixture, "shared size", "[curstat_size]")
 {
-    GIVEN("shared-file metadata with a checkpoint missing its order")
+    SECTION("propagates a checkpoint error")
     {
         constexpr auto expected_error = WT_ERROR;
         constexpr auto config =
           "checkpoint=(WiredTigerCheckpoint.1=(addr=\"\",order=,time=1,size=0,write_gen=1))";
 
-        WHEN("the shared size is requested")
-        {
-            int64_t size = 0;
-            const auto result = __ut_curstat_size_shared(session(), config, &size);
+        int64_t size = 0;
+        const auto result = __ut_curstat_size_shared(session(), config, &size);
 
-            THEN("it returns the checkpoint error")
-            {
-                REQUIRE(result == expected_error);
-            }
-        }
+        REQUIRE(result == expected_error);
     }
-}
 
-SCENARIO_METHOD(curstat_size_fixture, "shared size reports zero when there is no checkpoint entry",
-  "[curstat_size]")
-{
-    GIVEN("shared-file metadata with an empty checkpoint list")
+    SECTION("reports zero when there is no checkpoint entry")
     {
         constexpr auto config = "checkpoint=()";
 
-        WHEN("the shared size is requested")
-        {
-            int64_t size = 1;
-            const auto result = __ut_curstat_size_shared(session(), config, &size);
+        int64_t size = 1;
+        const auto result = __ut_curstat_size_shared(session(), config, &size);
 
-            THEN("it returns zero")
-            {
-                REQUIRE(result == 0);
-            }
-
-            AND_THEN("it reports a zero size")
-            {
-                REQUIRE(size == 0);
-            }
-        }
+        REQUIRE(result == 0);
+        REQUIRE(size == 0);
     }
-}
 
-SCENARIO_METHOD(
-  curstat_size_fixture, "shared size reports a zero-sized checkpoint", "[curstat_size]")
-{
-    GIVEN("shared-file metadata with a zero-sized checkpoint")
+    SECTION("reports a zero-sized checkpoint")
     {
         constexpr auto config =
           "checkpoint=(WiredTigerCheckpoint.1=(addr=\"\",order=1,time=1,size=0,write_gen=1))";
 
-        WHEN("the shared size is requested")
-        {
-            int64_t size = 1;
-            const auto result = __ut_curstat_size_shared(session(), config, &size);
+        int64_t size = 1;
+        const auto result = __ut_curstat_size_shared(session(), config, &size);
 
-            THEN("it returns zero")
-            {
-                REQUIRE(result == 0);
-            }
-
-            AND_THEN("it reports a zero size")
-            {
-                REQUIRE(size == 0);
-            }
-        }
+        REQUIRE(result == 0);
+        REQUIRE(size == 0);
     }
-}
 
-SCENARIO_METHOD(
-  curstat_size_fixture, "shared size reports a nonzero checkpoint size", "[curstat_size]")
-{
-    GIVEN("shared-file metadata with a nonzero checkpoint size")
+    SECTION("reports a nonzero checkpoint size")
     {
         constexpr int64_t expected_size = 5678;
         constexpr auto config =
           "checkpoint=(WiredTigerCheckpoint.1=(addr=\"\",order=1,time=1,size=5678,write_gen=1))";
 
-        WHEN("the shared size is requested")
-        {
-            int64_t size = 0;
-            const auto result = __ut_curstat_size_shared(session(), config, &size);
+        int64_t size = 0;
+        const auto result = __ut_curstat_size_shared(session(), config, &size);
 
-            THEN("it returns zero")
-            {
-                REQUIRE(result == 0);
-            }
-
-            AND_THEN("it reports the checkpoint size")
-            {
-                REQUIRE(size == expected_size);
-            }
-        }
+        REQUIRE(result == 0);
+        REQUIRE(size == expected_size);
     }
 }
 
-SCENARIO_METHOD(curstat_size_fixture, "file size propagates a metadata search error",
-  "[curstat_size][curstat_file_size]")
+TEST_CASE_METHOD(curstat_size_fixture, "file size", "[curstat_size][curstat_file_size]")
 {
-    GIVEN("a disaggregated connection whose metadata search returns an error")
+    SECTION("propagates a metadata search error")
     {
         enable_disaggregated_storage();
 
         constexpr auto expected_error = EIO;
         metadata_cursor().insert_metadata_error(file_uri, expected_error);
 
-        WHEN("the file size is requested")
-        {
-            bool was_fast = false;
-            int64_t size = 0;
-            const auto result = __ut_curstat_file_size(session(), file_uri, &was_fast, &size);
+        bool was_fast = false;
+        int64_t size = 0;
+        const auto result = __ut_curstat_file_size(session(), file_uri, &was_fast, &size);
 
-            THEN("it returns the metadata search error")
-            {
-                REQUIRE(result == expected_error);
-            }
-        }
+        REQUIRE(result == expected_error);
     }
-}
 
-SCENARIO_METHOD(curstat_size_fixture, "file size propagates a block manager classification error",
-  "[curstat_size][curstat_file_size]")
-{
-    GIVEN("a disaggregated connection with invalid block manager metadata")
+    SECTION("propagates a block manager classification error")
     {
         enable_disaggregated_storage();
 
@@ -485,24 +361,14 @@ SCENARIO_METHOD(curstat_size_fixture, "file size propagates a block manager clas
         constexpr auto file_config = "block_manager=(";
         metadata_cursor().insert_metadata(file_uri, file_config);
 
-        WHEN("the file size is requested")
-        {
-            bool was_fast = false;
-            int64_t size = 0;
-            const auto result = __ut_curstat_file_size(session(), file_uri, &was_fast, &size);
+        bool was_fast = false;
+        int64_t size = 0;
+        const auto result = __ut_curstat_file_size(session(), file_uri, &was_fast, &size);
 
-            THEN("it returns the block manager classification error")
-            {
-                REQUIRE(result == expected_error);
-            }
-        }
+        REQUIRE(result == expected_error);
     }
-}
 
-SCENARIO_METHOD(curstat_size_fixture, "file size propagates an error from shared sizing",
-  "[curstat_size][curstat_file_size]")
-{
-    GIVEN("a disaggregated connection with invalid shared-file checkpoint metadata")
+    SECTION("propagates an error from shared sizing")
     {
         enable_disaggregated_storage();
 
@@ -511,24 +377,14 @@ SCENARIO_METHOD(curstat_size_fixture, "file size propagates an error from shared
           "checkpoint=(WiredTigerCheckpoint.1=(addr=\"\",order=))";
         metadata_cursor().insert_metadata(file_uri, file_config);
 
-        WHEN("the file size is requested")
-        {
-            bool was_fast = false;
-            int64_t size = 0;
-            const auto result = __ut_curstat_file_size(session(), file_uri, &was_fast, &size);
+        bool was_fast = false;
+        int64_t size = 0;
+        const auto result = __ut_curstat_file_size(session(), file_uri, &was_fast, &size);
 
-            THEN("it returns the shared sizing error")
-            {
-                REQUIRE(result == WT_ERROR);
-            }
-        }
+        REQUIRE(result == WT_ERROR);
     }
-}
 
-SCENARIO_METHOD(curstat_size_fixture, "file size retrieves the shared checkpoint size",
-  "[curstat_size][curstat_file_size]")
-{
-    GIVEN("a disaggregated connection with shared-file metadata")
+    SECTION("retrieves the shared checkpoint size")
     {
         enable_disaggregated_storage();
 
@@ -539,266 +395,140 @@ SCENARIO_METHOD(curstat_size_fixture, "file size retrieves the shared checkpoint
           "addr=\"\",order=1,time=1,size=5678,write_gen=1))";
         metadata_cursor().insert_metadata(file_uri, file_config);
 
-        WHEN("the file size is requested")
-        {
-            bool was_fast = false;
-            int64_t size = 0;
-            const auto result = __ut_curstat_file_size(session(), file_uri, &was_fast, &size);
+        bool was_fast = false;
+        int64_t size = 0;
+        const auto result = __ut_curstat_file_size(session(), file_uri, &was_fast, &size);
 
-            THEN("it returns zero")
-            {
-                REQUIRE(result == 0);
-            }
-
-            AND_THEN("it indicates that the fast path resolved the size")
-            {
-                REQUIRE(was_fast);
-            }
-
-            AND_THEN("it reports the shared checkpoint size")
-            {
-                REQUIRE(size == expected_size);
-            }
-        }
+        REQUIRE(result == 0);
+        REQUIRE(was_fast);
+        REQUIRE(size == expected_size);
     }
-}
 
-SCENARIO_METHOD(curstat_size_fixture, "file size propagates an error from local sizing",
-  "[curstat_size][curstat_file_size]")
-{
-    GIVEN("a local connection whose file system size check returns an error")
+    SECTION("propagates an error from local sizing")
     {
         constexpr auto expected_error = EIO;
         file_system().fs_size = [](WT_FILE_SYSTEM *, WT_SESSION *, const char *, wt_off_t *) {
-            return expected_error;
+            return EIO;
         };
 
-        WHEN("the file size is requested")
-        {
-            bool was_fast = false;
-            int64_t size = 0;
-            const auto result = __ut_curstat_file_size(session(), file_uri, &was_fast, &size);
+        bool was_fast = false;
+        int64_t size = 0;
+        const auto result = __ut_curstat_file_size(session(), file_uri, &was_fast, &size);
 
-            THEN("it returns the local sizing error")
-            {
-                REQUIRE(result == expected_error);
-            }
-        }
+        REQUIRE(result == expected_error);
     }
-}
 
-SCENARIO_METHOD(curstat_size_fixture, "file size retrieves the local file size",
-  "[curstat_size][curstat_file_size]")
-{
-    GIVEN("a local connection with an existing file")
+    SECTION("retrieves the local file size")
     {
         constexpr wt_off_t expected_size = 4321;
         file_system().fs_size = [](WT_FILE_SYSTEM *, WT_SESSION *, const char *, wt_off_t *sizep) {
-            *sizep = expected_size;
+            *sizep = 4321;
             return 0;
         };
 
-        WHEN("the file size is requested")
-        {
-            bool was_fast = false;
-            int64_t size = 0;
-            const auto result = __ut_curstat_file_size(session(), file_uri, &was_fast, &size);
+        bool was_fast = false;
+        int64_t size = 0;
+        const auto result = __ut_curstat_file_size(session(), file_uri, &was_fast, &size);
 
-            THEN("it returns zero")
-            {
-                REQUIRE(result == 0);
-            }
-
-            AND_THEN("it indicates that the fast path resolved the size")
-            {
-                REQUIRE(was_fast);
-            }
-
-            AND_THEN("it reports the local file size")
-            {
-                REQUIRE(size == expected_size);
-            }
-        }
+        REQUIRE(result == 0);
+        REQUIRE(was_fast);
+        REQUIRE(size == expected_size);
     }
 }
 
-SCENARIO_METHOD(curstat_size_fixture, "table size reports missing table metadata",
-  "[curstat_size][curstat_table_size]")
+TEST_CASE_METHOD(curstat_size_fixture, "table size", "[curstat_size][curstat_table_size]")
 {
-    GIVEN("no metadata for the table")
+    SECTION("reports missing table metadata")
     {
-        WHEN("the table size is requested")
-        {
-            bool was_fast = false;
-            int64_t size = 0;
-            const auto result = __ut_curstat_table_size(session(), table_uri, &was_fast, &size);
+        bool was_fast = false;
+        int64_t size = 0;
+        const auto result = __ut_curstat_table_size(session(), table_uri, &was_fast, &size);
 
-            THEN("it returns not found")
-            {
-                REQUIRE(result == WT_NOTFOUND);
-            }
-        }
+        REQUIRE(result == WT_NOTFOUND);
     }
-}
 
-SCENARIO_METHOD(curstat_size_fixture, "table size propagates a metadata search error",
-  "[curstat_size][curstat_table_size]")
-{
-    GIVEN("a table metadata search that returns an error")
+    SECTION("propagates a metadata search error")
     {
         constexpr auto expected_error = EIO;
         metadata_cursor().insert_metadata_error(table_uri, expected_error);
 
-        WHEN("the table size is requested")
-        {
-            bool was_fast = false;
-            int64_t size = 0;
-            const auto result = __ut_curstat_table_size(session(), table_uri, &was_fast, &size);
+        bool was_fast = false;
+        int64_t size = 0;
+        const auto result = __ut_curstat_table_size(session(), table_uri, &was_fast, &size);
 
-            THEN("it returns the metadata search error")
-            {
-                REQUIRE(result == expected_error);
-            }
-        }
+        REQUIRE(result == expected_error);
     }
-}
 
-SCENARIO_METHOD(curstat_size_fixture, "table size propagates a columns lookup error",
-  "[curstat_size][curstat_table_size]")
-{
-    GIVEN("table metadata without a columns configuration")
+    SECTION("propagates a columns lookup error")
     {
         metadata_cursor().insert_metadata(table_uri, "key_format=S");
 
-        WHEN("the table size is requested")
-        {
-            bool was_fast = false;
-            int64_t size = 0;
-            const auto result = __ut_curstat_table_size(session(), table_uri, &was_fast, &size);
+        bool was_fast = false;
+        int64_t size = 0;
+        const auto result = __ut_curstat_table_size(session(), table_uri, &was_fast, &size);
 
-            THEN("it returns the columns lookup error")
-            {
-                REQUIRE(result == WT_NOTFOUND);
-            }
-        }
+        REQUIRE(result == WT_NOTFOUND);
     }
-}
 
-SCENARIO_METHOD(curstat_size_fixture, "table size propagates a simple-table classification error",
-  "[curstat_size][curstat_table_size]")
-{
-    GIVEN("table metadata with malformed columns")
+    SECTION("propagates a simple-table classification error")
     {
         metadata_cursor().insert_metadata(table_uri, "columns=\"(\"");
 
-        WHEN("the table size is requested")
-        {
-            bool was_fast = false;
-            int64_t size = 0;
-            const auto result = __ut_curstat_table_size(session(), table_uri, &was_fast, &size);
+        bool was_fast = false;
+        int64_t size = 0;
+        const auto result = __ut_curstat_table_size(session(), table_uri, &was_fast, &size);
 
-            THEN("it returns the simple-table classification error")
-            {
-                REQUIRE(result == EINVAL);
-            }
-        }
+        REQUIRE(result == EINVAL);
     }
-}
 
-SCENARIO_METHOD(curstat_size_fixture, "table size skips the fast path for a non-simple table",
-  "[curstat_size][curstat_table_size]")
-{
-    GIVEN("table metadata with named columns")
+    SECTION("skips the fast path for a non-simple table")
     {
         metadata_cursor().insert_metadata(table_uri, "columns=(key,value)");
 
-        WHEN("the table size is requested")
-        {
-            bool was_fast = true;
-            int64_t size = 0;
-            const auto result = __ut_curstat_table_size(session(), table_uri, &was_fast, &size);
+        bool was_fast = true;
+        int64_t size = 0;
+        const auto result = __ut_curstat_table_size(session(), table_uri, &was_fast, &size);
 
-            THEN("it returns zero")
-            {
-                REQUIRE(result == 0);
-            }
-
-            AND_THEN("it indicates that the fast path did not resolve the size")
-            {
-                REQUIRE_FALSE(was_fast);
-            }
-        }
+        REQUIRE(result == 0);
+        REQUIRE_FALSE(was_fast);
     }
-}
 
-SCENARIO_METHOD(curstat_size_fixture,
-  "table size propagates an error from the backing file size lookup",
-  "[curstat_size][curstat_table_size]")
-{
-    GIVEN("a simple table whose backing file size lookup returns an error")
+    SECTION("propagates an error from the backing file size lookup")
     {
         metadata_cursor().insert_metadata(table_uri, "columns=()");
 
         constexpr auto expected_error = EIO;
         file_system().fs_size = [](WT_FILE_SYSTEM *, WT_SESSION *, const char *, wt_off_t *) {
-            return expected_error;
+            return EIO;
         };
 
-        WHEN("the table size is requested")
-        {
-            bool was_fast = false;
-            int64_t size = 0;
-            const auto result = __ut_curstat_table_size(session(), table_uri, &was_fast, &size);
+        bool was_fast = false;
+        int64_t size = 0;
+        const auto result = __ut_curstat_table_size(session(), table_uri, &was_fast, &size);
 
-            THEN("it returns the backing file size lookup error")
-            {
-                REQUIRE(result == expected_error);
-            }
-        }
+        REQUIRE(result == expected_error);
     }
-}
 
-SCENARIO_METHOD(curstat_size_fixture, "table size retrieves its backing file size",
-  "[curstat_size][curstat_table_size]")
-{
-    GIVEN("a simple table backed by a local file")
+    SECTION("retrieves its backing file size")
     {
         metadata_cursor().insert_metadata(table_uri, "columns=()");
 
         constexpr wt_off_t expected_size = 4321;
         file_system().fs_size = [](WT_FILE_SYSTEM *, WT_SESSION *, const char *, wt_off_t *sizep) {
-            *sizep = expected_size;
+            *sizep = 4321;
             return 0;
         };
 
-        WHEN("the table size is requested")
-        {
-            bool was_fast = false;
-            int64_t size = 0;
-            const auto result = __ut_curstat_table_size(session(), table_uri, &was_fast, &size);
+        bool was_fast = false;
+        int64_t size = 0;
+        const auto result = __ut_curstat_table_size(session(), table_uri, &was_fast, &size);
 
-            THEN("it returns zero")
-            {
-                REQUIRE(result == 0);
-            }
-
-            AND_THEN("it indicates that the fast path resolved the size")
-            {
-                REQUIRE(was_fast);
-            }
-
-            AND_THEN("it reports the backing file size")
-            {
-                REQUIRE(size == expected_size);
-            }
-        }
+        REQUIRE(result == 0);
+        REQUIRE(was_fast);
+        REQUIRE(size == expected_size);
     }
-}
 
-SCENARIO_METHOD(curstat_size_fixture, "table size propagates a stable metadata search error",
-  "[curstat_size][curstat_table_size]")
-{
-    GIVEN("a simple table whose stable metadata search returns an error")
+    SECTION("propagates a stable metadata search error")
     {
         enable_disaggregated_storage();
 
@@ -807,24 +537,14 @@ SCENARIO_METHOD(curstat_size_fixture, "table size propagates a stable metadata s
         constexpr auto expected_error = EIO;
         metadata_cursor().insert_metadata_error(stable_uri, expected_error);
 
-        WHEN("the table size is requested")
-        {
-            bool was_fast = false;
-            int64_t size = 0;
-            const auto result = __ut_curstat_table_size(session(), table_uri, &was_fast, &size);
+        bool was_fast = false;
+        int64_t size = 0;
+        const auto result = __ut_curstat_table_size(session(), table_uri, &was_fast, &size);
 
-            THEN("it returns the stable metadata search error")
-            {
-                REQUIRE(result == expected_error);
-            }
-        }
+        REQUIRE(result == expected_error);
     }
-}
 
-SCENARIO_METHOD(curstat_size_fixture, "table size propagates an error from shared sizing",
-  "[curstat_size][curstat_table_size]")
-{
-    GIVEN("a simple table with invalid stable checkpoint metadata")
+    SECTION("propagates an error from shared sizing")
     {
         enable_disaggregated_storage();
 
@@ -833,24 +553,14 @@ SCENARIO_METHOD(curstat_size_fixture, "table size propagates an error from share
         constexpr auto stable_config = "checkpoint=(WiredTigerCheckpoint.1=(addr=\"\",order=))";
         metadata_cursor().insert_metadata(stable_uri, stable_config);
 
-        WHEN("the table size is requested")
-        {
-            bool was_fast = false;
-            int64_t size = 0;
-            const auto result = __ut_curstat_table_size(session(), table_uri, &was_fast, &size);
+        bool was_fast = false;
+        int64_t size = 0;
+        const auto result = __ut_curstat_table_size(session(), table_uri, &was_fast, &size);
 
-            THEN("it returns the shared sizing error")
-            {
-                REQUIRE(result == WT_ERROR);
-            }
-        }
+        REQUIRE(result == WT_ERROR);
     }
-}
 
-SCENARIO_METHOD(curstat_size_fixture, "table size retrieves the shared checkpoint size",
-  "[curstat_size][curstat_table_size]")
-{
-    GIVEN("a simple table with stable checkpoint metadata")
+    SECTION("retrieves the shared checkpoint size")
     {
         enable_disaggregated_storage();
 
@@ -863,64 +573,30 @@ SCENARIO_METHOD(curstat_size_fixture, "table size retrieves the shared checkpoin
 
         metadata_cursor().insert_metadata(stable_uri, stable_config);
 
-        WHEN("the table size is requested")
-        {
-            bool was_fast = false;
-            int64_t size = 0;
-            const auto result = __ut_curstat_table_size(session(), table_uri, &was_fast, &size);
+        bool was_fast = false;
+        int64_t size = 0;
+        const auto result = __ut_curstat_table_size(session(), table_uri, &was_fast, &size);
 
-            THEN("it returns zero")
-            {
-                REQUIRE(result == 0);
-            }
-
-            AND_THEN("it indicates that the fast path resolved the size")
-            {
-                REQUIRE(was_fast);
-            }
-
-            AND_THEN("it reports the shared checkpoint size")
-            {
-                REQUIRE(size == expected_size);
-            }
-        }
+        REQUIRE(result == 0);
+        REQUIRE(was_fast);
+        REQUIRE(size == expected_size);
     }
-}
 
-SCENARIO_METHOD(curstat_size_fixture,
-  "table size defers to the slow path when stable and local file metadata are missing",
-  "[curstat_size][curstat_table_size]")
-{
-    GIVEN("a simple table without stable or local file metadata")
+    SECTION("defers to the slow path when stable and local file metadata are missing")
     {
         enable_disaggregated_storage();
 
         metadata_cursor().insert_metadata(table_uri, "columns=()");
 
-        WHEN("the table size is requested")
-        {
-            bool was_fast = true;
-            int64_t size = 0;
-            const auto result = __ut_curstat_table_size(session(), table_uri, &was_fast, &size);
+        bool was_fast = true;
+        int64_t size = 0;
+        const auto result = __ut_curstat_table_size(session(), table_uri, &was_fast, &size);
 
-            THEN("it returns zero")
-            {
-                REQUIRE(result == 0);
-            }
-
-            AND_THEN("it indicates that the fast path did not resolve the size")
-            {
-                REQUIRE_FALSE(was_fast);
-            }
-        }
+        REQUIRE(result == 0);
+        REQUIRE_FALSE(was_fast);
     }
-}
 
-SCENARIO_METHOD(curstat_size_fixture,
-  "table size falls back to its local backing file when stable metadata is missing",
-  "[curstat_size][curstat_table_size]")
-{
-    GIVEN("a simple table without stable metadata")
+    SECTION("falls back to its local backing file when stable metadata is missing")
     {
         enable_disaggregated_storage();
 
@@ -931,30 +607,16 @@ SCENARIO_METHOD(curstat_size_fixture,
 
         constexpr wt_off_t expected_size = 4321;
         file_system().fs_size = [](WT_FILE_SYSTEM *, WT_SESSION *, const char *, wt_off_t *sizep) {
-            *sizep = expected_size;
+            *sizep = 4321;
             return 0;
         };
 
-        WHEN("the table size is requested")
-        {
-            bool was_fast = false;
-            int64_t size = 0;
-            const auto result = __ut_curstat_table_size(session(), table_uri, &was_fast, &size);
+        bool was_fast = false;
+        int64_t size = 0;
+        const auto result = __ut_curstat_table_size(session(), table_uri, &was_fast, &size);
 
-            THEN("it returns zero")
-            {
-                REQUIRE(result == 0);
-            }
-
-            AND_THEN("it indicates that the fast path resolved the size")
-            {
-                REQUIRE(was_fast);
-            }
-
-            AND_THEN("it reports the local backing file size")
-            {
-                REQUIRE(size == expected_size);
-            }
-        }
+        REQUIRE(result == 0);
+        REQUIRE(was_fast);
+        REQUIRE(size == expected_size);
     }
 }

--- a/test/catch2/cursors/unit/test_curstat_size.cpp
+++ b/test/catch2/cursors/unit/test_curstat_size.cpp
@@ -1,0 +1,960 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+#include <catch2/catch.hpp>
+
+#include <cstdarg>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <variant>
+
+#include "wt_internal.h"
+#include "../../wrappers/mock_session.h"
+
+namespace {
+
+constexpr auto filename = "test.wt";
+constexpr auto file_uri = "file:test.wt";
+constexpr auto table_uri = "table:test";
+constexpr auto stable_uri = "file:test.wt_stable";
+
+class mock_metadata_cursor {
+public:
+    using response = std::variant<std::string, int>;
+
+    mock_metadata_cursor()
+    {
+        _cursor.lang_private = this;
+        _cursor.set_key = set_key;
+        _cursor.search = search;
+        _cursor.get_value = get_value;
+        _cursor.reset = reset;
+    }
+
+    [[nodiscard]] WT_CURSOR &
+    cursor()
+    {
+        return _cursor;
+    }
+
+    void
+    insert_metadata(std::string_view uri, std::string_view value)
+    {
+        _responses.insert_or_assign(std::string(uri), response{std::string(value)});
+    }
+
+    void
+    insert_metadata_error(std::string_view uri, int error)
+    {
+        _responses.insert_or_assign(std::string(uri), response{error});
+    }
+
+private:
+    static mock_metadata_cursor &
+    self(WT_CURSOR *cursor)
+    {
+        return *static_cast<mock_metadata_cursor *>(cursor->lang_private);
+    }
+
+    static void
+    set_key(WT_CURSOR *cursor, ...)
+    {
+        va_list ap;
+        va_start(ap, cursor);
+        self(cursor)._key = va_arg(ap, const char *);
+        va_end(ap);
+    }
+
+    [[nodiscard]] const response *
+    find_response() const
+    {
+        const auto it = _responses.find(_key);
+        if (it == _responses.end())
+            return nullptr;
+
+        return &it->second;
+    }
+
+    static int
+    search(WT_CURSOR *cursor)
+    {
+        const auto *response = self(cursor).find_response();
+        if (response == nullptr)
+            return WT_NOTFOUND;
+
+        const auto *error = std::get_if<int>(response);
+        return error == nullptr ? 0 : *error;
+    }
+
+    static int
+    get_value(WT_CURSOR *cursor, ...)
+    {
+        const auto *response = self(cursor).find_response();
+        if (response == nullptr)
+            return WT_NOTFOUND;
+
+        const auto *value = std::get_if<std::string>(response);
+        if (value == nullptr)
+            return WT_NOTFOUND;
+
+        va_list ap;
+        va_start(ap, cursor);
+        *va_arg(ap, const char **) = value->c_str();
+        va_end(ap);
+        return 0;
+    }
+
+    static int
+    reset(WT_CURSOR *)
+    {
+        return 0;
+    }
+
+    WT_CURSOR _cursor{};
+
+    std::unordered_map<std::string, response> _responses;
+    std::string _key;
+};
+
+int
+fs_exist_default(WT_FILE_SYSTEM *, WT_SESSION *, const char *, bool *existp)
+{
+    *existp = true;
+    return 0;
+}
+
+int
+fs_size_default(WT_FILE_SYSTEM *, WT_SESSION *, const char *, wt_off_t *sizep)
+{
+    *sizep = 0;
+    return 0;
+}
+
+class curstat_size_fixture {
+public:
+    curstat_size_fixture() : _mock(mock_session::build_test_mock_session())
+    {
+        const auto connection = _mock->get_mock_connection();
+        auto *conn = connection->get_wt_connection_impl();
+        auto *session_impl = session();
+
+        REQUIRE(connection->setup_block_manager(session_impl) == 0);
+
+        // Metadata searches need both session and shared transaction state.
+        REQUIRE(__wt_calloc_one(session_impl, &_txn) == 0);
+        conn->txn_global.txn_shared_list = &_txn_shared;
+        session_impl->txn = _txn;
+
+        conn->file_system->fs_exist = fs_exist_default;
+        conn->file_system->fs_size = fs_size_default;
+
+        // Use the mock cursor for metadata lookups.
+        session_impl->meta_cursor = &_metadata_cursor.cursor();
+    }
+
+    ~curstat_size_fixture()
+    {
+        auto *session_impl = session();
+        auto *conn = S2C(session_impl);
+
+        // Detach test state before the mock session is destroyed.
+        session_impl->meta_cursor = nullptr;
+        session_impl->txn = nullptr;
+        conn->txn_global.txn_shared_list = nullptr;
+        __wt_free(session_impl, _txn);
+
+        // Reset optional disaggregated configuration.
+        conn->disaggregated_storage.page_log_meta = nullptr;
+        __wt_conn_config_discard(session_impl);
+    }
+
+    void
+    enable_disaggregated_storage()
+    {
+        auto *session_impl = session();
+
+        // File classification needs the default metadata configuration.
+        REQUIRE(__wt_conn_config_init(session_impl) == 0);
+
+        // A metadata page log handle marks the connection as disaggregated.
+        S2C(session_impl)->disaggregated_storage.page_log_meta = &_page_log_handle;
+    }
+
+    [[nodiscard]] WT_FILE_SYSTEM &
+    file_system()
+    {
+        return *S2C(session())->file_system;
+    }
+
+    [[nodiscard]] mock_metadata_cursor &
+    metadata_cursor()
+    {
+        return _metadata_cursor;
+    }
+
+    [[nodiscard]] WT_SESSION_IMPL *
+    session() const
+    {
+        return _mock->get_wt_session_impl();
+    }
+
+private:
+    std::shared_ptr<mock_session> _mock;
+    mock_metadata_cursor _metadata_cursor;
+    WT_TXN *_txn = nullptr;
+    WT_TXN_SHARED _txn_shared{};
+    WT_PAGE_LOG_HANDLE _page_log_handle{};
+};
+
+} // namespace
+
+SCENARIO_METHOD(curstat_size_fixture, "local size propagates a file system error", "[curstat_size]")
+{
+    GIVEN("a file system that returns an existence-check error")
+    {
+        constexpr auto expected_error = EIO;
+        file_system().fs_exist = [](WT_FILE_SYSTEM *, WT_SESSION *, const char *, bool *) {
+            return expected_error;
+        };
+
+        WHEN("the local size is requested")
+        {
+            bool was_fast = true;
+            int64_t size = 0;
+            const auto result = __ut_curstat_size_local(session(), filename, &was_fast, &size);
+
+            THEN("it returns the file system error")
+            {
+                REQUIRE(result == expected_error);
+            }
+        }
+    }
+}
+
+SCENARIO_METHOD(curstat_size_fixture, "local size reports a missing file", "[curstat_size]")
+{
+    GIVEN("a file system that reports the file does not exist")
+    {
+        file_system().fs_exist = [](WT_FILE_SYSTEM *, WT_SESSION *, const char *, bool *existp) {
+            *existp = false;
+            return 0;
+        };
+
+        WHEN("the local size is requested")
+        {
+            bool was_fast = true;
+            int64_t size = 0;
+            const auto result = __ut_curstat_size_local(session(), filename, &was_fast, &size);
+
+            THEN("it returns zero")
+            {
+                REQUIRE(result == 0);
+            }
+
+            AND_THEN("it indicates that the fast path did not resolve the size")
+            {
+                REQUIRE_FALSE(was_fast);
+            }
+        }
+    }
+}
+
+SCENARIO_METHOD(curstat_size_fixture, "local size propagates a size error", "[curstat_size]")
+{
+    GIVEN("a file system that returns a size-check error")
+    {
+        constexpr auto expected_error = EIO;
+        file_system().fs_size = [](WT_FILE_SYSTEM *, WT_SESSION *, const char *, wt_off_t *) {
+            return expected_error;
+        };
+
+        WHEN("the local size is requested")
+        {
+            bool was_fast = true;
+            int64_t size = 0;
+            const auto result = __ut_curstat_size_local(session(), filename, &was_fast, &size);
+
+            THEN("it returns the size error")
+            {
+                REQUIRE(result == expected_error);
+            }
+        }
+    }
+}
+
+SCENARIO_METHOD(
+  curstat_size_fixture, "local size treats a concurrent removal as missing", "[curstat_size]")
+{
+    GIVEN("a file system whose size check returns ENOENT")
+    {
+        constexpr auto expected_error = ENOENT;
+        file_system().fs_size = [](WT_FILE_SYSTEM *, WT_SESSION *, const char *, wt_off_t *) {
+            return expected_error;
+        };
+
+        WHEN("the local size is requested")
+        {
+            bool was_fast = true;
+            int64_t size = 0;
+            const auto result = __ut_curstat_size_local(session(), filename, &was_fast, &size);
+
+            THEN("it returns zero")
+            {
+                REQUIRE(result == 0);
+            }
+
+            AND_THEN("it indicates that the fast path did not resolve the size")
+            {
+                REQUIRE_FALSE(was_fast);
+            }
+        }
+    }
+}
+
+SCENARIO_METHOD(curstat_size_fixture, "local size reports a valid size", "[curstat_size]")
+{
+    GIVEN("a file system that reports an existing file with a valid size")
+    {
+        constexpr wt_off_t expected_size = 5678;
+        file_system().fs_size = [](WT_FILE_SYSTEM *, WT_SESSION *, const char *, wt_off_t *sizep) {
+            *sizep = expected_size;
+            return 0;
+        };
+
+        WHEN("the local size is requested")
+        {
+            bool was_fast = false;
+            int64_t size = 0;
+            const auto result = __ut_curstat_size_local(session(), filename, &was_fast, &size);
+
+            THEN("it returns zero")
+            {
+                REQUIRE(result == 0);
+            }
+
+            AND_THEN("it indicates that the fast path resolved the size")
+            {
+                REQUIRE(was_fast);
+            }
+
+            AND_THEN("it reports the file size")
+            {
+                REQUIRE(size == expected_size);
+            }
+        }
+    }
+}
+
+SCENARIO_METHOD(curstat_size_fixture, "shared size propagates a checkpoint error", "[curstat_size]")
+{
+    GIVEN("shared-file metadata with a checkpoint missing its order")
+    {
+        constexpr auto expected_error = WT_ERROR;
+        constexpr auto config =
+          "checkpoint=(WiredTigerCheckpoint.1=(addr=\"\",order=,time=1,size=0,write_gen=1))";
+
+        WHEN("the shared size is requested")
+        {
+            int64_t size = 0;
+            const auto result = __ut_curstat_size_shared(session(), config, &size);
+
+            THEN("it returns the checkpoint error")
+            {
+                REQUIRE(result == expected_error);
+            }
+        }
+    }
+}
+
+SCENARIO_METHOD(curstat_size_fixture, "shared size reports zero when there is no checkpoint entry",
+  "[curstat_size]")
+{
+    GIVEN("shared-file metadata with an empty checkpoint list")
+    {
+        constexpr auto config = "checkpoint=()";
+
+        WHEN("the shared size is requested")
+        {
+            int64_t size = 1;
+            const auto result = __ut_curstat_size_shared(session(), config, &size);
+
+            THEN("it returns zero")
+            {
+                REQUIRE(result == 0);
+            }
+
+            AND_THEN("it reports a zero size")
+            {
+                REQUIRE(size == 0);
+            }
+        }
+    }
+}
+
+SCENARIO_METHOD(
+  curstat_size_fixture, "shared size reports a zero-sized checkpoint", "[curstat_size]")
+{
+    GIVEN("shared-file metadata with a zero-sized checkpoint")
+    {
+        constexpr auto config =
+          "checkpoint=(WiredTigerCheckpoint.1=(addr=\"\",order=1,time=1,size=0,write_gen=1))";
+
+        WHEN("the shared size is requested")
+        {
+            int64_t size = 1;
+            const auto result = __ut_curstat_size_shared(session(), config, &size);
+
+            THEN("it returns zero")
+            {
+                REQUIRE(result == 0);
+            }
+
+            AND_THEN("it reports a zero size")
+            {
+                REQUIRE(size == 0);
+            }
+        }
+    }
+}
+
+SCENARIO_METHOD(
+  curstat_size_fixture, "shared size reports a nonzero checkpoint size", "[curstat_size]")
+{
+    GIVEN("shared-file metadata with a nonzero checkpoint size")
+    {
+        constexpr int64_t expected_size = 5678;
+        constexpr auto config =
+          "checkpoint=(WiredTigerCheckpoint.1=(addr=\"\",order=1,time=1,size=5678,write_gen=1))";
+
+        WHEN("the shared size is requested")
+        {
+            int64_t size = 0;
+            const auto result = __ut_curstat_size_shared(session(), config, &size);
+
+            THEN("it returns zero")
+            {
+                REQUIRE(result == 0);
+            }
+
+            AND_THEN("it reports the checkpoint size")
+            {
+                REQUIRE(size == expected_size);
+            }
+        }
+    }
+}
+
+SCENARIO_METHOD(curstat_size_fixture, "file size propagates a metadata search error",
+  "[curstat_size][curstat_file_size]")
+{
+    GIVEN("a disaggregated connection whose metadata search returns an error")
+    {
+        enable_disaggregated_storage();
+
+        constexpr auto expected_error = EIO;
+        metadata_cursor().insert_metadata_error(file_uri, expected_error);
+
+        WHEN("the file size is requested")
+        {
+            bool was_fast = false;
+            int64_t size = 0;
+            const auto result = __ut_curstat_file_size(session(), file_uri, &was_fast, &size);
+
+            THEN("it returns the metadata search error")
+            {
+                REQUIRE(result == expected_error);
+            }
+        }
+    }
+}
+
+SCENARIO_METHOD(curstat_size_fixture, "file size propagates a block manager classification error",
+  "[curstat_size][curstat_file_size]")
+{
+    GIVEN("a disaggregated connection with invalid block manager metadata")
+    {
+        enable_disaggregated_storage();
+
+        constexpr auto expected_error = EINVAL;
+        constexpr auto file_config = "block_manager=(";
+        metadata_cursor().insert_metadata(file_uri, file_config);
+
+        WHEN("the file size is requested")
+        {
+            bool was_fast = false;
+            int64_t size = 0;
+            const auto result = __ut_curstat_file_size(session(), file_uri, &was_fast, &size);
+
+            THEN("it returns the block manager classification error")
+            {
+                REQUIRE(result == expected_error);
+            }
+        }
+    }
+}
+
+SCENARIO_METHOD(curstat_size_fixture, "file size propagates an error from shared sizing",
+  "[curstat_size][curstat_file_size]")
+{
+    GIVEN("a disaggregated connection with invalid shared-file checkpoint metadata")
+    {
+        enable_disaggregated_storage();
+
+        constexpr auto file_config =
+          "block_manager=disagg,"
+          "checkpoint=(WiredTigerCheckpoint.1=(addr=\"\",order=))";
+        metadata_cursor().insert_metadata(file_uri, file_config);
+
+        WHEN("the file size is requested")
+        {
+            bool was_fast = false;
+            int64_t size = 0;
+            const auto result = __ut_curstat_file_size(session(), file_uri, &was_fast, &size);
+
+            THEN("it returns the shared sizing error")
+            {
+                REQUIRE(result == WT_ERROR);
+            }
+        }
+    }
+}
+
+SCENARIO_METHOD(curstat_size_fixture, "file size retrieves the shared checkpoint size",
+  "[curstat_size][curstat_file_size]")
+{
+    GIVEN("a disaggregated connection with shared-file metadata")
+    {
+        enable_disaggregated_storage();
+
+        constexpr int64_t expected_size = 5678;
+        constexpr auto file_config =
+          "block_manager=disagg,"
+          "checkpoint=(WiredTigerCheckpoint.1=("
+          "addr=\"\",order=1,time=1,size=5678,write_gen=1))";
+        metadata_cursor().insert_metadata(file_uri, file_config);
+
+        WHEN("the file size is requested")
+        {
+            bool was_fast = false;
+            int64_t size = 0;
+            const auto result = __ut_curstat_file_size(session(), file_uri, &was_fast, &size);
+
+            THEN("it returns zero")
+            {
+                REQUIRE(result == 0);
+            }
+
+            AND_THEN("it indicates that the fast path resolved the size")
+            {
+                REQUIRE(was_fast);
+            }
+
+            AND_THEN("it reports the shared checkpoint size")
+            {
+                REQUIRE(size == expected_size);
+            }
+        }
+    }
+}
+
+SCENARIO_METHOD(curstat_size_fixture, "file size propagates an error from local sizing",
+  "[curstat_size][curstat_file_size]")
+{
+    GIVEN("a local connection whose file system size check returns an error")
+    {
+        constexpr auto expected_error = EIO;
+        file_system().fs_size = [](WT_FILE_SYSTEM *, WT_SESSION *, const char *, wt_off_t *) {
+            return expected_error;
+        };
+
+        WHEN("the file size is requested")
+        {
+            bool was_fast = false;
+            int64_t size = 0;
+            const auto result = __ut_curstat_file_size(session(), file_uri, &was_fast, &size);
+
+            THEN("it returns the local sizing error")
+            {
+                REQUIRE(result == expected_error);
+            }
+        }
+    }
+}
+
+SCENARIO_METHOD(curstat_size_fixture, "file size retrieves the local file size",
+  "[curstat_size][curstat_file_size]")
+{
+    GIVEN("a local connection with an existing file")
+    {
+        constexpr wt_off_t expected_size = 4321;
+        file_system().fs_size = [](WT_FILE_SYSTEM *, WT_SESSION *, const char *, wt_off_t *sizep) {
+            *sizep = expected_size;
+            return 0;
+        };
+
+        WHEN("the file size is requested")
+        {
+            bool was_fast = false;
+            int64_t size = 0;
+            const auto result = __ut_curstat_file_size(session(), file_uri, &was_fast, &size);
+
+            THEN("it returns zero")
+            {
+                REQUIRE(result == 0);
+            }
+
+            AND_THEN("it indicates that the fast path resolved the size")
+            {
+                REQUIRE(was_fast);
+            }
+
+            AND_THEN("it reports the local file size")
+            {
+                REQUIRE(size == expected_size);
+            }
+        }
+    }
+}
+
+SCENARIO_METHOD(curstat_size_fixture, "table size reports missing table metadata",
+  "[curstat_size][curstat_table_size]")
+{
+    GIVEN("no metadata for the table")
+    {
+        WHEN("the table size is requested")
+        {
+            bool was_fast = false;
+            int64_t size = 0;
+            const auto result = __ut_curstat_table_size(session(), table_uri, &was_fast, &size);
+
+            THEN("it returns not found")
+            {
+                REQUIRE(result == WT_NOTFOUND);
+            }
+        }
+    }
+}
+
+SCENARIO_METHOD(curstat_size_fixture, "table size propagates a metadata search error",
+  "[curstat_size][curstat_table_size]")
+{
+    GIVEN("a table metadata search that returns an error")
+    {
+        constexpr auto expected_error = EIO;
+        metadata_cursor().insert_metadata_error(table_uri, expected_error);
+
+        WHEN("the table size is requested")
+        {
+            bool was_fast = false;
+            int64_t size = 0;
+            const auto result = __ut_curstat_table_size(session(), table_uri, &was_fast, &size);
+
+            THEN("it returns the metadata search error")
+            {
+                REQUIRE(result == expected_error);
+            }
+        }
+    }
+}
+
+SCENARIO_METHOD(curstat_size_fixture, "table size propagates a columns lookup error",
+  "[curstat_size][curstat_table_size]")
+{
+    GIVEN("table metadata without a columns configuration")
+    {
+        metadata_cursor().insert_metadata(table_uri, "key_format=S");
+
+        WHEN("the table size is requested")
+        {
+            bool was_fast = false;
+            int64_t size = 0;
+            const auto result = __ut_curstat_table_size(session(), table_uri, &was_fast, &size);
+
+            THEN("it returns the columns lookup error")
+            {
+                REQUIRE(result == WT_NOTFOUND);
+            }
+        }
+    }
+}
+
+SCENARIO_METHOD(curstat_size_fixture, "table size propagates a simple-table classification error",
+  "[curstat_size][curstat_table_size]")
+{
+    GIVEN("table metadata with malformed columns")
+    {
+        metadata_cursor().insert_metadata(table_uri, "columns=\"(\"");
+
+        WHEN("the table size is requested")
+        {
+            bool was_fast = false;
+            int64_t size = 0;
+            const auto result = __ut_curstat_table_size(session(), table_uri, &was_fast, &size);
+
+            THEN("it returns the simple-table classification error")
+            {
+                REQUIRE(result == EINVAL);
+            }
+        }
+    }
+}
+
+SCENARIO_METHOD(curstat_size_fixture, "table size skips the fast path for a non-simple table",
+  "[curstat_size][curstat_table_size]")
+{
+    GIVEN("table metadata with named columns")
+    {
+        metadata_cursor().insert_metadata(table_uri, "columns=(key,value)");
+
+        WHEN("the table size is requested")
+        {
+            bool was_fast = true;
+            int64_t size = 0;
+            const auto result = __ut_curstat_table_size(session(), table_uri, &was_fast, &size);
+
+            THEN("it returns zero")
+            {
+                REQUIRE(result == 0);
+            }
+
+            AND_THEN("it indicates that the fast path did not resolve the size")
+            {
+                REQUIRE_FALSE(was_fast);
+            }
+        }
+    }
+}
+
+SCENARIO_METHOD(curstat_size_fixture,
+  "table size propagates an error from the backing file size lookup",
+  "[curstat_size][curstat_table_size]")
+{
+    GIVEN("a simple table whose backing file size lookup returns an error")
+    {
+        metadata_cursor().insert_metadata(table_uri, "columns=()");
+
+        constexpr auto expected_error = EIO;
+        file_system().fs_size = [](WT_FILE_SYSTEM *, WT_SESSION *, const char *, wt_off_t *) {
+            return expected_error;
+        };
+
+        WHEN("the table size is requested")
+        {
+            bool was_fast = false;
+            int64_t size = 0;
+            const auto result = __ut_curstat_table_size(session(), table_uri, &was_fast, &size);
+
+            THEN("it returns the backing file size lookup error")
+            {
+                REQUIRE(result == expected_error);
+            }
+        }
+    }
+}
+
+SCENARIO_METHOD(curstat_size_fixture, "table size retrieves its backing file size",
+  "[curstat_size][curstat_table_size]")
+{
+    GIVEN("a simple table backed by a local file")
+    {
+        metadata_cursor().insert_metadata(table_uri, "columns=()");
+
+        constexpr wt_off_t expected_size = 4321;
+        file_system().fs_size = [](WT_FILE_SYSTEM *, WT_SESSION *, const char *, wt_off_t *sizep) {
+            *sizep = expected_size;
+            return 0;
+        };
+
+        WHEN("the table size is requested")
+        {
+            bool was_fast = false;
+            int64_t size = 0;
+            const auto result = __ut_curstat_table_size(session(), table_uri, &was_fast, &size);
+
+            THEN("it returns zero")
+            {
+                REQUIRE(result == 0);
+            }
+
+            AND_THEN("it indicates that the fast path resolved the size")
+            {
+                REQUIRE(was_fast);
+            }
+
+            AND_THEN("it reports the backing file size")
+            {
+                REQUIRE(size == expected_size);
+            }
+        }
+    }
+}
+
+SCENARIO_METHOD(curstat_size_fixture, "table size propagates a stable metadata search error",
+  "[curstat_size][curstat_table_size]")
+{
+    GIVEN("a simple table whose stable metadata search returns an error")
+    {
+        enable_disaggregated_storage();
+
+        metadata_cursor().insert_metadata(table_uri, "columns=()");
+
+        constexpr auto expected_error = EIO;
+        metadata_cursor().insert_metadata_error(stable_uri, expected_error);
+
+        WHEN("the table size is requested")
+        {
+            bool was_fast = false;
+            int64_t size = 0;
+            const auto result = __ut_curstat_table_size(session(), table_uri, &was_fast, &size);
+
+            THEN("it returns the stable metadata search error")
+            {
+                REQUIRE(result == expected_error);
+            }
+        }
+    }
+}
+
+SCENARIO_METHOD(curstat_size_fixture, "table size propagates an error from shared sizing",
+  "[curstat_size][curstat_table_size]")
+{
+    GIVEN("a simple table with invalid stable checkpoint metadata")
+    {
+        enable_disaggregated_storage();
+
+        metadata_cursor().insert_metadata(table_uri, "columns=()");
+
+        constexpr auto stable_config = "checkpoint=(WiredTigerCheckpoint.1=(addr=\"\",order=))";
+        metadata_cursor().insert_metadata(stable_uri, stable_config);
+
+        WHEN("the table size is requested")
+        {
+            bool was_fast = false;
+            int64_t size = 0;
+            const auto result = __ut_curstat_table_size(session(), table_uri, &was_fast, &size);
+
+            THEN("it returns the shared sizing error")
+            {
+                REQUIRE(result == WT_ERROR);
+            }
+        }
+    }
+}
+
+SCENARIO_METHOD(curstat_size_fixture, "table size retrieves the shared checkpoint size",
+  "[curstat_size][curstat_table_size]")
+{
+    GIVEN("a simple table with stable checkpoint metadata")
+    {
+        enable_disaggregated_storage();
+
+        metadata_cursor().insert_metadata(table_uri, "columns=()");
+
+        constexpr int64_t expected_size = 5678;
+        constexpr auto stable_config =
+          "checkpoint=(WiredTigerCheckpoint.1=("
+          "addr=\"\",order=1,time=1,size=5678,write_gen=1))";
+
+        metadata_cursor().insert_metadata(stable_uri, stable_config);
+
+        WHEN("the table size is requested")
+        {
+            bool was_fast = false;
+            int64_t size = 0;
+            const auto result = __ut_curstat_table_size(session(), table_uri, &was_fast, &size);
+
+            THEN("it returns zero")
+            {
+                REQUIRE(result == 0);
+            }
+
+            AND_THEN("it indicates that the fast path resolved the size")
+            {
+                REQUIRE(was_fast);
+            }
+
+            AND_THEN("it reports the shared checkpoint size")
+            {
+                REQUIRE(size == expected_size);
+            }
+        }
+    }
+}
+
+SCENARIO_METHOD(curstat_size_fixture,
+  "table size defers to the slow path when stable and local file metadata are missing",
+  "[curstat_size][curstat_table_size]")
+{
+    GIVEN("a simple table without stable or local file metadata")
+    {
+        enable_disaggregated_storage();
+
+        metadata_cursor().insert_metadata(table_uri, "columns=()");
+
+        WHEN("the table size is requested")
+        {
+            bool was_fast = true;
+            int64_t size = 0;
+            const auto result = __ut_curstat_table_size(session(), table_uri, &was_fast, &size);
+
+            THEN("it returns zero")
+            {
+                REQUIRE(result == 0);
+            }
+
+            AND_THEN("it indicates that the fast path did not resolve the size")
+            {
+                REQUIRE_FALSE(was_fast);
+            }
+        }
+    }
+}
+
+SCENARIO_METHOD(curstat_size_fixture,
+  "table size falls back to its local backing file when stable metadata is missing",
+  "[curstat_size][curstat_table_size]")
+{
+    GIVEN("a simple table without stable metadata")
+    {
+        enable_disaggregated_storage();
+
+        metadata_cursor().insert_metadata(table_uri, "columns=()");
+
+        // Mark the fallback file as local on the disaggregated connection.
+        metadata_cursor().insert_metadata(file_uri, "block_manager=default");
+
+        constexpr wt_off_t expected_size = 4321;
+        file_system().fs_size = [](WT_FILE_SYSTEM *, WT_SESSION *, const char *, wt_off_t *sizep) {
+            *sizep = expected_size;
+            return 0;
+        };
+
+        WHEN("the table size is requested")
+        {
+            bool was_fast = false;
+            int64_t size = 0;
+            const auto result = __ut_curstat_table_size(session(), table_uri, &was_fast, &size);
+
+            THEN("it returns zero")
+            {
+                REQUIRE(result == 0);
+            }
+
+            AND_THEN("it indicates that the fast path resolved the size")
+            {
+                REQUIRE(was_fast);
+            }
+
+            AND_THEN("it reports the local backing file size")
+            {
+                REQUIRE(size == expected_size);
+            }
+        }
+    }
+}

--- a/test/catch2/wrappers/mock_metadata_cursor.cpp
+++ b/test/catch2/wrappers/mock_metadata_cursor.cpp
@@ -1,0 +1,98 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+#include <cstdarg>
+
+#include "mock_metadata_cursor.h"
+
+namespace {
+
+mock_metadata_cursor &
+to_mock_cursor(WT_CURSOR *cursor)
+{
+    return *static_cast<mock_metadata_cursor *>(cursor->lang_private);
+}
+
+} // namespace
+
+mock_metadata_cursor::mock_metadata_cursor()
+{
+    _cursor.lang_private = this;
+    _cursor.set_key = set_key;
+    _cursor.search = search;
+    _cursor.get_value = get_value;
+    _cursor.reset = reset;
+}
+
+WT_CURSOR &
+mock_metadata_cursor::cursor()
+{
+    return _cursor;
+}
+
+void
+mock_metadata_cursor::insert_metadata(std::string_view uri, std::string_view value)
+{
+    _metadata.insert_or_assign(std::string(uri), std::string(value));
+}
+
+void
+mock_metadata_cursor::insert_metadata_error(std::string_view uri, int error)
+{
+    _metadata.insert_or_assign(std::string(uri), error);
+}
+
+void
+mock_metadata_cursor::set_key(WT_CURSOR *cursor, ...)
+{
+    va_list ap;
+    va_start(ap, cursor);
+    to_mock_cursor(cursor)._search_key = va_arg(ap, const char *);
+    va_end(ap);
+}
+
+int
+mock_metadata_cursor::search(WT_CURSOR *cursor)
+{
+    auto &mock = to_mock_cursor(cursor);
+    mock._search_result.reset();
+
+    const auto it = mock._metadata.find(mock._search_key);
+    if (it == mock._metadata.end())
+        return WT_NOTFOUND;
+
+    const auto *value = std::get_if<std::string>(&it->second);
+    if (value == nullptr)
+        return std::get<int>(it->second);
+
+    mock._search_result = *value;
+    return 0;
+}
+
+int
+mock_metadata_cursor::get_value(WT_CURSOR *cursor, ...)
+{
+    const auto &mock = to_mock_cursor(cursor);
+    if (!mock._search_result.has_value())
+        return EINVAL;
+
+    va_list ap;
+    va_start(ap, cursor);
+    *va_arg(ap, const char **) = mock._search_result->c_str();
+    va_end(ap);
+    return 0;
+}
+
+int
+mock_metadata_cursor::reset(WT_CURSOR *cursor)
+{
+    auto &mock = to_mock_cursor(cursor);
+    mock._search_key = {};
+    mock._search_result.reset();
+    return 0;
+}

--- a/test/catch2/wrappers/mock_metadata_cursor.h
+++ b/test/catch2/wrappers/mock_metadata_cursor.h
@@ -1,0 +1,40 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <variant>
+
+#include "wt_internal.h"
+
+class mock_metadata_cursor {
+    using metadata_result = std::variant<std::string, int>;
+
+public:
+    mock_metadata_cursor();
+
+    [[nodiscard]] WT_CURSOR &cursor();
+
+    void insert_metadata(std::string_view uri, std::string_view value);
+    void insert_metadata_error(std::string_view uri, int error);
+
+private:
+    static void set_key(WT_CURSOR *cursor, ...);
+    static int search(WT_CURSOR *cursor);
+    static int get_value(WT_CURSOR *cursor, ...);
+    static int reset(WT_CURSOR *cursor);
+
+    WT_CURSOR _cursor{};
+    std::unordered_map<std::string, metadata_result> _metadata;
+    std::string _search_key;
+    std::optional<std::string> _search_result;
+};

--- a/test/suite/test_disagg_checkpoint_size22.py
+++ b/test/suite/test_disagg_checkpoint_size22.py
@@ -26,10 +26,13 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
+import errno
+import os
 from collections import namedtuple
 from contextlib import closing
 from pathlib import Path
 from helper_disagg import DisaggSizeTestMixin, disagg_test_class
+import wiredtiger
 from wiredtiger import stat
 import wttest
 
@@ -80,7 +83,7 @@ class test_disagg_checkpoint_size22(DisaggSizeTestMixin, wttest.WiredTigerTestCa
             return cursor[key][2]
 
     def block_size(self, uri=None, session=None):
-        """Return the block size reported for a table."""
+        """Return the reported block size."""
         return self.size_stat(stat.dsrc.block_size, uri, session)
 
     def block_manager_consulted(self, uri=None, session=None):
@@ -93,6 +96,14 @@ class test_disagg_checkpoint_size22(DisaggSizeTestMixin, wttest.WiredTigerTestCa
         """Return the number of active dhandles on the connection."""
         with wttest.open_cursor(session or self.session, "statistics:") as cursor:
             return cursor[stat.conn.dh_conn_handle_count][2]
+
+    def follower_config(self):
+        """Return the configuration for a follower connection with statistics enabled."""
+        return (
+            self.extensionsConfig()
+            + ",create,statistics=(fast),"
+            + f'disaggregated=(page_log={self.page_log()},role="follower")'
+        )
 
     def test_layered_table_size_uses_checkpoint_meta(self):
         """A leader reports a layered table's checkpoint size without opening dhandles."""
@@ -111,20 +122,35 @@ class test_disagg_checkpoint_size22(DisaggSizeTestMixin, wttest.WiredTigerTestCa
         expected_size = self.open_layered_table()
 
         # A follower that has picked up the leader's checkpoint but never opened the table.
-        follower_config = (
-            self.extensionsConfig()
-            + ",create,statistics=(fast),"
-            + f'disaggregated=(page_log={self.page_log()},role="follower")'
-        )
-
         with closing(
-            self.wiredtiger_open("follower", follower_config)
+            self.wiredtiger_open("follower", self.follower_config())
         ) as follower_connection:
             self.disagg_advance_checkpoint(follower_connection)
             follower_session = follower_connection.open_session("")
 
             dhandles_before = self.dhandle_count(follower_session)
             self.assertEqual(self.block_size(session=follower_session), expected_size)
+            self.assertFalse(self.block_manager_consulted(session=follower_session))
+            self.assertEqual(self.dhandle_count(follower_session), dhandles_before)
+
+            follower_session.close()
+
+    def test_layered_table_follower_uses_zero_checkpoint_meta(self):
+        """A follower reports a picked-up zero-sized checkpoint without opening dhandles."""
+        self.session.create(self.layered_table.uri, self.layered_table.config)
+        self.session.checkpoint()
+
+        stable_uri = "file:" + self.layered_table.file_name
+        self.assertEqual(self.get_checkpoint_size(stable_uri), 0)
+
+        with closing(
+            self.wiredtiger_open("follower", self.follower_config())
+        ) as follower_connection:
+            self.disagg_advance_checkpoint(follower_connection)
+            follower_session = follower_connection.open_session("")
+
+            dhandles_before = self.dhandle_count(follower_session)
+            self.assertEqual(self.block_size(session=follower_session), 0)
             self.assertFalse(self.block_manager_consulted(session=follower_session))
             self.assertEqual(self.dhandle_count(follower_session), dhandles_before)
 
@@ -141,12 +167,112 @@ class test_disagg_checkpoint_size22(DisaggSizeTestMixin, wttest.WiredTigerTestCa
         )
         self.assertFalse(self.block_manager_consulted(self.local_table.uri))
 
-    def test_layered_table_size_without_checkpoint_uses_slow_path(self):
-        """A layered table with no checkpoint falls back to the slow path."""
+    def test_local_file_size_on_disagg_uses_filesystem(self):
+        """A local file on a disagg connection reports its filesystem size."""
+        self.session.create(self.local_table.uri, self.local_table.config)
+        file_uri = "file:" + self.local_table.file_name
+
+        self.assertEqual(
+            self.block_size(file_uri), Path(self.local_table.file_name).stat().st_size
+        )
+        self.assertFalse(self.block_manager_consulted(file_uri))
+
+    def test_layered_table_before_first_checkpoint_uses_fast_path(self):
+        """A layered table reports zero through the fast path before its first checkpoint."""
         self.open_and_populate(self.layered_table)
 
-        # No checkpoint has occurred, so we expect the slow path to be taken.
-        self.assertTrue(self.block_manager_consulted())
+        self.assertEqual(self.block_size(), 0)
+        self.assertFalse(self.block_manager_consulted())
+
+    def test_layered_table_fake_checkpoint_uses_checkpoint_meta(self):
+        """A fake checkpoint reports zero through the fast path."""
+        self.session.create(self.layered_table.uri, self.layered_table.config)
+        self.session.checkpoint()
+
+        stable_uri = "file:" + self.layered_table.file_name
+        expected_size = self.get_checkpoint_size(stable_uri)
+
+        # Ensure that it was a fake checkpoint.
+        with wttest.open_cursor(self.session, "metadata:") as cursor:
+            metadata = cursor[stable_uri]
+            self.assertEqual(metadata.count("WiredTigerCheckpoint."), 1)
+            self.assertIn('addr=""', metadata)
+
+        self.assertEqual(expected_size, 0)
+        self.assertEqual(self.block_size(), expected_size)
+        self.assertFalse(self.block_manager_consulted())
+
+    def test_layered_table_empty_root_checkpoint_uses_checkpoint_meta(self):
+        """An empty root after a real checkpoint reports zero through the fast path."""
+        self.session.create(self.layered_table.uri, self.layered_table.config)
+        with wttest.open_cursor(self.session, self.layered_table.uri) as cursor:
+            cursor["key"] = "value"
+        self.session.checkpoint()
+
+        stable_uri = "file:" + self.layered_table.file_name
+        self.assertGreater(self.get_checkpoint_size(stable_uri), 0)
+
+        with wttest.open_cursor(self.session, self.layered_table.uri) as cursor:
+            cursor.set_key("key")
+            self.assertEqual(cursor.remove(), 0)
+        self.session.checkpoint()
+
+        self.assertEqual(self.get_checkpoint_size(stable_uri), 0)
+        self.assertEqual(self.block_size(), 0)
+        self.assertFalse(self.block_manager_consulted())
+
+    def test_stable_file_empty_checkpoint_uses_checkpoint_meta(self):
+        """A direct stable-file query reports zero through the fast path for an empty checkpoint."""
+        self.session.create(self.layered_table.uri, self.layered_table.config)
+        self.session.checkpoint()
+
+        stable_uri = "file:" + self.layered_table.file_name
+        self.assertEqual(self.get_checkpoint_size(stable_uri), 0)
+
+        self.assertEqual(self.block_size(stable_uri), 0)
+        self.assertFalse(self.block_manager_consulted(stable_uri))
+
+    def test_stable_file_before_first_checkpoint_uses_fast_path(self):
+        """A direct stable-file query reports zero through the fast path before its first checkpoint."""
+        self.session.create(self.layered_table.uri, self.layered_table.config)
+
+        stable_uri = "file:" + self.layered_table.file_name
+        self.assertEqual(self.block_size(stable_uri), 0)
+        self.assertFalse(self.block_manager_consulted(stable_uri))
+
+    def test_stable_file_size_uses_checkpoint_meta(self):
+        """A direct stable-file query reports a non-zero checkpoint size without opening dhandles."""
+        expected_size = self.open_layered_table()
+        stable_uri = "file:" + self.layered_table.file_name
+
+        # Reopen to drop the cached dhandles.
+        with self.expectedStdoutPattern("Removing local file"):
+            self.reopen_conn()
+
+        dhandles_before = self.dhandle_count()
+        self.assertEqual(self.block_size(stable_uri), expected_size)
+        self.assertFalse(self.block_manager_consulted(stable_uri))
+        self.assertEqual(self.dhandle_count(), dhandles_before)
+
+    def test_missing_local_file_returns_enoent(self):
+        """A missing local file returns ENOENT."""
+        self.assertRaisesException(
+            wiredtiger.WiredTigerError,
+            lambda: self.block_size(f"file:{self.__class__.__name__}_missing.wt"),
+            os.strerror(errno.ENOENT),
+        )
+
+    def test_missing_stable_file_returns_enoent(self):
+        """A missing stable URI returns ENOENT without adding a connection dhandle."""
+        dhandles_before = self.dhandle_count()
+        self.assertRaisesException(
+            wiredtiger.WiredTigerError,
+            lambda: self.block_size(
+                f"file:{self.__class__.__name__}_missing.wt_stable"
+            ),
+            os.strerror(errno.ENOENT),
+        )
+        self.assertEqual(self.dhandle_count(), dhandles_before)
 
 
 if __name__ == "__main__":

--- a/test/suite/test_disagg_checkpoint_size22.py
+++ b/test/suite/test_disagg_checkpoint_size22.py
@@ -28,6 +28,7 @@
 
 import errno
 import os
+import re
 from collections import namedtuple
 from contextlib import closing
 from pathlib import Path
@@ -39,7 +40,7 @@ import wttest
 
 @disagg_test_class
 class test_disagg_checkpoint_size22(DisaggSizeTestMixin, wttest.WiredTigerTestCase):
-    """These tests assess how size-only statistics work for different tables on disagg connections"""
+    """Test size-only statistics for local and shared tables and files."""
 
     conn_config = 'disaggregated=(role="leader",lose_all_my_data=true)'
     base_config = "key_format=S,value_format=S"
@@ -49,7 +50,7 @@ class test_disagg_checkpoint_size22(DisaggSizeTestMixin, wttest.WiredTigerTestCa
     layered_table = Table(
         f"table:{__qualname__}",
         f"{__qualname__}.wt_stable",
-        base_config + ",block_manager=disagg,type=layered",
+        base_config + ",type=layered",
     )
 
     local_table = Table(
@@ -58,16 +59,22 @@ class test_disagg_checkpoint_size22(DisaggSizeTestMixin, wttest.WiredTigerTestCa
         base_config + ",block_manager=default,type=file",
     )
 
-    def open_and_populate(self, table):
-        """Open the table and insert enough rows to give it a nontrivial size."""
+    shared_table = Table(
+        f"table:{__qualname__}_shared",
+        f"{__qualname__}_shared.wt",
+        base_config + ",block_manager=disagg,type=file",
+    )
+
+    def create_and_populate(self, table):
+        """Create the table and insert enough rows to give it a nontrivial size."""
         self.session.create(table.uri, table.config)
         with wttest.open_cursor(self.session, table.uri) as cursor:
             for i in range(1000):
                 cursor[f"key{i:08d}"] = "x" * 100
 
-    def open_layered_table(self):
-        """Populate and checkpoint the layered table, returning its stable checkpoint size."""
-        self.open_and_populate(self.layered_table)
+    def create_and_checkpoint_layered_table(self):
+        """Create and checkpoint the layered table, returning its nonzero stable size."""
+        self.create_and_populate(self.layered_table)
         self.session.checkpoint()
         size = self.get_checkpoint_size("file:" + self.layered_table.file_name)
         self.assertGreater(size, 0)
@@ -86,10 +93,10 @@ class test_disagg_checkpoint_size22(DisaggSizeTestMixin, wttest.WiredTigerTestCa
         """Return the reported block size."""
         return self.size_stat(stat.dsrc.block_size, uri, session)
 
-    def block_manager_consulted(self, uri=None, session=None):
-        """Return whether size collection called the block manager statistics method."""
-        # The fast path zeroes the statistics and fills only block_size. block_magic is
-        # written only by a block manager's stat call.
+    def used_dhandle_stats_path(self, uri=None, session=None):
+        """Return whether size collection used the dhandle block manager statistics path."""
+        # The fast path fills only block_size. A dhandle block manager stat call also fills
+        # block_magic.
         return self.size_stat(stat.dsrc.block_magic, uri, session) != 0
 
     def dhandle_count(self, session=None):
@@ -105,9 +112,9 @@ class test_disagg_checkpoint_size22(DisaggSizeTestMixin, wttest.WiredTigerTestCa
             + f'disaggregated=(page_log={self.page_log()},role="follower")'
         )
 
-    def test_layered_table_size_uses_checkpoint_meta(self):
-        """A leader reports a layered table's checkpoint size without opening dhandles."""
-        expected_size = self.open_layered_table()
+    def test_layered_table_uses_file_metadata_fast_path(self):
+        """A layered table uses the file-metadata fast path without allocating a dhandle."""
+        expected_size = self.create_and_checkpoint_layered_table()
 
         # Reopen to drop the cached dhandles.
         with self.expectedStdoutPattern("Removing local file"):
@@ -115,28 +122,28 @@ class test_disagg_checkpoint_size22(DisaggSizeTestMixin, wttest.WiredTigerTestCa
 
         dhandles_before = self.dhandle_count()
         self.assertEqual(self.block_size(), expected_size)
+        self.assertFalse(self.used_dhandle_stats_path())
         self.assertEqual(self.dhandle_count(), dhandles_before)
 
-    def test_layered_table_follower_uses_checkpoint_meta(self):
-        """A follower reports the picked-up checkpoint size without opening dhandles."""
-        expected_size = self.open_layered_table()
+    def test_layered_table_on_follower_uses_file_metadata_fast_path(self):
+        """A follower uses the file-metadata fast path without allocating a dhandle."""
+        expected_size = self.create_and_checkpoint_layered_table()
 
         # A follower that has picked up the leader's checkpoint but never opened the table.
         with closing(
             self.wiredtiger_open("follower", self.follower_config())
         ) as follower_connection:
             self.disagg_advance_checkpoint(follower_connection)
-            follower_session = follower_connection.open_session("")
+            with closing(follower_connection.open_session("")) as follower_session:
+                dhandles_before = self.dhandle_count(follower_session)
+                self.assertEqual(
+                    self.block_size(session=follower_session), expected_size
+                )
+                self.assertFalse(self.used_dhandle_stats_path(session=follower_session))
+                self.assertEqual(self.dhandle_count(follower_session), dhandles_before)
 
-            dhandles_before = self.dhandle_count(follower_session)
-            self.assertEqual(self.block_size(session=follower_session), expected_size)
-            self.assertFalse(self.block_manager_consulted(session=follower_session))
-            self.assertEqual(self.dhandle_count(follower_session), dhandles_before)
-
-            follower_session.close()
-
-    def test_layered_table_follower_uses_zero_checkpoint_meta(self):
-        """A follower reports a picked-up zero-sized checkpoint without opening dhandles."""
+    def test_layered_table_zero_size_on_follower_uses_file_metadata_fast_path(self):
+        """A follower reports zero through the file-metadata fast path."""
         self.session.create(self.layered_table.uri, self.layered_table.config)
         self.session.checkpoint()
 
@@ -147,45 +154,89 @@ class test_disagg_checkpoint_size22(DisaggSizeTestMixin, wttest.WiredTigerTestCa
             self.wiredtiger_open("follower", self.follower_config())
         ) as follower_connection:
             self.disagg_advance_checkpoint(follower_connection)
-            follower_session = follower_connection.open_session("")
+            with closing(follower_connection.open_session("")) as follower_session:
+                dhandles_before = self.dhandle_count(follower_session)
+                self.assertEqual(self.block_size(session=follower_session), 0)
+                self.assertFalse(self.used_dhandle_stats_path(session=follower_session))
+                self.assertEqual(self.dhandle_count(follower_session), dhandles_before)
 
-            dhandles_before = self.dhandle_count(follower_session)
-            self.assertEqual(self.block_size(session=follower_session), 0)
-            self.assertFalse(self.block_manager_consulted(session=follower_session))
-            self.assertEqual(self.dhandle_count(follower_session), dhandles_before)
-
-            follower_session.close()
-
-    def test_local_table_size_on_disagg_uses_filesystem(self):
-        """A local table on a disagg connection reports its filesystem size."""
-        self.open_and_populate(self.local_table)
+    def test_local_table_uses_filesystem_fast_path(self):
+        """A local table uses the filesystem fast path."""
+        self.create_and_populate(self.local_table)
         self.session.checkpoint()
 
         self.assertEqual(
             self.block_size(self.local_table.uri),
             Path(self.local_table.file_name).stat().st_size,
         )
-        self.assertFalse(self.block_manager_consulted(self.local_table.uri))
+        self.assertFalse(self.used_dhandle_stats_path(self.local_table.uri))
 
-    def test_local_file_size_on_disagg_uses_filesystem(self):
-        """A local file on a disagg connection reports its filesystem size."""
+    def test_local_file_uses_filesystem_fast_path(self):
+        """A local file uses the filesystem fast path."""
         self.session.create(self.local_table.uri, self.local_table.config)
         file_uri = "file:" + self.local_table.file_name
 
         self.assertEqual(
             self.block_size(file_uri), Path(self.local_table.file_name).stat().st_size
         )
-        self.assertFalse(self.block_manager_consulted(file_uri))
+        self.assertFalse(self.used_dhandle_stats_path(file_uri))
 
-    def test_layered_table_before_first_checkpoint_uses_fast_path(self):
-        """A layered table reports zero through the fast path before its first checkpoint."""
-        self.open_and_populate(self.layered_table)
+    def test_shared_table_uses_file_metadata_fast_path(self):
+        """A shared table uses the file-metadata fast path."""
+        self.create_and_populate(self.shared_table)
+        file_uri = "file:" + self.shared_table.file_name
+
+        self.assertEqual(self.block_size(self.shared_table.uri), 0)
+        self.assertFalse(self.used_dhandle_stats_path(self.shared_table.uri))
+
+        self.session.checkpoint()
+        expected_size = self.get_checkpoint_size(file_uri)
+        self.assertGreater(expected_size, 0)
+        self.assertEqual(self.block_size(self.shared_table.uri), expected_size)
+        self.assertFalse(self.used_dhandle_stats_path(self.shared_table.uri))
+
+    def test_shared_file_uses_file_metadata_fast_path(self):
+        """A shared file uses the file-metadata fast path."""
+        self.create_and_populate(self.shared_table)
+        file_uri = "file:" + self.shared_table.file_name
+
+        self.assertEqual(self.block_size(file_uri), 0)
+        self.assertFalse(self.used_dhandle_stats_path(file_uri))
+
+        self.session.checkpoint()
+        expected_size = self.get_checkpoint_size(file_uri)
+        self.assertGreater(expected_size, 0)
+        self.assertEqual(self.block_size(file_uri), expected_size)
+        self.assertFalse(self.used_dhandle_stats_path(file_uri))
+
+    def test_indexed_table_uses_schema_path(self):
+        """An indexed table uses schema aggregation instead of the simple-table fast path."""
+        name = f"{self.__class__.__name__}_indexed"
+        table_uri = f"table:{name}"
+        file_uri = f"file:{name}.wt"
+        index_uri = f"index:{name}:value"
+
+        self.session.create(table_uri, self.base_config + ",columns=(key,value)")
+        self.session.create(index_uri, "columns=(value)")
+        with wttest.open_cursor(self.session, table_uri) as cursor:
+            for i in range(1000):
+                cursor[f"key{i:08d}"] = f"value{i:08d}"
+        self.session.checkpoint()
+
+        file_size = self.block_size(file_uri)
+        index_size = self.block_size(index_uri)
+        self.assertGreater(index_size, 0)
+        self.assertEqual(self.block_size(table_uri), file_size + index_size)
+
+    def test_layered_table_before_first_checkpoint_uses_file_metadata_fast_path(self):
+        """A layered table uses the file-metadata fast path before its first checkpoint."""
+        self.create_and_populate(self.layered_table)
 
         self.assertEqual(self.block_size(), 0)
-        self.assertFalse(self.block_manager_consulted())
+        self.assertFalse(self.used_dhandle_stats_path())
 
-    def test_layered_table_fake_checkpoint_uses_checkpoint_meta(self):
-        """A fake checkpoint reports zero through the fast path."""
+    def test_layered_table_fake_checkpoint_uses_file_metadata_fast_path(self):
+        """A layered table uses the file-metadata fast path for a fake checkpoint."""
         self.session.create(self.layered_table.uri, self.layered_table.config)
         self.session.checkpoint()
 
@@ -195,15 +246,15 @@ class test_disagg_checkpoint_size22(DisaggSizeTestMixin, wttest.WiredTigerTestCa
         # Ensure that it was a fake checkpoint.
         with wttest.open_cursor(self.session, "metadata:") as cursor:
             metadata = cursor[stable_uri]
-            self.assertEqual(metadata.count("WiredTigerCheckpoint."), 1)
-            self.assertIn('addr=""', metadata)
+        self.assertEqual(metadata.count("WiredTigerCheckpoint."), 1)
+        self.assertIn('addr=""', metadata)
 
         self.assertEqual(expected_size, 0)
         self.assertEqual(self.block_size(), expected_size)
-        self.assertFalse(self.block_manager_consulted())
+        self.assertFalse(self.used_dhandle_stats_path())
 
-    def test_layered_table_empty_root_checkpoint_uses_checkpoint_meta(self):
-        """An empty root after a real checkpoint reports zero through the fast path."""
+    def test_layered_table_post_delete_checkpoint_uses_file_metadata_fast_path(self):
+        """A layered table uses the file-metadata fast path after deleting its last key."""
         self.session.create(self.layered_table.uri, self.layered_table.config)
         with wttest.open_cursor(self.session, self.layered_table.uri) as cursor:
             cursor["key"] = "value"
@@ -219,30 +270,19 @@ class test_disagg_checkpoint_size22(DisaggSizeTestMixin, wttest.WiredTigerTestCa
 
         self.assertEqual(self.get_checkpoint_size(stable_uri), 0)
         self.assertEqual(self.block_size(), 0)
-        self.assertFalse(self.block_manager_consulted())
+        self.assertFalse(self.used_dhandle_stats_path())
 
-    def test_stable_file_empty_checkpoint_uses_checkpoint_meta(self):
-        """A direct stable-file query reports zero through the fast path for an empty checkpoint."""
-        self.session.create(self.layered_table.uri, self.layered_table.config)
-        self.session.checkpoint()
-
-        stable_uri = "file:" + self.layered_table.file_name
-        self.assertEqual(self.get_checkpoint_size(stable_uri), 0)
-
-        self.assertEqual(self.block_size(stable_uri), 0)
-        self.assertFalse(self.block_manager_consulted(stable_uri))
-
-    def test_stable_file_before_first_checkpoint_uses_fast_path(self):
-        """A direct stable-file query reports zero through the fast path before its first checkpoint."""
+    def test_stable_file_before_first_checkpoint_uses_file_metadata_fast_path(self):
+        """A stable file uses the file-metadata fast path before its first checkpoint."""
         self.session.create(self.layered_table.uri, self.layered_table.config)
 
         stable_uri = "file:" + self.layered_table.file_name
         self.assertEqual(self.block_size(stable_uri), 0)
-        self.assertFalse(self.block_manager_consulted(stable_uri))
+        self.assertFalse(self.used_dhandle_stats_path(stable_uri))
 
-    def test_stable_file_size_uses_checkpoint_meta(self):
-        """A direct stable-file query reports a non-zero checkpoint size without opening dhandles."""
-        expected_size = self.open_layered_table()
+    def test_stable_file_uses_file_metadata_fast_path(self):
+        """A stable file uses the file-metadata fast path without allocating a dhandle."""
+        expected_size = self.create_and_checkpoint_layered_table()
         stable_uri = "file:" + self.layered_table.file_name
 
         # Reopen to drop the cached dhandles.
@@ -251,25 +291,78 @@ class test_disagg_checkpoint_size22(DisaggSizeTestMixin, wttest.WiredTigerTestCa
 
         dhandles_before = self.dhandle_count()
         self.assertEqual(self.block_size(stable_uri), expected_size)
-        self.assertFalse(self.block_manager_consulted(stable_uri))
+        self.assertFalse(self.used_dhandle_stats_path(stable_uri))
         self.assertEqual(self.dhandle_count(), dhandles_before)
 
-    def test_missing_local_file_returns_enoent(self):
-        """A missing local file returns ENOENT."""
-        self.assertRaisesException(
-            wiredtiger.WiredTigerError,
-            lambda: self.block_size(f"file:{self.__class__.__name__}_missing.wt"),
-            os.strerror(errno.ENOENT),
-        )
+    def test_stable_checkpoint_view_uses_dhandle_stats_path(self):
+        """A stable checkpoint-view URI uses the dhandle statistics path."""
+        expected_size = self.create_and_checkpoint_layered_table()
+        stable_uri = "file:" + self.layered_table.file_name
 
-    def test_missing_stable_file_returns_enoent(self):
-        """A missing stable URI returns ENOENT without adding a connection dhandle."""
+        with wttest.open_cursor(self.session, "metadata:") as cursor:
+            metadata = cursor[stable_uri]
+        checkpoint_names = re.findall(r"(WiredTigerCheckpoint\.\d+)=", metadata)
+        self.assertTrue(checkpoint_names)
+
+        checkpoint_view_uri = f"{stable_uri}/{checkpoint_names[-1]}"
+        self.assertEqual(self.block_size(checkpoint_view_uri), expected_size)
+        self.assertTrue(self.used_dhandle_stats_path(checkpoint_view_uri))
+
+    def test_missing_file_without_metadata_returns_enoent_without_dhandle(self):
+        """A missing file without metadata returns ENOENT without allocating a dhandle."""
+        uri = f"file:{self.__class__.__name__}_missing.wt"
         dhandles_before = self.dhandle_count()
         self.assertRaisesException(
             wiredtiger.WiredTigerError,
-            lambda: self.block_size(
-                f"file:{self.__class__.__name__}_missing.wt_stable"
-            ),
+            lambda: self.block_size(uri),
+            os.strerror(errno.ENOENT),
+        )
+        self.assertEqual(self.dhandle_count(), dhandles_before)
+
+    def test_existing_file_without_metadata_returns_enoent_without_dhandle(self):
+        """An existing filesystem file without metadata returns ENOENT without allocating a dhandle."""
+        filename = f"{self.__class__.__name__}_without_metadata.wt"
+        Path(filename).write_bytes(b"not a WiredTiger file")
+
+        uri = "file:" + filename
+        dhandles_before = self.dhandle_count()
+        self.assertRaisesException(
+            wiredtiger.WiredTigerError,
+            lambda: self.block_size(uri),
+            os.strerror(errno.ENOENT),
+        )
+        self.assertEqual(self.dhandle_count(), dhandles_before)
+
+    def test_local_file_with_metadata_missing_from_disk_uses_dhandle_path(self):
+        """A local file with metadata but no filesystem file falls back to the dhandle path."""
+        self.create_and_populate(self.local_table)
+        self.session.checkpoint()
+
+        self.close_conn()
+        Path(self.local_table.file_name).unlink()
+        self.open_conn(config='disaggregated=(role="leader")')
+
+        file_uri = "file:" + self.local_table.file_name
+        self.assertFalse(Path(self.local_table.file_name).exists())
+        with wttest.open_cursor(self.session, "metadata:") as cursor:
+            cursor.set_key(file_uri)
+            self.assertEqual(cursor.search(), 0)
+
+        dhandles_before = self.dhandle_count()
+        self.assertRaisesException(
+            wiredtiger.WiredTigerError,
+            lambda: self.block_size(file_uri),
+            os.strerror(errno.ENOENT),
+        )
+        self.assertGreater(self.dhandle_count(), dhandles_before)
+
+    def test_missing_table_without_metadata_returns_enoent_without_dhandle(self):
+        """A missing table without metadata returns ENOENT without allocating a dhandle."""
+        uri = f"table:{self.__class__.__name__}_missing"
+        dhandles_before = self.dhandle_count()
+        self.assertRaisesException(
+            wiredtiger.WiredTigerError,
+            lambda: self.block_size(uri),
             os.strerror(errno.ENOENT),
         )
         self.assertEqual(self.dhandle_count(), dhandles_before)


### PR DESCRIPTION
Changes:
- Trust zero from the metadata for shared files
- (As per the discussion with Luke Pearson) Handle files that are disagg backed / shared by checking the block manager
- Add tests

Prior to this change, statistics=(size) always fell back to the slow path when the checkpoint metadata reports a size of zero. For disaggregated storage, the slow path then reread the same metadata while also opening dhandles.

For more information please refer to [WT-18119](https://jira.mongodb.org/browse/WT-18119).