### PR TITLE
WT-18247 Tolerate a drop already applied by checkpoint pick-up

### DIFF
--- a/test/csuite/schema_disagg_abort/worker.c
+++ b/test/csuite/schema_disagg_abort/worker.c
@@ -108,6 +108,10 @@ schema_op_execute(WT_SESSION *session, const SCHEMA_EVENT *ev)
               ev->uri, MAX_STARTUP);
         __wt_yield();
     }
+    /* The checkpoint pick-up may have already applied this drop, so a missing table is success. */
+    if (!is_create && ret == ENOENT)
+        ret = 0;
+
     testutil_assertfmt(ret == 0, "%s %s (ts %" PRIu64 "): %s", is_create ? "CREATE" : "DROP",
       ev->uri, ev->event_ts, wiredtiger_strerror(ret));
 }


### PR DESCRIPTION
`test/csuite/schema_disagg_abort` fails intermittently when a node applies the same layered table drop twice.

A node learns about a drop through two paths. Checkpoint pick-up replays the leader's drop from shared metadata, and the relayed schema event applies it directly. The schema lock serialises the two, so whichever runs second finds the
table already gone and `WT_SESSION::drop` returns ENOENT. The test treated that as fatal. Instead`schema_op_execute` now treats ENOENT on a drop as success. 