### PR TITLE
WT-18214 Fix test/format multi node failing with low op count

### DIFF
--- a/test/format/format.h
+++ b/test/format/format.h
@@ -229,7 +229,9 @@ extern u_int ntables;
 typedef struct {
     wt_shared uint64_t leader_hash;
     wt_shared uint64_t follower_hash;
-} DISAGG_MULTI_DB_HASH;
+    wt_shared uint64_t leader_ops_base;
+    wt_shared uint64_t follower_ops_base;
+} DISAGG_MULTI_SHARED;
 
 typedef struct {
     WT_CONNECTION *wts_conn;
@@ -288,6 +290,7 @@ typedef struct {
 
     wt_timestamp_t replay_cached_committed; /* Our committed timestamp, cached */
     uint32_t replay_calculate_committed;    /* Times before recalculating cached committed */
+    wt_timestamp_t replay_ops_base;         /* Timestamp the operations phase started from */
     wt_timestamp_t replay_start_timestamp;  /* Timestamp at the beginning of a run */
     FILE *replay_op_log;                    /* Predictable replay per-run operation log */
     wt_timestamp_t stop_timestamp;          /* If non-zero, stop when stable reaches this */
@@ -340,9 +343,9 @@ typedef struct {
 
     bool disagg_leader; /* If disaggregated storage role is configured as a leader. */
     pid_t follower_pid; /* For multi-node disagg follower process */
-    char checkpoint_metadata[FILENAME_MAX]; /* Last checkpoint metadata picked up by follower. */
-    DISAGG_MULTI_DB_HASH *disagg_multi_db_hash; /* Leader and follower database hash */
-    int disagg_multi_sync_socket;               /* Socket for leader-follower sync */
+    char checkpoint_metadata[FILENAME_MAX];   /* Last checkpoint metadata picked up by follower. */
+    DISAGG_MULTI_SHARED *disagg_multi_shared; /* Leader/follower shared validation state */
+    int disagg_multi_sync_socket;             /* Socket for leader-follower sync */
 
     wt_timestamp_t key_push_history[KEY_PUSH_HISTORY_MAX]; /* Push-mode key rotation: timestamps */
     size_t key_push_count; /* Number of pushed timestamps recorded */
@@ -505,6 +508,7 @@ void disagg_setup_multi_node(void);
 void disagg_switch_roles(void);
 void disagg_teardown_multi_node(void);
 void disagg_sync_multi_node(WT_SESSION *);
+void disagg_sync_ops_base(void);
 const char *session_prefetch_cfg(void);
 void fclose_and_clear(FILE **);
 void follower_read_latest_checkpoint(void);

--- a/test/format/format_disagg.c
+++ b/test/format/format_disagg.c
@@ -70,8 +70,8 @@ disagg_teardown_multi_node(void)
         g.follower_pid = 0;
     }
     close(g.disagg_multi_sync_socket);
-    testutil_check(munmap(g.disagg_multi_db_hash, sizeof(DISAGG_MULTI_DB_HASH)));
-    g.disagg_multi_db_hash = NULL;
+    testutil_check(munmap(g.disagg_multi_shared, sizeof(DISAGG_MULTI_SHARED)));
+    g.disagg_multi_shared = NULL;
 }
 
 /*
@@ -106,9 +106,9 @@ disagg_setup_multi_node(void)
      * Allocate a shared memory region to hold hash values shared between leader and follower
      * processes, used by disagg multi node tests to validate data consistency.
      */
-    g.disagg_multi_db_hash = mmap(NULL, sizeof(DISAGG_MULTI_DB_HASH), PROT_READ | PROT_WRITE,
-      MAP_SHARED | MAP_ANONYMOUS, -1, 0);
-    testutil_assert_errno(g.disagg_multi_db_hash != MAP_FAILED);
+    g.disagg_multi_shared = mmap(
+      NULL, sizeof(DISAGG_MULTI_SHARED), PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+    testutil_assert_errno(g.disagg_multi_shared != MAP_FAILED);
 
     /* Create a socket pair for leader-follower synchronization.*/
     if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) == -1)
@@ -157,6 +157,30 @@ disagg_multi_sync_point(void)
 }
 
 /*
+ * disagg_sync_ops_base --
+ *     Agree on a common predictable-replay operations base across the leader and follower.
+ */
+void
+disagg_sync_ops_base(void)
+{
+    wt_timestamp_t base;
+
+    if (!disagg_is_multi_node() || !GV(RUNS_PREDICTABLE_REPLAY))
+        return;
+
+    if (g.disagg_leader)
+        g.disagg_multi_shared->leader_ops_base = g.timestamp;
+    else
+        g.disagg_multi_shared->follower_ops_base = g.timestamp;
+
+    disagg_multi_sync_point();
+
+    base = WT_MAX(g.disagg_multi_shared->leader_ops_base, g.disagg_multi_shared->follower_ops_base);
+    testutil_assert(base >= g.timestamp);
+    g.replay_ops_base = base;
+}
+
+/*
  * disagg_sync_multi_node --
  *     Synchronization point in disagg multi-node setup for leader-follower data validation.
  */
@@ -170,9 +194,9 @@ disagg_sync_multi_node(WT_SESSION *session)
     if (GV(DISAGG_MULTI_VALIDATION)) {
         hash = checksum_database(session);
         if (g.disagg_leader)
-            g.disagg_multi_db_hash->leader_hash = hash;
+            g.disagg_multi_shared->leader_hash = hash;
         else
-            g.disagg_multi_db_hash->follower_hash = hash;
+            g.disagg_multi_shared->follower_hash = hash;
     }
 
     /* Initial synchronization between leader and follower processes. */
@@ -185,7 +209,7 @@ disagg_sync_multi_node(WT_SESSION *session)
          */
 
         bool hash_match =
-          g.disagg_multi_db_hash->leader_hash == g.disagg_multi_db_hash->follower_hash;
+          g.disagg_multi_shared->leader_hash == g.disagg_multi_shared->follower_hash;
         if (!hash_match && GV(DISAGG_PRESERVE))
             testutil_disagg_preserve(session->connection, "preserve", g.stable_timestamp);
 

--- a/test/format/format_timestamp.c
+++ b/test/format/format_timestamp.c
@@ -151,7 +151,7 @@ timestamp_once(WT_SESSION *session, bool allow_lag, bool final)
          */
         WT_ACQUIRE_READ_WITH_BARRIER(stop_timestamp, g.stop_timestamp);
         if (stable_timestamp > stop_timestamp && stop_timestamp != WT_TS_NONE)
-            stable_timestamp = stop_timestamp;
+            stable_timestamp = WT_MAX(stop_timestamp, g.stable_timestamp);
 
         /*
          * For predictable replay, we need the oldest timestamp to lag when the process exits. That
@@ -160,7 +160,7 @@ timestamp_once(WT_SESSION *session, bool allow_lag, bool final)
         if (stable_timestamp > 10 * WT_THOUSAND)
             oldest_timestamp = WT_MAX(stable_timestamp - 10 * WT_THOUSAND, g.oldest_timestamp);
         else
-            oldest_timestamp = stable_timestamp / 2;
+            oldest_timestamp = WT_MAX(stable_timestamp / 2, g.oldest_timestamp);
     } else if (!final) {
         /*
          * If lag is permitted, update the oldest timestamp halfway to the largest timestamp that's

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -343,7 +343,10 @@ operations(u_int ops_seconds, u_int run_current, u_int run_total)
              */
             thread_ops = -1;
             ops_seconds = 0;
-            g.stop_timestamp = (GV(RUNS_OPS) * (uint64_t)run_current) / run_total;
+            if (g.replay_ops_base == WT_TS_NONE)
+                g.replay_ops_base = g.timestamp;
+            g.stop_timestamp =
+              g.replay_ops_base + (GV(RUNS_OPS) * (uint64_t)run_current) / run_total;
         } else
             thread_ops = GV(RUNS_OPS) / GV(RUNS_THREADS);
     }

--- a/test/format/t.c
+++ b/test/format/t.c
@@ -383,6 +383,12 @@ main(int argc, char *argv[])
     scan_args.rnd = &g.extra_rnd;
     TIMED_MAJOR_OP(tables_apply(wts_read_scan, &scan_args));
 
+    /*
+     * Agree on the predictable-replay operations base before the first run computes its stop
+     * timestamp, and before any background thread can advance the timestamp asymmetrically.
+     */
+    disagg_sync_ops_base();
+
     /* Optionally start checkpoints. */
     wts_checkpoints();
 


### PR DESCRIPTION
## Motivation

`test/format` multi-node aborts at low operation counts. The predictable-replay stop
target was derived from `runs.ops` alone, but populate consumes timestamps in proportion
to table row counts — so with a small `runs.ops` the target lands *behind* the timestamp
populate already reached. Two things then break:

- `timestamp_once` clamps the stable timestamp backwards, and `set_timestamp` rejects that
  with `EINVAL` (`txn_timestamp.c:441`), aborting the run.
- `replay_prepare_ts` sees `stable >= stop` and quits every worker immediately, so the run
  performs no operations at all.

Until now we've never run disagg-multi below `runs.ops=500000`, so the target always cleared the
populate baseline and this was never hit. In [WT-16736](https://jira.mongodb.org/browse/WT-16736) we want shorter runs for pull-request task variants, so we hit this error during testing.

## What changed

- `operations()` anchors the stop target to `g.replay_ops_base`, fixed once before the first
  run, rather than computing an absolute target from `runs.ops` each run.
- New `disagg_sync_ops_base()` in `format_disagg.c` agrees that base across the leader and
  follower over the existing shared mapping, taking the **maximum** of the two. Both
  properties matter: the target must be the same absolute value on each side so
  rollback-to-stable trims the same suffix and the database hashes agree, and it must sit
  above *both* processes' timestamps, since populate leaves them a few apart. Re-deriving it
  from the local timestamp per run instead caused `disagg_sync_multi_node` hash mismatches.
- `timestamp_once` no longer hands `set_timestamp` a stable timestamp older than the current
  one, and floors `oldest` at its previous value on the `<= 10 * WT_THOUSAND` arm to match
  the other arm.
- `DISAGG_MULTI_DB_HASH` → `DISAGG_MULTI_SHARED`, which now carries the shared bases
  alongside the hashes.