### PR TITLE
WT-18330 Read the history store at the checkpoint pinned by the stable btree

### DIFF
--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -1435,19 +1435,11 @@ __verify_key_hs(WT_SESSION_IMPL *session, WT_ITEM *tmp1, wt_timestamp_t newer_st
     if (vs->skip_per_key_hs)
         return (0);
 
-    /*
-     * A stable btree opened from a checkpoint pins the shared history store checkpoint that goes
-     * with it, so read the history store there rather than through a live handle. Without a pinned
-     * name the shared history store has never been checkpointed and there is nothing to compare
-     * against.
-     */
-    if (WT_URI_IS_STABLE_CHECKPOINT(session->dhandle->name) && btree->hs_checkpoint_name == NULL)
+    WT_RET(__wt_hs_verify_cursor_open(session, hs_btree_id, &hs_cursor));
+    if (hs_cursor == NULL)
         return (0);
 
     WT_STAT_CONN_INCR(session, session_table_verify_hs_keys_checked);
-
-    WT_RET(__wt_curhs_open(session, hs_btree_id, btree->hs_checkpoint_name, NULL, &hs_cursor));
-    F_SET(hs_cursor, WT_CURSTD_HS_READ_COMMITTED);
 
     /*
      * Open a history store cursor positioned at the end of the data store key (the newest record)

--- a/src/btree/bt_vrfy.c
+++ b/src/btree/bt_vrfy.c
@@ -37,9 +37,8 @@ typedef struct {
     bool read_corrupt;
     bool skip_per_key_hs;
 
-    /* Whether to read from the history store, and if so, which checkpoint. */
+    /* Whether to read from the history store. */
     bool skip_hs;
-    const char *hs_checkpoint_name;
 
     /* Page layout information. */
     uint64_t depth, depth_internal[100], depth_leaf[100], tree_stack[100], keys_count_stack[100],
@@ -434,7 +433,6 @@ __verify_one_checkpoint(
 
     /* Only verify HS entries against the last checkpoint. */
     vs->skip_hs = skip_hs || !last_ckpt;
-    vs->hs_checkpoint_name = ckpt->name;
 
     /* Verify the tree. */
     WT_WITH_PAGE_INDEX(session, ret = __verify_tree(session, &btree->root, &addr_unpack, vs));
@@ -1437,14 +1435,18 @@ __verify_key_hs(WT_SESSION_IMPL *session, WT_ITEM *tmp1, wt_timestamp_t newer_st
     if (vs->skip_per_key_hs)
         return (0);
 
+    /*
+     * A stable btree opened from a checkpoint pins the shared history store checkpoint that goes
+     * with it, so read the history store there rather than through a live handle. Without a pinned
+     * name the shared history store has never been checkpointed and there is nothing to compare
+     * against.
+     */
+    if (WT_URI_IS_STABLE_CHECKPOINT(session->dhandle->name) && btree->hs_checkpoint_name == NULL)
+        return (0);
+
     WT_STAT_CONN_INCR(session, session_table_verify_hs_keys_checked);
 
-    /* Read the HS at the same checkpoint as the data store, so the two views are consistent. */
-    WT_ASSERT(session, session->hs_checkpoint == NULL);
-    session->hs_checkpoint = vs->hs_checkpoint_name;
-    ret = __wt_curhs_open(session, hs_btree_id, NULL, NULL, &hs_cursor);
-    session->hs_checkpoint = NULL;
-    WT_RET(ret);
+    WT_RET(__wt_curhs_open(session, hs_btree_id, btree->hs_checkpoint_name, NULL, &hs_cursor));
     F_SET(hs_cursor, WT_CURSTD_HS_READ_COMMITTED);
 
     /*

--- a/src/history/hs_verify.c
+++ b/src/history/hs_verify.c
@@ -97,6 +97,31 @@ err:
 }
 
 /*
+ * __wt_hs_verify_cursor_open --
+ *     Open a history store cursor for verify. A stable btree opened from a checkpoint pins the
+ *     shared history store checkpoint that goes with it, so read there rather than through a live
+ *     handle: both sides of the comparison then come from the same checkpoint, and a follower does
+ *     not get a live handle on a shared table. Returns a NULL cursor when the shared history store
+ *     has never been checkpointed and there is nothing to verify against.
+ */
+int
+__wt_hs_verify_cursor_open(WT_SESSION_IMPL *session, uint32_t btree_id, WT_CURSOR **hs_cursorp)
+{
+    WT_BTREE *btree;
+
+    btree = S2BT(session);
+    *hs_cursorp = NULL;
+
+    if (WT_URI_IS_STABLE_CHECKPOINT(session->dhandle->name) && btree->hs_checkpoint_name == NULL)
+        return (0);
+
+    WT_RET(__wt_curhs_open(session, btree_id, btree->hs_checkpoint_name, NULL, hs_cursorp));
+    F_SET(*hs_cursorp, WT_CURSTD_HS_READ_COMMITTED);
+
+    return (0);
+}
+
+/*
  * __wt_hs_verify_one --
  *     Verify the history store for a given btree. This must be called when we are known to have
  *     exclusive access to the btree.
@@ -104,25 +129,13 @@ err:
 int
 __wt_hs_verify_one(WT_SESSION_IMPL *session, uint32_t btree_id)
 {
-    WT_BTREE *btree;
     WT_CURSOR *hs_cursor;
     WT_CURSOR_BTREE ds_cbt;
     WT_DECL_RET;
 
-    btree = S2BT(session);
-    hs_cursor = NULL;
-
-    /*
-     * A stable btree opened from a checkpoint pins the shared history store checkpoint that goes
-     * with it. Read the history store there so both sides of the comparison come from the same
-     * checkpoint, and so a follower does not get a live handle on a shared table. No pinned name
-     * means the shared history store has never been checkpointed, so there is nothing to verify.
-     */
-    if (WT_URI_IS_STABLE_CHECKPOINT(session->dhandle->name) && btree->hs_checkpoint_name == NULL)
+    WT_RET(__wt_hs_verify_cursor_open(session, btree_id, &hs_cursor));
+    if (hs_cursor == NULL)
         return (0);
-
-    WT_ERR(__wt_curhs_open(session, btree_id, btree->hs_checkpoint_name, NULL, &hs_cursor));
-    F_SET(hs_cursor, WT_CURSTD_HS_READ_COMMITTED);
 
     /* Position the hs cursor on the requested btree id, there could be nothing in the HS yet. */
     hs_cursor->set_key(hs_cursor, 1, btree_id);

--- a/src/history/hs_verify.c
+++ b/src/history/hs_verify.c
@@ -134,8 +134,13 @@ __wt_hs_verify_one(WT_SESSION_IMPL *session, uint32_t btree_id)
     WT_DECL_RET;
 
     WT_RET(__wt_hs_verify_cursor_open(session, btree_id, &hs_cursor));
-    if (hs_cursor == NULL)
+    if (hs_cursor == NULL) {
+        /* Report the skip once per tree. */
+        __wt_verbose(session, WT_VERB_VERIFY,
+          "%s: no shared history store checkpoint is pinned, skipping history store verification",
+          session->dhandle->name);
         return (0);
+    }
 
     /* Position the hs cursor on the requested btree id, there could be nothing in the HS yet. */
     hs_cursor->set_key(hs_cursor, 1, btree_id);

--- a/src/history/hs_verify.c
+++ b/src/history/hs_verify.c
@@ -104,13 +104,24 @@ err:
 int
 __wt_hs_verify_one(WT_SESSION_IMPL *session, uint32_t btree_id)
 {
+    WT_BTREE *btree;
     WT_CURSOR *hs_cursor;
     WT_CURSOR_BTREE ds_cbt;
     WT_DECL_RET;
 
+    btree = S2BT(session);
     hs_cursor = NULL;
 
-    WT_ERR(__wt_curhs_open(session, btree_id, NULL, NULL, &hs_cursor));
+    /*
+     * A stable btree opened from a checkpoint pins the shared history store checkpoint that goes
+     * with it. Read the history store there so both sides of the comparison come from the same
+     * checkpoint, and so a follower does not get a live handle on a shared table. No pinned name
+     * means the shared history store has never been checkpointed, so there is nothing to verify.
+     */
+    if (WT_URI_IS_STABLE_CHECKPOINT(session->dhandle->name) && btree->hs_checkpoint_name == NULL)
+        return (0);
+
+    WT_ERR(__wt_curhs_open(session, btree_id, btree->hs_checkpoint_name, NULL, &hs_cursor));
     F_SET(hs_cursor, WT_CURSTD_HS_READ_COMMITTED);
 
     /* Position the hs cursor on the requested btree id, there could be nothing in the HS yet. */

--- a/src/include/extern.h
+++ b/src/include/extern.h
@@ -727,6 +727,8 @@ extern int __wt_hs_open(WT_SESSION_IMPL *session, const char **cfg)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_hs_verify(WT_SESSION_IMPL *session)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
+extern int __wt_hs_verify_cursor_open(WT_SESSION_IMPL *session, uint32_t btree_id,
+  WT_CURSOR **hs_cursorp) WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_hs_verify_one(WT_SESSION_IMPL *session, uint32_t btree_id)
   WT_GCC_FUNC_DECL_ATTRIBUTE((warn_unused_result));
 extern int __wt_import_repair(WT_SESSION_IMPL *session, const char *uri, char **configp)

--- a/test/suite/test_verify_disagg04.py
+++ b/test/suite/test_verify_disagg04.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+#
+# Public Domain 2014-present MongoDB, Inc.
+# Public Domain 2008-2014 WiredTiger, Inc.
+#
+# This is free and unencumbered software released into the public domain.
+#
+# Anyone is free to copy, modify, publish, use, compile, sell, or
+# distribute this software, either in source code form or as a compiled
+# binary, for any purpose, commercial or non-commercial, and by any
+# means.
+#
+# In jurisdictions that recognize copyright laws, the author or authors
+# of this software dedicate any and all copyright interest in the
+# software to the public domain. We make this dedication for the benefit
+# of the public at large and to the detriment of our heirs and
+# successors. We intend this dedication to be an overt act of
+# relinquishment in perpetuity of all present and future rights to this
+# software under copyright law.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+# IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+import wttest
+from helper_disagg import disagg_test_class, gen_disagg_storages
+from wtscenario import make_scenarios
+
+# test_verify_disagg04.py
+#    Run WT_SESSION::verify against a populated shared history store on a disaggregated
+#    follower. This drives __wt_hs_verify_one, which must read the history store at the
+#    checkpoint pinned by the stable btree rather than through a live handle.
+
+@disagg_test_class
+class test_verify_disagg04(wttest.WiredTigerTestCase):
+    test_name = __qualname__
+    disagg_storages = gen_disagg_storages(disagg_only=True)
+    scenarios = make_scenarios(disagg_storages)
+
+    conn_config = 'disaggregated=(role="leader")'
+    conn_config_follower = 'disaggregated=(role="follower")'
+
+    table_cfg = 'key_format=S,value_format=S,block_manager=disagg'
+    uri = f'layered:{test_name}'
+    nitems = 200
+
+    def test_verify_follower_populated_hs(self):
+        self.session.create(self.uri, self.table_cfg)
+        cursor = self.session.open_cursor(self.uri, None, None)
+
+        # Write every key at ts=5 and checkpoint.
+        for i in range(self.nitems):
+            self.session.begin_transaction()
+            cursor[str(i)] = 'v1_' + str(i)
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(5))
+        self.session.checkpoint()
+
+        # Overwrite every key at ts=10. The ts=5 versions move into the history store.
+        for i in range(self.nitems):
+            self.session.begin_transaction()
+            cursor[str(i)] = 'v2_' + str(i)
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(10))
+        self.session.checkpoint()
+
+        # Delete every other key at ts=15, giving those history store records a stop timestamp.
+        for i in range(0, self.nitems, 2):
+            self.session.begin_transaction()
+            cursor.set_key(str(i))
+            cursor.remove()
+            self.session.commit_transaction('commit_timestamp=' + self.timestamp_str(15))
+        self.session.checkpoint()
+        cursor.close()
+
+        self.verifyUntilSuccess(self.session)
+
+        conn_follow = self.wiredtiger_open('follower', self.extensionsConfig() + ',create,' +
+                                           self.conn_config_follower)
+        session_follow = conn_follow.open_session('')
+        self.disagg_advance_checkpoint(conn_follow)
+
+        # The stable btree is opened from its picked-up checkpoint, so the history store must
+        # be read from the checkpoint pinned alongside it.
+        self.verifyUntilSuccess(session_follow)
+
+        session_follow.close()
+        conn_follow.close()


### PR DESCRIPTION
## Problem

Both verify call sites opened the history store with a `NULL` checkpoint name:

```c
WT_ERR(__wt_curhs_open(session, btree_id, NULL, NULL, &hs_cursor));
```

On a disaggregated follower, `WT_SESSION::verify` on a layered table opens the stable
constituent as `file:X.wt_stable/<checkpoint>`. That URI form makes `__wt_btree_open` call
`__btree_pin_hs_dhandle`, which pins the matching shared history store checkpoint in
`btree->hs_checkpoint_name` and sets `WT_BTREE_READONLY`. Passing `NULL` throws that away and
gives verify a live, writable handle on a shared table instead.

This is the same defect WT-17358 fixed in `__hs_verify` a few lines below in the same file;
`__wt_hs_verify_one` and `__verify_key_hs` were missed. `__wt_hs_search` already passes the
pinned name correctly.

`__verify_key_hs` additionally carried a mechanism that never worked:

```c
/* Read the HS at the same checkpoint as the data store, so the two views are consistent. */
WT_ASSERT(session, session->hs_checkpoint == NULL);
session->hs_checkpoint = vs->hs_checkpoint_name;
ret = __wt_curhs_open(session, hs_btree_id, NULL, NULL, &hs_cursor);
session->hs_checkpoint = NULL;
```

`session->hs_checkpoint` is only read inside `if (WT_READING_CHECKPOINT(session))` in
`__curhs_file_cursor_open`, and verify always opens its handle with a NULL checkpoint
(`__wt_session_get_dhandle(session, uri, NULL, ...)`), so that branch is never taken. Confirmed
with a temporary assertion, on plain non-disaggregated WiredTiger:

```
__verify_key_hs(...), 1449: WiredTiger assertion failed: 'WT_READING_CHECKPOINT(session)'.
INSTRUMENT: session->hs_checkpoint=WiredTigerCheckpoint.1 is ignored;
dhandle=file:wt_verify_hs_overlap.wt dhandle->checkpoint=(null)
```

The value it passed was `vs->hs_checkpoint_name`, the *data store's* checkpoint name, not the
history store's. Those differ in practice — the same instrumentation on a follower showed the
data store at `WiredTigerCheckpoint.3` while the pinned history store checkpoint was
`WiredTigerCheckpoint.2` — so the two views would not have matched even had the mechanism
engaged.

## Solution

Pass `btree->hs_checkpoint_name` at both sites, with an early return when a stable checkpoint
handle has no pinned name (the shared history store has never been checkpointed, so there is
nothing to compare against).

Remove the dead mechanism in `__verify_key_hs` and its misleading comment, along with
`vs->hs_checkpoint_name` — both the field and its assignment in `__verify_one_checkpoint` —
which had no other reader.

Move the `session_table_verify_hs_keys_checked` increment below the new early return so a
follower with no pinned history store checkpoint does not count keys it never checks.

## Scope and what a reviewer should know

`btree->hs_checkpoint_name` is only ever set by the disaggregated `uri/<checkpoint>` open path,
so it is NULL on a leader and in non-disaggregated WiredTiger. **This change is a no-op
outside the disaggregated follower path**, by construction.

The guard uses `WT_URI_IS_STABLE_CHECKPOINT` rather than the `DISAGGREGATED && READONLY`
condition `__wt_hs_search` uses, deliberately: verify sets `WT_BTREE_READONLY` on every handle
it opens, so that condition would silently skip history store verification on the leader.

**`test_verify_disagg04.py` passes both before and after this change.** It is path coverage, not
a failing-before / passing-after reproducer. The exposure WT-17358 hit (`__wt_page_modify_set`
asserting `!DISAGG || leader`) fired because `__inmem_row_leaf` instantiated tombstones for
stop-timestamp records; WT-17601 removed that, so the live handle no longer dirties pages on
read and this defect is currently latent. It reopens if update instantiation on page read is
widened again, or a live shared handle on a follower is dirtied by any other route.

A separate, genuinely reproducible gap — verify reading the history store live rather than at
the checkpoint being verified, on non-disaggregated WiredTiger — is **not** addressed here and
is tracked in [WT-18332](https://jira.mongodb.org/browse/WT-18332) with its own reproducer.
That one needs verify to open the history store as a real checkpoint cursor matched to the data
store checkpoint, which is a materially larger change.

## Testing

`test_verify_disagg`, `test_verify_disagg02`, `test_verify_disagg03`, `test_verify_disagg04`,
`test_verify3`, `test_verify_hs_overlap` — 14 tests, all pass. The wider suite has not been run.
