### PR TITLE
WT-18085 Only compare the history store against the data store under a precise checkpoint

### DIFF
--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1420,6 +1420,11 @@ __verify_key_hs(WT_SESSION_IMPL *session, WT_ITEM *tmp1, wt_timestamp_t newer_st
      * checkpoint. The two files are not a snapshot of a single point in time, so only the ordering
      * among the history store records themselves can be trusted; comparing them against the data
      * store's page image reports overlaps that never coexisted.
+     *
+     * This is the connection's current setting, not the one in effect when the checkpoint was
+     * written. A checkpoint written without precise checkpoints and then verified by a connection
+     * that enables them is still exposed to the skew, until the pages involved are reconciled again
+     * or the stale history store records become obsolete.
      */
     check_data_store = F_ISSET(S2C(session), WT_CONN_PRECISE_CHECKPOINT);
     first = true;

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1409,9 +1409,20 @@ __verify_key_hs(WT_SESSION_IMPL *session, WT_ITEM *tmp1, wt_timestamp_t newer_st
     uint64_t hs_counter;
     int cmp;
     char ts_string[2][WT_TS_INT_STRING_SIZE];
+    bool check_data_store, first;
 
     WT_BTREE *btree = S2BT(session);
     uint32_t hs_btree_id = btree->id;
+
+    /*
+     * A non-precise checkpoint can write a page before a later eviction moves that page's older
+     * versions into the history store, and then capture those history store records in the same
+     * checkpoint. The two files are not a snapshot of a single point in time, so only the ordering
+     * among the history store records themselves can be trusted; comparing them against the data
+     * store's page image reports overlaps that never coexisted.
+     */
+    check_data_store = F_ISSET(S2C(session), WT_CONN_PRECISE_CHECKPOINT);
+    first = true;
 
     if (vs->skip_per_key_hs)
         return (0);
@@ -1452,8 +1463,8 @@ __verify_key_hs(WT_SESSION_IMPL *session, WT_ITEM *tmp1, wt_timestamp_t newer_st
          * start timestamp to the stop timestamp of the "later" entry (or entries), because we
          * expect those to overlap.
          */
-        if (newer_start_ts != WT_TS_NONE && older_start_ts < newer_start_ts &&
-          newer_start_ts < tw->stop_ts &&
+        if ((check_data_store || !first) && newer_start_ts != WT_TS_NONE &&
+          older_start_ts < newer_start_ts && newer_start_ts < tw->stop_ts &&
           !(older_start_ts == WT_TS_NONE && tw->stop_ts == newer_stop_ts)) {
             WT_ERR_MSG(session, WT_ERROR,
               "key %s has an overlap of timestamp ranges between history store stop timestamp %s "
@@ -1473,6 +1484,7 @@ __verify_key_hs(WT_SESSION_IMPL *session, WT_ITEM *tmp1, wt_timestamp_t newer_st
          */
         newer_start_ts = older_start_ts;
         newer_stop_ts = tw->stop_ts;
+        first = false;
     }
 err:
     WT_TRET(hs_cursor->close(hs_cursor));

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1421,10 +1421,10 @@ __verify_key_hs(WT_SESSION_IMPL *session, WT_ITEM *tmp1, wt_timestamp_t newer_st
      * among the history store records themselves can be trusted; comparing them against the data
      * store's page image reports overlaps that never coexisted.
      *
-     * This is the connection's current setting, not the one in effect when the checkpoint was
-     * written. A checkpoint written without precise checkpoints and then verified by a connection
-     * that enables them is still exposed to the skew, until the pages involved are reconciled again
-     * or the stale history store records become obsolete.
+     * FIXME-WT-18319: This is the connection's current setting, not the one in effect when the
+     * checkpoint was written. A checkpoint written without precise checkpoints and then verified by
+     * a connection that enables them is still exposed to the skew, until the pages involved are
+     * reconciled again or the stale history store records become obsolete.
      */
     check_data_store = F_ISSET(S2C(session), WT_CONN_PRECISE_CHECKPOINT);
     first = true;


### PR DESCRIPTION
`__verify_key_hs` compares each key's history store records against the data store's on-disk page image, assuming the two files are a snapshot of a single point in time. Under a non-precise checkpoint they are not: the checkpoint can write a leaf page and then, before its history store phase runs, a later eviction moves that page's older versions into the history store, and the same checkpoint captures those records. The history store view is then strictly newer than the page image for that key, and the check reports an overlap between versions that never coexisted.

This restricts the comparison against the page image to precise checkpoints, where neither file contains anything above stable and the two views do share a point in time. The ordering check among the history store records themselves is unchanged and still runs in all cases: only the seed comparison against the data store cell is gated, and `first` is cleared where `newer_start_ts`/`newer_stop_ts` already roll forward to the current record.
