### PR TITLE
WT-18202 Increase the idle time bar for long run test format test

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1609,9 +1609,15 @@ variables:
 # the number of runs adjusted to provide approximately six hours of testing.
 #########################################################################################
 
+  - &format-stress-idle-timeout
+    command: timeout.update
+    params:
+      timeout_secs: 10800
+
   - &format-stress-test
     exec_timeout_secs: 25200
     commands:
+      - *format-stress-idle-timeout
       - func: "get project"
       - func: "compile wiredtiger"
         vars:
@@ -1623,6 +1629,7 @@ variables:
   - &format-stress-asan-ppc-test
     exec_timeout_secs: 25200
     commands:
+      - *format-stress-idle-timeout
       - func: "get project"
       - func: "compile wiredtiger"
         vars:
@@ -1637,6 +1644,7 @@ variables:
   - &format-stress-asan-test
     exec_timeout_secs: 25200
     commands:
+      - *format-stress-idle-timeout
       - func: "get project"
       - func: "compile wiredtiger"
         vars:
@@ -1649,6 +1657,7 @@ variables:
   - &race-condition-stress-asan-test
     exec_timeout_secs: 25200
     commands:
+      - *format-stress-idle-timeout
       - func: "get project"
       - func: "compile wiredtiger"
         vars:

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1612,12 +1612,12 @@ variables:
   - &format-stress-idle-timeout
     command: timeout.update
     params:
+      # If the task does not produce any output for this amount of time, it will be terminated.
       timeout_secs: 10800 # 3 hours
 
   - &format-stress-test
     exec_timeout_secs: 25200
     commands:
-      - *format-stress-idle-timeout
       - func: "get project"
       - func: "compile wiredtiger"
         vars:

--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1612,7 +1612,7 @@ variables:
   - &format-stress-idle-timeout
     command: timeout.update
     params:
-      timeout_secs: 10800
+      timeout_secs: 10800 # 3 hours
 
   - &format-stress-test
     exec_timeout_secs: 25200


### PR DESCRIPTION
Increase the idle waiting time for long run test format tasks. See jira tickets for more details.