### PR TITLE
WT-17752 Fix buffer overflow in transaction state dump (9.0) (#14243)

### DIFF
--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -2760,7 +2760,7 @@ __wt_verbose_dump_txn_one(
     WT_DECL_RET;
     WT_TXN *txn;
     WT_TXN_SHARED *txn_shared;
-    uint32_t i, buf_len;
+    uint32_t i;
     char ckpt_lsn_str[WT_MAX_LSN_STRING];
     char ts_string[6][WT_TS_INT_STRING_SIZE];
     const char *iso_tag;
@@ -2780,11 +2780,10 @@ __wt_verbose_dump_txn_one(
       !F_ISSET(txn, WT_TXN_HAS_SNAPSHOT))
         return (0);
 
-    buf_len = 512;
-    WT_RET(__wt_scr_alloc(session, buf_len, &buf));
+    WT_RET(__wt_scr_alloc(session, 0, &buf));
 
     const char *session_name = __wt_atomic_load_ptr_relaxed(&txn_session->name);
-    WT_ERR(__wt_snprintf((char *)buf->data, buf_len,
+    WT_ERR(__wt_buf_fmt(session, buf,
       "session ID: %" PRIu32 ", txn ID: %" PRIu64 ", pinned ID: %" PRIu64
       ", metadata pinned ID: %" PRIu64 ", name: %s",
       txn_session->id, __wt_atomic_load_uint64_v_relaxed(&txn_shared->id),
@@ -2822,10 +2821,7 @@ __wt_verbose_dump_txn_one(
         WT_ERR(__wt_buf_catfmt(
           session, snapshot_buf, "%s%" PRIu64, i == 0 ? "" : ", ", txn->snapshot_data.snapshot[i]));
     WT_ERR(__wt_buf_catfmt(session, snapshot_buf, "%s", "]\0"));
-    buf_len = (uint32_t)snapshot_buf->size + 512;
-    if (txn_err_info->err_msg != NULL)
-        buf_len += strlen(txn_err_info->err_msg);
-    WT_ERR(__wt_scr_alloc(session, buf_len, &buf));
+    WT_ERR(__wt_scr_alloc(session, 0, &buf));
 
     WT_ERR(__wt_lsn_string(&txn->ckpt_lsn, sizeof(ckpt_lsn_str), ckpt_lsn_str));
 
@@ -2834,7 +2830,7 @@ __wt_verbose_dump_txn_one(
      * error message.
      */
     WT_ERR(
-      __wt_snprintf((char *)buf->data, buf_len,
+      __wt_buf_fmt(session, buf,
         "transaction id: %" PRIu64 ", mod count: %u"
         ", snap min: %" PRIu64 ", snap max: %" PRIu64 ", snapshot count: %u"
         ", snapshot: %s"


### PR DESCRIPTION
The per-transaction dump line in __wt_verbose_dump_txn_one() was formatted into a fixed-size buffer (snapshot length + a flat 512-byte allowance). The other fields can exceed that (~700 bytes worst case), so __wt_snprintf returned ERANGE, which panicked the eviction thread. Disaggregated storage hits this reliably because the checkpoint LSN and transaction timestamps are populated at once.

Fix: build both lines with a growable scratch buffer via __wt_buf_fmt instead of the pre-sized __wt_snprintf, so the buffer grows to fit and can't overflow. Used __wt_buf_fmt (replace) rather than __wt_buf_catfmt (append) as suggested in the ticket fix because each line is written in a single call.

Tested: test_txn28 and test_timestamp26 pass.
(cherry picked from commit 3a11bd180dc60757ff21fe98ea76656a745676cd)

