### PR TITLE
WT-18238 Fix TSan data race on eviction dirty/updates trigger reads

### DIFF
--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -642,8 +642,10 @@ __checkpoint_update_evict_triggers_start(
      * for now. Add an upper bound to how high the trigger can go (in terms of percentages, even
      * though these values can be absolute).
      */
-    saved_triggers->new_dirty_trigger = WT_MIN(40.0, evict->eviction_dirty_trigger * 1.3);
-    saved_triggers->new_updates_trigger = WT_MIN(40.0, evict->eviction_updates_trigger * 2.0);
+    saved_triggers->new_dirty_trigger =
+      WT_MIN(40.0, __wt_atomic_load_double_relaxed(&evict->eviction_dirty_trigger) * 1.3);
+    saved_triggers->new_updates_trigger =
+      WT_MIN(40.0, __wt_atomic_load_double_relaxed(&evict->eviction_updates_trigger) * 2.0);
     __wt_atomic_store_double_relaxed(
       &evict->eviction_dirty_trigger, saved_triggers->new_dirty_trigger);
     __wt_atomic_store_double_relaxed(

--- a/src/conn/conn_load_control.c
+++ b/src/conn/conn_load_control.c
@@ -41,8 +41,9 @@ __conn_load_control_configure(WT_SESSION_IMPL *session)
     /* Calculate max accepted for both read and write */
     __wt_atomic_store_uint64_relaxed(
       &load_control->read_load_max, (uint64_t)(bytes_max * evict->eviction_trigger / 100.0));
-    __wt_atomic_store_uint64_relaxed(
-      &load_control->write_load_max, (uint64_t)(bytes_max * evict->eviction_dirty_trigger / 100.0));
+    __wt_atomic_store_uint64_relaxed(&load_control->write_load_max,
+      (uint64_t)(bytes_max * __wt_atomic_load_double_relaxed(&evict->eviction_dirty_trigger) /
+        100.0));
 
     return;
 }

--- a/src/evict/evict_conn.c
+++ b/src/evict/evict_conn.c
@@ -79,14 +79,14 @@ __evict_validate_config(WT_SESSION_IMPL *session, const char *cfg[])
       session, &(evict->eviction_trigger), "eviction trigger", conn->cache_size, shared));
 
     WT_RET(__wt_config_gets(session, cfg, "eviction_dirty_target", &cval));
-    evict->eviction_dirty_target = (double)cval.val;
+    double dirty_target = (double)cval.val;
     WT_RET(__evict_config_abs_to_pct(
-      session, &(evict->eviction_dirty_target), "eviction dirty target", conn->cache_size, shared));
+      session, &dirty_target, "eviction dirty target", conn->cache_size, shared));
 
     WT_RET(__wt_config_gets(session, cfg, "eviction_dirty_trigger", &cval));
-    evict->eviction_dirty_trigger = (double)cval.val;
-    WT_RET(__evict_config_abs_to_pct(session, &(evict->eviction_dirty_trigger),
-      "eviction dirty trigger", conn->cache_size, shared));
+    double dirty_trigger = (double)cval.val;
+    WT_RET(__evict_config_abs_to_pct(
+      session, &dirty_trigger, "eviction dirty trigger", conn->cache_size, shared));
 
     WT_RET(__wt_config_gets(session, cfg, "eviction_updates_target", &cval));
     evict->eviction_updates_target = (double)cval.val;
@@ -105,31 +105,29 @@ __evict_validate_config(WT_SESSION_IMPL *session, const char *cfg[])
       "eviction checkpoint target", conn->cache_size, shared));
 
     /* Check for invalid configurations and automatically fix them to suitable values. */
-    if (evict->eviction_dirty_target > evict->eviction_target) {
+    if (dirty_target > evict->eviction_target) {
         WT_CONFIG_DEBUG(session,
           "config eviction_dirty_target=%f cannot exceed eviction_target=%f. Setting "
           "eviction_dirty_target to %f.",
-          evict->eviction_dirty_target, evict->eviction_target, evict->eviction_target);
-        evict->eviction_dirty_target = evict->eviction_target;
+          dirty_target, evict->eviction_target, evict->eviction_target);
+        dirty_target = evict->eviction_target;
     }
 
-    if (evict->eviction_checkpoint_target > 0 &&
-      evict->eviction_checkpoint_target < evict->eviction_dirty_target) {
+    if (evict->eviction_checkpoint_target > 0 && evict->eviction_checkpoint_target < dirty_target) {
         WT_CONFIG_DEBUG(session,
           "config eviction_checkpoint_target=%f cannot be less than eviction_dirty_target=%f. "
           "Setting "
           "eviction_checkpoint_target to %f.",
-          evict->eviction_checkpoint_target, evict->eviction_dirty_target,
-          evict->eviction_dirty_target);
-        evict->eviction_checkpoint_target = evict->eviction_dirty_target;
+          evict->eviction_checkpoint_target, dirty_target, dirty_target);
+        evict->eviction_checkpoint_target = dirty_target;
     }
 
-    if (evict->eviction_dirty_trigger > evict->eviction_trigger) {
+    if (dirty_trigger > evict->eviction_trigger) {
         WT_CONFIG_DEBUG(session,
           "config eviction_dirty_trigger=%f cannot exceed eviction_trigger=%f. Setting "
           "eviction_dirty_trigger to %f.",
-          evict->eviction_dirty_trigger, evict->eviction_trigger, evict->eviction_trigger);
-        evict->eviction_dirty_trigger = evict->eviction_trigger;
+          dirty_trigger, evict->eviction_trigger, evict->eviction_trigger);
+        dirty_trigger = evict->eviction_trigger;
     }
 
     bool precise_checkpoint = F_ISSET(conn, WT_CONN_PRECISE_CHECKPOINT);
@@ -146,14 +144,14 @@ __evict_validate_config(WT_SESSION_IMPL *session, const char *cfg[])
             WT_CONFIG_DEBUG(session,
               "config eviction_updates_target (%f) cannot be zero. Setting "
               "to eviction_dirty_target (%f) for precise checkpoint.",
-              evict->eviction_updates_target, evict->eviction_dirty_target);
-            evict->eviction_updates_target = evict->eviction_dirty_target;
+              evict->eviction_updates_target, dirty_target);
+            evict->eviction_updates_target = dirty_target;
         } else {
             WT_CONFIG_DEBUG(session,
               "config eviction_updates_target (%f) cannot be zero. Setting "
               "to 50%% of eviction_dirty_target (%f).",
-              evict->eviction_updates_target, evict->eviction_dirty_target / 2);
-            evict->eviction_updates_target = evict->eviction_dirty_target / 2;
+              evict->eviction_updates_target, dirty_target / 2);
+            evict->eviction_updates_target = dirty_target / 2;
         }
     }
 
@@ -166,19 +164,18 @@ __evict_validate_config(WT_SESSION_IMPL *session, const char *cfg[])
          * in cache, but handle cases where non-default dirty configurations would cause updates
          * target to exceed the trigger value with an asymmetric formula.
          */
-        if (precise_checkpoint &&
-          evict->eviction_dirty_trigger / 2 < evict->eviction_updates_target) {
+        if (precise_checkpoint && dirty_trigger / 2 < evict->eviction_updates_target) {
             WT_CONFIG_DEBUG(session,
               "config eviction_updates_trigger (%f) cannot be zero. Setting "
               "to eviction_dirty_trigger (%f) for precise checkpoint.",
-              updates_trigger, evict->eviction_dirty_trigger);
-            updates_trigger = evict->eviction_dirty_trigger;
+              updates_trigger, dirty_trigger);
+            updates_trigger = dirty_trigger;
         } else {
             WT_CONFIG_DEBUG(session,
               "config eviction_updates_trigger (%f) cannot be zero. Setting "
               "to 50%% of eviction_dirty_trigger (%f).",
-              updates_trigger, evict->eviction_dirty_trigger / 2);
-            updates_trigger = evict->eviction_dirty_trigger / 2;
+              updates_trigger, dirty_trigger / 2);
+            updates_trigger = dirty_trigger / 2;
         }
     }
 
@@ -194,14 +191,19 @@ __evict_validate_config(WT_SESSION_IMPL *session, const char *cfg[])
     /* The target size must be lower than the trigger size or we will never get any work done. */
     if (evict->eviction_target >= evict->eviction_trigger)
         WT_RET_MSG(session, EINVAL, "eviction target must be lower than the eviction trigger");
-    if (evict->eviction_dirty_target >= evict->eviction_dirty_trigger)
+    if (dirty_target >= dirty_trigger)
         WT_RET_MSG(
           session, EINVAL, "eviction dirty target must be lower than the eviction dirty trigger");
     if (evict->eviction_updates_target >= updates_trigger)
         WT_RET_MSG(session, EINVAL,
           "eviction updates target must be lower than the eviction updates trigger");
 
-    /* Store the value back to eviction updates trigger after we have validated it. */
+    /*
+     * Store the validated dirty target/trigger and updates trigger back atomically: they can be
+     * read concurrently by eviction, checkpoint, and connection close.
+     */
+    __wt_atomic_store_double_relaxed(&evict->eviction_dirty_target, dirty_target);
+    __wt_atomic_store_double_relaxed(&evict->eviction_dirty_trigger, dirty_trigger);
     __wt_atomic_store_double_relaxed(&evict->eviction_updates_trigger, updates_trigger);
     return (0);
 }

--- a/src/evict/evict_inline.h
+++ b/src/evict/evict_inline.h
@@ -664,7 +664,9 @@ __wti_evict_hs_dirty(WT_SESSION_IMPL *session)
 
     return (__wt_cache_bytes_plus_overhead(
               cache, __wt_atomic_load_uint64_relaxed(&cache->bytes_hs_dirty)) >=
-      ((uint64_t)(conn->evict->eviction_dirty_trigger * bytes_max) / 100));
+      ((uint64_t)(__wt_atomic_load_double_relaxed(&conn->evict->eviction_dirty_trigger) *
+         bytes_max) /
+        100));
 }
 
 /*

--- a/src/evict/evict_walk.c
+++ b/src/evict/evict_walk.c
@@ -292,7 +292,9 @@ __evict_btree_dominating_cache(WT_SESSION_IMPL *session, WT_BTREE *btree, uint32
         bytes_dirty = __wt_atomic_load_uint64_relaxed(&btree->bytes_dirty_intl) +
           __wt_atomic_load_uint64_relaxed(&btree->bytes_dirty_leaf);
         if (__wt_cache_bytes_plus_overhead(cache, bytes_dirty) >
-          (uint64_t)(0.5 * evict->eviction_dirty_target * bytes_max) / 100)
+          (uint64_t)(0.5 * __wt_atomic_load_double_relaxed(&evict->eviction_dirty_target) *
+            bytes_max) /
+            100)
             return (true);
     }
     if (LF_ISSET(WT_EVICT_CACHE_UPDATES) &&
@@ -819,8 +821,9 @@ __evict_skip_dirty_candidate(WT_SESSION_IMPL *session, WT_PAGE *page)
 
         if (F_ISSET(conn->evict, WT_EVICT_CACHE_DIRTY)) {
             WT_IGNORE_RET(__wt_evict_dirty_needed(session, &pct_dirty));
-            high_pressure = (pct_dirty >
-              (conn->evict->eviction_dirty_trigger * WT_DIRTY_PAGE_LOW_PRESSURE_THRESHOLD));
+            high_pressure =
+              (pct_dirty > (__wt_atomic_load_double_relaxed(&conn->evict->eviction_dirty_trigger) *
+                             WT_DIRTY_PAGE_LOW_PRESSURE_THRESHOLD));
         }
 
         if (!high_pressure && F_ISSET(conn->evict, WT_EVICT_CACHE_UPDATES)) {


### PR DESCRIPTION
## Summary
Two per-connection eviction tuning values are written by one thread and read by another without synchronization, which ThreadSanitizer treats as a data race even though the actual values involved have no correctness impact:

- A value that connection close aggressively lowers to speed up shutdown, while checkpoint concurrently reads and temporarily raises it — most accesses already used relaxed atomics, but a couple of read sites were still plain loads.
- A companion value that connection close also lowers at shutdown, which had a similar plain-load read elsewhere.

Fix: make every remaining read/write of these two values go through the same relaxed atomic access pattern already used everywhere else, so there's no more atomic/non-atomic mismatch for ThreadSanitizer to flag.

