### PR TITLE
WT-18302 Wait for checkpoint adoption before asserting picked-up content

### DIFF
--- a/test/suite/helpers/helper_disagg.py
+++ b/test/suite/helpers/helper_disagg.py
@@ -232,6 +232,28 @@ class DisaggConfigMixin:
         m = self.disagg_get_complete_checkpoint_meta(conn_leader)
         conn_follower.reconfigure(f'disaggregated=(checkpoint_meta="{m}")')
 
+    # Wait until every checkpoint delivered to the follower has been adopted. A caller that asserts
+    # on state the adoption produces needs this: a delivery that raced a snapshot's release is
+    # adopted by the pickup server rather than inline. Snapshots that predate a delivery block it
+    # indefinitely, so end them before waiting.
+    def disagg_wait_for_adoption(self, conn_follower, timeout=60):
+        session = conn_follower.open_session('')
+        try:
+            deadline = time.time() + timeout
+            while True:
+                cursor = session.open_cursor('statistics:')
+                delivered = cursor[wiredtiger.stat.conn.disagg_checkpoint_delivered_lsn][2]
+                adopted = cursor[wiredtiger.stat.conn.disagg_checkpoint_meta_lsn][2]
+                cursor.close()
+                if adopted >= delivered:
+                    return
+                if time.time() > deadline:
+                    raise Exception(f'checkpoint {delivered} not adopted within {timeout}s, ' +
+                                    f'newest adopted is {adopted}')
+                time.sleep(0.01)
+        finally:
+            session.close()
+
     # Switch the leader and the follower
     def disagg_switch_follower_and_leader(self, conn_follower, conn_leader=None):
         if conn_leader is None:

--- a/test/suite/test_layered_follower10.py
+++ b/test/suite/test_layered_follower10.py
@@ -143,6 +143,7 @@ class test_layered_follower10(wttest.WiredTigerTestCase):
         # until we pick up another checkpoint.
         self.session.checkpoint()
         self.disagg_advance_checkpoint(conn_follow)
+        self.disagg_wait_for_adoption(conn_follow)
 
         self.evict_ingest(session_follow, ts)
         count = self.count_ingest(session_follow)
@@ -240,6 +241,7 @@ class test_layered_follower10(wttest.WiredTigerTestCase):
         # Trigger advance checkpoint code again to set the prune timestamp to the last
         # checkpoint timestamp. We couldn't do that because there was a cursor holding the old content.
         self.disagg_advance_checkpoint(conn_follow)
+        self.disagg_wait_for_adoption(conn_follow)
 
         # Now eviction should remove all the items from the ingest table.
         self.evict_ingest(session_follow, ts)
@@ -295,6 +297,7 @@ class test_layered_follower10(wttest.WiredTigerTestCase):
 
         # Pickup the last checkpoint and perform the final garbage collection
         self.disagg_advance_checkpoint(conn_follow)
+        self.disagg_wait_for_adoption(conn_follow)
 
         # Now eviction should remove all the items from the ingest table.
         self.evict_ingest(session_follow, ts)
@@ -326,6 +329,7 @@ class test_layered_follower10(wttest.WiredTigerTestCase):
 
         # Take a checkpoint and advance it, make sure everything is garbage collected
         self.disagg_advance_checkpoint(conn_follow)
+        self.disagg_wait_for_adoption(conn_follow)
         oplog.check(self, session_follow, 0, self.nitems)
 
         # Now eviction should remove all the items from the ingest table.

--- a/test/suite/test_layered_follower16.py
+++ b/test/suite/test_layered_follower16.py
@@ -170,12 +170,15 @@ class test_layered_follower16(wttest.WiredTigerTestCase):
 
         self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(10)}')
         self.session.checkpoint()
-        # The survive scenario keeps its transaction open across the pickup, deferring the
-        # adoption, so there is nothing to wait for.
         self.disagg_advance_checkpoint(conn_follow)
 
         if self.txn_mode != 'survive':
+            # The counts below need a stable constituent to bind, so wait for the adoption:
+            # a delivery is not necessarily adopted by the time it returns.
+            self.disagg_wait_for_adoption(conn_follow)
             session_follow.begin_transaction()
+        # The survive scenario keeps its transaction open across the pickup, deferring the
+        # adoption indefinitely: waiting there would hang.
 
         # Only the operations that must consult stable open it. An exact search and a write defer
         # the follower's stable open until the ingest lookup misses, which for these keys happens

--- a/test/suite/test_layered_follower21.py
+++ b/test/suite/test_layered_follower21.py
@@ -124,7 +124,9 @@ class test_layered_follower21(wttest.WiredTigerTestCase):
 
     def check_new_data_visible(self, conn_follow):
         # Outside the racing transaction, the picked-up content must be there:
-        # a fresh transaction sees the post-pickup writes.
+        # a fresh transaction sees the post-pickup writes. Callers get here with the
+        # blocking snapshot ended, so the adoption it deferred can now be waited for.
+        self.disagg_wait_for_adoption(conn_follow)
         session = conn_follow.open_session('')
         session.begin_transaction()
         cursor = session.open_cursor(self.uri)
@@ -802,6 +804,7 @@ class test_layered_follower21(wttest.WiredTigerTestCase):
         # picked-up content with no rollbacks.
         conn_follow, session_follow = self.setup_with_first_checkpoint()
         self.commit_post_snapshot_writes(conn_follow)
+        self.disagg_wait_for_adoption(conn_follow)
 
         session_follow.begin_transaction()
         cursor = session_follow.open_cursor(self.uri)
@@ -838,9 +841,12 @@ class test_layered_follower21(wttest.WiredTigerTestCase):
         cursor.close()
         session_hold.rollback_transaction()
         session_hold.close()
-        # With the snapshot gone, a freshly delivered checkpoint is adopted synchronously.
+        # With the snapshot gone, nothing blocks the adoption. It still may not run inline: any
+        # snapshot the node happens to hold, including the ones the adoption itself takes, defers
+        # the delivery to the server, so wait for it before reading.
         self.session.checkpoint()
         self.disagg_advance_checkpoint(conn_follow)
+        self.disagg_wait_for_adoption(conn_follow)
 
         session = conn_follow.open_session('')
         session.begin_transaction()


### PR DESCRIPTION
### The problem

A checkpoint delivered to a disaggregated follower is not necessarily adopted by the time the delivering thread returns. The delivery is deferred to the pickup server whenever an untimestamped snapshot pinning the checkpoint generation is active, and every follower snapshot takes that pin — including the ones the node runs for its own internal work, among them the metadata transactions the adoption itself performs. A reader whose snapshot is established before the server drains the queue binds its stable constituent to the previously adopted checkpoint, and reads none of the delivered content.

The test asserted the opposite: that a delivery made with no reader blocking it is adopted inline, and read immediately afterwards. On a slow host the read landed first. This is the same failure mode as WT-18294, in a second file.

### The change

Wait for the adoption at the places that assert on state a pickup produces, with no blocking snapshot deliberately held:

- the final read of `test_step_down_restarts_deferred_pickup`, and the comment claiming synchronous adoption;
- `check_new_data_visible()`, reached after the blocking transaction ends, so the adoption it deferred is still in flight — this covers `test_new_cursor_after_pickup` and `test_pickup_then_step_up`;
- `test_transaction_after_pickup_unaffected`;
- the stable-open counts in `test_layered_follower16`, which need an adopted stable to bind.

The deliveries made while a cursor deliberately pins a snapshot are left alone: those adoptions cannot complete until the snapshot ends, so waiting there would hang by design.

### Scope

I swept the other 80 suite files that deliver checkpoints for the same two orderings. `test_layered_follower20` already waits on the pickup counter; the rest of the hits (`follower09`, `cursor25`, `async_stepdown06`, and the remaining `follower21` tests) assert pre-pickup content or a rollback, which a late adoption can only make more likely.

### Confidence

The failure does not reproduce on an unloaded x86 box either before or after the change, so the justification is the deferral condition in `__wti_disagg_pick_up_checkpoint_meta()`, not a repro. Test-only; no product change.