### PR TITLE
WT-18181 Clear the replacement result when reconciliation discards a page's address

### DIFF
--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -3416,6 +3416,14 @@ __rec_write_err(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
          * so the next reconciliation's wrapup sees no address to free.
          */
         __wt_ref_addr_free(session, r->ref);
+        /*
+         * The page has no address left, in the replacement or in the reference, so it can no longer
+         * claim a replacement result: the parent's reconciliation reads the reference address for
+         * such a child and would write an address cell from nothing. Present the page as never
+         * reconciled instead. It stays dirty, so the parent leaves it out of the current checkpoint
+         * and a later reconciliation gives it an address again.
+         */
+        page->modify->rec_result = 0;
     }
 
     WT_TRET(__wti_ovfl_track_wrapup_err(session, page));


### PR DESCRIPTION
`test/format` on disagg switch segfaults in `__wti_rec_cell_build_addr` with `addr=0x0, vpack=0x0`, called from `__wti_rec_row_int` under a checkpoint.

### Cause

The disaggregated cleanup in `__rec_write_err()` invalidates the page id, frees `mod_replace.block_cookie` and `mod_disk_image`, and frees `ref->addr` — but leaves `mod->rec_result` at `WT_PM_REC_REPLACE`. The page then claims a single-page replacement whose address exists nowhere.

When the parent internal page is reconciled, `__wti_rec_child_modify()` returns `WTI_CHILD_MODIFIED` for it (the `ref->addr == NULL -> WTI_CHILD_IGNORE` guard sits below the `rec_result != 0` early exit), and `__wti_rec_row_int()` falls through to `addr = ref->addr`, which is NULL. `__wt_off_page()` reports a null pointer as off-page — it sorts below `page->dsk` — so NULL is routed into the `WT_ADDR` branch and dereferenced at `switch (addr->type)`.

The err-path cleanup was introduced by WT-16864 (#14072); before it, `ref->addr` survived a failed reconciliation, so the parent always had an address to write. The failing build is release/non-diagnostic, so the sibling `WT_ASSERT` checks on this invariant (`rec_write.c:3237`, `__rec_copy_prev_addr`, `evict_page.c:777`) were compiled out and the state reached the parent instead of tripping an assertion.

### Evidence from the core

| Field | Value |
| --- | --- |
| `ref->addr` | `0x0` |
| `cms.state` | `WTI_CHILD_MODIFIED` |
| `mod->rec_result` | 3 = `WT_PM_REC_REPLACE` |
| `mod_replace.block_cookie` | `0x0` |
| `disagg_info->block_meta.page_id` | 0 = `WT_BLOCK_INVALID_PAGE_ID` |
| child `page->flags_atomic` | `0x1015` — includes `WT_PAGE_REC_FAIL` |
| child `mod->first_dirty_txn` | 2435894 |
| checkpoint `txn->snapshot_data.snap_max` | 2427248 |

The last two show how the poisoned leaf survived to the parent: `snap_max < first_dirty_txn`, so `__sync_checkpoint_can_skip()` skipped it in the leaf pass — the leaf was dirtied by a transaction newer than the checkpoint's snapshot — and the internal pass then wrote the parent.

### Fix

Clear `rec_result` alongside the address the same path just discarded, so the page presents as never reconciled. It stays dirty, so the parent leaves it out of the current checkpoint exactly as it does for any other child without an address, and a later reconciliation gives it an address again.

### Not included

No regression test. The failure needs a failed eviction reconciliation and a checkpoint snapshot to interleave in a specific order, and neither a Python nor a csuite harness reproduced it: both reach the stranded state readily (100+ per run, matching the core exactly), but every stranded leaf reaching the leaf pass was healed rather than skipped, because `first_dirty_txn` never landed above the running checkpoint's `snap_max`. Existing disagg format-stress coverage is what found this.

Worth noting separately: `__sync_checkpoint_can_skip()` guards `WT_PM_REC_MULTIBLOCK` with a missing cookie but has no equivalent guard for `WT_PM_REC_REPLACE` with a missing cookie. Not changed here.