### PR TITLE
WT-18188 Async graceful step-down coverage in schema_disagg_abort

### DIFF
--- a/test/csuite/schema_disagg_abort/README.md
+++ b/test/csuite/schema_disagg_abort/README.md
@@ -42,9 +42,9 @@ WT_TEST.foo.SAVE/                 copy of the home, taken just before verificati
 - **`PALITE/`** — shared by both nodes, and the only durable state that matters. Leader
   checkpoints write pages and checkpoint metadata into it; followers adopt from it via
   `pl_get_complete_checkpoint` → `reconfigure(checkpoint_meta)`. Single-writer is enforced by
-  protocol ordering: step-down closes the connection before the peer steps up.
-- **`WT_NODE<i>/`** — a node's local database, kept across its role switches; a follower
-  reopen does not wipe it. Verification does: it opens with
+  protocol ordering: the old leader completes its step-down before the peer steps up.
+- **`WT_NODE<i>/`** — a node's local database, kept across its role switches; both transitions are
+  in-place reconfigures of a connection that stays open. Verification does wipe it: it opens with
   `disaggregated=(lose_all_my_data=true)`, deleting the local files and rebuilding the home
   from the page log — hence the `.SAVE` copy, taken first and replaced on every rerun.
 - **`records/`** — named for the origin of what they log: `leader` files for the operations the
@@ -184,9 +184,10 @@ capacity.
         │            inserts commit+record → relay ▶ peer pipe         │
         └──────────────────────────────────────────────────────────────┘
   stop_run ──▶ quiesce → close(NULL: closing checkpoint) → exit(0)
-  handover ──▶ quiesce → LEAVE: stable := counter → final checkpoint
-               → CLOSE conn → send CKPT + SWITCH(counter) [peer alive]
-               ENTER follower: reopen conn ──▶ FOLLOWER
+  handover ──▶ quiesce → LEAVE: arm step-down at counter, stable := counter
+               → step-down checkpoint → reconfigure(role=follower)
+               → send CKPT + SWITCH(counter) [peer alive]
+               ENTER follower: restore frontier ──▶ FOLLOWER
   EPIPE on relay ──▶ peer_alive = false (lone leader keeps producing)
 
         ┌──────────────────────── FOLLOWER ────────────────────────────┐
@@ -215,8 +216,8 @@ capacity.
 | Counter | generator *allocates* `event_ts` values | *adopts* them from events (`counter_advance`) |
 | `EVENT_CKPT` | reader produces the checkpoint, then relays the event (no barrier: it races the workload) | reader barriers, then picks the checkpoint up |
 | Relay | workers relay applied events; reader relays `EVENT_CKPT` | — |
-| `leave()` | heavy: advance stable to the term's counter, final checkpoint, **close the connection**, hand over | empty |
-| `enter()` | reconfigure + seed counter + restore frontier (+ adopt-latest when lone) | reopen the connection |
+| `leave()` | heavy: arm the step-down at the term's counter, advance stable to it, step-down checkpoint, **`reconfigure(role=follower)`**, hand over | empty |
+| `enter()` | reconfigure + seed counter + restore frontier (+ adopt-latest when lone) | restore the frontier |
 | Graceful close | `close(NULL)` — closing checkpoint | `close(skip_checkpoint)` |
 | Readiness / records | `leader_ready`; `node*-leader-*` | `follower_ready`; `node*-follower-*` |
 | Peer-death signal | EPIPE while relaying | pipe EOF |
@@ -243,16 +244,17 @@ step-down has no peer to hand over to).
    the full ring, the checkpoints that would unwedge it. The slot machine makes this structural —
    a waiting slot emits nothing until coverage arrives.
 3. **Frontier hand-off**: at step-down the term is quiesced and drained, so `leader_leave`
-   advances oldest/stable/stable-epoch to the term's counter before its final checkpoint
-   (publishes above that epoch would die with the closed connection), and `leader_enter`
-   restores the same frontier so an early checkpoint of the new term cannot regress the
-   shared epoch.
+   advances oldest/stable/stable-epoch to the term's counter before its step-down checkpoint
+   (a publish that checkpoint does not carry is lost when the step-down clears the shared-metadata
+   queue), and `leader_enter` restores the same frontier so an early checkpoint of the new term
+   cannot regress the shared epoch.
 4. **Hand-over integrity**: `EVENT_SWITCH` is a term's last event; the receiver drains everything
    before acting and asserts its counter equals the event's, since every allocated value rides an
    event preceding the switch. The generator flushes pending publishes first — a step-down clears
    WiredTiger's shared-metadata queue and URIs are origin-namespaced, so one left behind could
-   never be published by anyone. The old leader closes its connection before the switch is sent
-   (one writer per page log).
+   never be published by anyone. That counter is also the boundary the step-down is armed at, which
+   the preceding drain makes safe, and the old leader completes the step-down before the switch is
+   sent (one writer per page log).
 5. **Uniform EBUSY policy**: workers retry the same operation with a MAX_OP_WAIT bound; the
    stream is fixed at generation time and the slot model flips when the generator emits, so
    the executed state converges to the model.

--- a/test/csuite/schema_disagg_abort/follower.c
+++ b/test/csuite/schema_disagg_abort/follower.c
@@ -92,20 +92,17 @@ follower_leave(WORKLOAD_STATE *state, uint64_t final_counter)
 
 /*
  * follower_enter --
- *     Step down: the connection was closed to release the page log's writer slot, so reopen it in
- *     the follower role and put it back in the epoch world.
+ *     Land in the follower role; leader_leave already reconfigured the connection.
  */
 static void
 follower_enter(WORKLOAD_STATE *state, uint64_t final_counter)
 {
-    node_open(state->cfg, node_role_follower.name, &state->conn);
-    /* A fresh connection has adopted nothing. */
+    /* This node produced its checkpoints rather than adopting them; nothing to skip. */
     state->adopted_ckpt_lsn = 0;
 
     /*
-     * The reopened connection starts outside the epoch world, and this node keeps publishing the
-     * operations it applies for the new leader, so restore the frontier at the term's final counter
-     * value. Everything the new leader relays was allocated above it.
+     * This node keeps publishing the operations it applies for the new leader, so its frontier must
+     * cover the whole term. Everything the new leader relays was allocated above it.
      */
     set_frontier(state->conn, final_counter);
 }

--- a/test/csuite/schema_disagg_abort/follower.c
+++ b/test/csuite/schema_disagg_abort/follower.c
@@ -92,7 +92,7 @@ follower_leave(WORKLOAD_STATE *state, uint64_t final_counter)
 
 /*
  * follower_enter --
- *     Land in the follower role; leader_leave already reconfigured the connection.
+ *     This method is called when the node enters the follower role.
  */
 static void
 follower_enter(WORKLOAD_STATE *state, uint64_t final_counter)

--- a/test/csuite/schema_disagg_abort/leader.c
+++ b/test/csuite/schema_disagg_abort/leader.c
@@ -7,9 +7,9 @@
  */
 
 /*
- * Leader role: the two ends of a leadership term. Stepping down makes the term's tail durable,
- * releases the page log's single writer slot by closing the connection, and hands the term over to
- * the peer; stepping up is a reconfigure that continues the previous term's counter.
+ * Leader role: the two ends of a leadership term, both in-place reconfigures. Stepping down makes
+ * the term's tail durable, releases the page log's single writer slot, and hands the term over to
+ * the peer; stepping up continues the previous term's counter.
  *
  * Everything a running leader does (generating, executing, and relaying events, checkpointing) is
  * the generic engine in node.c with role->leads set.
@@ -62,11 +62,11 @@ leader_checkpoint(
 
 /*
  * leader_leave --
- *     Step down: take a final checkpoint so the term's tail is durable, close the connection before
- *     the peer steps up (the page log allows one writer), then hand the term over - a checkpoint
- *     event first, so the peer picks up the final checkpoint through the normal path, then the
- *     switch event carrying the term's final counter value, which it must continue from. Without a
- *     live peer there is nothing to send: this node continues both sides of the swap itself.
+ *     Step down: take the step-down checkpoint so the term's tail is durable, reconfigure into the
+ *     follower role before the peer steps up (the page log allows one writer), then hand the term
+ *     over - a checkpoint event first, so the peer picks that checkpoint up through the normal
+ *     path, then the switch event carrying the term's final counter value, which it must continue
+ *     from. Without a live peer there is nothing to send: this node continues both sides itself.
  */
 static void
 leader_leave(WORKLOAD_STATE *state, uint64_t final_counter)
@@ -76,17 +76,18 @@ leader_leave(WORKLOAD_STATE *state, uint64_t final_counter)
     testutil_check(conn->open_session(conn, NULL, NULL, &session));
 
     /*
-     * The term is quiesced and fully drained: everything it allocated is committed and published.
-     * Advance the stable frontier over all of it before the final checkpoint - the timestamp
-     * thread's periodic advance can miss the drain's last burst, and publishes above the final
-     * checkpoint's stable epoch would be lost with the closed connection.
+     * The term is quiesced and drained, so its counter is the step-down boundary: nothing more will
+     * be committed or published. The checkpoint has to land on that boundary exactly - WiredTiger
+     * asserts it at the role change - and has to carry the epoch with it, since the step-down
+     * clears the shared metadata queue and loses any publish left behind.
      */
-    if (final_counter != 0)
+    if (final_counter != 0) {
+        set_ts(conn, "step_down_timestamp", final_counter);
         set_frontier(conn, final_counter);
+    }
     testutil_check(session->checkpoint(session, "use_timestamp=true"));
     testutil_check(session->close(session, NULL));
-    testutil_check(conn->close(conn, "debug=(skip_checkpoint=true)"));
-    state->conn = NULL;
+    testutil_check(conn->reconfigure(conn, "disaggregated=(role=follower)"));
 
     SCHEMA_EVENT ev = {0};
     ev.type = EVENT_CKPT;

--- a/test/csuite/schema_disagg_abort/main.c
+++ b/test/csuite/schema_disagg_abort/main.c
@@ -55,6 +55,18 @@ query_ts(WT_CONNECTION *conn, const char *name)
 }
 
 /*
+ * set_ts --
+ *     Set one of the connection's timestamps from an integer.
+ */
+void
+set_ts(WT_CONNECTION *conn, const char *name, uint64_t ts)
+{
+    char config[64];
+    testutil_snprintf(config, sizeof(config), "%s=%" PRIx64, name, ts);
+    testutil_check(conn->set_timestamp(conn, config));
+}
+
+/*
  * set_frontier --
  *     Move the connection's frontier - the oldest and stable timestamps and the stable schema epoch
  *     - to one allocator value. The three always advance together: a single counter feeds both the

--- a/test/csuite/schema_disagg_abort/schema_disagg_abort.h
+++ b/test/csuite/schema_disagg_abort/schema_disagg_abort.h
@@ -100,8 +100,9 @@ typedef enum { KILL_LONE = 0, KILL_LEADER, KILL_FOLLOWER } KILL_TARGET;
  * publish at a fresh epoch - so the independently paced checkpoints land between them, the window
  * this test targets.
  *
- * EVENT_SWITCH ends a term's stream, carrying the term's final counter value as a relay-integrity
- * check the receiver asserts against its own once drained.
+ * EVENT_SWITCH ends a term's stream, carrying the term's final counter value: a relay-integrity
+ * check the receiver asserts against its own once drained, and the boundary the leaving leader arms
+ * its step-down at.
  */
 typedef enum {
     EVENT_NONE = 0,
@@ -195,8 +196,8 @@ typedef struct {
  */
 typedef struct {
     TEST_CONFIG *cfg;    /* bound at creation */
-    WT_CONNECTION *conn; /* owned here; the control loop and the role transitions keep it
-                            current: a step-down closes it, a follower reopen replaces it */
+    WT_CONNECTION *conn; /* owned here; open for the node's whole life, since both role
+                            transitions are in-place reconfigures */
     /*
      * This phase leads: the generator produces the workload, checkpoint events are produced rather
      * than picked up, and every applied event is relayed to the peer. Fixed per phase.
@@ -285,6 +286,7 @@ typedef struct {
 /* main.c */
 void println(const char *fmt, ...) WT_GCC_FUNC_DECL_ATTRIBUTE((format(printf, 1, 2)));
 uint64_t query_ts(WT_CONNECTION *conn, const char *name);
+void set_ts(WT_CONNECTION *conn, const char *name, uint64_t ts);
 void set_frontier(WT_CONNECTION *conn, uint64_t ts);
 
 /* leader.c: the leader specifics - checkpoint production and the role transitions. */

--- a/test/csuite/schema_disagg_abort/smoke.sh
+++ b/test/csuite/schema_disagg_abort/smoke.sh
@@ -48,8 +48,12 @@ $TEST_WRAPPER "$test_bin" -b "$build_dir" -r l -t 10 -T 2 -u 4 -h WT_TEST.schema
 $TEST_WRAPPER "$test_bin" -b "$build_dir" -r f -t 10 -T 2 -h WT_TEST.schema_disagg_abort.f
 $TEST_WRAPPER "$test_bin" -b "$build_dir" -r f -s 6 -t 18 -T 2 -h WT_TEST.schema_disagg_abort.fs
 
-# Single-node role switches every 5 seconds, ending gracefully.
+# Single-node role switches every 5 seconds, ending gracefully; each swap is a graceful step-down
+# followed by a step-up over the node's own checkpoint.
 $TEST_WRAPPER "$test_bin" -b "$build_dir" -r l -s 5 -t 20 -T 2 -h WT_TEST.schema_disagg_abort.ls
+
+# The same, killed mid-run, so a crash can land next to a step-down.
+$TEST_WRAPPER "$test_bin" -b "$build_dir" -r l -s 5 -k 12 -t 20 -T 2 -h WT_TEST.schema_disagg_abort.lsk
 
 # Single-node crash: kill the lone node mid-run.
 $TEST_WRAPPER "$test_bin" -b "$build_dir" -r l -k 8 -t 10 -T 2 -h WT_TEST.schema_disagg_abort.lk


### PR DESCRIPTION
- async stepdown instead of hard close and reopen of the WT connection
- the same connection stays open for the lifetime of a node