### PR TITLE
WT-16612 Fix the error for update calculation in __evict_is_session_cache_trigger_tolerant (8.0)

### DIFF
--- a/src/include/cache_inline.h
+++ b/src/include/cache_inline.h
@@ -562,7 +562,7 @@ __evict_is_session_cache_trigger_tolerant(WT_SESSION_IMPL *session, uint8_t cach
 
     if (bytes_updates > bytes_updates_trigger) {
         /* Updates content is more than update trigger. */
-        bytes_over_updates_trigger = bytes_dirty - bytes_dirty_trigger;
+        bytes_over_updates_trigger = bytes_updates - bytes_updates_trigger;
 
         if (bytes_over_updates_trigger > bytes_updates_tolerance) {
             /* More than 100% of tolerance level. 100% of the app threads are non-tolerant. */


### PR DESCRIPTION
Cherry-pick of 59cb966f862b2d697d7e46dc9cf60f65ce7acecd for BACKPORT-26847

Co-authored-by: Vamsi Krishna <vamsi.krishna@mongodb.com>