### PR TITLE
WT-18116 Enable synchronous (Elegant) Step-Down in WT test/python

### DIFF
--- a/test/suite/test_layered_config11.py
+++ b/test/suite/test_layered_config11.py
@@ -77,10 +77,7 @@ class test_layered_config11(wttest.WiredTigerTestCase, DisaggConfigMixin):
 
         self.session.checkpoint()
 
-        follower_config = self.conn_base_config + 'disaggregated=(role="follower")'
-        self.reopen_conn(config=follower_config)
-
-        cursor = self.session.open_cursor(uri, None, None)
+        self.conn.reconfigure('disaggregated=(role="follower")')
 
         for i in range(self.nitems):
             self.assertEqual(cursor["Hello " + str(i)], "World")

--- a/test/suite/test_layered_cursor02.py
+++ b/test/suite/test_layered_cursor02.py
@@ -69,10 +69,8 @@ class test_layered_cursor02(wttest.WiredTigerTestCase, DisaggConfigMixin):
 
         self.session.checkpoint()
 
-        # We don't need a second WT to test what we want -- reopen the existing
-        # one and tell it to grab the latest checkpoint.
-        self.reopen_conn(config=self.conn_base_config + f'disaggregated=(role="follower",checkpoint_meta="{self.disagg_get_complete_checkpoint_meta()}")')
-        c = self.session.open_cursor(self.uri)
+        # Step down to a follower via a live reconfigure instead of restarting.
+        self.conn.reconfigure('disaggregated=(role="follower")')
 
         for k in range(1000):
             (oldv, mods, newv) = create_mods(r, size, repeats, nmods, maxdiff, self.valuefmt, old_vals[k])

--- a/test/suite/test_layered_cursor06.py
+++ b/test/suite/test_layered_cursor06.py
@@ -66,9 +66,7 @@ class test_layered_cursor06(wttest.WiredTigerTestCase):
         self.assertEqual(random_cursor.next(), 0)
         random_cursor.close()
 
-        follower_config = self.conn_base_config + 'disaggregated=(role="follower",' +\
-            f'checkpoint_meta="{self.disagg_get_complete_checkpoint_meta()}")'
-        self.reopen_conn(config = follower_config)
+        self.conn.reconfigure('disaggregated=(role="follower")')
 
         random_cursor = self.session.open_cursor(self.uri, None, "next_random=true")
         self.assertEqual(random_cursor.next(), 0)

--- a/test/suite/test_layered_cursor21.py
+++ b/test/suite/test_layered_cursor21.py
@@ -77,11 +77,7 @@ class test_layered_cursor21(wttest.WiredTigerTestCase):
         self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(10)}')
         self.session.checkpoint()
 
-        follower_config = (
-            'disaggregated=(role="follower",'
-            f'checkpoint_meta="{self.disagg_get_complete_checkpoint_meta()}")'
-        )
-        self.reopen_conn(config=follower_config)
+        self.conn.reconfigure('disaggregated=(role="follower")')
 
     def truncate_range(self, start, stop, ts):
         c1 = self.session.open_cursor(self.uri)
@@ -164,11 +160,7 @@ class test_layered_cursor21(wttest.WiredTigerTestCase):
         self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(20)}')
         self.session.checkpoint()
 
-        follower_config = (
-            'disaggregated=(role="follower",'
-            f'checkpoint_meta="{self.disagg_get_complete_checkpoint_meta()}")'
-        )
-        self.reopen_conn(config=follower_config)
+        self.conn.reconfigure('disaggregated=(role="follower")')
 
         # Follower-side truncate: tombstones land in ingest.
         self.truncate_range(self.nitems, 2 * self.nitems - 1, 30)
@@ -191,11 +183,7 @@ class test_layered_cursor21(wttest.WiredTigerTestCase):
         self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(20)}')
         self.session.checkpoint()
 
-        follower_config = (
-            'disaggregated=(role="follower",'
-            f'checkpoint_meta="{self.disagg_get_complete_checkpoint_meta()}")'
-        )
-        self.reopen_conn(config=follower_config)
+        self.conn.reconfigure('disaggregated=(role="follower")')
 
         # Follower-side remove: tombstones land in ingest.
         self.remove_range(self.nitems, 2 * self.nitems - 1, 30)

--- a/test/suite/test_layered_delta01.py
+++ b/test/suite/test_layered_delta01.py
@@ -100,11 +100,7 @@ class test_layered_delta01(wttest.WiredTigerTestCase):
 
         self.assertStatGreaterSoon(stat.conn.rec_page_delta_leaf, 0)
 
-        follower_config = self.conn_base_config + 'disaggregated=(role="follower",' +\
-            f'checkpoint_meta="{self.disagg_get_complete_checkpoint_meta()}")'
-        self.reopen_conn(config = follower_config)
-
-        cursor = self.session.open_cursor(self.uri, None, None)
+        self.conn.reconfigure('disaggregated=(role="follower")')
 
         self.session.begin_transaction("read_timestamp=" + self.timestamp_str(5))
         for i in range(self.nitems):
@@ -148,11 +144,7 @@ class test_layered_delta01(wttest.WiredTigerTestCase):
 
         self.assertStatGreaterSoon(stat.conn.rec_page_delta_leaf, 0)
 
-        follower_config = self.conn_base_config + 'disaggregated=(role="follower",' +\
-            f'checkpoint_meta="{self.disagg_get_complete_checkpoint_meta()}")'
-        self.reopen_conn(config = follower_config)
-
-        cursor = self.session.open_cursor(self.uri, None, None)
+        self.conn.reconfigure('disaggregated=(role="follower")')
 
         self.session.begin_transaction("read_timestamp=" + self.timestamp_str(5))
         for i in range(self.nitems):
@@ -195,11 +187,7 @@ class test_layered_delta01(wttest.WiredTigerTestCase):
 
         self.assertStatGreaterSoon(stat.conn.rec_page_delta_leaf, 0)
 
-        follower_config = self.conn_base_config + 'disaggregated=(role="follower",' +\
-            f'checkpoint_meta="{self.disagg_get_complete_checkpoint_meta()}")'
-        self.reopen_conn(config = follower_config)
-
-        cursor = self.session.open_cursor(self.uri, None, None)
+        self.conn.reconfigure('disaggregated=(role="follower")')
 
         self.session.begin_transaction("read_timestamp=" + self.timestamp_str(5))
         for i in range(self.nitems):
@@ -241,11 +229,7 @@ class test_layered_delta01(wttest.WiredTigerTestCase):
 
         self.assertStatGreaterSoon(stat.conn.rec_page_delta_leaf, 0)
 
-        follower_config = self.conn_base_config + 'disaggregated=(role="follower",' +\
-            f'checkpoint_meta="{self.disagg_get_complete_checkpoint_meta()}")'
-        self.reopen_conn(config = follower_config)
-
-        cursor = self.session.open_cursor(self.uri, None, None)
+        self.conn.reconfigure('disaggregated=(role="follower")')
 
         self.session.begin_transaction("read_timestamp=" + self.timestamp_str(5))
         for i in range(self.nitems):
@@ -298,11 +282,7 @@ class test_layered_delta01(wttest.WiredTigerTestCase):
 
         self.assertStatGreaterSoon(stat.conn.rec_page_delta_leaf, 0)
 
-        follower_config = self.conn_base_config + 'disaggregated=(role="follower",' +\
-            f'checkpoint_meta="{self.disagg_get_complete_checkpoint_meta()}")'
-        self.reopen_conn(config = follower_config)
-
-        cursor = self.session.open_cursor(self.uri, None, None)
+        self.conn.reconfigure('disaggregated=(role="follower")')
 
         self.session.begin_transaction("read_timestamp=" + self.timestamp_str(5))
         for i in range(self.nitems):
@@ -364,11 +344,7 @@ class test_layered_delta01(wttest.WiredTigerTestCase):
 
         self.assertStatGreaterSoon(stat.conn.rec_page_delta_leaf, 0)
 
-        follower_config = self.conn_base_config + 'disaggregated=(role="follower",' +\
-            f'checkpoint_meta="{self.disagg_get_complete_checkpoint_meta()}")'
-        self.reopen_conn(config = follower_config)
-
-        cursor = self.session.open_cursor(self.uri, None, None)
+        self.conn.reconfigure('disaggregated=(role="follower")')
 
         self.session.begin_transaction("read_timestamp=" + self.timestamp_str(5))
         for i in range(self.nitems):

--- a/test/suite/test_layered_delta03.py
+++ b/test/suite/test_layered_delta03.py
@@ -85,11 +85,7 @@ class test_layered_delta03(wttest.WiredTigerTestCase):
 
         self.session.checkpoint()
 
-        follower_config = self.conn_base_config + 'disaggregated=(role="follower",' +\
-            f'checkpoint_meta="{self.disagg_get_complete_checkpoint_meta()}")'
-        self.reopen_conn(config = follower_config)
-
-        cursor = self.session.open_cursor(self.uri, None, None)
+        self.conn.reconfigure('disaggregated=(role="follower")')
 
         for i in range(self.nitems):
             if i % 10 == 0:

--- a/test/suite/test_layered_delta04.py
+++ b/test/suite/test_layered_delta04.py
@@ -111,11 +111,7 @@ class test_layered_delta04(wttest.WiredTigerTestCase):
 
             self.session.checkpoint()
 
-        follower_config = self.conn_base_config + 'disaggregated=(role="follower",' +\
-            f'checkpoint_meta="{self.disagg_get_complete_checkpoint_meta()}")'
-        self.reopen_conn(config = follower_config)
-
-        cursor = self.session.open_cursor(self.uri, None, None)
+        self.conn.reconfigure('disaggregated=(role="follower")')
 
         if self.ts:
             self.session.begin_transaction("read_timestamp=" + self.timestamp_str(5))

--- a/test/suite/test_layered_delta06.py
+++ b/test/suite/test_layered_delta06.py
@@ -101,16 +101,7 @@ class test_layered_delta06(wttest.WiredTigerTestCase):
         # We should skip writing the page
         self.session.checkpoint()
 
-        # Specify "local_files_action=ignore" to avoid deleting local files on reopen.
-        # This is important for the disaggregated storage test, as we want to read the
-        # checkpoint meta file without deleting it.
-        # Error text:
-        # unable to read root page from file:WiredTigerShared.wt_stable: WT_ERROR: non-specific WiredTiger error
-        follower_config = self.conn_base_config + 'disaggregated=(role="follower",' +\
-            f'checkpoint_meta="{self.disagg_get_complete_checkpoint_meta()}",local_files_action=ignore)'
-        self.reopen_conn(config = follower_config)
-
-        cursor = self.session.open_cursor(self.uri, None, None)
+        self.conn.reconfigure('disaggregated=(role="follower")')
 
         self.session.begin_transaction("read_timestamp=" + self.timestamp_str(5))
         for i in range(self.nitems):

--- a/test/suite/test_layered_fast_truncate01.py
+++ b/test/suite/test_layered_fast_truncate01.py
@@ -73,9 +73,7 @@ class test_layered_fast_truncate01(LayeredFastTruncateConfigMixin, wttest.WiredT
         self.session.checkpoint()
 
         # Switch to follower.
-        follower_config = 'disaggregated=(role="follower",' +\
-            f'checkpoint_meta="{self.disagg_get_complete_checkpoint_meta()}")'
-        self.reopen_conn(config = follower_config)
+        self.conn.reconfigure('disaggregated=(role="follower")')
 
         c1 = self.session.open_cursor(self.uri)
         c1.set_key(str(100))
@@ -127,9 +125,7 @@ class test_layered_fast_truncate01(LayeredFastTruncateConfigMixin, wttest.WiredT
         self.session.checkpoint()
 
         # Switch to follower.
-        follower_config = 'disaggregated=(role="follower",' +\
-            f'checkpoint_meta="{self.disagg_get_complete_checkpoint_meta()}")'
-        self.reopen_conn(config = follower_config)
+        self.conn.reconfigure('disaggregated=(role="follower")')
 
         c1 = self.session.open_cursor(self.uri)
         c1.set_key(str(100))
@@ -167,9 +163,7 @@ class test_layered_fast_truncate01(LayeredFastTruncateConfigMixin, wttest.WiredT
         self.session.checkpoint()
 
         # Switch to follower.
-        follower_config = 'disaggregated=(role="follower",' +\
-            f'checkpoint_meta="{self.disagg_get_complete_checkpoint_meta()}")'
-        self.reopen_conn(config = follower_config)
+        self.conn.reconfigure('disaggregated=(role="follower")')
 
         c1 = self.session.open_cursor(self.uri)
         c1.set_key(str(100))

--- a/test/suite/test_layered_fast_truncate07.py
+++ b/test/suite/test_layered_fast_truncate07.py
@@ -67,9 +67,7 @@ class test_layered_fast_truncate07(LayeredFastTruncateConfigMixin, wttest.WiredT
         self.session.create(self.uri, self.session_create_config())
         self.insert_range(1, self.nitems)
         self.session.checkpoint()
-        follower_config = ('verbose=[layered:3],disaggregated=(role="follower",'
-            f'checkpoint_meta="{self.disagg_get_complete_checkpoint_meta()}")')
-        self.reopen_conn(config=follower_config)
+        self.conn.reconfigure('disaggregated=(role="follower")')
 
     def insert_range(self, lo, hi):
         c = self.session.open_cursor(self.uri)

--- a/test/suite/test_layered_fast_truncate09.py
+++ b/test/suite/test_layered_fast_truncate09.py
@@ -71,10 +71,7 @@ class test_layered_fast_truncate09(LayeredFastTruncateConfigMixin, wttest.WiredT
         self.conn.set_timestamp('stable_timestamp=' + self.timestamp_str(10))
         self.session.checkpoint()
 
-        follower_config = (
-            'disaggregated=(role="follower",'
-            f'checkpoint_meta="{self.disagg_get_complete_checkpoint_meta()}")')
-        self.reopen_conn(config=follower_config)
+        self.conn.reconfigure('disaggregated=(role="follower")')
 
     def truncate_range(self, session, start, stop):
         c_start = session.open_cursor(self.uri)

--- a/test/suite/test_layered_schema03.py
+++ b/test/suite/test_layered_schema03.py
@@ -148,15 +148,9 @@ class test_layered_schema03(wttest.WiredTigerTestCase):
         cursor.close()
 
         self.session.checkpoint()
-        # Get the checkpoint metadata before closing
-        checkpoint_meta = self.disagg_get_complete_checkpoint_meta()
-
-        # Configure as follower with checkpoint pickup (not using backup)
-        follower_config = 'disaggregated=(role="follower",' + \
-                         f'checkpoint_meta="{checkpoint_meta}")'
 
         # Switch to follower mode.
-        self.reopen_conn(config=follower_config)
+        self.conn.reconfigure('disaggregated=(role="follower")')
         self.session.drop(uri, "")
         self.validate_drop()
 

--- a/test/suite/test_layered_stepup02.py
+++ b/test/suite/test_layered_stepup02.py
@@ -64,8 +64,8 @@ class test_layered_stepup02(wttest.WiredTigerTestCase):
             # in the same directory, insert some new items and see them.
 
             self.session.checkpoint()
-            self.reopen_conn(config=self.conn_base_config +
-                    f'disaggregated=(role="follower",checkpoint_meta="{self.disagg_get_complete_checkpoint_meta()}")')
+            # Step down to a follower via a live reconfigure instead of restarting.
+            self.conn.reconfigure('disaggregated=(role="follower")')
 
             first_row = ds.rows + 1
             ds.rows += 1000


### PR DESCRIPTION
### Summary

As a prerequisite for ASYNC step-down, this replaces the crash/restart-based leader→follower transition used in test/suite disagg tests with a live, synchronous step-down via reconfigure(role="follower").

Previously, tests simulated a leader stepping down by tearing down and reopening the connection with role="follower" (often also fetching and threading through a checkpoint_meta string via disagg_get_complete_checkpoint_meta()). This exercised connection-open/restart semantics rather than the actual synchronous step-down path, and required re-creating cursors afterward since a restart invalidates the session.

This change converts those call sites to self.conn.reconfigure('disaggregated=(role="follower")'), which performs the role transition in place on the live connection — no restart, no session/cursor invalidation, and no need to snapshot checkpoint metadata beforehand.

### Changes

Converted 13 test files (25 call sites) from restart-based step-down to reconfigure(role="follower"), removing the now-unnecessary checkpoint_meta plumbing and stale cursor re-opens along the way:

- test_layered_config11.py
- test_layered_cursor02.py
- test_layered_cursor06.py
- test_layered_cursor21.py
- test_layered_delta01.py
- test_layered_delta03.py
- test_layered_delta04.py
- test_layered_delta06.py
- test_layered_fast_truncate01.py
- test_layered_fast_truncate07.py
- test_layered_fast_truncate09.py
- test_layered_schema03.py
- test_layered_stepup02.py

### Restart-based reopens in 

- test_layered_checkpoint12.py
- test_layered_fast_truncate20.py
- test_layered_follower03.py
- test_prepare_discover06.py
- test_prepare_discover07.py
- test_verify_disagg03.py
- test_layered_config13.py
- test_layered_stepup05.py 
- test_repair01.py 

were left as-is: in each of these, the restart itself is exercising behaviour distinct from the role transition (e.g. startup metadata verification, local-file-discard semantics, checkpoint-based prepared-transaction discovery, or debug-mode-only reopen), or the role change already went through reconfigure and the restart is incidental.
