### PR TITLE
WT-18168 Exclude checkpoint cursor btrees from shared disk image cache

### DIFF
--- a/src/include/cache.h
+++ b/src/include/cache.h
@@ -77,12 +77,13 @@ typedef enum {
 #define WT_DSK_CACHE_READABLE(state) \
     ((state) == WT_DSK_CACHE_ACTIVE || (state) == WT_DSK_CACHE_READONLY)
 
-#define WT_DSK_CACHE_CAN_READ(state, btree) \
-    (WT_DSK_CACHE_READABLE(state) && F_ISSET(btree, WT_BTREE_DISAGGREGATED))
+#define WT_DSK_CACHE_CAN_READ(state, btree)                                    \
+    (WT_DSK_CACHE_READABLE(state) && F_ISSET(btree, WT_BTREE_DISAGGREGATED) && \
+      !WT_DHANDLE_IS_CHECKPOINT((btree)->dhandle))
 
-#define WT_DSK_CACHE_CAN_WRITE(state, btree) \
-    ((state) == WT_DSK_CACHE_ACTIVE && F_ISSET(btree, WT_BTREE_DISAGGREGATED))
-
+#define WT_DSK_CACHE_CAN_WRITE(state, btree)                                     \
+    ((state) == WT_DSK_CACHE_ACTIVE && F_ISSET(btree, WT_BTREE_DISAGGREGATED) && \
+      !WT_DHANDLE_IS_CHECKPOINT((btree)->dhandle))
 struct __wt_shared_dsk_cache {
     wt_shared uint8_t state;
     wt_shared uint64_t readonly_since; /* Seconds when the cache went read-only on step-up. */


### PR DESCRIPTION
This PR is to exclude checkpoint cursor dhandles for disagg shared disk image cache, the issue here is when we reconstruct base and delta images, we will strip time windows that are considered as "globally visible", this is correct for normal btrees but will strip the time window useful for checkpoint btrees, however shared disk image cache will share a time window stripped btree with a checkpoint btree, and causes the wrong visibility bug.

This is not a problem in disagg as we should never open a checkpoint cursor, but we still need to block this on shared disk image cache layer.