### PR TITLE
WT-16346 Assert r->ref is non-NULL in __rec_split_write 

### DIFF
--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2462,6 +2462,9 @@ __rec_split_write(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WTI_REC_CHUNK *chu
     conn = S2C(session);
     btree = S2BT(session);
     page = r->page;
+
+    WT_ASSERT(session, r->ref != NULL);
+
     build_delta = false;
     skip_write = false;
 #ifdef HAVE_DIAGNOSTIC


### PR DESCRIPTION
Coverity NULL_FIELD #184206 flags __rec_split_write() in src/reconcile/rec_write.c: the WT_REC_RESULT_SINGLE_PAGE macro dereferences r->ref->page->modify without a r->ref != NULL check