### PR TITLE
WT-17091 Preserve the shared metadata queue across step-down

### DIFF
--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -422,6 +422,253 @@ __disagg_shared_metadata_queue_clear(WT_SESSION_IMPL *session)
     __wt_spin_unlock(session, &conn->disaggregated_storage.shared_metadata_queue_lock);
 }
 
+#ifdef HAVE_DIAGNOSTIC
+/*
+ * __disagg_shared_metadata_queue_verify --
+ *     Validate the queue that survives step-down: every entry is an uncovered create or remove
+ *     intent (schema epoch above the last checkpoint), and never a transient update --
+ *     an update exists only inside an in-flight checkpoint, and none runs during step-down.
+ */
+static void
+__disagg_shared_metadata_queue_verify(WT_SESSION_IMPL *session)
+{
+    WT_CONNECTION_IMPL *conn;
+    WT_DISAGG_METADATA_OP *entry;
+    wt_timestamp_t stable_schema_epoch;
+
+    conn = S2C(session);
+    stable_schema_epoch =
+      __wt_atomic_load_uint64_acquire(&conn->txn_global.last_ckpt_disaggregated_schema_epoch);
+
+    __wt_spin_lock(session, &conn->disaggregated_storage.shared_metadata_queue_lock);
+
+    TAILQ_FOREACH (entry, &conn->disaggregated_storage.shared_metadata_qh, q) {
+        WT_ASSERT(session,
+          entry->metadata_op == WT_SHARED_METADATA_CREATE ||
+            entry->metadata_op == WT_SHARED_METADATA_REMOVE);
+        /* An uncovered intent sits above the last checkpoint, except in epoch-less legacy mode. */
+        WT_ASSERT(session,
+          stable_schema_epoch == WT_SCHEMA_EPOCH_NONE ||
+            entry->schema_epoch == WT_SCHEMA_EPOCH_UNPUBLISHED ||
+            entry->schema_epoch > stable_schema_epoch);
+    }
+
+    __wt_spin_unlock(session, &conn->disaggregated_storage.shared_metadata_queue_lock);
+}
+
+/*
+ * __disagg_assert_stable_empty --
+ *     Validate that an uncovered stable constituent holds no data before it is dropped, so the drop
+ *     cannot discard committed data.
+ */
+static void
+__disagg_assert_stable_empty(WT_SESSION_IMPL *session, const char *stable_uri)
+{
+    WT_CURSOR *cursor;
+    WT_DECL_RET;
+    const char *cfg[] = {WT_CONFIG_BASE(session, WT_SESSION_open_cursor), NULL};
+
+    cursor = NULL;
+
+    WT_ERR(__wt_open_cursor(session, stable_uri, NULL, cfg, &cursor));
+    WT_ASSERT(session, cursor->next(cursor) == WT_NOTFOUND);
+
+err:
+    if (cursor != NULL)
+        WT_TRET(cursor->close(cursor));
+    WT_UNUSED(ret);
+}
+#endif
+
+/*
+ * __disagg_drop_local_stable --
+ *     Drop one local stable constituent, tolerating one already removed (a following remove dropped
+ *     it). Schema work during a role transition is allowed only on an internal session. Returns
+ *     EBUSY when the constituent's handle is in use.
+ */
+static int
+__disagg_drop_local_stable(WT_SESSION_IMPL *int_session, const char *stable_uri)
+{
+    WT_DECL_RET;
+    const char *drop_cfg[] = {WT_CONFIG_BASE(int_session, WT_SESSION_drop), "force=true", NULL};
+
+#ifdef HAVE_DIAGNOSTIC
+    __disagg_assert_stable_empty(int_session, stable_uri);
+#endif
+
+    WT_WITH_SCHEMA_LOCK(
+      int_session, ret = __wt_schema_drop(int_session, stable_uri, drop_cfg, false));
+    if (ret == ENOENT || ret == WT_NOTFOUND)
+        return (0);
+    return (ret);
+}
+
+/*
+ * __disagg_collect_local_only_stable_uris --
+ *     Collect into the caller's array the local layered tables' stable constituents that are absent
+ *     from the shared metadata.
+ */
+static int
+__disagg_collect_local_only_stable_uris(
+  WT_SESSION_IMPL *int_session, WT_CURSOR *shared, char ***urisp, size_t *countp, size_t *allocp)
+{
+    WT_CONFIG_ITEM cval;
+    WT_CURSOR *scan;
+    WT_DECL_RET;
+    char *stable_uri;
+    const char *layered_cfg, *layered_uri;
+
+    scan = NULL;
+    stable_uri = NULL;
+
+    WT_ERR(__wt_metadata_cursor(int_session, &scan));
+    scan->set_key(scan, "layered:");
+    WT_ERR(scan->bound(scan, "bound=lower"));
+    while ((ret = scan->next(scan)) == 0) {
+        WT_ERR(scan->get_key(scan, &layered_uri));
+        WT_ERR(scan->get_value(scan, &layered_cfg));
+        if (!WT_PREFIX_MATCH(layered_uri, "layered:"))
+            break;
+
+        WT_ERR(__wt_config_getones(int_session, layered_cfg, "stable", &cval));
+        WT_ERR(__wt_strndup(int_session, cval.str, cval.len, &stable_uri));
+
+        /* A constituent already in the shared metadata is published; keep it. */
+        if (shared != NULL) {
+            shared->set_key(shared, stable_uri);
+            ret = shared->search(shared);
+            if (ret == 0) {
+                __wt_free(int_session, stable_uri);
+                stable_uri = NULL;
+                continue;
+            }
+            if (ret != WT_NOTFOUND)
+                WT_ERR(ret);
+        }
+
+        WT_ERR(__wt_realloc_def(int_session, allocp, *countp + 1, urisp));
+        (*urisp)[(*countp)++] = stable_uri;
+        stable_uri = NULL;
+    }
+    WT_ERR_NOTFOUND_OK(ret, false);
+
+err:
+    __wt_free(int_session, stable_uri);
+    if (scan != NULL)
+        WT_TRET(__wt_metadata_cursor_release(int_session, &scan));
+    return (ret);
+}
+
+/*
+ * __disagg_drop_local_only_stable_tables_legacy --
+ *     Legacy step-down cleanup. Without schema epochs to mark coverage, drop every local stable
+ *     table missing from the shared metadata: it was created as leader and never published, so a
+ *     follower must not keep it. Also clear the queue, which a later step-up rebuilds from a scan.
+ */
+static int
+__disagg_drop_local_only_stable_tables_legacy(WT_SESSION_IMPL *session)
+{
+    WT_CURSOR *shared;
+    WT_DECL_RET;
+    WT_SESSION_IMPL *int_session;
+    size_t drop_allocated, drop_count, i;
+    char **drop_uris;
+    const char *cursor_cfg[] = {WT_CONFIG_BASE(session, WT_SESSION_open_cursor), NULL};
+
+    shared = NULL;
+    int_session = NULL;
+    drop_uris = NULL;
+    drop_allocated = drop_count = 0;
+
+    __disagg_shared_metadata_queue_clear(session);
+
+    /* A role transition permits schema work only on an internal session. */
+    WT_ERR(__wt_open_internal_session(S2C(session), "disagg-step-down", false, 0, 0, &int_session));
+
+    /* Read the shared metadata live: the checkpoint cursor would deadlock on the lock we hold. */
+    WT_ERR(__wt_open_cursor(int_session, WT_DISAGG_METADATA_URI, NULL, cursor_cfg, &shared));
+
+    /* Collect first, then drop: a drop closes handles and cannot run with the scan cursor open. */
+    WT_ERR(__disagg_collect_local_only_stable_uris(
+      int_session, shared, &drop_uris, &drop_count, &drop_allocated));
+    if (shared != NULL)
+        WT_ERR(shared->close(shared));
+    shared = NULL;
+
+    for (i = 0; i < drop_count; i++) {
+        ret = __disagg_drop_local_stable(int_session, drop_uris[i]);
+        /* Step-down is quiesced, so an uncovered stable drops cleanly; a busy one is a bug. */
+        WT_ASSERT(int_session, ret != EBUSY);
+        WT_ERR(ret);
+    }
+
+err:
+    for (i = 0; i < drop_count; i++)
+        __wt_free(int_session, drop_uris[i]);
+    __wt_free(int_session, drop_uris);
+    if (shared != NULL)
+        WT_TRET(shared->close(shared));
+    if (int_session != NULL)
+        WT_TRET(__wt_session_close_internal(int_session));
+    return (ret);
+}
+
+/*
+ * __disagg_drop_local_only_stable_tables_epoch --
+ *     Epoch step-down cleanup. The queue's uncovered create entries name the stable tables no
+ *     checkpoint covers; drop each one.
+ */
+static int
+__disagg_drop_local_only_stable_tables_epoch(WT_SESSION_IMPL *session)
+{
+    WT_CONNECTION_IMPL *conn;
+    WT_DECL_RET;
+    WT_DISAGG_METADATA_OP *entry;
+    WT_SESSION_IMPL *int_session;
+
+    conn = S2C(session);
+    int_session = NULL;
+
+    WT_RET(__wt_open_internal_session(conn, "disagg-step-down", false, 0, 0, &int_session));
+
+    /* The checkpoint lock freezes the queue for the walk. */
+    TAILQ_FOREACH (entry, &conn->disaggregated_storage.shared_metadata_qh, q) {
+        if (entry->metadata_op != WT_SHARED_METADATA_CREATE || entry->stable_value == NULL)
+            continue;
+
+        ret = __disagg_drop_local_stable(int_session, entry->stable_uri);
+        /* Step-down is quiesced, so an uncovered stable drops cleanly; a busy one is a bug. */
+        WT_ASSERT(int_session, ret != EBUSY);
+        WT_ERR(ret);
+
+        __wt_free(session, entry->stable_value);
+        entry->stable_value = NULL;
+    }
+
+err:
+    WT_TRET(__wt_session_close_internal(int_session));
+    return (ret);
+}
+
+/*
+ * __disagg_drop_local_only_stable_tables --
+ *     Step-down cleanup: drop the local stable tables no checkpoint covers so the follower stops
+ *     owning them; a later step-up rebuilds them from the surviving create intents.
+ */
+static int
+__disagg_drop_local_only_stable_tables(WT_SESSION_IMPL *session)
+{
+    WT_ASSERT_SPINLOCK_OWNED(session, &S2C(session)->checkpoint_lock);
+
+    /*
+     * No stable epoch means legacy mode, which reconciles against shared metadata instead. Test the
+     * configured epoch, not the last checkpoint's, so a node not yet checkpointed still counts.
+     */
+    if (__wt_get_stable_disaggregated_schema_epoch(session) == WT_SCHEMA_EPOCH_NONE)
+        return (__disagg_drop_local_only_stable_tables_legacy(session));
+    return (__disagg_drop_local_only_stable_tables_epoch(session));
+}
+
 /*
  * __wti_disagg_shared_metadata_queue_prune --
  *     Prune the shared metadata queue of any entries that are older than the given checkpoint.
@@ -1197,8 +1444,17 @@ __disagg_step_down(WT_SESSION_IMPL *session)
       session, ret = __disagg_mark_btrees_readonly_then_step_down(session));
     WT_ERR(ret);
 
-    /* Do some cleanup as we are abandoning the current checkpoint. */
-    __disagg_shared_metadata_queue_clear(session);
+    /*
+     * Reconcile local schema state for the follower role. The metadata queue survives the role
+     * change -- its create and remove intents are role-independent and a later step-up still needs
+     * them -- but the local stable tables no checkpoint covers must go, since a follower cannot own
+     * them.
+     */
+    WT_ERR(__disagg_drop_local_only_stable_tables(session));
+
+#ifdef HAVE_DIAGNOSTIC
+    __disagg_shared_metadata_queue_verify(session);
+#endif
 
     /*
      * Re-enable the shared disk cache on step-down. Create the table only if this node never had

--- a/test/suite/test_layered_checkpoint09.py
+++ b/test/suite/test_layered_checkpoint09.py
@@ -141,12 +141,11 @@ class test_layered_checkpoint09(wttest.WiredTigerTestCase):
             cursor[i] = 'value' + str(i)
         cursor.close()
 
-        # Step down to follower before closing so WiredTiger skips the implicit shutdown
-        # checkpoint. This leaves database_size=0 in the shared metadata and no btree
-        # checkpoint sizes in the local metadata. The database size verify should detect
-        # that both are zero and skip the comparison entirely.
-        self.conn.reconfigure('disaggregated=(role="follower")')
-        self.close_conn()
+        # Skip the implicit shutdown checkpoint on close. This leaves database_size=0 in
+        # the shared metadata and no btree checkpoint sizes in the local metadata. The
+        # database size verify should detect that both are zero and skip the comparison
+        # entirely.
+        self.close_conn('debug=(skip_checkpoint=true)')
 
         # Open fresh connection, no checkpoint_meta since no checkpoint was ever taken.
         self.open_conn(config=self.conn_config + ',verify_metadata=true')
@@ -159,8 +158,9 @@ class test_layered_checkpoint09(wttest.WiredTigerTestCase):
             cursor[i] = 'value' + str(i)
         cursor.close()
 
-        self.conn.reconfigure('disaggregated=(role="follower")')
-        self.close_conn()
+        # Skip the implicit shutdown checkpoint on close, leaving database_size=0 and no
+        # btree checkpoints.
+        self.close_conn('debug=(skip_checkpoint=true)')
 
         # Open fresh connection, database_size is 0 and no btree checkpoints exist, so the database
         # size verify skips the comparison entirely.

--- a/test/suite/test_layered_schema17.py
+++ b/test/suite/test_layered_schema17.py
@@ -92,21 +92,6 @@ class test_layered_schema17(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
         self.set_stable_epoch(epoch)
         self.leader_checkpoint(stable_ts)
 
-    def uri_layered_in_local_metadata(self, conn, uri):
-        """
-        Return True if the layered: entry is present in conn's local metadata.
-
-        Unlike uri_in_local_metadata, this does not rely on the stable constituent,
-        which follower-created tables lack until step-up.
-        """
-        session = conn.open_session('')
-        cursor = session.open_cursor('metadata:')
-        cursor.set_key(uri)
-        found = cursor.search() == 0
-        cursor.close()
-        session.close()
-        return found
-
     def run_panic_subprocess(self, name):
         """
         Run subprocess_<name> in a subprocess and assert it died from the strict
@@ -156,7 +141,7 @@ class test_layered_schema17(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
         self.disagg_advance_checkpoint(conn_follow)
 
         # uri2 survives locally and never reaches shared metadata.
-        self.assertTrue(self.uri_layered_in_local_metadata(conn_follow, self.uri2))
+        self.assertTrue(self.uri_in_local_metadata(conn_follow, self.uri2))
         self.assertFalse(self.uri_in_shared_metadata(conn_follow, self.uri2))
 
         conn_follow.close('debug=(skip_checkpoint=true)')
@@ -177,7 +162,7 @@ class test_layered_schema17(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
         self.leader_checkpoint_at_epoch(30, 2)
         self.disagg_advance_checkpoint(conn_follow)
 
-        self.assertTrue(self.uri_layered_in_local_metadata(conn_follow, self.uri2))
+        self.assertTrue(self.uri_in_local_metadata(conn_follow, self.uri2))
         self.assertFalse(self.uri_in_shared_metadata(conn_follow, self.uri2))
 
         conn_follow.close('debug=(skip_checkpoint=true)')
@@ -200,7 +185,7 @@ class test_layered_schema17(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
         self.disagg_advance_checkpoint(conn_follow)
 
         self.assertTrue(self.uri_in_shared_metadata(conn_follow, self.uri))
-        self.assertFalse(self.uri_layered_in_local_metadata(conn_follow, self.uri))
+        self.assertFalse(self.uri_in_local_metadata(conn_follow, self.uri))
         self.assertFalse(self.uri_in_local_metadata(conn_follow, self.uri))
 
         conn_follow.close('debug=(skip_checkpoint=true)')
@@ -363,10 +348,10 @@ class test_layered_schema17(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
 
         # The unpublished table survives locally and stays out of shared metadata
         # until a checkpoint covers its CREATE.
-        self.assertTrue(self.uri_layered_in_local_metadata(self.conn, self.uri2))
+        self.assertTrue(self.uri_in_local_metadata(self.conn, self.uri2))
         self.assertFalse(self.uri_in_shared_metadata(self.conn, self.uri2))
         # The table published before the step-down is still picked up normally.
-        self.assertTrue(self.uri_layered_in_local_metadata(self.conn, self.uri))
+        self.assertTrue(self.uri_in_local_metadata(self.conn, self.uri))
 
         conn_lead.close('debug=(skip_checkpoint=true)')
 
@@ -382,8 +367,8 @@ class test_layered_schema17(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
         self.conn.reconfigure('disaggregated=(strict_checkpoint_metadata=true)')
         self.disagg_advance_checkpoint(self.conn, conn_lead)
 
-        self.assertTrue(self.uri_layered_in_local_metadata(self.conn, self.uri))
-        self.assertFalse(self.uri_layered_in_local_metadata(self.conn, self.uri2))
+        self.assertTrue(self.uri_in_local_metadata(self.conn, self.uri))
+        self.assertFalse(self.uri_in_local_metadata(self.conn, self.uri2))
         self.assertFalse(self.uri_in_shared_metadata(self.conn, self.uri2))
 
         conn_lead.close('debug=(skip_checkpoint=true)')

--- a/test/suite/test_layered_schema17.py
+++ b/test/suite/test_layered_schema17.py
@@ -92,6 +92,21 @@ class test_layered_schema17(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
         self.set_stable_epoch(epoch)
         self.leader_checkpoint(stable_ts)
 
+    def uri_layered_in_local_metadata(self, conn, uri):
+        """
+        Return True if the layered: entry is present in conn's local metadata.
+
+        Unlike uri_in_local_metadata, this does not rely on the stable constituent,
+        which follower-created tables lack until step-up.
+        """
+        session = conn.open_session('')
+        cursor = session.open_cursor('metadata:')
+        cursor.set_key(uri)
+        found = cursor.search() == 0
+        cursor.close()
+        session.close()
+        return found
+
     def run_panic_subprocess(self, name):
         """
         Run subprocess_<name> in a subprocess and assert it died from the strict
@@ -115,14 +130,14 @@ class test_layered_schema17(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
         session_follow.close()
 
         # The startup pickup created uri locally, so the next pickup sees matched sets.
-        self.assertTrue(self.uri_stable_exists(conn_follow, self.uri))
+        self.assertTrue(self.uri_in_local_metadata(conn_follow, self.uri))
 
         self.leader_checkpoint_at_epoch(21, 2)
         # The advance passes only checkpoint_meta, so strict mode must remain on (sticky).
         self.disagg_advance_checkpoint(conn_follow)
 
         self.assertTrue(self.uri_in_shared_metadata(conn_follow, self.uri))
-        self.assertTrue(self.uri_stable_exists(conn_follow, self.uri))
+        self.assertTrue(self.uri_in_local_metadata(conn_follow, self.uri))
 
         conn_follow.close('debug=(skip_checkpoint=true)')
 
@@ -141,7 +156,7 @@ class test_layered_schema17(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
         self.disagg_advance_checkpoint(conn_follow)
 
         # uri2 survives locally and never reaches shared metadata.
-        self.assertTrue(self.uri_in_local_metadata(conn_follow, self.uri2))
+        self.assertTrue(self.uri_layered_in_local_metadata(conn_follow, self.uri2))
         self.assertFalse(self.uri_in_shared_metadata(conn_follow, self.uri2))
 
         conn_follow.close('debug=(skip_checkpoint=true)')
@@ -162,7 +177,7 @@ class test_layered_schema17(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
         self.leader_checkpoint_at_epoch(30, 2)
         self.disagg_advance_checkpoint(conn_follow)
 
-        self.assertTrue(self.uri_in_local_metadata(conn_follow, self.uri2))
+        self.assertTrue(self.uri_layered_in_local_metadata(conn_follow, self.uri2))
         self.assertFalse(self.uri_in_shared_metadata(conn_follow, self.uri2))
 
         conn_follow.close('debug=(skip_checkpoint=true)')
@@ -185,7 +200,7 @@ class test_layered_schema17(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
         self.disagg_advance_checkpoint(conn_follow)
 
         self.assertTrue(self.uri_in_shared_metadata(conn_follow, self.uri))
-        self.assertFalse(self.uri_stable_exists(conn_follow, self.uri))
+        self.assertFalse(self.uri_layered_in_local_metadata(conn_follow, self.uri))
         self.assertFalse(self.uri_in_local_metadata(conn_follow, self.uri))
 
         conn_follow.close('debug=(skip_checkpoint=true)')
@@ -303,10 +318,10 @@ class test_layered_schema17(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
         self.run_panic_subprocess('strict_at_open_panics')
 
     #
-    # Step-down tests: stepping down clears the metadata queue, so a table created
-    # but never published before the step-down becomes an unexplained local-only
-    # difference. The application must drop such tables (or disable strict mode)
-    # before the stepped-down node installs checkpoints.
+    # Step-down tests: stepping down preserves pending CREATE/REMOVE metadata-queue
+    # entries, so a table created but never published before the step-down remains
+    # an explained local-only difference and the stepped-down node can install
+    # checkpoints under strict mode.
     #
 
     def step_down_with_unpublished_table(self):
@@ -323,8 +338,8 @@ class test_layered_schema17(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
         # behind, waiting for a drop.
         self.session.create(self.uri2, self.table_config)
 
-        # Step down; the metadata queue is cleared, so uri2's CREATE no longer
-        # explains its presence in the local metadata.
+        # Step down; uri2's CREATE survives in the metadata queue and keeps
+        # explaining its presence in the local metadata.
         self.conn.reconfigure('disaggregated=(role="follower")')
         conn_follow.reconfigure('disaggregated=(role="leader")')
 
@@ -334,29 +349,32 @@ class test_layered_schema17(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
         session_lead.close()
         return conn_follow
 
-    def subprocess_step_down_pending_create_panics(self):
-        """Subprocess body for the step-down panic test; expected to panic/abort."""
+    def test_strict_step_down_pending_create(self):
+        """
+        A node that steps down with a created-but-unpublished table passes strict
+        validation: the queued CREATE survives the step-down at the unpublished
+        sentinel epoch, which exceeds any checkpoint epoch, so the local-only table
+        is explained and picking up the new leader's checkpoint succeeds.
+        """
         conn_lead = self.step_down_with_unpublished_table()
 
         self.conn.reconfigure('disaggregated=(strict_checkpoint_metadata=true)')
-        self.disagg_advance_checkpoint(self.conn, conn_lead)  # Expected to panic.
+        self.disagg_advance_checkpoint(self.conn, conn_lead)
 
-    def test_strict_step_down_pending_create_panics(self):
-        """
-        A node that steps down with a created-but-unpublished table cannot pass
-        strict validation: the queue was cleared on step-down, so the local-only
-        table is unexplained and picking up the new leader's checkpoint panics.
-        """
-        # Initialize self.conn so the test fixture can close it cleanly; the real test runs
-        # in a subprocess so that the panic/abort does not kill the test runner.
-        self.setup_leader_empty()
-        self.run_panic_subprocess('step_down_pending_create_panics')
+        # The unpublished table survives locally and stays out of shared metadata
+        # until a checkpoint covers its CREATE.
+        self.assertTrue(self.uri_layered_in_local_metadata(self.conn, self.uri2))
+        self.assertFalse(self.uri_in_shared_metadata(self.conn, self.uri2))
+        # The table published before the step-down is still picked up normally.
+        self.assertTrue(self.uri_layered_in_local_metadata(self.conn, self.uri))
+
+        conn_lead.close('debug=(skip_checkpoint=true)')
 
     def test_strict_step_down_drop_then_pickup(self):
         """
-        Completing the pending drop of the unpublished table resolves the step-down
-        inconsistency: once the table is gone from the local metadata, strict
-        validation passes and the stepped-down node can install checkpoints.
+        Completing the pending drop of the unpublished table also passes strict
+        validation: the table is gone from the local metadata and the queue, and
+        the stepped-down node can install checkpoints.
         """
         conn_lead = self.step_down_with_unpublished_table()
 
@@ -364,8 +382,8 @@ class test_layered_schema17(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
         self.conn.reconfigure('disaggregated=(strict_checkpoint_metadata=true)')
         self.disagg_advance_checkpoint(self.conn, conn_lead)
 
-        self.assertTrue(self.uri_in_local_metadata(self.conn, self.uri, leader=True))
-        self.assertFalse(self.uri_in_local_metadata(self.conn, self.uri2, leader=True))
+        self.assertTrue(self.uri_layered_in_local_metadata(self.conn, self.uri))
+        self.assertFalse(self.uri_layered_in_local_metadata(self.conn, self.uri2))
         self.assertFalse(self.uri_in_shared_metadata(self.conn, self.uri2))
 
         conn_lead.close('debug=(skip_checkpoint=true)')
@@ -391,7 +409,7 @@ class test_layered_schema17(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
         self.disagg_advance_checkpoint(conn_follow)
 
         self.assertTrue(self.uri_in_shared_metadata(conn_follow, self.uri2))
-        self.assertTrue(self.uri_stable_exists(conn_follow, self.uri2))
+        self.assertTrue(self.uri_in_local_metadata(conn_follow, self.uri2))
 
         conn_follow.close('debug=(skip_checkpoint=true)')
 
@@ -414,6 +432,6 @@ class test_layered_schema17(wttest.WiredTigerTestCase, suite_subprocess, DisaggS
         self.disagg_advance_checkpoint(conn_follow)
 
         self.assertTrue(self.uri_in_shared_metadata(conn_follow, self.uri2))
-        self.assertTrue(self.uri_stable_exists(conn_follow, self.uri2))
+        self.assertTrue(self.uri_in_local_metadata(conn_follow, self.uri2))
 
         conn_follow.close('debug=(skip_checkpoint=true)')

--- a/test/suite/test_layered_schema20.py
+++ b/test/suite/test_layered_schema20.py
@@ -26,15 +26,8 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-# Test that a table drop queued as a pending metadata operation survives a
-# step-down and is completed by publishing the old queue entries after a
-# step-up, rather than being discarded on step-down.
-#
-# A drop enqueues a REMOVE in the shared metadata queue. Like a pending CREATE,
-# that intent is role-independent and must survive the leader to follower
-# transition, so a later step-up can publish it and the next covering checkpoint
-# can apply it. This covers both the two-phase drop of an already-published table
-# and a create/drop pair that nets out once published.
+# Test that a pending table drop survives a step-down and is applied after a
+# step-up, instead of being discarded when the shared metadata queue is preserved.
 
 import wttest
 from helper_disagg import disagg_test_class, gen_disagg_storages, DisaggSchemaEpochMixin
@@ -47,16 +40,39 @@ class test_layered_schema20(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
     conn_config = conn_base_config + 'disaggregated=(role="leader",lose_all_my_data=true)'
     conn_config_follower = conn_base_config + 'disaggregated=(role="follower",lose_all_my_data=true)'
 
-    uri = f'layered:{test_name}'
-    uri2 = f'layered:{test_name}_uncovered'
     table_config = 'key_format=i,value_format=S'
 
     disagg_storages = gen_disagg_storages(disagg_only=True)
     scenarios = make_scenarios(disagg_storages)
 
-    def local_metadata_keys(self, conn):
+    def uri(self, name):
+        """Return a distinct layered table URI within this test."""
+        return f'layered:{self.test_name}_{name}'
+
+    def create_covered(self, uri, publish_epoch, stable_ts, commit_ts, rows=0):
+        """Create, publish, and cover a table with a checkpoint so it reaches shared metadata."""
+        self.session.create(uri, self.table_config)
+        if rows:
+            cursor = self.session.open_cursor(uri)
+            self.session.begin_transaction()
+            for i in range(rows):
+                cursor[i] = 'covered'
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(commit_ts))
+            cursor.close()
+        self.publish(uri, publish_epoch)
+        self.set_stable_epoch(publish_epoch)
+        self.leader_checkpoint(stable_ts)
+        self.assertTrue(self.uri_in_shared_metadata(self.conn, uri))
+
+    def step_down(self):
+        self.conn.reconfigure('disaggregated=(role="follower")')
+
+    def step_up(self):
+        self.conn.reconfigure('disaggregated=(role="leader")')
+
+    def local_metadata_keys(self, conn, uri):
         """Return the local metadata keys naming the table or its constituents."""
-        tablename = self.uri[len('layered:'):]
+        tablename = uri[len('layered:'):]
         session = conn.open_session('')
         mc = session.open_cursor('metadata:')
         keys = [k for k, _ in mc if tablename in k]
@@ -64,110 +80,126 @@ class test_layered_schema20(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
         session.close()
         return keys
 
+    def assert_follower_absent(self, uri):
+        """A fresh follower picking up the latest checkpoint must not see the table."""
+        conn_follow, session_follow = self.open_follower()
+        self.assertFalse(self.uri_in_local_metadata(conn_follow, uri))
+        self.assertFalse(self.uri_in_shared_metadata(conn_follow, uri))
+        session_follow.close()
+        conn_follow.close('debug=(skip_checkpoint=true)')
+
     def test_covered_table_keeps_data_uncovered_dropped(self):
         """
-        The step-down drop only sheds uncovered stable constituents, which hold no
-        data. A table whose data the step-down checkpoint covers keeps its stable
-        constituent and its data across the step-down; an uncovered empty table's
-        stable constituent is dropped.
+        Step-down keeps the stable constituent and data of a covered table and drops
+        the stable constituent of an uncovered one, keeping the uncovered ingest half.
         """
-        # Covered table: create, write data, publish, and cover it with a checkpoint.
         self.set_stable_epoch(10)
-        self.session.create(self.uri, self.table_config)
-        cursor = self.session.open_cursor(self.uri)
-        self.session.begin_transaction()
-        for i in range(10):
-            cursor[i] = 'covered'
-        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(5))
-        cursor.close()
-        self.publish(self.uri, 20)
-        self.set_stable_epoch(20)
-        self.leader_checkpoint(10)
-        self.assertTrue(self.uri_in_shared_metadata(self.conn, self.uri))
+        covered = self.uri('covered')
+        self.create_covered(covered, 20, stable_ts=10, commit_ts=5, rows=10)
 
         # Uncovered table: created after the checkpoint, so no checkpoint covers it.
-        self.session.create(self.uri2, self.table_config)
-        self.assertFalse(self.uri_in_shared_metadata(self.conn, self.uri2))
+        uncovered = self.uri('uncovered')
+        self.session.create(uncovered, self.table_config)
+        self.assertFalse(self.uri_in_shared_metadata(self.conn, uncovered))
 
-        # Step down: the covered table's stable and data survive; the uncovered
-        # table's stable constituent is dropped.
-        self.conn.reconfigure('disaggregated=(role="follower")')
-        self.assertTrue(self.uri_in_local_metadata(self.conn, self.uri))
-        self.assertFalse(self.uri_in_local_metadata(self.conn, self.uri2))
-        cursor = self.session.open_cursor(self.uri)
+        self.step_down()
+        self.assertTrue(self.uri_stable_exists(self.conn, covered))
+        self.assertFalse(self.uri_stable_exists(self.conn, uncovered))
+        cursor = self.session.open_cursor(covered)
         self.assertEqual({k: v for k, v in cursor}, {i: 'covered' for i in range(10)})
         cursor.close()
 
-    def test_two_phase_drop_after_step_down(self):
+    def test_multiple_covered_and_uncovered(self):
         """
-        Publish and checkpoint a table so it is in shared metadata, then drop it
-        and publish the drop at a higher epoch. Step down before any checkpoint
-        covers the drop: the pending REMOVE must survive, and after a step-up the
-        covering checkpoint must remove the table from shared metadata.
+        Step-down sheds every uncovered stable constituent and keeps every covered
+        one, regardless of how many tables of each kind exist.
         """
         self.set_stable_epoch(10)
-        self.session.create(self.uri, self.table_config)
-        self.publish(self.uri, 20)
-        self.set_stable_epoch(20)
-        self.leader_checkpoint(1)
-        self.assertTrue(self.uri_in_shared_metadata(self.conn, self.uri))
+        covered = [self.uri(f'covered{i}') for i in range(3)]
+        for i, uri in enumerate(covered):
+            self.create_covered(uri, 20 + i, stable_ts=10 * (i + 1), commit_ts=10 * (i + 1) - 5, rows=5)
+
+        uncovered = [self.uri(f'uncovered{i}') for i in range(3)]
+        for uri in uncovered:
+            self.session.create(uri, self.table_config)
+
+        self.step_down()
+        for uri in covered:
+            self.assertTrue(self.uri_stable_exists(self.conn, uri))
+        for uri in uncovered:
+            self.assertFalse(self.uri_stable_exists(self.conn, uri))
+            # The ingest half survives so a later step-up can rebuild the table.
+            self.assertTrue(self.uri_in_local_metadata(self.conn, uri))
+
+    def test_two_phase_drop_after_step_down(self):
+        """
+        A drop published above the last checkpoint epoch leaves a pending REMOVE. It
+        survives a step-down and back up, and the next covering checkpoint removes the
+        table from shared metadata.
+        """
+        uri = self.uri('drop')
+        self.set_stable_epoch(10)
+        self.create_covered(uri, 20, 1, 5)
 
         # Drop and publish the drop at an epoch no checkpoint has covered yet.
-        self.session.drop(self.uri)
-        self.publish(self.uri, 30)
-        self.assertEqual(self.local_metadata_keys(self.conn), [])
+        self.session.drop(uri)
+        self.publish(uri, 30)
+        self.assertEqual(self.local_metadata_keys(self.conn, uri), [])
 
-        # Step down and back up: the pending REMOVE survives the role change.
-        self.conn.reconfigure('disaggregated=(role="follower")')
-        self.conn.reconfigure('disaggregated=(role="leader")')
+        self.step_down()
+        self.step_up()
 
-        # A checkpoint covering the drop applies the surviving REMOVE.
         self.set_stable_epoch(30)
         self.leader_checkpoint(2)
-        self.assertFalse(self.uri_in_shared_metadata(self.conn, self.uri))
+        self.assertFalse(self.uri_in_shared_metadata(self.conn, uri))
+        self.assert_follower_absent(uri)
 
-        # A follower picking up that checkpoint must not see the table.
-        conn_follow, session_follow = self.open_follower()
-        self.assertFalse(self.uri_in_local_metadata(conn_follow, self.uri))
-        self.assertFalse(self.uri_in_shared_metadata(conn_follow, self.uri))
-        session_follow.close()
-        conn_follow.close('debug=(skip_checkpoint=true)')
+    def test_two_phase_drop_survives_repeated_failback(self):
+        """
+        A pending REMOVE survives several step-down and step-up cycles before a
+        covering checkpoint applies it.
+        """
+        uri = self.uri('drop_repeat')
+        self.set_stable_epoch(10)
+        self.create_covered(uri, 20, 1, 5)
+
+        self.session.drop(uri)
+        self.publish(uri, 30)
+
+        for _ in range(3):
+            self.step_down()
+            self.step_up()
+
+        self.set_stable_epoch(30)
+        self.leader_checkpoint(2)
+        self.assertFalse(self.uri_in_shared_metadata(self.conn, uri))
+        self.assert_follower_absent(uri)
 
     def test_create_drop_pair_after_step_down(self):
         """
-        Create a table and drop it while its create is still pending (never covered
-        by a checkpoint), publishing both at the same epoch. Step down with the
-        create/remove pair queued: both must survive, and after a step-up the
-        covering checkpoint must net them out without publishing the table.
+        A create and drop published at the same pending epoch survive a step-down and
+        back up as a queued pair, and the next covering checkpoint nets them out
+        without publishing the table.
         """
+        uri = self.uri('pair')
         self.set_stable_epoch(10)
-        self.session.create(self.uri, self.table_config)
-        self.publish(self.uri, 20)
+        self.session.create(uri, self.table_config)
+        self.publish(uri, 20)
 
         # A checkpoint below the publish epoch leaves the CREATE pending.
         self.leader_checkpoint(1)
-        self.assertTrue(self.uri_in_local_metadata(self.conn, self.uri))
-        self.assertFalse(self.uri_in_shared_metadata(self.conn, self.uri))
+        self.assertTrue(self.uri_in_local_metadata(self.conn, uri))
+        self.assertFalse(self.uri_in_shared_metadata(self.conn, uri))
 
-        # Drop and publish the drop at the same epoch as the create.
-        self.session.drop(self.uri)
-        self.publish(self.uri, 20)
-        self.assertEqual(self.local_metadata_keys(self.conn), [])
+        self.session.drop(uri)
+        self.publish(uri, 20)
+        self.assertEqual(self.local_metadata_keys(self.conn, uri), [])
 
-        # Step down and back up: the create/remove pair survives.
-        self.conn.reconfigure('disaggregated=(role="follower")')
-        self.conn.reconfigure('disaggregated=(role="leader")')
-        self.assertFalse(self.uri_in_local_metadata(self.conn, self.uri))
+        self.step_down()
+        self.step_up()
+        self.assertFalse(self.uri_in_local_metadata(self.conn, uri))
 
-        # A checkpoint covering the pair nets it out: the table is neither
-        # published to shared metadata nor left in the local metadata.
         self.set_stable_epoch(20)
         self.leader_checkpoint(2)
-        self.assertFalse(self.uri_in_shared_metadata(self.conn, self.uri))
-
-        # A follower picking up that checkpoint must not see the table.
-        conn_follow, session_follow = self.open_follower()
-        self.assertFalse(self.uri_in_local_metadata(conn_follow, self.uri))
-        self.assertFalse(self.uri_in_shared_metadata(conn_follow, self.uri))
-        session_follow.close()
-        conn_follow.close('debug=(skip_checkpoint=true)')
+        self.assertFalse(self.uri_in_shared_metadata(self.conn, uri))
+        self.assert_follower_absent(uri)

--- a/test/suite/test_layered_schema20.py
+++ b/test/suite/test_layered_schema20.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# Test that a table drop queued as a pending metadata operation survives a
+# step-down and is completed by publishing the old queue entries after a
+# step-up, rather than being discarded on step-down.
+#
+# A drop enqueues a REMOVE in the shared metadata queue. Like a pending CREATE,
+# that intent is role-independent and must survive the leader to follower
+# transition, so a later step-up can publish it and the next covering checkpoint
+# can apply it. This covers both the two-phase drop of an already-published table
+# and a create/drop pair that nets out once published.
+
+import wttest
+from helper_disagg import disagg_test_class, gen_disagg_storages, DisaggSchemaEpochMixin
+from wtscenario import make_scenarios
+
+@disagg_test_class
+class test_layered_schema20(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
+    test_name = __qualname__
+    conn_base_config = 'statistics=(all),precise_checkpoint=true,'
+    conn_config = conn_base_config + 'disaggregated=(role="leader",lose_all_my_data=true)'
+    conn_config_follower = conn_base_config + 'disaggregated=(role="follower",lose_all_my_data=true)'
+
+    uri = f'layered:{test_name}'
+    uri2 = f'layered:{test_name}_uncovered'
+    table_config = 'key_format=i,value_format=S'
+
+    disagg_storages = gen_disagg_storages(disagg_only=True)
+    scenarios = make_scenarios(disagg_storages)
+
+    def local_metadata_keys(self, conn):
+        """Return the local metadata keys naming the table or its constituents."""
+        tablename = self.uri[len('layered:'):]
+        session = conn.open_session('')
+        mc = session.open_cursor('metadata:')
+        keys = [k for k, _ in mc if tablename in k]
+        mc.close()
+        session.close()
+        return keys
+
+    def test_covered_table_keeps_data_uncovered_dropped(self):
+        """
+        The step-down drop only sheds uncovered stable constituents, which hold no
+        data. A table whose data the step-down checkpoint covers keeps its stable
+        constituent and its data across the step-down; an uncovered empty table's
+        stable constituent is dropped.
+        """
+        # Covered table: create, write data, publish, and cover it with a checkpoint.
+        self.set_stable_epoch(10)
+        self.session.create(self.uri, self.table_config)
+        cursor = self.session.open_cursor(self.uri)
+        self.session.begin_transaction()
+        for i in range(10):
+            cursor[i] = 'covered'
+        self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(5))
+        cursor.close()
+        self.publish(self.uri, 20)
+        self.set_stable_epoch(20)
+        self.leader_checkpoint(10)
+        self.assertTrue(self.uri_in_shared_metadata(self.conn, self.uri))
+
+        # Uncovered table: created after the checkpoint, so no checkpoint covers it.
+        self.session.create(self.uri2, self.table_config)
+        self.assertFalse(self.uri_in_shared_metadata(self.conn, self.uri2))
+
+        # Step down: the covered table's stable and data survive; the uncovered
+        # table's stable constituent is dropped.
+        self.conn.reconfigure('disaggregated=(role="follower")')
+        self.assertTrue(self.uri_in_local_metadata(self.conn, self.uri))
+        self.assertFalse(self.uri_in_local_metadata(self.conn, self.uri2))
+        cursor = self.session.open_cursor(self.uri)
+        self.assertEqual({k: v for k, v in cursor}, {i: 'covered' for i in range(10)})
+        cursor.close()
+
+    def test_two_phase_drop_after_step_down(self):
+        """
+        Publish and checkpoint a table so it is in shared metadata, then drop it
+        and publish the drop at a higher epoch. Step down before any checkpoint
+        covers the drop: the pending REMOVE must survive, and after a step-up the
+        covering checkpoint must remove the table from shared metadata.
+        """
+        self.set_stable_epoch(10)
+        self.session.create(self.uri, self.table_config)
+        self.publish(self.uri, 20)
+        self.set_stable_epoch(20)
+        self.leader_checkpoint(1)
+        self.assertTrue(self.uri_in_shared_metadata(self.conn, self.uri))
+
+        # Drop and publish the drop at an epoch no checkpoint has covered yet.
+        self.session.drop(self.uri)
+        self.publish(self.uri, 30)
+        self.assertEqual(self.local_metadata_keys(self.conn), [])
+
+        # Step down and back up: the pending REMOVE survives the role change.
+        self.conn.reconfigure('disaggregated=(role="follower")')
+        self.conn.reconfigure('disaggregated=(role="leader")')
+
+        # A checkpoint covering the drop applies the surviving REMOVE.
+        self.set_stable_epoch(30)
+        self.leader_checkpoint(2)
+        self.assertFalse(self.uri_in_shared_metadata(self.conn, self.uri))
+
+        # A follower picking up that checkpoint must not see the table.
+        conn_follow, session_follow = self.open_follower()
+        self.assertFalse(self.uri_in_local_metadata(conn_follow, self.uri))
+        self.assertFalse(self.uri_in_shared_metadata(conn_follow, self.uri))
+        session_follow.close()
+        conn_follow.close('debug=(skip_checkpoint=true)')
+
+    def test_create_drop_pair_after_step_down(self):
+        """
+        Create a table and drop it while its create is still pending (never covered
+        by a checkpoint), publishing both at the same epoch. Step down with the
+        create/remove pair queued: both must survive, and after a step-up the
+        covering checkpoint must net them out without publishing the table.
+        """
+        self.set_stable_epoch(10)
+        self.session.create(self.uri, self.table_config)
+        self.publish(self.uri, 20)
+
+        # A checkpoint below the publish epoch leaves the CREATE pending.
+        self.leader_checkpoint(1)
+        self.assertTrue(self.uri_in_local_metadata(self.conn, self.uri))
+        self.assertFalse(self.uri_in_shared_metadata(self.conn, self.uri))
+
+        # Drop and publish the drop at the same epoch as the create.
+        self.session.drop(self.uri)
+        self.publish(self.uri, 20)
+        self.assertEqual(self.local_metadata_keys(self.conn), [])
+
+        # Step down and back up: the create/remove pair survives.
+        self.conn.reconfigure('disaggregated=(role="follower")')
+        self.conn.reconfigure('disaggregated=(role="leader")')
+        self.assertFalse(self.uri_in_local_metadata(self.conn, self.uri))
+
+        # A checkpoint covering the pair nets it out: the table is neither
+        # published to shared metadata nor left in the local metadata.
+        self.set_stable_epoch(20)
+        self.leader_checkpoint(2)
+        self.assertFalse(self.uri_in_shared_metadata(self.conn, self.uri))
+
+        # A follower picking up that checkpoint must not see the table.
+        conn_follow, session_follow = self.open_follower()
+        self.assertFalse(self.uri_in_local_metadata(conn_follow, self.uri))
+        self.assertFalse(self.uri_in_shared_metadata(conn_follow, self.uri))
+        session_follow.close()
+        conn_follow.close('debug=(skip_checkpoint=true)')

--- a/test/suite/test_layered_schema21.py
+++ b/test/suite/test_layered_schema21.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# Test fail-back cycles (step-down followed by step-up) with a pending publish.
+#
+# A table published at a schema epoch above the last checkpoint's stable epoch has a
+# pending CREATE in the shared metadata queue. That intent is role-independent, so it
+# must survive a step-down and still be published by the next covering leader checkpoint
+# after a step-up.
+
+import wttest
+from helper_disagg import disagg_test_class, gen_disagg_storages, DisaggSchemaEpochMixin
+from wtscenario import make_scenarios
+
+@disagg_test_class
+class test_layered_schema21(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
+    test_name = __qualname__
+    conn_base_config = 'statistics=(all),precise_checkpoint=true,'
+    conn_config = conn_base_config + 'disaggregated=(role="leader",lose_all_my_data=true)'
+    conn_config_follower = conn_base_config + 'disaggregated=(role="follower",lose_all_my_data=true)'
+
+    uri = f'layered:{test_name}'
+    table_config = 'key_format=i,value_format=S'
+
+    disagg_storages = gen_disagg_storages(disagg_only=True)
+    scenarios = make_scenarios(disagg_storages)
+
+    def create_with_pending_publish(self, publish_epoch):
+        """
+        Create and publish the table at publish_epoch, then checkpoint at stable epoch 10.
+        The publish epoch is above the checkpoint's, so the CREATE stays pending in the
+        shared metadata queue and the table is absent from shared metadata.
+        """
+        self.set_stable_epoch(10)
+        self.session.create(self.uri, self.table_config)
+        self.publish(self.uri, publish_epoch)
+        self.leader_checkpoint(1)
+
+        self.assertTrue(self.uri_in_local_metadata(self.conn, self.uri))
+        self.assertFalse(self.uri_in_shared_metadata(self.conn, self.uri))
+
+    def test_failback_no_pickup(self):
+        """
+        A pending publish survives a step-down followed by an immediate step-up with no
+        checkpoint pickup in between; the next covering checkpoint publishes the table.
+        """
+        self.create_with_pending_publish(20)
+
+        # Step down: the uncovered local stable constituent is dropped, but the pending
+        # CREATE survives in the queue to explain and rebuild it.
+        self.conn.reconfigure('disaggregated=(role="follower")')
+        self.assertFalse(self.uri_in_local_metadata(self.conn, self.uri))
+
+        # Step back up without picking up any checkpoint: the surviving CREATE recreates
+        # the stable constituent.
+        self.conn.reconfigure('disaggregated=(role="leader")')
+        self.assertTrue(self.uri_in_local_metadata(self.conn, self.uri))
+        self.assertFalse(self.uri_in_shared_metadata(self.conn, self.uri))
+
+        # A checkpoint at a covering epoch publishes the table.
+        self.set_stable_epoch(20)
+        self.leader_checkpoint(2)
+        self.assertTrue(self.uri_in_shared_metadata(self.conn, self.uri))
+
+        # A follower picking up that checkpoint sees the table.
+        conn_follow, session_follow = self.open_follower()
+        self.assertTrue(self.uri_in_local_metadata(conn_follow, self.uri))
+        session_follow.close()
+        conn_follow.close('debug=(skip_checkpoint=true)')
+
+    def test_failback_noncovering_pickup(self):
+        """
+        A pending publish survives a step-down and a subsequent pickup of a checkpoint
+        that does not cover its epoch; after a fail-back the next covering checkpoint
+        publishes the table.
+        """
+        self.create_with_pending_publish(30)
+
+        # Open a second node, which picks up the checkpoint at epoch 10 and does not see
+        # the table.
+        conn_follow, session_follow = self.open_follower()
+        session_follow.close()
+        self.assertFalse(self.uri_in_local_metadata(conn_follow, self.uri))
+
+        # Swap roles: this node steps down with the CREATE (epoch 30) still pending.
+        self.conn.reconfigure('disaggregated=(role="follower")')
+        conn_follow.reconfigure('disaggregated=(role="leader")')
+
+        # The new leader checkpoints at epoch 20, which does not cover the pending CREATE.
+        self.set_stable_epoch(20, conn_follow)
+        session_follow = conn_follow.open_session('')
+        self.leader_checkpoint(2, conn_follow, session_follow)
+        session_follow.close()
+
+        # This node dropped its uncovered stable constituent on step-down; the pending
+        # CREATE survives, and the non-covering pickup neither rebuilds nor prunes it.
+        self.disagg_advance_checkpoint(self.conn, conn_follow)
+        self.assertFalse(self.uri_in_local_metadata(self.conn, self.uri))
+        self.assertFalse(self.uri_in_shared_metadata(self.conn, self.uri))
+
+        # Fail back to this node and checkpoint at a covering epoch: the table is
+        # published to shared metadata.
+        conn_follow.reconfigure('disaggregated=(role="follower")')
+        self.conn.reconfigure('disaggregated=(role="leader")')
+        self.set_stable_epoch(30)
+        self.leader_checkpoint(3)
+        self.assertTrue(self.uri_in_shared_metadata(self.conn, self.uri))
+
+        # The other node picks up the covering checkpoint and sees the table.
+        self.disagg_advance_checkpoint(conn_follow)
+        self.assertTrue(self.uri_in_local_metadata(conn_follow, self.uri))
+        conn_follow.close('debug=(skip_checkpoint=true)')

--- a/test/suite/test_layered_schema21.py
+++ b/test/suite/test_layered_schema21.py
@@ -26,12 +26,8 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-# Test fail-back cycles (step-down followed by step-up) with a pending publish.
-#
-# A table published at a schema epoch above the last checkpoint's stable epoch has a
-# pending CREATE in the shared metadata queue. That intent is role-independent, so it
-# must survive a step-down and still be published by the next covering leader checkpoint
-# after a step-up.
+# Test that a pending table create survives a fail-back (step-down then step-up)
+# and is published by the next covering checkpoint.
 
 import wttest
 from helper_disagg import disagg_test_class, gen_disagg_storages, DisaggSchemaEpochMixin
@@ -64,6 +60,12 @@ class test_layered_schema21(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
         self.assertTrue(self.uri_in_local_metadata(self.conn, self.uri))
         self.assertFalse(self.uri_in_shared_metadata(self.conn, self.uri))
 
+    def step_down(self):
+        self.conn.reconfigure('disaggregated=(role="follower")')
+
+    def step_up(self):
+        self.conn.reconfigure('disaggregated=(role="leader")')
+
     def test_failback_no_pickup(self):
         """
         A pending publish survives a step-down followed by an immediate step-up with no
@@ -73,13 +75,13 @@ class test_layered_schema21(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
 
         # Step down: the uncovered local stable constituent is dropped, but the pending
         # CREATE survives in the queue to explain and rebuild it.
-        self.conn.reconfigure('disaggregated=(role="follower")')
-        self.assertFalse(self.uri_in_local_metadata(self.conn, self.uri))
+        self.step_down()
+        self.assertFalse(self.uri_stable_exists(self.conn, self.uri))
 
         # Step back up without picking up any checkpoint: the surviving CREATE recreates
         # the stable constituent.
-        self.conn.reconfigure('disaggregated=(role="leader")')
-        self.assertTrue(self.uri_in_local_metadata(self.conn, self.uri))
+        self.step_up()
+        self.assertTrue(self.uri_stable_exists(self.conn, self.uri))
         self.assertFalse(self.uri_in_shared_metadata(self.conn, self.uri))
 
         # A checkpoint at a covering epoch publishes the table.
@@ -88,6 +90,29 @@ class test_layered_schema21(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
         self.assertTrue(self.uri_in_shared_metadata(self.conn, self.uri))
 
         # A follower picking up that checkpoint sees the table.
+        conn_follow, session_follow = self.open_follower()
+        self.assertTrue(self.uri_in_local_metadata(conn_follow, self.uri))
+        session_follow.close()
+        conn_follow.close('debug=(skip_checkpoint=true)')
+
+    def test_failback_repeated(self):
+        """
+        A pending CREATE survives several step-down and step-up cycles, its stable
+        constituent rebuilt on each step-up, and a later covering checkpoint publishes it.
+        """
+        self.create_with_pending_publish(20)
+
+        for _ in range(3):
+            self.step_down()
+            self.assertFalse(self.uri_stable_exists(self.conn, self.uri))
+            self.step_up()
+            self.assertTrue(self.uri_stable_exists(self.conn, self.uri))
+            self.assertFalse(self.uri_in_shared_metadata(self.conn, self.uri))
+
+        self.set_stable_epoch(20)
+        self.leader_checkpoint(2)
+        self.assertTrue(self.uri_in_shared_metadata(self.conn, self.uri))
+
         conn_follow, session_follow = self.open_follower()
         self.assertTrue(self.uri_in_local_metadata(conn_follow, self.uri))
         session_follow.close()
@@ -120,7 +145,7 @@ class test_layered_schema21(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
         # This node dropped its uncovered stable constituent on step-down; the pending
         # CREATE survives, and the non-covering pickup neither rebuilds nor prunes it.
         self.disagg_advance_checkpoint(self.conn, conn_follow)
-        self.assertFalse(self.uri_in_local_metadata(self.conn, self.uri))
+        self.assertFalse(self.uri_stable_exists(self.conn, self.uri))
         self.assertFalse(self.uri_in_shared_metadata(self.conn, self.uri))
 
         # Fail back to this node and checkpoint at a covering epoch: the table is

--- a/test/suite/test_layered_schema23.py
+++ b/test/suite/test_layered_schema23.py
@@ -27,14 +27,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 # Test that a legacy (no schema epoch) step-down drops the local stable
-# constituents that the shared metadata does not cover.
-#
-# Without schema epochs the shared metadata queue cannot mark which local stable
-# tables a checkpoint covers, so step-down reconciles against the shared metadata
-# directly, mirroring the legacy step-up that creates missing stable tables. A
-# table created as leader and checkpointed is published and kept; one created
-# without a covering checkpoint is uncovered, so its stable constituent must be
-# dropped when the node becomes a follower.
+# constituents that no checkpoint has published to the shared metadata.
 
 import wttest
 from helper_disagg import disagg_test_class, gen_disagg_storages, DisaggSchemaEpochMixin
@@ -47,35 +40,59 @@ class test_layered_schema23(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
     conn_config = conn_base_config + 'disaggregated=(role="leader",lose_all_my_data=true)'
     conn_config_follower = conn_base_config + 'disaggregated=(role="follower",lose_all_my_data=true)'
 
-    uri = f'layered:{test_name}'
-    uri_uncovered = f'layered:{test_name}_uncovered'
     table_config = 'key_format=i,value_format=S'
 
     disagg_storages = gen_disagg_storages(disagg_only=True)
     scenarios = make_scenarios(disagg_storages)
 
-    def stable_uri(self, uri):
-        """Return the stable constituent URI for a layered table URI."""
-        return 'file:' + uri.split(':', 1)[1] + '.wt_stable'
+    def uri(self, name):
+        """Return a distinct layered table URI within this test."""
+        return f'layered:{self.test_name}_{name}'
+
+    def create_published(self, uri, value=None):
+        """Create a table, optionally write a row, and checkpoint so it reaches shared metadata."""
+        self.session.create(uri, self.table_config)
+        if value is not None:
+            cursor = self.session.open_cursor(uri)
+            cursor[1] = value
+            cursor.close()
+        self.session.checkpoint()
+        self.assertTrue(self.uri_in_shared_metadata(self.conn, uri))
+
+    def step_down(self):
+        self.conn.reconfigure('disaggregated=(role="follower")')
 
     def test_legacy_step_down_drops_uncovered_stable(self):
-        # Legacy leader: no schema epoch is ever set.
-        self.session.create(self.uri, self.table_config)
-        cursor = self.session.open_cursor(self.uri)
-        cursor[1] = 'published'
-        cursor.close()
-
-        # A checkpoint publishes the first table to the shared metadata.
-        self.session.checkpoint()
-        self.assertTrue(self.uri_in_shared_metadata(self.conn, self.uri))
+        """A published table's stable is kept with its data; an uncovered table's is dropped."""
+        published = self.uri('published')
+        self.create_published(published, value='published')
 
         # A second table created without a covering checkpoint stays local-only.
-        self.session.create(self.uri_uncovered, self.table_config)
-        self.assertTrue(self.uri_in_local_metadata(self.conn, self.uri_uncovered))
-        self.assertFalse(self.uri_in_shared_metadata(self.conn, self.uri_uncovered))
+        uncovered = self.uri('uncovered')
+        self.session.create(uncovered, self.table_config)
+        self.assertFalse(self.uri_in_shared_metadata(self.conn, uncovered))
 
-        # Step down: the uncovered table's stable constituent is dropped, while the
-        # published table's stable constituent is kept.
-        self.conn.reconfigure('disaggregated=(role="follower")')
-        self.assertFalse(self.uri_in_local_metadata(self.conn, self.uri_uncovered))
-        self.assertTrue(self.uri_in_local_metadata(self.conn, self.uri))
+        self.step_down()
+        self.assertFalse(self.uri_stable_exists(self.conn, uncovered))
+        self.assertTrue(self.uri_stable_exists(self.conn, published))
+        cursor = self.session.open_cursor(published)
+        self.assertEqual({k: v for k, v in cursor}, {1: 'published'})
+        cursor.close()
+
+    def test_legacy_multiple_uncovered(self):
+        """Step-down keeps every published stable and drops every uncovered one."""
+        published = [self.uri(f'published{i}') for i in range(3)]
+        for uri in published:
+            self.create_published(uri, value='v')
+
+        uncovered = [self.uri(f'uncovered{i}') for i in range(3)]
+        for uri in uncovered:
+            self.session.create(uri, self.table_config)
+
+        self.step_down()
+        for uri in published:
+            self.assertTrue(self.uri_stable_exists(self.conn, uri))
+        for uri in uncovered:
+            self.assertFalse(self.uri_stable_exists(self.conn, uri))
+            # The ingest half survives the step-down.
+            self.assertTrue(self.uri_in_local_metadata(self.conn, uri))

--- a/test/suite/test_layered_schema23.py
+++ b/test/suite/test_layered_schema23.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+# Test that a legacy (no schema epoch) step-down drops the local stable
+# constituents that the shared metadata does not cover.
+#
+# Without schema epochs the shared metadata queue cannot mark which local stable
+# tables a checkpoint covers, so step-down reconciles against the shared metadata
+# directly, mirroring the legacy step-up that creates missing stable tables. A
+# table created as leader and checkpointed is published and kept; one created
+# without a covering checkpoint is uncovered, so its stable constituent must be
+# dropped when the node becomes a follower.
+
+import wttest
+from helper_disagg import disagg_test_class, gen_disagg_storages, DisaggSchemaEpochMixin
+from wtscenario import make_scenarios
+
+@disagg_test_class
+class test_layered_schema23(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
+    test_name = __qualname__
+    conn_base_config = 'statistics=(all),'
+    conn_config = conn_base_config + 'disaggregated=(role="leader",lose_all_my_data=true)'
+    conn_config_follower = conn_base_config + 'disaggregated=(role="follower",lose_all_my_data=true)'
+
+    uri = f'layered:{test_name}'
+    uri_uncovered = f'layered:{test_name}_uncovered'
+    table_config = 'key_format=i,value_format=S'
+
+    disagg_storages = gen_disagg_storages(disagg_only=True)
+    scenarios = make_scenarios(disagg_storages)
+
+    def stable_uri(self, uri):
+        """Return the stable constituent URI for a layered table URI."""
+        return 'file:' + uri.split(':', 1)[1] + '.wt_stable'
+
+    def test_legacy_step_down_drops_uncovered_stable(self):
+        # Legacy leader: no schema epoch is ever set.
+        self.session.create(self.uri, self.table_config)
+        cursor = self.session.open_cursor(self.uri)
+        cursor[1] = 'published'
+        cursor.close()
+
+        # A checkpoint publishes the first table to the shared metadata.
+        self.session.checkpoint()
+        self.assertTrue(self.uri_in_shared_metadata(self.conn, self.uri))
+
+        # A second table created without a covering checkpoint stays local-only.
+        self.session.create(self.uri_uncovered, self.table_config)
+        self.assertTrue(self.uri_in_local_metadata(self.conn, self.uri_uncovered))
+        self.assertFalse(self.uri_in_shared_metadata(self.conn, self.uri_uncovered))
+
+        # Step down: the uncovered table's stable constituent is dropped, while the
+        # published table's stable constituent is kept.
+        self.conn.reconfigure('disaggregated=(role="follower")')
+        self.assertFalse(self.uri_in_local_metadata(self.conn, self.uri_uncovered))
+        self.assertTrue(self.uri_in_local_metadata(self.conn, self.uri))


### PR DESCRIPTION
## Problem

When a disaggregated leader steps down to follower, it dropped the entire shared metadata queue. That was correct for crash-and-replay step-down, where the node discards all local state and oplog replay rebuilds the queue. It is wrong for an
async step-down that keeps local metadata: the queue is the only record of which create and remove intents are still pending (published above the last checkpoint, or not yet published at all). Discarding it loses that state, so a later step-up
cannot rebuild or publish those tables, and a resurrected table can leak.

## Change
Keep the shared metadata queue across step-down. Its create and remove intents are role-independent, and a later step-up still needs them to rebuild uncovered stable constituents and to publish or net out pending operations.

The queue must not, however, leave the node owning stable tables that no checkpoint covers, because a follower cannot own them. Step-down now drops only those local-only stable constituents:
- With schema epochs, the queue's uncovered create entries name the tables to drop.
- In legacy (no-epoch) mode, step-down reconciles against the shared metadata directly, dropping any local stable table absent from it, and rebuilds the queue from a scan on the next step-up.

An uncovered stable constituent holds no committed data (all its writes routed to the ingest half), so dropping it cannot lose data. A diagnostic assertion checks this before each drop, and a second diagnostic check validates that every queue
entry surviving step-down is an uncovered create or remove intent.