### PR TITLE
WT-18298 Publish the updates trigger only once it is validated

### DIFF
--- a/src/evict/evict_conn.c
+++ b/src/evict/evict_conn.c
@@ -94,10 +94,9 @@ __evict_validate_config(WT_SESSION_IMPL *session, const char *cfg[])
       "eviction updates target", conn->cache_size, shared));
 
     WT_RET(__wt_config_gets(session, cfg, "eviction_updates_trigger", &cval));
-    double updates_trigger_val = (double)cval.val;
+    double updates_trigger = (double)cval.val;
     WT_RET(__evict_config_abs_to_pct(
-      session, &updates_trigger_val, "eviction updates trigger", conn->cache_size, shared));
-    __wt_atomic_store_double_relaxed(&evict->eviction_updates_trigger, updates_trigger_val);
+      session, &updates_trigger, "eviction updates trigger", conn->cache_size, shared));
 
     WT_RET(__wt_config_gets(session, cfg, "eviction_checkpoint_target", &cval));
     evict->eviction_checkpoint_target = (double)cval.val;
@@ -155,7 +154,6 @@ __evict_validate_config(WT_SESSION_IMPL *session, const char *cfg[])
         }
     }
 
-    double updates_trigger = __wt_atomic_load_double_relaxed(&evict->eviction_updates_trigger);
     if (updates_trigger < DBL_EPSILON) {
         /*
          * Generally we want to allow a reasonable amount of updates content, the default dirty

--- a/test/catch2/CMakeLists.txt
+++ b/test/catch2/CMakeLists.txt
@@ -20,6 +20,7 @@ else()
         misc_tests/test_disagg_replace_checkpoint.cpp
         misc_tests/test_error.cpp
         misc_tests/test_evict_bounded_wait.cpp
+        misc_tests/test_evict_updates_trigger_reconfigure.cpp
         misc_tests/test_futex.cpp
         misc_tests/test_intpack.cpp
         misc_tests/test_mock_session.cpp

--- a/test/catch2/misc_tests/test_evict_updates_trigger_reconfigure.cpp
+++ b/test/catch2/misc_tests/test_evict_updates_trigger_reconfigure.cpp
@@ -22,9 +22,9 @@
 TEST_CASE("Reconfiguring eviction leaves the updates trigger visible to readers", "[evict]")
 {
     /*
-     * Leave eviction_updates_trigger unset so it is auto-computed from eviction_dirty_trigger:
-     * the auto-computed value is never written back into the connection's saved configuration
-     * string, so every reconfigure call re-derives it from scratch.
+     * Leave eviction_updates_trigger unset so it is auto-computed from eviction_dirty_trigger: the
+     * auto-computed value is never written back into the connection's saved configuration string,
+     * so every reconfigure call re-derives it from scratch.
      */
     connection_wrapper conn_wrapper =
       connection_wrapper(".", "create,eviction_dirty_trigger=20,eviction_dirty_target=5");

--- a/test/catch2/misc_tests/test_evict_updates_trigger_reconfigure.cpp
+++ b/test/catch2/misc_tests/test_evict_updates_trigger_reconfigure.cpp
@@ -1,0 +1,53 @@
+/*-
+ * Copyright (c) 2014-present MongoDB, Inc.
+ * Copyright (c) 2008-2014 WiredTiger, Inc.
+ *	All rights reserved.
+ *
+ * See the file LICENSE for redistribution information.
+ */
+
+#include <atomic>
+#include <thread>
+
+#include <catch2/catch.hpp>
+
+#include "wt_internal.h"
+#include "../wrappers/connection_wrapper.h"
+
+/*
+ * Reconfiguring without naming eviction_updates_trigger must never make concurrent readers of
+ * WT_EVICT::eviction_updates_trigger observe zero: a zero reading is indistinguishable from "not
+ * yet defaulted" and disables the updates-trigger check in eviction.
+ */
+TEST_CASE("Reconfiguring eviction leaves the updates trigger visible to readers", "[evict]")
+{
+    /*
+     * Leave eviction_updates_trigger unset so it is auto-computed from eviction_dirty_trigger:
+     * the auto-computed value is never written back into the connection's saved configuration
+     * string, so every reconfigure call re-derives it from scratch.
+     */
+    connection_wrapper conn_wrapper =
+      connection_wrapper(".", "create,eviction_dirty_trigger=20,eviction_dirty_target=5");
+    WT_CONNECTION *conn = conn_wrapper.get_wt_connection();
+    WT_EVICT *evict = conn_wrapper.get_wt_connection_impl()->evict;
+
+    std::atomic<bool> stop{false};
+    std::atomic<bool> zero_seen{false};
+
+    std::thread reader([&]() {
+        while (!stop.load()) {
+            if (__wt_atomic_load_double_relaxed(&evict->eviction_updates_trigger) < DBL_EPSILON)
+                zero_seen.store(true);
+        }
+    });
+
+    for (int i = 0; i < 5000 && !zero_seen.load(); i++) {
+        REQUIRE(conn->reconfigure(conn, "eviction_dirty_target=6") == 0);
+        REQUIRE(conn->reconfigure(conn, "eviction_dirty_target=5") == 0);
+    }
+
+    stop.store(true);
+    reader.join();
+
+    REQUIRE(!zero_seen.load());
+}


### PR DESCRIPTION
eviction_updates_trigger is stored to shared state straight from the parsed configuration value and only corrected after validation, so a reconfigure that does not name the knob leaves the field readable as the raw, unvalidated value for the width of the call — including zero, since the knob's own default parses to `'0'`. This differs from eviction_dirty_target/eviction_dirty_trigger in the same function, which are kept as pure locals until validated. This change keeps eviction_updates_trigger local until validation completes and publishes it once, matching the existing pattern for the dirty target/trigger.