### PR TITLE
WT-18218 Fix race issue on log file double fetching

### DIFF
--- a/src/log/log_mgr.c
+++ b/src/log/log_mgr.c
@@ -398,9 +398,10 @@ __compute_min_lognum(WT_SESSION_IMPL *session, WTI_LOG *log, uint32_t backup_fil
      * backup or the checkpoint LSN. Otherwise we want the minimum of the last log file written to
      * disk and the checkpoint LSN.
      */
-    min_lognum = backup_file == 0 ?
-      WT_MIN(__wt_lsn_file(&log->ckpt_lsn), __wt_lsn_file(&log->sync_lsn)) :
-      WT_MIN(__wt_lsn_file(&log->ckpt_lsn), backup_file);
+    uint32_t ckpt_file = __wt_lsn_file(&log->ckpt_lsn);
+    uint32_t sync_file = __wt_lsn_file(&log->sync_lsn);
+
+    min_lognum = backup_file == 0 ? WT_MIN(ckpt_file, sync_file) : WT_MIN(ckpt_file, backup_file);
 
     __wt_readlock(session, &conn->log_mgr.debug_log_retention_lock);
 
@@ -425,7 +426,11 @@ __compute_min_lognum(WT_SESSION_IMPL *session, WTI_LOG *log, uint32_t backup_fil
             min_lognum = log->fileid - (conn->debug.log_cnt + 1);
         else
             min_lognum = WT_MIN(log->fileid - (conn->debug.log_cnt + 1), min_lognum);
-    }
+    } else
+        /*
+         * Checkpoint log must maintain, violation is always data loss.
+         */
+        WT_ASSERT(session, min_lognum <= ckpt_file);
 
     __wt_readunlock(session, &conn->log_mgr.debug_log_retention_lock);
 #ifdef HAVE_DIAGNOSTIC


### PR DESCRIPTION
The issue here is WT_MIN is a macro, which will made the call twice. As `log->sync_lsn` is operated in multi-thread, so there has a race lead to a bad scenario that `min_lognum < __wt_lsn_file(&log->ckpt_lsn)`, then we face a silent data loss.

To make this process clear, the WT_MIN part can be expanded to following:
```c
// __wt_lsn_file -> __wt_atomic_load_uint32_relaxed(&lsn->l.file)
min_lognum = backup_file == 0 ? (
    __wt_lsn_file(&log->ckpt_lsn) < __wt_lsn_file(&log->sync_lsn) ? 
        __wt_lsn_file(&log->ckpt_lsn) : __wt_lsn_file(&log->sync_lsn)
    ) : __wt_lsn_file(&log->ckpt_lsn) < backup_file ? 
        __wt_lsn_file(&log->ckpt_lsn) : backup_file;
```
Let's assume the scenario that `ckpt_file == sync_lsn`, then `<` returns `false`, `min_lognum = __wt_lsn_file(&log->sync_lsn)`. What can happen here is when set the min_lognum, sync_file is been pushed 1 more, so it will become `min_lognum = ckpt_file + 1`, the ckpt log file will be silently deleted, then create a data loss.

The PR change is to make sure it's not happen.