### PR TITLE
WT-16481 Allow test/format multi-node mode to work with database reopen

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -1118,9 +1118,7 @@ functions:
           echo Iteration $i/${times}
           rm -rf RUNDIR
           ./t -c ../../../test/format/CONFIG.disagg ${format_args|} ${extra_arg|} || fail
-          if [ ${reopen|true} = true ]; then
-            ./t -R $format_args ${extra_args|} || fail
-          fi
+          ./t -R $format_args ${extra_args|} || fail
         done
   "many dbs test":
     command: shell.exec
@@ -1864,7 +1862,6 @@ variables:
           # FIXME-WT-16732: Enable truncate for multi node once predictable replay supports it.
           format_args: disagg.multi=1 runs.predictable_replay=1 ops.verify=1 disagg.multi_validation=1 runs.ops=1000000:2000000 ops.truncate=0
           times: 10
-          reopen: false # FIXME-WT-16481 Reopen currently causes failures in disagg multi mode.
 
   - &format-stress-test-disagg-multi-pull-request
     depends_on:
@@ -1876,7 +1873,6 @@ variables:
           # FIXME-WT-16732: Enable truncate for multi node once predictable replay supports it.
           format_args: disagg.multi=1 runs.predictable_replay=1 ops.verify=1 disagg.multi_validation=1 runs.rows=20000 runs.ops=100000 ops.truncate=0
           times: 10
-          reopen: false # FIXME-WT-16481 Reopen currently causes failures in disagg multi mode.
 
 #######################################
 #               Tasks                 #

--- a/test/evergreen_disagg.yml
+++ b/test/evergreen_disagg.yml
@@ -592,7 +592,6 @@ variables:
           # FIXME-WT-17278 Enable removes in disagg multi mode once the related issues have been resolved.
           format_args: disagg.multi=1 runs.predictable_replay=1 runs.ops=500000:2000000 ops.pct.delete=0
           times: 5
-          reopen: false # FIXME-WT-16481 Reopen currently causes failures in disagg multi mode.
 
   - &format-stress-test-disagg-multi-data-validation
     depends_on:
@@ -605,7 +604,6 @@ variables:
           # FIXME-WT-17278 Enable removes in disagg multi mode once the related issues have been resolved.
           format_args: disagg.multi=1 runs.predictable_replay=1 ops.verify=1 disagg.multi_validation=1 disagg.preserve=1 runs.ops=500000:2000000 ops.pct.delete=0
           times: 5
-          reopen: false # FIXME-WT-16481 Reopen currently causes failures in disagg multi mode.
 
   # FIXME-WT-17278 We can get rid of this task once the issues related to removes in disagg multi mode have been resolved.
   - &format-stress-test-disagg-multi-delete-enabled
@@ -617,7 +615,6 @@ variables:
         vars:
           format_args: disagg.multi=1 runs.predictable_replay=1 runs.ops=500000:2000000
           times: 5
-          reopen: false # FIXME-WT-16481 Reopen currently causes failures in disagg multi mode.
 
   # FIXME-WT-17278 We can get rid of this task once the issues related to removes in disagg multi mode have been resolved.
   - &format-stress-test-disagg-multi-delete-enabled-data-validation
@@ -630,7 +627,6 @@ variables:
           # Validate data with a non-layered table.
           format_args: disagg.multi=1 runs.predictable_replay=1 ops.verify=1 disagg.multi_validation=1 disagg.preserve=1 runs.ops=500000:2000000
           times: 5
-          reopen: false # FIXME-WT-16481 Reopen currently causes failures in disagg multi mode.
 
   # Long-running randomized stress for snapshot transactions without a read timestamp racing
   # checkpoint pickups on a follower: multi-node runs verify pre-commit re-reads through freshly
@@ -652,7 +648,6 @@ variables:
             disagg.multi=1 disagg.multi_validation=1 disagg.snapshot_read=1
             runs.predictable_replay=1 runs.rows=50000:200000 runs.ops=500000:2000000
           times: 10
-          reopen: false # FIXME-WT-16481 Reopen currently causes failures in disagg multi mode.
 
   - &timestamp-abort-test-disagg
     depends_on:

--- a/test/format/follower.c
+++ b/test/format/follower.c
@@ -86,7 +86,7 @@ err:
  */
 static bool
 follower_try_pickup_checkpoint(WT_SESSION *session, WT_CONNECTION *conn, WT_PAGE_LOG *page_log,
-  WT_ITEM *checkpoint_metadata, wt_timestamp_t checkpoint_ts, bool initialize_timestamps)
+  WT_ITEM *checkpoint_metadata, wt_timestamp_t checkpoint_ts)
 {
     WT_DISAGG_METADATA metadata;
     WT_ITEM full_metadata;
@@ -141,7 +141,7 @@ follower_try_pickup_checkpoint(WT_SESSION *session, WT_CONNECTION *conn, WT_PAGE
     testutil_check(conn->reconfigure(conn, config));
     printf("--- [Follower] Picked up checkpoint (metadata=[%.*s],timestamp=%#" PRIx64 ") ---\n",
       (int)checkpoint_metadata->size, (const char *)checkpoint_metadata->data, checkpoint_ts);
-    if (initialize_timestamps) {
+    if (g.reopen && disagg_is_multi_node()) {
         testutil_snprintf(config, sizeof(config),
           "oldest_timestamp=%" PRIx64 ",stable_timestamp=%" PRIx64, metadata.oldest_timestamp,
           checkpoint_ts);
@@ -182,8 +182,8 @@ follower_read_latest_checkpoint(void)
     ret = page_log->pl_get_complete_checkpoint(page_log, session, &args);
     testutil_check_error_ok(ret, WT_NOTFOUND);
     if (ret != WT_NOTFOUND)
-        (void)follower_try_pickup_checkpoint(session, conn, page_log, &args.checkpoint_metadata,
-          args.checkpoint_timestamp, g.reopen && disagg_is_multi_node());
+        (void)follower_try_pickup_checkpoint(
+          session, conn, page_log, &args.checkpoint_metadata, args.checkpoint_timestamp);
 
     free(args.checkpoint_metadata.mem);
     wt_wrap_close_session(session);
@@ -427,7 +427,7 @@ follower(void *arg)
               memcmp(g.checkpoint_metadata, (const char *)args.checkpoint_metadata.data,
                 args.checkpoint_metadata.size) != 0) {
                 if (follower_try_pickup_checkpoint(session, conn, page_log,
-                      &args.checkpoint_metadata, args.checkpoint_timestamp, false))
+                      &args.checkpoint_metadata, args.checkpoint_timestamp))
                     testutil_snprintf(g.checkpoint_metadata, sizeof(g.checkpoint_metadata), "%.*s",
                       (int)args.checkpoint_metadata.size,
                       (const char *)args.checkpoint_metadata.data);

--- a/test/format/follower.c
+++ b/test/format/follower.c
@@ -118,7 +118,7 @@ follower_try_pickup_checkpoint(WT_SESSION *session, WT_CONNECTION *conn, WT_PAGE
      * on the replay schedule rather than with application. The watermark only exists under
      * predictable replay.
      */
-    if (GV(RUNS_PREDICTABLE_REPLAY)) {
+    if (!set_connection_timestamps && GV(RUNS_PREDICTABLE_REPLAY)) {
         replayed_ts = replay_maximum_committed();
         if (replayed_ts < checkpoint_ts) {
             printf("--- [Follower] Skipping checkpoint pickup: checkpoint_timestamp(hex)=%" PRIx64

--- a/test/format/follower.c
+++ b/test/format/follower.c
@@ -184,8 +184,8 @@ follower_read_latest_checkpoint(void)
     ret = page_log->pl_get_complete_checkpoint(page_log, session, &args);
     testutil_check_error_ok(ret, WT_NOTFOUND);
     if (ret != WT_NOTFOUND)
-        (void)follower_try_pickup_checkpoint(
-          session, conn, page_log, &args.checkpoint_metadata, args.checkpoint_timestamp, g.reopen);
+        (void)follower_try_pickup_checkpoint(session, conn, page_log, &args.checkpoint_metadata,
+          args.checkpoint_timestamp, g.reopen && disagg_is_multi_node());
 
     free(args.checkpoint_metadata.mem);
     wt_wrap_close_session(session);

--- a/test/format/follower.c
+++ b/test/format/follower.c
@@ -146,8 +146,6 @@ follower_try_pickup_checkpoint(WT_SESSION *session, WT_CONNECTION *conn, WT_PAGE
           "oldest_timestamp=%" PRIx64 ",stable_timestamp=%" PRIx64, metadata.oldest_timestamp,
           checkpoint_ts);
         testutil_check(conn->set_timestamp(conn, config));
-        g.timestamp = g.stable_timestamp = checkpoint_ts;
-        g.oldest_timestamp = metadata.oldest_timestamp;
     }
     picked_up = true;
 

--- a/test/format/follower.c
+++ b/test/format/follower.c
@@ -86,7 +86,7 @@ err:
  */
 static bool
 follower_try_pickup_checkpoint(WT_SESSION *session, WT_CONNECTION *conn, WT_PAGE_LOG *page_log,
-  WT_ITEM *checkpoint_metadata, wt_timestamp_t checkpoint_ts)
+  WT_ITEM *checkpoint_metadata, wt_timestamp_t checkpoint_ts, bool set_connection_timestamps)
 {
     WT_DISAGG_METADATA metadata;
     WT_ITEM full_metadata;
@@ -141,7 +141,7 @@ follower_try_pickup_checkpoint(WT_SESSION *session, WT_CONNECTION *conn, WT_PAGE
     testutil_check(conn->reconfigure(conn, config));
     printf("--- [Follower] Picked up checkpoint (metadata=[%.*s],timestamp=%#" PRIx64 ") ---\n",
       (int)checkpoint_metadata->size, (const char *)checkpoint_metadata->data, checkpoint_ts);
-    if (g.reopen && disagg_is_multi_node()) {
+    if (set_connection_timestamps) {
         testutil_snprintf(config, sizeof(config),
           "oldest_timestamp=%" PRIx64 ",stable_timestamp=%" PRIx64, metadata.oldest_timestamp,
           checkpoint_ts);
@@ -182,8 +182,8 @@ follower_read_latest_checkpoint(void)
     ret = page_log->pl_get_complete_checkpoint(page_log, session, &args);
     testutil_check_error_ok(ret, WT_NOTFOUND);
     if (ret != WT_NOTFOUND)
-        (void)follower_try_pickup_checkpoint(
-          session, conn, page_log, &args.checkpoint_metadata, args.checkpoint_timestamp);
+        (void)follower_try_pickup_checkpoint(session, conn, page_log, &args.checkpoint_metadata,
+          args.checkpoint_timestamp, g.reopen && disagg_is_multi_node());
 
     free(args.checkpoint_metadata.mem);
     wt_wrap_close_session(session);
@@ -427,7 +427,7 @@ follower(void *arg)
               memcmp(g.checkpoint_metadata, (const char *)args.checkpoint_metadata.data,
                 args.checkpoint_metadata.size) != 0) {
                 if (follower_try_pickup_checkpoint(session, conn, page_log,
-                      &args.checkpoint_metadata, args.checkpoint_timestamp))
+                      &args.checkpoint_metadata, args.checkpoint_timestamp, false))
                     testutil_snprintf(g.checkpoint_metadata, sizeof(g.checkpoint_metadata), "%.*s",
                       (int)args.checkpoint_metadata.size,
                       (const char *)args.checkpoint_metadata.data);

--- a/test/format/follower.c
+++ b/test/format/follower.c
@@ -86,7 +86,7 @@ err:
  */
 static bool
 follower_try_pickup_checkpoint(WT_SESSION *session, WT_CONNECTION *conn, WT_PAGE_LOG *page_log,
-  WT_ITEM *checkpoint_metadata, wt_timestamp_t checkpoint_ts)
+  WT_ITEM *checkpoint_metadata, wt_timestamp_t checkpoint_ts, bool initialize_timestamps)
 {
     WT_DISAGG_METADATA metadata;
     WT_ITEM full_metadata;
@@ -141,6 +141,14 @@ follower_try_pickup_checkpoint(WT_SESSION *session, WT_CONNECTION *conn, WT_PAGE
     testutil_check(conn->reconfigure(conn, config));
     printf("--- [Follower] Picked up checkpoint (metadata=[%.*s],timestamp=%#" PRIx64 ") ---\n",
       (int)checkpoint_metadata->size, (const char *)checkpoint_metadata->data, checkpoint_ts);
+    if (initialize_timestamps) {
+        testutil_snprintf(config, sizeof(config),
+          "oldest_timestamp=%" PRIx64 ",stable_timestamp=%" PRIx64, metadata.oldest_timestamp,
+          checkpoint_ts);
+        testutil_check(conn->set_timestamp(conn, config));
+        g.timestamp = g.stable_timestamp = checkpoint_ts;
+        g.oldest_timestamp = metadata.oldest_timestamp;
+    }
     picked_up = true;
 
 done:
@@ -177,7 +185,7 @@ follower_read_latest_checkpoint(void)
     testutil_check_error_ok(ret, WT_NOTFOUND);
     if (ret != WT_NOTFOUND)
         (void)follower_try_pickup_checkpoint(
-          session, conn, page_log, &args.checkpoint_metadata, args.checkpoint_timestamp);
+          session, conn, page_log, &args.checkpoint_metadata, args.checkpoint_timestamp, g.reopen);
 
     free(args.checkpoint_metadata.mem);
     wt_wrap_close_session(session);
@@ -421,7 +429,7 @@ follower(void *arg)
               memcmp(g.checkpoint_metadata, (const char *)args.checkpoint_metadata.data,
                 args.checkpoint_metadata.size) != 0) {
                 if (follower_try_pickup_checkpoint(session, conn, page_log,
-                      &args.checkpoint_metadata, args.checkpoint_timestamp))
+                      &args.checkpoint_metadata, args.checkpoint_timestamp, false))
                     testutil_snprintf(g.checkpoint_metadata, sizeof(g.checkpoint_metadata), "%.*s",
                       (int)args.checkpoint_metadata.size,
                       (const char *)args.checkpoint_metadata.data);

--- a/test/format/format.h
+++ b/test/format/format.h
@@ -291,6 +291,7 @@ typedef struct {
 
     wt_timestamp_t replay_cached_committed; /* Our committed timestamp, cached */
     uint32_t replay_calculate_committed;    /* Times before recalculating cached committed */
+    wt_timestamp_t reopen_timestamp;        /* Timestamp recovered when reopening the database */
     wt_timestamp_t replay_start_timestamp;  /* Timestamp at the beginning of a run */
     FILE *replay_op_log;                    /* Predictable replay per-run operation log */
     wt_timestamp_t stop_timestamp;          /* If non-zero, stop when stable reaches this */

--- a/test/format/format_timestamp.c
+++ b/test/format/format_timestamp.c
@@ -125,6 +125,8 @@ timestamp_init(void)
         g.timestamp = WT_MAX(g.timestamp, stable_timestamp);
     if (g.timestamp == WT_TS_NONE)
         g.timestamp = MIN_TIMESTAMP;
+    if (g.reopen && disagg_is_multi_node())
+        g.reopen_timestamp = g.timestamp;
 }
 
 /*

--- a/test/format/format_timestamp.c
+++ b/test/format/format_timestamp.c
@@ -110,19 +110,14 @@ timestamp_query(const char *query, wt_timestamp_t *tsp)
 
 /*
  * timestamp_init --
- *     Set the timestamp on open to the database's recovery timestamp, or some non-zero value.
+ *     Set the timestamp on open to the recovery or stable timestamp, or some non-zero value.
  */
 void
 timestamp_init(void)
 {
-    WT_DECL_RET;
-    wt_timestamp_t stable_timestamp;
-
     testutil_check(timestamp_query("get=recovery", &g.timestamp));
-    ret = timestamp_query("get=stable_timestamp", &stable_timestamp);
-    testutil_assert(ret == 0 || ret == WT_NOTFOUND);
-    if (ret == 0)
-        g.timestamp = WT_MAX(g.timestamp, stable_timestamp);
+    if (g.reopen)
+        g.timestamp = WT_MAX(g.timestamp, g.stable_timestamp);
     if (g.timestamp == WT_TS_NONE)
         g.timestamp = MIN_TIMESTAMP;
     if (g.reopen && disagg_is_multi_node())

--- a/test/format/format_timestamp.c
+++ b/test/format/format_timestamp.c
@@ -115,7 +115,14 @@ timestamp_query(const char *query, wt_timestamp_t *tsp)
 void
 timestamp_init(void)
 {
+    WT_DECL_RET;
+    wt_timestamp_t stable_timestamp;
+
     testutil_check(timestamp_query("get=recovery", &g.timestamp));
+    ret = timestamp_query("get=stable_timestamp", &stable_timestamp);
+    testutil_assert(ret == 0 || ret == WT_NOTFOUND);
+    if (ret == 0)
+        g.timestamp = WT_MAX(g.timestamp, stable_timestamp);
     if (g.timestamp == WT_TS_NONE)
         g.timestamp = MIN_TIMESTAMP;
 }

--- a/test/format/ops.c
+++ b/test/format/ops.c
@@ -344,7 +344,8 @@ operations(u_int ops_seconds, u_int run_current, u_int run_total)
              */
             thread_ops = -1;
             ops_seconds = 0;
-            g.stop_timestamp = (GV(RUNS_OPS) * (uint64_t)run_current) / run_total;
+            g.stop_timestamp =
+              g.reopen_timestamp + (GV(RUNS_OPS) * (uint64_t)run_current) / run_total;
         } else
             thread_ops = GV(RUNS_OPS) / GV(RUNS_THREADS);
     }

--- a/test/format/t.c
+++ b/test/format/t.c
@@ -345,8 +345,7 @@ main(int argc, char *argv[])
         if (access(g.home_backup, F_OK) == 0)
             is_backup = true;
         wts_open(g.home, &g.wts_conn, !is_backup);
-        /* Followers must pick up the shared checkpoint before initializing their timestamp counter.
-         */
+        /* For disagg follower node pick up the latest checkpoint. */
         if (g.disagg_storage_config && !g.disagg_leader)
             follower_read_latest_checkpoint();
         /* Update the oldest and stable timestamps if they have been previously set. */

--- a/test/format/t.c
+++ b/test/format/t.c
@@ -349,12 +349,12 @@ main(int argc, char *argv[])
          */
         if (g.disagg_storage_config && !g.disagg_leader)
             follower_read_latest_checkpoint();
-        timestamp_init();
         /* Update the oldest and stable timestamps if they have been previously set. */
         ret = timestamp_query("get=oldest_timestamp", &g.oldest_timestamp);
         testutil_assert(ret == 0 || ret == WT_NOTFOUND);
         ret = timestamp_query("get=stable_timestamp", &g.stable_timestamp);
         testutil_assert(ret == 0 || ret == WT_NOTFOUND);
+        timestamp_init();
         locks_init(g.wts_conn);
     } else {
         wts_create_home();

--- a/test/format/t.c
+++ b/test/format/t.c
@@ -345,16 +345,20 @@ main(int argc, char *argv[])
         if (access(g.home_backup, F_OK) == 0)
             is_backup = true;
         wts_open(g.home, &g.wts_conn, !is_backup);
+        /* Single-node followers pick up a checkpoint before initializing their timestamps. */
+        if (g.disagg_storage_config && !g.disagg_leader && !disagg_is_multi_node())
+            follower_read_latest_checkpoint();
         timestamp_init();
-        /* For disagg follower node pick up the latest checkpoint. */
-        if (g.disagg_storage_config && !g.disagg_leader)
+        /* Multi-node followers initialize their timestamps from the checkpoint they pick up. */
+        if (g.disagg_storage_config && !g.disagg_leader && disagg_is_multi_node())
             follower_read_latest_checkpoint();
         /* Update the oldest and stable timestamps if they have been previously set. */
         ret = timestamp_query("get=oldest_timestamp", &g.oldest_timestamp);
         testutil_assert(ret == 0 || ret == WT_NOTFOUND);
         ret = timestamp_query("get=stable_timestamp", &g.stable_timestamp);
         testutil_assert(ret == 0 || ret == WT_NOTFOUND);
-        g.reopen_timestamp = g.timestamp;
+        if (disagg_is_multi_node())
+            g.reopen_timestamp = g.timestamp;
         locks_init(g.wts_conn);
     } else {
         wts_create_home();

--- a/test/format/t.c
+++ b/test/format/t.c
@@ -355,8 +355,6 @@ main(int argc, char *argv[])
         testutil_assert(ret == 0 || ret == WT_NOTFOUND);
         ret = timestamp_query("get=stable_timestamp", &g.stable_timestamp);
         testutil_assert(ret == 0 || ret == WT_NOTFOUND);
-        if (disagg_is_multi_node())
-            g.reopen_timestamp = g.timestamp;
         locks_init(g.wts_conn);
     } else {
         wts_create_home();

--- a/test/format/t.c
+++ b/test/format/t.c
@@ -345,13 +345,11 @@ main(int argc, char *argv[])
         if (access(g.home_backup, F_OK) == 0)
             is_backup = true;
         wts_open(g.home, &g.wts_conn, !is_backup);
-        /* Single-node followers pick up a checkpoint before initializing their timestamps. */
-        if (g.disagg_storage_config && !g.disagg_leader && !disagg_is_multi_node())
+        /* Followers must pick up the shared checkpoint before initializing their timestamp counter.
+         */
+        if (g.disagg_storage_config && !g.disagg_leader)
             follower_read_latest_checkpoint();
         timestamp_init();
-        /* Multi-node followers initialize their timestamps from the checkpoint they pick up. */
-        if (g.disagg_storage_config && !g.disagg_leader && disagg_is_multi_node())
-            follower_read_latest_checkpoint();
         /* Update the oldest and stable timestamps if they have been previously set. */
         ret = timestamp_query("get=oldest_timestamp", &g.oldest_timestamp);
         testutil_assert(ret == 0 || ret == WT_NOTFOUND);

--- a/test/format/t.c
+++ b/test/format/t.c
@@ -345,15 +345,16 @@ main(int argc, char *argv[])
         if (access(g.home_backup, F_OK) == 0)
             is_backup = true;
         wts_open(g.home, &g.wts_conn, !is_backup);
+        timestamp_init();
         /* For disagg follower node pick up the latest checkpoint. */
         if (g.disagg_storage_config && !g.disagg_leader)
             follower_read_latest_checkpoint();
-        timestamp_init();
         /* Update the oldest and stable timestamps if they have been previously set. */
         ret = timestamp_query("get=oldest_timestamp", &g.oldest_timestamp);
         testutil_assert(ret == 0 || ret == WT_NOTFOUND);
         ret = timestamp_query("get=stable_timestamp", &g.stable_timestamp);
         testutil_assert(ret == 0 || ret == WT_NOTFOUND);
+        g.reopen_timestamp = g.timestamp;
         locks_init(g.wts_conn);
     } else {
         wts_create_home();


### PR DESCRIPTION
Enable multi-node test/format reopen coverage and restore follower timestamps from the picked-up checkpoint so verification and replay continue from recovered state. 

Preserve switch-mode reopen ordering while basing multi-node replay targets on the recovered timestamp.