### PR TITLE
WT-18230 Skip checkpoint updates for pending disagg table creates

### DIFF
--- a/src/block_disagg/block_disagg_ckpt.c
+++ b/src/block_disagg/block_disagg_ckpt.c
@@ -117,6 +117,38 @@ __wti_block_disagg_checkpoint(WT_BM *bm, WT_SESSION_IMPL *session, WT_ITEM *root
 }
 
 /*
+ * __block_disagg_create_is_pending --
+ *     Return whether the table's CREATE is still pending at the checkpoint schema epoch.
+ */
+static bool
+__block_disagg_create_is_pending(
+  WT_SESSION_IMPL *session, const char *table_name, wt_timestamp_t schema_epoch)
+{
+    WT_CONNECTION_IMPL *conn = S2C(session);
+    bool unpublished = false;
+
+    __wt_spin_lock(session, &conn->disaggregated_storage.shared_metadata_queue_lock);
+
+    WT_DISAGG_METADATA_OP *entry;
+    TAILQ_FOREACH (entry, &conn->disaggregated_storage.shared_metadata_qh, q) {
+        if (entry->metadata_op != WT_SHARED_METADATA_CREATE)
+            continue;
+
+        bool create_pending = entry->deferred ||
+          (schema_epoch != WT_SCHEMA_EPOCH_NONE && entry->schema_epoch > schema_epoch);
+
+        if (create_pending && strcmp(entry->table_name, table_name) == 0) {
+            unpublished = true;
+            break;
+        }
+    }
+
+    __wt_spin_unlock(session, &conn->disaggregated_storage.shared_metadata_queue_lock);
+
+    return (unpublished);
+}
+
+/*
  * __block_disagg_checkpoint_resolve --
  *     Resolve the checkpoint. Assumes that the relevant locks are already acquired.
  */
@@ -195,6 +227,10 @@ __block_disagg_checkpoint_resolve(WT_BM *bm, WT_SESSION_IMPL *session, bool fail
         } else
             /* This can happen if the "file:" is created without a suffix in our tests. */
             WT_ERR(__wt_snprintf(table_name, len, "%s", block_disagg->name));
+
+        /* A pending CREATE for this table must publish before any checkpoint UPDATE for it. */
+        if (__block_disagg_create_is_pending(session, table_name, schema_epoch))
+            goto err;
 
         /*
          * Update the metadata of the stable/shared table in the current schema epoch.

--- a/src/block_disagg/block_disagg_ckpt.c
+++ b/src/block_disagg/block_disagg_ckpt.c
@@ -134,8 +134,8 @@ __block_disagg_create_is_pending(
         if (entry->metadata_op != WT_SHARED_METADATA_CREATE)
             continue;
 
-        bool create_pending = entry->deferred ||
-          (schema_epoch != WT_SCHEMA_EPOCH_NONE && entry->schema_epoch > schema_epoch);
+        bool create_pending =
+          (schema_epoch != WT_SCHEMA_EPOCH_NONE) && (entry->schema_epoch > schema_epoch);
 
         if (create_pending && strcmp(entry->table_name, table_name) == 0) {
             unpublished = true;

--- a/test/suite/test_layered_schema16.py
+++ b/test/suite/test_layered_schema16.py
@@ -145,6 +145,62 @@ class test_layered_schema16(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
             cursor.set_key(2)
             self.assertEqual(cursor.search(), wiredtiger.WT_NOTFOUND)
 
+    def test_checkpoint_update_not_skipped_for_other_pending_create(self):
+        """
+        A pending CREATE gates only its own table's checkpoint UPDATE. A CREATE
+        queued above the checkpoint epoch for a different table must not block
+        the UPDATE of a published table.
+        """
+        other_uri = self.uri + "_other"
+
+        self.conn.set_timestamp(
+            "stable_timestamp=" + self.timestamp_str(1)
+            + ",oldest_timestamp=" + self.timestamp_str(1)
+        )
+
+        # Seed a row that fingerprints the original checkpoint; its survival
+        # after recovery confirms we restored the right checkpoint.
+        self.session.create(self.uri, self.table_config)
+        with closing(self.session.open_cursor(self.uri)) as cursor:
+            with self.transaction(commit_timestamp=2):
+                cursor[1] = "durable"
+
+        # Put the original table's checkpoint on shared storage.
+        self.leader_checkpoint(3)
+
+        # Queue a CREATE for a different table above the checkpoint epoch. It
+        # is the decoy: the UPDATE skip must match on table name, not merely
+        # on the presence of any pending CREATE.
+        self.session.create(other_uri, self.table_config)
+        self.set_stable_epoch(3)
+        self.publish(other_uri, 4)
+
+        # A second stable row on the primary table; recovery must find it. If
+        # it did not, the decoy CREATE blocked this table's UPDATE.
+        with closing(self.session.open_cursor(self.uri)) as cursor:
+            with self.transaction(commit_timestamp=5):
+                cursor[2] = "durable"
+
+        # The checkpoint under test: the decoy CREATE queued at epoch 4 is
+        # above the schema epoch (3) and must not affect the primary table's
+        # UPDATE.
+        self.leader_checkpoint(5)
+
+        # Recover from shared storage alone, since local files could mask a
+        # skipped UPDATE.
+        self.restart_without_local_files(step_up=True)
+        self.conn.set_timestamp(
+            "stable_timestamp="
+            + self.timestamp_str(5)
+            + ",oldest_timestamp="
+            + self.timestamp_str(1)
+        )
+
+        # Both keys must survive: the decoy CREATE did not block the UPDATE.
+        with closing(self.session.open_cursor(self.uri)) as cursor:
+            self.assertEqual(cursor[1], "durable")
+            self.assertEqual(cursor[2], "durable")
+
     def test_unpublished_table_holds_unstable_data(self):
         """
         An unpublished table may legitimately hold unstable data. The checkpoint skips it without

--- a/test/suite/test_layered_schema16.py
+++ b/test/suite/test_layered_schema16.py
@@ -30,7 +30,8 @@
 #
 # A table's publish status is decided from its latest create/remove entry in the metadata queue.
 
-import wttest
+import wiredtiger, wttest
+from contextlib import closing
 from helper_disagg import disagg_test_class, gen_disagg_storages, DisaggSchemaEpochMixin
 from wtscenario import make_scenarios
 
@@ -86,6 +87,63 @@ class test_layered_schema16(wttest.WiredTigerTestCase, DisaggSchemaEpochMixin):
         # Assert neither constituent survived, so a partial resurrection cannot slip through.
         self.assertFalse(self.uri_stable_exists(self.conn, self.uri))
         self.assertFalse(self.uri_in_local_metadata(self.conn, self.uri))
+
+    def test_checkpoint_skips_pending_recreate_update(self):
+        """
+        A checkpoint must apply only metadata-queue entries at or below its
+        schema epoch. A drop/recreate queued above the epoch must leave the
+        original table's checkpoint intact.
+        """
+        self.conn.set_timestamp(
+            "stable_timestamp=" + self.timestamp_str(1)
+            + ",oldest_timestamp=" + self.timestamp_str(1)
+        )
+
+        # Seed a row that fingerprints the original table; its survival after
+        # recovery confirms we restored the right checkpoint.
+        self.session.create(self.uri, self.table_config)
+        with closing(self.session.open_cursor(self.uri)) as cursor:
+            with self.transaction(commit_timestamp=2):
+                cursor[1] = "durable"
+
+        # Put the original table's checkpoint on shared storage; this is the
+        # state recovery must return to.
+        self.leader_checkpoint(3)
+
+        # Queue a drop and recreate above the checkpoint epoch. The queue's
+        # latest entry now describes the new table, which the checkpoint must
+        # not adopt.
+        self.session.drop(self.uri)
+        self.session.create(self.uri, self.table_config)
+        self.set_stable_epoch(3)
+        self.publish(self.uri, 4)
+
+        # This canary row exists only on the newly created table; recovery must
+        # not find it. If it did, then the CREATE leaked into the checkpoint.
+        with closing(self.session.open_cursor(self.uri)) as cursor:
+            with self.transaction(commit_timestamp=5):
+                cursor[2] = "future"
+
+        # The checkpoint under test: the CREATE queued at epoch 4 is still
+        # above this epoch and must be skipped.
+        self.leader_checkpoint(3)
+
+        # Recover from shared storage alone, since local files could mask a
+        # wrong checkpoint.
+        self.restart_without_local_files(step_up=True)
+        self.conn.set_timestamp(
+            "stable_timestamp="
+            + self.timestamp_str(3)
+            + ",oldest_timestamp="
+            + self.timestamp_str(1)
+        )
+
+        # Key 1 must survive (original checkpoint restored).
+        # Key 2 must be absent (the pending CREATE did not leak).
+        with closing(self.session.open_cursor(self.uri)) as cursor:
+            self.assertEqual(cursor[1], "durable")
+            cursor.set_key(2)
+            self.assertEqual(cursor.search(), wiredtiger.WT_NOTFOUND)
 
     def test_unpublished_table_holds_unstable_data(self):
         """


### PR DESCRIPTION
During checkpoint resolution, a table’s metadata UPDATE could be queued even
when its CREATE belonged to a newer schema epoch. After a drop/recreate, an
older checkpoint could therefore reference the recreated table and expose data
that should not exist at that checkpoint.

Changes:

Added a queue check for pending or newer-epoch CREATE operations for the table.
Skip the checkpoint metadata UPDATE until the CREATE is publishable.