### PR TITLE
WT-18205 Use atomic accesses for layered_table_manager.leader

### DIFF
--- a/src/block_disagg/block_disagg_write.c
+++ b/src/block_disagg/block_disagg_write.c
@@ -117,8 +117,8 @@ __wti_block_disagg_write_internal(WT_SESSION_IMPL *session, WT_BLOCK_DISAGG *blo
     page_id = block_meta->page_id;
 
     /* Check that we are the leader (only leaders can write). */
-    WT_ASSERT_ALWAYS(
-      session, conn->layered_table_manager.leader, "Trying to write the page from a follower");
+    WT_ASSERT_ALWAYS(session, __wt_atomic_load_bool_relaxed(&conn->layered_table_manager.leader),
+      "Trying to write the page from a follower");
 
     /*
      * Update the block's checksum: if our caller specifies, checksum the complete data, otherwise

--- a/src/btree/bt_sync_obsolete.c
+++ b/src/btree/bt_sync_obsolete.c
@@ -836,7 +836,8 @@ __checkpoint_cleanup(void *arg)
         __wt_seconds(session, &now);
 
         /* Skip running checkpoint cleanup if we are the follower. */
-        if (__wt_conn_is_disagg(session) && !conn->layered_table_manager.leader)
+        if (__wt_conn_is_disagg(session) &&
+          !__wt_atomic_load_bool_relaxed(&conn->layered_table_manager.leader))
             continue;
 
         /*

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -513,7 +513,8 @@ __wt_checkpoint_get_handles(WT_SESSION_IMPL *session, const char *cfg[])
         if (WT_IS_DISAGG_META(btree->dhandle))
             return (0);
         /* Skip checkpointing shared tables if we are not a leader. */
-        if (F_ISSET(btree, WT_BTREE_DISAGGREGATED) && !S2C(session)->layered_table_manager.leader)
+        if (F_ISSET(btree, WT_BTREE_DISAGGREGATED) &&
+          !__wt_atomic_load_bool_relaxed(&S2C(session)->layered_table_manager.leader))
             return (0);
         /* Skip checkpointing outdated trees. */
         if (F_ISSET(btree->dhandle, WT_DHANDLE_OUTDATED))
@@ -1420,7 +1421,8 @@ __checkpoint_parse_config(
     WT_RET(__wt_config_gets(session, cfg, "debug.database_size_fix", &cval));
     ckpt_cfg->database_size_fix = cval.val != 0;
     if (ckpt_cfg->database_size_fix &&
-      !(__wt_conn_is_disagg(session) && S2C(session)->layered_table_manager.leader))
+      !(__wt_conn_is_disagg(session) &&
+        __wt_atomic_load_bool_relaxed(&S2C(session)->layered_table_manager.leader)))
         WT_RET_MSG(
           session, ENOTSUP, "database_size_fix requires a disaggregated leader connection");
 
@@ -1833,7 +1835,8 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
      */
     conn->disaggregated_storage.cur_checkpoint_timestamp = ckpt_tmp_ts;
     conn->disaggregated_storage.cur_schema_epoch = ckpt_disagg_schema_epoch;
-    if (__wt_conn_is_disagg(session) && conn->layered_table_manager.leader)
+    if (__wt_conn_is_disagg(session) &&
+      __wt_atomic_load_bool_relaxed(&conn->layered_table_manager.leader))
         __wt_verbose_debug1(session, WT_VERB_DISAGGREGATED_STORAGE,
           "Starting disaggregated storage checkpoint with timestamp: %" PRIu64
           " %s and schema epoch: %" PRIu64 " %s",
@@ -1862,7 +1865,8 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
     __checkpoint_timing_stress(session, WT_TIMING_STRESS_HS_CHECKPOINT_DELAY, &tsp);
 
     /* Get the handle to the shared history store. */
-    if (__wt_conn_is_disagg(session) && conn->layered_table_manager.leader) {
+    if (__wt_conn_is_disagg(session) &&
+      __wt_atomic_load_bool_relaxed(&conn->layered_table_manager.leader)) {
         WT_ERR_ERROR_OK(
           __wt_session_get_dhandle(session, WT_HS_URI_SHARED, NULL, NULL, 0), ENOENT, false);
         hs_dhandle_shared = session->dhandle;
@@ -1883,7 +1887,8 @@ __checkpoint_db_internal(WT_SESSION_IMPL *session, const char *cfg[])
      * Copy any updated metadata to the shared metadata table. Compute the drop size first so we can
      * adjust the overall database size after the checkpoint completes.
      */
-    if (__wt_conn_is_disagg(session) && conn->layered_table_manager.leader) {
+    if (__wt_conn_is_disagg(session) &&
+      __wt_atomic_load_bool_relaxed(&conn->layered_table_manager.leader)) {
         WT_WITH_SCHEMA_LOCK(session,
           ret = __wt_disagg_shared_metadata_queue_process(
             session, ckpt_disagg_schema_epoch, &drop_size));
@@ -2923,7 +2928,8 @@ __checkpoint_disagg_put(
 
     WT_CONNECTION_IMPL *conn = S2C(session);
 
-    if (!__wt_conn_is_disagg(session) || !conn->layered_table_manager.leader)
+    if (!__wt_conn_is_disagg(session) ||
+      !__wt_atomic_load_bool_relaxed(&conn->layered_table_manager.leader))
         return (0);
 
     /*
@@ -3457,7 +3463,8 @@ __checkpoint_metadata(WT_SESSION_IMPL *session, const char *cfg[], WT_TXN *txn)
      * uncommitted updates). In that case, we may evict it and the checkpoint transaction cannot
      * commit as the updates have gone from memory.
      */
-    if (__wt_conn_is_disagg(session) && conn->layered_table_manager.leader) {
+    if (__wt_conn_is_disagg(session) &&
+      __wt_atomic_load_bool_relaxed(&conn->layered_table_manager.leader)) {
         WT_RET(__wt_session_get_dhandle(session, WT_DISAGG_METADATA_URI, NULL, NULL, 0));
         if (S2BT(session)->modified)
             WT_RET(__wt_checkpoint_file(session, cfg));

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -494,7 +494,7 @@ __disagg_shared_metadata_op_helper(
     WT_DECL_RET;
     const char *cfg[] = {WT_CONFIG_BASE(session, WT_SESSION_open_cursor), "overwrite", NULL};
 
-    WT_ASSERT(session, S2C(session)->layered_table_manager.leader);
+    WT_ASSERT(session, __wt_atomic_load_bool_relaxed(&S2C(session)->layered_table_manager.leader));
 
     cursor = NULL;
 
@@ -853,7 +853,7 @@ __disagg_metadata_table_init(WT_SESSION_IMPL *session)
      * FIXME-WT-17040: Investigate if it's necessary to create the shared metadata table on
      * followers.
      */
-    if (!conn->layered_table_manager.leader) {
+    if (!__wt_atomic_load_bool_relaxed(&conn->layered_table_manager.leader)) {
         WT_WITHOUT_DHANDLE(
           session, ret = __wti_conn_dhandle_outdated(session, WT_DISAGG_METADATA_URI));
         WT_ERR_MSG_CHK(
@@ -910,7 +910,8 @@ __disagg_abandon_checkpoint(WT_SESSION_IMPL *session)
     WT_ASSERT_SPINLOCK_OWNED(session, &conn->checkpoint_lock);
 
     /* Only the leader can abandon a checkpoint. */
-    if (disagg->npage_log == NULL || !conn->layered_table_manager.leader)
+    if (disagg->npage_log == NULL ||
+      !__wt_atomic_load_bool_relaxed(&conn->layered_table_manager.leader))
         WT_RET(EINVAL);
 
     /*
@@ -956,7 +957,8 @@ __disagg_begin_checkpoint(WT_SESSION_IMPL *session)
     WT_ASSERT_SPINLOCK_OWNED(session, &conn->checkpoint_lock);
 
     /* Only the leader can begin a global checkpoint. */
-    if (disagg->npage_log == NULL || !conn->layered_table_manager.leader)
+    if (disagg->npage_log == NULL ||
+      !__wt_atomic_load_bool_relaxed(&conn->layered_table_manager.leader))
         return (0);
 
     /* On fresh startup, load an empty key to key provider. */
@@ -1039,9 +1041,10 @@ __disagg_step_up(WT_SESSION_IMPL *session)
 
     /*
      * Step up to the leader mode. We need to do this first, because the rest of the operations
-     * below depend on WiredTiger already being in the leader mode.
+     * below depend on WiredTiger already being in the leader mode. There is currently no need for
+     * stronger ordering, so keep the store relaxed.
      */
-    conn->layered_table_manager.leader = true;
+    __wt_atomic_store_bool_relaxed(&conn->layered_table_manager.leader, true);
     WT_STAT_CONN_SET(session, disagg_role_leader, 1);
 
     /*
@@ -1157,8 +1160,11 @@ __disagg_mark_btrees_readonly_then_step_down(WT_SESSION_IMPL *session)
         WT_WITH_BTREE(session, btree, __wt_evict_file_exclusive_off(session));
     }
 
-    /* Step down to the follower mode. */
-    conn->layered_table_manager.leader = false;
+    /*
+     * Step down to the follower mode. There is currently no need for stronger ordering, so keep the
+     * store relaxed.
+     */
+    __wt_atomic_store_bool_relaxed(&conn->layered_table_manager.leader, false);
     WT_STAT_CONN_SET(session, disagg_role_leader, 0);
     return (0);
 }
@@ -1310,7 +1316,7 @@ __wti_disagg_conn_config(WT_SESSION_IMPL *session, const char **cfg, bool reconf
     bool leader, picked_up, was_leader;
 
     conn = S2C(session);
-    leader = was_leader = conn->layered_table_manager.leader;
+    leader = was_leader = __wt_atomic_load_bool_relaxed(&conn->layered_table_manager.leader);
     npage_log = NULL;
     picked_up = false;
 
@@ -1366,7 +1372,7 @@ __wti_disagg_conn_config(WT_SESSION_IMPL *session, const char **cfg, bool reconf
 
     if (!reconfig) {
         /* Set the initial role. */
-        conn->layered_table_manager.leader = leader;
+        __wt_atomic_store_bool_relaxed(&conn->layered_table_manager.leader, leader);
         WT_STAT_CONN_SET(session, disagg_role_leader, leader ? 1 : 0);
     } else if (!was_leader && leader) {
         /* Follower step-up. */
@@ -1788,7 +1794,8 @@ __wt_disagg_advance_checkpoint(WT_SESSION_IMPL *session, bool ckpt_success)
     WT_ASSERT_SPINLOCK_OWNED(session, &conn->checkpoint_lock);
 
     /* Only the leader can advance the global checkpoint. */
-    if (disagg->npage_log == NULL || !conn->layered_table_manager.leader)
+    if (disagg->npage_log == NULL ||
+      !__wt_atomic_load_bool_relaxed(&conn->layered_table_manager.leader))
         return (0);
 
     WT_RET(__wt_scr_alloc(session, 0, &meta));

--- a/src/conn/conn_layered_checkpoint_pick_up.c
+++ b/src/conn/conn_layered_checkpoint_pick_up.c
@@ -1141,7 +1141,7 @@ err:
 
     if (ret == 0) {
         WT_STAT_CONN_INCR(session, layered_table_manager_checkpoints_disagg_pick_up_succeed);
-        if (!conn->layered_table_manager.leader)
+        if (!__wt_atomic_load_bool_relaxed(&conn->layered_table_manager.leader))
             WT_STAT_CONN_INCR(session, layered_table_manager_checkpoints_disagg_pick_up_follower);
     } else {
         WT_STAT_CONN_INCR(session, layered_table_manager_checkpoints_disagg_pick_up_failed);

--- a/src/conn/conn_sweep.c
+++ b/src/conn/conn_sweep.c
@@ -554,7 +554,8 @@ __sweep_server(void *arg)
         __sweep_check_session_sweep(session, now);
 
         /* On a stepped-up leader, mark the shared disk cache dead once its reuse window elapses. */
-        if (__wt_conn_is_disagg(session) && conn->layered_table_manager.leader &&
+        if (__wt_conn_is_disagg(session) &&
+          __wt_atomic_load_bool_relaxed(&conn->layered_table_manager.leader) &&
           __wt_atomic_load_uint8_acquire(&conn->cache->shared_dsk_cache.state) ==
             WT_DSK_CACHE_READONLY) {
             uint64_t readonly_since =

--- a/src/cursor/cur_hs.c
+++ b/src/cursor/cur_hs.c
@@ -47,8 +47,9 @@ __curhs_file_cursor_open(WT_SESSION_IMPL *session, const char *uri, const char *
         WT_ERR(__wt_snprintf(tmp, len, "checkpoint=%s", session->hs_checkpoint));
         open_cursor_cfg[2] = tmp;
     } else if (checkpoint_name != NULL) {
-        WT_ASSERT(
-          session, __wt_conn_is_disagg(session) && !S2C(session)->layered_table_manager.leader);
+        WT_ASSERT(session,
+          __wt_conn_is_disagg(session) &&
+            !__wt_atomic_load_bool_relaxed(&S2C(session)->layered_table_manager.leader));
         WT_ERR(__wt_scr_alloc(session, 0, &stable_uri_buf));
         /*
          * Use a URI with a "/<checkpoint name> suffix. This is interpreted as reading from the
@@ -160,7 +161,8 @@ __wt_curhs_cache(WT_SESSION_IMPL *session)
      * reconciliation for shared tables. It is also unsafe to cache the shared history store on the
      * standby as the sweep server may close the outdated history store dhandles.
      */
-    if (__wt_conn_is_disagg(session) && conn->layered_table_manager.leader) {
+    if (__wt_conn_is_disagg(session) &&
+      __wt_atomic_load_bool_relaxed(&conn->layered_table_manager.leader)) {
         WT_RET(__curhs_file_cursor_open(session, WT_HS_URI_SHARED, NULL, NULL, &cursor));
         WT_RET(cursor->close(cursor));
     }
@@ -1041,7 +1043,7 @@ __curhs_insert(WT_CURSOR *cursor)
 
     WT_ASSERT(session,
       !__wt_conn_is_disagg(session) || !F_ISSET(CUR2BT(file_cursor), WT_BTREE_DISAGGREGATED) ||
-        S2C(session)->layered_table_manager.leader);
+        __wt_atomic_load_bool_relaxed(&S2C(session)->layered_table_manager.leader));
 
     /*
      * Disable bulk loads into history store. This would normally occur when updating a record with
@@ -1183,7 +1185,7 @@ __curhs_remove(WT_CURSOR *cursor)
 
     WT_ASSERT(session,
       !__wt_conn_is_disagg(session) || !F_ISSET(CUR2BT(file_cursor), WT_BTREE_DISAGGREGATED) ||
-        S2C(session)->layered_table_manager.leader);
+        __wt_atomic_load_bool_relaxed(&S2C(session)->layered_table_manager.leader));
 
     /* Remove must be called with cursor positioned. */
     WT_ASSERT(session, F_ISSET(file_cursor, WT_CURSTD_KEY_INT));
@@ -1229,7 +1231,7 @@ __curhs_update(WT_CURSOR *cursor)
 
     WT_ASSERT(session,
       !__wt_conn_is_disagg(session) || !F_ISSET(CUR2BT(file_cursor), WT_BTREE_DISAGGREGATED) ||
-        S2C(session)->layered_table_manager.leader);
+        __wt_atomic_load_bool_relaxed(&S2C(session)->layered_table_manager.leader));
 
     /* Update must be called with cursor positioned. */
     WT_ASSERT(session, F_ISSET(file_cursor, WT_CURSTD_KEY_INT));
@@ -1306,7 +1308,7 @@ __curhs_range_truncate(WT_TRUNCATE_INFO *trunc_info)
     WT_ASSERT(session,
       !__wt_conn_is_disagg(session) ||
         !F_ISSET(CUR2BT(start_file_cursor), WT_BTREE_DISAGGREGATED) ||
-        S2C(session)->layered_table_manager.leader);
+        __wt_atomic_load_bool_relaxed(&S2C(session)->layered_table_manager.leader));
 
     WT_STAT_DSRC_INCR(session, cursor_truncate);
 

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -336,8 +336,9 @@ __clayered_enter(WTI_CURSOR_LAYERED *clayered, WTI_CLAYERED_OP_MODE mode, WTI_CL
 {
     WT_SESSION_IMPL *const session = CUR2S(clayered);
     WT_CONNECTION_IMPL *conn = S2C(session);
-    WTI_CLAYERED_ROLE role =
-      conn->layered_table_manager.leader ? WTI_CLAYERED_ROLE_LEADER : WTI_CLAYERED_ROLE_FOLLOWER;
+    WTI_CLAYERED_ROLE role = __wt_atomic_load_bool_relaxed(&conn->layered_table_manager.leader) ?
+      WTI_CLAYERED_ROLE_LEADER :
+      WTI_CLAYERED_ROLE_FOLLOWER;
     uint32_t flags = __clayered_enter_flags(clayered, mode, role);
 
     /*
@@ -1216,7 +1217,7 @@ __wt_clayered_range_truncate_stable_replay(WT_TRUNCATE_INFO *trunc_info)
     /* Only valid on stable tables during step up to leader, routed via WT_SESSION_INGEST_REPLAY. */
     WT_ASSERT(session, F_ISSET(session, WT_SESSION_INGEST_REPLAY));
     WT_ASSERT(session, WT_URI_IS_STABLE(trunc_info->start->internal_uri));
-    WT_ASSERT(session, S2C(session)->layered_table_manager.leader);
+    WT_ASSERT(session, __wt_atomic_load_bool_relaxed(&S2C(session)->layered_table_manager.leader));
 
     /* Both boundary cursors must be fully positioned. */
     WT_ASSERT(session, F_ISSET(trunc_info->start, WT_CURSTD_KEY_INT));
@@ -1253,7 +1254,7 @@ __wt_layered_truncate(WT_TRUNCATE_INFO *trunc_info)
      * mode, we need to perform truncate on the ingest table and add an entry inside the truncate
      * list.
      */
-    if (S2C(session)->layered_table_manager.leader)
+    if (__wt_atomic_load_bool_relaxed(&S2C(session)->layered_table_manager.leader))
         WT_RET(__clayered_truncate_leader(trunc_info));
     else {
         WT_ASSERT(session,

--- a/src/cursor/cur_stat.c
+++ b/src/cursor/cur_stat.c
@@ -433,7 +433,7 @@ __curstat_layered_init(WT_SESSION_IMPL *session, const char *uri, WT_CURSOR_STAT
 retry:
     stable_uri = layered->stable_uri;
     /* Now do the stable table. */
-    if (!S2C(session)->layered_table_manager.leader) {
+    if (!__wt_atomic_load_bool_relaxed(&S2C(session)->layered_table_manager.leader)) {
         /*
          * On a follower the stable's pages are not resident in the local cache, so its non-walk
          * stats are ~0 - except the block size, which we read from the checkpoint metadata directly

--- a/src/evict/evict_inline.h
+++ b/src/evict/evict_inline.h
@@ -582,7 +582,7 @@ __wt_evict_needed(
          * work that cannot succeed. Log a message if the cache fills with updates or dirty pages.
          */
         if (ignore_updates_dirty && __wt_conn_is_disagg(session) &&
-          (!conn->layered_table_manager.leader ||
+          (!__wt_atomic_load_bool_relaxed(&conn->layered_table_manager.leader) ||
             F_ISSET_ATOMIC_32(conn, WT_CONN_RECONFIGURING_STEP_UP) ||
             __wt_atomic_load_uint64_relaxed(&conn->txn_global.step_down_timestamp) != WT_TS_NONE)) {
             double cache_full = (evict->eviction_target + evict->eviction_trigger) / 2;

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -514,7 +514,9 @@ __wt_evict(WT_SESSION_IMPL *session, WT_REF *ref, WT_REF_STATE previous_state, u
      * follower are never modified, and should never be reconciled.
      */
     if (!tree_dead && is_dirty) {
-        WT_ASSERT(session, ref->page->disagg_info == NULL || conn->layered_table_manager.leader);
+        WT_ASSERT(session,
+          ref->page->disagg_info == NULL ||
+            __wt_atomic_load_bool_relaxed(&conn->layered_table_manager.leader));
         WT_ERR(__evict_reconcile(session, ref, flags));
     }
 

--- a/src/history/hs_verify.c
+++ b/src/history/hs_verify.c
@@ -169,7 +169,8 @@ __hs_verify(WT_SESSION_IMPL *session, uint32_t hs_id)
     btree_id = WT_BTREE_ID_INVALID;
     uri_data = NULL;
     ds_checkpoint_name = hs_checkpoint_name = hs_uri = NULL;
-    is_follower = __wt_conn_is_disagg(session) && !conn->layered_table_manager.leader;
+    is_follower = __wt_conn_is_disagg(session) &&
+      !__wt_atomic_load_bool_relaxed(&conn->layered_table_manager.leader);
 
     WT_ERR(__wt_scr_alloc(session, 0, &buf));
 

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -856,7 +856,8 @@ __wt_page_only_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page)
         return;
 
     WT_ASSERT(session,
-      !F_ISSET(btree, WT_BTREE_DISAGGREGATED) || S2C(session)->layered_table_manager.leader);
+      !F_ISSET(btree, WT_BTREE_DISAGGREGATED) ||
+        __wt_atomic_load_bool_relaxed(&S2C(session)->layered_table_manager.leader));
 
     /*
      * This is a relatively complex dance of operations so pay attention prior to modifying the code
@@ -967,8 +968,9 @@ __wt_tree_modify_set(WT_SESSION_IMPL *session)
     if (F_ISSET(btree, WT_BTREE_READONLY))
         return;
 
-    WT_ASSERT(
-      session, !F_ISSET(btree, WT_BTREE_DISAGGREGATED) || conn->layered_table_manager.leader);
+    WT_ASSERT(session,
+      !F_ISSET(btree, WT_BTREE_DISAGGREGATED) ||
+        __wt_atomic_load_bool_relaxed(&conn->layered_table_manager.leader));
 
     /*
      * Test before setting the dirty flag, it's a hot cache line.
@@ -1069,7 +1071,8 @@ __wt_page_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page)
         return;
 
     WT_ASSERT(session,
-      !F_ISSET(btree, WT_BTREE_DISAGGREGATED) || S2C(session)->layered_table_manager.leader);
+      !F_ISSET(btree, WT_BTREE_DISAGGREGATED) ||
+        __wt_atomic_load_bool_relaxed(&S2C(session)->layered_table_manager.leader));
 
     /*
      * Mark the tree dirty (even if the page is already marked dirty), newly created pages to
@@ -1109,7 +1112,8 @@ __wt_page_parent_modify_set(WT_SESSION_IMPL *session, WT_REF *ref, bool page_onl
         return (0);
 
     WT_ASSERT(session,
-      !F_ISSET(btree, WT_BTREE_DISAGGREGATED) || S2C(session)->layered_table_manager.leader);
+      !F_ISSET(btree, WT_BTREE_DISAGGREGATED) ||
+        __wt_atomic_load_bool_relaxed(&S2C(session)->layered_table_manager.leader));
 
     /*
      * This function exists as a place to stash this comment. There are a few places where we need
@@ -2185,7 +2189,7 @@ __wt_btree_can_discard(WT_SESSION_IMPL *session)
     if (!F_ISSET(btree, WT_BTREE_DISAGGREGATED))
         return (true);
 
-    if (!conn->layered_table_manager.leader)
+    if (!__wt_atomic_load_bool_relaxed(&conn->layered_table_manager.leader))
         return (true);
 
     rec_lsn_max = __wt_atomic_load_uint64_relaxed(&btree->rec_lsn_max);

--- a/src/include/connection.h
+++ b/src/include/connection.h
@@ -145,11 +145,7 @@ struct __wt_layered_table_manager {
     WT_LAYERED_TABLE_MANAGER_ENTRY **entries;
     size_t entries_allocated_bytes;
 
-    /*
-     * FIXME-WT-18205: written on role reconfigure while other threads read it unsynchronised;
-     * convert to atomic accesses.
-     */
-    bool leader;
+    wt_shared bool leader; /* The node's disaggregated role, written on role reconfigure */
 };
 
 /*

--- a/src/include/txn_inline.h
+++ b/src/include/txn_inline.h
@@ -1007,7 +1007,7 @@ __wt_txn_pinned_timestamp(WT_SESSION_IMPL *session, wt_timestamp_t *pinned_tsp)
      * retain all data on the ingest btree up to that point.
      */
     if (__wt_conn_is_disagg(session) &&
-      (!conn->layered_table_manager.leader ||
+      (!__wt_atomic_load_bool_relaxed(&conn->layered_table_manager.leader) ||
         F_ISSET_ATOMIC_32(conn, WT_CONN_RECONFIGURING_STEP_UP))) {
         checkpoint_ts =
           __wt_atomic_load_uint64_acquire(&conn->disaggregated_storage.last_checkpoint_timestamp);

--- a/src/prepared_discover/prepared_discover_walk.c
+++ b/src/prepared_discover/prepared_discover_walk.c
@@ -16,7 +16,8 @@
 static WT_INLINE bool
 __prepared_discover_is_follower_stable_walk(WT_SESSION_IMPL *session, const char *uri)
 {
-    return (__wt_conn_is_disagg(session) && !S2C(session)->layered_table_manager.leader &&
+    return (__wt_conn_is_disagg(session) &&
+      !__wt_atomic_load_bool_relaxed(&S2C(session)->layered_table_manager.leader) &&
       WT_URI_IS_STABLE(uri));
 }
 

--- a/src/schema/schema_create.c
+++ b/src/schema/schema_create.c
@@ -1219,7 +1219,7 @@ __create_layered(WT_SESSION_IMPL *session, const char *uri, bool exclusive, cons
     WT_ERR(__wt_schema_create(session, ingest_uri, constituent_cfg));
     __wt_free(session, constituent_cfg);
 
-    if (conn->layered_table_manager.leader) {
+    if (__wt_atomic_load_bool_relaxed(&conn->layered_table_manager.leader)) {
         stable_cfg[1] = disagg_config->data;
 
         /* Disable logging on the stable table to ensure we have timestamps. */

--- a/src/schema/schema_drop.c
+++ b/src/schema/schema_drop.c
@@ -72,7 +72,8 @@ __drop_file(
      */
     WT_ERR(ret);
     if (id_found && !F_ISSET(conn, WT_CONN_IN_MEMORY) && F_ISSET_ATOMIC_32(conn, WT_CONN_READY) &&
-      (!__wt_conn_is_disagg(session) || conn->layered_table_manager.leader ||
+      (!__wt_conn_is_disagg(session) ||
+        __wt_atomic_load_bool_relaxed(&conn->layered_table_manager.leader) ||
         !WT_BTREE_ID_SHARED(id)))
         if (__wt_hs_btree_truncate(session, id) != 0)
             __wt_verbose_warning(
@@ -203,7 +204,7 @@ __drop_layered(
     stable_uri = stable_uri_buf->data;
 
     /* Only the leader can issue a trim command. */
-    if (S2C(session)->layered_table_manager.leader)
+    if (__wt_atomic_load_bool_relaxed(&S2C(session)->layered_table_manager.leader))
         WT_ERR(__drop_issue_trim(session, stable_uri));
 
     /* Remove all the associated metadata from shared metadata table. */
@@ -219,7 +220,8 @@ __drop_layered(
      * treat ENOENT as an error for them.
      */
     WT_ERR_ERROR_OK(__wt_schema_drop(session, stable_uri, cfg, check_visibility), ENOENT, true);
-    if (WT_CHECK_AND_RESET(ret, ENOENT) && S2C(session)->layered_table_manager.leader)
+    if (WT_CHECK_AND_RESET(ret, ENOENT) &&
+      __wt_atomic_load_bool_relaxed(&S2C(session)->layered_table_manager.leader))
         WT_ERR_MSG(session, ENOENT,
           "stable constituent \"%s\" not found when dropping \"%s\" on leader", stable_uri, uri);
     WT_ERR(__wt_schema_drop(session, ingest_uri, cfg, check_visibility));

--- a/src/schema/schema_truncate.c
+++ b/src/schema/schema_truncate.c
@@ -255,7 +255,7 @@ __wt_schema_range_truncate(WT_TRUNCATE_INFO *trunc_info)
     } else if (WT_PREFIX_MATCH(uri, "table:"))
         ret = __wt_table_range_truncate(trunc_info);
     else if (WT_PREFIX_MATCH(uri, "layered:") &&
-      (S2C(session)->layered_table_manager.leader ||
+      (__wt_atomic_load_bool_relaxed(&S2C(session)->layered_table_manager.leader) ||
         !FLD_ISSET(S2C(session)->debug.flags, WT_CONN_DEBUG_DISAGG_SLOW_TRUNCATE_FOLLOWER)))
         ret = __layered_range_truncate(trunc_info);
     else if ((dsrc = __wt_schema_get_source(session, uri)) != NULL && dsrc->range_truncate != NULL)

--- a/src/schema/schema_worker.c
+++ b/src/schema/schema_worker.c
@@ -121,7 +121,7 @@ __schema_layered_stable_worker_verify(WT_SESSION_IMPL *session, const char *stab
     WT_ASSERT(session, stable_uri != NULL);
 
     /* Sample the role once so the open and the error message below agree if it changes. */
-    leader = S2C(session)->layered_table_manager.leader;
+    leader = __wt_atomic_load_bool_relaxed(&S2C(session)->layered_table_manager.leader);
 
     if (leader) {
         /* Verify the stable table of the layered table. */
@@ -174,7 +174,7 @@ __schema_layered_ingest_worker_verify(WT_SESSION_IMPL *session, const char *inge
     WT_ASSERT(session, ingest_uri != NULL);
 
     /* We don't verify the ingest table on a follower. */
-    if (!conn->layered_table_manager.leader)
+    if (!__wt_atomic_load_bool_relaxed(&conn->layered_table_manager.leader))
         return (0);
 
     /*

--- a/src/session/session_api.c
+++ b/src/session/session_api.c
@@ -2489,7 +2489,8 @@ __session_checkpoint(WT_SESSION *wt_session, const char *config)
     WT_ERR(__wt_inmem_unsupported_op(session, NULL));
 
     /* Skip running checkpoint for standby. */
-    if (__wt_conn_is_disagg(session) && !S2C(session)->layered_table_manager.leader)
+    if (__wt_conn_is_disagg(session) &&
+      !__wt_atomic_load_bool_relaxed(&S2C(session)->layered_table_manager.leader))
         goto done;
 
     /*

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -2707,7 +2707,8 @@ __wt_txn_global_shutdown(WT_SESSION_IMPL *session, const char **cfg)
          * real leader, the storage layer services should return an error as it is not allowed to
          * write.
          */
-        if (!skip_checkpoint && (!conn_is_disagg || conn->layered_table_manager.leader)) {
+        if (!skip_checkpoint &&
+          (!conn_is_disagg || __wt_atomic_load_bool_relaxed(&conn->layered_table_manager.leader))) {
             WT_TRET(__wt_open_internal_session(conn, "close_ckpt", true, 0, 0, &s));
             if (s != NULL) {
                 const char *checkpoint_cfg[] = {

--- a/src/txn/txn_timestamp.c
+++ b/src/txn/txn_timestamp.c
@@ -401,7 +401,7 @@ __wt_txn_global_set_timestamp(WT_SESSION_IMPL *session, const char *cfg[])
      * one is already set. These are hard invariants, so validate them even under force.
      */
     if (has_step_down) {
-        if (!S2C(session)->layered_table_manager.leader)
+        if (!__wt_atomic_load_bool_relaxed(&S2C(session)->layered_table_manager.leader))
             WT_RET_MSG(session, EINVAL,
               "set_timestamp: step down timestamp can only be set on a disaggregated leader");
         if (__wt_atomic_load_uint64_relaxed(&txn_global->step_down_timestamp) != WT_TS_NONE)

--- a/src/txn/txn_truncate.c
+++ b/src/txn/txn_truncate.c
@@ -420,7 +420,7 @@ __wt_truncate_delete_visible_check(WT_SESSION_IMPL *session, WT_TRUNCATE_LIST *t
     bool is_found = false;
 
     /* The truncate list is only populated on followers; leaders truncate stable directly. */
-    if (S2C(session)->layered_table_manager.leader)
+    if (__wt_atomic_load_bool_relaxed(&S2C(session)->layered_table_manager.leader))
         return (WT_NOTFOUND);
 
     /* In follower-slow truncate mode the list is empty; nothing to find. */

--- a/src/utilities/util_main.c
+++ b/src/utilities/util_main.c
@@ -73,7 +73,7 @@ util_disagg_pick_up_latest_checkpoint(WT_CONNECTION *conn, WT_SESSION *session)
      * Leader-mode pickup is handled inside wiredtiger_open by __wti_disagg_conn_config. Connections
      * without a page log don't need pickup.
      */
-    if (conn_impl->layered_table_manager.leader ||
+    if (__wt_atomic_load_bool_relaxed(&conn_impl->layered_table_manager.leader) ||
       conn_impl->disaggregated_storage.npage_log == NULL)
         return (0);
 


### PR DESCRIPTION
The flag is written on role reconfigure (step-up/step-down in `conn_layered.c`) and read without synchronization from ~50 sites across the tree (layered cursor routing, checkpoint, eviction, history store, schema, sweep). Until now the role effectively only changed while the system was quiesced; with asynchronous step-down and eventually step-up the reconfigure runs concurrently with application cursor traffic, so the plain stores/loads are a data race under the C memory model.

This change marks the field `wt_shared` and converts every access to `__wt_atomic_store_bool_relaxed` / `__wt_atomic_load_bool_relaxed`.