### PR TITLE
WT-18292 Suppress the benign SQLite WAL-index header race under TSan

### DIFF
--- a/test/evergreen.yml
+++ b/test/evergreen.yml
@@ -66,7 +66,7 @@ functions:
               export MSAN_OPTIONS="$COMMON_SAN_OPTIONS"
               export TESTUTIL_MSAN=1
             elif [[ "${CMAKE_BUILD_TYPE|}" =~ TSan ]]; then
-              export TSAN_OPTIONS="$COMMON_SAN_OPTIONS"
+              export TSAN_OPTIONS="$COMMON_SAN_OPTIONS:history_size=7:print_suppressions=0:suppressions=$WT_TOPDIR/test/evergreen/tsan_warnings.supp"
               export TESTUTIL_TSAN=1
             elif [[ "${CMAKE_BUILD_TYPE|}" =~ UBSan ]]; then
               export UBSAN_OPTIONS="$COMMON_SAN_OPTIONS:print_stacktrace=1"

--- a/test/evergreen/tsan_warnings.supp
+++ b/test/evergreen/tsan_warnings.supp
@@ -26,6 +26,12 @@ race:__tiered_queue_peek_empty
 # lock: a stale answer only delays the pickup server's next look at the queue.
 race:__disagg_deferred_ckpt_queued
 
+# SQLite reads the WAL-index header without synchronization on purpose: it keeps two redundant copies
+# plus a checksum and retries when they disagree, which TSan cannot see. The palite page log runs SQLite
+# in WAL mode, so any concurrent reader and writer of the page log reaches this.
+race:walIndexTryHdr
+race:walIndexWriteHdr
+
 # The ref track code is diagnostic only and allows for races
 race:__ref_track_state
 

--- a/test/evergreen_disagg.yml
+++ b/test/evergreen_disagg.yml
@@ -78,7 +78,7 @@ functions:
               export MSAN_OPTIONS="$COMMON_SAN_OPTIONS:verbosity=3"
               export TESTUTIL_MSAN=1
             elif [[ "${CMAKE_BUILD_TYPE|}" =~ TSan ]]; then
-              export TSAN_OPTIONS="$COMMON_SAN_OPTIONS:verbosity=3"
+              export TSAN_OPTIONS="$COMMON_SAN_OPTIONS:verbosity=3:history_size=7:print_suppressions=0:suppressions=$WT_TOPDIR/test/evergreen/tsan_warnings.supp"
               export TESTUTIL_TSAN=1
             elif [[ "${CMAKE_BUILD_TYPE|}" =~ UBSan ]]; then
               export UBSAN_OPTIONS="$COMMON_SAN_OPTIONS:print_stacktrace=1"


### PR DESCRIPTION
The TSan report in WT-18292 is entirely inside SQLite's WAL-index code: `walIndexTryHdr` racing with `walIndexWriteHdr` on the wal-index header, reached through the `palite` page log from a disaggregated checkpoint pickup on one side and a page discard on the other.

That read is unsynchronized by design. SQLite keeps two redundant copies of the header plus a checksum, reads them optimistically, and retries when the copies disagree — TSan cannot see the validation, so it flags every such read.

Upstream already knows this and annotates both functions with `SQLITE_NO_TSAN`, but the macro is gated on `#if defined(__clang__)` and the failing variants build with the mongodbtoolchain GCC, so it expands to nothing and the functions stay instrumented. The reported access is the `memcpy` interceptor besides, which the attribute would not suppress even on clang. Suppressing in the file avoids forking the vendored SQLite.

While here: `test/evergreen_disagg.yml` set `TSAN_OPTIONS` without a `suppressions=` entry, so no suppression in this file applied to disaggregated TSan runs. Both configs now load it from the shared `PREPARE_TEST_ENV` block, so new TSan variants get it without having to remember. The two existing per-variant overrides in `test/evergreen.yml` are now redundant but left in place as the per-variant knob.