### PR TITLE
WT-18200 Fix ignoring of log_slot_destroy stdout pattern

### DIFF
--- a/test/suite/test_bug018.py
+++ b/test/suite/test_bug018.py
@@ -105,7 +105,7 @@ class test_bug018(wttest.WiredTigerTestCase, suite_subprocess):
                 pass
 
         # Expect an error and messages, so turn off stderr checking.
-        self.ignoreStdoutPatternIfExists('log_slot_destroy: failed to write slot')
+        self.ignoreStdoutPattern('log_slot_destroy: failed to write slot')
         with self.expectedStderrPattern(''):
             try:
                 self.close_conn()


### PR DESCRIPTION
Use ignoreStdoutPattern(), not ignoreStdoutPatternIfExists(), because the former filters messages that occur later in the test, not ones that have already occured. The message occurs later during the connection closure.