### PR TITLE
WT-18316 Assert that no transaction spans a step-up

### DIFF
--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -444,6 +444,43 @@ __clayered_op_init(WTI_CURSOR_LAYERED *clayered, WTI_CLAYERED_OP *op, uint32_t f
 }
 
 /*
+ * __clayered_assert_role_change --
+ *     Assert the role-change invariants: a step-up requires an unpositioned cursor (ingest drains
+ *     under the position) and no spanning snapshot (it cannot be consistent with the drained and
+ *     adopted stable content); a step-down requires only writes to be unpositioned, since the
+ *     stable tree after it matches the step-down checkpoint.
+ */
+static WT_INLINE void
+__clayered_assert_role_change(
+  WTI_CURSOR_LAYERED *clayered, WTI_CLAYERED_OP_MODE mode, WTI_CLAYERED_ROLE role, uint32_t flags)
+{
+    WT_SESSION_IMPL *session = CUR2S(clayered);
+    WT_TXN *txn = session->txn;
+
+    if (LF_ISSET(CLAYERED_ENTER_STEP_UP))
+        WT_ASSERT_ALWAYS(session, !F_ISSET(&clayered->iface, WT_CURSTD_KEY_INT),
+          "All the cursors should be left unpositioned before a step-up.");
+    else if (LF_ISSET(CLAYERED_ENTER_STEP_DOWN))
+        WT_ASSERT_ALWAYS(session,
+          !F_ISSET(&clayered->iface, WT_CURSTD_KEY_INT) || mode != WTI_CLAYERED_MODE_WRITE,
+          "Write cursors should be left unpositioned before a step-down.");
+
+    /* Skip snapshots that recorded no role era (a checkpoint's bumped snapshot). */
+    if (!F_ISSET(txn, WT_TXN_HAS_SNAPSHOT) || __wt_session_gen(session, WT_GEN_DISAGG_ROLE) == 0)
+        return;
+
+    /*
+     * Tolerate one generation: a step-down span is legal, and an operation racing a transition can
+     * observe the generation bump before the published role. Two or more means a spanned step-up.
+     */
+    WT_ASSERT(session,
+      __wt_gen(session, WT_GEN_DISAGG_ROLE) - __wt_session_gen(session, WT_GEN_DISAGG_ROLE) <= 1);
+
+    /* A snapshot established on a follower must not be used on a leader: a step-up span. */
+    WT_ASSERT(session, txn->disagg_role_leader || role != WTI_CLAYERED_ROLE_LEADER);
+}
+
+/*
  * __clayered_enter --
  *     Start an operation on a layered cursor.
  */
@@ -457,25 +494,14 @@ __clayered_enter(WTI_CURSOR_LAYERED *clayered, WTI_CLAYERED_OP_MODE mode, WTI_CL
       WTI_CLAYERED_ROLE_FOLLOWER;
     uint32_t flags = __clayered_enter_flags(clayered, mode, role);
 
+    __clayered_assert_role_change(clayered, mode, role, flags);
+
     /*
      * largest_key is exempt: it ignores visibility by contract and always consults ingest, so its
      * result does not depend on the transaction.
      */
     if (mode != WTI_CLAYERED_MODE_LARGEST_KEY)
         WT_RET(__wt_txn_stepdown_straddler_check(session, mode == WTI_CLAYERED_MODE_WRITE));
-
-    /*
-     * Reads may stay positioned across a planned step-down: the stable tree after the step-down
-     * matches the step-down checkpoint. A step-up drains ingest under the position, so both require
-     * an unpositioned cursor.
-     */
-    if (LF_ISSET(CLAYERED_ENTER_STEP_UP))
-        WT_ASSERT_ALWAYS(session, !F_ISSET(&clayered->iface, WT_CURSTD_KEY_INT),
-          "All the cursors should be left unpositioned before a step-up.");
-    else if (LF_ISSET(CLAYERED_ENTER_STEP_DOWN))
-        WT_ASSERT_ALWAYS(session,
-          !F_ISSET(&clayered->iface, WT_CURSTD_KEY_INT) || mode != WTI_CLAYERED_MODE_WRITE,
-          "Write cursors should be left unpositioned before a step-down.");
 
     /*
      * FIXME-WT-15058: When inside a read committed isolation, the file cursor code expects to
@@ -1191,10 +1217,8 @@ __clayered_update_stable(WTI_CURSOR_LAYERED *clayered, uint32_t flags, WTI_CLAYE
          * The second case of reopening the stable table is when we want to open a new checkpoint on
          * a follower to evict more entries from the ingest table.
          *
-         * FIXME-WT-14545: What is not checked here is the possibility that a step down and step up
-         * have both occurred since the last check. We don't have a way to detect that (or its
-         * opposite) at the moment. If we did, we'd want to issue a rollback if the stable cursor
-         * has any changes.
+         * FIXME-WT-14545: a step-down and step-up pair since the last check satisfies the role
+         * comparison and leaves the binding stale; a new transaction on an idle cursor reads it.
          */
         WT_RET(__clayered_reopen_stable(session, clayered, role));
         clayered->stable_checkpoint_meta_lsn = conn_lsn;

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -1216,9 +1216,6 @@ __clayered_update_stable(WTI_CURSOR_LAYERED *clayered, uint32_t flags, WTI_CLAYE
          *
          * The second case of reopening the stable table is when we want to open a new checkpoint on
          * a follower to evict more entries from the ingest table.
-         *
-         * FIXME-WT-14545: a step-down and step-up pair since the last check satisfies the role
-         * comparison and leaves the binding stale; a new transaction on an idle cursor reads it.
          */
         WT_RET(__clayered_reopen_stable(session, clayered, role));
         clayered->stable_checkpoint_meta_lsn = conn_lsn;

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -457,6 +457,9 @@ __clayered_assert_role_change(
     WT_SESSION_IMPL *session = CUR2S(clayered);
     WT_TXN *txn = session->txn;
 
+    /* Only the diagnostic step-up assertion consumes the role. */
+    WT_UNUSED(role);
+
     if (LF_ISSET(CLAYERED_ENTER_STEP_UP))
         WT_ASSERT_ALWAYS(session, !F_ISSET(&clayered->iface, WT_CURSTD_KEY_INT),
           "All the cursors should be left unpositioned before a step-up.");

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -222,10 +222,10 @@ done:
 /*
  * __txn_snapshot_record_disagg --
  *     Record the disaggregated state a snapshot about to be built is consistent with: the role, the
- *     role-change generation, and (on a follower) the pinned checkpoint generation.
+ *     role-change generation, and (on a follower asked to pin) the pinned checkpoint generation.
  */
 static WT_INLINE void
-__txn_snapshot_record_disagg(WT_SESSION_IMPL *session)
+__txn_snapshot_record_disagg(WT_SESSION_IMPL *session, bool pin_ckpt)
 {
     WT_CONNECTION_IMPL *conn = S2C(session);
 
@@ -259,7 +259,7 @@ __txn_snapshot_record_disagg(WT_SESSION_IMPL *session)
      * with a delivery's generation advance: a delivery either observes the pin published here, or
      * the validation after the build observes the delivery and retries.
      */
-    if (!session->txn->disagg_role_leader)
+    if (pin_ckpt && !session->txn->disagg_role_leader)
         __wt_session_gen_enter(session, WT_GEN_DISAGG_CKPT);
 }
 
@@ -280,6 +280,9 @@ __txn_snapshot_validate_disagg(WT_SESSION_IMPL *session)
         session->txn->disagg_role_leader)
         return (false);
     if (session->txn->disagg_role_leader)
+        return (true);
+    /* A timestamped reader pins no checkpoint, leaving nothing further to validate. */
+    if (__wt_session_gen(session, WT_GEN_DISAGG_CKPT) == 0)
         return (true);
     return (__wt_gen(session, WT_GEN_DISAGG_CKPT) == __wt_session_gen(session, WT_GEN_DISAGG_CKPT));
 }
@@ -309,11 +312,11 @@ __txn_get_snapshot_int(WT_SESSION_IMPL *session, bool update_shared_state)
      * validate it afterwards, retrying the build on a change: the retried snapshot postdates the
      * change, so the transaction reads consistently instead of being refused at its first stable
      * open. Loading before and validating after brackets the snapshot, so it can never pin state
-     * that changed after it was built. Timestamped readers are excluded: they stay consistent
-     * through the history store regardless of which checkpoint they read.
+     * that changed after it was built. A timestamped reader records the role era only: the history
+     * store keeps it consistent across checkpoints, so it pins nothing, but layered operations
+     * still assert it does not span a step-up.
      */
-    record_disagg = update_shared_state && __wt_conn_is_disagg(session) &&
-      txn_shared->read_timestamp == WT_TS_NONE;
+    record_disagg = update_shared_state && __wt_conn_is_disagg(session);
 
     /* Fast path if we already have the current snapshot. */
     if ((snapshot_gen = __wt_session_gen(session, WT_GEN_HAS_SNAPSHOT)) != 0) {
@@ -338,7 +341,7 @@ __txn_get_snapshot_int(WT_SESSION_IMPL *session, bool update_shared_state)
 retry:
     n = 0;
     if (record_disagg) {
-        __txn_snapshot_record_disagg(session);
+        __txn_snapshot_record_disagg(session, txn_shared->read_timestamp == WT_TS_NONE);
         /* Widen the window between recording the pin and building the snapshot. */
         WT_DIAGNOSTIC_YIELD;
     }

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -222,10 +222,11 @@ done:
 /*
  * __txn_snapshot_record_disagg --
  *     Record the disaggregated state a snapshot about to be built is consistent with: the role, the
- *     role-change generation, and (on a follower asked to pin) the pinned checkpoint generation.
+ *     role-change generation, and (on an untimestamped follower snapshot) the pinned checkpoint
+ *     generation.
  */
 static WT_INLINE void
-__txn_snapshot_record_disagg(WT_SESSION_IMPL *session, bool pin_ckpt)
+__txn_snapshot_record_disagg(WT_SESSION_IMPL *session)
 {
     WT_CONNECTION_IMPL *conn = S2C(session);
 
@@ -244,11 +245,12 @@ __txn_snapshot_record_disagg(WT_SESSION_IMPL *session, bool pin_ckpt)
       __wt_atomic_load_bool_acquire(&conn->layered_table_manager.leader);
 
     /*
-     * Only a follower pins a checkpoint: its stable binds compare against the pin. A leader's
-     * stable table is written with local transaction ids and needs no pin, and its own checkpoints
-     * advance the checkpoint generation, so pinning would rebuild every snapshot that overlaps a
-     * checkpoint completion. A snapshot from before a step-down is left unpinned and refused if it
-     * binds checkpoint content afterwards.
+     * Only an untimestamped follower snapshot pins a checkpoint: its stable binds compare against
+     * the pin. A leader's stable table is written with local transaction ids and needs no pin, and
+     * its own checkpoints advance the checkpoint generation, so pinning would rebuild every
+     * snapshot that overlaps a checkpoint completion. A timestamped reader stays consistent through
+     * the history store, so pinning would only defer adoptions behind it. A snapshot from before a
+     * step-down is left unpinned and refused if it binds checkpoint content afterwards.
      *
      * The checkpoint generation is the newest checkpoint delivered plus one, advanced when the
      * metadata arrives, even before its adoption completes: arrival implies its content is already
@@ -259,7 +261,7 @@ __txn_snapshot_record_disagg(WT_SESSION_IMPL *session, bool pin_ckpt)
      * with a delivery's generation advance: a delivery either observes the pin published here, or
      * the validation after the build observes the delivery and retries.
      */
-    if (pin_ckpt && !session->txn->disagg_role_leader)
+    if (!F_ISSET(session->txn, WT_TXN_SHARED_TS_READ) && !session->txn->disagg_role_leader)
         __wt_session_gen_enter(session, WT_GEN_DISAGG_CKPT);
 }
 
@@ -341,7 +343,7 @@ __txn_get_snapshot_int(WT_SESSION_IMPL *session, bool update_shared_state)
 retry:
     n = 0;
     if (record_disagg) {
-        __txn_snapshot_record_disagg(session, txn_shared->read_timestamp == WT_TS_NONE);
+        __txn_snapshot_record_disagg(session);
         /* Widen the window between recording the pin and building the snapshot. */
         WT_DIAGNOSTIC_YIELD;
     }

--- a/test/suite/test_layered_follower21.py
+++ b/test/suite/test_layered_follower21.py
@@ -618,68 +618,6 @@ class test_layered_follower21(wttest.WiredTigerTestCase):
         aux_cursor.close()
         conn_follow.close()
 
-    def test_pickup_then_step_up(self):
-        # The follower picks up a checkpoint and then steps up to leader while
-        # the transaction is still open. The step-up must not launder the
-        # picked-up post-snapshot content into visibility: a new cursor opened
-        # after the role change must still read the transaction's snapshot.
-        self.ignoreStdoutPattern('Picking up the same checkpoint again')
-        conn_follow, session_follow = self.setup_with_first_checkpoint()
-
-        session_follow.begin_transaction()
-        aux_cursor = session_follow.open_cursor(self.aux_uri)
-        aux_cursor.set_key('anchor')
-        self.assertEqual(aux_cursor.search(), 0)
-
-        self.commit_post_snapshot_writes(conn_follow)
-
-        self.disagg_switch_follower_and_leader(conn_follow, self.conn)
-
-        # The step-up ended the role era the snapshot recorded, so the bind is
-        # refused rather than served: what it must never do is serve the
-        # post-snapshot content the step-up made current.
-        cursor = session_follow.open_cursor(self.uri)
-        self.assertEqual(self.search(cursor, 'key_inserted'), ('rollback', None),
-            'stepping up made post-snapshot checkpoint content visible')
-        session_follow.rollback_transaction()
-        cursor.close()
-        aux_cursor.close()
-
-        # The step-up must have force-adopted the checkpoint that was deferred
-        # behind the transaction: the new leader continues from the newest
-        # checkpoint, so its content is current and its LSN is the adopted one.
-        self.assertTrue(True,
-            'the step-up did not adopt the deferred checkpoint')
-        self.check_new_data_visible(conn_follow)
-        conn_follow.close()
-
-    def test_role_away_and_back_mid_transaction(self):
-        # The role changes away and back (follower to leader to follower)
-        # while the transaction is open, so the role recorded at establishment
-        # matches the final role and only the role-change generation can
-        # detect the transitions. A bind after the round trip must be refused:
-        # the step-up rebuilt the stable content in between.
-        self.ignoreStdoutPattern('Picking up the same checkpoint again')
-        conn_follow, session_follow = self.setup_with_first_checkpoint()
-
-        session_follow.begin_transaction()
-        aux_cursor = session_follow.open_cursor(self.aux_uri)
-        aux_cursor.set_key('anchor')
-        self.assertEqual(aux_cursor.search(), 0)
-
-        # Step up, then immediately back down: the roles return to the
-        # starting configuration.
-        self.disagg_switch_follower_and_leader(conn_follow, self.conn)
-        self.disagg_switch_follower_and_leader(self.conn, conn_follow)
-
-        cursor = session_follow.open_cursor(self.uri)
-        self.assertEqual(self.search(cursor, 'key_updated'), ('rollback', None),
-            'a snapshot spanning an away-and-back role transition was not refused')
-        session_follow.rollback_transaction()
-        cursor.close()
-        aux_cursor.close()
-        conn_follow.close()
-
     def test_inherited_cursor_across_transactions(self):
         # A cursor kept open across transactions. Its stable view was
         # established under the previous transaction's snapshot, so its first
@@ -741,7 +679,7 @@ class test_layered_follower21(wttest.WiredTigerTestCase):
         self.leader_checkpoint(20)
         self.conn.reconfigure('disaggregated=(role="follower")')
 
-        # As with the step-up, the role era ended, so the bind is refused; what
+        # The role era the snapshot recorded ended, so the bind is refused; what
         # it must never do is serve the write committed after the snapshot.
         cursor = session_txn.open_cursor(self.uri)
         self.assertEqual(self.search(cursor, 'key_inserted'), ('rollback', None),


### PR DESCRIPTION
### Problem
The step-down design relies on the server guarantee that no transaction spans a step-up, but it is never verified. A spanning snapshot cannot be consistent with the drained and adopted stable content, and a timestamped reader skips the stable-bind role check by design, so a violation silently returns wrong data with no diagnostic.

### Solution
Record the role era for every disaggregated snapshot (timestamped readers record it too, without pinning the checkpoint generation, so adoptions are not deferred behind them) and assert on every layered cursor operation that the snapshot does not span a step-up: the role comparison catches it directly, the role-change generation catches a transition that came full circle. Remove the two tests that held transactions across a step-up.