### PR TITLE
WT-16453 Add a stat for cache tolerance level (8.0)

### DIFF
--- a/dist/stat_data.py
+++ b/dist/stat_data.py
@@ -385,6 +385,7 @@ conn_stats = [
     CacheStat('cache_hs_ondisk_max', 'history store table max on-disk size', 'no_clear,no_scale,size'),
     CacheStat('cache_reentry_hs_eviction_milliseconds', 'total milliseconds spent inside reentrant history store evictions in a reconciliation', 'no_clear,no_scale,size'),
     CacheStat('cache_overhead', 'percentage overhead', 'no_clear,no_scale'),
+    CacheStat('cache_tolerance_level', 'cache tolerance configured', 'no_clear,no_scale,size'),
     CacheStat('cache_pages_dirty', 'tracked dirty pages in the cache', 'no_clear,no_scale'),
     CacheStat('cache_pages_inuse', 'pages currently held in the cache', 'no_clear,no_scale'),
     CacheStat('cache_read_app_count', 'application threads page read from disk to cache count'),

--- a/src/conn/conn_cache.c
+++ b/src/conn/conn_cache.c
@@ -347,6 +347,8 @@ __wti_cache_stats_update(WT_SESSION_IMPL *session)
     WT_STAT_SET(session, stats, cache_bytes_max, conn->cache_size);
     WT_STAT_SET(session, stats, cache_bytes_inuse, inuse);
     WT_STAT_SET(session, stats, cache_overhead, cache->overhead_pct);
+    WT_STAT_SET(session, stats, cache_tolerance_level,
+      cache->cache_eviction_controls.cache_tolerance_for_app_eviction);
 
     WT_STAT_SET(session, stats, cache_bytes_dirty, __wt_cache_dirty_inuse(cache));
     WT_STAT_SET(session, stats, cache_bytes_dirty_leaf, __wt_cache_dirty_leaf_inuse(cache));

--- a/src/include/stat.h
+++ b/src/include/stat.h
@@ -452,6 +452,7 @@ struct __wt_connection_stats {
     int64_t cache_bytes_other;
     int64_t cache_bytes_read;
     int64_t cache_bytes_write;
+    int64_t cache_tolerance_level;
     int64_t cache_eviction_blocked_checkpoint;
     int64_t cache_eviction_blocked_checkpoint_hs;
     int64_t eviction_server_evict_attempt;

--- a/src/include/wiredtiger.in
+++ b/src/include/wiredtiger.in
@@ -5762,1612 +5762,1614 @@ extern int wiredtiger_extension_terminate(WT_CONNECTION *connection);
 #define	WT_STAT_CONN_CACHE_BYTES_READ			1085
 /*! cache: bytes written from cache */
 #define	WT_STAT_CONN_CACHE_BYTES_WRITE			1086
+/*! cache: cache tolerance configured */
+#define	WT_STAT_CONN_CACHE_TOLERANCE_LEVEL		1087
 /*! cache: checkpoint blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_CHECKPOINT	1087
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_CHECKPOINT	1088
 /*!
  * cache: checkpoint of history store file blocked non-history store page
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_CHECKPOINT_HS	1088
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_CHECKPOINT_HS	1089
 /*! cache: evict page attempts by eviction server */
-#define	WT_STAT_CONN_EVICTION_SERVER_EVICT_ATTEMPT	1089
+#define	WT_STAT_CONN_EVICTION_SERVER_EVICT_ATTEMPT	1090
 /*! cache: evict page attempts by eviction worker threads */
-#define	WT_STAT_CONN_EVICTION_WORKER_EVICT_ATTEMPT	1090
+#define	WT_STAT_CONN_EVICTION_WORKER_EVICT_ATTEMPT	1091
 /*! cache: evict page failures by eviction server */
-#define	WT_STAT_CONN_EVICTION_SERVER_EVICT_FAIL		1091
+#define	WT_STAT_CONN_EVICTION_SERVER_EVICT_FAIL		1092
 /*! cache: evict page failures by eviction worker threads */
-#define	WT_STAT_CONN_EVICTION_WORKER_EVICT_FAIL		1092
+#define	WT_STAT_CONN_EVICTION_WORKER_EVICT_FAIL		1093
 /*! cache: eviction calls to get a page */
-#define	WT_STAT_CONN_CACHE_EVICTION_GET_REF		1093
+#define	WT_STAT_CONN_CACHE_EVICTION_GET_REF		1094
 /*! cache: eviction calls to get a page found queue empty */
-#define	WT_STAT_CONN_CACHE_EVICTION_GET_REF_EMPTY	1094
+#define	WT_STAT_CONN_CACHE_EVICTION_GET_REF_EMPTY	1095
 /*! cache: eviction calls to get a page found queue empty after locking */
-#define	WT_STAT_CONN_CACHE_EVICTION_GET_REF_EMPTY2	1095
+#define	WT_STAT_CONN_CACHE_EVICTION_GET_REF_EMPTY2	1096
 /*! cache: eviction currently operating in aggressive mode */
-#define	WT_STAT_CONN_CACHE_EVICTION_AGGRESSIVE_SET	1096
+#define	WT_STAT_CONN_CACHE_EVICTION_AGGRESSIVE_SET	1097
 /*! cache: eviction empty score */
-#define	WT_STAT_CONN_CACHE_EVICTION_EMPTY_SCORE		1097
+#define	WT_STAT_CONN_CACHE_EVICTION_EMPTY_SCORE		1098
 /*!
  * cache: eviction gave up due to detecting a disk value without a
  * timestamp behind the last update on the chain
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_1	1098
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_1	1099
 /*!
  * cache: eviction gave up due to detecting a tombstone without a
  * timestamp ahead of the selected on disk update
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_2	1099
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_2	1100
 /*!
  * cache: eviction gave up due to detecting a tombstone without a
  * timestamp ahead of the selected on disk update after validating the
  * update chain
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_3	1100
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_3	1101
 /*!
  * cache: eviction gave up due to detecting update chain entries without
  * timestamps after the selected on disk update
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_4	1101
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_TS_CHECKPOINT_RACE_4	1102
 /*!
  * cache: eviction gave up due to needing to remove a record from the
  * history store but checkpoint is running
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_REMOVE_HS_RACE_WITH_CHECKPOINT	1102
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_REMOVE_HS_RACE_WITH_CHECKPOINT	1103
 /*! cache: eviction gave up due to no progress being made */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_PROGRESS	1103
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_NO_PROGRESS	1104
 /*! cache: eviction passes of a file */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK_PASSES		1104
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK_PASSES		1105
 /*! cache: eviction server candidate queue empty when topping up */
-#define	WT_STAT_CONN_CACHE_EVICTION_QUEUE_EMPTY		1105
+#define	WT_STAT_CONN_CACHE_EVICTION_QUEUE_EMPTY		1106
 /*! cache: eviction server candidate queue not empty when topping up */
-#define	WT_STAT_CONN_CACHE_EVICTION_QUEUE_NOT_EMPTY	1106
+#define	WT_STAT_CONN_CACHE_EVICTION_QUEUE_NOT_EMPTY	1107
 /*! cache: eviction server completed walks of all dhandles */
-#define	WT_STAT_CONN_CACHE_EVICTION_DHANDLE_COMPLETE_WALK	1107
+#define	WT_STAT_CONN_CACHE_EVICTION_DHANDLE_COMPLETE_WALK	1108
 /*! cache: eviction server skips dirty pages during a running checkpoint */
-#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_DIRTY_PAGES_DURING_CHECKPOINT	1108
+#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_DIRTY_PAGES_DURING_CHECKPOINT	1109
 /*! cache: eviction server skips internal pages as it has an active child. */
-#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_INTL_PAGE_WITH_ACTIVE_CHILD	1109
+#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_INTL_PAGE_WITH_ACTIVE_CHILD	1110
 /*! cache: eviction server skips metadata pages with history */
-#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_METATDATA_WITH_HISTORY	1110
+#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_METATDATA_WITH_HISTORY	1111
 /*!
  * cache: eviction server skips pages that are written with transactions
  * greater than the last running
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_PAGES_LAST_RUNNING	1111
+#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_PAGES_LAST_RUNNING	1112
 /*!
  * cache: eviction server skips pages that previously failed eviction and
  * likely will again
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_PAGES_RETRY	1112
+#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_PAGES_RETRY	1113
 /*! cache: eviction server skips pages that we do not want to evict */
-#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_UNWANTED_PAGES	1113
+#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_UNWANTED_PAGES	1114
 /*! cache: eviction server skips tree that we do not want to evict */
-#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_UNWANTED_TREE	1114
+#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_UNWANTED_TREE	1115
 /*!
  * cache: eviction server skips trees because there are too many active
  * walks
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_TREES_TOO_MANY_ACTIVE_WALKS	1115
+#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_TREES_TOO_MANY_ACTIVE_WALKS	1116
 /*! cache: eviction server skips trees that are being checkpointed */
-#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_CHECKPOINTING_TREES	1116
+#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_CHECKPOINTING_TREES	1117
 /*!
  * cache: eviction server skips trees that are configured to stick in
  * cache
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_TREES_STICK_IN_CACHE	1117
+#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_TREES_STICK_IN_CACHE	1118
 /*! cache: eviction server skips trees that disable eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_TREES_EVICTION_DISABLED	1118
+#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_TREES_EVICTION_DISABLED	1119
 /*! cache: eviction server skips trees that were not useful before */
-#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_TREES_NOT_USEFUL_BEFORE	1119
+#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SKIP_TREES_NOT_USEFUL_BEFORE	1120
 /*!
  * cache: eviction server slept, because we did not make progress with
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SLEPT	1120
+#define	WT_STAT_CONN_CACHE_EVICTION_SERVER_SLEPT	1121
 /*! cache: eviction server unable to reach eviction goal */
-#define	WT_STAT_CONN_CACHE_EVICTION_SLOW		1121
+#define	WT_STAT_CONN_CACHE_EVICTION_SLOW		1122
 /*! cache: eviction server waiting for a leaf page */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK_LEAF_NOTFOUND	1122
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK_LEAF_NOTFOUND	1123
 /*! cache: eviction state */
-#define	WT_STAT_CONN_CACHE_EVICTION_STATE		1123
+#define	WT_STAT_CONN_CACHE_EVICTION_STATE		1124
 /*!
  * cache: eviction walk most recent sleeps for checkpoint handle
  * gathering
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK_SLEEPS		1124
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK_SLEEPS		1125
 /*! cache: eviction walk pages queued that had updates */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_UPDATES	1125
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_UPDATES	1126
 /*! cache: eviction walk pages queued that were clean */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_CLEAN	1126
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_CLEAN	1127
 /*! cache: eviction walk pages queued that were dirty */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_DIRTY	1127
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_DIRTY	1128
 /*! cache: eviction walk pages seen that had updates */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN_UPDATES	1128
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN_UPDATES	1129
 /*! cache: eviction walk pages seen that were clean */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN_CLEAN	1129
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN_CLEAN	1130
 /*! cache: eviction walk pages seen that were dirty */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN_DIRTY	1130
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN_DIRTY	1131
 /*! cache: eviction walk target pages histogram - 0-9 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT10	1131
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT10	1132
 /*! cache: eviction walk target pages histogram - 10-31 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT32	1132
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT32	1133
 /*! cache: eviction walk target pages histogram - 128 and higher */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_GE128	1133
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_GE128	1134
 /*! cache: eviction walk target pages histogram - 32-63 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT64	1134
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT64	1135
 /*! cache: eviction walk target pages histogram - 64-128 */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT128	1135
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_LT128	1136
 /*!
  * cache: eviction walk target pages reduced due to history store cache
  * pressure
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_REDUCED	1136
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_PAGE_REDUCED	1137
 /*! cache: eviction walk target strategy only clean pages */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_STRATEGY_CLEAN	1137
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_STRATEGY_CLEAN	1138
 /*! cache: eviction walk target strategy only dirty pages */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_STRATEGY_DIRTY	1138
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_STRATEGY_DIRTY	1139
 /*! cache: eviction walk target strategy pages with updates */
-#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_STRATEGY_UPDATES	1139
+#define	WT_STAT_CONN_CACHE_EVICTION_TARGET_STRATEGY_UPDATES	1140
 /*! cache: eviction walks abandoned */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_ABANDONED	1140
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_ABANDONED	1141
 /*! cache: eviction walks gave up because they restarted their walk twice */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_STOPPED	1141
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_STOPPED	1142
 /*!
  * cache: eviction walks gave up because they saw too many pages and
  * found no candidates
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_GAVE_UP_NO_TARGETS	1142
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_GAVE_UP_NO_TARGETS	1143
 /*!
  * cache: eviction walks gave up because they saw too many pages and
  * found too few candidates
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_GAVE_UP_RATIO	1143
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_GAVE_UP_RATIO	1144
 /*!
  * cache: eviction walks random search fails to locate a page, results in
  * a null position
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK_RANDOM_RETURNS_NULL_POSITION	1144
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK_RANDOM_RETURNS_NULL_POSITION	1145
 /*! cache: eviction walks reached end of tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_ENDED		1145
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_ENDED		1146
 /*! cache: eviction walks restarted */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK_RESTART	1146
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK_RESTART	1147
 /*! cache: eviction walks started from root of tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK_FROM_ROOT	1147
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK_FROM_ROOT	1148
 /*! cache: eviction walks started from saved location in tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK_SAVED_POS	1148
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK_SAVED_POS	1149
 /*! cache: eviction worker thread active */
-#define	WT_STAT_CONN_CACHE_EVICTION_ACTIVE_WORKERS	1149
+#define	WT_STAT_CONN_CACHE_EVICTION_ACTIVE_WORKERS	1150
 /*! cache: eviction worker thread created */
-#define	WT_STAT_CONN_CACHE_EVICTION_WORKER_CREATED	1150
+#define	WT_STAT_CONN_CACHE_EVICTION_WORKER_CREATED	1151
 /*! cache: eviction worker thread removed */
-#define	WT_STAT_CONN_CACHE_EVICTION_WORKER_REMOVED	1151
+#define	WT_STAT_CONN_CACHE_EVICTION_WORKER_REMOVED	1152
 /*! cache: eviction worker thread stable number */
-#define	WT_STAT_CONN_CACHE_EVICTION_STABLE_STATE_WORKERS	1152
+#define	WT_STAT_CONN_CACHE_EVICTION_STABLE_STATE_WORKERS	1153
 /*! cache: files with active eviction walks */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_ACTIVE	1153
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_ACTIVE	1154
 /*! cache: files with new eviction walks started */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_STARTED	1154
+#define	WT_STAT_CONN_CACHE_EVICTION_WALKS_STARTED	1155
 /*! cache: force re-tuning of eviction workers once in a while */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_RETUNE	1155
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_RETUNE	1156
 /*!
  * cache: forced eviction - do not retry count to evict pages selected to
  * evict during reconciliation
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_NO_RETRY	1156
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_NO_RETRY	1157
 /*!
  * cache: forced eviction - history store pages failed to evict while
  * session has history store cursor open
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_HS_FAIL	1157
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_HS_FAIL	1158
 /*!
  * cache: forced eviction - history store pages selected while session
  * has history store cursor open
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_HS		1158
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_HS		1159
 /*!
  * cache: forced eviction - history store pages successfully evicted
  * while session has history store cursor open
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_HS_SUCCESS	1159
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_HS_SUCCESS	1160
 /*! cache: forced eviction - pages evicted that were clean count */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_CLEAN		1160
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_CLEAN		1161
 /*! cache: forced eviction - pages evicted that were clean time (usecs) */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_CLEAN_TIME	1161
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_CLEAN_TIME	1162
 /*! cache: forced eviction - pages evicted that were dirty count */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_DIRTY		1162
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_DIRTY		1163
 /*! cache: forced eviction - pages evicted that were dirty time (usecs) */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_DIRTY_TIME	1163
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_DIRTY_TIME	1164
 /*!
  * cache: forced eviction - pages selected because of a large number of
  * updates to a single item
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_LONG_UPDATE_LIST	1164
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_LONG_UPDATE_LIST	1165
 /*!
  * cache: forced eviction - pages selected because of too many deleted
  * items count
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_DELETE	1165
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_DELETE	1166
 /*! cache: forced eviction - pages selected count */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE		1166
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE		1167
 /*! cache: forced eviction - pages selected unable to be evicted count */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_FAIL		1167
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_FAIL		1168
 /*! cache: forced eviction - pages selected unable to be evicted time */
-#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_FAIL_TIME	1168
+#define	WT_STAT_CONN_CACHE_EVICTION_FORCE_FAIL_TIME	1169
 /*! cache: hazard pointer blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_HAZARD	1169
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_HAZARD	1170
 /*! cache: hazard pointer check calls */
-#define	WT_STAT_CONN_CACHE_HAZARD_CHECKS		1170
+#define	WT_STAT_CONN_CACHE_HAZARD_CHECKS		1171
 /*! cache: hazard pointer check entries walked */
-#define	WT_STAT_CONN_CACHE_HAZARD_WALKS			1171
+#define	WT_STAT_CONN_CACHE_HAZARD_WALKS			1172
 /*! cache: hazard pointer maximum array length */
-#define	WT_STAT_CONN_CACHE_HAZARD_MAX			1172
+#define	WT_STAT_CONN_CACHE_HAZARD_MAX			1173
 /*! cache: history store table insert calls */
-#define	WT_STAT_CONN_CACHE_HS_INSERT			1173
+#define	WT_STAT_CONN_CACHE_HS_INSERT			1174
 /*! cache: history store table insert calls that returned restart */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_RESTART		1174
+#define	WT_STAT_CONN_CACHE_HS_INSERT_RESTART		1175
 /*! cache: history store table max on-disk size */
-#define	WT_STAT_CONN_CACHE_HS_ONDISK_MAX		1175
+#define	WT_STAT_CONN_CACHE_HS_ONDISK_MAX		1176
 /*! cache: history store table on-disk size */
-#define	WT_STAT_CONN_CACHE_HS_ONDISK			1176
+#define	WT_STAT_CONN_CACHE_HS_ONDISK			1177
 /*! cache: history store table reads */
-#define	WT_STAT_CONN_CACHE_HS_READ			1177
+#define	WT_STAT_CONN_CACHE_HS_READ			1178
 /*! cache: history store table reads missed */
-#define	WT_STAT_CONN_CACHE_HS_READ_MISS			1178
+#define	WT_STAT_CONN_CACHE_HS_READ_MISS			1179
 /*! cache: history store table reads requiring squashed modifies */
-#define	WT_STAT_CONN_CACHE_HS_READ_SQUASH		1179
+#define	WT_STAT_CONN_CACHE_HS_READ_SQUASH		1180
 /*!
  * cache: history store table resolved updates without timestamps that
  * lose their durable timestamp
  */
-#define	WT_STAT_CONN_CACHE_HS_ORDER_LOSE_DURABLE_TIMESTAMP	1180
+#define	WT_STAT_CONN_CACHE_HS_ORDER_LOSE_DURABLE_TIMESTAMP	1181
 /*!
  * cache: history store table truncation by rollback to stable to remove
  * an unstable update
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE	1181
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE	1182
 /*!
  * cache: history store table truncation by rollback to stable to remove
  * an update
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS		1182
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS		1183
 /*!
  * cache: history store table truncation to remove all the keys of a
  * btree
  */
-#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE		1183
+#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE		1184
 /*! cache: history store table truncation to remove an update */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE		1184
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE		1185
 /*!
  * cache: history store table truncation to remove range of updates due
  * to an update without a timestamp on data page
  */
-#define	WT_STAT_CONN_CACHE_HS_ORDER_REMOVE		1185
+#define	WT_STAT_CONN_CACHE_HS_ORDER_REMOVE		1186
 /*!
  * cache: history store table truncation to remove range of updates due
  * to key being removed from the data page during reconciliation
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_ONPAGE_REMOVAL	1186
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_ONPAGE_REMOVAL	1187
 /*!
  * cache: history store table truncations that would have happened in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE_DRYRUN	1187
+#define	WT_STAT_CONN_CACHE_HS_BTREE_TRUNCATE_DRYRUN	1188
 /*!
  * cache: history store table truncations to remove an unstable update
  * that would have happened in non-dryrun mode
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE_DRYRUN	1188
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_UNSTABLE_DRYRUN	1189
 /*!
  * cache: history store table truncations to remove an update that would
  * have happened in non-dryrun mode
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_DRYRUN	1189
+#define	WT_STAT_CONN_CACHE_HS_KEY_TRUNCATE_RTS_DRYRUN	1190
 /*!
  * cache: history store table updates without timestamps fixed up by
  * reinserting with the fixed timestamp
  */
-#define	WT_STAT_CONN_CACHE_HS_ORDER_REINSERT		1190
+#define	WT_STAT_CONN_CACHE_HS_ORDER_REINSERT		1191
 /*! cache: history store table writes requiring squashed modifies */
-#define	WT_STAT_CONN_CACHE_HS_WRITE_SQUASH		1191
+#define	WT_STAT_CONN_CACHE_HS_WRITE_SQUASH		1192
 /*! cache: in-memory page passed criteria to be split */
-#define	WT_STAT_CONN_CACHE_INMEM_SPLITTABLE		1192
+#define	WT_STAT_CONN_CACHE_INMEM_SPLITTABLE		1193
 /*! cache: in-memory page splits */
-#define	WT_STAT_CONN_CACHE_INMEM_SPLIT			1193
+#define	WT_STAT_CONN_CACHE_INMEM_SPLIT			1194
 /*! cache: internal page split blocked its eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_INTERNAL_PAGE_SPLIT	1194
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_INTERNAL_PAGE_SPLIT	1195
 /*! cache: internal pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL		1195
+#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL		1196
 /*! cache: internal pages queued for eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL_PAGES_QUEUED	1196
+#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL_PAGES_QUEUED	1197
 /*! cache: internal pages seen by eviction walk */
-#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL_PAGES_SEEN	1197
+#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL_PAGES_SEEN	1198
 /*! cache: internal pages seen by eviction walk that are already queued */
-#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL_PAGES_ALREADY_QUEUED	1198
+#define	WT_STAT_CONN_CACHE_EVICTION_INTERNAL_PAGES_ALREADY_QUEUED	1199
 /*! cache: internal pages split during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_INTERNAL	1199
+#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_INTERNAL	1200
 /*! cache: leaf pages split during eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_LEAF		1200
+#define	WT_STAT_CONN_CACHE_EVICTION_SPLIT_LEAF		1201
 /*!
  * cache: locate a random in-mem ref by examining all entries on the root
  * page
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_RANDOM_SAMPLE_INMEM_ROOT	1201
+#define	WT_STAT_CONN_CACHE_EVICTION_RANDOM_SAMPLE_INMEM_ROOT	1202
 /*! cache: maximum bytes configured */
-#define	WT_STAT_CONN_CACHE_BYTES_MAX			1202
+#define	WT_STAT_CONN_CACHE_BYTES_MAX			1203
 /*! cache: maximum clean page size seen at eviction per checkpoint */
-#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_CLEAN_PAGE_SIZE_PER_CHECKPOINT	1203
+#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_CLEAN_PAGE_SIZE_PER_CHECKPOINT	1204
 /*! cache: maximum dirty page size seen at eviction per checkpoint */
-#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_DIRTY_PAGE_SIZE_PER_CHECKPOINT	1204
+#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_DIRTY_PAGE_SIZE_PER_CHECKPOINT	1205
 /*!
  * cache: maximum gap between unvisited page and connection evict pass
  * generation seen at eviction
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_UNVISITED_GEN_GAP	1205
+#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_UNVISITED_GEN_GAP	1206
 /*!
  * cache: maximum gap between unvisited page and connection evict pass
  * generation seen at eviction per checkpoint
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_UNVISITED_GEN_GAP_PER_CHECKPOINT	1206
+#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_UNVISITED_GEN_GAP_PER_CHECKPOINT	1207
 /*!
  * cache: maximum gap between visited page and connection evict pass
  * generation seen at eviction
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_VISITED_GEN_GAP	1207
+#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_VISITED_GEN_GAP	1208
 /*!
  * cache: maximum gap between visited page and connection evict pass
  * generation seen at eviction per checkpoint
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_VISITED_GEN_GAP_PER_CHECKPOINT	1208
+#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_VISITED_GEN_GAP_PER_CHECKPOINT	1209
 /*! cache: maximum milliseconds spent at a single eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_MILLISECONDS	1209
+#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_MILLISECONDS	1210
 /*! cache: maximum milliseconds spent at a single eviction per checkpoint */
-#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_MILLISECONDS_PER_CHECKPOINT	1210
+#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_MILLISECONDS_PER_CHECKPOINT	1211
 /*! cache: maximum page size seen at eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_PAGE_SIZE	1211
+#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_PAGE_SIZE	1212
 /*! cache: maximum updates page size seen at eviction per checkpoint */
-#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_UPDATES_PAGE_SIZE_PER_CHECKPOINT	1212
+#define	WT_STAT_CONN_CACHE_EVICTION_MAXIMUM_UPDATES_PAGE_SIZE_PER_CHECKPOINT	1213
 /*! cache: modified page evict attempts by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_DIRTY_ATTEMPT		1213
+#define	WT_STAT_CONN_EVICTION_APP_DIRTY_ATTEMPT		1214
 /*! cache: modified page evict failures by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_DIRTY_FAIL		1214
+#define	WT_STAT_CONN_EVICTION_APP_DIRTY_FAIL		1215
 /*! cache: modified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1215
+#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY		1216
 /*! cache: multi-block reconciliation blocked whilst checkpoint is running */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_MULTI_BLOCK_RECONCILATION_DURING_CHECKPOINT	1216
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_MULTI_BLOCK_RECONCILATION_DURING_CHECKPOINT	1217
 /*! cache: number of times dirty trigger was reached */
-#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_DIRTY_REACHED	1217
+#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_DIRTY_REACHED	1218
 /*! cache: number of times eviction trigger was reached */
-#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_REACHED	1218
+#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_REACHED	1219
 /*! cache: number of times updates trigger was reached */
-#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_UPDATES_REACHED	1219
+#define	WT_STAT_CONN_CACHE_EVICTION_TRIGGER_UPDATES_REACHED	1220
 /*! cache: obsolete updates removed */
-#define	WT_STAT_CONN_CACHE_OBSOLETE_UPDATES_REMOVED	1220
+#define	WT_STAT_CONN_CACHE_OBSOLETE_UPDATES_REMOVED	1221
 /*! cache: operations timed out waiting for space in cache */
-#define	WT_STAT_CONN_CACHE_TIMED_OUT_OPS		1221
+#define	WT_STAT_CONN_CACHE_TIMED_OUT_OPS		1222
 /*!
  * cache: overflow keys on a multiblock row-store page blocked its
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_OVERFLOW_KEYS	1222
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_OVERFLOW_KEYS	1223
 /*! cache: overflow pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ_OVERFLOW		1223
+#define	WT_STAT_CONN_CACHE_READ_OVERFLOW		1224
 /*! cache: page evict attempts by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_ATTEMPT		1224
+#define	WT_STAT_CONN_EVICTION_APP_ATTEMPT		1225
 /*! cache: page evict failures by application threads */
-#define	WT_STAT_CONN_EVICTION_APP_FAIL			1225
+#define	WT_STAT_CONN_EVICTION_APP_FAIL			1226
 /*! cache: page split during eviction deepened the tree */
-#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1226
+#define	WT_STAT_CONN_CACHE_EVICTION_DEEPEN		1227
 /*! cache: page written requiring history store records */
-#define	WT_STAT_CONN_CACHE_WRITE_HS			1227
+#define	WT_STAT_CONN_CACHE_WRITE_HS			1228
 /*! cache: pages considered for eviction that were brought in by pre-fetch */
-#define	WT_STAT_CONN_CACHE_EVICTION_CONSIDER_PREFETCH	1228
+#define	WT_STAT_CONN_CACHE_EVICTION_CONSIDER_PREFETCH	1229
 /*! cache: pages currently held in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_INUSE			1229
+#define	WT_STAT_CONN_CACHE_PAGES_INUSE			1230
 /*! cache: pages dirtied due to obsolete time window by eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY_OBSOLETE_TW	1230
+#define	WT_STAT_CONN_CACHE_EVICTION_DIRTY_OBSOLETE_TW	1231
 /*! cache: pages evicted in parallel with checkpoint */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_IN_PARALLEL_WITH_CHECKPOINT	1231
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_IN_PARALLEL_WITH_CHECKPOINT	1232
 /*! cache: pages queued for eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED	1232
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED	1233
 /*! cache: pages queued for eviction post lru sorting */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_POST_LRU	1233
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_POST_LRU	1234
 /*! cache: pages queued for urgent eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_URGENT	1234
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_URGENT	1235
 /*! cache: pages queued for urgent eviction during walk */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_OLDEST	1235
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_OLDEST	1236
 /*!
  * cache: pages queued for urgent eviction from history store due to high
  * dirty content
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_URGENT_HS_DIRTY	1236
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_QUEUED_URGENT_HS_DIRTY	1237
 /*! cache: pages read into cache */
-#define	WT_STAT_CONN_CACHE_READ				1237
+#define	WT_STAT_CONN_CACHE_READ				1238
 /*! cache: pages read into cache after truncate */
-#define	WT_STAT_CONN_CACHE_READ_DELETED			1238
+#define	WT_STAT_CONN_CACHE_READ_DELETED			1239
 /*! cache: pages read into cache after truncate in prepare state */
-#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1239
+#define	WT_STAT_CONN_CACHE_READ_DELETED_PREPARED	1240
 /*! cache: pages read into cache by checkpoint */
-#define	WT_STAT_CONN_CACHE_READ_CHECKPOINT		1240
+#define	WT_STAT_CONN_CACHE_READ_CHECKPOINT		1241
 /*!
  * cache: pages removed from the ordinary queue to be queued for urgent
  * eviction
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_CLEAR_ORDINARY	1241
+#define	WT_STAT_CONN_CACHE_EVICTION_CLEAR_ORDINARY	1242
 /*! cache: pages requested from the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1242
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED		1243
 /*! cache: pages requested from the cache due to pre-fetch */
-#define	WT_STAT_CONN_CACHE_PAGES_PREFETCH		1243
+#define	WT_STAT_CONN_CACHE_PAGES_PREFETCH		1244
 /*! cache: pages requested from the history store */
-#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_HS		1244
+#define	WT_STAT_CONN_CACHE_PAGES_REQUESTED_HS		1245
 /*! cache: pages seen by eviction walk */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1245
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_SEEN		1246
 /*! cache: pages seen by eviction walk that are already queued */
-#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_ALREADY_QUEUED	1246
+#define	WT_STAT_CONN_CACHE_EVICTION_PAGES_ALREADY_QUEUED	1247
 /*! cache: pages selected for eviction unable to be evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_FAIL		1247
+#define	WT_STAT_CONN_CACHE_EVICTION_FAIL		1248
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * active children on an internal page
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_ACTIVE_CHILDREN_ON_AN_INTERNAL_PAGE	1248
+#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_ACTIVE_CHILDREN_ON_AN_INTERNAL_PAGE	1249
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * failure in reconciliation
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_IN_RECONCILIATION	1249
+#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_IN_RECONCILIATION	1250
 /*!
  * cache: pages selected for eviction unable to be evicted because of
  * race between checkpoint and updates without timestamps
  */
-#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_CHECKPOINT_NO_TS	1250
+#define	WT_STAT_CONN_CACHE_EVICTION_FAIL_CHECKPOINT_NO_TS	1251
 /*! cache: pages walked for eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_WALK		1251
+#define	WT_STAT_CONN_CACHE_EVICTION_WALK		1252
 /*! cache: pages written from cache */
-#define	WT_STAT_CONN_CACHE_WRITE			1252
+#define	WT_STAT_CONN_CACHE_WRITE			1253
 /*! cache: pages written requiring in-memory restoration */
-#define	WT_STAT_CONN_CACHE_WRITE_RESTORE		1253
+#define	WT_STAT_CONN_CACHE_WRITE_RESTORE		1254
 /*! cache: percentage overhead */
-#define	WT_STAT_CONN_CACHE_OVERHEAD			1254
+#define	WT_STAT_CONN_CACHE_OVERHEAD			1255
 /*! cache: recent modification of a page blocked its eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	1255
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_RECENTLY_MODIFIED	1256
 /*! cache: reverse splits performed */
-#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS		1256
+#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS		1257
 /*!
  * cache: reverse splits skipped because of VLCS namespace gap
  * restrictions
  */
-#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	1257
+#define	WT_STAT_CONN_CACHE_REVERSE_SPLITS_SKIPPED_VLCS	1258
 /*!
  * cache: the number of saved update lists processed in
  * __wt_hs_insert_updates
  */
-#define	WT_STAT_CONN_CACHE_HS_KEY_PROCESSED		1258
+#define	WT_STAT_CONN_CACHE_HS_KEY_PROCESSED		1259
 /*! cache: the number of times full update inserted to history store */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1259
+#define	WT_STAT_CONN_CACHE_HS_INSERT_FULL_UPDATE	1260
 /*! cache: the number of times reverse modify inserted to history store */
-#define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1260
+#define	WT_STAT_CONN_CACHE_HS_INSERT_REVERSE_MODIFY	1261
 /*! cache: the number of updates processed in __wt_hs_insert_updates */
-#define	WT_STAT_CONN_CACHE_HS_UPDATE_PROCESSED		1261
+#define	WT_STAT_CONN_CACHE_HS_UPDATE_PROCESSED		1262
 /*!
  * cache: total milliseconds spent inside reentrant history store
  * evictions in a reconciliation
  */
-#define	WT_STAT_CONN_CACHE_REENTRY_HS_EVICTION_MILLISECONDS	1262
+#define	WT_STAT_CONN_CACHE_REENTRY_HS_EVICTION_MILLISECONDS	1263
 /*! cache: tracked bytes belonging to internal pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1263
+#define	WT_STAT_CONN_CACHE_BYTES_INTERNAL		1264
 /*! cache: tracked bytes belonging to leaf pages in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1264
+#define	WT_STAT_CONN_CACHE_BYTES_LEAF			1265
 /*! cache: tracked dirty bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1265
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY			1266
 /*! cache: tracked dirty internal page bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL		1266
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_INTERNAL		1267
 /*! cache: tracked dirty leaf page bytes in the cache */
-#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF		1267
+#define	WT_STAT_CONN_CACHE_BYTES_DIRTY_LEAF		1268
 /*! cache: tracked dirty pages in the cache */
-#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1268
+#define	WT_STAT_CONN_CACHE_PAGES_DIRTY			1269
 /*! cache: uncommitted truncate blocked page eviction */
-#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	1269
+#define	WT_STAT_CONN_CACHE_EVICTION_BLOCKED_UNCOMMITTED_TRUNCATE	1270
 /*! cache: unmodified pages evicted */
-#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1270
+#define	WT_STAT_CONN_CACHE_EVICTION_CLEAN		1271
 /*! capacity: background fsync file handles considered */
-#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1271
+#define	WT_STAT_CONN_FSYNC_ALL_FH_TOTAL			1272
 /*! capacity: background fsync file handles synced */
-#define	WT_STAT_CONN_FSYNC_ALL_FH			1272
+#define	WT_STAT_CONN_FSYNC_ALL_FH			1273
 /*! capacity: background fsync time (msecs) */
-#define	WT_STAT_CONN_FSYNC_ALL_TIME			1273
+#define	WT_STAT_CONN_FSYNC_ALL_TIME			1274
 /*! capacity: bytes read */
-#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1274
+#define	WT_STAT_CONN_CAPACITY_BYTES_READ		1275
 /*! capacity: bytes written for checkpoint */
-#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1275
+#define	WT_STAT_CONN_CAPACITY_BYTES_CKPT		1276
 /*! capacity: bytes written for chunk cache */
-#define	WT_STAT_CONN_CAPACITY_BYTES_CHUNKCACHE		1276
+#define	WT_STAT_CONN_CAPACITY_BYTES_CHUNKCACHE		1277
 /*! capacity: bytes written for eviction */
-#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1277
+#define	WT_STAT_CONN_CAPACITY_BYTES_EVICT		1278
 /*! capacity: bytes written for log */
-#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1278
+#define	WT_STAT_CONN_CAPACITY_BYTES_LOG			1279
 /*! capacity: bytes written total */
-#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1279
+#define	WT_STAT_CONN_CAPACITY_BYTES_WRITTEN		1280
 /*! capacity: threshold to call fsync */
-#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1280
+#define	WT_STAT_CONN_CAPACITY_THRESHOLD			1281
 /*! capacity: time waiting due to total capacity (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1281
+#define	WT_STAT_CONN_CAPACITY_TIME_TOTAL		1282
 /*! capacity: time waiting during checkpoint (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1282
+#define	WT_STAT_CONN_CAPACITY_TIME_CKPT			1283
 /*! capacity: time waiting during eviction (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1283
+#define	WT_STAT_CONN_CAPACITY_TIME_EVICT		1284
 /*! capacity: time waiting during logging (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1284
+#define	WT_STAT_CONN_CAPACITY_TIME_LOG			1285
 /*! capacity: time waiting during read (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_READ			1285
+#define	WT_STAT_CONN_CAPACITY_TIME_READ			1286
 /*! capacity: time waiting for chunk cache IO bandwidth (usecs) */
-#define	WT_STAT_CONN_CAPACITY_TIME_CHUNKCACHE		1286
+#define	WT_STAT_CONN_CAPACITY_TIME_CHUNKCACHE		1287
 /*! checkpoint-cleanup: most recent duration on all eligible files (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_DURATION	1287
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_DURATION	1288
 /*! checkpoint-cleanup: most recent handles processed */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_HANDLE_PROCESSED	1288
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_HANDLE_PROCESSED	1289
 /*! checkpoint-cleanup: most recent in-memory pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_INMEM_PAGES_VISITED	1289
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_INMEM_PAGES_VISITED	1290
 /*! checkpoint-cleanup: pages added for eviction */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_EVICT	1290
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_EVICT	1291
 /*! checkpoint-cleanup: pages dirtied due to obsolete time window */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	1291
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_OBSOLETE_TW	1292
 /*! checkpoint-cleanup: pages read into cache (reclaim_space) */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	1292
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_RECLAIM_SPACE	1293
 /*! checkpoint-cleanup: pages read into cache due to obsolete time window */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	1293
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_READ_OBSOLETE_TW	1294
 /*! checkpoint-cleanup: pages removed */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_REMOVED	1294
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_REMOVED	1295
 /*! checkpoint-cleanup: pages skipped during tree walk */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	1295
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_WALK_SKIPPED	1296
 /*! checkpoint-cleanup: pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_VISITED	1296
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_PAGES_VISITED	1297
 /*! checkpoint-cleanup: successful calls */
-#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_SUCCESS		1297
+#define	WT_STAT_CONN_CHECKPOINT_CLEANUP_SUCCESS		1298
 /*! checkpoint: checkpoint has acquired a snapshot for its transaction */
-#define	WT_STAT_CONN_CHECKPOINT_SNAPSHOT_ACQUIRED	1298
+#define	WT_STAT_CONN_CHECKPOINT_SNAPSHOT_ACQUIRED	1299
 /*! checkpoint: checkpoints skipped because database was clean */
-#define	WT_STAT_CONN_CHECKPOINT_SKIPPED			1299
+#define	WT_STAT_CONN_CHECKPOINT_SKIPPED			1300
 /*! checkpoint: fsync calls after allocating the transaction ID */
-#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST		1300
+#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST		1301
 /*! checkpoint: fsync duration after allocating the transaction ID (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST_DURATION	1301
+#define	WT_STAT_CONN_CHECKPOINT_FSYNC_POST_DURATION	1302
 /*! checkpoint: generation */
-#define	WT_STAT_CONN_CHECKPOINT_GENERATION		1302
+#define	WT_STAT_CONN_CHECKPOINT_GENERATION		1303
 /*! checkpoint: max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_MAX		1303
+#define	WT_STAT_CONN_CHECKPOINT_TIME_MAX		1304
 /*! checkpoint: min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_MIN		1304
+#define	WT_STAT_CONN_CHECKPOINT_TIME_MIN		1305
 /*!
  * checkpoint: most recent duration for checkpoint dropping all handles
  * (usecs)
  */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROP_DURATION	1305
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROP_DURATION	1306
 /*! checkpoint: most recent duration for gathering all handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION		1306
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DURATION		1307
 /*! checkpoint: most recent duration for gathering applied handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLY_DURATION	1307
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLY_DURATION	1308
 /*! checkpoint: most recent duration for gathering skipped handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIP_DURATION	1308
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIP_DURATION	1309
 /*! checkpoint: most recent duration for handles metadata checked (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECK_DURATION	1309
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECK_DURATION	1310
 /*! checkpoint: most recent duration for locking the handles (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCK_DURATION	1310
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCK_DURATION	1311
 /*! checkpoint: most recent handles applied */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLIED		1311
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_APPLIED		1312
 /*! checkpoint: most recent handles checkpoint dropped */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROPPED		1312
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_DROPPED		1313
 /*! checkpoint: most recent handles metadata checked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECKED	1313
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_META_CHECKED	1314
 /*! checkpoint: most recent handles metadata locked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCKED		1314
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_LOCKED		1315
 /*! checkpoint: most recent handles skipped */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIPPED		1315
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_SKIPPED		1316
 /*! checkpoint: most recent handles walked */
-#define	WT_STAT_CONN_CHECKPOINT_HANDLE_WALKED		1316
+#define	WT_STAT_CONN_CHECKPOINT_HANDLE_WALKED		1317
 /*! checkpoint: most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_RECENT		1317
+#define	WT_STAT_CONN_CHECKPOINT_TIME_RECENT		1318
 /*! checkpoint: number of checkpoints started by api */
-#define	WT_STAT_CONN_CHECKPOINTS_API			1318
+#define	WT_STAT_CONN_CHECKPOINTS_API			1319
 /*! checkpoint: number of checkpoints started by compaction */
-#define	WT_STAT_CONN_CHECKPOINTS_COMPACT		1319
+#define	WT_STAT_CONN_CHECKPOINTS_COMPACT		1320
 /*! checkpoint: number of files synced */
-#define	WT_STAT_CONN_CHECKPOINT_SYNC			1320
+#define	WT_STAT_CONN_CHECKPOINT_SYNC			1321
 /*! checkpoint: number of handles visited after writes complete */
-#define	WT_STAT_CONN_CHECKPOINT_PRESYNC			1321
+#define	WT_STAT_CONN_CHECKPOINT_PRESYNC			1322
 /*! checkpoint: number of history store pages caused to be reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_HS_PAGES_RECONCILED	1322
+#define	WT_STAT_CONN_CHECKPOINT_HS_PAGES_RECONCILED	1323
 /*! checkpoint: number of internal pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_INTERNAL	1323
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_INTERNAL	1324
 /*! checkpoint: number of leaf pages visited */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_LEAF	1324
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_VISITED_LEAF	1325
 /*! checkpoint: number of pages caused to be reconciled */
-#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED	1325
+#define	WT_STAT_CONN_CHECKPOINT_PAGES_RECONCILED	1326
 /*! checkpoint: prepare currently running */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1326
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RUNNING		1327
 /*! checkpoint: prepare max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1327
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MAX		1328
 /*! checkpoint: prepare min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1328
+#define	WT_STAT_CONN_CHECKPOINT_PREP_MIN		1329
 /*! checkpoint: prepare most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1329
+#define	WT_STAT_CONN_CHECKPOINT_PREP_RECENT		1330
 /*! checkpoint: prepare total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1330
+#define	WT_STAT_CONN_CHECKPOINT_PREP_TOTAL		1331
 /*! checkpoint: progress state */
-#define	WT_STAT_CONN_CHECKPOINT_STATE			1331
+#define	WT_STAT_CONN_CHECKPOINT_STATE			1332
 /*! checkpoint: scrub dirty target */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1332
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TARGET		1333
 /*! checkpoint: scrub max time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1333
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MAX		1334
 /*! checkpoint: scrub min time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1334
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_MIN		1335
 /*! checkpoint: scrub most recent time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1335
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_RECENT		1336
 /*! checkpoint: scrub total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1336
+#define	WT_STAT_CONN_CHECKPOINT_SCRUB_TOTAL		1337
 /*! checkpoint: stop timing stress active */
-#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1337
+#define	WT_STAT_CONN_CHECKPOINT_STOP_STRESS_ACTIVE	1338
 /*! checkpoint: time spent on per-tree checkpoint work (usecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1338
+#define	WT_STAT_CONN_CHECKPOINT_TREE_DURATION		1339
 /*! checkpoint: total failed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1339
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_FAILED		1340
 /*! checkpoint: total succeed number of checkpoints */
-#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1340
+#define	WT_STAT_CONN_CHECKPOINTS_TOTAL_SUCCEED		1341
 /*! checkpoint: total time (msecs) */
-#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1341
+#define	WT_STAT_CONN_CHECKPOINT_TIME_TOTAL		1342
 /*! checkpoint: transaction checkpoints due to obsolete pages */
-#define	WT_STAT_CONN_CHECKPOINT_OBSOLETE_APPLIED	1342
+#define	WT_STAT_CONN_CHECKPOINT_OBSOLETE_APPLIED	1343
 /*! checkpoint: wait cycles while cache dirty level is decreasing */
-#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1343
+#define	WT_STAT_CONN_CHECKPOINT_WAIT_REDUCE_DIRTY	1344
 /*! chunk-cache: aggregate number of spanned chunks on read */
-#define	WT_STAT_CONN_CHUNKCACHE_SPANS_CHUNKS_READ	1344
+#define	WT_STAT_CONN_CHUNKCACHE_SPANS_CHUNKS_READ	1345
 /*! chunk-cache: chunks evicted */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_EVICTED		1345
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_EVICTED		1346
 /*! chunk-cache: could not allocate due to exceeding bitmap capacity */
-#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_BITMAP_CAPACITY	1346
+#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_BITMAP_CAPACITY	1347
 /*! chunk-cache: could not allocate due to exceeding capacity */
-#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_CAPACITY	1347
+#define	WT_STAT_CONN_CHUNKCACHE_EXCEEDED_CAPACITY	1348
 /*! chunk-cache: lookups */
-#define	WT_STAT_CONN_CHUNKCACHE_LOOKUPS			1348
+#define	WT_STAT_CONN_CHUNKCACHE_LOOKUPS			1349
 /*!
  * chunk-cache: number of chunks loaded from flushed tables in chunk
  * cache
  */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_LOADED_FROM_FLUSHED_TABLES	1349
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_LOADED_FROM_FLUSHED_TABLES	1350
 /*! chunk-cache: number of metadata entries inserted */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_INSERTED	1350
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_INSERTED	1351
 /*! chunk-cache: number of metadata entries removed */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_REMOVED	1351
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_REMOVED	1352
 /*!
  * chunk-cache: number of metadata inserts/deletes dropped by the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DROPPED	1352
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DROPPED	1353
 /*!
  * chunk-cache: number of metadata inserts/deletes pushed to the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_CREATED	1353
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_CREATED	1354
 /*!
  * chunk-cache: number of metadata inserts/deletes read by the worker
  * thread
  */
-#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DEQUEUED	1354
+#define	WT_STAT_CONN_CHUNKCACHE_METADATA_WORK_UNITS_DEQUEUED	1355
 /*! chunk-cache: number of misses */
-#define	WT_STAT_CONN_CHUNKCACHE_MISSES			1355
+#define	WT_STAT_CONN_CHUNKCACHE_MISSES			1356
 /*! chunk-cache: number of times a read from storage failed */
-#define	WT_STAT_CONN_CHUNKCACHE_IO_FAILED		1356
+#define	WT_STAT_CONN_CHUNKCACHE_IO_FAILED		1357
 /*! chunk-cache: retried accessing a chunk while I/O was in progress */
-#define	WT_STAT_CONN_CHUNKCACHE_RETRIES			1357
+#define	WT_STAT_CONN_CHUNKCACHE_RETRIES			1358
 /*! chunk-cache: retries from a chunk cache checksum mismatch */
-#define	WT_STAT_CONN_CHUNKCACHE_RETRIES_CHECKSUM_MISMATCH	1358
+#define	WT_STAT_CONN_CHUNKCACHE_RETRIES_CHECKSUM_MISMATCH	1359
 /*! chunk-cache: timed out due to too many retries */
-#define	WT_STAT_CONN_CHUNKCACHE_TOOMANY_RETRIES		1359
+#define	WT_STAT_CONN_CHUNKCACHE_TOOMANY_RETRIES		1360
 /*! chunk-cache: total bytes read from persistent content */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_READ_PERSISTENT	1360
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_READ_PERSISTENT	1361
 /*! chunk-cache: total bytes used by the cache */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE		1361
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE		1362
 /*! chunk-cache: total bytes used by the cache for pinned chunks */
-#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE_PINNED	1362
+#define	WT_STAT_CONN_CHUNKCACHE_BYTES_INUSE_PINNED	1363
 /*! chunk-cache: total chunks held by the chunk cache */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_INUSE		1363
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_INUSE		1364
 /*!
  * chunk-cache: total number of chunks inserted on startup from persisted
  * metadata.
  */
-#define	WT_STAT_CONN_CHUNKCACHE_CREATED_FROM_METADATA	1364
+#define	WT_STAT_CONN_CHUNKCACHE_CREATED_FROM_METADATA	1365
 /*! chunk-cache: total pinned chunks held by the chunk cache */
-#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_PINNED		1365
+#define	WT_STAT_CONN_CHUNKCACHE_CHUNKS_PINNED		1366
 /*! connection: auto adjusting condition resets */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1366
+#define	WT_STAT_CONN_COND_AUTO_WAIT_RESET		1367
 /*! connection: auto adjusting condition wait calls */
-#define	WT_STAT_CONN_COND_AUTO_WAIT			1367
+#define	WT_STAT_CONN_COND_AUTO_WAIT			1368
 /*!
  * connection: auto adjusting condition wait raced to update timeout and
  * skipped updating
  */
-#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1368
+#define	WT_STAT_CONN_COND_AUTO_WAIT_SKIPPED		1369
 /*! connection: detected system time went backwards */
-#define	WT_STAT_CONN_TIME_TRAVEL			1369
+#define	WT_STAT_CONN_TIME_TRAVEL			1370
 /*! connection: files currently open */
-#define	WT_STAT_CONN_FILE_OPEN				1370
+#define	WT_STAT_CONN_FILE_OPEN				1371
 /*! connection: hash bucket array size for data handles */
-#define	WT_STAT_CONN_BUCKETS_DH				1371
+#define	WT_STAT_CONN_BUCKETS_DH				1372
 /*! connection: hash bucket array size general */
-#define	WT_STAT_CONN_BUCKETS				1372
+#define	WT_STAT_CONN_BUCKETS				1373
 /*! connection: memory allocations */
-#define	WT_STAT_CONN_MEMORY_ALLOCATION			1373
+#define	WT_STAT_CONN_MEMORY_ALLOCATION			1374
 /*! connection: memory frees */
-#define	WT_STAT_CONN_MEMORY_FREE			1374
+#define	WT_STAT_CONN_MEMORY_FREE			1375
 /*! connection: memory re-allocations */
-#define	WT_STAT_CONN_MEMORY_GROW			1375
+#define	WT_STAT_CONN_MEMORY_GROW			1376
 /*! connection: number of sessions without a sweep for 5+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1376
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_5MIN		1377
 /*! connection: number of sessions without a sweep for 60+ minutes */
-#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1377
+#define	WT_STAT_CONN_NO_SESSION_SWEEP_60MIN		1378
 /*! connection: pthread mutex condition wait calls */
-#define	WT_STAT_CONN_COND_WAIT				1378
+#define	WT_STAT_CONN_COND_WAIT				1379
 /*! connection: pthread mutex shared lock read-lock calls */
-#define	WT_STAT_CONN_RWLOCK_READ			1379
+#define	WT_STAT_CONN_RWLOCK_READ			1380
 /*! connection: pthread mutex shared lock write-lock calls */
-#define	WT_STAT_CONN_RWLOCK_WRITE			1380
+#define	WT_STAT_CONN_RWLOCK_WRITE			1381
 /*! connection: total fsync I/Os */
-#define	WT_STAT_CONN_FSYNC_IO				1381
+#define	WT_STAT_CONN_FSYNC_IO				1382
 /*! connection: total read I/Os */
-#define	WT_STAT_CONN_READ_IO				1382
+#define	WT_STAT_CONN_READ_IO				1383
 /*! connection: total write I/Os */
-#define	WT_STAT_CONN_WRITE_IO				1383
+#define	WT_STAT_CONN_WRITE_IO				1384
 /*! cursor: Total number of deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1384
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_DEL_PAGE_SKIP	1385
 /*! cursor: Total number of entries skipped by cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1385
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_TOTAL		1386
 /*! cursor: Total number of entries skipped by cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1386
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_TOTAL		1387
 /*!
  * cursor: Total number of entries skipped to position the history store
  * cursor
  */
-#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1387
+#define	WT_STAT_CONN_CURSOR_SKIP_HS_CUR_POSITION	1388
 /*!
  * cursor: Total number of in-memory deleted pages skipped during tree
  * walk
  */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1388
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_INMEM_DEL_PAGE_SKIP	1389
 /*! cursor: Total number of on-disk deleted pages skipped during tree walk */
-#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1389
+#define	WT_STAT_CONN_CURSOR_TREE_WALK_ONDISK_DEL_PAGE_SKIP	1390
 /*!
  * cursor: Total number of times a search near has exited due to prefix
  * config
  */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1390
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_PREFIX_FAST_PATHS	1391
 /*!
  * cursor: Total number of times cursor fails to temporarily release
  * pinned page to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1391
+#define	WT_STAT_CONN_CURSOR_REPOSITION_FAILED		1392
 /*!
  * cursor: Total number of times cursor temporarily releases pinned page
  * to encourage eviction of hot or large page
  */
-#define	WT_STAT_CONN_CURSOR_REPOSITION			1392
+#define	WT_STAT_CONN_CURSOR_REPOSITION			1393
 /*! cursor: bulk cursor count */
-#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1393
+#define	WT_STAT_CONN_CURSOR_BULK_COUNT			1394
 /*! cursor: cached cursor count */
-#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1394
+#define	WT_STAT_CONN_CURSOR_CACHED_COUNT		1395
 /*! cursor: cursor bound calls that return an error */
-#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1395
+#define	WT_STAT_CONN_CURSOR_BOUND_ERROR			1396
 /*! cursor: cursor bounds cleared from reset */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1396
+#define	WT_STAT_CONN_CURSOR_BOUNDS_RESET		1397
 /*! cursor: cursor bounds comparisons performed */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1397
+#define	WT_STAT_CONN_CURSOR_BOUNDS_COMPARISONS		1398
 /*! cursor: cursor bounds next called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1398
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_UNPOSITIONED	1399
 /*! cursor: cursor bounds next early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1399
+#define	WT_STAT_CONN_CURSOR_BOUNDS_NEXT_EARLY_EXIT	1400
 /*! cursor: cursor bounds prev called on an unpositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1400
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_UNPOSITIONED	1401
 /*! cursor: cursor bounds prev early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1401
+#define	WT_STAT_CONN_CURSOR_BOUNDS_PREV_EARLY_EXIT	1402
 /*! cursor: cursor bounds search early exit */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1402
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_EARLY_EXIT	1403
 /*! cursor: cursor bounds search near call repositioned cursor */
-#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1403
+#define	WT_STAT_CONN_CURSOR_BOUNDS_SEARCH_NEAR_REPOSITIONED_CURSOR	1404
 /*! cursor: cursor bulk loaded cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1404
+#define	WT_STAT_CONN_CURSOR_INSERT_BULK			1405
 /*! cursor: cursor cache calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1405
+#define	WT_STAT_CONN_CURSOR_CACHE_ERROR			1406
 /*! cursor: cursor close calls that result in cache */
-#define	WT_STAT_CONN_CURSOR_CACHE			1406
+#define	WT_STAT_CONN_CURSOR_CACHE			1407
 /*! cursor: cursor close calls that return an error */
-#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1407
+#define	WT_STAT_CONN_CURSOR_CLOSE_ERROR			1408
 /*! cursor: cursor compare calls that return an error */
-#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1408
+#define	WT_STAT_CONN_CURSOR_COMPARE_ERROR		1409
 /*! cursor: cursor create calls */
-#define	WT_STAT_CONN_CURSOR_CREATE			1409
+#define	WT_STAT_CONN_CURSOR_CREATE			1410
 /*! cursor: cursor equals calls that return an error */
-#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1410
+#define	WT_STAT_CONN_CURSOR_EQUALS_ERROR		1411
 /*! cursor: cursor get key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1411
+#define	WT_STAT_CONN_CURSOR_GET_KEY_ERROR		1412
 /*! cursor: cursor get value calls that return an error */
-#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1412
+#define	WT_STAT_CONN_CURSOR_GET_VALUE_ERROR		1413
 /*! cursor: cursor insert calls */
-#define	WT_STAT_CONN_CURSOR_INSERT			1413
+#define	WT_STAT_CONN_CURSOR_INSERT			1414
 /*! cursor: cursor insert calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1414
+#define	WT_STAT_CONN_CURSOR_INSERT_ERROR		1415
 /*! cursor: cursor insert check calls that return an error */
-#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1415
+#define	WT_STAT_CONN_CURSOR_INSERT_CHECK_ERROR		1416
 /*! cursor: cursor insert key and value bytes */
-#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1416
+#define	WT_STAT_CONN_CURSOR_INSERT_BYTES		1417
 /*! cursor: cursor largest key calls that return an error */
-#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1417
+#define	WT_STAT_CONN_CURSOR_LARGEST_KEY_ERROR		1418
 /*! cursor: cursor modify calls */
-#define	WT_STAT_CONN_CURSOR_MODIFY			1418
+#define	WT_STAT_CONN_CURSOR_MODIFY			1419
 /*! cursor: cursor modify calls that return an error */
-#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1419
+#define	WT_STAT_CONN_CURSOR_MODIFY_ERROR		1420
 /*! cursor: cursor modify key and value bytes affected */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1420
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES		1421
 /*! cursor: cursor modify value bytes modified */
-#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1421
+#define	WT_STAT_CONN_CURSOR_MODIFY_BYTES_TOUCH		1422
 /*! cursor: cursor next calls */
-#define	WT_STAT_CONN_CURSOR_NEXT			1422
+#define	WT_STAT_CONN_CURSOR_NEXT			1423
 /*! cursor: cursor next calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1423
+#define	WT_STAT_CONN_CURSOR_NEXT_ERROR			1424
 /*!
  * cursor: cursor next calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1424
+#define	WT_STAT_CONN_CURSOR_NEXT_HS_TOMBSTONE		1425
 /*!
  * cursor: cursor next calls that skip greater than 1 and fewer than 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1425
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_LT_100		1426
 /*!
  * cursor: cursor next calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1426
+#define	WT_STAT_CONN_CURSOR_NEXT_SKIP_GE_100		1427
 /*! cursor: cursor next random calls that return an error */
-#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1427
+#define	WT_STAT_CONN_CURSOR_NEXT_RANDOM_ERROR		1428
 /*! cursor: cursor operation restarted */
-#define	WT_STAT_CONN_CURSOR_RESTART			1428
+#define	WT_STAT_CONN_CURSOR_RESTART			1429
 /*! cursor: cursor prev calls */
-#define	WT_STAT_CONN_CURSOR_PREV			1429
+#define	WT_STAT_CONN_CURSOR_PREV			1430
 /*! cursor: cursor prev calls that return an error */
-#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1430
+#define	WT_STAT_CONN_CURSOR_PREV_ERROR			1431
 /*!
  * cursor: cursor prev calls that skip due to a globally visible history
  * store tombstone
  */
-#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1431
+#define	WT_STAT_CONN_CURSOR_PREV_HS_TOMBSTONE		1432
 /*!
  * cursor: cursor prev calls that skip greater than or equal to 100
  * entries
  */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1432
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_GE_100		1433
 /*! cursor: cursor prev calls that skip less than 100 entries */
-#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1433
+#define	WT_STAT_CONN_CURSOR_PREV_SKIP_LT_100		1434
 /*! cursor: cursor reconfigure calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1434
+#define	WT_STAT_CONN_CURSOR_RECONFIGURE_ERROR		1435
 /*! cursor: cursor remove calls */
-#define	WT_STAT_CONN_CURSOR_REMOVE			1435
+#define	WT_STAT_CONN_CURSOR_REMOVE			1436
 /*! cursor: cursor remove calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1436
+#define	WT_STAT_CONN_CURSOR_REMOVE_ERROR		1437
 /*! cursor: cursor remove key bytes removed */
-#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1437
+#define	WT_STAT_CONN_CURSOR_REMOVE_BYTES		1438
 /*! cursor: cursor reopen calls that return an error */
-#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1438
+#define	WT_STAT_CONN_CURSOR_REOPEN_ERROR		1439
 /*! cursor: cursor reserve calls */
-#define	WT_STAT_CONN_CURSOR_RESERVE			1439
+#define	WT_STAT_CONN_CURSOR_RESERVE			1440
 /*! cursor: cursor reserve calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1440
+#define	WT_STAT_CONN_CURSOR_RESERVE_ERROR		1441
 /*! cursor: cursor reset calls */
-#define	WT_STAT_CONN_CURSOR_RESET			1441
+#define	WT_STAT_CONN_CURSOR_RESET			1442
 /*! cursor: cursor reset calls that return an error */
-#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1442
+#define	WT_STAT_CONN_CURSOR_RESET_ERROR			1443
 /*! cursor: cursor search calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH			1443
+#define	WT_STAT_CONN_CURSOR_SEARCH			1444
 /*! cursor: cursor search calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1444
+#define	WT_STAT_CONN_CURSOR_SEARCH_ERROR		1445
 /*! cursor: cursor search history store calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1445
+#define	WT_STAT_CONN_CURSOR_SEARCH_HS			1446
 /*! cursor: cursor search near calls */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1446
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR			1447
 /*! cursor: cursor search near calls that return an error */
-#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1447
+#define	WT_STAT_CONN_CURSOR_SEARCH_NEAR_ERROR		1448
 /*! cursor: cursor sweep buckets */
-#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1448
+#define	WT_STAT_CONN_CURSOR_SWEEP_BUCKETS		1449
 /*! cursor: cursor sweep cursors closed */
-#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1449
+#define	WT_STAT_CONN_CURSOR_SWEEP_CLOSED		1450
 /*! cursor: cursor sweep cursors examined */
-#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1450
+#define	WT_STAT_CONN_CURSOR_SWEEP_EXAMINED		1451
 /*! cursor: cursor sweeps */
-#define	WT_STAT_CONN_CURSOR_SWEEP			1451
+#define	WT_STAT_CONN_CURSOR_SWEEP			1452
 /*! cursor: cursor truncate calls */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE			1452
+#define	WT_STAT_CONN_CURSOR_TRUNCATE			1453
 /*! cursor: cursor truncates performed on individual keys */
-#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1453
+#define	WT_STAT_CONN_CURSOR_TRUNCATE_KEYS_DELETED	1454
 /*! cursor: cursor update calls */
-#define	WT_STAT_CONN_CURSOR_UPDATE			1454
+#define	WT_STAT_CONN_CURSOR_UPDATE			1455
 /*! cursor: cursor update calls that return an error */
-#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1455
+#define	WT_STAT_CONN_CURSOR_UPDATE_ERROR		1456
 /*! cursor: cursor update key and value bytes */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1456
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES		1457
 /*! cursor: cursor update value size change */
-#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1457
+#define	WT_STAT_CONN_CURSOR_UPDATE_BYTES_CHANGED	1458
 /*! cursor: cursors reused from cache */
-#define	WT_STAT_CONN_CURSOR_REOPEN			1458
+#define	WT_STAT_CONN_CURSOR_REOPEN			1459
 /*! cursor: open cursor count */
-#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1459
+#define	WT_STAT_CONN_CURSOR_OPEN_COUNT			1460
 /*! data-handle: connection data handle size */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1460
+#define	WT_STAT_CONN_DH_CONN_HANDLE_SIZE		1461
 /*! data-handle: connection data handles currently active */
-#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1461
+#define	WT_STAT_CONN_DH_CONN_HANDLE_COUNT		1462
 /*! data-handle: connection sweep candidate became referenced */
-#define	WT_STAT_CONN_DH_SWEEP_REF			1462
+#define	WT_STAT_CONN_DH_SWEEP_REF			1463
 /*! data-handle: connection sweep dhandles closed */
-#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1463
+#define	WT_STAT_CONN_DH_SWEEP_CLOSE			1464
 /*! data-handle: connection sweep dhandles removed from hash list */
-#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1464
+#define	WT_STAT_CONN_DH_SWEEP_REMOVE			1465
 /*! data-handle: connection sweep time-of-death sets */
-#define	WT_STAT_CONN_DH_SWEEP_TOD			1465
+#define	WT_STAT_CONN_DH_SWEEP_TOD			1466
 /*! data-handle: connection sweeps */
-#define	WT_STAT_CONN_DH_SWEEPS				1466
+#define	WT_STAT_CONN_DH_SWEEPS				1467
 /*!
  * data-handle: connection sweeps skipped due to checkpoint gathering
  * handles
  */
-#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1467
+#define	WT_STAT_CONN_DH_SWEEP_SKIP_CKPT			1468
 /*! data-handle: session dhandles swept */
-#define	WT_STAT_CONN_DH_SESSION_HANDLES			1468
+#define	WT_STAT_CONN_DH_SESSION_HANDLES			1469
 /*! data-handle: session sweep attempts */
-#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1469
+#define	WT_STAT_CONN_DH_SESSION_SWEEPS			1470
 /*! lock: checkpoint lock acquisitions */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1470
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_COUNT		1471
 /*! lock: checkpoint lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1471
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_APPLICATION	1472
 /*! lock: checkpoint lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1472
+#define	WT_STAT_CONN_LOCK_CHECKPOINT_WAIT_INTERNAL	1473
 /*! lock: dhandle lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1473
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_APPLICATION	1474
 /*! lock: dhandle lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1474
+#define	WT_STAT_CONN_LOCK_DHANDLE_WAIT_INTERNAL		1475
 /*! lock: dhandle read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1475
+#define	WT_STAT_CONN_LOCK_DHANDLE_READ_COUNT		1476
 /*! lock: dhandle write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1476
+#define	WT_STAT_CONN_LOCK_DHANDLE_WRITE_COUNT		1477
 /*! lock: metadata lock acquisitions */
-#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1477
+#define	WT_STAT_CONN_LOCK_METADATA_COUNT		1478
 /*! lock: metadata lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1478
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_APPLICATION	1479
 /*! lock: metadata lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1479
+#define	WT_STAT_CONN_LOCK_METADATA_WAIT_INTERNAL	1480
 /*! lock: schema lock acquisitions */
-#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1480
+#define	WT_STAT_CONN_LOCK_SCHEMA_COUNT			1481
 /*! lock: schema lock application thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1481
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_APPLICATION	1482
 /*! lock: schema lock internal thread wait time (usecs) */
-#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1482
+#define	WT_STAT_CONN_LOCK_SCHEMA_WAIT_INTERNAL		1483
 /*!
  * lock: table lock application thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1483
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_APPLICATION	1484
 /*!
  * lock: table lock internal thread time waiting for the table lock
  * (usecs)
  */
-#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1484
+#define	WT_STAT_CONN_LOCK_TABLE_WAIT_INTERNAL		1485
 /*! lock: table read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1485
+#define	WT_STAT_CONN_LOCK_TABLE_READ_COUNT		1486
 /*! lock: table write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1486
+#define	WT_STAT_CONN_LOCK_TABLE_WRITE_COUNT		1487
 /*! lock: txn global lock application thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1487
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_APPLICATION	1488
 /*! lock: txn global lock internal thread time waiting (usecs) */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1488
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WAIT_INTERNAL	1489
 /*! lock: txn global read lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1489
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_READ_COUNT		1490
 /*! lock: txn global write lock acquisitions */
-#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1490
+#define	WT_STAT_CONN_LOCK_TXN_GLOBAL_WRITE_COUNT	1491
 /*! log: busy returns attempting to switch slots */
-#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1491
+#define	WT_STAT_CONN_LOG_SLOT_SWITCH_BUSY		1492
 /*! log: force log remove time sleeping (usecs) */
-#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1492
+#define	WT_STAT_CONN_LOG_FORCE_REMOVE_SLEEP		1493
 /*! log: log bytes of payload data */
-#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1493
+#define	WT_STAT_CONN_LOG_BYTES_PAYLOAD			1494
 /*! log: log bytes written */
-#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1494
+#define	WT_STAT_CONN_LOG_BYTES_WRITTEN			1495
 /*! log: log files manually zero-filled */
-#define	WT_STAT_CONN_LOG_ZERO_FILLS			1495
+#define	WT_STAT_CONN_LOG_ZERO_FILLS			1496
 /*! log: log flush operations */
-#define	WT_STAT_CONN_LOG_FLUSH				1496
+#define	WT_STAT_CONN_LOG_FLUSH				1497
 /*! log: log force write operations */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE			1497
+#define	WT_STAT_CONN_LOG_FORCE_WRITE			1498
 /*! log: log force write operations skipped */
-#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1498
+#define	WT_STAT_CONN_LOG_FORCE_WRITE_SKIP		1499
 /*! log: log records compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1499
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITES		1500
 /*! log: log records not compressed */
-#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1500
+#define	WT_STAT_CONN_LOG_COMPRESS_WRITE_FAILS		1501
 /*! log: log records too small to compress */
-#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1501
+#define	WT_STAT_CONN_LOG_COMPRESS_SMALL			1502
 /*! log: log release advances write LSN */
-#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1502
+#define	WT_STAT_CONN_LOG_RELEASE_WRITE_LSN		1503
 /*! log: log scan operations */
-#define	WT_STAT_CONN_LOG_SCANS				1503
+#define	WT_STAT_CONN_LOG_SCANS				1504
 /*! log: log scan records requiring two reads */
-#define	WT_STAT_CONN_LOG_SCAN_REREADS			1504
+#define	WT_STAT_CONN_LOG_SCAN_REREADS			1505
 /*! log: log server thread advances write LSN */
-#define	WT_STAT_CONN_LOG_WRITE_LSN			1505
+#define	WT_STAT_CONN_LOG_WRITE_LSN			1506
 /*! log: log server thread write LSN walk skipped */
-#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1506
+#define	WT_STAT_CONN_LOG_WRITE_LSN_SKIP			1507
 /*! log: log sync operations */
-#define	WT_STAT_CONN_LOG_SYNC				1507
+#define	WT_STAT_CONN_LOG_SYNC				1508
 /*! log: log sync time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DURATION			1508
+#define	WT_STAT_CONN_LOG_SYNC_DURATION			1509
 /*! log: log sync_dir operations */
-#define	WT_STAT_CONN_LOG_SYNC_DIR			1509
+#define	WT_STAT_CONN_LOG_SYNC_DIR			1510
 /*! log: log sync_dir time duration (usecs) */
-#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1510
+#define	WT_STAT_CONN_LOG_SYNC_DIR_DURATION		1511
 /*! log: log write operations */
-#define	WT_STAT_CONN_LOG_WRITES				1511
+#define	WT_STAT_CONN_LOG_WRITES				1512
 /*! log: logging bytes consolidated */
-#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1512
+#define	WT_STAT_CONN_LOG_SLOT_CONSOLIDATED		1513
 /*! log: maximum log file size */
-#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1513
+#define	WT_STAT_CONN_LOG_MAX_FILESIZE			1514
 /*! log: number of pre-allocated log files to create */
-#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1514
+#define	WT_STAT_CONN_LOG_PREALLOC_MAX			1515
 /*! log: pre-allocated log files not ready and missed */
-#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1515
+#define	WT_STAT_CONN_LOG_PREALLOC_MISSED		1516
 /*! log: pre-allocated log files prepared */
-#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1516
+#define	WT_STAT_CONN_LOG_PREALLOC_FILES			1517
 /*! log: pre-allocated log files used */
-#define	WT_STAT_CONN_LOG_PREALLOC_USED			1517
+#define	WT_STAT_CONN_LOG_PREALLOC_USED			1518
 /*! log: records processed by log scan */
-#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1518
+#define	WT_STAT_CONN_LOG_SCAN_RECORDS			1519
 /*! log: slot close lost race */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1519
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_RACE		1520
 /*! log: slot close unbuffered waits */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1520
+#define	WT_STAT_CONN_LOG_SLOT_CLOSE_UNBUF		1521
 /*! log: slot closures */
-#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1521
+#define	WT_STAT_CONN_LOG_SLOT_CLOSES			1522
 /*! log: slot join atomic update races */
-#define	WT_STAT_CONN_LOG_SLOT_RACES			1522
+#define	WT_STAT_CONN_LOG_SLOT_RACES			1523
 /*! log: slot join calls atomic updates raced */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1523
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_RACE		1524
 /*! log: slot join calls did not yield */
-#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1524
+#define	WT_STAT_CONN_LOG_SLOT_IMMEDIATE			1525
 /*! log: slot join calls found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1525
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_CLOSE		1526
 /*! log: slot join calls slept */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1526
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_SLEEP		1527
 /*! log: slot join calls yielded */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD			1527
+#define	WT_STAT_CONN_LOG_SLOT_YIELD			1528
 /*! log: slot join found active slot closed */
-#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1528
+#define	WT_STAT_CONN_LOG_SLOT_ACTIVE_CLOSED		1529
 /*! log: slot joins yield time (usecs) */
-#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1529
+#define	WT_STAT_CONN_LOG_SLOT_YIELD_DURATION		1530
 /*! log: slot transitions unable to find free slot */
-#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1530
+#define	WT_STAT_CONN_LOG_SLOT_NO_FREE_SLOTS		1531
 /*! log: slot unbuffered writes */
-#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1531
+#define	WT_STAT_CONN_LOG_SLOT_UNBUFFERED		1532
 /*! log: total in-memory size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1532
+#define	WT_STAT_CONN_LOG_COMPRESS_MEM			1533
 /*! log: total log buffer size */
-#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1533
+#define	WT_STAT_CONN_LOG_BUFFER_SIZE			1534
 /*! log: total size of compressed records */
-#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1534
+#define	WT_STAT_CONN_LOG_COMPRESS_LEN			1535
 /*! log: written slots coalesced */
-#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1535
+#define	WT_STAT_CONN_LOG_SLOT_COALESCED			1536
 /*! log: yields waiting for previous log file close */
-#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1536
+#define	WT_STAT_CONN_LOG_CLOSE_YIELDS			1537
 /*! perf: file system read latency histogram (bucket 1) - 0-10ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1537
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT10	1538
 /*! perf: file system read latency histogram (bucket 2) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1538
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT50	1539
 /*! perf: file system read latency histogram (bucket 3) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1539
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT100	1540
 /*! perf: file system read latency histogram (bucket 4) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1540
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT250	1541
 /*! perf: file system read latency histogram (bucket 5) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1541
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT500	1542
 /*! perf: file system read latency histogram (bucket 6) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1542
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_LT1000	1543
 /*! perf: file system read latency histogram (bucket 7) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1543
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_GT1000	1544
 /*! perf: file system read latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1544
+#define	WT_STAT_CONN_PERF_HIST_FSREAD_LATENCY_TOTAL_MSECS	1545
 /*! perf: file system write latency histogram (bucket 1) - 0-10ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1545
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT10	1546
 /*! perf: file system write latency histogram (bucket 2) - 10-49ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1546
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT50	1547
 /*! perf: file system write latency histogram (bucket 3) - 50-99ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1547
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT100	1548
 /*! perf: file system write latency histogram (bucket 4) - 100-249ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1548
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT250	1549
 /*! perf: file system write latency histogram (bucket 5) - 250-499ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1549
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT500	1550
 /*! perf: file system write latency histogram (bucket 6) - 500-999ms */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1550
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_LT1000	1551
 /*! perf: file system write latency histogram (bucket 7) - 1000ms+ */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1551
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_GT1000	1552
 /*! perf: file system write latency histogram total (msecs) */
-#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1552
+#define	WT_STAT_CONN_PERF_HIST_FSWRITE_LATENCY_TOTAL_MSECS	1553
 /*! perf: operation read latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1553
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT100	1554
 /*! perf: operation read latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1554
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT250	1555
 /*! perf: operation read latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1555
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT500	1556
 /*! perf: operation read latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1556
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT1000	1557
 /*! perf: operation read latency histogram (bucket 5) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1557
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_LT10000	1558
 /*! perf: operation read latency histogram (bucket 6) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1558
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_GT10000	1559
 /*! perf: operation read latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1559
+#define	WT_STAT_CONN_PERF_HIST_OPREAD_LATENCY_TOTAL_USECS	1560
 /*! perf: operation write latency histogram (bucket 1) - 0-100us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1560
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT100	1561
 /*! perf: operation write latency histogram (bucket 2) - 100-249us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1561
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT250	1562
 /*! perf: operation write latency histogram (bucket 3) - 250-499us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1562
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT500	1563
 /*! perf: operation write latency histogram (bucket 4) - 500-999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1563
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT1000	1564
 /*! perf: operation write latency histogram (bucket 5) - 1000-9999us */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1564
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_LT10000	1565
 /*! perf: operation write latency histogram (bucket 6) - 10000us+ */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1565
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_GT10000	1566
 /*! perf: operation write latency histogram total (usecs) */
-#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1566
+#define	WT_STAT_CONN_PERF_HIST_OPWRITE_LATENCY_TOTAL_USECS	1567
 /*! prefetch: could not perform pre-fetch on internal page */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1567
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_PAGE	1568
 /*!
  * prefetch: could not perform pre-fetch on ref without the pre-fetch
  * flag set
  */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1568
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_FLAG_SET	1569
 /*! prefetch: number of times pre-fetch failed to start */
-#define	WT_STAT_CONN_PREFETCH_FAILED_START		1569
+#define	WT_STAT_CONN_PREFETCH_FAILED_START		1570
 /*! prefetch: pre-fetch not repeating for recently pre-fetched ref */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1570
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SAME_REF		1571
 /*! prefetch: pre-fetch not triggered after single disk read */
-#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1571
+#define	WT_STAT_CONN_PREFETCH_DISK_ONE			1572
 /*! prefetch: pre-fetch not triggered as there is no valid dhandle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1572
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_NO_VALID_DHANDLE	1573
 /*! prefetch: pre-fetch not triggered by page read */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED			1573
+#define	WT_STAT_CONN_PREFETCH_SKIPPED			1574
 /*! prefetch: pre-fetch not triggered due to disk read count */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1574
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_DISK_READ_COUNT	1575
 /*! prefetch: pre-fetch not triggered due to internal session */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1575
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_INTERNAL_SESSION	1576
 /*! prefetch: pre-fetch not triggered due to special btree handle */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1576
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_SPECIAL_HANDLE	1577
 /*! prefetch: pre-fetch page not on disk when reading */
-#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1577
+#define	WT_STAT_CONN_PREFETCH_PAGES_FAIL		1578
 /*! prefetch: pre-fetch pages queued */
-#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1578
+#define	WT_STAT_CONN_PREFETCH_PAGES_QUEUED		1579
 /*! prefetch: pre-fetch pages read in background */
-#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1579
+#define	WT_STAT_CONN_PREFETCH_PAGES_READ		1580
 /*! prefetch: pre-fetch skipped reading in a page due to harmless error */
-#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1580
+#define	WT_STAT_CONN_PREFETCH_SKIPPED_ERROR_OK		1581
 /*! prefetch: pre-fetch triggered by page read */
-#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1581
+#define	WT_STAT_CONN_PREFETCH_ATTEMPTS			1582
 /*! reconciliation: VLCS pages explicitly reconciled as empty */
-#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1582
+#define	WT_STAT_CONN_REC_VLCS_EMPTIED_PAGES		1583
 /*! reconciliation: approximate byte size of timestamps in pages written */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1583
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TS		1584
 /*!
  * reconciliation: approximate byte size of transaction IDs in pages
  * written
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1584
+#define	WT_STAT_CONN_REC_TIME_WINDOW_BYTES_TXN		1585
 /*! reconciliation: cursor next/prev calls during HS wrapup search_near */
-#define	WT_STAT_CONN_REC_HS_WRAPUP_NEXT_PREV_CALLS	1585
+#define	WT_STAT_CONN_REC_HS_WRAPUP_NEXT_PREV_CALLS	1586
 /*! reconciliation: fast-path pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1586
+#define	WT_STAT_CONN_REC_PAGE_DELETE_FAST		1587
 /*! reconciliation: leaf-page overflow keys */
-#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1587
+#define	WT_STAT_CONN_REC_OVERFLOW_KEY_LEAF		1588
 /*! reconciliation: maximum milliseconds spent in a reconciliation call */
-#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1588
+#define	WT_STAT_CONN_REC_MAXIMUM_MILLISECONDS		1589
 /*!
  * reconciliation: maximum milliseconds spent in building a disk image in
  * a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1589
+#define	WT_STAT_CONN_REC_MAXIMUM_IMAGE_BUILD_MILLISECONDS	1590
 /*!
  * reconciliation: maximum milliseconds spent in moving updates to the
  * history store in a reconciliation
  */
-#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1590
+#define	WT_STAT_CONN_REC_MAXIMUM_HS_WRAPUP_MILLISECONDS	1591
 /*! reconciliation: overflow values written */
-#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1591
+#define	WT_STAT_CONN_REC_OVERFLOW_VALUE			1592
 /*! reconciliation: page reconciliation calls */
-#define	WT_STAT_CONN_REC_PAGES				1592
+#define	WT_STAT_CONN_REC_PAGES				1593
 /*! reconciliation: page reconciliation calls for eviction */
-#define	WT_STAT_CONN_REC_PAGES_EVICTION			1593
+#define	WT_STAT_CONN_REC_PAGES_EVICTION			1594
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * prepared transaction metadata
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1594
+#define	WT_STAT_CONN_REC_PAGES_WITH_PREPARE		1595
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * timestamps
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1595
+#define	WT_STAT_CONN_REC_PAGES_WITH_TS			1596
 /*!
  * reconciliation: page reconciliation calls that resulted in values with
  * transaction ids
  */
-#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1596
+#define	WT_STAT_CONN_REC_PAGES_WITH_TXN			1597
 /*! reconciliation: pages deleted */
-#define	WT_STAT_CONN_REC_PAGE_DELETE			1597
+#define	WT_STAT_CONN_REC_PAGE_DELETE			1598
 /*!
  * reconciliation: pages written including an aggregated newest start
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1598
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_START_DURABLE_TS	1599
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * durable timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1599
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_DURABLE_TS	1600
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1600
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TS	1601
 /*!
  * reconciliation: pages written including an aggregated newest stop
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1601
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_STOP_TXN	1602
 /*!
  * reconciliation: pages written including an aggregated newest
  * transaction ID
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1602
+#define	WT_STAT_CONN_REC_TIME_AGGR_NEWEST_TXN		1603
 /*!
  * reconciliation: pages written including an aggregated oldest start
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1603
+#define	WT_STAT_CONN_REC_TIME_AGGR_OLDEST_START_TS	1604
 /*! reconciliation: pages written including an aggregated prepare */
-#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1604
+#define	WT_STAT_CONN_REC_TIME_AGGR_PREPARED		1605
 /*! reconciliation: pages written including at least one prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1605
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_PREPARED	1606
 /*!
  * reconciliation: pages written including at least one start durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1606
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_START_TS	1607
 /*! reconciliation: pages written including at least one start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1607
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TS	1608
 /*!
  * reconciliation: pages written including at least one start transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1608
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_START_TXN	1609
 /*!
  * reconciliation: pages written including at least one stop durable
  * timestamp
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1609
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_DURABLE_STOP_TS	1610
 /*! reconciliation: pages written including at least one stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1610
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TS	1611
 /*!
  * reconciliation: pages written including at least one stop transaction
  * ID
  */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1611
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PAGES_STOP_TXN	1612
 /*! reconciliation: records written including a prepare state */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1612
+#define	WT_STAT_CONN_REC_TIME_WINDOW_PREPARED		1613
 /*! reconciliation: records written including a start durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1613
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_START_TS	1614
 /*! reconciliation: records written including a start timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1614
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TS		1615
 /*! reconciliation: records written including a start transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1615
+#define	WT_STAT_CONN_REC_TIME_WINDOW_START_TXN		1616
 /*! reconciliation: records written including a stop durable timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1616
+#define	WT_STAT_CONN_REC_TIME_WINDOW_DURABLE_STOP_TS	1617
 /*! reconciliation: records written including a stop timestamp */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1617
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TS		1618
 /*! reconciliation: records written including a stop transaction ID */
-#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1618
+#define	WT_STAT_CONN_REC_TIME_WINDOW_STOP_TXN		1619
 /*! reconciliation: split bytes currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1619
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_BYTES		1620
 /*! reconciliation: split objects currently awaiting free */
-#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1620
+#define	WT_STAT_CONN_REC_SPLIT_STASHED_OBJECTS		1621
 /*! session: attempts to remove a local object and the object is in use */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1621
+#define	WT_STAT_CONN_LOCAL_OBJECTS_INUSE		1622
 /*! session: flush_tier failed calls */
-#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1622
+#define	WT_STAT_CONN_FLUSH_TIER_FAIL			1623
 /*! session: flush_tier operation calls */
-#define	WT_STAT_CONN_FLUSH_TIER				1623
+#define	WT_STAT_CONN_FLUSH_TIER				1624
 /*! session: flush_tier tables skipped due to no checkpoint */
-#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1624
+#define	WT_STAT_CONN_FLUSH_TIER_SKIPPED			1625
 /*! session: flush_tier tables switched */
-#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1625
+#define	WT_STAT_CONN_FLUSH_TIER_SWITCHED		1626
 /*! session: local objects removed */
-#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1626
+#define	WT_STAT_CONN_LOCAL_OBJECTS_REMOVED		1627
 /*! session: open session count */
-#define	WT_STAT_CONN_SESSION_OPEN			1627
+#define	WT_STAT_CONN_SESSION_OPEN			1628
 /*! session: session query timestamp calls */
-#define	WT_STAT_CONN_SESSION_QUERY_TS			1628
+#define	WT_STAT_CONN_SESSION_QUERY_TS			1629
 /*! session: table alter failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1629
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_FAIL		1630
 /*! session: table alter successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1630
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SUCCESS	1631
 /*! session: table alter triggering checkpoint calls */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1631
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_TRIGGER_CHECKPOINT	1632
 /*! session: table alter unchanged and skipped */
-#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1632
+#define	WT_STAT_CONN_SESSION_TABLE_ALTER_SKIP		1633
 /*! session: table compact conflicted with checkpoint */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1633
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_CONFLICTING_CHECKPOINT	1634
 /*! session: table compact dhandle successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1634
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_DHANDLE_SUCCESS	1635
 /*! session: table compact failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1635
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL		1636
 /*! session: table compact failed calls due to cache pressure */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1636
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_FAIL_CACHE_PRESSURE	1637
 /*! session: table compact passes */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1637
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_PASSES	1638
 /*! session: table compact pulled into eviction */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1638
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_EVICTION	1639
 /*! session: table compact running */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1639
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_RUNNING	1640
 /*! session: table compact skipped as process would not reduce file size */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1640
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SKIPPED	1641
 /*! session: table compact successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1641
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_SUCCESS	1642
 /*! session: table compact timeout */
-#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1642
+#define	WT_STAT_CONN_SESSION_TABLE_COMPACT_TIMEOUT	1643
 /*! session: table create failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1643
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_FAIL		1644
 /*! session: table create successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1644
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_SUCCESS	1645
 /*! session: table create with import failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1645
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_FAIL	1646
 /*! session: table create with import repair calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1646
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_REPAIR	1647
 /*! session: table create with import successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1647
+#define	WT_STAT_CONN_SESSION_TABLE_CREATE_IMPORT_SUCCESS	1648
 /*! session: table drop failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1648
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_FAIL		1649
 /*! session: table drop successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1649
+#define	WT_STAT_CONN_SESSION_TABLE_DROP_SUCCESS		1650
 /*! session: table rename failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1650
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_FAIL		1651
 /*! session: table rename successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1651
+#define	WT_STAT_CONN_SESSION_TABLE_RENAME_SUCCESS	1652
 /*! session: table salvage failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1652
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_FAIL		1653
 /*! session: table salvage successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1653
+#define	WT_STAT_CONN_SESSION_TABLE_SALVAGE_SUCCESS	1654
 /*! session: table truncate failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1654
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_FAIL	1655
 /*! session: table truncate successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1655
+#define	WT_STAT_CONN_SESSION_TABLE_TRUNCATE_SUCCESS	1656
 /*! session: table verify failed calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1656
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_FAIL		1657
 /*! session: table verify successful calls */
-#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1657
+#define	WT_STAT_CONN_SESSION_TABLE_VERIFY_SUCCESS	1658
 /*! session: tiered operations dequeued and processed */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1658
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_DEQUEUED		1659
 /*! session: tiered operations removed without processing */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1659
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_REMOVED		1660
 /*! session: tiered operations scheduled */
-#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1660
+#define	WT_STAT_CONN_TIERED_WORK_UNITS_CREATED		1661
 /*! session: tiered storage local retention time (secs) */
-#define	WT_STAT_CONN_TIERED_RETENTION			1661
+#define	WT_STAT_CONN_TIERED_RETENTION			1662
 /*! thread-state: active filesystem fsync calls */
-#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1662
+#define	WT_STAT_CONN_THREAD_FSYNC_ACTIVE		1663
 /*! thread-state: active filesystem read calls */
-#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1663
+#define	WT_STAT_CONN_THREAD_READ_ACTIVE			1664
 /*! thread-state: active filesystem write calls */
-#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1664
+#define	WT_STAT_CONN_THREAD_WRITE_ACTIVE		1665
 /*! thread-yield: application thread operations waiting for cache */
-#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1665
+#define	WT_STAT_CONN_APPLICATION_CACHE_OPS		1666
 /*! thread-yield: application thread snapshot refreshed for eviction */
-#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1666
+#define	WT_STAT_CONN_APPLICATION_EVICT_SNAPSHOT_REFRESHED	1667
 /*! thread-yield: application thread time waiting for cache (usecs) */
-#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1667
+#define	WT_STAT_CONN_APPLICATION_CACHE_TIME		1668
 /*!
  * thread-yield: connection close blocked waiting for transaction state
  * stabilization
  */
-#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1668
+#define	WT_STAT_CONN_TXN_RELEASE_BLOCKED		1669
 /*! thread-yield: connection close yielded for lsm manager shutdown */
-#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1669
+#define	WT_STAT_CONN_CONN_CLOSE_BLOCKED_LSM		1670
 /*! thread-yield: data handle lock yielded */
-#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1670
+#define	WT_STAT_CONN_DHANDLE_LOCK_BLOCKED		1671
 /*!
  * thread-yield: get reference for page index and slot time sleeping
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1671
+#define	WT_STAT_CONN_PAGE_INDEX_SLOT_REF_BLOCKED	1672
 /*! thread-yield: page access yielded due to prepare state change */
-#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1672
+#define	WT_STAT_CONN_PREPARED_TRANSITION_BLOCKED_PAGE	1673
 /*! thread-yield: page acquire busy blocked */
-#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1673
+#define	WT_STAT_CONN_PAGE_BUSY_BLOCKED			1674
 /*! thread-yield: page acquire eviction blocked */
-#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1674
+#define	WT_STAT_CONN_PAGE_FORCIBLE_EVICT_BLOCKED	1675
 /*! thread-yield: page acquire locked blocked */
-#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1675
+#define	WT_STAT_CONN_PAGE_LOCKED_BLOCKED		1676
 /*! thread-yield: page acquire read blocked */
-#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1676
+#define	WT_STAT_CONN_PAGE_READ_BLOCKED			1677
 /*! thread-yield: page acquire time sleeping (usecs) */
-#define	WT_STAT_CONN_PAGE_SLEEP				1677
+#define	WT_STAT_CONN_PAGE_SLEEP				1678
 /*!
  * thread-yield: page delete rollback time sleeping for state change
  * (usecs)
  */
-#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1678
+#define	WT_STAT_CONN_PAGE_DEL_ROLLBACK_BLOCKED		1679
 /*! thread-yield: page reconciliation yielded due to child modification */
-#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1679
+#define	WT_STAT_CONN_CHILD_MODIFY_BLOCKED_PAGE		1680
 /*! thread-yield: page split and restart read */
-#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1680
+#define	WT_STAT_CONN_PAGE_SPLIT_RESTART			1681
 /*! thread-yield: pages skipped during read due to deleted state */
-#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1681
+#define	WT_STAT_CONN_PAGE_READ_SKIP_DELETED		1682
 /*! transaction: Number of prepared updates */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1682
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES		1683
 /*! transaction: Number of prepared updates committed */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1683
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_COMMITTED	1684
 /*! transaction: Number of prepared updates repeated on the same key */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1684
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_KEY_REPEATED	1685
 /*! transaction: Number of prepared updates rolled back */
-#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1685
+#define	WT_STAT_CONN_TXN_PREPARED_UPDATES_ROLLEDBACK	1686
 /*!
  * transaction: a reader raced with a prepared transaction commit and
  * skipped an update or updates
  */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1686
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_COMMIT	1687
 /*! transaction: number of times overflow removed value is read */
-#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1687
+#define	WT_STAT_CONN_TXN_READ_OVERFLOW_REMOVE		1688
 /*! transaction: oldest pinned transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1688
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_PINNED		1689
 /*! transaction: oldest transaction ID rolled back for eviction */
-#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1689
+#define	WT_STAT_CONN_TXN_ROLLBACK_OLDEST_ID		1690
 /*! transaction: prepared transactions */
-#define	WT_STAT_CONN_TXN_PREPARE			1690
+#define	WT_STAT_CONN_TXN_PREPARE			1691
 /*! transaction: prepared transactions committed */
-#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1691
+#define	WT_STAT_CONN_TXN_PREPARE_COMMIT			1692
 /*! transaction: prepared transactions currently active */
-#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1692
+#define	WT_STAT_CONN_TXN_PREPARE_ACTIVE			1693
 /*! transaction: prepared transactions rolled back */
-#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1693
+#define	WT_STAT_CONN_TXN_PREPARE_ROLLBACK		1694
 /*! transaction: query timestamp calls */
-#define	WT_STAT_CONN_TXN_QUERY_TS			1694
+#define	WT_STAT_CONN_TXN_QUERY_TS			1695
 /*! transaction: race to read prepared update retry */
-#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1695
+#define	WT_STAT_CONN_TXN_READ_RACE_PREPARE_UPDATE	1696
 /*! transaction: rollback to stable calls */
-#define	WT_STAT_CONN_TXN_RTS				1696
+#define	WT_STAT_CONN_TXN_RTS				1697
 /*!
  * transaction: rollback to stable history store keys that would have
  * been swept in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1697
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS_DRYRUN	1698
 /*!
  * transaction: rollback to stable history store records with stop
  * timestamps older than newer records
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1698
+#define	WT_STAT_CONN_TXN_RTS_HS_STOP_OLDER_THAN_NEWER_START	1699
 /*! transaction: rollback to stable inconsistent checkpoint */
-#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1699
+#define	WT_STAT_CONN_TXN_RTS_INCONSISTENT_CKPT		1700
 /*! transaction: rollback to stable keys removed */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1700
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED		1701
 /*! transaction: rollback to stable keys restored */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1701
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED		1702
 /*!
  * transaction: rollback to stable keys that would have been removed in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1702
+#define	WT_STAT_CONN_TXN_RTS_KEYS_REMOVED_DRYRUN	1703
 /*!
  * transaction: rollback to stable keys that would have been restored in
  * non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1703
+#define	WT_STAT_CONN_TXN_RTS_KEYS_RESTORED_DRYRUN	1704
 /*! transaction: rollback to stable pages visited */
-#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1704
+#define	WT_STAT_CONN_TXN_RTS_PAGES_VISITED		1705
 /*! transaction: rollback to stable restored tombstones from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1705
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES	1706
 /*! transaction: rollback to stable restored updates from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1706
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES		1707
 /*! transaction: rollback to stable skipping delete rle */
-#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1707
+#define	WT_STAT_CONN_TXN_RTS_DELETE_RLE_SKIPPED		1708
 /*! transaction: rollback to stable skipping stable rle */
-#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1708
+#define	WT_STAT_CONN_TXN_RTS_STABLE_RLE_SKIPPED		1709
 /*! transaction: rollback to stable sweeping history store keys */
-#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1709
+#define	WT_STAT_CONN_TXN_RTS_SWEEP_HS_KEYS		1710
 /*!
  * transaction: rollback to stable tombstones from history store that
  * would have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1710
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_TOMBSTONES_DRYRUN	1711
 /*! transaction: rollback to stable tree walk skipping pages */
-#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1711
+#define	WT_STAT_CONN_TXN_RTS_TREE_WALK_SKIP_PAGES	1712
 /*! transaction: rollback to stable updates aborted */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1712
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED		1713
 /*!
  * transaction: rollback to stable updates from history store that would
  * have been restored in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1713
+#define	WT_STAT_CONN_TXN_RTS_HS_RESTORE_UPDATES_DRYRUN	1714
 /*! transaction: rollback to stable updates removed from history store */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1714
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED			1715
 /*!
  * transaction: rollback to stable updates that would have been aborted
  * in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1715
+#define	WT_STAT_CONN_TXN_RTS_UPD_ABORTED_DRYRUN		1716
 /*!
  * transaction: rollback to stable updates that would have been removed
  * from history store in non-dryrun mode
  */
-#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1716
+#define	WT_STAT_CONN_TXN_RTS_HS_REMOVED_DRYRUN		1717
 /*! transaction: sessions scanned in each walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1717
+#define	WT_STAT_CONN_TXN_SESSIONS_WALKED		1718
 /*! transaction: set timestamp calls */
-#define	WT_STAT_CONN_TXN_SET_TS				1718
+#define	WT_STAT_CONN_TXN_SET_TS				1719
 /*! transaction: set timestamp durable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1719
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE			1720
 /*! transaction: set timestamp durable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1720
+#define	WT_STAT_CONN_TXN_SET_TS_DURABLE_UPD		1721
 /*! transaction: set timestamp force calls */
-#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1721
+#define	WT_STAT_CONN_TXN_SET_TS_FORCE			1722
 /*!
  * transaction: set timestamp global oldest timestamp set to be more
  * recent than the global stable timestamp
  */
-#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1722
+#define	WT_STAT_CONN_TXN_SET_TS_OUT_OF_ORDER		1723
 /*! transaction: set timestamp oldest calls */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1723
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST			1724
 /*! transaction: set timestamp oldest updates */
-#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1724
+#define	WT_STAT_CONN_TXN_SET_TS_OLDEST_UPD		1725
 /*! transaction: set timestamp stable calls */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1725
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE			1726
 /*! transaction: set timestamp stable updates */
-#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1726
+#define	WT_STAT_CONN_TXN_SET_TS_STABLE_UPD		1727
 /*! transaction: transaction begins */
-#define	WT_STAT_CONN_TXN_BEGIN				1727
+#define	WT_STAT_CONN_TXN_BEGIN				1728
 /*!
  * transaction: transaction checkpoint history store file duration
  * (usecs)
  */
-#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1728
+#define	WT_STAT_CONN_TXN_HS_CKPT_DURATION		1729
 /*! transaction: transaction range of IDs currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_RANGE			1729
+#define	WT_STAT_CONN_TXN_PINNED_RANGE			1730
 /*! transaction: transaction range of IDs currently pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1730
+#define	WT_STAT_CONN_TXN_PINNED_CHECKPOINT_RANGE	1731
 /*! transaction: transaction range of timestamps currently pinned */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1731
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP		1732
 /*! transaction: transaction range of timestamps pinned by a checkpoint */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1732
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_CHECKPOINT	1733
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * active read timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1733
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_READER	1734
 /*!
  * transaction: transaction range of timestamps pinned by the oldest
  * timestamp
  */
-#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1734
+#define	WT_STAT_CONN_TXN_PINNED_TIMESTAMP_OLDEST	1735
 /*! transaction: transaction read timestamp of the oldest active reader */
-#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1735
+#define	WT_STAT_CONN_TXN_TIMESTAMP_OLDEST_ACTIVE_READ	1736
 /*! transaction: transaction rollback to stable currently running */
-#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1736
+#define	WT_STAT_CONN_TXN_ROLLBACK_TO_STABLE_RUNNING	1737
 /*! transaction: transaction walk of concurrent sessions */
-#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1737
+#define	WT_STAT_CONN_TXN_WALK_SESSIONS			1738
 /*! transaction: transactions committed */
-#define	WT_STAT_CONN_TXN_COMMIT				1738
+#define	WT_STAT_CONN_TXN_COMMIT				1739
 /*! transaction: transactions rolled back */
-#define	WT_STAT_CONN_TXN_ROLLBACK			1739
+#define	WT_STAT_CONN_TXN_ROLLBACK			1740
 /*! transaction: update conflicts */
-#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1740
+#define	WT_STAT_CONN_TXN_UPDATE_CONFLICT		1741
 
 /*!
  * @}

--- a/src/support/stat.c
+++ b/src/support/stat.c
@@ -1567,6 +1567,7 @@ static const char *const __stats_connection_desc[] = {
   "cache: bytes not belonging to page images in the cache",
   "cache: bytes read into cache",
   "cache: bytes written from cache",
+  "cache: cache tolerance configured",
   "cache: checkpoint blocked page eviction",
   "cache: checkpoint of history store file blocked non-history store page eviction",
   "cache: evict page attempts by eviction server",
@@ -2378,6 +2379,7 @@ __wt_stat_connection_clear_single(WT_CONNECTION_STATS *stats)
     /* not clearing cache_bytes_other */
     stats->cache_bytes_read = 0;
     stats->cache_bytes_write = 0;
+    /* not clearing cache_tolerance_level */
     stats->cache_eviction_blocked_checkpoint = 0;
     stats->cache_eviction_blocked_checkpoint_hs = 0;
     stats->eviction_server_evict_attempt = 0;
@@ -3143,6 +3145,7 @@ __wt_stat_connection_aggregate(WT_CONNECTION_STATS **from, WT_CONNECTION_STATS *
     to->cache_bytes_other += WT_STAT_READ(from, cache_bytes_other);
     to->cache_bytes_read += WT_STAT_READ(from, cache_bytes_read);
     to->cache_bytes_write += WT_STAT_READ(from, cache_bytes_write);
+    to->cache_tolerance_level += WT_STAT_READ(from, cache_tolerance_level);
     to->cache_eviction_blocked_checkpoint += WT_STAT_READ(from, cache_eviction_blocked_checkpoint);
     to->cache_eviction_blocked_checkpoint_hs +=
       WT_STAT_READ(from, cache_eviction_blocked_checkpoint_hs);


### PR DESCRIPTION
The change is to add a stat to represent the cache tolerance configured.\nThis will be used to monitor the atlas clusters that run the cache tolerance feature (non-zero value).\nThis stat can also be used to as anchor point to develop mongotune policy to automatically tune the cache tolerance.\n\nBackport of WT-16453.