### PR TITLE
WT-18090 Suppress "installer.sh: No such file or directory" message (#14275)

### DIFF
--- a/dist/s_string.ok
+++ b/dist/s_string.ok
@@ -1496,6 +1496,7 @@ perf
 pfx
 pid
 pindexp
+pipefail
 plh
 pluggable
 pmem

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -141,8 +141,13 @@ functions:
               EXTRA_ARGS="--download-url https://mongodbtoolchain.build.10gen.cc/toolchain/rhel80-zseries/x86_64/mongodbtoolchain-${MDB_TOOLCHAIN_REV}.tar.gz"
           fi
 
+          # The pinned toolchain tarball sources a script that it does not contain.
+          # pipefail preserves the installer's real exit status.
+          # FIXME-WT-18153: Remove this filter once the toolchain has been fixed.
+          set -o pipefail
           curl -fsSL https://s3.amazonaws.com/mongodbtoolchain.build.10gen.cc/installer.sh \
-              | bash -s -- --revision-id "$MDB_TOOLCHAIN_REV" $EXTRA_ARGS
+              | bash -s -- --revision-id "$MDB_TOOLCHAIN_REV" $EXTRA_ARGS 2>&1 \
+              | sed -E '/scripts\/installer\.sh: No such file or directory/d; /return: can only .return. from a function or sourced script/d'
 
   # Since Bazel (currently used in SCons) uses EngFlow's remote execution system instead of icecream,
   # additional credentials need to be setup to maintain efficient compilation speed.

--- a/test/evergreen_disagg.yml
+++ b/test/evergreen_disagg.yml
@@ -143,8 +143,14 @@ functions:
           fi
 
           echo "mongodbtoolchain $MDB_TOOLCHAIN_REV not installed, downloading..."
+
+          # The pinned toolchain tarball sources a script that it does not contain.
+          # pipefail preserves the installer's real exit status.
+          # FIXME-WT-18153: Remove this filter once the toolchain has been fixed.
+          set -o pipefail
           curl -fsSL https://s3.amazonaws.com/mongodbtoolchain.build.10gen.cc/installer.sh \
-              | bash -s -- --revision-id "$MDB_TOOLCHAIN_REV"
+              | bash -s -- --revision-id "$MDB_TOOLCHAIN_REV" 2>&1 \
+              | sed -E '/scripts\/installer\.sh: No such file or directory/d; /return: can only .return. from a function or sourced script/d'
 
   "dump stacktraces": &dump_stacktraces
     command: shell.exec


### PR DESCRIPTION
This PR effectively suppresses the `"installer.sh: No such file or directory"` message in evergreen task logs. This is to stop it from showing up as a distinct "failure" signature in the BBUI, which masks other errors.

(cherry picked from commit fa5be13d07a1ecefac0318ab51f32afad6999c09)