### PR TITLE
WT-18301 Stop background eviction server in scrub image accounting tests

### DIFF
--- a/test/suite/test_checkpoint_scrub_evict02.py
+++ b/test/suite/test_checkpoint_scrub_evict02.py
@@ -54,10 +54,13 @@ class test_checkpoint_scrub_evict02(wttest.WiredTigerTestCase):
     scenarios = make_scenarios(ckpt_threads)
 
     # A large cache so eviction only runs when a test asks for it, and scrub eviction forced on so
-    # the tests don't depend on the eviction server's scrub heuristic.
+    # the tests don't depend on the eviction server's scrub heuristic. The dirty thresholds are
+    # raised as the default 5% target causes the eviction server to run alongside the some tests,
+    # which can race with the retained images.
     def conn_config(self):
         return ('cache_size=200MB,statistics=(all),precise_checkpoint=true,'
                 'checkpoint_threads=%d,'
+                'eviction_dirty_target=80,eviction_dirty_trigger=90,'
                 'eviction=(checkpoint_scrub_eviction=on)' % self.ckpt_threads)
 
     def get_stat(self, statistic, uri=None):


### PR DESCRIPTION
test_checkpoint_scrub_evict02.test_image_max_bounds_the_cache fails intermittently on `assertGreater(pages, 0)`.

The test writes 20,000 rows to generate of dirty leaf content in the 200MB cache. That is past the eviction_dirty_target of 5% (10MB), so the eviction server runs for the duration of the checkpoint. The assertion failure is likely caused by the producer/consumer race.

The file intends for eviction to run only when a test asks for it, so eviction_dirty_target/trigger has been raised to 80/90 in conn_config so the eviction server stays idle. 