### PR TITLE
WT-18294 Wait for checkpoint adoption before asserting ingest garbage collection

### DIFF
--- a/test/suite/helpers/helper_disagg.py
+++ b/test/suite/helpers/helper_disagg.py
@@ -232,6 +232,28 @@ class DisaggConfigMixin:
         m = self.disagg_get_complete_checkpoint_meta(conn_leader)
         conn_follower.reconfigure(f'disaggregated=(checkpoint_meta="{m}")')
 
+    # Wait until every checkpoint delivered to the follower has been adopted. A caller that asserts
+    # on state the adoption produces needs this: a delivery that raced a snapshot's release is
+    # adopted by the pickup server rather than inline. Snapshots that predate a delivery block it
+    # indefinitely, so end them before waiting.
+    def disagg_wait_for_adoption(self, conn_follower, timeout=60):
+        session = conn_follower.open_session('')
+        try:
+            deadline = time.time() + timeout
+            while True:
+                cursor = session.open_cursor('statistics:')
+                delivered = cursor[wiredtiger.stat.conn.disagg_checkpoint_delivered_lsn][2]
+                adopted = cursor[wiredtiger.stat.conn.disagg_checkpoint_meta_lsn][2]
+                cursor.close()
+                if adopted >= delivered:
+                    return
+                if time.time() > deadline:
+                    raise Exception(f'checkpoint {delivered} not adopted within {timeout}s, ' +
+                                    f'newest adopted is {adopted}')
+                time.sleep(0.01)
+        finally:
+            session.close()
+
     # Switch the leader and the follower
     def disagg_switch_follower_and_leader(self, conn_follower, conn_leader=None):
         if conn_leader is None:

--- a/test/suite/test_layered_follower10.py
+++ b/test/suite/test_layered_follower10.py
@@ -143,6 +143,7 @@ class test_layered_follower10(wttest.WiredTigerTestCase):
         # until we pick up another checkpoint.
         self.session.checkpoint()
         self.disagg_advance_checkpoint(conn_follow)
+        self.disagg_wait_for_adoption(conn_follow)
 
         self.evict_ingest(session_follow, ts)
         count = self.count_ingest(session_follow)
@@ -240,6 +241,7 @@ class test_layered_follower10(wttest.WiredTigerTestCase):
         # Trigger advance checkpoint code again to set the prune timestamp to the last
         # checkpoint timestamp. We couldn't do that because there was a cursor holding the old content.
         self.disagg_advance_checkpoint(conn_follow)
+        self.disagg_wait_for_adoption(conn_follow)
 
         # Now eviction should remove all the items from the ingest table.
         self.evict_ingest(session_follow, ts)
@@ -295,6 +297,7 @@ class test_layered_follower10(wttest.WiredTigerTestCase):
 
         # Pickup the last checkpoint and perform the final garbage collection
         self.disagg_advance_checkpoint(conn_follow)
+        self.disagg_wait_for_adoption(conn_follow)
 
         # Now eviction should remove all the items from the ingest table.
         self.evict_ingest(session_follow, ts)
@@ -326,6 +329,7 @@ class test_layered_follower10(wttest.WiredTigerTestCase):
 
         # Take a checkpoint and advance it, make sure everything is garbage collected
         self.disagg_advance_checkpoint(conn_follow)
+        self.disagg_wait_for_adoption(conn_follow)
         oplog.check(self, session_follow, 0, self.nitems)
 
         # Now eviction should remove all the items from the ingest table.


### PR DESCRIPTION
`test_layered_follower10.test_gc_ingest_with_cursor` failed in CI with `AssertionError: Tuples differ: (1, 0) != (0, 0)` — one record survived the final ingest-table garbage collection.

### Cause

WT-18156 made checkpoint adoption asynchronous when a transaction snapshot predating the delivery is active: the checkpoint is queued and drained by the pickup server. `disagg_advance_checkpoint` only delivers — it waits for nothing — so a delivery is not necessarily adopted by the time it returns.

The test closes the cursor holding the blocking snapshot, which signals the pickup server to adopt the queued checkpoint on its own thread, then immediately delivers another checkpoint and asserts complete garbage collection. Under load the assertion ran before the adoption had advanced the prune timestamp.

The adoption ordering itself is safe — a superseded adoption is rejected with EINVAL/EBUSY and the deferred queue pruned — so this is a missing test barrier, not a correctness bug.

WT-18156 made this concession for the sibling `test_gc_ingest_table_with_remove`, relaxing its exact counts to "how many is eviction's choice"; `test_gc_ingest_with_cursor` received only a comment change and kept asserting exact zero.

### Change

`disagg_wait_for_adoption()` polls the follower until the adopted checkpoint LSN reaches the delivered one, using the statistics added by WT-18251, with a timeout that raises rather than hangs. It is called at the four deliveries followed by an exact-count assertion — one of which is this failure, the other three being the same latent hole in sibling tests in the file.

Deliveries made while a cursor deliberately holds a blocking snapshot are left alone: those adoptions cannot complete until the snapshot ends, so waiting there would hang by design.

I kept the exact-value oracles rather than relaxing them, since waiting makes them deterministic and they are the stronger check.