### PR TITLE
WT-18295 Hold the child hazard pointer through internal-page delta packing

### DIFF
--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -796,13 +796,9 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
         if (__wti_rec_need_split(r, key->len + val->len))
             WT_ERR(__wti_rec_split_crossing_bnd(session, r, key->len + val->len));
 
-        /*
-         * Copy the key and value onto the page. val->buf.data may point directly into ref's WT_ADDR
-         * block_cookie; hold the hazard pointer until after both copies.
-         */
+        /* Copy the key and value onto the page. */
         __wti_rec_image_copy(session, r, key);
         __wti_rec_image_copy(session, r, val);
-        WTI_CHILD_RELEASE_ERR(session, cms.hazard, ref);
         if (page_del != NULL)
             WTI_REC_CHUNK_TA_MERGE(session, r->cur_ptr, &ft_ta);
         WTI_REC_CHUNK_TA_MERGE(session, r->cur_ptr, &ta);
@@ -810,8 +806,14 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
         /* Update compression state. */
         __rec_key_state_update(r, false);
 
+        /*
+         * The value may point directly into the child's address cookie, which a concurrent split
+         * rewrite is free to discard once the child is unpinned, so keep the hazard pointer until
+         * the delta has taken its own copy.
+         */
         if (build_delta && prev_dirty && !retain_onpage)
             WT_ERR(__rec_pack_delta_row_int(session, r, key, val, &ta));
+        WTI_CHILD_RELEASE_ERR(session, cms.hazard, ref);
 
         /*
          * Set the ref dirty state to clean if there were no concurrent changes while reconciling

--- a/src/reconcile/rec_row.c
+++ b/src/reconcile/rec_row.c
@@ -799,12 +799,6 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
         /* Copy the key and value onto the page. */
         __wti_rec_image_copy(session, r, key);
         __wti_rec_image_copy(session, r, val);
-        if (page_del != NULL)
-            WTI_REC_CHUNK_TA_MERGE(session, r->cur_ptr, &ft_ta);
-        WTI_REC_CHUNK_TA_MERGE(session, r->cur_ptr, &ta);
-
-        /* Update compression state. */
-        __rec_key_state_update(r, false);
 
         /*
          * The value may point directly into the child's address cookie, which a concurrent split
@@ -814,6 +808,13 @@ __wti_rec_row_int(WT_SESSION_IMPL *session, WTI_RECONCILE *r, WT_PAGE *page)
         if (build_delta && prev_dirty && !retain_onpage)
             WT_ERR(__rec_pack_delta_row_int(session, r, key, val, &ta));
         WTI_CHILD_RELEASE_ERR(session, cms.hazard, ref);
+
+        if (page_del != NULL)
+            WTI_REC_CHUNK_TA_MERGE(session, r->cur_ptr, &ft_ta);
+        WTI_REC_CHUNK_TA_MERGE(session, r->cur_ptr, &ta);
+
+        /* Update compression state. */
+        __rec_key_state_update(r, false);
 
         /*
          * Set the ref dirty state to clean if there were no concurrent changes while reconciling


### PR DESCRIPTION
ASAN heap-use-after-free on the disagg-leader format stress variant: a 20-byte region allocated by `__wt_memdup` in `__rec_split_write` is freed by `__wt_split_rewrite` -> `__wt_ref_out` -> `__free_page_modify` on an eviction thread, and read by the checkpoint thread in `__rec_pack_delta_row_int` -> `__wti_rec_kv_copy`.

In `__wti_rec_row_int`, the off-page child address branch calls `__wti_rec_cell_build_addr()`, which makes `val->buf.data` alias the child's `WT_ADDR::block_cookie` directly instead of copying it. The loop released the child hazard pointer after `__wti_rec_image_copy(val)` but before `__rec_pack_delta_row_int()`, which copies `val` a second time into the delta buffer. Between those two points a concurrent split rewrite is free to discard the child's address, so the delta copy reads freed memory.

The delta call is guarded by `!retain_onpage`, which is exactly the off-page `WT_ADDR` case — the only case where `val->buf.data` points at heap memory owned by the child rather than into the parent's disk image. The window is only reachable with internal-page deltas enabled.

This is an incomplete fix from WT-17411 (f9ec2b306b), which moved `WTI_CHILD_RELEASE_ERR` past the two `__wti_rec_image_copy` calls but left the delta copy after the release. It is unrelated to WT-18156; 8fa1e5db is only where the failure first surfaced in the waterfall.

Move the release to after the delta packing. `__wti_rec_col_int` has no delta packing after its release and is unaffected.