### PR TITLE
WT-14034 Fix resolving the prepared key multiple times because of reserved updates (7.0)

### DIFF
--- a/src/btree/bt_cursor.c
+++ b/src/btree/bt_cursor.c
@@ -657,18 +657,7 @@ __wt_btcur_search_prepared(WT_CURSOR *cursor, WT_UPDATE **updp)
     F_CLR(&cbt->iface, WT_CURSTD_KEY_ONLY);
     /*
      * The following assertion relies on the fact that for every prepared update there must be an
-     * associated key. However this is only true if we pin the page to prevent eviction. By calling
-     * into the standard search function we avoid releasing our hazard pointer between update chain
-     * resolutions. It also depends on sorting the transaction modifications by key, if we didn't do
-     * that we would unpin the page between searches and later come back to the same key. We rely on
-     * resolving all updates for a single key in sequence.
-     *
-     * This is a complex scenario, suppose we have two updates to the same key by our transaction,
-     * and are resolving the prepared updates. The first pass resolves the update chain, now if we
-     * let eviction run it could evict the page and it will treat the update chain as a regular non
-     * prepared update chain. If we were rolling back the transaction the key may not exist after
-     * eviction, similarly if we wrote a globally visible tombstone. Thus our second attempt at
-     * resolution would fail as it wouldn't find a key.
+     * associated key and we only resolve the same key once.
      */
     WT_ASSERT_ALWAYS(
       CUR2S(cursor), ret == 0, "A valid key must exist when resolving prepared updates.");

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -2071,13 +2071,21 @@ __wt_txn_prepare(WT_SESSION_IMPL *session, const char *cfg[])
              * truncation pages, they aren't linked into the transaction's modify list and so can't
              * be considered.
              */
-            for (tmp = upd->next; tmp != NULL && tmp->txnid == upd->txnid; tmp = tmp->next)
+            for (tmp = upd->next; tmp != NULL; tmp = tmp->next) {
+                /* We may see aborted reserve updates in between the prepared updates. */
+                if (tmp->txnid == WT_TXN_ABORTED)
+                    continue;
+
+                if (tmp->txnid != upd->txnid)
+                    break;
+
                 if (tmp->type != WT_UPDATE_RESERVE &&
                   !F_ISSET(tmp, WT_UPDATE_RESTORED_FAST_TRUNCATE)) {
                     F_SET(op, WT_TXN_OP_KEY_REPEATED);
                     ++prepared_updates_key_repeated;
                     break;
                 }
+            }
             break;
         case WT_TXN_OP_REF_DELETE:
             __wt_txn_op_delete_apply_prepare_state(session, op->u.ref, false);


### PR DESCRIPTION
Cherry-pick of 6f632cdee2dcb7ea480a79e9094b606d8afddc41 for BACKPORT-25739