### PR TITLE
Revert "WT-18214 Fix test/format multi node failing with low op count"

### DIFF
--- a/test/format/format.h
+++ b/test/format/format.h
@@ -229,9 +229,7 @@ extern u_int ntables;
 typedef struct {
     wt_shared uint64_t leader_hash;
     wt_shared uint64_t follower_hash;
-    wt_shared uint64_t leader_ops_base;
-    wt_shared uint64_t follower_ops_base;
-} DISAGG_MULTI_SHARED;
+} DISAGG_MULTI_DB_HASH;
 
 typedef struct {
     WT_CONNECTION *wts_conn;
@@ -290,7 +288,6 @@ typedef struct {
 
     wt_timestamp_t replay_cached_committed; /* Our committed timestamp, cached */
     uint32_t replay_calculate_committed;    /* Times before recalculating cached committed */
-    wt_timestamp_t replay_ops_base;         /* Timestamp the operations phase started from */
     wt_timestamp_t replay_start_timestamp;  /* Timestamp at the beginning of a run */
     FILE *replay_op_log;                    /* Predictable replay per-run operation log */
     wt_timestamp_t stop_timestamp;          /* If non-zero, stop when stable reaches this */
@@ -343,9 +340,9 @@ typedef struct {
 
     bool disagg_leader; /* If disaggregated storage role is configured as a leader. */
     pid_t follower_pid; /* For multi-node disagg follower process */
-    char checkpoint_metadata[FILENAME_MAX];   /* Last checkpoint metadata picked up by follower. */
-    DISAGG_MULTI_SHARED *disagg_multi_shared; /* Leader/follower shared validation state */
-    int disagg_multi_sync_socket;             /* Socket for leader-follower sync */
+    char checkpoint_metadata[FILENAME_MAX]; /* Last checkpoint metadata picked up by follower. */
+    DISAGG_MULTI_DB_HASH *disagg_multi_db_hash; /* Leader and follower database hash */
+    int disagg_multi_sync_socket;               /* Socket for leader-follower sync */
 
     wt_timestamp_t key_push_history[KEY_PUSH_HISTORY_MAX]; /* Push-mode key rotation: timestamps */
     size_t key_push_count; /* Number of pushed timestamps recorded */
@@ -508,7 +505,6 @@ void disagg_setup_multi_node(void);
 void disagg_switch_roles(void);
 void disagg_teardown_multi_node(void);
 void disagg_sync_multi_node(WT_SESSION *);
-void disagg_sync_ops_base(void);
 const char *session_prefetch_cfg(void);
 void fclose_and_clear(FILE **);
 void follower_read_latest_checkpoint(void);

--- a/test/format/format_disagg.c
+++ b/test/format/format_disagg.c
@@ -70,8 +70,8 @@ disagg_teardown_multi_node(void)
         g.follower_pid = 0;
     }
     close(g.disagg_multi_sync_socket);
-    testutil_check(munmap(g.disagg_multi_shared, sizeof(DISAGG_MULTI_SHARED)));
-    g.disagg_multi_shared = NULL;
+    testutil_check(munmap(g.disagg_multi_db_hash, sizeof(DISAGG_MULTI_DB_HASH)));
+    g.disagg_multi_db_hash = NULL;
 }
 
 /*
@@ -106,9 +106,9 @@ disagg_setup_multi_node(void)
      * Allocate a shared memory region to hold hash values shared between leader and follower
      * processes, used by disagg multi node tests to validate data consistency.
      */
-    g.disagg_multi_shared = mmap(
-      NULL, sizeof(DISAGG_MULTI_SHARED), PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
-    testutil_assert_errno(g.disagg_multi_shared != MAP_FAILED);
+    g.disagg_multi_db_hash = mmap(NULL, sizeof(DISAGG_MULTI_DB_HASH), PROT_READ | PROT_WRITE,
+      MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+    testutil_assert_errno(g.disagg_multi_db_hash != MAP_FAILED);
 
     /* Create a socket pair for leader-follower synchronization.*/
     if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) == -1)
@@ -157,30 +157,6 @@ disagg_multi_sync_point(void)
 }
 
 /*
- * disagg_sync_ops_base --
- *     Agree on a common predictable-replay operations base across the leader and follower.
- */
-void
-disagg_sync_ops_base(void)
-{
-    wt_timestamp_t base;
-
-    if (!disagg_is_multi_node() || !GV(RUNS_PREDICTABLE_REPLAY))
-        return;
-
-    if (g.disagg_leader)
-        g.disagg_multi_shared->leader_ops_base = g.timestamp;
-    else
-        g.disagg_multi_shared->follower_ops_base = g.timestamp;
-
-    disagg_multi_sync_point();
-
-    base = WT_MAX(g.disagg_multi_shared->leader_ops_base, g.disagg_multi_shared->follower_ops_base);
-    testutil_assert(base >= g.timestamp);
-    g.replay_ops_base = base;
-}
-
-/*
  * disagg_sync_multi_node --
  *     Synchronization point in disagg multi-node setup for leader-follower data validation.
  */
@@ -194,9 +170,9 @@ disagg_sync_multi_node(WT_SESSION *session)
     if (GV(DISAGG_MULTI_VALIDATION)) {
         hash = checksum_database(session);
         if (g.disagg_leader)
-            g.disagg_multi_shared->leader_hash = hash;
+            g.disagg_multi_db_hash->leader_hash = hash;
         else
-            g.disagg_multi_shared->follower_hash = hash;
+            g.disagg_multi_db_hash->follower_hash = hash;
     }
 
     /* Initial synchronization between leader and follower processes. */
@@ -209,7 +185,7 @@ disagg_sync_multi_node(WT_SESSION *session)
          */
 
         bool hash_match =
-          g.disagg_multi_shared->leader_hash == g.disagg_multi_shared->follower_hash;
+          g.disagg_multi_db_hash->leader_hash == g.disagg_multi_db_hash->follower_hash;
         if (!hash_match && GV(DISAGG_PRESERVE))
             testutil_disagg_preserve(session->connection, "preserve", g.stable_timestamp);
 

--- a/test/format/format_timestamp.c
+++ b/test/format/format_timestamp.c
@@ -151,7 +151,7 @@ timestamp_once(WT_SESSION *session, bool allow_lag, bool final)
          */
         WT_ACQUIRE_READ_WITH_BARRIER(stop_timestamp, g.stop_timestamp);
         if (stable_timestamp > stop_timestamp && stop_timestamp != WT_TS_NONE)
-            stable_timestamp = WT_MAX(stop_timestamp, g.stable_timestamp);
+            stable_timestamp = stop_timestamp;
 
         /*
          * For predictable replay, we need the oldest timestamp to lag when the process exits. That
@@ -160,7 +160,7 @@ timestamp_once(WT_SESSION *session, bool allow_lag, bool final)
         if (stable_timestamp > 10 * WT_THOUSAND)
             oldest_timestamp = WT_MAX(stable_timestamp - 10 * WT_THOUSAND, g.oldest_timestamp);
         else
-            oldest_timestamp = WT_MAX(stable_timestamp / 2, g.oldest_timestamp);
+            oldest_timestamp = stable_timestamp / 2;
     } else if (!final) {
         /*
          * If lag is permitted, update the oldest timestamp halfway to the largest timestamp that's

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -343,10 +343,7 @@ operations(u_int ops_seconds, u_int run_current, u_int run_total)
              */
             thread_ops = -1;
             ops_seconds = 0;
-            if (g.replay_ops_base == WT_TS_NONE)
-                g.replay_ops_base = g.timestamp;
-            g.stop_timestamp =
-              g.replay_ops_base + (GV(RUNS_OPS) * (uint64_t)run_current) / run_total;
+            g.stop_timestamp = (GV(RUNS_OPS) * (uint64_t)run_current) / run_total;
         } else
             thread_ops = GV(RUNS_OPS) / GV(RUNS_THREADS);
     }

--- a/test/format/t.c
+++ b/test/format/t.c
@@ -383,12 +383,6 @@ main(int argc, char *argv[])
     scan_args.rnd = &g.extra_rnd;
     TIMED_MAJOR_OP(tables_apply(wts_read_scan, &scan_args));
 
-    /*
-     * Agree on the predictable-replay operations base before the first run computes its stop
-     * timestamp, and before any background thread can advance the timestamp asymmetrically.
-     */
-    disagg_sync_ops_base();
-
     /* Optionally start checkpoints. */
     wts_checkpoints();
 


### PR DESCRIPTION
Reverts wiredtiger/wiredtiger#14324

Seeing predictable replay failures after merging, likely to be caused by this commit.

