### PR TITLE
WT-16419 Make btree->original accesses atomic

### DIFF
--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -331,7 +331,8 @@ __wt_btree_open(WT_SESSION_IMPL *session, const char *op_cfg[])
      * eviction, it must either clear the evict-disabled-open flag or restore the eviction
      * configuration when finished so that handle close behaves correctly.
      */
-    if (btree->original || F_ISSET(btree, WT_BTREE_NO_EVICT | WT_BTREE_SALVAGE | WT_BTREE_VERIFY)) {
+    if (__wt_atomic_load_uint8_relaxed(&btree->original) ||
+      F_ISSET(btree, WT_BTREE_NO_EVICT | WT_BTREE_SALVAGE | WT_BTREE_VERIFY)) {
         WT_ERR(__wt_evict_file_exclusive_on(session));
         btree->evict_disabled_open = true;
     }
@@ -1012,7 +1013,7 @@ __btree_tree_open_empty(WT_SESSION_IMPL *session, bool empty_ckpt)
      * cleared when a row is inserted into the tree.
      */
     if (empty_ckpt)
-        btree->original = 1;
+        __wt_atomic_store_uint8_relaxed(&btree->original, 1);
 
     /*
      * A note about empty trees: the initial tree is a single root page. It has a single reference

--- a/src/btree/bt_sync_obsolete.c
+++ b/src/btree/bt_sync_obsolete.c
@@ -515,7 +515,7 @@ __checkpoint_cleanup_walk_btree(WT_SESSION_IMPL *session, WT_ITEM *uri)
         goto err;
 
     /* Ignore tables that are empty or is currently in a bulk-load phase. */
-    if (btree->original)
+    if (__wt_atomic_load_uint8_relaxed(&btree->original))
         goto err;
 
     /* Walk the tree. */

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -193,7 +193,7 @@ __checkpoint_flush_tier(WT_SESSION_IMPL *session, bool force)
              * dirty to ensure it participates in the checkpoint process, even if clean.
              */
             btree = S2BT(session);
-            if (btree->original) {
+            if (__wt_atomic_load_uint8_relaxed(&btree->original)) {
                 WT_STAT_CONN_INCR(session, flush_tier_skipped);
                 WT_ERR(__wt_session_release_dhandle(session));
                 release = false;
@@ -3084,8 +3084,12 @@ __checkpoint_tree(WT_SESSION_IMPL *session, bool is_checkpoint, const char *cfg[
      * the same name; in order to keep from having two checkpoints with the same name you would have
      * to use the bulk-load's fake checkpoint to delete a physical checkpoint, and that will end in
      * tears.
+     *
+     * FIXME-WT-18266: this decision doesn't check the tree's dirty state, so a concurrent clearer
+     * of "original" outside the schema lock (for example, a live-restore worker) can race with a
+     * stale read here and cause checkpoint to skip reconciling an already-dirty tree.
      */
-    if (is_checkpoint && btree->original) {
+    if (is_checkpoint && __wt_atomic_load_uint8_relaxed(&btree->original)) {
         __wt_checkpoint_tree_reconcile_update(session, &ta);
 
         fake_ckpt = true;

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -23,14 +23,14 @@ __wt_btree_disable_bulk(WT_SESSION_IMPL *session)
      * Once a tree is no longer empty, eviction should pay attention to it, and it's no longer
      * possible to bulk-load into it.
      */
-    if (!__wt_atomic_load_uint8_acquire(&btree->original))
+    if (!__wt_atomic_load_uint8_relaxed(&btree->original))
         return;
 
     /*
      * We use a compare-and-swap here to avoid races among the first inserts into a tree. Eviction
      * is disabled when an empty tree is opened, and it must only be enabled once.
      */
-    if (__wt_atomic_cas_uint8(&btree->original, 1, 0)) {
+    if (__wt_atomic_cas_uint8_relaxed(&btree->original, 1, 0)) {
         btree->evict_disabled_open = false;
         __wt_evict_file_exclusive_off(session);
     }

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -2732,7 +2732,7 @@ __wt_bulk_init(WT_SESSION_IMPL *session, WT_CURSOR_BULK *cbulk)
      * Bulk-load is only permitted on newly created files, not any empty file -- see the checkpoint
      * code for a discussion.
      */
-    if (!btree->original)
+    if (!__wt_atomic_load_uint8_relaxed(&btree->original))
         WT_RET_MSG(session, EINVAL, "bulk-load is only possible for newly created trees");
 
     /*


### PR DESCRIPTION
## Summary
- `btree->original` is cleared with an atomic CAS in `__wt_btree_disable_bulk` but was read/written elsewhere with plain accesses to the same byte, which is UB under the C memory model and is what TSan flags on `format-stress-test-tsan` (WT-16419).
- Switch all accesses to relaxed atomics (`__wt_atomic_load_uint8_relaxed` / `__wt_atomic_store_uint8_relaxed` / `__wt_atomic_cas_uint8_relaxed`). Relaxed is sufficient: `original` only ever transitions 1 -> 0 once, and no reader needs to synchronize with other memory written alongside the flag — they only need a torn-free read of the flag's own value. No behavioral change.
- Filed WT-18266 for a separate, pre-existing gap this doesn't address: the checkpoint fake-path decision in `__checkpoint_tree` doesn't check the tree's dirty state, so it can still skip reconciling a tree that was concurrently dirtied outside the schema lock (e.g. by a live-restore worker). Added a `FIXME-WT-18266` comment at that call site.