### PR TITLE
WT-18301 Wait for checkpoint adoption before asserting picked-up content

### DIFF
--- a/test/suite/test_layered_follower16.py
+++ b/test/suite/test_layered_follower16.py
@@ -170,12 +170,15 @@ class test_layered_follower16(wttest.WiredTigerTestCase):
 
         self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(10)}')
         self.session.checkpoint()
-        # The survive scenario keeps its transaction open across the pickup, deferring the
-        # adoption, so there is nothing to wait for.
         self.disagg_advance_checkpoint(conn_follow)
 
         if self.txn_mode != 'survive':
+            # The counts below need a stable constituent to bind, so wait for the adoption:
+            # a delivery is not necessarily adopted by the time it returns.
+            self.disagg_wait_for_adoption(conn_follow)
             session_follow.begin_transaction()
+        # The survive scenario keeps its transaction open across the pickup, deferring the
+        # adoption indefinitely: waiting there would hang.
 
         # Only the operations that must consult stable open it. An exact search and a write defer
         # the follower's stable open until the ingest lookup misses, which for these keys happens

--- a/test/suite/test_layered_follower21.py
+++ b/test/suite/test_layered_follower21.py
@@ -124,7 +124,9 @@ class test_layered_follower21(wttest.WiredTigerTestCase):
 
     def check_new_data_visible(self, conn_follow):
         # Outside the racing transaction, the picked-up content must be there:
-        # a fresh transaction sees the post-pickup writes.
+        # a fresh transaction sees the post-pickup writes. Callers get here with the
+        # blocking snapshot ended, so the adoption it deferred can now be waited for.
+        self.disagg_wait_for_adoption(conn_follow)
         session = conn_follow.open_session('')
         session.begin_transaction()
         cursor = session.open_cursor(self.uri)
@@ -802,6 +804,7 @@ class test_layered_follower21(wttest.WiredTigerTestCase):
         # picked-up content with no rollbacks.
         conn_follow, session_follow = self.setup_with_first_checkpoint()
         self.commit_post_snapshot_writes(conn_follow)
+        self.disagg_wait_for_adoption(conn_follow)
 
         session_follow.begin_transaction()
         cursor = session_follow.open_cursor(self.uri)
@@ -838,9 +841,12 @@ class test_layered_follower21(wttest.WiredTigerTestCase):
         cursor.close()
         session_hold.rollback_transaction()
         session_hold.close()
-        # With the snapshot gone, a freshly delivered checkpoint is adopted synchronously.
+        # With the snapshot gone, nothing blocks the adoption. It still may not run inline: any
+        # snapshot the node happens to hold, including the ones the adoption itself takes, defers
+        # the delivery to the server, so wait for it before reading.
         self.session.checkpoint()
         self.disagg_advance_checkpoint(conn_follow)
+        self.disagg_wait_for_adoption(conn_follow)
 
         session = conn_follow.open_session('')
         session.begin_transaction()


### PR DESCRIPTION
[WT-18301](https://jira.mongodb.org/browse/WT-18301) — `test_layered_follower21.test_step_down_restarts_deferred_pickup` failed on rhel8-zseries with `key_final` not found.

### The problem

A checkpoint delivered to a disaggregated follower is not necessarily adopted by the time the delivering thread returns. The delivery is deferred to the pickup server whenever an untimestamped snapshot pinning the checkpoint generation is active, and every follower snapshot takes that pin — including the ones the node runs for its own internal work, among them the metadata transactions the adoption itself performs. A reader whose snapshot is established before the server drains the queue binds its stable constituent to the previously adopted checkpoint, and reads none of the delivered content.

The test asserted the opposite: that a delivery made with no reader blocking it is adopted inline, and read immediately afterwards. On a slow host the read landed first. This is the same failure mode as WT-18294, in a second file.

### The change

Wait for the adoption at the three places that assert on state a pickup produces with no blocking snapshot deliberately held:

- the final read of `test_step_down_restarts_deferred_pickup`, and the comment claiming synchronous adoption;
- `check_new_data_visible()`, reached after the blocking transaction ends, so the adoption it deferred is still in flight — this covers `test_new_cursor_after_pickup` and `test_pickup_then_step_up`;
- `test_transaction_after_pickup_unaffected`.

The deliveries made while a cursor deliberately pins a snapshot are left alone: those adoptions cannot complete until the snapshot ends, so waiting there would hang by design.

`disagg_wait_for_adoption()` is identical to the helper on the WT-18294 branch. Whichever of the two lands second should drop its copy.

### Confidence

The failure does not reproduce on an unloaded x86 box either before or after the change, so the justification is the deferral condition in `__wti_disagg_pick_up_checkpoint_meta()`, not a repro. Test-only; no product change.