### PR TITLE
WT-18015 Make the concurrently modified WT_BTREE flags atomic

### DIFF
--- a/src/btree/bt_delete.c
+++ b/src/btree/bt_delete.c
@@ -723,7 +723,8 @@ __wti_delete_page_instantiate(WT_SESSION_IMPL *session, WT_REF *ref)
      * don't need to also store the length. No need to do this for read-only btrees as we will never
      * resolve the updates.
      */
-    if (!F_ISSET(S2BT(session), WT_BTREE_READONLY) && page_del != NULL && !page_del->committed) {
+    if (!F_ISSET_ATOMIC_32(S2BT(session), WT_BTREE_READONLY) && page_del != NULL &&
+      !page_del->committed) {
         count = 0;
         switch (page->type) {
         case WT_PAGE_COL_VAR:

--- a/src/btree/bt_handle.c
+++ b/src/btree/bt_handle.c
@@ -157,7 +157,7 @@ __btree_pin_hs_dhandle_and_get_meta_checkpoint(WT_SESSION_IMPL *session, WT_BTRE
         WT_ASSERT(session, !WT_IS_URI_HS(dhandle_name));
         return (__wt_set_return(session, EBUSY));
     }
-    F_SET(btree, WT_BTREE_READONLY);
+    F_SET_ATOMIC_32(btree, WT_BTREE_READONLY);
 
 err:
     /*
@@ -204,6 +204,7 @@ __wt_btree_open(WT_SESSION_IMPL *session, const char *op_cfg[])
     memset(btree, 0, WT_BTREE_CLEAR_SIZE);
     __wt_evict_clear_npos(btree);
     F_CLR(btree, ~WT_BTREE_SPECIAL_FLAGS);
+    F_CLR_ATOMIC_32(btree, WT_BTREE_READONLY | WT_BTREE_SKIP_CKPT);
 
     /* Set the data handle first, our called functions reasonably use it. */
     btree->dhandle = dhandle;
@@ -211,7 +212,7 @@ __wt_btree_open(WT_SESSION_IMPL *session, const char *op_cfg[])
     /* Checkpoint and verify files are readonly. */
     if (WT_DHANDLE_IS_CHECKPOINT(dhandle) || F_ISSET(btree, WT_BTREE_VERIFY) ||
       F_ISSET(S2C(session), WT_CONN_READONLY))
-        F_SET(btree, WT_BTREE_READONLY);
+        F_SET_ATOMIC_32(btree, WT_BTREE_READONLY);
 
     /* For disaggregated stable tree opens, separate any trailing checkpoint indicator. */
     WT_ERR(__wt_btree_shared_base_name(session, &dhandle_name, &checkpoint, &name_buf));
@@ -299,7 +300,7 @@ __wt_btree_open(WT_SESSION_IMPL *session, const char *op_cfg[])
          * checkpoint is for an empty file).
          */
         WT_ERR(bm->checkpoint_load(bm, session, ckpt.raw.data, ckpt.raw.size, root_addr,
-          &root_addr_size, F_ISSET(btree, WT_BTREE_READONLY)));
+          &root_addr_size, F_ISSET_ATOMIC_32(btree, WT_BTREE_READONLY)));
         if (empty_ckpt || root_addr_size == 0)
             WT_ERR(__btree_tree_open_empty(session, empty_ckpt));
         else {
@@ -784,7 +785,7 @@ __btree_conf(WT_SESSION_IMPL *session, WT_CKPT *ckpt, bool is_ckpt)
     /* Configure read-only. */
     WT_RET(__wt_config_gets(session, cfg, "readonly", &cval));
     if (cval.val)
-        F_SET(btree, WT_BTREE_READONLY);
+        F_SET_ATOMIC_32(btree, WT_BTREE_READONLY);
 
     /* Configure disaggregated storage tier. */
     WT_RET(__wt_config_gets(session, cfg, "disaggregated.storage_tier", &cval));
@@ -1371,7 +1372,7 @@ __wt_btree_switch_object(WT_SESSION_IMPL *session, uint32_t objectid)
 
     btree = S2BT(session);
     /* If the btree is readonly, there is nothing to do. */
-    if (F_ISSET(btree, WT_BTREE_READONLY))
+    if (F_ISSET_ATOMIC_32(btree, WT_BTREE_READONLY))
         return (0);
 
     /*

--- a/src/btree/bt_page.c
+++ b/src/btree/bt_page.c
@@ -950,7 +950,7 @@ __wti_page_inmem_updates(WT_SESSION_IMPL *session, WT_REF *ref)
      * error.
      */
     WT_UNUSED(btree);
-    WT_ASSERT(session, !F_ISSET(btree, WT_BTREE_READONLY));
+    WT_ASSERT(session, !F_ISSET_ATOMIC_32(btree, WT_BTREE_READONLY));
 
     /* We don't handle in-memory prepare resolution here. */
     WT_ASSERT(session, !__wt_btree_stays_in_memory(btree));
@@ -1391,7 +1391,8 @@ __inmem_col_var(
         }
 
         /* If we find a prepare, we'll have to instantiate it in the update chain later. */
-        if (!F_ISSET(btree, WT_BTREE_READONLY) && WT_TIME_WINDOW_HAS_PREPARE(&(unpack.tw)))
+        if (!F_ISSET_ATOMIC_32(btree, WT_BTREE_READONLY) &&
+          WT_TIME_WINDOW_HAS_PREPARE(&(unpack.tw)))
             instantiate_upd = true;
 
         indx++;
@@ -1690,7 +1691,7 @@ __inmem_row_leaf(WT_SESSION_IMPL *session, WT_PAGE *page, bool *instantiate_updp
         }
 
         /* If we find a prepare, we'll have to instantiate it in the update chain later. */
-        if (!F_ISSET(btree, WT_BTREE_READONLY) && WT_TIME_WINDOW_HAS_PREPARE(&unpack.tw))
+        if (!F_ISSET_ATOMIC_32(btree, WT_BTREE_READONLY) && WT_TIME_WINDOW_HAS_PREPARE(&unpack.tw))
             instantiate_prepare_upd = true;
     }
     WT_CELL_FOREACH_END;

--- a/src/btree/bt_read.c
+++ b/src/btree/bt_read.c
@@ -489,7 +489,8 @@ skip_disk_read:
     WT_ERR(__wt_conn_page_history_track_read(session, page));
 
     /* Read only page must be clean. */
-    WT_ASSERT(session, !F_ISSET(btree, WT_BTREE_READONLY) || !__wt_page_is_modified(page));
+    WT_ASSERT(
+      session, !F_ISSET_ATOMIC_32(btree, WT_BTREE_READONLY) || !__wt_page_is_modified(page));
 
 skip_read:
     F_CLR_ATOMIC_8(ref, WT_REF_FLAG_READING);

--- a/src/btree/bt_sync_obsolete.c
+++ b/src/btree/bt_sync_obsolete.c
@@ -508,7 +508,7 @@ __checkpoint_cleanup_walk_btree(WT_SESSION_IMPL *session, WT_ITEM *uri)
     btree = S2BT(session);
 
     /* Skip read-only btrees. */
-    if (F_ISSET(btree, WT_BTREE_READONLY))
+    if (F_ISSET_ATOMIC_32(btree, WT_BTREE_READONLY))
         goto err;
 
     /* There is nothing to do on an empty tree. */

--- a/src/checkpoint/checkpoint_stats.c
+++ b/src/checkpoint/checkpoint_stats.c
@@ -129,7 +129,7 @@ __wt_checkpoint_apply_or_skip_handle_stats(WT_SESSION_IMPL *session, uint64_t ti
 {
     WT_CKPT_CONNECTION *ckpt = &S2C(session)->ckpt;
 
-    if (F_ISSET(S2BT(session), WT_BTREE_SKIP_CKPT)) {
+    if (F_ISSET_ATOMIC_32(S2BT(session), WT_BTREE_SKIP_CKPT)) {
         ++ckpt->handle_stats.skip;
         ckpt->handle_stats.skip_time += time_us;
     } else {

--- a/src/checkpoint/checkpoint_txn.c
+++ b/src/checkpoint/checkpoint_txn.c
@@ -507,7 +507,8 @@ __wt_checkpoint_get_handles(WT_SESSION_IMPL *session, const char *cfg[])
         WT_RET(__checkpoint_disagg_maybe_publish(session, btree));
 
     /* Skip the history store file as it is checkpointed manually later. */
-    if (F_ISSET(btree, WT_BTREE_NO_CHECKPOINT | WT_BTREE_IN_MEMORY | WT_BTREE_READONLY) ||
+    if (F_ISSET(btree, WT_BTREE_NO_CHECKPOINT | WT_BTREE_IN_MEMORY) ||
+      F_ISSET_ATOMIC_32(btree, WT_BTREE_READONLY) ||
       F_ISSET_ATOMIC_32(btree, WT_BTREE_AWAITS_PUBLISH) || WT_IS_HS(btree->dhandle))
         return (0);
 
@@ -570,7 +571,7 @@ __wt_checkpoint_get_handles(WT_SESSION_IMPL *session, const char *cfg[])
     ++S2C(session)->ckpt.handle_stats.lock;
     S2C(session)->ckpt.handle_stats.lock_time += time_diff;
     WT_RET(ret);
-    if (F_ISSET(btree, WT_BTREE_SKIP_CKPT)) {
+    if (F_ISSET_ATOMIC_32(btree, WT_BTREE_SKIP_CKPT)) {
         __wt_checkpoint_update_generation(session, btree);
         return (0);
     }
@@ -2162,7 +2163,7 @@ err:
      * Tell logging that we have finished a database checkpoint. Do not write a log record if the
      * database was idle.
      */
-    bool idle = ret == 0 && F_ISSET(CUR2BT(session->meta_cursor), WT_BTREE_SKIP_CKPT);
+    bool idle = ret == 0 && F_ISSET_ATOMIC_32(CUR2BT(session->meta_cursor), WT_BTREE_SKIP_CKPT);
     WT_TRET_MSG(session,
       __checkpoint_log_stage(
         session, (ret == 0 && !idle) ? WT_TXN_LOG_CKPT_STOP : WT_TXN_LOG_CKPT_CLEANUP),
@@ -2532,7 +2533,7 @@ __checkpoint_lock_dirty_tree_int(WT_SESSION_IMPL *session, bool is_checkpoint, b
      * checkpoint.
      */
     WT_RET(__checkpoint_mark_skip(session, ckptbase, force));
-    if (F_ISSET(btree, WT_BTREE_SKIP_CKPT)) {
+    if (F_ISSET_ATOMIC_32(btree, WT_BTREE_SKIP_CKPT)) {
         /*
          * If we decide to skip checkpointing, clear the delete flag on the checkpoints. The list of
          * checkpoints will be cached for a future access. Which checkpoints need to be deleted can
@@ -2675,7 +2676,7 @@ __checkpoint_lock_dirty_tree(
 
         /* Skip the clean btree. */
         if (skip_ckpt) {
-            F_SET(btree, WT_BTREE_SKIP_CKPT);
+            F_SET_ATOMIC_32(btree, WT_BTREE_SKIP_CKPT);
             goto skip;
         }
     }
@@ -2761,7 +2762,7 @@ __checkpoint_lock_dirty_tree(
      * If we decided to skip checkpointing, we need to remove the new checkpoint entry we might have
      * appended to the list.
      */
-    if (F_ISSET(btree, WT_BTREE_SKIP_CKPT)) {
+    if (F_ISSET_ATOMIC_32(btree, WT_BTREE_SKIP_CKPT)) {
         WTI_CKPT_FOREACH_NAME_OR_ORDER (ckptbase, ckpt) {
             /* Checkpoint(s) to be added are always at the end of the list. */
             WT_ASSERT(session, !seen_ckpt_add || F_ISSET(ckpt, WT_CKPT_ADD));
@@ -2867,12 +2868,12 @@ __checkpoint_mark_skip(WT_SESSION_IMPL *session, WT_CKPT *ckptbase, bool force)
      * Checkpoint read-only objects otherwise: the application must be able to open the checkpoint
      * in a cursor after taking any checkpoint, which means it must exist.
      */
-    F_CLR(btree, WT_BTREE_SKIP_CKPT);
+    F_CLR_ATOMIC_32(btree, WT_BTREE_SKIP_CKPT);
     if (!btree->modified && !force && !bm->can_truncate(bm, session)) {
         u_int count = 0;
 
         if (__checkpoint_skip_ckptlist(ckptbase, &count)) {
-            F_SET(btree, WT_BTREE_SKIP_CKPT);
+            F_SET_ATOMIC_32(btree, WT_BTREE_SKIP_CKPT);
             /*
              * If there are potentially extra checkpoints to delete, we set the timer to recheck
              * later. If there are at most two checkpoints, the current one and possibly a previous
@@ -3608,7 +3609,7 @@ __wt_checkpoint_file(WT_SESSION_IMPL *session, const char *cfg[])
     WT_RET(__wt_config_gets_def(session, cfg, "force", 0, &cval));
     force = cval.val != 0;
     WT_SAVE_DHANDLE(session, ret = __checkpoint_lock_dirty_tree(session, true, force, true, cfg));
-    if (ret != 0 || F_ISSET(S2BT(session), WT_BTREE_SKIP_CKPT))
+    if (ret != 0 || F_ISSET_ATOMIC_32(S2BT(session), WT_BTREE_SKIP_CKPT))
         goto done;
     ret = __checkpoint_tree(session, true, cfg);
 
@@ -3709,7 +3710,7 @@ __wt_checkpoint_close(WT_SESSION_IMPL *session, bool final)
     WT_SAVE_DHANDLE(
       session, ret = __checkpoint_lock_dirty_tree(session, false, false, need_tracking, NULL));
     WT_ASSERT(session, ret == 0);
-    if (ret == 0 && !F_ISSET(btree, WT_BTREE_SKIP_CKPT))
+    if (ret == 0 && !F_ISSET_ATOMIC_32(btree, WT_BTREE_SKIP_CKPT))
         ret = __checkpoint_tree(session, false, NULL);
 
     __checkpoint_clear_time(session);

--- a/src/conn/conn_dhandle.c
+++ b/src/conn/conn_dhandle.c
@@ -303,7 +303,7 @@ __wt_conn_dhandle_find(WT_SESSION_IMPL *session, const char *uri, const char *ch
                  * previous leader era.
                  */
                 if (WT_DHANDLE_BTREE(dhandle) &&
-                  F_ISSET((WT_BTREE *)dhandle->handle, WT_BTREE_READONLY)) {
+                  F_ISSET_ATOMIC_32((WT_BTREE *)dhandle->handle, WT_BTREE_READONLY)) {
                     if (__wt_atomic_load_int32_acquire(&dhandle->session_inuse) == 0 ||
                       !WT_URI_IS_STABLE_CHECKPOINT(dhandle->name))
                         continue;

--- a/src/conn/conn_layered.c
+++ b/src/conn/conn_layered.c
@@ -1235,14 +1235,14 @@ __disagg_mark_btrees_readonly_then_step_down(WT_SESSION_IMPL *session)
 
         btree = (WT_BTREE *)dhandle->handle;
 
-        if (!F_ISSET(btree, WT_BTREE_DISAGGREGATED) || F_ISSET(btree, WT_BTREE_READONLY))
+        if (!F_ISSET(btree, WT_BTREE_DISAGGREGATED) || F_ISSET_ATOMIC_32(btree, WT_BTREE_READONLY))
             continue;
 
         WT_WITH_BTREE(session, btree, ret = __wt_evict_file_exclusive_on(session));
         WT_RET(ret);
 
         /* Mark the disaggregated as readonly. */
-        F_SET(btree, WT_BTREE_READONLY);
+        F_SET_ATOMIC_32(btree, WT_BTREE_READONLY);
 
         /*
          * Mark the handle outdated so that if we step back up as leader in the future, we open a

--- a/src/cursor/cur_layered.c
+++ b/src/cursor/cur_layered.c
@@ -337,7 +337,7 @@ __clayered_assert_stable_mode(WTI_CURSOR_LAYERED *clayered)
      *
      * WT_ASSERT(CUR2S(clayered),
      *   (clayered->last_role == WTI_CLAYERED_ROLE_LEADER) !=
-     *     F_ISSET(CUR2BT(clayered->stable_cursor), WT_BTREE_READONLY));
+     *     F_ISSET_ATOMIC_32(CUR2BT(clayered->stable_cursor), WT_BTREE_READONLY));
      */
 }
 

--- a/src/evict/evict_page.c
+++ b/src/evict/evict_page.c
@@ -1009,7 +1009,7 @@ __evict_review_obsolete_time_window(WT_SESSION_IMPL *session, WT_REF *ref)
         return (0);
 
     /* The checkpoint cursor dhandle is read-only. Do not mark these pages as dirty. */
-    if (F_ISSET(btree, WT_BTREE_READONLY))
+    if (F_ISSET_ATOMIC_32(btree, WT_BTREE_READONLY))
         return (0);
 
     /*

--- a/src/evict/evict_walk.c
+++ b/src/evict/evict_walk.c
@@ -427,7 +427,7 @@ retry:
         }
 
         /* Skip read-only btrees if we are not looking for clean/updates pages. */
-        if (F_ISSET(btree, WT_BTREE_READONLY) &&
+        if (F_ISSET_ATOMIC_32(btree, WT_BTREE_READONLY) &&
           !F_ISSET(evict, WT_EVICT_CACHE_CLEAN | WT_EVICT_CACHE_UPDATES)) {
             WT_STAT_CONN_INCR(session, eviction_server_skip_trees_read_only);
             __evict_disagg_btree_skip_count(session, btree);

--- a/src/history/hs_cursor.c
+++ b/src/history/hs_cursor.c
@@ -110,7 +110,7 @@ __wt_hs_find_upd(WT_SESSION_IMPL *session, WT_ITEM *key, const char *value_forma
      * data.
      */
     if (btree->hs_checkpoint_name == NULL && F_ISSET(btree, WT_BTREE_DISAGGREGATED) &&
-      F_ISSET(btree, WT_BTREE_READONLY)) {
+      F_ISSET_ATOMIC_32(btree, WT_BTREE_READONLY)) {
         ret = 0;
         goto done;
     }

--- a/src/include/btree.h
+++ b/src/include/btree.h
@@ -363,20 +363,23 @@ struct __wt_btree {
  * explanation.
  */
 /* AUTOMATIC FLAG VALUE GENERATION START 12 */
-#define WT_BTREE_BULK 0x0001000u            /* Bulk-load handle */
-#define WT_BTREE_CLOSED 0x0002000u          /* Handle closed */
-#define WT_BTREE_DISAGGREGATED 0x0004000u   /* In disaggregated storage */
-#define WT_BTREE_GARBAGE_COLLECT 0x0008000u /* Content becomes obsolete automatically */
-#define WT_BTREE_IGNORE_CACHE 0x0010000u    /* Cache-resident object */
-#define WT_BTREE_IN_MEMORY 0x0020000u       /* Cache-resident object */
-#define WT_BTREE_LOGGED 0x0040000u          /* Commit-level durability without timestamps */
-#define WT_BTREE_NO_CHECKPOINT 0x0080000u   /* Disable checkpoints */
-#define WT_BTREE_NO_EVICT 0x0100000u        /* Cache-resident object. Never run eviction on it. */
-#define WT_BTREE_READONLY 0x0200000u        /* Handle is readonly */
-#define WT_BTREE_SALVAGE 0x0400000u         /* Handle is for salvage */
-#define WT_BTREE_SKIP_CKPT 0x0800000u       /* Handle skipped checkpoint */
-#define WT_BTREE_VERIFY 0x1000000u          /* Handle is for verify */
-                                            /* AUTOMATIC FLAG VALUE GENERATION STOP 32 */
+#define WT_BTREE_BULK 0x001000u            /* Bulk-load handle */
+#define WT_BTREE_CLOSED 0x002000u          /* Handle closed */
+#define WT_BTREE_DISAGGREGATED 0x004000u   /* In disaggregated storage */
+#define WT_BTREE_GARBAGE_COLLECT 0x008000u /* Content becomes obsolete automatically */
+#define WT_BTREE_IGNORE_CACHE 0x010000u    /* Cache-resident object */
+#define WT_BTREE_IN_MEMORY 0x020000u       /* Cache-resident object */
+#define WT_BTREE_LOGGED 0x040000u          /* Commit-level durability without timestamps */
+#define WT_BTREE_NO_CHECKPOINT 0x080000u   /* Disable checkpoints */
+#define WT_BTREE_NO_EVICT 0x100000u        /* Cache-resident object. Never run eviction on it. */
+#define WT_BTREE_SALVAGE 0x200000u         /* Handle is for salvage */
+#define WT_BTREE_VERIFY 0x400000u          /* Handle is for verify */
+                                           /* AUTOMATIC FLAG VALUE GENERATION STOP 32 */
+    /*
+     * These flags are only modified while the data handle is held exclusively, that is, at open, at
+     * close, or by an operation that has locked out all other users of the handle. Anything that
+     * can change while other threads are using the tree belongs in the atomic flags below.
+     */
     uint32_t flags;
 
 /*
@@ -385,6 +388,8 @@ struct __wt_btree {
  */
 /* AUTOMATIC FLAG VALUE GENERATION START 0 */
 #define WT_BTREE_AWAITS_PUBLISH 0x1u /* An unpublished btree, which will be published later */
+#define WT_BTREE_READONLY 0x2u       /* Handle is readonly */
+#define WT_BTREE_SKIP_CKPT 0x4u      /* Handle skipped checkpoint */
                                      /* AUTOMATIC FLAG VALUE GENERATION STOP 32 */
     wt_shared uint32_t flags_atomic;
 };

--- a/src/include/btree_inline.h
+++ b/src/include/btree_inline.h
@@ -43,7 +43,8 @@ __wt_btree_disable_bulk(WT_SESSION_IMPL *session)
 static WT_INLINE bool
 __wt_btree_is_stale_disagg(WT_SESSION_IMPL *session)
 {
-    return (F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED | WT_BTREE_READONLY) &&
+    return ((F_ISSET(S2BT(session), WT_BTREE_DISAGGREGATED) ||
+              F_ISSET_ATOMIC_32(S2BT(session), WT_BTREE_READONLY)) &&
       F_ISSET(session->dhandle, WT_DHANDLE_OUTDATED));
 }
 
@@ -987,7 +988,7 @@ __wt_page_only_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page)
     WT_ASSERT_ALWAYS(session, !F_ISSET(page->modify, WT_PAGE_MODIFY_EXCLUSIVE),
       "Illegal attempt to modify a page that is being exclusively reconciled");
 
-    if (F_ISSET(btree, WT_BTREE_READONLY))
+    if (F_ISSET_ATOMIC_32(btree, WT_BTREE_READONLY))
         return;
 
     WT_ASSERT(session,
@@ -1100,7 +1101,7 @@ __wt_tree_modify_set(WT_SESSION_IMPL *session)
     btree = S2BT(session);
     conn = S2C(session);
 
-    if (F_ISSET(btree, WT_BTREE_READONLY))
+    if (F_ISSET_ATOMIC_32(btree, WT_BTREE_READONLY))
         return;
 
     WT_ASSERT(session,
@@ -1202,7 +1203,7 @@ __wt_page_modify_set(WT_SESSION_IMPL *session, WT_PAGE *page)
      * Prepared records in the datastore require page updates, even for read-only handles, don't
      * mark the tree or page dirty.
      */
-    if (F_ISSET(btree, WT_BTREE_READONLY))
+    if (F_ISSET_ATOMIC_32(btree, WT_BTREE_READONLY))
         return;
 
     WT_ASSERT(session,
@@ -1243,7 +1244,7 @@ __wt_page_parent_modify_set(WT_SESSION_IMPL *session, WT_REF *ref, bool page_onl
 
     btree = S2BT(session);
 
-    if (F_ISSET(btree, WT_BTREE_READONLY))
+    if (F_ISSET_ATOMIC_32(btree, WT_BTREE_READONLY))
         return (0);
 
     WT_ASSERT(session,
@@ -2503,7 +2504,7 @@ __wt_page_can_evict(WT_SESSION_IMPL *session, WT_REF *ref, bool *inmem_splitp)
         return (false);
     }
 
-    if (F_ISSET(btree, WT_BTREE_READONLY))
+    if (F_ISSET_ATOMIC_32(btree, WT_BTREE_READONLY))
         return (true);
 
     /*

--- a/src/reconcile/rec_write.c
+++ b/src/reconcile/rec_write.c
@@ -136,8 +136,8 @@ __wt_reconcile(WT_SESSION_IMPL *session, WT_REF *ref, WT_SALVAGE_COOKIE *salvage
     else
         WT_STAT_CONN_DSRC_INCR(session, rec_page_mods_gt500);
 
-    WT_ASSERT_ALWAYS(
-      session, !F_ISSET(btree, WT_BTREE_READONLY), "Attempting reconciliation on a read-only page");
+    WT_ASSERT_ALWAYS(session, !F_ISSET_ATOMIC_32(btree, WT_BTREE_READONLY),
+      "Attempting reconciliation on a read-only page");
 
     /*
      * Sanity check flags.


### PR DESCRIPTION
The `WT_BTREE` handle keeps its flags in a non-atomic `uint32_t`, manipulated with `F_SET`/`F_CLR`/`F_ISSET`. This audits the flags and moves the ones that are modified while the tree is in use into the existing `flags_atomic` word.

Classification:

| Flag | Written at | Verdict |
|---|---|---|
| `BULK`, `SALVAGE`, `VERIFY` | dhandle open/close, exclusive | set-once |
| `CLOSED` | `__wt_btree_close`, exclusive | set-once |
| `DISAGGREGATED`, `GARBAGE_COLLECT`, `IGNORE_CACHE`, `IN_MEMORY`, `LOGGED`, `NO_CHECKPOINT`, `NO_EVICT` | `__btree_conf`, under `__wt_btree_open` | set-once |
| `READONLY` | also `__disagg_mark_btrees_readonly_then_step_down`, on a live open handle | concurrent |
| `SKIP_CKPT` | set and cleared by the checkpoint thread on a tree other threads are using | concurrent |

The two runtime writers exclude each other -- step-down runs with the checkpoint and schema locks held -- so no flag update can be lost. The problem is the readers: both writers store into a word that other threads are reading with plain loads at the same time, for `LOGGED` / `GARBAGE_COLLECT` / `DISAGGREGATED` on the write and eviction paths as well as for these two flags themselves. That is a data race in the memory model and TSAN-reportable, even though it is benign in practice on an aligned 32-bit word with a single writer.

Changes:

- `WT_BTREE_READONLY` and `WT_BTREE_SKIP_CKPT` move to `flags_atomic`; all call sites use the `F_*_ATOMIC_32` macros. The two tests that combined them with non-atomic flags in a single `F_ISSET` are split.
- The invariant for the flags that remain in the non-atomic word is documented on the field.
- The re-open path's `F_CLR(btree, ~WT_BTREE_SPECIAL_FLAGS)` no longer covers these two, so they are cleared explicitly; otherwise a step-down's `READONLY` would survive into the next open of the handle.

Note that `WT_BTREE_IN_MEMORY` is only touched in `__btree_conf` on `develop`, so it correctly stays in the non-atomic word.
