### PR TITLE
WT-17434 Make the leaf-pages-in-cache statistics test independent of background eviction

### DIFF
--- a/test/suite/test_stat15.py
+++ b/test/suite/test_stat15.py
@@ -66,12 +66,27 @@ class test_stat15(wttest.WiredTigerTestCase):
         cursor.close()
         self.session.checkpoint(None)
 
+        # Reopen and read the whole table, so the number of resident leaf pages reflects the
+        # on-disk tree rather than however far background eviction happened to get.
+        self.reopen_conn()
+        cursor = self.session.open_cursor(self.uri, None, None)
+        while cursor.next() == 0:
+            pass
+        cursor.close()
+
         leaf_before = self.get_conn_stat(stat.conn.cache_pages_inuse_leaf)
         self.assertGreater(leaf_before, 0)
 
-        # Force eviction by reopening the connection (clears cache).
-        self.reopen_conn()
+        # Evict a page at a time with an eviction cursor.
+        evict_session = self.conn.open_session()
+        evict_cursor = evict_session.open_cursor(self.uri, None, 'debug=(release_evict)')
+        for i in range(0, 10000, 50):
+            evict_cursor.set_key(str(i).zfill(6))
+            self.assertEqual(evict_cursor.search(), 0)
+            evict_cursor.reset()
+        evict_cursor.close()
+        evict_session.close()
 
         leaf_after = self.get_conn_stat(stat.conn.cache_pages_inuse_leaf)
         self.assertLess(leaf_after, leaf_before,
-            'expected cache_pages_inuse_leaf to decrease after cache cleared')
+            'expected cache_pages_inuse_leaf to decrease after eviction')

--- a/test/suite/test_stat15.py
+++ b/test/suite/test_stat15.py
@@ -57,11 +57,16 @@ class test_stat15(wttest.WiredTigerTestCase):
         self.assertGreaterEqual(total_pages, leaf_pages,
             'expected cache_pages_inuse >= cache_pages_inuse_leaf')
 
+    # Enough keys of this size to populate several hundred leaf pages, sampled with a stride
+    # that lands on a different page each time.
+    num_keys = 10000
+    evict_stride = 50
+
     def test_cache_pages_inuse_leaf_decreases_after_eviction(self):
         # Create a table and insert enough data to populate multiple leaf pages
         self.session.create(self.uri, 'key_format=S,value_format=S')
         cursor = self.session.open_cursor(self.uri, None, None)
-        for i in range(10000):
+        for i in range(self.num_keys):
             cursor[str(i).zfill(6)] = 'x' * 1000
         cursor.close()
         self.session.checkpoint(None)
@@ -80,7 +85,7 @@ class test_stat15(wttest.WiredTigerTestCase):
         # Evict a page at a time with an eviction cursor.
         evict_session = self.conn.open_session()
         evict_cursor = evict_session.open_cursor(self.uri, None, 'debug=(release_evict)')
-        for i in range(0, 10000, 50):
+        for i in range(0, self.num_keys, self.evict_stride):
             evict_cursor.set_key(str(i).zfill(6))
             self.assertEqual(evict_cursor.search(), 0)
             evict_cursor.reset()


### PR DESCRIPTION
`test_stat15.test_cache_pages_inuse_leaf_decreases_after_eviction` failed on macOS ARM64 with `AssertionError: 2 not less than 2`.

The test read `cache_pages_inuse_leaf` on the connection that had just done the inserts, then reopened the connection and asserted the count dropped. Neither side of that comparison is anchored:

- The 10MB of inserts leaves the table as one leaf page with a large insert list. Leaf-page count only grows once eviction reconciles and splits that page, and at 10MB dirty against a 100MB cache that is below the dirty trigger, so only the background eviction server would do it. With the server starved, the reading is `2` (metadata leaf plus the table's single leaf page). Locally the same reading ranged from 3 to 165 depending on how much eviction got done.
- After the reopen the reading is `2` as well (metadata leaf plus history store leaf), a different page set that happens to have the same count.

So the assertion compares an eviction-timing artifact against a fixed floor, with no slack.

Read the checkpointed tree back on a fresh connection to establish the count, which makes it a property of the on-disk tree (363 pages, stable across runs), then evict pages explicitly with a `debug=(release_evict)` cursor instead of relying on the eviction server. The count drops to 163, so the assertion now has a wide margin.