### PR TITLE
WT-18159 Lazily open the stable table on the follower. (#14291)

### DIFF
--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -336,10 +336,43 @@ __clayered_assert_stable_mode(WTI_CURSOR_LAYERED *clayered)
 }
 
 /* __clayered_enter() local flags. */
-#define CLAYERED_ENTER_SKIP_STABLE 0x1u /* Follower writing without reading stable. */
+#define CLAYERED_ENTER_SKIP_STABLE 0x1u /* Follower operation not reading stable up front. */
 #define CLAYERED_ENTER_ITERATION 0x2u   /* Cursor is performing iteration. */
 #define CLAYERED_ENTER_RESET 0x4u       /* Reset constituent cursors if needed. */
 #define CLAYERED_ENTER_ROLE_CHANGE 0x8u /* Leader/follower role changed since last access. */
+
+/*
+ * __clayered_skip_stable --
+ *     Return whether the operation can start without an open stable constituent.
+ */
+static WT_INLINE bool
+__clayered_skip_stable(
+  WTI_CURSOR_LAYERED *clayered, WTI_CLAYERED_OP_MODE mode, WTI_CLAYERED_ROLE role)
+{
+    WT_SESSION_IMPL *session = CUR2S(clayered);
+
+    /* The leader always needs stable. */
+    if (role == WTI_CLAYERED_ROLE_LEADER)
+        return (false);
+
+    /* An exact search reads stable only when the ingest lookup misses, which opens it on demand. */
+    if (mode == WTI_CLAYERED_MODE_SEARCH)
+        return (true);
+
+    /*
+     * On a follower, if a read timestamp is set, even write operations need the stable table for
+     * the cross-table visibility check.
+     */
+    if (F_ISSET(session->txn, WT_TXN_SHARED_TS_READ))
+        return (false);
+
+    /* Writes to the ingest table can defer opening stable to lookup time. */
+    if (mode == WTI_CLAYERED_MODE_WRITE)
+        return (true);
+
+    /* All other cases (next, prev, search_near) still need to check the stable table. */
+    return (false);
+}
 
 /*
  * __clayered_enter_flags --
@@ -349,21 +382,14 @@ static WT_INLINE uint32_t
 __clayered_enter_flags(
   WTI_CURSOR_LAYERED *clayered, WTI_CLAYERED_OP_MODE mode, WTI_CLAYERED_ROLE role)
 {
-    WT_SESSION_IMPL *session = CUR2S(clayered);
     uint32_t flags = 0;
 
-    if (mode == WTI_CLAYERED_MODE_SEARCH)
+    if (mode == WTI_CLAYERED_MODE_SEARCH_NEAR || mode == WTI_CLAYERED_MODE_SEARCH)
         LF_SET(CLAYERED_ENTER_RESET);
     if (mode == WTI_CLAYERED_MODE_ITERATE || mode == WTI_CLAYERED_MODE_RANDOM)
         LF_SET(CLAYERED_ENTER_ITERATION);
 
-    /*
-     * Reads (search, search_near, iterate, random, scan) and non-overwrite writes always need the
-     * stable cursor; an overwrite write needs it on the leader, or on a follower with a read
-     * timestamp where the write-conflict check must consult the stable table.
-     */
-    if ((mode == WTI_CLAYERED_MODE_WRITE_OVERWRITE) && (role == WTI_CLAYERED_ROLE_FOLLOWER) &&
-      !F_ISSET(session->txn, WT_TXN_SHARED_TS_READ))
+    if (__clayered_skip_stable(clayered, mode, role))
         LF_SET(CLAYERED_ENTER_SKIP_STABLE);
 
     if (role != clayered->last_role)
@@ -875,6 +901,32 @@ __clayered_update_ingest(WTI_CURSOR_LAYERED *clayered, uint32_t flags)
 }
 
 /*
+ * __clayered_open_stable_first --
+ *     Open the stable constituent for the first time and record its checkpoint LSN. A follower the
+ *     table has no checkpoint for leaves the stable cursor NULL. The caller reads the connection's
+ *     LSN before the open, so a checkpoint picked up in between makes the recorded LSN older than
+ *     the checkpoint actually opened: that only costs a later reopen, it never claims a newer
+ *     checkpoint than the cursor holds.
+ */
+static int
+__clayered_open_stable_first(
+  WTI_CURSOR_LAYERED *clayered, WTI_CLAYERED_ROLE role, uint64_t conn_lsn)
+{
+    WT_SESSION_IMPL *const session = CUR2S(clayered);
+
+    if (clayered->stable_cursor != NULL ||
+      (role == WTI_CLAYERED_ROLE_FOLLOWER && conn_lsn == WT_DISAGG_LSN_NONE))
+        return (0);
+
+    F_CLR(clayered, WTI_CLAYERED_ITERATE_NEXT | WTI_CLAYERED_ITERATE_PREV);
+    WT_RET(__clayered_open_stable(clayered, false, role));
+    WT_RET(__clayered_copy_bounds(clayered));
+    clayered->stable_checkpoint_meta_lsn = conn_lsn;
+    WT_STAT_CONN_DSRC_INCR(session, layered_curs_open_stable);
+    return (0);
+}
+
+/*
  * __clayered_update_stable --
  *     Manage the stable cursor lifecycle: open it for the first time, advance it to a newer
  *     checkpoint, or reopen it in a different mode after a role change.
@@ -891,15 +943,8 @@ __clayered_update_stable(WTI_CURSOR_LAYERED *clayered, uint32_t flags, WTI_CLAYE
 
     if (clayered->stable_cursor == NULL) {
         /* Open stable the first time if needed. */
-        bool follower_open_stable =
-          (!FLD_ISSET(flags, CLAYERED_ENTER_SKIP_STABLE) && conn_lsn != WT_DISAGG_LSN_NONE);
-        if (role == WTI_CLAYERED_ROLE_LEADER || follower_open_stable) {
-            F_CLR(clayered, WTI_CLAYERED_ITERATE_NEXT | WTI_CLAYERED_ITERATE_PREV);
-            WT_RET(__clayered_open_stable(clayered, false, role));
-            WT_RET(__clayered_copy_bounds(clayered));
-            clayered->stable_checkpoint_meta_lsn = conn_lsn;
-            WT_STAT_CONN_DSRC_INCR(session, layered_curs_open_stable);
-        }
+        if (role == WTI_CLAYERED_ROLE_LEADER || !FLD_ISSET(flags, CLAYERED_ENTER_SKIP_STABLE))
+            WT_RET(__clayered_open_stable_first(clayered, role, conn_lsn));
     } else if (FLD_ISSET(flags, CLAYERED_ENTER_ROLE_CHANGE) ||
       __clayered_can_advance_stable(
         clayered, conn_lsn, FLD_ISSET(flags, CLAYERED_ENTER_ITERATION))) {
@@ -2059,6 +2104,25 @@ err:
 }
 
 /*
+ * __clayered_lookup_lazy_stable_open --
+ *     Open the stable constituent an operation deferred at enter time, and hand it to the
+ *     operation. The operation stays without a stable cursor if the follower has no checkpoint.
+ */
+static int
+__clayered_lookup_lazy_stable_open(WTI_CLAYERED_OP *op)
+{
+    WTI_CURSOR_LAYERED *clayered = op->clayered;
+    WT_SESSION_IMPL *session = CUR2S(clayered);
+
+    WT_RET(__clayered_open_stable_first(clayered, WTI_CLAYERED_ROLE_FOLLOWER,
+      __wt_atomic_load_uint64_acquire(
+        &S2C(session)->disaggregated_storage.last_checkpoint_meta_lsn)));
+    op->stable = clayered->stable_cursor;
+
+    return (0);
+}
+
+/*
  * __clayered_lookup --
  *     Position a layered cursor.
  */
@@ -2075,6 +2139,17 @@ __clayered_lookup(WTI_CLAYERED_OP *op, WT_ITEM *value)
     else
         /* Be sure we'll make a search attempt further down.  */
         WT_ASSERT(session, op->stable != NULL);
+
+    /* If the ingest lookup misses, open the deferred stable constituent. */
+    if (!found && op->stable == NULL) {
+        WT_ERR(__clayered_lookup_lazy_stable_open(op));
+        /*
+         * A successful open sets ret to zero, but that is not a lookup result. A table with no
+         * checkpoint leaves the stable cursor NULL and skips the search below, so keep the return
+         * as not found.
+         */
+        ret = WT_NOTFOUND;
+    }
 
     /* If the key didn't exist in ingest and the cursor is setup for reading, check stable. */
     if (!found && op->stable != NULL)
@@ -2475,7 +2550,7 @@ __clayered_search_near(WT_CURSOR *cursor, int *exactp)
     WT_ERR(__cursor_copy_release(cursor));
     WT_ERR(__cursor_needkey(cursor));
     __cursor_novalue(cursor);
-    WT_ERR(__clayered_enter(clayered, WTI_CLAYERED_MODE_SEARCH, &op));
+    WT_ERR(__clayered_enter(clayered, WTI_CLAYERED_MODE_SEARCH_NEAR, &op));
 
     CURSOR_API_CHECK_SYSTEM_OVERLOAD(session, ret);
 
@@ -2869,10 +2944,7 @@ __clayered_insert(WT_CURSOR *cursor)
     WT_ERR(__cursor_copy_release(cursor));
     WT_ERR(__cursor_needkey(cursor));
     WT_ERR(__cursor_needvalue(cursor));
-    WT_ERR(__clayered_enter(clayered,
-      F_ISSET(cursor, WT_CURSTD_OVERWRITE) ? WTI_CLAYERED_MODE_WRITE_OVERWRITE :
-                                             WTI_CLAYERED_MODE_WRITE,
-      &op));
+    WT_ERR(__clayered_enter(clayered, WTI_CLAYERED_MODE_WRITE, &op));
 
     /*
      * It isn't necessary to copy the key out after the lookup in this case because any non-failed
@@ -2895,7 +2967,7 @@ __clayered_insert(WT_CURSOR *cursor)
     WT_ERR(__clayered_deleted_encode(session, &cursor->value, op.ingest == NULL, &value, &buf));
     ret = __clayered_put(&op, &cursor->key, &value, WTI_CLAYERED_PUT_INSERT);
     if (ret == WT_DUPLICATE_KEY) {
-        WT_ASSERT(session, op.ingest == NULL);
+        WT_ASSERT(session, op.ingest == NULL && op.stable != NULL);
         /*
          * The btree cursor already holds a local copy of the existing value from duplicate
          * detection. Copy it directly without a second search.
@@ -2954,10 +3026,7 @@ __clayered_update(WT_CURSOR *cursor)
     WT_ERR(__cursor_copy_release(cursor));
     WT_ERR(__cursor_needkey(cursor));
     WT_ERR(__cursor_needvalue(cursor));
-    WT_ERR(__clayered_enter(clayered,
-      F_ISSET(cursor, WT_CURSTD_OVERWRITE) ? WTI_CLAYERED_MODE_WRITE_OVERWRITE :
-                                             WTI_CLAYERED_MODE_WRITE,
-      &op));
+    WT_ERR(__clayered_enter(clayered, WTI_CLAYERED_MODE_WRITE, &op));
 
     WT_ERR(__clayered_modify_check(session, clayered, &cursor->key));
 
@@ -3024,10 +3093,7 @@ __clayered_remove(WT_CURSOR *cursor)
     WT_ERR(__cursor_needkey(cursor));
     __cursor_novalue(cursor);
 
-    WT_ERR(__clayered_enter(clayered,
-      F_ISSET(cursor, WT_CURSTD_OVERWRITE) ? WTI_CLAYERED_MODE_WRITE_OVERWRITE :
-                                             WTI_CLAYERED_MODE_WRITE,
-      &op));
+    WT_ERR(__clayered_enter(clayered, WTI_CLAYERED_MODE_WRITE, &op));
 
     CURSOR_API_CHECK_SYSTEM_OVERLOAD(session, ret);
 

--- a/src/cursor/cur_layered_private.h
+++ b/src/cursor/cur_layered_private.h
@@ -50,12 +50,12 @@ struct __wti_cursor_layered {
  *	The kind of layered-table operation.
  */
 typedef enum {
-    WTI_CLAYERED_MODE_SEARCH,         /* search, search_near */
-    WTI_CLAYERED_MODE_ITERATE,        /* next, prev */
-    WTI_CLAYERED_MODE_RANDOM,         /* next_random */
-    WTI_CLAYERED_MODE_SCAN,           /* largest_key */
-    WTI_CLAYERED_MODE_WRITE,          /* reserve, modify; non-overwrite insert/update/remove */
-    WTI_CLAYERED_MODE_WRITE_OVERWRITE /* overwrite insert/update/remove */
+    WTI_CLAYERED_MODE_SEARCH_NEAR, /* search_near */
+    WTI_CLAYERED_MODE_SEARCH,      /* search */
+    WTI_CLAYERED_MODE_ITERATE,     /* next, prev */
+    WTI_CLAYERED_MODE_RANDOM,      /* next_random */
+    WTI_CLAYERED_MODE_SCAN,        /* largest_key */
+    WTI_CLAYERED_MODE_WRITE        /* reserve, modify, insert, update, remove */
 } WTI_CLAYERED_OP_MODE;
 
 /*

--- a/test/suite/test_layered_follower16.py
+++ b/test/suite/test_layered_follower16.py
@@ -174,7 +174,16 @@ class test_layered_follower16(wttest.WiredTigerTestCase):
         if self.txn_mode != 'survive':
             session_follow.begin_transaction()
 
-        opens_stable = not (self.overwrite and self.do_op in (_op_insert, _op_update, _op_remove))
+        # Only the operations that must consult stable open it. An exact search and a write defer
+        # the follower's stable open until the ingest lookup misses, which for these keys happens
+        # only for a non-overwrite insert of a brand-new key; search_near, iteration and largest_key
+        # merge the constituents, so they always open stable.
+        if self.do_op in (_op_search_near, _op_next, _op_prev, _op_largest_key):
+            opens_stable = 1
+        elif self.do_op is _op_insert and not self.overwrite:
+            opens_stable = 1
+        else:
+            opens_stable = 0
 
         # After the checkpoint arrives, repeat the same operation.
         self.do_op(cursor_follow)

--- a/test/suite/test_layered_follower17.py
+++ b/test/suite/test_layered_follower17.py
@@ -26,10 +26,9 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 
-# A follower must not reopen the stable cursor while no newer checkpoint exists. A transaction
-# reading at a timestamp is always allowed to advance the stable cursor, but only when a newer
-# checkpoint has actually arrived. With two operations in one such transaction, the first opens
-# stable and the second must not reopen it, because the checkpoint has not advanced.
+# The follower's stable cursor lifecycle for reads. An exact search defers the stable open until the
+# ingest lookup misses; search_near merges the constituents, so it always opens stable. Once open,
+# the stable cursor must not be reopened until a newer checkpoint arrives.
 
 import wiredtiger, wttest
 from helper_disagg import disagg_test_class, gen_disagg_storages
@@ -60,6 +59,12 @@ class test_layered_follower17(wttest.WiredTigerTestCase):
         stat_cursor.close()
         return val
 
+    def opened(self, session):
+        return self.get_stat(session, wiredtiger.stat.conn.layered_curs_open_stable)
+
+    def reopened(self, session):
+        return self.get_stat(session, wiredtiger.stat.conn.layered_curs_reopen_stable)
+
     def put(self, session, key, value, ts):
         cursor = session.open_cursor(self.uri)
         session.begin_transaction()
@@ -67,38 +72,82 @@ class test_layered_follower17(wttest.WiredTigerTestCase):
         session.commit_transaction(f'commit_timestamp={self.timestamp_str(ts)}')
         cursor.close()
 
-    def test_no_reopen_without_new_checkpoint(self):
+    def start_follower(self):
+        """Both keys reach the leader's stable table; only one is replicated to the follower."""
         self.session.create(self.uri, self.table_config)
         self.conn.set_timestamp(f'oldest_timestamp={self.timestamp_str(1)}')
-        # Write to stable on the leader and seal a checkpoint.
-        self.put(self.session, 'key', 'val', 10)
+        self.put(self.session, 'ingest_key', 'val', 10)
+        self.put(self.session, 'stable_key', 'val', 10)
         self.conn.set_timestamp(f'stable_timestamp={self.timestamp_str(10)}')
         self.session.checkpoint()
 
         conn_follow = self.wiredtiger_open('follower', self.follower_config())
         session_follow = conn_follow.open_session('')
         session_follow.create(self.uri, self.table_config)
+        self.put(session_follow, 'ingest_key', 'val', 10)
 
-        # Replicate the write to the follower's ingest so the cursor positions there, not on stable.
-        self.put(session_follow, 'key', 'val', 10)
-
-        # The follower picks up the leader's checkpoint, so the stable cursor will open.
+        # The follower picks up the leader's checkpoint, so the stable cursor becomes eligible.
         self.disagg_advance_checkpoint(conn_follow)
+        self.assertEqual(self.opened(session_follow), 0)
+        return conn_follow, session_follow
 
+    def test_lazy_stable_open(self):
+        conn_follow, session_follow = self.start_follower()
         cursor_follow = session_follow.open_cursor(self.uri)
 
-        # Two operations in a single transaction reading at a timestamp. The cursor positions on the
-        # ingest table (the key is present there), so it is never positioned on stable. The first
-        # operation opens stable; the second must not reopen it, since no newer checkpoint arrived.
+        # A search the ingest table satisfies must not open stable.
         session_follow.begin_transaction(f'read_timestamp={self.timestamp_str(10)}')
-        cursor_follow.set_key('key')
+        cursor_follow.set_key('ingest_key')
         self.assertEqual(cursor_follow.search(), 0)
-        cursor_follow.set_key('key')
+        self.assertEqual(cursor_follow.get_value(), 'val')
+        session_follow.commit_transaction()
+        self.assertEqual(self.opened(session_follow), 0,
+            'the stable cursor opened for a search the ingest table satisfied')
+
+        # A search that misses ingest opens stable and still finds the key.
+        session_follow.begin_transaction(f'read_timestamp={self.timestamp_str(10)}')
+        cursor_follow.set_key('stable_key')
+        self.assertEqual(cursor_follow.search(), 0)
+        self.assertEqual(cursor_follow.get_value(), 'val')
+        session_follow.commit_transaction()
+        self.assertEqual(self.opened(session_follow), 1)
+
+        # A key in neither constituent misses without a second open.
+        session_follow.begin_transaction(f'read_timestamp={self.timestamp_str(10)}')
+        cursor_follow.set_key('no_such_key')
+        self.assertEqual(cursor_follow.search(), wiredtiger.WT_NOTFOUND)
+        session_follow.commit_transaction()
+        self.assertEqual(self.opened(session_follow), 1)
+
+        cursor_follow.close()
+
+        # search_near merges the constituents, so it opens stable even on an ingest hit.
+        cursor_near = session_follow.open_cursor(self.uri)
+        session_follow.begin_transaction(f'read_timestamp={self.timestamp_str(10)}')
+        cursor_near.set_key('ingest_key')
+        self.assertEqual(cursor_near.search_near(), 0)
+        session_follow.commit_transaction()
+        self.assertEqual(self.opened(session_follow), 2,
+            'search_near did not open the stable cursor')
+
+        cursor_near.close()
+        conn_follow.close()
+
+    def test_no_reopen_without_new_checkpoint(self):
+        conn_follow, session_follow = self.start_follower()
+        cursor_follow = session_follow.open_cursor(self.uri)
+
+        # Two operations in a single transaction reading at a timestamp. Both miss ingest, so the
+        # first opens stable; the second must not reopen it, since no newer checkpoint arrived.
+        session_follow.begin_transaction(f'read_timestamp={self.timestamp_str(10)}')
+        cursor_follow.set_key('stable_key')
+        self.assertEqual(cursor_follow.search(), 0)
+        cursor_follow.set_key('stable_key')
         self.assertEqual(cursor_follow.search(), 0)
         session_follow.commit_transaction()
 
-        self.assertEqual(self.get_stat(session_follow, wiredtiger.stat.conn.layered_curs_open_stable), 1)
-        self.assertEqual(self.get_stat(session_follow, wiredtiger.stat.conn.layered_curs_reopen_stable), 0,
+        self.assertEqual(self.opened(session_follow), 1)
+        self.assertEqual(self.reopened(session_follow), 0,
             'the stable cursor was reopened without a newer checkpoint')
 
         cursor_follow.close()

--- a/test/suite/test_layered_stepup09.py
+++ b/test/suite/test_layered_stepup09.py
@@ -142,13 +142,14 @@ class test_layered_stepup09(wttest.WiredTigerTestCase):
         conn_follow, session_follow, cursor_follow = self.open_follower()
         self.disagg_advance_checkpoint(conn_follow)
 
-        # Replicate the leader's rows to the follower's ingest.
+        # Replicate only the first three of the leader's rows to the follower's ingest, leaving
+        # key_4 in stable alone so the search below misses ingest and forces the stable open.
         # `insert_keys` opens a default (overwrite) cursor so stable stays unopened.
-        self.insert_keys(session_follow, 5, 10)
+        self.insert_keys(session_follow, 3, 10)
         self.assertEqual(self.get_stat(wiredtiger.stat.conn.layered_curs_open_stable, session=session_follow), 0)
 
-        # First read opens the stable cursor in read-only mode.
-        cursor_follow.set_key('key_0')
+        # First read that misses ingest opens the stable cursor in read-only mode.
+        cursor_follow.set_key('key_4')
         self.assertEqual(cursor_follow.search(), 0)
         self.assertEqual(self.get_stat(wiredtiger.stat.conn.layered_curs_open_stable, session=session_follow), 1)
         self.assertEqual(self.get_stat(wiredtiger.stat.conn.layered_curs_reopen_stable, session=session_follow), 0)


### PR DESCRIPTION
On a follower, defer opening a layered table's stable constituent for an exact search or write until the ingest lookup misses. Most oplog-apply reads are satisfied by the ingest table, so the stable open (and its cold read) is usually wasted.

This is a cherry pick of WT-18159. The original PR is: https://github.com/wiredtiger/wiredtiger/pull/14291